### PR TITLE
Update warning messages to use ReactDOM and ReactDOMServer as appropriate

### DIFF
--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -61,7 +61,7 @@ function warnSetProps() {
     warning(
       false,
       'setProps(...) and replaceProps(...) are deprecated. ' +
-      'Instead, call React.render again at the top level.'
+      'Instead, call render again at the top level.'
     );
   }
 }

--- a/src/isomorphic/classic/class/__tests__/ReactClass-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactClass-test.js
@@ -381,7 +381,7 @@ describe('ReactClass-spec', function() {
     expect(console.error.calls.length).toBe(1);
     expect(console.error.calls[0].args[0]).toContain(
       'MyComponent.getDOMNode(...) is deprecated. Please use ' +
-      'React.findDOMNode(instance) instead.'
+      'ReactDOM.findDOMNode(instance) instead.'
     );
   });
 

--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -93,7 +93,7 @@ function getAddendaForKeyUse(messageType, element, parentType) {
     var parentName = typeof parentType === 'string' ?
       parentType : parentType.displayName || parentType.name;
     if (parentName) {
-      addendum = ` Check the React.render call using <${parentName}>.`;
+      addendum = ` Check the top-level render call using <${parentName}>.`;
     }
   }
 

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -113,7 +113,7 @@ describe('ReactElementValidator', function() {
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toBe(
       'Warning: Each child in an array or iterator should have a unique ' +
-      '"key" prop. Check the React.render call using <div>. See ' +
+      '"key" prop. Check the top-level render call using <div>. See ' +
       'https://fb.me/react-warning-keys for more information.'
     );
   });

