### PR TITLE
Remove SyntheticEvent.path

### DIFF
--- a/src/renderers/dom/client/syntheticEvents/SyntheticEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticEvent.js
@@ -23,7 +23,6 @@ var warning = require('warning');
  * @see http://www.w3.org/TR/DOM-Level-3-Events/
  */
 var EventInterface = {
-  path: null,
   type: null,
   // currentTarget is set when dispatching; no use in copying it here
   currentTarget: emptyFunction.thatReturnsNull,


### PR DESCRIPTION
Fixes #4929 

I left the couple places in tests where we set `nativeEvent.path` for whenever we decide to enable that codepath again.