### PR TITLE
Remove the recommendation to use `isMounted` from beginner docs

### DIFF
--- a/docs/tips/12-initial-ajax.md
+++ b/docs/tips/12-initial-ajax.md
@@ -9,7 +9,7 @@ next: false-in-jsx.html
 
 Fetch data in `componentDidMount`. When the response arrives, store the data in state, triggering a render to update your UI.
 
-When processing the response of an asynchronous request, be sure to check that the component is still mounted before updating its state by using `this.isMounted()`.
+When fetching data asynchronously, use `componentWillUnmount` to cancel any outstanding requests before the component is unmounted.
 
 This example fetches the desired Github user's latest gist:
 
@@ -23,15 +23,19 @@ var UserGist = React.createClass({
   },
 
   componentDidMount: function() {
-    $.get(this.props.source, function(result) {
-      var lastGist = result[0];
-      if (this.isMounted()) {
+    this.setState({
+      serverRequest: $.get(this.props.source, function(result) {
+        var lastGist = result[0];
         this.setState({
           username: lastGist.owner.login,
           lastGistUrl: lastGist.html_url
         });
-      }
-    }.bind(this));
+      }.bind(this))
+    });
+  },
+  
+  componentWillUnmount: function() {
+    this.state.serverRequest.abort();
   },
 
   render: function() {


### PR DESCRIPTION
Not sure how you want to phrase it, but here's a quick go at it.

I noticed that the tips-section on [loading initial data over ajax](https://facebook.github.io/react/tips/initial-ajax.html) includes a recommendation to use `isMounted`, while the front page of the blog says not to. Seems to be a tad contradictory, so I (try to) fix it here :smile: 