### PR TITLE
Add failing test about module component

### DIFF
--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -455,6 +455,34 @@ describe('ReactCompositeComponent', function() {
     );
   });
 
+  it('should support module component', function() {
+    function ModuleComponent(props) {
+      return {
+        render: function() {
+          return (
+            <div>{props.test}</div>
+          );
+        },
+      };
+    }
+
+    var Component = React.createClass({
+      render: function() {
+        return <ModuleComponent {...this.props} />;
+      },
+    })
+
+    var instance = ReactTestUtils.renderIntoDocument(
+      <Component test="test" />
+    );
+
+    expect(React.findDOMNode(instance).textContent).toBe('test');
+
+    instance.setProps({test: 'mest'});
+
+    expect(React.findDOMNode(instance).textContent).toBe('mest');
+  });
+
   it('should cleanup even if render() fatals', function() {
     var BadComponent = React.createClass({
       render: function() {


### PR DESCRIPTION
Module pattern components like
`function Component(props) { return { render() { return <div /> } } }`
doesn't update when props changed.

This behaviour looks like a buggy. Am I right?