### PR TITLE
[Docs] Add 'ing' to make "opening" and "closing" line up

### DIFF
--- a/docs/docs/02.1-jsx-in-depth.md
+++ b/docs/docs/02.1-jsx-in-depth.md
@@ -14,7 +14,7 @@ You don't have to use JSX with React. You can just use plain JS. However, we rec
 
 It's more familiar for casual developers such as designers.
 
-XML has the benefit of balanced open and closing tags. This helps make large trees easier to read than function calls or object literals.
+XML has the benefit of balanced opening and closing tags. This helps make large trees easier to read than function calls or object literals.
 
 It doesn't alter the semantics of JavaScript.
 


### PR DESCRIPTION
Summary:
Docs-only grammar change.

Test Plan:
None