### PR TITLE
Allow prefixes within keyMirror

### DIFF
--- a/src/shared/vendor/key-mirror/__tests__/keyMirror-test.js
+++ b/src/shared/vendor/key-mirror/__tests__/keyMirror-test.js
@@ -32,6 +32,23 @@ describe('keyMirror', function() {
     expect('qux' in mirror).toBe(true);
     expect(mirror.qux).toBe('qux');
   });
+  
+  it('should create an object with prefixed values matching keys provided when a prefix argument is supplied', function() {
+    var mirror = keyMirror({
+      foo: null,
+      bar: true,
+      "baz": {some: "object"},
+      qux: undefined
+    }, 'foo_');
+    expect('foo' in mirror).toBe(true);
+    expect(mirror.foo).toBe('foo_foo');
+    expect('bar' in mirror).toBe(true);
+    expect(mirror.bar).toBe('foo_bar');
+    expect('baz' in mirror).toBe(true);
+    expect(mirror.baz).toBe('foo_baz');
+    expect('qux' in mirror).toBe(true);
+    expect(mirror.qux).toBe('foo_qux');
+  });
 
   it('should not use properties from prototypes', function() {
     function Klass() {
@@ -51,6 +68,14 @@ describe('keyMirror', function() {
   it('should throw when a non-object argument is used', function() {
     [null, undefined, 0, 7, ['uno'], true, "string"].forEach(function(testVal) {
       expect(keyMirror.bind(null, testVal)).toThrow();
+    });
+  });
+  
+  it('should throw when a non-string prefix argument is used', function() {
+    [null, undefined, 0, 7, ['uno'], true, "string"].forEach(function(testVal) {
+      expect(keyMirror.bind(null, testVal, 1)).toThrow();
+      expect(keyMirror.bind(null, testVal, [])).toThrow();
+      expect(keyMirror.bind(null, testVal, {})).toThrow();
     });
   });
 

--- a/src/shared/vendor/key-mirror/keyMirror.js
+++ b/src/shared/vendor/key-mirror/keyMirror.js
@@ -30,20 +30,25 @@ var invariant = require('invariant');
  *   Output: {key1: key1, key2: key2}
  *
  * @param {object} obj
+ * @param {string} prefix
  * @return {object}
  */
-var keyMirror = function(obj) {
+var keyMirror = function(obj, prefix = '') {
   var ret = {};
   var key;
   invariant(
     obj instanceof Object && !Array.isArray(obj),
     'keyMirror(...): Argument must be an object.'
   );
+  invariant(
+    typeof prefix === 'string',
+    'keyMirror(...): Prefix must be a string.'
+  );
   for (key in obj) {
     if (!obj.hasOwnProperty(key)) {
       continue;
     }
-    ret[key] = key;
+    ret[key] = prefix + key;
   }
   return ret;
 };


### PR DESCRIPTION
Though this change may not exactly create a “mirror,” I wanted to at least start a discussion around a problem that we have begun to run into when modules from separate domains listen for the same action and experience value collisions. For example:

```js
// modules/audio/constants/ActionTypes.js
var AudioPlayerActionTypes = keyMirror({
  PLAY: null,
  PAUSE: null
});

// modules/video/constants/ActionTypes.js
var VideoPlayerActionTypes = keyMirror({
  PLAY: null,
  PAUSE: null
});
```

Both an audio player and a video player would implement some type of play button within a UI layer that, when clicked, runs through an action creator that eventually reaches the Dispatcher and ultimately sends a `'PLAY'` action out into the parent application. If the media components are only listening for a `'PLAY'` action to be dispatched, *both* will unintentionally begin playback.

One solution would be to namespace keys in each constants file:

```js
// modules/audio/constants/ActionTypes.js
var AudioPlayerActionTypes = keyMirror({
  AUDIO_PLAYER_PLAY: null,
  AUDIO_PLAYER_PAUSE: null
});

// modules/video/constants/ActionTypes.js
var VideoPlayerActionTypes = keyMirror({
  VIDEO_PLAYER_PLAY: null,
  VIDEO_PLAYER_PAUSE: null
});
```

This works, but is overly verbose and repetitive in my opinion (`VideoPlayerActionTypes.VIDEO_PLAYER_PLAY`.) By adding a prefix option, the keys remain slim, with their namespace still denoted by the object they are members of, but avoids any value collisions.