### PR TITLE
Added 'is' attribute for custom elements

### DIFF
--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -103,6 +103,7 @@ var HTMLDOMPropertyConfig = {
     httpEquiv: null,
     icon: null,
     id: MUST_USE_PROPERTY,
+    is: MUST_USE_ATTRIBUTE,
     keyParams: MUST_USE_ATTRIBUTE,
     keyType: MUST_USE_ATTRIBUTE,
     label: null,


### PR DESCRIPTION
I've been extending out my [current project](https://github.com/Wildhoney/Maple.js) for webcomponents in React, and I noticed that the [`is` attribute](http://www.w3.org/TR/custom-elements/#type-extension-semantics) isn't supported for React, and is therefore pruned from the element.

I can't be entirely sure this isn't intentional, but I thought I'd open a PR nonetheless. I think it definitely should be in the framework. If not, it would be nice to know what the rationale behind its exclusion is/was.