### PR TITLE
Add linting pre-commit hook

### DIFF
--- a/scripts/git/pre-commit
+++ b/scripts/git/pre-commit
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# To enable this hook, symlink or copy this file to .git/hooks/pre-commit.
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+# Redirect output to stderr.
+exec 1>&2
+
+git diff --cached --name-only --diff-filter=ACMRTUB | \
+  grep '\.js$' | \
+  xargs ./node_modules/.bin/eslint --


### PR DESCRIPTION
Anyone who wants it will have to do

```
ln -s scripts/git/pre-commit .git/hooks/pre-commit
```

or similar.