### PR TITLE
Properly handle direct event dispatches

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -325,7 +325,8 @@ function makeSimulator(eventType) {
     );
     mergeInto(event, eventData);
     EventPropagators.accumulateTwoPhaseDispatches(event);
-
+    EventPropagators.accumulateDirectDispatches(event);
+    
     ReactUpdates.batchedUpdates(function() {
       EventPluginHub.enqueueEvents(event);
       EventPluginHub.processEventQueue();


### PR DESCRIPTION
When registering events to `onMouseEnter` and `onMouseLeave` in a component, these events cannot be tested using the TestUtils. The methods `TestUtils.Simulate.mouseEnter` and `TestUtils.Simulate.mouseLeave` do exist, but the event is never actually dispatched, since `makeSimulator` function only calls `accumulateTwoPhaseDispatches`, which does not cover `mouseEnter` and `mouseLeave`.

Adding a call to `accumulateDirectDispatches` takes care of this and the events are being dispatched normally.
