### PR TITLE
Allow extraction of primatives from ReactFragment.extract*

### DIFF
--- a/src/addons/ReactFragment.js
+++ b/src/addons/ReactFragment.js
@@ -136,7 +136,7 @@ var ReactFragment = {
   // a plain object is passed here.
   extract: function(fragment) {
     if (__DEV__) {
-      if (canWarnForReactFragment) {
+      if (canWarnForReactFragment && fragment instanceof Object) {
         if (!fragment[fragmentKey]) {
           warning(
             didWarnForFragment(fragment),
@@ -156,7 +156,7 @@ var ReactFragment = {
   // can't determine what kind of object this is.
   extractIfFragment: function(fragment) {
     if (__DEV__) {
-      if (canWarnForReactFragment) {
+      if (canWarnForReactFragment && fragment instanceof Object) {
         // If it is the opaque type, return the keyed object.
         if (fragment[fragmentKey]) {
           return fragment[fragmentKey];

--- a/src/addons/__tests__/ReactFragment-test.js
+++ b/src/addons/__tests__/ReactFragment-test.js
@@ -101,4 +101,26 @@ describe('ReactFragment', function() {
     );
   });
 
+  it('should extract from primitives', function() {
+    [
+      null,
+      undefined,
+      0,
+      5,
+      true,
+      false,
+      'string'
+    ].forEach(function(v) {
+      expect(function() {
+        ReactFragment.extract(v);
+      }).not.toThrow();
+
+      expect(function() {
+        ReactFragment.extractIfFragment(v);
+      }).not.toThrow();
+
+      expect(ReactFragment.extract(v)).toEqual(v);
+      expect(ReactFragment.extractIfFragment(v)).toEqual(v);
+    });
+  });
 });

--- a/src/classic/types/ReactPropTypes.js
+++ b/src/classic/types/ReactPropTypes.js
@@ -292,6 +292,7 @@ function isNode(propValue) {
   switch (typeof propValue) {
     case 'number':
     case 'string':
+    case 'undefined':
       return true;
     case 'boolean':
       return !propValue;
@@ -299,7 +300,7 @@ function isNode(propValue) {
       if (Array.isArray(propValue)) {
         return propValue.every(isNode);
       }
-      if (ReactElement.isValidElement(propValue)) {
+      if (propValue === null || ReactElement.isValidElement(propValue)) {
         return true;
       }
       propValue = ReactFragment.extractIfFragment(propValue);

--- a/src/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/classic/types/__tests__/ReactPropTypes-test.js
@@ -384,7 +384,9 @@ describe('ReactPropTypes', function() {
           k30: <MyComponent />,
           k31: frag({k310: <a />}),
           k32: 'Another string'
-        })
+        }),
+        k4: null,
+        k5: undefined
       }));
       expect(console.warn.calls).toEqual([]);
 
@@ -397,7 +399,9 @@ describe('ReactPropTypes', function() {
           k30: <MyComponent />,
           k31: {k310: <a />},
           k32: 'Another string'
-        }
+        },
+        k4: null,
+        k5: undefined
       });
     });
 


### PR DESCRIPTION
We already allow it but this ensures that we allow it in `__DEV__` too.