### PR TITLE
[adler32] fix wrong name

### DIFF
--- a/src/shared/utils/__tests__/adler32-test.js
+++ b/src/shared/utils/__tests__/adler32-test.js
@@ -13,7 +13,7 @@
 
 var adler32 = require('adler32');
 
-describe('shallowEqual', function() {
+describe('adler32', function() {
   it('generates differing checksums', function() {
     expect(adler32('foo')).not.toBe(adler32('bar'));
   });


### PR DESCRIPTION
By the way, I can't find where is the implementation of `shallowEqual`.