### PR TITLE
Add hasOwnProperty check inside for..in loops.

### DIFF
--- a/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
@@ -447,7 +447,9 @@ var topLevelEventsToDispatchConfig = {
 };
 
 for (var type in topLevelEventsToDispatchConfig) {
-  topLevelEventsToDispatchConfig[type].dependencies = [type];
+  if (topLevelEventsToDispatchConfig.hasOwnProperty(type)) {
+    topLevelEventsToDispatchConfig[type].dependencies = [type];
+  }
 }
 
 var ON_CLICK_KEY = keyOf({onClick: null});

--- a/src/renderers/dom/shared/DOMProperty.js
+++ b/src/renderers/dom/shared/DOMProperty.js
@@ -74,78 +74,80 @@ var DOMPropertyInjection = {
     }
 
     for (var propName in Properties) {
-      invariant(
-        !DOMProperty.properties.hasOwnProperty(propName),
-        'injectDOMPropertyConfig(...): You\'re trying to inject DOM property ' +
-        '\'%s\' which has already been injected. You may be accidentally ' +
-        'injecting the same DOM property config twice, or you may be ' +
-        'injecting two configs that have conflicting property names.',
-        propName
-      );
+      if (Properties.hasOwnProperty(propName)) {
+        invariant(
+          !DOMProperty.properties.hasOwnProperty(propName),
+          'injectDOMPropertyConfig(...): You\'re trying to inject DOM property ' +
+          '\'%s\' which has already been injected. You may be accidentally ' +
+          'injecting the same DOM property config twice, or you may be ' +
+          'injecting two configs that have conflicting property names.',
+          propName
+        );
 
-      var lowerCased = propName.toLowerCase();
-      var propConfig = Properties[propName];
+        var lowerCased = propName.toLowerCase();
+        var propConfig = Properties[propName];
 
-      var propertyInfo = {
-        attributeName: lowerCased,
-        attributeNamespace: null,
-        propertyName: propName,
-        mutationMethod: null,
+        var propertyInfo = {
+          attributeName: lowerCased,
+          attributeNamespace: null,
+          propertyName: propName,
+          mutationMethod: null,
 
-        mustUseAttribute: checkMask(propConfig, Injection.MUST_USE_ATTRIBUTE),
-        mustUseProperty: checkMask(propConfig, Injection.MUST_USE_PROPERTY),
-        hasSideEffects: checkMask(propConfig, Injection.HAS_SIDE_EFFECTS),
-        hasBooleanValue: checkMask(propConfig, Injection.HAS_BOOLEAN_VALUE),
-        hasNumericValue: checkMask(propConfig, Injection.HAS_NUMERIC_VALUE),
-        hasPositiveNumericValue:
-          checkMask(propConfig, Injection.HAS_POSITIVE_NUMERIC_VALUE),
-        hasOverloadedBooleanValue:
-          checkMask(propConfig, Injection.HAS_OVERLOADED_BOOLEAN_VALUE),
-      };
+          mustUseAttribute: checkMask(propConfig, Injection.MUST_USE_ATTRIBUTE),
+          mustUseProperty: checkMask(propConfig, Injection.MUST_USE_PROPERTY),
+          hasSideEffects: checkMask(propConfig, Injection.HAS_SIDE_EFFECTS),
+          hasBooleanValue: checkMask(propConfig, Injection.HAS_BOOLEAN_VALUE),
+          hasNumericValue: checkMask(propConfig, Injection.HAS_NUMERIC_VALUE),
+          hasPositiveNumericValue:
+            checkMask(propConfig, Injection.HAS_POSITIVE_NUMERIC_VALUE),
+          hasOverloadedBooleanValue:
+            checkMask(propConfig, Injection.HAS_OVERLOADED_BOOLEAN_VALUE),
+        };
 
-      invariant(
-        !propertyInfo.mustUseAttribute || !propertyInfo.mustUseProperty,
-        'DOMProperty: Cannot require using both attribute and property: %s',
-        propName
-      );
-      invariant(
-        propertyInfo.mustUseProperty || !propertyInfo.hasSideEffects,
-        'DOMProperty: Properties that have side effects must use property: %s',
-        propName
-      );
-      invariant(
-        propertyInfo.hasBooleanValue + propertyInfo.hasNumericValue +
-          propertyInfo.hasOverloadedBooleanValue <= 1,
-        'DOMProperty: Value can be one of boolean, overloaded boolean, or ' +
-        'numeric value, but not a combination: %s',
-        propName
-      );
+        invariant(
+          !propertyInfo.mustUseAttribute || !propertyInfo.mustUseProperty,
+          'DOMProperty: Cannot require using both attribute and property: %s',
+          propName
+        );
+        invariant(
+          propertyInfo.mustUseProperty || !propertyInfo.hasSideEffects,
+          'DOMProperty: Properties that have side effects must use property: %s',
+          propName
+        );
+        invariant(
+          propertyInfo.hasBooleanValue + propertyInfo.hasNumericValue +
+            propertyInfo.hasOverloadedBooleanValue <= 1,
+          'DOMProperty: Value can be one of boolean, overloaded boolean, or ' +
+          'numeric value, but not a combination: %s',
+          propName
+        );
 
-      if (__DEV__) {
-        DOMProperty.getPossibleStandardName[lowerCased] = propName;
-      }
-
-      if (DOMAttributeNames.hasOwnProperty(propName)) {
-        var attributeName = DOMAttributeNames[propName];
-        propertyInfo.attributeName = attributeName;
         if (__DEV__) {
-          DOMProperty.getPossibleStandardName[attributeName] = propName;
+          DOMProperty.getPossibleStandardName[lowerCased] = propName;
         }
-      }
 
-      if (DOMAttributeNamespaces.hasOwnProperty(propName)) {
-        propertyInfo.attributeNamespace = DOMAttributeNamespaces[propName];
-      }
+        if (DOMAttributeNames.hasOwnProperty(propName)) {
+          var attributeName = DOMAttributeNames[propName];
+          propertyInfo.attributeName = attributeName;
+          if (__DEV__) {
+            DOMProperty.getPossibleStandardName[attributeName] = propName;
+          }
+        }
 
-      if (DOMPropertyNames.hasOwnProperty(propName)) {
-        propertyInfo.propertyName = DOMPropertyNames[propName];
-      }
+        if (DOMAttributeNamespaces.hasOwnProperty(propName)) {
+          propertyInfo.attributeNamespace = DOMAttributeNamespaces[propName];
+        }
 
-      if (DOMMutationMethods.hasOwnProperty(propName)) {
-        propertyInfo.mutationMethod = DOMMutationMethods[propName];
-      }
+        if (DOMPropertyNames.hasOwnProperty(propName)) {
+          propertyInfo.propertyName = DOMPropertyNames[propName];
+        }
 
-      DOMProperty.properties[propName] = propertyInfo;
+        if (DOMMutationMethods.hasOwnProperty(propName)) {
+          propertyInfo.mutationMethod = DOMMutationMethods[propName];
+        }
+
+        DOMProperty.properties[propName] = propertyInfo;
+      }
     }
   },
 };

