### PR TITLE
Generate SRI hashes for docs

### DIFF
--- a/docs/Rakefile
+++ b/docs/Rakefile
@@ -24,6 +24,25 @@ task :update_version do
   end
 end
 
+desc "update SRI hashes"
+task :update_hashes do
+  map = {
+    'react.js': 'dev',
+    'react.min.js': 'prod',
+    'react-with-addons.js': 'addons_dev',
+    'react-with-addons.min.js': 'addons_prod',
+    'react-dom.js': 'dom_dev',
+    'react-dom.min.js': 'dom_prod',
+    'react-dom-server.js': 'dom_server_dev',
+    'react-dom-server.min.js': 'dom_server_prod'
+  }
+  site_config = YAML.load_file('_config.yml')
+  map.each do |file, key|
+    site_config['react_hashes'][key] = `openssl dgst -sha384 -binary ../../react-bower/#{file} | openssl base64 -A`
+  end
+  File.open('_config.yml', 'w+') { |f| f.write(site_config.to_yaml) }
+end
+
 desc "update acknowledgements list"
 task :update_acknowledgements do
   authors = File.readlines('../AUTHORS').map {|author| author.gsub(/ <.*\n/,'')}

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,9 +2,9 @@
 name: React
 description: A JavaScript library for building user interfaces
 url: https://facebook.github.io
-baseurl: /react
-permalink: /blog/:year/:month/:day/:title.html
-paginate_path: /blog/page:num/
+baseurl: "/react"
+permalink: "/blog/:year/:month/:day/:title.html"
+paginate_path: "/blog/page:num/"
 relative_permalinks: true
 paginate: 5
 timezone: America/Los_Angeles
@@ -37,3 +37,12 @@ sass:
 gems:
 - jekyll-redirect-from
 react_version: 0.14.7
