### PR TITLE
Ship CJS modules instead of browserified build

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var React = require('./build/react');
+var React = require('./build/modules/React');
 var visitors = require('./vendor/fbtransform/visitors').transformVisitors;
 var transform = require('./vendor/fbtransform/lib/transform').transform;
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "README.md",
     "main.js",
     "bin/jsx",
-    "build/react.js",
+    "build/modules/",
     "vendor/fbtransform/",
     "vendor/woodchipper.js"
   ],
@@ -35,7 +35,8 @@
     "base62": "~0.1.1",
     "commoner": "~0.6.8",
     "esprima": "git://github.com/facebook/esprima#fb-harmony",
-    "recast": "~0.3.3"
+    "recast": "~0.3.3",
+    "source-map": "~0.1.22"
   },
   "devDependencies": {
     "browserify": "~2.14.2",
@@ -47,7 +48,6 @@
     "optimist": "~0.4.0",
     "phantomjs": ">= 1.9.0",
     "semver": ">= 1.1.4",
-    "source-map": "~0.1.22",
     "uglify-js": "~2.3.6",
     "grunt-contrib-clean": "~0.4.1",
     "grunt-compare-size": "~0.4.0",


### PR DESCRIPTION
It turns out that if you try to browserify a file requiring react-tools, it doesn't work. This is because browserify just visits the require statements in the file and looks for files in that path.
`./ReactCompositeComponent` doesn't exist and that's the point that fails. So the fix is to actually ship each of our CJS modules as individual files like browserify expects. This should have no negative side effects - we still only export React (though the rest of our modules are now actually accessible, which might make it easier to do more with the module).

The other change here is to move source-map to dependencies since it's required in the transform code.

Test Plan:

```
$ npm pack .
$ cd /tmp
$ npm install path/to/react-tools-0.3.1.tgz
$ echo "require('react-tools')" > test.js
$ browserify test.js
```
