### PR TITLE
Always toLowerCase when comparing nodeName or tagName

### DIFF
--- a/src/renderers/dom/client/ReactInputSelection.js
+++ b/src/renderers/dom/client/ReactInputSelection.js
@@ -30,9 +30,10 @@ function isInDocument(node) {
 var ReactInputSelection = {
 
   hasSelectionCapabilities: function(elem) {
-    return elem && (
-      (elem.nodeName === 'INPUT' && elem.type === 'text') ||
-      elem.nodeName === 'TEXTAREA' ||
+    var nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
+    return nodeName && (
+      (nodeName === 'input' && elem.type === 'text') ||
+      nodeName === 'textarea' ||
       elem.contentEditable === 'true'
     );
   },
@@ -84,7 +85,8 @@ var ReactInputSelection = {
         start: input.selectionStart,
         end: input.selectionEnd
       };
-    } else if (document.selection && input.nodeName === 'INPUT') {
+    } else if (document.selection &&
+        (input.nodeName && input.nodeName.toLowerCase() === 'input')) {
       // IE8 input.
       var range = document.selection.createRange();
       // There can only be one selection per document in IE, so it must
@@ -119,7 +121,8 @@ var ReactInputSelection = {
     if ('selectionStart' in input) {
       input.selectionStart = start;
       input.selectionEnd = Math.min(end, input.value.length);
-    } else if (document.selection && input.nodeName === 'INPUT') {
+    } else if (document.selection &&
+        (input.nodeName && input.nodeName.toLowerCase() === 'input')) {
       var range = input.createTextRange();
       range.collapse(true);
       range.moveStart('character', start);

--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -519,7 +519,7 @@ var ReactMount = {
     );
 
     warning(
-      container && container.tagName !== 'BODY',
+      container && container.tagName && container.tagName.toUpperCase() !== 'BODY',
       'render(): Rendering components directly into document.body is ' +
       'discouraged, since its children are often manipulated by third-party ' +
       'scripts and browser extensions. This may lead to subtle ' +

--- a/src/renderers/dom/client/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/ChangeEventPlugin.js
@@ -55,9 +55,10 @@ var activeElementValueProp = null;
  * SECTION: handle `change` event
  */
 function shouldUseChangeEvent(elem) {
+  var nodeName = elem.nodeName && elem.nodeName.toLowerCase();
   return (
-    elem.nodeName === 'SELECT' ||
-    (elem.nodeName === 'INPUT' && elem.type === 'file')
+    nodeName === 'select' ||
+    (nodeName === 'input' && elem.type === 'file')
   );
 }
 
@@ -289,7 +290,7 @@ function shouldUseClickEvent(elem) {
   // This approach works across all browsers, whereas `change` does not fire
   // until `blur` in IE8.
   return (
-    elem.nodeName === 'INPUT' &&
+    (elem.nodeName && elem.nodeName.toLowerCase() === 'input') &&
     (elem.type === 'checkbox' || elem.type === 'radio')
   );
 }

--- a/src/shared/utils/isTextInputElement.js
+++ b/src/shared/utils/isTextInputElement.js
@@ -33,9 +33,10 @@ var supportedInputTypes = {
 };
 
 function isTextInputElement(elem) {
-  return elem && (
-    (elem.nodeName === 'INPUT' && supportedInputTypes[elem.type]) ||
-    elem.nodeName === 'TEXTAREA'
+  var nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
+  return nodeName && (
+    (nodeName === 'input' && supportedInputTypes[elem.type]) ||
+    nodeName === 'textarea'
   );
 }
 


### PR DESCRIPTION
In xml node name casing is exactly the same as the node was originally named.
Make sure to convert node name to upper case before making any node name checks.

Fixes #3960.

---

I searched for `.nodeName` pattern across the code base whilst fixing this. Please have a look at (possibly) similar issues as well before merging this.

In one place I've seen `nodeName.toLowerCase()`. Maybe we want to make that consistent with this change.

I'm not sure how to test this.