### PR TITLE
Ensure ReactPerf always uses a string as a URL.

### DIFF
--- a/src/test/ReactPerf.js
+++ b/src/test/ReactPerf.js
@@ -68,7 +68,7 @@ var ReactPerf = {
 
 if (__DEV__) {
   var ExecutionEnvironment = require('ExecutionEnvironment');
-  var URL = ExecutionEnvironment.canUseDOM ? window.location.href : '';
+  var URL = (ExecutionEnvironment.canUseDOM && window.location.href) || '';
   ReactPerf.enableMeasure = ReactPerf.enableMeasure ||
     !!URL.match(/[?&]react_perf\b/);
 }


### PR DESCRIPTION
This is a pretty pointless exercise and it is mostly about fixing my not being in the contributors list.

Anyway, the reason I'm making this change is that I ran into a case where window.location.href was empty and URL.match would fail. It doesn't make a lot of sense to be in an environment where window exists and window.location.href does not, but in any case it is better to have an empty string instead of no string :)
