### PR TITLE
Expose event.altGraphKey

### DIFF
--- a/src/browser/syntheticEvents/SyntheticKeyboardEvent.js
+++ b/src/browser/syntheticEvents/SyntheticKeyboardEvent.js
@@ -21,6 +21,7 @@
 
 var SyntheticUIEvent = require('SyntheticUIEvent');
 
+var getEventAltGraphKey = require('getEventAltGraphKey');
 var getEventKey = require('getEventKey');
 var getEventModifierState = require('getEventModifierState');
 
@@ -35,6 +36,7 @@ var KeyboardEventInterface = {
   shiftKey: null,
   altKey: null,
   metaKey: null,
+  altGraphKey: getEventAltGraphKey,
   repeat: null,
   locale: null,
   getModifierState: getEventModifierState,

--- a/src/browser/syntheticEvents/SyntheticMouseEvent.js
+++ b/src/browser/syntheticEvents/SyntheticMouseEvent.js
@@ -22,6 +22,7 @@
 var SyntheticUIEvent = require('SyntheticUIEvent');
 var ViewportMetrics = require('ViewportMetrics');
 
+var getEventAltGraphKey = require('getEventAltGraphKey');
 var getEventModifierState = require('getEventModifierState');
 
 /**
@@ -37,6 +38,7 @@ var MouseEventInterface = {
   shiftKey: null,
   altKey: null,
   metaKey: null,
+  altGraphKey: getEventAltGraphKey,
   getEventModifierState: getEventModifierState,
   button: function(event) {
     // Webkit, Firefox, IE9+

--- a/src/browser/syntheticEvents/SyntheticTouchEvent.js
+++ b/src/browser/syntheticEvents/SyntheticTouchEvent.js
@@ -21,6 +21,7 @@
 
 var SyntheticUIEvent = require('SyntheticUIEvent');
 
+var getEventAltGraphKey = require('getEventAltGraphKey');
 var getEventModifierState = require('getEventModifierState');
 
 /**
@@ -35,6 +36,7 @@ var TouchEventInterface = {
   metaKey: null,
   ctrlKey: null,
   shiftKey: null,
+  altGraphKey: getEventAltGraphKey,
   getModifierState: getEventModifierState
 };
 

--- a/src/browser/ui/dom/getEventAltGraphKey.js
+++ b/src/browser/ui/dom/getEventAltGraphKey.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2013-2014 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @providesModule getEventAltGraphKey
+ * @typechecks static-only
+ */
+
+"use strict";
+
+function getEventAltGraphKey(nativeEvent) {
+  if ('altGraphKey' in nativeEvent) {
+    return nativeEvent['altGraphKey'];
+  }
+  // IE9 (and more perhaps) does not expose altGraphKey, but supports it via
+  // getModifierState. Chrome exposes altGraphKey but doesn't actually support
+  // it, OSX/PC inconsistencies makes it seemingly quite useless at current.
+  return (
+    'getModifierState' in nativeEvent &&
+    nativeEvent.getModifierState('AltGraph')
+  );
+}
+
+module.exports = getEventAltGraphKey;


### PR DESCRIPTION
At least IE9 doesn't expose `event.altGraphKey` but supports it via `event.getModifierState('AltGraphKey')`.