### PR TITLE
Documents that `classSet` concatenates its arguments

### DIFF
--- a/docs/docs/10.3-class-name-manipulation.md
+++ b/docs/docs/10.3-class-name-manipulation.md
@@ -42,4 +42,17 @@ render: function() {
 
 When using `classSet()`, pass an object with keys of the CSS class names you might or might not need. Truthy values will result in the key being a part of the resulting string.
 
+`classSet()` also lets pass class names in as arguments that are then concatenated for you:
+
+```javascript
+render: function() {
+  var cx = React.addons.classSet;
+  var importantModifier = 'message-important';
+  var readModifier = 'message-read';
+  var classes = cx('message', importantModifier, readModifier);
+  // Final string is 'message message-important message-read'
+  return <div className={classes}>Great, I'll be there.</div>;
+}
+```
+
 No more hacky string concatenations!


### PR DESCRIPTION
Just wanted it to be noted that `classSet` operates in two ways, both of which are valuable.