### PR TITLE
Add support for {harmony: true} to react-tools

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,10 +1,16 @@
 'use strict';
 
-var visitors = require('./vendor/fbtransform/visitors').transformVisitors;
+var visitors = require('./vendor/fbtransform/visitors');
 var transform = require('jstransform').transform;
 
 module.exports = {
-  transform: function(code) {
-    return transform(visitors.react, code).code;
+  transform: function(code, options) {
+    var visitorList;
+    if (options && options.harmony) {
+      visitorList = visitors.getAllVisitors();
+    } else {
+      visitorList = visitors.transformVisitors.react;
+    }
+    return transform(visitorList, code).code;
   }
 };


### PR DESCRIPTION
```
require('react-tools').transform(code, {harmony: true});
```

now enables all the harmony es6 transforms that are supported.

This is modeled after https://github.com/facebook/react/blob/master/bin/jsx#L17-L23
