### PR TITLE
[Jshint] Allow Jasmine globals in *-test.js

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -24,8 +24,15 @@
 
   "globals": {
     "__DEV__": false,
-    "require": false,
+    "exports": false,
     "module": false,
-    "exports": false
+    "require": false,
+
+    "afterEach": false,
+    "beforeEach": false,
+    "describe": false,
+    "expect": false,
+    "it": false,
+    "spyOn": false
   }
 }


### PR DESCRIPTION
Editors that inline lint use .jshintrc and directly lint the open
*-test.js files. This makes those linters actually useful.
