### PR TITLE
Enable strip-types transform for internal code

### DIFF
--- a/bin/jsx-internal
+++ b/bin/jsx-internal
@@ -2,8 +2,7 @@
 // -*- mode: js -*-
 "use strict";
 
-var getAllVisitors = require('../vendor/fbtransform/visitors').getAllVisitors;
-var transform = require('jstransform').transform;
+var transform = require('../main').transform;
 var propagate = require("../vendor/constants").propagate;
 
 require("commoner").version(
@@ -31,7 +30,7 @@ require("commoner").version(
   var constants = context.config.constants || {};
 
   // This is where JSX, ES6, etc. desugaring happens.
-  source = transform(getAllVisitors(), source).code;
+  source = transform(source, {harmony: true, stripTypes: true});
 
   // Constant propagation means removing any obviously dead code after
   // replacing constant expressions with literal (boolean) values.


### PR DESCRIPTION
Flow is coming so we need to be ready.

Somebody started writing a diff adding types to keyMirror which doesn't build. So I tested that this does:

``` diff
diff --git a/src/utils/keyMirror.js b/src/utils/keyMirror.js
index 0e0c614..eaaa5f0 100644
--- a/src/utils/keyMirror.js
+++ b/src/utils/keyMirror.js
@@ -32,7 +32,11 @@ var invariant = require('invariant');
  * @param {object} obj
  * @return {object}
  */
-var keyMirror = function(obj) {
+function keyMirror<T>(obj: T): T {
+ return keyMirrorInternal(obj);
+}
+
+function keyMirrorInternal(obj) {
   var ret = {};
   var key;
   invariant(
```
