### PR TITLE
Add onError to ReactDOMImg to complement onLoad

### DIFF
--- a/src/browser/dom/components/ReactDOMImg.js
+++ b/src/browser/dom/components/ReactDOMImg.js
@@ -41,10 +41,16 @@ var ReactDOMImg = ReactCompositeComponent.createClass({
   },
 
   componentDidMount: function() {
+    var node = this.getDOMNode();
     ReactEventEmitter.trapBubbledEvent(
       EventConstants.topLevelTypes.topLoad,
       'load',
-      this.getDOMNode()
+      node
+    );
+    ReactEventEmitter.trapBubbledEvent(
+      EventConstants.topLevelTypes.topError,
+      'error',
+      node
     );
   }
 });

--- a/src/browser/eventPlugins/SimpleEventPlugin.js
+++ b/src/browser/eventPlugins/SimpleEventPlugin.js
@@ -157,6 +157,12 @@ var eventTypes = {
       captured: keyOf({onLoadCapture: true})
     }
   },
+  error: {
+    phasedRegistrationNames: {
+      bubbled: keyOf({onError: true}),
+      captured: keyOf({onErrorCapture: true})
+    }
+  },
   // Note: We do not allow listening to mouseOver events. Instead, use the
   // onMouseEnter/onMouseLeave created by `EnterLeaveEventPlugin`.
   mouseDown: {
@@ -260,6 +266,7 @@ var topLevelEventsToDispatchConfig = {
   topDragOver:    eventTypes.dragOver,
   topDragStart:   eventTypes.dragStart,
   topDrop:        eventTypes.drop,
+  topError:       eventTypes.error,
   topFocus:       eventTypes.focus,
   topInput:       eventTypes.input,
   topKeyDown:     eventTypes.keyDown,
@@ -327,6 +334,7 @@ var SimpleEventPlugin = {
     switch (topLevelType) {
       case topLevelTypes.topInput:
       case topLevelTypes.topLoad:
+      case topLevelTypes.topError:
       case topLevelTypes.topReset:
       case topLevelTypes.topSubmit:
         // HTML Events

--- a/src/event/EventConstants.js
+++ b/src/event/EventConstants.js
@@ -44,6 +44,7 @@ var topLevelTypes = keyMirror({
   topDragOver: null,
   topDragStart: null,
   topDrop: null,
+  topError: null,
   topFocus: null,
   topInput: null,
   topKeyDown: null,


### PR DESCRIPTION
@spicyj added the the useful `onLoad`, lets complement it with `onError` for those times the images doesn't load. :)

It is _possible_ that we may want to overload `onLoad` to sometimes emit `onError` instead. I've seen people comment in various places that sometimes images fails to load but emit `onLoad` with 0 width/height image instead. But I wasn't able to reproduce it myself in IE8-11 and edge versions of browsers.
