### PR TITLE
Added a note about needing document globally available

### DIFF
--- a/docs/docs/10.4-test-utils.md
+++ b/docs/docs/10.4-test-utils.md
@@ -49,6 +49,11 @@ ReactComponent renderIntoDocument(
 
 Render a component into a detached DOM node in the document. **This function requires a DOM.**
 
+> Note:
+>
+> You will need to have `window`, `window.document` and `window.document.createElement`
+ globally available **before** you import React. Otherwise React will think it can't access the DOM and methods like `setState` won't work.  
+
 ### mockComponent
 
 ```javascript


### PR DESCRIPTION
As discussed in https://github.com/facebook/react/issues/4881 I added a note in ``10.4-test-utils.md` about needing `window`, `document` and
`document.createElement` globally available before importing React.

Fixes https://github.com/facebook/react/issues/4881