### PR TITLE
Roll back to babel-eslint 3.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "babel": "^5.3.3",
-    "babel-eslint": "^3.1.9",
+    "babel-eslint": "3.1.9",
     "benchmark": "~1.0.0",
     "browserify": "^9.0.3",
     "bundle-collapser": "^1.1.1",


### PR DESCRIPTION
@spicyj noticed newer versions of babel-eslint seemed not to error on no-unused-vars, and I was able to repro. It seems like something broke between 3.1.9 and 3.1.10. (Smaller repro case and babel-eslint bug report to come)

His commit failed on travis, but not on his local machine: https://travis-ci.org/facebook/react/jobs/65468729