### PR TITLE
Disable webdriver-jasmine:saucelabs_android test temporarily

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -122,7 +122,8 @@ module.exports = function(grunt) {
     'webdriver-jasmine:local',
 
     'sauce-tunnel',
-    'webdriver-jasmine:saucelabs_android',
+    // Temporarily disabled due to spurious test failures.
+    // 'webdriver-jasmine:saucelabs_android',
     'webdriver-jasmine:saucelabs_firefox',
     'webdriver-jasmine:saucelabs_chrome'
   ]);


### PR DESCRIPTION
The Android test suite is consistently failing with nonsensical error messages:

```
>> not ok 572 - vendor/immutable/__tests__/ImmutableObject-test
   ImmutableObject should create distinct object with deep field
   insertion:PROD.
   # Expected { oldShallowField : { newDeepField : 'hello' } } to equal
              { oldShallowField : { newDeepField : 'hello' } }.
```

Whatever the reason for this Android-specific SNAFU, it's not worth rendering our entire Travis test suite useless.

cc @subtleGradient
