### PR TITLE
Fix inaccurate spec description

### DIFF
--- a/src/browser/ui/dom/components/__tests__/LocalEventTrapMixin-test.js
+++ b/src/browser/ui/dom/components/__tests__/LocalEventTrapMixin-test.js
@@ -24,7 +24,7 @@ describe('LocalEventTrapMixin', function() {
     ReactTestUtils = require('ReactTestUtils');
   });
 
-  it('does not fatal when trapping bubbled state on null', function() {
+  it('throws when trapping bubbled state on null', function() {
     var BadImage = React.createClass({
       mixins: [LocalEventTrapMixin],
       render: function() {


### PR DESCRIPTION
The string here was initially accurate, but got out of sync with reality
when the commit was revised (as 892e357fd5acc).

cc: @yungsters 