### PR TITLE
Trim whitespace from end of tags to fix linter warnings.

### DIFF
--- a/vendor/fbtransform/transforms/react.js
+++ b/vendor/fbtransform/transforms/react.js
@@ -132,7 +132,7 @@ function visitReactTag(traverse, object, path, state) {
 
   // filter out whitespace
   if (childrenToRender.length > 0) {
-    utils.append(', ', state);
+    utils.append(',', state);
 
     object.children.forEach(function(child) {
       if (child.type === Syntax.Literal && !child.value.match(/\S/)) {


### PR DESCRIPTION
I'm building [SublimeLinter-jsxhint](https://github.com/STRML/SublimeLinter-jsxhint) for proper JSX linting in Sublime Text 3. Unfortunately we get trailing whitespace issues at the end of tags with the current version of react.

Deleting the trailing whitespace at L135 fixes the linter warnings and does not affect the output.
