### PR TITLE
More warnings to ReactFragment.create

### DIFF
--- a/src/addons/ReactFragment.js
+++ b/src/addons/ReactFragment.js
@@ -96,11 +96,19 @@ var ReactFragment = {
   // of its properties.
   create: function(object) {
     if (__DEV__) {
-      if (typeof object !== 'object' || !object) {
+      if (typeof object !== 'object' || !object || Array.isArray(object)) {
         warning(
           false,
-          'React.addons.createFragment only accepts a single object. Not %s',
+          'React.addons.createFragment only accepts a single object.',
           object
+        );
+        return object;
+      }
+      if (ReactElement.isValidElement(object)) {
+        warning(
+          false,
+          'React.addons.createFragment does not accept a ReactElement ' +
+          'without a wrapper object.'
         );
         return object;
       }

--- a/src/addons/__tests__/ReactFragment-test.js
+++ b/src/addons/__tests__/ReactFragment-test.js
@@ -73,12 +73,31 @@ describe('ReactFragment', function() {
     );
   });
 
-  it('should warn if accessing any property on a fragment', function() {
+  it('should warn if passing null to createFragment', function() {
     spyOn(console, 'warn');
     ReactFragment.create(null);
     expect(console.warn.calls.length).toBe(1);
     expect(console.warn.calls[0].args[0]).toContain(
-      'React.addons.createFragment only accepts a single object. Not null'
+      'React.addons.createFragment only accepts a single object.'
+    );
+  });
+
+  it('should warn if passing an array to createFragment', function() {
+    spyOn(console, 'warn');
+    ReactFragment.create([]);
+    expect(console.warn.calls.length).toBe(1);
+    expect(console.warn.calls[0].args[0]).toContain(
+      'React.addons.createFragment only accepts a single object.'
+    );
+  });
+
+  it('should warn if passing a ReactElement to createFragment', function() {
+    spyOn(console, 'warn');
+    ReactFragment.create(<div />);
+    expect(console.warn.calls.length).toBe(1);
+    expect(console.warn.calls[0].args[0]).toContain(
+      'React.addons.createFragment does not accept a ReactElement without a ' +
+      'wrapper object.'
     );
   });
 


### PR DESCRIPTION
Apparently I could've used these too because if you accept an arbitrary
node, then these could end up being objects, but those objects might
also be arrays or elements.