### PR TITLE
Use default prop when prop specified is `null` *or* `undefined`

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -902,7 +902,8 @@ var ReactCompositeComponentMixin = {
     var props = merge(newProps);
     var defaultProps = this._defaultProps;
     for (var propName in defaultProps) {
-      if (typeof props[propName] === 'undefined') {
+      // use default in case of null *or* undefined
+      if (props[propName] == null) {
         props[propName] = defaultProps[propName];
       }
     }


### PR DESCRIPTION
The undesired behavior can be seen here:
http://jsfiddle.net/sstur/kb3gN/1760/

This commits patches React to treat `null` and `undefined` more similarly in the case of default props.
