### PR TITLE
Add optional transitionCount prop allowing CSSTransitionGroup to wait for multiple transitions to finish before 

### DIFF
--- a/src/addons/transitions/ReactCSSTransitionGroup.js
+++ b/src/addons/transitions/ReactCSSTransitionGroup.js
@@ -30,14 +30,16 @@ var ReactCSSTransitionGroup = React.createClass({
     transitionName: React.PropTypes.string.isRequired,
     transitionAppear: React.PropTypes.bool,
     transitionEnter: React.PropTypes.bool,
-    transitionLeave: React.PropTypes.bool
+    transitionLeave: React.PropTypes.bool,
+    transitionCount: React.PropTypes.number
   },
 
   getDefaultProps: function() {
     return {
       transitionAppear: false,
       transitionEnter: true,
-      transitionLeave: true
+      transitionLeave: true,
+      transitionCount: 1
     };
   },
 
@@ -50,7 +52,8 @@ var ReactCSSTransitionGroup = React.createClass({
         name: this.props.transitionName,
         appear: this.props.transitionAppear,
         enter: this.props.transitionEnter,
-        leave: this.props.transitionLeave
+        leave: this.props.transitionLeave,
+        count: this.props.transitionCount
       },
       child
     );

--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -48,11 +48,14 @@ var ReactCSSTransitionGroupChild = React.createClass({
     var className = this.props.name + '-' + animationType;
     var activeClassName = className + '-active';
     var noEventTimeout = null;
+    var count = 0;
 
     var endListener = function(e) {
-      if (e && e.target !== node) {
+      count = count + 1;
+      if (count < this.props.count) {
         return;
       }
+
       if (__DEV__) {
         clearTimeout(noEventTimeout);
       }


### PR DESCRIPTION
In a few cases I have wanted to animate multiple child elements of a component independently.. for example I have a modal component where I would like the backdrop to fade in, at the same time as the body flies in with a transform.

```jsx
Modal = React.createComponent({
  render: function() {
    return (
      <div className="modal">
        <div className="modal-backdrop"/>
        <div className="modal-body">
          {this.props.children}
        </div>
      </div>
    );
  }
});
```

The current implementation detects transition end events, but only on the root dom element of a component.  A complex animation like the one I describe is possible, but requires an awkward workaround in the css.  Here I have set a transition on background color on the root element, animating between two different colors w/ alpha 0.. this animation ends up working as a timer to trigger the end of the animation in CSSTransitionGroupChild.

```css
.modal-enter {
  background-color: rgba(0,0,0,0);
  transition: background-color 0.5s;
}
  .modal-enter .modal-backdrop {
    opacity: 0;
    transition: opacity 0.5s;
  }
  .modal-enter .modal-body {
    opacity: 0;
    transition: transform 0.3s, opacity 0.3s;
    transform: scale(1.5);
  }
.modal-enter.modal-enter-active {
  background-color: rgba(1,0,0,0);
}
  .modal-enter.modal-enter-active .modal-backdrop {
    opacity: 0.65;
  }
  .modal-enter.modal-enter-active .modal-body {
    opacity: 1;
    transform: scale(1);
  }
```

I think a better approach may be just to allow the number of transitions to be specified, allow the events to bubble normally from children to the ReactCSSTransitionGroupChild element, and to only remove the component after the expected number of transitions have ended.

This pull adds an optional transitionCount prop to ReactCSSTransitionGroup, defaulting to 1.  It would preserve the current behavior in most cases, although it would revert changes to transitionend event bubbling behavior made in v0.12.2 and could break code written to depend on those changes.

```jsx
<ReactCSSTransitionGroup transitionName='modal' transitionCount={2}>
```

I opened this as a starting point for discussion, and have not written tests or ran the build scripts on it yet - If this is something that you could be convinced to accept, I will gladly get the pull in better shape to merge.