### PR TITLE
Rename defaultValue/Checked to initialValue/Checked

### DIFF
--- a/src/browser/ui/dom/DOMProperty.js
+++ b/src/browser/ui/dom/DOMProperty.js
@@ -146,7 +146,7 @@ var DOMPropertyInjection = {
     }
   }
 };
-var defaultValueCache = {};
+var initialValueCache = {};
 
 /**
  * DOMProperty exports lookup objects that can be used like functions:
@@ -275,11 +275,11 @@ var DOMProperty = {
    * TODO: Is it better to grab all the possible properties when creating an
    * element to avoid having to create the same element twice?
    */
-  getDefaultValueForProperty: function(nodeName, prop) {
-    var nodeDefaults = defaultValueCache[nodeName];
+  getinitialValueForProperty: function(nodeName, prop) {
+    var nodeDefaults = initialValueCache[nodeName];
     var testElement;
     if (!nodeDefaults) {
-      defaultValueCache[nodeName] = nodeDefaults = {};
+      initialValueCache[nodeName] = nodeDefaults = {};
     }
     if (!(prop in nodeDefaults)) {
       testElement = document.createElement(nodeName);

--- a/src/browser/ui/dom/DOMPropertyOperations.js
+++ b/src/browser/ui/dom/DOMPropertyOperations.js
@@ -179,13 +179,13 @@ var DOMPropertyOperations = {
         node.removeAttribute(DOMProperty.getAttributeName[name]);
       } else {
         var propName = DOMProperty.getPropertyName[name];
-        var defaultValue = DOMProperty.getDefaultValueForProperty(
+        var initialValue = DOMProperty.getinitialValueForProperty(
           node.nodeName,
           propName
         );
         if (!DOMProperty.hasSideEffects[name] ||
-            ('' + node[propName]) !== defaultValue) {
-          node[propName] = defaultValue;
+            ('' + node[propName]) !== initialValue) {
+          node[propName] = initialValue;
         }
       }
     } else if (DOMProperty.isCustomAttribute(name)) {

--- a/src/browser/ui/dom/components/LinkedValueUtils.js
+++ b/src/browser/ui/dom/components/LinkedValueUtils.js
@@ -93,7 +93,7 @@ var LinkedValueUtils = {
         return new Error(
           'You provided a `value` prop to a form field without an ' +
           '`onChange` handler. This will render a read-only field. If ' +
-          'the field should be mutable use `defaultValue`. Otherwise, ' +
+          'the field should be mutable use `initialValue`. Otherwise, ' +
           'set either `onChange` or `readOnly`.'
         );
       },
@@ -107,7 +107,7 @@ var LinkedValueUtils = {
         return new Error(
           'You provided a `checked` prop to a form field without an ' +
           '`onChange` handler. This will render a read-only field. If ' +
-          'the field should be mutable use `defaultChecked`. Otherwise, ' +
+          'the field should be mutable use `initialChecked`. Otherwise, ' +
           'set either `onChange` or `readOnly`.'
         );
       },

--- a/src/browser/ui/dom/components/ReactDOMInput.js
+++ b/src/browser/ui/dom/components/ReactDOMInput.js
@@ -45,7 +45,7 @@ function forceUpdateIfMounted() {
 
 /**
  * Implements an <input> native component that allows setting these optional
- * props: `checked`, `value`, `defaultChecked`, and `defaultValue`.
+ * props: `checked`, `value`, `initialChecked`, and `initialValue`.
  *
  * If `checked` or `value` are not supplied (or null/undefined), user actions
  * that affect the checked state or value will trigger updates to the element.
@@ -54,8 +54,8 @@ function forceUpdateIfMounted() {
  * trigger updates to the element. Instead, the props must change in order for
  * the rendered element to be updated.
  *
- * The rendered element will be initialized as unchecked (or `defaultChecked`)
- * with an empty value (or `defaultValue`).
+ * The rendered element will be initialized as unchecked (or `initialChecked`)
+ * with an empty value (or `initialValue`).
  *
  * @see http://www.w3.org/TR/2012/WD-html5-20121025/the-input-element.html
  */
@@ -65,10 +65,10 @@ var ReactDOMInput = ReactCompositeComponent.createClass({
   mixins: [AutoFocusMixin, LinkedValueUtils.Mixin, ReactBrowserComponentMixin],
 
   getInitialState: function() {
-    var defaultValue = this.props.defaultValue;
+    var initialValue = this.props.initialValue;
     return {
-      initialChecked: this.props.defaultChecked || false,
-      initialValue: defaultValue != null ? defaultValue : null
+      initialChecked: this.props.initialChecked || false,
+      initialValue: initialValue != null ? initialValue : null
     };
   },
 
@@ -76,8 +76,8 @@ var ReactDOMInput = ReactCompositeComponent.createClass({
     // Clone `this.props` so we don't mutate the input.
     var props = merge(this.props);
 
-    props.defaultChecked = null;
-    props.defaultValue = null;
+    props.initialChecked = null;
+    props.initialValue = null;
 
     var value = LinkedValueUtils.getValue(this);
     props.value = value != null ? value : this.state.initialValue;

--- a/src/browser/ui/dom/components/ReactDOMOption.js
+++ b/src/browser/ui/dom/components/ReactDOMOption.js
@@ -41,7 +41,7 @@ var ReactDOMOption = ReactCompositeComponent.createClass({
     if (__DEV__) {
       warning(
         this.props.selected == null,
-        'Use the `defaultValue` or `value` props on <select> instead of ' +
+        'Use the `initialValue` or `value` props on <select> instead of ' +
         'setting `selected` on <option>.'
       );
     }

--- a/src/browser/ui/dom/components/ReactDOMSelect.js
+++ b/src/browser/ui/dom/components/ReactDOMSelect.js
@@ -40,7 +40,7 @@ function updateWithPendingValueIfMounted() {
 }
 
 /**
- * Validation function for `value` and `defaultValue`.
+ * Validation function for `value` and `initialValue`.
  * @private
  */
 function selectValueType(props, propName, componentName) {
@@ -97,7 +97,7 @@ function updateOptions(component, propValue) {
 
 /**
  * Implements a <select> native component that allows optionally setting the
- * props `value` and `defaultValue`. If `multiple` is false, the prop must be a
+ * props `value` and `initialValue`. If `multiple` is false, the prop must be a
  * string. If `multiple` is true, the prop must be an array of strings.
  *
  * If `value` is not supplied (or null/undefined), user actions that change the
@@ -107,7 +107,7 @@ function updateOptions(component, propValue) {
  * update in response to user actions. Instead, the `value` prop must change in
  * order for the rendered options to update.
  *
- * If `defaultValue` is provided, any options with the supplied values will be
+ * If `initialValue` is provided, any options with the supplied values will be
  * selected.
  */
 var ReactDOMSelect = ReactCompositeComponent.createClass({
@@ -116,12 +116,12 @@ var ReactDOMSelect = ReactCompositeComponent.createClass({
   mixins: [AutoFocusMixin, LinkedValueUtils.Mixin, ReactBrowserComponentMixin],
 
   propTypes: {
-    defaultValue: selectValueType,
+    initialValue: selectValueType,
     value: selectValueType
   },
 
   getInitialState: function() {
-    return {value: this.props.defaultValue || (this.props.multiple ? [] : '')};
+    return {value: this.props.initialValue || (this.props.multiple ? [] : '')};
   },
 
   componentWillMount: function() {

--- a/src/browser/ui/dom/components/ReactDOMTextarea.js
+++ b/src/browser/ui/dom/components/ReactDOMTextarea.js
@@ -44,7 +44,7 @@ function forceUpdateIfMounted() {
 
 /**
  * Implements a <textarea> native component that allows setting `value`, and
- * `defaultValue`. This differs from the traditional DOM API because value is
+ * `initialValue`. This differs from the traditional DOM API because value is
  * usually set as PCDATA children.
  *
  * If `value` is not supplied (or null/undefined), user actions that affect the
@@ -55,7 +55,7 @@ function forceUpdateIfMounted() {
  * order for the rendered element to be updated.
  *
  * The rendered element will be initialized with an empty value, the prop
- * `defaultValue` if specified, or the children content (deprecated).
+ * `initialValue` if specified, or the children content (deprecated).
  */
 var ReactDOMTextarea = ReactCompositeComponent.createClass({
   displayName: 'ReactDOMTextarea',
@@ -63,20 +63,20 @@ var ReactDOMTextarea = ReactCompositeComponent.createClass({
   mixins: [AutoFocusMixin, LinkedValueUtils.Mixin, ReactBrowserComponentMixin],
 
   getInitialState: function() {
-    var defaultValue = this.props.defaultValue;
+    var initialValue = this.props.initialValue;
     // TODO (yungsters): Remove support for children content in <textarea>.
     var children = this.props.children;
     if (children != null) {
       if (__DEV__) {
         warning(
           false,
-          'Use the `defaultValue` or `value` props instead of setting ' +
+          'Use the `initialValue` or `value` props instead of setting ' +
           'children on <textarea>.'
         );
       }
       invariant(
-        defaultValue == null,
-        'If you supply `defaultValue` on a <textarea>, do not pass children.'
+        initialValue == null,
+        'If you supply `initialValue` on a <textarea>, do not pass children.'
       );
       if (Array.isArray(children)) {
         invariant(
@@ -86,10 +86,10 @@ var ReactDOMTextarea = ReactCompositeComponent.createClass({
         children = children[0];
       }
 
-      defaultValue = '' + children;
+      initialValue = '' + children;
     }
-    if (defaultValue == null) {
-      defaultValue = '';
+    if (initialValue == null) {
+      initialValue = '';
     }
     var value = LinkedValueUtils.getValue(this);
     return {
@@ -97,7 +97,7 @@ var ReactDOMTextarea = ReactCompositeComponent.createClass({
       // `textContent` (unnecessary since we update value).
       // The initial value can be a boolean or object so that's why it's
       // forced to be a string.
-      initialValue: '' + (value != null ? value : defaultValue)
+      initialValue: '' + (value != null ? value : initialValue)
     };
   },
 
@@ -110,7 +110,7 @@ var ReactDOMTextarea = ReactCompositeComponent.createClass({
       '`dangerouslySetInnerHTML` does not make sense on <textarea>.'
     );
 
-    props.defaultValue = null;
+    props.initialValue = null;
     props.value = null;
     props.onChange = this._handleChange;
 

--- a/src/browser/ui/dom/components/__tests__/ReactDOMInput-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMInput-test.js
@@ -35,38 +35,38 @@ describe('ReactDOMInput', function() {
     ReactTestUtils = require('ReactTestUtils');
   });
 
-  it('should display `defaultValue` of number 0', function() {
-    var stub = <input type="text" defaultValue={0} />;
+  it('should display `initialValue` of number 0', function() {
+    var stub = <input type="text" initialValue={0} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
     var node = stub.getDOMNode();
 
     expect(node.value).toBe('0');
   });
 
-  it('should display "true" for `defaultValue` of `true`', function() {
-    var stub = <input type="text" defaultValue={true} />;
+  it('should display "true" for `initialValue` of `true`', function() {
+    var stub = <input type="text" initialValue={true} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
     var node = stub.getDOMNode();
 
     expect(node.value).toBe('true');
   });
 
-  it('should display "false" for `defaultValue` of `false`', function() {
-    var stub = <input type="text" defaultValue={false} />;
+  it('should display "false" for `initialValue` of `false`', function() {
+    var stub = <input type="text" initialValue={false} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
     var node = stub.getDOMNode();
 
     expect(node.value).toBe('false');
   });
 
-  it('should display "foobar" for `defaultValue` of `objToString`', function() {
+  it('should display "foobar" for `initialValue` of `objToString`', function() {
     var objToString = {
       toString: function() {
         return "foobar";
       }
     };
 
-    var stub = <input type="text" defaultValue={objToString} />;
+    var stub = <input type="text" initialValue={objToString} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
     var node = stub.getDOMNode();
 
@@ -168,7 +168,7 @@ describe('ReactDOMInput', function() {
                 ref="c"
                 type="radio"
                 name="fruit"
-                defaultChecked={true}
+                initialChecked={true}
                 onChange={emptyFunction}
               />
             </form>

--- a/src/browser/ui/dom/components/__tests__/ReactDOMSelect-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMSelect-test.js
@@ -34,9 +34,9 @@ describe('ReactDOMSelect', function() {
     ReactTestUtils = require('ReactTestUtils');
   });
 
-  it('should allow setting `defaultValue`', function() {
+  it('should allow setting `initialValue`', function() {
     var stub =
-      <select defaultValue="giraffe">
+      <select initialValue="giraffe">
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
@@ -46,14 +46,14 @@ describe('ReactDOMSelect', function() {
 
     expect(node.value).toBe('giraffe');
 
-    // Changing `defaultValue` should do nothing.
-    stub.setProps({defaultValue: 'gorilla'});
+    // Changing `initialValue` should do nothing.
+    stub.setProps({initialValue: 'gorilla'});
     expect(node.value).toEqual('giraffe');
   });
 
-  it('should not control when using `defaultValue`', function() {
+  it('should not control when using `initialValue`', function() {
     var stub =
-      <select defaultValue="giraffe">
+      <select initialValue="giraffe">
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
@@ -69,9 +69,9 @@ describe('ReactDOMSelect', function() {
     expect(node.value).toEqual('monkey');
   });
 
-  it('should allow setting `defaultValue` with multiple', function() {
+  it('should allow setting `initialValue` with multiple', function() {
     var stub =
-      <select multiple={true} defaultValue={['giraffe', 'gorilla']}>
+      <select multiple={true} initialValue={['giraffe', 'gorilla']}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
@@ -83,8 +83,8 @@ describe('ReactDOMSelect', function() {
     expect(node.options[1].selected).toBe(true);  // giraffe
     expect(node.options[2].selected).toBe(true);  // gorilla
 
-    // Changing `defaultValue` should do nothing.
-    stub.setProps({defaultValue: ['monkey']});
+    // Changing `initialValue` should do nothing.
+    stub.setProps({initialValue: ['monkey']});
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -177,7 +177,7 @@ describe('ReactDOMSelect', function() {
 
   it('should allow switching to multiple', function() {
     var stub =
-      <select defaultValue="giraffe">
+      <select initialValue="giraffe">
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
@@ -190,7 +190,7 @@ describe('ReactDOMSelect', function() {
     expect(node.options[2].selected).toBe(false);  // gorilla
 
     // When making it multiple, giraffe should still be selected
-    stub.setProps({multiple: true, defaultValue: null});
+    stub.setProps({multiple: true, initialValue: null});
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -199,7 +199,7 @@ describe('ReactDOMSelect', function() {
 
   it('should allow switching from multiple', function() {
     var stub =
-      <select multiple={true} defaultValue={['giraffe', 'gorilla']}>
+      <select multiple={true} initialValue={['giraffe', 'gorilla']}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
@@ -213,7 +213,7 @@ describe('ReactDOMSelect', function() {
 
     // When removing multiple, giraffe should still be selected (but gorilla
     // will no longer be)
-    stub.setProps({multiple: false, defaultValue: null});
+    stub.setProps({multiple: false, initialValue: null});
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe

--- a/src/browser/ui/dom/components/__tests__/ReactDOMTextarea-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMTextarea-test.js
@@ -43,42 +43,42 @@ describe('ReactDOMTextarea', function() {
     };
   });
 
-  it('should allow setting `defaultValue`', function() {
-    var stub = <textarea defaultValue="giraffe" />;
+  it('should allow setting `initialValue`', function() {
+    var stub = <textarea initialValue="giraffe" />;
     stub = renderTextarea(stub);
     var node = stub.getDOMNode();
 
     expect(node.value).toBe('giraffe');
 
-    // Changing `defaultValue` should do nothing.
-    stub.replaceProps({defaultValue: 'gorilla'});
+    // Changing `initialValue` should do nothing.
+    stub.replaceProps({initialValue: 'gorilla'});
     expect(node.value).toEqual('giraffe');
   });
 
-  it('should display `defaultValue` of number 0', function() {
-    var stub = <textarea defaultValue={0} />;
+  it('should display `initialValue` of number 0', function() {
+    var stub = <textarea initialValue={0} />;
     stub = renderTextarea(stub);
     var node = stub.getDOMNode();
 
     expect(node.value).toBe('0');
   });
 
-  it('should display "false" for `defaultValue` of `false`', function() {
-    var stub = <textarea type="text" defaultValue={false} />;
+  it('should display "false" for `initialValue` of `false`', function() {
+    var stub = <textarea type="text" initialValue={false} />;
     stub = renderTextarea(stub);
     var node = stub.getDOMNode();
 
     expect(node.value).toBe('false');
   });
 
-  it('should display "foobar" for `defaultValue` of `objToString`', function() {
+  it('should display "foobar" for `initialValue` of `objToString`', function() {
     var objToString = {
       toString: function() {
         return "foobar";
       }
     };
 
-    var stub = <textarea type="text" defaultValue={objToString} />;
+    var stub = <textarea type="text" initialValue={objToString} />;
     stub = renderTextarea(stub);
     var node = stub.getDOMNode();
 
@@ -160,7 +160,7 @@ describe('ReactDOMTextarea', function() {
     expect(node.value).toBe('0');
   });
 
-  it('should treat children like `defaultValue`', function() {
+  it('should treat children like `initialValue`', function() {
     spyOn(console, 'warn');
 
     var stub = <textarea>giraffe</textarea>;
@@ -170,7 +170,7 @@ describe('ReactDOMTextarea', function() {
     expect(console.warn.argsForCall.length).toBe(1);
     expect(node.value).toBe('giraffe');
 
-    // Changing children should do nothing, it functions like `defaultValue`.
+    // Changing children should do nothing, it functions like `initialValue`.
     stub.replaceProps({children: 'gorilla'});
     expect(node.value).toEqual('giraffe');
   });


### PR DESCRIPTION
English is not my native language so I could be off here. But it seems there is a seemingly very intentional distinction between `initial` (state) and `default` (props) in React. `defaultValue` seems incorrect for inputs as the property does not represent the default value for when no value is given, but only the initial value (state) of the input. Nor can it be used as a default value for when `value` is not set.

The implementation even looks like this (`getInitialState`, `initialValue`, etc):

```
  getInitialState: function() {
    var defaultValue = this.props.defaultValue;
    return {
      initialChecked: this.props.defaultChecked || false,
      initialValue: defaultValue != null ? defaultValue : null
    };
  },
```

I realize this is a breaking change, but I feel like it sets an important precedent for what is the "correct" naming of properties. I also imagine the surface area should be rather small and very easily fixed for those affected, just search-replace (or very easy to codemod).

cc @sebmarkbage @zpao 
