### PR TITLE
Don't export (undefined) React in main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,7 +5,6 @@ var transform = require('jstransform').transform;
 var Buffer = require('buffer').Buffer;
 
 module.exports = {
-  React: React,
   transform: function(input, options) {
     options = options || {};
     var visitorList = getVisitors(options.harmony);


### PR DESCRIPTION
Previously, this was throwing an error. It was unintentionally (I assume) introduced in fc5bb9c.

Test Plan: jest
