### PR TITLE
Fix correlation direction of wording in Ballmer Peak example.

### DIFF
--- a/examples/ballmer-peak/example.js
+++ b/examples/ballmer-peak/example.js
@@ -32,7 +32,7 @@ var BallmerPeakCalculator = React.createClass({
         <p>
           If your BAC is{' '}
           <input type="text" onChange={this.handleChange} value={this.state.bac} />
-          {', '}then <b>{pct}</b> of your lines of code will have bugs.
+          {', '}then <b>{pct}</b> of your lines of code will be bug free.
         </p>
       </div>
     );


### PR DESCRIPTION
The Ballmer Peak XKCD suggests that it's a graph of ability, rather than bug frequency, which should be inversely correlated with ability.  A simple change of the wording fixes this terrible mishandling of Ballmer Peak data.
