### PR TITLE
Remove "Invariant Violation: " from Invariant Error Messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "eslint": "^1.5.1",
     "eslint-plugin-react": "^3.4.2",
     "eslint-plugin-react-internal": "file:eslint-rules",
-    "fbjs": "^0.3.1",
+    "fbjs": "^0.4.0",
     "fbjs-scripts": "^0.2.0",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",

--- a/src/addons/__tests__/ReactFragment-test.js
+++ b/src/addons/__tests__/ReactFragment-test.js
@@ -32,10 +32,10 @@ describe('ReactFragment', function() {
     var element = <div>{[children]}</div>;
     var container = document.createElement('div');
     expect(() => ReactDOM.render(element, container)).toThrow(
-      'Invariant Violation: Objects are not valid as a React child (found: ' +
-      'object with keys {x, y, z}). If you meant to render a collection of ' +
-      'children, use an array instead or wrap the object using ' +
-      'createFragment(object) from the React add-ons.'
+      'Objects are not valid as a React child (found: object with keys ' +
+      '{x, y, z}). If you meant to render a collection of children, use an ' +
+      'array instead or wrap the object using createFragment(object) from ' +
+      'the React add-ons.'
     );
   });
 
@@ -52,11 +52,10 @@ describe('ReactFragment', function() {
     }
     var container = document.createElement('div');
     expect(() => ReactDOM.render(<Foo />, container)).toThrow(
-      'Invariant Violation: Objects are not valid as a React child (found: ' +
-      'object with keys {a, b, c}). If you meant to render a collection of ' +
-      'children, use an array instead or wrap the object using ' +
-      'createFragment(object) from the React add-ons. Check the render ' +
-      'method of `Foo`.'
+      'Objects are not valid as a React child (found: object with keys ' +
+      '{a, b, c}). If you meant to render a collection of children, use an ' +
+      'array instead or wrap the object using createFragment(object) from ' +
+      'the React add-ons. Check the render method of `Foo`.'
     );
   });
 
@@ -64,10 +63,10 @@ describe('ReactFragment', function() {
     var oldEl = {_isReactElement: true, type: 'span', props: {}};
     var container = document.createElement('div');
     expect(() => ReactDOM.render(<div>{oldEl}</div>, container)).toThrow(
-      'Invariant Violation: Objects are not valid as a React child (found: ' +
-      'object with keys {_isReactElement, type, props}). It looks like ' +
-      'you\'re using an element created by a different version of React. ' +
-      'Make sure to use only one copy of React.'
+      'Objects are not valid as a React child (found: object with keys ' +
+      '{_isReactElement, type, props}). It looks like you\'re using an ' +
+      'element created by a different version of React. Make sure to use ' +
+      'only one copy of React.'
     );
   });
 

--- a/src/addons/__tests__/renderSubtreeIntoContainer-test.js
+++ b/src/addons/__tests__/renderSubtreeIntoContainer-test.js
@@ -88,8 +88,7 @@ describe('renderSubtreeIntoContainer', function() {
       componentDidMount: function() {
         expect(function() {
           renderSubtreeIntoContainer(<Parent />, <Component />, portal);
-        }).toThrow('Invariant Violation: parentComponent' +
-          'must be a valid React Component');
+        }).toThrow('parentComponentmust be a valid React Component');
       },
     });
   });

