### PR TITLE
added missing DOCTYPE

### DIFF
--- a/docs/docs/tutorial.ja-JP.md
+++ b/docs/docs/tutorial.ja-JP.md
@@ -35,6 +35,7 @@ next: thinking-in-react-ja-JP.html
 
 ```html
 <!-- index.html -->
+<!DOCTYPE html>
 <html>
   <head>
     <title>Hello React</title>

--- a/docs/docs/tutorial.ko-KR.md
+++ b/docs/docs/tutorial.ko-KR.md
@@ -36,6 +36,7 @@ next: thinking-in-react-ko-KR.html
 
 ```html
 <!-- index.html -->
+<!DOCTYPE html>
 <html>
   <head>
     <title>Hello React</title>

--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -35,6 +35,7 @@ For this tutorial, we'll use prebuilt JavaScript files on a CDN. Open up your fa
 
 ```html
 <!-- index.html -->
+<!DOCTYPE html>
 <html>
   <head>
     <title>Hello React</title>

--- a/examples/server-rendering/webapp/index.php
+++ b/examples/server-rendering/webapp/index.php
@@ -52,6 +52,7 @@ SCRIPT;
 }
 ?>
 
+<!DOCTYPE html>
 <html>
   <head>
     <title>React server rendering example</title>


### PR DESCRIPTION
`<!DOCTYPE html>` was missing in a few places, I added it for consistency.

Especially because in the source file it exists [here](https://github.com/reactjs/react-tutorial/blob/master/public/index.html).

Also all the [other](https://github.com/facebook/react/blob/master/docs/docs/02-displaying-data.md#getting-started) [tutorial](https://github.com/facebook/react/blob/master/docs/docs/getting-started.md#starter-kit) files define a DOCTYPE and it's not consistent to not have it on one tutorial.

