### PR TITLE
[WIP] Move child recursion to ReactReconciler

### DIFF
--- a/src/renderers/dom/client/utils/DOMLazyTree.js
+++ b/src/renderers/dom/client/utils/DOMLazyTree.js
@@ -33,6 +33,8 @@ var enableLazy = (
   /\bEdge\/\d/.test(navigator.userAgent)
 );
 
+var treeType = 'dom';
+
 function insertTreeChildren(tree) {
   if (!enableLazy) {
     return;
@@ -86,6 +88,7 @@ function queueText(tree, text) {
 
 function DOMLazyTree(node) {
   return {
+    lazy: treeType,
     node: node,
     children: [],
     html: null,
@@ -93,6 +96,7 @@ function DOMLazyTree(node) {
   };
 }
 
+DOMLazyTree.treeType = treeType;
 DOMLazyTree.insertTreeBefore = insertTreeBefore;
 DOMLazyTree.replaceChildWithTree = replaceChildWithTree;
 DOMLazyTree.queueChild = queueChild;

--- a/src/renderers/dom/client/utils/DOMLazyTree.js
+++ b/src/renderers/dom/client/utils/DOMLazyTree.js
@@ -33,7 +33,7 @@ var enableLazy = (
   /\bEdge\/\d/.test(navigator.userAgent)
 );
 
-var treeType = 'dom';
+var TREE_TYPE = 'dom';
 
 function insertTreeChildren(tree) {
   if (!enableLazy) {
@@ -88,7 +88,7 @@ function queueText(tree, text) {
 
 function DOMLazyTree(node) {
   return {
-    lazy: treeType,
+    lazy: TREE_TYPE,
     node: node,
     children: [],
     html: null,
@@ -96,7 +96,7 @@ function DOMLazyTree(node) {
   };
 }
 
-DOMLazyTree.treeType = treeType;
+DOMLazyTree.treeType = TREE_TYPE;
 DOMLazyTree.insertTreeBefore = insertTreeBefore;
 DOMLazyTree.replaceChildWithTree = replaceChildWithTree;
 DOMLazyTree.queueChild = queueChild;

--- a/src/renderers/dom/server/ReactServerRendering.js
+++ b/src/renderers/dom/server/ReactServerRendering.js
@@ -11,6 +11,7 @@
 'use strict';
 
 var ReactDOMContainerInfo = require('ReactDOMContainerInfo');
+var ReactReconciler = require('ReactReconciler');
 var ReactDefaultBatchingStrategy = require('ReactDefaultBatchingStrategy');
 var ReactElement = require('ReactElement');
 var ReactMarkupChecksum = require('ReactMarkupChecksum');
@@ -41,7 +42,8 @@ function renderToStringImpl(element, makeStaticMarkup) {
 
     return transaction.perform(function() {
       var componentInstance = instantiateReactComponent(element);
-      var markup = componentInstance.mountComponent(
+      var markup = ReactReconciler.mountComponent(
+        componentInstance,
         transaction,
         null,
         ReactDOMContainerInfo(),

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -571,7 +571,7 @@ ReactDOMComponent.Mixin = {
         mountImage = tagOpen + '/>';
       } else {
         mountImage =
-          tagOpen + '>' + tagContent + '</' + this._currentElement.type + '>';
+          [tagOpen + '>'].concat(tagContent, '</' + this._currentElement.type + '>');
       }
     }
 
@@ -691,7 +691,7 @@ ReactDOMComponent.Mixin = {
           transaction,
           context
         );
-        ret = mountImages.join('');
+        ret = mountImages;
       }
     }
     if (newlineEatingTags[this._tag] && ret.charAt(0) === '\n') {
@@ -716,7 +716,7 @@ ReactDOMComponent.Mixin = {
     var innerHTML = props.dangerouslySetInnerHTML;
     if (innerHTML != null) {
       if (innerHTML.__html != null) {
-        DOMLazyTree.queueHTML(lazyTree, innerHTML.__html);
+        lazyTree.html = innerHTML.__html;
       }
     } else {
       var contentToUse =
@@ -724,16 +724,15 @@ ReactDOMComponent.Mixin = {
       var childrenToUse = contentToUse != null ? null : props.children;
       if (contentToUse != null) {
         // TODO: Validate that text is allowed as a child of this node
-        DOMLazyTree.queueText(lazyTree, contentToUse);
+        lazyTree.text = contentToUse;
       } else if (childrenToUse != null) {
         var mountImages = this.mountChildren(
           childrenToUse,
           transaction,
           context
         );
-        for (var i = 0; i < mountImages.length; i++) {
-          DOMLazyTree.queueChild(lazyTree, mountImages[i]);
-        }
+        lazyTree.children = mountImages;
+        return mountImages;
       }
     }
   },

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -575,6 +575,11 @@ ReactDOMComponent.Mixin = {
       }
     }
 
+    return mountImage;
+  },
+
+  postMount: function(transaction) {
+    var props = this._currentElement.props;
     switch (this._tag) {
       case 'button':
       case 'input':
@@ -588,8 +593,6 @@ ReactDOMComponent.Mixin = {
         }
         break;
     }
-
-    return mountImage;
   },
 
   /**

--- a/src/renderers/dom/shared/ReactDOMTextComponent.js
+++ b/src/renderers/dom/shared/ReactDOMTextComponent.js
@@ -97,7 +97,7 @@ assign(ReactDOMTextComponent.prototype, {
       var el = ownerDocument.createElement('span');
       ReactDOMComponentTree.precacheNode(this, el);
       var lazyTree = DOMLazyTree(el);
-      DOMLazyTree.queueText(lazyTree, this._stringText);
+      lazyTree.text = this._stringText;
       return lazyTree;
     } else {
       var escapedText = escapeTextContentForBrowser(this._stringText);

--- a/src/renderers/dom/shared/ReactDefaultInjection.js
+++ b/src/renderers/dom/shared/ReactDefaultInjection.js
@@ -31,6 +31,8 @@ var ReactReconcileTransaction = require('ReactReconcileTransaction');
 var SVGDOMPropertyConfig = require('SVGDOMPropertyConfig');
 var SelectEventPlugin = require('SelectEventPlugin');
 var SimpleEventPlugin = require('SimpleEventPlugin');
+var DOMLazyTree = require('DOMLazyTree');
+
 
 var alreadyInjected = false;
 
@@ -91,6 +93,8 @@ function inject() {
   );
 
   ReactInjection.Component.injectEnvironment(ReactComponentBrowserEnvironment);
+
+  ReactInjection.ReactReconciler.injectLazyTreeImpl(DOMLazyTree);
 
   if (__DEV__) {
     var url = (ExecutionEnvironment.canUseDOM && window.location.href) || '';

--- a/src/renderers/dom/shared/ReactInjection.js
+++ b/src/renderers/dom/shared/ReactInjection.js
@@ -20,6 +20,7 @@ var ReactEmptyComponent = require('ReactEmptyComponent');
 var ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
 var ReactNativeComponent = require('ReactNativeComponent');
 var ReactPerf = require('ReactPerf');
+var ReactReconciler = require('ReactReconciler');
 var ReactUpdates = require('ReactUpdates');
 
 var ReactInjection = {
@@ -32,6 +33,7 @@ var ReactInjection = {
   EventEmitter: ReactBrowserEventEmitter.injection,
   NativeComponent: ReactNativeComponent.injection,
   Perf: ReactPerf.injection,
+  ReactReconciler: ReactReconciler.injection,
   Updates: ReactUpdates.injection,
 };
 

--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -289,10 +289,6 @@ var ReactCompositeComponentMixin = {
       markup = this.performInitialMount(renderedElement, nativeParent, nativeContainerInfo, transaction, context);
     }
 
-    if (inst.componentDidMount) {
-      transaction.getReactMountReady().enqueue(inst.componentDidMount, inst);
-    }
-
     return markup;
   },
 
@@ -352,6 +348,18 @@ var ReactCompositeComponentMixin = {
 
   getNativeNode: function() {
     return ReactReconciler.getNativeNode(this._renderedComponent);
+  },
+
+  /**
+   * Called after recursion of children has completed
+   * @final
+   * @internal
+   */
+  postMount: function(transaction) {
+    var inst = this._instance;
+    if (inst.componentDidMount) {
+      transaction.getReactMountReady().enqueue(inst.componentDidMount, inst);
+    }
   },
 
   /**

--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -347,15 +347,7 @@ var ReactCompositeComponentMixin = {
       renderedElement
     );
 
-    var markup = ReactReconciler.mountComponent(
-      this._renderedComponent,
-      transaction,
-      nativeParent,
-      nativeContainerInfo,
-      this._processChildContext(context)
-    );
-
-    return markup;
+    return this._renderedComponent;
   },
 
   getNativeNode: function() {

--- a/src/renderers/shared/reconciler/ReactMultiChild.js
+++ b/src/renderers/shared/reconciler/ReactMultiChild.js
@@ -219,15 +219,8 @@ var ReactMultiChild = {
       for (var name in children) {
         if (children.hasOwnProperty(name)) {
           var child = children[name];
-          var mountImage = ReactReconciler.mountComponent(
-            child,
-            transaction,
-            this,
-            this._nativeContainerInfo,
-            context
-          );
           child._mountIndex = index++;
-          mountImages.push(mountImage);
+          mountImages.push(child);
         }
       }
       return mountImages;

--- a/src/renderers/shared/reconciler/ReactReconciler.js
+++ b/src/renderers/shared/reconciler/ReactReconciler.js
@@ -44,11 +44,12 @@ var ReactReconciler = {
     context
   ) {
     var child = internalInstance.mountComponent(
-        transaction,
-        nativeParent,
-        nativeContainerInfo,
-        context
-      );
+      transaction,
+      nativeParent,
+      nativeContainerInfo,
+      context
+    );
+
     if (internalInstance._currentElement &&
         internalInstance._currentElement.ref != null) {
       transaction.getReactMountReady().enqueue(attachRefs, internalInstance);
@@ -59,7 +60,7 @@ var ReactReconciler = {
       child = [child];
       join = false;
     }
-    var processedChildren = child.map(function(childOfChild) {
+    var processedChildren = child.map(function processChild(childOfChild) {
       return ReactReconciler.processChild(
         childOfChild,
         internalInstance,
@@ -96,7 +97,7 @@ var ReactReconciler = {
         // ReactDOMComponent
         for (var i=0; i<child.children.length; ++i) {
           var childOfChild = child.children[i];
-          var mountImage2 = ReactReconciler.mountComponent(
+          var childMountImage = ReactReconciler.mountComponent(
             childOfChild,
             transaction,
             internalInstance,
@@ -104,7 +105,11 @@ var ReactReconciler = {
             internalInstance._processChildContext ?
               internalInstance._processChildContext(context) : context,
           );
-          lazyImpl.queueChild(child, mountImage2);
+          lazyImpl.queueChild(child, childMountImage);
+
+          if (internalInstance.postMount) {
+            internalInstance.postMount(transaction);
+          }
         }
       } else {
         throw new Error('Unknown child type');
@@ -120,6 +125,11 @@ var ReactReconciler = {
         internalInstance._processChildContext ?
           internalInstance._processChildContext(context) : context,
       );
+
+      if (internalInstance.postMount) {
+        internalInstance.postMount(transaction);
+      }
+
       return mountImage;
     }
   },

--- a/src/renderers/shared/reconciler/ReactSimpleEmptyComponent.js
+++ b/src/renderers/shared/reconciler/ReactSimpleEmptyComponent.js
@@ -28,7 +28,7 @@ assign(ReactSimpleEmptyComponent.prototype, {
     nativeContainerInfo,
     context
   ) {
-    return [this._renderedComponent];
+    return this._renderedComponent;
   },
   receiveComponent: function() {
   },

--- a/src/renderers/shared/reconciler/ReactSimpleEmptyComponent.js
+++ b/src/renderers/shared/reconciler/ReactSimpleEmptyComponent.js
@@ -28,13 +28,7 @@ assign(ReactSimpleEmptyComponent.prototype, {
     nativeContainerInfo,
     context
   ) {
-    return ReactReconciler.mountComponent(
-      this._renderedComponent,
-      transaction,
-      nativeParent,
-      nativeContainerInfo,
-      context
-    );
+    return [this._renderedComponent];
   },
   receiveComponent: function() {
   },


### PR DESCRIPTION
This is a PR for ideas that @sebmarkbage recommended in  https://github.com/facebook/react/issues/4012. 

The idea is to centralize the recursion logic so that React is more pluggable for separate renderers and to support streaming in the future. I am hoisting all of the `ReactReconciler` calls out of `React*Component`s and implementing the recursion inside of `ReactReconciler.mountComponent` and other methods. This will affect the `React*Component` interface and implementation due to the need for post-recursion logic for things like event queueing.

From my analysis these are the spots that need to be addressed and the progress of this PR with respect to each:

## ReactCompositeComponent

### mountComponent
Mount queue: componentDidMount (post-recursion)

- [x] hoist ReactReconciler calls
- [x] Add postMount interface to handle post-recursion
    
### receiveComponent
Mount queue: componentDidUpdate (post-recursion)
- [ ] hoist ReactReconciler calls
- [ ] Add postUpdate interface to handle post-recursion
    
### unmountComponent
- [ ] hoist ReactReconciler calls

## ReactDOMComponent

### mountComponent
Mount queue: trapBubbledEventsLocal (pre-recursion), putListener (pre-recursion), focusDOMComponent (post-recursion)

- [x] hoist ReactReconciler calls
- [x] Add postMount interface to handle post-recursion
    
### receiveComponent
Mount queue: putListener (pre-recursion), postUpdateSelectWrapper (post-recursion)

- [ ] hoist ReactReconciler calls
- [ ] Add postUpdate interface to handle post-recursion
    
### unmountComponent
- [ ] hoist ReactReconciler calls

## ReactReconciler

Also, `ReactDOMComponent` uses `DomLazyTree` objects that the reconciler would need to recognize. In order to keep `ReactReconciler` decoupled, there will need to be a generic interface for trees and a plugin for handling `DomLazyTree` specifically.

### mountComponent
- [x] implement recursion
- [x] attachRefs queue (pre: **must** be before other queued methods)
- [x] implement generic `LazyTree` injection
- [x] call `postMount` on `React*Component` for implementing post-recursion event queueing

### receiveComponent
- [ ] implement recursion
- [ ] call `postUpdate` on `React*Component` for implementing post-recursion event queueing

### unmountComponent
- [ ] implement recursion
- [ ] call `postUnmount` for implementing post-recursion event removal

## Testing
- [ ] Fix tests that are affected by internal API changes

It would be good to get thoughts on whether this is going down the right path or if there's duplicate/conflicting work that is currently underway. So far I have only implemented the `mountComponent` path and tested against the example applications, but will continue the work for updates and unmounts as well.