### PR TITLE
Avoid mutating state in the example code

### DIFF
--- a/docs/docs/10.1-animation.md
+++ b/docs/docs/10.1-animation.md
@@ -29,7 +29,7 @@ var TodoList = React.createClass({
     this.setState({items: newItems});
   },
   handleRemove: function(i) {
-    var newItems = this.state.items;
+    var newItems = this.state.items.slice();
     newItems.splice(i, 1);
     this.setState({items: newItems});
   },


### PR DESCRIPTION
According to react documentation it is advised to: 
NEVER mutate this.state directly, as calling setState() afterwards may replace the mutation you made. Treat this.state as if it were immutable.
https://facebook.github.io/react/docs/animation.html

In this particular case it is probably doesn't matter since setState is called directly after mutation, but it does provide a bad example of state mutation.

Another way of removing an item from an array can be `newItems = this.state.slice(0,i).concat(this.state.slice(i+1))` however the meaning can be less obvious to some.