### PR TITLE
Fix module option parsing of jsx command

### DIFF
--- a/bin/jsx
+++ b/bin/jsx
@@ -44,7 +44,7 @@ require('commoner').version(
     sourceMap: this.options.sourceMapInline,
     stripTypes: this.options.stripTypes,
     es6module: this.options.es6module,
-    nonStrictEs6Module: this.options.nonStrictEs6Module,
+    nonStrictEs6module: this.options.nonStrictEs6module,
     target: this.options.target
   };
   return transform(source, options);

--- a/main.js
+++ b/main.js
@@ -60,8 +60,8 @@ function processOptions(opts) {
   if (opts.es6module) {
     options.sourceType = 'module';
   }
-  if (opts.nonStrictEs6Module) {
-    options.sourceType = 'nonStrict6Module';
+  if (opts.nonStrictEs6module) {
+    options.sourceType = 'nonStrictModule';
   }
 
   // Instead of doing any fancy validation, only look for 'es3'. If we have


### PR DESCRIPTION
I got this shockingly wrong while refactoring in #2847. I found this while debugging #3379.

The command line option is `--non-strict-es6module`, which gets converted to `options.nonStrictEs6module`, not what I had. Even if I'd gotten it right, I was passing the wrong option to esprima...