### PR TITLE
Make ReactTextComponent properly injectable

### DIFF
--- a/docs/docs/10.4-test-utils.md
+++ b/docs/docs/10.4-test-utils.md
@@ -75,14 +75,6 @@ boolean isCompositeComponentWithType(ReactComponent instance, function component
 
 Returns true if `instance` is a composite component (created with `React.createClass()`) whose type is of a React `componentClass`.
 
-### isTextComponent
-
-```javascript
-boolean isTextComponent(ReactComponent instance)
-```
-
-Returns true if `instance` is a plain text component.
-
 ### findAllInRenderedTree
 
 ```javascript

--- a/src/browser/ui/React.js
+++ b/src/browser/ui/React.js
@@ -22,6 +22,7 @@ var ReactElement = require('ReactElement');
 var ReactElementValidator = require('ReactElementValidator');
 var ReactDOM = require('ReactDOM');
 var ReactDOMComponent = require('ReactDOMComponent');
+var ReactDOMTextComponent = require('ReactDOMTextComponent');
 var ReactDefaultInjection = require('ReactDefaultInjection');
 var ReactInstanceHandles = require('ReactInstanceHandles');
 var ReactMount = require('ReactMount');
@@ -30,7 +31,6 @@ var ReactPerf = require('ReactPerf');
 var ReactPropTypes = require('ReactPropTypes');
 var ReactRef = require('ReactRef');
 var ReactServerRendering = require('ReactServerRendering');
-var ReactTextComponent = require('ReactTextComponent');
 
 var assign = require('Object.assign');
 var deprecated = require('deprecated');
@@ -122,7 +122,7 @@ if (
     InstanceHandles: ReactInstanceHandles,
     Mount: ReactMount,
     MultiChild: ReactMultiChild,
-    TextComponent: ReactTextComponent
+    TextComponent: ReactDOMTextComponent
   });
 }
 

--- a/src/browser/ui/ReactDefaultInjection.js
+++ b/src/browser/ui/ReactDefaultInjection.js
@@ -32,6 +32,7 @@ var ReactDOMInput = require('ReactDOMInput');
 var ReactDOMOption = require('ReactDOMOption');
 var ReactDOMSelect = require('ReactDOMSelect');
 var ReactDOMTextarea = require('ReactDOMTextarea');
+var ReactDOMTextComponent = require('ReactDOMTextComponent');
 var ReactEventListener = require('ReactEventListener');
 var ReactInjection = require('ReactInjection');
 var ReactInstanceHandles = require('ReactInstanceHandles');
@@ -71,6 +72,10 @@ function inject() {
 
   ReactInjection.NativeComponent.injectGenericComponentClass(
     ReactDOMComponent
+  );
+
+  ReactInjection.NativeComponent.injectTextComponentClass(
+    ReactDOMTextComponent
   );
 
   ReactInjection.NativeComponent.injectComponentClasses({

--- a/src/browser/ui/__tests__/ReactDOMTextComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMTextComponent-test.js
@@ -13,7 +13,7 @@
 
 var React;
 
-describe('ReactTextComponent', function() {
+describe('ReactDOMTextComponent', function() {
   beforeEach(function() {
     React = require('React');
   });

--- a/src/core/ReactMultiChild.js
+++ b/src/core/ReactMultiChild.js
@@ -306,7 +306,7 @@ var ReactMultiChild = {
       // Remove children that are no longer present.
       for (name in prevChildren) {
         if (prevChildren.hasOwnProperty(name) &&
-            !(nextChildren && nextChildren[name])) {
+            !(nextChildren && nextChildren.hasOwnProperty(name))) {
           this._unmountChildByName(prevChildren[name], name);
         }
       }

--- a/src/core/ReactNativeComponent.js
+++ b/src/core/ReactNativeComponent.js
@@ -17,12 +17,18 @@ var invariant = require('invariant');
 var genericComponentClass = null;
 // This registry keeps track of wrapper classes around native tags
 var tagToComponentClass = {};
+var textComponentClass = null;
 
 var ReactNativeComponentInjection = {
   // This accepts a class that receives the tag string. This is a catch all
   // that can render any kind of tag.
   injectGenericComponentClass: function(componentClass) {
     genericComponentClass = componentClass;
+  },
+  // This accepts a text component class that takes the text string to be
+  // rendered as props.
+  injectTextComponentClass: function(componentClass) {
+    textComponentClass = componentClass;
   },
   // This accepts a keyed object with classes as values. Each key represents a
   // tag. That particular tag will use this class instead of the generic one.
@@ -60,8 +66,26 @@ function createInstanceForTag(tag, props, parentType) {
   return new componentClass(props);
 }
 
+/**
+ * @param {ReactText} text
+ * @return {ReactComponent}
+ */
+function createInstanceForText(text) {
+  return new textComponentClass(text);
+}
+
+/**
+ * @param {ReactComponent} component
+ * @return {boolean}
+ */
+function isTextComponent(component) {
+  return component instanceof textComponentClass;
+}
+
 var ReactNativeComponent = {
   createInstanceForTag: createInstanceForTag,
+  createInstanceForText: createInstanceForText,
+  isTextComponent: isTextComponent,
   injection: ReactNativeComponentInjection
 };
 

--- a/src/core/__tests__/ReactMultiChildText-test.js
+++ b/src/core/__tests__/ReactMultiChildText-test.js
@@ -70,8 +70,7 @@ var expectChildren = function(d, children) {
       if (typeof child === 'string') {
         reactComponentExpect(d)
           .expectRenderedChildAt(i)
-          .toBeTextComponent()
-          .instance();
+          .toBeTextComponent();
 
         textNode = d.getDOMNode().childNodes[i].firstChild;
 

--- a/src/core/instantiateReactComponent.js
+++ b/src/core/instantiateReactComponent.js
@@ -16,6 +16,7 @@ var ReactCompositeComponent = require('ReactCompositeComponent');
 var ReactNativeComponent = require('ReactNativeComponent');
 
 var assign = require('Object.assign');
+var invariant = require('invariant');
 var warning = require('warning');
 
 // To avoid a cyclic dependency, we create the final class in this module
@@ -46,60 +47,71 @@ function isInternalComponentType(type) {
 }
 
 /**
- * Given an `element` create an instance that will actually be mounted.
+ * Given a ReactNode, create an instance that will actually be mounted.
  *
- * @param {object} element
+ * @param {ReactNode} node
  * @param {*} parentCompositeType The composite type that resolved this.
  * @return {object} A new instance of the element's constructor.
  * @protected
  */
-function instantiateReactComponent(element, parentCompositeType) {
+function instantiateReactComponent(node, parentCompositeType) {
   var instance;
 
-  if (__DEV__) {
-    warning(
-      element && (typeof element.type === 'function' ||
-                  typeof element.type === 'string'),
-      'Only functions or strings can be mounted as React components.'
-    );
-  }
-
-  // Special case string values
-  if (typeof element.type === 'string') {
-    instance = ReactNativeComponent.createInstanceForTag(
-      element.type,
-      element.props,
-      parentCompositeType
-    );
-    // If the injected special class is not an internal class, but another
-    // composite, then we must wrap it.
-    // TODO: Move this resolution around to something cleaner.
-    if (typeof instance.mountComponent !== 'function') {
-      instance = new ReactCompositeComponentWrapper(instance);
+  if (typeof node === 'object') {
+    var element = node;
+    if (__DEV__) {
+      warning(
+        element && (typeof element.type === 'function' ||
+                    typeof element.type === 'string'),
+        'Only functions or strings can be mounted as React components.'
+      );
     }
-  } else if (isInternalComponentType(element.type)) {
-    // This is temporarily available for custom components that are not string
-    // represenations. I.e. ART. Once those are updated to use the string
-    // representation, we can drop this code path.
-    instance = new element.type(element);
+
+    // Special case string values
+    if (typeof element.type === 'string') {
+      instance = ReactNativeComponent.createInstanceForTag(
+        element.type,
+        element.props,
+        parentCompositeType
+      );
+      // If the injected special class is not an internal class, but another
+      // composite, then we must wrap it.
+      // TODO: Move this resolution around to something cleaner.
+      if (typeof instance.mountComponent !== 'function') {
+        instance = new ReactCompositeComponentWrapper(instance);
+      }
+    } else if (isInternalComponentType(element.type)) {
+      // This is temporarily available for custom components that are not string
+      // represenations. I.e. ART. Once those are updated to use the string
+      // representation, we can drop this code path.
+      instance = new element.type(element);
+    } else {
+      // TODO: Update to follow new ES6 initialization. Ideally, we can use
+      // props in property initializers.
+      var inst = new element.type(element.props);
+      instance = new ReactCompositeComponentWrapper(inst);
+    }
+  } else if (typeof node === 'string' || typeof node === 'number') {
+    instance = ReactNativeComponent.createInstanceForText(node);
   } else {
-    // TODO: Update to follow new ES6 initialization. Ideally, we can use props
-    // in property initializers.
-    var inst = new element.type(element.props);
-    instance = new ReactCompositeComponentWrapper(inst);
+    invariant(
+      false,
+      'Encountered invalid React node of type ' + typeof node
+    );
   }
 
   if (__DEV__) {
     warning(
       typeof instance.construct === 'function' &&
       typeof instance.mountComponent === 'function' &&
-      typeof instance.receiveComponent === 'function',
+      typeof instance.receiveComponent === 'function' &&
+      typeof instance.unmountComponent === 'function',
       'Only React Components can be mounted.'
     );
   }
 
   // Sets up the instance. This can probably just move into the constructor now.
-  instance.construct(element);
+  instance.construct(node);
 
   return instance;
 }

--- a/src/core/shouldUpdateReactComponent.js
+++ b/src/core/shouldUpdateReactComponent.js
@@ -12,6 +12,8 @@
 
 "use strict";
 
+var ReactNativeComponent = require('ReactNativeComponent');
+
 /**
  * Given a `prevElement` and `nextElement`, determines if the existing
  * instance should be updated as opposed to being destroyed or replaced by a new
@@ -24,11 +26,19 @@
  * @protected
  */
 function shouldUpdateReactComponent(prevElement, nextElement) {
-  if (prevElement && nextElement &&
-      prevElement.type === nextElement.type &&
-      prevElement.key === nextElement.key &&
-      prevElement._owner === nextElement._owner) {
-    return true;
+  if (prevElement != null && nextElement != null) {
+    var prevType = typeof prevElement;
+    var nextType = typeof nextElement;
+    if (prevType === 'string' || prevType === 'number') {
+      return (nextType === 'string' || nextType === 'number');
+    } else {
+      return (
+        nextType === 'object' &&
+        prevElement.type === nextElement.type &&
+        prevElement.key === nextElement.key &&
+        prevElement._owner === nextElement._owner
+      );
+    }
   }
   return false;
 }

--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -19,7 +19,6 @@ var ReactElement = require('ReactElement');
 var ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
 var ReactInstanceMap = require('ReactInstanceMap');
 var ReactMount = require('ReactMount');
-var ReactTextComponent = require('ReactTextComponent');
 var ReactUpdates = require('ReactUpdates');
 var SyntheticEvent = require('SyntheticEvent');
 
@@ -98,10 +97,6 @@ var ReactTestUtils = {
   isCompositeComponentElementWithType: function(inst, type) {
     return !!(ReactTestUtils.isCompositeComponentElement(inst) &&
              (inst.constructor === type));
-  },
-
-  isTextComponent: function(inst) {
-    return inst instanceof ReactTextComponent.type;
   },
 
   getInternalRepresentation: function(inst) {

--- a/src/test/reactComponentExpect.js
+++ b/src/test/reactComponentExpect.js
@@ -12,7 +12,6 @@
 
 "use strict";
 
-var ReactInstanceMap = require('ReactInstanceMap');
 var ReactTestUtils = require('ReactTestUtils');
 
 var assign = require('Object.assign');
@@ -131,7 +130,8 @@ assign(reactComponentExpect.prototype, {
   },
 
   toBeTextComponent: function() {
-    expect(ReactTestUtils.isTextComponent(this.instance())).toBe(true);
+    var elementType = typeof this._instance._currentElement;
+    expect(elementType === 'string' || elementType === 'number').toBe(true);
     return this;
   },
 

--- a/src/utils/flattenChildren.js
+++ b/src/utils/flattenChildren.js
@@ -11,8 +11,6 @@
 
 "use strict";
 
-var ReactTextComponent = require('ReactTextComponent');
-
 var traverseAllChildren = require('traverseAllChildren');
 var warning = require('warning');
 
@@ -33,18 +31,7 @@ function flattenSingleChildIntoContext(traverseContext, child, name) {
     name
   );
   if (keyUnique && child != null) {
-    var type = typeof child;
-    var normalizedValue;
-
-    if (type === 'string') {
-      normalizedValue = ReactTextComponent(child);
-    } else if (type === 'number') {
-      normalizedValue = ReactTextComponent('' + child);
-    } else {
-      normalizedValue = child;
-    }
-
-    result[name] = normalizedValue;
+    result[name] = child;
   }
 }
 

--- a/src/utils/traverseAllChildren.js
+++ b/src/utils/traverseAllChildren.js
@@ -21,11 +21,8 @@ var SEPARATOR = ReactInstanceHandles.SEPARATOR;
 var SUBSEPARATOR = ':';
 
 /**
- * TODO: Test that:
- * 1. `mapChildren` transforms strings and numbers into `ReactTextComponent`.
- * 2. it('should fail when supplied duplicate key', function() {
- * 3. That a single child and an array with one item have the same key pattern.
- * });
+ * TODO: Test that a single child and an array with one item have the same key
+ * pattern.
  */
 
 var userProvidedKeyEscaperLookup = {


### PR DESCRIPTION
ReactTextComponent's implementation is DOM-specific; instead of flattenChildren creating the ReactTextComponent instances, ReactNativeComponent now takes care of having ReactTextComponent injected and creating the element. I also renamed ReactTextComponent to ReactDOMTextComponent and moved it to browser/ui/ where it belongs.

Test Plan: jest, use ballmer-peak example.

Reviewers: @sebmarkbage @jordwalke
