### PR TITLE
Deprecate reactjs Google Group

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
 ## How to Get in Touch
 
 * IRC - [#reactjs on freenode](https://webchat.freenode.net/?channels=reactjs)
-* Mailing list - [reactjs on Google Groups](https://groups.google.com/group/reactjs)
+* Discussion forum - [discuss.reactjs.org](https://discuss.reactjs.org/)
 
 ## Style Guide
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -10,9 +10,11 @@ id: support
 
 Many members of the community use Stack Overflow to ask questions. Read through the [existing questions](http://stackoverflow.com/questions/tagged/reactjs) tagged with **reactjs** or [ask your own](http://stackoverflow.com/questions/ask)!
 
-## Google Groups mailing list
+## Discussion forum
 
-<a href="https://groups.google.com/group/reactjs" target="_blank">The **reactjs** Google Group</a> is also a good place to ask questions and find answers.
+For longer-form conversations about React, we've set up a [discussion forum at **discuss.reactjs.org**](https://discuss.reactjs.org/). This forum is a great place for discussion about best practices and application architecture as well as the future of React. If you have an answerable code-level question, please post it to Stack Overflow instead.
+
+In the forum there's also a category for job posts and a category for discussion of our weekly meeting notes.
 
 ## IRC
 
@@ -20,6 +22,6 @@ Many developers and users idle on Freenode.net's IRC network in **[#reactjs on f
 
 ## Twitter
 
-[**#reactjs** hash tag on Twitter](https://twitter.com/search?q=%23reactjs) is used to keep up with the latest React news.
+For the latest news about React, [follow **@reactjs** on Twitter](https://twitter.com/reactjs). In addition, you can use the [**#reactjs** hashtag](https://twitter.com/search?q=%23reactjs) to keep up with the latest React news.
 
 <div><a class="twitter-timeline" data-dnt="true" data-chrome="nofooter noheader transparent" href="https://twitter.com/search?q=%23reactjs" data-widget-id="342522405270470656"></a></div>

--- a/docs/tips/01-introduction.md
+++ b/docs/tips/01-introduction.md
@@ -10,4 +10,4 @@ The React tips section provides bite-sized information that can answer lots of q
 
 ## Contributing
 
-Submit a pull request to the [React repository](https://github.com/facebook/react) following the [current tips](https://github.com/facebook/react/tree/master/docs) entries' style. If you have a recipe that needs review prior to submitting a PR you can find help in the [#reactjs channel on freenode](irc://chat.freenode.net/reactjs) or the [reactjs Google group](https://groups.google.com/group/reactjs).
+Submit a pull request to the [React repository](https://github.com/facebook/react) following the [current tips](https://github.com/facebook/react/tree/master/docs) entries' style. If you have a recipe that needs review prior to submitting a PR you can find help in the [#reactjs channel on freenode](irc://chat.freenode.net/reactjs) or the [discuss.reactjs.org forum](https://discuss.reactjs.org/).


### PR DESCRIPTION
We're replacing the group with https://discuss.reactjs.org/.