### PR TITLE
use bundle-collapser to reduce browserified file size

### DIFF
--- a/grunt/config/browserify.js
+++ b/grunt/config/browserify.js
@@ -9,6 +9,7 @@ var grunt = require('grunt');
 var UglifyJS = require('uglify-js');
 var uglifyify = require('uglifyify');
 var derequire = require('derequire');
+var collapser = require('bundle-collapser/plugin');
 
 var SIMPLE_TEMPLATE =
 '/**\n\
@@ -69,6 +70,7 @@ var min = {
   debug: false,
   standalone: 'React',
   transforms: [envify({NODE_ENV: 'production'}), uglifyify],
+  plugins: [collapser],
   after: [es3ify.transform, derequire, minify, bannerify]
 };
 
@@ -104,6 +106,7 @@ var addonsMin = {
   standalone: 'React',
   packageName: 'React (with addons)',
   transforms: [envify({NODE_ENV: 'production'}), uglifyify],
+  plugins: [collapser],
   after: [es3ify.transform, derequire, minify, bannerify]
 };
 

--- a/grunt/config/browserify.js
+++ b/grunt/config/browserify.js
@@ -59,6 +59,7 @@ var basic = {
   debug: false,
   standalone: 'React',
   transforms: [envify({NODE_ENV: 'development'})],
+  plugins: [collapser],
   after: [es3ify.transform, derequire, simpleBannerify]
 };
 
@@ -82,6 +83,7 @@ var transformer = {
   debug: false,
   standalone: 'JSXTransformer',
   transforms: [],
+  plugins: [collapser],
   after: [es3ify.transform, derequire, simpleBannerify]
 };
 
@@ -94,6 +96,7 @@ var addons = {
   standalone: 'React',
   packageName: 'React (with addons)',
   transforms: [envify({NODE_ENV: 'development'})],
+  plugins: [collapser],
   after: [es3ify.transform, derequire, simpleBannerify]
 };
 
@@ -120,7 +123,8 @@ var withCodeCoverageLogging = {
   transforms: [
     envify({NODE_ENV: 'development'}),
     require('coverify')
-  ]
+  ],
+  plugins: [collapser]
 };
 
 module.exports = {

--- a/grunt/tasks/browserify.js
+++ b/grunt/tasks/browserify.js
@@ -13,6 +13,7 @@ module.exports = function() {
   // grunt.config.requires('outfile');
   // grunt.config.requires('entries');
   config.transforms = config.transforms || [];
+  config.plugins = config.plugins || [];
   config.after = config.after || [];
 
   // create the bundle we'll work with
@@ -30,6 +31,8 @@ module.exports = function() {
   config.transforms.forEach(function(transform) {
     bundle.transform({}, transform);
   });
+
+  config.plugins.forEach(bundle.plugin, bundle);
 
   // Actually bundle it up
   var _this = this;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "benchmark": "~1.0.0",
     "browserify": "^7.0.2",
+    "bundle-collapser": "^1.1.1",
     "coverify": "~1.0.4",
     "derequire": "^1.2.0",
     "envify": "^3.0.0",


### PR DESCRIPTION
PR #2792 

// v0.13.0-alpha.1

 file | before | after | reduced percentage
 ---- | ------ | ----- | ------------------
 react.min.js | 134656 | 116478 | 13.5%
 react-with-addons.min.js | 146071 | 126510 | 13.4%

grunt test all passed and didn't create any linter errors.