### PR TITLE
Fix componentDidMount does not receive DOMElement rootNode

### DIFF
--- a/docs/working-with-the-browser.html
+++ b/docs/working-with-the-browser.html
@@ -294,7 +294,7 @@
 <ul>
 <li><code>getInitialState(): object</code> is invoked before a component is mounted. Stateful components should implement this and return the initial state data.</li>
 <li><code>componentWillMount()</code> is invoked immediately before mounting occurs.</li>
-<li><code>componentDidMount(DOMElement rootNode)</code> is invoked immediately after mounting occurs. Initialization that requires DOM nodes should go here.</li>
+<li><code>componentDidMount()</code> is invoked immediately after mounting occurs. Initialization that requires DOM nodes should go here.</li>
 </ul>
 <h3 id="updating" class="anchor"><a href="#updating">Updating</a></h3>
 <ul>


### PR DESCRIPTION
However `componentDidUpdate` still receive the DOM node as an argument, I'm assuming because it's already available in the code, but it seems inconsistent, especially for @petehunt's comment in this https://github.com/facebook/react/issues/416
