### PR TITLE
Add clickable anchors to docs headers

### DIFF
--- a/docs/_css/react.scss
+++ b/docs/_css/react.scss
@@ -391,6 +391,16 @@ section.black content {
     font-size: 24px;
   }
 
+  h1, h2, h3, h4, h5, h6 {
+    a {
+      color: $darkTextColor;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
   // H2s form documentation topic dividers. Extra space helps.
   h2 {
     margin-top: 30px;

--- a/docs/_plugins/header_links.rb
+++ b/docs/_plugins/header_links.rb
@@ -11,7 +11,7 @@ class Redcarpet::Render::HTML
       .gsub(/\s+/, "-")
       .gsub(/[^A-Za-z0-9\-_.]/, "")
 
-    return "<h#{level} id=\"#{clean_title}\">#{title}</h#{level}>"
+    return "<h#{level} id=\"#{clean_title}\"><a href=\"##{clean_title}\">#{title}</a></h#{level}>"
   end
 end
 


### PR DESCRIPTION
This makes the headers red because they're links now.
Change them back to black.
