### PR TITLE
Basic shallow rendering support

### DIFF
--- a/src/core/ReactElement.js
+++ b/src/core/ReactElement.js
@@ -106,7 +106,21 @@ var ReactElement = function(type, key, ref, owner, context, props) {
     // an external backing store so that we can freeze the whole object.
     // This can be replaced with a WeakMap once they are implemented in
     // commonly used development environments.
-    this._store = { validated: false, props: props };
+    this._store = { props: props };
+
+    // To make comparing ReactElements easier for testing purposes, we make
+    // the validation flag non-enumerable (where possible, which should
+    // include every environment we run tests in), so the test framework
+    // ignores it.
+    try {
+      Object.defineProperty(this._store, 'validated', {
+        configurable: false,
+        enumerable: false,
+        writable: true
+      });
+    } catch (x) {
+    }
+    this._store.validated = false;
 
     // We're not allowed to set props directly on the object so we early
     // return and rely on the prototype membrane to forward to the backing

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2013-2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+"use strict";
+
+var React;
+var ReactTestUtils;
+
+var mocks;
+var warn;
+
+describe('ReactTestUtils', function() {
+
+  beforeEach(function() {
+    mocks = require('mocks');
+
+    React = require('React');
+    ReactTestUtils = require('ReactTestUtils');
+
+    warn = console.warn;
+    console.warn = mocks.getMockFunction();
+  });
+
+  afterEach(function() {
+    console.warn = warn;
+  });
+
+  it('should have shallow rendering', function() {
+    var SomeComponent = React.createClass({
+      render: function() {
+        return (
+          <div>
+            <span className="child1" />
+            <span className="child2" />
+          </div>
+        );
+      }
+    });
+
+    var shallowRenderer = ReactTestUtils.createRenderer();
+    shallowRenderer.render(<SomeComponent />);
+
+    var result = shallowRenderer.getRenderOutput();
+
+    expect(result.type).toBe('div');
+    expect(result.props.children).toEqual([
+      <span className="child1" />,
+      <span className="child2" />
+    ]);
+  });
+
+  it('lets you update shallowly rendered components', function() {
+    var SomeComponent = React.createClass({
+      getInitialState: function() {
+        return {clicked: false};
+      },
+
+      onClick: function() {
+        this.setState({clicked: true});
+      },
+
+      render: function() {
+        var className = this.state.clicked ? 'was-clicked' : '';
+
+        if (this.props.aNew === 'prop') {
+          return (
+            <a
+              href="#"
+              onClick={this.onClick}
+              className={className}>
+              Test link
+            </a>
+          );
+        } else {
+          return (
+            <div>
+              <span className="child1" />
+              <span className="child2" />
+            </div>
+          );
+        }
+      }
+    });
+
+    var shallowRenderer = ReactTestUtils.createRenderer();
+    shallowRenderer.render(<SomeComponent />);
+    var result = shallowRenderer.getRenderOutput();
+    expect(result.type).toBe('div');
+    expect(result.props.children).toEqual([
+      <span className="child1" />,
+      <span className="child2" />
+    ]);
+
+    shallowRenderer.render(<SomeComponent aNew="prop" />);
+    var updatedResult = shallowRenderer.getRenderOutput();
+    expect(updatedResult.type).toBe('a');
+
+    var mockEvent = {};
+    updatedResult.props.onClick(mockEvent);
+
+    var updatedResultCausedByClick = shallowRenderer.getRenderOutput();
+    expect(updatedResultCausedByClick.type).toBe('a');
+    expect(updatedResultCausedByClick.props.className).toBe('was-clicked');
+  });
+});


### PR DESCRIPTION
WIP to fix #2393.

Now redone on top of the new ReactCompositeComponent/ReactClass separation (#2445). Still only handles initial rendering not updating, but this is a simpler implementation that should be easier to add the missing parts to.

Sorry about closing the old PR (#2459), I'll just force-push next time I do a new version of a PR.

As a bonus, per @sebmarkbage's recommendation, this defines the validated flag to be a non-enumerable property, and avoids setting owner on the shallowly-rendered component, so we can now do a straight equality test on the expected and actual results and avoid helper functions like `areElementsEquivalent`.
