### PR TITLE
Show the full blog posts in the listing

### DIFF
--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -15,13 +15,10 @@ sectionid: blog
         <hr>
 
         <div class="post">
-         {{ page.excerpt }}
-         {% if page.excerpt != page.content %}
-           <p>
-             <a href="/react{{ page.url }}">Continue Reading &rarr;</a>
-          </p>
-         {% endif %}
+         {{ page.content }}
         </div>
+
+        <div class="fb-like" data-send="true" data-width="650" data-show-faces="false" data-href="{{ site.url }}{{ site.baseurl }}{{ page.url }}"></div>
       </div>
     {% endfor %}
   </div>


### PR DESCRIPTION
I dislike the current way the blogs page is setup. When I click on blog, I want to see some blog posts, not being redirected on a page that only has previews of the articles. If I'm presented a choice of ten things to click on, I'm going to click on 1 or 2. It's best to show the content directly on this page. I can just scroll to see more. If I'm really interested in one article in particular, there's always the listing on the left column.
