### PR TITLE
Remove leftovers from ReactTransitionGroup rewrite

### DIFF
--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -84,11 +84,6 @@ var ReactCSSTransitionGroupChild = React.createClass({
   queueClass: function(className) {
     this.classNameQueue.push(className);
 
-    if (this.props.runNextTick) {
-      this.props.runNextTick(this.flushClassNameQueue);
-      return;
-    }
-
     if (!this.timeout) {
       this.timeout = setTimeout(this.flushClassNameQueue, TICK);
     }


### PR DESCRIPTION
Looks like while rewriting @petehunt forgot to remove this block. See:
9ac27cb551b85293d03d334363acd7cf9c77813a This block used to contain the only
`runNextTick` ocurrences in the whole project. No tests broken after removal,
no documentation affected.
