### PR TITLE
Added test to quote 'for' attribute on labels

### DIFF
--- a/vendor/fbtransform/transforms/xjs.js
+++ b/vendor/fbtransform/transforms/xjs.js
@@ -95,7 +95,7 @@ function renderXJSExpressionContainer(traverse, object, isLast, path, state) {
 
 function quoteAttrName(attr) {
   // Quote invalid JS identifiers.
-  if (!/^[a-z_$][a-z\d_$]*$/i.test(attr)) {
+  if (!/^[a-z_$][a-z\d_$]*$/i.test(attr) || /^for$/i.test(attr)) {
     return '"' + attr + '"';
   }
   return attr;


### PR DESCRIPTION
As 'for' is a reserved word it causes an error in IE8, so I've added an additional regex to check for it. I thought the regex can be easily extended if other specific attirbutes are found that need quoting