### PR TITLE
Correct highlight in tutorial7.js snippet

### DIFF
--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -248,7 +248,7 @@ But there's a problem! Our rendered comments look like this in the browser: "`<p
 
 That's React protecting you from an [XSS attack](https://en.wikipedia.org/wiki/Cross-site_scripting). There's a way to get around it but the framework warns you not to use it:
 
-```javascript{4,14}
+```javascript{3-6,14}
 // tutorial7.js
 var Comment = React.createClass({
   rawMarkup: function() {


### PR DESCRIPTION
The entire rawMarkup property should be highlighted as it is its first occurrence in the tutorial