### PR TITLE
Update README's example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ var HelloMessage = React.createClass({
   }
 });
 
-React.render(
+ReactDOM.render(
   <HelloMessage name="John" />,
   document.getElementById('container')
 );


### PR DESCRIPTION
According to current React version, when I use `React.render`, browser console shows `Warning: React.render is deprecated. Please use ReactDOM.render from require('react-dom') instead.`

So this PR is a simple update for the README example.