### PR TITLE
Allow props to be a plain string, specifying className

### DIFF
--- a/src/classic/element/ReactElement.js
+++ b/src/classic/element/ReactElement.js
@@ -156,6 +156,9 @@ ReactElement.createElement = function(type, config, children) {
   var ref = null;
 
   if (config != null) {
+    if (typeof config === "string") {
+      config = { className: config };
+    }
     ref = config.ref === undefined ? null : config.ref;
     key = config.key === undefined ? null : '' + config.key;
     // Remaining properties are added to a new props object

--- a/src/classic/element/ReactElement.js
+++ b/src/classic/element/ReactElement.js
@@ -156,7 +156,7 @@ ReactElement.createElement = function(type, config, children) {
   var ref = null;
 
   if (config != null) {
-    if (typeof config === "string") {
+    if (typeof config === 'string') {
       config = { className: config };
     }
     ref = config.ref === undefined ? null : config.ref;

--- a/src/classic/element/__tests__/ReactElement-test.js
+++ b/src/classic/element/__tests__/ReactElement-test.js
@@ -363,9 +363,9 @@ describe('ReactElement', function() {
 
   it('allows props to be a string specifying className', function() {
       var div = ReactTestUtils.renderIntoDocument(
-        React.createElement("div", "foo")
+        React.createElement('div', 'foo')
       );
-      expect(div.props.className).toBe("foo");
+      expect(div.props.className).toBe('foo');
   });
 
 });

--- a/src/classic/element/__tests__/ReactElement-test.js
+++ b/src/classic/element/__tests__/ReactElement-test.js
@@ -361,4 +361,11 @@ describe('ReactElement', function() {
     expect(console.warn.argsForCall.length).toBe(0);
   });
 
+  it('allows props to be a string specifying className', function() {
+      var div = ReactTestUtils.renderIntoDocument(
+        React.createElement("div", "foo")
+      );
+      expect(div.props.className).toBe("foo");
+  });
+
 });


### PR DESCRIPTION
A tiny, low-impact (basically non-breaking) change that I find makes a big difference to succinctness when rendering without JSX. I've added a minimal test, checked lint, and submitted the CLA.

Render declaration trees tend to frequently include instances of `div` and `span` which only have `className` and nothing else, because they're purely structural and provide a way for CSS to inject styling.

Also with ES destructuring assignment, I can say:

    var { DOM: { div, span, p, input, button } } = React;

This succinctly imports frequently used elements into the scope, and combined with this pull-request, allows me to write render functions like this:

    render() {
      return div('container',
               div('heading',
                 span('column1'),
                 span('column2')
               ),
               div('blah')
             );
    }

This makes it somewhat more succinct than JSX! :)

The prior code was written to assume that props is an object, so this change simply checks for a string and converts it to an object with a property `className`.

Regarding static typing, no change is required to the `react.d.ts` file on DefinitelyTyped because all the properties of `HTMLAttributes` are optional, so `string` already conforms to it.

Furthermore, designers of components could optionally support a `className` property in their props if they wanted to be able to accept a string in this way (which they could then interpret however they wished). Although the main purpose here is to make plain DOM elements more succinct.