### PR TITLE
Include the owner name when warning about createElement(null/undefined).

### DIFF
--- a/src/classic/element/ReactElementValidator.js
+++ b/src/classic/element/ReactElementValidator.js
@@ -264,7 +264,7 @@ function checkPropTypes(componentName, propTypes, props, location) {
         // same error.
         loggedTypeFailures[error.message] = true;
 
-        var addendum = getDeclarationErrorAddendum(this);
+        var addendum = getDeclarationErrorAddendum();
         warning(false, 'Failed propType: %s%s', error.message, addendum);
       }
     }
@@ -402,7 +402,8 @@ var ReactElementValidator = {
       type != null,
       'React.createElement: type should not be null or undefined. It should ' +
         'be a string (for DOM elements) or a ReactClass (for composite ' +
-        'components).'
+        'components).%s',
+      getDeclarationErrorAddendum()
     );
 
     var element = ReactElement.createElement.apply(this, arguments);

--- a/src/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/classic/element/__tests__/ReactElementValidator-test.js
@@ -277,6 +277,27 @@ describe('ReactElementValidator', function() {
     expect(console.warn.calls.length).toBe(2);
   });
 
+  it('includes the owner name when passing null or undefined', function() {
+    spyOn(console, 'warn');
+    var ParentComp = React.createClass({
+      render: function() {
+        return React.createElement(null);
+      }
+    });
+    expect(function() {
+      ReactTestUtils.renderIntoDocument(React.createElement(ParentComp));
+    }).toThrow();
+    expect(console.warn.calls.length).toBe(2);
+    expect(console.warn.calls[0].args[0]).toBe(
+      'Warning: React.createElement: type should not be null or undefined. ' +
+      'It should be a string (for DOM elements) or a ReactClass (for ' +
+      'composite components). Check the render method of `ParentComp`.'
+    );
+    expect(console.warn.calls[1].args[0]).toBe(
+      'Warning: Only functions or strings can be mounted as React components.'
+    );
+  });
+
   it('should check default prop values', function() {
     spyOn(console, 'warn');
 


### PR DESCRIPTION
Makes it easier to find the callsite that needs to be fixed.

Builds on the warning message added by #2726