### PR TITLE
Fix ReactDOMSelection to avoid erroring on Firefox's anonymous divs

### DIFF
--- a/src/renderers/dom/client/ReactDOMSelection.js
+++ b/src/renderers/dom/client/ReactDOMSelection.js
@@ -76,6 +76,22 @@ function getModernOffsets(node) {
 
   var currentRange = selection.getRangeAt(0);
 
+  // In Firefox, range.startContainer and range.endContainer can be "anonymous
+  // divs", e.g. the up/down buttons on an <input type="number">. Anonymous
+  // divs do not seem to expose properties, triggering a "Permission denied
+  // error" if any of its properties are accessed. The only seemingly possible
+  // way to avoid erroring is to access a property that typically works for
+  // non-anonymous divs and catch any error that may otherwise arise. See
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=208427
+  try {
+    /* eslint-disable no-unused-expressions */
+    currentRange.startContainer.nodeType;
+    currentRange.endContainer.nodeType;
+    /* eslint-enable no-unused-expressions */
+  } catch (e) {
+    return null;
+  }
+
   // If the node and offset values are the same, the selection is collapsed.
   // `Selection.isCollapsed` is available natively, but IE sometimes gets
   // this value wrong.


### PR DESCRIPTION
If `contentEditables` are used in-conjunction with `<input type="number">` in Firefox, we run into an error when trying to restore selection back to the `contentEditable` after clicking on the up/down buttons in the `input`. This results from Firefox exposing the "anonymous divs" it uses for the buttons whose properties do not seem to be accessible.

We resolve the issue by first using a try...catch to detect the presence of such divs and treat it as though there is no selection to restore.

Demo: https://jsfiddle.net/hn2dzLwp/2/