### PR TITLE
Revert switch to parent context (temporarily)

### DIFF
--- a/src/addons/__tests__/renderSubtreeIntoContainer.js
+++ b/src/addons/__tests__/renderSubtreeIntoContainer.js
@@ -54,7 +54,7 @@ describe('renderSubtreeIntoContainer', function() {
     });
 
     ReactTestUtils.renderIntoDocument(<Parent />);
-    expect(portal.firstChild.innerHTML).toBe('bar');
+    // TODO: expect(portal.firstChild.innerHTML).toBe('bar'); after parent-context lands.
   });
 
   it('should throw if parentComponent is invalid', function () {

--- a/src/browser/ui/React.js
+++ b/src/browser/ui/React.js
@@ -16,6 +16,7 @@
 var ReactChildren = require('ReactChildren');
 var ReactComponent = require('ReactComponent');
 var ReactClass = require('ReactClass');
+var ReactContext = require('ReactContext');
 var ReactCurrentOwner = require('ReactCurrentOwner');
 var ReactElement = require('ReactElement');
 var ReactElementValidator = require('ReactElementValidator');
@@ -74,6 +75,7 @@ var React = {
   renderToStaticMarkup: ReactServerRendering.renderToStaticMarkup,
   unmountComponentAtNode: ReactMount.unmountComponentAtNode,
   isValidElement: ReactElement.isValidElement,
+  withContext: ReactContext.withContext,
 
   // Hook for JSX spread, don't use this for anything else.
   __spread: assign

--- a/src/classic/element/ReactElement.js
+++ b/src/classic/element/ReactElement.js
@@ -99,6 +99,10 @@ var ReactElement = function(type, key, ref, owner, context, props) {
   // Record the component responsible for creating this element.
   this._owner = owner;
 
+  // TODO: Deprecate withContext, and then the context becomes accessible
+  // through the owner.
+  this._context = context;
+
   if (__DEV__) {
     // The validation flag and props are currently mutative. We put them on
     // an external backing store so that we can freeze the whole object.

--- a/src/classic/element/__tests__/ReactElement-test.js
+++ b/src/classic/element/__tests__/ReactElement-test.js
@@ -86,6 +86,30 @@ describe('ReactElement', function() {
     expect(element.props).toEqual({foo:'56'});
   });
 
+  it('preserves the legacy context on the element', function() {
+    var Component = React.createFactory(ComponentClass);
+    var element;
+
+    var Wrapper = React.createClass({
+      childContextTypes: {
+        foo: React.PropTypes.string
+      },
+      getChildContext: function() {
+        return {foo: 'bar'};
+      },
+      render: function() {
+        element = Component();
+        return element;
+      }
+    });
+
+    ReactTestUtils.renderIntoDocument(
+      React.createElement(Wrapper)
+    );
+
+    expect(element._context).toEqual({foo: 'bar'});
+  });
+
   it('preserves the owner on the element', function() {
     var Component = React.createFactory(ComponentClass);
     var element;

--- a/src/core/ReactCompositeComponent.js
+++ b/src/core/ReactCompositeComponent.js
@@ -125,7 +125,7 @@ var ReactCompositeComponentMixin = {
     this._rootNodeID = rootID;
 
     var publicProps = this._processProps(this._currentElement.props);
-    var publicContext = this._processContext(context);
+    var publicContext = this._processContext(this._currentElement._context);
 
     var Component = ReactNativeComponent.getComponentClassForElement(
       this._currentElement
@@ -157,6 +157,10 @@ var ReactCompositeComponentMixin = {
 
     // Store a reference from the instance back to the internal representation
     ReactInstanceMap.set(inst, this);
+
+    if (__DEV__) {
+      this._warnIfContextsDiffer(this._currentElement._context, context);
+    }
 
     if (__DEV__) {
       // Since plain JS classes are defined without any special initialization
@@ -534,6 +538,30 @@ var ReactCompositeComponentMixin = {
   },
 
   /**
+   * Compare two contexts, warning if they are different
+   * TODO: Remove this check when owner-context is removed
+   */
+   _warnIfContextsDiffer: function(ownerBasedContext, parentBasedContext) {
+    ownerBasedContext = this._maskContext(ownerBasedContext);
+    parentBasedContext = this._maskContext(parentBasedContext);
+    var parentKeys = Object.keys(parentBasedContext).sort();
+    var displayName = this.getName() || 'ReactCompositeComponent';
+    for (var i = 0; i < parentKeys.length; i++) {
+      var key = parentKeys[i];
+      warning(
+        ownerBasedContext[key] === parentBasedContext[key],
+        'owner-based and parent-based contexts differ '  +
+        '(values: `%s` vs `%s`) for key (%s) while mounting %s ' +
+        '(see: http://fb.me/react-context-by-parent)',
+        ownerBasedContext[key],
+        parentBasedContext[key],
+        key,
+        displayName
+      );
+    }
+  },
+
+  /**
    * Perform an update to a mounted component. The componentWillReceiveProps and
    * shouldComponentUpdate methods are called, then (assuming the update isn't
    * skipped) the remaining update lifecycle methods are called and the DOM
@@ -562,8 +590,17 @@ var ReactCompositeComponentMixin = {
 
     // Distinguish between a props update versus a simple state update
     if (prevParentElement !== nextParentElement) {
-      nextContext = this._processContext(nextUnmaskedContext);
+      nextContext = this._processContext(nextParentElement._context);
       nextProps = this._processProps(nextParentElement.props);
+
+      if (__DEV__) {
+        if (nextUnmaskedContext != null) {
+          this._warnIfContextsDiffer(
+            nextParentElement._context,
+            nextUnmaskedContext
+          );
+        }
+      }
 
       // An update here will schedule an update but immediately set
       // _pendingStateQueue which will ensure that any state updates gets

--- a/src/core/ReactContext.js
+++ b/src/core/ReactContext.js
@@ -11,7 +11,11 @@
 
 'use strict';
 
+var assign = require('Object.assign');
 var emptyObject = require('emptyObject');
+var warning = require('warning');
+
+var didWarn = false;
 
 /**
  * Keeps track of the current context.
@@ -25,7 +29,45 @@ var ReactContext = {
    * @internal
    * @type {object}
    */
-  current: emptyObject
+  current: emptyObject,
+
+  /**
+   * Temporarily extends the current context while executing scopedCallback.
+   *
+   * A typical use case might look like
+   *
+   *  render: function() {
+   *    var children = ReactContext.withContext({foo: 'foo'}, () => (
+   *
+   *    ));
+   *    return <div>{children}</div>;
+   *  }
+   *
+   * @param {object} newContext New context to merge into the existing context
+   * @param {function} scopedCallback Callback to run with the new context
+   * @return {ReactComponent|array<ReactComponent>}
+   */
+  withContext: function(newContext, scopedCallback) {
+    if (__DEV__) {
+      warning(
+        didWarn,
+        'withContext is deprecated and will be removed in a future version. ' +
+        'Use a wrapper component with getChildContext instead.'
+      );
+
+      didWarn = true;
+    }
+
+    var result;
+    var previousContext = ReactContext.current;
+    ReactContext.current = assign({}, previousContext, newContext);
+    try {
+      result = scopedCallback();
+    } finally {
+      ReactContext.current = previousContext;
+    }
+    return result;
+  }
 
 };
 

--- a/src/core/__tests__/ReactCompositeComponent-test.js
+++ b/src/core/__tests__/ReactCompositeComponent-test.js
@@ -71,7 +71,12 @@ describe('ReactCompositeComponent', function() {
       }
     });
 
+    // Ignore the first warning which is fired by using withContext at all.
+    // That way we don't have to reset and assert it on every subsequent test.
+    // This will be killed soon anyway.
     console.error = mocks.getMockFunction();
+    React.withContext({}, function() { });
+
     spyOn(console, 'error');
   });
 
@@ -604,6 +609,178 @@ describe('ReactCompositeComponent', function() {
     reactComponentExpect(childInstance).scalarContextEqual({foo: 'bar', depth: 0});
   });
 
+  it('warn if context keys differ', function() {
+    var Component = React.createClass({
+      contextTypes: {
+        foo: ReactPropTypes.string.isRequired
+      },
+
+      render: function() {
+        return <div />;
+      }
+    });
+
+    React.withContext({foo: 'bar'}, function() {
+      ReactTestUtils.renderIntoDocument(<Component />);
+    });
+
+    expect(console.error.argsForCall.length).toBe(1);
+    expect(console.error.argsForCall[0][0]).toBe(
+      'Warning: owner-based and parent-based contexts differ ' +
+      '(values: `bar` vs `undefined`) for key (foo) ' +
+      'while mounting Component (see: http://fb.me/react-context-by-parent)'
+    );
+
+  });
+
+  it('warn if context values differ', function() {
+    var Parent = React.createClass({
+      childContextTypes: {
+        foo: ReactPropTypes.string
+      },
+
+      getChildContext: function() {
+        return {
+          foo: "bar"
+        };
+      },
+
+      render: function() {
+        return <div>{this.props.children}</div>;
+      }
+    });
+    var Component = React.createClass({
+      contextTypes: {
+        foo: ReactPropTypes.string.isRequired
+      },
+
+      render: function() {
+        return <div />;
+      }
+    });
+
+    var component = React.withContext({foo: 'noise'}, function() {
+      return <Component />;
+    });
+
+    ReactTestUtils.renderIntoDocument(<Parent>{component}</Parent>);
+
+    // Two warnings, one for the component and one for the div
+    // We may want to make this expect one warning in the future
+    expect(console.error.argsForCall.length).toBe(1);
+    expect(console.error.argsForCall[0][0]).toBe(
+      'Warning: owner-based and parent-based contexts differ ' +
+      '(values: `noise` vs `bar`) for key (foo) while mounting Component ' +
+      '(see: http://fb.me/react-context-by-parent)'
+    );
+
+  });
+
+  it('should warn if context values differ on update using withContext', function() {
+    var Parent = React.createClass({
+      childContextTypes: {
+        foo: ReactPropTypes.string
+      },
+
+      getChildContext: function() {
+        return {
+          foo: "bar"
+        };
+      },
+
+      render: function() {
+        return <div>{this.props.children}</div>;
+      }
+    });
+
+    var Component = React.createClass({
+      contextTypes: {
+        foo: ReactPropTypes.string.isRequired
+      },
+
+      render: function() {
+        return <div />;
+      }
+    });
+
+    var div = document.createElement('div');
+
+    var componentWithSameContext = React.withContext({foo: 'bar'}, function() {
+      return <Component />;
+    });
+    React.render(<Parent>{componentWithSameContext}</Parent>, div);
+
+    expect(console.error.argsForCall.length).toBe(0);
+
+    var componentWithDifferentContext = React.withContext({foo: 'noise'}, function() {
+      return <Component />;
+    });
+    React.render(<Parent>{componentWithDifferentContext}</Parent>, div);
+
+    // Two warnings, one for the component and one for the div
+    // We may want to make this expect one warning in the future
+    expect(console.error.argsForCall.length).toBe(1);
+    expect(console.error.argsForCall[0][0]).toBe(
+      'Warning: owner-based and parent-based contexts differ ' +
+      '(values: `noise` vs `bar`) for key (foo) while mounting Component ' +
+      '(see: http://fb.me/react-context-by-parent)'
+    );
+  });
+
+  it('should warn if context values differ on update using wrapper', function() {
+    var Parent = React.createClass({
+      childContextTypes: {
+        foo: ReactPropTypes.string
+      },
+
+      getChildContext: function() {
+        return {
+          foo: "bar"
+        };
+      },
+
+      render: function() {
+        return <div>{this.props.children}</div>;
+      }
+    });
+
+    var Component = React.createClass({
+      contextTypes: {
+        foo: ReactPropTypes.string.isRequired
+      },
+
+      render: function() {
+        return <div />;
+      }
+    });
+
+    var Wrapper = React.createClass({
+      childContextTypes: {
+        foo: ReactPropTypes.string
+      },
+
+      getChildContext: function() {
+        return {foo: this.props.foo};
+      },
+
+      render: function() { return <Parent><Component /></Parent>; }
+
+    });
+
+    var div = document.createElement('div');
+    React.render(<Wrapper foo='bar' />, div);
+    React.render(<Wrapper foo='noise' />, div);
+
+    // Two warnings, one for the component and one for the div
+    // We may want to make this expect one warning in the future
+    expect(console.error.argsForCall.length).toBe(1);
+    expect(console.error.argsForCall[0][0]).toBe(
+      'Warning: owner-based and parent-based contexts differ ' +
+      '(values: `noise` vs `bar`) for key (foo) while mounting Component ' +
+      '(see: http://fb.me/react-context-by-parent)'
+    );
+  });
+
   it('unmasked context propagates through updates', function() {
 
     var Leaf = React.createClass({
@@ -805,39 +982,6 @@ describe('ReactCompositeComponent', function() {
     expect(console.error.calls[0].args[0]).toContain(
       'NotAComponent(...): No `render` method found'
     );
-  });
-
-  it('context should be passed down from the parent', function() {
-    var Parent = React.createClass({
-      childContextTypes: {
-        foo: ReactPropTypes.string
-      },
-
-      getChildContext: function() {
-        return {
-          foo: "bar"
-        };
-      },
-
-      render: function() {
-        return <div>{this.props.children}</div>;
-      }
-    });
-
-    var Component = React.createClass({
-      contextTypes: {
-        foo: ReactPropTypes.string.isRequired
-      },
-
-      render: function() {
-        return <div />;
-      }
-    });
-
-    var div = document.createElement('div');
-    React.render(<Parent><Component /></Parent>, div);
-
-    expect(console.error.argsForCall.length).toBe(0);
   });
 
 });


### PR DESCRIPTION
Revert switch to parent context (temporarily).

Merging this with the internal site is too risky right now.  Let's try a different approach and re-land this diff before releasing 0.14

Reverts 5297ff66cf8f9b6459d6cf73d4e3a54cc010b34d and 7d4491753158afc839f2934367ad2f7878ff7283, and comments out the expectation in the renderSubtreeIntoContainer expectation.