### PR TITLE
Add a 'note' about passing arrays into the `value` attribute

### DIFF
--- a/docs/docs/06-forms.md
+++ b/docs/docs/06-forms.md
@@ -149,4 +149,4 @@ To make an uncontrolled component, `defaultValue` is used instead.
 
 > Note:
 >
-> You can pass an array into the `value` attribute, allowing you to select multiple options in a `select` tag: `<select multiple={true} value="{['B', 'C']}">`.
+> You can pass an array into the `value` attribute, allowing you to select multiple options in a `select` tag: `<select multiple={true} value={['B', 'C']}>`.


### PR DESCRIPTION
This is for #1700
