### PR TITLE
Fix ReactTestUtils.isCompositeComponent

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -111,8 +111,11 @@ var ReactTestUtils = {
       // this returns when we have DOM nodes as refs directly
       return false;
     }
-    return typeof inst.render === 'function' &&
-           typeof inst.setState === 'function';
+    return (
+      !!inst &&
+      typeof inst.render === 'function' &&
+      typeof inst.setState === 'function'
+    );
   },
 
   isCompositeComponentWithType: function(inst, type) {

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -25,6 +25,41 @@ describe('ReactTestUtils', function() {
     ReactTestUtils = require('ReactTestUtils');
   });
 
+  describe('isCompositeComponent', function() {
+    it('should be true when passed a composite component', function() {
+      var CompositeComponent = React.createClass({
+        render: function() {
+          return <div />;
+        },
+      });
+      var component = ReactTestUtils.renderIntoDocument(<CompositeComponent />);
+      expect(ReactTestUtils.isCompositeComponent(component)).toBe(true);
+    });
+
+    it('should be true when passed composite a component defined by ES6 classes', function() {
+      class ES6Component extends React.Component {
+        render() {
+          return <div />;
+        }
+      }
+      var component = ReactTestUtils.renderIntoDocument(<ES6Component />);
+      expect(ReactTestUtils.isCompositeComponent(component)).toBe(true);
+    });
+
+    it('should be false when passed a dom component', function() {
+      var component = ReactTestUtils.renderIntoDocument(<div/>);
+      expect(ReactTestUtils.isCompositeComponent(component)).toBe(false);
+    });
+
+    it('should be false when passed a string', function() {
+      expect(ReactTestUtils.isCompositeComponent('string')).toBe(false);
+    });
+
+    it('should be false when passed null', function() {
+      expect(ReactTestUtils.isCompositeComponent(null)).toBe(false);
+    });
+  });
+
   it('should have shallow rendering', function() {
     var SomeComponent = React.createClass({
       render: function() {


### PR DESCRIPTION
Currentry, ReactTestUtils.isCompositeComponent returns true even if passed a DOMComponent.

```js
ReactTestUtils.isCompositeComponent(ReactTestUtils.renderIntoDocument(<div/>)); // true
```

This is for fixing that.
I think every Component except DOMComponent is CompositeComponent. Is it correct?