### PR TITLE
test: get rid of 'should be 1' comment

### DIFF
--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -675,7 +675,7 @@ describe('ReactDOMComponent', function() {
       expect(nodeValueSetter.mock.calls.length).toBe(1);
 
       ReactDOM.render(<div checked={false} />, container);
-      expect(nodeValueSetter.mock.calls.length).toBe(2); // should be 1
+      expect(nodeValueSetter.mock.calls.length).toBe(2);
 
       ReactDOM.render(<div checked={true} />, container);
       expect(nodeValueSetter.mock.calls.length).toBe(3);


### PR DESCRIPTION
This should not be 1, since boolean properties always get set.

Fixes https://github.com/facebook/react/issues/5944