### PR TITLE
Reordered 'Using Props' before 'Component Properties'

### DIFF
--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -166,32 +166,12 @@ var CommentBox = React.createClass({
 
 Notice how we're mixing HTML tags and components we've built. HTML components are regular React components, just like the ones you define, with one difference. The JSX compiler will automatically rewrite HTML tags to `React.createElement(tagName)` expressions and leave everything else alone. This is to prevent the pollution of the global namespace.
 
-### Component Properties
-
-Let's create our third component, `Comment`. We will want to pass it the author name and comment text so we can reuse the same code for each unique comment. First let's add some comments to the `CommentList`:
-
-```javascript{6-7}
-// tutorial4.js
-var CommentList = React.createClass({
-  render: function() {
-    return (
-      <div className="commentList">
-        <Comment author="Pete Hunt">This is one comment</Comment>
-        <Comment author="Jordan Walke">This is *another* comment</Comment>
-      </div>
-    );
-  }
-});
-```
-
-Note that we have passed some data from the parent `CommentList` component to the child `Comment` components. For example, we passed *Pete Hunt* (via an attribute) and *This is one comment* (via an XML-like child node) to the first `Comment`. Data passed from parent to children components is called **props**, short for properties.
-
 ### Using props
 
 Let's create the Comment component. Using **props** we will be able to read the data passed to it from the `CommentList`, and render some markup:
 
 ```javascript
-// tutorial5.js
+// tutorial4.js
 var Comment = React.createClass({
   render: function() {
     return (
@@ -207,6 +187,26 @@ var Comment = React.createClass({
 ```
 
 By surrounding a JavaScript expression in braces inside JSX (as either an attribute or child), you can drop text or React components into the tree. We access named attributes passed to the component as keys on `this.props` and any nested elements as `this.props.children`.
+
+### Component Properties
+
+Let's create our third component, `Comment`. We will want to pass it the author name and comment text so we can reuse the same code for each unique comment. First let's add some comments to the `CommentList`:
+
+```javascript{6-7}
+// tutorial5.js
+var CommentList = React.createClass({
+  render: function() {
+    return (
+      <div className="commentList">
+        <Comment author="Pete Hunt">This is one comment</Comment>
+        <Comment author="Jordan Walke">This is *another* comment</Comment>
+      </div>
+    );
+  }
+});
+```
+
+Note that we have passed some data from the parent `CommentList` component to the child `Comment` components. For example, we passed *Pete Hunt* (via an attribute) and *This is one comment* (via an XML-like child node) to the first `Comment`. Data passed from parent to children components is called **props**, short for properties.
 
 ### Adding Markdown
 

--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -168,7 +168,7 @@ Notice how we're mixing HTML tags and components we've built. HTML components ar
 
 ### Using props
 
-Let's create the Comment component. Using **props** we will be able to read the data passed to it from the `CommentList`, and render some markup:
+Let's create the `Comment` component, which will depend on data passed in from it's parent. Data passed in from a parent component is available as a 'property' on the child component. These 'properties' are accessed through `this.props`. Using props we will be able to read the data passed to the `Comment` from the `CommentList`, and render some markup:
 
 ```javascript
 // tutorial4.js
@@ -190,7 +190,7 @@ By surrounding a JavaScript expression in braces inside JSX (as either an attrib
 
 ### Component Properties
 
-Let's create our third component, `Comment`. We will want to pass it the author name and comment text so we can reuse the same code for each unique comment. First let's add some comments to the `CommentList`:
+Now that we have defined the `Comment` component, we will want to pass it the author name and comment text. This allows us to reuse the same code for each unique comment. Now let's add some comments within our `CommentList`:
 
 ```javascript{6-7}
 // tutorial5.js
@@ -206,7 +206,7 @@ var CommentList = React.createClass({
 });
 ```
 
-Note that we have passed some data from the parent `CommentList` component to the child `Comment` components. For example, we passed *Pete Hunt* (via an attribute) and *This is one comment* (via an XML-like child node) to the first `Comment`. Data passed from parent to children components is called **props**, short for properties.
+Note that we have passed some data from the parent `CommentList` component to the child `Comment` components. For example, we passed *Pete Hunt* (via an attribute) and *This is one comment* (via an XML-like child node) to the first `Comment`. As noted above, the `Comment` component will access these 'properties' through `this.props.author`, and `this.props.children`.
 
 ### Adding Markdown
 


### PR DESCRIPTION
As noted in Issue https://github.com/facebook/react/issues/2395, the current ordering of these two sections leads to an error being thrown in the console. 

If we just reorder these two sections (without changing any of the text within them other than the naming of tutorial4.js and tutorial5.js), the code all works out perfectly. 

Console error: 
![image](https://cloud.githubusercontent.com/assets/7017045/5932478/53a60e76-a663-11e4-98c6-d52e9deeb8e7.png)

Current order: 
![image](https://cloud.githubusercontent.com/assets/7017045/5932492/7763eb9e-a663-11e4-911e-e59765aa724a.png)
![image](https://cloud.githubusercontent.com/assets/7017045/5932494/806ea0b2-a663-11e4-861c-ccefd9022f33.png)

Updated order with no errors: 
![image](https://cloud.githubusercontent.com/assets/7017045/5932497/88701c1e-a663-11e4-9cae-2f7fa41fe9da.png)
![image](https://cloud.githubusercontent.com/assets/7017045/5932498/907b7d04-a663-11e4-87a8-78d101dc9927.png)


