### PR TITLE
Make unmountAndReleaseReactRootNode not throw

### DIFF
--- a/src/core/ReactMount.js
+++ b/src/core/ReactMount.js
@@ -196,10 +196,14 @@ var ReactMount = {
   unmountAndReleaseReactRootNode: function(container) {
     var reactRootID = getReactRootID(container);
     var component = instanceByReactRootID[reactRootID];
-    // TODO: Consider throwing if no `component` was found.
-    component.unmountComponentFromNode(container);
-    delete instanceByReactRootID[reactRootID];
-    delete containersByReactRootID[reactRootID];
+    if (component) {
+      component.unmountComponentFromNode(container);
+      delete instanceByReactRootID[reactRootID];
+      delete containersByReactRootID[reactRootID];
+      return true;
+    } else {
+      return false;
+    }
   },
 
   /**


### PR DESCRIPTION
When there isn't any React node in the DOM, unmountAndReleaseReactRootNode threw an exception because component was undefined. Instead, return whether we were able to unmount the component.
