### PR TITLE
Fix inconsistency in mockComponent argument name

### DIFF
--- a/docs/docs/09.4-test-utils.md
+++ b/docs/docs/09.4-test-utils.md
@@ -38,7 +38,7 @@ Render a component into a detached DOM node in the document. **This function req
 ### mockComponent
 
 ```javascript
-object mockComponent(function componentClass, string? tagName)
+object mockComponent(function componentClass, string? mockTagName)
 ```
 
 Pass a mocked component module to this method to augment it with useful methods that allow it to be used as a dummy React component. Instead of rendering as usual, the component will become a simple `<div>` (or other tag if `mockTagName` is provided) containing any provided children.


### PR DESCRIPTION
The second argument of mockComponent was listed as `tagName`, but referred to in the description as `mockTagName`. I changed the actual argument to `mockTagName` to be consistent.

This is my first pull request; I've completed the Facebook CLA.
