### PR TITLE
Remove redundant uses of window.*

### DIFF
--- a/src/addons/transitions/ReactTransitionEvents.js
+++ b/src/addons/transitions/ReactTransitionEvents.js
@@ -95,7 +95,7 @@ var ReactTransitionEvents = {
     if (endEvents.length === 0) {
       // If CSS transitions are not supported, trigger an "end animation"
       // event immediately.
-      window.setTimeout(eventListener, 0);
+      setTimeout(eventListener, 0);
       return;
     }
     endEvents.forEach(function(endEvent) {

--- a/src/browser/eventPlugins/BeforeInputEventPlugin.js
+++ b/src/browser/eventPlugins/BeforeInputEventPlugin.js
@@ -37,7 +37,6 @@ var canUseTextInputEvent = (
  * text input events. Rely on keypress instead.
  */
 function isPresto() {
-  var opera = window.opera;
   return (
     typeof opera === 'object' &&
     typeof opera.version === 'function' &&

--- a/src/browser/eventPlugins/SelectEventPlugin.js
+++ b/src/browser/eventPlugins/SelectEventPlugin.js
@@ -78,7 +78,7 @@ function getSelection(node) {
       left: range.boundingLeft
     };
   } else {
-    var selection = window.getSelection();
+    var selection = getSelection();
     return {
       anchorNode: selection.anchorNode,
       anchorOffset: selection.anchorOffset,

--- a/src/browser/ui/ReactDOMSelection.js
+++ b/src/browser/ui/ReactDOMSelection.js
@@ -70,7 +70,7 @@ function getIEOffsets(node) {
  * @return {?object}
  */
 function getModernOffsets(node) {
-  var selection = window.getSelection && window.getSelection();
+  var selection = window.getSelection && getSelection();
 
   if (!selection || selection.rangeCount === 0) {
     return null;
@@ -165,7 +165,7 @@ function setModernOffsets(node, offsets) {
     return;
   }
 
-  var selection = window.getSelection();
+  var selection = getSelection();
   var length = node[getTextContentAccessor()].length;
   var start = Math.min(offsets.start, length);
   var end = typeof offsets.end === 'undefined' ?

--- a/src/browser/ui/ReactDefaultInjection.js
+++ b/src/browser/ui/ReactDefaultInjection.js
@@ -115,7 +115,7 @@ function inject() {
   ReactInjection.Component.injectEnvironment(ReactComponentBrowserEnvironment);
 
   if (__DEV__) {
-    var url = (ExecutionEnvironment.canUseDOM && window.location.href) || '';
+    var url = (ExecutionEnvironment.canUseDOM && location.href) || '';
     if ((/[?&]react_perf\b/).test(url)) {
       var ReactDefaultPerf = require('ReactDefaultPerf');
       ReactDefaultPerf.start();

--- a/src/vendor/core/ExecutionEnvironment.js
+++ b/src/vendor/core/ExecutionEnvironment.js
@@ -20,11 +20,7 @@
 
 "use strict";
 
-var canUseDOM = !!(
-  typeof window !== 'undefined' &&
-  window.document &&
-  window.document.createElement
-);
+var canUseDOM = typeof document === 'object' && !!document.createElement;
 
 /**
  * Simple, lightweight module assisting with the detection and context of


### PR DESCRIPTION
Very simple PR, removes redundant uses of `window.*`, there's no point in doing `window.abc && window.abc()` as we already know `abc` is global when it's time to execute it.

Reject if you don't feel like touching all the different lines for "no good reason".

PS. Alternatively enforce use of `window.` everywhere it makes sense (i.e. not for Array), but that might be rather redundant and heavy-handed.
