### PR TITLE
Make StatelessComponent work with ReactTestUtils

### DIFF
--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -911,9 +911,8 @@ ReactPerf.measureMethods(
 );
 
 var ReactCompositeComponent = {
-
   Mixin: ReactCompositeComponentMixin,
-
+  StatelessComponent: StatelessComponent,
 };
 
 module.exports = ReactCompositeComponent;

--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -42,7 +42,7 @@ function findAllInRenderedTreeInternal(inst, test) {
   if (!inst || !inst.getPublicInstance) {
     return [];
   }
-  var publicInst = inst.getPublicInstance();
+  var publicInst = (inst._instance != null && inst._instance instanceof ReactCompositeComponent.StatelessComponent) ? inst._instance : inst.getPublicInstance();
   var ret = test(publicInst) ? [publicInst] : [];
   var currentElement = inst._currentElement;
   if (ReactTestUtils.isDOMComponent(publicInst)) {
@@ -113,9 +113,14 @@ var ReactTestUtils = {
       // this returns when we have DOM nodes as refs directly
       return false;
     }
-    return inst != null &&
-           typeof inst.render === 'function' &&
-           typeof inst.setState === 'function';
+    return (
+      inst != null &&
+      (
+        typeof inst.render === 'function' &&
+        typeof inst.setState === 'function' ||
+        inst instanceof ReactCompositeComponent.StatelessComponent
+      )
+    );
   },
 
   isCompositeComponentWithType: function(inst, type) {
@@ -139,7 +144,8 @@ var ReactTestUtils = {
     var prototype = inst.type.prototype;
     return (
       typeof prototype.render === 'function' &&
-      typeof prototype.setState === 'function'
+      typeof prototype.setState === 'function' ||
+      prototype === ReactCompositeComponent.StatelessComponent
     );
   },
 

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -503,4 +503,15 @@ describe('ReactTestUtils', function() {
     expect(hrs.length).toBe(2);
   });
 
+  it('can find stateless components by type', function() {
+    var Stateless = () => <div></div>;
+    var SomeComponent = React.createClass({
+      render: function() {
+        return <Stateless />;
+      },
+    });
+    var inst = ReactTestUtils.renderIntoDocument(<SomeComponent />);
+    var result = ReactTestUtils.findRenderedComponentWithType(inst, Stateless);
+    expect(result).toBeDefined();
+  });
 });


### PR DESCRIPTION
ReactTestUtils doesn't recognize StatelessComponent as a CompositeComponent right now and doesn't add it to the list of components found by findAllInRenderedTree.

This makes ReactTestUtils recognize StatelessComponents as composite components and makes findAllInRenderedTree push the instance correctly.

Fixes https://github.com/facebook/react/issues/5555