### PR TITLE
[react-codemod] --no* options automatically set to false

### DIFF
--- a/packages/react-codemod/README.md
+++ b/packages/react-codemod/README.md
@@ -39,13 +39,13 @@ are using the master version (>0.13.1) of React as it is using
 `class` transforms `React.createClass` calls into ES2015 classes.
 
   * `jscodeshift -t react/packages/react-codemod/transforms/class.js <file>`
-  * If `--no-super-class=true` is specified it will not extend
+  * If `--no-super-class` is specified it will not extend
     `React.Component` if `setState` and `forceUpdate` aren't being called in a
     class. We do recommend always extending from `React.Component`, especially
     if you are using or planning to use [Flow](http://flowtype.org/). Also make
     sure you are not calling `setState` anywhere outside of your component.
 
-These three scripts take an option `--no-explicit-require=true` if you don't have a
+These three scripts take an option `--no-explicit-require` if you don't have a
 `require('React')` statement in your code files and if you access React as a
 global.
 
@@ -87,7 +87,7 @@ systems.
   * Creates a constructor if necessary. This is necessary if either
     `getInitialState` exists in the `React.createClass` spec OR if functions
     need to be bound to the instance.
-  * When `--no-super-class=true` is passed it only optionally extends
+  * When `--no-super-class` is passed it only optionally extends
     `React.Component` when `setState` or `forceUpdate` are used within the
     class.
 

--- a/packages/react-codemod/test/__tests__/transform-tests.js
+++ b/packages/react-codemod/test/__tests__/transform-tests.js
@@ -54,7 +54,7 @@ describe('Transform Tests', () => {
     test('class', 'class-test');
 
     test('class', 'class-test2', {
-      'no-super-class': true,
+      'super-class': false
     });
 
     test('class', 'class-test3');

--- a/packages/react-codemod/transforms/class.js
+++ b/packages/react-codemod/transforms/class.js
@@ -522,7 +522,7 @@ module.exports = (file, api, options) => {
   };
 
   if (
-    options['no-explicit-require'] || ReactUtils.hasReact(root)
+    !options['explicit-require'] || ReactUtils.hasReact(root)
   ) {
     const apply = (path, type) =>
       path
@@ -531,7 +531,7 @@ module.exports = (file, api, options) => {
         .filter(canConvertToClass)
         .forEach(classPath => updateToClass(
           classPath,
-          !options['no-super-class'],
+          !options['super-class'],
           type
         ));
 

--- a/packages/react-codemod/transforms/findDOMNode.js
+++ b/packages/react-codemod/transforms/findDOMNode.js
@@ -124,7 +124,7 @@ function getDOMNodeToFindDOMNode(file, api, options) {
   };
 
   if (
-    options['no-explicit-require'] ||
+    !options['explicit-require'] ||
     ReactUtils.hasReact(root)
   ) {
     const didTransform = ReactUtils

--- a/packages/react-codemod/transforms/pure-render-mixin.js
+++ b/packages/react-codemod/transforms/pure-render-mixin.js
@@ -165,7 +165,7 @@ function removePureRenderMixin(file, api, options) {
   };
 
   if (
-    options['no-explicit-require'] ||
+    !options['explicit-require'] ||
     ReactUtils.hasReact(root)
   ) {
     const didTransform = ReactUtils


### PR DESCRIPTION
`nomnom` module always converts options like `--no-debug=true` or `--no-debug` to `debug = false`.