### PR TITLE
Warn against contentEditable with children props

### DIFF
--- a/src/browser/ui/ReactDOMComponent.js
+++ b/src/browser/ui/ReactDOMComponent.js
@@ -58,6 +58,16 @@ function assertValidProps(props) {
     props.children == null || props.dangerouslySetInnerHTML == null,
     'Can only set one of `children` or `props.dangerouslySetInnerHTML`.'
   );
+  if (__DEV__) {
+    if (props.contentEditable && props.children != null) {
+      console.warn(
+        'A component is `contentEditable` and contains `children` managed by ' +
+        'React. It is now your responsibility to guarantee that none of those '+
+        'nodes are unexpectedly modified or duplicated. This is probably not ' +
+        'intentional.'
+      );
+    }
+  }
   invariant(
     props.style == null || typeof props.style === 'object',
     'The `style` prop expects a mapping from style properties to values, ' +

--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -335,6 +335,13 @@ describe('ReactDOMComponent', function() {
       );
     });
 
+    it("should warn about contentEditable and children", function() {
+      spyOn(console, 'warn');
+      mountComponent({ contentEditable: true, children: '' });
+      expect(console.warn.argsForCall.length).toBe(1);
+      expect(console.warn.argsForCall[0][0]).toContain('contentEditable');
+    });
+
     it("should validate against invalid styles", function() {
       expect(function() {
         mountComponent({ style: 'display: none' });
@@ -366,6 +373,16 @@ describe('ReactDOMComponent', function() {
         'Invariant Violation: Can only set one of `children` or ' +
         '`props.dangerouslySetInnerHTML`.'
       );
+    });
+
+    it("should warn about contentEditable and children", function() {
+      spyOn(console, 'warn');
+      React.renderComponent(
+        <div contentEditable><div /></div>,
+        container
+      );
+      expect(console.warn.argsForCall.length).toBe(1);
+      expect(console.warn.argsForCall[0][0]).toContain('contentEditable');
     });
 
     it("should validate against invalid styles", function() {


### PR DESCRIPTION
Implemented invariant to guard against #1466 

**EDIT:** Hmm, an argument against keeping `dangerouslySetInnerHTML` out of the validation would be that there are situations in which you might want, and it is practically feasible, to two-way bind a contentEditable (imagine; a regular text-field but slightly more flexible).
