### PR TITLE
Remove _addPromise from Dispatcher code example

### DIFF
--- a/docs/docs/flux-todo-list.md
+++ b/docs/docs/flux-todo-list.md
@@ -59,21 +59,6 @@ var merge = require('react/lib/merge');
 var _callbacks = [];
 var _promises = [];
 
-/**
- * Add a promise to the queue of callback invocation promises.
- * @param {function} callback The Store's registered callback.
- * @param {object} payload The data from the Action.
- */
-var _addPromise = function(callback, payload) {
-  _promises.push(new Promise(function(resolve, reject) {
-    if (callback(payload)) {
-      resolve(payload);
-    } else {
-      reject(new Error('Dispatcher callback unsuccessful'));
-    }
-  }));
-};
-
 var Dispatcher = function() {};
 Dispatcher.prototype = merge(Dispatcher.prototype, {
 


### PR DESCRIPTION
The function `_addPromise` is not used in the provided Dispatcher example, nor does it exist in the full Dispatcher.js example code found here: https://github.com/facebook/react/blob/master/examples/todomvc-flux/js/dispatcher/Dispatcher.js. Removing for clarity. Is this simply legacy code?
