### PR TITLE
Update Commoner Module Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "base62": "~0.1.1",
-    "commoner": ">= 0.6.10",
+    "commoner": "~0.6.10",
     "esprima": "git://github.com/facebook/esprima#fb-harmony",
     "recast": "~0.3.3",
     "source-map": "~0.1.22"


### PR DESCRIPTION
Ran into an issue using "jsx --watch" with node 0.6.x - updated my Node to 0.10.x, but looks like this diff in commoner address this.

https://github.com/benjamn/commoner/commit/e5db855f5b5237972b1a34ab0cf61e1c39df5923

Thoughts @benjamn ?
