### PR TITLE
Update uglify dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "sauce-tunnel": "~1.1.0",
     "tmp": "~0.0.18",
     "typescript": "^1.4.0",
-    "uglify-js": "~2.4.0",
+    "uglify-js": "^2.4.20",
     "uglifyify": "^3.0.1",
     "wd": "~0.2.6"
   },


### PR DESCRIPTION
Apparently we needed to get to v2.4.17 to get the fix for #2247. We
shrinkwrapped on the same day but the timing didn't work out so we missed it.