### PR TITLE
Upgrade for fbjs (w/ renamed rewrite-modules)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,7 @@ var flatten = require('gulp-flatten');
 var del = require('del');
 
 var babelPluginDEV = require('fbjs/scripts/babel/dev-expression');
-var babelPluginRequires = require('fbjs/scripts/babel/rewrite-requires');
+var babelPluginModules = require('fbjs/scripts/babel/rewrite-modules');
 
 var paths = {
   react: {
@@ -36,7 +36,7 @@ var babelOpts = {
   optional: [
     'es7.trailingFunctionCommas',
   ],
-  plugins: [babelPluginDEV, babelPluginRequires],
+  plugins: [babelPluginDEV, babelPluginModules],
   ignore: ['third_party'],
   _moduleMap: require('fbjs/module-map'),
 };

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -16,7 +16,7 @@ var ts = tsPreprocessor(defaultLibraries);
 // We should consider consuming this from a built fbjs module from npm.
 var moduleMap = require('fbjs/module-map');
 var babelPluginDEV = require('fbjs/scripts/babel/dev-expression');
-var babelPluginRequires = require('fbjs/scripts/babel/rewrite-requires');
+var babelPluginModules = require('fbjs/scripts/babel/rewrite-modules');
 
 module.exports = {
   process: function(src, path) {
@@ -37,7 +37,7 @@ module.exports = {
         optional: [
           'es7.trailingFunctionCommas',
         ],
-        plugins: [babelPluginDEV, babelPluginRequires],
+        plugins: [babelPluginDEV, babelPluginModules],
         ignore: ['third_party'],
         filename: path,
         retainLines: true,


### PR DESCRIPTION
In facebook/fbjs#21, the `rewrite-requires` module is renamed to `rewrite-modules`. When it gets accepted and a new package is deployed, we need to update react to point at the new version and use the new module name.