### PR TITLE
catch all newly created elements

### DIFF
--- a/src/classic/element/ReactElementValidator.js
+++ b/src/classic/element/ReactElementValidator.js
@@ -333,7 +333,7 @@ function is(a, b) {
  * @param {ReactElement} element
  */
 function checkAndWarnForMutatedProps(element) {
-  if (!element._store || "undefined" === typeof originalProps) {
+  if (!element._store || typeof originalProps === 'undefined') {
     // Element was created using `new ReactElement` directly or with
     // `ReactElement.createElement`; skip mutation checking
     return;

--- a/src/classic/element/ReactElementValidator.js
+++ b/src/classic/element/ReactElementValidator.js
@@ -333,7 +333,7 @@ function is(a, b) {
  * @param {ReactElement} element
  */
 function checkAndWarnForMutatedProps(element) {
-  if (!element._store) {
+  if (!element._store || "undefined" === typeof originalProps) {
     // Element was created using `new ReactElement` directly or with
     // `ReactElement.createElement`; skip mutation checking
     return;


### PR DESCRIPTION
Some new elements have a store but not originalProps; they pass the first validation but break in the `for` loop below. (Discovered when combining React + Flummox + react-slick).