### PR TITLE
Backbone example: changed key from Math.random() to todo.cid

### DIFF
--- a/examples/todomvc-backbone/js/app.js
+++ b/examples/todomvc-backbone/js/app.js
@@ -236,7 +236,7 @@ var TodoApp = React.createClass({
     var todoItems = this.props.todos.map(function(todo) {
       return (
         <TodoItem
-          key={Math.random()}
+          key={todo.cid}
           todo={todo}
           onToggle={todo.toggle.bind(todo)}
           onDestroy={todo.destroy.bind(todo)}


### PR DESCRIPTION
It doesn’t make much sense to generate a random key for each todo render, because it will re-draw all todo’s DOM nodes on each model change. I changed it to the unique identifier `todo.cid` already supplied by the backbone model.
