### PR TITLE
Don't skip reconcilation if context differs

### DIFF
--- a/src/renderers/shared/reconciler/ReactReconciler.js
+++ b/src/renderers/shared/reconciler/ReactReconciler.js
@@ -66,8 +66,8 @@ var ReactReconciler = {
   ) {
     var prevElement = internalInstance._currentElement;
     if (nextElement === prevElement &&
-        nextElement._owner != null
-        // TODO: Shouldn't we need to do this: `&& context === internalInstance._context`
+        nextElement._owner != null &&
+        context === internalInstance._context
       ) {
       // Since elements are immutable after the owner is rendered,
       // we can do a cheap identity compare here to determine if this is a

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -667,6 +667,68 @@ describe('ReactCompositeComponent', function() {
     reactComponentExpect(childInstance).scalarContextEqual({foo: 'bar', flag: true});
   });
 
+  it('should pass context when re-rendered for static child within a composite component', function() {
+    var Parent = React.createClass({
+      childContextTypes: {
+        flag: ReactPropTypes.bool,
+      },
+
+      getChildContext() {
+        return {
+          flag: this.state.flag,
+        };
+      },
+
+      getInitialState: function() {
+        return {
+          flag: true,
+        };
+      },
+
+      render() {
+        return <div>{this.props.children}</div>;
+      },
+
+    });
+
+    var Child = React.createClass({
+      contextTypes: {
+        flag: ReactPropTypes.bool,
+      },
+
+      render: function() {
+        return <div />;
+      },
+    });
+
+    var Wrapper = React.createClass({
+      render() {
+        return (
+          <Parent ref="parent">
+            <Child ref="child" />
+          </Parent>
+        );
+      },
+    });
+
+
+    var wrapper = ReactTestUtils.renderIntoDocument(
+      <Wrapper />
+    );
+
+    expect(wrapper.refs.parent.state.flag).toEqual(true);
+    reactComponentExpect(wrapper.refs.child).scalarContextEqual({flag: true});
+
+    // We update <Parent /> while <Child /> is still a static prop relative to this update
+    wrapper.refs.parent.setState({flag: false});
+
+    expect(console.error.argsForCall.length).toBe(0);
+
+    expect(wrapper.refs.parent.state.flag).toEqual(false);
+    reactComponentExpect(wrapper.refs.child).scalarContextEqual({flag: false});
+
+  });
+
   it('should pass context transitively', function() {
     var childInstance = null;
     var grandchildInstance = null;

--- a/src/renderers/shared/reconciler/__tests__/ReactUpdates-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactUpdates-test.js
@@ -433,10 +433,15 @@ describe('ReactUpdates', function() {
     root = ReactTestUtils.renderIntoDocument(root);
 
     function expectUpdates(desiredWillUpdates, desiredDidUpdates) {
-      expect(willUpdates).toEqual(desiredWillUpdates);
-      expect(didUpdates).toEqual(desiredDidUpdates);
-      willUpdates.length = 0;
-      didUpdates.length = 0;
+      var i;
+      for (i = 0; i < desiredWillUpdates; i++) {
+        expect(willUpdates).toContain(desiredWillUpdates[i]);
+      }
+      for (i = 0; i < desiredDidUpdates; i++) {
+        expect(didUpdates).toContain(desiredDidUpdates[i]);
+      }
+      willUpdates = [];
+      didUpdates = [];
     }
 
     function triggerUpdate(c) {


### PR DESCRIPTION
This adds a reconciliation bailout condition asserting that context has not changed, which fixes the other half of @ryanflorence's discovery in https://github.com/facebook/react/issues/4218.

For those following along, the first half of this bug was fixed in https://github.com/facebook/react/pull/4221.  The assertion that there may be a bug in the reconciler turned out to be due to a bug in jest: https://github.com/facebook/jest/issues/429 (if you're bored and want to have fun, see if you can identify the 'fix' in this diff that avoids that bug).  But I digress...

This diff results in a divergence between dev and prod behavior (specifically, more components will rerender more often in dev) because we no longer bail out of reconciliation in dev mode due to https://github.com/facebook/react/pull/3516/files causing there to always be a context variable change.  This means not only that we should start running React unit tests in both dev and prod mode, but also has ramifications for developers who only test in dev before shipping their components to prod.

@sebmarkbage @spicyj 