### PR TITLE
Fix for empty <select> elements with value

### DIFF
--- a/src/browser/ui/dom/components/ReactDOMSelect.js
+++ b/src/browser/ui/dom/components/ReactDOMSelect.js
@@ -89,7 +89,9 @@ function updateOptions(component, propValue) {
         return;
       }
     }
-    options[0].selected = true;
+    if (options.length) {
+      options[0].selected = true;
+    }
   }
 }
 

--- a/src/browser/ui/dom/components/__tests__/ReactDOMSelect-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMSelect-test.js
@@ -43,6 +43,14 @@ describe('ReactDOMSelect', function() {
     expect(node.value).toEqual('giraffe');
   });
 
+  it('should not throw with `defaultValue` and without children', function() {
+    var stub = <select defaultValue="dummy"></select>;
+
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(stub);
+    }).not.toThrow();
+  });
+
   it('should not control when using `defaultValue`', function() {
     var stub =
       <select defaultValue="giraffe">
@@ -98,6 +106,14 @@ describe('ReactDOMSelect', function() {
     // Changing the `value` prop should change the selected option.
     stub.setProps({value: 'gorilla'});
     expect(node.value).toEqual('gorilla');
+  });
+
+  it('should not throw with `value` and without children', function() {
+    var stub = <select value="dummy"></select>;
+
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(stub);
+    }).not.toThrow();
   });
 
   it('should allow setting `value` with multiple', function() {


### PR DESCRIPTION
There is an exception when value or defaultValue is set but there are no
children as ReactDOMSelect tries to mark the first children as selected
even if there are no children.

Found this issue when upgraded to 0.13 from 0.12.

JSFiddle bug demo: http://jsfiddle.net/3tL0krav/