### PR TITLE
Fix npm react having wrong version dependency for envify

### DIFF
--- a/npm-react/package.json
+++ b/npm-react/package.json
@@ -28,7 +28,7 @@
     "node": ">=0.10.0"
   },
   "peerDependencies": {
-    "envify": "~0.2.0"
+    "envify": "~1.0.1"
   },
   "browserify": {
     "transform": ["envify"]


### PR DESCRIPTION
React depends on `1.0.1` but npm-react depends on `0.2.0`.
