### PR TITLE
XJS -> JSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "commoner": "^0.10.0",
-    "jstransform": "^9.1.1"
+    "jstransform": "^10.0.0"
   },
   "devDependencies": {
     "benchmark": "~1.0.0",
@@ -41,7 +41,7 @@
     "es3ify": "~0.1.2",
     "es5-shim": "^4.0.0",
     "eslint": "^0.14.1",
-    "esprima-fb": "^12001.1.0-dev-harmony-fb",
+    "esprima-fb": "^13001.1.0-dev-harmony-fb",
     "grunt": "~0.4.2",
     "grunt-cli": "~0.1.9",
     "grunt-compare-size": "~0.4.0",

--- a/vendor/fbtransform/transforms/jsx.js
+++ b/vendor/fbtransform/transforms/jsx.js
@@ -11,7 +11,7 @@
 var Syntax = require('jstransform').Syntax;
 var utils = require('jstransform/src/utils');
 
-function renderXJSLiteral(object, isLast, state, start, end) {
+function renderJSXLiteral(object, isLast, state, start, end) {
   var lines = object.value.split(/\r\n|\n|\r/);
 
   if (start) {
@@ -75,13 +75,13 @@ function renderXJSLiteral(object, isLast, state, start, end) {
   utils.move(object.range[1], state);
 }
 
-function renderXJSExpressionContainer(traverse, object, isLast, path, state) {
+function renderJSXExpressionContainer(traverse, object, isLast, path, state) {
   // Plus 1 to skip `{`.
   utils.move(object.range[0] + 1, state);
   utils.catchup(object.expression.range[0], state);
   traverse(object.expression, path, state);
 
-  if (!isLast && object.expression.type !== Syntax.XJSEmptyExpression) {
+  if (!isLast && object.expression.type !== Syntax.JSXEmptyExpression) {
     // If we need to append a comma, make sure to do so after the expression.
     utils.catchup(object.expression.range[1], state, trimLeft);
     utils.append(', ', state);
@@ -105,7 +105,7 @@ function trimLeft(value) {
   return value.replace(/^[ ]+/, '');
 }
 
-exports.renderXJSExpressionContainer = renderXJSExpressionContainer;
-exports.renderXJSLiteral = renderXJSLiteral;
+exports.renderJSXExpressionContainer = renderJSXExpressionContainer;
+exports.renderJSXLiteral = renderJSXLiteral;
 exports.quoteAttrName = quoteAttrName;
 exports.trimLeft = trimLeft;

--- a/vendor/fbtransform/transforms/react.js
+++ b/vendor/fbtransform/transforms/react.js
@@ -12,12 +12,12 @@
 var Syntax = require('jstransform').Syntax;
 var utils = require('jstransform/src/utils');
 
-var renderXJSExpressionContainer =
-  require('./xjs').renderXJSExpressionContainer;
-var renderXJSLiteral = require('./xjs').renderXJSLiteral;
-var quoteAttrName = require('./xjs').quoteAttrName;
+var renderJSXExpressionContainer =
+  require('./jsx').renderJSXExpressionContainer;
+var renderJSXLiteral = require('./jsx').renderJSXLiteral;
+var quoteAttrName = require('./jsx').quoteAttrName;
 
-var trimLeft = require('./xjs').trimLeft;
+var trimLeft = require('./jsx').trimLeft;
 
 /**
  * Customized desugar processor for React JSX. Currently:
@@ -50,20 +50,20 @@ function visitReactTag(traverse, object, path, state) {
 
   utils.catchup(openingElement.range[0], state, trimLeft);
 
-  if (nameObject.type === Syntax.XJSNamespacedName && nameObject.namespace) {
+  if (nameObject.type === Syntax.JSXNamespacedName && nameObject.namespace) {
     throw new Error('Namespace tags are not supported. ReactJSX is not XML.');
   }
 
   // We assume that the React runtime is already in scope
   utils.append('React.createElement(', state);
 
-  if (nameObject.type === Syntax.XJSIdentifier && isTagName(nameObject.name)) {
+  if (nameObject.type === Syntax.JSXIdentifier && isTagName(nameObject.name)) {
     utils.append('"' + nameObject.name + '"', state);
     utils.move(nameObject.range[1], state);
   } else {
     // Use utils.catchup in this case so we can easily handle
-    // XJSMemberExpressions which look like Foo.Bar.Baz. This also handles
-    // XJSIdentifiers that aren't fallback tags.
+    // JSXMemberExpressions which look like Foo.Bar.Baz. This also handles
+    // JSXIdentifiers that aren't fallback tags.
     utils.move(nameObject.range[0], state);
     utils.catchup(nameObject.range[1], state);
   }
@@ -73,7 +73,7 @@ function visitReactTag(traverse, object, path, state) {
   var hasAttributes = attributesObject.length;
 
   var hasAtLeastOneSpreadProperty = attributesObject.some(function(attr) {
-    return attr.type === Syntax.XJSSpreadAttribute;
+    return attr.type === Syntax.JSXSpreadAttribute;
   });
 
   // if we don't have any attributes, pass in null
@@ -92,7 +92,7 @@ function visitReactTag(traverse, object, path, state) {
   attributesObject.forEach(function(attr, index) {
     var isLast = index === attributesObject.length - 1;
 
-    if (attr.type === Syntax.XJSSpreadAttribute) {
+    if (attr.type === Syntax.JSXSpreadAttribute) {
       // Close the previous object or initial object
       if (!previousWasSpread) {
         utils.append('}, ', state);
@@ -125,7 +125,7 @@ function visitReactTag(traverse, object, path, state) {
 
     // If the next attribute is a spread, we're effective last in this object
     if (!isLast) {
-      isLast = attributesObject[index + 1].type === Syntax.XJSSpreadAttribute;
+      isLast = attributesObject[index + 1].type === Syntax.JSXSpreadAttribute;
     }
 
     if (attr.name.namespace) {
@@ -154,9 +154,9 @@ function visitReactTag(traverse, object, path, state) {
       // Use catchupNewlines to skip over the '=' in the attribute
       utils.catchupNewlines(attr.value.range[0], state);
       if (attr.value.type === Syntax.Literal) {
-        renderXJSLiteral(attr.value, isLast, state);
+        renderJSXLiteral(attr.value, isLast, state);
       } else {
-        renderXJSExpressionContainer(traverse, attr.value, isLast, path, state);
+        renderJSXExpressionContainer(traverse, attr.value, isLast, path, state);
       }
     }
 
@@ -189,8 +189,8 @@ function visitReactTag(traverse, object, path, state) {
     var lastRenderableIndex;
 
     childrenToRender.forEach(function(child, index) {
-      if (child.type !== Syntax.XJSExpressionContainer ||
-          child.expression.type !== Syntax.XJSEmptyExpression) {
+      if (child.type !== Syntax.JSXExpressionContainer ||
+          child.expression.type !== Syntax.JSXEmptyExpression) {
         lastRenderableIndex = index;
       }
     });
@@ -205,9 +205,9 @@ function visitReactTag(traverse, object, path, state) {
       var isLast = index >= lastRenderableIndex;
 
       if (child.type === Syntax.Literal) {
-        renderXJSLiteral(child, isLast, state);
-      } else if (child.type === Syntax.XJSExpressionContainer) {
-        renderXJSExpressionContainer(traverse, child, isLast, path, state);
+        renderJSXLiteral(child, isLast, state);
+      } else if (child.type === Syntax.JSXExpressionContainer) {
+        renderJSXExpressionContainer(traverse, child, isLast, path, state);
       } else {
         traverse(child, path, state);
         if (!isLast) {
@@ -234,7 +234,7 @@ function visitReactTag(traverse, object, path, state) {
 }
 
 visitReactTag.test = function(object, path, state) {
-  return object.type === Syntax.XJSElement;
+  return object.type === Syntax.JSXElement;
 };
 
 exports.visitorList = [


### PR DESCRIPTION
This is the piece we need to bring into React. We need to do a couple things first before we can merge this (and this will need a small update too).

- [x] https://github.com/facebook/esprima/pull/85
- [x] ship updated esprima
- [x] ship updated jstransform using updated esprima
- [x] update our deps (we pull `Syntax` from the re-exported object in `jstransform`, so we only have to update that for this. We also depend on esprima-fb directly so we can use it in eslint... once we do that we can probably autolint our tests)

I tested this by using `npm link` and running our transform tests.