### PR TITLE
[performance] Remove hasOwnProperty calls to objects that are managed within React

### DIFF
--- a/src/addons/update.js
+++ b/src/addons/update.js
@@ -156,7 +156,7 @@ function update(value, spec) {
   }
 
   for (var k in spec) {
-    if (!(ALL_COMMANDS_SET.hasOwnProperty(k) && ALL_COMMANDS_SET[k])) {
+    if (!ALL_COMMANDS_SET[k]) {
       nextValue[k] = update(value[k], spec[k]);
     }
   }

--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -415,12 +415,12 @@ function validateTypeDef(Constructor, typeDef, location) {
 }
 
 function validateMethodOverride(proto, name) {
-  var specPolicy = ReactClassInterface.hasOwnProperty(name) ?
+  var specPolicy = ReactClassInterface[name] ?
     ReactClassInterface[name] :
     null;
 
   // Disallow overriding of base class methods unless explicitly allowed.
-  if (ReactClassMixin.hasOwnProperty(name)) {
+  if (ReactClassMixin[name]) {
     invariant(
       specPolicy === SpecPolicy.OVERRIDE_BASE,
       'ReactClassInterface: You are attempting to override ' +
@@ -486,7 +486,7 @@ function mixSpecIntoComponent(Constructor, spec) {
     var property = spec[name];
     validateMethodOverride(proto, name);
 
-    if (RESERVED_SPEC_KEYS.hasOwnProperty(name)) {
+    if (RESERVED_SPEC_KEYS[name]) {
       RESERVED_SPEC_KEYS[name](Constructor, property);
     } else {
       // Setup methods on prototype:
@@ -494,7 +494,7 @@ function mixSpecIntoComponent(Constructor, spec) {
       // 1. Expected ReactClass methods (in the "interface").
       // 2. Overridden methods (that were mixed in).
       var isReactClassMethod =
-        ReactClassInterface.hasOwnProperty(name);
+        !!ReactClassInterface[name];
       var isAlreadyDefined = proto.hasOwnProperty(name);
       var isFunction = typeof property === 'function';
       var shouldAutoBind =
@@ -701,13 +701,11 @@ function bindAutoBindMethod(component, method) {
  */
 function bindAutoBindMethods(component) {
   for (var autoBindKey in component.__reactAutoBindMap) {
-    if (component.__reactAutoBindMap.hasOwnProperty(autoBindKey)) {
-      var method = component.__reactAutoBindMap[autoBindKey];
-      component[autoBindKey] = bindAutoBindMethod(
-        component,
-        method
-      );
-    }
+    var method = component.__reactAutoBindMap[autoBindKey];
+    component[autoBindKey] = bindAutoBindMethod(
+      component,
+      method
+    );
   }
 }
 

--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -128,7 +128,7 @@ ReactElement.createElement = function(type, config, children) {
     // Remaining properties are added to a new props object
     for (propName in config) {
       if (config.hasOwnProperty(propName) &&
-          !RESERVED_PROPS.hasOwnProperty(propName)) {
+          !RESERVED_PROPS[propName]) {
         props[propName] = config[propName];
       }
     }
@@ -243,7 +243,7 @@ ReactElement.cloneElement = function(element, config, children) {
     // Remaining properties override existing props
     for (propName in config) {
       if (config.hasOwnProperty(propName) &&
-          !RESERVED_PROPS.hasOwnProperty(propName)) {
+          !RESERVED_PROPS[propName]) {
         props[propName] = config[propName];
       }
     }

--- a/src/renderers/dom/shared/DOMProperty.js
+++ b/src/renderers/dom/shared/DOMProperty.js
@@ -75,7 +75,7 @@ var DOMPropertyInjection = {
 
     for (var propName in Properties) {
       invariant(
-        !DOMProperty.properties.hasOwnProperty(propName),
+        !DOMProperty.properties[propName],
         'injectDOMPropertyConfig(...): You\'re trying to inject DOM property ' +
         '\'%s\' which has already been injected. You may be accidentally ' +
         'injecting the same DOM property config twice, or you may be ' +
@@ -125,7 +125,7 @@ var DOMPropertyInjection = {
         DOMProperty.getPossibleStandardName[lowerCased] = propName;
       }
 
-      if (DOMAttributeNames.hasOwnProperty(propName)) {
+      if (DOMAttributeNames[propName]) {
         var attributeName = DOMAttributeNames[propName];
         propertyInfo.attributeName = attributeName;
         if (__DEV__) {
@@ -133,15 +133,15 @@ var DOMPropertyInjection = {
         }
       }
 
-      if (DOMAttributeNamespaces.hasOwnProperty(propName)) {
+      if (DOMAttributeNamespaces[propName]) {
         propertyInfo.attributeNamespace = DOMAttributeNamespaces[propName];
       }
 
-      if (DOMPropertyNames.hasOwnProperty(propName)) {
+      if (DOMPropertyNames[propName]) {
         propertyInfo.propertyName = DOMPropertyNames[propName];
       }
 
-      if (DOMMutationMethods.hasOwnProperty(propName)) {
+      if (DOMMutationMethods[propName]) {
         propertyInfo.mutationMethod = DOMMutationMethods[propName];
       }
 

--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -25,10 +25,10 @@ var illegalAttributeNameCache = {};
 var validatedAttributeNameCache = {};
 
 function isAttributeNameSafe(attributeName) {
-  if (validatedAttributeNameCache.hasOwnProperty(attributeName)) {
+  if (validatedAttributeNameCache[attributeName]) {
     return true;
   }
-  if (illegalAttributeNameCache.hasOwnProperty(attributeName)) {
+  if (illegalAttributeNameCache[attributeName]) {
     return false;
   }
   if (VALID_ATTRIBUTE_NAME_REGEX.test(attributeName)) {
@@ -62,8 +62,7 @@ if (__DEV__) {
   var warnedProperties = {};
 
   var warnUnknownProperty = function(name) {
-    if (reactProps.hasOwnProperty(name) && reactProps[name] ||
-        warnedProperties.hasOwnProperty(name) && warnedProperties[name]) {
+    if (reactProps[name] || warnedProperties[name]) {
       return;
     }
 
@@ -74,9 +73,7 @@ if (__DEV__) {
     var standardName = (
       DOMProperty.isCustomAttribute(lowerCasedName) ?
         lowerCasedName :
-      DOMProperty.getPossibleStandardName.hasOwnProperty(lowerCasedName) ?
-        DOMProperty.getPossibleStandardName[lowerCasedName] :
-        null
+        DOMProperty.getPossibleStandardName[lowerCasedName] || null
     );
 
     // For now, only warn when we have a suggested correction. This prevents
@@ -88,13 +85,8 @@ if (__DEV__) {
       standardName
     );
 
-    var registrationName = (
-      EventPluginRegistry.possibleRegistrationNames.hasOwnProperty(
-        lowerCasedName
-      ) ?
-      EventPluginRegistry.possibleRegistrationNames[lowerCasedName] :
-      null
-    );
+    var registrationName =
+      EventPluginRegistry.possibleRegistrationNames[lowerCasedName] || null;
 
     warning(
       registrationName == null,
@@ -141,8 +133,7 @@ var DOMPropertyOperations = {
    * @return {?string} Markup string, or null if the property was invalid.
    */
   createMarkupForProperty: function(name, value) {
-    var propertyInfo = DOMProperty.properties.hasOwnProperty(name) ?
-        DOMProperty.properties[name] : null;
+    var propertyInfo = DOMProperty.properties[name] || null;
     if (propertyInfo) {
       if (shouldIgnoreValue(propertyInfo, value)) {
         return '';
@@ -186,8 +177,7 @@ var DOMPropertyOperations = {
    * @param {*} value
    */
   setValueForProperty: function(node, name, value) {
-    var propertyInfo = DOMProperty.properties.hasOwnProperty(name) ?
-        DOMProperty.properties[name] : null;
+    var propertyInfo = DOMProperty.properties[name] || null;
     if (propertyInfo) {
       var mutationMethod = propertyInfo.mutationMethod;
       if (mutationMethod) {
@@ -243,8 +233,7 @@ var DOMPropertyOperations = {
    * @param {string} name
    */
   deleteValueForProperty: function(node, name) {
-    var propertyInfo = DOMProperty.properties.hasOwnProperty(name) ?
-        DOMProperty.properties[name] : null;
+    var propertyInfo = DOMProperty.properties[name] || null;
     if (propertyInfo) {
       var mutationMethod = propertyInfo.mutationMethod;
       if (mutationMethod) {

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -214,7 +214,7 @@ function checkAndWarnForMutatedStyle(style1, style2, component) {
 
   var hash = ownerName + '|' + componentName;
 
-  if (styleMutationWarning.hasOwnProperty(hash)) {
+  if (styleMutationWarning[hash]) {
     return;
   }
 
@@ -378,15 +378,13 @@ function trapBubbledEventsLocal() {
       inst._wrapperState.listeners = [];
       // Create listener for each media event
       for (var event in mediaEvents) {
-        if (mediaEvents.hasOwnProperty(event)) {
-          inst._wrapperState.listeners.push(
-            ReactBrowserEventEmitter.trapBubbledEvent(
-              EventConstants.topLevelTypes[event],
-              mediaEvents[event],
-              node
-            )
-          );
-        }
+        inst._wrapperState.listeners.push(
+          ReactBrowserEventEmitter.trapBubbledEvent(
+            EventConstants.topLevelTypes[event],
+            mediaEvents[event],
+            node
+          )
+        );
       }
 
       break;
@@ -481,10 +479,9 @@ var voidElementTags = assign({
 
 var VALID_TAG_REGEX = /^[a-zA-Z][a-zA-Z:_\.\-\d]*$/; // Simplified subset
 var validatedTagCache = {};
-var hasOwnProperty = {}.hasOwnProperty;
 
 function validateDangerousTag(tag) {
-  if (!hasOwnProperty.call(validatedTagCache, tag)) {
+  if (!validatedTagCache[tag]) {
     invariant(VALID_TAG_REGEX.test(tag), 'Invalid tag: %s', tag);
     validatedTagCache[tag] = true;
   }
@@ -726,7 +723,7 @@ ReactDOMComponent.Mixin = {
       if (propValue == null) {
         continue;
       }
-      if (registrationNameModules.hasOwnProperty(propKey)) {
+      if (registrationNameModules[propKey]) {
         if (propValue) {
           enqueuePutListener(this, propKey, propValue, transaction);
         }
@@ -954,7 +951,7 @@ ReactDOMComponent.Mixin = {
           }
         }
         this._previousStyleCopy = null;
-      } else if (registrationNameModules.hasOwnProperty(propKey)) {
+      } else if (registrationNameModules[propKey]) {
         if (lastProps[propKey]) {
           // Only call deleteListener if there was a listener previously or
           // else willDeleteListener gets called when there wasn't actually a
@@ -1012,7 +1009,7 @@ ReactDOMComponent.Mixin = {
           // Relies on `updateStylesByID` not mutating `styleUpdates`.
           styleUpdates = nextProp;
         }
-      } else if (registrationNameModules.hasOwnProperty(propKey)) {
+      } else if (registrationNameModules[propKey]) {
         if (nextProp) {
           enqueuePutListener(this, propKey, nextProp, transaction);
         } else if (lastProp) {

--- a/src/renderers/shared/event/EventPluginRegistry.js
+++ b/src/renderers/shared/event/EventPluginRegistry.js
@@ -79,7 +79,7 @@ function recomputePluginOrdering() {
  */
 function publishEventForPlugin(dispatchConfig, PluginModule, eventName) {
   invariant(
-    !EventPluginRegistry.eventNameDispatchConfigs.hasOwnProperty(eventName),
+    !EventPluginRegistry.eventNameDispatchConfigs[eventName],
     'EventPluginHub: More than one plugin attempted to publish the same ' +
     'event name, `%s`.',
     eventName


### PR DESCRIPTION
Using profiling `hasOwnProperty` goes from 3.7% of ticks to 0.6% of ticks when calling `renderToStaticMarkup` 10,000 times. I made sure to only remove calls when the objects are internally created and managed and guaranteed to never have prototypes.

I've also been thinking about optimizations for `props`. By ensuring that props are a prototype-free object early on in `React.createElement` a lot of the `hasOwnProperty` checks downstream could be optimized. I think this may get in to micro-optimization territory though since I'm only seeing 0.6% of ticks in `hasOwnProperty` at this point (although paths other than `renderToStaticMarkup` may have more usage like the reconciler).