### PR TITLE
Use eslintrc from fbjs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,76 +1,33 @@
 ---
 parser: babel-eslint
 
+extends:
+  - ./node_modules/fbjs-scripts/eslint/.eslintrc
+
 plugins:
   - react
   - react-internal
 
-env:
-  browser: true
-  node: true
-
-globals:
-  __DEV__: true
-  # Jest / Jasmine
-  describe: false
-  xdescribe: false
-  beforeEach: false
-  afterEach: false
-  it: false
-  xit: false
-  jest: false
-  pit: false
-  expect: false
-  spyOn: false
-  jasmine: false
-
+# We're stricter than the default config, mostly. We'll override a few rules and
+# then enable some React specific ones.
 rules:
-  # ERRORS
-  space-before-blocks: 2
-  indent: [2, 2, {SwitchCase: 1}]
-  brace-style: 2
-  space-after-keywords: 2
-  strict: [2, global]
+  accessor-pairs: 0
+  brace-style: [2, 1tbs]
   comma-dangle: [2, always-multiline]
-  # Make this a warning for now. We do this in a few places so we might need to
-  # disable
-  no-unused-expressions: 2
-  eol-last: 2
-  dot-notation: 2
-  dot-location: [2, property]
   consistent-return: 2
-  no-unused-vars: [2, args: none]
-  quotes: [2, single, avoid-escape]
-  no-shadow: 2
+  dot-location: [2, property]
+  dot-notation: 2
+  eol-last: 2
+  indent: [2, 2, {SwitchCase: 1}]
+  no-bitwise: 0
   no-multi-spaces: 2
-  no-undef: 2
-
-  # WISHLIST. One day...
-  # We'll need a custom version of this that does a subset of the whole rule.
-  # Otherwise this is just too noisy.
-  # valid-jsdoc: 1
-  # Ideally, we could just warn when *new* lines are added that exceed 80 chars
-  # while not warning about existing ones (often URLs, etc. which are
-  # necessarily long), but we don't have a good way to do so.
-  # max-len: [0, 80]
-
-  # DISABLED. These aren't compatible with our style
-  # We use this for private/internal variables
-  no-underscore-dangle: 0
-  # We pass constructors around / access them from members
-  new-cap: 0
-  # We do this a lot.
-  no-use-before-define: 0
-  # We do this in a few places to align values
-  key-spacing: 0
-  # It's nice to be able to leave catch blocks empty
-  no-empty: 0
-  # It makes code more readable to make this explicit sometimes
-  no-undef-init: 0
-
-  # BROKEN. We'd like to turn these back on.
-  # causes a ton of noise, eslint is too picky?
-  block-scoped-var: 0
+  no-shadow: 2
+  no-unused-expressions: 2
+  no-unused-vars: [2, {args: none}]
+  quotes: [2, single, avoid-escape]
+  space-after-keywords: 2
+  space-before-blocks: 2
+  strict: [2, global]
 
   # JSX
   # Our transforms set this automatically

--- a/grunt/config/browserify.js
+++ b/grunt/config/browserify.js
@@ -80,7 +80,7 @@ var min = {
   // No need to derequire because the minifier will mangle
   // the "require" calls.
 
-  after: [/*derequire,*/ minify, bannerify],
+  after: [minify, bannerify],
 };
 
 var transformer = {
@@ -126,7 +126,7 @@ var addonsMin = {
   // No need to derequire because the minifier will mangle
   // the "require" calls.
 
-  after: [/*derequire,*/ minify, bannerify],
+  after: [minify, bannerify],
 };
 
 module.exports = {

--- a/packages/react-codemod/transforms/class.js
+++ b/packages/react-codemod/transforms/class.js
@@ -521,4 +521,4 @@ module.exports = (file, api, options) => {
   }
 
   return null;
-}
+};

--- a/packages/react-codemod/transforms/utils/ReactUtils.js
+++ b/packages/react-codemod/transforms/utils/ReactUtils.js
@@ -36,7 +36,7 @@ module.exports = function(j) {
         },
       })
       .filter(declarator => declarator.value.source.value === module)
