### PR TITLE
CSS transition fix

### DIFF
--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -88,9 +88,9 @@ var ReactCSSTransitionGroupChild = React.createClass({
 
     // Need to do this to actually trigger a transition.
     if ( REQUEST_ANIMATION_FRAME ) {
-        REQUEST_ANIMATION_FRAME(this.queueClass.bind(this, activeClassName));
+      REQUEST_ANIMATION_FRAME(this.queueClass.bind(this, activeClassName));
     } else {
-        this.queueClass(activeClassName);
+      this.queueClass(activeClassName);
     }
 
     if (__DEV__) {

--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -85,7 +85,7 @@ var ReactCSSTransitionGroupChild = React.createClass({
     CSSCore.addClass(node, className);
 
     // Need to do this to actually trigger a transition.
-    this.queueClass(activeClassName);
+    window.requestAnimationFrame(this.queueClass.bind(this, activeClassName));
 
     if (__DEV__) {
       noEventTimeout = setTimeout(noEventListener, NO_EVENT_TIMEOUT);

--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -29,6 +29,8 @@ var NO_EVENT_TIMEOUT = 5000;
 
 var noEventListener = null;
 
+var REQUEST_ANIMATION_FRAME = (window && window.requestAnimationFrame) ? window.requestAnimationFrame : false;
+
 
 if (__DEV__) {
   noEventListener = function() {
@@ -85,7 +87,11 @@ var ReactCSSTransitionGroupChild = React.createClass({
     CSSCore.addClass(node, className);
 
     // Need to do this to actually trigger a transition.
-    window.requestAnimationFrame(this.queueClass.bind(this, activeClassName));
+    if ( REQUEST_ANIMATION_FRAME ) {
+        REQUEST_ANIMATION_FRAME(this.queueClass.bind(this, activeClassName));
+    } else {
+        this.queueClass(activeClassName);
+    }
 
     if (__DEV__) {
       noEventTimeout = setTimeout(noEventListener, NO_EVENT_TIMEOUT);


### PR DESCRIPTION
Hey React Team!
I was playing around with transition groups and found that adding a call to requestAnimationFrame seems to help a lot with webkit transitionEnd events firing more consistently. I added a basic catch for browsers without the api call but this is a band-aid solution targeted at recent versions of evergreen browsers. [This chromium bug thread] (https://code.google.com/p/chromium/issues/detail?id=388082) helped me a ton in diagnosing the issue on Chrome.