### PR TITLE
Clean up data-react-checksum after checksum match

### DIFF
--- a/src/browser/server/ReactMarkupChecksum.js
+++ b/src/browser/server/ReactMarkupChecksum.js
@@ -38,15 +38,20 @@ var ReactMarkupChecksum = {
   /**
    * @param {string} markup to use
    * @param {DOMElement} element root React element
-   * @returns {boolean} whether or not the markup is the same
+   * @returns {boolean} whether or not the markup was reusable
    */
-  canReuseMarkup: function(markup, element) {
+  reuseMarkup: function(markup, element) {
     var existingChecksum = element.getAttribute(
       ReactMarkupChecksum.CHECKSUM_ATTR_NAME
     );
-    existingChecksum = existingChecksum && parseInt(existingChecksum, 10);
-    var markupChecksum = adler32(markup);
-    return markupChecksum === existingChecksum;
+    if (existingChecksum) {
+      var markupChecksum = '' + adler32(markup);
+      if (markupChecksum === existingChecksum) {
+        element.removeAttribute(ReactMarkupChecksum.CHECKSUM_ATTR_NAME);
+        return true;
+      }
+    }
+    return false;
   }
 };
 

--- a/src/browser/ui/ReactComponentBrowserEnvironment.js
+++ b/src/browser/ui/ReactComponentBrowserEnvironment.js
@@ -74,7 +74,7 @@ var ReactComponentBrowserEnvironment = {
       );
 
       if (shouldReuseMarkup) {
-        if (ReactMarkupChecksum.canReuseMarkup(
+        if (ReactMarkupChecksum.reuseMarkup(
           markup,
           getReactRootElementInContainer(container))) {
           return;


### PR DESCRIPTION
Primarily to go with #1570, (then) the final DOM would be completely clean of React markup in the end, even if you use server-rendering. Which I think would be nice given that it's virtually for free.

Not that it really matters, but I also made it safe to use with any hash (not just a numeric one), it should also save a byte or two in size.
