### PR TITLE
Don't warn about plain classes when in mocked components

### DIFF
--- a/src/classic/class/ReactClass.js
+++ b/src/classic/class/ReactClass.js
@@ -818,13 +818,13 @@ var ReactClass = {
       // mistake so we'll warn you to use the static property, property
       // initializer or constructor respectively.
       if (Constructor.getDefaultProps) {
-        Constructor.getDefaultProps._isReactClassApproved = true;
+        Constructor.getDefaultProps.isReactClassApproved = {};
       }
       if (Constructor.prototype.getInitialState) {
-        Constructor.prototype.getInitialState._isReactClassApproved = true;
+        Constructor.prototype.getInitialState.isReactClassApproved = {};
       }
       if (Constructor.prototype.componentWillMount) {
-        Constructor.prototype.componentWillMount._isReactClassApproved = true;
+        Constructor.prototype.componentWillMount.isReactClassApproved = {};
       }
     }
 

--- a/src/classic/element/ReactElementValidator.js
+++ b/src/classic/element/ReactElementValidator.js
@@ -380,7 +380,7 @@ var ReactElementValidator = {
       }
       if (typeof type.getDefaultProps === 'function') {
         warning(
-          type.getDefaultProps._isReactClassApproved,
+          type.getDefaultProps.isReactClassApproved,
           'getDefaultProps is only used on classic React.createClass ' +
           'definitions. Use a static property named `defaultProps` instead.'
         );

--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -204,7 +204,7 @@ var ReactCompositeComponentMixin = assign({},
       // catch them here, at initialization time, instead.
       warning(
         !inst.getInitialState ||
-        inst.getInitialState._isReactClassApproved,
+        inst.getInitialState.isReactClassApproved,
         'getInitialState was defined on %s, a plain JavaScript class. ' +
         'This is only supported for classes created using React.createClass. ' +
         'Did you mean to define a state property instead?',
@@ -212,7 +212,7 @@ var ReactCompositeComponentMixin = assign({},
       );
       warning(
         !inst.componentWillMount ||
-        inst.componentWillMount._isReactClassApproved,
+        inst.componentWillMount.isReactClassApproved,
         'componentWillMount was defined on %s, a plain JavaScript class. ' +
         'This is only supported for classes created using React.createClass. ' +
         'Did you mean to define a constructor instead?',

--- a/src/core/__tests__/ReactMockedComponent-test.js
+++ b/src/core/__tests__/ReactMockedComponent-test.js
@@ -31,6 +31,9 @@ describe('ReactMockedComponent', function() {
     ReactTestUtils = require('ReactTestUtils');
 
     OriginalComponent = React.createClass({
+      getDefaultProps: function() {
+        return { bar: 'baz' };
+      },
 
       getInitialState: function() {
         return { foo: 'bar' };
@@ -54,8 +57,10 @@ describe('ReactMockedComponent', function() {
     ReactTestUtils.mockComponent(MockedComponent);
   });
 
-  it('should allow an implicitly mocked component to be rendered', () => {
+  it('should allow an implicitly mocked component to be rendered without warnings', () => {
+    spyOn(console, 'warn');
     ReactTestUtils.renderIntoDocument(<AutoMockedComponent />);
+    expect(console.warn.calls.length).toBe(0);
   });
 
   it('should allow an implicitly mocked component to be updated', () => {


### PR DESCRIPTION
Implementation details of mocks are leaking... I'm not super happy with this but it *works* (and we already have a similar check a few lines earlier). cc @sebmarkbage 