### PR TITLE
Call componentWill* methods in reverse order

### DIFF
--- a/src/classic/class/ReactClass.js
+++ b/src/classic/class/ReactClass.js
@@ -43,6 +43,12 @@ var SpecPolicy = keyMirror({
    */
   DEFINE_MANY: null,
   /**
+   * These methods may be defined by both the class specification and mixins.
+   * Subsequent definitions will be chained, but are called in reverse order of
+   * their order when being mixed in. These methods must return void.
+   */
+  DEFINE_MANY_REVERSED: null,
+  /**
    * These methods are overriding the base class.
    */
   OVERRIDE_BASE: null,
@@ -187,7 +193,7 @@ var ReactClassInterface = {
    *
    * @optional
    */
-  componentWillMount: SpecPolicy.DEFINE_MANY,
+  componentWillMount: SpecPolicy.DEFINE_MANY_REVERSED,
 
   /**
    * Invoked when the component has been mounted and has a DOM representation.
@@ -220,7 +226,7 @@ var ReactClassInterface = {
    * @param {object} nextProps
    * @optional
    */
-  componentWillReceiveProps: SpecPolicy.DEFINE_MANY,
+  componentWillReceiveProps: SpecPolicy.DEFINE_MANY_REVERSED,
 
   /**
    * Invoked while deciding if the component should be updated as a result of
@@ -259,7 +265,7 @@ var ReactClassInterface = {
    * @param {ReactReconcileTransaction} transaction
    * @optional
    */
-  componentWillUpdate: SpecPolicy.DEFINE_MANY,
+  componentWillUpdate: SpecPolicy.DEFINE_MANY_REVERSED,
 
   /**
    * Invoked when the component's DOM representation has been updated.
@@ -286,7 +292,7 @@ var ReactClassInterface = {
    *
    * @optional
    */
-  componentWillUnmount: SpecPolicy.DEFINE_MANY,
+  componentWillUnmount: SpecPolicy.DEFINE_MANY_REVERSED,
 
 
 
@@ -424,7 +430,8 @@ function validateMethodOverride(proto, name) {
   if (proto.hasOwnProperty(name)) {
     invariant(
       specPolicy === SpecPolicy.DEFINE_MANY ||
-      specPolicy === SpecPolicy.DEFINE_MANY_MERGED,
+      specPolicy === SpecPolicy.DEFINE_MANY_MERGED ||
+      specPolicy === SpecPolicy.DEFINE_MANY_REVERSED,
       'ReactClassInterface: You are attempting to define ' +
       '`%s` on your component more than once. This conflict may be due ' +
       'to a mixin.',
@@ -506,8 +513,9 @@ function mixSpecIntoComponent(Constructor, spec) {
           // These cases should already be caught by validateMethodOverride
           invariant(
             isReactClassMethod && (
+              specPolicy === SpecPolicy.DEFINE_MANY ||
               specPolicy === SpecPolicy.DEFINE_MANY_MERGED ||
-              specPolicy === SpecPolicy.DEFINE_MANY
+              specPolicy === SpecPolicy.DEFINE_MANY_REVERSED
             ),
             'ReactClass: Unexpected spec policy %s for key %s ' +
             'when mixing in component specs.',
@@ -521,6 +529,8 @@ function mixSpecIntoComponent(Constructor, spec) {
             proto[name] = createMergedResultFunction(proto[name], property);
           } else if (specPolicy === SpecPolicy.DEFINE_MANY) {
             proto[name] = createChainedFunction(proto[name], property);
+          } else if (specPolicy === SpecPolicy.DEFINE_MANY_REVERSED) {
+            proto[name] = createChainedFunction(property, proto[name]);
           }
         } else {
           proto[name] = property;

--- a/src/classic/class/__tests__/ReactClassMixin-test.js
+++ b/src/classic/class/__tests__/ReactClassMixin-test.js
@@ -38,6 +38,9 @@ describe('ReactClass-mixin', function() {
       },
       componentDidMount: function() {
         this.props.listener('MixinA didMount');
+      },
+      componentWillUnmount: function() {
+        this.props.listener('MixinA willUnmount');
       }
     };
 
@@ -48,12 +51,18 @@ describe('ReactClass-mixin', function() {
       },
       componentDidMount: function() {
         this.props.listener('MixinB didMount');
+      },
+      componentWillUnmount: function() {
+        this.props.listener('MixinB willUnmount');
       }
     };
 
     var MixinBWithReverseSpec = {
       componentDidMount: function() {
         this.props.listener('MixinBWithReverseSpec didMount');
+      },
+      componentWillUnmount: function() {
+        this.props.listener('MixinBWithReverseSpec willUnmount');
       },
       mixins: [MixinA]
     };
@@ -64,6 +73,9 @@ describe('ReactClass-mixin', function() {
       },
       componentDidMount: function() {
         this.props.listener('MixinC didMount');
+      },
+      componentWillUnmount: function() {
+        this.props.listener('MixinC willUnmount');
       }
     };
 
@@ -84,6 +96,9 @@ describe('ReactClass-mixin', function() {
       componentDidMount: function() {
         this.props.listener('Component didMount');
       },
+      componentWillUnmount: function() {
+        this.props.listener('Component willUnmount');
+      },
       render: function() {
         return <div />;
       }
@@ -95,6 +110,9 @@ describe('ReactClass-mixin', function() {
       },
       componentDidMount: function() {
         this.props.listener('Component didMount');
+      },
+      componentWillUnmount: function() {
+        this.props.listener('Component willUnmount');
       },
       mixins: [MixinBWithReverseSpec, MixinC, MixinD]
     });
@@ -127,27 +145,39 @@ describe('ReactClass-mixin', function() {
 
   it('should support chaining delegate functions', function() {
     var listener = mocks.getMockFunction();
+    var container = document.createElement('div');
     var instance = <TestComponent listener={listener} />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
+    instance = React.render(instance, container);
+    React.unmountComponentAtNode(container);
 
     expect(listener.mock.calls).toEqual([
       ['MixinA didMount'],
       ['MixinB didMount'],
       ['MixinC didMount'],
-      ['Component didMount']
+      ['Component didMount'],
+      ['Component willUnmount'],
+      ['MixinC willUnmount'],
+      ['MixinB willUnmount'],
+      ['MixinA willUnmount']
     ]);
   });
 
   it('should chain functions regardless of spec property order', function() {
     var listener = mocks.getMockFunction();
+    var container = document.createElement('div');
     var instance = <TestComponentWithReverseSpec listener={listener} />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
+    instance = React.render(instance, container);
+    React.unmountComponentAtNode(container);
 
     expect(listener.mock.calls).toEqual([
       ['MixinA didMount'],
       ['MixinBWithReverseSpec didMount'],
       ['MixinC didMount'],
-      ['Component didMount']
+      ['Component didMount'],
+      ['Component willUnmount'],
+      ['MixinC willUnmount'],
+      ['MixinBWithReverseSpec willUnmount'],
+      ['MixinA willUnmount']
     ]);
   });
 


### PR DESCRIPTION
This ordering mirrors what you would see if each mixin was implemented as a wrapper component instead of a mixin, and allows any setup and teardown routines to see the component in a consistent state.

Fixes #2789.