### PR TITLE
Warn when passing invalid containers to render and unmountComponentAtNode

### DIFF
--- a/src/browser/ui/ReactMount.js
+++ b/src/browser/ui/ReactMount.js
@@ -370,8 +370,8 @@ var ReactMount = {
     var reactRootElement = getReactRootElementInContainer(container);
     var containerHasReactMarkup =
       reactRootElement && ReactMount.isRenderedByReact(reactRootElement);
-    var containerHasNonRootReactChild = ReactMount.hasNonRootReactChild(
-      container);
+    var containerHasNonRootReactChild =
+      ReactMount.hasNonRootReactChild(container);
 
     if (__DEV__) {
       warning(
@@ -381,7 +381,9 @@ var ReactMount = {
       );
     }
 
-    var shouldReuseMarkup = containerHasReactMarkup && !prevComponent &&
+    var shouldReuseMarkup =
+      containerHasReactMarkup &&
+      !prevComponent &&
       !containerHasNonRootReactChild;
 
     var component = ReactMount._renderNewRootComponent(

--- a/src/browser/ui/ReactMount.js
+++ b/src/browser/ui/ReactMount.js
@@ -370,8 +370,19 @@ var ReactMount = {
     var reactRootElement = getReactRootElementInContainer(container);
     var containerHasReactMarkup =
       reactRootElement && ReactMount.isRenderedByReact(reactRootElement);
+    var containerHasNonRootReactChild = ReactMount.hasNonRootReactChild(
+      container);
 
-    var shouldReuseMarkup = containerHasReactMarkup && !prevComponent;
+    if (__DEV__) {
+      warning(
+        !containerHasNonRootReactChild,
+        'renderComponent(...): Replacing React-rendered children with a new ' +
+        'root component.'
+      );
+    }
+
+    var shouldReuseMarkup = containerHasReactMarkup && !prevComponent &&
+      !containerHasNonRootReactChild;
 
     var component = ReactMount._renderNewRootComponent(
       nextDescriptor,
@@ -459,6 +470,28 @@ var ReactMount = {
     var reactRootID = getReactRootID(container);
     var component = instancesByReactRootID[reactRootID];
     if (!component) {
+      // Check if the node being unmounted was rendered by React, but isn't a
+      // root node.
+      var containerHasNonRootReactChild = ReactMount.hasNonRootReactChild(
+        container);
+
+      // Check if the container itself is a React root node.
+      var containerID = ReactMount.getID(container);
+      var containerRootID = ReactInstanceHandles.getReactRootIDFromNodeID(
+        containerID);
+      var isContainerReactRoot =
+        containerID && containerRootID && containerID === containerRootID;
+
+      if (__DEV__) {
+        warning(
+          !containerHasNonRootReactChild,
+          'unmountComponentAtNode(): The node you\'re attempting to unmount ' +
+          'is not a valid React root node, and thus cannot be unmounted.%s',
+          (isContainerReactRoot ? ' You may have passed in a React root ' +
+            'node as argument, rather than its container.' : '')
+        );
+      }
+
       return false;
     }
     ReactMount.unmountComponentFromNode(component, container);
@@ -558,6 +591,22 @@ var ReactMount = {
     }
     var id = ReactMount.getID(node);
     return id ? id.charAt(0) === SEPARATOR : false;
+  },
+
+  /**
+   * True if the supplied DOM node has a direct React-rendered child that is
+   * not a React root element. Useful for warning in renderComponent`,
+   * `unmountComponentAtNode`, etc.
+   *
+   * @param {?DOMElement} node The candidate DOM node.
+   * @return {boolean} True if the DOM element contains a direct child that was
+   * rendered by React but is not a root element.
+   * @internal
+   */
+  hasNonRootReactChild: function(node) {
+    var reactRootID = getReactRootID(node);
+    return reactRootID ? reactRootID !==
+      ReactInstanceHandles.getReactRootIDFromNodeID(reactRootID) : false;
   },
 
   /**

--- a/src/browser/ui/__tests__/ReactMount-test.js
+++ b/src/browser/ui/__tests__/ReactMount-test.js
@@ -114,4 +114,26 @@ describe('ReactMount', function() {
 
     expect(instance1 === instance2).toBe(true);
   });
+
+  it('should warn if render removes React-rendered children', function() {
+    var container = document.createElement('container');
+    var Component = React.createClass({
+      render: function() {
+        return <div>
+          <div />
+        </div>;
+      }
+    });
+    React.renderComponent(<Component />, container);
+
+    // Test that blasting away children throws a warning
+    spyOn(console, 'warn');
+    var rootNode = container.firstChild;
+    React.renderComponent(<span />, rootNode);
+    expect(console.warn.callCount).toBe(1);
+    expect(console.warn.mostRecentCall.args[0]).toBe(
+      'Warning: renderComponent(...): Replacing React-rendered children ' +
+      'with a new root component.'
+    );
+  });
 });

--- a/src/browser/ui/__tests__/ReactMount-test.js
+++ b/src/browser/ui/__tests__/ReactMount-test.js
@@ -119,9 +119,7 @@ describe('ReactMount', function() {
     var container = document.createElement('container');
     var Component = React.createClass({
       render: function() {
-        return <div>
-          <div />
-        </div>;
+        return <div><div /></div>;
       }
     });
     React.renderComponent(<Component />, container);

--- a/src/browser/ui/__tests__/ReactMountDestruction-test.js
+++ b/src/browser/ui/__tests__/ReactMountDestruction-test.js
@@ -56,11 +56,10 @@ describe('ReactMount', function() {
   it("should warn when unmounting a non-container root node", function() {
     var mainContainerDiv = document.createElement('div');
 
-    var component = (
+    var component =
       <div>
         <div />
-      </div>
-    );
+      </div>;
     React.renderComponent(component, mainContainerDiv);
 
     // Test that unmounting at a root node gives a helpful warning
@@ -79,13 +78,12 @@ describe('ReactMount', function() {
   it("should warn when unmounting a non-container, non-root node", function() {
     var mainContainerDiv = document.createElement('div');
 
-    var component = (
+    var component =
       <div>
         <div>
           <div />
         </div>
-      </div>
-    );
+      </div>;
     React.renderComponent(component, mainContainerDiv);
 
     // Test that unmounting at a non-root node gives a different warning

--- a/src/browser/ui/__tests__/ReactMountDestruction-test.js
+++ b/src/browser/ui/__tests__/ReactMountDestruction-test.js
@@ -52,4 +52,51 @@ describe('ReactMount', function() {
     React.unmountComponentAtNode(secondRootDiv);
     expect(secondRootDiv.firstChild).toBeNull();
   });
+
+  it("should warn when unmounting a non-container root node", function() {
+    var mainContainerDiv = document.createElement('div');
+
+    var component = (
+      <div>
+        <div />
+      </div>
+    );
+    React.renderComponent(component, mainContainerDiv);
+
+    // Test that unmounting at a root node gives a helpful warning
+    var rootDiv = mainContainerDiv.firstChild;
+    spyOn(console, 'warn');
+    React.unmountComponentAtNode(rootDiv);
+    expect(console.warn.callCount).toBe(1);
+    expect(console.warn.mostRecentCall.args[0]).toBe(
+      'Warning: unmountComponentAtNode(): The node you\'re attempting to ' +
+      'unmount is not a valid React root node, and thus cannot be ' +
+      'unmounted. You may have passed in a React root node as argument, ' +
+      'rather than its container.'
+    );
+  });
+
+  it("should warn when unmounting a non-container, non-root node", function() {
+    var mainContainerDiv = document.createElement('div');
+
+    var component = (
+      <div>
+        <div>
+          <div />
+        </div>
+      </div>
+    );
+    React.renderComponent(component, mainContainerDiv);
+
+    // Test that unmounting at a non-root node gives a different warning
+    var nonRootDiv = mainContainerDiv.firstChild.firstChild;
+    spyOn(console, 'warn');
+    React.unmountComponentAtNode(nonRootDiv);
+    expect(console.warn.callCount).toBe(1);
+    expect(console.warn.mostRecentCall.args[0]).toBe(
+      'Warning: unmountComponentAtNode(): The node you\'re attempting to ' +
+      'unmount is not a valid React root node, and thus cannot be ' +
+      'unmounted.'
+    );
+  });
 });

--- a/src/browser/ui/__tests__/ReactMountDestruction-test.js
+++ b/src/browser/ui/__tests__/ReactMountDestruction-test.js
@@ -26,18 +26,12 @@ describe('ReactMount', function() {
     var mainContainerDiv = document.createElement('div');
     document.documentElement.appendChild(mainContainerDiv);
 
-    var instanceOne = (
-      <div className="firstReactDiv">
-      </div>
-    );
+    var instanceOne = <div className="firstReactDiv" />;
     var firstRootDiv = document.createElement('div');
     mainContainerDiv.appendChild(firstRootDiv);
     React.renderComponent(instanceOne, firstRootDiv);
 
-    var instanceTwo = (
-      <div className="secondReactDiv">
-      </div>
-    );
+    var instanceTwo = <div className="secondReactDiv" />;
     var secondRootDiv = document.createElement('div');
     mainContainerDiv.appendChild(secondRootDiv);
     React.renderComponent(instanceTwo, secondRootDiv);


### PR DESCRIPTION
Resolves #1858 and #2045.

The `hasNonRootReactChild` method checks if the container has a React-rendered child (i.e., is non-empty) with a non-root ID, which is used as the criteria for warning in both `renderComponent` and `unmountComponentAtNode`. Note that there's also a specific warning for when you pass in a root node, rather than a container.

For example, if your markup is:

```html
<div id="root" data-reactid=".0">
  <div id="non-root" data-reactid=".0.0">
    <div data-reactid=".0.0.0"></div>
  </div>
</div>
```

Then you see the following warnings (prepended with method name, `warning`, etc.):

```js
var nonRoot = document.getElementById('non-root');
React.unmountComponentAtNode(nonRoot);
>>> "The node you're attempting to unmount is not a valid React root node, and thus cannot be unmounted."
```

Or:

```js
var root = document.getElementById('root');
React.unmountComponentAtNode(root);
>>> "The node you're attempting to unmount... You may have passed in a React root node as argument, rather than its container."
```

Or:
```js
var root = document.getElementById('root');
React.renderComponent(<div />, root);
>>> "Replacing React-rendered children with a new root component."
```

The naming here got a little verbose, so I'm open to suggestions. I think the specific warning for passing in a root node as a container is also worth discussing, but I left it in for now as it's easy to remove.