### PR TITLE
Fix empty JSX expressions sometimes emitting erroneous commas

### DIFF
--- a/vendor/fbtransform/transforms/react.js
+++ b/vendor/fbtransform/transforms/react.js
@@ -130,7 +130,9 @@ function visitReactTag(traverse, object, path, state) {
   var childrenToRender = object.children.filter(function(child) {
     return !(child.type === Syntax.Literal
              && typeof child.value === 'string'
-             && child.value.match(/^[ \t]*[\r\n][ \t\r\n]*$/));
+             && child.value.match(/^[ \t]*[\r\n][ \t\r\n]*$/)
+             || child.type === Syntax.XJSExpressionContainer
+             && child.expression.type === Syntax.XJSEmptyExpression);
   });
   if (childrenToRender.length > 0) {
     utils.append(', ', state);


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/1216

It is technically possible to significantly simplify the code, but it would come at the cost of no longer being in control of where `,` ends up, which is something we do want to control.
