### PR TITLE
Bugfix - Typos

### DIFF
--- a/docs/_posts/2013-10-3-community-roundup-9.md
+++ b/docs/_posts/2013-10-3-community-roundup-9.md
@@ -56,7 +56,7 @@ The video will be available soon on the [JSConf EU website](http://2013.jsconf.e
 
 [Todd Kennedy](http://blog.selfassembled.org/) working at [Cond&eacute; Nast](http://www.condenast.com/) implemented a wrapper on-top of [JSHint](http://www.jshint.com/) that first converts JSX files to JS.
 
-> A wrapper around JSHint to allow linting of files containg JSX syntax. Accepts glob patterns. Respects your local .jshintrc file and .gitignore to filter your glob patterns.
+> A wrapper around JSHint to allow linting of files containing JSX syntax. Accepts glob patterns. Respects your local .jshintrc file and .gitignore to filter your glob patterns.
 >
 > ```
 npm install -g jsxhint

--- a/docs/_posts/2014-01-06-community-roundup-14.md
+++ b/docs/_posts/2014-01-06-community-roundup-14.md
@@ -13,7 +13,7 @@ React is only one-piece of your web application stack. [Mark Lussier](https://gi
 >
 > I encourage you to fork, and make it right and submit a pull request!
 >
-> My current opinion is using tools like Grunt, Browserify, Bower and mutiple grunt plugins to get the job done. I also opted for Zepto over jQuery and the Flatiron Project's Director when I need a router. Oh and for the last little bit of tech that makes you mad, I am in the SASS camp when it comes to stylesheets
+> My current opinion is using tools like Grunt, Browserify, Bower and multiple grunt plugins to get the job done. I also opted for Zepto over jQuery and the Flatiron Project's Director when I need a router. Oh and for the last little bit of tech that makes you mad, I am in the SASS camp when it comes to stylesheets
 >
 > [Check it out on GitHub...](https://github.com/intabulas/reactjs-baseline)
 

--- a/docs/_posts/2014-02-16-react-v0.9-rc1.md
+++ b/docs/_posts/2014-02-16-react-v0.9-rc1.md
@@ -49,7 +49,7 @@ React.DOM.div(null,
 )
 ```
 
-We believe this new behavior is more helpful and elimates cases where unwanted whitespace was previously added.
+We believe this new behavior is more helpful and eliminates cases where unwanted whitespace was previously added.
 
 In cases where you want to preserve the space adjacent to a newline, you can write a JS string like `{"Monkeys: "}` in your JSX source. We've included a script to do an automated codemod of your JSX source tree that preserves the old whitespace behavior by adding and removing spaces appropriately. You can [install jsx\_whitespace\_transformer from npm](https://github.com/facebook/react/blob/master/npm-jsx_whitespace_transformer/README.md) and run it over your source tree to modify files in place. The transformed JSX files will preserve your code's existing whitespace behavior.
 

--- a/docs/_posts/2014-02-20-react-v0.9.md
+++ b/docs/_posts/2014-02-20-react-v0.9.md
@@ -57,7 +57,7 @@ React.DOM.div(null,
 )
 ```
 
-We believe this new behavior is more helpful and elimates cases where unwanted whitespace was previously added.
+We believe this new behavior is more helpful and eliminates cases where unwanted whitespace was previously added.
 
 In cases where you want to preserve the space adjacent to a newline, you can write `{'Monkeys: '}` or `Monkeys:{' '}` in your JSX source. We've included a script to do an automated codemod of your JSX source tree that preserves the old whitespace behavior by adding and removing spaces appropriately. You can [install jsx\_whitespace\_transformer from npm](https://github.com/facebook/react/blob/master/npm-jsx_whitespace_transformer/README.md) and run it over your source tree to modify files in place. The transformed JSX files will preserve your code's existing whitespace behavior.
 

--- a/docs/css/codemirror.css
+++ b/docs/css/codemirror.css
@@ -5,7 +5,7 @@
   font-family: monospace;
 }
 .CodeMirror-scroll {
-  /* Set scrolling behaviour here */
+  /* Set scrolling behavior here */
   overflow: auto;
 }
 
@@ -122,7 +122,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 }
 
 /* The fake, visible scrollbars. Used to force redraw during scrolling
-   before actuall scrolling happens, thus preventing shaking and
+   before actual scrolling happens, thus preventing shaking and
    flickering artifacts. */
 .CodeMirror-vscrollbar, .CodeMirror-hscrollbar, .CodeMirror-scrollbar-filler {
   position: absolute;

--- a/eslint-rules/warning-and-invariant-args.js
+++ b/eslint-rules/warning-and-invariant-args.js
@@ -17,7 +17,7 @@
  */
 
 module.exports = function(context) {
-  // we also allow literal strings and concatinated literal strings
+  // we also allow literal strings and concatenated literal strings
   function getLiteralString(node) {
     if (node.type === 'Literal' && typeof node.value === 'string') {
       return node.value;
@@ -67,7 +67,7 @@ module.exports = function(context) {
         );
         return;
       }
-      // count the number of formating substitutions, plus the first two args
+      // count the number of formatting substitutions, plus the first two args
       var expectedNArgs = (format.match(/%s/g) || []).length + 2;
       if (node.arguments.length !== expectedNArgs) {
         context.report(

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -19,7 +19,7 @@ var babelPluginDEV = require('fbjs-scripts/babel/dev-expression');
 var babelPluginModules = require('fbjs-scripts/babel/rewrite-modules');
 var createCacheKeyFunction = require('fbjs-scripts/jest/createCacheKeyFunction');
 
-// Use require.resolve to be resiliant to file moves, npm updates, etc
+// Use require.resolve to be resilient to file moves, npm updates, etc
 var pathToBabel = path.join(require.resolve('babel'), '..', 'package.json');
 var pathToModuleMap = require.resolve('fbjs/module-map');
 var pathToBabelPluginDev = require.resolve('fbjs-scripts/babel/dev-expression');

--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -433,7 +433,7 @@ function validateMethodOverride(proto, name) {
 
 /**
  * Mixin helper which handles policy validation and reserved
- * specification keys when building React classses.
+ * specification keys when building React classes.
  */
 function mixSpecIntoComponent(Constructor, spec) {
   if (!spec) {

--- a/src/isomorphic/classic/element/__tests__/ReactElement-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElement-test.js
@@ -213,7 +213,7 @@ describe('ReactElement', function() {
   it('allows the use of PropTypes validators in statics', function() {
     // TODO: This test was added to cover a special case where we proxied
     // methods. However, we don't do that any more so this test can probably
-    // be removed. Leaving it in classic as a safety precausion.
+    // be removed. Leaving it in classic as a safety precaution.
     var Component = React.createClass({
       render: () => null,
       statics: {

--- a/src/renderers/dom/client/ReactDOMSelection.js
+++ b/src/renderers/dom/client/ReactDOMSelection.js
@@ -162,7 +162,7 @@ function setIEOffsets(node, offsets) {
  *
  * Note: IE10+ supports the Selection object, but it does not support
  * the `extend` method, which means that even in modern IE, it's not possible
- * to programatically create a backward selection. Thus, for all IE
+ * to programmatically create a backward selection. Thus, for all IE
  * versions, we use the old IE API to create our selections.
  *
  * @param {DOMElement|DOMTextNode} node

--- a/src/renderers/dom/client/__tests__/ReactDOMTreeTraversal-test.js
+++ b/src/renderers/dom/client/__tests__/ReactDOMTreeTraversal-test.js
@@ -135,7 +135,7 @@ describe('ReactDOMTreeTraversal', function() {
       var enter = getInst(parent.refs.P_P1_C1.refs.DIV_2);
       var expectedAggregation = [
         {node: parent.refs.P_P1_C1.refs.DIV_1, isUp: true, arg: ARG},
-        // enter/leave shouldn't fire antyhing on the parent
+        // enter/leave shouldn't fire anything on the parent
         {node: parent.refs.P_P1_C1.refs.DIV_2, isUp: false, arg: ARG2},
       ];
       ReactDOMTreeTraversal.traverseEnterLeave(
@@ -245,7 +245,7 @@ describe('ReactDOMTreeTraversal', function() {
           two: parent.refs.P_P1,
           com: parent.refs.P_P1,
         },
-        // Grantparent across subcomponent boundaries.
+        // Grandparent across subcomponent boundaries.
         {
           one: parent.refs.P_P1_C1.refs.DIV_1,
           two: parent.refs.P_P1_C2.refs.DIV_1,

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -91,7 +91,7 @@ function friendlyStringify(obj) {
   } else if (typeof obj === 'function') {
     return '[function object]';
   }
-  // Differs from JSON.stringify in that undefined becauses undefined and that
+  // Differs from JSON.stringify in that undefined because undefined and that
   // inf and nan don't become null
   return String(obj);
 }
@@ -929,7 +929,7 @@ ReactDOMComponent.Mixin = {
           DOMProperty.isCustomAttribute(propKey)) {
         var node = getNode(this);
         // If we're updating to null or undefined, we should remove the property
-        // from the DOM node instead of inadvertantly setting to a string. This
+        // from the DOM node instead of inadvertently setting to a string. This
         // brings us in line with the same behavior we have on initial render.
         if (nextProp != null) {
           DOMPropertyOperations.setValueForProperty(node, propKey, nextProp);

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -242,7 +242,7 @@ describe('ReactDOMComponent', function() {
     it('should skip child object attribute on web components', function() {
       var container = document.createElement('div');
 
-      // Test intial render to null
+      // Test initial render to null
       ReactDOM.render(<my-component children={['foo']} />, container);
       expect(container.firstChild.hasAttribute('children')).toBe(false);
 
@@ -920,7 +920,7 @@ describe('ReactDOMComponent', function() {
   describe('onScroll warning', function() {
     it('should warn about the `onScroll` issue when unsupported (IE8)', () => {
       // Mock this here so we can mimic IE8 support. We require isEventSupported
-      // before React so it's pre-mocked before React qould require it.
+      // before React so it's pre-mocked before React would require it.
       jest.resetModuleRegistry()
         .mock('isEventSupported');
       var isEventSupported = require('isEventSupported');

--- a/src/renderers/shared/event/eventPlugins/ResponderEventPlugin.js
+++ b/src/renderers/shared/event/eventPlugins/ResponderEventPlugin.js
@@ -156,7 +156,7 @@ var eventTypes = {
  *   interaction is no longer locked to it - the system has taken over.
  *
  * - Responder being released:
- *   As soon as no more touches that *started* inside of descendents of the
+ *   As soon as no more touches that *started* inside of descendants of the
  *   *current* responderInst, an `onResponderRelease` event is dispatched to the
  *   current responder, and the responder lock is released.
  *

--- a/src/test/MetaMatchers.js
+++ b/src/test/MetaMatchers.js
@@ -20,7 +20,7 @@
 function getRunnerWithResults(describeFunction) {
   if (describeFunction._cachedRunner) {
     // Cached result of execution. This is a convenience way to test against
-    // the same authorative function multiple times.
+    // the same authoritative function multiple times.
     return describeFunction._cachedRunner;
   }
   // Patch the current global environment.


### PR DESCRIPTION
Fix few typos in React docs and comments.

I am unsure about modifying posts that are in `docs/_posts/`, as those are kinda already posted, but since those are in repo where people read 'em, I think those should still get fixed. This can be easily reverted, though, if needed.