### PR TITLE
Fix DOMProperty bitmask checking

### DIFF
--- a/src/browser/ui/dom/DOMProperty.js
+++ b/src/browser/ui/dom/DOMProperty.js
@@ -23,6 +23,10 @@
 
 var invariant = require('invariant');
 
+function checkMask(value, bitmask) {
+  return (value & bitmask) === bitmask;
+}
+
 var DOMPropertyInjection = {
   /**
    * Mapping from normalized, camelcased property names to a configuration that
@@ -109,19 +113,19 @@ var DOMPropertyInjection = {
 
       var propConfig = Properties[propName];
       DOMProperty.mustUseAttribute[propName] =
-        propConfig & DOMPropertyInjection.MUST_USE_ATTRIBUTE;
+        checkMask(propConfig, DOMPropertyInjection.MUST_USE_ATTRIBUTE);
       DOMProperty.mustUseProperty[propName] =
-        propConfig & DOMPropertyInjection.MUST_USE_PROPERTY;
+        checkMask(propConfig, DOMPropertyInjection.MUST_USE_PROPERTY);
       DOMProperty.hasSideEffects[propName] =
-        propConfig & DOMPropertyInjection.HAS_SIDE_EFFECTS;
+        checkMask(propConfig, DOMPropertyInjection.HAS_SIDE_EFFECTS);
       DOMProperty.hasBooleanValue[propName] =
-        propConfig & DOMPropertyInjection.HAS_BOOLEAN_VALUE;
+        checkMask(propConfig, DOMPropertyInjection.HAS_BOOLEAN_VALUE);
       DOMProperty.hasNumericValue[propName] =
-        propConfig & DOMPropertyInjection.HAS_NUMERIC_VALUE;
+        checkMask(propConfig, DOMPropertyInjection.HAS_NUMERIC_VALUE);
       DOMProperty.hasPositiveNumericValue[propName] =
-        propConfig & DOMPropertyInjection.HAS_POSITIVE_NUMERIC_VALUE;
+        checkMask(propConfig, DOMPropertyInjection.HAS_POSITIVE_NUMERIC_VALUE);
       DOMProperty.hasOverloadedBooleanValue[propName] =
-        propConfig & DOMPropertyInjection.HAS_OVERLOADED_BOOLEAN_VALUE;
+        checkMask(propConfig, DOMPropertyInjection.HAS_OVERLOADED_BOOLEAN_VALUE);
 
       invariant(
         !DOMProperty.mustUseAttribute[propName] ||

--- a/src/browser/ui/dom/__tests__/DOMPropertyOperations-test.js
+++ b/src/browser/ui/dom/__tests__/DOMPropertyOperations-test.js
@@ -158,6 +158,28 @@ describe('DOMPropertyOperations', function() {
       )).toBe('');
     });
 
+    it('should create markup for numeric properties', function() {
+      expect(DOMPropertyOperations.createMarkupForProperty(
+        'start',
+        5
+      )).toBe('start="5"');
+
+      expect(DOMPropertyOperations.createMarkupForProperty(
+        'start',
+        0
+      )).toBe('start="0"');
+
+      expect(DOMPropertyOperations.createMarkupForProperty(
+        'size',
+        0
+      )).toBe('');
+
+      expect(DOMPropertyOperations.createMarkupForProperty(
+        'size',
+        1
+      )).toBe('size="1"');
+    });
+
   });
 
   describe('setValueForProperty', function() {


### PR DESCRIPTION
[Was previously "Fix HAS_POSITIVE_NUMERIC_VALUE properties" — code and title updated to fix underlying problem]

The bitmask checks in `DOMProperty` do not properly handle masks with more than one bit set; specifically, properties marked `HAS_NUMERIC_VALUE` are also passing tests for `HAS_POSITIVE_NUMERIC_VALUE`, introduced in 5c9d616735c4c5c31fb68b789c8c6f3afeae9592.

This bug manifests when attempting to use the `start` attribute on an ordered list to make the list start at 0. The following test case (also available [on JSFiddle](http://jsfiddle.net/BinaryMuse/cjqzuuqb/) demonstrates):

``` html
<div id="list-1"></div>
<div id="list-2"></div>
<div id="list-3"></div>
<p>HTML starting at 0:
    <ol start="0">
        <li>First</li>
        <li>Second</li>
        <li>Third</li>
    </ol>
</p>
```

``` javascript
/** @jsx React.DOM */

var List = React.createClass({
    render: function() {
        return (
            <p>React starting at {this.props.start}:
                <ol start={this.props.start}>
                    <li>First</li>
                    <li>Second</li>
                    <li>Third</li>
                </ol>
            </p>
        );
    }
});

React.renderComponent(<List start="1" />, document.getElementById("list-1"));
React.renderComponent(<List start="0" />, document.getElementById("list-2"));
React.renderComponent(<List start="5" />, document.getElementById("list-3"));
```

The output of the above is:

```
React starting at 1:

  1. First
  2. Second
  3. Third

React starting at 0:

  1. First
  2. Second
  3. Third

React starting at 5:

  5. First
  6. Second
  7. Third

HTML starting at 0:

  0. First
  1. Second
  2. Third
```
