### PR TITLE
Store pending state updates directly in this.state

### DIFF
--- a/src/core/__tests__/ReactCompositeComponentState-test.js
+++ b/src/core/__tests__/ReactCompositeComponentState-test.js
@@ -41,8 +41,8 @@ describe('ReactCompositeComponent-state', function() {
         } else {
           this.props.stateListener(
             from,
-            this.state && this.state.color,
-            this._pendingState && this._pendingState.color
+            this.currentState && this.currentState.color,
+            this.state && this.state.color
           );
         }
       },
@@ -118,52 +118,52 @@ describe('ReactCompositeComponent-state', function() {
     expect(stateListener.mock.calls).toEqual([
       // there is no state when getInitialState() is called
       [ 'getInitialState', null, null ],
-      [ 'componentWillMount-start', 'red', null ],
+      [ 'componentWillMount-start', 'red', 'red' ],
       // setState() only enqueues a pending state.
       [ 'componentWillMount-after-sunrise', 'red', 'sunrise' ],
       [ 'componentWillMount-end', 'red', 'orange' ],
       // pending state has been applied
-      [ 'render', 'orange', null ],
-      [ 'componentDidMount-start', 'orange', null ],
+      [ 'render', 'orange', 'orange' ],
+      [ 'componentDidMount-start', 'orange', 'orange' ],
       // componentDidMount() called setState({color:'yellow'}), currently this
       // occurs inline.
       // In a future where setState() is async, this test result will change.
-      [ 'shouldComponentUpdate-currentState', 'orange', null ],
+      [ 'shouldComponentUpdate-currentState', 'orange', 'yellow' ],
       [ 'shouldComponentUpdate-nextState', 'yellow' ],
-      [ 'componentWillUpdate-currentState', 'orange', null ],
+      [ 'componentWillUpdate-currentState', 'orange', 'yellow' ],
       [ 'componentWillUpdate-nextState', 'yellow' ],
-      [ 'render', 'yellow', null ],
-      [ 'componentDidUpdate-currentState', 'yellow', null ],
+      [ 'render', 'yellow', 'yellow' ],
+      [ 'componentDidUpdate-currentState', 'yellow', 'yellow' ],
       [ 'componentDidUpdate-prevState', 'orange' ],
       // componentDidMount() finally closes.
-      [ 'componentDidMount-end', 'yellow', null ],
-      [ 'componentWillReceiveProps-start', 'yellow', null ],
+      [ 'componentDidMount-end', 'yellow', 'yellow' ],
+      [ 'componentWillReceiveProps-start', 'yellow', 'yellow' ],
       // setState({color:'green'}) only enqueues a pending state.
       [ 'componentWillReceiveProps-end', 'yellow', 'green' ],
-      [ 'shouldComponentUpdate-currentState', 'yellow', null ],
+      [ 'shouldComponentUpdate-currentState', 'yellow', 'green' ],
       [ 'shouldComponentUpdate-nextState', 'green' ],
-      [ 'componentWillUpdate-currentState', 'yellow', null ],
+      [ 'componentWillUpdate-currentState', 'yellow', 'green' ],
       [ 'componentWillUpdate-nextState', 'green' ],
-      [ 'render', 'green', null ],
-      [ 'componentDidUpdate-currentState', 'green', null ],
+      [ 'render', 'green', 'green' ],
+      [ 'componentDidUpdate-currentState', 'green', 'green' ],
       [ 'componentDidUpdate-prevState', 'yellow' ],
       // setFavoriteColor('blue')
-      [ 'shouldComponentUpdate-currentState', 'green', null ],
+      [ 'shouldComponentUpdate-currentState', 'green', 'blue' ],
       [ 'shouldComponentUpdate-nextState', 'blue' ],
-      [ 'componentWillUpdate-currentState', 'green', null ],
+      [ 'componentWillUpdate-currentState', 'green', 'blue' ],
       [ 'componentWillUpdate-nextState', 'blue' ],
-      [ 'render', 'blue', null ],
-      [ 'componentDidUpdate-currentState', 'blue', null ],
+      [ 'render', 'blue', 'blue' ],
+      [ 'componentDidUpdate-currentState', 'blue', 'blue' ],
       [ 'componentDidUpdate-prevState', 'green' ],
       // forceUpdate()
-      [ 'componentWillUpdate-currentState', 'blue', null ],
+      [ 'componentWillUpdate-currentState', 'blue', 'blue' ],
       [ 'componentWillUpdate-nextState', 'blue' ],
-      [ 'render', 'blue', null ],
-      [ 'componentDidUpdate-currentState', 'blue', null ],
+      [ 'render', 'blue', 'blue' ],
+      [ 'componentDidUpdate-currentState', 'blue', 'blue' ],
       [ 'componentDidUpdate-prevState', 'blue' ],
       // unmountComponent()
       // state is available within `componentWillUnmount()`
-      [ 'componentWillUnmount', 'blue', null ]
+      [ 'componentWillUnmount', 'blue', 'blue' ]
     ]);
   });
 });

