### PR TITLE
Use the public render API in ReactDOMComponent-test

### DIFF
--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -445,24 +445,10 @@ describe('ReactDOMComponent', function() {
       require('mock-modules').dumpCache();
 
       React = require('React');
-      var ReactMultiChild = require('ReactMultiChild');
-      var ReactDOMComponent = require('ReactDOMComponent');
-      var ReactReconcileTransaction = require('ReactReconcileTransaction');
-
-      var StubNativeComponent = function(element) {
-        this._currentElement = element;
-      };
-      assign(StubNativeComponent.prototype, ReactDOMComponent.Mixin);
-      assign(StubNativeComponent.prototype, ReactMultiChild.Mixin);
 
       mountComponent = function(props) {
-        var transaction = new ReactReconcileTransaction();
-        var stubComponent = new StubNativeComponent({
-          type: StubNativeComponent,
-          props: props,
-          _owner: null,
-        });
-        return stubComponent.mountComponent('test', transaction, {});
+        var container = document.createElement('div');
+        React.render(<div {...props} />, container);
       };
     });
 


### PR DESCRIPTION
Avoids testing a non-public API. First step towards refactoring more of
these internals to not be instances. Also gets rid of an _owner usage.