### PR TITLE
Remove constructAndRenderComponent

### DIFF
--- a/src/renderers/dom/ReactDOMClient.js
+++ b/src/renderers/dom/ReactDOMClient.js
@@ -29,8 +29,6 @@ ReactDefaultInjection.inject();
 var render = ReactPerf.measure('React', 'render', ReactMount.render);
 
 var React = {
-  constructAndRenderComponent: ReactMount.constructAndRenderComponent,
-  constructAndRenderComponentByID: ReactMount.constructAndRenderComponentByID,
   findDOMNode: findDOMNode,
   render: render,
   unmountComponentAtNode: ReactMount.unmountComponentAtNode,

--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -596,39 +596,6 @@ var ReactMount = {
   },
 
   /**
-   * Constructs a component instance of `constructor` with `initialProps` and
-   * renders it into the supplied `container`.
-   *
-   * @param {function} constructor React component constructor.
-   * @param {?object} props Initial props of the component instance.
-   * @param {DOMElement} container DOM element to render into.
-   * @return {ReactComponent} Component instance rendered in `container`.
-   */
-  constructAndRenderComponent: function(constructor, props, container) {
-    var element = ReactElement.createElement(constructor, props);
-    return ReactMount.render(element, container);
-  },
-
-  /**
-   * Constructs a component instance of `constructor` with `initialProps` and
-   * renders it into a container node identified by supplied `id`.
-   *
-   * @param {function} constructor React component constructor
-   * @param {?object} props Initial props of the component instance.
-   * @param {string} id ID of the DOM element to render into.
-   * @return {ReactComponent} Component instance rendered in the container node.
-   */
-  constructAndRenderComponentByID: function(constructor, props, id) {
-    var domNode = document.getElementById(id);
-    invariant(
-      domNode,
-      'Tried to get element with id of "%s" but it is not present on the page.',
-      id
-    );
-    return ReactMount.constructAndRenderComponent(constructor, props, domNode);
-  },
-
-  /**
    * Registers a container node into which React components will be rendered.
    * This also creates the "reactRoot" ID that will be assigned to the element
    * rendered within.

--- a/src/renderers/dom/client/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMount-test.js
@@ -29,18 +29,6 @@ describe('ReactMount', function() {
     // Leave WebComponents undefined.
   }
 
-  describe('constructAndRenderComponentByID', function() {
-    it('throws if given an id for a component that doesn\'t exist', function() {
-      expect(function() {
-        ReactMount.constructAndRenderComponentByID(
-          function dummyComponentConstructor() {},
-          {},
-          'SOME_ID_THAT_DOESNT_EXIST'
-        );
-      }).toThrow();
-    });
-  });
-
   describe('unmountComponentAtNode', function() {
     it('throws when given a non-node', function() {
       var nodeArray = document.getElementsByTagName('div');


### PR DESCRIPTION
These were never part of the public API and shouldn't have been part of the React object. Now they're not.