### PR TITLE
Added support for more HTML attributes: `summary`

### DIFF
--- a/docs/docs/ref-04-tags-and-attributes.ko-KR.md
+++ b/docs/docs/ref-04-tags-and-attributes.ko-KR.md
@@ -62,8 +62,8 @@ keyParams keyType label lang list loop low manifest marginHeight marginWidth max
 maxLength media mediaGroup method min multiple muted name noValidate open
 optimum pattern placeholder poster preload radioGroup readOnly rel required role
 rowSpan rows sandbox scope scoped scrolling seamless selected shape size sizes
-span spellCheck src srcDoc srcSet start step style tabIndex target title type
-useMap value width wmode
+span spellCheck src srcDoc srcSet start step style summary tabIndex target title
+type useMap value width wmode
 ```
 
 덧붙여, 이런 비표준 어트리뷰트도 지원됩니다.

--- a/docs/docs/ref-04-tags-and-attributes.md
+++ b/docs/docs/ref-04-tags-and-attributes.md
@@ -62,8 +62,8 @@ keyParams keyType label lang list loop low manifest marginHeight marginWidth max
 maxLength media mediaGroup method min multiple muted name noValidate open
 optimum pattern placeholder poster preload radioGroup readOnly rel required role
 rowSpan rows sandbox scope scoped scrolling seamless selected shape size sizes
-span spellCheck src srcDoc srcSet start step style tabIndex target title type
-useMap value width wmode wrap
+span spellCheck src srcDoc srcSet start step style summary tabIndex target title
+type useMap value width wmode wrap
 ```
 
 In addition, the following non-standard attributes are supported:

--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -150,6 +150,7 @@ var HTMLDOMPropertyConfig = {
     sizes: MUST_USE_ATTRIBUTE,
     span: HAS_POSITIVE_NUMERIC_VALUE,
     spellCheck: null,
+    summary: null,
     src: null,
     srcDoc: MUST_USE_PROPERTY,
     srcSet: MUST_USE_ATTRIBUTE,


### PR DESCRIPTION
Added support for the `summary` attribute to the `<table></table>` element.

See issue #4603