### PR TITLE
Use Singleton LifeCycle State

### DIFF
--- a/src/classic/class/ReactClass.js
+++ b/src/classic/class/ReactClass.js
@@ -15,6 +15,7 @@ var ReactComponentBase = require('ReactComponentBase');
 var ReactElement = require('ReactElement');
 var ReactErrorUtils = require('ReactErrorUtils');
 var ReactInstanceMap = require('ReactInstanceMap');
+var ReactLifeCycle = require('ReactLifeCycle');
 var ReactPropTypeLocations = require('ReactPropTypeLocations');
 var ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
 var ReactUpdateQueue = require('ReactUpdateQueue');
@@ -734,9 +735,10 @@ var ReactClassMixin = {
    */
   isMounted: function() {
     var internalInstance = ReactInstanceMap.get(this);
-    // In theory, isMounted is always true if it exists in the map.
-    // TODO: Remove the internal isMounted method.
-    return internalInstance && internalInstance.isMounted();
+    return (
+      internalInstance &&
+      internalInstance !== ReactLifeCycle.currentlyMountingInstance
+    );
   },
 
   /**

--- a/src/core/ReactLifeCycle.js
+++ b/src/core/ReactLifeCycle.js
@@ -11,50 +11,25 @@
 
 "use strict";
 
-var keyMirror = require('keyMirror');
-
 /**
- * `ReactCompositeComponent` maintains an auxiliary life cycle state in
- * `this._compositeLifeCycleState` (which can be null).
+ * This module manages the bookkeeping when a component is in the process
+ * of being mounted or being unmounted. This is used as a way to enforce
+ * invariants (or warnings) when it is not recommended to call
+ * setState/forceUpdate.
  *
- * This is different from the life cycle state maintained by `ReactComponent`.
- * The following diagram shows how the states overlap in
- * time. There are times when the CompositeLifeCycle is null - at those times it
- * is only meaningful to look at ComponentLifeCycle alone.
+ * currentlyMountingInstance: During the construction phase, it is not possible
+ * to trigger an update since the instance is not fully mounted yet. However, we
+ * currently allow this as a convenience for mutating the initial state.
  *
- * Top Row: ReactComponent.ComponentLifeCycle
- * Low Row: ReactComponent.CompositeLifeCycle
- *
- * +-------+---------------------------------+--------+
- * |  UN   |             MOUNTED             |   UN   |
- * |MOUNTED|                                 | MOUNTED|
- * +-------+---------------------------------+--------+
- * |       ^--------+   +-------+   +--------^        |
- * |       |        |   |       |   |        |        |
- * |    0--|MOUNTING|-0-|RECEIVE|-0-|   UN   |--->0   |
- * |       |        |   |PROPS  |   |MOUNTING|        |
- * |       |        |   |       |   |        |        |
- * |       |        |   |       |   |        |        |
- * |       +--------+   +-------+   +--------+        |
- * |       |                                 |        |
- * +-------+---------------------------------+--------+
+ * currentlyUnmountingInstance: During the unmounting phase, the instance is
+ * still mounted and can therefore schedule an update. However, this is not
+ * recommended and probably an error since it's about to be unmounted.
+ * Therefore we still want to trigger in an error for that case.
  */
-var ReactLifeCycle = keyMirror({
-  /**
-   * Components in the process of being mounted respond to state changes
-   * differently.
-   */
-  MOUNTING: null,
-  /**
-   * Components in the process of being unmounted are guarded against state
-   * changes.
-   */
-  UNMOUNTING: null,
-  /**
-   * Components that are mounted and receiving new props respond to state
-   * changes differently.
-   */
-  RECEIVING_PROPS: null
-});
+
+var ReactLifeCycle = {
+  currentlyMountingInstance: null,
+  currentlyUnmountingInstance: null
+};
 
 module.exports = ReactLifeCycle;

--- a/src/core/ReactUpdateQueue.js
+++ b/src/core/ReactUpdateQueue.js
@@ -21,7 +21,7 @@ var assign = require('Object.assign');
 var invariant = require('invariant');
 
 function enqueueUpdate(internalInstance) {
-  if (internalInstance._compositeLifeCycleState !== ReactLifeCycle.MOUNTING) {
+  if (internalInstance !== ReactLifeCycle.currentlyMountingInstance) {
     // If we're in a componentWillMount handler, don't enqueue a rerender
     // because ReactUpdates assumes we're in a browser context (which is
     // wrong for server rendering) and we're about to do a render anyway.
@@ -49,8 +49,7 @@ function getInternalInstanceReadyForUpdate(publicInstance, callerName) {
     callerName
   );
   invariant(
-    internalInstance._compositeLifeCycleState !==
-    ReactLifeCycle.UNMOUNTING,
+    internalInstance !== ReactLifeCycle.currentlyUnmountingInstance,
     '%s(...): Cannot call %s() on an unmounting component.',
     callerName,
     callerName
@@ -84,7 +83,7 @@ var ReactUpdateQueue = {
       internalInstance,
       'Cannot enqueue a callback on an instance that is unmounted.'
     );
-    if (internalInstance._compositeLifeCycleState === ReactLifeCycle.MOUNTING) {
+    if (internalInstance === ReactLifeCycle.currentlyMountingInstance) {
       // Ignore callbacks in componentWillMount. See enqueueUpdate.
       return;
     }
@@ -95,7 +94,8 @@ var ReactUpdateQueue = {
     }
     // TODO: The callback here is ignored when setState is called from
     // componentWillMount. Either fix it or disallow doing so completely in
-    // favor of getInitialState.
+    // favor of getInitialState. Alternatively, we can disallow
+    // componentWillMount during server-side rendering.
     enqueueUpdate(internalInstance);
   },
 


### PR DESCRIPTION
Builds on #2935 and #2930.

All entry points are for reconciliation are now within batching strategies.

Since we don't have any batching strategies with synchronous updates,
there can't be more than one life-cycle method on the stack at any given
time.

Therefore, it's safe to move the composite life cycle flag to a singleton.
This saves us some memory management.

I think that we can get rid of these life cycle states completely in the
future.