### PR TITLE
Added a new lifecycle method componentWillReceiveContext()

### DIFF
--- a/docs/docs/12-context.md
+++ b/docs/docs/12-context.md
@@ -145,6 +145,14 @@ void componentDidUpdate(
 )
 ```
 
+Additionally, a new lifecycle method named `componentWillReceiveContext` is included, which is called after `componentWillReceiveProps`, but before the update occurs. This method will *always* be called if contexts are enabled, unlike `componentWillReceiveProps`, which is only called if props change.
+
+```javascript
+void componentWillReceiveContext(
+  object nextContext
+)
+```
+
 ## Referencing context in stateless functional components
 
 Stateless functional components are also able to reference `context` if `contextTypes` is defined as a property of the function. The following code shows the `Button` component above written as a stateless functional component.

--- a/src/isomorphic/classic/__tests__/ReactContextValidator-test.js
+++ b/src/isomorphic/classic/__tests__/ReactContextValidator-test.js
@@ -73,6 +73,7 @@ describe('ReactContextValidator', function() {
 
   it('should filter context properly in callbacks', function() {
     var actualComponentWillReceiveProps;
+    var actualComponentWillReceiveContext;
     var actualShouldComponentUpdate;
     var actualComponentWillUpdate;
     var actualComponentDidUpdate;
@@ -105,6 +106,11 @@ describe('ReactContextValidator', function() {
         return true;
       },
 
+      componentWillReceiveContext: function(nextContext) {
+        actualComponentWillReceiveContext = nextContext;
+        return true;
+      },
+
       shouldComponentUpdate: function(nextProps, nextState, nextContext) {
         actualShouldComponentUpdate = nextContext;
         return true;
@@ -127,6 +133,7 @@ describe('ReactContextValidator', function() {
     ReactDOM.render(<Parent foo="abc" />, container);
     ReactDOM.render(<Parent foo="def" />, container);
     expect(actualComponentWillReceiveProps).toEqual({foo: 'def'});
+    expect(actualComponentWillReceiveContext).toEqual({foo: 'def'});
     expect(actualShouldComponentUpdate).toEqual({foo: 'def'});
     expect(actualComponentWillUpdate).toEqual({foo: 'def'});
     expect(actualComponentDidUpdate).toEqual({foo: 'abc'});

--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -220,6 +220,18 @@ var ReactClassInterface = {
   componentWillReceiveProps: SpecPolicy.DEFINE_MANY,
 
   /**
+   * Invoked before the component receives new context.
+   *
+   * This method is analogous to `componentWillReceiveProps`,
+   * but will only receive the new and changed context. This method exists
+   * for situations where the former does not trigger, as props have not changed.
+   *
+   * @param {object} nextContext
+   * @optional
+   */
+  componentWillReceiveContext: SpecPolicy.DEFINE_MANY,
+
+  /**
    * Invoked while deciding if the component should be updated as a result of
    * receiving new props, state and/or context.
    *
@@ -839,6 +851,12 @@ var ReactClass = {
         '%s has a method called ' +
         'componentWillRecieveProps(). Did you mean componentWillReceiveProps()?',
         spec.displayName || 'A component'
+      );
+      warning(
+          !Constructor.prototype.componentWillRecieveContext,
+          '%s has a method called ' +
+          'componentWillRecieveContext(). Did you mean componentWillReceiveContext()?',
+          spec.displayName || 'A component'
       );
     }
 

--- a/src/isomorphic/classic/class/__tests__/ReactClass-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactClass-test.js
@@ -178,6 +178,22 @@ describe('ReactClass-spec', function() {
     );
   });
 
+  it('should warn when mispelling componentWillReceiveContext', function() {
+    React.createClass({
+      componentWillRecieveContext: function() {
+        return false;
+      },
+      render: function() {
+        return <div />;
+      },
+    });
+    expect(console.error.argsForCall.length).toBe(1);
+    expect(console.error.argsForCall[0][0]).toBe(
+        'Warning: A component has a method called componentWillRecieveContext(). Did you ' +
+        'mean componentWillReceiveContext()?'
+    );
+  });
+
   it('should throw if a reserved property is in statics', function() {
     expect(function() {
       React.createClass({

--- a/src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
+++ b/src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
@@ -233,6 +233,34 @@ class NormalLifeCycles extends React.Component {
   }
 }
 
+// will call context life cycle methods
+class ContextChildLifeCycles extends React.Component {
+  props : any;
+  state = {};
+  static contextTypes = { foo: React.PropTypes.string };
+  componentWillReceiveProps(nextProps, nextContext) {
+    lifeCycles.push('receive-props', nextProps, nextContext);
+  }
+  componentWillReceiveContext(nextContext) {
+    lifeCycles.push('receive-context', nextContext);
+  }
+  render() {
+    return React.createElement('span', {className: this.props.value});
+  }
+}
+
+class ContextParentLifeCycles extends React.Component {
+  static childContextTypes = { foo: React.PropTypes.string };
+  getChildContext() {
+    return {
+      foo: 'foo'
+    };
+  }
+  render() {
+    return React.createElement('div', {}, React.createElement(ContextChildLifeCycles, { value: this.props.value }));
+  }
+}
+
 // warns when classic properties are defined on the instance,
 // but does not invoke them.
 var getInitialStateWasCalled = false;
@@ -266,6 +294,16 @@ class MisspelledComponent1 extends React.Component {
 // it should warn when misspelling componentWillReceiveProps
 class MisspelledComponent2 extends React.Component {
   componentWillRecieveProps() {
+    return false;
+  }
+  render() {
+    return React.createElement('span', {className: 'foo'});
+  }
+}
+
+// it should warn when misspelling componentWillReceiveContext
+class MisspelledComponent3 extends React.Component {
+  componentWillRecieveContext() {
     return false;
   }
   render() {
@@ -428,6 +466,20 @@ describe('ReactTypeScriptClass', function() {
     ]);
   });
 
+  it('will call context life cycle methods', function() {
+    lifeCycles = [];
+    test(React.createElement(ContextParentLifeCycles, {value: 'bar'}), 'DIV', '');
+    expect(lifeCycles).toEqual([]);
+
+    test(React.createElement(ContextParentLifeCycles, {value: 'baz'}), 'DIV', '');
+    expect(lifeCycles).toEqual([
+      'receive-props', {value: 'baz'}, {foo: 'foo'},
+      'receive-context', {foo: 'foo'}
+    ]);
+
+    ReactDOM.unmountComponentAtNode(container);
+  });
+
   it('warns when classic properties are defined on the instance, ' +
      'but does not invoke them.', function() {
     spyOn(console, 'error');
@@ -477,6 +529,19 @@ describe('ReactTypeScriptClass', function() {
       'Warning: ' +
       'MisspelledComponent2 has a method called componentWillRecieveProps(). ' +
       'Did you mean componentWillReceiveProps()?'
+    );
+  });
+
+  it('should warn when misspelling componentWillReceiveContext', function() {
+    spyOn(console, 'error');
+
+    test(React.createElement(MisspelledComponent3), 'SPAN', 'foo');
+
+    expect((<any>console.error).argsForCall.length).toBe(1);
+    expect((<any>console.error).argsForCall[0][0]).toBe(
+        'Warning: ' +
+        'MisspelledComponent3 has a method called componentWillRecieveContext(). ' +
+        'Did you mean componentWillReceiveContext()?'
     );
   });
 

--- a/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
@@ -140,6 +140,9 @@ describe('ReactServerRendering', function() {
           componentWillReceiveProps: function() {
             lifecycle.push('componentWillReceiveProps');
           },
+          componentWillReceiveContext: function() {
+            lifecycle.push('componentWillReceiveContext');
+          },
           componentWillUnmount: function() {
             lifecycle.push('componentWillUnmount');
           },
@@ -330,6 +333,9 @@ describe('ReactServerRendering', function() {
           },
           componentWillReceiveProps: function() {
             lifecycle.push('componentWillReceiveProps');
+          },
+          componentWillReceiveContext: function() {
+            lifecycle.push('componentWillReceiveContext');
           },
           componentWillUnmount: function() {
             lifecycle.push('componentWillUnmount');

--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -59,6 +59,7 @@ StatelessComponent.prototype.render = function() {
  *
  *       Update Phases:
  *       - componentWillReceiveProps (only called if parent updated)
+ *       - componentWillReceiveContext (only if there is a context)
  *       - shouldComponentUpdate
  *         - componentWillUpdate
  *           - render
@@ -271,6 +272,12 @@ var ReactCompositeComponentMixin = {
         '%s has a method called ' +
         'componentWillRecieveProps(). Did you mean componentWillReceiveProps()?',
         (this.getName() || 'A component')
+      );
+      warning(
+          typeof inst.componentWillRecieveContext !== 'function',
+          '%s has a method called ' +
+          'componentWillRecieveContext(). Did you mean componentWillReceiveContext()?',
+          (this.getName() || 'A component')
       );
     }
 
@@ -625,10 +632,10 @@ var ReactCompositeComponentMixin = {
   },
 
   /**
-   * Perform an update to a mounted component. The componentWillReceiveProps and
-   * shouldComponentUpdate methods are called, then (assuming the update isn't
-   * skipped) the remaining update lifecycle methods are called and the DOM
-   * representation is updated.
+   * Perform an update to a mounted component. The `componentWillReceiveProps`,
+   * `componentWillReceiveContext`, and `shouldComponentUpdate` methods are called,
+   * then (assuming the update isn't skipped) the remaining update lifecycle methods
+   * are called and the DOM representation is updated.
    *
    * By default, this implements React's rendering and reconciliation algorithm.
    * Sophisticated clients may wish to override this.
@@ -667,6 +674,11 @@ var ReactCompositeComponentMixin = {
       if (inst.componentWillReceiveProps) {
         inst.componentWillReceiveProps(nextProps, nextContext);
       }
+    }
+
+    // Only trigger if the context is not an empty object
+    if (nextContext !== emptyObject && inst.componentWillReceiveContext) {
+      inst.componentWillReceiveContext(nextContext);
     }
 
     var nextState = this._processPendingState(nextProps, nextContext);

--- a/src/renderers/shared/reconciler/__tests__/ReactComponentLifeCycle-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactComponentLifeCycle-test.js
@@ -524,30 +524,40 @@ describe('ReactComponentLifeCycle', function() {
       };
     };
     var Outer = React.createClass({
+      childContextTypes: {
+        foo: React.PropTypes.string,
+      },
+      getChildContext() {
+        return { foo: 'bar' };
+      },
       render: function() {
         return <div><Inner x={this.props.x} /></div>;
       },
       componentWillMount: logger('outer componentWillMount'),
       componentDidMount: logger('outer componentDidMount'),
       componentWillReceiveProps: logger('outer componentWillReceiveProps'),
+      componentWillReceiveContext: logger('outer componentWillReceiveContext'),
       shouldComponentUpdate: logger('outer shouldComponentUpdate'),
       componentWillUpdate: logger('outer componentWillUpdate'),
       componentDidUpdate: logger('outer componentDidUpdate'),
       componentWillUnmount: logger('outer componentWillUnmount'),
     });
     var Inner = React.createClass({
+      contextTypes: {
+        foo: React.PropTypes.string,
+      },
       render: function() {
         return <span>{this.props.x}</span>;
       },
       componentWillMount: logger('inner componentWillMount'),
       componentDidMount: logger('inner componentDidMount'),
       componentWillReceiveProps: logger('inner componentWillReceiveProps'),
+      componentWillReceiveContext: logger('inner componentWillReceiveContext'),
       shouldComponentUpdate: logger('inner shouldComponentUpdate'),
       componentWillUpdate: logger('inner componentWillUpdate'),
       componentDidUpdate: logger('inner componentDidUpdate'),
       componentWillUnmount: logger('inner componentWillUnmount'),
     });
-
 
     var container = document.createElement('div');
     log = [];
@@ -566,6 +576,7 @@ describe('ReactComponentLifeCycle', function() {
       'outer shouldComponentUpdate',
       'outer componentWillUpdate',
       'inner componentWillReceiveProps',
+      'inner componentWillReceiveContext',
       'inner shouldComponentUpdate',
       'inner componentWillUpdate',
       'inner componentDidUpdate',

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -812,6 +812,10 @@ describe('ReactCompositeComponent', function() {
         expect('foo' in nextContext).toBe(true);
       },
 
+      componentWillReceiveContext: function(nextContext) {
+        expect('foo' in nextContext).toBe(true);
+      },
+
       componentDidUpdate: function(prevProps, prevState, prevContext) {
         expect('foo' in prevContext).toBe(true);
       },
@@ -829,6 +833,10 @@ describe('ReactCompositeComponent', function() {
     var Intermediary = React.createClass({
 
       componentWillReceiveProps: function(nextProps, nextContext) {
+        expect('foo' in nextContext).toBe(false);
+      },
+
+      componentWillReceiveContext: function(nextContext) {
         expect('foo' in nextContext).toBe(false);
       },
 
@@ -897,6 +905,68 @@ describe('ReactCompositeComponent', function() {
     );
   });
 
+  it('should not call componentWillReceiveContext for the defining component', function() {
+    var notTriggered = true;
+
+    var Child = React.createClass({
+      contextTypes: {
+        foo: React.PropTypes.string,
+      },
+      render() {
+        return <div />;
+      },
+    });
+
+    var Parent = React.createClass({
+      childContextTypes: {
+        foo: React.PropTypes.string,
+      },
+      getChildContext() {
+        return { foo: 'bar' };
+      },
+      componentWillReceiveContext() {
+        notTriggered = false;
+      },
+      render() {
+        return <Child />;
+      },
+    });
+
+    ReactDOM.render(<Parent />, document.createElement('div'));
+    expect(notTriggered).toBe(true);
+  });
+
+  it('should not call componentWillReceiveContext if the context is an empty object', function() {
+    var notTriggered = true;
+
+    var Child = React.createClass({
+      contextTypes: {
+        foo: React.PropTypes.string,
+      },
+      componentWillReceiveContext() {
+        notTriggered = false;
+      },
+      render() {
+        return <div />;
+      },
+    });
+
+    var Parent = React.createClass({
+      childContextTypes: {
+        foo: React.PropTypes.string,
+      },
+      getChildContext() {
+        return { };
+      },
+      render() {
+        return <Child />;
+      },
+    });
+
+    ReactDOM.render(<Parent />, document.createElement('div'));
+    expect(notTriggered).toBe(true);
+  });
+
   it('only renders once if updated in componentWillReceiveProps', function() {
     var renders = 0;
     var Component = React.createClass({
@@ -920,6 +990,49 @@ describe('ReactCompositeComponent', function() {
     ReactDOM.render(<Component update={1} />, container);
     expect(renders).toBe(2);
     expect(instance.state.updated).toBe(true);
+  });
+
+  it('only renders once if updated in componentWillReceiveContext', function() {
+    var renders = 0;
+    var Child = React.createClass({
+      contextTypes: {
+        update: React.PropTypes.number,
+      },
+      getInitialState: function() {
+        return {updated: false};
+      },
+      componentWillReceiveContext: function(context) {
+        expect(context.update).toBe(1);
+        this.setState({updated: Boolean(context.update) });
+      },
+      render: function() {
+        renders++;
+        return <div />;
+      },
+    });
+
+    var Parent = React.createClass({
+      childContextTypes: {
+        update: React.PropTypes.number,
+      },
+      getDefaultProps() {
+        return { update: 0 };
+      },
+      getChildContext() {
+        return { update: this.props.update };
+      },
+      render() {
+        return <Child ref="child" />;
+      },
+    });
+
+    var container = document.createElement('div');
+    var instance = ReactDOM.render(<Parent update={0} />, container);
+    expect(renders).toBe(1);
+    expect(instance.refs.child.state.updated).toBe(false);
+    ReactDOM.render(<Parent update={1} />, container);
+    expect(renders).toBe(2);
+    expect(instance.refs.child.state.updated).toBe(true);
   });
 
   it('should update refs if shouldComponentUpdate gives false', function() {


### PR DESCRIPTION
I've been working with contexts a lot lately, and have run into a few issues where the current lifecycle isn't perfect. Specifically, I encounter certain situations where `componentWillReceiveProps` isn't triggered, even though the context has changed: https://github.com/facebook/react/issues/5756.

This new lifecycle may help with certain situations regarding contexts, like the following issues: https://github.com/facebook/react/issues/2517 https://github.com/facebook/react/pull/3973