### PR TITLE
Put deprecation warning for classSet

### DIFF
--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -21,14 +21,12 @@ var ReactPropTypes;
 var ReactServerRendering;
 var ReactTestUtils;
 
-var cx;
 var reactComponentExpect;
 var mocks;
 
 describe('ReactCompositeComponent', function() {
 
   beforeEach(function() {
-    cx = require('cx');
     mocks = require('mocks');
 
     reactComponentExpect = require('reactComponentExpect');
@@ -66,7 +64,7 @@ describe('ReactCompositeComponent', function() {
         return this.refs.anch;
       },
       render: function() {
-        var className = cx({'anchorClass': this.props.anchorClassOn});
+        var className = this.props.anchorClassOn ? 'anchorClass' : '';
         return this.props.renderAnchor ?
           <a ref="anch" className={className}></a> :
           <b></b>;

--- a/src/vendor/stubs/cx.js
+++ b/src/vendor/stubs/cx.js
@@ -24,7 +24,22 @@
  * @param [string ...]  Variable list of classNames in the string case.
  * @return string       Renderable space-separated CSS className.
  */
+
+'use strict';
+var warning = require('warning');
+
+var warned = false;
+
 function cx(classNames) {
+  if (__DEV__) {
+    warning(
+      warned,
+      'React.addons.classSet will be deprecated in a future version. See ' +
+      'http://fb.me/react-addons-classset'
+    );
+    warned = true;
+  }
+
   if (typeof classNames == 'object') {
     return Object.keys(classNames).filter(function(className) {
       return classNames[className];


### PR DESCRIPTION
Fixes #2910

Also removes the one test that used the module.

@zpao Didn't use your `deprecated` module because the warning message format didn't fit. Doesn't really matter though.

Will update the docs too.