### PR TITLE
fix sample code highlight

### DIFF
--- a/docs/docs/tutorial.it-IT.md
+++ b/docs/docs/tutorial.it-IT.md
@@ -258,7 +258,7 @@ Ma c'è un problema! I nostri commenti visualizzati appaiono come segue nel brow
 
 Questo è il risultato della protezione di React da parte di un [attacco XSS](https://en.wikipedia.org/wiki/Cross-site_scripting). C'è una maniera di aggirare questo comportamento, ma il framework ti avvisa di non farlo:
 
-```javascript{4,10}
+```javascript{3-6,14}
 // tutorial7.js
 var Comment = React.createClass({
   rawMarkup: function() {

--- a/docs/docs/tutorial.ja-JP.md
+++ b/docs/docs/tutorial.ja-JP.md
@@ -233,7 +233,7 @@ Markdown はインラインでテキストをフォーマットする簡単な�
 
 次に、Markdown で書かれたコメントを変換して出力してみましょう。
 
-```javascript{2,10}
+```javascript{9}
 // tutorial6.js
 var Comment = React.createClass({
   render: function() {
@@ -255,17 +255,21 @@ var Comment = React.createClass({
 
 このような現象が起きるのは React が XSS 攻撃に対する防御を行っているからです。これを回避する方法はありますが、それを使うときにはフレームワークが警告をします。
 
-```javascript{5,11}
+```javascript{3-6,14}
 // tutorial7.js
 var Comment = React.createClass({
-  render: function() {
+  rawMarkup: function() {
     var rawMarkup = marked(this.props.children.toString(), {sanitize: true});
+    return { __html: rawMarkup };
+  },
+
+  render: function() {
     return (
       <div className="comment">
         <h2 className="commentAuthor">
           {this.props.author}
         </h2>
-        <span dangerouslySetInnerHTML={{"{{"}}__html: rawMarkup}} />
+        <span dangerouslySetInnerHTML={this.rawMarkup()} />
       </div>
     );
   }
@@ -381,8 +385,7 @@ var CommentBox = React.createClass({
 #### State の更新
 コンポーネントの作成と同時に、サーバから JSON データを GET で取得し、state を更新して最新のデータを反映させてみましょう。実際のアプリケーションでは動的なエンドポイントになるでしょうが、今回の例では話を簡単にするため、以下の静的な JSON ファイルを使います。
 
-```javascript
-// tutorial13.json
+```json
 [
   {"author": "Pete Hunt", "text": "This is one comment"},
   {"author": "Jordan Walke", "text": "This is *another* comment"}

--- a/docs/docs/tutorial.ko-KR.md
+++ b/docs/docs/tutorial.ko-KR.md
@@ -262,7 +262,7 @@ var Comment = React.createClass({
 
 React는 이런 식으로 [XSS 공격](https://en.wikipedia.org/wiki/Cross-site_scripting)을 예방합니다. 우회할 방법이 있긴 하지만 프레임워크는 사용하지 않도록 경고하고 있습니다:
 
-```javascript{4,14}
+```javascript{3-6,14}
 // tutorial7.js
 var Comment = React.createClass({
   rawMarkup: function() {

--- a/docs/docs/tutorial.zh-CN.md
+++ b/docs/docs/tutorial.zh-CN.md
@@ -258,7 +258,7 @@ var Comment = React.createClass({
 
 那是 React 在保护你免受 [XSS 攻击](https://en.wikipedia.org/wiki/Cross-site_scripting)。有一个方法解决这个问题，但是框架会警告你别使用这种方法：
 
-```javascript{4,10}
+```javascript{3-6,14}
 // tutorial7.js
 var Comment = React.createClass({
   rawMarkup: function() {


### PR DESCRIPTION
tutorial7.js sample code in tutorial-ja-JP.md has incorrect highlights.
In theory, Highlights show added code from before step, but now show incorrect lines.