### PR TITLE
Actually make exec work

### DIFF
--- a/vendor/browser-transforms.js
+++ b/vendor/browser-transforms.js
@@ -29,7 +29,7 @@ var docblock = require('jstransform/src/docblock');
 exports.transform = transform;
 
 exports.exec = function(code) {
-  return eval(transform(code));
+  return eval(transform(code).code);
 };
 
 if (typeof window === "undefined" || window === null) {


### PR DESCRIPTION
The spec for eval (http://es5.github.io/x15.1.html#x15.1.2.1) says "If Type(x) is not String, return x." and that's exactly what's happening here -- it gets {code: ...} and does nothing.
