### PR TITLE
IE8 does not have a setter for property "enctype"

### DIFF
--- a/src/browser/ui/dom/HTMLDOMPropertyConfig.js
+++ b/src/browser/ui/dom/HTMLDOMPropertyConfig.js
@@ -176,7 +176,9 @@ var HTMLDOMPropertyConfig = {
     autoCorrect: 'autocorrect',
     autoFocus: 'autofocus',
     autoPlay: 'autoplay',
-    encType: 'enctype',
+    // `encoding` is equivalent to `enctype`, IE8 lacks an `enctype` setter.
+    // http://www.w3.org/TR/html5/forms.html#dom-fs-encoding
+    encType: 'encoding',
     hrefLang: 'hreflang',
     radioGroup: 'radiogroup',
     spellCheck: 'spellcheck',


### PR DESCRIPTION
```JS
f = document.createElement('form');
f.enctype = 'multipart/form-data';
console.log(f.enctype);
console.log(f.encoding);
console.log(f.getAttribute('enctype'));
```

Outputs (on IE8):

```
LOG: multipart/form-data
LOG: application/x-www-form-urlencoded
LOG: application/x-www-form-urlencoded
```

Whereas with `f.encoding = 'multipart/form-data';` or `f.setAttribute('enctype', 'multipart/form-data');`:

```
LOG: multipart/form-data
LOG: multipart/form-data
LOG: multipart/form-data
```

Unlikely that anyone would ever bump into this, but it is super-weird if you would and it's pretty much for free so why not.