### PR TITLE
Warn about unknown property values

### DIFF
--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -102,7 +102,12 @@ var ReactTransitionGroup = React.createClass({
   render: function() {
     return this.transferPropsTo(
       this.props.component(
-        null,
+        {
+          transitionName: null,
+          transitionEnter: null,
+          transitionLeave: null,
+          component: null
+        },
         this.renderTransitionableChildren(this.props.children)
       )
     );

--- a/src/dom/DOMProperty.js
+++ b/src/dom/DOMProperty.js
@@ -82,8 +82,11 @@ var DOMPropertyInjection = {
 
       DOMProperty.isStandardName[propName] = true;
 
+      var lowerCased = propName.toLowerCase();
+      DOMProperty.getPossibleStandardName[lowerCased] = propName;
+
       DOMProperty.getAttributeName[propName] =
-        DOMAttributeNames[propName] || propName.toLowerCase();
+        DOMAttributeNames[propName] || lowerCased;
 
       DOMProperty.getPropertyName[propName] =
         DOMPropertyNames[propName] || propName;
@@ -140,6 +143,13 @@ var DOMProperty = {
    * @type {Object}
    */
   isStandardName: {},
+
+  /**
+   * Mapping from lowercase property names to the properly cased version, used
+   * to warn in the case of missing properties.
+   * @type {Object}
+   */
+  getPossibleStandardName: {},
 
   /**
    * Mapping from normalized names to attribute names that differ. Attribute

--- a/src/dom/__tests__/DOMPropertyOperations-test.js
+++ b/src/dom/__tests__/DOMPropertyOperations-test.js
@@ -58,6 +58,16 @@ describe('DOMPropertyOperations', function() {
       )).toBe('id="simple"');
     });
 
+    it('should warn about incorrect casing', function() {
+      spyOn(console, 'warn');
+      expect(DOMPropertyOperations.createMarkupForProperty(
+        'tabindex',
+        '1'
+      )).toBe(null);
+      expect(console.warn.argsForCall.length).toBe(1);
+      expect(console.warn.argsForCall[0][0]).toContain('tabIndex');
+    });
+
     it('should create markup for boolean properties', function() {
       expect(DOMPropertyOperations.createMarkupForProperty(
         'checked',
@@ -141,17 +151,23 @@ describe('DOMPropertyOperations', function() {
 
   describe('injectDOMPropertyConfig', function() {
     it('should support custom attributes', function() {
+      spyOn(console, 'warn');
+
       // foobar does not exist yet
       expect(DOMPropertyOperations.createMarkupForProperty(
         'foobar',
         'simple'
       )).toBe(null);
 
+      expect(console.warn.argsForCall.length).toBe(1);
+
       // foo-* does not exist yet
       expect(DOMPropertyOperations.createMarkupForProperty(
         'foo-xyz',
         'simple'
       )).toBe(null);
+
+      expect(console.warn.argsForCall.length).toBe(2);
 
       // inject foobar DOM property
       DOMProperty.injection.injectDOMPropertyConfig({

--- a/src/dom/components/ReactDOMInput.js
+++ b/src/dom/components/ReactDOMInput.js
@@ -61,6 +61,8 @@ var ReactDOMInput = ReactCompositeComponent.createClass({
     // Clone `this.props` so we don't mutate the input.
     var props = merge(this.props);
 
+    props.defaultChecked = null;
+    props.defaultValue = null;
     props.checked =
       this.props.checked != null ? this.props.checked : this.state.checked;
     // Cast `this.props.value` to a string so equality checks pass.

--- a/src/dom/components/ReactDOMTextarea.js
+++ b/src/dom/components/ReactDOMTextarea.js
@@ -102,6 +102,7 @@ var ReactDOMTextarea = ReactCompositeComponent.createClass({
       '`dangerouslySetInnerHTML` does not make sense on <textarea>.'
     );
 
+    props.defaultValue = null;
     props.value =
       this.props.value != null ? this.props.value : this.state.value;
     props.onChange = this._handleChange;


### PR DESCRIPTION
Fixes #255.

Not thrilled about the hardcoded `reactProps` list though I suppose it should live somewhere? Presumably I should at least not be retyping `{owner}`, which I can fix.
