### PR TITLE
Make 'disabled' MUST_USE_ATTRIBUTE for compatibility with CSS [disabled] selectors

### DIFF
--- a/src/dom/DefaultDOMPropertyConfig.js
+++ b/src/dom/DefaultDOMPropertyConfig.js
@@ -57,7 +57,7 @@ var DefaultDOMPropertyConfig = {
     data: null, // For `<object />` acts as `src`.
     dateTime: MUST_USE_ATTRIBUTE,
     dir: null,
-    disabled: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
+    disabled: MUST_USE_ATTRIBUTE | HAS_BOOLEAN_VALUE,
     draggable: null,
     encType: null,
     form: MUST_USE_ATTRIBUTE,


### PR DESCRIPTION
When a ReactDOMComponent is created with the property `disabled: true` subsequently setting the property to `disabled: false` the HTML attribute `disabled="true"` was being left in the DOM.

Example: http://jsfiddle.net/kb3gN/409/
