### PR TITLE
Clarify componentWillMount behavior

### DIFF
--- a/docs/docs/ref-03-component-specs.md
+++ b/docs/docs/ref-03-component-specs.md
@@ -87,7 +87,7 @@ Various methods are executed at specific points in a component's lifecycle.
 componentWillMount()
 ```
 
-Invoked immediately before rendering occurs. If you call `setState` within this method, `render()` will see the updated state and will be executed only once despite the state change.
+Invoked once, immediately before the initial rendering occurs. If you call `setState` within this method, `render()` will see the updated state and will be executed only once despite the state change.
 
 
 ### Mounting: componentDidMount


### PR DESCRIPTION
The wording around `componentWillMount`'s behavior could be interpreted as "will be invoked before every render." This just adds a little clarity to that point.
