### PR TITLE
Prevent null reference access when unsetting styles

### DIFF
--- a/src/browser/ui/ReactDOMComponent.js
+++ b/src/browser/ui/ReactDOMComponent.js
@@ -307,7 +307,7 @@ ReactDOMComponent.Mixin = {
           // Unset styles on `lastProp` but not on `nextProp`.
           for (styleName in lastProp) {
             if (lastProp.hasOwnProperty(styleName) &&
-                !nextProp.hasOwnProperty(styleName)) {
+                (!nextProp || !nextProp.hasOwnProperty(styleName))) {
               styleUpdates = styleUpdates || {};
               styleUpdates[styleName] = '';
             }

--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -97,6 +97,11 @@ describe('ReactDOMComponent', function() {
       expect(stubStyle.display).toEqual('block');
       expect(stubStyle.fontFamily).toEqual('Helvetica');
       expect(stubStyle.lineHeight).toEqual('0.5');
+
+      stub.receiveComponent({props: { style: undefined }}, transaction);
+      expect(stubStyle.display).toBe('');
+      expect(stubStyle.fontFamily).toBe('');
+      expect(stubStyle.lineHeight).toBe('');
     });
 
     it("should update styles if initially null", function() {


### PR DESCRIPTION
#### Repro
1. Set component `style` to a valid value.
2. Set component `style` to `undefined`.
#### Expected
- Styles from 1.) are unset.
#### Actual
- Error `Cannot read property 'hasOwnProperty' of undefined` is thrown.
### Example

http://jsfiddle.net/gasi/9rWum/

![create_a_new_fiddle_-_jsfiddle](https://cloud.githubusercontent.com/assets/49583/3236190/0802545e-f0db-11e3-8a3b-16ab183759ac.png)
- Signed CLA.
- Added tests.
- No new lint warnings.
