### PR TITLE
Make Simulate.mouseEnter/Leave use direct dispatch

### DIFF
--- a/src/browser/__tests__/ReactBrowserEventEmitter-test.js
+++ b/src/browser/__tests__/ReactBrowserEventEmitter-test.js
@@ -57,6 +57,7 @@ var LISTENER = mocks.getMockFunction();
 var ON_CLICK_KEY = keyOf({onClick: null});
 var ON_TOUCH_TAP_KEY = keyOf({onTouchTap: null});
 var ON_CHANGE_KEY = keyOf({onChange: null});
+var ON_MOUSE_ENTER_KEY = keyOf({onMouseEnter: null});
 
 
 /**
@@ -318,6 +319,17 @@ describe('ReactBrowserEventEmitter', function() {
     );
     ReactTestUtils.Simulate.click(CHILD);
     expect(handleParentClick.mock.calls.length).toBe(0);
+  });
+
+  it('should have mouse enter simulated by test utils', function() {
+    ReactBrowserEventEmitter.putListener(
+      getID(CHILD),
+      ON_MOUSE_ENTER_KEY,
+      recordID.bind(null, getID(CHILD))
+    );
+    ReactTestUtils.Simulate.mouseEnter(CHILD);
+    expect(idCallOrder.length).toBe(1);
+    expect(idCallOrder[0]).toBe(getID(CHILD));
   });
 
   it('should infer onTouchTap from a touchStart/End', function() {

--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -398,17 +398,25 @@ function makeSimulator(eventType) {
       node = domComponentOrNode;
     }
 
+    var dispatchConfig =
+      ReactBrowserEventEmitter.eventNameDispatchConfigs[eventType];
+
     var fakeNativeEvent = new Event();
     fakeNativeEvent.target = node;
     // We don't use SyntheticEvent.getPooled in order to not have to worry about
     // properly destroying any properties assigned from `eventData` upon release
     var event = new SyntheticEvent(
-      ReactBrowserEventEmitter.eventNameDispatchConfigs[eventType],
+      dispatchConfig,
       ReactMount.getID(node),
       fakeNativeEvent
     );
     assign(event, eventData);
-    EventPropagators.accumulateTwoPhaseDispatches(event);
+
+    if (dispatchConfig.phasedRegistrationNames) {
+      EventPropagators.accumulateTwoPhaseDispatches(event);
+    } else {
+      EventPropagators.accumulateDirectDispatches(event);
+    }
 
     ReactUpdates.batchedUpdates(function() {
       EventPluginHub.enqueueEvents(event);


### PR DESCRIPTION
Fixes #1297.

onMouseEnter and onMouseLeave shouldn't *actually* use direct dispatch, but doing so is more useful than doing nothing (and I don't think it precludes adding proper enter/leave dispatching later, either).

Test Plan: grunt test