### PR TITLE
Add coveralls support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ static
 _SpecRunner.html
 __benchmarks__
 build/
+coverage/
 .module-cache
 *.gem
 docs/.bundle

--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "private": true,
   "version": "0.15.0-alpha",
   "devDependencies": {
+    "async": "^1.5.0",
     "babel": "^5.8.29",
     "babel-eslint": "4.1.5",
     "benchmark": "^1.0.0",
     "browserify": "^12.0.1",
     "bundle-collapser": "^1.1.1",
     "coffee-script": "^1.8.0",
+    "coveralls": "^2.11.6",
     "del": "^2.0.2",
     "derequire": "^2.0.3",
     "envify": "^3.0.0",
@@ -17,6 +19,7 @@
     "eslint-plugin-react-internal": "file:eslint-rules",
     "fbjs": "^0.4.0",
     "fbjs-scripts": "^0.5.0",
+    "glob": "^6.0.1",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-compare-size": "^0.4.0",
@@ -54,6 +57,16 @@
     "test": "jest"
   },
   "jest": {
+    "collectCoverage": true,
+    "collectCoverageOnlyFrom": {
+      "src/**/*.js": {
+        "ignore": [
+          "src/**/__tests__/*.js",
+          "src/shared/vendor/third_party/*.js",
+          "src/test/*.js"
+        ]
+      }
+    },
     "modulePathIgnorePatterns": [
       "/.module-cache/",
       "/react/build/"


### PR DESCRIPTION
This PR lays the groundwork for [Coveralls](https://coveralls.io/) support to address #5704.

The required bit for Coveralls will be [setting up an account](https://coveralls.io/authorize/github).
You can add a "secure" token to the [travis.yml](https://github.com/facebook/react/blob/master/.travis.yml).
_(If you've recently upgraded to OSX El Capitan you may need to [reinstall Ruby](https://gorails.com/setup/osx/10.11-el-capitan))_

```bash
gem install travis
cd react
travis encrypt COVERALLS_TOKEN=<token_specified_in_the_coveralls_setup>
```
Then add the generated secure string to another `- secure:` entry in the travis.yml.

Once the jest tests are run you can add a line to the travis.yml
```bash
cat ./coverage/lcov.info | coveralls
```

The Coveralls output will [look something like this](https://coveralls.io/builds/4524690).

A neat thing about this PR is it also works in glob support for the "collectCoverageOnlyFrom" field and works when "collectCoverage" is `false` or removed. Ideally this would just be supported by [jest-cli](https://www.npmjs.com/package/jest-cli) but until this it's p cool.

Related to #5703.