### PR TITLE
unmountChildren was missing an Object.hasOwnProperty check (src/core/ReactChildReconciler.js)

### DIFF
--- a/src/core/ReactChildReconciler.js
+++ b/src/core/ReactChildReconciler.js
@@ -115,8 +115,10 @@ var ReactChildReconciler = {
    */
   unmountChildren: function(renderedChildren) {
     for (var name in renderedChildren) {
-      var renderedChild = renderedChildren[name];
-      ReactReconciler.unmountComponent(renderedChild);
+      if (renderedChildren.hasOwnProperty(name)) {
+        var renderedChild = renderedChildren[name];
+        ReactReconciler.unmountComponent(renderedChild);
+      }
     }
   }
 


### PR DESCRIPTION
Adding a method to Object.prototype caused react to crash on me when unloading a component. Turns out that ReactChildReconciler::unmountChildren was missing a check renderedChildren.hasOwnProperty(name) 