### PR TITLE
Modify sample CSS so that it works in Safari

### DIFF
--- a/docs/docs/10.1-animation.md
+++ b/docs/docs/10.1-animation.md
@@ -63,11 +63,11 @@ You can use these classes to trigger a CSS animation or transition. For example,
 ```css
 .example-enter {
   opacity: 0.01;
-  transition: opacity .5s ease-in;
 }
 
 .example-enter.example-enter-active {
   opacity: 1;
+  transition: opacity .5s ease-in;
 }
 ```
 
@@ -76,11 +76,11 @@ You'll notice that when you try to remove an item `ReactCSSTransitionGroup` keep
 ```css
 .example-leave {
   opacity: 1;
-  transition: opacity .5s ease-in;
 }
 
 .example-leave.example-leave-active {
   opacity: 0.01;
+  transition: opacity .5s ease-in;
 }
 ```
 


### PR DESCRIPTION
When animating the max-height property in Safari, entering the leave state would trigger an animation to `max-height: 0` (I guess Safari interprets `auto` as `0` when transitioning on that property?). Then when the active state kicked in, it would jump and didn't really look right. Moving the `transition` css property to the active class fixed the issue for me and worked on Safari, Chrome and Firefox. Unfortunately I'm not in a position to test in IE at the moment, but I'll do that at my first convenience tomorrow.