### PR TITLE
Context warning should fire on update, not just initial mount.
Renamed a couple instances of context

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -687,6 +687,12 @@ var ReactCompositeComponentMixin = assign({},
       nextContext = this._processContext(nextParentElement._context);
       nextProps = this._processProps(nextParentElement.props);
 
+      if (__DEV__) {
+        if (nextUnmaskedContext != null) {
+          this._warnIfContextsDiffer(nextParentElement._context, nextUnmaskedContext);
+        }
+      }
+
       this._compositeLifeCycleState = CompositeLifeCycle.RECEIVING_PROPS;
       if (inst.componentWillReceiveProps) {
         inst.componentWillReceiveProps(nextProps, nextContext);
@@ -772,7 +778,7 @@ var ReactCompositeComponentMixin = assign({},
     inst.state = nextState;
     inst.context = nextContext;
 
-    this._updateRenderedComponent(transaction, nextContext);
+    this._updateRenderedComponent(transaction, unmaskedContext);
 
     if (inst.componentDidUpdate) {
       transaction.getReactMountReady().enqueue(


### PR DESCRIPTION
Context warning should fire on update, not just initial mount.
Renamed a couple instances of context to make it clear if it was masked/unmasked
