### PR TITLE
Get rid of getNativeNode()

### DIFF
--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -996,10 +996,6 @@ ReactDOMComponent.Mixin = {
     }
   },
 
-  getNativeNode: function() {
-    return getNode(this);
-  },
-
   /**
    * Destroys all event registrations for this instance. Does not remove from
    * the DOM. That must be done by the parent.
@@ -1044,6 +1040,7 @@ ReactDOMComponent.Mixin = {
         break;
     }
 
+    var nativeNode = getNode(this);
     this.unmountChildren();
     ReactDOMComponentTree.uncacheNode(this);
     EventPluginHub.deleteAllListeners(this);
@@ -1051,6 +1048,7 @@ ReactDOMComponent.Mixin = {
     this._rootNodeID = null;
     this._domID = null;
     this._wrapperState = null;
+    return nativeNode;
   },
 
   getPublicInstance: function() {

--- a/src/renderers/dom/shared/ReactDOMEmptyComponent.js
+++ b/src/renderers/dom/shared/ReactDOMEmptyComponent.js
@@ -57,11 +57,10 @@ assign(ReactDOMEmptyComponent.prototype, {
   },
   receiveComponent: function() {
   },
-  getNativeNode: function() {
-    return ReactDOMComponentTree.getNodeFromInstance(this);
-  },
   unmountComponent: function() {
+    var node = ReactDOMComponentTree.getNodeFromInstance(this);
     ReactDOMComponentTree.uncacheNode(this);
+    return node;
   },
 });
 

--- a/src/renderers/dom/shared/ReactDOMTextComponent.js
+++ b/src/renderers/dom/shared/ReactDOMTextComponent.js
@@ -137,13 +137,10 @@ assign(ReactDOMTextComponent.prototype, {
       }
     }
   },
-
-  getNativeNode: function() {
-    return getNode(this);
-  },
-
   unmountComponent: function() {
+    var node = getNode(this);
     ReactDOMComponentTree.uncacheNode(this);
+    return node;
   },
 
 });

--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -371,10 +371,6 @@ var ReactCompositeComponentMixin = {
     return markup;
   },
 
-  getNativeNode: function() {
-    return ReactReconciler.getNativeNode(this._renderedComponent);
-  },
-
   /**
    * Releases any resources allocated by `mountComponent`.
    *
@@ -389,7 +385,7 @@ var ReactCompositeComponentMixin = {
     }
 
     if (this._renderedComponent) {
-      ReactReconciler.unmountComponent(this._renderedComponent);
+      var unmountedNativeNode = ReactReconciler.unmountComponent(this._renderedComponent);
       this._renderedNodeType = null;
       this._renderedComponent = null;
       this._instance = null;
@@ -420,6 +416,7 @@ var ReactCompositeComponentMixin = {
     // TODO: inst.props = null;
     // TODO: inst.state = null;
     // TODO: inst.context = null;
+    return unmountedNativeNode;
   },
 
   /**
@@ -807,15 +804,7 @@ var ReactCompositeComponentMixin = {
         this._processChildContext(context)
       );
     } else {
-      // TODO: This is currently necessary due to the unfortunate caching
-      // that ReactMount does which makes it exceedingly difficult to unmount
-      // a set of siblings without accidentally repopulating the node cache (see
-      // #5151). Once ReactMount no longer stores the nodes by ID, this method
-      // can go away.
-      var oldNativeNode = ReactReconciler.getNativeNode(prevComponentInstance);
-
-      ReactReconciler.unmountComponent(prevComponentInstance);
-
+      var oldNativeNode = ReactReconciler.unmountComponent(prevComponentInstance);
       this._renderedNodeType = ReactNodeTypes.getType(nextRenderedElement);
       this._renderedComponent = this._instantiateReactComponent(
         nextRenderedElement

--- a/src/renderers/shared/reconciler/ReactReconciler.js
+++ b/src/renderers/shared/reconciler/ReactReconciler.js
@@ -55,14 +55,6 @@ var ReactReconciler = {
   },
 
   /**
-   * Returns a value that can be passed to
-   * ReactComponentEnvironment.replaceNodeWithMarkup.
-   */
-  getNativeNode: function(internalInstance) {
-    return internalInstance.getNativeNode();
-  },
-
-  /**
    * Releases any resources allocated by `mountComponent`.
    *
    * @final

--- a/src/renderers/shared/reconciler/ReactSimpleEmptyComponent.js
+++ b/src/renderers/shared/reconciler/ReactSimpleEmptyComponent.js
@@ -38,9 +38,6 @@ assign(ReactSimpleEmptyComponent.prototype, {
   },
   receiveComponent: function() {
   },
-  getNativeNode: function() {
-    return ReactReconciler.getNativeNode(this._renderedComponent);
-  },
   unmountComponent: function() {
     ReactReconciler.unmountComponent(this._renderedComponent);
     this._renderedComponent = null;

--- a/src/renderers/shared/reconciler/instantiateReactComponent.js
+++ b/src/renderers/shared/reconciler/instantiateReactComponent.js
@@ -104,7 +104,6 @@ function instantiateReactComponent(node) {
       typeof instance.construct === 'function' &&
       typeof instance.mountComponent === 'function' &&
       typeof instance.receiveComponent === 'function' &&
-      typeof instance.getNativeNode === 'function' &&
       typeof instance.unmountComponent === 'function',
       'Only React Components can be mounted.'
     );

--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -381,10 +381,6 @@ NoopInternalComponent.prototype = {
     this._currentElement = element;
   },
 
-  getNativeNode: function() {
-    return undefined;
-  },
-
   unmountComponent: function() {
   },
 


### PR DESCRIPTION
Get rid of getNativeNode(), which was a temporary hack added in https://github.com/facebook/react/pull/5160 to solve https://github.com/facebook/react/issues/5151.  We don't need it anymore, since we don't use React Ids.
