### PR TITLE
transferPropsTo should never transfer the "key" property

### DIFF
--- a/src/core/ReactPropTransferer.js
+++ b/src/core/ReactPropTransferer.js
@@ -53,6 +53,10 @@ var TransferStrategies = {
    */
   className: createTransferStrategy(joinClasses),
   /**
+   * Never transfer the `key` prop.
+   */
+  key: emptyFunction,
+  /**
    * Never transfer the `ref` prop.
    */
   ref: emptyFunction,


### PR DESCRIPTION
Right?

Not that it should ever matter, considering they are both mounted and unmounted together, but practically it serves no purpose.
