### PR TITLE
Run jest with grunt, add to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ after_script:
 env:
   matrix:
   - TEST_TYPE=test
+  - TEST_TYPE=jest
   - TEST_TYPE=lint
   - TEST_TYPE=test:webdriver:saucelabs:modern
   global:

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "grunt-contrib-connect": "~0.6.0",
     "grunt-contrib-copy": "^0.7.0",
     "grunt-contrib-jshint": "^0.10.0",
+    "grunt-jest": "^0.1.2",
     "gzip-js": "~0.3.2",
     "jasmine-tapreporter": "~0.2.2",
     "jest-cli": "^0.2.1",
@@ -58,8 +59,8 @@
     "populist": "~0.1.6",
     "recast": "^0.9.11",
     "sauce-tunnel": "~1.1.0",
-    "ts-compiler": "^2.0.0",
     "tmp": "~0.0.18",
+    "ts-compiler": "^2.0.0",
     "uglify-js": "~2.4.0",
     "uglifyify": "^2.4.0",
     "wd": "~0.2.6"


### PR DESCRIPTION
This is to make sure we don't end up with differences in our different
testing methods. We may switch out the failure allowances later (maybe
just jest will be good enough and we can let phantom fail for a little
bit).

We're using an empty config here which seems to just pick up the config from `package.json` (correct me if I'm wrong @leebyron)