### PR TITLE
Make ReactWebWorker-test.js less flaky

### DIFF
--- a/src/browser/__tests__/ReactWebWorker-test.js
+++ b/src/browser/__tests__/ReactWebWorker-test.js
@@ -31,6 +31,7 @@ describe('ReactWebWorker', function() {
       var data = JSON.parse(e.data);
       if (data.type == 'error') {
         error = data.message + "\n" + data.stack;
+        done = true;
       } else if (data.type == 'log') {
         console.log(data.message);
       } else {
@@ -41,7 +42,8 @@ describe('ReactWebWorker', function() {
 
     waitsFor(function() {
       return done;
-    });
+    }, "the final message to arrive from the worker", 2e4);
+
     runs(function() {
       if (error) {
         console.error(error);


### PR DESCRIPTION
This test has been causing roughly half of our builds to fail recently, even though nothing is actually broken.

Two improvements: make sure we set `done = true` when an error message is received, so that the test output contains the error message instead of eventually timing out and displaying nothing useful; and increase the timeout for this particular test from 5000ms (the default) to 20000ms.
