### PR TITLE
Remove the unexpected character in ReactEventListener

### DIFF
--- a/src/renderers/dom/client/ReactEventListener.js
+++ b/src/renderers/dom/client/ReactEventListener.js
@@ -126,7 +126,7 @@ function handleTopLevelWithPath(bookKeeping) {
       );
 
       // Jump to the root of this React render tree
-      while (currentPathElementID !== newRootID) {
+      while (currentPathElementID !== newRootID) {
         i++;
         currentPathElement = path[i];
         currentPathElementID = ReactMount.getID(currentPathElement);


### PR DESCRIPTION
```
>> Error while reading module ReactEventListener:
>> SyntaxError: ReactEventListener: Unexpected character '' (129:33)
>>   127 |
>>   128 |       // Jump to the root of this React render tree
>> > 129 |       while (currentPathElementID !== newRootID) {
>>       |                                  ^
>>   130 |         i++;
>>   131 |         currentPathElement = path[i];
>>   132 |         currentPathElementID = ReactMount.getID(currentPathElement);
```

![screen shot 2015-07-11 at 12 58 16 am](https://cloud.githubusercontent.com/assets/39830/8622856/82f455f8-2768-11e5-91f4-6276ef8bd131.png)