### PR TITLE
Avoid using Object.create for sham-less IE8 compatibility

### DIFF
--- a/src/event/synthetic/SyntheticEvent.js
+++ b/src/event/synthetic/SyntheticEvent.js
@@ -141,10 +141,13 @@ SyntheticEvent.Interface = EventInterface;
 SyntheticEvent.augmentClass = function(Class, Interface) {
   var Super = this;
 
-  var prototype = Object.create(Super.prototype);
+  function ctor() {
+    this.constructor = Class;
+  }
+  ctor.prototype = Super.prototype;
+  var prototype = new ctor();
   mergeInto(prototype, Class.prototype);
   Class.prototype = prototype;
-  Class.prototype.constructor = Class;
 
   Class.Interface = merge(Super.Interface, Interface);
   Class.augmentClass = Super.augmentClass;


### PR DESCRIPTION
Instead of using Object.create, just shuffle the prototypes around so that we don't need to include es5-sham.
