### PR TITLE
Contributing: cleanup quote style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
 * Commas last,
 * 2 spaces for indentation (no tabs)
 * Prefer `'` over `"`
-* `"use strict";`
+* `'use strict';`
 * 80 character line length
 * "Attractive"
 * Do not use the optional parameters of `setTimeout` and `setInterval`


### PR DESCRIPTION
The line above it recommends `'` over `"`, and yet the line in question uses `"`.