### PR TITLE
Check whether component actually exists before

### DIFF
--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -101,7 +101,7 @@ var ReactTransitionGroup = React.createClass({
 
     var component = this.refs[key];
 
-    if (component.componentWillEnter) {
+    if (component && component.componentWillEnter) {
       component.componentWillEnter(
         this._handleDoneEntering.bind(this, key)
       );
@@ -112,7 +112,7 @@ var ReactTransitionGroup = React.createClass({
 
   _handleDoneEntering: function(key) {
     var component = this.refs[key];
-    if (component.componentDidEnter) {
+    if (component && component.componentDidEnter) {
       component.componentDidEnter();
     }
 


### PR DESCRIPTION
When using ReactCSSTransitionGroup and adding a node by replacing a null-child React will complain with a `TypeError: Cannot read property 'componentWillLeave' of undefined` the first time. This change fixes that.
