### PR TITLE
Update refs even if shouldComponentUpdate is false

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -997,6 +997,7 @@ var ReactCompositeComponentMixin = {
       } else {
         // If it's determined that a component should not update, we still want
         // to set props and state.
+        var prevDescriptor = this._descriptor;
         this._descriptor = nextDescriptor;
         this.props = nextProps;
         this.state = nextState;
@@ -1005,6 +1006,14 @@ var ReactCompositeComponentMixin = {
         // Owner cannot change because shouldUpdateReactComponent doesn't allow
         // it. TODO: Remove this._owner completely.
         this._owner = nextDescriptor._owner;
+
+        // We're skipping almost all of the update steps, but we still want to
+        // update refs even if shouldComponentUpdate returned false.
+        ReactComponent.Mixin.updateComponent.call(
+          this,
+          transaction,
+          prevDescriptor
+        );
       }
     } finally {
       this._compositeLifeCycleState = null;

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -1345,4 +1345,40 @@ describe('ReactCompositeComponent', function() {
     expect(console.warn.argsForCall.length).toBe(0);
   });
 
+  it('should update refs if shouldComponentUpdate gives false', function() {
+    var Static = React.createClass({
+      shouldComponentUpdate: function() {
+        return false;
+      },
+      render: function() {
+        return <div>{this.props.children}</div>;
+      }
+    });
+    var Component = React.createClass({
+      render: function() {
+        if (this.props.flipped) {
+          return <div>
+            <Static ref="static0" key="B">B (ignored)</Static>
+            <Static ref="static1" key="A">A (ignored)</Static>
+          </div>;
+        } else {
+          return <div>
+            <Static ref="static0" key="A">A</Static>
+            <Static ref="static1" key="B">B</Static>
+          </div>;
+        }
+      }
+    });
+
+    var comp = ReactTestUtils.renderIntoDocument(<Component flipped={false} />);
+    expect(comp.refs.static0.getDOMNode().textContent).toBe('A');
+    expect(comp.refs.static1.getDOMNode().textContent).toBe('B');
+
+    // When flipping the order, the refs should update even though the actual
+    // contents do not
+    comp.setProps({flipped: true});
+    expect(comp.refs.static0.getDOMNode().textContent).toBe('B');
+    expect(comp.refs.static1.getDOMNode().textContent).toBe('A');
+  });
+
 });


### PR DESCRIPTION
Fixes #1392.

I think this makes sense; it's useful to be able to reorder components without rerendering them while having refs that correspond to the current indices.

Test Plan: grunt test
