### PR TITLE
Update recast to 0.6, update constants.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "phantomjs": "~1.9",
     "platform": "^1.1.0",
     "populist": "~0.1.6",
-    "recast": "~0.5.6",
+    "recast": "^0.6.10",
     "sauce-tunnel": "~1.1.0",
     "semver": "^2.3.0",
     "tmp": "~0.0.18",

--- a/vendor/constants.js
+++ b/vendor/constants.js
@@ -17,9 +17,7 @@
 
 var recast = require('recast');
 var types = recast.types;
-var namedTypes = types.namedTypes;
 var builders = types.builders;
-var hasOwn = Object.prototype.hasOwnProperty;
 
 function propagate(constants, source) {
   return recast.print(transform(recast.parse(source), constants)).code;
@@ -39,69 +37,60 @@ var DEV_EXPRESSION = builders.binaryExpression(
   )
 );
 
-function transform(ast, constants) {
-  constants = constants || {};
-
-  return types.traverse(ast, function(node, traverse) {
-    if (namedTypes.Identifier.check(node)) {
-      // If the identifier is the property of a member expression
-      // (e.g. object.property), then it definitely is not a constant
-      // expression that we want to replace.
-      if (namedTypes.MemberExpression.check(this.parent.node) &&
-          this.name === 'property' &&
-          !this.parent.node.computed) {
-        return false;
-      }
-
-      // There could in principle be a constant called "hasOwnProperty",
-      // so be careful always to use Object.prototype.hasOwnProperty.
-      if (node.name === '__DEV__') {
-        // replace __DEV__ with process.env.NODE_ENV !== 'production'
-        this.replace(DEV_EXPRESSION);
-        return false;
-      } else if (hasOwn.call(constants, node.name)) {
-        this.replace(builders.literal(constants[node.name]));
-        return false;
-      }
-
-    } else if (namedTypes.CallExpression.check(node)) {
-      if (namedTypes.Identifier.check(node.callee) &&
-          node.callee.name === 'invariant') {
-        // Truncate the arguments of invariant(condition, ...)
-        // statements to just the condition based on NODE_ENV
-        // (dead code removal will remove the extra bytes).
-        this.replace(
-          builders.conditionalExpression(
-            DEV_EXPRESSION,
-            node,
-            builders.callExpression(
-              node.callee,
-              [node.arguments[0]]
-            )
-          )
-        );
-        return false;
-      } else if (namedTypes.Identifier.check(node.callee) &&
-          node.callee.name === 'warning') {
-        // Eliminate warning(condition, ...) statements based on NODE_ENV
-        // (dead code removal will remove the extra bytes).
-        this.replace(
-          builders.conditionalExpression(
-            DEV_EXPRESSION,
-            node,
-            builders.literal(null)
-          )
-        );
-      }
+var visitors = {
+  visitIdentifier: function(nodePath) {
+    // If the identifier is the property of a member expression
+    // (e.g. object.property), then it definitely is not a constant
+    // expression that we want to replace.
+    if (nodePath.parentPath.value.type === 'MemberExpression') {
+      return false;
     }
-  });
+
+    // replace __DEV__ with process.env.NODE_ENV !== 'production'
+    if (nodePath.value.name === '__DEV__') {
+      nodePath.replace(DEV_EXPRESSION);
+    }
+    // TODO: bring back constant replacement if we decide we need it
+
+    this.traverse(nodePath);
+  },
+
+  visitCallExpression: function(nodePath) {
+    var node = nodePath.value;
+    if (node.callee.name === 'invariant') {
+      // Truncate the arguments of invariant(condition, ...)
+      // statements to just the condition based on NODE_ENV
+      // (dead code removal will remove the extra bytes).
+      nodePath.replace(
+        builders.conditionalExpression(
+          DEV_EXPRESSION,
+          node,
+          builders.callExpression(
+            node.callee,
+            [node.arguments[0]]
+          )
+        )
+      );
+      return false;
+    } else if (node.callee.name === 'warning') {
+      // Eliminate warning(condition, ...) statements based on NODE_ENV
+      // (dead code removal will remove the extra bytes).
+      nodePath.replace(
+        builders.conditionalExpression(
+          DEV_EXPRESSION,
+          node,
+          builders.literal(null)
+        )
+      );
+      return false;
+    }
+    this.traverse(nodePath);
+  }
 }
 
-if (!module.parent) {
-  var constants = JSON.parse(process.argv[3]);
-  recast.run(function(ast, callback) {
-    callback(transform(ast, constants));
-  });
+function transform(ast, constants) {
+  // TODO constants
+  return recast.visit(ast, visitors);
 }
 
 exports.propagate = propagate;


### PR DESCRIPTION
I dropped the part of constants.js that we weren't using (namely the
part where we insert constants) but left it open to do that. It should
be trivial, we just aren't using it.

Fixes #1824
