### PR TITLE
Update tutorial18.js

### DIFF
--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -569,14 +569,16 @@ Let's call the callback from the `CommentForm` when the user submits the form:
 var CommentForm = React.createClass({
   handleSubmit: function(e) {
     e.preventDefault();
-    var author = React.findDOMNode(this.refs.author).value.trim();
-    var text = React.findDOMNode(this.refs.text).value.trim();
+    var authorInput = this.refs.author.getDOMNode();
+    var textInput = this.refs.text.getDOMNode();
+    var author = authorInput.value.trim();
+    var text = textInput.value.trim();
     if (!text || !author) {
       return;
     }
     this.props.onCommentSubmit({author: author, text: text});
-    React.findDOMNode(this.refs.author).value = '';
-    React.findDOMNode(this.refs.text).value = '';
+    authorInput.value = '';
+    textInput.value = '';
     return;
   },
   render: function() {


### PR DESCRIPTION
React.findDOMNode doesn't seem exist in React 0.12.2. I followed the tutorial, but received undefined exception.
So I used getDOMNode() instead. It works for me now.