### PR TITLE
Update "Getting Started" docs: Install babel CLI from `babel-cli`.

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -94,7 +94,7 @@ Note that some browsers (Chrome, e.g.) will fail to load the file unless it's se
 First install the [Babel](http://babeljs.io/) command-line tools (requires [npm](https://www.npmjs.com/)):
 
 ```
-npm install --global babel
+npm install --global babel-cli
 ```
 
 Then, translate your `src/helloworld.js` file to plain JavaScript:


### PR DESCRIPTION
The `babel` CLI has been moved to the `babel-cli` package: https://babeljs.io/docs/usage/cli/