### PR TITLE
Warn when calling setState & other methods at wrong time

### DIFF
--- a/src/core/__tests__/ReactComponentLifeCycle-test.js
+++ b/src/core/__tests__/ReactComponentLifeCycle-test.js
@@ -239,6 +239,7 @@ describe('ReactComponentLifeCycle', function() {
   });
 
   it('should not allow update state inside of getInitialState', function() {
+    spyOn(console, 'warn');
     var StatefulComponent = React.createClass({
       getInitialState: function() {
         this.setState({stateField: 'something'});
@@ -251,12 +252,12 @@ describe('ReactComponentLifeCycle', function() {
         );
       }
     });
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(<StatefulComponent />);
-    }).toThrow(
-      'Invariant Violation: setState(...): Can only update a mounted or ' +
+    ReactTestUtils.renderIntoDocument(<StatefulComponent />);
+    expect(console.warn.calls.length).toBe(1);
+    expect(console.warn.argsForCall[0][0]).toBe(
+      'Warning: setState(...): Can only update a mounted or ' +
       'mounting component. This usually means you called setState() on an ' +
-      'unmounted component.'
+      'unmounted component. This is a no-op.'
     );
   });
 


### PR DESCRIPTION
Currently we use an invariant to prevent this code pattern. That is really
aggressive for something that doesn't actually put React in a bad state. This
diff replaces invariants with warnings and makes those code paths no-ops.

cc @sebmarkbage 