### PR TITLE
Documentation for stateless functions/components, condensed two pages about refs into one

### DIFF
--- a/docs/_data/nav_docs.yml
+++ b/docs/_data/nav_docs.yml
@@ -43,7 +43,7 @@
     title: Working With the Browser
     subitems:
     - id: more-about-refs
-      title: More About Refs
+      title: Refs to Components
   - id: tooling-integration
     title: Tooling Integration
   - id: addons

--- a/docs/_data/nav_tips.yml
+++ b/docs/_data/nav_tips.yml
@@ -30,8 +30,6 @@
     title: Communicate Between Components
   - id: expose-component-functions
     title: Expose Component Functions
-  - id: references-to-components
-    title: References to Components
   - id: children-undefined
     title: this.props.children undefined
   - id: use-react-with-other-libraries

--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -232,3 +232,33 @@ Methods follow the same semantics as regular ES6 classes, meaning that they don'
 ### No Mixins
 
 Unfortunately ES6 launched without any mixin support. Therefore, there is no support for mixins when you use React with ES6 classes. Instead, we're working on making it easier to support such use cases without resorting to mixins.
+
+
+
+## Stateless Functions
+
+You may also define your React classes as a plain JavaScript function. For example using the stateless function syntax:
+
+```javascript
+function HelloMessage(props) {
+  return <div>Hello {props.name}</div>;
+}
+React.render(<HelloMessage name="Sebastian" />, mountNode);
+```
+
+Or using the new ES6 arrow syntax:
+
+```javascript
+var HelloMessage = (props) => <div>Hello {props.name}</div>;
+React.render(<HelloMessage name="Sebastian" />, mountNode);
+```
+
+
+This simplified component API is intended for components that are pure functions of their props. These components must not retain internal state, do not have backing instances, and do not have the component lifecycle methods. They are pure functional transforms of their input, with zero boilerplate.
+
+> NOTE:
+> 
+> Because stateless functions don't have a backing instance, you can't attach a ref to a stateless function component. Normally this isn't an issue, since stateless functions do not provide an imperative API. Without an imperative API, there isn't much you could do with an instance anyway. However, if a user wants to find the DOM node of a stateless function component, they must wrap the component in a stateful component (eg. ES6 class component) and attach the ref to the stateful wrapper component.
+
+In an ideal world, most of your components would be stateless functions because these stateless components can follow a faster code path within the React core. This is the recommended pattern, when possible.
+

--- a/docs/docs/08-working-with-the-browser.md
+++ b/docs/docs/08-working-with-the-browser.md
@@ -20,46 +20,7 @@ Most of the time you should stay within React's "faked browser" world since it's
 
 ## Refs and findDOMNode()
 
-To interact with the browser, you'll need a reference to a DOM node. React has a `React.findDOMNode(component)` function which you can call to get a reference to the component's DOM node.
-
-> Note:
->
-> `findDOMNode()` only works on mounted components (that is, components that have been placed in the DOM). If you try to call this on a component that has not been mounted yet (like calling `findDOMNode()` in `render()` on a component that has yet to be created) an exception will be thrown.
-
-In order to get a reference to a React component, you can either use `this` to get the current React component, or you can use refs to refer to a component you own. They work like this:
-
-```javascript
-var MyComponent = React.createClass({
-  handleClick: function() {
-    // Explicitly focus the text input using the raw DOM API.
-    React.findDOMNode(this.refs.myTextInput).focus();
-  },
-  render: function() {
-    // The ref attribute adds a reference to the component to
-    // this.refs when the component is mounted.
-    return (
-      <div>
-        <input type="text" ref="myTextInput" />
-        <input
-          type="button"
-          value="Focus the text input"
-          onClick={this.handleClick}
-        />
-      </div>
-    );
-  }
-});
-
-React.render(
-  <MyComponent />,
-  document.getElementById('example')
-);
-```
-
-
-## More About Refs
-
-To learn more about refs, including ways to use them effectively, see our [more about refs](/react/docs/more-about-refs.html) documentation.
+To interact with the browser, you'll need a reference to a DOM node. You can attach a `ref` to any element, which allows you to reference the **backing instance** of the component.  This is useful if you need to invoke imperative functions on the component, or want to access the underlying DOM nodes.  To learn more about refs, including ways to use them effectively, see our [refs to components](/react/docs/more-about-refs.html) documentation.
 
 
 ## Component Lifecycle

--- a/docs/docs/08.1-more-about-refs.md
+++ b/docs/docs/08.1-more-about-refs.md
@@ -1,75 +1,76 @@
 ---
 id: more-about-refs
