### PR TITLE
Use replaceNode for IE8 setInnerHTML instead

### DIFF
--- a/src/browser/ui/dom/setInnerHTML.js
+++ b/src/browser/ui/dom/setInnerHTML.js
@@ -47,10 +47,7 @@ if (ExecutionEnvironment.canUseDOM) {
       // nodes when processing innerHTML, innerHTML on updated nodes suffers
       // from worse whitespace behavior. Re-adding a node like this triggers
       // the initial and more favorable whitespace behavior.
-      // TODO: What to do on a detached node?
-      if (node.parentNode) {
-        node.parentNode.replaceChild(node, node);
-      }
+      node.swapNode(node);
 
       // We also implement a workaround for non-visible tags disappearing into
       // thin air on IE8, this only happens if there is no visible text


### PR DESCRIPTION
> // TODO: What to do on a detached node?

This! :)

Verified in a native IE8 instance.

Switched to `swapNode` instead, it is even slightly faster than `replaceNode` (and shorter).
