### PR TITLE
add "cite" attribute to whitelist for <blockquote> elements

### DIFF
--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -48,6 +48,7 @@ var HTMLDOMPropertyConfig = {
     charSet: null,
     challenge: null,
     checked: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
+    cite: null,
     classID: null,
     className: null,
     cols: HAS_POSITIVE_NUMERIC_VALUE,


### PR DESCRIPTION
Questions:

* Would you like tests?
* Would it be better if this whitelist were scoped to the node type of the parent element? `cite` is meaningless for any element but `<blockquote>`, but will be rendered into the DOM for any component per the general whitelist.