### PR TITLE
Drop the @jsx docblock from unit tests

### DIFF
--- a/src/addons/link/__tests__/LinkedStateMixin-test.js
+++ b/src/addons/link/__tests__/LinkedStateMixin-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/addons/link/__tests__/ReactLinkPropTypes-test.js
+++ b/src/addons/link/__tests__/ReactLinkPropTypes-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/addons/transitions/__tests__/ReactTransitionChildMapping-test.js
+++ b/src/addons/transitions/__tests__/ReactTransitionChildMapping-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/browser/__tests__/ReactDOM-test.js
+++ b/src/browser/__tests__/ReactDOM-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/browser/__tests__/ReactWebWorker-test.js
+++ b/src/browser/__tests__/ReactWebWorker-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/browser/eventPlugins/__tests__/AnalyticsEventPlugin-test.js
+++ b/src/browser/eventPlugins/__tests__/AnalyticsEventPlugin-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/browser/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
+++ b/src/browser/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/browser/server/__tests__/ReactServerRendering-test.js
+++ b/src/browser/server/__tests__/ReactServerRendering-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/browser/ui/__tests__/ReactEventListener-test.js
+++ b/src/browser/ui/__tests__/ReactEventListener-test.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  * @emails react-core
- * @jsx React.DOM
  */
 
 'use strict';

--- a/src/browser/ui/__tests__/ReactMount-test.js
+++ b/src/browser/ui/__tests__/ReactMount-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/browser/ui/__tests__/ReactMountDestruction-test.js
+++ b/src/browser/ui/__tests__/ReactMountDestruction-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/browser/ui/__tests__/ReactRenderDocument-test.js
+++ b/src/browser/ui/__tests__/ReactRenderDocument-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/browser/ui/dom/__tests__/CSSProperty-test.js
+++ b/src/browser/ui/dom/__tests__/CSSProperty-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/browser/ui/dom/__tests__/CSSPropertyOperations-test.js
+++ b/src/browser/ui/dom/__tests__/CSSPropertyOperations-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/browser/ui/dom/__tests__/DOMPropertyOperations-test.js
+++ b/src/browser/ui/dom/__tests__/DOMPropertyOperations-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/browser/ui/dom/__tests__/Danger-test.js
+++ b/src/browser/ui/dom/__tests__/Danger-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 /*jslint evil: true */

--- a/src/browser/ui/dom/__tests__/getNodeForCharacterOffset-test.js
+++ b/src/browser/ui/dom/__tests__/getNodeForCharacterOffset-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/browser/ui/dom/components/__tests__/ReactDOMButton-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMButton-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/browser/ui/dom/components/__tests__/ReactDOMInput-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMInput-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/browser/ui/dom/components/__tests__/ReactDOMSelect-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMSelect-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/browser/ui/dom/components/__tests__/ReactDOMTextarea-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMTextarea-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/ReactBind-test.js
+++ b/src/core/__tests__/ReactBind-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 /*global global:true*/

--- a/src/core/__tests__/ReactComponent-test.js
+++ b/src/core/__tests__/ReactComponent-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/ReactComponentLifeCycle-test.js
+++ b/src/core/__tests__/ReactComponentLifeCycle-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/ReactCompositeComponentDOMMinimalism-test.js
+++ b/src/core/__tests__/ReactCompositeComponentDOMMinimalism-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/ReactCompositeComponentError-test.js
+++ b/src/core/__tests__/ReactCompositeComponentError-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/ReactCompositeComponentMixin-test.js
+++ b/src/core/__tests__/ReactCompositeComponentMixin-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/ReactCompositeComponentSpec-test.js
+++ b/src/core/__tests__/ReactCompositeComponentSpec-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/ReactCompositeComponentState-test.js
+++ b/src/core/__tests__/ReactCompositeComponentState-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/ReactElement-test.js
+++ b/src/core/__tests__/ReactElement-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/ReactIdentity-test.js
+++ b/src/core/__tests__/ReactIdentity-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/ReactInstanceHandles-test.js
+++ b/src/core/__tests__/ReactInstanceHandles-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/ReactMultiChild-test.js
+++ b/src/core/__tests__/ReactMultiChild-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/ReactMultiChildReconcile-test.js
+++ b/src/core/__tests__/ReactMultiChildReconcile-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/ReactMultiChildText-test.js
+++ b/src/core/__tests__/ReactMultiChildText-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/ReactPropTransferer-test.js
+++ b/src/core/__tests__/ReactPropTransferer-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/ReactPropTypes-test.js
+++ b/src/core/__tests__/ReactPropTypes-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/ReactStateSetters-test.js
+++ b/src/core/__tests__/ReactStateSetters-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/ReactTextComponent-test.js
+++ b/src/core/__tests__/ReactTextComponent-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/ReactUpdates-test.js
+++ b/src/core/__tests__/ReactUpdates-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/refs-destruction-test.js
+++ b/src/core/__tests__/refs-destruction-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/core/__tests__/refs-test.js
+++ b/src/core/__tests__/refs-test.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @jsx React.DOM
  * @emails react-core
  */
 

--- a/src/utils/__tests__/ReactChildren-test.js
+++ b/src/utils/__tests__/ReactChildren-test.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  * @emails react-core
- * @jsx React.DOM
  */
 
 "use strict";

--- a/src/utils/__tests__/accumulateInto-test.js
+++ b/src/utils/__tests__/accumulateInto-test.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  * @emails react-core
- * @jsx React.DOM
  */
 
 "use strict";

--- a/src/utils/__tests__/cloneWithProps-test.js
+++ b/src/utils/__tests__/cloneWithProps-test.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  * @emails react-core
- * @jsx React.DOM
  */
 
 "use strict";

--- a/src/utils/__tests__/onlyChild-test.js
+++ b/src/utils/__tests__/onlyChild-test.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  * @emails react-core
- * @jsx React.DOM
  */
 
 "use strict";

--- a/src/utils/__tests__/sliceChildren-test.js
+++ b/src/utils/__tests__/sliceChildren-test.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  * @emails react-core
- * @jsx React.DOM
  */
 
 "use strict";

--- a/src/utils/__tests__/traverseAllChildren-test.js
+++ b/src/utils/__tests__/traverseAllChildren-test.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  * @emails react-core
- * @jsx React.DOM
  */
 
 "use strict";


### PR DESCRIPTION
This is no longer necessary in our transforms.
