### PR TITLE
Corrects JSX typo in documentation code examples.

### DIFF
--- a/docs/docs/02.3-jsx-gotchas.it-IT.md
+++ b/docs/docs/02.3-jsx-gotchas.it-IT.md
@@ -49,7 +49,7 @@ Puoi usare array misti con stringhe ed elementi JSX.
 Come ultima risorsa, puoi sempre [inserire HTML nativo](/react/tips/dangerously-set-inner-html.html).
 
 ```javascript
-<div dangerouslySetInnerHTML={{'{{'}}__html: 'Primo &middot; Secondo'}} />
+<div dangerouslySetInnerHTML={{__html: 'Primo &middot; Secondo'}} />
 ```
 
 

--- a/docs/docs/02.3-jsx-gotchas.ja-JP.md
+++ b/docs/docs/02.3-jsx-gotchas.ja-JP.md
@@ -49,7 +49,7 @@ JSXはHTMLに似ていますが、重要な違いがいくつかあります。
 最後の手段として、常に[生のHTMLを挿入](/react/tips/dangerously-set-inner-html.html)することもできます。
 
 ```javascript
-<div dangerouslySetInnerHTML={{'{{'}}__html: 'First &middot; Second'}} />
+<div dangerouslySetInnerHTML={{__html: 'First &middot; Second'}} />
 ```
 
 

--- a/docs/docs/02.3-jsx-gotchas.ko-KR.md
+++ b/docs/docs/02.3-jsx-gotchas.ko-KR.md
@@ -49,7 +49,7 @@ JSX의 리터럴 텍스트에 HTML 엔티티를 넣을 수 있습니다.
 최후의 수단으로, 항상 [생 HTML을 삽입](/react/docs/dom-differences-ko-KR.html)할 수 있습니다.
 
 ```javascript
-<div dangerouslySetInnerHTML={{'{{'}}__html: 'First &middot; Second'}} />
+<div dangerouslySetInnerHTML={{__html: 'First &middot; Second'}} />
 ```
 
 

--- a/docs/docs/02.3-jsx-gotchas.md
+++ b/docs/docs/02.3-jsx-gotchas.md
@@ -49,7 +49,7 @@ You can use mixed arrays with strings and JSX elements.
 As a last resort, you always have the ability to [insert raw HTML](/react/tips/dangerously-set-inner-html.html).
 
 ```javascript
-<div dangerouslySetInnerHTML={{'{{'}}__html: 'First &middot; Second'}} />
+<div dangerouslySetInnerHTML={{__html: 'First &middot; Second'}} />
 ```
 
 

--- a/docs/docs/02.3-jsx-gotchas.zh-CN.md
+++ b/docs/docs/02.3-jsx-gotchas.zh-CN.md
@@ -49,7 +49,7 @@ HTML 实体可以插入到 JSX 的文本中。
 万不得已，可以直接[插入原始HTML](/react/tips/dangerously-set-inner-html.html)。
 
 ```javascript
-<div dangerouslySetInnerHTML={{'{{'}}__html: 'First &middot; Second'}} />
+<div dangerouslySetInnerHTML={{__html: 'First &middot; Second'}} />
 ```
 
 

--- a/docs/docs/04-multiple-components.it-IT.md
+++ b/docs/docs/04-multiple-components.it-IT.md
@@ -106,7 +106,7 @@ In molti casi, questo problema può essere aggirato nascondendo gli elementi anz
 </Card>
 // Seconda passata di rendering
 <Card>
-  <p style={{'{{'}}display: 'none'}}>Paragrafo 1</p>
+  <p style={{display: 'none'}}>Paragrafo 1</p>
   <p>Paragrafo 2</p>
 </Card>
 ```

--- a/docs/docs/04-multiple-components.ja-JP.md
+++ b/docs/docs/04-multiple-components.ja-JP.md
@@ -105,7 +105,7 @@ Reactのコンポーネントのインスタンスを作成する時には、以
 </Card>
 // パス2のレンダリング
 <Card>
-  <p style={{'{{'}}display: 'none'}}>Paragraph 1</p>
+  <p style={{display: 'none'}}>Paragraph 1</p>
   <p>Paragraph 2</p>
 </Card>
 ```

