### PR TITLE
Updating "JSX Gotchas" docs for Custom Attributes

### DIFF
--- a/docs/docs/02.3-jsx-gotchas.md
+++ b/docs/docs/02.3-jsx-gotchas.md
@@ -61,6 +61,12 @@ If you pass properties to native HTML elements that do not exist in the HTML spe
 <div data-custom-attribute="foo" />
 ```
 
+However, arbitrary attributes are supported on custom elements (those with a hyphen in the tag name or an `is="..."` attribute).
+
+```javascript
+<x-my-component custom-attribute="foo" />
+```
+
 [Web Accessibility](http://www.w3.org/WAI/intro/aria) attributes starting with `aria-` will be rendered properly.
 
 ```javascript


### PR DESCRIPTION
Adds note that custom attributes are supported on custom elements.

Based on this change in 0.14.x: https://github.com/facebook/react/pull/3067