### PR TITLE
test undefined use typeof 

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -571,7 +571,7 @@ function mergeObjectsWithNoDuplicateKeys(one, two) {
 
   mapObject(two, function(value, key) {
     invariant(
-      one[key] === undefined,
+      typeof one[key] === 'undefined',
       'mergeObjectsWithNoDuplicateKeys(): ' +
       'Tried to merge two objects with the same key: %s',
       key


### PR DESCRIPTION
When test react app using jest, I have found the undefined can't be tested

https://github.com/facebook/jest/issues/80

So change the test from one[key]=== undefined to typeof one[key]==='undefined' can fix this error, and in another line in this file, it also use typeof to test. in function _processProps:
typeof props[propName] === 'undefined'
