### PR TITLE
Update commoner to 0.8.8 for Windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test": "grunt build && grunt test"
   },
   "dependencies": {
-    "commoner": "~0.8.7",
+    "commoner": "~0.8.8",
     "esprima-fb": "~2001.1001.0-dev-harmony-fb",
     "jstransform": "~2.0.1"
   },


### PR DESCRIPTION
benjamn/commoner#44 fixed commoner to work on Windows when module path relativization isn't used; with this, the `jsx` binary should work properly on Windows (though `jsx-internal` still won't).

Fixes #316, fixes #391, fixes #567.
