### PR TITLE
cloneWithProps should not print warning message when child's ref is copied

### DIFF
--- a/src/utils/__tests__/cloneWithProps-test.js
+++ b/src/utils/__tests__/cloneWithProps-test.js
@@ -113,15 +113,19 @@ describe('cloneWithProps', function() {
   it('should not warn cloning with refs when refs are copied', function() {
     var Grandparent = React.createClass({
       render: function() {
-        return <Parent><div ref="yolo" /></Parent>;
+        var child = onlyChild(this.props.children);
+        return (
+          <div ref='grandpa'>
+            {cloneWithProps(child, {className: 'xyz', ref: child.ref})}
+          </div>
+        );
       }
     });
     var Parent = React.createClass({
       render: function() {
-        var child = onlyChild(this.props.children);
         return (
-          <div>
-            {cloneWithProps(child, {className: 'xyz', ref: child.ref})}
+          <div className={this.props.className}>
+            {this.props.children}
           </div>
         );
       }
@@ -132,8 +136,12 @@ describe('cloneWithProps', function() {
     try {
       console.warn = mocks.getMockFunction();
 
-      var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
-      expect(component.refs).toBe(emptyObject);
+      var component = ReactTestUtils.renderIntoDocument(
+        <Grandparent>
+          <Parent ref='yolo'>XYZ</Parent>
+        </Grandparent>
+      );
+      expect(component.refs.yolo.getDOMNode().className).toBe("xyz");
       expect(console.warn.mock.calls.length).toBe(0);
     } finally {
       console.warn = _warn;

--- a/src/utils/__tests__/cloneWithProps-test.js
+++ b/src/utils/__tests__/cloneWithProps-test.js
@@ -110,6 +110,36 @@ describe('cloneWithProps', function() {
     }
   });
 
+  it('should not warn cloning with refs when refs are copied', function() {
+    var Grandparent = React.createClass({
+      render: function() {
+        return <Parent><div ref="yolo" /></Parent>;
+      }
+    });
+    var Parent = React.createClass({
+      render: function() {
+        var child = onlyChild(this.props.children);
+        return (
+          <div>
+            {cloneWithProps(child, {className: 'xyz', ref: child.ref})}
+          </div>
+        );
+      }
+    });
+
+    var _warn = console.warn;
+
+    try {
+      console.warn = mocks.getMockFunction();
+
+      var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
+      expect(component.refs).toBe(emptyObject);
+      expect(console.warn.mock.calls.length).toBe(0);
+    } finally {
+      console.warn = _warn;
+    }
+  });
+
   it('should transfer the key property', function() {
     var Component = React.createClass({
       render: function() {

--- a/src/utils/cloneWithProps.js
+++ b/src/utils/cloneWithProps.js
@@ -32,7 +32,7 @@ var CHILDREN_PROP = keyOf({children: null});
 function cloneWithProps(child, props) {
   if (__DEV__) {
     warning(
-      !child.ref,
+      !child.ref || (child.ref === props.ref),
       'You are calling cloneWithProps() on a child with a ref. This is ' +
       'dangerous because you\'re creating a new child which will not be ' +
       'added as a ref to its parent.'


### PR DESCRIPTION
FYI, the warning doesn't make sense, since the ref has already been taken into consideration.