### PR TITLE
Fix markdown parsing error

### DIFF
--- a/docs/docs/10.5-clone-with-props.md
+++ b/docs/docs/10.5-clone-with-props.md
@@ -15,7 +15,9 @@ Do a shallow copy of `component` and merge any props provided by `extraProps`. T
 > Note:
 >
 > `cloneWithProps` does not transfer `key` to the cloned component. If you wish to preserve the key, add it to the `extraProps` object:
+>
 > ```js
 > var clonedComponent = cloneWithProps(originalComponent, { key : originalComponent.key });
 > ```
+>
 > `ref` is similarly not preserved.


### PR DESCRIPTION
(From https://github.com/facebook/react/issues/3075)

The documentation pages parse markdown differently compared to GitHub and [one code sample][1] appears wrong.  This PR is just a hunch that a couple of blank lines will make it display correctly.

[1]: http://facebook.github.io/react/docs/clone-with-props.html