### PR TITLE
bump baseline jstransform and esprima dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   },
   "dependencies": {
     "commoner": "~0.8.4",
-    "esprima-fb": "1001.1001.1000-dev-harmony-fb",
-    "jstransform": "~1.0.0"
+    "esprima-fb": "~1001.1001.2000-dev-harmony-fb",
+    "jstransform": "~1.0.1"
   },
   "devDependencies": {
     "browserify": "~2.29.0",


### PR DESCRIPTION
Updates the baseline versions for esprima + jstransform (in prep for 0.5 release)
