### PR TITLE
Added warning when calling methods on a released event.

### DIFF
--- a/src/renderers/dom/client/syntheticEvents/SyntheticEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticEvent.js
@@ -16,6 +16,7 @@ var PooledClass = require('PooledClass');
 
 var assign = require('Object.assign');
 var emptyFunction = require('emptyFunction');
+var warning = require('warning');
 
 /**
  * @interface Event
@@ -89,6 +90,16 @@ assign(SyntheticEvent.prototype, {
   preventDefault: function() {
     this.defaultPrevented = true;
     var event = this.nativeEvent;
+    if (__DEV__) {
+      warning(event,
+        'This Synthetic event is reused for performance reasons. If you\'re seeing this, ' +
+        'you\'re calling `preventDefault` on a released/nullified Synthetic event. ' +
+        'This is a no-op. See https://facebook.github.io/react/docs/events.html#event-pooling ' +
+        'for more information.'
+      );
+    }
+    if (!event) return;
+
     if (event.preventDefault) {
       event.preventDefault();
     } else {
@@ -99,6 +110,16 @@ assign(SyntheticEvent.prototype, {
 
   stopPropagation: function() {
     var event = this.nativeEvent;
+    if (__DEV__) {
+      warning(event,
+        'This Synthetic event is reused for performance reasons. If you\'re seeing this, ' +
+        'you\'re calling `stopPropagation` on a released/nullified Synthetic event. ' +
+        'This is a no-op. See https://facebook.github.io/react/docs/events.html#event-pooling ' +
+        'for more information.'
+      );
+    }
+    if (!event) return;
+
     if (event.stopPropagation) {
       event.stopPropagation();
     } else {

--- a/src/renderers/dom/client/syntheticEvents/__tests__/SyntheticEvent-test.js
+++ b/src/renderers/dom/client/syntheticEvents/__tests__/SyntheticEvent-test.js
@@ -72,4 +72,33 @@ describe('SyntheticEvent', function() {
     expect(syntheticEvent.isPersistent()).toBe(true);
   });
 
+  it('should warn if the Synthetic event has been released when calling `preventDefault`', function() {
+    spyOn(console, 'error');
+    var syntheticEvent = createEvent({});
+    SyntheticEvent.release(syntheticEvent);
+    syntheticEvent.preventDefault();
+    expect(console.error.calls.length).toBe(1);
+    expect(console.error.argsForCall[0][0]).toBe(
+      'Warning: ' +
+      'This Synthetic event is reused for performance reasons. If you\'re seeing this, ' +
+      'you\'re calling `preventDefault` on a released/nullified Synthetic event. ' +
+      'This is a no-op. See https://facebook.github.io/react/docs/events.html#event-pooling ' +
+      'for more information.'
+    );
+  });
+
+  it('should warn if the Synthetic event has been released when calling `stopPropagation`', function() {
+    spyOn(console, 'error');
+    var syntheticEvent = createEvent({});
+    SyntheticEvent.release(syntheticEvent);
+    syntheticEvent.stopPropagation();
+    expect(console.error.calls.length).toBe(1);
+    expect(console.error.argsForCall[0][0]).toBe(
+      'Warning: ' +
+      'This Synthetic event is reused for performance reasons. If you\'re seeing this, ' +
+      'you\'re calling `stopPropagation` on a released/nullified Synthetic event. ' +
+      'This is a no-op. See https://facebook.github.io/react/docs/events.html#event-pooling ' +
+      'for more information.'
+    );
+  });
 });


### PR DESCRIPTION
Fixes #4514 
Warns only if `__DEV__` is set.
Not quite sure that I got the smoothest message in there, would appreciate some feedback (on both the message and the code).

Changed behavior:
It exits the method if `nativeEvent` is falsy.

We should probably create a short-link to the docs.
cc @jimfb 