### PR TITLE
Enable linting for __tests__

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,9 +1,5 @@
 # We can probably lint these later but not important at this point
 src/shared/vendor
-# eslint uses JSX* node types to determine if using JSX. esprima-fb still uses
-# XJS* nodes. When we fix that (https://github.com/facebook/esprima/pull/85) we
-# can enable linting the tests and fix those errors.
-src/**/__tests__/**
 # This should be enabled but that folder has too much in it that doesn't belong
 src/test
 test/the-files-to-test.generated.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,12 +1,27 @@
 ---
 parser: babel-eslint
 
+plugins:
+  - react
+
 env:
   browser: true
   node: true
 
 globals:
   __DEV__: true
+  # Jest / Jasmine
+  describe: false
+  xdescribe: false
+  beforeEach: false
+  afterEach: false
+  it: false
+  xit: false
+  jest: false
+  pit: false
+  expect: false
+  spyOn: false
+  jasmine: false
 
 rules:
   # ERRORS
@@ -26,7 +41,7 @@ rules:
   dot-location: [2, property]
   consistent-return: 2
   no-unused-vars: [2, args: none]
-  quotes: [2, single]
+  quotes: [2, single, avoid-escape]
   no-shadow: 2
   no-multi-spaces: 2
 
@@ -50,7 +65,13 @@ rules:
   key-spacing: 0
   # It's nice to be able to leave catch blocks empty
   no-empty: 0
+  # It makes code more readable to make this explicit sometimes
+  no-undef-init: 0
 
   # BROKEN. We'd like to turn these back on.
   # causes a ton of noise, eslint is too picky?
   block-scoped-var: 0
+
+  # JSX
+  react/jsx-uses-react: 2
+  react/jsx-quotes: [2, "double"]

--- a/npm-react/addons.js
+++ b/npm-react/addons.js
@@ -1,8 +1,8 @@
 var warning = require('./lib/warning');
 warning(
   false,
-  'require("react/addons") is deprecated. ' +
-  'Access using require("react/addons/{addon}") instead.'
+  "require('react/addons') is deprecated. " +
+  "Access using require('react/addons/{addon}') instead."
 );
 
 module.exports = require('./lib/ReactWithAddons');

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "envify": "^3.0.0",
     "es5-shim": "^4.0.0",
     "eslint": "^0.21.2",
+    "eslint-plugin-react": "^2.3.0",
     "grunt": "~0.4.2",
     "grunt-cli": "^0.1.13",
     "grunt-compare-size": "~0.4.0",

--- a/src/addons/__tests__/ReactComponentWithPureRenderMixin-test.js
+++ b/src/addons/__tests__/ReactComponentWithPureRenderMixin-test.js
@@ -50,20 +50,20 @@ describe('ReactComponentWithPureRenderMixin', function() {
       getInitialState: function() {
         return {
           cut: false,
-          slices: 1,
+          slices: 1
         };
       },
 
       cut: function() {
         this.setState({
           cut: true,
-          slices: 10,
+          slices: 10
         });
       },
 
       eatSlice: function() {
         this.setState({
-          slices: this.state.slices - 1,
+          slices: this.state.slices - 1
         });
       },
 
@@ -101,7 +101,7 @@ describe('ReactComponentWithPureRenderMixin', function() {
     function getInitialState() {
       return {
         foo: [1, 2, 3],
-        bar: {a: 4, b: 5, c: 6},
+        bar: {a: 4, b: 5, c: 6}
       };
     }
 
@@ -127,7 +127,7 @@ describe('ReactComponentWithPureRenderMixin', function() {
     // Do not re-render if state is equal
     var settings = {
       foo: initialSettings.foo,
-      bar: initialSettings.bar,
+      bar: initialSettings.bar
     };
     instance.setState(settings);
     expect(renderCalls).toBe(1);

--- a/src/addons/__tests__/ReactFragment-test.js
+++ b/src/addons/__tests__/ReactFragment-test.js
@@ -27,7 +27,7 @@ describe('ReactFragment', function() {
       x: <span />,
       y: <span />
     };
-    <div>{children}</div>;
+    void <div>{children}</div>;
     expect(console.error.calls.length).toBe(1);
     expect(console.error.calls[0].args[0]).toContain(
       'Any use of a keyed object'
@@ -37,7 +37,7 @@ describe('ReactFragment', function() {
       x: <span />,
       y: <span />
     };
-    <div>{sameChildren}</div>;
+    void <div>{sameChildren}</div>;
     expect(console.error.calls.length).toBe(1);
   });
 
@@ -65,7 +65,7 @@ describe('ReactFragment', function() {
       y: <span />
     };
     var frag = ReactFragment.create(children);
-    frag.x;
+    void frag.x;
     frag.y = 10;
     expect(console.error.calls.length).toBe(1);
     expect(console.error.calls[0].args[0]).toContain(

--- a/src/addons/__tests__/renderSubtreeIntoContainer.js
+++ b/src/addons/__tests__/renderSubtreeIntoContainer.js
@@ -33,7 +33,7 @@ describe('renderSubtreeIntoContainer', function() {
 
     var Parent = React.createClass({
       childContextTypes: {
-        foo: React.PropTypes.string.isRequired,
+        foo: React.PropTypes.string.isRequired
       },
 
       getChildContext: function() {
@@ -72,7 +72,7 @@ describe('renderSubtreeIntoContainer', function() {
 
     var Parent = React.createClass({
       childContextTypes: {
-        foo: React.PropTypes.string.isRequired,
+        foo: React.PropTypes.string.isRequired
       },
 
       getChildContext: function() {

--- a/src/addons/__tests__/update-test.js
+++ b/src/addons/__tests__/update-test.js
@@ -72,7 +72,7 @@ describe('update', function() {
   });
 
   it('should support apply', function() {
-    expect(update(2, {$apply: function(x) { return x * 2; }})).toEqual(4);
+    expect(update(2, {$apply: (x) => x * 2})).toEqual(4);
     expect(update.bind(null, 2, {$apply: 123})).toThrow(
       'Invariant Violation: update(): expected spec of $apply to be a ' +
       'function; got 123.'

--- a/src/addons/link/__tests__/LinkedStateMixin-test.js
+++ b/src/addons/link/__tests__/LinkedStateMixin-test.js
@@ -16,13 +16,11 @@
 describe('LinkedStateMixin', function() {
   var LinkedStateMixin;
   var React;
-  var ReactLink;
   var ReactTestUtils;
 
   beforeEach(function() {
     LinkedStateMixin = require('LinkedStateMixin');
     React = require('React');
-    ReactLink = require('ReactLink');
     ReactTestUtils = require('ReactTestUtils');
   });
 

--- a/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
@@ -13,7 +13,6 @@
 
 var React;
 var ReactCSSTransitionGroup;
-var mocks;
 
 // Most of the real functionality is covered in other unit tests, this just
 // makes sure we're wired up correctly.
@@ -23,7 +22,6 @@ describe('ReactCSSTransitionGroup', function() {
   beforeEach(function() {
     React = require('React');
     ReactCSSTransitionGroup = require('ReactCSSTransitionGroup');
-    mocks = require('mocks');
 
     container = document.createElement('div');
     spyOn(console, 'error');
@@ -52,7 +50,7 @@ describe('ReactCSSTransitionGroup', function() {
 
     // For some reason jst is adding extra setTimeout()s and grunt test isn't,
     // so we need to do this disgusting hack.
-    for (var i = 0 ; i < setTimeout.mock.calls.length; i++) {
+    for (var i = 0; i < setTimeout.mock.calls.length; i++) {
       if (setTimeout.mock.calls[i][1] === 5000) {
         setTimeout.mock.calls[i][0]();
         break;

--- a/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
@@ -13,7 +13,6 @@
 
 var React;
 var ReactTransitionGroup;
-var mocks;
 
 // Most of the real functionality is covered in other unit tests, this just
 // makes sure we're wired up correctly.
@@ -23,7 +22,6 @@ describe('ReactTransitionGroup', function() {
   beforeEach(function() {
     React = require('React');
     ReactTransitionGroup = require('ReactTransitionGroup');
-    mocks = require('mocks');
 
     container = document.createElement('div');
   });
@@ -94,15 +92,15 @@ describe('ReactTransitionGroup', function() {
 
   it('should handle enter/leave/enter/leave correctly', function() {
     var log = [];
-    var cb;
+    var willEnterCb;
 
     var Child = React.createClass({
       componentDidMount: function() {
         log.push('didMount');
       },
-      componentWillEnter: function(_cb) {
+      componentWillEnter: function(cb) {
         log.push('willEnter');
-        cb = _cb;
+        willEnterCb = cb;
       },
       componentDidEnter: function() {
         log.push('didEnter');
@@ -139,12 +137,13 @@ describe('ReactTransitionGroup', function() {
     expect(log).toEqual(['didMount']);
     instance.setState({count: 2});
     expect(log).toEqual(['didMount', 'didMount', 'willEnter']);
-    for (var i = 0; i < 5; i++) {
+    for (var k = 0; k < 5; k++) {
       instance.setState({count: 2});
       expect(log).toEqual(['didMount', 'didMount', 'willEnter']);
       instance.setState({count: 1});
     }
-    cb();
+    // other animations are blocked until willEnterCb is called
+    willEnterCb();
     expect(log).toEqual([
       'didMount', 'didMount', 'willEnter',
       'didEnter', 'willLeave', 'didLeave', 'willUnmount'
@@ -153,15 +152,15 @@ describe('ReactTransitionGroup', function() {
 
   it('should handle enter/leave/enter correctly', function() {
     var log = [];
-    var cb;
+    var willEnterCb;
 
     var Child = React.createClass({
       componentDidMount: function() {
         log.push('didMount');
       },
-      componentWillEnter: function(_cb) {
+      componentWillEnter: function(cb) {
         log.push('willEnter');
-        cb = _cb;
+        willEnterCb = cb;
       },
       componentDidEnter: function() {
         log.push('didEnter');
@@ -198,12 +197,12 @@ describe('ReactTransitionGroup', function() {
     expect(log).toEqual(['didMount']);
     instance.setState({count: 2});
     expect(log).toEqual(['didMount', 'didMount', 'willEnter']);
-    for (var i = 0; i < 5; i++) {
+    for (var k = 0; k < 5; k++) {
       instance.setState({count: 1});
       expect(log).toEqual(['didMount', 'didMount', 'willEnter']);
       instance.setState({count: 2});
     }
-    cb();
+    willEnterCb();
     expect(log).toEqual([
       'didMount', 'didMount', 'willEnter', 'didEnter'
     ]);
@@ -211,7 +210,6 @@ describe('ReactTransitionGroup', function() {
 
   it('should handle entering/leaving several elements at once', function() {
     var log = [];
-    var cb;
 
     var Child = React.createClass({
       componentDidMount: function() {

--- a/src/isomorphic/children/__tests__/ReactChildren-test.js
+++ b/src/isomorphic/children/__tests__/ReactChildren-test.js
@@ -22,10 +22,6 @@ describe('ReactChildren', function() {
     ReactFragment = require('ReactFragment');
   });
 
-  function frag(obj) {
-    return ReactFragment.create(obj);
-  }
-
   function nthChild(mappedChildren, n) {
     var result = null;
     ReactChildren.forEach(mappedChildren, function(child, index) {
@@ -227,7 +223,7 @@ describe('ReactChildren', function() {
 
     var instance = (
       <div>{
-        [frag({
+        [ReactFragment.create({
           firstHalfKey: [zero, one, two],
           secondHalfKey: [three, four],
           keyFive: five
@@ -345,7 +341,9 @@ describe('ReactChildren', function() {
     var zero = <div key="something"/>;
     var one = <span key="something" />;
 
-    var mapFn = function(component) { return component; };
+    var mapFn = function(component) {
+      return component;
+    };
     var instance = (
       <div>{zero}{one}</div>
     );
@@ -410,7 +408,7 @@ describe('ReactChildren', function() {
 
     var instance = (
       <div>{
-        [frag({
+        [ReactFragment.create({
           firstHalfKey: [zero, one, two],
           secondHalfKey: [three, four],
           keyFive: five
@@ -438,7 +436,7 @@ describe('ReactChildren', function() {
       return c;
     });
     for (var key in frag) {
-      frag[key];
+      void frag[key];
       break;
     }
     expect(console.error.calls.length).toBe(1);
@@ -447,8 +445,8 @@ describe('ReactChildren', function() {
     var frag2 = ReactChildren.map([child, child], function(c) {
       return c;
     });
-    for (var key in frag2) {
-      frag2[key] = 123;
+    for (var key2 in frag2) {
+      frag2[key2] = 123;
       break;
     }
     expect(console.error.calls.length).toBe(2);

--- a/src/isomorphic/classic/__tests__/ReactContextValidator-test.js
+++ b/src/isomorphic/classic/__tests__/ReactContextValidator-test.js
@@ -21,7 +21,6 @@ var React;
 var ReactTestUtils;
 
 var reactComponentExpect;
-var mocks;
 
 describe('ReactContextValidator', function() {
   beforeEach(function() {
@@ -30,7 +29,6 @@ describe('ReactContextValidator', function() {
     React = require('React');
     ReactTestUtils = require('ReactTestUtils');
     reactComponentExpect = require('reactComponentExpect');
-    mocks = require('mocks');
 
     spyOn(console, 'error');
   });
@@ -86,7 +84,7 @@ describe('ReactContextValidator', function() {
       getChildContext: function() {
         return {
           foo: this.props.foo,
-          bar: "bar"
+          bar: 'bar'
         };
       },
 
@@ -125,7 +123,7 @@ describe('ReactContextValidator', function() {
 
     var instance = <Parent foo="abc" />;
     instance = ReactTestUtils.renderIntoDocument(instance);
-    instance.replaceProps({foo: "def"});
+    instance.replaceProps({foo: 'def'});
     expect(actualComponentWillReceiveProps).toEqual({foo: 'def'});
     expect(actualShouldComponentUpdate).toEqual({foo: 'def'});
     expect(actualComponentWillUpdate).toEqual({foo: 'def'});

--- a/src/isomorphic/classic/class/__tests__/ReactBind-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactBind-test.js
@@ -36,7 +36,7 @@ describe('autobinding', function() {
       // auto binding only occurs on top level functions in class defs.
       badIdeas: {
         badBind: function() {
-          this.state.something;
+          void this.state.something;
         }
       },
 
@@ -131,7 +131,7 @@ describe('autobinding', function() {
       }
     });
 
-    ReactTestUtils.renderIntoDocument(<TestBindComponent />)
+    ReactTestUtils.renderIntoDocument(<TestBindComponent />);
 
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toBe(
@@ -159,7 +159,7 @@ describe('autobinding', function() {
       }
     });
 
-    ReactTestUtils.renderIntoDocument(<TestBindComponent />)
+    ReactTestUtils.renderIntoDocument(<TestBindComponent />);
 
     expect(console.error.argsForCall.length).toBe(0);
   });

--- a/src/isomorphic/classic/class/__tests__/ReactClass-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactClass-test.js
@@ -175,7 +175,8 @@ describe('ReactClass-spec', function() {
       'because the function is expected to return a value.'
     );
 
-    var NamedComponent = React.createClass({
+    React.createClass({
+      displayName: 'NamedComponent',
       componentShouldUpdate: function() {
         return false;
       },
@@ -189,8 +190,6 @@ describe('ReactClass-spec', function() {
       'mean shouldComponentUpdate()? The name is phrased as a question ' +
       'because the function is expected to return a value.'
     );
-
-    <NamedComponent />; // Shut up lint
   });
 
   it('should throw if a reserved property is in statics', function() {

--- a/src/isomorphic/classic/class/__tests__/ReactClassMixin-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactClassMixin-test.js
@@ -15,7 +15,6 @@ var mocks = require('mocks');
 
 var React;
 var ReactTestUtils;
-var reactComponentExpect;
 
 var TestComponent;
 var TestComponentWithPropTypes;
@@ -28,7 +27,6 @@ describe('ReactClass-mixin', function() {
   beforeEach(function() {
     React = require('React');
     ReactTestUtils = require('ReactTestUtils');
-    reactComponentExpect = require('reactComponentExpect');
     mixinPropValidator = mocks.getMockFunction();
     componentPropValidator = mocks.getMockFunction();
 
@@ -288,18 +286,22 @@ describe('ReactClass-mixin', function() {
     );
   });
 
-  it("should throw if mixins override functions in statics", function() {
+  it('should throw if mixins override functions in statics', function() {
     expect(function() {
       var Mixin = {
         statics: {
-          abc: function() { console.log('foo'); }
+          abc: function() {
+            console.log('foo');
+          }
         }
       };
       React.createClass({
         mixins: [Mixin],
 
         statics: {
-          abc: function() { console.log('bar'); }
+          abc: function() {
+            console.log('bar');
+          }
         },
 
         render: function() {
@@ -313,7 +315,7 @@ describe('ReactClass-mixin', function() {
     );
   });
 
-  it("should throw if the mixin is a React component", function() {
+  it('should throw if the mixin is a React component', function() {
     expect(function() {
       React.createClass({
         mixins: [<div />],
@@ -328,7 +330,7 @@ describe('ReactClass-mixin', function() {
     );
   });
 
-  it("should throw if the mixin is a React component class", function() {
+  it('should throw if the mixin is a React component class', function() {
     expect(function() {
       var Component = React.createClass({
         render: function() {
@@ -351,7 +353,9 @@ describe('ReactClass-mixin', function() {
 
   it('should have bound the mixin methods to the component', function() {
     var mixin = {
-      mixinFunc: function() {return this;}
+      mixinFunc: function() {
+        return this;
+      }
     };
 
     var Component = React.createClass({
@@ -368,24 +372,24 @@ describe('ReactClass-mixin', function() {
   });
 
   it('should include the mixin keys in even if their values are falsy',
-    function() {
-      var mixin = {
-        keyWithNullValue: null,
-        randomCounter: 0
-      };
+      function() {
+    var mixin = {
+      keyWithNullValue: null,
+      randomCounter: 0
+    };
 
-      var Component = React.createClass({
-        mixins: [mixin],
-        componentDidMount: function() {
-          expect(this.randomCounter).toBe(0);
-          expect(this.keyWithNullValue).toBeNull();
-        },
-        render: function() {
-          return <span />;
-        }
-      });
-      var instance = <Component />;
-      instance = ReactTestUtils.renderIntoDocument(instance);
+    var Component = React.createClass({
+      mixins: [mixin],
+      componentDidMount: function() {
+        expect(this.randomCounter).toBe(0);
+        expect(this.keyWithNullValue).toBeNull();
+      },
+      render: function() {
+        return <span />;
+      }
+    });
+    var instance = <Component />;
+    instance = ReactTestUtils.renderIntoDocument(instance);
   });
 
   it('should work with a null getInitialState return value and a mixin', () => {

--- a/src/isomorphic/classic/element/__tests__/ReactElement-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElement-test.js
@@ -14,8 +14,6 @@
 // NOTE: We're explicitly not using JSX in this file. This is intended to test
 // classic JS without JSX.
 
-var mocks;
-
 var React;
 var ReactTestUtils;
 
@@ -25,12 +23,12 @@ describe('ReactElement', function() {
   beforeEach(function() {
     require('mock-modules').dumpCache();
 
-    mocks = require('mocks');
-
     React = require('React');
     ReactTestUtils = require('ReactTestUtils');
     ComponentClass = React.createClass({
-      render: function() { return React.createElement('div'); }
+      render: function() {
+        return React.createElement('div');
+      }
     });
   });
 
@@ -143,7 +141,7 @@ describe('ReactElement', function() {
   it('allows static methods to be called using the type property', function() {
     spyOn(console, 'error');
 
-    var ComponentClass = React.createClass({
+    var StaticMethodComponentClass = React.createClass({
       statics: {
         someStaticMethod: function() {
           return 'someReturnValue';
@@ -157,7 +155,7 @@ describe('ReactElement', function() {
       }
     });
 
-    var element = React.createElement(ComponentClass);
+    var element = React.createElement(StaticMethodComponentClass);
     expect(element.type.someStaticMethod()).toBe('someReturnValue');
     expect(console.error.argsForCall.length).toBe(0);
   });
@@ -177,7 +175,7 @@ describe('ReactElement', function() {
     expect(React.isValidElement(null)).toEqual(false);
     expect(React.isValidElement(true)).toEqual(false);
     expect(React.isValidElement({})).toEqual(false);
-    expect(React.isValidElement("string")).toEqual(false);
+    expect(React.isValidElement('string')).toEqual(false);
     expect(React.isValidElement(React.DOM.div)).toEqual(false);
     expect(React.isValidElement(Component)).toEqual(false);
   });
@@ -193,8 +191,8 @@ describe('ReactElement', function() {
       }
     });
 
-    expect(typeof Component.specialType).toBe("function");
-    expect(typeof Component.specialType.isRequired).toBe("function");
+    expect(typeof Component.specialType).toBe('function');
+    expect(typeof Component.specialType.isRequired).toBe('function');
   });
 
   it('is indistinguishable from a plain object', function() {
@@ -285,7 +283,7 @@ describe('ReactElement', function() {
 
   it('warns when adding a prop after element creation', function() {
     spyOn(console, 'error');
-    var el = document.createElement('div');
+    var container = document.createElement('div');
     var Outer = React.createClass({
       getDefaultProps: () => ({sound: 'meow'}),
       render: function() {
@@ -299,7 +297,7 @@ describe('ReactElement', function() {
         return el;
       }
     });
-    var outer = React.render(<Outer />, el);
+    var outer = React.render(<Outer />, container);
     expect(React.findDOMNode(outer).textContent).toBe('meow');
     expect(React.findDOMNode(outer).className).toBe('quack');
 
@@ -315,7 +313,7 @@ describe('ReactElement', function() {
 
     var newOuterEl = <Outer />;
     newOuterEl.props.sound = 'oink';
-    outer = React.render(newOuterEl, el);
+    outer = React.render(newOuterEl, container);
     expect(React.findDOMNode(outer).textContent).toBe('oink');
     expect(React.findDOMNode(outer).className).toBe('quack');
 

--- a/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
@@ -13,8 +13,6 @@
 
 require('mock-modules');
 
-var mocks = require('mocks');
-
 var React;
 var ReactTestUtils;
 

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -28,7 +28,9 @@ describe('ReactElementValidator', function() {
     ReactFragment = require('ReactFragment');
     ReactTestUtils = require('ReactTestUtils');
     ComponentClass = React.createClass({
-      render: function() { return React.createElement('div'); }
+      render: function() {
+        return React.createElement('div');
+      }
     });
   });
 
@@ -213,7 +215,8 @@ describe('ReactElementValidator', function() {
     );
   });
 
-  it('does not warn for numeric keys in entry iterables in rest args', function() {
+  it('does not warn for numeric keys in entry iterables in rest args',
+      function() {
     spyOn(console, 'error');
     var Component = React.createFactory(ComponentClass);
 
@@ -283,7 +286,7 @@ describe('ReactElementValidator', function() {
   });
 
   it('gives a helpful error when passing null, undefined, boolean, or number',
-      () => {
+      function() {
     spyOn(console, 'error');
     React.createElement(undefined);
     React.createElement(null);
@@ -315,7 +318,7 @@ describe('ReactElementValidator', function() {
   });
 
   it('includes the owner name when passing null, undefined, boolean, or number',
-      () => {
+      function() {
     spyOn(console, 'error');
     var ParentComp = React.createClass({
       render: function() {

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -55,7 +55,7 @@ describe('ReactPropTypes', function() {
   });
 
   describe('Primitive Types', function() {
-    it("should warn for invalid strings", function() {
+    it('should warn for invalid strings', function() {
       typeCheckFail(
         PropTypes.string,
         [],
@@ -97,7 +97,7 @@ describe('ReactPropTypes', function() {
       );
     });
 
-    it("should not warn for valid values", function() {
+    it('should not warn for valid values', function() {
       typeCheckPass(PropTypes.array, []);
       typeCheckPass(PropTypes.bool, false);
       typeCheckPass(PropTypes.func, function() {});
@@ -108,12 +108,12 @@ describe('ReactPropTypes', function() {
       typeCheckPass(PropTypes.object, /please/);
     });
 
-    it("should be implicitly optional and not warn without values", function() {
+    it('should be implicitly optional and not warn without values', function() {
       typeCheckPass(PropTypes.string, null);
       typeCheckPass(PropTypes.string, undefined);
     });
 
-    it("should warn for missing required values", function() {
+    it('should warn for missing required values', function() {
       typeCheckFail(PropTypes.string.isRequired, null, requiredMessage);
       typeCheckFail(PropTypes.string.isRequired, undefined, requiredMessage);
     });
@@ -126,12 +126,12 @@ describe('ReactPropTypes', function() {
       typeCheckPass(PropTypes.any, []);
     });
 
-    it("should be implicitly optional and not warn without values", function() {
+    it('should be implicitly optional and not warn without values', function() {
       typeCheckPass(PropTypes.any, null);
       typeCheckPass(PropTypes.any, undefined);
     });
 
-    it("should warn for missing required values", function() {
+    it('should warn for missing required values', function() {
       typeCheckFail(PropTypes.any.isRequired, null, requiredMessage);
       typeCheckFail(PropTypes.any.isRequired, undefined, requiredMessage);
     });
@@ -203,12 +203,12 @@ describe('ReactPropTypes', function() {
       typeCheckPass(PropTypes.arrayOf(PropTypes.number), []);
     });
 
-    it("should be implicitly optional and not warn without values", function() {
+    it('should be implicitly optional and not warn without values', function() {
       typeCheckPass(PropTypes.arrayOf(PropTypes.number), null);
       typeCheckPass(PropTypes.arrayOf(PropTypes.number), undefined);
     });
 
-    it("should warn for missing required values", function() {
+    it('should warn for missing required values', function() {
       typeCheckFail(
         PropTypes.arrayOf(PropTypes.number).isRequired,
         null,
@@ -263,19 +263,19 @@ describe('ReactPropTypes', function() {
       expect(console.error.argsForCall.length).toBe(1);
     });
 
-    it("should be implicitly optional and not warn without values", function() {
+    it('should be implicitly optional and not warn without values', function() {
       typeCheckPass(PropTypes.element, null);
       typeCheckPass(PropTypes.element, undefined);
     });
 
-    it("should warn for missing required values", function() {
+    it('should warn for missing required values', function() {
       typeCheckFail(PropTypes.element.isRequired, null, requiredMessage);
       typeCheckFail(PropTypes.element.isRequired, undefined, requiredMessage);
     });
   });
 
   describe('Instance Types', function() {
-    it("should warn for invalid instances", function() {
+    it('should warn for invalid instances', function() {
       function Person() {}
       var personName = Person.name || '<<anonymous>>';
       var dateName = Date.name || '<<anonymous>>';
@@ -313,7 +313,7 @@ describe('ReactPropTypes', function() {
       );
     });
 
-    it("should not warn for valid values", function() {
+    it('should not warn for valid values', function() {
       function Person() {}
       function Engineer() {}
       Engineer.prototype = new Person();
@@ -325,12 +325,12 @@ describe('ReactPropTypes', function() {
       typeCheckPass(PropTypes.instanceOf(RegExp), /please/);
     });
 
-    it("should be implicitly optional and not warn without values", function() {
+    it('should be implicitly optional and not warn without values', function() {
       typeCheckPass(PropTypes.instanceOf(String), null);
       typeCheckPass(PropTypes.instanceOf(String), undefined);
     });
 
-    it("should warn for missing required values", function() {
+    it('should warn for missing required values', function() {
       typeCheckFail(
         PropTypes.instanceOf(String).isRequired, null, requiredMessage
       );
@@ -500,12 +500,12 @@ describe('ReactPropTypes', function() {
       typeCheckPass(PropTypes.objectOf(PropTypes.number), {});
     });
 
-    it("should be implicitly optional and not warn without values", function() {
+    it('should be implicitly optional and not warn without values', function() {
       typeCheckPass(PropTypes.objectOf(PropTypes.number), null);
       typeCheckPass(PropTypes.objectOf(PropTypes.number), undefined);
     });
 
-    it("should warn for missing required values", function() {
+    it('should warn for missing required values', function() {
       typeCheckFail(
         PropTypes.objectOf(PropTypes.number).isRequired,
         null,
@@ -520,7 +520,7 @@ describe('ReactPropTypes', function() {
   });
 
   describe('OneOf Types', function() {
-    it("should fail for invalid argument", function() {
+    it('should fail for invalid argument', function() {
       typeCheckFail(
         PropTypes.oneOf('red', 'blue'),
         'red',
@@ -528,7 +528,7 @@ describe('ReactPropTypes', function() {
       );
     });
 
-    it("should warn for invalid strings", function() {
+    it('should warn for invalid strings', function() {
       typeCheckFail(
         PropTypes.oneOf(['red', 'blue']),
         true,
@@ -555,17 +555,17 @@ describe('ReactPropTypes', function() {
       );
     });
 
-    it("should not warn for valid values", function() {
+    it('should not warn for valid values', function() {
       typeCheckPass(PropTypes.oneOf(['red', 'blue']), 'red');
       typeCheckPass(PropTypes.oneOf(['red', 'blue']), 'blue');
     });
 
-    it("should be implicitly optional and not warn without values", function() {
+    it('should be implicitly optional and not warn without values', function() {
       typeCheckPass(PropTypes.oneOf(['red', 'blue']), null);
       typeCheckPass(PropTypes.oneOf(['red', 'blue']), undefined);
     });
 
-    it("should warn for missing required values", function() {
+    it('should warn for missing required values', function() {
       typeCheckFail(
         PropTypes.oneOf(['red', 'blue']).isRequired,
         null,
@@ -580,7 +580,7 @@ describe('ReactPropTypes', function() {
   });
 
   describe('Union Types', function() {
-    it("should fail for invalid argument", function() {
+    it('should fail for invalid argument', function() {
       typeCheckFail(
         PropTypes.oneOfType(PropTypes.string, PropTypes.number),
         'red',
@@ -623,7 +623,7 @@ describe('ReactPropTypes', function() {
       typeCheckPass(checker, {b: 1});
     });
 
-    it("should be implicitly optional and not warn without values", function() {
+    it('should be implicitly optional and not warn without values', function() {
       typeCheckPass(
         PropTypes.oneOfType([PropTypes.string, PropTypes.number]), null
       );
@@ -632,7 +632,7 @@ describe('ReactPropTypes', function() {
       );
     });
 
-    it("should warn for missing required values", function() {
+    it('should warn for missing required values', function() {
       typeCheckFail(
         PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
         null,
@@ -647,7 +647,7 @@ describe('ReactPropTypes', function() {
   });
 
   describe('Shape Types', function() {
-    it("should warn for non objects", function() {
+    it('should warn for non objects', function() {
       typeCheckFail(
         PropTypes.shape({}),
         'some string',
@@ -662,25 +662,25 @@ describe('ReactPropTypes', function() {
       );
     });
 
-    it("should not warn for empty values", function() {
+    it('should not warn for empty values', function() {
       typeCheckPass(PropTypes.shape({}), undefined);
       typeCheckPass(PropTypes.shape({}), null);
       typeCheckPass(PropTypes.shape({}), {});
     });
 
-    it("should not warn for an empty object", function() {
+    it('should not warn for an empty object', function() {
       typeCheckPass(PropTypes.shape({}).isRequired, {});
     });
 
-    it("should not warn for non specified types", function() {
+    it('should not warn for non specified types', function() {
       typeCheckPass(PropTypes.shape({}), {key: 1});
     });
 
-    it("should not warn for valid types", function() {
+    it('should not warn for valid types', function() {
       typeCheckPass(PropTypes.shape({key: PropTypes.number}), {key: 1});
     });
 
-    it("should warn for required valid types", function() {
+    it('should warn for required valid types', function() {
       typeCheckFail(
         PropTypes.shape({key: PropTypes.number.isRequired}),
         {},
@@ -688,7 +688,7 @@ describe('ReactPropTypes', function() {
       );
     });
 
-    it("should warn for the first required type", function() {
+    it('should warn for the first required type', function() {
       typeCheckFail(
         PropTypes.shape({
           key: PropTypes.number.isRequired,
@@ -699,7 +699,7 @@ describe('ReactPropTypes', function() {
       );
     });
 
-    it("should warn for invalid key types", function() {
+    it('should warn for invalid key types', function() {
       typeCheckFail(PropTypes.shape({key: PropTypes.number}),
         {key: 'abc'},
         'Invalid prop `testProp.key` of type `string` supplied to `testComponent`, ' +
@@ -707,7 +707,7 @@ describe('ReactPropTypes', function() {
       );
     });
 
-    it("should be implicitly optional and not warn without values", function() {
+    it('should be implicitly optional and not warn without values', function() {
       typeCheckPass(
         PropTypes.shape(PropTypes.shape({key: PropTypes.number})), null
       );
@@ -716,7 +716,7 @@ describe('ReactPropTypes', function() {
       );
     });
 
-    it("should warn for missing required values", function() {
+    it('should warn for missing required values', function() {
       typeCheckFail(
         PropTypes.shape({key: PropTypes.number}).isRequired,
         null,
@@ -738,7 +738,7 @@ describe('ReactPropTypes', function() {
 
     it('should have been called with the right params', function() {
       var spy = jasmine.createSpy();
-      var Component = React.createClass({
+      Component = React.createClass({
         propTypes: {num: spy},
 
         render: function() {
@@ -756,7 +756,7 @@ describe('ReactPropTypes', function() {
 
     it('should have been called even if the prop is not present', function() {
       var spy = jasmine.createSpy();
-      var Component = React.createClass({
+      Component = React.createClass({
         propTypes: {num: spy},
 
         render: function() {
@@ -778,7 +778,7 @@ describe('ReactPropTypes', function() {
           }
         }
       );
-      var Component = React.createClass({
+      Component = React.createClass({
         propTypes: {num: spy},
 
         render: function() {
@@ -790,7 +790,8 @@ describe('ReactPropTypes', function() {
       instance = ReactTestUtils.renderIntoDocument(instance);
       expect(console.error.argsForCall.length).toBe(1);
       expect(console.error.argsForCall[0][0]).toBe(
-      'Warning: Failed propType: num must be 5!');
+        'Warning: Failed propType: num must be 5!'
+      );
     });
 
     it('should not warn if the validator returned null',
@@ -800,7 +801,7 @@ describe('ReactPropTypes', function() {
             return null;
           }
         );
-        var Component = React.createClass({
+        Component = React.createClass({
           propTypes: {num: spy},
 
           render: function() {

--- a/src/isomorphic/deprecated/__tests__/cloneWithProps-test.js
+++ b/src/isomorphic/deprecated/__tests__/cloneWithProps-test.js
@@ -15,8 +15,6 @@ require('mock-modules')
   .dontMock('cloneWithProps')
   .dontMock('emptyObject');
 
-var mocks = require('mocks');
-
 var React;
 var ReactTestUtils;
 

--- a/src/isomorphic/modern/class/__tests__/ReactClassEquivalence-test.js
+++ b/src/isomorphic/modern/class/__tests__/ReactClassEquivalence-test.js
@@ -9,6 +9,8 @@
  * @emails react-core
  */
 
