### PR TITLE
Added PropType validator for componentClass to ensure the prop satisfies React.isValidClass

### DIFF
--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -32,6 +32,9 @@ React.createClass({
     // A React component.
     optionalComponent: React.PropTypes.component,
 
+    // A React component class
+    optionalComponentClass: React.PropTypes.componentClass,
+
     // You can also declare that a prop is an instance of a class. This uses
     // JS's instanceof operator.
     optionalMessage: React.PropTypes.instanceOf(Message),

--- a/src/core/ReactPropTypes.js
+++ b/src/core/ReactPropTypes.js
@@ -83,6 +83,7 @@ var ReactPropTypes = {
   any: createAnyTypeChecker(),
   arrayOf: createArrayOfTypeChecker,
   component: createComponentTypeChecker(),
+  componentClass: createComponentClassChecker(),
   instanceOf: createInstanceTypeChecker,
   objectOf: createObjectOfTypeChecker,
   oneOf: createEnumTypeChecker,
@@ -165,6 +166,19 @@ function createComponentTypeChecker() {
       return new Error(
         `Invalid ${locationName} \`${propName}\` supplied to ` +
         `\`${componentName}\`, expected a React component.`
+      );
+    }
+  }
+  return createChainableTypeChecker(validate);
+}
+
+function createComponentClassChecker() {
+  function validate(props, propName, componentName, location) {
+    if (!ReactDescriptor.isValidFactory(props[propName])) {
+      var locationName = ReactPropTypeLocationNames[location];
+      return new Error(
+        `Invalid ${locationName} \`${propName}\` supplied to ` +
+        `\`${componentName}\`, expected a React class.`
       );
     }
   }

--- a/src/core/__tests__/ReactPropTypes-test.js
+++ b/src/core/__tests__/ReactPropTypes-test.js
@@ -280,6 +280,65 @@ describe('ReactPropTypes', function() {
     });
   });
 
+  describe('Component Class', function() {
+    beforeEach(function() {
+      Component = React.createClass({
+        propTypes: {
+          label: PropTypes.componentClass.isRequired
+        },
+
+        render: function() {
+          var Label = this.props.label
+
+          if (Label) {
+              return <div><Label /></div>;
+          } else {
+            return null;
+          }
+        }
+      });
+      spyOn(console, 'warn');
+    });
+
+    it('should support component classes', () => {
+      typeCheckPass(PropTypes.componentClass, React.DOM.div);
+    });
+
+    it('should not support multiple component classes or scalar values', () => {
+      var message = 'Invalid prop `testProp` supplied to `testComponent`, ' +
+        'expected a React class.';
+      typeCheckFail(PropTypes.componentClass, [React.DOM.div, React.DOM.div], message);
+      typeCheckFail(PropTypes.componentClass, <div />, message);
+      typeCheckFail(PropTypes.componentClass, 123, message);
+      typeCheckFail(PropTypes.componentClass, 'foo', message);
+      typeCheckFail(PropTypes.componentClass, false, message);
+    });
+
+    it('should be able to define a single child as label', () => {
+      var instance = <Component label={React.DOM.div} />;
+      instance = ReactTestUtils.renderIntoDocument(instance);
+
+      expect(console.warn.argsForCall.length).toBe(0);
+    });
+
+    it('should warn when passing no label and isRequired is set', () => {
+      var instance = <Component />;
+      instance = ReactTestUtils.renderIntoDocument(instance);
+
+      expect(console.warn.argsForCall.length).toBe(1);
+    });
+
+    it("should be implicitly optional and not warn without values", function() {
+      typeCheckPass(PropTypes.component, null);
+      typeCheckPass(PropTypes.component, undefined);
+    });
+
+    it("should warn for missing required values", function() {
+      typeCheckFail(PropTypes.component.isRequired, null, requiredMessage);
+      typeCheckFail(PropTypes.component.isRequired, undefined, requiredMessage);
+    });
+  });
+
   describe('Instance Types', function() {
     it("should warn for invalid instances", function() {
       function Person() {}


### PR DESCRIPTION
[react-bootstrap](https://github.com/react-bootstrap/react-bootstrap) is currently using a [custom](https://github.com/react-bootstrap/react-bootstrap/blob/master/src/utils/CustomPropTypes.js) prop validator that ensures the prop satisfies `React.isValidClass`. I am finding that I will need the same functionality in another project without a dependency on react-bootstrap. This would be a nice validator to have in core. I'm open to renaming it to whatever sounds better to you, just let me know.

@pieterv