-title: More About Refs
+title: Refs to Components
 permalink: more-about-refs.html
 prev: working-with-the-browser.html
 next: tooling-integration.html
 ---
-After returning the structure of your UI from the render method, you may find yourself wanting to "reach out" and invoke methods on component instances returned from `render()`. Often, doing something like this isn't necessary for making data flow through your application, because the Reactive data flow always ensures that the most recent `props` are sent to each child that is output from `render()`. However, there are a few cases where it still might be necessary or beneficial.
+After building your component, you may find yourself wanting to "reach out" and invoke methods on component instances returned from `render()`. In most cases, this should be unnecessary because the reactive data flow always ensures that the most recent props are sent to each child that is output from render(). However, there are a few cases where it still might be necessary or beneficial, so React provides an escape hatch known as `refs`. These `refs` (references) are especially useful when you need to: find the DOM markup rendered by a component (for instance, to position it absolutely), use React components in a larger non-React application, or transition your existing codebase to React.
 
-Consider the case, when you wish to tell an `<input />` element (that exists within your instances sub-hierarchy) to focus after you update its value to be the empty string, `''`.
+Let's look at how to get a ref, and then dive into a complete example.
 
-```javascript
-  var App = React.createClass({
-    getInitialState: function() {
-      return {userInput: ''};
-    },
-    handleChange: function(e) {
-      this.setState({userInput: e.target.value});
-    },
-    clearAndFocusInput: function() {
-      this.setState({userInput: ''}); // Clear the input
-      // We wish to focus the <input /> now!
-    },
-    render: function() {
-      return (
-        <div>
-          <div onClick={this.clearAndFocusInput}>
-            Click to Focus and Reset
-          </div>
-          <input
-            value={this.state.userInput}
-            onChange={this.handleChange}
-          />
-        </div>
-      );
-    }
-  });
+## The ref returned from React.render
+
+Not to be confused with the `render()` function that you define on your component (and which returns a virtual DOM element), [React.render()](/react/docs/top-level-api.html#react.render) will return a reference to your component's **backing instance** (or `null` for [stateless components](/react/docs/reusable-components.html#stateless-functions)).
+
+
+```js
+var myComponent = React.render(<MyComponent />, myContainer);
 ```
 
+Keep in mind, however, that the JSX doesn't return a component instance! It's just a **ReactElement**: a lightweight representation that tells React what the mounted component should look like.
 
-Notice how, in this example, we want to "tell" the input something - something that it cannot infer from its props over time. In this case we want to "tell" it that it should now become focused. However, there are some challenges. What is returned from `render()` is not your actual composition of "child" components, but rather it is a *description* of the children at a particular instance in time - a snapshot.
+```js
+var myComponentElement = <MyComponent />; // This is just a ReactElement.
+
+// Some code here...
+
+var myComponentInstance = React.render(myComponentElement, myContainer);
+myComponentInstance.doSomething();
+```
 
 > Note:
 >
-> Remember, what you return from `render()` is not your *actual* rendered children instances. What you return from `render()` is merely a *description* of the children instances in your component's sub-hierarchy at a particular moment in time.
+> This should only ever be used at the top level. Inside components, let your `props` and `state` handle communication with child components, or use one of the other methods of getting a ref (string attribute or callbacks).
 
 
-This means that you should never "hold onto" something that you return from `render()` and then expect it to be anything meaningful.
+## The ref Callback Attribute
 
-```javascript
-  // antipattern: This won't work.
+React supports a special attribute that you can attach to any component. The `ref` attribute can be a callback function, and this callback will be executed immediately after the component is mounted. The referenced component will be passed in as a parameter, and the callback function may use the component immediately, or save the reference for future use (or both).
+
+It's as simple as adding a `ref` attribute to anything returned from `render`:
+
+```js
   render: function() {
-    var myInput = <input />;          // I'm going to try to call methods on this
-    this.rememberThisInput = myInput; // input at some point in the future! YAY!
     return (
-      <div>
-        <div>...</div>
-        {myInput}
-      </div>
+      <TextInput
+        ref={function(input) {
+          if (input != null) {
+            input.focus();
+          }
+        }} />
     );
-  }
+  },
+```
+or using an ES6 arrow function:
+
+```js
+  render: function() {
+    return <TextInput ref={(c) => this._input = c} />;
+  },
+  componentDidMount: function() {
+    this._input.focus();
+  },
 ```
 
