### PR TITLE
Allow style object to accept array of values

### DIFF
--- a/src/dom/CSSPropertyOperations.js
+++ b/src/dom/CSSPropertyOperations.js
@@ -53,7 +53,12 @@ var CSSPropertyOperations = {
         continue;
       }
       var styleValue = styles[styleName];
-      if (styleValue != null) {
+      if (Array.isArray(styleValue)) {
+        styleValue.forEach(function(styleValue) {
+          serialized += processStyleName(styleName) + ':';
+          serialized += dangerousStyleValue(styleName, styleValue) + ';';
+        });
+      } else if (styleValue != null && styleValue.length !== 0) {
         serialized += processStyleName(styleName) + ':';
         serialized += dangerousStyleValue(styleName, styleValue) + ';';
       }
@@ -74,9 +79,13 @@ var CSSPropertyOperations = {
       if (!styles.hasOwnProperty(styleName)) {
         continue;
       }
-      var styleValue = dangerousStyleValue(styleName, styles[styleName]);
-      if (styleValue) {
-        style[styleName] = styleValue;
+      var styleValue = styles[styleName];
+      if (Array.isArray(styleValue) && styleValue.length) {
+        styleValue.forEach(function(styleValue) {
+          style[styleName] = dangerousStyleValue(styleName, styleValue);
+        });
+      } else if (styleValue != null && styleValue.length !== 0) {
+        style[styleName] = dangerousStyleValue(styleName, styleValue);
       } else {
         var expansion = CSSProperty.shorthandPropertyExpansions[styleName];
         if (expansion) {

--- a/src/dom/__tests__/CSSPropertyOperations-test.js
+++ b/src/dom/__tests__/CSSPropertyOperations-test.js
@@ -52,6 +52,19 @@ describe('CSSPropertyOperations', function() {
     })).toBe('display:none;');
   });
 
+  it('should ignore empty strings', function() {
+    expect(CSSPropertyOperations.createMarkupForStyles({
+      backgroundColor: '',
+      display: 'none'
+    })).toBe('display:none;');
+  });
+
+  it('should add multiple styles', function() {
+    expect(CSSPropertyOperations.createMarkupForStyles({
+      cursor: ['-webkit-grab', '-moz-grab', 'grab']
+    })).toBe('cursor:-webkit-grab;cursor:-moz-grab;cursor:grab;');
+  });
+
   it('should return null for no styles', function() {
     expect(CSSPropertyOperations.createMarkupForStyles({
       backgroundColor: null,
@@ -103,6 +116,25 @@ describe('CSSPropertyOperations', function() {
     var root = document.createElement('div');
     React.renderComponent(div, root);
     expect(/style=".*"/.test(root.innerHTML)).toBe(false);
+  });
+
+  it('should set style for node', function() {
+    var div = document.createElement('div');
+    CSSPropertyOperations.setValueForStyles(div, {
+      backgroundColor: null,
+      display: 'none'
+    });
+    expect(div.style.getPropertyValue('background-color')).toBe(null);
+    expect(div.style.getPropertyValue('display')).toBe('none');
+  });
+
+  it('should set multiple style rules for node', function() {
+    var div = document.createElement('div');
+    // Last valid style wins
+    CSSPropertyOperations.setValueForStyles(div, {
+      cursor: ['crosshair', 'auto']
+    });
+    expect(div.style.getPropertyValue('cursor')).toBe('auto');
   });
 
 });


### PR DESCRIPTION
This allows components to set multiple values for a single css rule. The main use case is to set vendor prefix styles and allow for broader css compatibility. Example:

``` javascript
var style = {
  cursor: ['-webkit-grab', '-moz-grab', 'grab'],
  backgroundColor: ['rgb(200, 54, 54)', 'rgba(200, 54, 54, 0.5)']
};

React.renderComponent(<div style={style}>Grabbable!</div>, mountNode);
```

When the component initially renders, all styles will be set through the inline markup string. When the component updates its style, the last valid style in the array will be set. 
This change does not handle the edge case where you pass in a singleton array of an empty string, in the sense that it improperly unsets shorthand rules in IE8. I think the css stuff is due for a refactoring anyways though.

Something to think about: Should react manage css vendor prefixes automatically?

Other things I did:
- Added actual unit tests for `CSSPropertyOperations.setValueForStyles`
- Fix a bug where setting a style with an empty string will render markup for that rule.

Edit: Added backgroundColor to example.
