### PR TITLE
Fix small typo

### DIFF
--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -200,7 +200,7 @@ class HelloMessage extends React.Component {
 React.render(<HelloMessage name="Sebastian" />, mountNode);
 ```
 
-The API is similar to `React.createClass` with the exception or `getInitialState`. Instead of providing a separate `getInitialState` method, you set up your own `state` property in the constructor.
+The API is similar to `React.createClass` with the exception of `getInitialState`. Instead of providing a separate `getInitialState` method, you set up your own `state` property in the constructor.
 
 Another difference is that `propTypes` and `defaultProps` are defined as properties on the constructor instead of in the class body.
 


### PR DESCRIPTION
Just discovered this when reading up on the new ES6 syntax react. I guess it should read

>  with the exception [of] getInitialState

compared to the current version:

> with the exception [or] getInitialState

This PR fixes this :)