### PR TITLE
Use hasOwnProperty checks in Object.assign

### DIFF
--- a/src/vendor/stubs/Object.assign.js
+++ b/src/vendor/stubs/Object.assign.js
@@ -9,23 +9,15 @@
  * @providesModule Object.assign
  */
 
-// This is an optimized version that fails on hasOwnProperty checks
-// and non objects. It's not spec-compliant. It's a perf optimization.
-
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+// https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.assign
 
 function assign(target, sources) {
-  if (__DEV__) {
-    if (target == null) {
-      throw new TypeError('Object.assign target cannot be null or undefined');
-    }
-    if (typeof target !== 'object' && typeof target !== 'function') {
-      throw new TypeError(
-        'In this environment the target of assign MUST be an object. ' +
-        'This error is a performance optimization and not spec compliant.'
-      );
-    }
+  if (target == null) {
+    throw new TypeError('Object.assign target cannot be null or undefined');
   }
+
+  var to = Object(target);
+  var hasOwnProperty = Object.prototype.hasOwnProperty;
 
   for (var nextIndex = 1; nextIndex < arguments.length; nextIndex++) {
     var nextSource = arguments[nextIndex];
@@ -33,25 +25,21 @@ function assign(target, sources) {
       continue;
     }
 
+    var from = Object(nextSource);
+
     // We don't currently support accessors nor proxies. Therefore this
     // copy cannot throw. If we ever supported this then we must handle
-    // exceptions and side-effects.
+    // exceptions and side-effects. We don't support symbols so they won't
+    // be transferred.
 
-    for (var key in nextSource) {
-      if (__DEV__) {
-        if (!hasOwnProperty.call(nextSource, key)) {
-          throw new TypeError(
-            'One of the sources to assign has an enumerable key on the ' +
-            'prototype chain. This is an edge case that we do not support. ' +
-            'This error is a performance optimization and not spec compliant.'
-          );
-        }
+    for (var key in from) {
+      if (hasOwnProperty.call(from, key)) {
+        to[key] = from[key];
       }
-      target[key] = nextSource[key];
     }
   }
 
-  return target;
+  return to;
 };
 
 module.exports = assign;


### PR DESCRIPTION
Because IE8 polyfills add enumerable properties, this doesn't play nicely.
So for IE8 compatibility we add this check. Slower though. :(
