### PR TITLE
Better simulate Symbol-less environment

### DIFF
--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -17,8 +17,9 @@ var assign = require('Object.assign');
 
 // The Symbol used to tag the ReactElement type. If there is no native Symbol
 // nor polyfill, then a plain number is used for performance.
-var TYPE_SYMBOL = (typeof Symbol === 'function' && Symbol.for &&
-                  Symbol.for('react.element')) || 0xeac7;
+var TYPE_SYMBOL =
+  (typeof Symbol === 'function' && Symbol.for && Symbol.for('react.element')) ||
+  0xeac7;
 
 var RESERVED_PROPS = {
   key: true,

--- a/src/isomorphic/classic/element/__tests__/ReactElement-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElement-test.js
@@ -20,13 +20,15 @@ var ReactTestUtils;
 
 describe('ReactElement', function() {
   var ComponentClass;
+  var originalSymbol;
 
   beforeEach(function() {
     require('mock-modules').dumpCache();
 
     // Delete the native Symbol if we have one to ensure we test the
     // unpolyfilled environment.
-    delete global.Symbol;
+    originalSymbol = global.Symbol;
+    global.Symbol = undefined;
 
     React = require('React');
     ReactDOM = require('ReactDOM');
@@ -36,6 +38,14 @@ describe('ReactElement', function() {
         return React.createElement('div');
       },
     });
+  });
+
+  afterEach(function() {
+    global.Symbol = originalSymbol;
+  });
+
+  it('uses the fallback value when in an environment without Symbol', function() {
+    expect(<div />.$$typeof).toBe(0xeac7);
   });
 
   it('returns a complete element according to spec', function() {


### PR DESCRIPTION
This ensures that our tests expecting Symbol not to exist pass.

I was running the tests in node v4 where Symbol exists and one of the tests was failing (the parse & stringify test). It turns out what we were doing to delete Symbol wasn't working so we were actually getting our XSS protection when we weren't expecting it. @spicyj was correct in assuming that what we were doing wasn't going to work. So I fixed it and then added a test to ensure that we are using the Symbol-less fallback (and also reformatted a line). cc @sebmarkbage @cpojer 