### PR TITLE
Support reversed for <ol>s

### DIFF
--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -140,6 +140,7 @@ var HTMLDOMPropertyConfig = {
     readOnly: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
     rel: null,
     required: HAS_BOOLEAN_VALUE,
+    reversed: HAS_BOOLEAN_VALUE,
     role: MUST_USE_ATTRIBUTE,
     rows: MUST_USE_ATTRIBUTE | HAS_POSITIVE_NUMERIC_VALUE,
     rowSpan: MUST_USE_ATTRIBUTE | HAS_NUMERIC_VALUE,


### PR DESCRIPTION
Fixes #5414

test case:
```js
      var idx = 0;
      var states = [false, true, false, null, 0, 'hello', undefined]
      class ExampleApplication extends React.Component {
        constructor() {
          super();
          this.state = {reversed: states[0]};
          this.cycle = this.cycle.bind(this);
        }
        cycle() {
          this.setState({
            reversed: states[++idx % states.length]
          })
        }
        render() {
          return (
            <ol start="5" reversed={this.state.reversed} onClick={this.cycle}>
              <li>hello</li>
              <li>world</li>
              <li>{'' + this.state.reversed}</li>
            </ol>
          );
        }
      }
```

cc @spicyj because you made us use attributes for more things recently and want to sanity check, see what we should add to our test plans for these changes