### PR TITLE
Update tests

### DIFF
--- a/mocks/ReactElementTestChild.js
+++ b/mocks/ReactElementTestChild.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactElementTestChild
+ */
+
+'use strict';
+
+var React = require('React');
+
+var Child = React.createClass({
+  render: function() {
+    return React.createElement('div');
+  },
+});
+
+module.exports = Child;

--- a/mocks/ReactMockedComponentTestComponent.js
+++ b/mocks/ReactMockedComponentTestComponent.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactMockedComponentTestComponent
+ */
+
+'use strict';
+
+var React = require('React');
+
+var ReactMockedComponentTestComponent = React.createClass({
+  getDefaultProps: function() {
+    return {bar: 'baz'};
+  },
+
+  getInitialState: function() {
+    return {foo: 'bar'};
+  },
+
+  hasCustomMethod: function() {
+    return true;
+  },
+
+  render: function() {
+    return <span />;
+  },
+
+});
+
+module.exports = ReactMockedComponentTestComponent;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "gulp-flatten": "^0.1.0",
     "gulp-util": "^3.0.5",
     "gzip-js": "~0.3.2",
-    "jest-cli": "^0.5.7",
+    "jest-cli": "^0.6.1",
     "jstransform": "^11.0.0",
     "object-assign": "^3.0.0",
     "optimist": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     ],
     "testPathDirs": [
       "<rootDir>/eslint-rules",
+      "<rootDir>/mocks",
       "<rootDir>/src",
       "node_modules/fbjs"
     ],

