### PR TITLE
We don't currently have a way to trace the origin of a mixin

### DIFF
--- a/src/browser/ui/React.js
+++ b/src/browser/ui/React.js
@@ -65,6 +65,10 @@ var React = {
   createClass: ReactClass.createClass,
   createElement: createElement,
   createFactory: createFactory,
+  createMixin: function(mixin) {
+    // Currently a noop. Will be used to validate and trace mixins.
+    return mixin;
+  },
   constructAndRenderComponent: ReactMount.constructAndRenderComponent,
   constructAndRenderComponentByID: ReactMount.constructAndRenderComponentByID,
   findDOMNode: findDOMNode,


### PR DESCRIPTION
This makes it more difficult to find bugs in mixins both dynamically
and using a static type system.

We also don't have a way to find these to be upgraded to a new mixin
syntax if we needed to.

This hook is currently an optional noop but could be made required to
create a mixin class.