### PR TITLE
Fix typo in removeComponentAsRefFrom error message

### DIFF
--- a/src/renderers/shared/reconciler/ReactOwner.js
+++ b/src/renderers/shared/reconciler/ReactOwner.js
@@ -92,7 +92,7 @@ var ReactOwner = {
     invariant(
       ReactOwner.isValidOwner(owner),
       'removeComponentAsRefFrom(...): Only a ReactOwner can have refs. This ' +
-      'usually means that you\'re trying to remove a ref to a component that ' +
+      'usually means that you\'re trying to remove a ref from a component that ' +
       'doesn\'t have an owner (that is, was not created inside of another ' +
       'component\'s `render` method). Try rendering this component inside of ' +
       'a new top-level component which will hold the ref.'


### PR DESCRIPTION
Currently says `"remove a ref to a component"` - changed to `"remove a ref from a component"`