### PR TITLE
More informative error message for mergeObjectsWithNoDuplicateKeys

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -592,12 +592,10 @@ function mergeObjectsWithNoDuplicateKeys(one, two) {
     invariant(
       one[key] === undefined,
       'mergeObjectsWithNoDuplicateKeys(): ' +
-      'Tried to merge two objects with the same key: `%s`. ' +
-      'This conflict may be due to a mixin; in particular, you may be using ' +
-      'a mixin with its own getDefaultProps() or getInitialState(). This ' +
-      'could result in both the mixin and base component (or another mixin) ' +
-      'returning an object (either from getDefaultProps() or ' +
-      'getInitialState()) with the same key.',
+      'Tried to merge two objects with the same key: `%s`. This conflict ' +
+      'may be due to a mixin; in particular, this may be caused by two ' +
+      'getInitialState() or getDefaultProps() methods returning objects ' +
+      'with clashing keys.',
       key
     );
     one[key] = value;

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -688,12 +688,10 @@ describe('ReactCompositeComponent', function() {
       instance = ReactTestUtils.renderIntoDocument(instance);
     }).toThrow(
       'Invariant Violation: mergeObjectsWithNoDuplicateKeys(): ' +
-      'Tried to merge two objects with the same key: `x`. ' +
-      'This conflict may be due to a mixin; in particular, you may be using ' +
-      'a mixin with its own getDefaultProps() or getInitialState(). This ' +
-      'could result in both the mixin and base component (or another mixin) ' +
-      'returning an object (either from getDefaultProps() or ' +
-      'getInitialState()) with the same key.'
+      'Tried to merge two objects with the same key: `x`. This conflict ' +
+      'may be due to a mixin; in particular, this may be caused by two ' +
+      'getInitialState() or getDefaultProps() methods returning objects ' +
+      'with clashing keys.'
     );
   });
 


### PR DESCRIPTION
Fixes #1957. Maybe the message is too long? I wanted to add sufficient detail but am happy to amend.
