### PR TITLE
ReactJS support for IE6/IE7

### DIFF
--- a/src/browser/eventPlugins/ChangeEventPlugin.js
+++ b/src/browser/eventPlugins/ChangeEventPlugin.js
@@ -154,49 +154,31 @@ if (ExecutionEnvironment.canUseDOM) {
 }
 
 /**
- * (For old IE.) Replacement getter/setter for the `value` property that gets
- * set on the active element.
- */
-var newValueProp =  {
-  get: function() {
-    return activeElementValueProp.get.call(this);
-  },
-  set: function(val) {
-    // Cast to a string so we can do equality checks.
-    activeElementValue = '' + val;
-    activeElementValueProp.set.call(this, val);
-  }
-};
-
-/**
  * (For old IE.) Starts tracking propertychange events on the passed-in element
  * and override the value property so that we can distinguish user events from
  * value changes in JS.
+ * IE7 fix: changed behaviour choncerning IE7 does not support getter and setter
+ * To distinguish user events from value changes in JS special DOM attribute
+ * data-ie8_value is used
  */
 function startWatchingForValueChange(target, targetID) {
   activeElement = target;
   activeElementID = targetID;
   activeElementValue = target.value;
-  activeElementValueProp = Object.getOwnPropertyDescriptor(
-    target.constructor.prototype,
-    'value'
-  );
 
-  Object.defineProperty(activeElement, 'value', newValueProp);
   activeElement.attachEvent('onpropertychange', handlePropertyChange);
 }
 
 /**
  * (For old IE.) Removes the event listeners from the currently-tracked element,
  * if any exists.
+ * IE7 fix: do not need to delete value attribute anymore
  */
 function stopWatchingForValueChange() {
   if (!activeElement) {
     return;
   }
 
-  // delete restores the original property definition
-  delete activeElement.value;
   activeElement.detachEvent('onpropertychange', handlePropertyChange);
 
   activeElement = null;
@@ -212,6 +194,12 @@ function stopWatchingForValueChange() {
 function handlePropertyChange(nativeEvent) {
   if (nativeEvent.propertyName !== 'value') {
     return;
+  }
+  // IE7 fix: check if JS value change was made.
+  // True if value and data-ie8_value attribute are equal
+  var oldvalue = nativeEvent.srcElement.getAttribute('data-ie8_value');
+  if (oldvalue !== activeElementValue) {
+    activeElementValue = oldvalue;
   }
   var value = nativeEvent.srcElement.value;
   if (value === activeElementValue) {

--- a/src/browser/ui/ReactDOMIDOperations.js
+++ b/src/browser/ui/ReactDOMIDOperations.js
@@ -30,6 +30,8 @@ var ReactPerf = require('ReactPerf');
 var invariant = require('invariant');
 var setInnerHTML = require('setInnerHTML');
 
+var ExecutionEnvironment = require("ExecutionEnvironment");
+
 /**
  * Errors for properties that should not be updated with `updatePropertyById()`.
  *
@@ -72,6 +74,17 @@ var ReactDOMIDOperations = {
       // from the DOM node instead of inadvertantly setting to a string. This
       // brings us in line with the same behavior we have on initial render.
       if (value != null) {
+        // IE7 fix: for input and textarea we set data-ie8_value attribute first
+        // to distinguish value setter made by JS from user event value changes
+        if (ExecutionEnvironment.canUseDOM && !!window.attachEvent &&
+            name === 'value' &&
+            (node.tagName === 'INPUT' || node.tagName === 'TEXTAREA')) {
+          DOMPropertyOperations.setValueForProperty(
+            node,
+            'data-ie8_value',
+            value
+          );
+        }
         DOMPropertyOperations.setValueForProperty(node, name, value);
       } else {
         DOMPropertyOperations.deleteValueForProperty(node, name);

--- a/src/browser/ui/dom/Danger.js
+++ b/src/browser/ui/dom/Danger.js
@@ -110,10 +110,13 @@ var Danger = {
         emptyFunction // Do nothing special with <script> tags.
       );
 
+      // IE7 fix: hasAttribute isn't available
+      // using typeof renderNode[RESULT_INDEX_ATTR] instead
       for (i = 0; i < renderNodes.length; ++i) {
         var renderNode = renderNodes[i];
         if (renderNode.hasAttribute &&
-            renderNode.hasAttribute(RESULT_INDEX_ATTR)) {
+            renderNode.hasAttribute(RESULT_INDEX_ATTR) ||
+            typeof renderNode[RESULT_INDEX_ATTR] !== 'undefined') {
 
           resultIndex = +renderNode.getAttribute(RESULT_INDEX_ATTR);
           renderNode.removeAttribute(RESULT_INDEX_ATTR);

--- a/src/browser/ui/dom/components/ReactDOMInput.js
+++ b/src/browser/ui/dom/components/ReactDOMInput.js
@@ -44,6 +44,31 @@ function forceUpdateIfMounted() {
 }
 
 /**
+ * Implements polyfill for querySelectorAll to use in old IE browsers.
+ *
+ * Supports multiple / grouped selectors and the attribute selector with a "for"
+ * attribute.
+ *
+ * @see http://www.codecouch.com/2012/05/adding-document-queryselectorall-support-to-ie-7/
+ */
+function querySelectorAllPolyfill(r, c, i, j, a) {
+  var d=document,
+      s=d.createStyleSheet();
+  a = d.all;
+  c = [];
+  r = r.replace(/\[for\b/gi, '[htmlFor').split(',');
+  for (i = r.length; i--;) {
+    s.addRule(r[i], 'k:v');
+    for (j = a.length; j--;) {
+      a[j].currentStyle.k;
+      c.push(a[j]);
+    }
+    s.removeRule(0);
+  }
+  return c;
+}
+
+/**
  * Implements an <input> native component that allows setting these optional
  * props: `checked`, `value`, `defaultChecked`, and `defaultValue`.
  *
@@ -139,6 +164,10 @@ var ReactDOMInput = ReactCompositeComponent.createClass({
         queryRoot = queryRoot.parentNode;
       }
 
+      // IE7 fix: add querySelectorAll polyfill
+      if (!queryRoot.querySelectorAll) {
+        queryRoot.querySelectorAll = querySelectorAllPolyfill;
+      }
       // If `rootNode.form` was non-null, then we could try `form.elements`,
       // but that sometimes behaves strangely in IE8. We could also try using
       // `form.getElementsByName`, but that will only return direct children

--- a/src/browser/ui/dom/setInnerHTML.js
+++ b/src/browser/ui/dom/setInnerHTML.js
@@ -59,8 +59,9 @@ if (ExecutionEnvironment.canUseDOM) {
       // thin air on IE8, this only happens if there is no visible text
       // in-front of the non-visible tags. Piggyback on the whitespace fix
       // and simply check if any non-visible tags appear in the source.
+      // IE7 fix: charAt(0) instead of [0]
       if (WHITESPACE_TEST.test(html) ||
-          html[0] === '<' && NONVISIBLE_TEST.test(html)) {
+          html.charAt(0) === '<' && NONVISIBLE_TEST.test(html)) {
         // Recover leading whitespace by temporarily prepending any character.
         // \uFEFF has the potential advantage of being zero-width/invisible.
         node.innerHTML = '\uFEFF' + html;


### PR DESCRIPTION
Following changes were made to support old IE browsers IE6 and IE7
1. Algorithm to distinguish user event value changes and JS value changes on INPUT and TEXTAREA in ChangeEventPlugin was reimplemented by using data-ie8_value attribute on DOMNode
2. String[0] replaced by String.charAt(0) in setInnerHTML
3. Added querySelectorAll polyfill
4. Checking renderNode.hasAttribute extended by IE7 compatible attribute check
To run react.js apps in IE6/IE7 you have to use es5-shims and console-polyfill
