### PR TITLE
jQuery note in tutorial

### DIFF
--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -50,7 +50,9 @@ For this tutorial we'll use prebuilt JavaScript files on a CDN. Open up your fav
 
 For the remainder of this tutorial, we'll be writing our JavaScript code in this script tag.
 
-**Note:** We included jQuery but it's **NOT** mandatory for React to work.
+> Note:
+>
+> We included jQuery here because we want to simplify the code of our future ajax calls, but it's **NOT** mandatory for React to work.
 
 ### Your first component
 


### PR DESCRIPTION
Adding a note just below the jQuery inclusion in the tutorial to inform that jQuery is not mandatory.
It's linked with #603.
