### PR TITLE
ES6 import syntax for browser example

### DIFF
--- a/packages/react-dom/README.md
+++ b/packages/react-dom/README.md
@@ -13,8 +13,8 @@ npm install react react-dom
 ### In the browser
 
 ```js
-var React = require('react');
-var ReactDOM = require('react-dom');
+import React from 'react';
+import ReactDOM from 'react-dom';
 
 class MyComponent extends React.Component {
   render() {


### PR DESCRIPTION
Change import syntax for browser example to ES6 for uniformity.