### PR TITLE
Make ReactTransitionGroup work with a null child

### DIFF
--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -62,8 +62,9 @@ var ReactTransitionGroup = React.createClass({
     var children = {};
     var childMapping = ReactTransitionKeySet.getChildMapping(sourceChildren);
 
+    var prevKeys = this._transitionGroupCurrentKeys;
     var currentKeys = ReactTransitionKeySet.mergeKeySets(
-      this._transitionGroupCurrentKeys,
+      prevKeys,
       ReactTransitionKeySet.getKeySet(sourceChildren)
     );
 
@@ -73,7 +74,7 @@ var ReactTransitionGroup = React.createClass({
       // may look up an old key in the new children, and it may switch to
       // undefined. React's reconciler will keep the ReactTransitionableChild
       // instance alive such that we can animate it.
-      if (childMapping[key] || this.props.transitionLeave) {
+      if (childMapping[key] || (this.props.transitionLeave && prevKeys[key])) {
         children[key] = ReactTransitionableChild({
           name: this.props.transitionName,
           enter: this.props.transitionEnter,

--- a/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
@@ -118,13 +118,20 @@ describe('ReactTransitionGroup', function() {
     expect(a.getDOMNode().childNodes[1].id).toBe('two');
   });
 
-  describe('with an undefined child', function () {
-    it('should fail silently', function () {
-      React.renderComponent(
-        <ReactTransitionGroup transitionName="yolo">
-        </ReactTransitionGroup>,
-        container
-      );
-    });
+  it('should work with no children', function () {
+    React.renderComponent(
+      <ReactTransitionGroup transitionName="yolo">
+      </ReactTransitionGroup>,
+      container
+    );
+  });
+
+  it('should work with a null child', function () {
+    React.renderComponent(
+      <ReactTransitionGroup transitionName="yolo">
+        {[null]}
+      </ReactTransitionGroup>,
+      container
+    );
   });
 });


### PR DESCRIPTION
I believe this fixes what #814 was meant to fix.