--- a/docs/docs/04-multiple-components.ko-KR.md
+++ b/docs/docs/04-multiple-components.ko-KR.md
@@ -100,7 +100,7 @@ React 컴포넌트 인스턴스를 만들 때, 추가적인 React 컴포넌트�
 </Card>
 // Render Pass 2
 <Card>
-  <p style={{'{{'}}display: 'none'}}>Paragraph 1</p>
+  <p style={{display: 'none'}}>Paragraph 1</p>
   <p>Paragraph 2</p>
 </Card>
 ```

--- a/docs/docs/04-multiple-components.md
+++ b/docs/docs/04-multiple-components.md
@@ -100,7 +100,7 @@ In most cases, this can be sidestepped by hiding elements instead of destroying 
 </Card>
 // Render Pass 2
 <Card>
-  <p style={{'{{'}}display: 'none'}}>Paragraph 1</p>
+  <p style={{display: 'none'}}>Paragraph 1</p>
   <p>Paragraph 2</p>
 </Card>
 ```

--- a/docs/docs/04-multiple-components.zh-CN.md
+++ b/docs/docs/04-multiple-components.zh-CN.md
@@ -100,7 +100,7 @@ ReactDOM.render(
 </Card>
 // 第二次渲染
 <Card>
-  <p style={{'{{'}}display: 'none'}}>Paragraph 1</p>
+  <p style={{display: 'none'}}>Paragraph 1</p>
   <p>Paragraph 2</p>
 </Card>
 ```

--- a/docs/docs/12-context.ko-KR.md
+++ b/docs/docs/12-context.ko-KR.md
@@ -5,7 +5,7 @@ permalink: context-ko-KR.html
 prev: advanced-performance-ko-KR.html
 ---
 
-React의 가장 큰 장점 중 하나는 React 컴포넌트를 통해 데이터의 흐름을 추적하기 쉽다는 것입니다. 컴포넌트를 보면 각각의 프로퍼티가 어떻게 전달되었는지 쉽게 파악할 수 있습니다. 
+React의 가장 큰 장점 중 하나는 React 컴포넌트를 통해 데이터의 흐름을 추적하기 쉽다는 것입니다. 컴포넌트를 보면 각각의 프로퍼티가 어떻게 전달되었는지 쉽게 파악할 수 있습니다.
 
 때때로 컴포넌트 트리를 통해 props을 전단하는 대신 수동으로 모든 레벨에서 데이터를 전달하고 싶은 경우가 있습니다. React의 "컨텍스트" 기능은 이를 가능하게 해줍니다.
 
@@ -18,7 +18,7 @@ React의 가장 큰 장점 중 하나는 React 컴포넌트를 통해 데이터�
 >
 > **만약 컨텍스트를 사용해야 하는 경우에도, 가능한 아껴 사용하세요.**
 >
-> 구축하는것이 애플리케이션이든 라이브러리든간에, 가능한 컨텍스트의 사용은 작은 영역으로 격리하고 직접적으로 컨텍스트 API를 사용하는 것을 피하세요. 그렇게 하면 API가 변경 되더라도 쉽게 업데이트 할 수 있습니다. 
+> 구축하는것이 애플리케이션이든 라이브러리든간에, 가능한 컨텍스트의 사용은 작은 영역으로 격리하고 직접적으로 컨텍스트 API를 사용하는 것을 피하세요. 그렇게 하면 API가 변경 되더라도 쉽게 업데이트 할 수 있습니다.
 
 ## 트리를 통해 정보를 자동으로 전달하기
 
@@ -28,7 +28,7 @@ React의 가장 큰 장점 중 하나는 React 컴포넌트를 통해 데이터�
 var Button = React.createClass({
   render: function() {
     return (
-      <button style={{'{{'}}background: this.props.color}}>
+      <button style={{background: this.props.color}}>
         {this.props.children}
       </button>
     );
@@ -65,7 +65,7 @@ var Button = React.createClass({
   },
   render: function() {
     return (
-      <button style={{'{{'}}background: this.context.color}}>
+      <button style={{background: this.context.color}}>
         {this.props.children}
       </button>
     );
@@ -122,7 +122,7 @@ var MessageList = React.createClass({
 <Menu items={['가지', '땅콩호박', '클레멘타인']} />
 ```
 
