### PR TITLE
[docs] Amend "References to components" tip to mention descriptors.

### DIFF
--- a/docs/tips/16-references-to-components.md
+++ b/docs/tips/16-references-to-components.md
@@ -16,8 +16,6 @@ var myComponent = React.renderComponent(<MyComponent />, myContainer);
 
 Keep in mind, however, that the "constructor" of a component doesn't return a component instance! It's just a **descriptor**: a lightweight representation that tells React what the mounted component should look like.
 
-Descriptors also contain any methods that you define in the [statics](http://facebook.github.io/react/docs/component-specs.html#statics) property of the component.
-
 ```js
 /** @jsx React.DOM */
 


### PR DESCRIPTION
This tip was written before descriptors, so it only vaguely hinted that "the component passed into renderComponent may not be the one that's mounted." This updates the tip to (hopefully) be more clear.
