### PR TITLE
Add setter for the ID_ATTRIBUTE_NAME to top-level React

### DIFF
--- a/src/browser/ui/React.js
+++ b/src/browser/ui/React.js
@@ -25,6 +25,7 @@ var ReactDOM = require('ReactDOM');
 var ReactDOMTextComponent = require('ReactDOMTextComponent');
 var ReactDefaultInjection = require('ReactDefaultInjection');
 var ReactInstanceHandles = require('ReactInstanceHandles');
+var DOMProperty = require('DOMProperty');
 var ReactMount = require('ReactMount');
 var ReactPerf = require('ReactPerf');
 var ReactPropTypes = require('ReactPropTypes');
@@ -50,6 +51,9 @@ if (__DEV__) {
 var render = ReactPerf.measure('React', 'render', ReactMount.render);
 
 var React = {
+  setIdAttributeName: function(id) {
+    DOMProperty.ID_ATTRIBUTE_NAME = id;
+  },
   Children: {
     map: ReactChildren.map,
     forEach: ReactChildren.forEach,

--- a/src/browser/ui/ReactMount.js
+++ b/src/browser/ui/ReactMount.js
@@ -36,7 +36,6 @@ var warning = require('warning');
 
 var SEPARATOR = ReactInstanceHandles.SEPARATOR;
 
-var ATTR_NAME = DOMProperty.ID_ATTRIBUTE_NAME;
 var nodeCache = {};
 
 var ELEMENT_NODE_TYPE = 1;
@@ -100,7 +99,7 @@ function getID(node) {
         invariant(
           !isValid(cached, id),
           'ReactMount: Two valid but unequal nodes with the same `%s`: %s',
-          ATTR_NAME, id
+          DOMProperty.ID_ATTRIBUTE_NAME, id
         );
 
         nodeCache[id] = node;
@@ -117,7 +116,7 @@ function internalGetID(node) {
   // If node is something like a window, document, or text node, none of
   // which support attributes or a .getAttribute method, gracefully return
   // the empty string, as if the attribute were missing.
-  return node && node.getAttribute && node.getAttribute(ATTR_NAME) || '';
+  return node && node.getAttribute && node.getAttribute(DOMProperty.ID_ATTRIBUTE_NAME) || '';
 }
 
 /**
@@ -131,7 +130,7 @@ function setID(node, id) {
   if (oldID !== id) {
     delete nodeCache[oldID];
   }
-  node.setAttribute(ATTR_NAME, id);
+  node.setAttribute(DOMProperty.ID_ATTRIBUTE_NAME, id);
   nodeCache[id] = node;
 }
 
@@ -182,7 +181,7 @@ function isValid(node, id) {
     invariant(
       internalGetID(node) === id,
       'ReactMount: Unexpected modification of `%s`',
-      ATTR_NAME
+      DOMProperty.ID_ATTRIBUTE_NAME
     );
 
     var container = ReactMount.findReactContainerForID(id);


### PR DESCRIPTION
To facilitate use-cases where multiple React apps are running on the same page,
expose the DOMPropery ID_ATTRIBUTE_NAME on the top-level React object and make
ReactMount reference the propery from DOMPropery rather than its own local copy.

This branch is based on 0.13-stable. Issue with background: https://github.com/facebook/react/issues/1939