### PR TITLE
[WIP] Docs i18n

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -9,6 +9,9 @@ gem 'jekyll', '~>2.0'
 # Auto redirect pages
 gem 'jekyll-redirect-from'
 
+# i18n / l10n
+gem 'jekyll-multiple-languages'
+
 # JSON
 gem 'json'
 

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -32,6 +32,7 @@ GEM
     jekyll-coffeescript (1.0.0)
       coffee-script (~> 2.2)
     jekyll-gist (1.1.0)
+    jekyll-multiple-languages (1.0.8)
     jekyll-paginate (1.0.0)
     jekyll-redirect-from (0.5.0)
       jekyll (~> 2.0)
@@ -75,6 +76,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 2.0)
+  jekyll-multiple-languages
   jekyll-redirect-from
   json
   rake

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,4 +36,10 @@ sass:
   sass_dir: _css
 gems:
 - jekyll-redirect-from
+- jekyll-multiple-languages
 react_version: 0.14.2
+
+# i18n
+languages: ["en", "ko-KR"]
+default_language: "en"
+fill_default_content: true

--- a/docs/_data/nav_docs.yml
+++ b/docs/_data/nav_docs.yml
@@ -1,99 +1,99 @@
-- title: Quick Start
+- title: docs.titles.quick-start
   items:
   - id: getting-started
-    title: Getting Started
+    title: docs.titles.getting-started
   - id: tutorial
-    title: Tutorial
+    title: docs.titles.tutorial
   - id: thinking-in-react
-    title: Thinking in React
-- title: Community Resources
+    title: docs.titles.thinking-in-react
+- title: docs.titles.community-resources
   items:
   - id: conferences
-    title: Conferences
+    title: docs.titles.conferences
   - id: videos
-    title: Videos
+    title: docs.titles.videos
   - id: complementary-tools
-    title: Complementary Tools
+    title: docs.titles.complementary-tools
   - id: examples
-    title: Examples
-- title: Guides
+    title: docs.titles.examples
+- title: docs.titles.guides
   items:
   - id: why-react
-    title: Why React?
+    title: docs.titles.why-react
   - id: displaying-data
-    title: Displaying Data
+    title: docs.titles.displaying-data
     subitems:
     - id: jsx-in-depth
-      title: JSX in Depth
+      title: docs.titles.jsx-in-depth
     - id: jsx-spread
-      title: JSX Spread Attributes
+      title: docs.titles.jsx-spread
     - id: jsx-gotchas
-      title: JSX Gotchas
+      title: docs.titles.jsx-gotchas
   - id: interactivity-and-dynamic-uis
-    title: Interactivity and Dynamic UIs
+    title: docs.titles.interactivity-and-dynamic-uis
   - id: multiple-components
-    title: Multiple Components
+    title: docs.titles.multiple-components
   - id: reusable-components
-    title: Reusable Components
+    title: docs.titles.reusable-components
   - id: transferring-props
-    title: Transferring Props
+    title: docs.titles.transferring-props
   - id: forms
-    title: Forms
+    title: docs.titles.forms
   - id: working-with-the-browser
-    title: Working With the Browser
+    title: docs.titles.working-with-the-browser
     subitems:
     - id: more-about-refs
-      title: Refs to Components
+      title: docs.titles.more-about-refs
   - id: tooling-integration
-    title: Tooling Integration
+    title: docs.titles.tooling-integration
   - id: addons
-    title: Add-Ons
+    title: docs.titles.addons
     subitems:
     - id: animation
-      title: Animation
+      title: docs.titles.animation
     - id: two-way-binding-helpers
-      title: Two-Way Binding Helpers
+      title: docs.titles.two-way-binding-helpers
     - id: test-utils
-      title: Test Utilities
+      title: docs.titles.test-utils
     - id: clone-with-props
-      title: Cloning Elements
+      title: docs.titles.clone-with-props
     - id: create-fragment
-      title: Keyed Fragments
+      title: docs.titles.create-fragment
     - id: update
-      title: Immutability Helpers
+      title: docs.titles.update
     - id: pure-render-mixin
-      title: PureRenderMixin
+      title: docs.titles.pure-render-mixin
     - id: perf
-      title: Performance Tools
+      title: docs.titles.perf
   - id: advanced-performance
-    title: Advanced Performance
+    title: docs.titles.advanced-performance
   - id: context
-    title: Context
-- title: Reference
+    title: docs.titles.context
+- title: docs.titles.reference
   items:
   - id: top-level-api
-    title: Top-Level API
+    title: docs.titles.top-level-api
   - id: component-api
-    title: Component API
+    title: docs.titles.component-api
   - id: component-specs
-    title: Component Specs and Lifecycle
+    title: docs.titles.component-specs
   - id: tags-and-attributes
-    title: Supported Tags and Attributes
+    title: docs.titles.tags-and-attributes
   - id: events
-    title: Event System
+    title: docs.titles.events
   - id: dom-differences
-    title: DOM Differences
+    title: docs.titles.dom-differences
   - id: special-non-dom-attributes
-    title: Special Non-DOM Attributes
+    title: docs.titles.special-non-dom-attributes
   - id: reconciliation
-    title: Reconciliation
+    title: docs.titles.reconciliation
   - id: glossary
-    title: React (Virtual) DOM Terminology
-- title: Flux
+    title: docs.titles.glossary
+- title: docs.titles.flux
   items:
   - id: flux-overview
-    title: Flux Overview
+    title: docs.titles.flux-overview
     href: https://facebook.github.io/flux/docs/overview.html
   - id: flux-todo-list
-    title: Flux TodoMVC Tutorial
+    title: docs.titles.flux-todo-list
     href: https://facebook.github.io/flux/docs/todo-list.html

--- a/docs/_data/nav_tips.yml
+++ b/docs/_data/nav_tips.yml
@@ -1,38 +1,40 @@
-- title: Tips
+- title: tips.titles.tips
   items:
   - id: introduction
-    title: Introduction
+    title: tips.titles.introduction
   - id: inline-styles
-    title: Inline Styles
+    title: tips.titles.inline-styles
   - id: if-else-in-JSX
-    title: If-Else in JSX
+    title: tips.titles.if-else-in-JSX
   - id: self-closing-tag
-    title: Self-Closing Tag
+    title: tips.titles.self-closing-tag
   - id: maximum-number-of-jsx-root-nodes
-    title: Maximum Number of JSX Root Nodes
+    title: tips.titles.maximum-number-of-jsx-root-nodes
   - id: style-props-value-px
-    title: Shorthand for Specifying Pixel Values in style props
+    title: tips.titles.style-props-value-px
   - id: children-props-type
-    title: Type of the Children props
+    title: tips.titles.children-props-type
   - id: controlled-input-null-value
-    title: Value of null for Controlled Input
+    title: tips.titles.controlled-input-null-value
   - id: componentWillReceiveProps-not-triggered-after-mounting
-    title: componentWillReceiveProps Not Triggered After Mounting
+    title: tips.titles.componentWillReceiveProps-not-triggered-after-mounting
   - id: props-in-getInitialState-as-anti-pattern
-    title: Props in getInitialState Is an Anti-Pattern
+    title: tips.titles.props-in-getInitialState-as-anti-pattern
   - id: dom-event-listeners
-    title: DOM Event Listeners in a Component
+    title: tips.titles.dom-event-listeners
   - id: initial-ajax
-    title: Load Initial Data via AJAX
+    title: tips.titles.initial-ajax
   - id: false-in-jsx
-    title: False in JSX
+    title: tips.titles.false-in-jsx
   - id: communicate-between-components
-    title: Communicate Between Components
+    title: tips.titles.communicate-between-components
   - id: expose-component-functions
-    title: Expose Component Functions
+    title: tips.titles.expose-component-functions
+  - id: references-to-components
+    title: tips.titles.references-to-components
   - id: children-undefined
-    title: this.props.children undefined
+    title: tips.titles.children-undefined
   - id: use-react-with-other-libraries
-    title: Use React with Other Libraries
+    title: tips.titles.use-react-with-other-libraries
   - id: dangerously-set-inner-html
-    title: Dangerously Set innerHTML
+    title: tips.titles.dangerously-set-inner-html

--- a/docs/_i18n/en.yml
+++ b/docs/_i18n/en.yml
@@ -1,0 +1,82 @@
+global:
+  next: Next
+  previous: Previous
+
+docs:
+  titles:
+    quick-start: Quick Start
+    getting-started: Getting Started
+    tutorial: Tutorial
+    thinking-in-react: Thinking in React
+
+    community-resources: Community Resources
+    conferences: Conferences
+    videos: Videos
+    complementary-tools: Complementary Tools
+    examples: Examples
+
+    guides: Guides
+    why-react: Why React?
+    displaying-data: Displaying Data
+    jsx-in-depth: JSX in Depth
+    jsx-spread: JSX Spread Attributes
+    jsx-gotchas: JSX Gotchas
+    interactivity-and-dynamic-uis: Interactivity and Dynamic UIs
+    multiple-components: Multiple Components
+    reusable-components: Reusable Components
+    transferring-props: Transferring Props
+    forms: Forms
+    working-with-the-browser: Working With the Browser
+    more-about-refs: Refs to Components
+    tooling-integration: Tooling Integration
+    addons: Add-Ons
+    animation: Animation
+    two-way-binding-helpers: Two-Way Binding Helpers
+    test-utils: Test Utilities
+    clone-with-props: Cloning Elements
+    create-fragment: Keyed Fragments
+    update: Immutability Helpers
+    pure-render-mixin: PureRenderMixin
+    perf: Performance Tools
+    advanced-performance: Advanced Performance
+    context: Context
+
+    reference: Reference
+    top-level-api: Top-Level API
+    component-api: Component API
+    component-specs: Component Specs and Lifecycle
+    tags-and-attributes: Supported Tags and Attributes
+    events: Event System
+    dom-differences: DOM Differences
+    special-non-dom-attributes: Special Non-DOM Attributes
+    reconciliation: Reconciliation
+    glossary: React (Virtual) DOM Terminology
+
+    flux: Flux
+    flux-overview: Flux Overview
+    flux-todo-list: Flux TodoMVC Tutorial
+
+
+tips:
+  titles:
+    tips: Tips
+
+    introduction: Introduction
+    inline-styles: Inline Styles
+    if-else-in-JSX: If-Else in JSX
+    self-closing-tag: Self-Closing Tag
+    maximum-number-of-jsx-root-nodes: Maximum Number of JSX Root Nodes
+    style-props-value-px: Shorthand for Specifying Pixel Values in style props
+    children-props-type: Type of the Children props
+    controlled-input-null-value: Value of null for Controlled Input
+    componentWillReceiveProps-not-triggered-after-mounting: componentWillReceiveProps Not Triggered After Mounting
+    props-in-getInitialState-as-anti-pattern: Props in getInitialState Is an Anti-Pattern
+    dom-event-listeners: DOM Event Listeners in a Component
+    initial-ajax: Load Initial Data via AJAX
+    false-in-jsx: False in JSX
+    communicate-between-components: Communicate Between Components
+    expose-component-functions: Expose Component Functions
+    references-to-components: References to Components
+    children-undefined: this.props.children undefined
+    use-react-with-other-libraries: Use React with Other Libraries
+    dangerously-set-inner-html: Dangerously Set innerHTML

--- a/docs/_i18n/en.yml
+++ b/docs/_i18n/en.yml
@@ -32,6 +32,7 @@ docs:
     addons: Add-Ons
     animation: Animation
     two-way-binding-helpers: Two-Way Binding Helpers
+    class-name-manipulation: Class Name Manipulation
     test-utils: Test Utilities
     clone-with-props: Cloning Elements
     create-fragment: Keyed Fragments

--- a/docs/_i18n/ko-KR.yml
+++ b/docs/_i18n/ko-KR.yml
@@ -31,7 +31,7 @@ docs:
     transferring-props: Props 전달
     forms: 폼
     working-with-the-browser: 브라우저에서의 동작
-    more-about-refs: refs 심화
+    more-about-refs: refs에서 컴포넌트로
     tooling-integration: 툴 통합
     addons: 애드온
     animation: 애니메이션

--- a/docs/_i18n/ko-KR.yml
+++ b/docs/_i18n/ko-KR.yml
@@ -4,4 +4,83 @@ global:
 
 docs:
   titles:
+    why-react:
+
+docs:
+  titles:
+    quick-start: Quick Start
+    getting-started: 시작해보기
+    tutorial: 튜토리얼
+    thinking-in-react: 리액트로 생각해보기
+
+    community-resources: Community Resources
+    conferences: 컨퍼런스들
+    videos: 비디오들
+    complementary-tools: 상호 보완적인 도구들
+    examples: 예제들
+
+    guides: Guides
     why-react: 왜 React인가?
