### PR TITLE
Add a dependsOn type checker

### DIFF
--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -29,6 +29,10 @@ React.createClass({
     // containing these types.
     optionalNode: React.PropTypes.node,
 
+    // You can ensure that both this prop and a dependency are present.
+    // Dependencies can also be passed as an Array: ['oneProp', 'twoProp'].
+    optionalDependency: React.PropTypes.dependsOn('otherProp', optionalTypeChecker),
+
     // A React element.
     optionalElement: React.PropTypes.element,
 

--- a/src/classic/propTypes/ReactPropTypes.js
+++ b/src/classic/propTypes/ReactPropTypes.js
@@ -78,6 +78,7 @@ var ReactPropTypes = {
 
   any: createAnyTypeChecker(),
   arrayOf: createArrayOfTypeChecker,
+  dependsOn: createDependencyChecker,
   element: elementTypeChecker,
   instanceOf: createInstanceTypeChecker,
   node: nodeTypeChecker,
@@ -148,6 +149,31 @@ function createArrayOfTypeChecker(typeChecker) {
       var error = typeChecker(propValue, i, componentName, location);
       if (error instanceof Error) {
         return error;
+      }
+    }
+  }
+  return createChainableTypeChecker(validate);
+}
+
+function createDependencyChecker(expectedPropNames, typeChecker) {
+  function validate(props, propName, componentName, location) {
+    if (!Array.isArray(expectedPropNames)) {
+      expectedPropNames = [expectedPropNames];
+    }
+    for (var i = 0; i < expectedPropNames.length; i++) {
+      var expectedPropName = expectedPropNames[i];
+      if (!props[expectedPropName]) {
+        var locationName = ReactPropTypeLocationNames[location];
+        return new Error(
+          `Invalid ${locationName} \`${propName}\` supplied to ` +
+          `\`${componentName}\` without \`${expectedPropName}\`.`
+        );
+      }
+    }
+    if (typeChecker) {
+      var error = typeChecker(props, propName, componentName, location);
+      if (error instanceof Error) {
+        return error
       }
     }
   }

--- a/src/classic/propTypes/__tests__/ReactPropTypes-test.js
+++ b/src/classic/propTypes/__tests__/ReactPropTypes-test.js
@@ -21,6 +21,20 @@ var MyComponent;
 var requiredMessage =
   'Required prop `testProp` was not specified in `testComponent`.';
 
+function dependencyCheckPass(declaration, value, props) {
+  if (!props) {
+    props = {};
+  }
+  props.testProp = value;
+  var error = declaration(
+    props,
+    'testProp',
+    'testComponent',
+    ReactPropTypeLocations.prop
+  );
+  expect(error).toBe(undefined);
+}
+
 function typeCheckFail(declaration, value, message) {
   var props = {testProp: value};
   var error = declaration(
@@ -269,6 +283,58 @@ describe('ReactPropTypes', function() {
     it("should warn for missing required values", function() {
       typeCheckFail(PropTypes.element.isRequired, null, requiredMessage);
       typeCheckFail(PropTypes.element.isRequired, undefined, requiredMessage);
+    });
+  });
+
+  describe('DependsOn Types', function() {
+    it("should support the dependsOn propType", () => {
+      dependencyCheckPass(
+        PropTypes.dependsOn('testProp2'),
+        'value',
+        {testProp2: 'value2'}
+      );
+    });
+
+    it("should support an array of dependencies", () => {
+      dependencyCheckPass(
+        PropTypes.dependsOn(['testProp2', 'testProp3']),
+        'value',
+        {testProp2: 'value2', testProp3: 'value3'}
+      );
+    });
+
+    it("should support an optional typeChecker", () => {
+      dependencyCheckPass(
+        PropTypes.dependsOn('testProp2', React.PropTypes.string),
+        'value',
+        {testProp2: 'value2'}
+      );
+    });
+
+    it("should warn for missing dependency", () => {
+      typeCheckFail(
+        PropTypes.dependsOn('missingProp'),
+        'testProp',
+        'Invalid prop `testProp` supplied to `testComponent` ' +
+        'without `missingProp`.'
+      );
+    });
+
+    it("should warn for missing required values", () => {
+      typeCheckFail(
+        PropTypes.dependsOn('testProp').isRequired,
+        null,
+        requiredMessage
+      );
+    });
+
+    it("should warn for invalid type", () => {
+      typeCheckFail(
+        PropTypes.dependsOn('testProp', PropTypes.string),
+        1,
+        'Invalid prop `testProp` of type `number` supplied to ' +
+        '`testComponent`, expected `string`.'
+      );
     });
   });
 


### PR DESCRIPTION
The `dependsOn` type checker takes a name or an array of names of other props that the current prop expects to be present, as well as an optional type checker for the current prop. This allows property declarations along the lines of:

```
React.createClass({ 
  propTypes: { 
    one: React.PropTypes.dependsOn('two', React.PropTypes.string), 
    two: React.PropTypes.string 
  } 
});
```

where the presence of `one` is only validated if `two` is present.

While using `dependsOn` with `isRequired` might be a little weird, it does work. `dependsOn` doesn't change existing APIs.

--

Note: I'm not sure if this is something that the community is interested in, but I thought I would offer it up for discussion. We've been finding ourselves writing custom `dependsOn`-like validations in our components, and after a moment's consideration, we thought that it might be nice to put it out there for other people to use if desired.