### PR TITLE
ReactTransitionGroup can handle components being re-added before 'leave' transition has completed.

### DIFF
--- a/src/addons/transitions/ReactTransitionableChild.js
+++ b/src/addons/transitions/ReactTransitionableChild.js
@@ -130,15 +130,16 @@ var ReactTransitionableChild = React.createClass({
     if (!nextProps.children && this.props.children) {
       this.savedChildren = this.props.children;
     } else if (nextProps.children && !this.props.children) {
-      // We're being told to keep this node!  Better set it to enter again.
-      if (this.props.enter && this.isMounted())
-      {
+      // We're being told to re-add the child.  Let's stop leaving!
+      if (this.isMounted()) {
         var node = this.getDOMNode();
         var className = this.props.name;
         CSSCore.removeClass(node, className + '-leave');
         CSSCore.removeClass(node, className + '-leave-active');
-        CSSCore.addClass(node, className + '-enter');
-        CSSCore.addClass(node, className + '-enter-active');
+        if (this.props.enter) {
+          CSSCore.addClass(node, className + '-enter');
+          CSSCore.addClass(node, className + '-enter-active');
+        }
       }
     }
   },


### PR DESCRIPTION
It's quite possible to end up with DOM elements within ReactTransitionGroups staying behind despite the leave transition having ended.  This occurs when calling render which then attempts to add the same element to the Group at the same time as it is being removed/transitioning-out. 

These elements remain behind, with their class forever set to  '<i>name</i>-leave <i>name</i>-leave-active'.  In this instance I simply remove the 'leave' classes and re-add the 'enter' ones if necessary, to make the elements nicely reverse their animation/come back into view.

Fixes #649.

PS: I've signed the CLA with this github username.
