### PR TITLE
Add missing backtick in complementary-tools.md

### DIFF
--- a/docs/docs/complementary-tools.md
+++ b/docs/docs/complementary-tools.md
@@ -26,7 +26,7 @@ If you want your project on this list, or think one of these projects should be 
 
 ### Full-stack starter kits
 
-  * **[react-quickstart](https://github.com/andreypopp/react-quickstart)** Quick-start template for `express`, `browserify`, `react-router-component and `react-async` (**includes "isomorphic" server rendering**).
+  * **[react-quickstart](https://github.com/andreypopp/react-quickstart)** Quick-start template for `express`, `browserify`, `react-router-component` and `react-async` (**includes "isomorphic" server rendering**).
   * **[generator-react-webpack](https://github.com/newtriks/generator-react-webpack)** [Yeoman](http://yeoman.io/) generator for React and Webpack.
   * **[Genesis Skeleton](http://genesis-skeleton.com/)** Modern, opinionated, full-stack starter kit for rapid, streamlined application development (supports React).
   * **[react-starter-template](https://github.com/johnthethird/react-starter-template)** Starter template with Gulp, Webpack and Bootstrap.


### PR DESCRIPTION
The rendered live version looks like this at the moment:

![screenshot 2014-03-02 22 10 35](https://f.cloud.github.com/assets/9906/2305444/82695ef4-a257-11e3-9059-2961e7158a65.png)
