### PR TITLE
Remove unnecessary tests from insertChildAt and inline it instead

### DIFF
--- a/src/browser/ui/dom/DOMChildrenOperations.js
+++ b/src/browser/ui/dom/DOMChildrenOperations.js
@@ -42,20 +42,14 @@ var textContentAccessor = getTextContentAccessor();
  * @internal
  */
 function insertChildAt(parentNode, childNode, index) {
-  var childNodes = parentNode.childNodes;
-  if (childNodes[index] === childNode) {
-    return;
-  }
-  // If `childNode` is already a child of `parentNode`, remove it so that
-  // computing `childNodes[index]` takes into account the removal.
-  if (childNode.parentNode === parentNode) {
-    parentNode.removeChild(childNode);
-  }
-  if (index >= childNodes.length) {
-    parentNode.appendChild(childNode);
-  } else {
-    parentNode.insertBefore(childNode, childNodes[index]);
-  }
+  // By exploiting arrays returning `undefined` for an undefined index, we can
+  // rely exclusively on `insertBefore(node, null)` instead of also using
+  // `appendChild(node)`. However, using `undefined` is not allowed by all
+  // browsers so we must replace it with `null`.
+  parentNode.insertBefore(
+    childNode,
+    parentNode.childNodes[index] || null
+  );
 }
 
 var updateTextContent;


### PR DESCRIPTION
```
if (childNodes[index] === childNode) {
  return;
}
if (childNode.parentNode === parentNode) {
  parentNode.removeChild(childNode);
}
```

A `childNode` to be inserted/moved cannot find itself already in the DOM. It has already been detached by `processUpdates` as it was added to `updatedChildren` as part of the setup. _If_ it had been added twice to the list of updates, `processUpdates` would throw an error as it would try to detach it twice.

---

```
if (index >= childNodes.length) {
  parentNode.appendChild(childNode);
} else {
  parentNode.insertBefore(childNode, childNodes[index]);
}
```

`appendChild(node)` behaves identically to `insertBefore(node, null)`, however arrays return `undefined` for an undefined index. IE8 (and possibly others) do not like this, so by adding `|| null` we're all set!

---

I have also tested it using my torture test, if something is wrong the numbers would not be ascending order and it should quickly break and spew endless amounts of errors.

http://dev.cetrez.com/jsx/2/index3.html

---

```
   raw     gz Compared to last run
     =      = build/JSXTransformer.js
   -89    +20 build/react-with-addons.js
   -70    -24 build/react-with-addons.min.js
   -89    +10 build/react.js
   -70    -26 build/react.min.js
```
