### PR TITLE
Warn if a non-object value is used in ReactFragment.create

### DIFF
--- a/src/addons/ReactFragment.js
+++ b/src/addons/ReactFragment.js
@@ -96,6 +96,14 @@ var ReactFragment = {
   // of its properties.
   create: function(object) {
     if (__DEV__) {
+      if (typeof object !== 'object' || !object) {
+        warning(
+          false,
+          'React.addons.createFragment only accepts a single object. Not %s',
+          object
+        );
+        return object;
+      }
       if (canWarnForReactFragment) {
         var proxy = {};
         Object.defineProperty(proxy, fragmentKey, {

--- a/src/addons/__tests__/ReactFragment-test.js
+++ b/src/addons/__tests__/ReactFragment-test.js
@@ -73,4 +73,13 @@ describe('ReactFragment', function() {
     );
   });
 
+  it('should warn if accessing any property on a fragment', function() {
+    spyOn(console, 'warn');
+    ReactFragment.create(null);
+    expect(console.warn.calls.length).toBe(1);
+    expect(console.warn.calls[0].args[0]).toContain(
+      'React.addons.createFragment only accepts a single object. Not null'
+    );
+  });
+
 });


### PR DESCRIPTION
I made this mistake while upgrading a few callers.

I'm leaving this as warning so that it is always safe to wrap any existing
child in React.addons.createFragment without breaking prod.

This makes upgrading easier.