### PR TITLE
Link to inserting raw HTML document

### DIFF
--- a/docs/docs/02.3-jsx-gotchas.md
+++ b/docs/docs/02.3-jsx-gotchas.md
@@ -46,7 +46,7 @@ You can use mixed arrays with strings and JSX elements.
 <div>{['First ', <span>&middot;</span>, ' Second']}</div>
 ```
 
-As a last resort, you always have the ability to [insert raw HTML](/react/docs/dom-differences.html).
+As a last resort, you always have the ability to [insert raw HTML](/react/tips/dangerously-set-inner-html.html).
 
 ```javascript
 <div dangerouslySetInnerHTML={{'{{'}}__html: 'First &middot; Second'}} />


### PR DESCRIPTION
Previously linked to the "DOM Difference" document, which contains no information whatsoever on inserting raw HTML at this point.