### PR TITLE
Add naive custom element support

### DIFF
--- a/vendor/fbtransform/transforms/react.js
+++ b/vendor/fbtransform/transforms/react.js
@@ -61,8 +61,29 @@ function visitReactTag(traverse, object, path, state) {
   }
 
   var isFallbackTag = FALLBACK_TAGS.hasOwnProperty(nameObject.name);
+
+  // Support for <custom-element> tags
+  var isCustomElement = nameObject.name.indexOf('-') > 0;
+  //transform `custom-element` to `CustomElement`
+  function toPascalCase(name){
+    var camelCased = name.replace(/-([a-z])/g, function (g) {
+      return g[1].toUpperCase();
+    });
+    return camelCased[0].toUpperCase() + camelCased.slice(1);
+  };
+
+  function startComponent(name){
+    if(isFallbackTag) {
+      return jsxObjIdent + '.' + name;
+    } else if(isCustomElement) {
+      return toPascalCase(name);
+    } else {
+      return name;
+    }
+  };
+
   utils.append(
-    (isFallbackTag ? jsxObjIdent + '.' : '') + (nameObject.name) + '(',
+    startComponent(nameObject.name) + '(',
     state
   );
 


### PR DESCRIPTION
JSX will render `<custom-element />` as `custom-element()`. Rendering it as `CustomElement()` sounds like a better idea, because it is syntactically correct. If we operate on an assumption, that custom elements names map to React displayNames with this convention, we can build React-driven web component:

```
/** @jsx React.DOM */
var MyComponent = React.createClass({
  render: function(){
    return (<p>Hello {this.props.name}</p>);
  }
});

var MyComponentPrototype = Object.create(HTMLElement.prototype);

MyComponentPrototype.attachedCallback = function(){
  var props = {};
  Array.prototype.forEach.call(this.attributes, function(attr){
    props[attr.name] = attr.value;
  });
  React.renderComponent(MyComponent(props), this);
};

document.registerElement('my-component', { prototype: MyComponentPrototype });
```
