### PR TITLE
Fix typo in post

### DIFF
--- a/docs/_posts/2014-10-16-react-v0.12-rc1.md
+++ b/docs/_posts/2014-10-16-react-v0.12-rc1.md
@@ -41,7 +41,7 @@ We have wanted to do this since before we even open sourced React. No more `/** 
 
 The React specific JSX transform no longer transforms to function calls. Instead we use `React.createElement` and pass it arguments. This allows us to make optimizations and better support React as a compile target for things like Om. Read more in the [React Elements introduction](/react/blog/2014/10/14/introducting-react-elements.html).
 
-The result of this change is that we will no longer support arbitrary function calls. We understand that the ability to do was was a convenient shortcut for many people but we believe the gains will be worth it.
+The result of this change is that we will no longer support arbitrary function calls. We understand that the ability to do was a convenient shortcut for many people but we believe the gains will be worth it.
 
 
 ### JSX Lower-case Convention


### PR DESCRIPTION
This fixes a typo, 'was'.