### PR TITLE
removed trailing whitespace for linting

### DIFF
--- a/vendor/fbtransform/transforms/react.js
+++ b/vendor/fbtransform/transforms/react.js
@@ -132,7 +132,7 @@ function visitReactTag(traverse, object, path, state) {
 
   // filter out whitespace
   if (childrenToRender.length > 0) {
-    utils.append(', ', state);
+    utils.append(',', state);
 
     object.children.forEach(function(child) {
       if (child.type === Syntax.Literal && !child.value.match(/\S/)) {


### PR DESCRIPTION
Very minor change to allow compiled JSX to pass the jshint 'trailing' rule when set to true/default.
