### PR TITLE
docs(flux-todo-list): fix TodoStore syntax

### DIFF
--- a/docs/docs/flux-todo-list.md
+++ b/docs/docs/flux-todo-list.md
@@ -196,7 +196,7 @@ var TodoStore = merge(EventEmitter.prototype, {
    */
   removeChangeListener: function(callback) {
     this.removeListener(CHANGE_EVENT, callback);
-  }
+  },
 
   dispatcherIndex: AppDispatcher.register(function(payload) {
     var action = payload.action;


### PR DESCRIPTION
Add missing semicolon behind `TodoStore#addChangeListener'
