### PR TITLE
Add more information about defaultValue

### DIFF
--- a/docs/docs/07-forms.md
+++ b/docs/docs/07-forms.md
@@ -91,7 +91,7 @@ If you want to initialize the component with a non-empty value, you can supply a
   }
 ```
 
-This example will function much like the **Controlled Components** example above.  *Note:* the `defaultValue` prop is only applied when the component mounts for the first time.  If you need to programatically set the initial value of an input as a result of an asynchronous function call, for example, you will have to pass in that initial value with the `value` prop instead.
+This example will function much like the **Controlled Components** example above.  *Note:* the defaultValue prop is only applied when the component mounts for the first time. If you need to programmatically update the value after initial mount, you will need to use a controlled component (see section on controlled components).
 
 Likewise, `<input>` supports `defaultChecked` and `<select>` supports `defaultValue`.
 

--- a/docs/docs/07-forms.md
+++ b/docs/docs/07-forms.md
@@ -81,6 +81,8 @@ An `<input>` that does not supply a `value` (or sets it to `null`) is an *uncont
 
 This will render an input that starts off with an empty value. Any user input will be immediately reflected by the rendered element. If you wanted to listen to updates to the value, you could use the `onChange` event just like you can with controlled components.
 
+###Default Value
+
 If you want to initialize the component with a non-empty value, you can supply a `defaultValue` prop. For example:
 
 ```javascript
@@ -89,7 +91,7 @@ If you want to initialize the component with a non-empty value, you can supply a
   }
 ```
 
-This example will function much like the **Controlled Components** example above.
+This example will function much like the **Controlled Components** example above.  *Note:* the `defaultValue` prop is only applied when the component mounts for the first time.  If you need to programatically set the initial value of an input as a result of an asynchronous function call, for example, you will have to pass in that initial value with the `value` prop instead.
 
 Likewise, `<input>` supports `defaultChecked` and `<select>` supports `defaultValue`.
 


### PR DESCRIPTION
I came across an issue on a React project where I needed to programatically set the default value of an input as the result of an async call.  (I was prepopulating a zip code field from the Google Maps Geocoding API).  It didn't work when I passed in an updated defaultValue prop, until I came across this StackOverflow: http://stackoverflow.com/questions/30146105/react-input-defaultvalue-doesnt-update-with-state.  I was able to get it to do what I wanted by passing in the value prop instead.