### PR TITLE
Add support for patternUnits attribute. Fix #1535

### DIFF
--- a/src/browser/ui/dom/HTMLDOMPropertyConfig.js
+++ b/src/browser/ui/dom/HTMLDOMPropertyConfig.js
@@ -116,7 +116,6 @@ var HTMLDOMPropertyConfig = {
     name: null,
     noValidate: HAS_BOOLEAN_VALUE,
     pattern: null,
-    patternUnits: null,
     placeholder: null,
     poster: null,
     preload: null,

--- a/src/browser/ui/dom/SVGDOMPropertyConfig.js
+++ b/src/browser/ui/dom/SVGDOMPropertyConfig.js
@@ -37,6 +37,7 @@ var SVGDOMPropertyConfig = {
     gradientTransform: MUST_USE_ATTRIBUTE,
     gradientUnits: MUST_USE_ATTRIBUTE,
     offset: MUST_USE_ATTRIBUTE,
+    patternUnits: MUST_USE_ATTRIBUTE,
     points: MUST_USE_ATTRIBUTE,
     preserveAspectRatio: MUST_USE_ATTRIBUTE,
     r: MUST_USE_ATTRIBUTE,
@@ -63,6 +64,7 @@ var SVGDOMPropertyConfig = {
   DOMAttributeNames: {
     gradientTransform: 'gradientTransform',
     gradientUnits: 'gradientUnits',
+    patternUnits: 'patternUnits',
     preserveAspectRatio: 'preserveAspectRatio',
     spreadMethod: 'spreadMethod',
     stopColor: 'stop-color',


### PR DESCRIPTION
This fixes #1535

The `patternUnits` attribute defines how a pattern's coordinate system is defined (x, y, width, height). This is particularly important when using repeatable patterns in SVG. This commit adds this attribute to the lists of known properties.

I used #1487 as a reference point, please let me know if this needs to be added anywhere else.

![result](https://cloud.githubusercontent.com/assets/590904/3005355/f2f46d16-dddb-11e3-9829-174edf4c71bd.jpg)
