### PR TITLE
Warn when using constructor function directly

### DIFF
--- a/src/classic/class/ReactClass.js
+++ b/src/classic/class/ReactClass.js
@@ -828,6 +828,14 @@ var ReactClass = {
       // This constructor is overridden by mocks. The argument is used
       // by mocks to assert on what gets mounted.
 
+      if (__DEV__) {
+        warning(
+          this instanceof Constructor,
+          'Something is calling a React component directly. Use a factory or ' +
+          'JSX instead. See: http://fb.me/react-legacyfactory'
+        );
+      }
+
       // Wire up auto-binding
       if (this.__reactAutoBindMap) {
         bindAutoBindMethods(this);

--- a/src/classic/class/__tests__/ReactClass-test.js
+++ b/src/classic/class/__tests__/ReactClass-test.js
@@ -363,4 +363,19 @@ describe('ReactClass-spec', function() {
     ).not.toThrow();
   });
 
+  it('should throw when using legacy factories', function() {
+    var Component = React.createClass({
+      render() {
+        return <div />;
+      }
+    });
+
+    expect(() => Component()).toThrow();
+    expect(console.warn.calls.length).toBe(1);
+    expect(console.warn.argsForCall[0][0]).toBe(
+      'Warning: Something is calling a React component directly. Use a ' +
+      'factory or JSX instead. See: http://fb.me/react-legacyfactory'
+    );
+  });
+
 });


### PR DESCRIPTION
We no longer support the legacy factory style of calling component constructors
directly. We only support createElement or the wrapping of classes with
createFactory. Instead of letting this fail in a gross way as we try to run,
add a nice invariant.

Fixes #3200 