### PR TITLE
Add warning when accessing .type on a component class

### DIFF
--- a/src/classic/class/ReactClass.js
+++ b/src/classic/class/ReactClass.js
@@ -23,6 +23,7 @@ var invariant = require('invariant');
 var keyMirror = require('keyMirror');
 var keyOf = require('keyOf');
 var monitorCodeUse = require('monitorCodeUse');
+var warning = require('warning');
 
 var MIXINS_KEY = keyOf({mixins: null});
 
@@ -693,6 +694,20 @@ function bindAutoBindMethods(component) {
   }
 }
 
+var typeDeprecationDescriptor = {
+  enumerable: false,
+  get: function() {
+    var displayName = this.displayName || this.name || 'Component';
+    warning(
+      false,
+      '%s.type is deprecated. Use %s directly to access the class.',
+      displayName,
+      displayName
+    );
+    return this;
+  }
+};
+
 /**
  * Add more to the ReactClass base class. These are all legacy features and
  * therefore not already part of the modern ReactComponentBase.
@@ -877,8 +892,13 @@ var ReactClass = {
       }
     }
 
-    // Legacy hook TODO: Warn if this is accessed
+    // Legacy hook
     Constructor.type = Constructor;
+    if (__DEV__) {
+      if (Object.defineProperty) {
+        Object.defineProperty(Constructor, 'type', typeDeprecationDescriptor);
+      }
+    }
 
     return Constructor;
   },

--- a/src/classic/class/__tests__/ReactClass-test.js
+++ b/src/classic/class/__tests__/ReactClass-test.js
@@ -43,6 +43,21 @@ describe('ReactClass-spec', function() {
       .toBe('TestComponent');
   });
 
+  it('should warn when accessing .type on a React class', function() {
+    var TestComponent = React.createClass({
+      render: function() {
+        return <div />;
+      }
+    });
+    console.warn = mocks.getMockFunction();
+    expect(TestComponent.type).toBe(TestComponent);
+    expect(console.warn.mock.calls.length).toBe(1);
+    expect(console.warn.mock.calls[0][0]).toBe(
+      'Warning: TestComponent.type is deprecated. Use TestComponent ' +
+      'directly to access the class.'
+    );
+  });
+
   it('should copy prop types onto the Constructor', function() {
     var propValidator = mocks.getMockFunction();
     var TestComponent = React.createClass({


### PR DESCRIPTION
Since we removed the wrapper factory around classes, the class is just
the class now so there is no need for this indirection property.