### PR TITLE
Changed unit to pixels due to inconsistent font-size rendering of code elements.

### DIFF
--- a/docs/css/react.scss
+++ b/docs/css/react.scss
@@ -7,7 +7,7 @@
 
 @mixin code-typography {
   font-family: 'source-code-pro', Menlo, Consolas, 'Courier New', monospace;
-  font-size: 0.8em;
+  font-size: 13px;
   line-height: 1.5;
 }
 


### PR DESCRIPTION
I have introduced a change because of inconsistency of how browsers render font size of a `<code>` element, as researched [here](http://galjot.si/element-code-and-font-size).