### PR TITLE
Upgrade commoner build tool to v0.8.12.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/facebook/react"
   },
   "dependencies": {
-    "commoner": "~0.8.8",
+    "commoner": "~0.8.12",
     "esprima-fb": "~2001.1001.0-dev-harmony-fb",
     "jstransform": "~2.0.1"
   },


### PR DESCRIPTION
Fixes #394.
Fixes #615.

When a module fails to build, `STDERR` now contains a line indicating which module it was. Also, the build terminates immediately when such errors occur, causing `jsx` to have a non-zero exit code, so that `grunt` will also terminate immediately.

cc @petehunt @zpao @arsfeld @fabiomcosta
