### PR TITLE
Test that Node is a function before using instanceof on it

### DIFF
--- a/src/vendor/core/dom/isNode.js
+++ b/src/vendor/core/dom/isNode.js
@@ -23,7 +23,7 @@
  */
 function isNode(object) {
   return !!(object && (
-    typeof Node !== 'undefined' ? object instanceof Node :
+    typeof Node === 'function' ? object instanceof Node :
       typeof object === 'object' &&
       typeof object.nodeType === 'number' &&
       typeof object.nodeName === 'string'


### PR DESCRIPTION
We use React on a page that also uses the [Sarissa](http://dev.abiss.gr/sarissa/) library (as part of [RichFaces](http://www.jboss.org/richfaces)). This library defines [its own `Node` object](http://sarissa.cvs.sf.net/viewvc/sarissa/sarissa/src/main/js/gr/abiss/js/sarissa/sarissa.js?revision=1.31&view=markup#l69) if the browser doesn't already have one (as IE8 does not). This causes the `instanceof` check in isNode.js to throw an error.

Reduced test: http://coonrod.org/react/react-0.9.0/examples/basic/

This is the "basic" example from React using the unmodified React 0.9.0. I've added the Sarissa library as well as es5-shim.js and es5-sham.js. If you view it in IE8 you will see something like this:

![screen shot 2014-02-25 at 6 13 28 pm](https://f.cloud.github.com/assets/58823/2265933/a2a8398a-9e8b-11e3-8b7c-1f9e0dbcc188.png)

and the timer does not time.

I believe you want to always use `instanceof` with a function anyway so it seems like a good thing to test when you don't know if you have a good Node or not.
