### PR TITLE
Remove unreachable return from shouldUpdateReactComponent

### DIFF
--- a/src/renderers/shared/reconciler/shouldUpdateReactComponent.js
+++ b/src/renderers/shared/reconciler/shouldUpdateReactComponent.js
@@ -41,7 +41,6 @@ function shouldUpdateReactComponent(prevElement, nextElement) {
       prevElement.key === nextElement.key
     );
   }
-  return false;
 }
 
 module.exports = shouldUpdateReactComponent;


### PR DESCRIPTION
Eslint didn't catch this (we do have this rule turned on) because it's a
big. There are no other locations I think. Detected that when I minified
some code.