### PR TITLE
Fix incorrect port of standard Python server

### DIFF
--- a/examples/ballmer-peak/index.html
+++ b/examples/ballmer-peak/index.html
@@ -14,7 +14,7 @@
         <pre>
           python -m SimpleHTTPServer
         </pre>
-        and going to <a href="http://localhost:8080/">http://localhost:8080/</a>.
+        and going to <a href="http://localhost:8000/">http://localhost:8000/</a>.
       </p>
     </div>
     <h4>Example Details</h4>

--- a/examples/basic-jsx-external/index.html
+++ b/examples/basic-jsx-external/index.html
@@ -54,7 +54,7 @@
             <pre id="chromeServerCLI" class="codeBox">
 cd /Path/To/This/File
 python -m SimpleHTTPServer
-open -a "Google Chrome"  <a href="http://localhost:8080/">http://localhost:8080/</a>.  </pre>
+open -a "Google Chrome"  <a href="http://localhost:8000/">http://localhost:8000/</a>.  </pre>
           </li>
         </ol>
         <h4 id="chromeErrorFooter" style="color: #733"></h4>


### PR DESCRIPTION
- Adds missing replacement pointed out in #236.
- Signed CLA.

/ht @zpao
