### PR TITLE
Fix warning message for using React.DOM.* as type

### DIFF
--- a/src/core/ReactLegacyElement.js
+++ b/src/core/ReactLegacyElement.js
@@ -74,7 +74,7 @@ function warnForNonLegacyFactory(type) {
   warning(
     false,
     'Do not pass React.DOM.' + type.type + ' to JSX or createFactory. ' +
-    'Use the string "' + type + '" instead.'
+    'Use the string "' + type.type + '" instead.'
   );
 }
 


### PR DESCRIPTION
Previously, this said 'Use the string "function() { [native code] }" instead.'.

Test Plan: Crossed fingers.
