### PR TITLE
Test innerText/textContent on document.documentElement instead

### DIFF
--- a/src/browser/ui/dom/getTextContentAccessor.js
+++ b/src/browser/ui/dom/getTextContentAccessor.js
@@ -32,7 +32,7 @@ function getTextContentAccessor() {
   if (!contentKey && ExecutionEnvironment.canUseDOM) {
     // Prefer textContent to innerText because many browsers support both but
     // SVG <text> elements don't support innerText even when <div> does.
-    contentKey = 'textContent' in document.createElement('div') ?
+    contentKey = 'textContent' in document.documentElement ?
       'textContent' :
       'innerText';
   }


### PR DESCRIPTION
W3 specifies that `Document.documentElement` is an implementation of `Node` and testing on that should save us from temporarily creating a `div`. Testing in my browsers shows this to be true.
