### PR TITLE
Never reuse dirty rendered markup when mounting

### DIFF
--- a/src/browser/ui/ReactMount.js
+++ b/src/browser/ui/ReactMount.js
@@ -465,18 +465,22 @@ var ReactMount = {
     }
 
     var reactRootElement = getReactRootElementInContainer(container);
-    var containerHasReactMarkup =
-      reactRootElement && ReactMount.isRenderedByReact(reactRootElement);
+    var containerHasReactMarkup = (
+      reactRootElement &&
+      !reactRootElement.nextSibling &&
+      ReactMount.isRenderedByReact(reactRootElement)
+    );
 
     if (__DEV__) {
-      if (!containerHasReactMarkup || reactRootElement.nextSibling) {
+      if (!prevComponent && reactRootElement && reactRootElement.nextSibling) {
         var rootElementSibling = reactRootElement;
         while (rootElementSibling) {
           if (ReactMount.isRenderedByReact(rootElementSibling)) {
             console.warn(
               'render(): Target node has markup rendered by React, but there ' +
-              'are unrelated nodes as well. This is most commonly caused by ' +
-              'white-space inserted around server-rendered markup.'
+              'are unrelated nodes as well. The markup rendered by React has ' +
+              'not been reused. This is most commonly caused by white-space ' +
+              'inserted around server-rendered markup.'
             );
             break;
           }

--- a/src/browser/ui/__tests__/ReactMount-test.js
+++ b/src/browser/ui/__tests__/ReactMount-test.js
@@ -134,6 +134,12 @@ describe('ReactMount', function() {
     console.warn = mocks.getMockFunction();
     ReactMount.render(<div />, container);
     expect(console.warn.mock.calls.length).toBe(1);
+
+    container.innerHTML = React.renderToString(<div />);
+
+    console.warn = mocks.getMockFunction();
+    ReactMount.render(<div />, container);
+    expect(console.warn.mock.calls.length).toBe(0);
   });
 
   it('should not warn if mounting into non-empty node', function() {
@@ -143,5 +149,32 @@ describe('ReactMount', function() {
     console.warn = mocks.getMockFunction();
     ReactMount.render(<div />, container);
     expect(console.warn.mock.calls.length).toBe(0);
+  });
+
+  it('should reuse if mounting into rendered markup', function() {
+    var container = document.createElement('container');
+    container.innerHTML = React.renderToString(<div />);
+
+    var renderedNode = container.firstChild;
+    ReactMount.render(<div />, container);
+    expect(container.firstChild).toBe(renderedNode);
+  });
+
+  it('should not reuse if mounting into dirty rendered markup', function() {
+    var container = document.createElement('container');
+    var renderedMarkup = React.renderToString(<div />);
+    var renderedNode;
+
+    container.innerHTML = renderedMarkup + ' ';
+
+    renderedNode = container.firstChild;
+    ReactMount.render(<div />, container);
+    expect(container.firstChild).not.toBe(renderedNode);
+
+    container.innerHTML = ' ' + renderedMarkup;
+
+    renderedNode = container.firstChild;
+    ReactMount.render(<div />, container);
+    expect(container.firstChild).not.toBe(renderedNode);
   });
 });


### PR DESCRIPTION
@zpao @sebmarkbage #1912 only emits a warning, it's still inconsistent the way we decide to reuse rendered markup, if the rendered markup is the first node then we do reuse, else we don't. I suggest we make it consistent and never reuse unless the rendered markup is alone.

**Note:** if approved, must not be merged before #1912 has been shipped in a release.