### PR TITLE
[update] Replace instances of createFactory with createElement.

### DIFF
--- a/src/browser/ui/dom/components/ReactDOMButton.js
+++ b/src/browser/ui/dom/components/ReactDOMButton.js
@@ -18,8 +18,6 @@ var ReactElement = require('ReactElement');
 
 var keyMirror = require('keyMirror');
 
-var button = ReactElement.createFactory('button');
-
 var mouseListenerNames = keyMirror({
   onClick: true,
   onDoubleClick: true,
@@ -54,7 +52,7 @@ var ReactDOMButton = ReactClass.createClass({
       }
     }
 
-    return button(props, this.props.children);
+    return ReactElement.createElement('button', props, this.props.children);
   }
 
 });

--- a/src/browser/ui/dom/components/ReactDOMForm.js
+++ b/src/browser/ui/dom/components/ReactDOMForm.js
@@ -17,8 +17,6 @@ var ReactBrowserComponentMixin = require('ReactBrowserComponentMixin');
 var ReactClass = require('ReactClass');
 var ReactElement = require('ReactElement');
 
-var form = ReactElement.createFactory('form');
-
 /**
  * Since onSubmit doesn't bubble OR capture on the top level in IE8, we need
  * to capture it on the <form> element itself. There are lots of hacks we could
@@ -32,10 +30,10 @@ var ReactDOMForm = ReactClass.createClass({
   mixins: [ReactBrowserComponentMixin, LocalEventTrapMixin],
 
   render: function() {
-    // TODO: Instead of using `ReactDOM` directly, we should use JSX. However,
+    // TODO: Instead of using `createElement` directly, we should use JSX. However,
     // `jshint` fails to parse JSX so in order for linting to work in the open
     // source repo, we need to just use `ReactDOM.form`.
-    return form(this.props);
+    return ReactElement.createElement('form', this.props);
   },
 
   componentDidMount: function() {

--- a/src/browser/ui/dom/components/ReactDOMImg.js
+++ b/src/browser/ui/dom/components/ReactDOMImg.js
@@ -17,8 +17,6 @@ var ReactBrowserComponentMixin = require('ReactBrowserComponentMixin');
 var ReactClass = require('ReactClass');
 var ReactElement = require('ReactElement');
 
-var img = ReactElement.createFactory('img');
-
 /**
  * Since onLoad doesn't bubble OR capture on the top level in IE8, we need to
  * capture it on the <img> element itself. There are lots of hacks we could do
@@ -32,7 +30,7 @@ var ReactDOMImg = ReactClass.createClass({
   mixins: [ReactBrowserComponentMixin, LocalEventTrapMixin],
 
   render: function() {
-    return img(this.props);
+    return ReactElement.createElement('img', this.props);
   },
 
   componentDidMount: function() {

--- a/src/browser/ui/dom/components/ReactDOMInput.js
+++ b/src/browser/ui/dom/components/ReactDOMInput.js
@@ -23,8 +23,6 @@ var ReactUpdates = require('ReactUpdates');
 var assign = require('Object.assign');
 var invariant = require('invariant');
 
-var input = ReactElement.createFactory('input');
-
 var instancesByReactID = {};
 
 function forceUpdateIfMounted() {
@@ -79,7 +77,7 @@ var ReactDOMInput = ReactClass.createClass({
 
     props.onChange = this._handleChange;
 
-    return input(props, this.props.children);
+    return ReactElement.createElement('input', props, this.props.children);
   },
 
   componentDidMount: function() {

--- a/src/browser/ui/dom/components/ReactDOMOption.js
+++ b/src/browser/ui/dom/components/ReactDOMOption.js
@@ -17,8 +17,6 @@ var ReactElement = require('ReactElement');
 
 var warning = require('warning');
 
-var option = ReactElement.createFactory('option');
-
 /**
  * Implements an <option> native component that warns when `selected` is set.
  */
@@ -40,7 +38,7 @@ var ReactDOMOption = ReactClass.createClass({
   },
 
   render: function() {
-    return option(this.props, this.props.children);
+    return ReactElement.createElement('option', this.props, this.props.children);
   }
 
 });

--- a/src/browser/ui/dom/components/ReactDOMSelect.js
+++ b/src/browser/ui/dom/components/ReactDOMSelect.js
@@ -20,8 +20,6 @@ var ReactUpdates = require('ReactUpdates');
 
 var assign = require('Object.assign');
 
-var select = ReactElement.createFactory('select');
-
 function updateOptionsIfPendingUpdateAndMounted() {
   /*jshint validthis:true */
   if (this._pendingUpdate) {
@@ -125,7 +123,7 @@ var ReactDOMSelect = ReactClass.createClass({
     props.onChange = this._handleChange;
     props.value = null;
 
-    return select(props, this.props.children);
+    return ReactElement.createElement(props, this.props.children);
   },
 
   componentWillMount: function() {

--- a/src/browser/ui/dom/components/ReactDOMTextarea.js
+++ b/src/browser/ui/dom/components/ReactDOMTextarea.js
@@ -24,8 +24,6 @@ var invariant = require('invariant');
 
 var warning = require('warning');
 
-var textarea = ReactElement.createFactory('textarea');
-
 function forceUpdateIfMounted() {
   /*jshint validthis:true */
   if (this.isMounted()) {
@@ -108,7 +106,7 @@ var ReactDOMTextarea = ReactClass.createClass({
 
     // Always set children to the same thing. In IE9, the selection range will
     // get reset if `textContent` is mutated.
-    return textarea(props, this.state.initialValue);
+    return ReactElement.createElement('textarea', props, this.state.initialValue);
   },
 
   componentDidUpdate: function(prevProps, prevState, prevContext) {


### PR DESCRIPTION
This feels sort of arbitrary, but I noticed [the TODO on ReactDOMForm](https://github.com/facebook/react/blob/master/src/browser/ui/dom/components/ReactDOMForm.js#L35) when reading the source and thought this might be at least a step forward.

In terms of `jsx` support for `jshint`, this is sort of a funny issue. It seems like all of the `jsx` enabled variants of `jshint` rely on react-tools. Inevitably, this means that `npm` will not install react-tools as a dependency of react-tools.