### PR TITLE
Add onContextMenu to events doc

### DIFF
--- a/docs/docs/ref-05-events.md
+++ b/docs/docs/ref-05-events.md
@@ -112,8 +112,8 @@ For more information about the onChange event, see [Forms](/react/docs/forms.htm
 Event names:
 
 ```
-onClick onDoubleClick onDrag onDragEnd onDragEnter onDragExit onDragLeave
-onDragOver onDragStart onDrop onMouseDown onMouseEnter onMouseLeave
+onClick onContextMenu onDoubleClick onDrag onDragEnd onDragEnter onDragExit
+onDragLeave onDragOver onDragStart onDrop onMouseDown onMouseEnter onMouseLeave
 onMouseMove onMouseOut onMouseOver onMouseUp
 ```
 

--- a/docs/docs/ref-05-events.zh-CN.md
+++ b/docs/docs/ref-05-events.zh-CN.md
@@ -111,8 +111,8 @@ onChange onInput onSubmit
 事件名称：
 
 ```
-onClick onDoubleClick onDrag onDragEnd onDragEnter onDragExit onDragLeave
-onDragOver onDragStart onDrop onMouseDown onMouseEnter onMouseLeave
+onClick onContextMenu onDoubleClick onDrag onDragEnd onDragEnter onDragExit
+onDragLeave onDragOver onDragStart onDrop onMouseDown onMouseEnter onMouseLeave
 onMouseMove onMouseOut onMouseOver onMouseUp
 ```
 


### PR DESCRIPTION
Adds `onContextMenu` to the list of supported mouse events in the React documentation.

The event was implemented in 1ffe2d0927a395c53215fadb78ceffee99f87574 and works per [this JSFiddle](http://jsfiddle.net/BinaryMuse/860jytqb/).