### PR TITLE
Upgrade Commoner to --watch directories instead of individual files

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "base62": "~0.1.1",
-    "commoner": "~0.8.0",
+    "commoner": "~0.8.3",
     "esprima": "https://github.com/facebook/esprima/tarball/a3e0ea3979eb8d54d8bfade220c272903f928b1e",
     "recast": "~0.4.8",
     "source-map": "~0.1.22"


### PR DESCRIPTION
This behavior is new in Commoner v0.8.3, following the incorporation of @jeffreylin's `DirWatcher` implementation:
https://github.com/jeffreylin/jsx_transformer_fun/blob/master/dirWatcher.js

Watching directories instead of files reduces the total number of open files, and copes better with editors that save files by deleting and then immediately recreating them.

Closes #60.
Closes #71.

cc @jeffreylin @zpao @petehunt 
