### PR TITLE
Add clipPathUnits attribute

### DIFF
--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -50,6 +50,7 @@ var HTMLDOMPropertyConfig = {
     checked: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
     classID: null,
     className: null,
+    clipPathUnits: null,
     cols: HAS_POSITIVE_NUMERIC_VALUE,
     colSpan: null,
     content: null,


### PR DESCRIPTION
Hi, react says that it [supports](https://facebook.github.io/react/docs/tags-and-attributes.html#svg-elements) `clipPath`, but it doesn't support the [clipPathUnits](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/clipPathUnits) attribute.