### PR TITLE
Ship merge, mergeInto, copyProperties to npm

### DIFF
--- a/grunt/config/jsx.js
+++ b/grunt/config/jsx.js
@@ -8,6 +8,12 @@ var rootIDs = [
   "ReactWithAddons"
 ];
 
+// TODO: stop packaging these libraries
+rootIDs = rootIDs.concat([
+  "merge",
+  "mergeInto",
+  "copyProperties"
+]);
 
 var normal = {
   rootIDs: rootIDs,

--- a/src/vendor/README.md
+++ b/src/vendor/README.md
@@ -1,0 +1,1 @@
+The files in this directory are not related to React's core functionality. They are shared utility modules that are also used in other parts of Facebook's front-end. Changes to these files need more consideration than changes to React itself.

--- a/src/vendor_deprecated/README.md
+++ b/src/vendor_deprecated/README.md
@@ -1,0 +1,3 @@
+The files in this directory are modified from their original implementation. At some point the files here were included in the React package shipped to npm and used by other projects.
+
+We removed all uses of these files inside React itself but would like to provide a sane deprecation notice for other consumers. We made no promises about the files here; they were always "use at your own risk".

--- a/src/vendor_deprecated/core/copyProperties.js
+++ b/src/vendor_deprecated/core/copyProperties.js
@@ -45,3 +45,10 @@ function copyProperties(obj, a, b, c, d, e, f) {
 }
 
 module.exports = copyProperties;
+
+// deprecation notice
+console.warn(
+  'react/lib/copyProperties has been deprecated and will be removed in the ' +
+  'next version of React. All uses can be replaced with ' +
+  'Object.assign(obj, a, b, ...) or _.extend(obj, a, b, ...).'
+);

--- a/src/vendor_deprecated/core/merge.js
+++ b/src/vendor_deprecated/core/merge.js
@@ -23,3 +23,10 @@ var merge = function(one, two) {
 };
 
 module.exports = merge;
+
+// deprecation notice
+console.warn(
+  'react/lib/merge has been deprecated and will be removed in the ' +
+  'next version of React. All uses can be replaced with ' +
+  'Object.assign({}, a, b) or _.extend({}, a, b).'
+);

--- a/src/vendor_deprecated/core/mergeInto.js
+++ b/src/vendor_deprecated/core/mergeInto.js
@@ -13,3 +13,10 @@
 "use strict";
 
 module.exports = Object.assign;
+
+// deprecation notice
+console.warn(
+  'react/lib/mergeInto has been deprecated and will be removed in the ' +
+  'next version of React. All uses can be replaced with ' +
+  'Object.assign(a, b, c, ...) or _.extend(a, b, c, ...).'
+);


### PR DESCRIPTION
This makes sure `merge`, `mergeInto`, `copyProperties` end up in build/modules which then gets packaged up for npm. Is there anything we're missing?

Ideally we should have deprecation notices. But we've never officially supported these. Also, `merge` now uses `Object.assign` so anybody using these without polyfills will have a Bad Time™.

Reviewers: @spicyj @sebmarkbage @syranide 

Test Plan: `grunt build` and make sure files are in `build/modules/npm-react/lib` (before: they weren't)
