### PR TITLE
Restore CSSTransitionGroup tests

### DIFF
--- a/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
@@ -125,7 +125,7 @@ describe('ReactCSSTransitionGroup', function() {
     expect(a.getDOMNode().childNodes[0].id).toBe('three');
     expect(a.getDOMNode().childNodes[1].id).toBe('two');
   });
-  return;
+
   it('should work with no children', function () {
     React.renderComponent(
       <ReactCSSTransitionGroup transitionName="yolo">


### PR DESCRIPTION
Not sure what happened here.

Test Plan: grunt test
