### PR TITLE
Bug fix when a node get's removed after it's parent has already been removed

### DIFF
--- a/src/browser/ui/dom/DOMChildrenOperations.js
+++ b/src/browser/ui/dom/DOMChildrenOperations.js
@@ -133,7 +133,9 @@ var DOMChildrenOperations = {
     // Remove updated children first so that `toIndex` is consistent.
     if (updatedChildren) {
       for (var j = 0; j < updatedChildren.length; j++) {
-        updatedChildren[j].parentNode.removeChild(updatedChildren[j]);
+        if (updatedChildren[j]) {
+          updatedChildren[j].parentNode.removeChild(updatedChildren[j]);
+        }
       }
     }
 


### PR DESCRIPTION
Fixed a but that happens when in certain cases when a state change decides a node and it's parent should be removed, because of timing issues (I think) it can happen that updatedChildren[j] is undefined when trying to remove itself from the parentNode.

I ran all tests and lint (which gave error's but not related to this pull request and tested the fix on our own code. I don't have a specific test case for this because I don't know how to trigger this scenario, but I assume this piece of code is already covered pretty well. If a specific test is required I am happy to do so with some guidance on how to trigger this behaviour without copying our own code :-) 

A local fix is that instead of removing the child node I hide it instead, or applying this pull request.
