### PR TITLE
Fix problems with empty component ID registration

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -196,8 +196,13 @@ var ReactCompositeComponentMixin = assign({},
         }
       }
 
+      var renderedElement = this._renderValidatedComponent();
+      if (renderedElement === ReactEmptyComponent.emptyElement) {
+        ReactEmptyComponent.registerNullComponentID(this._rootNodeID);
+      }
+
       this._renderedComponent = this._instantiateReactComponent(
-        this._renderValidatedComponent(),
+        renderedElement,
         this._currentElement.type // The wrapping type
       );
 
@@ -229,6 +234,11 @@ var ReactCompositeComponentMixin = assign({},
       inst.componentWillUnmount();
     }
     this._compositeLifeCycleState = null;
+
+    if (this._renderedComponent._currentElement ===
+        ReactEmptyComponent.emptyElement) {
+      ReactEmptyComponent.deregisterNullComponentID(this._rootNodeID);
+    }
 
     this._renderedComponent.unmountComponent();
     this._renderedComponent = null;
@@ -641,6 +651,13 @@ var ReactCompositeComponentMixin = assign({},
       var thisID = this._rootNodeID;
       var prevComponentID = prevComponentInstance._rootNodeID;
       prevComponentInstance.unmountComponent();
+
+      if (nextRenderedElement === ReactEmptyComponent.emptyElement) {
+        ReactEmptyComponent.registerNullComponentID(this._rootNodeID);
+      } else if (prevRenderedElement === ReactEmptyComponent.emptyElement) {
+        ReactEmptyComponent.deregisterNullComponentID(this._rootNodeID);
+      }
+
       this._renderedComponent = this._instantiateReactComponent(
         nextRenderedElement,
         this._currentElement.type
@@ -683,10 +700,7 @@ var ReactCompositeComponentMixin = assign({},
           }
         }
         if (renderedComponent === null || renderedComponent === false) {
-          renderedComponent = ReactEmptyComponent.getEmptyComponent();
-          ReactEmptyComponent.registerNullComponentID(this._rootNodeID);
-        } else {
-          ReactEmptyComponent.deregisterNullComponentID(this._rootNodeID);
+          renderedComponent = ReactEmptyComponent.emptyElement;
         }
       } finally {
         ReactContext.current = previousContext;

--- a/src/core/ReactEmptyComponent.js
+++ b/src/core/ReactEmptyComponent.js
@@ -26,17 +26,17 @@ var ReactEmptyComponentInjection = {
   }
 };
 
