### PR TITLE
Preemptively error when required ES5 shim/shams are not available

### DIFF
--- a/src/browser/ui/React.js
+++ b/src/browser/ui/React.js
@@ -88,6 +88,34 @@ if (__DEV__) {
       'Download the React DevTools for a better development experience: ' +
       'http://fb.me/react-devtools'
     );
+
+    var expectedFeatures = [
+      // shims
+      Array.isArray,
+      Array.prototype.every,
+      Array.prototype.forEach,
+      Array.prototype.indexOf,
+      Array.prototype.map,
+      Date.now,
+      Function.prototype.bind,
+      Object.keys,
+      String.prototype.split,
+
+      // shams
+      Object.create,
+      Object.freeze
+    ];
+
+    for (var i in expectedFeatures) {
+      if (!expectedFeatures[i]) {
+        console.error(
+          'One or more ES5 shim/shams expected by React are not available: ' +
+          'http://facebook.github.io/react/docs/working-with-the-browser.html' +
+          '#polyfills-needed-to-support-older-browsers'
+        );
+        break;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
As per @andreypopp's idea in #1507, here's an implementation.

I searched through the React code and discovered the list of required shim/shams in the docs is not up-to-date and have updated _this_ PR accordingly (not the docs).

IE8 and really old (but still circulating) versions of most modern browsers are the troublemakers. So basically pretty much every browsers you'll run into has full support, except for a handful of visitors who lack most of them. http://kangax.github.io/compat-table/es5/

In order to keep an ecosystem of reusable components from second-guessing support (and us having to keep forgetting to update the list of required shims), I would recommend extending the list of required shims to include all ES5 shims (not shams): https://github.com/es-shims/es5-shim, it's not that many more and most are really useful.

_`__DEV__` only so didn't bother with size comparison._
