### PR TITLE
Use '.firstElementChild' when looking for root element

### DIFF
--- a/src/browser/ui/getReactRootElementInContainer.js
+++ b/src/browser/ui/getReactRootElementInContainer.js
@@ -33,7 +33,7 @@ function getReactRootElementInContainer(container) {
   if (container.nodeType === DOC_NODE_TYPE) {
     return container.documentElement;
   } else {
-    return container.firstChild;
+    return container.firstElementChild;
   }
 }
 


### PR DESCRIPTION
when looking for a react root element the function would look at the 'container.firstChild' attribute, which is a convenience for childNodes[0]. this might be non-html nodes (#text for example), causing hierarchies containing spaces between the container and child (react root element) to fail locating the react root elem. modified to '.firstElementChild', which is a similar convenience for children[0]