### PR TITLE
Remove "derequire" from minified bundles

### DIFF
--- a/grunt/config/browserify.js
+++ b/grunt/config/browserify.js
@@ -72,7 +72,10 @@ var min = {
   standalone: 'React',
   transforms: [envify({NODE_ENV: 'production'}), uglifyify],
   plugins: [collapser],
-  after: [es3ify.transform, derequire, minify, bannerify]
+  // No need to derequire because the minifier will mangle
+  // the "require" calls.
+
+  after: [es3ify.transform, /*derequire,*/ minify, bannerify]
 };
 
 var transformer = {
@@ -114,7 +117,10 @@ var addonsMin = {
   packageName: 'React (with addons)',
   transforms: [envify({NODE_ENV: 'production'}), uglifyify],
   plugins: [collapser],
-  after: [es3ify.transform, derequire, minify, bannerify]
+  // No need to derequire because the minifier will mangle
+  // the "require" calls.
+
+  after: [es3ify.transform, /*derequire,*/ minify, bannerify]
 };
 
 var withCodeCoverageLogging = {


### PR DESCRIPTION
The point of running "derequire" is to rename the `require` calls to something else. Well, minifying already does this in its mangle step. You still need "derequire" for the non-minified bundles though :disappointed:

This reduces the run time of `grunt build` from ~52sec to ~36sec on my machine (~30% less time). I can also shave off an extra 2-3 seconds by updating derequire's outdated `esprima-fb` and `estraverse` - I'll put in a PR for that in that project later.

/cc @zpao 