### PR TITLE
[docs] Update supported HTML attributes

### DIFF
--- a/docs/docs/ref-04-tags-and-attributes.md
+++ b/docs/docs/ref-04-tags-and-attributes.md
@@ -53,23 +53,24 @@ These standard attributes are supported:
 
 ```
 accept acceptCharset accessKey action allowFullScreen allowTransparency alt
-async autoComplete autoFocus autoPlay cellPadding cellSpacing charSet checked classID
-className cols colSpan content contentEditable contextMenu controls coords
-crossOrigin data dateTime defer dir disabled download draggable encType form
-formAction formEncType formMethod formNoValidate formTarget frameBorder height
-hidden href hrefLang htmlFor httpEquiv icon id label lang list loop manifest
-marginHeight marginWidth max maxLength media mediaGroup method min multiple
-muted name noValidate open pattern placeholder poster preload radioGroup
-readOnly rel required role rows rowSpan sandbox scope scoped scrolling seamless
-selected shape size sizes span spellCheck src srcDoc srcSet start step style
-tabIndex target title type useMap value width wmode
+async autoComplete autoFocus autoPlay cellPadding cellSpacing charSet checked
+classID className colSpan cols content contentEditable contextMenu controls
+coords crossOrigin data dateTime defer dir disabled download draggable encType
+form formAction formEncType formMethod formNoValidate formTarget frameBorder
+headers height hidden high href hrefLang htmlFor httpEquiv icon id label lang
+list loop low manifest marginHeight marginWidth max maxLength media mediaGroup
+method min multiple muted name noValidate open optimum pattern placeholder
+poster preload radioGroup readOnly rel required role rowSpan rows sandbox scope
+scoped scrolling seamless selected shape size sizes span spellCheck src srcDoc
+srcSet start step style tabIndex target title type useMap value width wmode
 ```
 
 In addition, the following non-standard attributes are supported:
 
 - `autoCapitalize autoCorrect` for Mobile Safari.
 - `property` for [Open Graph](http://ogp.me/) meta tags.
-- `itemProp itemScope itemType itemRef itemId` for [HTML5 microdata](http://schema.org/docs/gs.html).
+- `itemProp itemScope itemType itemRef itemID` for [HTML5 microdata](http://schema.org/docs/gs.html).
+- `unselectable` for Internet Explorer.
 
 There is also the React-specific attribute `dangerouslySetInnerHTML` ([more here](/react/docs/special-non-dom-attributes.html)), used for directly inserting HTML strings into a component.
 


### PR DESCRIPTION
We didn't do this *before* 0.13.2, but that's my fault. So I'm doing it now.