### PR TITLE
Update React-tools to support transform as object

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,7 +23,7 @@ module.exports = {
     var result = {};
     result.code = output.code;
     if (options && options.sourceMap) {
-      result.sourceMap = output.sourceMap;
+      result.sourceMap = output.sourceMap.toJSON();
     }
     return result;
   }


### PR DESCRIPTION
This change adds an additional function to the exported object to support getting access to the transformed result as an object rather than just a string result - the separate function designed to maintain backwards compatibility. 

This facilitates tools that want the code separate from the sourcemap or anything else as time goes by.
