### PR TITLE
Remove ReactBrowserComponentMixin dependency from ReactTextComponent

### DIFF
--- a/src/browser/ReactTextComponent.js
+++ b/src/browser/ReactTextComponent.js
@@ -20,7 +20,6 @@
 "use strict";
 
 var DOMPropertyOperations = require('DOMPropertyOperations');
-var ReactBrowserComponentMixin = require('ReactBrowserComponentMixin');
 var ReactComponent = require('ReactComponent');
 var ReactElement = require('ReactElement');
 


### PR DESCRIPTION
It's no longer used as of #1598, which just missed the require.

Test Plan: build, jest
