### PR TITLE
Fix documentation of behavior of v0.12 and v0.13

### DIFF
--- a/docs/docs/ref-05-events.md
+++ b/docs/docs/ref-05-events.md
@@ -31,7 +31,7 @@ string type
 
 > Note:
 >
-> As of v0.12, returning `false` from an event handler will no longer stop event propagation. Instead, `e.stopPropagation()` or `e.preventDefault()` should be triggered manually, as appropriate.
+> As of v0.14, returning `false` from an event handler will no longer stop event propagation. Instead, `e.stopPropagation()` or `e.preventDefault()` should be triggered manually, as appropriate.
 
 ## Event pooling
 


### PR DESCRIPTION
For relevant code in 0.11, 0.12, and 0.13, respectively see https://github.com/facebook/react/blob/0.11-stable/src/browser/eventPlugins/SimpleEventPlugin.js#L310-L313, https://github.com/facebook/react/blob/0.12-stable/src/browser/eventPlugins/SimpleEventPlugin.js#L314-L317, and https://github.com/facebook/react/blob/0.12-stable/src/browser/eventPlugins/SimpleEventPlugin.js#L314-L317.