### PR TITLE
#5473 warn and ignore setState and forceUpdate calls if rendered on server

### DIFF
--- a/src/isomorphic/modern/class/ReactComponent.js
+++ b/src/isomorphic/modern/class/ReactComponent.js
@@ -71,6 +71,15 @@ ReactComponent.prototype.setState = function(partialState, callback) {
       'setState(...): You passed an undefined or null state object; ' +
       'instead, use forceUpdate().'
     );
+    if (this._reactInternalInstance &&
+        this._reactInternalInstance._isServerSideRendered) {
+      warning(
+        false,
+        'setState(...): method calls are ignored if component was ' +
+        'rendered on server.'
+      );
+      return;
+    }
   }
   this.updater.enqueueSetState(this, partialState);
   if (callback) {
@@ -93,6 +102,17 @@ ReactComponent.prototype.setState = function(partialState, callback) {
  * @protected
  */
 ReactComponent.prototype.forceUpdate = function(callback) {
+  if (__DEV__) {
+    if (this._reactInternalInstance &&
+        this._reactInternalInstance._isServerSideRendered) {
+      warning(
+        false,
+        'forceUpdate(...): method calls are ignored if component was ' +
+        'rendered on server.'
+      );
+      return;
+    }
+  }
   this.updater.enqueueForceUpdate(this);
   if (callback) {
     this.updater.enqueueCallback(this, callback);

--- a/src/isomorphic/modern/class/ReactComponent.js
+++ b/src/isomorphic/modern/class/ReactComponent.js
@@ -72,10 +72,12 @@ ReactComponent.prototype.setState = function(partialState, callback) {
       'instead, use forceUpdate().'
     );
     if (this._reactInternalInstance &&
-        this._reactInternalInstance._isServerSideRendered) {
+        this._reactInternalInstance._isServerSideRendered &&
+        this._reactInternalInstance._isServerSideRendered.isAfterComponentWillMount) {
       warning(
         false,
-        'setState(...): method calls are ignored if component was ' +
+        'setState(...): method calls executed after componentWillMount ' +
+        '(e.g. setTimeout() callbacks)  are ignored if component was ' +
         'rendered on server.'
       );
       return;
@@ -107,7 +109,7 @@ ReactComponent.prototype.forceUpdate = function(callback) {
         this._reactInternalInstance._isServerSideRendered) {
       warning(
         false,
-        'forceUpdate(...): method calls are ignored if component was ' +
+        'forceUpdate(...): all method calls are ignored if component was ' +
         'rendered on server.'
       );
       return;

--- a/src/renderers/dom/server/ReactServerRendering.js
+++ b/src/renderers/dom/server/ReactServerRendering.js
@@ -42,7 +42,7 @@ function renderToStringImpl(element, makeStaticMarkup) {
     return transaction.perform(function() {
       var componentInstance = instantiateReactComponent(element);
       if (__DEV__) {
-        componentInstance._isServerSideRendered = {isAfterComponentWillMount: false};
+        componentInstance._serverSideRendered = {isAfterComponentWillMount: false};
       }
       var markup = componentInstance.mountComponent(
         transaction,

--- a/src/renderers/dom/server/ReactServerRendering.js
+++ b/src/renderers/dom/server/ReactServerRendering.js
@@ -41,6 +41,9 @@ function renderToStringImpl(element, makeStaticMarkup) {
 
     return transaction.perform(function() {
       var componentInstance = instantiateReactComponent(element);
+      if (__DEV__) {
+        componentInstance._isServerSideRendered = true;
+      }
       var markup = componentInstance.mountComponent(
         transaction,
         null,

--- a/src/renderers/dom/server/ReactServerRendering.js
+++ b/src/renderers/dom/server/ReactServerRendering.js
@@ -42,7 +42,7 @@ function renderToStringImpl(element, makeStaticMarkup) {
     return transaction.perform(function() {
       var componentInstance = instantiateReactComponent(element);
       if (__DEV__) {
-        componentInstance._isServerSideRendered = true;
+        componentInstance._isServerSideRendered = {isAfterComponentWillMount: false};
       }
       var markup = componentInstance.mountComponent(
         transaction,

--- a/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
@@ -255,14 +255,15 @@ describe('ReactServerRendering', function() {
       );
     });
 
-    it('should warn and ignore setState calls executed ' +
+    it('should warn once and ignore setState calls executed ' +
         'after componentWillMount', function() {
       spyOn(console, 'error');
 
       var Component = React.createClass({
         componentWillMount: function() {
           setTimeout(() => {
-            this.setState({text: 'hello, world'});
+            this.setState({hello: 'from the'});
+            this.setState({other: 'side'});
           });
         },
         render: function() {
@@ -288,7 +289,7 @@ describe('ReactServerRendering', function() {
       );
     });
 
-    it('should warn and ignore all forceUpdate calls', function() {
+    it('should warn once and ignore all forceUpdate calls', function() {
       spyOn(console, 'error');
 
       var Component = React.createClass({
@@ -311,13 +312,11 @@ describe('ReactServerRendering', function() {
         <Component />
       );
 
-      var expectedError = 'forceUpdate(...): all method calls are ignored ' +
-        'if component was rendered on server.';
       jest.runAllTimers();
       expect(setTimeout.mock.calls.length).toBe(1);
-      expect(console.error.calls.length).toBe(2);
-      expect(console.error.argsForCall[0][0]).toContain(expectedError);
-      expect(console.error.argsForCall[1][0]).toContain(expectedError);
+      expect(console.error.calls.length).toBe(1);
+      expect(console.error.argsForCall[0][0]).toContain('forceUpdate(...): ' +
+        'all method calls are ignored if component was rendered on server.');
     });
   });
 

--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -350,8 +350,8 @@ var ReactCompositeComponentMixin = {
     }
 
     if (__DEV__) {
-      if (this._isServerSideRendered) {
-        this._isServerSideRendered.isAfterComponentWillMount = true;
+      if (this._serverSideRendered) {
+        this._serverSideRendered.isAfterComponentWillMount = true;
       }
     }
 

--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -349,6 +349,12 @@ var ReactCompositeComponentMixin = {
       }
     }
 
+    if (__DEV__) {
+      if (this._isServerSideRendered) {
+        this._isServerSideRendered.isAfterComponentWillMount = true;
+      }
+    }
+
     // If not a stateless component, we now render
     if (renderedElement === undefined) {
       renderedElement = this._renderValidatedComponent();

--- a/src/renderers/shared/reconciler/instantiateReactComponent.js
+++ b/src/renderers/shared/reconciler/instantiateReactComponent.js
@@ -122,6 +122,7 @@ function instantiateReactComponent(node) {
   if (__DEV__) {
     instance._isOwnerNecessary = false;
     instance._warnedAboutRefsInRender = false;
+    instance._isServerSideRendered = false;
   }
 
   // Internal instances should fully constructed at this point, so they should

--- a/src/renderers/shared/reconciler/instantiateReactComponent.js
+++ b/src/renderers/shared/reconciler/instantiateReactComponent.js
@@ -122,7 +122,7 @@ function instantiateReactComponent(node) {
   if (__DEV__) {
     instance._isOwnerNecessary = false;
     instance._warnedAboutRefsInRender = false;
-    instance._isServerSideRendered = false;
+    instance._serverSideRendered = null;
   }
 
   // Internal instances should fully constructed at this point, so they should


### PR DESCRIPTION
As discussed in the #5473:
>In dev mode, we could mark a component as having been rendered using SSR. If setState or forceUpdate is ever called on such a component, print an intelligent warning.