### PR TITLE
Use populist for building jasmine test harness bundle

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,7 +58,7 @@ module.exports = function(grunt) {
   grunt.registerTask('build:test', [
     'jsx:jasmine',
     'jsx:test',
-    'browserify:jasmine',
+    'populist:jasmine',
     'populist:test'
   ]);
 

--- a/grunt/config/browserify.js
+++ b/grunt/config/browserify.js
@@ -76,33 +76,8 @@ var transformer = {
   after: [simpleBannerify]
 };
 
-var jasmine = {
-  entries: [
-    "./build/jasmine/all.js"
-  ],
-  requires: {
-    "jasmine": "./build/jasmine/all.js"
-  },
-  outfile: "./build/jasmine.js",
-  debug: false
-};
-
-var test = {
-  entries: [
-    "./build/modules/test/all.js",
-  ],
-  requires: [
-    "**/__tests__/*-test.js"
-  ],
-  outfile: './build/react-test.js',
-  debug: false,
-  standalone: false
-};
-
 module.exports = {
   basic: basic,
-  jasmine: jasmine,
-  test: test,
   min: min,
   transformer: transformer
 };

--- a/grunt/config/populist.js
+++ b/grunt/config/populist.js
@@ -1,6 +1,16 @@
 'use strict';
 
+var jasmine = {
+  rootDirectory: "build/jasmine",
+  // This syntax means to require and expose the "jasmine" module
+  // (build/jasmine/jasmine.js) as global.jasmine, and to require the
+  // "all" module (build/jasmine/all.js) but not expose it globally.
+  args: ["jasmine:jasmine", "all:"],
+  outfile: "./build/jasmine.js"
+};
+
 var test = {
+  rootDirectory: "build/modules",
   args: ["test/all:"],
   requires: [
     "**/__tests__/*-test.js"
@@ -9,5 +19,6 @@ var test = {
 };
 
 module.exports = {
+  jasmine: jasmine,
   test: test
 };

--- a/grunt/tasks/populist.js
+++ b/grunt/tasks/populist.js
@@ -10,16 +10,16 @@ module.exports = function() {
   var args = config.args;
 
   // Make sure the things that need to be exposed are.
-  var requires = config.requires || {};
+  var requires = config.requires || [];
   grunt.file.expand({
     nonull: true, // Keep IDs that don't expand to anything.
-    cwd: "src"
+    cwd: config.rootDirectory
   }, requires).forEach(function(name) {
     args.push(name.replace(/\.js$/i, ""));
   });
 
   require("populist").buildP({
-    rootDirectory: "build/modules",
+    rootDirectory: config.rootDirectory,
     args: args
   }).then(function(output) {
     grunt.file.write(config.outfile, output);

--- a/test/index.html
+++ b/test/index.html
@@ -13,7 +13,7 @@
     <script src="jasmine.js"></script>
     <script>
       window.onload = function() {
-        require("jasmine").getEnv().execute();
+        jasmine.getEnv().execute();
       };
     </script>
   </head>


### PR DESCRIPTION
We're using Populist for building the bundle of test modules and their dependencies, so it seems worthwhile for consistency to do the same for the test harness. Also, this will mean easier debugging of the test harness when running `grunt test --debug`.
