### PR TITLE
Handle className correctly for SVG nodes

### DIFF
--- a/src/browser/ui/dom/DefaultDOMPropertyConfig.js
+++ b/src/browser/ui/dom/DefaultDOMPropertyConfig.js
@@ -193,6 +193,29 @@ var DefaultDOMPropertyConfig = {
     spellCheck: 'spellcheck',
     srcDoc: 'srcdoc',
     srcSet: 'srcset'
+  },
+  DOMMutationMethods: {
+    /**
+     * Setting `className` to null may cause it to be set to the string "null".
+     *
+     * @param {DOMElement} node
+     * @param {*} value
+     */
+    className: function (node, value) {
+      // The className property of SVG elements is not a string but an
+      // "SVGAnimatedString" object and can't be written directly.
+      // if the property is a string, we write the property.
+      if (typeof node.className === 'string') {
+        node.className = value != null ? value : '';
+      } else {
+        // If not, fall back to using setAttribute.
+        if (value != null) {
+          node.setAttribute('class', value);
+        } else {
+          node.removeAttribute('class');
+        }
+      }
+    }
   }
 };
 


### PR DESCRIPTION
Bring back the DOM mutator to check if the className we're writing
to is actually a string.

For SVG nodes, the className property is not of type string but
and SVGAnimatedString and writing to the property will cause
a "TypeError: setting a property that has only a getter"
(See http://jsfiddle.net/ca47V/ )

This first checks if the className property is indeed a string
and uses setAttribute() / removeAttribute() otherwise.
