### PR TITLE
Update 10.4-test-utils.md

### DIFF
--- a/docs/docs/10.4-test-utils.md
+++ b/docs/docs/10.4-test-utils.md
@@ -232,6 +232,7 @@ After `render` has been called, returns shallowly rendered output. You can then 
 Then you can assert:
 
 ```javascript
+var renderer = ReactTestUtils.createRenderer();
 result = renderer.getRenderOutput();
 expect(result.type).toBe('div');
 expect(result.props.children).toEqual([


### PR DESCRIPTION
Added `var renderer = ReactTestUtils.createRenderer();` (Line 235) to clarify where `renderer` (Line 236) comes from.