### PR TITLE
Overflow problem fixed

### DIFF
--- a/docs/css/react.scss
+++ b/docs/css/react.scss
@@ -409,6 +409,7 @@ h1, h2, h3, h4, h5, h6 {
   .playgroundPreview {
     padding: 0;
     width: 600px;
+    word-wrap: break-word;
 
     pre {
       @include code-typography;


### PR DESCRIPTION
I fixed the overflow problem in "Playground Preview" area example.

Old: 

<img width="436" alt="old" src="https://cloud.githubusercontent.com/assets/330566/12519955/7fe0d34c-c14a-11e5-9497-c6b81b134577.png">

New:

<img width="426" alt="new" src="https://cloud.githubusercontent.com/assets/330566/12519965/84bcde74-c14a-11e5-9094-a03b084cb1e2.png">
