### PR TITLE
Remove superfluous classID from DOMAttributeNames

### DIFF
--- a/src/browser/ui/dom/HTMLDOMPropertyConfig.js
+++ b/src/browser/ui/dom/HTMLDOMPropertyConfig.js
@@ -168,7 +168,6 @@ var HTMLDOMPropertyConfig = {
     property: null // Supports OG in meta tags
   },
   DOMAttributeNames: {
-    classID: 'classid',
     className: 'class',
     htmlFor: 'for',
     httpEquiv: 'http-equiv'


### PR DESCRIPTION
No point having it there right?
