### PR TITLE
Add placeholders for static prop type tests

### DIFF
--- a/src/modern/types/__tests__/ReactFlowPropTypes-test.js
+++ b/src/modern/types/__tests__/ReactFlowPropTypes-test.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+"use strict";
+
+describe('ReactFlowPropTypes', function() {
+
+  // TODO: Test Flow integration and ensure that prop types works.
+
+});

--- a/src/modern/types/__tests__/ReactTypeScriptPropTypes-test.js
+++ b/src/modern/types/__tests__/ReactTypeScriptPropTypes-test.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+"use strict";
+
+describe('ReactTypeScriptPropTypes', function() {
+
+  // TODO: Test TypeScript integration and ensure that prop types works.
+
+});


### PR DESCRIPTION
This is where tests of static prop types should go when we have the
infrastructure set up to handle it.
