### PR TITLE
add srcLang attribute for track elements

### DIFF
--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -230,6 +230,7 @@ var HTMLDOMPropertyConfig = {
     radioGroup: 'radiogroup',
     spellCheck: 'spellcheck',
     srcDoc: 'srcdoc',
+    srcLang: 'srclang',
     srcSet: 'srcset',
   },
 };


### PR DESCRIPTION
`srclang` is necessary to determine the language the TextTrack contents are meant for.