### PR TITLE
Update DOM_OPERATION_TYPES mappings for ReactDefaultPerfAnalysis

### DIFF
--- a/src/test/ReactDefaultPerfAnalysis.js
+++ b/src/test/ReactDefaultPerfAnalysis.js
@@ -25,7 +25,9 @@ var DOM_OPERATION_TYPES = {
   'setValueForProperty': 'update attribute',
   'setValueForAttribute': 'update attribute',
   'deleteValueForProperty': 'remove attribute',
-  'dangerouslyReplaceNodeWithMarkupByID': 'replace',
+  'setValueForStyles': 'update styles',
+  'replaceNodeWithMarkup': 'replace',
+  'updateTextContent': 'set textContent',
 };
 
 function getTotalTime(measurements) {


### PR DESCRIPTION
Updated mappings for DOM operation types in ReactDefaultPerfAnalysis so they get correctly type names as in 0.13.3. 

Some of them are not correctly mapped after some refactoring that came with 0.14.0:
![](https://www.dropbox.com/s/s1q714y1aqjfr9c/Screenshot%202015-11-18%2020.57.30.png?dl=1)
