### PR TITLE
Add note about using react-devtools

### DIFF
--- a/npm-react/README.md
+++ b/npm-react/README.md
@@ -21,5 +21,8 @@ var React = require('react');
 
 // You can also access ReactWithAddons.
 var React = require('react/addons');
+
+// Optionally expose React globally in order to use the Chrome extension
+// window.React = React;
 ```
 


### PR DESCRIPTION
react-devtools requires a global `React` or a global `require` returning React.

In normal browserify environments neither is the case. Therefore I think this note could be useful for people who develop with browserify and wondered why the Chrome extension didn't show.

Kudos to syranide on #reactjs.
