### PR TITLE
Fix Github links in examples

### DIFF
--- a/examples/basic-jsx-precompile/index.html
+++ b/examples/basic-jsx-precompile/index.html
@@ -10,7 +10,7 @@
     <div id="container">
       <p>
         To install React, follow the instructions on
-        <a href="http://www.github.com/facebook/react.js/">GitHub</a>.
+        <a href="http://www.github.com/facebook/react/">GitHub</a>.
       </p>
       <p>
         If you can see this, React is not running. You probably didn't run:

--- a/examples/basic-jsx/index.html
+++ b/examples/basic-jsx/index.html
@@ -10,7 +10,7 @@
     <div id="container">
       <p>
         To install React, follow the instructions on
-        <a href="http://www.github.com/facebook/react.js/">GitHub</a>.
+        <a href="http://www.github.com/facebook/react/">GitHub</a>.
       </p>
       <p>
         If you can see this, React is not working right.

--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -10,7 +10,7 @@
     <div id="container">
       <p>
         To install React, follow the instructions on
-        <a href="http://www.github.com/facebook/react.js/">GitHub</a>.
+        <a href="http://www.github.com/facebook/react/">GitHub</a>.
       </p>
       <p>
         If you can see this, React is not working right.

--- a/examples/wrapup/index.html
+++ b/examples/wrapup/index.html
@@ -10,7 +10,7 @@
     <div id="container">
       <p>
         To install React, follow the instructions on
-        <a href="http://www.github.com/facebook/react.js/">GitHub</a>.
+        <a href="http://www.github.com/facebook/react/">GitHub</a>.
       </p>
       <p>
         If you can see this, React is not working right.


### PR DESCRIPTION
Looks like we link to github.com/facebook/react/ instead of react.js. This just fixes the links -- no more 404's :D

`grep -r "facebook/react.js" .` comes up clean now
