### PR TITLE
Remove "construct" call except on composites

### DIFF
--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -405,8 +405,10 @@ var globalIdCounter = 1;
  * @constructor ReactDOMComponent
  * @extends ReactMultiChild
  */
-function ReactDOMComponent(tag) {
+function ReactDOMComponent(element) {
+  var tag = element.type;
   validateDangerousTag(tag);
+  this._currentElement = element;
   this._tag = tag.toLowerCase();
   this._namespaceURI = null;
   this._renderedChildren = null;
@@ -428,10 +430,6 @@ function ReactDOMComponent(tag) {
 ReactDOMComponent.displayName = 'ReactDOMComponent';
 
 ReactDOMComponent.Mixin = {
-
-  construct: function(element) {
-    this._currentElement = element;
-  },
 
   /**
    * Generates root tag markup then recurses. This method has side effects and

--- a/src/renderers/dom/shared/ReactDOMEmptyComponent.js
+++ b/src/renderers/dom/shared/ReactDOMEmptyComponent.js
@@ -26,8 +26,6 @@ var ReactDOMEmptyComponent = function(instantiate) {
   this._domID = null;
 };
 assign(ReactDOMEmptyComponent.prototype, {
-  construct: function(element) {
-  },
   mountComponent: function(
     transaction,
     nativeParent,

--- a/src/renderers/dom/shared/ReactDOMTextComponent.js
+++ b/src/renderers/dom/shared/ReactDOMTextComponent.js
@@ -38,28 +38,20 @@ var getNode = ReactDOMComponentTree.getNodeFromInstance;
  * @extends ReactComponent
  * @internal
  */
-var ReactDOMTextComponent = function(props) {
-  // This constructor and its argument is currently used by mocks.
+var ReactDOMTextComponent = function(text) {
+  // TODO: This is really a ReactText (ReactNode), not a ReactElement
+  this._currentElement = text;
+  this._stringText = '' + text;
+  // ReactDOMComponentTree uses these:
+  this._nativeNode = null;
+  this._nativeParent = null;
+
+  // Properties
+  this._domID = null;
+  this._mountIndex = 0;
 };
 
 assign(ReactDOMTextComponent.prototype, {
-
-  /**
-   * @param {ReactText} text
-   * @internal
-   */
-  construct: function(text) {
-    // TODO: This is really a ReactText (ReactNode), not a ReactElement
-    this._currentElement = text;
-    this._stringText = '' + text;
-    // ReactDOMComponentTree uses these:
-    this._nativeNode = null;
-    this._nativeParent = null;
-
-    // Properties
-    this._domID = null;
-    this._mountIndex = 0;
-  },
 
   /**
    * Creates the markup for this text node. This node is not intended to have

--- a/src/renderers/shared/reconciler/ReactNativeComponent.js
+++ b/src/renderers/shared/reconciler/ReactNativeComponent.js
@@ -68,7 +68,7 @@ function createInternalComponent(element) {
     'There is no registered component for the tag %s',
     element.type
   );
-  return new genericComponentClass(element.type, element.props);
+  return new genericComponentClass(element);
 }
 
 /**

--- a/src/renderers/shared/reconciler/ReactSimpleEmptyComponent.js
+++ b/src/renderers/shared/reconciler/ReactSimpleEmptyComponent.js
@@ -20,8 +20,6 @@ var ReactSimpleEmptyComponent = function(placeholderElement, instantiate) {
   this._renderedComponent = instantiate(placeholderElement);
 };
 assign(ReactSimpleEmptyComponent.prototype, {
-  construct: function(element) {
-  },
   mountComponent: function(
     transaction,
     nativeParent,

--- a/src/renderers/shared/reconciler/instantiateReactComponent.js
+++ b/src/renderers/shared/reconciler/instantiateReactComponent.js
@@ -20,7 +20,9 @@ var invariant = require('invariant');
 var warning = require('warning');
 
 // To avoid a cyclic dependency, we create the final class in this module
-var ReactCompositeComponentWrapper = function() { };
+var ReactCompositeComponentWrapper = function(element) {
+  this.construct(element);
+};
 assign(
   ReactCompositeComponentWrapper.prototype,
   ReactCompositeComponent.Mixin,
@@ -87,7 +89,7 @@ function instantiateReactComponent(node) {
       // representation, we can drop this code path.
       instance = new element.type(element);
     } else {
-      instance = new ReactCompositeComponentWrapper();
+      instance = new ReactCompositeComponentWrapper(element);
     }
   } else if (typeof node === 'string' || typeof node === 'number') {
     instance = ReactNativeComponent.createInstanceForText(node);
@@ -101,7 +103,6 @@ function instantiateReactComponent(node) {
 
   if (__DEV__) {
     warning(
-      typeof instance.construct === 'function' &&
       typeof instance.mountComponent === 'function' &&
       typeof instance.receiveComponent === 'function' &&
       typeof instance.getNativeNode === 'function' &&
@@ -109,9 +110,6 @@ function instantiateReactComponent(node) {
       'Only React Components can be mounted.'
     );
   }
-
-  // Sets up the instance. This can probably just move into the constructor now.
-  instance.construct(node);
 
   // These two fields are used by the DOM and ART diffing algorithms
   // respectively. Instead of using expandos on components, we should be

--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -393,7 +393,9 @@ NoopInternalComponent.prototype = {
   },
 };
 
-var ShallowComponentWrapper = function() { };
+var ShallowComponentWrapper = function(element) {
+  this.construct(element);
+};
 assign(
   ShallowComponentWrapper.prototype,
   ReactCompositeComponent.Mixin, {
@@ -457,10 +459,7 @@ ReactShallowRenderer.prototype._render = function(element, transaction, context)
     this._instance.receiveComponent(element, transaction, context);
   } else {
     var instance = new ShallowComponentWrapper(element.type);
-    instance.construct(element);
-
     instance.mountComponent(transaction, null, null, context);
-
     this._instance = instance;
   }
 };


### PR DESCRIPTION
This is a little simpler (and a teeny tiny bit faster). The one in ReactCompositeComponent stays because of the way we create ReactCompositeComponentWrapper inside instantiateReactComponent.