### PR TITLE
Don't auto-upgrade phantomjs dependency past 1.9.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-jshint": "~0.5.4",
     "optimist": "~0.4.0",
-    "phantomjs": ">= 1.9.0",
+    "phantomjs": "~1.9.0",
     "semver": ">= 1.1.4",
     "uglify-js": "~2.3.6",
     "grunt-contrib-clean": "~0.4.1",


### PR DESCRIPTION
As discussed here: https://github.com/facebook/react/pull/167#issuecomment-20543568

cc @zpao
