### PR TITLE
Use explicit $.ajax dataType and add error callback

### DIFF
--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -388,7 +388,7 @@ var CommentBox = React.createClass({
         this.setState({data: data});
       }.bind(this),
       error: function(xhr, status, err) {
-        console.log("comments.json", status, err.toString());
+        console.error("comments.json", status, err.toString());
       }.bind(this)
     });
     return {data: []};


### PR DESCRIPTION
Working through the tutorial, I ran into a perplexing problem caused by my `.json` file being served as `text/html` instead of `application/json`:

https://ludios.org/tmp/react-json-wrong-mime-type_.png

An explicit `dataType` argument makes the server's incorrect `Content-Type` irrelevant.

After I specified the json dataType, my application silently failed to load comments because my `.json` file had a trailing semicolon.  This PR adds an error callback that logs errors to the console.  `.toString()` is necessary to print the exception message in Chrome 31 and Firefox 26.
