### PR TITLE
"data.length is null" error when set innerHTML (which has comment nodes) in IE-8 (only happens in compressed version)

### DIFF
--- a/src/browser/ui/dom/setInnerHTML.js
+++ b/src/browser/ui/dom/setInnerHTML.js
@@ -61,10 +61,10 @@ if (ExecutionEnvironment.canUseDOM) {
         // deleteData leaves an empty `TextNode` which offsets the index of all
         // children. Definitely want to avoid this.
         var textNode = node.firstChild;
-        if (textNode.data.length === 1) {
+        if (textNode.data && textNode.data.length === 1) {
           node.removeChild(textNode);
         } else {
-          textNode.deleteData(0, 1);
+          textNode.deleteData && textNode.deleteData(0, 1);
         }
       } else {
         node.innerHTML = html;


### PR DESCRIPTION
I have encountered a JS error when trying to set innerHTML of a node in IE-8 browser.

```
<html>
  <head>
    <meta http-equiv="X-UA-Compatible" content="IE=edge">
    <meta charset="utf-8" />
    <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/es5-shim/4.0.3/es5-shim.js">    </script>
    <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/es5-shim/4.0.3/es5-sham.js">    </script>
    <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/react/0.12.0/react.min.js"></script>
  </head>
  <body>
    <div id="container"></div>
    <div id="contentToCopy" style="display: none">
      <!-- a comment node -->     
      <h5>content to copy</h5>
    </div>
<script type="text/javascript">
var DivContainer = React.createClass({displayName: 'DivContainer',
  getInitialState: function() {
    return {content: 'hello world'};
  },
  setContent: function(str) {
    this.setState({content: str + '<!-- ' + (+new Date) + ' -->'});
  },
  render: function() {
    return React.createElement("div", {dangerouslySetInnerHTML: {__html: this.state.content || ''}});
  }
});

var mountNode = document.getElementById('container');

var instance = React.render(React.createElement(DivContainer), mountNode);

instance.setContent(document.getElementById('contentToCopy').innerHTML);
</script>

  </body>
</html>
```

However, if loading with the development version, that JS error would not happen. In this case, the `textNode.data` is an `empty string` instead of `undefined` as in compressed version.
