### PR TITLE
[idea] Construct an array of strings for transactions instead of one big string

### DIFF
--- a/src/browser/ReactReconcileTransaction.js
+++ b/src/browser/ReactReconcileTransaction.js
@@ -132,6 +132,7 @@ function ReactReconcileTransaction() {
   // accessible and defaults to false when `ReactDOMComponent` and
   // `ReactTextComponent` checks it in `mountComponent`.`
   this.renderToStaticMarkup = false;
+  this.markupFragments = [];
   this.reactMountReady = CallbackQueue.getPooled(null);
   this.putListenerQueue = ReactPutListenerQueue.getPooled();
 }
@@ -169,6 +170,8 @@ var Mixin = {
 
     ReactPutListenerQueue.release(this.putListenerQueue);
     this.putListenerQueue = null;
+
+    this.markupFragments.length = 0;
   }
 };
 

--- a/src/browser/ReactTextComponent.js
+++ b/src/browser/ReactTextComponent.js
@@ -77,8 +77,8 @@ mixInto(ReactTextComponent, {
       return escapedText;
     }
 
-    return (
-      '<span ' + DOMPropertyOperations.createMarkupForID(rootID) + '>' +
+    transaction.markupFragments.push(
+      '<span' + DOMPropertyOperations.createMarkupForID(rootID) + '>' +
         escapedText +
       '</span>'
     );

--- a/src/browser/server/ReactServerRendering.js
+++ b/src/browser/server/ReactServerRendering.js
@@ -50,8 +50,10 @@ function renderComponentToString(component) {
 
     return transaction.perform(function() {
       var componentInstance = instantiateReactComponent(component);
-      var markup = componentInstance.mountComponent(id, transaction, 0);
-      return ReactMarkupChecksum.addChecksumToMarkup(markup);
+      componentInstance.mountComponent(id, transaction, 0);
+      return ReactMarkupChecksum.addChecksumToMarkup(
+        transaction.markupFragments.join('')
+      );
     }, null);
   } finally {
     ReactServerRenderingTransaction.release(transaction);
@@ -76,7 +78,8 @@ function renderComponentToStaticMarkup(component) {
 
     return transaction.perform(function() {
       var componentInstance = instantiateReactComponent(component);
-      return componentInstance.mountComponent(id, transaction, 0);
+      componentInstance.mountComponent(id, transaction, 0);
+      return transaction.markupFragments.join('')
     }, null);
   } finally {
     ReactServerRenderingTransaction.release(transaction);

--- a/src/browser/server/ReactServerRenderingTransaction.js
+++ b/src/browser/server/ReactServerRenderingTransaction.js
@@ -67,6 +67,7 @@ var TRANSACTION_WRAPPERS = [
 function ReactServerRenderingTransaction(renderToStaticMarkup) {
   this.reinitializeTransaction();
   this.renderToStaticMarkup = renderToStaticMarkup;
+  this.markupFragments = [];
   this.reactMountReady = CallbackQueue.getPooled(null);
   this.putListenerQueue = ReactPutListenerQueue.getPooled();
 }
@@ -103,6 +104,8 @@ var Mixin = {
 
     ReactPutListenerQueue.release(this.putListenerQueue);
     this.putListenerQueue = null;
+
+    this.markupFragments = [];
   }
 };
 

--- a/src/browser/ui/dom/DOMPropertyOperations.js
+++ b/src/browser/ui/dom/DOMPropertyOperations.js
@@ -80,8 +80,10 @@ var DOMPropertyOperations = {
    * @return {string} Markup string.
    */
   createMarkupForID: function(id) {
-    return processAttributeNameAndPrefix(DOMProperty.ID_ATTRIBUTE_NAME) +
-      escapeTextForBrowser(id) + '"';
+    return (
+      ' ' + processAttributeNameAndPrefix(DOMProperty.ID_ATTRIBUTE_NAME) +
+      escapeTextForBrowser(id) + '"'
+    );
   },
 
   /**
@@ -94,25 +96,27 @@ var DOMPropertyOperations = {
   createMarkupForProperty: function(name, value) {
     if (DOMProperty.isStandardName[name]) {
       if (shouldIgnoreValue(name, value)) {
-        return '';
+        return;
       }
       var attributeName = DOMProperty.getAttributeName[name];
       if (DOMProperty.hasBooleanValue[name] ||
           (DOMProperty.hasOverloadedBooleanValue[name] && value === true)) {
         return escapeTextForBrowser(attributeName);
       }
-      return processAttributeNameAndPrefix(attributeName) +
-        escapeTextForBrowser(value) + '"';
+      return (
+        ' ' + processAttributeNameAndPrefix(attributeName) +
+        escapeTextForBrowser(value) + '"'
+      );
     } else if (DOMProperty.isCustomAttribute(name)) {
-      if (value == null) {
-        return '';
+      if (value != null) {
+        return (
+          ' ' + processAttributeNameAndPrefix(name) +
+          escapeTextForBrowser(value) + '"'
+        );
       }
-      return processAttributeNameAndPrefix(name) +
-        escapeTextForBrowser(value) + '"';
     } else if (__DEV__) {
       warnUnknownProperty(name);
     }
-    return null;
   },
 
   /**

--- a/src/core/ReactComponent.js
+++ b/src/core/ReactComponent.js
@@ -409,8 +409,12 @@ var ReactComponent = {
         container,
         transaction,
         shouldReuseMarkup) {
-      var markup = this.mountComponent(rootID, transaction, 0);
-      mountImageIntoNode(markup, container, shouldReuseMarkup);
+      this.mountComponent(rootID, transaction, 0);
+      mountImageIntoNode(
+        transaction.markupFragments.join(''),
+        container,
+        shouldReuseMarkup
+      );
     },
 
     /**

--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -1130,14 +1130,14 @@ var ReactCompositeComponentMixin = {
         var prevComponentID = prevComponentInstance._rootNodeID;
         prevComponentInstance.unmountComponent();
         this._renderedComponent = instantiateReactComponent(nextDescriptor);
-        var nextMarkup = this._renderedComponent.mountComponent(
+        this._renderedComponent.mountComponent(
           thisID,
           transaction,
           this._mountDepth + 1
         );
         ReactComponent.BackendIDOperations.dangerouslyReplaceNodeWithMarkupByID(
           prevComponentID,
-          nextMarkup
+          transaction.markupFragments.join('')
         );
       }
     }

--- a/src/core/ReactMultiChild.js
+++ b/src/core/ReactMultiChild.js
@@ -187,7 +187,6 @@ var ReactMultiChild = {
      */
     mountChildren: function(nestedChildren, transaction) {
       var children = flattenChildren(nestedChildren);
-      var mountImages = [];
       var index = 0;
       this._renderedChildren = children;
       for (var name in children) {
@@ -199,17 +198,15 @@ var ReactMultiChild = {
           children[name] = childInstance;
           // Inlined for performance, see `ReactInstanceHandles.createReactID`.
           var rootID = this._rootNodeID + name;
-          var mountImage = childInstance.mountComponent(
+          childInstance.mountComponent(
             rootID,
             transaction,
             this._mountDepth + 1
           );
           childInstance._mountIndex = index;
-          mountImages.push(mountImage);
           index++;
         }
       }
-      return mountImages;
     },
 
     /**
@@ -396,11 +393,13 @@ var ReactMultiChild = {
     _mountChildByNameAtIndex: function(child, name, index, transaction) {
       // Inlined for performance, see `ReactInstanceHandles.createReactID`.
       var rootID = this._rootNodeID + name;
-      var mountImage = child.mountComponent(
+      child.mountComponent(
         rootID,
         transaction,
         this._mountDepth + 1
       );
+      var mountImage = transaction.markupFragments.join('');
+      transaction.markupFragments.length = 0;
       child._mountIndex = index;
       this.createChild(child, mountImage);
       this._renderedChildren = this._renderedChildren || {};


### PR DESCRIPTION
Another poo-commit.

It can probably be improved further (performance wise), but it has some interesting results, Chrome: http://imgur.com/pHROMTO (right/red is this PR, left/black is master)

While I find that those perf tests tend to differ between each try, there are some tests that seem to show a significant and stable improvement of 5-8% it seems. I would also assume that this improvement increases for larger DOM updates (especially the initial rendering).

Running it through my old "torture-test" of mounting and unmounting a large tree, IE8 shows 0 difference, but IE9 runs 20% faster and IE10/FF runs 10% faster and IE11/Chrome is around 5% faster (just for mount+unmount, so no rendering involved and not layouting either I think).

I'm assuming this would also put significantly less pressure on the GC as new strings don't have to be created for every concatenation.

Pending your input on whether to proceed (and do it proper) or not.
