### PR TITLE
Don't instrument ReactCompositeComponent unless perf is on

### DIFF
--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -865,7 +865,7 @@ var ReactCompositeComponentMixin = {
 
 };
 
-ReactPerf.measureMethods(
+ReactPerf.lazyMeasureMethods(
   ReactCompositeComponentMixin,
   'ReactCompositeComponent',
   {

--- a/src/test/ReactDefaultPerf.js
+++ b/src/test/ReactDefaultPerf.js
@@ -38,11 +38,11 @@ var ReactDefaultPerf = {
     }
 
     ReactDefaultPerf._allMeasurements.length = 0;
-    ReactPerf.enableMeasure = true;
+    ReactPerf.enableMeasure();
   },
 
   stop: function() {
-    ReactPerf.enableMeasure = false;
+    ReactPerf.disableMeasure();
   },
 
   getLastMeasurements: function() {


### PR DESCRIPTION
This saves two stack frames for every level of composite component which makes reading stack traces more pleasant for me.