### PR TITLE
Merge the lists of JSX integrations in the docs.

### DIFF
--- a/docs/docs/08-tooling-integration.md
+++ b/docs/docs/08-tooling-integration.md
@@ -38,14 +38,7 @@ If you have [npm](http://npmjs.org/), you can simply run `npm install -g react-t
 
 ### Helpful Open-Source Projects
 
-The open-source community has built tools that integrate JSX with several build systems.
-
-* [reactify](https://github.com/andreypopp/reactify) - use JSX with [browserify](http://browserify.org/)
-* [grunt-react](https://github.com/ericclemmons/grunt-react) - [grunt](http://gruntjs.com/) task for JSX
-* [gulp-react](https://github.com/sindresorhus/gulp-react) - [gulp](http://gulpjs.com/) task for JSX
-* [jsx-requirejs-plugin](https://github.com/philix/jsx-requirejs-plugin) - use JSX with [require.js](http://requirejs.org/) and precompile JSX files with r.js
-* [pyReact](https://github.com/facebook/react-python) - use JSX with [Python](http://www.python.org/)
-* [react-rails](https://github.com/facebook/react-rails) - use JSX with [Ruby on Rails](http://rubyonrails.org/)
+The open-source community has built tools that integrate JSX with several build systems. See [JSX integrations](/react/docs/complementary-tools.html#jsx-integrations) for the full list.
 
 
 ### Syntax Highlighting & Linting

--- a/docs/docs/complementary-tools.md
+++ b/docs/docs/complementary-tools.md
@@ -21,6 +21,8 @@ If you want your project on this list, or think one of these projects should be 
   * **[gulp-react](https://npmjs.org/package/gulp-react)** [GulpJS](http://gulpjs.com/) plugin.
   * **[jsx-requirejs-plugin](https://github.com/philix/jsx-requirejs-plugin)** [RequireJS](http://requirejs.org/) plugin.
   * **[react-meteor](https://github.com/benjamn/react-meteor)** [Meteor](http://www.meteor.com/) plugin.
+  * **[pyReact](https://github.com/facebook/react-python)** [Python](http://www.python.org/) bridge to JSX.
+  * **[react-rails](https://github.com/facebook/react-rails)** Ruby gem for using JSX with [Ruby on Rails](http://rubyonrails.org/).
 
 ### Full-stack starter kits
 


### PR DESCRIPTION
There were these two lists of JSX tools at [Complimentary Tools](http://facebook.github.io/react/docs/complementary-tools.html#jsx-integrations)
and [Tooling Integration](http://facebook.github.io/react/docs/tooling-integration.html#helpful-open-source-projects), that were a bit out of sync with each other.

Bring them together and add a link to the former from the latter.
