### PR TITLE
Fix references to the old ReactID syntax

### DIFF
--- a/src/core/ReactInstanceHandles.js
+++ b/src/core/ReactInstanceHandles.js
@@ -303,8 +303,8 @@ var ReactInstanceHandles = {
 
   /**
    * Traverse a node ID, calling the supplied `cb` for each ancestor ID. For
-   * example, passing `.r[0].{row-0}.[1]` would result in `cb` getting called
-   * with `.r[0]`, `.r[0].{row-0}`, and `.r[0].{row-0}.[1]`.
+   * example, passing `.0.$row-0.1` would result in `cb` getting called
+   * with `.0`, `.0.$row-0`, and `.0.$row-0.1`.
    *
    * NOTE: This traversal happens on IDs without touching the DOM.
    *

--- a/src/core/ReactMount.js
+++ b/src/core/ReactMount.js
@@ -200,7 +200,7 @@ function findDeepestCachedAncestor(targetID) {
  *   );
  *
  *   <div id="container">                   <-- Supplied `container`.
- *     <div data-reactid=".r[3]">           <-- Rendered reactRoot of React
+ *     <div data-reactid=".3">              <-- Rendered reactRoot of React
  *       // ...                                 component.
  *     </div>
  *   </div>

--- a/src/core/__tests__/ReactEventEmitter-test.js
+++ b/src/core/__tests__/ReactEventEmitter-test.js
@@ -78,9 +78,9 @@ var ON_CHANGE_KEY = keyOf({onChange: null});
 var CHILD = document.createElement('div');
 var PARENT = document.createElement('div');
 var GRANDPARENT = document.createElement('div');
-setID(CHILD, '.reactRoot.[0].[0].[0]');
-setID(PARENT, '.reactRoot.[0].[0]');
-setID(GRANDPARENT, '.reactRoot.[0]');
+setID(CHILD, '.0.0.0.0');
+setID(PARENT, '.0.0.0');
+setID(GRANDPARENT, '.0.0');
 
 function registerSimpleTestHandler() {
   ReactEventEmitter.putListener(getID(CHILD), ON_CLICK_KEY, LISTENER);

--- a/src/core/__tests__/ReactInstanceHandles-test.js
+++ b/src/core/__tests__/ReactInstanceHandles-test.js
@@ -91,9 +91,9 @@ describe('ReactInstanceHandles', function() {
       parentNode.appendChild(childNodeA);
       parentNode.appendChild(childNodeB);
 
-      ReactMount.setID(parentNode, '.react[0]');
-      ReactMount.setID(childNodeA, '.react[0].0');
-      ReactMount.setID(childNodeB, '.react[0].0:1');
+      ReactMount.setID(parentNode, '.0');
+      ReactMount.setID(childNodeA, '.0.0');
+      ReactMount.setID(childNodeB, '.0.0:1');
 
       expect(
         ReactMount.findComponentRoot(
@@ -110,9 +110,9 @@ describe('ReactInstanceHandles', function() {
       parentNode.appendChild(childNodeA);
       parentNode.appendChild(childNodeB);
 
-      ReactMount.setID(parentNode, '.react[0]');
+      ReactMount.setID(parentNode, '.0');
       // No ID on `childNodeA`.
-      ReactMount.setID(childNodeB, '.react[0].0:1');
+      ReactMount.setID(childNodeB, '.0.0:1');
 
       expect(
         ReactMount.findComponentRoot(
@@ -129,9 +129,9 @@ describe('ReactInstanceHandles', function() {
       parentNode.appendChild(childNodeA);
       childNodeA.appendChild(childNodeB);
 
-      ReactMount.setID(parentNode, '.react[0]');
+      ReactMount.setID(parentNode, '.0');
       // No ID on `childNodeA`, it was "rendered by the browser".
-      ReactMount.setID(childNodeB, '.react[0].1:0');
+      ReactMount.setID(childNodeB, '.0.1:0');
 
       expect(ReactMount.findComponentRoot(
         parentNode,
@@ -144,10 +144,10 @@ describe('ReactInstanceHandles', function() {
           ReactMount.getID(childNodeB) + ":junk"
         );
       }).toThrow(
-        'Invariant Violation: findComponentRoot(..., .react[0].1:0:junk): ' +
+        'Invariant Violation: findComponentRoot(..., .0.1:0:junk): ' +
         'Unable to find element. This probably means the DOM was ' +
         'unexpectedly mutated (e.g., by the browser). Try inspecting the ' +
-        'child nodes of the element with React ID `.react[0]`.'
+        'child nodes of the element with React ID `.0`.'
       );
     });
   });

--- a/src/core/__tests__/ReactMultiChildReconcile-test.js
+++ b/src/core/__tests__/ReactMultiChildReconcile-test.js
@@ -42,7 +42,7 @@ var stripEmptyValues = function(obj) {
 };
 
 /**
- * Child key names are wrapped like '{key}[0]'. We strip the extra chars out
+ * Child key names are wrapped like '.$key:0'. We strip the extra chars out
  * here. This relies on an implementation detail of the rendering system.
  */
 var getOriginalKey = function(childName) {

--- a/src/eventPlugins/__tests__/ResponderEventPlugin-test.js
+++ b/src/eventPlugins/__tests__/ResponderEventPlugin-test.js
@@ -25,9 +25,9 @@ var ReactInstanceHandles;
 var ResponderEventPlugin;
 var SyntheticEvent;
 
-var GRANDPARENT_ID = '.r[0]';
-var PARENT_ID = '.r[0].0';
-var CHILD_ID = '.r[0].0.0';
+var GRANDPARENT_ID = '.0';
+var PARENT_ID = '.0.0';
+var CHILD_ID = '.0.0.0';
 
 var topLevelTypes;
 var responderEventTypes;

--- a/src/test/ReactDefaultPerf.js
+++ b/src/test/ReactDefaultPerf.js
@@ -59,7 +59,7 @@ if (__DEV__) {
      * Runs through the logs and builds an array of arrays, where each array
      * walks through the mounting/updating of each component underneath.
      *
-     * @param {string} rootID The reactID of the root node, e.g. '.r[2cpyq]'
+     * @param {string} rootID The reactID of the root node, e.g. '.0'
      * @return {array<array>}
      */
     getRawRenderHistory: function(rootID) {
@@ -94,7 +94,7 @@ if (__DEV__) {
      * is a multiline formatted way of walking through the mounting/updating
      * underneath.
      *
-     * @param {string} rootID The reactID of the root node, e.g. '.r[2cpyq]'
+     * @param {string} rootID The reactID of the root node, e.g. '.0'
      * @return {array<string>}
      */
     getRenderHistory: function(rootID) {
@@ -107,7 +107,7 @@ if (__DEV__) {
         );
         return headerString + subHistory.map(function(log) {
           // Add two spaces for every layer in the reactID.
-          var indents = '\t' + Array(log.reactID.split('.[').length).join('  ');
+          var indents = '\t' + Array(log.reactID.split('.').length).join('  ');
           var delta = _microTime(log.timing.delta);
           var bloat = _microTime(log.timing.timeToLog);
 
@@ -122,7 +122,7 @@ if (__DEV__) {
      * This is currently the best way to display perf data from
      * any React component; working on that.
      *
-     * @param {string} rootID The reactID of the root node, e.g. '.r[2cpyq]'
+     * @param {string} rootID The reactID of the root node, e.g. '.0'
      * @param {number} index
      */
     printRenderHistory: function(rootID, index) {


### PR DESCRIPTION
No one must find out :)

Thanks for @plievone for pointing it out, https://github.com/facebook/react/pull/934
