### PR TITLE
Normalize onChange behavior in IE for inputs with placeholders

### DIFF
--- a/src/browser/ui/dom/components/ReactDOMInput.js
+++ b/src/browser/ui/dom/components/ReactDOMInput.js
@@ -19,6 +19,7 @@ var ReactClass = require('ReactClass');
 var ReactElement = require('ReactElement');
 var ReactMount = require('ReactMount');
 var ReactUpdates = require('ReactUpdates');
+var isTextInputElement = require('isTextInputElement');
 
 var assign = require('Object.assign');
 var findDOMNode = require('findDOMNode');
@@ -28,11 +29,19 @@ var input = ReactElement.createFactory('input');
 
 var instancesByReactID = {};
 
+
 function forceUpdateIfMounted() {
   /*jshint validthis:true */
   if (this.isMounted()) {
     this.forceUpdate();
   }
+}
+
+function isIeInputEvent(event) {
+  return ('documentMode' in document)
+      && document.documentMode > 9
+      && event.nativeEvent.type === 'input'
+      && isTextInputElement(event.target);
 }
 
 /**
@@ -57,8 +66,15 @@ var ReactDOMInput = ReactClass.createClass({
 
   mixins: [AutoFocusMixin, LinkedValueUtils.Mixin, ReactBrowserComponentMixin],
 
+  componentWillMount: function() {
+    var defaultValue = this.props.defaultValue;
+
+    this._uncontrolledValue = defaultValue != null ? '' + defaultValue : '';
+  },
+
   getInitialState: function() {
     var defaultValue = this.props.defaultValue;
+
     return {
       initialChecked: this.props.defaultChecked || false,
       initialValue: defaultValue != null ? defaultValue : null
@@ -115,6 +131,24 @@ var ReactDOMInput = ReactClass.createClass({
   _handleChange: function(event) {
     var returnValue;
     var onChange = LinkedValueUtils.getOnChange(this.props);
+
+    // IE 10+ fire input events when setting/unsetting a placeholder
+    // we guard against it by checking if the next and
+    // last values are both empty and bailing out of the change
+    // https://github.com/facebook/react/issues/3484
+    if ( isIeInputEvent(event) ) {
+      var controlledValue = LinkedValueUtils.getValue(this.props);
+      var lastValue = controlledValue != null ?
+        '' + controlledValue :
+        this._uncontrolledValue;
+
+      this._uncontrolledValue = event.target.value;
+
+      if ( event.target.value === '' && lastValue === '') {
+        return returnValue;
+      }
+    }
+
     if (onChange) {
       returnValue = onChange.call(this, event);
     }

--- a/src/browser/ui/dom/components/ReactDOMInput.js
+++ b/src/browser/ui/dom/components/ReactDOMInput.js
@@ -74,9 +74,14 @@ var ReactDOMInput = ReactClass.createClass({
   mixins: [AutoFocusMixin, LinkedValueUtils.Mixin, ReactBrowserComponentMixin],
 
   componentWillMount: function() {
+    var value = LinkedValueUtils.getValue(this.props);
     var defaultValue = this.props.defaultValue;
 
-    this._uncontrolledValue = defaultValue != null ? '' + defaultValue : '';
+    if (defaultValue == null) {
+      defaultValue = '';
+    }
+
+    this._lastValue = value != null ? value : defaultValue;
   },
 
   getInitialState: function() {
@@ -144,15 +149,13 @@ var ReactDOMInput = ReactClass.createClass({
     // last values are both empty and bailing out of the change
     // https://github.com/facebook/react/issues/3484
     if (isIEInputEvent(event)) {
-      var controlledValue = LinkedValueUtils.getValue(this.props);
-      var lastValue = controlledValue != null ?
-        '' + controlledValue :
-        this._uncontrolledValue;
+      var lastValue = this._lastValue;
 
-      this._uncontrolledValue = event.target.value;
+      this._lastValue = event.target.value;
 
       if ( event.target.value === '' && lastValue === '') {
-        return returnValue;
+        event.stopPropagation();
+        return undefined;
       }
     }
 

--- a/src/browser/ui/dom/components/ReactDOMInput.js
+++ b/src/browser/ui/dom/components/ReactDOMInput.js
@@ -19,6 +19,7 @@ var ReactClass = require('ReactClass');
 var ReactElement = require('ReactElement');
 var ReactMount = require('ReactMount');
 var ReactUpdates = require('ReactUpdates');
+var ExecutionEnvironment = require('ExecutionEnvironment');
 var isTextInputElement = require('isTextInputElement');
 
 var assign = require('Object.assign');
@@ -28,7 +29,11 @@ var invariant = require('invariant');
 var input = ReactElement.createFactory('input');
 
 var instancesByReactID = {};
+var hasNoisyInputEvent = false;
 
+if (ExecutionEnvironment.canUseDOM) {
+  hasNoisyInputEvent = 'documentMode' in document && document.documentMode > 9;
+}
 
 function forceUpdateIfMounted() {
   /*jshint validthis:true */
