### PR TITLE
fixes iOS crasher

### DIFF
--- a/src/core/__tests__/ReactRenderDocument-test.js
+++ b/src/core/__tests__/ReactRenderDocument-test.js
@@ -40,10 +40,7 @@ describe('rendering React components at document', function() {
   });
 
   it('should be able to get root component id for document node', function() {
-    if (!testDocument) {
-      // These tests are not applicable in jst, since jsdom is buggy.
-      return;
-    }
+    expect(testDocument).not.toBeUndefined();
 
     var Root = React.createClass({
       render: function() {
@@ -69,10 +66,7 @@ describe('rendering React components at document', function() {
   });
 
   it('should be able to unmount component from document node', function() {
-    if (!testDocument) {
-      // These tests are not applicable in jst, since jsdom is buggy.
-      return;
-    }
+    expect(testDocument).not.toBeUndefined();
 
     var Root = React.createClass({
       render: function() {
@@ -100,10 +94,7 @@ describe('rendering React components at document', function() {
   });
 
   it('should be able to switch root constructors via state', function() {
-    if (!testDocument) {
-      // These tests are not applicable in jst, since jsdom is buggy.
-      return;
-    }
+    expect(testDocument).not.toBeUndefined();
 
     var Component = React.createClass({
       render: function() {
@@ -162,10 +153,7 @@ describe('rendering React components at document', function() {
   });
 
   it('should be able to switch root constructors', function() {
-    if (!testDocument) {
-      // These tests are not applicable in jst, since jsdom is buggy.
-      return;
-    }
+    expect(testDocument).not.toBeUndefined();
 
     var Component = React.createClass({
       render: function() {
@@ -210,10 +198,7 @@ describe('rendering React components at document', function() {
   });
 
   it('should be able to mount into document', function() {
-    if (!testDocument) {
-      // These tests are not applicable in jst, since jsdom is buggy.
-      return;
-    }
+    expect(testDocument).not.toBeUndefined();
 
     var Component = React.createClass({
       render: function() {
@@ -236,10 +221,7 @@ describe('rendering React components at document', function() {
   });
 
   it('should throw on full document render', function() {
-    if (!testDocument) {
-      // These tests are not applicable in jst, since jsdom is buggy.
-      return;
-    }
+    expect(testDocument).not.toBeUndefined();
 
     var container = testDocument;
     expect(function() {
@@ -255,10 +237,7 @@ describe('rendering React components at document', function() {
   });
 
   it('should throw on full document render of non-html', function() {
-    if (!testDocument) {
-      // These tests are not applicable in jst, since jsdom is buggy.
-      return;
-    }
+    expect(testDocument).not.toBeUndefined();
 
     var container = testDocument;
     ReactMount.allowFullPageRender = true;

--- a/src/test/getTestDocument.js
+++ b/src/test/getTestDocument.js
@@ -23,7 +23,7 @@ function getTestDocument() {
 
   var testDocument = iframe.contentDocument || iframe.contentWindow.document;
   testDocument.open();
-  testDocument.write('<!doctype html><meta charset=utf-8><title>test doc</title>');
+  testDocument.write('<!doctype html><html><meta charset=utf-8><title>test doc</title>');
   testDocument.close();
 
   iframe.parentNode.removeChild(iframe);


### PR DESCRIPTION
iOS Safari has buggy support for `document.implementation.createHTMLDocument`, let's not use that.
Bonus support for IE8.
