### PR TITLE
Stop generating gh-pages during release, update message

### DIFF
--- a/grunt/tasks/release.js
+++ b/grunt/tasks/release.js
@@ -12,8 +12,6 @@ var BOWER_FILES = [
   'react-dom.js',
   'react-dom.min.js',
 ];
-var GH_PAGES_PATH = '../react-gh-pages/';
-var GH_PAGES_GLOB = [GH_PAGES_PATH + '*'];
 
 var EXAMPLES_PATH = 'examples/';
 var EXAMPLES_GLOB = [EXAMPLES_PATH + '**/*.*'];
@@ -75,12 +73,6 @@ function setup() {
     return false;
   }
 
-  if (!grunt.file.exists(GH_PAGES_PATH)) {
-    grunt.log.error('Make sure you have the react gh-pages branch checked ' +
-                    'out at ../react-gh-pages.');
-    return false;
-  }
-
   VERSION = grunt.config.data.pkg.version;
   VERSION_STRING = 'v' + VERSION;
 }
@@ -104,28 +96,9 @@ function bower() {
 }
 
 function docs() {
-  var done = this.async();
-
   grunt.file.copy('build/react-' + VERSION + '.zip', 'docs/downloads/react-' + VERSION + '.zip');
   grunt.file.copy('build/react.js', 'docs/js/react.js');
   grunt.file.copy('build/react-dom.js', 'docs/js/react-dom.js');
-
-  var files = grunt.file.expand(GH_PAGES_GLOB);
-  files.forEach(function(file) {
-    grunt.file.delete(file, {force: true});
-  });
-
-  // Build the docs with `rake release`, which will compile the CSS & JS, then
-  // build jekyll into GH_PAGES_PATH
-  var rakeOpts = {
-    cmd: 'rake',
-    args: ['release'],
-    opts: {cwd: 'docs'},
-  };
-  grunt.util.spawn(rakeOpts, function() {
-    // Commit the repo. We don't really care about tagging this.
-    _gitCommitAndTag(GH_PAGES_PATH, VERSION_STRING, null, done);
-  });
 }
 
 function msg() {
@@ -134,8 +107,10 @@ function msg() {
   var steps = [
     'Still todo:',
     '* put files on CDN',
+    '* add starter pack (git add -f docs/downloads/react-version.zip)',
     '* push changes to git repositories',
-    '* publish npm module (`npm publish .`)',
+    '* update docs branch variable in Travis CI',
+    '* publish npm modules',
     '* announce it on FB/Twitter/mailing list',
   ];
   steps.forEach(function(ln) {


### PR DESCRIPTION
We don't push the gh-pages branch directly anymore so get rid of that code from our release process.