### PR TITLE
Adds new prop type validator for functions with a specific arity

### DIFF
--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -58,6 +58,9 @@ React.createClass({
       fontSize: React.PropTypes.number
     }),
 
+    // A function with a specific arity
+    optionalFuncWithArity: React.PropTypes.funcWithArity(2)
+
     // You can chain any of the above with `isRequired` to make sure a warning
     // is shown if the prop isn't provided.
     requiredFunc: React.PropTypes.func.isRequired,

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -83,6 +83,7 @@ var ReactPropTypes = {
   oneOf: createEnumTypeChecker,
   oneOfType: createUnionTypeChecker,
   shape: createShapeTypeChecker,
+  funcWithArity: createFuncWithArityTypeChecker,
 };
 
 function createChainableTypeChecker(validate) {
@@ -339,6 +340,32 @@ function createShapeTypeChecker(shapeTypes) {
     }
     return null;
   }
+  return createChainableTypeChecker(validate);
+}
+
+function createFuncWithArityTypeChecker(expectedArity) {
+  var funcTypeCheck = createPrimitiveTypeChecker('function');
+
+  function validate(props, propName, componentName, location, propFullName) {
+    var funcTypeError = funcTypeCheck.apply(this, arguments);
+
+    if (funcTypeError !== null) {
+      return funcTypeError;
+    }
+
+    var propArity = props[propName].length;
+    if (propArity !== expectedArity) {
+      var locationName = ReactPropTypeLocationNames[location];
+
+      return new Error(
+        `Invalid ${locationName} \`${propFullName}\` with arity of ` +
+        `\`${propArity}\` supplied to \`${componentName}\`, expected arity of ` +
+        `\`${expectedArity}\`.`
+      );
+    }
+    return null;
+  }
+
   return createChainableTypeChecker(validate);
 }
 

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -82,6 +82,15 @@ describe('ReactPropTypes', function() {
       );
     });
 
+    it('should warn for invalid functions', function() {
+      typeCheckFail(
+        PropTypes.func,
+        'not a function',
+        'Invalid prop `testProp` of type `string` supplied to ' +
+        '`testComponent`, expected `function`.'
+      );
+    });
+
     it('should fail date and regexp correctly', function() {
       typeCheckFail(
         PropTypes.string,
@@ -774,6 +783,24 @@ describe('ReactPropTypes', function() {
         PropTypes.shape({key: PropTypes.number}).isRequired,
         undefined,
         requiredMessage
+      );
+    });
+  });
+
+  describe('Function with arity', function() {
+    it('should warn for incorrect arity', function() {
+      typeCheckFail(PropTypes.funcWithArity(2),
+        function(a) { },
+        'Invalid prop `testProp` with arity of `1` supplied to `testComponent`, ' +
+        'expected arity of `2`.'
+      );
+    });
+
+    it('should warn if prop is not a function', function() {
+      typeCheckFail(PropTypes.funcWithArity(2),
+        'not-a-function',
+        'Invalid prop `testProp` of type `string` supplied to ' +
+        '`testComponent`, expected `function`.'
       );
     });
   });


### PR DESCRIPTION
I use prop type validation frequently while writing react components. Recently I wished I had a way to ensure a function passed in as a prop had a specific arity. 

I wasn't sure if this was worth the effort, but the code to add it was fairly trivial so it seemed worthy of a pull request.