### PR TITLE
Event plugin addons with fix to make sure touch events are enabled

### DIFF
--- a/src/browser/ReactWithAddons.js
+++ b/src/browser/ReactWithAddons.js
@@ -25,26 +25,44 @@
 
 "use strict";
 
+var AnalyticsEventPluginFactory = require('AnalyticsEventPluginFactory');
 var LinkedStateMixin = require('LinkedStateMixin');
 var React = require('React');
-var ReactComponentWithPureRenderMixin =
-  require('ReactComponentWithPureRenderMixin');
 var ReactCSSTransitionGroup = require('ReactCSSTransitionGroup');
+var ReactInjection = require('ReactInjection');
 var ReactTransitionGroup = require('ReactTransitionGroup');
+var ResponderEventPlugin = require('ResponderEventPlugin');
+var TapEventPlugin = require('TapEventPlugin');
 
 var cx = require('cx');
 var cloneWithProps = require('cloneWithProps');
-var update = require('update');
 
 React.addons = {
-  CSSTransitionGroup: ReactCSSTransitionGroup,
   LinkedStateMixin: LinkedStateMixin,
-  PureRenderMixin: ReactComponentWithPureRenderMixin,
+  CSSTransitionGroup: ReactCSSTransitionGroup,
   TransitionGroup: ReactTransitionGroup,
 
   classSet: cx,
   cloneWithProps: cloneWithProps,
-  update: update
+
+  injectTapEventPlugin: function() {
+    ReactInjection.EventPluginHub.injectEventPluginsByName({
+      TapEventPlugin: TapEventPlugin
+    });
+  },
+  injectResponderPlugin: function() {
+    ReactInjection.EventPluginHub.injectEventPluginsByName({
+      ResponderEventPlugin: ResponderEventPlugin
+    });
+  },
+  injectAnalyticsEventPlugin: function(cb, interval) {
+    ReactInjection.EventPluginHub.injectEventPluginsByName({
+      AnalyticsEventPlugin: AnalyticsEventPluginFactory.createAnalyticsPlugin(
+        cb,
+        interval
+      )
+    });
+  }
 };
 
 if (__DEV__) {
@@ -52,4 +70,3 @@ if (__DEV__) {
 }
 
 module.exports = React;
-

--- a/src/browser/eventPlugins/TapEventPlugin.js
+++ b/src/browser/eventPlugins/TapEventPlugin.js
@@ -22,6 +22,7 @@
 var EventConstants = require('EventConstants');
 var EventPluginUtils = require('EventPluginUtils');
 var EventPropagators = require('EventPropagators');
+var React = require('React');
 var SyntheticUIEvent = require('SyntheticUIEvent');
 var TouchEventUtils = require('TouchEventUtils');
 var ViewportMetrics = require('ViewportMetrics');
@@ -31,6 +32,8 @@ var topLevelTypes = EventConstants.topLevelTypes;
 
 var isStartish = EventPluginUtils.isStartish;
 var isEndish = EventPluginUtils.isEndish;
+
+React.initializeTouchEvents(true);
 
 /**
  * Number of pixels that are tolerated in between a `touchStart` and `touchEnd`


### PR DESCRIPTION
This includes #1170 changes and fixes #1619

If I'm opting into `React.addons.injectTapEventPlugin()` it should be implied that I want touch events enabled. So I just call `React.initializeTouchEvents(true)` in `TapEventPlugin.js`.

Created a [testcase](http://jsbin.com/roxat/9/edit) with a custom build based on this PR that works as expected.
