### PR TITLE
Fixes highlight issue for code blocks with overflow (css)

### DIFF
--- a/docs/css/react.scss
+++ b/docs/css/react.scss
@@ -743,6 +743,8 @@ p a code {
   margin-bottom: 0;
   background-color: transparent;
   border: 0;
+  float: left;
+  min-width: 100%;
 }
 
 .highlight pre code {


### PR DESCRIPTION
Fixes the small layout problem referred to in #5937 via css.
![fix](https://cloud.githubusercontent.com/assets/3195775/12692371/dfa7daea-c6aa-11e5-8768-0bd7b5ae0fa6.gif)
