### PR TITLE
Fix list formatting in glossary

### DIFF
--- a/docs/docs/ref-09-glossary.md
+++ b/docs/docs/ref-09-glossary.md
@@ -76,6 +76,7 @@ If you are using JSX you have no need for factories. JSX already provides a conv
 ## React Nodes
 
 A `ReactNode` can be either:
+
 - `ReactElement`
 - `string` (aka `ReactText`)
 - `number` (aka `ReactText`)


### PR DESCRIPTION
A missing newline was causing the markdown list to not render correctly.