### PR TITLE
Removed build:test from test:coverage.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -201,7 +201,6 @@ module.exports = function(grunt) {
   ]);
 
   grunt.registerTask('test:coverage', [
-    'build:test',
     'build:withCodeCoverageLogging',
     'test:webdriver:phantomjs',
     'coverage:parse'


### PR DESCRIPTION
This was a duplicate task for build:withCodeCoverageLogging.
It should now properly output the lines which are not covered.

This is the same PR as #3482 but without the messed up rebase.