### PR TITLE
Inject browser mixin before full-page components

### DIFF
--- a/src/browser/ui/ReactDefaultInjection.js
+++ b/src/browser/ui/ReactDefaultInjection.js
@@ -78,6 +78,10 @@ function inject() {
     ReactDOMTextComponent
   );
 
+  // This needs to happen before createFullPageComponent() otherwise the mixin
+  // won't be included.
+  ReactInjection.Class.injectMixin(ReactBrowserComponentMixin);
+
   ReactInjection.NativeComponent.injectComponentClasses({
     'button': ReactDOMButton,
     'form': ReactDOMForm,
@@ -91,10 +95,6 @@ function inject() {
     'head': createFullPageComponent('head'),
     'body': createFullPageComponent('body')
   });
-
-  // This needs to happen after createFullPageComponent() otherwise the mixin
-  // gets double injected.
-  ReactInjection.Class.injectMixin(ReactBrowserComponentMixin);
 
   ReactInjection.DOMProperty.injectDOMPropertyConfig(HTMLDOMPropertyConfig);
   ReactInjection.DOMProperty.injectDOMPropertyConfig(SVGDOMPropertyConfig);

--- a/src/browser/ui/__tests__/ReactRenderDocument-test.js
+++ b/src/browser/ui/__tests__/ReactRenderDocument-test.js
@@ -244,4 +244,21 @@ describe('rendering React components at document', function() {
     );
   });
 
+  it('supports getDOMNode on full-page components', function() {
+    var tree =
+      <html>
+        <head>
+          <title>Hello World</title>
+        </head>
+        <body>
+          Hello world
+        </body>
+      </html>;
+
+    var markup = React.renderToString(tree);
+    testDocument = getTestDocument(markup);
+    var component = React.render(tree, testDocument);
+    expect(testDocument.body.innerHTML).toBe('Hello world');
+    expect(component.getDOMNode().tagName).toBe('HTML');
+  });
 });


### PR DESCRIPTION
createFullPageComponent doesn't reference ReactBrowserComponentMixin directly so the mixin should get injected before the components are created. Previously, this test failed because getDOMNode wasn't present on the component instance.

Test Plan: jest
