### PR TITLE
Update Todo MVC example

### DIFF
--- a/examples/todomvc-flux/js/components/MainSection.react.js
+++ b/examples/todomvc-flux/js/components/MainSection.react.js
@@ -35,7 +35,7 @@ var MainSection = React.createClass({
     // This section should be hidden by default
     // and shown when there are todos.
     if (Object.keys(this.props.allTodos).length < 1) {
-      return <noscript />;
+      return null;
     }
 
     var allTodos = this.props.allTodos;

--- a/examples/todomvc-flux/package.json
+++ b/examples/todomvc-flux/package.json
@@ -5,7 +5,7 @@
   "main": "js/app.js",
   "dependencies": {
     "es6-promise": "~0.1.1",
-    "react": "~0.10"
+    "react": "~0.11.0"
   },
   "devDependencies": {
     "browserify": "~2.36.0",


### PR DESCRIPTION
A small patch for the Todo MVC example to use React 0.11.0-rc1.
This then allows the `MainSection` to return `null` instead of previous
`<noscript/>`.

Since returning null is the new `blessed` approach its better to get it into the examples.
