### PR TITLE
Improve and simplify findComponentRoot, do not optimistically traverse foreign nodes

### DIFF
--- a/perf/lib/BrowserPerfRunnerApp.react.js
+++ b/perf/lib/BrowserPerfRunnerApp.react.js
@@ -197,8 +197,10 @@ var GridViewTable = React.createClass({
 
   render: function(){
     return React.DOM.table(null,
-      this._renderRow(null, 0),
-      this.props.rows.map(this._renderRow, this)
+      React.DOM.tbody(null,
+        this._renderRow(null, 0),
+        this.props.rows.map(this._renderRow, this)
+      )
     );
   }
 

--- a/perf/lib/perf-test-runner.browser.js
+++ b/perf/lib/perf-test-runner.browser.js
@@ -195,10 +195,14 @@ perfRunner.ViewObject = function(props){
   
   if (typeof value != 'object') return React.DOM.span(props, [JSON.stringify(value), " ", typeof value]);
   
-  return React.DOM.table(props, Object.keys(value).map(function(key){
-    return React.DOM.tr(null,
-      React.DOM.th(null, key),
-      React.DOM.td(null, perfRunner.ViewObject({key:key, value:value[key]}))
-    );
-  }));
+  return React.DOM.table(props,
+    React.DOM.tbody(null,
+      Object.keys(value).map(function(key){
+        return React.DOM.tr(null,
+          React.DOM.th(null, key),
+          React.DOM.td(null, perfRunner.ViewObject({key:key, value:value[key]}))
+        );
+      })
+    )
+  );
 }

--- a/src/core/ReactInstanceHandles.js
+++ b/src/core/ReactInstanceHandles.js
@@ -323,11 +323,7 @@ var ReactInstanceHandles = {
    */
   _getFirstCommonAncestorID: getFirstCommonAncestorID,
 
-  /**
-   * Exposed for unit testing.
-   * @private
-   */
-  _getNextDescendantID: getNextDescendantID,
+  getNextDescendantID: getNextDescendantID,
 
   isAncestorIDOf: isAncestorIDOf,
 

--- a/src/core/__tests__/ReactInstanceHandles-test.js
+++ b/src/core/__tests__/ReactInstanceHandles-test.js
@@ -103,25 +103,6 @@ describe('ReactInstanceHandles', function() {
       ).toBe(childNodeB);
     });
 
-    it('should work around unidentified nodes', function() {
-      var parentNode = document.createElement('div');
-      var childNodeA = document.createElement('div');
-      var childNodeB = document.createElement('div');
-      parentNode.appendChild(childNodeA);
-      parentNode.appendChild(childNodeB);
-
-      ReactMount.setID(parentNode, '.0');
-      // No ID on `childNodeA`.
-      ReactMount.setID(childNodeB, '.0.0:1');
-
-      expect(
-        ReactMount.findComponentRoot(
-          parentNode,
-          ReactMount.getID(childNodeB)
-        )
-      ).toBe(childNodeB);
-    });
-
     it('should throw if a rendered element cannot be found', function() {
       var parentNode = document.createElement('table');
       var childNodeA = document.createElement('tbody');
@@ -130,8 +111,8 @@ describe('ReactInstanceHandles', function() {
       childNodeA.appendChild(childNodeB);
 
       ReactMount.setID(parentNode, '.0');
-      // No ID on `childNodeA`, it was "rendered by the browser".
-      ReactMount.setID(childNodeB, '.0.1:0');
+      ReactMount.setID(childNodeA, '.0.1:0');
+      ReactMount.setID(childNodeB, '.0.1:0.0');
 
       expect(ReactMount.findComponentRoot(
         parentNode,
@@ -141,7 +122,7 @@ describe('ReactInstanceHandles', function() {
       expect(function() {
         ReactMount.findComponentRoot(
           parentNode,
-          ReactMount.getID(childNodeB) + ":junk"
+          ReactMount.getID(childNodeA) + ":junk"
         );
       }).toThrow(
         'Invariant Violation: findComponentRoot(..., .0.1:0:junk): ' +
@@ -326,7 +307,7 @@ describe('ReactInstanceHandles', function() {
     it("should return next descendent from window", function() {
       var parent = renderParentIntoDocument();
       expect(
-        ReactInstanceHandles._getNextDescendantID(
+        ReactInstanceHandles.getNextDescendantID(
           '',
           parent.refs.P_P1._rootNodeID
         )
@@ -334,13 +315,13 @@ describe('ReactInstanceHandles', function() {
     });
 
     it("should return window for next descendent towards window", function() {
-      expect(ReactInstanceHandles._getNextDescendantID('', '')).toBe('');
+      expect(ReactInstanceHandles.getNextDescendantID('', '')).toBe('');
     });
 
     it("should return self for next descendent towards self", function() {
       var parent = renderParentIntoDocument();
       expect(
-        ReactInstanceHandles._getNextDescendantID(
+        ReactInstanceHandles.getNextDescendantID(
           parent.refs.P_P1._rootNodeID,
           parent.refs.P_P1._rootNodeID
         )


### PR DESCRIPTION
Based on code from #1570
Supersedes #2261 (#2005 for why I think optimistic traversal of foreign nodes is bad).

Improved and simplified implementation of `findComponentRoot`. Makes less use of the "hacky" `ReactInstanceHandles`. Once `_parentComponent` makes it appearance, one way or another, the dependency on `ReactInstanceHandles` can be dropped entirely (which is very good).

- [x] Test plan: `grunt test` and manual testing in our app
- [ ] If approved: test and tidy up the code, but I imagine there's too much friction for this PR now

```
   raw     gz Compared to master @ 57de1b07d0b58d5a76d46ee8b429d7d74d175c99
  -900   -532 build/react-with-addons.js
  -171    -82 build/react-with-addons.min.js
  -900   -500 build/react.js
  -171    -78 build/react.min.js
```