### PR TITLE
Add IE-only security attr to HTMLDOMPropertyConfig

### DIFF
--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -183,6 +183,9 @@ var HTMLDOMPropertyConfig = {
     itemRef: MUST_USE_ATTRIBUTE,
     // property is supported for OpenGraph in meta tags.
     property: null,
+    // IE-only attribute that specifies security restrictions on an iframe
+    // as an alternative to the sandbox attribute on IE<10
+    security: MUST_USE_ATTRIBUTE,
     // IE-only attribute that controls focus behavior
     unselectable: MUST_USE_ATTRIBUTE,
   },


### PR DESCRIPTION
See https://msdn.microsoft.com/en-us/library/ms534622(v=vs.85).aspx for an in-depth specification.

This fixes #4169.