### PR TITLE
Improve warning in react mount

### DIFF
--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -880,9 +880,20 @@ var ReactMount = {
           checksum
         );
 
-        var normalizer = document.createElement('div');
-        normalizer.innerHTML = markup;
-        var normalizedMarkup = normalizer.innerHTML;
+        // because rootMarkup is retrieved from the DOM, various normalizations
+        // will have occurred which will not be present in `markup`. Here,
+        // insert markup into a <div> or <iframe> depending on the container
+        // type to perform the same normalizations before comparing.
+        if (container.nodeType === ELEMENT_NODE_TYPE) {
+          var normalizer = document.createElement('div');
+          normalizer.innerHTML = markup;
+          var normalizedMarkup = normalizer.innerHTML;
+        } else {
+          var normalizer = document.createElement('iframe');
+          document.body.appendChild(normalizer);
+          normalizer.contentDocument.write(markup);
+          var normalizedMarkup = normalizer.contentDocument.documentElement.outerHTML;
+        }
 
         var diffIndex = firstDifferenceIndex(normalizedMarkup, rootMarkup);
         var difference = ' (client) ' +

--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -880,20 +880,24 @@ var ReactMount = {
           checksum
         );
 
-        // because rootMarkup is retrieved from the DOM, various normalizations
-        // will have occurred which will not be present in `markup`. Here,
-        // insert markup into a <div> or <iframe> depending on the container
-        // type to perform the same normalizations before comparing.
-        var normalizer, normalizedMarkup;
-        if (container.nodeType === ELEMENT_NODE_TYPE) {
-          normalizer = document.createElement('div');
-          normalizer.innerHTML = markup;
-          normalizedMarkup = normalizer.innerHTML;
-        } else {
-          normalizer = document.createElement('iframe');
-          document.body.appendChild(normalizer);
-          normalizer.contentDocument.write(markup);
-          normalizedMarkup = normalizer.contentDocument.documentElement.outerHTML;
+        var normalizedMarkup = markup;
+        if (__DEV__) {
+          // because rootMarkup is retrieved from the DOM, various normalizations
+          // will have occurred which will not be present in `markup`. Here,
+          // insert markup into a <div> or <iframe> depending on the container
+          // type to perform the same normalizations before comparing.
+          var normalizer;
+          if (container.nodeType === ELEMENT_NODE_TYPE) {
+            normalizer = document.createElement('div');
+            normalizer.innerHTML = markup;
+            normalizedMarkup = normalizer.innerHTML;
+          } else {
+            normalizer = document.createElement('iframe');
+            document.body.appendChild(normalizer);
+            normalizer.contentDocument.write(markup);
+            normalizedMarkup = normalizer.contentDocument.documentElement.outerHTML;
+            document.body.removeChild(normalizer);
+          }
         }
 
         var diffIndex = firstDifferenceIndex(normalizedMarkup, rootMarkup);

--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -884,15 +884,16 @@ var ReactMount = {
         // will have occurred which will not be present in `markup`. Here,
         // insert markup into a <div> or <iframe> depending on the container
         // type to perform the same normalizations before comparing.
+        var normalizer, normalizedMarkup;
         if (container.nodeType === ELEMENT_NODE_TYPE) {
-          var normalizer = document.createElement('div');
+          normalizer = document.createElement('div');
           normalizer.innerHTML = markup;
-          var normalizedMarkup = normalizer.innerHTML;
+          normalizedMarkup = normalizer.innerHTML;
         } else {
-          var normalizer = document.createElement('iframe');
+          normalizer = document.createElement('iframe');
           document.body.appendChild(normalizer);
           normalizer.contentDocument.write(markup);
-          var normalizedMarkup = normalizer.contentDocument.documentElement.outerHTML;
+          normalizedMarkup = normalizer.contentDocument.documentElement.outerHTML;
         }
 
         var diffIndex = firstDifferenceIndex(normalizedMarkup, rootMarkup);

--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -880,9 +880,13 @@ var ReactMount = {
           checksum
         );
 
-        var diffIndex = firstDifferenceIndex(markup, rootMarkup);
+        var normalizer = document.createElement('div');
+        normalizer.innerHTML = markup;
+        var normalizedMarkup = normalizer.innerHTML;
+
+        var diffIndex = firstDifferenceIndex(normalizedMarkup, rootMarkup);
         var difference = ' (client) ' +
-          markup.substring(diffIndex - 20, diffIndex + 20) +
+          normalizedMarkup.substring(diffIndex - 20, diffIndex + 20) +
           '\n (server) ' + rootMarkup.substring(diffIndex - 20, diffIndex + 20);
 
         invariant(

--- a/src/renderers/dom/client/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMount-test.js
@@ -16,7 +16,6 @@ var mocks = require('mocks');
 describe('ReactMount', function() {
   var React = require('React');
   var ReactMount = require('ReactMount');
-  var ReactMarkupChecksum = require('ReactMarkupChecksum');
   var ReactTestUtils = require('ReactTestUtils');
   var WebComponents = WebComponents;
 
@@ -170,7 +169,7 @@ describe('ReactMount', function() {
     expect(console.error.calls[0].args[0]).toContain(
       ' (client)  html entity: &amp; client text</div>\n' +
       ' (server)  html entity: &amp; server text</div>'
-    )
+    );
   });
 
   if (WebComponents !== undefined) {

--- a/src/renderers/dom/client/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMount-test.js
@@ -16,6 +16,7 @@ var mocks = require('mocks');
 describe('ReactMount', function() {
   var React = require('React');
   var ReactMount = require('ReactMount');
+  var ReactMarkupChecksum = require('ReactMarkupChecksum');
   var ReactTestUtils = require('ReactTestUtils');
   var WebComponents = WebComponents;
 
@@ -154,6 +155,22 @@ describe('ReactMount', function() {
     expect(console.error.calls[0].args[0]).toContain(
       'Rendering components directly into document.body is discouraged'
     );
+  });
+
+  it('should account for escaping on a checksum mismatch', function () {
+    var div = document.createElement('div');
+    var markup = React.renderToString(
+      <div>This markup contains an html entity: &amp; server text</div>);
+    div.innerHTML = markup;
+
+    spyOn(console, 'error');
+    React.render(
+      <div>This markup contains an html entity: &amp; client text</div>, div);
+    expect(console.error.calls.length).toBe(1);
+    expect(console.error.calls[0].args[0]).toContain(
+      ' (client)  html entity: &amp; client text</div>\n' +
+      ' (server)  html entity: &amp; server text</div>'
+    )
   });
 
   if (WebComponents !== undefined) {

--- a/src/renderers/dom/client/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMount-test.js
@@ -159,16 +159,18 @@ describe('ReactMount', function() {
   it('should account for escaping on a checksum mismatch', function () {
     var div = document.createElement('div');
     var markup = React.renderToString(
-      <div>This markup contains an html entity: &amp; server text</div>);
+      <div>This markup contains an nbsp entity: &nbsp; server text</div>);
     div.innerHTML = markup;
 
     spyOn(console, 'error');
     React.render(
-      <div>This markup contains an html entity: &amp; client text</div>, div);
+      <div>This markup contains an nbsp entity: &nbsp; client text</div>,
+      div
+    );
     expect(console.error.calls.length).toBe(1);
     expect(console.error.calls[0].args[0]).toContain(
-      ' (client)  html entity: &amp; client text</div>\n' +
-      ' (server)  html entity: &amp; server text</div>'
+      ' (client) nbsp entity: &nbsp; client text</div>\n' +
+      ' (server) nbsp entity: &nbsp; server text</div>'
     );
   });
 


### PR DESCRIPTION
While I was debugging a problem reusing server-rendered markup, I was thrown off the track for a while because React was telling me there were differences in various entity encodings and attribute representations between the server- and client-rendered markup. For instance, the server markup would contain `&nbsp;` while the client would contain a literal `\u00a0` character. Also, empty attributes on the client would be rendered as `attribute` whereas the server markup would show `attribute=""`. After finally realizing that the real problem was in fact a different string being rendered on server vs client, I came up with this method to present more useful information when this situation arises.