### PR TITLE
Silence console.error in ReactDOMInput-test, fixes #531

### DIFF
--- a/src/dom/components/__tests__/ReactDOMInput-test.js
+++ b/src/dom/components/__tests__/ReactDOMInput-test.js
@@ -199,6 +199,11 @@ describe('ReactDOMInput', function() {
   });
 
   it('should throw if both value and valueLink are provided', function() {
+    // Silences console.error messages
+    // ReactErrorUtils.guard is applied to all methods of a React component
+    // and calls console.error in __DEV__ (true for test environment)
+    spyOn(console, 'error');
+
     var node = document.createElement('div');
     var link = new ReactLink('yolo', mocks.getMockFunction());
     var instance = <input type="text" valueLink={link} />;


### PR DESCRIPTION
This test is expected to throw but because of ReactErrorUtils.guard which uses console.error in **DEV** it also logged the invariant error to the console. This change fixes it by temporarily stubbing out console.error.
