### PR TITLE
assertValidProps for updating DOM components through renderComponent

### DIFF
--- a/src/browser/ReactDOMComponent.js
+++ b/src/browser/ReactDOMComponent.js
@@ -204,7 +204,6 @@ ReactDOMComponent.Mixin = {
   },
 
   receiveComponent: function(nextComponent, transaction) {
-    assertValidProps(nextComponent.props);
     ReactComponent.Mixin.receiveComponent.call(
       this,
       nextComponent,
@@ -225,6 +224,7 @@ ReactDOMComponent.Mixin = {
     'ReactDOMComponent',
     'updateComponent',
     function(transaction, prevProps, prevOwner) {
+      assertValidProps(this.props);
       ReactComponent.Mixin.updateComponent.call(
         this,
         transaction,

--- a/src/core/__tests__/ReactDOMComponent-test.js
+++ b/src/core/__tests__/ReactDOMComponent-test.js
@@ -340,6 +340,41 @@ describe('ReactDOMComponent', function() {
     });
   });
 
+  describe('updateComponent', function() {
+    var React;
+    var container;
+
+    beforeEach(function() {
+      React = require('React');
+      container = document.createElement('div');
+    });
+
+    it("should validate against multiple children props", function() {
+      React.renderComponent(<div></div>, container);
+
+      expect(function() {
+        React.renderComponent(
+          <div children="" dangerouslySetInnerHTML={{__html: ''}}></div>,
+          container
+        );
+      }).toThrow(
+        'Invariant Violation: Can only set one of `children` or ' +
+        '`props.dangerouslySetInnerHTML`.'
+      );
+    });
+
+    it("should validate against invalid styles", function() {
+      React.renderComponent(<div></div>, container);
+
+      expect(function() {
+        React.renderComponent(<div style={1}></div>, container);
+      }).toThrow(
+        'Invariant Violation: The `style` prop expects a mapping from style ' +
+        'properties to values, not a string.'
+      );
+    });
+  });
+
   describe('unmountComponent', function() {
     it("should clean up listeners", function() {
       var React = require('React');


### PR DESCRIPTION
`renderComponent(<div style={invalidType}/>, container)` throws correctly,
but not when it's called a second time (i.e. updating rather than mounting).
It goes through `ReactDOMComponent.updateComponent` but there wasn't a
props assertion there.
(Removed the assertion in `receiveComponent`)
