### PR TITLE
Ensure FullPageComponents are treated as DOM components

### DIFF
--- a/src/browser/ui/dom/components/createFullPageComponent.js
+++ b/src/browser/ui/dom/components/createFullPageComponent.js
@@ -33,6 +33,7 @@ function createFullPageComponent(tag) {
   var elementFactory = ReactElement.createFactory(tag);
 
   var FullPageComponent = ReactClass.createClass({
+    tagName: tag.toUpperCase(),
     displayName: 'ReactFullPageComponent' + tag,
 
     componentWillUnmount: function() {

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -206,4 +206,28 @@ describe('ReactTestUtils', function() {
 
     expect(console.warn.calls.length).toBe(0);
   });
+
+  it('should support injected wrapper components as DOM components', function() {
+    var injectedDOMComponents = [
+      'button',
+      'form',
+      'iframe',
+      'img',
+      'input',
+      'option',
+      'select',
+      'textarea',
+      'html',
+      'head',
+      'body'
+    ];
+
+    injectedDOMComponents.forEach(function(type) {
+      var component = ReactTestUtils.renderIntoDocument(
+        React.createElement(type)
+      );
+      expect(component.tagName).toBe(type.toUpperCase());
+      expect(ReactTestUtils.isDOMComponent(component)).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
#3421 surfaced and looked like a general issue but that didn't make much sense since we use those methods. It turns out it's specific to a couple types of DOM components, specifically the ones we wrap with composite components to add warnings for full page rendering.

Fixes #3421.