### PR TITLE
[Blog] Fix post code snippet display

### DIFF
--- a/docs/_posts/2015-02-24-streamlining-react-elements.md
+++ b/docs/_posts/2015-02-24-streamlining-react-elements.md
@@ -162,7 +162,7 @@ In 0.13 we introduced a new callback-refs API that doesn’t suffer from these p
 In React 0.12, and earlier, you could use keyed objects to provide an external key to an element or a set. This pattern isn’t actually widely used. It shouldn’t be an issue for most of you.
 
 ```js
-<div>{{ a: <span />, b: <span /> }}</div>
+<div>{ {a: <span />, b: <span />} }</div>
 ```
 
 ### Problem: Relies on Enumeration Order


### PR DESCRIPTION
I think nokogiri (is that what we use?) accidentally escaped this
snippet. Simply putting spaces between braces fixes it.