### PR TITLE
Exposing ReactProps as React.Props

### DIFF
--- a/src/core/React.js
+++ b/src/core/React.js
@@ -22,6 +22,7 @@ var ReactCompositeComponent = require('ReactCompositeComponent');
 var ReactComponent = require('ReactComponent');
 var ReactDOM = require('ReactDOM');
 var ReactMount = require('ReactMount');
+var ReactProps = require('ReactProps');
 var ReactServerRendering = require('ReactServerRendering');
 
 var ReactDefaultInjection = require('ReactDefaultInjection');
@@ -30,6 +31,7 @@ ReactDefaultInjection.inject();
 
 var React = {
   DOM: ReactDOM,
+  Props: ReactProps,  
   initializeTouchEvents: function(shouldUseTouch) {
     ReactMount.useTouchEvents = shouldUseTouch;
   },


### PR DESCRIPTION
Right now, even though ReactProps is committed, there is no way to use it as it is not exposed.
