### PR TITLE
Don't return null children from flattenChildren

### DIFF
--- a/src/core/ReactMultiChild.js
+++ b/src/core/ReactMultiChild.js
@@ -191,7 +191,7 @@ var ReactMultiChild = {
       this._renderedChildren = children;
       for (var name in children) {
         var child = children[name];
-        if (children.hasOwnProperty(name) && child) {
+        if (children.hasOwnProperty(name)) {
           // Inlined for performance, see `ReactInstanceHandles.createReactID`.
           var rootID = this._rootNodeID + '.' + name;
           var mountImage = child.mountComponent(
@@ -220,8 +220,7 @@ var ReactMultiChild = {
         var prevChildren = this._renderedChildren;
         // Remove any rendered children.
         for (var name in prevChildren) {
-          if (prevChildren.hasOwnProperty(name) &&
-              prevChildren[name]) {
+          if (prevChildren.hasOwnProperty(name)) {
             this._unmountChildByName(prevChildren[name], name);
           }
         }
@@ -293,20 +292,15 @@ var ReactMultiChild = {
             lastIndex = Math.max(prevChild._mountIndex, lastIndex);
             this._unmountChildByName(prevChild, name);
           }
-          if (nextChild) {
-            this._mountChildByNameAtIndex(
-              nextChild, name, nextIndex, transaction
-            );
-          }
+          this._mountChildByNameAtIndex(
+            nextChild, name, nextIndex, transaction
+          );
         }
-        if (nextChild) {
-          nextIndex++;
-        }
+        nextIndex++;
       }
       // Remove children that are no longer present.
       for (name in prevChildren) {
         if (prevChildren.hasOwnProperty(name) &&
-            prevChildren[name] &&
             !(nextChildren && nextChildren[name])) {
           this._unmountChildByName(prevChildren[name], name);
         }
@@ -323,7 +317,8 @@ var ReactMultiChild = {
       var renderedChildren = this._renderedChildren;
       for (var name in renderedChildren) {
         var renderedChild = renderedChildren[name];
-        if (renderedChild && renderedChild.unmountComponent) {
+        // TODO: When is this not true?
+        if (renderedChild.unmountComponent) {
           renderedChild.unmountComponent();
         }
       }
@@ -413,6 +408,7 @@ var ReactMultiChild = {
      * @private
      */
     _unmountChildByName: function(child, name) {
+      // TODO: When is this not true?
       if (ReactComponent.isValidComponent(child)) {
         this.removeChild(child);
         child._mountImage = null;

--- a/src/utils/flattenChildren.js
+++ b/src/utils/flattenChildren.js
@@ -35,11 +35,14 @@ function flattenSingleChildIntoContext(traverseContext, child, name) {
     'Children keys must be unique.',
     name
   );
-  result[name] = child;
+  if (child != null) {
+    result[name] = child;
+  }
 }
 
 /**
- * Flattens children that are typically specified as `props.children`.
+ * Flattens children that are typically specified as `props.children`. Any null
+ * children will not be included in the resulting object.
  * @return {!object} flattened children keyed by name.
  */
 function flattenChildren(children) {

--- a/src/utils/sliceChildren.js
+++ b/src/utils/sliceChildren.js
@@ -42,15 +42,12 @@ function sliceChildren(children, start, end) {
       continue;
     }
     var child = flattenedMap[key];
-    // In this version of slice children we ignore empty children.
-    if (child !== null) {
-      if (ii >= start) {
-        slicedChildren[key] = child;
-      }
-      ii++;
-      if (end != null && ii >= end) {
-        break;
-      }
+    if (ii >= start) {
+      slicedChildren[key] = child;
+    }
+    ii++;
+    if (end != null && ii >= end) {
+      break;
     }
   }
   return slicedChildren;


### PR DESCRIPTION
This simplifies ReactMultiChild a little bit and will make it more practical to coalesce adjacent text strings (#742).
