### PR TITLE
Remove esprima-fb and use Syntax from jstransform

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "commoner": "^0.10.0",
-    "esprima-fb": "^6001.1.0-dev-harmony-fb",
     "jstransform": "^7.0.0"
   },
   "devDependencies": {

--- a/vendor/fbtransform/transforms/react.js
+++ b/vendor/fbtransform/transforms/react.js
@@ -9,7 +9,7 @@
 /*global exports:true*/
 "use strict";
 
-var Syntax = require('esprima-fb').Syntax;
+var Syntax = require('jstransform').Syntax;
 var utils = require('jstransform/src/utils');
 
 var FALLBACK_TAGS = require('./xjs').knownTags;

--- a/vendor/fbtransform/transforms/reactDisplayName.js
+++ b/vendor/fbtransform/transforms/reactDisplayName.js
@@ -9,7 +9,7 @@
 /*global exports:true*/
 "use strict";
 
-var Syntax = require('esprima-fb').Syntax;
+var Syntax = require('jstransform').Syntax;
 var utils = require('jstransform/src/utils');
 
 function addDisplayName(displayName, object, state) {

--- a/vendor/fbtransform/transforms/xjs.js
+++ b/vendor/fbtransform/transforms/xjs.js
@@ -8,7 +8,7 @@
  */
 /*global exports:true*/
 "use strict";
-var Syntax = require('esprima-fb').Syntax;
+var Syntax = require('jstransform').Syntax;
 var utils = require('jstransform/src/utils');
 
 var knownTags = {


### PR DESCRIPTION
Since https://github.com/facebook/jstransform/pull/29 was merged, `esprima-fb` is not necessary.

The changes to `jstransform` (https://github.com/facebook/jstransform/compare/f59f2e3...13e63c1) include getter/setters for `Class` by passing `{es5:true}` in `options` to `transform`. @zpao any thoughts on whether I should include the option in `bin/jsx` and/or have it as default in `main.js`?
