### PR TITLE
Use .bind when autobinding

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -1265,9 +1265,7 @@ var ReactCompositeComponentMixin = {
    */
   _bindAutoBindMethod: function(method) {
     var component = this;
-    var boundMethod = function() {
-      return method.apply(component, arguments);
-    };
+    var boundMethod = method.bind(component);
     if (__DEV__) {
       boundMethod.__reactBoundContext = component;
       boundMethod.__reactBoundMethod = method;

--- a/src/core/__tests__/ReactCompositeComponentError-test.js
+++ b/src/core/__tests__/ReactCompositeComponentError-test.js
@@ -26,7 +26,7 @@ var ReactErrorUtils = require('ReactErrorUtils');
 describe('ReactCompositeComponent-error', function() {
 
   it('should be passed the component and method name', function() {
-    spyOn(ReactErrorUtils, 'guard');
+    spyOn(ReactErrorUtils, 'guard').andCallThrough();
     var Component = React.createClass({
       someHandler: function() {},
       render: function() {


### PR DESCRIPTION
This eliminates all of the `boundMethod` frames from call stacks when debugging and as far as I know should behave the same otherwise.

Test Plan: jest
