### PR TITLE
Adding validation for array in ReactPropTypes.

### DIFF
--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -200,6 +200,12 @@ function createInstanceTypeChecker(expectedClass) {
 }
 
 function createEnumTypeChecker(expectedValues) {
+  if (!Array.isArray(expectedValues)) {
+    return new Error(
+      `Invalid argument supplied to oneOf, expected an instance of array.`
+    );
+  }
+
   function validate(props, propName, componentName, location, propFullName) {
     var propValue = props[propName];
     for (var i = 0; i < expectedValues.length; i++) {
@@ -249,6 +255,12 @@ function createObjectOfTypeChecker(typeChecker) {
 }
 
 function createUnionTypeChecker(arrayOfTypeCheckers) {
+  if (!Array.isArray(arrayOfTypeCheckers)) {
+    return new Error(
+      `Invalid argument supplied to oneOfType, expected an instance of array.`
+    );
+  }
+
   function validate(props, propName, componentName, location, propFullName) {
     for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
       var checker = arrayOfTypeCheckers[i];

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -520,6 +520,13 @@ describe('ReactPropTypes', function() {
   });
 
   describe('OneOf Types', function() {
+    it("should fail for invalid argument", function() {
+      var error = PropTypes.oneOf('red', 'blue');
+      expect(error instanceof Error).toBe(true);
+      expect(error.message).toBe('Invalid argument supplied to ' +
+        'oneOf, expected an instance of array.');
+    });
+
     it("should warn for invalid strings", function() {
       typeCheckFail(
         PropTypes.oneOf(['red', 'blue']),
@@ -572,6 +579,13 @@ describe('ReactPropTypes', function() {
   });
 
   describe('Union Types', function() {
+    it("should fail for invalid argument", function() {
+      var error = PropTypes.oneOfType('red', 'blue');
+      expect(error instanceof Error).toBe(true);
+      expect(error.message).toBe('Invalid argument supplied to ' +
+        'oneOfType, expected an instance of array.');
+    });
+
     it('should warn if none of the types are valid', function() {
       typeCheckFail(
         PropTypes.oneOfType([PropTypes.string, PropTypes.number]),


### PR DESCRIPTION
I had people on my team sending wrong arguments to oneOf and oneOfType attributes from PropTypes.

The current message exposed some internal attributes to the user with the following message:

```bash
Warning: Failed propType: checker is not a function Check the render method of Chart.
```

This warning is a little misleading, I had to spend some time trying to figure out who was invoking this **checker** function, unsuccessfully. Then, after some time, I realized the argument to oneOf and oneOfType was actually invalid and it had nothing to do with checker function.

I've opened a [StackOverflow](http://stackoverflow.com/questions/29995444/react-checker-is-not-a-function) case for this.

This pull request aims to fix this problem by validating the argument type as an array in both createUnionTypeChecker and createEnumTypeChecker. I've added the corresponding tests for this.

Alan
