### PR TITLE
[docs] Add jsfiddle integration for Babel

### DIFF
--- a/docs/js/jsfiddle-integration-babel.js
+++ b/docs/js/jsfiddle-integration-babel.js
@@ -1,0 +1,10 @@
+(function() {
+  var tag = document.querySelector(
+    'script[type="application/javascript;version=1.7"]'
+  );
+  if (!tag || tag.textContent.indexOf('window.onload=function(){') !== -1) {
+    alert('Bad JSFiddle configuration, please fork the original React JSFiddle');
+  }
+  tag.setAttribute('type', 'text/babel');
+  tag.textContent = tag.textContent.replace(/^\/\/<!\[CDATA\[/, '');
+})();


### PR DESCRIPTION
I already updated the "latest" fiddle with this (serving from my server for now). http://jsfiddle.net/reactjs/ghmpo42k/

I don't think we can just update the existing integration - there are too many fiddles in the wild that will break.