### PR TITLE
Updates the warning that is displayed when `setState` is called within either `render` or a component constructor.

### DIFF
--- a/src/renderers/shared/reconciler/ReactUpdateQueue.js
+++ b/src/renderers/shared/reconciler/ReactUpdateQueue.js
@@ -47,9 +47,11 @@ function getInternalInstanceReadyForUpdate(publicInstance, callerName) {
   if (__DEV__) {
     warning(
       ReactCurrentOwner.current == null,
-      '%s(...): Cannot update during an existing state transition ' +
-      '(such as within `render`). Render methods should be a pure function ' +
-      'of props and state.',
+      '%s(...): Cannot update during an existing state transition (such as ' +
+      'within `render` or another component\'s constructor). Render methods ' +
+      'should be a pure function of props and state; constructor ' +
+      'side-effects are an anti-pattern, but can be moved to ' +
+      '`componentWillMount`.',
       callerName
     );
   }

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -381,8 +381,10 @@ describe('ReactCompositeComponent', function() {
     expect(console.error.calls.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toBe(
       'Warning: setState(...): Cannot update during an existing state ' +
-      'transition (such as within `render`). Render methods should be a pure ' +
-      'function of props and state.'
+      'transition (such as within `render` or another component\'s ' +
+      'constructor). Render methods should be a pure function of props and ' +
+      'state; constructor side-effects are an anti-pattern, but can be moved ' +
+      'to `componentWillMount`.'
     );
 
     // The setState call is queued and then executed as a second pass. This


### PR DESCRIPTION
Follow up to https://github.com/facebook/react/pull/5343#issuecomment-154153739