### PR TITLE
[RFC] Refactor DOM properties diffing logic

### DIFF
--- a/src/browser/ui/ReactDOMIDOperations.js
+++ b/src/browser/ui/ReactDOMIDOperations.js
@@ -101,20 +101,21 @@ var ReactDOMIDOperations = {
     }
   ),
 
-  /**
-   * Updates a DOM node with new style values. If a value is specified as '',
-   * the corresponding style property will be unset.
-   *
-   * @param {string} id ID of the node to update.
-   * @param {object} styles Mapping from styles to values.
-   * @internal
-   */
-  updateStylesByID: ReactPerf.measure(
+  deleteStyleByID: ReactPerf.measure(
     'ReactDOMIDOperations',
-    'updateStylesByID',
-    function(id, styles) {
+    'deleteStyleByID',
+    function(id, styleName) {
       var node = ReactMount.getNode(id);
-      CSSPropertyOperations.setValueForStyles(node, styles);
+      CSSPropertyOperations.deleteStyle(node, styleName);
+    }
+  ),
+
+  updateStyleByID: ReactPerf.measure(
+    'ReactDOMIDOperations',
+    'updateStyleByID',
+    function(id, newStyle, styleName) {
+      var node = ReactMount.getNode(id);
+      CSSPropertyOperations.setValueForStyle(node, newStyle, styleName);
     }
   ),
 

--- a/src/browser/ui/dom/CSSPropertyOperations.js
+++ b/src/browser/ui/dom/CSSPropertyOperations.js
@@ -61,35 +61,22 @@ var CSSPropertyOperations = {
     return serialized || null;
   },
 
-  /**
-   * Sets the value for multiple styles on a node.  If a value is specified as
-   * '' (empty string), the corresponding style property will be unset.
-   *
-   * @param {DOMElement} node
-   * @param {object} styles
-   */
-  setValueForStyles: function(node, styles) {
+  deleteStyle: function(node, styleName) {
     var style = node.style;
-    for (var styleName in styles) {
-      if (!styles.hasOwnProperty(styleName)) {
-        continue;
+    var expansion = CSSProperty.shorthandPropertyExpansions[styleName];
+    if (expansion) {
+      // Shorthand property that IE8 won't like unsetting, so unset each
+      // component to placate it
+      for (var individualStyleName in expansion) {
+        style[individualStyleName] = '';
       }
-      var styleValue = dangerousStyleValue(styleName, styles[styleName]);
-      if (styleValue) {
-        style[styleName] = styleValue;
-      } else {
-        var expansion = CSSProperty.shorthandPropertyExpansions[styleName];
-        if (expansion) {
-          // Shorthand property that IE8 won't like unsetting, so unset each
-          // component to placate it
-          for (var individualStyleName in expansion) {
-            style[individualStyleName] = '';
-          }
-        } else {
-          style[styleName] = '';
-        }
-      }
+    } else {
+      style[styleName] = '';
     }
+  },
+
+  setValueForStyle: function(node, value, styleName) {
+    node.style[styleName] = dangerousStyleValue(styleName, value);
   }
 
 };

--- a/src/utils/__tests__/diffObjects-test.js
+++ b/src/utils/__tests__/diffObjects-test.js
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @jsx React.DOM
+ * @emails react-core
+ */
+
+/*jslint evil: true */
+
+"use strict";
+
+require('mock-modules')
+  .dontMock('diffObjects');
+
+var diffObjects;
+
+describe('diffObjects', () => {
+  var deleteSpy;
+  var updateSpy;
+
+  beforeEach(() => {
+    diffObjects = require('diffObjects');
+
+    deleteSpy = jasmine.createSpy();
+    updateSpy = jasmine.createSpy();
+  });
+
+  it('should call the callback with extra params', () => {
+    diffObjects({a: 1}, {a: 2}, deleteSpy, updateSpy, 'foo', 'bar');
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(updateSpy.argsForCall.length).toBe(1);
+    expect(updateSpy.argsForCall[0][3]).toBe('foo');
+    expect(updateSpy.argsForCall[0][4]).toBe('bar');
+  });
+
+  it('should diff between null and new object', () => {
+    var b = {a: 1, b: 2};
+    diffObjects(null, b, deleteSpy, updateSpy, 'foo', 'bar');
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(updateSpy.argsForCall.length).toBe(2);
+    expect(updateSpy.argsForCall[0]).toEqual(['a', null, b, 'foo', 'bar']);
+    expect(updateSpy.argsForCall[1]).toEqual(['b', null, b, 'foo', 'bar']);
+  });
+
+  it('should diff correctly when the second object is null', () => {
+    var a = {a: 1, b: 2};
+    diffObjects(a, null, deleteSpy, updateSpy, 'foo', 'bar');
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(deleteSpy.argsForCall.length).toBe(2);
+    expect(deleteSpy.argsForCall[0]).toEqual(['a', a, null, 'foo', 'bar']);
+    expect(deleteSpy.argsForCall[1]).toEqual(['b', a, null, 'foo', 'bar']);
+  });
+
+  it('should diff two nulls', () => {
+    diffObjects(null, null, deleteSpy, updateSpy, 'foo', 'bar');
+    diffObjects(undefined, undefined, deleteSpy, updateSpy, 'foo', 'bar');
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it('should add the new values correctly', () => {
+    var a = {};
+    var b = {a: 1, b: 2};
+    diffObjects(a, b, deleteSpy, updateSpy, 'foo', 'bar');
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(updateSpy.argsForCall.length).toBe(2);
+    expect(updateSpy.argsForCall[0]).toEqual(['a', a, b, 'foo', 'bar']);
+    expect(updateSpy.argsForCall[1]).toEqual(['b', a, b, 'foo', 'bar']);
+  });
+
+  it('should remove the old values correctly', () => {
+    var a = {a: 1, b: 2};
+    var b = {};
+    diffObjects(a, b, deleteSpy, updateSpy, 'foo', 'bar');
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(deleteSpy.argsForCall.length).toBe(2);
+    expect(deleteSpy.argsForCall[0]).toEqual(['a', a, b, 'foo', 'bar']);
+    expect(deleteSpy.argsForCall[1]).toEqual(['b', a, b, 'foo', 'bar']);
+  });
+
+  it('should update the values correctly', () => {
+    var a = {a: 1, b: 2};
+    var b = {a: 3, b: 4};
+    diffObjects(a, b, deleteSpy, updateSpy, 'foo', 'bar');
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(updateSpy.argsForCall.length).toBe(2);
+    expect(updateSpy.argsForCall[0]).toEqual(['a', a, b, 'foo', 'bar']);
+    expect(updateSpy.argsForCall[1]).toEqual(['b', a, b, 'foo', 'bar']);
+  });
+
+  it('should not include the values if they are not changed', () => {
+    var a = {a: 1, b: 2};
+    diffObjects(a, a, deleteSpy, updateSpy, 'foo', 'bar');
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('should do add/remove/update correctly at the same time', () => {
+    var a = {a: 1, b: 2, c: 3, d: 'bla'};
+    var b = {b: 3, c: 4, d: 'bla', e: 5};
+    diffObjects(a, b, deleteSpy, updateSpy, 'foo', 'bar');
+    expect(updateSpy.argsForCall.length).toBe(3);
+    expect(updateSpy.argsForCall[0]).toEqual(['b', a, b, 'foo', 'bar']);
+    expect(updateSpy.argsForCall[1]).toEqual(['c', a, b, 'foo', 'bar']);
+    expect(updateSpy.argsForCall[2]).toEqual(['e', a, b, 'foo', 'bar']);
+    expect(deleteSpy.argsForCall.length).toBe(1);
+    expect(deleteSpy.argsForCall[0]).toEqual(['a', a, b, 'foo', 'bar']);
+  });
+});

--- a/src/utils/diffObjects.js
+++ b/src/utils/diffObjects.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @providesModule diffObjects
+ */
+
+"use strict";
+
+/**
+ * Compare two objects, calling deleteFunc for each key in prevObj missing from
+ * nextObj and updateFunc for each key with a different value in nextObj.
+ *
+ * @param {object?} prevObj
+ * @param {object?} nextObj
+ * @param {function} deleteFunc
+ * @param {function} updateFunc
+ */
+function diffObjects(prevObj, nextObj, deleteFunc, updateFunc, a, b) {
+  if (prevObj == null && nextObj == null) {
+    return;
+  }
+
+  var key;
+  if (prevObj == null) {
+    for (key in nextObj) {
+      if (!nextObj.hasOwnProperty(key)) {
+        continue;
+      }
+      updateFunc(key, prevObj, nextObj, a, b);
+    }
+    return;
+  }
+
+  if (nextObj == null) {
+    for (key in prevObj) {
+      if (!prevObj.hasOwnProperty(key)) {
+        continue;
+      }
+      deleteFunc(key, prevObj, nextObj, a, b);
+    }
+    return;
+  }
+
+  for (key in prevObj) {
+    if (!prevObj.hasOwnProperty(key)) {
+      continue;
+    }
+    if (!nextObj.hasOwnProperty(key)) {
+      deleteFunc(key, prevObj, nextObj, a, b);
+    } else if (prevObj[key] !== nextObj[key]) {
+      updateFunc(key, prevObj, nextObj, a, b);
+    }
+  }
+
+  for (key in nextObj) {
+    if (!nextObj.hasOwnProperty(key)) {
+      continue;
+    }
+    if (!prevObj.hasOwnProperty(key)) {
+      updateFunc(key, prevObj, nextObj, a, b);
+    }
+  }
+}
+
+module.exports = diffObjects;


### PR DESCRIPTION
Better version of #1543.

This generalizes the diffing into a `diffObjects` method that we can use recursively, both for updating all the DOM props and for the style object. The method calls the delete/update callback for each appropriate object key. This saves a potential allocation that we used to have due to generating a diff for `style` and passing it onto `setValueForStyles`. This'll be an even bigger win for future props (dataSet, ariaSet), since none of those would allocate.

Another upside is that the code's more readable (I feel?).

The downside is it's slightly slower, because it's calling a callback for each prop rather than passing a diff onto `setValueForStyles`, which iterates over it.