### PR TITLE
Only set the owner during flattening

### DIFF
--- a/src/renderers/shared/reconciler/ReactChildReconciler.js
+++ b/src/renderers/shared/reconciler/ReactChildReconciler.js
@@ -14,7 +14,6 @@
 
 var ReactReconciler = require('ReactReconciler');
 
-var flattenChildren = require('flattenChildren');
 var instantiateReactComponent = require('instantiateReactComponent');
 var shouldUpdateReactComponent = require('shouldUpdateReactComponent');
 var traverseAllChildren = require('traverseAllChildren');
@@ -64,7 +63,7 @@ var ReactChildReconciler = {
    * Updates the rendered children and returns a new set of children.
    *
    * @param {?object} prevChildren Previously initialized set of children.
-   * @param {?object} nextNestedChildrenElements Nested child element maps.
+   * @param {?object} nextChildren Flat child element maps.
    * @param {ReactReconcileTransaction} transaction
    * @param {object} context
    * @return {?object} A new set of child instances.
@@ -72,7 +71,7 @@ var ReactChildReconciler = {
    */
   updateChildren: function(
     prevChildren,
-    nextNestedChildrenElements,
+    nextChildren,
     transaction,
     context) {
     // We currently don't have a way to track moves here but if we use iterators
@@ -80,7 +79,6 @@ var ReactChildReconciler = {
     // moved.
     // TODO: If nothing has changed, return the prevChildren object so that we
     // can quickly bailout if nothing has changed.
-    var nextChildren = flattenChildren(nextNestedChildrenElements);
     if (!nextChildren && !prevChildren) {
       return null;
     }

--- a/src/renderers/shared/reconciler/ReactMultiChild.js
+++ b/src/renderers/shared/reconciler/ReactMultiChild.js
@@ -19,6 +19,8 @@ var ReactCurrentOwner = require('ReactCurrentOwner');
 var ReactReconciler = require('ReactReconciler');
 var ReactChildReconciler = require('ReactChildReconciler');
 
+var flattenChildren = require('flattenChildren');
+
 /**
  * Updating children of a component may trigger recursive updates. The depth is
  * used to batch recursive updates to render markup more efficiently.
@@ -209,20 +211,23 @@ var ReactMultiChild = {
     },
 
     _reconcilerUpdateChildren: function(prevChildren, nextNestedChildrenElements, transaction, context) {
+      var nextChildren;
       if (__DEV__) {
         if (this._currentElement) {
           try {
             ReactCurrentOwner.current = this._currentElement._owner;
-            return ReactChildReconciler.updateChildren(
-              prevChildren, nextNestedChildrenElements, transaction, context
-            );
+            nextChildren = flattenChildren(nextNestedChildrenElements);
           } finally {
             ReactCurrentOwner.current = null;
           }
+          return ReactChildReconciler.updateChildren(
+            prevChildren, nextChildren, transaction, context
+          );
         }
       }
+      nextChildren = flattenChildren(nextNestedChildrenElements);
       return ReactChildReconciler.updateChildren(
-        prevChildren, nextNestedChildrenElements, transaction, context
+        prevChildren, nextChildren, transaction, context
       );
     },
 

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -1092,4 +1092,38 @@ describe('ReactCompositeComponent', function() {
     expect(moo.state.amIImmutable).toBe(undefined);
   });
 
+  it('should not warn about unmounting during unmounting', function() {
+    var container = document.createElement('div');
+    var layer = document.createElement('div');
+
+    var Component = React.createClass({
+      componentWillMount: function() {
+        React.render(<div />, layer);
+      },
+
+      componentWillUnmount: function() {
+        React.unmountComponentAtNode(layer);
+      },
+
+      render: function() {
+        return <div />;
+      },
+    });
+
+    var Outer = React.createClass({
+      render: function() {
+        return <div>{this.props.children}</div>;
+      },
+    });
+
+    React.render(<Outer><Component /></Outer>, container);
+
+    expect(console.error.calls.length).toBe(0);
+
+    React.render(<Outer />, container);
+
+    expect(console.error.calls.length).toBe(0);
+  });
+
+
 });


### PR DESCRIPTION
This used to do the update as well, which could have side-effects that
rely on owner being null.