### PR TITLE
Support un-braced element prop in JSX transform

### DIFF
--- a/vendor/fbtransform/transforms/react.js
+++ b/vendor/fbtransform/transforms/react.js
@@ -113,8 +113,14 @@ function visitReactTag(traverse, object, path, state) {
         }
       } else if (attr.value.type === Syntax.Literal) {
         renderXJSLiteral(attr.value, isLast, state);
-      } else {
+      } else if (attr.value.type === Syntax.XJSExpressionContainer) {
         renderXJSExpressionContainer(traverse, attr.value, isLast, path, state);
+      } else if (attr.value.type === Syntax.XJSElement) {
+        traverse(attr.value, path, state);
+        if (!isLast) {
+          utils.append(',', state);
+          state.g.buffer = state.g.buffer.replace(/(\s*),$/, ',$1');
+        }
       }
     }
 


### PR DESCRIPTION
Like `<LeftRight left=<a /> right=<b /> />`. facebook/esprima#9 makes this possible.

This should be merged with an esprima-fb version bump. However, facebook/esprima@8ca1599a1b3599fb3666f1094d9a0c226cf5ef5b necessitates a change to this transform to look at `object.openingElement` in most cases so I'll wait for an updated version to be synced out before this can be merged.
