### PR TITLE
Allow deeper trees

### DIFF
--- a/src/renderers/shared/reconciler/ReactInstanceHandles.js
+++ b/src/renderers/shared/reconciler/ReactInstanceHandles.js
@@ -22,7 +22,7 @@ var SEPARATOR_LENGTH = SEPARATOR.length;
 /**
  * Maximum depth of traversals before we consider the possibility of a bad ID.
  */
-var MAX_TREE_DEPTH = 100;
+var MAX_TREE_DEPTH = 10000;
 
 /**
  * Creates a DOM ID prefix to use when mounting React components.


### PR DESCRIPTION
No reason to limit at 100. I can't imagine a reasonable tree with depth over 10,000 but that should still be small enough to "catch infinite loops" quickly.