-원한다면 전체 React 컴포넌트를 프로퍼티로 전달할 수도 있습니다. 
+원한다면 전체 React 컴포넌트를 프로퍼티로 전달할 수도 있습니다.
 
 ## Referencing context in lifecycle methods
 
@@ -153,7 +153,7 @@ Stateless functional components are also able to reference `context` if `context
 ```javascript
 function Button(props, context) {
   return (
-    <button style={{'{{'}}background: context.color}}>
+    <button style={{background: context.color}}>
       {props.children}
     </button>
   );
@@ -165,9 +165,9 @@ Button.contextTypes = {color: React.PropTypes.string};
 
 대부분의 경우, 깔끔한 코드를 위해 전역 변수를 피하는 것과 마찬가지로 컨텍스트의 사용을 피해야 합니다. 특히 "타이핑을 줄이거나" 명시적인 프로퍼티 전달 대신 이를 사용하려는 경우 다시 한번 생각해 보세요.
 
-컨텍스트의 가장 적절한 사용 사례는 로그인한 유저, 언어 설정, 테마 정보 등을 암시적으로 전달하는 것입니다. 컨텍스트를 사용함으로써 이런 정보들을 전역으로 다루는 대신 단일 React 서브트리 내에서 다룰 수 있습니다. 
+컨텍스트의 가장 적절한 사용 사례는 로그인한 유저, 언어 설정, 테마 정보 등을 암시적으로 전달하는 것입니다. 컨텍스트를 사용함으로써 이런 정보들을 전역으로 다루는 대신 단일 React 서브트리 내에서 다룰 수 있습니다.
 
-모델 데이터를 컴포넌트로 전달하는데 컨텍스트를 사용하지 마세요. 트리를 통해 명시적으로 데이터를 엮어 전달하는 것이 훨씬 이해하기 쉽습니다. 컨텍스트는 렌더되는 위치에 따라 다르게 작동하기 때문에 컴포넌트를 더욱 연결되고(coupled) 재사용성이 떨어지게 만듭니다. 
+모델 데이터를 컴포넌트로 전달하는데 컨텍스트를 사용하지 마세요. 트리를 통해 명시적으로 데이터를 엮어 전달하는 것이 훨씬 이해하기 쉽습니다. 컨텍스트는 렌더되는 위치에 따라 다르게 작동하기 때문에 컴포넌트를 더욱 연결되고(coupled) 재사용성이 떨어지게 만듭니다.
 
 ## 알려진 한계점
 

--- a/docs/docs/12-context.md
+++ b/docs/docs/12-context.md
@@ -27,7 +27,7 @@ Suppose you have a structure like:
 var Button = React.createClass({
   render: function() {
     return (
-      <button style={{'{{'}}background: this.props.color}}>
+      <button style={{background: this.props.color}}>
         {this.props.children}
       </button>
     );
@@ -64,7 +64,7 @@ var Button = React.createClass({
   },
   render: function() {
     return (
-      <button style={{'{{'}}background: this.context.color}}>
+      <button style={{background: this.context.color}}>
         {this.props.children}
       </button>
     );
@@ -152,7 +152,7 @@ Stateless functional components are also able to reference `context` if `context
 ```javascript
 function Button(props, context) {
   return (
-    <button style={{'{{'}}background: context.color}}>
+    <button style={{background: context.color}}>
       {props.children}
     </button>
   );
