### PR TITLE
Remove unused grunt jsx config options

### DIFF
--- a/grunt/config/jsx/jsx.js
+++ b/grunt/config/jsx/jsx.js
@@ -9,11 +9,9 @@ var rootIDs = [
 
 var getDebugConfig = function() {
   return {
-    "debug": true,
     "commonerConfig": grunt.config.data.pkg.commonerConfig,
     "constants": {
-      "__VERSION__": grunt.config.data.pkg.version,
-      "__DEV__": true
+      "__VERSION__": grunt.config.data.pkg.version
     }
   };
 };
@@ -32,12 +30,10 @@ var test = {
   ]),
   getConfig: function() {
     return {
-      "debug": true,
       "mocking": true,
       "commonerConfig": grunt.config.data.pkg.commonerConfig,
       "constants": {
-        "__VERSION__": grunt.config.data.pkg.version,
-        "__DEV__": true
+        "__VERSION__": grunt.config.data.pkg.version
       }
     };
   },
@@ -50,11 +46,9 @@ var release = {
   rootIDs: rootIDs,
   getConfig: function() {
     return {
-      "debug": false,
       "commonerConfig": grunt.config.data.pkg.commonerConfig,
       "constants": {
-        "__VERSION__": grunt.config.data.pkg.version,
-        "__DEV__": false
+        "__VERSION__": grunt.config.data.pkg.version
       }
     };
   },


### PR DESCRIPTION
Since 5466d0a06382892106da7e237f3330b43a60cc95, the `__DEV__` isn't used any more. I can't find anything that uses the `debug` flag either.
