### PR TITLE
[docs] Small fixes to "more about refs"

### DIFF
--- a/docs/docs/08.1-more-about-refs.md
+++ b/docs/docs/08.1-more-about-refs.md
@@ -91,11 +91,13 @@ In order to get a reference to a React component, you can either use `this` to g
 var MyComponent = React.createClass({
   handleClick: function() {
     // Explicitly focus the text input using the raw DOM API.
-    this.myTextInput.focus();
+    if (this.myTextInput !== null) {
+      this.myTextInput.focus();
+    }
   },
   render: function() {
-    // The ref attribute adds a reference to the component to
-    // this.refs when the component is mounted.
+    // The ref attribute is a callback that saves a reference to the
+    // component to this.myTextInput when the component is mounted.
     return (
       <div>
         <input type="text" ref={(ref) => this.myTextInput = ref} />
@@ -131,7 +133,7 @@ Refs are a great way to send a message to a particular child instance in a way t
 
 ### Cautions:
 
-- *Never* access refs inside of any component's render method - or while any component's render method is even running anywhere in the call stack.
+- *Never* access refs inside of any component's render method – or while any component's render method is even running anywhere in the call stack.
 - If you want to preserve Google Closure Compiler advanced-mode crushing resilience, make sure to never access as a property what was specified as a string. This means you must access using `this.refs['myRefString']` if your ref was defined as `ref="myRefString"`.
-- If you have not programmed several apps with React, your first inclination is usually going to be to try to use refs to "make things happen" in your app. If this is the case, take a moment and think more critically about where `state` should be owned in the component hierarchy. Often, it becomes clear that the proper place to "own" that state is at a higher level in the hierarchy. Placing the state there often eliminates any desire to use `ref`s to "make things happen" – instead, the data flow will usually accomplish your goal.
+- If you have not programmed several apps with React, your first inclination is usually going to be to try to use refs to "make things happen" in your app. If this is the case, take a moment and think more critically about where state should be owned in the component hierarchy. Often, it becomes clear that the proper place to "own" that state is at a higher level in the hierarchy. Placing the state there often eliminates any desire to use `ref`s to "make things happen" – instead, the data flow will usually accomplish your goal.
 - Refs may not be attached to a [stateless function](/react/docs/reusable-components.html#stateless-functions), because the component does not have a backing instance. You can always wrap a stateless component in a standard composite component and attach a ref to the composite component.


### PR DESCRIPTION
* Add a null check to "A Complete Example".
* Fix outdated comment. (Found by @mjomble)
* Replace short dash - with longer dash –.
* Remove backticks from state, because it is not code.