### PR TITLE
add break-word in example

### DIFF
--- a/docs/css/react.scss
+++ b/docs/css/react.scss
@@ -347,6 +347,7 @@ h1, h2, h3, h4, h5, h6 {
   p {
     margin: 0 0 25px 0;
     max-width: $twoColumnWidth;
+    word-break:break-word;
   }
 
   .example {


### PR DESCRIPTION
To example convert the textarea's value in real-time.
lack word-break: break-word; at output