### PR TITLE
Added renderer as a migration path for setProps.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,11 +21,11 @@ rules:
   # Make this a warning for now. We do this in a few places so we might need to
   # disable
   no-unused-expressions: 2
-  block-scoped-var: 2
+  block-scoped-var: 1
   eol-last: 2
   dot-notation: 2
   consistent-return: 2
-  no-unused-vars: [2, args: none]
+  no-unused-vars: [1, args: none]
   quotes: [2, 'single']
 
   # WARNINGS

--- a/src/addons/ReactRenderer.js
+++ b/src/addons/ReactRenderer.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @typechecks
+ * @providesModule ReactRenderer
+ */
+
+'use strict';
+
+var React = require('React');
+var ReactUpdateQueue = require('ReactUpdateQueue');
+
+/**
+ * Provided as a temporary helper to assist in upgrading legacy code
+ * to a new version of React.
+ * React.render() is the preferred solution.
+ */
+class ReactRenderer {
+  constructor(nextElement, container, callback) {
+    this.component = React.render(nextElement, container, callback);
+  }
+
+  setProps(partialProps, callback) {
+    ReactUpdateQueue.enqueueSetProps(this.component, partialProps);
+    if (callback) {
+      ReactUpdateQueue.enqueueCallback(this.component, callback);
+    }
+  }
+}
+
+module.exports = ReactRenderer;

--- a/src/browser/ReactWithAddons.js
+++ b/src/browser/ReactWithAddons.js
@@ -24,6 +24,7 @@ var ReactComponentWithPureRenderMixin =
   require('ReactComponentWithPureRenderMixin');
 var ReactCSSTransitionGroup = require('ReactCSSTransitionGroup');
 var ReactFragment = require('ReactFragment');
+var ReactRenderer = require('ReactRenderer');
 var ReactTransitionGroup = require('ReactTransitionGroup');
 var ReactUpdates = require('ReactUpdates');
 
@@ -40,6 +41,7 @@ React.addons = {
   batchedUpdates: ReactUpdates.batchedUpdates,
   cloneWithProps: cloneWithProps,
   createFragment: ReactFragment.create,
+  ReactRenderer: ReactRenderer,
   shallowCompare: shallowCompare,
   update: update
 };

--- a/src/browser/__tests__/ReactDOM-test.js
+++ b/src/browser/__tests__/ReactDOM-test.js
@@ -14,7 +14,9 @@
 'use strict';
 
 var React = require('React');
+var ReactRenderer = require('ReactRenderer');
 var ReactTestUtils = require('ReactTestUtils');
