### PR TITLE
add a public method in React.addons to modify `CSSProperty.isUnitlessNumber`

### DIFF
--- a/npm-react/addons/extendUnitlessNumber.js
+++ b/npm-react/addons/extendUnitlessNumber.js
@@ -1,0 +1,1 @@
+module.exports = require('../lib/extendUnitlessNumber');

--- a/src/addons/ReactWithAddons.js
+++ b/src/addons/ReactWithAddons.js
@@ -31,6 +31,7 @@ var cloneWithProps = require('cloneWithProps');
 var renderSubtreeIntoContainer = require('renderSubtreeIntoContainer');
 var shallowCompare = require('shallowCompare');
 var update = require('update');
+var extendUnitlessNumber = require('extendUnitlessNumber');
 
 React.addons = {
   CSSTransitionGroup: ReactCSSTransitionGroup,
@@ -44,6 +45,7 @@ React.addons = {
   renderSubtreeIntoContainer: renderSubtreeIntoContainer,
   shallowCompare: shallowCompare,
   update: update,
+  extendUnitlessNumber: extendUnitlessNumber,
 };
 
 if (__DEV__) {

--- a/src/addons/extendUnitlessNumber.js
+++ b/src/addons/extendUnitlessNumber.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule extendUnitlessNumber
+ */
+/**
+ * This module provide a method to modify `CSSProperty.isUnitlessNumber`.
+ * CSS properties which accept numbers but are not in units of "px" defined in `isUnitlessNumber`, but `isUnitlessNumber` just contains part of unitless CSS properties.
+ * So we can add our unitless properties by `extendUnitlessNumber` method
+ */
+'use strict';
+
+var CSSProperty = require('CSSProperty');
+
+function extendUnitlessNumber(properties){
+
+  function prefixKey(prefix, key) {
+    return prefix + key.charAt(0).toUpperCase() + key.substring(1);
+  }
+
+  var prefixes = ['Webkit', 'ms', 'Moz', 'O'];
+
+  var isUnitlessNumber = CSSProperty.isUnitlessNumber;
+
+  Object.keys(properties).forEach(function(prop) {
+
+    isUnitlessNumber[prop] = properties[prop];
+
+    prefixes.forEach(function(prefix) {
+      isUnitlessNumber[prefixKey(prefix, prop)] = properties[prop];
+    });
+  });
+
+  return isUnitlessNumber;
+}
+
+module.exports = extendUnitlessNumber;

--- a/src/renderers/dom/shared/dangerousStyleValue.js
+++ b/src/renderers/dom/shared/dangerousStyleValue.js
@@ -14,8 +14,6 @@
 
 var CSSProperty = require('CSSProperty');
 
-var isUnitlessNumber = CSSProperty.isUnitlessNumber;
-
 /**
  * Convert a value into the proper css writable value. The style name `name`
  * should be logical (no hyphens), as specified
@@ -41,6 +39,7 @@ function dangerousStyleValue(name, value) {
     return '';
   }
 
+  var isUnitlessNumber = CSSProperty.isUnitlessNumber;
   var isNonNumeric = isNaN(value);
   if (isNonNumeric || value === 0 ||
       isUnitlessNumber.hasOwnProperty(name) && isUnitlessNumber[name]) {


### PR DESCRIPTION
CSS properties which accept numbers but are not in units of "px" defined in `isUnitlessNumber`, but `isUnitlessNumber` just contains part of unitless CSS properties.

So add a public method to modify `CSSProperty.isUnitlessNumber`, we can add our unitless properties by `extendUnitlessNumber` method such as `animationIterationCount` etc