### PR TITLE
[idea] escapeTextForBrowser, test string for unsafe chars before escaping

### DIFF
--- a/src/utils/escapeTextForBrowser.js
+++ b/src/utils/escapeTextForBrowser.js
@@ -20,11 +20,11 @@
 "use strict";
 
 var ESCAPE_LOOKUP = {
-  "&": "&amp;",
-  ">": "&gt;",
-  "<": "&lt;",
-  "\"": "&quot;",
-  "'": "&#x27;"
+  '&': '&amp;',
+  '>': '&gt;',
+  '<': '&lt;',
+  '"': '&quot;',
+  "'": '&#x27;'
 };
 
 var ESCAPE_REGEX = /[&><"']/g;
@@ -40,7 +40,13 @@ function escaper(match) {
  * @return {string} An escaped string.
  */
 function escapeTextForBrowser(text) {
-  return ('' + text).replace(ESCAPE_REGEX, escaper);
+  text = '' + text;
+
+  if (ESCAPE_REGEX.test(text)) {
+    return text.replace(ESCAPE_REGEX, escaper);
+  }
+
+  return text;
 }
 
 module.exports = escapeTextForBrowser;


### PR DESCRIPTION
http://jsperf.com/escapeindexo/2 (short strings), http://jsperf.com/escapeindexo/3 (long strings)

Rough performance figures in IE8 and Chrome:
Testing and not escaping results in +100-200% (short), +30-70% (long)
Testing and escaping results in -33% (short and long)

Performance gained by this PR naturally increases for shorter strings and decrease for longer strings, considering that most of the attributes (style being the exception) generally have very short strings, this is good.

I would think that (far) more than half of the strings we pass through that function don't need to be escaped, meaning this should result in a performance improvement.

Also changed `ESCAPE_LOOKUP` to use single quotes while I was at it (feel free to object :)).
I'm not convinced that we should take it, posting this to share my results.