### PR TITLE
Add classid property for <object/> tag

### DIFF
--- a/src/browser/ui/dom/HTMLDOMPropertyConfig.js
+++ b/src/browser/ui/dom/HTMLDOMPropertyConfig.js
@@ -55,7 +55,7 @@ var HTMLDOMPropertyConfig = {
     cellSpacing: null,
     charSet: MUST_USE_ATTRIBUTE,
     checked: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
-    classid: null,
+    classID: null,
     className: MUST_USE_PROPERTY,
     cols: MUST_USE_ATTRIBUTE | HAS_POSITIVE_NUMERIC_VALUE,
     colSpan: null,
@@ -139,6 +139,7 @@ var HTMLDOMPropertyConfig = {
     property: null // Supports OG in meta tags
   },
   DOMAttributeNames: {
+    classID: 'classid',
     className: 'class',
     htmlFor: 'for',
     httpEquiv: 'http-equiv'


### PR DESCRIPTION
This properties needed to work with ActiveX objects in IE, created by
`<object/>` tag.
