### PR TITLE
Add warning about object property order.

### DIFF
--- a/docs/docs/04-multiple-components.md
+++ b/docs/docs/04-multiple-components.md
@@ -134,6 +134,25 @@ The situation gets more complicated when the children are shuffled around (as in
 
 When React reconciles the keyed children, it will ensure that any child with `key` will be reordered (instead of clobbered) or destroyed (instead of reused).
 
+Keys can also be specified as object properties. However it is important to remember that JavaScript does not guarantee the ordering of properties will be preserved. In practice browsers will preserve property order **except** for properties that can be parsed as a 32-bit unsigned integers. Numeric properties will be ordered sequentially and before other properties. If this happens React will render components out of order. This can be avoided by adding a string prefix to the key:
+
+```javascript
+  render: function() {
+    var items = {};
+    
+    this.props.results.forEach(function(result) {
+      // Using the numeric 'id' value as a key would result non-deterministic ordering
+      // of results.
+      items['result-' + result.id] = <li>{result.text}</li>;
+    });
+    
+    return (
+      <ol>
+        {items}
+      </ol>
+    );
+  }
+```
 
 ## Data Flow
 


### PR DESCRIPTION
It's easy to misuse the properties-as-keys feature and end up with children rendered out of order. Add a note and example of how to avoid this.
