### PR TITLE
Update 2014-09-24-testing-flux-applications.md

### DIFF
--- a/docs/_posts/2014-09-24-testing-flux-applications.md
+++ b/docs/_posts/2014-09-24-testing-flux-applications.md
@@ -90,7 +90,7 @@ The example Flux TodoMVC application has been updated with an example test for t
 
 ```javascript
 jest.dontMock('../TodoStore');
-jest.dontMock('react/lib/merge');
+jest.dontMock('object-assign');
 
 describe('TodoStore', function() {
 


### PR DESCRIPTION
Adjust react/lib/merge to object-assign, as react/lib/merge is now deprecated.