### PR TITLE
[docs] Fix syntac error

### DIFF
--- a/docs/docs/10.1-animation.md
+++ b/docs/docs/10.1-animation.md
@@ -122,23 +122,23 @@ It is also possible to use custom class names for each of the steps in your tran
 ```javascript
   ...
   <ReactCSSTransitionGroup
-    transitionName={{
+    transitionName={ {
       enter: 'enter',
       enterActive: 'enterActive',
       leave: 'leave',
       leaveActive: 'leaveActive',
       appear: 'appear',
       appearActive: 'appearActive'
-    }}>
+    } }>
     {item}
   </ReactCSSTransitionGroup>
 
   <ReactCSSTransitionGroup
-    transitionName={{
+    transitionName={ {
       enter: 'enter',
       leave: 'leave',
       appear: 'appear'
-    }}>
+    } }>
     {item2}
   </ReactCSSTransitionGroup>
   ...


### PR DESCRIPTION
Split {{ in example code to avoid an Exception in jekyll.
> Liquid Exception: Variable '{{' was not properly terminated with regexp: /\}\}/ in docs/10.1-animation.md