### PR TITLE
Add additional contextual information to invalid-style-prop warning

### DIFF
--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -263,7 +263,7 @@ function assertValidProps(component, props) {
   }
   invariant(
     props.style == null || typeof props.style === 'object',
-    'The `style` prop of '+component._currentElement._owner._instance.__proto__.constructor.displayName + ' expects a mapping from style properties to values, ' +
+    'Please check the render method of '+ component._currentElement._owner._instance.__proto__.constructor.displayName + '. The `style` prop expects a mapping from style properties to values, ' +
     'not a string. For example, style={{marginRight: spacing + \'em\'}} when ' +
     'using JSX.'
   );

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -263,7 +263,7 @@ function assertValidProps(component, props) {
   }
   invariant(
     props.style == null || typeof props.style === 'object',
-    ' A component inside its render method has incorrect inline style syntax.' +
+    'A component inside its render method has incorrect inline style syntax.' +
      ' The `style` prop expects a mapping from style properties to values, ' +
     'not a string. For example, style={{marginRight: spacing + \'em\'}} when ' +
     'using JSX. %s',

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -263,7 +263,7 @@ function assertValidProps(component, props) {
   }
   invariant(
     props.style == null || typeof props.style === 'object',
-    'The `style` prop expects a mapping from style properties to values, ' +
+    'The `style` prop of '+component._currentElement._owner._instance.__proto__.constructor.displayName + ' expects a mapping from style properties to values, ' +
     'not a string. For example, style={{marginRight: spacing + \'em\'}} when ' +
     'using JSX.'
   );

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -263,7 +263,7 @@ function assertValidProps(component, props) {
   }
   invariant(
     props.style == null || typeof props.style === 'object',
-    'A component inside its render method has incorrect inline style syntax.' +
+    'A dom node has incorrect inline style syntax.' +
      ' The `style` prop expects a mapping from style properties to values, ' +
     'not a string. For example, style={{marginRight: spacing + \'em\'}} when ' +
     'using JSX. %s',

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -263,8 +263,7 @@ function assertValidProps(component, props) {
   }
   invariant(
     props.style == null || typeof props.style === 'object',
-    'Please check the render method of ' +
-     component._currentElement._owner._instance.__proto__.constructor.displayName +
+      getDeclarationErrorAddendum(component) +
     '. The `style` prop expects a mapping from style properties to values, ' +
     'not a string. For example, style={{marginRight: spacing + \'em\'}} when ' +
     'using JSX.'

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -263,10 +263,9 @@ function assertValidProps(component, props) {
   }
   invariant(
     props.style == null || typeof props.style === 'object',
-    'A dom node has incorrect inline style syntax.' +
-     ' The `style` prop expects a mapping from style properties to values, ' +
+    'The `style` prop expects a mapping from style properties to values, ' +
     'not a string. For example, style={{marginRight: spacing + \'em\'}} when ' +
-    'using JSX. %s',
+    'using JSX.%s',
      getDeclarationErrorAddendum(component)
   );
 }

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -263,7 +263,7 @@ function assertValidProps(component, props) {
   }
   invariant(
     props.style == null || typeof props.style === 'object',
-    'Invariant Violation: A component inside its render method has incorrect inline style syntax.' +
+    ' A component inside its render method has incorrect inline style syntax.' +
      ' The `style` prop expects a mapping from style properties to values, ' +
     'not a string. For example, style={{marginRight: spacing + \'em\'}} when ' +
     'using JSX. %s',

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -263,11 +263,12 @@ function assertValidProps(component, props) {
   }
   invariant(
     props.style == null || typeof props.style === 'object',
-    '%s. A component inside its render method has incorrect inline style syntax.' +
+    'Invariant Violation: A component inside its render method has incorrect inline style syntax.' +
      ' The `style` prop expects a mapping from style properties to values, ' +
     'not a string. For example, style={{marginRight: spacing + \'em\'}} when ' +
-    'using JSX.',
-     getDeclarationErrorAddendum(component));
+    'using JSX. %s',
+     getDeclarationErrorAddendum(component)
+  );
 }
 
 function enqueuePutListener(id, registrationName, listener, transaction) {

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -263,11 +263,11 @@ function assertValidProps(component, props) {
   }
   invariant(
     props.style == null || typeof props.style === 'object',
-      getDeclarationErrorAddendum(component) +
-    '. The `style` prop expects a mapping from style properties to values, ' +
+    '%s. A component inside its render method has incorrect inline style syntax.' +
+     ' The `style` prop expects a mapping from style properties to values, ' +
     'not a string. For example, style={{marginRight: spacing + \'em\'}} when ' +
-    'using JSX.'
-  );
+    'using JSX.',
+     getDeclarationErrorAddendum(component));
 }
 
 function enqueuePutListener(id, registrationName, listener, transaction) {

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -263,7 +263,9 @@ function assertValidProps(component, props) {
   }
   invariant(
     props.style == null || typeof props.style === 'object',
-    'Please check the render method of '+ component._currentElement._owner._instance.__proto__.constructor.displayName + '. The `style` prop expects a mapping from style properties to values, ' +
+    'Please check the render method of ' +
+     component._currentElement._owner._instance.__proto__.constructor.displayName +
+    '. The `style` prop expects a mapping from style properties to values, ' +
     'not a string. For example, style={{marginRight: spacing + \'em\'}} when ' +
     'using JSX.'
   );

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -582,9 +582,9 @@ describe('ReactDOMComponent', function() {
       expect(function() {
         mountComponent({style: 'display: none'});
       }).toThrow(
-        "A component inside its render method has incorrect inline style syntax." +
-        " The `style` prop expects a mapping from style properties to values, not" +
-        " a string. For example, style={{marginRight: spacing + 'em'}} when using JSX."
+        'A component inside its render method has incorrect inline style syntax.' +
+        ' The `style` prop expects a mapping from style properties to values, not' +
+        ' a string. For example, style={{marginRight: spacing + \'em\'}} when using JSX.'
       );
     });
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -582,9 +582,9 @@ describe('ReactDOMComponent', function() {
       expect(function() {
         mountComponent({style: 'display: none'});
       }).toThrow(
-        'Invariant Violation: The `style` prop expects a mapping from style ' +
-        'properties to values, not a string. For example, ' +
-        'style={{marginRight: spacing + \'em\'}} when using JSX.'
+        "A component inside its render method has incorrect inline style syntax." +
+        " The `style` prop expects a mapping from style properties to values, not" +
+        " a string. For example, style={{marginRight: spacing + 'em'}} when using JSX."
       );
     });
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -582,9 +582,28 @@ describe('ReactDOMComponent', function() {
       expect(function() {
         mountComponent({style: 'display: none'});
       }).toThrow(
-        'Invariant Violation: A dom node has incorrect inline style syntax.' +
-        ' The `style` prop expects a mapping from style properties to values, not' +
-        ' a string. For example, style={{marginRight: spacing + \'em\'}} when using JSX. '
+        'Invariant Violation: ' +
+        'The `style` prop expects a mapping from style properties to values, ' +
+        'not a string. For example, style={{marginRight: spacing + \'em\'}} when ' +
+        'using JSX.'
+      );
+    });
+
+    it('should report component containing invalid styles', function() {
+      var container = document.createElement('div');
+      var Animal = React.createClass({
+        render: function() {
+          return <div style={1}></div>;
+        },
+      });
+
+      expect(function() {
+        React.render(<Animal/>, container);
+      }).toThrow(
+        'Invariant Violation: ' +
+        'The `style` prop expects a mapping from style properties to values, not ' +
+        'a string. For example, style={{marginRight: spacing + \'em\'}} when using JSX. ' +
+        'This DOM node was rendered by `Animal`.'
       );
     });
 
@@ -718,9 +737,27 @@ describe('ReactDOMComponent', function() {
       expect(function() {
         React.render(<div style={1}></div>, container);
       }).toThrow(
-        'Invariant Violation: A dom node has incorrect inline style syntax.' +
-        ' The `style` prop expects a mapping from style properties to values, not' +
-        ' a string. For example, style={{marginRight: spacing + \'em\'}} when using JSX. '
+        'Invariant Violation: ' +
+        'The `style` prop expects a mapping from style properties to values, ' +
+        'not a string. For example, style={{marginRight: spacing + \'em\'}} when ' +
+        'using JSX.'
+      );
+    });
+
+    it('should report component containing invalid styles', function() {
+      var Animal = React.createClass({
+        render: function() {
+          return <div style={1}></div>;
+        },
+      });
+
+      expect(function() {
+        React.render(<Animal/>, container);
+      }).toThrow(
+        'Invariant Violation: ' +
+        'The `style` prop expects a mapping from style properties to values, ' +
+        'not a string. For example, style={{marginRight: spacing + \'em\'}} when ' +
+        'using JSX. This DOM node was rendered by `Animal`.'
       );
     });
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -582,7 +582,7 @@ describe('ReactDOMComponent', function() {
       expect(function() {
         mountComponent({style: 'display: none'});
       }).toThrow(
-        'A component inside its render method has incorrect inline style syntax.' +
+        '. A component inside its render method has incorrect inline style syntax.' +
         ' The `style` prop expects a mapping from style properties to values, not' +
         ' a string. For example, style={{marginRight: spacing + \'em\'}} when using JSX.'
       );
@@ -718,9 +718,9 @@ describe('ReactDOMComponent', function() {
       expect(function() {
         React.render(<div style={1}></div>, container);
       }).toThrow(
-        'Invariant Violation: The `style` prop expects a mapping from style ' +
-        'properties to values, not a string. For example, ' +
-        'style={{marginRight: spacing + \'em\'}} when using JSX.'
+        '. A component inside its render method has incorrect inline style syntax.' +
+        ' The `style` prop expects a mapping from style properties to values, not' +
+        ' a string. For example, style={{marginRight: spacing + \'em\'}} when using JSX.'
       );
     });
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -582,9 +582,9 @@ describe('ReactDOMComponent', function() {
       expect(function() {
         mountComponent({style: 'display: none'});
       }).toThrow(
-        '. A component inside its render method has incorrect inline style syntax.' +
+        'Invariant Violation: A component inside its render method has incorrect inline style syntax.' +
         ' The `style` prop expects a mapping from style properties to values, not' +
-        ' a string. For example, style={{marginRight: spacing + \'em\'}} when using JSX.'
+        ' a string. For example, style={{marginRight: spacing + \'em\'}} when using JSX. '
       );
     });
 
@@ -718,9 +718,9 @@ describe('ReactDOMComponent', function() {
       expect(function() {
         React.render(<div style={1}></div>, container);
       }).toThrow(
-        '. A component inside its render method has incorrect inline style syntax.' +
+        'Invariant Violation: A component inside its render method has incorrect inline style syntax.' +
         ' The `style` prop expects a mapping from style properties to values, not' +
-        ' a string. For example, style={{marginRight: spacing + \'em\'}} when using JSX.'
+        ' a string. For example, style={{marginRight: spacing + \'em\'}} when using JSX. '
       );
     });
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -582,7 +582,7 @@ describe('ReactDOMComponent', function() {
       expect(function() {
         mountComponent({style: 'display: none'});
       }).toThrow(
-        'Invariant Violation: A component inside its render method has incorrect inline style syntax.' +
+        'Invariant Violation: A dom node has incorrect inline style syntax.' +
         ' The `style` prop expects a mapping from style properties to values, not' +
         ' a string. For example, style={{marginRight: spacing + \'em\'}} when using JSX. '
       );
@@ -718,7 +718,7 @@ describe('ReactDOMComponent', function() {
       expect(function() {
         React.render(<div style={1}></div>, container);
       }).toThrow(
-        'Invariant Violation: A component inside its render method has incorrect inline style syntax.' +
+        'Invariant Violation: A dom node has incorrect inline style syntax.' +
         ' The `style` prop expects a mapping from style properties to values, not' +
         ' a string. For example, style={{marginRight: spacing + \'em\'}} when using JSX. '
       );


### PR DESCRIPTION
inline style prop error thrown for JSX React elements now names React class that erroring element is a child of.  Fixes #4168