### PR TITLE
Normalize deltaY for FireFox

### DIFF
--- a/src/event/synthetic/SyntheticWheelEvent.js
+++ b/src/event/synthetic/SyntheticWheelEvent.js
@@ -29,15 +29,18 @@ var WheelEventInterface = {
   deltaX: function(event) {
     // NOTE: IE<9 does not support x-axis delta.
     return (
-      'deltaX' in event ? event.deltaX :
+      // deltaMode 1 is DOM_DELTA_LINE, observed in FireFox.
+      'deltaX' in event ? event.deltaX *
+        ('deltaMode' in event && event.deltaMode === 1 ? 40 : 1) :
       // Fallback to `wheelDeltaX` for Webkit and normalize (right is positive).
       'wheelDeltaX' in event ? -event.wheelDeltaX : 0
     );
   },
   deltaY: function(event) {
     return (
-      // Normalize (up is positive).
-      'deltaY' in event ? -event.deltaY :
+      // Normalize (up is positive)
+      'deltaY' in event ? -event.deltaY *
+        ('deltaMode' in event && event.deltaMode === 1 ? 40 : 1) :
       // Fallback to `wheelDeltaY` for Webkit.
       'wheelDeltaY' in event ? event.wheelDeltaY :
       // Fallback to `wheelDelta` for IE<9.
@@ -47,6 +50,7 @@ var WheelEventInterface = {
   deltaZ: null,
   deltaMode: null
 };
+
 
 /**
  * @param {object} dispatchConfig Configuration used to dispatch this event.


### PR DESCRIPTION
FireFox reports deltaY in deltaMode `DOM_DELTA_LINE`, where a line is 1/40th of a pixel (by FireFox's standards at least). This change normalizes it to report in `DOM_DELTA_PIXEL` instead, which is consistent with every other browser, and not as uselessly ambiguous as `DOM_DELTA_LINE`. As it stands, the developer must "guessingly" multiply with 40 if deltaMode is `DOM_DELTA_LINE` in order for it to be of any use, this way we at least keep it intuitive and we can fix it whenever the situation changes (which can't reasonably be expected of users out there).

It is in keeping with the standard, but normalizing it to the more reasonable `DOM_DELTA_PIXEL` is preferable in my opinion (yes, deltaMode should be forced to return `0` if we do that).

However, many uses specifically wants to count "clicks" rather than distance, I haven't researched it properly yet, but it is pretty much a minefield of inconsistent browser behaviors, perhaps something could be done about that as well.
