### PR TITLE
Use more specific ignore pattern for jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
       "ts"
     ],
     "modulePathIgnorePatterns": [
-      "/build/",
+      "/react/build/",
       "/node_modules/",
       "/.module-cache/"
     ],


### PR DESCRIPTION
TravisCI clones into /home/travis/build/facebook/react, which /build/ matches so we never ran any of our tests.

Is "victoriously idiotic" a phrase? I think it probably should be.