### PR TITLE
Don't use owner to determine if the auto-bailout should be used

### DIFF
--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMSelect-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMSelect-test.js
@@ -226,7 +226,14 @@ describe('ReactDOMSelect', function() {
 
     // Changing the `value` prop should change the selected options.
     objectToString.animal = 'monkey';
-    ReactDOM.render(el, container);
+
+    var el2 =
+      <select multiple={true} value={[objectToString]}>
+        <option value="monkey">A monkey!</option>
+        <option value="giraffe">A giraffe!</option>
+        <option value="gorilla">A gorilla!</option>
+      </select>;
+    ReactDOM.render(el2, container);
 
     expect(node.options[0].selected).toBe(true);  // monkey
     expect(node.options[1].selected).toBe(false);  // giraffe

--- a/src/renderers/shared/reconciler/ReactReconciler.js
+++ b/src/renderers/shared/reconciler/ReactReconciler.js
@@ -65,8 +65,8 @@ var ReactReconciler = {
     internalInstance, nextElement, transaction, context
   ) {
     var prevElement = internalInstance._currentElement;
+
     if (nextElement === prevElement &&
-        nextElement._owner != null &&
         context === internalInstance._context
       ) {
       // Since elements are immutable after the owner is rendered,


### PR DESCRIPTION
I didn't realize that we actually special cased this. This is an
unfortunate heuristic but it helps minimize the harm that this optimization
does.

Should we try to remove it?

See https://github.com/facebook/react/issues/4067#issuecomment-110792425