### PR TITLE
Hide ReactElement constructor

### DIFF
--- a/src/core/ReactElement.js
+++ b/src/core/ReactElement.js
@@ -120,11 +120,15 @@ var ReactElement = function(type, key, ref, owner, context, props) {
   this.props = props;
 };
 
+// We intentionally don't expose the function on the constructor property.
+// ReactElement should be indistinguishable from a plain object.
+ReactElement.prototype = {
+  _isReactElement: true
+};
+
 if (__DEV__) {
   defineMutationMembrane(ReactElement.prototype);
 }
-
-ReactElement.prototype._isReactElement = true;
 
 ReactElement.createElement = function(type, config, children) {
   var propName;

--- a/src/core/__tests__/ReactElement-test.js
+++ b/src/core/__tests__/ReactElement-test.js
@@ -311,4 +311,10 @@ describe('ReactElement', function() {
     expect(instance.getDOMNode().tagName).toBe('DIV');
   });
 
+  it('is indistinguishable from a plain object', function() {
+    var element = React.createElement('div', { className: 'foo' });
+    var object = {};
+    expect(element.constructor).toBe(object.constructor);
+  });
+
 });


### PR DESCRIPTION
This prevents feature tests like:

``` javascript
var ReactElement = React.createElement(...).constructor;

if (element.constructor === ReactElement) ...

// or

if (element.constructor !== Object) ...
```

This is intentional so that we have the option to make these plain objects. E.g. for direct inlining or replacing them with value types.

I suspect that people will be tempted to use this hack. E.g. to avoid passing null props. Therefore I'm adding this PR to 0.12 last minute.
