### PR TITLE
Make constant propagation smarter about pruning if statements

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "grunt-contrib-jshint": "~0.6.0",
     "optimist": "~0.6.0",
     "phantomjs": "~1.9.1-4",
-    "recast": "~0.4.8",
+    "recast": "~0.4.16",
     "semver": "~2.1.0",
     "uglify-js": "~2.4.0",
     "grunt-contrib-clean": "~0.5.0",

--- a/src/dom/DOMPropertyOperations.js
+++ b/src/dom/DOMPropertyOperations.js
@@ -87,12 +87,10 @@ var DOMPropertyOperations = {
       }
       return processAttributeNameAndPrefix(name) +
         escapeTextForBrowser(value) + '"';
-    } else {
-      if (__DEV__) {
-        warnUnknownProperty(name);
-      }
-      return null;
+    } else if (__DEV__) {
+      warnUnknownProperty(name);
     }
+    return null;
   },
 
   /**
@@ -121,10 +119,8 @@ var DOMPropertyOperations = {
       }
     } else if (DOMProperty.isCustomAttribute(name)) {
       node.setAttribute(name, value);
-    } else {
-      if (__DEV__) {
-        warnUnknownProperty(name);
-      }
+    } else if (__DEV__) {
+      warnUnknownProperty(name);
     }
   },
 
@@ -150,10 +146,8 @@ var DOMPropertyOperations = {
       }
     } else if (DOMProperty.isCustomAttribute(name)) {
       node.removeAttribute(name);
-    } else {
-      if (__DEV__) {
-        warnUnknownProperty(name);
-      }
+    } else if (__DEV__) {
+      warnUnknownProperty(name);
     }
   }
 

--- a/vendor/constants.js
+++ b/vendor/constants.js
@@ -53,7 +53,13 @@ var ConstantVisitor = recast.Visitor.extend({
       } else if (stmt.alternate) {
         return stmt.alternate;
       } else {
-        this.remove();
+        // In case this if statement is an alternate clause for another
+        // if-statement, replacing that alternate with null will have the
+        // effect of pruning the unnecessary clause.  If this is just a
+        // free-floating if statement, replacing it with null will have
+        // the effect of removing it from the enclosing list of
+        // statements.
+        return null;
       }
     }
   }


### PR DESCRIPTION
The `this.remove()` call was overreaching and removing the entire parent `if` statement. A more conservative approach is just to replace the `if` statement with `null`.

cc @zpao @petehunt @spicyj
