### PR TITLE
Lock babel @ 5.6.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "jstransform": "^11.0.0"
   },
   "devDependencies": {
-    "babel": "^5.5.5",
+    "babel": "~5.6.23",
+    "babel-core": "~5.6.20",
     "babel-eslint": "^3.1.14",
     "benchmark": "^1.0.0",
     "browserify": "^9.0.3",


### PR DESCRIPTION
5.7 and 5.8 are having issues with linting and I don't want to deal with that.