### PR TITLE
Fix #1357. Don't append "px" suffix to CSS string values.

### DIFF
--- a/src/renderers/dom/shared/CSSPropertyOperations.js
+++ b/src/renderers/dom/shared/CSSPropertyOperations.js
@@ -125,9 +125,10 @@ var CSSPropertyOperations = {
    * The result should be HTML-escaped before insertion into the DOM.
    *
    * @param {object} styles
+   * @param {ReactDOMComponent} component
    * @return {?string}
    */
-  createMarkupForStyles: function(styles) {
+  createMarkupForStyles: function(styles, component) {
     var serialized = '';
     for (var styleName in styles) {
       if (!styles.hasOwnProperty(styleName)) {
@@ -139,7 +140,7 @@ var CSSPropertyOperations = {
       }
       if (styleValue != null) {
         serialized += processStyleName(styleName) + ':';
-        serialized += dangerousStyleValue(styleName, styleValue) + ';';
+        serialized += dangerousStyleValue(styleName, styleValue, component) + ';';
       }
     }
     return serialized || null;

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -714,7 +714,7 @@ ReactDOMComponent.Mixin = {
             }
             propValue = this._previousStyleCopy = assign({}, props.style);
           }
-          propValue = CSSPropertyOperations.createMarkupForStyles(propValue);
+          propValue = CSSPropertyOperations.createMarkupForStyles(propValue, this);
         }
         var markup = null;
         if (this._tag != null && isCustomComponent(this._tag, props)) {

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -147,6 +147,46 @@ describe('ReactDOMComponent', function() {
       expect(console.error.argsForCall.length).toBe(2);
     });
 
+    it('should warn about styles with numeric string values for non-unitless properties', function() {
+      spyOn(console, 'error');
+
+      var div = document.createElement('div');
+      var One = React.createClass({
+        render: function() {
+          return this.props.inline ? <span style={{fontSize: '1'}} /> : <div style={{fontSize: '1'}} />;
+        },
+      });
+      var Two = React.createClass({
+        render: function() {
+          return <div style={{fontSize: '1'}} />;
+        },
+      });
+      ReactDOM.render(<One inline={false} />, div);
+      expect(console.error.calls.length).toBe(1);
+      expect(console.error.argsForCall[0][0]).toBe(
+        'Warning: a `div` tag (owner: `One`) was passed a numeric string value ' +
+        'for CSS property `fontSize` (value: `1`) which will be treated ' +
+        'as a unitless number in a future version of React.'
+      );
+
+      // Don't warn again for the same component
+      ReactDOM.render(<One inline={true} />, div);
+      expect(console.error.calls.length).toBe(1);
+
+      // Do warn for different components
+      ReactDOM.render(<Two />, div);
+      expect(console.error.calls.length).toBe(2);
+      expect(console.error.argsForCall[1][0]).toBe(
+        'Warning: a `div` tag (owner: `Two`) was passed a numeric string value ' +
+        'for CSS property `fontSize` (value: `1`) which will be treated ' +
+        'as a unitless number in a future version of React.'
+      );
+
+      // Really don't warn again for the same component
+      ReactDOM.render(<One inline={true} />, div);
+      expect(console.error.calls.length).toBe(2);
+    });
+
     it('should warn semi-nicely about NaN in style', function() {
       spyOn(console, 'error');
 


### PR DESCRIPTION
This implements the change discussed in #1357 by simply not appending "px" if the CSS value is already a string.