### PR TITLE
Ensure IE8 style expansion list is up to date

### DIFF
--- a/src/renderers/dom/shared/CSSProperty.js
+++ b/src/renderers/dom/shared/CSSProperty.js
@@ -80,10 +80,16 @@ Object.keys(isUnitlessNumber).forEach(function(prop) {
  */
 var shorthandPropertyExpansions = {
   background: {
-    backgroundImage: true,
-    backgroundPosition: true,
-    backgroundRepeat: true,
+    backgroundAttachment: true,
     backgroundColor: true,
+    backgroundImage: true,
+    backgroundPositionX: true,
+    backgroundPositionY: true,
+    backgroundRepeat: true,
+  },
+  backgroundPosition: {
+    backgroundPositionX: true,
+    backgroundPositionY: true,
   },
   border: {
     borderWidth: true,
@@ -117,6 +123,11 @@ var shorthandPropertyExpansions = {
     fontSize: true,
     lineHeight: true,
     fontFamily: true,
+  },
+  outline: {
+    outlineWidth: true,
+    outlineStyle: true,
+    outlineColor: true,
   },
 };
 


### PR DESCRIPTION
In conjunction with #1953, fixes #2407. This seems to be all of the shorthand style properties that IE8 supports, excluding a few nonstandard ones.