### PR TITLE
Include vendor/ when running jest tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,11 +79,11 @@
     "jest": "jest"
   },
   "jest": {
-    "rootDir": "src",
-    "scriptPreprocessor": "../jest/preprocessor.js",
-    "setupEnvScriptFile": "../jest/environment.js",
-    "unmockedModulePathPatterns": [
-      ""
-    ]
+    "rootDir": "",
+    "scriptPreprocessor": "jest/preprocessor.js",
+    "setupEnvScriptFile": "jest/environment.js",
+    "modulePathIgnorePatterns": ["/build/", "/node_modules/"],
+    "testPathIgnorePatterns": ["/build/", "/node_modules/"],
+    "unmockedModulePathPatterns": [""]
   }
 }

--- a/vendor/fbtransform/syntax.js
+++ b/vendor/fbtransform/syntax.js
@@ -18,7 +18,7 @@ function transformAll(source, options, excludes) {
 
   // The typechecker transform must run in a second pass in order to operate on
   // the entire source code -- so exclude it from the first pass
-  var visitorsList = visitors.getVisitorsList(excludes.concat('typechecker'));
+  var visitorsList = visitors.getAllVisitors(excludes.concat('typechecker'));
   source = transform(visitorsList, source, options);
   if (excludes.indexOf('typechecks') == -1 && /@typechecks/.test(source.code)) {
     source = transform(


### PR DESCRIPTION
Now the two transform tests get run alongside the React core tests.

Test Plan: jest
