### PR TITLE
[lint] Make eqeqeq a failure

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,7 @@ rules:
   dot-location: [2, property]
   dot-notation: 2
   eol-last: 2
+  eqeqeq: [2, allow-null]
   indent: [2, 2, {SwitchCase: 1}]
   jsx-quotes: [2, prefer-double]
   no-bitwise: 0

--- a/scripts/jest/ts-preprocessor.js
+++ b/scripts/jest/ts-preprocessor.js
@@ -37,7 +37,7 @@ function compile(content, contentFilename) {
         try {
           source = fs.readFileSync(filename).toString();
         } catch (e) {
-          if (e.code == 'ENOENT') {
+          if (e.code === 'ENOENT') {
             return undefined;
           }
           throw e;


### PR DESCRIPTION
It's disabled in fbjs because it's noisy on the extended codebase but we're stricter about a few things here so turn it on. This also fixes the one place where it's failing.