### PR TITLE
Fix travis after_script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,31 +42,33 @@ script:
         fi
         popd
       fi
+    elif [ "$TEST_TYPE" = build ]; then
+      if [ "$SERVER" ]; then
+        set -e
+        ./node_modules/.bin/grunt build
+        curl \
+          -F "react=@build/react.js" \
+          -F "react.min=@build/react.min.js" \
+          -F "transformer=@build/JSXTransformer.js" \
+          -F "react-with-addons=@build/react-with-addons.js" \
+          -F "react-with-addons.min=@build/react-with-addons.min.js" \
+          -F "npm-react=@build/packages/react.tgz" \
+          -F "npm-react-dom=@build/packages/react-dom.tgz" \
+          -F "npm-react-codemod=@build/packages/react-codemod.tgz" \
+          -F "commit=$TRAVIS_COMMIT" \
+          -F "date=`git log --format='%ct' -1`" \
+          -F "pull_request=$TRAVIS_PULL_REQUEST" \
+          -F "token=$SECRET_TOKEN" \
+          -F "branch=$TRAVIS_BRANCH" \
+          $SERVER
+      fi
     else
       ./node_modules/.bin/grunt $TEST_TYPE
-    fi
-after_script:
-- |
-    if [ "$TEST_TYPE" = test ] && [ "$SERVER" ]; then
-      ./node_modules/.bin/grunt build
-      curl \
-        -F "react=@build/react.js" \
-        -F "react.min=@build/react.min.js" \
-        -F "transformer=@build/JSXTransformer.js" \
-        -F "react-with-addons=@build/react-with-addons.js" \
-        -F "react-with-addons.min=@build/react-with-addons.min.js" \
-        -F "npm-react=@build/react.tgz" \
-        -F "npm-react-tools=@build/react-tools.tgz" \
-        -F "commit=$TRAVIS_COMMIT" \
-        -F "date=`git log --format='%ct' -1`" \
-        -F "pull_request=$TRAVIS_PULL_REQUEST" \
-        -F "token=$SECRET_TOKEN" \
-        -F "branch=$TRAVIS_BRANCH" \
-        $SERVER
     fi
 env:
   matrix:
   - TEST_TYPE=test
+  - TEST_TYPE=build
   - TEST_TYPE=jest
   - TEST_TYPE=lint
   - TEST_TYPE=build_website


### PR DESCRIPTION
Way at the bottom of the travis output:

```
1571: curl: (26) couldn't open file "build/react.tgz"
```

This seems to be broken since 12c9fee94ed97dee1ae0dad701c03d4fc14ca0a7

I'm guessing the server this posts to also needs to be updated, so this PR is mostly informational.