### PR TITLE
Respect event.stopPropagation() when nested

### DIFF
--- a/src/browser/syntheticEvents/SyntheticEvent.js
+++ b/src/browser/syntheticEvents/SyntheticEvent.js
@@ -88,7 +88,12 @@ function SyntheticEvent(dispatchConfig, dispatchMarker, nativeEvent) {
   } else {
     this.isDefaultPrevented = emptyFunction.thatReturnsFalse;
   }
-  this.isPropagationStopped = emptyFunction.thatReturnsFalse;
+  var propagationStopped = nativeEvent.cancelBubble;
+  if (propagationStopped) {
+    this.isPropagationStopped = emptyFunction.thatReturnsTrue;
+  } else {
+    this.isPropagationStopped = emptyFunction.thatReturnsFalse;
+  }
 }
 
 mergeInto(SyntheticEvent.prototype, {
@@ -102,7 +107,11 @@ mergeInto(SyntheticEvent.prototype, {
 
   stopPropagation: function() {
     var event = this.nativeEvent;
-    event.stopPropagation ? event.stopPropagation() : event.cancelBubble = true;
+    if (event.stopPropagation) {
+      event.stopPropagation();
+    }
+    // PhantomJS doesn't automatically update cancelBubble on stopPropagation.
+    event.cancelBubble = true;
     this.isPropagationStopped = emptyFunction.thatReturnsTrue;
   },
 

--- a/src/browser/ui/__tests__/event-propagation-test.js
+++ b/src/browser/ui/__tests__/event-propagation-test.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2013-2014 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @jsx React.DOM
+ * @emails react-core
+ */
+
+"use strict";
+
+var React = require('React');
+var ReactMount = require('ReactMount');
+var mocks = require('mocks');
+
+describe('Event propagation', function() {
+  var stopPropagation;
+
+  function maybeStopPropagation(event) {
+    if (stopPropagation) {
+      event.stopPropagation();
+    }
+  }
+
+  var onClick = mocks.getMockFunction();
+
+  var childContainer = document.createElement('div');
+  var childControl = <div onClick={maybeStopPropagation}>Child</div>;
+  var parentContainer = document.createElement('div');
+  var parentControl = <div onClick={onClick}>Parent</div>;
+  childControl = ReactMount.renderComponent(childControl, childContainer);
+  parentControl = ReactMount.renderComponent(parentControl, parentContainer);
+  parentControl.getDOMNode().appendChild(childContainer);
+
+  // PhantomJS event bubbling only works for attached elements.
+  document.body.appendChild(parentContainer);
+
+  function simulateClick(node) {
+    if (document.createEvent) {
+      // Event constructors are not yet supported in PhantomJS.
+      // https://github.com/ariya/phantomjs/issues/11289
+      var event = document.createEvent('MouseEvents');
+      event.initEvent('click', true, true);
+      return node.dispatchEvent(event);
+    } else {
+      return node.fireEvent('onclick');
+    }
+  }
+
+  beforeEach(function() {
+    stopPropagation = undefined;
+    onClick.mockClear();
+  });
+
+  it('should propagate events down without stopPropagation', function() {
+    stopPropagation = false;
+    simulateClick(childControl.getDOMNode());
+    expect(onClick.mock.calls.length).toBe(1);
+  });
+
+  it('should not propagate events down after stopPropagation', function() {
+    stopPropagation = true;
+    simulateClick(childControl.getDOMNode());
+    expect(onClick.mock.calls.length).toBe(0);
+  });
+
+});

--- a/src/event/EventPluginUtils.js
+++ b/src/event/EventPluginUtils.js
@@ -101,7 +101,7 @@ function forEachEventDispatch(event, cb) {
       // Listeners and IDs are two parallel arrays that are always in sync.
       cb(event, dispatchListeners[i], dispatchIDs[i]);
     }
-  } else if (dispatchListeners) {
+  } else if (dispatchListeners && !event.isPropagationStopped()) {
     cb(event, dispatchListeners, dispatchIDs);
   }
 }


### PR DESCRIPTION
When nesting top-level components (e.g., calling React.renderComponent within
componentDidMount), events bubble to the parent component.

This change ensures that when `event.stopPropagation()` is called in an event
handler of the inner top-level component, event handlers of outer top-level
components are not called. Closes #1691.

As of the current W3C DOM4 draft, there is no standardised way to determine if
`stopPropagation()` has been called on an event. This change sets the
deprecated `cancelBubble` property existing in most current browsers and
should continue to work if the property is removed in the future.