### PR TITLE
Fix live_editor.js usage of class=

### DIFF
--- a/docs/_js/live_editor.js
+++ b/docs/_js/live_editor.js
@@ -81,7 +81,7 @@ var ReactPlayground = React.createClass({
         />;
     } else if (this.state.mode === this.MODES.JS) {
       content =
-        <div class={{playgroundJS: true, playgroundStage: true}}>
+        <div class="playgroundJS playgroundStage">
             {this.getDesugaredCode()}
         </div>;
     }
@@ -121,7 +121,7 @@ var ReactPlayground = React.createClass({
       }
     } catch (e) {
       React.renderComponent(
-        <div content={e.toString()} class={{playgroundError: true}} />,
+        <div content={e.toString()} class="playgroundError" />,
         mountNode
       );
     }


### PR DESCRIPTION
We don't use the `class={{myClassName: true}}` syntax anywhere else and the inclusion of it breaks JSX when you use the in-browser compilation. TBH, I'm not sure why this even works in this case...
