### PR TITLE
Establish a convention for forcing jsx rebuilds

### DIFF
--- a/grunt/config/jsx/jsx.js
+++ b/grunt/config/jsx/jsx.js
@@ -10,7 +10,7 @@ var rootIDs = [
 var getDebugConfig = function() {
   return {
     "debug": true,
-    "jsxConfig": grunt.config.data.pkg.jsxConfig,
+    "commonerConfig": grunt.config.data.pkg.commonerConfig,
     "constants": {
       "__VERSION__": grunt.config.data.pkg.version,
       "__DEV__": true
@@ -34,7 +34,7 @@ var test = {
     return {
       "debug": true,
       "mocking": true,
-      "jsxConfig": grunt.config.data.pkg.jsxConfig,
+      "commonerConfig": grunt.config.data.pkg.commonerConfig,
       "constants": {
         "__VERSION__": grunt.config.data.pkg.version,
         "__DEV__": true
@@ -51,7 +51,7 @@ var release = {
   getConfig: function() {
     return {
       "debug": false,
-      "jsxConfig": grunt.config.data.pkg.jsxConfig,
+      "commonerConfig": grunt.config.data.pkg.commonerConfig,
       "constants": {
         "__VERSION__": grunt.config.data.pkg.version,
         "__DEV__": false

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "node": ">=0.10.0"
   },
   "preferGlobal": true,
-  "jsxConfig": {
+  "commonerConfig": {
     "version": 1
   }
 }


### PR DESCRIPTION
Pull request #526 updated the behavior of `vendor/constants.js` without changing any source files or the `bin/jsx-internal` script, so files that should have been rebuilt (like `utils/__tests__/ImmutableObject-test.js`) were not automatically rebuilt (unless you knew to do `rm -rf .module-cache` manually).

This commit allows us to bump a version number (`commonerCacheBuster`) when we know the transform toolchain has been altered in a way that will not be visible to commoner/jsx.

With this convention, if we reset to an older revision (e.g. during a `git bisect`) and the appropriate cached module files are still in the `.module-cache/`, they can be used without rebuilding. That's why I prefer this approach to just deleting the `.module-cache/`.

cc @subtleGradient @zpao

Closes #104.
Closes #496.
Closes #530.
