### PR TITLE
fixed docs on ReactElement that were out of sync with code

### DIFF
--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -30,8 +30,10 @@ var RESERVED_PROPS = {
 };
 
 /**
- * Base constructor for all React elements. This is only used to make this
- * work with a dynamic instanceof check. Nothing should live on this prototype.
+ * Factory method to create a new React element. This no longer adheres to
+ * the class pattern, so do not use new to call it. Also, no instanceof check
+ * will work. Instead test $$typeof field against Symbol.for('react.element') to check
+ * if something is a React Element.
  *
  * @param {*} type
  * @param {*} key


### PR DESCRIPTION
Due to this commit

https://github.com/facebook/react/commit/750338ef4794af164d452d7560cb97a558c56d3c

docs on ReactElement

https://github.com/facebook/react/blob/master/src/isomorphic/classic/element/ReactElement.js#L33

diverge from implementation

https://github.com/facebook/react/blob/master/src/isomorphic/classic/element/ReactElement.js#L50

as ReactElement no longer is a constructor function.