### PR TITLE
Remove obsolete jshint options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -12,10 +12,7 @@
   "newcap": false,
   "noempty": true,
   "nonstandard": true,
-  "onecase": true,
   "sub": true,
-  "regexdash": true,
-  "trailing": true,
   "undef": true,
   "unused": "vars"
 }

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -15,10 +15,7 @@
   "noempty": true,
   "nonstandard": true,
   "maxlen": 80,
-  "onecase": true,
-  "regexdash": true,
   "sub": false,
-  "trailing": true,
   "undef": true,
   "unused": "vars",
 


### PR DESCRIPTION
This options are obsolete in JSHint 2.5.0 release

`"onecase"`:
- [Relate Issue Thread](https://github.com/jshint/jshint/issues/1249)
- [jshint.js src](https://github.com/jshint/jshint/blob/master/src/jshint.js#L157)

`"regexdash"`:
- [jshint.js src](https://github.com/jshint/jshint/blob/master/src/jshint.js#L159)

`"trailing"`:
- [JSHint 2.5.0 release](https://github.com/jshint/jshint/releases/tag/2.5.0)
- [jshint.js src](https://github.com/jshint/jshint/blob/master/src/jshint.js#L230)

Lint checker with options:
![react-master-jshint](https://cloud.githubusercontent.com/assets/182219/4782567/bf4165a6-5cfb-11e4-99ae-a4c7fbc32e86.png)

Lint checker without options:
![react-enaqx-jshint](https://cloud.githubusercontent.com/assets/182219/4782568/cf733a9e-5cfb-11e4-87b3-10188aa82c29.png)
