### PR TITLE
Use old event propagation if path is not reasonable (eg. detached DOM).  Fixes #4452


### DIFF
--- a/src/renderers/dom/client/ReactEventListener.js
+++ b/src/renderers/dom/client/ReactEventListener.js
@@ -62,7 +62,7 @@ PooledClass.addPoolingTo(
 );
 
 function handleTopLevelImpl(bookKeeping) {
-  if (bookKeeping.nativeEvent.path) {
+  if (bookKeeping.nativeEvent.path && bookKeeping.nativeEvent.path.length > 1) {
     // New browsers have a path attribute on native events
     handleTopLevelWithPath(bookKeeping);
   } else {


### PR DESCRIPTION
Use old event propagation if path is not reasonable (eg. detached DOM).  Fixes #4452
