### PR TITLE
Remove 'require' to fix an error message

### DIFF
--- a/docs/docs/10.1-animation.md
+++ b/docs/docs/10.1-animation.md
@@ -17,7 +17,7 @@ React provides a `ReactTransitionGroup` add-on component as a low-level API for 
 `ReactCSSTransitionGroup` is the interface to `ReactTransitions`. This is a simple element that wraps all of the components you are interested in animating. Here's an example where we fade list items in and out.
 
 ```javascript{28-30}
-var ReactCSSTransitionGroup = require('react-addons-css-transition-group');
+var ReactCSSTransitionGroup = ('react-addons-css-transition-group');
 
 var TodoList = React.createClass({
   getInitialState: function() {


### PR DESCRIPTION
using 'require' results in this error message: "Uncaught ReferenceError: require is not defined"