### PR TITLE
isRequiredIf proptype feature

### DIFF
--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -62,6 +62,13 @@ React.createClass({
     // is shown if the prop isn't provided.
     requiredFunc: React.PropTypes.func.isRequired,
 
+    // You can also chain any of the above with `isRequiredIf()` that accepts a
+    // boolean or a function to determine if the prop is required. This will also
+    // show warning if the prop isn't provided when the argument is true.
+    requiredFuncIf: React.PropTypes.func.isRequiredIf(function(props, propName, componentName) {
+      return Boolean(props.otherProp) // This is only required if otherProp exists!
+    })
+
     // A value of any data type
     requiredAny: React.PropTypes.any.isRequired,
 

--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -66,7 +66,7 @@ React.createClass({
     // boolean or a function to determine if the prop is required. This will also
     // show warning if the prop isn't provided when the argument is true.
     requiredFuncIf: React.PropTypes.func.isRequiredIf(function(props, propName, componentName) {
-      return Boolean(props.otherProp) // This is only required if otherProp exists!
+      return props.hasOwnProperty(otherProp) // This is only required if otherProp exists!
     })
 
     // A value of any data type

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -104,9 +104,9 @@ function createChainableTypeChecker(validate) {
     componentName = componentName || ANONYMOUS;
     propFullName = propFullName || propName;
     if (Boolean(isRequiredIf)) {
-      if (typeof isRequiredIf == 'boolean') {
+      if (typeof isRequiredIf === 'boolean') {
         isRequired = isRequiredIf;
-      } else if (typeof isRequiredIf == 'function') {
+      } else if (typeof isRequiredIf === 'function') {
         isRequired = isRequiredIf(assign({}, props), propName, componentName);
       }
     }
@@ -129,7 +129,7 @@ function createChainableTypeChecker(validate) {
   chainedCheckType.isRequired = checkType.bind(null, true, null);
   chainedCheckType.isRequiredIf = function(condition) {
     return checkType.bind(null, false, condition);
-  }
+  };
 
   return chainedCheckType;
 }

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -14,6 +14,7 @@
 var ReactElement = require('ReactElement');
 var ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
 
+var assign = require('Object.assign');
 var emptyFunction = require('emptyFunction');
 var getIteratorFn = require('getIteratorFn');
 
@@ -29,6 +30,11 @@ var getIteratorFn = require('getIteratorFn');
  *
  *       // A required enum prop named "category".
  *       category: Props.oneOf(['News','Photos']).isRequired,
+ *
+ *       // A required string only if description prop is provided.
+ *       blurb: Props.string.isRequiredIf(function(props, propName, componentName) {
+ *         return Boolean(props['description']);
+ *       });
  *
  *       // A prop named "dialog" that requires an instance of Dialog.
  *       dialog: Props.instanceOf(Dialog).isRequired
@@ -88,6 +94,7 @@ var ReactPropTypes = {
 function createChainableTypeChecker(validate) {
   function checkType(
     isRequired,
+    isRequiredIf,
     props,
     propName,
     componentName,
@@ -96,6 +103,14 @@ function createChainableTypeChecker(validate) {
   ) {
     componentName = componentName || ANONYMOUS;
     propFullName = propFullName || propName;
+    if (Boolean(isRequiredIf)) {
+      if (typeof isRequiredIf == 'boolean') {
+        isRequired = isRequiredIf;
+      } else if (typeof isRequiredIf == 'function') {
+        isRequired = isRequiredIf(assign({}, props), propName, componentName);
+      }
+    }
+
     if (props[propName] == null) {
       var locationName = ReactPropTypeLocationNames[location];
       if (isRequired) {
@@ -110,8 +125,11 @@ function createChainableTypeChecker(validate) {
     }
   }
 
-  var chainedCheckType = checkType.bind(null, false);
-  chainedCheckType.isRequired = checkType.bind(null, true);
+  var chainedCheckType = checkType.bind(null, false, null);
+  chainedCheckType.isRequired = checkType.bind(null, true, null);
+  chainedCheckType.isRequiredIf = function(condition) {
+    return checkType.bind(null, false, condition);
+  }
 
   return chainedCheckType;
 }

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -133,7 +133,7 @@ describe('ReactPropTypes', function() {
       typeCheckPass(PropTypes.string.isRequiredIf(false), undefined);
     });
 
-    it('should not warn for missing requiredIf values when condition is a function that returns false', function(){
+    it('should not warn for missing requiredIf values when condition is a function that returns false', function() {
       typeCheckPass(PropTypes.string.isRequiredIf(() => false), null);
       typeCheckPass(PropTypes.string.isRequiredIf(() => false), undefined);
     });
@@ -171,7 +171,7 @@ describe('ReactPropTypes', function() {
       typeCheckPass(PropTypes.any.isRequiredIf(false), undefined);
     });
 
-    it('should not warn for missing requiredIf values when condition is a function that returns false', function(){
+    it('should not warn for missing requiredIf values when condition is a function that returns false', function() {
       typeCheckPass(PropTypes.any.isRequiredIf(() => false), null);
       typeCheckPass(PropTypes.any.isRequiredIf(() => false), undefined);
     });
@@ -306,7 +306,7 @@ describe('ReactPropTypes', function() {
       );
     });
 
-    it('should not warn for missing requiredIf values when condition is a function that returns false', function(){
+    it('should not warn for missing requiredIf values when condition is a function that returns false', function() {
       typeCheckPass(
         PropTypes.arrayOf(PropTypes.number).isRequiredIf(() => false),
         null
@@ -322,7 +322,7 @@ describe('ReactPropTypes', function() {
     beforeEach(function() {
       Component = React.createClass({
         propTypes: {
-          label: PropTypes.element.isRequired
+          label: PropTypes.element.isRequired,
         },
 
         render: function() {
@@ -384,7 +384,7 @@ describe('ReactPropTypes', function() {
       typeCheckPass(PropTypes.element.isRequiredIf(false), undefined);
     });
 
-    it('should not warn for missing requiredIf values when condition is a function that returns false', function(){
+    it('should not warn for missing requiredIf values when condition is a function that returns false', function() {
       typeCheckPass(PropTypes.element.isRequiredIf(() => false), null);
       typeCheckPass(PropTypes.element.isRequiredIf(() => false), undefined);
     });
@@ -495,7 +495,7 @@ describe('ReactPropTypes', function() {
       );
     });
 
-    it('should not warn for missing requiredIf values when condition is a function that returns false', function(){
+    it('should not warn for missing requiredIf values when condition is a function that returns false', function() {
       typeCheckPass(
         PropTypes.instanceOf(String).isRequiredIf(() => false), null
       );
@@ -648,7 +648,7 @@ describe('ReactPropTypes', function() {
       );
     });
 
-    it('should not warn for missing requiredIf values when condition is a function that returns false', function(){
+    it('should not warn for missing requiredIf values when condition is a function that returns false', function() {
       typeCheckPass(
         PropTypes.node.isRequiredIf(() => false),
         null
@@ -665,7 +665,7 @@ describe('ReactPropTypes', function() {
 
     it('should accept empty array for requiredIf props that is a function that returns true', function() {
       typeCheckPass(PropTypes.node.isRequiredIf(() => true), []);
-    })
+    });
   });
 
   describe('ObjectOf Type', function() {
@@ -803,7 +803,7 @@ describe('ReactPropTypes', function() {
       );
     });
 
-    it('should not warn for missing requiredIf values when condition is a function that returns false', function(){
+    it('should not warn for missing requiredIf values when condition is a function that returns false', function() {
       typeCheckPass(
         PropTypes.objectOf(PropTypes.number).isRequiredIf(() => false),
         null
@@ -911,7 +911,7 @@ describe('ReactPropTypes', function() {
       );
     });
 
-    it('should not warn for missing requiredIf values when condition is a function that returns false', function(){
+    it('should not warn for missing requiredIf values when condition is a function that returns false', function() {
       typeCheckPass(
         PropTypes.oneOf(['red', 'blue']).isRequiredIf(() => false),
         null
@@ -1026,7 +1026,7 @@ describe('ReactPropTypes', function() {
       );
     });
 
-    it('should not warn for missing requiredIf values when condition is a function that returns false', function(){
+    it('should not warn for missing requiredIf values when condition is a function that returns false', function() {
       typeCheckPass(
         PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequiredIf(() => false),
         null
@@ -1158,7 +1158,7 @@ describe('ReactPropTypes', function() {
       );
     });
 
-    it('should not warn for missing requiredIf values when condition is a function that returns false', function(){
+    it('should not warn for missing requiredIf values when condition is a function that returns false', function() {
       typeCheckPass(
         PropTypes.shape({key: PropTypes.number}).isRequiredIf(() => false),
         null

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -117,6 +117,26 @@ describe('ReactPropTypes', function() {
       typeCheckFail(PropTypes.string.isRequired, null, requiredMessage);
       typeCheckFail(PropTypes.string.isRequired, undefined, requiredMessage);
     });
+
+    it('should warn for missing requiredIf values when condition is a true boolean', function() {
+      typeCheckFail(PropTypes.string.isRequiredIf(true), null, requiredMessage);
+      typeCheckFail(PropTypes.string.isRequiredIf(true), undefined, requiredMessage);
+    });
+
+    it('should warn for missing requiredIf values when condition is a function that returns true', function() {
+      typeCheckFail(PropTypes.string.isRequiredIf(() => true), null, requiredMessage);
+      typeCheckFail(PropTypes.string.isRequiredIf(() => true), undefined, requiredMessage);
+    });
+
+    it('should not warn for missing requiredIf values when condition is a false boolean', function() {
+      typeCheckPass(PropTypes.string.isRequiredIf(false), null);
+      typeCheckPass(PropTypes.string.isRequiredIf(false), undefined);
+    });
+
+    it('should not warn for missing requiredIf values when condition is a function that returns false', function(){
+      typeCheckPass(PropTypes.string.isRequiredIf(() => false), null);
+      typeCheckPass(PropTypes.string.isRequiredIf(() => false), undefined);
+    });
   });
 
   describe('Any type', function() {
@@ -134,6 +154,26 @@ describe('ReactPropTypes', function() {
     it('should warn for missing required values', function() {
       typeCheckFail(PropTypes.any.isRequired, null, requiredMessage);
       typeCheckFail(PropTypes.any.isRequired, undefined, requiredMessage);
+    });
+
+    it('should warn for missing requiredIf values when condition is a true boolean', function() {
+      typeCheckFail(PropTypes.any.isRequiredIf(true), null, requiredMessage);
+      typeCheckFail(PropTypes.any.isRequiredIf(true), undefined, requiredMessage);
+    });
+
+    it('should warn for missing requiredIf values when condition is a function that returns true', function() {
+      typeCheckFail(PropTypes.any.isRequiredIf(() => true), null, requiredMessage);
+      typeCheckFail(PropTypes.any.isRequiredIf(() => true), undefined, requiredMessage);
+    });
+
+    it('should not warn for missing requiredIf values when condition is a false boolean', function() {
+      typeCheckPass(PropTypes.any.isRequiredIf(false), null);
+      typeCheckPass(PropTypes.any.isRequiredIf(false), undefined);
+    });
+
+    it('should not warn for missing requiredIf values when condition is a function that returns false', function(){
+      typeCheckPass(PropTypes.any.isRequiredIf(() => false), null);
+      typeCheckPass(PropTypes.any.isRequiredIf(() => false), undefined);
     });
   });
 
@@ -228,13 +268,61 @@ describe('ReactPropTypes', function() {
         requiredMessage
       );
     });
+
+    it('should warn for missing requiredIf values when condition is a true boolean', function() {
+      typeCheckFail(
+        PropTypes.arrayOf(PropTypes.number).isRequiredIf(true),
+        null,
+        requiredMessage
+      );
+      typeCheckFail(
+        PropTypes.arrayOf(PropTypes.number).isRequiredIf(true),
+        undefined,
+        requiredMessage
+      );
+    });
+
+    it('should warn for missing requiredIf values when condition is a function that returns true', function() {
+      typeCheckFail(
+        PropTypes.arrayOf(PropTypes.number).isRequiredIf(() => true),
+        null,
+        requiredMessage
+      );
+      typeCheckFail(
+        PropTypes.arrayOf(PropTypes.number).isRequiredIf(() => true),
+        undefined,
+        requiredMessage
+      );
+    });
+
+    it('should not warn for missing requiredIf values when condition is a false boolean', function() {
+      typeCheckPass(
+        PropTypes.arrayOf(PropTypes.number).isRequiredIf(false),
+        null
+      );
+      typeCheckPass(
+        PropTypes.arrayOf(PropTypes.number).isRequiredIf(false),
+        undefined
+      );
+    });
+
+    it('should not warn for missing requiredIf values when condition is a function that returns false', function(){
+      typeCheckPass(
+        PropTypes.arrayOf(PropTypes.number).isRequiredIf(() => false),
+        null
+      );
+      typeCheckPass(
+        PropTypes.arrayOf(PropTypes.number).isRequiredIf(() => false),
+        undefined
+      );
+    });
   });
 
   describe('Component Type', function() {
     beforeEach(function() {
       Component = React.createClass({
         propTypes: {
-          label: PropTypes.element.isRequired,
+          label: PropTypes.element.isRequired
         },
 
         render: function() {
@@ -279,6 +367,26 @@ describe('ReactPropTypes', function() {
     it('should warn for missing required values', function() {
       typeCheckFail(PropTypes.element.isRequired, null, requiredMessage);
       typeCheckFail(PropTypes.element.isRequired, undefined, requiredMessage);
+    });
+
+    it('should warn for missing requiredIf values when condition is a true boolean', function() {
+      typeCheckFail(PropTypes.element.isRequiredIf(true), null, requiredMessage);
+      typeCheckFail(PropTypes.element.isRequiredIf(true), undefined, requiredMessage);
+    });
+
+    it('should warn for missing requiredIf values when condition is a function that returns true', function() {
+      typeCheckFail(PropTypes.element.isRequiredIf(() => true), null, requiredMessage);
+      typeCheckFail(PropTypes.element.isRequiredIf(() => true), undefined, requiredMessage);
+    });
+
+    it('should not warn for missing requiredIf values when condition is a false boolean', function() {
+      typeCheckPass(PropTypes.element.isRequiredIf(false), null);
+      typeCheckPass(PropTypes.element.isRequiredIf(false), undefined);
+    });
+
+    it('should not warn for missing requiredIf values when condition is a function that returns false', function(){
+      typeCheckPass(PropTypes.element.isRequiredIf(() => false), null);
+      typeCheckPass(PropTypes.element.isRequiredIf(() => false), undefined);
     });
   });
 
@@ -357,6 +465,42 @@ describe('ReactPropTypes', function() {
       );
       typeCheckFail(
         PropTypes.instanceOf(String).isRequired, undefined, requiredMessage
+      );
+    });
+
+    it('should warn for missing requiredIf values when condition is a true boolean', function() {
+      typeCheckFail(
+        PropTypes.instanceOf(String).isRequiredIf(true), null, requiredMessage
+      );
+      typeCheckFail(
+        PropTypes.instanceOf(String).isRequiredIf(true), undefined, requiredMessage
+      );
+    });
+
+    it('should warn for missing requiredIf values when condition is a function that returns true', function() {
+      typeCheckFail(
+        PropTypes.instanceOf(String).isRequiredIf(() => true), null, requiredMessage
+      );
+      typeCheckFail(
+        PropTypes.instanceOf(String).isRequiredIf(() => true), undefined, requiredMessage
+      );
+    });
+
+    it('should not warn for missing requiredIf values when condition is a false boolean', function() {
+      typeCheckPass(
+        PropTypes.instanceOf(String).isRequiredIf(false), null
+      );
+      typeCheckPass(
+        PropTypes.instanceOf(String).isRequiredIf(false), undefined
+      );
+    });
+
+    it('should not warn for missing requiredIf values when condition is a function that returns false', function(){
+      typeCheckPass(
+        PropTypes.instanceOf(String).isRequiredIf(() => false), null
+      );
+      typeCheckPass(
+        PropTypes.instanceOf(String).isRequiredIf(() => false), undefined
       );
     });
   });
@@ -466,6 +610,62 @@ describe('ReactPropTypes', function() {
     it('should accept empty array for required props', function() {
       typeCheckPass(PropTypes.node.isRequired, []);
     });
+
+    it('should warn for missing requiredIf values when condition is a true boolean', function() {
+      typeCheckFail(
+        PropTypes.node.isRequiredIf(true),
+        null,
+        requiredMessage
+      );
+      typeCheckFail(
+        PropTypes.node.isRequiredIf(true),
+        undefined,
+        requiredMessage
+      );
+    });
+
+    it('should warn for missing requiredIf values when condition is a function that returns true', function() {
+      typeCheckFail(
+        PropTypes.node.isRequiredIf(() => true),
+        null,
+        requiredMessage
+      );
+      typeCheckFail(
+        PropTypes.node.isRequiredIf(() => true),
+        undefined,
+        requiredMessage
+      );
+    });
+
+    it('should not warn for missing requiredIf values when condition is a false boolean', function() {
+      typeCheckPass(
+        PropTypes.node.isRequiredIf(false),
+        null
+      );
+      typeCheckPass(
+        PropTypes.node.isRequiredIf(false),
+        undefined
+      );
+    });
+
+    it('should not warn for missing requiredIf values when condition is a function that returns false', function(){
+      typeCheckPass(
+        PropTypes.node.isRequiredIf(() => false),
+        null
+      );
+      typeCheckPass(
+        PropTypes.node.isRequiredIf(() => false),
+        undefined
+      );
+    });
+
+    it('should accept empty array for requiredIf props that is a true boolean', function() {
+      typeCheckPass(PropTypes.node.isRequiredIf(true), []);
+    });
+
+    it('should accept empty array for requiredIf props that is a function that returns true', function() {
+      typeCheckPass(PropTypes.node.isRequiredIf(() => true), []);
+    })
   });
 
   describe('ObjectOf Type', function() {
@@ -565,6 +765,54 @@ describe('ReactPropTypes', function() {
         requiredMessage
       );
     });
+
+    it('should warn for missing requiredIf values when condition is a true boolean', function() {
+      typeCheckFail(
+        PropTypes.objectOf(PropTypes.number).isRequiredIf(true),
+        null,
+        requiredMessage
+      );
+      typeCheckFail(
+        PropTypes.objectOf(PropTypes.number).isRequiredIf(true),
+        undefined,
+        requiredMessage
+      );
+    });
+
+    it('should warn for missing requiredIf values when condition is a function that returns true', function() {
+      typeCheckFail(
+        PropTypes.objectOf(PropTypes.number).isRequiredIf(() => true),
+        null,
+        requiredMessage
+      );
+      typeCheckFail(
+        PropTypes.objectOf(PropTypes.number).isRequiredIf(() => true),
+        undefined,
+        requiredMessage
+      );
+    });
+
+    it('should not warn for missing requiredIf values when condition is a false boolean', function() {
+      typeCheckPass(
+        PropTypes.objectOf(PropTypes.number).isRequiredIf(false),
+        null
+      );
+      typeCheckPass(
+        PropTypes.objectOf(PropTypes.number).isRequiredIf(false),
+        undefined
+      );
+    });
+
+    it('should not warn for missing requiredIf values when condition is a function that returns false', function(){
+      typeCheckPass(
+        PropTypes.objectOf(PropTypes.number).isRequiredIf(() => false),
+        null
+      );
+      typeCheckPass(
+        PropTypes.objectOf(PropTypes.number).isRequiredIf(() => false),
+        undefined
+      );
+    });
   });
 
   describe('OneOf Types', function() {
@@ -623,6 +871,54 @@ describe('ReactPropTypes', function() {
         PropTypes.oneOf(['red', 'blue']).isRequired,
         undefined,
         requiredMessage
+      );
+    });
+
+    it('should warn for missing requiredIf values when condition is a true boolean', function() {
+      typeCheckFail(
+        PropTypes.oneOf(['red', 'blue']).isRequiredIf(true),
+        null,
+        requiredMessage
+      );
+      typeCheckFail(
+        PropTypes.oneOf(['red', 'blue']).isRequiredIf(true),
+        undefined,
+        requiredMessage
+      );
+    });
+
+    it('should warn for missing requiredIf values when condition is a function that returns true', function() {
+      typeCheckFail(
+        PropTypes.oneOf(['red', 'blue']).isRequiredIf(() => true),
+        null,
+        requiredMessage
+      );
+      typeCheckFail(
+        PropTypes.oneOf(['red', 'blue']).isRequiredIf(() => true),
+        undefined,
+        requiredMessage
+      );
+    });
+
+    it('should not warn for missing requiredIf values when condition is a false boolean', function() {
+      typeCheckPass(
+        PropTypes.oneOf(['red', 'blue']).isRequiredIf(false),
+        null
+      );
+      typeCheckPass(
+        PropTypes.oneOf(['red', 'blue']).isRequiredIf(false),
+        undefined
+      );
+    });
+
+    it('should not warn for missing requiredIf values when condition is a function that returns false', function(){
+      typeCheckPass(
+        PropTypes.oneOf(['red', 'blue']).isRequiredIf(() => false),
+        null
+      );
+      typeCheckPass(
+        PropTypes.oneOf(['red', 'blue']).isRequiredIf(() => false),
+        undefined
       );
     });
   });
@@ -690,6 +986,54 @@ describe('ReactPropTypes', function() {
         PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
         undefined,
         requiredMessage
+      );
+    });
+
+    it('should warn for missing requiredIf values when condition is a true boolean', function() {
+      typeCheckFail(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequiredIf(true),
+        null,
+        requiredMessage
+      );
+      typeCheckFail(
+        PropTypes.oneOf(['red', 'blue']).isRequiredIf(true),
+        undefined,
+        requiredMessage
+      );
+    });
+
+    it('should warn for missing requiredIf values when condition is a function that returns true', function() {
+      typeCheckFail(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequiredIf(() => true),
+        null,
+        requiredMessage
+      );
+      typeCheckFail(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequiredIf(() => true),
+        undefined,
+        requiredMessage
+      );
+    });
+
+    it('should not warn for missing requiredIf values when condition is a false boolean', function() {
+      typeCheckPass(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequiredIf(false),
+        null
+      );
+      typeCheckPass(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequiredIf(false),
+        undefined
+      );
+    });
+
+    it('should not warn for missing requiredIf values when condition is a function that returns false', function(){
+      typeCheckPass(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequiredIf(() => false),
+        null
+      );
+      typeCheckPass(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequiredIf(() => false),
+        undefined
       );
     });
   });
@@ -774,6 +1118,54 @@ describe('ReactPropTypes', function() {
         PropTypes.shape({key: PropTypes.number}).isRequired,
         undefined,
         requiredMessage
+      );
+    });
+
+    it('should warn for missing requiredIf values when condition is a true boolean', function() {
+      typeCheckFail(
+        PropTypes.shape({key: PropTypes.number}).isRequiredIf(true),
+        null,
+        requiredMessage
+      );
+      typeCheckFail(
+        PropTypes.shape({key: PropTypes.number}).isRequiredIf(true),
+        undefined,
+        requiredMessage
+      );
+    });
+
+    it('should warn for missing requiredIf values when condition is a function that returns true', function() {
+      typeCheckFail(
+        PropTypes.shape({key: PropTypes.number}).isRequiredIf(() => true),
+        null,
+        requiredMessage
+      );
+      typeCheckFail(
+        PropTypes.shape({key: PropTypes.number}).isRequiredIf(() => true),
+        undefined,
+        requiredMessage
+      );
+    });
+
+    it('should not warn for missing requiredIf values when condition is a false boolean', function() {
+      typeCheckPass(
+        PropTypes.shape({key: PropTypes.number}).isRequiredIf(false),
+        null
+      );
+      typeCheckPass(
+        PropTypes.shape({key: PropTypes.number}).isRequiredIf(false),
+        undefined
+      );
+    });
+
+    it('should not warn for missing requiredIf values when condition is a function that returns false', function(){
+      typeCheckPass(
+        PropTypes.shape({key: PropTypes.number}).isRequiredIf(() => false),
+        null
+      );
+      typeCheckPass(
+        PropTypes.shape({key: PropTypes.number}).isRequiredIf(() => false),
+        undefined
       );
     });
   });


### PR DESCRIPTION
Hey everyone, thanks for all of your work here on React. First PR!

I ran into a use case the other day where I wanted to conditionally enforce isRequired based on another prop's existence. It was fairly simple using a custom validator but this required re-implementing all of the type checking that comes for free with PropTypes anyway. With this change, it will introduce chaining any propType with `isRequiredIf(condition)` where `condition` can be a boolean or a function that returns a truthy value. 

The function has the same arguments as a custom propType validator: 
`isRequiredIf((props, propName, componentName) => props.hasOwnProperty('otherProp'))`

Thanks!