### PR TITLE
Add AltGraph to keys supported by getEventModifierState

### DIFF
--- a/src/browser/ui/dom/getEventModifierState.js
+++ b/src/browser/ui/dom/getEventModifierState.js
@@ -26,6 +26,7 @@
 
 var modifierKeyToProp = {
   'Alt': 'altKey',
+  'AltGraph': 'altGraphKey',
   'Control': 'ctrlKey',
   'Meta': 'metaKey',
   'Shift': 'shiftKey'


### PR DESCRIPTION
What the title says, it's hard to verify whether this actually affects any browsers (i.e, browsers that supported `altGraphKey` but not `getModifierState`), but I figure it's innocent enough to just add it.