### PR TITLE
Add newline before JSX spread when appropriate

### DIFF
--- a/vendor/fbtransform/transforms/__tests__/react-test.js
+++ b/vendor/fbtransform/transforms/__tests__/react-test.js
@@ -379,8 +379,21 @@ describe('react jsx', function() {
       '<Component { ... x } y\n' +
       '={2 } z />';
     var result =
-      'React.createElement(Component, Object.assign({},   x , {y: \n' +
+      'React.createElement(Component, Object.assign({},    x , {y: \n' +
       '2, z: true}))';
+
+    expect(transform(code).code).toBe(result);
+  });
+
+  it('adds appropriate newlines when using spread attribute', function() {
+    var code =
+      '<Component\n' +
+      '  {...this.props}\n' +
+      '  sound="moo" />';
+    var result =
+      'React.createElement(Component, Object.assign({}, \n' +
+      '  this.props, \n' +
+      '  {sound: "moo"}))';
 
     expect(transform(code).code).toBe(result);
   });

--- a/vendor/fbtransform/transforms/react.js
+++ b/vendor/fbtransform/transforms/react.js
@@ -142,16 +142,17 @@ function visitReactTag(traverse, object, path, state) {
     var isLast = index === attributesObject.length - 1;
 
     if (attr.type === Syntax.XJSSpreadAttribute) {
-      // Plus 1 to skip `{`.
-      utils.move(attr.range[0] + 1, state);
-
       // Close the previous object or initial object
       if (!previousWasSpread) {
         utils.append('}, ', state);
       }
 
+
       // Move to the expression start, ignoring everything except parenthesis
       // and whitespace.
+      utils.catchup(attr.range[0], state, stripNonWhiteParen);
+      // Plus 1 to skip `{`.
+      utils.move(attr.range[0] + 1, state);
       utils.catchup(attr.argument.range[0], state, stripNonWhiteParen);
 
       traverse(attr.argument, path, state);


### PR DESCRIPTION
Previously, we were losing the newline before a JSX spread attribute which would cause the lines to not match up; this fixes the problem.
