### PR TITLE
Update ES3 example to be more idiomatic JavaScript

### DIFF
--- a/docs/_posts/2015-01-27-react-v0.13.0-beta-1.md
+++ b/docs/_posts/2015-01-27-react-v0.13.0-beta-1.md
@@ -148,15 +148,13 @@ class Counter extends React.Component
     div(onClick: @tick, 'Clicks: ', @state.count)
 ```
 
-You can even use the old ES3 module pattern if you want:
+You can even use the old ES3 class pattern if you want:
 
 ```javascript
 function MyComponent(initialProps) {
-  return {
-    state: { value: initialProps.initialValue },
-    render: function() {
-      return <span className={this.state.value} />
-    }
-  };
+  this.state = { value: initialProps.initialValue };
 }
+MyComponent.prototype.render = function () {
+  return <span className={this.state.value} />
+};
 ```


### PR DESCRIPTION
This updates the ES3 example in the latest blog post to:

```js
function MyComponent(initialProps) {
  this.state = { value: initialProps.initialValue };
}
MyComponent.prototype.render = function () {
  return <span className={this.state.value} />
};
```

rather than:

```js
function MyComponent(initialProps) {
  return {
    state: { value: initialProps.initialValue },
    render: function() {
      return <span className={this.state.value} />
    }
  };
}
```

I assume both work, and using `this` and `prototype` is more idiomatic of JavaScript code written before the class syntax existed.