### PR TITLE
fix(docs): adjust babel release to match the babel.js changelog

### DIFF
--- a/docs/_posts/2015-10-07-react-v0.14.md
+++ b/docs/_posts/2015-10-07-react-v0.14.md
@@ -99,7 +99,7 @@ If you can’t use `npm` yet, we provide pre-built browser builds for your conve
     ```
 
     This change also applies to the return result of `ReactDOM.render` when passing a DOM node as the top component. As with refs, this change does not affect custom components.
-    
+
     With this change, we’re deprecating `.getDOMNode()` and replacing it with `ReactDOM.findDOMNode` (see below). If your components are currently using `.getDOMNode()`, they will continue to work with a warning until 0.15.
 
 - #### Stateless functional components
@@ -124,7 +124,7 @@ If you can’t use `npm` yet, we provide pre-built browser builds for your conve
     ```
 
     These components behave just like a React class with only a `render` method defined. Since no component instance is created for a functional component, any `ref` added to one will evaluate to `null`. Functional components do not have lifecycle methods, but you can set `.propTypes` and `.defaultProps` as properties on the function.
-    
+
     This pattern is designed to encourage the creation of these simple components that should comprise large portions of your apps. In the future, we’ll also be able to make performance optimizations specific to these components by avoiding unnecessary checks and memory allocations.
 
 - #### Deprecation of react-tools
@@ -133,7 +133,7 @@ If you can’t use `npm` yet, we provide pre-built browser builds for your conve
 
 - #### Compiler optimizations
 
-    React now supports two compiler optimizations that can be enabled in Babel 5.8.23 and newer. Both of these transforms **should be enabled only in production** (e.g., just before minifying your code) because although they improve runtime performance, they make warning messages more cryptic and skip important checks that happen in development mode, including propTypes.
+    React now supports two compiler optimizations that can be enabled in Babel 5.8.24 and newer. Both of these transforms **should be enabled only in production** (e.g., just before minifying your code) because although they improve runtime performance, they make warning messages more cryptic and skip important checks that happen in development mode, including propTypes.
 
     **Inlining React elements:** The `optimisation.react.inlineElements` transform converts JSX elements to object literals like `{type: 'div', props: ...}` instead of calls to `React.createElement`.
 


### PR DESCRIPTION
Per the babel changelog, the transformer updates went out in 5.8.24 instead of 5.8.23 - https://github.com/babel/babel/blob/master/CHANGELOG.md#5824