### PR TITLE
Allow to render child custom component in shallow renderer

### DIFF
--- a/src/renderers/shared/reconciler/ReactChildReconciler.js
+++ b/src/renderers/shared/reconciler/ReactChildReconciler.js
@@ -19,29 +19,29 @@ var shouldUpdateReactComponent = require('shouldUpdateReactComponent');
 var traverseAllChildren = require('traverseAllChildren');
 var warning = require('warning');
 
-function instantiateChild(childInstances, child, name) {
-  // We found a component instance.
-  var keyUnique = (childInstances[name] === undefined);
-  if (__DEV__) {
-    warning(
-      keyUnique,
-      'flattenChildren(...): Encountered two children with the same key, ' +
-      '`%s`. Child keys must be unique; when two children share a key, only ' +
-      'the first child will be used.',
-      name
-    );
-  }
-  if (child != null && keyUnique) {
-    childInstances[name] = instantiateReactComponent(child, null);
-  }
-}
-
 /**
  * ReactChildReconciler provides helpers for initializing or updating a set of
  * children. Its output is suitable for passing it onto ReactMultiChild which
  * does diffed reordering and insertion.
  */
 var ReactChildReconciler = {
+  _instantiateReactComponent: instantiateReactComponent,
+  instantiateChild: function(childInstances, child, name) {
+    // We found a component instance.
+    var keyUnique = (childInstances[name] === undefined);
+    if (__DEV__) {
+      warning(
+        keyUnique,
+        'flattenChildren(...): Encountered two children with the same key, ' +
+        '`%s`. Child keys must be unique; when two children share a key, only ' +
+        'the first child will be used.',
+        name
+      );
+    }
+    if (child != null && keyUnique) {
+      childInstances[name] = this._instantiateReactComponent(child, null);
+    }
+  },
   /**
    * Generates a "mount image" for each of the supplied children. In the case
    * of `ReactDOMComponent`, a mount image is a string of markup.
@@ -55,7 +55,7 @@ var ReactChildReconciler = {
       return null;
     }
     var childInstances = {};
-    traverseAllChildren(nestedChildNodes, instantiateChild, childInstances);
+    traverseAllChildren(nestedChildNodes, this.instantiateChild.bind(this), childInstances);
     return childInstances;
   },
 

--- a/src/renderers/shared/reconciler/ReactMultiChild.js
+++ b/src/renderers/shared/reconciler/ReactMultiChild.js
@@ -191,13 +191,13 @@ var ReactMultiChild = {
    * @lends {ReactMultiChild.prototype}
    */
   Mixin: {
-
+    _childReconciler: ReactChildReconciler,
     _reconcilerInstantiateChildren: function(nestedChildren, transaction, context) {
       if (__DEV__) {
         if (this._currentElement) {
           try {
             ReactCurrentOwner.current = this._currentElement._owner;
-            return ReactChildReconciler.instantiateChildren(
+            return this._childReconciler.instantiateChildren(
               nestedChildren, transaction, context
             );
           } finally {
@@ -205,7 +205,7 @@ var ReactMultiChild = {
           }
         }
       }
-      return ReactChildReconciler.instantiateChildren(
+      return this._childReconciler.instantiateChildren(
         nestedChildren, transaction, context
       );
     },
@@ -220,13 +220,13 @@ var ReactMultiChild = {
           } finally {
             ReactCurrentOwner.current = null;
           }
-          return ReactChildReconciler.updateChildren(
+          return this._childReconciler.updateChildren(
             prevChildren, nextChildren, transaction, context
           );
         }
       }
       nextChildren = flattenChildren(nextNestedChildrenElements);
-      return ReactChildReconciler.updateChildren(
+      return this._childReconciler.updateChildren(
         prevChildren, nextChildren, transaction, context
       );
     },
@@ -275,7 +275,7 @@ var ReactMultiChild = {
       try {
         var prevChildren = this._renderedChildren;
         // Remove any rendered children.
-        ReactChildReconciler.unmountChildren(prevChildren);
+        this._childReconciler.unmountChildren(prevChildren);
         // TODO: The setTextContent operation should be enough
         for (var name in prevChildren) {
           if (prevChildren.hasOwnProperty(name)) {
@@ -309,7 +309,7 @@ var ReactMultiChild = {
       try {
         var prevChildren = this._renderedChildren;
         // Remove any rendered children.
-        ReactChildReconciler.unmountChildren(prevChildren);
+        this._childReconciler.unmountChildren(prevChildren);
         for (var name in prevChildren) {
           if (prevChildren.hasOwnProperty(name)) {
             this._unmountChild(prevChildren[name]);
@@ -417,7 +417,7 @@ var ReactMultiChild = {
      */
     unmountChildren: function() {
       var renderedChildren = this._renderedChildren;
-      ReactChildReconciler.unmountChildren(renderedChildren);
+      this._childReconciler.unmountChildren(renderedChildren);
       this._renderedChildren = null;
     },
 

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -257,6 +257,58 @@ describe('ReactTestUtils', function() {
 
   });
 
+  it('should not shallowly render custom components by default', function() {
+    var renderSpy = jasmine.createSpy('ChildComponent.render');
+
+    var ChildComponent = React.createClass({
+      render: renderSpy,
+    });
+
+    var SomeComponent = React.createClass({
+      render: function() {
+        return (<div>
+          <ChildComponent />
+        </div>);
+      },
+    });
+
+    var shallowRenderer = ReactTestUtils.createRenderer();
+    shallowRenderer.render(<SomeComponent />);
+    var result = shallowRenderer.getRenderOutput();
+
+    expect(result).toEqual(<div>
+      <ChildComponent />
+    </div>);
+
+    expect(renderSpy).not.toHaveBeenCalled();
+  });
+
+  it('can shallowly render custom components which are on white list', function() {
+    var ChildComponent = React.createClass({
+      render: function() {
+        return <div className="child"></div>;
+      },
+    });
+
+    ReactTestUtils.renderComponentsAsChild.push(ChildComponent);
+
+    var SomeComponent = React.createClass({
+      render: function() {
+        return (<div>
+          <ChildComponent />
+        </div>);
+      },
+    });
+
+    var shallowRenderer = ReactTestUtils.createRenderer();
+    shallowRenderer.render(<SomeComponent />);
+    var result = shallowRenderer.getRenderOutput();
+
+    expect(result).toEqual(<div>
+      <div className="child"></div>
+    </div>);
+  });
+
   it('can scryRenderedDOMComponentsWithClass with className contains \\n', function() {
     var Wrapper = React.createClass({
       render: function() {


### PR DESCRIPTION
Motivation: https://medium.com/@bruderstein/the-missing-piece-to-the-react-testing-puzzle-c51cd30df7a0#.o7qri0ufc

Currently there is no way to easy refactor spaghetti components by smash them into smaller components while using shallow renderer to test. It fixes that. 

I know, that inject custom `instantiateReactComponent` function is tricky, but I did not find better solution for this. I'm open for suggestions to do it better, maybe some core devs have some ideas?

Im also not convinced about add components to the "whitelist" - `renderComponentsAsChild` array. This name does not explain purpose enough for me. Again, I'm open to any suggestions.

The plus is, that there is no any regression in this but I'm little scary, that tests dont cover all corner cases so probably it should go as 0.15 release's feature, because users could report some bugs with them tests.