### PR TITLE
Fix wording to make it more clear that checkbox (input) supports defaultChecked

### DIFF
--- a/docs/docs/07-forms.md
+++ b/docs/docs/07-forms.md
@@ -95,7 +95,7 @@ If you want to initialize the component with a non-empty value, you can supply a
 
 This example will function much like the **Uncontrolled Components** example above.
 
-Likewise, `<input>` supports `defaultChecked` and `<select>` supports `defaultValue`.
+Likewise, `<input type="checkbox">` and `<input type="radio">` support `defaultChecked`, and `<select>` supports `defaultValue`.
 
 > Note:
 >


### PR DESCRIPTION
Fix some confusion about why `input` would support `defaultChecked` (it's because you can have an input of type checkbox).  This has come up a couple of times (https://github.com/facebook/react/pull/5633, https://github.com/facebook/react/pull/5774) but both those PRs were wrong and it was just easier to fix it myself.