### PR TITLE
Add property key names + type of value to fragment warning

### DIFF
--- a/src/addons/ReactFragment.js
+++ b/src/addons/ReactFragment.js
@@ -83,13 +83,17 @@ if (__DEV__) {
 
   var issuedWarnings = {};
 
-  var didWarnForFragment = function(fragment) {
-    // We use the keys and the type of the value as a heuristic to dedupe the
-    // warning to avoid spamming too much.
+  var getFragmentKeyString = function(fragment) {
     var fragmentCacheKey = '';
     for (var key in fragment) {
       fragmentCacheKey += key + ':' + (typeof fragment[key]) + ',';
     }
+    return fragmentCacheKey;
+  };
+
+  var didWarnForFragment = function(fragmentCacheKey) {
+    // We use the keys and the type of the value as a heuristic to dedupe the
+    // warning to avoid spamming too much.
     var alreadyWarnedOnce = !!issuedWarnings[fragmentCacheKey];
     issuedWarnings[fragmentCacheKey] = true;
     return alreadyWarnedOnce;
@@ -143,11 +147,13 @@ var ReactFragment = {
     if (__DEV__) {
       if (canWarnForReactFragment) {
         if (!fragment[fragmentKey]) {
+          var fragmentKeys = getFragmentKeyString(fragment);
           warning(
-            didWarnForFragment(fragment),
+            didWarnForFragment(fragmentKeys),
             'Any use of a keyed object should be wrapped in ' +
             'React.addons.createFragment(object) before being passed as a ' +
-            'child.'
+            'child. {%s}',
+            fragmentKeys
           );
           return fragment;
         }

--- a/src/addons/__tests__/ReactFragment-test.js
+++ b/src/addons/__tests__/ReactFragment-test.js
@@ -32,6 +32,9 @@ describe('ReactFragment', function() {
     expect(console.error.calls[0].args[0]).toContain(
       'Any use of a keyed object'
     );
+    expect(console.error.calls[0].args[0]).toContain(
+      '{x:object,y:object,}'
+    );
     // Only warn once for the same set of children
     var sameChildren = {
       x: <span />,
@@ -55,6 +58,9 @@ describe('ReactFragment', function() {
     expect(console.error.calls.length).toBe(1);
     expect(console.error.calls[0].args[0]).toContain(
       'Any use of a keyed object'
+    );
+    expect(console.error.calls[0].args[0]).toContain(
+      '{x:object,y:object,z:object,}'
     );
   });
 


### PR DESCRIPTION
This provides useful context in the logs to help us filter out things like
{__html:...}.

cc @spicyj 