### PR TITLE
Fix WheelEvent incorrectly flipping sign of deltaY

### DIFF
--- a/src/event/synthetic/SyntheticWheelEvent.js
+++ b/src/event/synthetic/SyntheticWheelEvent.js
@@ -27,7 +27,6 @@ var SyntheticMouseEvent = require('SyntheticMouseEvent');
  */
 var WheelEventInterface = {
   deltaX: function(event) {
-    // NOTE: IE<9 does not support x-axis delta.
     return (
       'deltaX' in event ? event.deltaX :
       // Fallback to `wheelDeltaX` for Webkit and normalize (right is positive).
@@ -36,15 +35,19 @@ var WheelEventInterface = {
   },
   deltaY: function(event) {
     return (
-      // Normalize (up is positive).
-      'deltaY' in event ? -event.deltaY :
-      // Fallback to `wheelDeltaY` for Webkit.
-      'wheelDeltaY' in event ? event.wheelDeltaY :
-      // Fallback to `wheelDelta` for IE<9.
-      'wheelDelta' in event ? event.wheelDelta : 0
+      'deltaY' in event ? event.deltaY :
+      // Fallback to `wheelDeltaY` for Webkit and normalize (down is positive).
+      'wheelDeltaY' in event ? -event.wheelDeltaY :
+      // Fallback to `wheelDelta` for IE<9 and normalize (down is positive).
+      'wheelDelta' in event ? -event.wheelDelta : 0
     );
   },
   deltaZ: null,
+  
+  // Browsers without "deltaMode" is reporting in raw wheel delta where one
+  // notch on the scroll is always +/- 120, roughly equivalent to pixels.
+  // A good approximation of DOM_DELTA_LINE (1) is 5% of viewport size or
+  // ~40 pixels, for DOM_DELTA_SCREEN (2) it is 87.5% of viewport size.
   deltaMode: null
 };
 

--- a/src/event/synthetic/__tests__/SyntheticWheelEvent-test.js
+++ b/src/event/synthetic/__tests__/SyntheticWheelEvent-test.js
@@ -46,11 +46,11 @@ describe('SyntheticWheelEvent', function() {
   it('should normalize properties from the WheelEvent interface', function() {
     var standardEvent = createEvent({deltaX: 10, deltaY: -50});
     expect(standardEvent.deltaX).toBe(10);
-    expect(standardEvent.deltaY).toBe(50);
+    expect(standardEvent.deltaY).toBe(-50);
 
     var webkitEvent = createEvent({wheelDeltaX: -10, wheelDeltaY: 50});
     expect(webkitEvent.deltaX).toBe(10);
-    expect(webkitEvent.deltaY).toBe(50);
+    expect(webkitEvent.deltaY).toBe(-50);
   });
 
   it('should be able to `preventDefault` and `stopPropagation`', function() {


### PR DESCRIPTION
`MouseWheel` incorrectly inverts `deltaY` to be `positive = up`, This is incorrect, `delta*` is supposed to represent the actual scrolling motion of the viewport, which is `positive = down`. The standard isn't really being overly detailed on the subject, but the current way of flipping Y but not X, is weird and inconsistent regardless.

From the W3 standard: `...the value MUST be the measurement along the y-axis to be scrolled...`

```
deltaX of type double, readonly 

In user agents where the default action of the wheel event is to scroll, the
value MUST be the measurement along the y-axis (in pixels, lines, or pages) to
be scrolled in the case where the event is not cancelled. Otherwise, this is an
implementation-specific measurement (in pixels, lines, or pages) of the movement
of a wheel device around the y-axis.
```

I know this is a breaking change, but it seems really bad to break with the standard (behavior) like this for no reason, and should be easy to fix for anyone affected.

---

I also removed a half-truthy note about `IE < 9` not supporting `deltaX`, this is true, but it's also true of FireFox, and likely older versions of other major browsers.
