### PR TITLE
Fix for issue/6027.

### DIFF
--- a/src/renderers/dom/client/wrappers/ReactDOMSelect.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMSelect.js
@@ -236,7 +236,7 @@ function _handleChange(event) {
   var props = this._currentElement.props;
   var returnValue = LinkedValueUtils.executeOnChange(props, event);
 
-  if (this._rootNodeID && !this._wrapperState.pendingUpdate) {
+  if (this._rootNodeID) {
     this._wrapperState.pendingUpdate = true;
   }
   ReactUpdates.asap(updateOptionsIfPendingUpdateAndMounted, this);

--- a/src/renderers/dom/client/wrappers/ReactDOMSelect.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMSelect.js
@@ -236,7 +236,7 @@ function _handleChange(event) {
   var props = this._currentElement.props;
   var returnValue = LinkedValueUtils.executeOnChange(props, event);
 
-  if (this._rootNodeID && this._wrapperState.pendingUpdate) {
+  if (this._rootNodeID && !this._wrapperState.pendingUpdate) {
     this._wrapperState.pendingUpdate = true;
   }
   ReactUpdates.asap(updateOptionsIfPendingUpdateAndMounted, this);

--- a/src/renderers/dom/client/wrappers/ReactDOMSelect.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMSelect.js
@@ -236,7 +236,9 @@ function _handleChange(event) {
   var props = this._currentElement.props;
   var returnValue = LinkedValueUtils.executeOnChange(props, event);
 
-  this._wrapperState.pendingUpdate = true;
+  if (this._rootNodeID && this._wrapperState.pendingUpdate) {
+    this._wrapperState.pendingUpdate = true;
+  }
   ReactUpdates.asap(updateOptionsIfPendingUpdateAndMounted, this);
   return returnValue;
 }

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMSelect-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMSelect-test.js
@@ -517,4 +517,24 @@ describe('ReactDOMSelect', function() {
     );
     expect(console.error.argsForCall.length).toBe(1);
   });
+
+  it('should be able to safely remove select onChange', function() {
+    function changeView() {
+      ReactDOM.unmountComponentAtNode(container);
+    }
+
+    var container = document.createElement('div');
+    var stub =
+      <select value="giraffe" onChange={changeView}>
+        <option value="monkey">A monkey!</option>
+        <option value="giraffe">A giraffe!</option>
+        <option value="gorilla">A gorilla!</option>
+      </select>;
+    stub = ReactDOM.render(stub, container);
+    var node = ReactDOM.findDOMNode(stub);
+
+    expect(() => ReactTestUtils.Simulate.change(node)).not.toThrow(
+      "Cannot set property 'pendingUpdate' of null"
+    );
+  });
 });


### PR DESCRIPTION
ReactDOMSelect's _handleChange function tries to set
this._wrapperState.pendingUpdate = true after executing the onChange
function. However, if the select was removed as a result of said
fuction, this._wrapperState would be null. Resulting in an
Uncaught TypeError: Cannot set property 'pendingUpdate' of null.

https://github.com/facebook/react/issues/6027