### PR TITLE
Simplify joinClasses utility, faster

### DIFF
--- a/src/utils/__tests__/joinClasses-test.js
+++ b/src/utils/__tests__/joinClasses-test.js
@@ -34,24 +34,17 @@ describe('joinClasses', function() {
     expect(joinClasses(aaa, bbb)).toEqual('aaa bbb');
   });
 
-  it('should join many classes together', function() {
-    var aaa = 'aaa';
-    var bbb = 'bbb';
-    var ccc = 'ccc';
-    var ddd = 'ddd';
-    var eee = 'eee';
-    expect(joinClasses(aaa, bbb, ccc, ddd, eee)).toEqual('aaa bbb ccc ddd eee');
-  });
-
   it('should omit undefined and empty classes', function() {
     var aaa = 'aaa';
     var bbb;
     var ccc = null;
     var ddd = '';
     var eee = 'eee';
-    expect(joinClasses(bbb)).toEqual('');
-    expect(joinClasses(bbb, bbb, bbb)).toEqual('');
-    expect(joinClasses(aaa, bbb, ccc, ddd, eee)).toEqual('aaa eee');
+    expect(joinClasses(aaa)).toEqual('aaa');
+    expect(joinClasses(bbb, bbb)).toEqual('');
+    expect(joinClasses(ccc, bbb)).toEqual('');
+    expect(joinClasses(ccc, aaa)).toEqual('aaa');
+    expect(joinClasses(eee, ddd)).toEqual('eee');
   });
 
 });

--- a/src/utils/joinClasses.js
+++ b/src/utils/joinClasses.js
@@ -21,24 +21,22 @@
 
 /**
  * Combines multiple className strings into one.
- * http://jsperf.com/joinclasses-args-vs-array
+ * http://jsperf.com/joinclasses-args-vs-array/8
  *
- * @param {...?string} classes
+ * @param {?string} className1
+ * @param {?string} className2
  * @return {string}
  */
-function joinClasses(className/*, ... */) {
-  if (!className) {
-    className = '';
+function joinClasses(className1, className2) {
+  if (className1 && className2) {
+    return className1 + ' ' + className2;
+  } else if (className1) {
+    return className1;
+  } else if (className2) {
+    return className2;
+  } else {
+    return '';
   }
-  var nextClass;
-  var argLength = arguments.length;
-  if (argLength > 1) {
-    for (var ii = 1; ii < argLength; ii++) {
-      nextClass = arguments[ii];
-      nextClass && (className += ' ' + nextClass);
-    }
-  }
-  return className;
 }
 
 module.exports = joinClasses;


### PR DESCRIPTION
`joinClasses` is only used for `createTransferStrategy` which only ever sends 2 arguments, `merge` is used the same way and also only supports 2 arguments. So I propose simplifying it and shaving a few bytes, it's (by itself) also considerably faster, not that it really matters, but it's something.

http://jsperf.com/joinclasses-args-vs-array/8

```
IE8: 331,053 => 808,776
IE11: 2,012,439 => 7,316,248
FireFox: 8,170,716 => 37,780,175
Chrome: 11,019,243 => 50,732,389
```

```
   raw     gz Compared to master @ 1b67ac90f2bdca189a61a3e873af157198cdf7a5
     =      = build/JSXTransformer.js
     =      = build/react-test.js
   -37    -50 build/react-with-addons.js
   -67    -32 build/react-with-addons.min.js
   -37    -50 build/react.js
   -67    -31 build/react.min.js
```
