### PR TITLE
Fix 1530 - Asynchronously load scripts with JSX transformer

### DIFF
--- a/vendor/browser-transforms.js
+++ b/vendor/browser-transforms.js
@@ -148,9 +148,9 @@ var load = exports.load = function(url, callback) {
   xhr = window.ActiveXObject ? new window.ActiveXObject('Microsoft.XMLHTTP')
                              : new XMLHttpRequest();
 
-  // Disable async since we need to execute scripts in the order they are in the
+  // async, however scripts will be executed in the order they are in the
   // DOM to mirror normal script loading.
-  xhr.open('GET', url, false);
+  xhr.open('GET', url, true);
   if ('overrideMimeType' in xhr) {
     xhr.overrideMimeType('text/plain');
   }
@@ -182,13 +182,20 @@ runScripts = function() {
 
   console.warn("You are using the in-browser JSX transformer. Be sure to precompile your JSX for production - http://facebook.github.io/react/docs/tooling-integration.html#jsx");
 
-  jsxScripts.forEach(function(script) {
+  function tick() {
+    if (!jsxScripts.length) return;
+
+    var script = jsxScripts.shift();
+
     if (script.src) {
-      load(script.src);
+      load(script.src, tick);
     } else {
       run(script.innerHTML, null);
+      tick();
     }
-  });
+  }
+
+  tick();
 };
 
 if (typeof window !== "undefined" && window !== null) {


### PR DESCRIPTION
I was kind of curious about how this script worked, so I took a stab at #1530. The implementation is fairly simple, an enhancement would be to load all of the script tags in parallel and then `run` them sequentially.

But, this gets the waterfall without synchronize requests on [an example I had](http://www.natehunzaker.com/d3-react-fun/):

![screen shot 2014-05-18 at 3 28 43 pm](https://cloud.githubusercontent.com/assets/590904/3008566/b57cf6aa-dec2-11e3-9eec-4f48a2fbe987.png)

Also, I wasn't able to find tests for this script, do any exist?
