### PR TITLE
Improve readability of multi-line nav items.

### DIFF
--- a/docs/_css/react.scss
+++ b/docs/_css/react.scss
@@ -224,7 +224,7 @@ h1, h2, h3, h4, h5, h6 {
     margin: 0;
   }
   ul ul {
-    margin-left: 20px;
+    margin: 6px 0 0 20px;
   }
   li {
     line-height: 16px;


### PR DESCRIPTION
I made a small adjustment to the nav list styles that appear on the lefthand side of the docs pages. This improves the readability of section titles that wrap to a second (or third) line. This is particularly helpful for the list items under the TIPS header.

This is my first PR. I completed the CLA.
