### PR TITLE
Use double quote for transformed `displayName`

### DIFF
--- a/vendor/fbtransform/transforms/__tests__/react-displayName-test.js
+++ b/vendor/fbtransform/transforms/__tests__/react-displayName-test.js
@@ -24,7 +24,7 @@ describe('react displayName jsx', function() {
     var code = [
       '"use strict";',
       'var Whateva = React.createClass({',
-      '  displayName: \'Whateva\',',
+      '  displayName: "Whateva",',
       '  render: function() {',
       '    return null;',
       '  }',
@@ -34,7 +34,7 @@ describe('react displayName jsx', function() {
     var result = [
       '"use strict";',
       'var Whateva = React.createClass({',
-      '  displayName: \'Whateva\',',
+      '  displayName: "Whateva",',
       '  render: function() {',
       '    return null;',
       '  }',
@@ -54,7 +54,7 @@ describe('react displayName jsx', function() {
     ].join('\n');
 
     var result = [
-      'var Component = React.createClass({displayName: \'Component\',',
+      'var Component = React.createClass({displayName: "Component",',
       '  render: function() {',
       '    return null;',
       '  }',
@@ -76,7 +76,7 @@ describe('react displayName jsx', function() {
 
     var result = [
       'var Component;',
-      'Component = React.createClass({displayName: \'Component\',',
+      'Component = React.createClass({displayName: "Component",',
       '  render: function() {',
       '    return null;',
       '  }',
@@ -96,7 +96,7 @@ describe('react displayName jsx', function() {
     ].join('\n');
 
     var result = [
-      'exports.Component = React.createClass({displayName: \'Component\',',
+      'exports.Component = React.createClass({displayName: "Component",',
       '  render: function() {',
       '    return null;',
       '  }',
@@ -119,7 +119,7 @@ describe('react displayName jsx', function() {
 
     var result = [
       'exports = {',
-      '  Component: React.createClass({displayName: \'Component\',',
+      '  Component: React.createClass({displayName: "Component",',
       '    render: function() {',
       '      return null;',
       '    }',

--- a/vendor/fbtransform/transforms/reactDisplayName.js
+++ b/vendor/fbtransform/transforms/reactDisplayName.js
@@ -33,7 +33,7 @@ function addDisplayName(displayName, object, state) {
 
     if (safe) {
       utils.catchup(object['arguments'][0].range[0] + 1, state);
-      utils.append("displayName: '" + displayName + "',", state);
+      utils.append('displayName: "' + displayName + '",', state);
     }
   }
 }

--- a/vendor/fbtransform/transforms/xjs.js
+++ b/vendor/fbtransform/transforms/xjs.js
@@ -231,7 +231,7 @@ function renderXJSExpressionContainer(traverse, object, isLast, path, state) {
 function quoteAttrName(attr) {
   // Quote invalid JS identifiers.
   if (!/^[a-z_$][a-z\d_$]*$/i.test(attr)) {
-    return "'" + attr + "'";
+    return '"' + attr + '"';
   }
   return attr;
 }


### PR DESCRIPTION
JSX currently transforms everything to double quote except these two. This way, it's at least consistent and will satisfy half of the people who do put a strict quotation linting on their project.

Test: `jest`, check the double quoted transformed `data-bla="something"`.
