### PR TITLE
Remove last call to `getDOMNode` in tests

### DIFF
--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -597,7 +597,7 @@ describe('ReactDOMComponent', function() {
       expect(
         ReactBrowserEventEmitter.getListener(rootNodeID, 'onClick')
       ).toBe(callback);
-      expect(rootNode).toBe(instance.getDOMNode());
+      expect(rootNode).toBe(React.findDOMNode(instance));
 
       React.unmountComponentAtNode(container);
 


### PR DESCRIPTION
Pulled out out #3567 so that that one could get merged more easily.

@zpao 