### PR TITLE
improve ReactTestUtils.Simulate documentation

### DIFF
--- a/docs/docs/10.4-test-utils.md
+++ b/docs/docs/10.4-test-utils.md
@@ -16,14 +16,21 @@ Simulate.{eventName}(DOMElement element, object eventData)
 
 Simulate an event dispatch on a DOM node with optional `eventData` event data. **This is possibly the single most useful utility in `ReactTestUtils`.**
 
-Example usage:
+**Clicking an element**  
+```javascript
+var node = React.findDOMNode(this.refs.button);
+React.addons.TestUtils.Simulate.click(node);
+```
 
+**Changing the value of an input field and then pressing ENTER**  
 ```javascript
 var node = React.findDOMNode(this.refs.input);
-React.addons.TestUtils.Simulate.click(node);
-React.addons.TestUtils.Simulate.change(node, {target: {value: 'Hello, world'}});
-React.addons.TestUtils.Simulate.keyDown(node, {key: "Enter"});
+node.value = 'giraffe'
+React.addons.TestUtils.Simulate.change(node);
+React.addons.TestUtils.Simulate.keyDown(node, {key: "Enter", keyCode: 13, which: 13});
 ```
+
+*note that you will have to provide any event property that you're using in your component (e.g. keyCode, which, etc...) as React is not creating any of these for you*
 
 `Simulate` has a method for every event that React understands.
 


### PR DESCRIPTION
As per issue https://github.com/facebook/react/issues/4375, I've found the docs for Simulate.change misleading as I needed to bother @jimfb to make it work.

I've also added another example, since it doesn't seems very clear how the optional eventData are used.