### PR TITLE
Enforce NODE_ENV=test

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "linc": "git diff --name-only --diff-filter=ACMRTUB `git merge-base HEAD master` | grep '\\.js$' | xargs eslint --",
     "lint": "grunt lint",
     "postinstall": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",
-    "test": "NODE_ENV=test jest"
+    "test": "jest"
   },
   "jest": {
     "modulePathIgnorePatterns": [

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -1,5 +1,9 @@
 'use strict';
 
+// React's test can only work in NODE_ENV=test because of how things
+// are set up. So we might as well enforce it.
+process.env.NODE_ENV = 'test';
+
 var path = require('path');
 
 var assign = require('object-assign');


### PR DESCRIPTION
You could make the argument that this should be optional, but it doesn't
work without it so we might as well just enforce it.

Makes `jest` work by default.