### PR TITLE
Treat `[undefined]` as valid `PropTypes.renderable`

### DIFF
--- a/src/core/ReactPropTypes.js
+++ b/src/core/ReactPropTypes.js
@@ -281,6 +281,9 @@ function isRenderable(propValue) {
         }
       }
       return true;
+    case 'undefined':
+      // Establishes symmetry with `null` case, which is a valid renderable.
+      return true;
     default:
       return false;
   }

--- a/src/core/__tests__/ReactPropTypes-test.js
+++ b/src/core/__tests__/ReactPropTypes-test.js
@@ -401,6 +401,11 @@ describe('React Component Types', function() {
     typeCheckPass(PropTypes.renderable.isRequired, []);
     typeCheckPass(PropTypes.renderable.isRequired, {});
   });
+
+  it('should accept an array of null or undefined for required props', function() {
+    typeCheckPass(PropTypes.renderable.isRequired, [null]);
+    typeCheckPass(PropTypes.renderable.isRequired, [undefined]);
+  });
 });
 
 describe('OneOf Types', function() {


### PR DESCRIPTION
- #1647: React no longer issues a warning when passing in `[undefined]` as `React.PropTypes.renderable`, hence treating it the same as `[null]`.
#### Notes
- Tests pass.
- Lint reports many warnings but not due to newly added code.
- Previously signed CLA.
