### PR TITLE
Fix docs typo: "overridden" -> "overwritten"

### DIFF
--- a/docs/docs/10.7-update.md
+++ b/docs/docs/10.7-update.md
@@ -20,7 +20,7 @@ myData.x.y.z = 7;
 myData.a.b.push(9);
 ```
 
-you have no way of determining which data has changed since the previous copy is overridden. Instead, you need to create a new copy of `myData` and change only the parts of it that need to be changed. Then you can compare the old copy of `myData` with the new one in `shouldComponentUpdate()` using triple-equals:
+you have no way of determining which data has changed since the previous copy has been overwritten. Instead, you need to create a new copy of `myData` and change only the parts of it that need to be changed. Then you can compare the old copy of `myData` with the new one in `shouldComponentUpdate()` using triple-equals:
 
 ```js
 var newData = deepCopy(myData);


### PR DESCRIPTION
I think this was meant to say "overwritten", since "the statement overwrites the data" makes more sense than "the statement overrides the data".