### PR TITLE
RFC Treat null key value as an intentionally omitted key

### DIFF
--- a/src/core/ReactDescriptor.js
+++ b/src/core/ReactDescriptor.js
@@ -45,7 +45,7 @@ var NUMERIC_PROPERTY_REGEX = /^\d+$/;
  * @param {ReactComponent} component Component that requires a key.
  */
 function validateExplicitKey(component) {
-  if (component._store.validated || component.props.key != null) {
+  if (component._store.validated || component.props.key !== undefined) {
     return;
   }
   component._store.validated = true;


### PR DESCRIPTION
I propose allowing `key: null` to signal intentional omission of the key and thus avoiding the explicit key warning (allows you to avoid cluttering up the console with lots of useless warnings in some cases, that could otherwise hide the important ones).
