### PR TITLE
Update docs to indicate that componentDDidUpdate is fired after changes are flushed to the DOM.  Fix

### DIFF
--- a/docs/docs/ref-03-component-specs.md
+++ b/docs/docs/ref-03-component-specs.md
@@ -195,7 +195,7 @@ Use this as an opportunity to perform preparation before an update occurs.
 componentDidUpdate(object prevProps, object prevState)
 ```
 
-Invoked immediately after updating occurs. This method is not called for the initial render.
+Invoked immediately after the component's updates are flushed to the DOM. This method is not called for the initial render.
 
 Use this as an opportunity to operate on the DOM when the component has been updated.
 


### PR DESCRIPTION
Update docs to indicate that componentDDidUpdate is fired after changes are flushed to the DOM.  Fixes #2796
