### PR TITLE
Set state takes a function

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -96,7 +96,8 @@ var ReactCompositeComponentMixin = {
 
     // See ReactUpdateQueue
     this._pendingElement = null;
-    this._pendingState = null;
+    this._pendingStateQueue = null;
+    this._pendingReplaceState = false;
     this._pendingForceUpdate = false;
 
     this._renderedComponent = null;
@@ -191,7 +192,8 @@ var ReactCompositeComponentMixin = {
       this.getName() || 'ReactCompositeComponent'
     );
 
-    this._pendingState = null;
+    this._pendingStateQueue = null;
+    this._pendingReplaceState = false;
     this._pendingForceUpdate = false;
 
     if (inst.componentWillMount) {
@@ -203,10 +205,9 @@ var ReactCompositeComponentMixin = {
         ReactLifeCycle.currentlyMountingInstance = previouslyMounting;
       }
       // When mounting, calls to `setState` by `componentWillMount` will set
-      // `this._pendingState` without triggering a re-render.
-      if (this._pendingState) {
-        inst.state = this._pendingState;
-        this._pendingState = null;
+      // `this._pendingStateQueue` without triggering a re-render.
+      if (this._pendingStateQueue) {
+        inst.state = this._processPendingState(inst.props, inst.context);
       }
     }
 
@@ -252,7 +253,8 @@ var ReactCompositeComponentMixin = {
     this._renderedComponent = null;
 
     // Reset pending fields
-    this._pendingState = null;
+    this._pendingStateQueue = null;
+    this._pendingReplaceState = false;
     this._pendingForceUpdate = false;
     this._pendingCallbacks = null;
     this._pendingElement = null;
@@ -470,7 +472,7 @@ var ReactCompositeComponentMixin = {
   },
 
   /**
-   * If any of `_pendingElement`, `_pendingState`, or `_pendingForceUpdate`
+   * If any of `_pendingElement`, `_pendingStateQueue`, or `_pendingForceUpdate`
    * is set, update the component.
    *
    * @param {ReactReconcileTransaction} transaction
@@ -486,7 +488,7 @@ var ReactCompositeComponentMixin = {
       );
     }
 
-    if (this._pendingState != null || this._pendingForceUpdate) {
+    if (this._pendingStateQueue !== null || this._pendingForceUpdate) {
       if (__DEV__) {
         ReactElementValidator.checkAndWarnForMutatedProps(
           this._currentElement
@@ -551,10 +553,8 @@ var ReactCompositeComponentMixin = {
   ) {
     var inst = this._instance;
 
-    var prevContext = inst.context;
-    var prevProps = inst.props;
-    var nextContext = prevContext;
-    var nextProps = prevProps;
+    var nextContext = inst.context;
+    var nextProps = inst.props;
 
     // Distinguish between a props update versus a simple state update
     if (prevParentElement !== nextParentElement) {
@@ -568,7 +568,7 @@ var ReactCompositeComponentMixin = {
       }
 
       // An update here will schedule an update but immediately set
-      // _pendingState which will ensure that any state updates gets
+      // _pendingStateQueue which will ensure that any state updates gets
       // immediately reconciled instead of waiting for the next batch.
 
       if (inst.componentWillReceiveProps) {
@@ -576,8 +576,7 @@ var ReactCompositeComponentMixin = {
       }
     }
 
-    var nextState = this._pendingState || inst.state;
-    this._pendingState = null;
+    var nextState = this._processPendingState(nextProps, nextContext);
 
     var shouldUpdate =
       this._pendingForceUpdate ||
@@ -614,6 +613,31 @@ var ReactCompositeComponentMixin = {
       inst.state = nextState;
       inst.context = nextContext;
     }
+  },
+
+  _processPendingState: function(props, context) {
+    var inst = this._instance;
+    var queue = this._pendingStateQueue;
+    var replace = this._pendingReplaceState;
+    this._pendingReplaceState = false;
+    this._pendingStateQueue = null;
+
+    if (!queue) {
+      return inst.state;
+    }
+
+    var nextState = assign({}, replace ? queue[0] : inst.state);
+    for (var i = replace ? 1 : 0; i < queue.length; i++) {
+      var partial = queue[i];
+      assign(
+        nextState,
+        typeof partial === 'function' ?
+          partial.call(inst, nextState, props, context) :
+          partial
+      );
+    }
+
+    return nextState;
   },
 
   /**

--- a/src/core/ReactUpdateQueue.js
+++ b/src/core/ReactUpdateQueue.js
@@ -154,7 +154,8 @@ var ReactUpdateQueue = {
       'replaceState'
     );
 
-    internalInstance._pendingState = completeState;
+    internalInstance._pendingStateQueue = [completeState];
+    internalInstance._pendingReplaceState = true;
 
     enqueueUpdate(internalInstance);
   },
@@ -175,12 +176,10 @@ var ReactUpdateQueue = {
       'setState'
     );
 
-    // Merge with `_pendingState` if it exists, otherwise with existing state.
-    internalInstance._pendingState = assign(
-      {},
-      internalInstance._pendingState || internalInstance._instance.state,
-      partialState
-    );
+    var queue =
+      internalInstance._pendingStateQueue ||
+      (internalInstance._pendingStateQueue = []);
+    queue.push(partialState);
 
     enqueueUpdate(internalInstance);
   },

--- a/src/core/__tests__/ReactCompositeComponentNestedState-test.js
+++ b/src/core/__tests__/ReactCompositeComponentNestedState-test.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2013-2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var mocks = require('mocks');
+
+var React;
+var ReactTestUtils;
+
+describe('ReactCompositeComponentNestedState-state', function() {
+
+  beforeEach(function() {
+    React = require('React');
+    ReactTestUtils = require('ReactTestUtils');
+  });
+
+  it('should provide up to date values for props', function() {
+    var ParentComponent = React.createClass({
+      getInitialState: function() {
+        return { color: 'blue' };
+      },
+
+      handleColor: function(color) {
+        this.props.logger('parent-handleColor', this.state.color);
+        this.setState({ color: color }, function () {
+          this.props.logger('parent-after-setState', this.state.color);
+        });
+      },
+
+      render: function() {
+        this.props.logger('parent-render', this.state.color);
+        return <ChildComponent
+          logger={this.props.logger}
+          color={this.state.color}
+          onSelectColor={this.handleColor}
+        />;
+      }
+    });
+
+    var ChildComponent = React.createClass({
+      getInitialState: function() {
+        this.props.logger('getInitialState', this.props.color);
+        return { hue: 'dark ' + this.props.color };
+      },
+
+      handleHue: function(shade, color) {
+        this.props.logger('handleHue', this.state.hue, this.props.color);
+        this.props.onSelectColor(color);
+        this.setState(function (state, props) {
+          this.props.logger('setState-this', this.state.hue, this.props.color);
+          this.props.logger('setState-args', state.hue, props.color);
+          return { hue: shade + ' ' + props.color }
+        }, function () {
+          this.props.logger('after-setState', this.state.hue, this.props.color);
+        });
+      },
+
+      render: function() {
+        this.props.logger('render', this.state.hue, this.props.color);
+        return <div>
+          <button onClick={this.handleHue.bind(this, 'dark', 'blue')}>
+            Dark Blue
+          </button>
+          <button onClick={this.handleHue.bind(this, 'light', 'blue')}>
+            Light Blue
+          </button>
+          <button onClick={this.handleHue.bind(this, 'dark', 'green')}>
+            Dark Green
+          </button>
+          <button onClick={this.handleHue.bind(this, 'light', 'green')}>
+            Light Green
+          </button>
+        </div>
+      }
+    });
+
+    var container = document.createElement('div');
+    document.documentElement.appendChild(container);
+
+    var logger = mocks.getMockFunction();
+
+    var instance = React.render(
+      <ParentComponent logger={logger} />,
+      container
+    );
+
+    // click "light green"
+    ReactTestUtils.Simulate.click(
+      container.childNodes[0].childNodes[3]
+    );
+
+    expect(logger.mock.calls).toEqual([
+      [ 'parent-render', 'blue' ],
+      [ 'getInitialState', 'blue' ],
+      [ 'render', 'dark blue', 'blue' ],
+      [ 'handleHue', 'dark blue', 'blue' ],
+      [ 'parent-handleColor', 'blue' ],
+      [ 'parent-render', 'green' ],
+      [ 'setState-this', 'dark blue', 'blue' ],
+      [ 'setState-args', 'dark blue', 'green' ],
+      [ 'render', 'light green', 'green' ],
+      [ 'parent-after-setState', 'green' ],
+      [ 'after-setState', 'light green', 'green' ],
+    ]);
+  });
+});

--- a/src/modern/class/ReactComponent.js
+++ b/src/modern/class/ReactComponent.js
@@ -36,15 +36,26 @@ function ReactComponent(props, context) {
  * callback that will be executed when the call to setState is actually
  * completed.
  *
- * @param {object} partialState Next partial state to be merged with state.
+ * When a function is provided to setState, it will be called at some point in
+ * the future (not synchronously). It will be called with the up to date
+ * component arguments (state, props, context). These values can be different
+ * from this.* because your function may be called after receiveProps but before
+ * shouldComponentUpdate, and this new state, props, and context will not yet be
+ * assigned to this.
+ *
+ * @param {object|function} partialState Next partial state or function to
+ *        produce next partial state to be merged with current state.
  * @param {?function} callback Called after state is updated.
  * @final
  * @protected
  */
 ReactComponent.prototype.setState = function(partialState, callback) {
   invariant(
-    typeof partialState === 'object' || partialState == null,
-    'setState(...): takes an object of state variables to update.'
+    typeof partialState === 'object' ||
+    typeof partialState === 'function' ||
+    partialState == null,
+    'setState(...): takes an object of state variables to update or a ' +
+    'function which returns an object of state variables.'
   );
   if (__DEV__) {
     warning(


### PR DESCRIPTION
This diff enables setState to accept a function in addition to a state partial. If you provide a function, it will be called with the up-to-date `state, props, context` as arguments.

This enables some nicer syntax for complex setState patterns:

If setState is doing an increment and wants to guarantee atomicy, you need a function:

```
this.setState(state => ({ number: state.number + 1 }));
```

This atomicy is particularly important if setState is called multiple times in a single frame of execution as the result of complex user actions. It's a tricky bug to chase down and difficult to determine how to fix when you find it. The current pattern of reaching into _pendingState relies on an implementation detail.

In this example: props.doAction() may result in your ancestor re-rendering and providing you with new props or context. If setState is called directly with an object literal referencing `this.props` or `this.context`, it will use the *old* version of those values, not the new value. Using a function solves for this case:

```
this.props.doAction();
this.setState((state, props) => ({ number: state.number * props.multiplier }));
```