### PR TITLE
Clarify dependency installation

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -27,11 +27,18 @@ ReactDOM.render(
 );
 ```
 
-To install React DOM and build your bundle after installing browserify:
+To install React DOM and build your bundle with browserify:
 
 ```sh
 $ npm install --save react react-dom babelify babel-preset-react
 $ browserify -t [ babelify --presets [ react ] ] main.js -o bundle.js
+```
+
+To install React DOM and build your bundle with webpack:  
+
+```sh
+$ npm install --save react react-dom babel-preset-react
+$ webpack
 ```
 
 > Note:


### PR DESCRIPTION
- Split browserify and webpack to separate sections
- Remove `babelify` from the webpack section since it's only for browserify

