### PR TITLE
Allow single component as children of ReactTransitionGroup

### DIFF
--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -104,6 +104,13 @@ var ReactTransitionGroup = React.createClass({
   },
 
   render: function() {
+    var children = [];
+    if (Array.isArray(this.props.children)) {
+      children = this.props.children;
+    } else if (this.props.children) {
+      children = [this.props.children];
+    }
+
     return this.transferPropsTo(
       this.props.component(
         {
@@ -112,7 +119,7 @@ var ReactTransitionGroup = React.createClass({
           transitionLeave: null,
           component: null
         },
-        this.renderTransitionableChildren(this.props.children)
+        this.renderTransitionableChildren(children)
       )
     );
   }


### PR DESCRIPTION
This is somehow related to #751 (if `@props.children` was always an array, this would work out of the box). Not sure this is desired, after all the user can wrap a single component in an array...

``` coffee
# message is "some string" or null
ReactTransitionGroup transitionName: 'example',
  message
```

What I am more interested in is the ability to use inline styles instead of a CSS class (thoughts?).
