### PR TITLE
use adoptNode to set the correct namespace in case of svg

### DIFF
--- a/src/browser/ui/dom/DOMChildrenOperations.js
+++ b/src/browser/ui/dom/DOMChildrenOperations.js
@@ -46,8 +46,10 @@ function insertChildAt(parentNode, childNode, index) {
   // rely exclusively on `insertBefore(node, null)` instead of also using
   // `appendChild(node)`. However, using `undefined` is not allowed by all
   // browsers so we must replace it with `null`.
+  var newChildNode = parentNode.ownerDocument.adoptNode(childNode, true);
+
   parentNode.insertBefore(
-    childNode,
+    newChildNode,
     parentNode.childNodes[index] || null
   );
 }

--- a/src/browser/ui/dom/Danger.js
+++ b/src/browser/ui/dom/Danger.js
@@ -178,8 +178,11 @@ var Danger = {
       'server rendering. See renderComponentToString().'
     );
 
-    var newChild = createNodesFromMarkup(markup, emptyFunction)[0];
-    oldChild.parentNode.replaceChild(newChild, oldChild);
+    var newChild = createNodesFromMarkup(markup, emptyFunction)[0],
+        parentNode = oldChild.parentNode,
+        adoptedNewChild = parentNode.ownerDocument.adoptNode(newChild, true);
+
+    parentNode.replaceChild(adoptedNewChild, oldChild);
   }
 
 };

--- a/src/browser/ui/dom/setInnerHTML.js
+++ b/src/browser/ui/dom/setInnerHTML.js
@@ -18,7 +18,37 @@
 
 "use strict";
 
-var ExecutionEnvironment = require('ExecutionEnvironment');
+var ExecutionEnvironment = require('ExecutionEnvironment'),
+    domParser = new DOMParser(),
+    svgNodes = {
+      circle: true,
+      defs: true,
+      ellipse: true,
+      g: true,
+      line: true,
+      linearGradient: true,
+      mask: true,
+      path: true,
+      pattern: true,
+      polygon: true,
+      polyline: true,
+      radialGradient: true,
+      rect: true,
+      stop: true,
+      svg: true,
+      text: true,
+      tspan: true
+    };
+
+function setInnerSVG(node, text) {
+    var toParse =  '<svg xmlns="http://www.w3.org/2000/svg">' + text + '</svg>',
+    parsed = domParser.parseFromString(toParse, 'application/xml'),
+    newNode = node.ownerDocument.adoptNode(parsed.documentElement, true);
+
+    //TODO: check that it works everywhere
+    node.innerHTML = '';
+    node.appendChild(newNode);
+}
 
 /**
  * Set the innerHTML property of a node, ensuring that whitespace is preserved
@@ -29,7 +59,11 @@ var ExecutionEnvironment = require('ExecutionEnvironment');
  * @internal
  */
 var setInnerHTML = function(node, html) {
-  node.innerHTML = html;
+  if (svgNodes[node.nodeName]) {
+      setInnerSVG(node, html);
+  } else {
+      node.innerHTML = html;
+  }
 };
 
 if (ExecutionEnvironment.canUseDOM) {

--- a/src/vendor/core/getMarkupWrap.js
+++ b/src/vendor/core/getMarkupWrap.js
@@ -54,7 +54,7 @@ var selectWrap = [1, '<select multiple="true">', '</select>'];
 var tableWrap = [1, '<table>', '</table>'];
 var trWrap = [3, '<table><tbody><tr>', '</tr></tbody></table>'];
 
-var svgWrap = [1, '<svg>', '</svg>'];
+var svgWrap = [1, '<svg xmlns="http://www.w3.org/2000/svg">', '</svg>'];
 
 var markupWrap = {
   '*': [1, '?<div>', '</div>'],


### PR DESCRIPTION
there's an issue rendering svg on browsers that are not chrome.

the issue is tracked here: https://github.com/facebook/react/issues/1900

the problem seems to be that using innerHTML on svg only works on chrome, on other browsers it doesn't set the correct namespace and this makes the svg to be there but not to render.

a set of potential solution were explored here:

http://marianoguerra.github.io/bugs/svgbug/

and the one that seems to work on most browsers and causes the least amount of changes is to use importNode/adoptNode before adding the child content in case it's svg instead of using innerHTML.

a first approach for a fix is here, there's a failing test but it was failing before this change was done.

I will inline comments on the code since there are some further improvements that I think can be done.