### PR TITLE
Allow render method to be non enumerable

### DIFF
--- a/src/classic/class/ReactClass.js
+++ b/src/classic/class/ReactClass.js
@@ -893,7 +893,7 @@ var ReactClass = {
     }
 
     invariant(
-      Constructor.prototype.render,
+      'render' in Constructor.prototype,
       'createClass(...): Class specification must implement a `render` method.'
     );
 


### PR DESCRIPTION
If the render method is non enumerable you will not be able to check it's presence using `Constructor.prototype.render` you would need to check via `'render' in Constructor.prototype`

This allows React classes to be created using ES6 classes (which methods are non enumerable) like so:

```javascript
class HW {
  render() {
    return <div>Hello, World</div>;
  }
}

React.createClass(HW.prototype);
```
