### PR TITLE
escapeTextContentForBrowser does not need to escape single-quote (')

### DIFF
--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -443,8 +443,8 @@ describe('ReactDOMComponent', function() {
           }, '\'"<>&')
         )
       ).toBe(
-        '<div title="&#x27;&quot;&lt;&gt;&amp;" style="text-align:&#x27;&quot;&lt;&gt;&amp;;">' +
-          '&#x27;&quot;&lt;&gt;&amp;' +
+        '<div title="\'&quot;&lt;&gt;&amp;" style="text-align:\'&quot;&lt;&gt;&amp;;">' +
+          '\'&quot;&lt;&gt;&amp;' +
         '</div>'
       );
     });

--- a/src/utils/__tests__/escapeTextContentForBrowser-test.js
+++ b/src/utils/__tests__/escapeTextContentForBrowser-test.js
@@ -35,10 +35,9 @@ describe('escapeTextContentForBrowser', function() {
   });
 
   it('should escape string', function() {
-    var escaped = escapeTextContentForBrowser('<script type=\'\' src=""></script>');
+    var escaped = escapeTextContentForBrowser('<script src=""></script>');
     expect(escaped).not.toContain('<');
     expect(escaped).not.toContain('>');
-    expect(escaped).not.toContain('\'');
     expect(escaped).not.toContain('\"');
 
     escaped = escapeTextContentForBrowser('&');

--- a/src/utils/__tests__/quoteAttributeValueForBrowser-test.js
+++ b/src/utils/__tests__/quoteAttributeValueForBrowser-test.js
@@ -35,10 +35,9 @@ describe('quoteAttributeValueForBrowser', function() {
   });
 
   it('should escape string', function() {
-    var escaped = quoteAttributeValueForBrowser('<script type=\'\' src=""></script>');
+    var escaped = quoteAttributeValueForBrowser('<script src=""></script>');
     expect(escaped).not.toContain('<');
     expect(escaped).not.toContain('>');
-    expect(escaped).not.toContain('\'');
     expect(escaped.substr(1, -1)).not.toContain('\"');
 
     escaped = quoteAttributeValueForBrowser('&');

--- a/src/utils/escapeTextContentForBrowser.js
+++ b/src/utils/escapeTextContentForBrowser.js
@@ -15,11 +15,10 @@ var ESCAPE_LOOKUP = {
   '&': '&amp;',
   '>': '&gt;',
   '<': '&lt;',
-  '"': '&quot;',
-  '\'': '&#x27;'
+  '"': '&quot;'
 };
 
-var ESCAPE_REGEX = /[&><"']/g;
+var ESCAPE_REGEX = /[&><"]/g;
 
 function escaper(match) {
   return ESCAPE_LOOKUP[match];


### PR DESCRIPTION
OWASP says `Properly quoted attributes can only be escaped with the corresponding quote.`.
We only ever use `"` for quoting attribute values, hence escaping `'` is unnecessary (as evidenced below).

cc @yungsters 

----

Semi-proof:
```JS
document.body.innerHTML = '<div></div>';
document.body.firstChild.textContent = '<>\'"&/';
document.body.firstChild.style.content = '\'<>\\\'"&/\'';
document.body.firstChild.setAttribute('test', '<>\'"&/');
document.body.innerHTML;
```
...yields...
```HTML
<div
  test="<>'&quot;&amp;/"
  style="content: '<>\'&quot;&amp;/';">
  &lt;&gt;'"&amp;/
</div>
```