### PR TITLE
Don't store <input> instance until mount-ready

### DIFF
--- a/src/renderers/dom/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMInput.js
@@ -75,7 +75,10 @@ var ReactDOMInput = {
       initialValue: defaultValue != null ? defaultValue : null,
       onChange: _handleChange.bind(inst),
     };
+  },
 
+  mountReadyWrapper: function(inst) {
+    // Can't be in mountWrapper or else server rendering leaks.
     instancesByReactID[inst._rootNodeID] = inst;
   },
 

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -606,8 +606,10 @@ ReactDOMComponent.Mixin = {
     }
 
     switch (this._tag) {
-      case 'button':
       case 'input':
+        ReactDOMInput.mountReadyWrapper(this);
+        // falls through
+      case 'button':
       case 'select':
       case 'textarea':
         if (props.autoFocus) {


### PR DESCRIPTION
Fixes #4870.

This more or less matches what we were doing with the old wrapper components (not storing until componentDidMount).