### PR TITLE
incorrect include in css transition group example?

### DIFF
--- a/docs/docs/09.1-animation.md
+++ b/docs/docs/09.1-animation.md
@@ -20,7 +20,7 @@ React provides a `ReactTransitionGroup` addon component as a low-level API for a
 ```javascript{22-24}
 /** @jsx React.DOM */
 
-var ReactCSSTransitionGroup = React.addons.TransitionGroup;
+var ReactCSSTransitionGroup = React.addons.CSSTransitionGroup;
 
 var TodoList = React.createClass({
   getInitialState: function() {


### PR DESCRIPTION
TransitionGroup maps to ReactTransitionGroup, shouldn't it be a ReactCSSTransitionGroup?
