### PR TITLE
Add stop-opacity to unitless style properties

### DIFF
--- a/docs/js/react.js
+++ b/docs/js/react.js
@@ -711,6 +711,7 @@ var isUnitlessNumber = {
 
   // SVG-related properties
   fillOpacity: true,
+  stopOpacity: true,
   strokeDashoffset: true,
   strokeOpacity: true,
   strokeWidth: true

--- a/docs/js/react.js
+++ b/docs/js/react.js
@@ -711,7 +711,6 @@ var isUnitlessNumber = {
 
   // SVG-related properties
   fillOpacity: true,
-  stopOpacity: true,
   strokeDashoffset: true,
   strokeOpacity: true,
   strokeWidth: true

--- a/docs/tips/06-style-props-value-px.ko-KR.md
+++ b/docs/tips/06-style-props-value-px.ko-KR.md
@@ -18,6 +18,7 @@ React.render(<div style={divStyle}>Hello World!</div>, mountNode);
 
 개발 하다보면 CSS 속성들이 단위 없이 그대로 유지되어야 할 때가 있을 겁니다. 아래의 프로퍼티들은 자동으로 "px"가 붙지 않는 속성 리스트 입니다:
 
+- `animationIterationCount`
 - `boxFlex`
 - `boxFlexGroup`
 - `boxOrdinalGroup`
@@ -35,7 +36,10 @@ React.render(<div style={divStyle}>Hello World!</div>, mountNode);
 - `opacity`
 - `order`
 - `orphans`
+- `stopOpacity`
+- `strokeDashoffset`
 - `strokeOpacity`
+- `strokeWidth`
 - `tabSize`
 - `widows`
 - `zIndex`

--- a/docs/tips/06-style-props-value-px.md
+++ b/docs/tips/06-style-props-value-px.md
@@ -18,6 +18,7 @@ See [Inline Styles](/react/tips/inline-styles.html) for more info.
 
 Sometimes you _do_ want to keep the CSS properties unitless. Here's a list of properties that won't get the automatic "px" suffix:
 
+- `animationIterationCount`
 - `boxFlex`
 - `boxFlexGroup`
 - `boxOrdinalGroup`
@@ -35,7 +36,10 @@ Sometimes you _do_ want to keep the CSS properties unitless. Here's a list of pr
 - `opacity`
 - `order`
 - `orphans`
+- `stopOpacity`
+- `strokeDashoffset`
 - `strokeOpacity`
+- `strokeWidth`
 - `tabSize`
 - `widows`
 - `zIndex`

--- a/src/renderers/dom/shared/CSSProperty.js
+++ b/src/renderers/dom/shared/CSSProperty.js
@@ -39,6 +39,7 @@ var isUnitlessNumber = {
 
   // SVG-related properties
   fillOpacity: true,
+  stopOpacity: true,
   strokeDashoffset: true,
   strokeOpacity: true,
   strokeWidth: true,


### PR DESCRIPTION
The stop-opacity is used to style the stop tag in the SVG linear-gradient tag, and it doesn't take any units.

Currently React appends 'px' whenever this property is used in JSX, making it invalid.

The following JSX
```javascript
return (
  <linearGradient id={props.name} x1={x1} y1={y1} x2={x2} y2={y2}>
    <stop offset='0%'
      style={{
        stopColor: props.color,
        stopOpacity: 0.3
      }}
    />
  </linearGradient>
);
```

results in

```html
<linearGradient x1="0%" y1="100%" x2="0%" y2="0%">
  <stop offset="0%" style="stop-color:#FDDE90; stop-opacity:0.3px;"></stop>
</linearGradient>
```

'px' should not be appended to the stop-opacity value.