### PR TITLE
Remove redundancy regarding 'latest React news'

### DIFF
--- a/docs/support.md
+++ b/docs/support.md
@@ -22,6 +22,6 @@ Many developers and users idle on Freenode.net's IRC network in **[#reactjs on f
 
 ## Twitter
 
-For the latest news about React, [follow **@reactjs** on Twitter](https://twitter.com/reactjs) or use the [**#reactjs** hashtag](https://twitter.com/search?q=%23reactjs).
+For the latest news about React, [follow **@reactjs** on Twitter](https://twitter.com/reactjs). In addition, you can use the #reactjs hashtag to see what others are saying or add to the conversation.
 
 <div><a class="twitter-timeline" data-dnt="true" data-chrome="nofooter noheader transparent" href="https://twitter.com/search?q=%23reactjs" data-widget-id="342522405270470656"></a></div>

--- a/docs/support.md
+++ b/docs/support.md
@@ -22,6 +22,6 @@ Many developers and users idle on Freenode.net's IRC network in **[#reactjs on f
 
 ## Twitter
 
-For the latest news about React, [follow **@reactjs** on Twitter](https://twitter.com/reactjs). In addition, you can use the [**#reactjs** hashtag](https://twitter.com/search?q=%23reactjs) to keep up with the latest React news.
+For the latest news about React, [follow **@reactjs** on Twitter](https://twitter.com/reactjs) or use the [**#reactjs** hashtag](https://twitter.com/search?q=%23reactjs).
 
 <div><a class="twitter-timeline" data-dnt="true" data-chrome="nofooter noheader transparent" href="https://twitter.com/search?q=%23reactjs" data-widget-id="342522405270470656"></a></div>


### PR DESCRIPTION
Previously, it repeated 'latest React news' when the first sentence already begins with the same words.