### PR TITLE
Don't test frag cases in ReactMultiChildText-test

### DIFF
--- a/src/renderers/shared/reconciler/__tests__/ReactMultiChildText-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactMultiChildText-test.js
@@ -15,10 +15,7 @@ require('mock-modules');
 
 var React = require('React');
 var ReactDOM = require('ReactDOM');
-var ReactFragment = require('ReactFragment');
 var ReactTestUtils = require('ReactTestUtils');
-
-var frag = ReactFragment.create;
 
 // Helpers
 var testAllPermutations = function(testCases) {
@@ -163,20 +160,6 @@ describe('ReactMultiChildText', function() {
 
       [true, [1.2, '', <div />, 'foo'], true, 1.2], ['1.2', '', <div />, 'foo', '1.2'],
       ['', 'foo', [true, <div />, 1.2, ''], 'foo'], ['', 'foo', <div />, '1.2', '', 'foo'],
-
-      // values inside objects
-      [frag({a: true}), frag({a: true})], [],
-      [frag({a: 1.2}), frag({a: 1.2})], ['1.2', '1.2'],
-      [frag({a: ''}), frag({a: ''})], ['', ''],
-      [frag({a: 'foo'}), frag({a: 'foo'})], ['foo', 'foo'],
-      [frag({a: <div />}), frag({a: <div />})], [<div />, <div />],
-
-      [frag({a: true, b: 1.2, c: <div />}), '', 'foo'], ['1.2', <div />, '', 'foo'],
-      [1.2, '', frag({a: <div />, b: 'foo', c: true})], ['1.2', '', <div />, 'foo'],
-      ['', frag({a: 'foo', b: <div />, c: true}), 1.2], ['', 'foo', <div />, '1.2'],
-
-      [true, frag({a: 1.2, b: '', c: <div />, d: 'foo'}), true, 1.2], ['1.2', '', <div />, 'foo', '1.2'],
-      ['', 'foo', frag({a: true, b: <div />, c: 1.2, d: ''}), 'foo'], ['', 'foo', <div />, '1.2', '', 'foo'],
 
       // values inside elements
       [<div>{true}{1.2}{<div />}</div>, '', 'foo'], [<div />, '', 'foo'],


### PR DESCRIPTION
These are now just testing the same as the array cases directly above. This should make this test a bunch faster because it (intentionally) has n^2 runtime.