### PR TITLE
JSX Transformer / DisplayName Visitor: Multiple declarations with one `var` statement

### DIFF
--- a/vendor/fbtransform/transforms/reactDisplayName.js
+++ b/vendor/fbtransform/transforms/reactDisplayName.js
@@ -36,8 +36,7 @@ var getDocblock = require('../lib/utils').getDocblock;
  * });
  */
 function visitReactDisplayName(traverse, object, path, state) {
-  if (object.type === Syntax.VariableDeclarator &&
-      object.id.type === Syntax.Identifier &&
+  if (object.id.type === Syntax.Identifier &&
       object.init &&
       object.init.type === Syntax.CallExpression &&
       object.init.callee.type === Syntax.MemberExpression &&


### PR DESCRIPTION
The bug fixed by this commit prevented the correct parsing of `var` statements with multiple variables being declared. Instead of trying to parse a whole 'variable declarations' (a `var` statement with all its declarations), this visitor now only parses single 'variable declarators'.

An example (from the tutorial) that did not work before this patch:

``` javascript
    var CommentBox = React.createClass({
      ...
    }),

    CommentList = React.createClass({
      ...
    });
```

What did  work is the following:

``` javascript
    var CommentBox = React.createClass({
      ...
    });

    var CommentList = React.createClass({
      ...
    });
```

Of course, there are different coding styles and guidelines. Most developers probably don't like multiple variables being declared with one `var` statement, but nevertheless, it should be possible. 
