### PR TITLE
Fix copying files to build/npm-react recursively

### DIFF
--- a/grunt/tasks/npm-react.js
+++ b/grunt/tasks/npm-react.js
@@ -14,9 +14,13 @@ function buildRelease() {
   // mkdir -p build/react-core/lib
   grunt.file.mkdir(lib);
 
-  // Copy everything over
-  // console.log(grunt.file.expandMapping(src + '**/*', dest, {flatten: true}));
-  grunt.file.expandMapping(src + '**/*', dest, {flatten: true}).forEach(function(mapping) {
+  // Copy npm-react/**/* to build/npm-react
+  // and build/modules/**/* to build/react-core/lib
+  var mappings = [].concat(
+    grunt.file.expandMapping('**/*', dest, {cwd: src}),
+    grunt.file.expandMapping('**/*', lib, {cwd: modSrc})
+  );
+  mappings.forEach(function(mapping) {
     var src = mapping.src[0];
     var dest = mapping.dest;
     if (grunt.file.isDir(src)) {
@@ -24,11 +28,6 @@ function buildRelease() {
     } else {
       grunt.file.copy(src, dest);
     }
-  });
-
-  // copy build/modules/*.js to build/react-core/lib
-  grunt.file.expandMapping(modSrc + '*.js', lib, { flatten: true }).forEach(function(mapping) {
-    grunt.file.copy(mapping.src[0], mapping.dest);
   });
 
   // modify build/react-core/package.json to set version ##


### PR DESCRIPTION
The intention of the `npm-react/**/*` rule was to copy recursively but it would have flattened any nested directory structure. I changed the `build/modules` rule to copy recursively as well, which is necessary for `ReactTestUtils` to be able to require `test/mock-modules.js` successfully.  (`ReactTestUtils` isn't included in a clean `npm-react` build currently but it will be in the future.)

This also makes running ART tests more practical.
