### PR TITLE
Replace jsx extensions with js in react visitor

### DIFF
--- a/vendor/fbtransform/transforms/__tests__/react-test.js
+++ b/vendor/fbtransform/transforms/__tests__/react-test.js
@@ -377,4 +377,11 @@ describe('react jsx', function() {
     ).toBeCalledWith({x: "1"}, { y: 2 }, {z: 3});
   });
 
+  it('replace any jsx extensions with js', function() {
+    var code = 'var foo = require("file.jsx");';
+    var result = 'var foo = require("file.js");';
+
+    expect(transform(code).code).toBe(result);
+  });
+
 });

--- a/vendor/fbtransform/transforms/react.js
+++ b/vendor/fbtransform/transforms/react.js
@@ -43,6 +43,20 @@ function isTagName(name) {
   return tagConvention.test(name);
 }
 
+function visitReactDeps(traverse, node, path, state) {
+  var nodeSrcText = utils.getNodeSourceText(node, state);
+  if (nodeSrcText.indexOf('.jsx') > 0) {
+    utils.append(nodeSrcText.replace('.jsx', '.js'), state);
+    utils.move(node.range[1], state);
+  }
+}
+visitReactDeps.test = function(node, path, state) {
+  return node.type === Syntax.CallExpression && 
+          node.callee && 
+          node.callee.type === Syntax.Identifier && 
+          node.callee.name === 'require';
+};
+
 function visitReactTag(traverse, object, path, state) {
   var openingElement = object.openingElement;
   var nameObject = openingElement.name;
@@ -238,5 +252,6 @@ visitReactTag.test = function(object, path, state) {
 };
 
 exports.visitorList = [
-  visitReactTag
+  visitReactTag,
+  visitReactDeps
 ];


### PR DESCRIPTION
Disclaimer: I am very new to React and I am not sure if this is right solution but it works for my use case. I ran into a problem with my compiled jsx files where even though they were transformed to JS they still reference component dependencies with the JSX extension.  I am adding a new react visitor to replace any `require("foo.jsx")` with `require("foo.js")`.