### PR TITLE
Add top-level API docs section for React.createElement.

### DIFF
--- a/docs/docs/ref-01-top-level-api.md
+++ b/docs/docs/ref-01-top-level-api.md
@@ -22,6 +22,21 @@ Create a component given a specification. A component implements a `render` meth
 For more information about the specification object, see [Component Specs and Lifecycle](/react/docs/component-specs.html).
 
 
+### React.createElement
+
+```javascript
+function createElement(
+  string/ReactComponent type,
+  [object props],
+  [children ...]
+)
+```
+
+Create and return a new ReactElement of the given type. The type argument can be either an
+html tag name string (eg. 'div', 'span', etc), or a `ReactComponent` class that was created
+with `React.createClass`.
+
+
 ### React.render
 
 ```javascript


### PR DESCRIPTION
I thought it was strange that React.createElement is not documented in the [top level API docs](http://facebook.github.io/react/docs/top-level-api.html). It's mentioned elsewhere in the docs so it appears to be a part of the public interface.

This PR just adds a basic mention of this function in that document. I did sign the facebook CLA under this github username, fwiw.
