### PR TITLE
[traverseAllChildren] fix out-of-scope var use.

### DIFF
--- a/src/utils/__tests__/traverseAllChildren-test.js
+++ b/src/utils/__tests__/traverseAllChildren-test.js
@@ -288,7 +288,58 @@ describe('traverseAllChildren', function() {
     );
   });
 
-  it('should be called for each child in an iterable', function() {
+  it('should be called for each child in an iterable without keys', function() {
+    var threeDivIterable = {
+      '@@iterator': function() {
+        var i = 0;
+        return {
+          next: function() {
+            if (i++ < 3) {
+              return { value: <div />, done: false };
+            } else {
+              return { value: undefined, done: true };
+            }
+          }
+        };
+      }
+    };
+
+    var traverseContext = [];
+    var traverseFn =
+      jasmine.createSpy().andCallFake(function(context, kid, key, index) {
+        context.push(kid);
+      });
+
+    var instance = (
+      <div>
+        {threeDivIterable}
+      </div>
+    );
+
+    traverseAllChildren(instance.props.children, traverseFn, traverseContext);
+    expect(traverseFn.calls.length).toBe(3);
+
+    expect(traverseFn).toHaveBeenCalledWith(
+      traverseContext,
+      traverseContext[0],
+      '.0',
+      0
+    );
+    expect(traverseFn).toHaveBeenCalledWith(
+      traverseContext,
+      traverseContext[1],
+      '.1',
+      1
+    );
+    expect(traverseFn).toHaveBeenCalledWith(
+      traverseContext,
+      traverseContext[2],
+      '.2',
+      2
+    );
+  });
+
+  it('should be called for each child in an iterable with keys', function() {
     var threeDivIterable = {
       '@@iterator': function() {
         var i = 0;

--- a/src/utils/traverseAllChildren.js
+++ b/src/utils/traverseAllChildren.js
@@ -125,8 +125,7 @@ function traverseAllChildrenImpl(
     for (var i = 0; i < children.length; i++) {
       child = children[i];
       nextName = (
-        nameSoFar +
-        (nameSoFar ? SUBSEPARATOR : SEPARATOR) +
+        (nameSoFar !== '' ? nameSoFar + SUBSEPARATOR : SEPARATOR) +
         getComponentKey(child, i)
       );
       nextIndex = indexSoFar + subtreeCount;
@@ -144,12 +143,12 @@ function traverseAllChildrenImpl(
       var iterator = iteratorFn.call(children);
       var step;
       if (iteratorFn !== children.entries) {
+        var ii = 0;
         while (!(step = iterator.next()).done) {
           child = step.value;
           nextName = (
-            nameSoFar +
-            (nameSoFar ? SUBSEPARATOR : SEPARATOR) +
-            getComponentKey(child, i)
+            (nameSoFar !== '' ? nameSoFar + SUBSEPARATOR : SEPARATOR) +
+            getComponentKey(child, ii++)
           );
           nextIndex = indexSoFar + subtreeCount;
           subtreeCount += traverseAllChildrenImpl(
@@ -167,7 +166,7 @@ function traverseAllChildrenImpl(
           if (entry) {
             child = entry[1];
             nextName = (
-              nameSoFar + (nameSoFar ? SUBSEPARATOR : SEPARATOR) +
+              (nameSoFar !== '' ? nameSoFar + SUBSEPARATOR : SEPARATOR) +
               wrapUserProvidedKey(entry[0]) + SUBSEPARATOR +
               getComponentKey(child, 0)
             );
@@ -192,7 +191,7 @@ function traverseAllChildrenImpl(
         if (children.hasOwnProperty(key)) {
           child = children[key];
           nextName = (
-            nameSoFar + (nameSoFar ? SUBSEPARATOR : SEPARATOR) +
+            (nameSoFar !== '' ? nameSoFar + SUBSEPARATOR : SEPARATOR) +
             wrapUserProvidedKey(key) + SUBSEPARATOR +
             getComponentKey(child, 0)
           );


### PR DESCRIPTION
Dear ES6 gods, bring us `let` soon.

This fixes an issue where non-keyed iterables are used as children and the value of `i` would be undefined because its used out of scope. This adds a separately scoped iteration index value and appropriately increments it as iteration continues. Doi.

While I'm in there, make the usage of falsey `nameSoFar` more obvious and more consistent with the existing usage on L115

Test plan: first wrote a test covering this previously untested path. Saw an identical issue as was experienced in development environment. Then ensured test passed after this diff.
