### PR TITLE
Solves issue #114 - Stop requiring docblock for JSX transformer

### DIFF
--- a/vendor/browser-transforms.js
+++ b/vendor/browser-transforms.js
@@ -38,9 +38,7 @@ if (typeof window === "undefined" || window === null) {
 headEl = document.getElementsByTagName('head')[0];
 
 var run = exports.run = function(code) {
-  var jsx = docblock.parseAsObject(docblock.extract(code)).jsx;
-
-  var functionBody = jsx ? transform(code).code : code;
+  var functionBody = transform(code).code;
   var scriptEl = document.createElement('script');
 
   scriptEl.innerHTML = functionBody;

--- a/vendor/fbtransform/transforms/react.js
+++ b/vendor/fbtransform/transforms/react.js
@@ -56,7 +56,7 @@ var JSX_ATTRIBUTE_TRANSFORMS = {
 };
 
 function visitReactTag(traverse, object, path, state) {
-  var jsxObjIdent = getDocblock(state).jsx;
+  var jsxObjIdent = getDocblock(state).jsx || "React.DOM";
 
   catchup(object.openingElement.range[0], state);
 
@@ -177,10 +177,8 @@ function visitReactTag(traverse, object, path, state) {
   return false;
 }
 
-visitReactTag.test = function(object, path, state) {
-  // only run react when react @jsx namespace is specified in docblock
-  var jsx = getDocblock(state).jsx;
-  return object.type === Syntax.XJSElement && jsx && jsx.length;
+visitReactTag.test = function(object) {
+  return object.type === Syntax.XJSElement;
 };
 
 exports.visitReactTag = visitReactTag;

--- a/vendor/fbtransform/transforms/reactDisplayName.js
+++ b/vendor/fbtransform/transforms/reactDisplayName.js
@@ -57,7 +57,7 @@ function visitReactDisplayName(traverse, object, path, state) {
  * Will only run on @jsx files for now.
  */
 visitReactDisplayName.test = function(object, path, state) {
-  return object.type === Syntax.VariableDeclarator && !!getDocblock(state).jsx;
+  return object.type === Syntax.VariableDeclarator;
 };
 
 exports.visitReactDisplayName = visitReactDisplayName;


### PR DESCRIPTION
- '@jsx something' is still supported
- by default React.DOM is used (so no @jsx is needed)
