### PR TITLE
Normalize which using keyCode and charCode

### DIFF
--- a/src/event/synthetic/SyntheticKeyboardEvent.js
+++ b/src/event/synthetic/SyntheticKeyboardEvent.js
@@ -38,7 +38,12 @@ var KeyboardEventInterface = {
   // Legacy Interface
   charCode: null,
   keyCode: null,
-  which: null
+  which: function(event) {
+    return (
+      'which' in event ? event.which :
+      'charCode' in event ? event.charCode : event.keyCode
+    );
+  }
 };
 
 /**


### PR DESCRIPTION
Is there a good reason why this isn't being done already? `key` and `char` are mentioned in the code, but `char` has since been deprecated in the standard and `key` relies on the browser to implement, leaving `which` as the only cross-browser solution for now. There doesn't seem to be a full-featured polyfill either that could be recommended as a substitute for `key`-support.

IE8 and older browsers don't support `which`, but only `keyCode` and `charCode`, seeing as we have the synthetic events, normalizing behavior according to (old) standards should be better than pushing it onto the developer.

**I propose that this PR be closed and that this solution be used instead https://github.com/facebook/react/issues/607**
