### PR TITLE
Add documentation about JSX and displayName.

### DIFF
--- a/docs/docs/02.1-jsx-in-depth.md
+++ b/docs/docs/02.1-jsx-in-depth.md
@@ -73,6 +73,15 @@ var app = React.createElement(
 );
 ```
 
+JSX will infer the class's [displayName](/react/docs/component-specs.html#displayName) from the variable assignment when the displayName is undefined:
+
+```javascript
+// Input (JSX):
+var Nav = React.createClass({ });
+// Output (JS):
+var Nav = React.createClass({displayName: "Nav", });
+```
+
 Use the [JSX Compiler](/react/jsx-compiler.html) to try out JSX and see how it
 desugars into native JavaScript, and the
 [HTML to JSX converter](/react/html-jsx.html) to convert your existing HTML to

--- a/docs/docs/ref-03-component-specs.md
+++ b/docs/docs/ref-03-component-specs.md
@@ -95,7 +95,7 @@ Methods defined within this block are _static_, meaning that you can run them be
 string displayName
 ```
 
-The `displayName` string is used in debugging messages. JSX sets this value automatically; see [JSX in Depth](/react/docs/jsx-in-depth.html#react-composite-components).
+The `displayName` string is used in debugging messages. JSX sets this value automatically; see [JSX in Depth](/react/docs/jsx-in-depth.html#the-transform).
 
 
 ## Lifecycle Methods


### PR DESCRIPTION
The section that described how JSX transform handles displayName was lost in commit 9b1ee4de4636fcc9af1cf93099e062a3f6eb96f5

Fixes #3338