### PR TITLE
Allow passing a string directly to dangerouslySetInnerHTML

### DIFF
--- a/src/browser/ui/ReactDOMComponent.js
+++ b/src/browser/ui/ReactDOMComponent.js
@@ -185,8 +185,12 @@ ReactDOMComponent.Mixin = {
     // Intentional use of != to avoid catching zero/false.
     var innerHTML = this.props.dangerouslySetInnerHTML;
     if (innerHTML != null) {
+      // Support use of legacy {__html: } object for dangerouslySerInnerHTML
       if (innerHTML.__html != null) {
         return innerHTML.__html;
+      }
+      if (innerHTML.__html === undefined) {
+        return innerHTML;
       }
     } else {
       var contentToUse =
@@ -359,12 +363,20 @@ ReactDOMComponent.Mixin = {
     var nextContent =
       CONTENT_TYPES[typeof nextProps.children] ? nextProps.children : null;
 
-    var lastHtml =
-      lastProps.dangerouslySetInnerHTML &&
-      lastProps.dangerouslySetInnerHTML.__html;
-    var nextHtml =
-      nextProps.dangerouslySetInnerHTML &&
-      nextProps.dangerouslySetInnerHTML.__html;
+    var lastHtml = (
+      lastProps.dangerouslySetInnerHTML && (
+        lastProps.dangerouslySetInnerHTML.__html !== undefined ?
+          lastProps.dangerouslySetInnerHTML.__html :
+          lastProps.dangerouslySetInnerHTML
+      )
+    );
+    var nextHtml = (
+      nextProps.dangerouslySetInnerHTML && (
+        nextProps.dangerouslySetInnerHTML.__html !== undefined ?
+          nextProps.dangerouslySetInnerHTML.__html :
+          nextProps.dangerouslySetInnerHTML
+      )
+    );
 
     // Note the use of `!=` which checks for null or undefined.
     var lastChildren = lastContent != null ? null : lastProps.children;

--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -152,7 +152,7 @@ describe('ReactDOMComponent', function() {
 
     it("should empty element when removing innerHTML", function() {
       var stub = ReactTestUtils.renderIntoDocument(
-        <div dangerouslySetInnerHTML={{__html: ':)'}} />
+        <div dangerouslySetInnerHTML=":)" />
       );
 
       expect(stub.getDOMNode().innerHTML).toEqual(':)');
@@ -167,7 +167,7 @@ describe('ReactDOMComponent', function() {
 
       expect(stub.getDOMNode().innerHTML).toEqual('hello');
       stub.receiveComponent(
-        {props: {dangerouslySetInnerHTML: {__html: 'goodbye'}}},
+        {props: {dangerouslySetInnerHTML: 'goodbye'}},
         transaction
       );
       expect(stub.getDOMNode().innerHTML).toEqual('goodbye');
@@ -175,11 +175,35 @@ describe('ReactDOMComponent', function() {
 
     it("should transition from innerHTML to string content", function() {
       var stub = ReactTestUtils.renderIntoDocument(
-        <div dangerouslySetInnerHTML={{__html: 'bonjour'}} />
+        <div dangerouslySetInnerHTML="bonjour" />
       );
 
       expect(stub.getDOMNode().innerHTML).toEqual('bonjour');
       stub.receiveComponent({props: {children: 'adieu'}}, transaction);
+      expect(stub.getDOMNode().innerHTML).toEqual('adieu');
+    });
+
+    it("should transition from innerHTML legacy object to string", function() {
+      var stub = ReactTestUtils.renderIntoDocument(
+        <div dangerouslySetInnerHTML={{__html: 'bonjour'}} />
+      );
+
+      expect(stub.getDOMNode().innerHTML).toEqual('bonjour');
+      stub.receiveComponent({
+        props: {dangerouslySetInnerHTML: 'adieu'}
+      }, transaction);
+      expect(stub.getDOMNode().innerHTML).toEqual('adieu');
+    });
+
+    it("should transition from innerHTML string to legacy object", function() {
+      var stub = ReactTestUtils.renderIntoDocument(
+        <div dangerouslySetInnerHTML="bonjour" />
+      );
+
+      expect(stub.getDOMNode().innerHTML).toEqual('bonjour');
+      stub.receiveComponent({
+        props: {dangerouslySetInnerHTML: {__html: 'adieu'}}
+      }, transaction);
       expect(stub.getDOMNode().innerHTML).toEqual('adieu');
     });
 
@@ -282,16 +306,41 @@ describe('ReactDOMComponent', function() {
       this.addMatchers({
         toHaveInnerhtml: function(html) {
           var expected = '^' + quoteRegexp(html) + '$';
-          return this.actual.match(new RegExp(expected));
+          return ('' + this.actual).match(new RegExp(expected));
         }
       });
     });
 
     it("should handle dangerouslySetInnerHTML", function() {
-      var innerHTML = {__html: 'testContent'};
       expect(
-        genMarkup({ dangerouslySetInnerHTML: innerHTML })
+        genMarkup({dangerouslySetInnerHTML: 'testContent'})
       ).toHaveInnerhtml('testContent');
+
+      expect(
+        genMarkup({dangerouslySetInnerHTML: false})
+      ).toHaveInnerhtml('false');
+
+      expect(
+        genMarkup({dangerouslySetInnerHTML: null})
+      ).toHaveInnerhtml('');
+    });
+
+    it("should support dangerouslySetInnerHTML legacy object", function() {
+      expect(
+        genMarkup({dangerouslySetInnerHTML: {__html: 'testContent'}})
+      ).toHaveInnerhtml('testContent');
+
+      expect(
+        genMarkup({dangerouslySetInnerHTML: {__html: ''}})
+      ).toHaveInnerhtml('');
+
+      expect(
+        genMarkup({dangerouslySetInnerHTML: {__html: false}})
+      ).toHaveInnerhtml('false');
+
+      expect(
+        genMarkup({dangerouslySetInnerHTML: {__html: null}})
+      ).toHaveInnerhtml('');
     });
   });
 
@@ -359,7 +408,7 @@ describe('ReactDOMComponent', function() {
 
       expect(function() {
         React.renderComponent(
-          <div children="" dangerouslySetInnerHTML={{__html: ''}}></div>,
+          <div children="" dangerouslySetInnerHTML=""></div>,
           container
         );
       }).toThrow(

--- a/src/browser/ui/__tests__/ReactDOMIDOperations-test.js
+++ b/src/browser/ui/__tests__/ReactDOMIDOperations-test.js
@@ -34,7 +34,7 @@ describe('ReactDOMIDOperations', function() {
       ReactDOMIDOperations.updatePropertyByID(
         'testID',
         keyOf({dangerouslySetInnerHTML: null}),
-        {__html: 'testContent'}
+        'testContent'
       );
     }).toThrow();
 

--- a/src/core/__tests__/ReactMultiChildText-test.js
+++ b/src/core/__tests__/ReactMultiChildText-test.js
@@ -283,7 +283,7 @@ describe('ReactMultiChildText', function() {
   it('should throw if rendering both HTML and children', function() {
     expect(function() {
       ReactTestUtils.renderIntoDocument(
-        <div dangerouslySetInnerHTML={{_html: 'abcdef'}}>ghjkl</div>
+        <div dangerouslySetInnerHTML="abcdef">ghjkl</div>
       );
     }).toThrow();
   });


### PR DESCRIPTION
In response to #1370 and to move the discussion along.

As far as I understand it, `{__html: X}` is not _really_ intended as another safe-guard, but a remnant of how XHP worked/works.

Here's a fully backwards-compatible implementation, with a bunch of test-cases added to ensure correct functioning.

```
   raw     gz Compared to master @ 32b84a4c5ea32835b93a857cf00f0db86d6c755a
  -290    -34 build/JSXTransformer-previous.js
-19584  -3777 build/JSXTransformer.js
     =      = build/react-previous.min.js
 +3227   +434 build/react-test.js
  +421    +68 build/react-with-addons.js
  +170    +32 build/react-with-addons.min.js
  +421    +71 build/react.js
  +170    +23 build/react.min.js
```
