### PR TITLE
Add warning for getDOMNode calls.

### DIFF
--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -47,7 +47,7 @@ var ReactCSSTransitionGroupChild = React.createClass({
   displayName: 'ReactCSSTransitionGroupChild',
 
   transition: function(animationType, finishCallback) {
-    var node = this.getDOMNode();
+    var node = React.findDOMNode(this);
     var className = this.props.name + '-' + animationType;
     var activeClassName = className + '-active';
     var noEventTimeout = null;
@@ -95,7 +95,7 @@ var ReactCSSTransitionGroupChild = React.createClass({
   flushClassNameQueue: function() {
     if (this.isMounted()) {
       this.classNameQueue.forEach(
-        CSSCore.addClass.bind(CSSCore, this.getDOMNode())
+        CSSCore.addClass.bind(CSSCore, React.findDOMNode(this))
       );
     }
     this.classNameQueue.length = 0;

--- a/src/browser/ui/ReactBrowserComponentMixin.js
+++ b/src/browser/ui/ReactBrowserComponentMixin.js
@@ -11,7 +11,12 @@
 
 'use strict';
 
+var ReactInstanceMap = require('ReactInstanceMap');
+
 var findDOMNode = require('findDOMNode');
+var warning = require('warning');
+
+var didWarnKey = '_getDOMNodeDidWarn';
 
 var ReactBrowserComponentMixin = {
   /**
@@ -22,6 +27,13 @@ var ReactBrowserComponentMixin = {
    * @protected
    */
   getDOMNode: function() {
+    warning(
+      this.constructor[didWarnKey],
+      '%s.getDOMNode(...) is deprecated. Please use ' +
+      'React.findDOMNode(instance) instead.',
+      ReactInstanceMap.get(this).getName() || this.tagName || 'Unknown'
+    );
+    this.constructor[didWarnKey] = true;
     return findDOMNode(this);
   }
 };

--- a/src/classic/class/__tests__/ReactClass-test.js
+++ b/src/classic/class/__tests__/ReactClass-test.js
@@ -378,4 +378,23 @@ describe('ReactClass-spec', function() {
     );
   });
 
+  it('warns when calling getDOMNode', function() {
+    var MyComponent = React.createClass({
+      render: function() {
+        return <div />;
+      }
+    });
+
+    var container = document.createElement('div');
+    var instance = React.render(<MyComponent />, container);
+
+    instance.getDOMNode();
+
+    expect(console.warn.calls.length).toBe(1);
+    expect(console.warn.calls[0].args[0]).toContain(
+      'MyComponent.getDOMNode(...) is deprecated. Please use ' +
+      'React.findDOMNode(instance) instead.'
+    );
+  });
+
 });

--- a/src/core/__tests__/ReactComponent-test.js
+++ b/src/core/__tests__/ReactComponent-test.js
@@ -265,4 +265,19 @@ describe('ReactComponent', function() {
     expect(callback.mock.calls.length).toBe(3);
   });
 
+  it('warns when calling getDOMNode', function() {
+    spyOn(console, 'warn');
+
+    var container = document.createElement('div');
+    var instance = React.render(<div />, container);
+
+    instance.getDOMNode();
+
+    expect(console.warn.calls.length).toBe(1);
+    expect(console.warn.calls[0].args[0]).toContain(
+      'DIV.getDOMNode(...) is deprecated. Please use ' +
+      'React.findDOMNode(instance) instead.'
+    );
+  });
+
 });


### PR DESCRIPTION
This adds a warning for calls to getDOMNode and removes the last callers in ReactCSSTransitionGroup.

I was thinking of doing one warning per page load but changed it to one warning per component instance. It kinda sucks but I honestly don't know how to clear the module registry in the open source tests to be able to test for this :)