### PR TITLE
Test that text spans aren't remounted needlessly

### DIFF
--- a/src/core/__tests__/ReactTextComponent-test.js
+++ b/src/core/__tests__/ReactTextComponent-test.js
@@ -18,12 +18,28 @@ describe('ReactTextComponent', function() {
     React = require('React');
   });
 
-  it('should escape the rootID', function(){
+  it('should escape the rootID', function() {
     var ThisThingShouldBeEscaped = '">>> LULZ <<<"';
     var ThisThingWasBeEscaped = '&quot;&gt;&gt;&gt; LULZ &lt;&lt;&lt;&quot;';
     var thing = <div><span key={ThisThingShouldBeEscaped}>LULZ</span></div>;
     var html = React.renderToString(thing);
     expect(html).not.toContain(ThisThingShouldBeEscaped);
     expect(html).toContain(ThisThingWasBeEscaped);
-  })
+  });
+
+  it('updates a mounted text component in place', function() {
+    var el = document.createElement('div');
+    var inst = React.render(<div>{'foo'}{'bar'}</div>, el);
+
+    var foo = inst.getDOMNode().children[0];
+    var bar = inst.getDOMNode().children[1];
+    expect(foo.tagName).toBe('SPAN');
+    expect(bar.tagName).toBe('SPAN');
+
+    var inst = React.render(<div>{'baz'}{'qux'}</div>, el);
+    // After the update, the spans should have stayed in place (as opposed to
+    // getting unmounted and remounted)
+    expect(inst.getDOMNode().children[0]).toBe(foo);
+    expect(inst.getDOMNode().children[1]).toBe(bar);
+  });
 });


### PR DESCRIPTION
While working on #2382, I accidentally broke this behavior (causing text components to get unmounted and remounted for any update) but we didn't have any unit test for it. Now we do.

Test Plan: jest TextComponent