--- a/src/core/__tests__/ReactUpdates-test.js
+++ b/src/core/__tests__/ReactUpdates-test.js
@@ -46,15 +46,18 @@ describe('ReactUpdates', function() {
 
     var instance = ReactTestUtils.renderIntoDocument(<Component />);
     expect(instance.state.x).toBe(0);
+    expect(instance.currentState.x).toBe(0);
 
     ReactUpdates.batchedUpdates(function() {
       instance.setState({x: 1});
       instance.setState({x: 2});
-      expect(instance.state.x).toBe(0);
+      expect(instance.state.x).toBe(2);
+      expect(instance.currentState.x).toBe(0);
       expect(updateCount).toBe(0);
     });
 
     expect(instance.state.x).toBe(2);
+    expect(instance.currentState.x).toBe(2);
     expect(updateCount).toBe(1);
   });
 
@@ -75,17 +78,23 @@ describe('ReactUpdates', function() {
     var instance = ReactTestUtils.renderIntoDocument(<Component />);
     expect(instance.state.x).toBe(0);
     expect(instance.state.y).toBe(0);
+    expect(instance.currentState.x).toBe(0);
+    expect(instance.currentState.y).toBe(0);
 
     ReactUpdates.batchedUpdates(function() {
       instance.setState({x: 1});
       instance.setState({y: 2});
-      expect(instance.state.x).toBe(0);
-      expect(instance.state.y).toBe(0);
+      expect(instance.state.x).toBe(1);
+      expect(instance.state.y).toBe(2);
+      expect(instance.currentState.x).toBe(0);
+      expect(instance.currentState.y).toBe(0);
       expect(updateCount).toBe(0);
     });
 
     expect(instance.state.x).toBe(1);
     expect(instance.state.y).toBe(2);
+    expect(instance.currentState.x).toBe(1);
+    expect(instance.currentState.y).toBe(2);
     expect(updateCount).toBe(1);
   });
 
