### PR TITLE
Generate XML-compatible void tags and boolean attributes

### DIFF
--- a/src/browser/ui/ReactDOMComponent.js
+++ b/src/browser/ui/ReactDOMComponent.js
@@ -216,7 +216,7 @@ ReactDOMComponent.Mixin = {
     assertValidProps(this, this._currentElement.props);
     var tagOpen = this._createOpenTagMarkupAndPutListeners(transaction);
     var tagContent = this._createContentMarkup(transaction, context);
-    if(!tagContent && omittedCloseTags[this._tag]){
+    if (!tagContent && omittedCloseTags[this._tag]) {
       return tagOpen + '/>';
     }
     return tagOpen + '>' + tagContent + '</' + this._tag + '>';

--- a/src/browser/ui/ReactDOMComponent.js
+++ b/src/browser/ui/ReactDOMComponent.js
@@ -208,12 +208,12 @@ ReactDOMComponent.Mixin = {
   mountComponent: function(rootID, transaction, context) {
     this._rootNodeID = rootID;
     assertValidProps(this, this._currentElement.props);
-    var closeTag = omittedCloseTags[this._tag] ? '' : '</' + this._tag + '>';
-    return (
-      this._createOpenTagMarkupAndPutListeners(transaction) +
-      this._createContentMarkup(transaction, context) +
-      closeTag
-    );
+    var tagOpen = this._createOpenTagMarkupAndPutListeners(transaction);
+    var tagContent = this._createContentMarkup(transaction, context);
+    if(!tagContent && omittedCloseTags[this._tag]){
+      return tagOpen + '/>';
+    }
+    return tagOpen + '>' + tagContent + '</' + this._tag + '>';
   },
 
   /**
@@ -260,11 +260,11 @@ ReactDOMComponent.Mixin = {
     // For static pages, no need to put React ID and checksum. Saves lots of
     // bytes.
     if (transaction.renderToStaticMarkup) {
-      return ret + '>';
+      return ret;
     }
 
     var markupForID = DOMPropertyOperations.createMarkupForID(this._rootNodeID);
-    return ret + ' ' + markupForID + '>';
+    return ret + ' ' + markupForID;
   },
 
   /**

--- a/src/browser/ui/ReactDOMComponent.js
+++ b/src/browser/ui/ReactDOMComponent.js
@@ -144,6 +144,12 @@ var omittedCloseTags = {
   // NOTE: menuitem's close tag should be omitted, but that causes problems.
 };
 
+var newlineEatingTags = {
+  'listing': true,
+  'pre': true,
+  'textarea': true
+};
+
 // For HTML, certain tags cannot have children. This has the same purpose as
 // `omittedCloseTags` except that `menuitem` should still have its closing tag.
 
@@ -300,12 +306,7 @@ ReactDOMComponent.Mixin = {
         ret = mountImages.join('');
       }
     }
-    if (
-      (this._tag === 'listing'
-       || this._tag === 'pre'
-       || this._tag === 'textarea')
-      && ret.charAt(0) === '\n'
-    ) {
+    if (newlineEatingTags[this._tag] && ret.charAt(0) === '\n') {
       // text/html ignores the first character in these tags if it's a newline
       // Prefer to break application/xml over text/html (for now) by adding
       // a newline specifically to get eaten by the parser.

--- a/src/browser/ui/ReactDOMComponent.js
+++ b/src/browser/ui/ReactDOMComponent.js
@@ -306,14 +306,17 @@ ReactDOMComponent.Mixin = {
        || this._tag === 'textarea')
       && ret.charAt(0) === '\n'
     ) {
-      // Add an invisible node that's not a newline, because the HTML syntax
-      // ignores the first character in these tags if it's a newline
+      // text/html ignores the first character in these tags if it's a newline
+      // Prefer to break application/xml over text/html (for now) by adding
+      // a newline specifically to get eaten by the parser.
+      // (Alternately for textareas, replacing "^\n" with "\r\n" doesn't get eaten,
+      // and the first \r is normalized out by HTMLTextAreaElement#value.)
       // See: <http://www.w3.org/TR/html-polyglot/#newlines-in-textarea-and-pre>
       // See: <http://www.w3.org/TR/html5/syntax.html#element-restrictions>
       // See: <http://www.w3.org/TR/html5/syntax.html#newlines>
       // See: Parsing of "textarea" "listing" and "pre" elements
       //  from <http://www.w3.org/TR/html5/syntax.html#parsing-main-inbody>
-      return '<!---->' + ret;
+      return '\n' + ret;
     } else {
       return ret;
     }

--- a/src/browser/ui/dom/DOMPropertyOperations.js
+++ b/src/browser/ui/dom/DOMPropertyOperations.js
@@ -96,7 +96,7 @@ var DOMPropertyOperations = {
       var attributeName = DOMProperty.getAttributeName[name];
       if (DOMProperty.hasBooleanValue[name] ||
           (DOMProperty.hasOverloadedBooleanValue[name] && value === true)) {
-        return attributeName;
+        return attributeName + '=""';
       }
       return attributeName + '=' + quoteAttributeValueForBrowser(value);
     } else if (DOMProperty.isCustomAttribute(name)) {

--- a/src/browser/ui/dom/__tests__/DOMPropertyOperations-test.js
+++ b/src/browser/ui/dom/__tests__/DOMPropertyOperations-test.js
@@ -78,12 +78,12 @@ describe('DOMPropertyOperations', function() {
       expect(DOMPropertyOperations.createMarkupForProperty(
         'checked',
         'simple'
-      )).toBe('checked');
+      )).toBe('checked=""');
 
       expect(DOMPropertyOperations.createMarkupForProperty(
         'checked',
         true
-      )).toBe('checked');
+      )).toBe('checked=""');
 
       expect(DOMPropertyOperations.createMarkupForProperty(
         'checked',
@@ -100,7 +100,7 @@ describe('DOMPropertyOperations', function() {
       expect(DOMPropertyOperations.createMarkupForProperty(
         'download',
         true
-      )).toBe('download');
+      )).toBe('download=""');
 
       expect(DOMPropertyOperations.createMarkupForProperty(
         'download',


### PR DESCRIPTION
This fixes two parts of the markup generation to be XML-compatible per #2278 (specifically, self-closing tags and boolean attributes). More work is necessary to output valid Polyglot HTML5, as well as generic XML (for things like DocBook, etc). However, this should let React generate valid XML for the lion's share of use cases.

This breaks tests that are (incorrectly) checking for invalid XML, but these changes are nonetheless still valid HTML5. Advice is requested on if I should 'fix' the tests. Thanks!