### PR TITLE
Better invariant / warning replacement

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "preferGlobal": true,
   "commonerConfig": {
-    "version": 6
+    "version": 7
   },
   "scripts": {
     "test": "jest",

--- a/vendor/constants.js
+++ b/vendor/constants.js
@@ -37,21 +37,73 @@ module.exports = function(babel) {
     CallExpression: {
       exit: function(node, parent) {
         if (this.get('callee').isIdentifier({name: 'invariant'})) {
-          // Truncate the arguments of invariant(condition, ...)
-          // statements to just the condition based on NODE_ENV
-          // (dead code removal will remove the extra bytes).
-          return t.conditionalExpression(
-            DEV_EXPRESSION,
-            node,
-            t.callExpression(node.callee, [node.arguments[0]])
+          // Turns this code:
+          //
+          // invariant(condition, argument, argument);
+          //
+          // into this:
+          //
+          // if (!condition) {
+          //   if ("production" !== process.env.NODE_ENV) {
+          //     invariant(false, argument, argument);
+          //   } else {
+          //     invariant(false);
+          //   }
+          // }
+          //
+          // Specifically this does 2 things:
+          // 1. Checks the condition first, preventing an extra function call.
+          // 2. Adds an environment check so that verbose error messages aren't
+          //    shipped to production.
+          // The generated code is longer than the original code but will dead
+          // code removal in a minifier will strip that out.
+          var condition = node.arguments[0];
+          return t.ifStatement(
+            t.unaryExpression('!', condition),
+            t.blockStatement([
+              t.ifStatement(
+                DEV_EXPRESSION,
+                t.blockStatement([
+                  t.expressionStatement(
+                    t.callExpression(
+                      node.callee,
+                      [t.literal(false)].concat(node.arguments.slice(1))
+                    )
+                  )
+                ]),
+                t.blockStatement([
+                  t.expressionStatement(
+                    t.callExpression(
+                      node.callee,
+                      [t.literal(false)]
+                    )
+                  )
+                ])
+              )
+            ])
           );
         } else if (this.get('callee').isIdentifier({name: 'warning'})) {
-          // Eliminate warning(condition, ...) statements based on NODE_ENV
-          // (dead code removal will remove the extra bytes).
-          return t.conditionalExpression(
+          // Turns this code:
+          //
+          // warning(condition, argument, argument);
+          //
+          // into this:
+          //
+          // if ("production" !== process.env.NODE_ENV) {
+          //   warning(condition, argument, argument);
+          // }
+          //
+          // The goal is to strip out warning calls entirely in production. We
+          // don't need the same optimizations for conditions that we use for
+          // invariant because we don't care about an extra call in __DEV__
+
+          return t.ifStatement(
             DEV_EXPRESSION,
-            node,
-            t.literal(null)
+            t.blockStatement([
+              t.expressionStatement(
+                node
+              )
+            ])
           );
         }
       }


### PR DESCRIPTION
Does 2 things:

1. Changes how we replace `invariant` to check the condition before the environment, then call `invariant(false, ...)`
2. Use an if statement for the environment check around `warning`, not a condition expression.

Fixes #3701 

Here are some comparisons:

```js
// invariant before
("production" !== process.env.NODE_ENV ? invariant(
  componentOrElement.render == null ||
  typeof componentOrElement.render !== 'function',
  'Component (with keys: %s) contains `render` method ' +
  'but is not mounted in the DOM',
  Object.keys(componentOrElement)
) : invariant(componentOrElement.render == null ||
typeof componentOrElement.render !== 'function'));

// invariant after
if (!(componentOrElement.render == null || typeof componentOrElement.render !== 'function')) {
  if ("production" !== process.env.NODE_ENV) {
    invariant(false);
  } else {
    invariant(false, 'Component (with keys: %s) contains `render` method ' +
    'but is not mounted in the DOM', Object.keys(componentOrElement));
  }
};

// warning before
("production" !== process.env.NODE_ENV ? warning(
  !ieCompatibilityMode,
  'Internet Explorer is running in compatibility mode; please add the ' +
  'following tag to your HTML to prevent this from happening: ' +
  '<meta http-equiv="X-UA-Compatible" content="IE=edge" />'
) : null);

// warning after
if ("production" !== process.env.NODE_ENV) {
  warning(
    !ieCompatibilityMode,
    'Internet Explorer is running in compatibility mode; please add the ' +
    'following tag to your HTML to prevent this from happening: ' +
    '<meta http-equiv="X-UA-Compatible" content="IE=edge" />'
  );
};
```