### PR TITLE
Make definitions more readable & optional params more obvious

### DIFF
--- a/docs/docs/10.4-test-utils.md
+++ b/docs/docs/10.4-test-utils.md
@@ -11,7 +11,10 @@ next: clone-with-props.html
 ### Simulate
 
 ```javascript
-Simulate.{eventName}(DOMElement element, object eventData)
+Simulate.{eventName}(
+  DOMElement element,
+  [object eventData]
+)
 ```
 
 Simulate an event dispatch on a DOM node with optional `eventData` event data. **This is possibly the single most useful utility in `ReactTestUtils`.**
@@ -39,7 +42,9 @@ React.addons.TestUtils.Simulate.keyDown(node, {key: "Enter", keyCode: 13, which:
 ### renderIntoDocument
 
 ```javascript
-ReactComponent renderIntoDocument(ReactElement instance)
+ReactComponent renderIntoDocument(
+  ReactElement instance
+)
 ```
 
 Render a component into a detached DOM node in the document. **This function requires a DOM.**
@@ -47,7 +52,10 @@ Render a component into a detached DOM node in the document. **This function req
 ### mockComponent
 
 ```javascript
-object mockComponent(function componentClass, string? mockTagName)
+object mockComponent(
+  function componentClass,
+  [string mockTagName]
+)
 ```
 
 Pass a mocked component module to this method to augment it with useful methods that allow it to be used as a dummy React component. Instead of rendering as usual, the component will become a simple `<div>` (or other tag if `mockTagName` is provided) containing any provided children.
@@ -55,7 +63,9 @@ Pass a mocked component module to this method to augment it with useful methods 
 ### isElement
 
 ```javascript
-boolean isElement(ReactElement element)
+boolean isElement(
+  ReactElement element
+)
 ```
 
 Returns `true` if `element` is any ReactElement.
@@ -63,7 +73,10 @@ Returns `true` if `element` is any ReactElement.
 ### isElementOfType
 
 ```javascript
-boolean isElementOfType(ReactElement element, function componentClass)
+boolean isElementOfType(
+  ReactElement element,
+  function componentClass
+)
 ```
 
 Returns `true` if `element` is a ReactElement whose type is of a React `componentClass`.
@@ -71,7 +84,9 @@ Returns `true` if `element` is a ReactElement whose type is of a React `componen
 ### isDOMComponent
 
 ```javascript
-boolean isDOMComponent(ReactComponent instance)
+boolean isDOMComponent(
+  ReactComponent instance
+)
 ```
 
 Returns `true` if `instance` is a DOM component (such as a `<div>` or `<span>`).
@@ -79,7 +94,9 @@ Returns `true` if `instance` is a DOM component (such as a `<div>` or `<span>`).
 ### isCompositeComponent
 
 ```javascript
-boolean isCompositeComponent(ReactComponent instance)`
+boolean isCompositeComponent(
+  ReactComponent instance
+)
 ```
 
 Returns `true` if `instance` is a composite component (created with `React.createClass()`).
@@ -87,7 +104,10 @@ Returns `true` if `instance` is a composite component (created with `React.creat
 ### isCompositeComponentWithType
 
 ```javascript
-boolean isCompositeComponentWithType(ReactComponent instance, function componentClass)
+boolean isCompositeComponentWithType(
+  ReactComponent instance,
+  function componentClass
+)
 ```
 
 Returns `true` if `instance` is a composite component (created with `React.createClass()`) whose type is of a React `componentClass`.
@@ -95,7 +115,10 @@ Returns `true` if `instance` is a composite component (created with `React.creat
 ### findAllInRenderedTree
 
 ```javascript
-array findAllInRenderedTree(ReactComponent tree, function test)
+array findAllInRenderedTree(
+  ReactComponent tree,
+  function test
+)
 ```
 
 Traverse all components in `tree` and accumulate all components where `test(component)` is `true`. This is not that useful on its own, but it's used as a primitive for other test utils.
@@ -103,7 +126,9 @@ Traverse all components in `tree` and accumulate all components where `test(comp
 ### scryRenderedDOMComponentsWithClass
 
 ```javascript
-array scryRenderedDOMComponentsWithClass(ReactComponent tree, string className)
+array scryRenderedDOMComponentsWithClass(
+  ReactComponent tree, string className
+)
 ```
 
 Finds all instances of components in the rendered tree that are DOM components with the class name matching `className`.
@@ -111,7 +136,10 @@ Finds all instances of components in the rendered tree that are DOM components w
 ### findRenderedDOMComponentWithClass
 
 ```javascript
-ReactComponent findRenderedDOMComponentWithClass(ReactComponent tree, string className)
+ReactComponent findRenderedDOMComponentWithClass(
+  ReactComponent tree,
+  string className
+)
 ```
 
 Like `scryRenderedDOMComponentsWithClass()` but expects there to be one result, and returns that one result, or throws exception if there is any other number of matches besides one.
@@ -119,7 +147,10 @@ Like `scryRenderedDOMComponentsWithClass()` but expects there to be one result, 
 ### scryRenderedDOMComponentsWithTag
 
 ```javascript
-array scryRenderedDOMComponentsWithTag(ReactComponent tree, string tagName)
+array scryRenderedDOMComponentsWithTag(
+  ReactComponent tree,
+  string tagName
+)
 ```
 
 Finds all instances of components in the rendered tree that are DOM components with the tag name matching `tagName`.
@@ -127,7 +158,10 @@ Finds all instances of components in the rendered tree that are DOM components w
 ### findRenderedDOMComponentWithTag
 
 ```javascript
-ReactComponent findRenderedDOMComponentWithTag(ReactComponent tree, string tagName)
+ReactComponent findRenderedDOMComponentWithTag(
+  ReactComponent tree,
+  string tagName
+)
 ```
 
 Like `scryRenderedDOMComponentsWithTag()` but expects there to be one result, and returns that one result, or throws exception if there is any other number of matches besides one.
@@ -135,7 +169,10 @@ Like `scryRenderedDOMComponentsWithTag()` but expects there to be one result, an
 ### scryRenderedComponentsWithType
 
 ```javascript
-array scryRenderedComponentsWithType(ReactComponent tree, function componentClass)
+array scryRenderedComponentsWithType(
+  ReactComponent tree,
+  function componentClass
+)
 ```
 
 Finds all instances of components with type equal to `componentClass`.
@@ -143,7 +180,9 @@ Finds all instances of components with type equal to `componentClass`.
 ### findRenderedComponentWithType
 
 ```javascript
-ReactComponent findRenderedComponentWithType(ReactComponent tree, function componentClass)
+ReactComponent findRenderedComponentWithType(
+  ReactComponent tree, function componentClass
+)
 ```
 
 Same as `scryRenderedComponentsWithType()` but expects there to be one result and returns that one result, or throws exception if there is any other number of matches besides one.
@@ -160,7 +199,9 @@ ReactShallowRenderer createRenderer()
 Call this in your tests to create a shallow renderer. You can think of this as a "place" to render the component you're testing, where it can respond to events and update itself.
 
 ```javascript
-shallowRenderer.render(ReactElement element)
+shallowRenderer.render(
+  ReactElement element
+)
 ```
 
 Similar to `React.render`.


### PR DESCRIPTION
I have been reading the `TestUtils` docs and struggled with a few things, so I made some small improvements:
- Spread out function definitions across multiple lines as its done in the rest of the docs (for example the [Top Level API docs](https://facebook.github.io/react/docs/top-level-api.html)); it's a lot easier to read, especially when dealing with very long function names (e.g. `scryRenderedDOMComponentsWithTag`) which also take parameters
- Used the standard `(required, [optional])` pattern to denote whether a parameter is optional or not