### PR TITLE
Do not get `process` object by using `require`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var path = require('path');
-var process = require('process');
 
 var GULP_EXE = 'gulp';
 if (process.platform === 'win32') {


### PR DESCRIPTION
[`process`](https://nodejs.org/api/process.html) is a global object and there is no need to load it via `require`.
