### PR TITLE
Update stripTypes transform to use fixed up jstransform transform

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,6 +2,7 @@
 
 var visitors = require('./vendor/fbtransform/visitors');
 var transform = require('jstransform').transform;
+var typesSyntax = require('jstransform/visitors/type-syntax');
 var Buffer = require('buffer').Buffer;
 
 module.exports = {
@@ -37,7 +38,11 @@ function innerTransform(input, options) {
     visitorSets.push('harmony');
   }
   if (options.stripTypes) {
-    visitorSets.push('type-annotations');
+    // Stripping types needs to happen before the other transforms
+    // unfortunately, due to bad interactions. For example,
+    // es6-rest-param-visitors conflict with stripping rest param type
+    // annotation
+    input = transform(typesSyntax.visitorList, input, options).code;
   }
 
   var visitorList = visitors.getVisitorsBySet(visitorSets);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "commoner": "^0.10.0",
-    "jstransform": "^7.0.0"
+    "jstransform": "^8.0.0"
   },
   "devDependencies": {
     "benchmark": "~1.0.0",

--- a/vendor/fbtransform/syntax.js
+++ b/vendor/fbtransform/syntax.js
@@ -4,6 +4,7 @@
 "use strict";
 
 var transform = require('jstransform').transform;
+var typesSyntax = require('jstransform/visitors/type-syntax');
 var visitors = require('./visitors');
 
 /**
@@ -15,6 +16,12 @@ var visitors = require('./visitors');
  */
 function transformAll(source, options, excludes) {
   excludes = excludes || [];
+
+  // Stripping types needs to happen before the other transforms
+  // unfortunately, due to bad interactions. For example,
+  // es6-rest-param-visitors conflict with stripping rest param type
+  // annotation
+  source = transform(typesSyntax.visitorList, source, options).code;
 
   // The typechecker transform must run in a second pass in order to operate on
   // the entire source code -- so exclude it from the first pass

--- a/vendor/fbtransform/visitors.js
+++ b/vendor/fbtransform/visitors.js
@@ -9,7 +9,6 @@ var es6Templates = require('jstransform/visitors/es6-template-visitors');
 var es7SpreadProperty = require('jstransform/visitors/es7-spread-property-visitors');
 var react = require('./transforms/react');
 var reactDisplayName = require('./transforms/reactDisplayName');
-var typesSyntax = require('jstransform/visitors/type-syntax');
 
 /**
  * Map from transformName => orderedListOfVisitors.
@@ -23,8 +22,7 @@ var transformVisitors = {
   'es6-rest-params': es6RestParameters.visitorList,
   'es6-templates': es6Templates.visitorList,
   'es7-spread-property': es7SpreadProperty.visitorList,
-  'react': react.visitorList.concat(reactDisplayName.visitorList),
-  'types': typesSyntax.visitorList
+  'react': react.visitorList.concat(reactDisplayName.visitorList)
 };
 
 var transformSets = {
@@ -40,9 +38,6 @@ var transformSets = {
   ],
   'react': [
     'react'
-  ],
-  'type-annotations': [
-    'types'
   ]
 };
 
@@ -50,7 +45,6 @@ var transformSets = {
  * Specifies the order in which each transform should run.
  */
 var transformRunOrder = [
-  'types',
   'es6-arrow-functions',
   'es6-object-concise-method',
   'es6-object-short-notation',


### PR DESCRIPTION
I've [updated](https://github.com/facebook/jstransform/pull/38) the jstransform transform that strips out types. Unfortunately, this transform can conflict with other transforms (the previous version had similar problems), so it needs to be run before the other transforms as a separate step. This PR finds the 3 places where we are doing transforms (jsx - offline transform, browser-transform.js - in-browser transform, syntax.js - test transform).

For the browser transforms, I added the convention that `stripTypes=true` enables the type stripping behavior (similar to `harmony=true`). 

Test Plan: 
1. `npm test`
2. Created a file with type annotations and ran `./bin/jsx --strip-types foo.js`
3. Created a bundle for the browser with `./node_modules/.bin/browserify vendor/browser-transforms.js > bundle.js` and made sure that script with `type="text/jsx;stripTypes=true;harmony=true"` was transformed.
