### PR TITLE
Animation documentation for ReactTransitionGroup

### DIFF
--- a/docs/docs/10.1-animation.md
+++ b/docs/docs/10.1-animation.md
@@ -141,7 +141,7 @@ You can disable animating `enter` or `leave` animations if you want. For example
 
 ## Low-level API: `ReactTransitionGroup`
 
-`ReactTransitionGroup` is the basis for animations. When children are declaratively added or removed from it (as in the example above) special lifecycle hooks are called on them.
+`ReactTransitionGroup` is the basis for animations. It is accessible as `React.addons.TransitionGroup`. When children are declaratively added or removed from it (as in the example above) special lifecycle hooks are called on them.
 
 ### `componentWillEnter(callback)`
 


### PR DESCRIPTION
Update to the animation documentation for ReactTransitionGroup to clear the air on where one can use it.

If someone tries to use it off of React.addons.ReactTransitionGroup, which is undefined, instead of its real location, React.addons.TransitionGroup, they get a vague error about being unable to set defaultProps of undefined in the React createElement body.
