### PR TITLE
Bump version of wd

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "jasmine-tapreporter": "~0.2.2",
     "grunt-contrib-connect": "~0.5.0",
     "es5-shim": "~2.1.0",
-    "wd": "~0.2.2",
+    "wd": "~0.2.6",
     "sauce-tunnel": "~1.1.0",
     "coverify": "~0.1.1",
     "grunt-complexity": "~0.1.3"


### PR DESCRIPTION
wd 0.2.2 gives `TypeError: Cannot call method 'jsCondition' of undefined` since #551; 0.2.6 is the latest and works so switch to that.
