### PR TITLE
Remove second argument to invariant()

### DIFF
--- a/vendor/constants.js
+++ b/vendor/constants.js
@@ -34,6 +34,15 @@ var ConstantVisitor = recast.Visitor.extend({
     }
   },
 
+  visitCallExpression: function(call) {
+    if (!this.constants.__DEV__) {
+      if (call.callee.type === 'Identifier' && call.callee.name === 'invariant') {
+        call.arguments.length = 1;
+      }
+    }
+    this.genericVisit(call);
+  },
+
   visitIfStatement: function(stmt) {
     // Replaces all identifiers in this.constants with literal values.
     this.genericVisit(stmt);


### PR DESCRIPTION
We were leaving the invariant strings in our minified builds. This diff saves 4kb pre-gzip in minified React.

@benjamn @jeffmo @zpao