--- a/src/addons/__tests__/update-test.js
+++ b/src/addons/__tests__/update-test.js
@@ -17,53 +17,47 @@ describe('update', function() {
   it('should support push', function() {
     expect(update([1], {$push: [7]})).toEqual([1, 7]);
     expect(update.bind(null, [], {$push: 7})).toThrow(
-      'Invariant Violation: update(): expected spec of $push to be an ' +
-      'array; got 7. Did you forget to wrap your parameter in an array?'
+      'update(): expected spec of $push to be an array; got 7. Did you ' +
+      'forget to wrap your parameter in an array?'
     );
     expect(update.bind(null, 1, {$push: 7})).toThrow(
-      'Invariant Violation: update(): expected target of $push to be an ' +
-      'array; got 1.'
+      'update(): expected target of $push to be an array; got 1.'
     );
   });
 
   it('should support unshift', function() {
     expect(update([1], {$unshift: [7]})).toEqual([7, 1]);
     expect(update.bind(null, [], {$unshift: 7})).toThrow(
-      'Invariant Violation: update(): expected spec of $unshift to be an ' +
-      'array; got 7. Did you forget to wrap your parameter in an array?'
+      'update(): expected spec of $unshift to be an array; got 7. Did you ' +
+      'forget to wrap your parameter in an array?'
     );
     expect(update.bind(null, 1, {$unshift: 7})).toThrow(
-      'Invariant Violation: update(): expected target of $unshift to be an ' +
-      'array; got 1.'
+      'update(): expected target of $unshift to be an array; got 1.'
     );
   });
 
   it('should support splice', function() {
     expect(update([1, 4, 3], {$splice: [[1, 1, 2]]})).toEqual([1, 2, 3]);
     expect(update.bind(null, [], {$splice: 1})).toThrow(
-      'Invariant Violation: update(): expected spec of $splice to be an ' +
-      'array of arrays; got 1. Did you forget to wrap your parameters in an ' +
-      'array?'
+      'update(): expected spec of $splice to be an array of arrays; got 1. ' +
+      'Did you forget to wrap your parameters in an array?'
     );
     expect(update.bind(null, [], {$splice: [1]})).toThrow(
-      'Invariant Violation: update(): expected spec of $splice to be an ' +
-      'array of arrays; got 1. Did you forget to wrap your parameters in an ' +
-      'array?'
+      'update(): expected spec of $splice to be an array of arrays; got 1. ' +
+      'Did you forget to wrap your parameters in an array?'
     );
     expect(update.bind(null, 1, {$splice: 7})).toThrow(
-      'Invariant Violation: Expected $splice target to be an array; got 1'
+      'Expected $splice target to be an array; got 1'
     );
   });
 
   it('should support merge', function() {
     expect(update({a: 'b'}, {$merge: {c: 'd'}})).toEqual({a: 'b', c: 'd'});
     expect(update.bind(null, {}, {$merge: 7})).toThrow(
-      'Invariant Violation: update(): $merge expects a spec of type ' +
-      '\'object\'; got 7'
+      'update(): $merge expects a spec of type \'object\'; got 7'
     );
     expect(update.bind(null, 7, {$merge: {a: 'b'}})).toThrow(
-      'Invariant Violation: update(): $merge expects a target of type ' +
-      '\'object\'; got 7'
+      'update(): $merge expects a target of type \'object\'; got 7'
     );
   });
 
@@ -74,8 +68,7 @@ describe('update', function() {
   it('should support apply', function() {
     expect(update(2, {$apply: (x) => x * 2})).toEqual(4);
     expect(update.bind(null, 2, {$apply: 123})).toThrow(
-      'Invariant Violation: update(): expected spec of $apply to be a ' +
-      'function; got 123.'
+      'update(): expected spec of $apply to be a function; got 123.'
     );
   });
 
@@ -88,9 +81,9 @@ describe('update', function() {
 
   it('should require a command', function() {
     expect(update.bind(null, {a: 'b'}, {a: 'c'})).toThrow(
-      'Invariant Violation: update(): You provided a key path to update() ' +
-      'that did not contain one of $push, $unshift, $splice, $set, $merge, ' +
-      '$apply. Did you forget to include {$set: ...}?'
+      'update(): You provided a key path to update() that did not contain ' +
+      'one of $push, $unshift, $splice, $set, $merge, $apply. Did you ' +
+      'forget to include {$set: ...}?'
     );
   });
 

--- a/src/isomorphic/classic/class/__tests__/ReactClass-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactClass-test.js
@@ -30,8 +30,7 @@ describe('ReactClass-spec', function() {
     expect(function() {
       React.createClass({});
     }).toThrow(
-      'Invariant Violation: createClass(...): Class specification must ' +
-      'implement a `render` method.'
+      'createClass(...): Class specification must implement a `render` method.'
     );
   });
 
@@ -197,10 +196,10 @@ describe('ReactClass-spec', function() {
         },
       });
     }).toThrow(
-      'Invariant Violation: ReactClass: You are attempting to ' +
-      'define a reserved property, `getDefaultProps`, that shouldn\'t be on ' +
-      'the "statics" key. Define it as an instance property instead; it ' +
-      'will still be accessible on the constructor.'
+      'ReactClass: You are attempting to define a reserved property, ' +
+      '`getDefaultProps`, that shouldn\'t be on the "statics" key. Define ' +
+      'it as an instance property instead; it will still be accessible on ' +
+      'the constructor.'
     );
   });
 
@@ -331,8 +330,7 @@ describe('ReactClass-spec', function() {
       expect(function() {
         instance = ReactTestUtils.renderIntoDocument(instance);
       }).toThrow(
-        'Invariant Violation: Component.getInitialState(): ' +
-        'must return an object or null'
+        'Component.getInitialState(): must return an object or null'
       );
     });
   });

--- a/src/isomorphic/classic/class/__tests__/ReactClassMixin-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactClassMixin-test.js
@@ -208,11 +208,10 @@ describe('ReactClass-mixin', function() {
     expect(function() {
       instance = ReactTestUtils.renderIntoDocument(instance);
     }).toThrow(
-      'Invariant Violation: mergeIntoWithNoDuplicateKeys(): ' +
-      'Tried to merge two objects with the same key: `x`. This conflict ' +
-      'may be due to a mixin; in particular, this may be caused by two ' +
-      'getInitialState() or getDefaultProps() methods returning objects ' +
-      'with clashing keys.'
+      'mergeIntoWithNoDuplicateKeys(): Tried to merge two objects with the ' +
+      'same key: `x`. This conflict may be due to a mixin; in particular, ' +
+      'this may be caused by two getInitialState() or getDefaultProps() ' +
+      'methods returning objects with clashing keys.'
     );
   });
 
