### PR TITLE
Don't break on top-level non-numeric object keys

### DIFF
--- a/src/core/ReactDescriptor.js
+++ b/src/core/ReactDescriptor.js
@@ -95,6 +95,11 @@ function validateExplicitKey(component) {
  * @param {ReactComponent} component Component that requires a key.
  */
 function validatePropertyKey(name) {
+  // We can't provide friendly warnings for top level components.
+  if (!ReactCurrentOwner.current) {
+    return;
+  }
+
   if (NUMERIC_PROPERTY_REGEX.test(name)) {
     // Name of the component whose render method tried to pass children.
     var currentName = ReactCurrentOwner.current.constructor.displayName;


### PR DESCRIPTION
Previously, this threw (in `__DEV__` only) in `ReactCurrentOwner.current.constructor.displayName` because `ReactCurrentOwner.current` is null:

```
React.renderComponent(<div>{{1: <div />, 2: <div />}}</div>, document.body);
```
