### PR TITLE
ReactEventListener.dispatchEvent should ignore non own documents.

### DIFF
--- a/src/browser/ui/ReactEventListener.js
+++ b/src/browser/ui/ReactEventListener.js
@@ -164,6 +164,11 @@ var ReactEventListener = {
       return;
     }
 
+    var targetDocument = getEventTarget(nativeEvent).ownerDocument;
+    if (targetDocument !== window.document) {
+      return;
+    }
+
     var bookKeeping = TopLevelCallbackBookKeeping.getPooled(
       topLevelType,
       nativeEvent

--- a/src/browser/ui/__tests__/ReactEventListener-test.js
+++ b/src/browser/ui/__tests__/ReactEventListener-test.js
@@ -190,4 +190,16 @@ describe('ReactEventListener', function() {
     expect(calls[0][EVENT_TARGET_PARAM])
       .toBe(React.findDOMNode(instance.getInner()));
   });
+
+  it('should not dispatch events coming from non own elements', function() {
+    var callback = ReactEventListener.dispatchEvent.bind(null, 'test');
+    callback({
+      target: {
+        ownerDocument: {}
+      }
+    });
+
+    var calls = handleTopLevel.mock.calls;
+    expect(calls.length).toBe(0);
+  });
 });


### PR DESCRIPTION
We are writing firefox sidebar plugin with React and faced some issues with dead objects. 

Due to overprivileged environment of plugin event can bubble/capture out of iframe. And if surrounded application has React instance it captures `event.target` of element of non own document. After reloading the iframe and trying to interact with iframe content it throws an exception about Firefox dead object(garbage collected DOM element).
```
+sidebar------+
|React1       |
|             |
|  +iframe-+  |
|  |React2 |  |
|  |       |  |
|  +-------+  |
|             |
+-------------+
```
Also it could lead to an issue with the same `reactId`: `Error: Invariant Violation: ReactMount: Two valid but unequal nodes with the same data-reactid: .0`.

Please find the example Firefox plugin along with the souce code: https://dl.dropboxusercontent.com/u/37680916/react-bug.zip