### PR TITLE
Check that console exists before warning

### DIFF
--- a/src/vendor/core/warning.js
+++ b/src/vendor/core/warning.js
@@ -45,7 +45,9 @@ if (__DEV__) {
     if (!condition) {
       var argIndex = 0;
       var message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
-      console.warn(message);
+      if (typeof console !== 'undefined') {
+        console.warn(message);
+      }
       try {
         // --- Welcome to debugging React ---
         // This error was thrown as a convenience so that you can use this stack


### PR DESCRIPTION
`console` is `undefined` in earlier versions of IE when it is not open. This causes an uncaught exception, and breaks applications in these versions of IE when attempting to `warn` while the  console is closed.
Admittedly, `console` will usually be open when testing in development, but still, React should not break the application when it is not. I often fire up IE 9 to do quick smoke tests in development and don't bother to open the `console`.
This just adds a check in `warning.js` that `console` exists before calling `warn` on it.