### PR TITLE
Drop Some ReactCurrentOwner Dependencies

### DIFF
--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -105,9 +105,8 @@ function validateExplicitKey(element, parentType) {
   warning(
     false,
     'Each child in an array or iterator should have a unique "key" prop.' +
-    '%s%s%s',
+    '%s%s',
     addenda.parentOrOwner || '',
-    addenda.childOwner || '',
     addenda.url || ''
   );
 }
@@ -170,19 +169,7 @@ function getAddendaForKeyUse(messageType, element, parentType) {
       parentName ? ` Check the React.render call using <${parentName}>.` :
       null,
     url: ' See https://fb.me/react-warning-keys for more information.',
-    childOwner: null,
   };
-
-  // Usually the current owner is the offender, but if it accepts children as a
-  // property, it may be the creator of the child that's responsible for
-  // assigning it a key.
-  if (element &&
-      element._owner &&
-      element._owner !== ReactCurrentOwner.current) {
-    // Give the component that originally created this child.
-    addenda.childOwner =
-      ` It was passed a child from ${getName(element._owner)}.`;
-  }
 
   return addenda;
 }

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -50,7 +50,7 @@ describe('ReactElementValidator', function() {
     );
   });
 
-  it('warns for keys for arrays of elements with owner info', function() {
+  it('warns for keys for arrays of elements passed from an owner', function() {
     spyOn(console, 'error');
     var Component = React.createFactory(ComponentClass);
 
@@ -77,8 +77,7 @@ describe('ReactElementValidator', function() {
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toContain(
       'Each child in an array or iterator should have a unique "key" prop. ' +
-      'Check the render method of InnerClass. ' +
-      'It was passed a child from ComponentWrapper. '
+      'Check the render method of InnerClass. '
     );
   });
 

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -59,7 +59,7 @@ describe('ReactJSXElementValidator', function() {
     );
   });
 
-  it('warns for keys for arrays of elements with owner info', function() {
+  it('warns for keys for arrays of elements passed from an owner', function() {
     spyOn(console, 'error');
 
     class InnerComponent {
@@ -83,8 +83,7 @@ describe('ReactJSXElementValidator', function() {
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toContain(
       'Each child in an array or iterator should have a unique "key" prop. ' +
-      'Check the render method of InnerComponent. ' +
-      'It was passed a child from ComponentWrapper. '
+      'Check the render method of InnerComponent. '
     );
   });
 

--- a/src/renderers/dom/ReactDOMClient.js
+++ b/src/renderers/dom/ReactDOMClient.js
@@ -13,7 +13,6 @@
 
 'use strict';
 
-var ReactCurrentOwner = require('ReactCurrentOwner');
 var ReactDOMTextComponent = require('ReactDOMTextComponent');
 var ReactDefaultInjection = require('ReactDefaultInjection');
 var ReactInstanceHandles = require('ReactInstanceHandles');
@@ -42,7 +41,10 @@ if (
   typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined' &&
   typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.inject === 'function') {
   __REACT_DEVTOOLS_GLOBAL_HOOK__.inject({
-    CurrentOwner: ReactCurrentOwner,
+    // We want to stop tracking owner. We'll leave that responsibility to
+    // the devtools. TODO: Expose before/after render hooks that enable the
+    // devtools this capability.
+    CurrentOwner: { current: null},
     InstanceHandles: ReactInstanceHandles,
     Mount: ReactMount,
     Reconciler: ReactReconciler,

--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -13,7 +13,6 @@
 
 var DOMProperty = require('DOMProperty');
 var ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
-var ReactCurrentOwner = require('ReactCurrentOwner');
 var ReactElement = require('ReactElement');
 var ReactElementValidator = require('ReactElementValidator');
 var ReactEmptyComponent = require('ReactEmptyComponent');
@@ -22,6 +21,7 @@ var ReactInstanceMap = require('ReactInstanceMap');
 var ReactMarkupChecksum = require('ReactMarkupChecksum');
 var ReactPerf = require('ReactPerf');
 var ReactReconciler = require('ReactReconciler');
+var ReactPureFunction = require('ReactPureFunction');
 var ReactUpdateQueue = require('ReactUpdateQueue');
 var ReactUpdates = require('ReactUpdates');
 
@@ -435,15 +435,14 @@ var ReactMount = {
     // Various parts of our code (such as ReactCompositeComponent's
     // _renderValidatedComponent) assume that calls to render aren't nested;
     // verify that that's the case.
-    warning(
-      ReactCurrentOwner.current == null,
-      '_renderNewRootComponent(): Render methods should be a pure function ' +
-      'of props and state; triggering nested component updates from ' +
-      'render is not allowed. If necessary, trigger nested updates in ' +
-      'componentDidUpdate. Check the render method of %s.',
-      ReactCurrentOwner.current && ReactCurrentOwner.current.getName() ||
-        'ReactCompositeComponent'
-    );
+    if (__DEV__) {
+      ReactPureFunction.assertSideEffect(
+        'Do not render new trees within render(). Render methods should be a ' +
+        'pure function of props and state; triggering nested component ' +
+        'updates from render is not allowed. If necessary, trigger nested ' +
+        'updates in componentDidUpdate.'
+      );
+    }
 
     var componentInstance = instantiateReactComponent(nextElement, null);
     var reactRootID = ReactMount._registerComponent(
@@ -667,15 +666,14 @@ var ReactMount = {
     // _renderValidatedComponent) assume that calls to render aren't nested;
     // verify that that's the case. (Strictly speaking, unmounting won't cause a
     // render but we still don't expect to be in a render call here.)
-    warning(
-      ReactCurrentOwner.current == null,
-      'unmountComponentAtNode(): Render methods should be a pure function ' +
-      'of props and state; triggering nested component updates from render ' +
-      'is not allowed. If necessary, trigger nested updates in ' +
-      'componentDidUpdate. Check the render method of %s.',
-      ReactCurrentOwner.current && ReactCurrentOwner.current.getName() ||
-        'ReactCompositeComponent'
-    );
+    if (__DEV__) {
+      ReactPureFunction.assertSideEffect(
+        'Do not call unmountComponentAtNode() inside of render(). Render' +
+        'should be a pure function of props and state; triggering nested ' +
+        'component updates from render is not allowed. If necessary, trigger ' +
+        'nested updates in componentDidUpdate.'
+      );
+    }
 
     invariant(
       container && (

--- a/src/renderers/dom/client/findDOMNode.js
+++ b/src/renderers/dom/client/findDOMNode.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var ReactCurrentOwner = require('ReactCurrentOwner');
+var ReactPureFunction = require('ReactPureFunction');
 var ReactInstanceMap = require('ReactInstanceMap');
 var ReactMount = require('ReactMount');
 
@@ -28,19 +28,13 @@ var warning = require('warning');
  */
 function findDOMNode(componentOrElement) {
   if (__DEV__) {
-    var owner = ReactCurrentOwner.current;
-    if (owner !== null) {
-      warning(
-        owner._warnedAboutRefsInRender,
-        '%s is accessing getDOMNode or findDOMNode inside its render(). ' +
-        'render() should be a pure function of props and state. It should ' +
-        'never access something that requires stale data from the previous ' +
-        'render, such as refs. Move this logic to componentDidMount and ' +
-        'componentDidUpdate instead.',
-        owner.getName() || 'A component'
-      );
-      owner._warnedAboutRefsInRender = true;
-    }
+    ReactPureFunction.assertSideEffect(
+      'Do not access getDOMNode or findDOMNode inside of render(). ' +
+      'render() should be a pure function of props and state. It should ' +
+      'never access something that requires stale data from the previous ' +
+      'render, such as refs. Move this logic to componentDidMount and ' +
+      'componentDidUpdate instead.'
+    );
   }
   if (componentOrElement == null) {
     return null;

--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -20,6 +20,7 @@ var ReactNativeComponent = require('ReactNativeComponent');
 var ReactPerf = require('ReactPerf');
 var ReactPropTypeLocations = require('ReactPropTypeLocations');
 var ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
+var ReactPureFunction = require('ReactPureFunction');
 var ReactReconciler = require('ReactReconciler');
 
 var assign = require('Object.assign');
@@ -743,11 +744,17 @@ var ReactCompositeComponentMixin = {
   _renderValidatedComponent: function() {
     var renderedComponent;
     ReactCurrentOwner.current = this;
+    if (__DEV__) {
+      ReactPureFunction.isPureScope = true;
+    }
     try {
       renderedComponent =
         this._renderValidatedComponentWithoutOwnerOrContext();
     } finally {
       ReactCurrentOwner.current = null;
+      if (__DEV__) {
+        ReactPureFunction.isPureScope = false;
+      }
     }
     invariant(
       // TODO: An `isValidNode` function would probably be more appropriate

--- a/src/renderers/shared/reconciler/ReactPureFunction.js
+++ b/src/renderers/shared/reconciler/ReactPureFunction.js
@@ -23,12 +23,22 @@ var warning = require('warning');
 var ReactPureFunction = {};
 
 if (__DEV__) {
+  var warningDedupeMap = {};
   ReactPureFunction.assertSideEffect = function(message) {
-    warning(
-      !ReactPureFunction.isPureScope,
-      message
-    );
-  }
+    if (ReactPureFunction.isPureScope) {
+      // As a heuristic we can use half the stack size for deduping errors.
+      // This ensures that we don't warn too much for similar callsites.
+      var warningKey = new Error().stack;
+      warningKey = warningKey.substr(0, Math.floor(warningKey.length / 2));
+      if (!warningDedupeMap[warningKey]) {
+        warningDedupeMap[warningKey] = true;
+        warning(
+          false,
+          message
+        );
+      }
+    }
+  };
   ReactPureFunction.isPureScope = false;
 }
 

--- a/src/renderers/shared/reconciler/ReactPureFunction.js
+++ b/src/renderers/shared/reconciler/ReactPureFunction.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactPureFunction
+ */
+
+'use strict';
+
+var warning = require('warning');
+
+/**
+ * This module is used to assert side-effects. In DEV mode, we track if the
+ * currently executing scope is pure. If it is, then any assertion of
+ * side-effects triggers a warning. There should be no side-effects in pure
+ * functions.
+ */
+
+var ReactPureFunction = {};
+
+if (__DEV__) {
+  ReactPureFunction.assertSideEffect = function(message) {
+    warning(
+      !ReactPureFunction.isPureScope,
+      message
+    );
+  }
+  ReactPureFunction.isPureScope = false;
+}
+
+module.exports = ReactPureFunction;

--- a/src/renderers/shared/reconciler/ReactUpdateQueue.js
+++ b/src/renderers/shared/reconciler/ReactUpdateQueue.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-var ReactCurrentOwner = require('ReactCurrentOwner');
 var ReactElement = require('ReactElement');
 var ReactInstanceMap = require('ReactInstanceMap');
+var ReactPureFunction = require('ReactPureFunction');
 var ReactUpdates = require('ReactUpdates');
 
 var assign = require('Object.assign');
@@ -26,12 +26,10 @@ function enqueueUpdate(internalInstance) {
 
 function getInternalInstanceReadyForUpdate(publicInstance, callerName) {
   if (__DEV__) {
-    warning(
-      ReactCurrentOwner.current == null,
-      '%s(...): Cannot update during an existing state transition ' +
-      '(such as within `render`). Render methods should be a pure function ' +
-      'of props and state.',
-      callerName
+    ReactPureFunction.assertSideEffect(
+      'Cannot ' + callerName + ' during an existing state transition (such ' +
+      'as within `render`). Render methods should be a pure function of ' +
+      'props and state.'
     );
   }
 
@@ -72,19 +70,13 @@ var ReactUpdateQueue = {
    */
   isMounted: function(publicInstance) {
     if (__DEV__) {
-      var owner = ReactCurrentOwner.current;
-      if (owner !== null) {
-        warning(
-          owner._warnedAboutRefsInRender,
-          '%s is accessing isMounted inside its render() function. ' +
-          'render() should be a pure function of props and state. It should ' +
-          'never access something that requires stale data from the previous ' +
-          'render, such as refs. Move this logic to componentDidMount and ' +
-          'componentDidUpdate instead.',
-          owner.getName() || 'A component'
-        );
-        owner._warnedAboutRefsInRender = true;
-      }
+      ReactPureFunction.assertSideEffect(
+        'Do not access isMounted inside of the render() function. ' +
+        'render() should be a pure function of props and state. It should ' +
+        'never access something that requires stale data from the previous ' +
+        'render, such as refs. Move this logic to componentDidMount and ' +
+        'componentDidUpdate instead.'
+      );
     }
     var internalInstance = ReactInstanceMap.get(publicInstance);
     if (internalInstance) {

--- a/src/renderers/shared/reconciler/__tests__/ReactComponentLifeCycle-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactComponentLifeCycle-test.js
@@ -253,7 +253,7 @@ describe('ReactComponentLifeCycle', function() {
 
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toContain(
-      'Component is accessing isMounted inside its render()'
+      'Do not access isMounted inside of the render() function'
     );
   });
 
@@ -320,7 +320,7 @@ describe('ReactComponentLifeCycle', function() {
     ReactTestUtils.renderIntoDocument(<Component />);
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toContain(
-      'Component is accessing getDOMNode or findDOMNode inside its render()'
+      'Do not access getDOMNode or findDOMNode inside of render()'
     );
   });
 

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -396,6 +396,9 @@ describe('ReactCompositeComponent', function() {
     expect(renderedState).toBe(1);
     expect(instance.state.value).toBe(1);
 
+    // Should've only warned once
+    expect(console.error.calls.length).toBe(1);
+
     // Forcing a rerender anywhere will cause the update to happen.
     var instance2 = React.render(<Component prop={123} />, container);
     expect(instance).toBe(instance2);

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -14,7 +14,7 @@
 var ChildUpdates;
 var MorphingComponent;
 var React;
-var ReactCurrentOwner;
+var ReactPureFunction;
 var ReactMount;
 var ReactPropTypes;
 var ReactServerRendering;
@@ -31,7 +31,7 @@ describe('ReactCompositeComponent', function() {
 
     reactComponentExpect = require('reactComponentExpect');
     React = require('React');
-    ReactCurrentOwner = require('ReactCurrentOwner');
+    ReactPureFunction = require('ReactPureFunction');
     ReactPropTypes = require('ReactPropTypes');
     ReactTestUtils = require('ReactTestUtils');
     ReactMount = require('ReactMount');
@@ -384,7 +384,7 @@ describe('ReactCompositeComponent', function() {
 
     expect(console.error.calls.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toBe(
-      'Warning: setState(...): Cannot update during an existing state ' +
+      'Warning: Cannot setState during an existing state ' +
       'transition (such as within `render`). Render methods should be a pure ' +
       'function of props and state.'
     );
@@ -472,18 +472,19 @@ describe('ReactCompositeComponent', function() {
   it('should cleanup even if render() fatals', function() {
     var BadComponent = React.createClass({
       render: function() {
+        expect(ReactPureFunction.isPureScope).toBe(true);
         throw new Error();
       },
     });
     var instance = <BadComponent />;
 
-    expect(ReactCurrentOwner.current).toBe(null);
+    expect(ReactPureFunction.isPureScope).toBe(false);
 
     expect(function() {
       instance = ReactTestUtils.renderIntoDocument(instance);
     }).toThrow();
 
-    expect(ReactCurrentOwner.current).toBe(null);
+    expect(ReactPureFunction.isPureScope).toBe(false);
   });
 
   it('should call componentWillUnmount before unmounting', function() {
@@ -797,10 +798,10 @@ describe('ReactCompositeComponent', function() {
     ReactTestUtils.renderIntoDocument(<Outer />);
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toBe(
-      'Warning: _renderNewRootComponent(): Render methods should ' +
-      'be a pure function of props and state; triggering nested component ' +
-      'updates from render is not allowed. If necessary, trigger nested ' +
-      'updates in componentDidUpdate. Check the render method of Outer.'
+      'Warning: Do not render new trees within render(). Render methods ' +
+      'should be a pure function of props and state; triggering nested ' +
+      'component updates from render is not allowed. If necessary, trigger ' +
+      'nested updates in componentDidUpdate.'
     );
   });
 


### PR DESCRIPTION
This drops all ReactCurrentOwner dependencies from the renderer. Instead
it tracks ReactPureFunction.isPureScope for DEV only. We can use it for
tracking functions that should be pure and trigger a warning when a
side-effectful or stateful function is called.

This removes the "owner" displayName from the error message. The idea is
that we can do better with stack traces than displayName and that is a more
generic solution.

There is still one remaining dependency for string refs which we can get
rid of later.

I also have some `_owner` references to drop in a follow up.