### PR TITLE
`react-core` npm module

### DIFF
--- a/contrib/react-core/README.md
+++ b/contrib/react-core/README.md
@@ -1,0 +1,17 @@
+# react-core
+
+An npm package to get you immediate access to `React`, without also requiring the JSX transformer. This is especially useful for cases where you want to [`browserify`](https://github.com/substack/node-browserify) your module using `React`.
+
+## An Example
+
+```js
+// react-tools-test.js
+var React = require('react-tools').React;
+```
+
+```js
+// react-core-test.js
+var React = require('react-core').React;
+```
+
+After being packaged with `browserify`, the `react-tools` test package is 645K, while the `react-core` test package is 330K. Minification & gzip bring those package sizes down further, but the `react-core` test package is consistently 50+% smaller.

--- a/contrib/react-core/main.js
+++ b/contrib/react-core/main.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  React: require('react-tools/build/modules/React')
+};

--- a/contrib/react-core/package.json
+++ b/contrib/react-core/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "react-core",
+  "version": "0.4.0",
+  "keywords": [
+    "react"
+  ],
+  "homepage": "https://github.com/facebook/react/contrib/react-core",
+  "bugs": "https://github.com/facebook/react/issues",
+  "licenses": [
+    {
+      "type": "Apache-2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+  ],
+  "files": [
+    "README.md",
+    "main.js"
+  ],
+  "main": "main.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebook/react"
+  },
+  "dependencies": {
+    "react-tools": "0.4.0"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  }
+}


### PR DESCRIPTION
Jordan wanted an easy way to use React, and specifically behave nicely
with browserify. He has been using
https://github.com/jordwalke/npm-react-core as a placeholder, but in
order to keep doing that, it requires another build step and more places
for us to screw up. This just re-uses the NPM module we're already
shipping and is really easy to update.

Note: we may want to pull this out into it's own project eventually, but
for now... move fast?
