### PR TITLE
Better warnings for nested propTypes

### DIFF
--- a/src/addons/link/__tests__/ReactLinkPropTypes-test.js
+++ b/src/addons/link/__tests__/ReactLinkPropTypes-test.js
@@ -48,22 +48,22 @@ describe('ReactLink', function() {
     typeCheckFail(
       LinkPropTypes.link(React.PropTypes.any),
       {},
-      'Required prop `value` was not specified in `testComponent`.'
+      'Required prop `testProp.value` was not specified in `testComponent`.'
     );
     typeCheckFail(
       LinkPropTypes.link(React.PropTypes.any),
       {value: 123},
-      'Required prop `requestChange` was not specified in `testComponent`.'
+      'Required prop `testProp.requestChange` was not specified in `testComponent`.'
     );
     typeCheckFail(
       LinkPropTypes.link(React.PropTypes.any),
       {requestChange: emptyFunction},
-      'Required prop `value` was not specified in `testComponent`.'
+      'Required prop `testProp.value` was not specified in `testComponent`.'
     );
     typeCheckFail(
       LinkPropTypes.link(React.PropTypes.any),
       {value: null, requestChange: null},
-      'Required prop `value` was not specified in `testComponent`.'
+      'Required prop `testProp.value` was not specified in `testComponent`.'
     );
   });
 
@@ -104,7 +104,7 @@ describe('ReactLink', function() {
     typeCheckFail(
       LinkPropTypes.link(React.PropTypes.string),
       {value: 123, requestChange: emptyFunction},
-      'Invalid prop `value` of type `number` supplied to `testComponent`,' +
+      'Invalid prop `testProp.value` of type `number` supplied to `testComponent`,' +
       ' expected `string`.'
     );
   });
@@ -148,7 +148,7 @@ describe('ReactLink', function() {
     typeCheckFail(
       LinkPropTypes.link(React.PropTypes.oneOfType([React.PropTypes.number])),
       {value: 'imastring', requestChange: emptyFunction},
-      'Invalid prop `value` supplied to `testComponent`.'
+      'Invalid prop `testProp.value` supplied to `testComponent`.'
     );
   });
 });

--- a/src/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/classic/types/__tests__/ReactPropTypes-test.js
@@ -161,7 +161,7 @@ describe('ReactPropTypes', function() {
       typeCheckFail(
         PropTypes.arrayOf(PropTypes.number),
         [1, 2, 'b'],
-        'Invalid prop `2` of type `string` supplied to `testComponent`, ' +
+        'Invalid prop `testProp[2]` of type `string` supplied to `testComponent`, ' +
         'expected `number`.'
       );
     });
@@ -173,7 +173,7 @@ describe('ReactPropTypes', function() {
       typeCheckFail(
         PropTypes.arrayOf(PropTypes.instanceOf(Thing)),
         [new Thing(), 'xyz'],
-        'Invalid prop `1` supplied to `testComponent`, expected instance of `' +
+        'Invalid prop `testProp[1]` supplied to `testComponent`, expected instance of `' +
         name + '`.'
       );
     });
@@ -458,7 +458,7 @@ describe('ReactPropTypes', function() {
       typeCheckFail(
         PropTypes.objectOf(PropTypes.number),
         {a: 1, b: 2, c: 'b'},
-        'Invalid prop `c` of type `string` supplied to `testComponent`, ' +
+        'Invalid prop `testProp.c` of type `string` supplied to `testComponent`, ' +
         'expected `number`.'
       );
     });
@@ -470,7 +470,7 @@ describe('ReactPropTypes', function() {
       typeCheckFail(
         PropTypes.objectOf(PropTypes.instanceOf(Thing)),
         {a: new Thing(), b: 'xyz'},
-        'Invalid prop `b` supplied to `testComponent`, expected instance of `' +
+        'Invalid prop `testProp.b` supplied to `testComponent`, expected instance of `' +
         name + '`.'
       );
     });
@@ -668,7 +668,7 @@ describe('ReactPropTypes', function() {
       typeCheckFail(
         PropTypes.shape({key: PropTypes.number.isRequired}),
         {},
-        'Required prop `key` was not specified in `testComponent`.'
+        'Required prop `testProp.key` was not specified in `testComponent`.'
       );
     });
 
@@ -679,14 +679,14 @@ describe('ReactPropTypes', function() {
           secondKey: PropTypes.number.isRequired
         }),
         {},
-        'Required prop `key` was not specified in `testComponent`.'
+        'Required prop `testProp.key` was not specified in `testComponent`.'
       );
     });
 
     it("should warn for invalid key types", function() {
       typeCheckFail(PropTypes.shape({key: PropTypes.number}),
         {key: 'abc'},
-        'Invalid prop `key` of type `string` supplied to `testComponent`, ' +
+        'Invalid prop `testProp.key` of type `string` supplied to `testComponent`, ' +
         'expected `number`.'
       );
     });


### PR DESCRIPTION
`arrayOf`, `shape` and `objectOf` warnings now display the full path of the invalid key.

Examples:
```
PropTypes.shape({ key: PropTypes.number })({ key: 'bar' }, 'testProp', 'testComponent');
// Invalid prop `testProp.key` of type `string` supplied to `testComponent`, expected `number`.
PropTypes.arrayOf(PropTypes.number)(['foo'], 'testProp', 'testComponent');
// Invalid prop `testProp[0]` of type `string` supplied to `testComponent`, expected `number`.
```