### PR TITLE
Enable rendering into shadow roots

### DIFF
--- a/src/browser/ReactComponentBrowserEnvironment.js
+++ b/src/browser/ReactComponentBrowserEnvironment.js
@@ -32,6 +32,7 @@ var invariant = require('invariant');
 
 var ELEMENT_NODE_TYPE = 1;
 var DOC_NODE_TYPE = 9;
+var SHADOW_ROOT_NODE_TYPE = 11;
 
 
 /**
@@ -67,7 +68,8 @@ var ReactComponentBrowserEnvironment = {
       invariant(
         container && (
           container.nodeType === ELEMENT_NODE_TYPE ||
-            container.nodeType === DOC_NODE_TYPE
+            container.nodeType === DOC_NODE_TYPE ||
+            container.nodeType === SHADOW_ROOT_NODE_TYPE
         ),
         'mountComponentIntoNode(...): Target container is not valid.'
       );

--- a/src/browser/ReactComponentBrowserEnvironment.js
+++ b/src/browser/ReactComponentBrowserEnvironment.js
@@ -20,6 +20,7 @@
 
 "use strict";
 
+var DOMNodeTypes = require('DOMNodeTypes');
 var ReactDOMIDOperations = require('ReactDOMIDOperations');
 var ReactMarkupChecksum = require('ReactMarkupChecksum');
 var ReactMount = require('ReactMount');
@@ -28,11 +29,6 @@ var ReactReconcileTransaction = require('ReactReconcileTransaction');
 
 var getReactRootElementInContainer = require('getReactRootElementInContainer');
 var invariant = require('invariant');
-
-
-var ELEMENT_NODE_TYPE = 1;
-var DOC_NODE_TYPE = 9;
-var SHADOW_ROOT_NODE_TYPE = 11;
 
 
 /**
@@ -67,9 +63,9 @@ var ReactComponentBrowserEnvironment = {
     function(markup, container, shouldReuseMarkup) {
       invariant(
         container && (
-          container.nodeType === ELEMENT_NODE_TYPE ||
-            container.nodeType === DOC_NODE_TYPE ||
-            container.nodeType === SHADOW_ROOT_NODE_TYPE
+          container.nodeType === DOMNodeTypes.ELEMENT ||
+            container.nodeType === DOMNodeTypes.DOC ||
+            container.nodeType === DOMNodeTypes.SHADOW_ROOT
         ),
         'mountComponentIntoNode(...): Target container is not valid.'
       );
@@ -81,7 +77,7 @@ var ReactComponentBrowserEnvironment = {
           return;
         } else {
           invariant(
-            container.nodeType !== DOC_NODE_TYPE,
+            container.nodeType !== DOMNodeTypes.DOC,
             'You\'re trying to render a component to the document using ' +
             'server rendering but the checksum was invalid. This usually ' +
             'means you rendered a different component type or props on ' +
@@ -108,7 +104,7 @@ var ReactComponentBrowserEnvironment = {
       }
 
       invariant(
-        container.nodeType !== DOC_NODE_TYPE,
+        container.nodeType !== DOMNodeTypes.DOC,
         'You\'re trying to render a component to the document but ' +
           'you didn\'t use server rendering. We can\'t do this ' +
           'without using server rendering due to cross-browser quirks. ' +

--- a/src/browser/ReactDOMComponent.js
+++ b/src/browser/ReactDOMComponent.js
@@ -20,6 +20,7 @@
 "use strict";
 
 var CSSPropertyOperations = require('CSSPropertyOperations');
+var DOMNodeTypes = require('DOMNodeTypes');
 var DOMProperty = require('DOMProperty');
 var DOMPropertyOperations = require('DOMPropertyOperations');
 var ReactBrowserComponentMixin = require('ReactBrowserComponentMixin');
@@ -44,8 +45,6 @@ var CONTENT_TYPES = {'string': true, 'number': true};
 
 var STYLE = keyOf({style: null});
 
-var ELEMENT_NODE_TYPE = 1;
-
 /**
  * @param {?object} props
  */
