### PR TITLE
Add helper getDefaultView for IE8

### DIFF
--- a/src/browser/eventPlugins/EnterLeaveEventPlugin.js
+++ b/src/browser/eventPlugins/EnterLeaveEventPlugin.js
@@ -25,6 +25,7 @@ var SyntheticMouseEvent = require('SyntheticMouseEvent');
 
 var ReactMount = require('ReactMount');
 var keyOf = require('keyOf');
+var getDefaultView = require('getDefaultView');
 
 var topLevelTypes = EventConstants.topLevelTypes;
 var getFirstReactDOM = ReactMount.getFirstReactDOM;
@@ -87,12 +88,8 @@ var EnterLeaveEventPlugin = {
       win = topLevelTarget;
     } else {
       // TODO: Figure out why `ownerDocument` is sometimes undefined in IE8.
-      var doc = topLevelTarget.ownerDocument;
-      if (doc) {
-        win = doc.defaultView || doc.parentWindow;
-      } else {
-        win = window;
-      }
+      var doc = topLevelTarget.ownerDocument || document;
+      win = getDefaultView(doc);
     }
 
     var from, to;

--- a/src/browser/syntheticEvents/SyntheticUIEvent.js
+++ b/src/browser/syntheticEvents/SyntheticUIEvent.js
@@ -22,6 +22,7 @@
 var SyntheticEvent = require('SyntheticEvent');
 
 var getEventTarget = require('getEventTarget');
+var getDefaultView = require('getDefaultView');
 
 /**
  * @interface UIEvent
@@ -39,13 +40,9 @@ var UIEventInterface = {
       return target;
     }
 
-    var doc = target.ownerDocument;
     // TODO: Figure out why `ownerDocument` is sometimes undefined in IE8.
-    if (doc) {
-      return doc.defaultView || doc.parentWindow;
-    } else {
-      return window;
-    }
+    var doc = target.ownerDocument || document;
+    return getDefaultView(doc);
   },
   detail: function(event) {
     return event.detail || 0;

--- a/src/browser/ui/dom/getDefaultView.js
+++ b/src/browser/ui/dom/getDefaultView.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2013-2014 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @providesModule getDefaultView
+ * @typechecks static-only
+ */
+
+"use strict";
+
+var ExecutionEnvironment = require('ExecutionEnvironment');
+
+var getDefaultView = function(doc) {
+  return doc.defaultView;
+};
+
+if (ExecutionEnvironment.canUseDOM) {
+  // IE8 only supports the non-standard parentWindow.
+  if (!('defaultView' in document)) {
+    getDefaultView = function(doc) {
+      return doc.parentWindow;
+    };
+  }
+}
+
+module.exports = getDefaultView;


### PR DESCRIPTION
This is an IE8 only workaround that is used in two places, lets put it in a helper instead so it's easier to spot when we stop supporting IE8. Or perhaps we should explicitly comment in both places that `parentWindow` is a fallback for IE8.
