### PR TITLE
Fix PropTypes.{oneOf, oneOfType} validation

### DIFF
--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -201,9 +201,11 @@ function createInstanceTypeChecker(expectedClass) {
 
 function createEnumTypeChecker(expectedValues) {
   if (!Array.isArray(expectedValues)) {
-    return new Error(
-      `Invalid argument supplied to oneOf, expected an instance of array.`
-    );
+    return createChainableTypeChecker(function() {
+      return new Error(
+        `Invalid argument supplied to oneOf, expected an instance of array.`
+      );
+    });
   }
 
   function validate(props, propName, componentName, location, propFullName) {
@@ -256,9 +258,11 @@ function createObjectOfTypeChecker(typeChecker) {
 
 function createUnionTypeChecker(arrayOfTypeCheckers) {
   if (!Array.isArray(arrayOfTypeCheckers)) {
-    return new Error(
-      `Invalid argument supplied to oneOfType, expected an instance of array.`
-    );
+    return createChainableTypeChecker(function() {
+      return new Error(
+        `Invalid argument supplied to oneOfType, expected an instance of array.`
+      );
+    });
   }
 
   function validate(props, propName, componentName, location, propFullName) {

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -521,10 +521,11 @@ describe('ReactPropTypes', function() {
 
   describe('OneOf Types', function() {
     it("should fail for invalid argument", function() {
-      var error = PropTypes.oneOf('red', 'blue');
-      expect(error instanceof Error).toBe(true);
-      expect(error.message).toBe('Invalid argument supplied to ' +
-        'oneOf, expected an instance of array.');
+      typeCheckFail(
+        PropTypes.oneOf('red', 'blue'),
+        'red',
+        'Invalid argument supplied to oneOf, expected an instance of array.'
+      );
     });
 
     it("should warn for invalid strings", function() {
@@ -580,10 +581,11 @@ describe('ReactPropTypes', function() {
 
   describe('Union Types', function() {
     it("should fail for invalid argument", function() {
-      var error = PropTypes.oneOfType('red', 'blue');
-      expect(error instanceof Error).toBe(true);
-      expect(error.message).toBe('Invalid argument supplied to ' +
-        'oneOfType, expected an instance of array.');
+      typeCheckFail(
+        PropTypes.oneOfType(PropTypes.string, PropTypes.number),
+        'red',
+        'Invalid argument supplied to oneOfType, expected an instance of array.'
+      );
     });
 
     it('should warn if none of the types are valid', function() {


### PR DESCRIPTION
Follow-up to #3963. (Returning an Error wasn't useful; it just caused a later error when actually using it because type checkers need to be functions.)