### PR TITLE
Trailing commas break old IE versions

### DIFF
--- a/docs/_js/jsx-compiler.js
+++ b/docs/_js/jsx-compiler.js
@@ -37,7 +37,7 @@ var CompilerPlayground = React.createClass({
         </label>
       </div>
     );
-  },
+  }
 });
 React.render(
   <CompilerPlayground />,

--- a/src/core/ReactNativeComponent.js
+++ b/src/core/ReactNativeComponent.js
@@ -62,7 +62,7 @@ function createInstanceForTag(tag, props, parentType) {
 
 var ReactNativeComponent = {
   createInstanceForTag: createInstanceForTag,
-  injection: ReactNativeComponentInjection,
+  injection: ReactNativeComponentInjection
 };
 
 module.exports = ReactNativeComponent;


### PR DESCRIPTION
Sadly, it doesn't look like there is an option (without side-effects) to check that with jshint :-1: 
(see https://github.com/jshint/jshint/issues/136)
