### PR TITLE
Replace "comments.json" with this.props.url in the docs tutorial code snippet

### DIFF
--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -386,13 +386,13 @@ var CommentBox = React.createClass({
   },
   componentWillMount: function() {
     $.ajax({
-      url: 'comments.json',
+      url: this.props.url,
       dataType: 'json',
       success: function(data) {
         this.setState({data: data});
       }.bind(this),
       error: function(xhr, status, err) {
-        console.error("comments.json", status, err.toString());
+        console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
   },


### PR DESCRIPTION
Example AJAX request should make use of this.props.url in all places.  The first time it is added, the file name is hardcoded in and then switched out for the props reference in the next example.
