### PR TITLE
Update 09.2-form-input-binding-sugar.md -> document checkedLink

### DIFF
--- a/docs/docs/09.2-form-input-binding-sugar.md
+++ b/docs/docs/09.2-form-input-binding-sugar.md
@@ -66,9 +66,9 @@ var WithLink = React.createClass({
 
 `ReactLink` objects can be passed up and down the tree as props, so it's easy (and explicit) to set up two-way binding between a component deep in the hierarchy and state that lives higher in the hierarchy.
 
-Note that `<input>` supports ReactLink for both `value` and `checked`. For checkboxes, you should use `checkedLink` instead of `valueLink`, as their value is fixed to `on`: 
+Note that checkboxes have a special behavior regarding their `value` attribute, which is the value that will be sent on form submit if the checkbox is checked (defaults to `on`). The `value` attribute is not updated when the checkbox is checked or unchecked. For checkboxes, you should use `checkedLink` instead of `valueLink`:
 ```
-<input type="checkbox" checkedLink=valueLink={this.linkState('booleanValue')} />
+<input type="checkbox" checkedLink={this.linkState('booleanValue')} />
 ```
 
 


### PR DESCRIPTION
Add better explanation for 2-way data binding to checkboxes using `checkedLink`. As mentionned here: https://github.com/facebook/react/issues/1930
