### PR TITLE
[jest] Use persistModuleRegistryBetweenSpecs

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "rootDir": "",
     "scriptPreprocessor": "jest/preprocessor.js",
     "setupEnvScriptFile": "jest/environment.js",
+    "persistModuleRegistryBetweenSpecs": true,
     "testFileExtensions": [
       "js",
       "coffee",


### PR DESCRIPTION
This more closely matches how we have jest configured at FB, so when we
pull in and run internally we will have fewer things to waste time on.