### PR TITLE
Create dummyNode at run time instead of include time

### DIFF
--- a/src/vendor/core/createNodesFromMarkup.js
+++ b/src/vendor/core/createNodesFromMarkup.js
@@ -28,9 +28,9 @@ var invariant = require('invariant');
 /**
  * Dummy container used to render all markup.
  */
-var dummyNode = function() {
+function getDummyNode() {
   return ExecutionEnvironment.canUseDOM ? document.createElement('div') : null;
-};
+}
 
 /**
  * Pattern used by `getNodeName`.
@@ -59,7 +59,7 @@ function getNodeName(markup) {
  * @return {array<DOMElement|DOMTextNode>} An array of rendered nodes.
  */
 function createNodesFromMarkup(markup, handleScript) {
-  var node = dummyNode();
+  var node = getDummyNode();
   invariant(!!node, 'createNodesFromMarkup dummy not initialized');
   var nodeName = getNodeName(markup);
 


### PR DESCRIPTION
I ran into a problem while testing using jsdom, where it would throw a "Wrong document" error when inserting a child node. I traced it back to the fact that the `dummyNode` variable is instantiated when the module is required and so its document can potentially be different to the one that the component is rendered to. The easiest fix I could find was just to create the dummyNode at run time instead. Not sure if this has any performance implications. 

First time contributor so let me know if I've missed anything!
