### PR TITLE
Upgrade jstransform to 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "commoner": "^0.9.2",
     "esprima-fb": "~3001.1.0-dev-harmony-fb",
-    "jstransform": "~3.0.0"
+    "jstransform": "~4.0.0"
   },
   "devDependencies": {
     "benchmark": "~1.0.0",

--- a/vendor/fbtransform/visitors.js
+++ b/vendor/fbtransform/visitors.js
@@ -1,6 +1,7 @@
 /*global exports:true*/
 var es6ArrowFunctions = require('jstransform/visitors/es6-arrow-function-visitors');
 var es6Classes = require('jstransform/visitors/es6-class-visitors');
+var es6ObjectConciseMethod = require('jstransform/visitors/es6-object-concise-method-visitors');
 var es6ObjectShortNotation = require('jstransform/visitors/es6-object-short-notation-visitors');
 var es6RestParameters = require('jstransform/visitors/es6-rest-param-visitors');
 var es6Templates = require('jstransform/visitors/es6-template-visitors');
@@ -13,6 +14,7 @@ var reactDisplayName = require('./transforms/reactDisplayName');
 var transformVisitors = {
   'es6-arrow-functions': es6ArrowFunctions.visitorList,
   'es6-classes': es6Classes.visitorList,
+  'es6-object-concise-method': es6ObjectConciseMethod.visitorList,
   'es6-object-short-notation': es6ObjectShortNotation.visitorList,
   'es6-rest-params': es6RestParameters.visitorList,
   'es6-templates': es6Templates.visitorList,
@@ -24,6 +26,7 @@ var transformVisitors = {
  */
 var transformRunOrder = [
   'es6-arrow-functions',
+  'es6-object-concise-method',
   'es6-object-short-notation',
   'es6-classes',
   'es6-rest-params',


### PR DESCRIPTION
Also enables the object-concise-method transform for --harmony

closes #1438

Tested with `pbpaste | bin/jsx --harmony` (with this on clipboard):

``` js
var foo = {
  bar(x) {
    return x;
  }
};
```
