### PR TITLE
Allow running one spec/suite in the web interface

### DIFF
--- a/test/lib/jasmine-execute.js
+++ b/test/lib/jasmine-execute.js
@@ -1,7 +1,12 @@
 document.write('<style> @import "../vendor/jasmine/jasmine.css?_=' + (+new Date).toString(36) + '"; </style>');
 
 ;(function(env){
-  env.addReporter(new jasmine.HtmlReporter);
+  var htmlReporter = new jasmine.HtmlReporter();
+  env.addReporter(htmlReporter);
+  env.specFilter = function(spec) {
+    return htmlReporter.specFilter(spec);
+  };
+
   // Clean up any nodes the previous test might have added.
   env.afterEach(function() {
     harness.removeNextSiblings(document.body);

--- a/vendor/jasmine-jsreporter/jasmine-jsreporter.js
+++ b/vendor/jasmine-jsreporter/jasmine-jsreporter.js
@@ -113,7 +113,8 @@
         reportSpecResults: function (spec) {
             // Finish timing this spec and calculate duration/delta (in sec)
             spec.finishedAt = new Date();
-            spec.durationSec = elapsedSec(spec.startedAt.getTime(), spec.finishedAt.getTime());
+            // If the spec was skipped, reportSpecStarting is never called and spec.startedAt is undefined
+            spec.durationSec = spec.startedAt ? elapsedSec(spec.startedAt.getTime(), spec.finishedAt.getTime()) : 0;
         },
 
         reportSuiteResults: function (suite) {


### PR DESCRIPTION
This is the proper way to make it filter the spec list:

https://github.com/pivotal/jasmine/blob/1_3_x/spec/runner.html

I submitted the jasmine-jsreporter change as a pull request here:

https://github.com/detro/jasmine-jsreporter/pull/2

Fixes #563.
