### PR TITLE
Set value by setAttribute(value) for html input box for #4618

### DIFF
--- a/src/renderers/dom/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMInput.js
@@ -74,7 +74,7 @@ var ReactDOMInput = {
     }, props, {
       defaultChecked: undefined,
       defaultValue: undefined,
-      value: value != null ? value : inst._wrapperState.initialValue,
+      value: value != null ? value : props.defaultValue,
       checked: checked != null ? checked : inst._wrapperState.initialChecked,
       onChange: inst._wrapperState.onChange,
     });
@@ -137,10 +137,8 @@ var ReactDOMInput = {
       warnIfValueIsNull(props);
     }
 
-    var defaultValue = props.defaultValue;
     inst._wrapperState = {
       initialChecked: props.defaultChecked || false,
-      initialValue: defaultValue != null ? defaultValue : null,
       listeners: null,
       onChange: _handleChange.bind(inst),
     };
@@ -165,13 +163,16 @@ var ReactDOMInput = {
 
     var value = LinkedValueUtils.getValue(props);
     if (value != null) {
+      var node = ReactDOMComponentTree.getNodeFromInstance(inst);
+
       // Cast `value` to a string to ensure the value is set correctly. While
       // browsers typically do this as necessary, jsdom doesn't.
-      DOMPropertyOperations.setValueForProperty(
-        ReactDOMComponentTree.getNodeFromInstance(inst),
-        'value',
-        '' + value
-      );
+      var newValue = '' + value;
+
+      // To avoid side effects (such as losing text selection), only set value if changed
+      if (newValue !== node.value) {
+        node.value = newValue;
+      }
     }
   },
 };

--- a/src/renderers/dom/client/wrappers/ReactDOMTextarea.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMTextarea.js
@@ -11,7 +11,6 @@
 
 'use strict';
 
-var DOMPropertyOperations = require('DOMPropertyOperations');
 var LinkedValueUtils = require('LinkedValueUtils');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var ReactUpdates = require('ReactUpdates');
@@ -66,12 +65,46 @@ var ReactDOMTextarea = {
       '`dangerouslySetInnerHTML` does not make sense on <textarea>.'
     );
 
-    // Always set children to the same thing. In IE9, the selection range will
-    // get reset if `textContent` is mutated.
+    var value = LinkedValueUtils.getValue(props);
+
+    // only bother fetching default value if we're going to use it
+    if (value == null) {
+      var defaultValue = props.defaultValue;
+      // TODO (yungsters): Remove support for children content in <textarea>.
+      var children = props.children;
+      if (children != null) {
+        if (__DEV__) {
+          warning(
+            false,
+            'Use the `defaultValue` or `value` props instead of setting ' +
+            'children on <textarea>.'
+          );
+        }
+        invariant(
+          defaultValue == null,
+          'If you supply `defaultValue` on a <textarea>, do not pass children.'
+        );
+        if (Array.isArray(children)) {
+          invariant(
+            children.length <= 1,
+            '<textarea> can only have at most one child.'
+          );
+          children = children[0];
+        }
+
+        defaultValue = '' + children;
+      }
+      if (defaultValue == null) {
+        defaultValue = '';
+      }
+    }
+
+    // The value can be a boolean or object so that's why it's
+    // forced to be a string.
     var nativeProps = assign({}, props, {
-      defaultValue: undefined,
+      defaultValue: '' + (value != null ? value : defaultValue),
       value: undefined,
-      children: inst._wrapperState.initialValue,
+      children: undefined,
       onChange: inst._wrapperState.onChange,
     });
 
@@ -110,41 +143,7 @@ var ReactDOMTextarea = {
       warnIfValueIsNull(props);
     }
 
-    var defaultValue = props.defaultValue;
-    // TODO (yungsters): Remove support for children content in <textarea>.
-    var children = props.children;
-    if (children != null) {
-      if (__DEV__) {
-        warning(
-          false,
-          'Use the `defaultValue` or `value` props instead of setting ' +
-          'children on <textarea>.'
-        );
-      }
-      invariant(
-        defaultValue == null,
-        'If you supply `defaultValue` on a <textarea>, do not pass children.'
-      );
-      if (Array.isArray(children)) {
-        invariant(
-          children.length <= 1,
-          '<textarea> can only have at most one child.'
-        );
-        children = children[0];
-      }
-
-      defaultValue = '' + children;
-    }
-    if (defaultValue == null) {
-      defaultValue = '';
-    }
-    var value = LinkedValueUtils.getValue(props);
     inst._wrapperState = {
-      // We save the initial value so that `ReactDOMComponent` doesn't update
-      // `textContent` (unnecessary since we update value).
-      // The initial value can be a boolean or object so that's why it's
-      // forced to be a string.
-      initialValue: '' + (value != null ? value : defaultValue),
       listeners: null,
       onChange: _handleChange.bind(inst),
     };
