### PR TITLE
Update 14-communicate-between-components.md for grammatical changes

### DIFF
--- a/docs/tips/14-communicate-between-components.md
+++ b/docs/tips/14-communicate-between-components.md
@@ -38,4 +38,4 @@ React.render(
 
 Notice the use of `bind(this, arg1, arg2, ...)`: we're simply passing more arguments to `handleClick`. This is not a new React concept; it's just JavaScript.
 
-For communication between two components that don't have a parent-child relationship, you can set up your own global event system. Subscribe to events in `componentDidMount()`, unsubscribe in `componentWillUnmount()`, and when you receive an event, call `setState()`.
+For communication between two components that don't have a parent-child relationship, you can set up your own global event system. Subscribe to events in `componentDidMount()`, unsubscribe in `componentWillUnmount()`, and call `setState()` when you receive an event.


### PR DESCRIPTION
Update to improve grammatical parallelism, as expressions separated by commas should share similar form.

BEFORE: Subscribe to events in `componentDidMount()`, unsubscribe in `componentWillUnmount()`, and when you receive an event, call `setState()`.
AFTER: Subscribe to events in `componentDidMount()`, unsubscribe in `componentWillUnmount()`, and call `setState()` when you receive an event.
