### PR TITLE
Add a method to filter wrappers depending on the DOM

### DIFF
--- a/src/renderers/dom/client/ReactReconcileTransaction.js
+++ b/src/renderers/dom/client/ReactReconcileTransaction.js
@@ -17,6 +17,7 @@ var PooledClass = require('PooledClass');
 var ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
 var ReactInputSelection = require('ReactInputSelection');
 var Transaction = require('Transaction');
+var ExecutionEnvironment = require('ExecutionEnvironment');
 
 var assign = require('Object.assign');
 
@@ -25,6 +26,10 @@ var assign = require('Object.assign');
  * input) is not disturbed by performing the transaction.
  */
 var SELECTION_RESTORATION = {
+  /**
+   * @param {boolean} The dependence of this wrapper on the presence of the DOM.
+   */
+  requiresDOM: true,
   /**
    * @return {Selection} Selection information.
    */
@@ -86,11 +91,11 @@ var ON_DOM_READY_QUEUEING = {
  * being member methods, but with an implied ordering while being isolated from
  * each other.
  */
-var TRANSACTION_WRAPPERS = [
+var TRANSACTION_WRAPPERS = ExecutionEnvironment.filter([
   SELECTION_RESTORATION,
   EVENT_SUPPRESSION,
   ON_DOM_READY_QUEUEING,
-];
+]);
 
 /**
  * Currently:

--- a/src/shared/vendor/core/ExecutionEnvironment.js
+++ b/src/shared/vendor/core/ExecutionEnvironment.js
@@ -19,6 +19,20 @@ var canUseDOM = !!(
   window.document.createElement
 );
 
+var canUseWrapper = function(wrapper) {
+  var requiresDOM = !!(wrapper && wrapper.requiresDOM);
+  return (!requiresDOM || canUseDOM);
+};
+
+var filter = function(wrappers) {
+  var selectedWrappers = [];
+  for (var i = 0, len = wrappers.length; i < len; i++) {
+    if (canUseWrapper(wrappers[i]))
+      selectedWrappers.push(wrappers[i]);
+  }
+  return selectedWrappers;
+};
+
 /**
  * Simple, lightweight module assisting with the detection and context of
  * Worker. Helps avoid circular dependencies and allows code to reason about
@@ -36,7 +50,9 @@ var ExecutionEnvironment = {
 
   canUseViewport: canUseDOM && !!window.screen,
 
-  isInWorker: !canUseDOM // For now, this is true - might change in the future.
+  isInWorker: !canUseDOM, // For now, this is true - might change in the future.
+
+  filter: filter,
 
 };
 


### PR DESCRIPTION
A minimal approach for a solution to the problems related to transaction wrappers trying to access the DOM in its absence.

Surely this requires more work including some new tests as at this point all tests are passing even when the only wrapper being filtered out is `SELECTION_RESTORATION`.

Is this a workable path? All suggestions are welcome.

Related to #3620 and #4019.