### PR TITLE
Always call callback in component context

### DIFF
--- a/src/core/ReactMount.js
+++ b/src/core/ReactMount.js
@@ -318,7 +318,7 @@ var ReactMount = {
       container,
       shouldReuseMarkup
     );
-    callback && callback();
+    callback && callback.call(component);
     return component;
   },
 

--- a/src/core/ReactUpdates.js
+++ b/src/core/ReactUpdates.js
@@ -102,7 +102,7 @@ function enqueueUpdate(component, callback) {
 
   if (!batchingStrategy.isBatchingUpdates) {
     component.performUpdateIfNecessary();
-    callback && callback();
+    callback && callback.call(component);
     return;
   }
 


### PR DESCRIPTION
This brings these other call sites in line with line 67 of ReactUpdates.js:

``` js
callbacks[j].call(component);
```
