### PR TITLE
make properties notation consistent over docs

### DIFF
--- a/docs/docs/ref-02-component-api.it-IT.md
+++ b/docs/docs/ref-02-component-api.it-IT.md
@@ -14,7 +14,7 @@ Istanze di un React Component sono create internamente a React durante il render
 ### setState
 
 ```javascript
-setState(
+void setState(
   function|object nextState,
   [function callback]
 )
@@ -53,7 +53,7 @@ Il secondo parametro (opzionale) è una funzione callback che verrà eseguita qu
 ### replaceState
 
 ```javascript
-replaceState(
+void replaceState(
   object nextState,
   [function callback]
 )
@@ -69,7 +69,7 @@ Come `setState()`, ma elimina ogni chiave preesistente che non si trova in `next
 ### forceUpdate
 
 ```javascript
-forceUpdate(
+void forceUpdate(
   [function callback]
 )
 ```
@@ -99,7 +99,7 @@ Se questo componente è stato montato nel DOM, restituisce il corrispondente ele
 ### isMounted
 
 ```javascript
-bool isMounted()
+boolean isMounted()
 ```
 
 `isMounted()` restituisce `true` se il rendering del componente è stato effettuato nel DOM, `false` altrimenti. Puoi usare questo metodo come guardia per chiamate asincrone a `setState()` o `forceUpdate()`.
@@ -112,7 +112,7 @@ bool isMounted()
 ### setProps
 
 ```javascript
-setProps(
+void setProps(
   object nextProps,
   [function callback]
 )
@@ -133,7 +133,7 @@ Chiamare `setProps()` su un componente al livello radice cambierà le sue propri
 ### replaceProps
 
 ```javascript
-replaceProps(
+void replaceProps(
   object nextProps,
   [function callback]
 )

--- a/docs/docs/ref-02-component-api.ko-KR.md
+++ b/docs/docs/ref-02-component-api.ko-KR.md
@@ -14,7 +14,7 @@ React 컴포넌트의 인스턴스는 React가 렌더링 시에 내부적으로 
 ### setState
 
 ```javascript
-setState(function|object nextState[, function callback])
+void setState(function|object nextState[, function callback])
 ```
 
 `nextState`를 현재 state에 합칩니다. 이벤트 핸들러와 서버 요청 콜백에서 UI 업데이트를 발생시키기 위해 이 메소드를 주로 사용합니다.
@@ -51,7 +51,7 @@ setState(function(previousState, currentProps) {
 ### replaceState
 
 ```javascript
-replaceState(object nextState[, function callback])
+void replaceState(object nextState[, function callback])
 ```
 
 `setState()`와 비슷하지만 기존에 존재하는 state 중 nextState에 없는 키는 모두 삭제됩니다.
@@ -64,7 +64,7 @@ replaceState(object nextState[, function callback])
 ### forceUpdate
 
 ```javascript
-forceUpdate([function callback])
+void forceUpdate([function callback])
 ```
 
 기본적으로, 컴포넌트의 state나 props가 변경되면, 컴포넌트는 다시 렌더됩니다. 하지만 이런 변경이 묵시적이거나(예를들어 객체의 변경 없이 깊이 있는 데이터만 변경된 경우) `render()` 함수가 다른 값에 의존하는 경우, `forceUpdate()`를 호출해 React에게 `render()`를 다시 실행할 필요가 있다고 알릴 수 있습니다.
@@ -92,7 +92,7 @@ DOMElement getDOMNode()
 ### isMounted
 
 ```javascript
-bool isMounted()
+boolean isMounted()
 ```
 
 `isMounted()`는 컴포넌트가 DOM에 렌더링되었으면 true를, 아니면 false를 리턴합니다. 비동기적으로 `setState()`나 `forceUpdate()`를 호출할 때 이 메소드를 사용하여 오류를 방지할 수 있습니다.
@@ -105,7 +105,7 @@ bool isMounted()
 ### setProps
 
 ```javascript
-setProps(object nextProps[, function callback])
+void setProps(object nextProps[, function callback])
 ```
 
 외부 JavaScript 애플리케이션과 연동하는 경우 `React.render()`로 렌더링된 React 컴포넌트에 변경을 알리고 싶을 때가 있습니다.
@@ -124,7 +124,7 @@ setProps(object nextProps[, function callback])
 ### replaceProps
 
 ```javascript
-replaceProps(object nextProps[, function callback])
+void replaceProps(object nextProps[, function callback])
 ```
 
 `setProps()`와 비슷하지만 두 객체를 합치는 대신 이전에 존재하던 props를 삭제합니다.

--- a/docs/docs/ref-02-component-api.md
+++ b/docs/docs/ref-02-component-api.md
@@ -14,7 +14,7 @@ Instances of a React Component are created internally in React when rendering. T
 ### setState
 
 ```javascript
-setState(
+void setState(
   function|object nextState,
   [function callback]
 )
@@ -53,7 +53,7 @@ The second (optional) parameter is a callback function that will be executed onc
 ### replaceState
 
 ```javascript
-replaceState(
+void replaceState(
   object nextState,
   [function callback]
 )
@@ -69,7 +69,7 @@ Like `setState()` but deletes any pre-existing state keys that are not in nextSt
 ### forceUpdate
 
 ```javascript
-forceUpdate(
+void forceUpdate(
   [function callback]
 )
 ```
@@ -99,7 +99,7 @@ If this component has been mounted into the DOM, this returns the corresponding 
 ### isMounted
 
 ```javascript
-bool isMounted()
+boolean isMounted()
 ```
 
 `isMounted()` returns `true` if the component is rendered into the DOM, `false` otherwise. You can use this method to guard asynchronous calls to `setState()` or `forceUpdate()`.
@@ -112,7 +112,7 @@ bool isMounted()
 ### setProps
 
 ```javascript
-setProps(
+void setProps(
   object nextProps,
   [function callback]
 )
@@ -133,7 +133,7 @@ Calling `setProps()` on a root-level component will change its properties and tr
 ### replaceProps
 
 ```javascript
-replaceProps(
+void replaceProps(
   object nextProps,
   [function callback]
 )

--- a/docs/docs/ref-03-component-specs.it-IT.md
+++ b/docs/docs/ref-03-component-specs.it-IT.md
@@ -109,7 +109,7 @@ Vari metodi vengono eseguiti durante precisi momenti del ciclo di vita di un com
 ### Montaggio: componentWillMount
 
 ```javascript
-componentWillMount()
+void componentWillMount()
 ```
 
 Invocato una volta, sia sul client che sul server, immediatamente prima che il rendering iniziale abbia luogo. Se chiami `setState` all'interno di questo metodo, `render()` vedrà lo stato aggiornato e sarà eseguito solo una volta nonostante il cambiamento di stato.
@@ -118,7 +118,7 @@ Invocato una volta, sia sul client che sul server, immediatamente prima che il r
 ### Montaggio: componentDidMount
 
 ```javascript
-componentDidMount()
+void componentDidMount()
 ```
 
 Invocato una volta, solo sul client (e non sul server), immediatamente dopo che il rendering iniziale ha avuto luogo. A questo punto del ciclo di vita, il componente ha una rappresentazione DOM che puoi accedere attraverso `React.findDOMNode(this)`. Il metodo `componentDidMount()` dei componenti figli è invocato prima di quello dei componenti genitori.
@@ -129,7 +129,7 @@ Se desideri integrare con altri framework JavaScript, impostare dei timer usando
 ### Aggiornamento: componentWillReceiveProps
 
 ```javascript
-componentWillReceiveProps(
+void componentWillReceiveProps(
   object nextProps
 )
 ```
@@ -179,7 +179,7 @@ Se le prestazioni diventano un collo di bottiglia, specialmente in presenza di  
 ### Aggiornamento: componentWillUpdate
 
 ```javascript
-componentWillUpdate(
+void componentWillUpdate(
   object nextProps, object nextState
 )
 ```
@@ -196,7 +196,7 @@ Usa questo metodo come opportunità per effettuare la preparazione prima che si 
 ### Aggiornamento: componentDidUpdate
 
 ```javascript
-componentDidUpdate(
+void componentDidUpdate(
   object prevProps, object prevState
 )
 ```
@@ -209,7 +209,7 @@ Usa questo metodo come opportunità per operare sul DOM quando il componente è 
 ### Smontaggio: componentWillUnmount
 
 ```javascript
-componentWillUnmount()
+void componentWillUnmount()
 ```
 
 Invocato immediatamente prima che un componente venga smontato dal DOM.

--- a/docs/docs/ref-03-component-specs.ko-KR.md
+++ b/docs/docs/ref-03-component-specs.ko-KR.md
@@ -110,7 +110,7 @@ string displayName
 ### 마운트 시: componentWillMount
 
 ```javascript
-componentWillMount()
+void componentWillMount()
 ```
 
 최초 렌더링이 일어나기 직전에 클라이언트 및 서버에서 한번 호출됩니다. 이 메소드 안에서 `setState`를 호출하면, `render()`에서 업데이트된 state를 확인할 수 있고 state가 변함에도 불구하고 `render()`가 한번만 실행됩니다.
@@ -119,7 +119,7 @@ componentWillMount()
 ### 마운트 시: componentDidMount
 
 ```javascript
-componentDidMount()
+void componentDidMount()
 ```
 
 최초 렌더링이 일어난 다음 클라이언트에서만 한번 호출됩니다. (서버에서는 호출되지 않습니다.) 이 시점에 컴포넌트는 `React.findDOMNode(this)`로 접근 가능한 DOM 표현을 가집니다.
@@ -130,7 +130,7 @@ componentDidMount()
 ### 업데이트 시: componentWillReceiveProps
 
 ```javascript
-componentWillReceiveProps(object nextProps)
+void componentWillReceiveProps(object nextProps)
 ```
 
 컴포넌트가 새로운 props를 받을 때 호출됩니다. 이 메소드는 최초 렌더링 시에는 호출되지 않습니다.
@@ -178,7 +178,7 @@ shouldComponentUpdate: function(nextProps, nextState) {
 ### 업데이트 시: componentWillUpdate
 
 ```javascript
-componentWillUpdate(object nextProps, object nextState)
+void componentWillUpdate(object nextProps, object nextState)
 ```
 
 새로운 props나 state를 받았을 때 렌더링 직전에 호출됩니다. 최초 렌더링 시에는 호출되지 않습니다.
@@ -193,7 +193,7 @@ componentWillUpdate(object nextProps, object nextState)
 ### 업데이트 시: componentDidUpdate
 
 ```javascript
-componentDidUpdate(object prevProps, object prevState)
+void componentDidUpdate(object prevProps, object prevState)
 ```
 
 컴포넌트의 업데이트가 DOM에 반영된 직후에 호출됩니다. 최초 렌더링 시에는 호출되지 않습니다.
@@ -204,7 +204,7 @@ componentDidUpdate(object prevProps, object prevState)
 ### 마운트 해제 시: componentWillUnmount
 
 ```javascript
-componentWillUnmount()
+void componentWillUnmount()
 ```
 
 컴포넌트가 DOM에서 마운트 해제 되기 직전에 호출됩니다.

--- a/docs/docs/ref-03-component-specs.md
+++ b/docs/docs/ref-03-component-specs.md
@@ -109,7 +109,7 @@ Various methods are executed at specific points in a component's lifecycle.
 ### Mounting: componentWillMount
 
 ```javascript
-componentWillMount()
+void componentWillMount()
 ```
 
 Invoked once, both on the client and server, immediately before the initial rendering occurs. If you call `setState` within this method, `render()` will see the updated state and will be executed only once despite the state change.
@@ -118,7 +118,7 @@ Invoked once, both on the client and server, immediately before the initial rend
 ### Mounting: componentDidMount
 
 ```javascript
-componentDidMount()
+void componentDidMount()
 ```
 
 Invoked once, only on the client (not on the server), immediately after the initial rendering occurs. At this point in the lifecycle, the component has a DOM representation which you can access via `React.findDOMNode(this)`. The `componentDidMount()` method of child components is invoked before that of parent components.
@@ -129,7 +129,7 @@ If you want to integrate with other JavaScript frameworks, set timers using `set
 ### Updating: componentWillReceiveProps
 
 ```javascript
-componentWillReceiveProps(
+void componentWillReceiveProps(
   object nextProps
 )
 ```
@@ -180,7 +180,7 @@ If performance is a bottleneck, especially with dozens or hundreds of components
 ### Updating: componentWillUpdate
 
 ```javascript
-componentWillUpdate(
+void componentWillUpdate(
   object nextProps, object nextState
 )
 ```
@@ -197,7 +197,7 @@ Use this as an opportunity to perform preparation before an update occurs.
 ### Updating: componentDidUpdate
 
 ```javascript
-componentDidUpdate(
+void componentDidUpdate(
   object prevProps, object prevState
 )
 ```
@@ -210,7 +210,7 @@ Use this as an opportunity to operate on the DOM when the component has been upd
 ### Unmounting: componentWillUnmount
 
 ```javascript
-componentWillUnmount()
+void componentWillUnmount()
 ```
 
 Invoked immediately before a component is unmounted from the DOM.

--- a/docs/docs/ref-05-events.it-IT.md
+++ b/docs/docs/ref-05-events.it-IT.md
@@ -93,17 +93,17 @@ Proprietà:
 
 ```javascript
 boolean altKey
-Number charCode
+number charCode
 boolean ctrlKey
-function getModifierState(key)
-String key
-Number keyCode
-String locale
-Number location
+boolean getModifierState(key)
+string key
+number keyCode
+string locale
+number location
 boolean metaKey
 boolean repeat
 boolean shiftKey
-Number which
+number which
 ```
 
 
@@ -149,18 +149,18 @@ Proprietà:
 
 ```javascript
 boolean altKey
-Number button
-Number buttons
-Number clientX
-Number clientY
+number button
+number buttons
+number clientX
+number clientY
 boolean ctrlKey
-function getModifierState(key)
+boolean getModifierState(key)
 boolean metaKey
-Number pageX
-Number pageY
+number pageX
+number pageY
 DOMEventTarget relatedTarget
-Number screenX
-Number screenY
+number screenX
+number screenY
 boolean shiftKey
 ```
 
@@ -179,7 +179,7 @@ Proprietà:
 boolean altKey
 DOMTouchList changedTouches
 boolean ctrlKey
-function getModifierState(key)
+boolean getModifierState(key)
 boolean metaKey
 boolean shiftKey
 DOMTouchList targetTouches
@@ -198,7 +198,7 @@ onScroll
 Proprietà:
 
 ```javascript
-Number detail
+number detail
 DOMAbstractView view
 ```
 
@@ -214,10 +214,10 @@ onWheel
 Proprietà:
 
 ```javascript
-Number deltaMode
-Number deltaX
-Number deltaY
-Number deltaZ
+number deltaMode
+number deltaX
+number deltaY
+number deltaZ
 ```
 
 ### Eventi dei Media

--- a/docs/docs/ref-05-events.ko-KR.md
+++ b/docs/docs/ref-05-events.ko-KR.md
@@ -68,17 +68,17 @@ onKeyDown onKeyPress onKeyUp
 
 ```javascript
 boolean altKey
-Number charCode
+number charCode
 boolean ctrlKey
-function getModifierState(key)
-String key
-Number keyCode
-String locale
-Number location
+boolean getModifierState(key)
+string key
+number keyCode
+string locale
+number location
 boolean metaKey
 boolean repeat
 boolean shiftKey
-Number which
+number which
 ```
 
 
@@ -124,18 +124,18 @@ onMouseMove onMouseOut onMouseOver onMouseUp
 
 ```javascript
 boolean altKey
-Number button
-Number buttons
-Number clientX
-Number clientY
+number button
+number buttons
+number clientX
+number clientY
 boolean ctrlKey
-function getModifierState(key)
+boolean getModifierState(key)
 boolean metaKey
-Number pageX
-Number pageY
+number pageX
+number pageY
 DOMEventTarget relatedTarget
-Number screenX
-Number screenY
+number screenX
+number screenY
 boolean shiftKey
 ```
 
@@ -154,7 +154,7 @@ onTouchCancel onTouchEnd onTouchMove onTouchStart
 boolean altKey
 DOMTouchList changedTouches
 boolean ctrlKey
-function getModifierState(key)
+boolean getModifierState(key)
 boolean metaKey
 boolean shiftKey
 DOMTouchList targetTouches
@@ -173,7 +173,7 @@ onScroll
 프로퍼티:
 
 ```javascript
-Number detail
+number detail
 DOMAbstractView view
 ```
 
@@ -189,10 +189,10 @@ onWheel
 프로퍼티:
 
 ```javascript
-Number deltaMode
-Number deltaX
-Number deltaY
-Number deltaZ
+number deltaMode
+number deltaX
+number deltaY
+number deltaZ
 ```
 
 ### 미디어 이벤트

--- a/docs/docs/ref-05-events.md
+++ b/docs/docs/ref-05-events.md
@@ -94,17 +94,17 @@ Properties:
 
 ```javascript
 boolean altKey
-Number charCode
+number charCode
 boolean ctrlKey
-function getModifierState(key)
-String key
-Number keyCode
-String locale
-Number location
+boolean getModifierState(key)
+string key
+number keyCode
+string locale
+number location
 boolean metaKey
 boolean repeat
 boolean shiftKey
-Number which
+number which
 ```
 
 
@@ -150,18 +150,18 @@ Properties:
 
 ```javascript
 boolean altKey
-Number button
-Number buttons
-Number clientX
-Number clientY
+number button
+number buttons
+number clientX
+number clientY
 boolean ctrlKey
-function getModifierState(key)
+boolean getModifierState(key)
 boolean metaKey
-Number pageX
-Number pageY
+number pageX
+number pageY
 DOMEventTarget relatedTarget
-Number screenX
-Number screenY
+number screenX
+number screenY
 boolean shiftKey
 ```
 
@@ -180,7 +180,7 @@ Properties:
 boolean altKey
 DOMTouchList changedTouches
 boolean ctrlKey
-function getModifierState(key)
+boolean getModifierState(key)
 boolean metaKey
 boolean shiftKey
 DOMTouchList targetTouches
@@ -199,7 +199,7 @@ onScroll
 Properties:
 
 ```javascript
-Number detail
+number detail
 DOMAbstractView view
 ```
 
@@ -215,10 +215,10 @@ onWheel
 Properties:
 
 ```javascript
-Number deltaMode
-Number deltaX
-Number deltaY
-Number deltaZ
+number deltaMode
+number deltaX
+number deltaY
+number deltaZ
 ```
 
 ### Media Events

--- a/docs/docs/ref-05-events.zh-CN.md
+++ b/docs/docs/ref-05-events.zh-CN.md
@@ -17,7 +17,7 @@ boolean bubbles
 boolean cancelable
 DOMEventTarget currentTarget
 boolean defaultPrevented
-Number eventPhase
+number eventPhase
 boolean isTrusted
 DOMEvent nativeEvent
 void preventDefault()
@@ -25,8 +25,8 @@ boolean isDefaultPrevented()
 void stopPropagation()
 boolean isPropagationStopped()
 DOMEventTarget target
-Date timeStamp
-String type
+number timeStamp
+string type
 ```
 
 > 注意：
@@ -68,17 +68,17 @@ onKeyDown onKeyPress onKeyUp
 
 ```javascript
 boolean altKey
-Number charCode
+number charCode
 boolean ctrlKey
-function getModifierState(key)
-String key
-Number keyCode
-String locale
-Number location
+boolean getModifierState(key)
+string key
+number keyCode
+string locale
+number location
 boolean metaKey
 boolean repeat
 boolean shiftKey
-Number which
+number which
 ```
 
 
@@ -122,18 +122,18 @@ onMouseMove onMouseOut onMouseOver onMouseUp
 
 ```javascript
 boolean altKey
-Number button
-Number buttons
-Number clientX
-Number clientY
+number button
+number buttons
+number clientX
+number clientY
 boolean ctrlKey
-function getModifierState(key)
+boolean getModifierState(key)
 boolean metaKey
-Number pageX
-Number pageY
+number pageX
+number pageY
 DOMEventTarget relatedTarget
-Number screenX
-Number screenY
+number screenX
+number screenY
 boolean shiftKey
 ```
 
@@ -152,7 +152,7 @@ onTouchCancel onTouchEnd onTouchMove onTouchStart
 boolean altKey
 DOMTouchList changedTouches
 boolean ctrlKey
-function getModifierState(key)
+boolean getModifierState(key)
 boolean metaKey
 boolean shiftKey
 DOMTouchList targetTouches
@@ -171,7 +171,7 @@ onScroll
 属性：
 
 ```javascript
-Number detail
+number detail
 DOMAbstractView view
 ```
 
@@ -187,8 +187,8 @@ onWheel
 属性：
 
 ```javascript
-Number deltaMode
-Number deltaX
-Number deltaY
-Number deltaZ
+number deltaMode
+number deltaX
+number deltaY
+number deltaZ
 ```


### PR DESCRIPTION
- make all types lowercase
- replace `function` type with type function returns
- add `void` type to functions which has no return
- replace `bool` with `boolean`