### PR TITLE
Use 'document.createEvent' not 'new Event'

### DIFF
--- a/src/shared/utils/ReactErrorUtils.js
+++ b/src/shared/utils/ReactErrorUtils.js
@@ -61,13 +61,14 @@ if (__DEV__) {
    * real browser event.
    */
   if (typeof window !== 'undefined' &&
-      typeof window.dispatchEvent === 'function' &&
-      typeof Event === 'function') {
+      typeof window.dispatchEvent === 'function') {
     var fakeNode = document.createElement('react');
     ReactErrorUtils.invokeGuardedCallback = function(name, func, a, b) {
       var boundFunc = func.bind(null, a, b);
       fakeNode.addEventListener(name, boundFunc, false);
-      fakeNode.dispatchEvent(new Event(name));
+      var evt = document.createEvent('Event');
+      evt.initEvent(name, false, false);
+      fakeNode.dispatchEvent(evt);
       fakeNode.removeEventListener(name, boundFunc, false);
     };
   }


### PR DESCRIPTION
Fixes #5153.

This seems to work in all browsers I tested, including old Android and all IE > 8 which didn't work before.