### PR TITLE
[docs] remove unnecessary findDOMNode from example

### DIFF
--- a/docs/tips/18-use-react-with-other-libraries.ko-KR.md
+++ b/docs/tips/18-use-react-with-other-libraries.ko-KR.md
@@ -16,7 +16,7 @@ var App = React.createClass({
   },
 
   componentDidMount: function() {
-    $(ReactDOM.findDOMNode(this.refs.placeholder)).append($('<span />'));
+    $(this.refs.placeholder).append($('<span />'));
   },
 
   componentWillUnmount: function() {

--- a/docs/tips/18-use-react-with-other-libraries.md
+++ b/docs/tips/18-use-react-with-other-libraries.md
@@ -16,7 +16,7 @@ var App = React.createClass({
   },
 
   componentDidMount: function() {
-    $(ReactDOM.findDOMNode(this.refs.placeholder)).append($('<span />'));
+    $(this.refs.placeholder).append($('<span />'));
   },
 
   componentWillUnmount: function() {


### PR DESCRIPTION
This call is not needed anymore due to https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#dom-node-refs