### PR TITLE
Fix for TypeScript test on Windows

### DIFF
--- a/scripts/jest/ts-preprocessor.js
+++ b/scripts/jest/ts-preprocessor.js
@@ -19,7 +19,16 @@ function compile(content, contentFilename) {
   var output = null;
   var compilerHost = {
     getSourceFile: function(filename, languageVersion) {
-      var source;
+      var source, reactRegex;
+
+      // Accomodations for backslashes in Windows file paths.
+      if (process.platform === 'win32') {
+        filename = filename.replace(/\//g, '\\');
+        reactRegex = /\\(?:React|ReactDOM)(?:\.d)?\.ts$/;
+      } else {
+        reactRegex = /\/(?:React|ReactDOM)(?:\.d)?\.ts$/;
+      }
+
       if (filename === 'lib.d.ts') {
         source = fs.readFileSync(
           require.resolve('typescript/bin/lib.d.ts')
@@ -30,7 +39,7 @@ function compile(content, contentFilename) {
         ).toString();
       } else if (filename === contentFilename) {
         source = content;
-      } else if (/\/(?:React|ReactDOM)(?:\.d)?\.ts$/.test(filename)) {
+      } else if (reactRegex.test(filename)) {
         // TypeScript will look for the .d.ts files in each ancestor directory,
         // so there may not be a file at the referenced path as it climbs the
         // hierarchy.

--- a/scripts/jest/ts-preprocessor.js
+++ b/scripts/jest/ts-preprocessor.js
@@ -19,15 +19,14 @@ function compile(content, contentFilename) {
   var output = null;
   var compilerHost = {
     getSourceFile: function(filename, languageVersion) {
-      var source, reactRegex;
+      var source;
 
-      // Accomodations for backslashes in Windows file paths.
-      if (process.platform === 'win32') {
-        filename = filename.replace(/\//g, '\\');
-        reactRegex = /\\(?:React|ReactDOM)(?:\.d)?\.ts$/;
-      } else {
-        reactRegex = /\/(?:React|ReactDOM)(?:\.d)?\.ts$/;
-      }
+      // `path.normalize` and `path.join` are used to turn forward slashes in
+      // the file path into backslashes on Windows.
+      filename = path.normalize(filename);
+      var reactRegex = new RegExp(
+        path.join('/', '(?:React|ReactDOM)(?:\.d)?\.ts$')
+      );
 
       if (filename === 'lib.d.ts') {
         source = fs.readFileSync(


### PR DESCRIPTION
The tests `ReactTypeScriptClass` and `ReactClassEquivalence` fail on Windows because of file paths using backslashes. This PR fixes the problem.