### PR TITLE
Add setTimeout to AutoFocusMixin.

### DIFF
--- a/src/browser/ui/dom/components/AutoFocusMixin.js
+++ b/src/browser/ui/dom/components/AutoFocusMixin.js
@@ -24,7 +24,10 @@ var focusNode = require('focusNode');
 var AutoFocusMixin = {
   componentDidMount: function() {
     if (this.props.autoFocus) {
-      focusNode(this.getDOMNode());
+      var domNode = this.getDOMNode();
+      setTimeout(function () {
+        focusNode(domNode);
+      }, 0);
     }
   }
 };


### PR DESCRIPTION
This ensures the element gets focused after the component is mounted. Without it, the element may not be focused as the browser hasn't finished rendering it, an issue which I encountered.