### PR TITLE
Make DOM wrapper component using lower-level primitives

### DIFF
--- a/src/renderers/dom/client/wrappers/AutoFocusUtils.js
+++ b/src/renderers/dom/client/wrappers/AutoFocusUtils.js
@@ -6,16 +6,18 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule AutoFocusMixin
+ * @providesModule AutoFocusUtils
  * @typechecks static-only
  */
 
 'use strict';
 
+var ReactMount = require('ReactMount');
+
 var findDOMNode = require('findDOMNode');
 var focusNode = require('focusNode');
 
-var AutoFocusMixin = {
+var Mixin = {
   componentDidMount: function() {
     if (this.props.autoFocus) {
       focusNode(findDOMNode(this));
@@ -23,4 +25,12 @@ var AutoFocusMixin = {
   }
 };
 
-module.exports = AutoFocusMixin;
+var AutoFocusUtils = {
+  Mixin: Mixin,
+
+  focusDOMComponent: function() {
+    focusNode(ReactMount.getNode(this._rootNodeID));
+  }
+};
+
+module.exports = AutoFocusUtils;

--- a/src/renderers/dom/client/wrappers/LinkedValueUtils.js
+++ b/src/renderers/dom/client/wrappers/LinkedValueUtils.js
@@ -15,6 +15,7 @@
 var ReactPropTypes = require('ReactPropTypes');
 
 var invariant = require('invariant');
+var warning = require('warning');
 
 var hasReadOnlyValue = {
   'button': true,
@@ -52,20 +53,48 @@ function _assertCheckedLink(inputProps) {
   );
 }
 
-/**
- * @param {SyntheticEvent} e change event to handle
- */
-function _handleLinkedValueChange(e) {
-  /*jshint validthis:true */
-  this.props.valueLink.requestChange(e.target.value);
-}
+var propTypes = {
+  value: function(props, propName, componentName) {
+    if (!props[propName] ||
+        hasReadOnlyValue[props.type] ||
+        props.onChange ||
+        props.readOnly ||
+        props.disabled) {
+      return null;
+    }
+    return new Error(
+      'You provided a `value` prop to a form field without an ' +
+      '`onChange` handler. This will render a read-only field. If ' +
+      'the field should be mutable use `defaultValue`. Otherwise, ' +
+      'set either `onChange` or `readOnly`.'
+    );
+  },
+  checked: function(props, propName, componentName) {
+    if (!props[propName] ||
+        props.onChange ||
+        props.readOnly ||
+        props.disabled) {
+      return null;
+    }
+    return new Error(
+      'You provided a `checked` prop to a form field without an ' +
+      '`onChange` handler. This will render a read-only field. If ' +
+      'the field should be mutable use `defaultChecked`. Otherwise, ' +
+      'set either `onChange` or `readOnly`.'
+    );
+  },
+  onChange: ReactPropTypes.func
+};
 
-/**
-  * @param {SyntheticEvent} e change event to handle
-  */
-function _handleLinkedCheckChange(e) {
-  /*jshint validthis:true */
-  this.props.checkedLink.requestChange(e.target.checked);
+var loggedTypeFailures = {};
+function getDeclarationErrorAddendum(owner) {
+  if (owner) {
+    var name = owner.getName();
+    if (name) {
+      return ' Check the render method of `' + name + '`.';
+    }
+  }
+  return '';
 }
 
 /**
@@ -73,38 +102,19 @@ function _handleLinkedCheckChange(e) {
  * this outside of the ReactDOM controlled form components.
  */
 var LinkedValueUtils = {
-  Mixin: {
-    propTypes: {
-      value: function(props, propName, componentName) {
-        if (!props[propName] ||
-            hasReadOnlyValue[props.type] ||
-            props.onChange ||
-            props.readOnly ||
-            props.disabled) {
-          return null;
-        }
-        return new Error(
-          'You provided a `value` prop to a form field without an ' +
-          '`onChange` handler. This will render a read-only field. If ' +
-          'the field should be mutable use `defaultValue`. Otherwise, ' +
-          'set either `onChange` or `readOnly`.'
-        );
-      },
-      checked: function(props, propName, componentName) {
-        if (!props[propName] ||
-            props.onChange ||
-            props.readOnly ||
-            props.disabled) {
-          return null;
-        }
-        return new Error(
-          'You provided a `checked` prop to a form field without an ' +
-          '`onChange` handler. This will render a read-only field. If ' +
-          'the field should be mutable use `defaultChecked`. Otherwise, ' +
-          'set either `onChange` or `readOnly`.'
-        );
-      },
-      onChange: ReactPropTypes.func
+  checkPropTypes: function (tagName, props, owner) {
+    for (var propName in propTypes) {
+      if (propTypes.hasOwnProperty(propName)) {
+        var error = propTypes[propName](props, propName, tagName, location);
+      }
+      if (error instanceof Error && !(error.message in loggedTypeFailures)) {
+        // Only monitor this failure once because there tends to be a lot of the
+        // same error.
+        loggedTypeFailures[error.message] = true;
+
+        var addendum = getDeclarationErrorAddendum(owner);
+        warning(false, 'Failed form propType: %s%s', error.message, addendum);
+      }
     }
   },
 
@@ -135,17 +145,18 @@ var LinkedValueUtils = {
 
   /**
    * @param {object} inputProps Props for form component
-   * @return {function} change callback either from onChange prop or link.
+   * @param {SyntheticEvent} event change event to handle
    */
-  getOnChange: function(inputProps) {
+  executeOnChange: function(inputProps, event) {
     if (inputProps.valueLink) {
       _assertValueLink(inputProps);
-      return _handleLinkedValueChange;
+      return inputProps.valueLink.requestChange(event.target.value);
     } else if (inputProps.checkedLink) {
       _assertCheckedLink(inputProps);
-      return _handleLinkedCheckChange;
+      return inputProps.checkedLink.requestChange(event.target.checked);
+    } else if (inputProps.onChange) {
+      return inputProps.onChange.call(undefined, event);
     }
-    return inputProps.onChange;
   }
 };
 

--- a/src/renderers/dom/client/wrappers/ReactDOMButton.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMButton.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var AutoFocusMixin = require('AutoFocusMixin');
+var AutoFocusUtils = require('AutoFocusUtils');
 var ReactBrowserComponentMixin = require('ReactBrowserComponentMixin');
 var ReactClass = require('ReactClass');
 var ReactElement = require('ReactElement');
@@ -41,7 +41,7 @@ var ReactDOMButton = ReactClass.createClass({
   displayName: 'ReactDOMButton',
   tagName: 'BUTTON',
 
-  mixins: [AutoFocusMixin, ReactBrowserComponentMixin],
+  mixins: [AutoFocusUtils.Mixin, ReactBrowserComponentMixin],
 
   render: function() {
     var props = {};

--- a/src/renderers/dom/client/wrappers/ReactDOMTextarea.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMTextarea.js
@@ -11,12 +11,13 @@
 
 'use strict';
 
-var AutoFocusMixin = require('AutoFocusMixin');
+var AutoFocusUtils = require('AutoFocusUtils');
 var DOMPropertyOperations = require('DOMPropertyOperations');
 var LinkedValueUtils = require('LinkedValueUtils');
 var ReactBrowserComponentMixin = require('ReactBrowserComponentMixin');
 var ReactClass = require('ReactClass');
 var ReactElement = require('ReactElement');
+var ReactInstanceMap = require('ReactInstanceMap');
 var ReactUpdates = require('ReactUpdates');
 
 var assign = require('Object.assign');
@@ -53,7 +54,15 @@ var ReactDOMTextarea = ReactClass.createClass({
   displayName: 'ReactDOMTextarea',
   tagName: 'TEXTAREA',
 
-  mixins: [AutoFocusMixin, LinkedValueUtils.Mixin, ReactBrowserComponentMixin],
+  mixins: [AutoFocusUtils.Mixin, ReactBrowserComponentMixin],
+
+  componentWillMount: function() {
+    LinkedValueUtils.checkPropTypes(
+      'textarea',
+      this.props,
+      ReactInstanceMap.get(this)._currentElement._owner
+    );
+  },
 
   getInitialState: function() {
     var defaultValue = this.props.defaultValue;
@@ -123,11 +132,7 @@ var ReactDOMTextarea = ReactClass.createClass({
   },
 
   _handleChange: function(event) {
-    var returnValue;
-    var onChange = LinkedValueUtils.getOnChange(this.props);
-    if (onChange) {
-      returnValue = onChange.call(this, event);
-    }
+    var returnValue = LinkedValueUtils.executeOnChange(this.props, event);
     ReactUpdates.asap(forceUpdateIfMounted, this);
     return returnValue;
   }

--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -54,7 +54,7 @@ var HTMLDOMPropertyConfig = {
     alt: null,
     async: HAS_BOOLEAN_VALUE,
     autoComplete: null,
-    // autoFocus is polyfilled/normalized by AutoFocusMixin
+    // autoFocus is polyfilled/normalized by AutoFocusUtils
     // autoFocus: HAS_BOOLEAN_VALUE,
     autoPlay: HAS_BOOLEAN_VALUE,
     capture: MUST_USE_ATTRIBUTE | HAS_BOOLEAN_VALUE,

--- a/src/renderers/dom/shared/ReactDefaultInjection.js
+++ b/src/renderers/dom/shared/ReactDefaultInjection.js
@@ -29,7 +29,6 @@ var ReactDOMForm = require('ReactDOMForm');
 var ReactDOMImg = require('ReactDOMImg');
 var ReactDOMIDOperations = require('ReactDOMIDOperations');
 var ReactDOMIframe = require('ReactDOMIframe');
-var ReactDOMInput = require('ReactDOMInput');
 var ReactDOMOption = require('ReactDOMOption');
 var ReactDOMSelect = require('ReactDOMSelect');
 var ReactDOMTextarea = require('ReactDOMTextarea');
@@ -120,7 +119,6 @@ function inject() {
     'form': ReactDOMForm,
     'iframe': ReactDOMIframe,
     'img': ReactDOMImg,
-    'input': ReactDOMInput,
     'option': ReactDOMOption,
     'select': ReactDOMSelect,
     'textarea': ReactDOMTextarea,

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -308,7 +308,8 @@ describe('ReactDOMComponent', function() {
       genMarkup = function(props) {
         var transaction = new ReactReconcileTransaction();
         return (new NodeStub(props))._createOpenTagMarkupAndPutListeners(
-          transaction
+          transaction,
+          props
         );
       };
 
@@ -357,7 +358,11 @@ describe('ReactDOMComponent', function() {
 
       genMarkup = function(props) {
         var transaction = new ReactReconcileTransaction();
-        return (new NodeStub(props))._createContentMarkup(transaction, {});
+        return (new NodeStub(props))._createContentMarkup(
+          transaction,
+          props,
+          {}
+        );
       };
 
       this.addMatchers({


### PR DESCRIPTION
Introducing: a really lame version of composite components, right inside of ReactDOMComponent!

Now ReactDOMInput isn't an actual component. This brings us closer to exposing DOM nodes as refs.
