### PR TITLE
Add support for inline sourcemaps in jsx executable

### DIFF
--- a/bin/jsx
+++ b/bin/jsx
@@ -2,8 +2,7 @@
 // -*- mode: js -*-
 "use strict";
 
-var visitors = require('../vendor/fbtransform/visitors');
-var transform = require('jstransform').transform;
+var transform = require('../main').transform;
 
 require('commoner').version(
   require('../package.json').version
@@ -12,13 +11,14 @@ require('commoner').version(
 }).option(
   '--harmony',
   'Turns on JS transformations such as ES6 Classes etc.'
+).option(
+  '--source-map-inline',
+  'Embed inline sourcemap in transformed source'
 ).process(function(id, source) {
   // This is where JSX, ES6, etc. desugaring happens.
-  var visitorList;
-  if (this.options.harmony) {
-    visitorList = visitors.getAllVisitors();
-  } else {
-    visitorList = visitors.transformVisitors.react;
-  }
-  return transform(visitorList, source).code;
+  var options = {
+    harmony: this.options.harmony,
+    sourceMap: this.options.sourceMapInline
+  };
+  return transform(source, options);
 });

--- a/npm-react-tools/README.md
+++ b/npm-react-tools/README.md
@@ -26,6 +26,7 @@ This package installs a `jsx` executable that can be used to transform JSX into 
       --source-charset <utf8 | win1252 | ...>  Charset of source (default: utf8)
       --output-charset <utf8 | win1252 | ...>  Charset of output (default: utf8)
       --harmony                                Turns on JS transformations such as ES6 Classes etc.
+      --source-map-inline                      Embed inline sourcemap in transformed source
 
 ## API
 


### PR DESCRIPTION
I kept the option as `--source-map-inline` based on #833. I'm going to punt on the external part, though that should be easy now with `transformWithDetails` also being in react-tools.

I think it's important we get this in before 0.11 since we support sourcemaps in some form everywhere else and it's clowny not to do it in our own executable.

(I didn't update the readme yet, but I will)
