### PR TITLE
Double quotes for strings in JSON data

### DIFF
--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -262,8 +262,8 @@ So far we've been inserting the comments directly in the source code. Instead, l
 ```javascript
 // tutorial8.js
 var data = [
-  {author: 'Pete Hunt', text: 'This is one comment'},
-  {author: 'Jordan Walke', text: 'This is *another* comment'}
+  {author: "Pete Hunt", text: "This is one comment"},
+  {author: "Jordan Walke", text: "This is *another* comment"}
 ];
 ```
 
@@ -357,8 +357,8 @@ When the component is first created, we want to GET some JSON from the server an
 ```javascript
 // tutorial13.json
 [
-  {'author': 'Pete Hunt', 'text': 'This is one comment'},
-  {'author': 'Jordan Walke', 'text': 'This is *another* comment'}
+  {"author": "Pete Hunt", "text": "This is one comment"},
+  {"author": "Jordan Walke", "text": "This is *another* comment"}
 ]
 ```
 


### PR DESCRIPTION
Use double quotes rather than single quotes for JSON data in the tutorial, as per JSON specification. Otherwise, jQuery will fail silently. Taken from the jQuery documentation: 

Important: As of jQuery 1.4, if the JSON file contains a syntax error, the request will usually fail silently. Avoid frequent hand-editing of JSON data for this reason. JSON is a data-interchange format with syntax rules that are stricter than those of JavaScript's object literal notation. For example, all strings represented in JSON, whether they are properties or values, must be enclosed in double-quotes. For details on the JSON format, see http://json.org/.
