### PR TITLE
Minify both before and after browserify

### DIFF
--- a/grunt/config/browserify.js
+++ b/grunt/config/browserify.js
@@ -5,8 +5,8 @@
 
 var envify = require('envify/custom');
 var grunt = require('grunt');
-var through = require('through');
 var UglifyJS = require('uglify-js');
+var uglifyify = require('uglifyify');
 
 var SIMPLE_TEMPLATE =
 '/**\n\
@@ -33,20 +33,7 @@ var LICENSE_TEMPLATE =
  */';
 
 function minify(src) {
-  return UglifyJS.minify(src, {
-    fromString: true,
-    mangle: {toplevel: true}
-  }).code;
-}
-
-function minifyTransform(file) {
-  var src = '';
-  return through(function write(buf) {
-    src += buf;
-  }, function end() {
-    this.queue(minify(src));
-    this.queue(null);
-  });
+  return UglifyJS.minify(src, { fromString: true }).code;
 }
 
 // TODO: move this out to another build step maybe.
@@ -81,7 +68,7 @@ var basic = {
 var min = grunt.util._.merge({}, basic, {
   outfile: './build/react.min.js',
   debug: false,
-  transforms: [envify({NODE_ENV: 'production'}), minifyTransform],
+  transforms: [envify({NODE_ENV: 'production'}), uglifyify],
   after: [minify, bannerify]
 });
 
@@ -110,7 +97,7 @@ var addons = {
 var addonsMin = grunt.util._.merge({}, addons, {
   outfile: './build/react-with-addons.min.js',
   debug: false,
-  transforms: [envify({NODE_ENV: 'production'}), minifyTransform],
+  transforms: [envify({NODE_ENV: 'production'}), uglifyify],
   after: [minify, bannerify]
 });
 

--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
     "recast": "~0.5.6",
     "sauce-tunnel": "~1.1.0",
     "semver": "~2.2.1",
-    "through": "~2.3.4",
     "tmp": "~0.0.18",
     "uglify-js": "~2.4.0",
+    "uglifyify": "~1.0.1",
     "wd": "~0.2.6"
   },
   "engines": {


### PR DESCRIPTION
Excludes `ReactDefaultPerf` and `performanceNow` from the minified build, so we save bytes. Looks like there are a few other minor differences because uglifyjs isn't quite idempotent but they appear to be harmless.

Feels silly but I don't think there's another way. (We need to run uglify after as well so that require, module, exports are minified)

```
   raw     gz Compared to master @ f877c6224fbf217d639a0ef2d7abf28c4cfbafa4
     =      = build/JSXTransformer.js
     =      = build/react-test.js
     =      = build/react-with-addons.js
  -406   -129 build/react-with-addons.min.js
     =      = build/react.js
  -406   -108 build/react.min.js
```
