### PR TITLE
Use feature detection and more robust recovering of whitespace for innerHTML in IE8

### DIFF
--- a/src/core/ReactDOMIDOperations.js
+++ b/src/core/ReactDOMIDOperations.js
@@ -49,7 +49,7 @@ var INVALID_PROPERTY_ERRORS = {
  */
 var textContentAccessor = getTextContentAccessor() || 'NA';
 
-var LEADING_SPACE = /^ /;
+var useWhitespaceWorkaround;
 
 /**
  * Operations used to process updates to DOM nodes. This is made injectable via
@@ -124,9 +124,35 @@ var ReactDOMIDOperations = {
    */
   updateInnerHTMLByID: function(id, html) {
     var node = ReactMount.getNode(id);
-    // HACK: IE8- normalize whitespace in innerHTML, removing leading spaces.
+    
+    // IE8: When updating a just created node with innerHTML only leading
+    // whitespace is removed. When updating an existing node with innerHTML
+    // whitespace in root TextNodes is also collapsed.
     // @see quirksmode.org/bugreports/archives/2004/11/innerhtml_and_t.html
-    node.innerHTML = html.replace(LEADING_SPACE, '&nbsp;');
+    
+    if (useWhitespaceWorkaround === undefined) {
+      // Feature detection; only IE8 is known to behave improperly like this.
+      var temp = document.createElement('div');
+      temp.innerHTML = ' ';
+      useWhitespaceWorkaround = temp.innerHTML === '';
+    }
+    
+    if (useWhitespaceWorkaround) {
+      // Magic theory: IE8 supposedly differentiates between added and updated
+      // nodes when processing innerHTML, innerHTML on updated nodes suffers
+      // from worse whitespace behavior. Re-adding a node like this triggers
+      // the initial and more favorable whitespace behavior.
+      node.parentNode.replaceChild(node, node);
+    }
+    
+    if (useWhitespaceWorkaround && html.match(/^[ \r\n\t\f]/)) {
+      // Recover leading whitespace by temporarily prepending any character.
+      // \uFEFF has the potential advantage of being zero-width/invisible.
+      node.innerHTML = '\uFEFF' + html;
+      node.firstChild.deleteData(0, 1);
+    } else {
+      node.innerHTML = html;
+    }
   },
 
   /**

--- a/src/core/__tests__/ReactDOMIDOperations-test.js
+++ b/src/core/__tests__/ReactDOMIDOperations-test.js
@@ -47,19 +47,21 @@ describe('ReactDOMIDOperations', function() {
     ).toBe(0);
   });
 
-  it('should update innerHTML and special-case whitespace', function() {
+  it('should update innerHTML and preserve whitespace', function() {
     var stubNode = document.createElement('div');
     spyOn(ReactMount, "getNode").andReturn(stubNode);
 
+    var html = '\n  \t  <span>  \n  testContent  \t  </span>  \n  \t';
+    
     ReactDOMIDOperations.updateInnerHTMLByID(
       'testID',
-      ' testContent'
+      html
     );
 
     expect(
       ReactMount.getNode.argsForCall[0][0]
     ).toBe('testID');
 
-    expect(stubNode.innerHTML).toBe('&nbsp;testContent');
+    expect(stubNode.innerHTML).toBe(html);
   });
 });


### PR DESCRIPTION
`dangerouslySetInnerHTML` in IE8 collapses whitespace in **root TextNodes** and removes leading whitespace. Your current fix for this is to replace any first space with `&nbsp;` which is a surprisingly good and simple fix, but it does this for all browsers and doesn't solve the collapsing whitespace (or any whitespace besides space).

I propose the following fix instead, which makes it work identically to all other browsers at minimal cost, and does so via feature detection so only IE8 is affected.

PS. Make sure to spot the seriously magic trick I discovered to making IE8 behave better!

```
   raw     gz Compared to master @ 09bdcefd4f246eb49b82aa5bfece8d40cb8a2fca
     =      = build/JSXTransformer.js
 +3155   +642 build/react-test.js
  +658   +217 build/react-with-addons.js
  +169    +74 build/react-with-addons.min.js
  +658   +214 build/react.js
  +169    +91 build/react.min.js
```

_Disclaimer: if the root node is a TABLE/TBODY/OL/SELECT or anything else that (kind of) doesn't support TextNodes AND there is whitespace in the beginning of the HTML, this will create a faulty TextNode with whitespace (when it actually should be removed)... however, the code/size penalty for solving this is unreasonably large when the use-cases are virtually none, as far as I'm aware_
