### PR TITLE
Remove fast_finish in travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,8 +91,6 @@ env:
   - secure: EHCyCSKMwKlLHNtcj9nmkRzmiiPE3aDGlPcnEyrDJeRI0SeN/iCXHXfFivR0vFq3vr+9naMBczAR2AEidtps5KbJrKqdZnjPFRbmfVtzWr/LlvVCub3u13Pub6TdKIVBTny1PuZ5X8GvdxMNVig89jGjvzhhWuQRaz3VhJnTra4=
   # COVERALLS_TOKEN
   - secure: h/cUq+TrUMZOQmkFD7CvuwX0uAwmjIfKZ4qSUzY+QzUtDzOzA0L/XF84xTBq1Q5YYsEiaoF6GxxGCdrLQiBA/ZTd+88UHgeZPMRvi0xG9Q+PeePVOsZMTxy4/WWFgOfSQCk49Mj9zizGgO78i6vxq+SDXMtFHnZ+TpPJIEW6/m0=
-matrix:
-  fast_finish: true
 notifications:
   irc:
     use_notice: true


### PR DESCRIPTION
I noticed a `fast_finish` entry in the travis.yml.
I hadn't seen that option before and [looked it up](https://docs.travis-ci.com/user/customizing-the-build/#Fast-Finishing).

It seems to only apply if you `allow_failures` which I don't see in the yml.