### PR TITLE
Fix file reference typo in starter

### DIFF
--- a/starter/README.md
+++ b/starter/README.md
@@ -6,6 +6,6 @@ To begin, check out the `examples/` directory for a bunch of examples, or check 
 
 In some browsers our examples won't work from the local file system; run `python -m SimpleHTTPServer` and visit `http://localhost:8000/` to view them.
 
-Want to start your own app? Just copy `examples/basic-jsx-external` and start hacking! Remember: before launching you'll want to precompile your JSX code as we do in `examples/basic-jsx-precompiled`; this requires doing `npm install -g react-tools` and then running our `jsx` tool. See [Getting Started](https://facebook.github.io/react/docs/getting-started.html) for more information.
+Want to start your own app? Just copy `examples/basic-jsx-external` and start hacking! Remember: before launching you'll want to precompile your JSX code as we do in `examples/basic-jsx-precompile`; this requires doing `npm install -g react-tools` and then running our `jsx` tool. See [Getting Started](https://facebook.github.io/react/docs/getting-started.html) for more information.
 
 Happy Hacking!


### PR DESCRIPTION
Fixes the file reference typo in the starter/README:
`examples/basic-jsx-precompiled` (before)
`examples/basic-jsx-precompile` (after)