### PR TITLE
Use script tags to demarcate text components

### DIFF
--- a/src/browser/ReactTextComponent.js
+++ b/src/browser/ReactTextComponent.js
@@ -33,8 +33,9 @@ var mixInto = require('mixInto');
  *  - When mounting text into the DOM, adjacent text nodes are merged.
  *  - Text nodes cannot be assigned a React root ID.
  *
- * This component is used to wrap strings in elements so that they can undergo
- * the same reconciliation that is applied to elements.
+ * This component is used to add a <script> tag before each text node so that
+ * they can undergo a reconciliation process similar to the one applied to
+ * elements.
  *
  * TODO: Investigate representing React components in the DOM with text nodes.
  *
@@ -71,16 +72,15 @@ mixInto(ReactTextComponent, {
     var escapedText = escapeTextForBrowser(this.props);
 
     if (transaction.renderToStaticMarkup) {
-      // Normally we'd wrap this in a `span` for the reasons stated above, but
-      // since this is a situation where React won't take over (static pages),
-      // we can simply return the text as it is.
+      // Normally we'd add a preceding `script` for the reasons stated above,
+      // but since this is a situation where React won't take over (static
+      // pages), we can simply return the text as it is.
       return escapedText;
     }
 
     return (
-      '<span ' + DOMPropertyOperations.createMarkupForID(rootID) + '>' +
-        escapedText +
-      '</span>'
+      '<script ' + DOMPropertyOperations.createMarkupForID(rootID) +
+      '></script>' + escapedText
     );
   },
 
@@ -95,7 +95,7 @@ mixInto(ReactTextComponent, {
     var nextProps = nextComponent.props;
     if (nextProps !== this.props) {
       this.props = nextProps;
-      ReactComponent.BackendIDOperations.updateTextContentByID(
+      ReactComponent.BackendIDOperations.updateTextContentAfterByID(
         this._rootNodeID,
         nextProps
       );

--- a/src/browser/server/__tests__/ReactServerRendering-test.js
+++ b/src/browser/server/__tests__/ReactServerRendering-test.js
@@ -94,8 +94,8 @@ describe('ReactServerRendering', function() {
         '<div ' + ID_ATTRIBUTE_NAME + '="[^"]+" ' +
           ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="[^"]+">' +
           '<span ' + ID_ATTRIBUTE_NAME + '="[^"]+">' +
-            '<span ' + ID_ATTRIBUTE_NAME + '="[^"]+">My name is </span>' +
-            '<span ' + ID_ATTRIBUTE_NAME + '="[^"]+">child</span>' +
+            '<script ' + ID_ATTRIBUTE_NAME + '="[^"]+"></script>My name is ' +
+            '<script ' + ID_ATTRIBUTE_NAME + '="[^"]+"></script>child' +
           '</span>' +
         '</div>'
       );
@@ -143,8 +143,10 @@ describe('ReactServerRendering', function() {
         expect(response).toMatch(
           '<span ' + ID_ATTRIBUTE_NAME + '="[^"]+" ' +
             ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="[^"]+">' +
-            '<span ' + ID_ATTRIBUTE_NAME + '="[^"]+">Component name: </span>' +
-            '<span ' + ID_ATTRIBUTE_NAME + '="[^"]+">TestComponent</span>' +
+            '<script ' + ID_ATTRIBUTE_NAME + '="[^"]+"></script>' +
+            'Component name: ' +
+            '<script ' + ID_ATTRIBUTE_NAME + '="[^"]+"></script>' +
+            'TestComponent' +
           '</span>'
         );
         expect(lifecycle).toEqual(

--- a/src/browser/ui/ReactDOMIDOperations.js
+++ b/src/browser/ui/ReactDOMIDOperations.js
@@ -135,18 +135,18 @@ var ReactDOMIDOperations = {
   ),
 
   /**
-   * Updates a DOM node's text content set by `props.content`.
+   * Updates the text content after a DOM node.
    *
    * @param {string} id ID of the node to update.
    * @param {string} content Text content.
    * @internal
    */
-  updateTextContentByID: ReactPerf.measure(
+  updateTextContentAfterByID: ReactPerf.measure(
     'ReactDOMIDOperations',
-    'updateTextContentByID',
+    'updateTextContentAfterByID',
     function(id, content) {
       var node = ReactMount.getNode(id);
-      DOMChildrenOperations.updateTextContent(node, content);
+      DOMChildrenOperations.updateTextContentAfter(node, content);
     }
   ),
 

--- a/src/core/__tests__/ReactMultiChildText-test.js
+++ b/src/core/__tests__/ReactMultiChildText-test.js
@@ -28,6 +28,21 @@ var ReactTestUtils = require('ReactTestUtils');
 
 var reactComponentExpect = require('reactComponentExpect');
 
+var TEXT_NODE = 3;
+
+var assertTextNodeAfter = function(node, text) {
+  expect(node.tagName).toBe('SCRIPT');
+  if (text === '') {
+    expect(
+      !node.nextSibling ||
+      node.nextSibling.nodeType !== TEXT_NODE
+    ).toBe(true);
+  } else {
+    expect(node.nextSibling.nodeType).toBe(TEXT_NODE);
+    expect(node.nextSibling.nodeValue).toBe(text);
+  }
+};
+
 var assertNodeText = function(instance, text) {
   expect(instance.getDOMNode().childNodes.length).toBe(1);
   expect(instance.getDOMNode().innerHTML).toBe('' + text);
@@ -38,15 +53,16 @@ var assertEmptyNode = function(instance) {
 };
 
 var assertMultiChild = function(instance, textOne, textTwo) {
-  expect(instance.getDOMNode().childNodes.length).toBe(2);
+  expect(instance.getDOMNode().childNodes.length).toBe(
+    2 + (textOne === '' ? 0 : 1) + (textTwo === '' ? 0 : 1)
+  );
   var firstTextDOMNode =
     reactComponentExpect(instance)
       .expectRenderedChildAt(0)
       .toBeTextComponent()
       .instance()
       .getDOMNode();
-  expect(firstTextDOMNode.childNodes.length).toBe(textOne === '' ? 0 : 1);
-  expect(firstTextDOMNode.innerHTML).toBe('' + textOne);
+  assertTextNodeAfter(firstTextDOMNode, textOne);
 
   var secondTextDOMNode =
     reactComponentExpect(instance)
@@ -54,20 +70,18 @@ var assertMultiChild = function(instance, textOne, textTwo) {
       .toBeTextComponent()
       .instance()
       .getDOMNode();
-  expect(secondTextDOMNode.childNodes.length).toBe(textTwo === '' ? 0 : 1);
-  expect(secondTextDOMNode.innerHTML).toBe('' + textTwo);
+  assertTextNodeAfter(secondTextDOMNode, textTwo);
 };
 
 var assertSingleChild = function(instance, text) {
-  expect(instance.getDOMNode().childNodes.length).toBe(1);
+  expect(instance.getDOMNode().childNodes.length).toBe(2);
   var textDOMNode =
     reactComponentExpect(instance)
       .expectRenderedChildAt(0)
       .toBeTextComponent()
       .instance()
       .getDOMNode();
-  expect(textDOMNode.childNodes.length).toBe(1);
-  expect(textDOMNode.innerHTML).toBe('' + text);
+  assertTextNodeAfter(textDOMNode, text);
 };
 
 // Helpers


### PR DESCRIPTION
tl;dr: `<script></script>A<script></script>B` instead of `<span>A</span><span>B</span>`.

Old:

![image](https://cloud.githubusercontent.com/assets/6820/3631177/af021294-0eb3-11e4-8b4a-d334cef48dea.png)

New:

![image](https://cloud.githubusercontent.com/assets/6820/3631172/a74a7866-0eb3-11e4-9591-1320ba0c326a.png)

This is nicer in that if you add styles on `span`, your text nodes now won't be affected. Similarly, the target of mouse events will now never be a ReactTextComponent span because the script elements aren't rendered at all.

Test Plan: jest, and some simple browser sanity checking.