### PR TITLE
Remove references to react-page

### DIFF
--- a/docs/docs/08-tooling-integration.md
+++ b/docs/docs/08-tooling-integration.md
@@ -55,7 +55,3 @@ The open-source community has built tools that integrate JSX with several build 
     that support `*.tmLanguage`.
 * Linting provides accurate line numbers after compiling without sourcemaps.
 * Elements use standard scoping so linters can find usage of out-of-scope components.
-
-## React Page
-
-To get started on a new project, you can use [react-page](https://github.com/facebook/react-page/), a complete React project creator. It supports both server-side and client-side rendering, source transform and packaging JSX files using CommonJS modules, and instant reload.

--- a/docs/docs/10-examples.md
+++ b/docs/docs/10-examples.md
@@ -17,6 +17,5 @@ prev: class-name-manipulation.html
 
 * We've included [a step-by-step comment box tutorial](/react/docs/tutorial.html).
 * [The React starter kit](/react/downloads.html) includes several examples which you can [view online in our GitHub repository](https://github.com/facebook/react/tree/master/examples/).
-* [React Page](https://github.com/facebook/react-page) is a simple React project creator to get you up-and-running quickly with React. It supports both server-side and client-side rendering, source transform and packaging JSX files using CommonJS modules, and instant reload.
 * [React one-hour email](https://github.com/petehunt/react-one-hour-email/commits/master) goes step-by-step from a static HTML mock to an interactive email reader (written in just one hour!)
 * [Rendr + React app template](https://github.com/petehunt/rendr-react-template/) demonstrates how to use React's server rendering capabilities.


### PR DESCRIPTION
I don't think we're going to have bandwidth to support this project. Let's start by no longer recommending it to people.
