### PR TITLE
Nicer warning for arrayOf propTypes checker

### DIFF
--- a/src/classic/types/ReactPropTypes.js
+++ b/src/classic/types/ReactPropTypes.js
@@ -145,7 +145,13 @@ function createArrayOfTypeChecker(typeChecker) {
       );
     }
     for (var i = 0; i < propValue.length; i++) {
-      var error = typeChecker(propValue, i, componentName, location);
+      // the type checker functions implicitly retrieve prop value through
+      // props[propName] (and warn using propName). Which requires passing (array,
+      // index, ...) here. But for debugging we'd want to see the name of the
+      // prop instead of an index. This makes it work.
+      var obj = {};
+      obj[propName] = propValue[i];
+      var error = typeChecker(obj, propName, componentName, location);
       if (error instanceof Error) {
         return error;
       }

--- a/src/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/classic/types/__tests__/ReactPropTypes-test.js
@@ -161,8 +161,8 @@ describe('ReactPropTypes', function() {
       typeCheckFail(
         PropTypes.arrayOf(PropTypes.number),
         [1, 2, 'b'],
-        'Invalid prop `2` of type `string` supplied to `testComponent`, ' +
-        'expected `number`.'
+        'Invalid prop `testProp` of type `string` supplied to ' +
+        '`testComponent`, expected `number`.'
       );
     });
 
@@ -173,7 +173,7 @@ describe('ReactPropTypes', function() {
       typeCheckFail(
         PropTypes.arrayOf(PropTypes.instanceOf(Thing)),
         [new Thing(), 'xyz'],
-        'Invalid prop `1` supplied to `testComponent`, expected instance of `' +
+        'Invalid prop `testProp` supplied to `testComponent`, expected instance of `' +
         name + '`.'
       );
     });


### PR DESCRIPTION
Every type checker follows the signature (props, propName, ...), through
which the value `props[propName]` is retrieved. This works badly with
`arrayOf` since it'd pass the index of the item as the prop name; the
warning message will therefore show "Invalid prop `1` of bla" instead of
the more helpful "Invalid prop `myProp` of bla". This fixes that.
Ideally we'd pass the prop value as an argument, but it's too many
changes.