### PR TITLE
Warn when rendering directly into document.body

### DIFF
--- a/src/browser/ui/ReactMount.js
+++ b/src/browser/ui/ReactMount.js
@@ -448,6 +448,13 @@ var ReactMount = {
       )
     );
 
+    warning(
+      container !== document.body,
+      'render(): You\'re trying to render a component into document.body, ' +
+      'whose list of children is often manipulated by third party scripts ' +
+      'and browser extensions. This may lead to subtle reconciliation issues.'
+    );
+
     var prevComponent = instancesByReactRootID[getReactRootID(container)];
 
     if (prevComponent) {

--- a/src/browser/ui/ReactMount.js
+++ b/src/browser/ui/ReactMount.js
@@ -449,7 +449,7 @@ var ReactMount = {
     );
 
     warning(
-      container !== document.body,
+      container && container.tagName !== 'BODY',
       'render(): Rendering components directly into document.body is ' +
       'discouraged, since its children are often manipulated by third-party ' +
       'scripts and browser extensions. This may lead to subtle reconciliation ' +

--- a/src/browser/ui/ReactMount.js
+++ b/src/browser/ui/ReactMount.js
@@ -451,8 +451,8 @@ var ReactMount = {
     warning(
       container !== document.body,
       'render(): Rendering components directly into document.body is ' +
-      'discouraged, since its children are often manipulated by third party' +
-      'scripts and browser extensions. This may lead to subtle reconciliation' +
+      'discouraged, since its children are often manipulated by third-party ' +
+      'scripts and browser extensions. This may lead to subtle reconciliation ' +
       'issues. Try rendering into a container element created for your app.'
     );
 

--- a/src/browser/ui/ReactMount.js
+++ b/src/browser/ui/ReactMount.js
@@ -450,9 +450,10 @@ var ReactMount = {
 
     warning(
       container !== document.body,
-      'render(): You\'re trying to render a component into document.body, ' +
-      'whose list of children is often manipulated by third party scripts ' +
-      'and browser extensions. This may lead to subtle reconciliation issues.'
+      'render(): Rendering components directly into document.body is ' +
+      'discouraged, since its children are often manipulated by third party' +
+      'scripts and browser extensions. This may lead to subtle reconciliation' +
+      'issues. Try rendering into a container element created for your app.'
     );
 
     var prevComponent = instancesByReactRootID[getReactRootID(container)];

--- a/src/browser/ui/__tests__/ReactMount-test.js
+++ b/src/browser/ui/__tests__/ReactMount-test.js
@@ -150,7 +150,7 @@ describe('ReactMount', function() {
     ReactMount.render(<div />, document.body);
     expect(console.warn.calls.length).toBe(1);
     expect(console.warn.calls[0].args[0]).toContain(
-      'You\'re trying to render a component into document.body'
+      'Rendering components directly into document.body is discouraged'
     );
   });
 });

--- a/src/browser/ui/__tests__/ReactMount-test.js
+++ b/src/browser/ui/__tests__/ReactMount-test.js
@@ -146,8 +146,12 @@ describe('ReactMount', function() {
   });
 
   it('should warn when mounting into document.body', function () {
-    spyOn(console, 'warn')
-    ReactMount.render(<div />, document.body);
+    var iFrame = document.createElement('iframe');
+    document.body.appendChild(iFrame);
+    spyOn(console, 'warn');
+
+    ReactMount.render(<div />, iFrame.contentDocument.body);
+
     expect(console.warn.calls.length).toBe(1);
     expect(console.warn.calls[0].args[0]).toContain(
       'Rendering components directly into document.body is discouraged'

--- a/src/browser/ui/__tests__/ReactMount-test.js
+++ b/src/browser/ui/__tests__/ReactMount-test.js
@@ -144,4 +144,13 @@ describe('ReactMount', function() {
     ReactMount.render(<div />, container);
     expect(console.warn.mock.calls.length).toBe(0);
   });
+
+  it('should warn when mounting into document.body', function () {
+    spyOn(console, 'warn')
+    ReactMount.render(<div />, document.body);
+    expect(console.warn.calls.length).toBe(1);
+    expect(console.warn.calls[0].args[0]).toContain(
+      'You\'re trying to render a component into document.body'
+    );
+  });
 });


### PR DESCRIPTION
This is in response to #3207 to address concerns regarding third-party
scripts and browser plugins potentially altering DOM nodes within
document.body, causing problems with reconciliation.