### PR TITLE
Refactor composite component update flow

### DIFF
--- a/src/browser/ReactTextComponent.js
+++ b/src/browser/ReactTextComponent.js
@@ -18,6 +18,7 @@ var ReactElement = require('ReactElement');
 
 var assign = require('Object.assign');
 var escapeTextForBrowser = require('escapeTextForBrowser');
+var invariant = require('invariant');
 
 /**
  * Text nodes violate a couple assumptions that React makes about components:
@@ -84,12 +85,22 @@ assign(ReactTextComponent.prototype, ReactComponent.Mixin, {
   receiveComponent: function(nextComponent, transaction) {
     var nextProps = nextComponent.props;
     if (nextProps !== this.props) {
+      // TODO: Save this as pending props and use performUpdateIfNecessary
+      // and/or updateComponent to do the actual update for consistency with
+      // other component types?
       this.props = nextProps;
       ReactComponent.BackendIDOperations.updateTextContentByID(
         this._rootNodeID,
         nextProps
       );
     }
+  },
+
+  updateComponent: function() {
+    invariant(
+      false,
+      'ReactTextComponent: updateComponent() should never be called'
+    );
   }
 
 });

--- a/src/browser/ui/ReactDOMComponent.js
+++ b/src/browser/ui/ReactDOMComponent.js
@@ -303,18 +303,20 @@ ReactDOMComponent.Mixin = {
    *
    * @param {ReactReconcileTransaction} transaction
    * @param {ReactElement} prevElement
+   * @param {ReactElement} nextElement
    * @internal
    * @overridable
    */
   updateComponent: ReactPerf.measure(
     'ReactDOMComponent',
     'updateComponent',
-    function(transaction, prevElement) {
+    function(transaction, prevElement, nextElement) {
       assertValidProps(this._currentElement.props);
       ReactComponent.Mixin.updateComponent.call(
         this,
         transaction,
-        prevElement
+        prevElement,
+        nextElement
       );
       this._updateDOMProperties(prevElement.props, transaction);
       this._updateDOMChildren(prevElement.props, transaction);

--- a/src/core/ReactComponent.js
+++ b/src/core/ReactComponent.js
@@ -323,7 +323,7 @@ var ReactComponent = {
       this.props = nextElement.props;
       this._owner = nextElement._owner;
       this._pendingElement = null;
-      this.updateComponent(transaction, prevElement);
+      this.updateComponent(transaction, prevElement, nextElement);
     },
 
     /**
@@ -331,11 +331,10 @@ var ReactComponent = {
      *
      * @param {ReactReconcileTransaction} transaction
      * @param {object} prevElement
+     * @param {object} nextElement
      * @internal
      */
-    updateComponent: function(transaction, prevElement) {
-      var nextElement = this._currentElement;
-
+    updateComponent: function(transaction, prevElement, nextElement) {
       // If either the owner or a `ref` has changed, make sure the newest owner
       // has stored a reference to `this`, and the previous owner (if different)
       // has forgotten the reference to `this`. We use the element instead

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -1483,4 +1483,40 @@ describe('ReactCompositeComponent', function() {
     );
   });
 
+  it('should update refs if shouldComponentUpdate gives false', function() {
+    var Static = React.createClass({
+      shouldComponentUpdate: function() {
+        return false;
+      },
+      render: function() {
+        return <div>{this.props.children}</div>;
+      }
+    });
+    var Component = React.createClass({
+      render: function() {
+        if (this.props.flipped) {
+          return <div>
+            <Static ref="static0" key="B">B (ignored)</Static>
+            <Static ref="static1" key="A">A (ignored)</Static>
+          </div>;
+        } else {
+          return <div>
+            <Static ref="static0" key="A">A</Static>
+            <Static ref="static1" key="B">B</Static>
+          </div>;
+        }
+      }
+    });
+
+    var comp = ReactTestUtils.renderIntoDocument(<Component flipped={false} />);
+    expect(comp.refs.static0.getDOMNode().textContent).toBe('A');
+    expect(comp.refs.static1.getDOMNode().textContent).toBe('B');
+
+    // When flipping the order, the refs should update even though the actual
+    // contents do not
+    comp.setProps({flipped: true});
+    expect(comp.refs.static0.getDOMNode().textContent).toBe('B');
+    expect(comp.refs.static1.getDOMNode().textContent).toBe('A');
+  });
+
 });


### PR DESCRIPTION
Fixes #1392.

Previously, ReactComponent.updateComponent set the new props and owner and updated the component's refs. Because it did the actual props assignment, it had to be called by ReactCompositeComponent between componentWillMount and componentDidMount, meaning that it was skipped if shouldComponentUpdate returned false. Now, updateComponent takes the old and new descriptors and only updates refs, allowing a subclass to call updateComponent at a convenient time (specifically, it can be before `this._descriptor` is updated if the subclass also overrides performUpdateIfNecessary).

The new update cycle for composites is:
- receiveComponent is called which stores `this._pendingDescriptor` and calls performUpdateIfNecessary directly or a state update is enqueued, in which case ReactUpdates will call performUpdateIfNecessary
- performUpdateIfNecessary ensures that an update is still pending (which might no longer be the case if an update is queued for a subcomponent that was updated through a parent's reconciliation) and calls updateComponent with the old and new descriptors
- updateComponent calls super to update refs, then calls componentWillReceiveProps (if applicable) and shouldComponentUpdate -- if shouldComponentUpdate returns false, `this._descriptor`, `this.props`, and `this.state` are updated and the update is skipped; else, _performComponentUpdate is called
- _performComponentUpdate calls componentWillUpdate and _updateRenderedComponent, and enqueues the componentDidUpdate call (in that order)
- _updateRenderedComponent calls render and updates the rendered component appropriately

For DOM components (essentially unchanged):
- receiveComponent is called which does a short-circuit check for descriptor equality and delegates to super (which stores `this._pendingDescriptor` and calls performUpdateIfNecessary)
- performUpdateIfNecessary (not overridden) sets new values for `this.props`, etc. and calls updateComponent
- updateComponent does the DOM property and children updates (some synchronously, some queued for the transaction close)

For text and ART components (unchanged):
- receiveComponent updates the DOM or ART directly based on the new props
- updateComponent is never called

Notable changes:
- When shouldComponentUpdate returns false, refs are still updated
- ReactDefaultPerf now includes lifecycle methods in component timings
- updateComponent's signature changed (technically this is part of the public API, though we've never documented it)

Test Plan: jest