@@ -280,9 +279,8 @@ describe('ReactClass-mixin', function() {
         },
       });
     }).toThrow(
-      'Invariant Violation: ReactClass: You are attempting to ' +
-      'define `abc` on your component more than once. This conflict may be ' +
-      'due to a mixin.'
+      'ReactClass: You are attempting to define `abc` on your component more ' +
+      'than once. This conflict may be due to a mixin.'
     );
   });
 
@@ -309,9 +307,8 @@ describe('ReactClass-mixin', function() {
         },
       });
     }).toThrow(
-      'Invariant Violation: ReactClass: You are attempting to ' +
-      'define `abc` on your component more than once. This conflict may be ' +
-      'due to a mixin.'
+      'ReactClass: You are attempting to define `abc` on your component ' +
+      'more than once. This conflict may be due to a mixin.'
     );
   });
 
@@ -325,8 +322,8 @@ describe('ReactClass-mixin', function() {
         },
       });
     }).toThrow(
-      'Invariant Violation: ReactClass: You\'re attempting to ' +
-      'use a component as a mixin. Instead, just use a regular object.'
+      'ReactClass: You\'re attempting to use a component as a mixin. ' +
+      'Instead, just use a regular object.'
     );
   });
 
@@ -346,9 +343,8 @@ describe('ReactClass-mixin', function() {
         },
       });
     }).toThrow(
-      'Invariant Violation: ReactClass: You\'re attempting to ' +
-      'use a component class or function as a mixin. Instead, just use a ' +
-      'regular object.'
+      'ReactClass: You\'re attempting to use a component class or function ' +
+      'as a mixin. Instead, just use a regular object.'
     );
   });
 

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -287,9 +287,9 @@ describe('ReactElementValidator', function() {
     expect(function() {
       ReactTestUtils.renderIntoDocument(React.createElement(ParentComp));
     }).toThrow(
-      'Invariant Violation: Element type is invalid: expected a string (for ' +
-      'built-in components) or a class/function (for composite components) ' +
-      'but got: null. Check the render method of `ParentComp`.'
+      'Element type is invalid: expected a string (for built-in components) ' +
+      'or a class/function (for composite components) but got: null. Check ' +
+      'the render method of `ParentComp`.'
     );
     expect(console.error.calls.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toBe(

--- a/src/isomorphic/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/src/isomorphic/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -154,7 +154,7 @@ describe 'ReactCoffeeScriptClass', ->
       expect(->
         test React.createElement(Foo), 'span', ''
       ).toThrow(
-        'Invariant Violation: Foo.state: must be set to an object or null'
+        'Foo.state: must be set to an object or null'
       )
 
   it 'should render with null in the initial state property', ->

--- a/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
+++ b/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
@@ -176,8 +176,7 @@ describe('ReactES6Class', function() {
         }
       }
       expect(() => test(<Foo />, 'span', '')).toThrow(
-        'Invariant Violation: Foo.state: ' +
-        'must be set to an object or null'
+        'Foo.state: must be set to an object or null'
       );
     });
   });

