### PR TITLE
Text fix in ReactClass.js

### DIFF
--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -455,7 +455,8 @@ function mixSpecIntoComponent(Constructor, spec) {
   invariant(
     typeof spec !== 'function',
     'ReactClass: You\'re attempting to ' +
-    'use a component class as a mixin. Instead, just use a regular object.'
+    'use a component class or function as a mixin. Instead, just use a ' +
+    'regular object.'
   );
   invariant(
     !ReactElement.isValidElement(spec),

--- a/src/isomorphic/classic/class/__tests__/ReactClassMixin-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactClassMixin-test.js
@@ -347,7 +347,8 @@ describe('ReactClass-mixin', function() {
       });
     }).toThrow(
       'Invariant Violation: ReactClass: You\'re attempting to ' +
-      'use a component class as a mixin. Instead, just use a regular object.'
+      'use a component class or function as a mixin. Instead, just use a ' +
+      'regular object.'
     );
   });
 


### PR DESCRIPTION
It's better to add `function` in the message since we are checking with `typeof spec !== 'function'`