### PR TITLE
Fix #5941 - Provide a way to register a last-chance exception handler

### DIFF
--- a/src/renderers/dom/ReactDOM.js
+++ b/src/renderers/dom/ReactDOM.js
@@ -20,6 +20,7 @@ var ReactPerf = require('ReactPerf');
 var ReactReconciler = require('ReactReconciler');
 var ReactUpdates = require('ReactUpdates');
 var ReactVersion = require('ReactVersion');
+var ReactEventListener = require('ReactEventListener');
 
 var findDOMNode = require('findDOMNode');
 var getNativeComponentFromComposite = require('getNativeComponentFromComposite');
@@ -35,6 +36,7 @@ var React = {
   render: render,
   unmountComponentAtNode: ReactMount.unmountComponentAtNode,
   version: ReactVersion,
+  onUnhandledError: ReactEventListener.onUnhandledError,
 
   /* eslint-disable camelcase */
   unstable_batchedUpdates: ReactUpdates.batchedUpdates,

--- a/src/renderers/dom/client/ReactEventListener.js
+++ b/src/renderers/dom/client/ReactEventListener.js
@@ -91,6 +91,7 @@ function scrollValueMonitor(cb) {
 var ReactEventListener = {
   _enabled: true,
   _handleTopLevel: null,
+  _unhandledErrorCallback: null,
 
   WINDOW_HANDLE: ExecutionEnvironment.canUseDOM ? window : null,
 
@@ -169,9 +170,19 @@ var ReactEventListener = {
       // Event queue being processed in the same cycle allows
       // `preventDefault`.
       ReactUpdates.batchedUpdates(handleTopLevelImpl, bookKeeping);
+    } catch (err) {
+      if (ReactEventListener._unhandledErrorCallback) {
+        ReactEventListener._unhandledErrorCallback(err);
+      } else {
+        throw err;
+      }
     } finally {
       TopLevelCallbackBookKeeping.release(bookKeeping);
     }
+  },
+
+  onUnhandledError: function(handler) {
+    ReactEventListener._unhandledErrorCallback = handler;
   },
 };
 

--- a/src/shared/utils/ReactErrorUtils.js
+++ b/src/shared/utils/ReactErrorUtils.js
@@ -65,7 +65,9 @@ if (__DEV__) {
       typeof document.createEvent === 'function') {
     var fakeNode = document.createElement('react');
     ReactErrorUtils.invokeGuardedCallback = function(name, func, a, b) {
-      var boundFunc = func.bind(null, a, b);
+      var boundFunc = function() {
+        invokeGuardedCallback(name, func, a, b);
+      };
       var evtType = `react-${name}`;
       fakeNode.addEventListener(evtType, boundFunc, false);
       var evt = document.createEvent('Event');


### PR DESCRIPTION
Add an onUnhandledError function to ReactDOM to allow registration of a callback for unhandled exceptions.
Call the registered callback from the catch block of ReactEventListener.dispatchEvent.
Call the production invokeGuardedCallback function from the dev version of ReactErrorUtils.invokeGuardedCallback.