### PR TITLE
"nuts and bolts" isn't hyphenated

### DIFF
--- a/docs/_posts/2013-06-03-why-react.md
+++ b/docs/_posts/2013-06-03-why-react.md
@@ -102,7 +102,7 @@ Head on over to
 [facebook.github.io/react](http://facebook.github.io/react) to check
 out what we have built. Our documentation is geared towards building
 apps with the framework, but if you are interested in the
-nuts-and-bolts
+nuts and bolts
 [get in touch](http://facebook.github.io/react/support.html) with us!
 
 Thanks for reading!


### PR DESCRIPTION
Google "nuts and bolts" or see http://books.google.com/ngrams/graph?content=nuts+and+bolts%2C+nuts-and-bolts&year_start=1800&year_end=2000&corpus=15&smoothing=3&share= for evidence that this is the case. :)
