### PR TITLE
Don't use .returnValue if .defaultPrevented exists

### DIFF
--- a/src/event/synthetic/SyntheticEvent.js
+++ b/src/event/synthetic/SyntheticEvent.js
@@ -79,7 +79,10 @@ function SyntheticEvent(dispatchConfig, dispatchMarker, nativeEvent) {
     }
   }
 
-  if (nativeEvent.defaultPrevented || nativeEvent.returnValue === false) {
+  var defaultPrevented = nativeEvent.defaultPrevented != null ?
+    nativeEvent.defaultPrevented :
+    nativeEvent.returnValue === false;
+  if (defaultPrevented) {
     this.isDefaultPrevented = emptyFunction.thatReturnsTrue;
   } else {
     this.isDefaultPrevented = emptyFunction.thatReturnsFalse;


### PR DESCRIPTION
`.defaultPrevented` exists in IE9+. I checked in IE9, Chrome, and Firefox that it does default to `false`.

Fixes #527.
