### PR TITLE
Run es3ify over unminified builds

### DIFF
--- a/grunt/config/browserify.js
+++ b/grunt/config/browserify.js
@@ -4,6 +4,7 @@
 'use strict';
 
 var envify = require('envify/custom');
+var es3ify = require('es3ify');
 var grunt = require('grunt');
 var UglifyJS = require('uglify-js');
 var uglifyify = require('uglifyify');
@@ -63,7 +64,7 @@ var basic = {
   debug: false,
   standalone: 'React',
   transforms: [envify({NODE_ENV: 'development'})],
-  after: [simpleBannerify]
+  after: [es3ify.transform, simpleBannerify]
 };
 
 var min = _.merge({}, basic, {
@@ -80,7 +81,7 @@ var transformer = {
   outfile: './build/JSXTransformer.js',
   debug: false,
   standalone: 'JSXTransformer',
-  after: [simpleBannerify]
+  after: [es3ify.transform, simpleBannerify]
 };
 
 var addons = {
@@ -92,7 +93,7 @@ var addons = {
   standalone: 'React',
   transforms: [envify({NODE_ENV: 'development'})],
   packageName: 'React (with addons)',
-  after: [simpleBannerify]
+  after: [es3ify.transform, simpleBannerify]
 };
 
 var addonsMin = _.merge({}, addons, {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "browserify": "~3.20.0",
     "coverify": "~1.0.4",
     "envify": "~1.0.1",
+    "es3ify": "~0.1.2",
     "es5-shim": "~2.3.0",
     "grunt": "~0.4.2",
     "grunt-cli": "~0.1.9",


### PR DESCRIPTION
Makes no difference to react.js and react-with-addons.js; quotes `.static` in four places for JSXTransformer.js:

https://gist.github.com/spicyj/aada5352e813752a4667
