### PR TITLE
Use warning module for context warning instead of invoking console.warn ...

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -597,19 +597,16 @@ var ReactCompositeComponentMixin = assign({},
    _warnIfContextsDiffer: function(ownerBasedContext, parentBasedContext) {
     var ownerKeys = Object.keys(ownerBasedContext).sort();
     var parentKeys = Object.keys(parentBasedContext).sort();
-    if (ownerKeys.length != parentKeys.length || ownerKeys.toString() != parentKeys.toString()) {
-      var message = ("owner based context (keys: " +
-        Object.keys(ownerBasedContext) + ") does not equal parent based" +
-        " context (keys: "+Object.keys(parentBasedContext)+")" +
-        " while mounting " +
-        (this._instance.constructor.displayName || 'ReactCompositeComponent'));
-      console.warn(message);
-      monitorCodeUse('contexts_differ', {
-        ownerBasedKeys: Object.keys(ownerBasedContext),
-        parentBasedKeys: Object.keys(parentBasedContext),
-        mounting: (this._instance.constructor.displayName || 'ReactCompositeComponent')
-      });
-    }
+    warning(
+      ownerKeys.length === parentKeys.length &&
+      ownerKeys.toString() === parentKeys.toString(),
+      'owner based context (keys: %s) does not equal parent based' +
+      ' context (keys: %s) while mounting %s' +
+      ' (see: http://fb.me/react-context-by-parent)',
+      Object.keys(ownerBasedContext),
+      Object.keys(parentBasedContext),
+      (this._instance.constructor.displayName || 'ReactCompositeComponent')
+    );
   },
 
   /**

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -1026,8 +1026,9 @@ describe('ReactCompositeComponent', function() {
 
     expect(console.warn.mock.calls.length).toBe(2);
     expect(console.warn.mock.calls[1][0]).toBe(
-      'owner based context (keys: foo) does not equal parent based ' +
-      'context (keys: ) while mounting ReactCompositeComponent'
+      'Warning: owner based context (keys: foo) does not equal parent based ' +
+      'context (keys: ) while mounting ReactCompositeComponent ' +
+      '(see: http://fb.me/react-context-by-parent)'
     );
 
   });


### PR DESCRIPTION
Use warning module for context warning instead of invoking console.warn and monitorCodeUse directly.  Depends on internal change: https://phabricator.fb.com/D1695279

@sebmarkbage Is this what you had in mind?
