### PR TITLE
Custom class names in ReactCSSTransitionGroup

### DIFF
--- a/docs/docs/10.1-animation.md
+++ b/docs/docs/10.1-animation.md
@@ -85,6 +85,7 @@ You'll notice that when you try to remove an item `ReactCSSTransitionGroup` keep
 ```
 
 ### Custom Classes ###
+
 It is also possible to use custom class names for each of the steps in your transitions. Instead of passing a string into transitionName you can pass an object containing either the `enter` and `leave` class names, or an object containing the `enter`, `enter-active`, `leave-active`, and `leave` class names. If only the enter and leave classes are provided, the enter-active and leave-active classes will be determined by appending '-active' to the end of the class name. Here are two examples using custom classes:
 
 ```javascript
@@ -94,7 +95,9 @@ It is also possible to use custom class names for each of the steps in your tran
       enter: 'enter',
       enterActive: 'enterActive',
       leave: 'leave',
-      leaveActive: 'leaveActive'
+      leaveActive: 'leaveActive',
+      appear: 'appear',
+      appearActive: 'appearActive'
     }>
     {item}
   </ReactCSSTransitionGroup>
@@ -102,7 +105,8 @@ It is also possible to use custom class names for each of the steps in your tran
   <ReactCSSTransitionGroup
     transitionName={
       enter: 'enter',
-      leave: 'leave'
+      leave: 'leave',
+      appear: 'appear'
     }>
     {item2}
   </ReactCSSTransitionGroup>

--- a/docs/docs/10.1-animation.md
+++ b/docs/docs/10.1-animation.md
@@ -84,6 +84,32 @@ You'll notice that when you try to remove an item `ReactCSSTransitionGroup` keep
 }
 ```
 
+### Custom Classes ###
+It is also possible to use custom class names for each of the steps in your transitions. Instead of passing a string into transitionName you can pass an object containing either the `enter` and `leave` class names, or an object containing the `enter`, `enter-active`, `leave-active`, and `leave` class names. If only the enter and leave classes are provided, the enter-active and leave-active classes will be determined by appending '-active' to the end of the class name. Here are two examples using custom classes:
+
+```javascript
+  ...
+  <ReactCSSTransitionGroup
+    transitionName={
+      enter: 'enter',
+      enterActive: 'enterActive',
+      leave: 'leave',
+      leaveActive: 'leaveActive'
+    }>
+    {item}
+  </ReactCSSTransitionGroup>
+  
+  <ReactCSSTransitionGroup
+    transitionName={
+      enter: 'enter',
+      leave: 'leave'
+    }>
+    {item2}
+  </ReactCSSTransitionGroup>
+  ...
+    
+```
+
 ### Animation Group Must Be Mounted To Work
 
 In order for it to apply transitions to its children, the `ReactCSSTransitionGroup` must already be mounted in the DOM. The example below would not work, because the `ReactCSSTransitionGroup` is being mounted along with the new item, instead of the new item being mounted within it. Compare this to the [Getting Started](#getting-started) section above to see the difference.

--- a/src/addons/transitions/ReactCSSTransitionGroup.js
+++ b/src/addons/transitions/ReactCSSTransitionGroup.js
@@ -31,13 +31,16 @@ var ReactCSSTransitionGroup = React.createClass({
       React.PropTypes.string,
       React.PropTypes.shape({
         enter: React.PropTypes.string,
-        leave: React.PropTypes.string
+        leave: React.PropTypes.string,
+        active: React.PropTypes.string
       }),
       React.PropTypes.shape({
         enter: React.PropTypes.string,
         enterActive: React.PropTypes.string,
         leave: React.PropTypes.string,
-        leaveActive: React.PropTypes.string
+        leaveActive: React.PropTypes.string,
+        appear: React.PropTypes.string,
+        appearActive: React.PropTypes.string
       })
     ]).isRequired,
     transitionAppear: React.PropTypes.bool,

--- a/src/addons/transitions/ReactCSSTransitionGroup.js
+++ b/src/addons/transitions/ReactCSSTransitionGroup.js
@@ -27,7 +27,19 @@ var ReactCSSTransitionGroup = React.createClass({
   displayName: 'ReactCSSTransitionGroup',
 
   propTypes: {
-    transitionName: React.PropTypes.string.isRequired,
+    transitionName: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.shape({
+        enter: React.PropTypes.string,
+        leave: React.PropTypes.string
+      }),
+      React.PropTypes.shape({
+        enter: React.PropTypes.string,
+        enterActive: React.PropTypes.string,
+        leave: React.PropTypes.string,
+        leaveActive: React.PropTypes.string
+      })
+    ]).isRequired,
     transitionAppear: React.PropTypes.bool,
     transitionEnter: React.PropTypes.bool,
     transitionLeave: React.PropTypes.bool

--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -48,8 +48,8 @@ var ReactCSSTransitionGroupChild = React.createClass({
 
   transition: function(animationType, finishCallback) {
     var node = React.findDOMNode(this);
-    var className = this.props.name + '-' + animationType;
-    var activeClassName = className + '-active';
+    var className = this.props.name[animationType] || this.props.name + '-' + animationType;
+    var activeClassName = this.props.name[animationType + 'Active'] || className + '-active';
     var noEventTimeout = null;
 
     var endListener = function(e) {


### PR DESCRIPTION
resolving #2680. API for adding custom classnames follows the proposed API in the issue.