### PR TITLE
typo

### DIFF
--- a/docs/docs/09.4-test-utils.md
+++ b/docs/docs/09.4-test-utils.md
@@ -98,7 +98,7 @@ Traverse all components in `tree` and accumulate all components where `test(comp
 array scryRenderedDOMComponentsWithClass(ReactComponent tree, string className)
 ```
 
-Finds all instance of components in the rendered tree that are DOM components with the class name matching `className`.
+Finds all instances of components in the rendered tree that are DOM components with the class name matching `className`.
 
 ### findRenderedDOMComponentWithClass
 
@@ -114,7 +114,7 @@ Like `scryRenderedDOMComponentsWithClass()` but expects there to be one result, 
 array scryRenderedDOMComponentsWithTag(ReactComponent tree, string tagName)
 ```
 
-Finds all instance of components in the rendered tree that are DOM components with the tag name matching `tagName`.
+Finds all instances of components in the rendered tree that are DOM components with the tag name matching `tagName`.
 
 ### findRenderedDOMComponentWithTag
 


### PR DESCRIPTION
_Previous PR made on wrong branch (facebook/react/#1984)_

"Instance" needed to be pluralized. 

Made the edit in two places (line 101 & 117):

> Finds all _**instance**_ of components

to

> Finds all _**instances**_ of components

![image](https://cloud.githubusercontent.com/assets/2935356/3789840/50cd72d8-1ac8-11e4-9156-d2e21fbfcb42.png)
