### PR TITLE
Fix grammar in "Why Relay"

### DIFF
--- a/blog/2015/08/11/relay-technical-preview.html
+++ b/blog/2015/08/11/relay-technical-preview.html
@@ -119,7 +119,7 @@
 
 <p>Declarative data-fetching means that Relay applications specify <em>what</em> data they need, not <em>how</em> to fetch that data. Just as React uses a description of the desired UI to manage view updates, Relay uses a data description in the form of GraphQL queries. Given these descriptions, Relay coalesces queries into batches for efficiency, manages error-prone asynchronous logic, caches data for performance, and automatically updates views as data changes.</p>
 
-<p>Relay is also component-oriented, extending the notion of a React component to include a description of what data is necessary to render it. This colocation allows developers to reason locally about their application and eliminates bugs such under- or over-fetching data.</p>
+<p>Relay is also component-oriented, extending the notion of a React component to include a description of what data is necessary to render it. This colocation allows developers to reason locally about their application and eliminates bugs such as under- or over-fetching data.</p>
 
 <p>Relay is in use at Facebook in production apps, and we&#39;re using it more and more because <em>Relay lets developers focus on their products and move fast</em>. It&#39;s working for us and we&#39;d like to share it with the community.</p>
 <h2><a class="anchor" name="whats-included"></a>What&#39;s Included <a class="hash-link" href="#whats-included">#</a></h2>


### PR DESCRIPTION
Should read: "eliminates bugs such **as** under- or over-fetching data"