### PR TITLE
Concatenate warning message, due to parsing issues

### DIFF
--- a/packages/react/addons.js
+++ b/packages/react/addons.js
@@ -1,8 +1,8 @@
 var warning = require('./lib/warning');
 warning(
   false,
-  "require('react/addons') is deprecated. " +
-  "Access using require('react-addons-{addon}') instead."
+  'require' + "('react/addons') is deprecated. " +
+  'Access using require' + "('react-addons-{addon}') instead."
 );
 
 module.exports = require('./lib/ReactWithAddons');


### PR DESCRIPTION
The addons module warning is currently causing issues with babel/JSPM due to the warning message getting parsed as a require statement. Adding a break using string concatenation appears to prevent any issues.

Example error using JSPM:
```console
Error loading "react-addons-{addon}" from "..." at ".../react-addons-{addon}.js"
```