### PR TITLE
Only fire input value change events when the value changes

### DIFF
--- a/src/renderers/dom/client/__tests__/inputValueTracking-test.js
+++ b/src/renderers/dom/client/__tests__/inputValueTracking-test.js
@@ -1,0 +1,165 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+'use strict';
+
+var React = require('React');
+var ReactTestUtils = require('ReactTestUtils');
+var inputValueTracking = require('inputValueTracking');
+
+describe('inputValueTracking', function() {
+  var input, checkbox, mockComponent;
+
+  beforeEach(function() {
+    input = document.createElement('input');
+    input.type = 'text';
+    checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    mockComponent = { _nativeNode: input, _wrapperState: {} };
+  });
+
+  it('should attach tracker to wrapper state', function() {
+    inputValueTracking.track(mockComponent);
+
+    expect(
+      mockComponent._wrapperState.hasOwnProperty('valueTracker')
+    ).toBe(true);
+  });
+
+  it('should define `value` on the instance node', function() {
+    inputValueTracking.track(mockComponent);
+
+    expect(
+      input.hasOwnProperty('value')
+    ).toBe(true);
+  });
+
+  it('should define `checked` on the instance node', function() {
+    mockComponent._nativeNode = checkbox;
+    inputValueTracking.track(mockComponent);
+
+    expect(checkbox.hasOwnProperty('checked')).toBe(true);
+  });
+
+  it('should initialize with the current value', function() {
+    input.value ='foo';
+
+    inputValueTracking.track(mockComponent);
+
+    var tracker = mockComponent._wrapperState.valueTracker;
+
+    expect(tracker.getValue()).toEqual('foo');
+  });
+
+  it('should initialize with the current `checked`', function() {
+    mockComponent._nativeNode = checkbox;
+    checkbox.checked = true;
+    inputValueTracking.track(mockComponent);
+
+    var tracker = mockComponent._wrapperState.valueTracker;
+
+    expect(tracker.getValue()).toEqual('true');
+  });
+
+  it('should track value changes', function() {
+    input.value ='foo';
+
+    inputValueTracking.track(mockComponent);
+
+    var tracker = mockComponent._wrapperState.valueTracker;
+
+    input.value ='bar';
+    expect(tracker.getValue()).toEqual('bar');
+  });
+
+  it('should tracked`checked` changes', function() {
+    mockComponent._nativeNode = checkbox;
+    checkbox.checked = true;
+    inputValueTracking.track(mockComponent);
+
+    var tracker = mockComponent._wrapperState.valueTracker;
+
+    checkbox.checked = false;
+    expect(tracker.getValue()).toEqual('false');
+  });
+
+  it('should update value manually', function() {
+    input.value ='foo';
+    inputValueTracking.track(mockComponent);
+
+    var tracker = mockComponent._wrapperState.valueTracker;
+
+    tracker.setValue('bar');
+    expect(tracker.getValue()).toEqual('bar');
+  });
+
+  it('should coerce value to a string', function() {
+    input.value ='foo';
+    inputValueTracking.track(mockComponent);
+
+    var tracker = mockComponent._wrapperState.valueTracker;
+
+    tracker.setValue(500);
+    expect(tracker.getValue()).toEqual('500');
+  });
+
+  it('should update value if it changed and return result', function() {
+    inputValueTracking.track(mockComponent);
+    input.value ='foo';
+
+    var tracker = mockComponent._wrapperState.valueTracker;
+
+    expect(
+      inputValueTracking.updateValueIfChanged(mockComponent)
+    ).toBe(false);
+
+    tracker.setValue('bar');
+
+    expect(
+      inputValueTracking.updateValueIfChanged(mockComponent)
+    ).toBe(true);
+
+    expect(tracker.getValue()).toEqual('foo');
+  });
+
+  it('should track value and return true when updating untracked instance', function() {
+    input.value ='foo';
+
+    expect(
+      inputValueTracking.updateValueIfChanged(mockComponent)
+    )
+    .toBe(true);
+
+    var tracker = mockComponent._wrapperState.valueTracker;
+    expect(tracker.getValue()).toEqual('foo');
+  });
+
+  it('should return tracker from node', function() {
+    var node = ReactTestUtils.renderIntoDocument(<input type="text" defaultValue="foo" />);
+    var tracker = inputValueTracking._getTrackerFromNode(node);
+    expect(tracker.getValue()).toEqual('foo');
+  });
+
+  it('should stop tracking', function() {
+    inputValueTracking.track(mockComponent);
+
+    expect(
+      mockComponent._wrapperState.hasOwnProperty('valueTracker')
+    ).toBe(true);
+
+    inputValueTracking.stopTracking(mockComponent);
+
+    expect(
+      mockComponent._wrapperState.hasOwnProperty('valueTracker')
+    ).toBe(false);
+
+    expect(input.hasOwnProperty('value')).toBe(false);
+  });
+});

