### PR TITLE
Make React a peerDep of react-dom

### DIFF
--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/facebook/react/issues"
   },
   "homepage": "https://github.com/facebook/react/tree/master/npm-react-dom",
-  "dependencies": {
+  "peerDependencies": {
     "react": "^0.15.0-alpha"
   }
 }


### PR DESCRIPTION
I think this is probably the right thing to do to avoid even more dependency hell. There's basically no point where you're using ReactDOM that you don't also need React. While we reach deeply, we should make sure there's only 1 version. This matches what we already do for the addons packages.

fixes #5282