### PR TITLE
Use faster cached regexps for tests in setInnerHTML

### DIFF
--- a/src/browser/ui/dom/setInnerHTML.js
+++ b/src/browser/ui/dom/setInnerHTML.js
@@ -20,6 +20,9 @@
 
 var ExecutionEnvironment = require('ExecutionEnvironment');
 
+var WHITESPACE_TEST = /^[ \r\n\t\f]/;
+var NONVISIBLE_TEST = /<(!--|link|noscript|meta|script|style)[ \r\n\t\f\/>]/;
+
 /**
  * Set the innerHTML property of a node, ensuring that whitespace is preserved
  * even in IE8.
@@ -56,13 +59,8 @@ if (ExecutionEnvironment.canUseDOM) {
       // thin air on IE8, this only happens if there is no visible text
       // in-front of the non-visible tags. Piggyback on the whitespace fix
       // and simply check if any non-visible tags appear in the source.
-      if (html.match(/^[ \r\n\t\f]/) ||
-          html[0] === '<' && (
-            html.indexOf('<noscript') !== -1 ||
-            html.indexOf('<script') !== -1 ||
-            html.indexOf('<style') !== -1 ||
-            html.indexOf('<meta') !== -1 ||
-            html.indexOf('<link') !== -1)) {
+      if (WHITESPACE_TEST.test(html) ||
+          html[0] === '<' && NONVISIBLE_TEST.test(html)) {
         // Recover leading whitespace by temporarily prepending any character.
         // \uFEFF has the potential advantage of being zero-width/invisible.
         node.innerHTML = '\uFEFF' + html;


### PR DESCRIPTION
This is significantly faster than the current code.
http://jsperf.com/reacttestindexof (only relevant on IE8)

Also added comments to the list of non-visible tags and made the test even stricter.

Since this code is explicitly aimed at IE8, we could also switch the current extensive "feature test" for just `document.documentMode === 8`, it correctly identifies emulation mode (which emulates the crappy whitespace behavior). The upside to this would be that we _only_ target IE8 mode and doesn't apply potentially wonky logic to some other potentially broken browser out there (which I doubt there is).