+    displaying-data: 데이터를 표시하기
+    jsx-in-depth: JSX 깊이보기
+    jsx-spread: JSX 스프레드 어트리뷰트
+    jsx-gotchas: JSX Gotchas
+    interactivity-and-dynamic-uis: 상호 작용 및 동적 UI
+    multiple-components: 복합 컴포넌트
+    reusable-components: 재사용가능한 컴포넌트
+    transferring-props: Props 전달
+    forms: 폼
+    working-with-the-browser: 브라우저에서의 동작
+    more-about-refs: refs 심화
+    tooling-integration: 툴 통합
+    addons: 애드온
+    animation: 애니메이션
+    two-way-binding-helpers: 양방향 바인딩 핼퍼
+    class-name-manipulation: 클래스 이름 조작
+    test-utils: 테스트 유틸리티
+    clone-with-props: ReactElement 클론하기
+    create-fragment: 키가 할당된 프래그먼트
+    update: 불변성 헬퍼들
+    pure-render-mixin: PureRenderMixin
+    perf: 성능 도구
+    advanced-performance: 성능 심화
+
+    reference: Reference
+    top-level-api: 최상위 API
+    component-api: 컴포넌트 API
+    component-specs: 컴포넌트 명세와 생명주기
+    tags-and-attributes: 태그와 어트리뷰트
+    events: 이벤트 시스템
+    dom-differences: DOM과의 차이점
+    special-non-dom-attributes: DOM이 아닌 특별한 어트리뷰트
+    reconciliation: 비교조정(Reconciliation)
+    glossary: React (가상) DOM 용어
+
+    flux: Flux
+    flux-overview: Flux 애플리케이션 아키텍쳐
+    flux-todo-list: Flux TodoMVC 튜토리얼
+
+
+tips:
+  titles:
+    tips: Tips
+
+    introduction: Introduction
+    inline-styles: Inline Styles
+    if-else-in-JSX: If-Else in JSX
+    self-closing-tag: Self-Closing Tag
+    maximum-number-of-jsx-root-nodes: Maximum Number of JSX Root Nodes
+    style-props-value-px: Shorthand for Specifying Pixel Values in style props
+    children-props-type: Type of the Children props
+    controlled-input-null-value: Value of null for Controlled Input
+    componentWillReceiveProps-not-triggered-after-mounting: componentWillReceiveProps Not Triggered After Mounting
+    props-in-getInitialState-as-anti-pattern: Props in getInitialState Is an Anti-Pattern
+    dom-event-listeners: DOM Event Listeners in a Component
+    initial-ajax: Load Initial Data via AJAX
+    false-in-jsx: False in JSX
+    communicate-between-components: Communicate Between Components
+    expose-component-functions: Expose Component Functions
+    references-to-components: References to Components
+    children-undefined: this.props.children undefined
+    use-react-with-other-libraries: Use React with Other Libraries
+    dangerously-set-inner-html: Dangerously Set innerHTML

--- a/docs/_i18n/ko-KR.yml
+++ b/docs/_i18n/ko-KR.yml
@@ -65,22 +65,22 @@ tips:
   titles:
     tips: Tips
 
-    introduction: Introduction
-    inline-styles: Inline Styles
-    if-else-in-JSX: If-Else in JSX
-    self-closing-tag: Self-Closing Tag
-    maximum-number-of-jsx-root-nodes: Maximum Number of JSX Root Nodes
-    style-props-value-px: Shorthand for Specifying Pixel Values in style props
-    children-props-type: Type of the Children props
-    controlled-input-null-value: Value of null for Controlled Input
-    componentWillReceiveProps-not-triggered-after-mounting: componentWillReceiveProps Not Triggered After Mounting
-    props-in-getInitialState-as-anti-pattern: Props in getInitialState Is an Anti-Pattern
-    dom-event-listeners: DOM Event Listeners in a Component
-    initial-ajax: Load Initial Data via AJAX
-    false-in-jsx: False in JSX
-    communicate-between-components: Communicate Between Components
-    expose-component-functions: Expose Component Functions
-    references-to-components: References to Components
-    children-undefined: this.props.children undefined
-    use-react-with-other-libraries: Use React with Other Libraries
+    introduction: 개요
+    inline-styles: 인라인 스타일
+    if-else-in-JSX: JSX에서 If-Else
+    self-closing-tag: 자기 자신을 닫는 태그
+    maximum-number-of-jsx-root-nodes: JSX 루트 노드의 최대 갯수
+    style-props-value-px: 스타일 속성에서 특정 픽셀 값 넣는 간단한 방법
+    children-props-type: 자식 속성들의 타입
+    controlled-input-null-value: 제어되는 input 내의 null 값
+    componentWillReceiveProps-not-triggered-after-mounting: 마운트 후에는 componentWillReceiveProps가 실행되지 않음
+    props-in-getInitialState-as-anti-pattern: getInitialState의 Props는 안티패턴
+    dom-event-listeners: 컴포넌트에서 DOM 이벤트 리스너
+    initial-ajax: AJAX를 통해 초기 데이터 읽어오기
+    false-in-jsx: JSX에서 False
+    communicate-between-components: 컴포넌트간의 통신
+    expose-component-functions: 컴포넌트 함수 드러내기
+    references-to-components: 컴포넌트 참조
+    children-undefined: 정의되지 않은 this.props.children
+    use-react-with-other-libraries: React와 다른 라이브러리를 함께 사용하기
     dangerously-set-inner-html: Dangerously Set innerHTML

--- a/docs/_i18n/ko-KR.yml
+++ b/docs/_i18n/ko-KR.yml
@@ -1,0 +1,7 @@
+global:
+  next: 다음
+  previous: 이전
+
+docs:
+  titles:
+    why-react: 왜 React인가?

--- a/docs/_i18n/ko-KR.yml
+++ b/docs/_i18n/ko-KR.yml
@@ -44,6 +44,7 @@ docs:
     pure-render-mixin: PureRenderMixin
     perf: 성능 도구
     advanced-performance: 성능 심화
+    context: 컨텍스트
 
     reference: Reference
     top-level-api: 최상위 API

--- a/docs/_includes/nav_docs.html
+++ b/docs/_includes/nav_docs.html
@@ -2,16 +2,16 @@
   <!-- Docs Nav -->
   {% for section in site.data.nav_docs %}
     <div class="nav-docs-section">
-      <h3>{{ section.title }}</h3>
+      <h3>{% t section.title %}</h3>
       <ul>
         {% for item in section.items %}
           <li>
-            {{ item | sidebar_item_link}}
+            {% sidebaritem item %}{% t item.title %}{% endsidebaritem %}
             {% if item.subitems %}
               <ul>
                 {% for subitem in item.subitems %}
                   <li>
-                    {{ subitem | sidebar_item_link}}
+                    {% sidebaritem subitem %}{% t subitem.title %}{% endsidebaritem %}
                   </li>
                 {% endfor %}
               </ul>
@@ -25,11 +25,11 @@
   <!-- Tips Nav -->
   {% for section in site.data.nav_tips %}
     <div class="nav-docs-section">
-      <h3>{{ section.title }}</h3>
+      <h3>{% t section.title %}</h3>
       <ul>
         {% for item in section.items %}
           <li>
-            <a href="/react/tips/{{ item.id }}.html"{% if page.id == item.id %} class="active"{% endif %}>{{ item.title }}</a>
+            <a href="/react/tips/{{ item.id }}.html"{% if page.id == item.id %} class="active"{% endif %}>{%t item.title %}</a>
           </li>
         {% endfor %}
       </ul>

--- a/docs/_includes/nav_docs.html
+++ b/docs/_includes/nav_docs.html
@@ -29,7 +29,7 @@
       <ul>
         {% for item in section.items %}
           <li>
-            <a href="/react/tips/{{ item.id }}.html"{% if page.id == item.id %} class="active"{% endif %}>{%t item.title %}</a>
+            {% sidebartipitem item %}{% t item.title %}{% endsidebartipitem %}
           </li>
         {% endfor %}
       </ul>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -46,9 +46,9 @@
           React
         </a>
         <ul class="nav-site nav-site-internal">
-          <li><a href="/react/docs/getting-started.html"{% if page.sectionid == 'docs' or page.sectionid == 'tips' %} class="active"{% endif %}>Docs</a></li>
-          <li><a href="/react/support.html"{% if page.id == 'support' %} class="active"{% endif %}>Support</a></li>
-          <li><a href="/react/downloads.html"{% if page.id == 'downloads' %} class="active"{% endif %}>Download</a></li>
+          <li><a href="{{"/react/docs/getting-started.html"|translate_link}}"{% if page.sectionid == 'docs' or page.sectionid == 'tips' %} class="active"{% endif %}>Docs</a></li>
+          <li><a href="{{"/react/support.html"|translate_link}}"{% if page.id == 'support' %} class="active"{% endif %}>Support</a></li>
+          <li><a href="{{"/react/downloads.html"|translate_link}}"{% if page.id == 'downloads' %} class="active"{% endif %}>Download</a></li>
           <li><a href="/react/blog/"{% if page.sectionid == 'blog' %} class="active"{% endif %}>Blog</a></li>
         </ul>
 

--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -17,10 +17,10 @@ sectionid: docs
 
     <div class="docs-prevnext">
       {% if page.prev %}
-        <a class="docs-prev" href="/react/{{ page.prev }}">&larr; {% t global.previous %}</a>
+        <a class="docs-prev" href="{{ page.prev | translate_link_docs }}">&larr; {% t global.previous %}</a>
       {% endif %}
       {% if page.next %}
-        <a class="docs-next" href="/react/{{ page.next }}">{% t global.next %} &rarr;</a>
+        <a class="docs-next" href="{{ page.next | translate_link_docs }}">{% t global.next %} &rarr;</a>
       {% endif %}
     </div>
 

--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -8,7 +8,7 @@ sectionid: docs
 
   <div class="inner-content">
     <h1>
-      {{ page.title }}
+      {% t page.title %}
       <a class="edit-page-link" href="https://github.com/facebook/react/tree/master/docs/{{ page.path }}" target="_blank">Edit on GitHub</a>
     </h1>
     <div class="subHeader">{{ page.description }}</div>

--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -17,11 +17,12 @@ sectionid: docs
 
     <div class="docs-prevnext">
       {% if page.prev %}
-        <a class="docs-prev" href="/react/docs/{{ page.prev }}">&larr; Prev</a>
+        <a class="docs-prev" href="/react/{{ page.prev }}">&larr; {% t global.previous %}</a>
       {% endif %}
       {% if page.next %}
-        <a class="docs-next" href="/react/docs/{{ page.next }}">Next &rarr;</a>
+        <a class="docs-next" href="/react/{{ page.next }}">{% t global.next %} &rarr;</a>
       {% endif %}
     </div>
+
   </div>
 </section>

--- a/docs/_layouts/tips.html
+++ b/docs/_layouts/tips.html
@@ -7,16 +7,16 @@ sectionid: tips
   {% include nav_docs.html %}
 
   <div class="inner-content">
-    <h1>{{ page.title }}</h1>
+    <h1>{% t page.title %}</h1>
     <div class="subHeader">{{ page.description }}</div>
     {{ content }}
 
     <div class="docs-prevnext">
       {% if page.prev %}
-        <a class="docs-prev" href="/react/tips/{{ page.prev }}">&larr; Prev</a>
+        <a class="docs-prev" href="/react/tips/{{ page.prev }}">&larr; {% t global.previous %}</a>
       {% endif %}
       {% if page.next %}
-        <a class="docs-next" href="/react/tips/{{ page.next }}">Next &rarr;</a>
+        <a class="docs-next" href="/react/tips/{{ page.next }}">{% t global.next %} &rarr;</a>
       {% endif %}
     </div>
   </div>

--- a/docs/_plugins/sidebar_item.rb
+++ b/docs/_plugins/sidebar_item.rb
@@ -1,6 +1,26 @@
 module Jekyll
+  class SidebarItemBlock < Liquid::Block
+    def initialize(tag_name, item, tokens)
+      super
+      @item = item
+    end
+
+    def render(context)
+      pageID = context["page"]["id"]
+      item = context[@item]
+      itemID = item["id"]
+      # TODO: link to correct locale
+      href = item["href"] || "/react/docs/#{itemID}.html"
+      className = pageID == itemID ? ' class="active"' : ''
+      
+      return "<a data-id=\"#{pageID}\" data-other=\"#{itemID}\" href=\"#{href}\"#{className}>#{super}</a>"
+    end
+  end
+
+  # DECPRECATED
   module SidebarItemFilter
     def sidebar_item_link(item)
+      # item, label = split_params(params)
       pageID = @context.registers[:page]["id"]
       itemID = item["id"]
       href = item["href"] || "/react/docs/#{itemID}.html"
@@ -12,3 +32,4 @@ module Jekyll
 end
 
 Liquid::Template.register_filter(Jekyll::SidebarItemFilter)
+Liquid::Template.register_tag('sidebaritem', Jekyll::SidebarItemBlock)

--- a/docs/_plugins/sidebar_item.rb
+++ b/docs/_plugins/sidebar_item.rb
@@ -1,3 +1,13 @@
+def get_lang_path(context)
+  lang = context["page"]["language"]
+  is_default_lang = context["page"]["is_default_language"]
+  if is_default_lang then
+    ""
+  else
+    "#{lang}/"
+  end
+end
+
 module Jekyll
   class SidebarItemBlock < Liquid::Block
     def initialize(tag_name, item, tokens)
@@ -7,29 +17,35 @@ module Jekyll
 
     def render(context)
       pageID = context["page"]["id"]
+      lang_path = get_lang_path(context)
       item = context[@item]
       itemID = item["id"]
       # TODO: link to correct locale
-      href = item["href"] || "/react/docs/#{itemID}.html"
+      href = item["href"] || "/react/#{lang_path}docs/#{itemID}.html"
       className = pageID == itemID ? ' class="active"' : ''
-      
+
       return "<a data-id=\"#{pageID}\" data-other=\"#{itemID}\" href=\"#{href}\"#{className}>#{super}</a>"
     end
   end
+  class SidebarTipItemBlock < Liquid::Block
+    def initialize(tag_name, item, tokens)
+      super
+      @item = item
+    end
 
-  # DECPRECATED
-  module SidebarItemFilter
-    def sidebar_item_link(item)
-      # item, label = split_params(params)
-      pageID = @context.registers[:page]["id"]
+    def render(context)
+      pageID = context["page"]["id"]
+      lang_path = get_lang_path(context)
+      item = context[@item]
       itemID = item["id"]
-      href = item["href"] || "/react/docs/#{itemID}.html"
+      # TODO: link to correct locale
+      href = item["href"] || "/react/#{lang_path}tips/#{itemID}.html"
       className = pageID == itemID ? ' class="active"' : ''
 
-      return "<a href=\"#{href}\"#{className}>#{item["title"]}</a>"
+      return "<a data-id=\"#{pageID}\" data-other=\"#{itemID}\" href=\"#{href}\"#{className}>#{super}</a>"
     end
   end
 end
 
-Liquid::Template.register_filter(Jekyll::SidebarItemFilter)
 Liquid::Template.register_tag('sidebaritem', Jekyll::SidebarItemBlock)
