### PR TITLE
Allow null and undefined values in non-frag object passed to PropTypes.node

### DIFF
--- a/src/classic/types/ReactPropTypes.js
+++ b/src/classic/types/ReactPropTypes.js
@@ -292,6 +292,7 @@ function isNode(propValue) {
   switch (typeof propValue) {
     case 'number':
     case 'string':
+    case 'undefined':
       return true;
     case 'boolean':
       return !propValue;
@@ -299,7 +300,7 @@ function isNode(propValue) {
       if (Array.isArray(propValue)) {
         return propValue.every(isNode);
       }
-      if (ReactElement.isValidElement(propValue)) {
+      if (propValue === null || ReactElement.isValidElement(propValue)) {
         return true;
       }
       propValue = ReactFragment.extractIfFragment(propValue);

--- a/src/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/classic/types/__tests__/ReactPropTypes-test.js
@@ -384,7 +384,9 @@ describe('ReactPropTypes', function() {
           k30: <MyComponent />,
           k31: frag({k310: <a />}),
           k32: 'Another string'
-        })
+        }),
+        k4: null,
+        k5: undefined
       }));
       expect(console.warn.calls).toEqual([]);
 
@@ -397,7 +399,9 @@ describe('ReactPropTypes', function() {
           k30: <MyComponent />,
           k31: {k310: <a />},
           k32: 'Another string'
-        }
+        },
+        k4: null,
+        k5: undefined
       });
     });
 


### PR DESCRIPTION
Fixes #3328

This matches the behavior we already have as far as treating null and undefined as valid nodes. However that check happens in a much different place (see the `== null` check in `createChainableTypeChecker`). We're going recursive in `isNode` when we hit a fragment and we can't really combine these in a nice sane way so we special case them.