### PR TITLE
Fix package.json's reference to vendor/constants.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bin/jsx",
     "build/modules/",
     "vendor/fbtransform/",
-    "vendor/woodchipper.js"
+    "vendor/constants.js"
   ],
   "main": "main.js",
   "bin": {


### PR DESCRIPTION
This fixes the package.json so that when installing react-tools via npm, everything works.

As a heads up, I signed the CLA. Cheers!
