### PR TITLE
Remove stray call to ReactDOMTextarea.unmountWrapper

### DIFF
--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMTextarea-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMTextarea-test.js
@@ -251,4 +251,10 @@ describe('ReactDOMTextarea', function() {
     expect(link.requestChange.mock.calls.length).toBe(1);
     expect(link.requestChange.mock.calls[0][0]).toEqual('test');
   });
+
+  it('should unmount', function() {
+    var container = document.createElement('div');
+    renderTextarea(<textarea />, container);
+    React.unmountComponentAtNode(container);
+  });
 });

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -787,9 +787,6 @@ ReactDOMComponent.Mixin = {
       case 'input':
         ReactDOMInput.unmountWrapper(this);
         break;
-      case 'textarea':
-        ReactDOMTextarea.unmountWrapper(this);
-        break;
       case 'html':
       case 'head':
       case 'body':


### PR DESCRIPTION
ReactDOMInput has this but ReactDOMTextarea doesn't so we shouldn't try to call it.