### PR TITLE
Move option parsing into react-tools proper.

### DIFF
--- a/bin/jsx
+++ b/bin/jsx
@@ -27,20 +27,17 @@ require('commoner').version(
   '--source-map-inline',
   'Embed inline sourcemap in transformed source'
 ).process(function(id, source) {
-  var sourceType;
-  if (this.options.es6module) {
-    sourceType = 'module';
-  }
-  if (this.options.nonStrictEs6module) {
-    sourceType = 'nonStrictModule';
-  }
-
   // This is where JSX, ES6, etc. desugaring happens.
+  // We don't do any pre-processing of options so that the command line and the
+  // JS API both expose the same set of options. We do extract the options that
+  // we care about from commoner though so we aren't passing too many things
+  // along.
   var options = {
     harmony: this.options.harmony,
     sourceMap: this.options.sourceMapInline,
     stripTypes: this.options.stripTypes,
-    sourceType: sourceType,
+    es6module: this.options.es6module,
+    nonStrictEs6Module: this.options.nonStrictEs6Module
   };
   return transform(source, options);
 });

--- a/main.js
+++ b/main.js
@@ -7,35 +7,58 @@ var Buffer = require('buffer').Buffer;
 
 module.exports = {
   transform: function(input, options) {
+    options = processOptions(options);
     var output = innerTransform(input, options);
     var result = output.code;
-    if (options && options.sourceMap) {
+    if (options.sourceMap) {
       var map = inlineSourceMap(
         output.sourceMap,
         input,
-        options.sourceFilename
+        options.filename
       );
       result += '\n' + map;
     }
     return result;
   },
   transformWithDetails: function(input, options) {
+    options = processOptions(options);
     var output = innerTransform(input, options);
     var result = {};
     result.code = output.code;
-    if (options && options.sourceMap) {
+    if (options.sourceMap) {
       result.sourceMap = output.sourceMap.toJSON();
     }
-    if (options && options.sourceFilename) {
-      result.sourceMap.sources = [options.sourceFilename];
+    if (options.filename) {
+      result.sourceMap.sources = [options.filename];
     }
     return result;
   }
 };
 
-function innerTransform(input, options) {
-  options = options || {};
+/**
+ * Only copy the values that we need. We'll do some preprocessing to account for
+ * converting command line flags to options that jstransform can actually use.
+ */
+function processOptions(opts) {
+  opts = opts || {};
+  var options = {};
 
+  options.harmony = opts.harmony;
+  options.stripTypes = opts.stripTypes;
+  options.sourceMap = opts.sourceMap;
+  options.filename = opts.sourceFilename;
+
+  if (opts.es6module) {
+    options.sourceType = 'module';
+  }
+  if (opts.nonStrictEs6Module) {
+    options.sourceType = 'nonStrict6Module';
+  }
+
+  return options;
+}
+
+function innerTransform(input, options) {
   var visitorSets = ['react'];
   if (options.harmony) {
     visitorSets.push('harmony');
@@ -49,9 +72,6 @@ function innerTransform(input, options) {
   }
 
   var visitorList = visitors.getVisitorsBySet(visitorSets);
-  if (options.sourceFilename) {
-    options.filename = options.sourceFilename;
-  }
   return transform(visitorList, input, options);
 }
 


### PR DESCRIPTION
We were doing some preprocessing for module options in the command line. Since
we also expose the same API via react-tools (and JSXTransformer), we need to do
the same processing from the API. So just move it all to the same place.

cc @jeffmo @gabelevi