### PR TITLE
Note how to access Perf in docs

### DIFF
--- a/docs/docs/09.8-perf.md
+++ b/docs/docs/09.8-perf.md
@@ -16,6 +16,8 @@ In addition to giving you an overview of your app's overall performance, ReactPe
 
 ## General API
 
+The `Perf` object documented here is exposed as `React.addons.Perf` when using the `react-with-addons.js` build in development mode.
+
 ### `Perf.start()` and `Perf.stop()`
 Start/stop the measurement. The React operations in-between are recorded for analyses below. Operations that took an insignificant amount of time are ignored.
 


### PR DESCRIPTION
I took me a little bit of digging in the source to spot how to reach the `Perf` object, so I thought it would be useful to note this.

I wasn't sure if mentioning `react/lib/ReactDefaultPerf` for CommonJS was a bit too internal, so have left that out for now.
