### PR TITLE
Remove unnecessary catch-clauses for try-finally

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -1001,8 +1001,6 @@ var ReactCompositeComponentMixin = {
         this._currentContext = nextFullContext;
         this.context = nextContext;
       }
-    } catch (e) {
-      throw e;
     } finally {
       this._compositeLifeCycleState = null;
     }
@@ -1164,9 +1162,6 @@ var ReactCompositeComponentMixin = {
     ReactCurrentOwner.current = this;
     try {
       renderedComponent = this.render();
-    } catch (error) {
-      // IE8 requires `catch` in order to use `finally`.
-      throw error;
     } finally {
       ReactContext.current = previousContext;
       ReactCurrentOwner.current = null;

--- a/src/core/ReactContext.js
+++ b/src/core/ReactContext.js
@@ -56,9 +56,6 @@ var ReactContext = {
     ReactContext.current = merge(previousContext, newContext);
     try {
       result = scopedCallback();
-    } catch (error) {
-      // IE8 requires `catch` in order to use `finally`.
-      throw error;
     } finally {
       ReactContext.current = previousContext;
     }

--- a/src/core/ReactUpdates.js
+++ b/src/core/ReactUpdates.js
@@ -79,9 +79,6 @@ function flushBatchedUpdates() {
   // Run these in separate functions so the JIT can optimize
   try {
     runBatchedUpdates();
-  } catch (e) {
-    // IE 8 requires catch to use finally.
-    throw e;
   } finally {
     clearDirtyComponents();
   }

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -737,8 +737,6 @@ describe('ReactCompositeComponent', function() {
       );
 
       NamedComponent(); // Shut up lint
-    } catch (e) {
-      throw e;
     } finally {
       console.warn = warn;
     }
@@ -780,8 +778,6 @@ describe('ReactCompositeComponent', function() {
         'createClass(...): `childContextTypes` is now a static property and ' +
         'should be defined inside "statics".'
       );
-    } catch (e) {
-      throw e;
     } finally {
       console.warn = warn;
     }


### PR DESCRIPTION
Talked with @spicyj in the chat yesterday when he was trying to reproduce the idea that IE8 doesn't support `try {} finally {}` without `catch(e) {}`. He couldn't reproduce it and I can't either, no matter the craziness.

After searching more I'm 99% convinced that this is actually false. The reason people incorrectly assume this is the case is because IE8 always reports uncaught exceptions at last `finally`. So if you confuse IE8 really well and get a `This command is not supported`, it will report that error and that error alone at the last `finally` clause. Thus leading everyone to believe `finally` is the cause and not the error itself.

This seems to be corroborated here: https://github.com/knockout/knockout/pull/545#issuecomment-10762998

So unless you guys know for sure that this is an issue, I say we get rid of them (because some browsers actually mess up the exceptions when you re-throw them).

Credit goes to @spicyj for bringing it up.
