### PR TITLE
Normalize whitespace for transformed JSX code

### DIFF
--- a/vendor/fbtransform/transforms/xjs.js
+++ b/vendor/fbtransform/transforms/xjs.js
@@ -180,12 +180,14 @@ function renderXJSLiteral(object, isLast, state, start, end) {
       trimmedLine = trimmedLine.replace(/[ ]+$/, '');
     }
 
-    utils.append(line.match(/^[ \t]*/)[0], state);
+    if (!isFirstLine) {
+      utils.append(line.match(/^[ \t]*/)[0], state);
+    }
 
     if (trimmedLine || isLastNonEmptyLine) {
       utils.append(
         JSON.stringify(trimmedLine) +
-        (!isLastNonEmptyLine ? "+' '+" : ''),
+        (!isLastNonEmptyLine ? " + ' ' +" : ''),
         state);
 
       if (isLastNonEmptyLine) {
@@ -193,12 +195,12 @@ function renderXJSLiteral(object, isLast, state, start, end) {
           utils.append(end, state);
         }
         if (!isLast) {
-          utils.append(',', state);
+          utils.append(', ', state);
         }
       }
 
       // only restore tail whitespace if line had literals
-      if (trimmedLine) {
+      if (trimmedLine && !isLastLine) {
         utils.append(line.match(/[ \t]*$/)[0], state);
       }
     }
@@ -215,14 +217,15 @@ function renderXJSExpressionContainer(traverse, object, isLast, path, state) {
   // Plus 1 to skip `{`.
   utils.move(object.range[0] + 1, state);
   traverse(object.expression, path, state);
+
   if (!isLast && object.expression.type !== Syntax.XJSEmptyExpression) {
     // If we need to append a comma, make sure to do so after the expression.
-    utils.catchup(object.expression.range[1], state);
-    utils.append(',', state);
+    utils.catchup(object.expression.range[1], state, trimLeft);
+    utils.append(', ', state);
   }
 
   // Minus 1 to skip `}`.
-  utils.catchup(object.range[1] - 1, state);
+  utils.catchup(object.range[1] - 1, state, trimLeft);
   utils.move(object.range[1], state);
   return false;
 }
@@ -235,7 +238,12 @@ function quoteAttrName(attr) {
   return attr;
 }
 
+function trimLeft(value) {
+  return value.replace(/^[ ]+/, '');
+}
+
 exports.knownTags = knownTags;
 exports.renderXJSExpressionContainer = renderXJSExpressionContainer;
 exports.renderXJSLiteral = renderXJSLiteral;
 exports.quoteAttrName = quoteAttrName;
+exports.trimLeft = trimLeft;


### PR DESCRIPTION
It currently generates "pretty output" as we agreed upon, it respects original indenting all that, newlines are kept as-is. It also puts `{}` at just after/before the outer `()`.

There is only one case that I know of currently that produces incorrect output and that is when the attribute name and value are on different lines (see below), I could fix it, but I don't think it's worth the code complexity for something you really shouldn't do, but I could fix it.

I back-tracked on removing trailing spaces after commas, it's not super hard to do, but it's a bit of messy to sort out and I don't find it worthwhile right now. I'll leave it for another PR for now.

I haven't had time to test it extensively yet.

PS. There's a also a bunch of source code lines that got trimmed now that I'm using a better editor (I unintentionally added them with my previous whitespace PR). So that's why there's a bunch of weird "empty" changes below.

```
<div>
  <div    >  </   div   ><div></div>
  <    div>{0}    A    B    {1}    {2}</div>
  <div>    A    </div>
  <div>
      A
  </div>
  <div

    a

    =

    "a"

    b =
    "b"

    c
    = "c"
  />
  <div a="A" b="B" />
  <div a="A"/>
  <div   a  =     "b"   c = "d"    />
  <div
    a="A"
    b="B"

    c="C"

  />
  <div id="test"
    >


    {0}A{1}B{2}C {    D
  }E


    A


    B


    {1}


    {2}

    awdawdawd
    awdawdawd

  </div>
```

Produces:

```
React.DOM.div(null,
  React.DOM.div(null, "  "), React.DOM.div(null),
  React.DOM.div(null, 0, "    A    B    ", 1, "    ", 2),
  React.DOM.div(null, "    A    "),
  React.DOM.div(null,
      "A"
  ),
  React.DOM.div({

    a:



"a",

    b:
"b",

    c:
"c"
  }),
  React.DOM.div({a: "A", b: "B"}),
  React.DOM.div({a: "A"}),
  React.DOM.div({a: "b", c: "d"}),
  React.DOM.div({
    a: "A",
    b: "B",

    c: "C"

  }),
  React.DOM.div({id: "test"
    },


    0, "A", 1, "B", 2, "C ", D,
  "E" + ' ' +


    "A" + ' ' +


    "B",


    1,


    2,

    "awdawdawd" + ' ' +
    "awdawdawd"

  )
)
```
