### PR TITLE
Load custom eslint rules as plugin, w/o --rulesdir

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@ parser: babel-eslint
 
 plugins:
   - react
+  - react-internal
 
 env:
   browser: true
@@ -97,4 +98,4 @@ rules:
 
   # CUSTOM RULES
   # the second argument of warning/invariant should be a literal string
-  warning-and-invariant-args: 2
+  react-internal/warning-and-invariant-args: 2

--- a/eslint-rules/README.md
+++ b/eslint-rules/README.md
@@ -1,0 +1,5 @@
+# Custom ESLint Rules
+
+This is a dummy npm package that allows us to treat it as an eslint-plugin. It's not actually published, nor are the rules here useful for users of react. If you want to lint your react code, try <https://github.com/yannickcr/eslint-plugin-react>.
+
+**If you modify this rule, you must re-run `npm install ./eslint-rules` for it to take effect.**

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  rules: {
+    'warning-and-invariant-args': require('./warning-and-invariant-args'),
+  },
+};

--- a/eslint-rules/package.json
+++ b/eslint-rules/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "eslint-plugin-react-internal",
+  "version": "0.0.0"
+}

--- a/grunt/tasks/eslint.js
+++ b/grunt/tasks/eslint.js
@@ -6,7 +6,7 @@ module.exports = function() {
   var done = this.async();
   grunt.util.spawn({
     cmd: 'node_modules/.bin/eslint',
-    args: ['.', '--rulesdir=eslint-rules'],
+    args: ['.'],
     opts: {stdio: 'inherit'}, // allows colors to passthrough
   }, function(err, result, code) {
     if (err) {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "es5-shim": "^4.0.0",
     "eslint": "^0.21.2",
     "eslint-plugin-react": "^2.5.0",
+    "eslint-plugin-react-internal": "file:eslint-rules",
     "eslint-tester": "^0.7.0",
     "grunt": "~0.4.2",
     "grunt-cli": "^0.1.13",


### PR DESCRIPTION
This allows us to load the eslint rules without requiring command-line arguments, which avoids breaking editors with eslint plugins.

https://github.com/eslint/eslint/issues/2180#issuecomment-87722150

@zpao