### PR TITLE
isReactClass -> .prototype.isReactComponent

### DIFF
--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -847,7 +847,6 @@ var ReactClass = {
     };
     Constructor.prototype = new ReactClassComponent();
     Constructor.prototype.constructor = Constructor;
-    Constructor.isReactClass = {};
 
     injectedMixins.forEach(
       mixSpecIntoComponent.bind(null, Constructor)

--- a/src/isomorphic/modern/class/ReactComponent.js
+++ b/src/isomorphic/modern/class/ReactComponent.js
@@ -29,7 +29,7 @@ function ReactComponent(props, context, updater) {
   this.updater = updater || ReactNoopUpdateQueue;
 }
 
-ReactComponent.isReactClass = {};
+ReactComponent.prototype.isReactComponent = {};
 
 /**
  * Sets a subset of the state. Always use this to mutate

--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -412,7 +412,7 @@ function findFirstReactDOMImpl(node) {
  * here.
  */
 var TopLevelWrapper = function() {};
-TopLevelWrapper.isReactClass = {};
+TopLevelWrapper.prototype.isReactComponent = {};
 if (__DEV__) {
   TopLevelWrapper.displayName = 'TopLevelWrapper';
 }

--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -176,7 +176,7 @@ var ReactCompositeComponentMixin = {
         // We support ES6 inheriting from React.Component, the module pattern,
         // and stateless components, but not ES6 classes that don't extend
         warning(
-          Component.isReactClass ||
+          (Component.prototype && Component.prototype.isReactComponent) ||
             !canInstantiate ||
             !(inst instanceof Component),
           '%s(...): React component classes must extend React.Component.',

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -1211,5 +1211,35 @@ describe('ReactCompositeComponent', function() {
     expect(console.error.calls.length).toBe(0);
   });
 
+  it('should warn when a class does not extend React.Component', function() {
+
+    var container = document.createElement('div');
+
+    class Foo {
+      render() {
+        return <span />;
+      }
+    }
+
+    function Bar() { }
+    Bar.prototype = Object.create(React.Component.prototype);
+    Bar.prototype.render = function() {
+      return <span />;
+    };
+
+    expect(console.error.calls.length).toBe(0);
+
+    ReactDOM.render(<Bar />, container);
+
+    expect(console.error.calls.length).toBe(0);
+
+    ReactDOM.render(<Foo />, container);
+
+    expect(console.error.calls.length).toBe(1);
+    expect(console.error.argsForCall[0][0]).toContain(
+      'React component classes must extend React.Component'
+    );
+
+  });
 
 });


### PR DESCRIPTION
Put the flag on the prototype instead to help certain limited forms
of class extensions that doesn't properly transfer static properties.

Fixes #4836