### PR TITLE
Update broken link in "Why React" post

### DIFF
--- a/docs/_posts/2013-06-05-why-react.md
+++ b/docs/_posts/2013-06-05-why-react.md
@@ -41,7 +41,7 @@ React really shines when your data changes over time.
 In a traditional JavaScript application, you need to look at what data changed
 and imperatively make changes to the DOM to keep it up-to-date. Even AngularJS,
 which provides a declarative interface via directives and data binding [requires
-a linking function to manually update DOM nodes](http://docs.angularjs.org/guide/directive#reasonsbehindthecompilelinkseparation).
+a linking function to manually update DOM nodes](http://code.angularjs.org/1.0.8/docs/guide/directive#reasonsbehindthecompilelinkseparation).
 
 React takes a different approach.
 


### PR DESCRIPTION
The AngularJS docs have been updated since the post was originally published.

It should point to the docs from that date (June 5th).
