### PR TITLE
Fix cycle in AutoFocusUtils

### DIFF
--- a/src/renderers/dom/client/wrappers/AutoFocusUtils.js
+++ b/src/renderers/dom/client/wrappers/AutoFocusUtils.js
@@ -14,20 +14,9 @@
 
 var ReactMount = require('ReactMount');
 
-var findDOMNode = require('findDOMNode');
 var focusNode = require('focusNode');
 
-var Mixin = {
-  componentDidMount: function() {
-    if (this.props.autoFocus) {
-      focusNode(findDOMNode(this));
-    }
-  },
-};
-
 var AutoFocusUtils = {
-  Mixin: Mixin,
-
   focusDOMComponent: function() {
     focusNode(ReactMount.getNode(this._rootNodeID));
   },


### PR DESCRIPTION
In 5c5d2ec182e4f517b7f3b865d0277ed0dc4f0abd I accidentally introduced a dependency cycle:

AutoFocusUtils -> findDOMNode -> ReactDOMComponent -> AutoFocusUtils

This breaks some tools internally. We're not actually using findDOMNode in AutoFocusUtils any more so we can just delete it.