### PR TITLE
Multiple addons packages

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,6 +75,10 @@ module.exports = function(grunt) {
   var npmReactDOMTasks = require('./grunt/tasks/npm-react-dom');
   grunt.registerTask('npm-react-dom:pack', npmReactDOMTasks.packRelease);
 
+  var npmReactAddonsTasks = require('./grunt/tasks/npm-react-addons');
+  grunt.registerTask('npm-react-addons:release', npmReactAddonsTasks.buildReleases);
+  grunt.registerTask('npm-react-addons:pack', npmReactAddonsTasks.packReleases);
+
   var gemReactSourceTasks = require('./grunt/tasks/gem-react-source');
   grunt.registerTask('gem-react-source:release', gemReactSourceTasks.buildRelease);
   grunt.registerTask('gem-react-source:pack', gemReactSourceTasks.packRelease);
@@ -228,6 +232,8 @@ module.exports = function(grunt) {
     'npm-react-tools:release',
     'npm-react-tools:pack',
     'npm-react-dom:pack',
+    'npm-react-addons:release',
+    'npm-react-addons:pack',
     'compare_size',
   ]);
 

--- a/grunt/tasks/npm-react-addons.js
+++ b/grunt/tasks/npm-react-addons.js
@@ -1,0 +1,114 @@
+'use strict';
+
+var assign = require('object-assign');
+var fs = require('fs');
+var grunt = require('grunt');
+var path = require('path');
+
+var addons = {
+  CSSTransitionGroup: {
+    module: 'ReactCSSTransitionGroup',
+    name: 'css-transition-group',
+  },
+  LinkedStateMixin: {
+    module: 'LinkedStateMixin',
+    name: 'linked-state-mixin',
+  },
+  PureRenderMixin: {
+    module: 'ReactComponentWithPureRenderMixin',
+    name: 'pure-render-mixin',
+  },
+  TransitionGroup: {
+    module: 'ReactTransitionGroup',
+    name: 'transition-group',
+  },
+  batchedUpdates: {
+    module: 'ReactUpdates',
+    method: 'batchedUpdates',
+    name: 'batched-updates',
+  },
+  cloneWithProps: {
+    module: 'cloneWithProps',
+    name: 'clone-with-props',
+  },
+  createFragment: {
+    module: 'ReactFragment',
+    method: 'create',
+    name: 'create-fragment',
+  },
+  shallowCompare: {
+    module: 'shallowCompare',
+    name: 'shallow-compare',
+  },
+  updates: {
+    module: 'updates',
+    name: 'updates',
+  },
+};
+
+function generateSource(info) {
+  var pieces = [
+    "module.exports = require('react/lib/",
+    info.module,
+    "')",
+  ];
+  if (info.method) {
+    pieces.push('.', info.method);
+  }
+  pieces.push(';');
+  return pieces.join('');
+}
+
+function buildReleases() {
+  var pkgTemplate = grunt.file.readJSON('./packages/react-addons/package.json');
+  // var done = this.async();
+  Object.keys(addons).map(function(k) {
+    var info = addons[k];
+    var pkgName = 'react-addons-' + info.name;
+    var destDir = 'build/packages/' + pkgName;
+
+    var pkgData = assign({}, pkgTemplate);
+    pkgData.name = pkgName;
+
+    grunt.file.mkdir(destDir);
+    fs.writeFileSync(path.join(destDir, 'index.js'), generateSource(info));
+    fs.writeFileSync(path.join(destDir, 'package.json'), JSON.stringify(pkgData, null, 2));
+
+    // TODO: Make a readme. Consider using a template and sticking it in the original source directory. Also, maybe a license, patents file.
+  });
+  // done();
+}
+
+function packReleases() {
+  var done = this.async();
+  var count = 0;
+
+  var addonKeys = Object.keys(addons);
+
+  addonKeys.forEach(function(k) {
+    var info = addons[k];
+    var pkgName = 'react-addons-' + info.name;
+    var pkgDir = 'build/packages/' + pkgName;
+
+    var spawnCmd = {
+      cmd: 'npm',
+      args: ['pack', pkgDir],
+    };
+    grunt.util.spawn(spawnCmd, function() {
+      var buildSrc = pkgName + '-' + grunt.config.data.pkg.version + '.tgz';
+      var buildDest = 'build/packages/' + pkgName + '.tgz';
+      fs.rename(buildSrc, buildDest, maybeDone);
+    });
+  });
+
+  function maybeDone() {
+    if (++count === addonKeys.length) {
+      done();
+    }
+  }
+}
+
+module.exports = {
+  buildReleases: buildReleases,
+  packReleases: packReleases,
+};