@@ -159,13 +158,16 @@ var ReactDOMTextarea = {
 
     var value = LinkedValueUtils.getValue(props);
     if (value != null) {
+      var node = ReactDOMComponentTree.getNodeFromInstance(inst);
+
       // Cast `value` to a string to ensure the value is set correctly. While
       // browsers typically do this as necessary, jsdom doesn't.
-      DOMPropertyOperations.setValueForProperty(
-        ReactDOMComponentTree.getNodeFromInstance(inst),
-        'value',
-        '' + value
-      );
+      var newValue = '' + value;
+
+      // To avoid side effects (such as losing text selection), only set value if changed
+      if (newValue !== node.value) {
+        node.value = newValue;
+      }
     }
   },
 };

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
@@ -59,8 +59,7 @@ describe('ReactDOMInput', function() {
   it('should update `defaultValue` for uncontrolled input', function() {
     var container = document.createElement('div');
 
-    var el = ReactDOM.render(<input type="text" defaultValue="0" />, container);
-    var node = ReactDOM.findDOMNode(el);
+    var node = ReactDOM.render(<input type="text" defaultValue="0" />, container);
 
     expect(node.value).toBe('0');
 
@@ -69,47 +68,10 @@ describe('ReactDOMInput', function() {
     expect(node.value).toBe('1');
   });
 
-  it('should take `defaultValue` for a controlled input', function() {
-    var container = document.createElement('div');
-
-    var el = ReactDOM.render(<input type="text" value={null} defaultValue="0" />, container);
-    var node = ReactDOM.findDOMNode(el);
-
-    expect(node.value).toBe('0');
-
-    ReactDOM.render(<input type="text" value={null} defaultValue="1" />, container);
-
-    expect(node.value).toBe('1');
-
-    ReactDOM.render(<input type="text" value={3} defaultValue="2" />, container);
-
-    expect(node.value).toBe('3');
-
-    ReactDOM.render(<input type="text" value={5} defaultValue="4" />, container);
-
-    expect(node.value).toBe('5');
-    expect(node.getAttribute('value')).toBe('5');
-    expect(node.defaultValue).toBe('5');
-  });
-
-  it('should update `value` when changing to controlled input', function() {
-    var container = document.createElement('div');
-
-    var el = ReactDOM.render(<input type="text" defaultValue="0" />, container);
-    var node = ReactDOM.findDOMNode(el);
-
-    expect(node.value).toBe('0');
-
-    ReactDOM.render(<input type="text" value="1" defaultValue="0" />, container);
-
-    expect(node.value).toBe('1');
-  });
-
   it('should take `defaultValue` when changing to uncontrolled input', function() {
     var container = document.createElement('div');
 
-    var el = ReactDOM.render(<input type="text" value="0" readOnly="true" />, container);
-    var node = ReactDOM.findDOMNode(el);
+    var node = ReactDOM.render(<input type="text" value="0" readOnly="true" />, container);
 
     expect(node.value).toBe('0');
 
@@ -143,8 +105,7 @@ describe('ReactDOMInput', function() {
   it('should allow setting `value` to `true`', function() {
     var container = document.createElement('div');
     var stub = <input type="text" value="yolo" onChange={emptyFunction} />;
-    stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    var node = ReactDOM.render(stub, container);
 
     expect(node.value).toBe('yolo');
 
@@ -158,8 +119,7 @@ describe('ReactDOMInput', function() {
   it('should allow setting `value` to `false`', function() {
     var container = document.createElement('div');
     var stub = <input type="text" value="yolo" onChange={emptyFunction} />;
-    stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    var node = ReactDOM.render(stub, container);
 
     expect(node.value).toBe('yolo');
 
@@ -173,8 +133,7 @@ describe('ReactDOMInput', function() {
   it('should allow setting `value` to `objToString`', function() {
     var container = document.createElement('div');
     var stub = <input type="text" value="foo" onChange={emptyFunction} />;
-    stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    var node = ReactDOM.render(stub, container);
 
     expect(node.value).toBe('foo');
 

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
@@ -36,6 +36,7 @@ describe('ReactDOMInput', function() {
     stub = ReactTestUtils.renderIntoDocument(stub);
     var node = ReactDOM.findDOMNode(stub);
 
+    expect(node.getAttribute('value')).toBe('0');
     expect(node.value).toBe('0');
   });
 
@@ -53,6 +54,68 @@ describe('ReactDOMInput', function() {
     var node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('false');
+  });
+
+  it('should update `defaultValue` for uncontrolled input', function() {
+    var container = document.createElement('div');
+
+    var el = ReactDOM.render(<input type="text" defaultValue="0" />, container);
+    var node = ReactDOM.findDOMNode(el);
+
+    expect(node.value).toBe('0');
+
+    ReactDOM.render(<input type="text" defaultValue="1" />, container);
+
+    expect(node.value).toBe('1');
+  });
+
+  it('should take `defaultValue` for a controlled input', function() {
+    var container = document.createElement('div');
+
+    var el = ReactDOM.render(<input type="text" value={null} defaultValue="0" />, container);
+    var node = ReactDOM.findDOMNode(el);
+
+    expect(node.value).toBe('0');
+
+    ReactDOM.render(<input type="text" value={null} defaultValue="1" />, container);
+
+    expect(node.value).toBe('1');
+
+    ReactDOM.render(<input type="text" value={3} defaultValue="2" />, container);
+
+    expect(node.value).toBe('3');
+
+    ReactDOM.render(<input type="text" value={5} defaultValue="4" />, container);
+
+    expect(node.value).toBe('5');
+    expect(node.getAttribute('value')).toBe('5');
+    expect(node.defaultValue).toBe('5');
+  });
+
+  it('should update `value` when changing to controlled input', function() {
+    var container = document.createElement('div');
+
+    var el = ReactDOM.render(<input type="text" defaultValue="0" />, container);
+    var node = ReactDOM.findDOMNode(el);
+
+    expect(node.value).toBe('0');
+
+    ReactDOM.render(<input type="text" value="1" defaultValue="0" />, container);
+
+    expect(node.value).toBe('1');
+  });
+
+  it('should take `defaultValue` when changing to uncontrolled input', function() {
+    var container = document.createElement('div');
+
+    var el = ReactDOM.render(<input type="text" value="0" readOnly="true" />, container);
+    var node = ReactDOM.findDOMNode(el);
+
+    expect(node.value).toBe('0');
+
+    ReactDOM.render(<input type="text" defaultValue="1" />, container);
+
+    expect(node.value).toBe('1');
   });
 
   it('should display "foobar" for `defaultValue` of `objToString`', function() {
@@ -125,6 +188,29 @@ describe('ReactDOMInput', function() {
       container
     );
     expect(node.value).toEqual('foobar');
+  });
+
+  it('should not incur unnecessary DOM mutations', function() {
+    var container = document.createElement('div');
+    ReactDOM.render(<input value="a" />, container);
+
+    var node = container.firstChild;
+    var nodeValue = 'a'; // node.value always returns undefined
+    var nodeValueSetter = jest.genMockFn();
+    Object.defineProperty(node, 'value', {
+      get: function() {
+        return nodeValue;
+      },
+      set: nodeValueSetter.mockImplementation(function(newValue) {
+        nodeValue = newValue;
+      }),
+    });
+
+    ReactDOM.render(<input value="a" />, container);
+    expect(nodeValueSetter.mock.calls.length).toBe(0);
+
+    ReactDOM.render(<input value="b"/>, container);
+    expect(nodeValueSetter.mock.calls.length).toBe(1);
   });
 
   it('should properly control a value of number `0`', function() {

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMTextarea-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMTextarea-test.js
@@ -31,47 +31,43 @@ describe('ReactDOMTextarea', function() {
       if (!container) {
         container = document.createElement('div');
       }
-      var stub = ReactDOM.render(component, container);
-      var node = ReactDOM.findDOMNode(stub);
+      var node = ReactDOM.render(component, container);
 
       if (!skipReplace) {
         // Fixing jsdom's quirky behavior -- in reality, the parser should strip
         // off the leading newline but we need to do it by hand here.
         node.value = node.innerHTML.replace(/^\n/, '');
       }
-      return stub;
+      return node;
     };
   });
 
   it('should allow setting `defaultValue`', function() {
     var container = document.createElement('div');
-    var stub = renderTextarea(<textarea defaultValue="giraffe" />, container, true);
-    var node = ReactDOM.findDOMNode(stub);
+    var node = renderTextarea(<textarea defaultValue="giraffe" />, container, true);
 
     expect(node.value).toBe('giraffe');
 
     // Changing `defaultValue` should change if no value set.
-    stub = renderTextarea(<textarea defaultValue="gorilla" />, container, true);
+    renderTextarea(<textarea defaultValue="gorilla" />, container, true);
     expect(node.value).toEqual('gorilla');
 
     node.value = 'cat';
 
-    stub = renderTextarea(<textarea defaultValue="monkey" />, container, true);
+    renderTextarea(<textarea defaultValue="monkey" />, container, true);
     expect(node.value).toEqual('cat');
   });
 
   it('should display `defaultValue` of number 0', function() {
     var stub = <textarea defaultValue={0} />;
-    stub = renderTextarea(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    var node = renderTextarea(stub);
 
     expect(node.value).toBe('0');
   });
 
   it('should display "false" for `defaultValue` of `false`', function() {
     var stub = <textarea defaultValue={false} />;
-    stub = renderTextarea(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    var node = renderTextarea(stub);
 
     expect(node.value).toBe('false');
   });
@@ -84,24 +80,21 @@ describe('ReactDOMTextarea', function() {
     };
 
     var stub = <textarea defaultValue={objToString} />;
-    stub = renderTextarea(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    var node = renderTextarea(stub);
 
     expect(node.value).toBe('foobar');
   });
 
   it('should not render value as an attribute', function() {
     var stub = <textarea value="giraffe" onChange={emptyFunction} />;
-    stub = renderTextarea(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    var node = renderTextarea(stub);
 
     expect(node.getAttribute('value')).toBe(null);
   });
 
   it('should display `value` of number 0', function() {
     var stub = <textarea value={0} />;
-    stub = renderTextarea(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    var node = renderTextarea(stub);
 
     expect(node.value).toBe('0');
   });
@@ -109,8 +102,7 @@ describe('ReactDOMTextarea', function() {
   it('should allow setting `value` to `giraffe`', function() {
     var container = document.createElement('div');
     var stub = <textarea value="giraffe" onChange={emptyFunction} />;
-    stub = renderTextarea(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    var node = renderTextarea(stub, container);
 
     expect(node.value).toBe('giraffe');
 
@@ -124,8 +116,7 @@ describe('ReactDOMTextarea', function() {
   it('should allow setting `value` to `true`', function() {
     var container = document.createElement('div');
     var stub = <textarea value="giraffe" onChange={emptyFunction} />;
-    stub = renderTextarea(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    var node = renderTextarea(stub, container);
 
     expect(node.value).toBe('giraffe');
 
@@ -139,8 +130,7 @@ describe('ReactDOMTextarea', function() {
   it('should allow setting `value` to `false`', function() {
     var container = document.createElement('div');
     var stub = <textarea value="giraffe" onChange={emptyFunction} />;
-    stub = renderTextarea(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    var node = renderTextarea(stub, container);
 
     expect(node.value).toBe('giraffe');
 
@@ -154,8 +144,7 @@ describe('ReactDOMTextarea', function() {
   it('should allow setting `value` to `objToString`', function() {
     var container = document.createElement('div');
     var stub = <textarea value="giraffe" onChange={emptyFunction} />;
-    stub = renderTextarea(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    var node = renderTextarea(stub, container);
 
     expect(node.value).toBe('giraffe');
 
@@ -174,8 +163,7 @@ describe('ReactDOMTextarea', function() {
   it('should take updates to `defaultValue` for uncontrolled textarea', function() {
     var container = document.createElement('div');
 
-    var el = ReactDOM.render(<textarea type="text" defaultValue="0" />, container);
-    var node = ReactDOM.findDOMNode(el);
+    var node = ReactDOM.render(<textarea type="text" defaultValue="0" />, container);
 
     expect(node.value).toBe('0');
 
@@ -187,8 +175,7 @@ describe('ReactDOMTextarea', function() {
   it('should take updates to children in lieu of `defaultValue` for uncontrolled textarea', function() {
     var container = document.createElement('div');
 
-    var el = ReactDOM.render(<textarea type="text" defaultValue="0" />, container);
-    var node = ReactDOM.findDOMNode(el);
+    var node = ReactDOM.render(<textarea type="text" defaultValue="0" />, container);
 
     expect(node.value).toBe('0');
 
@@ -224,8 +211,7 @@ describe('ReactDOMTextarea', function() {
 
   it('should properly control a value of number `0`', function() {
     var stub = <textarea value={0} onChange={emptyFunction} />;
-    stub = renderTextarea(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    var node = renderTextarea(stub);
 
     node.value = 'giraffe';
     ReactTestUtils.Simulate.change(node);
@@ -237,8 +223,7 @@ describe('ReactDOMTextarea', function() {
 
     var container = document.createElement('div');
     var stub = <textarea>giraffe</textarea>;
-    stub = renderTextarea(stub, container, true);
-    var node = ReactDOM.findDOMNode(stub);
+    var node = renderTextarea(stub, container, true);
 
     expect(console.error.argsForCall.length).toBe(1);
     expect(node.value).toBe('giraffe');
@@ -251,8 +236,7 @@ describe('ReactDOMTextarea', function() {
   it('should not keep value when switching to uncontrolled element if not changed', function() {
     var container = document.createElement('div');
 
-    var stub = renderTextarea(<textarea value="kitten" onChange={emptyFunction} />, container, true);
-    var node = ReactDOM.findDOMNode(stub);
+    var node = renderTextarea(<textarea value="kitten" onChange={emptyFunction} />, container, true);
 
     expect(node.value).toBe('kitten');
 
@@ -264,8 +248,7 @@ describe('ReactDOMTextarea', function() {
   it('should keep value when switching to uncontrolled element if changed', function() {
     var container = document.createElement('div');
 
-    var stub = renderTextarea(<textarea value="kitten" onChange={emptyFunction} />, container, true);
-    var node = ReactDOM.findDOMNode(stub);
+    var node = renderTextarea(<textarea value="kitten" onChange={emptyFunction} />, container, true);
 
     expect(node.value).toBe('kitten');
 
@@ -280,14 +263,14 @@ describe('ReactDOMTextarea', function() {
 
   it('should allow numbers as children', function() {
     spyOn(console, 'error');
-    var node = ReactDOM.findDOMNode(renderTextarea(<textarea>{17}</textarea>));
+    var node = renderTextarea(<textarea>{17}</textarea>);
     expect(console.error.argsForCall.length).toBe(1);
     expect(node.value).toBe('17');
   });
 
   it('should allow booleans as children', function() {
     spyOn(console, 'error');
-    var node = ReactDOM.findDOMNode(renderTextarea(<textarea>{false}</textarea>));
+    var node = renderTextarea(<textarea>{false}</textarea>);
     expect(console.error.argsForCall.length).toBe(1);
     expect(node.value).toBe('false');
   });
@@ -299,7 +282,7 @@ describe('ReactDOMTextarea', function() {
         return 'sharkswithlasers';
       },
     };
-    var node = ReactDOM.findDOMNode(renderTextarea(<textarea>{obj}</textarea>));
+    var node = renderTextarea(<textarea>{obj}</textarea>);
     expect(console.error.argsForCall.length).toBe(1);
     expect(node.value).toBe('sharkswithlasers');
   });
@@ -317,7 +300,7 @@ describe('ReactDOMTextarea', function() {
 
     var node;
     expect(function() {
-      node = ReactDOM.findDOMNode(renderTextarea(<textarea><strong /></textarea>));
+      node = renderTextarea(<textarea><strong /></textarea>);
     }).not.toThrow();
 
     expect(node.value).toBe('[object Object]');
@@ -337,12 +320,12 @@ describe('ReactDOMTextarea', function() {
     );
 
 
-    expect(ReactDOM.findDOMNode(instance).value).toBe('yolo');
+    expect(instance.value).toBe('yolo');
     expect(link.value).toBe('yolo');
     expect(link.requestChange.mock.calls.length).toBe(0);
 
-    ReactDOM.findDOMNode(instance).value = 'test';
-    ReactTestUtils.Simulate.change(ReactDOM.findDOMNode(instance));
+    instance.value = 'test';
+    ReactTestUtils.Simulate.change(instance);
 
     expect(link.requestChange.mock.calls.length).toBe(1);
     expect(link.requestChange.mock.calls[0][0]).toEqual('test');

--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -17,7 +17,6 @@ var ExecutionEnvironment = require('ExecutionEnvironment');
 var MUST_USE_ATTRIBUTE = DOMProperty.injection.MUST_USE_ATTRIBUTE;
 var MUST_USE_PROPERTY = DOMProperty.injection.MUST_USE_PROPERTY;
 var HAS_BOOLEAN_VALUE = DOMProperty.injection.HAS_BOOLEAN_VALUE;
-var HAS_SIDE_EFFECTS = DOMProperty.injection.HAS_SIDE_EFFECTS;
 var HAS_NUMERIC_VALUE = DOMProperty.injection.HAS_NUMERIC_VALUE;
 var HAS_POSITIVE_NUMERIC_VALUE =
   DOMProperty.injection.HAS_POSITIVE_NUMERIC_VALUE;
@@ -81,6 +80,7 @@ var HTMLDOMPropertyConfig = {
     data: null, // For `<object />` acts as `src`.
     dateTime: MUST_USE_ATTRIBUTE,
     default: HAS_BOOLEAN_VALUE,
+    defaultValue: MUST_USE_PROPERTY,
     defer: HAS_BOOLEAN_VALUE,
     dir: MUST_USE_ATTRIBUTE,
     disabled: MUST_USE_ATTRIBUTE | HAS_BOOLEAN_VALUE,
@@ -169,7 +169,7 @@ var HTMLDOMPropertyConfig = {
     // Setting .type throws on non-<input> tags
     type: MUST_USE_ATTRIBUTE,
     useMap: null,
-    value: MUST_USE_PROPERTY | HAS_SIDE_EFFECTS,
+    value: MUST_USE_ATTRIBUTE,
     width: MUST_USE_ATTRIBUTE,
     wmode: MUST_USE_ATTRIBUTE,
     wrap: MUST_USE_ATTRIBUTE,

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -575,25 +575,25 @@ describe('ReactDOMComponent', function() {
 
     it('should not incur unnecessary DOM mutations', function() {
       var container = document.createElement('div');
-      ReactDOM.render(<div value="" />, container);
+      ReactDOM.render(<div id="" />, container);
 
       var node = container.firstChild;
-      var nodeValue = ''; // node.value always returns undefined
-      var nodeValueSetter = jest.genMockFn();
-      Object.defineProperty(node, 'value', {
+      var nodeId = ''; // node.value always returns undefined
+      var nodeIdSetter = jest.genMockFn();
+      Object.defineProperty(node, 'id', {
         get: function() {
-          return nodeValue;
+          return nodeId;
         },
-        set: nodeValueSetter.mockImplementation(function(newValue) {
-          nodeValue = newValue;
+        set: nodeIdSetter.mockImplementation(function(newValue) {
+          nodeId = newValue;
         }),
       });
 
-      ReactDOM.render(<div value="" />, container);
-      expect(nodeValueSetter.mock.calls.length).toBe(0);
+      ReactDOM.render(<div id="" />, container);
+      expect(nodeIdSetter.mock.calls.length).toBe(0);
 
       ReactDOM.render(<div />, container);
-      expect(nodeValueSetter.mock.calls.length).toBe(1);
+      expect(nodeIdSetter.mock.calls.length).toBe(1);
     });
 
     it('should ignore attribute whitelist for elements with the "is: attribute', function() {


### PR DESCRIPTION
This is an alternate approach for #5666, using `setAttribute(value)` instead of `defaultValue` as a DOM property. Both this and #5666 are fixes for #4618 and are mutually exclusive approaches.

Fixes issue #4618, which allows updates to defaultValue on uncontrolled <input>s by changing `element.value` via `element.setAttribute(value)`. We move `hasSideEffects` code into the input and textarea wrappers (each wrapper updates still via `element.value = ...`). Browsers will reflect changes to `setValue(value)` on `<input>` elements unless the user has adjusted the value on an uncontrolled element. This is the approach suggested by @spicyj. 

Note: even after this patch, changes to defaultValue on textarea and select elements will not be reflected after the component is mounted.

Here's a simple test of the patch on JSBin: https://jsbin.com/tobuye/10/edit?html,js,output