### PR TITLE
Better error message when using the minified build

### DIFF
--- a/src/vendor/core/invariant.js
+++ b/src/vendor/core/invariant.js
@@ -28,7 +28,7 @@
 
 function invariant(condition) {
   if (!condition) {
-    throw new Error('Invariant Violation');
+    throw new Error('Generic React Exception. Use the non-minified build for the full message.');
   }
 }
 


### PR DESCRIPTION
Many people are complaining that the 'Invariant Violation' error message is very misleading and think that error messages on React really suck (which is not true).

@zpao: invariant on fb codebase is not character per character equal to this file. I'm not really sure where to modify it.
