### PR TITLE
Improve npm packages' metadata

### DIFF
--- a/grunt/tasks/npm-react-addons.js
+++ b/grunt/tasks/npm-react-addons.js
@@ -9,35 +9,43 @@ var addons = {
   CSSTransitionGroup: {
     module: 'ReactCSSTransitionGroup',
     name: 'css-transition-group',
+    docs: 'animation',
   },
   LinkedStateMixin: {
     module: 'LinkedStateMixin',
     name: 'linked-state-mixin',
+    docs: 'two-way-binding-helpers',
   },
   Perf: {
     module: 'ReactDefaultPerf',
     name: 'perf',
+    docs: 'perf',
   },
   PureRenderMixin: {
     module: 'ReactComponentWithPureRenderMixin',
     name: 'pure-render-mixin',
+    docs: 'pure-render-mixin',
   },
   TestUtils: {
     module: 'ReactTestUtils',
     name: 'test-utils',
+    docs: 'test-utils',
   },
   TransitionGroup: {
     module: 'ReactTransitionGroup',
     name: 'transition-group',
+    docs: 'animation',
   },
   cloneWithProps: {
     module: 'cloneWithProps',
     name: 'clone-with-props',
+    docs: 'clone-with-props',
   },
   createFragment: {
     module: 'ReactFragment',
     method: 'create',
     name: 'create-fragment',
+    docs: 'create-fragment',
   },
   shallowCompare: {
     module: 'shallowCompare',
@@ -46,6 +54,7 @@ var addons = {
   updates: {
     module: 'update',
     name: 'update',
+    docs: 'update',
   },
 };
 
@@ -76,15 +85,20 @@ function buildReleases() {
     pkgData.name = pkgName;
 
     grunt.file.mkdir(destDir);
+    var link = info.docs ? info.docs : 'addons';
+    link = `https://facebook.github.io/react/docs/${link}.html`;
     fs.writeFileSync(path.join(destDir, 'index.js'), generateSource(info));
     fs.writeFileSync(path.join(destDir, 'package.json'), JSON.stringify(pkgData, null, 2));
     fs.writeFileSync(path.join(destDir, 'LICENSE'), license);
     fs.writeFileSync(path.join(destDir, 'PATENTS'), patents);
     fs.writeFileSync(
       path.join(destDir, 'README.md'),
-      '# ' + pkgName + '\n\n' +
-      'This package provides the React ' + k + ' add-on. See ' +
-      'http://facebook.github.io/react/docs/addons.html for more information.\n'
+      `
+# ${pkgName}
+
+This package provides the React ${k} add-on.
+
+See <${link}> for more information.`.slice(1)
     );
   });
 

--- a/packages/react-addons/package.json
+++ b/packages/react-addons/package.json
@@ -1,7 +1,12 @@
 {
-  "name": "react-addons",
+  "name": "react-addons-template",
   "version": "0.15.0-alpha",
   "main": "index.js",
+  "repository": "facebook/react",
+  "keywords": [
+    "react",
+    "react-addon"
+  ],
   "license": "BSD-3-Clause",
   "peerDependencies": {
     "react": "^0.15.0-alpha"

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -3,10 +3,7 @@
   "version": "0.15.0-alpha",
   "description": "React package for working with the DOM.",
   "main": "index.js",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/facebook/react.git"
-  },
+  "repository": "facebook/react",
   "keywords": [
     "react"
   ],


### PR DESCRIPTION
fixes #5388

But also makes the readmes for the addons packages better. npm pulls the first paragraph as a subheader which looks like shit.

<img width="729" alt="screen shot 2015-11-04 at 5 34 15 pm" src="https://github-cloud.s3.amazonaws.com/assets%2F8445%2F10957557%2F537c6c62-831a-11e5-830f-39bf293a40c4.png">

This moves the link sentence to a standalone line so it shouldn't be part of that text and also gives each addon a link to its actual docs (except for shallowCompare which doesn't have docs… see #5378)