### PR TITLE
Extending period in which click events are ignored

### DIFF
--- a/src/browser/eventPlugins/TapEventPlugin.js
+++ b/src/browser/eventPlugins/TapEventPlugin.js
@@ -85,7 +85,7 @@ var eventTypes = {
 
 var usedTouch = false;
 var usedTouchTime = 0;
-var TOUCH_DELAY = 500;
+var TOUCH_DELAY = 1000;
 
 var TapEventPlugin = {
 


### PR DESCRIPTION
Tap plugin ignores click events that follow touch events in small timeframe to deal with iOS simulated click events.
According to apple documentation, these simulated clicks are fired 300ms after touch start/end happens.
Unfortunately, that is not always true, and the time is variable(probably with cpu load).
Ignore time frame was setup to 500ms, but once during testing click events were happening in ~600ms after touch events. 

To make sure these problems no longer happen, 1000ms should provide large enough time frame.
