### PR TITLE
Fix small typo in 11-advanced-performance.md.

### DIFF
--- a/docs/docs/11-advanced-performance.md
+++ b/docs/docs/11-advanced-performance.md
@@ -38,7 +38,7 @@ Here's a subtree of components. For each one is indicated what `shouldComponentU
 
 <figure><img src="/react/img/docs/should-component-update.png" /></figure>
 
-In the example above, since `shouldComponentUpdate` returned `false` for the subtree rooted at C2, React had no need to generate the new virtual DOM, and therefore, it neither needed to reconcile the DOM. Note that React didn't even had to invoke `shouldComponentUpdate` on C4 and C5.
+In the example above, since `shouldComponentUpdate` returned `false` for the subtree rooted at C2, React had no need to generate the new virtual DOM, and therefore, it neither needed to reconcile the DOM. Note that React didn't even have to invoke `shouldComponentUpdate` on C4 and C5.
 
 For C1 and C3 `shouldComponentUpdate` returned `true`, so React had to go down to the leaves and check them. For C6 it returned `true`; since the virtual DOMs weren't equivalent it had to reconcile the DOM.
 The last interesting case is C8. For this node React had to compute the virtual DOM, but since it was equal to the old one, it didn't have to reconcile it's DOM.


### PR DESCRIPTION
"React didn't even had"->"React didn't even have"

http://english.stackexchange.com/questions/204603/proper-usage-of-didnt-had-or-didnt-have