### PR TITLE
Fixes for several failing tests in Firefox and Safari

### DIFF
--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -586,7 +586,7 @@ describe('ReactDOMComponent', function() {
       var ReactMount = require('ReactMount');
 
       var container = document.createElement('div');
-      document.documentElement.appendChild(container);
+      document.body.appendChild(container);
 
       var callback = function() {};
       var instance = <div onClick={callback} />;

--- a/src/browser/ui/__tests__/ReactMount-test.js
+++ b/src/browser/ui/__tests__/ReactMount-test.js
@@ -76,7 +76,7 @@ describe('ReactMount', function() {
 
   it('should render different components in same root', function() {
     var container = document.createElement('container');
-    document.documentElement.appendChild(container);
+    document.body.appendChild(container);
 
     ReactMount.render(<div></div>, container);
     expect(container.firstChild.nodeName).toBe('DIV');

--- a/src/browser/ui/__tests__/ReactMountDestruction-test.js
+++ b/src/browser/ui/__tests__/ReactMountDestruction-test.js
@@ -16,7 +16,7 @@ var React = require('React');
 describe('ReactMount', function() {
   it("should destroy a react root upon request", function() {
     var mainContainerDiv = document.createElement('div');
-    document.documentElement.appendChild(mainContainerDiv);
+    document.body.appendChild(mainContainerDiv);
 
     var instanceOne = (
       <div className="firstReactDiv">

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -271,7 +271,7 @@ describe('ReactCompositeComponent', function() {
 
   it('should warn about `forceUpdate` on unmounted components', function() {
     var container = document.createElement('div');
-    document.documentElement.appendChild(container);
+    document.body.appendChild(container);
 
     var Component = React.createClass({
       render: function() {
@@ -300,7 +300,7 @@ describe('ReactCompositeComponent', function() {
 
   it('should warn about `setState` on unmounted components', function() {
     var container = document.createElement('div');
-    document.documentElement.appendChild(container);
+    document.body.appendChild(container);
 
     var Component = React.createClass({
       getInitialState: function() {
@@ -333,7 +333,7 @@ describe('ReactCompositeComponent', function() {
      function() {
     var cbCalled = false;
     var container = document.createElement('div');
-    document.documentElement.appendChild(container);
+    document.body.appendChild(container);
 
     var Component = React.createClass({
       getInitialState: function() {
@@ -363,7 +363,7 @@ describe('ReactCompositeComponent', function() {
 
   it('should not allow `setProps` on unmounted components', function() {
     var container = document.createElement('div');
-    document.documentElement.appendChild(container);
+    document.body.appendChild(container);
 
     var Component = React.createClass({
       render: function() {
@@ -395,7 +395,7 @@ describe('ReactCompositeComponent', function() {
 
   it('should only allow `setProps` on top-level components', function() {
     var container = document.createElement('div');
-    document.documentElement.appendChild(container);
+    document.body.appendChild(container);
 
     var innerInstance;
 

--- a/src/core/__tests__/ReactCompositeComponentNestedState-test.js
+++ b/src/core/__tests__/ReactCompositeComponentNestedState-test.js
@@ -84,7 +84,7 @@ describe('ReactCompositeComponentNestedState-state', function() {
     });
 
     var container = document.createElement('div');
-    document.documentElement.appendChild(container);
+    document.body.appendChild(container);
 
     var logger = mocks.getMockFunction();
 

--- a/src/core/__tests__/ReactCompositeComponentState-test.js
+++ b/src/core/__tests__/ReactCompositeComponentState-test.js
@@ -134,7 +134,7 @@ describe('ReactCompositeComponent-state', function() {
 
   it('should support setting state', function() {
     var container = document.createElement('div');
-    document.documentElement.appendChild(container);
+    document.body.appendChild(container);
 
     var stateListener = mocks.getMockFunction();
     var instance = React.render(


### PR DESCRIPTION
This fixes 644 out of the 678 tests failing in Firefox and Safari when running them manually (with `grunt test --debug`), although they pass in Chrome and PhantomJS. See #3598 

![Tests Failing in Firefox](http://i.imgur.com/LnUBDSU.png)

There're 34 tests still failing for some other reason.

Apparently, trying to append a container directly to the HTML element is breaking all the tests moving forward. Also, using to document.body is more consistent with the rest of the tests.