### PR TITLE
Actually don't store <input> until mount-ready

### DIFF
--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -422,6 +422,10 @@ function trapBubbledEventsLocal() {
   }
 }
 
+function mountReadyInputWrapper() {
+  ReactDOMInput.mountReadyWrapper(this);
+}
+
 function postUpdateSelectWrapper() {
   ReactDOMSelect.postUpdateWrapper(this);
 }
@@ -607,7 +611,10 @@ ReactDOMComponent.Mixin = {
 
     switch (this._tag) {
       case 'input':
-        ReactDOMInput.mountReadyWrapper(this);
+        transaction.getReactMountReady().enqueue(
+          mountReadyInputWrapper,
+          this
+        );
         // falls through
       case 'button':
       case 'select':


### PR DESCRIPTION
So #4976 was a lie. Fixes #4870 for real (thanks @STRML).