### PR TITLE
Fixed failing unit tests in browsers that don't support WebComponents

### DIFF
--- a/src/renderers/dom/client/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMount-test.js
@@ -17,12 +17,16 @@ describe('ReactMount', function() {
   var React = require('React');
   var ReactMount = require('ReactMount');
   var ReactTestUtils = require('ReactTestUtils');
-  var WebComponents = undefined;
+  var WebComponents = WebComponents;
 
   try {
-    WebComponents = require('WebComponents');
+    if (WebComponents === undefined && jest !== undefined) {
+      WebComponents = require('WebComponents');
+    }
   } catch(e) {
-    /* leave WebComponents undefined */
+    // Parse error expected on engines that don't support setters
+    // or otherwise aren't supportable by the polyfill.
+    // Leave WebComponents undefined.
   }
 
   describe('constructAndRenderComponentByID', function() {

--- a/test/index.html
+++ b/test/index.html
@@ -5,6 +5,7 @@
 ;(function(){
 
   var urls = [
+    '../src/shared/vendor/third_party/webcomponents.js',
     '../vendor/jasmine/jasmine.js',
     '../vendor/jasmine/jasmine-support.js',
     '../vendor/jasmine/jasmine-html.js',


### PR DESCRIPTION
As per https://github.com/facebook/react/issues/3919, our tests currently only pass in the browser when running in Chrome because when webcomponents.js is actually loaded, it's currently getting packaged into react-test because we're requiring it. It creates a new Node which is resulting in nodes we create with createNodeFromMarkup to have a different prototype than what is expected in WebComponents. WebComponents's new Node prototype has a different implementation of insertBefore which does an instanceof Node check which our nodes are failing.

This PR explicitly checks for PhantomJS (probably not strictly necessary, since we had the try-catch there before, but Paul asked for a check).  Also loads webcomponents.js for tests before any of the other javascript.

There are still a couple of tests failing in my Firefox, but presumably that's unrelated.  We can investigate those tests further tomorrow.  In the mean time, this diff should be ready to land.

cc @zpao 

Fixes #3919