### PR TITLE
Better SVG markup wrap

### DIFF
--- a/src/renderers/dom/client/utils/DOMChildrenOperations.js
+++ b/src/renderers/dom/client/utils/DOMChildrenOperations.js
@@ -97,17 +97,23 @@ var DOMChildrenOperations = {
       }
     }
 
-    var renderedMarkup = Danger.dangerouslyRenderMarkup(markupList);
+    var rootList = [];
+    if (updates) {
+      for (var j = 0; j < updates.length; j++) {
+        rootList.push(updates[j].parentNode);
+      }
+    }
+    var renderedMarkup = Danger.dangerouslyRenderMarkup(markupList, rootList);
 
     // Remove updated children first so that `toIndex` is consistent.
     if (updatedChildren) {
-      for (var j = 0; j < updatedChildren.length; j++) {
-        updatedChildren[j].parentNode.removeChild(updatedChildren[j]);
+      for (var k = 0; k < updatedChildren.length; k++) {
+        updatedChildren[k].parentNode.removeChild(updatedChildren[k]);
       }
     }
 
-    for (var k = 0; k < updates.length; k++) {
-      update = updates[k];
+    for (var l = 0; l < updates.length; l++) {
+      update = updates[l];
       switch (update.type) {
         case ReactMultiChildUpdateTypes.INSERT_MARKUP:
           insertChildAt(

--- a/src/shared/vendor/core/createNodesFromMarkup.js
+++ b/src/shared/vendor/core/createNodesFromMarkup.js
@@ -47,15 +47,16 @@ function getNodeName(markup) {
  * an exception is thrown if any <script> elements are rendered.
  *
  * @param {string} markup A string of valid HTML markup.
+ * @param {?string} root Future root node of the current node.
  * @param {?function} handleScript Invoked once for each rendered <script>.
  * @return {array<DOMElement|DOMTextNode>} An array of rendered nodes.
  */
-function createNodesFromMarkup(markup, handleScript) {
+function createNodesFromMarkup(markup, root, handleScript) {
   var node = dummyNode;
   invariant(!!dummyNode, 'createNodesFromMarkup dummy not initialized');
   var nodeName = getNodeName(markup);
 
-  var wrap = nodeName && getMarkupWrap(nodeName);
+  var wrap = nodeName && getMarkupWrap(nodeName, root);
   if (wrap) {
     node.innerHTML = wrap[1] + markup + wrap[2];
 

--- a/src/shared/vendor/core/getMarkupWrap.js
+++ b/src/shared/vendor/core/getMarkupWrap.js
@@ -25,24 +25,7 @@ var dummyNode =
  *
  * In IE8, certain elements cannot render alone, so wrap all elements ('*').
  */
-var shouldWrap = {
-  // Force wrapping for SVG elements because if they get created inside a <div>,
-  // they will be initialized in the wrong namespace (and will not display).
-  'circle': true,
-  'clipPath': true,
-  'defs': true,
-  'ellipse': true,
-  'g': true,
-  'line': true,
-  'linearGradient': true,
-  'path': true,
-  'polygon': true,
-  'polyline': true,
-  'radialGradient': true,
-  'rect': true,
-  'stop': true,
-  'text': true
-};
+var shouldWrap = {};
 
 var selectWrap = [1, '<select multiple="true">', '</select>'];
 var tableWrap = [1, '<table>', '</table>'];
@@ -69,22 +52,7 @@ var markupWrap = {
   'thead': tableWrap,
 
   'td': trWrap,
-  'th': trWrap,
-
-  'circle': svgWrap,
-  'clipPath': svgWrap,
-  'defs': svgWrap,
-  'ellipse': svgWrap,
-  'g': svgWrap,
-  'line': svgWrap,
-  'linearGradient': svgWrap,
-  'path': svgWrap,
-  'polygon': svgWrap,
-  'polyline': svgWrap,
-  'radialGradient': svgWrap,
-  'rect': svgWrap,
-  'stop': svgWrap,
-  'text': svgWrap
+  'th': trWrap
 };
 
 /**
@@ -93,9 +61,10 @@ var markupWrap = {
  * NOTE: This lazily detects which wraps are necessary for the current browser.
  *
  * @param {string} nodeName Lowercase `nodeName`.
+ * @param {?string} root Future root node of the current node.
  * @return {?array} Markup wrap configuration, if applicable.
  */
-function getMarkupWrap(nodeName) {
+function getMarkupWrap(nodeName, root) {
   invariant(!!dummyNode, 'Markup wrapping node not initialized');
   if (!markupWrap.hasOwnProperty(nodeName)) {
     nodeName = '*';
@@ -107,6 +76,9 @@ function getMarkupWrap(nodeName) {
       dummyNode.innerHTML = '<' + nodeName + '></' + nodeName + '>';
     }
     shouldWrap[nodeName] = !dummyNode.firstChild;
+  }
+  if (root instanceof SVGElement) {
+    return svgWrap;
   }
   return shouldWrap[nodeName] ? markupWrap[nodeName] : null;
 }


### PR DESCRIPTION
This PR adds support for passing the future root node which will contain the markup to `getMarkupWrap`. 

It also improves SVG nodes wrapping: now every nodes which will be contained inside a SVGElement will be wrapped with SVG.
This also removes the need to maintain the `shouldWrap` object - which miss several important tags.

A test case is available [here](https://gist.github.com/framp/ddce0620819ce1c43b9e):
React renders: `<defs><pattern><img ...></pattern></defs>`
With the new PR it renders: `<defs><pattern><image ...></pattern></defs>`

Together with https://github.com/facebook/react/pull/3718 it will also render the image in browser (due to the namespace attribute bug).