### PR TITLE
Error boundaries

### DIFF
--- a/src/core/__tests__/ReactErrorBoundaries-test.js
+++ b/src/core/__tests__/ReactErrorBoundaries-test.js
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var React;
+var ReactDOM;
+
+describe('ReactErrorBoundaries', function() {
+
+  beforeEach(function() {
+    ReactDOM = require('ReactDOM');
+    React = require('React');
+  });
+
+  it('does not register event handlers for unmounted children', function() {
+    class Angry extends React.Component {
+      render() {
+        throw new Error('Please, do not render me.');
+      }
+    }
+
+    class Boundary extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {error: false};
+      }
+      render() {
+        if (!this.state.error) {
+          return (<div><button onClick={this.onClick}>ClickMe</button><Angry /></div>);
+        } else {
+          return (<div>Happy Birthday!</div>);
+        }
+      }
+      onClick() {
+        /* do nothing */
+      }
+      unstable_handleError() {
+        this.setState({error: true});
+      }
+    }
+
+    var EventPluginHub = require('EventPluginHub');
+    var container = document.createElement('div');
+    EventPluginHub.putListener = jest.genMockFn();
+    ReactDOM.render(<Boundary />, container);
+    expect(EventPluginHub.putListener).not.toBeCalled();
+  });
+
+  it('expect uneventful render to succeed', function() {
+    class Boundary extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {error: false};
+      }
+      render() {
+        return (<div><button onClick={this.onClick}>ClickMe</button></div>);
+      }
+      onClick() {
+        /* do nothing */
+      }
+      unstable_handleError() {
+        this.setState({error: true});
+      }
+    }
+
+    var EventPluginHub = require('EventPluginHub');
+    var container = document.createElement('div');
+    EventPluginHub.putListener = jest.genMockFn();
+    ReactDOM.render(<Boundary />, container);
+    expect(EventPluginHub.putListener).toBeCalled();
+  });
+
+
+  it('catches errors from children', function() {
+    var log = [];
+
+    class Box extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {errorMessage: null};
+      }
+      render() {
+        if (this.state.errorMessage != null) {
+          log.push('Box renderError');
+          return <div>Error: {this.state.errorMessage}</div>;
+        }
+        log.push('Box render');
+        var ref = function(x) {
+          log.push('Inquisitive ref ' + x);
+        };
+        return (
+          <div>
+            <Inquisitive ref={ref} />
+            <Angry />
+          </div>
+        );
+      }
+      unstable_handleError(e) {
+        this.setState({errorMessage: e.message});
+      }
+      componentDidMount() {
+        log.push('Box componentDidMount');
+      }
+      componentWillUnmount() {
+        log.push('Box componentWillUnmount');
+      }
+    }
+
+    class Inquisitive extends React.Component {
+      render() {
+        log.push('Inquisitive render');
+        return <div>What is love?</div>;
+      }
+      componentDidMount() {
+        log.push('Inquisitive componentDidMount');
+      }
+      componentWillUnmount() {
+        log.push('Inquisitive componentWillUnmount');
+      }
+    }
+
+    class Angry extends React.Component {
+      render() {
+        log.push('Angry render');
+        throw new Error('Please, do not render me.');
+      }
+      componentDidMount() {
+        log.push('Angry componentDidMount');
+      }
+      componentWillUnmount() {
+        log.push('Angry componentWillUnmount');
+      }
+    }
+
+    var container = document.createElement('div');
+    ReactDOM.render(<Box />, container);
+    expect(container.textContent).toBe('Error: Please, do not render me.');
+    expect(log).toEqual([
+      'Box render',
+      'Inquisitive render',
+      'Angry render',
+      'Inquisitive ref null',
+      'Inquisitive componentWillUnmount',
+      'Angry componentWillUnmount',
+      'Box renderError',
+      'Box componentDidMount',
+    ]);
+  });
+});

--- a/src/renderers/dom/client/ReactReconcileTransaction.js
+++ b/src/renderers/dom/client/ReactReconcileTransaction.js
@@ -137,6 +137,19 @@ var Mixin = {
   },
 
   /**
+   * Save current transaction state -- if the return value from this method is
+   * passed to `rollback`, the transaction will be reset to that state.
+   */
+  checkpoint: function() {
+    // reactMountReady is the our only stateful wrapper
+    return this.reactMountReady.checkpoint();
+  },
+
+  rollback: function(checkpoint) {
+    this.reactMountReady.rollback(checkpoint);
+  },
+
+  /**
    * `PooledClass` looks for this, and will invoke this before allowing this
    * instance to be reused.
    */

--- a/src/shared/utils/CallbackQueue.js
+++ b/src/shared/utils/CallbackQueue.js
@@ -72,6 +72,17 @@ assign(CallbackQueue.prototype, {
     }
   },
 
+  checkpoint: function() {
+    return this._callbacks ? this._callbacks.length : 0;
+  },
+
+  rollback: function(len) {
+    if (this._callbacks) {
+      this._callbacks.length = len;
+      this._contexts.length = len;
+    }
+  },
+
   /**
    * Resets the internal queue.
    *


### PR DESCRIPTION
Implements error boundaries for initial render, which allow React components to become isolation boundaries.  If a child of an error bounadry crashes, the error boundary has the ability to handle the error and render something different (like an error message or a frown face).  This allows application authors to partition their app into regions, and a crash in a single region won't take down the entire page/application.

Fixes #2461