### PR TITLE
Elements at root, makes for smooth components

### DIFF
--- a/src/isomorphic/ReactIsomorphic.js
+++ b/src/isomorphic/ReactIsomorphic.js
@@ -61,9 +61,9 @@ var React = {
     return mixin;
   },
 
-  // This looks DOM specific but these are actually isomorphic helpers
+  // These are actually isomorphic helpers
   // since they are just generating DOM strings.
-  DOM: ReactDOMFactories,
+  ...ReactDOMFactories,
 
   version: ReactVersion,
 


### PR DESCRIPTION
So I'm new to react, but I've very much been enjoying the new functional export way. It lets me write things like this:

``` javascript
import { DOM } from "react"
import users from "./users"

let { main } = DOM

export default (props) => main({}, users)
```

Except I found out how to eliminate the `let`:

``` javascript
import { main } from "react/lib/ReactDOMFactories"
import users from "./users"

export default (props) => main({}, users)
```

The problem is that this heavily depends on `lib/ReactDOMFactories` existing and wasn't easy to discover (due to the difference between what's in source and what's delivered to NPM).

Realistically I can't expect the change I'm suggesting (it may not even work as I expect, like I said I'm new to React/ES6), but it's something I'd like to have:

``` javascript
import { main } from "react"
```

Or failing that I'd like to know what I need to do to make this happen:

``` javascript
import { main } from "react-element"
```

Thoughts?