### PR TITLE
Improve error for nested render calls

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -1164,17 +1164,6 @@ var ReactCompositeComponentMixin = {
     'ReactCompositeComponent',
     '_renderValidatedComponent',
     function() {
-      // We set ReactCurrentOwner.current back to null at the end of this
-      // function, so it should be null right now. If it's not, later code may
-      // give confusing errors.
-      invariant(
-        ReactCurrentOwner.current == null,
-        '%s.render(): Render methods should be a pure function of props and ' +
-          'state; triggering nested component updates from render is not ' +
-          'allowed. If necessary, trigger nested updates in ' +
-          'componentDidUpdate.',
-        this.constructor.displayName || 'ReactCompositeComponent'
-      );
       var renderedComponent;
       var previousContext = ReactContext.current;
       ReactContext.current = this._processChildContext(

--- a/src/core/ReactUpdates.js
+++ b/src/core/ReactUpdates.js
@@ -18,6 +18,7 @@
 
 "use strict";
 
+var ReactCurrentOwner = require('ReactCurrentOwner');
 var ReactPerf = require('ReactPerf');
 
 var invariant = require('invariant');
@@ -102,6 +103,19 @@ function enqueueUpdate(component, callback) {
     'isn\'t callable.'
   );
   ensureBatchingStrategy();
+
+  // Various parts of our code (such as ReactCompositeComponent's
+  // _renderValidatedComponent) assume that calls to render aren't nested;
+  // verify that that's the case. (This is called by each top-level update
+  // function, like setProps, setState, forceUpdate, etc.; creation and
+  // destruction of top-level components is guarded in ReactMount.)
+  invariant(
+    ReactCurrentOwner.current == null,
+    'enqueueUpdate(): Render methods should be a pure function of props ' +
+    'and state; triggering nested component updates from render is not ' +
+    'allowed. If necessary, trigger nested updates in ' +
+    'componentDidUpdate.'
+  );
 
   if (!batchingStrategy.isBatchingUpdates) {
     component.performUpdateIfNecessary();

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -1361,10 +1361,10 @@ describe('ReactCompositeComponent', function() {
     expect(() => {
       ReactTestUtils.renderIntoDocument(<Outer />);
     }).toThrow(
-      'Invariant Violation: Inner.render(): Render methods should be a pure ' +
-      'function of props and state; triggering nested component updates ' +
-      'from render is not allowed. If necessary, trigger nested updates in ' +
-      'componentDidUpdate.'
+      'Invariant Violation: _renderNewRootComponent(): Render methods should ' +
+      'be a pure function of props and state; triggering nested component ' +
+      'updates from render is not allowed. If necessary, trigger nested ' +
+      'updates in componentDidUpdate.'
     );
   });
 


### PR DESCRIPTION
In the future we could consider wrapping the entire public API (renderComponent, setProps, setState, etc) in this check but this should do for now.

Test Plan: grunt test
