### PR TITLE
Rename Woodchipper to ConstantVisitor, and simplify the vendor/constants.js interface

### DIFF
--- a/bin/jsx
+++ b/bin/jsx
@@ -25,17 +25,12 @@ require("commoner").resolve(function(id) {
 
 }).process(function(id, source) {
   var context = this;
+  var constants = context.config.constants || {};
 
   // This is where JSX, ES6, etc. desugaring happens.
   source = transform(visitors.react, source).code;
 
-  return context.makePromise(function(callback) {
-    var constants = context.config.constants || {};
-
-    // Constant propagation means removing dead code after replacing
-    // constant conditional expressions with literal (boolean) values.
-    propagate(constants, source, function(source) {
-      callback(null, source);
-    });
-  });
+  // Constant propagation means removing any obviously dead code after
+  // replacing constant expressions with literal (boolean) values.
+  return propagate(constants, source);
 });

--- a/vendor/constants.js
+++ b/vendor/constants.js
@@ -17,14 +17,10 @@
 
 var recast = require('recast');
 
-exports.propagate = function(constants, source, writeback) {
-  recast.runString(
-    source,
-    function(ast, callback) {
-      callback(new ConstantVisitor(constants).visit(ast));
-    },
-    { writeback: writeback }
-  );
+exports.propagate = function(constants, source) {
+  var ast = recast.parse(source);
+  ast = new ConstantVisitor(constants).visit(ast);
+  return recast.print(ast);
 };
 
 var ConstantVisitor = recast.Visitor.extend({


### PR DESCRIPTION
I think "constant propagation" is the best term for what this module is doing, so I've altered the terminology to reflect that intent: http://en.wikipedia.org/wiki/Constant_folding#Constant_propagation

While I was at it, I simplified the `require("vendor/constants").propagate` interface to be synchronous instead of requiring a callback.
