### PR TITLE
Docs: Update code comment to match correct property name

### DIFF
--- a/docs/tips/10-props-in-getInitialState-as-anti-pattern.md
+++ b/docs/tips/10-props-in-getInitialState-as-anti-pattern.md
@@ -48,7 +48,7 @@ However, it's **not** an anti-pattern if you make it clear that synchronization'
 ```js
 var Counter = React.createClass({
   getInitialState: function() {
-    // naming it initialX clearly indicates that the only purpose
+    // naming it initialCount clearly indicates that the only purpose
     // of the passed down prop is to initialize something internally
     return {count: this.props.initialCount};
   },


### PR DESCRIPTION
In the tip "Props in getInitialState is an Anti Pattern", the code comment refers to a property called `initialX`, but the actual property name is `initialCount`. This patch corrects the code comment.