### PR TITLE
Add github star counts

### DIFF
--- a/docs/_css/react.scss
+++ b/docs/_css/react.scss
@@ -703,3 +703,14 @@ p code {
     float: right;
   }
 }
+
+.github-count {
+  overflow: hidden;
+  display: inline-block;
+  top: 4px;
+  position: relative;
+
+  iframe {
+    margin-left: -52px;
+  }
+}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -43,9 +43,14 @@
           <li><a href="/react/support.html"{% if page.id == 'support' %} class="active"{% endif %}>support</a></li>
           <li><a href="/react/downloads.html"{% if page.id == 'downloads' %} class="active"{% endif %}>download</a></li>
           <li><a href="/react/blog/"{% if page.sectionid == 'blog' %} class="active"{% endif %}>blog</a></li>
-          <li><a href="http://github.com/facebook/react">github</a>
+          <li><a href="http://github.com/facebook/react">
+            github
+            <span class="github-count">
+              <iframe src="http://ghbtns.com/github-btn.html?user=facebook&repo=react&type=watch&count=true"
+    allowtransparency="true" frameborder="0" scrolling="0" width="102" height="20"></iframe>
+            </span>
+          </a></li>
         </ul>
-        <!-- <iframe src="http://ghbtns.com/github&#45;btn.html?user=facebook&#38;repo=react.js&#38;type=fork"allowtransparency="true" frameborder="0" scrolling="0" width="62" height="20"></iframe> -->
       </div>
     </div>
 


### PR DESCRIPTION
Using a margin-left and overflow: hidden we can only show the star counts :)

![github-count](https://f.cloud.github.com/assets/197597/1145058/1bcf5a24-1dee-11e3-9b1f-1a67b19e542a.png)

This gives social signal while not being so ugly.