+'use strict';
+
 var MetaMatchers = require('MetaMatchers');
 
 describe('ReactClassEquivalence', function() {

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElement-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElement-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-var mocks;
-
 var React;
 var ReactTestUtils;
 
@@ -22,12 +20,12 @@ describe('ReactJSXElement', function() {
   beforeEach(function() {
     require('mock-modules').dumpCache();
 
-    mocks = require('mocks');
-
     React = require('React');
     ReactTestUtils = require('ReactTestUtils');
     Component = class {
-      render() { return <div />; }
+      render() {
+        return <div />;
+      }
     };
   });
 
@@ -145,7 +143,7 @@ describe('ReactJSXElement', function() {
     expect(React.isValidElement(null)).toEqual(false);
     expect(React.isValidElement(true)).toEqual(false);
     expect(React.isValidElement({})).toEqual(false);
-    expect(React.isValidElement("string")).toEqual(false);
+    expect(React.isValidElement('string')).toEqual(false);
     expect(React.isValidElement(Component)).toEqual(false);
   });
 

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -29,7 +29,9 @@ describe('ReactJSXElementValidator', function() {
     ReactTestUtils = require('ReactTestUtils');
 
     Component = class {
-      render() { return <div />; }
+      render() {
+        return <div />;
+      }
     };
   });
 
@@ -40,7 +42,7 @@ describe('ReactJSXElementValidator', function() {
   it('warns for keys for arrays of elements in children position', function() {
     spyOn(console, 'error');
 
-    <Component>{[<Component />, <Component />]}</Component>;
+    void <Component>{[<Component />, <Component />]}</Component>;
 
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toContain(
@@ -55,7 +57,7 @@ describe('ReactJSXElementValidator', function() {
       render() {
         return <Component>{this.props.childSet}</Component>;
       }
-    };
+    }
 
     class ComponentWrapper {
       render() {
@@ -65,7 +67,7 @@ describe('ReactJSXElementValidator', function() {
           />
         );
       }
-    };
+    }
 
     ReactTestUtils.renderIntoDocument(<ComponentWrapper />);
 
@@ -92,7 +94,7 @@ describe('ReactJSXElementValidator', function() {
       }
     };
 
-    <Component>{iterable}</Component>;
+    void <Component>{iterable}</Component>;
 
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toContain(
@@ -103,7 +105,7 @@ describe('ReactJSXElementValidator', function() {
   it('does not warns for arrays of elements with keys', function() {
     spyOn(console, 'error');
 
-    <Component>{[<Component key="#1" />, <Component key="#2" />]}</Component>;
+    void <Component>{[<Component key="#1" />, <Component key="#2" />]}</Component>;
 
     expect(console.error.argsForCall.length).toBe(0);
   });
@@ -126,7 +128,7 @@ describe('ReactJSXElementValidator', function() {
       }
     };
 
-    <Component>{iterable}</Component>
+    void <Component>{iterable}</Component>;
 
     expect(console.error.argsForCall.length).toBe(0);
   });
@@ -134,7 +136,7 @@ describe('ReactJSXElementValidator', function() {
   it('warns for numeric keys on objects as children', function() {
     spyOn(console, 'error');
 
-    <Component>{frag({1: <Component />, 2: <Component />})}</Component>;
+    void <Component>{frag({1: <Component />, 2: <Component />})}</Component>;
 
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toContain(
@@ -158,7 +160,7 @@ describe('ReactJSXElementValidator', function() {
     };
     iterable.entries = iterable['@@iterator'];
 
-    <Component>{iterable}</Component>;
+    void <Component>{iterable}</Component>;
 
     expect(console.error.argsForCall.length).toBe(0);
   });
@@ -166,7 +168,7 @@ describe('ReactJSXElementValidator', function() {
   it('does not warn when the element is directly as children', function() {
     spyOn(console, 'error');
 
-    <Component><Component /><Component /></Component>;
+    void <Component><Component /><Component /></Component>;
 
     expect(console.error.argsForCall.length).toBe(0);
   });
@@ -174,7 +176,7 @@ describe('ReactJSXElementValidator', function() {
   it('does not warn when the child array contains non-elements', function() {
     spyOn(console, 'error');
 
-    <Component>{[ {}, {} ]}</Component>;
+    void <Component>{[ {}, {} ]}</Component>;
 
     expect(console.error.argsForCall.length).toBe(0);
   });
@@ -215,10 +217,10 @@ describe('ReactJSXElementValidator', function() {
     var Num = 123;
     var Div = 'div';
     spyOn(console, 'error');
-    <Undefined />;
-    <Null />;
-    <True />;
-    <Num />;
+    void <Undefined />;
+    void <Null />;
+    void <True />;
+    void <Num />;
     expect(console.error.calls.length).toBe(4);
     expect(console.error.calls[0].args[0]).toContain(
       'type should not be null, undefined, boolean, or number. It should be ' +
@@ -236,7 +238,7 @@ describe('ReactJSXElementValidator', function() {
       'type should not be null, undefined, boolean, or number. It should be ' +
       'a string (for DOM elements) or a ReactClass (for composite components).'
     );
-    <Div />;
+    void <Div />;
     expect(console.error.calls.length).toBe(4);
   });
 

--- a/src/renderers/dom/client/__tests__/ReactDOM-test.js
+++ b/src/renderers/dom/client/__tests__/ReactDOM-test.js
@@ -45,13 +45,13 @@ describe('ReactDOM', function() {
   });
   */
 
-  it("allows a DOM element to be used with a string", function() {
+  it('allows a DOM element to be used with a string', function() {
     var element = React.createElement('div', {className: 'foo'});
     var instance = ReactTestUtils.renderIntoDocument(element);
     expect(React.findDOMNode(instance).tagName).toBe('DIV');
   });
 
-  it("should allow children to be passed as an argument", function() {
+  it('should allow children to be passed as an argument', function() {
     var argDiv = ReactTestUtils.renderIntoDocument(
       div(null, 'child')
     );
@@ -59,7 +59,7 @@ describe('ReactDOM', function() {
     expect(argNode.innerHTML).toBe('child');
   });
 
-  it("should overwrite props.children with children argument", function() {
+  it('should overwrite props.children with children argument', function() {
     var conflictDiv = ReactTestUtils.renderIntoDocument(
       div({children: 'fakechild'}, 'child')
     );
@@ -71,7 +71,7 @@ describe('ReactDOM', function() {
    * We need to make sure that updates occur to the actual node that's in the
    * DOM, instead of a stale cache.
    */
-  it("should purge the DOM cache when removing nodes", function() {
+  it('should purge the DOM cache when removing nodes', function() {
     var myDiv = ReactTestUtils.renderIntoDocument(
       <div>
         <div key="theDog" className="dog" />,

--- a/src/renderers/dom/client/__tests__/ReactDOMIDOperations-test.js
+++ b/src/renderers/dom/client/__tests__/ReactDOMIDOperations-test.js
@@ -18,8 +18,8 @@ describe('ReactDOMIDOperations', function() {
   var keyOf = require('keyOf');
 
   it('should disallow updating special properties', function() {
-    spyOn(ReactMount, "getNode");
-    spyOn(DOMPropertyOperations, "setValueForProperty");
+    spyOn(ReactMount, 'getNode');
+    spyOn(DOMPropertyOperations, 'setValueForProperty');
 
     expect(function() {
       ReactDOMIDOperations.updatePropertyByID(
@@ -40,7 +40,7 @@ describe('ReactDOMIDOperations', function() {
 
   it('should update innerHTML and preserve whitespace', function() {
     var stubNode = document.createElement('div');
-    spyOn(ReactMount, "getNode").andReturn(stubNode);
+    spyOn(ReactMount, 'getNode').andReturn(stubNode);
 
     var html = '\n  \t  <span>  \n  testContent  \t  </span>  \n  \t';
 

--- a/src/renderers/dom/client/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMount-test.js
@@ -169,25 +169,27 @@ describe('ReactMount', function() {
     );
   });
 
-  (WebComponents === undefined ? xit : it)
-      ('should allow mounting/unmounting to document fragment container', function() {
-    var shadowRoot;
-    var proto = Object.create(HTMLElement.prototype, {
-      createdCallback: {
-        value: function() {
+  if (WebComponents !== undefined) {
+    it('should allow mounting/unmounting to document fragment container',
+        function() {
+      var shadowRoot;
+      var proto = Object.create(HTMLElement.prototype, {
+        createdCallback: {
+          value: function() {
             shadowRoot = this.createShadowRoot();
             React.render(<div>Hi, from within a WC!</div>, shadowRoot);
             expect(shadowRoot.firstChild.tagName).toBe('DIV');
             React.render(<span>Hi, from within a WC!</span>, shadowRoot);
             expect(shadowRoot.firstChild.tagName).toBe('SPAN');
+          }
         }
-      }
+      });
+      proto.unmount = function() {
+        React.unmountComponentAtNode(shadowRoot);
+      };
+      document.registerElement('x-foo', {prototype: proto});
+      var element = document.createElement('x-foo');
+      element.unmount();
     });
-    proto.unmount = function() {
-      React.unmountComponentAtNode(shadowRoot);
-    };
-    document.registerElement('x-foo', {prototype: proto});
-    var element = document.createElement('x-foo');
-    element.unmount();
-  });
+  }
 });

--- a/src/renderers/dom/client/__tests__/ReactMountDestruction-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMountDestruction-test.js
@@ -14,7 +14,7 @@
 var React = require('React');
 
 describe('ReactMount', function() {
-  it("should destroy a react root upon request", function() {
+  it('should destroy a react root upon request', function() {
     var mainContainerDiv = document.createElement('div');
     document.body.appendChild(mainContainerDiv);
 

--- a/src/renderers/dom/client/__tests__/findDOMNode-test.js
+++ b/src/renderers/dom/client/__tests__/findDOMNode-test.js
@@ -34,14 +34,18 @@ describe('findDOMNode', function() {
   });
 
   it('findDOMNode should reject random objects', function() {
-    expect(function() {React.findDOMNode({foo: 'bar'});})
+    expect(function() {
+      React.findDOMNode({foo: 'bar'});
+    })
       .toThrow('Invariant Violation: Element appears to be neither ' +
         'ReactComponent nor DOMNode (keys: foo)'
       );
   });
 
   it('findDOMNode should reject unmounted objects with render func', function() {
-    expect(function() {React.findDOMNode({render: function() {}});})
+    expect(function() {
+      React.findDOMNode({render: function() {}});
+    })
       .toThrow('Invariant Violation: Component (with keys: render) ' +
         'contains `render` method but is not mounted in the DOM'
       );

--- a/src/renderers/dom/client/eventPlugins/__tests__/AnalyticsEventPlugin-test.js
+++ b/src/renderers/dom/client/eventPlugins/__tests__/AnalyticsEventPlugin-test.js
@@ -18,7 +18,6 @@ describe('AnalyticsEventPlugin', function() {
   var EventPluginHub;
   var EventPluginRegistry;
   var React;
-  var ReactBrowserEventEmitter;
   var ReactTestUtils;
 
   var DefaultEventPluginOrder;
@@ -32,7 +31,6 @@ describe('AnalyticsEventPlugin', function() {
     EventPluginHub = require('EventPluginHub');
     EventPluginRegistry = require('EventPluginRegistry');
     React = require('React');
-    ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
     ReactTestUtils = require('ReactTestUtils');
 
     EventPluginRegistry._resetEventPlugins();
@@ -65,7 +63,7 @@ describe('AnalyticsEventPlugin', function() {
         return (
           <div ref="testDiv"
             data-analytics-id={TEST_ANALYTICS_ID}
-            data-analytics-events='click,doubleClick'>
+            data-analytics-events="click,doubleClick">
             Test
           </div>
         );
@@ -118,8 +116,8 @@ describe('AnalyticsEventPlugin', function() {
       render: function() {
         return (
           <div ref="testDiv"
-            data-analytics-id='test_invalid_events'
-            data-analytics-events='click,123'>
+            data-analytics-id="test_invalid_events"
+            data-analytics-events="click,123">
             Test
           </div>
         );

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
@@ -56,7 +56,7 @@ describe('ReactDOMInput', function() {
   it('should display "foobar" for `defaultValue` of `objToString`', function() {
     var objToString = {
       toString: function() {
-        return "foobar";
+        return 'foobar';
       }
     };
 
@@ -86,7 +86,7 @@ describe('ReactDOMInput', function() {
     expect(node.value).toEqual('true');
   });
 
-  it("should allow setting `value` to `false`", function() {
+  it('should allow setting `value` to `false`', function() {
     var stub = <input type="text" value="yolo" onChange={emptyFunction} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
     var node = React.findDOMNode(stub);
@@ -106,7 +106,7 @@ describe('ReactDOMInput', function() {
 
     var objToString = {
       toString: function() {
-        return "foobar";
+        return 'foobar';
       }
     };
 

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMSelect-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMSelect-test.js
@@ -154,7 +154,7 @@ describe('ReactDOMSelect', function() {
   });
 
   it('should reset child options selected when they are changed and `value` is set', function() {
-    var stub = <select multiple={true} value={["a", "b"]} />;
+    var stub = <select multiple={true} value={['a', 'b']} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
 
     stub.setProps({
@@ -174,7 +174,7 @@ describe('ReactDOMSelect', function() {
 
   it('should allow setting `value` with `objectToString`', function() {
     var objectToString = {
-      animal: "giraffe",
+      animal: 'giraffe',
       toString: function() {
         return this.animal;
       }
@@ -194,7 +194,7 @@ describe('ReactDOMSelect', function() {
     expect(node.options[2].selected).toBe(false);  // gorilla
 
     // Changing the `value` prop should change the selected options.
-    objectToString.animal = "monkey";
+    objectToString.animal = 'monkey';
     stub.forceUpdate();
 
     expect(node.options[0].selected).toBe(true);  // monkey

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMTextarea-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMTextarea-test.js
@@ -67,7 +67,7 @@ describe('ReactDOMTextarea', function() {
   it('should display "foobar" for `defaultValue` of `objToString`', function() {
     var objToString = {
       toString: function() {
-        return "foobar";
+        return 'foobar';
       }
     };
 
@@ -136,7 +136,7 @@ describe('ReactDOMTextarea', function() {
 
     var objToString = {
       toString: function() {
-        return "foo";
+        return 'foo';
       }
     };
     stub.replaceProps({value: objToString, onChange: emptyFunction});
@@ -186,7 +186,7 @@ describe('ReactDOMTextarea', function() {
     spyOn(console, 'error');
     var obj = {
       toString: function() {
-        return "sharkswithlasers";
+        return 'sharkswithlasers';
       }
     };
     var node = React.findDOMNode(renderTextarea(<textarea>{obj}</textarea>));

--- a/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
@@ -14,7 +14,6 @@
 require('mock-modules')
   .dontMock('ExecutionEnvironment')
   .dontMock('React')
-  .dontMock('ReactMount')
   .dontMock('ReactServerRendering')
   .dontMock('ReactTestUtils')
   .dontMock('ReactMarkupChecksum');
@@ -24,7 +23,6 @@ var mocks = require('mocks');
 var ExecutionEnvironment;
 var React;
 var ReactMarkupChecksum;
-var ReactMount;
 var ReactReconcileTransaction;
 var ReactTestUtils;
 var ReactServerRendering;
@@ -36,7 +34,6 @@ describe('ReactServerRendering', function() {
     require('mock-modules').dumpCache();
     React = require('React');
     ReactMarkupChecksum = require('ReactMarkupChecksum');
-    ReactMount = require('ReactMount');
     ReactTestUtils = require('ReactTestUtils');
     ReactReconcileTransaction = require('ReactReconcileTransaction');
 

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -212,7 +212,11 @@ describe('DOMPropertyOperations', function() {
     it('should convert attribute values to string first', function() {
       // Browsers default to this behavior, but some test environments do not.
       // This ensures that we have consistent behavior.
-      var obj = {toString: function() { return '<html>'; }};
+      var obj = {
+        toString: function() {
+          return '<html>';
+        }
+      };
       DOMPropertyOperations.setValueForProperty(stubNode, 'role', obj);
       expect(stubNode.getAttribute('role')).toBe('<html>');
     });

--- a/src/renderers/dom/shared/__tests__/Danger-test.js
+++ b/src/renderers/dom/shared/__tests__/Danger-test.js
@@ -99,7 +99,7 @@ describe('Danger', function() {
         'Invariant Violation: dangerouslyRenderMarkup(...): Missing markup.'
       );
 
-      spyOn(console, "error");
+      spyOn(console, 'error');
 
       var renderedMarkup = Danger.dangerouslyRenderMarkup(['<p></p><p></p>']);
       var args = console.error.argsForCall[0];

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -25,7 +25,7 @@ describe('ReactDOMComponent', function() {
       ReactTestUtils = require('ReactTestUtils');
     });
 
-    it("should handle className", function() {
+    it('should handle className', function() {
       var container = document.createElement('div');
       React.render(<div style={{}} />, container);
 
@@ -37,7 +37,7 @@ describe('ReactDOMComponent', function() {
       expect(container.firstChild.className).toEqual('');
     });
 
-    it("should gracefully handle various style value types", function() {
+    it('should gracefully handle various style value types', function() {
       var container = document.createElement('div');
       React.render(<div style={{}} />, container);
       var stubStyle = container.firstChild.style;
@@ -59,7 +59,7 @@ describe('ReactDOMComponent', function() {
     });
 
     // TODO: (poshannessy) deprecate this pattern.
-    it("should update styles when mutating style object", function() {
+    it('should update styles when mutating style object', function() {
       // not actually used. Just to suppress the style mutation warning
       spyOn(console, 'error');
 
@@ -138,7 +138,7 @@ describe('ReactDOMComponent', function() {
       expect(console.error.argsForCall.length).toBe(2);
     });
 
-    it("should update styles if initially null", function() {
+    it('should update styles if initially null', function() {
       var styles = null;
       var container = document.createElement('div');
       React.render(<div style={styles} />, container);
@@ -151,7 +151,7 @@ describe('ReactDOMComponent', function() {
       expect(stubStyle.display).toEqual('block');
     });
 
-    it("should update styles if updated to null multiple times", function() {
+    it('should update styles if updated to null multiple times', function() {
       var styles = null;
       var container = document.createElement('div');
       React.render(<div style={styles} />, container);
@@ -172,25 +172,25 @@ describe('ReactDOMComponent', function() {
       expect(stubStyle.display).toEqual('');
     });
 
-    it("should remove attributes", function() {
+    it('should remove attributes', function() {
       var container = document.createElement('div');
-      React.render(<img height='17' />, container);
+      React.render(<img height="17" />, container);
 
       expect(container.firstChild.hasAttribute('height')).toBe(true);
       React.render(<img />, container);
       expect(container.firstChild.hasAttribute('height')).toBe(false);
     });
 
-    it("should remove properties", function() {
+    it('should remove properties', function() {
       var container = document.createElement('div');
-      React.render(<div className='monkey' />, container);
+      React.render(<div className="monkey" />, container);
 
       expect(container.firstChild.className).toEqual('monkey');
       React.render(<div />, container);
       expect(container.firstChild.className).toEqual('');
     });
 
-    it("should clear a single style prop when changing 'style'", function() {
+    it('should clear a single style prop when changing `style`', function() {
       var styles = {display: 'none', color: 'red'};
       var container = document.createElement('div');
       React.render(<div style={styles} />, container);
@@ -203,7 +203,7 @@ describe('ReactDOMComponent', function() {
       expect(stubStyle.color).toEqual('green');
     });
 
-    it("should clear all the styles when removing 'style'", function() {
+    it('should clear all the styles when removing `style`', function() {
       var styles = {display: 'none', color: 'red'};
       var container = document.createElement('div');
       React.render(<div style={styles} />, container);
@@ -215,7 +215,7 @@ describe('ReactDOMComponent', function() {
       expect(stubStyle.color).toEqual('');
     });
 
-    it("should update styles when 'style' changes from null to object", function() {
+    it('should update styles when `style` changes from null to object', function() {
       var container = document.createElement('div');
       var styles = {color: 'red'};
       React.render(<div style={styles} />, container);
@@ -226,7 +226,7 @@ describe('ReactDOMComponent', function() {
       expect(stubStyle.color).toEqual('red');
     });
 
-    it("should empty element when removing innerHTML", function() {
+    it('should empty element when removing innerHTML', function() {
       var container = document.createElement('div');
       React.render(<div dangerouslySetInnerHTML={{__html: ':)'}} />, container);
 
@@ -235,7 +235,7 @@ describe('ReactDOMComponent', function() {
       expect(container.firstChild.innerHTML).toEqual('');
     });
 
-    it("should transition from string content to innerHTML", function() {
+    it('should transition from string content to innerHTML', function() {
       var container = document.createElement('div');
       React.render(<div>hello</div>, container);
 
@@ -247,7 +247,7 @@ describe('ReactDOMComponent', function() {
       expect(container.firstChild.innerHTML).toEqual('goodbye');
     });
 
-    it("should transition from innerHTML to string content", function() {
+    it('should transition from innerHTML to string content', function() {
       var container = document.createElement('div');
       React.render(
         <div dangerouslySetInnerHTML={{__html: 'bonjour'}} />,
@@ -259,7 +259,7 @@ describe('ReactDOMComponent', function() {
       expect(container.firstChild.innerHTML).toEqual('adieu');
     });
 
-    it("should not incur unnecessary DOM mutations", function() {
+    it('should not incur unnecessary DOM mutations', function() {
       var container = document.createElement('div');
       React.render(<div value="" />, container);
 
@@ -287,7 +287,7 @@ describe('ReactDOMComponent', function() {
     var genMarkup;
 
     function quoteRegexp(str) {
-      return (str + '').replace(/([.?*+\^$\[\]\\(){}|-])/g, "\\$1");
+      return (str + '').replace(/([.?*+\^$\[\]\\(){}|-])/g, '\\$1');
     }
 
     beforeEach(function() {
@@ -315,7 +315,7 @@ describe('ReactDOMComponent', function() {
       this.addMatchers({
         toHaveAttribute: function(attr, value) {
           var expected = '(?:^|\\s)' + attr + '=[\\\'"]';
-          if (typeof value != 'undefined') {
+          if (typeof value !== 'undefined') {
             expected += quoteRegexp(value) + '[\\\'"]';
           }
           return this.actual.match(new RegExp(expected));
@@ -323,13 +323,13 @@ describe('ReactDOMComponent', function() {
       });
     });
 
-    it("should generate the correct markup with className", function() {
+    it('should generate the correct markup with className', function() {
       expect(genMarkup({className: 'a'})).toHaveAttribute('class', 'a');
       expect(genMarkup({className: 'a b'})).toHaveAttribute('class', 'a b');
       expect(genMarkup({className: ''})).toHaveAttribute('class', '');
     });
 
-    it("should escape style names and values", function() {
+    it('should escape style names and values', function() {
       expect(genMarkup({
         style: {'b&ckground': '<3'}
       })).toHaveAttribute('style', 'b&amp;ckground:&lt;3;');
@@ -340,7 +340,7 @@ describe('ReactDOMComponent', function() {
     var genMarkup;
 
     function quoteRegexp(str) {
-      return (str + '').replace(/([.?*+\^$\[\]\\(){}|-])/g, "\\$1");
+      return (str + '').replace(/([.?*+\^$\[\]\\(){}|-])/g, '\\$1');
     }
 
     beforeEach(function() {
@@ -368,7 +368,7 @@ describe('ReactDOMComponent', function() {
       });
     });
 
-    it("should handle dangerouslySetInnerHTML", function() {
+    it('should handle dangerouslySetInnerHTML', function() {
       var innerHTML = {__html: 'testContent'};
       expect(
         genMarkup({dangerouslySetInnerHTML: innerHTML})
@@ -399,13 +399,13 @@ describe('ReactDOMComponent', function() {
         var stubComponent = new StubNativeComponent({
           type: StubNativeComponent,
           props: props,
-          _owner: null,
+          _owner: null
         });
         return stubComponent.mountComponent('test', transaction, {});
       };
     });
 
-    it("should warn against children for void elements", function() {
+    it('should warn against children for void elements', function() {
       spyOn(console, 'error');
 
       var container = document.createElement('div');
@@ -416,7 +416,7 @@ describe('ReactDOMComponent', function() {
       expect(console.error.argsForCall[0][0]).toContain('void element');
     });
 
-    it("should warn against dangerouslySetInnerHTML for void elements", function() {
+    it('should warn against dangerouslySetInnerHTML for void elements', function() {
       spyOn(console, 'error');
 
       var container = document.createElement('div');
@@ -430,7 +430,7 @@ describe('ReactDOMComponent', function() {
       expect(console.error.argsForCall[0][0]).toContain('void element');
     });
 
-    it("should treat menuitem as a void element but still create the closing tag", function() {
+    it('should treat menuitem as a void element but still create the closing tag', function() {
       spyOn(console, 'error');
 
       var container = document.createElement('div');
@@ -445,7 +445,7 @@ describe('ReactDOMComponent', function() {
       expect(console.error.argsForCall[0][0]).toContain('void element');
     });
 
-    it("should validate against multiple children props", function() {
+    it('should validate against multiple children props', function() {
       expect(function() {
         mountComponent({children: '', dangerouslySetInnerHTML: ''});
       }).toThrow(
@@ -490,14 +490,14 @@ describe('ReactDOMComponent', function() {
       }).not.toThrow();
     });
 
-    it("should warn about contentEditable and children", function() {
+    it('should warn about contentEditable and children', function() {
       spyOn(console, 'error');
       mountComponent({contentEditable: true, children: ''});
       expect(console.error.argsForCall.length).toBe(1);
       expect(console.error.argsForCall[0][0]).toContain('contentEditable');
     });
 
-    it("should validate against invalid styles", function() {
+    it('should validate against invalid styles', function() {
       expect(function() {
         mountComponent({style: 'display: none'});
       }).toThrow(
@@ -507,8 +507,7 @@ describe('ReactDOMComponent', function() {
       );
     });
 
-    it("should execute custom event plugin listening behavior", function() {
-      var React = require('React');
+    it('should execute custom event plugin listening behavior', function() {
       var SimpleEventPlugin = require('SimpleEventPlugin');
 
       SimpleEventPlugin.didPutListener = mocks.getMockFunction();
@@ -527,8 +526,7 @@ describe('ReactDOMComponent', function() {
       expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(1);
     });
 
-    it("should handle null and missing properly with event hooks", function() {
-      var React = require('React');
+    it('should handle null and missing properly with event hooks', function() {
       var SimpleEventPlugin = require('SimpleEventPlugin');
 
       SimpleEventPlugin.didPutListener = mocks.getMockFunction();
@@ -570,7 +568,7 @@ describe('ReactDOMComponent', function() {
       container = document.createElement('div');
     });
 
-    it("should warn against children for void elements", function() {
+    it('should warn against children for void elements', function() {
       spyOn(console, 'error');
 
       React.render(<input />, container);
@@ -580,7 +578,7 @@ describe('ReactDOMComponent', function() {
       expect(console.error.argsForCall[0][0]).toContain('void element');
     });
 
-    it("should warn against dangerouslySetInnerHTML for void elements", function() {
+    it('should warn against dangerouslySetInnerHTML for void elements', function() {
       spyOn(console, 'error');
 
       React.render(<input />, container);
@@ -593,7 +591,7 @@ describe('ReactDOMComponent', function() {
       expect(console.error.argsForCall[0][0]).toContain('void element');
     });
 
-    it("should validate against multiple children props", function() {
+    it('should validate against multiple children props', function() {
       React.render(<div></div>, container);
 
       expect(function() {
@@ -607,7 +605,7 @@ describe('ReactDOMComponent', function() {
       );
     });
 
-    it("should warn about contentEditable and children", function() {
+    it('should warn about contentEditable and children', function() {
       spyOn(console, 'error');
       React.render(
         <div contentEditable><div /></div>,
@@ -617,7 +615,7 @@ describe('ReactDOMComponent', function() {
       expect(console.error.argsForCall[0][0]).toContain('contentEditable');
     });
 
-    it("should validate against invalid styles", function() {
+    it('should validate against invalid styles', function() {
       React.render(<div></div>, container);
 
       expect(function() {
@@ -629,7 +627,7 @@ describe('ReactDOMComponent', function() {
       );
     });
 
-    it("should properly escape text content and attributes values", function() {
+    it('should properly escape text content and attributes values', function() {
       expect(
         React.renderToStaticMarkup(
           React.DOM.div({
@@ -648,7 +646,7 @@ describe('ReactDOMComponent', function() {
   });
 
   describe('unmountComponent', function() {
-    it("should clean up listeners", function() {
+    it('should clean up listeners', function() {
       var React = require('React');
       var ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
       var ReactMount = require('ReactMount');
@@ -784,10 +782,14 @@ describe('ReactDOMComponent', function() {
         render: () => <Row />
       });
       var Table = React.createClass({
-        render: function() { return <table>{this.props.children}</table>; }
+        render: function() {
+          return <table>{this.props.children}</table>;
+        }
       });
       var FancyTable = React.createClass({
-        render: function() { return <Table>{this.props.children}</Table>; }
+        render: function() {
+          return <Table>{this.props.children}</Table>;
+        }
       });
 
       var Viz1 = React.createClass({
@@ -833,7 +835,9 @@ describe('ReactDOMComponent', function() {
       );
 
       var Link = React.createClass({
-        render: function() { return <a>{this.props.children}</a>; }
+        render: function() {
+          return <a>{this.props.children}</a>;
+        }
       });
       ReactTestUtils.renderIntoDocument(<Link><div><Link /></div></Link>);
       expect(console.error.calls.length).toBe(6);

--- a/src/renderers/shared/event/__tests__/EventPluginHub-test.js
+++ b/src/renderers/shared/event/__tests__/EventPluginHub-test.js
@@ -26,7 +26,7 @@ describe('EventPluginHub', function() {
     isEventSupported.mockReturnValueOnce(false);
   });
 
-  it("should prevent non-function listeners", function() {
+  it('should prevent non-function listeners', function() {
     expect(function() {
       EventPluginHub.putListener(1, 'onClick', 'not a function');
     }).toThrow(

--- a/src/renderers/shared/reconciler/__tests__/ReactComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactComponent-test.js
@@ -12,19 +12,15 @@
 'use strict';
 
 var React;
-var ReactInstanceMap;
 var ReactTestUtils;
 
 var mocks;
-var reactComponentExpect;
 
 describe('ReactComponent', function() {
   beforeEach(function() {
     mocks = require('mocks');
     React = require('React');
-    ReactInstanceMap = require('ReactInstanceMap');
     ReactTestUtils = require('ReactTestUtils');
-    reactComponentExpect = require('reactComponentExpect');
   });
 
   it('should throw on invalid render targets', function() {

--- a/src/renderers/shared/reconciler/__tests__/ReactComponentLifeCycle-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactComponentLifeCycle-test.js
@@ -207,7 +207,7 @@ describe('ReactComponentLifeCycle', function() {
   it('throws when accessing state in componentWillMount', function() {
     var StatefulComponent = React.createClass({
       componentWillMount: function() {
-        this.state.yada;
+        void this.state.yada;
       },
       render: function() {
         return (
@@ -271,7 +271,7 @@ describe('ReactComponentLifeCycle', function() {
         expect(this.isMounted()).toBeTruthy();
       },
       render: function() {
-        expect(this.isMounted()).toBeFalsy()
+        expect(this.isMounted()).toBeFalsy();
         return <div/>;
       }
     });
@@ -530,7 +530,7 @@ describe('ReactComponentLifeCycle', function() {
 
     // Since `instance` is a root component, we can set its props. This also
     // makes Tooltip rerender the tooltip component, which shouldn't throw.
-    instance.setProps({text: "dos", tooltipText: "two"});
+    instance.setProps({text: 'dos', tooltipText: 'two'});
   });
 
   it('should not allow setProps() called on an unmounted element',

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -326,7 +326,7 @@ describe('ReactCompositeComponent', function() {
         expect(() => {
           this.setState({value: 2}, function() {
             cbCalled = true;
-          })
+          });
         }).not.toThrow();
       },
       render: function() {
@@ -515,7 +515,7 @@ describe('ReactCompositeComponent', function() {
 
       render: function() {
         return <div>{this.context.foo}</div>;
-      },
+      }
     });
 
     var component = ReactTestUtils.renderIntoDocument(<Parent />);
@@ -632,7 +632,7 @@ describe('ReactCompositeComponent', function() {
 
     expect(parentInstance.state.flag).toBe(false);
     ReactUpdates.batchedUpdates(function() {
-        parentInstance.setState({flag: true});
+      parentInstance.setState({flag: true});
     });
     expect(parentInstance.state.flag).toBe(true);
 
@@ -852,7 +852,7 @@ describe('ReactCompositeComponent', function() {
 
       getChildContext: function() {
         return {
-          foo: "bar"
+          foo: 'bar'
         };
       },
 

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentError-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentError-test.js
@@ -12,7 +12,6 @@
 'use strict';
 
 var React = require('React');
-var ReactTestUtils = require('ReactTestUtils');
 var ReactErrorUtils = require('ReactErrorUtils');
 
 describe('ReactCompositeComponent-error', function() {
@@ -26,7 +25,7 @@ describe('ReactCompositeComponent-error', function() {
       }
     });
 
-    new Component();
+    void new Component();
 
     expect(ReactErrorUtils.guard.mostRecentCall.args[1])
       .toEqual('Component.someHandler');

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentNestedState-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentNestedState-test.js
@@ -58,7 +58,7 @@ describe('ReactCompositeComponentNestedState-state', function() {
         this.setState(function(state, props) {
           this.props.logger('setState-this', this.state.hue, this.props.color);
           this.props.logger('setState-args', state.hue, props.color);
-          return {hue: shade + ' ' + props.color}
+          return {hue: shade + ' ' + props.color};
         }, function() {
           this.props.logger('after-setState', this.state.hue, this.props.color);
         });
@@ -79,7 +79,7 @@ describe('ReactCompositeComponentNestedState-state', function() {
           <button onClick={this.handleHue.bind(this, 'light', 'green')}>
             Light Green
           </button>
-        </div>
+        </div>;
       }
     });
 
@@ -88,7 +88,7 @@ describe('ReactCompositeComponentNestedState-state', function() {
 
     var logger = mocks.getMockFunction();
 
-    var instance = React.render(
+    void React.render(
       <ParentComponent logger={logger} />,
       container
     );

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentState-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentState-test.js
@@ -14,9 +14,6 @@
 var mocks = require('mocks');
 
 var React;
-var ReactInstanceMap;
-var ReactTestUtils;
-var reactComponentExpect;
 
 var TestComponent;
 
@@ -24,9 +21,6 @@ describe('ReactCompositeComponent-state', function() {
 
   beforeEach(function() {
     React = require('React');
-    ReactInstanceMap = require('ReactInstanceMap');
-    ReactTestUtils = require('ReactTestUtils');
-    reactComponentExpect = require('reactComponentExpect');
 
     TestComponent = React.createClass({
       peekAtState: function(from, state) {

--- a/src/renderers/shared/reconciler/__tests__/ReactEmptyComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactEmptyComponent-test.js
@@ -235,7 +235,9 @@ describe('ReactEmptyComponent', function() {
   it('does not break when updating during mount', function() {
     var Child = React.createClass({
       componentDidMount() {
-        this.props.onMount && this.props.onMount();
+        if (this.props.onMount) {
+          this.props.onMount();
+        }
       },
       render() {
         if (!this.props.visible) {
@@ -262,7 +264,7 @@ describe('ReactEmptyComponent', function() {
     });
 
     expect(function() {
-      ReactTestUtils.renderIntoDocument(<Parent/>)
+      ReactTestUtils.renderIntoDocument(<Parent />);
     }).not.toThrow();
   });
 });

--- a/src/renderers/shared/reconciler/__tests__/ReactIdentity-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactIdentity-test.js
@@ -107,12 +107,12 @@ describe('ReactIdentity', function() {
     var Wrapper = React.createClass({
 
       render: function() {
-        var span1 = <span ref="span1" key={key} />;
-        var span2 = <span ref="span2" />;
+        var s1 = <span ref="span1" key={key} />;
+        var s2 = <span ref="span2" />;
 
         var map = {};
-        map[key] = span2;
-        return <div>{[span1, frag(map)]}</div>;
+        map[key] = s2;
+        return <div>{[s1, frag(map)]}</div>;
       }
 
     });
@@ -132,7 +132,10 @@ describe('ReactIdentity', function() {
 
   it('should allow any character as a key, in a detached parent', function() {
     var detachedContainer = document.createElement('div');
-    renderAComponentWithKeyIntoContainer("<'WEIRD/&\\key'>", detachedContainer);
+    renderAComponentWithKeyIntoContainer(
+      "<'WEIRD/&\\key'>",
+      detachedContainer
+    );
   });
 
   it('should allow any character as a key, in an attached parent', function() {
@@ -141,7 +144,10 @@ describe('ReactIdentity', function() {
     var attachedContainer = document.createElement('div');
     document.body.appendChild(attachedContainer);
 
-    renderAComponentWithKeyIntoContainer("<'WEIRD/&\\key'>", attachedContainer);
+    renderAComponentWithKeyIntoContainer(
+      "<'WEIRD/&\\key'>",
+      attachedContainer
+    );
 
     document.body.removeChild(attachedContainer);
   });

--- a/src/renderers/shared/reconciler/__tests__/ReactInstanceHandles-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactInstanceHandles-test.js
@@ -141,7 +141,7 @@ describe('ReactInstanceHandles', function() {
       expect(function() {
         ReactMount.findComponentRoot(
           parentNode,
-          ReactMount.getID(childNodeB) + ":junk"
+          ReactMount.getID(childNodeB) + ':junk'
         );
       }).toThrow(
         'Invariant Violation: findComponentRoot(..., .0.1:0:junk): ' +
@@ -177,14 +177,14 @@ describe('ReactInstanceHandles', function() {
   });
 
   describe('traverseTwoPhase', function() {
-    it("should not traverse when traversing outside DOM", function() {
+    it('should not traverse when traversing outside DOM', function() {
       var targetID = '';
       var expectedAggregation = [];
       ReactInstanceHandles.traverseTwoPhase(targetID, argAggregator, ARG);
       expect(aggregatedArgs).toEqual(expectedAggregation);
     });
 
-    it("should traverse two phase across component boundary", function() {
+    it('should traverse two phase across component boundary', function() {
       var parent = renderParentIntoDocument();
       var targetID = getNodeID(parent.refs.P_P1_C1.refs.DIV_1);
       var expectedAggregation = [
@@ -202,7 +202,7 @@ describe('ReactInstanceHandles', function() {
       expect(aggregatedArgs).toEqual(expectedAggregation);
     });
 
-    it("should traverse two phase at shallowest node", function() {
+    it('should traverse two phase at shallowest node', function() {
       var parent = renderParentIntoDocument();
       var targetID = getNodeID(parent.refs.P);
       var expectedAggregation = [
@@ -215,7 +215,7 @@ describe('ReactInstanceHandles', function() {
   });
 
   describe('traverseEnterLeave', function() {
-    it("should not traverse when enter/leaving outside DOM", function() {
+    it('should not traverse when enter/leaving outside DOM', function() {
       var targetID = '';
       var expectedAggregation = [];
       ReactInstanceHandles.traverseEnterLeave(
@@ -224,7 +224,7 @@ describe('ReactInstanceHandles', function() {
       expect(aggregatedArgs).toEqual(expectedAggregation);
     });
 
-    it("should not traverse if enter/leave the same node", function() {
+    it('should not traverse if enter/leave the same node', function() {
       var parent = renderParentIntoDocument();
       var leaveID = getNodeID(parent.refs.P_P1_C1.refs.DIV_1);
       var enterID = getNodeID(parent.refs.P_P1_C1.refs.DIV_1);
@@ -235,7 +235,7 @@ describe('ReactInstanceHandles', function() {
       expect(aggregatedArgs).toEqual(expectedAggregation);
     });
 
-    it("should traverse enter/leave to sibling - avoids parent", function() {
+    it('should traverse enter/leave to sibling - avoids parent', function() {
       var parent = renderParentIntoDocument();
       var leaveID = getNodeID(parent.refs.P_P1_C1.refs.DIV_1);
       var enterID = getNodeID(parent.refs.P_P1_C1.refs.DIV_2);
@@ -250,7 +250,7 @@ describe('ReactInstanceHandles', function() {
       expect(aggregatedArgs).toEqual(expectedAggregation);
     });
 
-    it("should traverse enter/leave to parent - avoids parent", function() {
+    it('should traverse enter/leave to parent - avoids parent', function() {
       var parent = renderParentIntoDocument();
       var leaveID = getNodeID(parent.refs.P_P1_C1.refs.DIV_1);
       var enterID = getNodeID(parent.refs.P_P1_C1.refs.DIV);
@@ -263,7 +263,7 @@ describe('ReactInstanceHandles', function() {
       expect(aggregatedArgs).toEqual(expectedAggregation);
     });
 
-    it("should enter from the window", function() {
+    it('should enter from the window', function() {
       var parent = renderParentIntoDocument();
       var leaveID = ''; // From the window or outside of the React sandbox.
       var enterID = getNodeID(parent.refs.P_P1_C1.refs.DIV);
@@ -278,7 +278,7 @@ describe('ReactInstanceHandles', function() {
       expect(aggregatedArgs).toEqual(expectedAggregation);
     });
 
-    it("should enter from the window to the shallowest", function() {
+    it('should enter from the window to the shallowest', function() {
       var parent = renderParentIntoDocument();
       var leaveID = ''; // From the window or outside of the React sandbox.
       var enterID = getNodeID(parent.refs.P);
@@ -291,7 +291,7 @@ describe('ReactInstanceHandles', function() {
       expect(aggregatedArgs).toEqual(expectedAggregation);
     });
 
-    it("should leave to the window", function() {
+    it('should leave to the window', function() {
       var parent = renderParentIntoDocument();
       var enterID = ''; // From the window or outside of the React sandbox.
       var leaveID = getNodeID(parent.refs.P_P1_C1.refs.DIV);
@@ -306,7 +306,7 @@ describe('ReactInstanceHandles', function() {
       expect(aggregatedArgs).toEqual(expectedAggregation);
     });
 
-    it("should leave to the window from the shallowest", function() {
+    it('should leave to the window from the shallowest', function() {
       var parent = renderParentIntoDocument();
       var enterID = ''; // From the window or outside of the React sandbox.
       var leaveID = getNodeID(parent.refs.P_P1_C1.refs.DIV);
@@ -323,7 +323,7 @@ describe('ReactInstanceHandles', function() {
   });
 
   describe('getNextDescendantID', function() {
-    it("should return next descendent from window", function() {
+    it('should return next descendent from window', function() {
       var parent = renderParentIntoDocument();
       expect(
         ReactInstanceHandles._getNextDescendantID(
@@ -333,11 +333,11 @@ describe('ReactInstanceHandles', function() {
       ).toBe(getNodeID(parent.refs.P));
     });
 
-    it("should return window for next descendent towards window", function() {
+    it('should return window for next descendent towards window', function() {
       expect(ReactInstanceHandles._getNextDescendantID('', '')).toBe('');
     });
 
-    it("should return self for next descendent towards self", function() {
+    it('should return self for next descendent towards self', function() {
       var parent = renderParentIntoDocument();
       expect(
         ReactInstanceHandles._getNextDescendantID(
@@ -349,7 +349,7 @@ describe('ReactInstanceHandles', function() {
   });
 
   describe('getFirstCommonAncestorID', function() {
-    it("should determine the first common ancestor correctly", function() {
+    it('should determine the first common ancestor correctly', function() {
       var parent = renderParentIntoDocument();
       var ancestors = [
         // Common ancestor from window to deep element is ''.

--- a/src/renderers/shared/reconciler/__tests__/ReactUpdates-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactUpdates-test.js
@@ -530,7 +530,7 @@ describe('ReactUpdates', function() {
         return {x: 0};
       },
       componentDidUpdate: function() {
-        expect(React.findDOMNode(b).textContent).toBe("B1");
+        expect(React.findDOMNode(b).textContent).toBe('B1');
         aUpdated = true;
       },
       render: function() {
@@ -698,7 +698,9 @@ describe('ReactUpdates', function() {
     });
 
     var Z = React.createClass({
-      render: function() { return <div />; },
+      render: function() {
+        return <div />;
+      },
       componentWillUpdate: function() {
         x.go();
       }
@@ -785,7 +787,6 @@ describe('ReactUpdates', function() {
         return <div />;
       },
       componentDidUpdate: function() {
-        var component = this;
         ReactUpdates.asap(function() {
           expect(this).toBe(component);
           callbackCount++;
@@ -793,7 +794,7 @@ describe('ReactUpdates', function() {
             callbackCount++;
           });
           expect(callbackCount).toBe(1);
-        }, this);
+        }, component);
         expect(callbackCount).toBe(0);
       }
     });

--- a/src/renderers/shared/reconciler/__tests__/refs-destruction-test.js
+++ b/src/renderers/shared/reconciler/__tests__/refs-destruction-test.js
@@ -12,7 +12,6 @@
 'use strict';
 
 var React = require('React');
-var ReactTestUtils = require('ReactTestUtils');
 var reactComponentExpect = require('reactComponentExpect');
 
 var TestComponent = React.createClass({
@@ -34,7 +33,7 @@ describe('refs-destruction', function() {
     require('mock-modules').dumpCache();
   });
 
-  it("should remove refs when destroying the parent", function() {
+  it('should remove refs when destroying the parent', function() {
     var container = document.createElement('div');
     var testInstance = React.render(<TestComponent />, container);
     reactComponentExpect(testInstance.refs.theInnerDiv)
@@ -44,7 +43,7 @@ describe('refs-destruction', function() {
     expect(Object.keys(testInstance.refs || {}).length).toEqual(0);
   });
 
-  it("should remove refs when destroying the child", function() {
+  it('should remove refs when destroying the child', function() {
     var container = document.createElement('div');
     var testInstance = React.render(<TestComponent />, container);
     reactComponentExpect(testInstance.refs.theInnerDiv)

--- a/src/renderers/shared/reconciler/__tests__/refs-test.js
+++ b/src/renderers/shared/reconciler/__tests__/refs-test.js
@@ -38,8 +38,8 @@ var ClickCounter = React.createClass({
       children.push(
         <div
           className="clickLogDiv"
-          key={"clickLog" + i}
-          ref={"clickLog" + i}
+          key={'clickLog' + i}
+          ref={'clickLog' + i}
         />
       );
     }
@@ -122,7 +122,7 @@ describe('reactiverefs', function() {
    * Ensure that for every click log there is a corresponding ref (from the
    * perspective of the injected ClickCounter component.
    */
-  it("Should increase refs with an increase in divs", function() {
+  it('Should increase refs with an increase in divs', function() {
     var testRefsComponent = renderTestRefsComponent();
     var clickIncrementer =
       ReactTestUtils.findRenderedDOMComponentWithClass(
@@ -195,7 +195,7 @@ describe('ref swapping', function() {
     }
   });
 
-  it("Allow refs to hop around children correctly", function() {
+  it('Allow refs to hop around children correctly', function() {
     var refHopsAround = ReactTestUtils.renderIntoDocument(<RefHopsAround />);
 
     var firstDiv =

--- a/src/shared/utils/__tests__/OrderedMap-test.js
+++ b/src/shared/utils/__tests__/OrderedMap-test.js
@@ -252,10 +252,8 @@ describe('OrderedMap', function() {
       expect(om.has(0)).toBe(true);
       expect(om.has('0')).toBe(true);
     };
-    var om = OrderedMap.fromArray(hasZeroStringKey, extractUniqueID);
-    verifyOM(om);
-    om = OrderedMap.fromArray(hasZeroNumberKey, extractUniqueID);
-    verifyOM(om);
+    verifyOM(OrderedMap.fromArray(hasZeroStringKey, extractUniqueID));
+    verifyOM(OrderedMap.fromArray(hasZeroNumberKey, extractUniqueID));
   });
 
   it('should throw when getting invalid public key', function() {
@@ -494,22 +492,22 @@ describe('OrderedMap', function() {
   });
 
   it('should compute indices on array that extracted numeric ids', function() {
-    var om = OrderedMap.fromArray(hasZeroStringKey, extractUniqueID);
-    expect(om.keyAtIndex(0)).toBe('greg');
-    expect(om.keyAtIndex(1)).toBe('0');
-    expect(om.keyAtIndex(2)).toBe('tom');
-    expect(om.indexOfKey('greg')).toBe(0);
-    expect(om.indexOfKey('0')).toBe(1);
-    expect(om.indexOfKey('tom')).toBe(2);
+    var som = OrderedMap.fromArray(hasZeroStringKey, extractUniqueID);
+    expect(som.keyAtIndex(0)).toBe('greg');
+    expect(som.keyAtIndex(1)).toBe('0');
+    expect(som.keyAtIndex(2)).toBe('tom');
+    expect(som.indexOfKey('greg')).toBe(0);
+    expect(som.indexOfKey('0')).toBe(1);
+    expect(som.indexOfKey('tom')).toBe(2);
 
 
-    var verifyNumericKeys = function(om) {
-      expect(om.keyAtIndex(0)).toBe('0');
-      expect(om.keyAtIndex(1)).toBe('2');
-      expect(om.keyAtIndex(2)).toBe('1');
-      expect(om.indexOfKey('0')).toBe(0);
-      expect(om.indexOfKey('2')).toBe(1); // Proove these are not ordered by
-      expect(om.indexOfKey('1')).toBe(2); // their keys
+    var verifyNumericKeys = function(nom) {
+      expect(nom.keyAtIndex(0)).toBe('0');
+      expect(nom.keyAtIndex(1)).toBe('2');
+      expect(nom.keyAtIndex(2)).toBe('1');
+      expect(nom.indexOfKey('0')).toBe(0);
+      expect(nom.indexOfKey('2')).toBe(1); // Prove these are not ordered by
+      expect(nom.indexOfKey('1')).toBe(2); // their keys
     };
     var omStringNumberKeys =
       OrderedMap.fromArray(hasAllNumericStringKeys, extractUniqueID);
@@ -731,7 +729,7 @@ describe('OrderedMap', function() {
       om.forEachRange(duplicate, 0, 3, scope);
     }).not.toThrow();
     expect(function() {
-      om.mapKeyRange(duplicate, 'x' , 3, scope);
+      om.mapKeyRange(duplicate, 'x', 3, scope);
     }).toThrow(
       'Invariant Violation: mapKeyRange must be given keys ' +
       'that are present.'

--- a/src/shared/utils/__tests__/Transaction-test.js
+++ b/src/shared/utils/__tests__/Transaction-test.js
@@ -56,7 +56,9 @@ describe('Transaction', function() {
           }
         },
         {
-          initialize: function() { return 'asdf'; },
+          initialize: function() {
+            return 'asdf';
+          },
           close: function(initResult) {
             this.secondCloseParam = initResult;
           }
@@ -201,7 +203,7 @@ describe('Transaction', function() {
       var isTypeError = false;
       try {
         transaction.perform(function() {
-          throw new TypeError("Thrown in main wrapped operation");
+          throw new TypeError('Thrown in main wrapped operation');
         });
       } catch (err) {
         isTypeError = (err instanceof TypeError);


### PR DESCRIPTION
Closes #3971.

> After #3968, the next thing we should do is start linting our tests.
> Historically we've ignored them due to lack of parser compatibility.
> But that shouldn't be a problem anymore. We may want to integrate
> https://www.npmjs.com/package/eslint-plugin-react to more aggressively
> lint our JSX in tests.

I understand this diff touches a lot of stuff, so I tried to keep it to
a near-minimal set of changes to make eslint happy. If you're wondering
why I changed something, let me know and I'll try to map it up to the
rule that I was fixing it for.