### PR TITLE
Update 05-reusable-components.md

### DIFF
--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -61,7 +61,7 @@ React.createClass({
     // shown if the prop isn't provided.
     requiredFunc: React.PropTypes.func.isRequired,
 
-    // An object of any kind
+    // A value of any data type
     requiredAny: React.PropTypes.any.isRequired,
 
     // You can also specify a custom validator.


### PR DESCRIPTION
`any` also seems to accept primitive values, not only objects. And since we already have `React.PropType.object`, the description was confusing.
