### PR TITLE
Move Component Class Instantiation into ReactCompositeComponent

### DIFF
--- a/src/classic/class/ReactClass.js
+++ b/src/classic/class/ReactClass.js
@@ -805,7 +805,7 @@ var ReactClass = {
    * @public
    */
   createClass: function(spec) {
-    var Constructor = function(props) {
+    var Constructor = function(props, context) {
       // This constructor is overridden by mocks. The argument is used
       // by mocks to assert on what gets mounted.
 
@@ -815,6 +815,7 @@ var ReactClass = {
       }
 
       this.props = props;
+      this.context = context;
       this.state = null;
 
       // ReactClasses doesn't have constructors. Instead, they use the

--- a/src/classic/class/__tests__/ReactClass-test.js
+++ b/src/classic/class/__tests__/ReactClass-test.js
@@ -278,6 +278,36 @@ describe('ReactClass-spec', function() {
     expect(instance.state.occupation).toEqual('clown');
   });
 
+  it('renders based on context getInitialState', function() {
+    var Foo = React.createClass({
+      contextTypes: {
+        className: React.PropTypes.string
+      },
+      getInitialState() {
+        return { className: this.context.className };
+      },
+      render() {
+        return <span className={this.state.className} />;
+      }
+    });
+
+    var Outer = React.createClass({
+      childContextTypes: {
+        className: React.PropTypes.string
+      },
+      getChildContext() {
+        return { className: 'foo' };
+      },
+      render() {
+        return <Foo />;
+      }
+    });
+
+    var container = document.createElement('div');
+    React.render(<Outer />, container);
+    expect(container.firstChild.className).toBe('foo');
+  });
+
   it('should throw with non-object getInitialState() return values', function() {
     [['an array'], 'a string', 1234].forEach(function(state) {
       var Component = React.createClass({

--- a/src/classic/element/ReactElementValidator.js
+++ b/src/classic/element/ReactElementValidator.js
@@ -22,6 +22,7 @@ var ReactElement = require('ReactElement');
 var ReactPropTypeLocations = require('ReactPropTypeLocations');
 var ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
 var ReactCurrentOwner = require('ReactCurrentOwner');
+var ReactNativeComponent = require('ReactNativeComponent');
 
 var getIteratorFn = require('getIteratorFn');
 var monitorCodeUse = require('monitorCodeUse');
@@ -361,26 +362,33 @@ var ReactElementValidator = {
     }
 
     if (type) {
-      var name = type.displayName || type.name;
-      if (type.propTypes) {
+      // Extract the component class from the element. Converts string types
+      // to a composite class which may have propTypes.
+      // TODO: Validating a string's propTypes is not decoupled from the
+      // rendering target which is problematic.
+      var componentClass = ReactNativeComponent.getComponentClassForElement(
+        element
+      );
+      var name = componentClass.displayName || componentClass.name;
+      if (componentClass.propTypes) {
         checkPropTypes(
           name,
-          type.propTypes,
+          componentClass.propTypes,
           element.props,
           ReactPropTypeLocations.prop
         );
       }
-      if (type.contextTypes) {
+      if (componentClass.contextTypes) {
         checkPropTypes(
           name,
-          type.contextTypes,
+          componentClass.contextTypes,
           element._context,
           ReactPropTypeLocations.context
         );
       }
-      if (typeof type.getDefaultProps === 'function') {
+      if (typeof componentClass.getDefaultProps === 'function') {
         warning(
-          type.getDefaultProps.isReactClassApproved,
+          componentClass.getDefaultProps.isReactClassApproved,
           'getDefaultProps is only used on classic React.createClass ' +
           'definitions. Use a static property named `defaultProps` instead.'
         );

--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -169,7 +169,7 @@ var ReactCompositeComponentMixin = assign({},
     );
 
     // Initialize the public class
-    var inst = new Component(publicProps);
+    var inst = new Component(publicProps, publicContext);
     // These should be set up in the constructor, but as a convenience for
     // simpler class abstractions, we set them up after the fact.
     inst.props = publicProps;

--- a/src/core/ReactNativeComponent.js
+++ b/src/core/ReactNativeComponent.js
@@ -57,27 +57,36 @@ function autoGenerateWrapperClass(type) {
 }
 
 /**
- * Create an internal class for a specific tag.
+ * Get a composite component wrapper class for a specific tag.
  *
- * @param {string} tag The tag for which to create an internal instance.
- * @param {any} props The props passed to the instance constructor.
- * @return {ReactComponent} component The injected empty component.
+ * @param {ReactElement} element The tag for which to get the class.
+ * @return {function} The React class constructor function.
  */
-function createInstanceForTag(tag, props, parentType) {
+function getComponentClassForElement(element) {
+  if (typeof element.type === 'function') {
+    return element.type;
+  }
+  var tag = element.type;
   var componentClass = tagToComponentClass[tag];
   if (componentClass == null) {
     tagToComponentClass[tag] = componentClass = autoGenerateWrapperClass(tag);
   }
-  if (parentType === tag) {
-    // Avoid recursion
-    invariant(
-      genericComponentClass,
-      'There is no registered component for the tag %s',
-      tag
-    );
-    return new genericComponentClass(tag, props);
-  }
-  return new componentClass(props);
+  return componentClass;
+}
+
+/**
+ * Get a native internal component class for a specific tag.
+ *
+ * @param {ReactElement} element The element to create.
+ * @return {function} The internal class constructor function.
+ */
+function createInternalComponent(element) {
+  invariant(
+    genericComponentClass,
+    'There is no registered component for the tag %s',
+    element.type
+  );
+  return new genericComponentClass(element.type, element.props);
 }
 
 /**
@@ -97,7 +106,8 @@ function isTextComponent(component) {
 }
 
 var ReactNativeComponent = {
-  createInstanceForTag: createInstanceForTag,
+  getComponentClassForElement: getComponentClassForElement,
+  createInternalComponent: createInternalComponent,
   createInstanceForText: createInstanceForText,
   isTextComponent: isTextComponent,
   injection: ReactNativeComponentInjection

--- a/src/modern/class/ReactComponentBase.js
+++ b/src/modern/class/ReactComponentBase.js
@@ -19,8 +19,9 @@ var warning = require('warning');
 /**
  * Base class helpers for the updating state of a component.
  */
-function ReactComponentBase(props) {
+function ReactComponentBase(props, context) {
   this.props = props;
+  this.context = context;
 }
 
 /**

--- a/src/modern/class/__tests__/ReactES6Class-test.js
+++ b/src/modern/class/__tests__/ReactES6Class-test.js
@@ -98,6 +98,37 @@ describe('ReactES6Class', function() {
     test(<Foo />, 'SPAN', 'bar');
   });
 
+  it('renders based on context in the constructor', function() {
+    class Foo extends React.Component {
+      constructor(props, context) {
+        super(props, context);
+        this.state = { tag: context.tag, className: this.context.className };
+      }
+      render() {
+        var Tag = this.state.tag;
+        return <Tag className={this.state.className} />;
+      }
+    }
+    Foo.contextTypes = {
+      tag: React.PropTypes.string,
+      className: React.PropTypes.string
+    };
+
+    class Outer extends React.Component {
+      getChildContext() {
+        return { tag: 'span', className: 'foo' };
+      }
+      render() {
+        return <Foo />;
+      }
+    }
+    Outer.childContextTypes = {
+      tag: React.PropTypes.string,
+      className: React.PropTypes.string
+    };
+    test(<Outer />, 'SPAN', 'foo');
+  });
+
   it('renders only once when setting state in componentWillMount', function() {
     var renderCount = 0;
     class Foo extends React.Component {


### PR DESCRIPTION
We need to move instantiation into the mount phase for context purposes.

To do this I moved the shallow rendering stuff into ReactTestUtils and
reused more of the existing code for it by instantiating a noop child.

Everywhere we refer to the "type" we should pass it to ReactNativeComponent
to resolve any string value into the underlying composite.

After that I added context to the public instance constructor so that we can set it up before getInitialState.

Fixes #2898