### PR TITLE
Make devtools warning disappear if installed

### DIFF
--- a/src/core/React.js
+++ b/src/core/React.js
@@ -72,7 +72,8 @@ if (__DEV__) {
   var ExecutionEnvironment = require('ExecutionEnvironment');
   if (ExecutionEnvironment.canUseDOM &&
       window.top === window.self &&
-      navigator.userAgent.indexOf('Chrome') > -1) {
+      navigator.userAgent.indexOf('Chrome') > -1 &&
+      typeof __react_devtools__ === "undefined") {
     console.debug(
       'Download the React DevTools for a better development experience: ' +
       'http://fb.me/react-devtools'


### PR DESCRIPTION
Depends on facebook/react-devtools#23 to be useful.
