### PR TITLE
Fix typo in comment of jquery-bootstrap example

### DIFF
--- a/examples/jquery-bootstrap/js/app.js
+++ b/examples/jquery-bootstrap/js/app.js
@@ -12,8 +12,8 @@ var BootstrapButton = React.createClass({
 });
 
 var BootstrapModal = React.createClass({
-  // The following four methods are the only places we need to
-  // integrate with Bootstrap or jQuery!
+  // The following two methods are the only places we need to
+  // integrate Bootstrap or jQuery with the components lifecycle methods.
   componentDidMount: function() {
     // When the component is added, turn it into a modal
     $(this.getDOMNode())


### PR DESCRIPTION
Minor typo in comment. May even make more sense to just remove the number from the comment...
