### PR TITLE
Creates a getMeasurementsSummaryMap in ReactDefaultPerf

### DIFF
--- a/src/test/ReactDefaultPerf.js
+++ b/src/test/ReactDefaultPerf.js
@@ -90,7 +90,7 @@ var ReactDefaultPerf = {
     );
   },
 
-  getMeasurementsSummaryMap: function(measurements){
+  getMeasurementsSummaryMap: function(measurements) {
     var summary = ReactDefaultPerfAnalysis.getInclusiveSummary(
       measurements,
       true


### PR DESCRIPTION
=== Problem
ReactDefaultPerf has a printWasted function that uses console.table to show the results of the performance measurements.
PhantomJS doesn't have the console.table function, so it's hard to get the metrics and present them in a CI pipeline.

=== Solution
Create a ReactDefaultPerf.getMeasurementsSummaryMap that receives a set of measurements and just generate the summary map. 
This solution make possible to get the performance summary and format them as you like. Even using console.log().

```
// very simple example
console.log(
    Perf.getMeasurementsSummaryMap(Perf.getLastMeasurements())
);
```
