### PR TITLE
Cancelling Travis build on commits with docs updates only.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,15 @@ node_js:
 cache:
   directories:
   - node_modules
+before_install:
+- |
+    if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+      TRAVIS_COMMIT_RANGE="FETCH_HEAD...$TRAVIS_BRANCH"
+    fi
+    git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^(docs|examples))/' || {
+      echo "Only docs were updated, stopping build process."
+      exit
+    }
 script:
 - |
     grunt $TEST_TYPE


### PR DESCRIPTION
Currently recognized patterns:
- any Markdown files (*.md)
- any files in docs or examples directories.

Closes facebook/react#1768.
