### PR TITLE
Bring in jsfiddle integration script, add harmony

### DIFF
--- a/docs/_js/jsfiddle-integration.js
+++ b/docs/_js/jsfiddle-integration.js
@@ -1,0 +1,11 @@
+(function() {
+  var tag = document.querySelector(
+    'script[type="application/javascript;version=1.7"]'
+  );
+  if (!tag || tag.textContent.indexOf('window.onload=function(){') !== -1) {
+    alert('Bad JSFiddle configuration, please fork the original React JSFiddle');
+  }
+  tag.setAttribute('type', 'text/jsx;harmony=true');
+  tag.textContent = tag.textContent.replace(/^\/\/<!\[CDATA\[/, '');
+})();
+


### PR DESCRIPTION
Brings in http://dragon.ak.fbcdn.net/hphotos-ak-prn1/851561_341095626017279_6573_n.js which is currently living at http://fb.me/react-js-fiddle-integration.js. We should just serve from GitHub for this so its easier to update. In fact we can skip the fb.me hop entirely and update the base fiddle to point at facebook.github.io/js/jsfiddle-integration.js

cc @vjeux 
