### PR TITLE
Remove npm scripts, in favor of grunt

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,12 +70,6 @@
   "commonerConfig": {
     "version": 7
   },
-  "scripts": {
-    "test": "jest",
-    "jest": "jest",
-    "lint": "grunt lint",
-    "build": "grunt build"
-  },
   "jest": {
     "rootDir": "",
     "scriptPreprocessor": "jest/preprocessor.js",


### PR DESCRIPTION
In response to #4028. I don't think we use these anywhere, and we recommend using grunt for everything anyways.