### PR TITLE
Warn when unitless values assigned to unit-requiring fields.  Fixes #1873.


### DIFF
--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -40,6 +40,8 @@ describe('ReactDOMComponent', function() {
     });
 
     it("should gracefully handle various style value types", function() {
+      spyOn(console, 'warn');
+
       var container = document.createElement('div');
       React.render(<div style={{}} />, container);
       var stubStyle = container.firstChild.style;
@@ -50,6 +52,13 @@ describe('ReactDOMComponent', function() {
       expect(stubStyle.display).toEqual('block');
       expect(stubStyle.left).toEqual('1px');
       expect(stubStyle.fontFamily).toEqual('Arial');
+      expect(console.warn.argsForCall.length).toBe(2);
+      expect(console.warn.argsForCall[0][0]).toContain(
+        'Warning: Unitless css property (`left`) specified with value `1`; assuming `1px`.'
+      );
+      expect(console.warn.argsForCall[1][0]).toContain(
+        'Warning: Unitless css property (`top`) specified with value `2`; assuming `2px`.'
+      );
 
       // reset the style to their default state
       var reset = { display: '', left: null, top: false, fontFamily: true };

--- a/src/browser/ui/dom/__tests__/CSSPropertyOperations-test.js
+++ b/src/browser/ui/dom/__tests__/CSSPropertyOperations-test.js
@@ -17,10 +17,17 @@ var React = require('React');
 
 describe('CSSPropertyOperations', function() {
   var CSSPropertyOperations;
+  var warn;
 
   beforeEach(function() {
     require('mock-modules').dumpCache();
     CSSPropertyOperations = require('CSSPropertyOperations');
+
+    warn = console.warn;
+  });
+
+  afterEach(function() {
+    console.warn = warn;
   });
 
   it('should create markup for simple styles', function() {
@@ -51,21 +58,42 @@ describe('CSSPropertyOperations', function() {
     })).toBe(null);
   });
 
-  it('should automatically append `px` to relevant styles', function() {
+  it('should automatically append `px` to relevant styles (and warn)', function() {
+
+    var mocks = require('mocks');
+    console.warn = mocks.getMockFunction();
+
     expect(CSSPropertyOperations.createMarkupForStyles({
       left: 0,
       margin: 16,
       opacity: 0.5,
       padding: '4px'
     })).toBe('left:0;margin:16px;opacity:0.5;padding:4px;');
+
+    expect(console.warn.mock.calls.length).toBe(1);
+    expect(console.warn.mock.calls[0][0]).toBe(
+      'Warning: Unitless css property (`margin`) specified with value `16`; assuming `16px`.'
+    );
   });
 
-  it('should trim values so `px` will be appended correctly', function() {
+  it('should trim values so `px` will be appended correctly (and warn)', function() {
+
+    var mocks = require('mocks');
+    console.warn = mocks.getMockFunction();
+
     expect(CSSPropertyOperations.createMarkupForStyles({
       margin: '16 ',
       opacity: 0.5,
       padding: ' 4 '
     })).toBe('margin:16px;opacity:0.5;padding:4px;');
+
+    expect(console.warn.mock.calls.length).toBe(2);
+    expect(console.warn.mock.calls[0][0]).toBe(
+      'Warning: Unitless css property (`margin`) specified with value `16`; assuming `16px`.'
+    );
+    expect(console.warn.mock.calls[1][0]).toBe(
+      'Warning: Unitless css property (`padding`) specified with value `4`; assuming `4px`.'
+    );
   });
 
   it('should not append `px` to styles that might need a number', function() {

--- a/src/browser/ui/dom/dangerousStyleValue.js
+++ b/src/browser/ui/dom/dangerousStyleValue.js
@@ -13,8 +13,12 @@
 'use strict';
 
 var CSSProperty = require('CSSProperty');
+var ReactCurrentOwner = require('ReactCurrentOwner');
 
 var isUnitlessNumber = CSSProperty.isUnitlessNumber;
+var warning = require('warning');
+
+var loggedTypeFailures = {};
 
 /**
  * Convert a value into the proper css writable value. The style name `name`
@@ -50,6 +54,23 @@ function dangerousStyleValue(name, value) {
   if (typeof value === 'string') {
     value = value.trim();
   }
+
+  if (__DEV__) {
+    var message = 'Unitless css property (`' + name + '`) specified with ' +
+      'value `' + value + '`; assuming `' + value + 'px`.';
+    if (ReactCurrentOwner.current) {
+      message = message + '  Please check render method of ' +
+        '`' + ReactCurrentOwner.current + '`.';
+    }
+
+    if (!(message in loggedTypeFailures)) {
+        // Only monitor this failure once because there tends to be a lot of the
+        // same error.
+        loggedTypeFailures[message] = true;
+        warning(false, '%s', message);
+      }
+    }
+
   return value + 'px';
 }
 

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -503,6 +503,32 @@ describe('ReactCompositeComponent', function() {
     }
   });
 
+  it('should warn once for each of multiple properties', function() {
+    var warn = console.warn;
+    console.warn = mocks.getMockFunction();
+
+    try {
+      var Component = React.createClass({
+        render: function() {
+          var setup = { display: 'block', left: '1', top: 2, fontFamily: 'Arial' };
+          return <div style={setup}><div style={setup} /><div style={setup} /></div>;
+        }
+      });
+
+      // Render three times
+      ReactTestUtils.renderIntoDocument(<Component />);
+      ReactTestUtils.renderIntoDocument(<Component />);
+      ReactTestUtils.renderIntoDocument(<Component />);
+
+      expect(console.warn.mock.calls.length).toBe(2);
+      expect(console.warn.mock.calls[0][0]).toBe(
+        'Warning: Unitless css property (`left`) specified with value `1`; assuming `1px`.'
+      );
+    } finally {
+      console.warn = warn;
+    }
+  });
+
   it('should pass context', function() {
     var childInstance = null;
     var grandchildInstance = null;


### PR DESCRIPTION
Warn when unitless values assigned to unit-requiring fields.  Fixes #1873.
