### PR TITLE
Use same pathways for browser transforms as we use in react-tools

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,9 +1,18 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 'use strict';
 /*eslint-disable no-undef*/
 var visitors = require('./vendor/fbtransform/visitors');
 var transform = require('jstransform').transform;
 var typesSyntax = require('jstransform/visitors/type-syntax');
-var Buffer = require('buffer').Buffer;
+var inlineSourceMap = require('./vendor/inline-source-map');
 
 module.exports = {
   transform: function(input, options) {
@@ -53,13 +62,4 @@ function innerTransform(input, options) {
     options.filename = options.sourceFilename;
   }
   return transform(visitorList, input, options);
-}
-
-function inlineSourceMap(sourceMap, sourceCode, sourceFilename) {
-  var json = sourceMap.toJSON();
-  json.sources = [sourceFilename];
-  json.sourcesContent = [sourceCode];
-  var base64 = Buffer(JSON.stringify(json)).toString('base64');
-  return '//# sourceMappingURL=data:application/json;base64,' +
-         base64;
 }

--- a/vendor/inline-source-map.js
+++ b/vendor/inline-source-map.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var Buffer = require('buffer').Buffer;
+
+function inlineSourceMap(sourceMap, sourceCode, sourceFilename) {
+  // This can be used with a sourcemap that has already has toJSON called on it.
+  // Check first.
+  var json = sourceMap;
+  if (typeof sourceMap.toJSON === 'function') {
+    json = sourceMap.toJSON();
+  }
+  json.sources = [sourceFilename];
+  json.sourcesContent = [sourceCode];
+  var base64 = Buffer(JSON.stringify(json)).toString('base64');
+  return '//# sourceMappingURL=data:application/json;base64,' + base64;
+}
+
+module.exports = inlineSourceMap;


### PR DESCRIPTION
This makes sure we can use the same options everywhere, even from react-rails,
without having to specify each one separately in JSXTransformer as well.