### PR TITLE
Can bind events to ShadowRoots.

### DIFF
--- a/src/browser/ui/ReactDOMComponent.js
+++ b/src/browser/ui/ReactDOMComponent.js
@@ -82,16 +82,16 @@ var ShadowRoot = ExecutionEnvironment.canUseDOM ? window.ShadowRoot : false;
  */
 var realContainer = !!ShadowRoot ?
   function(node) { // if browser supports shadow DOM
-    if (node instanceof ShadowRoot || !node.parentNode) {
-      return node;
+    var _node = node;
+    // iterates until we find the shadow root or until the parent is reached
+    while (!(_node instanceof ShadowRoot) && _node.parentNode)
+    {
+      _node = node.parentNode;
     }
-    return realContainer(node.parentNode);   // tries to go up in the shadow DOM tree to get the root
+    return _node;
   } :
   function(node) {
-    if (!node.parentNode) {
-      return node;
-    }
-    return realContainer(node.parentNode);
+    return node.ownerDocument;
   };
   
 function putListener(id, registrationName, listener, transaction) {

--- a/src/browser/ui/ReactDOMComponent.js
+++ b/src/browser/ui/ReactDOMComponent.js
@@ -15,6 +15,7 @@
 var CSSPropertyOperations = require('CSSPropertyOperations');
 var DOMProperty = require('DOMProperty');
 var DOMPropertyOperations = require('DOMPropertyOperations');
+var ExecutionEnvironment = require('ExecutionEnvironment');
 var ReactComponent = require('ReactComponent');
 var ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
 var ReactMount = require('ReactMount');
@@ -74,6 +75,25 @@ function assertValidProps(props) {
   );
 }
 
+var ShadowRoot = ExecutionEnvironment.canUseDOM ? window.ShadowRoot : false;
+
+/**
+ * @param {object}  node
+ */
+var realContainer = !!ShadowRoot ?
+  function(node) { // if browser supports shadow DOM
+    if (node instanceof ShadowRoot || !node.parentNode) {
+      return node;
+    }
+    return realContainer(node.parentNode);   // tries to go up in the shadow DOM tree to get the root
+  } :
+  function(node) {
+    if (!node.parentNode) {
+      return node;
+    }
+    return realContainer(node.parentNode);
+  };
+  
 function putListener(id, registrationName, listener, transaction) {
   if (__DEV__) {
     // IE8 has no API for event capturing and the `onScroll` event doesn't

--- a/src/browser/ui/ReactDOMComponent.js
+++ b/src/browser/ui/ReactDOMComponent.js
@@ -107,7 +107,7 @@ function putListener(id, registrationName, listener, transaction) {
   var container = ReactMount.findReactContainerForID(id);
   if (container) {
     var doc = container.nodeType === ELEMENT_NODE_TYPE ?
-      container.ownerDocument :
+      realContainer(container) :
       container;
     listenTo(registrationName, doc);
   }


### PR DESCRIPTION
I created a chrome extension with react. And when inserting in the DOM, the styles would collapse with the page.

The solution I found was the most elegant was to create a shadow root and render my react component inside it.

Problem is that the events were not bound properly because of shadow boundaries. Here are my modifications :)
