### PR TITLE
Add additional supported methods to event documentation

### DIFF
--- a/docs/docs/ref-05-events.md
+++ b/docs/docs/ref-05-events.md
@@ -21,7 +21,9 @@ Number eventPhase
 boolean isTrusted
 DOMEvent nativeEvent
 void preventDefault()
+void isDefaultPrevented()
 void stopPropagation()
+void isPropagationStopped()
 DOMEventTarget target
 Date timeStamp
 String type


### PR DESCRIPTION
`isPropagationStopped` and `isDefaultPrevented` methods do in fact exist on `SyntheticEvent`

I have indeed signed the CLA.