### PR TITLE
Revert "Add key warning to nested collections"

### DIFF
--- a/src/addons/__tests__/ReactFragment-test.js
+++ b/src/addons/__tests__/ReactFragment-test.js
@@ -49,13 +49,13 @@ describe('ReactFragment', function() {
       z: <span />
     };
     var element = <div>{[children]}</div>;
+    expect(console.error.calls.length).toBe(0);
+    var container = document.createElement('div');
+    React.render(element, container);
     expect(console.error.calls.length).toBe(1);
     expect(console.error.calls[0].args[0]).toContain(
       'Any use of a keyed object'
     );
-    var container = document.createElement('div');
-    React.render(element, container);
-    expect(console.error.calls.length).toBe(1);
   });
 
   it('should warn if accessing any property on a fragment', function() {

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -475,4 +475,21 @@ describe('ReactElementValidator', function() {
     expect(console.error.argsForCall.length).toBe(1);
   });
 
+  it('does not warn when using DOM node as children', function() {
+    spyOn(console, 'error');
+    var DOMContainer = React.createClass({
+      render: function() {
+        return <div />;
+      },
+      componentDidMount: function() {
+        React.findDOMNode(this).appendChild(this.props.children);
+      }
+    });
+
+    var node = document.createElement('div');
+    // This shouldn't cause a stack overflow or any other problems (#3883)
+    ReactTestUtils.renderIntoDocument(<DOMContainer>{node}</DOMContainer>);
+    expect(console.error.argsForCall.length).toBe(0);
+  });
+
 });

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -120,56 +120,6 @@ describe('ReactElementValidator', function() {
     );
   });
 
-  it('warns for keys for nested arrays of elements', function() {
-    spyOn(console, 'error');
-
-    var divs = [
-      [
-        <div />,
-        <div />
-      ],
-      <div key="foo" />
-    ];
-    ReactTestUtils.renderIntoDocument(<div>{divs}</div>);
-
-    expect(console.error.argsForCall.length).toBe(1);
-    expect(console.error.argsForCall[0][0]).toBe(
-      'Warning: Each child in a nested array or iterator should have a ' +
-      'unique "key" prop. Check the React.render call using <div>. See ' +
-      'https://fb.me/react-warning-keys for more information.'
-    );
-  });
-
-  it('warns for keys when reusing children', function() {
-    spyOn(console, 'error');
-
-    var f = <span />;
-    var g = <span />;
-
-    var children = [f, g];
-
-    ReactTestUtils.renderIntoDocument(
-      <div>
-        <div key="0">
-          {g}
-        </div>
-        <div key="1">
-          {f}
-        </div>
-        <div key="2">
-          {children}
-        </div>
-      </div>
-    );
-
-    expect(console.error.argsForCall.length).toBe(1);
-    expect(console.error.argsForCall[0][0]).toBe(
-      'Warning: Each child in an array or iterator should have a unique ' +
-      '"key" prop. Check the React.render call using <div>. See ' +
-      'https://fb.me/react-warning-keys for more information.'
-    );
-  });
-
   it('does not warn for keys when passing children down', function() {
     spyOn(console, 'error');
 


### PR DESCRIPTION
This heuristic isn't great because it relies on inspecting deep children which aren't guaranteed to be React elements. In particular, this was causing stack overflows in a component we had that used a *DOM node* as children, like `<DOMContainer>{node}</DOMContainer>`.

This reverts commits: 0a3aa8493aa014668f5dd3bac30868c18397538e 64c9d9d7629600da81ceefcaa59c46e64d030874 0c58f4f6b12bd7856b73f14163db905cb13c5fc7 8cf226e44241aeafe147f6256a1351b46ac3cf91 086636747f26b577b4a4577a0888118310ee91b3