### PR TITLE
DataSet and AriaSet (RFC)

### DIFF
--- a/src/browser/ui/ReactDOMComponent.js
+++ b/src/browser/ui/ReactDOMComponent.js
@@ -20,6 +20,7 @@
 "use strict";
 
 var CSSPropertyOperations = require('CSSPropertyOperations');
+var CustomPropertyOperations = require('CustomPropertyOperations');
 var DOMProperty = require('DOMProperty');
 var DOMPropertyOperations = require('DOMPropertyOperations');
 var ReactBrowserComponentMixin = require('ReactBrowserComponentMixin');
@@ -34,6 +35,7 @@ var invariant = require('invariant');
 var keyOf = require('keyOf');
 var merge = require('merge');
 var mixInto = require('mixInto');
+var warning = require('warning');
 
 var deleteListener = ReactEventEmitter.deleteListener;
 var listenTo = ReactEventEmitter.listenTo;
@@ -43,6 +45,8 @@ var registrationNameModules = ReactEventEmitter.registrationNameModules;
 var CONTENT_TYPES = {'string': true, 'number': true};
 
 var STYLE = keyOf({style: null});
+var DATA_SET = keyOf({dataSet: null});
+var ARIA_SET = keyOf({ariaSet: null});
 
 var ELEMENT_NODE_TYPE = 1;
 
