### PR TITLE
Compiling with Closure Compiler's ADVANCED mode

### DIFF
--- a/src/core/ReactDefaultInjection.js
+++ b/src/core/ReactDefaultInjection.js
@@ -58,12 +58,12 @@ function inject() {
    * them).
    */
   EventPluginHub.injection.injectEventPluginsByName({
-    'SimpleEventPlugin': SimpleEventPlugin,
-    'EnterLeaveEventPlugin': EnterLeaveEventPlugin,
-    'ChangeEventPlugin': ChangeEventPlugin,
-    'CompositionEventPlugin': CompositionEventPlugin,
-    'MobileSafariClickEventPlugin': MobileSafariClickEventPlugin,
-    'SelectEventPlugin': SelectEventPlugin
+    SimpleEventPlugin: SimpleEventPlugin,
+    EnterLeaveEventPlugin: EnterLeaveEventPlugin,
+    ChangeEventPlugin: ChangeEventPlugin,
+    CompositionEventPlugin: CompositionEventPlugin,
+    MobileSafariClickEventPlugin: MobileSafariClickEventPlugin,
+    SelectEventPlugin: SelectEventPlugin
   });
 
   ReactDOM.injection.injectComponentClasses({


### PR DESCRIPTION
So I've tried today to compile React in advanced mode and the first error I've got was 

```
Uncaught Error: Invariant Violation: EventPluginRegistry: Cannot inject event plugins that do not exist in the plugin ordering, `SimpleEventPlugin`.
```

I guess I should strive to get minimally working (breaking, I mean) example, and I'll try to do that without dropping my whole setup on you, but this requires a bit of time, I'm not sure if it will be hard to reproduce it.
