### PR TITLE
Fixup jsdoc for findDOMNode

### DIFF
--- a/src/browser/findDOMNode.js
+++ b/src/browser/findDOMNode.js
@@ -22,7 +22,7 @@ var isNode = require('isNode');
 /**
  * Returns the DOM node rendered by this element.
  *
- * @param {ReactComponent|DOMElement} element
+ * @param {ReactComponent|DOMElement} componentOrElement
  * @return {DOMElement} The root node of this element.
  */
 function findDOMNode(componentOrElement) {


### PR DESCRIPTION
One of our internal transforms that adds some typechecks relies on matching jsdoc pieces to actual parameters. When there's a mismatch it barfs and tests fail.
