### PR TITLE
Workaround for dealing with exceptions thrown in asynchronous render method

### DIFF
--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -786,7 +786,18 @@ var ReactCompositeComponentMixin = {
    */
   _renderValidatedComponentWithoutOwnerOrContext: function() {
     var inst = this._instance;
-    var renderedComponent = inst.render();
+    var renderedComponent = null;
+    try {
+      renderedComponent = inst.render();
+    } catch (e) {
+      var exceptionCallBack = inst._reactInternalInstance._currentElement.type.prototype.exceptionCallBack;
+      if (typeof exceptionCallBack === 'function') {
+        exceptionCallBack(e);
+        return null;
+      } else {
+        throw e;
+      }
+    }
     if (__DEV__) {
       // We allow auto-mocks to proceed as if they're returning null.
       if (typeof renderedComponent === 'undefined' &&


### PR DESCRIPTION
We provide a workaround for [this](https://github.com/facebook/react/issues/2461) issue by allowing the user to define a callback function to be executed whenever an exception is thrown inside the body of a `render` method. This function should be called `exceptionCallBack`, as in the following example, adapted from [this](https://github.com/facebook/react/issues/5549) issue:

```javascript
var a = false;

var MyComponent = React.createClass({
	render: function() {
		if (this.props.a) {
			throw 'err';
		}

		return (      
			<h1 onClick={ () => {a = true; run()} }>Hello {this.props.name}</h1>      
		);
	},
	exceptionCallBack: function(e) {
		console.log(e);
	}	
});

function run() {
	ReactDOM.render(
		<MyComponent a={a} name={"Rui Cardoso"} />,
		document.getElementById('example')
	);
}

ReactDOM.render(<MyComponent a={false} name={"Rui Cardoso"} />, document.getElementById('example'));
```

This produces the expected result of **err** being logged to the console when the component is clicked.