### PR TITLE
Updated the Performance tools doc page.

### DIFF
--- a/docs/docs/10.9-perf.md
+++ b/docs/docs/10.9-perf.md
@@ -21,6 +21,8 @@ The `Perf` object documented here is exposed as `React.addons.Perf` when using t
 ### `Perf.start()` and `Perf.stop()`
 Start/stop the measurement. The React operations in-between are recorded for analyses below. Operations that took an insignificant amount of time are ignored.
 
+After stopping, you will need `Perf.getLastMeasurements()` (described below) to get the measurements.
+
 ### `Perf.printInclusive(measurements)`
 Prints the overall time taken. If no argument's passed, defaults to all the measurements from the last recording. This prints a nicely formatted table in the console, like so:
 


### PR DESCRIPTION
Now it’s possible to read the page from top to the bottom without
asking oneself “Ok, but how do I get these measurements?”