### PR TITLE
Fixed Copyright year for three files and react.js licence to BSD-license

### DIFF
--- a/npm-jsx_orphaned_brackets_transformer/transforms/react.js
+++ b/npm-jsx_orphaned_brackets_transformer/transforms/react.js
@@ -1,17 +1,10 @@
 /**
- * Copyright 2013-2014 Facebook, Inc.
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
  */
 /*global exports:true*/
 "use strict";

--- a/src/browser/ui/dom/components/ReactDOMIframe.js
+++ b/src/browser/ui/dom/components/ReactDOMIframe.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014, Facebook, Inc.
+ * Copyright 2013-2015, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/browser/ui/dom/setTextContent.js
+++ b/src/browser/ui/dom/setTextContent.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014, Facebook, Inc.
+ * Copyright 2013-2015, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the


### PR DESCRIPTION
I did something stupid in rebase and need to redo pull request. Sorry about this. I changed react.js licence to BSD-license and update the year in that, ReactDOMIframe.js, and setTextContent.js to 2015. Thanks.