### PR TITLE
Add Meta Matchers for Testing Tests

### DIFF
--- a/src/modern/class/__tests__/ReactClassEquivalence-test.js
+++ b/src/modern/class/__tests__/ReactClassEquivalence-test.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+var MetaMatchers = require('MetaMatchers');
+
+describe('ReactClassEquivalence', function() {
+
+  beforeEach(function() {
+    this.addMatchers(MetaMatchers);
+  });
+
+  var es6 = () => require('./ReactES6Class-test.js');
+  var coffee = () => require('./ReactCoffeeScriptClass-test.coffee');
+
+  it('tests the same thing for es6 classes and coffee script', function() {
+    expect(coffee).toEqualSpecsIn(es6);
+  });
+
+});

--- a/src/test/MetaMatchers.js
+++ b/src/test/MetaMatchers.js
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule MetaMatchers
+ */
+
+'use strict';
+
+/**
+ * This modules adds a jasmine matcher toEqualSpecsIn that can be used to
+ * compare the specs in two different "describe" functions and their result.
+ * It can be used to test a test.
+ */
+
+function getRunnerWithResults(describeFunction) {
+  if (describeFunction._cachedRunner) {
+    // Cached result of execution. This is a convenience way to test against
+    // the same authorative function multiple times.
+    return describeFunction._cachedRunner;
+  }
+  // Patch the current global environment.
+  var env = new jasmine.Env();
+  // Execute the tests synchronously.
+  env.updateInterval = 0;
+  var outerGetEnv = jasmine.getEnv;
+  jasmine.getEnv = function() { return env; };
+  // TODO: Bring over matchers from the existing environment.
+  var runner = env.currentRunner();
+  try {
+    env.describe('', describeFunction);
+    env.execute();
+  } finally {
+    // Restore the environment.
+    jasmine.getEnv = outerGetEnv;
+  }
+  describeFunction._cachedRunner = runner;
+  return runner;
+}
+
+function compareSpec(actual, expected) {
+  if (actual.results().totalCount !== expected.results().totalCount) {
+    return (
+      'Expected ' + expected.results().totalCount + ' expects, ' +
+      'but got ' + actual.results().totalCount + ':' +
+      actual.getFullName()
+    );
+  }
+  return null;
+}
+
+function includesDescription(specs, description, startIndex) {
+  for (var i = startIndex; i < specs.length; i++) {
+    if (specs[i].description === description) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function compareSpecs(actualSpecs, expectedSpecs) {
+  for (var i = 0; i < actualSpecs.length && i < expectedSpecs.length; i++) {
+    var actual = actualSpecs[i];
+    var expected = expectedSpecs[i];
+    if (actual.description === expected.description) {
+      var errorMessage = compareSpec(actual, expected);
+      if (errorMessage) {
+        return errorMessage;
+      }
+      continue;
+    } else if (includesDescription(actualSpecs, expected.description, i)) {
+      return 'Did not expect the spec:' + actualSpecs[i].getFullName();
+    } else {
+      return 'Expected an equivalent to:' + expectedSpecs[i].getFullName();
+    }
+  }
+  if (i < actualSpecs.length) {
+    return 'Did not expect the spec:' + actualSpecs[i].getFullName();
+  }
+  if (i < expectedSpecs.length) {
+    return 'Expected an equivalent to:' + expectedSpecs[i].getFullName();
+  }
+  return null;
+}
+
+function compareDescription(a, b) {
+  if (a.description === b.description) {
+    return 0;
+  }
+  return a.description < b.description ? -1 : 1;
+}
+
+function compareRunners(actual, expected) {
+  return compareSpecs(
+    actual.specs().sort(compareDescription),
+    expected.specs().sort(compareDescription)
+  );
+}
+
+var MetaMatchers = {
+  toEqualSpecsIn: function(expectedDescribeFunction) {
+    var actualDescribeFunction = this.actual;
+    if (typeof actualDescribeFunction !== 'function') {
+      throw Error('toEqualSpecsIn() should be used on a describe function');
+    }
+    if (typeof expectedDescribeFunction !== 'function') {
+      throw Error('toEqualSpecsIn() should be passed a describe function');
+    }
+    var actual = getRunnerWithResults(actualDescribeFunction);
+    var expected = getRunnerWithResults(expectedDescribeFunction);
+    var errorMessage = compareRunners(actual, expected);
+    this.message = function() {
+      return [
+        errorMessage,
+        'The specs are equal. Expected them to be different.'
+      ];
+    };
+    return !errorMessage;
+  }
+};
+
+module.exports = MetaMatchers;

--- a/src/test/__tests__/MetaMatchers-test.js
+++ b/src/test/__tests__/MetaMatchers-test.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+var MetaMatchers = require('MetaMatchers');
+
+describe('meta-matchers', function() {
+
+  beforeEach(function() {
+    this.addMatchers(MetaMatchers);
+  });
+
+  function a() {
+    it('should add 1 and 2', function() {
+      expect(1 + 2).toBe(3);
+    });
+  }
+
+  function b() {
+    it('should add 1 and 2', function() {
+      expect(1 + 2).toBe(3);
+    });
+  }
+
+  function c() {
+    it('should add 1 and 2', function() {
+      expect(1 + 2).toBe(3);
+    });
+    it('should mutiply 1 and 2', function() {
+      expect(1 * 2).toBe(2);
+    });
+  }
+
+  function d() {
+    it('should add 1 and 2', function() {
+      expect(1 + 2).toBe(3);
+    });
+    it('should mutiply 1 and 2', function() {
+      expect(1 * 2).toBe(2);
+      expect(2 * 1).toBe(2);
+    });
+  }
+
+  it('tests equality of specs', function() {
+    expect(a).toEqualSpecsIn(b);
+  });
+
+  it('tests inequality of specs and expects', function() {
+    expect(b).not.toEqualSpecsIn(c);
+    expect(c).not.toEqualSpecsIn(d);
+  });
+
+});


### PR DESCRIPTION
This adds a matcher called toEqualSpecsIn which executes two test suites,
without reporting the result. It then compares the specs and the number
of expects executed by each spec.

This will be used to ensure that tests written in other languages test the
same thing as the base line, ES6 classes.