### PR TITLE
move transition into `example-enter-active` selector

### DIFF
--- a/docs/docs/09.1-animation.md
+++ b/docs/docs/09.1-animation.md
@@ -62,11 +62,11 @@ You can use these classes to trigger a CSS animation or transition. For example,
 ```css
 .example-enter {
   opacity: 0.01;
-  transition: opacity .5s ease-in;
 }
 
 .example-enter.example-enter-active {
   opacity: 1;
+  transition: opacity .5s ease-in;
 }
 ```
 


### PR DESCRIPTION
I was only able to get these animations to work by placing the `transition` declaration within the `example-enter-active` selector. When it was in the `example-enter` selector it didn't work. 

For whatever reason the animation began when the `example-enter` classname was added and was then halted when the `example-enter-active` classname was added. 

Chrome Version 36.0.1985.143
