### PR TITLE
[PropTypes] Add warnings if necessary parameters are omitted

### DIFF
--- a/src/classic/types/ReactPropTypes.js
+++ b/src/classic/types/ReactPropTypes.js
@@ -137,6 +137,20 @@ function createAnyTypeChecker() {
 }
 
 function createArrayOfTypeChecker(typeChecker) {
+  if (arguments.length !== 1) {
+    // The user might have specified a propType as `React.PropTypes.arrayOf`
+    // with no typeChecker parameter. Guess at where this was used.
+    var inferredPropName = arguments[1];
+    var inferredComponentName = arguments[2];
+    var inferredLocation = arguments[3];
+    var inferredLocationName = ReactPropTypeLocationNames[inferredLocation];
+    return new Error(
+      `React.PropTypes.arrayOf must take one PropType argument to specify ` +
+      `the type of the array elements. You may have forgotten to pass this ` +
+      `argument in the ${inferredLocationName} type of ` +
+      `\`${inferredPropName}\` in \`${inferredComponentName}\`.`
+    );
+  }
   function validate(props, propName, componentName, location) {
     var propValue = props[propName];
     if (!Array.isArray(propValue)) {
@@ -173,6 +187,20 @@ function createElementTypeChecker() {
 }
 
 function createInstanceTypeChecker(expectedClass) {
+  if (arguments.length !== 1) {
+    // The user might have specified a propType as `React.PropTypes.instanceOf`
+    // with no shape object parameter. Guess at where this was used.
+    var inferredPropName = arguments[1];
+    var inferredComponentName = arguments[2];
+    var inferredLocation = arguments[3];
+    var inferredLocationName = ReactPropTypeLocationNames[inferredLocation];
+    return new Error(
+      `React.PropTypes.instanceOf must take one class argument to specify ` +
+      `the expected class. You may have forgotten to pass this argument ` +
+      `in the ${inferredLocationName} type of \`${inferredPropName}\` in ` +
+      `\`${inferredComponentName}\`.`
+    );
+  }
   function validate(props, propName, componentName, location) {
     if (!(props[propName] instanceof expectedClass)) {
       var locationName = ReactPropTypeLocationNames[location];
@@ -188,6 +216,20 @@ function createInstanceTypeChecker(expectedClass) {
 }
 
 function createEnumTypeChecker(expectedValues) {
+  if (arguments.length !== 1) {
+    // The user might have specified a propType as `React.PropTypes.oneOf`
+    // with no shape object parameter. Guess at where this was used.
+    var inferredPropName = arguments[1];
+    var inferredComponentName = arguments[2];
+    var inferredLocation = arguments[3];
+    var inferredLocationName = ReactPropTypeLocationNames[inferredLocation];
+    return new Error(
+      `React.PropTypes.oneOf must take one array argument to specify ` +
+      `the expected values. You may have forgotten to pass this argument ` +
+      `in the ${inferredLocationName} type of \`${inferredPropName}\` in ` +
+      `\`${inferredComponentName}\`.`
+    );
+  }
   function validate(props, propName, componentName, location) {
     var propValue = props[propName];
     for (var i = 0; i < expectedValues.length; i++) {
@@ -207,6 +249,20 @@ function createEnumTypeChecker(expectedValues) {
 }
 
 function createObjectOfTypeChecker(typeChecker) {
+  if (arguments.length !== 1) {
+    // The user might have specified a propType as `React.PropTypes.objectOf`
+    // with no typeChecker parameter. Guess at where this was used.
+    var inferredPropName = arguments[1];
+    var inferredComponentName = arguments[2];
+    var inferredLocation = arguments[3];
+    var inferredLocationName = ReactPropTypeLocationNames[inferredLocation];
+    return new Error(
+      `React.PropTypes.objectOf must take one PropType argument to specify ` +
+      `the expected value types. You may have forgotten to pass this ` +
+      `argument in the ${inferredLocationName} type of ` +
+      `\`${inferredPropName}\` in \`${inferredComponentName}\`.`
+    );
+  }
   function validate(props, propName, componentName, location) {
     var propValue = props[propName];
     var propType = getPropType(propValue);
@@ -231,6 +287,20 @@ function createObjectOfTypeChecker(typeChecker) {
 }
 
 function createUnionTypeChecker(arrayOfTypeCheckers) {
+  if (arguments.length !== 1) {
+    // The user might have specified a propType as `React.PropTypes.oneOfType`
+    // with no arrayOfTypeCheckers parameter. Guess at where this was used.
+    var inferredPropName = arguments[1];
+    var inferredComponentName = arguments[2];
+    var inferredLocation = arguments[3];
+    var inferredLocationName = ReactPropTypeLocationNames[inferredLocation];
+    return new Error(
+      `React.PropTypes.oneOfType must take one array argument to specify ` +
+      `the possible types. You may have forgotten to pass this ` +
+      `argument in the ${inferredLocationName} type of ` +
+      `\`${inferredPropName}\` in \`${inferredComponentName}\`.`
+    );
+  }
   function validate(props, propName, componentName, location) {
     for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
       var checker = arrayOfTypeCheckers[i];
@@ -263,6 +333,20 @@ function createNodeChecker() {
 }
 
 function createShapeTypeChecker(shapeTypes) {
+  if (arguments.length !== 1) {
+    // The user might have specified a propType as `React.PropTypes.shape`
+    // with no shape object parameter. Guess at where this was used.
+    var inferredPropName = arguments[1];
+    var inferredComponentName = arguments[2];
+    var inferredLocation = arguments[3];
+    var inferredLocationName = ReactPropTypeLocationNames[inferredLocation];
+    return new Error(
+      `React.PropTypes.shape must take one object argument to specify ` +
+      `the shape. You may have forgotten to pass this argument in the ` +
+      `${inferredLocationName} type of \`${inferredPropName}\` in ` +
+      `\`${inferredComponentName}\`.`
+    );
+  }
   function validate(props, propName, componentName, location) {
     var propValue = props[propName];
     var propType = getPropType(propValue);

--- a/src/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/classic/types/__tests__/ReactPropTypes-test.js
@@ -220,6 +220,16 @@ describe('ReactPropTypes', function() {
         requiredMessage
       );
     });
+
+    it("should warn if not passed a type argument", function() {
+      typeCheckFail(
+        PropTypes.arrayOf,
+        [],
+        'React.PropTypes.arrayOf must take one PropType argument to specify ' +
+        'the type of the array elements. You may have forgotten to pass ' +
+        'this argument in the prop type of `testProp` in `testComponent`.'
+      );
+    });
   });
 
   describe('Component Type', function() {
@@ -336,6 +346,16 @@ describe('ReactPropTypes', function() {
       );
       typeCheckFail(
         PropTypes.instanceOf(String).isRequired, undefined, requiredMessage
+      );
+    });
+
+    it("should warn if not passed an instance argument", function() {
+      typeCheckFail(
+        PropTypes.instanceOf,
+        null,
+        'React.PropTypes.instanceOf must take one class argument to ' +
+        'specify the expected class. You may have forgotten to pass ' +
+        'this argument in the prop type of `testProp` in `testComponent`.'
       );
     });
   });
@@ -517,6 +537,16 @@ describe('ReactPropTypes', function() {
         requiredMessage
       );
     });
+
+    it("should warn if not passed a type argument", function() {
+      typeCheckFail(
+        PropTypes.objectOf,
+        {hi: 5},
+        'React.PropTypes.objectOf must take one PropType argument to ' +
+        'specify the expected value types. You may have forgotten to pass ' +
+        'this argument in the prop type of `testProp` in `testComponent`.'
+      );
+    });
   });
 
   describe('OneOf Types', function() {
@@ -567,6 +597,16 @@ describe('ReactPropTypes', function() {
         PropTypes.oneOf(['red', 'blue']).isRequired,
         undefined,
         requiredMessage
+      );
+    });
+
+    it("should warn if not passed an array argument", function() {
+      typeCheckFail(
+        PropTypes.oneOf,
+        'value',
+        'React.PropTypes.oneOf must take one array argument to ' +
+        'specify the expected values. You may have forgotten to pass ' +
+        'this argument in the prop type of `testProp` in `testComponent`.'
       );
     });
   });
@@ -626,6 +666,16 @@ describe('ReactPropTypes', function() {
         PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
         undefined,
         requiredMessage
+      );
+    });
+
+    it("should warn if not passed an array argument", function() {
+      typeCheckFail(
+        PropTypes.oneOfType,
+        6,
+        'React.PropTypes.oneOfType must take one array argument to ' +
+        'specify the possible types. You may have forgotten to pass ' +
+        'this argument in the prop type of `testProp` in `testComponent`.'
       );
     });
   });
@@ -710,6 +760,16 @@ describe('ReactPropTypes', function() {
         PropTypes.shape({key: PropTypes.number}).isRequired,
         undefined,
         requiredMessage
+      );
+    });
+
+    it("should warn if not passed a shape argument", function() {
+      typeCheckFail(
+        PropTypes.shape,
+        {hi: 5},
+        'React.PropTypes.shape must take one object argument to ' +
+        'specify the shape. You may have forgotten to pass ' +
+        'this argument in the prop type of `testProp` in `testComponent`.'
       );
     });
   });


### PR DESCRIPTION
Summary:
Right now, if a component specifies a propType as, for example, `myProp: React.PropTypes.shape`, without an actual shape parameter, any prop type will be accepted, because `React.PropTypes.shape` returns a function (the actual validator), not an Error, indicating that propType checking passed.

This can create an unfortunate situation where a component looks like it has fully specified `propTypes`, but in fact does not.

This commit addresses this by making `React.PropTypes.shape` et al. warn if they are passed arguments from propType checking rather than the single argument expected at creation time.

Alternatively, we could check that only `null` or instances of `Error` are returned from propType functions, but given there is a test case testing that this is not true for custom components, I wasn't sure if that was the right way to implement this.

Test Plan:
Added unit tests; ran `jest` in the root repo directory.
Also ran `grunt lint` and `grunt test`