### PR TITLE
Fixed ReactTestUtils scry for TextComponents.  Fix

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -124,6 +124,9 @@ var ReactTestUtils = {
         if (!renderedChildren.hasOwnProperty(key)) {
           continue;
         }
+        if (!renderedChildren[key].getPublicInstance) {
+          continue;
+        }
         ret = ret.concat(
           ReactTestUtils.findAllInRenderedTree(
             renderedChildren[key].getPublicInstance(),
@@ -167,7 +170,9 @@ var ReactTestUtils = {
     var all =
       ReactTestUtils.scryRenderedDOMComponentsWithClass(root, className);
     if (all.length !== 1) {
-      throw new Error('Did not find exactly one match for class:' + className);
+      throw new Error('Did not find exactly one match '+
+        '(found: ' + all.length + ') for class:' + className
+      );
     }
     return all[0];
   },

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -110,4 +110,14 @@ describe('ReactTestUtils', function() {
     expect(updatedResultCausedByClick.type).toBe('a');
     expect(updatedResultCausedByClick.props.className).toBe('was-clicked');
   });
+
+  it('Test scryRenderedDOMComponentsWithClass with TextComponent', function() {
+    var renderedComponent = ReactTestUtils.renderIntoDocument(<div>Hello <span>Jim</span></div>);
+    var scryResults = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+      renderedComponent,
+      'NonExistantClass'
+    );
+    expect(scryResults.length).toBe(0);
+
+  });
 });


### PR DESCRIPTION
Fixed ReactTestUtils scry for TextComponents.  Fixes issue #2654.

We talked about it in #2654. But then we talked with @sebmarkbage in person and decided to just fix the scry.
