### PR TITLE
Introducing ReactComponentBase base class

### DIFF
--- a/src/browser/ui/React.js
+++ b/src/browser/ui/React.js
@@ -17,6 +17,7 @@ var DOMPropertyOperations = require('DOMPropertyOperations');
 var EventPluginUtils = require('EventPluginUtils');
 var ReactChildren = require('ReactChildren');
 var ReactComponent = require('ReactComponent');
+var ReactComponentBase = require('ReactComponentBase');
 var ReactClass = require('ReactClass');
 var ReactContext = require('ReactContext');
 var ReactCurrentOwner = require('ReactCurrentOwner');
@@ -57,6 +58,7 @@ var React = {
     count: ReactChildren.count,
     only: onlyChild
   },
+  Component: ReactComponentBase,
   DOM: ReactDOM,
   PropTypes: ReactPropTypes,
   initializeTouchEvents: function(shouldUseTouch) {

--- a/src/classic/class/ReactClass.js
+++ b/src/classic/class/ReactClass.js
@@ -11,6 +11,7 @@
 
 "use strict";
 
+var ReactComponentBase = require('ReactComponentBase');
 var ReactElement = require('ReactElement');
 var ReactErrorUtils = require('ReactErrorUtils');
 var ReactInstanceMap = require('ReactInstanceMap');
@@ -22,7 +23,6 @@ var invariant = require('invariant');
 var keyMirror = require('keyMirror');
 var keyOf = require('keyOf');
 var monitorCodeUse = require('monitorCodeUse');
-var warning = require('warning');
 
 var MIXINS_KEY = keyOf({mixins: null});
 
@@ -692,48 +692,10 @@ function bindAutoBindMethods(component) {
 }
 
 /**
- * @lends {ReactClass.prototype}
+ * Add more to the ReactClass base class. These are all legacy features and
+ * therefore not already part of the modern ReactComponentBase.
  */
 var ReactClassMixin = {
-
-  /**
-   * Sets a subset of the state. Always use this or `replaceState` to mutate
-   * state. You should treat `this.state` as immutable.
-   *
-   * There is no guarantee that `this.state` will be immediately updated, so
-   * accessing `this.state` after calling this method may return the old value.
-   *
-   * There is no guarantee that calls to `setState` will run synchronously,
-   * as they may eventually be batched together.  You can provide an optional
-   * callback that will be executed when the call to setState is actually
-   * completed.
-   *
-   * @param {object} partialState Next partial state to be merged with state.
-   * @param {?function} callback Called after state is updated.
-   * @final
-   * @protected
-   */
-  setState: function(partialState, callback) {
-    invariant(
-      typeof partialState === 'object' || partialState == null,
-      'setState(...): takes an object of state variables to update.'
-    );
-    if (__DEV__) {
-      warning(
-        partialState != null,
-        'setState(...): You passed an undefined or null state object; ' +
-        'instead, use forceUpdate().'
-      );
-    }
-    var internalInstance = ReactInstanceMap.get(this);
-    invariant(
-      internalInstance,
-      'setState(...): Can only update a mounted or mounting component.'
-    );
-    internalInstance.setState(
-      partialState, callback && callback.bind(this)
-    );
-  },
 
   /**
    * TODO: This will be deprecated because state should always keep a consistent
@@ -743,36 +705,13 @@ var ReactClassMixin = {
     var internalInstance = ReactInstanceMap.get(this);
     invariant(
       internalInstance,
-      'replaceState(...): Can only update a mounted or mounting component.'
+      'replaceState(...): Can only update a mounted or mounting component. ' +
+      'This usually means you called replaceState() on an unmounted component.'
     );
     internalInstance.replaceState(
       newState,
       callback && callback.bind(this)
     );
-  },
-
-  /**
-   * Forces an update. This should only be invoked when it is known with
-   * certainty that we are **not** in a DOM transaction.
-   *
-   * You may want to call this when you know that some deeper aspect of the
-   * component's state has changed but `setState` was not called.
-   *
-   * This will not invoke `shouldUpdateComponent`, but it will invoke
-   * `componentWillUpdate` and `componentDidUpdate`.
-   *
-   * @param {?function} callback Called after update is complete.
-   * @final
-   * @protected
-   */
-  forceUpdate: function(callback) {
-    var internalInstance = ReactInstanceMap.get(this);
-    invariant(
-      internalInstance,
-      'forceUpdate(...): Can only force an update on mounted or mounting ' +
-        'components.'
-    );
-    internalInstance.forceUpdate(callback && callback.bind(this));
   },
 
   /**
@@ -829,6 +768,7 @@ var ReactClassMixin = {
 var ReactClassBase = function() {};
 assign(
   ReactClassBase.prototype,
+  ReactComponentBase.prototype,
   ReactClassMixin
 );
 

--- a/src/modern/class/ReactComponentBase.js
+++ b/src/modern/class/ReactComponentBase.js
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2013-2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactComponentBase
+ */
+
+"use strict";
+
+var ReactInstanceMap = require('ReactInstanceMap');
+
+var assign = require('Object.assign');
+var invariant = require('invariant');
+var warning = require('warning');
+
+/**
+ * Base class helpers for the updating state of a component.
+ */
+function ReactComponentBase(props) {
+  this.props = props;
+}
+
+/**
+ * Sets a subset of the state. Always use this to mutate
+ * state. You should treat `this.state` as immutable.
+ *
+ * There is no guarantee that `this.state` will be immediately updated, so
+ * accessing `this.state` after calling this method may return the old value.
+ *
+ * There is no guarantee that calls to `setState` will run synchronously,
+ * as they may eventually be batched together.  You can provide an optional
+ * callback that will be executed when the call to setState is actually
+ * completed.
+ *
+ * @param {object} partialState Next partial state to be merged with state.
+ * @param {?function} callback Called after state is updated.
+ * @final
+ * @protected
+ */
+ReactComponentBase.prototype.setState = function(partialState, callback) {
+  invariant(
+    typeof partialState === 'object' || partialState == null,
+    'setState(...): takes an object of state variables to update.'
+  );
+  if (__DEV__) {
+    warning(
+      partialState != null,
+      'setState(...): You passed an undefined or null state object; ' +
+      'instead, use forceUpdate().'
+    );
+  }
+
+  var internalInstance = ReactInstanceMap.get(this);
+  invariant(
+    internalInstance,
+    'setState(...): Can only update a mounted or mounting component. ' + 
+    'This usually means you called setState() on an unmounted ' +
+    'component.'
+  );
+  internalInstance.setState(
+    partialState, callback && callback.bind(this)
+  );
+};
+
+/**
+ * Forces an update. This should only be invoked when it is known with
+ * certainty that we are **not** in a DOM transaction.
+ *
+ * You may want to call this when you know that some deeper aspect of the
+ * component's state has changed but `setState` was not called.
+ *
+ * This will not invoke `shouldUpdateComponent`, but it will invoke
+ * `componentWillUpdate` and `componentDidUpdate`.
+ *
+ * @param {?function} callback Called after update is complete.
+ * @final
+ * @protected
+ */
+ReactComponentBase.prototype.forceUpdate = function(callback) {
+  var internalInstance = ReactInstanceMap.get(this);
+  invariant(
+    internalInstance,
+    'forceUpdate(...): Can only force an update on mounted or mounting ' +
+    'components. This usually means you called forceUpdate() on an ' +
+    'unmounted component.'
+  );
+  internalInstance.forceUpdate(callback && callback.bind(this));
+};
+
+/**
+ * Deprecated APIs. These APIs used to exist on classic React classes but since
+ * we would like to deprecate them, we're not going to move them over to this
+ * modern base class. Instead, we define a getter that warns if it's accessed.
+ */
+if (__DEV__) {
+  if (Object.defineProperty) {
+    var deprecatedAPIs = {
+      getDOMNode: 'getDOMNode',
+      isMounted: 'isMounted',
+      replaceState: 'replaceState',
+      setProps: 'setProps'
+    };
+    var defineDeprecationWarning = function(methodName, displayName) {
+      Object.defineProperty(ReactComponentBase.prototype, methodName, {
+        get: function() {
+          warning(
+            false,
+            '%s(...) is deprecated in plain JavaScript React classes.',
+            displayName
+          );
+          return undefined;
+        }
+      });
+    };
+    for (var methodName in deprecatedAPIs) {
+      if (deprecatedAPIs.hasOwnProperty(methodName)) {
+        defineDeprecationWarning(methodName, deprecatedAPIs[methodName]);
+      }
+    }
+  }
+}
+
+module.exports = ReactComponentBase;

--- a/src/modern/class/__tests__/ReactES6Class-test.js
+++ b/src/modern/class/__tests__/ReactES6Class-test.js
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2013-2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+"use strict";
+
+var mocks = require('mocks');
+
+var React;
+
+describe('ReactES6Class', function() {
+
+  var container;
+  var Inner;
+  var attachedListener = null;
+  var renderedName = null;
+
+  beforeEach(function() {
+    React = require('React');
+    container = document.createElement();
+    attachedListener = null;
+    renderedName = null;
+    Inner = class extends React.Component {
+      getName() {
+        return this.props.name;
+      }
+      render() {
+        attachedListener = this.props.onClick;
+        renderedName = this.props.name;
+        return <div className={this.props.name} />;
+      }
+    };
+  });
+
+  function test(element, expectedTag, expectedClassName) {
+    var instance = React.render(element, container);
+    expect(container.firstChild).not.toBeNull();
+    expect(container.firstChild.tagName).toBe(expectedTag);
+    expect(container.firstChild.className).toBe(expectedClassName);
+    return instance;
+  }
+
+  it('preserves the name of the class for use in error messages', function() {
+    class Foo extends React.Component { }
+    expect(Foo.name).toBe('Foo');
+  });
+
+  it('throws if no render function is defined', function() {
+    class Foo extends React.Component { }
+    expect(() => React.render(<Foo />, container)).toThrow();
+  });
+
+  it('renders a simple stateless component with prop', function() {
+    class Foo {
+      render() {
+        return <Inner name={this.props.bar} />;
+      }
+    }
+    test(<Foo bar="foo" />, 'DIV', 'foo');
+    test(<Foo bar="bar" />, 'DIV', 'bar');
+  });
+
+  it('renders using forceUpdate even when there is no state', function() {
+    class Foo extends React.Component {
+      constructor(props) {
+        this.mutativeValue = props.initialValue;
+      }
+      handleClick() {
+        this.mutativeValue = 'bar';
+        this.forceUpdate();
+      }
+      render() {
+        return (
+          <Inner
+            name={this.mutativeValue}
+            onClick={this.handleClick.bind(this)}
+          />
+        );
+      }
+    }
+    test(<Foo initialValue="foo" />, 'DIV', 'foo');
+    attachedListener();
+    expect(renderedName).toBe('bar');
+  });
+
+  it('should throw AND warn when trying to access classic APIs', function() {
+    spyOn(console, 'warn');
+    var instance = test(<Inner name="foo" />, 'DIV', 'foo');
+    expect(() => instance.getDOMNode()).toThrow();
+    expect(() => instance.replaceState({})).toThrow();
+    expect(() => instance.isMounted()).toThrow();
+    expect(() => instance.setProps({ name: 'bar' })).toThrow();
+    expect(console.warn.calls.length).toBe(4);
+    expect(console.warn.calls[0].args[0]).toContain(
+      'getDOMNode(...) is deprecated in plain JavaScript React classes'
+    );
+    expect(console.warn.calls[1].args[0]).toContain(
+      'replaceState(...) is deprecated in plain JavaScript React classes'
+    );
+    expect(console.warn.calls[2].args[0]).toContain(
+      'isMounted(...) is deprecated in plain JavaScript React classes'
+    );
+    expect(console.warn.calls[3].args[0]).toContain(
+      'setProps(...) is deprecated in plain JavaScript React classes'
+    );
+  });
+
+  it('supports this.context passed via getChildContext', function() {
+    class Bar {
+      render() {
+        return <div className={this.context.bar} />;
+      }
+    }
+    Bar.contextTypes = { bar: React.PropTypes.string };
+    class Foo {
+      getChildContext() {
+        return { bar: 'bar-through-context' };
+      }
+      render() {
+        return <Bar />;
+      }
+    }
+    Foo.childContextTypes = { bar: React.PropTypes.string };
+    test(<Foo />, 'DIV', 'bar-through-context');
+  });
+
+  it('supports classic refs', function() {
+    class Foo {
+      render() {
+        return <Inner name="foo" ref="inner" />;
+      }
+    }
+    var instance = test(<Foo />, 'DIV', 'foo');
+    expect(instance.refs.inner.getName()).toBe('foo');
+  });
+
+  it('supports drilling through to the DOM using findDOMNode', function() {
+    var instance = test(<Inner name="foo" />, 'DIV', 'foo');
+    var node = React.findDOMNode(instance);
+    expect(node).toBe(container.firstChild);
+  });
+
+});


### PR DESCRIPTION
This is the base class that will be used by ES6 classes.

I'm only moving setState and forceUpdate to this base class and the other
functions are disabled for modern classes as we're intending to deprecate
them. The base classes only have getters that warn if accessed. It's as if
they didn't exist.

ReactClass now extends ReactComponentBase but also adds the deprecated
methods. They are not yet fully deprecated on the ReactClass API.

I added some extra tests to composite component which we weren't testing
to avoid regressions.

I also added some test for ES6 classes. These are not testing the new
state initialization process. That's coming in a follow up.