### PR TITLE
Requiring event listeners to be functions for binding

### DIFF
--- a/src/event/CallbackRegistry.js
+++ b/src/event/CallbackRegistry.js
@@ -20,6 +20,7 @@
 "use strict";
 
 var listenerBank = {};
+var invariant = require('invariant');
 
 /**
  * Stores "listeners" by `registrationName`/`id`. There should be at most one
@@ -40,6 +41,11 @@ var CallbackRegistry = {
    * @param {?function} listener The callback to store.
    */
   putListener: function(id, registrationName, listener) {
+    invariant(
+      typeof listener === 'function',
+      'Trying to bind an event handler to a non-function for %s',
+      registrationName
+    );
     var bankForRegistrationName =
       listenerBank[registrationName] || (listenerBank[registrationName] = {});
     bankForRegistrationName[id] = listener;

--- a/src/event/__tests__/CallbackRegistry-test.js
+++ b/src/event/__tests__/CallbackRegistry-test.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @emails react-core
+ */
+
+"use strict";
+
+describe('CallbackRegistry', function() {
+  var CallbackRegistry;
+
+  beforeEach(function() {
+    CallbackRegistry = require('CallbackRegistry');
+  });
+
+  it('should bind to a function', function(){
+    var noop = function(){};
+    expect(function(){
+      CallbackRegistry.putListener('test', 'onClick', noop);
+    }).not.toThrow();
+  });
+
+  it('should throw when binding to a non-function', function(){
+    expect(function(){
+      CallbackRegistry.putListener('test', 'onClick', {});
+    }).toThrow();
+  });
+});


### PR DESCRIPTION
Fixes #354.

This ensures that passed in `listener`s are functions so that they can be called correctly.

Throws if not. (matches the pattern Ember, Backbone and (I believe) Angular set forth).

Working on the CLA process via e-mail with Pete Hunt (pete@instagram.com) as mentioned in the #reactjs chat.
