### PR TITLE
add break word in all examples

### DIFF
--- a/docs/css/react.scss
+++ b/docs/css/react.scss
@@ -344,6 +344,8 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 #examples {
+  word-break: break-word;
+  
   p {
     margin: 0 0 25px 0;
     max-width: $twoColumnWidth;


### PR DESCRIPTION
The bug it happens in all preview examples, i added in element parent #examples the  break-word.
So avoid redundancy on elements.

That would be the best solution for [#4181](https://github.com/facebook/react/pull/4181), [#4181](https://github.com/facebook/react/pull/4177).