### PR TITLE
Fix EnterLeaveEventPlugin-test in IE10

### DIFF
--- a/src/browser/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
+++ b/src/browser/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
@@ -46,9 +46,10 @@ describe('EnterLeaveEventPlugin', function() {
 
     var iframeDocument = iframe.contentDocument;
 
-    if (!iframeDocument.innerHTML) {
-      iframeDocument.innerHTML = '<html><head></head><body></body></html>';
-    }
+    iframeDocument.write(
+      '<!DOCTYPE html><html><head></head><body></body></html>'
+    );
+    iframeDocument.close();
 
     var component = React.renderComponent(<div />, iframeDocument.body);
     var div = component.getDOMNode();


### PR DESCRIPTION
Previously this was failing because iframeDocument.body wasn't properly initialized. Creating the document this way seems to work in all environments

Test Plan: Ran the test in jest, phantomjs, IE10, Chrome, and Firefox.
