### PR TITLE
Add a note about setState and componentWillUnmount

### DIFF
--- a/docs/docs/ref-03-component-specs.md
+++ b/docs/docs/ref-03-component-specs.md
@@ -213,3 +213,7 @@ componentWillUnmount()
 Invoked immediately before a component is unmounted from the DOM.
 
 Perform any necessary cleanup in this method, such as invalidating timers or cleaning up any DOM elements that were created in `componentDidMount`.
+
+> Note:
+>
+> You *cannot* use `this.setState()` in this method.


### PR DESCRIPTION
I don’t believe that calling `this.setState()` is allowed in a componentWillUnmount call.

(At least, that’s been my experience during the development process.)