### PR TITLE
[NEEDS WORK] Try to fix #4288

### DIFF
--- a/src/renderers/dom/client/__tests__/ReactBrowserEventEmitter-test.js
+++ b/src/renderers/dom/client/__tests__/ReactBrowserEventEmitter-test.js
@@ -426,6 +426,38 @@ describe('ReactBrowserEventEmitter', function() {
     }
   });
 
+  it('should set target on change plugin events', function() {
+    ReactBrowserEventEmitter.putListener(
+      getID(CHILD),
+      ON_CHANGE_KEY,
+      function(event) {
+        recordID(getID(CHILD));
+        expect(event.target).toBe(CHILD);
+      }
+    );
+    ReactBrowserEventEmitter.putListener(
+      getID(PARENT),
+      ON_CHANGE_KEY,
+      function(event) {
+        recordID(getID(PARENT));
+        expect(event.target).toBe(CHILD);
+      }
+    );
+    ReactBrowserEventEmitter.putListener(
+      getID(GRANDPARENT),
+      ON_CHANGE_KEY,
+      function(event) {
+        recordID(getID(GRANDPARENT));
+        expect(event.target).toBe(CHILD);
+      }
+    );
+    ReactTestUtils.SimulateNative.input(CHILD);
+    expect(idCallOrder.length).toBe(3);
+    expect(idCallOrder[0]).toBe(getID(CHILD));
+    expect(idCallOrder[1]).toBe(getID(CHILD));
+    expect(idCallOrder[2]).toBe(getID(CHILD));
+  });
+
   it('should bubble onTouchTap', function() {
     ReactBrowserEventEmitter.putListener(
       getID(CHILD),

--- a/src/renderers/dom/client/eventPlugins/BeforeInputEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/BeforeInputEventPlugin.js
@@ -237,7 +237,8 @@ function extractCompositionEvent(
   topLevelType,
   topLevelTarget,
   topLevelTargetID,
-  nativeEvent
+  nativeEvent,
+  nativeEventTarget
 ) {
   var eventType;
   var fallbackData;
@@ -271,7 +272,8 @@ function extractCompositionEvent(
   var event = SyntheticCompositionEvent.getPooled(
     eventType,
     topLevelTargetID,
-    nativeEvent
+    nativeEvent,
+    nativeEventTarget
   );
 
   if (fallbackData) {
@@ -411,7 +413,8 @@ function extractBeforeInputEvent(
   topLevelType,
   topLevelTarget,
   topLevelTargetID,
-  nativeEvent
+  nativeEvent,
+  nativeEventTarget
 ) {
   var chars;
 
@@ -430,7 +433,8 @@ function extractBeforeInputEvent(
   var event = SyntheticInputEvent.getPooled(
     eventTypes.beforeInput,
     topLevelTargetID,
-    nativeEvent
+    nativeEvent,
+    nativeEventTarget
   );
 
   event.data = chars;
@@ -472,20 +476,23 @@ var BeforeInputEventPlugin = {
     topLevelType,
     topLevelTarget,
     topLevelTargetID,
-    nativeEvent
+    nativeEvent,
+    nativeEventTarget
   ) {
     return [
       extractCompositionEvent(
         topLevelType,
         topLevelTarget,
         topLevelTargetID,
-        nativeEvent
+        nativeEvent,
+        nativeEventTarget
       ),
       extractBeforeInputEvent(
         topLevelType,
         topLevelTarget,
         topLevelTargetID,
-        nativeEvent
+        nativeEvent,
+        nativeEventTarget
       ),
     ];
   },

--- a/src/renderers/dom/client/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/ChangeEventPlugin.js
@@ -74,7 +74,8 @@ function manualDispatchChangeEvent(nativeEvent) {
   var event = SyntheticEvent.getPooled(
     eventTypes.change,
     activeElementID,
-    nativeEvent
+    nativeEvent,
+    nativeEvent.target
   );
   EventPropagators.accumulateTwoPhaseDispatches(event);
 
@@ -330,7 +331,8 @@ var ChangeEventPlugin = {
       topLevelType,
       topLevelTarget,
       topLevelTargetID,
-      nativeEvent) {
+      nativeEvent,
+      nativeEventTarget) {
 
     var getTargetIDFunc, handleEventFunc;
     if (shouldUseChangeEvent(topLevelTarget)) {
@@ -360,7 +362,8 @@ var ChangeEventPlugin = {
         var event = SyntheticEvent.getPooled(
           eventTypes.change,
           targetID,
-          nativeEvent
+          nativeEvent,
+          nativeEventTarget
         );
         event.type = 'change';
         EventPropagators.accumulateTwoPhaseDispatches(event);


### PR DESCRIPTION
This is my attempt at fixing the #4288 regression in `0.14.0-beta1`.

I also included a fix for onBeforeInput which I expect has the same bug as onChange.

However I could not get the test system to work (change listeners aren't fired by the mock input event like they're supposed to).

Someone more experienced than me is going to have to write a test for this bug that actually works.