### PR TITLE
Update 06-transferring-props.md

### DIFF
--- a/docs/docs/06-transferring-props.md
+++ b/docs/docs/06-transferring-props.md
@@ -24,7 +24,7 @@ The rest of this tutorial explains best practices. It uses JSX and experimental 
 
 ## Manual Transfer
 
-Most of the time you should explicitly pass the properties down. That ensures that you only expose a subset of the inner API, one that you know will work.
+Most of the time you should explicitly pass the properties down. This ensures that you only expose a subset of the inner API, one that you know will work.
 
 ```javascript
 var FancyCheckbox = React.createClass({


### PR DESCRIPTION
"This ensures that" sounds a better than "That ensures that." This change is just my personal opinion, so I totally understand my change doesn't get merged.