### PR TITLE
Serve unminified react.js on docs site

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -30,7 +30,7 @@
   <![endif]-->
   <script type="text/javascript" src="/react/js/codemirror.js"></script>
   <script type="text/javascript" src="/react/js/javascript.js"></script>
-  <script type="text/javascript" src="/react/js/react.min.js"></script>
+  <script type="text/javascript" src="/react/js/react.js"></script>
   <script type="text/javascript" src="/react/js/JSXTransformer.js"></script>
   <script type="text/javascript" src="/react/js/live_editor.js"></script>
   <script type="text/javascript" src="/react/js/showdown.js"></script>

--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -5,7 +5,7 @@ module.exports = {
   react_docs: {
     files: [
       {
-        src: ['react.min.js', 'JSXTransformer.js'],
+        src: ['react.js', 'JSXTransformer.js'],
         dest: 'docs/js/',
         cwd: 'build/',
         expand: true


### PR DESCRIPTION
I haven't tested this, but from a cursory look over the build process this should work. CLA signed.
