### PR TITLE
Adding "Tutorial" label to Flux Todo List nav item

### DIFF
--- a/docs/_data/nav_docs.yml
+++ b/docs/_data/nav_docs.yml
@@ -82,4 +82,4 @@
   - id: flux-overview
     title: Flux Overview
   - id: flux-todo-list
-    title: Flux Tutorial (Todo List)
+    title: Flux TodoMVC Tutorial


### PR DESCRIPTION
When initially going through the React docs, I skipped the **Flux Todo List** page because I thought it was notes for future improvements to Flux, i.e. things to be aware of that will be developed but aren't ready yet (as Flux is new) - in the same spirit as the **JSX Gotchas** page.

I later followed a link on the React blog to the Flux tutorial, and realised it was the page I skipped. So this nav update hopefully makes it a little clearer that the page is actually a really useful tutorial of how to create a Todo List, rather than a Todo List for Flux.
