### PR TITLE
Add note about key prop being excluded by cloneWithProps

### DIFF
--- a/docs/docs/09.5-clone-with-props.md
+++ b/docs/docs/09.5-clone-with-props.md
@@ -13,8 +13,9 @@ In rare situations a component may want to change the props of a component that 
 
 Do a shallow copy of `component` and merge any props provided by `extraProps`. Props are merged in the same manner as [`transferPropsTo()`](/react/docs/component-api.html#transferpropsto), so props like `className` will be merged intelligently.
 
-**NOTE:** `cloneWithProps` does not transfer the `key` prop to the cloned component. If you wish to preserve the key, add it to the `extraProps` object:
-
-```js
-var clonedComponent = cloneWithProps(originalComponent, { key : originalComponent.props.key });
-```
+> Note:
+>
+> `cloneWithProps` does not transfer the `key` prop to the cloned component. If you wish to preserve the key, add it to the `extraProps` object:
+> ```js
+> var clonedComponent = cloneWithProps(originalComponent, { key : originalComponent.props.key });
+> ```


### PR DESCRIPTION
Whilst this is intentional behaviour (see #1274), it is not documented anywhere, so it is worth mentioning.

It would also be nice if React issued a warning to console if a cloned component loses its key (as this will silently break reconciliation?)
