### PR TITLE
Swap places of mounted and pending update checks

### DIFF
--- a/src/renderers/dom/client/wrappers/ReactDOMSelect.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMSelect.js
@@ -22,7 +22,7 @@ var valueContextKey =
   '__ReactDOMSelect_value$' + Math.random().toString(36).slice(2);
 
 function updateOptionsIfPendingUpdateAndMounted() {
-  if (this._wrapperState.pendingUpdate && this._rootNodeID) {
+  if (this._rootNodeID && this._wrapperState.pendingUpdate) {
     this._wrapperState.pendingUpdate = false;
 
     var props = this._currentElement.props;


### PR DESCRIPTION
Prevents `Uncaught TypeError: Cannot read property 'pendingUpdate' of null`.