### PR TITLE
Replace REACT_ELEMENT_TYPE magicnum with Infinity.

### DIFF
--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -20,7 +20,7 @@ var canDefineProperty = require('canDefineProperty');
 // nor polyfill, then a plain number is used for performance.
 var REACT_ELEMENT_TYPE =
   (typeof Symbol === 'function' && Symbol.for && Symbol.for('react.element')) ||
-  0xeac7;
+  Infinity;
 
 var RESERVED_PROPS = {
   key: true,

--- a/src/isomorphic/classic/element/__tests__/ReactElement-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElement-test.js
@@ -45,7 +45,7 @@ describe('ReactElement', function() {
   });
 
   it('uses the fallback value when in an environment without Symbol', function() {
-    expect(<div />.$$typeof).toBe(0xeac7);
+    expect(<div />.$$typeof).toBe(Infinity);
   });
 
   it('returns a complete element according to spec', function() {
@@ -207,7 +207,9 @@ describe('ReactElement', function() {
     expect(React.isValidElement({ type: 'div', props: {} })).toEqual(false);
 
     var jsonElement = JSON.stringify(React.createElement('div'));
-    expect(React.isValidElement(JSON.parse(jsonElement))).toBe(true);
+    // Should be false, even with Symbol not present, due to Infinity value
+    // which cannot be serialized into/from JSON.
+    expect(React.isValidElement(JSON.parse(jsonElement))).toBe(false);
   });
 
   it('allows the use of PropTypes validators in statics', function() {


### PR DESCRIPTION
This closes the XSS hole on older browsers that don't support Symbol.

More discussion: https://github.com/facebook/react/pull/4832#discussion_r39344352

Figured this would be helpful to get in before 0.15 hits.