### PR TITLE
Simplify bin/jsx to perform just the JSX transform

### DIFF
--- a/bin/jsx
+++ b/bin/jsx
@@ -3,53 +3,10 @@
 
 var visitors = require('../vendor/fbtransform/visitors').transformVisitors;
 var transform = require('jstransform').transform;
-var propagate = require("../vendor/constants").propagate;
 
 require("commoner").resolve(function(id) {
-  var context = this;
-
-  // Note that the result of context.getProvidedP() is cached for the
-  // duration of the build, so it is both consistent and cheap to
-  // evaluate multiple times.
-  return context.getProvidedP().then(function(idToPath) {
-    // If a module declares its own identifier using @providesModule
-    // then that identifier will be a key in the idToPath object.
-    if (idToPath.hasOwnProperty(id)) {
-      return context.readFileP(idToPath[id]);
-    }
-
-    // Otherwise assume the identifier maps directly to a path in the
-    // filesystem.
-    return context.readModuleP(id);
-  });
-
+  return this.readModuleP(id);
 }).process(function(id, source) {
-  var context = this;
-  var constants = context.config.constants || {};
-
   // This is where JSX, ES6, etc. desugaring happens.
-  source = transform(visitors.react, source).code;
-
-  // Constant propagation means removing any obviously dead code after
-  // replacing constant expressions with literal (boolean) values.
-  source = propagate(constants, source);
-
-  if (context.config.mocking) {
-    // Make sure there is exactly one newline at the end of the module.
-    source = source.replace(/\s+$/m, "\n");
-
-    return context.getProvidedP().then(function(idToPath) {
-      if (id !== "mock-modules" &&
-          id !== "mocks" &&
-          id !== "test/all" &&
-          idToPath.hasOwnProperty("mock-modules")) {
-        return source + '\nrequire("mock-modules").register(' +
-          JSON.stringify(id) + ', module);\n';
-      }
-
-      return source;
-    });
-  }
-
-  return source;
+  return transform(visitors.react, source).code;
 });

--- a/bin/jsx-internal
+++ b/bin/jsx-internal
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+"use strict";
+
+var visitors = require('../vendor/fbtransform/visitors').transformVisitors;
+var transform = require('jstransform').transform;
+var propagate = require("../vendor/constants").propagate;
+
+require("commoner").resolve(function(id) {
+  var context = this;
+
+  // Note that the result of context.getProvidedP() is cached for the
+  // duration of the build, so it is both consistent and cheap to
+  // evaluate multiple times.
+  return context.getProvidedP().then(function(idToPath) {
+    // If a module declares its own identifier using @providesModule
+    // then that identifier will be a key in the idToPath object.
+    if (idToPath.hasOwnProperty(id)) {
+      return context.readFileP(idToPath[id]);
+    }
+
+    // Otherwise assume the identifier maps directly to a path in the
+    // filesystem.
+    return context.readModuleP(id);
+  });
+
+}).process(function(id, source) {
+  var context = this;
+  var constants = context.config.constants || {};
+
+  // This is where JSX, ES6, etc. desugaring happens.
+  source = transform(visitors.react, source).code;
+
+  // Constant propagation means removing any obviously dead code after
+  // replacing constant expressions with literal (boolean) values.
+  source = propagate(constants, source);
+
+  if (context.config.mocking) {
+    // Make sure there is exactly one newline at the end of the module.
+    source = source.replace(/\s+$/m, "\n");
+
+    return context.getProvidedP().then(function(idToPath) {
+      if (id !== "mock-modules" &&
+          id !== "mocks" &&
+          id !== "test/all" &&
+          idToPath.hasOwnProperty("mock-modules")) {
+        return source + '\nrequire("mock-modules").register(' +
+          JSON.stringify(id) + ', module);\n';
+      }
+
+      return source;
+    });
+  }
+
+  return source;
+});

--- a/grunt/tasks/jsx.js
+++ b/grunt/tasks/jsx.js
@@ -27,7 +27,7 @@ module.exports = function() {
   args.push("--config", config.configFile);
 
   var child = spawn({
-    cmd: "bin/jsx",
+    cmd: "bin/jsx-internal",
     args: args
   }, function(error, result, code) {
     if (error) {

--- a/grunt/tasks/npm.js
+++ b/grunt/tasks/npm.js
@@ -64,8 +64,8 @@ module.exports = function() {
           var pkgDir = path.join(nodePath, pkg.name);
           var doneCount = 2;
 
-          // Make sure that bin/jsx is runnable by echoing main.js.
-          run("bin/jsx", ["main.js"], {
+          // Make sure that bin/jsx-internal is runnable by echoing main.js.
+          run("bin/jsx-internal", ["main.js"], {
             cwd: pkgDir
           }, function(result) {
             assert.ok(result.stdout.indexOf("transform") >= 0, result.stdout);

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
   "dependencies": {
     "commoner": "~0.8.4",
     "esprima-fb": "1001.1001.1000-dev-harmony-fb",
-    "jstransform": "~1.0.0",
-    "recast": "~0.4.8"
+    "jstransform": "~1.0.0"
   },
   "devDependencies": {
     "browserify": "~2.29.0",
@@ -51,6 +50,7 @@
     "grunt-contrib-jshint": "~0.6.0",
     "optimist": "~0.6.0",
     "phantomjs": "~1.9.1-4",
+    "recast": "~0.4.8",
     "semver": "~2.1.0",
     "uglify-js": "~2.4.0",
     "grunt-contrib-clean": "~0.5.0",


### PR DESCRIPTION
We will continue using `bin/jsx-internal`, well, internally.

Note that this version no longer respects `@providesModule`, and it doesn't do anything special with constants like `__DEV__`, so we can no longer get to claim that `bin/jsx` can be used to build the core.

I'm happy about this, personally, because it demonstrates the flexibility of Commoner.

cc @zpao @petehunt
