### PR TITLE
Fix script source HTTPS error in html-jsx.md doc

### DIFF
--- a/docs/html-jsx.md
+++ b/docs/html-jsx.md
@@ -6,6 +6,6 @@ id: html-jsx
 <div class="jsxCompiler">
   <h1>HTML to JSX Compiler</h1>
   <div id="jsxCompiler"></div>
-  <script src="https://reactjs.github.io/react-magic/htmltojsx.min.js"></script>
+  <script src="https://reactcommunity.org/react-magic/htmltojsx.min.js"></script>
   <script src="js/html-jsx.js"></script>
 </div>


### PR DESCRIPTION
It appears that the original source link (https://reactjs.github.io/react-magic/htmltojsx.min.js) now redirects to https://reactcommunity.org/react-magic/htmltojsx.min.js.  If you go to https://facebook.github.io/react/html-jsx.html in Chrome, you get the following error:
```
ReferenceError: HTMLtoJSX is not defined
```
This is a result of the following error in the console:
```
Mixed Content: The page at 'https://facebook.github.io/react/html-jsx.html' was loaded over HTTPS, but requested an insecure script 'http://reactcommunity.org/react-magic/htmltojsx.min.js'. This request has been blocked; the content must be served over HTTPS.
```
I believe that the original link is redirecting to the HTTP version of reactcommunity.org and Chrome doesn't handle the fact that the web server eventually redirects you to HTTPS anyways (since you can load http://reactcommunity.org/react-magic/htmltojsx.min.js in the address bar and it redirects to HTTPS).

This pull request just updates the source of the script to be the new redirect target.