### PR TITLE
Support SVG vector-effect attribute

### DIFF
--- a/docs/docs/ref-04-tags-and-attributes.md
+++ b/docs/docs/ref-04-tags-and-attributes.md
@@ -79,5 +79,6 @@ cx cy d dx dy fill fillOpacity fontFamily fontSize fx fy gradientTransform
 gradientUnits markerEnd markerMid markerStart offset opacity
 patternContentUnits patternUnits points preserveAspectRatio r rx ry
 spreadMethod stopColor stopOpacity stroke strokeDasharray strokeLinecap
-strokeOpacity strokeWidth textAnchor transform version viewBox x1 x2 x y1 y2 y
+strokeOpacity strokeWidth textAnchor transform vectorEffect version viewBox x1
+x2 x y1 y2 y
 ```

--- a/src/browser/ui/dom/SVGDOMPropertyConfig.js
+++ b/src/browser/ui/dom/SVGDOMPropertyConfig.js
@@ -54,6 +54,7 @@ var SVGDOMPropertyConfig = {
     strokeWidth: MUST_USE_ATTRIBUTE,
     textAnchor: MUST_USE_ATTRIBUTE,
     transform: MUST_USE_ATTRIBUTE,
+    vectorEffect: MUST_USE_ATTRIBUTE,
     version: MUST_USE_ATTRIBUTE,
     viewBox: MUST_USE_ATTRIBUTE,
     x1: MUST_USE_ATTRIBUTE,
@@ -83,6 +84,7 @@ var SVGDOMPropertyConfig = {
     strokeOpacity: 'stroke-opacity',
     strokeWidth: 'stroke-width',
     textAnchor: 'text-anchor',
+    vectorEffect: 'vector-effect',
     viewBox: 'viewBox'
   }
 };


### PR DESCRIPTION
Support for SVG elements to define the `vector-effect` attribute introduced in SVG Tiny 1.2. Read more about it [here](http://www.w3.org/TR/SVGMobile12/painting.html#NonScalingStroke).