### PR TITLE
Only add children in ReactDOMOption when there are children

### DIFF
--- a/src/renderers/dom/client/wrappers/ReactDOMOption.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMOption.js
@@ -85,7 +85,10 @@ var ReactDOMOption = {
       }
     });
 
-    nativeProps.children = content;
+    if (content) {
+      nativeProps.children = content;
+    }
+
     return nativeProps;
   },
 

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMOption-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMOption-test.js
@@ -63,4 +63,12 @@ describe('ReactDOMOption', function() {
     expect(console.error.calls.length).toBe(0);
     expect(node.innerHTML).toBe('1  2');
   });
+
+  it('should be able to use dangerouslySetInnerHTML on option', function() {
+    var stub = <option dangerouslySetInnerHTML={{ __html: 'foobar' }} />;
+    stub = ReactTestUtils.renderIntoDocument(stub);
+
+    var node = ReactDOM.findDOMNode(stub);
+    expect(node.innerHTML).toBe('foobar');
+  });
 });


### PR DESCRIPTION
After upgrading from 0.13 to 0.14 I found that you can't have dangerouslySetInnerHTML on an option tag. I get the invariant "Can only set one of `children` or `props.dangerouslySetInnerHTML`" which is confusing because I never set both. Upon inspecting React source code I see that option tags get children added in dynamically. This is technically a breaking change between 0.13.x and 0.14.x

Here's the [commit](https://github.com/facebook/react/commit/abfd151b90c54510d0a7a5b4404c443688510c35) which adds this behavior.

Here's one option in how to make this more user friendly, lets put up an invariant violation whenever you use dangerouslySetInnerHTML in option so at least you'll know where its coming from.

cc @spicyj 