### PR TITLE
add test to show `this` is indeed undefined - closes #3613

### DIFF
--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
@@ -279,6 +279,17 @@ describe('ReactDOMInput', function() {
     expect(console.error.argsForCall.length).toBe(1);
   });
 
+  it('should have a this value of undefined if bind is not used', function() {
+    var unboundInputOnChange = function() {
+      expect(this).toBe(undefined);
+    };
+
+    var instance = <input type="text" onChange={unboundInputOnChange} />;
+    instance = ReactTestUtils.renderIntoDocument(instance);
+
+    ReactTestUtils.Simulate.change(instance);
+  });
+
   it('should throw if both value and valueLink are provided', function() {
     var node = document.createElement('div');
     var link = new ReactLink('yolo', mocks.getMockFunction());


### PR DESCRIPTION
Turns out #3613 was fixed in 52a229f168ea10c342d0e69e1ddc63d425579656