### PR TITLE
Add --strip-types flag to bin/jsx

### DIFF
--- a/bin/jsx
+++ b/bin/jsx
@@ -12,13 +12,17 @@ require('commoner').version(
   '--harmony',
   'Turns on JS transformations such as ES6 Classes etc.'
 ).option(
+  '--strip-types',
+  'Strips out type annotations.'
+).option(
   '--source-map-inline',
   'Embed inline sourcemap in transformed source'
 ).process(function(id, source) {
   // This is where JSX, ES6, etc. desugaring happens.
   var options = {
     harmony: this.options.harmony,
-    sourceMap: this.options.sourceMapInline
+    sourceMap: this.options.sourceMapInline,
+    stripTypes: this.options.stripTypes
   };
   return transform(source, options);
 });

--- a/main.js
+++ b/main.js
@@ -31,16 +31,17 @@ module.exports = {
 
 function innerTransform(input, options) {
   options = options || {};
-  var visitorList = getVisitors(options.harmony);
-  return transform(visitorList, input, options);
-}
 
-function getVisitors(harmony) {
-  if (harmony) {
-    return visitors.getAllVisitors();
-  } else {
-    return visitors.transformVisitors.react;
+  var visitorSets = ['react'];
+  if (options.harmony) {
+    visitorSets.push('harmony');
   }
+  if (options.stripTypes) {
+    visitorSets.push('type-annotations');
+  }
+
+  var visitorList = visitors.getVisitorsBySet(visitorSets);
+  return transform(visitorList, input, options);
 }
 
 function inlineSourceMap(sourceMap, sourceCode, sourceFilename) {

--- a/vendor/fbtransform/visitors.js
+++ b/vendor/fbtransform/visitors.js
@@ -9,6 +9,7 @@ var es6Templates = require('jstransform/visitors/es6-template-visitors');
 var es7SpreadProperty = require('jstransform/visitors/es7-spread-property-visitors');
 var react = require('./transforms/react');
 var reactDisplayName = require('./transforms/reactDisplayName');
+var typesSyntax = require('jstransform/visitors/type-syntax');
 
 /**
  * Map from transformName => orderedListOfVisitors.
@@ -22,13 +23,34 @@ var transformVisitors = {
   'es6-rest-params': es6RestParameters.visitorList,
   'es6-templates': es6Templates.visitorList,
   'es7-spread-property': es7SpreadProperty.visitorList,
-  'react': react.visitorList.concat(reactDisplayName.visitorList)
+  'react': react.visitorList.concat(reactDisplayName.visitorList),
+  'types': typesSyntax.visitorList
+};
+
+var transformSets = {
+  'harmony': [
+    'es6-arrow-functions',
+    'es6-object-concise-method',
+    'es6-object-short-notation',
+    'es6-classes',
+    'es6-rest-params',
+    'es6-templates',
+    'es6-destructuring',
+    'es7-spread-property'
+  ],
+  'react': [
+    'react'
+  ],
+  'type-annotations': [
+    'types'
+  ]
 };
 
 /**
  * Specifies the order in which each transform should run.
  */
 var transformRunOrder = [
+  'types',
   'es6-arrow-functions',
   'es6-object-concise-method',
   'es6-object-short-notation',
@@ -57,5 +79,34 @@ function getAllVisitors(excludes) {
   return ret;
 }
 
+/**
+ * Given a list of visitor set names, return the ordered list of visitors to be
+ * passed to jstransform.
+ *
+ * @param {array}
+ * @return {array}
+ */
+function getVisitorsBySet(sets) {
+  var visitorsToInclude = sets.reduce(function(visitors, set) {
+    if (!transformSets.hasOwnProperty(set)) {
+      throw new Error('Unknown visitor set: ' + set);
+    }
+    transformSets[set].forEach(function(visitor) {
+      visitors[visitor] = true;
+    });
+    return visitors;
+  }, {});
+
+  var visitorList = [];
+  for (var i = 0; i < transformRunOrder.length; i++) {
+    if (visitorsToInclude.hasOwnProperty(transformRunOrder[i])) {
+      visitorList = visitorList.concat(transformVisitors[transformRunOrder[i]]);
+    }
+  }
+
+  return visitorList;
+}
+
+exports.getVisitorsBySet = getVisitorsBySet;
 exports.getAllVisitors = getAllVisitors;
 exports.transformVisitors = transformVisitors;


### PR DESCRIPTION
This adds support for a new `bin/jsx` flag that strips type annotations from source
