### PR TITLE
add tip for the important jsx convention

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -60,7 +60,7 @@ React.renderComponent(
 
 > Note:
 >
-> ```/** @jsx React.DOM */``` is *must*, which is jsx convention. The comment parser is very strict right now; in order for it to pick up the `@jsx` modifier, two conditions are required. The `@jsx` comment block must be the first comment on the file. The comment must start with `/**` (`/*` and `//` will not work). If the parser can't find the `@jsx` comment, it will output the file without transforming it.
+> ```/** @jsx React.DOM */``` is *required*. The comment parser is very strict right now; in order for it to pick up the `@jsx` modifier, two conditions are required. The `@jsx` comment block must be the first comment on the file. The comment must start with `/**` (`/*` and `//` will not work). If the parser can't find the `@jsx` comment, it will output the file without transforming it.
 
 
 Then reference it from `helloworld.html`:


### PR DESCRIPTION
I missed the convention and wast hours to figure out what's wrong. 
Add this tip in the document for who would miss the importance comment.
