### PR TITLE
Remove warning about maps

### DIFF
--- a/src/shared/utils/traverseAllChildren.js
+++ b/src/shared/utils/traverseAllChildren.js
@@ -150,15 +150,6 @@ function traverseAllChildrenImpl(
           );
         }
       } else {
-        if (__DEV__) {
-          warning(
-            didWarnAboutMaps,
-            'Using Maps as children is not yet fully supported. It is an ' +
-            'experimental feature that might be removed. Convert it to a ' +
-            'sequence / iterable of keyed ReactElements instead.'
-          );
-          didWarnAboutMaps = true;
-        }
         // Iterator will provide entry [k,v] tuples rather than values.
         while (!(step = iterator.next()).done) {
           var entry = step.value;


### PR DESCRIPTION
This is now officially a part of the standard: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map