### PR TITLE
Ignore transitionend events originating from children

### DIFF
--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -56,7 +56,12 @@ var ReactCSSTransitionGroupChild = React.createClass({
     var activeClassName = className + '-active';
     var noEventTimeout = null;
 
-    var endListener = function() {
+    var endListener = function(ev) {
+      // ignore events originating from children
+      if (ev && ev.target !== node) {
+          return;
+      }
+
       if (__DEV__) {
         clearTimeout(noEventTimeout);
       }


### PR DESCRIPTION
On Mobile Safari, in `ReactCSSTransitionGroupChild.js`, `transitionend` events from child nodes would bubble up to the `endListener` causing a premature DOM removal if the transition durations were not in sync.
