### PR TITLE
Revert "Overwriting of mutated props in constructor"

### DIFF
--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -199,7 +199,7 @@ var ReactCompositeComponentMixin = {
 
     // These should be set up in the constructor, but as a convenience for
     // simpler class abstractions, we set them up after the fact.
-    inst.props = inst.props || publicProps;
+    inst.props = publicProps;
     inst.context = publicContext;
     inst.refs = emptyObject;
     inst.updater = ReactUpdateQueue;

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -1241,39 +1241,4 @@ describe('ReactCompositeComponent', function() {
 
   });
 
-  it('should not overwrite mutated properties', function() {
-    class Moo extends React.Component {
-      render() {
-        return <span />;
-      }
-    }
-    Moo.defaultProps = { idx: 'moo' };
-
-    function Foo(props) {
-      var _props = { idx: this.constructor.defaultProps.idx + '?' };
-
-      React.Component.call(this, _props);
-    }
-    Foo.prototype = Object.create(React.Component.prototype, {
-      constructor: {
-        value: Foo,
-      },
-    });
-    Foo.prototype.render = function() {
-      return <span />;
-    };
-    Foo.defaultProps = { idx: 'foo' };
-
-    class Bar extends Foo {}
-    Bar.defaultProps = { idx: 'bar' };
-
-    var moo = ReactTestUtils.renderIntoDocument(<Moo />);
-    expect(moo.props.idx).toBe('moo');
-
-    var foo = ReactTestUtils.renderIntoDocument(<Foo />);
-    expect(foo.props.idx).toBe('foo?');
-
-    var bar = ReactTestUtils.renderIntoDocument(<Bar />);
-    expect(bar.props.idx).toBe('bar?');
-  });
 });


### PR DESCRIPTION
Reverts facebook/react#5320

I'm not sure this should be a supported pattern because it doesn't work for updates, only the initial value.