--- a/src/isomorphic/modern/class/ReactComponent.js
+++ b/src/isomorphic/modern/class/ReactComponent.js
@@ -105,7 +105,7 @@ if (__DEV__) {
   var deprecatedAPIs = {
     getDOMNode: [
       'getDOMNode',
-      'Use React.findDOMNode(component) instead.',
+      'Use ReactDOM.findDOMNode(component) instead.',
     ],
     isMounted: [
       'isMounted',
@@ -114,7 +114,7 @@ if (__DEV__) {
     ],
     replaceProps: [
       'replaceProps',
-      'Instead, call React.render again at the top level.',
+      'Instead, call render again at the top level.',
     ],
     replaceState: [
       'replaceState',
@@ -123,7 +123,7 @@ if (__DEV__) {
     ],
     setProps: [
       'setProps',
-      'Instead, call React.render again at the top level.',
+      'Instead, call render again at the top level.',
     ],
   };
   var defineDeprecationWarning = function(methodName, info) {

--- a/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
+++ b/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
@@ -411,7 +411,7 @@ describe('ReactES6Class', function() {
     expect(console.error.calls.length).toBe(5);
     expect(console.error.calls[0].args[0]).toContain(
       'getDOMNode(...) is deprecated in plain JavaScript React classes. ' +
-      'Use React.findDOMNode(component) instead.'
+      'Use ReactDOM.findDOMNode(component) instead.'
     );
     expect(console.error.calls[1].args[0]).toContain(
       'replaceState(...) is deprecated in plain JavaScript React classes'

--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -531,7 +531,7 @@ var ReactMount = {
   _renderSubtreeIntoContainer: function(parentComponent, nextElement, container, callback) {
     invariant(
       ReactElement.isValidElement(nextElement),
-      'React.render(): Invalid component element.%s',
+      'ReactDOM.render(): Invalid component element.%s',
       (
         typeof nextElement === 'string' ?
           ' Instead of passing an element string, make sure to instantiate ' +
@@ -982,7 +982,7 @@ var ReactMount = {
       'You\'re trying to render a component to the document but ' +
         'you didn\'t use server rendering. We can\'t do this ' +
         'without using server rendering due to cross-browser quirks. ' +
-        'See React.renderToString() for server rendering.'
+        'See ReactDOMServer.renderToString() for server rendering.'
     );
 
     if (transaction.useCreateElement) {

--- a/src/renderers/dom/client/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMount-test.js
@@ -47,7 +47,7 @@ describe('ReactMount', function() {
     expect(function() {
       ReactTestUtils.renderIntoDocument('div');
     }).toThrow(
-      'Invariant Violation: React.render(): Invalid component element. ' +
+      'Invariant Violation: ReactDOM.render(): Invalid component element. ' +
       'Instead of passing an element string, make sure to instantiate it ' +
       'by passing it to React.createElement.'
     );
@@ -62,7 +62,7 @@ describe('ReactMount', function() {
     expect(function() {
       ReactTestUtils.renderIntoDocument(Component);
     }).toThrow(
-      'Invariant Violation: React.render(): Invalid component element. ' +
+      'Invariant Violation: ReactDOM.render(): Invalid component element. ' +
       'Instead of passing a component class, make sure to instantiate it ' +
       'by passing it to React.createElement.'
     );

--- a/src/renderers/dom/client/__tests__/ReactRenderDocument-test.js
+++ b/src/renderers/dom/client/__tests__/ReactRenderDocument-test.js
@@ -244,7 +244,7 @@ describe('rendering React components at document', function() {
       'Invariant Violation: You\'re trying to render a component to the ' +
       'document but you didn\'t use server rendering. We can\'t do this ' +
       'without using server rendering due to cross-browser quirks. See ' +
-      'React.renderToString() for server rendering.'
+      'ReactDOMServer.renderToString() for server rendering.'
     );
   });
 

--- a/src/renderers/dom/shared/Danger.js
+++ b/src/renderers/dom/shared/Danger.js
@@ -54,7 +54,7 @@ var Danger = {
       'dangerouslyRenderMarkup(...): Cannot render markup in a worker ' +
       'thread. Make sure `window` and `document` are available globally ' +
       'before requiring React when unit testing or use ' +
-      'React.renderToString for server rendering.'
+      'ReactDOMServer.renderToString for server rendering.'
     );
     var nodeName;
     var markupByNodeName = {};
@@ -161,7 +161,7 @@ var Danger = {
       'dangerouslyReplaceNodeWithMarkup(...): Cannot render markup in a ' +
       'worker thread. Make sure `window` and `document` are available ' +
       'globally before requiring React when unit testing or use ' +
-      'React.renderToString for server rendering.'
+      'ReactDOMServer.renderToString() for server rendering.'
     );
     invariant(markup, 'dangerouslyReplaceNodeWithMarkup(...): Missing markup.');
     invariant(
@@ -169,7 +169,7 @@ var Danger = {
       'dangerouslyReplaceNodeWithMarkup(...): Cannot replace markup of the ' +
       '<html> node. This is because browser quirks make this unreliable ' +
       'and/or slow. If you want to render to the root you must use ' +
-      'server rendering. See React.renderToString().'
+      'server rendering. See ReactDOMServer.renderToString().'
     );
 
     var newChild;

--- a/src/renderers/dom/shared/ReactBrowserComponentMixin.js
+++ b/src/renderers/dom/shared/ReactBrowserComponentMixin.js
@@ -30,7 +30,7 @@ var ReactBrowserComponentMixin = {
     warning(
       this.constructor[didWarnKey],
       '%s.getDOMNode(...) is deprecated. Please use ' +
-      'React.findDOMNode(instance) instead.',
+      'ReactDOM.findDOMNode(instance) instead.',
       ReactInstanceMap.get(this).getName() || this.tagName || 'Unknown'
     );
     this.constructor[didWarnKey] = true;

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -138,7 +138,7 @@ function legacySetProps(partialProps, callback) {
     warning(
       false,
       'ReactDOMComponent: Do not access .setProps() of a DOM node. ' +
-      'Instead, call React.render again at the top level.%s',
+      'Instead, call ReactDOM.render again at the top level.%s',
       getDeclarationErrorAddendum(component)
     );
   }
@@ -157,7 +157,7 @@ function legacyReplaceProps(partialProps, callback) {
     warning(
       false,
       'ReactDOMComponent: Do not access .replaceProps() of a DOM node. ' +
-      'Instead, call React.render again at the top level.%s',
+      'Instead, call ReactDOM.render again at the top level.%s',
       getDeclarationErrorAddendum(component)
     );
   }

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -1019,11 +1019,11 @@ describe('ReactDOMComponent', function() {
       expect(console.error.calls.length).toBe(2);
       expect(console.error.calls[0].args[0]).toBe(
         'Warning: ReactDOMComponent: Do not access .setProps() of a DOM node. ' +
-        'Instead, call React.render again at the top level.'
+        'Instead, call ReactDOM.render again at the top level.'
       );
       expect(console.error.calls[1].args[0]).toBe(
         'Warning: ReactDOMComponent: Do not access .replaceProps() of a DOM ' +
-        'node. Instead, call React.render again at the top level.'
+        'node. Instead, call ReactDOM.render again at the top level.'
       );
     });
 

--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -457,7 +457,7 @@ var ReactCompositeComponentMixin = {
         }
         if (error instanceof Error) {
           // We may want to extend this logic for similar errors in
-          // React.render calls, so I'm abstracting it away into
+          // top-level render calls, so I'm abstracting it away into
           // a function to minimize refactoring in the future
           var addendum = getDeclarationErrorAddendum(this);
 
@@ -822,7 +822,7 @@ var ReactCompositeComponentMixin = {
 
   /**
    * Get the publicly accessible representation of this component - i.e. what
-   * is exposed by refs and returned by React.render. Can be null for stateless
+   * is exposed by refs and returned by render. Can be null for stateless
    * components.
    *
    * @return {ReactComponent} the public component instance.

--- a/src/renderers/shared/reconciler/__tests__/ReactComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactComponent-test.js
@@ -284,7 +284,7 @@ describe('ReactComponent', function() {
     expect(console.error.calls.length).toBe(1);
     expect(console.error.calls[0].args[0]).toContain(
       'Potato.getDOMNode(...) is deprecated. Please use ' +
-      'React.findDOMNode(instance) instead.'
+      'ReactDOM.findDOMNode(instance) instead.'
     );
   });
 

--- a/src/renderers/shared/reconciler/__tests__/ReactEmptyComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactEmptyComponent-test.js
@@ -230,7 +230,7 @@ describe('ReactEmptyComponent', function() {
     expect(function() {
       ReactDOM.render(null, div);
     }).toThrow(
-      'Invariant Violation: React.render(): Invalid component element.'
+      'Invariant Violation: ReactDOM.render(): Invalid component element.'
     );
   });
 


### PR DESCRIPTION
Fixes #4710.

- `React.findDOMNode` => `ReactDOM.findDOMNode`
- `React.render` => `ReactDOM.render` or "top-level render" (depends on whether we're in DOM-specific usage or generic cases)
- `React.renderToString` => `ReactDOMServer.renderToString`
- `React.renderToStaticMarkup` => `ReactDOMServer.renderToStaticMarkup`