### PR TITLE
Add vendor/inline-source-map.js to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "main.js",
     "bin/jsx",
     "src/",
-    "vendor/fbtransform/"
+    "vendor/fbtransform/",
+    "vendor/inline-source-map.js"
   ],
   "main": "main.js",
   "bin": {

--- a/vendor/fbtransform/visitors.js
+++ b/vendor/fbtransform/visitors.js
@@ -13,6 +13,8 @@ var es6ObjectShortNotation =
   require('jstransform/visitors/es6-object-short-notation-visitors');
 var es6RestParameters = require('jstransform/visitors/es6-rest-param-visitors');
 var es6Templates = require('jstransform/visitors/es6-template-visitors');
+var es6CallSpread =
+  require('jstransform/visitors/es6-call-spread-visitors');
 var es7SpreadProperty =
   require('jstransform/visitors/es7-spread-property-visitors');
 var react = require('./transforms/react');
@@ -30,6 +32,7 @@ var transformVisitors = {
   'es6-object-short-notation': es6ObjectShortNotation.visitorList,
   'es6-rest-params': es6RestParameters.visitorList,
   'es6-templates': es6Templates.visitorList,
+  'es6-call-spread': es6CallSpread.visitorList,
   'es7-spread-property': es7SpreadProperty.visitorList,
   'react': react.visitorList.concat(reactDisplayName.visitorList),
   'reserved-words': reservedWords.visitorList
@@ -44,6 +47,7 @@ var transformSets = {
     'es6-rest-params',
     'es6-templates',
     'es6-destructuring',
+    'es6-call-spread',
     'es7-spread-property'
   ],
   'es3': [
@@ -66,6 +70,7 @@ var transformRunOrder = [
   'es6-rest-params',
   'es6-templates',
   'es6-destructuring',
+  'es6-call-spread',
   'es7-spread-property',
   'react'
 ];


### PR DESCRIPTION
It was originally added in:
0e0a8f65c52cae5c1e7ea7ef4bd196465667f842

Fixes installation via `npm` breaking `main.js`.