### PR TITLE
Newlines handled incorrectly by innerText in IE8

### DIFF
--- a/src/browser/ui/dom/DOMChildrenOperations.js
+++ b/src/browser/ui/dom/DOMChildrenOperations.js
@@ -15,16 +15,8 @@
 var Danger = require('Danger');
 var ReactMultiChildUpdateTypes = require('ReactMultiChildUpdateTypes');
 
-var getTextContentAccessor = require('getTextContentAccessor');
+var setTextContent = require('setTextContent');
 var invariant = require('invariant');
-
-/**
- * The DOM property to use when setting text content.
- *
- * @type {string}
- * @private
- */
-var textContentAccessor = getTextContentAccessor();
 
 /**
  * Inserts `childNode` as a child of `parentNode` at the `index`.
@@ -45,37 +37,6 @@ function insertChildAt(parentNode, childNode, index) {
   );
 }
 
-var updateTextContent;
-if (textContentAccessor === 'textContent') {
-  /**
-   * Sets the text content of `node` to `text`.
-   *
-   * @param {DOMElement} node Node to change
-   * @param {string} text New text content
-   */
-  updateTextContent = function(node, text) {
-    node.textContent = text;
-  };
-} else {
-  /**
-   * Sets the text content of `node` to `text`.
-   *
-   * @param {DOMElement} node Node to change
-   * @param {string} text New text content
-   */
-  updateTextContent = function(node, text) {
-    // In order to preserve newlines correctly, we can't use .innerText to set
-    // the contents (see #1080), so we empty the element then append a text node
-    while (node.firstChild) {
-      node.removeChild(node.firstChild);
-    }
-    if (text) {
-      var doc = node.ownerDocument || document;
-      node.appendChild(doc.createTextNode(text));
-    }
-  };
-}
-
 /**
  * Operations for updating with DOM children.
  */
@@ -83,7 +44,7 @@ var DOMChildrenOperations = {
 
   dangerouslyReplaceNodeWithMarkup: Danger.dangerouslyReplaceNodeWithMarkup,
 
-  updateTextContent: updateTextContent,
+  updateTextContent: setTextContent,
 
   /**
    * Updates a component's children by processing a series of updates. The
@@ -156,7 +117,7 @@ var DOMChildrenOperations = {
           );
           break;
         case ReactMultiChildUpdateTypes.TEXT_CONTENT:
-          updateTextContent(
+          setTextContent(
             update.parentNode,
             update.textContent
           );

--- a/src/browser/ui/dom/setTextContent.js
+++ b/src/browser/ui/dom/setTextContent.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2013-2014 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @providesModule setTextContent
+ */
+
+"use strict";
+
+var ExecutionEnvironment = require('ExecutionEnvironment');
+var escapeTextForBrowser = require('escapeTextForBrowser');
+var setInnerHTML = require('setInnerHTML');
+
+/**
+ * Set the textContent property of a node, ensuring that whitespace is preserved
+ * even in IE8. innerText is a poor substitute for textContent and, among many
+ * issues, inserts <br> instead of the literal newline chars. innerHTML behaves
+ * as it should.
+ *
+ * @param {DOMElement} node
+ * @param {string} text
+ * @internal
+ */
+var setTextContent = function(node, text) {
+  node.textContent = text;
+};
+
+if (ExecutionEnvironment.canUseDOM) {
+  if (!('textContent' in document.documentElement)) {
+    setTextContent = function(node, text) {
+      setInnerHTML(node, escapeTextForBrowser(text));
+    };
+  }
+}
+
+module.exports = setTextContent;


### PR DESCRIPTION
Before this PR: http://dev.cetrez.com/jsx/2/indexie8.html
After this PR: http://dev.cetrez.com/jsx/2/indexie8fix.html

There's already fix to deal with this, but `\r\n` incorrectly become two newlines as you can see above. With this PR, the implementation builds on our "proven" consistent behavior of `innerHTML` for IE8, rather than `TextNode`, so it should also be favorable in that regard.

So if there are any other inconsistencies we are unaware of with `innerHTML`, they should at least be consistent between initial render and update now, which is a preferable behavior IMHO.

Pairs well with #1599 and especially #1863 to enjoy less overhead, #1863 could also be transplanted into `setTextContent` if we don't want to take it as-is.

PS. While we should probably follow #2273 and drop `setInnerHTML`, it would be too heavy-handed for setting text content. When that time comes, simply stripping `setInnerHTML` down to the essentials and inlining it into `setTextContent` should be the correct approach.