### PR TITLE
Allow for "endListener" override in ReactCSSTransitionGroupChild.transition

### DIFF
--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -57,7 +57,7 @@ var ReactCSSTransitionGroupChild = React.createClass({
     leaveTimeout: React.PropTypes.number,
   },
 
-  transition: function(animationType, finishCallback, userSpecifiedDelay) {
+  transition: function(animationType, finishCallback, userSpecifiedDelay, endListener) {
     var node = ReactDOM.findDOMNode(this);
 
     if (!node) {
@@ -70,8 +70,18 @@ var ReactCSSTransitionGroupChild = React.createClass({
     var className = this.props.name[animationType] || this.props.name + '-' + animationType;
     var activeClassName = this.props.name[animationType + 'Active'] || className + '-active';
     var timeout = null;
+    var boundEndListenerWrapper = function(listener) {
+      return function(e) {
+        if (e && e.target !== node) {
+          return;
+        }
 
-    var endListener = function(e) {
+        clearTimeout(timeout);
+        listener(e, node);
+      };
+    };
+
+    endListener = (typeof endListener === 'function') ? boundEndListenerWrapper(endListener.bind(this)) : function(e) {
       if (e && e.target !== node) {
         return;
       }


### PR DESCRIPTION
There are certain cases where one needs to extend `ReactCSSTransitionGroupChild`.
For the sake of convenience, it would be nice to allow that `transition` accepts `endListener` as well, since the rest of the transition method is quiet flexible