### PR TITLE
Allow mixins to be es6 classes.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,11 +21,11 @@ rules:
   # Make this a warning for now. We do this in a few places so we might need to
   # disable
   no-unused-expressions: 2
-  block-scoped-var: 2
+  block-scoped-var: 1
   eol-last: 2
   dot-notation: 2
   consistent-return: 2
-  no-unused-vars: [2, args: none]
+  no-unused-vars: [1, args: none]
   quotes: [2, 'single']
 
   # WARNINGS

--- a/src/classic/class/ReactClass.js
+++ b/src/classic/class/ReactClass.js
@@ -443,7 +443,7 @@ function mixSpecIntoComponent(Constructor, spec) {
   }
 
   invariant(
-    typeof spec !== 'function',
+    typeof spec !== 'function' || typeof spec.prototype.render === 'undefined',
     'ReactClass: You\'re attempting to ' +
     'use a component class as a mixin. Instead, just use a regular object.'
   );
@@ -462,14 +462,22 @@ function mixSpecIntoComponent(Constructor, spec) {
     RESERVED_SPEC_KEYS.mixins(Constructor, spec.mixins);
   }
 
-  for (var name in spec) {
+  Object.getOwnPropertyNames(spec).forEach(function(name) {
+
+    // These are defined on ES6 classes and are forbidden
+    if (typeof spec === 'function' &&
+        (name === 'caller' || name === 'callee' || name === 'arguments')
+      ) {
+      return;
+    }
+
     if (!spec.hasOwnProperty(name)) {
-      continue;
+      return;
     }
 
     if (name === MIXINS_KEY) {
       // We have already handled mixins in a special case above
-      continue;
+      return;
     }
 
     var property = spec[name];
@@ -532,7 +540,7 @@ function mixSpecIntoComponent(Constructor, spec) {
         }
       }
     }
-  }
+  });
 }
 
 function mixStaticSpecIntoComponent(Constructor, statics) {

--- a/src/core/ReactStateSetters.js
+++ b/src/core/ReactStateSetters.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var ReactStateSetters = {
+class ReactStateSetters {
   /**
    * Returns a function that calls the provided function, and uses the result
    * of that to set the component's state.
@@ -22,14 +22,14 @@ var ReactStateSetters = {
    * @return {function} callback that when invoked uses funcReturningState to
    *                    determined the object literal to setState.
    */
-  createStateSetter: function(component, funcReturningState) {
+  static createStateSetter(component, funcReturningState) {
     return function(a, b, c, d, e, f) {
       var partialState = funcReturningState.call(component, a, b, c, d, e, f);
       if (partialState) {
         component.setState(partialState);
       }
     };
-  },
+  }
 
   /**
    * Returns a single-argument callback that can be used to update a single
@@ -42,12 +42,12 @@ var ReactStateSetters = {
    * @return {function} callback of 1 argument which calls setState() with
    *                    the provided keyName and callback argument.
    */
-  createStateKeySetter: function(component, key) {
+  static createStateKeySetter(component, key) {
     // Memoize the setters.
     var cache = component.__keySetters || (component.__keySetters = {});
     return cache[key] || (cache[key] = createStateKeySetter(component, key));
   }
-};
+}
 
 function createStateKeySetter(component, key) {
   // Partial state is allocated outside of the function closure so it can be
@@ -60,7 +60,8 @@ function createStateKeySetter(component, key) {
   };
 }
 
-ReactStateSetters.Mixin = {
+class ReactStateSettersMixin
+{
   /**
    * Returns a function that calls the provided function, and uses the result
    * of that to set the component's state.
@@ -77,9 +78,9 @@ ReactStateSetters.Mixin = {
    * @return {function} callback that when invoked uses funcReturningState to
    *                    determined the object literal to setState.
    */
-  createStateSetter: function(funcReturningState) {
+  static createStateSetter(funcReturningState) {
     return ReactStateSetters.createStateSetter(this, funcReturningState);
-  },
+  }
 
   /**
    * Returns a single-argument callback that can be used to update a single
@@ -96,9 +97,11 @@ ReactStateSetters.Mixin = {
    * @return {function} callback of 1 argument which calls setState() with
    *                    the provided keyName and callback argument.
    */
-  createStateKeySetter: function(key) {
+  static createStateKeySetter(key) {
     return ReactStateSetters.createStateKeySetter(this, key);
   }
-};
+}
+
+ReactStateSetters.Mixin = ReactStateSettersMixin;
 
 module.exports = ReactStateSetters;


### PR DESCRIPTION
Allow mixins to be es6 classes.

Side note: I had to downgrade two lint rules to warnings because apparently eslint (in it's current form) doesn't understand ES6 classes.  Meh, sucks.  We should get our eslint install fixed or file a ticket on eslint.  We never ran into this before because we only used es6 classes in tests and have linting disabled completely for tests?