### PR TITLE
Upgrade Commoner and Recast to latest versions

### DIFF
--- a/grunt/tasks/jsx.js
+++ b/grunt/tasks/jsx.js
@@ -10,6 +10,7 @@ module.exports = function() {
   var args = [
     "bin/jsx",
     "--cache-dir", ".module-cache",
+    "--relativize",
     config.sourceDir,
     config.outputDir
   ];

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   },
   "dependencies": {
     "base62": "~0.1.1",
-    "commoner": "~0.6.8",
+    "commoner": "~0.7.0",
     "esprima": "git://github.com/facebook/esprima#fb-harmony",
-    "recast": "~0.3.3",
+    "recast": "~0.4.5",
     "source-map": "~0.1.22"
   },
   "devDependencies": {


### PR DESCRIPTION
The Commoner upgrade is a big one because it makes `bin/jsx` no longer rewrite module identifiers to be relative by default, which should reduce confusion for people trying to use it as a standalone transformer.

Closes #80.
