### PR TITLE
Fix sourcemap filenames when using transformWithDetails. Fixes #3140

### DIFF
--- a/main.js
+++ b/main.js
@@ -26,6 +26,9 @@ module.exports = {
     if (options && options.sourceMap) {
       result.sourceMap = output.sourceMap.toJSON();
     }
+    if (options && options.sourceFilename) {
+      result.sourceMap.sources = [options.sourceFilename];
+    }
     return result;
   }
 };
@@ -46,6 +49,9 @@ function innerTransform(input, options) {
   }
 
   var visitorList = visitors.getVisitorsBySet(visitorSets);
+  if (options.sourceFilename) {
+    options.filename = options.sourceFilename;
+  }
   return transform(visitorList, input, options);
 }
 


### PR DESCRIPTION
Quick fix for #3140: sourcemap sources seemed to be hard coded (not depending on any options passed to transform). This change overwrites the return object's sources array if sourceFilename was defined.

Transform does use options.filename for sourcemap.file in the return object. Defining `options.filename = options.sourceFilename` corrects the filename, which would otherwise be `'transformed.js'`