### PR TITLE
Add support for empty XJS expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "base62": "~0.1.1",
     "commoner": "~0.7.0",
-    "esprima": "https://github.com/facebook/esprima/tarball/ca28795124d45968e62a7b4b336d23a053ac3a84",
+    "esprima": "https://github.com/facebook/esprima/tarball/a3e0ea3979eb8d54d8bfade220c272903f928b1e",
     "recast": "~0.4.8",
     "source-map": "~0.1.22"
   },

--- a/vendor/fbtransform/transforms/react.js
+++ b/vendor/fbtransform/transforms/react.js
@@ -24,7 +24,8 @@ var move = require('../lib/utils').move;
 var getDocblock = require('../lib/utils').getDocblock;
 
 var FALLBACK_TAGS = require('./xjs').knownTags;
-var renderXJSExpression = require('./xjs').renderXJSExpression;
+var renderXJSExpressionContainer =
+  require('./xjs').renderXJSExpressionContainer;
 var renderXJSLiteral = require('./xjs').renderXJSLiteral;
 var quoteAttrName = require('./xjs').quoteAttrName;
 
@@ -121,7 +122,7 @@ function visitReactTag(traverse, object, path, state) {
       renderXJSLiteral(attr.value, isLast, state);
     } else {
       move(attr.value.range[0], state);
-      renderXJSExpression(traverse, attr.value, isLast, path, state);
+      renderXJSExpressionContainer(traverse, attr.value, isLast, path, state);
     }
 
     if (isLast) {
@@ -150,8 +151,8 @@ function visitReactTag(traverse, object, path, state) {
 
       if (child.type === Syntax.Literal) {
         renderXJSLiteral(child, isLast, state);
-      } else if (child.type === Syntax.XJSExpression) {
-        renderXJSExpression(traverse, child, isLast, path, state);
+      } else if (child.type === Syntax.XJSExpressionContainer) {
+        renderXJSExpressionContainer(traverse, child, isLast, path, state);
       } else {
         traverse(child, path, state);
         if (!isLast) {

--- a/vendor/fbtransform/transforms/xjs.js
+++ b/vendor/fbtransform/transforms/xjs.js
@@ -15,9 +15,10 @@
  */
 /*global exports:true*/
 "use strict";
-var catchup = require('../lib/utils').catchup;
 var append = require('../lib/utils').append;
+var catchup = require('../lib/utils').catchup;
 var move = require('../lib/utils').move;
+var Syntax = require('esprima').Syntax;
 
 var knownTags = {
   a: true,
@@ -255,15 +256,16 @@ function renderXJSLiteral(object, isLast, state, start, end) {
   move(object.range[1], state);
 }
 
-function renderXJSExpression(traverse, object, isLast, path, state) {
+function renderXJSExpressionContainer(traverse, object, isLast, path, state) {
   // Plus 1 to skip `{`.
   move(object.range[0] + 1, state);
-  traverse(object.value, path, state);
-  if (!isLast) {
+  traverse(object.expression, path, state);
+  if (!isLast && object.expression.type !== Syntax.XJSEmptyExpression) {
     // If we need to append a comma, make sure to do so after the expression.
-    catchup(object.value.range[1], state);
+    catchup(object.expression.range[1], state);
     append(',', state);
   }
+
   // Minus 1 to skip `}`.
   catchup(object.range[1] - 1, state);
   move(object.range[1], state);
@@ -279,6 +281,6 @@ function quoteAttrName(attr) {
 }
 
 exports.knownTags = knownTags;
-exports.renderXJSExpression = renderXJSExpression;
+exports.renderXJSExpressionContainer = renderXJSExpressionContainer;
 exports.renderXJSLiteral = renderXJSLiteral;
 exports.quoteAttrName = quoteAttrName;


### PR DESCRIPTION
Allows for empty expressions so that something like this is now possible:
`
<div>
  {/* this is a comment */}
  <span>child1</span>
 </div>`

This then becomes a good way of commenting within a JSX child declaration body

See https://github.com/facebook/react/issues/82
