### PR TITLE
Fix ReactRenderDocument tests

### DIFF
--- a/src/core/__tests__/ReactRenderDocument-test.js
+++ b/src/core/__tests__/ReactRenderDocument-test.js
@@ -37,12 +37,12 @@ describe('rendering React components at document', function() {
     testDocument = getTestDocument();
   });
 
-  if (!testDocument) {
-    // These tests are not applicable in jst, since jsdom is buggy.
-    return;
-  }
-
   it('should be able to switch root constructors via state', function() {
+    if (!testDocument) {
+      // These tests are not applicable in jst, since jsdom is buggy.
+      return;
+    }
+
     var Component = React.createClass({
       render: function() {
         return (
@@ -100,6 +100,11 @@ describe('rendering React components at document', function() {
   });
 
   it('should be able to switch root constructors', function() {
+    if (!testDocument) {
+      // These tests are not applicable in jst, since jsdom is buggy.
+      return;
+    }
+
     var Component = React.createClass({
       render: function() {
         return (
@@ -143,6 +148,11 @@ describe('rendering React components at document', function() {
   });
 
   it('should be able to mount into document', function() {
+    if (!testDocument) {
+      // These tests are not applicable in jst, since jsdom is buggy.
+      return;
+    }
+
     var Component = React.createClass({
       render: function() {
         return (
@@ -164,6 +174,11 @@ describe('rendering React components at document', function() {
   });
 
   it('should throw on full document render', function() {
+    if (!testDocument) {
+      // These tests are not applicable in jst, since jsdom is buggy.
+      return;
+    }
+
     var container = testDocument;
     expect(function() {
       React.renderComponent(<html />, container);
@@ -178,6 +193,11 @@ describe('rendering React components at document', function() {
   });
 
   it('should throw on full document render of non-html', function() {
+    if (!testDocument) {
+      // These tests are not applicable in jst, since jsdom is buggy.
+      return;
+    }
+
     var container = testDocument;
     ReactMount.allowFullPageRender = true;
     expect(function() {


### PR DESCRIPTION
I am unsure how this was ever supposed to work, as testDocument is guaranteed to be undefined at that point since beforeEach doesn't run synchronously. (I don't think there's any way to have beforeEach halt the tests, but let me know if you know differently.)

The tests will fail now, but they should be failing because of #337.

/cc @petehunt
