### PR TITLE
Render <noscript> contents to string

### DIFF
--- a/src/browser/ReactDOM.js
+++ b/src/browser/ReactDOM.js
@@ -127,7 +127,7 @@ var ReactDOM = mapObject({
   meta: true,
   meter: false,
   nav: false,
-  noscript: false, // NOTE: Injected, see `ReactDOMNoscript`.
+  noscript: false, // NOTE: Injected, see `ReactDOMNoScript`.
   object: false,
   ol: false,
   optgroup: false,

--- a/src/browser/ui/ReactDefaultInjection.js
+++ b/src/browser/ui/ReactDefaultInjection.js
@@ -39,7 +39,7 @@ var ReactDOMButton = require('ReactDOMButton');
 var ReactDOMForm = require('ReactDOMForm');
 var ReactDOMImg = require('ReactDOMImg');
 var ReactDOMInput = require('ReactDOMInput');
-var ReactDOMNoscript = require('ReactDOMNoscript');
+var ReactDOMNoScript = require('ReactDOMNoScript');
 var ReactDOMOption = require('ReactDOMOption');
 var ReactDOMSelect = require('ReactDOMSelect');
 var ReactDOMTextarea = require('ReactDOMTextarea');
@@ -85,7 +85,7 @@ function inject() {
     form: ReactDOMForm,
     img: ReactDOMImg,
     input: ReactDOMInput,
-    noscript: ReactDOMNoscript,
+    noscript: ReactDOMNoScript,
     option: ReactDOMOption,
     select: ReactDOMSelect,
     textarea: ReactDOMTextarea,

--- a/src/browser/ui/dom/components/ReactDOMNoScript.js
+++ b/src/browser/ui/dom/components/ReactDOMNoScript.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @providesModule ReactDOMNoscript
+ * @providesModule ReactDOMNoScript
  */
 
 "use strict";
@@ -36,8 +36,8 @@ var noscript = ReactDOM.noscript;
  * <noscript> for server-side rendering without causing reconciliation problems
  * for the browser (where they would be seen as a string anyway).
  */
-var ReactDOMNoscript = ReactCompositeComponent.createClass({
-  displayName: 'ReactDOMNoscript',
+var ReactDOMNoScript = ReactCompositeComponent.createClass({
+  displayName: 'ReactDOMNoScript',
   tagName: 'NOSCRIPT',
 
   mixins: [ReactBrowserComponentMixin],
@@ -69,4 +69,4 @@ var ReactDOMNoscript = ReactCompositeComponent.createClass({
   }
 });
 
-module.exports = ReactDOMNoscript;
+module.exports = ReactDOMNoScript;

--- a/src/browser/ui/dom/components/__tests__/ReactDOMNoScript-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMNoScript-test.js
@@ -21,7 +21,7 @@
 
 /*jshint evil:true */
 
-describe('ReactDOMNoscript', function() {
+describe('ReactDOMNoScript', function() {
   var React;
   var ReactTestUtils;
 


### PR DESCRIPTION
This is the fix for #1252; it uses `renderComponentToStaticMarkup` on the children so that the server and browser both treat them the same (as text content). In browsers that have JS disabled…well, React won't be loaded so it can't be upset that the contents are actual elements :stuck_out_tongue_closed_eyes:

Let me know if any improvements can be made. I didn't see a `map` utility for the children list that produced an array so I used `ReactChildren.forEach`. I think the tests cover everything, but if not, let me know!
