### PR TITLE
Update Danger.js to support IE8 in Quirks mode

### DIFF
--- a/src/browser/ui/dom/Danger.js
+++ b/src/browser/ui/dom/Danger.js
@@ -105,10 +105,12 @@ var Danger = {
 
       for (i = 0; i < renderNodes.length; ++i) {
         var renderNode = renderNodes[i];
+        var indexAttr = renderNode.getAttribute(RESULT_INDEX_ATTR);
         if (renderNode.hasAttribute &&
-            renderNode.hasAttribute(RESULT_INDEX_ATTR)) {
+            renderNode.hasAttribute(RESULT_INDEX_ATTR) ||
+            indexAttr != null && indexAttr != '') {
 
-          resultIndex = +renderNode.getAttribute(RESULT_INDEX_ATTR);
+          resultIndex = +indexAttr;
           renderNode.removeAttribute(RESULT_INDEX_ATTR);
 
           invariant(


### PR DESCRIPTION
The hasAttribute method requires IE8 Standards mode, while getAttribute is supported also in IE8 compatibility mode. In the limited context of a named attribute expecting to return an integer, checking for null and empty string on getAttribute would be largely equivalent to the result of hasAttribute. This seems to me the only way to extend support to IE8 in compatibility mode since hasAttribute cannot be shimmed. However, I'm not sure this is the only place where changes are needed to support IE8 in compatibility mode.
