### PR TITLE
Bump jstransform dependency to point at 4.0.1 or higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "commoner": "^0.9.2",
     "esprima-fb": "~3001.1.0-dev-harmony-fb",
-    "jstransform": "~4.0.0"
+    "jstransform": "~4.0.1"
   },
   "devDependencies": {
     "benchmark": "~1.0.0",


### PR DESCRIPTION
As noted in https://github.com/facebook/react/issues/1454, jstransform 4.0.0 accidentally bumped it's dependency on `source-map` down to 0.1.8 (from 0.1.31).

jstransform@4.0.1 fixes this -- so bump react's dependency to point at that nothing before that version
