### PR TITLE
Fix tests broken by undefined `window` references in ReactEventListener.

### DIFF
--- a/src/browser/ui/ReactEventListener.js
+++ b/src/browser/ui/ReactEventListener.js
@@ -20,6 +20,7 @@
 "use strict";
 
 var EventListener = require('EventListener');
+var ExecutionEnvironment = require('ExecutionEnvironment');
 var PooledClass = require('PooledClass');
 var ReactInstanceHandles = require('ReactInstanceHandles');
 var ReactMount = require('ReactMount');
@@ -101,7 +102,7 @@ var ReactEventListener = {
   _enabled: true,
   _handleTopLevel: null,
 
-  WINDOW_HANDLE: window,
+  WINDOW_HANDLE: ExecutionEnvironment.canUseDOM ? window : null,
 
   setHandleTopLevel: function(handleTopLevel) {
     ReactEventListener._handleTopLevel = handleTopLevel;


### PR DESCRIPTION
This test breakage blames to e1c2d02fddb40cb0b246d2c2da97b41b6ba378bc.

cc @petehunt
