### PR TITLE
Add support for the svg cursor attribute

### DIFF
--- a/src/renderers/dom/shared/SVGDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/SVGDOMPropertyConfig.js
@@ -23,6 +23,7 @@ var NS = {
 var SVGDOMPropertyConfig = {
   Properties: {
     clipPath: MUST_USE_ATTRIBUTE,
+    cursor: MUST_USE_ATTRIBUTE,
     cx: MUST_USE_ATTRIBUTE,
     cy: MUST_USE_ATTRIBUTE,
     d: MUST_USE_ATTRIBUTE,


### PR DESCRIPTION
React strips the `cursor` attribute from svg elements. This PR just adds it to the list of supported svg attributes. 

See docs [here](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/cursor)

It is not possible to style the cursor on svg elements with css. So this is a limiting factor when using svg to draw portions of a UI.