### PR TITLE
Add `findRenderedDOMComponentWithID` to TestUtils

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -241,6 +241,25 @@ var ReactTestUtils = {
   },
 
   /**
+   * Finds the instances of components with id equal to `componentId`, or
+   * throws exception if there is any other number of matches besides one.
+   * @return {!ReactComponent} The one match
+   */
+  findRenderedDOMComponentWithId: function(root, componentId) {
+    var all = ReactTestUtils.findAllInRenderedTree(root, function(inst) {
+      return ReactTestUtils.isDOMComponent(inst) &&
+            inst.props.id === componentId;
+    });
+
+    if (all.length !== 1) {
+      throw new Error(
+        'Did not find exactly one match for componentId:' + componentId
+      );
+    }
+    return all[0];
+  },
+
+  /**
    * Pass a mocked component module to this method to augment it with
    * useful methods that allow it to be used as a dummy React component.
    * Instead of rendering as usual, the component will become a simple

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -169,6 +169,17 @@ describe('ReactTestUtils', function() {
 
   });
 
+  it('Test findRenderedDOMComponentWithId', function() {
+    var renderedComponent = ReactTestUtils.renderIntoDocument(<div>Hello <span id="example">Jim</span></div>);
+    var result = ReactTestUtils.findRenderedDOMComponentWithId(
+      renderedComponent,
+      'example'
+    );
+    expect(result.tagName).toBe('SPAN');
+    expect(result.props.children).toEqual('Jim')
+
+  });
+
   it('traverses children in the correct order', function() {
     var container = document.createElement('div');
 


### PR DESCRIPTION
Fixes #1616. Although there is a [pr](https://github.com/facebook/react/pull/1651)
 try to solve this issue in a different way, but was pending there for 10 months. And have this ability in TestUnits is somehow crucial, in my humble opinion.

Also just wondering if we really need `scryRenderedDOMComponentsWithId` since elements with duplicate id violates the html rule?