### PR TITLE
Add CDNJS to docs. Fixes #244

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You'll notice that we used an XML-like syntax; [we call it JSX](http://facebook.
 
 ## Installation
 
-The fastest way to get started is to serve JavaScript from the CDN:
+The fastest way to get started is to serve JavaScript from the CDN (also available on [CDNJS](http://cdnjs.com/#react)):
 
 ```html
 <!-- The core React library -->

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -35,6 +35,8 @@ The JSX transformer used to support [XML syntax](/react/docs/syntax.html) in Jav
 <script src="http://fb.me/JSXTransformer-{{site.react_version}}.js"></script>
 ```
 
+All scripts are also available via [CDNJS](http://cdnjs.com/#react).
+
 ## Bower
 
 ```sh


### PR DESCRIPTION
This would've helped us out earlier, as all things Facebook are commonly blocked at large companies, so if you serve from FB's CDN then all the things break