--- a/src/renderers/dom/client/inputValueTracking.js
+++ b/src/renderers/dom/client/inputValueTracking.js
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule inputValueTracking
+ */
+
+'use strict';
+var ReactDOMComponentTree = require('ReactDOMComponentTree');
+
+function isCheckable(elem) {
+  var type = elem.type;
+  var nodeName = elem.nodeName;
+  return (
+    (nodeName && nodeName.toLowerCase() === 'input') &&
+    (type === 'checkbox' || type === 'radio')
+  );
+}
+
+function getTracker(inst) {
+  return inst._wrapperState.valueTracker;
+}
+
+function attachTracker(inst, tracker) {
+  inst._wrapperState.valueTracker = tracker;
+}
+
+function detachTracker(inst) {
+  delete inst._wrapperState.valueTracker;
+}
+
+function getValueFromNode(node) {
+  var value;
+  if (node) {
+    value = isCheckable(node)
+      ? '' + node.checked
+      : node.value;
+  }
+  return value;
+}
+
+var inputValueTracking = {
+  // exposed for testing
+  _getTrackerFromNode(node) {
+    return getTracker(
+      ReactDOMComponentTree.getInstanceFromNode(node)
+    );
+  },
+
+  track: function(inst) {
+    if (getTracker(inst)) {
+      return;
+    }
+
+    var node = ReactDOMComponentTree.getNodeFromInstance(inst);
+    var valueField = isCheckable(node) ? 'checked' : 'value';
+    var descriptor = Object.getOwnPropertyDescriptor(
+      node.constructor.prototype,
+      valueField
+    );
+
+    var currentValue = '' + node[valueField];
+
+    // if someone has already defined a value bail and don't track value
+    // will cause over reporting of changes, but it's better then a hard failure
+    // (needed for certain tests that spyOn input values)
+    if (node.hasOwnProperty(valueField)) {
+      return;
+    }
+
+    Object.defineProperty(node, valueField, {
+      enumerable: descriptor.enumerable,
+      configurable: true,
+      get: function() {
+        return descriptor.get.call(this);
+      },
+      set: function(value) {
+        currentValue = '' + value;
+        descriptor.set.call(this, value);
+      },
+    });
+
+    attachTracker(inst, {
+      getValue() {
+        return currentValue;
+      },
+      setValue(value) {
+        currentValue = '' + value;
+      },
+      stopTracking() {
+        detachTracker(inst);
+        delete node[valueField];
+      },
+    });
+  },
+
+  updateValueIfChanged(inst) {
+    if (!inst) {
+      return false;
+    }
+    var tracker = getTracker(inst);
+
+    if (!tracker) {
+      inputValueTracking.track(inst);
+      return true;
+    }
+
+    var lastValue = tracker.getValue();
+    var nextValue = getValueFromNode(
+      ReactDOMComponentTree.getNodeFromInstance(inst)
+    );
+
+    if (nextValue !== lastValue) {
+      tracker.setValue(nextValue);
+      return true;
+    }
+
+    return false;
+  },
+
+  stopTracking(inst) {
+    var tracker = getTracker(inst);
+    if (tracker) {
+      tracker.stopTracking();
+    }
+  },
+};
+
+module.exports = inputValueTracking;

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
@@ -13,9 +13,6 @@
 
 
 var emptyFunction = require('emptyFunction');
