### PR TITLE
[ReactTransitionGroup] Entry transition only when adding to an existing group

### DIFF
--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -28,6 +28,7 @@ var ReactTransitionGroup = React.createClass({
     transitionName: React.PropTypes.string.isRequired,
     transitionEnter: React.PropTypes.bool,
     transitionLeave: React.PropTypes.bool,
+    transitionOnMount: React.PropTypes.bool,
     onTransition: React.PropTypes.func,
     component: React.PropTypes.func
   },
@@ -36,6 +37,7 @@ var ReactTransitionGroup = React.createClass({
     return {
       transitionEnter: true,
       transitionLeave: true,
+      transitionOnMount: false,
       component: React.DOM.span
     };
   },
@@ -62,6 +64,7 @@ var ReactTransitionGroup = React.createClass({
     var children = {};
     var childMapping = ReactTransitionKeySet.getChildMapping(sourceChildren);
 
+    var allowEnterTransitions = this.props.transitionOnMount || this.isMounted();
     var currentKeys = ReactTransitionKeySet.mergeKeySets(
       this._transitionGroupCurrentKeys,
       ReactTransitionKeySet.getKeySet(sourceChildren)
@@ -76,7 +79,7 @@ var ReactTransitionGroup = React.createClass({
       if (childMapping[key] || this.props.transitionLeave) {
         children[key] = ReactTransitionableChild({
           name: this.props.transitionName,
-          enter: this.props.transitionEnter && this.isMounted(),
+          enter: allowEnterTransitions && this.props.transitionEnter,
           onDoneLeaving: this._handleDoneLeaving.bind(this, key)
         }, childMapping[key]);
       }
@@ -101,6 +104,7 @@ var ReactTransitionGroup = React.createClass({
           transitionName: null,
           transitionEnter: null,
           transitionLeave: null,
+          transitionOnMount: null,
           component: null
         },
         this.renderTransitionableChildren(this.props.children)

--- a/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
@@ -36,7 +36,7 @@ describe('ReactTransitionGroup', function() {
     container = document.createElement('div');
   });
 
-  it('should not run the entry transition for initial children', function() {
+  it('should not transition in initial children by default', function() {
     var container;
     var a;
 
@@ -51,16 +51,28 @@ describe('ReactTransitionGroup', function() {
     expect(a.getDOMNode().childNodes[0].className).toBe('');
   });
 
-  it('should warn after time with no transitionend', function() {
-    var a = React.renderComponent(
-      <ReactTransitionGroup transitionName="yolo">
-        {[]}
+  it('should transition in initial children when specified', function() {
+    var container;
+    var a;
+
+    container = document.createElement('div');
+    a = React.renderComponent(
+      <ReactTransitionGroup transitionName="yolo" transitionOnMount={true}>
+        <span key="one" id="one" />
       </ReactTransitionGroup>,
       container
     );
+    expect(a.getDOMNode().childNodes.length).toBe(1);
+    expect(a.getDOMNode().childNodes[0].className.trim()).toBe('yolo-enter');
+  });
 
+  it('should warn after time with no transitionend', function() {
+    var container;
+    var a;
+
+    container = document.createElement('div');
     a = React.renderComponent(
-      <ReactTransitionGroup transitionName="yolo">
+      <ReactTransitionGroup transitionName="yolo" transitionOnMount={true}>
         <span key="one" id="one" />
       </ReactTransitionGroup>,
       container


### PR DESCRIPTION
Currently if you add a new ReactTransitionGroup with some children during a
render pass, the children are transitioned. This is generally not desirable
(e.g. if adding a transition-enabled list that already has some items, you don't
want to transition all of the initial items when first rendering the list).

This diff makes it so that entry transitions are applied only when the
transition group already exists. This is implemented by applying entry
transitions only when the group has already been mounted.
