### PR TITLE
Remove fasttest task. fasttest is not fast

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -108,9 +108,6 @@ module.exports = function(grunt) {
     'npm-react:release',
   ]);
 
-  grunt.registerTask('fasttest', function() {
-    grunt.task.run('test');
-  });
   grunt.registerTask('test', ['jest']);
   grunt.registerTask('npm:test', ['build', 'npm:pack']);
 

--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@ We use grunt to automate many tasks. Run `grunt -h` to see a mostly complete lis
 grunt test
 # Build and run tests in your browser
 grunt test --debug
-# For speed, you can use fasttest and add --filter to only run one test
-grunt fasttest --filter=ReactIdentity
 # Lint the code with ESLint
 grunt lint
 # Wipe out build directory


### PR DESCRIPTION
`grunt fasttest` seems to be just an alias of `grunt test`.
And `--filter=xxx` option seems to be ignored.

I think you should remove it because it's confusing.