### PR TITLE
Batch updates in initial render

### DIFF
--- a/src/addons/ReactRAFBatchingStrategy.js
+++ b/src/addons/ReactRAFBatchingStrategy.js
@@ -31,8 +31,8 @@ var ReactRAFBatchingStrategy = {
    * Call the provided function in a context within which calls to `setState`
    * and friends are batched such that components aren't updated unnecessarily.
    */
-  batchedUpdates: function(callback, a, b) {
-    callback(a, b);
+  batchedUpdates: function(callback, a, b, c, d) {
+    callback(a, b, c, d);
   }
 };
 

--- a/src/core/ReactDefaultBatchingStrategy.js
+++ b/src/core/ReactDefaultBatchingStrategy.js
@@ -54,16 +54,16 @@ var ReactDefaultBatchingStrategy = {
    * Call the provided function in a context within which calls to `setState`
    * and friends are batched such that components aren't updated unnecessarily.
    */
-  batchedUpdates: function(callback, a, b) {
+  batchedUpdates: function(callback, a, b, c, d) {
     var alreadyBatchingUpdates = ReactDefaultBatchingStrategy.isBatchingUpdates;
 
     ReactDefaultBatchingStrategy.isBatchingUpdates = true;
 
     // The code is written this way to avoid extra allocations
     if (alreadyBatchingUpdates) {
-      callback(a, b);
+      callback(a, b, c, d);
     } else {
-      transaction.perform(callback, null, a, b);
+      transaction.perform(callback, null, a, b, c, d);
     }
   }
 };

--- a/src/core/ReactUpdates.js
+++ b/src/core/ReactUpdates.js
@@ -104,9 +104,9 @@ assign(
 
 PooledClass.addPoolingTo(ReactUpdatesFlushTransaction);
 
-function batchedUpdates(callback, a, b) {
+function batchedUpdates(callback, a, b, c, d) {
   ensureInjected();
-  batchingStrategy.batchedUpdates(callback, a, b);
+  batchingStrategy.batchedUpdates(callback, a, b, c, d);
 }
 
 /**

--- a/src/core/__tests__/ReactCompositeComponentState-test.js
+++ b/src/core/__tests__/ReactCompositeComponentState-test.js
@@ -155,9 +155,9 @@ describe('ReactCompositeComponent-state', function() {
       [ 'componentDidMount-start', 'orange', null ],
       // setState-sunrise and setState-orange should be called here,
       // after the bug in #1740
-      // componentDidMount() called setState({color:'yellow'}), currently this
-      // occurs inline.
-      // In a future where setState() is async, this test result will change.
+      // componentDidMount() called setState({color:'yellow'}), which is async.
+      // The update doesn't happen until the next flush.
+      [ 'componentDidMount-end', 'orange', 'yellow' ],
       [ 'shouldComponentUpdate-currentState', 'orange', null ],
       [ 'shouldComponentUpdate-nextState', 'yellow' ],
       [ 'componentWillUpdate-currentState', 'orange', null ],
@@ -166,8 +166,6 @@ describe('ReactCompositeComponent-state', function() {
       [ 'componentDidUpdate-currentState', 'yellow', null ],
       [ 'componentDidUpdate-prevState', 'orange' ],
       [ 'setState-yellow', 'yellow', null ],
-      // componentDidMount() finally closes.
-      [ 'componentDidMount-end', 'yellow', null ],
       [ 'initial-callback', 'yellow', null ],
       [ 'componentWillReceiveProps-start', 'yellow', null ],
       // setState({color:'green'}) only enqueues a pending state.


### PR DESCRIPTION
Currently, the first setState that happens during initial render will
start a new batch. Any subsequent updates will be batched. That means that
the first setState is synchronous but any subsequent setStates are
asynchronous.

This commit makes it so that the batching starts at the root. That way all
the setStates that happen within life-cycle methods are asynchronous.