### PR TITLE
Example Bootstrap modal closing bug fix.

### DIFF
--- a/examples/jquery-bootstrap/js/app.js
+++ b/examples/jquery-bootstrap/js/app.js
@@ -19,11 +19,16 @@ var BootstrapModal = React.createClass({
   // integrate with Bootstrap or jQuery!
   componentDidMount: function() {
     // When the component is added, turn it into a modal
-    $(this.getDOMNode()).modal({backdrop: 'static', keyboard: false});
+    $(this.getDOMNode())
+      .modal({
+        backdrop: 'static',
+        keyboard: false,
+        show: this.props.initiallyVisible
+      })
+      .on('hidden', this.handleHidden);
   },
   componentWillUnmount: function() {
-    // And when it's destroyed, hide it.
-    $(this.getDOMNode()).modal('hide');
+    $(this.getDOMNode()).off('hidden', this.handleHidden);
   },
   render: function() {
     var confirmButton = null;
@@ -67,51 +72,53 @@ var BootstrapModal = React.createClass({
       </div>
     );
   },
+  close: function() {
+    $(this.getDOMNode()).modal('toggle');
+  },
   onCancel: React.autoBind(function() {
     if (this.props.onCancel) {
       this.props.onCancel();
     }
-    this.close();
   }),
   onConfirm: React.autoBind(function() {
     if (this.props.onConfirm) {
       this.props.onConfirm();
     }
-    this.close();
   }),
-  close: function() {
-    if (this.props.onClose) {
-      this.props.onClose();
+  handleHidden: React.autoBind(function() {
+    if (this.props.onHidden) {
+      this.props.onHidden();
     }
-  }
+  })
 });
 
 var Example = React.createClass({
-  getInitialState: function() {
-    return {modalVisible: false};
-  },
   toggleModal: React.autoBind(function() {
-    this.setState({modalVisible: !this.state.modalVisible});
+    this.refs.modal.close();
   }),
   handleCancel: React.autoBind(function() {
     if (confirm('Are you sure you want to cancel?')) {
       this.toggleModal();
     }
   }),
+  handleHidden: function() {
+    console.log('Modal closed.');
+  },
   render: function() {
     var modal = null;
-    if (this.state.modalVisible) {
-      modal = (
-        <BootstrapModal
-          confirm="OK"
-          cancel="Cancel"
-          onCancel={this.handleCancel}
-          onConfirm={this.toggleModal}
-          title="Hello, Bootstrap!">
-            This is a React component powered by jQuery and Bootstrap!
-        </BootstrapModal>
-      );
-    }
+    modal = (
+      <BootstrapModal
+        confirm="OK"
+        cancel="Cancel"
+        onCancel={this.handleCancel}
+        onConfirm={this.toggleModal}
+        title="Hello, Bootstrap!"
+        initiallyVisible={false}
+        onHidden={this.handleHidden}
+        ref="modal">
+          This is a React component powered by jQuery and Bootstrap!
+      </BootstrapModal>
+    );
     return (
       <div class="example">
         {modal}


### PR DESCRIPTION
The old version's modal doesn't close correctly, because it gets re-rendered (following a parent's state variable change) before having the change to play the closing animation. This fixes it, but more or less defeats the purpose of showing a toggling state in parent. Will open new issue to discuss about this.
