### PR TITLE
add note re: handling events in capture phase

### DIFF
--- a/docs/docs/ref-05-events.md
+++ b/docs/docs/ref-05-events.md
@@ -35,7 +35,9 @@ String type
 ## Supported Events
 
 React normalizes events so that they have consistent properties across
-different browsers. The event handlers below are triggered by an event in the bubbling phase; to register an event handler for the capture phase, append "Capture" to the event name (for example: onClick -> onClickCapture).
+different browsers. 
+
+The event handlers below are triggered by an event in the bubbling phase. To register an event handler for the capture phase, append `Capture` to the event name; for example, instead of using `onClick`, you would use `onClickCapture` to handle the click event in the capture phase.
 
 
 ### Clipboard Events


### PR DESCRIPTION
Couldn't find any mention in the documentation on how to handle events during the capture phase. I added a sentence in the events documentation to explain the "...Capture" syntax. Feel free to move the explanation elsewhere.
