### PR TITLE
Add React.version

### DIFF
--- a/grunt/config/jsx/debug.json
+++ b/grunt/config/jsx/debug.json
@@ -1,6 +1,0 @@
-{
-    "debug": true,
-    "constants": {
-        "__DEV__": true
-    }
-}

--- a/grunt/config/jsx/jsx.js
+++ b/grunt/config/jsx/jsx.js
@@ -1,12 +1,24 @@
 'use strict';
 
+var grunt = require('grunt');
+
 var rootIDs = [
   "React"
 ];
 
+var getDebugConfig = function() {
+  return {
+    "debug": true,
+    "constants": {
+      "__VERSION__": grunt.config.data.pkg.version,
+      "__DEV__": true
+    }
+  };
+};
+
 var debug = {
   rootIDs: rootIDs,
-  configFile: "grunt/config/jsx/debug.json",
+  getConfig: getDebugConfig,
   sourceDir: "src",
   outputDir: "build/modules"
 };
@@ -15,7 +27,7 @@ var jasmine = {
   rootIDs: [
     "all"
   ],
-  configFile: debug.configFile,
+  getConfig: getDebugConfig,
   sourceDir: "vendor/jasmine",
   outputDir: "build/jasmine"
 };
@@ -25,17 +37,36 @@ var test = {
     "test/all.js",
     "**/__tests__/*.js"
   ]),
-  configFile: "grunt/config/jsx/test.json",
+  getConfig: function() {
+    return {
+      "debug": true,
+      "mocking": true,
+      "constants": {
+        "__VERSION__": grunt.config.data.pkg.version,
+        "__DEV__": true
+      }
+    };
+  },
   sourceDir: "src",
   outputDir: "build/modules"
 };
 
+
 var release = {
   rootIDs: rootIDs,
-  configFile: "grunt/config/jsx/release.json",
+  getConfig: function() {
+    return {
+      "debug": false,
+      "constants": {
+        "__VERSION__": grunt.config.data.pkg.version,
+        "__DEV__": false
+      }
+    };
+  },
   sourceDir: "src",
   outputDir: "build/modules"
 };
+
 
 module.exports = {
   debug: debug,

--- a/grunt/config/jsx/release.json
+++ b/grunt/config/jsx/release.json
@@ -1,6 +1,0 @@
-{
-    "debug": false,
-    "constants": {
-        "__DEV__": false
-    }
-}

--- a/grunt/config/jsx/test.json
+++ b/grunt/config/jsx/test.json
@@ -1,7 +1,0 @@
-{
-    "debug": true,
-    "mocking": true,
-    "constants": {
-        "__DEV__": true
-    }
-}

--- a/grunt/tasks/jsx.js
+++ b/grunt/tasks/jsx.js
@@ -24,7 +24,7 @@ module.exports = function() {
   });
 
   args.push.apply(args, rootIDs);
-  args.push("--config", config.configFile);
+  args.push("--config" /* from stdin */);
 
   var child = spawn({
     cmd: "bin/jsx",
@@ -37,6 +37,9 @@ module.exports = function() {
       done();
     }
   });
+
+  child.stdin.write(JSON.stringify(config.getConfig()));
+  child.stdin.end();
 
   child.stdout.pipe(process.stdout);
   child.stderr.pipe(process.stderr);

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -19,6 +19,7 @@
   "unused": "vars",
 
   "globals": {
+    "__VERSION__": false,
     "__DEV__": false,
     "require": false,
     "module": false,

--- a/src/core/React.js
+++ b/src/core/React.js
@@ -30,6 +30,7 @@ var ReactDefaultInjection = require('ReactDefaultInjection');
 ReactDefaultInjection.inject();
 
 var React = {
+  version: __VERSION__,
   DOM: ReactDOM,
   PropTypes: ReactPropTypes,
   initializeTouchEvents: function(shouldUseTouch) {


### PR DESCRIPTION
getConfig needs to be a function because grunt.config.data.pkg.version isn't available at the time that grunt/config/jsx/jsx.js is required.

Test Plan:
grunt build, grunt lint, grunt test all work. After building, both react.js and react.min.js contain the version number.