--- a/src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
+++ b/src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
@@ -361,18 +361,15 @@ describe('ReactTypeScriptClass', function() {
   it('should throw with non-object in the initial state property', function() {
     expect(() => test(React.createElement(ArrayState), 'span', ''))
     .toThrow(
-      'Invariant Violation: ArrayState.state: ' +
-      'must be set to an object or null'
+      'ArrayState.state: must be set to an object or null'
     );
     expect(() => test(React.createElement(StringState), 'span', ''))
     .toThrow(
-      'Invariant Violation: StringState.state: ' +
-      'must be set to an object or null'
+      'StringState.state: must be set to an object or null'
     );
     expect(() => test(React.createElement(NumberState), 'span', ''))
     .toThrow(
-      'Invariant Violation: NumberState.state: ' +
-      'must be set to an object or null'
+      'NumberState.state: must be set to an object or null'
     );
   });
 

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -301,8 +301,8 @@ describe('ReactJSXElementValidator', function() {
     ReactTestUtils.renderIntoDocument(<NullPropTypeComponent />);
     expect(console.error.calls.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toContain(
-      'Invariant Violation: NullPropTypeComponent: prop type `prop` is ' +
-      'invalid; it must be a function, usually from React.PropTypes.'
+      'NullPropTypeComponent: prop type `prop` is invalid; it must be a ' +
+      'function, usually from React.PropTypes.'
     );
   });
 
@@ -319,8 +319,8 @@ describe('ReactJSXElementValidator', function() {
     ReactTestUtils.renderIntoDocument(<NullContextTypeComponent />);
     expect(console.error.calls.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toContain(
-      'Invariant Violation: NullContextTypeComponent: context type `prop` is ' +
-      'invalid; it must be a function, usually from React.PropTypes.'
+      'NullContextTypeComponent: context type `prop` is invalid; it must ' +
+      'be a function, usually from React.PropTypes.'
     );
   });
 

--- a/src/renderers/dom/client/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMount-test.js
@@ -37,8 +37,7 @@ describe('ReactMount', function() {
       expect(function() {
         ReactDOM.unmountComponentAtNode(nodeArray);
       }).toThrow(
-        'Invariant Violation: unmountComponentAtNode(...): Target container ' +
-        'is not a DOM element.'
+        'unmountComponentAtNode(...): Target container is not a DOM element.'
       );
     });
   });
@@ -47,9 +46,9 @@ describe('ReactMount', function() {
     expect(function() {
       ReactTestUtils.renderIntoDocument('div');
     }).toThrow(
-      'Invariant Violation: ReactDOM.render(): Invalid component element. ' +
-      'Instead of passing an element string, make sure to instantiate it ' +
-      'by passing it to React.createElement.'
+      'ReactDOM.render(): Invalid component element. Instead of passing an ' +
+      'element string, make sure to instantiate it by passing it to ' +
+      'React.createElement.'
     );
   });
 
@@ -62,9 +61,9 @@ describe('ReactMount', function() {
     expect(function() {
       ReactTestUtils.renderIntoDocument(Component);
     }).toThrow(
-      'Invariant Violation: ReactDOM.render(): Invalid component element. ' +
-      'Instead of passing a component class, make sure to instantiate it ' +
-      'by passing it to React.createElement.'
+      'ReactDOM.render(): Invalid component element. Instead of passing a ' +
+      'component class, make sure to instantiate it by passing it to ' +
+      'React.createElement.'
     );
   });
 

--- a/src/renderers/dom/client/__tests__/ReactRenderDocument-test.js
+++ b/src/renderers/dom/client/__tests__/ReactRenderDocument-test.js
@@ -25,7 +25,7 @@ var getTestDocument;
 var testDocument;
 
 var UNMOUNT_INVARIANT_MESSAGE =
-  'Invariant Violation: <html> tried to unmount. ' +
+  '<html> tried to unmount. ' +
   'Because of cross-browser quirks it is impossible to unmount some ' +
   'top-level components (eg <html>, <head>, and <body>) reliably and ' +
   'efficiently. To fix this, have a single top-level component that ' +
@@ -215,7 +215,6 @@ describe('rendering React components at document', function() {
       // Notice the text is different!
       ReactDOM.render(<Component text="Hello world" />, testDocument);
     }).toThrow(
-      'Invariant Violation: ' +
       'You\'re trying to render a component to the document using ' +
       'server rendering but the checksum was invalid. This usually ' +
       'means you rendered a different component type or props on ' +
@@ -252,9 +251,9 @@ describe('rendering React components at document', function() {
     expect(function() {
       ReactDOM.render(<Component />, container);
     }).toThrow(
-      'Invariant Violation: You\'re trying to render a component to the ' +
-      'document but you didn\'t use server rendering. We can\'t do this ' +
-      'without using server rendering due to cross-browser quirks. See ' +
+      'You\'re trying to render a component to the document but you didn\'t ' +
+      'use server rendering. We can\'t do this without using server ' +
+      'rendering due to cross-browser quirks. See ' +
       'ReactDOMServer.renderToString() for server rendering.'
     );
   });

--- a/src/renderers/dom/client/__tests__/findDOMNode-test.js
+++ b/src/renderers/dom/client/__tests__/findDOMNode-test.js
@@ -37,10 +37,9 @@ describe('findDOMNode', function() {
   it('findDOMNode should reject random objects', function() {
     expect(function() {
       ReactDOM.findDOMNode({foo: 'bar'});
-    })
-      .toThrow('Invariant Violation: Element appears to be neither ' +
-        'ReactComponent nor DOMNode (keys: foo)'
-      );
+    }).toThrow(
+      'Element appears to be neither ReactComponent nor DOMNode (keys: foo)'
+    );
   });
 
   it('findDOMNode should reject unmounted objects with render func', function() {
@@ -55,7 +54,7 @@ describe('findDOMNode', function() {
     ReactDOM.unmountComponentAtNode(container);
 
     expect(() => ReactDOM.findDOMNode(inst)).toThrow(
-      'Invariant Violation: findDOMNode was called on an unmounted component.'
+      'findDOMNode was called on an unmounted component.'
     );
   });
 

--- a/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
@@ -246,8 +246,7 @@ describe('ReactServerRendering', function() {
           'not a component'
         )
       ).toThrow(
-        'Invariant Violation: renderToString(): You must pass ' +
-        'a valid ReactElement.'
+        'renderToString(): You must pass a valid ReactElement.'
       );
     });
   });
@@ -356,8 +355,7 @@ describe('ReactServerRendering', function() {
           'not a component'
         )
       ).toThrow(
-        'Invariant Violation: renderToString(): You must pass ' +
-        'a valid ReactElement.'
+        'renderToString(): You must pass a valid ReactElement.'
       );
     });
 

