### PR TITLE
Object.hasOwnProperty fix for ReactRef[attachRefs & detachRefs] (src/cor...

### DIFF
--- a/src/core/ReactRef.js
+++ b/src/core/ReactRef.js
@@ -34,7 +34,7 @@ function detachRef(ref, component, owner) {
 }
 
 ReactRef.attachRefs = function(instance, element) {
-  var ref = element.ref;
+  var ref = (element && element.ref) || null;
   if (ref != null) {
     attachRef(ref, instance, element._owner);
   }
@@ -60,7 +60,7 @@ ReactRef.shouldUpdateRefs = function(prevElement, nextElement) {
 };
 
 ReactRef.detachRefs = function(instance, element) {
-  var ref = element.ref;
+  var ref = (element && element.ref) || null;
   if (ref != null) {
     detachRef(ref, instance, element._owner);
   }


### PR DESCRIPTION
Objects with extended prototype causes these methods to throw when
calling setState() ReactRef.attachRefs & ReactRef.detachRefs

FIX: a simple integrity check for @element argument.

(src/core/ReactRef.js)
