### PR TITLE
JSFiddle integration

### DIFF
--- a/docs/js/JSFiddleIntegration.js
+++ b/docs/js/JSFiddleIntegration.js
@@ -1,3 +1,10 @@
-var tag = document.querySelector('script[type="application/javascript;version=1.7"]');
+(function() {
+var tag = document.querySelector(
+  'script[type="application/javascript;version=1.7"]'
+);
+if (!tag || tag.textContent.indexOf('window.onload=function(){') !== -1) {
+  alert('Bad JSFiddle configuration, please fork the original React JSFiddle');
+}
 tag.setAttribute('type', 'text/jsx');
-tag.textContent = '/** @jsx React.DOM */' + tag.textContent.substr(12, tag.textContent.length - 17);
+tag.textContent = tag.textContent.replace(/^\/\/<!\[CDATA\[/, '');
+})();


### PR DESCRIPTION
This is a small snippet that exploits the fact that we can run custom script on jsfiddle before the Javascript1.7 transpiler is executed. We change the script type to text/jsx to run our transpiler pipeline instead.
http://facebook.github.io/react/js/JSFiddleIntegration.js
