### PR TITLE
Re-rendering components into a document leaks components

### DIFF
--- a/src/core/ReactMount.js
+++ b/src/core/ReactMount.js
@@ -430,6 +430,10 @@ var ReactMount = {
   unmountComponentFromNode: function(instance, container) {
     instance.unmountComponent();
 
+    if (container.nodeType === DOC_NODE_TYPE) {
+      container = container.documentElement;
+    }
+
     // http://jsperf.com/emptying-a-node
     while (container.lastChild) {
       container.removeChild(container.lastChild);
@@ -591,6 +595,8 @@ var ReactMount = {
    */
 
   ATTR_NAME: ATTR_NAME,
+
+  getReactRootID: getReactRootID,
 
   getID: getID,
 

--- a/src/core/__tests__/ReactRenderDocument-test.js
+++ b/src/core/__tests__/ReactRenderDocument-test.js
@@ -39,6 +39,66 @@ describe('rendering React components at document', function() {
     testDocument = getTestDocument();
   });
 
+  it('should be able to get root component id for document node', function() {
+    if (!testDocument) {
+      // These tests are not applicable in jst, since jsdom is buggy.
+      return;
+    }
+
+    var Root = React.createClass({
+      render: function() {
+        return (
+          <html>
+            <head>
+              <title>Hello World</title>
+            </head>
+            <body>
+              Hello world
+            </body>
+          </html>
+        );
+      }
+    });
+
+    ReactMount.allowFullPageRender = true;
+    var component = React.renderComponent(<Root />, testDocument);
+    expect(testDocument.body.innerHTML).toBe(' Hello world ');
+
+    var componentID = ReactMount.getReactRootID(testDocument);
+    expect(componentID).toBe(component._rootNodeID);
+  });
+
+  it('should be able to unmount component from document node', function() {
+    if (!testDocument) {
+      // These tests are not applicable in jst, since jsdom is buggy.
+      return;
+    }
+
+    var Root = React.createClass({
+      render: function() {
+        return (
+          <html>
+            <head>
+              <title>Hello World</title>
+            </head>
+            <body>
+              Hello world
+            </body>
+          </html>
+        );
+      }
+    });
+
+    ReactMount.allowFullPageRender = true;
+    React.renderComponent(<Root />, testDocument);
+    expect(testDocument.body.innerHTML).toBe(' Hello world ');
+
+    var unmounted = React.unmountComponentAtNode(testDocument);
+    expect(unmounted).toBe(true);
+    expect(testDocument.documentElement).not.toBe(null);
+    expect(testDocument.documentElement.innerHTML).toBe('');
+  });
+
   it('should be able to switch root constructors via state', function() {
     if (!testDocument) {
       // These tests are not applicable in jst, since jsdom is buggy.

--- a/src/core/getReactRootElementInContainer.js
+++ b/src/core/getReactRootElementInContainer.js
@@ -18,12 +18,23 @@
 
 "use strict";
 
+var DOC_NODE_TYPE = 9;
+
 /**
- * @param {DOMElement} container DOM element that may contain a React component
+ * @param {DOMElement|DOMDocument} container DOM element that may contain
+ *                                           a React component
  * @return {?*} DOM element that may have the reactRoot ID, or null.
  */
 function getReactRootElementInContainer(container) {
-  return container && container.firstChild;
+  if (!container) {
+    return null;
+  }
+
+  if (container.nodeType === DOC_NODE_TYPE) {
+    return container.documentElement;
+  } else {
+    return container.firstChild;
+  }
 }
 
 module.exports = getReactRootElementInContainer;


### PR DESCRIPTION
This PR does three things:
- provides test cases which 
  - test if we are able to unmount a component mounted into a document.
  - test if we can get reference to a component mounted into a document.
- fixes unmounting such components from document element
- fixes if such components can be queried by its container element

Merge test cases only, make sure they are sane, make sure they fail without further commits, then merge the rest and see everything is green.
