### PR TITLE
Fixed pure-render-mixin documentation

### DIFF
--- a/docs/docs/10.7-pure-render-mixin.md
+++ b/docs/docs/10.7-pure-render-mixin.md
@@ -11,7 +11,7 @@ If your React component's render function is "pure" (in other words, it renders 
 Example:
 
 ```js
-var PureRenderMixin = require('react').addons.PureRenderMixin;
+var PureRenderMixin = require('react/addons').addons.PureRenderMixin;
 React.createClass({
   mixins: [PureRenderMixin],
 


### PR DESCRIPTION
Fixed the PureRenderMixin documentation which was incorrectly importing the base React library instead of ReactWithAddons.