### PR TITLE
Proof of concept: Automatically determine MUST_USE_PROPERTY/ATTRIBUTE

### DIFF
--- a/src/browser/ui/dom/DOMProperty.js
+++ b/src/browser/ui/dom/DOMProperty.js
@@ -104,8 +104,8 @@ var DOMPropertyInjection = {
       }
 
       var propConfig = Properties[propName];
-      DOMProperty.mustUseAttribute[propName] =
-        propConfig & DOMPropertyInjection.MUST_USE_ATTRIBUTE;
+      //DOMProperty.mustUseAttribute[propName] =
+      //  propConfig & DOMPropertyInjection.MUST_USE_ATTRIBUTE;
       DOMProperty.mustUseProperty[propName] =
         propConfig & DOMPropertyInjection.MUST_USE_PROPERTY;
       DOMProperty.hasSideEffects[propName] =

--- a/src/browser/ui/dom/DOMPropertyOperations.js
+++ b/src/browser/ui/dom/DOMPropertyOperations.js
@@ -129,12 +129,19 @@ var DOMPropertyOperations = {
         mutationMethod(node, value);
       } else if (shouldIgnoreValue(name, value)) {
         this.deleteValueForProperty(node, name);
-      } else if (DOMProperty.mustUseAttribute[name]) {
-        node.setAttribute(DOMProperty.getAttributeName[name], '' + value);
       } else {
-        var propName = DOMProperty.getPropertyName[name];
-        if (!DOMProperty.hasSideEffects[name] || node[propName] !== value) {
-          node[propName] = value;
+        if (!((node.nodeName + '.' + name) in DOMProperty.mustUseAttribute)) {
+          var node2 = document.createElement(node.nodeName);
+          DOMProperty.mustUseAttribute[(node.nodeName + '.' + name)] =
+            !(DOMProperty.getPropertyName[name] in node2);
+        }
+        if (DOMProperty.mustUseAttribute[(node.nodeName + '.' + name)]) {
+          node.setAttribute(DOMProperty.getAttributeName[name], '' + value);
+        } else {
+          var propName = DOMProperty.getPropertyName[name];
+          if (!DOMProperty.hasSideEffects[name] || node[propName] !== value) {
+            node[propName] = value;
+          }
         }
       }
     } else if (DOMProperty.isCustomAttribute(name)) {
@@ -159,17 +166,24 @@ var DOMPropertyOperations = {
       var mutationMethod = DOMProperty.getMutationMethod[name];
       if (mutationMethod) {
         mutationMethod(node, undefined);
-      } else if (DOMProperty.mustUseAttribute[name]) {
-        node.removeAttribute(DOMProperty.getAttributeName[name]);
       } else {
-        var propName = DOMProperty.getPropertyName[name];
-        var defaultValue = DOMProperty.getDefaultValueForProperty(
-          node.nodeName,
-          propName
-        );
-        if (!DOMProperty.hasSideEffects[name] ||
-            node[propName] !== defaultValue) {
-          node[propName] = defaultValue;
+        if (!((node.nodeName + '.' + name) in DOMProperty.mustUseAttribute)) {
+          var node2 = document.createElement(node.nodeName);
+          DOMProperty.mustUseAttribute[(node.nodeName + '.' + name)] =
+            !(DOMProperty.getPropertyName[name] in node2);
+        }
+        if (DOMProperty.mustUseAttribute[(node.nodeName + '.' + name)]) {
+          node.removeAttribute(DOMProperty.getAttributeName[name]);
+        } else {
+          var propName = DOMProperty.getPropertyName[name];
+          var defaultValue = DOMProperty.getDefaultValueForProperty(
+            node.nodeName,
+            propName
+          );
+          if (!DOMProperty.hasSideEffects[name] ||
+              node[propName] !== defaultValue) {
+            node[propName] = defaultValue;
+          }
         }
       }
     } else if (DOMProperty.isCustomAttribute(name)) {


### PR DESCRIPTION
Hand meet glove #1449 (per node-type list of attributes/properties).
This is a super shitty implementation, but simply to get the discussion going.

Rather than manually determine if something is an attribute or property, this does it automatically. Combined with #1449 this could be done at start-up if preferred (well we could anyway, but then we'd have to keep a minimal set of elements and attributes/properties). Using the same principle we can also determine the type of each property, but it would not work attributes (I think?).

Supported by all browsers? Sure seems so, very quick testing in IE8 revealed no issues.

---

This naturally feeds into if we should even have these whitelists at all, but it seems like there's a handful of decidedly non-trivial issues/decisions that would have to be resolved/agreed upon. So I intentionally omitted it here to keep it focused, but obviously feel free to discuss it.

2 failed tests, but they are not indicative of a fundamental issue with this patch, simply "changing circumstances" that are coincidentally addressed by my other recent PRs.
