### PR TITLE
Fix for style not always reset when set to null

### DIFF
--- a/src/browser/ui/ReactDOMComponent.js
+++ b/src/browser/ui/ReactDOMComponent.js
@@ -442,6 +442,8 @@ ReactDOMComponent.Mixin = {
       if (propKey === STYLE) {
         if (nextProp) {
           nextProp = this._previousStyleCopy = assign({}, nextProp);
+        } else {
+          this._previousStyleCopy = null;
         }
         if (lastProp) {
           // Unset styles on `lastProp` but not on `nextProp`.

--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -109,6 +109,27 @@ describe('ReactDOMComponent', function() {
       expect(stubStyle.display).toEqual('block');
     });
 
+    it("should update styles if updated to null multiple times", function() {
+      var styles = null;
+      var container = document.createElement('div');
+      React.render(<div style={styles} />, container);
+
+      styles = {display: 'block'};
+      var stubStyle = container.firstChild.style;
+
+      React.render(<div style={styles} />, container);
+      expect(stubStyle.display).toEqual('block');
+
+      React.render(<div style={null} />, container);
+      expect(stubStyle.display).toEqual('');
+
+      React.render(<div style={styles} />, container);
+      expect(stubStyle.display).toEqual('block');
+
+      React.render(<div style={null} />, container);
+      expect(stubStyle.display).toEqual('');
+    });
+
     it("should remove attributes", function() {
       var container = document.createElement('div');
       React.render(<img height='17' />, container);


### PR DESCRIPTION
When the style property existed, but was set to null, `this._previousStyleCopy`
was not set back to `null` causing an old value to persist. This broke setting
the style to `null` the next time.

Fixes #3606.