@@ -37,11 +42,13 @@ function forceUpdateIfMounted() {
   }
 }
 
-function isIeInputEvent(event) {
-  return ('documentMode' in document)
-      && document.documentMode > 9
-      && event.nativeEvent.type === 'input'
-      && isTextInputElement(event.target);
+
+function isIEInputEvent(event) {
+  return (
+    hasNoisyInputEvent &&
+    event.nativeEvent.type === 'input' &&
+    isTextInputElement(event.target)
+  );
 }
 
 /**
@@ -136,7 +143,7 @@ var ReactDOMInput = ReactClass.createClass({
     // we guard against it by checking if the next and
     // last values are both empty and bailing out of the change
     // https://github.com/facebook/react/issues/3484
-    if ( isIeInputEvent(event) ) {
+    if (isIEInputEvent(event)) {
       var controlledValue = LinkedValueUtils.getValue(this.props);
       var lastValue = controlledValue != null ?
         '' + controlledValue :

--- a/src/browser/ui/dom/components/ReactDOMTextarea.js
+++ b/src/browser/ui/dom/components/ReactDOMTextarea.js
@@ -69,9 +69,14 @@ var ReactDOMTextarea = ReactClass.createClass({
   mixins: [AutoFocusMixin, LinkedValueUtils.Mixin, ReactBrowserComponentMixin],
 
   componentWillMount: function() {
+    var value = LinkedValueUtils.getValue(this.props);
     var defaultValue = this.props.defaultValue;
 
-    this._uncontrolledValue = defaultValue != null ? '' + defaultValue : '';
+    if (defaultValue == null) {
+      defaultValue = '';
+    }
+
+    this._lastValue = value != null ? value : defaultValue;
   },
 
   getInitialState: function() {
@@ -150,15 +155,13 @@ var ReactDOMTextarea = ReactClass.createClass({
     // last values are both empty and bailing out of the change
     // https://github.com/facebook/react/issues/3484
     if (isIEInputEvent(event)) {
-      var controlledValue = LinkedValueUtils.getValue(this.props);
-      var lastValue = controlledValue != null ?
-        '' + controlledValue :
-        this._uncontrolledValue;
+      var lastValue = this._lastValue;
 
-      this._uncontrolledValue = event.target.value;
+      this._lastValue = event.target.value;
 
       if ( event.target.value === '' && lastValue === '') {
-        return returnValue;
+        event.stopPropagation();
+        return undefined;
       }
     }
 

--- a/src/browser/ui/dom/components/ReactDOMTextarea.js
+++ b/src/browser/ui/dom/components/ReactDOMTextarea.js
@@ -18,6 +18,7 @@ var ReactBrowserComponentMixin = require('ReactBrowserComponentMixin');
 var ReactClass = require('ReactClass');
 var ReactElement = require('ReactElement');
 var ReactUpdates = require('ReactUpdates');
+var ExecutionEnvironment = require('ExecutionEnvironment');
 
 var assign = require('Object.assign');
 var findDOMNode = require('findDOMNode');
@@ -26,6 +27,11 @@ var invariant = require('invariant');
 var warning = require('warning');
 
 var textarea = ReactElement.createFactory('textarea');
+var hasNoisyInputEvent = false;
+
+if (ExecutionEnvironment.canUseDOM) {
+  hasNoisyInputEvent = 'documentMode' in document && document.documentMode > 9;
+}
 
 function forceUpdateIfMounted() {
   /*jshint validthis:true */
@@ -34,10 +40,11 @@ function forceUpdateIfMounted() {
   }
 }
 
