### PR TITLE
chore(ReactComponentWithPureRenderMixin.js): made "Mixin" lowercase

### DIFF
--- a/src/addons/ReactComponentWithPureRenderMixin.js
+++ b/src/addons/ReactComponentWithPureRenderMixin.js
@@ -15,7 +15,7 @@ var shallowCompare = require('shallowCompare');
 
 /**
  * If your React component's render function is "pure", e.g. it will render the
- * same result given the same props and state, provide this Mixin for a
+ * same result given the same props and state, provide this mixin for a
  * considerable performance boost.
  *
  * Most React components have pure render functions.


### PR DESCRIPTION
When referring to mixin, the rest of the comment is in lowercase; see line 36 and line 37. 
This change helps with the consistency of the usage of "mixin", and not to confuse it with a variable name.