### PR TITLE
Fix Class tests

### DIFF
--- a/src/isomorphic/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/src/isomorphic/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -301,7 +301,7 @@ describe 'ReactCoffeeScriptClass', ->
       'contextTypes was defined as an instance property on Foo.'
     )
 
-  it 'should warn when mispelling shouldComponentUpdate', ->
+  it 'should warn when misspelling shouldComponentUpdate', ->
     spyOn console, 'error'
     class NamedComponent
       componentShouldUpdate: ->
@@ -319,7 +319,7 @@ describe 'ReactCoffeeScriptClass', ->
        question because the function is expected to return a value.'
     )
 
-    it 'should warn when mispelling componentWillReceiveProps', ->
+  it 'should warn when misspelling componentWillReceiveProps', ->
     spyOn console, 'error'
     class NamedComponent
       componentWillRecieveProps: ->

--- a/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
+++ b/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
@@ -341,7 +341,7 @@ describe('ReactES6Class', function() {
     );
   });
 
-  it('should warn when mispelling shouldComponentUpdate', function() {
+  it('should warn when misspelling shouldComponentUpdate', function() {
     spyOn(console, 'error');
 
     class NamedComponent {
@@ -363,7 +363,7 @@ describe('ReactES6Class', function() {
     );
   });
 
-  it('should warn when mispelling componentWillReceiveProps', function() {
+  it('should warn when misspelling componentWillReceiveProps', function() {
     spyOn(console, 'error');
 
     class NamedComponent {
@@ -379,8 +379,8 @@ describe('ReactES6Class', function() {
     expect(console.error.calls.length).toBe(1);
     expect(console.error.calls[0].args[0]).toBe(
       'Warning: ' +
-      'NamedComponent has a method called componentWillRecieveProps(). Did you ' +
-      'mean componentWillReceiveProps()?'
+      'NamedComponent has a method called componentWillRecieveProps(). Did ' +
+      'you mean componentWillReceiveProps()?'
     );
   });
 

--- a/src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
+++ b/src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
@@ -252,11 +252,18 @@ class ClassicProperties extends React.Component {
   }
 }
 
-// it should warn when mispelling shouldComponentUpdate
-class NamedComponent {
+// it should warn when misspelling shouldComponentUpdate
+class MisspelledComponent1 {
   componentShouldUpdate() {
     return false;
   }
+  render() {
+    return React.createElement('span', {className: 'foo'});
+  }
+}
+
+// it should warn when misspelling componentWillReceiveProps
+class MisspelledComponent2 {
   componentWillRecieveProps() {
     return false;
   }
@@ -439,32 +446,32 @@ describe('ReactTypeScriptClass', function() {
     );
   });
 
-  it('should warn when mispelling shouldComponentUpdate', function() {
+  it('should warn when misspelling shouldComponentUpdate', function() {
     var warn = jest.genMockFn();
     console.error = warn;
 
-    test(React.createElement(NamedComponent), 'SPAN', 'foo');
+    test(React.createElement(MisspelledComponent1), 'SPAN', 'foo');
 
     expect(warn.mock.calls.length).toBe(1);
     expect(warn.mock.calls[0][0]).toBe(
       'Warning: ' +
-      'NamedComponent has a method called componentShouldUpdate(). Did you ' +
-      'mean shouldComponentUpdate()? The name is phrased as a question ' +
+      'MisspelledComponent1 has a method called componentShouldUpdate(). Did ' +
+      'you mean shouldComponentUpdate()? The name is phrased as a question ' +
       'because the function is expected to return a value.'
     );
   });
 
-  it('should warn when mispelling componentWillReceiveProps', function() {
+  it('should warn when misspelling componentWillReceiveProps', function() {
     var warn = jest.genMockFn();
     console.error = warn;
 
-    test(React.createElement(NamedComponent), 'SPAN', 'foo');
+    test(React.createElement(MisspelledComponent2), 'SPAN', 'foo');
 
     expect(warn.mock.calls.length).toBe(1);
     expect(warn.mock.calls[0][0]).toBe(
       'Warning: ' +
-      'NamedComponent has a method called componentWillRecieveProps(). Did you ' +
-      'mean componentWillReceiveProps()?'
+      'MisspelledComponent2 has a method called componentWillRecieveProps(). ' +
+      'Did you mean componentWillReceiveProps()?'
     );
   });
 


### PR DESCRIPTION
These were introduced in #4045 as a result of jest not running properly in CI.

- Fixed indentation (THANKS COFFEESCRIPT)
- Fixed re-use of single component and split into 2 since we can't have classes defined in methods (THANKS TYPESCRIPT)
- I also fixed the places where we misspelled "misspelling". (THANKS @sebmarkbage)