--- a/src/renderers/shared/event/EventPluginRegistry.js
+++ b/src/renderers/shared/event/EventPluginRegistry.js
@@ -35,36 +35,40 @@ function recomputePluginOrdering() {
     return;
   }
   for (var pluginName in namesToPlugins) {
-    var PluginModule = namesToPlugins[pluginName];
-    var pluginIndex = EventPluginOrder.indexOf(pluginName);
-    invariant(
-      pluginIndex > -1,
-      'EventPluginRegistry: Cannot inject event plugins that do not exist in ' +
-      'the plugin ordering, `%s`.',
-      pluginName
-    );
-    if (EventPluginRegistry.plugins[pluginIndex]) {
-      continue;
-    }
-    invariant(
-      PluginModule.extractEvents,
-      'EventPluginRegistry: Event plugins must implement an `extractEvents` ' +
-      'method, but `%s` does not.',
-      pluginName
-    );
-    EventPluginRegistry.plugins[pluginIndex] = PluginModule;
-    var publishedEvents = PluginModule.eventTypes;
-    for (var eventName in publishedEvents) {
+    if (namesToPlugins.hasOwnProperty(pluginName)) {
+      var PluginModule = namesToPlugins[pluginName];
+      var pluginIndex = EventPluginOrder.indexOf(pluginName);
       invariant(
-        publishEventForPlugin(
-          publishedEvents[eventName],
-          PluginModule,
-          eventName
-        ),
-        'EventPluginRegistry: Failed to publish event `%s` for plugin `%s`.',
-        eventName,
+        pluginIndex > -1,
+        'EventPluginRegistry: Cannot inject event plugins that do not exist in ' +
+        'the plugin ordering, `%s`.',
         pluginName
       );
+      if (EventPluginRegistry.plugins[pluginIndex]) {
+        continue;
+      }
+      invariant(
+        PluginModule.extractEvents,
+        'EventPluginRegistry: Event plugins must implement an `extractEvents` ' +
+        'method, but `%s` does not.',
+        pluginName
+      );
+      EventPluginRegistry.plugins[pluginIndex] = PluginModule;
+      var publishedEvents = PluginModule.eventTypes;
+      for (var eventName in publishedEvents) {
+        if (publishedEvents.hasOwnProperty(eventName)) {
+          invariant(
+            publishEventForPlugin(
+              publishedEvents[eventName],
+              PluginModule,
+              eventName
+            ),
+            'EventPluginRegistry: Failed to publish event `%s` for plugin `%s`.',
+            eventName,
+            pluginName
+          );
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
React initialization will fail if the JS Object prototype is extended
before React is loaded. I've added hasOwnProperty checks in the `for..in` loops that were triggering the exception.

You can check this example: https://jsfiddle.net/cpjnq10z/