### PR TITLE
rename this tip to be less confusing

### DIFF
--- a/docs/tips/10-props-in-getInitialState-as-anti-pattern.md
+++ b/docs/tips/10-props-in-getInitialState-as-anti-pattern.md
@@ -68,14 +68,12 @@ However, it's **not** an anti-pattern if you intentionally make it clear that sy
 
 var Counter = React.createClass({
   getInitialState: function() {
-    // naming it initialX clearly indicates that the only purpose 
+    // naming it initialX clearly indicates that the only purpose
     // of the passed down prop is to initialize something internal
     return {count: this.props.initialCount};
   },
   handleClick: function() {
-    this.setState({
-      count: this.state.count + 1
-    });
+    this.setState({count: this.state.count + 1});
   },
   render: function() {
     return <div onClick={this.handleClick}>{this.state.count}</div>;


### PR DESCRIPTION
Using props to initialize state is completely fine (to my understanding); the issue is using state as a "cache" for values calculated based off of props. This title makes it more clear.