--- a/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
@@ -23,7 +23,7 @@ describe('ReactCSSTransitionGroup', function() {
   var container;
 
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactCSSTransitionGroup = require('ReactCSSTransitionGroup');

--- a/src/isomorphic/classic/__tests__/ReactContextValidator-test.js
+++ b/src/isomorphic/classic/__tests__/ReactContextValidator-test.js
@@ -25,7 +25,7 @@ var reactComponentExpect;
 
 describe('ReactContextValidator', function() {
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
 
     React = require('React');
     ReactDOM = require('ReactDOM');

--- a/src/isomorphic/classic/class/__tests__/ReactBind-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactBind-test.js
@@ -11,7 +11,6 @@
 /*global global:true*/
 'use strict';
 
-var mocks = require('mocks');
 var React = require('React');
 var ReactTestUtils = require('ReactTestUtils');
 var reactComponentExpect = require('reactComponentExpect');
@@ -21,9 +20,9 @@ describe('autobinding', function() {
 
   it('Holds reference to instance', function() {
 
-    var mouseDidEnter = mocks.getMockFunction();
-    var mouseDidLeave = mocks.getMockFunction();
-    var mouseDidClick = mocks.getMockFunction();
+    var mouseDidEnter = jest.genMockFn();
+    var mouseDidLeave = jest.genMockFn();
+    var mouseDidClick = jest.genMockFn();
 
     var TestBindComponent = React.createClass({
       getInitialState: function() {
@@ -96,7 +95,7 @@ describe('autobinding', function() {
   });
 
   it('works with mixins', function() {
-    var mouseDidClick = mocks.getMockFunction();
+    var mouseDidClick = jest.genMockFn();
 
     var TestMixin = {
       onClick: mouseDidClick,

--- a/src/isomorphic/classic/class/__tests__/ReactBindOptout-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactBindOptout-test.js
@@ -11,7 +11,6 @@
 /*global global:true*/
 'use strict';
 
-var mocks = require('mocks');
 var React = require('React');
 var ReactTestUtils = require('ReactTestUtils');
 var reactComponentExpect = require('reactComponentExpect');
@@ -21,9 +20,9 @@ describe('autobind optout', function() {
 
   it('should work with manual binding', function() {
 
-    var mouseDidEnter = mocks.getMockFunction();
-    var mouseDidLeave = mocks.getMockFunction();
-    var mouseDidClick = mocks.getMockFunction();
+    var mouseDidEnter = jest.genMockFn();
+    var mouseDidLeave = jest.genMockFn();
+    var mouseDidClick = jest.genMockFn();
 
     var TestBindComponent = React.createClass({
       autobind: false,
@@ -139,7 +138,7 @@ describe('autobind optout', function() {
   });
 
   it('works with mixins that have not opted out of autobinding', function() {
-    var mouseDidClick = mocks.getMockFunction();
+    var mouseDidClick = jest.genMockFn();
 
     var TestMixin = {
       onClick: mouseDidClick,
@@ -165,7 +164,7 @@ describe('autobind optout', function() {
   });
 
   it('works with mixins that have opted out of autobinding', function() {
-    var mouseDidClick = mocks.getMockFunction();
+    var mouseDidClick = jest.genMockFn();
 
     var TestMixin = {
       autobind: false,

--- a/src/isomorphic/classic/class/__tests__/ReactClass-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactClass-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-var mocks = require('mocks');
-
 var React;
 var ReactDOM;
 var ReactTestUtils;
@@ -46,7 +44,7 @@ describe('ReactClass-spec', function() {
   });
 
   it('should copy prop types onto the Constructor', function() {
-    var propValidator = mocks.getMockFunction();
+    var propValidator = jest.genMockFn();
     var TestComponent = React.createClass({
       propTypes: {
         value: propValidator,
@@ -63,7 +61,7 @@ describe('ReactClass-spec', function() {
 
   it('should warn on invalid prop types', function() {
     var warn = console.error;
-    console.error = mocks.getMockFunction();
+    console.error = jest.genMockFn();
     try {
 
       React.createClass({
@@ -87,7 +85,7 @@ describe('ReactClass-spec', function() {
 
   it('should warn on invalid context types', function() {
     var warn = console.error;
-    console.error = mocks.getMockFunction();
+    console.error = jest.genMockFn();
     try {
       React.createClass({
         displayName: 'Component',
@@ -110,7 +108,7 @@ describe('ReactClass-spec', function() {
 
   it('should throw on invalid child context types', function() {
     var warn = console.error;
-    console.error = mocks.getMockFunction();
+    console.error = jest.genMockFn();
     try {
       React.createClass({
         displayName: 'Component',

--- a/src/isomorphic/classic/class/__tests__/ReactClassMixin-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactClassMixin-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-var mocks = require('mocks');
-
 var React;
 var ReactTestUtils;
 
@@ -27,8 +25,8 @@ describe('ReactClass-mixin', function() {
   beforeEach(function() {
     React = require('React');
     ReactTestUtils = require('ReactTestUtils');
-    mixinPropValidator = mocks.getMockFunction();
-    componentPropValidator = mocks.getMockFunction();
+    mixinPropValidator = jest.genMockFn();
+    componentPropValidator = jest.genMockFn();
 
     var MixinA = {
       propTypes: {
@@ -109,7 +107,7 @@ describe('ReactClass-mixin', function() {
   });
 
   it('should support merging propTypes and statics', function() {
-    var listener = mocks.getMockFunction();
+    var listener = jest.genMockFn();
     var instance = <TestComponent listener={listener} />;
     instance = ReactTestUtils.renderIntoDocument(instance);
 
@@ -124,7 +122,7 @@ describe('ReactClass-mixin', function() {
   });
 
   it('should support chaining delegate functions', function() {
-    var listener = mocks.getMockFunction();
+    var listener = jest.genMockFn();
     var instance = <TestComponent listener={listener} />;
     instance = ReactTestUtils.renderIntoDocument(instance);
 
@@ -137,7 +135,7 @@ describe('ReactClass-mixin', function() {
   });
 
   it('should chain functions regardless of spec property order', function() {
-    var listener = mocks.getMockFunction();
+    var listener = jest.genMockFn();
     var instance = <TestComponentWithReverseSpec listener={listener} />;
     instance = ReactTestUtils.renderIntoDocument(instance);
 

--- a/src/isomorphic/classic/element/__tests__/ReactElement-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElement-test.js
@@ -369,23 +369,14 @@ describe('ReactElement', function() {
 });
 
 describe('comparing jsx vs .createFactory() vs .createElement()', function() {
-  var Child, mocks;
+  var Child;
 
   beforeEach(function() {
     jest.resetModuleRegistry();
-    mocks = require('mocks');
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactTestUtils = require('ReactTestUtils');
-
-    var metaData = mocks.getMetadata(React.createClass({
-      render: function() {
-        return React.createElement('div');
-      },
-    }));
-
-    Child = mocks.generateFromMetadata(metaData);
-
+    Child = jest.genMockFromModule('ReactElementTestChild');
   });
 
 

--- a/src/isomorphic/classic/element/__tests__/ReactElement-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElement-test.js
@@ -23,7 +23,7 @@ describe('ReactElement', function() {
   var originalSymbol;
 
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
 
     // Delete the native Symbol if we have one to ensure we test the
     // unpolyfilled environment.
@@ -339,7 +339,7 @@ describe('ReactElement', function() {
       return OTHER_SYMBOL;
     };
 
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
 
     React = require('React');
 
@@ -372,7 +372,7 @@ describe('comparing jsx vs .createFactory() vs .createElement()', function() {
   var Child, mocks;
 
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     mocks = require('mocks');
     React = require('React');
     ReactDOM = require('ReactDOM');

--- a/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-require('mock-modules');
-
 var React;
 var ReactDOM;
 var ReactTestUtils;

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -22,7 +22,7 @@ describe('ReactElementValidator', function() {
   var ComponentClass;
 
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
 
     React = require('React');
     ReactDOM = require('ReactDOM');

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -764,7 +764,7 @@ describe('ReactPropTypes', function() {
 
   describe('Custom validator', function() {
     beforeEach(function() {
-      require('mock-modules').dumpCache();
+      jest.resetModuleRegistry();
       spyOn(console, 'error');
     });
 

--- a/src/isomorphic/deprecated/__tests__/cloneWithProps-test.js
+++ b/src/isomorphic/deprecated/__tests__/cloneWithProps-test.js
@@ -22,7 +22,7 @@ var emptyObject;
 describe('cloneWithProps', function() {
 
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactTestUtils = require('ReactTestUtils');

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElement-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElement-test.js
@@ -19,7 +19,7 @@ describe('ReactJSXElement', function() {
   var Component;
 
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
 
     React = require('React');
     ReactDOM = require('ReactDOM');

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -22,7 +22,7 @@ describe('ReactJSXElementValidator', function() {
   var RequiredPropComponent;
 
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
 
     React = require('React');
     ReactTestUtils = require('ReactTestUtils');

--- a/src/renderers/dom/__tests__/ReactDOMProduction-test.js
+++ b/src/renderers/dom/__tests__/ReactDOMProduction-test.js
@@ -22,7 +22,7 @@ describe('ReactDOMProduction', function() {
     oldProcess = process;
     global.process = {env: {NODE_ENV: 'production'}};
 
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     React = require('React');
     ReactDOM = require('ReactDOM');
   });

--- a/src/renderers/dom/client/__tests__/ReactBrowserEventEmitter-test.js
+++ b/src/renderers/dom/client/__tests__/ReactBrowserEventEmitter-test.js
@@ -12,7 +12,6 @@
 'use strict';
 
 var keyOf = require('keyOf');
-var mocks = require('mocks');
 
 var ReactMount = require('ReactMount');
 var idToNode = {};
@@ -44,7 +43,7 @@ var recordIDAndReturnFalse = function(id, event) {
   recordID(id);
   return false;
 };
-var LISTENER = mocks.getMockFunction();
+var LISTENER = jest.genMockFn();
 var ON_CLICK_KEY = keyOf({onClick: null});
 var ON_TOUCH_TAP_KEY = keyOf({onTouchTap: null});
 var ON_CHANGE_KEY = keyOf({onChange: null});
@@ -76,7 +75,7 @@ function registerSimpleTestHandler() {
 
 describe('ReactBrowserEventEmitter', function() {
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     LISTENER.mockClear();
     EventPluginHub = require('EventPluginHub');
     EventPluginRegistry = require('EventPluginRegistry');
@@ -306,7 +305,7 @@ describe('ReactBrowserEventEmitter', function() {
    */
 
   it('should invoke handlers that were removed while bubbling', function() {
-    var handleParentClick = mocks.getMockFunction();
+    var handleParentClick = jest.genMockFn();
     var handleChildClick = function(event) {
       EventPluginHub.deleteAllListeners(getID(PARENT));
     };
@@ -325,7 +324,7 @@ describe('ReactBrowserEventEmitter', function() {
   });
 
   it('should not invoke newly inserted handlers while bubbling', function() {
-    var handleParentClick = mocks.getMockFunction();
+    var handleParentClick = jest.genMockFn();
     var handleChildClick = function(event) {
       EventPluginHub.putListener(
         getID(PARENT),

--- a/src/renderers/dom/client/__tests__/ReactEventIndependence-test.js
+++ b/src/renderers/dom/client/__tests__/ReactEventIndependence-test.js
@@ -17,7 +17,7 @@ var ReactTestUtils;
 
 describe('ReactEventIndependence', function() {
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
 
     React = require('React');
     ReactDOM = require('ReactDOM');

--- a/src/renderers/dom/client/__tests__/ReactEventListener-test.js
+++ b/src/renderers/dom/client/__tests__/ReactEventListener-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-var mocks = require('mocks');
-
 
 var EVENT_TARGET_PARAM = 1;
 
@@ -27,7 +25,7 @@ describe('ReactEventListener', function() {
   var handleTopLevel;
 
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     React = require('React');
 
     ReactDOM = require('ReactDOM');
@@ -36,7 +34,7 @@ describe('ReactEventListener', function() {
     ReactEventListener = require('ReactEventListener');
     ReactTestUtils = require('ReactTestUtils');
 
-    handleTopLevel = mocks.getMockFunction();
+    handleTopLevel = jest.genMockFn();
     ReactEventListener._handleTopLevel = handleTopLevel;
   });
 

--- a/src/renderers/dom/client/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMount-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-var mocks = require('mocks');
-
 describe('ReactMount', function() {
   var React = require('React');
   var ReactDOM = require('ReactDOM');
@@ -81,8 +79,8 @@ describe('ReactMount', function() {
   it('should unmount and remount if the key changes', function() {
     var container = document.createElement('container');
 
-    var mockMount = mocks.getMockFunction();
-    var mockUnmount = mocks.getMockFunction();
+    var mockMount = jest.genMockFn();
+    var mockUnmount = jest.genMockFn();
 
     var Component = React.createClass({
       componentDidMount: mockMount,
@@ -199,9 +197,9 @@ describe('ReactMount', function() {
   }
 
   it('warns when using two copies of React before throwing', function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     var RD1 = require('ReactDOM');
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     var RD2 = require('ReactDOM');
 
     var X = React.createClass({

--- a/src/renderers/dom/client/__tests__/ReactRenderDocument-test.js
+++ b/src/renderers/dom/client/__tests__/ReactRenderDocument-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-require('mock-modules')
+jest
   .mock('ServerReactRootIndex');
 
 var React;
@@ -33,7 +33,7 @@ var UNMOUNT_INVARIANT_MESSAGE =
 
 describe('rendering React components at document', function() {
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
 
     // Negative integer creator. So they won't get confused with
     // the Client positive ids.

--- a/src/renderers/dom/client/__tests__/validateDOMNesting-test.js
+++ b/src/renderers/dom/client/__tests__/validateDOMNesting-test.js
@@ -47,7 +47,7 @@ function isTagStackValid(stack) {
 
 describe('ReactContextValidator', function() {
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
 
     validateDOMNesting = require('validateDOMNesting');
   });

--- a/src/renderers/dom/client/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
+++ b/src/renderers/dom/client/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
@@ -21,7 +21,7 @@ var topLevelTypes;
 
 describe('EnterLeaveEventPlugin', function() {
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
 
     EnterLeaveEventPlugin = require('EnterLeaveEventPlugin');
     EventConstants = require('EventConstants');

--- a/src/renderers/dom/client/eventPlugins/__tests__/SelectEventPlugin-test.js
+++ b/src/renderers/dom/client/eventPlugins/__tests__/SelectEventPlugin-test.js
@@ -61,15 +61,13 @@ describe('SelectEventPlugin', function() {
   });
 
   it('should extract if an `onSelect` listener is present', function() {
-    var mocks = require('mocks');
-
     var WithSelect = React.createClass({
       render: function() {
         return <input type="text" onSelect={this.props.onSelect} />;
       },
     });
 
-    var cb = mocks.getMockFunction();
+    var cb = jest.genMockFn();
 
     var rendered = ReactTestUtils.renderIntoDocument(
       <WithSelect onSelect={cb} />

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMButton-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMButton-test.js
@@ -12,14 +12,12 @@
 'use strict';
 
 
-var mocks = require('mocks');
-
 describe('ReactDOMButton', function() {
   var React;
   var ReactDOM;
   var ReactTestUtils;
 
-  var onClick = mocks.getMockFunction();
+  var onClick = jest.genMockFn();
 
   function expectClickThru(button) {
     onClick.mockClear();

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
@@ -13,7 +13,6 @@
 
 
 var emptyFunction = require('emptyFunction');
-var mocks = require('mocks');
 
 describe('ReactDOMInput', function() {
   var EventConstants;
@@ -23,7 +22,7 @@ describe('ReactDOMInput', function() {
   var ReactTestUtils;
 
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     EventConstants = require('EventConstants');
     React = require('React');
     ReactDOM = require('ReactDOM');
@@ -235,7 +234,7 @@ describe('ReactDOMInput', function() {
   });
 
   it('should support ReactLink', function() {
-    var link = new ReactLink('yolo', mocks.getMockFunction());
+    var link = new ReactLink('yolo', jest.genMockFn());
     var instance = <input type="text" valueLink={link} />;
 
     instance = ReactTestUtils.renderIntoDocument(instance);
@@ -252,7 +251,7 @@ describe('ReactDOMInput', function() {
   });
 
   it('should warn with value and no onChange handler', function() {
-    var link = new ReactLink('yolo', mocks.getMockFunction());
+    var link = new ReactLink('yolo', jest.genMockFn());
     ReactTestUtils.renderIntoDocument(<input type="text" valueLink={link} />);
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toContain(
@@ -260,7 +259,7 @@ describe('ReactDOMInput', function() {
     );
 
     ReactTestUtils.renderIntoDocument(
-      <input type="text" value="zoink" onChange={mocks.getMockFunction()} />
+      <input type="text" value="zoink" onChange={jest.genMockFn()} />
     );
     expect(console.error.argsForCall.length).toBe(1);
     ReactTestUtils.renderIntoDocument(<input type="text" value="zoink" />);
@@ -292,7 +291,7 @@ describe('ReactDOMInput', function() {
 
   it('should throw if both value and valueLink are provided', function() {
     var node = document.createElement('div');
-    var link = new ReactLink('yolo', mocks.getMockFunction());
+    var link = new ReactLink('yolo', jest.genMockFn());
     var instance = <input type="text" valueLink={link} />;
 
     expect(() => ReactDOM.render(instance, node)).not.toThrow();
@@ -312,7 +311,7 @@ describe('ReactDOMInput', function() {
   });
 
   it('should support checkedLink', function() {
-    var link = new ReactLink(true, mocks.getMockFunction());
+    var link = new ReactLink(true, jest.genMockFn());
     var instance = <input type="checkbox" checkedLink={link} />;
 
     instance = ReactTestUtils.renderIntoDocument(instance);
@@ -330,7 +329,7 @@ describe('ReactDOMInput', function() {
 
   it('should warn with checked and no onChange handler', function() {
     var node = document.createElement('div');
-    var link = new ReactLink(true, mocks.getMockFunction());
+    var link = new ReactLink(true, jest.genMockFn());
     ReactDOM.render(<input type="checkbox" checkedLink={link} />, node);
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toContain(
@@ -341,7 +340,7 @@ describe('ReactDOMInput', function() {
       <input
         type="checkbox"
         checked="false"
-        onChange={mocks.getMockFunction()}
+        onChange={jest.genMockFn()}
       />
     );
     expect(console.error.argsForCall.length).toBe(1);
@@ -369,7 +368,7 @@ describe('ReactDOMInput', function() {
 
   it('should throw if both checked and checkedLink are provided', function() {
     var node = document.createElement('div');
-    var link = new ReactLink(true, mocks.getMockFunction());
+    var link = new ReactLink(true, jest.genMockFn());
     var instance = <input type="checkbox" checkedLink={link} />;
 
     expect(() => ReactDOM.render(instance, node)).not.toThrow();
@@ -391,7 +390,7 @@ describe('ReactDOMInput', function() {
 
   it('should throw if both checkedLink and valueLink are provided', function() {
     var node = document.createElement('div');
-    var link = new ReactLink(true, mocks.getMockFunction());
+    var link = new ReactLink(true, jest.genMockFn());
     var instance = <input type="checkbox" checkedLink={link} />;
 
     expect(() => ReactDOM.render(instance, node)).not.toThrow();

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMSelect-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMSelect-test.js
@@ -12,8 +12,6 @@
 'use strict';
 
 
-var mocks = require('mocks');
-
 describe('ReactDOMSelect', function() {
   var React;
   var ReactDOM;
@@ -350,7 +348,7 @@ describe('ReactDOMSelect', function() {
   });
 
   it('should support ReactLink', function() {
-    var link = new ReactLink('giraffe', mocks.getMockFunction());
+    var link = new ReactLink('giraffe', jest.genMockFn());
     var stub =
       <select valueLink={link}>
         <option value="monkey">A monkey!</option>

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMTextarea-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMTextarea-test.js
@@ -12,7 +12,6 @@
 'use strict';
 
 var emptyFunction = require('emptyFunction');
-var mocks = require('mocks');
 
 describe('ReactDOMTextarea', function() {
   var React;
@@ -238,7 +237,7 @@ describe('ReactDOMTextarea', function() {
   });
 
   it('should support ReactLink', function() {
-    var link = new ReactLink('yolo', mocks.getMockFunction());
+    var link = new ReactLink('yolo', jest.genMockFn());
     var instance = <textarea valueLink={link} />;
 
     spyOn(console, 'error');

--- a/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-var mocks = require('mocks');
-
 var ExecutionEnvironment;
 var React;
 var ReactDOM;
@@ -25,7 +23,7 @@ var ID_ATTRIBUTE_NAME;
 
 describe('ReactServerRendering', function() {
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactMarkupChecksum = require('ReactMarkupChecksum');
@@ -74,7 +72,7 @@ describe('ReactServerRendering', function() {
 
     it('should not register event listeners', function() {
       var EventPluginHub = require('EventPluginHub');
-      var cb = mocks.getMockFunction();
+      var cb = jest.genMockFn();
 
       ReactServerRendering.renderToString(
         <span onClick={cb}>hello world</span>
@@ -288,7 +286,7 @@ describe('ReactServerRendering', function() {
 
     it('should not register event listeners', function() {
       var EventPluginHub = require('EventPluginHub');
-      var cb = mocks.getMockFunction();
+      var cb = jest.genMockFn();
 
       ReactServerRendering.renderToString(
         <span onClick={cb}>hello world</span>

--- a/src/renderers/dom/shared/__tests__/CSSProperty-test.js
+++ b/src/renderers/dom/shared/__tests__/CSSProperty-test.js
@@ -15,7 +15,7 @@ describe('CSSProperty', function() {
   var CSSProperty;
 
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     CSSProperty = require('CSSProperty');
   });
 

--- a/src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
@@ -19,7 +19,7 @@ describe('CSSPropertyOperations', function() {
   var CSSPropertyOperations;
 
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     CSSPropertyOperations = require('CSSPropertyOperations');
   });
 

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -15,8 +15,6 @@ describe('DOMPropertyOperations', function() {
   var DOMPropertyOperations;
   var DOMProperty;
 
-  var mocks;
-
   beforeEach(function() {
     jest.resetModuleRegistry();
     var ReactDefaultInjection = require('ReactDefaultInjection');
@@ -24,8 +22,6 @@ describe('DOMPropertyOperations', function() {
 
     DOMPropertyOperations = require('DOMPropertyOperations');
     DOMProperty = require('DOMProperty');
-
-    mocks = require('mocks');
   });
 
   describe('createMarkupForProperty', function() {

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -18,7 +18,7 @@ describe('DOMPropertyOperations', function() {
   var mocks;
 
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     var ReactDefaultInjection = require('ReactDefaultInjection');
     ReactDefaultInjection.inject();
 
@@ -270,7 +270,7 @@ describe('DOMPropertyOperations', function() {
     });
 
     it('should use mutation method where applicable', function() {
-      var foobarSetter = mocks.getMockFunction();
+      var foobarSetter = jest.genMockFn();
       // inject foobar DOM property
       DOMProperty.injection.injectDOMPropertyConfig({
         Properties: {foobar: null},

--- a/src/renderers/dom/shared/__tests__/Danger-test.js
+++ b/src/renderers/dom/shared/__tests__/Danger-test.js
@@ -17,7 +17,7 @@ describe('Danger', function() {
     var Danger;
 
     beforeEach(function() {
-      require('mock-modules').dumpCache();
+      jest.resetModuleRegistry();
       Danger = require('Danger');
     });
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -12,7 +12,6 @@
 'use strict';
 
 var assign = require('Object.assign');
-var mocks = require('mocks');
 
 describe('ReactDOMComponent', function() {
   var React;
@@ -21,7 +20,7 @@ describe('ReactDOMComponent', function() {
   var ReactDOMServer;
 
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactDOMServer = require('ReactDOMServer');
@@ -404,7 +403,7 @@ describe('ReactDOMComponent', function() {
 
       var node = container.firstChild;
       var nodeValue = ''; // node.value always returns undefined
-      var nodeValueSetter = mocks.getMockFunction();
+      var nodeValueSetter = jest.genMockFn();
       Object.defineProperty(node, 'value', {
         get: function() {
           return nodeValue;
@@ -431,7 +430,7 @@ describe('ReactDOMComponent', function() {
       var container = document.createElement('div');
       var node = ReactDOM.render(<div />, container);
 
-      var setter = mocks.getMockFunction();
+      var setter = jest.genMockFn();
       node.setAttribute = setter;
 
       ReactDOM.render(<div dir={null} />, container);
@@ -659,8 +658,8 @@ describe('ReactDOMComponent', function() {
     it('should execute custom event plugin listening behavior', function() {
       var SimpleEventPlugin = require('SimpleEventPlugin');
 
-      SimpleEventPlugin.didPutListener = mocks.getMockFunction();
-      SimpleEventPlugin.willDeleteListener = mocks.getMockFunction();
+      SimpleEventPlugin.didPutListener = jest.genMockFn();
+      SimpleEventPlugin.willDeleteListener = jest.genMockFn();
 
       var container = document.createElement('div');
       ReactDOM.render(
@@ -678,8 +677,8 @@ describe('ReactDOMComponent', function() {
     it('should handle null and missing properly with event hooks', function() {
       var SimpleEventPlugin = require('SimpleEventPlugin');
 
-      SimpleEventPlugin.didPutListener = mocks.getMockFunction();
-      SimpleEventPlugin.willDeleteListener = mocks.getMockFunction();
+      SimpleEventPlugin.didPutListener = jest.genMockFn();
+      SimpleEventPlugin.willDeleteListener = jest.genMockFn();
       var container = document.createElement('div');
 
       ReactDOM.render(<div onClick={false} />, container);
@@ -858,8 +857,7 @@ describe('ReactDOMComponent', function() {
     it('should warn about the `onScroll` issue when unsupported (IE8)', () => {
       // Mock this here so we can mimic IE8 support. We require isEventSupported
       // before React so it's pre-mocked before React qould require it.
-      require('mock-modules')
-        .dumpCache()
+      jest.resetModuleRegistry()
         .mock('isEventSupported');
       var isEventSupported = require('isEventSupported');
       isEventSupported.mockReturnValueOnce(false);

--- a/src/renderers/shared/event/__tests__/EventPluginHub-test.js
+++ b/src/renderers/shared/event/__tests__/EventPluginHub-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-require('mock-modules')
+jest
   .dontMock('EventPluginHub')
   .mock('isEventSupported');
 
@@ -20,7 +20,7 @@ describe('EventPluginHub', function() {
   var isEventSupported;
 
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     EventPluginHub = require('EventPluginHub');
     isEventSupported = require('isEventSupported');
     isEventSupported.mockReturnValueOnce(false);

--- a/src/renderers/shared/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
+++ b/src/renderers/shared/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
@@ -330,7 +330,7 @@ var siblings = {
 
 describe('ResponderEventPlugin', function() {
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
 
     EventConstants = require('EventConstants');
     EventPluginHub = require('EventPluginHub');

--- a/src/renderers/shared/reconciler/__tests__/ReactComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactComponent-test.js
@@ -258,7 +258,7 @@ describe('ReactComponent', function() {
   });
 
   it('fires the callback after a component is rendered', function() {
-    var callback = mocks.getMockFunction();
+    var callback = jest.genMockFn();
     var container = document.createElement('div');
     ReactDOM.render(<div />, container, callback);
     expect(callback.mock.calls.length).toBe(1);

--- a/src/renderers/shared/reconciler/__tests__/ReactComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactComponent-test.js
@@ -15,11 +15,8 @@ var React;
 var ReactDOM;
 var ReactTestUtils;
 
-var mocks;
-
 describe('ReactComponent', function() {
   beforeEach(function() {
-    mocks = require('mocks');
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactTestUtils = require('ReactTestUtils');

--- a/src/renderers/shared/reconciler/__tests__/ReactComponentLifeCycle-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactComponentLifeCycle-test.js
@@ -98,7 +98,7 @@ function getLifeCycleState(instance) {
  */
 describe('ReactComponentLifeCycle', function() {
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactTestUtils = require('ReactTestUtils');

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -27,7 +27,7 @@ var reactComponentExpect;
 describe('ReactCompositeComponent', function() {
 
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     reactComponentExpect = require('reactComponentExpect');
     React = require('React');
     ReactDOM = require('ReactDOM');

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentNestedState-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentNestedState-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-var mocks = require('mocks');
-
 var React;
 var ReactDOM;
 var ReactTestUtils;
@@ -92,7 +90,7 @@ describe('ReactCompositeComponentNestedState-state', function() {
     var container = document.createElement('div');
     document.body.appendChild(container);
 
-    var logger = mocks.getMockFunction();
+    var logger = jest.genMockFn();
 
     void ReactDOM.render(
       <ParentComponent logger={logger} />,

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentState-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentState-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-var mocks = require('mocks');
-
 var React;
 var ReactDOM;
 
@@ -132,7 +130,7 @@ describe('ReactCompositeComponent-state', function() {
     var container = document.createElement('div');
     document.body.appendChild(container);
 
-    var stateListener = mocks.getMockFunction();
+    var stateListener = jest.genMockFn();
     var instance = ReactDOM.render(
       <TestComponent stateListener={stateListener} />,
       container,

--- a/src/renderers/shared/reconciler/__tests__/ReactEmptyComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactEmptyComponent-test.js
@@ -20,7 +20,7 @@ var reactComponentExpect;
 
 describe('ReactEmptyComponent', function() {
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
 
     React = require('React');
     ReactDOM = require('ReactDOM');

--- a/src/renderers/shared/reconciler/__tests__/ReactIdentity-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactIdentity-test.js
@@ -20,7 +20,7 @@ var ReactMount;
 describe('ReactIdentity', function() {
 
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactFragment = require('ReactFragment');

--- a/src/renderers/shared/reconciler/__tests__/ReactMockedComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactMockedComponent-test.js
@@ -14,43 +14,17 @@
 var React;
 var ReactTestUtils;
 
-var mocks;
-
-var OriginalComponent;
 var AutoMockedComponent;
 var MockedComponent;
 
 describe('ReactMockedComponent', function() {
 
   beforeEach(function() {
-    mocks = require('mocks');
-
     React = require('React');
     ReactTestUtils = require('ReactTestUtils');
 
-    OriginalComponent = React.createClass({
-      getDefaultProps: function() {
-        return {bar: 'baz'};
-      },
-
-      getInitialState: function() {
-        return {foo: 'bar'};
-      },
-
-      hasCustomMethod: function() {
-        return true;
-      },
-
-      render: function() {
-        return <span />;
-      },
-
-    });
-
-    var metaData = mocks.getMetadata(OriginalComponent);
-
-    AutoMockedComponent = mocks.generateFromMetadata(metaData);
-    MockedComponent = mocks.generateFromMetadata(metaData);
+    AutoMockedComponent = jest.genMockFromModule('ReactMockedComponentTestComponent');
+    MockedComponent = jest.genMockFromModule('ReactMockedComponentTestComponent');
 
     ReactTestUtils.mockComponent(MockedComponent);
   });

--- a/src/renderers/shared/reconciler/__tests__/ReactMultiChild-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactMultiChild-test.js
@@ -11,15 +11,13 @@
 
 'use strict';
 
-var mocks = require('mocks');
-
 describe('ReactMultiChild', function() {
   var React;
 
   var ReactDOM;
 
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     React = require('React');
     ReactDOM = require('ReactDOM');
   });
@@ -28,9 +26,9 @@ describe('ReactMultiChild', function() {
     it('should update children when possible', function() {
       var container = document.createElement('div');
 
-      var mockMount = mocks.getMockFunction();
-      var mockUpdate = mocks.getMockFunction();
-      var mockUnmount = mocks.getMockFunction();
+      var mockMount = jest.genMockFn();
+      var mockUpdate = jest.genMockFn();
+      var mockUnmount = jest.genMockFn();
 
       var MockComponent = React.createClass({
         componentDidMount: mockMount,
@@ -61,8 +59,8 @@ describe('ReactMultiChild', function() {
     it('should replace children with different constructors', function() {
       var container = document.createElement('div');
 
-      var mockMount = mocks.getMockFunction();
-      var mockUnmount = mocks.getMockFunction();
+      var mockMount = jest.genMockFn();
+      var mockUnmount = jest.genMockFn();
 
       var MockComponent = React.createClass({
         componentDidMount: mockMount,
@@ -89,8 +87,8 @@ describe('ReactMultiChild', function() {
     it('should NOT replace children with different owners', function() {
       var container = document.createElement('div');
 
-      var mockMount = mocks.getMockFunction();
-      var mockUnmount = mocks.getMockFunction();
+      var mockMount = jest.genMockFn();
+      var mockUnmount = jest.genMockFn();
 
       var MockComponent = React.createClass({
         componentDidMount: mockMount,
@@ -126,8 +124,8 @@ describe('ReactMultiChild', function() {
     it('should replace children with different keys', function() {
       var container = document.createElement('div');
 
-      var mockMount = mocks.getMockFunction();
-      var mockUnmount = mocks.getMockFunction();
+      var mockMount = jest.genMockFn();
+      var mockUnmount = jest.genMockFn();
 
       var MockComponent = React.createClass({
         componentDidMount: mockMount,

--- a/src/renderers/shared/reconciler/__tests__/ReactMultiChildReconcile-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactMultiChildReconcile-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-require('mock-modules');
-
 var React = require('React');
 var ReactDOM = require('ReactDOM');
 var ReactInstanceMap = require('ReactInstanceMap');
@@ -237,7 +235,7 @@ function testPropsSequence(sequence) {
 
 describe('ReactMultiChildReconcile', function() {
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
   });
 
   it('should reset internal state if removed then readded', function() {

--- a/src/renderers/shared/reconciler/__tests__/ReactMultiChildText-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactMultiChildText-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-require('mock-modules');
-
 var React = require('React');
 var ReactDOM = require('ReactDOM');
 var ReactTestUtils = require('ReactTestUtils');

--- a/src/renderers/shared/reconciler/__tests__/ReactStateSetters-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactStateSetters-test.js
@@ -20,7 +20,7 @@ var TestComponentWithMixin;
 
 describe('ReactStateSetters', function() {
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
 
     TestComponent = React.createClass({
       getInitialState: function() {

--- a/src/renderers/shared/reconciler/__tests__/refs-destruction-test.js
+++ b/src/renderers/shared/reconciler/__tests__/refs-destruction-test.js
@@ -19,7 +19,7 @@ var TestComponent;
 
 describe('refs-destruction', function() {
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
 
     React = require('React');
     ReactDOM = require('ReactDOM');

--- a/src/renderers/shared/reconciler/__tests__/refs-test.js
+++ b/src/renderers/shared/reconciler/__tests__/refs-test.js
@@ -115,7 +115,7 @@ var expectClickLogsLengthToBe = function(instance, length) {
 
 describe('reactiverefs', function() {
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
   });
 
   /**
@@ -158,7 +158,7 @@ describe('reactiverefs', function() {
  */
 describe('ref swapping', function() {
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
   });
 
   var RefHopsAround = React.createClass({

--- a/src/shared/utils/__tests__/OrderedMap-test.js
+++ b/src/shared/utils/__tests__/OrderedMap-test.js
@@ -134,7 +134,7 @@ var extractUniqueID = function(entity) {
 
 describe('OrderedMap', function() {
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     OrderedMap = require('OrderedMap');
   });
 

--- a/src/shared/utils/__tests__/Transaction-test.js
+++ b/src/shared/utils/__tests__/Transaction-test.js
@@ -18,7 +18,7 @@ var Transaction;
 var INIT_ERRORED = 'initErrored';     // Just a dummy value to check for.
 describe('Transaction', function() {
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     Transaction = require('Transaction');
   });
 

--- a/src/shared/utils/__tests__/accumulateInto-test.js
+++ b/src/shared/utils/__tests__/accumulateInto-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-require('mock-modules')
+jest
   .dontMock('accumulateInto');
 
 var accumulateInto;

--- a/src/shared/utils/__tests__/traverseAllChildren-test.js
+++ b/src/shared/utils/__tests__/traverseAllChildren-test.js
@@ -16,7 +16,7 @@ describe('traverseAllChildren', function() {
   var React;
   var ReactFragment;
   beforeEach(function() {
-    require('mock-modules').dumpCache();
+    jest.resetModuleRegistry();
     traverseAllChildren = require('traverseAllChildren');
     React = require('React');
     ReactFragment = require('ReactFragment');

--- a/src/test/__tests__/ReactDefaultPerf-test.js
+++ b/src/test/__tests__/ReactDefaultPerf-test.js
@@ -24,7 +24,7 @@ describe('ReactDefaultPerf', function() {
 
   beforeEach(function() {
     var now = 0;
-    require('mock-modules').setMock('performanceNow', function() {
+    jest.setMock('performanceNow', function() {
       return now++;
     });
 

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -75,7 +75,7 @@ describe('ReactTestUtils', function() {
   });
 
   it('should have shallow unmounting', function() {
-    var componentWillUnmount = mocks.getMockFunction();
+    var componentWillUnmount = jest.genMockFn();
 
     var SomeComponent = React.createClass({
       render: function() {

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -16,13 +16,9 @@ var ReactDOM;
 var ReactDOMServer;
 var ReactTestUtils;
 
-var mocks;
-
 describe('ReactTestUtils', function() {
 
   beforeEach(function() {
-    mocks = require('mocks');
-
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactDOMServer = require('ReactDOMServer');


### PR DESCRIPTION
I'm removing some old and deprecated APIs from jest that should have never made it into any of our open source libraries because these APIs were deprecated from the start and only persisted because we didn't have tools like jscodeshift when jest was originally created.

In a future version (likely 0.7.0) jest will not support the `mocks` or `mock-modules` modules. This pull request:

* Updates jest to 0.6.1
* Updates deprecated API usage through a codemod, see http://astexplorer.net/#/zrybZ6UvRA and https://github.com/cpojer/js-codemod/blob/master/transforms/jest-update.js
* Created two mock modules because `getMetadata` and `generateFromMetadata` will be fully removed from jest's "public" API. They are implicit APIs that only work through the module boundary. The replacement is `genMockFromModule`.

The last of these changes is probably slightly controversial because it creates two mock files. Across all internal tests at FB `getMetadata` and `generateFromMetadata` is used less than 10 times but those use cases may be valid. I'm considering to add an API like `jest.mockClass(MyClass)`, however currently I'm focused on reducing the surface area of jest to be able to rewrite the module loader and resolver. I'd prefer to move forward with this PR and then move the test components back into the tests when a new API in jest is available iff it proves necessary.
