### PR TITLE
Use HTTPS protocol for jsdelivr.com URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You'll notice that we used an HTML-like syntax; [we call it JSX](https://faceboo
 
 ## Installation
 
-The fastest way to get started is to serve JavaScript from the CDN (also available on [cdnjs](https://cdnjs.com/libraries/react) and [jsdelivr](http://www.jsdelivr.com/#!react)):
+The fastest way to get started is to serve JavaScript from the CDN (also available on [cdnjs](https://cdnjs.com/libraries/react) and [jsdelivr](https://www.jsdelivr.com/#!react)):
 
 ```html
 <!-- The core React library -->


### PR DESCRIPTION
jsdelivr.com is accesible via HTTPS. https://www.jsdelivr.com/projects/react

ref. [Web Security: Why You Should Always Use HTTPS](http://mashable.com/2011/05/31/https-web-security/)
