### PR TITLE
Clarify section introducing callbacks

### DIFF
--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -519,7 +519,7 @@ We use the `ref` attribute to assign a name to a child component and `this.refs`
 
 When a user submits a comment, we will need to refresh the list of comments to include the new one. It makes sense to do all of this logic in `CommentBox` since `CommentBox` owns the state that represents the list of comments.
 
-We need to pass data from the child component to its parent. We do this by passing a `callback` in props from parent to child:
+We need to pass data from the child component back up to its parent. We do this in our parent's `render` method by passing a new callback (`handleCommentSubmit`) into the child, binding it to the child's `onCommentSubmit` event. Whenever the event is triggered, the callback will be invoked:
 
 ```javascript{15-17,30}
 // tutorial17.js


### PR DESCRIPTION
`callback` being in code blocks caused me to trip up, I was looking for it within the code. I think it's a bit clearer if the actual callback and event names are in code blocks.
