### PR TITLE
Add `scryRenderedComponentsWithRef` and `findRenderedComponentWithRef`.

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -164,7 +164,6 @@ var ReactTestUtils = {
     return all[0];
   },
 
-
   /**
    * Finds all instance of components in the rendered tree that are DOM
    * components with the tag name matching `tagName`.
@@ -219,6 +218,35 @@ var ReactTestUtils = {
     if (all.length !== 1) {
       throw new Error(
         'Did not find exactly one match for componentType:' + componentType
+      );
+    }
+    return all[0];
+  },
+
+  /**
+   * Finds all instances of components with a `ref` equal to `refName`.
+   * @return an array of all the matches.
+   */
+  scryRenderedComponentsWithRef: function(root, refName) {
+    return ReactTestUtils.findAllInRenderedTree(root, function(inst) {
+      return !!(inst.refs && inst.refs[refName]);
+    });
+  },
+
+  /**
+   * Same as `scryRenderedComponentsWithRef` but expects there to be one result
+   * and returns that one result, or throws exception if there is any other
+   * number of matches besides one.
+   * @return {!ReactComponent} The one match.
+   */
+  findRenderedComponentWithRef: function(root, refName) {
+    var all = ReactTestUtils.scryRenderedComponentsWithRef(
+      root,
+      refName
+    );
+    if (all.length !== 1) {
+      throw new Error(
+        'Did not find exactly one match for refName:' + refName
       );
     }
     return all[0];


### PR DESCRIPTION
This allows for testing that a component has rendered a `ref` without needing to worry about its contents. E.g., when a child element does not deserve its own component but yet needs to be checked for existence.

This helper is especially powerful because it is markup agnostic in a similar fashion to `scryRenderedComponentsWithType` or `findRenderedComponentWithType`.