### PR TITLE
Enable ES7 spread transform when using --harmony

### DIFF
--- a/vendor/fbtransform/visitors.js
+++ b/vendor/fbtransform/visitors.js
@@ -6,6 +6,7 @@ var es6ObjectConciseMethod = require('jstransform/visitors/es6-object-concise-me
 var es6ObjectShortNotation = require('jstransform/visitors/es6-object-short-notation-visitors');
 var es6RestParameters = require('jstransform/visitors/es6-rest-param-visitors');
 var es6Templates = require('jstransform/visitors/es6-template-visitors');
+var es7SpreadProperty = require('jstransform/visitors/es7-spread-property-visitors');
 var react = require('./transforms/react');
 var reactDisplayName = require('./transforms/reactDisplayName');
 
@@ -20,6 +21,7 @@ var transformVisitors = {
   'es6-object-short-notation': es6ObjectShortNotation.visitorList,
   'es6-rest-params': es6RestParameters.visitorList,
   'es6-templates': es6Templates.visitorList,
+  'es7-spread-property': es7SpreadProperty.visitorList,
   'react': react.visitorList.concat(reactDisplayName.visitorList)
 };
 
@@ -34,6 +36,7 @@ var transformRunOrder = [
   'es6-rest-params',
   'es6-templates',
   'es6-destructuring',
+  'es7-spread-property',
   'react'
 ];
 


### PR DESCRIPTION
Test Plan: `echo "var o = {...x};" | bin/jsx --harmony` outputs `var o = Object.assign({},x);`.
