### PR TITLE
Fixed consistency of behavior boolean properties

### DIFF
--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -173,6 +173,9 @@ var DOMPropertyOperations = {
         // ('' + value) makes it output the correct toString()-value.
         if (namespace) {
           node.setAttributeNS(namespace, attributeName, '' + value);
+        } else if (propertyInfo.hasBooleanValue ||
+                   (propertyInfo.hasOverloadedBooleanValue && value === true)) {
+          node.setAttribute(attributeName, '');
         } else {
           node.setAttribute(attributeName, '' + value);
         }

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -224,6 +224,15 @@ describe('DOMPropertyOperations', function() {
         .toEqual(['http://www.w3.org/1999/xlink', 'xlink:href', 'about:blank']);
     });
 
+    it('should set values as boolean properties', function() {
+      DOMPropertyOperations.setValueForProperty(stubNode, 'disabled', 'disabled');
+      expect(stubNode.getAttribute('disabled')).toBe('');
+      DOMPropertyOperations.setValueForProperty(stubNode, 'disabled', true);
+      expect(stubNode.getAttribute('disabled')).toBe('');
+      DOMPropertyOperations.setValueForProperty(stubNode, 'disabled', false);
+      expect(stubNode.getAttribute('disabled')).toBe(null);
+    });
+
     it('should convert attribute values to string first', function() {
       // Browsers default to this behavior, but some test environments do not.
       // This ensures that we have consistent behavior.


### PR DESCRIPTION
The behavior of DOM Component boolean property is different by the component lifecycle (create or update).

```js
var Button = React.createClass({
    getInitialState: function() {
        return {
            disabled: true
        };
    },
    render: function() {
        return <div><button disabled={this.state.disabled}>click</button></div>;
    }
});
 
var component = React.render(<Button />, document.getElementById('container'));
console.log(React.findDOMNode(component).innerHTML);
// <button disabled="" data-reactid=".0.0">click</button>

component.setState({disabled: false});
console.log(React.findDOMNode(component).innerHTML);

component.setState({disabled: true});
console.log(React.findDOMNode(component).innerHTML);
// <button data-reactid=".0.0" disabled="true">click</button>
```

https://jsfiddle.net/koba04/arehgdsq/

I think it should be the same behavior regardless of the component lifecycle.
This PR applies the DOM operation in the creating component process to the updating process.
