### PR TITLE
Fix #4963 - SVG <use> swallows click events

### DIFF
--- a/src/renderers/dom/client/utils/getEventTarget.js
+++ b/src/renderers/dom/client/utils/getEventTarget.js
@@ -20,6 +20,12 @@
  */
 function getEventTarget(nativeEvent) {
   var target = nativeEvent.target || nativeEvent.srcElement || window;
+
+  // Normalize SVG <use> element events #4963
+  if (target.correspondingUseElement) {
+    target = target.correspondingUseElement;
+  }
+
   // Safari may fire events on text nodes (Node.TEXT_NODE is 3).
   // @see http://www.quirksmode.org/js/events_properties.html
   return target.nodeType === 3 ? target.parentNode : target;


### PR DESCRIPTION
Info about the issue in #4963

This fix uses the corresponding `<use>` element as the target of a click handler instead of the `<svg>` it refers to, thereby normalizing the behavior of IE, Edge and iOS to the behavior of Chrome. Without this fix there is no way to handle click events on `<use>` elements in the aforementioned browsers as their target becomes the referred to `<svg>` which may be far outside of the attached click handler causing it to be dropped.