### PR TITLE
Deprecate non-isomorphic react methods in npm module

### DIFF
--- a/grunt/config/jsx.js
+++ b/grunt/config/jsx.js
@@ -6,6 +6,8 @@ var grunt = require('grunt');
 var rootIDs = [
   'React',
   'ReactWithAddons',
+  // deprecated is used in the npm package but not anywhere else, so build it.
+  'deprecated',
 ];
 
 var normal = {

--- a/npm-react/react.js
+++ b/npm-react/react.js
@@ -1,1 +1,53 @@
-module.exports = require('./lib/React');
+'use strict';
+
+var React = require('./lib/React');
+
+var assign = require('./lib/Object.assign');
+var deprecated = require('./lib/deprecated');
+
+// We want to warn once when any of these methods are used.
+if (process.env.NODE_ENV !== 'production') {
+  var deprecations = {
+    // ReactDOMClient
+    findDOMNode: deprecated(
+      'findDOMNode',
+      'react-dom',
+      React,
+      React.findDOMNode
+    ),
+    render: deprecated(
+      'render',
+      'react-dom',
+      React,
+      React.render
+    ),
+    unmountComponentAtNode: deprecated(
+      'unmountComponentAtNode',
+      'react-dom',
+      React,
+      React.unmountComponentAtNode
+    ),
+    // ReactDOMServer
+    renderToString: deprecated(
+      'renderToString',
+      'react-dom/server',
+      React,
+      React.renderToString
+    ),
+    renderToStaticMarkup: deprecated(
+      'renderToStaticMarkup',
+      'react-dom/server',
+      React,
+      React.renderToStaticMarkup
+    ),
+  };
+  // Export a wrapped object. We'll use assign and take advantage of the fact
+  // that this will override the original methods in React.
+  module.exports = assign(
+    {},
+    React,
+    deprecations
+  );
+} else {
+  module.exports = React;
+}

--- a/src/shared/utils/deprecated.js
+++ b/src/shared/utils/deprecated.js
@@ -18,30 +18,27 @@ var warning = require('warning');
  * This will log a single deprecation notice per function and forward the call
  * on to the new API.
  *
- * @param {string} namespace The namespace of the call, eg 'React'
- * @param {string} oldName The old function name, eg 'renderComponent'
- * @param {string} newName The new function name, eg 'render'
+ * @param {string} fnName The name of the function
+ * @param {string} newModule The module that fn will exist in
  * @param {*} ctx The context this forwarded call should run in
  * @param {function} fn The function to forward on to
- * @return {*} Will be the value as returned from `fn`
+ * @return {function} The function that will warn once and then call fn
  */
-function deprecated(namespace, oldName, newName, ctx, fn) {
+function deprecated(fnName, newModule, ctx, fn) {
   var warned = false;
   if (__DEV__) {
     var newFn = function() {
       warning(
         warned,
-        '%s.%s will be deprecated in a future version. ' +
-        'Use %s.%s instead.',
-        namespace,
-        oldName,
-        namespace,
-        newName
+        '`require("react").%s` is deprecated. Please use `require("%s").%s` ' +
+        'instead.',
+        fnName,
+        newModule,
+        fnName
       );
       warned = true;
       return fn.apply(ctx, arguments);
     };
-    newFn.displayName = `${namespace}_${oldName}`;
     // We need to make sure all properties of the original fn are copied over.
     // In particular, this is needed to support PropTypes
     return assign(newFn, fn);


### PR DESCRIPTION
This is obviously not right (not everything on these objects is a function - might do it as a getter instead or inspect types).

cc @sebmarkbage