### PR TITLE
Fix isMounted inside of render

### DIFF
--- a/src/core/__tests__/ReactComponent-test.js
+++ b/src/core/__tests__/ReactComponent-test.js
@@ -263,6 +263,7 @@ describe('ReactComponent', function() {
         expect(this.isMounted()).toBeTruthy();
       },
       render: function() {
+        expect(this.isMounted()).toBeFalsy()
         return <div/>;
       }
     });

--- a/src/core/__tests__/ReactComponentLifeCycle-test.js
+++ b/src/core/__tests__/ReactComponentLifeCycle-test.js
@@ -260,6 +260,18 @@ describe('ReactComponentLifeCycle', function() {
     );
   });
 
+  it('is not mounted inside initial render', function() {
+    var InitialRender = React.createClass({
+      render: function() {
+        expect(this.isMounted()).toBe(false);
+        return (
+          <div></div>
+        );
+      }
+    });
+    ReactTestUtils.renderIntoDocument(<InitialRender />);
+  });
+
   it('should carry through each of the phases of setup', function() {
     var LifeCycleComponent = React.createClass({
       getInitialState: function() {
@@ -360,7 +372,7 @@ describe('ReactComponentLifeCycle', function() {
       ComponentLifeCycle.MOUNTED
     );
     expect(instance._testJournal.compositeLifeCycleInInitialRender).toBe(
-      null
+      CompositeComponentLifeCycle.MOUNTING
     );
 
     expect(getLifeCycleState(instance)).toBe(ComponentLifeCycle.MOUNTED);


### PR DESCRIPTION
This is apparently used to determine if you can access refs.

Bad pattern, but a pattern nonetheless.