### PR TITLE
jsx transform: "for" should be renamed as "class" is

### DIFF
--- a/vendor/fbtransform/transforms/react.js
+++ b/vendor/fbtransform/transforms/react.js
@@ -45,7 +45,8 @@ var quoteAttrName = require('./xjs').quoteAttrName;
 
 var JSX_ATTRIBUTE_RENAMES = {
   'class': 'className',
-  cxName: 'className'
+  cxName: 'className',
+  'for': 'htmlFor'
 };
 
 var JSX_ATTRIBUTE_TRANSFORMS = {


### PR DESCRIPTION
JSX renames `class` to `className`, but is not doing the same for `for`, which causes a bit of confusion.
