### PR TITLE
shallow renderer: fixed setState on componentWillMount (fixes #4461)

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -427,9 +427,7 @@ ReactShallowRenderer.prototype.render = function(element, context) {
   if (!context) {
     context = emptyObject;
   }
-  var transaction = ReactUpdates.ReactReconcileTransaction.getPooled(true);
-  this._render(element, transaction, context);
-  ReactUpdates.ReactReconcileTransaction.release(transaction);
+  ReactUpdates.batchedUpdates(_batchedRender, this, element, context);
 
   return this.getRenderOutput();
 };
@@ -447,6 +445,12 @@ ReactShallowRenderer.prototype.unmount = function() {
     this._instance.unmountComponent();
   }
 };
+
+function _batchedRender(renderer, element, context) {
+  var transaction = ReactUpdates.ReactReconcileTransaction.getPooled(true);
+  renderer._render(element, transaction, context);
+  ReactUpdates.ReactReconcileTransaction.release(transaction);
+}
 
 ReactShallowRenderer.prototype._render = function(element, transaction, context) {
   if (this._instance) {

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -217,6 +217,24 @@ describe('ReactTestUtils', function() {
     expect(result.props.className).toEqual('clicked');
   });
 
+  it('can setState in componentWillMount with shallow render', function() {
+    var SimpleComponent = React.createClass({
+      contextTypes: {
+        name: React.PropTypes.string,
+      },
+      componentWillMount: function() {
+        this.setState({hello: 'ociffer'});
+      },
+      render: function() {
+        return <div>{this.state.hello}</div>;
+      },
+    });
+
+    var shallowRenderer = ReactTestUtils.createRenderer();
+    var result = shallowRenderer.render(<SimpleComponent />);
+    expect(result).not.toBeUndefined();
+  });
+
   it('can pass context when shallowly rendering', function() {
     var SimpleComponent = React.createClass({
       contextTypes: {


### PR DESCRIPTION
The problem was that `setState` caused a re-render of the component while mounting the component was not yet finished and thus `_currentElement` was not set. This change adds `ReactUpdates.batchedUpdates` similar to how the DOM renderer is implemented.