### PR TITLE
Add CNAME file to claim react.js.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+react.js.org


### PR DESCRIPTION
Fixes #3754. Note that this will **not** cause the existing page http://facebook.github.io/react/ to redirect.