### PR TITLE
Fix #5929. Set default prop when prop is undefined while cloning

### DIFF
--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -264,6 +264,16 @@ ReactElement.cloneElement = function(element, config, children) {
     props.children = childArray;
   }
 
+  // Resolve default props
+  if (element.type && element.type.defaultProps) {
+    var defaultProps = element.type.defaultProps;
+    for (propName in defaultProps) {
+      if (props[propName] === undefined) {
+        props[propName] = defaultProps[propName];
+      }
+    }
+  }
+
   return ReactElement(
     element.type,
     key,

--- a/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
@@ -263,4 +263,22 @@ describe('ReactElementClone', function() {
     );
   });
 
+  it('overwrites undefined props when a default is available', function() {
+    var Component = React.createClass({
+      getDefaultProps: function() {
+        return {fruit: 'persimmon'};
+      },
+      render: function() {
+        return React.createElement('span');
+      },
+    });
+
+    let element = React.createElement(Component);
+    element = React.cloneElement(element, {
+      fruit: undefined,
+    });
+
+    expect(element.props.fruit).toBe('persimmon');
+  });
+
 });


### PR DESCRIPTION
Set default props if a passed in prop is undefined while using cloneElement, the same as what happens when doing createElement.