### PR TITLE
Use getSelection in IE where available

### DIFF
--- a/src/browser/ui/ReactDOMSelection.js
+++ b/src/browser/ui/ReactDOMSelection.js
@@ -189,7 +189,11 @@ function setModernOffsets(node, offsets) {
   }
 }
 
-var useIEOffsets = ExecutionEnvironment.canUseDOM && document.selection;
+var useIEOffsets = (
+  ExecutionEnvironment.canUseDOM &&
+  'selection' in document &&
+  !('getSelection' in window)
+);
 
 var ReactDOMSelection = {
   /**


### PR DESCRIPTION
IE9+ has support for window.getSelection, but we’re still using
document.selection for IE9/10. Only use the old IE selection API if the
modern one is unavailable.
