### PR TITLE
Use null instead of '' in ternary expression

### DIFF
--- a/docs/tips/03-if-else-in-JSX.md
+++ b/docs/tips/03-if-else-in-JSX.md
@@ -30,7 +30,7 @@ React.createElement("div", {id: if (condition) { 'msg' }}, "Hello World!");
 That's not valid JS. You probably want to make use of a ternary expression:
 
 ```js
-ReactDOM.render(<div id={condition ? 'msg' : ''}>Hello World!</div>, mountNode);
+ReactDOM.render(<div id={condition ? 'msg' : null}>Hello World!</div>, mountNode);
 ```
 
 If a ternary expression isn't robust enough, you can use `if` statements outside of your JSX to determine which components should be used:


### PR DESCRIPTION
A blank string (`''`) resolves to `<span></span>` which produces a warning when place inside a `<tr>`

I am not sure if it is always better to use `null` instead of `''`, if not the docs should at least explain that using `null` is a possibility:
>A blank string (`''`) is converted to to `<span></span>`. You may also use `null` which produces no HTML at all. 