### PR TITLE
[docs] fix forms Default Value example

### DIFF
--- a/docs/docs/07-forms.md
+++ b/docs/docs/07-forms.md
@@ -95,7 +95,7 @@ If you want to initialize the component with a non-empty value, you can supply a
   }
 ```
 
-This example will function much like the **Controlled Components** example above.
+This example will function much like the **Uncontrolled Components** example above.
 
 Likewise, `<input>` supports `defaultChecked` and `<select>` supports `defaultValue`.
 


### PR DESCRIPTION
The Default Value section in the forms docs says "This example will function much like the Controlled Components example above."

The example actually functions like the Uncontrolled Components example, not the Controlled Components example.