### PR TITLE
Fix html-jsx compiler

### DIFF
--- a/docs/_js/live_editor.js
+++ b/docs/_js/live_editor.js
@@ -57,8 +57,16 @@ var ReactPlayground = React.createClass({
 
   propTypes: {
     codeText: React.PropTypes.string.isRequired,
-    transformer: React.PropTypes.func.isRequired,
+    transformer: React.PropTypes.func,
     renderCode: React.PropTypes.bool,
+  },
+
+  getDefaultProps: function() {
+    return {
+      transformer: function(code) {
+        return JSXTransformer.transform(code).code;
+      }
+    };
   },
 
   getInitialState: function() {


### PR DESCRIPTION
It changed React Playground to add a required props but unfortunately didn't update the call sites of the front-page. I don't think it should be required so I'm just making it optional and providing the correct default value.

Test Plan:
- Open the front page and make sure examples are working
- Open /react/jsx-compiler.html and make sure it is working
- Open /react/html-jsx.html and make sure it is working
