### PR TITLE
Specify focus events work on all elements in the React DOM

### DIFF
--- a/docs/docs/ref-05-events.md
+++ b/docs/docs/ref-05-events.md
@@ -138,6 +138,7 @@ Properties:
 DOMEventTarget relatedTarget
 ```
 
+These focus events work on all elements in the React DOM, not just form elements.
 
 ### Form Events
 


### PR DESCRIPTION
Generally, focus/blur events only apply to focusable elements found in forms. In React, you can listen to focus/blur events on any element.