### PR TITLE
foo.getDOMNode => React.findDOMNode(foo)

### DIFF
--- a/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
@@ -36,7 +36,7 @@ describe('ReactCSSTransitionGroup', function() {
       </ReactCSSTransitionGroup>,
       container
     );
-    expect(a.getDOMNode().childNodes.length).toBe(1);
+    expect(React.findDOMNode(a).childNodes.length).toBe(1);
 
     setTimeout.mock.calls.length = 0;
 
@@ -46,9 +46,9 @@ describe('ReactCSSTransitionGroup', function() {
       </ReactCSSTransitionGroup>,
       container
     );
-    expect(a.getDOMNode().childNodes.length).toBe(2);
-    expect(a.getDOMNode().childNodes[0].id).toBe('two');
-    expect(a.getDOMNode().childNodes[1].id).toBe('one');
+    expect(React.findDOMNode(a).childNodes.length).toBe(2);
+    expect(React.findDOMNode(a).childNodes[0].id).toBe('two');
+    expect(React.findDOMNode(a).childNodes[1].id).toBe('one');
 
     // For some reason jst is adding extra setTimeout()s and grunt test isn't,
     // so we need to do this disgusting hack.
@@ -59,7 +59,7 @@ describe('ReactCSSTransitionGroup', function() {
       }
     }
 
-    expect(a.getDOMNode().childNodes.length).toBe(2);
+    expect(React.findDOMNode(a).childNodes.length).toBe(2);
     expect(console.warn.argsForCall.length).toBe(1);
   });
 
