### PR TITLE
Expose --target=esversion flag on jsx executable

### DIFF
--- a/bin/jsx
+++ b/bin/jsx
@@ -12,6 +12,13 @@ require('commoner').version(
   '--harmony',
   'Turns on JS transformations such as ES6 Classes etc.'
 ).option(
+  '--target [version]',
+  'Specify your target version of ECMAScript. Valid values are "es3" and ' +
+  '"es5". The default is "es5". "es3" will avoid uses of defineProperty and ' +
+  'will quote reserved words. WARNING: "es5" is not properly supported, even ' +
+  'with the use of es5shim, es5sham. If you need to support IE8, use "es3".',
+  'es5'
+).option(
   '--strip-types',
   'Strips out type annotations.'
 ).option(
@@ -37,7 +44,8 @@ require('commoner').version(
     sourceMap: this.options.sourceMapInline,
     stripTypes: this.options.stripTypes,
     es6module: this.options.es6module,
-    nonStrictEs6Module: this.options.nonStrictEs6Module
+    nonStrictEs6Module: this.options.nonStrictEs6Module,
+    target: this.options.target
   };
   return transform(source, options);
 });

--- a/main.js
+++ b/main.js
@@ -64,6 +64,11 @@ function processOptions(opts) {
     options.sourceType = 'nonStrict6Module';
   }
 
+  // Instead of doing any fancy validation, only look for 'es3'. If we have
+  // that, then use it. Otherwise use 'es5'.
+  options.es3 = opts.target === 'es3';
+  options.es5 = !options.es3;
+
   return options;
 }
 
@@ -72,6 +77,11 @@ function innerTransform(input, options) {
   if (options.harmony) {
     visitorSets.push('harmony');
   }
+
+  if (options.es3) {
+    visitorSets.push('es3');
+  }
+
   if (options.stripTypes) {
     // Stripping types needs to happen before the other transforms
     // unfortunately, due to bad interactions. For example,

--- a/vendor/fbtransform/visitors.js
+++ b/vendor/fbtransform/visitors.js
@@ -17,6 +17,7 @@ var es7SpreadProperty =
   require('jstransform/visitors/es7-spread-property-visitors');
 var react = require('./transforms/react');
 var reactDisplayName = require('./transforms/reactDisplayName');
+var reservedWords = require('jstransform/visitors/reserved-words-visitors');
 
 /**
  * Map from transformName => orderedListOfVisitors.
@@ -30,7 +31,8 @@ var transformVisitors = {
   'es6-rest-params': es6RestParameters.visitorList,
   'es6-templates': es6Templates.visitorList,
   'es7-spread-property': es7SpreadProperty.visitorList,
-  'react': react.visitorList.concat(reactDisplayName.visitorList)
+  'react': react.visitorList.concat(reactDisplayName.visitorList),
+  'reserved-words': reservedWords.visitorList
 };
 
 var transformSets = {
@@ -44,6 +46,9 @@ var transformSets = {
     'es6-destructuring',
     'es7-spread-property'
   ],
+  'es3': [
+    'reserved-words'
+  ],
   'react': [
     'react'
   ]
@@ -53,6 +58,7 @@ var transformSets = {
  * Specifies the order in which each transform should run.
  */
 var transformRunOrder = [
+  'reserved-words',
   'es6-arrow-functions',
   'es6-object-concise-method',
   'es6-object-short-notation',


### PR DESCRIPTION
This passes through the es5 flag to jstransform, which is used to support getters and setters in ES6 classes.

Fixes #2820

cc @fkling who added this in jstransform (https://github.com/facebook/jstransform/pull/19)
and @jeffmo who might know if we plan to support this particular option if we transition away from jstransform

It might actually make more sense to introduce a `target` option, like reactify has done (https://github.com/andreypopp/reactify/pull/27). Possible values would be "es3" (default) and "es5". Under "es3" we could also do the reserved words quoting (not happening currently). "es5" would not do the reserved word quoting but would do the getters.