### PR TITLE
Bump jstransform version to 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "commoner": "~0.8.12",
     "esprima-fb": "~2001.1001.0-dev-harmony-fb",
-    "jstransform": "~2.0.1"
+    "jstransform": "~2.0.2"
   },
   "devDependencies": {
     "browserify": "~2.36.1",


### PR DESCRIPTION
Necessary for JSXTransformer.js to work since 7675611.