@@ -70,16 +70,16 @@ describe('ReactCSSTransitionGroup', function() {
       </ReactCSSTransitionGroup>,
       container
     );
-    expect(a.getDOMNode().childNodes.length).toBe(1);
+    expect(React.findDOMNode(a).childNodes.length).toBe(1);
     React.render(
       <ReactCSSTransitionGroup transitionName="yolo">
         <span key="two" id="two" />
       </ReactCSSTransitionGroup>,
       container
     );
-    expect(a.getDOMNode().childNodes.length).toBe(2);
-    expect(a.getDOMNode().childNodes[0].id).toBe('two');
-    expect(a.getDOMNode().childNodes[1].id).toBe('one');
+    expect(React.findDOMNode(a).childNodes.length).toBe(2);
+    expect(React.findDOMNode(a).childNodes[0].id).toBe('two');
+    expect(React.findDOMNode(a).childNodes[1].id).toBe('one');
   });
 
   it('should switch transitionLeave from false to true', function() {
@@ -92,7 +92,7 @@ describe('ReactCSSTransitionGroup', function() {
       </ReactCSSTransitionGroup>,
       container
     );
-    expect(a.getDOMNode().childNodes.length).toBe(1);
+    expect(React.findDOMNode(a).childNodes.length).toBe(1);
     React.render(
       <ReactCSSTransitionGroup
           transitionName="yolo"
@@ -102,7 +102,7 @@ describe('ReactCSSTransitionGroup', function() {
       </ReactCSSTransitionGroup>,
       container
     );
-    expect(a.getDOMNode().childNodes.length).toBe(1);
+    expect(React.findDOMNode(a).childNodes.length).toBe(1);
     React.render(
       <ReactCSSTransitionGroup
           transitionName="yolo"
@@ -112,9 +112,9 @@ describe('ReactCSSTransitionGroup', function() {
       </ReactCSSTransitionGroup>,
       container
     );
-    expect(a.getDOMNode().childNodes.length).toBe(2);
-    expect(a.getDOMNode().childNodes[0].id).toBe('three');
-    expect(a.getDOMNode().childNodes[1].id).toBe('two');
+    expect(React.findDOMNode(a).childNodes.length).toBe(2);
+    expect(React.findDOMNode(a).childNodes[0].id).toBe('three');
+    expect(React.findDOMNode(a).childNodes[1].id).toBe('two');
   });
 
   it('should work with no children', function() {
@@ -141,7 +141,7 @@ describe('ReactCSSTransitionGroup', function() {
       </ReactCSSTransitionGroup>,
       container
     );
-    expect(a.getDOMNode().childNodes.length).toBe(1);
+    expect(React.findDOMNode(a).childNodes.length).toBe(1);
     React.render(
       <ReactCSSTransitionGroup transitionName="yolo">
         {null}
@@ -150,8 +150,8 @@ describe('ReactCSSTransitionGroup', function() {
     );
     // (Here, we expect the original child to stick around but test that no
     // exception is thrown)
-    expect(a.getDOMNode().childNodes.length).toBe(1);
-    expect(a.getDOMNode().childNodes[0].id).toBe('one');
+    expect(React.findDOMNode(a).childNodes.length).toBe(1);
+    expect(React.findDOMNode(a).childNodes[0].id).toBe('one');
   });
 
   it('should transition from false to one', function() {
@@ -161,15 +161,15 @@ describe('ReactCSSTransitionGroup', function() {
       </ReactCSSTransitionGroup>,
       container
     );
-    expect(a.getDOMNode().childNodes.length).toBe(0);
+    expect(React.findDOMNode(a).childNodes.length).toBe(0);
     React.render(
       <ReactCSSTransitionGroup transitionName="yolo">
         <span key="one" id="one" />
       </ReactCSSTransitionGroup>,
       container
     );
-    expect(a.getDOMNode().childNodes.length).toBe(1);
-    expect(a.getDOMNode().childNodes[0].id).toBe('one');
+    expect(React.findDOMNode(a).childNodes.length).toBe(1);
+    expect(React.findDOMNode(a).childNodes[0].id).toBe('one');
   });
 
 });

--- a/src/browser/__tests__/ReactDOM-test.js
+++ b/src/browser/__tests__/ReactDOM-test.js
@@ -38,7 +38,7 @@ describe('ReactDOM', function() {
         return <form><input type="submit" value="Submit" /></form>;
       },
       componentDidMount: function() {
-        form = this.getDOMNode();
+        form = React.findDOMNode(this);
       }
     });
     var instance = ReactTestUtils.renderIntoDocument(<Parent />);
@@ -50,14 +50,14 @@ describe('ReactDOM', function() {
   it("allows a DOM element to be used with a string", function() {
     var element = React.createElement('div', {className: 'foo'});
     var instance = ReactTestUtils.renderIntoDocument(element);
-    expect(instance.getDOMNode().tagName).toBe('DIV');
+    expect(React.findDOMNode(instance).tagName).toBe('DIV');
   });
 
   it("should allow children to be passed as an argument", function() {
     var argDiv = ReactTestUtils.renderIntoDocument(
       div(null, 'child')
     );
-    var argNode = argDiv.getDOMNode();
+    var argNode = React.findDOMNode(argDiv);
     expect(argNode.innerHTML).toBe('child');
   });
 
@@ -65,7 +65,7 @@ describe('ReactDOM', function() {
     var conflictDiv = ReactTestUtils.renderIntoDocument(
       div({children: 'fakechild'}, 'child')
     );
-    var conflictNode = conflictDiv.getDOMNode();
+    var conflictNode = React.findDOMNode(conflictDiv);
     expect(conflictNode.innerHTML).toBe('child');
   });
 
@@ -107,7 +107,7 @@ describe('ReactDOM', function() {
         <div key="theBird" className="bird" />
       ]
     });
-    var root = myDiv.getDOMNode();
+    var root = React.findDOMNode(myDiv);
     var dog = root.childNodes[0];
     expect(dog.className).toBe('bigdog');
   });

--- a/src/browser/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
+++ b/src/browser/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
@@ -44,7 +44,7 @@ describe('EnterLeaveEventPlugin', function() {
     iframeDocument.close();
 
     var component = React.render(<div />, iframeDocument.body);
-    var div = component.getDOMNode();
+    var div = React.findDOMNode(component);
 
     var extracted = EnterLeaveEventPlugin.extractEvents(
       topLevelTypes.topMouseOver,

--- a/src/browser/server/__tests__/ReactServerRendering-test.js
+++ b/src/browser/server/__tests__/ReactServerRendering-test.js
@@ -225,7 +225,7 @@ describe('ReactServerRendering', function() {
 
       // Ensure the events system works
       expect(numClicks).toEqual(0);
-      ReactTestUtils.Simulate.click(instance.refs.span.getDOMNode());
+      ReactTestUtils.Simulate.click(React.findDOMNode(instance.refs.span));
       expect(numClicks).toEqual(1);
     });
 

--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -586,6 +586,7 @@ describe('ReactDOMComponent', function() {
       expect(
         ReactBrowserEventEmitter.getListener(rootNodeID, 'onClick')
       ).toBe(callback);
+      expect(rootNode).toBe(instance.getDOMNode());
 
       React.unmountComponentAtNode(container);
 

--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -581,7 +581,7 @@ describe('ReactDOMComponent', function() {
       var instance = <div onClick={callback} />;
       instance = React.render(instance, container);
 
-      var rootNode = instance.getDOMNode();
+      var rootNode = React.findDOMNode(instance);
       var rootNodeID = ReactMount.getID(rootNode);
       expect(
         ReactBrowserEventEmitter.getListener(rootNodeID, 'onClick')

--- a/src/browser/ui/__tests__/ReactDOMTextComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMTextComponent-test.js
@@ -31,15 +31,15 @@ describe('ReactDOMTextComponent', function() {
     var el = document.createElement('div');
     var inst = React.render(<div>{'foo'}{'bar'}</div>, el);
 
-    var foo = inst.getDOMNode().children[0];
-    var bar = inst.getDOMNode().children[1];
+    var foo = React.findDOMNode(inst).children[0];
+    var bar = React.findDOMNode(inst).children[1];
     expect(foo.tagName).toBe('SPAN');
     expect(bar.tagName).toBe('SPAN');
 
     inst = React.render(<div>{'baz'}{'qux'}</div>, el);
     // After the update, the spans should have stayed in place (as opposed to
     // getting unmounted and remounted)
-    expect(inst.getDOMNode().children[0]).toBe(foo);
-    expect(inst.getDOMNode().children[1]).toBe(bar);
+    expect(React.findDOMNode(inst).children[0]).toBe(foo);
+    expect(React.findDOMNode(inst).children[1]).toBe(bar);
   });
 });

--- a/src/browser/ui/__tests__/ReactEventListener-test.js
+++ b/src/browser/ui/__tests__/ReactEventListener-test.js
@@ -45,17 +45,19 @@ describe('ReactEventListener', function() {
       childControl = ReactMount.render(childControl, childContainer);
       parentControl =
         ReactMount.render(parentControl, parentContainer);
-      parentControl.getDOMNode().appendChild(childContainer);
+      React.findDOMNode(parentControl).appendChild(childContainer);
 
       var callback = ReactEventListener.dispatchEvent.bind(null, 'test');
       callback({
-        target: childControl.getDOMNode()
+        target: React.findDOMNode(childControl)
       });
 
       var calls = handleTopLevel.mock.calls;
       expect(calls.length).toBe(2);
-      expect(calls[0][EVENT_TARGET_PARAM]).toBe(childControl.getDOMNode());
-      expect(calls[1][EVENT_TARGET_PARAM]).toBe(parentControl.getDOMNode());
+      expect(calls[0][EVENT_TARGET_PARAM])
+        .toBe(React.findDOMNode(childControl));
+      expect(calls[1][EVENT_TARGET_PARAM])
+        .toBe(React.findDOMNode(parentControl));
     });
 
     it('should propagate events two levels down', function() {
@@ -70,20 +72,22 @@ describe('ReactEventListener', function() {
         ReactMount.render(parentControl, parentContainer);
       grandParentControl =
         ReactMount.render(grandParentControl, grandParentContainer);
-      parentControl.getDOMNode().appendChild(childContainer);
-      grandParentControl.getDOMNode().appendChild(parentContainer);
+      React.findDOMNode(parentControl).appendChild(childContainer);
+      React.findDOMNode(grandParentControl).appendChild(parentContainer);
 
       var callback = ReactEventListener.dispatchEvent.bind(null, 'test');
       callback({
-        target: childControl.getDOMNode()
+        target: React.findDOMNode(childControl)
       });
 
       var calls = handleTopLevel.mock.calls;
       expect(calls.length).toBe(3);
-      expect(calls[0][EVENT_TARGET_PARAM]).toBe(childControl.getDOMNode());
-      expect(calls[1][EVENT_TARGET_PARAM]).toBe(parentControl.getDOMNode());
+      expect(calls[0][EVENT_TARGET_PARAM])
+        .toBe(React.findDOMNode(childControl));
+      expect(calls[1][EVENT_TARGET_PARAM])
+        .toBe(React.findDOMNode(parentControl));
       expect(calls[2][EVENT_TARGET_PARAM])
-        .toBe(grandParentControl.getDOMNode());
+        .toBe(React.findDOMNode(grandParentControl));
     });
 
     it('should not get confused by disappearing elements', function() {
@@ -94,13 +98,13 @@ describe('ReactEventListener', function() {
       childControl = ReactMount.render(childControl, childContainer);
       parentControl =
         ReactMount.render(parentControl, parentContainer);
-      parentControl.getDOMNode().appendChild(childContainer);
+      React.findDOMNode(parentControl).appendChild(childContainer);
 
       // ReactBrowserEventEmitter.handleTopLevel might remove the
       // target from the DOM. Here, we have handleTopLevel remove the
       // node when the first event handlers are called; we'll still
       // expect to receive a second call for the parent control.
-      var childNode = childControl.getDOMNode();
+      var childNode = React.findDOMNode(childControl);
       handleTopLevel.mockImplementation(
         function(topLevelType, topLevelTarget, topLevelTargetID, nativeEvent) {
           if (topLevelTarget === childNode) {
@@ -117,7 +121,8 @@ describe('ReactEventListener', function() {
       var calls = handleTopLevel.mock.calls;
       expect(calls.length).toBe(2);
       expect(calls[0][EVENT_TARGET_PARAM]).toBe(childNode);
-      expect(calls[1][EVENT_TARGET_PARAM]).toBe(parentControl.getDOMNode());
+      expect(calls[1][EVENT_TARGET_PARAM])
+        .toBe(React.findDOMNode(parentControl));
     });
 
     it('should batch between handlers from different roots', function() {
@@ -131,11 +136,11 @@ describe('ReactEventListener', function() {
         <div>Parent</div>,
         parentContainer
       );
-      parentControl.getDOMNode().appendChild(childContainer);
+      React.findDOMNode(parentControl).appendChild(childContainer);
 
       // Suppose an event handler in each root enqueues an update to the
       // childControl element -- the two updates should get batched together.
-      var childNode = childControl.getDOMNode();
+      var childNode = React.findDOMNode(childControl);
       handleTopLevel.mockImplementation(
         function(topLevelType, topLevelTarget, topLevelTargetID, nativeEvent) {
           ReactMount.render(
@@ -177,11 +182,12 @@ describe('ReactEventListener', function() {
 
     var callback = ReactEventListener.dispatchEvent.bind(null, 'test');
     callback({
-      target: instance.getInner().getDOMNode()
+      target: React.findDOMNode(instance.getInner())
     });
 
     var calls = handleTopLevel.mock.calls;
     expect(calls.length).toBe(1);
-    expect(calls[0][EVENT_TARGET_PARAM]).toBe(instance.getInner().getDOMNode());
+    expect(calls[0][EVENT_TARGET_PARAM])
+      .toBe(React.findDOMNode(instance.getInner()));
   });
 });

--- a/src/browser/ui/__tests__/ReactRenderDocument-test.js
+++ b/src/browser/ui/__tests__/ReactRenderDocument-test.js
@@ -246,7 +246,7 @@ describe('rendering React components at document', function() {
     );
   });
 
-  it('supports getDOMNode on full-page components', function() {
+  it('supports findDOMNode on full-page components', function() {
     var tree =
       <html>
         <head>
@@ -261,6 +261,6 @@ describe('rendering React components at document', function() {
     testDocument = getTestDocument(markup);
     var component = React.render(tree, testDocument);
     expect(testDocument.body.innerHTML).toBe('Hello world');
-    expect(component.getDOMNode().tagName).toBe('HTML');
+    expect(React.findDOMNode(component).tagName).toBe('HTML');
   });
 });

--- a/src/browser/ui/dom/components/AutoFocusMixin.js
+++ b/src/browser/ui/dom/components/AutoFocusMixin.js
@@ -12,12 +12,13 @@
 
 'use strict';
 
+var findDOMNode = require('findDOMNode');
 var focusNode = require('focusNode');
 
 var AutoFocusMixin = {
   componentDidMount: function() {
     if (this.props.autoFocus) {
-      focusNode(this.getDOMNode());
+      focusNode(findDOMNode(this));
     }
   }
 };

--- a/src/browser/ui/dom/components/LocalEventTrapMixin.js
+++ b/src/browser/ui/dom/components/LocalEventTrapMixin.js
@@ -14,6 +14,7 @@
 var ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
 
 var accumulateInto = require('accumulateInto');
+var findDOMNode = require('findDOMNode');
 var forEachAccumulated = require('forEachAccumulated');
 var invariant = require('invariant');
 
@@ -26,7 +27,7 @@ var LocalEventTrapMixin = {
     invariant(this.isMounted(), 'Must be mounted to trap events');
     // If a component renders to null or if another component fatals and causes
     // the state of the tree to be corrupted, `node` here can be null.
-    var node = this.getDOMNode();
+    var node = findDOMNode(this);
     invariant(
       node,
       'LocalEventTrapMixin.trapBubbledEvent(...): Requires node to be rendered.'

--- a/src/browser/ui/dom/components/ReactDOMInput.js
+++ b/src/browser/ui/dom/components/ReactDOMInput.js
@@ -21,6 +21,7 @@ var ReactMount = require('ReactMount');
 var ReactUpdates = require('ReactUpdates');
 
 var assign = require('Object.assign');
+var findDOMNode = require('findDOMNode');
 var invariant = require('invariant');
 
 var input = ReactElement.createFactory('input');
@@ -83,18 +84,18 @@ var ReactDOMInput = ReactClass.createClass({
   },
 
   componentDidMount: function() {
-    var id = ReactMount.getID(this.getDOMNode());
+    var id = ReactMount.getID(findDOMNode(this));
     instancesByReactID[id] = this;
   },
 
   componentWillUnmount: function() {
-    var rootNode = this.getDOMNode();
+    var rootNode = findDOMNode(this);
     var id = ReactMount.getID(rootNode);
     delete instancesByReactID[id];
   },
 
   componentDidUpdate: function(prevProps, prevState, prevContext) {
-    var rootNode = this.getDOMNode();
+    var rootNode = findDOMNode(this);
     if (this.props.checked != null) {
       DOMPropertyOperations.setValueForProperty(
         rootNode,
@@ -124,7 +125,7 @@ var ReactDOMInput = ReactClass.createClass({
 
     var name = this.props.name;
     if (this.props.type === 'radio' && name != null) {
-      var rootNode = this.getDOMNode();
+      var rootNode = findDOMNode(this);
       var queryRoot = rootNode;
 
       while (queryRoot.parentNode) {

--- a/src/browser/ui/dom/components/ReactDOMSelect.js
+++ b/src/browser/ui/dom/components/ReactDOMSelect.js
@@ -19,6 +19,7 @@ var ReactElement = require('ReactElement');
 var ReactUpdates = require('ReactUpdates');
 
 var assign = require('Object.assign');
+var findDOMNode = require('findDOMNode');
 
 var select = ReactElement.createFactory('select');
 
@@ -65,7 +66,7 @@ function selectValueType(props, propName, componentName) {
  */
 function updateOptions(component, propValue) {
   var selectedValue, i, l;
-  var options = component.getDOMNode().options;
+  var options = findDOMNode(component).options;
 
   if (component.props.multiple) {
     selectedValue = {};

--- a/src/browser/ui/dom/components/ReactDOMTextarea.js
+++ b/src/browser/ui/dom/components/ReactDOMTextarea.js
@@ -20,6 +20,7 @@ var ReactElement = require('ReactElement');
 var ReactUpdates = require('ReactUpdates');
 
 var assign = require('Object.assign');
+var findDOMNode = require('findDOMNode');
 var invariant = require('invariant');
 
 var warning = require('warning');
@@ -114,7 +115,7 @@ var ReactDOMTextarea = ReactClass.createClass({
   componentDidUpdate: function(prevProps, prevState, prevContext) {
     var value = LinkedValueUtils.getValue(this);
     if (value != null) {
-      var rootNode = this.getDOMNode();
+      var rootNode = findDOMNode(this);
       // Cast `value` to a string to ensure the value is set correctly. While
       // browsers typically do this as necessary, jsdom doesn't.
       DOMPropertyOperations.setValueForProperty(rootNode, 'value', '' + value);

--- a/src/browser/ui/dom/components/__tests__/ReactDOMButton-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMButton-test.js
@@ -23,13 +23,13 @@ describe('ReactDOMButton', function() {
 
   function expectClickThru(button) {
     onClick.mockClear();
-    ReactTestUtils.Simulate.click(button.getDOMNode());
+    ReactTestUtils.Simulate.click(React.findDOMNode(button));
     expect(onClick.mock.calls.length).toBe(1);
   }
 
   function expectNoClickThru(button) {
     onClick.mockClear();
-    ReactTestUtils.Simulate.click(button.getDOMNode());
+    ReactTestUtils.Simulate.click(React.findDOMNode(button));
     expect(onClick.mock.calls.length).toBe(0);
   }
 

--- a/src/browser/ui/dom/components/__tests__/ReactDOMIframe-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMIframe-test.js
@@ -28,7 +28,7 @@ describe('ReactDOMIframe', function() {
     var loadEvent = document.createEvent('Event');
     loadEvent.initEvent('load', false, false);
 
-    iframe.getDOMNode().dispatchEvent(loadEvent);
+    React.findDOMNode(iframe).dispatchEvent(loadEvent);
 
     expect(onLoadSpy).toHaveBeenCalled();
   });

--- a/src/browser/ui/dom/components/__tests__/ReactDOMInput-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMInput-test.js
@@ -32,7 +32,7 @@ describe('ReactDOMInput', function() {
   it('should display `defaultValue` of number 0', function() {
     var stub = <input type="text" defaultValue={0} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.value).toBe('0');
   });
@@ -40,7 +40,7 @@ describe('ReactDOMInput', function() {
   it('should display "true" for `defaultValue` of `true`', function() {
     var stub = <input type="text" defaultValue={true} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.value).toBe('true');
   });
@@ -48,7 +48,7 @@ describe('ReactDOMInput', function() {
   it('should display "false" for `defaultValue` of `false`', function() {
     var stub = <input type="text" defaultValue={false} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.value).toBe('false');
   });
@@ -62,7 +62,7 @@ describe('ReactDOMInput', function() {
 
     var stub = <input type="text" defaultValue={objToString} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.value).toBe('foobar');
   });
@@ -70,7 +70,7 @@ describe('ReactDOMInput', function() {
   it('should display `value` of number 0', function() {
     var stub = <input type="text" value={0} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.value).toBe('0');
   });
@@ -78,7 +78,7 @@ describe('ReactDOMInput', function() {
   it('should allow setting `value` to `true`', function() {
     var stub = <input type="text" value="yolo" onChange={emptyFunction} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.value).toBe('yolo');
 
@@ -89,7 +89,7 @@ describe('ReactDOMInput', function() {
   it("should allow setting `value` to `false`", function() {
     var stub = <input type="text" value="yolo" onChange={emptyFunction} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.value).toBe('yolo');
 
@@ -100,7 +100,7 @@ describe('ReactDOMInput', function() {
   it('should allow setting `value` to `objToString`', function() {
     var stub = <input type="text" value="foo" onChange={emptyFunction} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.value).toBe('foo');
 
@@ -117,7 +117,7 @@ describe('ReactDOMInput', function() {
   it('should properly control a value of number `0`', function() {
     var stub = <input type="text" value={0} onChange={emptyFunction} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     node.value = 'giraffe';
     ReactTestUtils.Simulate.change(node);
@@ -127,7 +127,7 @@ describe('ReactDOMInput', function() {
   it('should not set a value for submit buttons unnecessarily', function() {
     var stub = <input type="submit" />;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     // The value shouldn't be '', or else the button will have no text; it
     // should have the default "Submit" or "Submit Query" label. Most browsers
@@ -172,9 +172,9 @@ describe('ReactDOMInput', function() {
     });
 
     var stub = ReactTestUtils.renderIntoDocument(<RadioGroup />);
-    var aNode = stub.refs.a.getDOMNode();
-    var bNode = stub.refs.b.getDOMNode();
-    var cNode = stub.refs.c.getDOMNode();
+    var aNode = React.findDOMNode(stub.refs.a);
+    var bNode = React.findDOMNode(stub.refs.b);
+    var cNode = React.findDOMNode(stub.refs.c);
 
     expect(aNode.checked).toBe(true);
     expect(bNode.checked).toBe(false);
@@ -202,12 +202,12 @@ describe('ReactDOMInput', function() {
 
     instance = ReactTestUtils.renderIntoDocument(instance);
 
-    expect(instance.getDOMNode().value).toBe('yolo');
+    expect(React.findDOMNode(instance).value).toBe('yolo');
     expect(link.value).toBe('yolo');
     expect(link.requestChange.mock.calls.length).toBe(0);
 
-    instance.getDOMNode().value = 'test';
-    ReactTestUtils.Simulate.change(instance.getDOMNode());
+    React.findDOMNode(instance).value = 'test';
+    ReactTestUtils.Simulate.change(React.findDOMNode(instance));
 
     expect(link.requestChange.mock.calls.length).toBe(1);
     expect(link.requestChange.mock.calls[0][0]).toEqual('test');
@@ -270,12 +270,12 @@ describe('ReactDOMInput', function() {
 
     instance = ReactTestUtils.renderIntoDocument(instance);
 
-    expect(instance.getDOMNode().checked).toBe(true);
+    expect(React.findDOMNode(instance).checked).toBe(true);
     expect(link.value).toBe(true);
     expect(link.requestChange.mock.calls.length).toBe(0);
 
-    instance.getDOMNode().checked = false;
-    ReactTestUtils.Simulate.change(instance.getDOMNode());
+    React.findDOMNode(instance).checked = false;
+    ReactTestUtils.Simulate.change(React.findDOMNode(instance));
 
     expect(link.requestChange.mock.calls.length).toBe(1);
     expect(link.requestChange.mock.calls[0][0]).toEqual(false);

--- a/src/browser/ui/dom/components/__tests__/ReactDOMSelect-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMSelect-test.js
@@ -34,7 +34,7 @@ describe('ReactDOMSelect', function() {
         <option value="gorilla">A gorilla!</option>
       </select>;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.value).toBe('giraffe');
 
@@ -51,7 +51,7 @@ describe('ReactDOMSelect', function() {
         <option value="gorilla">A gorilla!</option>
       </select>;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.value).toBe('giraffe');
 
@@ -69,7 +69,7 @@ describe('ReactDOMSelect', function() {
         <option value="gorilla">A gorilla!</option>
       </select>;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -91,7 +91,7 @@ describe('ReactDOMSelect', function() {
         <option value="gorilla">A gorilla!</option>
       </select>;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.value).toBe('giraffe');
 
@@ -108,7 +108,7 @@ describe('ReactDOMSelect', function() {
         <option value="gorilla">A gorilla!</option>
       </select>;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -130,7 +130,7 @@ describe('ReactDOMSelect', function() {
         <option value="12">twelve</option>
       </select>;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.options[0].selected).toBe(false);  // one
     expect(node.options[1].selected).toBe(false);  // two
@@ -149,7 +149,7 @@ describe('ReactDOMSelect', function() {
       ]
     });
 
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.options[0].selected).toBe(true);  // a
     expect(node.options[1].selected).toBe(true);  // b
@@ -171,7 +171,7 @@ describe('ReactDOMSelect', function() {
         <option value="gorilla">A gorilla!</option>
       </select>;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -194,7 +194,7 @@ describe('ReactDOMSelect', function() {
         <option value="gorilla">A gorilla!</option>
       </select>;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -216,7 +216,7 @@ describe('ReactDOMSelect', function() {
         <option value="gorilla">A gorilla!</option>
       </select>;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -239,7 +239,7 @@ describe('ReactDOMSelect', function() {
         <option value="gorilla">A gorilla!</option>
       </select>;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -260,7 +260,7 @@ describe('ReactDOMSelect', function() {
         <option value="gorilla">A gorilla!</option>
       </select>;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     stub.setProps({value: 'gorilla'});
 
@@ -284,7 +284,7 @@ describe('ReactDOMSelect', function() {
         <option value="gorilla">A gorilla!</option>
       </select>;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe

--- a/src/browser/ui/dom/components/__tests__/ReactDOMTextarea-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMTextarea-test.js
@@ -28,7 +28,7 @@ describe('ReactDOMTextarea', function() {
 
     renderTextarea = function(component) {
       var stub = ReactTestUtils.renderIntoDocument(component);
-      var node = stub.getDOMNode();
+      var node = React.findDOMNode(stub);
       // Fixing jsdom's quirky behavior -- in reality, the parser should strip
       // off the leading newline but we need to do it by hand here.
       node.value = node.innerHTML.replace(/^\n/, '');
@@ -39,7 +39,7 @@ describe('ReactDOMTextarea', function() {
   it('should allow setting `defaultValue`', function() {
     var stub = <textarea defaultValue="giraffe" />;
     stub = renderTextarea(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.value).toBe('giraffe');
 
@@ -51,7 +51,7 @@ describe('ReactDOMTextarea', function() {
   it('should display `defaultValue` of number 0', function() {
     var stub = <textarea defaultValue={0} />;
     stub = renderTextarea(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.value).toBe('0');
   });
@@ -59,7 +59,7 @@ describe('ReactDOMTextarea', function() {
   it('should display "false" for `defaultValue` of `false`', function() {
     var stub = <textarea type="text" defaultValue={false} />;
     stub = renderTextarea(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.value).toBe('false');
   });
@@ -73,7 +73,7 @@ describe('ReactDOMTextarea', function() {
 
     var stub = <textarea type="text" defaultValue={objToString} />;
     stub = renderTextarea(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.value).toBe('foobar');
   });
@@ -81,7 +81,7 @@ describe('ReactDOMTextarea', function() {
   it('should not render value as an attribute', function() {
     var stub = <textarea value="giraffe" onChange={emptyFunction} />;
     stub = renderTextarea(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.getAttribute('value')).toBe(null);
   });
@@ -89,7 +89,7 @@ describe('ReactDOMTextarea', function() {
   it('should display `value` of number 0', function() {
     var stub = <textarea value={0} />;
     stub = renderTextarea(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.value).toBe('0');
   });
@@ -97,7 +97,7 @@ describe('ReactDOMTextarea', function() {
   it('should allow setting `value` to `giraffe`', function() {
     var stub = <textarea value="giraffe" onChange={emptyFunction} />;
     stub = renderTextarea(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.value).toBe('giraffe');
 
@@ -108,7 +108,7 @@ describe('ReactDOMTextarea', function() {
   it('should allow setting `value` to `true`', function() {
     var stub = <textarea value="giraffe" onChange={emptyFunction} />;
     stub = renderTextarea(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.value).toBe('giraffe');
 
@@ -119,7 +119,7 @@ describe('ReactDOMTextarea', function() {
   it('should allow setting `value` to `false`', function() {
     var stub = <textarea value="giraffe" onChange={emptyFunction} />;
     stub = renderTextarea(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.value).toBe('giraffe');
 
@@ -130,7 +130,7 @@ describe('ReactDOMTextarea', function() {
   it('should allow setting `value` to `objToString`', function() {
     var stub = <textarea value="giraffe" onChange={emptyFunction} />;
     stub = renderTextarea(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(node.value).toBe('giraffe');
 
@@ -146,7 +146,7 @@ describe('ReactDOMTextarea', function() {
   it('should properly control a value of number `0`', function() {
     var stub = <textarea value={0} onChange={emptyFunction} />;
     stub = renderTextarea(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     node.value = 'giraffe';
     ReactTestUtils.Simulate.change(node);
@@ -158,7 +158,7 @@ describe('ReactDOMTextarea', function() {
 
     var stub = <textarea>giraffe</textarea>;
     stub = renderTextarea(stub);
-    var node = stub.getDOMNode();
+    var node = React.findDOMNode(stub);
 
     expect(console.warn.argsForCall.length).toBe(1);
     expect(node.value).toBe('giraffe');
@@ -170,14 +170,14 @@ describe('ReactDOMTextarea', function() {
 
   it('should allow numbers as children', function() {
     spyOn(console, 'warn');
-    var node = renderTextarea(<textarea>{17}</textarea>).getDOMNode();
+    var node = React.findDOMNode(renderTextarea(<textarea>{17}</textarea>));
     expect(console.warn.argsForCall.length).toBe(1);
     expect(node.value).toBe('17');
   });
 
   it('should allow booleans as children', function() {
     spyOn(console, 'warn');
-    var node = renderTextarea(<textarea>{false}</textarea>).getDOMNode();
+    var node = React.findDOMNode(renderTextarea(<textarea>{false}</textarea>));
     expect(console.warn.argsForCall.length).toBe(1);
     expect(node.value).toBe('false');
   });
@@ -189,7 +189,7 @@ describe('ReactDOMTextarea', function() {
         return "sharkswithlasers";
       }
     };
-    var node = renderTextarea(<textarea>{obj}</textarea>).getDOMNode();
+    var node = React.findDOMNode(renderTextarea(<textarea>{obj}</textarea>));
     expect(console.warn.argsForCall.length).toBe(1);
     expect(node.value).toBe('sharkswithlasers');
   });
@@ -207,7 +207,7 @@ describe('ReactDOMTextarea', function() {
 
     var node;
     expect(function() {
-      node = renderTextarea(<textarea><strong /></textarea>).getDOMNode();
+      node = React.findDOMNode(renderTextarea(<textarea><strong /></textarea>));
     }).not.toThrow();
 
     expect(node.value).toBe('[object Object]');
@@ -221,12 +221,12 @@ describe('ReactDOMTextarea', function() {
 
     instance = renderTextarea(instance);
 
-    expect(instance.getDOMNode().value).toBe('yolo');
+    expect(React.findDOMNode(instance).value).toBe('yolo');
     expect(link.value).toBe('yolo');
     expect(link.requestChange.mock.calls.length).toBe(0);
 
-    instance.getDOMNode().value = 'test';
-    ReactTestUtils.Simulate.change(instance.getDOMNode());
+    React.findDOMNode(instance).value = 'test';
+    ReactTestUtils.Simulate.change(React.findDOMNode(instance));
 
     expect(link.requestChange.mock.calls.length).toBe(1);
     expect(link.requestChange.mock.calls[0][0]).toEqual('test');

--- a/src/classic/element/__tests__/ReactElement-test.js
+++ b/src/classic/element/__tests__/ReactElement-test.js
@@ -283,7 +283,7 @@ describe('ReactElement', function() {
       }
     });
     var outer = ReactTestUtils.renderIntoDocument(<Outer color="orange" />);
-    expect(outer.getDOMNode().className).toBe('quack');
+    expect(React.findDOMNode(outer).className).toBe('quack');
 
     expect(console.warn.argsForCall.length).toBe(1);
     expect(console.warn.argsForCall[0][0]).toContain(
@@ -324,8 +324,8 @@ describe('ReactElement', function() {
       }
     });
     var outer = React.render(<Outer />, el);
-    expect(outer.getDOMNode().textContent).toBe('meow');
-    expect(outer.getDOMNode().className).toBe('quack');
+    expect(React.findDOMNode(outer).textContent).toBe('meow');
+    expect(React.findDOMNode(outer).className).toBe('quack');
 
     expect(console.warn.argsForCall.length).toBe(1);
     expect(console.warn.argsForCall[0][0]).toContain(
@@ -340,8 +340,8 @@ describe('ReactElement', function() {
     var newOuterEl = <Outer />;
     newOuterEl.props.sound = 'oink';
     outer = React.render(newOuterEl, el);
-    expect(outer.getDOMNode().textContent).toBe('oink');
-    expect(outer.getDOMNode().className).toBe('quack');
+    expect(React.findDOMNode(outer).textContent).toBe('oink');
+    expect(React.findDOMNode(outer).className).toBe('quack');
 
     expect(console.warn.argsForCall.length).toBe(1);
     expect(console.warn.argsForCall[0][0]).toContain(

--- a/src/classic/element/__tests__/ReactElementClone-test.js
+++ b/src/classic/element/__tests__/ReactElementClone-test.js
@@ -41,7 +41,7 @@ describe('ReactElementClone', function() {
       }
     });
     var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
-    expect(component.getDOMNode().childNodes[0].className).toBe('xyz');
+    expect(React.findDOMNode(component).childNodes[0].className).toBe('xyz');
   });
 
   it('should clone a composite component with new props', function() {
@@ -65,7 +65,7 @@ describe('ReactElementClone', function() {
       }
     });
     var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
-    expect(component.getDOMNode().childNodes[0].className).toBe('xyz');
+    expect(React.findDOMNode(component).childNodes[0].className).toBe('xyz');
   });
 
   it('should keep the original ref if it is not overridden', function() {

--- a/src/core/__tests__/ReactComponentLifeCycle-test.js
+++ b/src/core/__tests__/ReactComponentLifeCycle-test.js
@@ -287,7 +287,7 @@ describe('ReactComponentLifeCycle', function() {
     );
   });
 
-  it('warns if getDOMNode is used inside render', function() {
+  it('warns if findDOMNode is used inside render', function() {
     spyOn(console, 'warn');
     var Component = React.createClass({
       getInitialState: function() {
@@ -298,7 +298,7 @@ describe('ReactComponentLifeCycle', function() {
       },
       render: function() {
         if (this.state.isMounted) {
-          expect(this.getDOMNode().tagName).toBe('DIV');
+          expect(React.findDOMNode(this).tagName).toBe('DIV');
         }
         return <div/>;
       }

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -152,7 +152,7 @@ describe('ReactCompositeComponent', function() {
     // rerender
     instance.setProps({renderAnchor: true, anchorClassOn: false});
     var anchor = instance.getAnchor();
-    var actualDOMAnchorNode = anchor.getDOMNode();
+    var actualDOMAnchorNode = React.findDOMNode(anchor);
     expect(actualDOMAnchorNode.className).toBe('');
   });
 
@@ -451,10 +451,10 @@ describe('ReactCompositeComponent', function() {
     });
     var Inner = React.createClass({
       componentWillUnmount: function() {
-        // It's important that ReactMount.purgeID be called after any component
+        // It's important that ReactMount.purgeID is called after any component
         // lifecycle methods, because a componentWillMount implementation is
-        // likely call this.getDOMNode(), which will repopulate the node cache
-        // after it's been cleared, causing a memory leak.
+        // likely to call React.findDOMNode(this), which will repopulate the
+        // node cache after it's been cleared, causing a memory leak.
         expect(ReactMount.purgeID.calls.length).toBe(0);
         innerUnmounted = true;
       },
@@ -923,25 +923,25 @@ describe('ReactCompositeComponent', function() {
     });
 
     var comp = ReactTestUtils.renderIntoDocument(<Component flipped={false} />);
-    expect(comp.refs.static0.getDOMNode().textContent).toBe('A');
-    expect(comp.refs.static1.getDOMNode().textContent).toBe('B');
+    expect(React.findDOMNode(comp.refs.static0).textContent).toBe('A');
+    expect(React.findDOMNode(comp.refs.static1).textContent).toBe('B');
 
     // When flipping the order, the refs should update even though the actual
     // contents do not
     comp.setProps({flipped: true});
-    expect(comp.refs.static0.getDOMNode().textContent).toBe('B');
-    expect(comp.refs.static1.getDOMNode().textContent).toBe('A');
+    expect(React.findDOMNode(comp.refs.static0).textContent).toBe('B');
+    expect(React.findDOMNode(comp.refs.static1).textContent).toBe('A');
   });
 
-  it('should allow access to getDOMNode in componentWillUnmount', function() {
+  it('should allow access to findDOMNode in componentWillUnmount', function() {
     var a = null;
     var b = null;
     var Component = React.createClass({
       componentDidMount: function() {
-        a = this.getDOMNode();
+        a = React.findDOMNode(this);
       },
       componentWillUnmount: function() {
-        b = this.getDOMNode();
+        b = React.findDOMNode(this);
       },
       render: function() {
         return <div />;

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -154,6 +154,7 @@ describe('ReactCompositeComponent', function() {
     var anchor = instance.getAnchor();
     var actualDOMAnchorNode = React.findDOMNode(anchor);
     expect(actualDOMAnchorNode.className).toBe('');
+    expect(actualDOMAnchorNode).toBe(anchor.getDOMNode());
   });
 
   it('should auto bind methods and values correctly', function() {
@@ -926,11 +927,21 @@ describe('ReactCompositeComponent', function() {
     expect(React.findDOMNode(comp.refs.static0).textContent).toBe('A');
     expect(React.findDOMNode(comp.refs.static1).textContent).toBe('B');
 
+    expect(React.findDOMNode(comp.refs.static0))
+      .toBe(comp.refs.static0.getDOMNode());
+    expect(React.findDOMNode(comp.refs.static1))
+      .toBe(comp.refs.static1.getDOMNode());
+
     // When flipping the order, the refs should update even though the actual
     // contents do not
     comp.setProps({flipped: true});
     expect(React.findDOMNode(comp.refs.static0).textContent).toBe('B');
     expect(React.findDOMNode(comp.refs.static1).textContent).toBe('A');
+
+    expect(React.findDOMNode(comp.refs.static0))
+      .toBe(comp.refs.static0.getDOMNode());
+    expect(React.findDOMNode(comp.refs.static1))
+      .toBe(comp.refs.static1.getDOMNode());
   });
 
   it('should allow access to findDOMNode in componentWillUnmount', function() {
@@ -939,9 +950,11 @@ describe('ReactCompositeComponent', function() {
     var Component = React.createClass({
       componentDidMount: function() {
         a = React.findDOMNode(this);
+        expect(a).toBe(this.getDOMNode());
       },
       componentWillUnmount: function() {
         b = React.findDOMNode(this);
+        expect(b).toBe(this.getDOMNode());
       },
       render: function() {
         return <div />;

--- a/src/core/__tests__/ReactEmptyComponent-test.js
+++ b/src/core/__tests__/ReactEmptyComponent-test.js
@@ -33,11 +33,11 @@ describe('ReactEmptyComponent', function() {
         return {component: this.props.firstComponent};
       },
       componentDidMount: function() {
-        console.log(this.getDOMNode());
+        console.log(React.findDOMNode(this));
         this.setState({component: this.props.secondComponent});
       },
       componentDidUpdate: function() {
-        console.log(this.getDOMNode());
+        console.log(React.findDOMNode(this));
       },
       render: function() {
         var Component = this.state.component;
@@ -188,13 +188,13 @@ describe('ReactEmptyComponent', function() {
       componentDidMount: function() {
         // Make sure the DOM node resolves properly even if we're replacing a
         // `null` component
-        expect(this.getDOMNode()).not.toBe(null);
+        expect(React.findDOMNode(this)).not.toBe(null);
         assertions++;
       },
       componentWillUnmount: function() {
         // Even though we're getting replaced by `null`, we haven't been
         // replaced yet!
-        expect(this.getDOMNode()).not.toBe(null);
+        expect(React.findDOMNode(this)).not.toBe(null);
         assertions++;
       }
     });
@@ -209,15 +209,15 @@ describe('ReactEmptyComponent', function() {
 
     // Render the <Inner /> component...
     component = React.render(<Wrapper showInner={true} />, el);
-    expect(component.getDOMNode()).not.toBe(null);
+    expect(React.findDOMNode(component)).not.toBe(null);
 
     // Switch to null...
     component = React.render(<Wrapper showInner={false} />, el);
-    expect(component.getDOMNode()).toBe(null);
+    expect(React.findDOMNode(component)).toBe(null);
 
     // ...then switch back.
     component = React.render(<Wrapper showInner={true} />, el);
-    expect(component.getDOMNode()).not.toBe(null);
+    expect(React.findDOMNode(component)).not.toBe(null);
 
     expect(assertions).toBe(3);
   });

--- a/src/core/__tests__/ReactIdentity-test.js
+++ b/src/core/__tests__/ReactIdentity-test.js
@@ -51,7 +51,7 @@ describe('ReactIdentity', function() {
       </div>;
 
     instance = React.render(instance, document.createElement('div'));
-    var node = instance.getDOMNode();
+    var node = React.findDOMNode(instance);
     reactComponentExpect(instance).toBeDOMComponentWithChildCount(2);
     checkId(node.childNodes[0], '.0.$first:0');
     checkId(node.childNodes[1], '.0.$second:0');
@@ -67,7 +67,7 @@ describe('ReactIdentity', function() {
       </div>;
 
     instance = React.render(instance, document.createElement('div'));
-    var node = instance.getDOMNode();
+    var node = React.findDOMNode(instance);
     reactComponentExpect(instance).toBeDOMComponentWithChildCount(4);
     checkId(node.childNodes[0], '.0.$apple');
     checkId(node.childNodes[1], '.0.$banana');
@@ -91,7 +91,7 @@ describe('ReactIdentity', function() {
       </div>;
 
     instance = React.render(instance, document.createElement('div'));
-    var node = instance.getDOMNode();
+    var node = React.findDOMNode(instance);
     reactComponentExpect(instance).toBeDOMComponentWithChildCount(3);
 
     checkId(node.childNodes[0], '.0.$wrap1');
@@ -121,13 +121,13 @@ describe('ReactIdentity', function() {
     var span1 = instance.refs.span1;
     var span2 = instance.refs.span2;
 
-    expect(span1.getDOMNode()).not.toBe(null);
-    expect(span2.getDOMNode()).not.toBe(null);
+    expect(React.findDOMNode(span1)).not.toBe(null);
+    expect(React.findDOMNode(span2)).not.toBe(null);
 
     key = key.replace(/=/g, '=0');
 
-    checkId(span1.getDOMNode(), '.0.$' + key);
-    checkId(span2.getDOMNode(), '.0.1:$' + key + ':0');
+    checkId(React.findDOMNode(span1), '.0.$' + key);
+    checkId(React.findDOMNode(span2), '.0.1:$' + key + ':0');
   }
 
   it('should allow any character as a key, in a detached parent', function() {
@@ -292,11 +292,11 @@ describe('ReactIdentity', function() {
 
     wrapped = React.render(wrapped, document.createElement('div'));
 
-    var beforeID = ReactMount.getID(wrapped.getDOMNode().firstChild);
+    var beforeID = ReactMount.getID(React.findDOMNode(wrapped).firstChild);
 
     wrapped.swap();
 
-    var afterID = ReactMount.getID(wrapped.getDOMNode().firstChild);
+    var afterID = ReactMount.getID(React.findDOMNode(wrapped).firstChild);
 
     expect(beforeID).not.toEqual(afterID);
 

--- a/src/core/__tests__/ReactMultiChildReconcile-test.js
+++ b/src/core/__tests__/ReactMultiChildReconcile-test.js
@@ -188,7 +188,7 @@ function verifyStatesPreserved(lastInternalStates, statusDisplays) {
  * accurately reflects what is in the DOM.
  */
 function verifyDomOrderingAccurate(parentInstance, statusDisplays) {
-  var containerNode = parentInstance.getDOMNode();
+  var containerNode = React.findDOMNode(parentInstance);
   var statusDisplayNodes = containerNode.childNodes;
   var i;
   var orderedDomIds = [];

--- a/src/core/__tests__/ReactMultiChildText-test.js
+++ b/src/core/__tests__/ReactMultiChildText-test.js
@@ -55,7 +55,7 @@ var updateChildren = function(d, children) {
 var expectChildren = function(d, children) {
   var textNode;
   if (typeof children === 'string') {
-    textNode = d.getDOMNode().firstChild;
+    textNode = React.findDOMNode(d).firstChild;
 
     if (children === '') {
       expect(textNode != null).toBe(false);
@@ -65,7 +65,7 @@ var expectChildren = function(d, children) {
       expect(textNode.data).toBe('' + children);
     }
   } else {
-    expect(d.getDOMNode().childNodes.length).toBe(children.length);
+    expect(React.findDOMNode(d).childNodes.length).toBe(children.length);
 
     for (var i = 0; i < children.length; i++) {
       var child = children[i];
@@ -75,7 +75,7 @@ var expectChildren = function(d, children) {
           .expectRenderedChildAt(i)
           .toBeTextComponentWithValue(child);
 
-        textNode = d.getDOMNode().childNodes[i].firstChild;
+        textNode = React.findDOMNode(d).childNodes[i].firstChild;
 
         if (child === '') {
           expect(textNode != null).toBe(false);
@@ -85,12 +85,11 @@ var expectChildren = function(d, children) {
           expect(textNode.data).toBe('' + child);
         }
       } else {
-        var elementDOMNode =
-          reactComponentExpect(d)
-            .expectRenderedChildAt(i)
-            .toBeComponentOfType('div')
-            .instance()
-            .getDOMNode();
+        var elementDOMNode = React.findDOMNode(reactComponentExpect(d)
+          .expectRenderedChildAt(i)
+          .toBeComponentOfType('div')
+          .instance()
+        );
 
         expect(elementDOMNode.tagName).toBe('DIV');
       }

--- a/src/core/__tests__/ReactUpdates-test.js
+++ b/src/core/__tests__/ReactUpdates-test.js
@@ -530,7 +530,7 @@ describe('ReactUpdates', function() {
         return {x: 0};
       },
       componentDidUpdate: function() {
-        expect(b.getDOMNode().textContent).toBe("B1");
+        expect(React.findDOMNode(b).textContent).toBe("B1");
         aUpdated = true;
       },
       render: function() {
@@ -646,7 +646,7 @@ describe('ReactUpdates', function() {
               depth={this.props.depth + 1}
               count={this.props.count}
             />,
-            this.getDOMNode()
+            React.findDOMNode(this)
           );
         }
       }
@@ -709,10 +709,10 @@ describe('ReactUpdates', function() {
 
     x = ReactTestUtils.renderIntoDocument(<X />);
     y = ReactTestUtils.renderIntoDocument(<Y />);
-    expect(x.getDOMNode().textContent).toBe('0');
+    expect(React.findDOMNode(x).textContent).toBe('0');
 
     y.forceUpdate();
-    expect(x.getDOMNode().textContent).toBe('1');
+    expect(React.findDOMNode(x).textContent).toBe('1');
   });
 
   it('should queue updates from during mount', function() {
@@ -750,7 +750,7 @@ describe('ReactUpdates', function() {
     });
 
     expect(a.state.x).toBe(1);
-    expect(a.getDOMNode().textContent).toBe('A1');
+    expect(React.findDOMNode(a).textContent).toBe('A1');
   });
 
   it('calls componentWillReceiveProps setState callback properly', function() {

--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -26,6 +26,7 @@ var ReactUpdates = require('ReactUpdates');
 var SyntheticEvent = require('SyntheticEvent');
 
 var assign = require('Object.assign');
+var findDOMNode = require('findDOMNode');
 
 var topLevelTypes = EventConstants.topLevelTypes;
 
@@ -293,7 +294,7 @@ var ReactTestUtils = {
       fakeNativeEvent) {
     ReactTestUtils.simulateNativeEventOnNode(
       topLevelType,
-      comp.getDOMNode(),
+      findDOMNode(comp),
       fakeNativeEvent
     );
   },
@@ -405,7 +406,7 @@ function makeSimulator(eventType) {
   return function(domComponentOrNode, eventData) {
     var node;
     if (ReactTestUtils.isDOMComponent(domComponentOrNode)) {
-      node = domComponentOrNode.getDOMNode();
+      node = findDOMNode(domComponentOrNode);
     } else if (domComponentOrNode.tagName) {
       node = domComponentOrNode;
     }

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -173,7 +173,7 @@ describe('ReactTestUtils', function() {
 
     var log = [];
     ReactTestUtils.findAllInRenderedTree(tree, function(child) {
-      log.push(child.getDOMNode().textContent);
+      log.push(React.findDOMNode(child).textContent);
     });
 
     // Should be document order, not mount order (which would be purple, orange)

--- a/src/utils/__tests__/cloneWithProps-test.js
+++ b/src/utils/__tests__/cloneWithProps-test.js
@@ -50,7 +50,7 @@ describe('cloneWithProps', function() {
       }
     });
     var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
-    expect(component.getDOMNode().childNodes[0].className)
+    expect(React.findDOMNode(component).childNodes[0].className)
       .toBe('xyz child');
   });
 
@@ -77,7 +77,7 @@ describe('cloneWithProps', function() {
       }
     });
     var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
-    expect(component.getDOMNode().childNodes[0].className)
+    expect(React.findDOMNode(component).childNodes[0].className)
       .toBe('xyz child');
   });
 


### PR DESCRIPTION
This updates all call sites (mostly in tests) from `foo.getDOMNode` to `(React.)findDOMNode(foo)`.