### PR TITLE
Fix typo

### DIFF
--- a/src/renderers/shared/event/EventPropagators.js
+++ b/src/renderers/shared/event/EventPropagators.js
@@ -57,7 +57,7 @@ function accumulateDirectionalDispatches(domID, upwards, event) {
 /**
  * Collect dispatches (must be entirely collected before dispatching - see unit
  * tests). Lazily allocate the array to conserve memory.  We must loop through
- * each event and perform the traversal for each one. We can not perform a
+ * each event and perform the traversal for each one. We cannot perform a
  * single traversal for the entire collection of events because each event may
  * have a different target.
  */


### PR DESCRIPTION
Can not should be a single word: 'cannot'