### PR TITLE
adler32: Properly break loop into 4096-char blocks

### DIFF
--- a/src/shared/utils/adler32.js
+++ b/src/shared/utils/adler32.js
@@ -25,7 +25,8 @@ function adler32(data) {
   var l = data.length;
   var m = l & ~0x3;
   while (i < m) {
-    for (; i < Math.min(i + 4096, m); i += 4) {
+    var n = Math.min(i + 4096, m);
+    for (; i < n; i += 4) {
       b += (
         (a += data.charCodeAt(i)) +
         (a += data.charCodeAt(i + 1)) +


### PR DESCRIPTION
I believe this was lost in translation in #4400. Can't say I fully understand why this is significant at all though...