### PR TITLE
Clarify note about stable keys

### DIFF
--- a/docs/docs/ref-08-reconciliation.md
+++ b/docs/docs/ref-08-reconciliation.md
@@ -129,5 +129,5 @@ Because we rely on two heuristics, if the assumptions behind them are not met, p
 
 1. The algorithm will not try to match sub-trees of different components classes. If you see yourself alternating between two components classes with very similar output, you may want to make it the same class. In practice, we haven't found this to be an issue.
 
-2. If you don't provide stable keys (by using Math.random() for example), all the sub-trees are going to be re-rendered every single time. By giving the users the choice to choose the key, they have the ability to shoot themselves in the foot.
+2. Keys should be stable, predictable, and unique. Unstable keys (like those produced by Math.random()) will cause many nodes to be unnecessarily re-created, which can cause performance degradation and lost state in child components.
 


### PR DESCRIPTION
Hello,

I've been reading [docs](https://facebook.github.io/react/docs/reconciliation.html) that say

> If you don't provide stable keys (by using Math.random() for example), all the sub-trees are going to be re-rendered every single time. By giving the users the choice to choose the key, they have the ability to shoot themselves in the foot.

and then I see this [comment](https://github.com/facebook/react/issues/1342#issuecomment-39230939) on some issue that says

> We made this mistake in one of our examples for a while and it's just really bad. By doing this, you'll actually end up recreating all of your nodes on every render because the key will be different.

Please let me know if it makes sense to remove this piece of doc from the site.

Thank you
