### PR TITLE
Interruptible transition group

### DIFF
--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -113,6 +113,8 @@ var ReactTransitionGroup = React.createClass({
 
     this.actionsToPerform = nextActionsToPerform;
 
+    // If we want to someday check for reordering, we could do it here.
+    
     return DOMChildren;
   },
   

--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-present, Facebook, Inc.
+ * Copyright 2013-2015, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -14,7 +14,6 @@
 var React = require('React');
 var ReactTransitionChildMapping = require('ReactTransitionChildMapping');
 
-var assign = require('Object.assign');
 var emptyFunction = require('emptyFunction');
 
 var ReactTransitionGroup = React.createClass({
@@ -33,138 +32,153 @@ var ReactTransitionGroup = React.createClass({
   },
 
   getInitialState: function() {
+    // objectiveChildren - the set of children that we are trying to acheive
+    // DOMChildren - expresses our current state and is what we actually render
+  
+    var objectiveChildren = ReactTransitionChildMapping.getChildMapping(this.props.children);
+    
     return {
-      children: ReactTransitionChildMapping.getChildMapping(this.props.children),
+      objectiveChildren: objectiveChildren,
+      DOMChildren: {},
     };
   },
 
   componentWillMount: function() {
-    this.currentlyTransitioningKeys = {};
-    this.keysToEnter = [];
-    this.keysToLeave = [];
+    this.actionsToPerform = {};
+    this.isInitialMount = true;
+    this.setState({
+      DOMChildren: this.updateDOMChildren(this.state.objectiveChildren),
+    });
   },
 
   componentDidMount: function() {
-    var initialChildMapping = this.state.children;
-    for (var key in initialChildMapping) {
-      if (initialChildMapping[key]) {
-        this.performAppear(key);
-      }
-    }
+    this.performDOMChildrenActions();
   },
 
   componentWillReceiveProps: function(nextProps) {
-    var nextChildMapping = ReactTransitionChildMapping.getChildMapping(
-      nextProps.children
-    );
-    var prevChildMapping = this.state.children;
+    this.isInitialMount = false;
+
+    var nextChildMapping = ReactTransitionChildMapping.getChildMapping(nextProps.children);
+
+    var nextDOMChildren = this.updateDOMChildren(nextChildMapping);
 
     this.setState({
-      children: ReactTransitionChildMapping.mergeChildMappings(
-        prevChildMapping,
-        nextChildMapping
-      ),
+      objectiveChildren: nextChildMapping,
+      DOMChildren: nextDOMChildren,
     });
-
-    var key;
-
-    for (key in nextChildMapping) {
-      var hasPrev = prevChildMapping && prevChildMapping.hasOwnProperty(key);
-      if (nextChildMapping[key] && !hasPrev &&
-          !this.currentlyTransitioningKeys[key]) {
-        this.keysToEnter.push(key);
-      }
-    }
-
-    for (key in prevChildMapping) {
-      var hasNext = nextChildMapping && nextChildMapping.hasOwnProperty(key);
-      if (prevChildMapping[key] && !hasNext &&
-          !this.currentlyTransitioningKeys[key]) {
-        this.keysToLeave.push(key);
-      }
-    }
-
-    // If we want to someday check for reordering, we could do it here.
   },
 
   componentDidUpdate: function() {
-    var keysToEnter = this.keysToEnter;
-    this.keysToEnter = [];
-    keysToEnter.forEach(this.performEnter);
+    this.performDOMChildrenActions();
+  },
 
-    var keysToLeave = this.keysToLeave;
-    this.keysToLeave = [];
-    keysToLeave.forEach(this.performLeave);
+  updateDOMChildren: function(newObjectiveChildren) {
+    newObjectiveChildren = newObjectiveChildren || {};
+    var DOMChildren = this.state.DOMChildren;
+    var nextActionsToPerform = {};
+
+    // Find new children and add
+    for (var key in newObjectiveChildren) {
+
+      if (DOMChildren[key]) {
+        // Already exists
+
+        // Exists but was on it's way out. Let's interrupt
+        if (!DOMChildren[key].shouldBeInDOM) {
+          DOMChildren[key].shouldBeInDOM = true;
+          // Queue action to be performed during componentDidUpdate
+          nextActionsToPerform[key] = DOMChildren[key];
+        }
+      } else {
+        // Is new
+        DOMChildren[key] = {
+          child: newObjectiveChildren[key],
+          shouldBeInDOM: true,
+        };
+        // Queue action to be performed during componentDidUpdate
+        nextActionsToPerform[key] = DOMChildren[key];
+      }
+    }
+
+    // Find nodes that should longer exist, mark for removal
+    var objectiveChildrenKeys = Object.keys(newObjectiveChildren);
+    var keysForRemoval = Object.keys(DOMChildren).filter(function(k) {
+      return objectiveChildrenKeys.indexOf(k) < 0;
+    });
+    keysForRemoval.forEach(function(keyToRemove) {
+      DOMChildren[keyToRemove].shouldBeInDOM = false;
+      // Queue action to be performed during componentDidUpdate
+      nextActionsToPerform[keyToRemove] = DOMChildren[keyToRemove];
+    });
+
+    this.actionsToPerform = nextActionsToPerform;
+
+    return DOMChildren;
+  },
+  
+  performDOMChildrenActions: function() {
+    for (var key in this.actionsToPerform) {
+      if (this.actionsToPerform[key].shouldBeInDOM) {
+        if (this.isInitialMount) {
+          this.performAppear(key);
+        } else {
+          this.performEnter(key);
+        }
+      } else {
+        this.performLeave(key);
+      }
+    }
+    // Reset actions since we've performed all of them.
+    this.actionsToPerform = {};
   },
 
   performAppear: function(key) {
-    this.currentlyTransitioningKeys[key] = true;
-
     var component = this.refs[key];
 
     if (component.componentWillAppear) {
-      component.componentWillAppear(
-        this._handleDoneAppearing.bind(this, key)
-      );
+      component.componentWillAppear(this._handleDoneAppearing.bind(this, key));
     } else {
       this._handleDoneAppearing(key);
     }
   },
 
   _handleDoneAppearing: function(key) {
-    var component = this.refs[key];
-    if (component.componentDidAppear) {
-      component.componentDidAppear();
+    if (!this.state.DOMChildren[key].shouldBeInDOM) {
+      return;
     }
 
-    delete this.currentlyTransitioningKeys[key];
-
-    var currentChildMapping = ReactTransitionChildMapping.getChildMapping(
-      this.props.children
-    );
-
-    if (!currentChildMapping || !currentChildMapping.hasOwnProperty(key)) {
-      // This was removed before it had fully appeared. Remove it.
-      this.performLeave(key);
+    var component = this.refs[key];
+    
+    if (component.componentDidAppear) {
+      component.componentDidAppear();
     }
   },
 
   performEnter: function(key) {
-    this.currentlyTransitioningKeys[key] = true;
-
     var component = this.refs[key];
 
     if (component.componentWillEnter) {
-      component.componentWillEnter(
-        this._handleDoneEntering.bind(this, key)
-      );
+      component.componentWillEnter(this._handleDoneEntering.bind(this, key));
     } else {
       this._handleDoneEntering(key);
     }
   },
 
   _handleDoneEntering: function(key) {
-    var component = this.refs[key];
-    if (component.componentDidEnter) {
-      component.componentDidEnter();
+    if (!this.state.DOMChildren[key].shouldBeInDOM) {
+      return;
     }
 
-    delete this.currentlyTransitioningKeys[key];
+    var component = this.refs[key];
 
-    var currentChildMapping = ReactTransitionChildMapping.getChildMapping(
-      this.props.children
-    );
-
-    if (!currentChildMapping || !currentChildMapping.hasOwnProperty(key)) {
-      // This was removed before it had fully entered. Remove it.
-      this.performLeave(key);
+    if (component.componentDidEnter) {
+      component.componentDidEnter();
     }
   },
 
   performLeave: function(key) {
-    this.currentlyTransitioningKeys[key] = true;
-
     var component = this.refs[key];
+
     if (component.componentWillLeave) {
       component.componentWillLeave(this._handleDoneLeaving.bind(this, key));
     } else {
@@ -176,36 +190,29 @@ var ReactTransitionGroup = React.createClass({
   },
 
   _handleDoneLeaving: function(key) {
+    if (this.state.DOMChildren[key].shouldBeInDOM) {
+      return;
+    }
+    
     var component = this.refs[key];
 
     if (component.componentDidLeave) {
       component.componentDidLeave();
     }
 
-    delete this.currentlyTransitioningKeys[key];
-
-    var currentChildMapping = ReactTransitionChildMapping.getChildMapping(
-      this.props.children
-    );
-
-    if (currentChildMapping && currentChildMapping.hasOwnProperty(key)) {
-      // This entered again before it fully left. Add it again.
-      this.performEnter(key);
-    } else {
-      this.setState(function(state) {
-        var newChildren = assign({}, state.children);
-        delete newChildren[key];
-        return {children: newChildren};
-      });
-    }
+    var newDOMChildren = this.state.DOMChildren;
+    delete newDOMChildren[key];
+    this.setState({
+      DOMChildren: newDOMChildren,
+    });
   },
 
   render: function() {
     // TODO: we could get rid of the need for the wrapper node
     // by cloning a single child
     var childrenToRender = [];
-    for (var key in this.state.children) {
-      var child = this.state.children[key];
+    for (var key in this.state.DOMChildren) {
+      var child = this.state.DOMChildren[key].child;
       if (child) {
         // You may need to apply reactive updates to a child as it is leaving.
         // The normal React way to do it won't work since the child will have
@@ -213,15 +220,16 @@ var ReactTransitionGroup = React.createClass({
         // a childFactory function to wrap every child, even the ones that are
         // leaving.
         childrenToRender.push(React.cloneElement(
-          this.props.childFactory(child),
-          {ref: key, key: key}
+          this.props.childFactory(child), 
+          { ref: key, key: key }
         ));
       }
     }
+
     return React.createElement(
       this.props.component,
       this.props,
-      childrenToRender
+      childrenToRender,
     );
   },
 });

--- a/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-present, Facebook, Inc.
+ * Copyright 2013-2015, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -23,7 +23,7 @@ describe('ReactCSSTransitionGroup', function() {
   var container;
 
   beforeEach(function() {
-    jest.resetModuleRegistry();
+    require('mock-modules').dumpCache();
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactCSSTransitionGroup = require('ReactCSSTransitionGroup');
@@ -90,8 +90,8 @@ describe('ReactCSSTransitionGroup', function() {
       container
     );
     expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(2);
-    expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('two');
-    expect(ReactDOM.findDOMNode(a).childNodes[1].id).toBe('one');
+    expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('one');
+    expect(ReactDOM.findDOMNode(a).childNodes[1].id).toBe('two');
 
     // For some reason jst is adding extra setTimeout()s and grunt test isn't,
     // so we need to do this disgusting hack.
@@ -125,8 +125,8 @@ describe('ReactCSSTransitionGroup', function() {
       container
     );
     expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(2);
-    expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('two');
-    expect(ReactDOM.findDOMNode(a).childNodes[1].id).toBe('one');
+    expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('one');
+    expect(ReactDOM.findDOMNode(a).childNodes[1].id).toBe('two');
   });
 
   it('should switch transitionLeave from false to true', function() {
@@ -160,8 +160,8 @@ describe('ReactCSSTransitionGroup', function() {
       container
     );
     expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(2);
-    expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('three');
-    expect(ReactDOM.findDOMNode(a).childNodes[1].id).toBe('two');
+    expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('two');
+    expect(ReactDOM.findDOMNode(a).childNodes[1].id).toBe('three');
   });
 
   it('should work with no children', function() {

--- a/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-present, Facebook, Inc.
+ * Copyright 2013-2015, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -92,9 +92,8 @@ describe('ReactTransitionGroup', function() {
     });
   });
 
-  it('should handle enter/leave/enter/leave correctly', function() {
+  it('should handle enter/leave/enter/leave correctly when able to complete transitions', function() {
     var log = [];
-    var willEnterCb;
 
     var Child = React.createClass({
       componentDidMount: function() {
@@ -102,7 +101,7 @@ describe('ReactTransitionGroup', function() {
       },
       componentWillEnter: function(cb) {
         log.push('willEnter');
-        willEnterCb = cb;
+        cb();
       },
       componentDidEnter: function() {
         log.push('didEnter');
@@ -137,24 +136,34 @@ describe('ReactTransitionGroup', function() {
 
     var instance = ReactDOM.render(<Component />, container);
     expect(log).toEqual(['didMount']);
+
     instance.setState({count: 2});
-    expect(log).toEqual(['didMount', 'didMount', 'willEnter']);
-    for (var k = 0; k < 5; k++) {
-      instance.setState({count: 2});
-      expect(log).toEqual(['didMount', 'didMount', 'willEnter']);
-      instance.setState({count: 1});
-    }
-    // other animations are blocked until willEnterCb is called
-    willEnterCb();
+    expect(log).toEqual(['didMount', 'didMount', 'willEnter', 'didEnter']);
+
+    instance.setState({count: 1});
     expect(log).toEqual([
-      'didMount', 'didMount', 'willEnter',
-      'didEnter', 'willLeave', 'didLeave', 'willUnmount',
+      'didMount', 'didMount', 'willEnter', 'didEnter', 
+      'willLeave', 'didLeave', 'willUnmount',
+    ]);
+
+    instance.setState({count: 2});
+    expect(log).toEqual([
+      'didMount', 'didMount', 'willEnter', 'didEnter', 
+      'willLeave', 'didLeave', 'willUnmount',
+      'didMount', 'willEnter', 'didEnter',
+    ]);
+
+    instance.setState({count: 1});
+    expect(log).toEqual([
+      'didMount', 'didMount', 'willEnter', 'didEnter', 
+      'willLeave', 'didLeave', 'willUnmount',
+      'didMount', 'willEnter', 'didEnter',
+      'willLeave', 'didLeave', 'willUnmount',
     ]);
   });
 
-  it('should handle enter/leave/enter correctly', function() {
+  it('should handle enter/leave/enter/leave correctly when unable to complete enter transition', function() {
     var log = [];
-    var willEnterCb;
 
     var Child = React.createClass({
       componentDidMount: function() {
@@ -162,7 +171,7 @@ describe('ReactTransitionGroup', function() {
       },
       componentWillEnter: function(cb) {
         log.push('willEnter');
-        willEnterCb = cb;
+        // no callback (this animation didn't have time to complete)
       },
       componentDidEnter: function() {
         log.push('didEnter');
@@ -197,16 +206,110 @@ describe('ReactTransitionGroup', function() {
 
     var instance = ReactDOM.render(<Component />, container);
     expect(log).toEqual(['didMount']);
+
     instance.setState({count: 2});
     expect(log).toEqual(['didMount', 'didMount', 'willEnter']);
-    for (var k = 0; k < 5; k++) {
-      instance.setState({count: 1});
-      expect(log).toEqual(['didMount', 'didMount', 'willEnter']);
-      instance.setState({count: 2});
-    }
-    willEnterCb();
+
+    instance.setState({count: 1});
+    expect(log).toEqual([
+      'didMount', 'didMount', 'willEnter', 
+      'willLeave', 'didLeave', 'willUnmount',
+    ]);
+
+    instance.setState({count: 2});
+    expect(log).toEqual([
+      'didMount', 'didMount', 'willEnter', 
+      'willLeave', 'didLeave', 'willUnmount',
+      'didMount', 'willEnter',
+    ]);
+
+    instance.setState({count: 1});
+    expect(log).toEqual([
+      'didMount', 'didMount', 'willEnter', 
+      'willLeave', 'didLeave', 'willUnmount',
+      'didMount', 'willEnter',
+      'willLeave', 'didLeave', 'willUnmount',
+    ]);
+  });
+
+  it('should handle enter/leave/enter/leave correctly when unable to complete leave transition', function() {
+    var log = [];
+    var leaveCB;
+
+    var Child = React.createClass({
+      componentDidMount: function() {
+        log.push('didMount');
+      },
+      componentWillEnter: function(cb) {
+        log.push('willEnter');
+        cb();
+      },
+      componentDidEnter: function() {
+        log.push('didEnter');
+      },
+      componentWillLeave: function(cb) {
+        log.push('willLeave');
+        // no callback (this animation didn't have time to complete)
+        leaveCB = cb;
+      },
+      componentDidLeave: function() {
+        log.push('didLeave');
+      },
+      componentWillUnmount: function() {
+        log.push('willUnmount');
+      },
+      render: function() {
+        return <span />;
+      },
+    });
+
+    var Component = React.createClass({
+      getInitialState: function() {
+        return {count: 1};
+      },
+      render: function() {
+        var children = [];
+        for (var i = 0; i < this.state.count; i++) {
+          children.push(<Child key={i} />);
+        }
+        return <ReactTransitionGroup>{children}</ReactTransitionGroup>;
+      },
+    });
+
+    var instance = ReactDOM.render(<Component />, container);
+    expect(log).toEqual(['didMount']);
+    instance.setState({count: 2});
+    expect(log).toEqual(['didMount', 'didMount', 'willEnter', 'didEnter']);
+
+    instance.setState({count: 1});
     expect(log).toEqual([
       'didMount', 'didMount', 'willEnter', 'didEnter',
+      'willLeave',
+    ]);
+
+    instance.setState({count: 2});
+    expect(log).toEqual([
+      'didMount', 'didMount', 'willEnter', 'didEnter',
+      'willLeave', 
+      'willEnter', 'didEnter',
+    ]);
+
+    instance.setState({count: 1});
+    expect(log).toEqual([
+      'didMount', 'didMount', 'willEnter', 'didEnter',
+      'willLeave', 
+      'willEnter', 'didEnter',
+      'willLeave',
+    ]);
+
+    leaveCB(); // Leave given enough time to complete
+
+    expect(log).toEqual([
+      'didMount', 'didMount', 'willEnter', 'didEnter',
+      'willLeave', 
+      'willEnter', 'didEnter',
+      'willLeave',
+      'didLeave', 'willUnmount',
     ]);
   });
 


### PR DESCRIPTION
Updated the ReactTransitionGroup to accommodate interruptions. Pulling a component out of a transition group will immediately trigger componentWillLeave even if the enter transition hasn't completed (componentDidEnter not fired). This allows for cancelable animations.

This update does not change the behavior of CSSTransitionGroup since it uses timeouts to control the adding and removing of elements.

Note: This is my first pull request with FB. I completed the CLA just prior to this pull request.