### PR TITLE
Use String.charAt to lookup string characters by index

### DIFF
--- a/src/browser/ui/ReactMount.js
+++ b/src/browser/ui/ReactMount.js
@@ -63,7 +63,7 @@ var findComponentRootReusableArray = [];
 function firstDifferenceIndex(string1, string2) {
   var minLen = Math.min(string1.length, string2.length);
   for (var i = 0; i < minLen; i++) {
-    if (string1[i] !== string2[i]) {
+    if (string1.charAt(i) !== string2.charAt(i)) {
       return i;
     }
   }


### PR DESCRIPTION
Using object property accessor for string character lookup breaks in non-modern browsers.
