### PR TITLE
Separate React Composite and Class

### DIFF
--- a/src/browser/ui/ReactBrowserComponentMixin.js
+++ b/src/browser/ui/ReactBrowserComponentMixin.js
@@ -11,7 +11,6 @@
 
 "use strict";
 
-var ReactEmptyComponent = require('ReactEmptyComponent');
 var ReactMount = require('ReactMount');
 
 var invariant = require('invariant');
@@ -29,10 +28,7 @@ var ReactBrowserComponentMixin = {
       this.isMounted(),
       'getDOMNode(): A component must be mounted to have a DOM node.'
     );
-    if (ReactEmptyComponent.isNullComponentID(this._rootNodeID)) {
-      return null;
-    }
-    return ReactMount.getNode(this._rootNodeID);
+    return ReactMount.getNodeFromInstance(this);
   }
 };
 

--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -21,41 +21,39 @@ describe('ReactDOMComponent', function() {
   describe('updateDOM', function() {
     var React;
     var ReactTestUtils;
-    var transaction;
 
     beforeEach(function() {
       React = require('React');
       ReactTestUtils = require('ReactTestUtils');
-
-      var ReactReconcileTransaction = require('ReactReconcileTransaction');
-      transaction = new ReactReconcileTransaction();
     });
 
     it("should handle className", function() {
-      var stub = ReactTestUtils.renderIntoDocument(<div style={{}} />);
+      var container = document.createElement('div');
+      React.render(<div style={{}} />, container);
 
-      stub.receiveComponent({props: { className: 'foo' }}, transaction);
-      expect(stub.getDOMNode().className).toEqual('foo');
-      stub.receiveComponent({props: { className: 'bar' }}, transaction);
-      expect(stub.getDOMNode().className).toEqual('bar');
-      stub.receiveComponent({props: { className: null }}, transaction);
-      expect(stub.getDOMNode().className).toEqual('');
+      React.render(<div className={'foo'} />, container);
+      expect(container.firstChild.className).toEqual('foo');
+      React.render(<div className={'bar'} />, container);
+      expect(container.firstChild.className).toEqual('bar');
+      React.render(<div className={null} />, container);
+      expect(container.firstChild.className).toEqual('');
     });
 
     it("should gracefully handle various style value types", function() {
-      var stub = ReactTestUtils.renderIntoDocument(<div style={{}} />);
-      var stubStyle = stub.getDOMNode().style;
+      var container = document.createElement('div');
+      React.render(<div style={{}} />, container);
+      var stubStyle = container.firstChild.style;
 
       // set initial style
       var setup = { display: 'block', left: '1', top: 2, fontFamily: 'Arial' };
-      stub.receiveComponent({props: { style: setup }}, transaction);
+      React.render(<div style={setup} />, container);
       expect(stubStyle.display).toEqual('block');
       expect(stubStyle.left).toEqual('1px');
       expect(stubStyle.fontFamily).toEqual('Arial');
 
       // reset the style to their default state
       var reset = { display: '', left: null, top: false, fontFamily: true };
-      stub.receiveComponent({props: { style: reset }}, transaction);
+      React.render(<div style={reset} />, container);
       expect(stubStyle.display).toEqual('');
       expect(stubStyle.left).toEqual('');
       expect(stubStyle.top).toEqual('');
@@ -64,34 +62,35 @@ describe('ReactDOMComponent', function() {
 
     it("should update styles when mutating style object", function() {
       var styles = { display: 'none', fontFamily: 'Arial', lineHeight: 1.2 };
-      var stub = ReactTestUtils.renderIntoDocument(<div style={styles} />);
+      var container = document.createElement('div');
+      React.render(<div style={styles} />, container);
 
-      var stubStyle = stub.getDOMNode().style;
+      var stubStyle = container.firstChild.style;
       stubStyle.display = styles.display;
       stubStyle.fontFamily = styles.fontFamily;
 
       styles.display = 'block';
 
-      stub.receiveComponent({props: { style: styles }}, transaction);
+      React.render(<div style={styles} />, container);
       expect(stubStyle.display).toEqual('block');
       expect(stubStyle.fontFamily).toEqual('Arial');
       expect(stubStyle.lineHeight).toEqual('1.2');
 
       styles.fontFamily = 'Helvetica';
 
-      stub.receiveComponent({props: { style: styles }}, transaction);
+      React.render(<div style={styles} />, container);
       expect(stubStyle.display).toEqual('block');
       expect(stubStyle.fontFamily).toEqual('Helvetica');
       expect(stubStyle.lineHeight).toEqual('1.2');
 
       styles.lineHeight = 0.5;
 
-      stub.receiveComponent({props: { style: styles }}, transaction);
+      React.render(<div style={styles} />, container);
       expect(stubStyle.display).toEqual('block');
       expect(stubStyle.fontFamily).toEqual('Helvetica');
       expect(stubStyle.lineHeight).toEqual('0.5');
 
-      stub.receiveComponent({props: { style: undefined }}, transaction);
+      React.render(<div style={undefined} />, container);
       expect(stubStyle.display).toBe('');
       expect(stubStyle.fontFamily).toBe('');
       expect(stubStyle.lineHeight).toBe('');
@@ -99,92 +98,96 @@ describe('ReactDOMComponent', function() {
 
     it("should update styles if initially null", function() {
       var styles = null;
-      var stub = ReactTestUtils.renderIntoDocument(<div style={styles} />);
+      var container = document.createElement('div');
+      React.render(<div style={styles} />, container);
 
-      var stubStyle = stub.getDOMNode().style;
+      var stubStyle = container.firstChild.style;
 
       styles = {display: 'block'};
 
-      stub.receiveComponent({props: { style: styles }}, transaction);
+      React.render(<div style={styles} />, container);
       expect(stubStyle.display).toEqual('block');
     });
 
     it("should remove attributes", function() {
-      var stub = ReactTestUtils.renderIntoDocument(<img height='17' />);
+      var container = document.createElement('div');
+      React.render(<img height='17' />, container);
 
-      expect(stub.getDOMNode().hasAttribute('height')).toBe(true);
-      stub.receiveComponent({props: {}}, transaction);
-      expect(stub.getDOMNode().hasAttribute('height')).toBe(false);
+      expect(container.firstChild.hasAttribute('height')).toBe(true);
+      React.render(<img />, container);
+      expect(container.firstChild.hasAttribute('height')).toBe(false);
     });
 
     it("should remove properties", function() {
-      var stub = ReactTestUtils.renderIntoDocument(<div className='monkey' />);
+      var container = document.createElement('div');
+      React.render(<div className='monkey' />, container);
 
-      expect(stub.getDOMNode().className).toEqual('monkey');
-      stub.receiveComponent({props: {}}, transaction);
-      expect(stub.getDOMNode().className).toEqual('');
+      expect(container.firstChild.className).toEqual('monkey');
+      React.render(<div />, container);
+      expect(container.firstChild.className).toEqual('');
     });
 
     it("should clear a single style prop when changing 'style'", function() {
       var styles = {display: 'none', color: 'red'};
-      var stub = ReactTestUtils.renderIntoDocument(<div style={styles} />);
+      var container = document.createElement('div');
+      React.render(<div style={styles} />, container);
 
-      var stubStyle = stub.getDOMNode().style;
+      var stubStyle = container.firstChild.style;
 
       styles = {color: 'green'};
-      stub.receiveComponent({props: { style: styles }}, transaction);
+      React.render(<div style={styles} />, container);
       expect(stubStyle.display).toEqual('');
       expect(stubStyle.color).toEqual('green');
     });
 
     it("should clear all the styles when removing 'style'", function() {
       var styles = {display: 'none', color: 'red'};
-      var stub = ReactTestUtils.renderIntoDocument(<div style={styles} />);
+      var container = document.createElement('div');
+      React.render(<div style={styles} />, container);
 
-      var stubStyle = stub.getDOMNode().style;
+      var stubStyle = container.firstChild.style;
 
-      stub.receiveComponent({props: {}}, transaction);
+      React.render(<div />, container);
       expect(stubStyle.display).toEqual('');
       expect(stubStyle.color).toEqual('');
     });
 
     it("should empty element when removing innerHTML", function() {
-      var stub = ReactTestUtils.renderIntoDocument(
-        <div dangerouslySetInnerHTML={{__html: ':)'}} />
-      );
+      var container = document.createElement('div');
+      React.render(<div dangerouslySetInnerHTML={{__html: ':)'}} />, container);
 
-      expect(stub.getDOMNode().innerHTML).toEqual(':)');
-      stub.receiveComponent({props: {}}, transaction);
-      expect(stub.getDOMNode().innerHTML).toEqual('');
+      expect(container.firstChild.innerHTML).toEqual(':)');
+      React.render(<div />, container);
+      expect(container.firstChild.innerHTML).toEqual('');
     });
 
     it("should transition from string content to innerHTML", function() {
-      var stub = ReactTestUtils.renderIntoDocument(
-        <div>hello</div>
-      );
+      var container = document.createElement('div');
+      React.render(<div>hello</div>, container);
 
-      expect(stub.getDOMNode().innerHTML).toEqual('hello');
-      stub.receiveComponent(
-        {props: {dangerouslySetInnerHTML: {__html: 'goodbye'}}},
-        transaction
+      expect(container.firstChild.innerHTML).toEqual('hello');
+      React.render(
+        <div dangerouslySetInnerHTML={{__html: 'goodbye'}} />,
+        container
       );
-      expect(stub.getDOMNode().innerHTML).toEqual('goodbye');
+      expect(container.firstChild.innerHTML).toEqual('goodbye');
     });
 
     it("should transition from innerHTML to string content", function() {
-      var stub = ReactTestUtils.renderIntoDocument(
-        <div dangerouslySetInnerHTML={{__html: 'bonjour'}} />
-      );
+      var container = document.createElement('div');
+      React.render(<div dangerouslySetInnerHTML={{__html: 'bonjour'}} />
+      , container);
 
-      expect(stub.getDOMNode().innerHTML).toEqual('bonjour');
-      stub.receiveComponent({props: {children: 'adieu'}}, transaction);
-      expect(stub.getDOMNode().innerHTML).toEqual('adieu');
+      expect(container.firstChild.innerHTML).toEqual('bonjour');
+      React.render(<div>adieu</div>, container);
+      expect(container.firstChild.innerHTML).toEqual('adieu');
     });
 
     it("should not incur unnecessary DOM mutations", function() {
-      var stub = ReactTestUtils.renderIntoDocument(<div value="" />);
+      var container = document.createElement('div');
+      React.render(<div value="" />, container);
 
-      var node = stub.getDOMNode();
+      var node = container.firstChild;
       var nodeValue = ''; // node.value always returns undefined
       var nodeValueSetter = mocks.getMockFunction();
       Object.defineProperty(node, 'value', {
@@ -196,10 +199,10 @@ describe('ReactDOMComponent', function() {
         })
       });
 
-      stub.receiveComponent({props: {value: ''}}, transaction);
+      React.render(<div value="" />, container);
       expect(nodeValueSetter.mock.calls.length).toBe(0);
 
-      stub.receiveComponent({props: {}}, transaction);
+      React.render(<div />, container);
       expect(nodeValueSetter.mock.calls.length).toBe(1);
     });
   });

--- a/src/browser/ui/__tests__/ReactRenderDocument-test.js
+++ b/src/browser/ui/__tests__/ReactRenderDocument-test.js
@@ -14,6 +14,7 @@
 "use strict";
 
 var React;
+var ReactInstanceMap;
 var ReactMount;
 
 var getTestDocument;
@@ -32,6 +33,7 @@ describe('rendering React components at document', function() {
     require('mock-modules').dumpCache();
 
     React = require('React');
+    ReactInstanceMap = require('ReactInstanceMap');
     ReactMount = require('ReactMount');
     getTestDocument = require('getTestDocument');
 
@@ -61,8 +63,10 @@ describe('rendering React components at document', function() {
     var component = React.render(<Root />, testDocument);
     expect(testDocument.body.innerHTML).toBe('Hello world');
 
+    // TODO: This is a bad test. I have no idea what this is testing.
+    // Node IDs is an implementation detail and not part of the public API.
     var componentID = ReactMount.getReactRootID(testDocument);
-    expect(componentID).toBe(component._rootNodeID);
+    expect(componentID).toBe(ReactInstanceMap.get(component)._rootNodeID);
   });
 
   it('should not be able to unmount component from document node', function() {

--- a/src/core/ReactComponent.js
+++ b/src/core/ReactComponent.js
@@ -442,6 +442,18 @@ var ReactComponent = {
         return null;
       }
       return owner.refs[ref];
+    },
+
+    /**
+     * Get the publicly accessible representation of this component - i.e. what
+     * is exposed by refs and renderComponent. Can be null for stateless
+     * components.
+     *
+     * @return {?ReactComponent} the actual sibling Component.
+     * @internal
+     */
+    getPublicInstance: function() {
+      return this;
     }
   }
 };

--- a/src/core/ReactElementValidator.js
+++ b/src/core/ReactElementValidator.js
@@ -48,7 +48,9 @@ var NUMERIC_PROPERTY_REGEX = /^\d+$/;
  */
 function getCurrentOwnerDisplayName() {
   var current = ReactCurrentOwner.current;
-  return current && current.constructor.displayName || undefined;
+  return (
+    current && current.getPublicInstance().constructor.displayName || undefined
+  );
 }
 
 /**
@@ -128,7 +130,8 @@ function warnAndMonitorForKeyUse(warningID, message, component, parentType) {
       component._owner &&
       component._owner !== ReactCurrentOwner.current) {
     // Name of the component that originally created this child.
-    childOwnerName = component._owner.constructor.displayName;
+    childOwnerName =
+      component._owner.getPublicInstance().constructor.displayName;
 
     message += ` It was passed a child from ${childOwnerName}.`;
   }

--- a/src/core/ReactInstanceMap.js
+++ b/src/core/ReactInstanceMap.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2013-2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactInstanceMap
+ */
+
+"use strict";
+
+/**
+ * `ReactInstanceMap` maintains a mapping from a public facing stateful
+ * instance (key) and the internal representation (value). This allows public
+ * methods to accept the user facing instance as an argument and map them back
+ * to internal methods.
+ */
+
+// TODO: Replace this with ES6: var ReactInstanceMap = new Map();
+var ReactInstanceMap = {
+
+  /**
+   * This API should be called `delete` but we'd have to make sure to always
+   * transform these to strings for IE support. When this transform is fully
+   * supported we can rename it.
+   */
+  remove: function(key) {
+    key._reactInternalInstance = undefined;
+  },
+
+  get: function(key) {
+    return key._reactInternalInstance;
+  },
+
+  has: function(key) {
+    return key._reactInternalInstance !== undefined;
+  },
+
+  set: function(key, value) {
+    key._reactInternalInstance = value;
+  }
+
+};
+
+module.exports = ReactInstanceMap;

--- a/src/core/ReactOwner.js
+++ b/src/core/ReactOwner.js
@@ -100,7 +100,7 @@ var ReactOwner = {
     );
     // Check that `component` is still the current ref because we do not want to
     // detach the ref if another component stole it.
-    if (owner.refs[ref] === component) {
+    if (owner.getPublicInstance().refs[ref] === component.getPublicInstance()) {
       owner.detachRef(ref);
     }
   },
@@ -113,7 +113,8 @@ var ReactOwner = {
   Mixin: {
 
     construct: function() {
-      this.refs = emptyObject;
+      var inst = this.getPublicInstance();
+      inst.refs = emptyObject;
     },
 
     /**
@@ -125,13 +126,16 @@ var ReactOwner = {
      * @private
      */
     attachRef: function(ref, component) {
+      // TODO: Remove this invariant. This is never exposed and cannot be called
+      // by user code. The unit test is already removed.
       invariant(
         component.isOwnedBy(this),
         'attachRef(%s, ...): Only a component\'s owner can store a ref to it.',
         ref
       );
-      var refs = this.refs === emptyObject ? (this.refs = {}) : this.refs;
-      refs[ref] = component;
+      var inst = this.getPublicInstance();
+      var refs = inst.refs === emptyObject ? (inst.refs = {}) : inst.refs;
+      refs[ref] = component.getPublicInstance();
     },
 
     /**
@@ -142,7 +146,8 @@ var ReactOwner = {
      * @private
      */
     detachRef: function(ref) {
-      delete this.refs[ref];
+      var refs = this.getPublicInstance().refs;
+      delete refs[ref];
     }
 
   }

--- a/src/core/ReactPropTransferer.js
+++ b/src/core/ReactPropTransferer.js
@@ -129,7 +129,7 @@ var ReactPropTransferer = {
      */
     transferPropsTo: function(element) {
       invariant(
-        element._owner === this,
+        element._owner && element._owner.getPublicInstance() === this,
         '%s: You can\'t call transferPropsTo() on a component that you ' +
         'don\'t own, %s. This usually means you are calling ' +
         'transferPropsTo() on a component passed in as props or children.',

--- a/src/core/ReactRef.js
+++ b/src/core/ReactRef.js
@@ -89,7 +89,7 @@ assign(ReactRef.prototype, {
 });
 
 ReactRef.attachRef = function(ref, value) {
-  ref._value = value;
+  ref._value = value.getPublicInstance();
 };
 
 ReactRef.detachRef = function(ref, value) {

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -623,6 +623,63 @@ describe('ReactCompositeComponent', function() {
     );
   });
 
+  it('should not allow `setState` on unmounted components', function() {
+    var container = document.createElement('div');
+    document.documentElement.appendChild(container);
+
+    var Component = React.createClass({
+      getInitialState: function() {
+        return { value: 0 };
+      },
+      render: function() {
+        return <div />;
+      }
+    });
+
+    var instance = <Component />;
+    expect(instance.setState).not.toBeDefined();
+
+    instance = React.render(instance, container);
+    expect(function() {
+      instance.setState({ value: 1 });
+    }).not.toThrow();
+
+    React.unmountComponentAtNode(container);
+    expect(function() {
+      instance.setState({ value: 2 });
+    }).toThrow(
+      'Invariant Violation: setState(...): Can only update a mounted or ' +
+      'mounting component.'
+    );
+  });
+
+  it('should not allow `setProps` on unmounted components', function() {
+    var container = document.createElement('div');
+    document.documentElement.appendChild(container);
+
+    var Component = React.createClass({
+      render: function() {
+        return <div />;
+      }
+    });
+
+    var instance = <Component />;
+    expect(instance.setProps).not.toBeDefined();
+
+    instance = React.render(instance, container);
+    expect(function() {
+      instance.setProps({ value: 1 });
+    }).not.toThrow();
+
+    React.unmountComponentAtNode(container);
+    expect(function() {
+      instance.setProps({ value: 2 });
+    }).toThrow(
+      'Invariant Violation: setProps(...): Can only update a mounted ' +
+      'component.'
+    );
+  });
+
   it('should cleanup even if render() fatals', function() {
     var BadComponent = React.createClass({
       render: function() {

--- a/src/core/__tests__/ReactCompositeComponentState-test.js
+++ b/src/core/__tests__/ReactCompositeComponentState-test.js
@@ -14,6 +14,7 @@
 var mocks = require('mocks');
 
 var React;
+var ReactInstanceMap;
 var ReactTestUtils;
 var reactComponentExpect;
 
@@ -23,6 +24,7 @@ describe('ReactCompositeComponent-state', function() {
 
   beforeEach(function() {
     React = require('React');
+    ReactInstanceMap = require('ReactInstanceMap');
     ReactTestUtils = require('ReactTestUtils');
     reactComponentExpect = require('reactComponentExpect');
 
@@ -31,10 +33,13 @@ describe('ReactCompositeComponent-state', function() {
         if (state) {
           this.props.stateListener(from, state && state.color);
         } else {
+          var internalInstance = ReactInstanceMap.get(this);
+          var pendingState = internalInstance ? internalInstance._pendingState :
+                             null;
           this.props.stateListener(
             from,
             this.state && this.state.color,
-            this._pendingState && this._pendingState.color
+            pendingState && pendingState.color
           );
         }
       },
@@ -99,13 +104,17 @@ describe('ReactCompositeComponent-state', function() {
   });
 
   it('should support setting state', function() {
+    var container = document.createElement('div');
+    document.documentElement.appendChild(container);
+
     var stateListener = mocks.getMockFunction();
     var instance = <TestComponent stateListener={stateListener} />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
+    instance = React.render(instance, container);
     instance.setProps({nextColor: 'green'});
     instance.setFavoriteColor('blue');
     instance.forceUpdate();
-    instance.unmountComponent();
+
+    React.unmountComponentAtNode(container);
 
     expect(stateListener.mock.calls).toEqual([
       // there is no state when getInitialState() is called

--- a/src/core/__tests__/ReactElement-test.js
+++ b/src/core/__tests__/ReactElement-test.js
@@ -138,7 +138,7 @@ describe('ReactElement', function() {
 
     var instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
 
-    expect(element._owner).toBe(instance);
+    expect(element._owner.getPublicInstance()).toBe(instance);
   });
 
   it('merges an additional argument onto the children prop', function() {

--- a/src/core/__tests__/ReactInstanceHandles-test.js
+++ b/src/core/__tests__/ReactInstanceHandles-test.js
@@ -62,6 +62,14 @@ describe('ReactInstanceHandles', function() {
     });
   }
 
+  function getNodeID(instance) {
+    if (instance === null) {
+      return '';
+    }
+    var internal = ReactTestUtils.getInternalRepresentation(instance);
+    return internal._rootNodeID;
+  }
+
   beforeEach(function() {
     ReactInstanceHandles = require('ReactInstanceHandles');
     aggregatedArgs = [];
@@ -178,17 +186,17 @@ describe('ReactInstanceHandles', function() {
 
     it("should traverse two phase across component boundary", function() {
       var parent = renderParentIntoDocument();
-      var targetID = parent.refs.P_P1_C1.refs.DIV_1._rootNodeID;
+      var targetID = getNodeID(parent.refs.P_P1_C1.refs.DIV_1);
       var expectedAggregation = [
-        {id: parent.refs.P._rootNodeID, isUp: false, arg: ARG},
-        {id: parent.refs.P_P1._rootNodeID, isUp: false, arg: ARG},
-        {id: parent.refs.P_P1_C1.refs.DIV._rootNodeID, isUp: false, arg: ARG},
-        {id: parent.refs.P_P1_C1.refs.DIV_1._rootNodeID, isUp: false, arg: ARG},
+        {id: getNodeID(parent.refs.P), isUp: false, arg: ARG},
+        {id: getNodeID(parent.refs.P_P1), isUp: false, arg: ARG},
+        {id: getNodeID(parent.refs.P_P1_C1.refs.DIV), isUp: false, arg: ARG},
+        {id: getNodeID(parent.refs.P_P1_C1.refs.DIV_1), isUp: false, arg: ARG},
 
-        {id: parent.refs.P_P1_C1.refs.DIV_1._rootNodeID, isUp: true, arg: ARG},
-        {id: parent.refs.P_P1_C1.refs.DIV._rootNodeID, isUp: true, arg: ARG},
-        {id: parent.refs.P_P1._rootNodeID, isUp: true, arg: ARG},
-        {id: parent.refs.P._rootNodeID, isUp: true, arg: ARG}
+        {id: getNodeID(parent.refs.P_P1_C1.refs.DIV_1), isUp: true, arg: ARG},
+        {id: getNodeID(parent.refs.P_P1_C1.refs.DIV), isUp: true, arg: ARG},
+        {id: getNodeID(parent.refs.P_P1), isUp: true, arg: ARG},
+        {id: getNodeID(parent.refs.P), isUp: true, arg: ARG}
       ];
       ReactInstanceHandles.traverseTwoPhase(targetID, argAggregator, ARG);
       expect(aggregatedArgs).toEqual(expectedAggregation);
@@ -196,10 +204,10 @@ describe('ReactInstanceHandles', function() {
 
     it("should traverse two phase at shallowest node", function() {
       var parent = renderParentIntoDocument();
-      var targetID = parent.refs.P._rootNodeID;
+      var targetID = getNodeID(parent.refs.P);
       var expectedAggregation = [
-        {id: parent.refs.P._rootNodeID, isUp: false, arg: ARG},
-        {id: parent.refs.P._rootNodeID, isUp: true, arg: ARG}
+        {id: getNodeID(parent.refs.P), isUp: false, arg: ARG},
+        {id: getNodeID(parent.refs.P), isUp: true, arg: ARG}
       ];
       ReactInstanceHandles.traverseTwoPhase(targetID, argAggregator, ARG);
       expect(aggregatedArgs).toEqual(expectedAggregation);
@@ -218,8 +226,8 @@ describe('ReactInstanceHandles', function() {
 
     it("should not traverse if enter/leave the same node", function() {
       var parent = renderParentIntoDocument();
-      var leaveID = parent.refs.P_P1_C1.refs.DIV_1._rootNodeID;
-      var enterID = parent.refs.P_P1_C1.refs.DIV_1._rootNodeID;
+      var leaveID = getNodeID(parent.refs.P_P1_C1.refs.DIV_1);
+      var enterID = getNodeID(parent.refs.P_P1_C1.refs.DIV_1);
       var expectedAggregation = [];
       ReactInstanceHandles.traverseEnterLeave(
         leaveID, enterID, argAggregator, ARG, ARG2
@@ -229,12 +237,12 @@ describe('ReactInstanceHandles', function() {
 
     it("should traverse enter/leave to sibling - avoids parent", function() {
       var parent = renderParentIntoDocument();
-      var leaveID = parent.refs.P_P1_C1.refs.DIV_1._rootNodeID;
-      var enterID = parent.refs.P_P1_C1.refs.DIV_2._rootNodeID;
+      var leaveID = getNodeID(parent.refs.P_P1_C1.refs.DIV_1);
+      var enterID = getNodeID(parent.refs.P_P1_C1.refs.DIV_2);
       var expectedAggregation = [
-        {id: parent.refs.P_P1_C1.refs.DIV_1._rootNodeID, isUp: true, arg: ARG},
+        {id: getNodeID(parent.refs.P_P1_C1.refs.DIV_1), isUp: true, arg: ARG},
         // enter/leave shouldn't fire antyhing on the parent
-        {id: parent.refs.P_P1_C1.refs.DIV_2._rootNodeID, isUp: false, arg: ARG2}
+        {id: getNodeID(parent.refs.P_P1_C1.refs.DIV_2), isUp: false, arg: ARG2}
       ];
       ReactInstanceHandles.traverseEnterLeave(
         leaveID, enterID, argAggregator, ARG, ARG2
@@ -244,10 +252,10 @@ describe('ReactInstanceHandles', function() {
 
     it("should traverse enter/leave to parent - avoids parent", function() {
       var parent = renderParentIntoDocument();
-      var leaveID = parent.refs.P_P1_C1.refs.DIV_1._rootNodeID;
-      var enterID = parent.refs.P_P1_C1.refs.DIV._rootNodeID;
+      var leaveID = getNodeID(parent.refs.P_P1_C1.refs.DIV_1);
+      var enterID = getNodeID(parent.refs.P_P1_C1.refs.DIV);
       var expectedAggregation = [
-        {id: parent.refs.P_P1_C1.refs.DIV_1._rootNodeID, isUp: true, arg: ARG}
+        {id: getNodeID(parent.refs.P_P1_C1.refs.DIV_1), isUp: true, arg: ARG}
       ];
       ReactInstanceHandles.traverseEnterLeave(
         leaveID, enterID, argAggregator, ARG, ARG2
@@ -258,11 +266,11 @@ describe('ReactInstanceHandles', function() {
     it("should enter from the window", function() {
       var parent = renderParentIntoDocument();
       var leaveID = ''; // From the window or outside of the React sandbox.
-      var enterID = parent.refs.P_P1_C1.refs.DIV._rootNodeID;
+      var enterID = getNodeID(parent.refs.P_P1_C1.refs.DIV);
       var expectedAggregation = [
-        {id: parent.refs.P._rootNodeID, isUp: false, arg: ARG2},
-        {id: parent.refs.P_P1._rootNodeID, isUp: false, arg: ARG2},
-        {id: parent.refs.P_P1_C1.refs.DIV._rootNodeID, isUp: false, arg: ARG2}
+        {id: getNodeID(parent.refs.P), isUp: false, arg: ARG2},
+        {id: getNodeID(parent.refs.P_P1), isUp: false, arg: ARG2},
+        {id: getNodeID(parent.refs.P_P1_C1.refs.DIV), isUp: false, arg: ARG2}
       ];
       ReactInstanceHandles.traverseEnterLeave(
         leaveID, enterID, argAggregator, ARG, ARG2
@@ -273,9 +281,9 @@ describe('ReactInstanceHandles', function() {
     it("should enter from the window to the shallowest", function() {
       var parent = renderParentIntoDocument();
       var leaveID = ''; // From the window or outside of the React sandbox.
-      var enterID = parent.refs.P._rootNodeID;
+      var enterID = getNodeID(parent.refs.P);
       var expectedAggregation = [
-        {id: parent.refs.P._rootNodeID, isUp: false, arg: ARG2}
+        {id: getNodeID(parent.refs.P), isUp: false, arg: ARG2}
       ];
       ReactInstanceHandles.traverseEnterLeave(
         leaveID, enterID, argAggregator, ARG, ARG2
@@ -286,11 +294,11 @@ describe('ReactInstanceHandles', function() {
     it("should leave to the window", function() {
       var parent = renderParentIntoDocument();
       var enterID = ''; // From the window or outside of the React sandbox.
-      var leaveID = parent.refs.P_P1_C1.refs.DIV._rootNodeID;
+      var leaveID = getNodeID(parent.refs.P_P1_C1.refs.DIV);
       var expectedAggregation = [
-        {id: parent.refs.P_P1_C1.refs.DIV._rootNodeID, isUp: true, arg: ARG},
-        {id: parent.refs.P_P1._rootNodeID, isUp: true, arg: ARG},
-        {id: parent.refs.P._rootNodeID, isUp: true, arg: ARG}
+        {id: getNodeID(parent.refs.P_P1_C1.refs.DIV), isUp: true, arg: ARG},
+        {id: getNodeID(parent.refs.P_P1), isUp: true, arg: ARG},
+        {id: getNodeID(parent.refs.P), isUp: true, arg: ARG}
       ];
       ReactInstanceHandles.traverseEnterLeave(
         leaveID, enterID, argAggregator, ARG, ARG2
@@ -301,11 +309,11 @@ describe('ReactInstanceHandles', function() {
     it("should leave to the window from the shallowest", function() {
       var parent = renderParentIntoDocument();
       var enterID = ''; // From the window or outside of the React sandbox.
-      var leaveID = parent.refs.P_P1_C1.refs.DIV._rootNodeID;
+      var leaveID = getNodeID(parent.refs.P_P1_C1.refs.DIV);
       var expectedAggregation = [
-        {id: parent.refs.P_P1_C1.refs.DIV._rootNodeID, isUp: true, arg: ARG},
-        {id: parent.refs.P_P1._rootNodeID, isUp: true, arg: ARG},
-        {id: parent.refs.P._rootNodeID, isUp: true, arg: ARG}
+        {id: getNodeID(parent.refs.P_P1_C1.refs.DIV), isUp: true, arg: ARG},
+        {id: getNodeID(parent.refs.P_P1), isUp: true, arg: ARG},
+        {id: getNodeID(parent.refs.P), isUp: true, arg: ARG}
       ];
       ReactInstanceHandles.traverseEnterLeave(
         leaveID, enterID, argAggregator, ARG, ARG2
@@ -320,9 +328,9 @@ describe('ReactInstanceHandles', function() {
       expect(
         ReactInstanceHandles._getNextDescendantID(
           '',
-          parent.refs.P_P1._rootNodeID
+          getNodeID(parent.refs.P_P1)
         )
-      ).toBe(parent.refs.P._rootNodeID);
+      ).toBe(getNodeID(parent.refs.P));
     });
 
     it("should return window for next descendent towards window", function() {
@@ -333,10 +341,10 @@ describe('ReactInstanceHandles', function() {
       var parent = renderParentIntoDocument();
       expect(
         ReactInstanceHandles._getNextDescendantID(
-          parent.refs.P_P1._rootNodeID,
-          parent.refs.P_P1._rootNodeID
+          getNodeID(parent.refs.P_P1),
+          getNodeID(parent.refs.P_P1)
         )
-      ).toBe(parent.refs.P_P1._rootNodeID);
+      ).toBe(getNodeID(parent.refs.P_P1));
     });
   });
 
@@ -345,19 +353,19 @@ describe('ReactInstanceHandles', function() {
       var parent = renderParentIntoDocument();
       var ancestors = [
         // Common ancestor from window to deep element is ''.
-        { one: {_rootNodeID: ''},
+        { one: null,
           two: parent.refs.P_P1_C1.refs.DIV_1,
-          com: {_rootNodeID: ''}
+          com: null
         },
         // Same as previous - reversed direction.
         { one: parent.refs.P_P1_C1.refs.DIV_1,
-          two: {_rootNodeID: ''},
-          com: {_rootNodeID: ''}
+          two: null,
+          com: null
         },
         // Common ancestor from window to shallow id is ''.
         { one: parent.refs.P,
-          two: {_rootNodeID: ''},
-          com: {_rootNodeID: ''}
+          two: null,
+          com: null
         },
         // Common ancestor with self is self.
         { one: parent.refs.P_P1_C1.refs.DIV_1,
@@ -401,10 +409,10 @@ describe('ReactInstanceHandles', function() {
       for (i = 0; i < ancestors.length; i++) {
         var plan = ancestors[i];
         var firstCommon = ReactInstanceHandles._getFirstCommonAncestorID(
-          plan.one._rootNodeID,
-          plan.two._rootNodeID
+          getNodeID(plan.one),
+          getNodeID(plan.two)
         );
-        expect(firstCommon).toBe(plan.com._rootNodeID);
+        expect(firstCommon).toBe(getNodeID(plan.com));
       }
     });
   });

--- a/src/core/__tests__/ReactMultiChildReconcile-test.js
+++ b/src/core/__tests__/ReactMultiChildReconcile-test.js
@@ -14,6 +14,7 @@
 require('mock-modules');
 
 var React = require('React');
+var ReactInstanceMap = require('ReactInstanceMap');
 var ReactTestUtils = require('ReactTestUtils');
 var ReactMount = require('ReactMount');
 
@@ -83,7 +84,10 @@ var FriendsStatusDisplay = React.createClass({
   getStatusDisplays: function() {
     var name;
     var orderOfUsernames = [];
-    var statusDisplays = this._renderedComponent._renderedChildren;
+    // TODO: Update this to a better test that doesn't rely so much on internal
+    // implementation details.
+    var statusDisplays =
+      ReactInstanceMap.get(this)._renderedComponent._renderedChildren;
     for (name in statusDisplays) {
       var child = statusDisplays[name];
       var isPresent = !!child;
@@ -195,7 +199,7 @@ function verifyDomOrderingAccurate(parentInstance, statusDisplays) {
       continue;
     }
     var statusDisplay = statusDisplays[username];
-    orderedLogicalIds.push(statusDisplay._rootNodeID);
+    orderedLogicalIds.push(ReactInstanceMap.get(statusDisplay)._rootNodeID);
   }
   expect(orderedDomIds).toEqual(orderedLogicalIds);
 }

--- a/src/core/__tests__/refs-destruction-test.js
+++ b/src/core/__tests__/refs-destruction-test.js
@@ -19,9 +19,11 @@ var TestComponent = React.createClass({
   render: function() {
     return (
       <div>
-        <div ref="theInnerDiv">
-          Lets try to destroy this.
-        </div>
+        {this.props.destroy ? null :
+          <div ref="theInnerDiv">
+            Lets try to destroy this.
+          </div>
+        }
       </div>
     );
   }
@@ -33,20 +35,22 @@ describe('refs-destruction', function() {
   });
 
   it("should remove refs when destroying the parent", function() {
-    var testInstance = ReactTestUtils.renderIntoDocument(<TestComponent />);
+    var container = document.createElement('div');
+    var testInstance = React.render(<TestComponent />, container);
     reactComponentExpect(testInstance.refs.theInnerDiv)
         .toBeDOMComponentWithTag('div');
     expect(Object.keys(testInstance.refs || {}).length).toEqual(1);
-    testInstance.unmountComponent();
+    React.unmountComponentAtNode(container);
     expect(Object.keys(testInstance.refs || {}).length).toEqual(0);
   });
 
   it("should remove refs when destroying the child", function() {
-    var testInstance = ReactTestUtils.renderIntoDocument(<TestComponent />);
+    var container = document.createElement('div');
+    var testInstance = React.render(<TestComponent />, container);
     reactComponentExpect(testInstance.refs.theInnerDiv)
         .toBeDOMComponentWithTag('div');
     expect(Object.keys(testInstance.refs || {}).length).toEqual(1);
-    testInstance.refs.theInnerDiv.unmountComponent();
+    React.render(<TestComponent destroy={true} />, container);
     expect(Object.keys(testInstance.refs || {}).length).toEqual(0);
   });
 });


### PR DESCRIPTION
ReactClass is now composed by ReactCompositeComponent rather than
inherit from it.

The state transition functions currently use ReactInstanceMap to map an
instance back to an internal representation.

I updated some tests to use public APIs. Other unit tests still reach into
internals but now we can find them using ReactInstanceMap.

I will do more cleanup in follow ups. The purpose of this diff is to
preserve semantics and most of the existing code.

This effectively enables support for ES6 classes. All you would need to
expose is ReactClassMixin.