--- a/src/renderers/dom/shared/__tests__/Danger-test.js
+++ b/src/renderers/dom/shared/__tests__/Danger-test.js
@@ -79,7 +79,7 @@ describe('Danger', function() {
       expect(function() {
         Danger.dangerouslyRenderMarkup(['']);
       }).toThrow(
-        'Invariant Violation: dangerouslyRenderMarkup(...): Missing markup.'
+        'dangerouslyRenderMarkup(...): Missing markup.'
       );
 
       spyOn(console, 'error');

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -586,8 +586,7 @@ describe('ReactDOMComponent', function() {
       expect(function() {
         mountComponent({children: '', dangerouslySetInnerHTML: ''});
       }).toThrow(
-        'Invariant Violation: Can only set one of `children` or ' +
-        '`props.dangerouslySetInnerHTML`.'
+        'Can only set one of `children` or `props.dangerouslySetInnerHTML`.'
       );
     });
 
@@ -605,7 +604,6 @@ describe('ReactDOMComponent', function() {
       expect(function() {
         mountComponent({dangerouslySetInnerHTML: '<span>Hi Jim!</span>'});
       }).toThrow(
-        'Invariant Violation: ' +
         '`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. ' +
         'Please visit https://fb.me/react-invariant-dangerously-set-inner-html for more information.'
       );
@@ -615,7 +613,6 @@ describe('ReactDOMComponent', function() {
       expect(function() {
         mountComponent({dangerouslySetInnerHTML: {foo: 'bar'} });
       }).toThrow(
-        'Invariant Violation: ' +
         '`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. ' +
         'Please visit https://fb.me/react-invariant-dangerously-set-inner-html for more information.'
       );
@@ -638,9 +635,9 @@ describe('ReactDOMComponent', function() {
       expect(function() {
         mountComponent({style: 'display: none'});
       }).toThrow(
-        'Invariant Violation: The `style` prop expects a mapping from style ' +
-        'properties to values, not a string. For example, ' +
-        'style={{marginRight: spacing + \'em\'}} when using JSX.'
+        'The `style` prop expects a mapping from style properties to values, ' +
+        'not a string. For example, style={{marginRight: spacing + \'em\'}} ' +
+        'when using JSX.'
       );
     });
 
@@ -755,8 +752,7 @@ describe('ReactDOMComponent', function() {
           container
         );
       }).toThrow(
-        'Invariant Violation: Can only set one of `children` or ' +
-        '`props.dangerouslySetInnerHTML`.'
+        'Can only set one of `children` or `props.dangerouslySetInnerHTML`.'
       );
     });
 
@@ -776,9 +772,9 @@ describe('ReactDOMComponent', function() {
       expect(function() {
         ReactDOM.render(<div style={1}></div>, container);
       }).toThrow(
-        'Invariant Violation: The `style` prop expects a mapping from style ' +
-        'properties to values, not a string. For example, ' +
-        'style={{marginRight: spacing + \'em\'}} when using JSX.'
+        'The `style` prop expects a mapping from style properties to values, ' +
+        'not a string. For example, style={{marginRight: spacing + \'em\'}} ' +
+        'when using JSX.'
       );
     });
 
@@ -792,10 +788,9 @@ describe('ReactDOMComponent', function() {
       expect(function() {
         ReactDOM.render(<Animal/>, container);
       }).toThrow(
-        'Invariant Violation: The `style` prop expects a mapping from style ' +
-        'properties to values, not a string. For example, ' +
-        'style={{marginRight: spacing + \'em\'}} when using JSX. ' +
-        'This DOM node was rendered by `Animal`.'
+        'The `style` prop expects a mapping from style properties to values, ' +
+        'not a string. For example, style={{marginRight: spacing + \'em\'}} ' +
+        'when using JSX. This DOM node was rendered by `Animal`.'
       );
     });
 
@@ -872,7 +867,7 @@ describe('ReactDOMComponent', function() {
       expect(
         () => ReactTestUtils.renderIntoDocument(hackzor)
       ).toThrow(
-        'Invariant Violation: Invalid tag: script tag'
+        'Invalid tag: script tag'
       );
     });
 
@@ -882,7 +877,7 @@ describe('ReactDOMComponent', function() {
       expect(
         () => ReactTestUtils.renderIntoDocument(hackzor)
       ).toThrow(
-        'Invariant Violation: Invalid tag: div><img /><div'
+        'Invalid tag: div><img /><div'
       );
     });
   });

--- a/src/renderers/shared/event/__tests__/EventPluginHub-test.js
+++ b/src/renderers/shared/event/__tests__/EventPluginHub-test.js
@@ -30,8 +30,7 @@ describe('EventPluginHub', function() {
     expect(function() {
       EventPluginHub.putListener(1, 'onClick', 'not a function');
     }).toThrow(
-      'Invariant Violation: Expected onClick listener to be a function, ' +
-      'instead got type string'
+      'Expected onClick listener to be a function, instead got type string'
     );
   });
 });

