### PR TITLE
Added jsx_orphaned_brackets_transformer for breaking JSX parser change

### DIFF
--- a/npm-jsx_orphaned_brackets_transformer/.gitignore
+++ b/npm-jsx_orphaned_brackets_transformer/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/npm-jsx_orphaned_brackets_transformer/README.md
+++ b/npm-jsx_orphaned_brackets_transformer/README.md
@@ -1,0 +1,31 @@
+# JSX Orphaned Brackets Transformer
+
+React 0.13 no longer parses orphaned > and } as text.
+
+Take this example block:
+
+```js
+<div>
+  > }
+</div>
+```
+
+In 0.12 and below, this would be transformed to the following:
+
+```js
+React.DOM.div(null,
+  "> }",
+)
+```
+
+In 0.13, this will instead throw a parser error.
+
+
+## Usage
+
+The `jsx_orphaned_brackets_transformer` module ships an executable which transforms a file or directory of files. Files will be modified in place, so be sure you are prepared for that.
+
+```sh
+$ npm -g install jsx_orphaned_brackets_transformer
+$ jsx_orphaned_brackets_transformer <path_to_file_or_files>
+```

--- a/npm-jsx_orphaned_brackets_transformer/package.json
+++ b/npm-jsx_orphaned_brackets_transformer/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "jsx_orphaned_brackets_transformer",
+  "description": "A utility to update your JSX to work with React 0.13.",
+  "version": "1.0.0",
+  "main": "run.js",
+  "dependencies": {
+    "esprima-fb": "10001.1.0-dev-harmony-fb",
+    "graceful-fs": "~2.0.0",
+    "jstransform": "~2.0.1",
+    "node-find-files": "0.0.2",
+    "optimist": "~0.6.0"
+  },
+  "bin": {
+    "jsx_orphaned_brackets_transformer": "./run.js"
+  },
+  "license": "Apache-2.0",
+  "preferGlobal": true
+}

--- a/npm-jsx_orphaned_brackets_transformer/run.js
+++ b/npm-jsx_orphaned_brackets_transformer/run.js
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+var esprima = require('esprima-fb');
+var FileFinder = require('node-find-files');
+var fs = require('graceful-fs');
+var jstransform = require('jstransform');
+var path = require('path');
+var visitReactTag = require('./transforms/react').visitReactTag;
+
+var S = esprima.Syntax;
+
+var USAGE =
+  'Read a file (or directory of files) from disk, transform any orphaned ' +
+  '} and > characters to avoid parser errors with React 0.13.';
+
+function _visitFbt(node, path, state) {
+  return false;
+}
+_visitFbt.test = function(node, path, state) {
+  return node.type === S.XJSElement
+         && node.openingElement.name.name === 'fbt';
+};
+
+var VISITORS_LIST = [
+  _visitFbt,
+  visitReactTag
+];
+
+function _transformSource(source) {
+  return jstransform.transform(VISITORS_LIST, source).code;
+}
+
+function transformDir(dirPath, exclude) {
+  var finder = new FileFinder({
+    rootFolder: dirPath,
+    filterFunction: function(path, stat) {
+      return /\.jsx?$/.test(path) && (!exclude || !exclude.test(path));
+    }
+  });
+
+  var numTransforms = 0;
+  var completeTransforms = 0;
+  var findingComplete = false;
+  function _printProgress() {
+    process.stdout.clearLine();
+    process.stdout.cursorTo(0);
+    process.stdout.write(
+      completeTransforms + '/' + numTransforms + ' transforms complete'
+    );
+
+    if (findingComplete && completeTransforms === numTransforms) {
+      console.log('\ndone!');
+    }
+  }
+
+  finder.on('match', function(pathStr, stat) {
+    fs.readFile(pathStr, 'utf8', function(err, data) {
+      if (err) {
+        err.message = err.message + ' (' + pathStr + ')';
+        throw err;
+      }
+
+      numTransforms++;
+      _printProgress();
+
+      var transformedData;
+      try {
+        transformedData = _transformSource(data);
+      } catch (e) {
+        e.message = e.message + ' (' + pathStr + ')';
+        throw e;
+      }
+
+      if (transformedData !== data) {
+        fs.writeFile(pathStr, transformedData, function(err) {
+          if (err) {
+            err.message = err.message + ' (' + pathStr + ')';
+            throw err;
+          }
+          completeTransforms++;
+          _printProgress();
+        });
+      } else {
+        completeTransforms++;
+        _printProgress();
+      }
+    });
+  });
+
+  finder.on('error', function(err) {
+    console.log('\nError: ', err.stack);
+    throw err;
+  });
+
+  finder.on('complete', function() {
+    findingComplete = true;
+  });
+
+  finder.startSearch();
+}
+
+function transformFile(pathStr) {
+  fs.readFile(pathStr, 'utf8', function(err, data) {
+    if (err) {
+      err.message = err.message + ' (' + pathStr + ')';
+      throw err;
+    }
+
+    var transformedData;
+    try {
+      transformedData = _transformSource(data);
+    } catch (e) {
+      e.message = e.message + ' (' + pathStr + ')';
+      throw e;
+    }
+
+    if (transformedData !== data) {
+      fs.writeFile(pathStr, transformedData, function(err) {
+        if (err) {
+          err.message = err.message + ' (' + pathStr + ')';
+          throw err;
+        }
+        console.log('done!');
+      });
+    } else {
+      console.log('done!');
+    }
+  });
+}
+
+if (require.main === module) {
+  var argv = require('optimist')
+    .usage(USAGE)
+    .argv;
+
+  if (argv._.length === 0) {
+    throw new Error(
+      'Please specify a file or directory path as the first arg!'
+    );
+  }
+
+  argv._.forEach(function(arg) {
+    var absPath = path.resolve(arg);
+
+    fs.stat(absPath, function(err, stat) {
+      if (err) throw err;
+
+      if (stat.isFile()) {
+        transformFile(absPath);
+      } else if (stat.isDirectory()) {
+        var exclude = null;
+        if (argv.exclude) {
+          exclude = new RegExp(argv.exclude);
+        }
+        transformDir(absPath, exclude);
+      } else {
+        throw new Error('Unknown filesystem node type: ' + absPath);
+      }
+    });
+  });
+}
+
+exports.transformDir = transformDir;

