### PR TITLE
reactComponentExpect expects itself

### DIFF
--- a/src/test/reactComponentExpect.js
+++ b/src/test/reactComponentExpect.js
@@ -18,7 +18,7 @@ var ReactTestUtils = require('ReactTestUtils');
 var assign = require('Object.assign');
 
 function reactComponentExpect(instance) {
-  if (instance instanceof reactComponentExpect) {
+  if (instance instanceof reactComponentExpectInternal) {
     return instance;
   }
 


### PR DESCRIPTION
This was a bug when reactComponentExpectInternal was separated from
the normal reactComponentExpect flow.
