### PR TITLE
Add es3ify to JSX transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "commoner": "~0.9.1",
+    "es3ify": "~0.1.3",
     "esprima-fb": "~3001.1.0-dev-harmony-fb",
     "jstransform": "~3.0.0"
   },
@@ -42,7 +43,6 @@
     "browserify": "~3.20.0",
     "coverify": "~1.0.4",
     "envify": "~1.2.0",
-    "es3ify": "~0.1.2",
     "es5-shim": "~2.3.0",
     "grunt": "~0.4.2",
     "grunt-cli": "~0.1.9",

--- a/vendor/fbtransform/transforms/xjs.js
+++ b/vendor/fbtransform/transforms/xjs.js
@@ -15,6 +15,7 @@
  */
 /*global exports:true*/
 "use strict";
+var es3ify = require('es3ify');
 var Syntax = require('esprima-fb').Syntax;
 var utils = require('jstransform/src/utils');
 
@@ -229,8 +230,8 @@ function renderXJSExpressionContainer(traverse, object, isLast, path, state) {
 
 function quoteAttrName(attr) {
   // Quote invalid JS identifiers.
-  if (!/^[a-z_$][a-z\d_$]*$/i.test(attr)) {
-    return "'" + attr + "'";
+  if (!/^[a-z_$][a-z\d_$]*$/i.test(attr) || es3ify.isReserved(attr)) {
+    return JSON.stringify(attr);
   }
   return attr;
 }

--- a/vendor/fbtransform/visitors.js
+++ b/vendor/fbtransform/visitors.js
@@ -1,4 +1,5 @@
 /*global exports:true*/
+var es3ify = require('es3ify');
 var es6ArrowFunctions = require('jstransform/visitors/es6-arrow-function-visitors');
 var es6Classes = require('jstransform/visitors/es6-class-visitors');
 var es6ObjectShortNotation = require('jstransform/visitors/es6-object-short-notation-visitors');
@@ -16,7 +17,11 @@ var transformVisitors = {
   'es6-object-short-notation': es6ObjectShortNotation.visitorList,
   'es6-rest-params': es6RestParameters.visitorList,
   'es6-templates': es6Templates.visitorList,
-  'react': react.visitorList.concat(reactDisplayName.visitorList)
+  'react': [].concat(
+    es3ify.visitorList,
+    react.visitorList,
+    reactDisplayName.visitorList
+  )
 };
 
 /**


### PR DESCRIPTION
This would make #1223 easier to deal with in older browsers.

With this change,

```
<div class="orange" />
```

compiles into

```
React.DOM.div( {"class":"orange"} );
```

and `this.props.class` turns into `this.props["class"]`.
