### PR TITLE
npm script to run lint only on changed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "test": "jest",
     "jest": "jest",
     "lint": "grunt lint",
+    "linc": "git diff --name-only --diff-filter=ACMRTUB `git merge-base HEAD master` | grep '\\.js$' | xargs eslint --",
     "build": "grunt build"
   },
   "jest": {


### PR DESCRIPTION
Sort of useful and faster than `grunt lint`. *nix only. I also have some untracked files locally which screw up linting so this is better.