### PR TITLE
Temporary workaround for use of purged ID in updateComponent

### DIFF
--- a/src/browser/ui/ReactDOMIDOperations.js
+++ b/src/browser/ui/ReactDOMIDOperations.js
@@ -161,9 +161,13 @@ var ReactDOMIDOperations = {
   dangerouslyReplaceNodeWithMarkupByID: ReactPerf.measure(
     'ReactDOMIDOperations',
     'dangerouslyReplaceNodeWithMarkupByID',
-    function(id, markup) {
+    function(id, markupCallback) {
       var node = ReactMount.getNode(id);
-      DOMChildrenOperations.dangerouslyReplaceNodeWithMarkup(node, markup);
+      var markup = markupCallback();
+      DOMChildrenOperations.dangerouslyReplaceNodeWithMarkup(
+        node,
+        markup
+      );
     }
   ),
 

--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -1167,16 +1167,25 @@ var ReactCompositeComponentMixin = {
         // These two IDs are actually the same! But nothing should rely on that.
         var thisID = this._rootNodeID;
         var prevComponentID = prevComponentInstance._rootNodeID;
-        prevComponentInstance.unmountComponent();
-        this._renderedComponent = instantiateReactComponent(nextDescriptor);
-        var nextMarkup = this._renderedComponent.mountComponent(
-          thisID,
-          transaction,
-          this._mountDepth + 1
-        );
+
+        // This callback pattern is a temporary workaround until a refactor is
+        // carried out. The problem it solves is that even though prevComponent
+        // was unmounted (and its ID purged), its ID would later be used for
+        // dangerouslyReplaceNodeWithMarkupByID.
+        var thisComponent = this;
         ReactComponent.BackendIDOperations.dangerouslyReplaceNodeWithMarkupByID(
           prevComponentID,
-          nextMarkup
+          function() {
+            prevComponentInstance.unmountComponent();
+            thisComponent._renderedComponent =
+              instantiateReactComponent(nextDescriptor);
+            var nextMarkup = thisComponent._renderedComponent.mountComponent(
+              thisID,
+              transaction,
+              thisComponent._mountDepth + 1
+            );
+            return nextMarkup;
+          }
         );
       }
     }


### PR DESCRIPTION
Would this be an acceptable temporary workaround for #1569 @sebmarkbage? Seeing as the alternative seems to be quite an extensive refactor, which may not come any time soon.

With this PR and #1568 (which is straightforward) it would be possible to go ahead with my #1570 PR (remove reactid from DOM) when you guys have reviewed it and decided whether you prefer lazy/immediate traversal.
