### PR TITLE
Add dangerouslySetDefaultInnerHTML

### DIFF
--- a/src/browser/ui/ReactDOMIDOperations.js
+++ b/src/browser/ui/ReactDOMIDOperations.js
@@ -39,6 +39,9 @@ var setInnerHTML = require('setInnerHTML');
 var INVALID_PROPERTY_ERRORS = {
   dangerouslySetInnerHTML:
     '`dangerouslySetInnerHTML` must be set using `updateInnerHTMLByID()`.',
+  dangerouslySetDefaultInnerHTML:
+    '`dangerouslySetDefaultInnerHTML` must be set using ' +
+    '`updateInnerHTMLByID()`.',
   style: '`style` must be set using `updateStylesByID()`.'
 };
 

--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -341,9 +341,18 @@ describe('ReactDOMComponent', function() {
       expect(function() {
         mountComponent({ children: '', dangerouslySetInnerHTML: '' });
       }).toThrow(
-        'Invariant Violation: Can only set one of `children` or ' +
-        '`props.dangerouslySetInnerHTML`.'
+        'Invariant Violation: Can only set `children` or ' +
+        '`props.dangerouslySetInnerHTML` and `dangerouslySetDefaultInnerHTML`.'
       );
+    });
+
+    it("should validate for both default and set innerHTML", function() {
+      expect(function() {
+        mountComponent({
+          dangerouslySetInnerHTML: '',
+          dangerouslySetDefaultInnerHTML: ''
+        });
+      }).not.toThrow();
     });
 
     it("should warn about contentEditable and children", function() {
@@ -381,9 +390,81 @@ describe('ReactDOMComponent', function() {
           container
         );
       }).toThrow(
-        'Invariant Violation: Can only set one of `children` or ' +
-        '`props.dangerouslySetInnerHTML`.'
+        'Invariant Violation: Can only set `children` or ' +
+        '`props.dangerouslySetInnerHTML` and `dangerouslySetDefaultInnerHTML`.'
       );
+    });
+
+    it("should validate for both default and set innerHTML", function() {
+      React.renderComponent(<div></div>, container);
+
+      expect(function() {
+        React.renderComponent(
+          <div
+            dangerouslySetInnerHTML={{__html: ''}}
+            dangerouslySetDefaultInnerHTML={{__html: ''}}
+          />,
+          container
+        );
+      }).not.toThrow()
+    });
+
+    it("should not update children when adding dangerouslySetDefaultInnerHTML", function() {
+      var stub = React.renderComponent(
+        <div />,
+        container
+      );
+
+      React.renderComponent(
+        <div dangerouslySetDefaultInnerHTML={{__html: 'updated'}} />,
+        container
+      );
+
+      expect(stub.getDOMNode().innerHTML).toBe('');
+    });
+
+    it("should not update children when updating dangerouslySetDefaultInnerHTML", function() {
+      var stub = React.renderComponent(
+        <div dangerouslySetDefaultInnerHTML={{__html: 'default'}} />,
+        container
+      );
+
+      expect(stub.getDOMNode().innerHTML).toBe('default');
+
+      React.renderComponent(
+        <div dangerouslySetDefaultInnerHTML={{__html: 'updated'}} />,
+        container
+      );
+
+      expect(stub.getDOMNode().innerHTML).toBe('default');
+    });
+
+    it("should not clear children when removing dangerouslySetInnerHTML and dangerouslySetDefaultInnerHTML is set", function() {
+      var stub = React.renderComponent(
+        <div dangerouslySetInnerHTML={{__html: 'set'}} />,
+        container
+      );
+
+      React.renderComponent(
+        <div dangerouslySetDefaultInnerHTML={{__html: 'updated'}} />,
+        container
+      );
+
+      expect(stub.getDOMNode().innerHTML).toBe('set');
+    });
+
+    it("should clear children when removing dangerouslySetDefaultInnerHTML", function() {
+      var stub = React.renderComponent(
+        <div dangerouslySetDefaultInnerHTML={{__html: 'default'}} />,
+        container
+      );
+
+      React.renderComponent(
+        <div />,
+        container
+      );
+
+      expect(stub.getDOMNode().innerHTML).toBe('');
     });
 
     it("should warn about contentEditable and children", function() {

--- a/src/browser/ui/dom/DOMPropertyOperations.js
+++ b/src/browser/ui/dom/DOMPropertyOperations.js
@@ -41,6 +41,7 @@ if (__DEV__) {
   var reactProps = {
     children: true,
     dangerouslySetInnerHTML: true,
+    dangerouslySetDefaultInnerHTML: true,
     key: true,
     ref: true
   };

--- a/src/browser/ui/dom/components/ReactDOMTextarea.js
+++ b/src/browser/ui/dom/components/ReactDOMTextarea.js
@@ -106,8 +106,10 @@ var ReactDOMTextarea = ReactCompositeComponent.createClass({
     var props = merge(this.props);
 
     invariant(
-      props.dangerouslySetInnerHTML == null,
-      '`dangerouslySetInnerHTML` does not make sense on <textarea>.'
+      props.dangerouslySetInnerHTML == null &&
+      props.dangerouslySetDefaultInnerHTML == null,
+      '`dangerouslySetInnerHTML` and `dangerouslySetDefaultInnerHTML` does ' +
+      'not make sense on <textarea>.'
     );
 
     props.defaultValue = null;

--- a/src/core/__tests__/ReactMultiChildText-test.js
+++ b/src/core/__tests__/ReactMultiChildText-test.js
@@ -220,6 +220,12 @@ describe('ReactMultiChildText', function() {
         <div dangerouslySetInnerHTML={{_html: 'abcdef'}}>ghjkl</div>
       );
     }).toThrow();
+
+    expect(function() {
+      ReactTestUtils.renderIntoDocument(
+        <div dangerouslySetDefaultInnerHTML={{_html: 'abcdef'}}>ghjkl</div>
+      );
+    }).toThrow();
   });
 
   it('should render between nested components and inline children', function() {


### PR DESCRIPTION
`dangerouslySetInnerHTML` is a poor fit when trying to provide initial children for other libraries to consume, while safe as long as you don't update the value, it's not very sanitary and in some ways relies implementation details. `dangerouslySetDefaultInnerHTML` works just like `value` vs `defaultValue`, as you would expect.

Should probably be named `dangerousDefaultInnerHTML`, but I kept the current naming convention until #2257 is resolved.