### PR TITLE
Don't fail silently for null or falsy event listeners. Fix #1255

### DIFF
--- a/src/browser/ui/ReactDOMComponent.js
+++ b/src/browser/ui/ReactDOMComponent.js
@@ -144,12 +144,9 @@ ReactDOMComponent.Mixin = {
         continue;
       }
       var propValue = props[propKey];
-      if (propValue == null) {
-        continue;
-      }
       if (registrationNameModules[propKey]) {
         putListener(this._rootNodeID, propKey, propValue, transaction);
-      } else {
+      } else if (propValue != null) {
         if (propKey === STYLE) {
           if (propValue) {
             propValue = props.style = merge(props.style);

--- a/src/event/EventPluginHub.js
+++ b/src/event/EventPluginHub.js
@@ -159,7 +159,7 @@ var EventPluginHub = {
       'Cannot call putListener() in a non-DOM environment.'
     );
     invariant(
-      !listener || typeof listener === 'function',
+      typeof listener === 'function',
       'Expected %s listener to be a function, instead got type %s',
       registrationName, typeof listener
     );


### PR DESCRIPTION
Make sure ReactDOMComponent passes down null values.
Don't ignore falsey values. (I'm maybe missing something here, it probably existed for a reason?)
