### PR TITLE
Don't force sourcemaps on for JSXTransformer APIs

### DIFF
--- a/vendor/browser-transforms.js
+++ b/vendor/browser-transforms.js
@@ -42,15 +42,16 @@ var supportsAccessors = Object.prototype.hasOwnProperty('__defineGetter__');
  */
 function transformReact(source, options) {
   // TODO: just use react-tools
+  options = options || {};
   var visitorList;
-  if (options && options.harmony) {
+  if (options.harmony) {
     visitorList = visitors.getAllVisitors();
   } else {
     visitorList = visitors.transformVisitors.react;
   }
 
   return transform(visitorList, source, {
-    sourceMap: supportsAccessors
+    sourceMap: supportsAccessors && options.sourceMap
   });
 }
 
@@ -250,11 +251,11 @@ function loadScripts(scripts) {
   }
 
   scripts.forEach(function(script, i) {
-    var options;
+    var options = {
+      sourceMap: true
+    };
     if (/;harmony=true(;|$)/.test(script.type)) {
-      options = {
-        harmony: true
-      };
+      options.harmony = true
     }
 
     // script.async is always true for non-javascript script tags


### PR DESCRIPTION
In case somebody doesn't want sourcemaps (eg, react-rails) or r.js

Should fix #972. cc @philix @thomasboyt - Looks like you can stop shipping a modified JSXTransformer (or whatever we end up calling this by the time 0.12 happens - cf #1966)
