### PR TITLE
Update jsx binary to latest jstransform + latest flow syntax features

### DIFF
--- a/bin/jsx
+++ b/bin/jsx
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // -*- mode: js -*-
-"use strict";
+'use strict';
 
 var transform = require('../main').transform;
 
@@ -15,14 +15,32 @@ require('commoner').version(
   '--strip-types',
   'Strips out type annotations.'
 ).option(
+  '--es6module',
+  'Parses the file as a valid ES6 module. ' +
+  '(Note that this means implicit strict mode)'
+).option(
+  '--non-strict-es6module',
+  'Parses the file as an ES6 module, except disables implicit strict-mode. ' +
+  '(This is useful if you\'re porting non-ES6 modules to ES6, but haven\'t ' +
+  'yet verified that they are strict-mode safe yet)'
+).option(
   '--source-map-inline',
   'Embed inline sourcemap in transformed source'
 ).process(function(id, source) {
+  var sourceType;
+  if (this.options.es6module) {
+    sourceType = 'module';
+  }
+  if (this.options.nonStrictEs6module) {
+    sourceType = 'nonStrictModule';
+  }
+
   // This is where JSX, ES6, etc. desugaring happens.
   var options = {
     harmony: this.options.harmony,
     sourceMap: this.options.sourceMapInline,
-    stripTypes: this.options.stripTypes
+    stripTypes: this.options.stripTypes,
+    sourceType: sourceType,
   };
   return transform(source, options);
 });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "commoner": "^0.10.0",
-    "jstransform": "^8.0.0"
+    "jstransform": "^9.1.0"
   },
   "devDependencies": {
     "benchmark": "~1.0.0",
@@ -40,7 +40,7 @@
     "es3ify": "~0.1.2",
     "es5-shim": "^4.0.0",
     "eslint": "^0.14.1",
-    "esprima-fb": "^10001.1.0-dev-harmony-fb",
+    "esprima-fb": "^12001.1.0-dev-harmony-fb",
     "grunt": "~0.4.2",
     "grunt-cli": "~0.1.9",
     "grunt-compare-size": "~0.4.0",


### PR DESCRIPTION
* Updates the jstransform version to include new Flow syntactic features (like `import type` and type casts)
* Adds new `--es6module` and `--non-strict-es6module` flags to the `jsx` executable

Why a special flag for es6 modules, you ask?

ES6 modules are parsed in a different mode than regular scripts: (1) They are implictly strict-mode (2) Only modules can have `import`/`export` declarations (scripts cannot); So the parser needs to know which mode it should parse the file.

Whats up with `--non-strict-es6module` you ask?

There are a lot of non-ES6 modules out in the wild (i.e. CommonJS modules) that are just begging to be converted to ES6 modules. However, because es6 modules are implicit-strict, it's not immediately safe to just convert the `require()`s to `import`s and call it a day. So this new `--non-strict-es6module` is a compatibility mode that lets people switch to the new syntax and defer the strict-mode conversion until they have time to come around to it.

cc @sebmck w.r.t. the new Flow syntax features (see https://github.com/facebook/jstransform/commit/de1173c3ee91b916f5921881439863589fca4b1d and https://github.com/facebook/jstransform/commit/a4099d9e2209c4d43df2c009209d87c4c26d9dd0)