### PR TITLE
Ignore transition end events from nested nodes (fixes ReactCSSTransitionGroup behaviour)

### DIFF
--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -57,8 +57,8 @@ var ReactCSSTransitionGroupChild = React.createClass({
     var noEventTimeout = null;
 
     var endListener = function(e) {
-      var target = e.target;
-      if (target !== node) {
+      // Prevent end events bubbled from nested nodes
+      if (e.target !== node) {
         return;
       }
 


### PR DESCRIPTION
This commit fixes pretty common problem: when you have nested node with CSS transition (non `ReactCSSTransitionGroupChild`), end event bubbles up to the parent that leads to prematurely node removal.

E.g modal window (wrapped into `ReactCSSTransitionGroupChild`) going to move up and then disappear after pressing "close window". But right after window (with that button) move a bit up button gets mouse out event, that leads to background transition (on hover → normal state) that leads to transition end event. End event bubbles up and modal window get's it. Boom, modal window removed earlier than it should be.
