### PR TITLE
Fix for the jekyll docs build process

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     redcarpet (3.1.2)
-    safe_yaml (1.0.3)
+    safe_yaml (1.0.4)
     sanitize (2.0.6)
       nokogiri (>= 1.4.4)
     sass (3.3.14)


### PR DESCRIPTION
Bumps safe_yaml to 1.0.4 (was 1.0.3) to fix a bug when you try to run `bundle exec jekyll serve -w` due to safe_yaml 1.0.3 havign some issues with Ruby 2.2.0:  
https://github.com/dtao/safe_yaml/issues/67

Updating to 1.0.4 fixes this.