### PR TITLE
"Better" duck typing in reactComponentExpect

### DIFF
--- a/src/test/reactComponentExpect.js
+++ b/src/test/reactComponentExpect.js
@@ -125,8 +125,7 @@ assign(reactComponentExpectInternal.prototype, {
   toBeCompositeComponent: function() {
     expect(
       typeof this.instance() === 'object' &&
-      typeof this.instance().render === 'function' &&
-      typeof this.instance().setState === 'function'
+      typeof this.instance().render === 'function'
     ).toBe(true);
     return this;
   },


### PR DESCRIPTION
`setState` is not a requirement for an ES6 react class instance.