### PR TITLE
Remove all uses of ExecutionEnvironment.global

### DIFF
--- a/src/core/ReactEventTopLevelCallback.js
+++ b/src/core/ReactEventTopLevelCallback.js
@@ -19,7 +19,6 @@
 
 "use strict";
 
-var ExecutionEnvironment = require('ExecutionEnvironment');
 var ReactEventEmitter = require('ReactEventEmitter');
 var ReactMount = require('ReactMount');
 
@@ -74,7 +73,7 @@ var ReactEventTopLevelCallback = {
       }
       var topLevelTarget = ReactMount.getFirstReactDOM(
         getEventTarget(nativeEvent)
-      ) || ExecutionEnvironment.global;
+      ) || window;
       var topLevelTargetID = ReactMount.getID(topLevelTarget) || '';
       ReactEventEmitter.handleTopLevel(
         topLevelType,

--- a/src/dom/getEventTarget.js
+++ b/src/dom/getEventTarget.js
@@ -19,8 +19,6 @@
 
 "use strict";
 
-var ExecutionEnvironment = require('ExecutionEnvironment');
-
 /**
  * Gets the target node from a native browser event by accounting for
  * inconsistencies in browser DOM APIs.
@@ -29,10 +27,7 @@ var ExecutionEnvironment = require('ExecutionEnvironment');
  * @return {DOMEventTarget} Target node.
  */
 function getEventTarget(nativeEvent) {
-  var target =
-    nativeEvent.target ||
-    nativeEvent.srcElement ||
-    ExecutionEnvironment.global;
+  var target = nativeEvent.target || nativeEvent.srcElement || window;
   // Safari may fire events on text nodes (Node.TEXT_NODE is 3).
   // @see http://www.quirksmode.org/js/events_properties.html
   return target.nodeType === 3 ? target.parentNode : target;

--- a/src/eventPlugins/EnterLeaveEventPlugin.js
+++ b/src/eventPlugins/EnterLeaveEventPlugin.js
@@ -21,7 +21,6 @@
 
 var EventConstants = require('EventConstants');
 var EventPropagators = require('EventPropagators');
-var ExecutionEnvironment = require('ExecutionEnvironment');
 var SyntheticMouseEvent = require('SyntheticMouseEvent');
 
 var ReactMount = require('ReactMount');
@@ -73,9 +72,9 @@ var EnterLeaveEventPlugin = {
       from = topLevelTarget;
       to =
         getFirstReactDOM(nativeEvent.relatedTarget || nativeEvent.toElement) ||
-        ExecutionEnvironment.global;
+        window;
     } else {
-      from = ExecutionEnvironment.global;
+      from = window;
       to = topLevelTarget;
     }
 

--- a/src/test/ReactPerf.js
+++ b/src/test/ReactPerf.js
@@ -67,10 +67,7 @@ var ReactPerf = {
 
 if (__DEV__) {
   var ExecutionEnvironment = require('ExecutionEnvironment');
-  var URL = ExecutionEnvironment.global &&
-    ExecutionEnvironment.global.location &&
-    ExecutionEnvironment.global.location.href ||
-    '';
+  var URL = ExecutionEnvironment.canUseDOM ? window.location.href : '';
   ReactPerf.enableMeasure = ReactPerf.enableMeasure ||
     !!URL.match(/[?&]react_perf\b/);
 }

--- a/src/vendor/core/ExecutionEnvironment.js
+++ b/src/vendor/core/ExecutionEnvironment.js
@@ -34,9 +34,7 @@ var ExecutionEnvironment = {
 
   canUseWorkers: typeof Worker !== 'undefined',
 
-  isInWorker: !canUseDOM, // For now, this is true - might change in the future.
-
-  global: new Function('return this;')()
+  isInWorker: !canUseDOM // For now, this is true - might change in the future.
 
 };
 


### PR DESCRIPTION
Closes #271.

All three of these files are DOM-specific so it should be fine to use window. (ReactEventTopLevelCallback isn't obviously DOM-specific but it calls getEventTarget which is so I think we're fine here.)

Test Plan:
grunt test, tried events in a real browser and they seemed to work still.
