### PR TITLE
Run all component lifecycle methods when shallow rendering

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -411,7 +411,7 @@ ReactShallowRenderer.prototype.render = function(element, context) {
     context = emptyObject;
   }
   var transaction = ReactUpdates.ReactReconcileTransaction.getPooled(false);
-  this._render(element, transaction, context);
+  transaction.perform(this._render, this, element, transaction, context);
   ReactUpdates.ReactReconcileTransaction.release(transaction);
 };
 

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -91,6 +91,46 @@ describe('ReactTestUtils', function() {
     expect(componentWillUnmount).toBeCalled();
   });
 
+  it('should run all lifecycle methods', function() {
+    var componentWillMount = mocks.getMockFunction();
+    var componentDidMount = mocks.getMockFunction();
+    var componentWillReceiveProps = mocks.getMockFunction();
+    var shouldComponentUpdate = mocks.getMockFunction();
+    var componentWillUpdate = mocks.getMockFunction();
+    var componentDidUpdate = mocks.getMockFunction();
+    var componentWillUnmount = mocks.getMockFunction();
+
+    var SomeComponent = React.createClass({
+      render: function() {
+        return <SomeComponent onChange={() => this.setState({a: 1})} />;
+      },
+      componentWillMount,
+      componentDidMount,
+      componentWillReceiveProps,
+      shouldComponentUpdate() {
+        shouldComponentUpdate();
+        return true;
+      },
+      componentWillUpdate,
+      componentDidUpdate,
+      componentWillUnmount,
+    });
+
+    var shallowRenderer = ReactTestUtils.createRenderer();
+    shallowRenderer.render(<SomeComponent />);
+    shallowRenderer.getRenderOutput().props.onChange();
+    shallowRenderer.render(<SomeComponent />);
+    shallowRenderer.unmount();
+
+    expect(componentWillMount).toBeCalled();
+    expect(componentDidMount).toBeCalled();
+    expect(componentWillReceiveProps).toBeCalled();
+    expect(shouldComponentUpdate).toBeCalled();
+    expect(componentWillUpdate).toBeCalled();
+    expect(componentDidUpdate).toBeCalled();
+    expect(componentWillUnmount).toBeCalled();
+  });
+
   it('can shallow render to null', function() {
     var SomeComponent = React.createClass({
       render: function() {


### PR DESCRIPTION
Performs transaction around shallow render so remaining component lifecycle methods (componentDidMount, componentDidUpdate) are processed.

Fixes https://github.com/facebook/react/issues/4919