### PR TITLE
Fix IE8 potentially throwing during restoreSelection

### DIFF
--- a/src/vendor/core/dom/focusNode.js
+++ b/src/vendor/core/dom/focusNode.js
@@ -19,14 +19,15 @@
 "use strict";
 
 /**
- * IE8 throws if an input/textarea is disabled and we try to focus it.
- * Focus only when necessary.
- *
  * @param {DOMElement} node input/textarea to focus
  */
 function focusNode(node) {
-  if (!node.disabled) {
+  // IE8 can throw "Can't move focus to the control because it is invisible,
+  // not enabled, or of a type that does not accept the focus." for all kinds of
+  // reasons that are too expensive and fragile to test.
+  try {
     node.focus();
+  } catch(e) {
   }
 }
 


### PR DESCRIPTION
> Can't move focus to the control because it is invisible, not enabled, or of a type that does not accept the focus.

I'm unable to reproduce this separately because I don't really understand the cause. I have a custom implementation of a drop-down used in a custom popup, when you click on the drop-down (just divs) it expands and shows a list of items (just more divs). When the drop-down is closed the above error is thrown in `focusNode()`, called by `restoreSelection()`, only IE8 AFAIK.

If I delay the closing of the drop-down (which is litterally just setting `this.state.open` to false and not rendering it), the error still occurs. I do _nothing_ except set the state to closed. Nor do I in any way force focus when it's opened.

Not fixed in master.
