### PR TITLE
Proof-of-concept, relative react IDs

### DIFF
--- a/perf/lib/BrowserPerfRunnerApp.react.js
+++ b/perf/lib/BrowserPerfRunnerApp.react.js
@@ -33,7 +33,7 @@ var BrowserPerfRunnerApp = React.createClass({
 
   handleComplete: function(queueItem){
     queueItem.completed = true;
-    
+
     if (!this.props.onCompleteEach) {
       return;
     }
@@ -53,7 +53,7 @@ var BrowserPerfRunnerApp = React.createClass({
       .map(function(key){return this.state.results[key];}, this)
     ;
     this.props.onCompleteEach(resultsForAllVersions);
-    
+
     if (this.props.onComplete && incompleteCount === 0) {
       this.props.onComplete(this.state.results);
     }
@@ -99,7 +99,7 @@ BrowserPerfRunnerApp.renderBenchmarkCell = function(props, row, col){
       return benchmark && !benchmark.isRunning && benchmark.stats;
     })
   ;
-  
+
   if (col == null) return React.DOM.th({style:{verticalAlign:'top', textAlign:'right'}},
     React.DOM.a({href:'?test=' + row}, benchmarks[0] && benchmarks[0].name || row)
   );
@@ -107,8 +107,8 @@ BrowserPerfRunnerApp.renderBenchmarkCell = function(props, row, col){
   var key = row + '@' + col;
   var benchmark = props.value[key];
   if (!(benchmark && benchmark.stats)) return React.DOM.td({key:key});
- 
- 
+
+
   var colors = [
     '000000',
     'AA0000',
@@ -197,8 +197,11 @@ var GridViewTable = React.createClass({
 
   render: function(){
     return React.DOM.table(null,
-      this._renderRow(null, 0),
-      this.props.rows.map(this._renderRow, this)
+      React.DOM.tbody(
+        null,
+        this._renderRow(null, 0),
+        this.props.rows.map(this._renderRow, this)
+      )
     );
   }
 

--- a/perf/lib/perf-test-runner.browser.js
+++ b/perf/lib/perf-test-runner.browser.js
@@ -40,9 +40,9 @@ perfRunner.WriteReactLibScript = function(params){
   } else {
     minSuffix = '.min';
   }
-  
+
   if (params.version && typeof params.version != 'string') throw TypeError("Expected 'version' to be a string");
-  
+
   if (params.version == 'edge' || !params.version) {
     console.log('React edge (local)');
     perfRunner.WriteScript({src:'../build/react' + minSuffix + '.js'});
@@ -83,7 +83,7 @@ perfRunner.getQueryParamArray = function(key){
   var values;
   var queryString = location.search.substr(1);
   var _key = encodeURIComponent(key) + '=';
-  
+
   if (queryString.indexOf(_key) > -1) {
     values = queryString
       .split(_key)
@@ -98,7 +98,7 @@ perfRunner.getQueryParamArray = function(key){
       })
     ;
   }
-  
+
   perfRunner.assert(values && values.length && values[0], 'expected ' + key + ' query param');
   return values;
 }
@@ -142,7 +142,7 @@ perfRunner.quickBench = function(benchmarkOptions, onComplete, onBeforeStart){
   bench.on('cycle', function(){
     var bench = this,
         size = bench.stats.size;
-  
+
     if (!bench.aborted) {
       console.warn(bench.name + ' × ' + bench.count +
         ' (' + bench.stats.sample.length + ' samples)' +
@@ -162,12 +162,12 @@ perfRunner.quickBench = function(benchmarkOptions, onComplete, onBeforeStart){
       // times: bench.times,
       // stats: bench.stats
     };
-    
+
     results['s/op'] = bench.stats.mean
     results['ms/op'] = results['s/op'] * 1000
     results['op/s'] = 1 / results['s/op']
     results["% frame 60"] = results['ms/op'] / (1000 / 60) * 100
-    
+
     console.log(results);
     onComplete(null, results);
   });
@@ -192,13 +192,15 @@ perfRunner.singleTest = function(benchmarkOptions, onComplete){
 perfRunner.ViewObject = function(props){
   var value = props.value;
   delete props.value;
-  
+
   if (typeof value != 'object') return React.DOM.span(props, [JSON.stringify(value), " ", typeof value]);
-  
-  return React.DOM.table(props, Object.keys(value).map(function(key){
-    return React.DOM.tr(null,
-      React.DOM.th(null, key),
-      React.DOM.td(null, perfRunner.ViewObject({key:key, value:value[key]}))
-    );
-  }));
+
+  return React.DOM.table(props,
+    React.DOM.tbody(null, Object.keys(value).map(function(key){
+      return React.DOM.tr(null,
+        React.DOM.th(null, key),
+        React.DOM.td(null, perfRunner.ViewObject({key:key, value:value[key]}))
+      )
+    }))
+  );
 }

--- a/src/browser/ui/dom/DOMPropertyOperations.js
+++ b/src/browser/ui/dom/DOMPropertyOperations.js
@@ -81,7 +81,7 @@ var DOMPropertyOperations = {
    */
   createMarkupForID: function(id) {
     return processAttributeNameAndPrefix(DOMProperty.ID_ATTRIBUTE_NAME) +
-      escapeTextForBrowser(id) + '"';
+      escapeTextForBrowser(id.substr(id.lastIndexOf('.') + 1)) + '"';
   },
 
   /**

--- a/src/core/ReactInstanceHandles.js
+++ b/src/core/ReactInstanceHandles.js
@@ -229,7 +229,7 @@ var ReactInstanceHandles = {
    * @return {string} A React root ID.
    */
   createReactRootID: function() {
-    return getReactRootIDString(ReactRootIndex.createReactRootIndex());
+    return getReactRootIDString('#' + ReactRootIndex.createReactRootIndex());
   },
 
   /**


### PR DESCRIPTION
cc @petehunt

I did a quick take on it to see what the outcome was, so here it is, each node only has a relative ID. Having to traverse up the tree to reconstruct the key is significantly expensive though (not surprisingly). The only two ways out of that is to cache the reconstructed key in each node traversed (ick) or to use an absolute ID at say custom component roots, which would significantly limit the depth.

Results: http://i.imgur.com/EzkzZkp.png

As you can see, two of the tests has taken a _significant_ hit, presumably from `ReactMount.getID` becoming significantly more expensive due to having to reconstruct the ID. Expectedly though, the brute renderComponent test shows a significant ~11% improvement, presumably from the significantly shorter HTML generated.

---

Having run some basic performance tests on [mounting + unmounting], and [mounting + traversing + unmount], it doesn't seem like there's a significant cost to traverse all inserted nodes. Given that `data-reactid` actually seems to add a measurably significant cost during insertion into the DOM, I'm feeling confident that removing the `data-reactid` attribute and immediately traversing the DOM would compete in performance. It would also bring with it a bunch of other significant benefits; all DOM components already have a ref to its node, less DOM clutter, less bloat for server-rendered DOM, etc.

I'm not familiar enough with the core, but intuitively it seems like traversing the inserted DOM and renderedComponents in sync should be fairly straight-forward. Additionally, since we're traversing the DOM, rather than invent a react ID at all, it seems like it should be enough to just put a "hidden" reference directly to each DOM component in each node. You now have a super cheap `DOM node <=> ReactDOMComponent`. Additionally, we would no longer need to maintain the `nodeCache` either.

Perhaps there are technical issues standing in the way, but it would seem like the same information could also be used in `DOMChildrenOperations` to remove the dependency on `_mountIndex`, which would be a **very** good thing (but perhaps it's just wishful thinking).
