### PR TITLE
Add additional secret property to build artifact for react-dom-server

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -13,3 +13,4 @@ examples/
 build/
 scripts/bench/bench-*.js
 vendor/react-dom.js
+vendor/react-dom-server.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,8 @@ script:
           -F "react-with-addons.min=@build/react-with-addons.min.js" \
           -F "react-dom=@build/react-dom.js" \
           -F "react-dom.min=@build/react-dom.min.js" \
+          -F "react-dom-server=@build/react-dom-server.js"
+          -F "react-dom-server.min=@build/react-dom-server.min.js"
           -F "npm-react=@build/packages/react.tgz" \
           -F "npm-react-dom=@build/packages/react-dom.tgz" \
           -F "commit=$TRAVIS_COMMIT" \

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -112,6 +112,7 @@ module.exports = function(grunt) {
     'npm-react:release',
   ]);
   grunt.registerTask('build:react-dom', require('./grunt/tasks/react-dom'));
+  grunt.registerTask('build:react-dom-server', require('./grunt/tasks/react-dom-server'));
 
   grunt.registerTask('test', ['jest']);
   grunt.registerTask('npm:test', ['build', 'npm:pack']);
@@ -129,6 +130,7 @@ module.exports = function(grunt) {
     'browserify:min',
     'browserify:addonsMin',
     'build:react-dom',
+    'build:react-dom-server',
     'npm-react:release',
     'npm-react:pack',
     'npm-react-dom:release',

--- a/grunt/tasks/react-dom-server.js
+++ b/grunt/tasks/react-dom-server.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var grunt = require('grunt');
+var UglifyJS = require('uglify-js');
+
+var LICENSE_TEMPLATE =
+  grunt.file.read('./grunt/data/header-template-extended.txt');
+
+module.exports = function() {
+  var templateData = {
+    package: 'ReactDOMServer',
+    version: grunt.config.data.pkg.version,
+  };
+  var header = grunt.template.process(
+    LICENSE_TEMPLATE,
+    {data: templateData}
+  );
+  var src = grunt.file.read('vendor/react-dom-server.js');
+  grunt.file.write(
+    'build/react-dom-server.js',
+    header + src
+  );
+  grunt.file.write(
+    'build/react-dom-server.min.js',
+    header + UglifyJS.minify(src, {fromString: true}).code
+  );
+};

--- a/src/React.js
+++ b/src/React.js
@@ -65,5 +65,6 @@ assign(React, {
 });
 
 React.__SECRET_DOM_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = ReactDOM;
+React.__SECRET_DOM_SERVER_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = ReactDOMServer;
 
 module.exports = React;

--- a/vendor/react-dom-server.js
+++ b/vendor/react-dom-server.js
@@ -1,0 +1,31 @@
+// Based off https://github.com/ForbesLindesay/umd/blob/master/template.js
+;(function(f) {
+  // CommonJS
+  if (typeof exports === "object" && typeof module !== "undefined") {
+    module.exports = f(require('react'));
+
+  // RequireJS
+  } else if (typeof define === "function" && define.amd) {
+    define(['react'], f);
+
+  // <script>
+  } else {
+    var g
+    if (typeof window !== "undefined") {
+      g = window;
+    } else if (typeof global !== "undefined") {
+      g = global;
+    } else if (typeof self !== "undefined") {
+      g = self;
+    } else {
+      // works providing we're not in "use strict";
+      // needed for Java 8 Nashorn
+      // see https://github.com/facebook/react/issues/3037
+      g = this;
+    }
+    g.ReactDOM = f(g.React);
+  }
+
+})(function(React) {
+  return React.__SECRET_DOM_SERVER_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+});


### PR DESCRIPTION
Related https://github.com/facebook/react/issues/5134 and https://github.com/facebook/react/issues/5311.

In upgrading to React 0.14.2 today, I found that methods for rendering static markup aren't available as UMD artifacts anymore.  We've been using this for HTML rendering in the browser in a handful of places where we're doing interop with other libraries and need plain HTML as part of an existing API.  With React's awesome release process, this is only a warning for now.

I read around a bit but couldn't quite tell what the direction folks wanted to go with the build setup here.  In my poking around I just made this PR as a workaround, adding another secret property to expose `ReactDOMServer`, and a build step to produce this a UMD artifact in the same way that `react-dom` is built in https://github.com/facebook/react/pull/4814.    This PR likely won't be useful, and closing it right away makes sense to me, but if anyone else needs a one-off build for this I figured it's worth posting.

Longer term, I'd second the idea that this rendering code has uses beyond just server rendering, and that it may be worth including in `ReactDOM` as @jimfb suggested in https://github.com/facebook/react/issues/5311#issuecomment-152010489.