+
 var div = React.createFactory('div');
 
 describe('ReactDOM', function() {
@@ -74,40 +76,42 @@ describe('ReactDOM', function() {
    * DOM, instead of a stale cache.
    */
   it("should purge the DOM cache when removing nodes", function() {
-    var myDiv = ReactTestUtils.renderIntoDocument(
+    var container = document.createElement('div');
+    var myRenderer = new ReactRenderer(
       <div>
         <div key="theDog" className="dog" />,
         <div key="theBird" className="bird" />
-      </div>
+      </div>,
+      container
     );
     // Warm the cache with theDog
-    myDiv.setProps({
+    myRenderer.setProps({
       children: [
         <div key="theDog" className="dogbeforedelete" />,
         <div key="theBird" className="bird" />
       ]
     });
     // Remove theDog - this should purge the cache
-    myDiv.setProps({
+    myRenderer.setProps({
       children: [
         <div key="theBird" className="bird" />
       ]
     });
     // Now, put theDog back. It's now a different DOM node.
-    myDiv.setProps({
+    myRenderer.setProps({
       children: [
         <div key="theDog" className="dog" />,
         <div key="theBird" className="bird" />
       ]
     });
     // Change the className of theDog. It will use the same element
-    myDiv.setProps({
+    myRenderer.setProps({
       children: [
         <div key="theDog" className="bigdog" />,
         <div key="theBird" className="bird" />
       ]
     });
-    var root = React.findDOMNode(myDiv);
+    var root = React.findDOMNode(myRenderer.component);
     var dog = root.childNodes[0];
     expect(dog.className).toBe('bigdog');
   });

--- a/src/browser/ui/dom/components/__tests__/ReactDOMButton-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMButton-test.js
@@ -17,29 +17,32 @@ var mocks = require('mocks');
 
 describe('ReactDOMButton', function() {
   var React;
+  var ReactRenderer;
   var ReactTestUtils;
 
   var onClick = mocks.getMockFunction();
 
-  function expectClickThru(button) {
+  function expectClickThru(buttonRenderer) {
     onClick.mockClear();
-    ReactTestUtils.Simulate.click(React.findDOMNode(button));
+    ReactTestUtils.Simulate.click(React.findDOMNode(buttonRenderer.component));
     expect(onClick.mock.calls.length).toBe(1);
   }
 
-  function expectNoClickThru(button) {
+  function expectNoClickThru(buttonRenderer) {
     onClick.mockClear();
-    ReactTestUtils.Simulate.click(React.findDOMNode(button));
+    ReactTestUtils.Simulate.click(React.findDOMNode(buttonRenderer.component));
     expect(onClick.mock.calls.length).toBe(0);
   }
 
   function mounted(button) {
-    button = ReactTestUtils.renderIntoDocument(button);
-    return button;
+    var container = document.createElement('div');
+    var buttonRenderer = new ReactRenderer(button, container);
+    return buttonRenderer;
   }
 
   beforeEach(function() {
     React = require('React');
+    ReactRenderer = require('ReactRenderer');
     ReactTestUtils = require('ReactTestUtils');
   });
 
@@ -54,27 +57,27 @@ describe('ReactDOMButton', function() {
   });
 
   it('should forward clicks when it becomes not disabled', function() {
-    var btn = mounted(<button disabled={true} onClick={onClick} />);
-    btn.setProps({disabled: false});
-    expectClickThru(btn);
+    var btnRenderer = mounted(<button disabled={true} onClick={onClick} />);
+    btnRenderer.setProps({disabled: false});
+    expectClickThru(btnRenderer);
   });
 
   it('should not forward clicks when it becomes disabled', function() {
-    var btn = mounted(<button onClick={onClick} />);
-    btn.setProps({disabled: true});
-    expectNoClickThru(btn);
+    var btnRenderer = mounted(<button onClick={onClick} />);
+    btnRenderer.setProps({disabled: true});
+    expectNoClickThru(btnRenderer);
   });
 
   it('should work correctly if the listener is changed', function() {
-    var btn = mounted(
+    var btnRenderer = mounted(
       <button disabled={true} onClick={function() {}} />
     );
 
-    btn.setProps({
+    btnRenderer.setProps({
       disabled: false,
       onClick: onClick
     });
 
-    expectClickThru(btn);
+    expectClickThru(btnRenderer);
   });
 });

--- a/src/browser/ui/dom/components/__tests__/ReactDOMSelect-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMSelect-test.js
@@ -19,11 +19,13 @@ describe('ReactDOMSelect', function() {
   var React;
   var ReactLink;
   var ReactTestUtils;
+  var ReactRenderer;
 
   beforeEach(function() {
     React = require('React');
     ReactLink = require('ReactLink');
     ReactTestUtils = require('ReactTestUtils');
+    ReactRenderer = require('ReactRenderer');
   });
 
   it('should allow setting `defaultValue`', function() {
@@ -33,8 +35,9 @@ describe('ReactDOMSelect', function() {
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = React.findDOMNode(stub);
+    var container = document.createElement('div');
+    stub = new ReactRenderer(stub, container);
+    var node = React.findDOMNode(stub.component);
 
     expect(node.value).toBe('giraffe');
 
@@ -76,8 +79,9 @@ describe('ReactDOMSelect', function() {
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = React.findDOMNode(stub);
+    var container = document.createElement('div');
+    stub = new ReactRenderer(stub, container);
+    var node = React.findDOMNode(stub.component);
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -98,8 +102,9 @@ describe('ReactDOMSelect', function() {
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = React.findDOMNode(stub);
+    var container = document.createElement('div');
+    stub = new ReactRenderer(stub, container);
+    var node = React.findDOMNode(stub.component);
 
     expect(node.value).toBe('giraffe');
 
@@ -123,8 +128,9 @@ describe('ReactDOMSelect', function() {
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = React.findDOMNode(stub);
+    var container = document.createElement('div');
+    stub = new ReactRenderer(stub, container);
+    var node = React.findDOMNode(stub.component);
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -155,7 +161,10 @@ describe('ReactDOMSelect', function() {
 
   it('should reset child options selected when they are changed and `value` is set', function() {
     var stub = <select multiple={true} value={["a", "b"]} />;
-    stub = ReactTestUtils.renderIntoDocument(stub);
+    var container = document.createElement('div');
+    stub = new ReactRenderer(stub, container);
+    var node = React.findDOMNode(stub.component);
+
 
     stub.setProps({
       children: [
@@ -164,8 +173,6 @@ describe('ReactDOMSelect', function() {
         <option value="c">c</option>
       ]
     });
-
-    var node = React.findDOMNode(stub);
 
     expect(node.options[0].selected).toBe(true);  // a
     expect(node.options[1].selected).toBe(true);  // b
@@ -209,8 +216,10 @@ describe('ReactDOMSelect', function() {
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = React.findDOMNode(stub);
+    var container = document.createElement('div');
+    stub = new ReactRenderer(stub, container);
+    var node = React.findDOMNode(stub.component);
+
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -231,8 +240,10 @@ describe('ReactDOMSelect', function() {
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = React.findDOMNode(stub);
+    var container = document.createElement('div');
+    stub = new ReactRenderer(stub, container);
+    var node = React.findDOMNode(stub.component);
+
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -254,8 +265,10 @@ describe('ReactDOMSelect', function() {
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = React.findDOMNode(stub);
+    var container = document.createElement('div');
+    stub = new ReactRenderer(stub, container);
+    var node = React.findDOMNode(stub.component);
+
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -275,8 +288,10 @@ describe('ReactDOMSelect', function() {
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = React.findDOMNode(stub);
+    var container = document.createElement('div');
+    stub = new ReactRenderer(stub, container);
+    var node = React.findDOMNode(stub.component);
+
 
     stub.setProps({value: 'gorilla'});
 

--- a/src/classic/class/ReactClass.js
+++ b/src/classic/class/ReactClass.js
@@ -777,6 +777,11 @@ var ReactClassMixin = {
    * @deprecated
    */
   setProps: function(partialProps, callback) {
+    warning(
+      false,
+      'setProps is deprecated.  Please use React.render() ' +
+      '(or React.addons.ReactRenderer as a temporary migration helper)'
+    );
     ReactUpdateQueue.enqueueSetProps(this, partialProps);
     if (callback) {
       ReactUpdateQueue.enqueueCallback(this, callback);

--- a/src/classic/class/__tests__/ReactClass-test.js
+++ b/src/classic/class/__tests__/ReactClass-test.js
@@ -397,4 +397,24 @@ describe('ReactClass-spec', function() {
     );
   });
 
+  it('warns when calling setProps', function() {
+    var MyComponent = React.createClass({
+      render: function() {
+        return <div />;
+      }
+    });
+
+    var container = document.createElement('div');
+    var instance = React.render(<MyComponent />, container);
+
+    instance.setProps({foo: 'bar'});
+
+    expect(console.error.calls.length).toBe(1);
+    expect(console.error.calls[0].args[0]).toContain(
+      'Warning: setProps is deprecated.  ' +
+      'Please use React.render() ' +
+      '(or React.addons.ReactRenderer as a temporary migration helper)'
+    );
+  });
+
 });

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -20,6 +20,7 @@ var ReactPropTypes;
 var ReactServerRendering;
 var ReactTestUtils;
 var ReactUpdates;
+var ReactRenderer;
 
 var reactComponentExpect;
 var mocks;
@@ -37,6 +38,7 @@ describe('ReactCompositeComponent', function() {
     ReactMount = require('ReactMount');
     ReactServerRendering = require('ReactServerRendering');
     ReactUpdates = require('ReactUpdates');
+    ReactRenderer = require('ReactRenderer');
 
     MorphingComponent = React.createClass({
       getInitialState: function() {
@@ -357,15 +359,16 @@ describe('ReactCompositeComponent', function() {
     var instance = <Component />;
     expect(instance.setProps).not.toBeDefined();
 
-    instance = React.render(instance, container);
+    var renderer = new ReactRenderer(instance, container);
+    instance = renderer.component;
     expect(function() {
-      instance.setProps({value: 1});
+      renderer.setProps({value: 1});
     }).not.toThrow();
     expect(console.error.calls.length).toBe(0);
 
     React.unmountComponentAtNode(container);
     expect(function() {
-      instance.setProps({value: 2});
+      renderer.setProps({value: 2});
     }).not.toThrow();
 
     expect(console.error.calls.length).toBe(1);

--- a/src/core/__tests__/ReactCompositeComponentState-test.js
+++ b/src/core/__tests__/ReactCompositeComponentState-test.js
@@ -15,6 +15,7 @@ var mocks = require('mocks');
 
 var React;
 var ReactInstanceMap;
+var ReactRenderer;
 var ReactTestUtils;
 var reactComponentExpect;
 
@@ -25,6 +26,7 @@ describe('ReactCompositeComponent-state', function() {
   beforeEach(function() {
     React = require('React');
     ReactInstanceMap = require('ReactInstanceMap');
+    ReactRenderer = require('ReactRenderer');
     ReactTestUtils = require('ReactTestUtils');
     reactComponentExpect = require('reactComponentExpect');
 
@@ -137,14 +139,15 @@ describe('ReactCompositeComponent-state', function() {
     document.body.appendChild(container);
 
     var stateListener = mocks.getMockFunction();
-    var instance = React.render(
+    var renderer = new ReactRenderer(
       <TestComponent stateListener={stateListener} />,
       container,
       function peekAtInitialCallback() {
         this.peekAtState('initial-callback');
       }
     );
-    instance.setProps(
+    var instance = renderer.component;
+    renderer.setProps(
       {nextColor: 'green'},
       instance.peekAtCallback('setProps')
     );


### PR DESCRIPTION
Added renderer as a migration path for setProps.

Side note: I had to downgrade two lint rules to warnings because apparently eslint (in it's current form) doesn't understand ES6 classes. Meh, sucks. We should get our eslint install fixed or file a ticket on eslint. We never ran into this before because we only used es6 classes in tests and have linting disabled completely for tests?