### PR TITLE
ESLint ignores built files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -17,3 +17,6 @@ docs/js/
 # This should be more like examples/**/thirdparty/** but
 # we should fix https://github.com/facebook/esprima/pull/85 first
 examples/
+# Ignore built files.
+build/
+


### PR DESCRIPTION
Currently, `grunt lint` has many errors and warnings against build files.

```
➜ grunt lint
:
✖ 120208 problems (118178 errors, 2030 warnings)
```

Ignore `build` directory.

```
➜ grunt lint
:
✖ 104 problems (0 errors, 104 warnings)
```

Do you have any reason why you are including built files to ESLint target?