### PR TITLE
Update todo example. fixes 'Create' that shouldn't happen

### DIFF
--- a/examples/todomvc-flux/js/components/Header.react.js
+++ b/examples/todomvc-flux/js/components/Header.react.js
@@ -45,7 +45,10 @@ var Header = React.createClass({
    * @param {string} text
    */
   _onSave: function(text) {
-    TodoActions.create(text);
+    if(text.trim()){
+      TodoActions.create(text);
+    }
+    
   }
 
 });


### PR DESCRIPTION
Currently, an `onBlur` creates a new todo on `TodoTextInput`. This makes sense for existing items but not for new items. I.e consider the following: 
1. cursor on new item ("What needs to be done?")
2. click 'x' on the first item. 

This results in two actions being fired: 
1. TODO_CREATE, with an empty string as 'text'
2. TODO_DESTROY

The proposed fix doesn't send a TODO_CREATE if `text.trim() === "")`
