### PR TITLE
avoid reading the scroll position twice

### DIFF
--- a/src/browser/ui/dom/ViewportMetrics.js
+++ b/src/browser/ui/dom/ViewportMetrics.js
@@ -11,16 +11,13 @@
 
 "use strict";
 
-var getUnboundedScrollPosition = require('getUnboundedScrollPosition');
-
 var ViewportMetrics = {
 
   currentScrollLeft: 0,
 
   currentScrollTop: 0,
 
-  refreshScrollValues: function() {
-    var scrollPosition = getUnboundedScrollPosition(window);
+  refreshScrollValues: function(scrollPosition) {
     ViewportMetrics.currentScrollLeft = scrollPosition.x;
     ViewportMetrics.currentScrollTop = scrollPosition.y;
   }


### PR DESCRIPTION
Removing unnecessary scroll position read.
The scroll position is already passed to refreshScrollValues when it's called: https://github.com/facebook/react/blob/master/src/browser/ui/ReactEventListener.js#L89-L92
