### PR TITLE
Don't add 'px' to strokeDashoffset CSS Properties

### DIFF
--- a/src/browser/ui/dom/CSSProperty.js
+++ b/src/browser/ui/dom/CSSProperty.js
@@ -34,7 +34,8 @@ var isUnitlessNumber = {
   // SVG-related properties
   fillOpacity: true,
   strokeOpacity: true,
-  strokeWidth: true
+  strokeWidth: true,
+  strokeDashoffset: true
 };
 
 /**

--- a/src/browser/ui/dom/CSSProperty.js
+++ b/src/browser/ui/dom/CSSProperty.js
@@ -33,9 +33,9 @@ var isUnitlessNumber = {
 
   // SVG-related properties
   fillOpacity: true,
+  strokeDashoffset: true,
   strokeOpacity: true,
-  strokeWidth: true,
-  strokeDashoffset: true
+  strokeWidth: true
 };
 
 /**


### PR DESCRIPTION
This is a SVG CSS Property. The standard expects values or percentages, and adding "px" to the value will break it.

http://www.w3.org/TR/SVG/painting.html#StrokeDashoffsetProperty