### PR TITLE
Add an example argument to the Simulate.change method

### DIFF
--- a/docs/docs/10.4-test-utils.md
+++ b/docs/docs/10.4-test-utils.md
@@ -21,7 +21,7 @@ Example usage:
 ```javascript
 var node = this.refs.input.getDOMNode();
 React.addons.TestUtils.Simulate.click(node);
-React.addons.TestUtils.Simulate.change(node);
+React.addons.TestUtils.Simulate.change(node, {target: {value: "New value"}});
 React.addons.TestUtils.Simulate.keyDown(node, {key: "Enter"});
 ```
 


### PR DESCRIPTION
The previous documentation didn't make it clear that the new value of the node should be passed as an extra argument to .change(). It was easy to think that prior to calling change(), one must use the node.value setter (which is wrong and doesn't cause the onChange handler to get called).
