### PR TITLE
Added challenge, keyParams and keyType on <keygen>

### DIFF
--- a/docs/docs/ref-04-tags-and-attributes.ko-KR.md
+++ b/docs/docs/ref-04-tags-and-attributes.ko-KR.md
@@ -53,13 +53,13 @@ React는 모든 `data-*`, `aria-*` 어트리뷰트와 밑에 있는 모든 어�
 
 ```
 accept acceptCharset accessKey action allowFullScreen allowTransparency alt
-async autoComplete autoFocus autoPlay cellPadding cellSpacing charSet checked
-classID className colSpan cols content contentEditable contextMenu controls
+async autoComplete autoFocus autoPlay cellPadding cellSpacing charSet challenge
+checked classID className colSpan cols content contentEditable contextMenu controls
 coords crossOrigin data dateTime defer dir disabled download draggable encType
 form formAction formEncType formMethod formNoValidate formTarget frameBorder
-headers height hidden high href hrefLang htmlFor httpEquiv icon id label lang
-list loop low manifest marginHeight marginWidth max maxLength media mediaGroup
-method min multiple muted name noValidate open optimum pattern placeholder
+headers height hidden high href hrefLang htmlFor httpEquiv icon id keyParams keyType
+label lang list loop low manifest marginHeight marginWidth max maxLength media
+mediaGroup method min multiple muted name noValidate open optimum pattern placeholder
 poster preload radioGroup readOnly rel required role rowSpan rows sandbox scope
 scoped scrolling seamless selected shape size sizes span spellCheck src srcDoc
 srcSet start step style tabIndex target title type useMap value width wmode

--- a/docs/docs/ref-04-tags-and-attributes.md
+++ b/docs/docs/ref-04-tags-and-attributes.md
@@ -53,13 +53,13 @@ These standard attributes are supported:
 
 ```
 accept acceptCharset accessKey action allowFullScreen allowTransparency alt
-async autoComplete autoFocus autoPlay cellPadding cellSpacing charSet checked
-classID className colSpan cols content contentEditable contextMenu controls
+async autoComplete autoFocus autoPlay cellPadding cellSpacing charSet challenge
+checked classID className colSpan cols content contentEditable contextMenu controls
 coords crossOrigin data dateTime defer dir disabled download draggable encType
 form formAction formEncType formMethod formNoValidate formTarget frameBorder
-headers height hidden high href hrefLang htmlFor httpEquiv icon id label lang
-list loop low manifest marginHeight marginWidth max maxLength media mediaGroup
-method min multiple muted name noValidate open optimum pattern placeholder
+headers height hidden high href hrefLang htmlFor httpEquiv icon id keyParams keyType
+label lang list loop low manifest marginHeight marginWidth max maxLength media
+mediaGroup method min multiple muted name noValidate open optimum pattern placeholder
 poster preload radioGroup readOnly rel required role rowSpan rows sandbox scope
 scoped scrolling seamless selected shape size sizes span spellCheck src srcDoc
 srcSet start step style tabIndex target title type useMap value width wmode

--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -61,6 +61,7 @@ var HTMLDOMPropertyConfig = {
     cellPadding: null,
     cellSpacing: null,
     charSet: MUST_USE_ATTRIBUTE,
+    challenge: MUST_USE_ATTRIBUTE,
     checked: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
     classID: MUST_USE_ATTRIBUTE,
     // To set className on SVG elements, it's necessary to use .setAttribute;
@@ -102,6 +103,8 @@ var HTMLDOMPropertyConfig = {
     httpEquiv: null,
     icon: null,
     id: MUST_USE_PROPERTY,
+    keyParams: MUST_USE_ATTRIBUTE,
+    keyType: MUST_USE_ATTRIBUTE,
     label: null,
     lang: null,
     list: MUST_USE_ATTRIBUTE,


### PR DESCRIPTION
Closes https://github.com/facebook/react/issues/3961.

Now `<keygen>` with these attributes will work:
`<keygen name="name" challenge="challenge string" keytype="type" keyparams="pqg-params">`

Chrome allowed some of these to be `null` (allow `node.challenge` etc),
but FF didn't work, so I had to use `MUST_USE_ATTRIBUTE`. This will tell React to use `node.setAttribute()` to
set these values.

Tested in FF, Chrome, Safari. <keygen> isn't supported on IE.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/keygen

**For my testing**:
I created a component with a button that changed the values of these attributes on every click.

Initial value was `*-`.

Safari
![screen shot 2015-05-27 at 11 33 55 am](https://cloud.githubusercontent.com/assets/606014/7844863/16edbdd6-0468-11e5-8025-c020738b8383.png)
Chrome
![screen shot 2015-05-27 at 11 32 15 am](https://cloud.githubusercontent.com/assets/606014/7844864/16eeabf6-0468-11e5-8749-a2b01191917b.png)
FF
![screen shot 2015-05-27 at 11 32 02 am](https://cloud.githubusercontent.com/assets/606014/7844862/16eca964-0468-11e5-80ba-e0fcc3bddcc6.png)
