### PR TITLE
Don't cache purged nodes that are focused on unmount

### DIFF
--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -317,6 +317,10 @@ function batchedMountComponentIntoNode(
  * @see {ReactMount.unmountComponentAtNode}
  */
 function unmountComponentFromNode(instance, container) {
+  // Unmounting a focused component causes a blur event to fire, so we want to
+  // suppress React event-listening during unmount.
+  var previouslyEnabled = ReactBrowserEventEmitter.isEnabled();
+  ReactBrowserEventEmitter.setEnabled(false);
   ReactReconciler.unmountComponent(instance);
 
   if (container.nodeType === DOC_NODE_TYPE) {
@@ -327,6 +331,8 @@ function unmountComponentFromNode(instance, container) {
   while (container.lastChild) {
     container.removeChild(container.lastChild);
   }
+
+  ReactBrowserEventEmitter.setEnabled(previouslyEnabled);
 }
 
 /**


### PR DESCRIPTION
Fixes #2988.

Unmounting was causing the blur event to fire, which was in turn causing the blurred node to be added to ReactMount.nodeCache.