### PR TITLE
Add more useful ES6 transforms to jsx-internal.

### DIFF
--- a/bin/jsx-internal
+++ b/bin/jsx-internal
@@ -2,7 +2,7 @@
 // -*- mode: js -*-
 "use strict";
 
-var visitors = require('../vendor/fbtransform/visitors').transformVisitors;
+var getVisitorsList = require('../vendor/fbtransform/visitors').getVisitorsList;
 var transform = require('jstransform').transform;
 var propagate = require("../vendor/constants").propagate;
 
@@ -31,7 +31,7 @@ require("commoner").version(
   var constants = context.config.constants || {};
 
   // This is where JSX, ES6, etc. desugaring happens.
-  source = transform(visitors.react, source).code;
+  source = transform(getVisitorsList(), source).code;
 
   // Constant propagation means removing any obviously dead code after
   // replacing constant expressions with literal (boolean) values.

--- a/vendor/fbtransform/visitors.js
+++ b/vendor/fbtransform/visitors.js
@@ -1,5 +1,9 @@
 /*global exports:true*/
-var es6Classes = require('jstransform/visitors/es6-class-visitors').visitorList;
+var es6ArrowFunctions = require('jstransform/visitors/es6-arrow-function-visitors');
+var es6Classes = require('jstransform/visitors/es6-class-visitors');
+var es6ObjectShortNotation = require('jstransform/visitors/es6-object-short-notation-visitors');
+var es6RestParameters = require('jstransform/visitors/es6-rest-param-visitors');
+var es6Templates = require('jstransform/visitors/es6-template-visitors');
 var react = require('./transforms/react');
 var reactDisplayName = require('./transforms/reactDisplayName');
 
@@ -7,7 +11,11 @@ var reactDisplayName = require('./transforms/reactDisplayName');
  * Map from transformName => orderedListOfVisitors.
  */
 var transformVisitors = {
-  'es6-classes': es6Classes,
+  'es6-arrow-functions': es6ArrowFunctions.visitorList,
+  'es6-classes': es6Classes.visitorList,
+  'es6-object-short-notation': es6ObjectShortNotation.visitorList,
+  'es6-rest-params': es6RestParameters.visitorList,
+  'es6-templates': es6Templates.visitorList,
   'react': [
     react.visitReactTag,
     reactDisplayName.visitReactDisplayName
@@ -18,7 +26,11 @@ var transformVisitors = {
  * Specifies the order in which each transform should run.
  */
 var transformRunOrder = [
+  'es6-arrow-functions',
+  'es6-object-short-notation',
   'es6-classes',
+  'es6-rest-params',
+  'es6-templates',
   'react'
 ];
 


### PR DESCRIPTION
Comment is self-descriptive - it is high time we start using the good stuff.

I will follow up with removing 'arguments' from React and replacing it with rest-params.
