### PR TITLE
Docs: shallowRenderer.render() accepts a context as a 2nd argument

### DIFF
--- a/docs/docs/10.4-test-utils.md
+++ b/docs/docs/10.4-test-utils.md
@@ -210,7 +210,7 @@ Call this in your tests to create a shallow renderer. You can think of this as a
 
 ```javascript
 shallowRenderer.render(
-  ReactElement element
+  ReactElement element, object optionalContext
 )
 ```
 


### PR DESCRIPTION
It's not mentioned in the current documentation, but I found this after digging, and that's very handy.
People should know :)