### PR TITLE
Fix typos and redundant words

### DIFF
--- a/src/renderers/dom/client/ReactReconcileTransaction.js
+++ b/src/renderers/dom/client/ReactReconcileTransaction.js
@@ -63,7 +63,7 @@ var EVENT_SUPPRESSION = {
 
 /**
  * Provides a queue for collecting `componentDidMount` and
- * `componentDidUpdate` callbacks during the the transaction.
+ * `componentDidUpdate` callbacks during the transaction.
  */
 var ON_DOM_READY_QUEUEING = {
   /**

--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -203,7 +203,7 @@ var HTMLDOMPropertyConfig = {
     itemScope: MUST_USE_ATTRIBUTE | HAS_BOOLEAN_VALUE,
     itemType: MUST_USE_ATTRIBUTE,
     // itemID and itemRef are for Microdata support as well but
-    // only specified in the the WHATWG spec document. See
+    // only specified in the WHATWG spec document. See
     // https://html.spec.whatwg.org/multipage/microdata.html#microdata-dom-api
     itemID: MUST_USE_ATTRIBUTE,
     itemRef: MUST_USE_ATTRIBUTE,

--- a/src/renderers/shared/event/eventPlugins/ResponderEventPlugin.js
+++ b/src/renderers/shared/event/eventPlugins/ResponderEventPlugin.js
@@ -135,7 +135,7 @@ var eventTypes = {
  *   immediately to indicate so, either by highlighting or moving accordingly.
  * - To be the responder means, that touches are exclusively important to that
  *   responder view, and no other view.
- * - While touches are still occuring, the responder lock can be transfered to
+ * - While touches are still occurring, the responder lock can be transferred to
  *   a new view, but only to increasingly "higher" views (meaning ancestors of
  *   the current responder).
  *
@@ -330,7 +330,7 @@ function setResponderAndExtractTransfer(
       eventTypes.selectionChangeShouldSetResponder :
     eventTypes.scrollShouldSetResponder;
 
-  // TODO: stop one short of the the current responder.
+  // TODO: stop one short of the current responder.
   var bubbleShouldSetFrom = !responderInst ?
     targetInst :
     EventPluginUtils.getLowestCommonAncestor(responderInst, targetInst);
@@ -499,7 +499,7 @@ var ResponderEventPlugin = {
         nativeEvent,
         nativeEventTarget) :
       null;
-    // Responder may or may not have transfered on a new touch start/move.
+    // Responder may or may not have transferred on a new touch start/move.
     // Regardless, whoever is the responder after any potential transfer, we
     // direct all touch start/move/ends to them in the form of
     // `onResponderMove/Start/End`. These will be called for *every* additional

--- a/src/renderers/shared/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
+++ b/src/renderers/shared/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
@@ -728,7 +728,7 @@ describe('ResponderEventPlugin', function() {
 
     config = oneEventLoopTestConfig(three);
 
-    // Parent is responder, and responder is transfered by a second touch start
+    // Parent is responder, and responder is transferred by a second touch start
     config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: true};
     config.responderTerminationRequest.parent = {order: 1, returnVal: true};
     config.responderGrant.grandParent = {order: 2};


### PR DESCRIPTION
Just noticed few other typos when going through the source code. Probably not the highest value PRs, I know... :)

Also one of the comments in `ReactDOMComponentTree` is not ended, any idea what you wanted to write there @spicyj?

https://github.com/facebook/react/blob/master/src/renderers/dom/client/ReactDOMComponentTree.js#L67

Thanks!