### PR TITLE
defaultProps should merge when initiating component

### DIFF
--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -123,16 +123,6 @@ ReactElement.createElement = function(type, config, children) {
     props.children = childArray;
   }
 
-  // Resolve default props
-  if (type && type.defaultProps) {
-    var defaultProps = type.defaultProps;
-    for (propName in defaultProps) {
-      if (typeof props[propName] === 'undefined') {
-        props[propName] = defaultProps[propName];
-      }
-    }
-  }
-
   return new ReactElement(
     type,
     key,

--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -26,6 +26,7 @@ var ReactCurrentOwner = require('ReactCurrentOwner');
 
 var getIteratorFn = require('getIteratorFn');
 var invariant = require('invariant');
+var processProps = require('processProps');
 var warning = require('warning');
 
 function getDeclarationErrorAddendum() {
@@ -268,10 +269,11 @@ function validatePropTypes(element) {
   }
   var name = componentClass.displayName || componentClass.name;
   if (componentClass.propTypes) {
+    var props = processProps(element);
     checkPropTypes(
       name,
       componentClass.propTypes,
-      element.props,
+      props,
       ReactPropTypeLocations.prop
     );
   }

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElement-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElement-test.js
@@ -189,4 +189,22 @@ describe('ReactJSXElement', function() {
     expect(inst2.props.prop).toBe(null);
   });
 
+  it('should merge defaultProps when initiating component', function() {
+    class Parent {
+      render() {
+        return <span><b>{this.props.children.props.a||''}</b>{this.props.children}</span>;
+      }
+    }
+    class Child {
+      render() {
+        return <u>{this.props.a}</u>;
+      }
+    }
+    Child.defaultProps = {a: 'a'};
+    var instance = ReactTestUtils.renderIntoDocument(<Parent><Child /></Parent>);
+    var node = React.findDOMNode(instance);
+    expect(node.childNodes[0].innerHTML).toBe('');
+    expect(node.childNodes[1].innerHTML).toBe('a');
+  });
+
 });

--- a/src/shared/utils/processProps.js
+++ b/src/shared/utils/processProps.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule processProps
+ * @typechecks static-only
+ */
+
+'use strict';
+
+var assign = require('Object.assign');
+
+/**
+ * Processes props by setting default values for unspecified props. Does not mutate its argument; returns
+ * a new props object with defaults merged in.
+ *
+ * @param {ReactElement} element
+ * @return {object}
+ */
+function processProps(element) {
+  var props = element.props;
+  var type = element.type;
+  var defaultProps = type && type.defaultProps;
+  // Resolve default props
+  if (defaultProps) {
+    var propName;
+    var originalProps = props;
+    for (propName in defaultProps) {
+      if (typeof props[propName] === 'undefined') {
+        if (props === originalProps) {
+          props = assign({}, originalProps);
+        }
+        props[propName] = defaultProps[propName];
+      }
+    }
+  }
+  return props;
+}
+
+module.exports = processProps;


### PR DESCRIPTION
I think it should not merge when create ReactElement (it isn't before? as [this method](https://github.com/facebook/react/blob/d3f338ff27ee52ce631891ffa5f99c2b139b92ab/src/renderers/shared/reconciler/ReactCompositeComponent.js#L406) says)

Here is my use case:  want to set prop value in Parent component for Child component if user does not provide value for this prop, but Child component can have defaultProps, because it can be also used without Parent component.

https://jsfiddle.net/yiminghe/o60fo9ew/1/