### PR TITLE
Add PropTypes.ArrayOf and clean up ReactPropTypes.js

### DIFF
--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -37,6 +37,9 @@ React.createClass({
     // it as an enum.
     optionalEnum: React.PropTypes.oneOf(['News','Photos']),
 
+    // Expect an array of a certain propType
+    optionalArrayOf: React.PropTypes.arrayOf(React.PropTypes.number)
+
     // You can also declare that a prop is an instance of a class. This uses
     // JS's instanceof operator.
     someClass: React.PropTypes.instanceOf(SomeClass),


### PR DESCRIPTION
React.PropTypes.arrayOf can be super useful to describe a propType that should be an arrayOf(Thing).

I modified some of the PropTypes code to make it a little easier to understand and all validators now return a value.
