### PR TITLE
Make SelectEventPlugin not throw for range inputs

### DIFF
--- a/src/eventPlugins/SelectEventPlugin.js
+++ b/src/eventPlugins/SelectEventPlugin.js
@@ -22,6 +22,7 @@ var EventConstants = require('EventConstants');
 var EventPluginHub = require('EventPluginHub');
 var EventPropagators = require('EventPropagators');
 var ExecutionEnvironment = require('ExecutionEnvironment');
+var ReactInputSelection = require('ReactInputSelection');
 var SyntheticEvent = require('SyntheticEvent');
 
 var getActiveElement = require('getActiveElement');
@@ -65,7 +66,8 @@ var mouseDown = false;
  * @param {object}
  */
 function getSelection(node) {
-  if ('selectionStart' in node) {
+  if ('selectionStart' in node &&
+      ReactInputSelection.hasSelectionCapabilities(node)) {
     return {
       start: node.selectionStart,
       end: node.selectionEnd


### PR DESCRIPTION
Accessing .selectionStart on a non-text input will throw (see http://www.w3.org/TR/2009/WD-html5-20090423/editing.html#textFieldSelection), so check that the input has selection capabilities before accessing the property.

Fixes #437.

cc @joshduck
