### PR TITLE
Custom CSSTransitionGroup classnames

### DIFF
--- a/docs/docs/10.1-animation.md
+++ b/docs/docs/10.1-animation.md
@@ -84,6 +84,54 @@ You'll notice that when you try to remove an item `ReactCSSTransitionGroup` keep
 }
 ```
 
+### Custom Class Names
+
+CSSTransitionGroup also allows you to provide your own class names for transitions. This allows you to, for instance, use animations provided by third party CSS libraries which don't conform to the `example-enter` scheme. Here the above example implementing custom class names to add a `bounceInLeft` and `bounceInRight` effect on entry and exit.
+
+```javascript{28-30}
+var ReactCSSTransitionGroup = React.addons.CSSTransitionGroup;
+
+var TodoList = React.createClass({
+  getInitialState: function() {
+    return {items: ['hello', 'world', 'click', 'me']};
+  },
+  handleAdd: function() {
+    var newItems =
+      this.state.items.concat([prompt('Enter some text')]);
+    this.setState({items: newItems});
+  },
+  handleRemove: function(i) {
+    var newItems = this.state.items;
+    newItems.splice(i, 1);
+    this.setState({items: newItems});
+  },
+  render: function() {
+    var items = this.state.items.map(function(item, i) {
+      return (
+        <div key={item} onClick={this.handleRemove.bind(this, i)}>
+          {item}
+        </div>
+      );
+    }.bind(this));
+    var transitionNames = {
+      name: 'addAndRemoveItemAnimation",
+      enter: 'bounceInLeft',
+      leave: 'bounceOutRight'
+    };
+    return (
+      <div>
+        <button onClick={this.handleAdd}>Add Item</button>
+        <ReactCSSTransitionGroup transitionName={transitionNames}>
+          {items}
+        </ReactCSSTransitionGroup>
+      </div>
+    );
+  }
+});
+```
+
+In this example, the class names applied on enter and leave will be `bounceInLeft` and `bounceOutRight` respectively. Because a custom name is not provided, during an appear transition the class name `addAndRemoveItemAnimation-appear` will be used. You can also provide custom names for active class names by providing values for `enterActive`. If not provided, it will use the default convention based on the `transitionName.name` value.
+
 ### Animation Group Must Be Mounted To Work
 
 In order for it to apply transitions to its children, the `ReactCSSTransitionGroup` must already be mounted in the DOM. The example below would not work, because the `ReactCSSTransitionGroup` is being mounted along with the new item, instead of the new item being mounted within it. Compare this to the [Getting Started](#getting-started) section above to see the difference.

--- a/src/addons/transitions/ReactCSSTransitionGroup.js
+++ b/src/addons/transitions/ReactCSSTransitionGroup.js
@@ -27,7 +27,9 @@ var ReactCSSTransitionGroup = React.createClass({
   displayName: 'ReactCSSTransitionGroup',
 
   propTypes: {
-    transitionName: React.PropTypes.string.isRequired,
+    transitionName: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.objectOf(React.PropTypes.string) ]).isRequired,
     transitionAppear: React.PropTypes.bool,
     transitionEnter: React.PropTypes.bool,
     transitionLeave: React.PropTypes.bool

--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -48,8 +48,19 @@ var ReactCSSTransitionGroupChild = React.createClass({
 
   transition: function(animationType, finishCallback) {
     var node = this.getDOMNode();
-    var className = this.props.name + '-' + animationType;
-    var activeClassName = className + '-active';
+    var className, activeClassName;
+
+    if(typeof this.props.name === 'string') {
+      className = this.props.name + '-' + animationType;
+      activeClassName = className + '-active';
+    }
+    if(typeof this.props.name === 'object') {
+      className = this.props.name[animationType];
+      activeClassName = this.props.name[animationType + 'Active'];
+      activeClassName = activeClassName ? activeClassName 
+        : this.props.name.name + '-' + animationType + '-active';
+    }
+
     var noEventTimeout = null;
 
     var endListener = function(e) {

--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -50,15 +50,16 @@ var ReactCSSTransitionGroupChild = React.createClass({
     var node = this.getDOMNode();
     var className, activeClassName;
 
-    if(typeof this.props.name === 'string') {
+    if (typeof this.props.name === 'string') {
       className = this.props.name + '-' + animationType;
       activeClassName = className + '-active';
     }
-    if(typeof this.props.name === 'object') {
+    if (typeof this.props.name === 'object') {
       className = this.props.name[animationType];
-      className = className ? classneme : this.props.name.name + '-' + animationType;
+      className = className ? className 
+        : this.props.name.name + '-' + animationType;
       activeClassName = this.props.name[animationType + 'Active'];
-      activeClassName = activeClassName ? activeClassName 
+      activeClassName = activeClassName ? activeClassName
         : this.props.name.name + '-' + animationType + '-active';
     }
 

--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -56,6 +56,7 @@ var ReactCSSTransitionGroupChild = React.createClass({
     }
     if(typeof this.props.name === 'object') {
       className = this.props.name[animationType];
+      className = className ? classneme : this.props.name.name + '-' + animationType;
       activeClassName = this.props.name[animationType + 'Active'];
       activeClassName = activeClassName ? activeClassName 
         : this.props.name.name + '-' + animationType + '-active';

--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -56,7 +56,7 @@ var ReactCSSTransitionGroupChild = React.createClass({
     }
     if (typeof this.props.name === 'object') {
       className = this.props.name[animationType];
-      className = className ? className 
+      className = className ? className
         : this.props.name.name + '-' + animationType;
       activeClassName = this.props.name[animationType + 'Active'];
       activeClassName = activeClassName ? activeClassName


### PR DESCRIPTION
This implements #2680 allowing you to provide your own class names during transitions.

I've provided the changes and the documentation but not tests.