### PR TITLE
CSSTransitionGroup don't fall back to deprecated behaviour if transition*Timeout is 0

### DIFF
--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -92,7 +92,7 @@ var ReactCSSTransitionGroupChild = React.createClass({
     this.queueClass(activeClassName);
 
     // If the user specified a timeout delay.
-    if (userSpecifiedDelay) {
+    if (typeof(userSpecifiedDelay) === 'number') {
       // Clean-up the animation after the specified delay
       timeout = setTimeout(endListener, userSpecifiedDelay);
       this.transitionTimeouts.push(timeout);

--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -92,7 +92,7 @@ var ReactCSSTransitionGroupChild = React.createClass({
     this.queueClass(activeClassName);
 
     // If the user specified a timeout delay.
-    if (typeof(userSpecifiedDelay) === 'number') {
+    if (userSpecifiedDelay != null) {
       // Clean-up the animation after the specified delay
       timeout = setTimeout(endListener, userSpecifiedDelay);
       this.transitionTimeouts.push(timeout);


### PR DESCRIPTION
After look around #5873 i think we should consider `transition*Timeout` if it's a number. Right now, if user passes any transitionTimeout as `0` it falls back to the deprecated behaviour