### PR TITLE
Move isMounted logic into the ReactUpdateQueue

### DIFF
--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -12,11 +12,8 @@
 'use strict';
 
 var ReactComponent = require('ReactComponent');
-var ReactCurrentOwner = require('ReactCurrentOwner');
 var ReactElement = require('ReactElement');
 var ReactErrorUtils = require('ReactErrorUtils');
-var ReactInstanceMap = require('ReactInstanceMap');
-var ReactLifeCycle = require('ReactLifeCycle');
 var ReactPropTypeLocations = require('ReactPropTypeLocations');
 var ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
 var ReactUpdateQueue = require('ReactUpdateQueue');
@@ -728,27 +725,7 @@ var ReactClassMixin = {
    * @final
    */
   isMounted: function() {
-    if (__DEV__) {
-      var owner = ReactCurrentOwner.current;
-      if (owner !== null) {
-        warning(
-          owner._warnedAboutRefsInRender,
-          '%s is accessing isMounted inside its render() function. ' +
-          'render() should be a pure function of props and state. It should ' +
-          'never access something that requires stale data from the previous ' +
-          'render, such as refs. Move this logic to componentDidMount and ' +
-          'componentDidUpdate instead.',
-          owner.getName() || 'A component'
-        );
-        owner._warnedAboutRefsInRender = true;
-      }
-    }
-    var internalInstance = ReactInstanceMap.get(this);
-    if (internalInstance) {
-      return internalInstance !== ReactLifeCycle.currentlyMountingInstance;
-    } else {
-      return false;
-    }
+    return ReactUpdateQueue.isMounted(this);
   },
 
   /**

--- a/src/renderers/shared/reconciler/ReactUpdateQueue.js
+++ b/src/renderers/shared/reconciler/ReactUpdateQueue.js
@@ -73,6 +73,37 @@ function getInternalInstanceReadyForUpdate(publicInstance, callerName) {
 var ReactUpdateQueue = {
 
   /**
+   * Checks whether or not this composite component is mounted.
+   * @param {ReactClass} publicInstance The instance we want to test.
+   * @return {boolean} True if mounted, false otherwise.
+   * @protected
+   * @final
+   */
+  isMounted: function(publicInstance) {
+    if (__DEV__) {
+      var owner = ReactCurrentOwner.current;
+      if (owner !== null) {
+        warning(
+          owner._warnedAboutRefsInRender,
+          '%s is accessing isMounted inside its render() function. ' +
+          'render() should be a pure function of props and state. It should ' +
+          'never access something that requires stale data from the previous ' +
+          'render, such as refs. Move this logic to componentDidMount and ' +
+          'componentDidUpdate instead.',
+          owner.getName() || 'A component'
+        );
+        owner._warnedAboutRefsInRender = true;
+      }
+    }
+    var internalInstance = ReactInstanceMap.get(publicInstance);
+    if (internalInstance) {
+      return internalInstance !== ReactLifeCycle.currentlyMountingInstance;
+    } else {
+      return false;
+    }
+  },
+
+  /**
    * Enqueue a callback that will be executed after all the pending updates
    * have processed.
    *


### PR DESCRIPTION
This is kind of a confusing place for it but it is intimitely tied to the
update life cycle which is what the update queue is about.

This kills some dependencies from isomorphic to the renderer.