### PR TITLE
Lock typescript dep at 1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "optimist": "^0.6.1",
     "platform": "^1.1.0",
     "tmp": "~0.0.18",
-    "typescript": "^1.4.0",
+    "typescript": "~1.4.0",
     "uglify-js": "^2.4.23",
     "uglifyify": "^3.0.1"
   },


### PR DESCRIPTION
Do this instead of #4458. I'll file a followup to have somebody who knows what they're doing upgrade.