### PR TITLE
Update polymer children using polymer api

### DIFF
--- a/src/renderers/dom/client/utils/DOMChildrenOperations.js
+++ b/src/renderers/dom/client/utils/DOMChildrenOperations.js
@@ -20,7 +20,13 @@ var setInnerHTML = require('setInnerHTML');
 var setTextContent = require('setTextContent');
 
 function getNodeAfter(parentNode, node) {
-  return node ? node.nextSibling : parentNode.firstChild;
+  if (node) {
+    return node.nextSibling;
+  }
+  if (window.Polymer !== undefined) {
+    parentNode = window.Polymer.dom(parentNode);
+  }
+  return parentNode.firstChild;
 }
 
 /**

--- a/src/renderers/dom/client/utils/DOMLazyTree.js
+++ b/src/renderers/dom/client/utils/DOMLazyTree.js
@@ -51,6 +51,9 @@ function insertTreeChildren(tree) {
 }
 
 function insertTreeBefore(parentNode, tree, referenceNode) {
+  if (window.Polymer !== undefined) {
+    parentNode = window.Polymer.dom(parentNode);
+  }
   parentNode.insertBefore(tree.node, referenceNode);
   insertTreeChildren(tree);
 }

--- a/src/renderers/dom/client/utils/setTextContent.js
+++ b/src/renderers/dom/client/utils/setTextContent.js
@@ -26,12 +26,18 @@ var setInnerHTML = require('setInnerHTML');
  * @internal
  */
 var setTextContent = function(node, text) {
+  if (window.Polymer !== undefined) {
+    node = window.Polymer.dom(node);
+  }
   node.textContent = text;
 };
 
 if (ExecutionEnvironment.canUseDOM) {
   if (!('textContent' in document.documentElement)) {
     setTextContent = function(node, text) {
+      if (window.Polymer !== undefined) {
+        node = window.Polymer.dom(node);
+      }
       setInnerHTML(node, escapeTextContentForBrowser(text));
     };
   }


### PR DESCRIPTION
For web components using polymer, we sometimes screw up the updates of children, because polymer uses a shady dom.  This PR will use the polymer DOM api to update children IFF the user is using polymer, thereby ensuring that all DOM child operations happen correctly.