### PR TITLE
Add a note about react classe name convention

### DIFF
--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -87,6 +87,8 @@ React.render(
 );
 ```
 
+Note that native HTML element names start with a lowercase letter, while custom React classes names begin with an uppercase letter.
+
 #### JSX Syntax
 
 The first thing you'll notice is the XML-ish syntax in your JavaScript. We have a simple precompiler that translates the syntactic sugar to this plain JavaScript:


### PR DESCRIPTION
I lost quite some time trying to figure out what was happening. No error in console and nothing showing up. Turns out it was only because of not using uppercase first letter for my classes names. So I'd like to add it in this tutorial as a note.