-var ChangeEventPlugin = require('ChangeEventPlugin');
-
-var lastInputValue = ChangeEventPlugin.__lastInputValue;
 
 describe('ReactDOMInput', function() {
   var EventConstants;
@@ -24,6 +21,14 @@ describe('ReactDOMInput', function() {
   var ReactDOMFeatureFlags;
   var ReactLink;
   var ReactTestUtils;
+  var inputValueTracking;
+
+  function setUntrackedValue(elem, value) {
+    var tracker = inputValueTracking._getTrackerFromNode(elem);
+    var current = tracker.getValue();
+    elem.value = value;
+    tracker.setValue(current);
+  }
 
   beforeEach(function() {
     jest.resetModuleRegistry();
@@ -33,6 +38,7 @@ describe('ReactDOMInput', function() {
     ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
     ReactLink = require('ReactLink');
     ReactTestUtils = require('ReactTestUtils');
+    inputValueTracking = require('inputValueTracking');
     spyOn(console, 'error');
   });
 
@@ -152,8 +158,7 @@ describe('ReactDOMInput', function() {
     var container = document.createElement('div');
     var node = ReactDOM.render(stub, container);
 
-    node.value = 'giraffe';
-    lastInputValue.set(node, undefined);
+    setUntrackedValue(node, 'giraffe');
 
     var fakeNativeEvent = new function() {};
     fakeNativeEvent.target = node;

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
@@ -13,6 +13,9 @@
 
 
 var emptyFunction = require('emptyFunction');
+var ChangeEventPlugin = require('ChangeEventPlugin');
+
+var lastInputValue = ChangeEventPlugin.__lastInputValue;
 
 describe('ReactDOMInput', function() {
   var EventConstants;
@@ -150,6 +153,7 @@ describe('ReactDOMInput', function() {
     var node = ReactDOM.render(stub, container);
 
     node.value = 'giraffe';
+    lastInputValue.set(node, undefined);
 
     var fakeNativeEvent = new function() {};
     fakeNativeEvent.target = node;

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -41,6 +41,7 @@ var invariant = require('invariant');
 var isEventSupported = require('isEventSupported');
 var keyOf = require('keyOf');
 var shallowEqual = require('shallowEqual');
+var inputValueTracking = require('inputValueTracking');
 var validateDOMNesting = require('validateDOMNesting');
 var warning = require('warning');
 
@@ -255,6 +256,10 @@ var mediaEvents = {
   topVolumeChange: 'volumechange',
   topWaiting: 'waiting',
 };
+
+function trackInputValue() {
+  inputValueTracking.track(this);
+}
 
 function trapBubbledEventsLocal() {
   var inst = this;
@@ -478,6 +483,7 @@ ReactDOMComponent.Mixin = {
       case 'input':
         ReactDOMInput.mountWrapper(this, props, nativeParent);
         props = ReactDOMInput.getNativeProps(this, props);
+        transaction.getReactMountReady().enqueue(trackInputValue, this);
         transaction.getReactMountReady().enqueue(trapBubbledEventsLocal, this);
         break;
       case 'option':
@@ -492,6 +498,7 @@ ReactDOMComponent.Mixin = {
       case 'textarea':
         ReactDOMTextarea.mountWrapper(this, props, nativeParent);
         props = ReactDOMTextarea.getNativeProps(this, props);
+        transaction.getReactMountReady().enqueue(trackInputValue, this);
         transaction.getReactMountReady().enqueue(trapBubbledEventsLocal, this);
         break;
     }
@@ -580,10 +587,10 @@ ReactDOMComponent.Mixin = {
     }
 
     switch (this._tag) {
-      case 'button':
       case 'input':
-      case 'select':
       case 'textarea':
+      case 'select':
+      case 'button':
         if (props.autoFocus) {
           transaction.getReactMountReady().enqueue(
             AutoFocusUtils.focusDOMComponent,
@@ -1028,6 +1035,10 @@ ReactDOMComponent.Mixin = {
             listeners[i].remove();
           }
         }
+        break;
+      case 'input':
+      case 'textarea':
+        inputValueTracking.stopTracking(this);
         break;
       case 'html':
       case 'head':

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -19,6 +19,7 @@ describe('ReactDOMComponent', function() {
   var ReactDOM;
   var ReactDOMFeatureFlags;
   var ReactDOMServer;
+  var inputValueTracking;
 
   beforeEach(function() {
     jest.resetModuleRegistry();
@@ -26,6 +27,7 @@ describe('ReactDOMComponent', function() {
     ReactDOM = require('ReactDOM');
     ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
     ReactDOMServer = require('ReactDOMServer');
+    inputValueTracking = require('inputValueTracking');
   });
 
   describe('updateDOM', function() {
@@ -1074,6 +1076,24 @@ describe('ReactDOMComponent', function() {
       );
     });
 
+    it('should track input values', function() {
+      var container = document.createElement('div');
+      var inst = ReactDOM.render(<input type="text" defaultValue="foo"/>, container);
+
+      var tracker = inputValueTracking._getTrackerFromNode(inst);
+
+      expect(tracker.getValue()).toEqual('foo');
+    });
+
+    it('should track textarea values', function() {
+      var container = document.createElement('div');
+      var inst = ReactDOM.render(<textarea defaultValue="foo"/>, container);
+
+      var tracker = inputValueTracking._getTrackerFromNode(inst);
+
+      expect(tracker.getValue()).toEqual('foo');
+    });
+
     it('should execute custom event plugin listening behavior', function() {
       var SimpleEventPlugin = require('SimpleEventPlugin');
 
@@ -1271,6 +1291,30 @@ describe('ReactDOMComponent', function() {
       expect(
         EventPluginHub.getListener(inst, 'onClick')
       ).toBe(undefined);
+    });
+
+    it('should clean up input value tracking', function() {
+      var container = document.createElement('div');
+      var node = ReactDOM.render(<input type="text" defaultValue="foo"/>, container);
+      var tracker = inputValueTracking._getTrackerFromNode(node);
+
+      spyOn(tracker, 'stopTracking');
+
+      ReactDOM.unmountComponentAtNode(container);
+
+      expect(tracker.stopTracking.calls.length).toBe(1);
+    });
+
+    it('should clean up input textarea tracking', function() {
+      var container = document.createElement('div');
+      var node = ReactDOM.render(<textarea defaultValue="foo"/>, container);
+      var tracker = inputValueTracking._getTrackerFromNode(node);
+
+      spyOn(tracker, 'stopTracking');
+
+      ReactDOM.unmountComponentAtNode(container);
+
+      expect(tracker.stopTracking.calls.length).toBe(1);
     });
 
     it('unmounts children before unsetting DOM node info', function() {


### PR DESCRIPTION
More aggressive alternative to #5687, This PR tracks the value for all inputs and only fires a change when the value changed. This is similar in theory to how the onInput polyfill works __except__ it doesn't track the value in `activeElement` but on the input DOM node. It certainly starts to edge into "not to spec" territory, but onChange is already pretty unique in React so perhaps that's not important.

The extra state tracking isn't ideal, but it has benefits over the track-when-focused approach. For one testing is easier. detached inputs will still fire onChange events, which will break a lot less existing tests. I could also track the value on the node instance, instead of the DOM node, but I wasn't sure if how ya'll feel about mutating the component instance that way.

The downside to this approach is that manually triggered events won't fire if the value hasn't changed. As far as I can tell there isn't a way to distinguish between naturally triggered events and manually triggered ones. Not sure if it's worth it, since most are triggered in testing by the ReactTestUtils, it might make sense add a flag that way?

fixes #554, fixes #1471, fixes #2185 (that last one is probably caused by something else entirely but it was fixed in my testing)

cc: @jimfb @spicyj @syranide 