### PR TITLE
Adds support for headers html attribute 

### DIFF
--- a/docs/docs/ref-04-tags-and-attributes.md
+++ b/docs/docs/ref-04-tags-and-attributes.md
@@ -56,7 +56,7 @@ accept acceptCharset accessKey action allowFullScreen allowTransparency alt
 async autoComplete autoPlay cellPadding cellSpacing charSet checked classID
 className cols colSpan content contentEditable contextMenu controls coords
 crossOrigin data dateTime defer dir disabled download draggable encType form
-formNoValidate frameBorder height hidden href hrefLang htmlFor httpEquiv icon
+formNoValidate frameBorder headers height hidden href hrefLang htmlFor httpEquiv icon
 id label lang list loop manifest max maxLength media mediaGroup method min
 multiple muted name noValidate open pattern placeholder poster preload
 radioGroup readOnly rel required role rows rowSpan sandbox scope scrolling

--- a/src/browser/ui/dom/HTMLDOMPropertyConfig.js
+++ b/src/browser/ui/dom/HTMLDOMPropertyConfig.js
@@ -90,6 +90,7 @@ var HTMLDOMPropertyConfig = {
     form: MUST_USE_ATTRIBUTE,
     formNoValidate: HAS_BOOLEAN_VALUE,
     frameBorder: MUST_USE_ATTRIBUTE,
+    headers: null,
     height: MUST_USE_ATTRIBUTE,
     hidden: MUST_USE_ATTRIBUTE | HAS_BOOLEAN_VALUE,
     href: null,


### PR DESCRIPTION
Currently 'headers' is not a supported HTML attribute for React. For any table that has multiple column headers, screen readers are not able to process the headers without the 'headers' attribute.

This technique is used when data cells are associated with more than one row and/or one column header. This allows screen readers to speak the headers associated with each data cell when the relationships are too complex to be identified using the th element alone or the th element with the scope attribute. Using this technique also makes these complex relationships perceivable when the presentation format changes.

http://www.w3.org/TR/WCAG20-TECHS/H43.html
