### PR TITLE
Add mockClassSpec to mockComponent

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -223,15 +223,20 @@ var ReactTestUtils = {
    *
    * @param {object} module the mock function object exported from a
    *                        module that defines the component to be mocked
+   * @param {?object} mockClassSpec optional spec for the mock component
+   *                                that allows you to mock the component's
+   *                                properties and methods (so you can
+   *                                assert them in tests)
    * @param {?string} mockTagName optional dummy root tag name to return
    *                              from render method (overrides
    *                              module.mockTagName if provided)
    * @return {object} the ReactTestUtils object (for chaining)
    */
-  mockComponent: function(module, mockTagName) {
+  mockComponent: function(module, mockClassSpec, mockTagName) {
     mockTagName = mockTagName || module.mockTagName || "div";
+    mockClassSpec = mockClassSpec || {};
 
-    var ConvenienceConstructor = React.createClass({
+    var convenienceConstructorSpec = assign({
       render: function() {
         return React.createElement(
           mockTagName,
@@ -239,8 +244,9 @@ var ReactTestUtils = {
           this.props.children
         );
       }
-    });
+    }, mockClassSpec);
 
+    var ConvenienceConstructor = React.createClass(convenienceConstructorSpec);
     module.mockImplementation(ConvenienceConstructor);
 
     module.type = ConvenienceConstructor.type;


### PR DESCRIPTION
Currently, `TestUtils.mockComponent` does not allow for assertions of mock properties and methods. This is useful for the testing of refs. For example:
```
var Child = React.createClass({
  childFn: function() { ... },
  render: function() { ... }
});

var Parent = React.createClass({
  parentFn: function() {
    // This function is currently not testable
    this.refs['child'].childFn();
  },

  render: function() {
    return <Child ref="child" />;
  }
});
```

This pull request allows you to write a test like this:
```
jest.dontMock('Parent');

it('calls childFn', function() {
  // Assuming we are using jest, this is a mock
  var Child = require('Child');
  var mockChildFn = jest.genMockFn();
  TestUtils.mockComponent(Child, { childFn: mockChildFn }, 'mockChild');
  
  var Parent = require('Parent');
  var parent = TestUtils.renderIntoDocument(<Parent />);

  parent.parentFn();
  expect(mockChildFn).toBeCalled();
});
```

This is my first PR, and I've completed the FB CLA.