### PR TITLE
Add 'use strict' to statisfy linter rules

### DIFF
--- a/src/stubs/Object.assign.js
+++ b/src/stubs/Object.assign.js
@@ -11,6 +11,8 @@
 
 // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.assign
 
+"use strict";
+
 function assign(target, sources) {
   if (target == null) {
     throw new TypeError('Object.assign target cannot be null or undefined');
@@ -40,6 +42,6 @@ function assign(target, sources) {
   }
 
   return to;
-};
+}
 
 module.exports = assign;

--- a/src/utils/deprecated.js
+++ b/src/utils/deprecated.js
@@ -9,6 +9,8 @@
  * @providesModule deprecated
  */
 
+"use strict";
+
 var assign = require('Object.assign');
 var warning = require('warning');
 

--- a/src/vendor_deprecated/core/copyProperties.js
+++ b/src/vendor_deprecated/core/copyProperties.js
@@ -9,6 +9,8 @@
  * @providesModule copyProperties
  */
 
+"use strict";
+
 /**
  * Copy properties from one or more objects (up to 5) into the first object.
  * This is a shallow copy. It mutates the first object and also returns it.


### PR DESCRIPTION
Add "use strict" and remove trailing semicolon to make jshint little happier.
