### PR TITLE
Added option to define a fallback class in case all values return false.

### DIFF
--- a/src/vendor/stubs/cx.js
+++ b/src/vendor/stubs/cx.js
@@ -29,7 +29,7 @@
  *                      In the object case, the values are conditions that
  *                      determine if the className keys should be included.
  * @param [string ...]  Variable list of classNames in the string case.
- * @param {string}		classElse A single class to be used in the case that all results return false.
+ * @param {string}      classElse A single class to be used in the case that all results return false.
  * @return string       Renderable space-separated CSS className.
  */
 function cx(classNames,classElse) {
@@ -37,7 +37,9 @@ function cx(classNames,classElse) {
     var ret = Object.keys(classNames).filter(function(className) {
       return classNames[className];
     }).join(' ');
-    return (ret.length > 0) ? ret : ((typeof classElse !== 'undefined') ? classElse : '');
+    return (ret.length > 0) ? 
+      ret : ((typeof classElse !== 'undefined') ?
+        classElse : '');
   } else {
     return Array.prototype.join.call(arguments, ' ');
   }


### PR DESCRIPTION
I ran into the problem when building a drag and drop file uploader where i was detecting filetype and displaying a specific font-awesome icon.

the code before was something like: 

``` javascript

var image = new RegExp("image/");
    image = image.test(items[i].type);
var text = new RegExp("text/");
    text = text.test(items[i].type);
var pdf = new RegExp("/pdf");
    pdf = pdf.test(items[i].type);

var classes=cx({
  'fa-file-image-o':image,
  'fa-file-text-o':text,
  'fa-file-pdf-o':pdf,
  'fa fa-fw':true,
  'fa-file-o':!image && !text && !pdf
})
```

This in my opinion made it more difficult to add new file types than it needed to be. so my solution was to come up with a way to add a fallback in case something returned false, while not breaking the code where i used cx() earlier. This in my opinion is a much better way to do it. My code to set the classes now looks like below giving me easier control without any real noticeable performance loss.

``` javascript
var image = new RegExp("image/");
var text = new RegExp("text/");
var pdf = new RegExp("/pdf");

var classes=cx({
  'fa fa-fw fa-file-image-o':image.test(items[i].type),
  'fa fa-fw fa-file-text-o':text.test(items[i].type),
  'fa fa-fw fa-file-pdf-o':pdf.test(items[i].type),
},'fa fa-fw fa-file-o')

```
