### PR TITLE
Load external scripts in parallel in JSXTransformer

### DIFF
--- a/vendor/browser-transforms.js
+++ b/vendor/browser-transforms.js
@@ -180,8 +180,8 @@ loadScripts = function(scripts) {
       script = result[i];
 
       if (script && !script.executed) {
-        script.executed = true;
         run(script.content, script.url);
+        script.executed = true;
       } else if (!script) {
         break;
       }


### PR DESCRIPTION
Following up from https://github.com/facebook/react/pull/1558#issuecomment-43717533, this pull request loads jsx scripts in parallel, loading them sequentially as they come in.

Just like before, I'm testing this against http://natehunzaker.com/d3-react-fun/
