### PR TITLE
fix shallowRenderer.getRenderOutput() return type in docs

### DIFF
--- a/docs/docs/10.4-test-utils.md
+++ b/docs/docs/10.4-test-utils.md
@@ -217,7 +217,7 @@ shallowRenderer.render(
 Similar to `ReactDOM.render`.
 
 ```javascript
-ReactComponent shallowRenderer.getRenderOutput()
+ReactElement shallowRenderer.getRenderOutput()
 ```
 
 After `render` has been called, returns shallowly rendered output. You can then begin to assert facts about the output. For example, if your component's render method returns:


### PR DESCRIPTION
As far as I understand `shallowRenderer.getRenderOutput()` returns an Element, not Component. At least when I try to run following, I get `findAllInRenderedTree(...): instance must be a composite component` although types seem to match.

```js
const renderer = createRenderer()
renderer.render(<Comp />)
const tree = renderer.getRenderOutput()
findAllInRenderedTree(tree, fn)
```