### PR TITLE
fix className check in scryRenderedDOMComponentsWithClass when encounter new line

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -174,7 +174,7 @@ var ReactTestUtils = {
         var instClassName = React.findDOMNode(inst).className;
         return (
           instClassName &&
-          (' ' + instClassName + ' ').indexOf(' ' + className + ' ') !== -1
+          (('' + instClassName).split(/\s+/)).indexOf(className) !== -1
         );
       }
       return false;

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -187,6 +187,17 @@ describe('ReactTestUtils', function() {
 
   });
 
+  it('Test scryRenderedDOMComponentsWithClass with className contains \\n', function() {
+    var renderedComponent = ReactTestUtils.renderIntoDocument(<div>Hello <span className={`x
+    y`}>Jim</span></div>);
+    var scryResults = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+      renderedComponent,
+      'x'
+    );
+    expect(scryResults.length).toBe(1);
+
+  });
+
   it('traverses children in the correct order', function() {
     var container = document.createElement('div');
 

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -188,14 +188,15 @@ describe('ReactTestUtils', function() {
   });
 
   it('Test scryRenderedDOMComponentsWithClass with className contains \\n', function() {
-    var renderedComponent = ReactTestUtils.renderIntoDocument(<div>Hello <span className={`x
-    y`}>Jim</span></div>);
+    var renderedComponent = ReactTestUtils.renderIntoDocument(
+      <div>Hello <span className={`x
+      y`}>Jim</span></div>
+    );
     var scryResults = ReactTestUtils.scryRenderedDOMComponentsWithClass(
       renderedComponent,
       'x'
     );
     expect(scryResults.length).toBe(1);
-
   });
 
   it('traverses children in the correct order', function() {

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -189,8 +189,7 @@ describe('ReactTestUtils', function() {
 
   it('Test scryRenderedDOMComponentsWithClass with className contains \\n', function() {
     var renderedComponent = ReactTestUtils.renderIntoDocument(
-      <div>Hello <span className={`x
-      y`}>Jim</span></div>
+      <div>Hello <span className={'x\ny'}>Jim</span></div>
     );
     var scryResults = ReactTestUtils.scryRenderedDOMComponentsWithClass(
       renderedComponent,


### PR DESCRIPTION
we usually use new line to avoid long lines of code,such as

```js
var className=`a b c d e f g h
i j k`;
var el = <div className={className} />;
```