### PR TITLE
Use containers on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 language: node_js
 node_js:
 - '0.10'
+sudo: false
 cache:
   directories:
   - node_modules


### PR DESCRIPTION
This _should_ enabled the caching of node_modules for faster builds. We
may need to tweak this later to make sure node_modules gets updated

See http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
