### PR TITLE
Bump Commoner version to fix EMFILE errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "base62": "~0.1.1",
-    "commoner": "~0.7.0",
+    "commoner": "~0.7.1",
     "esprima": "https://github.com/facebook/esprima/tarball/a3e0ea3979eb8d54d8bfade220c272903f928b1e",
     "recast": "~0.4.8",
     "source-map": "~0.1.22"


### PR DESCRIPTION
Finally found a more robust solution for the "too many open files"
problem: https://github.com/benjamn/commoner/commit/ad72ba42db.

Closes #137.
Closes #138.

cc @zpao @jeffreylin
