### PR TITLE
Perf regression fix

### DIFF
--- a/src/core/ReactDOMComponent.js
+++ b/src/core/ReactDOMComponent.js
@@ -111,6 +111,10 @@ ReactDOMComponent.Mixin = {
         mountDepth
       );
       assertValidProps(this.props);
+      if ('id' in this.props) {
+        DOMProperty.alternateAttributeReactIDs[this._rootNodeID] = true;
+      }
+
       return (
         this._createOpenTagMarkup() +
         this._createContentMarkup(transaction) +
@@ -222,6 +226,9 @@ ReactDOMComponent.Mixin = {
         prevProps,
         prevOwner
       );
+      if (!DOMProperty.alternateAttributeReactIDs[this._rootNodeID] && 'id' in this.props) {
+        DOMProperty.alternateAttributeReactIDs[this._rootNodeID] = true;
+      }
       this._updateDOMProperties(prevProps);
       this._updateDOMChildren(prevProps, transaction);
     }
@@ -383,6 +390,7 @@ ReactDOMComponent.Mixin = {
     this.unmountChildren();
     ReactEventEmitter.deleteAllListeners(this._rootNodeID);
     ReactComponent.Mixin.unmountComponent.call(this);
+    delete DOMProperty.alternateAttributeReactIDs[this._rootNodeID];
   }
 
 };

--- a/src/dom/DOMProperty.js
+++ b/src/dom/DOMProperty.js
@@ -151,7 +151,10 @@ var defaultValueCache = {};
  */
 var DOMProperty = {
 
-  ID_ATTRIBUTE_NAME: 'data-reactid',
+  ALTERNATE_ID_ATTRIBUTE_NAME: 'data-reactid',
+
+  /** Set of react IDs that don't want their id attribute clobbered */
+  alternateAttributeReactIDs: {},
 
   /**
    * Checks whether a property name is a standard property.

--- a/src/dom/DOMPropertyOperations.js
+++ b/src/dom/DOMPropertyOperations.js
@@ -78,8 +78,12 @@ var DOMPropertyOperations = {
    * @return {string} Markup string.
    */
   createMarkupForID: function(id) {
-    return processAttributeNameAndPrefix(DOMProperty.ID_ATTRIBUTE_NAME) +
-      escapeTextForBrowser(id) + '"';
+    return (
+      processAttributeNameAndPrefix(
+        DOMProperty.alternateAttributeReactIDs[id] ?
+          DOMProperty.ALTERNATE_ID_ATTRIBUTE_NAME : 'id'
+      ) + escapeTextForBrowser(id) + '"'
+    );
   },
 
   /**


### PR DESCRIPTION
The switch to `data-reactid` really messed up our "first update" performance. Once the cache was warmed perf was fine, but initial render perf was really, really slow. This is probably why we didn't spot this since we average over 1000s of runs.

This diff goes back to using the `id` attribute, and falls back to the DOM walk/`data-reactid` strategy if the user provides an `id` attribute. Tests coming soon.

Test case (courtesy of ebryn and mmun of #emberjs-dev): http://jsbin.com/OqOJidIQ/2/edit
