### PR TITLE
ReactDOMComponent should warn on unrecognized elements

### DIFF
--- a/src/browser/ui/ReactDOMComponent.js
+++ b/src/browser/ui/ReactDOMComponent.js
@@ -23,6 +23,9 @@ var ReactComponentBrowserEnvironment =
 var ReactMount = require('ReactMount');
 var ReactMultiChild = require('ReactMultiChild');
 var ReactPerf = require('ReactPerf');
+var ExecutionEnvironment = require('ExecutionEnvironment');
+var createNodesFromMarkup = require('createNodesFromMarkup');
+var emptyFunction = require('emptyFunction');
 
 var assign = require('Object.assign');
 var escapeTextContentForBrowser = require('escapeTextContentForBrowser');
@@ -214,11 +217,22 @@ var voidElementTags = assign({
 var VALID_TAG_REGEX = /^[a-zA-Z][a-zA-Z:_\.\-\d]*$/; // Simplified subset
 var validatedTagCache = {};
 var hasOwnProperty = {}.hasOwnProperty;
+var unknownConstructor = ExecutionEnvironment.canUseDOM &&
+  (typeof window.HTMLGenericElement !== 'undefined' ?
+    window.HTMLGenericElement : window.HTMLUnknownElement);
 
 function validateDangerousTag(tag) {
   if (!hasOwnProperty.call(validatedTagCache, tag)) {
     invariant(VALID_TAG_REGEX.test(tag), 'Invalid tag: %s', tag);
     validatedTagCache[tag] = true;
+  }
+  if (__DEV__ && unknownConstructor) {
+    var dummyElement = createNodesFromMarkup('<' + tag + '>', emptyFunction)[0];
+    warning(
+      !(dummyElement instanceof unknownConstructor),
+      'The tag ' + tag + ' is unrecognized in this browser. If you meant to ' +
+      'render a React component, start its name with an uppercase letter.'
+    );
   }
 }
 

--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -444,8 +444,8 @@ describe('ReactDOMComponent', function() {
 
       React.render(<menu><menuitem>children</menuitem></menu>, container);
 
-      expect(console.error.argsForCall.length).toBe(1);
-      expect(console.error.argsForCall[0][0]).toContain('void element');
+      expect(console.error.mostRecentCall.args.length).toBe(1);
+      expect(console.error.mostRecentCall.args[0]).toContain('void element');
     });
 
     it("should validate against multiple children props", function() {

--- a/src/browser/ui/__tests__/ReactDOMComponent-test.js
+++ b/src/browser/ui/__tests__/ReactDOMComponent-test.js
@@ -724,6 +724,33 @@ describe('ReactDOMComponent', function() {
     });
   });
 
+  describe('tag validation', function() {
+    var oldUnknownElement;
+
+    beforeEach(function() {
+      // Work around lack of HTMLUnknownElement in PhantomJS
+      oldUnknownElement = window.HTMLUnknownElement;
+      window.HTMLUnknownElement = window.HTMLParagraphElement;
+    });
+
+    afterEach(function() {
+      window.HTMLUnknownElement = oldUnknownElement;
+    });
+
+    it('warns on unrecognized tags', () => {
+      var React = require('React');
+      var ReactTestUtils = require('ReactTestUtils');
+
+      spyOn(console, 'error');
+      ReactTestUtils.renderIntoDocument(<p/>);
+      expect(console.error.calls.length).toBe(1);
+      expect(console.error.mostRecentCall.args[0]).toBe(
+        'Warning: The tag p is unrecognized in this browser. If you meant to ' +
+        'render a React component, start its name with an uppercase letter.'
+      );
+    });
+  });
+
   describe('nesting validation', function() {
     var React;
     var ReactTestUtils;


### PR DESCRIPTION
This fixes #3726

Rather than checking for ```HTMLUnknownElement```, it checks to see if there's a ```React.DOM``` factory for that tag. This will throw false negatives for non-standard elements but that seems like it might be preferable to instantiating elements and checking for ```HTMLUnknownElement``` (possible, but PhantomJS 1.9 doesn't support it, so we wouldn't get a test case). If you disagree, I can change it.

We might consider renaming ```validateDangerousTag``` to something like ```validateTag```.