### PR TITLE
Fix `EventPluginRegistry` Unit Tests

### DIFF
--- a/src/event/EventPluginRegistry.js
+++ b/src/event/EventPluginRegistry.js
@@ -3,6 +3,8 @@
  * @typechecks
  */
 
+"use strict";
+
 var invariant = require('invariant');
 
 /**
@@ -200,6 +202,27 @@ var EventPluginRegistry = {
       }
     }
     return null;
+  },
+
+  /**
+   * Exposed for unit testing.
+   * @private
+   */
+  _resetEventPlugins: function() {
+    EventPluginOrder = null;
+    for (var pluginName in namesToPlugins) {
+      if (namesToPlugins.hasOwnProperty(pluginName)) {
+        delete namesToPlugins[pluginName];
+      }
+    }
+    EventPluginRegistry.plugins.length = 0;
+    var registrationNames = EventPluginRegistry.registrationNames;
+    for (var registrationName in registrationNames) {
+      if (registrationNames.hasOwnProperty(registrationName)) {
+        delete registrationNames[registrationName];
+      }
+    }
+    EventPluginRegistry.registrationNamesKeys.length = 0;
   }
 
 };

--- a/src/event/__tests__/EventPluginRegistry-test.js
+++ b/src/event/__tests__/EventPluginRegistry-test.js
@@ -11,8 +11,8 @@ describe('EventPluginRegistry', function() {
   var createPlugin;
 
   beforeEach(function() {
-    require('mock-modules').dumpCache();
     EventPluginRegistry = require('EventPluginRegistry');
+    EventPluginRegistry._resetEventPlugins();
 
     createPlugin = function(properties) {
       return merge({extractEvents: function() {}}, properties);

--- a/src/eventPlugins/__tests__/AnalyticsEventPlugin-test.js
+++ b/src/eventPlugins/__tests__/AnalyticsEventPlugin-test.js
@@ -24,20 +24,25 @@ var mocks = require('mocks');
 describe('AnalyticsEventPlugin', function() {
   var AnalyticsEventPluginFactory;
   var EventPluginHub;
+  var EventPluginRegistry;
   var React;
+  var ReactDefaultInjection;
   var ReactEventEmitter;
   var ReactEventTopLevelCallback;
   var ReactTestUtils;
 
   beforeEach(function() {
-    require('mock-modules').dumpCache();
-
     AnalyticsEventPluginFactory = require('AnalyticsEventPluginFactory');
     EventPluginHub = require('EventPluginHub');
+    EventPluginRegistry = require('EventPluginRegistry');
     React = require('React');
+    ReactDefaultInjection = require('ReactDefaultInjection');
     ReactEventEmitter = require('ReactEventEmitter');
     ReactEventTopLevelCallback = require('ReactEventTopLevelCallback');
     ReactTestUtils = require('ReactTestUtils');
+
+    EventPluginRegistry._resetEventPlugins();
+    ReactDefaultInjection.inject();
 
     ReactEventEmitter.ensureListening(false, ReactEventTopLevelCallback);
   });


### PR DESCRIPTION
Dumping the mock cache isn't dirying the modules, so we have to unit test a different way. If we can fix our unit test framework, we should revert this.

Also, I added strict mode to `EventPluginRegistry.js`.

**Test Plan**
Ran `grunt test` successfully.
