### PR TITLE
Fix and test for <input> rerendering issue (and tentative fix for related <textarea> issue)

### DIFF
--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
@@ -128,6 +128,46 @@ describe('ReactDOMInput', function() {
     expect(node.value).toEqual('foobar');
   });
 
+  it('should not rerender when another DOM element is updated', function() {
+    var ReactDefaultPerf = require('ReactDefaultPerf');
+    var ReactDefaultPerfAnalysis = require('ReactDefaultPerfAnalysis');
+
+    var RerenderTest = React.createClass({
+      render: function() {
+        return (
+          <div>
+            <p>{this.props.paragraphContents}</p>
+            <input type="text" value="foo" onChange={emptyFunction} />
+          </div>
+        );
+      },
+    });
+
+    var container = document.createElement('div');
+
+    ReactDOM.render(
+      <RerenderTest paragraphContents="giraffe" />,
+      container
+    );
+
+    ReactDefaultPerf.start();
+    ReactDOM.render(
+      <RerenderTest paragraphContents="gorilla" />,
+      container
+    );
+    ReactDefaultPerf.stop();
+
+    var measurements = ReactDefaultPerf.getLastMeasurements();
+    var summary = ReactDefaultPerfAnalysis.getDOMSummary(measurements);
+
+    expect(summary.length).toBe(1);
+
+    var summaryObj = summary[0];
+
+    expect(summaryObj.id).toBe('.0.0');
+    expect(summaryObj.type).toBe('set textContent');
+  });
+
   it('should properly control a value of number `0`', function() {
     var stub = <input type="text" value={0} onChange={emptyFunction} />;
     stub = ReactTestUtils.renderIntoDocument(stub);

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMTextarea-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMTextarea-test.js
@@ -164,6 +164,46 @@ describe('ReactDOMTextarea', function() {
     expect(node.value).toEqual('foo');
   });
 
+  it('should not rerender when another DOM element is updated', function() {
+    var ReactDefaultPerf = require('ReactDefaultPerf');
+    var ReactDefaultPerfAnalysis = require('ReactDefaultPerfAnalysis');
+
+    var RerenderTest = React.createClass({
+      render: function() {
+        return (
+          <div>
+            <p>{this.props.paragraphContents}</p>
+            <textarea value="foo" onChange={emptyFunction} />
+          </div>
+        );
+      },
+    });
+
+    var container = document.createElement('div');
+
+    ReactDOM.render(
+      <RerenderTest paragraphContents="giraffe" />,
+      container
+    );
+
+    ReactDefaultPerf.start();
+    ReactDOM.render(
+      <RerenderTest paragraphContents="gorilla" />,
+      container
+    );
+    ReactDefaultPerf.stop();
+
+    var measurements = ReactDefaultPerf.getLastMeasurements();
+    var summary = ReactDefaultPerfAnalysis.getDOMSummary(measurements);
+
+    expect(summary.length).toBe(1);
+
+    var summaryObj = summary[0];
+
+    expect(summaryObj.id).toBe('.a.0');
+    expect(summaryObj.type).toBe('set textContent');
+  });
+
   it('should properly control a value of number `0`', function() {
     var stub = <textarea value={0} onChange={emptyFunction} />;
     stub = renderTextarea(stub);

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -888,7 +888,9 @@ ReactDOMComponent.Mixin = {
         nextProps = ReactDOMSelect.getNativeProps(this, nextProps);
         break;
       case 'textarea':
-        ReactDOMTextarea.updateWrapper(this);
+        if (lastProps.value !== nextProps.value) {
+          ReactDOMTextarea.updateWrapper(this);
+        }
         lastProps = ReactDOMTextarea.getNativeProps(this, lastProps);
         nextProps = ReactDOMTextarea.getNativeProps(this, nextProps);
         break;

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -876,7 +876,6 @@ ReactDOMComponent.Mixin = {
         nextProps = ReactDOMButton.getNativeProps(this, nextProps);
         break;
       case 'input':
-        ReactDOMInput.updateWrapper(this);
         lastProps = ReactDOMInput.getNativeProps(this, lastProps);
         nextProps = ReactDOMInput.getNativeProps(this, nextProps);
         break;


### PR DESCRIPTION
This is a fix for #5295.

`<input>` and `<textarea>` elements are being updated in the DOM every time that `ReactDOMComponent.updateComponent` is called. This PR makes it so that the elements are only updated in the DOM when their values change. I also added tests to make sure that this is the case.

I am not sure about the `<textarea>` fix - it doesn't seem like the right place to be checking if the value has been updated. However, `ReactDOMTextarea.getNativeProps` sets `props.value` to `undefined`, so it isn't possible to compare the previous and next props after that.