### PR TITLE
Fix stale usage of emptyObject in cloneWithProps-test

### DIFF
--- a/src/utils/__tests__/cloneWithProps-test.js
+++ b/src/utils/__tests__/cloneWithProps-test.js
@@ -19,16 +19,17 @@
 
 "use strict";
 
-require('mock-modules').dontMock('cloneWithProps');
+require('mock-modules')
+  .dontMock('cloneWithProps')
+  .dontMock('emptyObject');
 
 var mocks = require('mocks');
-
-var cloneWithProps = require('cloneWithProps');
 
 var React;
 var ReactTestUtils;
 
 var onlyChild;
+var cloneWithProps;
 var emptyObject;
 
 describe('cloneWithProps', function() {
@@ -37,6 +38,7 @@ describe('cloneWithProps', function() {
     React = require('React');
     ReactTestUtils = require('ReactTestUtils');
     onlyChild = require('onlyChild');
+    cloneWithProps = require('cloneWithProps');
     emptyObject = require('emptyObject');
   });
 


### PR DESCRIPTION
After we run `require('mock-modules').dumpCache()`, the object exported by the `emptyObject` module will no longer be identical to previously exported objects, so tests like `expect(component.refs).toBe(emptyObject)` will fail.

Note that this behavior only manifests itself in tests, because of course we do not call `dumpCache` in production code.

We could consider storing the `emptyObject` globally to thwart the effects of `dumpCache`, but it's more idiomatic simply to re-`require` the latest version of `emptyObject`.

cc @petehunt
