### PR TITLE
[docs] Add missing sections to events reference page in IT and CN

### DIFF
--- a/docs/docs/ref-05-events.it-IT.md
+++ b/docs/docs/ref-05-events.it-IT.md
@@ -81,6 +81,22 @@ DOMDataTransfer clipboardData
 ```
 
 
+### Eventi di Composizione
+
+Nomi degli eventi:
+
+```
+onCompositionEnd onCompositionStart onCompositionUpdate
+```
+
+Proprietà:
+
+```javascript
+string data
+
+```
+
+
 ### Eventi di Tastiera
 
 Nomi degli eventi:
@@ -162,6 +178,15 @@ DOMEventTarget relatedTarget
 number screenX
 number screenY
 boolean shiftKey
+```
+
+
+### Eventi di Selezione
+
+Nomi degli eventi:
+
+```
+onSelect
 ```
 
 

--- a/docs/docs/ref-05-events.md
+++ b/docs/docs/ref-05-events.md
@@ -183,7 +183,7 @@ boolean shiftKey
 ```
 
 
-### Selection events
+### Selection Events
 
 Event names:
 
@@ -192,7 +192,7 @@ onSelect
 ```
 
 
-### Touch events
+### Touch Events
 
 Event names:
 

--- a/docs/docs/ref-05-events.zh-CN.md
+++ b/docs/docs/ref-05-events.zh-CN.md
@@ -138,6 +138,15 @@ boolean shiftKey
 ```
 
 
+### Selection Events
+
+事件名称:
+
+```
+onSelect
+```
+
+
 ### 触控事件
 
 事件名称：
@@ -191,4 +200,20 @@ number deltaMode
 number deltaX
 number deltaY
 number deltaZ
+```
+
+### Media Events
+
+事件名称:
+
+```
+onAbort onCanPlay onCanPlayThrough onDurationChange onEmptied onEncrypted onEnded onError onLoadedData onLoadedMetadata onLoadStart onPause onPlay onPlaying onProgress onRateChange onSeeked onSeeking onStalled onSuspend onTimeUpdate onVolumeChange onWaiting
+```
+
+### Image Events
+
+事件名称:
+
+```
+onLoad onError
 ```


### PR DESCRIPTION
Fixes #432.

This PR adds missing parts of the events documentation to the respective Italian and Chinese translations. The english version was already done in #5142.

The translations are still WIP. Following section titles still need to be translated:

it-IT (done):
```
Composition Events
Selection Events
```

ko-KR:
```
Composition Events
```

zh-CN:
```
Selection Events
Media Events
Image Events
```

Could you guys help a bit? @minwe @marocchino @claudiopro 

Thanks!