### PR TITLE
Deprecate replaceProps

### DIFF
--- a/src/modern/class/ReactComponent.js
+++ b/src/modern/class/ReactComponent.js
@@ -100,6 +100,7 @@ if (__DEV__) {
   var deprecatedAPIs = {
     getDOMNode: 'getDOMNode',
     isMounted: 'isMounted',
+    replaceProps: 'replaceProps',
     replaceState: 'replaceState',
     setProps: 'setProps'
   };

--- a/src/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/src/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -318,7 +318,8 @@ describe 'ReactCoffeeScriptClass', ->
     expect(-> instance.replaceState {}).toThrow()
     expect(-> instance.isMounted()).toThrow()
     expect(-> instance.setProps name: 'bar').toThrow()
-    expect(console.warn.calls.length).toBe 4
+    expect(-> instance.replaceProps name: 'bar').toThrow()
+    expect(console.warn.calls.length).toBe 5
     expect(console.warn.calls[0].args[0]).toContain(
       'getDOMNode(...) is deprecated in plain JavaScript React classes'
     )
@@ -330,6 +331,9 @@ describe 'ReactCoffeeScriptClass', ->
     )
     expect(console.warn.calls[3].args[0]).toContain(
       'setProps(...) is deprecated in plain JavaScript React classes'
+    )
+    expect(console.warn.calls[4].args[0]).toContain(
+      'replaceProps(...) is deprecated in plain JavaScript React classes'
     )
 
   it 'supports this.context passed via getChildContext', ->

--- a/src/modern/class/__tests__/ReactES6Class-test.js
+++ b/src/modern/class/__tests__/ReactES6Class-test.js
@@ -354,7 +354,8 @@ describe('ReactES6Class', function() {
     expect(() => instance.replaceState({})).toThrow();
     expect(() => instance.isMounted()).toThrow();
     expect(() => instance.setProps({name: 'bar'})).toThrow();
-    expect(console.warn.calls.length).toBe(4);
+    expect(() => instance.replaceProps({name: 'bar'})).toThrow();
+    expect(console.warn.calls.length).toBe(5);
     expect(console.warn.calls[0].args[0]).toContain(
       'getDOMNode(...) is deprecated in plain JavaScript React classes'
     );
@@ -366,6 +367,9 @@ describe('ReactES6Class', function() {
     );
     expect(console.warn.calls[3].args[0]).toContain(
       'setProps(...) is deprecated in plain JavaScript React classes'
+    );
+    expect(console.warn.calls[4].args[0]).toContain(
+      'replaceProps(...) is deprecated in plain JavaScript React classes'
     );
   });
 

--- a/src/modern/class/__tests__/ReactTypeScriptClass-test.ts
+++ b/src/modern/class/__tests__/ReactTypeScriptClass-test.ts
@@ -451,7 +451,8 @@ describe('ReactTypeScriptClass', function() {
     expect(() => instance.replaceState({})).toThrow();
     expect(() => instance.isMounted()).toThrow();
     expect(() => instance.setProps({ name: 'bar' })).toThrow();
-    expect(warn.mock.calls.length).toBe(4);
+    expect(() => instance.replaceProps({ name: 'bar' })).toThrow();
+    expect(warn.mock.calls.length).toBe(5);
     expect(warn.mock.calls[0][0]).toContain(
       'getDOMNode(...) is deprecated in plain JavaScript React classes'
     );
@@ -463,6 +464,9 @@ describe('ReactTypeScriptClass', function() {
     );
     expect(warn.mock.calls[3][0]).toContain(
       'setProps(...) is deprecated in plain JavaScript React classes'
+    );
+    expect(warn.mock.calls[4][0]).toContain(
+      'replaceProps(...) is deprecated in plain JavaScript React classes'
     );
   });
 


### PR DESCRIPTION
This isn't supported on plain JS classes anyway, so this is just adding
a warning in DEV before the code throws.