### PR TITLE
Update 2015-05-01-graphql-introduction.md

### DIFF
--- a/docs/_posts/2015-05-01-graphql-introduction.md
+++ b/docs/_posts/2015-05-01-graphql-introduction.md
@@ -69,7 +69,7 @@ Obviously GraphQL is not the first system to manage client-server interactions. 
 
 ### REST
 
-REST an acronym for Representational State Transfer, which is an architectural style rather than a formal protocol. There is actually much debate about what exactly REST is and is not. We wish to avoid such debates. We are interested in the typical attributes of systems that *self-identify* as REST, rather than systems which are formally REST.
+REST, an acronym for Representational State Transfer, is an architectural style rather than a formal protocol. There is actually much debate about what exactly REST is and is not. We wish to avoid such debates. We are interested in the typical attributes of systems that *self-identify* as REST, rather than systems which are formally REST.
 
 Objects in a typical REST system are addressable by URI and interacted with using verbs in the HTTP protocol. An HTTP GET to a particular URI fetches an object and returns a server-specified set of fields. An HTTP PUT edits an object; an HTTP DELETE deletes an object; and so on.
 


### PR DESCRIPTION
Or the alternative:

`REST is an acronym for Representational State Transfer, which is an architectural style rather than a formal protocol`.

Sorry , I'am not a native speaker:)