### PR TITLE
escapeTextContentForBrowser no longer escapes ' and ", quoteAttributeValueForBrowser no longer escapes '

### DIFF
--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -443,8 +443,8 @@ describe('ReactDOMComponent', function() {
           }, '\'"<>&')
         )
       ).toBe(
-        '<div title="&#x27;&quot;&lt;&gt;&amp;" style="text-align:&#x27;&quot;&lt;&gt;&amp;;">' +
-          '&#x27;&quot;&lt;&gt;&amp;' +
+        '<div title="\'&quot;&lt;&gt;&amp;" style="text-align:\'&quot;&lt;&gt;&amp;;">' +
+          '\'"&lt;&gt;&amp;' +
         '</div>'
       );
     });

--- a/src/utils/__tests__/escapeTextContentForBrowser-test.js
+++ b/src/utils/__tests__/escapeTextContentForBrowser-test.js
@@ -35,11 +35,9 @@ describe('escapeTextContentForBrowser', function() {
   });
 
   it('should escape string', function() {
-    var escaped = escapeTextContentForBrowser('<script type=\'\' src=""></script>');
+    var escaped = escapeTextContentForBrowser('<script></script>');
     expect(escaped).not.toContain('<');
     expect(escaped).not.toContain('>');
-    expect(escaped).not.toContain('\'');
-    expect(escaped).not.toContain('\"');
 
     escaped = escapeTextContentForBrowser('&');
     expect(escaped).toBe('&amp;');

--- a/src/utils/__tests__/quoteAttributeValueForBrowser-test.js
+++ b/src/utils/__tests__/quoteAttributeValueForBrowser-test.js
@@ -35,10 +35,9 @@ describe('quoteAttributeValueForBrowser', function() {
   });
 
   it('should escape string', function() {
-    var escaped = quoteAttributeValueForBrowser('<script type=\'\' src=""></script>');
+    var escaped = quoteAttributeValueForBrowser('<script src=""></script>');
     expect(escaped).not.toContain('<');
     expect(escaped).not.toContain('>');
-    expect(escaped).not.toContain('\'');
     expect(escaped.substr(1, -1)).not.toContain('\"');
 
     escaped = quoteAttributeValueForBrowser('&');

--- a/src/utils/escapeTextContentForBrowser.js
+++ b/src/utils/escapeTextContentForBrowser.js
@@ -11,24 +11,25 @@
 
 'use strict';
 
+// `"` and `'` are not escaped; they are parsed as regular characters in the
+// context of text content.
+
 var ESCAPE_LOOKUP = {
   '&': '&amp;',
   '>': '&gt;',
-  '<': '&lt;',
-  '"': '&quot;',
-  '\'': '&#x27;'
+  '<': '&lt;'
 };
 
-var ESCAPE_REGEX = /[&><"']/g;
+var ESCAPE_REGEX = /[&><]/g;
 
 function escaper(match) {
   return ESCAPE_LOOKUP[match];
 }
 
 /**
- * Escapes text to prevent scripting attacks.
+ * Escapes text content to prevent scripting attacks.
  *
- * @param {*} text Text value to escape.
+ * @param {*} text Text content value to escape.
  * @return {string} An escaped string.
  */
 function escapeTextContentForBrowser(text) {

--- a/src/utils/quoteAttributeValueForBrowser.js
+++ b/src/utils/quoteAttributeValueForBrowser.js
@@ -11,16 +11,33 @@
 
 "use strict";
 
-var escapeTextContentForBrowser = require('escapeTextContentForBrowser');
+// `'` is not escaped; OWASP asserts "Properly quoted attributes can only be
+// escaped with the corresponding quote.". All attribute value quoting must use
+// this function which exclusively quotes with `"`. However, `<` and `>` are
+// still escaped as a precaution for when markup is served within inline
+// scripts or comments without sufficient escaping.
+
+var ESCAPE_LOOKUP = {
+  '&': '&amp;',
+  '>': '&gt;',
+  '<': '&lt;',
+  '"': '&quot;'
+};
+
+var ESCAPE_REGEX = /[&><"]/g;
+
+function escaper(match) {
+  return ESCAPE_LOOKUP[match];
+}
 
 /**
  * Escapes attribute value to prevent scripting attacks.
  *
- * @param {*} value Value to escape.
+ * @param {*} value Attribute value to escape.
  * @return {string} An escaped string.
  */
 function quoteAttributeValueForBrowser(value) {
-  return '"' + escapeTextContentForBrowser(value) + '"';
+  return '"' + ('' + value).replace(ESCAPE_REGEX, escaper) + '"';
 }
 
 module.exports = quoteAttributeValueForBrowser;


### PR DESCRIPTION
cc @yungsters, @vjeux, @zpao 

After digging around and evaluating, i see the following possible rule changes:

A. `escapeTextContentForBrowser` ignore `"` and `'`, they have no special meaning in text content.
B. `quoteAttributeValueForBrowser` ignore `'`, can only be broken out of with `"` (OWASP).
C. `quoteAttributeValueForBrowser` ignore `<` and `>`, cannot break out of quoted attribute values.

----

*The following safety observations are only guaranteed to hold for React generated markup, it does not hold when markup is introduced via `dangerouslySetInnerHTML` using different escaping/quoting or post-process manipulated.*

**Markup as a string in inline scripts**
Proper escaping: JSON stringify + replace `</script` with `<\/script`.

With current rules (if no encoding):
* Leads to XSS if inside a `'`-string if there are legitimate occurrences of `</script>` (breaks layout during load).
* Leads to XSS if inside a `"`-string (throws error on load if markup has a quoted attribute value).

With rules A+B:
* Leads to XSS if inside a `'`-string (throws error on load if markup has a `'`).

With rules A+B+C:
* Leads to XSS if `</script>` is used as an attribute value (only observed if actively tested for).

**Markup within a HTML comment**
Proper encoding: HTML encode

With current rules  (if no encoding):
* Leads to XSS if there are legitimate occurrences of `<!-- -->` (breaks layout during load).
* Leads to XSS if comment is evaluted by a library (likely to throw error or break layout during load).

With rules A+B:
* (nothing new)

With rules A+B+C:
* Leads to XSS if `-->` is used as an attribute value (only observed if actively tested for).

----

The ruleset A+B is ever slightly more exploitable in the case of markup as a string within an inline script without proper encoding, but the flip-side benefit is that the lack of proper escaping is much more likely to be observed during development. I find this to be an acceptable trade-off and it's a dangerous situation to be in with or without the new rules so having a chance to catch it earlier is for the better.

So while the ruleset A+B+C is safe for HTML rendering it consistently elevates likely (relatively) minor safety issues to full-blown XSS and without increasing the chances of the lack of proper escaping being observed at development, although these are errors on behalf of the user and technically not our concern. This seems like a dangerous step that is not worth taking lightly, considering knowledge of proper escaping is far less common than it should be. `<` and `>` are also rarely used in attribute values so it would also have little practical impact. It would be easy to fix `</script` and `-->` but there's always the question of *what else*.

**tl;dr** I'm confident ruleset reduction A+B is, all things considered, as safe and perhaps even preferable due to earlier detection. This PR implements A+B.

----

```JS
document.body.innerHTML = '<div></div>';
document.body.firstChild.setAttribute('attr', '<>\'"&/'); // quoteAttributeValueForBrowser
document.body.firstChild.style.content = '\'<>\\\'"&/\''; // quoteAttributeValueForBrowser
document.body.firstChild.textContent = '<>\'"&/'; // escapeTextContentForBrowser
```
```HTML
<div
  attr="<>'&quot;&amp;/"
  style="content: '<>\'&quot;&amp;/';">
  &lt;&gt;'"&amp;/
</div>
```