### PR TITLE
Warn for an invalid propType specification

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -287,6 +287,18 @@ var RESERVED_SPEC_KEYS = {
     }
   },
   propTypes: function(Constructor, propTypes) {
+    if (__DEV__) {
+      for (var propName in propTypes) {
+        if (propTypes.hasOwnProperty(propName) &&
+            typeof propTypes[propName] !== 'function') {
+          console.warn(
+            (Constructor.displayName || 'ReactCompositeComponent') +
+            '.propTypes: You gave an invalid prop type for "' + propName +
+            '"; check for typos in your specification.'
+          );
+        }
+      }
+    }
     Constructor.propTypes = propTypes;
   }
 };
@@ -676,9 +688,11 @@ var ReactCompositeComponentMixin = {
     if (propTypes) {
       var componentName = this.constructor.displayName;
       for (propName in propTypes) {
-        var checkProp = propTypes[propName];
-        if (checkProp) {
-          checkProp(props, propName, componentName);
+        if (propTypes.hasOwnProperty(propName)) {
+          var checkProp = propTypes[propName];
+          if (checkProp) {
+            checkProp(props, propName, componentName);
+          }
         }
       }
     }

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -289,6 +289,33 @@ describe('ReactCompositeComponent', function() {
     }).not.toThrow();
   });
 
+  it('should warn about invalid prop types', function() {
+    var warn = console.warn;
+    console.warn = mocks.getMockFunction();
+
+    try {
+      var Component = React.createClass({
+        propTypes: {
+          // Should be `isRequired`, not `required`
+          key: ReactPropTypes.string.required
+        },
+        render: function() {
+          return <span>{this.props.key}</span>;
+        }
+      });
+
+      expect(console.warn.mock.calls.length).toBe(1);
+      expect(console.warn.mock.calls[0][0]).toBe(
+        'Component.propTypes: You gave an invalid prop type for "key"; check ' +
+        'for typos in your specification.'
+      );
+    } catch (e) {
+      throw e;
+    } finally {
+      console.warn = warn;
+    }
+  });
+
   it('should not allow `forceUpdate` on unmounted components', function() {
     var container = document.createElement('div');
     document.documentElement.appendChild(container);


### PR DESCRIPTION
Closes #415.

We could use `invariant` but that'll break code for people who currently have invalid specs -- I'm undecided on whether that's a good or bad thing.
