### PR TITLE
Don't try building a %s module.

### DIFF
--- a/src/shared/utils/deprecated.js
+++ b/src/shared/utils/deprecated.js
@@ -30,6 +30,9 @@ function deprecated(fnName, newModule, ctx, fn) {
     var newFn = function() {
       warning(
         warned,
+        // Require examples in this string must be split to prevent React's
+        // build tools from mistaking them for real requires.
+        // Otherwise the build tools will attempt to build a '%s' module.
         '`require' + '("react").%s` is deprecated. Please use `require' + '("%s").%s` ' +
         'instead.',
         fnName,

--- a/src/shared/utils/deprecated.js
+++ b/src/shared/utils/deprecated.js
@@ -30,7 +30,7 @@ function deprecated(fnName, newModule, ctx, fn) {
     var newFn = function() {
       warning(
         warned,
-        '`require("react").%s` is deprecated. Please use `require("%s").%s` ' +
+        '`require' + '("react").%s` is deprecated. Please use `require' + '("%s").%s` ' +
         'instead.',
         fnName,
         newModule,


### PR DESCRIPTION
React's build tools are reading the `require("react")` and `react("%s")` inside the warning string and thinking they are actual requires.