### PR TITLE
Fix home page code samples

### DIFF
--- a/docs/_js/live_editor.js
+++ b/docs/_js/live_editor.js
@@ -61,6 +61,14 @@ var ReactPlayground = React.createClass({
     renderCode: React.PropTypes.bool,
   },
 
+  getDefaultProps: function() {
+    return {
+      transformer: function(code) {
+        return JSXTransformer.transform(code).code;
+      }
+    };
+  },
+
   getInitialState: function() {
     return {mode: this.MODES.XJS, code: this.props.codeText};
   },


### PR DESCRIPTION
This change defaults the ReactPlayground to JSX compilation by default, which fixes the errors with the samples on the home page.
