### PR TITLE
collapse requires

### DIFF
--- a/grunt/config/browserify.js
+++ b/grunt/config/browserify.js
@@ -64,7 +64,8 @@ var basic = {
   debug: false,
   standalone: 'React',
   transforms: [envify({NODE_ENV: 'development'})],
-  after: [es3ify.transform, simpleBannerify]
+  after: [es3ify.transform, simpleBannerify],
+  collapseRequires: true
 };
 
 var min = _.merge({}, basic, {
@@ -81,7 +82,8 @@ var transformer = {
   outfile: './build/JSXTransformer.js',
   debug: false,
   standalone: 'JSXTransformer',
-  after: [es3ify.transform, simpleBannerify]
+  after: [es3ify.transform, simpleBannerify],
+  collapseRequires: true
 };
 
 var addons = {
@@ -93,7 +95,8 @@ var addons = {
   standalone: 'React',
   transforms: [envify({NODE_ENV: 'development'})],
   packageName: 'React (with addons)',
-  after: [es3ify.transform, simpleBannerify]
+  after: [es3ify.transform, simpleBannerify],
+  collapseRequires: true
 };
 
 var addonsMin = _.merge({}, addons, {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
   "devDependencies": {
     "benchmark": "~1.0.0",
     "browserify": "^4.1.10",
+    "bundle-collapser": "zpao/bundle-collapser#dereq",
+    "concat-stream": "^1.4.6",
     "coverify": "~1.0.4",
     "envify": "^2.0.0",
     "es3ify": "~0.1.2",


### PR DESCRIPTION
This uses my fork of bundle-collapser to catch `_dereq_`. I'm going to try to get that upstreamed.

```
   raw     gz Sizes
397097  79877 build/JSXTransformer.js
525695 125006 build/react-with-addons.js
120910  34456 build/react-with-addons.min.js
480396 114182 build/react.js
112073  32094 build/react.min.js

   raw     gz Compared to last run
-20183  -3806 build/JSXTransformer.js
-125430 -9021 build/react-with-addons.js
-15766  -2982 build/react-with-addons.min.js
-112805 -7773 build/react.js
-14753  -2736 build/react.min.js
```
