### PR TITLE
Performance improvement for ReactTransitionGroup with large children body

### DIFF
--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -14,7 +14,6 @@
 var React = require('React');
 var ReactTransitionChildMapping = require('ReactTransitionChildMapping');
 
-var assign = require('Object.assign');
 var emptyFunction = require('emptyFunction');
 
 var ReactTransitionGroup = React.createClass({
@@ -42,6 +41,7 @@ var ReactTransitionGroup = React.createClass({
     this.currentlyTransitioningKeys = {};
     this.keysToEnter = [];
     this.keysToLeave = [];
+    this.keysLeaving = [];
   },
 
   componentDidMount: function() {
@@ -163,6 +163,7 @@ var ReactTransitionGroup = React.createClass({
 
   performLeave: function(key) {
     this.currentlyTransitioningKeys[key] = true;
+    this.keysLeaving.push(key);
 
     var component = this.refs[key];
     if (component.componentWillLeave) {
@@ -182,6 +183,7 @@ var ReactTransitionGroup = React.createClass({
       component.componentDidLeave();
     }
 
+    this.keysLeaving.splice(this.keysLeaving.indexOf(key), 1);
     delete this.currentlyTransitioningKeys[key];
 
     var currentChildMapping = ReactTransitionChildMapping.getChildMapping(
@@ -192,11 +194,11 @@ var ReactTransitionGroup = React.createClass({
       // This entered again before it fully left. Add it again.
       this.performEnter(key);
     } else {
-      this.setState(function(state) {
-        var newChildren = assign({}, state.children);
-        delete newChildren[key];
-        return {children: newChildren};
-      });
+      delete this.state.children[key];
+    }
+
+    if (this.keysLeaving.length === 0) {
+      this.forceUpdate();
     }
   },
 


### PR DESCRIPTION
If you have multiple children leaving at the same time, the TG will re-render its children after each child's leave is complete. There will be 20 re-renders if 20 children were leaving within one render of their parent. 

This creates a clearly visible bottleneck if you have a large volume of children and when their parent gets quick re-renders.

One example is a search/filter with a large list of filtered items entering and leaving as the user types -- you have to display all filtered items, however many, so that the user can stop typing and scroll if they'd like. I've seen visible bottleneck with just 30 items as I type in 4 letters (4 re-renders from parent).
 
This commit fixes the performance issue by keeping track of all currently leaving children (which are also added from `performAppear`/`performEnter`) and only trigger re-render after the last leaving child's leave is complete.