### PR TITLE
Move key and ref to descriptor and read from there

### DIFF
--- a/src/core/ReactComponent.js
+++ b/src/core/ReactComponent.js
@@ -269,10 +269,10 @@ var ReactComponent = {
         'single component instance in multiple places.',
         rootID
       );
-      var props = this._descriptor.props;
-      if (props.ref != null) {
+      var ref = this._descriptor.ref;
+      if (ref != null) {
         var owner = this._descriptor._owner;
-        ReactOwner.addComponentAsRefTo(this, props.ref, owner);
+        ReactOwner.addComponentAsRefTo(this, ref, owner);
       }
       this._rootNodeID = rootID;
       this._lifeCycleState = ComponentLifeCycle.MOUNTED;
@@ -295,9 +295,9 @@ var ReactComponent = {
         this.isMounted(),
         'unmountComponent(): Can only unmount a mounted component.'
       );
-      var props = this.props;
-      if (props.ref != null) {
-        ReactOwner.removeComponentAsRefFrom(this, props.ref, this._owner);
+      var ref = this._descriptor.ref;
+      if (ref != null) {
+        ReactOwner.removeComponentAsRefFrom(this, ref, this._owner);
       }
       unmountIDFromEnvironment(this._rootNodeID);
       this._rootNodeID = null;
@@ -377,17 +377,17 @@ var ReactComponent = {
       // instantiateReactComponent is done.
 
       if (nextDescriptor._owner !== prevDescriptor._owner ||
-          nextDescriptor.props.ref !== prevDescriptor.props.ref) {
-        if (prevDescriptor.props.ref != null) {
+          nextDescriptor.ref !== prevDescriptor.ref) {
+        if (prevDescriptor.ref != null) {
           ReactOwner.removeComponentAsRefFrom(
-            this, prevDescriptor.props.ref, prevDescriptor._owner
+            this, prevDescriptor.ref, prevDescriptor._owner
           );
         }
         // Correct, even if the owner is the same, and only the ref has changed.
-        if (nextDescriptor.props.ref != null) {
+        if (nextDescriptor.ref != null) {
           ReactOwner.addComponentAsRefTo(
             this,
-            nextDescriptor.props.ref,
+            nextDescriptor.ref,
             nextDescriptor._owner
           );
         }

--- a/src/core/ReactDescriptor.js
+++ b/src/core/ReactDescriptor.js
@@ -59,7 +59,7 @@ function getCurrentOwnerDisplayName() {
  * @param {*} parentType component's parent's type.
  */
 function validateExplicitKey(component, parentType) {
-  if (component._store.validated || component.props.key != null) {
+  if (component._store.validated || component.key != null) {
     return;
   }
   component._store.validated = true;
@@ -285,6 +285,11 @@ ReactDescriptor.createFactory = function(type) {
     // TODO: Deprecate withContext, and then the context becomes accessible
     // through the owner.
     descriptor._context = ReactContext.current;
+
+    // These props are special and affect how the reconciler, etc. work so we
+    // pull them out to live on the descriptor
+    descriptor.key = props.key;
+    descriptor.ref = props.ref;
 
     if (__DEV__) {
       // The validation flag and props are currently mutative. We put them on

--- a/src/core/shouldUpdateReactComponent.js
+++ b/src/core/shouldUpdateReactComponent.js
@@ -32,10 +32,9 @@
  */
 function shouldUpdateReactComponent(prevDescriptor, nextDescriptor) {
   if (prevDescriptor && nextDescriptor &&
-      prevDescriptor.type === nextDescriptor.type && (
-        (prevDescriptor.props && prevDescriptor.props.key) ===
-        (nextDescriptor.props && nextDescriptor.props.key)
-      ) && prevDescriptor._owner === nextDescriptor._owner) {
+      prevDescriptor.type === nextDescriptor.type &&
+      prevDescriptor.key === nextDescriptor.key &&
+      prevDescriptor._owner === nextDescriptor._owner) {
     return true;
   }
   return false;

--- a/src/utils/traverseAllChildren.js
+++ b/src/utils/traverseAllChildren.js
@@ -54,9 +54,9 @@ function userProvidedKeyEscaper(match) {
  * @return {string}
  */
 function getComponentKey(component, index) {
-  if (component && component.props && component.props.key != null) {
+  if (component && component.key != null) {
     // Explicit key
-    return wrapUserProvidedKey(component.props.key);
+    return wrapUserProvidedKey(component.key);
   }
   // Implicit key determined by the index in the set
   return index.toString(36);


### PR DESCRIPTION
I think this probably makes sense; you could imagine a different factory that took key and ref separately from the props.

ReactPropTransferer/cloneWithProps still knows about `key` and `ref` but otherwise, React core doesn't look inside props now.

Test Plan: grunt test
