### PR TITLE
Reduce unnecessary warning while including JSX transformer in browser

### DIFF
--- a/vendor/browser-transforms.js
+++ b/vendor/browser-transforms.js
@@ -312,6 +312,10 @@ function runScripts() {
     }
   }
 
+  if (jsxScripts.length < 1) {
+    return;
+  }
+
   console.warn(
     'You are using the in-browser JSX transformer. Be sure to precompile ' +
     'your JSX for production - ' +


### PR DESCRIPTION
Yet prevents calling `loadScripts` with empty array, hope it helps.
