### PR TITLE
Upgrade Commoner to v0.9.2 to silence deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/facebook/react"
   },
   "dependencies": {
-    "commoner": "~0.9.1",
+    "commoner": "^0.9.2",
     "esprima-fb": "~3001.1.0-dev-harmony-fb",
     "jstransform": "~3.0.0"
   },


### PR DESCRIPTION
Closes #1278.
