### PR TITLE
Nominalized 'shallow copy'

### DIFF
--- a/docs/docs/10.7-update.md
+++ b/docs/docs/10.7-update.md
@@ -39,7 +39,7 @@ var newData = extend(myData, {
 });
 ```
 
-While this is fairly performant (since it only shallow copies `log n` objects and reuses the rest), it's a big pain to write. Look at all the repetition! This is not only annoying, but also provides a large surface area for bugs.
+While this is fairly performant (since it only makes a shallow copy of `log n` objects and reuses the rest), it's a big pain to write. Look at all the repetition! This is not only annoying, but also provides a large surface area for bugs.
 
 `update()` provides simple syntactic sugar around this pattern to make writing this code easier. This code becomes:
 


### PR DESCRIPTION
I mis-parsed 'shallow copies' as adjective noun, instead of as a compound verb. I've adjusted the text to make it easier to parse on the first read, which should also help ESL learners to be able to parse it easier.