### PR TITLE
move docs tooling from JSX in Depth

### DIFF
--- a/docs/docs/02.1-jsx-in-depth.md
+++ b/docs/docs/02.1-jsx-in-depth.md
@@ -157,19 +157,6 @@ It's easy to add comments within your JSX; they're just JS expressions:
 var content = <Container>{/* this is a comment */}<Nav /></Container>;
 ```
 
-## Tooling
-
-Beyond the compilation step, JSX does not require any special tools.
-
-* Many editors already include reasonable support for JSX (Vim, Emacs js2-mode).
-  * JSX syntax highlighting is available for Sublime Text and other editors
-    that support `*.tmLanguage` using the third-party
-    [`JavaScript (JSX).tmLanguage`][1].
-* Linting provides accurate line numbers after compiling without sourcemaps.
-* Elements use standard scoping so linters can find usage of out-of-scope
-  components.
-
-[1]: https://github.com/yungsters/sublime/blob/master/tmLanguage/JavaScript%20(JSX).tmLanguage
 
 ## Prior Work
 

--- a/docs/docs/08-tooling-integration.md
+++ b/docs/docs/08-tooling-integration.md
@@ -47,6 +47,14 @@ The open-source community has built tools that integrate JSX with several build 
 * [react-rails](https://github.com/facebook/react-rails) - use JSX with [Ruby on Rails](http://rubyonrails.org/)
 
 
+### Syntax Highlighting & Linting
+
+* Many editors already include reasonable support for JSX (Vim, Emacs js2-mode).
+  * [JSX syntax highlighting](https://github.com/yungsters/sublime/blob/master/tmLanguage/JavaScript%20(JSX\).tmLanguage) is available for Sublime Text and other editors
+    that support `*.tmLanguage`.
+* Linting provides accurate line numbers after compiling without sourcemaps.
+* Elements use standard scoping so linters can find usage of out-of-scope components.
+
 ## React Page
 
 To get started on a new project, you can use [react-page](https://github.com/facebook/react-page/), a complete React project creator. It supports both server-side and client-side rendering, source transform and packaging JSX files using CommonJS modules, and instant reload.


### PR DESCRIPTION
Also removes the code wrap around the syntax highlighting link.
#490.