-In this example, the `<input />` is merely a *description* of an `<input />`. This description is used to create a *real* **backing instance** for the `<input />`.
+Note that when the referenced component is unmounted and whenever the ref changes, the old ref will be called with `null` as an argument. This prevents memory leaks in the case that the instance is stored, as in the first example. Also note that when writing refs with inline function expressions as in the examples here, React sees a different function object each time so on every update, ref will be called with `null` immediately before it's called with the component instance.
 
-So how do we talk to the *real* backing instance of the input?
+You can access the component's DOM node directly by calling `React.findDOMNode(argumentToYourCallback)`.
+
 
 ## The ref String Attribute
 
-React supports a very special property that you can attach to any component that is output from `render()`. This special property allows you to refer to the corresponding **backing instance** of anything returned from `render()`. It is always guaranteed to be the proper instance, at any point in time.
-
-It's as simple as:
+React also supports using a string (instead of a callback) as a ref prop on any component, although this approach is mostly legacy at this point.
 
 1. Assign a `ref` attribute to anything returned from `render` such as:
 
@@ -86,75 +87,40 @@ It's as simple as:
   You can access the component's DOM node directly by calling `React.findDOMNode(this.refs.myInput)`.
 
 
-## The ref Callback Attribute
-
-The `ref` attribute can be a callback function instead of a name.  This callback will be executed immediately after the component is mounted.  The referenced component will be passed in as a parameter, and the callback function may use the component immediately, or save the reference for future use (or both).
-
-It's as simple as adding a `ref` attribute to anything returned from `render` by using an ES6 arrow function:
-
-```html
-  render: function() {
-    return <TextInput ref={(c) => this._input = c} />;
-  },
-  componentDidMount: function() {
-    this._input.focus();
-  },
-```
-
-or
-
-```html
-  render: function() {
-    return (
-      <TextInput
-        ref={function(input) {
-          if (input != null) {
-            input.focus();
-          }
-        }} />
-    );
-  },
-```
-
-Note that when the referenced component is unmounted and whenever the ref changes, the old ref will be called with `null` as an argument. This prevents memory leaks in the case that the instance is stored, as in the first example. Note that when writing refs with inline function expressions as in the examples here, React sees a different function object each time so on every update, ref will be called with `null` immediately before it's called with the component instance.
-
-
-## Completing the Example
+## A Complete Example
+In order to get a reference to a React component, you can either use `this` to get the current React component, or you can use a ref to get a reference to a component you own. They work like this:
 
 ```javascript
-  var App = React.createClass({
-    getInitialState: function() {
-      return {userInput: ''};
-    },
-    handleChange: function(e) {
-      this.setState({userInput: e.target.value});
-    },
-    clearAndFocusInput: function() {
-      // Clear the input
-      this.setState({userInput: ''}, function() {
-        // This code executes after the component is re-rendered
-        React.findDOMNode(this.refs.theInput).focus();   // Boom! Focused!
-      });
-    },
-    render: function() {
-      return (
-        <div>
-          <div onClick={this.clearAndFocusInput}>
-            Click to Focus and Reset
-          </div>
-          <input
-            ref="theInput"
-            value={this.state.userInput}
-            onChange={this.handleChange}
-          />
-        </div>
-      );
-    }
-  });
+var MyComponent = React.createClass({
+  handleClick: function() {
+    // Explicitly focus the text input using the raw DOM API.
+    this.myTextInput.focus();
+  },
+  render: function() {
+    // The ref attribute adds a reference to the component to
+    // this.refs when the component is mounted.
+    return (
+      <div>
+        <input type="text" ref={(ref) => this.myTextInput = ref} />
+        <input
+          type="button"
+          value="Focus the text input"
+          onClick={this.handleClick}
+        />
+      </div>
+    );
+  }
+});
+
+React.render(
+  <MyComponent />,
+  document.getElementById('example')
+);
 ```
 
-In this example, our render function returns a description of an `<input />` instance. But the true instance is accessed via `this.refs.theInput`. As long as a child component with `ref="theInput"` is returned from `render`, `this.refs.theInput` will access the proper instance. This even works on higher level (non-DOM) components such as `<Typeahead ref="myTypeahead" />`.
+In this example, we get a reference to the text input **backing instance** and we call `focus()` when the button is clicked.
 
