### PR TITLE
Fix infinite recursion in browsers with iterators

### DIFF
--- a/src/classic/element/ReactElementValidator.js
+++ b/src/classic/element/ReactElementValidator.js
@@ -194,7 +194,10 @@ function validateChildKeys(node, parentType) {
         validateChildKeys(child, parentType);
       }
     }
-  } else if (ReactElement.isValidElement(node)) {
+  } else if (
+      typeof node === 'string' || typeof node === 'number' ||
+      ReactElement.isValidElement(node)
+    ) {
     // This element was passed in a valid location.
     return;
   } else if (node) {

--- a/src/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/classic/element/__tests__/ReactElementValidator-test.js
@@ -173,7 +173,6 @@ describe('ReactElementValidator', function() {
   it('does not warn for keys when passing children down', function() {
     spyOn(console, 'error');
 
-    debugger;
     var Wrapper = React.createClass({
       render: function() {
         return (


### PR DESCRIPTION
My old code here didn't work properly -- for a string child, getIteratorFn would return an iterator that gave each character as its own string, and we'd attempt to loop over that too.

Tests now work in Chrome again.