### PR TITLE
ReactLink for radio buttons (radioLink)

### DIFF
--- a/docs/docs/10.2-form-input-binding-sugar.md
+++ b/docs/docs/10.2-form-input-binding-sugar.md
@@ -61,9 +61,14 @@ var WithLink = React.createClass({
 
 `ReactLink` objects can be passed up and down the tree as props, so it's easy (and explicit) to set up two-way binding between a component deep in the hierarchy and state that lives higher in the hierarchy.
 
-Note that checkboxes have a special behavior regarding their `value` attribute, which is the value that will be sent on form submit if the checkbox is checked (defaults to `on`). The `value` attribute is not updated when the checkbox is checked or unchecked. For checkboxes, you should use `checkedLink` instead of `valueLink`:
+Note that checkboxes and radioboxes have a special behavior regarding their `value` attribute, which is the value that will be sent on form submit if the checkbox/radiobox is checked (defaults to `on`). The `value` attribute is not updated when the checkbox/radiobox is checked or unchecked. For checkboxes, you should use `checkedLink` instead of `valueLink`:
 ```
 <input type="checkbox" checkedLink={this.linkState('booleanValue')} />
+```
+
+For radioboxes, you should use `radioLink` instead of `valueLink`:
+```
+<input type="radiobox" value="choice1" radioLink={this.linkState('multipleChoiceValue')} />
 ```
 
 

--- a/src/browser/ui/dom/components/LinkedValueUtils.js
+++ b/src/browser/ui/dom/components/LinkedValueUtils.js
@@ -27,9 +27,12 @@ var hasReadOnlyValue = {
 };
 
 function _assertSingleLink(input) {
+  var trueCount =
+    (input.props.checkedLink == null ? 0 : 1) +
+    (input.props.valueLink == null ? 0 : 1) +
+    (input.props.radioLink == null ? 0 : 1);
   invariant(
-    input.props.checkedLink == null || input.props.valueLink == null ||
-    input.props.radioLink,
+    trueCount == 1,
     'Cannot provide more than one out of checkedLink, valueLink, and ' +
     'radioLink. If you want to use checkedLink, you probably don\'t want to ' +
     'use valueLink or radioLink. There can be only one.'

--- a/src/browser/ui/dom/components/LinkedValueUtils.js
+++ b/src/browser/ui/dom/components/LinkedValueUtils.js
@@ -28,9 +28,11 @@ var hasReadOnlyValue = {
 
 function _assertSingleLink(input) {
   invariant(
-    input.props.checkedLink == null || input.props.valueLink == null,
-    'Cannot provide a checkedLink and a valueLink. If you want to use ' +
-    'checkedLink, you probably don\'t want to use valueLink and vice versa.'
+    input.props.checkedLink == null || input.props.valueLink == null ||
+    input.props.radioLink,
+    'Cannot provide more than one out of checkedLink, valueLink, and ' +
+    'radioLink. If you want to use checkedLink, you probably don\'t want to ' +
+    'use valueLink or radioLink. There can be only one.'
   );
 }
 function _assertValueLink(input) {
@@ -52,6 +54,16 @@ function _assertCheckedLink(input) {
   );
 }
 
+function _assertRadioLink(input) {
+  _assertSingleLink(input);
+  invariant(
+    input.props.checked == null && input.props.onChange == null,
+    'Cannot provide a radioLink and a checked property or onChange event. ' +
+    'If you want to use checked or onChange, you probably don\'t want to ' +
+    'use radioLink'
+  );
+}
+
 /**
  * @param {SyntheticEvent} e change event to handle
  */
@@ -66,6 +78,14 @@ function _handleLinkedValueChange(e) {
 function _handleLinkedCheckChange(e) {
   /*jshint validthis:true */
   this.props.checkedLink.requestChange(e.target.checked);
+}
+
+/**
+  * @param {SyntheticEvent} e change event to handle
+  */
+function _handleLinkedRadioChange(e) {
+  /*jshint validthis:true */
+  this.props.radioLink.requestChange(e.target.id);
 }
 
 /**
@@ -129,6 +149,9 @@ var LinkedValueUtils = {
     if (input.props.checkedLink) {
       _assertCheckedLink(input);
       return input.props.checkedLink.value;
+    } else if (input.props.radioLink) {
+      _assertRadioLink(input);
+      return input.props.radioLink.value === input.props.id;
     }
     return input.props.checked;
   },
@@ -144,6 +167,9 @@ var LinkedValueUtils = {
     } else if (input.props.checkedLink) {
       _assertCheckedLink(input);
       return _handleLinkedCheckChange;
+    } else if (input.props.radioLink) {
+      _assertRadioLink(input);
+      return _handleLinkedRadioChange;
     }
     return input.props.onChange;
   }

--- a/src/browser/ui/dom/components/LinkedValueUtils.js
+++ b/src/browser/ui/dom/components/LinkedValueUtils.js
@@ -32,7 +32,7 @@ function _assertSingleLink(input) {
     (input.props.valueLink == null ? 0 : 1) +
     (input.props.radioLink == null ? 0 : 1);
   invariant(
-    trueCount == 1,
+    trueCount === 1,
     'Cannot provide more than one out of checkedLink, valueLink, and ' +
     'radioLink. If you want to use checkedLink, you probably don\'t want to ' +
     'use valueLink or radioLink. There can be only one.'

--- a/src/browser/ui/dom/components/LinkedValueUtils.js
+++ b/src/browser/ui/dom/components/LinkedValueUtils.js
@@ -85,7 +85,7 @@ function _handleLinkedCheckChange(e) {
   */
 function _handleLinkedRadioChange(e) {
   /*jshint validthis:true */
-  this.props.radioLink.requestChange(e.target.id);
+  this.props.radioLink.requestChange(e.target.value);
 }
 
 /**
@@ -151,7 +151,7 @@ var LinkedValueUtils = {
       return input.props.checkedLink.value;
     } else if (input.props.radioLink) {
       _assertRadioLink(input);
-      return input.props.radioLink.value === input.props.id;
+      return input.props.radioLink.value === input.props.value;
     }
     return input.props.checked;
   },


### PR DESCRIPTION
Adresses #3573 .

I modified LinkedValueUtils.js to add support for the following syntax:

    <input type="radio" name="mygroup" value="value1" radioLink={this.linkState("myval")}/>
    <input type="radio" name="mygroup" value="value2" radioLink={this.linkState("myval")}/>

State will have a variable named `myval` that will hold the radio buttons `value` attribute (e.g., `value1` or `value2`). Setting this state variable to a specific value will cause the corresponding radio button to be selected. If there is no corresponding radio button, all will be deselected.

Also updated documentation.