### PR TITLE
Support native arrow functions as stateless components

### DIFF
--- a/src/renderers/shared/reconciler/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactStatelessComponent-test.js
@@ -183,4 +183,19 @@ describe('ReactStatelessComponent', function() {
     ReactDOM.render(<Parent />, el);
     expect(el.textContent).toBe('en');
   });
+
+  it('should work with arrow functions', function() {
+    // TODO: actually use arrow functions, probably need node v4 and maybe
+    // a separate file that we blacklist from the arrow function transform.
+    // We can't actually test this without native arrow functions since the
+    // issues (non-newable) don't apply to any other functions.
+    var Child = function() {
+      return <div />;
+    };
+    // Will create a new bound function without a prototype, much like a native
+    // arrow function.
+    Child = Child.bind(this);
+
+    expect(() => ReactTestUtils.renderIntoDocument(<Child />)).not.toThrow();
+  });
 });


### PR DESCRIPTION
I tested this with arrow functions in Chrome (just modified the non-transforming basic example).

We could simulate part of the issue with arrow functions in the test (undefined prototype), but not the newable part. So we'll want a proper test when we can switch to node 4 and have some tests that don't transform.

Fixes #4856