### PR TITLE
Remove deprecated methods since 0.12 shipped

### DIFF
--- a/src/browser/ui/React.js
+++ b/src/browser/ui/React.js
@@ -35,7 +35,6 @@ var ReactRef = require('ReactRef');
 var ReactServerRendering = require('ReactServerRendering');
 
 var assign = require('Object.assign');
-var deprecated = require('deprecated');
 var onlyChild = require('onlyChild');
 
 ReactDefaultInjection.inject();
@@ -78,37 +77,7 @@ var React = {
   withContext: ReactContext.withContext,
 
   // Hook for JSX spread, don't use this for anything else.
-  __spread: assign,
-
-  // Deprecations (remove for 0.13)
-  renderComponent: deprecated(
-    'React',
-    'renderComponent',
-    'render',
-    this,
-    render
-  ),
-  renderComponentToString: deprecated(
-    'React',
-    'renderComponentToString',
-    'renderToString',
-    this,
-    ReactServerRendering.renderToString
-  ),
-  renderComponentToStaticMarkup: deprecated(
-    'React',
-    'renderComponentToStaticMarkup',
-    'renderToStaticMarkup',
-    this,
-    ReactServerRendering.renderToStaticMarkup
-  ),
-  isValidComponent: deprecated(
-    'React',
-    'isValidComponent',
-    'isValidElement',
-    this,
-    ReactElement.isValidElement
-  )
+  __spread: assign
 };
 
 // Inject the runtime into a devtools global hook regardless of browser.

--- a/src/browser/ui/ReactMount.js
+++ b/src/browser/ui/ReactMount.js
@@ -24,7 +24,6 @@ var ReactUpdates = require('ReactUpdates');
 
 var emptyObject = require('emptyObject');
 var containsNode = require('containsNode');
-var deprecated = require('deprecated');
 var getReactRootElementInContainer = require('getReactRootElementInContainer');
 var instantiateReactComponent = require('instantiateReactComponent');
 var invariant = require('invariant');
@@ -815,14 +814,5 @@ ReactPerf.measureMethods(ReactMount, 'ReactMount', {
   _renderNewRootComponent: '_renderNewRootComponent',
   _mountImageIntoNode: '_mountImageIntoNode'
 });
-
-// Deprecations (remove for 0.13)
-ReactMount.renderComponent = deprecated(
-  'ReactMount',
-  'renderComponent',
-  'render',
-  this,
-  ReactMount.render
-);
 
 module.exports = ReactMount;

--- a/src/classic/propTypes/ReactPropTypes.js
+++ b/src/classic/propTypes/ReactPropTypes.js
@@ -14,7 +14,6 @@
 var ReactElement = require('ReactElement');
 var ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
 
-var deprecated = require('deprecated');
 var emptyFunction = require('emptyFunction');
 
 /**
@@ -85,22 +84,7 @@ var ReactPropTypes = {
   objectOf: createObjectOfTypeChecker,
   oneOf: createEnumTypeChecker,
   oneOfType: createUnionTypeChecker,
-  shape: createShapeTypeChecker,
-
-  component: deprecated(
-    'React.PropTypes',
-    'component',
-    'element',
-    this,
-    elementTypeChecker
-  ),
-  renderable: deprecated(
-    'React.PropTypes',
-    'renderable',
-    'node',
-    this,
-    nodeTypeChecker
-  )
+  shape: createShapeTypeChecker
 };
 
 function createChainableTypeChecker(validate) {

--- a/src/classic/propTypes/__tests__/ReactPropTypes-test.js
+++ b/src/classic/propTypes/__tests__/ReactPropTypes-test.js
@@ -405,35 +405,6 @@ describe('ReactPropTypes', function() {
     it('should accept empty array for required props', function() {
       typeCheckPass(PropTypes.node.isRequired, []);
     });
-
-    it('should still work for deprecated typechecks', function() {
-      // We can't use typeCheckPass here because the warning module may do
-      // something different in some environments. Luckily they should be fine
-      // if they detect that console.warn is spied upon.
-      spyOn(console, 'warn');
-
-      // typeCheckPass(PropTypes.renderable, []);
-      var error = PropTypes.renderable(
-        {testProp: []},
-        'testProp',
-        'testComponent',
-        ReactPropTypeLocations.prop
-      );
-
-      expect(error).toBe(undefined);
-      expect(console.warn.calls.length).toBe(1);
-
-      // typeCheckPass(PropTypes.renderable.isRequired, []);
-      error = PropTypes.renderable.isRequired(
-        {testProp: []},
-        'testProp',
-        'testComponent',
-        ReactPropTypeLocations.prop
-      );
-
-      expect(error).toBe(undefined);
-      expect(console.warn.calls.length).toBe(1);
-    });
   });
 
   describe('ObjectOf Type', function() {


### PR DESCRIPTION
Test plan: `npm test`