+Liquid::Template.register_tag('sidebartipitem', Jekyll::SidebarTipItemBlock)

--- a/docs/_plugins/t_link.rb
+++ b/docs/_plugins/t_link.rb
@@ -1,5 +1,5 @@
 module Jekyll
-  module TranslateLinkilter
+  module TranslateLinkFilter
     def translate_link(link)
       is_default_lang = @context.registers[:page]["is_default_language"]
       if is_default_lang
@@ -14,7 +14,17 @@ module Jekyll
       pieces.insert(1, lang)
       return pieces.join('/')
     end
+
+    # for next/prev links, links within if need be
+    def translate_link_docs(link)
+      is_default_lang = @context.registers[:page]["is_default_language"]
+      if is_default_lang
+        return link
+      end
+      lang = @context.registers[:page]["language"]
+      return "/react/#{lang}/docs/#{link}"
+    end
   end
 end
 
-Liquid::Template.register_filter(Jekyll::TranslateLinkilter)
+Liquid::Template.register_filter(Jekyll::TranslateLinkFilter)

--- a/docs/_plugins/t_link.rb
+++ b/docs/_plugins/t_link.rb
@@ -1,0 +1,20 @@
+module Jekyll
+  module TranslateLinkilter
+    def translate_link(link)
+      is_default_lang = @context.registers[:page]["is_default_language"]
+      if is_default_lang
+        return link
+      end
+
+      lang = @context.registers[:page]["language"]
+
+      # We're going to assume everything is relative to root otherwise this breaks
+      # hard code that we have react/foo/bar/whatever.html
+      pieces = link.split('/')
+      pieces.insert(1, lang)
+      return pieces.join('/')
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::TranslateLinkilter)

--- a/docs/docs/01-why-react.ko-KR.md
+++ b/docs/docs/01-why-react.ko-KR.md
@@ -2,7 +2,7 @@
 id: why-react
 title: docs.titles.why-react
 permalink: why-react.html
-next: /ko/docs/displaying-data.html
+next: displaying-data.html
 ---
 
 React는 페이스북과 인스타그램에서 사용자 인터페이스를 구성하기 위해 만들어진 라이브러리입니다. 많은 사람들은 React를 **[MVC](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller)** 에서의 **V** 로 생각하는 경향이 있습니다.

--- a/docs/docs/01-why-react.ko-KR.md
+++ b/docs/docs/01-why-react.ko-KR.md
@@ -1,8 +1,8 @@
 ---
-id: why-react-ko-KR
-title: 왜 React인가?
-permalink: why-react-ko-KR.html
-next: displaying-data-ko-KR.html
+id: why-react
+title: docs.titles.why-react
+permalink: why-react.html
+next: /ko/docs/displaying-data.html
 ---
 
 React는 페이스북과 인스타그램에서 사용자 인터페이스를 구성하기 위해 만들어진 라이브러리입니다. 많은 사람들은 React를 **[MVC](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller)** 에서의 **V** 로 생각하는 경향이 있습니다.

--- a/docs/docs/01-why-react.md
+++ b/docs/docs/01-why-react.md
@@ -2,7 +2,7 @@
 id: why-react
 title: docs.titles.why-react
 permalink: why-react.html
-next: /docs/displaying-data.html
+next: displaying-data.html
 ---
 
 React is a JavaScript library for creating user interfaces by Facebook and Instagram. Many people choose to think of React as the **V** in **[MVC](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller)**.

--- a/docs/docs/01-why-react.md
+++ b/docs/docs/01-why-react.md
@@ -1,9 +1,10 @@
 ---
 id: why-react
-title: Why React?
+title: docs.titles.why_react
 permalink: why-react.html
-next: displaying-data.html
+next: /docs/displaying-data.html
 ---
+
 React is a JavaScript library for creating user interfaces by Facebook and Instagram. Many people choose to think of React as the **V** in **[MVC](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller)**.
 
 We built React to solve one problem: **building large applications with data that changes over time**.

--- a/docs/docs/01-why-react.md
+++ b/docs/docs/01-why-react.md
@@ -1,6 +1,6 @@
 ---
 id: why-react
-title: docs.titles.why_react
+title: docs.titles.why-react
 permalink: why-react.html
 next: /docs/displaying-data.html
 ---

--- a/docs/docs/02-displaying-data.ko-KR.md
+++ b/docs/docs/02-displaying-data.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: displaying-data-ko-KR
-title: 데이터를 표시하기
-permalink: displaying-data-ko-KR.html
-prev: why-react-ko-KR.html
-next: jsx-in-depth-ko-KR.html
+id: displaying-data
+title: docs.titles.displaying-data
+permalink: displaying-data.html
+prev: why-react.html
+next: jsx-in-depth.html
 ---
 
 UI를 가지고 할 수 있는 가장 기초적인 것은 데이터를 표시하는 것입니다. React는 데이터를 표시하고 데이터가 변할 때마다 인터페이스를 최신의 상태로 자동으로 유지하기 쉽게 해 줍니다.

--- a/docs/docs/02-displaying-data.md
+++ b/docs/docs/02-displaying-data.md
@@ -1,6 +1,6 @@
 ---
 id: displaying-data
-title: Displaying Data
+title: docs.titles.displaying-data
 permalink: displaying-data.html
 prev: why-react.html
 next: jsx-in-depth.html

