### PR TITLE
Pass context to render in ReactCompositeComponent. Related to #1387

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -750,7 +750,7 @@ var ReactCompositeComponentMixin = {
    */
   _renderValidatedComponentWithoutOwnerOrContext: function() {
     var inst = this._instance;
-    var renderedComponent = inst.render();
+    var renderedComponent = inst.render(inst);
     if (__DEV__) {
       // We allow auto-mocks to proceed as if they're returning null.
       if (typeof renderedComponent === 'undefined' &&

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -954,4 +954,21 @@ describe('ReactCompositeComponent', function() {
     expect(a).toBe(b);
   });
 
+  it ('passes the instance into its render function', function() {
+    var Component = React.createClass({
+      getDefaultProps: function() {
+        return {
+          exists: 'yes'
+        }
+      },
+      render: function(context) {
+        return <p ref="answer">{ context.props.exists }</p>
+      }
+    });
+
+    var test = ReactTestUtils.renderIntoDocument(<Component />)
+
+    expect(test.refs.answer.getDOMNode().innerHTML).toEqual('yes')
+  })
+
 });


### PR DESCRIPTION
Not a super big deal, but I wanted to put some legs behind #1387.

I'm not really sure this is all that is required, but this change should allow `props` and `state` to be passed to the `render()` method by passing in the component instance:

```javascript
render({ props, state }) {
    return <p>{ props.thing }</p>
}
```