### PR TITLE
Tell user to keep the @jsx declaration at the top of the script

### DIFF
--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -43,6 +43,7 @@ For this tutorial we'll use prebuilt JavaScript files on a CDN. Open up your fav
       /**
        * @jsx React.DOM
        */
+      // The above declaration must remain intact at the top of the script.
       // Your code here
     </script>
   </body>


### PR DESCRIPTION
Working through the tutorial, I added some code above the

```
      /**
       * @jsx React.DOM
       */
```

declaration, and this resulted in a very unhelpful error message from JSXTransformer:

```
Uncaught SyntaxError: Unexpected token <
851547_221914424655081_22271_n.js:10217
```

Hopefully the comment will convince a few people to keep the declaration at the very beginning.
