### PR TITLE
Fix addons.Perf displayName with ES6 classes

### DIFF
--- a/src/test/ReactDefaultPerf.js
+++ b/src/test/ReactDefaultPerf.js
@@ -242,17 +242,12 @@ var ReactDefaultPerf = {
           addValue(entry.inclusive, rootNodeID, totalTime);
         }
 
-        var displayName = null;
-        if (this._instance.constructor.displayName) {
-          displayName = this._instance.constructor.displayName;
-        } else if (this._currentElement.type) {
-          displayName = this._currentElement.type;
-        }
-
         entry.displayNames[rootNodeID] = {
-          current: displayName,
+          current: typeof this._currentElement.type === 'string' ?
+            this._currentElement.type :
+            this.getName(),
           owner: this._currentElement._owner ?
-            this._currentElement._owner._instance.constructor.displayName :
+            this._currentElement._owner.getName() :
             '<root>'
         };
 


### PR DESCRIPTION
React.addons.Perf uses with ES6 classes, displayName doesn't show correctly. 

* `React.createClass`
  * http://jsfiddle.net/koba04/qfwnr39c/3/

![create-class](https://dl.dropboxusercontent.com/u/6806786/screenshot/create-class.png)

* `ES6 classes`
  * http://jsfiddle.net/koba04/qfwnr39c/4/

![es6-classes](https://dl.dropboxusercontent.com/u/6806786/screenshot/es6-classes.png)

This pull request is fixing it.
Instead of this, should `ES6 classes` support `displayName` same as `React.createClass`?

We might want to be able to get component identifier through `getName` API on All component type(`DOMCompnent`, `CompositeComponent` and component created `ES6 classes`).

https://github.com/facebook/react/blob/master/src/core/ReactCompositeComponent.js#L827