### PR TITLE
Allow to execute JSXTransformer outside of browser environment

### DIFF
--- a/vendor/browser-transforms.js
+++ b/vendor/browser-transforms.js
@@ -32,6 +32,11 @@ exports.exec = function(code) {
   return eval(transform(code));
 };
 
+if (typeof window === "undefined" || window === null) {
+  return;
+}
+headEl = document.getElementsByTagName('head')[0];
+
 var run = exports.run = function(code) {
   var jsx = docblock.parseAsObject(docblock.extract(code)).jsx;
 
@@ -41,11 +46,6 @@ var run = exports.run = function(code) {
   scriptEl.innerHTML = functionBody;
   headEl.appendChild(scriptEl);
 };
-
-if (typeof window === "undefined" || window === null) {
-  return;
-}
-headEl = document.getElementsByTagName('head')[0];
 
 var load = exports.load = function(url, callback) {
   var xhr;


### PR DESCRIPTION
Hi guys,
Great job! React is awesome.

A little PR incoming...

I'm not sure if I correctly guessed that 

```
if (typeof window === "undefined" || window === null) {
  return;
}
```

is there to allow JSXTransformer.js to run outside of browser environment. If so, then it's necessary to move reference to document to be after this if. Also it might be nice to have a regression for this.

Otherwise, any hints on how to prepare non-browser non-node build of JSXTransformer? I'm working on a gem to simply compile jsxes server side in rails (sprockets engine). If you think it suits this repo then I can PR it too.
