### PR TITLE
Ignore third_party JS in internal transform step

### DIFF
--- a/bin/jsx-internal
+++ b/bin/jsx-internal
@@ -7,6 +7,8 @@ var babel = require('babel');
 
 var constants = require('../vendor/constants')(babel);
 
+var TRANSFORM_IGNORE_RE = /^WebComponents$/;
+
 require("commoner").version(
   require("../package.json").version
 ).resolve(function(id) {
@@ -30,12 +32,16 @@ require("commoner").version(
 }).process(function(id, source) {
   var context = this;
 
-  // This is where JSX, ES6, etc. desugaring happens.
-  source = babel.transform(source, {
-    blacklist: ['spec.functionName', 'validation.react'],
-    plugins: [constants],
-    filename: id
-  }).code;
+  // This is hacky but that's ok… It really only matters for tests since it
+  // won't otherwise be in the dependency tree.
+  if (!TRANSFORM_IGNORE_RE.test(id)) {
+    // This is where JSX, ES6, etc. desugaring happens.
+    source = babel.transform(source, {
+      blacklist: ['spec.functionName', 'validation.react'],
+      plugins: [constants],
+      filename: id
+    }).code;
+  }
 
   if (context.config.mocking) {
     // Make sure there is exactly one newline at the end of the module.

--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -20,7 +20,7 @@ module.exports = {
     if (path.match(/\.ts$/) && !path.match(/\.d\.ts$/)) {
       return ts.compile(src, path);
     }
-    if (!path.match(/\/node_modules\//)) {
+    if (!path.match(/\/node_modules\//) && !path.match(/\/third_party\//)) {
       return babel.transform(src, {
         blacklist: ['spec.functionName', 'validation.react'],
         filename: path


### PR DESCRIPTION
I noticed output from babel saying the webcomponents.js file was getting deopted because it was too large. We shouldn't be applying transforms to that anyway. So this ignores it.