### PR TITLE
Wrap setInnerHTML in Windows 8 apps (Fixes #441)

### DIFF
--- a/src/browser/ui/dom/setInnerHTML.js
+++ b/src/browser/ui/dom/setInnerHTML.js
@@ -30,11 +30,11 @@ var setInnerHTML = function(node, html) {
 
 // Win8 apps: Allow all html to be inserted
 if (typeof MSApp !== 'undefined' && MSApp.execUnsafeLocalFunction) {
-    setInnerHTML = function (node, html) {
-        MSApp.execUnsafeLocalFunction(function () {
-            node.innerHTML = html;
-        });
-    };
+  setInnerHTML = function(node, html) {
+    MSApp.execUnsafeLocalFunction(function() {
+      node.innerHTML = html;
+    });
+  };
 }
 
 if (ExecutionEnvironment.canUseDOM) {

--- a/src/browser/ui/dom/setInnerHTML.js
+++ b/src/browser/ui/dom/setInnerHTML.js
@@ -28,6 +28,15 @@ var setInnerHTML = function(node, html) {
   node.innerHTML = html;
 };
 
+// Win8 apps: Allow all html to be inserted
+if (typeof MSApp !== 'undefined' && MSApp.execUnsafeLocalFunction) {
+    setInnerHTML = function (node, html) {
+        MSApp.execUnsafeLocalFunction(function () {
+            node.innerHTML = html;
+        });
+    };
+}
+
 if (ExecutionEnvironment.canUseDOM) {
   // IE8: When updating a just created node with innerHTML only leading
   // whitespace is removed. When updating an existing node with innerHTML


### PR DESCRIPTION
See #441 

If React is running in a Windows 8 metro app, creates a version of setInnerHTML that uses [execUnsafeLocalFunction](http://msdn.microsoft.com/en-us/library/windows/apps/hh767331.aspx) to bypass the restrictive html-insertion security policy of that javascript runtime.