### PR TITLE
Use Rest Parameters where it makes sense

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -1,5 +1,6 @@
 {
   "browser": true,
+  "esnext": true,
 
   "bitwise": true,
   "boss": true,

--- a/src/core/ReactComponent.js
+++ b/src/core/ReactComponent.js
@@ -276,7 +276,7 @@ var ReactComponent = {
     },
 
     /**
-     * Base constructor for all React component.
+     * Base constructor for all React components.
      *
      * Subclasses that override this method should make sure to invoke
      * `ReactComponent.Mixin.construct.call(this, ...)`.

--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -1156,7 +1156,7 @@ var ReactCompositeComponentMixin = {
       boundMethod.__reactBoundArguments = null;
       var componentName = component.constructor.displayName;
       var _bind = boundMethod.bind;
-      boundMethod.bind = function(newThis) {
+      boundMethod.bind = function(newThis, ...args) {
         // User is trying to bind() an autobound method; we effectively will
         // ignore the value of "this" that the user is trying to use, so
         // let's warn.
@@ -1165,7 +1165,7 @@ var ReactCompositeComponentMixin = {
             'bind(): React component methods may only be bound to the ' +
             'component instance. See ' + componentName
           );
-        } else if (arguments.length === 1) {
+        } else if (!args.length) {
           console.warn(
             'bind(): You are binding a component method to the component. ' +
             'React does this for you automatically in a high-performance ' +
@@ -1176,8 +1176,7 @@ var ReactCompositeComponentMixin = {
         var reboundMethod = _bind.apply(boundMethod, arguments);
         reboundMethod.__reactBoundContext = component;
         reboundMethod.__reactBoundMethod = method;
-        reboundMethod.__reactBoundArguments =
-          Array.prototype.slice.call(arguments, 1);
+        reboundMethod.__reactBoundArguments = args;
         return reboundMethod;
       };
     }

--- a/src/test/ReactDefaultPerf.js
+++ b/src/test/ReactDefaultPerf.js
@@ -187,9 +187,9 @@ if (__DEV__) {
 
       var fnArgs = _getFnArguments(func);
 
-      return function() {
+      return function(...args) {
         var timeBeforeFn = performanceNow();
-        var fnReturn = func.apply(this, arguments);
+        var fnReturn = func.apply(this, args);
         var timeAfterFn = performanceNow();
 
         /**
@@ -197,9 +197,9 @@ if (__DEV__) {
          * args is also passed to the callback, so if you want to save an
          * argument in the log, do so in the callback.
          */
-        var args = {};
-        for (var i = 0; i < arguments.length; i++) {
-          args[fnArgs[i]] = arguments[i];
+        var argsObject = {};
+        for (var i = 0; i < args.length; i++) {
+          argsObject[fnArgs[i]] = args[i];
         }
 
         var log = {
@@ -224,7 +224,7 @@ if (__DEV__) {
          * - the wrapped method's info object.
          */
         var callback = _getCallback(objName, fnName);
-        callback && callback(this, args, fnReturn, log, info);
+        callback && callback(this, argsObject, fnReturn, log, info);
 
         log.timing.timeToLog = performanceNow() - timeAfterFn;
 

--- a/src/vendor/error/ex.js
+++ b/src/vendor/error/ex.js
@@ -29,13 +29,9 @@
  * @param {string} errorMessage
  */
 
-var ex = function(errorMessage/*, arg1, arg2, ...*/) {
-  var args = Array.prototype.slice.call(arguments).map(function(arg) {
-    return String(arg);
-  });
-  var expectedLength = errorMessage.split('%s').length - 1;
-
-  if (expectedLength !== args.length - 1) {
+var ex = function(...args) {
+  args = args.map((arg) => String(arg));
+  if (args[0].split('%s').length !== args.length) {
     // something wrong with the formatting string
     return ex('ex args number mismatch: %s', JSON.stringify(args));
   }


### PR DESCRIPTION
Depends on #636

This changes a bunch functions to use rest parameters instead of 'arguments'.

It makes the code simpler to read and ensures we always work with arrays instead of an imposter.
