### PR TITLE
Bump populist version to v0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "browserify": "~2.34.1",
     "wrapup": "~0.12.0",
-    "populist": "~0.1.3",
+    "populist": "~0.1.4",
     "grunt-cli": "~0.1.9",
     "grunt": "~0.4.1",
     "grunt-contrib-copy": "~0.4.1",


### PR DESCRIPTION
The new version includes a fix for this IE8 issue reported by @subtleGradient: https://github.com/benjamn/populist/issues/4

Closes #456.
