### PR TITLE
Add children as a proptype

### DIFF
--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -85,6 +85,11 @@ var ReactPropTypes = {
   shape: createShapeTypeChecker,
 };
 
+ReactPropTypes.children = ReactPropTypes.oneOfType([
+  ReactPropTypes.node,
+  ReactPropTypes.arrayOf(ReactPropTypes.node),
+]);
+
 function createChainableTypeChecker(validate) {
   function checkType(
     isRequired,

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -466,6 +466,11 @@ describe('ReactPropTypes', function() {
     it('should accept empty array for required props', function() {
       typeCheckPass(PropTypes.node.isRequired, []);
     });
+
+    it('should accept both single child and array of children for the children prop type', function() {
+      typeCheckPass(PropTypes.children, <div/>);
+      typeCheckPass(PropTypes.children, [<div/>, <div/>]);
+    });
   });
 
   describe('ObjectOf Type', function() {


### PR DESCRIPTION
I'm not sure if you actually want this, but it's a small thing, so why not just push it?

We created this small `PropType` for our components that has to have some children, but whether it's a single child or multiple doesn't matter.