### PR TITLE
[docs] Use a generator to assign complete author data before generating site

### DIFF
--- a/docs/_includes/blog_post.html
+++ b/docs/_includes/blog_post.html
@@ -1,5 +1,4 @@
 {% assign page = include.page %}
-{% assign author = site.data.authors[page.author] %}
 
 <h1>
 {% if include.isPermalink %}
@@ -12,10 +11,10 @@
 <p class="meta">
   {{ page.date | date: "%B %e, %Y" }}
   by
-  {% if author.url %}
-    <a href="{{author.url}}">{{ author.name }}</a>
+  {% if page.author.url %}
+    <a href="{{page.author.url}}">{{ page.author.name }}</a>
   {% else %}
-    {{ author.name }}
+    {{ page.author.name }}
   {% endif %}
 </p>
 

--- a/docs/_plugins/authors.rb
+++ b/docs/_plugins/authors.rb
@@ -1,0 +1,14 @@
+# This transforms the data associated with each post, specifically the author.
+# We store our author information in a yaml file and specify the keys in The
+# post front matter. Instead of looking up the complete data each time we need
+# it, we'll just look it up here and assign. This plays nicely with tools like
+# jekyll-feed which expect post.author to be in a specific format.
+module Authors
+  class Generator < Jekyll::Generator
+    def generate(site)
+      site.posts.each do |post|
+        post.data['author'] = site.data['authors'][post['author']]
+      end
+    end
+  end
+end

--- a/docs/blog/all.html
+++ b/docs/blog/all.html
@@ -9,8 +9,7 @@ id: all-posts
   <div class="inner-content">
     <h1>All Posts</h1>
     {% for page in site.posts %}
-      {% assign author = site.data.authors[page.author] %}
-      <p><strong><a href="/react{{ page.url }}">{{ page.title }}</a></strong> on {{ page.date | date: "%B %e, %Y" }} by {{ author.name }}</p>
+      <p><strong><a href="/react{{ page.url }}">{{ page.title }}</a></strong> on {{ page.date | date: "%B %e, %Y" }} by {{ page.author.name }}</p>
     {% endfor %}
   </div>
 </section>


### PR DESCRIPTION
~~I may have gotten distracted by https://github.com/blog/2053-easier-feeds-for-github-pages … sorry.~~

~~FWIW, here's the diff of the feeds: https://gist.github.com/zpao/a11adf27d2432f473847. The important pieces (content title, body) are identical.~~

Just making it easier to consume author data consistently by using a generator to assign author data to the post.