### PR TITLE
[Addons] Fix TransitionGroup null children bug

### DIFF
--- a/src/addons/transitions/ReactTransitionChildMapping.js
+++ b/src/addons/transitions/ReactTransitionChildMapping.js
@@ -23,16 +23,31 @@ var ReactChildren = require('ReactChildren');
 
 var ReactTransitionChildMapping = {
   /**
-   * Given `this.props.children`, return an object mapping key to child. Just
-   * simple syntactic sugar around ReactChildren.map().
+   * Given `this.props.children`, return an object mapping key to child. `null`
+   * and `undefined` are stripped.
    *
    * @param {*} children `this.props.children`
    * @return {object} Mapping of key to child
    */
   getChildMapping: function(children) {
-    return ReactChildren.map(children, function(child) {
+    var mapping = ReactChildren.map(children, function(child) {
       return child;
     });
+
+    // We remove null children here so that `mergeChildMappings`'s merging can
+    // focus on its job of reasoning about old/new keys rather than checking the
+    // content that those keys carry. For the purpose of TransitionGroup, a null
+    // child is the same as not having a child.
+    for (var key in mapping) {
+      if (!mapping.hasOwnProperty(key)) {
+        continue;
+      }
+      if (mapping[key] == null) {
+        delete mapping[key];
+      }
+    }
+
+    return mapping;
   },
 
   /**

--- a/src/addons/transitions/__tests__/ReactTransitionChildMapping-test.js
+++ b/src/addons/transitions/__tests__/ReactTransitionChildMapping-test.js
@@ -42,6 +42,19 @@ describe('ReactTransitionChildMapping', function() {
     });
   });
 
+  it('should special case getChildMapping with object with null values',
+    function() {
+      var two = <div key="two" />;
+      var component = <div>{null}{two}{null}</div>;
+
+      expect(
+        ReactTransitionChildMapping.getChildMapping(component.props.children)
+      ).toEqual({
+        '.$two': two
+      });
+    }
+  );
+
   it('should support mergeChildMappings for adding keys', function() {
     var prev = {
       one: true,

--- a/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
@@ -209,4 +209,56 @@ describe('ReactTransitionGroup', function() {
       'didMount', 'didMount', 'willEnter', 'didEnter'
     ]);
   });
+
+  it('should trigger willEnter/Leave when the child count did not change',
+    function() {
+      var log = [];
+
+      var Child = React.createClass({
+        componentWillEnter: function(cb) {
+          log.push('willEnter');
+          cb();
+        },
+        componentWillLeave: function(cb) {
+          log.push('willLeave');
+          cb();
+        },
+        render: function() {
+          return <span />;
+        }
+      });
+
+      var Component = React.createClass({
+        render: function() {
+          var group;
+
+          if (this.props.nullChildren) {
+            group = <ReactTransitionGroup>{null}{null}</ReactTransitionGroup>;
+          } else {
+            group =
+              <ReactTransitionGroup>
+                <Child />
+                <Child />
+              </ReactTransitionGroup>;
+          }
+
+          return group;
+        }
+      });
+
+      React.renderComponent(<Component />, container);
+      expect(log.length).toBe(0);
+      React.renderComponent(<Component nullChildren={true} />, container);
+      expect(log).toEqual(['willLeave', 'willLeave']);
+
+      // phantomjs behaves differently than normal chrome. We can't directly
+      // update the component with nullChildren={false} to make the children
+      // reappear for some reason. It does works in normal chrome and ff.
+      var newContainer = document.createElement('div');
+      log = [];
+      React.renderComponent(<Component nullChildren={true} />, newContainer);
+      React.renderComponent(<Component />, newContainer);
+      expect(log).toEqual(['willEnter', 'willEnter']);
+    }
+  );
 });


### PR DESCRIPTION
Fixes #1949

When we render two children to two nulls, `ReactTransitionChildMapping.getChildMapping` now returns `{}` rather than `{'.0': null, '.1': null}`. Otherwise mergeChildMapping doesn't doesn't understand that the children have disappeared.