### PR TITLE
Composite component throws on attaching ref to stateless component #4939

### DIFF
--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -808,10 +808,10 @@ var ReactCompositeComponentMixin = {
   attachRef: function(ref, component) {
     var inst = this.getPublicInstance();
     invariant(inst != null, 'Stateless function components cannot have refs.');
-    var componentInstance = component.getPublicInstance();
-    invariant(componentInstance != null, 'Stateless function components cannot be given refs.');
+    var publicComponentInstance = component.getPublicInstance();
+    invariant(publicComponentInstance != null, 'Stateless function components cannot be given refs.');
     var refs = inst.refs === emptyObject ? (inst.refs = {}) : inst.refs;
-    refs[ref] = componentInstance;
+    refs[ref] = publicComponentInstance;
   },
 
   /**

--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -808,8 +808,10 @@ var ReactCompositeComponentMixin = {
   attachRef: function(ref, component) {
     var inst = this.getPublicInstance();
     invariant(inst != null, 'Stateless function components cannot have refs.');
+    var componentInstance = component.getPublicInstance();
+    invariant(componentInstance != null, 'Stateless function components cannot be given refs.');
     var refs = inst.refs === emptyObject ? (inst.refs = {}) : inst.refs;
-    refs[ref] = component.getPublicInstance();
+    refs[ref] = componentInstance;
   },
 
   /**

--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -809,7 +809,7 @@ var ReactCompositeComponentMixin = {
     var inst = this.getPublicInstance();
     invariant(inst != null, 'Stateless function components cannot have refs.');
     var publicComponentInstance = component.getPublicInstance();
-    invariant(publicComponentInstance != null, 'Stateless function components cannot be given refs.');
+    warning(publicComponentInstance != null, 'Stateless function components cannot be given refs.');
     var refs = inst.refs === emptyObject ? (inst.refs = {}) : inst.refs;
     refs[ref] = publicComponentInstance;
   },

--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -809,16 +809,18 @@ var ReactCompositeComponentMixin = {
     var inst = this.getPublicInstance();
     invariant(inst != null, 'Stateless function components cannot have refs.');
     var publicComponentInstance = component.getPublicInstance();
-    var componentName = component && component.getName ?
-      component.getName() : 'a component';
-    warning(publicComponentInstance != null,
-      'Stateless function components cannot be given refs ' +
-      '(See ref "%s" in %s created by %s). ' +
-      'Attempts to access this ref will fail.',
-      ref,
-      componentName,
-      this.getName()
-    );
+    if (__DEV__) {
+      var componentName = component && component.getName ?
+        component.getName() : 'a component';
+      warning(publicComponentInstance != null,
+        'Stateless function components cannot be given refs ' +
+        '(See ref "%s" in %s created by %s). ' +
+        'Attempts to access this ref will fail.',
+        ref,
+        componentName,
+        this.getName()
+      );
+    }
     var refs = inst.refs === emptyObject ? (inst.refs = {}) : inst.refs;
     refs[ref] = publicComponentInstance;
   },

--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -809,7 +809,16 @@ var ReactCompositeComponentMixin = {
     var inst = this.getPublicInstance();
     invariant(inst != null, 'Stateless function components cannot have refs.');
     var publicComponentInstance = component.getPublicInstance();
-    warning(publicComponentInstance != null, 'Stateless function components cannot be given refs.');
+    var componentName = component && component.getName ?
+      component.getName() : 'a component';
+    warning(publicComponentInstance != null,
+      'Stateless function components cannot be given refs ' +
+      '(See ref "%s" in %s created by %s). ' +
+      'Attempts to access this ref will fail.',
+      ref,
+      componentName,
+      this.getName()
+    );
     var refs = inst.refs === emptyObject ? (inst.refs = {}) : inst.refs;
     refs[ref] = publicComponentInstance;
   },

--- a/src/renderers/shared/reconciler/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactStatelessComponent-test.js
@@ -125,17 +125,19 @@ describe('ReactStatelessComponent', function() {
     );
   });
 
-  it('should throw when given a ref', function() {
+  it('should warn when given a ref', function() {
+    spyOn(console, 'error');
+
     var Parent = React.createClass({
       render: function() {
         return <StatelessComponent name="A" ref="stateless"/>;
       },
     });
+    ReactTestUtils.renderIntoDocument(<Parent/>);
 
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(<Parent/>);
-    }).toThrow(
-      'Invariant Violation: Stateless function components cannot be given refs.'
+    expect(console.error.argsForCall.length).toBe(1);
+    expect(console.error.argsForCall[0][0]).toContain(
+      'Stateless function components cannot be given refs.'
     );
   });
 

--- a/src/renderers/shared/reconciler/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactStatelessComponent-test.js
@@ -129,6 +129,7 @@ describe('ReactStatelessComponent', function() {
     spyOn(console, 'error');
 
     var Parent = React.createClass({
+      displayName: 'Parent',
       render: function() {
         return <StatelessComponent name="A" ref="stateless"/>;
       },
@@ -137,7 +138,9 @@ describe('ReactStatelessComponent', function() {
 
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toContain(
-      'Stateless function components cannot be given refs.'
+      'Stateless function components cannot be given refs ' +
+      '(See ref "stateless" in StatelessComponent created by Parent). ' +
+      'Attempts to access this ref will fail.'
     );
   });
 

--- a/src/renderers/shared/reconciler/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactStatelessComponent-test.js
@@ -125,6 +125,20 @@ describe('ReactStatelessComponent', function() {
     );
   });
 
+  it('should throw when given a ref', function() {
+    var Parent = React.createClass({
+      render: function() {
+        return <StatelessComponent name="A" ref="stateless"/>;
+      },
+    });
+
+    expect(function() {
+      ReactTestUtils.renderIntoDocument(<Parent/>);
+    }).toThrow(
+      'Invariant Violation: Stateless function components cannot be given refs.'
+    );
+  });
+
   it('should provide a null ref', function() {
     function Child() {
       return <div />;


### PR DESCRIPTION
Fixes #4939. I know the issue was specifically to add a warning, but I thought it would be more consistent to throw.

I'm happy to back it down to a warning if that is preferable.