### PR TITLE
Further cleanup of isEventSupported

### DIFF
--- a/src/dom/isEventSupported.js
+++ b/src/dom/isEventSupported.js
@@ -20,13 +20,13 @@
 
 var ExecutionEnvironment = require('ExecutionEnvironment');
 
-var testNode, useHasFeature;
+var useHasFeature;
 if (ExecutionEnvironment.canUseDOM) {
-  testNode = document.createElement('div');
   useHasFeature =
     document.implementation &&
     document.implementation.hasFeature &&
-    // `hasFeature` always returns true in Firefox 19+.
+    // always returns true in newer browsers as per the standard.
+    // @see http://dom.spec.whatwg.org/#dom-domimplementation-hasfeature
     document.implementation.hasFeature('', '') !== true;
 }
 
@@ -45,15 +45,16 @@ if (ExecutionEnvironment.canUseDOM) {
  * @license Modernizr 3.0.0pre (Custom Build) | MIT
  */
 function isEventSupported(eventNameSuffix, capture) {
-  if (!testNode || (capture && !testNode.addEventListener)) {
+  if (!ExecutionEnvironment.canUseDOM ||
+      capture && !('addEventListener' in document)) {
     return false;
   }
-  var element = document.createElement('div');
-
+  
   var eventName = 'on' + eventNameSuffix;
-  var isSupported = eventName in element;
+  var isSupported = eventName in document;
 
   if (!isSupported) {
+    var element = document.createElement('div');
     element.setAttribute(eventName, 'return;');
     isSupported = typeof element[eventName] === 'function';
   }


### PR DESCRIPTION
I did a double-take on `isEventSupported` and realized that it could be further cleaned up.

It now performs all the tests directly on `document` instead of `document.createElement('div')`, unless we need to use the fallback method. In my tests, in all primary major browsers and IE8-11, this method has identical results to testing on a `<div>` for any event we are interested in and I don't see why it shouldn't.
