### PR TITLE
Allow nonce attribute

### DIFF
--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -128,6 +128,7 @@ var HTMLDOMPropertyConfig = {
     multiple: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
     muted: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
     name: null,
+    nonce: MUST_USE_ATTRIBUTE,
     noValidate: HAS_BOOLEAN_VALUE,
     open: HAS_BOOLEAN_VALUE,
     optimum: null,


### PR DESCRIPTION
The nonce attribute has been added to script and style tags in the WHATWG spec here (https://github.com/whatwg/html/commit/882803c4cc8fba2fa5472b76f628d95cc82c421d)

Closes #5432