### PR TITLE
Add ReactTransitionGroup to the build

### DIFF
--- a/grunt/config/jsx/jsx.js
+++ b/grunt/config/jsx/jsx.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var rootIDs = [
-  "React"
+  "React",
+  "ReactTransitionGroup"
 ];
 
 var debug = {


### PR DESCRIPTION
We need this so that ReactTransitionGroup actually builds and is available.
