### PR TITLE
fix doc & example transition opacity from .99 to 1

### DIFF
--- a/docs/docs/09-addons.md
+++ b/docs/docs/09-addons.md
@@ -67,7 +67,7 @@ You can use these classes to trigger a CSS animation or transition. For example,
 }
 
 .example-enter.example-enter-active {
-  opacity: 0.99;
+  opacity: 1;
 }
 ```
 
@@ -75,7 +75,7 @@ You'll notice that when you try to remove an item `ReactTransitionGroup` keeps i
 
 ```css
 .example-leave {
-  opacity: 0.99;
+  opacity: 1;
   transition: opacity .5s ease-in;
 }
 

--- a/examples/transitions/transition.css
+++ b/examples/transitions/transition.css
@@ -20,7 +20,7 @@
 .example-enter.example-enter-active,
 .example-leave {
   margin-left: 0;
-  opacity: 0.99;
+  opacity: 1;
 }
 
 .animateExample {


### PR DESCRIPTION
The initial thought was that an opacity animation from 0.01 to 1 causes trouble on some browser. But after testing on opera 12.15, ff 23, ie 10, chrome 30, desktop/mobile safari 7 and chrome android I confirm this works.
