### PR TITLE
Add destructors to pooled classes in ReactChildren

### DIFF
--- a/src/isomorphic/children/ReactChildren.js
+++ b/src/isomorphic/children/ReactChildren.js
@@ -35,6 +35,11 @@ function ForEachBookKeeping(forEachFunction, forEachContext) {
   this.context = forEachContext;
   this.count = 0;
 }
+ForEachBookKeeping.prototype.destructor = function() {
+  this.func = null;
+  this.context = null;
+  this.count = 0;
+};
 PooledClass.addPoolingTo(ForEachBookKeeping, twoArgumentPooler);
 
 function forEachSingleChild(traverseContext, child, name) {
@@ -79,6 +84,12 @@ function MapBookKeeping(mapResult, mapFunction, mapContext) {
   this.context = mapContext;
   this.count = 0;
 }
+MapBookKeeping.prototype.destructor = function() {
+  this.result = null;
+  this.func = null;
+  this.context = null;
+  this.count = 0;
+};
 PooledClass.addPoolingTo(MapBookKeeping, threeArgumentPooler);
 
 function mapSingleChildIntoContext(traverseContext, child, name) {

--- a/src/renderers/dom/client/eventPlugins/FallbackCompositionState.js
+++ b/src/renderers/dom/client/eventPlugins/FallbackCompositionState.js
@@ -35,6 +35,12 @@ function FallbackCompositionState(root) {
 }
 
 assign(FallbackCompositionState.prototype, {
+  destructor: function() {
+    this._root = null;
+    this._startText = null;
+    this._fallbackText = null;
+  },
+
   /**
    * Get current text of input.
    *

--- a/src/shared/utils/PooledClass.js
+++ b/src/shared/utils/PooledClass.js
@@ -81,9 +81,7 @@ var standardReleaser = function(instance) {
     instance instanceof Klass,
     'Trying to release an instance into a pool of a different type.'
   );
-  if (instance.destructor) {
-    instance.destructor();
-  }
+  instance.destructor();
   if (Klass.instancePool.length < Klass.poolSize) {
     Klass.instancePool.push(instance);
   }

--- a/src/shared/utils/__tests__/PooledClass-test.js
+++ b/src/shared/utils/__tests__/PooledClass-test.js
@@ -18,6 +18,7 @@ describe('Pooled class', function() {
   beforeEach(function() {
     PooledClass = require('PooledClass');
     PoolableClass = function() {};
+    PoolableClass.prototype.destructor = function() {};
     PooledClass.addPoolingTo(PoolableClass);
   });
 
@@ -63,6 +64,7 @@ describe('Pooled class', function() {
     var PoolableClassWithMultiArguments = function(a, b) {
       log.push(a, b);
     };
+    PoolableClassWithMultiArguments.prototype.destructor = function() {};
     PooledClass.addPoolingTo(
       PoolableClassWithMultiArguments,
       PooledClass.twoArgumentPooler
@@ -76,6 +78,7 @@ describe('Pooled class', function() {
     var PoolableClassWithOneArgument = function(a) {
       log.push(a);
     };
+    PoolableClassWithOneArgument.prototype.destructor = function() {};
     PooledClass.addPoolingTo(
       PoolableClassWithOneArgument
     );
@@ -88,6 +91,7 @@ describe('Pooled class', function() {
     var PoolableClassWithOneArgument = function(a) {
       log.push(a);
     };
+    PoolableClassWithOneArgument.prototype.destructor = function() {};
     PooledClass.addPoolingTo(
       PoolableClassWithOneArgument
     );
@@ -100,6 +104,7 @@ describe('Pooled class', function() {
   it('should throw when the class releases an instance of a different type',
     function() {
       var RandomClass = function() {};
+      RandomClass.prototype.destructor = function() {};
       PooledClass.addPoolingTo(RandomClass);
       var randomInstance = RandomClass.getPooled();
       PoolableClass.getPooled();
@@ -111,4 +116,13 @@ describe('Pooled class', function() {
       );
     }
   );
+
+  it('should throw if no destructor is defined', function() {
+    var ImmortalClass = function() {};
+    PooledClass.addPoolingTo(ImmortalClass);
+    var inst = ImmortalClass.getPooled();
+    expect(function() {
+      ImmortalClass.release(inst);
+    }).toThrow();
+  });
 });


### PR DESCRIPTION
And make destructors mandatory so we're less likely to forget again.