### PR TITLE
Update ref-01-top-level-api.md

### DIFF
--- a/docs/docs/ref-01-top-level-api.md
+++ b/docs/docs/ref-01-top-level-api.md
@@ -76,19 +76,19 @@ Similar to `renderComponentToString`, except this doesn't create extra DOM attri
 ### React.isValidClass
 
 ```javascript
-boolean isValidClass(ReactClassDescriptor factory)
+boolean isValidClass(* factory)
 ```
 
-Verifies the factory is a React class. See `React.createClass`.
+Verifies the factory is a React class descriptor. See `React.createClass`.
 
 
 ### React.isValidComponent
 
 ```javascript
-boolean isValidComponent(ReactComponent object)
+boolean isValidComponent(* object)
 ```
 
-Verifies the object is a React component.
+Verifies the object is a React component descriptor.
 
 
 ### React.DOM


### PR DESCRIPTION
Added docs for `React.isValidClass` and `React.isValidComponent`. 

Still missing top level api:
- `constructAndRenderComponent`
- `constructAndRenderComponentById`
- `withContext`
