### PR TITLE
Remove empty TextNode left behind by IE8 setInnerHTML workaround

### DIFF
--- a/src/browser/ui/__tests__/ReactMount-test.js
+++ b/src/browser/ui/__tests__/ReactMount-test.js
@@ -106,4 +106,12 @@ describe('ReactMount', function() {
     expect(mockMount.mock.calls.length).toBe(2);
     expect(mockUnmount.mock.calls.length).toBe(1);
   });
+
+  it('should reuse markup if rendering to the same target twice', function() {
+    var container = document.createElement('container');
+    var instance1 = React.renderComponent(<div />, container);
+    var instance2 = React.renderComponent(<div />, container);
+
+    expect(instance1 === instance2).toBe(true);
+  });
 });

--- a/src/browser/ui/dom/setInnerHTML.js
+++ b/src/browser/ui/dom/setInnerHTML.js
@@ -66,7 +66,15 @@ if (ExecutionEnvironment.canUseDOM) {
         // Recover leading whitespace by temporarily prepending any character.
         // \uFEFF has the potential advantage of being zero-width/invisible.
         node.innerHTML = '\uFEFF' + html;
-        node.firstChild.deleteData(0, 1);
+
+        // deleteData leaves an empty `TextNode` which offsets the index of all
+        // children. Definitely want to avoid this.
+        var textNode = node.firstChild;
+        if (textNode.data.length === 1) {
+          node.removeChild(textNode);
+        } else {
+          textNode.deleteData(0, 1);
+        }
       } else {
         node.innerHTML = html;
       }


### PR DESCRIPTION
What the title says, if it appends the `\uFEFF` to fix whitespace it can end up leaving an empty TextNode behind. This is very bad because it offsets the index of children. Also, `renderComponent` still uses `firstChild` which causes it to see the TextNode and replace the content rather than update it as it should.

@zpao We definitely want to merge this sooner rather than later.
