### PR TITLE
Custom propTypes should be able to use mixins.

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -678,7 +678,7 @@ var ReactCompositeComponentMixin = {
       for (propName in propTypes) {
         var checkProp = propTypes[propName];
         if (checkProp) {
-          checkProp(props, propName, componentName);
+          checkProp.call(this, props, propName, componentName);
         }
       }
     }

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -266,6 +266,30 @@ describe('ReactCompositeComponent', function() {
     }).not.toThrow();
   });
 
+  it('should allow custom propTypes to use mixins', function(){
+    var Mixin = {
+      keyValidation: function(){
+        throw new Error('Validation failed!');
+      }
+    }
+
+    var Component = React.createClass({
+      mixins: [Mixin],
+      propTypes: {
+        key: function(){
+          this.keyValidation();
+        }
+      },
+      render: function() {
+        return <span></span>;
+      }
+    });
+
+    expect(function() {
+      ReactTestUtils.renderIntoDocument(<Component />);
+    }).toThrow('Validation failed!');
+  });
+
   it('should not allow `forceUpdate` on unmounted components', function() {
     var container = document.createElement('div');
     document.documentElement.appendChild(container);


### PR DESCRIPTION
Pull request for this issue: https://github.com/facebook/react/issues/431

Contributing:
- `grunt test` and `grunt lint` both pass
- I have filled out the CLA under `tommyh`
