### PR TITLE
Fix the context handling when updating a rendered component.

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -743,7 +743,7 @@ var ReactCompositeComponentMixin = {
         this._renderedComponent,
         thisID,
         transaction,
-        context
+        this._processChildContext(context)
       );
       this._replaceNodeWithMarkupByID(prevComponentID, nextMarkup);
     }


### PR DESCRIPTION
When a component is re-rendered, the context is not properly processed for children. The new test-case demonstrates it: with the current code base, 2 warnings are emitted because of the context mismatch.

Note: this PR is based on the comments of the issue #3404.

I have accepted the CLA.
