### PR TITLE
Fixed shallowEqual for arguments that are not objects

### DIFF
--- a/src/utils/__tests__/shallowEqual-test.js
+++ b/src/utils/__tests__/shallowEqual-test.js
@@ -41,6 +41,24 @@ describe('shallowEqual', function() {
     ).toBe(true);
   });
 
+  it('returns false if arguments are not objects and not equal', function() {
+    expect(
+      shallowEqual(
+        1,
+        2
+      )
+    ).toBe(false);
+  });
+
+  it('returns false if only one argument is not an object', function() {
+    expect(
+      shallowEqual(
+        1,
+        {}
+      )
+    ).toBe(false);
+  })
+
   it('returns false if first argument has too many keys', function() {
     expect(
       shallowEqual(

--- a/src/utils/shallowEqual.js
+++ b/src/utils/shallowEqual.js
@@ -27,6 +27,10 @@ function shallowEqual(objA, objB) {
     return false;
   }
 
+  if (typeof objA !== 'object' || typeof objB !== 'object') {
+    return false;
+  }
+
   var key;
   // Test for A's keys different from B.
   for (key in objA) {


### PR DESCRIPTION
Fixed shallowEqual implementation to handle the case when inputs are not objects.

If either argument is not an object and unequal, then shallowEqual should return false.
If only one argument is an object, then shallowEqual should return false.

Fixes #3369