### PR TITLE
Fail jest tests on any un-spied warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "rootDir": "",
     "scriptPreprocessor": "scripts/jest/preprocessor.js",
     "setupEnvScriptFile": "scripts/jest/environment.js",
+    "setupTestFrameworkScriptFile": "scripts/jest/test-framework-setup.js",
     "testFileExtensions": [
       "coffee",
       "js",

--- a/scripts/jest/test-framework-setup.js
+++ b/scripts/jest/test-framework-setup.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var env = jasmine.getEnv();
+
+var oldError = console.error;
+var newError = function() {
+  oldError.apply(this, arguments);
+  var spec = env.currentSpec;
+  if (spec) {
+    var expectationResult = new jasmine.ExpectationResult({
+      passed: false,
+      message:
+        'Expected test not to warn. If the warning is expected, mock it ' +
+        'out using spyOn(console, \'error\'); and test that the warning ' +
+        'occurs.',
+    });
+    spec.addMatcherResult(expectationResult);
+  }
+};
+console.error = newError;
+
+// Make sure console.error is set back at the end of each test, or else the
+// above logic won't work
+afterEach(function() {
+  // TODO: Catch test cases that call spyOn() but don't inspect the mock
+  // properly.
+
+  if (console.error !== newError && !console.error.isSpy) {
+    var expectationResult = new jasmine.ExpectationResult({
+      passed: false,
+      message: 'Test did not tear down console.error mock properly.',
+    });
+    env.currentSpec.addMatcherResult(expectationResult);
+  }
+});

--- a/src/renderers/dom/client/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMount-test.js
@@ -212,16 +212,16 @@ describe('ReactMount', function() {
     });
 
     var container = document.createElement('div');
-    console.error = mocks.getMockFunction();
+    spyOn(console, 'error');
     var component = RD1.render(<X />, container);
-    expect(console.error.mock.calls.length).toBe(0);
+    expect(console.error.argsForCall.length).toBe(0);
 
     // This fails but logs a warning first
     expect(function() {
       RD2.findDOMNode(component);
     }).toThrow();
-    expect(console.error.mock.calls.length).toBe(1);
-    expect(console.error.mock.calls[0][0]).toContain('two copies of React');
+    expect(console.error.argsForCall.length).toBe(1);
+    expect(console.error.argsForCall[0][0]).toContain('two copies of React');
   });
 
   it('should warn if render removes React-rendered children', function() {
@@ -231,12 +231,12 @@ describe('ReactMount', function() {
         return <div><div /></div>;
       },
     });
-    React.render(<Component />, container);
+    ReactDOM.render(<Component />, container);
 
     // Test that blasting away children throws a warning
     spyOn(console, 'error');
     var rootNode = container.firstChild;
-    React.render(<span />, rootNode);
+    ReactDOM.render(<span />, rootNode);
     expect(console.error.callCount).toBe(1);
     expect(console.error.mostRecentCall.args[0]).toBe(
       'Warning: render(...): Replacing React-rendered children with a new ' +


### PR DESCRIPTION
Originally #4223 -- we lost this when we switched to jest.