### PR TITLE
DOCS - typo in ref callback example

### DIFF
--- a/docs/docs/08.1-more-about-refs.md
+++ b/docs/docs/08.1-more-about-refs.md
@@ -94,7 +94,7 @@ It's as simple as adding a `ref` attribute to anything returned from `render` by
 
 ```html
   render: function() {
-    return <TextInput ref={(c) => this._input = c} } />;
+    return <TextInput ref={(c) => this._input = c} />;
   },
   componentDidMount: function() {
     this._input.focus();


### PR DESCRIPTION
deleted extra ending curly brace in arrow function