### PR TITLE
set className with setAttribute for SVG compat

### DIFF
--- a/src/browser/dom/DefaultDOMPropertyConfig.js
+++ b/src/browser/dom/DefaultDOMPropertyConfig.js
@@ -187,7 +187,7 @@ var DefaultDOMPropertyConfig = {
      * @param {*} value
      */
     className: function(node, value) {
-      node.className = value || '';
+      node.setAttribute('class', value || '');
     }
   }
 };


### PR DESCRIPTION
Fixes SVG bug where changes to the className prop are not changed in the svg element.
