### PR TITLE
Add setter for the ID_ATTRIBUTE_NAME to top-level React

### DIFF
--- a/src/isomorphic/ReactIsomorphic.js
+++ b/src/isomorphic/ReactIsomorphic.js
@@ -11,6 +11,7 @@
 
 'use strict';
 
+var DOMProperty = require('DOMProperty');
 var ReactChildren = require('ReactChildren');
 var ReactComponent = require('ReactComponent');
 var ReactClass = require('ReactClass');
@@ -33,7 +34,9 @@ if (__DEV__) {
 }
 
 var React = {
-
+  setIdAttributeName: function(id) {
+    DOMProperty.ID_ATTRIBUTE_NAME = id;
+  },
   // Modern
 
   Children: {

--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -37,7 +37,6 @@ var warning = require('warning');
 
 var SEPARATOR = ReactInstanceHandles.SEPARATOR;
 
-var ATTR_NAME = DOMProperty.ID_ATTRIBUTE_NAME;
 var nodeCache = {};
 
 var ELEMENT_NODE_TYPE = 1;
@@ -123,7 +122,7 @@ function getID(node) {
         invariant(
           !isValid(cached, id),
           'ReactMount: Two valid but unequal nodes with the same `%s`: %s',
-          ATTR_NAME, id
+          DOMProperty.ID_ATTRIBUTE_NAME, id
         );
 
         nodeCache[id] = node;
@@ -140,7 +139,7 @@ function internalGetID(node) {
   // If node is something like a window, document, or text node, none of
   // which support attributes or a .getAttribute method, gracefully return
   // the empty string, as if the attribute were missing.
-  return node && node.getAttribute && node.getAttribute(ATTR_NAME) || '';
+  return node && node.getAttribute && node.getAttribute(DOMProperty.ID_ATTRIBUTE_NAME) || '';
 }
 
 /**
@@ -154,7 +153,7 @@ function setID(node, id) {
   if (oldID !== id) {
     delete nodeCache[oldID];
   }
-  node.setAttribute(ATTR_NAME, id);
+  node.setAttribute(DOMProperty.ID_ATTRIBUTE_NAME, id);
   nodeCache[id] = node;
 }
 
@@ -205,7 +204,7 @@ function isValid(node, id) {
     invariant(
       internalGetID(node) === id,
       'ReactMount: Unexpected modification of `%s`',
-      ATTR_NAME
+      DOMProperty.ID_ATTRIBUTE_NAME
     );
 
     var container = ReactMount.findReactContainerForID(id);


### PR DESCRIPTION
To facilitate use-cases where multiple React apps are running on the same page,
expose the DOMPropery ID_ATTRIBUTE_NAME on the top-level React object and make
ReactMount reference the propery from DOMPropery rather than its own local copy.

This is most probably not the right place to add something like this, so feedback
with suggestions is most welcome.

This is based off master (currently 0.14-beta3). Issue with background: https://github.com/facebook/react/issues/1939