### PR TITLE
Remove need for wrapper node with ReactTransitionGroup

### DIFF
--- a/docs/docs/10.1-animation.md
+++ b/docs/docs/10.1-animation.md
@@ -200,6 +200,16 @@ You can disable animating `enter` or `leave` animations if you want. For example
 >
 > When using `ReactCSSTransitionGroup`, there's no way for your components to be notified when a transition has ended or to perform any more complex logic around animation. If you want more fine-grained control, you can use the lower-level `ReactTransitionGroup` API which provides the hooks you need to do custom transitions.
 
+### Rendering a Different Component
+
+By default `ReactCSSTransitionGroup` renders as a `span`. You can change this behavior by providing a `component` prop. For example, here's how you would render a `<ul>`:
+
+```javascript{1}
+<ReactCSSTransitionGroup component="ul">
+  ...
+</ReactCSSTransitionGroup>
+```
+
 ## Low-level API: `ReactTransitionGroup`
 
 `ReactTransitionGroup` is the basis for animations. It is accessible from `require('react-addons-transition-group')`. When children are declaratively added or removed from it (as in the example above) special lifecycle hooks are called on them.
@@ -230,10 +240,20 @@ This is called when the `willLeave` `callback` is called (at the same time as `c
 
 ### Rendering a Different Component
 
-By default `ReactTransitionGroup` renders as a `span`. You can change this behavior by providing a `component` prop. For example, here's how you would render a `<ul>`:
+#### Unspecified component prop
+
+If the optional `component` prop is not specified, there are three cases determining how it renders:
+
+- If `ReactTransitionGroup` only contains no children, it renders nothing.
+- If `ReactTransitionGroup` only contains a single child, it renders that child only.
+- If `ReactTransitionGroup` only contains multiple children, it renders as a `span` that wraps its children.
+
+#### Explicitly specified component prop
+
+The optional `component` prop allows you to specify the component that `ReactTransitionGroup` renders as. For example, here's how you would render a `<div>`:
 
 ```javascript{1}
-<ReactTransitionGroup component="ul">
+<ReactTransitionGroup component="div">
   ...
 </ReactTransitionGroup>
 ```

--- a/src/addons/transitions/ReactCSSTransitionGroup.js
+++ b/src/addons/transitions/ReactCSSTransitionGroup.js
@@ -48,7 +48,7 @@ var ReactCSSTransitionGroup = React.createClass({
 
   propTypes: {
     transitionName: ReactCSSTransitionGroupChild.propTypes.name,
-
+    component: React.PropTypes.any,
     transitionAppear: React.PropTypes.bool,
     transitionEnter: React.PropTypes.bool,
     transitionLeave: React.PropTypes.bool,
@@ -59,6 +59,7 @@ var ReactCSSTransitionGroup = React.createClass({
 
   getDefaultProps: function() {
     return {
+      component: 'span',
       transitionAppear: false,
       transitionEnter: true,
       transitionLeave: true,

--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -27,7 +27,6 @@ var ReactTransitionGroup = React.createClass({
 
   getDefaultProps: function() {
     return {
-      component: 'span',
       childFactory: emptyFunction.thatReturnsArgument,
     };
   },
@@ -201,8 +200,6 @@ var ReactTransitionGroup = React.createClass({
   },
 
   render: function() {
-    // TODO: we could get rid of the need for the wrapper node
-    // by cloning a single child
     var childrenToRender = [];
     for (var key in this.state.children) {
       var child = this.state.children[key];
@@ -218,11 +215,15 @@ var ReactTransitionGroup = React.createClass({
         ));
       }
     }
-    return React.createElement(
-      this.props.component,
-      this.props,
-      childrenToRender
-    );
+    if (this.props.component || childrenToRender.length > 1) {
+      return React.createElement(
+        this.props.component || 'span',
+        this.props,
+        childrenToRender
+      );
+    } else {
+      return childrenToRender[0] || null;
+    }
   },
 });
 

--- a/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
@@ -74,7 +74,7 @@ describe('ReactTransitionGroup', function() {
         for (var i = 0; i < this.state.count; i++) {
           children.push(<Child key={i} />);
         }
-        return <ReactTransitionGroup>{children}</ReactTransitionGroup>;
+        return <ReactTransitionGroup component="span">{children}</ReactTransitionGroup>;
       },
     });
 
@@ -131,7 +131,7 @@ describe('ReactTransitionGroup', function() {
         for (var i = 0; i < this.state.count; i++) {
           children.push(<Child key={i} />);
         }
-        return <ReactTransitionGroup>{children}</ReactTransitionGroup>;
+        return <ReactTransitionGroup component="div">{children}</ReactTransitionGroup>;
       },
     });
 
@@ -191,7 +191,7 @@ describe('ReactTransitionGroup', function() {
         for (var i = 0; i < this.state.count; i++) {
           children.push(<Child key={i} />);
         }
-        return <ReactTransitionGroup>{children}</ReactTransitionGroup>;
+        return <ReactTransitionGroup component="span">{children}</ReactTransitionGroup>;
       },
     });
 
@@ -248,7 +248,7 @@ describe('ReactTransitionGroup', function() {
         for (var i = 0; i < this.state.count; i++) {
           children.push(<Child key={i} id={i} />);
         }
-        return <ReactTransitionGroup>{children}</ReactTransitionGroup>;
+        return <ReactTransitionGroup component="span">{children}</ReactTransitionGroup>;
       },
     });
 
@@ -268,5 +268,40 @@ describe('ReactTransitionGroup', function() {
       'willLeave0', 'didLeave0', 'willLeave1', 'didLeave1',
       'willLeave2', 'didLeave2', 'willUnmount0', 'willUnmount1', 'willUnmount2',
     ]);
+  });
+
+  describe('component property not defined', function() {
+    it('should return single child unwrapped', function() {
+      var Component = React.createClass({
+        render: function() {
+          return (
+            <ReactTransitionGroup>
+              <span id="singleChild" />
+            </ReactTransitionGroup>
+          );
+        },
+      });
+
+      var instance = ReactDOM.render(<Component />, container);
+      expect(ReactDOM.findDOMNode(instance).id).toBe('singleChild');
+    });
+
+    it('should return children wrapped in a span', function() {
+      var Component = React.createClass({
+        render: function() {
+          return (
+            <ReactTransitionGroup>
+              <span id="childOne" />
+              <span id="childTwo" />
+            </ReactTransitionGroup>
+          );
+        },
+      });
+
+      var instance = ReactDOM.render(<Component />, container);
+      expect(ReactDOM.findDOMNode(instance).childNodes.length).toBe(2);
+      expect(ReactDOM.findDOMNode(instance).childNodes[0].id).toBe('childOne');
+      expect(ReactDOM.findDOMNode(instance).childNodes[1].id).toBe('childTwo');
+    });
   });
 });


### PR DESCRIPTION
- Allow `ReactCSSTransitionGroup` to take an optional `component` prop
  (defaults to `span`)
- Remove need for wrapper node with `ReactTransitionGroup`.
  - If no children are specified return `null`.
  - If there is one child, return that child without a wrapper node (unless the
    `component` prop was explicitly provided).
  - If there are multiple children, use the provided `component` prop as a
    wrapper node, defaulting to `span` if one was not provided.