### PR TITLE
Bump Commoner version to disable dependency scanning by default

### DIFF
--- a/grunt/tasks/jsx.js
+++ b/grunt/tasks/jsx.js
@@ -11,6 +11,7 @@ module.exports = function() {
   var args = [
     "--cache-dir", ".module-cache",
     "--relativize",
+    "--follow-requires",
     config.sourceDir,
     config.outputDir
   ];

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "base62": "~0.1.1",
-    "commoner": "~0.7.1",
+    "commoner": "~0.8.0",
     "esprima": "https://github.com/facebook/esprima/tarball/a3e0ea3979eb8d54d8bfade220c272903f928b1e",
     "recast": "~0.4.8",
     "source-map": "~0.1.22"


### PR DESCRIPTION
If you are using `bin/jsx` independently, you may need to pass `--follow-requires` to it if you rely on its dependency scanning.

Dependency scanning is still a good idea, but it's difficult to make it work perfectly for everyone the first time they try `bin/jsx`.

Closes #131.

cc @petehunt @zpao 
