### PR TITLE
After each test, remove any stray nodes added to the document

### DIFF
--- a/src/test/all.js
+++ b/src/test/all.js
@@ -44,7 +44,7 @@ exports.enableTest = function(testID) {
   require("../" + testID);
 };
 
-exports.removeSiblings = function(node) {
+exports.removeNextSiblings = function(node) {
   var parent = node && node.parentNode;
   if (parent) {
     while (node.nextSibling) {

--- a/test/index.html
+++ b/test/index.html
@@ -12,8 +12,8 @@
       (function(env) {
         // Clean up any nodes the previous test might have added.
         env.afterEach(function() {
-          harness.removeSiblings(document.body);
-          harness.removeSiblings(document.getElementById("HTMLReporter"));
+          harness.removeNextSiblings(document.body);
+          harness.removeNextSiblings(document.getElementById("HTMLReporter"));
         });
 
         env.execute();


### PR DESCRIPTION
This was not necessary when we were running each test in its own `<iframe>`, and it doesn't seem to affect any test behavior currently, but it seems wise for the sake of test isolation and hygiene.
