### PR TITLE
Use Babel to build React

### DIFF
--- a/bin/jsx-internal
+++ b/bin/jsx-internal
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 // -*- mode: js -*-
+// vim: set ft=javascript :
 "use strict";
 
-var transform = require('../main').transform;
+var babel = require('babel-core');
+
 var propagate = require("../vendor/constants").propagate;
 
 require("commoner").version(
@@ -30,7 +32,10 @@ require("commoner").version(
   var constants = context.config.constants || {};
 
   // This is where JSX, ES6, etc. desugaring happens.
-  source = transform(source, {harmony: true, stripTypes: true});
+  source = babel.transform(source, {
+    blacklist: ['spec.functionName', 'validation.react'],
+    filename: id
+  }).code;
 
   // Constant propagation means removing any obviously dead code after
   // replacing constant expressions with literal (boolean) values.

--- a/grunt/config/browserify.js
+++ b/grunt/config/browserify.js
@@ -3,7 +3,6 @@
 'use strict';
 
 var envify = require('envify/custom');
-var es3ify = require('es3ify');
 var grunt = require('grunt');
 var UglifyJS = require('uglify-js');
 var uglifyify = require('uglifyify');
@@ -59,7 +58,7 @@ var basic = {
   standalone: 'React',
   transforms: [envify({NODE_ENV: 'development'})],
   plugins: [collapser],
-  after: [es3ify.transform, derequire, simpleBannerify]
+  after: [derequire, simpleBannerify]
 };
 
 var min = {
@@ -74,7 +73,7 @@ var min = {
   // No need to derequire because the minifier will mangle
   // the "require" calls.
 
-  after: [es3ify.transform, /*derequire,*/ minify, bannerify]
+  after: [/*derequire,*/ minify, bannerify]
 };
 
 var transformer = {
@@ -90,7 +89,7 @@ var transformer = {
   // collapser passes a number; this would throw.
 
   // plugins: [collapser],
-  after: [es3ify.transform, derequire, simpleBannerify]
+  after: [derequire, simpleBannerify]
 };
 
 var addons = {
@@ -103,7 +102,7 @@ var addons = {
   packageName: 'React (with addons)',
   transforms: [envify({NODE_ENV: 'development'})],
   plugins: [collapser],
-  after: [es3ify.transform, derequire, simpleBannerify]
+  after: [derequire, simpleBannerify]
 };
 
 var addonsMin = {
@@ -119,7 +118,7 @@ var addonsMin = {
   // No need to derequire because the minifier will mangle
   // the "require" calls.
 
-  after: [es3ify.transform, /*derequire,*/ minify, bannerify]
+  after: [/*derequire,*/ minify, bannerify]
 };
 
 var withCodeCoverageLogging = {

--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var ReactTools = require('../main.js');
-
+var babel = require('babel-core');
 var coffee = require('coffee-script');
+
 var tsPreprocessor = require('./ts-preprocessor');
 
 var defaultLibraries = [
@@ -20,6 +20,12 @@ module.exports = {
     if (path.match(/\.ts$/) && !path.match(/\.d\.ts$/)) {
       return ts.compile(src, path);
     }
-    return ReactTools.transform(src, {harmony: true});
+    if (!path.match(/\/node_modules\//)) {
+      return babel.transform(src, {
+        blacklist: ['spec.functionName', 'validation.react'],
+        filename: path
+      }).code;
+    }
+    return src;
   }
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "jstransform": "^10.1.0"
   },
   "devDependencies": {
+    "babel-core": "^5.2.7",
     "benchmark": "~1.0.0",
     "browserify": "^9.0.3",
     "bundle-collapser": "^1.1.1",
@@ -70,7 +71,7 @@
   },
   "preferGlobal": true,
   "commonerConfig": {
-    "version": 4
+    "version": 5
   },
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "coverify": "~1.0.4",
     "derequire": "^2.0.0",
     "envify": "^3.0.0",
-    "es3ify": "~0.1.2",
     "es5-shim": "^4.0.0",
     "eslint": "^0.14.1",
     "esprima-fb": "^13001.1001.0-dev-harmony-fb",

--- a/src/browser/ui/dom/setInnerHTML.js
+++ b/src/browser/ui/dom/setInnerHTML.js
@@ -67,7 +67,11 @@ if (ExecutionEnvironment.canUseDOM) {
           html[0] === '<' && NONVISIBLE_TEST.test(html)) {
         // Recover leading whitespace by temporarily prepending any character.
         // \uFEFF has the potential advantage of being zero-width/invisible.
-        node.innerHTML = '\uFEFF' + html;
+        // UglifyJS drops U+FEFF chars when parsing, so use String.fromCharCode
+        // in hopes that this is preserved even if "\uFEFF" is transformed to
+        // the actual Unicode character (by Babel, for example).
+        // https://github.com/mishoo/UglifyJS2/blob/v2.4.20/lib/parse.js#L216
+        node.innerHTML = String.fromCharCode(0xFEFF) + html;
 
         // deleteData leaves an empty `TextNode` which offsets the index of all
         // children. Definitely want to avoid this.

--- a/src/test/mocks.js
+++ b/src/test/mocks.js
@@ -69,7 +69,7 @@ function makeComponent(metadata) {
 
         instances.push(this);
         calls.push(Array.prototype.slice.call(arguments));
-        if (this instanceof arguments.callee) {
+        if (this instanceof f) {
           // This is probably being called as a constructor
           for (var slot in prototype) {
             // Copy prototype methods to the instance to make
@@ -106,8 +106,8 @@ function makeComponent(metadata) {
         }
 
         // Otherwise use prototype implementation
-        if (returnValue === undefined && arguments.callee._protoImpl) {
-          return arguments.callee._protoImpl.apply(this, arguments);
+        if (returnValue === undefined && f._protoImpl) {
+          return f._protoImpl.apply(this, arguments);
         }
 
         return returnValue;


### PR DESCRIPTION
Size comparison:

```
   raw     gz Compared to master @ 6ed98ec0c83918d91b16517544e658e2ec068070
     =      = build/JSXTransformer.js
-15736  -3247 build/react-with-addons.js
  +287     +7 build/react-with-addons.min.js
-14412  -2887 build/react.js
  +274    +15 build/react.min.js
```

Differences mostly look to be various bits of whitespace that Babel ends up removing during its transforms. In minified files, mostly additions of `"use strict";`.