### PR TITLE
Update fbjs from v0.6.x to v0.7.x

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "envify": "^3.0.0",
-    "fbjs": "^0.6.1"
+    "fbjs": "^0.7.2"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
npm v3 tries to dedupe the dependencies by default, and keeping dependencies up-to-date helps better deduplication.
