### PR TITLE
add npm 3.x to devengines

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devEngines": {
     "node": "4.x",
-    "npm": "2.x"
+    "npm": "2.x || 3.x"
   },
   "commonerConfig": {
     "version": 7


### PR DESCRIPTION
Maybe this isn't specific enough?  Everything installs fine on 3.3.6