### PR TITLE
Fix for transition group trying to call lifecycle methods on undefined component 

### DIFF
--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -109,7 +109,7 @@ var ReactTransitionGroup = React.createClass({
 
   _handleDoneEntering: function(key) {
     var component = this.refs[key];
-    if (component.componentDidEnter) {
+    if (component != null && component.componentDidEnter) {
       component.componentDidEnter();
     }
 
@@ -142,7 +142,7 @@ var ReactTransitionGroup = React.createClass({
   _handleDoneLeaving: function(key) {
     var component = this.refs[key];
 
-    if (component.componentDidLeave) {
+    if (component != null && component.componentDidLeave) {
       component.componentDidLeave();
     }
 


### PR DESCRIPTION
When a component has a `TransitionGroup` as a child, and the component is unmounted before the enter (or leave) animation is complete, the following error occurs...

`Uncaught TypeError: Cannot read property 'componentDidEnter' of undefined`

This is a small fix to just make sure `component` is not `undefined` before checking for the `componentDidEnter` and `componentDidLeave` methods.
