### PR TITLE
Add scoped property to the list of DOM standard properties

### DIFF
--- a/docs/docs/ref-04-tags-and-attributes.md
+++ b/docs/docs/ref-04-tags-and-attributes.md
@@ -60,7 +60,7 @@ formAction formEncType formMethod formNoValidate formTarget frameBorder height
 hidden href hrefLang htmlFor httpEquiv icon id label lang list loop manifest
 marginHeight marginWidth max maxLength media mediaGroup method min multiple
 muted name noValidate open pattern placeholder poster preload radioGroup
-readOnly rel required role rows rowSpan sandbox scope scrolling seamless
+readOnly rel required role rows rowSpan sandbox scope scoped scrolling seamless
 selected shape size sizes span spellCheck src srcDoc srcSet start step style
 tabIndex target title type useMap value width wmode
 ```

--- a/src/browser/ui/dom/HTMLDOMPropertyConfig.js
+++ b/src/browser/ui/dom/HTMLDOMPropertyConfig.js
@@ -134,6 +134,7 @@ var HTMLDOMPropertyConfig = {
     rowSpan: null,
     sandbox: null,
     scope: null,
+    scoped: HAS_BOOLEAN_VALUE,
     scrolling: null,
     seamless: MUST_USE_ATTRIBUTE | HAS_BOOLEAN_VALUE,
     selected: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,

--- a/src/browser/ui/dom/__tests__/DOMPropertyOperations-test.js
+++ b/src/browser/ui/dom/__tests__/DOMPropertyOperations-test.js
@@ -89,6 +89,11 @@ describe('DOMPropertyOperations', function() {
         'checked',
         false
       )).toBe('');
+
+      expect(DOMPropertyOperations.createMarkupForProperty(
+        'scoped',
+        true
+      )).toBe('scoped=""');
     });
 
     it('should create markup for booleanish properties', function() {


### PR DESCRIPTION
Allow the use of "scoped" property on the style tag.
http://w3c.github.io/html-reference/style.html#style-interface

Useful to isolate the scope of application of the style code.
Needed for example to create a component that get external style code and apply it only to the component instead of all DOM.