### PR TITLE
Remove some unnecessary code in ReactComponents

### DIFF
--- a/src/browser/ui/ReactDOMComponent.js
+++ b/src/browser/ui/ReactDOMComponent.js
@@ -172,7 +172,6 @@ ReactDOMComponent.Mixin = {
    * @return {string} The computed markup.
    */
   mountComponent: function(rootID, transaction, mountDepth, context) {
-    invariant(context !== undefined, "Context is required parameter");
     ReactComponent.Mixin.mountComponent.call(
       this,
       rootID,
@@ -287,7 +286,6 @@ ReactDOMComponent.Mixin = {
   },
 
   receiveComponent: function(nextElement, transaction, context) {
-    invariant(context !== undefined, "Context is required parameter");
     if (nextElement === this._currentElement &&
         nextElement._owner != null) {
       // Since elements are immutable after the owner is rendered,
@@ -316,8 +314,6 @@ ReactDOMComponent.Mixin = {
    * @overridable
    */
   updateComponent: function(transaction, prevElement, nextElement, context) {
-    if(context === undefined) throw new Error("Context required for mounting");
-    if(context === null) throw new Error("Assert: context is not null");
     assertValidProps(this._currentElement.props);
     ReactComponent.Mixin.updateComponent.call(
       this,
@@ -435,7 +431,6 @@ ReactDOMComponent.Mixin = {
    * @param {ReactReconcileTransaction} transaction
    */
   _updateDOMChildren: function(lastProps, transaction, context) {
-    invariant(context !== undefined, "Context is required parameter");
     var nextProps = this._currentElement.props;
 
     var lastContent =

--- a/src/core/ReactComponent.js
+++ b/src/core/ReactComponent.js
@@ -108,7 +108,6 @@ var ReactComponent = {
      * @internal
      */
     mountComponent: function(rootID, transaction, mountDepth, context) {
-      invariant(context !== undefined, "Context is required parameter");
       var ref = this._currentElement.ref;
       if (ref != null) {
         var owner = this._currentElement._owner;
@@ -144,7 +143,6 @@ var ReactComponent = {
      * @internal
      */
     updateComponent: function(transaction, prevElement, nextElement, context) {
-      invariant(context !== undefined, "Context is required parameter");
       // If either the owner or a `ref` has changed, make sure the newest owner
       // has stored a reference to `this`, and the previous owner (if different)
       // has forgotten the reference to `this`. We use the element instead

--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -158,7 +158,6 @@ var ReactCompositeComponentMixin = assign({},
    * @internal
    */
   mountComponent: function(rootID, transaction, mountDepth, context) {
-    invariant(context !== undefined, "Context is required parameter");
     ReactComponent.Mixin.mountComponent.call(
       this,
       rootID,
@@ -520,7 +519,6 @@ var ReactCompositeComponentMixin = assign({},
   },
 
   receiveComponent: function(nextElement, transaction, context) {
-    invariant(context !== undefined, "Context is required parameter");
     if (nextElement === this._currentElement &&
         nextElement._owner != null) {
       // Since elements are immutable after the owner is rendered,
@@ -589,8 +587,6 @@ var ReactCompositeComponentMixin = assign({},
    * TODO: Remove this check when owner-context is removed
    */
    _warnIfContextsDiffer: function(ownerBasedContext, parentBasedContext) {
-    invariant(ownerBasedContext !== undefined, "Owner based context is required parameter");
-    invariant(parentBasedContext !== undefined, "Parent based ontext is required parameter");
     var ownerKeys = Object.keys(ownerBasedContext).sort();
     var parentKeys = Object.keys(parentBasedContext).sort();
     if (ownerKeys.length != parentKeys.length || ownerKeys.toString() != parentKeys.toString()) {
@@ -720,8 +716,6 @@ var ReactCompositeComponentMixin = assign({},
     transaction,
     unmaskedContext
   ) {
-    invariant(unmaskedContext !== undefined, "Context required for mounting");
-    invariant(unmaskedContext !== null, "Context must be non-null");
     var inst = this._instance;
 
     var prevProps = inst.props;
@@ -755,7 +749,6 @@ var ReactCompositeComponentMixin = assign({},
    * @internal
    */
   _updateRenderedComponent: function(transaction, context) {
-    invariant(context !== undefined, "Context is required parameter");
     var prevComponentInstance = this._renderedComponent;
     var prevRenderedElement = prevComponentInstance._currentElement;
     var nextRenderedElement = this._renderValidatedComponent();
@@ -968,25 +961,11 @@ var ShallowMixin = assign({},
     var prevComponentInstance = this._renderedComponent;
     var prevRenderedElement = prevComponentInstance._currentElement;
     // Use the without-owner-or-context variant of _rVC below:
-    var nextRenderedElement = this._renderValidatedComponentWithoutOwnerOrContext();
-    if (shouldUpdateReactComponent(prevRenderedElement, nextRenderedElement)) {
-      prevComponentInstance.receiveComponent(
-        nextRenderedElement,
-        transaction
-      );
-    } else {
-      // These two IDs are actually the same! But nothing should rely on that.
-      var thisID = this._rootNodeID;
-      var prevComponentID = prevComponentInstance._rootNodeID;
-      // Don't unmount previous instance since it was never mounted, due to
-      // shallow render.
-      //prevComponentInstance.unmountComponent();
-      this._renderedComponent = nextRenderedElement;
-      // ^ no instantiateReactComponent
-      //
-      // no recursive mountComponent
-      return nextRenderedElement;
-    }
+    var nextRenderedElement =
+      this._renderValidatedComponentWithoutOwnerOrContext();
+    // This is a noop in shallow render
+    shouldUpdateReactComponent(prevRenderedElement, nextRenderedElement);
+    this._renderedComponent = nextRenderedElement;
   }
 
 });

--- a/src/core/ReactMultiChild.js
+++ b/src/core/ReactMultiChild.js
@@ -17,7 +17,6 @@ var ReactMultiChildUpdateTypes = require('ReactMultiChildUpdateTypes');
 
 var flattenChildren = require('flattenChildren');
 var instantiateReactComponent = require('instantiateReactComponent');
-var invariant = require('invariant');
 var shouldUpdateReactComponent = require('shouldUpdateReactComponent');
 
 /**
@@ -180,7 +179,6 @@ var ReactMultiChild = {
      * @internal
      */
     mountChildren: function(nestedChildren, transaction, context) {
-      invariant(context !== undefined, "Context is required parameter");
       var children = flattenChildren(nestedChildren);
       var mountImages = [];
       var index = 0;
@@ -244,7 +242,6 @@ var ReactMultiChild = {
      * @internal
      */
     updateChildren: function(nextNestedChildren, transaction, context) {
-      invariant(context !== undefined, "Context is required parameter");
       updateDepth++;
       var errorThrown = true;
       try {
@@ -268,7 +265,6 @@ var ReactMultiChild = {
      * @protected
      */
     _updateChildren: function(nextNestedChildren, transaction, context) {
-      invariant(context !== undefined, "Context is required parameter");
       var nextChildren = flattenChildren(nextNestedChildren);
       var prevChildren = this._renderedChildren;
       if (!nextChildren && !prevChildren) {
@@ -400,7 +396,6 @@ var ReactMultiChild = {
       index,
       transaction,
       context) {
-      invariant(context !== undefined, "Context is required parameter");
       // Inlined for performance, see `ReactInstanceHandles.createReactID`.
       var rootID = this._rootNodeID + name;
       var mountImage = child.mountComponent(


### PR DESCRIPTION
This is just a little extra careful checks to help debugging. We'll ensure that it won't happen. Eventually, we'll switch to static types to catch this.

For now, these are in my way and distract me while grepping.

Also deleted some dead code in the shallow testing.
