### PR TITLE
[RFC] Per React container event listening/dispatching

### DIFF
--- a/src/browser/ui/ReactDOMComponent.js
+++ b/src/browser/ui/ReactDOMComponent.js
@@ -35,16 +35,12 @@ var keyOf = require('keyOf');
 var merge = require('merge');
 var mixInto = require('mixInto');
 
-var deleteListener = ReactBrowserEventEmitter.deleteListener;
-var listenTo = ReactBrowserEventEmitter.listenTo;
 var registrationNameModules = ReactBrowserEventEmitter.registrationNameModules;
 
 // For quickly matching children type, to test if can be treated as content.
 var CONTENT_TYPES = {'string': true, 'number': true};
 
 var STYLE = keyOf({style: null});
-
-var ELEMENT_NODE_TYPE = 1;
 
 /**
  * @param {?object} props
@@ -68,10 +64,7 @@ function assertValidProps(props) {
 function putListener(id, registrationName, listener, transaction) {
   var container = ReactMount.findReactContainerForID(id);
   if (container) {
-    var doc = container.nodeType === ELEMENT_NODE_TYPE ?
-      container.ownerDocument :
-      container;
-    listenTo(registrationName, doc);
+    ReactBrowserEventEmitter.listenTo(registrationName, container);
   }
   transaction.getPutListenerQueue().enqueuePutListener(
     id,
@@ -283,7 +276,7 @@ ReactDOMComponent.Mixin = {
           }
         }
       } else if (registrationNameModules.hasOwnProperty(propKey)) {
-        deleteListener(this._rootNodeID, propKey);
+        ReactBrowserEventEmitter.deleteListener(this._rootNodeID, propKey);
       } else if (
           DOMProperty.isStandardName[propKey] ||
           DOMProperty.isCustomAttribute(propKey)) {

--- a/src/browser/ui/ReactMount.js
+++ b/src/browser/ui/ReactMount.js
@@ -461,6 +461,8 @@ var ReactMount = {
     if (!component) {
       return false;
     }
+
+    ReactBrowserEventEmitter.removeListenedEvents(container);
     ReactMount.unmountComponentFromNode(component, container);
     delete instancesByReactRootID[reactRootID];
     delete containersByReactRootID[reactRootID];

--- a/src/vendor/stubs/EventListener.js
+++ b/src/vendor/stubs/EventListener.js
@@ -3,6 +3,8 @@
  * @typechecks
  */
 
+'use strict';
+
 var emptyFunction = require('emptyFunction');
 
 /**


### PR DESCRIPTION
Work in progress. `enterleave` plugin (and maybe `analyticsPlugin`) is broken because it relied on the old behavior. But wanted to put this out here for suggestions. There are also some comments that need to be changed, I'll do it when the code is finalized.

If we attach the event listening/dispatching at container level, it'll benefit the case of `<Editor/><Plugin1/>` (both are container roots), since `Plugin1` won't disturb `Editor`.

We also detach those listeners now. There wasn't really a need in the past.

@spicyj @zpao @nathansobo

Fixes #2043
Should help with #1964