### PR TITLE
Allow JSXTransformer to be "HTML Import" aware.

### DIFF
--- a/vendor/browser-transforms.js
+++ b/vendor/browser-transforms.js
@@ -346,6 +346,19 @@ function runScripts() {
 
 }
 
+// Listen for load event if we're in a browser and then kick off finding and
+// running of scripts.
+if (typeof window !== 'undefined' && window !== null) {
+  headEl = document.getElementsByTagName('head')[0];
+  dummyAnchor = document.createElement('a');
+
+  if (window.addEventListener) {
+    window.addEventListener('DOMContentLoaded', runScripts, false);
+  } else {
+    window.attachEvent('onload', runScripts);
+  }
+}
+
 module.exports = {
   transform: transformReact,
   exec: exec

--- a/vendor/browser-transforms.js
+++ b/vendor/browser-transforms.js
@@ -316,7 +316,7 @@ function runScripts() {
 
   }
 
-  function processDeferredScripts(documentScope) {
+  function processDeferredScripts() {
 
     if (this.import) {
       processScripts(this.import);

--- a/vendor/browser-transforms.js
+++ b/vendor/browser-transforms.js
@@ -309,7 +309,7 @@ function runScripts() {
       if (imports[i].import) {
         processScripts(imports[i].import);
       } else {
-        imports[i].addEventListener('load', processDeferredScripts.bind(null, imports[i]));
+        imports[i].addEventListener('load', processDeferredScripts);
       }
 
     }
@@ -318,8 +318,8 @@ function runScripts() {
 
   function processDeferredScripts(documentScope) {
 
-    if (documentScope.import) {
-      processScripts(documentScope.import);
+    if (this.import) {
+      processScripts(this.import);
     }
 
   }

--- a/vendor/browser-transforms.js
+++ b/vendor/browser-transforms.js
@@ -303,19 +303,23 @@ function runScripts() {
     for (var i = 0; i < imports.length; i++) {
 
       if (imports[i].getAttribute('rel').toLowerCase() !== 'import') {
-        continue
+        continue;
       }
 
       if (imports[i].import) {
         processScripts(imports[i].import);
       } else {
-        imports[i].addEventListener('load', function() {
-          if (this.import) {
-            processScripts(this.import);
-          }
-        }.bind(imports[i]));
+        imports[i].addEventListener('load', processDeferredScripts.bind(null, imports[i]));
       }
 
+    }
+
+  }
+
+  function processDeferredScripts(documentScope) {
+
+    if (documentScope.import) {
+      processScripts(documentScope.import);
     }
 
   }
@@ -326,9 +330,9 @@ function runScripts() {
 
     // Array.prototype.slice cannot be used on NodeList on IE8
     var jsxScripts = [];
-    for (var i = 0; i < scripts.length; i++) {
-      if (/^text\/jsx(;|$)/.test(scripts.item(i).type)) {
-        jsxScripts.push(scripts.item(i));
+    for (var j = 0; j < scripts.length; j++) {
+      if (/^text\/jsx(;|$)/.test(scripts.item(j).type)) {
+        jsxScripts.push(scripts.item(j));
       }
     }
 

--- a/vendor/browser-transforms.js
+++ b/vendor/browser-transforms.js
@@ -310,7 +310,9 @@ function runScripts() {
         processScripts(imports[i].import);
       } else {
         imports[i].addEventListener('load', function() {
-          processScripts(this.import);
+          if (this.import) {
+            processScripts(this.import);
+          }
         }.bind(imports[i]));
       }
 


### PR DESCRIPTION
**Note:** I'm not sure if this is the correct place to issue a PR for JSXTransformer, because I was unable to find any associated tests. I'm thinking that JSXTransformer is more of an internal Facebook product, and you simply include it into this repository &ndash; hence it residing in the `vendor` directory. C'est la vie!

I've modified JSXTransformer to allow it to transpile JSX documents when they're loaded via HTML imports. Currently `runScripts` is invoked once on `DOMContentLoaded` and then garbage collected, since the implementation has been abstracted away. This will keep it alive for any top-level HTML imports &ndash; but will not wait for HTML imports of those HTML imports, unless `JSXTransformer.js` is included again :+1: 