### PR TITLE
Remove withContext from top-level API

### DIFF
--- a/src/browser/ui/React.js
+++ b/src/browser/ui/React.js
@@ -16,7 +16,6 @@
 var ReactChildren = require('ReactChildren');
 var ReactComponent = require('ReactComponent');
 var ReactClass = require('ReactClass');
-var ReactContext = require('ReactContext');
 var ReactCurrentOwner = require('ReactCurrentOwner');
 var ReactElement = require('ReactElement');
 var ReactElementValidator = require('ReactElementValidator');
@@ -75,7 +74,6 @@ var React = {
   renderToStaticMarkup: ReactServerRendering.renderToStaticMarkup,
   unmountComponentAtNode: ReactMount.unmountComponentAtNode,
   isValidElement: ReactElement.isValidElement,
-  withContext: ReactContext.withContext,
 
   // Hook for JSX spread, don't use this for anything else.
   __spread: assign


### PR DESCRIPTION
We removed the implementation in #3615 but never got rid of the API from `React`.