### PR TITLE
Add tagName to all overloaded DOM components

### DIFF
--- a/src/browser/ui/dom/components/ReactDOMButton.js
+++ b/src/browser/ui/dom/components/ReactDOMButton.js
@@ -48,6 +48,8 @@ var mouseListenerNames = keyMirror({
 var ReactDOMButton = ReactCompositeComponent.createClass({
   displayName: 'ReactDOMButton',
 
+  tagName: button.tagName,
+
   mixins: [AutoFocusMixin, ReactBrowserComponentMixin],
 
   render: function() {

--- a/src/browser/ui/dom/components/ReactDOMForm.js
+++ b/src/browser/ui/dom/components/ReactDOMForm.js
@@ -36,6 +36,8 @@ var form = ReactDOM.form;
 var ReactDOMForm = ReactCompositeComponent.createClass({
   displayName: 'ReactDOMForm',
 
+  tagName: form.tagName,
+
   mixins: [ReactBrowserComponentMixin],
 
   render: function() {

--- a/src/browser/ui/dom/components/ReactDOMImg.js
+++ b/src/browser/ui/dom/components/ReactDOMImg.js
@@ -35,7 +35,8 @@ var img = ReactDOM.img;
  */
 var ReactDOMImg = ReactCompositeComponent.createClass({
   displayName: 'ReactDOMImg',
-  tagName: 'IMG',
+
+  tagName: img.tagName,
 
   mixins: [ReactBrowserComponentMixin],
 

--- a/src/browser/ui/dom/components/ReactDOMInput.js
+++ b/src/browser/ui/dom/components/ReactDOMInput.js
@@ -53,6 +53,8 @@ var instancesByReactID = {};
 var ReactDOMInput = ReactCompositeComponent.createClass({
   displayName: 'ReactDOMInput',
 
+  tagName: input.tagName,
+
   mixins: [AutoFocusMixin, LinkedValueUtils.Mixin, ReactBrowserComponentMixin],
 
   getInitialState: function() {

--- a/src/browser/ui/dom/components/ReactDOMOption.js
+++ b/src/browser/ui/dom/components/ReactDOMOption.js
@@ -33,6 +33,8 @@ var option = ReactDOM.option;
 var ReactDOMOption = ReactCompositeComponent.createClass({
   displayName: 'ReactDOMOption',
 
+  tagName: option.tagName,
+
   mixins: [ReactBrowserComponentMixin],
 
   componentWillMount: function() {

--- a/src/browser/ui/dom/components/ReactDOMSelect.js
+++ b/src/browser/ui/dom/components/ReactDOMSelect.js
@@ -104,6 +104,8 @@ function updateOptions(component, propValue) {
 var ReactDOMSelect = ReactCompositeComponent.createClass({
   displayName: 'ReactDOMSelect',
 
+  tagName: select.tagName,
+
   mixins: [AutoFocusMixin, LinkedValueUtils.Mixin, ReactBrowserComponentMixin],
 
   propTypes: {

--- a/src/browser/ui/dom/components/ReactDOMTextarea.js
+++ b/src/browser/ui/dom/components/ReactDOMTextarea.js
@@ -51,6 +51,8 @@ var textarea = ReactDOM.textarea;
 var ReactDOMTextarea = ReactCompositeComponent.createClass({
   displayName: 'ReactDOMTextarea',
 
+  tagName: textarea.tagName,
+
   mixins: [AutoFocusMixin, LinkedValueUtils.Mixin, ReactBrowserComponentMixin],
 
   getInitialState: function() {

--- a/src/browser/ui/dom/components/createFullPageComponent.js
+++ b/src/browser/ui/dom/components/createFullPageComponent.js
@@ -41,6 +41,8 @@ function createFullPageComponent(componentClass) {
       componentClass.type.displayName || ''
     ),
 
+    tagName: componentClass.type.tagName,
+
     componentWillUnmount: function() {
       invariant(
         false,


### PR DESCRIPTION
Fixes #1185.

https://github.com/facebook/react/pull/873

Putting this PR here for discussion, if we should keep `tagName` in overloaded DOM components or not.

I chose to reference the initial tagName rather than redefine, compresses better and keeps them nicely in sync.

```
   raw     gz Compared to last run
     =      = build/JSXTransformer.js
  +167    +36 build/react-with-addons.js
  +108    +15 build/react-with-addons.min.js
  +167    +37 build/react.js
  +108    +18 build/react.min.js
```
