### PR TITLE
Give `displayName` for all compositeComponent spec functions

### DIFF
--- a/src/classic/class/ReactClass.js
+++ b/src/classic/class/ReactClass.js
@@ -322,7 +322,7 @@ var RESERVED_SPEC_KEYS = {
   mixins: function(Constructor, mixins) {
     if (mixins) {
       for (var i = 0; i < mixins.length; i++) {
-        mixSpecIntoComponent(Constructor, mixins[i]);
+        mixSpecIntoComponent(Constructor, mixins[i], true);
       }
     }
   },
@@ -437,7 +437,7 @@ function validateMethodOverride(proto, name) {
  * Mixin helper which handles policy validation and reserved
  * specification keys when building React classses.
  */
-function mixSpecIntoComponent(Constructor, spec) {
+function mixSpecIntoComponent(Constructor, spec, isFromMixin) {
   if (!spec) {
     return;
   }
@@ -522,13 +522,22 @@ function mixSpecIntoComponent(Constructor, spec) {
           }
         } else {
           proto[name] = property;
-          if (__DEV__) {
-            // Add verbose displayName to the function, which helps when looking
-            // at profiling tools.
-            if (typeof property === 'function' && spec.displayName) {
-              proto[name].displayName = spec.displayName + '_' + name;
-            }
-          }
+        }
+      }
+      if (__DEV__) {
+        // Add verbose displayName to the function, which helps when looking
+        // at profiling tools.
+        var displayName;
+        if (isFromMixin) {
+          displayName = 'mixin';
+        } else {
+          displayName = Constructor.displayName || 'anonymous';
+        }
+        if (typeof property === 'function') {
+          // `proto[name]` might not === `property` if the former is a
+          // chained/merged method.
+          proto[name].displayName = displayName + '_' + name;
+          property.displayName = displayName + '_' + name;
         }
       }
     }

--- a/src/classic/class/__tests__/ReactClass-test.js
+++ b/src/classic/class/__tests__/ReactClass-test.js
@@ -44,6 +44,49 @@ describe('ReactClass-spec', function() {
       .toBe('TestComponent');
   });
 
+  it('gives methods a displayName for testing purposes', function() {
+      var a = function() {};
+      var b = function() {};
+      var c = function() {};
+      var d = function() {return <div></div>;};
+      var e = function() {};
+      var f = function() {};
+      var g = function() {};
+      var mixin = {
+        getInitialState: f,
+        componentDidMount: g,
+      };
+      var Component = React.createClass({
+        mixins: [mixin],
+        componentDidMount: a, // DEFINE_MANY
+        onClick: b,
+        random: c,
+        render: d,
+        getInitialState: e, // DEFINE_MANY_MERGED
+      });
+      // componentDidMount on component
+      expect(a.displayName).toBe('Component_componentDidMount');
+      expect(b.displayName).toBe('Component_onClick');
+      expect(c.displayName).toBe('Component_random');
+      expect(d.displayName).toBe('Component_render');
+      // getInitialState on component
+      expect(e.displayName).toBe('Component_getInitialState');
+      // both on mixin
+      expect(f.displayName).toBe('mixin_getInitialState');
+      expect(g.displayName).toBe('mixin_componentDidMount');
+      // DEFINE_MANY and DEFINE_MANY_MERGED specs create new chained/merged
+      // functions, test those too
+      expect(Component.type.prototype.getInitialState.displayName)
+        .toBe('Component_getInitialState');
+      expect(Component.type.prototype.componentDidMount.displayName)
+        .toBe('Component_componentDidMount');
+
+      React.createClass({
+        render: d,
+      });
+      expect(d.displayName).toBe('anonymous_render');
+    });
+
   it('should warn when accessing .type on a React class', function() {
     var TestComponent = React.createClass({
       render: function() {


### PR DESCRIPTION
(#2052 broke somehow, resubmitting)

Previously it was only given to a subset of the functions on the spec.
Fixes #3173.
@zpao 