### PR TITLE
Fix ReactEmptyComponent disappearing and throwing in IE8

### DIFF
--- a/src/browser/ui/ReactDefaultInjection.js
+++ b/src/browser/ui/ReactDefaultInjection.js
@@ -97,7 +97,7 @@ function inject() {
   ReactInjection.DOMProperty.injectDOMPropertyConfig(HTMLDOMPropertyConfig);
   ReactInjection.DOMProperty.injectDOMPropertyConfig(SVGDOMPropertyConfig);
 
-  ReactInjection.EmptyComponent.injectEmptyComponent(ReactDOM.script);
+  ReactInjection.EmptyComponent.injectEmptyComponent(ReactDOM.noscript);
 
   ReactInjection.Updates.injectReconcileTransaction(
     ReactComponentBrowserEnvironment.ReactReconcileTransaction

--- a/src/browser/ui/dom/setInnerHTML.js
+++ b/src/browser/ui/dom/setInnerHTML.js
@@ -52,7 +52,17 @@ if (ExecutionEnvironment.canUseDOM) {
         node.parentNode.replaceChild(node, node);
       }
 
-      if (html.match(/^[ \r\n\t\f]/)) {
+      // We also implement a workaround for non-visible tags disappearing into
+      // thin air on IE8, this only happens if there is no visible text
+      // in-front of the non-visible tags. Piggyback on the whitespace fix
+      // and simply check if any non-visible tags appear in the source.
+      if (html.match(/^[ \r\n\t\f]/) ||
+          html[0] === '<' && (
+            html.indexOf('<noscript') !== -1 ||
+            html.indexOf('<script') !== -1 ||
+            html.indexOf('<style') !== -1 ||
+            html.indexOf('<meta') !== -1 ||
+            html.indexOf('<link') !== -1)) {
         // Recover leading whitespace by temporarily prepending any character.
         // \uFEFF has the potential advantage of being zero-width/invisible.
         node.innerHTML = '\uFEFF' + html;

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -129,7 +129,7 @@ describe('ReactCompositeComponent', function() {
       .toBeDOMComponentWithTag('a');
   });
 
-  it('should render null and false as a script tag under the hood', () => {
+  it('should render null and false as a noscript tag under the hood', () => {
     var Component1 = React.createClass({
       render: function() {
         return null;
@@ -145,10 +145,10 @@ describe('ReactCompositeComponent', function() {
     var instance2 = ReactTestUtils.renderIntoDocument(<Component2 />);
     reactComponentExpect(instance1)
       .expectRenderedChild()
-      .toBeDOMComponentWithTag('script');
+      .toBeDOMComponentWithTag('noscript');
     reactComponentExpect(instance2)
       .expectRenderedChild()
-      .toBeDOMComponentWithTag('script');
+      .toBeDOMComponentWithTag('noscript');
   });
 
   it('should still throw when rendering to undefined', () => {


### PR DESCRIPTION
One possible fix for https://github.com/facebook/react/issues/1494 and at the same time enabling the safe use of non-visible tags in IE8 for React components as well.

The down-side is cost, http://jsperf.com/testnoscrip, in worst-case scenarios it's 20% slower, that is; there's no leading text and only one element being inserted. However, using a more precise test (with no hits) the overall performance seems to only dip by 6%. Looking at http://jsperf.com/testnoscrip/3 with 6 elements being inserted, the cost of the lookups has already become reduced to only 2% slower overall performance. **This does NOT include any overhead by React nor layouting/rendering, so the numbers should be significantly lower in practice.** Also, this obviously only affects IE8.

Another possibility is to _tag_ HTML insertions of non-visible tags inside React which could probably remove the overhead all-together, but I don't think there's an obvious non-intrusive way of doing it in React that would be worth it considering only IE8 is affected.

My PR implements the faster fix, including another check intended to further improve certain cases.

```
   raw     gz Compared to master @ 32b84a4c5ea32835b93a857cf00f0db86d6c755a
     =      = build/JSXTransformer-previous.js
     =      = build/JSXTransformer.js
     =      = build/react-previous.min.js
 -1477   +141 build/react-test.js
  +569   +184 build/react-with-addons.js
  +148    +45 build/react-with-addons.min.js
  +569   +181 build/react.js
  +148    +46 build/react.min.js
```
