### PR TITLE
Allow iterables to pass node prop type check

### DIFF
--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -349,12 +349,22 @@ function isNode(propValue) {
 
       var iteratorFn = getIteratorFn(propValue);
       if (iteratorFn) {
+        var iterator = iteratorFn.call(propValue);
+        var step;
         if (iteratorFn !== propValue.entries) {
-          var iterator = iteratorFn.call(propValue);
-          var step;
           while (!(step = iterator.next()).done) {
             if (!isNode(step.value)) {
               return false;
+            }
+          }
+        } else {
+          // Iterator will provide entry [k,v] tuples rather than values.
+          while (!(step = iterator.next()).done) {
+            var entry = step.value;
+            if (entry) {
+              if (!isNode(entry[1])) {
+                return false;
+              }
             }
           }
         }

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -16,6 +16,7 @@ var ReactFragment = require('ReactFragment');
 var ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
 
 var emptyFunction = require('emptyFunction');
+var getIteratorFn = require('getIteratorFn');
 
 /**
  * Collection of methods that allow declaration and validation of props that are
@@ -345,12 +346,27 @@ function isNode(propValue) {
       if (propValue === null || ReactElement.isValidElement(propValue)) {
         return true;
       }
-      propValue = ReactFragment.extractIfFragment(propValue);
-      for (var k in propValue) {
-        if (!isNode(propValue[k])) {
-          return false;
+
+      var iteratorFn = getIteratorFn(propValue);
+      if (iteratorFn) {
+        if (iteratorFn !== propValue.entries) {
+          var iterator = iteratorFn.call(propValue);
+          var step;
+          while (!(step = iterator.next()).done) {
+            if (!isNode(step.value)) {
+              return false;
+            }
+          }
+        }
+      } else {
+        propValue = ReactFragment.extractIfFragment(propValue);
+        for (var k in propValue) {
+          if (!isNode(propValue[k])) {
+            return false;
+          }
         }
       }
+
       return true;
     default:
       return false;

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -405,6 +405,22 @@ describe('ReactPropTypes', function() {
       });
     });
 
+    it('should not warn for iterables', function() {
+      var iterable = {
+        '@@iterator': function() {
+          var i = 0;
+          return {
+            next: function() {
+              var done = ++i > 2;
+              return {value: done ? undefined : <MyComponent />, done: done};
+            },
+          };
+        },
+      };
+
+      typeCheckPass(PropTypes.node, iterable);
+    });
+
     it('should not warn for null/undefined if not required', function() {
       typeCheckPass(PropTypes.node, null);
       typeCheckPass(PropTypes.node, undefined);

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -421,6 +421,23 @@ describe('ReactPropTypes', function() {
       typeCheckPass(PropTypes.node, iterable);
     });
 
+    it('should not warn for entry iterables', function() {
+      var iterable = {
+        '@@iterator': function() {
+          var i = 0;
+          return {
+            next: function() {
+              var done = ++i > 2;
+              return {value: done ? undefined : ['#' + i, <MyComponent />], done: done};
+            },
+          };
+        },
+      };
+      iterable.entries = iterable['@@iterator'];
+
+      typeCheckPass(PropTypes.node, iterable);
+    });
+
     it('should not warn for null/undefined if not required', function() {
       typeCheckPass(PropTypes.node, null);
       typeCheckPass(PropTypes.node, undefined);


### PR DESCRIPTION
#2376 add support for iterables as children. However if a component adds React.PropTypes.node validation to children, validation fails. This pull request adds an iterable check to ReactPropTypes.isNode()