### PR TITLE
Don't double-escape style names

### DIFF
--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -252,6 +252,12 @@ describe('ReactDOMComponent', function() {
       expect(genMarkup({ className: 'a b' })).toHaveAttribute('class', 'a b');
       expect(genMarkup({ className: '' })).toHaveAttribute('class', '');
     });
+
+    it("should escape style names and values", function() {
+      expect(genMarkup({
+        style: {'b&ckground': '<3'}
+      })).toHaveAttribute('style', 'b&amp;ckground:&lt;3;');
+    });
   });
 
   describe('createContentMarkup', function() {

--- a/src/browser/ui/dom/CSSPropertyOperations.js
+++ b/src/browser/ui/dom/CSSPropertyOperations.js
@@ -22,12 +22,11 @@
 var CSSProperty = require('CSSProperty');
 
 var dangerousStyleValue = require('dangerousStyleValue');
-var escapeTextForBrowser = require('escapeTextForBrowser');
 var hyphenateStyleName = require('hyphenateStyleName');
 var memoizeStringOnly = require('memoizeStringOnly');
 
 var processStyleName = memoizeStringOnly(function(styleName) {
-  return escapeTextForBrowser(hyphenateStyleName(styleName));
+  return hyphenateStyleName(styleName);
 });
 
 /**
@@ -42,6 +41,7 @@ var CSSPropertyOperations = {
    *   "width:200px;height:0;"
    *
    * Undefined values are ignored so that declarative programming is easier.
+   * The result should be HTML-escaped before insertion into the DOM.
    *
    * @param {object} styles
    * @return {?string}


### PR DESCRIPTION
Previously we were escaping both in createMarkupForStyles and then in
createMarkupForProperty; now we escape only in the latter (otherwise the
hypothetical style name `b&ckground` would become `b&amp;amp;ckground`).

Test Plan: grunt fasttest
