### PR TITLE
Add range input to ChangeEventPlugin - Fixes #554

### DIFF
--- a/src/browser/eventPlugins/ChangeEventPlugin.js
+++ b/src/browser/eventPlugins/ChangeEventPlugin.js
@@ -64,7 +64,8 @@ var activeElementValueProp = null;
 function shouldUseChangeEvent(elem) {
   return (
     elem.nodeName === 'SELECT' ||
-    (elem.nodeName === 'INPUT' && elem.type === 'file')
+    (elem.nodeName === 'INPUT' &&
+      (elem.type === 'file' || elem.type === 'range'))
   );
 }
 

--- a/src/browser/eventPlugins/__tests__/ChangeEventPlugin-test.js
+++ b/src/browser/eventPlugins/__tests__/ChangeEventPlugin-test.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2013-2014 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @jsx React.DOM
+ * @emails react-core
+ */
+
+"use strict";
+
+var ChangeEventPlugin;
+var React;
+var ReactTestUtils;
+
+var createMockedComponent = function(type, mockChange){
+  var inputType = type || 'text';
+
+  return React.createClass({
+    displayName: 'MockComponent',
+
+    onChange: mockChange,
+
+    render: function() {
+      return React.DOM.input({type: inputType, onChange: this.onChange});
+    }
+  });
+};
+
+describe('ChangeEventPlugin', function() {
+  var container;
+
+  beforeEach(function() {
+    React = require('React');
+    ReactTestUtils = require('ReactTestUtils');
+    ChangeEventPlugin = require('ChangeEventPlugin');
+
+    container = document.createElement('div');
+  });
+
+  it('range input should get a React change on native change', function() {
+    var mockChange = jasmine.createSpy('mockChange');
+
+    var MockComponent = createMockedComponent('range', mockChange);
+    var component = React.renderComponent(<MockComponent/>, container);
+
+    var input = component.getDOMNode();
+    ReactTestUtils.SimulateNative.change(input);
+
+    expect(mockChange).toHaveBeenCalled();
+  });
+
+
+  it('text input should not get a React change on native change', function() {
+    var mockChange = jasmine.createSpy('mockChange');
+
+    var MockComponent = createMockedComponent('text', mockChange);
+    var component = React.renderComponent(<MockComponent/>, container);
+
+    var input = component.getDOMNode();
+    ReactTestUtils.SimulateNative.change(input);
+
+    expect(mockChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
- Added type check for range inputs in to ChangeEventPlugin
- Added tests to check that native change events trigger synthetic events on range inputs but
  not text inputs

This replaces #1561, which enabled ChangeEventPlugin for all inputs.
