### PR TITLE
Fixes #554 - Listen for change events on all inputs

### DIFF
--- a/src/browser/eventPlugins/ChangeEventPlugin.js
+++ b/src/browser/eventPlugins/ChangeEventPlugin.js
@@ -64,7 +64,7 @@ var activeElementValueProp = null;
 function shouldUseChangeEvent(elem) {
   return (
     elem.nodeName === 'SELECT' ||
-    (elem.nodeName === 'INPUT' && elem.type === 'file')
+    elem.nodeName === 'INPUT'
   );
 }
 


### PR DESCRIPTION
Enables the changeEventPlugin for all input types, rather than just file inputs. In particular this helps when working with range inputs.
- Removed check for 'file' input type in ChangeEventPlugin
