### PR TITLE
[docs] Use id for TodoApp example

### DIFF
--- a/docs/_js/examples/todo.js
+++ b/docs/_js/examples/todo.js
@@ -1,8 +1,8 @@
 var TODO_COMPONENT = `
 var TodoList = React.createClass({
   render: function() {
-    var createItem = function(itemText, index) {
-      return <li key={index + itemText}>{itemText}</li>;
+    var createItem = function(item) {
+      return <li key={item.id}>{item.text}</li>;
     };
     return <ul>{this.props.items.map(createItem)}</ul>;
   }
@@ -16,7 +16,7 @@ var TodoApp = React.createClass({
   },
   handleSubmit: function(e) {
     e.preventDefault();
-    var nextItems = this.state.items.concat([this.state.text]);
+    var nextItems = this.state.items.concat([{text: this.state.text, id: Date.now()}]);
     var nextText = '';
     this.setState({items: nextItems, text: nextText});
   },


### PR DESCRIPTION
Just realized that the todo example on the homepage for http://facebook.github.io/react/ is using a combination of the array index and text for the `key`.

In https://github.com/facebook/react/pull/5257, @spicyj mentioned that 

> We should probably introduce some sort of id property here. We shouldn't use the text of the message.

@zpao then added an `id` property that uses the current timestamp for the tutorial example.