### PR TITLE
The compare_size cache gets wiped out with `grunt clean`

### DIFF
--- a/grunt/config/compare_size.js
+++ b/grunt/config/compare_size.js
@@ -12,6 +12,6 @@ module.exports = {
         return gzip.zip(contents, {}).length;
       }
     },
-    cache: "build/.sizecache.json"
+    cache: ".grunt/sizecache.json"
   }
 };


### PR DESCRIPTION
`.grunt/` is the directory that is suggested for storing task related
files, and this file is not useful if it gets wiped out often. So I'm
moving the compare_size cache into `.grunt/` so we keep it around
longer.
