### PR TITLE
Fix hasOwnProperty check typo in mixStaticSpecIntoComponent

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -505,7 +505,7 @@ function mixStaticSpecIntoComponent(ConvenienceConstructor, statics) {
   for (var name in statics) {
     var property = statics[name];
     if (!statics.hasOwnProperty(name)) {
-      return;
+      continue;
     }
 
     var isInherited = name in ConvenienceConstructor;


### PR DESCRIPTION
In rare cases rest of statics may have been ignored due to early return instead of continue.
