### PR TITLE
Add findElementByRef method to shallow renderer

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -384,6 +384,44 @@ ReactShallowRenderer.prototype.unmount = function() {
   }
 };
 
+ReactShallowRenderer.prototype.findElementByRef = function(refName) {
+  var result = null;
+  var renderedElement = this.getRenderOutput();
+
+  if (null !== renderedElement) {
+    result = this._findRef(refName, renderedElement);
+  }
+
+  return result;
+};
+
+ReactShallowRenderer.prototype._findRef = function(refName, element) {
+  if (element.ref == refName) {
+    return element;
+  }
+
+  var children = element.props.children;
+
+  if (typeof children == "object") {
+
+    if (typeof children.forEach == "function") {
+      var result = null;
+
+      children.forEach(function(element) {
+        result = this._findRef(refName, element) || result;
+
+      }.bind(this));
+
+      return result;
+
+    } else {
+      return this._findRef(refName, children);
+    }
+  }
+
+  return null;
+};
+
 ReactShallowRenderer.prototype._render = function(element, transaction, context) {
   if (!this._instance) {
     var rootID = ReactInstanceHandles.createReactRootID();

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -177,6 +177,34 @@ describe('ReactTestUtils', function() {
     expect(result).toEqual(<div>foo</div>);
   });
 
+  it('can find element by ref when shallow rendering', function() {
+    var SimpleComponent = React.createClass({
+      render: function() {
+        return (
+          <div ref="parent">
+            <div ref="foo">bar</div>
+            <div ref="bar"></div>
+          </div>
+        );
+      },
+    });
+
+    var shallowRenderer = ReactTestUtils.createRenderer();
+    shallowRenderer.render(<SimpleComponent />);
+
+    var parentElement = shallowRenderer.findElementByRef("parent");
+    expect(parentElement.ref).toEqual("parent");
+
+    var fooElement = shallowRenderer.findElementByRef("foo");
+    expect(fooElement).toEqual(<div ref="foo">bar</div>);
+
+    var barElement = shallowRenderer.findElementByRef("bar");
+    expect(barElement).toEqual(<div ref="bar"></div>);
+
+    var undefinedElement = shallowRenderer.findElementByRef("undefined");
+    expect(undefinedElement).toEqual(null);
+  });
+
   it('Test scryRenderedDOMComponentsWithClass with TextComponent', function() {
     var renderedComponent = ReactTestUtils.renderIntoDocument(<div>Hello <span>Jim</span></div>);
     var scryResults = ReactTestUtils.scryRenderedDOMComponentsWithClass(


### PR DESCRIPTION
I found many cases when exploring rendered tree from shallow renderer is just too laborious.  I would like to use refs to quick get element and mock its prop functions or just do some asserts.

Plus it makes tests more flexible in case of change order of elements in tree or just add some before that, which is actually testing.

What do you think?  