### PR TITLE
Fix onLoad and onError on images

### DIFF
--- a/src/browser/ui/dom/components/ReactDOMImg.js
+++ b/src/browser/ui/dom/components/ReactDOMImg.js
@@ -44,8 +44,8 @@ var ReactDOMImg = ReactCompositeComponent.createClass({
   },
 
   componentDidMount: function() {
-    this.trapBubbledEvent(EventConstants.topLevelTypes.topReset, 'load');
-    this.trapBubbledEvent(EventConstants.topLevelTypes.topSubmit, 'error');
+    this.trapBubbledEvent(EventConstants.topLevelTypes.topLoad, 'load');
+    this.trapBubbledEvent(EventConstants.topLevelTypes.topError, 'error');
   }
 });
 


### PR DESCRIPTION
Fixes bug introduced in c62c2c5.

Test Plan: Tested that the onLoad event was properly triggered on an image. Didn't test onError but I can only assume that it works equally well.
