### PR TITLE
Cleanup classnames documentation

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
       rb-inotify (>= 0.9)
     mercenary (0.3.4)
     mini_portile (0.6.0)
-    nokogiri (1.6.3.1)
+    nokogiri (1.6.6.2)
       mini_portile (= 0.6.0)
     parslet (1.5.0)
       blankslate (~> 2.0)

--- a/docs/docs/10.3-class-name-manipulation.ko-KR.md
+++ b/docs/docs/10.3-class-name-manipulation.ko-KR.md
@@ -10,9 +10,9 @@ next: test-utils-ko-KR.html
 >
 > 이 모듈은 이제 [JedWatson/classnames](https://github.com/JedWatson/classnames)에 독립적으로 있고 React와 관련없습니다. 그러므로 이 애드온은 제거될 예정입니다.
 
-`classSet()`은 간단히 DOM `class` 문자열을 조작하는 편리한 도구입니다.
+`classnames`은 간단히 DOM `class` 문자열을 조작하는 편리한 도구입니다.
 
-일반적으로 있을법한 경우와 `classSet()`을 사용하지 않았을 때의 처리법을 보시죠.
+일반적으로 있을법한 경우와 `classnames`을 사용하지 않았을 때의 처리법을 보시죠.
 
 ```javascript
 // 어떤 `<Message />` React 컴포넌트의 안쪽
@@ -29,12 +29,19 @@ render: function() {
 }
 ```
 
-이것은 순식간에 장황해질 수 있습니다. 클래스 이름 문자열은 읽기 어렵고 에러가 발생하기도 쉽죠. `classSet()`가 이 문제를 해결할 수 있습니다.
+이것은 순식간에 장황해질 수 있습니다. 클래스 이름 문자열은 읽기 어렵고 에러가 발생하기도 쉽죠. `classnames`가 이 문제를 해결할 수 있습니다.
+
+```
+npm install classnames
+```
+
+```javascript
+var classnames = require('classnames');
+```
 
 ```javascript
 render: function() {
-  var cx = React.addons.classSet;
-  var classes = cx({
+  var classes = classnames({
     'message': true,
     'message-important': this.props.isImportant,
     'message-read': this.props.isRead
@@ -44,16 +51,15 @@ render: function() {
 }
 ```
 
-`classSet()`을 사용할 때 사용할지 안할지 잘 모르는 CSS 클래스 이름 키와 함께 객체를 전달합니다. true로 간주되는(Truthy) 값은 키를 결과 문자열의 일부로 만듭니다.
+`classnames`을 사용할 때 사용할지 안할지 잘 모르는 CSS 클래스 이름 키와 함께 객체를 전달합니다. true로 간주되는(Truthy) 값은 키를 결과 문자열의 일부로 만듭니다.
 
-`classSet()`은 클래스 이름을 인자로 넘겨 연결되게 할 수도 있습니다.
+`classnames`은 클래스 이름을 인자로 넘겨 연결되게 할 수도 있습니다.
 
 ```javascript
 render: function() {
-  var cx = React.addons.classSet;
   var importantModifier = 'message-important';
   var readModifier = 'message-read';
-  var classes = cx('message', importantModifier, readModifier);
+  var classes = classnames('message', importantModifier, readModifier);
   // 최종 문자열은 'message message-important message-read'
   return <div className={classes}>좋아요, 거기서 봅시다.</div>;
 }

--- a/docs/docs/10.3-class-name-manipulation.ko-KR.md
+++ b/docs/docs/10.3-class-name-manipulation.ko-KR.md
@@ -8,7 +8,7 @@ next: test-utils-ko-KR.html
 
 > 주의:
 >
-> 이 모듈은 이제 [JedWatson/classnames](https://github.com/JedWatson/classnames)에 독립적으로 있고 React와 관련없습니다. 그러므로 이 애드온은 제거될 예정입니다.
+> 이 모듈은 이제 [JedWatson/classnames](https://github.com/JedWatson/classnames)에 독립적으로 있고 React와 관련없습니다.
 
 `classnames`은 간단히 DOM `class` 문자열을 조작하는 편리한 도구입니다.
 

--- a/docs/docs/10.3-class-name-manipulation.md
+++ b/docs/docs/10.3-class-name-manipulation.md
@@ -10,9 +10,9 @@ next: test-utils.html
 >
 > This module now exists independently at [JedWatson/classnames](https://github.com/JedWatson/classnames) and is React-agnostic. The add-on here will thus be removed in the future.
 
-`classSet()` is a neat utility for easily manipulating the DOM `class` string.
+`classnames` is a neat utility for easily manipulating the DOM `class` string.
 
-Here's a common scenario and its solution without `classSet()`:
+Here's a common scenario and its solution without `classnames`:
 
 ```javascript
 // inside some `<Message />` React component
@@ -29,12 +29,19 @@ render: function() {
 }
 ```
 
-This can quickly get tedious, as assigning class name strings can be hard to read and error-prone. `classSet()` solves this problem:
+This can quickly get tedious, as assigning class name strings can be hard to read and error-prone. `classnames` solves this problem:
+
+```
+npm install classnames
+```
+
+```javascript
+var classnames = require('classnames');
+```
 
 ```javascript
 render: function() {
-  var cx = React.addons.classSet;
-  var classes = cx({
+  var classes = classnames({
     'message': true,
     'message-important': this.props.isImportant,
     'message-read': this.props.isRead
@@ -44,16 +51,15 @@ render: function() {
 }
 ```
 
-When using `classSet()`, pass an object with keys of the CSS class names you might or might not need. Truthy values will result in the key being a part of the resulting string.
+When using `classnames`, pass an object with keys of the CSS class names you might or might not need. Truthy values will result in the key being a part of the resulting string.
 
-`classSet()` also lets pass class names in as arguments that are then concatenated for you:
+`classnames` also lets pass class names in as arguments that are then concatenated for you:
 
 ```javascript
 render: function() {
-  var cx = React.addons.classSet;
   var importantModifier = 'message-important';
   var readModifier = 'message-read';
-  var classes = cx('message', importantModifier, readModifier);
+  var classes = classnames('message', importantModifier, readModifier);
   // Final string is 'message message-important message-read'
   return <div className={classes}>Great, I'll be there.</div>;
 }

--- a/docs/docs/10.3-class-name-manipulation.md
+++ b/docs/docs/10.3-class-name-manipulation.md
@@ -8,7 +8,7 @@ next: test-utils.html
 
 > NOTE:
 >
-> This module now exists independently at [JedWatson/classnames](https://github.com/JedWatson/classnames) and is React-agnostic. The add-on here will thus be removed in the future.
+> This module now exists independently at [JedWatson/classnames](https://github.com/JedWatson/classnames) and is React-agnostic.
 
 `classnames` is a neat utility for easily manipulating the DOM `class` string.
 


### PR DESCRIPTION
React.addons.cx has been deprecated yet the code examples still use it. This PR updates the English and Korean documentation to use the classnames npm module. It also adds some code blocks to document how to install (via npm) and require the module.

I bumped nokogiri version to 1.6.6.2 because I couldn't get the site to run without it. http://stackoverflow.com/questions/5528839/why-does-installing-nokogiri-on-mac-os-fail-with-libiconv-is-missing