### PR TITLE
Fix shouldUpdateReactComponent not considering props.key

### DIFF
--- a/src/core/shouldUpdateReactComponent.js
+++ b/src/core/shouldUpdateReactComponent.js
@@ -31,7 +31,8 @@
 function shouldUpdateReactComponent(prevComponent, nextComponent) {
   // TODO: Remove warning after a release.
   if (prevComponent && nextComponent &&
-      prevComponent.constructor === nextComponent.constructor) {
+      prevComponent.constructor === nextComponent.constructor &&
+      prevComponent.props.key === nextComponent.props.key) {
     if (prevComponent._owner === nextComponent._owner) {
       return true;
     } else {


### PR DESCRIPTION
**Apparently @spicyj already has a pending PR for this that should be considered instead, https://github.com/facebook/react/pull/591.**

---

`key` is currently only obeyed by descendants of the root-node, the root-node itself does not obey `key`. This simple fix ensures that it works on the root-node as well.

I would consider this a bug and speaking hastily to petehunt, he seemed to agree:

`<@petehunt> yeah i think that would be a bug`

My personal motivation for this is my `<swf>`-component that I will be releasing, it requires this to support changing `src` at run-time (although other workarounds do exist). In my opinion, there's no reason why the root-node should be any different from the other children in this regard.
