### PR TITLE
Clarify React class constructor comments

### DIFF
--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -748,7 +748,7 @@ var ReactClass = {
    */
   createClass: function(spec) {
     var Constructor = function(props, context, updater) {
-      // This constructor is overridden by mocks. The argument is used
+      // This constructor gets overridden by mocks. The argument is used
       // by mocks to assert on what gets mounted.
 
       if (__DEV__) {


### PR DESCRIPTION
- The constructor is not always overridden by mocks. Makes viewing this constructor during debugging less confusing.