-      .size() === 1
+      .size() === 1;
 
   const hasReact = path => (
     hasModule(path, 'React') ||

--- a/src/addons/__tests__/renderSubtreeIntoContainer.js
+++ b/src/addons/__tests__/renderSubtreeIntoContainer.js
@@ -17,7 +17,7 @@ var renderSubtreeIntoContainer = require('renderSubtreeIntoContainer');
 
 describe('renderSubtreeIntoContainer', function() {
 
-  it('should pass context when rendering subtree elsewhere', function () {
+  it('should pass context when rendering subtree elsewhere', function() {
 
     var portal = document.createElement('div');
 
@@ -57,7 +57,7 @@ describe('renderSubtreeIntoContainer', function() {
     expect(portal.firstChild.innerHTML).toBe('bar');
   });
 
-  it('should throw if parentComponent is invalid', function () {
+  it('should throw if parentComponent is invalid', function() {
     var portal = document.createElement('div');
 
     var Component = React.createClass({

--- a/src/isomorphic/classic/class/__tests__/ReactBindOptout-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactBindOptout-test.js
@@ -83,7 +83,7 @@ describe('autobind optout', function() {
   });
 
   it('should not hold reference to instance', function() {
-    var mouseDidClick = function () {
+    var mouseDidClick = function() {
       void this.state.something;
     };
 
@@ -129,11 +129,11 @@ describe('autobind optout', function() {
 
     expect(mountedInstance1.onClick).toBe(mountedInstance2.onClick);
 
-    expect(function () {
+    expect(function() {
       ReactTestUtils.Simulate.click(rendered1);
     }).toThrow();
 
-    expect(function () {
+    expect(function() {
       ReactTestUtils.Simulate.click(rendered2);
     }).toThrow();
   });

--- a/src/isomorphic/classic/element/__tests__/ReactElement-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElement-test.js
@@ -142,7 +142,9 @@ describe('ReactElement', function() {
 
   it('merges rest arguments onto the children prop in an array', function() {
     spyOn(console, 'error');
-    var a = 1, b = 2, c = 3;
+    var a = 1;
+    var b = 2;
+    var c = 3;
     var element = React.createFactory(ComponentClass)(null, a, b, c);
     expect(element.props.children).toEqual([1, 2, 3]);
     expect(console.error.argsForCall.length).toBe(0);

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -212,7 +212,7 @@ describe('ReactElementValidator', function() {
     spyOn(console, 'error');
     var Component = React.createFactory(ComponentClass);
 
-    Component(null, [ {}, {} ]);
+    Component(null, [{}, {}]);
 
     expect(console.error.argsForCall.length).toBe(0);
   });

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElement-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElement-test.js
@@ -119,7 +119,9 @@ describe('ReactJSXElement', function() {
 
   it('merges JSX children onto the children prop in an array', function() {
     spyOn(console, 'error');
-    var a = 1, b = 2, c = 3;
+    var a = 1;
+    var b = 2;
+    var c = 3;
     var element = <Component>{a}{b}{c}</Component>;
     expect(element.props.children).toEqual([1, 2, 3]);
     expect(console.error.argsForCall.length).toBe(0);

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -168,7 +168,7 @@ describe('ReactJSXElementValidator', function() {
   it('does not warn when the child array contains non-elements', function() {
     spyOn(console, 'error');
 
-    void <Component>{[ {}, {} ]}</Component>;
+    void <Component>{[{}, {}]}</Component>;
 
     expect(console.error.argsForCall.length).toBe(0);
   });

--- a/src/renderers/dom/client/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMount-test.js
@@ -145,7 +145,7 @@ describe('ReactMount', function() {
     expect(console.error.calls.length).toBe(0);
   });
 
-  it('should warn when mounting into document.body', function () {
+  it('should warn when mounting into document.body', function() {
     var iFrame = document.createElement('iframe');
     document.body.appendChild(iFrame);
     spyOn(console, 'error');
@@ -158,7 +158,7 @@ describe('ReactMount', function() {
     );
   });
 
-  it('should account for escaping on a checksum mismatch', function () {
+  it('should account for escaping on a checksum mismatch', function() {
     var div = document.createElement('div');
     var markup = ReactDOMServer.renderToString(
       <div>This markup contains an nbsp entity: &nbsp; server text</div>);

--- a/src/renderers/dom/client/wrappers/LinkedValueUtils.js
+++ b/src/renderers/dom/client/wrappers/LinkedValueUtils.js
@@ -103,7 +103,7 @@ function getDeclarationErrorAddendum(owner) {
  * this outside of the ReactDOM controlled form components.
  */
 var LinkedValueUtils = {
-  checkPropTypes: function (tagName, props, owner) {
+  checkPropTypes: function(tagName, props, owner) {
     for (var propName in propTypes) {
       if (propTypes.hasOwnProperty(propName)) {
         var error = propTypes[propName](

--- a/src/renderers/shared/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
+++ b/src/renderers/shared/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
@@ -216,7 +216,7 @@ var oneEventLoopTestConfig = function(readableIDToID) {
  */
 var registerTestHandlers = function(eventTestConfig, readableIDToID) {
   var runs = {dispatchCount: 0};
-  var neverFire = function (readableID, registrationName) {
+  var neverFire = function(readableID, registrationName) {
     runs.dispatchCount++;
     expect('').toBe(
       'Event type: ' + registrationName +

--- a/src/renderers/shared/reconciler/__tests__/ReactComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactComponent-test.js
@@ -51,7 +51,8 @@ describe('ReactComponent', function() {
   });
 
   it('should support refs on owned components', function() {
-    var innerObj = {}, outerObj = {};
+    var innerObj = {};
+    var outerObj = {};
 
     var Wrapper = React.createClass({
 
@@ -101,7 +102,8 @@ describe('ReactComponent', function() {
   });
 
   it('should support new-style refs', function() {
-    var innerObj = {}, outerObj = {};
+    var innerObj = {};
+    var outerObj = {};
 
     var Wrapper = React.createClass({
       getObject: function() {

--- a/src/renderers/shared/reconciler/__tests__/ReactComponentLifeCycle-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactComponentLifeCycle-test.js
@@ -285,7 +285,7 @@ describe('ReactComponentLifeCycle', function() {
     );
   });
 
-  it('isMounted should return false when unmounted', function () {
+  it('isMounted should return false when unmounted', function() {
     var Component = React.createClass({
       render: function() {
         return <div/>;

--- a/src/renderers/shared/reconciler/__tests__/ReactMultiChildReconcile-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactMultiChildReconcile-test.js
@@ -283,7 +283,7 @@ describe('ReactMultiChildReconcile', function() {
       bob: 'bobStatus',
     };
 
-    testPropsSequence([ {usernameToStatus: usernameToStatus} ]);
+    testPropsSequence([{usernameToStatus: usernameToStatus}]);
   });
 
   it('should preserve order if children order has not changed', function() {

--- a/src/shared/utils/__tests__/adler32-test.js
+++ b/src/shared/utils/__tests__/adler32-test.js
@@ -29,7 +29,7 @@ describe('adler32', function() {
   it('doesn\'t barf on large inputs', function() {
     var str = '';
     for (var i = 0; i < 100000; i++) {
-      str = str + 'This will be repeated to be very large indeed. ';
+      str += 'This will be repeated to be very large indeed. ';
     }
     expect(adler32(str)).toBe(692898118);
   });

--- a/src/shared/utils/traverseAllChildren.js
+++ b/src/shared/utils/traverseAllChildren.js
@@ -184,7 +184,7 @@ function traverseAllChildrenImpl(
         if (ReactCurrentOwner.current) {
           var name = ReactCurrentOwner.current.getName();
           if (name) {
-            addendum = ' Check the render method of `' + name + '`.'
+            addendum = ' Check the render method of `' + name + '`.';
           }
         }
       }


### PR DESCRIPTION
This brings us up to date with most of our internal lint settings. Importantly it makes sure that we have settings defined for all the rules we care about. I missed that in the upgrade to eslint@^1.0 we lost the default config. Rather than just extend the recommended config, I took the opportunity to go all the way and sync out our config to fbjs.

Depends on https://github.com/facebook/fbjs/pull/49.

Note: this should definitely fail Travis until I publish fbjs