### PR TITLE
Revert #4993 with an added test for refs

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -431,7 +431,7 @@ ReactShallowRenderer.prototype.render = function(element, context) {
     context = emptyObject;
   }
   var transaction = ReactUpdates.ReactReconcileTransaction.getPooled(true);
-  transaction.perform(this._render, this, element, transaction, context);
+  this._render(element, transaction, context);
   ReactUpdates.ReactReconcileTransaction.release(transaction);
 };
 

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -87,46 +87,6 @@ describe('ReactTestUtils', function() {
     expect(componentWillUnmount).toBeCalled();
   });
 
-  it('should run all lifecycle methods', function() {
-    var componentWillMount = jest.genMockFn();
-    var componentDidMount = jest.genMockFn();
-    var componentWillReceiveProps = jest.genMockFn();
-    var shouldComponentUpdate = jest.genMockFn();
-    var componentWillUpdate = jest.genMockFn();
-    var componentDidUpdate = jest.genMockFn();
-    var componentWillUnmount = jest.genMockFn();
-
-    var SomeComponent = React.createClass({
-      render: function() {
-        return <SomeComponent onChange={() => this.setState({a: 1})} />;
-      },
-      componentWillMount,
-      componentDidMount,
-      componentWillReceiveProps,
-      shouldComponentUpdate() {
-        shouldComponentUpdate();
-        return true;
-      },
-      componentWillUpdate,
-      componentDidUpdate,
-      componentWillUnmount,
-    });
-
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    shallowRenderer.render(<SomeComponent />);
-    shallowRenderer.getRenderOutput().props.onChange();
-    shallowRenderer.render(<SomeComponent />);
-    shallowRenderer.unmount();
-
-    expect(componentWillMount).toBeCalled();
-    expect(componentDidMount).toBeCalled();
-    expect(componentWillReceiveProps).toBeCalled();
-    expect(shouldComponentUpdate).toBeCalled();
-    expect(componentWillUpdate).toBeCalled();
-    expect(componentDidUpdate).toBeCalled();
-    expect(componentWillUnmount).toBeCalled();
-  });
-
   it('can shallow render to null', function() {
     var SomeComponent = React.createClass({
       render: function() {
@@ -140,6 +100,18 @@ describe('ReactTestUtils', function() {
     var result = shallowRenderer.getRenderOutput();
 
     expect(result).toBe(null);
+  });
+
+  it('can shallow render with a ref', function() {
+    var SomeComponent = React.createClass({
+      render: function() {
+        return <div ref="hello" />;
+      },
+    });
+
+    var shallowRenderer = ReactTestUtils.createRenderer();
+    // Shouldn't crash.
+    shallowRenderer.render(<SomeComponent />);
   });
 
   it('lets you update shallowly rendered components', function() {


### PR DESCRIPTION
We were shallow-rendering a component that used refs at FB so this can't go in as-is. It's a little unclear what we _should_ do though, since there is nothing to hold a ref to (since we're shallowly rendering) and we generally promise that child refs are resolved before a parent's componentDidMount. Also, changing shallow rendering to use the original `_renderValidatedComponent` (instead of `_renderValidatedComponentWithoutOwnerOrContext`) breaks tests because now the `_owner` field doesn't match up for `toEqual` (non-null in `getRenderOutput` but null if constructed in a test).