### PR TITLE
Rename ReactDOMClient to ReactDOM

### DIFF
--- a/packages/react-dom/index.js
+++ b/packages/react-dom/index.js
@@ -1,1 +1,1 @@
-module.exports = require('react/lib/ReactDOMClient');
+module.exports = require('react/lib/ReactDOM');

--- a/packages/react/react.js
+++ b/packages/react/react.js
@@ -8,7 +8,7 @@ var deprecated = require('./lib/deprecated');
 // We want to warn once when any of these methods are used.
 if (process.env.NODE_ENV !== 'production') {
   var deprecations = {
-    // ReactDOMClient
+    // ReactDOM
     findDOMNode: deprecated(
       'findDOMNode',
       'react-dom',

--- a/src/React.js
+++ b/src/React.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var ReactDOMClient = require('ReactDOMClient');
+var ReactDOM = require('ReactDOM');
 var ReactDOMServer = require('ReactDOMServer');
 var ReactIsomorphic = require('ReactIsomorphic');
 
@@ -20,7 +20,7 @@ var assign = require('Object.assign');
 var React = {};
 
 assign(React, ReactIsomorphic);
-assign(React, ReactDOMClient);
+assign(React, ReactDOM);
 assign(React, ReactDOMServer);
 
 React.version = '0.14.0-beta1';

--- a/src/isomorphic/ReactIsomorphic.js
+++ b/src/isomorphic/ReactIsomorphic.js
@@ -14,7 +14,7 @@
 var ReactChildren = require('ReactChildren');
 var ReactComponent = require('ReactComponent');
 var ReactClass = require('ReactClass');
-var ReactDOM = require('ReactDOM');
+var ReactDOMFactories = require('ReactDOMFactories');
 var ReactElement = require('ReactElement');
 var ReactElementValidator = require('ReactElementValidator');
 var ReactPropTypes = require('ReactPropTypes');
@@ -61,7 +61,7 @@ var React = {
 
   // This looks DOM specific but these are actually isomorphic helpers
   // since they are just generating DOM strings.
-  DOM: ReactDOM,
+  DOM: ReactDOMFactories,
 
   // Hook for JSX spread, don't use this for anything else.
   __spread: assign,

--- a/src/isomorphic/classic/element/ReactDOMFactories.js
+++ b/src/isomorphic/classic/element/ReactDOMFactories.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule ReactDOM
+ * @providesModule ReactDOMFactories
  * @typechecks static-only
  */
 
@@ -36,7 +36,7 @@ function createDOMFactory(tag) {
  *
  * @public
  */
-var ReactDOM = mapObject({
+var ReactDOMFactories = mapObject({
   a: 'a',
   abbr: 'abbr',
   address: 'address',
@@ -174,4 +174,4 @@ var ReactDOM = mapObject({
 
 }, createDOMFactory);
 
-module.exports = ReactDOM;
+module.exports = ReactDOMFactories;

--- a/src/renderers/dom/ReactDOM.js
+++ b/src/renderers/dom/ReactDOM.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule ReactDOMClient
+ * @providesModule ReactDOM
  */
 
 /* globals __REACT_DEVTOOLS_GLOBAL_HOOK__*/


### PR DESCRIPTION
This closer matches the npm package name and (I assume) is what we want to call it internally.