### PR TITLE
getModifierState incorrectly exposed as SyntheticMouseEvent.getEventModifierState

### DIFF
--- a/src/browser/syntheticEvents/SyntheticMouseEvent.js
+++ b/src/browser/syntheticEvents/SyntheticMouseEvent.js
@@ -37,7 +37,7 @@ var MouseEventInterface = {
   shiftKey: null,
   altKey: null,
   metaKey: null,
-  getEventModifierState: getEventModifierState,
+  getModifierState: getEventModifierState,
   button: function(event) {
     // Webkit, Firefox, IE9+
     // which:  1 2 3


### PR DESCRIPTION
What the title says.
