### PR TITLE
Use github tarball link for esprima dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "base62": "~0.1.1",
     "commoner": "~0.7.0",
-    "esprima": "git://github.com/facebook/esprima#fb-harmony",
+    "esprima": "https://github.com/facebook/esprima/tarball/ca28795124d45968e62a7b4b336d23a053ac3a84",
     "recast": "~0.4.8",
     "source-map": "~0.1.22"
   },


### PR DESCRIPTION
It turns out that (at least for local development) npm has a long
standing bug where it doesn't recognize changing dependencies stored as
git urls (see https://github.com/isaacs/npm/issues/1727). Luckily npm
understand tarballs and GitHub provides tarballs for every commit, so
the workaround is easy, though unfortunate.

We'll want to put out a 0.3.x for this so that we don't break it when @jeffmo updates esprima
