### PR TITLE
Allow null return values for functions to-be-merged.

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -547,10 +547,14 @@ function mergeObjectsWithNoDuplicateKeys(one, two) {
  */
 function createMergedResultFunction(one, two) {
   return function mergedResult() {
-    return mergeObjectsWithNoDuplicateKeys(
-      one.apply(this, arguments),
-      two.apply(this, arguments)
-    );
+    var a = one.apply(this, arguments);
+    var b = two.apply(this, arguments);
+    if (a == null) {
+      return b;
+    } else if (b == null) {
+      return a;
+    }
+    return mergeObjectsWithNoDuplicateKeys(a, b);
   };
 }
 

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -477,30 +477,6 @@ describe('ReactCompositeComponent', function() {
     );
   });
 
-  it('should throw with bad getInitialState() return values', function() {
-    var Mixin = {
-      getInitialState: function() {
-        return null;
-      }
-    };
-    var Component = React.createClass({
-      mixins: [Mixin],
-      getInitialState: function() {
-        return {x: true};
-      },
-      render: function() {
-        return <span />;
-      }
-    });
-    var instance = <Component />;
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(instance);
-    }).toThrow(
-      'Invariant Violation: mergeObjectsWithNoDuplicateKeys(): ' +
-      'Cannot merge non-objects'
-    );
-  });
-
   it('should work with object getInitialState() return values', function() {
     var Component = React.createClass({
       getInitialState: function() {
@@ -546,7 +522,77 @@ describe('ReactCompositeComponent', function() {
         return <span />;
       }
     });
-    expect(() => <Component />).not.toThrow();
+    expect(
+      () => ReactTestUtils.renderIntoDocument(<Component />)
+    ).not.toThrow();
+  });
+
+  it('should work with a null getInitialState return value and a mixin', () => {
+    var Component;
+    var instance;
+
+    var Mixin = {
+      getInitialState: function() {
+        return {foo: 'bar'};
+      }
+    };
+    Component = React.createClass({
+      mixins: [Mixin],
+      getInitialState: function() {
+        return null;
+      },
+      render: function() {
+        return <span />;
+      }
+    });
+    expect(
+      () => ReactTestUtils.renderIntoDocument(<Component />)
+    ).not.toThrow();
+
+    instance = <Component />;
+    ReactTestUtils.renderIntoDocument(instance);
+    expect(instance.state).toEqual({foo: 'bar'});
+
+    // Also the other way round should work
+    var Mixin2 = {
+      getInitialState: function() {
+        return null;
+      }
+    };
+    Component = React.createClass({
+      mixins: [Mixin2],
+      getInitialState: function() {
+        return {foo: 'bar'};
+      },
+      render: function() {
+        return <span />;
+      }
+    });
+    expect(
+      () => ReactTestUtils.renderIntoDocument(<Component />)
+    ).not.toThrow();
+
+    instance = <Component />;
+    ReactTestUtils.renderIntoDocument(instance);
+    expect(instance.state).toEqual({foo: 'bar'});
+
+    // Multiple mixins should be fine too
+    Component = React.createClass({
+      mixins: [Mixin, Mixin2],
+      getInitialState: function() {
+        return {x: true};
+      },
+      render: function() {
+        return <span />;
+      }
+    });
+    expect(
+      () => ReactTestUtils.renderIntoDocument(<Component />)
+    ).not.toThrow();
+
+    instance = <Component />;
+    ReactTestUtils.renderIntoDocument(instance);
+    expect(instance.state).toEqual({foo: 'bar', x: true});
   });
 
   it('should work with object getInitialState() return values', function() {


### PR DESCRIPTION
This is a follow-up to #725 and fixes #883.

If a component and its mixin both define `getInitialState` and one of them returns null, we used to throw (was also covered by a test). This changes it not to throw for any functions that are merged through `createMergedResultFunction`. I'm not entirely sure if this will have unexpected side-effects but our tests seem to comply with the change.
