### PR TITLE
Alternate method of jumping to the root of the render tree.

### DIFF
--- a/src/renderers/dom/client/ReactEventListener.js
+++ b/src/renderers/dom/client/ReactEventListener.js
@@ -62,18 +62,13 @@ PooledClass.addPoolingTo(
 );
 
 function handleTopLevelImpl(bookKeeping) {
-  // TODO: Re-enable event.path handling
-  //
-  // if (bookKeeping.nativeEvent.path && bookKeeping.nativeEvent.path.length > 1) {
-  //   // New browsers have a path attribute on native events
-  //   handleTopLevelWithPath(bookKeeping);
-  // } else {
-  //   // Legacy browsers don't have a path attribute on native events
-  //   handleTopLevelWithoutPath(bookKeeping);
-  // }
-
-  void handleTopLevelWithPath;  // temporarily unused
-  handleTopLevelWithoutPath(bookKeeping);
+  if (bookKeeping.nativeEvent.path && bookKeeping.nativeEvent.path.length > 1) {
+    // New browsers have a path attribute on native events
+    handleTopLevelWithPath(bookKeeping);
+  } else {
+    // Legacy browsers don't have a path attribute on native events
+    handleTopLevelWithoutPath(bookKeeping);
+  }
 }
 
 // Legacy browsers don't have a path attribute on native events
@@ -133,10 +128,9 @@ function handleTopLevelWithPath(bookKeeping) {
       );
 
       // Jump to the root of this React render tree
-      while (currentPathElementID !== newRootID) {
+      var container = ReactMount.findReactContainerForID(newRootID);
+      while (i + 1 < path.length && path[i + 1] !== container) {
         i++;
-        currentPathElement = path[i];
-        currentPathElementID = ReactMount.getID(currentPathElement);
       }
     }
   }


### PR DESCRIPTION
Alternate method of jumping to the root of the render tree.

https://github.com/facebook/react/issues/4511 is a nasty bug to fix, but the recent event work makes it slightly more likely that we'll hit this bug.  This change helps mitigate the issue by avoiding the calls to `ReactMount.getId()` that do invariant checks, thus allowing us to tiptoe around the underlying issue.

On a side note, there are some thoughts that this might be slightly faster too, so it might even be a perf win :).