### PR TITLE
Added callback chain in TransitionGroup addon

### DIFF
--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -169,7 +169,7 @@ var ReactTransitionGroup = React.createClass({
     if (component.componentWillLeave) {
       component.componentWillLeave(this._handleDoneLeaving.bind(this, key));
     } else {
-      if(this.queue.length === 0){
+      if (this.queue.length === 0) {
         this._handleDoneLeaving(key);
         // Add your own key.
         // This was just to know that there is an async call going,
@@ -182,10 +182,10 @@ var ReactTransitionGroup = React.createClass({
     }
   },
   // Calls the next _handleDoneLeaving after the previous was removed.
-  _handleNextDoneLeaving: function(){
+  _handleNextDoneLeaving: function() {
     // Remove our own key first
     this.queue.shift();
-    if(this.queue.length !== 0){
+    if (this.queue.length !== 0) {
       this._handleDoneLeaving(this.queue[0]);
     }
   },


### PR DESCRIPTION
This added to prevent that the state gets updated before the last changes was not yet processed.
This should close #3111.

Honestly I could not create an unit tests which reproduces the fault as described in #3111. If someone could point me in the right direction, I will extend this issue with the necessary unit tests.

I tested this through play testing. Builded, created a single html page as given in the jsfiddle in #3111 and tested it like that. 