### PR TITLE
Don't throw for onClick={false} in initial render

### DIFF
--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -656,7 +656,9 @@ ReactDOMComponent.Mixin = {
         continue;
       }
       if (registrationNameModules.hasOwnProperty(propKey)) {
-        enqueuePutListener(this._rootNodeID, propKey, propValue, transaction);
+        if (propValue) {
+          enqueuePutListener(this._rootNodeID, propKey, propValue, transaction);
+        }
       } else {
         if (propKey === STYLE) {
           if (propValue) {

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -630,6 +630,10 @@ describe('ReactDOMComponent', function() {
       SimpleEventPlugin.willDeleteListener = mocks.getMockFunction();
       var container = document.createElement('div');
 
+      ReactDOM.render(<div onClick={false} />, container);
+      expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(0);
+      expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(0);
+
       ReactDOM.render(<div onClick={null} />, container);
       expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(0);
       expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(0);


### PR DESCRIPTION
I accidentally regressed this in #3246. Now this matches what we already checked for updates.