### PR TITLE
getModifierState should always return a boolean

### DIFF
--- a/src/browser/ui/dom/getEventModifierState.js
+++ b/src/browser/ui/dom/getEventModifierState.js
@@ -42,7 +42,7 @@ function modifierStateGetter(keyArg) {
     return nativeEvent.getModifierState(keyArg);
   }
   var keyProp = modifierKeyToProp[keyArg];
-  return keyProp && nativeEvent[keyProp];
+  return keyProp ? !!nativeEvent[keyProp] : false
 }
 
 function getEventModifierState(nativeEvent) {


### PR DESCRIPTION
Standard says it returns a boolean and this is a simple enough fix.
