### PR TITLE
Warn when defined methods are used in plain JS classes

### DIFF
--- a/src/classic/class/ReactClass.js
+++ b/src/classic/class/ReactClass.js
@@ -808,11 +808,21 @@ var ReactClass = {
     // Initialize the defaultProps property after all mixins have been merged
     if (Constructor.getDefaultProps) {
       Constructor.defaultProps = Constructor.getDefaultProps();
-      if (__DEV__) {
-        // This is a tag to indicate that this use of getDefaultProps is ok,
-        // since it's used with createClass. If it's not, then it's likely a
-        // mistake so we'll warn you to use the static property instead.
+    }
+
+    if (__DEV__) {
+      // This is a tag to indicate that the use of these method names is ok,
+      // since it's used with createClass. If it's not, then it's likely a
+      // mistake so we'll warn you to use the static property, property
+      // initializer or constructor respectively.
+      if (Constructor.getDefaultProps) {
         Constructor.getDefaultProps._isReactClassApproved = true;
+      }
+      if (Constructor.prototype.getInitialState) {
+        Constructor.prototype.getInitialState._isReactClassApproved = true;
+      }
+      if (Constructor.prototype.componentWillMount) {
+        Constructor.prototype.componentWillMount._isReactClassApproved = true;
       }
     }
 

--- a/src/modern/class/__tests__/ReactES6Class-test.js
+++ b/src/modern/class/__tests__/ReactES6Class-test.js
@@ -90,6 +90,67 @@ describe('ReactES6Class', function() {
     expect(renderedName).toBe('bar');
   });
 
+  it('warns when classic properties are defined on the instance, ' +
+     'but does not invoke them.', function() {
+    spyOn(console, 'warn');
+    var getInitialStateWasCalled = false;
+    var componentWillMountWasCalled = false;
+    class Foo extends React.Component {
+      constructor() {
+        this.contextTypes = {};
+        this.propTypes = {};
+      }
+      getInitialState() {
+        getInitialStateWasCalled = true;
+        return {};
+      }
+      componentWillMount() {
+        componentWillMountWasCalled = true;
+      }
+      render() {
+        return <span className="foo" />;
+      }
+    }
+    test(<Foo />, 'SPAN', 'foo');
+    // TODO: expect(getInitialStateWasCalled).toBe(false);
+    // TODO: expect(componentWillMountWasCalled).toBe(false);
+    expect(console.warn.calls.length).toBe(4);
+    expect(console.warn.calls[0].args[0]).toContain(
+      'getInitialState was defined on Foo, a plain JavaScript class.'
+    );
+    expect(console.warn.calls[1].args[0]).toContain(
+      'componentWillMount was defined on Foo, a plain JavaScript class.'
+    );
+    expect(console.warn.calls[2].args[0]).toContain(
+      'propTypes was defined as an instance property on Foo.'
+    );
+    expect(console.warn.calls[3].args[0]).toContain(
+      'contextTypes was defined as an instance property on Foo.'
+    );
+  });
+
+  it('should warn when mispelling shouldComponentUpdate', function() {
+    spyOn(console, 'warn');
+
+    class NamedComponent {
+      componentShouldUpdate() {
+        return false;
+      }
+      render() {
+        return <span className="foo" />;
+      }
+    }
+    test(<NamedComponent />, 'SPAN', 'foo');
+
+    expect(console.warn.calls.length).toBe(1);
+    expect(console.warn.calls[0].args[0]).toBe(
+      'Warning: ' +
+      'NamedComponent has a method called componentShouldUpdate(). Did you ' +
+      'mean shouldComponentUpdate()? The name is phrased as a question ' +
+      'because the function is expected to return a value.'
+    );
+  });
+
   it('should throw AND warn when trying to access classic APIs', function() {
     spyOn(console, 'warn');
     var instance = test(<Inner name="foo" />, 'DIV', 'foo');


### PR DESCRIPTION
This is building on top of #2805

In ReactClass we use early validation to warn you if an accidentally defined
propTypes in the wrong place or if you mispelled componentShouldUpdate.

For plain JS classes there is no early validation process. Therefore, we
wait to do this validation until the component is mounted before we issue
the warning.

This should bring us to warning-parity with ReactClass.