### PR TITLE
Batch updates caused by handlers in multiple roots

### DIFF
--- a/src/core/ReactEventEmitterMixin.js
+++ b/src/core/ReactEventEmitterMixin.js
@@ -19,7 +19,6 @@
 "use strict";
 
 var EventPluginHub = require('EventPluginHub');
-var ReactUpdates = require('ReactUpdates');
 
 function runEventQueueInBatch(events) {
   EventPluginHub.enqueueEvents(events);
@@ -49,8 +48,7 @@ var ReactEventEmitterMixin = {
       nativeEvent
     );
 
-    // Event queue being processed in the same cycle allows `preventDefault`.
-    ReactUpdates.batchedUpdates(runEventQueueInBatch, events);
+    runEventQueueInBatch(events);
   }
 };
 


### PR DESCRIPTION
Fixes #1227.

It seems rare that event handlers in two roots nested in the DOM will update the same component in the same tick, but if that happens, the updates should be batched together.
