### PR TITLE
Upgrade Commoner to v0.9.0 to get rid of output directory locking

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/facebook/react"
   },
   "dependencies": {
-    "commoner": "~0.8.14",
+    "commoner": "~0.9.0",
     "esprima-fb": "~2001.1001.0-dev-harmony-fb",
     "jstransform": "~2.0.2"
   },


### PR DESCRIPTION
Closes #957.