--- a/grunt/tasks/version-check.js
+++ b/grunt/tasks/version-check.js
@@ -10,11 +10,15 @@ var reactVersionExp = /\bReact\.version\s*=\s*['"]([^'"]+)['"];/;
 module.exports = function() {
   var pkgVersion = grunt.config.data.pkg.version;
 
+  var addonsData = grunt.file.readJSON('./packages/react-addons/package.json');
   var versions = {
     'packages/react/package.json':
       grunt.file.readJSON('./packages/react/package.json').version,
     'packages/react-dom/package.json':
       grunt.file.readJSON('./packages/react-dom/package.json').version,
+    'packages/react-addons/package.json (version)': addonsData.version,
+    // Get the "version" without the range bit
+    'packages/react-addons/package.json (react dependency)': addonsData.peerDependencies.react.slice(1),
     'src/React.js': reactVersionExp.exec(grunt.file.read('./src/React.js'))[1],
   };
 

--- a/packages/react-addons/package.json
+++ b/packages/react-addons/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "react-addons",
+  "version": "0.14.0-alpha3",
+  "main": "index.js",
+  "license": "BSD-3-Clause",
+  "peerDependencies": {
+    "react": "^0.14.0-alpha3"
+  }
+}

--- a/src/addons/ReactWithAddons.js
+++ b/src/addons/ReactWithAddons.js
@@ -28,7 +28,6 @@ var ReactTransitionGroup = require('ReactTransitionGroup');
 var ReactUpdates = require('ReactUpdates');
 
 var cloneWithProps = require('cloneWithProps');
-var renderSubtreeIntoContainer = require('renderSubtreeIntoContainer');
 var shallowCompare = require('shallowCompare');
 var update = require('update');
 
@@ -41,7 +40,6 @@ React.addons = {
   batchedUpdates: ReactUpdates.batchedUpdates,
   cloneWithProps: cloneWithProps,
   createFragment: ReactFragment.create,
-  renderSubtreeIntoContainer: renderSubtreeIntoContainer,
   shallowCompare: shallowCompare,
   update: update,
 };

--- a/src/renderers/dom/ReactDOMClient.js
+++ b/src/renderers/dom/ReactDOMClient.js
@@ -22,6 +22,7 @@ var ReactPerf = require('ReactPerf');
 var ReactReconciler = require('ReactReconciler');
 
 var findDOMNode = require('findDOMNode');
+var renderSubtreeIntoContainer = require('renderSubtreeIntoContainer');
 var warning = require('warning');
 
 ReactDefaultInjection.inject();
@@ -34,6 +35,7 @@ var React = {
   findDOMNode: findDOMNode,
   render: render,
   unmountComponentAtNode: ReactMount.unmountComponentAtNode,
+  _renderSubtreeIntoContainer: renderSubtreeIntoContainer,
 };
 
 // Inject the runtime into a devtools global hook regardless of browser.


### PR DESCRIPTION
This adds a grunt task to build multiple react-addons-* packages, one for each of our current addons. It might be a bit excessive and we might want to add some more of these to blessed APIs (See also #4184).

There are still a couple small pieces here but they should be fairly straightforward (readmes, license). We probably also want to delete the pieces in packages/react/addons so that we aren't adding 2 new ways to access addons in 0.14.

We may also want to do this a little less fancily so that we have finer control.