### PR TITLE
Use getAttribute instead of getAttributeNode in ReactID.rawGetID

### DIFF
--- a/src/core/ReactID.js
+++ b/src/core/ReactID.js
@@ -57,13 +57,7 @@ function getID(node) {
 }
 
 function internalGetID(node) {
-  if (node && node.getAttributeNode) {
-    var attributeNode = node.getAttributeNode(ATTR_NAME);
-    if (attributeNode) {
-      return attributeNode.value || '';
-    }
-  }
-  return '';
+  return node && node.getAttribute && node.getAttribute(ATTR_NAME) || '';
 }
 
 /**


### PR DESCRIPTION
Also known as `internalGetID`, internally.

cc @zpao @yungsters
