### PR TITLE
fix render order error in safari

### DIFF
--- a/src/browser/ui/dom/DOMChildrenOperations.js
+++ b/src/browser/ui/dom/DOMChildrenOperations.js
@@ -31,10 +31,20 @@ function insertChildAt(parentNode, childNode, index) {
   // rely exclusively on `insertBefore(node, null)` instead of also using
   // `appendChild(node)`. However, using `undefined` is not allowed by all
   // browsers so we must replace it with `null`.
-  parentNode.insertBefore(
-    childNode,
-    parentNode.childNodes[index] || null
-  );
+
+  // fix render order error in safari
+  try {
+    parentNode.insertBefore(
+      childNode,
+      parentNode.childNodes.item(index) || null
+    );
+  } catch (e) {
+    //IE8 can't use `item` when childNodes is empty.
+    parentNode.insertBefore(
+      childNode,
+      parentNode.childNodes[index] || null
+    );  
+  }
 }
 
 /**

--- a/src/browser/ui/dom/DOMChildrenOperations.js
+++ b/src/browser/ui/dom/DOMChildrenOperations.js
@@ -33,13 +33,14 @@ function insertChildAt(parentNode, childNode, index) {
   // browsers so we must replace it with `null`.
 
   // fix render order error in safari
-  try {
+  if (!(document.all && !document.addEventListener)) {
     parentNode.insertBefore(
       childNode,
       parentNode.childNodes.item(index) || null
     );
-  } catch (e) {
-    //IE8 can't use `item` when childNodes is empty.
+  } else {
+    //IE8 can't use `item` when childNodes is empty or dynamic insert.
+    //But read is well after insert.
     parentNode.insertBefore(
       childNode,
       parentNode.childNodes[index] || null

--- a/src/browser/ui/dom/DOMChildrenOperations.js
+++ b/src/browser/ui/dom/DOMChildrenOperations.js
@@ -33,19 +33,17 @@ function insertChildAt(parentNode, childNode, index) {
   // browsers so we must replace it with `null`.
 
   // fix render order error in safari
-  if (!(document.all && !document.addEventListener)) {
-    parentNode.insertBefore(
-      childNode,
-      parentNode.childNodes.item(index) || null
-    );
-  } else {
-    //IE8 can't use `item` when childNodes is empty or dynamic insert.
-    //But read is well after insert.
-    parentNode.insertBefore(
-      childNode,
-      parentNode.childNodes[index] || null
-    );  
-  }
+  // IE8 can't use `item` when childNodes is empty or dynamic insert.
+  // Because index out of list
+  // But read is well after insert.
+  var beforeChild = index >= parentNode.childNodes.length ?
+                    null :
+                    parentNode.childNodes.item(index);
+
+  parentNode.insertBefore(
+    childNode,
+    beforeChild
+  );
 }
 
 /**

--- a/src/browser/ui/dom/DOMChildrenOperations.js
+++ b/src/browser/ui/dom/DOMChildrenOperations.js
@@ -33,9 +33,7 @@ function insertChildAt(parentNode, childNode, index) {
   // browsers so we must replace it with `null`.
 
   // fix render order error in safari
-  // IE8 can't use `item` when childNodes is empty or dynamic insert.
-  // Because index out of list
-  // But read is well after insert.
+  // IE8 will throw error when index out of list size.
   var beforeChild = index >= parentNode.childNodes.length ?
                     null :
                     parentNode.childNodes.item(index);


### PR DESCRIPTION
safari version 8.0.5 (10600.5.16).

When a dom's id is a number string, link `<div id="1"></div>`, use childNodes in safari will make errors.
If `div#1` is the first and only child of parent, when you get `childNodes[1]`, it will return this dom, not `undefined`.Then, dom's order will be confused.

In safari, `childNodes` will find id that equal index, it may be a error.But, all popular browser has `childNodes.item`, it will get child with index.

see the demo: http://mariodu.github.io/childNodes.html.