### PR TITLE
Docs wording tweak: subject verb agreement

### DIFF
--- a/docs/docs/04-multiple-components.md
+++ b/docs/docs/04-multiple-components.md
@@ -171,7 +171,7 @@ var MyComponent = React.createClass({
 });
 ```
 
-You can also key children by passing an object. The object keys will be used as `key` for each value. However it is important to remember that JavaScript does not guarantee the ordering of properties will be preserved. In practice browsers will preserve property order **except** for properties that can be parsed as a 32-bit unsigned integers. Numeric properties will be ordered sequentially and before other properties. If this happens React will render components out of order. This can be avoided by adding a string prefix to the key:
+You can also key children by passing an object. The object keys will be used as `key` for each value. However it is important to remember that JavaScript does not guarantee the ordering of properties will be preserved. In practice browsers will preserve property order **except** for properties that can be parsed as 32-bit unsigned integers. Numeric properties will be ordered sequentially and before other properties. If this happens React will render components out of order. This can be avoided by adding a string prefix to the key:
 
 ```javascript
   render: function() {


### PR DESCRIPTION
Deleted the 'a' in the following sentence to create subject verb agreement: 

"In practice browsers will preserve property order except for properties that can be parsed as **a** 32-bit unsigned integers."

![image](https://cloud.githubusercontent.com/assets/7017045/5928706/103139da-a632-11e4-92bf-d98f56476e6c.png)

![image](https://cloud.githubusercontent.com/assets/7017045/5928700/05f2ae5e-a632-11e4-97dd-c4a7577c96cf.png)