@@ -106,12 +115,14 @@ describe('ReactUpdates', function() {
     var instance = ReactTestUtils.renderIntoDocument(<Component x={0} />);
     expect(instance.props.x).toBe(0);
     expect(instance.state.y).toBe(0);
+    expect(instance.currentState.y).toBe(0);
 
     ReactUpdates.batchedUpdates(function() {
       instance.setProps({x: 1});
       instance.setState({y: 2});
       expect(instance.props.x).toBe(0);
-      expect(instance.state.y).toBe(0);
+      expect(instance.state.y).toBe(2);
+      expect(instance.currentState.y).toBe(0);
       expect(updateCount).toBe(0);
     });
 
@@ -149,19 +160,25 @@ describe('ReactUpdates', function() {
     var instance = ReactTestUtils.renderIntoDocument(<Parent />);
     var child = instance.refs.child;
     expect(instance.state.x).toBe(0);
+    expect(instance.currentState.x).toBe(0);
     expect(child.state.y).toBe(0);
+    expect(child.currentState.y).toBe(0);
 
     ReactUpdates.batchedUpdates(function() {
       instance.setState({x: 1});
       child.setState({y: 2});
-      expect(instance.state.x).toBe(0);
-      expect(child.state.y).toBe(0);
+      expect(instance.state.x).toBe(1);
+      expect(instance.currentState.x).toBe(0);
+      expect(child.state.y).toBe(2);
+      expect(child.currentState.y).toBe(0);
       expect(parentUpdateCount).toBe(0);
       expect(childUpdateCount).toBe(0);
     });
 
     expect(instance.state.x).toBe(1);
+    expect(instance.currentState.x).toBe(1);
     expect(child.state.y).toBe(2);
+    expect(child.currentState.y).toBe(2);
     expect(parentUpdateCount).toBe(1);
     expect(childUpdateCount).toBe(1);
   });
@@ -195,19 +212,25 @@ describe('ReactUpdates', function() {
     var instance = ReactTestUtils.renderIntoDocument(<Parent />);
     var child = instance.refs.child;
     expect(instance.state.x).toBe(0);
+    expect(instance.currentState.x).toBe(0);
     expect(child.state.y).toBe(0);
+    expect(child.currentState.y).toBe(0);
 
     ReactUpdates.batchedUpdates(function() {
       child.setState({y: 2});
       instance.setState({x: 1});
-      expect(instance.state.x).toBe(0);
-      expect(child.state.y).toBe(0);
+      expect(instance.state.x).toBe(1);
+      expect(instance.currentState.x).toBe(0);
+      expect(child.state.y).toBe(2);
+      expect(child.currentState.y).toBe(0);
       expect(parentUpdateCount).toBe(0);
       expect(childUpdateCount).toBe(0);
     });
 
     expect(instance.state.x).toBe(1);
+    expect(instance.currentState.x).toBe(1);
     expect(child.state.y).toBe(2);
+    expect(child.currentState.y).toBe(2);
     expect(parentUpdateCount).toBe(1);
 
     // Batching reduces the number of updates here to 1.
@@ -230,6 +253,7 @@ describe('ReactUpdates', function() {
 
     var instance = ReactTestUtils.renderIntoDocument(<Component />);
     expect(instance.state.x).toBe(0);
+    expect(instance.currentState.x).toBe(0);
 
     var innerCallbackRun = false;
     ReactUpdates.batchedUpdates(function() {
@@ -238,17 +262,21 @@ describe('ReactUpdates', function() {
           expect(this).toBe(instance);
           innerCallbackRun = true;
           expect(instance.state.x).toBe(2);
+          expect(instance.currentState.x).toBe(2);
           expect(updateCount).toBe(2);
         });
-        expect(instance.state.x).toBe(1);
+        expect(instance.state.x).toBe(2);
+        expect(instance.currentState.x).toBe(1);
         expect(updateCount).toBe(1);
       });
-      expect(instance.state.x).toBe(0);
+      expect(instance.state.x).toBe(1);
+      expect(instance.currentState.x).toBe(0);
       expect(updateCount).toBe(0);
     });
 
     expect(innerCallbackRun).toBeTruthy();
     expect(instance.state.x).toBe(2);
+    expect(instance.currentState.x).toBe(2);
     expect(updateCount).toBe(2);
   });
 
@@ -272,6 +300,7 @@ describe('ReactUpdates', function() {
 
     var instance = ReactTestUtils.renderIntoDocument(<Component />);
     expect(instance.state.x).toBe(0);
+    expect(instance.currentState.x).toBe(0);
 
     var callbacksRun = 0;
     ReactUpdates.batchedUpdates(function() {
@@ -281,7 +310,9 @@ describe('ReactUpdates', function() {
       instance.forceUpdate(function() {
         callbacksRun++;
       });
-      expect(instance.state.x).toBe(0);
+      expect(instance.state.x).toBe(1);
+      expect(instance.currentState.x).toBe(0);
+      expect(callbacksRun).toBe(0);
       expect(updateCount).toBe(0);
     });
 
@@ -289,6 +320,7 @@ describe('ReactUpdates', function() {
     // shouldComponentUpdate shouldn't be called since we're forcing
     expect(shouldUpdateCount).toBe(0);
     expect(instance.state.x).toBe(1);
+    expect(instance.currentState.x).toBe(1);
     expect(updateCount).toBe(1);
   });
 


### PR DESCRIPTION
...and leave the last rendered state in currentState, as suggested in https://groups.google.com/d/msg/reactjs/R61kPjs-yXE/bk5AGv78RYAJ.

This is a breaking change in that now componentWillUpdate and shouldComponentUpdate need to look at this.currentState when comparing, _not_ this.state. (Perhaps that's an argument towards including prevProps and prevState as arguments to those lifecycle methods...)

I don't feel super strongly about this but it seems that others do.

Fixes #122.
