### PR TITLE
De-register null component flag for _rootNodeID when we remove a composite component.

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -824,6 +824,8 @@ var ReactCompositeComponentMixin = {
     }
     this._compositeLifeCycleState = null;
 
+    ReactEmptyComponent.deregisterNullComponentID(this._rootNodeID);
+
     this._renderedComponent.unmountComponent();
     this._renderedComponent = null;
 

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -1465,4 +1465,54 @@ describe('ReactCompositeComponent', function() {
     );
   });
 
+  it('should deregister null components on unmount', function() {
+    var ComponentThatRendersToNull = React.createClass({
+      render: function() {
+        return null;
+      }
+    });
+
+    var MainView = React.createClass({
+      render: function() {
+        return (
+          <div>
+            <h1>MainView</h1>
+            <ComponentThatRendersToNull />
+          </div>
+        );
+      }
+    });
+
+    var ref = "SET ME";
+
+    var OtherView = React.createClass({
+      componentDidMount: function() {
+        ref = this.refs["c"].getDOMNode();
+      },
+
+      render: function() {
+        return (
+          <div>
+            <h1>OtherView</h1>
+            <div ref="c">Component</div>
+          </div>
+        );
+      }
+    });
+
+    var Container = React.createClass({
+      render: function() {
+        if (this.props.view == "MainView") {
+          return <MainView />;
+        } else {
+          return <OtherView />;
+        }
+      }
+    });
+
+    var instance = ReactTestUtils.renderIntoDocument(<Container view="MainView" />);
+    instance.replaceProps({view: "OtherView"});
+    expect(ref.nodeName).toBe("DIV");
+  });
+
 });


### PR DESCRIPTION
When React renders a composite component, it registers if the result of the render resulted in an empty element
(represented by empty noscript tags).

If the component is removed, this registration is never removed.
This pull-request fixes that problem.

See the following JSFiddle, for an example of one of the possible implications of this.
http://jsfiddle.net/Lhoqemev/2/

In all cases, we expect the getDOMNode() call to return the mounted div,
but because of the above issue, if the previous node was a composite component that rendered to an empty element,
we will get a null-reference instead.

Any feedback is welcome. Unit test of the issue included. The added code lints and all tests pass.
