### PR TITLE
Add ability to remove/reset state back to null

### DIFF
--- a/docs/docs/ref-02-component-api.md
+++ b/docs/docs/ref-02-component-api.md
@@ -36,7 +36,7 @@ Merges nextState with the current state. This is the primary method you use to t
 replaceState(object nextState[, function callback])
 ```
 
-Like `setState()` but deletes any pre-existing state keys that are not in nextState.
+Like `setState()` but deletes any pre-existing state keys that are not in nextState. If you pass `null` instead of object, `this.state` will be reset back to `null`.
 
 
 ### forceUpdate()

--- a/src/core/__tests__/ReactCompositeComponentState-test.js
+++ b/src/core/__tests__/ReactCompositeComponentState-test.js
@@ -48,10 +48,6 @@ describe('ReactCompositeComponent-state', function() {
         this.setState({color: nextColor});
       },
 
-      removeState: function() {
-        this.replaceState(null);
-      },
-
       getInitialState: function() {
         this.peekAtState('getInitialState');
         return {color: 'red'};
@@ -117,7 +113,7 @@ describe('ReactCompositeComponent-state', function() {
     instance.setProps({nextColor: 'green'});
     instance.setFavoriteColor('blue');
     instance.forceUpdate();
-    instance.removeState();
+    instance.replaceState(null);
 
     React.unmountComponentAtNode(container);
     expect(stateListener.mock.calls).toEqual([
@@ -166,7 +162,7 @@ describe('ReactCompositeComponent-state', function() {
       [ 'render', 'blue', null ],
       [ 'componentDidUpdate-currentState', 'blue', null ],
       [ 'componentDidUpdate-prevState', 'blue' ],
-      // removeState()
+      // replaceState(null)
       [ 'shouldComponentUpdate-currentState', 'blue', null ],
       [ 'shouldComponentUpdate-nextState', null ],
       [ 'componentWillUpdate-currentState', 'blue', null ],

--- a/src/core/__tests__/ReactCompositeComponentState-test.js
+++ b/src/core/__tests__/ReactCompositeComponentState-test.js
@@ -30,7 +30,7 @@ describe('ReactCompositeComponent-state', function() {
 
     TestComponent = React.createClass({
       peekAtState: function(from, state) {
-        if (state) {
+        if (state !== undefined) {
           this.props.stateListener(from, state && state.color);
         } else {
           var internalInstance = ReactInstanceMap.get(this);
@@ -48,6 +48,10 @@ describe('ReactCompositeComponent-state', function() {
         this.setState({color: nextColor});
       },
 
+      removeState: function() {
+        this.replaceState(null);
+      },
+
       getInitialState: function() {
         this.peekAtState('getInitialState');
         return {color: 'red'};
@@ -55,7 +59,7 @@ describe('ReactCompositeComponent-state', function() {
 
       render: function() {
         this.peekAtState('render');
-        return <div>{this.state.color}</div>;
+        return <div>{this.state && this.state.color}</div>;
       },
 
       componentWillMount: function() {
@@ -113,9 +117,9 @@ describe('ReactCompositeComponent-state', function() {
     instance.setProps({nextColor: 'green'});
     instance.setFavoriteColor('blue');
     instance.forceUpdate();
+    instance.removeState();
 
     React.unmountComponentAtNode(container);
-
     expect(stateListener.mock.calls).toEqual([
       // there is no state when getInitialState() is called
       [ 'getInitialState', null, null ],
@@ -162,9 +166,17 @@ describe('ReactCompositeComponent-state', function() {
       [ 'render', 'blue', null ],
       [ 'componentDidUpdate-currentState', 'blue', null ],
       [ 'componentDidUpdate-prevState', 'blue' ],
+      // removeState()
+      [ 'shouldComponentUpdate-currentState', 'blue', null ],
+      [ 'shouldComponentUpdate-nextState', null ],
+      [ 'componentWillUpdate-currentState', 'blue', null ],
+      [ 'componentWillUpdate-nextState', null ],
+      [ 'render', null, null ],
+      [ 'componentDidUpdate-currentState', null, null ],
+      [ 'componentDidUpdate-prevState', 'blue' ],
       // unmountComponent()
       // state is available within `componentWillUnmount()`
-      [ 'componentWillUnmount', 'blue', null ]
+      [ 'componentWillUnmount', null, null ]
     ]);
   });
 });


### PR DESCRIPTION
As mentioned in #2572, replaceState(null) should set the state of component back to null.