### PR TITLE
getDOMNodeID: Don't return .id on random objects

### DIFF
--- a/src/dom/getDOMNodeID.js
+++ b/src/dom/getDOMNodeID.js
@@ -21,8 +21,9 @@
 
 /**
  * Accessing "id" or calling getAttribute('id') on a form element can return its
- * control whose name or ID is "id". However, not all DOM nodes support
- * `getAttributeNode` (document - which is not a form) so that is checked first.
+ * control whose name or ID is "id". All DOM nodes support `getAttributeNode`
+ * but this can also get called on other objects so just return '' if we're
+ * given something other than a DOM node (such as window).
  *
  * @param {DOMElement|DOMWindow|DOMDocument} domNode DOM node.
  * @returns {string} ID of the supplied `domNode`.
@@ -32,7 +33,7 @@ function getDOMNodeID(domNode) {
     var attributeNode = domNode.getAttributeNode('id');
     return attributeNode && attributeNode.value || '';
   } else {
-    return domNode.id || '';
+    return '';
   }
 }
 


### PR DESCRIPTION
If you defined a global named `id` (a horrible name, I know) then `getDOMNodeID(window)` would return that object. Since only DOM nodes can have IDs, this should be a noop change otherwise.

Test Plan:
Verified that `document.documentElement` and `document.body` both support `getAttributeNode` in latest Chrome and in IE8.
