### PR TITLE
Upgrade populist dependency to v0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "browserify": "~2.36.1",
     "envify": "~0.2.0",
-    "populist": "~0.1.5",
+    "populist": "~0.1.6",
     "grunt-cli": "~0.1.9",
     "grunt": "~0.4.1",
     "grunt-contrib-copy": "~0.4.1",


### PR DESCRIPTION
This reduces the time taken by `grunt populist:test` from 7s to 550ms, which should make @spicyj especially happy.

Relevant commits from the `populist` and `ast-types` repositories:
https://github.com/benjamn/populist/commit/9863ad16c0753f714fdb83007515637511c346d6
https://github.com/benjamn/ast-types/commit/dabef2a4ac48ebdb5c76baf1fb94f4997b6484ac
