### PR TITLE
Reject falsey cx() arguments

### DIFF
--- a/src/vendor/stubs/cx.js
+++ b/src/vendor/stubs/cx.js
@@ -37,7 +37,7 @@ function cx(classNames) {
       return classNames[className];
     }).join(' ');
   } else {
-    return Array.prototype.join.call(arguments, ' ');
+    return Array.prototype.filter.call(arguments, Boolean).join(' ');
   }
 }
 


### PR DESCRIPTION
This adds another layer of convenience to `cx` by rejecting falsey arguments.

Example use:

``` javascript
var active = true
var empty = ''
var classes = cx('product-list', active && 'active', emptyClass)
```

Yields:

``` javascript
"product-list active"
```
