### PR TITLE
TestUtils docs: isComponentOfType -> isDescriptorOfType

### DIFF
--- a/docs/docs/09.4-test-utils.md
+++ b/docs/docs/09.4-test-utils.md
@@ -43,13 +43,13 @@ object mockComponent(function componentClass, string? tagName)
 
 Pass a mocked component module to this method to augment it with useful methods that allow it to be used as a dummy React component. Instead of rendering as usual, the component will become a simple `<div>` (or other tag if `mockTagName` is provided) containing any provided children.
 
-### isComponentOfType
+### isDescriptorOfType
 
 ```javascript
-boolean isComponentOfType(ReactComponent instance, function componentClass)
+boolean isDescriptorOfType(ReactDescriptor descriptor, function componentClass)
 ```
 
-Returns true if `instance` is an instance of a React `componentClass`.
+Returns true if `descriptor` is an instance of a React `componentClass`.
 
 ### isDOMComponent
 


### PR DESCRIPTION
Fixes #1946

There are other things that should be updated here too, but those are just confusing uses of descriptor vs instance vs component in type information. This should all get autogenned at some point...
