### PR TITLE
Safely silence console messages by spying on console.{warn,error}

### DIFF
--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -134,6 +134,8 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should auto bind methods and values correctly', function() {
+    spyOn(console, "warn");
+
     var ComponentClass = React.createClass({
       getInitialState: function() {
         return {valueToReturn: 'hi'};
@@ -168,7 +170,9 @@ describe('ReactCompositeComponent', function() {
     // Next, prove that once mounted, the scope is bound correctly to the actual
     // component.
     ReactTestUtils.renderIntoDocument(instance);
+    expect(console.warn.argsForCall.length).toBe(0);
     var explicitlyBound = instance.methodToBeExplicitlyBound.bind(instance);
+    expect(console.warn.argsForCall.length).toBe(1);
     var autoBound = instance.methodAutoBound;
     var explicitlyNotBound = instance.methodExplicitlyNotBound;
 

--- a/src/core/__tests__/ReactInstanceHandles-test.js
+++ b/src/core/__tests__/ReactInstanceHandles-test.js
@@ -138,6 +138,9 @@ describe('ReactInstanceHandles', function() {
         ReactID.getID(childNodeB)
       )).toBe(childNodeB);
 
+      spyOn(console, "error");
+      expect(console.error.argsForCall.length).toBe(0);
+
       expect(function() {
         ReactInstanceHandles.findComponentRoot(
           parentNode,
@@ -148,6 +151,8 @@ describe('ReactInstanceHandles', function() {
         'Unable to find element. This probably means the DOM was ' +
         'unexpectedly mutated (e.g. by the browser).'
       );
+
+      expect(console.error.argsForCall.length).toBe(1);
     });
   });
 

--- a/src/core/__tests__/refs-test.js
+++ b/src/core/__tests__/refs-test.js
@@ -44,7 +44,11 @@ var ClickCounter = React.createClass({
     var i;
     for (i=0; i < this.state.count; i++) {
       children.push(
-        <div className="clickLogDiv" ref={"clickLog" + i} />
+        <div
+          className="clickLogDiv"
+          key={"clickLog" + i}
+          ref={"clickLog" + i}
+        />
       );
     }
     return (

--- a/src/dom/components/__tests__/ReactDOMTextarea-test.js
+++ b/src/dom/components/__tests__/ReactDOMTextarea-test.js
@@ -62,9 +62,12 @@ describe('ReactDOMTextarea', function() {
   });
 
   it('should treat children like `defaultValue`', function() {
+    spyOn(console, "warn");
+
     var stub = <textarea>giraffe</textarea>;
     var node = renderTextarea(stub);
 
+    expect(console.warn.argsForCall.length).toBe(1);
     expect(node.value).toBe('giraffe');
 
     // Changing children should do nothing, it functions like `defaultValue`.
@@ -73,21 +76,29 @@ describe('ReactDOMTextarea', function() {
   });
 
   it('should allow numbers as children', function() {
+    spyOn(console, "warn");
     var node = renderTextarea(<textarea>{17}</textarea>);
+    expect(console.warn.argsForCall.length).toBe(1);
     expect(node.value).toBe('17');
   });
 
   it("should throw with multiple or invalid children", function() {
+    spyOn(console, "warn");
+
     expect(function() {
       ReactTestUtils.renderIntoDocument(
         <textarea>{'hello'}{'there'}</textarea>
       );
     }).toThrow();
 
+    expect(console.warn.argsForCall.length).toBe(1);
+
     expect(function() {
       ReactTestUtils.renderIntoDocument(
         <textarea><strong /></textarea>
       );
     }).toThrow();
+
+    expect(console.warn.argsForCall.length).toBe(2);
   });
 });


### PR DESCRIPTION
This eliminates _all_ spurious console messages in `grunt test`, thanks to a great suggestion from @petehunt.
