### PR TITLE
Add site title to first code snippet of getting started

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -28,6 +28,7 @@ In the root directory of the starter kit, create a `helloworld.html` with the fo
 <!DOCTYPE html>
 <html>
   <head>
+    <title>Hello React!</title>
     <script src="build/react.js"></script>
     <script src="build/JSXTransformer.js"></script>
   </head>


### PR DESCRIPTION
On https://facebook.github.io/react/docs/getting-started.html, in the second code snippet, the `<title>` tag suddenly appears. It wasn't included as part of the first code snippet.

**First state:**

![screen shot 2015-06-24 at 5 12 38 pm](https://cloud.githubusercontent.com/assets/1315101/8326553/7552913e-1a94-11e5-961f-de64a68d3ddb.png)

**Second state:** (Note that the `<title>` magically appears)

![screen shot 2015-06-24 at 5 12 44 pm](https://cloud.githubusercontent.com/assets/1315101/8326549/6ff0c2ba-1a94-11e5-8ce9-95061fc97ea1.png)

