### PR TITLE
Fixing grunt jsx task in Windows

### DIFF
--- a/grunt/tasks/jsx.js
+++ b/grunt/tasks/jsx.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var path = require("path");
 var grunt = require("grunt");
 var expand = grunt.file.expand;
 var spawn = grunt.util.spawn;
@@ -27,8 +28,8 @@ module.exports = function() {
   args.push("--config" /* from stdin */);
 
   var child = spawn({
-    cmd: "bin/jsx-internal",
-    args: args
+    cmd: "node",
+    args: [path.join("bin", "jsx-internal")].concat(args)
   }, function(error, result, code) {
     if (error) {
       grunt.log.error(error);


### PR DESCRIPTION
Spawning node directly instead of relying on shebang in the jsx-internal script

Fixes #1292
