### PR TITLE
Replace vendor/constants recast transform with babel

### DIFF
--- a/bin/jsx-internal
+++ b/bin/jsx-internal
@@ -5,7 +5,7 @@
 
 var babel = require('babel-core');
 
-var propagate = require("../vendor/constants").propagate;
+var constants = require('../vendor/constants')(babel);
 
 require("commoner").version(
   require("../package.json").version
@@ -29,17 +29,13 @@ require("commoner").version(
 
 }).process(function(id, source) {
   var context = this;
-  var constants = context.config.constants || {};
 
   // This is where JSX, ES6, etc. desugaring happens.
   source = babel.transform(source, {
     blacklist: ['spec.functionName', 'validation.react'],
+    plugins: [constants],
     filename: id
   }).code;
-
-  // Constant propagation means removing any obviously dead code after
-  // replacing constant expressions with literal (boolean) values.
-  source = propagate(constants, source);
 
   if (context.config.mocking) {
     // Make sure there is exactly one newline at the end of the module.

--- a/grunt/config/jsx.js
+++ b/grunt/config/jsx.js
@@ -12,8 +12,7 @@ var normal = {
   rootIDs: rootIDs,
   getConfig: function() {
     return {
-      commonerConfig: grunt.config.data.pkg.commonerConfig,
-      constants: {}
+      commonerConfig: grunt.config.data.pkg.commonerConfig
     };
   },
   sourceDir: 'src',

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "phantomjs": "~1.9",
     "platform": "^1.1.0",
     "populist": "~0.1.6",
-    "recast": "^0.9.11",
     "sauce-tunnel": "~1.1.0",
     "tmp": "~0.0.18",
     "typescript": "^1.4.0",
@@ -70,7 +69,7 @@
   },
   "preferGlobal": true,
   "commonerConfig": {
-    "version": 5
+    "version": 6
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
Built files look the same up to parenthesization and quoting. This only saves 1.5 seconds out of ~20 on a clean build but it's a little simpler.