### PR TITLE
Make ReactTestUtils.scryRenderedComponentWithClass find multiple classes

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -174,14 +174,16 @@ var ReactTestUtils = {
    * components with the class name matching `className`.
    * @return {array} an array of all the matches.
    */
-  scryRenderedDOMComponentsWithClass: function(root, className) {
+  scryRenderedDOMComponentsWithClass: function(root, classNames) {
+    if (!Array.isArray(classNames)) {
+      classNames = classNames.split(/\s+/);
+    }
     return ReactTestUtils.findAllInRenderedTree(root, function(inst) {
       if (ReactTestUtils.isDOMComponent(inst)) {
-        var instClassName = ReactDOM.findDOMNode(inst).className;
-        return (
-          instClassName &&
-          (('' + instClassName).split(/\s+/)).indexOf(className) !== -1
-        );
+        var classList = ReactDOM.findDOMNode(inst).className.split(/\s+/);
+        return classNames.every(function(className) {
+          return classList.indexOf(className) !== -1;
+        });
       }
       return false;
     });

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -223,6 +223,47 @@ describe('ReactTestUtils', function() {
     expect(scryResults.length).toBe(1);
   });
 
+  it('can scryRenderedDOMComponentsWithClass with multiple classes', function() {
+    var Wrapper = React.createClass({
+      render: function() {
+        return <div>Hello <span className={'x y z'}>Jim</span></div>;
+      },
+    });
+    var renderedComponent = ReactTestUtils.renderIntoDocument(<Wrapper />);
+    var scryResults1 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+      renderedComponent,
+      'x y'
+    );
+    expect(scryResults1.length).toBe(1);
+
+    var scryResults2 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+      renderedComponent,
+      'x z'
+    );
+    expect(scryResults2.length).toBe(1);
+
+    var scryResults3 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+      renderedComponent,
+      ['x', 'y']
+    );
+    expect(scryResults3.length).toBe(1);
+
+    expect(scryResults1[0]).toBe(scryResults2[0]);
+    expect(scryResults1[0]).toBe(scryResults3[0]);
+
+    var scryResults4 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+      renderedComponent,
+      ['x', 'a']
+    );
+    expect(scryResults4.length).toBe(0);
+
+    var scryResults5 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+      renderedComponent,
+      ['x a']
+    );
+    expect(scryResults5.length).toBe(0);
+  });
+
   it('traverses children in the correct order', function() {
     var Wrapper = React.createClass({
       render: function() {


### PR DESCRIPTION
Fixes #4952

This now allows an array of classnames which is a better API to use but it also allows the whitespace separated API from before work (better than it used to but also technically different behavior).