### PR TITLE
Un-mixin ReactBrowserComponentMixin from ReactTextComponent

### DIFF
--- a/src/browser/ReactTextComponent.js
+++ b/src/browser/ReactTextComponent.js
@@ -47,7 +47,6 @@ var ReactTextComponent = function(props) {
 };
 
 mixInto(ReactTextComponent, ReactComponent.Mixin);
-mixInto(ReactTextComponent, ReactBrowserComponentMixin);
 mixInto(ReactTextComponent, {
 
   /**

--- a/src/core/__tests__/ReactMultiChildText-test.js
+++ b/src/core/__tests__/ReactMultiChildText-test.js
@@ -58,8 +58,9 @@ var updateChildren = function(d, children) {
 };
 
 var expectChildren = function(d, children) {
+  var textNode;
   if (typeof children === 'string') {
-    var textNode = d.getDOMNode().firstChild;
+    textNode = d.getDOMNode().firstChild;
 
     if (children === '') {
       expect(textNode != null).toBe(false);
@@ -75,13 +76,20 @@ var expectChildren = function(d, children) {
       var child = children[i];
 
       if (typeof child === 'string') {
-        var textWrapperNode =
-          reactComponentExpect(d)
-            .expectRenderedChildAt(i)
-            .toBeTextComponent()
-            .instance();
+        reactComponentExpect(d)
+          .expectRenderedChildAt(i)
+          .toBeTextComponent()
+          .instance();
 
-        expectChildren(textWrapperNode, child);
+        textNode = d.getDOMNode().childNodes[i].firstChild;
+
+        if (child === '') {
+          expect(textNode != null).toBe(false);
+        } else {
+          expect(textNode != null).toBe(true);
+          expect(textNode.nodeType).toBe(3);
+          expect(textNode.data).toBe('' + child);
+        }
       } else {
         var elementDOMNode =
           reactComponentExpect(d)


### PR DESCRIPTION
ReactTextComponent having `getDOMNode` is an implementation detail, it's also very likely that it won't support it in the future (and since it's technically not always a span, it's even wrong in some sense today).

PS. Can you even access it today without cheating your way in and using private members? I don't think so...
