### PR TITLE
In `Transferring Props` guide, `Manual Transfer` section will lead an er...

### DIFF
--- a/docs/docs/06-transferring-props.md
+++ b/docs/docs/06-transferring-props.md
@@ -38,7 +38,7 @@ var FancyCheckbox = React.createClass({
   }
 });
 React.render(
-  <FancyCheckbox checked={true} onClick={console.log}>
+  <FancyCheckbox checked={true} onClick={console.log.bind(console)}>
     Hello world!
   </FancyCheckbox>,
   document.body


### PR DESCRIPTION
...ror

``` c
var FancyCheckbox = React.createClass({
  render: function() {
    var fancyClass = this.props.checked ? 'FancyChecked' : 'FancyUnchecked';
    return (
      <div className={fancyClass} onClick={this.props.onClick}>
        {this.props.children}
      </div>
    );
  }
});
React.render(
  <FancyCheckbox checked={true} onClick={console.log}>
    Hello world!
  </FancyCheckbox>,
  document.body
);
```

When click `Hello world!` will lead a `Uncaught TypeError: Illegal invocation` error
