### PR TITLE
Fix issue with bind in IE8

### DIFF
--- a/src/browser/ui/dom/HTMLDOMPropertyConfig.js
+++ b/src/browser/ui/dom/HTMLDOMPropertyConfig.js
@@ -41,9 +41,9 @@ if (ExecutionEnvironment.canUseDOM) {
 
 
 var HTMLDOMPropertyConfig = {
-  isCustomAttribute: RegExp.prototype.test.bind(
-    /^(data|aria)-[a-z_][a-z\d_.\-]*$/
-  ),
+  isCustomAttribute: function (str) {
+    return /^(data|aria)-[a-z_][a-z\d_.\-]*$/.test(str);
+  },
   Properties: {
     /**
      * Standard Properties


### PR DESCRIPTION
I was getting the following error in IE8:

`Function does not have a valid prototype object`

I'm using an ES5 `bind` polyfill ([core-js](https://github.com/zloirock/core-js) via [Babel](https://babeljs.io)) and the exception was being thrown in IE8 here:

https://github.com/zloirock/core-js/blob/26fcc125a430e5b8f8860733df281a1387c9aaab/src/es5.js#L126

`this` was an instance of `[object DispHTMLWindow2]` and I guess calling `instanceof` on it causes that error.  This change seemed to do the trick but I don't entirely understand the issue.