### PR TITLE
ReactTransitionGroup: fix fast enter/leave issue

### DIFF
--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -86,7 +86,7 @@ var ReactTransitionGroup = React.createClass({
       children: ReactTransitionChildMapping.mergeChildMappings(
         this.state.children,
         nextChildMapping
-      )
+      ),
     });
 
     // If we want to someday check for reordering, we could do it here.
@@ -183,7 +183,7 @@ var ReactTransitionGroup = React.createClass({
 
     delete this.currentlyTransitioningKeys[key];
 
-    var newChildren = Object.assign({}, this.state.children);
+    var newChildren = assign({}, this.state.children);
     delete newChildren[key];
     this.setState({children: newChildren});
   },


### PR DESCRIPTION
This fixes https://github.com/facebook/react/issues/5027 by making entering/leaving transitions interruptible, just like CSS:

* It internally keeps track of whether a component is appearing, entering, or leaving
* If a component is removed while it's entering or appearing, its state is set to leaving and its `componentWillLeave` is called immediately
* If a component is added back while it's leaving, its state is set to entering and its `componentWillEnter` is called immediately
* When `componentWillAppear` calls its callback, no action is taken unless the component is in appearing state.
* When `componentWillEnter` calls its callback, no action is taken unless the component is in entering state.
* When `componentWillLeave` calls its callback, no action is taken unless the component is in leaving state.

**I haven't yet edited the tests to reflect the new behavior, work in progress.**