### PR TITLE
Iterator `done` property breaks code when compressed with the closure compiler

### DIFF
--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -183,7 +183,7 @@ function validateChildKeys(node, parentType) {
       if (iteratorFn !== node.entries) {
         var iterator = iteratorFn.call(node);
         var step;
-        while (!(step = iterator.next()).done) {
+        while (!(step = iterator.next())['done']) {
           if (ReactElement.isValidElement(step.value)) {
             validateExplicitKey(step.value, parentType);
           }

--- a/src/shared/utils/traverseAllChildren.js
+++ b/src/shared/utils/traverseAllChildren.js
@@ -139,7 +139,7 @@ function traverseAllChildrenImpl(
       var step;
       if (iteratorFn !== children.entries) {
         var ii = 0;
-        while (!(step = iterator.next()).done) {
+        while (!(step = iterator.next())['done']) {
           child = step.value;
           nextName = nextNamePrefix + getComponentKey(child, ii++);
           subtreeCount += traverseAllChildrenImpl(
@@ -160,7 +160,7 @@ function traverseAllChildrenImpl(
           didWarnAboutMaps = true;
         }
         // Iterator will provide entry [k,v] tuples rather than values.
-        while (!(step = iterator.next()).done) {
+        while (!(step = iterator.next())['done']) {
           var entry = step.value;
           if (entry) {
             child = entry[1];


### PR DESCRIPTION
The closure compiler doesn't yet support the ES6 iterator correctly.

To get my code working correctly I've had to make the property a string literal.

This is essentially a work around for a feature not yet supported by the closure-compiler.

Without the workaround the script gets stuck in an infinite while loop and crashes the page because `!undefined` is `true`.

**Maybe related**: google/closure-compiler#757