### PR TITLE
[React] Fix getEventModifierState in Chrome

### DIFF
--- a/src/browser/ui/dom/getEventModifierState.js
+++ b/src/browser/ui/dom/getEventModifierState.js
@@ -35,7 +35,10 @@ function getEventModifierState(nativeEvent) {
   // IE8 does not implement getModifierState so we simply map it to the only
   // modifier keys exposed by the event itself, does not support Lock-keys.
   // Currently, all major browsers except Chrome seems to support Lock-keys.
-  return nativeEvent.getModifierState || function(keyArg) {
+  return function(keyArg) {
+    if (nativeEvent.getModifierState) {
+      return nativeEvent.getModifierState(keyArg);
+    }
     var keyProp = modifierKeyToProp[keyArg.toLowerCase()];
     return keyProp && nativeEvent[keyProp];
   };


### PR DESCRIPTION
Summary: When returning event.getModifierState directly it loses the context of the native event which results in an IllegalInvocation error in Chrome. This fixes it by always wrapping the function and by calling `getModifierState` on the native event.

Test Plan: In Chrome, I invoked `event.getModifierState('Alt')` in an onKeyDown event. It throws without the fix and works fine with the fix applied.
