### PR TITLE
Prevent NaN props from triggering warnings

### DIFF
--- a/src/classic/element/ReactElementValidator.js
+++ b/src/classic/element/ReactElementValidator.js
@@ -312,8 +312,14 @@ function checkAndWarnForMutatedProps(element) {
 
   for (var propName in props) {
     if (props.hasOwnProperty(propName)) {
-      if (!originalProps.hasOwnProperty(propName) ||
-          originalProps[propName] !== props[propName]) {
+      var valueChanged = originalProps[propName] !== props[propName];
+      // Necessary because NaN !== NaN
+      if (typeof originalProps[propName] === 'number' &&
+          typeof props[propName] === 'number' &&
+          isNaN(originalProps[propName]) && isNaN(props[propName])) {
+        valueChanged = false;
+      }
+      if (!originalProps.hasOwnProperty(propName) || valueChanged) {
         warnForPropsMutation(propName, element);
 
         // Copy over the new value so that the two props objects match again


### PR DESCRIPTION
Previously, `checkAndWarnForMutatedProps` would flag `NaN` props as having been mutated, because `NaN !== NaN`. This prevents that warning from being emitted by explicitly checking for `NaN`s.

I couldn't see any tests for this method, but let me know if I've missed something!