### PR TITLE
Fix incorrect update of style when props.style transitions from null to non-null

### DIFF
--- a/src/browser/ui/ReactDOMComponent.js
+++ b/src/browser/ui/ReactDOMComponent.js
@@ -367,6 +367,7 @@ ReactDOMComponent.Mixin = {
             styleUpdates[styleName] = '';
           }
         }
+        this._previousStyleCopy = null;
       } else if (registrationNameModules.hasOwnProperty(propKey)) {
         if (lastProps[propKey]) {
           // Only call deleteListener if there was a listener previously or

--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -152,6 +152,17 @@ describe('ReactDOMComponent', function() {
       expect(stubStyle.color).toEqual('');
     });
 
+    it("should update styles when 'style' changes from null to object", function() {
+      var container = document.createElement('div');
+      var styles = {color: 'red'};
+      React.render(<div style={styles} />, container);
+      React.render(<div />, container);
+      React.render(<div style={styles} />, container);
+
+      var stubStyle = container.firstChild.style;
+      expect(stubStyle.color).toEqual('red');
+    });
+
     it("should empty element when removing innerHTML", function() {
       var container = document.createElement('div');
       React.render(<div dangerouslySetInnerHTML={{__html: ':)'}} />, container);


### PR DESCRIPTION
ReactDOMComponent maintains a copy of the previous style
object to support in-place mutations of props.style.

This cached object was not cleared when the style
property was removed in a props update.

Fixes #3409