### PR TITLE
Overwriting of mutated props in constructor

### DIFF
--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -199,7 +199,7 @@ var ReactCompositeComponentMixin = {
 
     // These should be set up in the constructor, but as a convenience for
     // simpler class abstractions, we set them up after the fact.
-    inst.props = publicProps;
+    inst.props = inst.props || publicProps;
     inst.context = publicContext;
     inst.refs = emptyObject;
     inst.updater = ReactUpdateQueue;

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -1242,17 +1242,11 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should not overwrite mutated properties', function() {
-    function Moo(props) {
-      React.Component.call(this, props);
+    class Moo extends React.Component {
+      render() {
+        return <span />;
+      }
     }
-    Moo.prototype = Object.create(React.Component.prototype, {
-      constructor: {
-        value: Moo,
-      },
-    });
-    Moo.prototype.render = function() {
-      return <span />;
-    };
     Moo.defaultProps = { idx: 'moo' };
 
     function Foo(props) {
@@ -1270,15 +1264,7 @@ describe('ReactCompositeComponent', function() {
     };
     Foo.defaultProps = { idx: 'foo' };
 
-    function Bar() {
-      Foo.call(this);
-    }
-
-    Bar.prototype = Object.create(Foo.prototype, {
-      constructor: {
-        value: Bar,
-      },
-    });
+    class Bar extends Foo {}
     Bar.defaultProps = { idx: 'bar' };
 
     var moo = ReactTestUtils.renderIntoDocument(<Moo />);

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -1241,4 +1241,53 @@ describe('ReactCompositeComponent', function() {
 
   });
 
+  it('should not overwrite mutated properties', function() {
+    function Moo(props) {
+      React.Component.call(this, props);
+    }
+    Moo.prototype = Object.create(React.Component.prototype, {
+      constructor: {
+        value: Moo,
+      },
+    });
+    Moo.prototype.render = function() {
+      return <span />;
+    };
+    Moo.defaultProps = { idx: 'moo' };
+
+    function Foo(props) {
+      var _props = { idx: this.constructor.defaultProps.idx + '?' };
+
+      React.Component.call(this, _props);
+    }
+    Foo.prototype = Object.create(React.Component.prototype, {
+      constructor: {
+        value: Foo,
+      },
+    });
+    Foo.prototype.render = function() {
+      return <span />;
+    };
+    Foo.defaultProps = { idx: 'foo' };
+
+    function Bar() {
+      Foo.call(this);
+    }
+
+    Bar.prototype = Object.create(Foo.prototype, {
+      constructor: {
+        value: Bar,
+      },
+    });
+    Bar.defaultProps = { idx: 'bar' };
+
+    var moo = ReactTestUtils.renderIntoDocument(<Moo />);
+    expect(moo.props.idx).toBe('moo');
+
+    var foo = ReactTestUtils.renderIntoDocument(<Foo />);
+    expect(foo.props.idx).toBe('foo?');
+
+    var bar = ReactTestUtils.renderIntoDocument(<Bar />);
+    expect(bar.props.idx).toBe('bar?');
+  });
 });


### PR DESCRIPTION
When rendering the class ```Bar``` from the following example, the ```Bar``` instance has the moo prop set as 'BOO' and not the expected 'BOO!' because the props passed to the constructor are overwritten with their initial state in the chance they are undefined. This PR just ignores that logic if props is defined.

```Javascript
class Foo extends React.Component {
  constructor(props) {
    var _props = { moo: new.target.defaultProps.moo + '!' }
    super(_props);
  }
}
Foo.defaultProps = { moo: 'MOO' };

class Bar extends Foo {}
Bar.defaultProps = { moo: 'BOO' };
```
