### PR TITLE
Added support for shared mixins

### DIFF
--- a/src/classic/class/ReactClass.js
+++ b/src/classic/class/ReactClass.js
@@ -472,6 +472,13 @@ function mixSpecIntoComponent(Constructor, spec) {
       continue;
     }
 
+    if (spec[name] === proto[name]) {
+      // If the spec property and the proto property is the same, continue
+      // This case is useful when one common mixin is shared among other
+      // mixins used at the same time.
+      continue;
+    }
+
     var property = spec[name];
     validateMethodOverride(proto, name);
 


### PR DESCRIPTION
There is a case scenario where two or more *mixins* (**A**, **B**) share a common *mixin* (**C**).

Right now is impossible to use the *mixins* **A** and **B** at the same time in a *React Class* (as will try to override the method, and triggers the invariant exception automatically).

This pull request add the ability to do it in a very simple and effective way.