### PR TITLE
Remove reference to old browser logger

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -11,7 +11,6 @@
     '../node_modules/jasmine-tapreporter/src/tapreporter.js',
     '../vendor/jasmine-jsreporter/jasmine-jsreporter.js',
 
-    'lib/testImageURL.browser.js',
     'lib/reportTestResults.browser.js',
 
     '../build/react.js',


### PR DESCRIPTION
The file was removed in 37bb9b76aba0deb445874273b93955ffb1c18bf8; this was giving a 404.
