### PR TITLE
Increase trailing context when reporting a checksum error

### DIFF
--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -944,8 +944,8 @@ var ReactMount = {
 
         var diffIndex = firstDifferenceIndex(normalizedMarkup, rootMarkup);
         var difference = ' (client) ' +
-          normalizedMarkup.substring(diffIndex - 20, diffIndex + 20) +
-          '\n (server) ' + rootMarkup.substring(diffIndex - 20, diffIndex + 20);
+          normalizedMarkup.substring(diffIndex - 20, diffIndex + 100) +
+          '\n (server) ' + rootMarkup.substring(diffIndex - 20, diffIndex + 100);
 
         invariant(
           container.nodeType !== DOC_NODE_TYPE,


### PR DESCRIPTION
In my own debugging, I've found the +/-20 character context in the checksum error report to be insufficient.  When dealing with a tag that is longer than 20 characters it doesn't show me what I need, or can be misleading because of attribute ordering (an attribute might be present and equal in both versions, but because of ordering might be truncated from one version and not the other).

Arguably the context should go until at least `>` is reached (but with some maximum), such as `markup.substring(diffIndex - 20, Math.min(Math.max(diffIndex+20, markup.indexOf('>', diffIndex)), diffIndex+200))`, but here I've just bumped the number up.