### PR TITLE
Correctly trim strings for css properties

### DIFF
--- a/src/browser/ui/dom/__tests__/CSSPropertyOperations-test.js
+++ b/src/browser/ui/dom/__tests__/CSSPropertyOperations-test.js
@@ -68,6 +68,14 @@ describe('CSSPropertyOperations', function() {
     })).toBe('left:0;margin:16px;opacity:0.5;padding:4px;');
   });
 
+  it('should trim values so `px` will be appended correctly', function() {
+    expect(CSSPropertyOperations.createMarkupForStyles({
+      margin: '16 ',
+      opacity: 0.5,
+      padding: ' 4 '
+    })).toBe('margin:16px;opacity:0.5;padding:4px;');
+  });
+
   it('should not append `px` to styles that might need a number', function() {
     var CSSProperty = require('CSSProperty');
     var unitlessProperties = Object.keys(CSSProperty.isUnitlessNumber);

--- a/src/browser/ui/dom/dangerousStyleValue.js
+++ b/src/browser/ui/dom/dangerousStyleValue.js
@@ -54,6 +54,9 @@ function dangerousStyleValue(name, value) {
     return '' + value; // cast to string
   }
 
+  if (typeof value === 'string') {
+    value = value.trim();
+  }
   return value + 'px';
 }
 


### PR DESCRIPTION
This PR correctly trims property strings if passed in with a space. It also correctly matches unit less properties if the name is passed in as a 'string' and not camelCase by converting the string to camelCase.
- If a unit less value is passed with a space it'll return `1 px`
- ~~If passed 'z-index': 1 it'll return 'z-index': '1px' convert str camelCase when doin unitless lookup~~

See [test case]()

Not applicable anymore see #1662 

``` js
var Hello = React.createClass({
    render: function() {
        var styles = {
            'z-index': 1,
            margin: '10 '
        };
        return <div style={styles}>Hello {this.props.name}</div>;
    }
});
```

~~The following component yields inline styles: `z-index:1px;margin:10 px;`~~
