### PR TITLE
add srcObject and mozSrcObject attributes

### DIFF
--- a/src/browser/ui/dom/HTMLDOMPropertyConfig.js
+++ b/src/browser/ui/dom/HTMLDOMPropertyConfig.js
@@ -133,6 +133,8 @@ var HTMLDOMPropertyConfig = {
     /**
      * Non-standard Properties
      */
+    srcObject: MUST_USE_PROPERTY | HAS_SIDE_EFFECTS,
+    mozSrcObject: MUST_USE_PROPERTY | HAS_SIDE_EFFECTS,
     autoCapitalize: null, // Supported in Mobile Safari for keyboard hints
     autoCorrect: null, // Supported in Mobile Safari for keyboard hints
     property: null // Supports OG in meta tags


### PR DESCRIPTION
In previous versions of firefox in chrome (pre window.URL) this is how you attached MediaStreams to a video element.

``` js
el.srcObject = stream; // chrome and opera
el.mozSrcObject = stream; // firefox
```

To support those browsers I am proposing that these attributes be added so you can construct a video element like so:

``` js
// chrome
React.DOM.video({
  srcObject: stream
});

// firefox
React.DOM.video({
  mozSrcObject: stream
});
```

(CLA signed)
