### PR TITLE
Sync out transforms from fb internal

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   },
   "dependencies": {
     "commoner": "~0.9.0",
-    "esprima-fb": "~2001.1001.0-dev-harmony-fb",
-    "jstransform": "~2.0.2"
+    "esprima-fb": "~3001.1.0-dev-harmony-fb",
+    "jstransform": "~3.0.0"
   },
   "devDependencies": {
     "benchmark": "~1.0.0",

--- a/vendor/fbtransform/transforms/reactDisplayName.js
+++ b/vendor/fbtransform/transforms/reactDisplayName.js
@@ -102,4 +102,6 @@ visitReactDisplayName.test = function(object, path, state) {
   }
 };
 
-exports.visitReactDisplayName = visitReactDisplayName;
+exports.visitorList = [
+  visitReactDisplayName
+];

--- a/vendor/fbtransform/transforms/xjs.js
+++ b/vendor/fbtransform/transforms/xjs.js
@@ -151,27 +151,27 @@ var knownTags = {
 
 function renderXJSLiteral(object, isLast, state, start, end) {
   var lines = object.value.split(/\r\n|\n|\r/);
-  
+
   if (start) {
     utils.append(start, state);
   }
-  
+
   var lastNonEmptyLine = 0;
-  
+
   lines.forEach(function (line, index) {
     if (line.match(/[^ \t]/)) {
       lastNonEmptyLine = index;
     }
   });
-  
+
   lines.forEach(function (line, index) {
     var isFirstLine = index === 0;
     var isLastLine = index === lines.length - 1;
     var isLastNonEmptyLine = index === lastNonEmptyLine;
-    
+
     // replace rendered whitespace tabs with spaces
     var trimmedLine = line.replace(/\t/g, ' ');
-    
+
     // trim whitespace touching a newline
     if (!isFirstLine) {
       trimmedLine = trimmedLine.replace(/^[ ]+/, '');
@@ -179,15 +179,15 @@ function renderXJSLiteral(object, isLast, state, start, end) {
     if (!isLastLine) {
       trimmedLine = trimmedLine.replace(/[ ]+$/, '');
     }
-    
+
     utils.append(line.match(/^[ \t]*/)[0], state);
-    
+
     if (trimmedLine || isLastNonEmptyLine) {
       utils.append(
         JSON.stringify(trimmedLine) +
         (!isLastNonEmptyLine ? "+' '+" : ''),
         state);
-      
+
       if (isLastNonEmptyLine) {
         if (end) {
           utils.append(end, state);
@@ -196,18 +196,18 @@ function renderXJSLiteral(object, isLast, state, start, end) {
           utils.append(',', state);
         }
       }
-      
+
       // only restore tail whitespace if line had literals
       if (trimmedLine) {
         utils.append(line.match(/[ \t]*$/)[0], state);
       }
     }
-    
+
     if (!isLastLine) {
       utils.append('\n', state);
     }
   });
-  
+
   utils.move(object.range[1], state);
 }
 

--- a/vendor/fbtransform/visitors.js
+++ b/vendor/fbtransform/visitors.js
@@ -16,10 +16,7 @@ var transformVisitors = {
   'es6-object-short-notation': es6ObjectShortNotation.visitorList,
   'es6-rest-params': es6RestParameters.visitorList,
   'es6-templates': es6Templates.visitorList,
-  'react': [
-    react.visitReactTag,
-    reactDisplayName.visitReactDisplayName
-  ]
+  'react': react.visitorList.concat(reactDisplayName.visitorList)
 };
 
 /**


### PR DESCRIPTION
This syncs all of our internal transforms out to react master + updates esprima-fb to the latest compatible version.

It also updates jstransform to it's latest version (so that only one version of esprima-fb is needed rather than two)
