### PR TITLE
Mouse enter and leave work consistently with disabled elements

### DIFF
--- a/src/renderers/dom/client/ReactBrowserEventEmitter.js
+++ b/src/renderers/dom/client/ReactBrowserEventEmitter.js
@@ -117,6 +117,8 @@ var topEventMapping = {
   topLoadedMetadata: 'loadedmetadata',
   topLoadStart: 'loadstart',
   topMouseDown: 'mousedown',
+  topMouseEnter: 'mousenter',
+  topMouseLeave: 'mouseleave',
   topMouseMove: 'mousemove',
   topMouseOut: 'mouseout',
   topMouseOver: 'mouseover',
@@ -280,6 +282,24 @@ var ReactBrowserEventEmitter = assign({}, ReactEventEmitterMixin, {
               ReactBrowserEventEmitter.ReactEventListener.WINDOW_HANDLE
             );
           }
+        } else if (dependency === topLevelTypes.topMouseEnter ||
+            dependency === topLevelTypes.topMouseLeave) {
+
+          if (isEventSupported('mouseenter', true)) {
+            ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
+              topLevelTypes.topMouseEnter,
+              'mouseenter',
+              mountAt
+            );
+            ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
+              topLevelTypes.topMouseLeave,
+              'mouseleave',
+              mountAt
+            );
+          }
+
+          isListening[topLevelTypes.topMouseEnter] = true;
+          isListening[topLevelTypes.topMouseLeave] = true;
         } else if (dependency === topLevelTypes.topFocus ||
             dependency === topLevelTypes.topBlur) {
 

--- a/src/renderers/dom/client/ReactDOMTreeTraversal.js
+++ b/src/renderers/dom/client/ReactDOMTreeTraversal.js
@@ -80,6 +80,17 @@ function getParentInstance(inst) {
 }
 
 /**
+ *
+ */
+function traverseUntil(inst, fn) {
+  while (inst && !fn(inst)) {
+    inst = inst._nativeParent;
+  }
+
+  return inst;
+}
+
+/**
  * Simulates the traversal of a two-phase, capture/bubble event dispatch.
  */
 function traverseTwoPhase(inst, fn, arg) {
@@ -97,38 +108,11 @@ function traverseTwoPhase(inst, fn, arg) {
   }
 }
 
-/**
- * Traverses the ID hierarchy and invokes the supplied `cb` on any IDs that
- * should would receive a `mouseEnter` or `mouseLeave` event.
- *
- * Does not invoke the callback on the nearest common ancestor because nothing
- * "entered" or "left" that element.
- */
-function traverseEnterLeave(from, to, fn, argFrom, argTo) {
-  var common = from && to ? getLowestCommonAncestor(from, to) : null;
-  var pathFrom = [];
-  while (from && from !== common) {
-    pathFrom.push(from);
-    from = from._nativeParent;
-  }
-  var pathTo = [];
-  while (to && to !== common) {
-    pathTo.push(to);
-    to = to._nativeParent;
-  }
-  var i;
-  for (i = 0; i < pathFrom.length; i++) {
-    fn(pathFrom[i], true, argFrom);
-  }
-  for (i = pathTo.length; i-- > 0;) {
-    fn(pathTo[i], false, argTo);
-  }
-}
 
 module.exports = {
   isAncestor: isAncestor,
   getLowestCommonAncestor: getLowestCommonAncestor,
   getParentInstance: getParentInstance,
+  traverseUntil: traverseUntil,
   traverseTwoPhase: traverseTwoPhase,
-  traverseEnterLeave: traverseEnterLeave,
 };

--- a/src/renderers/dom/client/__tests__/ReactDOMTreeTraversal-test.js
+++ b/src/renderers/dom/client/__tests__/ReactDOMTreeTraversal-test.js
@@ -19,7 +19,6 @@ var ReactTestUtils = require('ReactTestUtils');
  * Ensure that all callbacks are invoked, passing this unique argument.
  */
 var ARG = {arg: true};
-var ARG2 = {arg2: true};
 
 var ChildComponent = React.createClass({
   render: function() {
@@ -104,114 +103,6 @@ describe('ReactDOMTreeTraversal', function() {
         {node: parent.refs.P, isUp: true, arg: ARG},
       ];
       ReactDOMTreeTraversal.traverseTwoPhase(target, argAggregator, ARG);
-      expect(aggregatedArgs).toEqual(expectedAggregation);
-    });
-  });
-
-  describe('traverseEnterLeave', function() {
-    it('should not traverse when enter/leaving outside DOM', function() {
-      var target = null;
-      var expectedAggregation = [];
-      ReactDOMTreeTraversal.traverseEnterLeave(
-        target, target, argAggregator, ARG, ARG2
-      );
-      expect(aggregatedArgs).toEqual(expectedAggregation);
-    });
-
-    it('should not traverse if enter/leave the same node', function() {
-      var parent = renderParentIntoDocument();
-      var leave = getInst(parent.refs.P_P1_C1.refs.DIV_1);
-      var enter = getInst(parent.refs.P_P1_C1.refs.DIV_1);
-      var expectedAggregation = [];
-      ReactDOMTreeTraversal.traverseEnterLeave(
-        leave, enter, argAggregator, ARG, ARG2
-      );
-      expect(aggregatedArgs).toEqual(expectedAggregation);
-    });
-
-    it('should traverse enter/leave to sibling - avoids parent', function() {
-      var parent = renderParentIntoDocument();
-      var leave = getInst(parent.refs.P_P1_C1.refs.DIV_1);
-      var enter = getInst(parent.refs.P_P1_C1.refs.DIV_2);
-      var expectedAggregation = [
-        {node: parent.refs.P_P1_C1.refs.DIV_1, isUp: true, arg: ARG},
-        // enter/leave shouldn't fire anything on the parent
-        {node: parent.refs.P_P1_C1.refs.DIV_2, isUp: false, arg: ARG2},
-      ];
-      ReactDOMTreeTraversal.traverseEnterLeave(
-        leave, enter, argAggregator, ARG, ARG2
-      );
-      expect(aggregatedArgs).toEqual(expectedAggregation);
-    });
-
-    it('should traverse enter/leave to parent - avoids parent', function() {
-      var parent = renderParentIntoDocument();
-      var leave = getInst(parent.refs.P_P1_C1.refs.DIV_1);
-      var enter = getInst(parent.refs.P_P1_C1.refs.DIV);
-      var expectedAggregation = [
-        {node: parent.refs.P_P1_C1.refs.DIV_1, isUp: true, arg: ARG},
-      ];
-      ReactDOMTreeTraversal.traverseEnterLeave(
-        leave, enter, argAggregator, ARG, ARG2
-      );
-      expect(aggregatedArgs).toEqual(expectedAggregation);
-    });
-
-    it('should enter from the window', function() {
-      var parent = renderParentIntoDocument();
-      var leave = null; // From the window or outside of the React sandbox.
-      var enter = getInst(parent.refs.P_P1_C1.refs.DIV);
-      var expectedAggregation = [
-        {node: parent.refs.P, isUp: false, arg: ARG2},
-        {node: parent.refs.P_P1, isUp: false, arg: ARG2},
-        {node: parent.refs.P_P1_C1.refs.DIV, isUp: false, arg: ARG2},
-      ];
-      ReactDOMTreeTraversal.traverseEnterLeave(
-        leave, enter, argAggregator, ARG, ARG2
-      );
-      expect(aggregatedArgs).toEqual(expectedAggregation);
-    });
-
-    it('should enter from the window to the shallowest', function() {
-      var parent = renderParentIntoDocument();
-      var leave = null; // From the window or outside of the React sandbox.
-      var enter = getInst(parent.refs.P);
-      var expectedAggregation = [
-        {node: parent.refs.P, isUp: false, arg: ARG2},
-      ];
-      ReactDOMTreeTraversal.traverseEnterLeave(
-        leave, enter, argAggregator, ARG, ARG2
-      );
-      expect(aggregatedArgs).toEqual(expectedAggregation);
-    });
-
-    it('should leave to the window', function() {
-      var parent = renderParentIntoDocument();
-      var enter = null; // From the window or outside of the React sandbox.
-      var leave = getInst(parent.refs.P_P1_C1.refs.DIV);
-      var expectedAggregation = [
-        {node: parent.refs.P_P1_C1.refs.DIV, isUp: true, arg: ARG},
-        {node: parent.refs.P_P1, isUp: true, arg: ARG},
-        {node: parent.refs.P, isUp: true, arg: ARG},
-      ];
-      ReactDOMTreeTraversal.traverseEnterLeave(
-        leave, enter, argAggregator, ARG, ARG2
-      );
-      expect(aggregatedArgs).toEqual(expectedAggregation);
-    });
-
-    it('should leave to the window from the shallowest', function() {
-      var parent = renderParentIntoDocument();
-      var enter = null; // From the window or outside of the React sandbox.
-      var leave = getInst(parent.refs.P_P1_C1.refs.DIV);
-      var expectedAggregation = [
-        {node: parent.refs.P_P1_C1.refs.DIV, isUp: true, arg: ARG},
-        {node: parent.refs.P_P1, isUp: true, arg: ARG},
-        {node: parent.refs.P, isUp: true, arg: ARG},
-      ];
-      ReactDOMTreeTraversal.traverseEnterLeave(
-        leave, enter, argAggregator, ARG, ARG2
-      );
       expect(aggregatedArgs).toEqual(expectedAggregation);
     });
   });

--- a/src/renderers/shared/event/EventConstants.js
+++ b/src/renderers/shared/event/EventConstants.js
@@ -56,6 +56,8 @@ var topLevelTypes = keyMirror({
   topLoadedMetadata: null,
   topLoadStart: null,
   topMouseDown: null,
+  topMouseEnter: null,
+  topMouseLeave: null,
   topMouseMove: null,
   topMouseOut: null,
   topMouseOver: null,

--- a/src/renderers/shared/event/EventPluginUtils.js
+++ b/src/renderers/shared/event/EventPluginUtils.js
@@ -248,6 +248,9 @@ var EventPluginUtils = {
   getParentInstance: function(inst) {
     return TreeTraversal.getParentInstance(inst);
   },
+  traverseUntil: function(inst, fn) {
+    return TreeTraversal.traverseUntil(inst, fn);
+  },
   traverseTwoPhase: function(target, fn, arg) {
     return TreeTraversal.traverseTwoPhase(target, fn, arg);
   },


### PR DESCRIPTION
makes an attempt at fixing #4251.

First, I added support for native mouseenter and mouseleave, I am not sure why they weren't used before, there may have been a good reason I didn't realize :)

This drastically changes how enter|leave is implemented, modeled after the jQuery approach. I tried to keep with the current implementation but browsers just don't fire the necessary mouse events so it seemed that there was no way to "fix" the current approach.

The EnterLeave logic is pretty deeply integrated so I am not sure I added the various utils in the right spot to maintain correct encapsulation.

While fairly easy to implement with normal handlers the React event system made this sort of tough since you don't know interested nodes. One concern with this approach is that it needs to walk up the instance tree for every mouseout|over event fired to try and find a parent node listening for enter|leave. I thought this approach was more in keeping with how stuff works other places, but I wasn't sure if it represents an unacceptable philosophical or perf concern (my light testing didn't seem to indicate that).

Alternatively I could have just used the didPutListener hook to manually attach mouse over|out listeners.

There could also be a hook or accumulation pattern that does this already that I missed.

thanks for all the hard work ya'll and Happy new years!
