### PR TITLE
Remove envify from the basic-commonjs example

### DIFF
--- a/examples/basic-commonjs/package.json
+++ b/examples/basic-commonjs/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "devDependencies": {
     "browserify": "^6.3.3",
-    "envify": "^3.2.0",
     "react": "^0.13.0",
     "reactify": "^0.17.1"
   },


### PR DESCRIPTION
`envify` is installed as a dependency of the `react` package. There is no need in installing it one more time