### PR TITLE
RFC: Initial outline for new devtools api

### DIFF
--- a/src/renderers/dom/ReactDOM.js
+++ b/src/renderers/dom/ReactDOM.js
@@ -14,6 +14,7 @@
 'use strict';
 
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
+var ReactDOMDevtools = require('ReactDOMDevtools');
 var ReactDefaultInjection = require('ReactDefaultInjection');
 var ReactMount = require('ReactMount');
 var ReactPerf = require('ReactPerf');
@@ -35,6 +36,8 @@ var React = {
   render: render,
   unmountComponentAtNode: ReactMount.unmountComponentAtNode,
   version: ReactVersion,
+  addDevtool: ReactDOMDevtools.addDevtool,
+  removeDevtool: ReactDOMDevtools.removeDevtool,
 
   /* eslint-disable camelcase */
   unstable_batchedUpdates: ReactUpdates.batchedUpdates,

--- a/src/renderers/dom/shared/ReactDOMDevtools.js
+++ b/src/renderers/dom/shared/ReactDOMDevtools.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactDOMDevtools
+ */
+
+'use strict';
+
+var warning = require('warning');
+
+var eventHandlers = [];
+var handlerDoesThrowForEvent = {};
+
+var ReactDOMDevtools = {
+  addDevtool(devtool) {
+    eventHandlers.push(devtool);
+  },
+
+  removeDevtool(devtool) {
+    for (var i = 0; i < eventHandlers.length; i++) {
+      if (eventHandlers[i] === devtool) {
+        eventHandlers.splice(i, 1);
+        i--;
+      }
+    }
+  },
+
+  emitEvent(eventName, eventData) {
+    if (__DEV__) {
+      eventHandlers.forEach(function(handler) {
+        try {
+          handler.handleEvent(eventName, eventData);
+        } catch (e) {
+          warning(
+            !handlerDoesThrowForEvent[eventName],
+            'exception thrown by devtool while handling %s: %s',
+            eventName,
+            e.message
+          );
+          handlerDoesThrowForEvent[eventName] = true;
+        }
+      });
+    }
+  },
+};
+
+module.exports = ReactDOMDevtools;


### PR DESCRIPTION
Posting primarily to get feedback/thoughts/comments, and catch concerns early rather than late in the process.

The basic idea is to use a [CQRS](https://msdn.microsoft.com/en-us/library/dn568103.aspx) (or more specifically, [Event Sourcing](https://msdn.microsoft.com/en-us/library/dn589792.aspx)) pattern whereby the core will emit an event every time it does something (starts a render, ends a render, registers a dom-event-handler, resolves a ref, etc).  The devtools can listen to each of these events, and derive a shadow copy of any state desired.  This allows devtools to "follow along" with everything React is doing, and emit very information-full error messages, without us actually routing things through the core for the sole purpose of warnings.

Devtools are registered with React, which is global state, but is effectively what was happening before (except the current devtools uses monkeypatching, this is an explicit public API)

The "devmode" build of React (ie. the one that emits warnings) would simply be a copy of React bundled with a default devtool that registers its self with React, and keeps the necessary state to emit warnings.  This means that the production and dev code paths become more similar, because the only difference is that in production `emitEvent` is a no-op.

This was built with lessons learned from other tools (hot-reloading, people wanting to customize the warnings module, etc) in mind.  It allows other people to build custom devtools/warnings/etc.  See https://github.com/facebook/react/issues/5306 for details on the objectives.