### PR TITLE
Set isInTransaction to false even if close throws

### DIFF
--- a/src/utils/Transaction.js
+++ b/src/utils/Transaction.js
@@ -161,19 +161,22 @@ var Mixin = {
     } finally {
       var memberEnd = Date.now();
       this.methodInvocationTime += (memberEnd - memberStart);
-      if (errorThrown) {
-        // If `method` throws, prefer to show that stack trace over any thrown
-        // by invoking `closeAll`.
-        try {
+      try {
+        if (errorThrown) {
+          // If `method` throws, prefer to show that stack trace over any thrown
+          // by invoking `closeAll`.
+          try {
+            this.closeAll(0);
+          } catch (err) {
+          }
+        } else {
+          // Since `method` didn't throw, we don't want to silence the exception
+          // here.
           this.closeAll(0);
-        } catch (err) {
         }
-      } else {
-        // Since `method` didn't throw, we don't want to silence the exception
-        // here.
-        this.closeAll(0);
+      } finally {
+        this._isInTransaction = false;
       }
-      this._isInTransaction = false;
     }
     return ret;
   },

--- a/src/utils/__tests__/Transaction-test.js
+++ b/src/utils/__tests__/Transaction-test.js
@@ -243,6 +243,7 @@ describe('Transaction', function() {
     expect(function() {
       transaction.perform(function() {});
     }).toThrow(exceptionMsg);
+    expect(transaction.isInTransaction()).toBe(false);
   });
 
   it('should allow nesting of transactions', function() {


### PR DESCRIPTION
If a transaction wrapper's closer throws (such as flushBatchedUpdates in ReactDefaultBatchingStrategy) then we still want to properly deinitialize the transaction by setting isInTransaction to false. Without this, we can't reuse the transaction object (in this case, all future batched updates would fail because nested transactions aren't allowed).
