### PR TITLE
Enable more eslint-plugin-react rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -71,8 +71,29 @@ rules:
   block-scoped-var: 0
 
   # JSX
+  # Our transforms set this automatically
+  react/display-name: 0
+  react/jsx-boolean-value: [2, always]
+  react/jsx-no-undef: 2
+  react/jsx-quotes: [2, double]
+  # We don't care to do this
+  react/jsx-sort-prop-types: 0
+  react/jsx-sort-props: 0
   react/jsx-uses-react: 2
-  react/jsx-quotes: [2, "double"]
+  react/jsx-uses-vars: 2
+  # It's easier to test some things this way
+  react/no-did-mount-set-state: 0
+  react/no-did-update-set-state: 0
+  # We define multiple components in test files
+  react/no-multi-comp: 0
+  react/no-unknown-property: 2
+  # This isn't useful in our test code
+  react/prop-types: 0
+  react/react-in-jsx-scope: 2
+  react/self-closing-comp: 2
+  # We don't care to do this
+  react/sort-comp: 0
+  #react/wrap-multilines: 2
 
   # CUSTOM RULES
   # the second argument of warning/invariant should be a literal string

--- a/.eslintrc
+++ b/.eslintrc
@@ -93,7 +93,7 @@ rules:
   react/self-closing-comp: 2
   # We don't care to do this
   react/sort-comp: 0
-  #react/wrap-multilines: 2
+  react/wrap-multilines: [2, {declaration: false, assignment: false}]
 
   # CUSTOM RULES
   # the second argument of warning/invariant should be a literal string

--- a/docs/_js/examples/.eslintrc
+++ b/docs/_js/examples/.eslintrc
@@ -1,3 +1,6 @@
+---
 rules:
-  block-scoped-var: false
-  no-undef: false
+  block-scoped-var: 0
+  no-undef: 0
+  react/react-in-jsx-scope: 0
+  react/jsx-no-undef: 0

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "envify": "^3.0.0",
     "es5-shim": "^4.0.0",
     "eslint": "^0.21.2",
-    "eslint-plugin-react": "^2.3.0",
+    "eslint-plugin-react": "^2.5.0",
     "eslint-tester": "^0.7.0",
     "grunt": "~0.4.2",
     "grunt-cli": "^0.1.13",

--- a/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
@@ -117,8 +117,7 @@ describe('ReactCSSTransitionGroup', function() {
 
   it('should work with no children', function() {
     React.render(
-      <ReactCSSTransitionGroup transitionName="yolo">
-      </ReactCSSTransitionGroup>,
+      <ReactCSSTransitionGroup transitionName="yolo" />,
       container
     );
   });

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -663,7 +663,7 @@ describe('ReactDOMComponent', function() {
     it('should warn about contentEditable and children', function() {
       spyOn(console, 'error');
       React.render(
-        <div contentEditable><div /></div>,
+        <div contentEditable={true}><div /></div>,
         container
       );
       expect(console.error.argsForCall.length).toBe(1);

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -429,10 +429,12 @@ describe('ReactCompositeComponent', function() {
 
     var Component = React.createClass({
       render: function() {
-        return <div>
-          <Inner />
-          Text
-        </div>;
+        return (
+          <div>
+            <Inner />
+            Text
+          </div>
+        );
       },
     });
     var Inner = React.createClass({
@@ -774,15 +776,19 @@ describe('ReactCompositeComponent', function() {
     var Component = React.createClass({
       render: function() {
         if (this.props.flipped) {
-          return <div>
-            <Static ref="static0" key="B">B (ignored)</Static>
-            <Static ref="static1" key="A">A (ignored)</Static>
-          </div>;
+          return (
+            <div>
+              <Static ref="static0" key="B">B (ignored)</Static>
+              <Static ref="static1" key="A">A (ignored)</Static>
+            </div>
+          );
         } else {
-          return <div>
-            <Static ref="static0" key="A">A</Static>
-            <Static ref="static1" key="B">B</Static>
-          </div>;
+          return (
+            <div>
+              <Static ref="static0" key="A">A</Static>
+              <Static ref="static1" key="B">B</Static>
+            </div>
+          );
         }
       },
     });

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentNestedState-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentNestedState-test.js
@@ -38,11 +38,13 @@ describe('ReactCompositeComponentNestedState-state', function() {
 
       render: function() {
         this.props.logger('parent-render', this.state.color);
-        return <ChildComponent
-          logger={this.props.logger}
-          color={this.state.color}
-          onSelectColor={this.handleColor}
-        />;
+        return (
+          <ChildComponent
+            logger={this.props.logger}
+            color={this.state.color}
+            onSelectColor={this.handleColor}
+          />
+        );
       },
     });
 
@@ -66,20 +68,22 @@ describe('ReactCompositeComponentNestedState-state', function() {
 
       render: function() {
         this.props.logger('render', this.state.hue, this.props.color);
-        return <div>
-          <button onClick={this.handleHue.bind(this, 'dark', 'blue')}>
-            Dark Blue
-          </button>
-          <button onClick={this.handleHue.bind(this, 'light', 'blue')}>
-            Light Blue
-          </button>
-          <button onClick={this.handleHue.bind(this, 'dark', 'green')}>
-            Dark Green
-          </button>
-          <button onClick={this.handleHue.bind(this, 'light', 'green')}>
-            Light Green
-          </button>
-        </div>;
+        return (
+          <div>
+            <button onClick={this.handleHue.bind(this, 'dark', 'blue')}>
+              Dark Blue
+            </button>
+            <button onClick={this.handleHue.bind(this, 'light', 'blue')}>
+              Light Blue
+            </button>
+            <button onClick={this.handleHue.bind(this, 'dark', 'green')}>
+              Dark Green
+            </button>
+            <button onClick={this.handleHue.bind(this, 'light', 'green')}>
+              Light Green
+            </button>
+          </div>
+        );
       },
     });
 

--- a/src/renderers/shared/reconciler/__tests__/ReactUpdates-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactUpdates-test.js
@@ -675,9 +675,11 @@ describe('ReactUpdates', function() {
       },
       render: function() {
         if (this.state.s === 0) {
-          return <div>
-            <span>0</span>
-          </div>;
+          return (
+            <div>
+              <span>0</span>
+            </div>
+          );
         } else {
           return <div>1</div>;
         }
@@ -691,9 +693,11 @@ describe('ReactUpdates', function() {
 
     var Y = React.createClass({
       render: function() {
-        return <div>
-          <Z />
-        </div>;
+        return (
+          <div>
+            <Z />
+          </div>
+        );
       },
     });
 


### PR DESCRIPTION
This should contain all the rules we probably want to use. This is divided into two commits to make it easier to review.

The wrap-multiline codemod commit was mostly made using:

```sh
$ codemod '^(?P<indent>[ \t]+)([^\s][^\n]*?[^(>])(\n(?P=indent)\s+<[^>]+>(\n(?P=indent)\s+[^\n]+)+>)' '\1\2 (\3\n\g<indent>)' -m -d src
$ codemod '^(?P<indent>[ \t]+)([^\s][^\n]*?[^(>])(\n(?P=indent)\s+<[^>]+(\n(?P=indent)\s+[^\n>]+)+/>)' '\1\2 (\3\n\g<indent>)' -m -d src
```