### PR TITLE
Throw a caught error in the default warning module

### DIFF
--- a/src/vendor/core/warning.js
+++ b/src/vendor/core/warning.js
@@ -33,7 +33,14 @@ if (__DEV__) {
 
     if (!condition) {
       var argIndex = 0;
-      console.warn('Warning: ' + format.replace(/%s/g, () => args[argIndex++]));
+      var message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
+      console.warn(message);
+      try {
+        // --- Welcome to debugging React ---
+        // This error was thrown as a convenience so that you can use this stack
+        // to find the callsite that caused this warning to fire.
+        throw new Error(message);
+      } catch(x) {}
     }
   };
 }


### PR DESCRIPTION
This throws an error that is immediately caught. This allows you to use the
debugger's "break on caught exception" feature to break on warnings.

This should help with tracking down these warnings using the stack.

However, it could also add more noise to other debugging pattern.
