### PR TITLE
add more information to isValidDescriptor invariant error

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -1233,9 +1233,13 @@ var ReactCompositeComponentMixin = {
       }
       invariant(
         ReactDescriptor.isValidDescriptor(renderedComponent),
-        '%s.render(): A valid ReactComponent must be returned. You may have ' +
-          'returned undefined, an array or some other invalid object.',
-        this.constructor.displayName || 'ReactCompositeComponent'
+        '%s.render(): A valid ReactComponent must be returned. You have ' +
+          'returned (%s) `%s`',
+        this.constructor.displayName || 'ReactCompositeComponent',
+        renderedComponent === undefined 
+          ? 'Undefined' 
+          : Object.prototype.toString.call(renderedComponent).slice(8, -1),
+        renderedComponent
       );
       return renderedComponent;
     }

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -184,8 +184,21 @@ describe('ReactCompositeComponent', function() {
       ReactTestUtils.renderIntoDocument(<Component />);
     }).toThrow(
       'Invariant Violation: Component.render(): A valid ReactComponent must ' +
-      'be returned. You may have returned undefined, an array or some other ' +
-      'invalid object.'
+      'be returned. You have returned (Undefined) `undefined`'
+    );
+  });
+
+  it('should still throw when rendering to an array', () => {
+    var Component = React.createClass({
+      render: function() {
+        return [];
+      }
+    });
+    expect(function() {
+      ReactTestUtils.renderIntoDocument(<Component />);
+    }).toThrow(
+      'Invariant Violation: Component.render(): A valid ReactComponent must ' +
+      'be returned. You have returned (Array) ``'
     );
   });
 


### PR DESCRIPTION
Just a minor tweak to tell you what's being returned (I had a problem where an array was being returned earlier today).  


This ternary is completely to work around a [bug in PhantomJS's][1] implementation of Object::toString which gives DOMWindow for some reason when called on `undefined` or `null` and caused the tests to fail.  V8, SM, and JSC all work correctly for all values (per spec).

```js
        renderedComponent === undefined 
          ? 'Undefined' 
          : Object.prototype.toString.call(renderedComponent).slice(8, -1),
```

[1]: https://github.com/ariya/phantomjs/issues/11722