### PR TITLE
Update documentation on react-dispatcher and Flux

### DIFF
--- a/docs/docs/flux-todo-list.md
+++ b/docs/docs/flux-todo-list.md
@@ -54,9 +54,7 @@ We'll use the dispatcher from the [Flux GitHub repository](https://github.com/fa
 
 The dispatcher's source code is written in [ECMAScript 6](https://github.com/lukehoban/es6features), the future version of JavaScript.  To use the future of JS in today's browser's we need to transpile it back to a version of JS that browsers can use.  We perform this build step, transpiling from ES6 into common JavaScript, using npm.
 
-> Note: [Michael Jackson](https://twitter.com/mjackson)'s npm module version of the Flux project, called [react-dispatcher](https://www.npmjs.org/package/react-dispatcher) is now deprecated. 
-
-Use Facebook's [flux](https://www.npmjs.org/package/flux) to get disaptcher up and running:
+Use Facebook's [flux](https://www.npmjs.org/package/flux) to get dispatcher up and running:
 
 ```
 npm install flux


### PR DESCRIPTION
It seems that react-dispatcher is deprecated in favor of Flux. Updating the document to reflect the same.
