### PR TITLE
Simplify react-codemod.

### DIFF
--- a/packages/react-codemod/.npmignore
+++ b/packages/react-codemod/.npmignore
@@ -1,1 +1,0 @@
-/transforms/

--- a/packages/react-codemod/README.md
+++ b/packages/react-codemod/README.md
@@ -1,13 +1,15 @@
 ## react-codemod
 
-This repository contains a collection of codemod scripts based on
+This repository contains a collection of codemod scripts based for use with
 [JSCodeshift](https://github.com/facebook/jscodeshift) that help update React
 APIs.
 
 ### Setup & Run
 
-  * `npm install -g react-codemod`
-  * `react-codemod <codemod-script> <file>`
+  * `npm install -g jscodeshift`
+  * `git clone https://github.com/facebook/react.git` or download a zip file
+    from `https://github.com/facebook/react/archive/master.zip`
+  * `jscodeshift -t <codemod-script> <file>`
   * Use the `-d` option for a dry-run and use `-p` to print the output
     for comparison
 
@@ -20,7 +22,7 @@ update calls on the component instance or its refs. You can use this script to
 update most calls to `getDOMNode` and then manually go through the remaining
 calls.
 
-  * `react-codemod findDOMNode <file>`
+  * `jscodeshift -t react/packages/react-codemod/transforms/findDOMNode.js <file>`
 
 `pure-render-mixin` removes `PureRenderMixin` and inlines
 `shouldComponentUpdate` so that the ES6 class transform can pick up the React
@@ -28,7 +30,7 @@ component and turn it into an ES6 class. NOTE: This currently only works if you
 are using the master version (>0.13.1) of React as it is using
 `React.addons.shallowCompare`
 
- * `react-codemod pure-render-mixin <file>`
+ * `jscodeshift -t react/packages/react-codemod/transforms/pure-render-mixin.js <file>`
  * If `--mixin-name=<name>` is specified it will look for the specified name
    instead of `PureRenderMixin`. Note that it is not possible to use a
    namespaced name for the mixin. `mixins: [React.addons.PureRenderMixin]` will
@@ -36,7 +38,7 @@ are using the master version (>0.13.1) of React as it is using
 
 `class` transforms `React.createClass` calls into ES6 classes.
 
-  * `react-codemod class <file>`
+  * `jscodeshift -t react/packages/react-codemod/transforms/class.js <file>`
   * If `--no-super-class=true` is specified it will not extend
     `React.Component` if `setState` and `forceUpdate` aren't being called in a
     class. We do recommend always extending from `React.Component`, especially
@@ -97,4 +99,4 @@ The constructor logic is as follows:
 Options to [recast](https://github.com/benjamn/recast)'s printer can be provided
 through the `printOptions` command line argument
 
- * `react-codemod class <file> --printOptions='{"quote":"double"}'`
+ * `jscodeshift -t transform.js <file> --printOptions='{"quote":"double"}'`

--- a/packages/react-codemod/package.json
+++ b/packages/react-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-codemod",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "React codemod scripts",
   "license": "BSD-3-Clause",
   "repository": {
@@ -8,18 +8,12 @@
     "url": "https://github.com/facebook/react"
   },
   "scripts": {
-    "build": "rm -rf build; babel transforms/ --out-dir=build/",
-    "test": "jest",
-    "prepublish": "npm run build"
-  },
-  "bin": {
-    "react-codemod": "./react-codemod"
+    "test": "jest"
   },
   "dependencies": {
-    "jscodeshift": "^0.1.0"
+    "jscodeshift": "^0.3.2"
   },
   "devDependencies": {
-    "babel": "^4.7.16",
     "babel-jest": "^4.0.0",
     "jest-cli": "^0.4.0"
   },

--- a/packages/react-codemod/react-codemod
+++ b/packages/react-codemod/react-codemod
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-DIR=$(npm root -g)/react-codemod
-TRANSFORM=$1
-shift
-
-$DIR/node_modules/.bin/jscodeshift -t $DIR/build/$TRANSFORM.js $@

--- a/packages/react-codemod/transforms/class.js
+++ b/packages/react-codemod/transforms/class.js
@@ -222,7 +222,7 @@ function updateReactCreateClassToES6(file, api, options) {
   // Boom!
   const createMethodDefinition = fn =>
     withComments(j.methodDefinition(
-      '',
+      'method',
       fn.key,
       fn.value
     ), fn);
@@ -495,7 +495,7 @@ function updateReactCreateClassToES6(file, api, options) {
     ) > 0;
 
     if (didTransform) {
-      return root.toSource(printOptions) + '\n';
+      return root.toSource(printOptions);
     }
   }
 

--- a/packages/react-codemod/transforms/findDOMNode.js
+++ b/packages/react-codemod/transforms/findDOMNode.js
@@ -133,7 +133,7 @@ function getDOMNodeToFindDOMNode(file, api, options) {
       .size() > 0;
 
     if (didTransform) {
-      return root.toSource(printOptions) + '\n';
+      return root.toSource(printOptions);
     }
   }
 

--- a/packages/react-codemod/transforms/pure-render-mixin.js
+++ b/packages/react-codemod/transforms/pure-render-mixin.js
@@ -177,7 +177,7 @@ function removePureRenderMixin(file, api, options) {
 
     if (didTransform) {
       deletePureRenderMixin(root);
-      return root.toSource(printOptions) + '\n';
+      return root.toSource(printOptions);
     }
   }
 


### PR DESCRIPTION
jscodeshift was fully upgraded to babel and now also transforms transform files (hah!). This simplifies the codemod repo structure quite significantly as we no longer need babel or a build process. See https://github.com/facebook/jscodeshift/releases/tag/v0.3.0 (this PR is only blocked by https://github.com/benjamn/ast-types/pull/120 being merged to make the tests pass).

I changed the README instructions to install jscodeshift and clone this repo to run the codemods. If we decide to split off react-codemod into a separate repo, this will make more sense because users won't be required to clone all of React but I think this is fine for now.