### PR TITLE
Add app id for comments moderation

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -10,6 +10,7 @@
   <meta property="og:url" content="http://facebook.github.io/react{{ page.url }}" />
   <meta property="og:image" content="http://facebook.github.io/react/img/logo_og.png" />
   <meta property="og:description" content="A JavaScript library for building user interfaces" />
+  <meta property="fb:app_id" content="623268441017527" />
 
   <link rel="shortcut icon" href="/react/favicon.ico">
   <link rel="alternate" type="application/rss+xml" title="{{ site.name }}" href="{{ site.url }}{{ site.baseurl }}/feed.xml">


### PR DESCRIPTION
This way we can be notified when any new comment appear in the docs/blog and add moderators

Comments will be available there for the moderators: https://developers.facebook.com/tools/comments
Docs: https://developers.facebook.com/docs/reference/plugins/comments/
