### PR TITLE
fix wrong method name

### DIFF
--- a/src/renderers/shared/reconciler/ReactMultiChild.js
+++ b/src/renderers/shared/reconciler/ReactMultiChild.js
@@ -315,7 +315,7 @@ var ReactMultiChild = {
         ReactChildReconciler.unmountChildren(prevChildren);
         for (var name in prevChildren) {
           if (prevChildren.hasOwnProperty(name)) {
-            this._unmountChildByName(prevChildren[name], name);
+            this._unmountChild(prevChildren[name]);
           }
         }
         this.setMarkup(nextMarkup);


### PR DESCRIPTION
_unmountChildByName is a non-exist method.

Actually according to https://github.com/facebook/react/blob/a468eed33f8067053d27c16852b4406bc47e3571/src/renderers/dom/shared/ReactDOMComponent.js#L1047

The following codes in *updateMarkup*
```js
var prevChildren = this._renderedChildren;
// Remove any rendered children.
ReactChildReconciler.unmountChildren(prevChildren);
for (var name in prevChildren) {
    if (prevChildren.hasOwnProperty(name)) {
        this._unmountChild(prevChildren[name]);
    }
}        
``` 

have no effect and can be removed, this also applies to *updateTextContent*.