### PR TITLE
Update derequire (and greatly improve build speed)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bundle-collapser": "^1.1.1",
     "coffee-script": "^1.8.0",
     "coverify": "~1.0.4",
-    "derequire": "^1.2.0",
+    "derequire": "^2.0.0",
     "envify": "^3.0.0",
     "es3ify": "~0.1.2",
     "es5-shim": "^4.0.0",


### PR DESCRIPTION
Just wrapped up a rewrite of [`derequire`](https://github.com/calvinmetcalf/derequire). It's **super** fast now (see https://github.com/calvinmetcalf/derequire/pull/26). Related: https://github.com/facebook/react/issues/1933 https://github.com/facebook/react/pull/2964.

Here are some samples from running `time grunt browserify`:

**Before:**
```
real	0m31.057s
user	0m30.734s
sys	0m0.664s
```

**After:**
```
real	0m17.412s
user	0m17.087s
sys	0m0.614s
```

