### PR TITLE
Allow use of onChange when using valueLink

### DIFF
--- a/src/browser/ui/dom/components/LinkedValueUtils.js
+++ b/src/browser/ui/dom/components/LinkedValueUtils.js
@@ -43,19 +43,18 @@ function _assertSingleLink(input) {
 function _assertValueLink(input) {
   _assertSingleLink(input);
   invariant(
-    input.props.value == null && input.props.onChange == null,
-    'Cannot provide a valueLink and a value or onChange event. If you want ' +
-    'to use value or onChange, you probably don\'t want to use valueLink.'
+    input.props.value == null,
+    'Cannot provide a valueLink and a value. If you want to use value, you ' +
+    'probably don\'t want to use valueLink.'
   );
 }
 
 function _assertCheckedLink(input) {
   _assertSingleLink(input);
   invariant(
-    input.props.checked == null && input.props.onChange == null,
-    'Cannot provide a checkedLink and a checked property or onChange event. ' +
-    'If you want to use checked or onChange, you probably don\'t want to ' +
-    'use checkedLink'
+    input.props.checked == null,
+    'Cannot provide a checkedLink and a checked property. If you want to use ' +
+    'checked, you probably don\'t want to use checkedLink.'
   );
 }
 
@@ -65,6 +64,9 @@ function _assertCheckedLink(input) {
 function _handleLinkedValueChange(e) {
   /*jshint validthis:true */
   this.props.valueLink.requestChange(e.target.value);
+  if (this.props.onChange) {
+    this.props.onChange(e);
+  }
 }
 
 /**
@@ -73,6 +75,9 @@ function _handleLinkedValueChange(e) {
 function _handleLinkedCheckChange(e) {
   /*jshint validthis:true */
   this.props.checkedLink.requestChange(e.target.checked);
+  if (this.props.onChange) {
+    this.props.onChange(e);
+  }
 }
 
 /**

--- a/src/browser/ui/dom/components/__tests__/ReactDOMInput-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMInput-test.js
@@ -268,12 +268,11 @@ describe('ReactDOMInput', function() {
         type="text"
         valueLink={link}
         value="test"
-        onChange={emptyFunction}
       />;
     expect(React.renderComponent.bind(React, instance, node)).toThrow();
 
     instance = <input type="text" valueLink={link} onChange={emptyFunction} />;
-    expect(React.renderComponent.bind(React, instance, node)).toThrow();
+    expect(React.renderComponent.bind(React, instance, node)).not.toThrow();
 
   });
 
@@ -351,13 +350,12 @@ describe('ReactDOMInput', function() {
         type="checkbox"
         checkedLink={link}
         checked="false"
-        onChange={emptyFunction}
       />;
     expect(React.renderComponent.bind(React, instance, node)).toThrow();
 
     instance =
       <input type="checkbox" checkedLink={link} onChange={emptyFunction} />;
-    expect(React.renderComponent.bind(React, instance, node)).toThrow();
+    expect(React.renderComponent.bind(React, instance, node)).not.toThrow();
 
   });
 


### PR DESCRIPTION
Being able to use `onChange` to listen to changes themselves while using `valueLink` seems kind of useful to me, and I don't see why we shouldn't support it?

There's `onInput` which is perhaps better suited for this, but it does not fire on IE8... perhaps that should be fixed instead? (although it does not exist natively on IE8 so we could only approximate it)
