### PR TITLE
Minor cleanup of ReactES6Class-test output by expecting the warning

### DIFF
--- a/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
+++ b/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
@@ -55,8 +55,16 @@ describe('ReactES6Class', function() {
   });
 
   it('throws if no render function is defined', function() {
+    spyOn(console, 'error');
     class Foo extends React.Component { }
     expect(() => React.render(<Foo />, container)).toThrow();
+    expect(console.error.calls[0].args[0]).toBe(
+      'Warning: Foo(...): ' +
+      'No `render` method found on the returned component instance: you may ' +
+      'have forgotten to define `render` in your component or you may have ' +
+      'accidentally tried to render an element whose type is a function that ' +
+      'isn\'t a React component.'
+    );
   });
 
   it('renders a simple stateless component with prop', function() {


### PR DESCRIPTION
When testing to see if calls to render would throw an exception, the render call was generating a warning, which then resulted in a warning when the tests were run.  This adds a check to make sure render generated the warning, eliminating the warning when running tests.  

As part of #3890 