### PR TITLE
fix onChange with placeholder on IE

### DIFF
--- a/src/renderers/dom/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMInput.js
@@ -28,8 +28,8 @@ function forceUpdateIfMounted() {
   }
 }
 
-function isTextInput(props) {
-  return !props.type || props.type === 'text';
+function hasPlaceholder(props) {
+  return 'placeholder' in props;
 }
 
 /**
@@ -86,7 +86,7 @@ var ReactDOMInput = {
     // Can't be in mountWrapper or else server rendering leaks.
     instancesByReactID[inst._rootNodeID] = inst;
     var rootNode = ReactMount.getNode(inst._rootNodeID);
-    if (isTextInput(inst._currentElement.props)) {
+    if (hasPlaceholder(inst._currentElement.props)) {
       inst._wrapperState._currentValue = rootNode.value;
     }
   },
@@ -118,7 +118,7 @@ var ReactDOMInput = {
         'value',
         value
       );
-      if (isTextInput(props)) {
+      if (hasPlaceholder(props)) {
         inst._wrapperState._currentValue = value;
       }
     }
@@ -128,7 +128,8 @@ var ReactDOMInput = {
 function _handleChange(event) {
   var props = this._currentElement.props;
 
-  if (isTextInput(props)) {
+  // #5004: IE fires input event for placeholder wrongly
+  if (hasPlaceholder(props)) {
     var value = event.target.value;
     if (value === this._wrapperState._currentValue) {
       event.stopPropagation();

--- a/src/renderers/dom/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMInput.js
@@ -131,6 +131,7 @@ function _handleChange(event) {
   if (isTextInput(props)) {
     var value = event.target.value;
     if (value === this._wrapperState._currentValue) {
+      event.stopPropagation();
       return undefined;
     }
     this._wrapperState._currentValue = value;

--- a/src/renderers/dom/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMInput.js
@@ -82,7 +82,7 @@ var ReactDOMInput = {
     instancesByReactID[inst._rootNodeID] = inst;
     var rootNode = ReactMount.getNode(inst._rootNodeID);
     var props = inst._currentElement.props;
-    if(!props.type || props.type==='text') {
+    if (!props.type || props.type==='text') {
       inst._currentValue = rootNode.value;
     }
   },
@@ -120,10 +120,10 @@ var ReactDOMInput = {
 function _handleChange(event) {
   var props = this._currentElement.props;
 
-  if(!props.type || props.type === 'text') {
+  if (!props.type || props.type === 'text') {
     var value = event.target.value;
     if (value === this._currentValue) {
-      return;
+      return undefined;
     }
     this._currentValue = value;
   }

--- a/src/renderers/dom/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMInput.js
@@ -78,6 +78,7 @@ var ReactDOMInput = {
       initialChecked: props.defaultChecked || false,
       initialValue: defaultValue != null ? defaultValue : null,
       onChange: _handleChange.bind(inst),
+      _currentValue: '',
     };
   },
 
@@ -86,7 +87,7 @@ var ReactDOMInput = {
     instancesByReactID[inst._rootNodeID] = inst;
     var rootNode = ReactMount.getNode(inst._rootNodeID);
     if (isTextInput(inst._currentElement.props)) {
-      inst._currentValue = rootNode.value;
+      inst._wrapperState._currentValue = rootNode.value;
     }
   },
 
@@ -118,7 +119,7 @@ var ReactDOMInput = {
         value
       );
       if (isTextInput(props)) {
-        inst._currentValue = value;
+        inst._wrapperState._currentValue = value;
       }
     }
   },
@@ -129,10 +130,10 @@ function _handleChange(event) {
 
   if (isTextInput(props)) {
     var value = event.target.value;
-    if (value === this._currentValue) {
+    if (value === this._wrapperState._currentValue) {
       return undefined;
     }
-    this._currentValue = value;
+    this._wrapperState._currentValue = value;
   }
 
   var returnValue = LinkedValueUtils.executeOnChange(props, event);

--- a/src/renderers/dom/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMInput.js
@@ -28,6 +28,10 @@ function forceUpdateIfMounted() {
   }
 }
 
+function isTextInput(props) {
+  return !props.type || props.type === 'text';
+}
+
 /**
  * Implements an <input> native component that allows setting these optional
  * props: `checked`, `value`, `defaultChecked`, and `defaultValue`.
@@ -81,8 +85,7 @@ var ReactDOMInput = {
     // Can't be in mountWrapper or else server rendering leaks.
     instancesByReactID[inst._rootNodeID] = inst;
     var rootNode = ReactMount.getNode(inst._rootNodeID);
-    var props = inst._currentElement.props;
-    if (!props.type || props.type==='text') {
+    if (isTextInput(inst._currentElement.props)) {
       inst._currentValue = rootNode.value;
     }
   },
@@ -108,11 +111,15 @@ var ReactDOMInput = {
     if (value != null) {
       // Cast `value` to a string to ensure the value is set correctly. While
       // browsers typically do this as necessary, jsdom doesn't.
+      value = '' + value;
       ReactDOMIDOperations.updatePropertyByID(
         inst._rootNodeID,
         'value',
-        '' + value
+        value
       );
+      if (isTextInput(props)) {
+        inst._currentValue = value;
+      }
     }
   },
 };
@@ -120,7 +127,7 @@ var ReactDOMInput = {
 function _handleChange(event) {
   var props = this._currentElement.props;
 
-  if (!props.type || props.type === 'text') {
+  if (isTextInput(props)) {
     var value = event.target.value;
     if (value === this._currentValue) {
       return undefined;

--- a/src/renderers/dom/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMInput.js
@@ -80,6 +80,11 @@ var ReactDOMInput = {
   mountReadyWrapper: function(inst) {
     // Can't be in mountWrapper or else server rendering leaks.
     instancesByReactID[inst._rootNodeID] = inst;
+    var rootNode = ReactMount.getNode(inst._rootNodeID);
+    var props = inst._currentElement.props;
+    if(!props.type || props.type==='text') {
+      inst._currentValue = rootNode.value;
+    }
   },
 
   unmountWrapper: function(inst) {
@@ -114,6 +119,14 @@ var ReactDOMInput = {
 
 function _handleChange(event) {
   var props = this._currentElement.props;
+
+  if(!props.type || props.type === 'text') {
+    var value = event.target.value;
+    if (value === this._currentValue) {
+      return;
+    }
+    this._currentValue = value;
+  }
 
   var returnValue = LinkedValueUtils.executeOnChange(props, event);
 

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
@@ -387,7 +387,7 @@ describe('ReactDOMInput', function() {
     expect(() => ReactDOM.render(instance, node)).toThrow();
   });
 
-  it('will not fire onChange when render with placeholder', function () {
+  it('will not fire onChange when render with placeholder', function() {
     var node = document.createElement('div');
     document.body.appendChild(node);
     var onChange = mocks.getMockFunction();

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
@@ -386,4 +386,16 @@ describe('ReactDOMInput', function() {
       <input type="checkbox" checkedLink={link} valueLink={emptyFunction} />;
     expect(() => ReactDOM.render(instance, node)).toThrow();
   });
+
+  it('will not fire onChange when render with placeholder', function () {
+    var node = document.createElement('div');
+    document.body.appendChild(node);
+    var onChange = mocks.getMockFunction();
+    var instance = <input placeholder="一鸣，何" onChange={onChange} />;
+    // can not use renderIntoDocument
+    ReactDOM.render(instance, node);
+    expect(onChange.mock.calls.length).toBe(0);
+    ReactDOM.unmountComponentAtNode(node);
+    document.body.removeChild(node);
+  });
 });

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
@@ -391,10 +391,12 @@ describe('ReactDOMInput', function() {
     var node = document.createElement('div');
     document.body.appendChild(node);
     var onChange = mocks.getMockFunction();
-    var instance = <input placeholder="中文" onChange={onChange} />;
+    var parentOnChange = mocks.getMockFunction();
+    var instance = <div onChange={parentOnChange}><input placeholder="中文" onChange={onChange} /></div>;
     // can not use renderIntoDocument
     ReactDOM.render(instance, node);
     expect(onChange.mock.calls.length).toBe(0);
+    expect(parentOnChange.mock.calls.length).toBe(0);
     ReactDOM.unmountComponentAtNode(node);
     document.body.removeChild(node);
   });

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
@@ -391,7 +391,7 @@ describe('ReactDOMInput', function() {
     var node = document.createElement('div');
     document.body.appendChild(node);
     var onChange = mocks.getMockFunction();
-    var instance = <input placeholder="一鸣，何" onChange={onChange} />;
+    var instance = <input placeholder="中文" onChange={onChange} />;
     // can not use renderIntoDocument
     ReactDOM.render(instance, node);
     expect(onChange.mock.calls.length).toBe(0);


### PR DESCRIPTION
IE 10/11 will fire input event when input renders if input's placeholder contains Chinese words:

plain: http://jsfiddle.net/yiminghe/fm3rckaz/2/
react: https://jsfiddle.net/yiminghe/69z2wepo/17145/

and other situations: https://connect.microsoft.com/IE/feedback/details/885747/ie-11-fires-the-input-event-when-a-input-field-with-placeholder-is-focused