### PR TITLE
Fix PropType for travis

### DIFF
--- a/src/core/ReactPropTypes.js
+++ b/src/core/ReactPropTypes.js
@@ -287,6 +287,11 @@ function getPropType(propValue) {
   if (Array.isArray(propValue)) {
     return 'array';
   }
+  if (propValue instanceof RegExp) {
+    // Some browsers return 'function' rather than 'object' for typeof a RegExp.
+    // We'll normalize this here so that /bla/ passes PropTypes.object.
+    return 'object';
+  }
   return propType;
 }
 
@@ -297,7 +302,7 @@ function getPreciseType(propValue) {
   if (propType === 'object') {
     if (propValue instanceof Date) {
       return 'date';
-    } else if(propValue instanceof RegExp) {
+    } else if (propValue instanceof RegExp) {
       return 'regexp';
     }
   }


### PR DESCRIPTION
Some browsers (including travis's phantom) recognize the type of a regexp as
a function (callable) rather than an object.
This is solely for making travis pass.

Test plan: make travis pass.
