### PR TITLE
Don't add top-level events for uncontrolled inputs

### DIFF
--- a/src/browser/ui/dom/components/ReactDOMInput.js
+++ b/src/browser/ui/dom/components/ReactDOMInput.js
@@ -84,7 +84,21 @@ var ReactDOMInput = ReactCompositeComponent.createClass({
     var checked = LinkedValueUtils.getChecked(this);
     props.checked = checked != null ? checked : this.state.initialChecked;
 
-    props.onChange = this._handleChange;
+    // Skip attaching top-level event handlers to an uncontrolled input with no
+    // onChange handler -- in the case of radio buttons, we still need the
+    // handler even if this radio button is "uncontrolled" because clicking A in
+    //   <input type="radio" name="x" value="A" />
+    //   <input type="radio" name="x" value="B" checked={true} />
+    // shouldn't uncheck B. (If we had a "weak listen" operation that put the
+    // listener but didn't attach the handlers to the DOM, we could use that
+    // instead for uncontrolled radios.)
+    if (value != null || checked != null ||
+        LinkedValueUtils.getOnChange(this) != null ||
+        this.props.type === "radio") {
+      props.onChange = this._handleChange;
+    } else {
+      props.onChange = null;
+    }
 
     return input(props, this.props.children);
   },

--- a/src/browser/ui/dom/components/ReactDOMTextarea.js
+++ b/src/browser/ui/dom/components/ReactDOMTextarea.js
@@ -111,7 +111,14 @@ var ReactDOMTextarea = ReactCompositeComponent.createClass({
 
     props.defaultValue = null;
     props.value = null;
-    props.onChange = this._handleChange;
+
+    // Avoid binding top-level events if only uncontrolled inputs are used
+    if (LinkedValueUtils.getValue(this) != null ||
+        LinkedValueUtils.getOnChange(this) != null) {
+      props.onChange = this._handleChange;
+    } else {
+      props.onChange = null;
+    }
 
     // Always set children to the same thing. In IE9, the selection range will
     // get reset if `textContent` is mutated.


### PR DESCRIPTION
Fixes #1964.

Test Plan: jest. Also verified that the ballmer-peak example still works and works when changed to use a textarea or select, but that if the input is changed to an uncontrolled component with no onChange, that Chrome doesn't list the event handlers bound in the Elements > Event Listeners panel.