### PR TITLE
Throw an error when functions on `statics` clash due to duplicate keys

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -555,6 +555,16 @@ function mixStaticSpecIntoComponent(Constructor, statics) {
       continue;
     }
 
+    var isReserved = name in RESERVED_SPEC_KEYS;
+    invariant(
+      !isReserved,
+      'ReactCompositeComponent: You are attempting to define a reserved ' +
+      'property, `%s`, that shouldn\'t be on the "statics" key. Define it ' +
+      'as an instance property instead; it will still be accessible on the ' +
+      'constructor.',
+      name
+    );
+
     var isInherited = name in Constructor;
     invariant(
       !isInherited,

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -1272,6 +1272,29 @@ describe('ReactCompositeComponent', function() {
     expect(Component.pqr()).toBe(Component.type);
   });
 
+  it('should throw if a reserved property is in statics', function() {
+    expect(function() {
+      React.createClass({
+        statics: {
+          getDefaultProps: function() {
+            return {
+              foo: 0
+            };
+          }
+        },
+
+        render: function() {
+          return <span />;
+        }
+      });
+    }).toThrow(
+      'Invariant Violation: ReactCompositeComponent: You are attempting to ' +
+      'define a reserved property, `getDefaultProps`, that shouldn\'t be on ' +
+      'the "statics" key. Define it as an instance property instead; it ' +
+      'will still be accessible on the constructor.'
+    );
+  });
+
   it('should support statics in mixins', function() {
     var Mixin = {
       statics: {


### PR DESCRIPTION
Fixes #1947.

I agree with @spicyj and find this behavior confusing, so I thought I'd send in a pull request. (This is my first PR for React--did my best to follow the contributing guidelines!)
