### PR TITLE
Allow rendering into document fragments. Fixes #840


### DIFF
--- a/src/browser/ui/ReactMount.js
+++ b/src/browser/ui/ReactMount.js
@@ -41,6 +41,7 @@ var nodeCache = {};
 
 var ELEMENT_NODE_TYPE = 1;
 var DOC_NODE_TYPE = 9;
+var DOCUMENT_FRAGMENT_NODE_TYPE = 11;
 
 /** Mapping from reactRootID to React component instance. */
 var instancesByReactRootID = {};
@@ -355,7 +356,8 @@ var ReactMount = {
     invariant(
       container && (
         container.nodeType === ELEMENT_NODE_TYPE ||
-        container.nodeType === DOC_NODE_TYPE
+        container.nodeType === DOC_NODE_TYPE ||
+        container.nodeType === DOCUMENT_FRAGMENT_NODE_TYPE
       ),
       '_registerComponent(...): Target container is not a DOM element.'
     );
@@ -578,7 +580,8 @@ var ReactMount = {
     invariant(
       container && (
         container.nodeType === ELEMENT_NODE_TYPE ||
-        container.nodeType === DOC_NODE_TYPE
+        container.nodeType === DOC_NODE_TYPE ||
+        container.nodeType === DOCUMENT_FRAGMENT_NODE_TYPE
       ),
       'unmountComponentAtNode(...): Target container is not a DOM element.'
     );
@@ -790,7 +793,8 @@ var ReactMount = {
     invariant(
       container && (
         container.nodeType === ELEMENT_NODE_TYPE ||
-          container.nodeType === DOC_NODE_TYPE
+        container.nodeType === DOC_NODE_TYPE ||
+        container.nodeType === DOCUMENT_FRAGMENT_NODE_TYPE
       ),
       'mountComponentIntoNode(...): Target container is not valid.'
     );


### PR DESCRIPTION
Allow rendering into document fragments. Fixes #840

Manually tested mounting and unmounting; that worked.  Meaningful unit tests require the webcomponent polyfill, which is non-trivial to load into jsdom, so we'll figure out how to add more unit tests later.