### PR TITLE
Added support for itemscope, itemtype, itemprop attributes.

### DIFF
--- a/docs/docs/ref-04-tags-and-attributes.md
+++ b/docs/docs/ref-04-tags-and-attributes.md
@@ -57,14 +57,18 @@ accept accessKey action allowFullScreen allowTransparency alt async
 autoComplete autoFocus autoPlay cellPadding cellSpacing charSet checked
 className colSpan cols content contentEditable contextMenu controls data
 dateTime defer dir disabled draggable encType form formNoValidate frameBorder
-height hidden href htmlFor httpEquiv icon id itemProp itemScope itemType
-label lang list loop max maxLength method min multiple name noValidate
-pattern placeholder poster preload radioGroup readOnly rel required role
-rowSpan rows sandbox scope scrollLeft scrollTop seamless selected size span
-spellCheck src srcDoc step style tabIndex target title type value width wmode
+height hidden href htmlFor httpEquiv icon id label lang list loop max
+maxLength method min multiple name noValidate pattern placeholder poster
+preload radioGroup readOnly rel required role rowSpan rows sandbox scope
+scrollLeft scrollTop seamless selected size span spellCheck src srcDoc step
+style tabIndex target title type value width wmode
 ```
 
-In addition, the non-standard `autoCapitalize` and `autoCorrect` attributes are supported for Mobile Safari, and the `property` attribute is supported for Open Graph `<meta>` tags.
+In addition, the following non-standard attributes are supported:
+
+- `autoCapitalize autoCorrect` for Mobile Safari.
+- `property` for [Open Graph](http://ogp.me/) meta tags.
+- `itemProp itemScope itemType` for [HTML5 microdata](http://schema.org/docs/gs.html).
 
 There is also the React-specific attribute `dangerouslySetInnerHTML` ([more here](/react/docs/special-non-dom-attributes.html)), used for directly inserting HTML strings into a component.
 

--- a/src/browser/ui/dom/HTMLDOMPropertyConfig.js
+++ b/src/browser/ui/dom/HTMLDOMPropertyConfig.js
@@ -135,10 +135,10 @@ var HTMLDOMPropertyConfig = {
      */
     autoCapitalize: null, // Supported in Mobile Safari for keyboard hints
     autoCorrect: null, // Supported in Mobile Safari for keyboard hints
-    property: null, // Supports OG in meta tags
+    itemProp: MUST_USE_ATTRIBUTE, // Microdata: http://schema.org/docs/gs.html
     itemScope: MUST_USE_ATTRIBUTE | HAS_BOOLEAN_VALUE, // Microdata: http://schema.org/docs/gs.html
     itemType: MUST_USE_ATTRIBUTE, // Microdata: http://schema.org/docs/gs.html
-    itemProp: MUST_USE_ATTRIBUTE // Microdata: http://schema.org/docs/gs.html
+    property: null // Supports OG in meta tags
   },
   DOMAttributeNames: {
     className: 'class',


### PR DESCRIPTION
Related issue: #1126
Documentation: http://schema.org/docs/gs.html

**Sample:**

``` html
<div itemScope itemType="http://schema.org/Movie">
  <h1 itemProp="name">Avatar</h1>
  <span>Director: <span itemProp="director">James Cameron</span> (born August 16, 1954)</span>
  <span itemProp="genre">Science fiction</span>
  <a href="../movies/avatar-theatrical-trailer.html" itemProp="trailer">Trailer</a>
</div>
```

(I signed the CLA for what it's worth)
