### PR TITLE
DRY quadratic formula example

### DIFF
--- a/examples/quadratic/example.js
+++ b/examples/quadratic/example.js
@@ -23,8 +23,10 @@ var QuadraticCalculator = React.createClass({
     var a = this.state.a;
     var b = this.state.b;
     var c = this.state.c;
-    var x1 = (-b + Math.sqrt(Math.pow(b, 2) - 4 * a * c)) / (2 * a);
-    var x2 = (-b - Math.sqrt(Math.pow(b, 2) - 4 * a * c)) / (2 * a);
+    var root = Math.sqrt(Math.pow(b, 2) - 4 * a * c);
+    var denominator = 2 * a;
+    var x1 = (-b + root) / denominator;
+    var x2 = (-b - root) / denominator;
     return (
       <div>
         <strong>


### PR DESCRIPTION
Minor improvement to avoid calculating root and denominator part twice in quadratic formula example.