### PR TITLE
Reject non-objects in spec/key path

### DIFF
--- a/src/addons/__tests__/update-test.js
+++ b/src/addons/__tests__/update-test.js
@@ -79,6 +79,24 @@ describe('update', function() {
     });
   });
 
+  it('should reject malformed specs', function() {
+    var wrongSpecs = [
+      null,
+      false,
+      [],
+      [[]],
+      {a: {b: [[]]}},
+    ];
+
+    wrongSpecs.forEach(function(spec) {
+      expect(update.bind(null, {a: 'b'}, spec)).toThrow(
+        'update(): You provided a key path to update() that did not contain ' +
+        'one of $push, $unshift, $splice, $set, $merge, $apply. Did you ' +
+        'forget to include {$set: ...}?'
+      );
+    });
+  });
+
   it('should require a command', function() {
     expect(update.bind(null, {a: 'b'}, {a: 'c'})).toThrow(
       'update(): You provided a key path to update() that did not contain ' +

--- a/src/addons/__tests__/update-test.js
+++ b/src/addons/__tests__/update-test.js
@@ -79,30 +79,36 @@ describe('update', function() {
     });
   });
 
-  it('should reject malformed specs', function() {
-    var wrongSpecs = [
-      null,
-      false,
+  it('should reject arrays and specs containing arrays', function() {
+    var specs = [
       [],
-      [[]],
-      {a: {b: [[]]}},
+      {a: []},
+      {a: {$set: 1}, b: [[]]},
     ];
-
-    wrongSpecs.forEach(function(spec) {
+    specs.forEach(function(spec) {
       expect(update.bind(null, {a: 'b'}, spec)).toThrow(
-        'update(): You provided a key path to update() that did not contain ' +
-        'one of $push, $unshift, $splice, $set, $merge, $apply. Did you ' +
-        'forget to include {$set: ...}?'
+        'update(): You provided an invalid spec to update(). The spec ' +
+        'may not contain an array except as the value of $set, $push, ' +
+        '$unshift or $splice.'
       );
     });
   });
 
-  it('should require a command', function() {
-    expect(update.bind(null, {a: 'b'}, {a: 'c'})).toThrow(
-      'update(): You provided a key path to update() that did not contain ' +
-      'one of $push, $unshift, $splice, $set, $merge, $apply. Did you ' +
-      'forget to include {$set: ...}?'
-    );
+  it('should require a plain object spec containing command(s)', function() {
+    var specs = [
+      null,
+      false,
+      {a: 'c'},
+      {a: {b: 'c'}},
+    ];
+    specs.forEach(function(spec) {
+      expect(update.bind(null, {a: 'b'}, spec)).toThrow(
+        'update(): You provided an invalid spec to update(). The spec ' +
+        'and every included key path must be plain objects containing one ' +
+        'of the following commands: $push, $unshift, $splice, $set, ' +
+        '$merge, $apply.'
+      );
+    });
   });
 
   it('should perform safe hasOwnProperty check', function() {

--- a/src/addons/update.js
+++ b/src/addons/update.js
@@ -69,11 +69,18 @@ function invariantArrayCase(value, spec, command) {
 
 function update(value, spec) {
   invariant(
-    typeof spec === 'object' && spec !== null && !Array.isArray(spec),
-    'update(): You provided a key path to update() that did not contain one ' +
-    'of %s. Did you forget to include {%s: ...}?',
-    ALL_COMMANDS_LIST.join(', '),
-    COMMAND_SET
+    !Array.isArray(spec),
+    'update(): You provided an invalid spec to update(). The spec may ' +
+    'not contain an array except as the value of $set, $push, $unshift ' +
+    'or $splice.'
+  );
+
+  invariant(
+    typeof spec === 'object' && spec !== null,
+    'update(): You provided an invalid spec to update(). The spec and ' +
+    'every included key path must be plain objects containing one of the ' +
+    'following commands: %s.',
+    ALL_COMMANDS_LIST.join(', ')
   );
 
   if (hasOwnProperty.call(spec, COMMAND_SET)) {

--- a/src/addons/update.js
+++ b/src/addons/update.js
@@ -69,7 +69,7 @@ function invariantArrayCase(value, spec, command) {
 
 function update(value, spec) {
   invariant(
-    typeof spec === 'object',
+    typeof spec === 'object' && spec !== null && !Array.isArray(spec),
     'update(): You provided a key path to update() that did not contain one ' +
     'of %s. Did you forget to include {%s: ...}?',
     ALL_COMMANDS_LIST.join(', '),


### PR DESCRIPTION
The `update` function currently accepts various malformed inputs in its `spec` parameter, leading to bad error reporting or buggy behaviour:

```js
update({a:[1, 2]}, null); 
// TypeError: Cannot convert undefined or null to object

update({a:[]}, []); 
// no error

update({a:[]}, [[]]); 
// {0: undefined, a: []}

update({a:[1, 2]}, {a: {$slice: [[0,1]]}}) 
// TypeError: Cannot read property '0' of undefined

```

This PR strengthens the first `invariant` in order to reject any spec/key path that is not a plain object.