### PR TITLE
Fix cases where owner warning is shown

### DIFF
--- a/src/core/shouldUpdateReactComponent.js
+++ b/src/core/shouldUpdateReactComponent.js
@@ -31,11 +31,11 @@
 function shouldUpdateReactComponent(prevComponent, nextComponent) {
   // TODO: Remove warning after a release.
   if (prevComponent && nextComponent &&
-      prevComponent.constructor === nextComponent.constructor) {
-    if (prevComponent._owner === nextComponent._owner && (
-          (prevComponent.props && prevComponent.props.key) ===
-          (nextComponent.props && nextComponent.props.key)
-        )) {
+      prevComponent.constructor === nextComponent.constructor && (
+        (prevComponent.props && prevComponent.props.key) ===
+        (nextComponent.props && nextComponent.props.key)
+      )) {
+    if (prevComponent._owner === nextComponent._owner) {
       return true;
     } else {
       if (__DEV__) {


### PR DESCRIPTION
In b0431a5 I added the check in the wrong place which could cause the warning to be shown because of key changes rather than owner changes like the warning suggests.
