### PR TITLE
Stop treating key={null} as an unspecified key

### DIFF
--- a/src/core/ReactElement.js
+++ b/src/core/ReactElement.js
@@ -141,16 +141,7 @@ ReactElement.createElement = function(type, config, children) {
 
   if (config != null) {
     ref = config.ref === undefined ? null : config.ref;
-    if (__DEV__) {
-      warning(
-        config.key !== null,
-        'createElement(...): Encountered component with a `key` of null. In ' +
-        'a future version, this will be treated as equivalent to the string ' +
-        '\'null\'; instead, provide an explicit key or use undefined.'
-      );
-    }
-    // TODO: Change this back to `config.key === undefined`
-    key = config.key == null ? null : '' + config.key;
+    key = config.key === undefined ? null : '' + config.key;
     // Remaining properties are added to a new props object
     for (propName in config) {
       if (config.hasOwnProperty(propName) &&

--- a/src/core/__tests__/ReactElement-test.js
+++ b/src/core/__tests__/ReactElement-test.js
@@ -81,22 +81,6 @@ describe('ReactElement', function() {
     expect(element.props).toEqual({foo:'56'});
   });
 
-  it('treats a null key as omitted but warns', function() {
-    spyOn(console, 'warn');
-    var element = React.createFactory(ComponentClass)({
-      key: null,
-      foo: '56'
-    });
-    expect(element.type).toBe(ComponentClass);
-    expect(element.key).toBe(null);  // as opposed to string 'null'
-    expect(element.ref).toBe(null);
-    expect(element.props).toEqual({foo:'56'});
-    expect(console.warn.argsForCall.length).toBe(1);
-    expect(console.warn.argsForCall[0][0]).toContain(
-      'will be treated as equivalent to the string \'null\''
-    );
-  });
-
   it('preserves the context on the element', function() {
     var Component = React.createFactory(ComponentClass);
     var element;


### PR DESCRIPTION
This reverts commit dd92786fb038c4eb7c6545928646ec8aa9ecfa36, which was intended to be temporary for the 0.12 release.

Fixes #2394.
