### PR TITLE
Use a getter for canDefineProperty check.

### DIFF
--- a/src/shared/utils/canDefineProperty.js
+++ b/src/shared/utils/canDefineProperty.js
@@ -14,7 +14,7 @@
 var canDefineProperty = false;
 if (__DEV__) {
   try {
-    Object.defineProperty({}, 'x', {});
+    Object.defineProperty({}, 'x', {get: function() {}});
     canDefineProperty = true;
   } catch (x) {
     // IE will fail on defineProperty


### PR DESCRIPTION
This ensures that we treat es5-sham as a broken implementation of defineProperty and we won't try to use it.

Fixes #5323