### PR TITLE
Support ReactLink on select elements with `multiple` set

### DIFF
--- a/src/browser/ui/dom/components/LinkedValueUtils.js
+++ b/src/browser/ui/dom/components/LinkedValueUtils.js
@@ -64,7 +64,19 @@ function _assertCheckedLink(input) {
  */
 function _handleLinkedValueChange(e) {
   /*jshint validthis:true */
-  this.props.valueLink.requestChange(e.target.value);
+  var target = e.target;
+  if (target.nodeName.toLowerCase() === 'select' && target.multiple) {
+    var selectedValue = [];
+    var options = target.options;
+    for (var i = 0, l = options.length; i < l; i++) {
+      if (options[i].selected) {
+        selectedValue.push(options[i].value);
+      }
+    }
+    this.props.valueLink.requestChange(selectedValue);
+  } else {
+    this.props.valueLink.requestChange(e.target.value);
+  }
 }
 
 /**

--- a/src/browser/ui/dom/components/__tests__/ReactDOMSelect-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMSelect-test.js
@@ -244,4 +244,28 @@ describe('ReactDOMSelect', function() {
     expect(link.requestChange.mock.calls[0][0]).toEqual('gorilla');
 
   });
+
+  it('should support ReactLink and multiple', function() {
+    var link = new ReactLink(['monkey', 'gorilla'], mocks.getMockFunction());
+    var stub =
+      <select multiple={true} valueLink={link}>
+        <option value="monkey">A monkey!</option>
+        <option value="giraffe">A giraffe!</option>
+        <option value="gorilla">A gorilla!</option>
+      </select>;
+    stub = ReactTestUtils.renderIntoDocument(stub);
+    var node = stub.getDOMNode();
+
+    expect(node.options[0].selected).toBe(true);  // monkey
+    expect(node.options[1].selected).toBe(false); // giraffe
+    expect(node.options[2].selected).toBe(true);  // gorilla
+    expect(link.requestChange.mock.calls.length).toBe(0);
+
+    node.options[0].selected = false;
+    node.options[1].selected = true;
+    ReactTestUtils.Simulate.change(node);
+
+    expect(link.requestChange.mock.calls.length).toBe(1);
+    expect(link.requestChange.mock.calls[0][0]).toEqual(['giraffe', 'gorilla']);
+  });
 });


### PR DESCRIPTION
`ReactLink` doesn't work on select elements with `multiple` set since `node.value` only returns the value of the element's first selected option. Some discussion over IRC indicated that it might make sense for the behavior to instead match that of the `value` property, which allows setting multiple values via an array; this PR implements that behavior.
