### PR TITLE
Wrap insertBefore in Windows 8 apps

### DIFF
--- a/src/renderers/dom/client/utils/DOMChildrenOperations.js
+++ b/src/renderers/dom/client/utils/DOMChildrenOperations.js
@@ -9,6 +9,8 @@
  * @providesModule DOMChildrenOperations
  */
 
+/* globals MSApp */
+
 'use strict';
 
 var DOMLazyTree = require('DOMLazyTree');
@@ -35,7 +37,14 @@ function insertChildAt(parentNode, childNode, referenceNode) {
   // We rely exclusively on `insertBefore(node, null)` instead of also using
   // `appendChild(node)`. (Using `undefined` is not allowed by all browsers so
   // we are careful to use `null`.)
-  parentNode.insertBefore(childNode, referenceNode);
+
+  if (typeof MSApp !== 'undefined' && MSApp.execUnsafeLocalFunction) {
+    MSApp.execUnsafeLocalFunction(function() {
+      parentNode.insertBefore(childNode, referenceNode);
+    });
+  } else {
+    parentNode.insertBefore(childNode, referenceNode);
+  }
 }
 
 function insertLazyTreeChildAt(parentNode, childTree, referenceNode) {

--- a/src/renderers/dom/client/utils/DOMLazyTree.js
+++ b/src/renderers/dom/client/utils/DOMLazyTree.js
@@ -9,6 +9,8 @@
  * @providesModule DOMLazyTree
  */
 
+/* globals MSApp */
+
 'use strict';
 
 var setTextContent = require('setTextContent');
@@ -51,7 +53,14 @@ function insertTreeChildren(tree) {
 }
 
 function insertTreeBefore(parentNode, tree, referenceNode) {
-  parentNode.insertBefore(tree.node, referenceNode);
+  if (typeof MSApp !== 'undefined' && MSApp.execUnsafeLocalFunction) {
+    MSApp.execUnsafeLocalFunction(function() {
+      parentNode.insertBefore(tree.node, referenceNode);
+    });
+  } else {
+    parentNode.insertBefore(tree.node, referenceNode);
+  }
+
   insertTreeChildren(tree);
 }
 


### PR DESCRIPTION
React does not work correctly on Windows 8 app. This platform has security restrictions and in some cases it throws this error:

> 0x800c001c - JavaScript runtime error: Unable to add dynamic content. A script attempted to inject dynamic content, or elements previously modified dynamically, that might be unsafe. For example, using the innerHTML property to add script or malformed HTML will generate this exception. Use the toStaticHTML method to filter dynamic content, or explicitly create elements and attributes with a method such as createElement. For more information, see http://go.microsoft.com/fwlink/?LinkID=247104.

The bug is related to #441 and have a similar reason but with `insertBefore` call. It can be fixed in the same way.