### PR TITLE
Fix a library path for react-addons-updates

### DIFF
--- a/grunt/tasks/npm-react-addons.js
+++ b/grunt/tasks/npm-react-addons.js
@@ -36,8 +36,8 @@ var addons = {
     name: 'shallow-compare',
   },
   updates: {
-    module: 'updates',
-    name: 'updates',
+    module: 'update',
+    name: 'update',
   },
 };
 


### PR DESCRIPTION
Currentry, react-addons-updates doesn't work..

```js
var update = require('react-addons-updates');
```

* error

```
Error: Cannot find module 'react/lib/updates'
```

It seems to mistake a require path.

```
➜  npm install react-addons-updates react@0.14.0-beta1

➜  ls node_modules/react/lib/up*
node_modules/react/lib/update.js
➜  cat node_modules/react-addons-updates/index.js
module.exports = require('react/lib/updates');
```