### PR TITLE
Updated for new 'react-addons-css-transition-group' package

### DIFF
--- a/docs/docs/10.1-animation.md
+++ b/docs/docs/10.1-animation.md
@@ -17,7 +17,7 @@ React provides a `ReactTransitionGroup` addon component as a low-level API for a
 `ReactCSSTransitionGroup` is the interface to `ReactTransitions`. This is a simple element that wraps all of the components you are interested in animating. Here's an example where we fade list items in and out.
 
 ```javascript{28-30}
-var ReactCSSTransitionGroup = React.addons.CSSTransitionGroup;
+var ReactCSSTransitionGroup = require('react-addons-css-transition-group');
 
 var TodoList = React.createClass({
   getInitialState: function() {


### PR DESCRIPTION
As of 0.14, `react-addons-css-transition-group` is in it's own package and add ons doesn't come with React.