### PR TITLE
Use a regular expression to parse out React.version

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,8 +55,11 @@ module.exports = function(grunt) {
   // Check that the version we're exporting is the same one we expect in the
   // package. This is not an ideal way to do this, but makes sure that we keep
   // them in sync.
+  var reactVersionExp = /\bReact\.version\s*=\s*['"]([^'"]+)['"];/;
   grunt.registerTask('version-check', function() {
-    var version = require('./build/modules/React').version;
+    var version = reactVersionExp.exec(
+      grunt.file.read('./build/modules/React.js')
+    )[1];
     var expectedVersion = grunt.config.data.pkg.version;
     if (version !== expectedVersion) {
       grunt.log.error('Versions do not match. Expected %s, saw %s', expectedVersion, version);


### PR DESCRIPTION
This fixes a silent failure of the test suite after whatever grunt step follows `version-check`. The failure appears to be due to the presence of the call `require('./build/modules/React')` in the `version-check` step, but I am not sure why it fails.

This is also nice because it no longer requires evaluating the entire React dependency tree just to check the version.

cc @zpao @spicyj
