### PR TITLE
Pull in my rewritten Function.prototype.bind polyfill from upstream

### DIFF
--- a/src/test/all.js
+++ b/src/test/all.js
@@ -12,39 +12,23 @@ if (!Fp.bind) {
   Fp.bind = function(context) {
     var func = this;
     var args = slice.call(arguments, 1);
-    var bound;
 
-    if (func.prototype) {
-      if (args.length > 0) {
-        bound = function() {
-          return func.apply(
-            !(this instanceof func) && context || this,
-            args.concat(slice.call(arguments))
-          );
-        };
-      } else {
-        bound = function() {
-          return func.apply(
-            !(this instanceof func) && context || this,
-            arguments
-          );
-        };
-      }
-
-      bound.prototype = Object.create(func.prototype);
-
-    } else if (args.length > 0) {
-      bound = function() {
-        return func.apply(
-          context || this,
-          args.concat(slice.call(arguments))
-        );
-      };
-    } else {
-      bound = function() {
-        return func.apply(context || this, arguments);
-      };
+    function bound() {
+      var invokedAsConstructor = func.prototype && (this instanceof func);
+      return func.apply(
+        // Ignore the context parameter when invoking the bound function
+        // as a constructor. Note that this includes not only constructor
+        // invocations using the new keyword but also calls to base class
+        // constructors such as BaseClass.call(this, ...) or super(...).
+        !invokedAsConstructor && context || this,
+        args.concat(slice.call(arguments))
+      );
     }
+
+    // The bound function must share the .prototype of the unbound
+    // function so that any object created by one constructor will count
+    // as an instance of both constructors.
+    bound.prototype = func.prototype;
 
     return bound;
   };


### PR DESCRIPTION
We don't sync upstream polyfills (because we don't have a story for how they would be used), so this needs to be updated manually.

Sacrificed some negligible performance optimizations to reduce the number of different cases from four to one.

It's important to test this implementation in PhantomJS, since that's the only browser that I know of where built-in functions sometimes do not have a `.prototype`.

cc @zpao
