### PR TITLE
npm-react-codemod: Class transform doesn’t need aliases

### DIFF
--- a/npm-react-codemod/package.json
+++ b/npm-react-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-codemod",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "React codemod scripts",
   "license": "BSD-3-Clause",
   "repository": {

--- a/npm-react-codemod/test/class-test3.output.js
+++ b/npm-react-codemod/test/class-test3.output.js
@@ -3,7 +3,7 @@
 var React = require('React');
 
 // Comment
-module.exports = class __exports extends React.Component {
+module.exports = class extends React.Component {
   constructor(props, context) {
     super(props, context);
 

--- a/npm-react-codemod/transforms/class.js
+++ b/npm-react-codemod/transforms/class.js
@@ -338,9 +338,7 @@ function updateReactCreateClassToES6(file, api, options) {
     shouldAddSuperClass
   ) =>
     withComments(j.classDeclaration(
-      // ast-types does not yet support empty class names
-      // See: https://github.com/benjamn/ast-types/pull/102
-      name ? j.identifier(name) : j.identifier('__exports'),
+      name ? j.identifier(name) : null,
       j.classBody(
         [].concat(
           createConstructor(


### PR DESCRIPTION
Before: `module.exports = class __exports extends React.Component {}`
After: `module.exports = class extends React.Component {}`

See https://github.com/benjamn/ast-types/commit/638ef2b9d2f43938f64677c1109188092393b644