### PR TITLE
Warn when using React.unmountComponentAtNode on a different React instance's tree

### DIFF
--- a/src/browser/ui/ReactMount.js
+++ b/src/browser/ui/ReactMount.js
@@ -688,6 +688,13 @@ var ReactMount = {
     var reactRootID = getReactRootID(container);
     var component = instancesByReactRootID[reactRootID];
     if (!component) {
+      if (__DEV__) {
+        warning(
+          !reactRootID,
+          'unmountComponentAtNode(...): Target container was not rendered by ' +
+          'current instance of React.'
+        );
+      }
       return false;
     }
     ReactUpdates.batchedUpdates(

--- a/src/browser/ui/__tests__/ReactMount-test.js
+++ b/src/browser/ui/__tests__/ReactMount-test.js
@@ -47,6 +47,19 @@ describe('ReactMount', function() {
         'is not a DOM element.'
       );
     });
+
+    it('should warn if unmounting a component from another React', function() {
+      var container = document.createElement('div');
+      container.innerHTML = React.renderToString(<div />);
+      spyOn(console, 'error');
+
+      React.unmountComponentAtNode(container);
+
+      expect(console.error.calls.length).toBe(1);
+      expect(console.error.calls[0].args[0]).toContain(
+        'Target container was not rendered by current instance of React'
+      );
+    });
   });
 
   it('throws when given a string', function() {


### PR DESCRIPTION
Fixes #3787