### PR TITLE
Fixes #5959 - jquery-bootstrap example uses handleHidden which does not exist

### DIFF
--- a/examples/jquery-bootstrap/js/app.js
+++ b/examples/jquery-bootstrap/js/app.js
@@ -19,9 +19,13 @@ var BootstrapModal = React.createClass({
   componentDidMount: function() {
     // When the component is added, turn it into a modal
     $(this.refs.root).modal({backdrop: 'static', keyboard: false, show: false});
+
+    // Bootstrap's modal class exposes a few events for hooking into modal
+    // functionality. Lets hook into one of them:
+    $(this.refs.root).on('hidden.bs.modal', this.handleHidden);
   },
   componentWillUnmount: function() {
-    $(this.refs.root).off('hidden', this.handleHidden);
+    $(this.refs.root).off('hidden.bs.modal', this.handleHidden);
   },
   close: function() {
     $(this.refs.root).modal('hide');
@@ -84,6 +88,11 @@ var BootstrapModal = React.createClass({
     if (this.props.onConfirm) {
       this.props.onConfirm();
     }
+  },
+  handleHidden: function() {
+    if (this.props.onHidden) {
+      this.props.onHidden();
+    }
   }
 });
 
@@ -102,6 +111,7 @@ var Example = React.createClass({
         cancel="Cancel"
         onCancel={this.handleCancel}
         onConfirm={this.closeModal}
+        onHidden={this.handleModalDidClose}
         title="Hello, Bootstrap!">
           This is a React component powered by jQuery and Bootstrap!
       </BootstrapModal>
@@ -120,6 +130,9 @@ var Example = React.createClass({
   },
   closeModal: function() {
     this.refs.modal.close();
+  },
+  handleModalDidClose: function() {
+    alert("The modal has been dismissed!");
   }
 });
 


### PR DESCRIPTION
Fixes #5959. I've fixed this by adding a hook into the modal's `hidden.bs.modal` event.