### PR TITLE
Add warning for using mixin instead of mixins

### DIFF
--- a/src/class/ReactClass.js
+++ b/src/class/ReactClass.js
@@ -656,6 +656,12 @@ var ReactClass = {
     );
 
     if (__DEV__) {
+      if (spec.hasOwnProperty('mixin') && Array.isArray(spec.mixin) && !spec.hasOwnProperty('mixins')) {
+        console.warn(
+          (spec.displayName || 'A component') + ' is trying to use `mixin`. ' +
+          'Did you mean to use `mixins`?'
+        );
+      }
       if (Constructor.prototype.componentShouldUpdate) {
         monitorCodeUse(
           'react_component_should_update_warning',

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -910,6 +910,23 @@ describe('ReactCompositeComponent', function() {
     }
   });
 
+  it('should warn if mixin is supplied instead of mixins', function () {
+    var warn = spyOn(console, 'warn');
+    console.warn = mocks.getMockFunction();
+
+    var mixinTypoClass = React.createClass({
+      mixin: [],
+
+      render: function() {
+        return <div />;
+      }
+    });
+    expect(console.warn.mock.calls.length).toBe(1);
+    expect(console.warn.mock.calls[0][0]).toBe(
+      'mixinTypoClass is trying to use `mixin`. Did you mean to use `mixins`?'
+    );
+  });
+
   it('should warn when mispelling shouldComponentUpdate', function() {
     var warn = console.warn;
     console.warn = mocks.getMockFunction();


### PR DESCRIPTION
I've made this typo at least a dozen times and keep making it. I think it'd be nice to have in __DEV__...