### PR TITLE
Add empty dependencies for packages

### DIFF
--- a/packages/react-addons/package.json
+++ b/packages/react-addons/package.json
@@ -8,6 +8,7 @@
     "react-addon"
   ],
   "license": "BSD-3-Clause",
+  "dependencies": {},
   "peerDependencies": {
     "react": "^0.15.0-alpha.1"
   }

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/facebook/react/issues"
   },
   "homepage": "https://facebook.github.io/react/",
+  "dependencies": {},
   "peerDependencies": {
     "react": "^0.15.0-alpha.1"
   }


### PR DESCRIPTION
This ensures that broken npm versions won't crash when doing install --production

Fixes #5918