### PR TITLE
Add ReactLink deprecation notice

### DIFF
--- a/docs/docs/10.2-form-input-binding-sugar.md
+++ b/docs/docs/10.2-form-input-binding-sugar.md
@@ -10,7 +10,7 @@ next: test-utils.html
 
 > Note:
 >
-> If you're new to the framework, note that `ReactLink` is not needed for most applications and should be used cautiously.
+> ReactLink is deprecated as of React v15. The recommendation is to explicitly set the value and change handler, instead of using ReactLink.
 
 In React, data flows one way: from owner to child. This is because data only flows one direction in [the Von Neumann model of computing](https://en.wikipedia.org/wiki/Von_Neumann_architecture). You can think of it as "one-way data binding."
 


### PR DESCRIPTION
Not sure if the "framework" keyword was intended, because according to the docs:

> A JAVASCRIPT LIBRARY FOR BUILDING USER INTERFACES