### PR TITLE
Use callback refs instead of string refs in tutorial

### DIFF
--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -511,8 +511,8 @@ var CommentForm = React.createClass({
   render: function() {
     return (
       <form className="commentForm" onSubmit={this.handleSubmit}>
-        <input type="text" placeholder="Your name" ref={(ref) => this.authorInput = ref} />
-        <input type="text" placeholder="Say something..." ref={(ref) => this.textInput = ref} />
+        <input type="text" placeholder="Your name" ref={(ref) => {this.authorInput = ref}} />
+        <input type="text" placeholder="Say something..." ref={(ref) => {this.textInput = ref}} />
         <input type="submit" value="Post" />
       </form>
     );

--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -499,21 +499,20 @@ Let's make the form interactive. When the user submits the form, we should clear
 var CommentForm = React.createClass({
   handleSubmit: function(e) {
     e.preventDefault();
-    var author = this.refs.author.value.trim();
-    var text = this.refs.text.value.trim();
+    var author = this.authorInput.value.trim();
+    var text = this.textInput.value.trim();
     if (!text || !author) {
       return;
     }
     // TODO: send request to the server
-    this.refs.author.value = '';
-    this.refs.text.value = '';
-    return;
+    this.authorInput.value = '';
+    this.textInput.value = '';
   },
   render: function() {
     return (
       <form className="commentForm" onSubmit={this.handleSubmit}>
-        <input type="text" placeholder="Your name" ref="author" />
-        <input type="text" placeholder="Say something..." ref="text" />
+        <input type="text" placeholder="Your name" ref={(ref) => this.authorInput = ref} />
+        <input type="text" placeholder="Say something..." ref={(ref) => this.textInput = ref} />
         <input type="submit" value="Post" />
       </form>
     );
@@ -582,21 +581,20 @@ Let's call the callback from the `CommentForm` when the user submits the form:
 var CommentForm = React.createClass({
   handleSubmit: function(e) {
     e.preventDefault();
-    var author = this.refs.author.value.trim();
-    var text = this.refs.text.value.trim();
+    var author = this.authorInput.value.trim();
+    var text = this.textInput.value.trim();
     if (!text || !author) {
       return;
     }
     this.props.onCommentSubmit({author: author, text: text});
-    this.refs.author.value = '';
-    this.refs.text.value = '';
-    return;
+    this.authorInput.value = '';
+    this.textInput.value = '';
   },
   render: function() {
     return (
       <form className="commentForm" onSubmit={this.handleSubmit}>
-        <input type="text" placeholder="Your name" ref="author" />
-        <input type="text" placeholder="Say something..." ref="text" />
+        <input type="text" placeholder="Your name" ref={(ref) => {this.authorInput = ref}} />
+        <input type="text" placeholder="Say something..." ref={(ref) => {this.textInput = ref}} />
         <input type="submit" value="Post" />
       </form>
     );


### PR DESCRIPTION
Updated tutorial to use pass a callback to refs. I've made a related change to the source code in the react-tutorial project under the same bug (#5427)