### PR TITLE
Fix to sample code for href in ReactPropTypes

### DIFF
--- a/src/core/ReactPropTypes.js
+++ b/src/core/ReactPropTypes.js
@@ -55,7 +55,8 @@ var emptyFunction = require('emptyFunction');
  *      // An optional string or URI prop named "href".
  *      href: function(props, propName, componentName) {
  *        var propValue = props[propName];
- *        if (propValue != null && typeof propValue !== 'string' && !(propValue instanceof URI)) {
+ *        if (propValue != null && typeof propValue !== 'string' &&
+ *            !(propValue instanceof URI)) {
  *          return new Error(
  *            'Expected a string or an URI for ' + propName + ' in ' +
  *            componentName


### PR DESCRIPTION
Fix to 2 problems in the sample code for ReactPropTypes:
- Condition was inverted (error should be thrown when the previous condition is "not" met).
- Missing null check (the href propType is described as optional in the comment but a null in the prop would have failed the check)
