### PR TITLE
Improve `grunt test` performance

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,7 +20,7 @@ module.exports = function(grunt) {
     copy: require('./grunt/config/copy'),
     jsx: require('./grunt/config/jsx'),
     browserify: require('./grunt/config/browserify'),
-    populist: require('./grunt/config/populist'),
+    populist: require('./grunt/config/populist')(grunt),
     connect: require('./grunt/config/server')(grunt),
     "webdriver-jasmine": require('./grunt/config/webdriver-jasmine'),
     "webdriver-perf": require('./grunt/config/webdriver-perf'),
@@ -179,6 +179,13 @@ module.exports = function(grunt) {
     'test:webdriver:phantomjs',
     'coverage:parse'
   ]);
+  grunt.registerTask('fasttest', function() {
+    if (grunt.option('debug')) {
+      grunt.task.run('build:test', 'connect:server:keepalive');
+    } else {
+      grunt.task.run('build:test', 'test:webdriver:phantomjs');
+    }
+  });
   grunt.registerTask('test', function() {
     if (grunt.option('debug')) {
       grunt.task.run('build:test', 'build:basic', 'connect:server:keepalive');

--- a/grunt/config/populist.js
+++ b/grunt/config/populist.js
@@ -1,24 +1,32 @@
 'use strict';
 
-var jasmine = {
-  rootDirectory: "build/jasmine",
-  // This syntax means to require and expose the "jasmine" module
-  // (build/jasmine/jasmine.js) as global.jasmine, and to require the
-  // "all" module (build/jasmine/all.js) but not expose it globally.
-  args: ["jasmine:jasmine", "all:"],
-  outfile: "./build/jasmine.js"
-};
+module.exports = function(grunt) {
+  var jasmine = {
+    rootDirectory: "build/jasmine",
+    // This syntax means to require and expose the "jasmine" module
+    // (build/jasmine/jasmine.js) as global.jasmine, and to require the
+    // "all" module (build/jasmine/all.js) but not expose it globally.
+    args: ["jasmine:jasmine", "all:"],
+    outfile: "./build/jasmine.js"
+  };
 
-var test = {
-  rootDirectory: "build/modules",
-  args: ["test/all:harness"],
-  requires: [
-    "**/__tests__/*-test.js"
-  ],
-  outfile: './build/react-test.js'
-};
+  var filterExpr = grunt.option('filter');
 
-module.exports = {
-  jasmine: jasmine,
-  test: test
+  if (filterExpr) {
+    filterExpr = '**/__tests__/' + filterExpr + '-test.js';
+  } else {
+    filterExpr = '**/__tests__/*-test.js';
+  }
+
+  var test = {
+    rootDirectory: "build/modules",
+    args: ["test/all:harness"],
+    requires: [filterExpr],
+    outfile: './build/react-test.js'
+  };
+
+  return {
+    jasmine: jasmine,
+    test: test
+  };
 };


### PR DESCRIPTION
This brings warm cache `grunt test` time down to around 9 seconds (before this PR, it was 27 seconds).

Also adds `--test=name` flag to run a single unit test.
