### PR TITLE
Remove sometimes-confusing console error

### DIFF
--- a/src/core/ReactMount.js
+++ b/src/core/ReactMount.js
@@ -576,17 +576,11 @@ var ReactMount = {
 
     firstChildren.length = 0;
 
-    if (__DEV__) {
-      console.error(
-        'Error while invoking `findComponentRoot` with the following ' +
-        'ancestor node:',
-        ancestorNode
-      );
-    }
     invariant(
       false,
       'findComponentRoot(..., %s): Unable to find element. This probably ' +
-      'means the DOM was unexpectedly mutated (e.g. by the browser).',
+      'means the DOM was unexpectedly mutated (e.g., by the browser). ' +
+      'Try inspecting the child nodes of the element with React ID `%s`.',
       id,
       ReactMount.getID(ancestorNode)
     );

--- a/src/core/__tests__/ReactInstanceHandles-test.js
+++ b/src/core/__tests__/ReactInstanceHandles-test.js
@@ -138,9 +138,6 @@ describe('ReactInstanceHandles', function() {
         ReactMount.getID(childNodeB)
       )).toBe(childNodeB);
 
-      spyOn(console, 'error');
-      expect(console.error.argsForCall.length).toBe(0);
-
       expect(function() {
         ReactMount.findComponentRoot(
           parentNode,
@@ -149,10 +146,9 @@ describe('ReactInstanceHandles', function() {
       }).toThrow(
         'Invariant Violation: findComponentRoot(..., .react[0].1:0:junk): ' +
         'Unable to find element. This probably means the DOM was ' +
-        'unexpectedly mutated (e.g. by the browser).'
+        'unexpectedly mutated (e.g., by the browser). Try inspecting the ' +
+        'child nodes of the element with React ID `.react[0]`.'
       );
-
-      expect(console.error.argsForCall.length).toBe(1);
     });
   });
 


### PR DESCRIPTION
Fixes #767. This essentially reverts 738de8c.

We could store some sort of flag to silence the console error here but since we've made significant improvements in markup wrapping, this error is fairly rare now. We'll also have validation of node structure soon in #735.
