### PR TITLE
Added support for SVG clipPath element and clip-path attribute

### DIFF
--- a/docs/docs/ref-04-tags-and-attributes.md
+++ b/docs/docs/ref-04-tags-and-attributes.md
@@ -30,7 +30,7 @@ thead time title tr track u ul var video wbr
 The following SVG elements are supported:
 
 ```
-circle defs ellipse g line linearGradient mask path pattern polygon polyline
+circle clipPath defs ellipse g line linearGradient mask path pattern polygon polyline
 radialGradient rect stop svg text tspan
 ```
 
@@ -76,7 +76,7 @@ There is also the React-specific attribute `dangerouslySetInnerHTML` ([more here
 ### SVG Attributes
 
 ```
-cx cy d dx dy fill fillOpacity fontFamily fontSize fx fy gradientTransform
+clip-path cx cy d dx dy fill fillOpacity fontFamily fontSize fx fy gradientTransform
 gradientUnits markerEnd markerMid markerStart offset opacity
 patternContentUnits patternUnits points preserveAspectRatio r rx ry
 spreadMethod stopColor stopOpacity stroke strokeDasharray strokeLinecap

--- a/src/browser/ReactDOM.js
+++ b/src/browser/ReactDOM.js
@@ -153,6 +153,7 @@ var ReactDOM = mapObject({
 
   // SVG
   circle: 'circle',
+  clipPath: 'clipPath',
   defs: 'defs',
   ellipse: 'ellipse',
   g: 'g',

--- a/src/browser/ui/dom/SVGDOMPropertyConfig.js
+++ b/src/browser/ui/dom/SVGDOMPropertyConfig.js
@@ -65,6 +65,7 @@ var SVGDOMPropertyConfig = {
     y: MUST_USE_ATTRIBUTE
   },
   DOMAttributeNames: {
+    clipPath: 'clip-path',
     fillOpacity: 'fill-opacity',
     fontFamily: 'font-family',
     fontSize: 'font-size',
@@ -84,8 +85,7 @@ var SVGDOMPropertyConfig = {
     strokeOpacity: 'stroke-opacity',
     strokeWidth: 'stroke-width',
     textAnchor: 'text-anchor',
-    viewBox: 'viewBox',
-    clipPath: 'clip-path'
+    viewBox: 'viewBox'
   }
 };
 

--- a/src/browser/ui/dom/SVGDOMPropertyConfig.js
+++ b/src/browser/ui/dom/SVGDOMPropertyConfig.js
@@ -19,6 +19,7 @@ var MUST_USE_ATTRIBUTE = DOMProperty.injection.MUST_USE_ATTRIBUTE;
 
 var SVGDOMPropertyConfig = {
   Properties: {
+    clipPath: MUST_USE_ATTRIBUTE,
     cx: MUST_USE_ATTRIBUTE,
     cy: MUST_USE_ATTRIBUTE,
     d: MUST_USE_ATTRIBUTE,
@@ -83,7 +84,8 @@ var SVGDOMPropertyConfig = {
     strokeOpacity: 'stroke-opacity',
     strokeWidth: 'stroke-width',
     textAnchor: 'text-anchor',
-    viewBox: 'viewBox'
+    viewBox: 'viewBox',
+    clipPath: 'clip-path'
   }
 };
 

--- a/src/vendor/core/getMarkupWrap.js
+++ b/src/vendor/core/getMarkupWrap.js
@@ -29,6 +29,7 @@ var shouldWrap = {
   // Force wrapping for SVG elements because if they get created inside a <div>,
   // they will be initialized in the wrong namespace (and will not display).
   'circle': true,
+  'clipPath': true,
   'defs': true,
   'ellipse': true,
   'g': true,


### PR DESCRIPTION
I added the above because I need them in my library: https://github.com/codesuki/react-d3-components
I hope this gets into the next release since the workaround I used so far was very ugly:

For the attribute:
```
style={{clipPath: `url(#lineClip${this._reactInternalInstance._rootNodeID})`}}
```
For the element even worse:
```
let rect = React.renderToString(<rect width={width} height={height}/>);
<g dangerouslySetInnerHTML={{__html: `<defs><clipPath id="lineClip${this._reactInternalInstance._rootNodeID}">${rect}`}}/>
```