### PR TITLE
Add "Edit on GitHub" link on docs pages

### DIFF
--- a/docs/_css/react.scss
+++ b/docs/_css/react.scss
@@ -566,6 +566,19 @@ figure {
   margin: 0 auto;
 }
 
+h1 {
+  // Contains .edit-page-link
+  @include clearfix;
+}
+
+.edit-page-link {
+  float: right;
+  font-size: 16px;
+  font-weight: normal;
+  line-height: 20px;
+  margin-top: 17px;
+}
+
 /* Blog */
 
 .post-list-item + .post-list-item {

--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -7,8 +7,12 @@ sectionid: docs
   {% include nav_docs.html %}
 
   <div class="inner-content">
-    <h1>{{ page.title }}</h1>
+    <h1>
+      {{ page.title }}
+      <a class="edit-page-link" href="https://github.com/facebook/react/tree/master/docs/{{ page.path }}" target="_blank">Edit on GitHub</a>
+    </h1>
     <div class="subHeader">{{ page.description }}</div>
+
     {{ content }}
 
     <div class="docs-prevnext">


### PR DESCRIPTION
Ember's docs do this and I rather like the idea of encouraging people to make improvements.

![image](https://cloud.githubusercontent.com/assets/6820/3595072/900d6d68-0cae-11e4-8e01-4a2afdeffd29.png)
