### PR TITLE
Give context aware message if markup reuse fails

### DIFF
--- a/src/browser/ui/__tests__/ReactRenderDocument-test.js
+++ b/src/browser/ui/__tests__/ReactRenderDocument-test.js
@@ -210,7 +210,9 @@ describe('rendering React components at document', function() {
       'are impure. React cannot handle this case due to cross-browser ' +
       'quirks by rendering at the document root. You should look for ' +
       'environment dependent code in your components and ensure ' +
-      'the props are the same client and server side.'
+      'the props are the same client and server side:\n' +
+      ' (client) data-reactid=".0.1">Hello world</body></\n' +
+      ' (server) data-reactid=".0.1">Goodbye world</body>'
     );
   });
 


### PR DESCRIPTION
If markup reuse fails, give context for the failure by showing where output from both server and client side markup start to differ:

![image](https://cloud.githubusercontent.com/assets/35656/5238366/ed1b1c0a-78ae-11e4-810d-67afe4ca9817.png)
