### PR TITLE
Cleanup lint warnings in src

### DIFF
--- a/src/core/ReactComponent.js
+++ b/src/core/ReactComponent.js
@@ -125,7 +125,9 @@ function assignKey(groupingIndex, child, index) {
 function tryToReuseArray(children) {
   for (var i = 0; i < children.length; i++) {
     var child = children[i];
-    if (isEmptyChild(child)) return false;
+    if (isEmptyChild(child)) {
+      return false;
+    }
     assignKey(0, child, i);
   }
   return true;
@@ -142,7 +144,9 @@ function tryToReuseArray(children) {
 function appendNestedChildren(groupingIndex, sourceArray, targetArray) {
   for (var i = 0; i < sourceArray.length; i++) {
     var child = sourceArray[i];
-    if (isEmptyChild(child)) continue;
+    if (isEmptyChild(child)) {
+      continue;
+    }
     assignKey(groupingIndex, child, i);
     // TODO: Invalid components like strings could possibly need
     // keys assigned to them here. Usually they're not stateful but
@@ -338,9 +342,13 @@ var ReactComponent = {
       for (var i = 1; i < arguments.length; i++) {
         var child = arguments[i];
         if (Array.isArray(child)) {
-          if (child.length === 0) continue;
+          if (child.length === 0) {
+            continue;
+          }
 
-          if (targetArray === null) targetArray = [];
+          if (targetArray === null) {
+            targetArray = [];
+          }
           appendNestedChildren(i - 1, child, targetArray);
 
         } else if (!isEmptyChild(child)) {
@@ -352,7 +360,9 @@ var ReactComponent = {
             child._key = createKey(child.props.key, i - 1);
           }
 
-          if (targetArray === null) targetArray = [];
+          if (targetArray === null) {
+            targetArray = [];
+          }
           targetArray.push(child);
 
         }

--- a/src/core/ReactCurrentOwner.js
+++ b/src/core/ReactCurrentOwner.js
@@ -40,7 +40,9 @@ var ReactCurrentOwner = {
    */
   getDepth: function() {
     var owner = ReactCurrentOwner.current;
-    if (!owner) return 0;
+    if (!owner) {
+      return 0;
+    }
     return owner._compositionLevel;
   }
 

--- a/src/dom/DOMChildrenOperations.js
+++ b/src/dom/DOMChildrenOperations.js
@@ -16,6 +16,9 @@
  * @providesModule DOMChildrenOperations
  */
 
+// Empty blocks improve readability so disable that warning
+// jshint -W035
+
 "use strict";
 
 var Danger = require('Danger');

--- a/src/dom/getEventTarget.js
+++ b/src/dom/getEventTarget.js
@@ -17,6 +17,8 @@
  * @typechecks
  */
 
+"use strict";
+
 var ExecutionEnvironment = require('ExecutionEnvironment');
 
 /**

--- a/src/event/synthetic/SyntheticEvent.js
+++ b/src/event/synthetic/SyntheticEvent.js
@@ -17,6 +17,8 @@
  * @typechecks
  */
 
+"use strict";
+
 var PooledClass = require('PooledClass');
 
 var emptyFunction = require('emptyFunction');

--- a/src/event/synthetic/SyntheticFocusEvent.js
+++ b/src/event/synthetic/SyntheticFocusEvent.js
@@ -17,6 +17,8 @@
  * @typechecks
  */
 
+"use strict";
+
 var SyntheticUIEvent = require('SyntheticUIEvent');
 
 /**

--- a/src/event/synthetic/SyntheticKeyboardEvent.js
+++ b/src/event/synthetic/SyntheticKeyboardEvent.js
@@ -17,6 +17,8 @@
  * @typechecks
  */
 
+"use strict";
+
 var SyntheticUIEvent = require('SyntheticUIEvent');
 
 /**

--- a/src/event/synthetic/SyntheticMouseEvent.js
+++ b/src/event/synthetic/SyntheticMouseEvent.js
@@ -17,6 +17,8 @@
  * @typechecks
  */
 
+"use strict";
+
 var BrowserEnv = require('BrowserEnv');
 var SyntheticUIEvent = require('SyntheticUIEvent');
 

--- a/src/event/synthetic/SyntheticMutationEvent.js
+++ b/src/event/synthetic/SyntheticMutationEvent.js
@@ -17,6 +17,8 @@
  * @typechecks
  */
 
+"use strict";
+
 var SyntheticEvent = require('SyntheticEvent');
 
 /**

--- a/src/event/synthetic/SyntheticTouchEvent.js
+++ b/src/event/synthetic/SyntheticTouchEvent.js
@@ -17,6 +17,8 @@
  * @typechecks
  */
 
+"use strict";
+
 var SyntheticUIEvent = require('SyntheticUIEvent');
 
 /**

--- a/src/event/synthetic/SyntheticUIEvent.js
+++ b/src/event/synthetic/SyntheticUIEvent.js
@@ -17,6 +17,8 @@
  * @typechecks
  */
 
+"use strict";
+
 var SyntheticEvent = require('SyntheticEvent');
 
 /**

--- a/src/event/synthetic/SyntheticWheelEvent.js
+++ b/src/event/synthetic/SyntheticWheelEvent.js
@@ -17,6 +17,8 @@
  * @typechecks
  */
 
+"use strict";
+
 var SyntheticMouseEvent = require('SyntheticMouseEvent');
 
 /**

--- a/src/eventPlugins/EnterLeaveEventPlugin.js
+++ b/src/eventPlugins/EnterLeaveEventPlugin.js
@@ -72,8 +72,9 @@ var EnterLeaveEventPlugin = {
     var from, to;
     if (topLevelType === topLevelTypes.topMouseOut) {
       from = topLevelTarget;
-      to = getFirstReactDOM(nativeEvent.relatedTarget || nativeEvent.toElement)
-        || ExecutionEnvironment.global;
+      to =
+        getFirstReactDOM(nativeEvent.relatedTarget || nativeEvent.toElement) ||
+        ExecutionEnvironment.global;
     } else {
       from = ExecutionEnvironment.global;
       to = topLevelTarget;

--- a/src/utils/mergeDeepInto.js
+++ b/src/utils/mergeDeepInto.js
@@ -16,6 +16,9 @@
  * @providesModule mergeDeepInto
  */
 
+// Empty blocks improve readability so disable that warning
+// jshint -W035
+
 "use strict";
 
 var keyMirror = require('keyMirror');


### PR DESCRIPTION
Mostly trivial things that should have been caught upstream + some jshint directives to ignore empty block warnings in those files. We might want to eventually clean those up anway.

I'm trying this thing where I work exclusively in the github repo and try to improve the sync process. To that end, feel free to "accept" here but don't merge it in.
