### PR TITLE
Apply CSS shorthand expansion to IE<9 only

### DIFF
--- a/src/browser/ui/dom/CSSPropertyOperations.js
+++ b/src/browser/ui/dom/CSSPropertyOperations.js
@@ -32,8 +32,15 @@ var processStyleName = memoizeStringOnly(function(styleName) {
   return hyphenateStyleName(styleName);
 });
 
+var hasShorthandPropertyBug = false;
 var styleFloatAccessor = 'cssFloat';
 if (ExecutionEnvironment.canUseDOM) {
+  try {
+    // IE8 throws "Invalid argument." if resetting shorthand style properties.
+    document.createElement('div').style.font = '';
+  } catch (e) {
+    hasShorthandPropertyBug = true;
+  }
   // IE8 only supports accessing cssFloat (standard) as styleFloat
   if (document.documentElement.style.cssFloat === undefined) {
     styleFloatAccessor = 'styleFloat';
@@ -118,7 +125,7 @@ var CSSPropertyOperations = {
       }
       if (styleValue) {
         style[styleName] = styleValue;
-      } else {
+      } else if (hasShorthandPropertyBug) {
         var expansion = CSSProperty.shorthandPropertyExpansions[styleName];
         if (expansion) {
           // Shorthand property that IE8 won't like unsetting, so unset each
@@ -129,6 +136,8 @@ var CSSPropertyOperations = {
         } else {
           style[styleName] = '';
         }
+      } else {
+        style[styleName] = '';
       }
     }
   }


### PR DESCRIPTION
Following up on #1886 and #1901, perhaps this is an edge-case that is unlikely to have a significant real-word impact, but faster is better (and a step towards isolating IE8 fixes). :)

@zpao Feel free to do as you want, but perhaps this is a solution for starting small and going from there.

Unsetting shorthand bug is reproducible on IE when document mode is 8 or less (we don't actually support IE<8, but whatever). According to all information I can find (and common sense), this only applies to IE<8 and no other browser. http://bugs.jquery.com/ticket/12385 https://github.com/jamietre/CsQuery/issues/93

Warning: #2407 need to verify if this PR actually surfaces that problem even more