### PR TITLE
Make events propagate through shadow DOMs.


### DIFF
--- a/src/renderers/dom/client/eventPlugins/EnterLeaveEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/EnterLeaveEventPlugin.js
@@ -63,7 +63,8 @@ var EnterLeaveEventPlugin = {
       topLevelType,
       topLevelTarget,
       topLevelTargetID,
-      nativeEvent) {
+      nativeEvent,
+      nativeEventTarget) {
     if (topLevelType === topLevelTypes.topMouseOver &&
         (nativeEvent.relatedTarget || nativeEvent.fromElement)) {
       return null;
@@ -110,7 +111,8 @@ var EnterLeaveEventPlugin = {
     var leave = SyntheticMouseEvent.getPooled(
       eventTypes.mouseLeave,
       fromID,
-      nativeEvent
+      nativeEvent,
+      nativeEventTarget
     );
     leave.type = 'mouseleave';
     leave.target = from;
@@ -119,7 +121,8 @@ var EnterLeaveEventPlugin = {
     var enter = SyntheticMouseEvent.getPooled(
       eventTypes.mouseEnter,
       toID,
-      nativeEvent
+      nativeEvent,
+      nativeEventTarget
     );
     enter.type = 'mouseenter';
     enter.target = to;

--- a/src/renderers/dom/client/eventPlugins/SelectEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/SelectEventPlugin.js
@@ -92,7 +92,7 @@ function getSelection(node) {
  * @param {object} nativeEvent
  * @return {?SyntheticEvent}
  */
-function constructSelectEvent(nativeEvent) {
+function constructSelectEvent(nativeEvent, nativeEventTarget) {
   // Ensure we have the right element, and that the user is not dragging a
   // selection (this matches native `select` event behavior). In HTML5, select
   // fires only on input and textarea thus if there's no focused element we
@@ -111,7 +111,8 @@ function constructSelectEvent(nativeEvent) {
     var syntheticEvent = SyntheticEvent.getPooled(
       eventTypes.select,
       activeElementID,
-      nativeEvent
+      nativeEvent,
+      nativeEventTarget
     );
 
     syntheticEvent.type = 'select';
@@ -155,8 +156,8 @@ var SelectEventPlugin = {
       topLevelType,
       topLevelTarget,
       topLevelTargetID,
-      nativeEvent) {
-
+      nativeEvent,
+      nativeEventTarget) {
     if (!hasListener) {
       return null;
     }
@@ -185,7 +186,7 @@ var SelectEventPlugin = {
       case topLevelTypes.topContextMenu:
       case topLevelTypes.topMouseUp:
         mouseDown = false;
-        return constructSelectEvent(nativeEvent);
+        return constructSelectEvent(nativeEvent, nativeEventTarget);
 
       // Chrome and IE fire non-standard event when selection is changed (and
       // sometimes when it hasn't).
@@ -196,7 +197,7 @@ var SelectEventPlugin = {
       case topLevelTypes.topSelectionChange:
       case topLevelTypes.topKeyDown:
       case topLevelTypes.topKeyUp:
-        return constructSelectEvent(nativeEvent);
+        return constructSelectEvent(nativeEvent, nativeEventTarget);
     }
 
     return null;

--- a/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
@@ -334,7 +334,8 @@ var SimpleEventPlugin = {
       topLevelType,
       topLevelTarget,
       topLevelTargetID,
-      nativeEvent) {
+      nativeEvent,
+      nativeEventTarget) {
     var dispatchConfig = topLevelEventsToDispatchConfig[topLevelType];
     if (!dispatchConfig) {
       return null;
@@ -418,7 +419,8 @@ var SimpleEventPlugin = {
     var event = EventConstructor.getPooled(
       dispatchConfig,
       topLevelTargetID,
-      nativeEvent
+      nativeEvent,
+      nativeEventTarget
     );
     EventPropagators.accumulateTwoPhaseDispatches(event);
     return event;

--- a/src/renderers/dom/client/eventPlugins/TapEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/TapEventPlugin.js
@@ -101,7 +101,8 @@ var TapEventPlugin = {
       topLevelType,
       topLevelTarget,
       topLevelTargetID,
-      nativeEvent) {
+      nativeEvent,
+      nativeEventTarget) {
     if (!isStartish(topLevelType) && !isEndish(topLevelType)) {
       return null;
     }
@@ -122,7 +123,8 @@ var TapEventPlugin = {
       event = SyntheticUIEvent.getPooled(
         eventTypes.touchTap,
         topLevelTargetID,
-        nativeEvent
+        nativeEvent,
+        nativeEventTarget
       );
     }
     if (isStartish(topLevelType)) {

--- a/src/renderers/dom/client/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
+++ b/src/renderers/dom/client/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
@@ -48,7 +48,8 @@ describe('EnterLeaveEventPlugin', function() {
       topLevelTypes.topMouseOver,
       div,
       ReactMount.getID(div),
-      {target: div}
+      {target: div},
+      div
     );
     expect(extracted.length).toBe(2);
 

--- a/src/renderers/dom/client/eventPlugins/__tests__/SelectEventPlugin-test.js
+++ b/src/renderers/dom/client/eventPlugins/__tests__/SelectEventPlugin-test.js
@@ -30,7 +30,8 @@ describe('SelectEventPlugin', function() {
       topLevelEvent,
       node,
       ReactMount.getID(node),
-      {target: node}
+      {target: node},
+      node
     );
   }
 

--- a/src/renderers/dom/client/syntheticEvents/SyntheticClipboardEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticClipboardEvent.js
@@ -34,8 +34,8 @@ var ClipboardEventInterface = {
  * @param {object} nativeEvent Native browser event.
  * @extends {SyntheticUIEvent}
  */
-function SyntheticClipboardEvent(dispatchConfig, dispatchMarker, nativeEvent) {
-  SyntheticEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent);
+function SyntheticClipboardEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  SyntheticEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
 }
 
 SyntheticEvent.augmentClass(SyntheticClipboardEvent, ClipboardEventInterface);

--- a/src/renderers/dom/client/syntheticEvents/SyntheticCompositionEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticCompositionEvent.js
@@ -31,8 +31,9 @@ var CompositionEventInterface = {
 function SyntheticCompositionEvent(
   dispatchConfig,
   dispatchMarker,
-  nativeEvent) {
-  SyntheticEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent);
+  nativeEvent,
+  nativeEventTarget) {
+  SyntheticEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
 }
 
 SyntheticEvent.augmentClass(

--- a/src/renderers/dom/client/syntheticEvents/SyntheticDragEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticDragEvent.js
@@ -28,8 +28,8 @@ var DragEventInterface = {
  * @param {object} nativeEvent Native browser event.
  * @extends {SyntheticUIEvent}
  */
-function SyntheticDragEvent(dispatchConfig, dispatchMarker, nativeEvent) {
-  SyntheticMouseEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent);
+function SyntheticDragEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  SyntheticMouseEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
 }
 
 SyntheticMouseEvent.augmentClass(SyntheticDragEvent, DragEventInterface);

--- a/src/renderers/dom/client/syntheticEvents/SyntheticEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticEvent.js
@@ -16,15 +16,14 @@ var PooledClass = require('PooledClass');
 
 var assign = require('Object.assign');
 var emptyFunction = require('emptyFunction');
-var getEventTarget = require('getEventTarget');
 
 /**
  * @interface Event
  * @see http://www.w3.org/TR/DOM-Level-3-Events/
  */
 var EventInterface = {
+  path: null,
   type: null,
-  target: getEventTarget,
   // currentTarget is set when dispatching; no use in copying it here
   currentTarget: emptyFunction.thatReturnsNull,
   eventPhase: null,
@@ -54,10 +53,12 @@ var EventInterface = {
  * @param {string} dispatchMarker Marker identifying the event target.
  * @param {object} nativeEvent Native browser event.
  */
-function SyntheticEvent(dispatchConfig, dispatchMarker, nativeEvent) {
+function SyntheticEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
   this.dispatchConfig = dispatchConfig;
   this.dispatchMarker = dispatchMarker;
   this.nativeEvent = nativeEvent;
+  this.target = nativeEventTarget;
+  this.currentTarget = nativeEventTarget;
 
   var Interface = this.constructor.Interface;
   for (var propName in Interface) {
@@ -156,9 +157,9 @@ SyntheticEvent.augmentClass = function(Class, Interface) {
   Class.Interface = assign({}, Super.Interface, Interface);
   Class.augmentClass = Super.augmentClass;
 
-  PooledClass.addPoolingTo(Class, PooledClass.threeArgumentPooler);
+  PooledClass.addPoolingTo(Class, PooledClass.fourArgumentPooler);
 };
 
-PooledClass.addPoolingTo(SyntheticEvent, PooledClass.threeArgumentPooler);
+PooledClass.addPoolingTo(SyntheticEvent, PooledClass.fourArgumentPooler);
 
 module.exports = SyntheticEvent;

--- a/src/renderers/dom/client/syntheticEvents/SyntheticFocusEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticFocusEvent.js
@@ -28,8 +28,8 @@ var FocusEventInterface = {
  * @param {object} nativeEvent Native browser event.
  * @extends {SyntheticUIEvent}
  */
-function SyntheticFocusEvent(dispatchConfig, dispatchMarker, nativeEvent) {
-  SyntheticUIEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent);
+function SyntheticFocusEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  SyntheticUIEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
 }
 
 SyntheticUIEvent.augmentClass(SyntheticFocusEvent, FocusEventInterface);

--- a/src/renderers/dom/client/syntheticEvents/SyntheticInputEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticInputEvent.js
@@ -32,8 +32,9 @@ var InputEventInterface = {
 function SyntheticInputEvent(
   dispatchConfig,
   dispatchMarker,
-  nativeEvent) {
-  SyntheticEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent);
+  nativeEvent,
+  nativeEventTarget) {
+  SyntheticEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
 }
 
 SyntheticEvent.augmentClass(

--- a/src/renderers/dom/client/syntheticEvents/SyntheticKeyboardEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticKeyboardEvent.js
@@ -76,8 +76,8 @@ var KeyboardEventInterface = {
  * @param {object} nativeEvent Native browser event.
  * @extends {SyntheticUIEvent}
  */
-function SyntheticKeyboardEvent(dispatchConfig, dispatchMarker, nativeEvent) {
-  SyntheticUIEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent);
+function SyntheticKeyboardEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  SyntheticUIEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
 }
 
 SyntheticUIEvent.augmentClass(SyntheticKeyboardEvent, KeyboardEventInterface);

--- a/src/renderers/dom/client/syntheticEvents/SyntheticMouseEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticMouseEvent.js
@@ -72,8 +72,8 @@ var MouseEventInterface = {
  * @param {object} nativeEvent Native browser event.
  * @extends {SyntheticUIEvent}
  */
-function SyntheticMouseEvent(dispatchConfig, dispatchMarker, nativeEvent) {
-  SyntheticUIEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent);
+function SyntheticMouseEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  SyntheticUIEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
 }
 
 SyntheticUIEvent.augmentClass(SyntheticMouseEvent, MouseEventInterface);

--- a/src/renderers/dom/client/syntheticEvents/SyntheticTouchEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticTouchEvent.js
@@ -37,8 +37,8 @@ var TouchEventInterface = {
  * @param {object} nativeEvent Native browser event.
  * @extends {SyntheticUIEvent}
  */
-function SyntheticTouchEvent(dispatchConfig, dispatchMarker, nativeEvent) {
-  SyntheticUIEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent);
+function SyntheticTouchEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  SyntheticUIEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
 }
 
 SyntheticUIEvent.augmentClass(SyntheticTouchEvent, TouchEventInterface);

--- a/src/renderers/dom/client/syntheticEvents/SyntheticUIEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticUIEvent.js
@@ -51,8 +51,8 @@ var UIEventInterface = {
  * @param {object} nativeEvent Native browser event.
  * @extends {SyntheticEvent}
  */
-function SyntheticUIEvent(dispatchConfig, dispatchMarker, nativeEvent) {
-  SyntheticEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent);
+function SyntheticUIEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  SyntheticEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
 }
 
 SyntheticEvent.augmentClass(SyntheticUIEvent, UIEventInterface);

--- a/src/renderers/dom/client/syntheticEvents/SyntheticWheelEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticWheelEvent.js
@@ -50,8 +50,8 @@ var WheelEventInterface = {
  * @param {object} nativeEvent Native browser event.
  * @extends {SyntheticMouseEvent}
  */
-function SyntheticWheelEvent(dispatchConfig, dispatchMarker, nativeEvent) {
-  SyntheticMouseEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent);
+function SyntheticWheelEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  SyntheticMouseEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
 }
 
 SyntheticMouseEvent.augmentClass(SyntheticWheelEvent, WheelEventInterface);

--- a/src/renderers/dom/client/syntheticEvents/__tests__/SyntheticEvent-test.js
+++ b/src/renderers/dom/client/syntheticEvents/__tests__/SyntheticEvent-test.js
@@ -20,7 +20,8 @@ describe('SyntheticEvent', function() {
     SyntheticEvent = require('SyntheticEvent');
 
     createEvent = function(nativeEvent) {
-      return SyntheticEvent.getPooled({}, '', nativeEvent);
+      var target = require('getEventTarget')(nativeEvent);
+      return SyntheticEvent.getPooled({}, '', nativeEvent, target);
     };
   });
 

--- a/src/renderers/dom/client/syntheticEvents/__tests__/SyntheticWheelEvent-test.js
+++ b/src/renderers/dom/client/syntheticEvents/__tests__/SyntheticWheelEvent-test.js
@@ -20,7 +20,8 @@ describe('SyntheticWheelEvent', function() {
     SyntheticWheelEvent = require('SyntheticWheelEvent');
 
     createEvent = function(nativeEvent) {
-      return SyntheticWheelEvent.getPooled({}, '', nativeEvent);
+      var target = require('getEventTarget')(nativeEvent);
+      return SyntheticWheelEvent.getPooled({}, '', nativeEvent, target);
     };
   });
 

--- a/src/renderers/shared/event/EventPluginHub.js
+++ b/src/renderers/shared/event/EventPluginHub.js
@@ -230,7 +230,8 @@ var EventPluginHub = {
       topLevelType,
       topLevelTarget,
       topLevelTargetID,
-      nativeEvent) {
+      nativeEvent,
+      nativeEventTarget) {
     var events;
     var plugins = EventPluginRegistry.plugins;
     for (var i = 0; i < plugins.length; i++) {
@@ -241,7 +242,8 @@ var EventPluginHub = {
           topLevelType,
           topLevelTarget,
           topLevelTargetID,
-          nativeEvent
+          nativeEvent,
+          nativeEventTarget
         );
         if (extractedEvents) {
           events = accumulateInto(events, extractedEvents);

--- a/src/renderers/shared/event/eventPlugins/ResponderEventPlugin.js
+++ b/src/renderers/shared/event/eventPlugins/ResponderEventPlugin.js
@@ -325,7 +325,8 @@ to return true:wantsResponderID|                            |
 function setResponderAndExtractTransfer(
     topLevelType,
     topLevelTargetID,
-    nativeEvent) {
+    nativeEvent,
+    nativeEventTarget) {
   var shouldSetEventType =
     isStartish(topLevelType) ? eventTypes.startShouldSetResponder :
     isMoveish(topLevelType) ? eventTypes.moveShouldSetResponder :
@@ -346,7 +347,8 @@ function setResponderAndExtractTransfer(
   var shouldSetEvent = ResponderSyntheticEvent.getPooled(
     shouldSetEventType,
     bubbleShouldSetFrom,
-    nativeEvent
+    nativeEvent,
+    nativeEventTarget
   );
   shouldSetEvent.touchHistory = ResponderTouchHistoryStore.touchHistory;
   if (skipOverBubbleShouldSetFrom) {
@@ -366,7 +368,8 @@ function setResponderAndExtractTransfer(
   var grantEvent = ResponderSyntheticEvent.getPooled(
     eventTypes.responderGrant,
     wantsResponderID,
-    nativeEvent
+    nativeEvent,
+    nativeEventTarget
   );
   grantEvent.touchHistory = ResponderTouchHistoryStore.touchHistory;
 
@@ -376,7 +379,8 @@ function setResponderAndExtractTransfer(
     var terminationRequestEvent = ResponderSyntheticEvent.getPooled(
       eventTypes.responderTerminationRequest,
       responderID,
-      nativeEvent
+      nativeEvent,
+      nativeEventTarget
     );
     terminationRequestEvent.touchHistory = ResponderTouchHistoryStore.touchHistory;
     EventPropagators.accumulateDirectDispatches(terminationRequestEvent);
@@ -391,7 +395,8 @@ function setResponderAndExtractTransfer(
       var terminateEvent = ResponderSyntheticEvent.getPooled(
         terminateType,
         responderID,
-        nativeEvent
+        nativeEvent,
+        nativeEventTarget
       );
       terminateEvent.touchHistory = ResponderTouchHistoryStore.touchHistory;
       EventPropagators.accumulateDirectDispatches(terminateEvent);
@@ -401,7 +406,8 @@ function setResponderAndExtractTransfer(
       var rejectEvent = ResponderSyntheticEvent.getPooled(
         eventTypes.responderReject,
         wantsResponderID,
-        nativeEvent
+        nativeEvent,
+        nativeEventTarget
       );
       rejectEvent.touchHistory = ResponderTouchHistoryStore.touchHistory;
       EventPropagators.accumulateDirectDispatches(rejectEvent);
@@ -487,8 +493,8 @@ var ResponderEventPlugin = {
       topLevelType,
       topLevelTarget,
       topLevelTargetID,
-      nativeEvent) {
-
+      nativeEvent,
+      nativeEventTarget) {
     if (isStartish(topLevelType)) {
       trackedTouchCount += 1;
     } else if (isEndish(topLevelType)) {
@@ -499,10 +505,14 @@ var ResponderEventPlugin = {
       );
     }
 
-    ResponderTouchHistoryStore.recordTouchTrack(topLevelType, nativeEvent);
+    ResponderTouchHistoryStore.recordTouchTrack(topLevelType, nativeEvent, nativeEventTarget);
 
     var extracted = canTriggerTransfer(topLevelType, topLevelTargetID) ?
-      setResponderAndExtractTransfer(topLevelType, topLevelTargetID, nativeEvent) :
+      setResponderAndExtractTransfer(
+        topLevelType,
+        topLevelTargetID,
+        nativeEvent,
+        nativeEventTarget) :
       null;
     // Responder may or may not have transfered on a new touch start/move.
     // Regardless, whoever is the responder after any potential transfer, we
@@ -525,7 +535,12 @@ var ResponderEventPlugin = {
 
     if (incrementalTouch) {
       var gesture =
-        ResponderSyntheticEvent.getPooled(incrementalTouch, responderID, nativeEvent);
+        ResponderSyntheticEvent.getPooled(
+          incrementalTouch,
+          responderID,
+          nativeEvent,
+          nativeEventTarget
+        );
       gesture.touchHistory = ResponderTouchHistoryStore.touchHistory;
       EventPropagators.accumulateDirectDispatches(gesture);
       extracted = accumulate(extracted, gesture);
@@ -545,7 +560,7 @@ var ResponderEventPlugin = {
       null;
     if (finalTouch) {
       var finalEvent =
-        ResponderSyntheticEvent.getPooled(finalTouch, responderID, nativeEvent);
+        ResponderSyntheticEvent.getPooled(finalTouch, responderID, nativeEvent, nativeEventTarget);
       finalEvent.touchHistory = ResponderTouchHistoryStore.touchHistory;
       EventPropagators.accumulateDirectDispatches(finalEvent);
       extracted = accumulate(extracted, finalEvent);

--- a/src/renderers/shared/event/eventPlugins/ResponderSyntheticEvent.js
+++ b/src/renderers/shared/event/eventPlugins/ResponderSyntheticEvent.js
@@ -31,8 +31,8 @@ var ResponderEventInterface = {
  * @param {object} nativeEvent Native event.
  * @extends {SyntheticEvent}
  */
-function ResponderSyntheticEvent(dispatchConfig, dispatchMarker, nativeEvent) {
-  SyntheticEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent);
+function ResponderSyntheticEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
+  SyntheticEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
 }
 
 SyntheticEvent.augmentClass(ResponderSyntheticEvent, ResponderEventInterface);

--- a/src/renderers/shared/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
+++ b/src/renderers/shared/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
@@ -67,7 +67,7 @@ var antiSubsequence = function(arr, indices) {
  * @param allTouchHandles
  */
 var _touchConfig =
-  function(topType, targetNodeHandle, allTouchHandles, changedIndices) {
+  function(topType, targetNodeHandle, allTouchHandles, changedIndices, eventTarget) {
   var allTouchObjects = allTouchHandles.map(touch);
   var changedTouchObjects = subsequence(allTouchObjects, changedIndices);
   var activeTouchObjects =
@@ -112,7 +112,8 @@ var startConfig = function(nodeHandle, allTouchHandles, changedIndices) {
     topLevelTypes.topTouchStart,
     nodeHandle,
     allTouchHandles,
-    changedIndices
+    changedIndices,
+    nodeHandle
   );
 };
 
@@ -124,7 +125,8 @@ var moveConfig = function(nodeHandle, allTouchHandles, changedIndices) {
     topLevelTypes.topTouchMove,
     nodeHandle,
     allTouchHandles,
-    changedIndices
+    changedIndices,
+    nodeHandle
   );
 };
 
@@ -136,7 +138,8 @@ var endConfig = function(nodeHandle, allTouchHandles, changedIndices) {
     topLevelTypes.topTouchEnd,
     nodeHandle,
     allTouchHandles,
-    changedIndices
+    changedIndices,
+    nodeHandle
   );
 };
 
@@ -290,7 +293,8 @@ var run = function(config, hierarchyConfig, nativeEventConfig) {
     nativeEventConfig.topLevelType,
     nativeEventConfig.target,
     nativeEventConfig.targetID,
-    nativeEventConfig.nativeEvent
+    nativeEventConfig.nativeEvent,
+    nativeEventConfig.target
   );
 
   // At this point the negotiation events have been dispatched as part of the

--- a/src/renderers/shared/reconciler/ReactEventEmitterMixin.js
+++ b/src/renderers/shared/reconciler/ReactEventEmitterMixin.js
@@ -33,14 +33,15 @@ var ReactEventEmitterMixin = {
       topLevelType,
       topLevelTarget,
       topLevelTargetID,
-      nativeEvent) {
+      nativeEvent,
+      nativeEventTarget) {
     var events = EventPluginHub.extractEvents(
       topLevelType,
       topLevelTarget,
       topLevelTargetID,
-      nativeEvent
+      nativeEvent,
+      nativeEventTarget
     );
-
     runEventQueueInBatch(events);
   },
 };

--- a/src/shared/utils/PooledClass.js
+++ b/src/shared/utils/PooledClass.js
@@ -53,6 +53,17 @@ var threeArgumentPooler = function(a1, a2, a3) {
   }
 };
 
+var fourArgumentPooler = function(a1, a2, a3, a4) {
+  var Klass = this;
+  if (Klass.instancePool.length) {
+    var instance = Klass.instancePool.pop();
+    Klass.call(instance, a1, a2, a3, a4);
+    return instance;
+  } else {
+    return new Klass(a1, a2, a3, a4);
+  }
+};
+
 var fiveArgumentPooler = function(a1, a2, a3, a4, a5) {
   var Klass = this;
   if (Klass.instancePool.length) {
@@ -106,6 +117,7 @@ var PooledClass = {
   oneArgumentPooler: oneArgumentPooler,
   twoArgumentPooler: twoArgumentPooler,
   threeArgumentPooler: threeArgumentPooler,
+  fourArgumentPooler: fourArgumentPooler,
   fiveArgumentPooler: fiveArgumentPooler,
 };
 

--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -450,7 +450,8 @@ function makeSimulator(eventType) {
     var event = new SyntheticEvent(
       dispatchConfig,
       ReactMount.getID(node),
-      fakeNativeEvent
+      fakeNativeEvent,
+      node
     );
     assign(event, eventData);
 


### PR DESCRIPTION
Make events propagate through shadow DOMs.  This is necessary for WebComponents, which often render into shadow DOMs, through which events may need to propagate.