--- a/docs/docs/02.1-jsx-in-depth.ko-KR.md
+++ b/docs/docs/02.1-jsx-in-depth.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: jsx-in-depth-ko-KR
-title: JSX 깊이보기
-permalink: jsx-in-depth-ko-KR.html
-prev: displaying-data-ko-KR.html
-next: jsx-spread-ko-KR.html
+id: jsx-in-depth
+title: docs.titles.jsx-in-depth
+permalink: jsx-in-depth.html
+prev: displaying-data.html
+next: jsx-spread.html
 ---
 
 [JSX](https://facebook.github.io/jsx/)는 XML과 비슷한 JavaScript문법 확장입니다. React에서 변환되는 간단한 JSX 구문을 사용하실 수 있습니다.

--- a/docs/docs/02.1-jsx-in-depth.md
+++ b/docs/docs/02.1-jsx-in-depth.md
@@ -1,6 +1,6 @@
 ---
 id: jsx-in-depth
-title: JSX in Depth
+title: docs.titles.jsx-in-depth
 permalink: jsx-in-depth.html
 prev: displaying-data.html
 next: jsx-spread.html

--- a/docs/docs/02.2-jsx-spread.ko-KR.md
+++ b/docs/docs/02.2-jsx-spread.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: jsx-spread-ko-KR
-title: JSX 스프레드 어트리뷰트
-permalink: jsx-spread-ko-KR.html
-prev: jsx-in-depth-ko-KR.html
-next: jsx-gotchas-ko-KR.html
+id: jsx-spread
+title: docs.titles.jsx-spread
+permalink: jsx-spread.html
+prev: jsx-in-depth.html
+next: jsx-gotchas.html
 ---
 
 미리 컴포넌트에 넣을 모든 프로퍼티를 알게 된다면, JSX를 사용하기 쉬워집니다.

--- a/docs/docs/02.2-jsx-spread.md
+++ b/docs/docs/02.2-jsx-spread.md
@@ -1,6 +1,6 @@
 ---
 id: jsx-spread
-title: JSX Spread Attributes
+title: docs.titles.jsx-spread
 permalink: jsx-spread.html
 prev: jsx-in-depth.html
 next: jsx-gotchas.html

--- a/docs/docs/02.3-jsx-gotchas.ko-KR.md
+++ b/docs/docs/02.3-jsx-gotchas.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: jsx-gotchas-ko-KR
-title: JSX Gotchas
-permalink: jsx-gotchas-ko-KR.html
-prev: jsx-spread-ko-KR.html
-next: interactivity-and-dynamic-uis-ko-KR.html
+id: jsx-gotchas
+title: docs.titles.jsx-gotchas
+permalink: jsx-gotchas.html
+prev: jsx-spread.html
+next: interactivity-and-dynamic-uis.html
 ---
 
 JSX는 HTML처럼 보이지만, 작업하다 보면 마주치게 될 몇 가지 중요한 차이점이 있습니다.

--- a/docs/docs/02.3-jsx-gotchas.md
+++ b/docs/docs/02.3-jsx-gotchas.md
@@ -1,6 +1,6 @@
 ---
 id: jsx-gotchas
-title: JSX Gotchas
+title: docs.titles.jsx-gotchas
 permalink: jsx-gotchas.html
 prev: jsx-spread.html
 next: interactivity-and-dynamic-uis.html

--- a/docs/docs/03-interactivity-and-dynamic-uis.ko-KR.md
+++ b/docs/docs/03-interactivity-and-dynamic-uis.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: interactivity-and-dynamic-uis-ko-KR
-title: 상호 작용 및 동적 UI
-permalink: interactivity-and-dynamic-uis-ko-KR.html
-prev: jsx-gotchas-ko-KR.html
-next: multiple-components-ko-KR.html
+id: interactivity-and-dynamic-uis
+title: docs.titles.interactivity-and-dynamic-uis
+permalink: interactivity-and-dynamic-uis.html
+prev: jsx-gotchas.html
+next: multiple-components.html
 ---
 
 이미 React에서 [어떻게 데이터를 표시](/react/docs/displaying-data-ko-KR.html)하는지를 배웠습니다. 이제 UI와의 상호작용을 어떻게 만드는지 살펴보죠.

--- a/docs/docs/03-interactivity-and-dynamic-uis.md
+++ b/docs/docs/03-interactivity-and-dynamic-uis.md
@@ -1,6 +1,6 @@
 ---
 id: interactivity-and-dynamic-uis
-title: Interactivity and Dynamic UIs
+title: docs.titles.interactivity-and-dynamic-uis
 permalink: interactivity-and-dynamic-uis.html
 prev: jsx-gotchas.html
 next: multiple-components.html

--- a/docs/docs/04-multiple-components.ko-KR.md
+++ b/docs/docs/04-multiple-components.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: multiple-components-ko-KR
-title: 복합 컴포넌트
-permalink: multiple-components-ko-KR.html
-prev: interactivity-and-dynamic-uis-ko-KR.html
-next: reusable-components-ko-KR.html
+id: multiple-components
+title: docs.titles.multiple-components
+permalink: multiple-components.html
+prev: interactivity-and-dynamic-uis.html
+next: reusable-components.html
 ---
 
 지금까지, 단일 컴포넌트에서 데이터를 표시하고 유저 입력을 다루는 것을 살펴보았습니다. 다음엔 React의 최고의 기능 중 하나인 조합가능성(composability)을 살펴봅시다.

--- a/docs/docs/04-multiple-components.md
+++ b/docs/docs/04-multiple-components.md
@@ -1,6 +1,6 @@
 ---
 id: multiple-components
-title: Multiple Components
+title: docs.titles.multiple-components
 permalink: multiple-components.html
 prev: interactivity-and-dynamic-uis.html
 next: reusable-components.html

--- a/docs/docs/05-reusable-components.ko-KR.md
+++ b/docs/docs/05-reusable-components.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: reusable-components-ko-KR
-title: 재사용가능한 컴포넌트
-permalink: reusable-components-ko-KR.html
-prev: multiple-components-ko-KR.html
-next: transferring-props-ko-KR.html
+id: reusable-components
+title: docs.titles.reusable-components
+permalink: reusable-components.html
+prev: multiple-components.html
+next: transferring-props.html
 ---
 
 인터페이스를 설계할 때, 공통적으로 사용되는 디자인 요소들(버튼, 폼 필드, 레이아웃 컴포넌트 등.)을 잘 정의된 인터페이스의 재사용 가능한 컴포넌트로 분해합니다. 이런 방법으로 다음에 UI를 구축할 때에는 훨씬 적은 코드로 만들 수 있습니다. 이 말은 더 빠른 개발 시간, 더 적은 버그, 더 적은 용량으로 할 수 있다는 뜻이죠.

--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -1,6 +1,6 @@
 ---
 id: reusable-components
-title: Reusable Components
+title: docs.titles.reusable-components
 permalink: reusable-components.html
 prev: multiple-components.html
 next: transferring-props.html

--- a/docs/docs/06-transferring-props.ko-KR.md
+++ b/docs/docs/06-transferring-props.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: transferring-props-ko-KR
-title: Props 전달
-permalink: transferring-props-ko-KR.html
-prev: reusable-components-ko-KR.html
-next: forms-ko-KR.html
+id: transferring-props
+title: docs.titles.transferring-props
+permalink: transferring-props.html
+prev: reusable-components.html
+next: forms.html
 ---
 
 React에서는 컴포넌트를 감싸서 추상화하는 것이 일반적인 패턴입니다. 외부 컴포넌트에서는 간단한 프로퍼티만을 노출하여 복잡한 세부 구현을 감출 수 있습니다.

--- a/docs/docs/06-transferring-props.md
+++ b/docs/docs/06-transferring-props.md
@@ -1,6 +1,6 @@
 ---
 id: transferring-props
-title: Transferring Props
+title: docs.titles.transferring-props
 permalink: transferring-props.html
 prev: reusable-components.html
 next: forms.html

--- a/docs/docs/07-forms.ko-KR.md
+++ b/docs/docs/07-forms.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: forms-ko-KR
-title: 폼
-permalink: forms-ko-KR.html
-prev: transferring-props-ko-KR.html
-next: working-with-the-browser-ko-KR.html
+id: forms
+title: docs.titles.forms
+permalink: forms.html
+prev: transferring-props.html
+next: working-with-the-browser.html
 ---
 
 `<input>`, `<textarea>`, `<option>` 같은 폼 컴포넌트는 다른 네이티브 컴포넌트와 다릅니다. 왜냐하면, 사용자의 상호작용에 의해 변경될 수 있기 때문이죠. 이런 컴포넌트들은 사용자의 상호작용에 반응하여 폼을 더 쉽게 관리할 수 있도록 인터페이스를 제공합니다.

--- a/docs/docs/07-forms.md
+++ b/docs/docs/07-forms.md
@@ -1,6 +1,6 @@
 ---
 id: forms
-title: Forms
+title: docs.titles.forms
 permalink: forms.html
 prev: transferring-props.html
 next: working-with-the-browser.html

--- a/docs/docs/08-working-with-the-browser.ko-KR.md
+++ b/docs/docs/08-working-with-the-browser.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: working-with-the-browser-ko-KR
-title: 브라우저에서의 동작
-permalink: working-with-the-browser-ko-KR.html
-prev: forms-ko-KR.html
-next: more-about-refs-ko-KR.html
+id: working-with-the-browser
+title: docs.titles.working-with-the-browser
+permalink: working-with-the-browser.html
+prev: forms.html
+next: more-about-refs.html
 ---
 
 React는 대부분의 경우 직접 DOM을 다루지 않아도 될만큼 강력한 추상화를 제공합니다. 하지만 서드파티 라이브러리나 기존의 코드들을 다루다 보면 간혹 기저(underlying)의 API에 접근해야 할 때도 있습니다.

--- a/docs/docs/08-working-with-the-browser.md
+++ b/docs/docs/08-working-with-the-browser.md
@@ -1,6 +1,6 @@
 ---
 id: working-with-the-browser
-title: Working With the Browser
+title: docs.titles.working-with-the-browser
 permalink: working-with-the-browser.html
 prev: forms.html
 next: more-about-refs.html

--- a/docs/docs/08.1-more-about-refs.ko-KR.md
+++ b/docs/docs/08.1-more-about-refs.ko-KR.md
@@ -1,12 +1,12 @@
 ---
-id: more-about-refs-ko-KR
-title: refs에서 컴포넌트로
-permalink: more-about-refs-ko-KR.html
-prev: working-with-the-browser-ko-KR.html
-next: tooling-integration-ko-KR.html
+id: more-about-refs
+title: docs.titles.more-about-refs
+permalink: more-about-refs.html
+prev: working-with-the-browser.html
+next: tooling-integration.html
 ---
 컴포넌트를 빌드한 후에는 `render()`에서 반환된 컴포넌트 인스턴스에 접근하거나 메소드를 호출할 방법이 필요할 수도 있습니다. 반응적 데이터 플로우가 `render()`의 결과물에서 최신의 `props`가 각각의 자식으로 보내진 것을 항상 보장하기 때문에 애플리케이션의 데이터 플로우를 만드는데 대체로 이런 작업은 필요가 없지만, 여전히 이런 작업이 필요하거나 유리한 경우가 있긴 합니다. React는 이를 위해 `refs`라는 탈출구를 제공합니다. `refs`(레퍼런스)는 특히 다음과 같은 경우 유용합니다: 컴포넌트에 의해 렌더된 DOM 마크업을 찾을때 (인스턴스내의 절대적인 위치), 큰 프로젝트의 일부에 React 컴포넌트를 사용하는 경우 또는 기존의 코드베이스를 React로 변경하는 경우.
- 
+
 ref를 어떻게 얻는지 살펴보고, 예제를 완성해 봅시다.
 
 ## ReactDOM.render에서 반환된 ref
@@ -17,7 +17,7 @@ ref를 어떻게 얻는지 살펴보고, 예제를 완성해 봅시다.
 ```js
 var myComponent = ReactDOM.render(<MyComponent />, myContainer);
 ```
- 
+
 명심하세요. 위의 코드는 컴포넌트 인스턴스를 반환하지 않습니다! 이는 그저 **ReactElement**:React에 마운트된 컴포넌트가 어떻게 보여야 할지 알려주는 경량의 표상(representation) 입니다.
 
 ```js
@@ -34,10 +34,10 @@ myComponentInstance.doSomething();
 > 이는 오직 최상위 레벨에서만 사용되어야 합니다. 컴포넌트의 내부에서는 `props`와 `state`가 자식 컴포넌트와 통신하도록 하거나 문자열이나 콜백 어트리뷰트 등 ref를 얻어오는 다른 방법을 사용하도록 하세요.
 
 ## ref 콜백 어트리뷰트
- 
+
 React는 어떤 컴포넌트에든 추가할 수 있는 특별한 어트리뷰트를 제공합니다. `ref` 어트리뷰트는 콜백 함수일 수 있으며 이는 컴포넌트가 마운트 된 후 즉시 실행됩니다. 참조된 컴포넌트는 파라미터로 전달될 것이며 콜백 함수는 즉시, 혹은 미래에 사용하기 위해 컴포넌트의 참조를 저장합니다.
 
-`render`에서 반환되는 무엇에든 `ref` 어트리뷰트를 추가하는 것은 간단합니다: 
+`render`에서 반환되는 무엇에든 `ref` 어트리뷰트를 추가하는 것은 간단합니다:
 
 ```js
   render: function() {
@@ -95,7 +95,7 @@ var MyComponent = React.createClass({
     this.myTextInput.focus();
   },
   render: function() {
-    // ref 어트리뷰트는 컴포넌트가 마운트되면 
+    // ref 어트리뷰트는 컴포넌트가 마운트되면
     // this.refs에 컴포넌트에 대한 참조를 추가합니다.
     return (
       <div>
@@ -119,7 +119,7 @@ ReactDOM.render(
 이 예제에서, 텍스트 인풋의 **지원 인스턴스**에 대한 참조를 얻었으며 버튼이 클릭되었을때 `focus()`를 호출했습니다.
 
 합성 컴포넌트에서는 참조는 컴포넌트 클래스의 인스턴스를 가리키기 때문에 클래스에 정의된 어떤 메소드도 호출할 수 있습니다. 컴포넌트의 기저에 있는 DOM 노드에 접근하기 위해서는 [ReactDOM.findDOMNode](/react/docs/top-level-api-ko-KR.html#reactdom.finddomnode)를 "탈출구"로 사용할 수 있습니다. 하지만 이는 캡슐화를 깨며, 대부분의 경우 React 모델을 이용해 더 명확한 방법으로 구조를 짤 수 있기 때문에 추천하지 않습니다.
- 
+
 
 ## 요약
 

--- a/docs/docs/08.1-more-about-refs.md
+++ b/docs/docs/08.1-more-about-refs.md
@@ -1,6 +1,6 @@
 ---
 id: more-about-refs
-title: Refs to Components
+title: docs.titles.more-about-refs
 permalink: more-about-refs.html
 prev: working-with-the-browser.html
 next: tooling-integration.html

--- a/docs/docs/09-tooling-integration.ko-KR.md
+++ b/docs/docs/09-tooling-integration.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: tooling-integration-ko-KR
-title: 툴 통합
-permalink: tooling-integration-ko-KR.html
-prev: more-about-refs-ko-KR.html
-next: addons-ko-KR.html
+id: tooling-integration
+title: docs.titles.tooling-integration
+permalink: tooling-integration.html
+prev: more-about-refs.html
+next: addons.html
 ---
 
 모든 프로젝트는 JavaScript를 빌드, 배포할 때 다른 시스템을 사용합니다. 우리는 가능한 한 React를 환경에 구속받지 않도록 하려 노력했습니다.

--- a/docs/docs/09-tooling-integration.md
+++ b/docs/docs/09-tooling-integration.md
@@ -1,6 +1,6 @@
 ---
 id: tooling-integration
-title: Tooling Integration
+title: docs.titles.tooling-integration
 permalink: tooling-integration.html
 prev: more-about-refs.html
 next: addons.html

--- a/docs/docs/10-addons.ko-KR.md
+++ b/docs/docs/10-addons.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: addons-ko-KR
-title: 애드온
-permalink: addons-ko-KR.html
-prev: tooling-integration-ko-KR.html
-next: animation-ko-KR.html
+id: addons
+title: docs.titles.addons
+permalink: addons.html
+prev: tooling-integration.html
+next: animation.html
 ---
 
 React 애드온은 React 앱을 만드는 데 유용한 유틸리티의 모음입니다. **실험적인 기능으로 취급해야 하고** 코어보다 더 자주 변경될 수 있습니다.

--- a/docs/docs/10-addons.md
+++ b/docs/docs/10-addons.md
@@ -1,6 +1,6 @@
 ---
 id: addons
-title: Add-ons
+title: docs.titles.addons
 permalink: addons.html
 prev: tooling-integration.html
 next: animation.html

--- a/docs/docs/10.1-animation.ko-KR.md
+++ b/docs/docs/10.1-animation.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: animation-ko-KR
-title: 애니메이션
-permalink: animation-ko-KR.html
-prev: addons-ko-KR.html
-next: two-way-binding-helpers-ko-KR.html
+id: animation
+title: docs.titles.animation
+permalink: animation.html
+prev: addons.html
+next: two-way-binding-helpers.html
 ---
 
 React에는 애니메이션을 위한 저 수준 API로 `ReactTransitionGroup` 애드온 컴포넌트가 있고 간단히 기초 CSS 애니메이션과 트랜지션을 구현할 수 있는 `ReactCSSTransitionGroup`가 있습니다.

--- a/docs/docs/10.1-animation.md
+++ b/docs/docs/10.1-animation.md
@@ -1,6 +1,6 @@
 ---
 id: animation
-title: Animation
+title: docs.titles.animation
 permalink: animation.html
 prev: addons.html
 next: two-way-binding-helpers.html

--- a/docs/docs/10.2-form-input-binding-sugar.ko-KR.md
+++ b/docs/docs/10.2-form-input-binding-sugar.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: two-way-binding-helpers-ko-KR
-title: 양방향 바인딩 핼퍼
-permalink: two-way-binding-helpers-ko-KR.html
-prev: animation-ko-KR.html
-next: test-utils-ko-KR.html
+id: two-way-binding-helpers
+title: docs.titles.two-way-binding-helpers
+permalink: two-way-binding-helpers.html
+prev: animation.html
+next: test-utils.html
 ---
 
 `ReactLink`는 React에서 양방향 바인딩을 표현하는 쉬운 방법입니다.

--- a/docs/docs/10.2-form-input-binding-sugar.md
+++ b/docs/docs/10.2-form-input-binding-sugar.md
@@ -1,6 +1,6 @@
 ---
 id: two-way-binding-helpers
-title: Two-Way Binding Helpers
+title: docs.titles.two-way-binding-helpers
 permalink: two-way-binding-helpers.html
 prev: animation.html
 next: test-utils.html

--- a/docs/docs/10.3-class-name-manipulation.ko-KR.md
+++ b/docs/docs/10.3-class-name-manipulation.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: class-name-manipulation-ko-KR
-title: 클래스 이름 조작
-permalink: class-name-manipulation-ko-KR.html
-prev: two-way-binding-helpers-ko-KR.html
-next: test-utils-ko-KR.html
+id: class-name-manipulation
+title: docs.titles.class-name-manipulation
+permalink: class-name-manipulation.html
+prev: two-way-binding-helpers.html
+next: test-utils.html
 ---
 
 > 주의:

--- a/docs/docs/10.3-class-name-manipulation.md
+++ b/docs/docs/10.3-class-name-manipulation.md
@@ -1,6 +1,6 @@
 ---
 id: class-name-manipulation
-title: Class Name Manipulation
+title: docs.titles.class-name-manipulation
 permalink: class-name-manipulation.html
 prev: two-way-binding-helpers.html
 next: test-utils.html

--- a/docs/docs/10.4-test-utils.ko-KR.md
+++ b/docs/docs/10.4-test-utils.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: test-utils-ko-KR
-title: 테스트 유틸리티
-permalink: test-utils-ko-KR.html
-prev: two-way-binding-helpers-ko-KR.html
-next: clone-with-props-ko-KR.html
+id: test-utils
+title: docs.titles.test-utils
+permalink: test-utils.html
+prev: two-way-binding-helpers.html
+next: clone-with-props.html
 ---
 
 `ReactTestUtils`는 선택한 테스트 프레임워크(React는 [Jest](https://facebook.github.io/jest/)를 사용)에서 React 컴포넌트를 테스트하기 쉽게 합니다.

--- a/docs/docs/10.4-test-utils.md
+++ b/docs/docs/10.4-test-utils.md
@@ -1,6 +1,6 @@
 ---
 id: test-utils
-title: Test Utilities
+title: docs.titles.test-utils
 permalink: test-utils.html
 prev: two-way-binding-helpers.html
 next: clone-with-props.html

--- a/docs/docs/10.5-clone-with-props.ko-KR.md
+++ b/docs/docs/10.5-clone-with-props.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: clone-with-props-ko-KR
-title: ReactElement 클론하기
-permalink: clone-with-props-ko-KR.html
-prev: test-utils-ko-KR.html
-next: create-fragment-ko-KR.html
+id: clone-with-props
+title: docs.titles.clone-with-props
+permalink: clone-with-props.html
+prev: test-utils.html
+next: create-fragment.html
 ---
 
 > 주의:

--- a/docs/docs/10.5-clone-with-props.md
+++ b/docs/docs/10.5-clone-with-props.md
@@ -1,6 +1,6 @@
 ---
 id: clone-with-props
-title: Cloning ReactElements
+title: docs.titles.clone-with-props
 permalink: clone-with-props.html
 prev: test-utils.html
 next: create-fragment.html

--- a/docs/docs/10.6-create-fragment.ko-KR.md
+++ b/docs/docs/10.6-create-fragment.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: create-fragment-ko-KR
-title: 키가 할당된 프래그먼트
-permalink: create-fragment-ko-KR.html
-prev: clone-with-props-ko-KR.html
-next: update-ko-KR.html
+id: create-fragment
+title: docs.titles.create-fragment
+permalink: create-fragment.html
+prev: clone-with-props.html
+next: update.html
 ---
 
 대부분의 경우는 `key` prop으로 `render`에서 반환된 엘리먼트에 키를 명시할 수 있습니다. 하지만 말썽을 부리는 경우가 한가지 있습니다: 재정렬을 할 두개의 자식 집합을 가지고 있는 경우, 감싸는 엘리먼트 없이 각각의 집합에 키를 부여하는 것은 불가능 합니다.

--- a/docs/docs/10.6-create-fragment.md
+++ b/docs/docs/10.6-create-fragment.md
@@ -1,6 +1,6 @@
 ---
 id: create-fragment
-title: Keyed Fragments
+title: docs.titles.create-fragment
 permalink: create-fragment.html
 prev: clone-with-props.html
 next: update.html

--- a/docs/docs/10.7-update.ko-KR.md
+++ b/docs/docs/10.7-update.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: update-ko-KR
-title: 불변성 헬퍼들
-permalink: update-ko-KR.html
-prev: create-fragment-ko-KR.html
-next: pure-render-mixin-ko-KR.html
+id: update
+title: docs.titles.update
+permalink: update.html
+prev: create-fragment.html
+next: pure-render-mixin.html
 ---
 
 React에서는 mutation을 포함해 어떤 데이터 관리 방식도 사용하실 수 있습니다. 하지만 애플리케이션의 성능이 중요한 부분에서 불변의(immutable) 데이터를 사용할 수 있다면, 쉽게 빠른 `shouldComponentUpdate()` 메소드를 구현해 애플리케이션의 속도를 크게 향상시킬 수 있습니다.

--- a/docs/docs/10.7-update.md
+++ b/docs/docs/10.7-update.md
@@ -1,6 +1,6 @@
 ---
 id: update
-title: Immutability Helpers
+title: docs.titles.update
 permalink: update.html
 prev: create-fragment.html
 next: pure-render-mixin.html

--- a/docs/docs/10.8-pure-render-mixin.ko-KR.md
+++ b/docs/docs/10.8-pure-render-mixin.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: pure-render-mixin-ko-KR
-title: PureRenderMixin
-permalink: pure-render-mixin-ko-KR.html
-prev: update-ko-KR.html
-next: perf-ko-KR.html
+id: pure-render-mixin
+title: docs.titles.pure-render-mixin
+permalink: pure-render-mixin.html
+prev: update.html
+next: perf.html
 ---
 
 React 컴포넌트의 렌더 함수가 "pure"하다면 (다른 말로, props나 state에 같은 값이 주어질 때 같은 결과를 렌더한다면) 몇몇 경우엔 이 믹스인을 사용하여 성능을 향상시킬 수 있습니다.

--- a/docs/docs/10.8-pure-render-mixin.md
+++ b/docs/docs/10.8-pure-render-mixin.md
@@ -1,6 +1,6 @@
 ---
 id: pure-render-mixin
-title: PureRenderMixin
+title: docs.titles.pure-render-mixin
 permalink: pure-render-mixin.html
 prev: update.html
 next: perf.html

--- a/docs/docs/10.9-perf.ko-KR.md
+++ b/docs/docs/10.9-perf.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: perf-ko-KR
-title: 성능 도구
-permalink: perf-ko-KR.html
-prev: pure-render-mixin-ko-KR.html
-next: advanced-performance-ko-KR.html
+id: perf
+title: docs.titles.perf
+permalink: perf.html
+prev: pure-render-mixin.html
+next: advanced-performance.html
 ---
 
 React는 보통 처음에는 꽤 빠릅니다. 하지만 모든 성능을 짜내야 하는 상황일 때를 위해, React는 [shouldComponentUpdate](/react/docs/component-specs.html#updating-shouldcomponentupdate) 훅을 제공해 React의 diff 알고리즘을 위한 최적화 힌트를 추가할 수 있습니다.

--- a/docs/docs/10.9-perf.md
+++ b/docs/docs/10.9-perf.md
@@ -1,6 +1,6 @@
 ---
 id: perf
-title: Performance Tools
+title: docs.titles.perf
 permalink: perf.html
 prev: pure-render-mixin.html
 next: advanced-performance.html

--- a/docs/docs/11-advanced-performance.ko-KR.md
+++ b/docs/docs/11-advanced-performance.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: advanced-performance-ko-KR
-title: 성능 심화
-permalink: advanced-performance-ko-KR.html
-prev: perf-ko-KR.html
-next: context-ko-KR.html
+id: advanced-performance
+title: docs.titles.advanced-performance
+permalink: advanced-performance.html
+prev: perf.html
+next: context.html
 ---
 
 React를 도입하려 할 때 많은 사람이 묻는 첫 번째 질문은 React를 사용하지 않을 때처럼 애플리케이션이 빠르고 반응성도 좋을 것이냐는 것입니다. 모든 상태변화에 대해 컴포넌트의 하위 트리를 전부 다시 렌더링하는 아이디어에 대해 사람들은 이 프로세스가 성능에 부정적인 영향을 줄 것으로 생각하지만, React는 여러 가지 영리한 방법을 통해 UI를 업데이트하는데 필요한 비싼 DOM 조작을 최소화합니다.

--- a/docs/docs/11-advanced-performance.md
+++ b/docs/docs/11-advanced-performance.md
@@ -1,6 +1,6 @@
 ---
 id: advanced-performance
-title: Advanced Performance
+title: docs.titles.advanced-performance
 permalink: advanced-performance.html
 prev: perf.html
 next: context.html

--- a/docs/docs/12-context.ko-KR.md
+++ b/docs/docs/12-context.ko-KR.md
@@ -1,8 +1,8 @@
 ---
 id: context
-title: 컨텍스트
-permalink: context-ko-KR.html
-prev: advanced-performance-ko-KR.html
+title: docs.titles.context
+permalink: context.html
+prev: advanced-performance.html
 ---
 
 React의 가장 큰 장점 중 하나는 React 컴포넌트를 통해 데이터의 흐름을 추적하기 쉽다는 것입니다. 컴포넌트를 보면 각각의 프로퍼티가 어떻게 전달되었는지 쉽게 파악할 수 있습니다. 

--- a/docs/docs/12-context.md
+++ b/docs/docs/12-context.md
@@ -1,6 +1,6 @@
 ---
 id: context
-title: Context
+title: docs.titles.context
 permalink: context.html
 prev: advanced-performance.html
 ---

--- a/docs/docs/complementary-tools.ko-KR.md
+++ b/docs/docs/complementary-tools.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: complementary-tools-ko-KR
-title: 상호 보완적인 도구들
-permalink: complementary-tools-ko-KR.html
-prev: videos-ko-KR.html
-next: examples-ko-KR.html
+id: complementary-tools
+title: docs.titles.complementary-tools
+permalink: complementary-tools.html
+prev: videos.html
+next: examples.html
 ---
 
 이 페이지는 이동되었습니다. [GitHub wiki](https://github.com/facebook/react/wiki/Complementary-Tools).

--- a/docs/docs/complementary-tools.md
+++ b/docs/docs/complementary-tools.md
@@ -1,6 +1,6 @@
 ---
 id: complementary-tools
-title: Complementary Tools
+title: docs.titles.complementary-tools
 permalink: complementary-tools.html
 prev: videos.html
 next: examples.html

--- a/docs/docs/conferences.ko-KR.md
+++ b/docs/docs/conferences.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: conferences-ko-KR
-title: 컨퍼런스들
-permalink: conferences-ko-KR.html
-prev: thinking-in-react-ko-KR.html
-next: videos-ko-KR.html
+id: conferences
+title: docs.titles.conferences
+permalink: conferences.html
+prev: thinking-in-react.html
+next: videos.html
 ---
 
 ### React.js Conf 2015

--- a/docs/docs/conferences.md
+++ b/docs/docs/conferences.md
@@ -1,6 +1,6 @@
 ---
 id: conferences
-title: Conferences
+title: docs.titles.conferences
 permalink: conferences.html
 prev: thinking-in-react.html
 next: videos.html

--- a/docs/docs/examples.ko-KR.md
+++ b/docs/docs/examples.ko-KR.md
@@ -1,8 +1,8 @@
 ---
-id: examples-ko-KR
-title: 예제들
-permalink: examples-ko-KR.html
-prev: complementary-tools-ko-KR.html
+id: examples
+title: docs.titles.examples
+permalink: examples.html
+prev: complementary-tools.html
 ---
 
 이 페이지는 이동되었습니다. [GitHub wiki](https://github.com/facebook/react/wiki/Examples).

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -1,6 +1,6 @@
 ---
 id: examples
-title: Examples
+title: docs.titles.examples
 permalink: examples.html
 prev: complementary-tools.html
 ---

--- a/docs/docs/flux-overview.ko-KR.md
+++ b/docs/docs/flux-overview.ko-KR.md
@@ -1,7 +1,7 @@
 ---
-id: flux-overview-ko-KR
-title: Flux 애플리케이션 아키텍쳐
-permalink: flux-overview-ko-KR.html
+id: flux-overview
+title: docs.titles.flux-overview
+permalink: flux-overview.html
 ---
 
 이 페이지는 Flux 웹사이트로 이동되었습니다. [거기서 보세요](https://facebook.github.io/flux/docs/overview.html).

--- a/docs/docs/flux-overview.md
+++ b/docs/docs/flux-overview.md
@@ -1,6 +1,6 @@
 ---
 id: flux-overview
-title: Flux Application Architecture
+title: docs.titles.flux-overview
 permalink: flux-overview.html
 ---
 

--- a/docs/docs/flux-todo-list.ko-KR.md
+++ b/docs/docs/flux-todo-list.ko-KR.md
@@ -1,7 +1,7 @@
 ---
-id: flux-todo-list-ko-KR
-title: Flux TodoMVC 튜토리얼
-permalink: flux-todo-list-ko-KR.html
+id: flux-todo-list
+title: docs.titles.flux-todo-list
+permalink: flux-todo-list.html
 ---
 
 이 페이지는 Flux 웹사이트로 이동되었습니다. [거기서 보세요](https://facebook.github.io/flux/docs/todo-list.html).

--- a/docs/docs/flux-todo-list.md
+++ b/docs/docs/flux-todo-list.md
@@ -1,6 +1,6 @@
 ---
 id: flux-todo-list
-title: Flux TodoMVC Tutorial
+title: docs.titles.flux-todo-list
 permalink: flux-todo-list.html
 ---
 

--- a/docs/docs/getting-started.ko-KR.md
+++ b/docs/docs/getting-started.ko-KR.md
@@ -1,8 +1,8 @@
 ---
-id: getting-started-ko-KR
-title: 시작해보기
-permalink: getting-started-ko-KR.html
-next: tutorial-ko-KR.html
+id: getting-started
+title: docs.titles.getting-started
+permalink: getting-started.html
+next: tutorial.html
 redirect_from: "docs/index-ko-KR.html"
 ---
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -1,6 +1,6 @@
 ---
 id: getting-started
-title: Getting Started
+title: docs.titles.getting-started
 next: tutorial.html
 redirect_from: "docs/index.html"
 ---

--- a/docs/docs/ref-01-top-level-api.ko-KR.md
+++ b/docs/docs/ref-01-top-level-api.ko-KR.md
@@ -1,8 +1,8 @@
 ---
-id: top-level-api-ko-KR
-title: 최상위 API
-permalink: top-level-api-ko-KR.html
-next: component-api-ko-KR.html
+id: top-level-api
+title: docs.titles.top-level-api
+permalink: top-level-api.html
+next: component-api.html
 redirect_from: "/docs/reference-ko-KR.html"
 ---
 

--- a/docs/docs/ref-01-top-level-api.md
+++ b/docs/docs/ref-01-top-level-api.md
@@ -1,6 +1,6 @@
 ---
 id: top-level-api
-title: Top-Level API
+title: docs.titles.top-level-api
 permalink: top-level-api.html
 next: component-api.html
 redirect_from: "/docs/reference.html"

--- a/docs/docs/ref-02-component-api.ko-KR.md
+++ b/docs/docs/ref-02-component-api.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: component-api-ko-KR
-title: 컴포넌트 API
-permalink: component-api-ko-KR.html
-prev: top-level-api-ko-KR.html
-next: component-specs-ko-KR.html
+id: component-api
+title: docs.titles.component-api
+permalink: component-api.html
+prev: top-level-api.html
+next: component-specs.html
 ---
 
 ## React.Component

--- a/docs/docs/ref-02-component-api.md
+++ b/docs/docs/ref-02-component-api.md
@@ -1,6 +1,6 @@
 ---
 id: component-api
-title: Component API
+title: docs.titles.component-api
 permalink: component-api.html
 prev: top-level-api.html
 next: component-specs.html

--- a/docs/docs/ref-03-component-specs.ko-KR.md
+++ b/docs/docs/ref-03-component-specs.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: component-specs-ko-KR
-title:  컴포넌트 명세와 생명주기
-permalink: component-specs-ko-KR.html
-prev: component-api-ko-KR.html
-next: tags-and-attributes-ko-KR.html
+id: component-specs
+title: docs.titles.component-specs
+permalink: component-specs.html
+prev: component-api.html
+next: tags-and-attributes.html
 ---
 
 ## 컴포넌트 명세

--- a/docs/docs/ref-03-component-specs.md
+++ b/docs/docs/ref-03-component-specs.md
@@ -1,6 +1,6 @@
 ---
 id: component-specs
-title: Component Specs and Lifecycle
+title: docs.titles.component-specs
 permalink: component-specs.html
 prev: component-api.html
 next: tags-and-attributes.html

--- a/docs/docs/ref-04-tags-and-attributes.ko-KR.md
+++ b/docs/docs/ref-04-tags-and-attributes.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: tags-and-attributes-ko-KR
-title: 태그와 어트리뷰트
-permalink: tags-and-attributes-ko-KR.html
-prev: component-specs-ko-KR.html
-next: events-ko-KR.html
+id: tags-and-attributes
+title: docs.titles.tags-and-attributes
+permalink: tags-and-attributes.html
+prev: component-specs.html
+next: events.html
 ---
 
 ## 지원되는 태그

--- a/docs/docs/ref-04-tags-and-attributes.md
+++ b/docs/docs/ref-04-tags-and-attributes.md
@@ -1,6 +1,6 @@
 ---
 id: tags-and-attributes
-title: Tags and Attributes
+title: docs.titles.tags-and-attributes
 permalink: tags-and-attributes.html
 prev: component-specs.html
 next: events.html

--- a/docs/docs/ref-05-events.ko-KR.md
+++ b/docs/docs/ref-05-events.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: events-ko-KR
-title: 이벤트 시스템
-permalink: events-ko-KR.html
-prev: tags-and-attributes-ko-KR.html
-next: dom-differences-ko-KR.html
+id: events
+title: docs.titles.events
+permalink: events.html
+prev: tags-and-attributes.html
+next: dom-differences.html
 ---
 
 ## 통합적인(Synthetic) 이벤트

--- a/docs/docs/ref-05-events.md
+++ b/docs/docs/ref-05-events.md
@@ -1,6 +1,6 @@
 ---
 id: events
-title: Event System
+title: docs.titles.events
 permalink: events.html
 prev: tags-and-attributes.html
 next: dom-differences.html

--- a/docs/docs/ref-06-dom-differences.ko-KR.md
+++ b/docs/docs/ref-06-dom-differences.ko-KR.md
@@ -1,9 +1,10 @@
 ---
-id: dom-differences-ko-KR
+id: dom-differences
+title: docs.titles.dom-differences
 title: DOM과의 차이점
-permalink: dom-differences-ko-KR.html
-prev: events-ko-KR.html
-next: special-non-dom-attributes-ko-KR.html
+permalink: dom-differences.html
+prev: events.html
+next: special-non-dom-attributes.html
 ---
 
 React는 성능과 크로스 브라우저 호환성을 이유로 브라우저에 독립적인 이벤트와 DOM 시스템으로 구현되었습니다. 브라우저 DOM 구현의 일관성없는 부분들을 정리할 기회를 가졌습니다.

--- a/docs/docs/ref-06-dom-differences.md
+++ b/docs/docs/ref-06-dom-differences.md
@@ -1,6 +1,6 @@
 ---
 id: dom-differences
-title: DOM Differences
+title: docs.titles.dom-differences
 permalink: dom-differences.html
 prev: events.html
 next: special-non-dom-attributes.html

--- a/docs/docs/ref-07-special-non-dom-attributes.ko-KR.md
+++ b/docs/docs/ref-07-special-non-dom-attributes.ko-KR.md
@@ -1,9 +1,10 @@
 ---
-id: special-non-dom-attributes-ko-KR
+id: special-non-dom-attributes
+title: docs.titles.special-non-dom-attributes
 title: DOM이 아닌 특별한 어트리뷰트
-permalink: special-non-dom-attributes-ko-KR.html
-prev: dom-differences-ko-KR.html
-next: reconciliation-ko-KR.html
+permalink: special-non-dom-attributes.html
+prev: dom-differences.html
+next: reconciliation.html
 ---
 
 [DOM 차이점](/react/docs/dom-differences-ko-KR.html)처럼, React는 DOM에는 존재하지 않는 몇몇 어트리뷰트도 제공합니다.

--- a/docs/docs/ref-07-special-non-dom-attributes.md
+++ b/docs/docs/ref-07-special-non-dom-attributes.md
@@ -1,6 +1,6 @@
 ---
 id: special-non-dom-attributes
-title: Special Non-DOM Attributes
+title: docs.titles.special-non-dom-attributes
 permalink: special-non-dom-attributes.html
 prev: dom-differences.html
 next: reconciliation.html

--- a/docs/docs/ref-08-reconciliation.ko-KR.md
+++ b/docs/docs/ref-08-reconciliation.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: reconciliation-ko-KR
-title: 비교조정(Reconciliation)
-permalink: reconciliation-ko-KR.html
-prev: special-non-dom-attributes-ko-KR.html
-next: glossary-ko-KR.html
+id: reconciliation
+title: docs.titles.reconciliation
+permalink: reconciliation.html
+prev: special-non-dom-attributes.html
+next: glossary.html
 ---
 
 React의 주요 설계 철학은 업데이트할 때마다 전체 앱을 다시 렌더하는 것처럼 보이게 API를 만드는 것입니다. 이렇게 하면 애플리케이션 작성이 훨씬 쉬워지지만 한편으로는 어려운 도전 과제이기도 합니다. 이 글에서는 강력한 휴리스틱으로 어떻게 O(n<sup>3</sup>) 복잡도의 문제를 O(n)짜리로 바꿀 수 있었는지 설명합니다.

--- a/docs/docs/ref-08-reconciliation.md
+++ b/docs/docs/ref-08-reconciliation.md
@@ -1,6 +1,6 @@
 ---
 id: reconciliation
-title: Reconciliation
+title: docs.titles.reconciliation
 permalink: reconciliation.html
 prev: special-non-dom-attributes.html
 next: glossary.html

--- a/docs/docs/ref-09-glossary.ko-KR.md
+++ b/docs/docs/ref-09-glossary.ko-KR.md
@@ -1,8 +1,8 @@
 ---
-id: glossary-ko-KR
-title: React (가상) DOM 용어
-permalink: glossary-ko-KR.html
-prev: reconciliation-ko-KR.html
+id: glossary
+title: docs.titles.glossary
+permalink: glossary.html
+prev: reconciliation.html
 ---
 
 다음은 React에서 사용되는 용어들로, 이 다섯 가지의 타입을 구별하는 것은 중요합니다.
@@ -190,4 +190,3 @@ type ReactComponent<TProps> = {
   render : () => ReactElement
 };
 ```
-

--- a/docs/docs/ref-09-glossary.md
+++ b/docs/docs/ref-09-glossary.md
@@ -1,6 +1,6 @@
 ---
 id: glossary
-title: React (Virtual) DOM Terminology
+title: docs.titles.glossary
 permalink: glossary.html
 prev: reconciliation.html
 ---

--- a/docs/docs/thinking-in-react.ko-KR.md
+++ b/docs/docs/thinking-in-react.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: thinking-in-react-ko-KR
-title: 리액트로 생각해보기
-permalink: thinking-in-react-ko-KR.html
-prev: tutorial-ko-KR.html
-next: videos-ko-KR.html
+id: thinking-in-react
+title: docs.titles.thinking-in-react
+permalink: thinking-in-react.html
+prev: tutorial.html
+next: videos.html
 ---
 
 Pete Hunt의 글입니다.

--- a/docs/docs/thinking-in-react.md
+++ b/docs/docs/thinking-in-react.md
@@ -1,6 +1,6 @@
 ---
 id: thinking-in-react
-title: Thinking in React
+title: docs.titles.thinking-in-react
 prev: tutorial.html
 next: conferences.html
 redirect_from: 'blog/2013/11/05/thinking-in-react.html'

--- a/docs/docs/tutorial.ko-KR.md
+++ b/docs/docs/tutorial.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: tutorial-ko-KR
-title: 튜토리얼
-permalink: tutorial-ko-KR.html
-prev: getting-started-ko-KR.html
-next: thinking-in-react-ko-KR.html
+id: tutorial
+title: docs.titles.tutorial
+permalink: tutorial.html
+prev: getting-started.html
+next: thinking-in-react.html
 ---
 
 블로그에 붙일만한 간단하지만 실용적인 댓글상자를 만들어 볼 것입니다. Disqus, LiveFyre, Facebook에서 제공하는 것 같은 실시간 댓글의 간단한 버전이죠.

--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -1,6 +1,6 @@
 ---
 id: tutorial
-title: Tutorial
+title: docs.titles.tutorial
 prev: getting-started.html
 next: thinking-in-react.html
 ---

--- a/docs/docs/videos.ko-KR.md
+++ b/docs/docs/videos.ko-KR.md
@@ -1,9 +1,9 @@
 ---
-id: videos-ko-KR
-title: 비디오들
-permalink: videos-ko-KR.html
-prev: conferences-ko-KR.html
-next: complementary-tools-ko-KR.html
+id: videos
+title: docs.titles.videos
+permalink: videos.html
+prev: conferences.html
+next: complementary-tools.html
 ---
 
 ### Rethinking best practices - JSConf.eu

--- a/docs/docs/videos.md
+++ b/docs/docs/videos.md
@@ -1,6 +1,6 @@
 ---
 id: videos
-title: Videos
+title: docs.titles.videos
 permalink: videos.html
 prev: conferences.html
 next: complementary-tools.html

--- a/docs/tips/01-introduction.ko-KR.md
+++ b/docs/tips/01-introduction.ko-KR.md
@@ -1,6 +1,6 @@
 ---
-id: introduction-ko-KR
-title: 개요
+id: introduction
+title: tips.titles.introduction
 layout: tips
 permalink: introduction-ko-KR.html
 next: inline-styles-ko-KR.html

--- a/docs/tips/01-introduction.ko-KR.md
+++ b/docs/tips/01-introduction.ko-KR.md
@@ -2,8 +2,8 @@
 id: introduction
 title: tips.titles.introduction
 layout: tips
-permalink: introduction-ko-KR.html
-next: inline-styles-ko-KR.html
+permalink: introduction.html
+next: inline-styles.html
 ---
 
 React 팁 섹션에서는 여러 궁금증을 해결해주고 흔히 하는 실수를 피할 수 있도록 짧은 정보들을 제공합니다.

--- a/docs/tips/01-introduction.md
+++ b/docs/tips/01-introduction.md
@@ -1,6 +1,6 @@
 ---
 id: introduction
-title: Introduction
+title: tips.titles.introduction
 layout: tips
 permalink: introduction.html
 next: inline-styles.html

--- a/docs/tips/02-inline-styles.ko-KR.md
+++ b/docs/tips/02-inline-styles.ko-KR.md
@@ -1,6 +1,6 @@
 ---
-id: inline-styles-ko-KR
-title: 인라인 스타일
+id: inline-styles
+title: tips.titles.inline-styles
 layout: tips
 permalink: inline-styles-ko-KR.html
 next: if-else-in-JSX-ko-KR.html

--- a/docs/tips/02-inline-styles.ko-KR.md
+++ b/docs/tips/02-inline-styles.ko-KR.md
@@ -2,9 +2,9 @@
 id: inline-styles
 title: tips.titles.inline-styles
 layout: tips
-permalink: inline-styles-ko-KR.html
-next: if-else-in-JSX-ko-KR.html
-prev: introduction-ko-KR.html
+permalink: inline-styles.html
+next: if-else-in-JSX.html
+prev: introduction.html
 ---
 
 React에서는 인라인 스타일을 문자열로 지정하지 않습니다. 대신 스타일 이름을 camelCased 형식으로 바꾼 키와 스타일의 값(주로 문자열입니다 - [자세히 알아보기](/react/tips/style-props-value-px-ko-KR.html))을 가진 객체로 지정됩니다.

--- a/docs/tips/02-inline-styles.md
+++ b/docs/tips/02-inline-styles.md
@@ -1,6 +1,6 @@
 ---
 id: inline-styles
-title: Inline Styles
+title: tips.titles.inline-styles
 layout: tips
 permalink: inline-styles.html
 next: if-else-in-JSX.html

--- a/docs/tips/03-if-else-in-JSX.ko-KR.md
+++ b/docs/tips/03-if-else-in-JSX.ko-KR.md
@@ -2,9 +2,9 @@
 id: if-else-in-JSX
 title: tips.titles.if-else-in-JSX
 layout: tips
-permalink: if-else-in-JSX-ko-KR.html
-prev: inline-styles-ko-KR.html
-next: self-closing-tag-ko-KR.html
+permalink: if-else-in-JSX.html
+prev: inline-styles.html
+next: self-closing-tag.html
 ---
 
 JSX 안에서는 `if-else` 구문이 작동하지 않습니다. 왜냐하면 JSX가 그저 함수 호출과 객체 생성의 편의 문법이기 때문입니다. 다음의 기본적인 예제를 살펴봅시다.

--- a/docs/tips/03-if-else-in-JSX.ko-KR.md
+++ b/docs/tips/03-if-else-in-JSX.ko-KR.md
@@ -1,6 +1,6 @@
 ---
-id: if-else-in-JSX-ko-KR
-title: JSX에서 If-Else
+id: if-else-in-JSX
+title: tips.titles.if-else-in-JSX
 layout: tips
 permalink: if-else-in-JSX-ko-KR.html
 prev: inline-styles-ko-KR.html

--- a/docs/tips/03-if-else-in-JSX.md
+++ b/docs/tips/03-if-else-in-JSX.md
@@ -1,6 +1,6 @@
 ---
 id: if-else-in-JSX
-title: If-Else in JSX
+title: tips.titles.if-else-in-JSX
 layout: tips
 permalink: if-else-in-JSX.html
 prev: inline-styles.html

--- a/docs/tips/04-self-closing-tag.ko-KR.md
+++ b/docs/tips/04-self-closing-tag.ko-KR.md
@@ -2,9 +2,9 @@
 id: self-closing-tag
 title: tips.titles.self-closing-tag
 layout: tips
-permalink: self-closing-tag-ko-KR.html
-prev: if-else-in-JSX-ko-KR.html
-next: maximum-number-of-jsx-root-nodes-ko-KR.html
+permalink: self-closing-tag.html
+prev: if-else-in-JSX.html
+next: maximum-number-of-jsx-root-nodes.html
 ---
 
 JSX에서 `<MyComponent>`는 유효하지 않고 `<MyComponent />`만 유효합니다. 모든 태그는 닫혀야 합니다. 자기 자신을 닫는 형식을 사용하거나 대응되는 닫는 태그(`</MyComponent>`)가 필요합니다.

--- a/docs/tips/04-self-closing-tag.ko-KR.md
+++ b/docs/tips/04-self-closing-tag.ko-KR.md
@@ -1,6 +1,6 @@
 ---
-id: self-closing-tag-ko-KR
-title: 자기 자신을 닫는 태그
+id: self-closing-tag
+title: tips.titles.self-closing-tag
 layout: tips
 permalink: self-closing-tag-ko-KR.html
 prev: if-else-in-JSX-ko-KR.html

--- a/docs/tips/04-self-closing-tag.md
+++ b/docs/tips/04-self-closing-tag.md
@@ -1,6 +1,6 @@
 ---
 id: self-closing-tag
-title: Self-Closing Tag
+title: tips.titles.self-closing-tag
 layout: tips
 permalink: self-closing-tag.html
 prev: if-else-in-JSX.html

--- a/docs/tips/05-maximum-number-of-jsx-root-nodes.ko-KR.md
+++ b/docs/tips/05-maximum-number-of-jsx-root-nodes.ko-KR.md
@@ -2,9 +2,9 @@
 id: maximum-number-of-jsx-root-nodes
 title: tips.titles.maximum-number-of-jsx-root-nodes
 layout: tips
-permalink: maximum-number-of-jsx-root-nodes-ko-KR.html
-prev: self-closing-tag-ko-KR.html
-next: style-props-value-px-ko-KR.html
+permalink: maximum-number-of-jsx-root-nodes.html
+prev: self-closing-tag.html
+next: style-props-value-px.html
 ---
 
 현재 컴포넌트의 `render`는 한 노드만 리턴할 수 있습니다. 만약 `div` 배열을 리턴하려면, `div`, `span`과 같은 다른 컴포넌트로 한 번 더 싸주어야 합니다. 

--- a/docs/tips/05-maximum-number-of-jsx-root-nodes.ko-KR.md
+++ b/docs/tips/05-maximum-number-of-jsx-root-nodes.ko-KR.md
@@ -1,6 +1,6 @@
 ---
-id: maximum-number-of-jsx-root-nodes-ko-KR
-title: JSX 루트 노드의 최대 갯수
+id: maximum-number-of-jsx-root-nodes
+title: tips.titles.maximum-number-of-jsx-root-nodes
 layout: tips
 permalink: maximum-number-of-jsx-root-nodes-ko-KR.html
 prev: self-closing-tag-ko-KR.html

--- a/docs/tips/05-maximum-number-of-jsx-root-nodes.md
+++ b/docs/tips/05-maximum-number-of-jsx-root-nodes.md
@@ -1,6 +1,6 @@
 ---
 id: maximum-number-of-jsx-root-nodes
-title: Maximum Number of JSX Root Nodes
+title: tips.titles.maximum-number-of-jsx-root-nodes
 layout: tips
 permalink: maximum-number-of-jsx-root-nodes.html
 prev: self-closing-tag.html

--- a/docs/tips/06-style-props-value-px.ko-KR.md
+++ b/docs/tips/06-style-props-value-px.ko-KR.md
@@ -2,9 +2,9 @@
 id: style-props-value-px
 title: tips.titles.style-props-value-px
 layout: tips
-permalink: style-props-value-px-ko-KR.html
-prev: maximum-number-of-jsx-root-nodes-ko-KR.html
-next: children-props-type-ko-KR.html
+permalink: style-props-value-px.html
+prev: maximum-number-of-jsx-root-nodes.html
+next: children-props-type.html
 ---
 
 인라인 `style` prop에서 픽셀 값을 넣을때, React가 자동으로 숫자뒤에 "px"를 붙여줍니다. 다음과 같이 동작합니다:

--- a/docs/tips/06-style-props-value-px.ko-KR.md
+++ b/docs/tips/06-style-props-value-px.ko-KR.md
@@ -1,6 +1,6 @@
 ---
-id: style-props-value-px-ko-KR
-title: 스타일 속성에서 특정 픽셀 값 넣는 간단한 방법 
+id: style-props-value-px
+title: tips.titles.style-props-value-px
 layout: tips
 permalink: style-props-value-px-ko-KR.html
 prev: maximum-number-of-jsx-root-nodes-ko-KR.html

--- a/docs/tips/06-style-props-value-px.md
+++ b/docs/tips/06-style-props-value-px.md
@@ -1,6 +1,6 @@
 ---
 id: style-props-value-px
-title: Shorthand for Specifying Pixel Values in style props
+title: tips.titles.style-props-value-px
 layout: tips
 permalink: style-props-value-px.html
 prev: maximum-number-of-jsx-root-nodes.html

--- a/docs/tips/07-children-props-type.ko-KR.md
+++ b/docs/tips/07-children-props-type.ko-KR.md
@@ -1,6 +1,6 @@
 ---
-id: children-props-type-ko-KR
-title: 자식 속성들의 타입
+id: children-props-type
+title: tips.titles.children-props-type
 layout: tips
 permalink: children-props-type-ko-KR.html
 prev: style-props-value-px-ko-KR.html

--- a/docs/tips/07-children-props-type.ko-KR.md
+++ b/docs/tips/07-children-props-type.ko-KR.md
@@ -2,9 +2,9 @@
 id: children-props-type
 title: tips.titles.children-props-type
 layout: tips
-permalink: children-props-type-ko-KR.html
-prev: style-props-value-px-ko-KR.html
-next: controlled-input-null-value-ko-KR.html
+permalink: children-props-type.html
+prev: style-props-value-px.html
+next: controlled-input-null-value.html
 ---
 
 컴포넌트의 자식들(`this.props.children`)은 대부분 컴포넌트의 배열로 들어갑니다:

--- a/docs/tips/07-children-props-type.md
+++ b/docs/tips/07-children-props-type.md
@@ -1,6 +1,6 @@
 ---
 id: children-props-type
-title: Type of the Children props
+title: tips.titles.children-props-type
 layout: tips
 permalink: children-props-type.html
 prev: style-props-value-px.html

--- a/docs/tips/08-controlled-input-null-value.ko-KR.md
+++ b/docs/tips/08-controlled-input-null-value.ko-KR.md
@@ -1,6 +1,6 @@
 ---
-id: controlled-input-null-value-ko-KR
-title: 제어되는 input 내의 null 값
+id: controlled-input-null-value
+title: tips.titles.controlled-input-null-value
 layout: tips
 permalink: controlled-input-null-value-ko-KR.html
 prev: children-props-type-ko-KR.html

--- a/docs/tips/08-controlled-input-null-value.ko-KR.md
+++ b/docs/tips/08-controlled-input-null-value.ko-KR.md
@@ -2,9 +2,9 @@
 id: controlled-input-null-value
 title: tips.titles.controlled-input-null-value
 layout: tips
-permalink: controlled-input-null-value-ko-KR.html
-prev: children-props-type-ko-KR.html
-next: componentWillReceiveProps-not-triggered-after-mounting-ko-KR.html
+permalink: controlled-input-null-value.html
+prev: children-props-type.html
+next: componentWillReceiveProps-not-triggered-after-mounting.html
 ---
 
 [제어되는 컴포넌트들](/react/docs/forms-ko-KR.html)의 `value` 속성 값을 지정하면 유저에 의해 입력값을 바꿀 수 없습니다.

--- a/docs/tips/08-controlled-input-null-value.md
+++ b/docs/tips/08-controlled-input-null-value.md
@@ -1,6 +1,6 @@
 ---
 id: controlled-input-null-value
-title: Value of null for Controlled Input
+title: tips.titles.controlled-input-null-value
 layout: tips
 permalink: controlled-input-null-value.html
 prev: children-props-type.html

--- a/docs/tips/09-componentWillReceiveProps-not-triggered-after-mounting.ko-KR.md
+++ b/docs/tips/09-componentWillReceiveProps-not-triggered-after-mounting.ko-KR.md
@@ -1,6 +1,6 @@
 ---
-id: componentWillReceiveProps-not-triggered-after-mounting-ko-KR
-title: 마운트 후에는 componentWillReceiveProps가 실행되지 않음.
+id: componentWillReceiveProps-not-triggered-after-mounting
+title: tips.titles.componentWillReceiveProps-not-triggered-after-mounting
 layout: tips
 permalink: componentWillReceiveProps-not-triggered-after-mounting-ko-KR.html
 prev: controlled-input-null-value-ko-KR.html

--- a/docs/tips/09-componentWillReceiveProps-not-triggered-after-mounting.ko-KR.md
+++ b/docs/tips/09-componentWillReceiveProps-not-triggered-after-mounting.ko-KR.md
@@ -2,9 +2,9 @@
 id: componentWillReceiveProps-not-triggered-after-mounting
 title: tips.titles.componentWillReceiveProps-not-triggered-after-mounting
 layout: tips
-permalink: componentWillReceiveProps-not-triggered-after-mounting-ko-KR.html
-prev: controlled-input-null-value-ko-KR.html
-next: props-in-getInitialState-as-anti-pattern-ko-KR.html
+permalink: componentWillReceiveProps-not-triggered-after-mounting.html
+prev: controlled-input-null-value.html
+next: props-in-getInitialState-as-anti-pattern.html
 ---
 
 `componentWillReceiveProps`는 노드가 더해진 후엔 실행되지 않습니다. 이는 설계에 의한 것입니다. [다른 생명주기 메소드](/react/docs/component-specs-ko-KR.html)에서 요구사항에 적합한 것을 찾아보세요.

--- a/docs/tips/09-componentWillReceiveProps-not-triggered-after-mounting.md
+++ b/docs/tips/09-componentWillReceiveProps-not-triggered-after-mounting.md
@@ -1,6 +1,6 @@
 ---
 id: componentWillReceiveProps-not-triggered-after-mounting
-title: componentWillReceiveProps Not Triggered After Mounting
+title: tips.titles.componentWillReceiveProps-not-triggered-after-mounting
 layout: tips
 permalink: componentWillReceiveProps-not-triggered-after-mounting.html
 prev: controlled-input-null-value.html

--- a/docs/tips/10-props-in-getInitialState-as-anti-pattern.ko-KR.md
+++ b/docs/tips/10-props-in-getInitialState-as-anti-pattern.ko-KR.md
@@ -1,6 +1,6 @@
 ---
-id: props-in-getInitialState-as-anti-pattern-ko-KR
-title: getInitialState의 Props는 안티패턴
+id: props-in-getInitialState-as-anti-pattern
+title: tips.titles.props-in-getInitialState-as-anti-pattern
 layout: tips
 permalink: props-in-getInitialState-as-anti-pattern-ko-KR.html
 prev: componentWillReceiveProps-not-triggered-after-mounting-ko-KR.html

--- a/docs/tips/10-props-in-getInitialState-as-anti-pattern.ko-KR.md
+++ b/docs/tips/10-props-in-getInitialState-as-anti-pattern.ko-KR.md
@@ -2,9 +2,9 @@
 id: props-in-getInitialState-as-anti-pattern
 title: tips.titles.props-in-getInitialState-as-anti-pattern
 layout: tips
-permalink: props-in-getInitialState-as-anti-pattern-ko-KR.html
-prev: componentWillReceiveProps-not-triggered-after-mounting-ko-KR.html
-next: dom-event-listeners-ko-KR.html
+permalink: props-in-getInitialState-as-anti-pattern.html
+prev: componentWillReceiveProps-not-triggered-after-mounting.html
+next: dom-event-listeners.html
 ---
 
 > 주의 : 

--- a/docs/tips/10-props-in-getInitialState-as-anti-pattern.md
+++ b/docs/tips/10-props-in-getInitialState-as-anti-pattern.md
@@ -1,6 +1,6 @@
 ---
 id: props-in-getInitialState-as-anti-pattern
-title: Props in getInitialState Is an Anti-Pattern
+title: tips.titles.props-in-getInitialState-as-anti-pattern
 layout: tips
 permalink: props-in-getInitialState-as-anti-pattern.html
 prev: componentWillReceiveProps-not-triggered-after-mounting.html

--- a/docs/tips/11-dom-event-listeners.ko-KR.md
+++ b/docs/tips/11-dom-event-listeners.ko-KR.md
@@ -1,6 +1,6 @@
 ---
-id: dom-event-listeners-ko-KR
-title: 컴포넌트에서 DOM 이벤트 리스너
+id: dom-event-listeners
+title: tips.titles.dom-event-listeners
 layout: tips
 permalink: dom-event-listeners-ko-KR.html
 prev: props-in-getInitialState-as-anti-pattern-ko-KR.html

--- a/docs/tips/11-dom-event-listeners.ko-KR.md
+++ b/docs/tips/11-dom-event-listeners.ko-KR.md
@@ -2,9 +2,9 @@
 id: dom-event-listeners
 title: tips.titles.dom-event-listeners
 layout: tips
-permalink: dom-event-listeners-ko-KR.html
-prev: props-in-getInitialState-as-anti-pattern-ko-KR.html
-next: initial-ajax-ko-KR.html
+permalink: dom-event-listeners.html
+prev: props-in-getInitialState-as-anti-pattern.html
+next: initial-ajax.html
 ---
 
 > 주의:

--- a/docs/tips/11-dom-event-listeners.md
+++ b/docs/tips/11-dom-event-listeners.md
@@ -1,6 +1,6 @@
 ---
 id: dom-event-listeners
-title: DOM Event Listeners in a Component
+title: tips.titles.dom-event-listeners
 layout: tips
 permalink: dom-event-listeners.html
 prev: props-in-getInitialState-as-anti-pattern.html

--- a/docs/tips/12-initial-ajax.ko-KR.md
+++ b/docs/tips/12-initial-ajax.ko-KR.md
@@ -2,9 +2,9 @@
 id: initial-ajax
 title: tips.titles.initial-ajax
 layout: tips
-permalink: initial-ajax-ko-KR.html
-prev: dom-event-listeners-ko-KR.html
-next: false-in-jsx-ko-KR.html
+permalink: initial-ajax.html
+prev: dom-event-listeners.html
+next: false-in-jsx.html
 ---
 
 `componentDidMount`에서 데이터를 가져옵니다. 응답이 올 때 데이터가 state에 저장되고 렌더링을 시작하여 UI를 갱신합니다.

--- a/docs/tips/12-initial-ajax.ko-KR.md
+++ b/docs/tips/12-initial-ajax.ko-KR.md
@@ -1,6 +1,6 @@
 ---
-id: initial-ajax-ko-KR
-title: AJAX를 통해 초기 데이터 읽어오기
+id: initial-ajax
+title: tips.titles.initial-ajax
 layout: tips
 permalink: initial-ajax-ko-KR.html
 prev: dom-event-listeners-ko-KR.html

--- a/docs/tips/12-initial-ajax.md
+++ b/docs/tips/12-initial-ajax.md
@@ -1,6 +1,6 @@
 ---
 id: initial-ajax
-title: Load Initial Data via AJAX
+title: tips.titles.initial-ajax
 layout: tips
 permalink: initial-ajax.html
 prev: dom-event-listeners.html

--- a/docs/tips/13-false-in-jsx.ko-KR.md
+++ b/docs/tips/13-false-in-jsx.ko-KR.md
@@ -2,9 +2,9 @@
 id: false-in-jsx
 title: tips.titles.false-in-jsx
 layout: tips
-permalink: false-in-jsx-ko-KR.html
-prev: initial-ajax-ko-KR.html
-next: communicate-between-components-ko-KR.html
+permalink: false-in-jsx.html
+prev: initial-ajax.html
+next: communicate-between-components.html
 ---
 
 `false` 렌더링이 여러 상황에서 어떻게 다뤄지는지 봅시다.

--- a/docs/tips/13-false-in-jsx.ko-KR.md
+++ b/docs/tips/13-false-in-jsx.ko-KR.md
@@ -1,6 +1,6 @@
 ---
-id: false-in-jsx-ko-KR
-title: JSX에서 False
+id: false-in-jsx
+title: tips.titles.false-in-jsx
 layout: tips
 permalink: false-in-jsx-ko-KR.html
 prev: initial-ajax-ko-KR.html

--- a/docs/tips/13-false-in-jsx.md
+++ b/docs/tips/13-false-in-jsx.md
@@ -1,6 +1,6 @@
 ---
 id: false-in-jsx
-title: False in JSX
+title: tips.titles.false-in-jsx
 layout: tips
 permalink: false-in-jsx.html
 prev: initial-ajax.html

--- a/docs/tips/14-communicate-between-components.ko-KR.md
+++ b/docs/tips/14-communicate-between-components.ko-KR.md
@@ -1,6 +1,6 @@
 ---
-id: communicate-between-components-ko-KR
-title: 컴포넌트간의 통신
+id: communicate-between-components
+title: tips.titles.communicate-between-components
 layout: tips
 permalink: communicate-between-components-ko-KR.html
 prev: false-in-jsx-ko-KR.html

--- a/docs/tips/14-communicate-between-components.ko-KR.md
+++ b/docs/tips/14-communicate-between-components.ko-KR.md
@@ -2,9 +2,9 @@
 id: communicate-between-components
 title: tips.titles.communicate-between-components
 layout: tips
-permalink: communicate-between-components-ko-KR.html
-prev: false-in-jsx-ko-KR.html
-next: expose-component-functions-ko-KR.html
+permalink: communicate-between-components.html
+prev: false-in-jsx.html
+next: expose-component-functions.html
 ---
 
 부모-자식 통신을 위해서는, 간단히 [props를 넘기면 됩니다](/react/docs/multiple-components-ko-KR.html).

--- a/docs/tips/14-communicate-between-components.md
+++ b/docs/tips/14-communicate-between-components.md
@@ -1,6 +1,6 @@
 ---
 id: communicate-between-components
-title: Communicate Between Components
+title: tips.titles.communicate-between-components
 layout: tips
 permalink: communicate-between-components.html
 prev: false-in-jsx.html

--- a/docs/tips/15-expose-component-functions.ko-KR.md
+++ b/docs/tips/15-expose-component-functions.ko-KR.md
@@ -2,12 +2,12 @@
 id: expose-component-functions
 title: tips.titles.expose-component-functions
 layout: tips
-permalink: expose-component-functions-ko-KR.html
-prev: communicate-between-components-ko-KR.html
-next: children-undefined-ko-KR.html
+permalink: expose-component-functions.html
+prev: communicate-between-components.html
+next: children-undefined.html
 ---
 
-[컴포넌트간의 통신](/react/tips/communicate-between-components-ko-KR.html)을 위한 (일반적이지 않은) 또다른 방법이 있습니다: 단순히 부모의 호출을 위해 자식 컴포넌트의 메소드를 노출하는 겁니다. 
+[컴포넌트간의 통신](/react/tips/communicate-between-components-ko-KR.html)을 위한 (일반적이지 않은) 또다른 방법이 있습니다: 단순히 부모의 호출을 위해 자식 컴포넌트의 메소드를 노출하는 겁니다.
 
 할일 목록을 생각해보죠. 아이템을 클릭하면 제거되고, 하나가 남으면 애니메이션 효과를 줍니다:
 

--- a/docs/tips/15-expose-component-functions.ko-KR.md
+++ b/docs/tips/15-expose-component-functions.ko-KR.md
@@ -1,6 +1,6 @@
 ---
-id: expose-component-functions-ko-KR
-title: 컴포넌트 함수 드러내기
+id: expose-component-functions
+title: tips.titles.expose-component-functions
 layout: tips
 permalink: expose-component-functions-ko-KR.html
 prev: communicate-between-components-ko-KR.html

--- a/docs/tips/15-expose-component-functions.md
+++ b/docs/tips/15-expose-component-functions.md
@@ -1,6 +1,6 @@
 ---
 id: expose-component-functions
-title: Expose Component Functions
+title: tips.titles.expose-component-functions
 layout: tips
 permalink: expose-component-functions.html
 prev: communicate-between-components.html

--- a/docs/tips/16-references-to-components.ko-KR.md
+++ b/docs/tips/16-references-to-components.ko-KR.md
@@ -1,6 +1,6 @@
 ---
-id: references-to-components-ko-KR
-title: 컴포넌트 참조
+id: references-to-components
+title: tips.titles.references-to-components
 layout: tips
 permalink: references-to-components-ko-KR.html
 prev: expose-component-functions-ko-KR.html

--- a/docs/tips/16-references-to-components.ko-KR.md
+++ b/docs/tips/16-references-to-components.ko-KR.md
@@ -2,9 +2,9 @@
 id: references-to-components
 title: tips.titles.references-to-components
 layout: tips
-permalink: references-to-components-ko-KR.html
-prev: expose-component-functions-ko-KR.html
-next: children-undefined-ko-KR.html
+permalink: references-to-components.html
+prev: expose-component-functions.html
+next: children-undefined.html
 ---
 
 이 페이지는 이동되었습니다. [refs](/react/docs/more-about-refs-ko-KR.html)

--- a/docs/tips/16-references-to-components.md
+++ b/docs/tips/16-references-to-components.md
@@ -1,6 +1,6 @@
 ---
 id: references-to-components
-title: References to Components
+title: tips.titles.references-to-components
 layout: tips
 permalink: references-to-components.html
 prev: expose-component-functions.html

--- a/docs/tips/17-children-undefined.ko-KR.md
+++ b/docs/tips/17-children-undefined.ko-KR.md
@@ -1,6 +1,6 @@
 ---
-id: children-undefined-ko-KR
-title: 정의되지 않은 this.props.children
+id: children-undefined
+title: tips.titles.children-undefined
 layout: tips
 permalink: children-undefined-ko-KR.html
 prev: expose-component-functions-ko-KR.html

--- a/docs/tips/17-children-undefined.ko-KR.md
+++ b/docs/tips/17-children-undefined.ko-KR.md
@@ -2,9 +2,9 @@
 id: children-undefined
 title: tips.titles.children-undefined
 layout: tips
-permalink: children-undefined-ko-KR.html
-prev: expose-component-functions-ko-KR.html
-next: use-react-with-other-libraries-ko-KR.html
+permalink: children-undefined.html
+prev: expose-component-functions.html
+next: use-react-with-other-libraries.html
 ---
 
 `this.props.children`을 통해 자식 컴포넌트에 접근할 수 없습니다. `this.props.children`은 소유자에 의해 자식이 **전달**되도록 지정합니다:
@@ -12,7 +12,7 @@ next: use-react-with-other-libraries-ko-KR.html
 ```js
 var App = React.createClass({
   componentDidMount: function() {
-    // 이는 `span`을 참조하지 않습니다! 
+    // 이는 `span`을 참조하지 않습니다!
     // 마지막 줄의 `<App></App>` 사이의 정의되지 않은 자식을 참조합니다.
     console.log(this.props.children);
   },

--- a/docs/tips/17-children-undefined.md
+++ b/docs/tips/17-children-undefined.md
@@ -1,6 +1,6 @@
 ---
 id: children-undefined
-title: this.props.children undefined
+title: tips.titles.children-undefined
 layout: tips
 permalink: children-undefined.html
 prev: expose-component-functions.html

--- a/docs/tips/18-use-react-with-other-libraries.ko-KR.md
+++ b/docs/tips/18-use-react-with-other-libraries.ko-KR.md
@@ -2,9 +2,9 @@
 id: use-react-with-other-libraries
 title: tips.titles.use-react-with-other-libraries
 layout: tips
-permalink: use-react-with-other-libraries-ko-KR.html
-prev: children-undefined-ko-KR.html
-next: dangerously-set-inner-html-ko-KR.html
+permalink: use-react-with-other-libraries.html
+prev: children-undefined.html
+next: dangerously-set-inner-html.html
 ---
 
 React만으로 만들 필요는 없습니다. 컴포넌트의 [생명주기 이벤트](/react/docs/component-specs-ko-KR.html#lifecycle-methods), 특히 `componentDidMount`와 `componentDidUpdate`는 다른 라이브러리들의 로직을 넣기에 좋은 장소입니다.

--- a/docs/tips/18-use-react-with-other-libraries.ko-KR.md
+++ b/docs/tips/18-use-react-with-other-libraries.ko-KR.md
@@ -1,6 +1,6 @@
 ---
-id: use-react-with-other-libraries-ko-KR
-title: React와 다른 라이브러리를 함께 사용하기
+id: use-react-with-other-libraries
+title: tips.titles.use-react-with-other-libraries
 layout: tips
 permalink: use-react-with-other-libraries-ko-KR.html
 prev: children-undefined-ko-KR.html

--- a/docs/tips/18-use-react-with-other-libraries.md
+++ b/docs/tips/18-use-react-with-other-libraries.md
@@ -1,6 +1,6 @@
 ---
 id: use-react-with-other-libraries
-title: Use React with Other Libraries
+title: tips.titles.use-react-with-other-libraries
 layout: tips
 permalink: use-react-with-other-libraries.html
 prev: children-undefined.html

--- a/docs/tips/19-dangerously-set-inner-html.ko-KR.md
+++ b/docs/tips/19-dangerously-set-inner-html.ko-KR.md
@@ -1,6 +1,6 @@
 ---
-id: dangerously-set-inner-html-ko-KR
-title: Dangerously Set innerHTML
+id: dangerously-set-inner-html
+title: tips.titles.dangerously-set-inner-html
 layout: tips
 permalink: dangerously-set-inner-html-ko-KR.html
 prev: children-undefined-ko-KR.html

--- a/docs/tips/19-dangerously-set-inner-html.ko-KR.md
+++ b/docs/tips/19-dangerously-set-inner-html.ko-KR.md
@@ -2,8 +2,8 @@
 id: dangerously-set-inner-html
 title: tips.titles.dangerously-set-inner-html
 layout: tips
-permalink: dangerously-set-inner-html-ko-KR.html
-prev: children-undefined-ko-KR.html
+permalink: dangerously-set-inner-html.html
+prev: children-undefined.html
 ---
 
 부적절히 `innerHTML`를 사용하면 [사이트 간 스크립팅 (XSS)](https://en.wikipedia.org/wiki/Cross-site_scripting) 공격에 노출됩니다. 화면의 사용자 입력을 정제하다(sanitize) 오류를 내기 쉬우며, 적절하게 사용자의 입력을 정제하지 못하면 인터넷 상 [웹 취약점의 원인](https://owasptop10.googlecode.com/files/OWASP%20Top%2010%20-%202013.pdf)이 됩니다.

--- a/docs/tips/19-dangerously-set-inner-html.md
+++ b/docs/tips/19-dangerously-set-inner-html.md
@@ -1,6 +1,6 @@
 ---
 id: dangerously-set-inner-html
-title: Dangerously Set innerHTML
+title: tips.titles.dangerously-set-inner-html
 layout: tips
 permalink: dangerously-set-inner-html.html
 prev: children-undefined.html


### PR DESCRIPTION
We went past the tipping point on this a while ago and we need to surface our translated docs. I spent some time this week looking into other options for generating our site but this gets us there way faster with minimal changes. It's only half the work though - there but there's still a bunch to do. The infra is here now but we're still going to have some hacks we have to do to make links work right.

### How it works (we're using http://jekyll-langs.liaohuqiu.net/):
- translated files live side by side like we already have with the exact same file naming convention (though perhaps we will end
- translated phrases live as key-value pairs in `_i18n/lang.yml`. I've done as much of the Korean as I can (copy + paste from the titles in the docs files)
- We can use these keys in a lot of places, `{% t string|key %}` outputs the value and will fall back to English (default).
- Due to limitations in how Jekyll passes things around there unfortunately a lot of duplicate keys in these files. I tried to cut it but couldn't make it work.
- English is unchanged (well except for 1 tiny thing which actually is broken on 1 page)

### Give it a try:
I set up a testing server - http://reacti18n.zpao.com/react/ko-KR/docs/getting-started.html

Links are definitely broken right now so no need to remind me :)

But I wanted to get some feedback before I took it any further, namely from the people who have been doing the bulk of the translation work - @tako-black, @makky3939, @marocchino, @sairion (and many others, perhaps you can spread the word amongst the translators you've been working with?), @spicyj . Does this approach so far seem like it's more maintainable for you moving forward? All of your current links will be broken but I'm not too worried about that (are you?).

### TODO: 
- [x] make next / prev / sidebar links actually go to current language. Might need to do full paths in next/prev, needs more investigation
- [ ] link to other language entry points somewhere
- [ ] decide if we want full locale in the url or the short version (`/ko-KR/` vs `/ko/`, `/ja-JP/` vs `/ja/`, `/zh-CN/` vs `/zh/ (or cn?)`)
- [ ] Make header fragment links work
- [ ] language specific CSS (eg, font-size)