### PR TITLE
Correctly handle 0 in CSSTransitionGroup timeout props

### DIFF
--- a/src/addons/transitions/ReactCSSTransitionGroup.js
+++ b/src/addons/transitions/ReactCSSTransitionGroup.js
@@ -27,7 +27,7 @@ function createTransitionTimeoutPropValidator(transitionType) {
     // If the transition is enabled
     if (props[enabledPropName]) {
       // If no timeout duration is provided
-      if (!props[timeoutPropName]) {
+      if (props[timeoutPropName] == null) {
         return new Error(
           timeoutPropName + ' wasn\'t supplied to ReactCSSTransitionGroup: ' +
           'this can cause unreliable animations and won\'t be supported in ' +

--- a/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
@@ -23,6 +23,7 @@ describe('ReactCSSTransitionGroup', function() {
   var container;
 
   beforeEach(function() {
+    require('mock-modules').dumpCache();
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactCSSTransitionGroup = require('ReactCSSTransitionGroup');
@@ -45,6 +46,22 @@ describe('ReactCSSTransitionGroup', function() {
 
     // Warning about the missing transitionLeaveTimeout prop
     expect(console.error.argsForCall.length).toBe(1);
+  });
+
+  it('should not warn if timeouts is zero', function() {
+    ReactDOM.render(
+      <ReactCSSTransitionGroup
+        transitionName="yolo"
+        transitionEnter={false}
+        transitionLeave={true}
+        transitionLeaveTimeout={0}
+      >
+        <span key="one" id="one" />
+      </ReactCSSTransitionGroup>,
+      container
+    );
+
+    expect(console.error.argsForCall.length).toBe(0);
   });
 
   it('should clean-up silently after the timeout elapses', function() {


### PR DESCRIPTION
Fixes #5162.

I used the `== null` check, which is what we do for `.isRequired` and that's what we're trying to emulate there.