### PR TITLE
Concatenate warning message, due to parsing issues

### DIFF
--- a/packages/react/addons.js
+++ b/packages/react/addons.js
@@ -1,8 +1,8 @@
 var warning = require('./lib/warning');
 warning(
   false,
-  "require('react/addons') is deprecated. " +
-  "Access using require('react-addons-{addon}') instead."
+  'require' + "('react/addons') is deprecated. " +
+  'Access using require' + "('react-addons-{addon}') instead."
 );
 
 module.exports = require('./lib/ReactWithAddons');

--- a/packages/react/addons.js
+++ b/packages/react/addons.js
@@ -1,6 +1,9 @@
 var warning = require('./lib/warning');
 warning(
   false,
+  // Require examples in this string must be split to prevent React's
+  // build tools from mistaking them for real requires.
+  // Otherwise the build tools will attempt to build a 'react-addons-{addon}' module.
   'require' + "('react/addons') is deprecated. " +
   'Access using require' + "('react-addons-{addon}') instead."
 );


### PR DESCRIPTION
The addons module warning is currently causing issues with babel/JSPM due to the warning message getting parsed as a require statement. Adding a break using string concatenation appears to prevent any issues.

Example error using JSPM:

```
Error loading "react-addons-{addon}" from...
```