### PR TITLE
RFC Remove event pooling

### DIFF
--- a/src/browser/eventPlugins/BeforeInputEventPlugin.js
+++ b/src/browser/eventPlugins/BeforeInputEventPlugin.js
@@ -206,7 +206,7 @@ var BeforeInputEventPlugin = {
       return;
     }
 
-    var event = SyntheticInputEvent.getPooled(
+    var event = new SyntheticInputEvent(
       eventTypes.beforeInput,
       topLevelTargetID,
       nativeEvent

--- a/src/browser/eventPlugins/ChangeEventPlugin.js
+++ b/src/browser/eventPlugins/ChangeEventPlugin.js
@@ -77,7 +77,7 @@ if (ExecutionEnvironment.canUseDOM) {
 }
 
 function manualDispatchChangeEvent(nativeEvent) {
-  var event = SyntheticEvent.getPooled(
+  var event = new SyntheticEvent(
     eventTypes.change,
     activeElementID,
     nativeEvent
@@ -363,7 +363,7 @@ var ChangeEventPlugin = {
         topLevelTargetID
       );
       if (targetID) {
-        var event = SyntheticEvent.getPooled(
+        var event = new SyntheticEvent(
           eventTypes.change,
           targetID,
           nativeEvent

--- a/src/browser/eventPlugins/CompositionEventPlugin.js
+++ b/src/browser/eventPlugins/CompositionEventPlugin.js
@@ -245,7 +245,7 @@ var CompositionEventPlugin = {
     }
 
     if (eventType) {
-      var event = SyntheticCompositionEvent.getPooled(
+      var event = new SyntheticCompositionEvent(
         eventType,
         topLevelTargetID,
         nativeEvent

--- a/src/browser/eventPlugins/EnterLeaveEventPlugin.js
+++ b/src/browser/eventPlugins/EnterLeaveEventPlugin.js
@@ -114,7 +114,7 @@ var EnterLeaveEventPlugin = {
     var fromID = from ? ReactMount.getID(from) : '';
     var toID = to ? ReactMount.getID(to) : '';
 
-    var leave = SyntheticMouseEvent.getPooled(
+    var leave = new SyntheticMouseEvent(
       eventTypes.mouseLeave,
       fromID,
       nativeEvent
@@ -123,7 +123,7 @@ var EnterLeaveEventPlugin = {
     leave.target = from;
     leave.relatedTarget = to;
 
-    var enter = SyntheticMouseEvent.getPooled(
+    var enter = new SyntheticMouseEvent(
       eventTypes.mouseEnter,
       toID,
       nativeEvent

--- a/src/browser/eventPlugins/ResponderEventPlugin.js
+++ b/src/browser/eventPlugins/ResponderEventPlugin.js
@@ -169,22 +169,19 @@ function setResponderAndExtractTransfer(
     eventTypes.scrollShouldSetResponder;
 
   var bubbleShouldSetFrom = responderID || topLevelTargetID;
-  var shouldSetEvent = SyntheticEvent.getPooled(
+  var shouldSetEvent = new SyntheticEvent(
     shouldSetEventType,
     bubbleShouldSetFrom,
     nativeEvent
   );
   EventPropagators.accumulateTwoPhaseDispatches(shouldSetEvent);
   var wantsResponderID = executeDispatchesInOrderStopAtTrue(shouldSetEvent);
-  if (!shouldSetEvent.isPersistent()) {
-    shouldSetEvent.constructor.release(shouldSetEvent);
-  }
 
   if (!wantsResponderID || wantsResponderID === responderID) {
     return null;
   }
   var extracted;
-  var grantEvent = SyntheticEvent.getPooled(
+  var grantEvent = new SyntheticEvent(
     eventTypes.responderGrant,
     wantsResponderID,
     nativeEvent
@@ -192,7 +189,7 @@ function setResponderAndExtractTransfer(
 
   EventPropagators.accumulateDirectDispatches(grantEvent);
   if (responderID) {
-    var terminationRequestEvent = SyntheticEvent.getPooled(
+    var terminationRequestEvent = new SyntheticEvent(
       eventTypes.responderTerminationRequest,
       responderID,
       nativeEvent
@@ -200,13 +197,10 @@ function setResponderAndExtractTransfer(
     EventPropagators.accumulateDirectDispatches(terminationRequestEvent);
     var shouldSwitch = !hasDispatches(terminationRequestEvent) ||
       executeDirectDispatch(terminationRequestEvent);
-    if (!terminationRequestEvent.isPersistent()) {
-      terminationRequestEvent.constructor.release(terminationRequestEvent);
-    }
 
     if (shouldSwitch) {
       var terminateType = eventTypes.responderTerminate;
-      var terminateEvent = SyntheticEvent.getPooled(
+      var terminateEvent = new SyntheticEvent(
         terminateType,
         responderID,
         nativeEvent
@@ -215,7 +209,7 @@ function setResponderAndExtractTransfer(
       extracted = accumulate(extracted, [grantEvent, terminateEvent]);
       responderID = wantsResponderID;
     } else {
-      var rejectEvent = SyntheticEvent.getPooled(
+      var rejectEvent = new SyntheticEvent(
         eventTypes.responderReject,
         wantsResponderID,
         nativeEvent
@@ -297,7 +291,7 @@ var ResponderEventPlugin = {
       isEndish(topLevelType) ? eventTypes.responderRelease :
       isStartish(topLevelType) ? eventTypes.responderStart : null;
     if (type) {
-      var gesture = SyntheticEvent.getPooled(
+      var gesture = new SyntheticEvent(
         type,
         responderID || '',
         nativeEvent

--- a/src/browser/eventPlugins/SelectEventPlugin.js
+++ b/src/browser/eventPlugins/SelectEventPlugin.js
@@ -110,7 +110,7 @@ function constructSelectEvent(nativeEvent) {
   if (!lastSelection || !shallowEqual(lastSelection, currentSelection)) {
     lastSelection = currentSelection;
 
-    var syntheticEvent = SyntheticEvent.getPooled(
+    var syntheticEvent = new SyntheticEvent(
       eventTypes.select,
       activeElementID,
       nativeEvent

--- a/src/browser/eventPlugins/SimpleEventPlugin.js
+++ b/src/browser/eventPlugins/SimpleEventPlugin.js
@@ -405,8 +405,7 @@ var SimpleEventPlugin = {
       'SimpleEventPlugin: Unhandled event type, `%s`.',
       topLevelType
     );
-    var event = EventConstructor.getPooled(
-      dispatchConfig,
+    var event = new EventConstructor(dispatchConfig,
       topLevelTargetID,
       nativeEvent
     );

--- a/src/browser/eventPlugins/TapEventPlugin.js
+++ b/src/browser/eventPlugins/TapEventPlugin.js
@@ -113,7 +113,7 @@ var TapEventPlugin = {
     var event = null;
     var distance = getDistance(startCoords, nativeEvent);
     if (isEndish(topLevelType) && distance < tapMoveThreshold) {
-      event = SyntheticUIEvent.getPooled(
+      event = new SyntheticUIEvent(
         eventTypes.touchTap,
         topLevelTargetID,
         nativeEvent

--- a/src/browser/syntheticEvents/SyntheticEvent.js
+++ b/src/browser/syntheticEvents/SyntheticEvent.js
@@ -19,8 +19,6 @@
 
 "use strict";
 
-var PooledClass = require('PooledClass');
-
 var emptyFunction = require('emptyFunction');
 var getEventTarget = require('getEventTarget');
 var merge = require('merge');
@@ -106,35 +104,6 @@ mergeInto(SyntheticEvent.prototype, {
     this.isPropagationStopped = emptyFunction.thatReturnsTrue;
   },
 
-  /**
-   * We release all dispatched `SyntheticEvent`s after each event loop, adding
-   * them back into the pool. This allows a way to hold onto a reference that
-   * won't be added back into the pool.
-   */
-  persist: function() {
-    this.isPersistent = emptyFunction.thatReturnsTrue;
-  },
-
-  /**
-   * Checks if this event should be released back into the pool.
-   *
-   * @return {boolean} True if this should not be released, false otherwise.
-   */
-  isPersistent: emptyFunction.thatReturnsFalse,
-
-  /**
-   * `PooledClass` looks for `destructor` on each instance it releases.
-   */
-  destructor: function() {
-    var Interface = this.constructor.Interface;
-    for (var propName in Interface) {
-      this[propName] = null;
-    }
-    this.dispatchConfig = null;
-    this.dispatchMarker = null;
-    this.nativeEvent = null;
-  }
-
 });
 
 SyntheticEvent.Interface = EventInterface;
@@ -155,10 +124,6 @@ SyntheticEvent.augmentClass = function(Class, Interface) {
 
   Class.Interface = merge(Super.Interface, Interface);
   Class.augmentClass = Super.augmentClass;
-
-  PooledClass.addPoolingTo(Class, PooledClass.threeArgumentPooler);
 };
-
-PooledClass.addPoolingTo(SyntheticEvent, PooledClass.threeArgumentPooler);
 
 module.exports = SyntheticEvent;

--- a/src/browser/syntheticEvents/__tests__/SyntheticEvent-test.js
+++ b/src/browser/syntheticEvents/__tests__/SyntheticEvent-test.js
@@ -27,7 +27,7 @@ describe('SyntheticEvent', function() {
     SyntheticEvent = require('SyntheticEvent');
 
     createEvent = function(nativeEvent) {
-      return SyntheticEvent.getPooled({}, '', nativeEvent);
+      return new SyntheticEvent({}, '', nativeEvent);
     };
   });
 
@@ -68,14 +68,6 @@ describe('SyntheticEvent', function() {
     expect(syntheticEvent.isPropagationStopped()).toBe(true);
 
     expect(nativeEvent.cancelBubble).toBe(true);
-  });
-
-  it('should be able to `persist`', function() {
-    var syntheticEvent = createEvent({});
-
-    expect(syntheticEvent.isPersistent()).toBe(false);
-    syntheticEvent.persist();
-    expect(syntheticEvent.isPersistent()).toBe(true);
   });
 
 });

--- a/src/browser/syntheticEvents/__tests__/SyntheticWheelEvent-test.js
+++ b/src/browser/syntheticEvents/__tests__/SyntheticWheelEvent-test.js
@@ -27,7 +27,7 @@ describe('SyntheticWheelEvent', function() {
     SyntheticWheelEvent = require('SyntheticWheelEvent');
 
     createEvent = function(nativeEvent) {
-      return SyntheticWheelEvent.getPooled({}, '', nativeEvent);
+      return new SyntheticWheelEvent({}, '', nativeEvent);
     };
   });
 
@@ -64,14 +64,6 @@ describe('SyntheticWheelEvent', function() {
     expect(syntheticEvent.isPropagationStopped()).toBe(false);
     syntheticEvent.stopPropagation();
     expect(syntheticEvent.isPropagationStopped()).toBe(true);
-  });
-
-  it('should be able to `persist`', function() {
-    var syntheticEvent = createEvent({});
-
-    expect(syntheticEvent.isPersistent()).toBe(false);
-    syntheticEvent.persist();
-    expect(syntheticEvent.isPersistent()).toBe(true);
   });
 
 });

--- a/src/event/EventPluginHub.js
+++ b/src/event/EventPluginHub.js
@@ -53,10 +53,6 @@ var executeDispatchesAndRelease = function(event) {
       executeDispatch = PluginModule.executeDispatch;
     }
     EventPluginUtils.executeDispatchesInOrder(event, executeDispatch);
-
-    if (!event.isPersistent()) {
-      event.constructor.release(event);
-    }
   }
 };
 


### PR DESCRIPTION
I couldn't really find anyone on IRC who _really_ knew why we do this. It's annoying to debug and people often don't understand what's happening.

I understand the idea of decreasing the pressure on the GC, but I fail to see how pooling events is going to matter, we're talking worst-case of a consistent stream of about 2 events per frame (give or take, or?). If all we do is dispatch events and there is no render, any pressure on the GC should be imperceptible and any half-decent GC shouldn't find it hard to deal short-lived objects. If any of those update an immutable store we're going to see a handful of objects created and unreferenced, if any of those cause a React render, we might be seeing hundreds of objects created and unreferenced.

For internal classes, pooling is great no matter what really, but we're talking about a public API that's also rather common and standardized. This is not intuitive behavior and so event pooling comes at a great cost, but from where I'm standing there doesn't seem to be an equal or greater benefit.

PS. Only after doing this PR did I discover that there actually is a `event.persist()` method, if we stick to pooled events, we _really_ should document it as it definitely makes it less of a pain.

PS2. PR because I can, not because I care :)