+react_hashes:
+  dev: xQae1pUPdAKUe0u0KUTNt09zzdwheX4VSUsV8vatqM+t6X7rta01qOzessL808ox
+  prod: zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ
+  addons_dev: I5TF2q2QDmB31aN5lcClArdUo+WJH/Yi3hcH3PBVXFe5DYtYCFh7Jx/dmpba12zn
+  addons_prod: KPHTQfiYMhtsIRbZcY4ri1lBYZQbj4ePsSdzODR2Bu5L5ts3APVyqwKPBThO5Hgc
+  dom_dev: A1t0GCrR06cTHvMjaxeSE8XOiz6j7NvWdmxhN/9z748wEvJTVk13Rr8gMzTUnd8G
+  dom_prod: ntqCsHbLdMxT352UbhPbT7fqjE8xi4jLmQYQa8mYR+ylAapbXRfdsDweueDObf7m
+  dom_server_dev: 3I5+eGB/ILYa6pQQX+rM9O0SyDltamM40RiZ5JvIijSYEfVGZU0vY4Iwx9a1eYyD
+  dom_server_prod: Kt9dEqXzv00orFPW2o3H+kxQtSiNO8EqXsXJT3i99rCcp74N/Km98V0kUxAzy44k

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -24,32 +24,48 @@ If you're just starting out, make sure to use the development version.
 The uncompressed, development version of [react.js](https://fb.me/react-{{site.react_version}}.js) and [react-dom.js](https://fb.me/react-dom-{{site.react_version}}.js) with inline documentation (you need both files).
 
 ```html
-<script src="https://fb.me/react-{{site.react_version}}.js" integrity="sha384-{{site.react_hashes.dev}}" crossorigin="anonymous"></script>
-<script src="https://fb.me/react-dom-{{site.react_version}}.js" integrity="sha384-{{site.react_hashes.dom_dev}}" crossorigin="anonymous"></script>
+<script src="https://fb.me/react-{{site.react_version}}.js"
+        integrity="sha384-{{site.react_hashes.dev}}"
+        crossorigin="anonymous"></script>
+<script src="https://fb.me/react-dom-{{site.react_version}}.js"
+        integrity="sha384-{{site.react_hashes.dom_dev}}"
+        crossorigin="anonymous"></script>
 ```
 
 #### React {{site.react_version}} (production)
 The compressed, production version of [react.js](https://fb.me/react-{{site.react_version}}.min.js) and [react-dom.js](https://fb.me/react-dom-{{site.react_version}}.min.js) (you need both).
 
 ```html
-<script src="https://fb.me/react-{{site.react_version}}.min.js" integrity="sha384-{{site.react_hashes.prod}}" crossorigin="anonymous"></script>
-<script src="https://fb.me/react-dom-{{site.react_version}}.min.js" integrity="sha384-{{site.react_hashes.dom_prod}}" crossorigin="anonymous"></script>
+<script src="https://fb.me/react-{{site.react_version}}.min.js"
+        integrity="sha384-{{site.react_hashes.prod}}"
+        crossorigin="anonymous"></script>
+<script src="https://fb.me/react-dom-{{site.react_version}}.min.js"
+        integrity="sha384-{{site.react_hashes.dom_prod}}"
+        crossorigin="anonymous"></script>
 ```
 
 #### React with Add-Ons {{site.react_version}} (development)
 The uncompressed, development version of React with [optional add-ons](/react/docs/addons.html).
 
 ```html
-<script src="https://fb.me/react-with-addons-{{site.react_version}}.js" integrity="sha384-{{site.react_hashes.addons_dev}}" crossorigin="anonymous"></script>
-<script src="https://fb.me/react-dom-{{site.react_version}}.js" integrity="sha384-{{site.react_hashes.dom_dev}}" crossorigin="anonymous"></script>
+<script src="https://fb.me/react-with-addons-{{site.react_version}}.js"
+        integrity="sha384-{{site.react_hashes.addons_dev}}"
+        crossorigin="anonymous"></script>
+<script src="https://fb.me/react-dom-{{site.react_version}}.js"
+        integrity="sha384-{{site.react_hashes.dom_dev}}"
+        crossorigin="anonymous"></script>
 ```
 
 #### React with Add-Ons {{site.react_version}} (production)
 The compressed, production version of React with [optional add-ons](/react/docs/addons.html).
 
 ```html
-<script src="https://fb.me/react-with-addons-{{site.react_version}}.min.js" integrity="sha384-{{site.react_hashes.addons_prod}}" crossorigin="anonymous"></script>
-<script src="https://fb.me/react-dom-{{site.react_version}}.min.js" integrity="sha384-{{site.react_hashes.dom_prod}}" crossorigin="anonymous"></script>
+<script src="https://fb.me/react-with-addons-{{site.react_version}}.min.js"
+        integrity="sha384-{{site.react_hashes.addons_prod}}"
+        crossorigin="anonymous"></script>
+<script src="https://fb.me/react-dom-{{site.react_version}}.min.js"
+        integrity="sha384-{{site.react_hashes.dom_prod}}"
+        crossorigin="anonymous"></script>
 ```
 
 All scripts are also available via [CDNJS](https://cdnjs.com/libraries/react/).

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -24,32 +24,32 @@ If you're just starting out, make sure to use the development version.
 The uncompressed, development version of [react.js](https://fb.me/react-{{site.react_version}}.js) and [react-dom.js](https://fb.me/react-dom-{{site.react_version}}.js) with inline documentation (you need both files).
 
 ```html
-<script src="https://fb.me/react-{{site.react_version}}.js"  integrity="sha384-xQae1pUPdAKUe0u0KUTNt09zzdwheX4VSUsV8vatqM+t6X7rta01qOzessL808ox" crossorigin="anonymous"></script>
-<script src="https://fb.me/react-dom-{{site.react_version}}.js" integrity="sha384-A1t0GCrR06cTHvMjaxeSE8XOiz6j7NvWdmxhN/9z748wEvJTVk13Rr8gMzTUnd8G" crossorigin="anonymous"></script>
+<script src="https://fb.me/react-{{site.react_version}}.js" integrity="sha384-{{site.react_hashes.dev}}" crossorigin="anonymous"></script>
+<script src="https://fb.me/react-dom-{{site.react_version}}.js" integrity="sha384-{{site.react_hashes.dom_dev}}" crossorigin="anonymous"></script>
 ```
 
 #### React {{site.react_version}} (production)
 The compressed, production version of [react.js](https://fb.me/react-{{site.react_version}}.min.js) and [react-dom.js](https://fb.me/react-dom-{{site.react_version}}.min.js) (you need both).
 
 ```html
-<script src="https://fb.me/react-{{site.react_version}}.min.js" integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ" crossorigin="anonymous"></script>
-<script src="https://fb.me/react-dom-{{site.react_version}}.min.js" integrity="sha384-ntqCsHbLdMxT352UbhPbT7fqjE8xi4jLmQYQa8mYR+ylAapbXRfdsDweueDObf7m" crossorigin="anonymous"></script>
+<script src="https://fb.me/react-{{site.react_version}}.min.js" integrity="sha384-{{site.react_hashes.prod}}" crossorigin="anonymous"></script>
+<script src="https://fb.me/react-dom-{{site.react_version}}.min.js" integrity="sha384-{{site.react_hashes.dom_prod}}" crossorigin="anonymous"></script>
 ```
 
 #### React with Add-Ons {{site.react_version}} (development)
 The uncompressed, development version of React with [optional add-ons](/react/docs/addons.html).
 
 ```html
-<script src="https://fb.me/react-with-addons-{{site.react_version}}.js" integrity="sha384-I5TF2q2QDmB31aN5lcClArdUo+WJH/Yi3hcH3PBVXFe5DYtYCFh7Jx/dmpba12zn" crossorigin="anonymous"></script>
-<script src="https://fb.me/react-dom-{{site.react_version}}.js" integrity="sha384-A1t0GCrR06cTHvMjaxeSE8XOiz6j7NvWdmxhN/9z748wEvJTVk13Rr8gMzTUnd8G" crossorigin="anonymous"></script>
+<script src="https://fb.me/react-with-addons-{{site.react_version}}.js" integrity="sha384-{{site.react_hashes.addons_dev}}" crossorigin="anonymous"></script>
+<script src="https://fb.me/react-dom-{{site.react_version}}.js" integrity="sha384-{{site.react_hashes.dom_dev}}" crossorigin="anonymous"></script>
 ```
 
 #### React with Add-Ons {{site.react_version}} (production)
 The compressed, production version of React with [optional add-ons](/react/docs/addons.html).
 
 ```html
-<script src="https://fb.me/react-with-addons-{{site.react_version}}.min.js" integrity="sha384-KPHTQfiYMhtsIRbZcY4ri1lBYZQbj4ePsSdzODR2Bu5L5ts3APVyqwKPBThO5Hgc" crossorigin="anonymous"></script>
-<script src="https://fb.me/react-dom-{{site.react_version}}.min.js" integrity="sha384-ntqCsHbLdMxT352UbhPbT7fqjE8xi4jLmQYQa8mYR+ylAapbXRfdsDweueDObf7m" crossorigin="anonymous"></script>
+<script src="https://fb.me/react-with-addons-{{site.react_version}}.min.js" integrity="sha384-{{site.react_hashes.addons_prod}}" crossorigin="anonymous"></script>
+<script src="https://fb.me/react-dom-{{site.react_version}}.min.js" integrity="sha384-{{site.react_hashes.dom_prod}}" crossorigin="anonymous"></script>
 ```
 
 All scripts are also available via [CDNJS](https://cdnjs.com/libraries/react/).


### PR DESCRIPTION
Followup to #6004 so that we don't have to hardcode them. I've already run the script and it looks like everything matches to those generated via srihash.org in the previous PR.

We'll have to run this manually on releases for now, but that's ok. We already have a separate step we do to update the docs.

Fixes #5970