### PR TITLE
Don't build up mount-ready queue for server side rendering

### DIFF
--- a/src/renderers/dom/server/ReactServerRenderingTransaction.js
+++ b/src/renderers/dom/server/ReactServerRenderingTransaction.js
@@ -13,35 +13,20 @@
 'use strict';
 
 var PooledClass = require('PooledClass');
-var CallbackQueue = require('CallbackQueue');
 var Transaction = require('Transaction');
 
 var assign = require('Object.assign');
-var emptyFunction = require('emptyFunction');
-
-/**
- * Provides a `CallbackQueue` queue for collecting `onDOMReady` callbacks
- * during the performing of the transaction.
- */
-var ON_DOM_READY_QUEUEING = {
-  /**
-   * Initializes the internal `onDOMReady` queue.
-   */
-  initialize: function() {
-    this.reactMountReady.reset();
-  },
-
-  close: emptyFunction,
-};
 
 /**
  * Executed within the scope of the `Transaction` instance. Consider these as
  * being member methods, but with an implied ordering while being isolated from
  * each other.
  */
-var TRANSACTION_WRAPPERS = [
-  ON_DOM_READY_QUEUEING,
-];
+var TRANSACTION_WRAPPERS = [];
+
+var noopCallbackQueue = {
+  enqueue: function() {},
+};
 
 /**
  * @class ReactServerRenderingTransaction
@@ -50,7 +35,6 @@ var TRANSACTION_WRAPPERS = [
 function ReactServerRenderingTransaction(renderToStaticMarkup) {
   this.reinitializeTransaction();
   this.renderToStaticMarkup = renderToStaticMarkup;
-  this.reactMountReady = CallbackQueue.getPooled(null);
   this.useCreateElement = false;
 }
 
@@ -69,7 +53,7 @@ var Mixin = {
    * @return {object} The queue to collect `onDOMReady` callbacks with.
    */
   getReactMountReady: function() {
-    return this.reactMountReady;
+    return noopCallbackQueue;
   },
 
   /**
@@ -77,8 +61,6 @@ var Mixin = {
    * instance to be reused.
    */
   destructor: function() {
-    CallbackQueue.release(this.reactMountReady);
-    this.reactMountReady = null;
   },
 };
 


### PR DESCRIPTION
This is a little faster when rendering iframe/img/form/video/audio on the server.