-/**
- * @return {ReactComponent} component The injected empty component.
- */
-function getEmptyComponent() {
+var ReactEmptyComponentType = function() {};
+ReactEmptyComponentType.prototype.render = function() {
   invariant(
     component,
     'Trying to return null from a render, but no null placeholder component ' +
     'was injected.'
   );
   return component();
-}
+};
+
+var emptyElement = ReactElement.createElement(ReactEmptyComponentType);
 
 /**
  * Mark the component as having rendered to null.
@@ -63,9 +63,10 @@ function isNullComponentID(id) {
 }
 
 var ReactEmptyComponent = {
-  deregisterNullComponentID: deregisterNullComponentID,
-  getEmptyComponent: getEmptyComponent,
+  emptyElement: emptyElement,
   injection: ReactEmptyComponentInjection,
+
+  deregisterNullComponentID: deregisterNullComponentID,
   isNullComponentID: isNullComponentID,
   registerNullComponentID: registerNullComponentID
 };

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -21,7 +21,6 @@ var ReactMount;
 var ReactPropTypes;
 var ReactServerRendering;
 var ReactTestUtils;
-var TogglingComponent;
 
 var cx;
 var reactComponentExpect;
@@ -78,23 +77,6 @@ describe('ReactCompositeComponent', function() {
       }
     });
 
-    TogglingComponent = React.createClass({
-      getInitialState: function() {
-        return {component: this.props.firstComponent};
-      },
-      componentDidMount: function() {
-        console.log(this.getDOMNode());
-        this.setState({component: this.props.secondComponent});
-      },
-      componentDidUpdate: function() {
-        console.log(this.getDOMNode());
-      },
-      render: function() {
-        var Component = this.state.component;
-        return Component ? <Component /> : null;
-      }
-    });
-
     warn = console.warn;
     console.warn = mocks.getMockFunction();
   });
@@ -146,139 +128,6 @@ describe('ReactCompositeComponent', function() {
       .expectRenderedChild()
       .toBeDOMComponentWithTag('a');
   });
-
-  it('should render null and false as a noscript tag under the hood', () => {
-    var Component1 = React.createClass({
-      render: function() {
-        return null;
-      }
-    });
-    var Component2 = React.createClass({
-      render: function() {
-        return false;
-      }
-    });
-
-    var instance1 = ReactTestUtils.renderIntoDocument(<Component1 />);
-    var instance2 = ReactTestUtils.renderIntoDocument(<Component2 />);
-    reactComponentExpect(instance1)
-      .expectRenderedChild()
-      .toBeDOMComponentWithTag('noscript');
-    reactComponentExpect(instance2)
-      .expectRenderedChild()
-      .toBeDOMComponentWithTag('noscript');
-  });
-
-  it('should still throw when rendering to undefined', () => {
-    var Component = React.createClass({
-      render: function() {}
-    });
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(<Component />);
-    }).toThrow(
-      'Invariant Violation: Component.render(): A valid ReactComponent must ' +
-      'be returned. You may have returned undefined, an array or some other ' +
-      'invalid object.'
-    );
-  });
-
-  it('should be able to switch between rendering null and a normal tag', () => {
-    spyOn(console, 'log');
-
-    var instance1 =
-      <TogglingComponent
-        firstComponent={null}
-        secondComponent={'div'}
-      />;
-    var instance2 =
-      <TogglingComponent
-        firstComponent={'div'}
-        secondComponent={null}
-      />;
-
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(instance1);
-      ReactTestUtils.renderIntoDocument(instance2);
-    }).not.toThrow();
-
-    expect(console.log.argsForCall.length).toBe(4);
-    expect(console.log.argsForCall[0][0]).toBe(null);
-    expect(console.log.argsForCall[1][0].tagName).toBe('DIV');
-    expect(console.log.argsForCall[2][0].tagName).toBe('DIV');
-    expect(console.log.argsForCall[3][0]).toBe(null);
-  });
-
-  it('should distinguish between a script placeholder and an actual script tag',
-    () => {
-      spyOn(console, 'log');
-
-      var instance1 =
-        <TogglingComponent
-          firstComponent={null}
-          secondComponent={'script'}
-        />;
-      var instance2 =
-        <TogglingComponent
-          firstComponent={'script'}
-          secondComponent={null}
-        />;
-
-      expect(function() {
-        ReactTestUtils.renderIntoDocument(instance1);
-      }).not.toThrow();
-      expect(function() {
-        ReactTestUtils.renderIntoDocument(instance2);
-      }).not.toThrow();
-
-      expect(console.log.argsForCall.length).toBe(4);
-      expect(console.log.argsForCall[0][0]).toBe(null);
-      expect(console.log.argsForCall[1][0].tagName).toBe('SCRIPT');
-      expect(console.log.argsForCall[2][0].tagName).toBe('SCRIPT');
-      expect(console.log.argsForCall[3][0]).toBe(null);
-    }
-  );
-
-  it('should have getDOMNode return null when multiple layers of composite ' +
-    'components render to the same null placeholder', () => {
-      spyOn(console, 'log');
-
-      var GrandChild = React.createClass({
-        render: function() {
-          return null;
-        }
-      });
-
-      var Child = React.createClass({
-        render: function() {
-          return <GrandChild />;
-        }
-      });
-
-      var instance1 =
-        <TogglingComponent
-          firstComponent={'div'}
-          secondComponent={Child}
-        />;
-      var instance2 =
-        <TogglingComponent
-          firstComponent={Child}
-          secondComponent={'div'}
-        />;
-
-      expect(function() {
-        ReactTestUtils.renderIntoDocument(instance1);
-      }).not.toThrow();
-      expect(function() {
-        ReactTestUtils.renderIntoDocument(instance2);
-      }).not.toThrow();
-
-      expect(console.log.argsForCall.length).toBe(4);
-      expect(console.log.argsForCall[0][0].tagName).toBe('DIV');
-      expect(console.log.argsForCall[1][0]).toBe(null);
-      expect(console.log.argsForCall[2][0]).toBe(null);
-      expect(console.log.argsForCall[3][0].tagName).toBe('DIV');
-    }
-  );
 
   it('should not thrash a server rendered layout with client side one', () => {
     var Child = React.createClass({

--- a/src/core/__tests__/ReactEmptyComponent-test.js
+++ b/src/core/__tests__/ReactEmptyComponent-test.js
@@ -1,0 +1,225 @@
+/**
+ * Copyright 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+"use strict";
+
+var React;
+var ReactEmptyComponent;
+var ReactTestUtils;
+var TogglingComponent;
+
+var reactComponentExpect;
+
+describe('ReactEmptyComponent', function() {
+  beforeEach(function() {
+    require('mock-modules').dumpCache();
+
+    React = require('React');
+    ReactEmptyComponent = require('ReactEmptyComponent');
+    ReactTestUtils = require('ReactTestUtils');
+
+    reactComponentExpect = require('reactComponentExpect');
+
+    TogglingComponent = React.createClass({
+      getInitialState: function() {
+        return {component: this.props.firstComponent};
+      },
+      componentDidMount: function() {
+        console.log(this.getDOMNode());
+        this.setState({component: this.props.secondComponent});
+      },
+      componentDidUpdate: function() {
+        console.log(this.getDOMNode());
+      },
+      render: function() {
+        var Component = this.state.component;
+        return Component ? <Component /> : null;
+      }
+    });
+  });
+
+  it('should render null and false as a noscript tag under the hood', () => {
+    var Component1 = React.createClass({
+      render: function() {
+        return null;
+      }
+    });
+    var Component2 = React.createClass({
+      render: function() {
+        return false;
+      }
+    });
+
+    var instance1 = ReactTestUtils.renderIntoDocument(<Component1 />);
+    var instance2 = ReactTestUtils.renderIntoDocument(<Component2 />);
+    reactComponentExpect(instance1)
+      .expectRenderedChild()
+      .toBeComponentOfType(ReactEmptyComponent.emptyElement.type);
+    reactComponentExpect(instance2)
+      .expectRenderedChild()
+      .toBeComponentOfType(ReactEmptyComponent.emptyElement.type);
+  });
+
+  it('should still throw when rendering to undefined', () => {
+    var Component = React.createClass({
+      render: function() {}
+    });
+    expect(function() {
+      ReactTestUtils.renderIntoDocument(<Component />);
+    }).toThrow(
+      'Invariant Violation: Component.render(): A valid ReactComponent must ' +
+      'be returned. You may have returned undefined, an array or some other ' +
+      'invalid object.'
+    );
+  });
+
+  it('should be able to switch between rendering null and a normal tag', () => {
+    spyOn(console, 'log');
+
+    var instance1 =
+      <TogglingComponent
+        firstComponent={null}
+        secondComponent={'div'}
+      />;
+    var instance2 =
+      <TogglingComponent
+        firstComponent={'div'}
+        secondComponent={null}
+      />;
+
+    expect(function() {
+      ReactTestUtils.renderIntoDocument(instance1);
+      ReactTestUtils.renderIntoDocument(instance2);
+    }).not.toThrow();
+
+    expect(console.log.argsForCall.length).toBe(4);
+    expect(console.log.argsForCall[0][0]).toBe(null);
+    expect(console.log.argsForCall[1][0].tagName).toBe('DIV');
+    expect(console.log.argsForCall[2][0].tagName).toBe('DIV');
+    expect(console.log.argsForCall[3][0]).toBe(null);
+  });
+
+  it('should distinguish between a script placeholder and an actual script tag',
+    () => {
+      spyOn(console, 'log');
+
+      var instance1 =
+        <TogglingComponent
+          firstComponent={null}
+          secondComponent={'script'}
+        />;
+      var instance2 =
+        <TogglingComponent
+          firstComponent={'script'}
+          secondComponent={null}
+        />;
+
+      expect(function() {
+        ReactTestUtils.renderIntoDocument(instance1);
+      }).not.toThrow();
+      expect(function() {
+        ReactTestUtils.renderIntoDocument(instance2);
+      }).not.toThrow();
+
+      expect(console.log.argsForCall.length).toBe(4);
+      expect(console.log.argsForCall[0][0]).toBe(null);
+      expect(console.log.argsForCall[1][0].tagName).toBe('SCRIPT');
+      expect(console.log.argsForCall[2][0].tagName).toBe('SCRIPT');
+      expect(console.log.argsForCall[3][0]).toBe(null);
+    }
+  );
+
+  it('should have getDOMNode return null when multiple layers of composite ' +
+    'components render to the same null placeholder', () => {
+      spyOn(console, 'log');
+
+      var GrandChild = React.createClass({
+        render: function() {
+          return null;
+        }
+      });
+
+      var Child = React.createClass({
+        render: function() {
+          return <GrandChild />;
+        }
+      });
+
+      var instance1 =
+        <TogglingComponent
+          firstComponent={'div'}
+          secondComponent={Child}
+        />;
+      var instance2 =
+        <TogglingComponent
+          firstComponent={Child}
+          secondComponent={'div'}
+        />;
+
+      expect(function() {
+        ReactTestUtils.renderIntoDocument(instance1);
+      }).not.toThrow();
+      expect(function() {
+        ReactTestUtils.renderIntoDocument(instance2);
+      }).not.toThrow();
+
+      expect(console.log.argsForCall.length).toBe(4);
+      expect(console.log.argsForCall[0][0].tagName).toBe('DIV');
+      expect(console.log.argsForCall[1][0]).toBe(null);
+      expect(console.log.argsForCall[2][0]).toBe(null);
+      expect(console.log.argsForCall[3][0].tagName).toBe('DIV');
+    }
+  );
+
+  it('works when switching components', function() {
+    var assertions = 0;
+    var Inner = React.createClass({
+      render: function() {
+        return <span />;
+      },
+      componentDidMount: function() {
+        // Make sure the DOM node resolves properly even if we're replacing a
+        // `null` component
+        expect(this.getDOMNode()).not.toBe(null);
+        assertions++;
+      },
+      componentWillUnmount: function() {
+        // Even though we're getting replaced by `null`, we haven't been
+        // replaced yet!
+        expect(this.getDOMNode()).not.toBe(null);
+        assertions++;
+      }
+    });
+    var Wrapper = React.createClass({
+      render: function() {
+        return this.props.showInner ? <Inner /> : null;
+      }
+    });
+
+    var el = document.createElement('div');
+    var component;
+
+    // Render the <Inner /> component...
+    component = React.render(<Wrapper showInner={true} />, el);
+    expect(component.getDOMNode()).not.toBe(null);
+
+    // Switch to null...
+    component = React.render(<Wrapper showInner={false} />, el);
+    expect(component.getDOMNode()).toBe(null);
+
+    // ...then switch back.
+    component = React.render(<Wrapper showInner={true} />, el);
+    expect(component.getDOMNode()).not.toBe(null);
+
+    expect(assertions).toBe(3);
+  });
+});
+

--- a/src/test/reactComponentExpect.js
+++ b/src/test/reactComponentExpect.js
@@ -61,6 +61,7 @@ assign(reactComponentExpect.prototype, {
   expectRenderedChild: function() {
     this.toBeCompositeComponent();
     var child = this._instance._renderedComponent;
+    // TODO: Hide ReactEmptyComponent instances here?
     return new reactComponentExpect(child);
   },
 


### PR DESCRIPTION
Fixes #2493, also closes #2353 as it incorporates a variant of that fix.
- Instead of having getEmptyComponent return `<noscript />` directly, wrap it in a class that we can easily identify later as being an empty component
- Cache the empty component element instead of recreating one each time
- Avoid touching the nullComponentIdsRegistry dictionary at all when not dealing with empty components
- Move empty-component tests to a separate file

Test Plan: jest
