### PR TITLE
Improve PropTypes.oneOf warning for non-primitive values

### DIFF
--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -217,13 +217,24 @@ function createEnumTypeChecker(expectedValues) {
 
   function validate(props, propName, componentName, location, propFullName) {
     var propValue = props[propName];
+    var locationName = ReactPropTypeLocationNames[location];
+
     for (var i = 0; i < expectedValues.length; i++) {
+      if (expectedValues[i] !== null &&
+        (typeof expectedValues[i] === 'object' || typeof expectedValues[i] === 'function')
+      ) {
+        return new Error(
+          `Invalid ${locationName} \`${propFullName}\` of value \`${propValue}\` ` +
+          `supplied to \`${componentName}\`, \`oneOf\` expects an enum of primitive values. ` +
+          `Did you mean to use \`oneOfType\`?`
+        );
+      }
+
       if (propValue === expectedValues[i]) {
         return null;
       }
     }
 
-    var locationName = ReactPropTypeLocationNames[location];
     var valuesString = JSON.stringify(expectedValues);
     return new Error(
       `Invalid ${locationName} \`${propFullName}\` of value \`${propValue}\` ` +

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -601,6 +601,18 @@ describe('ReactPropTypes', function() {
         'Invalid prop `testProp` of value `false` supplied to ' +
         '`testComponent`, expected one of [0,"false"].'
       );
+      typeCheckFail(
+        PropTypes.oneOf(['red', 'blue']),
+        {},
+        'Invalid prop `testProp` of value `[object Object]` supplied to ' +
+        '`testComponent`, expected one of ["red","blue"].'
+      );
+      typeCheckFail(
+        PropTypes.oneOf(['red', 'blue']),
+        PropTypes.string,
+        'Invalid prop `testProp` of value `function () { [native code] }` supplied to ' +
+        '`testComponent`, expected one of ["red","blue"].'
+      );
     });
 
     it('should not warn for valid values', function() {


### PR DESCRIPTION
The improvement was suggested in facebook/react#1919.