### PR TITLE
Add optional harmony support to browser transform

### DIFF
--- a/vendor/browser-transforms.js
+++ b/vendor/browser-transforms.js
@@ -22,7 +22,7 @@ var headEl;
 
 var buffer = require('buffer');
 var transform = require('jstransform').transform;
-var visitors = require('./fbtransform/visitors').transformVisitors;
+var visitors = require('./fbtransform/visitors');
 var docblock = require('jstransform/src/docblock');
 
 // The source-map library relies on Object.defineProperty, but IE8 doesn't
@@ -31,16 +31,23 @@ var docblock = require('jstransform/src/docblock');
 // the source map in that case.
 var supportsAccessors = Object.prototype.hasOwnProperty('__defineGetter__');
 
-function transformReact(source) {
-  return transform(visitors.react, source, {
+function transformReact(source, options) {
+  var visitorList;
+  if (options && options.harmony) {
+    visitorList = visitors.getAllVisitors();
+  } else {
+    visitorList = visitors.transformVisitors.react;
+  }
+
+  return transform(visitorList, source, {
     sourceMap: supportsAccessors
   });
 }
 
 exports.transform = transformReact;
 
-exports.exec = function(code) {
-  return eval(transformReact(code).code);
+exports.exec = function(code, options) {
+  return eval(transformReact(code, options).code);
 };
 
 var inlineScriptCount = 0;


### PR DESCRIPTION
This mirrors the react-tools API; it doesn't include support (yet) for transforming `<script type="text/jsx">` blocks with the ES6 transforms, mostly because I don't have a good API in mind there.

Test Plan: Ran

```
JSXTransformer.transform("var two = () => 2;", {harmony: true}).code
```

in Chrome's dev console and got back some ES5 code.

cc @Daniel15 @cpojer
