### PR TITLE
Fix Outdated Copyright Year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ BSD License
 
 For React software
 
-Copyright (c) 2013-2014, Facebook, Inc.
+Copyright (c) 2013-2015, Facebook, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,


### PR DESCRIPTION
Fix outdated copyright year (update to 2015)
The copyright year was out of date. Copyright notices must reflect the current year. This commit updates the listed year to 2015.