### PR TITLE
Don't crash in event handling when mixing React copies

### DIFF
--- a/src/renderers/dom/client/ReactEventListener.js
+++ b/src/renderers/dom/client/ReactEventListener.js
@@ -112,11 +112,13 @@ function handleTopLevelWithPath(bookKeeping) {
   var eventsFired = 0;
   for (var i = 0; i < path.length; i++) {
     var currentPathElement = path[i];
-    var currentPathElementID = ReactMount.getID(currentPathElement);
     if (currentPathElement.nodeType === DOCUMENT_FRAGMENT_NODE_TYPE) {
       currentNativeTarget = path[i + 1];
     }
-    if (ReactMount.isRenderedByReact(currentPathElement)) {
+    // TODO: slow
+    var reactParent = ReactMount.getFirstReactDOM(currentPathElement);
+    if (reactParent === currentPathElement) {
+      var currentPathElementID = ReactMount.getID(currentPathElement);
       var newRootID = ReactInstanceHandles.getReactRootIDFromNodeID(
         currentPathElementID
       );

--- a/src/renderers/dom/client/__tests__/ReactBrowserEventEmitter-test.js
+++ b/src/renderers/dom/client/__tests__/ReactBrowserEventEmitter-test.js
@@ -21,7 +21,8 @@ var setID = function(el, id) {
   ReactMount.setID(el, id);
   idToNode[id] = el;
 };
-var oldGetNode = ReactMount.getNode;
+var oldGetNode;
+var oldGetFirstReactDOM;
 
 var EventPluginHub;
 var ReactBrowserEventEmitter;
@@ -83,9 +84,16 @@ describe('ReactBrowserEventEmitter', function() {
     EventListener = require('EventListener');
     ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
     ReactTestUtils = require('ReactTestUtils');
+
+    oldGetNode = ReactMount.getNode;
+    oldGetFirstReactDOM = ReactMount.oldGetFirstReactDOM;
     ReactMount.getNode = function(id) {
       return idToNode[id];
     };
+    ReactMount.getFirstReactDOM = function(node) {
+      return node;
+    };
+
     idCallOrder = [];
     tapMoveThreshold = TapEventPlugin.tapMoveThreshold;
     EventPluginHub.injection.injectEventPluginsByName({
@@ -95,6 +103,7 @@ describe('ReactBrowserEventEmitter', function() {
 
   afterEach(function() {
     ReactMount.getNode = oldGetNode;
+    ReactMount.getFirstReactDOM = oldGetFirstReactDOM;
   });
 
   it('should store a listener correctly', function() {

--- a/src/renderers/dom/client/eventPlugins/EnterLeaveEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/EnterLeaveEventPlugin.js
@@ -89,24 +89,30 @@ var EnterLeaveEventPlugin = {
       }
     }
 
-    var from, to;
+    var from;
+    var to;
+    var fromID = '';
+    var toID = '';
     if (topLevelType === topLevelTypes.topMouseOut) {
       from = topLevelTarget;
-      to =
-        getFirstReactDOM(nativeEvent.relatedTarget || nativeEvent.toElement) ||
-        win;
+      fromID = topLevelTargetID;
+      to = getFirstReactDOM(nativeEvent.relatedTarget || nativeEvent.toElement);
+      if (to) {
+        toID = ReactMount.getID(to);
+      } else {
+        to = win;
+      }
+      to = to || win;
     } else {
       from = win;
       to = topLevelTarget;
+      toID = topLevelTargetID;
     }
 
     if (from === to) {
       // Nothing pertains to our managed components.
       return null;
     }
-
-    var fromID = from ? ReactMount.getID(from) : '';
-    var toID = to ? ReactMount.getID(to) : '';
 
     var leave = SyntheticMouseEvent.getPooled(
       eventTypes.mouseLeave,

--- a/src/renderers/dom/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMInput.js
@@ -141,6 +141,10 @@ function _handleChange(event) {
           otherNode.form !== rootNode.form) {
         continue;
       }
+      // This will throw if radio buttons rendered by different copies of React
+      // and the same name are rendered into the same form (same as #1939).
+      // That's probably okay; we don't support it just as we don't support
+      // mixing React with non-React.
       var otherID = ReactMount.getID(otherNode);
       invariant(
         otherID,

--- a/src/renderers/shared/reconciler/__tests__/ReactInstanceHandles-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactInstanceHandles-test.js
@@ -74,14 +74,6 @@ describe('ReactInstanceHandles', function() {
     aggregatedArgs = [];
   });
 
-  describe('isRenderedByReact', function() {
-    it('should not crash on text nodes', function() {
-      expect(function() {
-        ReactMount.isRenderedByReact(document.createTextNode('yolo'));
-      }).not.toThrow();
-    });
-  });
-
   describe('findComponentRoot', function() {
     it('should find the correct node with prefix sibling IDs', function() {
       var parentNode = document.createElement('div');


### PR DESCRIPTION
Should fix #1939.

Test Plan:
With two copies of React, render a div using React1 and use that as a container to render a div with React2. Add onMouseEnter/onMouseLeave to both divs that log. Mouse around and see correct logs (as if each React was isolated), no errors.