### PR TITLE
[Docs] Add like button to tips/docs entries

### DIFF
--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -11,6 +11,8 @@ sectionid: docs
     <div class="subHeader">{{ page.description }}</div>
     {{ content }}
 
+    <div class="fb-like" data-send="true" data-width="650" data-show-faces="false"></div>
+
     <div class="docs-prevnext">
       {% if page.prev %}
         <a class="docs-prev" href="/react/docs/{{ page.prev }}">&larr; Prev</a>

--- a/docs/_layouts/tips.html
+++ b/docs/_layouts/tips.html
@@ -11,6 +11,8 @@ sectionid: tips
     <div class="subHeader">{{ page.description }}</div>
     {{ content }}
 
+    <div class="fb-like" data-send="true" data-width="650" data-show-faces="false"></div>
+
     <div class="docs-prevnext">
       {% if page.prev %}
         <a class="docs-prev" href="/react/tips/{{ page.prev }}">&larr; Prev</a>


### PR DESCRIPTION
Following #925 change of removing comments. Not sure why the button wasn't added then.
