### PR TITLE
Add additional field for ART reconciler

### DIFF
--- a/src/core/ReactComponent.js
+++ b/src/core/ReactComponent.js
@@ -89,7 +89,11 @@ var ReactComponent = {
       // We keep the old element and a reference to the pending element
       // to track updates.
       this._currentElement = element;
+      // These two fields are used by the DOM and ART diffing algorithms
+      // respectively. Instead of using expandos on components, we should be
+      // storing the state needed by the diffing algorithms elsewhere.
       this._mountIndex = 0;
+      this._mountImage = null;
     },
 
     /**


### PR DESCRIPTION
ART, just like MultiChild adds an expando property to manage it's diffing
state. This is ugly and bad. We should be moving this state outside the
component for use by the diffing algorithm. This state is not needed by
components nested in composites, and varies by diffing algorithm.

It sucks that I have to add it to every component just to support ART,
but that's the quickest solution, other than disabling preventExtensions.

At least now we know that it sucks.
