### PR TITLE
Fix getEventModifierState, no allocations

### DIFF
--- a/src/browser/ui/dom/getEventModifierState.js
+++ b/src/browser/ui/dom/getEventModifierState.js
@@ -31,14 +31,22 @@ var modifierKeyToProp = {
   'shift': 'shiftKey'
 };
 
+// IE8 does not implement getModifierState so we simply map it to the only
+// modifier keys exposed by the event itself, does not support Lock-keys.
+// Currently, all major browsers except Chrome seems to support Lock-keys.
+function modifierStateGetter(keyArg) {
+  /*jshint validthis:true */
+  var syntheticEvent = this;
+  var nativeEvent = syntheticEvent.nativeEvent;
+  if (nativeEvent.getModifierState) {
+    return nativeEvent.getModifierState(keyArg);
+  }
+  var keyProp = modifierKeyToProp[keyArg.toLowerCase()];
+  return keyProp && nativeEvent[keyProp];
+}
+
 function getEventModifierState(nativeEvent) {
-  // IE8 does not implement getModifierState so we simply map it to the only
-  // modifier keys exposed by the event itself, does not support Lock-keys.
-  // Currently, all major browsers except Chrome seems to support Lock-keys.
-  return nativeEvent.getModifierState || function(keyArg) {
-    var keyProp = modifierKeyToProp[keyArg.toLowerCase()];
-    return keyProp && nativeEvent[keyProp];
-  };
+  return modifierStateGetter;
 }
 
 module.exports = getEventModifierState;


### PR DESCRIPTION
Alternative to #1637 that doesn't allocate on every event.

Test Plan: Crossed fingers.
