### PR TITLE
Better error message if `onChange` is undefined

### DIFF
--- a/src/browser/ui/dom/components/LinkedValueUtils.js
+++ b/src/browser/ui/dom/components/LinkedValueUtils.js
@@ -90,12 +90,20 @@ var LinkedValueUtils = {
             props.disabled) {
           return;
         }
-        return new Error(
-          'You provided a `value` prop to a form field without an ' +
-          '`onChange` handler. This will render a read-only field. If ' +
-          'the field should be mutable use `defaultValue`. Otherwise, ' +
-          'set either `onChange` or `readOnly`.'
-        );
+
+        if ('onChange' in props) {
+          return new Error(
+            'You provided a non function value for a `onChange` handler. (' +
+            'check the spelling of the function name you used).'
+          );
+        } else {
+          return new Error(
+            'You provided a `value` prop to a form field without an ' +
+            '`onChange` handler. This will render a read-only field. If ' +
+            'the field should be mutable use `defaultValue`. Otherwise, ' +
+            'set either `onChange` or `readOnly`.'
+          );
+        }
       },
       checked: function(props, propName, componentName) {
         if (!props[propName] ||
@@ -104,12 +112,20 @@ var LinkedValueUtils = {
             props.disabled) {
           return;
         }
-        return new Error(
-          'You provided a `checked` prop to a form field without an ' +
-          '`onChange` handler. This will render a read-only field. If ' +
-          'the field should be mutable use `defaultChecked`. Otherwise, ' +
-          'set either `onChange` or `readOnly`.'
-        );
+
+        if ('onChange' in props) {
+          return new Error(
+            'You provided a non function value for a `onChange` handler. (' +
+            'check the spelling of the function name you used).'
+          );
+        } else {
+          return new Error(
+            'You provided a `checked` prop to a form field without an ' +
+            '`onChange` handler. This will render a read-only field. If ' +
+            'the field should be mutable use `defaultChecked`. Otherwise, ' +
+            'set either `onChange` or `readOnly`.'
+          );
+        }
       },
       onChange: ReactPropTypes.func
     }

--- a/src/browser/ui/dom/components/__tests__/ReactDOMInput-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMInput-test.js
@@ -250,6 +250,12 @@ describe('ReactDOMInput', function() {
         node
       );
       expect(console.warn.mock.calls.length).toBe(2);
+
+      React.renderComponent(
+        <input type="text" value="zoink" onChange={undefined} />,
+        node
+      );
+      expect(console.warn.mock.calls.length).toBe(3);
     } finally {
       console.warn = oldWarn;
     }
@@ -333,6 +339,12 @@ describe('ReactDOMInput', function() {
         node
       );
       expect(console.warn.mock.calls.length).toBe(2);
+
+      React.renderComponent(
+        <input type="checkbox" checked="false" onChange={undefined} />,
+        node
+      );
+      expect(console.warn.mock.calls.length).toBe(3);
     } finally {
       console.warn = oldWarn;
     }


### PR DESCRIPTION
Today I spent half an hour wondering why my component didn't work. React kept telling me I don't have a `onChange` handler defined on my controlled input. I did, I just spelled it wrong :)

So I thought this might save somebody some time in the future. Let me know what you think.