### PR TITLE
Allow `results` and `autosave` attributes (WebKit/Blink)

### DIFF
--- a/docs/docs/ref-04-tags-and-attributes.md
+++ b/docs/docs/ref-04-tags-and-attributes.md
@@ -72,6 +72,7 @@ In addition, the following non-standard attributes are supported:
 - `property` for [Open Graph](http://ogp.me/) meta tags.
 - `itemProp itemScope itemType itemRef itemID` for [HTML5 microdata](http://schema.org/docs/gs.html).
 - `unselectable` for Internet Explorer.
+- `results autoSave` for WebKit/Blink input fields of type `search`.
 
 There is also the React-specific attribute `dangerouslySetInnerHTML` ([more here](/react/docs/special-non-dom-attributes.html)), used for directly inserting HTML strings into a component.
 

--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -174,6 +174,8 @@ var HTMLDOMPropertyConfig = {
     // keyboard hints.
     autoCapitalize: null,
     autoCorrect: null,
+    // autoSave allows WebKit/Blink to persist values of input fields on page reloads
+    autoSave: null,
     // itemProp, itemScope, itemType are for
     // Microdata support. See http://schema.org/docs/gs.html
     itemProp: MUST_USE_ATTRIBUTE,
@@ -186,6 +188,9 @@ var HTMLDOMPropertyConfig = {
     itemRef: MUST_USE_ATTRIBUTE,
     // property is supported for OpenGraph in meta tags.
     property: null,
+    // results show looking glass icon and recent searches on input
+    // search fields in WebKit/Blink
+    results: null,
     // IE-only attribute that specifies security restrictions on an iframe
     // as an alternative to the sandbox attribute on IE<10
     security: MUST_USE_ATTRIBUTE,
@@ -204,6 +209,7 @@ var HTMLDOMPropertyConfig = {
     autoCorrect: 'autocorrect',
     autoFocus: 'autofocus',
     autoPlay: 'autoplay',
+    autoSave: 'autosave',
     // `encoding` is equivalent to `enctype`, IE8 lacks an `enctype` setter.
     // http://www.w3.org/TR/html5/forms.html#dom-fs-encoding
     encType: 'encoding',


### PR DESCRIPTION
WebKit/Blink supports the non-standard attributes `results` and `autosave` for input-elements of type `search`.

They allow the input element to be rendered as a search input (looking glass is added), allows the ability to show a list of recent searches, and also makes it possible to autosave the value of the field - [more info here](http://www.wufoo.com/html5/types/5-search.html).

React currently do not pass these attributes on, and I have not found a way of adding the attributes except in the `componentDidMount`-method. I'd prefer to have some way of adding these attributes inside of the react world, so the server and client can generate them.

I realize that adding all sorts of non-standard attributes might eventually pile up - perhaps there is a better way of adding these attributes? `<input nonStandardAttributes={{ results: 5, autoCapitalize: false }}>` or similar?
