### PR TITLE
Allow input elements to opt out of selection restoration

### DIFF
--- a/src/browser/ui/ReactInputSelection.js
+++ b/src/browser/ui/ReactInputSelection.js
@@ -41,7 +41,7 @@ var ReactInputSelection = {
       (elem.nodeName === 'INPUT' && elem.type === 'text') ||
       elem.nodeName === 'TEXTAREA' ||
       elem.contentEditable === 'true'
-    );
+    ) && !elem.getAttribute('data-react-skip-selection-restoration');
   },
 
   getSelectionInformation: function() {


### PR DESCRIPTION
Refs #1350

This PR is mainly to start a conversation. I'm not sure if this is the ideal implementation, and tests need to be added regardless. But I wanted to get some feedback before investing further time.

I'm building a new editor view for Atom with React, and selection restoration is costing ~2ms when handling text insertions. I'd like to selectively disable it for the hidden input element that receives input events on behalf of the editor.

With selection restoration:
![screenshot_2014-04-23_09_11_00](https://cloud.githubusercontent.com/assets/1789/2779455/369cf1ac-cafc-11e3-8189-3a5b1d719d80.png)

Without selection restoration:
![screenshot 2014-04-23 09 14 27](https://cloud.githubusercontent.com/assets/1789/2779392/8b98a5a8-cafb-11e3-8cfb-9fbcf68e393c.png)

Ideally I'd like to check a property on the component corresponding to the input node, like `unsafeSkipSelectionRestoration`, but I couldn't figure out how to map the raw DOM node back to the react component that originated it. Is there any global mapping of react id's to component instances?