### PR TITLE
Revert class name manipulation doc to english

### DIFF
--- a/docs/docs/10.3-class-name-manipulation.md
+++ b/docs/docs/10.3-class-name-manipulation.md
@@ -6,6 +6,6 @@ prev: two-way-binding-helpers.html
 next: test-utils.html
 ---
 
-> 주의:
+> NOTE:
 >
-> 이 모듈은 폐기예정입니다. 대신 [JedWatson/classnames](https://github.com/JedWatson/classnames)를 사용하세요.
+> This module has been deprecated; use [JedWatson/classnames](https://github.com/JedWatson/classnames) instead.


### PR DESCRIPTION
Hi! While checking a warning given by React 0.13, I had the surprise to stumble on a Korean translation on the documentation website : http://facebook.github.io/react/docs/class-name-manipulation.html

It seems there's been a mistake in https://github.com/facebook/react/pull/5385 and that `docs/docs/10.3-class-name-manipulation.md` was edited instead of `docs/docs/10.3-class-name-manipulation.ko-KR.md`

This restores the english translation of the main file.