### PR TITLE
Changed 'hasAttribute' function to 'getAttribute' function in Danger.js

### DIFF
--- a/src/browser/ui/dom/Danger.js
+++ b/src/browser/ui/dom/Danger.js
@@ -105,8 +105,8 @@ var Danger = {
 
       for (i = 0; i < renderNodes.length; ++i) {
         var renderNode = renderNodes[i];
-        if (renderNode.hasAttribute &&
-            renderNode.hasAttribute(RESULT_INDEX_ATTR)) {
+        if (renderNode.getAttribute &&
+            renderNode.getAttribute(RESULT_INDEX_ATTR)) {
 
           resultIndex = +renderNode.getAttribute(RESULT_INDEX_ATTR);
           renderNode.removeAttribute(RESULT_INDEX_ATTR);


### PR DESCRIPTION
I have changed the 'hasAttribute' function to 'getAttribute' in Danger.js. The hasAttribute function was the only thing causing React to not work in IE7 when using the appropriate shims. 

I tried to find a shim/sham to accomplish this, but it doesn't seem like it can be accomplished with it. 

All tests pass, the lint doesn't, but it doesn't pass in master either.
