### PR TITLE
JSXTransformer, concatenate consecutive strings

### DIFF
--- a/src/dom/components/__tests__/ReactDOMTextarea-test.js
+++ b/src/dom/components/__tests__/ReactDOMTextarea-test.js
@@ -188,7 +188,7 @@ describe('ReactDOMTextarea', function() {
 
     expect(function() {
       ReactTestUtils.renderIntoDocument(
-        <textarea>{'hello'}{'there'}</textarea>
+        <textarea>{'hello'}{'there'+'avoid jsx concat'}</textarea>
       );
     }).toThrow();
 

--- a/vendor/fbtransform/transforms/xjs.js
+++ b/vendor/fbtransform/transforms/xjs.js
@@ -171,7 +171,7 @@ function trimWithSingleSpace(string) {
  *   "line "+
  *   "line"
  */
-function renderXJSLiteral(object, isLast, state, start, end) {
+function renderXJSLiteral(object, isLast, state, start, end, concat) {
   /** Added blank check filtering and triming*/
   var trimmedChildValue = safeTrim(object.value);
   var hasFinalNewLine = false;
@@ -253,7 +253,7 @@ function renderXJSLiteral(object, isLast, state, start, end) {
 
   // add comma before trailing whitespace
   if (!isLast) {
-    utils.append(',', state);
+    utils.append(concat ? '+' : ',', state);
   }
 
   // tail whitespace
@@ -264,14 +264,16 @@ function renderXJSLiteral(object, isLast, state, start, end) {
   utils.move(object.range[1], state);
 }
 
-function renderXJSExpressionContainer(traverse, object, isLast, path, state) {
+function renderXJSExpressionContainer(
+  traverse, object, isLast, path, state, concat
+) {
   // Plus 1 to skip `{`.
   utils.move(object.range[0] + 1, state);
   traverse(object.expression, path, state);
   if (!isLast && object.expression.type !== Syntax.XJSEmptyExpression) {
     // If we need to append a comma, make sure to do so after the expression.
     utils.catchup(object.expression.range[1], state);
-    utils.append(',', state);
+    utils.append(concat ? '+' : ',', state);
   }
 
   // Minus 1 to skip `}`.


### PR DESCRIPTION
JSXTransformer currently produces suboptimal code when _fixed strings_ are inserted with braces, `{'Abc'}` or `{"Abc"}`, as is required if you want to override the JSX whitespace collapsing.

This means that `<div>A{'\n'}B</div>` does not generate 1 div, but 1 div and 3 spans `<div><span>A</span><span>\n</span><span>B</span></div>` rather than just `<div><span>A\nB</span></div>`.

My proposed changes treats `{'Abc'}` and `{"Abc"}`, and ONLY those as if they were actually written inline without braces, but _after_ whitespace collapsing has occured, so their content is exactly what ends up in the DOM. To clarify `{StringVar}`, `{'A'+'B'}` and even `{('Abc')}` are _not transformed_, so this will have no effect on runtime keying.

If my PR for stricter whitespace collapsing rules is accepted, this will hopefully be less of an issue. But still, a single `{'\n'}` can cause 0 spans to become 3 which can be a heavy price considering the DOM is the costly part, and this is part of the JSXTransformer which in my opinion, should make a reasonable effort to generate "fast code" as long as it doesn't affect readability.

I also removed a duplicated piece of code (I can move it into it's own PR), because it simplifies the implementation of this PR.
### Example

```
<div>
  abc{'\n'}def
  def{" \t"}ghi
  ghi{Var}jkl
  jkl{' '+Var}mno
</div>
```
### Before

Although a contrived example, this will end up creating 9 spans.

```
React.DOM.div(null, 
  'abc','\n','def '+
  'def'," \t",'ghi '+
  'ghi',Var,'jkl '+
  'jkl',' '+Var,'mno'
)
```
### After

After fixed strings have been concatenated, only 5 spans will be generated. Note that the two expressions with `Var` have not been concatenated, but remains as arguments, and as such still have their own spans.

```
React.DOM.div(null, 
  'abc'+'\n'+'def '+
  'def'+" \t"+'ghi '+
  'ghi',Var,'jkl '+
  'jkl',' '+Var,'mno'
)
```
