### PR TITLE
Replaced call to deprected .getDOMNode() with React.findDOMNode().

### DIFF
--- a/docs/tips/18-use-react-with-other-libraries.ko-KR.md
+++ b/docs/tips/18-use-react-with-other-libraries.ko-KR.md
@@ -16,7 +16,7 @@ var App = React.createClass({
   },
 
   componentDidMount: function() {
-    $(this.refs.placeholder.getDOMNode()).append($('<span />'));
+    $(React.findDOMNode(this.refs.placeholder)).append($('<span />'));
   },
 
   componentWillUnmount: function() {

--- a/docs/tips/18-use-react-with-other-libraries.md
+++ b/docs/tips/18-use-react-with-other-libraries.md
@@ -16,7 +16,7 @@ var App = React.createClass({
   },
 
   componentDidMount: function() {
-    $(this.refs.placeholder.getDOMNode()).append($('<span />'));
+    $(React.findDOMNode(this.refs.placeholder)).append($('<span />'));
   },
 
   componentWillUnmount: function() {


### PR DESCRIPTION
The code sample in tip 18 in the docs contained a call to the
.getDOMNode() method which has been deprecated. The method call was
replaced with a call to React.findDOMNode(), which is the preferred way
of getting DOM nodes from a ref.