### PR TITLE
Look for devtools global hook

### DIFF
--- a/src/browser/ui/React.js
+++ b/src/browser/ui/React.js
@@ -107,13 +107,17 @@ var React = {
 
 if (__DEV__) {
   var ExecutionEnvironment = require('ExecutionEnvironment');
-  if (ExecutionEnvironment.canUseDOM &&
-      window.top === window.self &&
-      navigator.userAgent.indexOf('Chrome') > -1) {
-    console.debug(
-      'If you haven\'t already, download the React DevTools for a better ' +
-      'development experience: http://fb.me/react-devtools'
-    );
+  if (ExecutionEnvironment.canUseDOM && window.top === window.self) {
+
+    // If we're in Chrome, look for the devtools marker and provide a download
+    // link if not installed.
+    if (navigator.userAgent.indexOf('Chrome') > -1 &&
+        typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === 'undefined') {
+      console.debug(
+        'If you haven\'t already, download the React DevTools for a better ' +
+        'development experience: http://fb.me/react-devtools'
+      );
+    }
 
     var expectedFeatures = [
       // shims


### PR DESCRIPTION
It doesn't exist yet, but it could. And yes, this is basically identical to #953.

This also ensures we actually do our polyfill checks in _all_ browsers,
not just Chrome.
