### PR TITLE
Update to jest-cli 0.9.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "gulp-babel": "^5.3.0",
     "gulp-flatten": "^0.2.0",
     "gzip-js": "~0.3.2",
-    "jest-cli": "^0.6.1",
+    "jest-cli": "^0.9.0-fb1",
     "platform": "^1.1.0",
     "run-sequence": "^1.1.4",
     "through2": "^2.0.0",

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -51,26 +51,10 @@ module.exports = {
       !filePath.match(/\/node_modules\//) &&
       !filePath.match(/\/third_party\//)
     ) {
-      var rv = babel.transform(
+      return babel.transform(
         src,
         Object.assign({filename: filePath}, babelOptions)
       ).code;
-      // hax to turn fbjs/lib/foo into /path/to/node_modules/fbjs/lib/foo
-      // because jest is slooow with node_modules paths (facebook/jest#465)
-      rv = rv.replace(
-        /require\('(fbjs\/lib\/.+)'\)/g,
-        function(call, arg) {
-          return (
-            'require(' +
-            JSON.stringify(
-              path.join(__dirname, '../../node_modules', arg)
-            ) +
-            ')'
-          );
-        }
-      );
-
-      return rv;
     }
     return src;
   },

--- a/src/test/__tests__/ReactDefaultPerf-test.js
+++ b/src/test/__tests__/ReactDefaultPerf-test.js
@@ -24,7 +24,7 @@ describe('ReactDefaultPerf', function() {
 
   beforeEach(function() {
     var now = 0;
-    jest.setMock('performanceNow', function() {
+    jest.setMock('fbjs/lib/performanceNow', function() {
       return now++;
     });
 


### PR DESCRIPTION
This brings the runtime down to ~20-25s and we can finally get rid of the ugly rewrite thing that was previously necessary because Jest was clowny :)

Also fixed the `performanceNow` mock in one of the tests. Jest now doesn't look into `node_modules` by default, so I updated the module name/path for the mock.