### PR TITLE
Emphasis on single child.

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -50,7 +50,7 @@ React.createClass({
 function createClass(object specification)
 ```
 
-Creates a component given a specification. A component implements a `render` method which returns a single child. That child may have an arbitrarily deep child structure. One thing that makes components different than a standard prototypal classes is that you don't need to call new on them. They are convenience wrappers that construct backing instances (via new) for you.
+Creates a component given a specification. A component implements a `render` method which returns **one single** child. That child may have an arbitrarily deep child structure. One thing that makes components different than a standard prototypal classes is that you don't need to call new on them. They are convenience wrappers that construct backing instances (via new) for you.
 
 #### React.renderComponent
 


### PR DESCRIPTION
Returning more than one child from render will naturally yield and error, but currently the error message for having multiple children looks like this:

`Uncaught Error: Line 82: Invalid regular expression: missing /`

Would be better if this error has its own error message.
