### PR TITLE
Make __VERSION__ optional

### DIFF
--- a/src/core/React.js
+++ b/src/core/React.js
@@ -52,6 +52,8 @@ var React = {
 
 // Version exists only in the open-source version of React, not in Facebook's
 // internal version.
-React.version = __VERSION__;
+if (typeof __VERSION__ !== 'undefined') {
+  React.version = __VERSION__;
+}
 
 module.exports = React;

--- a/vendor/constants.js
+++ b/vendor/constants.js
@@ -34,6 +34,29 @@ var ConstantVisitor = recast.Visitor.extend({
     }
   },
 
+  visitUnaryExpression: function(unary) {
+    this.genericVisit(unary);
+    if (unary.operator === 'typeof' &&
+        unary.argument.type === recast.Syntax.Literal) {
+      return recast.builder.literal(typeof unary.argument.value);
+    }
+  },
+
+  visitBinaryExpression: function(binary) {
+    this.genericVisit(binary);
+    if (binary.left.type === recast.Syntax.Literal &&
+        binary.right.type === recast.Syntax.Literal) {
+      var left = binary.left.value;
+      var right = binary.right.value;
+      switch (binary.operator) {
+        case "===":
+          return recast.builder.literal(left === right);
+        case "!==":
+          return recast.builder.literal(left !== right);
+      }
+    }
+  },
+
   visitCallExpression: function(call) {
     if (!this.constants.__DEV__) {
       if (call.callee.type === 'Identifier' && call.callee.name === 'invariant') {


### PR DESCRIPTION
If it's not present at build time, then it'll be removed completely -- this seems fair because if you're doing your own build then you likely don't match the release version numbers anyway.

I'm not sure how I feel about this though; not sure if this is more logic than desirable for constants.js. It compiles into:

```
if (true) {
  React.version = "0.5.0-alpha";
}
```
