### PR TITLE
Change the organization of react-source files to allow copy-less boot of react-rails

### DIFF
--- a/gem-react-source/react-source.gemspec
+++ b/gem-react-source/react-source.gemspec
@@ -17,12 +17,5 @@ gemspec = Gem::Specification.new do |s|
   s.authors = ['Paul O’Shannessy']
   s.email = ['paul@oshannessy.com']
 
-  s.files = Dir[
-    'build/react.js',
-    'build/react.min.js',
-    'build/react-with-addons.js',
-    'build/react-with-addons.min.js',
-    'build/JSXTransformer.js',
-    'lib/react/source.rb'
-  ]
+  s.files = %w(lib/react/source.rb) + Dir['build/**/*.js']
 end

--- a/grunt/tasks/gem-react-source.js
+++ b/grunt/tasks/gem-react-source.js
@@ -7,8 +7,11 @@ var src = 'gem-react-source/';
 var dest = 'build/gem-react-source/';
 var build = dest + 'build/';
 var buildFiles = [
-  'react.js', 'react.min.js', 'JSXTransformer.js',
-  'react-with-addons.js', 'react-with-addons.min.js'
+  ['react.js', 'development/', 'react.js'],
+  ['react-with-addons.js', 'development-with-addons/', 'react.js'],
+  ['react.min.js', 'production/', 'react.js'],
+  ['react-with-addons.min.js', 'production-with-addons/', 'react.js'],
+  ['JSXTransformer.js', '', 'JSXTransformer.js']
 ];
 
 function buildRelease() {
@@ -31,9 +34,12 @@ function buildRelease() {
   });
 
   // Make built source available inside npm package
-  grunt.file.mkdir(build);
   buildFiles.forEach(function(file) {
-    grunt.file.copy('build/' + file, build + file);
+    var source = file[0];
+    var destDir = build + file[1];
+    var destPath = destDir + file[2];
+    grunt.file.mkdir(destDir);
+    grunt.file.copy('build/' + source, destPath);
   });
 }
 


### PR DESCRIPTION
See https://github.com/reactjs/react-rails/pull/254 for context

Unfortunately I was unable to test this change, I'm really not familiar with node so I didn't manage to run that task.

ping @rmosolgo are you also a react contributor?