### PR TITLE
fix example bugs

### DIFF
--- a/examples/jquery-bootstrap/js/app.js
+++ b/examples/jquery-bootstrap/js/app.js
@@ -60,7 +60,7 @@ var BootstrapModal = React.createClass({
             className="close"
             onClick={this.handleCancel}
             dangerouslySetInnerHTML={{__html: '&times'}}
-            />
+          />
           <h3>{this.props.title}</h3>
         </div>
         <div className="modal-body">


### PR DESCRIPTION
Old one had some bugs:
- 'x' on modal wasn't showing.
- trying to close modal in unmount, but modal had a closing animation.

Oh and, changing `class` into `className` like suggested in docs.
