### PR TITLE
Remove custom attrs properly when setting to null

### DIFF
--- a/src/browser/ui/dom/DOMPropertyOperations.js
+++ b/src/browser/ui/dom/DOMPropertyOperations.js
@@ -136,7 +136,7 @@ var DOMPropertyOperations = {
       }
     } else if (DOMProperty.isCustomAttribute(name)) {
       if (value == null) {
-        node.removeAttribute(DOMProperty.getAttributeName[name]);
+        node.removeAttribute(name);
       } else {
         node.setAttribute(name, '' + value);
       }

--- a/src/browser/ui/dom/__tests__/DOMPropertyOperations-test.js
+++ b/src/browser/ui/dom/__tests__/DOMPropertyOperations-test.js
@@ -153,6 +153,21 @@ describe('DOMPropertyOperations', function() {
       expect(stubNode.hasAttribute('allowFullScreen')).toBe(false);
     });
 
+    it('should remove when setting custom attr to null', function() {
+      DOMPropertyOperations.setValueForProperty(
+        stubNode,
+        'data-foo',
+        'bar'
+      );
+      expect(stubNode.hasAttribute('data-foo')).toBe(true);
+      DOMPropertyOperations.setValueForProperty(
+        stubNode,
+        'data-foo',
+        null
+      );
+      expect(stubNode.hasAttribute('data-foo')).toBe(false);
+    });
+
     it('should use mutation method where applicable', function() {
       var foobarSetter = mocks.getMockFunction();
       // inject foobar DOM property


### PR DESCRIPTION
I don't think this particular codepath was exercised at all (because all the
callers call deleteValueForProperty) but this fixes a bug here nonetheless.
