### PR TITLE
Use Object.prototype.hasOwnProperty for doc in IE8

### DIFF
--- a/src/browser/ReactEventEmitter.js
+++ b/src/browser/ReactEventEmitter.js
@@ -129,7 +129,9 @@ var topEventMapping = {
 var topListenersIDKey = "_reactListenersID" + String(Math.random()).slice(2);
 
 function getListeningForDocument(mountAt) {
-  if (!mountAt.hasOwnProperty(topListenersIDKey)) {
+  // In IE8, `mountAt` is a host object and doesn't have `hasOwnProperty`
+  // directly.
+  if (!Object.prototype.hasOwnProperty.call(mountAt, topListenersIDKey)) {
     mountAt[topListenersIDKey] = reactTopListenersCounter++;
     alreadyListeningTo[mountAt[topListenersIDKey]] = {};
   }


### PR DESCRIPTION
Test Plan: Loaded ballmer-peak example in IE8 without errors and interacted with the text field.
