### PR TITLE
Change tabIndex to MUST_USE_ATTRIBUTE to avoid special focus treatment in Chrome

### DIFF
--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -163,7 +163,7 @@ var HTMLDOMPropertyConfig = {
     step: null,
     style: null,
     summary: null,
-    tabIndex: null,
+    tabIndex: MUST_USE_ATTRIBUTE,
     target: null,
     title: null,
     // Setting .type throws on non-<input> tags


### PR DESCRIPTION
Chrome treats anchor tags with an explicit `tabIndex='0'` different then if the attribute was not present. Specifically when clicking a link with an implicit tab index (i.e. no attribute on the node) no focus outline is shown. Whereas with an explicit tabindex='0' it does get shown. This is super minor, but maintaining react-bootstrap has taught me that A LOT of people are VERY touchy about browser focus outlines.

If anything this just makes the behavior consistent across browsers. (tested in recent FF, Chrome, and Edge)

example: https://jsfiddle.net/7kmck1f7/1/