--- a/src/renderers/shared/event/__tests__/EventPluginRegistry-test.js
+++ b/src/renderers/shared/event/__tests__/EventPluginRegistry-test.js
@@ -97,8 +97,8 @@ describe('EventPluginRegistry', function() {
         bad: BadPlugin,
       });
     }).toThrow(
-      'Invariant Violation: EventPluginRegistry: Event plugins must ' +
-      'implement an `extractEvents` method, but `bad` does not.'
+      'EventPluginRegistry: Event plugins must implement an `extractEvents` ' +
+      'method, but `bad` does not.'
     );
   });
 
@@ -114,8 +114,8 @@ describe('EventPluginRegistry', function() {
         random: RandomPlugin,
       });
     }).toThrow(
-      'Invariant Violation: EventPluginRegistry: Cannot inject event plugins ' +
-      'that do not exist in the plugin ordering, `random`.'
+      'EventPluginRegistry: Cannot inject event plugins that do not exist ' +
+      'in the plugin ordering, `random`.'
     );
   });
 
@@ -127,9 +127,8 @@ describe('EventPluginRegistry', function() {
     expect(function() {
       EventPluginRegistry.injectEventPluginOrder(pluginOrdering);
     }).toThrow(
-      'Invariant Violation: EventPluginRegistry: Cannot inject event plugin ' +
-      'ordering more than once. You are likely trying to load more than one ' +
-      'copy of React.'
+      'EventPluginRegistry: Cannot inject event plugin ordering more than ' +
+      'once. You are likely trying to load more than one copy of React.'
     );
   });
 
@@ -142,8 +141,8 @@ describe('EventPluginRegistry', function() {
     expect(function() {
       EventPluginRegistry.injectEventPluginsByName({same: TwoPlugin});
     }).toThrow(
-      'Invariant Violation: EventPluginRegistry: Cannot inject two different ' +
-      'event plugins using the same name, `same`.'
+      'EventPluginRegistry: Cannot inject two different event plugins using ' +
+      'the same name, `same`.'
     );
   });
 
@@ -206,8 +205,8 @@ describe('EventPluginRegistry', function() {
     expect(function() {
       EventPluginRegistry.injectEventPluginOrder(['one', 'two']);
     }).toThrow(
-      'Invariant Violation: EventPluginHub: More than one plugin attempted ' +
-      'to publish the same registration name, `onPhotoCapture`.'
+      'EventPluginHub: More than one plugin attempted to publish the same ' +
+      'registration name, `onPhotoCapture`.'
     );
   });
 
@@ -223,8 +222,8 @@ describe('EventPluginRegistry', function() {
     expect(function() {
       EventPluginRegistry.injectEventPluginOrder(['one']);
     }).toThrow(
-      'Invariant Violation: EventPluginRegistry: Failed to publish event ' +
-      '`badEvent` for plugin `one`.'
+      'EventPluginRegistry: Failed to publish event `badEvent` for plugin ' +
+      '`one`.'
     );
   });
 

--- a/src/renderers/shared/reconciler/__tests__/ReactComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactComponent-test.js
@@ -31,15 +31,13 @@ describe('ReactComponent', function() {
     expect(function() {
       ReactDOM.render(<div></div>, [container]);
     }).toThrow(
-      'Invariant Violation: _registerComponent(...): Target container ' +
-      'is not a DOM element.'
+      '_registerComponent(...): Target container is not a DOM element.'
     );
 
     expect(function() {
       ReactDOM.render(<div></div>, null);
     }).toThrow(
-      'Invariant Violation: _registerComponent(...): Target container ' +
-      'is not a DOM element.'
+      '_registerComponent(...): Target container is not a DOM element.'
     );
   });
 
