### PR TITLE
Reset module cache between tests

### DIFF
--- a/src/isomorphic/deprecated/__tests__/cloneWithProps-test.js
+++ b/src/isomorphic/deprecated/__tests__/cloneWithProps-test.js
@@ -25,6 +25,7 @@ var emptyObject;
 describe('cloneWithProps', function() {
 
   beforeEach(function() {
+    require('mock-modules').dumpCache();
     React = require('React');
     ReactTestUtils = require('ReactTestUtils');
     onlyChild = require('onlyChild');

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -26,6 +26,7 @@ var reactComponentExpect;
 describe('ReactCompositeComponent', function() {
 
   beforeEach(function() {
+    require('mock-modules').dumpCache();
     reactComponentExpect = require('reactComponentExpect');
     React = require('React');
     ReactCurrentOwner = require('ReactCurrentOwner');


### PR DESCRIPTION
Jest is currently failing because of some new deprecation warnings. This fixes it.