### PR TITLE
Swapping defaultChecked and defaultValue

### DIFF
--- a/docs/docs/07-forms.md
+++ b/docs/docs/07-forms.md
@@ -87,7 +87,7 @@ If you want to initialize the component with a non-empty value, you can supply a
 
 This example will function much like the **Controlled Components** example above.
 
-Likewise, `<input>` supports `defaultValue` and `<select>` supports `defaultChecked`.
+Likewise, `<input>` supports `defaultChecked` and `<select>` supports `defaultValue`.
 
 
 ## Advanced Topics


### PR DESCRIPTION
The current documentation states that the `<select>` tag supports `defaultChecked`, but it actually doesn't. I believe this documentation was meant to be written in the proposed order. 

Non-working fiddle using `defaultChecked`: http://jsfiddle.net/jqs1hsLr/1/
Working fiddle using `defaultValue`: http://jsfiddle.net/nv7z0yzL/1/