### PR TITLE
Remove unnecessary 'NA'-fallback for getTextContentAccessor()

### DIFF
--- a/src/core/ReactDOMIDOperations.js
+++ b/src/core/ReactDOMIDOperations.js
@@ -47,7 +47,7 @@ var INVALID_PROPERTY_ERRORS = {
  * @type {string}
  * @private
  */
-var textContentAccessor = getTextContentAccessor() || 'NA';
+var textContentAccessor = getTextContentAccessor();
 
 var useWhitespaceWorkaround;
 

--- a/src/dom/DOMChildrenOperations.js
+++ b/src/dom/DOMChildrenOperations.js
@@ -30,7 +30,7 @@ var getTextContentAccessor = require('getTextContentAccessor');
  * @type {string}
  * @private
  */
-var textContentAccessor = getTextContentAccessor() || 'NA';
+var textContentAccessor = getTextContentAccessor();
 
 /**
  * Inserts `childNode` as a child of `parentNode` at the `index`.


### PR DESCRIPTION
The `'NA'`-fallback is not used in https://github.com/facebook/react/blob/master/src/eventPlugins/CompositionEventPlugin.js#L175

I don't see why we need it at all? If the browser doesn't support a text content accessor then there's nothing we can do, assigning to `'NA'` or `undefined` should be a meaningless distinction with the same result.
