### PR TITLE
Fix blog post authors

### DIFF
--- a/docs/_data/authors.yml
+++ b/docs/_data/authors.yml
@@ -1,8 +1,6 @@
 # Map of short name to more information. `name` will be used but if you don't
 # want to use your real name, just use whatever. If url is included, your name
 # will be a link to the provided url.
-billandjing:
-  name: Bill Fisher and Jing Chen
 chenglou:
   name: Cheng Lou
   url: https://twitter.com/_chenglou
@@ -18,8 +16,12 @@ jaredly:
 jgebhardt:
   name: Jonas Gebhardt
   url: https://twitter.com/jonasgebhardt
-jimandsebastian:
-  name: Jim Sproch and Sebastian Markbåge
+jimfb:
+  name: Jim Sproch
+  url: http://www.jimsproch.com
+jingc:
+  name: Jing Chen
+  url: https://twitter.com/jingc
 josephsavona:
   name: Joseph Savona
   url: https://twitter.com/en_JS

--- a/docs/_includes/blog_post.html
+++ b/docs/_includes/blog_post.html
@@ -11,11 +11,14 @@
 <p class="meta">
   {{ page.date | date: "%B %e, %Y" }}
   by
-  {% if page.author.url %}
-    <a href="{{page.author.url}}">{{ page.author.name }}</a>
-  {% else %}
-    {{ page.author.name }}
-  {% endif %}
+  {% for author in page.authors %}
+    {% if author.url %}
+      <a href="{{author.url}}">{{ author.name }}</a>
+    {% else %}
+      {{ author.name }}
+    {% endif %}
+    {% if forloop.last == false %} and {% endif %}
+  {% endfor %}
 </p>
 
 <hr>

--- a/docs/_plugins/authors.rb
+++ b/docs/_plugins/authors.rb
@@ -7,7 +7,15 @@ module Authors
   class Generator < Jekyll::Generator
     def generate(site)
       site.posts.each do |post|
-        post.data['author'] = site.data['authors'][post['author']]
+        authors = []
+        if post['author'].kind_of?(Array)
+          for author in post['author']
+            authors.push(site.data['authors'][author])
+          end
+        else
+          authors.push(site.data['authors'][post['author']])
+        end
+        post.data['authors'] = authors
       end
     end
   end

--- a/docs/_posts/2014-05-06-flux.md
+++ b/docs/_posts/2014-05-06-flux.md
@@ -1,6 +1,6 @@
 ---
 title: "Flux: An Application Architecture for React"
-author: fisherwebdevandjing
+author: [fisherwebdev, jingc]
 ---
 
 We recently spoke at one of f8's breakout session about Flux, a data flow architecture that works well with React.  Check out the video here:

--- a/docs/_posts/2015-10-01-react-render-and-top-level-api.md
+++ b/docs/_posts/2015-10-01-react-render-and-top-level-api.md
@@ -1,6 +1,6 @@
 ---
 title: "ReactDOM.render and the Top Level React API"
-author: jimandsebastian
+author: ["jimfb", "sebmarkbage"]
 ---
 
 

--- a/docs/blog/all.html
+++ b/docs/blog/all.html
@@ -9,7 +9,16 @@ id: all-posts
   <div class="inner-content">
     <h1>All Posts</h1>
     {% for page in site.posts %}
-      <p><strong><a href="/react{{ page.url }}">{{ page.title }}</a></strong> on {{ page.date | date: "%B %e, %Y" }} by {{ page.author.name }}</p>
+      <p><strong><a href="/react{{ page.url }}">{{ page.title }}</a></strong> on {{ page.date | date: "%B %e, %Y" }} by
+        {% for author in page.authors %}
+          {% if author.url %}
+            <a href="{{author.url}}">{{ author.name }}</a>
+          {% else %}
+            {{ author.name }}
+          {% endif %}
+          {% if forloop.last == false %} and {% endif %}
+        {% endfor %}
+      </p>
     {% endfor %}
   </div>
 </section>


### PR DESCRIPTION
Fixed issue where a blog post (["Flux: An Application Architecture for React"](http://facebook.github.io/react/blog/2014/05/06/flux.html)) was listed as having no author in the byline.  Added support for multiple authors for blog posts.