### PR TITLE
Be resilient to fn.name not existing in IE

### DIFF
--- a/src/core/__tests__/ReactPropTypes-test.js
+++ b/src/core/__tests__/ReactPropTypes-test.js
@@ -124,18 +124,19 @@ describe('Instance Types', function() {
 
   it("should throw for invalid instances", function() {
     function Person() {}
+    var name = Person.name || '<<anonymous>>';
 
     expect(typeCheck(Props.instanceOf(Person), false)).toThrow(
       'Invariant Violation: Invalid prop `testProp` supplied to ' +
-      '`testComponent`, expected instance of `Person`.'
+      '`testComponent`, expected instance of `' + name + '`.'
     );
     expect(typeCheck(Props.instanceOf(Person), {})).toThrow(
       'Invariant Violation: Invalid prop `testProp` supplied to ' +
-      '`testComponent`, expected instance of `Person`.'
+      '`testComponent`, expected instance of `' + name + '`.'
     );
     expect(typeCheck(Props.instanceOf(Person), '')).toThrow(
       'Invariant Violation: Invalid prop `testProp` supplied to ' +
-      '`testComponent`, expected instance of `Person`.'
+      '`testComponent`, expected instance of `' + name + '`.'
     );
   });
 


### PR DESCRIPTION
Fixes #516.
