### PR TITLE
Add PropTypes.component to demand a single React component.

### DIFF
--- a/src/core/ReactPropTypes.js
+++ b/src/core/ReactPropTypes.js
@@ -86,7 +86,8 @@ var Props = {
 
   instanceOf: createInstanceTypeChecker,
 
-  renderable: createRenderableTypeChecker()
+  renderable: createRenderableTypeChecker(),
+  component: createComponentTypeChecker()
 
 };
 
@@ -198,6 +199,25 @@ function createRenderableTypeChecker() {
     );
   }
   return createChainableTypeChecker(validateRenderableType);
+}
+
+function createComponentTypeChecker() {
+  function validateComponentType(
+    shouldThrow, propValue, propName, componentName, location
+  ) {
+    var isValid = ReactComponent.isValidComponent(propValue);
+    if (!shouldThrow) {
+      return isValid;
+    }
+    invariant(
+      isValid,
+      'Invalid %s `%s` supplied to `%s`, expected a React component.',
+      ReactPropTypeLocationNames[location],
+      propName,
+      componentName
+    );
+  }
+  return createChainableTypeChecker(validateComponentType);
 }
 
 function createChainableTypeChecker(validate) {

--- a/src/core/__tests__/ReactPropTypes-test.js
+++ b/src/core/__tests__/ReactPropTypes-test.js
@@ -19,6 +19,8 @@
 
 "use strict";
 
+var ReactTestUtils;
+
 var Props = require('ReactPropTypes');
 var React = require('React');
 var ReactPropTypeLocations = require('ReactPropTypeLocations');
@@ -46,6 +48,8 @@ var MyComponent = React.createClass({
 describe('Primitive Types', function() {
   beforeEach(function() {
     require('mock-modules').dumpCache();
+
+    ReactTestUtils = require('ReactTestUtils');
   });
 
   it("should throw for invalid strings", function() {
@@ -167,6 +171,56 @@ describe('Instance Types', function() {
 
     expect(typeCheck(Props.instanceOf(Person), new Person())).not.toThrow();
     expect(typeCheck(Props.instanceOf(Person), new Engineer())).not.toThrow();
+  });
+});
+
+describe('Component Type', function() {
+  it('should support components', () => {
+    expect(typeCheck(Props.component, <div />)).not.toThrow();
+  });
+
+  it('should not support multiple components or scalar values', () => {
+    [[<div />, <div />], 123, 'foo', false].forEach((value) => {
+      expect(typeCheck(Props.component, value)).toThrow();
+    });
+  });
+
+  var Component = React.createClass({
+    propTypes: {
+      children: Props.component.isRequired
+    },
+
+    render: function() {
+      return <div>{this.props.children}</div>;
+    }
+  });
+
+  it('should be able to define a single child as children', () => {
+    expect(() => {
+      var instance =
+        <Component>
+          <div />
+        </Component>;
+      ReactTestUtils.renderIntoDocument(instance);
+    }).not.toThrow();
+  });
+
+  it('should throw when passing more than one child', () => {
+    expect(() => {
+      var instance =
+        <Component>
+          <div />
+          <div />
+        </Component>;
+      ReactTestUtils.renderIntoDocument(instance);
+    }).toThrow();
+  });
+
+  it('should throw when passing no children and isRequired is set', () => {
+    expect(() => {
+      var instance = <Component />;
+      ReactTestUtils.renderIntoDocument(instance);
+    }).toThrow();
   });
 });
 


### PR DESCRIPTION
This is super useful for components that wrap a single child, see the test that defines 'children: Props.component'.
