### PR TITLE
Fix ReactServerRendering memory leak in ReactEmptyComponent

### DIFF
--- a/src/renderers/shared/reconciler/ReactEmptyComponent.js
+++ b/src/renderers/shared/reconciler/ReactEmptyComponent.js
@@ -25,6 +25,10 @@ var ReactEmptyComponentInjection = {
   },
 };
 
+function registerNullComponentID() {
+  ReactEmptyComponentRegistry.registerNullComponentID(this._rootNodeID);
+}
+
 var ReactEmptyComponent = function(instantiate) {
   this._currentElement = null;
   this._rootNodeID = null;
@@ -34,7 +38,7 @@ assign(ReactEmptyComponent.prototype, {
   construct: function(element) {
   },
   mountComponent: function(rootID, transaction, context) {
-    ReactEmptyComponentRegistry.registerNullComponentID(rootID);
+    transaction.getReactMountReady().enqueue(registerNullComponentID, this);
     this._rootNodeID = rootID;
     return ReactReconciler.mountComponent(
       this._renderedComponent,


### PR DESCRIPTION
`ReactEmptyComponent` registers null component IDs on mount and deregisters them on unmount. However, when rendering server-side `unmountComponent` is never called on the component instance. As a result, null IDs accumulate over time.

The solution in the PR is simply to not register the IDs when server-side rendering. I have no idea if that's the right solution, but it's certainly _a_ solution!

I'm also not sure if this is still an issue in 0.15. The issue was found in 0.14.7. You can see in this heapdump a ton of React ID strings, each one being retained by `nullComponentIDsRegistry`:

<img width="940" alt="screen shot 2016-02-17 at 5 11 16 pm" src="https://cloud.githubusercontent.com/assets/135977/13130574/e50e0d94-d599-11e5-80cf-d83b1b586296.png">
