### PR TITLE
normalize range input onChange events

### DIFF
--- a/src/renderers/dom/client/eventPlugins/__tests__/ChangeEventPlugin-test.js
+++ b/src/renderers/dom/client/eventPlugins/__tests__/ChangeEventPlugin-test.js
@@ -27,4 +27,39 @@ describe('ChangeEventPlugin', function() {
     ReactTestUtils.SimulateNative.click(input);
     expect(called).toBe(1);
   });
+
+  it('should listen for both change and input events for range inputs', function() {
+    var called = 0;
+
+    function cb(e) {
+      called += 1;
+      expect(e.type).toBe('change');
+    }
+
+    var input = ReactTestUtils.renderIntoDocument(<input type="range" onChange={cb}/>);
+
+    ReactTestUtils.SimulateNative.input(input);
+    input.value = 'foo';
+    ReactTestUtils.SimulateNative.change(input);
+
+    expect(called).toBe(2);
+  });
+
+  it('should only fire events when the value changes for range inputs', function() {
+    var called = 0;
+
+    function cb(e) {
+      called += 1;
+      expect(e.type).toBe('change');
+    }
+
+    var input = ReactTestUtils.renderIntoDocument(<input type="range" onChange={cb}/>);
+
+    ReactTestUtils.SimulateNative.input(input);
+    ReactTestUtils.SimulateNative.change(input);
+    input.value = 'foo';
+    ReactTestUtils.SimulateNative.input(input);
+    ReactTestUtils.SimulateNative.change(input);
+    expect(called).toBe(2);
+  });
 });


### PR DESCRIPTION
Addresses the core of #554. ping @jimfb @spicyj 

This plugin is getting large...personally I'd break it out into smaller modules but I didn't want to presume that here, so its all together. The other thing I didn't do was make the obvious DRY changes. There is a common pattern of tracking the active input used by three code branches that could be refactored into something a bit more concise. I have that change locally if ya'll feel like its appropriate for this PR otherwise I can leave the repetition.

There is also a larger question of whether it makes sense to just run all (or more than just ranges) inputs through this branch, which would also address annoyances similar to #3377 and #3484. That's a sweeping change though and, again, didn't want to presume.

I need to actually test this on old IE (Edge fires input events) but I don't have the vm set up at the moment.