### PR TITLE
Only stop if the transition on this element ended

### DIFF
--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -55,7 +55,7 @@ var ReactCSSTransitionGroupChild = React.createClass({
     var noEventTimeout = null;
 
     var endListener = function(e) {
-      if (e.target !== node) {
+      if (e && e.target !== node) {
         return;
       }
       if (__DEV__) {


### PR DESCRIPTION
This way it doesn't end when some random element elsewhere on the page has an ending transition.

It must be noted that this is not a complete fix. If you have multiple transitions on the element, it still ends when the first ends.

I ran into this not working (the transition ends almost immediately, because some unrelated transition ends). This fixes it for me, but I was wondering whether this cornercase was considered, and whether the other cornercase (multiple transitions) was considered.

I think it's very hard to get this correct, and think it might be better to make the timeout explicit, or at least allow to set it explicit, and fall back to this behaviour. But I'm really interested in feedback on this one.
