### PR TITLE
Support marginHeight and marginWidth attributes

### DIFF
--- a/src/browser/ui/dom/HTMLDOMPropertyConfig.js
+++ b/src/browser/ui/dom/HTMLDOMPropertyConfig.js
@@ -104,6 +104,8 @@ var HTMLDOMPropertyConfig = {
     list: MUST_USE_ATTRIBUTE,
     loop: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
     manifest: MUST_USE_ATTRIBUTE,
+    marginHeight: MUST_USE_ATTRIBUTE | HAS_POSITIVE_NUMERIC_VALUE,
+    marginWidth: MUST_USE_ATTRIBUTE | HAS_POSITIVE_NUMERIC_VALUE,
     max: null,
     maxLength: MUST_USE_ATTRIBUTE,
     media: MUST_USE_ATTRIBUTE,


### PR DESCRIPTION
These are used for iframes to set the default margin on the body of the iframe.
