### PR TITLE
addons/bindMethods helper to simplify binding of component handlers

### DIFF
--- a/grunt/tasks/npm-react-addons.js
+++ b/grunt/tasks/npm-react-addons.js
@@ -51,6 +51,10 @@ var addons = {
     module: 'shallowCompare',
     name: 'shallow-compare',
   },
+  bindMethods: {
+    module: 'bindMethods',
+    name: 'bind-methods',
+  },
   updates: {
     module: 'update',
     name: 'update',

--- a/src/addons/ReactWithAddons.js
+++ b/src/addons/ReactWithAddons.js
@@ -29,6 +29,7 @@ var ReactUpdates = require('ReactUpdates');
 
 var cloneWithProps = require('cloneWithProps');
 var shallowCompare = require('shallowCompare');
+var bindMethods = require('bindMethods');
 var update = require('update');
 var warning = require('warning');
 
@@ -54,6 +55,7 @@ React.addons = {
   cloneWithProps: cloneWithProps,
   createFragment: ReactFragment.create,
   shallowCompare: shallowCompare,
+  bindMethods: bindMethods,
   update: update,
 };
 

--- a/src/addons/__tests__/bindMethods-test.js
+++ b/src/addons/__tests__/bindMethods-test.js
@@ -13,8 +13,8 @@
 
 var bindMethods = require('bindMethods');
 
-describe('#bindMethods', function () {
-  beforeEach(function () {
+describe('#bindMethods', function() {
+  beforeEach(function() {
     this.object = {
       count: 1,
 
@@ -24,18 +24,18 @@ describe('#bindMethods', function () {
 
       decrement() {
         this.count--;
-      }
+      },
     };
   });
 
-  it('craches without binding', function () {
+  it('craches without binding', function() {
     const {increment, decrement} = this.object;
 
     expect(() => increment()).toThrow("Cannot read property 'count' of undefined");
     expect(() => decrement()).toThrow("Cannot read property 'count' of undefined");
   });
 
-  it('binds the object correctly', function () {
+  it('binds the object correctly', function() {
     bindMethods(this.object, ['increment', 'decrement']);
     const {increment, decrement} = this.object;
 

--- a/src/addons/__tests__/bindMethods-test.js
+++ b/src/addons/__tests__/bindMethods-test.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var bindMethods = require('bindMethods');
+
+describe('#bindMethods', function () {
+  beforeEach(function () {
+    this.object = {
+      count: 1,
+
+      increment() {
+        this.count++;
+      },
+
+      decrement() {
+        this.count--;
+      }
+    };
+  });
+
+  it('craches without binding', function () {
+    const {increment, decrement} = this.object;
+
+    expect(() => increment()).toThrow("Cannot read property 'count' of undefined");
+    expect(() => decrement()).toThrow("Cannot read property 'count' of undefined");
+  });
+
+  it('binds the object correctly', function () {
+    bindMethods(this.object, ['increment', 'decrement']);
+    const {increment, decrement} = this.object;
+
+    increment(); // +1
+    expect(this.object.count).toBe(2);
+
+    decrement(); // -1
+    expect(this.object.count).toBe(1);
+  });
+});

--- a/src/addons/bindMethods.js
+++ b/src/addons/bindMethods.js
@@ -19,9 +19,9 @@
  * @param {Array} methods names to bind to the given self.
  **/
 function bindMethods(self, methods) {
-	methods.forEach(function (method) {
-		self[method] = self[method].bind(self);
-	});
+  methods.forEach(function(method) {
+    self[method] = self[method].bind(self);
+  });
 }
 
 module.exports = bindMethods;

--- a/src/addons/bindMethods.js
+++ b/src/addons/bindMethods.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+* @providesModule bindMethods
+*/
+
+'use strict';
+
+/**
+ * Helper method to force bind methods to object
+ * This helper simplifies binding compoment's handlers since ES6 Component classes has no autobinding.
+ *
+ * @param {Object} self object with the methods that we want to bind.
+ * @param {Array} methods names to bind to the given self.
+ **/
+function bindMethods(self, methods) {
+	methods.forEach(function (method) {
+		self[method] = self[method].bind(self);
+	});
+}
+
+module.exports = bindMethods;


### PR DESCRIPTION
This helper simplifies the manual binding of handlers on Component classes.

```js
import React, {Component} from 'react';
import bindMethods from 'bindMethods';

class NiceButton extends Component {
   constructor(props) {
      super(props);
      
      // Instead of binding verbosely:
      // this.handleClick = this.handleClick.bind(this);
      // this.handleHover = this.handleHover.bind(this);
      // We can do it in one line using the bindMethods helper:
      bindMethods(this, ['handleClick', 'handleHover']);
   }
   
   handleClick() {
       // do something nice and use "this" for something
       ...
   }

   handleHover() {
       // do something nice and use "this" for something
       ...
   }

   render() {
       // Doing the binding here is worst because every time the component re-render 
       // we would be creating a new function 
       return <button onClick={this.handleClick} onHover={this.handleHover}>...</button>;
   }
}
```