### PR TITLE
Removed unnecessary variables/assertions.

### DIFF
--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -143,10 +143,7 @@ describe('ReactCompositeComponent', function() {
     instance.setProps({renderAnchor: false});  // Clear out the anchor
     // rerender
     instance.setProps({renderAnchor: true, anchorClassOn: false});
-    var anchor = instance.getAnchor();
-    var actualDOMAnchorNode = ReactDOM.findDOMNode(anchor);
-    expect(actualDOMAnchorNode.className).toBe('');
-    expect(actualDOMAnchorNode).toBe(ReactDOM.findDOMNode(anchor));
+    expect(instance.getAnchor().className).toBe('');
   });
 
   it('should auto bind methods and values correctly', function() {


### PR DESCRIPTION
Removed unnecessary variables/assertions.

instance.getAnchor() is a DOM node, so `actualDOMAnchorNode` is meaningless, and asserting that `anchor === anchor` is also pointless.  Unless I'm miss-understanding something.  I think this is just noise from back when internal instances were not DOM nodes?  cc @spicyj 