### PR TITLE
Remove lodash devDependency

### DIFF
--- a/grunt/config/jsx.js
+++ b/grunt/config/jsx.js
@@ -1,7 +1,7 @@
 'use strict';
 
+var assign = require('../../src/stubs/Object.assign');
 var grunt = require('grunt');
-var _ = require('lodash');
 
 var rootIDs = [
   'React',
@@ -27,7 +27,7 @@ var test = {
     '**/__tests__/*.js'
   ]),
   getConfig: function() {
-    return _.merge({}, normal.getConfig(), {
+    return assign({}, normal.getConfig(), {
       mocking: true
     });
   },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "gzip-js": "~0.3.2",
     "jasmine-tapreporter": "~0.2.2",
     "jest-cli": "^0.2.1",
-    "lodash": "~2.4.1",
     "optimist": "~0.6.0",
     "phantomjs": "~1.9",
     "platform": "^1.1.0",


### PR DESCRIPTION
Using Object.assign in the build allows us to get rid of lodash as a dev dependency.