### PR TITLE
Change spec policy for getDefaultProps to SpecPolicy.DEFINE_MANY_MERGED

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -110,7 +110,7 @@ var ReactCompositeComponentInterface = {
    * @return {object}
    * @optional
    */
-  getDefaultProps: SpecPolicy.DEFINE_ONCE,
+  getDefaultProps: SpecPolicy.DEFINE_MANY_MERGED,
 
   /**
    * Invoked once before the component is mounted. The return value will be used


### PR DESCRIPTION
This will allow multiple mixins for a component to define
getDefaultProps and their values will be merged.

See also:
https://groups.google.com/d/msg/reactjs/UzSiXw2Vo5s/FxK7AHWOzLMJ

I work together with Dustin and we are both enjoying using React this was a question I initially posed to him when I came across the error message during development; he posted the topic here and encouraged me to submit this pull request after receiving your tacit approval to do so.
