### PR TITLE
[docs] Give authors links.

### DIFF
--- a/docs/_data/authors.yml
+++ b/docs/_data/authors.yml
@@ -1,0 +1,53 @@
+# Map of short name to more information. `name` will be used but if you don't
+# want to use your real name, just use whatever. If url is included, your name
+# will be a link to the provided url.
+billandjing:
+  name: Bill Fisher and Jing Chen
+chenglou:
+  name: Cheng Lou
+  url: https://twitter.com/_chenglou
+Daniel15:
+  name: Daniel Lo Nigro
+  url: http://dan.cx/
+fisherwebdev:
+  name: Bill Fisher
+  url: https://twitter.com/fisherwebdev
+jgebhardt:
+  name: Jonas Gebhardt
+  url: https://twitter.com/jonasgebhardt
+josephsavona:
+  name: Joseph Savona
+  url: https://twitter.com/en_JS
+kmeht:
+  name: Kunal Mehta
+  url: https://github.com/kmeht
+LoukaN:
+  name: Lou Husson
+  url: https://twitter.com/loukan42
+matthewjohnston4:
+  name: Matthew Johnston
+  url: https://github.com/matthewathome
+petehunt:
+  name: Pete Hunt
+  url: https://twitter.com/floydophone
+schrockn:
+  name: Nick Schrock
+  url: https://twitter.com/schrockn
+sebmarkbage:
+  name: Sebastian Markbåge
+  url: https://twitter.com/sebmarkbage
+spicyj:
+  name: Ben Alpert
+  url: http://benalpert.com
+steveluscher:
+  name: Steven Luscher
+  url: https://twitter.com/steveluscher
+vjeux:
+  name: Vjeux
+  url: https://twitter.com/vjeux
+wincent:
+  name: Greg Hurrell
+  url: https://twitter.com/wincent
+zpao:
+  name: Paul O’Shannessy
+  url: https://twitter.com/zpao

--- a/docs/_includes/blog_post.html
+++ b/docs/_includes/blog_post.html
@@ -1,10 +1,30 @@
-<h1><a href="/react{{ page.url }}">{{ page.title }}</a></h1>
-<p class="meta">{{ page.date | date_to_string }} by {{ page.author }}</p>
+{% assign page = include.page %}
+{% assign author = site.data.authors[page.author] %}
 
-<div id="post">
-{% if content != '' %}
-  {{ page.excerpt }}
+<h1>
+{% if include.isPermalink %}
+  {{ page.title }}
 {% else %}
-  {{ page.content }}
+  <a href="/react{{ page.url }}">{{ page.title }}</a>
 {% endif %}
+</h1>
+
+<p class="meta">
+  {{ page.date | date: "%B %e, %Y" }}
+  by
+  {% if author.url %}
+    <a href="{{author.url}}">{{ author.name }}</a>
+  {% else %}
+    {{ author.name }}
+  {% endif %}
+</p>
+
+<hr>
+
+<div class="post">
+  {{ include.content }}
 </div>
+
+{% if include.isPermalink %}
+  <div class="fb-like" data-send="true" data-width="650" data-show-faces="false"></div>
+{% endif %}

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -6,15 +6,6 @@ sectionid: blog
 <section class="content wrap blogContent">
   {% include nav_blog.html %}
   <div class="inner-content">
-    <h1>{{ page.title }}</h1>
-    <p class="meta">{{ page.date | date: "%B %e, %Y" }} by {{ page.author }}</p>
-
-    <hr>
-
-    <div class="post">
-      {{ content }}
-    </div>
-
-    <div class="fb-like" data-send="true" data-width="650" data-show-faces="false"></div>
+    {% include blog_post.html isPermalink="true" page=page content=content %}
   </div>
 </section>

--- a/docs/_posts/2013-06-02-jsfiddle-integration.md
+++ b/docs/_posts/2013-06-02-jsfiddle-integration.md
@@ -1,6 +1,6 @@
 ---
 title: JSFiddle Integration
