### PR TITLE
Adds a composite component for an iframe to handle load events

### DIFF
--- a/src/browser/ui/ReactDefaultInjection.js
+++ b/src/browser/ui/ReactDefaultInjection.js
@@ -28,6 +28,7 @@ var ReactDOMButton = require('ReactDOMButton');
 var ReactDOMForm = require('ReactDOMForm');
 var ReactDOMImg = require('ReactDOMImg');
 var ReactDOMIDOperations = require('ReactDOMIDOperations');
+var ReactDOMIframe = require('ReactDOMIframe');
 var ReactDOMInput = require('ReactDOMInput');
 var ReactDOMOption = require('ReactDOMOption');
 var ReactDOMSelect = require('ReactDOMSelect');
@@ -85,6 +86,7 @@ function inject() {
   ReactInjection.NativeComponent.injectComponentClasses({
     'button': ReactDOMButton,
     'form': ReactDOMForm,
+    'iframe': ReactDOMIframe,
     'img': ReactDOMImg,
     'input': ReactDOMInput,
     'option': ReactDOMOption,

--- a/src/browser/ui/dom/components/ReactDOMIframe.js
+++ b/src/browser/ui/dom/components/ReactDOMIframe.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2013-2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactDOMIframe
+ */
+
+'use strict';
+
+var EventConstants = require('EventConstants');
+var LocalEventTrapMixin = require('LocalEventTrapMixin');
+var ReactBrowserComponentMixin = require('ReactBrowserComponentMixin');
+var ReactClass = require('ReactClass');
+var ReactElement = require('ReactElement');
+
+var iframe = ReactElement.createFactory('iframe');
+
+/**
+ * Since onLoad doesn't bubble OR capture on the top level in IE8, we need to
+ * capture it on the <iframe> element itself. There are lots of hacks we could
+ * do to accomplish this, but the most reliable is to make <iframe> a composite
+ * component and use `componentDidMount` to attach the event handlers.
+ */
+var ReactDOMIframe = ReactClass.createClass({
+  displayName: 'ReactDOMIframe',
+  tagName: 'IFRAME',
+
+  mixins: [ReactBrowserComponentMixin, LocalEventTrapMixin],
+
+  render: function() {
+    return iframe(this.props);
+  },
+
+  componentDidMount: function() {
+    this.trapBubbledEvent(EventConstants.topLevelTypes.topLoad, 'load');
+  }
+});
+
+module.exports = ReactDOMIframe;

--- a/src/browser/ui/dom/components/__tests__/ReactDOMIframe-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMIframe-test.js
@@ -1,0 +1,36 @@
+
+/**
+ * Copyright 2013-2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+"use strict";
+
+describe('ReactDOMIframe', function() {
+  var React;
+  var ReactTestUtils;
+
+  beforeEach(function() {
+    React = require('React');
+    ReactTestUtils = require('ReactTestUtils');
+  });
+
+  it('should trigger load events', function() {
+    var onLoadSpy = jasmine.createSpy();
+    var iframe = React.createElement('iframe', {onLoad: onLoadSpy});
+    iframe = ReactTestUtils.renderIntoDocument(iframe);
+
+    var loadEvent = document.createEvent('Event');
+    loadEvent.initEvent('load', false, false);
+
+    iframe.getDOMNode().dispatchEvent(loadEvent);
+
+    expect(onLoadSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
I stumbled upon #1718 because I had the same issue in my application and tried to fix it by copying the code from the `ReactDOMImg` component as suggest by @syranide in a [comment](https://github.com/facebook/react/issues/1718#issuecomment-57080315).

I removed the `error` event because as far as I am aware an `iframe` will never trigger it ([Source](https://code.google.com/p/chromium/issues/detail?id=365457)).

The test code is pretty ugly but I tried using `ReactTestUtils.SimulateNative.load` and when using it the tests passed with or without my changes. May be someone has a suggestion on how to make a prettier :smile: 
I also tested it in the different browser I have available (Chrome, Safari, Firefox and IE10).
