### PR TITLE
link to docs in unique key prop warning

### DIFF
--- a/src/core/ReactComponent.js
+++ b/src/core/ReactComponent.js
@@ -90,6 +90,7 @@ function validateExplicitKey(component) {
     message += ' It was passed a child from ' + childOwnerName + '.';
   }
 
+  message += ' See http://fb.me/react-warning-keys for more information.'
   console.warn(message);
 }
 


### PR DESCRIPTION
This adds a link to http://fb.me/react-warning-keys in the console warning displayed when rendering array children without a `key` property.

This depends on a facebook employee creating the shorturl linking http://fb.me/react-warning-keys to http://facebook.github.io/react/docs/multiple-components.html#dynamic-children.

I signed the CLA today as well.
