### PR TITLE
Also list <form> in error message as possible culprit

### DIFF
--- a/src/browser/ui/ReactMount.js
+++ b/src/browser/ui/ReactMount.js
@@ -649,9 +649,10 @@ var ReactMount = {
       false,
       'findComponentRoot(..., %s): Unable to find element. This probably ' +
       'means the DOM was unexpectedly mutated (e.g., by the browser), ' +
-      'usually due to forgetting a <tbody> when using tables, nesting <p> ' +
-      'or <a> tags, or using non-SVG elements in an <svg> parent. Try ' +
-      'inspecting the child nodes of the element with React ID `%s`.',
+      'usually due to forgetting a <tbody> when using tables, nesting tags ' +
+      'like <form>, <p>, or <a>, or using non-SVG elements in an <svg> ' +
+      'parent. ' +
+      'Try inspecting the child nodes of the element with React ID `%s`.',
       targetID,
       ReactMount.getID(ancestorNode)
     );

--- a/src/browser/ui/dom/DOMChildrenOperations.js
+++ b/src/browser/ui/dom/DOMChildrenOperations.js
@@ -119,9 +119,9 @@ var DOMChildrenOperations = {
           'processUpdates(): Unable to find child %s of element. This ' +
           'probably means the DOM was unexpectedly mutated (e.g., by the ' +
           'browser), usually due to forgetting a <tbody> when using tables, ' +
-          'nesting <p> or <a> tags, or using non-SVG elements in an <svg> '+
-          'parent. Try inspecting the child nodes of the element with React ' +
-          'ID `%s`.',
+          'nesting tags like <form>, <p>, or <a>, or using non-SVG elements '+
+          'in an <svg> parent. Try inspecting the child nodes of the element ' +
+          'with React ID `%s`.',
           updatedIndex,
           parentID
         );

--- a/src/core/__tests__/ReactInstanceHandles-test.js
+++ b/src/core/__tests__/ReactInstanceHandles-test.js
@@ -147,10 +147,10 @@ describe('ReactInstanceHandles', function() {
         'Invariant Violation: findComponentRoot(..., .0.1:0:junk): ' +
         'Unable to find element. This probably means the DOM was ' +
         'unexpectedly mutated (e.g., by the browser), usually due to ' +
-        'forgetting a <tbody> when using tables, nesting <p> or <a> tags, ' +
-        'or using non-SVG elements in an <svg> parent. Try inspecting the ' +
-        'child nodes of the element with React ' +
-        'ID `.0`.'
+        'forgetting a <tbody> when using tables, nesting tags ' +
+        'like <form>, <p>, or <a>, or using non-SVG elements in an <svg> ' +
+        'parent. ' +
+        'Try inspecting the child nodes of the element with React ID `.0`.'
       );
     });
   });


### PR DESCRIPTION
very small change, but once you start listing things that can't be nested `<form>` should be among them ;)
