### PR TITLE
Fix homepage URLs in package.json files

### DIFF
--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/facebook/react/issues"
   },
-  "homepage": "https://github.com/facebook/react/tree/master/npm-react-dom",
+  "homepage": "https://facebook.github.io/react/",
   "peerDependencies": {
     "react": "^0.15.0-alpha.1"
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "react"
   ],
-  "homepage": "https://github.com/facebook/react/tree/master/npm-react",
+  "homepage": "https://facebook.github.io/react/",
   "bugs": "https://github.com/facebook/react/issues",
   "license": "BSD-3-Clause",
   "files": [


### PR DESCRIPTION
I'm getting 404s for the current hompage URLs:

```sh
$ npm info react-dom homepage
https://github.com/facebook/react/tree/master/npm-react-dom

$ npm info react homepage 
https://github.com/facebook/react/tree/master/npm-react
```

This PR updates them:

- react-dom: https://github.com/facebook/react/tree/master/packages/react-dom#readme
- react: https://facebook.github.io/react/
