### PR TITLE
ReactClass should not replace inheriting Class methods with autoBinding

### DIFF
--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -702,7 +702,8 @@ function bindAutoBindMethod(component, method) {
  */
 function bindAutoBindMethods(component) {
   for (var autoBindKey in component.__reactAutoBindMap) {
-    if (component.__reactAutoBindMap.hasOwnProperty(autoBindKey)) {
+    if (component.__reactAutoBindMap.hasOwnProperty(autoBindKey) &&
+      component.__reactAutoBindMap[autoBindKey] === component[autoBindKey]) {
       var method = component.__reactAutoBindMap[autoBindKey];
       component[autoBindKey] = bindAutoBindMethod(
         component,

--- a/src/isomorphic/classic/class/__tests__/ReactBind-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactBind-test.js
@@ -164,4 +164,31 @@ describe('autobinding', function() {
     expect(console.error.argsForCall.length).toBe(0);
   });
 
+  it('does not bind if an inheriting class overwrites prototype method', function() {
+
+    var classMethodCalled = false;
+
+    var TestBindComponent = React.createClass({
+      nonBoundMethod: function() {
+        throw new Error();
+      },
+      componentDidMount: function() {
+        this.nonBoundMethod();
+      },
+      render: function() {
+        return <div />;
+      },
+    });
+
+    class TestChildComponent extends TestBindComponent {
+      nonBoundMethod() {
+        classMethodCalled = true;
+      }
+    }
+
+    ReactTestUtils.renderIntoDocument(<TestChildComponent />);
+
+    expect(classMethodCalled).toBe(true);
+  });
+
 });


### PR DESCRIPTION
Currently, it is not possible to define methods on a Class inheriting from a `React.createClass` component constructor, without having any colliding methods [automatically replaced](https://github.com/facebook/react/blob/d7b59de1c39c509aaf0d9d3f16999dc14fc5bd14/src/isomorphic/classic/class/ReactClass.js#L816-L818) by the methods which have been designated for autobinding.

This adds a simple check to ensure the function in the `__reactAutoBindMap` is === to the method on the component it intends to replace, otherwise the auto-binding does not replace the method on the inheriting class body.

To visualize, adapted from the included test:
```js
var ParentComponent = React.createClass({
  testMethod: function() {
    throw new Error();
  },
  componentDidMount: function() {
    this.testMethod();
  },
  render: function() {
    return <div />;
  },
});

class ChildComponent extends ParentComponent {
  testMethod() {
  }
}
```

Previously, `testMethod` on the ParentComponent always replaces that of the `ChildComponent`, and `Error` would always be thrown.