### PR TITLE
Remove jQuery in tutorial, keep jQuery for reference

### DIFF
--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -389,7 +389,7 @@ var CommentBox = React.createClass({
       if (req.readyState !== 4 || req.status !== 200) return;
       this.setState({data: JSON.parse(req.responseText)});
     }.bind(this);
-    req.open("GET", this.props.url, true);
+    req.open("GET", 'comments.json', true);
     req.send();
     // $.ajax({
     //   url: 'comments.json',


### PR DESCRIPTION
This pull request closes issue 603 (https://github.com/facebook/react/issues/603). This removes jQuery from the tutorial such that the tutorial does not imply that jQuery is necessary when using React.
