### PR TITLE
ensure tags are upperCase before comparing. #4388

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -213,7 +213,7 @@ var ReactTestUtils = {
   scryRenderedDOMComponentsWithTag: function(root, tagName) {
     return ReactTestUtils.findAllInRenderedTree(root, function(inst) {
       return ReactTestUtils.isDOMComponent(inst) &&
-            inst.tagName === tagName.toUpperCase();
+            inst.tagName.toUpperCase() === tagName.toUpperCase();
     });
   },
 


### PR DESCRIPTION
Fix #4388 where `svg` was lower case