### PR TITLE
add an intersection version of PropType.oneOfType called PropType.allOfType

### DIFF
--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -81,6 +81,7 @@ var ReactPropTypes = {
   node: createNodeChecker(),
   objectOf: createObjectOfTypeChecker,
   oneOf: createEnumTypeChecker,
+  allOfType: createIntersectionTypeChecker,
   oneOfType: createUnionTypeChecker,
   shape: createShapeTypeChecker
 };
@@ -249,6 +250,28 @@ function createObjectOfTypeChecker(typeChecker) {
         if (error instanceof Error) {
           return error;
         }
+      }
+    }
+    return null;
+  }
+  return createChainableTypeChecker(validate);
+}
+
+function createIntersectionTypeChecker(arrayOfTypeCheckers) {
+  if (!Array.isArray(arrayOfTypeCheckers)) {
+    return createChainableTypeChecker(function() {
+      return new Error(
+        `Invalid argument supplied to allOfType, expected an instance of array.`
+      );
+    });
+  }
+
+  function validate(props, propName, componentName, location, propFullName) {
+    for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
+      var checker = arrayOfTypeCheckers[i];
+      var error = checker(props, propName, componentName, location, propFullName);
+      if (error instanceof Error) {
+        return error;
       }
     }
     return null;

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -579,6 +579,82 @@ describe('ReactPropTypes', function() {
     });
   });
 
+  describe('Intersection Types', function() {
+    it("should fail for invalid argument", function() {
+      typeCheckFail(
+        PropTypes.allOfType(PropTypes.string, PropTypes.number),
+        'red',
+        'Invalid argument supplied to allOfType, expected an instance of array.'
+      );
+    });
+
+    it('should warn if none of the types are valid', function() {
+      typeCheckFail(
+        PropTypes.allOfType([PropTypes.string, PropTypes.number]),
+        [],
+        'Invalid prop `testProp` of type `array` supplied to `testComponent`, expected `string`.'
+      );
+
+      typeCheckFail(
+        PropTypes.allOfType([PropTypes.number, PropTypes.string]),
+        [],
+        'Invalid prop `testProp` of type `array` supplied to `testComponent`, expected `number`.'
+      );
+
+      var checker = PropTypes.allOfType([
+        PropTypes.shape({a: PropTypes.number.isRequired}),
+        PropTypes.shape({b: PropTypes.number.isRequired})
+      ]);
+      typeCheckFail(
+        checker,
+        {a: 1},
+        'Required prop `testProp.b` was not specified in `testComponent`.'
+      );
+      typeCheckFail(
+        checker,
+        {b: 1},
+        'Required prop `testProp.a` was not specified in `testComponent`.'
+      );
+    });
+
+    it('should not warn if all of the types are valid', function() {
+      var checker = PropTypes.allOfType([
+        PropTypes.number,
+        PropTypes.number
+      ]);
+      typeCheckPass(checker, null);
+      typeCheckPass(checker, 123);
+
+      checker = PropTypes.allOfType([
+        PropTypes.shape({a: PropTypes.number.isRequired}),
+        PropTypes.shape({b: PropTypes.number.isRequired})
+      ]);
+      typeCheckPass(checker, {a: 1, b: 1});
+    });
+
+    it("should be implicitly optional and not warn without values", function() {
+      typeCheckPass(
+        PropTypes.allOfType([PropTypes.string, PropTypes.string]), null
+      );
+      typeCheckPass(
+        PropTypes.allOfType([PropTypes.string, PropTypes.string]), undefined
+      );
+    });
+
+    it("should warn for missing required values", function() {
+      typeCheckFail(
+        PropTypes.allOfType([PropTypes.string, PropTypes.string]).isRequired,
+        null,
+        requiredMessage
+      );
+      typeCheckFail(
+        PropTypes.allOfType([PropTypes.string, PropTypes.string]).isRequired,
+        undefined,
+        requiredMessage
+      );
+    });
+  });
+
   describe('Union Types', function() {
     it("should fail for invalid argument", function() {
       typeCheckFail(


### PR DESCRIPTION
A couple of use cases:

- Password proptypes: can just combine proptypes for string, length, complexity, etc.
- Object proptypes: combinations of existing proptypes (ie, if the view was accepting a prop that was a combination of the public user data and their authentication info, you could just say that object had to match both of your existing proptypes for public user data and auth info)