### PR TITLE
Warn if any child passed to ReactCSSTransitionGroup is without key

### DIFF
--- a/src/addons/transitions/ReactCSSTransitionGroup.js
+++ b/src/addons/transitions/ReactCSSTransitionGroup.js
@@ -15,6 +15,7 @@
 var React = require('React');
 
 var assign = require('Object.assign');
+var warning = require('warning');
 
 var ReactTransitionGroup = require('ReactTransitionGroup');
 var ReactCSSTransitionGroupChild = require('ReactCSSTransitionGroupChild');
@@ -64,6 +65,26 @@ var ReactCSSTransitionGroup = React.createClass({
       transitionEnter: true,
       transitionLeave: true,
     };
+  },
+
+  componentWillMount() {
+    if (__DEV__) {
+      if (this.props.children) {
+        var allChildrenHaveKeys = true;
+        React.Children.forEach(this.props.children, function(child) {
+          if (child != null && child.key == null) {
+            allChildrenHaveKeys = false;
+          }
+        });
+        warning(
+          allChildrenHaveKeys,
+          'You must provide the key attribute for all children of ' +
+          'ReactCSSTransitionGroup, even when only rendering a single item. ' +
+          'This is how React will determine which children have entered, ' +
+          'left, or stayed.'
+        );
+      }
+    }
   },
 
   _wrapChild: function(child) {

--- a/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
@@ -291,4 +291,24 @@ describe('ReactCSSTransitionGroup', function() {
     // Testing that no exception is thrown here, as the timeout has been cleared.
     jest.runAllTimers();
   });
+
+  it('should warn if some children do not have the key specified', function() {
+    ReactDOM.render(
+      <ReactCSSTransitionGroup
+        transitionName="yolo"
+        transitionEnter={false}
+        transitionLeave={true}
+        transitionLeaveTimeout={0}
+      >
+        <span key="one" id="one" />
+        <span id="two" />
+      </ReactCSSTransitionGroup>,
+      container
+    );
+
+    expect(console.error.argsForCall.length).toBe(1);
+    expect(console.error.argsForCall[0][0]).toContain(
+      'You must provide the key attribute for all children of ReactCSSTransitionGroup'
+    );
+  });
 });


### PR DESCRIPTION
Solves #5322

I am not sure if the same check should be performed also in `componentWillReceiveProps` or in a different place altogether.

Thank you for feedback.

/cc @LeZuse