### PR TITLE
Warn against JSX transform failure for non-HTTP-served JSX

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -64,6 +64,8 @@ Then reference it from `helloworld.html`:
 <script type="text/jsx" src="src/helloworld.js"></script>
 ```
 
+Note that some browsers (Chrome, e.g.) will fail to load the file unless it's served via HTTP.
+
 ### Offline Transform
 
 First install the command-line tools (requires [npm](https://www.npmjs.com/)):


### PR DESCRIPTION
Failures have been observed in Chrome 43 for JSX requested via XHR through file:// protocol.

Resolves #4354.

I ran the text for the English changeset through [Google Translate](https://translate.google.com/) to get the Korean, Chinese, and Japanese versions. For the Chinese version, I used "Chinese (Simplified)" as opposed to "Chinese (Traditional)".