### PR TITLE
Fix shallow renderer with ref as function

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -396,6 +396,9 @@ NoopInternalComponent.prototype = {
   unmountComponent: function() {
   },
 
+  getPublicInstance: function() {
+    return null;
+  },
 };
 
 var ShallowComponentWrapper = function() { };

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -191,6 +191,31 @@ describe('ReactTestUtils', function() {
     expect(result).toEqual(<div />);
   });
 
+  it('can shallowly render components with ref as function', function() {
+    var SimpleComponent = React.createClass({
+      getInitialState: function() {
+        return {clicked: false};
+      },
+      handleUserClick: function() {
+        this.setState({ clicked: true });
+      },
+      render: function() {
+        return <div ref={() => {}} onClick={this.handleUserClick} className={this.state.clicked ? 'clicked' : ''}></div>;
+      },
+    });
+
+    var shallowRenderer = ReactTestUtils.createRenderer();
+    shallowRenderer.render(<SimpleComponent />);
+    var result = shallowRenderer.getRenderOutput();
+    expect(result.type).toEqual('div');
+    expect(result.props.className).toEqual('');
+    result.props.onClick();
+
+    result = shallowRenderer.getRenderOutput();
+    expect(result.type).toEqual('div');
+    expect(result.props.className).toEqual('clicked');
+  });
+
   it('can pass context when shallowly rendering', function() {
     var SimpleComponent = React.createClass({
       contextTypes: {


### PR DESCRIPTION
I noticed, that I am getting `component.getPublicInstance is not a function` error while testing component rerendering, where i render `div` with ref as function. Someone just forget `getPublicInstance` in `NoopInternalComponent`. This is easy quick fix with test coverage.

Please merge it ASAP, because it is blocking my work.