### PR TITLE
Documentation: Fixed typo / grammar in 'clone with props'

### DIFF
--- a/docs/docs/10.5-clone-with-props.md
+++ b/docs/docs/10.5-clone-with-props.md
@@ -6,7 +6,7 @@ prev: test-utils.html
 next: create-fragment.html
 ---
 
-In rare situations a element may want to change the props of a element that it doesn't own (like changing the `className` of a element passed as `this.props.children`). Other times it may want to make multiple copies of a element passed to it. `cloneWithProps()` makes this possible.
+In rare situations an element may want to change the props of an element that it doesn't own (like changing the `className` of an element passed as `this.props.children`). Other times it may want to make multiple copies of an element passed to it. `cloneWithProps()` makes this possible.
 
 #### `ReactElement React.addons.cloneWithProps(ReactElement element, object? extraProps)`
 

--- a/docs/docs/11-advanced-performance.md
+++ b/docs/docs/11-advanced-performance.md
@@ -11,7 +11,7 @@ One of the first questions people ask when considering React for a project is wh
 
 React makes use of a *virtual DOM*, which is a descriptor of a DOM subtree rendered in the browser. This parallel representation allows React to avoid creating DOM nodes and accessing existing ones, which is slower than operations on JavaScript objects. When a component's props or state change, React decides whether an actual DOM update is necessary by constructing a new virtual DOM and comparing it to the old one. Only in the case they are not equal, will React [reconcile](http://facebook.github.io/react/docs/reconciliation.html) the DOM, applying as few mutations as possible.
 
-On top of this, React provides a component lifecycle function, `shouldComponentUpdate`, which is triggered before the re-rendering process starts, giving the developer the ability to short circuit this process. The default implementation of this function returns `true`, leaving React to perform the update:
+On top of this, React provides a component lifecycle function, `shouldComponentUpdate`, which is triggered before the re-rendering process starts (virtual DOM comparision and possible eventual DOM reconciliation), giving the developer the ability to short circuit this process. The default implementation of this function returns `true`, leaving React to perform the update:
 
 ```javascript
 shouldComponentUpdate: function(nextProps, nextState) {


### PR DESCRIPTION
As per grammar rules, you use 'a' before words that begin with a consonant sound and 'an' before words that begin with a vowel sound, hence, 'an element' rather than 'a element'.