### PR TITLE
Even better normalization of KeyboardEvent + MouseEvent

### DIFF
--- a/docs/docs/ref-05-events.md
+++ b/docs/docs/ref-05-events.md
@@ -62,8 +62,9 @@ Properties:
 
 ```javascript
 boolean altKey
-boolean ctrlKey
 Number charCode
+boolean ctrlKey
+function getModifierState(key)
 String key
 Number keyCode
 String locale
@@ -120,6 +121,7 @@ Number buttons
 Number clientX
 Number clientY
 boolean ctrlKey
+function getModifierState(key)
 boolean metaKey
 Number pageX
 Number pageY
@@ -147,6 +149,7 @@ Properties:
 boolean altKey
 DOMTouchList changedTouches
 boolean ctrlKey
+function getModifierState(key)
 boolean metaKey
 boolean shiftKey
 DOMTouchList targetTouches
@@ -181,8 +184,8 @@ onWheel
 Properties:
 
 ```javascript
-Number deltaX
 Number deltaMode
+Number deltaX
 Number deltaY
 Number deltaZ
 ```

--- a/src/browser/eventPlugins/SimpleEventPlugin.js
+++ b/src/browser/eventPlugins/SimpleEventPlugin.js
@@ -341,8 +341,14 @@ var SimpleEventPlugin = {
         // @see http://www.w3.org/TR/html5/index.html#events-0
         EventConstructor = SyntheticEvent;
         break;
-      case topLevelTypes.topKeyDown:
       case topLevelTypes.topKeyPress:
+        // FireFox creates a keypress event for function keys too. This removes
+        // the unwanted keypress events.
+        if (nativeEvent.charCode === 0) {
+          return null;
+        }
+        /* falls through */
+      case topLevelTypes.topKeyDown:
       case topLevelTypes.topKeyUp:
         EventConstructor = SyntheticKeyboardEvent;
         break;

--- a/src/browser/syntheticEvents/SyntheticKeyboardEvent.js
+++ b/src/browser/syntheticEvents/SyntheticKeyboardEvent.js
@@ -22,6 +22,7 @@
 var SyntheticUIEvent = require('SyntheticUIEvent');
 
 var getEventKey = require('getEventKey');
+var getEventModifierState = require('getEventModifierState');
 
 /**
  * @interface KeyboardEvent
@@ -36,11 +37,39 @@ var KeyboardEventInterface = {
   metaKey: null,
   repeat: null,
   locale: null,
+  getModifierState: getEventModifierState,
   // Legacy Interface
-  'char': null,
-  charCode: null,
-  keyCode: null,
-  which: null
+  charCode: function(event) {
+    // `charCode` is the result of a KeyPress event and represents the value of
+    // the actual printable character.
+
+    // KeyPress is deprecated but its replacement is not yet final and not
+    // implemented in any major browser.
+    if (event.type === 'keypress') {
+      // IE8 does not implement "charCode", but "keyCode" has the correct value.
+      return 'charCode' in event ? event.charCode : event.keyCode;
+    }
+    return 0;
+  },
+  keyCode: function(event) {
+    // `keyCode` is the result of a KeyDown/Up event and represents the value of
+    // physical keyboard key.
+
+    // The actual meaning of the value depends on the users' keyboard layout
+    // which cannot be detected. Assuming that it is a US keyboard layout
+    // provides a surprisingly accurate mapping for US and European users.
+    // Due to this, it is left to the user to implement at this time.
+    if (event.type === 'keydown' || event.type === 'keyup') {
+      return event.keyCode;
+    }
+    return 0;
+  },
+  which: function(event) {
+    // `which` is an alias for either `keyCode` or `charCode` depending on the
+    // type of the event. There is no need to determine the type of the event
+    // as `keyCode` and `charCode` are either aliased or default to zero.
+    return event.keyCode || event.charCode;
+  }
 };
 
 /**

--- a/src/browser/syntheticEvents/SyntheticMouseEvent.js
+++ b/src/browser/syntheticEvents/SyntheticMouseEvent.js
@@ -22,6 +22,8 @@
 var SyntheticUIEvent = require('SyntheticUIEvent');
 var ViewportMetrics = require('ViewportMetrics');
 
+var getEventModifierState = require('getEventModifierState');
+
 /**
  * @interface MouseEvent
  * @see http://www.w3.org/TR/DOM-Level-3-Events/
@@ -35,6 +37,7 @@ var MouseEventInterface = {
   shiftKey: null,
   altKey: null,
   metaKey: null,
+  getEventModifierState: getEventModifierState,
   button: function(event) {
     // Webkit, Firefox, IE9+
     // which:  1 2 3

--- a/src/browser/syntheticEvents/SyntheticTouchEvent.js
+++ b/src/browser/syntheticEvents/SyntheticTouchEvent.js
@@ -21,6 +21,8 @@
 
 var SyntheticUIEvent = require('SyntheticUIEvent');
 
+var getEventModifierState = require('getEventModifierState');
+
 /**
  * @interface TouchEvent
  * @see http://www.w3.org/TR/touch-events/
@@ -32,7 +34,8 @@ var TouchEventInterface = {
   altKey: null,
   metaKey: null,
   ctrlKey: null,
-  shiftKey: null
+  shiftKey: null,
+  getModifierState: getEventModifierState
 };
 
 /**

--- a/src/browser/ui/dom/getEventModifierState.js
+++ b/src/browser/ui/dom/getEventModifierState.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @providesModule getEventModifierState
+ * @typechecks static-only
+ */
+
+"use strict";
+
+/**
+ * Translation from modifier key to the associated property in the event.
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/#keys-Modifiers
+ */
+
+var modifierKeyToProp = {
+  'alt': 'altKey',
+  'control': 'ctrlKey',
+  'meta': 'metaKey',
+  'shift': 'shiftKey'
+};
+
+function getEventModifierState(nativeEvent) {
+  // IE8 does not implement getModifierState so we simply map it to the only
+  // modifier keys exposed by the event itself, does not support Lock-keys.
+  // Currently, all major browsers except Chrome seems to support Lock-keys.
+  return nativeEvent.getModifierState || function(keyArg) {
+    var keyProp = modifierKeyToProp[keyArg.toLowerCase()];
+    return keyProp && nativeEvent[keyProp];
+  };
+}
+
+module.exports = getEventModifierState;


### PR DESCRIPTION
`KeyboardEvent` now normalizes `charCode`, `keyCode`, `which` across all browsers, partial `key`-support for KeyDown/KeyUp, full `key`-support for KeyPress. `getModifierState` is added to the interface of `KeyboardEvent`, `MouseEvent`  and `TouchEvent` and is polyfilled for IE8.

`TouchEvent` doesn't support `getModifierState` according to the latest draft, but considering that the interface is otherwise identical in the design, it would be exceptionally inconsistent for it to be intentionally omitted. `which` is redundant and not very precisely defined, but it is in the legacy standard. I also took the liberty to remove `char` from the interface, it existed briefly in the working draft before it got dropped. It was only ever supported by IE9, which makes it practically useless.

I've also extensively documented all the nuances.

```
   raw     gz Compared to master @ e91a8a1bc30e675c4683d5667b4122106962828b
     =      = build/JSXTransformer.js
 +3586   -904 build/react-test.js
 +4484  +1292 build/react-with-addons.js
  +839   +242 build/react-with-addons.min.js
 +4483  +1283 build/react.js
  +840   +218 build/react.min.js
```

Fixes #706.
