### PR TITLE
Added component displayName to warning message in ReactUpdateQueue.js

### DIFF
--- a/src/renderers/shared/reconciler/ReactUpdateQueue.js
+++ b/src/renderers/shared/reconciler/ReactUpdateQueue.js
@@ -50,8 +50,7 @@ function getInternalInstanceReadyForUpdate(publicInstance, callerName) {
         !callerName,
         '%s(...): Can only update a mounted or mounting component. ' +
         'This usually means you called %s() on an unmounted component. ' +
-        'Please check the code for the %s component. ' +
-        'This is a no-op.',
+        'This is a no-op. Please check the code for the %s component.',
         callerName,
         callerName,
         publicInstance.constructor.displayName

--- a/src/renderers/shared/reconciler/ReactUpdateQueue.js
+++ b/src/renderers/shared/reconciler/ReactUpdateQueue.js
@@ -49,10 +49,12 @@ function getInternalInstanceReadyForUpdate(publicInstance, callerName) {
       warning(
         !callerName,
         '%s(...): Can only update a mounted or mounting component. ' +
-        'This usually means you called %s() on an unmounted ' +
-        'component. This is a no-op.',
+        'This usually means you called %s() on an unmounted component. ' +
+        'Please check the code for the %s component. ' +
+        'This is a no-op.',
         callerName,
-        callerName
+        callerName,
+        publicInstance.constructor.displayName
       );
     }
     return null;

--- a/src/renderers/shared/reconciler/__tests__/ReactComponentLifeCycle-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactComponentLifeCycle-test.js
@@ -257,8 +257,8 @@ describe('ReactComponentLifeCycle', function() {
     expect(console.error.argsForCall[0][0]).toBe(
       'Warning: setState(...): Can only update a mounted or ' +
       'mounting component. This usually means you called setState() on an ' +
-      'unmounted component. Please check the code for the ' +
-      'StatefulComponent component. This is a no-op.'
+      'unmounted component. This is a no-op. Please check the code for the ' +
+      'StatefulComponent component.'
     );
   });
 

--- a/src/renderers/shared/reconciler/__tests__/ReactComponentLifeCycle-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactComponentLifeCycle-test.js
@@ -257,7 +257,8 @@ describe('ReactComponentLifeCycle', function() {
     expect(console.error.argsForCall[0][0]).toBe(
       'Warning: setState(...): Can only update a mounted or ' +
       'mounting component. This usually means you called setState() on an ' +
-      'unmounted component. This is a no-op.'
+      'unmounted component. Please check the code for the ' +
+      'StatefulComponent component. This is a no-op.'
     );
   });
 
@@ -636,4 +637,3 @@ describe('ReactComponentLifeCycle', function() {
     ]);
   });
 });
-

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -277,8 +277,8 @@ describe('ReactCompositeComponent', function() {
     expect(console.error.argsForCall[0][0]).toBe(
       'Warning: forceUpdate(...): Can only update a mounted or ' +
       'mounting component. This usually means you called forceUpdate() on an ' +
-      'unmounted component. Please check the code for the ' +
-      'Component component. This is a no-op.'
+      'unmounted component. This is a no-op. Please check the code for the ' +
+      'Component component.'
     );
   });
 
@@ -309,8 +309,8 @@ describe('ReactCompositeComponent', function() {
     expect(console.error.argsForCall[0][0]).toBe(
       'Warning: setState(...): Can only update a mounted or ' +
       'mounting component. This usually means you called setState() on an ' +
-      'unmounted component. Please check the code for the ' +
-      'Component component. This is a no-op.'
+      'unmounted component. This is a no-op. Please check the code for the ' +
+      'Component component.'
     );
   });
 
@@ -374,8 +374,8 @@ describe('ReactCompositeComponent', function() {
     expect(console.error.argsForCall[0][0]).toBe(
       'Warning: setProps(...): Can only update a mounted or ' +
       'mounting component. This usually means you called setProps() on an ' +
-      'unmounted component. Please check the code for the ' +
-      'Component component. This is a no-op.'
+      'unmounted component. This is a no-op. Please check the code for the ' +
+      'Component component.'
     );
   });
 

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -276,8 +276,9 @@ describe('ReactCompositeComponent', function() {
     expect(console.error.calls.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toBe(
       'Warning: forceUpdate(...): Can only update a mounted or ' +
-      'mounting component. This usually means you called forceUpdate() on ' +
-      'an unmounted component. This is a no-op.'
+      'mounting component. This usually means you called forceUpdate() on an ' +
+      'unmounted component. Please check the code for the ' +
+      'Component component. This is a no-op.'
     );
   });
 
@@ -308,7 +309,8 @@ describe('ReactCompositeComponent', function() {
     expect(console.error.argsForCall[0][0]).toBe(
       'Warning: setState(...): Can only update a mounted or ' +
       'mounting component. This usually means you called setState() on an ' +
-      'unmounted component. This is a no-op.'
+      'unmounted component. Please check the code for the ' +
+      'Component component. This is a no-op.'
     );
   });
 
@@ -372,7 +374,8 @@ describe('ReactCompositeComponent', function() {
     expect(console.error.argsForCall[0][0]).toBe(
       'Warning: setProps(...): Can only update a mounted or ' +
       'mounting component. This usually means you called setProps() on an ' +
-      'unmounted component. This is a no-op.'
+      'unmounted component. Please check the code for the ' +
+      'Component component. This is a no-op.'
     );
   });
 


### PR DESCRIPTION
ref https://github.com/facebook/react/issues/3878
New message will look like this:
> Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. Please check the code for the ExampleApplication component. This is a no-op.