### PR TITLE
Add support for data={object}

### DIFF
--- a/src/core/ReactDOMComponent.js
+++ b/src/core/ReactDOMComponent.js
@@ -104,22 +104,22 @@ ReactDOMComponent.Mixin = {
     }
   ),
 
-  _processDataAttribute: function(props) {
-    if (props.data && typeof props.data === 'object') {
-      var objectProps = Object.keys(props.data),
-        objectPropName,
-        objectPropValue;
+  _processDatasetAttribute: function(props) {
+    if (props.dataset && typeof props.dataset === 'object') {
+      var datasetProps = Object.keys(props.dataset),
+          datasetPropName,
+          datasetPropValue;
 
-      for (var i = 0, l = objectProps.length; i < l; i++) {
-        objectPropName = objectProps[i];
-        objectPropValue = props.data[objectPropName];
-        if (typeof objectPropValue === "function") {
-          objectPropValue = objectPropValue.call(this);
+      for (var i = 0, l = datasetProps.length; i < l; i++) {
+        datasetPropName = datasetProps[i];
+        datasetPropValue = props.dataset[datasetPropName];
+        if (typeof datasetPropValue === "function") {
+          datasetPropValue = datasetPropValue.call(this);
         }
-        props['data-' + objectPropName] = objectPropValue;
+        props['data-' + datasetPropName] = datasetPropValue;
       }
 
-      props.data = null;
+      props.dataset = null;
     }
   },
 
@@ -137,7 +137,7 @@ ReactDOMComponent.Mixin = {
   _createOpenTagMarkup: function() {
     var props = this.props;
     var ret = this._tagOpen;
-    this._processDataAttribute(props);
+    this._processDatasetAttribute(props);
     for (var propKey in props) {
       if (!props.hasOwnProperty(propKey)) {
         continue;
@@ -241,7 +241,7 @@ ReactDOMComponent.Mixin = {
     var propKey;
     var styleName;
     var styleUpdates;
-    this._processDataAttribute(nextProps);
+    this._processDatasetAttribute(nextProps);
     for (propKey in lastProps) {
       if (nextProps.hasOwnProperty(propKey) ||
          !lastProps.hasOwnProperty(propKey)) {

--- a/src/core/__tests__/ReactDOMComponent-test.js
+++ b/src/core/__tests__/ReactDOMComponent-test.js
@@ -56,7 +56,7 @@ describe('ReactDOMComponent', function() {
           return "b";
         }
       };
-      var stub = ReactTestUtils.renderIntoDocument(<div data={testObject} />);
+      var stub = ReactTestUtils.renderIntoDocument(<div dataset={testObject} />);
       var domNode = stub.getDOMNode();
       expect(domNode.dataset.a).toEqual('a');
       expect(domNode.dataset.b).toEqual('b');
@@ -66,7 +66,7 @@ describe('ReactDOMComponent', function() {
         },
         b: "2"
       };
-      stub.receiveProps({data: testObject});
+      stub.receiveProps({dataset: testObject});
       expect(domNode.dataset.a).toEqual("1");
       expect(domNode.dataset.b).toEqual("2");
     });


### PR DESCRIPTION
Turns:

var obj = {x:1, t:function(){ return "2"; }};

&lt;p data={obj}/&gt;

into:

&lt;p data-x="1" data-t="2" /&gt;

Possible improvement areas:
- call function with additional parameters (like propTypes)
- add invariant tests
- add support for attributes besides data
