### PR TITLE
Rename ReactComponentBase -> ReactComponent

### DIFF
--- a/src/browser/ui/React.js
+++ b/src/browser/ui/React.js
@@ -16,7 +16,7 @@
 var DOMPropertyOperations = require('DOMPropertyOperations');
 var EventPluginUtils = require('EventPluginUtils');
 var ReactChildren = require('ReactChildren');
-var ReactComponentBase = require('ReactComponentBase');
+var ReactComponent = require('ReactComponent');
 var ReactClass = require('ReactClass');
 var ReactContext = require('ReactContext');
 var ReactCurrentOwner = require('ReactCurrentOwner');
@@ -56,7 +56,7 @@ var React = {
     count: ReactChildren.count,
     only: onlyChild
   },
-  Component: ReactComponentBase,
+  Component: ReactComponent,
   DOM: ReactDOM,
   PropTypes: ReactPropTypes,
   initializeTouchEvents: function(shouldUseTouch) {

--- a/src/classic/class/ReactClass.js
+++ b/src/classic/class/ReactClass.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var ReactComponentBase = require('ReactComponentBase');
+var ReactComponent = require('ReactComponent');
 var ReactElement = require('ReactElement');
 var ReactErrorUtils = require('ReactErrorUtils');
 var ReactInstanceMap = require('ReactInstanceMap');
@@ -712,7 +712,7 @@ var typeDeprecationDescriptor = {
 
 /**
  * Add more to the ReactClass base class. These are all legacy features and
- * therefore not already part of the modern ReactComponentBase.
+ * therefore not already part of the modern ReactComponent.
  */
 var ReactClassMixin = {
 
@@ -774,10 +774,10 @@ var ReactClassMixin = {
   }
 };
 
-var ReactClassBase = function() {};
+var ReactClassComponent = function() {};
 assign(
-  ReactClassBase.prototype,
-  ReactComponentBase.prototype,
+  ReactClassComponent.prototype,
+  ReactComponent.prototype,
   ReactClassMixin
 );
 
@@ -830,7 +830,7 @@ var ReactClass = {
 
       this.state = initialState;
     };
-    Constructor.prototype = new ReactClassBase();
+    Constructor.prototype = new ReactClassComponent();
     Constructor.prototype.constructor = Constructor;
 
     injectedMixins.forEach(

--- a/src/modern/class/ReactComponent.js
+++ b/src/modern/class/ReactComponent.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule ReactComponentBase
+ * @providesModule ReactComponent
  */
 
 'use strict';
@@ -19,7 +19,7 @@ var warning = require('warning');
 /**
  * Base class helpers for the updating state of a component.
  */
-function ReactComponentBase(props, context) {
+function ReactComponent(props, context) {
   this.props = props;
   this.context = context;
 }
@@ -41,7 +41,7 @@ function ReactComponentBase(props, context) {
  * @final
  * @protected
  */
-ReactComponentBase.prototype.setState = function(partialState, callback) {
+ReactComponent.prototype.setState = function(partialState, callback) {
   invariant(
     typeof partialState === 'object' || partialState == null,
     'setState(...): takes an object of state variables to update.'
@@ -73,7 +73,7 @@ ReactComponentBase.prototype.setState = function(partialState, callback) {
  * @final
  * @protected
  */
-ReactComponentBase.prototype.forceUpdate = function(callback) {
+ReactComponent.prototype.forceUpdate = function(callback) {
   ReactUpdateQueue.enqueueForceUpdate(this);
   if (callback) {
     ReactUpdateQueue.enqueueCallback(this, callback);
@@ -94,7 +94,7 @@ if (__DEV__) {
       setProps: 'setProps'
     };
     var defineDeprecationWarning = function(methodName, displayName) {
-      Object.defineProperty(ReactComponentBase.prototype, methodName, {
+      Object.defineProperty(ReactComponent.prototype, methodName, {
         get: function() {
           warning(
             false,
@@ -113,4 +113,4 @@ if (__DEV__) {
   }
 }
 
-module.exports = ReactComponentBase;
+module.exports = ReactComponent;


### PR DESCRIPTION
We freed up this internal name by removing the internal base class.
We're now free to use this name as it was intended.

ReactDOMComponent and ReactCompositeComponent are still confusing as
they're internal but we'll rename them later.