### PR TITLE
New class instantiation and initialization process

### DIFF
--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -343,9 +343,8 @@ describe('ReactCompositeComponent', function() {
       },
       componentWillUnmount: function() {
         expect(() => this.setState({ value: 2 })).toThrow(
-          'Invariant Violation: replaceState(...): Cannot update while ' +
-          'unmounting component. This usually means you called setState() ' +
-          'on an unmounted component.'
+          'Invariant Violation: setState(...): Cannot call setState() on an ' +
+          'unmounting component.'
         );
       },
       render: function() {
@@ -383,8 +382,9 @@ describe('ReactCompositeComponent', function() {
     expect(function() {
       instance.setProps({ value: 2 });
     }).toThrow(
-      'Invariant Violation: setProps(...): Can only update a mounted ' +
-      'component.'
+      'Invariant Violation: setProps(...): Can only update a mounted or ' +
+      'mounting component. This usually means you called setProps() on an ' +
+      'unmounted component.'
     );
   });
 


### PR DESCRIPTION
Builds on top of #2806

This allows state to be set up in the constructor instead of through
getInitialState. getInitialState is now considered part of "classic".
Therefore, they move into ReactClass's constructor.

As a consequence of this, we no longer have a mapping between the internal
representation and the public instance during the mounting process.
Because the constructor hasn't returned yet.

We used to have a special case for calling setState in getInitialState
which was just ignored. This makes that throw and the component is
considered unmounted during the construction phase.
