### PR TITLE
Use ES6 static get methods for propTypes and similar class properties

### DIFF
--- a/docs/_posts/2015-01-27-react-v0.13.0-beta-1.md
+++ b/docs/_posts/2015-01-27-react-v0.13.0-beta-1.md
@@ -33,13 +33,19 @@ class HelloMessage extends React.Component {
 React.render(<HelloMessage name="Sebastian" />, mountNode);
 ```
 
-The API is mostly what you would expect, with the exception for `getInitialState`. We figured that the idiomatic way to specify class state is to just use a simple instance property. Likewise `getDefaultProps` and `propTypes` are really just properties on the constructor.
+The API is mostly what you would expect, with the exception for `getInitialState`. We figured that the idiomatic way to specify class state is to just use a simple instance property. Likewise `getDefaultProps` and `propTypes` can be retrieved using static get methods.
 
 ```javascript
 export class Counter extends React.Component {
   constructor(props) {
     super(props);
     this.state = {count: props.initialCount};
+  }
+  static get propTypes() {
+    return { initialCount: React.PropTypes.number };
+  }
+  static get defaultProps() {
+    return { initialCount: 0 };
   }
   tick() {
     this.setState({count: this.state.count + 1});
@@ -52,8 +58,6 @@ export class Counter extends React.Component {
     );
   }
 }
-Counter.propTypes = { initialCount: React.PropTypes.number };
-Counter.defaultProps = { initialCount: 0 };
 ```
 
 ### ES7+ Property Initializers

--- a/src/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/src/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -292,6 +292,37 @@ describe 'ReactCoffeeScriptClass', ->
       'contextTypes was defined as an instance property on Foo.'
     )
 
+  it 'does not warn when properties match propTypes', ->
+    spyOn console, 'warn'
+    class Foo extends React.Component
+      @propTypes: {
+        bar: React.PropTypes.string.isRequired
+      }
+
+      render: ->
+        span
+          className: 'foo'
+
+    test React.createElement(Foo, { bar: 'hello' }), 'SPAN', 'foo'
+    expect(console.warn.calls.length).toBe 0
+
+  it 'warns when properties do not match propTypes', ->
+    spyOn console, 'warn'
+    class Foo extends React.Component
+      @propTypes: {
+        bar: React.PropTypes.string.isRequired
+      }
+
+      render: ->
+        span
+          className: 'foo'
+
+    test React.createElement(Foo), 'SPAN', 'foo'
+    expect(console.warn.calls.length).toBe 1
+    expect(console.warn.calls[0].args[0]).toContain(
+      'Warning: Failed propType: Required prop `bar` was not specified in `Foo`.'
+    )
+
   it 'should warn when mispelling shouldComponentUpdate', ->
     spyOn console, 'warn'
     class NamedComponent

--- a/src/modern/class/__tests__/ReactES6Class-test.js
+++ b/src/modern/class/__tests__/ReactES6Class-test.js
@@ -104,17 +104,27 @@ describe('ReactES6Class', function() {
         super(props, context);
         this.state = {tag: context.tag, className: this.context.className};
       }
+
+      static get contextTypes() {
+        return {
+          tag: React.PropTypes.string,
+          className: React.PropTypes.string
+        };
+      }
+
       render() {
         var Tag = this.state.tag;
         return <Tag className={this.state.className} />;
       }
     }
-    Foo.contextTypes = {
-      tag: React.PropTypes.string,
-      className: React.PropTypes.string
-    };
 
     class Outer extends React.Component {
+      static get childContextTypes() {
+        return {
+          tag: React.PropTypes.string,
+          className: React.PropTypes.string
+        };
+      }
       getChildContext() {
         return {tag: 'span', className: 'foo'};
       }
@@ -122,10 +132,6 @@ describe('ReactES6Class', function() {
         return <Foo />;
       }
     }
-    Outer.childContextTypes = {
-      tag: React.PropTypes.string,
-      className: React.PropTypes.string
-    };
     test(<Outer />, 'SPAN', 'foo');
   });
 
@@ -322,6 +328,41 @@ describe('ReactES6Class', function() {
     );
     expect(console.warn.calls[2].args[0]).toContain(
       'contextTypes was defined as an instance property on Foo.'
+    );
+  });
+
+  it('does not warn when properties match propTypes', function() {
+    spyOn(console, 'warn');
+    class Foo extends React.Component {
+      static get propTypes() {
+        return {
+          bar: React.PropTypes.string.isRequired
+        };
+      }
+      render() {
+        return <span className="foo" />;
+      }
+    }
+    test(<Foo bar='hello'/>, 'SPAN', 'foo');
+    expect(console.warn.calls.length).toBe(0);
+  });
+
+  it('warns when properties do not match propTypes', function() {
+    spyOn(console, 'warn');
+    class Foo extends React.Component {
+      static get propTypes() {
+        return {
+          bar: React.PropTypes.string.isRequired
+        };
+      }
+      render() {
+        return <span className="foo" />;
+      }
+    }
+    test(<Foo />, 'SPAN', 'foo');
+    expect(console.warn.calls.length).toBe(1);
+    expect(console.warn.calls[0].args[0]).toContain(
+      'Warning: Failed propType: Required prop `bar` was not specified in `Foo`.'
     );
   });
 

--- a/src/modern/class/__tests__/ReactTypeScriptClass-test.ts
+++ b/src/modern/class/__tests__/ReactTypeScriptClass-test.ts
@@ -247,6 +247,26 @@ class ClassicProperties extends React.Component {
   }
 }
 
+// does not warn when properties match propTypes
+class PropTypesMatch extends React.Component {
+  static propTypes = {
+    bar: React.PropTypes.string.isRequired
+  }
+  render() {
+    return React.createElement('span', { className: 'foo' });
+  }
+}
+
+// warns when properties do not match propTypes
+class PropTypesMismatch extends React.Component {
+  static propTypes = {
+    bar: React.PropTypes.string.isRequired
+  }
+  render() {
+    return React.createElement('span', { className: 'foo' });
+  }
+}
+
 // it should warn when mispelling shouldComponentUpdate
 class NamedComponent {
   componentShouldUpdate() {
@@ -422,6 +442,23 @@ describe('ReactTypeScriptClass', function() {
     );
     expect(warn.mock.calls[2][0]).toContain(
       'contextTypes was defined as an instance property on ClassicProperties.'
+    );
+  });
+
+  it('does not warn when properties match propTypes', function() {
+    var warn = jest.genMockFn();
+    console.warn = warn;
+    test(React.createElement(PropTypesMatch, { bar: 'hello'}), 'SPAN', 'foo');
+    expect(warn.mock.calls.length).toBe(0);
+  });
+
+  it('warns when properties do not match propTypes', function() {
+    var warn = jest.genMockFn();
+    console.warn = warn;
+    test(React.createElement(PropTypesMismatch), 'SPAN', 'foo');
+    expect(warn.mock.calls.length).toBe(1);
+    expect(warn.mock.calls[0][0]).toContain(
+      'Warning: Failed propType: Required prop `bar` was not specified in `PropTypesMismatch`.'
     );
   });
 


### PR DESCRIPTION
I believe that we can use ES6 static get methods for propTypes, defaultProps, contextTypes, childContextTypes, and getChildContext rather than setting properties on the constructor.

This keeps everything neatly inside the class definition.

```javascript
    class Foo extends React.Component {
      static get propTypes() {
        return {
          bar: React.PropTypes.string.isRequired
        };
      }
      render() {
        return <span className="foo" />;
      }
    }
```

I have updated the example in the blog and added a few tests.
