### PR TITLE
Polyfill event.dataTransfer.type for drag & drop events

### DIFF
--- a/src/renderers/dom/client/syntheticEvents/SyntheticDragEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticDragEvent.js
@@ -22,6 +22,72 @@ var DragEventInterface = {
   dataTransfer: null,
 };
 
+var SyntheticDataTransfer = function(nativeDataTransfer) {
+  this.nativeDataTransfer = nativeDataTransfer;
+};
+
+SyntheticDataTransfer.prototype.clearData = function(format) {
+  return this.nativeDataTransfer.clearData(format);
+};
+
+SyntheticDataTransfer.prototype.getData = function(format) {
+  return this.nativeDataTransfer.getData(format);
+};
+
+SyntheticDataTransfer.prototype.setData = function(format, data) {
+  return this.nativeDataTransfer.setData(format, data);
+};
+
+SyntheticDataTransfer.prototype.setDragImage = function(img, xOffset, yOffset) {
+  return this.nativeDataTransfer.setDragImage(img, xOffset, yOffset);
+};
+
+Object.defineProperty(SyntheticDataTransfer.prototype, 'dropEffect', {
+  get: function() {
+    return this.nativeDataTransfer.dropEffect;
+  },
+
+  set: function(value) {
+    this.nativeDataTransfer.dropEffect = value;
+  },
+});
+
+Object.defineProperty(SyntheticDataTransfer.prototype, 'effectAllowed', {
+  get: function() {
+    return this.nativeDataTransfer.effectAllowed;
+  },
+
+  set: function(value) {
+    this.nativeDataTransfer.effectAllowed = value;
+  },
+});
+
+Object.defineProperty(SyntheticDataTransfer.prototype, 'files', {
+  enumerable: true,
+
+  get: function() {
+    return this.nativeDataTransfer.files;
+  },
+});
+
+Object.defineProperty(SyntheticDataTransfer.prototype, 'items', {
+  get: function() {
+    return this.nativeDataTransfer.items;
+  },
+});
+
+Object.defineProperty(SyntheticDataTransfer.prototype, 'types', {
+  enumerable: true,
+
+  get: function() {
+    if ('DOMStringList' in window && this.nativeDataTransfer.types instanceof DOMStringList) {
+      return Array.prototype.slice.call(this.nativeDataTransfer.types, 0);
+    } else {
+      return this.nativeDataTransfer.types;
+    }
+  },
+});
+
 /**
  * @param {object} dispatchConfig Configuration used to dispatch this event.
  * @param {string} dispatchMarker Marker identifying the event target.
@@ -30,6 +96,8 @@ var DragEventInterface = {
  */
 function SyntheticDragEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
   SyntheticMouseEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
+
+  this.dataTransfer = new SyntheticDataTransfer(nativeEvent.dataTransfer);
 }
 
 SyntheticMouseEvent.augmentClass(SyntheticDragEvent, DragEventInterface);


### PR DESCRIPTION
This pull request demonstrates our idea (me and @hejld) how to fix #3656 and #2676. We started with just polyfilling the types property for now.

There are few aspects that are not finished yet - object pooling, checking if it is possible to use defineProperty, and tests - but it should be enough to gather initial feedback.

Thanks a lot!

cc @syranide