### PR TITLE
Use jest for `npm test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "version": 4
   },
   "scripts": {
-    "test": "./node_modules/.bin/grunt test",
+    "test": "jest",
     "jest": "jest"
   },
   "jest": {


### PR DESCRIPTION
I've given in and this is easier than `npm run jest`. `grunt test` still
exists and is used by Travis so this has no CI implications.
