### PR TITLE
Changing api documentation for jsx transformer

### DIFF
--- a/npm-react-tools/README.md
+++ b/npm-react-tools/README.md
@@ -37,7 +37,7 @@ option | values | default
 -------|--------|---------
 `sourceMap` | `true`: append inline source map at the end of the transformed source | `false`
 `harmony` | `true`: enable ES6 features | `false`
-`filename` | the output filename for the source map | `"source.js"`
+`sourceFilename` | the output filename for the source map | `"source.js"`
 `stripTypes` | `true`: strips out type annotations | `false`
 
 ```js


### PR DESCRIPTION
Hi in chrome debugger, the files that use sourcemaps from the transformer get "null" as the filename during debug, https://github.com/facebook/react/blob/master/main.js#L15 "sourceFilename" is used instead of "filename" to specify the filename in the sourcemap.
