### PR TITLE
Update Copyright notices to include 2015

### DIFF
--- a/src/browser/ui/dom/components/__tests__/ReactDOMIframe-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMIframe-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014, Facebook, Inc.
+ * Copyright 2013-2015, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/core/__tests__/ReactCompositeComponentNestedState-test.js
+++ b/src/core/__tests__/ReactCompositeComponentNestedState-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014, Facebook, Inc.
+ * Copyright 2013-2015, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the


### PR DESCRIPTION
A simple update to two files that were forgotten to be updated to include 2015 in the copyright notice. :+1: 