### PR TITLE
Polyfill and normalize HTML5 "key", deprecates which and keyCode

### DIFF
--- a/src/event/synthetic/SyntheticKeyboardEvent.js
+++ b/src/event/synthetic/SyntheticKeyboardEvent.js
@@ -22,12 +22,70 @@
 var SyntheticUIEvent = require('SyntheticUIEvent');
 
 /**
+ * Normalization of deprecated HTML5 "key" values
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Key_names
+ */
+
+var normalizeKey = {
+  'Esc': 'Escape',
+  'Spacebar': ' ',
+  'Left': 'ArrowLeft',
+  'Up': 'ArrowUp',
+  'Right': 'ArrowRight',
+  'Down': 'ArrowDown',
+  'Del': 'Delete',
+  'Win': 'OS',
+  'Menu': 'ContextMenu',
+  'Apps': 'ContextMenu',
+  'Scroll': 'ScrollLock',
+  'MozPrintableKey': 'Unidentified'
+};
+
+/**
+ * Translation from legacy "which/keyCode" to HTML5 "key"
+ * Only special keys supported, all others depend on keyboard layout or browser
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Key_names
+ */
+
+var translateToKey = {
+  8: 'Backspace',
+  9: 'Tab',
+  12: 'Clear',
+  13: 'Enter',
+  16: 'Shift',
+  17: 'Control',
+  18: 'Alt',
+  19: 'Pause',
+  20: 'CapsLock',
+  27: 'Escape',
+  32: ' ',
+  33: 'PageUp',
+  34: 'PageDown',
+  35: 'End',
+  36: 'Home',
+  37: 'ArrowLeft',
+  38: 'ArrowUp',
+  39: 'ArrowRight',
+  40: 'ArrowDown',
+  45: 'Insert',
+  46: 'Delete',
+  112: 'F1', 113: 'F2', 114: 'F3', 115: 'F4', 116: 'F5', 117: 'F6',
+  118: 'F7', 119: 'F8', 120: 'F9', 121: 'F10', 122: 'F11', 123: 'F12',
+  144: 'NumLock',
+  145: 'ScrollLock',
+  224: 'Meta'
+};
+
+/**
  * @interface KeyboardEvent
  * @see http://www.w3.org/TR/DOM-Level-3-Events/
  */
 var KeyboardEventInterface = {
-  'char': null,
-  key: null,
+  key: function(event) {
+    return 'key' in event ?
+      normalizeKey[event.key] || event.key :
+      translateToKey[event.which || event.keyCode] || 'Unidentified';
+  },
   location: null,
   ctrlKey: null,
   shiftKey: null,
@@ -36,6 +94,7 @@ var KeyboardEventInterface = {
   repeat: null,
   locale: null,
   // Legacy Interface
+  'char': null,
   charCode: null,
   keyCode: null,
   which: null


### PR DESCRIPTION
Implements the HTML5 `key` property for all browsers and normalizes behavior of those that already do, only special keys are supported. Non-special keys **cannot** be supported because they depend on the user's keyboard layout which cannot be determined, among other things. IE (IE9+ even) and latest FF both support the `key` property, but they are broken for anything but special keys.

Deprecates my PR https://github.com/facebook/react/pull/502, while you can listen to other values for which and keyCode, doing so relies on the user having a specific keyboard layout, which is quite simply broken behavior (and quite dangerous as it is not immediately apparent).

So all-in-all, this is pretty much as good and reliable as is humanly possible today, in **any browser**, and it's compatible with the future of HTML5.

Why would you want this? If you're making a webapp that should be in any way "keyboard friendly", like say, listen to enter in a field, or support pressing the arrows keys in a slideshow, then you need this, or you need to make it yourself. In my opinion, this is a hugely useful feature that is quite broken by default in browsers and something that should be solved and not thrust upon the users.

You can play with it here: http://dev.cetrez.com/jsx/ (check the console)

```
   raw     gz Sizes
341286  68450 build/JSXTransformer.js
135467  27432 build/jasmine.js
1033330182163 build/react-test.js
495169 103484 build/react-with-addons.js
103829  29131 build/react-with-addons.min.js
461512  96312 build/react.js
 97113  27265 build/react.min.js

   raw     gz Compared to master @ 564c8669f8ef511b9fc59e7006af5c8db30e4585
     =      = build/JSXTransformer.js
     =      = build/jasmine.js
     =      = build/react-test.js
 +1379   +551 build/react-with-addons.js
  +691   +387 build/react-with-addons.min.js
 +1379   +545 build/react.js
  +692   +381 build/react.min.js
```
