### PR TITLE
adding __self and __source special props

### DIFF
--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -539,6 +539,8 @@ var ReactMount = {
       null,
       null,
       null,
+      null,
+      null,
       nextElement
     );
 


### PR DESCRIPTION
As discussed with @sebmarkbage.
Names can be changed if we want.

```
__self: A *temporary* helper to detect places where `this` is
different from the `owner` when React.createElement is called, so that we
can warn. We want to get rid of owner and replace string `ref`s with arrow
functions, and as long as `this` and owner are the same, there will be no
change in behavior.
__source: An annotation object (added by a transpiler or otherwise)
indicating filename, line number, and/or other information.
```