### PR TITLE
Add hooks for ReactTransitionGroup

### DIFF
--- a/docs/docs/10.1-animation.md
+++ b/docs/docs/10.1-animation.md
@@ -250,3 +250,13 @@ Any additional, user-defined, properties will become properties of the rendered 
   ...
 </ReactTransitionGroup>
 ```
+
+### Notifying parent component
+
+Both `ReactCSSTransitionGroup` and the low-level `ReactTransitionGroup` accept the following callbacks as props:
+
+ - `afterAppear={function (key) {}}`
+ - `afterEnter={function (key) {}}`
+ - `afterLeave={function (key) {}}`
+
+Where the `key` argument is the original key you used for your item. These will be called after the specified transition has occured.

--- a/src/addons/transitions/ReactCSSTransitionGroup.js
+++ b/src/addons/transitions/ReactCSSTransitionGroup.js
@@ -56,6 +56,10 @@ var ReactCSSTransitionGroup = React.createClass({
     transitionAppearTimeout: createTransitionTimeoutPropValidator('Appear'),
     transitionEnterTimeout: createTransitionTimeoutPropValidator('Enter'),
     transitionLeaveTimeout: createTransitionTimeoutPropValidator('Leave'),
+
+    afterAppear: React.PropTypes.func,
+    afterEnter: React.PropTypes.func,
+    afterLeave: React.PropTypes.func,
   },
 
   getDefaultProps: function() {

--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -23,6 +23,10 @@ var ReactTransitionGroup = React.createClass({
   propTypes: {
     component: React.PropTypes.any,
     childFactory: React.PropTypes.func,
+
+    afterAppear: React.PropTypes.func,
+    afterEnter: React.PropTypes.func,
+    afterLeave: React.PropTypes.func,
   },
 
   getDefaultProps: function() {
@@ -117,6 +121,10 @@ var ReactTransitionGroup = React.createClass({
       component.componentDidAppear();
     }
 
+    if (this.props.afterAppear) {
+      this.props.afterAppear(component.props.children.key);
+    }
+
     delete this.currentlyTransitioningKeys[key];
 
     var currentChildMapping = ReactTransitionChildMapping.getChildMapping(
@@ -147,6 +155,10 @@ var ReactTransitionGroup = React.createClass({
     var component = this.refs[key];
     if (component.componentDidEnter) {
       component.componentDidEnter();
+    }
+
+    if (this.props.afterEnter) {
+      this.props.afterEnter(component.props.children.key);
     }
 
     delete this.currentlyTransitioningKeys[key];
@@ -180,6 +192,10 @@ var ReactTransitionGroup = React.createClass({
 
     if (component.componentDidLeave) {
       component.componentDidLeave();
+    }
+
+    if (this.props.afterLeave) {
+      this.props.afterLeave(component.props.children.key);
     }
 
     delete this.currentlyTransitioningKeys[key];

--- a/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
@@ -252,4 +252,103 @@ describe('ReactCSSTransitionGroup', function() {
     var leavingNode = ReactDOM.findDOMNode(a).childNodes[0];
     expect(CSSCore.hasClass(leavingNode, 'custom-leaving')).toBe(true);
   });
+
+  it('should call afterAppear', function() {
+    var callback = jest.genMockFunction();
+
+    var a = ReactDOM.render(
+      <ReactCSSTransitionGroup
+        transitionName="yolo"
+        transitionAppear={true}
+        transitionEnter={false}
+        transitionLeave={false}
+        transitionAppearTimeout={210}
+        afterAppear={callback}
+      >
+        <span key="one" id="one" />
+      </ReactCSSTransitionGroup>,
+      container
+    );
+    expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);
+
+    // Wait for the timer
+    for (var i = 0; i < setTimeout.mock.calls.length; i++) {
+      if (setTimeout.mock.calls[i][1] === 210) {
+        setTimeout.mock.calls[i][0]();
+        break;
+      }
+    }
+
+    expect(callback).toBeCalledWith('one');
+  });
+
+  it('should call afterEnter/afterLeave', function() {
+    var afterEnter = jest.genMockFunction();
+    var afterLeave = jest.genMockFunction();
+
+    var a = ReactDOM.render(
+      <ReactCSSTransitionGroup
+        transitionName="yolo"
+        transitionEnterTimeout={211}
+        transitionLeaveTimeout={212}
+        afterEnter={afterEnter}
+        afterLeave={afterLeave}
+      >
+        <span key="one" id="one" />
+      </ReactCSSTransitionGroup>,
+      container
+    );
+    expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);
+
+    // Add an element
+    ReactDOM.render(
+      <ReactCSSTransitionGroup
+        transitionName="yolo"
+        transitionEnterTimeout={211}
+        transitionLeaveTimeout={212}
+        afterEnter={afterEnter}
+        afterLeave={afterLeave}
+      >
+        <span key="one" id="one" />
+        <span key="two" id="two" />
+      </ReactCSSTransitionGroup>,
+      container
+    );
+    expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(2);
+
+    // Wait for the timer
+    for (var i = 0; i < setTimeout.mock.calls.length; i++) {
+      if (setTimeout.mock.calls[i][1] === 211) {
+        setTimeout.mock.calls[i][0]();
+        break;
+      }
+    }
+
+    expect(afterEnter).toBeCalledWith('two');
+
+    // Remove an element
+    ReactDOM.render(
+      <ReactCSSTransitionGroup
+        transitionName="yolo"
+        transitionEnterTimeout={211}
+        transitionLeaveTimeout={212}
+        afterEnter={afterEnter}
+        afterLeave={afterLeave}
+      >
+        <span key="two" id="two" />
+      </ReactCSSTransitionGroup>,
+      container
+    );
+    expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(2);
+
+    // Wait for the timer
+    for (var j = 0; j < setTimeout.mock.calls.length; j++) {
+      if (setTimeout.mock.calls[j][1] === 212) {
+        setTimeout.mock.calls[j][0]();
+        break;
+      }
+    }
+
+    expect(afterLeave).toBeCalledWith('one');
+  });
 });


### PR DESCRIPTION
This adds 3 new optional props for `ReactCSSTransitionGroup` and `ReactTransitionGroup`.

- `afterAppear={function (key) {}}`
- `afterEnter={function (key) {}}`
- `afterLeave={function (key) {}}`

Where the `key` argument is the original key used for the transitioning child. These will be called after the specified transition has occured.

Also contains tests and docs update