### PR TITLE
Improve error behavior of Danger.dangerouslyRenderMarkup

### DIFF
--- a/src/dom/__tests__/Danger-test.js
+++ b/src/dom/__tests__/Danger-test.js
@@ -96,11 +96,21 @@ describe('Danger', function() {
         'Invariant Violation: dangerouslyRenderMarkup(...): Missing markup.'
       );
 
-      expect(function() {
-        Danger.dangerouslyRenderMarkup(['<p></p><p></p>']);
-      }).toThrow(
-        'Invariant Violation: dangerouslyRenderMarkupO(...): Unexpected nodes.'
-      );
+      spyOn(console, "error");
+
+      var renderedMarkup = Danger.dangerouslyRenderMarkup(['<p></p><p></p>']);
+      var args = console.error.argsForCall[0];
+
+      expect(renderedMarkup.length).toBe(1);
+      expect(renderedMarkup[0].nodeName).toBe('P');
+
+      expect(console.error.argsForCall.length).toBe(1);
+
+      expect(args.length).toBe(3);
+      expect(args[0]).toBe(
+        "Danger: '<p></p><p></p>' rendered as 2 nodes instead of 1:");
+      expect(args[1]).toBe(renderedMarkup[0]);
+      expect(args[2].nodeName).toBe('P');
     });
   });
 


### PR DESCRIPTION
This is a less ambitious version of https://github.com/facebook/react/pull/246, which I will close shortly.

HTML comment nodes are now interspersed in the original markup list so that we can tell which chunks of markup rendered as more or less than one node, and give a more helpful error message in that case.

Regardless of how many nodes were rendered, we only take the first one. If zero nodes were rendered, then `resultList` will contain `null` at the corresponding position.

If we decide to revisit the idea of using document fragments, it will be very easy to handle the `!== 1` case by returning a document fragment.

cc @yungsters @zpao
