### PR TITLE
Fixed grammar in CLA section of contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ The core team will be monitoring for pull requests. When we get one, we'll run s
 5. Make sure your code lints (`grunt lint`) - we've done our best to make sure these rules match our internal linting guidelines.
 6. If you haven't already, complete the CLA.
 
-### Contributor License Agreement ("CLA")
+### Contributor License Agreement (CLA)
 
 In order to accept your pull request, we need you to submit a CLA. You only need to do this once, so if you've done this for another Facebook open source project, you're good to go. If you are submitting a pull request for the first time, just let us know that you have completed the CLA and we can cross-check with your GitHub username.
 


### PR DESCRIPTION
The header for the CLA section currently has the acronym in quotation marks--this is not in keeping with Modern Language Association (MLA) standards. 

Before:
![screen shot 2015-06-11 at 5 42 57 pm](https://cloud.githubusercontent.com/assets/8728339/8121603/b85ddb96-1062-11e5-9c6d-66ef91aa1f5a.png)

After:
![screen shot 2015-06-11 at 5 45 35 pm](https://cloud.githubusercontent.com/assets/8728339/8121604/ba8ada54-1062-11e5-8195-daafbcb08b02.png)

Also, I did complete my CLA agreement.
