### PR TITLE
Add console message to get devtools for firefox

### DIFF
--- a/src/renderers/dom/ReactDOM.js
+++ b/src/renderers/dom/ReactDOM.js
@@ -59,10 +59,12 @@ if (__DEV__) {
   var ExecutionEnvironment = require('ExecutionEnvironment');
   if (ExecutionEnvironment.canUseDOM && window.top === window.self) {
 
-    // If we're in Chrome, look for the devtools marker and provide a download
-    // link if not installed.
-    if (navigator.userAgent.indexOf('Chrome') > -1) {
-      if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === 'undefined') {
+    // First check if devtools is not installed
+    if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === 'undefined') {
+      // If we're in Chrome or Firefox, provide a download link if not installed.
+      if ((navigator.userAgent.indexOf('Chrome') > -1 &&
+          navigator.userAgent.indexOf('Edge') === -1) ||
+          navigator.userAgent.indexOf('Firefox') > -1) {
         console.debug(
           'Download the React DevTools for a better development experience: ' +
           'https://fb.me/react-devtools'


### PR DESCRIPTION
Resolves issue #4774 now that devtools for Firefox is available. Also will no longer alert Edge users to get devtools.