### PR TITLE
Fix inverted definition of Controlled component

### DIFF
--- a/docs/docs/07-forms.md
+++ b/docs/docs/07-forms.md
@@ -72,7 +72,7 @@ In this example, we are accepting the value provided by the user and updating th
 
 This would accept user input and truncate the value to the first 140 characters.
 
-A **Controlled** component maintains its own internal state; the component renders purely based on props.
+A **Controlled** component does not maintain its own internal state; the component renders purely based on props.
 
 ### Potential Issues With Checkboxes and Radio Buttons
 


### PR DESCRIPTION
I'm pretty sure this was a typo.  [Later on this page](https://github.com/facebook/react/compare/master...dpercy:patch-2#diff-2be959bd27e4226660572ce24d7ba2a2R93) it says: "An uncontrolled component maintains its own internal state."  Also, since the component rendering purely based on props it doesn't need to maintain its internal state.