### PR TITLE
[performance] Replace hasOwnProperty in child processing with typeof undefined check

### DIFF
--- a/src/utils/ReactChildren.js
+++ b/src/utils/ReactChildren.js
@@ -81,7 +81,7 @@ function mapSingleChildIntoContext(traverseContext, child, name, i) {
   var mapBookKeeping = traverseContext;
   var mapResult = mapBookKeeping.mapResult;
 
-  var keyUnique = !mapResult.hasOwnProperty(name);
+  var keyUnique = ('undefined' === typeof mapResult[name]);
   if (__DEV__) {
     warning(
       keyUnique,

--- a/src/utils/ReactChildren.js
+++ b/src/utils/ReactChildren.js
@@ -81,7 +81,7 @@ function mapSingleChildIntoContext(traverseContext, child, name, i) {
   var mapBookKeeping = traverseContext;
   var mapResult = mapBookKeeping.mapResult;
 
-  var keyUnique = ('undefined' === typeof mapResult[name]);
+  var keyUnique = (mapResult[name] === undefined);
   if (__DEV__) {
     warning(
       keyUnique,

--- a/src/utils/flattenChildren.js
+++ b/src/utils/flattenChildren.js
@@ -22,7 +22,7 @@ var warning = require('warning');
 function flattenSingleChildIntoContext(traverseContext, child, name) {
   // We found a component instance.
   var result = traverseContext;
-  var keyUnique = !result.hasOwnProperty(name);
+  var keyUnique = ('undefined' === typeof result[name]);
   if (__DEV__) {
     warning(
       keyUnique,

--- a/src/utils/flattenChildren.js
+++ b/src/utils/flattenChildren.js
@@ -22,7 +22,7 @@ var warning = require('warning');
 function flattenSingleChildIntoContext(traverseContext, child, name) {
   // We found a component instance.
   var result = traverseContext;
-  var keyUnique = ('undefined' === typeof result[name]);
+  var keyUnique = (result[name] === undefined);
   if (__DEV__) {
     warning(
       keyUnique,


### PR DESCRIPTION
`hasOwnProperty` within `flattenSingleChildIntoContext` is showing up in the top of [profiling](https://github.com/mridgway/react-perf/blob/singleChild/profile.txt#L12) so I ran an [experiment](https://github.com/mridgway/react-perf/tree/singleChild) with replacing it with a simple typeof === undefined check. Performance difference shown in Travis: https://travis-ci.org/mridgway/react-perf/builds/58356726