### PR TITLE
Move logic for `null` to instantiateReactComponent

### DIFF
--- a/src/browser/ui/ReactMount.js
+++ b/src/browser/ui/ReactMount.js
@@ -361,7 +361,7 @@ var ReactMount = {
           ' Instead of passing a component class, make sure to instantiate ' +
           'it by passing it to React.createElement.' :
         // Check if it quacks like an element
-        typeof nextElement.props !== "undefined" ?
+        nextElement != null && nextElement.props !== undefined ?
           ' This may be caused by unintentionally loading two independent ' +
           'copies of React.' :
           ''

--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -15,7 +15,6 @@ var ReactComponent = require('ReactComponent');
 var ReactContext = require('ReactContext');
 var ReactCurrentOwner = require('ReactCurrentOwner');
 var ReactElement = require('ReactElement');
-var ReactEmptyComponent = require('ReactEmptyComponent');
 var ReactInstanceMap = require('ReactInstanceMap');
 var ReactOwner = require('ReactOwner');
 var ReactPerf = require('ReactPerf');
@@ -197,10 +196,6 @@ var ReactCompositeComponentMixin = assign({},
       }
 
       var renderedElement = this._renderValidatedComponent();
-      if (renderedElement === ReactEmptyComponent.emptyElement) {
-        ReactEmptyComponent.registerNullComponentID(this._rootNodeID);
-      }
-
       this._renderedComponent = this._instantiateReactComponent(
         renderedElement,
         this._currentElement.type // The wrapping type
@@ -234,11 +229,6 @@ var ReactCompositeComponentMixin = assign({},
       inst.componentWillUnmount();
     }
     this._compositeLifeCycleState = null;
-
-    if (this._renderedComponent._currentElement ===
-        ReactEmptyComponent.emptyElement) {
-      ReactEmptyComponent.deregisterNullComponentID(this._rootNodeID);
-    }
 
     this._renderedComponent.unmountComponent();
     this._renderedComponent = null;
@@ -652,12 +642,6 @@ var ReactCompositeComponentMixin = assign({},
       var prevComponentID = prevComponentInstance._rootNodeID;
       prevComponentInstance.unmountComponent();
 
-      if (nextRenderedElement === ReactEmptyComponent.emptyElement) {
-        ReactEmptyComponent.registerNullComponentID(this._rootNodeID);
-      } else if (prevRenderedElement === ReactEmptyComponent.emptyElement) {
-        ReactEmptyComponent.deregisterNullComponentID(this._rootNodeID);
-      }
-
       this._renderedComponent = this._instantiateReactComponent(
         nextRenderedElement,
         this._currentElement.type
@@ -699,14 +683,13 @@ var ReactCompositeComponentMixin = assign({},
             renderedComponent = null;
           }
         }
-        if (renderedComponent === null || renderedComponent === false) {
-          renderedComponent = ReactEmptyComponent.emptyElement;
-        }
       } finally {
         ReactContext.current = previousContext;
         ReactCurrentOwner.current = null;
       }
       invariant(
+        // TODO: An `isValidNode` function would probably be more appropriate
+        renderedComponent === null || renderedComponent === false ||
         ReactElement.isValidElement(renderedComponent),
         '%s.render(): A valid ReactComponent must be returned. You may have ' +
           'returned undefined, an array or some other invalid object.',

--- a/src/core/ReactEmptyComponent.js
+++ b/src/core/ReactEmptyComponent.js
@@ -12,6 +12,7 @@
 "use strict";
 
 var ReactElement = require('ReactElement');
+var ReactInstanceMap = require('ReactInstanceMap');
 
 var invariant = require('invariant');
 
@@ -27,6 +28,14 @@ var ReactEmptyComponentInjection = {
 };
 
 var ReactEmptyComponentType = function() {};
+ReactEmptyComponentType.prototype.componentDidMount = function() {
+  var internalInstance = ReactInstanceMap.get(this);
+  registerNullComponentID(internalInstance._rootNodeID);
+};
+ReactEmptyComponentType.prototype.componentWillUnmount = function() {
+  var internalInstance = ReactInstanceMap.get(this);
+  deregisterNullComponentID(internalInstance._rootNodeID);
+};
 ReactEmptyComponentType.prototype.render = function() {
   invariant(
     component,
@@ -65,10 +74,7 @@ function isNullComponentID(id) {
 var ReactEmptyComponent = {
   emptyElement: emptyElement,
   injection: ReactEmptyComponentInjection,
-
-  deregisterNullComponentID: deregisterNullComponentID,
-  isNullComponentID: isNullComponentID,
-  registerNullComponentID: registerNullComponentID
+  isNullComponentID: isNullComponentID
 };
 
 module.exports = ReactEmptyComponent;

--- a/src/core/__tests__/ReactEmptyComponent-test.js
+++ b/src/core/__tests__/ReactEmptyComponent-test.js
@@ -221,5 +221,15 @@ describe('ReactEmptyComponent', function() {
 
     expect(assertions).toBe(3);
   });
+
+  it('throws when rendering null at the top level', function() {
+    // TODO: This should actually work since `null` is a valid ReactNode
+    var div = document.createElement('div');
+    expect(function() {
+      React.render(null, div);
+    }).toThrow(
+      'Invariant Violation: renderComponent(): Invalid component element.'
+    );
+  });
 });
 

--- a/src/core/instantiateReactComponent.js
+++ b/src/core/instantiateReactComponent.js
@@ -13,6 +13,7 @@
 "use strict";
 
 var ReactCompositeComponent = require('ReactCompositeComponent');
+var ReactEmptyComponent = require('ReactEmptyComponent');
 var ReactNativeComponent = require('ReactNativeComponent');
 
 var assign = require('Object.assign');
@@ -56,6 +57,10 @@ function isInternalComponentType(type) {
  */
 function instantiateReactComponent(node, parentCompositeType) {
   var instance;
+
+  if (node === null || node === false) {
+    node = ReactEmptyComponent.emptyElement;
+  }
 
   if (typeof node === 'object') {
     var element = node;


### PR DESCRIPTION
This cleans up the code a bit and also brings us closer to allowing any ReactNode to be rendered at the top level.

Test Plan: jest
