### PR TITLE
Permit th `headers` attribute

### DIFF
--- a/src/browser/ui/dom/HTMLDOMPropertyConfig.js
+++ b/src/browser/ui/dom/HTMLDOMPropertyConfig.js
@@ -90,6 +90,7 @@ var HTMLDOMPropertyConfig = {
     form: MUST_USE_ATTRIBUTE,
     formNoValidate: HAS_BOOLEAN_VALUE,
     frameBorder: MUST_USE_ATTRIBUTE,
+    headers: null,
     height: MUST_USE_ATTRIBUTE,
     hidden: MUST_USE_ATTRIBUTE | HAS_BOOLEAN_VALUE,
     href: null,


### PR DESCRIPTION
Permits the headers attribute [as defined by the W3C](http://www.w3.org/TR/WCAG20-TECHS/H43.html).  Resolves #2516.
