### PR TITLE
Remove dependence on ES5 shams per #4189

### DIFF
--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -109,8 +109,10 @@ var ReactElement = function(type, key, ref, self, source, owner, props) {
       element._self = self;
       element._source = source;
     }
-    Object.freeze(element.props);
-    Object.freeze(element);
+    if (Object.freeze) {
+      Object.freeze(element.props);
+      Object.freeze(element);
+    }
   }
 
   return element;

--- a/src/renderers/dom/ReactDOM.js
+++ b/src/renderers/dom/ReactDOM.js
@@ -98,16 +98,12 @@ if (__DEV__) {
       Object.keys,
       String.prototype.split,
       String.prototype.trim,
-
-      // shams
-      Object.create,
-      Object.freeze,
     ];
 
     for (var i = 0; i < expectedFeatures.length; i++) {
       if (!expectedFeatures[i]) {
         console.error(
-          'One or more ES5 shim/shams expected by React are not available: ' +
+          'One or more ES5 shims expected by React are not available: ' +
           'https://fb.me/react-warning-polyfills'
         );
         break;

--- a/src/renderers/dom/client/syntheticEvents/SyntheticEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticEvent.js
@@ -175,7 +175,10 @@ SyntheticEvent.Interface = EventInterface;
 SyntheticEvent.augmentClass = function(Class, Interface) {
   var Super = this;
 
-  var prototype = Object.create(Super.prototype);
+  var E = function () {};
+  E.prototype = Super.prototype;
+  var prototype = new E();
+
   assign(prototype, Class.prototype);
   Class.prototype = prototype;
   Class.prototype.constructor = Class;


### PR DESCRIPTION
React now only uses `Object.create` and `Object.freeze` in a couple places (one each, based on my grepping).  This commit removes the dependency on having non-functional or incomplete shams for these methods in the global environment.

As previously discussed, use of `Object.freeze` merely needs to be guarded by a check for whether it exists.  The discussed remedy for `Object.create` was to "use ES6 classes," but that doesn't seem in line with current style, and in any case it would be a larger change.  The necessary code to perform `Object.create(proto)` with a non-null `proto` is three lines of code that are well-known to most developers.  They could be inlined or broken out into a utility (which is what I chose here).

This code has not been tested in IE 8 yet; I wanted to start the ball rolling.