### PR TITLE
Make setState in render a warning, not an invariant

### DIFF
--- a/src/renderers/shared/reconciler/ReactUpdateQueue.js
+++ b/src/renderers/shared/reconciler/ReactUpdateQueue.js
@@ -32,7 +32,7 @@ function enqueueUpdate(internalInstance) {
 }
 
 function getInternalInstanceReadyForUpdate(publicInstance, callerName) {
-  invariant(
+  warning(
     ReactCurrentOwner.current == null,
     '%s(...): Cannot update during an existing state transition ' +
     '(such as within `render`). Render methods should be a pure function ' +


### PR DESCRIPTION
We keep track of the fact that something is rendering for a bunch of
warnings. (ReactCurrentOwner.current !== null)

Once we get rid of owner for string refs, I'll convert those to something
like "isRendering" instead. The interesting part is that feature is
 `__DEV__` only. It is only used for warnings. Except for this one case.

This means that we can get rid of the special case for the isRendering
stack on in prod.