### PR TITLE
Add warning for putting React prop types inside oneOf.

### DIFF
--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -213,6 +213,15 @@ function createEnumTypeChecker(expectedValues) {
   function validate(props, propName, componentName, location, propFullName) {
     var propValue = props[propName];
     for (var i = 0; i < expectedValues.length; i++) {
+      for (var reactPropKey in ReactPropTypes) {
+        if (expectedValues[i] === ReactPropTypes[reactPropKey]) {
+          return new Error(
+            `\'oneOf\' does not expect React prop types in the supplied ` +
+            `array. Maybe you're looking for \`oneOfType\`?`
+          );
+        }
+      }
+
       if (propValue === expectedValues[i]) {
         return null;
       }


### PR DESCRIPTION
First PR!

Took me a few minutes to figure out I needed `oneOfType` instead. Is this worthy? My reasoning for this was that there isn't much to differentiate between `oneOf` and `oneOfType`, if one or the other wasn't known, as opposed to `number` and `string`.