### PR TITLE
Add boxFlex and boxFlexGroup to CSS Unitless Properties

### DIFF
--- a/src/browser/ui/dom/CSSProperty.js
+++ b/src/browser/ui/dom/CSSProperty.js
@@ -15,6 +15,8 @@
  * CSS properties which accept numbers but are not in units of "px".
  */
 var isUnitlessNumber = {
+  boxFlex: true,
+  boxFlexGroup: true,
   columnCount: true,
   flex: true,
   flexGrow: true,


### PR DESCRIPTION
Fixes #2812

It's a deprecated spec but it's unfortunately still in use for a bit.

http://www.w3.org/TR/2009/WD-css3-flexbox-20090723/#property indicates we should probably add `boxOrdinalGroup` to the list as well...