### PR TITLE
Always trigger an update when a callback is enqueued.

### DIFF
--- a/src/core/ReactUpdateQueue.js
+++ b/src/core/ReactUpdateQueue.js
@@ -111,6 +111,7 @@ var ReactUpdateQueue = {
     } else {
       internalInstance._pendingCallbacks = [callback];
     }
+    enqueueUpdate(internalInstance);
   },
 
   /**

--- a/src/core/__tests__/ReactComponent-test.js
+++ b/src/core/__tests__/ReactComponent-test.js
@@ -15,10 +15,12 @@ var React;
 var ReactInstanceMap;
 var ReactTestUtils;
 
+var mocks;
 var reactComponentExpect;
 
 describe('ReactComponent', function() {
   beforeEach(function() {
+    mocks = require('mocks');
     React = require('React');
     ReactInstanceMap = require('ReactInstanceMap');
     ReactTestUtils = require('ReactTestUtils');
@@ -270,4 +272,16 @@ describe('ReactComponent', function() {
     var instance = ReactTestUtils.renderIntoDocument(element);
     expect(instance.isMounted()).toBeTruthy();
   });
+
+  it('fires the callback after a component is rendered', function() {
+    var callback = mocks.getMockFunction();
+    var container = document.createElement('div');
+    React.render(<div />, container, callback);
+    expect(callback.mock.calls.length).toBe(1);
+    React.render(<div className="foo" />, container, callback);
+    expect(callback.mock.calls.length).toBe(2);
+    React.render(<span />, container, callback);
+    expect(callback.mock.calls.length).toBe(3);
+  });
+
 });


### PR DESCRIPTION
enqueueCallbackInternal forgot to schedule an update.

We could rely on the implicit contract of enqueueElement to do it. However,
if we're currently outside a transaction, it'll flush synchronously. Before
we enqueue the callback. We could also enqueueCallback before we
enqueueElement, but that causes a fragile relationship between them. E.g.
enqueueElement should not need to schedule an update if it is the same
element.