### PR TITLE
Add rowSpan DOM property

### DIFF
--- a/src/dom/DefaultDOMPropertyConfig.js
+++ b/src/dom/DefaultDOMPropertyConfig.js
@@ -82,6 +82,7 @@ var DefaultDOMPropertyConfig = {
     readOnly: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
     required: HAS_BOOLEAN_VALUE,
     role: MUST_USE_ATTRIBUTE,
+    rowSpan: null,
     scrollLeft: MUST_USE_PROPERTY,
     scrollTop: MUST_USE_PROPERTY,
     selected: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,


### PR DESCRIPTION
Refs #264
- [x] Add `rowSpan` DOM property
- [x] ~~Relevant tests~~

I don't see any functional test that effectively tests the proper creation of a DOM utilizing the `DefaultDOMPropertyConfig` attributes.

So, is this PR complete, or is there a place for me to put in tests?
