### PR TITLE
Enable null return values in plain functions

### DIFF
--- a/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
+++ b/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
@@ -64,9 +64,7 @@ describe('ReactES6Class', function() {
     expect(console.error.calls.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toBe(
       'Warning: Foo(...): No `render` method found on the returned component ' +
-      'instance: you may have forgotten to define `render`, returned ' +
-      'null/false from a stateless component, or tried to render an element ' +
-      'whose type is a function that isn\'t a React component.'
+      'instance: you may have forgotten to define `render`.'
     );
   });
 

--- a/src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
+++ b/src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
@@ -319,9 +319,7 @@ describe('ReactTypeScriptClass', function() {
     expect((<any>console.error).argsForCall.length).toBe(1);
     expect((<any>console.error).argsForCall[0][0]).toBe(
       'Warning: Empty(...): No `render` method found on the returned ' +
-      'component instance: you may have forgotten to define `render`, ' +
-      'returned null/false from a stateless component, or tried to render an ' +
-      'element whose type is a function that isn\'t a React component.'
+      'component instance: you may have forgotten to define `render`.'
     );
   });
 

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -1103,19 +1103,6 @@ describe('ReactCompositeComponent', function() {
     expect(a).toBe(b);
   });
 
-  it('should warn when using non-React functions in JSX', function() {
-    function NotAComponent() {
-      return [<div />, <div />];
-    }
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(<div><NotAComponent /></div>);
-    }).toThrow();  // has no method 'render'
-    expect(console.error.calls.length).toBe(1);
-    expect(console.error.argsForCall[0][0]).toContain(
-      'NotAComponent(...): No `render` method found'
-    );
-  });
-
   it('context should be passed down from the parent', function() {
     var Parent = React.createClass({
       childContextTypes: {
@@ -1245,37 +1232,6 @@ describe('ReactCompositeComponent', function() {
     ReactDOM.render(<Outer />, container);
 
     expect(console.error.calls.length).toBe(0);
-  });
-
-  it('should warn when a class does not extend React.Component', function() {
-
-    var container = document.createElement('div');
-
-    class Foo {
-      render() {
-        return <span />;
-      }
-    }
-
-    function Bar() { }
-    Bar.prototype = Object.create(React.Component.prototype);
-    Bar.prototype.render = function() {
-      return <span />;
-    };
-
-    expect(console.error.calls.length).toBe(0);
-
-    ReactDOM.render(<Bar />, container);
-
-    expect(console.error.calls.length).toBe(0);
-
-    ReactDOM.render(<Foo />, container);
-
-    expect(console.error.calls.length).toBe(1);
-    expect(console.error.argsForCall[0][0]).toContain(
-      'React component classes must extend React.Component'
-    );
-
   });
 
   it('should warn when mutated props are passed', function() {

--- a/src/renderers/shared/reconciler/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactStatelessComponent-test.js
@@ -98,19 +98,19 @@ describe('ReactStatelessComponent', function() {
     expect(el.textContent).toBe('mest');
   });
 
-  it('should support module pattern components', function() {
-    function Child({test}) {
-      return {
-        render() {
-          return <div>{test}</div>;
-        },
-      };
+  it('should warn when stateless component returns array', function() {
+    spyOn(console, 'error');
+    function NotAComponent() {
+      return [<div />, <div />];
     }
-
-    var el = document.createElement('div');
-    ReactDOM.render(<Child test="test" />, el);
-
-    expect(el.textContent).toBe('test');
+    expect(function() {
+      ReactTestUtils.renderIntoDocument(<div><NotAComponent /></div>);
+    }).toThrow();
+    expect(console.error.calls.length).toBe(1);
+    expect(console.error.argsForCall[0][0]).toContain(
+      'NotAComponent must be a class extending React.Component or be a stateless ' +
+      'function that returns a valid React element.'
+    );
   });
 
   it('should throw on string refs in pure functions', function() {
@@ -204,10 +204,6 @@ describe('ReactStatelessComponent', function() {
   });
 
   it('should work with arrow functions', function() {
-    // TODO: actually use arrow functions, probably need node v4 and maybe
-    // a separate file that we blacklist from the arrow function transform.
-    // We can't actually test this without native arrow functions since the
-    // issues (non-newable) don't apply to any other functions.
     var Child = function() {
       return <div />;
     };
@@ -216,5 +212,34 @@ describe('ReactStatelessComponent', function() {
     Child = Child.bind(this);
 
     expect(() => ReactTestUtils.renderIntoDocument(<Child />)).not.toThrow();
+  });
+
+  it('should allow simple functions to return null', function() {
+    var Child = function() {
+      return null;
+    };
+    expect(() => ReactTestUtils.renderIntoDocument(<Child />)).not.toThrow();
+  });
+
+  it('should allow simple functions to return false', function() {
+    function Child() {
+      return false;
+    };
+    expect(() => ReactTestUtils.renderIntoDocument(<Child />)).not.toThrow();
+  });
+
+  it('should warn when using non-React functions in JSX', function() {
+    spyOn(console, 'error');
+    function NotAComponent() {
+      return [<div />, <div />];
+    }
+    expect(function() {
+      ReactTestUtils.renderIntoDocument(<div><NotAComponent /></div>);
+    }).toThrow();  // has no method 'render'
+    expect(console.error.calls.length).toBe(1);
+    expect(console.error.argsForCall[0][0]).toContain(
+      'Warning: NotAComponent must be a class extending React.Component or be a stateless ' +
+      'function that returns a valid React element.'
+    );
   });
 });


### PR DESCRIPTION
Enable null return values in plain functions by removing support for inheritless classes, as per #5355.
