### PR TITLE
Kill .type (was deprecated in 0.13, to be removed in 0.14)

### DIFF
--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -704,23 +704,6 @@ function bindAutoBindMethods(component) {
   }
 }
 
-var typeDeprecationDescriptor = {
-  enumerable: false,
-  get: function() {
-    var displayName = this.displayName || this.name || 'Component';
-    warning(
-      false,
-      '%s.type is deprecated. Use %s directly to access the class.',
-      displayName,
-      displayName
-    );
-    Object.defineProperty(this, 'type', {
-      value: this
-    });
-    return this;
-  }
-};
-
 /**
  * Add more to the ReactClass base class. These are all legacy features and
  * therefore not already part of the modern ReactComponent.
@@ -912,16 +895,6 @@ var ReactClass = {
     for (var methodName in ReactClassInterface) {
       if (!Constructor.prototype[methodName]) {
         Constructor.prototype[methodName] = null;
-      }
-    }
-
-    // Legacy hook
-    Constructor.type = Constructor;
-    if (__DEV__) {
-      try {
-        Object.defineProperty(Constructor, 'type', typeDeprecationDescriptor);
-      } catch (x) {
-        // IE will fail on defineProperty (es5-shim/sham too)
       }
     }
 

--- a/src/isomorphic/classic/class/__tests__/ReactClass-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactClass-test.js
@@ -44,35 +44,6 @@ describe('ReactClass-spec', function() {
       .toBe('TestComponent');
   });
 
-  it('should warn when accessing .type on a React class', function() {
-    var TestComponent = React.createClass({
-      render: function() {
-        return <div />;
-      }
-    });
-    var SecondTestComponent = React.createClass({
-      render: function() {
-        return <div />;
-      }
-    });
-    expect(TestComponent.type).toBe(TestComponent);
-    expect(console.error.argsForCall.length).toBe(1);
-    expect(console.error.argsForCall[0][0]).toBe(
-      'Warning: TestComponent.type is deprecated. Use TestComponent ' +
-      'directly to access the class.'
-    );
-    // Warn once per class
-    expect(SecondTestComponent.type).toBe(SecondTestComponent);
-    expect(console.error.argsForCall.length).toBe(2);
-    expect(console.error.argsForCall[1][0]).toBe(
-      'Warning: SecondTestComponent.type is deprecated. Use ' +
-      'SecondTestComponent directly to access the class.'
-    );
-    // Not again
-    expect(TestComponent.type).toBe(TestComponent);
-    expect(console.error.argsForCall.length).toBe(2);
-  });
-
   it('should copy prop types onto the Constructor', function() {
     var propValidator = mocks.getMockFunction();
     var TestComponent = React.createClass({


### PR DESCRIPTION
Kill .type (was deprecated in 0.13, to be removed in 0.14)