### PR TITLE
#1295 simple __type__ hook

### DIFF
--- a/src/core/shouldUpdateReactComponent.js
+++ b/src/core/shouldUpdateReactComponent.js
@@ -36,7 +36,7 @@ function shouldUpdateReactComponent(prevDescriptor, nextDescriptor) {
         (prevDescriptor.props && prevDescriptor.props.key) ===
         (nextDescriptor.props && nextDescriptor.props.key)
       ) && prevDescriptor._owner === nextDescriptor._owner) {
-    return true;
+    return prevDescriptor.props.__type__ === nextDescriptor.props.__type__
   }
   return false;
 }


### PR DESCRIPTION
This addresses #1295, this is a hook we need for Om and also removes the constructor hack that caused warnings from React 0.10. We would love to be able to adopt React 0.10 as 0.9 doesn't include the Chrome Dev Tools support so all Om users need to produce a custom build of React to get this support. If this looks OK would it be possible to cut 0.10.1 with this included? Thanks all.
