### PR TITLE
Remount ReactDOMInput when changing type

### DIFF
--- a/src/browser/ui/dom/components/__tests__/ReactDOMInput-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMInput-test.js
@@ -82,7 +82,7 @@ describe('ReactDOMInput', function() {
 
     expect(node.value).toBe('yolo');
 
-    stub.replaceProps({value: true, onChange: emptyFunction});
+    stub.replaceProps({value: true, type: 'text', onChange: emptyFunction});
     expect(node.value).toEqual('true');
   });
 
@@ -93,7 +93,7 @@ describe('ReactDOMInput', function() {
 
     expect(node.value).toBe('yolo');
 
-    stub.replaceProps({value: false});
+    stub.replaceProps({value: false, type: 'text'});
     expect(node.value).toEqual('false');
   });
 
@@ -110,7 +110,11 @@ describe('ReactDOMInput', function() {
       }
     };
 
-    stub.replaceProps({value: objToString, onChange: emptyFunction});
+    stub.replaceProps({
+      value: objToString,
+      type: 'text',
+      onChange: emptyFunction
+    });
     expect(node.value).toEqual('foobar');
   });
 
@@ -194,6 +198,40 @@ describe('ReactDOMInput', function() {
     // The original state should have been restored
     expect(aNode.checked).toBe(true);
     expect(cNode.checked).toBe(true);
+  });
+
+  it('should not remount when adding type text', function() {
+    var node = document.createElement('div');
+
+    React.render(
+      <input defaultValue="foo" />,
+      node
+    );
+
+
+  });
+
+  it('should remount when changing type', function() {
+    var node = document.createElement('div');
+
+    React.render(
+      <input defaultValue="foobar" />,
+      node
+    );
+
+    var stub = React.render(
+      <input type="text" defaultValue="foo" />,
+      node
+    );
+
+    expect(stub.getDOMNode().value).toBe('foo');
+
+    stub = React.render(
+      <input type="foobar" defaultValue="bar" />,
+      node
+    );
+
+    expect(stub.getDOMNode().value).toBe('bar');
   });
 
   it('should support ReactLink', function() {


### PR DESCRIPTION
IE8 throws if you change input `type`, It applies to all values of `type` (even unsupported ones).

```JS
React.renderComponent(<input type="radio" />, document.body);
React.renderComponent(<input type="checkbox" />, document.body);
[ERROR for attribute]  Could not get the type property. This command is not supported.
[ERROR for property]  "This command is not supported."
```

Additionally, all other versions of IE does not respect `checked` unless `type="checkbox"` or `type="radio"`. So changing from `type="textfield"` to `type="checkbox"` while `checked` causes it to be unchecked. Which **should** be an issue for React, except that `ReactDOMInput` explicitly calls `DOMPropertyOperations.setValueForProperty` for every `componentDidUpdate` ([source link](https://github.com/facebook/react/blob/master/src/browser/ui/dom/components/ReactDOMInput.js#L107)). Why? Seems wasteful.

It seems to me that the correct solution (to all of this) is to consider a different `type` as a different component. `type` is a really weird HTML feature, which to me is akin to transforming `span` into `div` rather than remounting... which we don't.

cc @zpao @spicyj 

(PS. PR just because, not saying we should take it as-is)