### PR TITLE
Get rid of initializeTouchEvents

### DIFF
--- a/src/core/React.js
+++ b/src/core/React.js
@@ -32,9 +32,6 @@ ReactDefaultInjection.inject();
 var React = {
   DOM: ReactDOM,
   PropTypes: ReactPropTypes,
-  initializeTouchEvents: function(shouldUseTouch) {
-    ReactMount.useTouchEvents = shouldUseTouch;
-  },
   autoBind: ReactCompositeComponent.autoBind,
   createClass: ReactCompositeComponent.createClass,
   constructAndRenderComponent: ReactMount.constructAndRenderComponent,

--- a/src/core/ReactEventEmitter.js
+++ b/src/core/ReactEventEmitter.js
@@ -150,11 +150,10 @@ function registerScrollValueMonitoring() {
  * Also, `keyup`/`keypress`/`keydown` do not bubble to the window on IE, but
  * they bubble to document.
  *
- * @param {boolean} touchNotMouse Listen to touch events instead of mouse.
  * @private
  * @see http://www.quirksmode.org/dom/events/keys.html.
  */
-function listenAtTopLevel(touchNotMouse) {
+function listenAtTopLevel() {
   invariant(
     !_isListening,
     'listenAtTopLevel(...): Cannot setup top-level listener more than once.'
@@ -170,12 +169,10 @@ function listenAtTopLevel(touchNotMouse) {
   trapBubbledEvent(topLevelTypes.topMouseOut, 'mouseout', mountAt);
   trapBubbledEvent(topLevelTypes.topClick, 'click', mountAt);
   trapBubbledEvent(topLevelTypes.topDoubleClick, 'dblclick', mountAt);
-  if (touchNotMouse) {
-    trapBubbledEvent(topLevelTypes.topTouchStart, 'touchstart', mountAt);
-    trapBubbledEvent(topLevelTypes.topTouchEnd, 'touchend', mountAt);
-    trapBubbledEvent(topLevelTypes.topTouchMove, 'touchmove', mountAt);
-    trapBubbledEvent(topLevelTypes.topTouchCancel, 'touchcancel', mountAt);
-  }
+  trapBubbledEvent(topLevelTypes.topTouchStart, 'touchstart', mountAt);
+  trapBubbledEvent(topLevelTypes.topTouchEnd, 'touchend', mountAt);
+  trapBubbledEvent(topLevelTypes.topTouchMove, 'touchmove', mountAt);
+  trapBubbledEvent(topLevelTypes.topTouchCancel, 'touchcancel', mountAt);
   trapBubbledEvent(topLevelTypes.topKeyUp, 'keyup', mountAt);
   trapBubbledEvent(topLevelTypes.topKeyPress, 'keypress', mountAt);
   trapBubbledEvent(topLevelTypes.topKeyDown, 'keydown', mountAt);
@@ -256,9 +253,8 @@ var ReactEventEmitter = {
    * there's a touch top-level listeners, anchors don't receive clicks for some
    * reason, and only in some cases).
    *
-   * @param {boolean} touchNotMouse Listen to touch events instead of mouse.
    */
-  ensureListening: function(touchNotMouse) {
+  ensureListening: function() {
     invariant(
       ExecutionEnvironment.canUseDOM,
       'ensureListening(...): Cannot toggle event listening in a Worker ' +
@@ -271,7 +267,7 @@ var ReactEventEmitter = {
       'creator being injected.'
     );
     if (!_isListening) {
-      listenAtTopLevel(touchNotMouse);
+      listenAtTopLevel();
       _isListening = true;
     }
   },

--- a/src/core/ReactMount.js
+++ b/src/core/ReactMount.js
@@ -204,9 +204,6 @@ var ReactMount = {
   /** Time spent inserting markup into the DOM. */
   totalInjectionTime: 0,
 
-  /** Whether support for touch events should be initialized. */
-  useTouchEvents: false,
-
   /**
    * This is a hook provided to support rendering React components while
    * ensuring that the apparent scroll position of its `container` does not
@@ -226,7 +223,7 @@ var ReactMount = {
    * @private
    */
   prepareTopLevelEvents: function() {
-    ReactEventEmitter.ensureListening(ReactMount.useTouchEvents);
+    ReactEventEmitter.ensureListening();
   },
 
   /**

--- a/src/core/__tests__/ReactEventEmitter-test.js
+++ b/src/core/__tests__/ReactEventEmitter-test.js
@@ -95,7 +95,7 @@ describe('ReactEventEmitter', function() {
     ReactTestUtils = require('ReactTestUtils');
     idCallOrder = [];
     tapMoveThreshold = TapEventPlugin.tapMoveThreshold;
-    ReactEventEmitter.ensureListening(false);
+    ReactEventEmitter.ensureListening();
     EventPluginHub.injection.injectEventPluginsByName({
       TapEventPlugin: TapEventPlugin
     });

--- a/src/eventPlugins/__tests__/AnalyticsEventPlugin-test.js
+++ b/src/eventPlugins/__tests__/AnalyticsEventPlugin-test.js
@@ -61,7 +61,7 @@ describe('AnalyticsEventPlugin', function() {
       'ChangeEventPlugin': ChangeEventPlugin
     });
 
-    ReactEventEmitter.ensureListening(false);
+    ReactEventEmitter.ensureListening();
   });
 
   it('should count events correctly', function() {


### PR DESCRIPTION
We don't need it any more, thanks to @yungsters's 4deb0d61. Before that we weren't getting click events regardless of whether touch events were initialized, which was (as far as I know) the only thing to be worried about with this change.

We could also keep initializeTouchEvents around for API compatibility and make it a noop, but I don't think anyone here really cares about keeping it.

Test Plan:
On an iPad, verified that a single element can receive touchstart, touchmove, touchend, mousedown, mouseup, and click events all at the same time (with a single tap, no less!).
