### PR TITLE
Upgrade Commoner and Populist to force upgrade to graceful-fs v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "base62": "~0.1.1",
-    "commoner": "~0.8.3",
+    "commoner": "~0.8.4",
     "esprima": "https://github.com/facebook/esprima/tarball/a3e0ea3979eb8d54d8bfade220c272903f928b1e",
     "recast": "~0.4.8",
     "source-map": "~0.1.22"
@@ -44,7 +44,7 @@
   "devDependencies": {
     "browserify": "~2.24.1",
     "wrapup": "~0.12.0",
-    "populist": "~0.1.2",
+    "populist": "~0.1.3",
     "grunt-cli": "~0.1.9",
     "grunt": "~0.4.1",
     "grunt-contrib-copy": "~0.4.1",


### PR DESCRIPTION
A silent upgrade from `graceful-fs` v1.2.2 to v1.2.3 (a dependency for both Commoner and Populist) broke the build process, even though tests were still passing. The 2.0.0 version fixes whatever was broken, though I won't pretend to know exactly what the root cause was.

These upgrades are not strictly necessary if you're doing `npm install` from scratch, but I want to make sure we skip over that bad version of `graceful-fs`.

cc @zpao
