### PR TITLE
"Advanced performance" typo fix

### DIFF
--- a/docs/docs/11-advanced-performance.md
+++ b/docs/docs/11-advanced-performance.md
@@ -49,7 +49,7 @@ So, how should we implement `shouldComponentUpdate`? Say that you have a compone
 
 ```javascript
 React.createClass({
-  propsTypes: {
+  propTypes: {
     value: React.PropTypes.string.isRequired
   },
 
@@ -73,7 +73,7 @@ But what if your components' props or state are mutable data structures?. Say th
 
 ```javascript
 React.createClass({
-  propsTypes: {
+  propTypes: {
     value: React.PropTypes.object.isRequired
   },
 


### PR DESCRIPTION
Example code used the key "propsTypes" - correct to "propTypes".

As this is my first PR on Facebook repos, I've completed a CLA.