### PR TITLE
Add support to JSX transform for <hyphenated-tags>

### DIFF
--- a/vendor/fbtransform/transforms/react.js
+++ b/vendor/fbtransform/transforms/react.js
@@ -61,15 +61,42 @@ function visitReactTag(traverse, object, path, state) {
     throw new Error('Namespace tags are not supported. ReactJSX is not XML.');
   }
 
+  // Only identifiers can be fallback tags or need quoting. We don't need to
+  // handle quoting for other types.
+  var didAddTag = false;
+
   // Only identifiers can be fallback tags. XJSMemberExpressions are not.
-  var isFallbackTag =
-    nameObject.type === Syntax.XJSIdentifier &&
-    FALLBACK_TAGS.hasOwnProperty(nameObject.name);
+  if (nameObject.type === Syntax.XJSIdentifier) {
+    var tagName = nameObject.name;
+    var quotedTagName = quoteAttrName(tagName);
 
-  utils.append(isFallbackTag ? jsxObjIdent + '.' : '', state);
+    if (FALLBACK_TAGS.hasOwnProperty(tagName)) {
+      // "Properly" handle invalid identifiers, like <font-face>, which needs to
+      // be enclosed in quotes.
+      var predicate =
+        tagName === quotedTagName ?
+          ('.' + tagName) :
+          ('[' + quotedTagName + ']');
+      utils.append(jsxObjIdent + predicate, state);
+      utils.move(nameObject.range[1], state);
+      didAddTag = true;
+    } else if (tagName !== quotedTagName) {
+      // If we're in the case where we need to quote and but don't recognize the
+      // tag, throw.
+      throw new Error(
+        'Tags must be valid JS identifiers or a recognized special case. `<' +
+        tagName + '>` is not one of them.'
+      );
+    }
+  }
 
-  utils.move(nameObject.range[0], state);
-  utils.catchup(nameObject.range[1], state);
+  // Use utils.catchup in this case so we can easily handle XJSMemberExpressions
+  // which look like Foo.Bar.Baz. This also handles unhyphenated XJSIdentifiers
+  // that aren't fallback tags.
+  if (!didAddTag) {
+    utils.move(nameObject.range[0], state);
+    utils.catchup(nameObject.range[1], state);
+  }
 
   utils.append('(', state);
 
@@ -193,3 +220,4 @@ visitReactTag.test = function(object, path, state) {
 exports.visitorList = [
   visitReactTag
 ];
+

--- a/vendor/fbtransform/transforms/xjs.js
+++ b/vendor/fbtransform/transforms/xjs.js
@@ -19,6 +19,7 @@ var Syntax = require('esprima-fb').Syntax;
 var utils = require('jstransform/src/utils');
 
 var knownTags = {
+  'font-face': true,
   a: true,
   abbr: true,
   address: true,


### PR DESCRIPTION
This really only adds support for tags in our knownTags list. If we want
to support SVG fully we'll need to do that OR we do like we do for
styles and force camelCase.

Tested with `<font-face/>` which produces `React.DOM["font-face"]`. See #938 for even more.
