### PR TITLE
CSSTransitionGroup documentation example update

### DIFF
--- a/docs/docs/10.1-animation.md
+++ b/docs/docs/10.1-animation.md
@@ -17,7 +17,7 @@ React provides a `ReactTransitionGroup` addon component as a low-level API for a
 `ReactCSSTransitionGroup` is the interface to `ReactTransitions`. This is a simple element that wraps all of the components you are interested in animating. Here's an example where we fade list items in and out.
 
 ```javascript{28-30}
-var ReactCSSTransitionGroup = React.addons.CSSTransitionGroup;
+var ReactCSSTransitionGroup = require('react/addons').addons.CSSTransitionGroup;
 
 var TodoList = React.createClass({
   getInitialState: function() {


### PR DESCRIPTION
`React.addons` is an `undefined` object. `'react/addons'` should be required instead. This commit changes the example in the documentation in order to take this change in account.

Note that it may be bound to our transpilation stack with gulp & browserify (I didn't tried it with webpack). In this case we should add a note anyway for browserify users.