### PR TITLE
Replaced document.createElement with ReactTestUtil

### DIFF
--- a/src/addons/link/__tests__/LinkedStateMixin-test.js
+++ b/src/addons/link/__tests__/LinkedStateMixin-test.js
@@ -17,11 +17,13 @@ describe('LinkedStateMixin', function() {
   var LinkedStateMixin;
   var React;
   var ReactLink;
+  var ReactTestUtils;
 
   beforeEach(function() {
     LinkedStateMixin = require('LinkedStateMixin');
     React = require('React');
     ReactLink = require('ReactLink');
+    ReactTestUtils = require('ReactTestUtils');
   });
 
   it('should create a ReactLink for state', function() {
@@ -36,8 +38,7 @@ describe('LinkedStateMixin', function() {
         return <span>value is {this.state.value}</span>;
       }
     });
-    var container = document.createElement('div');
-    var component = React.render(<Component />, container);
+    var component = ReactTestUtils.renderIntoDocument(<Component />);
     var link = component.linkState('value');
     expect(component.state.value).toBe('initial value');
     expect(link.value).toBe('initial value');

--- a/src/browser/ui/__tests__/ReactEventListener-test.js
+++ b/src/browser/ui/__tests__/ReactEventListener-test.js
@@ -21,6 +21,7 @@ describe('ReactEventListener', function() {
 
   var ReactMount;
   var ReactEventListener;
+  var ReactTestUtils;
   var handleTopLevel;
 
   beforeEach(function() {
@@ -29,6 +30,7 @@ describe('ReactEventListener', function() {
 
     ReactMount = require('ReactMount');
     ReactEventListener = require('ReactEventListener');
+    ReactTestUtils = require('ReactTestUtils');
 
     handleTopLevel = mocks.getMockFunction();
     ReactEventListener._handleTopLevel = handleTopLevel;
@@ -158,7 +160,6 @@ describe('ReactEventListener', function() {
   });
 
   it('should not fire duplicate events for a React DOM tree', function() {
-    var container = document.createElement('div');
     var Wrapper = React.createClass({
 
       getInner: function() {
@@ -172,7 +173,7 @@ describe('ReactEventListener', function() {
 
     });
 
-    var instance = ReactMount.render(<Wrapper />, container);
+    var instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
 
     var callback = ReactEventListener.dispatchEvent.bind(null, 'test');
     callback({

--- a/src/browser/ui/dom/components/__tests__/ReactDOMInput-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMInput-test.js
@@ -195,11 +195,10 @@ describe('ReactDOMInput', function() {
   });
 
   it('should support ReactLink', function() {
-    var container = document.createElement('div');
     var link = new ReactLink('yolo', mocks.getMockFunction());
     var instance = <input type="text" valueLink={link} />;
 
-    instance = React.render(instance, container);
+    instance = ReactTestUtils.renderIntoDocument(instance);
 
     expect(instance.getDOMNode().value).toBe('yolo');
     expect(link.value).toBe('yolo');
@@ -274,11 +273,10 @@ describe('ReactDOMInput', function() {
   });
 
   it('should support checkedLink', function() {
-    var container = document.createElement('div');
     var link = new ReactLink(true, mocks.getMockFunction());
     var instance = <input type="checkbox" checkedLink={link} />;
 
-    instance = React.render(instance, container);
+    instance = ReactTestUtils.renderIntoDocument(instance);
 
     expect(instance.getDOMNode().checked).toBe(true);
     expect(link.value).toBe(true);

--- a/src/core/__tests__/ReactComponentLifeCycle-test.js
+++ b/src/core/__tests__/ReactComponentLifeCycle-test.js
@@ -440,10 +440,8 @@ describe('ReactComponentLifeCycle', function() {
       }
     });
 
-    var container = document.createElement('div');
-    var instance = React.render(
-      <Component text="uno" tooltipText="one" />,
-      container
+    var instance = ReactTestUtils.renderIntoDocument(
+      <Component text="uno" tooltipText="one" />
     );
 
     // Since `instance` is a root component, we can set its props. This also

--- a/src/core/__tests__/ReactIdentity-test.js
+++ b/src/core/__tests__/ReactIdentity-test.js
@@ -182,7 +182,7 @@ describe('ReactIdentity', function() {
 
     expect(function() {
 
-      React.render(<TestContainer />, document.createElement('div'));
+      ReactTestUtils.renderIntoDocument(<TestContainer />);
 
     }).not.toThrow();
   });
@@ -218,7 +218,7 @@ describe('ReactIdentity', function() {
 
     expect(function() {
 
-      React.render(<TestContainer />, document.createElement('div'));
+      ReactTestUtils.renderIntoDocument(<TestContainer />);
 
     }).not.toThrow();
   });
@@ -245,7 +245,7 @@ describe('ReactIdentity', function() {
 
     expect(function() {
 
-      React.render(<TestContainer />, document.createElement('div'));
+      ReactTestUtils.renderIntoDocument(<TestContainer />);
 
     }).not.toThrow();
   });
@@ -304,7 +304,7 @@ describe('ReactIdentity', function() {
       </div>;
 
     expect(function() {
-      React.render(component, document.createElement('div'));
+      ReactTestUtils.renderIntoDocument(component);
     }).not.toThrow();
   });
 

--- a/src/core/__tests__/ReactMultiChildText-test.js
+++ b/src/core/__tests__/ReactMultiChildText-test.js
@@ -214,23 +214,18 @@ describe('ReactMultiChildText', function() {
   });
 
   it('should render between nested components and inline children', function() {
-    var container = document.createElement('div');
-    React.render(<div><h1><span /><span /></h1></div>, container);
+    ReactTestUtils.renderIntoDocument(<div><h1><span /><span /></h1></div>);
 
     expect(function() {
-      React.render(<div><h1>A</h1></div>, container);
+      ReactTestUtils.renderIntoDocument(<div><h1>A</h1></div>);
     }).not.toThrow();
 
-    React.render(<div><h1><span /><span /></h1></div>, container);
-
     expect(function() {
-      React.render(<div><h1>{['A']}</h1></div>, container);
+      ReactTestUtils.renderIntoDocument(<div><h1>{['A']}</h1></div>);
     }).not.toThrow();
 
-    React.render(<div><h1><span /><span /></h1></div>, container);
-
     expect(function() {
-      React.render(<div><h1>{['A', 'B']}</h1></div>, container);
+      ReactTestUtils.renderIntoDocument(<div><h1>{['A', 'B']}</h1></div>);
     }).not.toThrow();
   });
 });

--- a/src/core/__tests__/ReactUpdates-test.js
+++ b/src/core/__tests__/ReactUpdates-test.js
@@ -798,8 +798,7 @@ describe('ReactUpdates', function() {
       }
     });
 
-    var container = document.createElement('div');
-    var component = React.render(<A />, container);
+    var component = ReactTestUtils.renderIntoDocument(<A />);
     component.forceUpdate();
     expect(callbackCount).toBe(2);
   });
@@ -832,8 +831,7 @@ describe('ReactUpdates', function() {
       }
     });
 
-    var container = document.createElement('div');
-    var component = React.render(<A />, container);
+    var component = ReactTestUtils.renderIntoDocument(<A />);
     component.setState({updates: 1});
     expect(log).toEqual([
       'render-0',
@@ -880,9 +878,7 @@ describe('ReactUpdates', function() {
       }
     });
 
-    var container = document.createElement('div');
-
-    var component = React.render(<A />, container);
+    var component = ReactTestUtils.renderIntoDocument(<A />);
 
     ReactUpdates.batchedUpdates(function() {
       // B will have scheduled an update but the batching should ensure that its


### PR DESCRIPTION
Replaced document.createElement with ReactTestUtils.renderIntoDocument where container was not subsequently utilized.
Fixes #1250
