### PR TITLE
[docs] Update Flux TodoMVC Tutorial

### DIFF
--- a/docs/docs/flux-todo-list.md
+++ b/docs/docs/flux-todo-list.md
@@ -142,8 +142,6 @@ class Dispatcher {
 }
 ```
 
-We use register() to register a store's callback with the dispatcher, and dispatch() to invoke all of callbacks we previously registered.  A data payload (the action) is the sole argument provided to the callback.
-
 Now we are all set to create a dispatcher that is more specific to our app, which we'll call AppDispatcher.
 
 ```javascript


### PR DESCRIPTION
I was reminded by @whatasunnyday in the Flux repo's [issue #37](https://github.com/facebook/flux/issues/37) that the Flux TodoMVC tutorial needs to be updated to reflect the latest dispatcher we have released.  The tutorial had previously used a dispatcher based on promises, and this was confusing for newcomers.
