### PR TITLE
Use single quotes for strings generated by JSX

### DIFF
--- a/vendor/fbtransform/transforms/xjs.js
+++ b/vendor/fbtransform/transforms/xjs.js
@@ -188,7 +188,7 @@ function renderXJSLiteral(object, isLast, state, start, end) {
 
     if (trimmedLine || isLastNonEmptyLine) {
       utils.append(
-        JSON.stringify(trimmedLine) +
+        quoteLiteral(trimmedLine) +
         (!isLastNonEmptyLine ? " + ' ' +" : ''),
         state);
 
@@ -232,10 +232,20 @@ function renderXJSExpressionContainer(traverse, object, isLast, path, state) {
   return false;
 }
 
+function swapSingleDoubleQuotes(str) {
+  return str.replace(/['"]/g, function(str) {
+    return str === '"' ? '\'' : '"';
+  });
+}
+
+function quoteLiteral(str) {
+  return swapSingleDoubleQuotes(JSON.stringify(swapSingleDoubleQuotes(str)));
+}
+
 function quoteAttrName(attr) {
   // Quote invalid JS identifiers.
   if (!/^[a-z_$][a-z\d_$]*$/i.test(attr)) {
-    return "'" + attr + "'";
+    return quoteLiteral(attr);
   }
   return attr;
 }


### PR DESCRIPTION
Related #445

Kind of hacky, but very simple and robust if this is something we want to commit to.

Could easily make it configurable (certainly preferable), but I'm not familiar with the code/modules that makes up the JSX runnable and there doesn't seem to be an intuitive way of accessing options in the visitors themselves.
