### PR TITLE
Add support for `npm test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,8 @@
   "preferGlobal": true,
   "commonerConfig": {
     "version": 4
+  },
+  "scripts": {
+    "test": "./node_modules/.bin/grunt test"
   }
 }


### PR DESCRIPTION
I already have npm installed [globally] on my system...it's annoying that I have to install something else just for react in order to run react tests.

Of course I could just do `node_modules/.bin/grunt test` -- but that's long and there's an alternative to all of this: `npm test`

This effectively aliases `npm test` to `grunt test` to make react's repo at least pretend to be more like most other repos on npm.
