### PR TITLE
Fix missing line highlight in tutorial

### DIFF
--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -480,7 +480,7 @@ var CommentForm = React.createClass({
 
 Let's make the form interactive. When the user submits the form, we should clear it, submit a request to the server, and refresh the list of comments. To start, let's listen for the form's submit event and clear it.
 
-```javascript{3-13,16-19}
+```javascript{3-14,16-19}
 // tutorial16.js
 var CommentForm = React.createClass({
   handleSubmit: function(e) {


### PR DESCRIPTION
The line containing the closing brace and comma for `CommentForm.handleSubmit` in `tutorial16.js` should be highlighted since it is an addition like the rest of `handleSubmit`:

![screen shot 2015-04-18 at 6 34 45 pm](https://cloud.githubusercontent.com/assets/101698/7217598/019e66c4-e5fa-11e4-9629-077378a3942c.png)

This patch highlights the line:

![screen shot 2015-04-18 at 6 35 16 pm](https://cloud.githubusercontent.com/assets/101698/7217599/044dc6a8-e5fa-11e4-9e0d-4de7be0a5b70.png)

Thanks for React!