### PR TITLE
Catch errors from component's render()

### DIFF
--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -786,7 +786,26 @@ var ReactCompositeComponentMixin = {
    */
   _renderValidatedComponentWithoutOwnerOrContext: function() {
     var inst = this._instance;
-    var renderedComponent = inst.render();
+
+    if (typeof inst.render !== 'function') {
+      throw new TypeError('render is not a function');
+    }
+
+    try {
+      var renderedComponent = inst.render();
+    } catch (err) {
+      warning(
+        false,
+        '%s(...): The `render` method threw error. Empty element will ' +
+        'be displayed instead.',
+        this.getName() || 'ReactCompositeComponent'
+      );
+      setTimeout(function() {
+        throw err;
+      }, 0);
+      renderedComponent = null;
+    }
+
     if (__DEV__) {
       // We allow auto-mocks to proceed as if they're returning null.
       if (typeof renderedComponent === 'undefined' &&

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -475,9 +475,10 @@ describe('ReactCompositeComponent', function() {
 
     expect(function() {
       instance = ReactTestUtils.renderIntoDocument(instance);
-    }).toThrow();
+    }).not.toThrow();
 
     expect(ReactCurrentOwner.current).toBe(null);
+    expect(console.error.calls.length).toBe(1);
   });
 
   it('should call componentWillUnmount before unmounting', function() {


### PR DESCRIPTION
This is an attempt at fixing #2461

If a Component's `render()` function throws an error we catch it, display a warning in the console and then we throw the error using `setTimeout` so that React does not get into inconsistent state but the error is not swallowed and bubbles to the top.

Please let us know if this is the right direction. We are really not sure about the usage of `setTimeout`, it feels like a dirty hack. The reason for its usage is to not silently fail but to let the error propagate to the top. But we cannot do it synchronously because otherwise React will end up in state that is "beyond repair".

We worked on this PR together with @LeZuse

See the test case here: http://jsfiddle.net/XeeD/pLqphjm4/