### PR TITLE
Simpler way to prevent flushing updates on server

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -864,7 +864,15 @@ var ReactCompositeComponentMixin = {
   replaceState: function(completeState, callback) {
     validateLifeCycleOnReplaceState(this);
     this._pendingState = completeState;
-    ReactUpdates.enqueueUpdate(this, callback);
+    if (this._compositeLifeCycleState !== CompositeLifeCycle.MOUNTING) {
+      // If we're in a componentWillMount handler, don't enqueue a rerender
+      // because ReactUpdates assumes we're in a browser context (which is wrong
+      // for server rendering) and we're about to do a render anyway.
+      // TODO: The callback here is ignored when setState is called from
+      // componentWillMount. Either fix it or disallow doing so completely in
+      // favor of getInitialState.
+      ReactUpdates.enqueueUpdate(this, callback);
+    }
   },
 
   /**

--- a/src/core/ReactUpdates.js
+++ b/src/core/ReactUpdates.js
@@ -172,25 +172,6 @@ var flushBatchedUpdates = ReactPerf.measure(
     // componentDidUpdate) but we need to check here too in order to catch
     // updates enqueued by setState callbacks.
     while (dirtyComponents.length) {
-      var allUnmounted = true;
-      for (var i = 0, l = dirtyComponents.length; i < l; i++) {
-        if (dirtyComponents[i].isMounted()) {
-          allUnmounted = false;
-          break;
-        }
-      }
-
-      if (allUnmounted) {
-        // All the "dirty" components are unmounted, which probably means that
-        // they were marked dirty due to setState calls in componentWillMount
-        // handlers and the components are currently in the process of mounting.
-        // `runBatchedUpdates` will be a noop. In that case, initializing the
-        // DOM-dependent ReactReconcileTransaction is thus not what we want to
-        // do, especially when using server rendering, so we skip it.
-        dirtyComponents.length = 0;
-        return;
-      }
-
       var transaction = ReactUpdatesFlushTransaction.getPooled();
       transaction.perform(runBatchedUpdates, null, transaction);
       ReactUpdatesFlushTransaction.release(transaction);


### PR DESCRIPTION
Test Plan: Only failing tests in jest are immutable tests that were already failing.
