### PR TITLE
Docs: Clarify that React.PropTypes.node accepts fragments

### DIFF
--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -26,7 +26,7 @@ React.createClass({
     optionalString: React.PropTypes.string,
 
     // Anything that can be rendered: numbers, strings, elements or an array
-    // containing these types.
+    // (or fragment) containing these types.
     optionalNode: React.PropTypes.node,
 
     // A React element.


### PR DESCRIPTION
As of #3293 `ReactFragment` counts as a node, but this isn't made clear in the docs.