### PR TITLE
Add validation for arrayOf and objectOf in ReactPropTypes

### DIFF
--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -146,7 +146,7 @@ function createArrayOfTypeChecker(typeChecker) {
   function validate(props, propName, componentName, location, propFullName) {
     if (typeof typeChecker !== 'function') {
       return new Error(
-        `Invalid argument \`${propFullName}\` supplied to \`${componentName}\`, expected valid PropType.`
+        `Property \`${propFullName}\` of component \`${componentName}\` has invalid PropType notation inside arrayOf.`
       );
     }
     var propValue = props[propName];
@@ -237,7 +237,7 @@ function createObjectOfTypeChecker(typeChecker) {
   function validate(props, propName, componentName, location, propFullName) {
     if (typeof typeChecker !== 'function') {
       return new Error(
-        `Invalid argument \`${propFullName}\` supplied to \`${componentName}\`, expected valid PropType.`
+        `Property \`${propFullName}\` of component \`${componentName}\` has invalid PropType notation inside objectOf.`
       );
     }
     var propValue = props[propName];

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -144,6 +144,11 @@ function createAnyTypeChecker() {
 
 function createArrayOfTypeChecker(typeChecker) {
   function validate(props, propName, componentName, location, propFullName) {
+    if (typeof typeChecker !== 'function') {
+      return new Error(
+        `Invalid argument \`${propFullName}\` supplied to \`${componentName}\`, expected valid PropType.`
+      );
+    }
     var propValue = props[propName];
     if (!Array.isArray(propValue)) {
       var locationName = ReactPropTypeLocationNames[location];
@@ -230,6 +235,11 @@ function createEnumTypeChecker(expectedValues) {
 
 function createObjectOfTypeChecker(typeChecker) {
   function validate(props, propName, componentName, location, propFullName) {
+    if (typeof typeChecker !== 'function') {
+      return new Error(
+        `Invalid argument \`${propFullName}\` supplied to \`${componentName}\`, expected valid PropType.`
+      );
+    }
     var propValue = props[propName];
     var propType = getPropType(propValue);
     if (propType !== 'object') {

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -142,7 +142,7 @@ describe('ReactPropTypes', function() {
       typeCheckFail(
         PropTypes.arrayOf({ foo: PropTypes.string }),
         { foo: 'bar' },
-        'Invalid argument `testProp` supplied to `testComponent`, expected valid PropType.'
+        'Property `testProp` of component `testComponent` has invalid PropType notation inside arrayOf.'
       );
     });
 
@@ -473,7 +473,7 @@ describe('ReactPropTypes', function() {
       typeCheckFail(
         PropTypes.objectOf({ foo: PropTypes.string }),
         { foo: 'bar' },
-        'Invalid argument `testProp` supplied to `testComponent`, expected valid PropType.'
+        'Property `testProp` of component `testComponent` has invalid PropType notation inside objectOf.'
       );
     });
 

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -138,6 +138,14 @@ describe('ReactPropTypes', function() {
   });
 
   describe('ArrayOf Type', function() {
+    it('should fail for invalid argument', function() {
+      typeCheckFail(
+        PropTypes.arrayOf({ foo: PropTypes.string }),
+        { foo: 'bar' },
+        'Invalid argument `testProp` supplied to `testComponent`, expected valid PropType.'
+      );
+    });
+
     it('should support the arrayOf propTypes', function() {
       typeCheckPass(PropTypes.arrayOf(PropTypes.number), [1, 2, 3]);
       typeCheckPass(PropTypes.arrayOf(PropTypes.string), ['a', 'b', 'c']);
@@ -461,6 +469,14 @@ describe('ReactPropTypes', function() {
   });
 
   describe('ObjectOf Type', function() {
+    it('should fail for invalid argument', function() {
+      typeCheckFail(
+        PropTypes.objectOf({ foo: PropTypes.string }),
+        { foo: 'bar' },
+        'Invalid argument `testProp` supplied to `testComponent`, expected valid PropType.'
+      );
+    });
+
     it('should support the objectOf propTypes', function() {
       typeCheckPass(PropTypes.objectOf(PropTypes.number), {a: 1, b: 2, c: 3});
       typeCheckPass(


### PR DESCRIPTION
```javascript
  static propTypes = {
    instrument: PropTypes.object.isRequired,
    data: PropTypes.arrayOf({
      timestamp: PropTypes.object.isRequired,
      value: PropTypes.number.isRequired,
    }).isRequired,
    height: PropTypes.number.isRequired,
    width: PropTypes.number.isRequired,
  };
```
Notice data property. it should look like
```javascript
    data: PropTypes.arrayOf(PropTypes.shape({
      timestamp: PropTypes.object.isRequired,
      value: PropTypes.number.isRequired,
    })).isRequired,
```
instead.

This is one of common mistakes. But error message is very cryptic:
`Warning: Failed propType: typeChecker is not a function Check the render method of 'ChartPanel'.`

So I wrote some tests and pretty error messages.

now error looks like this
`Warning: Failed propType: Invalid prop 'data' supplied to 'ChartContainer', expected valid PropType. Check the render method of 'ChartPanel'.`


This is kind of same as #3963 but for arrayOf and objectOf proptypes