@@ -179,10 +179,10 @@ var MediaQuery = React.createClass({
     var checkMediaQuery = function(){
       var type = window.matchMedia("min-width: 1025px").matches ? 'desktop' : 'mobile';
       if (type !== this.state.type){
-        this.setState({type:type}); 
+        this.setState({type:type});
       }
     };
-    
+
     window.addEventListener('resize', checkMediaQuery);
     checkMediaQuery();
   },

--- a/docs/docs/12-context.zh-CN.md
+++ b/docs/docs/12-context.zh-CN.md
@@ -27,7 +27,7 @@ React最大的优势之一是他很容易从你的React组件里跟踪数据流�
 var Button = React.createClass({
   render: function() {
     return (
-      <button style={{'{{'}}background: this.props.color}}>
+      <button style={{background: this.props.color}}>
         {this.props.children}
       </button>
     );
@@ -64,7 +64,7 @@ var Button = React.createClass({
   },
   render: function() {
     return (
-      <button style={{'{{'}}background: this.context.color}}>
+      <button style={{background: this.context.color}}>
         {this.props.children}
       </button>
     );
@@ -152,7 +152,7 @@ void componentDidUpdate(
 ```javascript
 function Button(props, context) {
   return (
-    <button style={{'{{'}}background: context.color}}>
+    <button style={{background: context.color}}>
       {props.children}
     </button>
   );
@@ -170,4 +170,4 @@ context最好的使用场景是隐式的传入登录的用户,当前的语言,�
 
 ## 已知的限制
 
-如果一个由组件提供的context值变动,使用那个值的子级不会更新,如果一个直接的父级从 `shouldComponentUpdate` 返回 `false` .详见 issue [#2517](https://github.com/facebook/react/issues/2517) . 
+如果一个由组件提供的context值变动,使用那个值的子级不会更新,如果一个直接的父级从 `shouldComponentUpdate` 返回 `false` .详见 issue [#2517](https://github.com/facebook/react/issues/2517) .

--- a/docs/docs/ref-08-reconciliation.it-IT.md
+++ b/docs/docs/ref-08-reconciliation.it-IT.md
@@ -66,8 +66,8 @@ renderB: <div id="after" />
 Anziché trattare lo stile come una stringa opaca, viene rappresentato come un oggetto chiave-valore. Ciò ci permette di aggiornare solo le proprietà che sono cambiate.
 
 ```xml
-renderA: <div style={{'{{'}}color: 'red'}} />
-renderB: <div style={{'{{'}}fontWeight: 'bold'}} />
+renderA: <div style={{color: 'red'}} />
+renderB: <div style={{fontWeight: 'bold'}} />
 => [removeStyle color], [addStyle font-weight 'bold']
 ```
 

--- a/docs/docs/ref-08-reconciliation.ko-KR.md
+++ b/docs/docs/ref-08-reconciliation.ko-KR.md
@@ -66,8 +66,8 @@ renderB: <div id="after" />
 스타일을 불명확한 문자열로 다루지 않고 키-값 객체를 사용합니다. 이는 변경된 프로퍼티만 업데이트 하도록 해줍니다.
 
 ```xml
-renderA: <div style={{'{{'}}color: 'red'}} />
-renderB: <div style={{'{{'}}fontWeight: 'bold'}} />
+renderA: <div style={{color: 'red'}} />
+renderB: <div style={{fontWeight: 'bold'}} />
 => [removeStyle color], [addStyle font-weight 'bold']
 ```
 

--- a/docs/docs/ref-08-reconciliation.md
+++ b/docs/docs/ref-08-reconciliation.md
@@ -66,8 +66,8 @@ renderB: <div id="after" />
 Instead of treating style as an opaque string, a key-value object is used instead. This lets us update only the properties that changed.
 
 ```xml
-renderA: <div style={{'{{'}}color: 'red'}} />
-renderB: <div style={{'{{'}}fontWeight: 'bold'}} />
+renderA: <div style={{color: 'red'}} />
+renderB: <div style={{fontWeight: 'bold'}} />
 => [removeStyle color], [addStyle font-weight 'bold']
 ```
 


### PR DESCRIPTION
In several places the docs read `style={{'{{'}}foo: 'bar'}}`, this
corrects that to the proper value showcasing a plain object passed
to the properties without the `{{'{{'}}` which appears to be an
escaping / typo.