### PR TITLE
[RFC] Add enum utility function

### DIFF
--- a/src/utils/enum.js
+++ b/src/utils/enum.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2013-2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule keyMirror
+ * @typechecks static-only
+ */
+
+"use strict";
+
+/**
+ * Constructs an object with keys equal to their value.
+ *
+ * For example:
+ *
+ *   var COLORS = enum('blue', 'red');
+ *   var myColor = COLORS.blue;
+ *   var isColorValid = !!COLORS[myColor];
+ *
+ * The last line could not be performed if the values of the generated enum were
+ * not equal to their keys.
+ *
+ *   Input:  'key1', 'key2', ..., 'keyN'
+ *   Output: {key1: 'key1', key2: 'key2', ..., keyN: 'keyN'}
+ *
+ * @param string(s)
+ * @return {object}
+ */
+var enum = function(...values) {
+  var keyMirror = require('keyMirror');
+  return Object.freeze(keyMirror(asKeys(values)));
+
+  function asKeys(values) {
+    var o = {};
+
+    values.forEach(function (key) {
+      o[key] = null;
+    });
+
+    return o;
+  }
+};
+
+module.exports = enum;


### PR DESCRIPTION
_Initially this PR is not intended for merge for but primarily as a Request for Comments._

A few days ago I was poking around the code base with a friend and I came across the `keyMirror` utility function. I could see from how it was being used what the intention behind the function was but I had the feeling that the implementation (and api) of the function wasn't carried through enough to be useable in a practical sense.

When I'm thinking of creating an enum what I want to do is simply define the set of valid values for it, I don't want to be hassled into first constructing an object literal whose keys represent my values. If I'm going to do that I might as well make a macro in my editor which transforms some structured list into that object. 

I'd rather do this:

``` js
var COLORS = enum('red', 'blue');
```

than: 

``` js
var COLORS = keyMirror({
  red: null,
  blue: null
});
```

I've implemented `enum` in terms of `keyMirror` but it really doesn't need to be. If `keyMirror` is only being used to build enumerations then I think it makes more sense to replace it entirely with `enum` however I'm not sure how important BC is. I've given some thought on how to bring the two functions together but I'm interested in knowing your opinion on it.

I'm also using the spread operator from ES6, I'm not sure if that's allowed or not.

**Note** I'm waiting on feedback before adding tests for this, no need to waste time on something that's not going anywhere :)
