### PR TITLE
Add the built source to npm package. See #1699

### DIFF
--- a/grunt/tasks/npm-react.js
+++ b/grunt/tasks/npm-react.js
@@ -7,6 +7,11 @@ var src = 'npm-react/';
 var dest = 'build/npm-react/';
 var modSrc = 'build/modules/';
 var lib = dest + 'lib/';
+var dist = dest + 'dist/';
+var distFiles = [
+  'react.js', 'react.min.js', 'JSXTransformer.js',
+  'react-with-addons.js', 'react-with-addons.min.js'
+];
 
 function buildRelease() {
   // delete build/react-core for fresh start
@@ -29,6 +34,12 @@ function buildRelease() {
     } else {
       grunt.file.copy(src, dest);
     }
+  });
+
+  // Make built source available inside npm package
+  grunt.file.mkdir(dist);
+  distFiles.forEach(function(file) {
+    grunt.file.copy('build/' + file, dist + file);
   });
 
   // modify build/react-core/package.json to set version ##

--- a/npm-react/package.json
+++ b/npm-react/package.json
@@ -17,6 +17,7 @@
     "README.md",
     "addons.js",
     "react.js",
+    "dist/",
     "lib/"
   ],
   "main": "react.js",


### PR DESCRIPTION
This will add the built source to the npm package, so that anyone using react via npm (and not using browserify) will have the built source available, with the exact same versions. (vs. tracking the built source from the packaged zip file or some other method).

CLA has been submitted. Thanks.
