### PR TITLE
Tie MultiChild queue to ReactReconcileTransaction

### DIFF
--- a/src/browser/ui/ReactDOMComponent.js
+++ b/src/browser/ui/ReactDOMComponent.js
@@ -377,12 +377,12 @@ ReactDOMComponent.Mixin = {
     if (lastChildren != null && nextChildren == null) {
       this.updateChildren(null, transaction);
     } else if (lastHasContentOrHtml && !nextHasContentOrHtml) {
-      this.updateTextContent('');
+      this.updateTextContent('', transaction);
     }
 
     if (nextContent != null) {
       if (lastContent !== nextContent) {
-        this.updateTextContent('' + nextContent);
+        this.updateTextContent('' + nextContent, transaction);
       }
     } else if (nextHtml != null) {
       if (lastHtml !== nextHtml) {

--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -157,6 +157,7 @@ describe('ReactDOMComponent', function() {
 
       expect(stub.getDOMNode().innerHTML).toEqual(':)');
       stub.receiveComponent({props: {}}, transaction);
+      transaction.getMultiChildUpdateQueue().processUpdates();
       expect(stub.getDOMNode().innerHTML).toEqual('');
     });
 
@@ -180,6 +181,7 @@ describe('ReactDOMComponent', function() {
 
       expect(stub.getDOMNode().innerHTML).toEqual('bonjour');
       stub.receiveComponent({props: {children: 'adieu'}}, transaction);
+      transaction.getMultiChildUpdateQueue().processUpdates();
       expect(stub.getDOMNode().innerHTML).toEqual('adieu');
     });
 

--- a/src/core/ReactMultiChildUpdateQueue.js
+++ b/src/core/ReactMultiChildUpdateQueue.js
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2013-2014 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @providesModule ReactMultiChildUpdateQueue
+ */
+
+"use strict";
+
+var PooledClass = require('PooledClass');
+var ReactComponent = require('ReactComponent');
+var ReactMultiChildUpdateTypes = require('ReactMultiChildUpdateTypes');
+
+var mixInto = require('mixInto');
+
+function ReactMultiChildUpdateQueue() {
+  /**
+   * Queue of update configuration objects.
+   *
+   * Each object has a `type` property that is in `ReactMultiChildUpdateTypes`.
+   *
+   * @type {array<object>}
+   * @private
+   */
+  this.updateQueue = [];
+
+  /**
+   * Queue of markup to be rendered.
+   *
+   * @type {array<string>}
+   * @private
+   */
+  this.markupQueue = [];
+}
+
+mixInto(ReactMultiChildUpdateQueue, {
+  /**
+   * Enqueues markup to be rendered and inserted at a supplied index.
+   *
+   * @param {string} parentID ID of the parent component.
+   * @param {string} markup Markup that renders into an element.
+   * @param {number} toIndex Destination index.
+   * @private
+   */
+  enqueueMarkup: function(parentID, markup, toIndex) {
+    // NOTE: Null values reduce hidden classes.
+    this.updateQueue.push({
+      parentID: parentID,
+      parentNode: null,
+      type: ReactMultiChildUpdateTypes.INSERT_MARKUP,
+      markupIndex: this.markupQueue.push(markup) - 1,
+      textContent: null,
+      fromIndex: null,
+      toIndex: toIndex
+    });
+  },
+
+  /**
+   * Enqueues moving an existing element to another index.
+   *
+   * @param {string} parentID ID of the parent component.
+   * @param {number} fromIndex Source index of the existing element.
+   * @param {number} toIndex Destination index of the element.
+   * @private
+   */
+  enqueueMove: function(parentID, fromIndex, toIndex) {
+    // NOTE: Null values reduce hidden classes.
+    this.updateQueue.push({
+      parentID: parentID,
+      parentNode: null,
+      type: ReactMultiChildUpdateTypes.MOVE_EXISTING,
+      markupIndex: null,
+      textContent: null,
+      fromIndex: fromIndex,
+      toIndex: toIndex
+    });
+  },
+
+  /**
+   * Enqueues removing an element at an index.
+   *
+   * @param {string} parentID ID of the parent component.
+   * @param {number} fromIndex Index of the element to remove.
+   * @private
+   */
+  enqueueRemove: function(parentID, fromIndex) {
+    // NOTE: Null values reduce hidden classes.
+    this.updateQueue.push({
+      parentID: parentID,
+      parentNode: null,
+      type: ReactMultiChildUpdateTypes.REMOVE_NODE,
+      markupIndex: null,
+      textContent: null,
+      fromIndex: fromIndex,
+      toIndex: null
+    });
+  },
+
+  /**
+   * Enqueues setting the text content.
+   *
+   * @param {string} parentID ID of the parent component.
+   * @param {string} textContent Text content to set.
+   * @private
+   */
+  enqueueTextContent: function(parentID, textContent) {
+    // NOTE: Null values reduce hidden classes.
+    this.updateQueue.push({
+      parentID: parentID,
+      parentNode: null,
+      type: ReactMultiChildUpdateTypes.TEXT_CONTENT,
+      markupIndex: null,
+      textContent: textContent,
+      fromIndex: null,
+      toIndex: null
+    });
+  },
+
+  /**
+   * Processes any enqueued updates.
+   *
+   * @private
+   */
+  processUpdates: function() {
+    if (this.updateQueue.length) {
+      ReactComponent.BackendIDOperations.dangerouslyProcessChildrenUpdates(
+        this.updateQueue,
+        this.markupQueue
+      );
+      this.reset();
+    }
+  },
+
+  reset: function() {
+    this.updateQueue.length = 0;
+    this.markupQueue.length = 0;
+  },
+
+  destructor: function() {
+    this.reset();
+  }
+});
+
+PooledClass.addPoolingTo(ReactMultiChildUpdateQueue);
+
+module.exports = ReactMultiChildUpdateQueue;


### PR DESCRIPTION
Fixes #1147.

This now forces all DOM operations for a subtree to be applied when the calling `setState` or `React.renderComponent` call returns (when updates aren't being batched). This means that we can't batch innerHTML setting across different component hierarchies, but our strategy for doing so before seems flawed. It could be possible to make the old way work but it would require making setState always async even when batching isn't in play and refactoring DOMChildrenOperations to not be confused by multiple updates to the same node.

Still need to add tests. Not sure this is exactly what we want to do but I think it agrees more with what we've been doing.