### PR TITLE
Fix checksum hash attribute insertion for self-closing root tags.  Fixes #4323


### DIFF
--- a/src/renderers/dom/server/ReactMarkupChecksum.js
+++ b/src/renderers/dom/server/ReactMarkupChecksum.js
@@ -22,9 +22,11 @@ var ReactMarkupChecksum = {
    */
   addChecksumToMarkup: function(markup) {
     var checksum = adler32(markup);
+
+    // Add checksum (handle both parent tags and self-closing tags)
     return markup.replace(
-      '>',
-      ' ' + ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="' + checksum + '">'
+      /\/?>/,
+      ' ' + ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="' + checksum + '"$&'
     );
   },
 

--- a/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
@@ -57,6 +57,16 @@ describe('ReactServerRendering', function() {
       );
     });
 
+    it('should generate simple markup for self-closing tags', function() {
+      var response = ReactServerRendering.renderToString(
+        <img />
+      );
+      expect(response).toMatch(
+        '<img ' + ID_ATTRIBUTE_NAME + '="[^"]+" ' +
+          ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="[^"]+"/>'
+      );
+    });
+
     it('should not register event listeners', function() {
       var EventPluginHub = require('EventPluginHub');
       var cb = mocks.getMockFunction();


### PR DESCRIPTION
Fix checksum hash attribute insertion for self-closing root tags.  Fixes #4323
