### PR TITLE
Remove usage of {' '} in docs and tests

### DIFF
--- a/examples/ballmer-peak/example.js
+++ b/examples/ballmer-peak/example.js
@@ -30,9 +30,8 @@ var BallmerPeakCalculator = React.createClass({
         <p>Credit due to <a href="http://xkcd.com/323/">xkcd</a>.</p>
         <h4>Compute your Ballmer Peak:</h4>
         <p>
-          If your BAC is{' '}
-          <input type="text" onChange={this.handleChange} value={this.state.bac} />
-          {', '}then <b>{pct}</b> of your lines of code will have bugs.
+          If your BAC is <input onChange={this.handleChange} value={this.state.bac} />,
+          then <b>{pct}</b> of your lines of code will have bugs.
         </p>
       </div>
     );

--- a/src/browser/ui/dom/components/__tests__/ReactDOMInput-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMInput-test.js
@@ -143,8 +143,8 @@ describe('ReactDOMInput', function() {
       render: function() {
         return (
           <div>
-            <input ref="a" type="radio" name="fruit" checked={true} />A{' '}
-            <input ref="b" type="radio" name="fruit" />B{' '}
+            <input ref="a" type="radio" name="fruit" checked={true} />A
+            <input ref="b" type="radio" name="fruit" />B
 
             <form>
               <input ref="c" type="radio" name="fruit" defaultChecked={true} />

--- a/src/core/__tests__/refs-destruction-test.js
+++ b/src/core/__tests__/refs-destruction-test.js
@@ -28,7 +28,7 @@ var TestComponent = React.createClass({
     return (
       <div>
         <div ref="theInnerDiv">
-          {' '}Lets try to destroy this.{' '}
+          Lets try to destroy this.
         </div>
       </div>
     );


### PR DESCRIPTION
Fixes #1136.
With this and #1156, there's now no more {' '} in the codebase.
