### PR TITLE
Add clearer invariant in processUpdates

### DIFF
--- a/src/browser/ui/dom/DOMChildrenOperations.js
+++ b/src/browser/ui/dom/DOMChildrenOperations.js
@@ -23,6 +23,7 @@ var Danger = require('Danger');
 var ReactMultiChildUpdateTypes = require('ReactMultiChildUpdateTypes');
 
 var getTextContentAccessor = require('getTextContentAccessor');
+var invariant = require('invariant');
 
 /**
  * The DOM property to use when setting text content.
@@ -118,6 +119,17 @@ var DOMChildrenOperations = {
         var updatedIndex = update.fromIndex;
         var updatedChild = update.parentNode.childNodes[updatedIndex];
         var parentID = update.parentID;
+
+        invariant(
+          updatedChild,
+          'processUpdates(): Unable to find child %s of element. This ' +
+          'probably means the DOM was unexpectedly mutated (e.g., by the ' +
+          'browser), usually due to forgetting a <tbody> when using tables ' +
+          'or nesting <p> or <a> tags. Try inspecting the child nodes of the ' +
+          'element with React ID `%s`.',
+          updatedIndex,
+          parentID
+        );
 
         initialChildren = initialChildren || {};
         initialChildren[parentID] = initialChildren[parentID] || [];


### PR DESCRIPTION
The `updatedChildren[j].parentNode.removeChild(updatedChildren[j]);` line below can fail if (1) we're moving/moving the same node twice or (2) the node we're looking for is gone completely. This makes it easier to distinguish between the two cases.

Perf shouldn't be a concern here because this is DOM code and invariants are fast in comparison.

Test Plan: grunt test
