### PR TITLE
Update 10.4-test-utils.md

### DIFF
--- a/docs/docs/10.4-test-utils.md
+++ b/docs/docs/10.4-test-utils.md
@@ -220,7 +220,7 @@ Similar to `ReactDOM.render`.
 ReactElement shallowRenderer.getRenderOutput()
 ```
 
-After `render` has been called, returns shallowly rendered output. You can then begin to assert facts about the output. For example, if your component's render method returns:
+After `getRenderOutput` has been called, returns shallowly rendered output. You can then begin to assert facts about the output. For example, if your component's render method returns:
 
 ```javascript
 <div>


### PR DESCRIPTION
Shallow rendering part, may below:
>  After `render` has been called

Will lead some misunderstand, so made this PR.