### PR TITLE
Disable ViewportMetrics unless MouseEvent lacks support for pageX/pageY

### DIFF
--- a/src/browser/ReactBrowserEventEmitter.js
+++ b/src/browser/ReactBrowserEventEmitter.js
@@ -83,6 +83,7 @@ var merge = require('merge');
  *    React Core     .  General Purpose Event Plugin System
  */
 
+var hasEventPageXY;
 var alreadyListeningTo = {};
 var isMonitoringScrollValue = false;
 var reactTopListenersCounter = 0;
@@ -331,12 +332,19 @@ var ReactBrowserEventEmitter = merge(ReactEventEmitterMixin, {
    * Listens to window scroll and resize events. We cache scroll values so that
    * application code can access them without triggering reflows.
    *
+   * ViewportMetrics is only used by SyntheticMouse/TouchEvent and only when
+   * pageX/pageY isn't supported (legacy browsers).
+   *
    * NOTE: Scroll events do not bubble.
    *
    * @see http://www.quirksmode.org/dom/events/scroll.html
    */
   ensureScrollValueMonitoring: function(){
-    if (!isMonitoringScrollValue) {
+    if (hasEventPageXY === undefined) {
+      hasEventPageXY =
+        document.createEvent && 'pageX' in document.createEvent('MouseEvent');
+    }
+    if (!hasEventPageXY && !isMonitoringScrollValue) {
       var refresh = ViewportMetrics.refreshScrollValues;
       ReactBrowserEventEmitter.ReactEventListener.monitorScrollValue(refresh);
       isMonitoringScrollValue = true;


### PR DESCRIPTION
For #1300, only IE8 lacks `pageX`/`pageY` (and perhaps really old FF or w/e I guess).

- [ ] Test plan: not yet (want your input on the PR first)
- [ ] If approved: will need to make a manual test and verify in all browsers

From my https://github.com/facebook/react/issues/1300#issuecomment-52509117:

----

https://github.com/facebook/react/blob/master/src/browser/ui/ReactEventListener.js#L65
https://github.com/facebook/react/blob/master/src/browser/ui/ReactEventListener.js#L165

That makes no sense at all to me, `refresh` does not take an argument, yet we get the scroll position and provide it as an argument. Instead, `refresh` gets the scroll position internally and uses that? So we call `getUnboundedScrollPosition` twice, but only use the result once (also, this should be broken for events inside iframes, for IE8).

---

https://github.com/facebook/react/blob/master/src/browser/eventPlugins/TapEventPlugin.js#L54
I'm pretty sure any browsers that supports touch also supports `pageX`/`pageY`... ?