### PR TITLE
Support CSS3 Grid Layout Module for inline styles

### DIFF
--- a/src/renderers/dom/shared/CSSProperty.js
+++ b/src/renderers/dom/shared/CSSProperty.js
@@ -26,6 +26,8 @@ var isUnitlessNumber = {
   flexShrink: true,
   flexNegative: true,
   flexOrder: true,
+  gridRow: true,
+  gridColumn: true,
   fontWeight: true,
   lineClamp: true,
   lineHeight: true,

--- a/src/renderers/dom/shared/__tests__/CSSProperty-test.js
+++ b/src/renderers/dom/shared/__tests__/CSSProperty-test.js
@@ -24,6 +24,8 @@ describe('CSSProperty', function() {
     expect(CSSProperty.isUnitlessNumber.WebkitLineClamp).toBeTruthy();
     expect(CSSProperty.isUnitlessNumber.msFlexGrow).toBeTruthy();
     expect(CSSProperty.isUnitlessNumber.MozFlexGrow).toBeTruthy();
+    expect(CSSProperty.isUnitlessNumber.msGridRow).toBeTruthy();
+    expect(CSSProperty.isUnitlessNumber.msGridColumn).toBeTruthy();
   });
 
 });


### PR DESCRIPTION
The gridRow and gridColumn styles are numerical but should be treated as unitless. Currently React is appending the px suffix causing them to be invalid.