### PR TITLE
Make optional the use of 'initialProps' in base constructor

### DIFF
--- a/src/core/ReactComponent.js
+++ b/src/core/ReactComponent.js
@@ -357,7 +357,12 @@ var ReactComponent = {
      * @internal
      */
     construct: function(initialProps, children) {
-      this.props = initialProps || {};
+      var firstChild = Number(!(ReactComponent.isValidComponent(initialProps) ||
+                              'string' === typeof initialProps ||
+                               Array.isArray(initialProps)));
+
+      this.props = initialProps && firstChild ? initialProps : {};
+
       // Record the component responsible for creating this component.
       this._owner = ReactCurrentOwner.current;
       // All components start unmounted.
@@ -373,19 +378,20 @@ var ReactComponent = {
       this._pendingOwner = this._owner;
 
       // Children can be more than one argument
-      var childrenLength = arguments.length - 1;
+      var childrenLength = arguments.length - firstChild;
+
       if (childrenLength === 1) {
         if (__DEV__) {
-          validateChildKeys(children);
+          validateChildKeys(arguments[firstChild]);
         }
-        this.props.children = children;
+        this.props.children = arguments[firstChild];
       } else if (childrenLength > 1) {
         var childArray = Array(childrenLength);
         for (var i = 0; i < childrenLength; i++) {
           if (__DEV__) {
-            validateChildKeys(arguments[i + 1]);
+            validateChildKeys(arguments[i + firstChild]);
           }
-          childArray[i] = arguments[i + 1];
+          childArray[i] = arguments[i + firstChild];
         }
         this.props.children = childArray;
       }

--- a/src/core/__tests__/ReactComponent-test.js
+++ b/src/core/__tests__/ReactComponent-test.js
@@ -207,4 +207,46 @@ describe('ReactComponent', function() {
     expect(root.refs.switcher.refs.box.refs.boxDiv._mountDepth).toBe(3);
     expect(root.refs.child.refs.span._mountDepth).toBe(6);
   });
+
+  it('should allow the initialProps to be optional', function() {
+    var Root = React.createClass({
+      render: function() {
+        var div = React.DOM.div;
+
+        var children = [
+          div({ key: 1, ref: 'child' }),
+          div({ key: 2 }),
+          div({ key: 3 })
+        ];
+
+        var array = [
+          div({ key: 1, ref: 'array' }),
+          div({ key: 2 }),
+          div({ key: 3 })
+        ];
+
+        return (
+          div(
+            div({ ref: 'children' }, children),
+            div(null, 'null', div({ ref: 'null' })),
+            div('string', 'string', div({ ref: 'string' })),
+            div(div({ ref: 'siblingA' }), div({ ref: 'siblingB' }), div({ ref: 'siblingC' })),
+            div(array)
+          )
+        )
+      }
+    });
+
+
+    var root = ReactTestUtils.renderIntoDocument(Root());
+    expect(root._mountDepth).toBe(0);
+    expect(root.refs.children._mountDepth).toBe(2);
+    expect(root.refs.child._mountDepth).toBe(3);
+    expect(root.refs.null._mountDepth).toBe(3);
+    expect(root.refs.string._mountDepth).toBe(3);
+    expect(root.refs.siblingA._mountDepth).toBe(3);
+    expect(root.refs.siblingB._mountDepth).toBe(3);
+    expect(root.refs.siblingC._mountDepth).toBe(3);
+    expect(root.refs.array._mountDepth).toBe(3);
+  });
 });


### PR DESCRIPTION
Allow 'templating' to be easier to read when writing React.js components with pure JS.
