### PR TITLE
Handle 6 or more arguments to StateSetter.

### DIFF
--- a/src/core/ReactStateSetters.js
+++ b/src/core/ReactStateSetters.js
@@ -24,7 +24,8 @@ var ReactStateSetters = {
    */
   createStateSetter: function(component, funcReturningState) {
     return function(a, b, c, d, e, f) {
-      var partialState = funcReturningState.call(component, a, b, c, d, e, f);
+      var partialState = funcReturningState.apply(component, arguments);
+
       if (partialState) {
         component.setState(partialState);
       }

--- a/src/core/__tests__/ReactStateSetters-test.js
+++ b/src/core/__tests__/ReactStateSetters-test.js
@@ -68,6 +68,29 @@ describe('ReactStateSetters', function() {
     expect(instance.state).toEqual({foo: 33, bar: 1320});
   });
 
+  it('createStateSetter should update state with more than 6 arguments', function() {
+    var instance = <TestComponent />;
+    instance = ReactTestUtils.renderIntoDocument(instance);
+    expect(instance.state).toEqual({foo: 'foo'});
+
+    var setter = ReactStateSetters.createStateSetter(
+      instance,
+      function(a, b, c, d, e, f, g) {
+        return {
+          foo: a + b + c + d + e + f + g
+        };
+      }
+    );
+    expect(instance.state).toEqual({foo: 'foo'});
+
+    setter(1, 2, 3, 4, 5, 6, 7);
+    expect(instance.state).toEqual({foo: 28});
+
+    setter(1, 2, 3, 4, 5, 6, 8);
+    expect(instance.state).toEqual({foo: 29});
+
+  });
+
   it('createStateKeySetter should update state', function() {
     var instance = <TestComponent />;
     instance = ReactTestUtils.renderIntoDocument(instance);


### PR DESCRIPTION
In some cases I want to pass more than 6 arguments
but I can not. This change uses the optimized code path for most people
however it falls back to apply to handle the rare use case of many
arguments, instead of just silently failing.