### PR TITLE
Add 'patternContentUnits' to SVG attributes.

### DIFF
--- a/src/browser/ui/dom/SVGDOMPropertyConfig.js
+++ b/src/browser/ui/dom/SVGDOMPropertyConfig.js
@@ -37,6 +37,7 @@ var SVGDOMPropertyConfig = {
     gradientTransform: MUST_USE_ATTRIBUTE,
     gradientUnits: MUST_USE_ATTRIBUTE,
     offset: MUST_USE_ATTRIBUTE,
+    patternContentUnits: MUST_USE_ATTRIBUTE,
     points: MUST_USE_ATTRIBUTE,
     preserveAspectRatio: MUST_USE_ATTRIBUTE,
     r: MUST_USE_ATTRIBUTE,
@@ -63,6 +64,7 @@ var SVGDOMPropertyConfig = {
   DOMAttributeNames: {
     gradientTransform: 'gradientTransform',
     gradientUnits: 'gradientUnits',
+    patternContentUnits: 'patternContentUnits',
     preserveAspectRatio: 'preserveAspectRatio',
     spreadMethod: 'spreadMethod',
     stopColor: 'stop-color',


### PR DESCRIPTION
The [patternContentUnits](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/patternContentUnits) attribute is commonly used when defining a SVG [pattern](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/pattern).

This work is part of #1657.
