### PR TITLE
Put target on synthetic event, leave native alone

### DIFF
--- a/src/core/ReactEvent.js
+++ b/src/core/ReactEvent.js
@@ -144,16 +144,16 @@ function trapCapturedEvent(topLevelType, handlerBaseName, onWhat) {
  * reflows.
  */
 function registerDocumentScrollListener() {
-  listen(window, 'scroll', function(nativeEvent) {
-    if (nativeEvent.target === window) {
+  listen(window, 'scroll', function(nativeEvent, target) {
+    if (target === window) {
       BrowserEnv.refreshAuthoritativeScrollValues();
     }
   });
 }
 
 function registerDocumentResizeListener() {
-  listen(window, 'resize', function(nativeEvent) {
-    if (nativeEvent.target === window) {
+  listen(window, 'resize', function(nativeEvent, target) {
+    if (target === window) {
       BrowserEnv.refreshAuthoritativeScrollValues();
     }
   });
@@ -252,11 +252,13 @@ function listenAtTopLevel(touchNotMouse) {
 function handleTopLevel(
     topLevelType,
     nativeEvent,
+    target,
     renderedTargetID,
     renderedTarget) {
   var abstractEvents = EventPluginHub.extractAbstractEvents(
     topLevelType,
     nativeEvent,
+    target,
     renderedTargetID,
     renderedTarget
   );

--- a/src/core/ReactEventTopLevelCallback.js
+++ b/src/core/ReactEventTopLevelCallback.js
@@ -55,17 +55,21 @@ var ReactEventTopLevelCallback = {
    *   framework are called `renderedTarget`/`renderedTargetID` respectively.
    */
   createTopLevelCallback: function(topLevelType) {
-    return function(fixedNativeEvent) {
+    return function(nativeEvent, target) {
       if (!_topLevelListenersEnabled) {
         return;
       }
       var renderedTarget = ReactInstanceHandles.getFirstReactDOM(
-        fixedNativeEvent.target
+        target
       ) || ExecutionEnvironment.global;
       var renderedTargetID = getDOMNodeID(renderedTarget);
-      var event = fixedNativeEvent;
-      var target = renderedTarget;
-      ReactEvent.handleTopLevel(topLevelType, event, renderedTargetID, target);
+      ReactEvent.handleTopLevel(
+        topLevelType,
+        nativeEvent,
+        target,
+        renderedTargetID,
+        renderedTarget
+      );
     };
   }
 

--- a/src/event/AbstractEvent.js
+++ b/src/event/AbstractEvent.js
@@ -48,6 +48,7 @@ function AbstractEvent(
     abstractTargetID,  // Allows the abstract target to differ from native.
     originatingTopLevelEventType,
     nativeEvent,
+    eventTarget,
     data) {
   this.type = abstractEventType;
   this.abstractTargetID = abstractTargetID || '';
@@ -55,7 +56,7 @@ function AbstractEvent(
   this.nativeEvent = nativeEvent;
   this.data = data;
   // TODO: Deprecate storing target - doesn't always make sense for some types
-  this.target = nativeEvent && nativeEvent.target;
+  this.target = eventTarget;
 
   /**
    * As a performance optimization, we tag the existing event with the listeners
@@ -91,7 +92,7 @@ AbstractEvent.prototype.destructor = function() {
  * `PooledClass` that our copy constructor accepts five arguments (this is just
  * a performance optimization). These objects are instantiated frequently.
  */
-PooledClass.addPoolingTo(AbstractEvent, PooledClass.fiveArgumentPooler);
+PooledClass.addPoolingTo(AbstractEvent, PooledClass.sixArgumentPooler);
 
 AbstractEvent.prototype.stopPropagation = function() {
   this.isPropagationStopped = true;

--- a/src/event/EventPluginHub.js
+++ b/src/event/EventPluginHub.js
@@ -232,7 +232,7 @@ var deleteAllListeners = function(domID) {
  * @param {string} renderedTargetID string ID of `renderedTarget`.
  */
 var extractAbstractEvents =
-  function(topLevelType, nativeEvent, renderedTargetID, renderedTarget) {
+  function(topLevelType, nativeEvent, target, renderedTargetID, renderedTarget) {
     var abstractEvents;
     var plugins = injection.plugins;
     var len = plugins.length;
@@ -244,6 +244,7 @@ var extractAbstractEvents =
         possiblePlugin.extractAbstractEvents(
           topLevelType,
           nativeEvent,
+          target,
           renderedTargetID,
           renderedTarget
         );

--- a/src/event/NormalizedEventListener.js
+++ b/src/event/NormalizedEventListener.js
@@ -22,34 +22,22 @@ var EventListener = require('EventListener');
 
 /**
  * @param {?Event} eventParam Event parameter from an attached listener.
- * @return {Event} Normalized event object.
+ * @return {EventTarget} Normalized event target.
  * @private
  */
-function normalizeEvent(eventParam) {
-  var normalized = eventParam || window.event;
-  // In some browsers (OLD FF), setting the target throws an error. A good way
-  // to tell if setting the target will throw an error, is to check if the event
-  // has a `target` property. Safari events have a `target` but it's not always
-  // normalized. Even if a `target` property exists, it's good to only set the
-  // target property if we realize that a change will actually take place.
-  var hasTargetProperty = 'target' in normalized;
-  var eventTarget = normalized.target || normalized.srcElement || window;
+function normalizedTarget(eventParam) {
+  var event = eventParam || window.event;
+  var eventTarget = event.target || event.srcElement || window;
   // Safari may fire events on text nodes (Node.TEXT_NODE is 3)
   // @see http://www.quirksmode.org/js/events_properties.html
   var textNodeNormalizedTarget =
     (eventTarget.nodeType === 3) ? eventTarget.parentNode : eventTarget;
-  if (!hasTargetProperty || normalized.target !== textNodeNormalizedTarget) {
-    // Create an object that inherits from the native event so that we can set
-    // `target` on it. (It is read-only and setting it throws in strict mode).
-    normalized = Object.create(normalized);
-    normalized.target = textNodeNormalizedTarget;
-  }
-  return normalized;
+  return textNodeNormalizedTarget;
 }
 
 function createNormalizedCallback(cb) {
-  return function(unfixedNativeEvent) {
-    cb(normalizeEvent(unfixedNativeEvent));
+  return function(nativeEvent) {
+    cb(nativeEvent, normalizedTarget(nativeEvent));
   };
 }
 

--- a/src/eventPlugins/AnalyticsEventPluginFactory.js
+++ b/src/eventPlugins/AnalyticsEventPluginFactory.js
@@ -141,6 +141,7 @@ if (__DEV__) {
 function extractAbstractEvents(
     topLevelType,
     nativeEvent,
+    target,
     renderedTargetID,
     renderedTarget) {
   var currentEvent = topLevelTypesToAnalyticsEvent[topLevelType];

--- a/src/eventPlugins/EnterLeaveEventPlugin.js
+++ b/src/eventPlugins/EnterLeaveEventPlugin.js
@@ -49,6 +49,7 @@ var abstractEventTypes = {
 var extractAbstractEvents = function(
     topLevelType,
     nativeEvent,
+    target,
     renderedTargetID,
     renderedTarget) {
 
@@ -72,7 +73,7 @@ var extractAbstractEvents = function(
   }
 
   // Nothing pertains to our managed components.
-  if (from === to ) {
+  if (from === to) {
     return;
   }
 
@@ -82,13 +83,15 @@ var extractAbstractEvents = function(
     abstractEventTypes.mouseLeave,
     fromID,
     topLevelType,
-    nativeEvent
+    nativeEvent,
+    target
   );
   var enter = AbstractEvent.getPooled(
     abstractEventTypes.mouseEnter,
     toID,
     topLevelType,
-    nativeEvent
+    nativeEvent,
+    target
   );
   EventPropagators.accumulateEnterLeaveDispatches(leave, enter, fromID, toID);
   return [leave, enter];

--- a/src/eventPlugins/ResponderEventPlugin.js
+++ b/src/eventPlugins/ResponderEventPlugin.js
@@ -169,7 +169,7 @@ var abstractEventTypes = {
  * @return {Accumulation<AbstractEvent>} Extracted events.
  */
 var setResponderAndExtractTransfer =
-  function(topLevelType, nativeEvent, renderedTargetID) {
+  function(topLevelType, nativeEvent, target, renderedTargetID) {
     var type;
     var shouldSetEventType =
       isStartish(topLevelType) ? abstractEventTypes.startShouldSetResponder :
@@ -182,6 +182,7 @@ var setResponderAndExtractTransfer =
       bubbleShouldSetFrom,
       topLevelType,
       nativeEvent,
+      target,
       AbstractEvent.normalizePointerData(nativeEvent)
     );
     EventPropagators.accumulateTwoPhaseDispatches(shouldSetEvent);
@@ -196,7 +197,8 @@ var setResponderAndExtractTransfer =
       abstractEventTypes.responderGrant,
       wantsResponderID,
       topLevelType,
-      nativeEvent
+      nativeEvent,
+      target
     );
 
     EventPropagators.accumulateDirectDispatches(grantEvent);
@@ -213,7 +215,8 @@ var setResponderAndExtractTransfer =
           terminateType,
           responderID,
           topLevelType,
-          nativeEvent
+          nativeEvent,
+          target
         );
         EventPropagators.accumulateDirectDispatches(terminateEvent);
         extracted = accumulate(extracted, [grantEvent, terminateEvent]);
@@ -223,7 +226,8 @@ var setResponderAndExtractTransfer =
           abstractEventTypes.responderReject,
           wantsResponderID,
           topLevelType,
-          nativeEvent
+          nativeEvent,
+          target
         );
         EventPropagators.accumulateDirectDispatches(rejectEvent);
         extracted = accumulate(extracted, rejectEvent);
@@ -254,7 +258,7 @@ function canTriggerTransfer(topLevelType) {
 }
 
 var extractAbstractEvents =
-  function(topLevelType, nativeEvent, renderedTargetID, renderedTarget) {
+  function(topLevelType, nativeEvent, target, renderedTargetID, renderedTarget) {
     var extracted;
     // Must have missed an end event - reset the state here.
     if (responderID && isStartish(topLevelType)) {
@@ -269,8 +273,8 @@ var extractAbstractEvents =
       var transfer = setResponderAndExtractTransfer(
         topLevelType,
         nativeEvent,
-        renderedTargetID,
-        renderedTarget
+        target,
+        renderedTargetID
       );
       if (transfer) {
         extracted = accumulate(extracted, transfer);
@@ -288,6 +292,7 @@ var extractAbstractEvents =
         responderID,
         topLevelType,
         nativeEvent,
+        target,
         data
       );
       EventPropagators.accumulateDirectDispatches(gesture);

--- a/src/eventPlugins/SimpleEventPlugin.js
+++ b/src/eventPlugins/SimpleEventPlugin.js
@@ -164,46 +164,51 @@ var SimpleEventPlugin = {
   /**
    * @see EventPluginHub.extractAbstractEvents
    */
-  extractAbstractEvents:
-    function(topLevelType, nativeEvent, renderedTargetID, renderedTarget) {
-      var data;
-      var abstractEventType =
-        SimpleEventPlugin.topLevelTypesToAbstract[topLevelType];
-      if (!abstractEventType) {
-        return null;
-      }
-      switch(topLevelType) {
-        case topLevelTypes.topMouseWheel:
-          data = AbstractEvent.normalizeMouseWheelData(nativeEvent);
-          break;
-        case topLevelTypes.topScroll:
-          data = AbstractEvent.normalizeScrollDataFromTarget(renderedTarget);
-          break;
-        case topLevelTypes.topClick:
-        case topLevelTypes.topDoubleClick:
-        case topLevelTypes.topChange:
-        case topLevelTypes.topDOMCharacterDataModified:
-        case topLevelTypes.topMouseDown:
-        case topLevelTypes.topMouseUp:
-        case topLevelTypes.topMouseMove:
-        case topLevelTypes.topTouchMove:
-        case topLevelTypes.topTouchStart:
-        case topLevelTypes.topTouchEnd:
-          data = AbstractEvent.normalizePointerData(nativeEvent);
-          break;
-        default:
-          data = null;
-      }
-      var abstractEvent = AbstractEvent.getPooled(
-        abstractEventType,
-        renderedTargetID,
-        topLevelType,
-        nativeEvent,
-        data
-      );
-      EventPropagators.accumulateTwoPhaseDispatches(abstractEvent);
-      return abstractEvent;
+  extractAbstractEvents: function(
+      topLevelType,
+      nativeEvent,
+      target,
+      renderedTargetID,
+      renderedTarget) {
+    var data;
+    var abstractEventType =
+      SimpleEventPlugin.topLevelTypesToAbstract[topLevelType];
+    if (!abstractEventType) {
+      return null;
     }
+    switch(topLevelType) {
+      case topLevelTypes.topMouseWheel:
+        data = AbstractEvent.normalizeMouseWheelData(nativeEvent);
+        break;
+      case topLevelTypes.topScroll:
+        data = AbstractEvent.normalizeScrollDataFromTarget(renderedTarget);
+        break;
+      case topLevelTypes.topClick:
+      case topLevelTypes.topDoubleClick:
+      case topLevelTypes.topChange:
+      case topLevelTypes.topDOMCharacterDataModified:
+      case topLevelTypes.topMouseDown:
+      case topLevelTypes.topMouseUp:
+      case topLevelTypes.topMouseMove:
+      case topLevelTypes.topTouchMove:
+      case topLevelTypes.topTouchStart:
+      case topLevelTypes.topTouchEnd:
+        data = AbstractEvent.normalizePointerData(nativeEvent);
+        break;
+      default:
+        data = null;
+    }
+    var abstractEvent = AbstractEvent.getPooled(
+      abstractEventType,
+      renderedTargetID,
+      topLevelType,
+      nativeEvent,
+      target,
+      data
+    );
+    EventPropagators.accumulateTwoPhaseDispatches(abstractEvent);
+    return abstractEvent;
+  }
 };
 
 SimpleEventPlugin.topLevelTypesToAbstract = {

--- a/src/eventPlugins/TapEventPlugin.js
+++ b/src/eventPlugins/TapEventPlugin.js
@@ -51,6 +51,7 @@ var abstractEventTypes = {
 var extractAbstractEvents = function(
     topLevelType,
     nativeEvent,
+    target,
     renderedTargetID,
     renderedTarget) {
 
@@ -66,7 +67,8 @@ var extractAbstractEvents = function(
       type,
       abstractTargetID,
       topLevelType,
-      nativeEvent
+      nativeEvent,
+      target
     );
   }
   if (isStartish(topLevelType)) {

--- a/src/eventPlugins/__tests__/ResponderEventPlugin-test.js
+++ b/src/eventPlugins/__tests__/ResponderEventPlugin-test.js
@@ -34,6 +34,7 @@ var responderAbstractEventTypes;
 var spies;
 
 var DUMMY_NATIVE_EVENT = {};
+var DUMMY_TARGET = {};
 var DUMMY_RENDERED_TARGET = {};
 
 var onStartShouldSetResponder = function(id, cb, capture) {
@@ -82,6 +83,7 @@ var extractForTouchStart = function(renderedTargetID) {
   return ResponderEventPlugin.extractAbstractEvents(
     topLevelTypes.topTouchStart,
     DUMMY_NATIVE_EVENT,
+    DUMMY_TARGET,
     renderedTargetID,
     DUMMY_RENDERED_TARGET
   );
@@ -91,6 +93,7 @@ var extractForTouchMove = function(renderedTargetID) {
   return ResponderEventPlugin.extractAbstractEvents(
     topLevelTypes.topTouchMove,
     DUMMY_NATIVE_EVENT,
+    DUMMY_TARGET,
     renderedTargetID,
     DUMMY_RENDERED_TARGET
   );
@@ -100,6 +103,7 @@ var extractForTouchEnd = function(renderedTargetID) {
   return ResponderEventPlugin.extractAbstractEvents(
     topLevelTypes.topTouchEnd,
     DUMMY_NATIVE_EVENT,
+    DUMMY_TARGET,
     renderedTargetID,
     DUMMY_RENDERED_TARGET
   );
@@ -109,6 +113,7 @@ var extractForMouseDown = function(renderedTargetID) {
   return ResponderEventPlugin.extractAbstractEvents(
     topLevelTypes.topMouseDown,
     DUMMY_NATIVE_EVENT,
+    DUMMY_TARGET,
     renderedTargetID,
     DUMMY_RENDERED_TARGET
   );
@@ -118,6 +123,7 @@ var extractForMouseMove = function(renderedTargetID) {
   return ResponderEventPlugin.extractAbstractEvents(
     topLevelTypes.topMouseMove,
     DUMMY_NATIVE_EVENT,
+    DUMMY_TARGET,
     renderedTargetID,
     DUMMY_RENDERED_TARGET
   );
@@ -128,6 +134,7 @@ var extractForMouseUp = function(renderedTargetID) {
   return ResponderEventPlugin.extractAbstractEvents(
     topLevelTypes.topMouseUp,
     DUMMY_NATIVE_EVENT,
+    DUMMY_TARGET,
     renderedTargetID,
     DUMMY_RENDERED_TARGET
   );
@@ -137,6 +144,7 @@ var extractForScroll = function(renderedTargetID) {
   return ResponderEventPlugin.extractAbstractEvents(
     topLevelTypes.topScroll,
     DUMMY_NATIVE_EVENT,
+    DUMMY_TARGET,
     renderedTargetID,
     DUMMY_RENDERED_TARGET
   );

--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -193,7 +193,7 @@ var ReactTestUtils = {
     var virtualHandler =
       ReactEvent.TopLevelCallbackCreator.createTopLevelCallback(topLevelType);
     fakeNativeEvent.target = node;
-    virtualHandler(fakeNativeEvent);
+    virtualHandler(fakeNativeEvent, node);
   },
 
   /**
@@ -214,7 +214,7 @@ var ReactTestUtils = {
     fakeNativeEvent.target = node;
     /* jsdom is returning nodes without id's - fixing that issue here. */
     node.id = reactRootID;
-    virtualHandler(fakeNativeEvent);
+    virtualHandler(fakeNativeEvent, node);
   },
 
   nativeTouchData: function(x, y) {

--- a/src/utils/PooledClass.js
+++ b/src/utils/PooledClass.js
@@ -47,14 +47,14 @@ var twoArgumentPooler = function(a1, a2) {
   }
 };
 
-var fiveArgumentPooler = function(a1, a2, a3, a4, a5) {
+var sixArgumentPooler = function(a1, a2, a3, a4, a5, a6) {
   var Klass = this;
   if (Klass.instancePool.length) {
     var instance = Klass.instancePool.pop();
-    Klass.call(instance, a1, a2, a3, a4, a5);
+    Klass.call(instance, a1, a2, a3, a4, a5, a6);
     return instance;
   } else {
-    return new Klass(a1, a2, a3, a4, a5);
+    return new Klass(a1, a2, a3, a4, a5, a6);
   }
 };
 
@@ -95,7 +95,7 @@ var PooledClass = {
   addPoolingTo: addPoolingTo,
   oneArgumentPooler: oneArgumentPooler,
   twoArgumentPooler: twoArgumentPooler,
-  fiveArgumentPooler: fiveArgumentPooler
+  sixArgumentPooler: sixArgumentPooler
 };
 
 module.exports = PooledClass;


### PR DESCRIPTION
The Object.create code in src/event/NormalizedEventListener.js was causing problems in IE -- 8 doesn't support Object.create and 9 and 10 weren't happy with the assignment to the read-only target property even after the copy using Object.create. Instead, pass the target property around separately and attach it directly to the AbstractEvent.

I'm told that the FB codebase has 38 uses of .nativeEvent.target but that they can be changed.