--- a/npm-jsx_orphaned_brackets_transformer/transforms/react.js
+++ b/npm-jsx_orphaned_brackets_transformer/transforms/react.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2013-2014 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*global exports:true*/
+"use strict";
+var Syntax = require('esprima-fb').Syntax;
+var utils = require('jstransform/src/utils');
+
+function visitReactTag(traverse, object, path, state) {
+  object.attributes.forEach(function(attr, index) {
+    if (attr.value) {
+      traverse(attr.value, path, state);
+    }
+  });
+
+  object.children.forEach(function(child, index) {
+    if (child.type === Syntax.Literal) {
+      codemodXJSLiteral(child, state);
+    } else {
+      traverse(child, path, state);
+    }
+  });
+
+  return false;
+}
+
+visitReactTag.test = function(object, path, state) {
+  return object.type === Syntax.XJSElement;
+};
+
+function codemodXJSLiteral(object, state) {
+  var value = object.raw;
+
+  utils.catchup(object.range[0], state);
+
+  var rightCurlyBracket = '&#125;'; // or {'}'}
+  var rightAngledBracket = '&gt;'; // or {'>'}
+
+  value = value.replace(/\}/g, rightCurlyBracket);
+  value = value.replace(/\>/g, rightAngledBracket);
+
+  utils.append(value, state);
+  utils.move(object.range[1], state);
+}
+
+exports.visitReactTag = visitReactTag;


### PR DESCRIPTION
Codemod for https://github.com/facebook/esprima/pull/36

Feel free to suggest/request better naming or descriptions, this is largely the same as the whitespace-codemod with just a few tweaks.

```
<a value={<a> > } </a>}>
  > }
  {<a> > } </a>}
</a>
```

...yields...

```
<a value={<a> &gt; &#125; </a>}>
  &gt; &#125;
  {<a> &gt; &#125; </a>}
</a>
```

...or... (if you modify the transformer)

```
<a value={<a> {'>'} {'}'} </a>}>
  {'>'} {'}'}
  {<a> {'>'} {'}'} </a>}
</a>
```

...but that affects output so it cannot be default behavior.

cc @jeffmo @gabelevi