### PR TITLE
Add link to HTML to JSX converter to “JSX In Depth” page

### DIFF
--- a/docs/docs/02.1-jsx-in-depth.md
+++ b/docs/docs/02.1-jsx-in-depth.md
@@ -106,7 +106,7 @@ See [Multiple Components](/react/docs/multiple-components.html) to learn more ab
 
 > Note:
 >
-> Since JSX is JavaScript, identifiers such as `class` and `for` are not allowed
+> Since JSX is JavaScript, identifiers such as `class` and `for` are discouraged
 > as XML attribute names. Instead, React DOM components expect attributes like
 > `className` and `htmlFor`, respectively.
 


### PR DESCRIPTION
Added link to HTML to JSX converter to “JSX In Depth” page.

Also adjusted the sentence on identifiers like `class` and `for`. Not only are these discouraged, they don't actually work (at least "class" doesn't)