+For composite components, the reference will refer to an instance of the component class so you can invoke any methods that are defined on that class. If you need access to the underlying DOM node for that component, you can use [React.findDOMNode](/react/docs/top-level-api.html#react.finddomnode).
 
 ## Summary
 
@@ -171,3 +137,4 @@ Refs are a great way to send a message to a particular child instance in a way t
 - *Never* access refs inside of any component's render method - or while any component's render method is even running anywhere in the call stack.
 - If you want to preserve Google Closure Compiler Crushing resilience, make sure to never access as a property what was specified as a string. This means you must access using `this.refs['myRefString']` if your ref was defined as `ref="myRefString"`.
 - If you have not programmed several apps with React, your first inclination is usually going to be to try to use refs to "make things happen" in your app. If this is the case, take a moment and think more critically about where `state` should be owned in the component hierarchy. Often, it becomes clear that the proper place to "own" that state is at a higher level in the hierarchy. Placing the state there often eliminates any desire to use `ref`s to "make things happen" – instead, the data flow will usually accomplish your goal.
+- Refs may not be attached to a [stateless function](/react/docs/reusable-components.html#stateless-functions), because the component does not have a backing instance. You can always wrap a stateless component in a standard composite component and attach a ref to the composite component.

--- a/docs/docs/ref-01-top-level-api.md
+++ b/docs/docs/ref-01-top-level-api.md
@@ -81,7 +81,7 @@ ReactComponent render(
 )
 ```
 
-Render a ReactElement into the DOM in the supplied `container` and return a reference to the component.
+Render a ReactElement into the DOM in the supplied `container` and return a [reference](/react/docs/more-about-refs.html) to the component (or returns `null` for [stateless components](/react/docs/reusable-components.html#stateless-functions)).
 
 If the ReactElement was previously rendered into `container`, this will perform an update on it and only mutate the DOM as necessary to reflect the latest React component.
 
@@ -143,6 +143,12 @@ DOMElement findDOMNode(ReactComponent component)
 ```
 If this component has been mounted into the DOM, this returns the corresponding native browser DOM element. This method is useful for reading values out of the DOM, such as form field values and performing DOM measurements. When `render` returns `null` or `false`, `findDOMNode` returns `null`.
 
+> Note:
+>
+> `findDOMNode()` is an escape hatch used to access the underlying DOM node. In most cases, use of this escape hatch is discouraged because it pierces the component abstraction. However, there are some situations where this is necessary (for instance, you may need to find a DOM node in order to position it absolutely or to determine the rendered width measured in pixels).
+
+>
+> `findDOMNode()` only works on mounted components (that is, components that have been placed in the DOM). If you try to call this on a component that has not been mounted yet (like calling `findDOMNode()` in `render()` on a component that has yet to be created) an exception will be thrown.
 
 ### React.DOM
 

--- a/docs/tips/15-expose-component-functions.md
+++ b/docs/tips/15-expose-component-functions.md
@@ -4,7 +4,7 @@ title: Expose Component Functions
 layout: tips
 permalink: expose-component-functions.html
 prev: communicate-between-components.html
-next: references-to-components.html
+next: children-undefined.html
 ---
 
 There's another (uncommon) way of [communicating between components](/react/tips/communicate-between-components.html): simply expose a method on the child component for the parent to call.

--- a/docs/tips/16-references-to-components.md
+++ b/docs/tips/16-references-to-components.md
@@ -7,22 +7,4 @@ prev: expose-component-functions.html
 next: children-undefined.html
 ---
 
-If you're using React components in a larger non-React application or transitioning your code to React, you may need to keep references to components. `React.render` returns a reference to the mounted component:
-
-```js
-var myComponent = React.render(<MyComponent />, myContainer);
-```
-
-Keep in mind, however, that the JSX doesn't return a component instance! It's just a **ReactElement**: a lightweight representation that tells React what the mounted component should look like.
-
-```js
-var myComponentElement = <MyComponent />; // This is just a ReactElement.
-
-// Some code here...
-
-var myComponentInstance = React.render(myComponentElement, myContainer);
-```
-
-> Note:
->
-> This should only ever be used at the top level. Inside components, let your `props` and `state` handle communication with child components, and only reference components via [refs](/react/docs/more-about-refs.html).
+This page has moved to: [refs](/react/docs/more-about-refs.html).

--- a/docs/tips/17-children-undefined.md
+++ b/docs/tips/17-children-undefined.md
@@ -3,7 +3,7 @@ id: children-undefined
 title: this.props.children undefined
 layout: tips
 permalink: children-undefined.html
-prev: references-to-components.html
+prev: expose-component-functions.html
 next: use-react-with-other-libraries.html
 ---
 


### PR DESCRIPTION
Condensed the two refs pages into a single refs page, added a note about stateless components having null references.
