### PR TITLE
Fix for 'grunt lint' on Windows

### DIFF
--- a/grunt/tasks/eslint.js
+++ b/grunt/tasks/eslint.js
@@ -2,10 +2,12 @@
 
 var grunt = require('grunt');
 
+var extension = process.platform === 'win32' ? '.cmd': '';
+
 module.exports = function() {
   var done = this.async();
   grunt.util.spawn({
-    cmd: 'node_modules/.bin/eslint',
+    cmd: 'node_modules/.bin/eslint' + extension,
     args: ['.'],
     opts: {stdio: 'inherit'}, // allows colors to passthrough
   }, function(err, result, code) {


### PR DESCRIPTION
`grunt.util.spawn` requires the `.cmd` file extension to run the local copy of `eslint` on Windows. Otherwise, it throws an `ENOENT` error.