### PR TITLE
Check in eslint-plugin-react-internal "symlink" to node_modules

### DIFF
--- a/node_modules/eslint-plugin-react-internal/index.js
+++ b/node_modules/eslint-plugin-react-internal/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../../eslint-rules');

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "envify": "^3.0.0",
     "eslint": "^1.1.0",
     "eslint-plugin-react": "^3.2.1",
-    "eslint-plugin-react-internal": "file:eslint-rules",
     "fbjs": "0.1.0-alpha.4",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",


### PR DESCRIPTION
Any reason we don't do this? Can't remember.