### PR TITLE
Keep reference equality when possible in update()

### DIFF
--- a/src/addons/__tests__/update-test.js
+++ b/src/addons/__tests__/update-test.js
@@ -70,6 +70,11 @@ describe('update', function() {
   it('should support set', function() {
     expect(update({a: 'b'}, {$set: {c: 'd'}})).toEqual({c: 'd'});
   });
+  
+  it('should keep reference equality when possible with set', function() {
+    var original = {a: 1};
+    expect(update(original, {a: {$set: 1}})).toBe(original);
+  });
 
   it('should support apply', function() {
     expect(update(2, {$apply: function(x) { return x * 2; }})).toEqual(4);
@@ -77,6 +82,14 @@ describe('update', function() {
       'Invariant Violation: update(): expected spec of $apply to be a ' +
       'function; got 123.'
     );
+  });
+  
+  it('should keep reference equality when possible with apply', function() {
+    var original = {a: {b: {}}};
+    function identity(val) {
+      return val;
+    }
+    expect(update(original, {a: {$apply: identity}})).toBe(original);
   });
 
   it('should support deep updates', function() {


### PR DESCRIPTION
Same as https://github.com/facebook/react/pull/4968 but targeting 0.13-stable in case that is a better place for it.

--------

For $set and $apply it is cheap and easy to check whether the new value will
be identical (===) to the old value and create a new object only when this is not
the case. This will reduce excessive renders when using the pureRenderMixin.

The same should be possible for for merge, but is more complicated so is not
attempted here.

Addresses https://github.com/facebook/react/issues/1923