@@ -68,7 +67,7 @@ function assertValidProps(props) {
 function putListener(id, registrationName, listener, transaction) {
   var container = ReactMount.findReactContainerForID(id);
   if (container) {
-    var doc = container.nodeType === ELEMENT_NODE_TYPE ?
+    var doc = container.nodeType === DOMNodeTypes.ELEMENT ?
       container.ownerDocument :
       container;
     listenTo(registrationName, doc);

--- a/src/browser/ReactMount.js
+++ b/src/browser/ReactMount.js
@@ -18,6 +18,7 @@
 
 "use strict";
 
+var DOMNodeTypes = require('DOMNodeTypes');
 var DOMProperty = require('DOMProperty');
 var ReactEventEmitter = require('ReactEventEmitter');
 var ReactInstanceHandles = require('ReactInstanceHandles');
@@ -32,10 +33,6 @@ var SEPARATOR = ReactInstanceHandles.SEPARATOR;
 
 var ATTR_NAME = DOMProperty.ID_ATTRIBUTE_NAME;
 var nodeCache = {};
-
-var ELEMENT_NODE_TYPE = 1;
-var DOC_NODE_TYPE = 9;
-var SHADOW_ROOT_NODE_TYPE = 11;
 
 /** Mapping from reactRootID to React component instance. */
 var instancesByReactRootID = {};
@@ -270,9 +267,9 @@ var ReactMount = {
   _registerComponent: function(nextComponent, container) {
     invariant(
       container && (
-        container.nodeType === ELEMENT_NODE_TYPE ||
-        container.nodeType === DOC_NODE_TYPE ||
-        container.nodeType === SHADOW_ROOT_NODE_TYPE
+        container.nodeType === DOMNodeTypes.ELEMENT ||
+        container.nodeType === DOMNodeTypes.DOC ||
+        container.nodeType === DOMNodeTypes.SHADOW_ROOT
       ),
       '_registerComponent(...): Target container is not a DOM element.'
     );
@@ -446,7 +443,7 @@ var ReactMount = {
   unmountComponentFromNode: function(instance, container) {
     instance.unmountComponent();
 
-    if (container.nodeType === DOC_NODE_TYPE) {
+    if (container.nodeType === DOMNodeTypes.DOC) {
       container = container.documentElement;
     }
 

--- a/src/browser/ReactMount.js
+++ b/src/browser/ReactMount.js
@@ -35,6 +35,7 @@ var nodeCache = {};
 
 var ELEMENT_NODE_TYPE = 1;
 var DOC_NODE_TYPE = 9;
+var SHADOW_ROOT_NODE_TYPE = 11;
 
 /** Mapping from reactRootID to React component instance. */
 var instancesByReactRootID = {};
@@ -270,7 +271,8 @@ var ReactMount = {
     invariant(
       container && (
         container.nodeType === ELEMENT_NODE_TYPE ||
-        container.nodeType === DOC_NODE_TYPE
+        container.nodeType === DOC_NODE_TYPE ||
+        container.nodeType === SHADOW_ROOT_NODE_TYPE
       ),
       '_registerComponent(...): Target container is not a DOM element.'
     );

--- a/src/browser/dom/DOMNodeTypes.js
+++ b/src/browser/dom/DOMNodeTypes.js
@@ -13,28 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @providesModule getReactRootElementInContainer
+ * @providesModule DOMNodeTypes
+ * @typechecks static-only
  */
+
+/*jslint evil: true */
 
 "use strict";
 
-var DOMNodeTypes = require('DOMNodeTypes');
-
 /**
- * @param {DOMElement|DOMDocument} container DOM element that may contain
- *                                           a React component
- * @return {?*} DOM element that may have the reactRoot ID, or null.
+ * A collection of `nodeType` values.
+ *
+ * @type {object}
+ * @internal
  */
-function getReactRootElementInContainer(container) {
-  if (!container) {
-    return null;
-  }
+var DOMNodeTypes = {
+  ELEMENT: 1,
+  DOC: 9,
+  SHADOW_ROOT: 11
+};
 
-  if (container.nodeType === DOMNodeTypes.DOC) {
-    return container.documentElement;
-  } else {
-    return container.firstChild;
-  }
-}
-
-module.exports = getReactRootElementInContainer;
+module.exports = DOMNodeTypes;

--- a/src/browser/putDOMComponentListener.js
+++ b/src/browser/putDOMComponentListener.js
@@ -18,17 +18,16 @@
 
 "use strict";
 
+var DOMNodeTypes = require('DOMNodeTypes');
 var ReactEventEmitter = require('ReactEventEmitter');
 var ReactMount = require('ReactMount');
 
 var listenTo = ReactEventEmitter.listenTo;
 
-var ELEMENT_NODE_TYPE = 1;
-
 function putDOMComponentListener(id, registrationName, listener) {
   var container = ReactMount.findReactContainerForID(id);
   if (container) {
-    var doc = container.nodeType === ELEMENT_NODE_TYPE ?
+    var doc = container.nodeType === DOMNodeTypes.ELEMENT ?
       container.ownerDocument :
       container;
     listenTo(registrationName, doc);


### PR DESCRIPTION
This adds the shadow root `nodeType` to the list of node types that can be rendered into.

I have completed the CLA.

Please let me know if I left anything out!