@@ -295,23 +293,20 @@ describe('ReactComponent', function() {
 
     var X = undefined;
     expect(() => ReactTestUtils.renderIntoDocument(<X />)).toThrow(
-      'Invariant Violation: Element type is invalid: expected a string (for ' +
-      'built-in components) or a class/function (for composite components) ' +
-      'but got: undefined.'
+      'Element type is invalid: expected a string (for built-in components) ' +
+      'or a class/function (for composite components) but got: undefined.'
     );
 
     var Y = null;
     expect(() => ReactTestUtils.renderIntoDocument(<Y />)).toThrow(
-      'Invariant Violation: Element type is invalid: expected a string (for ' +
-      'built-in components) or a class/function (for composite components) ' +
-      'but got: null.'
+      'Element type is invalid: expected a string (for built-in components) ' +
+      'or a class/function (for composite components) but got: null.'
     );
 
     var Z = {};
     expect(() => ReactTestUtils.renderIntoDocument(<Z />)).toThrow(
-      'Invariant Violation: Element type is invalid: expected a string (for ' +
-      'built-in components) or a class/function (for composite components) ' +
-      'but got: object.'
+      'Element type is invalid: expected a string (for built-in components) ' +
+      'or a class/function (for composite components) but got: object.'
     );
 
     // One warning for each element creation

--- a/src/renderers/shared/reconciler/__tests__/ReactComponentLifeCycle-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactComponentLifeCycle-test.js
@@ -477,11 +477,10 @@ describe('ReactComponentLifeCycle', function() {
     expect(function() {
       instance = ReactTestUtils.renderIntoDocument(instance);
     }).toThrow(
-      'Invariant Violation: setProps(...): You called `setProps` on a ' +
-      'component with a parent. This is an anti-pattern since props will get ' +
-      'reactively updated when rendered. Instead, change the owner\'s ' +
-      '`render` method to pass the correct value as props to the component ' +
-      'where it is created.'
+      'setProps(...): You called `setProps` on a component with a parent. ' +
+      'This is an anti-pattern since props will get reactively updated ' +
+      'when rendered. Instead, change the owner\'s `render` method to pass ' +
+      'the correct value as props to the component where it is created.'
     );
     expect(console.error.calls.length).toBe(1);  // setProps deprecated
   });

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -459,11 +459,10 @@ describe('ReactCompositeComponent', function() {
     expect(function() {
       innerInstance.setProps({value: 1});
     }).toThrow(
-      'Invariant Violation: setProps(...): You called `setProps` on a ' +
-      'component with a parent. This is an anti-pattern since props will get ' +
-      'reactively updated when rendered. Instead, change the owner\'s ' +
-      '`render` method to pass the correct value as props to the component ' +
-      'where it is created.'
+      'setProps(...): You called `setProps` on a component with a parent. ' +
+      'This is an anti-pattern since props will get reactively updated when ' +
+      'rendered. Instead, change the owner\'s `render` method to pass the ' +
+      'correct value as props to the component where it is created.'
     );
   });
 

--- a/src/renderers/shared/reconciler/__tests__/ReactEmptyComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactEmptyComponent-test.js
@@ -75,9 +75,8 @@ describe('ReactEmptyComponent', function() {
     expect(function() {
       ReactTestUtils.renderIntoDocument(<Component />);
     }).toThrow(
-      'Invariant Violation: Component.render(): A valid ReactComponent must ' +
-      'be returned. You may have returned undefined, an array or some other ' +
-      'invalid object.'
+      'Component.render(): A valid ReactComponent must be returned. You may ' +
+      'have returned undefined, an array or some other invalid object.'
     );
   });
 
@@ -226,7 +225,7 @@ describe('ReactEmptyComponent', function() {
     expect(function() {
       ReactDOM.render(null, div);
     }).toThrow(
-      'Invariant Violation: ReactDOM.render(): Invalid component element.'
+      'ReactDOM.render(): Invalid component element.'
     );
   });
 

--- a/src/renderers/shared/reconciler/__tests__/ReactInstanceHandles-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactInstanceHandles-test.js
@@ -142,13 +142,12 @@ describe('ReactInstanceHandles', function() {
           junkID
         );
       }).toThrow(
-        'Invariant Violation: findComponentRoot(..., ' + junkID + '): ' +
-        'Unable to find element. This probably means the DOM was ' +
-        'unexpectedly mutated (e.g., by the browser), usually due to ' +
-        'forgetting a <tbody> when using tables, nesting tags ' +
-        'like <form>, <p>, or <a>, or using non-SVG elements in an <svg> ' +
-        'parent. ' +
-        'Try inspecting the child nodes of the element with React ID ``.'
+        'findComponentRoot(..., ' + junkID + '): Unable to find element. ' +
+      'This probably means the DOM was unexpectedly mutated (e.g., by the ' +
+      'browser), usually due to forgetting a <tbody> when using tables, ' +
+      'nesting tags like <form>, <p>, or <a>, or using non-SVG elements in ' +
+      'an <svg> parent. Try inspecting the child nodes of the element with ' +
+      'React ID ``.'
       );
 
       expect(console.error.argsForCall.length).toBe(1);

--- a/src/renderers/shared/reconciler/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactStatelessComponent-test.js
@@ -121,7 +121,7 @@ describe('ReactStatelessComponent', function() {
     expect(function() {
       ReactTestUtils.renderIntoDocument(<Child test="test" />);
     }).toThrow(
-      'Invariant Violation: Stateless function components cannot have refs.'
+      'Stateless function components cannot have refs.'
     );
   });
 

--- a/src/shared/utils/__tests__/OrderedMap-test.js
+++ b/src/shared/utils/__tests__/OrderedMap-test.js
@@ -733,14 +733,12 @@ describe('OrderedMap', function() {
     expect(function() {
       om.mapKeyRange(duplicate, 'x', 3, scope);
     }).toThrow(
-      'Invariant Violation: mapKeyRange must be given keys ' +
-      'that are present.'
+      'mapKeyRange must be given keys that are present.'
     );
     expect(function() {
       om.forEachKeyRange(duplicate, 'x', 3, scope);
     }).toThrow(
-      'Invariant Violation: forEachKeyRange must be given keys ' +
-      'that are present.'
+      'forEachKeyRange must be given keys that are present.'
     );
 
     expect(function() {

--- a/src/shared/utils/__tests__/PooledClass-test.js
+++ b/src/shared/utils/__tests__/PooledClass-test.js
@@ -111,8 +111,7 @@ describe('Pooled class', function() {
       expect(function() {
         PoolableClass.release(randomInstance);
       }).toThrow(
-        'Invariant Violation: Trying to release an instance into a pool ' +
-        'of a different type.'
+        'Trying to release an instance into a pool of a different type.'
       );
     }
   );

--- a/src/shared/utils/__tests__/accumulateInto-test.js
+++ b/src/shared/utils/__tests__/accumulateInto-test.js
@@ -26,8 +26,7 @@ describe('accumulateInto', function() {
     expect(function() {
       accumulateInto([], null);
     }).toThrow(
-      'Invariant Violation: accumulateInto(...): Accumulated items must not ' +
-      'be null or undefined.'
+      'accumulateInto(...): Accumulated items must not be null or undefined.'
     );
   });
 

--- a/src/shared/utils/__tests__/traverseAllChildren-test.js
+++ b/src/shared/utils/__tests__/traverseAllChildren-test.js
@@ -480,10 +480,10 @@ describe('traverseAllChildren', function() {
     expect(function() {
       traverseAllChildren({a: 1, b: 2}, function() {}, null);
     }).toThrow(
-      'Invariant Violation: Objects are not valid as a React child (found: ' +
-      'object with keys {a, b}). If you meant to render a collection of ' +
-      'children, use an array instead or wrap the object using ' +
-      'createFragment(object) from the React add-ons.'
+      'Objects are not valid as a React child (found: object with keys ' +
+      '{a, b}). If you meant to render a collection of children, use an ' +
+      'array instead or wrap the object using createFragment(object) from ' +
+      'the React add-ons.'
     );
   });
 
@@ -493,10 +493,9 @@ describe('traverseAllChildren', function() {
     expect(function() {
       traverseAllChildren(/abc/, function() {}, null);
     }).toThrow(
-      'Invariant Violation: Objects are not valid as a React child (found: ' +
-      '/abc/). If you meant to render a collection of children, use an array ' +
-      'instead or wrap the object using createFragment(object) from the ' +
-      'React add-ons.'
+      'Objects are not valid as a React child (found: /abc/). If you meant ' +
+      'to render a collection of children, use an array instead or wrap the ' +
+      'object using createFragment(object) from the React add-ons.'
     );
   });
 

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -62,15 +62,15 @@ describe('ReactTestUtils', function() {
 
     var shallowRenderer = ReactTestUtils.createRenderer();
     expect(() => shallowRenderer.render(SomeComponent)).toThrow(
-      'Invariant Violation: ReactShallowRenderer render(): Invalid component ' +
-      'element. Instead of passing a component class, make sure to ' +
-      'instantiate it by passing it to React.createElement.'
+      'ReactShallowRenderer render(): Invalid component element. Instead of ' +
+      'passing a component class, make sure to instantiate it by passing it ' +
+      'to React.createElement.'
     );
     expect(() => shallowRenderer.render(<div />)).toThrow(
-      'Invariant Violation: ReactShallowRenderer render(): Shallow rendering ' +
-      'works only with custom components, not primitives (div). Instead of ' +
-      'calling `.render(el)` and inspecting the rendered output, look at ' +
-      '`el.props` directly instead.'
+      'ReactShallowRenderer render(): Shallow rendering works only with ' +
+      'custom components, not primitives (div). Instead of calling ' +
+      '`.render(el)` and inspecting the rendered output, look at `el.props` ' +
+      'directly instead.'
     );
   });
 


### PR DESCRIPTION
This upgrades all expectations of `invariant`'s error message to exclude the "Invariant Violation: " prefix when facebook/fbjs#71 lands.