### PR TITLE
Implemented nextUpdate() for React testing

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -31,6 +31,13 @@ var topLevelTypes = EventConstants.topLevelTypes;
 
 function Event(suffix) {}
 
+function createChainedFunction(one, two) {
+  return function chainedFunction() {
+    one.apply(this, arguments);
+    two.apply(this, arguments);
+  };
+}
+
 /**
  * @class ReactTestUtils
  */
@@ -219,19 +226,7 @@ var ReactTestUtils = {
     return this;
   },
 
-  /**
-   *
-   */
-
   nextUpdate: function(component, callback) {
-    // TODO: deregister self
-    function createChainedFunction(one, two) {
-      return function chainedFunction() {
-        one.apply(this, arguments);
-        two.apply(this, arguments);
-      };
-    }
-
     var oldFn = component.componentDidUpdate;
     var newFn;
 

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -64,7 +64,23 @@ describe('ReactTestUtils', function() {
       ReactTestUtils.nextUpdate(root, function() {});
 
       component.forceUpdate(function() {
-        expect(component.componentDidUpdate === original).toBe(true);
+        expect(component.componentDidUpdate).toBe(original);
+      });
+    });
+
+    it("works without an initial componentDidUpdate", function() {
+      var root = ReactTestUtils.renderIntoDocument(<TestComponent />);
+      var component = ReactTestUtils.findRenderedComponentWithType(root, TestComponent);
+
+      component.componentDidUpdate = undefined;
+
+      ReactTestUtils.nextUpdate(root, function() {
+        newDidFire = true;
+      });
+
+      component.forceUpdate(function() {
+        expect(component.componentDidUpdate).toBe(undefined);
+        expect(newDidFire).toBe(true);
       });
     });
 


### PR DESCRIPTION
Per conversations with @petehunt in IRC, this PR adds a new `nextUpdate(component, callback)` method in ReactTestUtils.

This is a convenience method for adding an additional, one-time `componentDidUpdate` method to a component. It's useful for testing components that are updated asynchronously from outside data sources (such as components that fetch data through AJAX). For example, if you had a component that changed a value that was updated asynchronously, you might test in Mocha it with something like:

``` js
it('updates the value of input.foo with the current state.value', function(done) {
  expect(1);

  ReactTestUtils.nextUpdate(component, function() {
    expect(component.getDOMNode().querySelector('input.foo').value).to.be(expected);
    done();  // (mocha-style async callback)
  });

  setTimeout(function() {
    component.setState({value: expected});
  }, 10);
});
```

Internally, this creates a new `chainedFunction` like a mixin would, but resets `componentDidUpdate` back to its initial value after the callback was called.
