### PR TITLE
Add "Why React"

### DIFF
--- a/docs/_posts/2013-06-03-why-react.md
+++ b/docs/_posts/2013-06-03-why-react.md
@@ -39,7 +39,8 @@ reasons:
     ability to build abstractions.** This is incredibly important in
     large applications.
 - "Logic" and "markup" are intimately tied, and are both part of the
-  "presentation" layer, so we're not breaking separation of concerns.
+  "presentation" layer, so we're unifying the presentation layer,
+  not breaking separation of concerns.
 - Large projects usually don't use WYSIWYG editors for production
   code, so breaking apart markup from the code that creates it usually
   only introduces friction.


### PR DESCRIPTION
We need a way to communicate what we're actually doing rather than just how we build apps (like we do on the site.docs). This does a pretty good job of it, I think.
