### PR TITLE
Jasmine spies call count property consistency, take II

### DIFF
--- a/src/renderers/dom/client/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMount-test.js
@@ -237,7 +237,7 @@ describe('ReactMount', function() {
     spyOn(console, 'error');
     var rootNode = container.firstChild;
     ReactDOM.render(<span />, rootNode);
-    expect(console.error.callCount).toBe(1);
+    expect(console.error.calls.length).toBe(1);
     expect(console.error.mostRecentCall.args[0]).toBe(
       'Warning: render(...): Replacing React-rendered children with a new ' +
       'root component. If you intended to update the children of this node, ' +

--- a/src/renderers/dom/client/__tests__/ReactMountDestruction-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMountDestruction-test.js
@@ -53,7 +53,7 @@ describe('ReactMount', function() {
     var rootDiv = mainContainerDiv.firstChild;
     spyOn(console, 'error');
     ReactDOM.unmountComponentAtNode(rootDiv);
-    expect(console.error.callCount).toBe(1);
+    expect(console.error.calls.length).toBe(1);
     expect(console.error.mostRecentCall.args[0]).toBe(
       'Warning: unmountComponentAtNode(): The node you\'re attempting to ' +
       'unmount was rendered by React and is not a top-level container. You ' +
@@ -77,7 +77,7 @@ describe('ReactMount', function() {
     var nonRootDiv = mainContainerDiv.firstChild.firstChild;
     spyOn(console, 'error');
     ReactDOM.unmountComponentAtNode(nonRootDiv);
-    expect(console.error.callCount).toBe(1);
+    expect(console.error.calls.length).toBe(1);
     expect(console.error.mostRecentCall.args[0]).toBe(
       'Warning: unmountComponentAtNode(): The node you\'re attempting to ' +
       'unmount was rendered by React and is not a top-level container. ' +

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -522,7 +522,7 @@ describe('ReactCompositeComponent', function() {
     // unmountIDFromEnvironment which calls purgeID, for a total of 3.
     // TODO: Test the effect of this. E.g. does the node cache get repopulated
     // after a getDOMNode call?
-    expect(ReactMount.purgeID.callCount).toBe(3);
+    expect(ReactMount.purgeID.calls.length).toBe(3);
   });
 
   it('should warn when shouldComponentUpdate() returns undefined', function() {


### PR DESCRIPTION
Continuation of #3105.

----

### stats:
- `calls.length`: 243 matches across 33 files
- `callCount`: 4 matches across 3 files

Converted `callCount` to the consistent property `calls.length` across all tests.