### PR TITLE
Fix docstring typo for pure render mixin

### DIFF
--- a/src/addons/ReactComponentWithPureRenderMixin.js
+++ b/src/addons/ReactComponentWithPureRenderMixin.js
@@ -29,7 +29,7 @@ var shallowEqual = require('shallowEqual');
  *
  * Example:
  *
- *   var ReactComponentWithPureRender =
+ *   var ReactComponentWithPureRenderMixin =
  *     require('ReactComponentWithPureRenderMixin');
  *   React.createClass({
  *     mixins: [ReactComponentWithPureRenderMixin],


### PR DESCRIPTION
The full name is used right below in the component.
