### PR TITLE
Update Advanced Performance code examples so they would output values

### DIFF
--- a/docs/docs/11-advanced-performance.md
+++ b/docs/docs/11-advanced-performance.md
@@ -54,7 +54,7 @@ React.createClass({
   },
 
   render: function() {
-    return <div>this.props.value</div>;
+    return <div>{this.props.value}</div>;
   }
 });
 ```
@@ -78,7 +78,7 @@ React.createClass({
   },
 
   render: function() {
-    return <div>this.props.value.foo</div>;
+    return <div>{this.props.value.foo}</div>;
   }
 });
 ```


### PR DESCRIPTION
Noticed the code examples in [Advanced Performance - shouldComponentUpdate in action](https://facebook.github.io/react/docs/advanced-performance.html#shouldcomponentupdate-in-action) wouldn't be rendering the example props, this could lead to some minor confusion for new users.