### PR TITLE
Redirect /docs to the right page

### DIFF
--- a/docs/_layouts/redirect.html
+++ b/docs/_layouts/redirect.html
@@ -1,0 +1,6 @@
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; {{ page.destination }}">
+</head>
+<body></body>
+</html>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -1,0 +1,4 @@
+---
+layout: redirect
+destination: getting-started.html
+---


### PR DESCRIPTION
I've hit this a few times where I want to get to docs so I take whatever
my urlbar gives me and strip out the actual page so I can get to the
root, however that's a 404.

This introduces a super easy way to redirect, which could be handy in
the future as docs get rewritten.

I would much rather do this with a real htaccess file or even just
handle 404s gracefully, but that's not currently an option with GitHub
pages (since we generate our own and don't use a custom domain).