-function isIeInputEvent(event) {
-  return ('documentMode' in document)
-      && document.documentMode > 9
-      && event.nativeEvent.type === 'input';
+function isIEInputEvent(event) {
+  return (
+    hasNoisyInputEvent &&
+    event.nativeEvent.type === 'input'
+  );
 }
 
 /**
@@ -142,7 +149,7 @@ var ReactDOMTextarea = ReactClass.createClass({
     // we guard against it by checking if the next and
     // last values are both empty and bailing out of the change
     // https://github.com/facebook/react/issues/3484
-    if ( isIeInputEvent(event) ) {
+    if (isIEInputEvent(event)) {
       var controlledValue = LinkedValueUtils.getValue(this.props);
       var lastValue = controlledValue != null ?
         '' + controlledValue :

--- a/src/browser/ui/dom/components/__tests__/ReactDOMInput-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMInput-test.js
@@ -348,4 +348,20 @@ describe('ReactDOMInput', function() {
       <input type="checkbox" checkedLink={link} valueLink={emptyFunction} />;
     expect(React.render.bind(React, instance, node)).toThrow();
   });
+
+  it('should not fire change handlers when setting placeholders', function() {
+    var change = mocks.getMockFunction();
+    var instance = <input type="text" onChange={change} placeholder={'test'}/>;
+
+    instance = ReactTestUtils.renderIntoDocument(instance);
+
+    React.findDOMNode(instance).focus()
+
+    instance.replaceProps({ type: "text", onChange: change });
+
+    expect(change.mock.calls.length).toBe(0);
+    
+    ReactTestUtils.Simulate.change(React.findDOMNode(instance));
+    expect(change.mock.calls.length).toBe(1);
+  });
 });

--- a/src/browser/ui/dom/components/__tests__/ReactDOMTextarea-test.js
+++ b/src/browser/ui/dom/components/__tests__/ReactDOMTextarea-test.js
@@ -231,4 +231,20 @@ describe('ReactDOMTextarea', function() {
     expect(link.requestChange.mock.calls.length).toBe(1);
     expect(link.requestChange.mock.calls[0][0]).toEqual('test');
   });
+
+  it('should not fire change handlers when setting placeholders', function() {
+    var change = mocks.getMockFunction();
+    var instance = <textarea onChange={change} placeholder={'test'}/>;
+
+    instance = ReactTestUtils.renderIntoDocument(instance);
+
+    React.findDOMNode(instance).focus()
+
+    instance.replaceProps({ onChange: change });
+
+    expect(change.mock.calls.length).toBe(0);
+
+    ReactTestUtils.Simulate.change(React.findDOMNode(instance));
+    expect(change.mock.calls.length).toBe(1);
+  });
 });


### PR DESCRIPTION
Checks for actual changes to the input/textarea value, eliminating the case where an empty
value moves to empty value triggers a input event, which happens when IE 10+ sets/unsets a placeholder. I made the change in the actual components vs the ChangeEventPlugin, because comparing last/next values is struck me as the easiest fix and that's much harder from the event handler.

fixes #3377 and fixes #3484