### PR TITLE
Add callback into addons/TestUtils.renderIntoDocument()

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -42,14 +42,14 @@ function Event(suffix) {}
  * @lends ReactTestUtils
  */
 var ReactTestUtils = {
-  renderIntoDocument: function(instance) {
+  renderIntoDocument: function(instance, callback) {
     var div = document.createElement('div');
     // None of our tests actually require attaching the container to the
     // DOM, and doing so creates a mess that we rely on test isolation to
     // clean up, so we're going to stop honoring the name of this method
     // (and probably rename it eventually) if no problems arise.
     // document.documentElement.appendChild(div);
-    return React.render(instance, div);
+    return React.render(instance, div, callback);
   },
 
   isElement: function(element) {


### PR DESCRIPTION
Hi,

I want to `React.addons.TestUtils.renderIntoDocument()` can receive callback function.

In testing, rewrite state after `renderIntoDocument()`.

Please try to consider it.