### PR TITLE
Update eslint-related dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "jstransform": "^11.0.0"
   },
   "devDependencies": {
-    "babel": "^5.3.3",
-    "babel-eslint": "3.1.9",
+    "babel": "^5.5.5",
+    "babel-eslint": "^3.1.14",
     "benchmark": "~1.0.0",
     "browserify": "^9.0.3",
     "bundle-collapser": "^1.1.1",
@@ -39,7 +39,7 @@
     "derequire": "^2.0.0",
     "envify": "^3.0.0",
     "es5-shim": "^4.0.0",
-    "eslint": "^0.21.2",
+    "eslint": "^0.22.1",
     "eslint-plugin-react": "^2.5.0",
     "eslint-tester": "^0.7.0",
     "grunt": "~0.4.2",

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElement-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElement-test.js
@@ -116,7 +116,7 @@ describe('ReactJSXElement', function() {
   it('allows static methods to be called using the type property', function() {
     spyOn(console, 'error');
 
-    class Component {
+    class StaticMethodComponent {
       static someStaticMethod() {
         return 'someReturnValue';
       }
@@ -125,18 +125,12 @@ describe('ReactJSXElement', function() {
       }
     }
 
-    var element = <Component />;
+    var element = <StaticMethodComponent />;
     expect(element.type.someStaticMethod()).toBe('someReturnValue');
     expect(console.error.argsForCall.length).toBe(0);
   });
 
   it('identifies valid elements', function() {
-    class Component {
-      render() {
-        return <div />;
-      }
-    }
-
     expect(React.isValidElement(<div />)).toEqual(true);
     expect(React.isValidElement(<Component />)).toEqual(true);
 
@@ -154,11 +148,6 @@ describe('ReactJSXElement', function() {
   });
 
   it('should use default prop value when removing a prop', function() {
-    class Component {
-      render() {
-        return <span />;
-      }
-    }
     Component.defaultProps = {fruit: 'persimmon'};
 
     var container = document.createElement('div');
@@ -173,17 +162,18 @@ describe('ReactJSXElement', function() {
   });
 
   it('should normalize props with default values', function() {
-    class Component {
+    class NormalizingComponent {
       render() {
         return <span>{this.props.prop}</span>;
       }
     }
-    Component.defaultProps = {prop: 'testKey'};
+    NormalizingComponent.defaultProps = {prop: 'testKey'};
 
-    var instance = ReactTestUtils.renderIntoDocument(<Component />);
+    var instance = ReactTestUtils.renderIntoDocument(<NormalizingComponent />);
     expect(instance.props.prop).toBe('testKey');
 
-    var inst2 = ReactTestUtils.renderIntoDocument(<Component prop={null} />);
+    var inst2 =
+      ReactTestUtils.renderIntoDocument(<NormalizingComponent prop={null} />);
     expect(inst2.props.prop).toBe(null);
   });
 

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -20,6 +20,7 @@ var ReactTestUtils;
 
 describe('ReactJSXElementValidator', function() {
   var Component;
+  var RequiredPropComponent;
 
   beforeEach(function() {
     require('mock-modules').dumpCache();
@@ -33,6 +34,14 @@ describe('ReactJSXElementValidator', function() {
         return <div />;
       }
     };
+
+    RequiredPropComponent = class {
+      render() {
+        return <span>{this.props.prop}</span>;
+      }
+    };
+    RequiredPropComponent.displayName = 'RequiredPropComponent';
+    RequiredPropComponent.propTypes = {prop: React.PropTypes.string.isRequired};
   });
 
   function frag(obj) {
@@ -245,71 +254,48 @@ describe('ReactJSXElementValidator', function() {
   it('should check default prop values', function() {
     spyOn(console, 'error');
 
-    class Component {
-      render() {
-        return <span>{this.props.prop}</span>;
-      }
-    }
-    Component.defaultProps = {prop: null};
-    Component.propTypes = {prop: React.PropTypes.string.isRequired};
+    RequiredPropComponent.defaultProps = {prop: null};
 
-    ReactTestUtils.renderIntoDocument(<Component />);
+    ReactTestUtils.renderIntoDocument(<RequiredPropComponent />);
 
     expect(console.error.calls.length).toBe(1);
     expect(console.error.calls[0].args[0]).toBe(
       'Warning: Failed propType: ' +
-      'Required prop `prop` was not specified in `Component`.'
+      'Required prop `prop` was not specified in `RequiredPropComponent`.'
     );
   });
 
   it('should not check the default for explicit null', function() {
     spyOn(console, 'error');
 
-    class Component {
-      render() {
-        return <span>{this.props.prop}</span>;
-      }
-    }
-    Component.defaultProps = {prop: 'text'};
-    Component.propTypes = {prop: React.PropTypes.string.isRequired};
-
-    ReactTestUtils.renderIntoDocument(<Component prop={null} />);
+    ReactTestUtils.renderIntoDocument(<RequiredPropComponent prop={null} />);
 
     expect(console.error.calls.length).toBe(1);
     expect(console.error.calls[0].args[0]).toBe(
       'Warning: Failed propType: ' +
-      'Required prop `prop` was not specified in `Component`.'
+      'Required prop `prop` was not specified in `RequiredPropComponent`.'
     );
   });
 
   it('should check declared prop types', function() {
     spyOn(console, 'error');
 
-    class Component {
-      render() {
-        return <span>{this.props.prop}</span>;
-      }
-    }
-    Component.propTypes = {
-      prop: React.PropTypes.string.isRequired,
-    };
-
-    ReactTestUtils.renderIntoDocument(<Component />);
-    ReactTestUtils.renderIntoDocument(<Component prop={42} />);
+    ReactTestUtils.renderIntoDocument(<RequiredPropComponent />);
+    ReactTestUtils.renderIntoDocument(<RequiredPropComponent prop={42} />);
 
     expect(console.error.calls.length).toBe(2);
     expect(console.error.calls[0].args[0]).toBe(
       'Warning: Failed propType: ' +
-      'Required prop `prop` was not specified in `Component`.'
+      'Required prop `prop` was not specified in `RequiredPropComponent`.'
     );
 
     expect(console.error.calls[1].args[0]).toBe(
       'Warning: Failed propType: ' +
       'Invalid prop `prop` of type `number` supplied to ' +
-      '`Component`, expected `string`.'
+      '`RequiredPropComponent`, expected `string`.'
     );
 
-    ReactTestUtils.renderIntoDocument(<Component prop="string" />);
+    ReactTestUtils.renderIntoDocument(<RequiredPropComponent prop="string" />);
 
     // Should not error for strings
     expect(console.error.calls.length).toBe(2);
@@ -321,51 +307,51 @@ describe('ReactJSXElementValidator', function() {
     // actually occurs. Since this step is skipped in production, we should just
     // warn instead of throwing for this case.
     spyOn(console, 'error');
-    class Component {
+    class NullPropTypeComponent {
       render() {
         return <span>{this.props.prop}</span>;
       }
     }
-    Component.propTypes = {
+    NullPropTypeComponent.propTypes = {
       prop: null,
     };
-    ReactTestUtils.renderIntoDocument(<Component />);
+    ReactTestUtils.renderIntoDocument(<NullPropTypeComponent />);
     expect(console.error.calls.length).toBe(1);
     expect(console.error.calls[0].args[0]).toContain(
-      'Invariant Violation: Component: prop type `prop` is invalid; ' +
-      'it must be a function, usually from React.PropTypes.'
+      'Invariant Violation: NullPropTypeComponent: prop type `prop` is ' +
+      'invalid; it must be a function, usually from React.PropTypes.'
     );
   });
 
   it('should warn on invalid context types', function() {
     spyOn(console, 'error');
-    class Component {
+    class NullContextTypeComponent {
       render() {
         return <span>{this.props.prop}</span>;
       }
     }
-    Component.contextTypes = {
+    NullContextTypeComponent.contextTypes = {
       prop: null,
     };
-    ReactTestUtils.renderIntoDocument(<Component />);
+    ReactTestUtils.renderIntoDocument(<NullContextTypeComponent />);
     expect(console.error.calls.length).toBe(1);
     expect(console.error.calls[0].args[0]).toContain(
-      'Invariant Violation: Component: context type `prop` is invalid; ' +
-      'it must be a function, usually from React.PropTypes.'
+      'Invariant Violation: NullContextTypeComponent: context type `prop` is ' +
+      'invalid; it must be a function, usually from React.PropTypes.'
     );
   });
 
   it('should warn if getDefaultProps is specificed on the class', function() {
     spyOn(console, 'error');
-    class Component {
+    class GetDefaultPropsComponent {
       render() {
         return <span>{this.props.prop}</span>;
       }
     }
-    Component.getDefaultProps = () => ({
+    GetDefaultPropsComponent.getDefaultProps = () => ({
       prop: 'foo',
     });
-    ReactTestUtils.renderIntoDocument(<Component />);
+    ReactTestUtils.renderIntoDocument(<GetDefaultPropsComponent />);
     expect(console.error.calls.length).toBe(1);
     expect(console.error.calls[0].args[0]).toContain(
       'getDefaultProps is only used on classic React.createClass definitions.' +


### PR DESCRIPTION
- babel-eslint ~~`^3.1.13`~~ `^3.1.14` fixes babel/babel-eslint#120
- babel updated from `^5.3.3` to ~~`^3.5.3`~~ `^3.5.5`, which changes stuff, I guess
- eslint updated from `^0.21.2` to `^0.22.1`, which makes `no-shadow` also check class declarations

(this effectively reverts #4032)