### PR TITLE
JSX should use a "children" array instead of variable arguments

### DIFF
--- a/src/core/ReactDescriptor.js
+++ b/src/core/ReactDescriptor.js
@@ -275,6 +275,16 @@ ReactDescriptor.createFactory = function(type) {
         childArray[i] = arguments[i + 1];
       }
       props.children = childArray;
+    } else if (__DEV__) {
+      if (props.children) {
+        if (!Array.isArray(props.children)) {
+          validateChildKeys(props.children, type);
+        } else {
+          for (var i = 0; i < props.children.length; i++) {
+            validateChildKeys(props.children[i], type);
+          }
+        }
+      }
     }
 
     var descriptor = Object.create(descriptorPrototype);


### PR DESCRIPTION
Intuitively it seems like this would be a performance win as we can bypass the run-time addition of `children` to `props` and also avoid an array allocation/population if there are multiple children.

Does it really matter in the end? I made a very crude test for the perf-suite, it `renderComponent` the same tree 100 times (exact tree below).

Due to GCing kicking in often it's hard to provide any conclusive results. But after running the tests on IE11/Chrome many times I think I'm (imagining) seeing a consistent perf improvement of about ~1-3%. It seems like the graph is slightly less jaggy, but it could simply be a result of unrelated factors. So in large hierarchies (without `shouldComponentUpdate`) with lots of redundant descriptors it could probably provide a measurable but very minor improvement, but by and large it's probably safe to say it does not have a significant impact.

The downside to all of this is the produced code is not as neat and slightly bigger because of `children: []`, although the size should even out after GZ.

I'm probably :-1: on this myself but thought I'd post it FYI if you see it differently. Also, perhaps you still want my "addition" to `ReactDescriptor` that improves it to always check the validity of `props.children` (in `__DEV__`).

```
React.DOM.div({title: "abc", children: [
  React.DOM.div({title: "abc", children: [
    React.DOM.div({title: "abc", children: [
      React.DOM.div({title: "abc", children: "a"}),
      React.DOM.div({title: "abc", children: "b"}),
      React.DOM.div({title: "abc", children: "c"})
    ]}),
    React.DOM.div({title: "abc"}),
    React.DOM.div({title: "abc"})
  ]}),
  React.DOM.div({title: "abc"}),
  React.DOM.div({title: "abc"})
]})
```
