### PR TITLE
Add back mocking removed to make ReactEventTopLevelCallback-test pass

### DIFF
--- a/src/core/__tests__/ReactEventTopLevelCallback-test.js
+++ b/src/core/__tests__/ReactEventTopLevelCallback-test.js
@@ -22,28 +22,23 @@ require('mock-modules')
   .dontMock('ReactEventTopLevelCallback')
   .dontMock('ReactMount')
   .dontMock('ReactInstanceHandles')
-  .dontMock('ReactDOM');
+  .dontMock('ReactDOM')
+  .mock('ReactEventEmitter');
 
 var EVENT_TARGET_PARAM = 1;
 
 describe('ReactEventTopLevelCallback', function() {
-  var mocks;
-
   var React;
   var ReactEventTopLevelCallback;
   var ReactDOM;
-  var ReactEventEmitter;
+  var ReactEventEmitter; // mocked
 
   beforeEach(function() {
     require('mock-modules').dumpCache();
-    mocks = require('mocks');
-
     React = require('React');
     ReactEventTopLevelCallback = require('ReactEventTopLevelCallback');
     ReactDOM = require('ReactDOM');
-    ReactEventEmitter = require('ReactEventEmitter');
-
-    ReactEventEmitter.handleTopLevel = mocks.getMockFunction();
+    ReactEventEmitter = require('ReactEventEmitter'); // mocked
   });
 
   describe('Propagation', function() {


### PR DESCRIPTION
This is a partial reversion of commit 9937f0c8bd.

cc @spicyj @Daniel15
