### PR TITLE
Support React.PropTypes.{boolean,function}

### DIFF
--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -85,6 +85,9 @@ var ReactPropTypes = {
   shape: createShapeTypeChecker,
 };
 
+ReactPropTypes['boolean'] = ReactPropTypes.bool;
+ReactPropTypes['function'] = ReactPropTypes.func;
+
 function createChainableTypeChecker(validate) {
   function checkType(
     isRequired,


### PR DESCRIPTION
I originally chose the names `ReactPropTypes.bool` and `ReactPropTypes.func` because `boolean` and `function` were invalid identifiers in older supported browsers. With the advent of Babel and the automatic transform from these identifiers to their computed cousins, we can just make them all behave as expected.

This should significantly help cut down on the number of these warnings in codebases with engineers that don't test their own code:

```
Warning: MyComponent: prop type `myProp` is invalid; it must be a function, usually from React.PropTypes.
```