### PR TITLE
Prevent header anchors from interfering with clickable content in docs.

### DIFF
--- a/docs/_css/react.scss
+++ b/docs/_css/react.scss
@@ -80,6 +80,7 @@ h1, h2, h3, h4, h5, h6 {
   &.anchor {
     position: relative;
     top: -$navHeight;
+    z-index: -1;
     > a {
       color: $darkTextColor;
       position: relative;


### PR DESCRIPTION
Content just above headers was not selectable or clickable because of the relative positioning. This tweak makes sure all content can be interacted with when desired.
