### PR TITLE
Check for compatible node,npm versions on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,14 +32,16 @@
     "optimist": "^0.6.1",
     "platform": "^1.1.0",
     "run-sequence": "^1.1.0",
+    "semver": "^5.0.1",
     "through2": "^2.0.0",
     "tmp": "~0.0.18",
     "typescript": "~1.4.0",
     "uglify-js": "^2.4.23",
     "uglifyify": "^3.0.1"
   },
-  "engines": {
-    "node": ">=0.10.0"
+  "devEngines": {
+    "node": "0.10.x",
+    "npm": "2.x"
   },
   "commonerConfig": {
     "version": 7
@@ -48,6 +50,7 @@
     "build": "grunt build",
     "linc": "git diff --name-only --diff-filter=ACMRTUB `git merge-base HEAD master` | grep '\\.js$' | xargs eslint --",
     "lint": "grunt lint",
+    "postinstall": "node scripts/check-dev-engines.js",
     "test": "NODE_ENV=test jest"
   },
   "jest": {

--- a/scripts/check-dev-engines.js
+++ b/scripts/check-dev-engines.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var devEngines = require('../package').devEngines;
+
+var assert = require('assert');
+var exec = require('child_process').exec;
+var semver = require('semver');
+var f = require('util').format;
+
+if (devEngines.node !== undefined) {
+  // First check that devEngines are valid semver
+  assert(
+    semver.validRange(devEngines.node),
+    f('devEngines.node (%s) is not a valid semver range', devEngines.node)
+  );
+  // Then actually check that our version satisfies
+  var nodeVersion = process.versions.node;
+  assert(
+    semver.satisfies(nodeVersion, devEngines.node),
+    f('Current node version is not supported for development, expected "%s" to satisfy "%s".', nodeVersion, devEngines.node)
+  );
+}
+
+if (devEngines.npm !== undefined) {
+  // First check that devEngines are valid semver
+  assert(
+    semver.validRange(devEngines.npm),
+    f('devEngines.npm (%s) is not a valid semver range', devEngines.npm)
+  );
+
+  // Then actually check that our version satisfies
+  exec('npm --version', function(err, stdout, stderr) {
+    assert(err === null, f('Failed to get npm version... %s'), stderr);
+
+    var npmVersion = stdout.trim();
+    assert(
+      semver.satisfies(npmVersion, devEngines.npm),
+      f('Current npm version is not supported for development, expected "%s" to satisfy "%s".', npmVersion, devEngines.npm)
+    );
+  });
+}


### PR DESCRIPTION
This is only for building React and doesnn't apply to production installs.

We're going to switch to iojs shortly and I wanted to make sure we short-circuit people trying to develop React so we don't get reports of weird issues.