### PR TITLE
build npm-react module, upload to builds page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ after_script:
         -F "transformer=@build/JSXTransformer.js" \
         -F "react-with-addons=@build/react-with-addons.js" \
         -F "react-with-addons.min=@build/react-with-addons.min.js" \
+        -f "npm-react=@build/react.tgz" \
         -F "commit=$TRAVIS_COMMIT" \
         -F "date=`git log --format='%ct' -1`" \
         -F "pull_request=$TRAVIS_PULL_REQUEST" \

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,6 +65,7 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('npm', npmTask);
 
   grunt.registerTask('npm-react:release', npmReactTasks.buildRelease);
+  grunt.registerTask('npm-react:pack', npmReactTasks.packRelease);
 
   grunt.registerTask('version-check', versionCheckTask);
 
@@ -193,6 +194,7 @@ module.exports = function(grunt) {
     'browserify:min',
     'browserify:addonsMin',
     'npm-react:release',
+    'npm-react:pack',
     'copy:react_docs',
     'compare_size'
   ]);

--- a/grunt/tasks/npm-react.js
+++ b/grunt/tasks/npm-react.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var fs = require('fs');
 var grunt = require('grunt');
 
 var src = 'npm-react/';
@@ -36,11 +37,23 @@ function buildRelease() {
   grunt.file.write(dest + 'package.json', JSON.stringify(pkg, null, 2));
 }
 
-function buildDev() {
-  // TODO: same as above except different destination
+function packRelease() {
+  var done = this.async();
+  var spawnCmd = {
+    cmd: 'npm',
+    args: ['pack', 'npm-react'],
+    opts: {
+      cwd: 'build/'
+    }
+  };
+  grunt.util.spawn(spawnCmd, function() {
+    var src = 'build/react-' + grunt.config.data.pkg.version + '.tgz'
+    var dest = 'build/react.tgz';
+    fs.rename(src, dest, done);
+  });
 }
 
 module.exports = {
   buildRelease: buildRelease,
-  buildDev: buildDev
+  packRelease: packRelease
 };


### PR DESCRIPTION
I'm not actually sure if the Travis part of this works, but the rest does!

About the version in the file name... it might make sense to rename the file and strip that out so you could always access the package at the same url and not need to know the version.

Next up is to do this with `react-tools` too.
