### PR TITLE
IE8 support for JSXTransformer

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   },
   "dependencies": {
     "commoner": "~0.8.7",
-    "esprima-fb": "~1001.1001.2000-dev-harmony-fb",
-    "jstransform": "~1.0.1"
+    "esprima-fb": "~2001.1001.0-dev-harmony-fb",
+    "jstransform": "~2.0.1"
   },
   "devDependencies": {
     "browserify": "~2.34.1",

--- a/vendor/browser-transforms.js
+++ b/vendor/browser-transforms.js
@@ -43,7 +43,7 @@ var run = exports.run = function(code) {
   var functionBody = jsx ? transform(code).code : code;
   var scriptEl = document.createElement('script');
 
-  scriptEl.innerHTML = functionBody;
+  scriptEl.text = functionBody;
   headEl.appendChild(scriptEl);
 };
 
@@ -75,11 +75,15 @@ var load = exports.load = function(url, callback) {
 
 runScripts = function() {
   var scripts = document.getElementsByTagName('script');
-  scripts = Array.prototype.slice.call(scripts);
-  var jsxScripts = scripts.filter(function(script) {
-    return script.type === 'text/jsx';
-  });
-
+  
+  // Array.prototype.slice cannot be used on NodeList on IE8
+  var jsxScripts = [];
+  for (var i = 0; i < scripts.length; i++) {
+    if (scripts.item(i).type === 'text/jsx') {
+      jsxScripts.push(scripts.item(i));
+    }
+  }
+  
   console.warn("You are using the in-browser JSX transformer. Be sure to precompile your JSX for production - http://facebook.github.io/react/docs/tooling-integration.html#jsx");
 
   jsxScripts.forEach(function(script) {


### PR DESCRIPTION
This depends on a pending PR (https://github.com/facebook/esprima/pull/4) for esprima/fb-harmony, this is not harmful without that PR, but IE8 support won't be functional without it.

The esprima PR is simply changing `default: def` to `'default': def`

(Very sorry, my initial extra PR was for recast where I led myself to believe that I had found the problem, the real fix is the following for esprima/fb-harmony https://github.com/facebook/esprima/pull/4).
