### PR TITLE
fix render callback context when update

### DIFF
--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -626,11 +626,14 @@ var ReactMount = {
       var prevWrappedElement = prevComponent._currentElement;
       var prevElement = prevWrappedElement.props;
       if (shouldUpdateReactComponent(prevElement, nextElement)) {
+        var updatedCallback = callback && function() {
+          callback.call(prevComponent._renderedComponent.getPublicInstance());
+        };
         return ReactMount._updateRootComponent(
           prevComponent,
           nextWrappedElement,
           container,
-          callback
+          updatedCallback
         )._renderedComponent.getPublicInstance();
       } else {
         ReactMount.unmountComponentAtNode(container);

--- a/src/renderers/dom/client/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMount-test.js
@@ -300,4 +300,45 @@ describe('ReactMount', function() {
     ReactDOM.render(<Component step={1} />, container);
     ReactMount.getID(container.querySelector('a'));
   });
+
+  it('should specify correct context in callback when update', function() {
+    var Component = React.createClass({
+      componentDidUpdate() {
+        var self = this;
+        var node = ReactDOM.render(<div data-id="2"></div>, self.div, function() {
+          expect(this).toBe(self.div.firstChild);
+          expect(this.getAttribute && this.getAttribute('data-id')).toBe('2');
+        });
+        expect(node.getAttribute('data-id')).toBe('1');
+      },
+      componentDidMount() {
+        var div = document.createElement('div');
+        document.body.appendChild(div);
+        // this applies to custom component too!
+        var node = ReactDOM.render(<div data-id="1"></div>, div, function() {
+          expect(this).toBe(div.firstChild);
+          expect(this.getAttribute('data-id')).toBe('1');
+        });
+        expect(node.getAttribute('data-id')).toBe('1');
+        this.div = div;
+      },
+      componentWillUnmount() {
+        if (this.div) {
+          ReactDOM.unmountComponentAtNode(this.div);
+          document.body.removeChild(this.div);
+        }
+      },
+      render() {
+        return <div></div>;
+      },
+    });
+    var container = document.createElement('div');
+    document.body.appendChild(container);
+    var root = ReactDOM.render(<Component />, container);
+    root.setState({
+      time: 1,
+    });
+    ReactDOM.unmountComponentAtNode(container);
+    document.body.removeChild(container);
+  });
 });


### PR DESCRIPTION
**this change in 0.14.0 breaks compatibility**

Can not use instance which returned by React.render when update involves batching, and update render callback's context should be consistent with render when init.

https://jsfiddle.net/yiminghe/3h1o7mj5/1/