@@ -138,8 +142,43 @@ ReactDOMComponent.Mixin = {
   _createOpenTagMarkupAndPutListeners: function(transaction) {
     var props = this.props;
     var ret = this._tagOpen;
+    var propKey;
+    var dataSet = props.dataSet;
+    var ariaSet = props.ariaSet;
 
-    for (var propKey in props) {
+    if (__DEV__) {
+      for (propKey in props) {
+        if (!props.hasOwnProperty(propKey)) {
+          continue;
+        }
+        if (DOMProperty.isCustomAttribute(propKey)) {
+          warning(
+            false,
+            'Direct usage of data-* and aria-* is being deprecated. Use ' +
+            '`dataSet` and `ariaSet` instead, akin to `style`.'
+          );
+          break;
+        }
+      }
+    }
+
+    // We spread dataSet.* and ariaSet.* into `props` as data-* (hyphenated).
+    // Two reasons:
+    // 1. data-foo-bar and dataSet.fooBar will be merged correctly. The former
+    // should be deprecated soon.
+    // 2. We piggy ride on the following diffing procedure for data-* and aria-*
+    if (dataSet || ariaSet) {
+      props = merge(props);
+    }
+
+    if (dataSet) {
+      CustomPropertyOperations.spreadDataSetOntoPropsByMutating(props, dataSet);
+    }
+    if (ariaSet) {
+      CustomPropertyOperations.spreadAriaSetOntoPropsByMutating(props, ariaSet);
+    }
+
+    for (propKey in props) {
       if (!props.hasOwnProperty(propKey)) {
         continue;
       }
@@ -147,6 +186,10 @@ ReactDOMComponent.Mixin = {
       if (propValue == null) {
         continue;
       }
+      if (propKey === DATA_SET || propKey === ARIA_SET) {
+        continue;
+      }
+
       if (registrationNameModules[propKey]) {
         putListener(this._rootNodeID, propKey, propValue, transaction);
       } else {
@@ -266,9 +309,66 @@ ReactDOMComponent.Mixin = {
    */
   _updateDOMProperties: function(lastProps, transaction) {
     var nextProps = this.props;
-    var propKey;
     var styleName;
     var styleUpdates;
+    var propKey;
+
+    if (__DEV__) {
+      for (propKey in nextProps) {
+        if (!nextProps.hasOwnProperty(propKey)) {
+          continue;
+        }
+        if (DOMProperty.isCustomAttribute(propKey)) {
+          warning(
+            false,
+            'Direct usage of data-* and aria-* is being deprecated. Use ' +
+            '`dataSet` and `ariaSet` instead, akin to `style`.'
+          );
+          break;
+        }
+      }
+    }
+
+    // See `_createOpenTagMarkupAndPutListeners` for the reasoning for `dataSet`
+    // and `ariaSet`.
+    var lastDataSet = lastProps.dataSet;
+    var nextDataSet = nextProps.dataSet;
+    var lastAriaSet = lastProps.ariaSet;
+    var nextAriaSet = nextProps.ariaSet;
+
+    if (nextDataSet || nextAriaSet) {
+      nextProps = merge(this.props);
+    }
+    if (nextDataSet) {
+      CustomPropertyOperations.spreadDataSetOntoPropsByMutating(
+        nextProps,
+        nextDataSet
+      );
+      delete nextProps.dataSet;
+    }
+    if (nextAriaSet) {
+      CustomPropertyOperations.spreadAriaSetOntoPropsByMutating(
+        nextProps,
+        nextAriaSet
+      );
+      delete nextProps.ariaSet;
+    }
+
+    if (lastDataSet) {
+      CustomPropertyOperations.spreadDataSetOntoPropsByMutating(
+        lastProps,
+        lastDataSet
+      );
+      delete lastProps.dataSet;
+    }
+    if (lastAriaSet) {
+      CustomPropertyOperations.spreadAriaSetOntoPropsByMutating(
+        lastProps,
+        lastAriaSet
+      );
+      delete lastProps.ariaSet;
+    }
+
     for (propKey in lastProps) {
       if (nextProps.hasOwnProperty(propKey) ||
          !lastProps.hasOwnProperty(propKey)) {

--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -33,6 +33,7 @@ describe('ReactDOMComponent', function() {
     beforeEach(function() {
       React = require('React');
       ReactTestUtils = require('ReactTestUtils');
+      require('mock-modules').dumpCache();
 
       var ReactReconcileTransaction = require('ReactReconcileTransaction');
       transaction = new ReactReconcileTransaction();
@@ -111,6 +112,145 @@ describe('ReactDOMComponent', function() {
       expect(stubStyle.display).toEqual('block');
     });
 
+    it("should give one deprecation warning for setting data-* and aria-*",
+      () => {
+        spyOn(console, 'warn');
+        var message = 'Warning: Direct usage of data-* and aria-* is being ' +
+          'deprecated. Use `dataSet` and `ariaSet` instead, akin to `style`.';
+
+        var instance1 = ReactTestUtils.renderIntoDocument(
+          <div data-foo-bar="a" data-bar-baz="b" />
+        ).getDOMNode();
+
+        ReactTestUtils.renderIntoDocument(
+          <div aria-foo-bar="a" aria-bar-baz="b" />
+        );
+
+        expect(instance1.getAttribute('data-foo-bar')).toBe('a');
+        expect(instance1.getAttribute('data-bar-baz')).toBe('b');
+        expect(console.warn.argsForCall.length).toBe(2);
+        expect(console.warn.argsForCall[0][0]).toBe(message);
+        expect(console.warn.argsForCall[1][0]).toBe(message);
+      }
+    );
+
+    it('should render capitalized data & aria attributes correctly', () => {
+      var stub = ReactTestUtils.renderIntoDocument(
+        <div dataSet={{aBC: 'b'}} ariaSet={{aBC: 'b'}}/>
+      );
+      var instance = stub.getDOMNode();
+      expect(instance.getAttribute('data-a-b-c')).toBe('b');
+      expect(instance.getAttribute('aria-a-b-c')).toBe('b');
+
+      stub.receiveComponent({
+        props: {dataSet: {aBC: 'c'}, ariaSet: {aBC: 'c'}}
+      }, transaction);
+      expect(instance.getAttribute('data-a-b-c')).toBe('c');
+      expect(instance.getAttribute('aria-a-b-c')).toBe('c');
+    });
+
+    it('should warn for data-* and aria-* added at re-render', () => {
+      spyOn(console, 'warn');
+      var message = 'Warning: Direct usage of data-* and aria-* is being ' +
+        'deprecated. Use `dataSet` and `ariaSet` instead, akin to `style`.';
+
+      var stub = ReactTestUtils.renderIntoDocument(<div />);
+
+      stub.receiveComponent(
+        {props: {'data-foo': 'a', 'aria-bar': 'b'}},
+        transaction
+      );
+      expect(console.warn.argsForCall.length).toBe(1);
+      expect(console.warn.argsForCall[0][0]).toBe(message);
+    });
+
+    it("should update data-* and aria-* correctly", () => {
+      var stub = ReactTestUtils.renderIntoDocument(
+        <div data-foo-bar="a" data-bar-baz="b" aria-qux="c" />
+      );
+      var instance = stub.getDOMNode();
+
+      stub.receiveComponent({
+        props: {'data-foo-bar': "d", 'aria-what': 'd'}
+      }, transaction);
+      expect(instance.getAttribute('data-foo-bar')).toEqual('d');
+      expect(instance.getAttribute('data-bar-baz')).toEqual(null);
+      expect(instance.getAttribute('aria-qux')).toEqual(null);
+      expect(instance.getAttribute('aria-what')).toEqual('d');
+    });
+
+    it("should mix data-*, dataSet.*, aria-* and ariaSet correctly", () => {
+      spyOn(console, 'warn');
+      var warning = 'Warning: Direct usage of data-* and aria-* is being ' +
+        'deprecated. Use `dataSet` and `ariaSet` instead, akin to `style`.';
+
+      var instance1 = ReactTestUtils.renderIntoDocument(
+        <div data-foo-bar="a"
+          dataSet={{fooBar: 'b'}}
+          aria-foo-bar="c"
+          ariaSet={{fooBar: 'd'}}
+        />
+      ).getDOMNode();
+
+      var instance2 = ReactTestUtils.renderIntoDocument(
+        <div
+          ariaSet={{fooBar: 'd'}}
+          aria-foo-bar="c"
+          dataSet={{fooBar: 'b'}}
+          data-foo-bar="a"
+        />
+      ).getDOMNode();
+
+      expect(instance1.getAttribute('data-foo-bar')).toBe('b');
+      expect(instance1.getAttribute('aria-foo-bar')).toBe('d');
+      expect(instance2.getAttribute('data-foo-bar')).toBe('b');
+      expect(instance2.getAttribute('aria-foo-bar')).toBe('d');
+      expect(console.warn.argsForCall.length).toBe(2);
+      expect(console.warn.argsForCall[0][0]).toBe(warning);
+      expect(console.warn.argsForCall[1][0]).toBe(warning);
+    });
+
+    it("should handle dataSet as data-* and ariaSet as aria-*", () => {
+      var stub = ReactTestUtils.renderIntoDocument(
+        <div dataSet={{}} ariaSet={{}} />
+      );
+      var instance = stub.getDOMNode();
+
+      var dataSetup = {id: 42, firstName: 'Douglas'};
+      var ariaSetup = {id: 47, firstName: 'John'};
+      stub.receiveComponent(
+        {props: {dataSet: dataSetup, ariaSet: ariaSetup}},
+        transaction
+      );
+      expect(instance.getAttribute('data-id')).toEqual('42');
+      expect(instance.getAttribute('data-first-name')).toEqual('Douglas');
+      expect(instance.getAttribute('aria-id')).toEqual('47');
+      expect(instance.getAttribute('aria-first-name')).toEqual('John');
+
+      var dataReset = {firstName: ''};
+      var ariaReset = {id: ''};
+      stub.receiveComponent(
+        {props: {dataSet: dataReset, ariaSet: ariaReset}},
+        transaction
+      );
+      expect(instance.getAttribute('data-id')).toBe(null);
+      expect(instance.getAttribute('data-first-name')).toBe('');
+      expect(instance.getAttribute('aria-id')).toBe('');
+      expect(instance.getAttribute('aria-first-name')).toBe(null);
+    });
+
+    it("should update data if initially null", () => {
+      var stub = ReactTestUtils.renderIntoDocument(
+        <div dataSet={null} ariaSet={null} />
+      );
+      stub.receiveComponent(
+        {props: {dataSet: {id: 42}, ariaSet: {id: 20}}},
+        transaction
+      );
+      expect(stub.getDOMNode().getAttribute('data-id')).toBe('42');
+      expect(stub.getDOMNode().getAttribute('aria-id')).toBe('20');
+    });
+
     it("should remove attributes", function() {
       var stub = ReactTestUtils.renderIntoDocument(<img height='17' />);
 
@@ -148,6 +288,46 @@ describe('ReactDOMComponent', function() {
       stub.receiveComponent({props: {}}, transaction);
       expect(stubStyle.display).toEqual('');
       expect(stubStyle.color).toEqual('');
+    });
+
+    it("should clear a single data prop when changing dataSet", () => {
+      var data = {id: 42, firstName: 'Douglas'};
+      var stub = ReactTestUtils.renderIntoDocument(<div dataSet={data} />);
+      var instance = stub.getDOMNode();
+
+      stub.receiveComponent({props: {dataSet: {id: 20}}}, transaction);
+      expect(instance.getAttribute('data-id')).toEqual('20');
+      expect(instance.getAttribute('data-first-name')).toEqual(null);
+    });
+
+    it("should clear all the data when removing dataSet", () => {
+      var data = {id: 42, firstName: 'Douglas'};
+      var stub = ReactTestUtils.renderIntoDocument(<div dataSet={data} />);
+      var instance = stub.getDOMNode();
+
+      stub.receiveComponent({props: {}}, transaction);
+      expect(instance.getAttribute('data-id')).toEqual(null);
+      expect(instance.getAttribute('data-first-name')).toEqual(null);
+    });
+
+    it("should clear a single aria prop when changing ariaSet", () => {
+      var aria = {id: 42, firstName: 'Douglas'};
+      var stub = ReactTestUtils.renderIntoDocument(<div ariaSet={aria} />);
+      var instance = stub.getDOMNode();
+
+      stub.receiveComponent({props: {ariaSet: {id: 20}}}, transaction);
+      expect(instance.getAttribute('aria-id')).toEqual('20');
+      expect(instance.getAttribute('aria-first-name')).toEqual(null);
+    });
+
+    it("should clear all the aria when removing ariaSet", () => {
+      var aria = {id: 42, firstName: 'Douglas'};
+      var stub = ReactTestUtils.renderIntoDocument(<div ariaSet={aria} />);
+      var instance = stub.getDOMNode();
+
+      stub.receiveComponent({props: {}}, transaction);
+      expect(instance.getAttribute('aria-id')).toEqual(null);
+      expect(instance.getAttribute('aria-first-name')).toEqual(null);
     });
 
     it("should empty element when removing innerHTML", function() {

--- a/src/browser/ui/dom/CustomPropertyOperations.js
+++ b/src/browser/ui/dom/CustomPropertyOperations.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2013-2014 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @providesModule CustomPropertyOperations
+ * @typechecks static-only
+ */
+
+"use strict";
+
+// TODO: deprecate the old data-* way of setting data properties.
+var hyphenate = require('hyphenate');
+var memoizeStringOnly = require('memoizeStringOnly');
+
+var hyphenateKey = memoizeStringOnly(function(key) {
+  return hyphenate(key);
+});
+
+/**
+ * Operations for dealing with data-* properties.
+ */
+var CustomPropertyOperations = {
+  /**
+   * Spread the hyphenated keys of `dataSet` onto the props
+   *
+   * props: {a: 'b'}. object: {fooBar: 'c'}
+   * props then become {a: 'b', 'data-foo-bar': 'c'}
+   *
+   * @param {object} props The props to mutate
+   * @param {object} object `dataSet`
+   */
+  spreadDataSetOntoPropsByMutating: function(props, object) {
+    for (var key in object) {
+      if (!object.hasOwnProperty(key)) {
+        continue;
+      }
+      props[hyphenateKey('data-' + key)] = object[key];
+    }
+  },
+
+  spreadAriaSetOntoPropsByMutating: function(props, object) {
+    for (var key in object) {
+      if (!object.hasOwnProperty(key)) {
+        continue;
+      }
+      props[hyphenateKey('aria-' + key)] = object[key];
+    }
+  }
+};
+
+module.exports = CustomPropertyOperations;

--- a/src/core/ReactPropTransferer.js
+++ b/src/core/ReactPropTransferer.js
@@ -70,9 +70,12 @@ var TransferStrategies = {
    */
   ref: emptyFunction,
   /**
-   * Transfer the `style` prop (which is an object) by merging them.
+   * Transfer `style`, `dataSet` and `ariaSet` (which are objects) by merging
+   * them.
    */
-  style: transferStrategyMerge
+  style: transferStrategyMerge,
+  dataSet: transferStrategyMerge,
+  ariaSet: transferStrategyMerge
 };
 
 /**

--- a/src/core/__tests__/ReactPropTransferer-test.js
+++ b/src/core/__tests__/ReactPropTransferer-test.js
@@ -40,6 +40,10 @@ describe('ReactPropTransferer', function() {
             style={{display: 'block', color: 'green'}}
             type="text"
             value=""
+            data-foo-bar="a"
+            dataSet={{fooBar: 'b', barBaz: 'c'}}
+            aria-foo-bar="a"
+            ariaSet={{fooBar: 'b', barBaz: 'c'}}
           />
         );
       }
@@ -72,12 +76,16 @@ describe('ReactPropTransferer', function() {
   });
 
   it('should transfer using merge strategies', function() {
-    var instance =
+    var component =
       <TestComponent
         className="hidden_elem"
         style={{width: '100%', display: 'none'}}
+        data-foo-bar="this will not be assigned"
+        dataSet={{barBaz: 'not assigned', bazQux: 'assigned'}}
+        aria-foo-bar="this will not be assigned"
+        ariaSet={{barBaz: 'not assigned', bazQux: 'assigned'}}
       />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
+    var instance = ReactTestUtils.renderIntoDocument(component);
 
     reactComponentExpect(instance)
       .expectRenderedChild()
@@ -88,6 +96,18 @@ describe('ReactPropTransferer', function() {
             color: 'green',
             display: 'block',
             width: '100%'
+          },
+          'data-foo-bar': 'a',
+          dataSet: {
+            fooBar: 'b',
+            barBaz: 'c',
+            bazQux: 'assigned'
+          },
+          'aria-foo-bar': 'a',
+          ariaSet: {
+            fooBar: 'b',
+            barBaz: 'c',
+            bazQux: 'assigned'
           }
         });
   });


### PR DESCRIPTION
Fixes #1259.

aria-\* and data-\* should be deprecated soon. Right now it's a warning.
`<div data-foo="a" dataSet={{foo: 'b'}} />` <- gives the same warning
Under the hood ariaSet and dataSet are spread on props as aria-\* and data-\* (hyphenated), so the logic largely stays the same.
Tested on ie8.

RFC because this touches one of the hottest code paths and I feel bad about it. @petehunt @kmeht
