### PR TITLE
support onLoad synthetic event attribute on 'object' tags

### DIFF
--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -265,6 +265,7 @@ function trapBubbledEventsLocal() {
 
   switch (inst._tag) {
     case 'iframe':
+    case 'object':
       inst._wrapperState.listeners = [
         ReactBrowserEventEmitter.trapBubbledEvent(
           EventConstants.topLevelTypes.topLoad,
@@ -465,6 +466,7 @@ ReactDOMComponent.Mixin = {
 
     switch (this._tag) {
       case 'iframe':
+      case 'object':
       case 'img':
       case 'form':
       case 'video':
@@ -1022,6 +1024,7 @@ ReactDOMComponent.Mixin = {
   unmountComponent: function() {
     switch (this._tag) {
       case 'iframe':
+      case 'object':
       case 'img':
       case 'form':
       case 'video':


### PR DESCRIPTION
It seems like a bug that onLoad attributes are ignored on 'object' tags - this fixes it by cargoculting the 'iframe' tag example.  This is useful for telling when SVGs have loaded when SVGs are embedded as objects (such that the SVG can be dynamically edited from JS).