### PR TITLE
Fix incorrect port of standard Python server

### DIFF
--- a/examples/ballmer-peak/index.html
+++ b/examples/ballmer-peak/index.html
@@ -14,7 +14,7 @@
         <pre>
           python -m SimpleHTTPServer
         </pre>
-        and going to <a href="http://localhost:8080/">http://localhost:8080/</a>.
+        and going to <a href="http://localhost:8000/">http://localhost:8000/</a>.
       </p>
     </div>
     <h4>Example Details</h4>


### PR DESCRIPTION
- Python’s built-in server listens on port _8000_, not _8080_.
