### PR TITLE
Documentation (minor): template missing jquery reference

### DIFF
--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -32,6 +32,7 @@ For this tutorial we'll use prebuilt JavaScript files on a CDN. Open up your fav
     <title>Hello React</title>
     <script src="http://fb.me/react-{{site.react_version}}.js"></script>
     <script src="http://fb.me/JSXTransformer-{{site.react_version}}.js"></script>
+    <script src="http://code.jquery.com/jquery-1.10.0.min.js"></script>
   </head>
   <body>
     <div id="content"></div>


### PR DESCRIPTION
Tutorial template markup needs a reference to jquery for the ajax calls from step 13 onwards.
