### PR TITLE
check that React renders the menuitem closing tag

### DIFF
--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -438,9 +438,9 @@ describe('ReactDOMComponent', function() {
 
       var container = document.createElement('div');
 
-      React.render(<menu><menuitem /></menu>, container);
+      var returnedValue = React.renderToString(<menu><menuitem /></menu>);
 
-      expect(container.innerHTML).toContain('</menuitem>');
+      expect(returnedValue).toContain('</menuitem>');
 
       React.render(<menu><menuitem>children</menuitem></menu>, container);
 


### PR DESCRIPTION
This was all wrapped up and ready in #3783, but I had several commits that did not rebase well. There are failing tests now, but they have nothing to do with these changes, they are on the base facebook/react repo (I think the failing test was introduced in #3781).