### PR TITLE
Put comma after any non-whitespace non-comment characters in XJSExpression

### DIFF
--- a/vendor/fbtransform/transforms/__tests__/react-test.js
+++ b/vendor/fbtransform/transforms/__tests__/react-test.js
@@ -325,13 +325,13 @@ describe('react jsx', function() {
   });
 
   it('handles overparenthesized JS', function() {
-      var code = 
-        '<foo a={(b)} c={(d)}>Foo {(e+f/* */)\n' +
-        '} bar\n' +
-        '</foo>';
-      var result = 'React.createElement("foo", {a: (b), c: (d)}, "Foo ",(e+f/* */), \n' +
-          '" bar"\n' +
-          ')';
+    var code =
+    '<foo a={(b)} c={(d)}>Foo {(e+f/* */)\n' +
+      '} bar\n' +
+    '</foo>';
+    var result = 'React.createElement("foo", {a: (b), c: (d)}, "Foo ",(e+f/* */), \n' +
+    '" bar"\n' +
+    ')';
     expect(transform(code).code).toBe(result);
   });
 

--- a/vendor/fbtransform/transforms/__tests__/react-test.js
+++ b/vendor/fbtransform/transforms/__tests__/react-test.js
@@ -330,7 +330,7 @@ describe('react jsx', function() {
         '/* A multiline comment */)\n' +
       '} bar\n' +
     '</foo>';
-    var result = 'React.createElement("foo", {a: (b), c: (d)}, "Foo ",(e+f //A line comment\n' +
+    var result = 'React.createElement("foo", {a: (b), c: (d)}, "Foo ", (e+f //A line comment\n' +
             '/* A multiline comment */), \n' +
     '" bar"\n' +
     ')';

--- a/vendor/fbtransform/transforms/__tests__/react-test.js
+++ b/vendor/fbtransform/transforms/__tests__/react-test.js
@@ -324,6 +324,17 @@ describe('react jsx', function() {
     expect(transform(code).code).toBe(result);
   });
 
+  it('handles overparenthesized JS', function() {
+      var code = 
+        '<foo a={(b)} c={(d)}>Foo {(e+f/* */)\n' +
+        '} bar\n' +
+        '</foo>';
+      var result = 'React.createElement("foo", {a: (b), c: (d)}, "Foo ",(e+f/* */), \n' +
+          '" bar"\n' +
+          ')';
+    expect(transform(code).code).toBe(result);
+  });
+
   it('should transform known hyphenated tags', function() {
     var code = '<font-face />;';
     var result = 'React.createElement("font-face", null);';

--- a/vendor/fbtransform/transforms/__tests__/react-test.js
+++ b/vendor/fbtransform/transforms/__tests__/react-test.js
@@ -326,10 +326,12 @@ describe('react jsx', function() {
 
   it('handles overparenthesized JS', function() {
     var code =
-    '<foo a={(b)} c={(d)}>Foo {(e+f/* */)\n' +
+    '<foo a={(b)} c={(d)}>Foo {(e+f //A line comment\n' +
+        '/* A multiline comment */)\n' +
       '} bar\n' +
     '</foo>';
-    var result = 'React.createElement("foo", {a: (b), c: (d)}, "Foo ",(e+f/* */), \n' +
+    var result = 'React.createElement("foo", {a: (b), c: (d)}, "Foo ",(e+f //A line comment\n' +
+            '/* A multiline comment */), \n' +
     '" bar"\n' +
     ')';
     expect(transform(code).code).toBe(result);

--- a/vendor/fbtransform/transforms/jsx.js
+++ b/vendor/fbtransform/transforms/jsx.js
@@ -12,40 +12,39 @@ var Syntax = require('jstransform').Syntax;
 var utils = require('jstransform/src/utils');
 
 function commaAfterLastParen(value) {
-  var state = "normal";
+  var state = 'normal';
   var commaPos = 0;
   for (var i = 0; i < value.length; ++i) {
-    if (state === "normal") {
-      if (value.charAt(i) === "/") {
+    if (state === 'normal') {
+      if (value.charAt(i) === '/') {
         if (i + 1 < value.length) {
-          if (value.charAt(i + 1) === "/") {
-            state = "singleline";
+          if (value.charAt(i + 1) === '/') {
+            state = 'singleline';
             i += 1;
             continue;
 
           }
-          if (value.charAt(i + 1) === "*") {
-            state = "multiline";
+          if (value.charAt(i + 1) === '*') {
+            state = 'multiline';
             i += 1;
             continue;
           }
         }
       }
-      if (value.charAt(i).trim() !== "") {
+      if (value.charAt(i).trim() !== '') {
         commaPos = i + 1;
       }
-    }
-    else if (state === "singleline" && value.charAt(i) === "\n") {
-      state = "normal";
-    } else if (state === "multiline" &&
-        value.charAt(i) === "*" &&
+    } else if (state === 'singleline' && value.charAt(i) === '\n') {
+      state = 'normal';
+    } else if (state === 'multiline' &&
+        value.charAt(i) === '*' &&
         i + 1 < value.length &&
-        value.charAt(i + 1) === "/") {
-          i += 1;
-          state = "normal";
-        }
+        value.charAt(i + 1) === '/') {
+      i += 1;
+      state = 'normal';
+    }
   }
-  return value.substring(0, commaPos) + ", " + trimLeft(value.substring(commaPos));
+  return value.substring(0, commaPos) + ', ' + trimLeft(value.substring(commaPos));
 }
 
 function renderJSXLiteral(object, isLast, state, start, end) {
@@ -121,12 +120,11 @@ function renderJSXExpressionContainer(traverse, object, isLast, path, state) {
   if (!isLast && object.expression.type !== Syntax.JSXEmptyExpression) {
     // If we need to append a comma, make sure to do so after the expression.
     utils.catchup(object.expression.range[1], state, trimLeft);
-    utils.catchup(object.range[1] -1, state, commaAfterLastParen)
+    utils.catchup(object.range[1] - 1, state, commaAfterLastParen);
     //utils.append(', ', state);
-  }
-  else {
-      // Minus 1 to skip `}`.
-      utils.catchup(object.range[1] - 1, state, trimLeft);
+  } else {
+    // Minus 1 to skip `}`.
+    utils.catchup(object.range[1] - 1, state, trimLeft);
   }
   utils.move(object.range[1], state);
   return false;

--- a/vendor/fbtransform/transforms/jsx.js
+++ b/vendor/fbtransform/transforms/jsx.js
@@ -15,46 +15,38 @@ function commaAfterLastParen(value) {
     var state = "normal";
     var commaPos = 0;
     for (var i=0;i<value.length;++i) {
-        switch (state) {
-            case "normal":
-                switch (value.charAt(i)) {
-                    case "/":
-                        if (i+1 < value.length) {
-                            if (value.charAt(i+1) === "/") {
-                                state = "singleline";
-                                i+=1;
+        if (state === "normal") {
+            if (value.charAt(i) == "/") {
+                if (i+1 < value.length) {
+                    if (value.charAt(i+1) === "/") {
+                        state = "singleline";
+                        i+=1;
 
-                            }
-                            else if (value.charAt(i+1) === "*") {
-                                state = "multiline"
-                                    i+=1;
-                            }
-                            else {
-                                commaPos = i+1;
-                            }
-                        }
-                        else {
-                            commaPos = i+1;
-                        }
-                        break;
-                    default:
-                        if (value.charAt(i).trim() !== "") {
-                            commaPos = i+1;
-                        }
-                }
-                break;
-            case "singleline":
-                if(value.charAt(i) === "\n") {
-                    state = "normal"
-                }
-                break;
-            case "multiline":
-                if(value.charAt(i) === "*" &&
-                        i+1 < value.length &&
-                        value.charAt(i+1) == "/") {
+                    }
+                    else if (value.charAt(i+1) === "*") {
+                        state = "multiline"
                             i+=1;
-                            state = "normal"
-                        }
+                    }
+                    else {
+                        commaPos = i+1;
+                    }
+                }
+                else {
+                    commaPos = i+1;
+                }
+            }
+            else if (value.charAt(i).trim() !== "") {
+                commaPos = i+1;
+            }
+        }
+        else if (state == "singleline" && value.charAt(i) === "\n") {
+            state = "normal"
+        } else if (state == "multiline" &&
+                value.charAt(i) === "*" &&
+                i+1 < value.length &&
+                value.charAt(i+1) == "/") {
+                    i+=1;
+                    state = "normal"
         }
     }
     return value.substring(0,commaPos) + ', ' + trimLeft(value.substring(commaPos));

--- a/vendor/fbtransform/transforms/jsx.js
+++ b/vendor/fbtransform/transforms/jsx.js
@@ -21,21 +21,17 @@ function commaAfterLastParen(value) {
                     if (value.charAt(i+1) === "/") {
                         state = "singleline";
                         i+=1;
+                        continue;
 
                     }
-                    else if (value.charAt(i+1) === "*") {
+                    if (value.charAt(i+1) === "*") {
                         state = "multiline"
                             i+=1;
+                        continue;
                     }
-                    else {
-                        commaPos = i+1;
-                    }
-                }
-                else {
-                    commaPos = i+1;
                 }
             }
-            else if (value.charAt(i).trim() !== "") {
+            if (value.charAt(i).trim() !== "") {
                 commaPos = i+1;
             }
         }

--- a/vendor/fbtransform/transforms/jsx.js
+++ b/vendor/fbtransform/transforms/jsx.js
@@ -84,7 +84,7 @@ function renderJSXLiteral(object, isLast, state, start, end) {
           utils.append(end, state);
         }
         if (!isLast) {
-          utils.append(',', state);
+          utils.append(', ', state);
         }
       }
 

--- a/vendor/fbtransform/transforms/jsx.js
+++ b/vendor/fbtransform/transforms/jsx.js
@@ -16,22 +16,13 @@ function commaAfterLastParen(value) {
   var commaPos = 0;
   for (var i = 0; i < value.length; ++i) {
     if (state === 'normal') {
-      if (value.charAt(i) === '/') {
-        if (i + 1 < value.length) {
-          if (value.charAt(i + 1) === '/') {
-            state = 'singleline';
-            i += 1;
-            continue;
-
-          }
-          if (value.charAt(i + 1) === '*') {
-            state = 'multiline';
-            i += 1;
-            continue;
-          }
-        }
-      }
-      if (value.charAt(i).trim() !== '') {
+      if (value.substr(i, 2) === '//') {
+        state = 'singleline';
+        i += 1;
+      } else if (value.substr(i, 2) === '/*') {
+        state = 'multiline';
+        i += 1;
+      } else if (value.charAt(i).trim() !== '') {
         commaPos = i + 1;
       }
     } else if (state === 'singleline' && value.charAt(i) === '\n') {

--- a/vendor/fbtransform/transforms/jsx.js
+++ b/vendor/fbtransform/transforms/jsx.js
@@ -121,7 +121,6 @@ function renderJSXExpressionContainer(traverse, object, isLast, path, state) {
     // If we need to append a comma, make sure to do so after the expression.
     utils.catchup(object.expression.range[1], state, trimLeft);
     utils.catchup(object.range[1] - 1, state, commaAfterLastParen);
-    //utils.append(', ', state);
   } else {
     // Minus 1 to skip `}`.
     utils.catchup(object.range[1] - 1, state, trimLeft);

--- a/vendor/fbtransform/transforms/jsx.js
+++ b/vendor/fbtransform/transforms/jsx.js
@@ -12,44 +12,41 @@ var Syntax = require('jstransform').Syntax;
 var utils = require('jstransform/src/utils');
 
 function commaAfterLastParen(value) {
-    var state = "normal";
-    var commaPos = 0;
-    for (var i=0;i<value.length;++i) {
-        if (state === "normal") {
-            if (value.charAt(i) == "/") {
-                if (i+1 < value.length) {
-                    if (value.charAt(i+1) === "/") {
-                        state = "singleline";
-                        i+=1;
-                        continue;
+  var state = "normal";
+  var commaPos = 0;
+  for (var i = 0; i < value.length; ++i) {
+    if (state === "normal") {
+      if (value.charAt(i) === "/") {
+        if (i + 1 < value.length) {
+          if (value.charAt(i + 1) === "/") {
+            state = "singleline";
+            i += 1;
+            continue;
 
-                    }
-                    if (value.charAt(i+1) === "*") {
-                        state = "multiline"
-                            i+=1;
-                        continue;
-                    }
-                }
-            }
-            if (value.charAt(i).trim() !== "") {
-                commaPos = i+1;
-            }
+          }
+          if (value.charAt(i + 1) === "*") {
+            state = "multiline";
+            i += 1;
+            continue;
+          }
         }
-        else if (state == "singleline" && value.charAt(i) === "\n") {
-            state = "normal"
-        } else if (state == "multiline" &&
-                value.charAt(i) === "*" &&
-                i+1 < value.length &&
-                value.charAt(i+1) == "/") {
-                    i+=1;
-                    state = "normal"
-        }
+      }
+      if (value.charAt(i).trim() !== "") {
+        commaPos = i + 1;
+      }
     }
-    return value.substring(0,commaPos) + ', ' + trimLeft(value.substring(commaPos));
+    else if (state === "singleline" && value.charAt(i) === "\n") {
+      state = "normal";
+    } else if (state === "multiline" &&
+        value.charAt(i) === "*" &&
+        i + 1 < value.length &&
+        value.charAt(i + 1) === "/") {
+          i += 1;
+          state = "normal";
+        }
+  }
+  return value.substring(0, commaPos) + ", " + trimLeft(value.substring(commaPos));
 }
-
-
-            
 
 function renderJSXLiteral(object, isLast, state, start, end) {
   var lines = object.value.split(/\r\n|\n|\r/);


### PR DESCRIPTION
For some reason the comma was emitted in renderXJSExpressionContainer if
it was an XJSExpressionContainer, and in the caller of the function
otherwise.  This made getting things like `<Foo bar=(baz) quux={biff} />`
hard.

This should fix issue #1673