### PR TITLE
bump 'jest-cli' to avoid 'node-gyp rebuild'

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "gulp-flatten": "^0.1.0",
     "gulp-util": "^3.0.5",
     "gzip-js": "~0.3.2",
-    "jest-cli": "^0.4.13",
+    "jest-cli": "^0.5.2",
     "jstransform": "^11.0.0",
     "object-assign": "^3.0.0",
     "optimist": "^0.6.1",


### PR DESCRIPTION
Rebuilding 'contextify' (deps from old 'jsdom') on Windows and even on Linux could be problematic (#3744). Bump solves it because current  version of jsdom do not use 'contextify' anymore and 'jest-cli'@0.5.x has dependecy on 'jsdom' without earlier mentioned plugin. 

But there is a restriction that new 'jest-cli' will be working only on iojs >= 2 so accepting that PR is totally up to you and your perferences.