### PR TITLE
Fix dead link to reference in tutorial

### DIFF
--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -677,4 +677,4 @@ var CommentBox = React.createClass({
 
 ### Congrats!
 
-You have just built a comment box in a few simple steps. Learn more about React in the [reference](syntax.html) or start hacking! Good luck!
+You have just built a comment box in a few simple steps. Learn more about [why to use React](why-react.html), or dive into the [API reference](reference.html) and start hacking! Good luck!


### PR DESCRIPTION
I _think_ this is supposed to go to reference.html? Current link on site is dead
