### PR TITLE
Update broken link in 'why react' article

### DIFF
--- a/docs/_posts/2013-06-05-why-react.md
+++ b/docs/_posts/2013-06-05-why-react.md
@@ -81,11 +81,9 @@ some pretty cool things with it:
   (including IE8) and automatically use
   [event delegation](http://davidwalsh.name/event-delegate).
 
-Head on over to
-[facebook.github.io/react](http://facebook.github.io/react) to check
-out what we have built. Our documentation is geared towards building
-apps with the framework, but if you are interested in the
-nuts and bolts
-[get in touch](http://facebook.github.io/react/support.html) with us!
+Head on over to [facebook.github.io/react](/react) to check out what we have
+built. Our documentation is geared towards building apps with the framework,
+but if you are interested in the nuts and bolts
+[get in touch](/react/support.html) with us!
 
 Thanks for reading!


### PR DESCRIPTION
The link to JSX in the [why-react](http://facebook.github.io/react/blog/2013/06/05/why-react.html) article was not up-to-date.
