### PR TITLE
Expose some more addons

### DIFF
--- a/src/ReactWithAddons.js
+++ b/src/ReactWithAddons.js
@@ -25,16 +25,33 @@
 
 "use strict";
 
+var EventPluginHub = require('EventPluginHub');
+var ImmutableObject = require('ImmutableObject');
 var LinkedStateMixin = require('LinkedStateMixin');
 var React = require('React');
+var ReactStateSetters = require('ReactStateSetters');
+var ReactTestUtils = require('ReactTestUtils');
 var ReactTransitionGroup = require('ReactTransitionGroup');
+var ResponderEventPlugin = require('ResponderEventPlugin');
+var TapEventPlugin = require('TapEventPlugin');
 
 var cx = require('cx');
 
 React.addons = {
   classSet: cx,
+
+  ImmutableObject: ImmutableObject,
   LinkedStateMixin: LinkedStateMixin,
-  TransitionGroup: ReactTransitionGroup
+  ResponderEventPlugin: ResponderEventPlugin,
+  StateSetters: ReactStateSetters,
+  TestUtils: ReactTestUtils,
+  TapEventPlugin: TapEventPlugin,
+  TransitionGroup: ReactTransitionGroup,
+
+  injection: {
+    injectEventPluginsByName:
+      EventPluginHub.injection.injectEventPluginsByName
+  }
 };
 
 module.exports = React;


### PR DESCRIPTION
This adds some more addons.

If this is accepted we will update the documentation to have instructions for using addons from `npm` as well as from the premade builds. If using `npm` you should `require('react/lib/ReactTransitionGroup')` rather than using `react/addons` so you don't pull in extra dependencies.

I think we definitely need the event plugins and TestUtils. I wasn't sure about `ImmutableObject` and `StateSetters`, but they seem like good ideas.

I considered adding `ReactUpdates.injection` in there for pluggable batching strategies and `ReactPerf`, but this already works in npm today (`react-raf-batching` and `react-profiler`) and I wanted to keep this as constrained as possible.

If someone signs off on this I'll stack a commit on top with docs (or do it in a new PR, either way).