-author: Christopher Chedeau
+author: vjeux
 ---
 
 [JSFiddle](https://jsfiddle.net) just announced support for React. This is an exciting news as it makes collaboration on snippets of code a lot easier. You can play around this **[base React JSFiddle](https://jsfiddle.net/vjeux/kb3gN/)**, fork it and share it! A [fiddle without JSX](https://jsfiddle.net/vjeux/VkebS/) is also available.

--- a/docs/_posts/2013-06-05-why-react.md
+++ b/docs/_posts/2013-06-05-why-react.md
@@ -1,6 +1,6 @@
 ---
 title: Why did we build React?
-author: Pete Hunt
+author: petehunt
 ---
 
 There are a lot of JavaScript MVC frameworks out there. Why did we build React

--- a/docs/_posts/2013-06-12-community-roundup.md
+++ b/docs/_posts/2013-06-12-community-roundup.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #1"
-author: Vjeux
+author: vjeux
 ---
 
 React was open sourced two weeks ago and it's time for a little round-up of what has been going on.

--- a/docs/_posts/2013-06-19-community-roundup-2.md
+++ b/docs/_posts/2013-06-19-community-roundup-2.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #2"
-author: Vjeux
+author: vjeux
 ---
 
 Since the launch we have received a lot of feedback and are actively working on React 0.4. In the meantime, here are the highlights of this week.

--- a/docs/_posts/2013-06-21-react-v0-3-3.md
+++ b/docs/_posts/2013-06-21-react-v0-3-3.md
@@ -1,6 +1,6 @@
 ---
 title: "React v0.3.3"
-author: Paul O'Shannessy
+author: zpao
 ---
 
 We have a ton of great stuff coming in v0.4, but in the meantime we're releasing v0.3.3. This release addresses some small issues people were having and simplifies our tools to make them easier to use.

--- a/docs/_posts/2013-06-27-community-roundup-3.md
+++ b/docs/_posts/2013-06-27-community-roundup-3.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #3"
-author: Vjeux
+author: vjeux
 ---
 
 The highlight of this week is that an interaction-heavy app has been ported to React. React components are solving issues they had with nested views.

--- a/docs/_posts/2013-07-02-react-v0-4-autobind-by-default.md
+++ b/docs/_posts/2013-07-02-react-v0-4-autobind-by-default.md
@@ -1,6 +1,6 @@
 ---
 title: "New in React v0.4: Autobind by Default"
-author: Paul O'Shannessy
+author: zpao
 ---
 
 React v0.4 is very close to completion. As we finish it off, we'd like to share with you some of the major changes we've made since v0.3. This is the first of several posts we'll be making over the next week.

--- a/docs/_posts/2013-07-03-community-roundup-4.md
+++ b/docs/_posts/2013-07-03-community-roundup-4.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #4"
-author: Vjeux
+author: vjeux
 ---
 
 React reconciliation process appears to be very well suited to implement a text editor with a live preview as people at Khan Academy show us.

--- a/docs/_posts/2013-07-11-react-v0-4-prop-validation-and-default-values.md
+++ b/docs/_posts/2013-07-11-react-v0-4-prop-validation-and-default-values.md
@@ -1,6 +1,6 @@
 ---
 title: "New in React v0.4: Prop Validation and Default Values"
-author: Paul O'Shannessy
+author: zpao
 ---
 
 Many of the questions we got following the public launch of React revolved around `props`, specifically that people wanted to do validation and to make sure their components had sensible defaults.

--- a/docs/_posts/2013-07-17-react-v0-4-0.md
+++ b/docs/_posts/2013-07-17-react-v0-4-0.md
@@ -1,6 +1,6 @@
 ---
 title: "React v0.4.0"
-author: Paul O'Shannessy
+author: zpao
 ---
 
 Over the past 2 months we've been taking feedback and working hard to make React even better. We fixed some bugs, made some under-the-hood improvements, and added several features that we think will improve the experience developing with React. Today we're proud to announce the availability of React v0.4!

--- a/docs/_posts/2013-07-23-community-roundup-5.md
+++ b/docs/_posts/2013-07-23-community-roundup-5.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #5"
-author: Vjeux
+author: vjeux
 ---
 
 We launched the [React Facebook Page](https://www.facebook.com/react) along with the React v0.4 launch. 700 people already liked it to get updated on the project :)

--- a/docs/_posts/2013-07-26-react-v0-4-1.md
+++ b/docs/_posts/2013-07-26-react-v0-4-1.md
@@ -1,6 +1,6 @@
 ---
 title: "React v0.4.1"
-author: Paul O'Shannessy
+author: zpao
 ---
 
 React v0.4.1 is a small update, mostly containing correctness fixes. Some code has been restructured internally but those changes do not impact any of our public APIs.

--- a/docs/_posts/2013-07-30-use-react-and-jsx-in-ruby-on-rails.md
+++ b/docs/_posts/2013-07-30-use-react-and-jsx-in-ruby-on-rails.md
@@ -1,6 +1,6 @@
 ---
 title: "Use React and JSX in Ruby on Rails"
-author: Paul O'Shannessy
+author: zpao
 ---
 
 Today we're releasing a gem to make it easier to use React and JSX in Ruby on Rails applications: [react-rails](https://github.com/facebook/react-rails).

--- a/docs/_posts/2013-08-05-community-roundup-6.md
+++ b/docs/_posts/2013-08-05-community-roundup-6.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #6"
-author: Vjeux
+author: vjeux
 ---
 
 This is the first Community Round-up where none of the items are from Facebook/Instagram employees. It's great to see the adoption of React growing.

--- a/docs/_posts/2013-08-19-use-react-and-jsx-in-python-applications.md
+++ b/docs/_posts/2013-08-19-use-react-and-jsx-in-python-applications.md
@@ -1,6 +1,6 @@
 ---
 title: "Use React and JSX in Python Applications"
-author: Kunal Mehta
+author: kmeht
 ---
 
 Today we're happy to announce the initial release of [PyReact](https://github.com/facebook/react-python), which makes it easier to use React and JSX in your Python applications. It's designed to provide an API to transform your JSX files into JavaScript, as well as provide access to the latest React source files.

--- a/docs/_posts/2013-08-26-community-roundup-7.md
+++ b/docs/_posts/2013-08-26-community-roundup-7.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #7"
-author: Vjeux
+author: vjeux
 ---
 
 It's been three months since we open sourced React and it is going well. Some stats so far:

--- a/docs/_posts/2013-09-24-community-roundup-8.md
+++ b/docs/_posts/2013-09-24-community-roundup-8.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #8"
-author: Vjeux
+author: vjeux
 ---
 
 A lot has happened in the month since our last update. Here are some of the more interesting things we've found. But first, we have a couple updates before we share links.

--- a/docs/_posts/2013-10-16-react-v0.5.0.md
+++ b/docs/_posts/2013-10-16-react-v0.5.0.md
@@ -1,6 +1,6 @@
 ---
 title: "React v0.5"
-author: Paul O'Shannessy
+author: zpao
 ---
 
 This release is the result of several months of hard work from members of the team and the community. While there are no groundbreaking changes in core, we've worked hard to improve performance and memory usage. We've also worked hard to make sure we are being consistent in our usage of DOM properties.

--- a/docs/_posts/2013-10-29-react-v0-5-1.md
+++ b/docs/_posts/2013-10-29-react-v0-5-1.md
@@ -1,6 +1,6 @@
 ---
 title: "React v0.5.1"
-author: Paul O'Shannessy
+author: zpao
 ---
 
 This release focuses on fixing some small bugs that have been uncovered over the past two weeks. I would like to thank everybody involved, specifically members of the community who fixed half of the issues found. Thanks to [Ben Alpert][1], [Andrey Popp][2], and [Laurence Rowe][3] for their contributions!

--- a/docs/_posts/2013-10-3-community-roundup-9.md
+++ b/docs/_posts/2013-10-3-community-roundup-9.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #9"
-author: Vjeux
+author: vjeux
 ---
 
 We organized a React hackathon last week-end in the Facebook Seattle office. 50 people, grouped into 15 teams, came to hack for a day on React. It was a lot of fun and we'll probably organize more in the future.

--- a/docs/_posts/2013-11-05-thinking-in-react.md
+++ b/docs/_posts/2013-11-05-thinking-in-react.md
@@ -1,6 +1,6 @@
 ---
 title: "Thinking in React"
-author: Pete Hunt
+author: petehunt
 ---
 
 React is, in my opinion, the premier way to build big, fast Web apps with JavaScript. It has scaled very well for us at Facebook and Instagram.

--- a/docs/_posts/2013-11-06-community-roundup-10.md
+++ b/docs/_posts/2013-11-06-community-roundup-10.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #10"
-author: Vjeux
+author: vjeux
 ---
 
 This is the 10th round-up already and React has come quite far since it was open sourced. Almost all new web projects at Khan Academy, Facebook, and Instagram are being developed using React. React has been deployed in a variety of contexts: a Chrome extension, a Windows 8 application, mobile websites, and desktop websites supporting Internet Explorer 8! Language-wise, React is not only being used within JavaScript but also CoffeeScript and ClojureScript.

--- a/docs/_posts/2013-11-18-community-roundup-11.md
+++ b/docs/_posts/2013-11-18-community-roundup-11.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #11"
-author: Vjeux
+author: vjeux
 ---
 
 This round-up is the proof that React has taken off from its Facebook's root: it features three in-depth presentations of React done by external people. This is awesome, keep them coming!

--- a/docs/_posts/2013-12-18-react-v0.5.2-v0.4.2.md
+++ b/docs/_posts/2013-12-18-react-v0.5.2-v0.4.2.md
@@ -1,6 +1,6 @@
 ---
 title: "React v0.5.2, v0.4.2"
-author: Paul O'Shannessy
+author: zpao
 ---
 
 Today we're releasing an update to address a potential XSS vulnerability that can	 arise when using user data as a `key`. Typically "safe" data is used for a `key`, for example, an id from your database, or a unique hash. However there are cases where it may be reasonable to use user generated content. A carefully crafted piece of content could result in arbitrary JS execution. While we make a very concerted effort to ensure all text is escaped before inserting it into the DOM, we missed one case. Immediately following the discovery of this vulnerability, we performed an audit to ensure we this was the only such vulnerability.

--- a/docs/_posts/2013-12-19-react-v0.8.0.md
+++ b/docs/_posts/2013-12-19-react-v0.8.0.md
@@ -1,6 +1,6 @@
 ---
 title: "React v0.8"
-author: Paul O'Shannessy
+author: zpao
 ---
 
 I'll start by answering the obvious question:

--- a/docs/_posts/2013-12-23-community-roundup-12.md
+++ b/docs/_posts/2013-12-23-community-roundup-12.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #12"
-author: Vjeux
+author: vjeux
 ---
 
 React got featured on the front-page of Hacker News thanks to the Om library. If you try it out for the first time, take a look at the [docs](/react/docs/getting-started.html) and do not hesitate to ask questions on the [Google Group](https://groups.google.com/group/reactjs), [IRC](irc://chat.freenode.net/reactjs) or [Stack Overflow](http://stackoverflow.com/questions/tagged/reactjs). We are trying our best to help you out!

--- a/docs/_posts/2013-12-30-community-roundup-13.md
+++ b/docs/_posts/2013-12-30-community-roundup-13.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #13"
-author: Vjeux
+author: vjeux
 ---
 
 Happy holidays! This blog post is a little-late Christmas present for all the React users. Hopefully it will inspire you to write awesome web apps in 2014!

--- a/docs/_posts/2014-01-02-react-chrome-developer-tools.md
+++ b/docs/_posts/2014-01-02-react-chrome-developer-tools.md
@@ -1,6 +1,6 @@
 ---
 title: "React Chrome Developer Tools"
-author: Sebastian Markbåge
+author: sebmarkbage
 ---
 
 With the new year, we thought you'd enjoy some new tools for debugging React code. Today we're releasing the [React Developer Tools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi), an extension to the Chrome Developer Tools. [Download them from the Chrome Web Store](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi).

--- a/docs/_posts/2014-01-06-community-roundup-14.md
+++ b/docs/_posts/2014-01-06-community-roundup-14.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #14"
-author: Vjeux
+author: vjeux
 ---
 
 The theme of this first round-up of 2014 is integration. I've tried to assemble a list of articles and projects that use React in various environments.

--- a/docs/_posts/2014-02-05-community-roundup-15.md
+++ b/docs/_posts/2014-02-05-community-roundup-15.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #15"
-author: Jonas Gebhardt
+author: jgebhardt
 ---
 
 Interest in React seems to have surged ever since David Nolen ([@swannodette](https://twitter.com/swannodette))'s introduction of [Om](https://github.com/swannodette/om) in his post ["The Future of Javascript MVC Frameworks"](https://swannodette.github.io/2013/12/17/the-future-of-javascript-mvcs/).

--- a/docs/_posts/2014-02-15-community-roundup-16.md
+++ b/docs/_posts/2014-02-15-community-roundup-16.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #16"
-author: Jonas Gebhardt
+author: jgebhardt
 ---
 
 There have been many posts recently covering the <i>why</i> and <i>how</i> of React. This week's community round-up includes a collection of recent articles to help you get started with React, along with a few posts that explain some of the inner workings.

--- a/docs/_posts/2014-02-16-react-v0.9-rc1.md
+++ b/docs/_posts/2014-02-16-react-v0.9-rc1.md
@@ -1,6 +1,6 @@
 ---
 title: React v0.9 RC
-author: Ben Alpert
+author: spicyj
 ---
 
 We're almost ready to release React v0.9! We're posting a release candidate so that you can test your apps on it; we'd much prefer to find show-stopping bugs now rather than after we release.

--- a/docs/_posts/2014-02-20-react-v0.9.md
+++ b/docs/_posts/2014-02-20-react-v0.9.md
@@ -1,6 +1,6 @@
 ---
 title: React v0.9
-author: Ben Alpert
+author: spicyj
 ---
 
 I'm excited to announce that today we're releasing React v0.9, which incorporates many bug fixes and several new features since the last release. This release contains almost four months of work, including over 800 commits from over 70 committers!

--- a/docs/_posts/2014-02-24-community-roundup-17.md
+++ b/docs/_posts/2014-02-24-community-roundup-17.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #17"
-author: Jonas Gebhardt
+author: jgebhardt
 ---
 
 

--- a/docs/_posts/2014-03-14-community-roundup-18.md
+++ b/docs/_posts/2014-03-14-community-roundup-18.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #18"
-author: Jonas Gebhardt
+author: jgebhardt
 ---
 
 In this Round-up, we are taking a few closer looks at React's interplay with different frameworks and architectures.

--- a/docs/_posts/2014-03-19-react-v0.10-rc1.md
+++ b/docs/_posts/2014-03-19-react-v0.10-rc1.md
@@ -1,6 +1,6 @@
 ---
 title: React v0.10 RC
-author: Paul O’Shannessy
+author: zpao
 ---
 
 [v0.9 has only been out for a month](/react/blog/2014/02/20/react-v0.9.html), but we’re getting ready to push out v0.10 already. Unlike v0.9 which took a long time, we don't have a long list of changes to talk about.

--- a/docs/_posts/2014-03-21-react-v0.10.md
+++ b/docs/_posts/2014-03-21-react-v0.10.md
@@ -1,6 +1,6 @@
 ---
 title: React v0.10
-author: Paul O’Shannessy
+author: zpao
 ---
 
 Hot on the heels of the [release candidate earlier this week](/react/blog/2014/03/19/react-v0.10-rc1.html), we're ready to call v0.10 done. The only major issue we discovered had to do with the `react-tools` package, which has been updated. We've copied over the changelog from the RC with some small clarifying changes.

--- a/docs/_posts/2014-03-28-the-road-to-1.0.md
+++ b/docs/_posts/2014-03-28-the-road-to-1.0.md
@@ -1,6 +1,6 @@
 ---
 title: The Road to 1.0
-author: Paul O'Shannessy
+author: zpao
 ---
 
 When we launched React last spring, we purposefully decided not to call it 1.0. It was production ready, but we had plans to evolve APIs and behavior as we saw how people were using React, both internally and externally. We've learned a lot over the past 9 months and we've thought a lot about what 1.0 will mean for React. A couple weeks ago, I outlined [several projects][projects] that we have planned to take us to 1.0 and beyond. Today I'm writing a bit more about them to give our users a better insight into our plans.

--- a/docs/_posts/2014-04-04-reactnet.md
+++ b/docs/_posts/2014-04-04-reactnet.md
@@ -1,6 +1,6 @@
 ---
 title: "Use React and JSX in ASP.NET MVC"
-author: Daniel Lo Nigro
+author: Daniel15
 ---
 
 Today we're happy to announce the initial release of

--- a/docs/_posts/2014-05-06-flux.md
+++ b/docs/_posts/2014-05-06-flux.md
@@ -1,6 +1,6 @@
 ---
 title: "Flux: An Application Architecture for React"
-author: Bill Fisher and Jing Chen
+author: fisherwebdevandjing
 ---
 
 We recently spoke at one of f8's breakout session about Flux, a data flow architecture that works well with React.  Check out the video here:

--- a/docs/_posts/2014-05-29-one-year-of-open-source-react.md
+++ b/docs/_posts/2014-05-29-one-year-of-open-source-react.md
@@ -1,6 +1,6 @@
 ---
 title: "One Year of Open-Source React"
-author: Cheng Lou
+author: chenglou
 ---
 
 Today marks the one-year open-source anniversary of React.

--- a/docs/_posts/2014-06-27-community-roundup-19.md
+++ b/docs/_posts/2014-06-27-community-roundup-19.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #19"
-author: Cheng Lou
+author: chenglou
 ---
 
 ## React Meetups!

--- a/docs/_posts/2014-07-13-react-v0.11-rc1.md
+++ b/docs/_posts/2014-07-13-react-v0.11-rc1.md
@@ -1,6 +1,6 @@
 ---
 title: React v0.11 RC
-author: Paul O’Shannessy
+author: zpao
 ---
 
 It's that time again… we're just about ready to ship a new React release! v0.11 includes a wide array of bug fixes and features. We highlighted some of the most important changes below, along with the full changelog.

--- a/docs/_posts/2014-07-17-react-v0.11.md
+++ b/docs/_posts/2014-07-17-react-v0.11.md
@@ -1,6 +1,6 @@
 ---
 title: React v0.11
-author: Paul O’Shannessy
+author: zpao
 ---
 
 **Update:** We missed a few important changes in our initial post and changelog. We've updated this post with details about [Descriptors](#descriptors) and [Prop Type Validation](#prop-type-validation).

--- a/docs/_posts/2014-07-25-react-v0.11.1.md
+++ b/docs/_posts/2014-07-25-react-v0.11.1.md
@@ -1,6 +1,6 @@
 ---
 title: React v0.11.1
-author: Paul O’Shannessy
+author: zpao
 ---
 
 Today we're releasing React v0.11.1 to address a few small issues. Thanks to everybody who has reported them as they've begun upgrading.

--- a/docs/_posts/2014-07-28-community-roundup-20.md
+++ b/docs/_posts/2014-07-28-community-roundup-20.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #20"
-author: Lou Husson
+author: LoukaN
 ---
 
 It's an exciting time for React as there are now more commits from open source contributors than from Facebook engineers! Keep up the good work :)
@@ -112,4 +112,3 @@ var Foo = React.createClass({
 ## Random Tweet
 
 <blockquote class="twitter-tweet" data-conversation="none" lang="en"><p>“<a href="https://twitter.com/apphacker">@apphacker</a>: I take back the mean things I said about <a href="https://twitter.com/reactjs">@reactjs</a> I actually like it.” Summarizing the life of ReactJS in a single tweet.</p>&mdash; Jordan (@jordwalke) <a href="https://twitter.com/jordwalke/statuses/490747339607265280">July 20, 2014</a></blockquote>
-

--- a/docs/_posts/2014-07-30-flux-actions-and-the-dispatcher.md
+++ b/docs/_posts/2014-07-30-flux-actions-and-the-dispatcher.md
@@ -1,6 +1,6 @@
 ---
 title: "Flux: Actions and the Dispatcher"
-author: Bill Fisher
+author: fisherwebdev
 ---
 
 Flux is the application architecture Facebook uses to build JavaScript applications. It's based on a unidirectional data flow.  We've built everything from small widgets to huge applications with Flux, and it's handled everything we've thrown at it. Because we've found it to be a great way to structure our code, we're excited to share it with the open source community. [Jing Chen presented Flux](http://youtu.be/nYkdrAPrdcw?t=10m20s) at the F8 conference, and since that time we've seen a lot of interest in it. We've also published an [overview of Flux](https://facebook.github.io/flux/docs/overview.html) and a [TodoMVC example](https://github.com/facebook/flux/tree/master/examples/flux-todomvc/), with an accompanying [tutorial](https://facebook.github.io/flux/docs/todo-list.html).

--- a/docs/_posts/2014-08-03-community-roundup-21.md
+++ b/docs/_posts/2014-08-03-community-roundup-21.md
@@ -1,6 +1,6 @@
 ---
 title: "Community Round-up #21"
-author: Lou Husson
+author: LoukaN
 ---
 
 ## React Router

--- a/docs/_posts/2014-09-03-introducing-the-jsx-specification.md
+++ b/docs/_posts/2014-09-03-introducing-the-jsx-specification.md
@@ -1,6 +1,6 @@
 ---
 title: "Introducing the JSX Specification"
-author: Sebastian Markbåge
+author: sebmarkbage
 ---
 
 At Facebook we've been using JSX for a long time. We originally introduced it to the world last year alongside React, but we actually used it in another form before that to create native DOM nodes. We've also seen some similar efforts grow out of our work in order to be used with other libraries and in interesting ways. At this point React JSX is just one of many implementations.

--- a/docs/_posts/2014-09-12-community-round-up-22.md
+++ b/docs/_posts/2014-09-12-community-round-up-22.md
@@ -1,7 +1,7 @@
 ---
 title: "Community Round-up #22"
 layout: post
-author: Lou Husson
+author: LoukaN
 ---
 
 This has been an exciting summer as four big companies: Yahoo, Mozilla, Airbnb and Reddit announced that they were using React!

--- a/docs/_posts/2014-09-16-react-v0.11.2.md
+++ b/docs/_posts/2014-09-16-react-v0.11.2.md
@@ -1,6 +1,6 @@
 ---
 title: React v0.11.2
-author: Paul O’Shannessy
+author: zpao
 ---
 
 Today we're releasing React v0.11.2 to add a few small features.

--- a/docs/_posts/2014-09-24-testing-flux-applications.md
+++ b/docs/_posts/2014-09-24-testing-flux-applications.md
@@ -1,6 +1,6 @@
 ---
 title: "Testing Flux Applications"
-author: Bill Fisher
+author: fisherwebdev
 ---
 
 **A more up-to-date version of this post is available as part of the [Flux documentation](https://facebook.github.io/flux/docs/testing-flux-applications.html).**

--- a/docs/_posts/2014-10-14-introducing-react-elements.md
+++ b/docs/_posts/2014-10-14-introducing-react-elements.md
@@ -1,6 +1,6 @@
 ---
 title: "Introducing React Elements"
-author: Sebastian Markbåge
+author: sebmarkbage
 redirect_from: "blog/2014/10/14/introducting-react-elements.html"
 ---
 

--- a/docs/_posts/2014-10-16-react-v0.12-rc1.md
+++ b/docs/_posts/2014-10-16-react-v0.12-rc1.md
@@ -1,6 +1,6 @@
 ---
 title: "React v0.12 RC"
-author: Sebastian Markbåge
+author: sebmarkbage
 ---
 
 We are finally ready to share the work we've been doing over the past couple months. A lot has gone into this and we want to make sure we iron out any potential issues before we make this final. So, we're shipping a Release Candidate for React v0.12 today. If you get a chance, please give it a try and report any issues you find! A full changelog will accompany the final release but we've highlighted the interesting and breaking changes below.

--- a/docs/_posts/2014-10-17-community-roundup-23.md
+++ b/docs/_posts/2014-10-17-community-roundup-23.md
@@ -1,7 +1,7 @@
 ---
 title: "Community Round-up #23"
 layout: post
-author: Lou Husson
+author: LoukaN
 ---
 
 This round-up is a special edition on [Flux](https://facebook.github.io/flux/). If you expect to see diagrams showing arrows that all point in the same direction, you won't be disappointed!

--- a/docs/_posts/2014-10-27-react-js-conf.md
+++ b/docs/_posts/2014-10-27-react-js-conf.md
@@ -1,6 +1,6 @@
 ---
 title: React.js Conf
-author: Vjeux
+author: vjeux
 ---
 
 Every few weeks someone asks us when we are going to organize a conference for React. Our answer has always been "some day". In the mean time, people have been talking about React at other JavaScript conferences around the world. But now the time has finally come for us to have a conference of our own.

--- a/docs/_posts/2014-10-28-react-v0.12.md
+++ b/docs/_posts/2014-10-28-react-v0.12.md
@@ -1,6 +1,6 @@
 ---
 title: React v0.12
-author: Paul O’Shannessy
+author: zpao
 ---
 
 We're happy to announce the availability of React v0.12! After over a week of baking as the release candidate, we uncovered and fixed a few small issues. Thanks to all of you who upgraded and gave us feedback!

--- a/docs/_posts/2014-11-24-react-js-conf-updates.md
+++ b/docs/_posts/2014-11-24-react-js-conf-updates.md
@@ -1,6 +1,6 @@
 ---
 title: React.js Conf Updates
-author: Vjeux
+author: vjeux
 ---
 
 Yesterday was the [React.js Conf](http://conf.reactjs.com/index.html) call for presenters submission deadline. We were

--- a/docs/_posts/2014-11-25-community-roundup-24.md
+++ b/docs/_posts/2014-11-25-community-roundup-24.md
@@ -1,7 +1,7 @@
 ---
 title: "Community Round-up #24"
 layout: post
-author: Steven Luscher
+author: steveluscher
 ---
 
 ## Keep it Simple

--- a/docs/_posts/2014-12-18-react-v0.12.2.md
+++ b/docs/_posts/2014-12-18-react-v0.12.2.md
@@ -1,6 +1,6 @@
 ---
 title: React v0.12.2
-author: Paul O’Shannessy
+author: zpao
 ---
 
 We just shipped React v0.12.2, bringing the 0.12 branch up to date with a few small fixes that landed in master over the past 2 months.

--- a/docs/_posts/2014-12-19-react-js-conf-diversity-scholarship.md
+++ b/docs/_posts/2014-12-19-react-js-conf-diversity-scholarship.md
@@ -1,6 +1,6 @@
 ---
 title: React.js Conf Diversity Scholarship
-author: Paul O’Shannessy
+author: zpao
 ---
 
 Today I'm really happy to announce the React.js Conf Diversity Scholarship! We believe that a diverse set of viewpoints and opinions is really important to build a thriving community. In an ideal world, every part of the tech community would be made up of people from all walks of life. However the reality is that we must be proactive and make an effort to make sure everybody has a voice. As conference organizers we worked closely with the Diversity Team here at Facebook to set aside 10 tickets and provide a scholarship. 10 tickets may not be many in the grand scheme but we really believe that this will have a positive impact on the discussions we have at the conference.

--- a/docs/_posts/2015-01-27-react-v0.13.0-beta-1.md
+++ b/docs/_posts/2015-01-27-react-v0.13.0-beta-1.md
@@ -1,6 +1,6 @@
 ---
 title: React v0.13.0 Beta 1
-author: Sebastian Markbåge
+author: sebmarkbage
 ---
 
 React 0.13 has a lot of nice features but there is one particular feature that I'm really excited about. I couldn't wait for React.js Conf to start tomorrow morning.

--- a/docs/_posts/2015-02-18-react-conf-roundup-2015.md
+++ b/docs/_posts/2015-02-18-react-conf-roundup-2015.md
@@ -1,7 +1,7 @@
 ---
 title: React.js Conf Round-up 2015
 layout: post
-author: Steven Luscher
+author: steveluscher
 ---
 
 It was a privilege to welcome the React community to Facebook HQ on January 28–29 for the first-ever React.js Conf, and a pleasure to be be able to unveil three new technologies that we've been using internally at Facebook for some time: GraphQL, Relay, and React Native.

--- a/docs/_posts/2015-02-20-introducing-relay-and-graphql.md
+++ b/docs/_posts/2015-02-20-introducing-relay-and-graphql.md
@@ -1,7 +1,7 @@
 ---
 title: "Introducing Relay and GraphQL"
 layout: post
-author: Greg Hurrell
+author: wincent
 ---
 
 ## Data fetching for React applications

--- a/docs/_posts/2015-02-24-react-v0.13-rc1.md
+++ b/docs/_posts/2015-02-24-react-v0.13-rc1.md
@@ -1,6 +1,6 @@
 ---
 title: "React v0.13 RC"
-author: Paul O'Shannessy
+author: zpao
 date: 2015-02-24 14:00
 ---
 

--- a/docs/_posts/2015-02-24-streamlining-react-elements.md
+++ b/docs/_posts/2015-02-24-streamlining-react-elements.md
@@ -1,6 +1,6 @@
 ---
 title: "Streamlining React Elements"
-author: Sebastian Markbåge
+author: sebmarkbage
 date: 2015-02-24 11:00
 ---
 

--- a/docs/_posts/2015-03-03-react-v0.13-rc2.md
+++ b/docs/_posts/2015-03-03-react-v0.13-rc2.md
@@ -1,6 +1,6 @@
 ---
 title: "React v0.13 RC2"
-author: Sebastian Markbåge
+author: sebmarkbage
 ---
 
 Thanks to everybody who has already been testing the release candidate. We've received some good feedback and as a result we're going to do a second release candidate. The changes are minimal. We haven't changed the behavior of any APIs we exposed in the previous release candidate. Here's a summary of the changes:

--- a/docs/_posts/2015-03-04-community-roundup-25.md
+++ b/docs/_posts/2015-03-04-community-roundup-25.md
@@ -1,7 +1,7 @@
 ---
 title: "Community Round-up #25"
 layout: post
-author: Matthew Johnston
+author: matthewjohnston4
 ---
 
 ## React 101

--- a/docs/_posts/2015-03-10-react-v0.13.md
+++ b/docs/_posts/2015-03-10-react-v0.13.md
@@ -1,6 +1,6 @@
 ---
 title: "React v0.13"
-author: Ben Alpert
+author: spicyj
 ---
 
 Today, we're happy to release React v0.13!

--- a/docs/_posts/2015-03-16-react-v0.13.1.md
+++ b/docs/_posts/2015-03-16-react-v0.13.1.md
@@ -1,6 +1,6 @@
 ---
 title: "React v0.13.1"
-author: Paul O’Shannessy
+author: zpao
 ---
 
 It's been less than a week since we shipped v0.13.0 but it's time to do another quick release. We just released v0.13.1 which contains bugfixes for a number of small issues.

--- a/docs/_posts/2015-03-19-building-the-facebook-news-feed-with-relay.md
+++ b/docs/_posts/2015-03-19-building-the-facebook-news-feed-with-relay.md
@@ -1,6 +1,6 @@
 ---
 title: "Building The Facebook News Feed With Relay"
-author: Joseph Savona
+author: josephsavona
 ---
 
 At React.js Conf in January we gave a preview of Relay, a new framework for building data-driven applications in React. In this post, we'll describe the process of creating a Relay application. This post assumes some familiarity with the concepts of Relay and GraphQL, so if you haven't already we recommend reading [our introductory blog post](/react/blog/2015/02/20/introducing-relay-and-graphql.html) or watching [the conference talk](https://www.youtube-nocookie.com/watch?v=9sc8Pyc51uU).

--- a/docs/_posts/2015-03-26-introducing-react-native.md
+++ b/docs/_posts/2015-03-26-introducing-react-native.md
@@ -1,6 +1,6 @@
 ---
 title: "Introducing React Native"
-author: Ben Alpert
+author: spicyj
 ---
 
 In January at React.js Conf, we announced React Native, a new framework for building native apps using React. We're happy to announce that we're open-sourcing React Native and you can start building your apps with it today.

--- a/docs/_posts/2015-03-30-community-roundup-26.md
+++ b/docs/_posts/2015-03-30-community-roundup-26.md
@@ -1,7 +1,7 @@
 ---
 title: "Community Round-up #26"
 layout: post
-author: Vjeux
+author: vjeux
 ---
 
 We open sourced React Native last week and the community reception blew away all our expectations! So many of you tried it, made cool stuff with it, raised many issues and even submitted pull requests to fix them! The entire team wants to say thank you!

--- a/docs/_posts/2015-04-17-react-native-v0.4.md
+++ b/docs/_posts/2015-04-17-react-native-v0.4.md
@@ -1,7 +1,7 @@
 ---
 title: "React Native v0.4"
 layout: post
-author: Vjeux
+author: vjeux
 ---
 
 It's been three weeks since we open sourced React Native and there's been some insane amount of activity already: over 12.5k stars, 1000 commits, 500 issues, 380 pull requests, and 100 contributors, plus [35 plugins](http://react.parts/native-ios) and [1 app in the app store](http://herman.asia/building-a-flashcard-app-with-react-native)! We were expecting some buzz around the project but this is way beyond anything we imagined. Thank you!

--- a/docs/_posts/2015-04-18-react-v0.13.2.md
+++ b/docs/_posts/2015-04-18-react-v0.13.2.md
@@ -1,6 +1,6 @@
 ---
 title: "React v0.13.2"
-author: Paul O’Shannessy
+author: zpao
 ---
 
 Yesterday the [React Native team shipped v0.4](/react/blog/2015/04/17/react-native-v0.4.html). Those of us working on the web team just a few feet away couldn't just be shown up like that so we're shipping v0.13.2 today as well! This is a bug fix release to address a few things while we continue to work towards v0.14.

--- a/docs/_posts/2015-05-01-graphql-introduction.md
+++ b/docs/_posts/2015-05-01-graphql-introduction.md
@@ -1,6 +1,6 @@
 ---
 title: "GraphQL Introduction"
-author: Nick Schrock
+author: schrockn
 ---
 
 At the React.js conference in late January 2015, we revealed our next major technology in the React family: [Relay](http://facebook.github.io/react/blog/2015/02/20/introducing-relay-and-graphql.html). 

--- a/docs/_posts/2015-05-08-react-v0.13.3.md
+++ b/docs/_posts/2015-05-08-react-v0.13.3.md
@@ -1,6 +1,6 @@
 ---
 title: "React v0.13.3"
-author: Paul O’Shannessy
+author: zpao
 ---
 
 Today we're sharing another patch release in the v0.13 branch. There are only a few small changes, with a couple to address some issues that arose around that undocumented feature so many of you are already using: `context`. We also improved developer ergonomics just a little bit, making some warnings better.

--- a/docs/blog/all.html
+++ b/docs/blog/all.html
@@ -9,7 +9,8 @@ id: all-posts
   <div class="inner-content">
     <h1>All Posts</h1>
     {% for page in site.posts %}
-      <p><strong><a href="/react{{ page.url }}">{{ page.title }}</a></strong> on {{ page.date | date: "%B %e, %Y" }} by {{ page.author }}</p>
+      {% assign author = site.data.authors[page.author] %}
+      <p><strong><a href="/react{{ page.url }}">{{ page.title }}</a></strong> on {{ page.date | date: "%B %e, %Y" }} by {{ author.name }}</p>
     {% endfor %}
   </div>
 </section>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -9,12 +9,7 @@ sectionid: blog
   <div class="inner-content">
     {% for page in paginator.posts %}
       <div class="post-list-item">
-        <h1><a href="/react{{ page.url }}">{{ page.title }}</a></h1>
-        <p class="meta">{{ page.date | date: "%B %e, %Y" }} by {{ page.author }}</p>
-        <hr />
-        <div class="post">
-         {{ page.content }}
-        </div>
+        {% include blog_post.html page=page content=page.content%}
       </div>
     {% endfor %}
 


### PR DESCRIPTION
Fix of the week candidate right here.

Display names should all be ok (since they are identical), but links might not be. I defaulted to Twitter because that's what we do. I could also link back to github instead and do that across the board. I don't really care where the link goes (FB profile, personal blog) so let me know if you'd like something else. I decided to just use github username for the key in the authors hash.

I'll give this a couple days in case people want to change anything, let me know if you do. I'll check you off as I go.

- [x] @Daniel15 
- [ ] @LoukaN
- [ ] @chenglou 
- [ ] @fisherwebdev 
- [ ] @jgebhardt 
- [ ] @josephsavona 
- [ ] @kmeht 
- [ ] @matthewjohnston4 
- [x] @petehunt 
- [ ] @schrockn 
- [ ] @sebmarkbage 
- [x] @spicyj 
- [ ] @vjeux 
- [x] @wincent 
- [x] @zpao
