### PR TITLE
RFC: Convert var to let/const.

### DIFF
--- a/src/React.js
+++ b/src/React.js
@@ -11,14 +11,14 @@
 
 'use strict';
 
-var ReactDOM = require('ReactDOM');
-var ReactDOMServer = require('ReactDOMServer');
-var ReactIsomorphic = require('ReactIsomorphic');
+const ReactDOM = require('ReactDOM');
+const ReactDOMServer = require('ReactDOMServer');
+const ReactIsomorphic = require('ReactIsomorphic');
 
-var assign = require('Object.assign');
+const assign = require('Object.assign');
 
 // `version` will be added here by ReactIsomorphic.
-var React = {};
+const React = {};
 
 assign(React, ReactIsomorphic);
 

--- a/src/addons/ReactComponentWithPureRenderMixin.js
+++ b/src/addons/ReactComponentWithPureRenderMixin.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var shallowCompare = require('shallowCompare');
+const shallowCompare = require('shallowCompare');
 
 /**
  * If your React component's render function is "pure", e.g. it will render the
@@ -37,7 +37,7 @@ var shallowCompare = require('shallowCompare');
  * differences. Only mixin to components which have simple props and state, or
  * use `forceUpdate()` when you know deep data structures have changed.
  */
-var ReactComponentWithPureRenderMixin = {
+const ReactComponentWithPureRenderMixin = {
   shouldComponentUpdate: function(nextProps, nextState) {
     return shallowCompare(this, nextProps, nextState);
   },

--- a/src/addons/ReactFragment.js
+++ b/src/addons/ReactFragment.js
@@ -11,12 +11,12 @@
 
 'use strict';
 
-var ReactChildren = require('ReactChildren');
-var ReactElement = require('ReactElement');
+const ReactChildren = require('ReactChildren');
+const ReactElement = require('ReactElement');
 
-var emptyFunction = require('emptyFunction');
-var invariant = require('invariant');
-var warning = require('warning');
+const emptyFunction = require('emptyFunction');
+const invariant = require('invariant');
+const warning = require('warning');
 
 /**
  * We used to allow keyed objects to serve as a collection of ReactElements,
@@ -26,11 +26,11 @@ var warning = require('warning');
  * create a keyed fragment. The resulting data structure is an array.
  */
 
-var numericPropertyRegex = /^\d+$/;
+const numericPropertyRegex = /^\d+$/;
 
-var warnedAboutNumeric = false;
+let warnedAboutNumeric = false;
 
-var ReactFragment = {
+const ReactFragment = {
   // Wrap a keyed object in an opaque proxy that warns you if you access any
   // of its properties.
   create: function(object) {
@@ -57,9 +57,9 @@ var ReactFragment = {
       'elements are not valid children of React components.'
     );
 
-    var result = [];
+    const result = [];
 
-    for (var key in object) {
+    for (let key in object) {
       if (__DEV__) {
         if (!warnedAboutNumeric && numericPropertyRegex.test(key)) {
           warning(

--- a/src/addons/ReactFragment.js
+++ b/src/addons/ReactFragment.js
@@ -59,7 +59,7 @@ const ReactFragment = {
 
     const result = [];
 
-    for (let key in object) {
+    for (const key in object) {
       if (__DEV__) {
         if (!warnedAboutNumeric && numericPropertyRegex.test(key)) {
           warning(

--- a/src/addons/ReactWithAddons.js
+++ b/src/addons/ReactWithAddons.js
@@ -18,16 +18,16 @@
 
 'use strict';
 
-var LinkedStateMixin = require('LinkedStateMixin');
-var React = require('React');
-var ReactComponentWithPureRenderMixin =
+const LinkedStateMixin = require('LinkedStateMixin');
+const React = require('React');
+const ReactComponentWithPureRenderMixin =
   require('ReactComponentWithPureRenderMixin');
-var ReactCSSTransitionGroup = require('ReactCSSTransitionGroup');
-var ReactFragment = require('ReactFragment');
-var ReactTransitionGroup = require('ReactTransitionGroup');
+const ReactCSSTransitionGroup = require('ReactCSSTransitionGroup');
+const ReactFragment = require('ReactFragment');
+const ReactTransitionGroup = require('ReactTransitionGroup');
 
-var shallowCompare = require('shallowCompare');
-var update = require('update');
+const shallowCompare = require('shallowCompare');
+const update = require('update');
 
 React.addons = {
   CSSTransitionGroup: ReactCSSTransitionGroup,

--- a/src/addons/__tests__/ReactComponentWithPureRenderMixin-test.js
+++ b/src/addons/__tests__/ReactComponentWithPureRenderMixin-test.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-var React;
-var ReactComponentWithPureRenderMixin;
-var ReactTestUtils;
+let React;
+let ReactComponentWithPureRenderMixin;
+let ReactTestUtils;
 
 describe('ReactComponentWithPureRenderMixin', function() {
 
@@ -25,7 +25,7 @@ describe('ReactComponentWithPureRenderMixin', function() {
   });
 
   it('provides a default shouldComponentUpdate implementation', function() {
-    var renderCalls = 0;
+    let renderCalls = 0;
     class PlasticWrap extends React.Component {
       constructor(props, context) {
         super(props, context);
@@ -44,7 +44,7 @@ describe('ReactComponentWithPureRenderMixin', function() {
       }
     }
 
-    var Apple = React.createClass({
+    const Apple = React.createClass({
       mixins: [ReactComponentWithPureRenderMixin],
 
       getInitialState: function() {
@@ -73,7 +73,7 @@ describe('ReactComponentWithPureRenderMixin', function() {
       },
     });
 
-    var instance = ReactTestUtils.renderIntoDocument(<PlasticWrap />);
+    const instance = ReactTestUtils.renderIntoDocument(<PlasticWrap />);
     expect(renderCalls).toBe(1);
 
     // Do not re-render based on props
@@ -105,10 +105,10 @@ describe('ReactComponentWithPureRenderMixin', function() {
       };
     }
 
-    var renderCalls = 0;
-    var initialSettings = getInitialState();
+    let renderCalls = 0;
+    const initialSettings = getInitialState();
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       mixins: [ReactComponentWithPureRenderMixin],
 
       getInitialState: function() {
@@ -121,11 +121,11 @@ describe('ReactComponentWithPureRenderMixin', function() {
       },
     });
 
-    var instance = ReactTestUtils.renderIntoDocument(<Component />);
+    const instance = ReactTestUtils.renderIntoDocument(<Component />);
     expect(renderCalls).toBe(1);
 
     // Do not re-render if state is equal
-    var settings = {
+    const settings = {
       foo: initialSettings.foo,
       bar: initialSettings.bar,
     };

--- a/src/addons/__tests__/ReactFragment-test.js
+++ b/src/addons/__tests__/ReactFragment-test.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
-var ReactFragment;
+let React;
+let ReactDOM;
+let ReactFragment;
 
 describe('ReactFragment', function() {
 
@@ -24,13 +24,13 @@ describe('ReactFragment', function() {
   });
 
   it('should throw if a plain object is used as a child', function() {
-    var children = {
+    const children = {
       x: <span />,
       y: <span />,
       z: <span />,
     };
-    var element = <div>{[children]}</div>;
-    var container = document.createElement('div');
+    const element = <div>{[children]}</div>;
+    const container = document.createElement('div');
     expect(() => ReactDOM.render(element, container)).toThrow(
       'Objects are not valid as a React child (found: object with keys ' +
       '{x, y, z}). If you meant to render a collection of children, use an ' +
@@ -42,7 +42,7 @@ describe('ReactFragment', function() {
   it('should throw if a plain object even if it is in an owner', function() {
     class Foo extends React.Component {
       render() {
-        var children = {
+        const children = {
           a: <span />,
           b: <span />,
           c: <span />,
@@ -50,7 +50,7 @@ describe('ReactFragment', function() {
         return <div>{[children]}</div>;
       }
     }
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     expect(() => ReactDOM.render(<Foo />, container)).toThrow(
       'Objects are not valid as a React child (found: object with keys ' +
       '{a, b, c}). If you meant to render a collection of children, use an ' +
@@ -60,8 +60,8 @@ describe('ReactFragment', function() {
   });
 
   it('should throw if a plain object looks like an old element', function() {
-    var oldEl = {_isReactElement: true, type: 'span', props: {}};
-    var container = document.createElement('div');
+    const oldEl = {_isReactElement: true, type: 'span', props: {}};
+    const container = document.createElement('div');
     expect(() => ReactDOM.render(<div>{oldEl}</div>, container)).toThrow(
       'Objects are not valid as a React child (found: object with keys ' +
       '{_isReactElement, type, props}). It looks like you\'re using an ' +

--- a/src/addons/__tests__/renderSubtreeIntoContainer-test.js
+++ b/src/addons/__tests__/renderSubtreeIntoContainer-test.js
@@ -11,17 +11,17 @@
 
 'use strict';
 
-var React = require('React');
-var ReactTestUtils = require('ReactTestUtils');
-var renderSubtreeIntoContainer = require('renderSubtreeIntoContainer');
+const React = require('React');
+const ReactTestUtils = require('ReactTestUtils');
+const renderSubtreeIntoContainer = require('renderSubtreeIntoContainer');
 
 describe('renderSubtreeIntoContainer', function() {
 
   it('should pass context when rendering subtree elsewhere', function() {
 
-    var portal = document.createElement('div');
+    const portal = document.createElement('div');
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       contextTypes: {
         foo: React.PropTypes.string.isRequired,
       },
@@ -31,7 +31,7 @@ describe('renderSubtreeIntoContainer', function() {
       },
     });
 
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       childContextTypes: {
         foo: React.PropTypes.string.isRequired,
       },
@@ -58,9 +58,9 @@ describe('renderSubtreeIntoContainer', function() {
   });
 
   it('should throw if parentComponent is invalid', function() {
-    var portal = document.createElement('div');
+    const portal = document.createElement('div');
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       contextTypes: {
         foo: React.PropTypes.string.isRequired,
       },
@@ -70,7 +70,7 @@ describe('renderSubtreeIntoContainer', function() {
       },
     });
 
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       childContextTypes: {
         foo: React.PropTypes.string.isRequired,
       },

--- a/src/addons/__tests__/update-test.js
+++ b/src/addons/__tests__/update-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var update = require('update');
+const update = require('update');
 
 describe('update', function() {
 
@@ -20,7 +20,7 @@ describe('update', function() {
       expect(update([1], {$push: [7]})).toEqual([1, 7]);
     });
     it('does not mutate the original object', function() {
-      var obj = [1];
+      const obj = [1];
       update(obj, {$push: [7]});
       expect(obj).toEqual([1]);
     });
@@ -42,7 +42,7 @@ describe('update', function() {
       expect(update([1], {$unshift: [7]})).toEqual([7, 1]);
     });
     it('does not mutate the original object', function() {
-      var obj = [1];
+      const obj = [1];
       update(obj, {$unshift: [7]});
       expect(obj).toEqual([1]);
     });
@@ -64,7 +64,7 @@ describe('update', function() {
       expect(update([1, 4, 3], {$splice: [[1, 1, 2]]})).toEqual([1, 2, 3]);
     });
     it('does not mutate the original object', function() {
-      var obj = [1, 4, 3];
+      const obj = [1, 4, 3];
       update(obj, {$splice: [[1, 1, 2]]});
       expect(obj).toEqual([1, 4, 3]);
     });
@@ -90,7 +90,7 @@ describe('update', function() {
       expect(update({a: 'b'}, {$merge: {c: 'd'}})).toEqual({a: 'b', c: 'd'});
     });
     it('does not mutate the original object', function() {
-      var obj = {a: 'b'};
+      const obj = {a: 'b'};
       update(obj, {$merge: {c: 'd'}});
       expect(obj).toEqual({a: 'b'});
     });
@@ -111,21 +111,21 @@ describe('update', function() {
       expect(update({a: 'b'}, {$set: {c: 'd'}})).toEqual({c: 'd'});
     });
     it('does not mutate the original object', function() {
-      var obj = {a: 'b'};
+      const obj = {a: 'b'};
       update(obj, {$set: {c: 'd'}});
       expect(obj).toEqual({a: 'b'});
     });
   });
 
   describe('$apply', function() {
-    var applier = function(node) {
+    const applier = function(node) {
       return {v: node.v * 2};
     };
     it('applies', function() {
       expect(update({v: 2}, {$apply: applier})).toEqual({v: 4});
     });
     it('does not mutate the original object', function() {
-      var obj = {v: 2};
+      const obj = {v: 2};
       update(obj, {$apply: applier});
       expect(obj).toEqual({v: 2});
     });

--- a/src/addons/link/LinkedInput.js
+++ b/src/addons/link/LinkedInput.js
@@ -11,12 +11,12 @@
 
 'use strict';
 
-var React = require('React');
-var LinkedValueUtils = require('LinkedValueUtils');
+const React = require('React');
+const LinkedValueUtils = require('LinkedValueUtils');
 
 class LinkedInput extends React.Component {
   render() {
-    var newProps = Object.assign({}, this.props);
+    const newProps = Object.assign({}, this.props);
     newProps.value = LinkedValueUtils.getValue(this.props);
     newProps.checked = LinkedValueUtils.getChecked(this.props);
     delete newProps.valueLink;

--- a/src/addons/link/LinkedStateMixin.js
+++ b/src/addons/link/LinkedStateMixin.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-var ReactLink = require('ReactLink');
-var ReactStateSetters = require('ReactStateSetters');
+const ReactLink = require('ReactLink');
+const ReactStateSetters = require('ReactStateSetters');
 
 /**
  * A simple mixin around ReactLink.forState().
  */
-var LinkedStateMixin = {
+const LinkedStateMixin = {
   /**
    * Create a ReactLink that's linked to part of this component's state. The
    * ReactLink will have the current value of this.state[key] and will call

--- a/src/addons/link/ReactLink.js
+++ b/src/addons/link/ReactLink.js
@@ -34,7 +34,7 @@
  * consumption of ReactLink easier; see LinkedValueUtils and LinkedStateMixin.
  */
 
-var React = require('React');
+const React = require('React');
 
 /**
  * @param {*} value current value of the link
@@ -54,7 +54,7 @@ function ReactLink(value, requestChange) {
  * }
  */
 function createLinkTypeChecker(linkType) {
-  var shapes = {
+  const shapes = {
     value: linkType === undefined ?
       React.PropTypes.any.isRequired :
       linkType.isRequired,

--- a/src/addons/link/__tests__/LinkedInput-test.js
+++ b/src/addons/link/__tests__/LinkedInput-test.js
@@ -13,9 +13,9 @@
 
 
 describe('LinkedStateMixin', function() {
-  var LinkedInput;
-  var React;
-  var ReactDOM;
+  let LinkedInput;
+  let React;
+  let ReactDOM;
 
   beforeEach(function() {
     LinkedInput = require('LinkedInput');
@@ -24,17 +24,17 @@ describe('LinkedStateMixin', function() {
   });
 
   it('should basically work', function() {
-    var container = document.createElement('div');
-    var component = ReactDOM.render(<LinkedInput value="foo" onChange={function() {}} />, container);
-    var input = ReactDOM.findDOMNode(component);
+    const container = document.createElement('div');
+    const component = ReactDOM.render(<LinkedInput value="foo" onChange={function() {}} />, container);
+    const input = ReactDOM.findDOMNode(component);
     expect(input.value).toBe('foo');
     ReactDOM.render(<LinkedInput valueLink={{value: 'boo', requestChange: function() {}}} />, container);
     expect(input.value).toBe('boo');
   });
 
   it('should throw', function() {
-    var container = document.createElement('div');
-    var element = <LinkedInput value="foo" valueLink={{value: 'boo', requestChange: function() {}}} />;
+    const container = document.createElement('div');
+    const element = <LinkedInput value="foo" valueLink={{value: 'boo', requestChange: function() {}}} />;
     expect(function() {
       ReactDOM.render(element, container);
     }).toThrow();

--- a/src/addons/link/__tests__/LinkedStateMixin-test.js
+++ b/src/addons/link/__tests__/LinkedStateMixin-test.js
@@ -13,9 +13,9 @@
 
 
 describe('LinkedStateMixin', function() {
-  var LinkedStateMixin;
-  var React;
-  var ReactTestUtils;
+  let LinkedStateMixin;
+  let React;
+  let ReactTestUtils;
 
   beforeEach(function() {
     LinkedStateMixin = require('LinkedStateMixin');
@@ -24,7 +24,7 @@ describe('LinkedStateMixin', function() {
   });
 
   it('should create a ReactLink for state', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       mixins: [LinkedStateMixin],
 
       getInitialState: function() {
@@ -35,8 +35,8 @@ describe('LinkedStateMixin', function() {
         return <span>value is {this.state.value}</span>;
       },
     });
-    var component = ReactTestUtils.renderIntoDocument(<Component />);
-    var link = component.linkState('value');
+    const component = ReactTestUtils.renderIntoDocument(<Component />);
+    const link = component.linkState('value');
     expect(component.state.value).toBe('initial value');
     expect(link.value).toBe('initial value');
     link.requestChange('new value');

--- a/src/addons/link/__tests__/ReactLinkPropTypes-test.js
+++ b/src/addons/link/__tests__/ReactLinkPropTypes-test.js
@@ -11,18 +11,18 @@
 
 'use strict';
 
-var emptyFunction = require('emptyFunction');
-var LinkPropTypes = require('ReactLink').PropTypes;
-var React = require('React');
-var ReactPropTypeLocations = require('ReactPropTypeLocations');
+const emptyFunction = require('emptyFunction');
+const LinkPropTypes = require('ReactLink').PropTypes;
+const React = require('React');
+const ReactPropTypeLocations = require('ReactPropTypeLocations');
 
-var invalidMessage = 'Invalid prop `testProp` supplied to `testComponent`.';
-var requiredMessage =
+const invalidMessage = 'Invalid prop `testProp` supplied to `testComponent`.';
+const requiredMessage =
   'Required prop `testProp` was not specified in `testComponent`.';
 
 function typeCheckFail(declaration, value, message) {
-  var props = {testProp: value};
-  var error = declaration(
+  const props = {testProp: value};
+  const error = declaration(
     props,
     'testProp',
     'testComponent',
@@ -33,8 +33,8 @@ function typeCheckFail(declaration, value, message) {
 }
 
 function typeCheckPass(declaration, value) {
-  var props = {testProp: value};
-  var error = declaration(
+  const props = {testProp: value};
+  const error = declaration(
     props,
     'testProp',
     'testComponent',

--- a/src/addons/renderSubtreeIntoContainer.js
+++ b/src/addons/renderSubtreeIntoContainer.js
@@ -11,6 +11,6 @@
 
 'use strict';
 
-var ReactMount = require('ReactMount');
+const ReactMount = require('ReactMount');
 
 module.exports = ReactMount.renderSubtreeIntoContainer;

--- a/src/addons/shallowCompare.js
+++ b/src/addons/shallowCompare.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var shallowEqual = require('shallowEqual');
+const shallowEqual = require('shallowEqual');
 
 /**
  * Does a shallow comparison for props and state.

--- a/src/addons/transitions/ReactCSSTransitionGroup.js
+++ b/src/addons/transitions/ReactCSSTransitionGroup.js
@@ -11,16 +11,16 @@
 
 'use strict';
 
-var React = require('React');
+const React = require('React');
 
-var assign = require('Object.assign');
+const assign = require('Object.assign');
 
-var ReactTransitionGroup = require('ReactTransitionGroup');
-var ReactCSSTransitionGroupChild = require('ReactCSSTransitionGroupChild');
+const ReactTransitionGroup = require('ReactTransitionGroup');
+const ReactCSSTransitionGroupChild = require('ReactCSSTransitionGroupChild');
 
 function createTransitionTimeoutPropValidator(transitionType) {
-  var timeoutPropName = 'transition' + transitionType + 'Timeout';
-  var enabledPropName = 'transition' + transitionType;
+  const timeoutPropName = 'transition' + transitionType + 'Timeout';
+  const enabledPropName = 'transition' + transitionType;
 
   return function(props) {
     // If the transition is enabled
@@ -43,7 +43,7 @@ function createTransitionTimeoutPropValidator(transitionType) {
   };
 }
 
-var ReactCSSTransitionGroup = React.createClass({
+const ReactCSSTransitionGroup = React.createClass({
   displayName: 'ReactCSSTransitionGroup',
 
   propTypes: {

--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -11,17 +11,17 @@
 
 'use strict';
 
-var React = require('React');
-var ReactDOM = require('ReactDOM');
+const React = require('React');
+const ReactDOM = require('ReactDOM');
 
-var CSSCore = require('CSSCore');
-var ReactTransitionEvents = require('ReactTransitionEvents');
+const CSSCore = require('CSSCore');
+const ReactTransitionEvents = require('ReactTransitionEvents');
 
-var onlyChild = require('onlyChild');
+const onlyChild = require('onlyChild');
 
-var TICK = 17;
+const TICK = 17;
 
-var ReactCSSTransitionGroupChild = React.createClass({
+const ReactCSSTransitionGroupChild = React.createClass({
   displayName: 'ReactCSSTransitionGroupChild',
 
   propTypes: {
@@ -54,7 +54,7 @@ var ReactCSSTransitionGroupChild = React.createClass({
   },
 
   transition: function(animationType, finishCallback, userSpecifiedDelay) {
-    var node = ReactDOM.findDOMNode(this);
+    const node = ReactDOM.findDOMNode(this);
 
     if (!node) {
       if (finishCallback) {
@@ -63,11 +63,11 @@ var ReactCSSTransitionGroupChild = React.createClass({
       return;
     }
 
-    var className = this.props.name[animationType] || this.props.name + '-' + animationType;
-    var activeClassName = this.props.name[animationType + 'Active'] || className + '-active';
-    var timeout = null;
+    const className = this.props.name[animationType] || this.props.name + '-' + animationType;
+    const activeClassName = this.props.name[animationType + 'Active'] || className + '-active';
+    let timeout = null;
 
-    var endListener = function(e) {
+    const endListener = function(e) {
       if (e && e.target !== node) {
         return;
       }

--- a/src/addons/transitions/ReactTransitionChildMapping.js
+++ b/src/addons/transitions/ReactTransitionChildMapping.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-var flattenChildren = require('flattenChildren');
+const flattenChildren = require('flattenChildren');
 
-var ReactTransitionChildMapping = {
+const ReactTransitionChildMapping = {
   /**
    * Given `this.props.children`, return an object mapping key to child. Just
    * simple syntactic sugar around flattenChildren().
@@ -59,10 +59,10 @@ var ReactTransitionChildMapping = {
 
     // For each key of `next`, the list of keys to insert before that key in
     // the combined list
-    var nextKeysPending = {};
+    const nextKeysPending = {};
 
-    var pendingKeys = [];
-    for (var prevKey in prev) {
+    let pendingKeys = [];
+    for (let prevKey in prev) {
       if (next.hasOwnProperty(prevKey)) {
         if (pendingKeys.length) {
           nextKeysPending[prevKey] = pendingKeys;
@@ -73,12 +73,12 @@ var ReactTransitionChildMapping = {
       }
     }
 
-    var i;
-    var childMapping = {};
-    for (var nextKey in next) {
+    let i;
+    const childMapping = {};
+    for (let nextKey in next) {
       if (nextKeysPending.hasOwnProperty(nextKey)) {
         for (i = 0; i < nextKeysPending[nextKey].length; i++) {
-          var pendingNextKey = nextKeysPending[nextKey][i];
+          const pendingNextKey = nextKeysPending[nextKey][i];
           childMapping[nextKeysPending[nextKey][i]] = getValueForKey(
             pendingNextKey
           );

--- a/src/addons/transitions/ReactTransitionChildMapping.js
+++ b/src/addons/transitions/ReactTransitionChildMapping.js
@@ -62,7 +62,7 @@ const ReactTransitionChildMapping = {
     const nextKeysPending = {};
 
     let pendingKeys = [];
-    for (let prevKey in prev) {
+    for (const prevKey in prev) {
       if (next.hasOwnProperty(prevKey)) {
         if (pendingKeys.length) {
           nextKeysPending[prevKey] = pendingKeys;
@@ -75,7 +75,7 @@ const ReactTransitionChildMapping = {
 
     let i;
     const childMapping = {};
-    for (let nextKey in next) {
+    for (const nextKey in next) {
       if (nextKeysPending.hasOwnProperty(nextKey)) {
         for (i = 0; i < nextKeysPending[nextKey].length; i++) {
           const pendingNextKey = nextKeysPending[nextKey][i];

--- a/src/addons/transitions/ReactTransitionEvents.js
+++ b/src/addons/transitions/ReactTransitionEvents.js
@@ -55,9 +55,9 @@ function detectEvents() {
     delete EVENT_NAME_MAP.transitionend.transition;
   }
 
-  for (let baseEventName in EVENT_NAME_MAP) {
+  for (const baseEventName in EVENT_NAME_MAP) {
     const baseEvents = EVENT_NAME_MAP[baseEventName];
-    for (let styleName in baseEvents) {
+    for (const styleName in baseEvents) {
       if (styleName in style) {
         endEvents.push(baseEvents[styleName]);
         break;

--- a/src/addons/transitions/ReactTransitionEvents.js
+++ b/src/addons/transitions/ReactTransitionEvents.js
@@ -11,14 +11,14 @@
 
 'use strict';
 
-var ExecutionEnvironment = require('ExecutionEnvironment');
+const ExecutionEnvironment = require('ExecutionEnvironment');
 
 /**
  * EVENT_NAME_MAP is used to determine which event fired when a
  * transition/animation ends, based on the style property used to
  * define that event.
  */
-var EVENT_NAME_MAP = {
+const EVENT_NAME_MAP = {
   transitionend: {
     'transition': 'transitionend',
     'WebkitTransition': 'webkitTransitionEnd',
@@ -36,11 +36,11 @@ var EVENT_NAME_MAP = {
   },
 };
 
-var endEvents = [];
+const endEvents = [];
 
 function detectEvents() {
-  var testEl = document.createElement('div');
-  var style = testEl.style;
+  const testEl = document.createElement('div');
+  const style = testEl.style;
 
   // On some platforms, in particular some releases of Android 4.x,
   // the un-prefixed "animation" and "transition" properties are defined on the
@@ -55,9 +55,9 @@ function detectEvents() {
     delete EVENT_NAME_MAP.transitionend.transition;
   }
 
-  for (var baseEventName in EVENT_NAME_MAP) {
-    var baseEvents = EVENT_NAME_MAP[baseEventName];
-    for (var styleName in baseEvents) {
+  for (let baseEventName in EVENT_NAME_MAP) {
+    const baseEvents = EVENT_NAME_MAP[baseEventName];
+    for (let styleName in baseEvents) {
       if (styleName in style) {
         endEvents.push(baseEvents[styleName]);
         break;
@@ -83,7 +83,7 @@ function removeEventListener(node, eventName, eventListener) {
   node.removeEventListener(eventName, eventListener, false);
 }
 
-var ReactTransitionEvents = {
+const ReactTransitionEvents = {
   addEndEventListener: function(node, eventListener) {
     if (endEvents.length === 0) {
       // If CSS transitions are not supported, trigger an "end animation"

--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-var React = require('React');
-var ReactTransitionChildMapping = require('ReactTransitionChildMapping');
+const React = require('React');
+const ReactTransitionChildMapping = require('ReactTransitionChildMapping');
 
-var assign = require('Object.assign');
-var emptyFunction = require('emptyFunction');
+const assign = require('Object.assign');
+const emptyFunction = require('emptyFunction');
 
-var ReactTransitionGroup = React.createClass({
+const ReactTransitionGroup = React.createClass({
   displayName: 'ReactTransitionGroup',
 
   propTypes: {
@@ -45,8 +45,8 @@ var ReactTransitionGroup = React.createClass({
   },
 
   componentDidMount: function() {
-    var initialChildMapping = this.state.children;
-    for (var key in initialChildMapping) {
+    const initialChildMapping = this.state.children;
+    for (let key in initialChildMapping) {
       if (initialChildMapping[key]) {
         this.performAppear(key);
       }
@@ -54,10 +54,10 @@ var ReactTransitionGroup = React.createClass({
   },
 
   componentWillReceiveProps: function(nextProps) {
-    var nextChildMapping = ReactTransitionChildMapping.getChildMapping(
+    const nextChildMapping = ReactTransitionChildMapping.getChildMapping(
       nextProps.children
     );
-    var prevChildMapping = this.state.children;
+    const prevChildMapping = this.state.children;
 
     this.setState({
       children: ReactTransitionChildMapping.mergeChildMappings(
@@ -66,10 +66,10 @@ var ReactTransitionGroup = React.createClass({
       ),
     });
 
-    var key;
+    let key;
 
     for (key in nextChildMapping) {
-      var hasPrev = prevChildMapping && prevChildMapping.hasOwnProperty(key);
+      const hasPrev = prevChildMapping && prevChildMapping.hasOwnProperty(key);
       if (nextChildMapping[key] && !hasPrev &&
           !this.currentlyTransitioningKeys[key]) {
         this.keysToEnter.push(key);
@@ -77,7 +77,7 @@ var ReactTransitionGroup = React.createClass({
     }
 
     for (key in prevChildMapping) {
-      var hasNext = nextChildMapping && nextChildMapping.hasOwnProperty(key);
+      const hasNext = nextChildMapping && nextChildMapping.hasOwnProperty(key);
       if (prevChildMapping[key] && !hasNext &&
           !this.currentlyTransitioningKeys[key]) {
         this.keysToLeave.push(key);
@@ -88,11 +88,11 @@ var ReactTransitionGroup = React.createClass({
   },
 
   componentDidUpdate: function() {
-    var keysToEnter = this.keysToEnter;
+    const keysToEnter = this.keysToEnter;
     this.keysToEnter = [];
     keysToEnter.forEach(this.performEnter);
 
-    var keysToLeave = this.keysToLeave;
+    const keysToLeave = this.keysToLeave;
     this.keysToLeave = [];
     keysToLeave.forEach(this.performLeave);
   },
@@ -100,7 +100,7 @@ var ReactTransitionGroup = React.createClass({
   performAppear: function(key) {
     this.currentlyTransitioningKeys[key] = true;
 
-    var component = this.refs[key];
+    const component = this.refs[key];
 
     if (component.componentWillAppear) {
       component.componentWillAppear(
@@ -112,14 +112,14 @@ var ReactTransitionGroup = React.createClass({
   },
 
   _handleDoneAppearing: function(key) {
-    var component = this.refs[key];
+    const component = this.refs[key];
     if (component.componentDidAppear) {
       component.componentDidAppear();
     }
 
     delete this.currentlyTransitioningKeys[key];
 
-    var currentChildMapping = ReactTransitionChildMapping.getChildMapping(
+    const currentChildMapping = ReactTransitionChildMapping.getChildMapping(
       this.props.children
     );
 
@@ -132,7 +132,7 @@ var ReactTransitionGroup = React.createClass({
   performEnter: function(key) {
     this.currentlyTransitioningKeys[key] = true;
 
-    var component = this.refs[key];
+    const component = this.refs[key];
 
     if (component.componentWillEnter) {
       component.componentWillEnter(
@@ -144,14 +144,14 @@ var ReactTransitionGroup = React.createClass({
   },
 
   _handleDoneEntering: function(key) {
-    var component = this.refs[key];
+    const component = this.refs[key];
     if (component.componentDidEnter) {
       component.componentDidEnter();
     }
 
     delete this.currentlyTransitioningKeys[key];
 
-    var currentChildMapping = ReactTransitionChildMapping.getChildMapping(
+    const currentChildMapping = ReactTransitionChildMapping.getChildMapping(
       this.props.children
     );
 
@@ -164,7 +164,7 @@ var ReactTransitionGroup = React.createClass({
   performLeave: function(key) {
     this.currentlyTransitioningKeys[key] = true;
 
-    var component = this.refs[key];
+    const component = this.refs[key];
     if (component.componentWillLeave) {
       component.componentWillLeave(this._handleDoneLeaving.bind(this, key));
     } else {
@@ -176,7 +176,7 @@ var ReactTransitionGroup = React.createClass({
   },
 
   _handleDoneLeaving: function(key) {
-    var component = this.refs[key];
+    const component = this.refs[key];
 
     if (component.componentDidLeave) {
       component.componentDidLeave();
@@ -184,7 +184,7 @@ var ReactTransitionGroup = React.createClass({
 
     delete this.currentlyTransitioningKeys[key];
 
-    var currentChildMapping = ReactTransitionChildMapping.getChildMapping(
+    const currentChildMapping = ReactTransitionChildMapping.getChildMapping(
       this.props.children
     );
 
@@ -193,7 +193,7 @@ var ReactTransitionGroup = React.createClass({
       this.performEnter(key);
     } else {
       this.setState(function(state) {
-        var newChildren = assign({}, state.children);
+        const newChildren = assign({}, state.children);
         delete newChildren[key];
         return {children: newChildren};
       });
@@ -203,9 +203,9 @@ var ReactTransitionGroup = React.createClass({
   render: function() {
     // TODO: we could get rid of the need for the wrapper node
     // by cloning a single child
-    var childrenToRender = [];
-    for (var key in this.state.children) {
-      var child = this.state.children[key];
+    const childrenToRender = [];
+    for (let key in this.state.children) {
+      const child = this.state.children[key];
       if (child) {
         // You may need to apply reactive updates to a child as it is leaving.
         // The normal React way to do it won't work since the child will have

--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -46,7 +46,7 @@ const ReactTransitionGroup = React.createClass({
 
   componentDidMount: function() {
     const initialChildMapping = this.state.children;
-    for (let key in initialChildMapping) {
+    for (const key in initialChildMapping) {
       if (initialChildMapping[key]) {
         this.performAppear(key);
       }
@@ -204,7 +204,7 @@ const ReactTransitionGroup = React.createClass({
     // TODO: we could get rid of the need for the wrapper node
     // by cloning a single child
     const childrenToRender = [];
-    for (let key in this.state.children) {
+    for (const key in this.state.children) {
       const child = this.state.children[key];
       if (child) {
         // You may need to apply reactive updates to a child as it is leaving.

--- a/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
@@ -11,16 +11,16 @@
 
 'use strict';
 
-var CSSCore = require('CSSCore');
+const CSSCore = require('CSSCore');
 
-var React;
-var ReactDOM;
-var ReactCSSTransitionGroup;
+let React;
+let ReactDOM;
+let ReactCSSTransitionGroup;
 
 // Most of the real functionality is covered in other unit tests, this just
 // makes sure we're wired up correctly.
 describe('ReactCSSTransitionGroup', function() {
-  var container;
+  let container;
 
   beforeEach(function() {
     jest.resetModuleRegistry();
@@ -65,7 +65,7 @@ describe('ReactCSSTransitionGroup', function() {
   });
 
   it('should clean-up silently after the timeout elapses', function() {
-    var a = ReactDOM.render(
+    const a = ReactDOM.render(
       <ReactCSSTransitionGroup
         transitionName="yolo"
         transitionEnter={false}
@@ -95,7 +95,7 @@ describe('ReactCSSTransitionGroup', function() {
 
     // For some reason jst is adding extra setTimeout()s and grunt test isn't,
     // so we need to do this disgusting hack.
-    for (var i = 0; i < setTimeout.mock.calls.length; i++) {
+    for (let i = 0; i < setTimeout.mock.calls.length; i++) {
       if (setTimeout.mock.calls[i][1] === 200) {
         setTimeout.mock.calls[i][0]();
         break;
@@ -111,7 +111,7 @@ describe('ReactCSSTransitionGroup', function() {
   });
 
   it('should keep both sets of DOM nodes around', function() {
-    var a = ReactDOM.render(
+    const a = ReactDOM.render(
       <ReactCSSTransitionGroup transitionName="yolo">
         <span key="one" id="one" />
       </ReactCSSTransitionGroup>,
@@ -130,7 +130,7 @@ describe('ReactCSSTransitionGroup', function() {
   });
 
   it('should switch transitionLeave from false to true', function() {
-    var a = ReactDOM.render(
+    const a = ReactDOM.render(
       <ReactCSSTransitionGroup
           transitionName="yolo"
           transitionEnter={false}
@@ -181,7 +181,7 @@ describe('ReactCSSTransitionGroup', function() {
   });
 
   it('should transition from one to null', function() {
-    var a = ReactDOM.render(
+    const a = ReactDOM.render(
       <ReactCSSTransitionGroup transitionName="yolo">
         <span key="one" id="one" />
       </ReactCSSTransitionGroup>,
@@ -201,7 +201,7 @@ describe('ReactCSSTransitionGroup', function() {
   });
 
   it('should transition from false to one', function() {
-    var a = ReactDOM.render(
+    const a = ReactDOM.render(
       <ReactCSSTransitionGroup transitionName="yolo">
         {false}
       </ReactCSSTransitionGroup>,
@@ -219,12 +219,12 @@ describe('ReactCSSTransitionGroup', function() {
   });
 
   it('should use transition-type specific names when they\'re provided', function() {
-    var customTransitionNames = {
+    const customTransitionNames = {
       enter: 'custom-entering',
       leave: 'custom-leaving',
     };
 
-    var a = ReactDOM.render(
+    const a = ReactDOM.render(
       <ReactCSSTransitionGroup
         transitionName={customTransitionNames}
         transitionEnterTimeout={1}
@@ -250,7 +250,7 @@ describe('ReactCSSTransitionGroup', function() {
     );
     expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(2);
 
-    var enteringNode = ReactDOM.findDOMNode(a).childNodes[1];
+    const enteringNode = ReactDOM.findDOMNode(a).childNodes[1];
     expect(CSSCore.hasClass(enteringNode, 'custom-entering')).toBe(true);
 
     // Remove an element
@@ -266,12 +266,12 @@ describe('ReactCSSTransitionGroup', function() {
     );
     expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(2);
 
-    var leavingNode = ReactDOM.findDOMNode(a).childNodes[0];
+    const leavingNode = ReactDOM.findDOMNode(a).childNodes[0];
     expect(CSSCore.hasClass(leavingNode, 'custom-leaving')).toBe(true);
   });
 
   it('should clear transition timeouts when unmounted', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         return (
           <ReactCSSTransitionGroup

--- a/src/addons/transitions/__tests__/ReactTransitionChildMapping-test.js
+++ b/src/addons/transitions/__tests__/ReactTransitionChildMapping-test.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-var React;
-var ReactTransitionChildMapping;
+let React;
+let ReactTransitionChildMapping;
 
 describe('ReactTransitionChildMapping', function() {
   beforeEach(function() {
@@ -21,11 +21,11 @@ describe('ReactTransitionChildMapping', function() {
   });
 
   it('should support getChildMapping', function() {
-    var oneone = <div key="oneone" />;
-    var onetwo = <div key="onetwo" />;
-    var one = <div key="one">{oneone}{onetwo}</div>;
-    var two = <div key="two" />;
-    var component = <div>{one}{two}</div>;
+    const oneone = <div key="oneone" />;
+    const onetwo = <div key="onetwo" />;
+    const one = <div key="one">{oneone}{onetwo}</div>;
+    const two = <div key="two" />;
+    const component = <div>{one}{two}</div>;
     expect(
       ReactTransitionChildMapping.getChildMapping(component.props.children)
     ).toEqual({
@@ -35,11 +35,11 @@ describe('ReactTransitionChildMapping', function() {
   });
 
   it('should support mergeChildMappings for adding keys', function() {
-    var prev = {
+    const prev = {
       one: true,
       two: true,
     };
-    var next = {
+    const next = {
       one: true,
       two: true,
       three: true,
@@ -52,12 +52,12 @@ describe('ReactTransitionChildMapping', function() {
   });
 
   it('should support mergeChildMappings for removing keys', function() {
-    var prev = {
+    const prev = {
       one: true,
       two: true,
       three: true,
     };
-    var next = {
+    const next = {
       one: true,
       two: true,
     };
@@ -69,12 +69,12 @@ describe('ReactTransitionChildMapping', function() {
   });
 
   it('should support mergeChildMappings for adding and removing', function() {
-    var prev = {
+    const prev = {
       one: true,
       two: true,
       three: true,
     };
-    var next = {
+    const next = {
       one: true,
       two: true,
       four: true,
@@ -88,13 +88,13 @@ describe('ReactTransitionChildMapping', function() {
   });
 
   it('should reconcile overlapping insertions and deletions', function() {
-    var prev = {
+    const prev = {
       one: true,
       two: true,
       four: true,
       five: true,
     };
-    var next = {
+    const next = {
       one: true,
       two: true,
       three: true,
@@ -110,12 +110,12 @@ describe('ReactTransitionChildMapping', function() {
   });
 
   it('should support mergeChildMappings with undefined input', function() {
-    var prev = {
+    let prev = {
       one: true,
       two: true,
     };
 
-    var next = undefined;
+    let next = undefined;
 
     expect(ReactTransitionChildMapping.mergeChildMappings(prev, next)).toEqual({
       one: true,

--- a/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
@@ -11,14 +11,14 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
-var ReactTransitionGroup;
+let React;
+let ReactDOM;
+let ReactTransitionGroup;
 
 // Most of the real functionality is covered in other unit tests, this just
 // makes sure we're wired up correctly.
 describe('ReactTransitionGroup', function() {
-  var container;
+  let container;
 
   beforeEach(function() {
     React = require('React');
@@ -30,9 +30,9 @@ describe('ReactTransitionGroup', function() {
 
 
   it('should handle willEnter correctly', function() {
-    var log = [];
+    let log = [];
 
-    var Child = React.createClass({
+    const Child = React.createClass({
       componentDidMount: function() {
         log.push('didMount');
       },
@@ -65,20 +65,20 @@ describe('ReactTransitionGroup', function() {
       },
     });
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       getInitialState: function() {
         return {count: 1};
       },
       render: function() {
-        var children = [];
-        for (var i = 0; i < this.state.count; i++) {
+        const children = [];
+        for (let i = 0; i < this.state.count; i++) {
           children.push(<Child key={i} />);
         }
         return <ReactTransitionGroup>{children}</ReactTransitionGroup>;
       },
     });
 
-    var instance = ReactDOM.render(<Component />, container);
+    const instance = ReactDOM.render(<Component />, container);
     expect(log).toEqual(['didMount', 'willAppear', 'didAppear']);
 
     log = [];
@@ -93,10 +93,10 @@ describe('ReactTransitionGroup', function() {
   });
 
   it('should handle enter/leave/enter/leave correctly', function() {
-    var log = [];
-    var willEnterCb;
+    const log = [];
+    let willEnterCb;
 
-    var Child = React.createClass({
+    const Child = React.createClass({
       componentDidMount: function() {
         log.push('didMount');
       },
@@ -122,24 +122,24 @@ describe('ReactTransitionGroup', function() {
       },
     });
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       getInitialState: function() {
         return {count: 1};
       },
       render: function() {
-        var children = [];
-        for (var i = 0; i < this.state.count; i++) {
+        const children = [];
+        for (let i = 0; i < this.state.count; i++) {
           children.push(<Child key={i} />);
         }
         return <ReactTransitionGroup>{children}</ReactTransitionGroup>;
       },
     });
 
-    var instance = ReactDOM.render(<Component />, container);
+    const instance = ReactDOM.render(<Component />, container);
     expect(log).toEqual(['didMount']);
     instance.setState({count: 2});
     expect(log).toEqual(['didMount', 'didMount', 'willEnter']);
-    for (var k = 0; k < 5; k++) {
+    for (let k = 0; k < 5; k++) {
       instance.setState({count: 2});
       expect(log).toEqual(['didMount', 'didMount', 'willEnter']);
       instance.setState({count: 1});
@@ -153,10 +153,10 @@ describe('ReactTransitionGroup', function() {
   });
 
   it('should handle enter/leave/enter correctly', function() {
-    var log = [];
-    var willEnterCb;
+    const log = [];
+    let willEnterCb;
 
-    var Child = React.createClass({
+    const Child = React.createClass({
       componentDidMount: function() {
         log.push('didMount');
       },
@@ -182,24 +182,24 @@ describe('ReactTransitionGroup', function() {
       },
     });
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       getInitialState: function() {
         return {count: 1};
       },
       render: function() {
-        var children = [];
-        for (var i = 0; i < this.state.count; i++) {
+        const children = [];
+        for (let i = 0; i < this.state.count; i++) {
           children.push(<Child key={i} />);
         }
         return <ReactTransitionGroup>{children}</ReactTransitionGroup>;
       },
     });
 
-    var instance = ReactDOM.render(<Component />, container);
+    const instance = ReactDOM.render(<Component />, container);
     expect(log).toEqual(['didMount']);
     instance.setState({count: 2});
     expect(log).toEqual(['didMount', 'didMount', 'willEnter']);
-    for (var k = 0; k < 5; k++) {
+    for (let k = 0; k < 5; k++) {
       instance.setState({count: 1});
       expect(log).toEqual(['didMount', 'didMount', 'willEnter']);
       instance.setState({count: 2});
@@ -211,9 +211,9 @@ describe('ReactTransitionGroup', function() {
   });
 
   it('should handle entering/leaving several elements at once', function() {
-    var log = [];
+    let log = [];
 
-    var Child = React.createClass({
+    const Child = React.createClass({
       componentDidMount: function() {
         log.push('didMount' + this.props.id);
       },
@@ -239,20 +239,20 @@ describe('ReactTransitionGroup', function() {
       },
     });
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       getInitialState: function() {
         return {count: 1};
       },
       render: function() {
-        var children = [];
-        for (var i = 0; i < this.state.count; i++) {
+        const children = [];
+        for (let i = 0; i < this.state.count; i++) {
           children.push(<Child key={i} id={i} />);
         }
         return <ReactTransitionGroup>{children}</ReactTransitionGroup>;
       },
     });
 
-    var instance = ReactDOM.render(<Component />, container);
+    const instance = ReactDOM.render(<Component />, container);
     expect(log).toEqual(['didMount0']);
     log = [];
 

--- a/src/addons/update.js
+++ b/src/addons/update.js
@@ -13,10 +13,10 @@
 
 'use strict';
 
-var assign = require('Object.assign');
-var keyOf = require('keyOf');
-var invariant = require('invariant');
-var hasOwnProperty = {}.hasOwnProperty;
+const assign = require('Object.assign');
+const keyOf = require('keyOf');
+const invariant = require('invariant');
+const hasOwnProperty = {}.hasOwnProperty;
 
 function shallowCopy(x) {
   if (Array.isArray(x)) {
@@ -28,14 +28,14 @@ function shallowCopy(x) {
   }
 }
 
-var COMMAND_PUSH = keyOf({$push: null});
-var COMMAND_UNSHIFT = keyOf({$unshift: null});
-var COMMAND_SPLICE = keyOf({$splice: null});
-var COMMAND_SET = keyOf({$set: null});
-var COMMAND_MERGE = keyOf({$merge: null});
-var COMMAND_APPLY = keyOf({$apply: null});
+const COMMAND_PUSH = keyOf({$push: null});
+const COMMAND_UNSHIFT = keyOf({$unshift: null});
+const COMMAND_SPLICE = keyOf({$splice: null});
+const COMMAND_SET = keyOf({$set: null});
+const COMMAND_MERGE = keyOf({$merge: null});
+const COMMAND_APPLY = keyOf({$apply: null});
 
-var ALL_COMMANDS_LIST = [
+const ALL_COMMANDS_LIST = [
   COMMAND_PUSH,
   COMMAND_UNSHIFT,
   COMMAND_SPLICE,
@@ -44,7 +44,7 @@ var ALL_COMMANDS_LIST = [
   COMMAND_APPLY,
 ];
 
-var ALL_COMMANDS_SET = {};
+const ALL_COMMANDS_SET = {};
 
 ALL_COMMANDS_LIST.forEach(function(command) {
   ALL_COMMANDS_SET[command] = true;
@@ -57,7 +57,7 @@ function invariantArrayCase(value, spec, command) {
     command,
     value
   );
-  var specValue = spec[command];
+  const specValue = spec[command];
   invariant(
     Array.isArray(specValue),
     'update(): expected spec of %s to be an array; got %s. ' +
@@ -86,10 +86,10 @@ function update(value, spec) {
     return spec[COMMAND_SET];
   }
 
-  var nextValue = shallowCopy(value);
+  let nextValue = shallowCopy(value);
 
   if (hasOwnProperty.call(spec, COMMAND_MERGE)) {
-    var mergeObj = spec[COMMAND_MERGE];
+    const mergeObj = spec[COMMAND_MERGE];
     invariant(
       mergeObj && typeof mergeObj === 'object',
       'update(): %s expects a spec of type \'object\'; got %s',
@@ -155,7 +155,7 @@ function update(value, spec) {
     nextValue = spec[COMMAND_APPLY](nextValue);
   }
 
-  for (var k in spec) {
+  for (let k in spec) {
     if (!(ALL_COMMANDS_SET.hasOwnProperty(k) && ALL_COMMANDS_SET[k])) {
       nextValue[k] = update(value[k], spec[k]);
     }

--- a/src/addons/update.js
+++ b/src/addons/update.js
@@ -155,7 +155,7 @@ function update(value, spec) {
     nextValue = spec[COMMAND_APPLY](nextValue);
   }
 
-  for (let k in spec) {
+  for (const k in spec) {
     if (!(ALL_COMMANDS_SET.hasOwnProperty(k) && ALL_COMMANDS_SET[k])) {
       nextValue[k] = update(value[k], spec[k]);
     }

--- a/src/core/__tests__/ReactErrorBoundaries-test.js
+++ b/src/core/__tests__/ReactErrorBoundaries-test.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
+let React;
+let ReactDOM;
 
 describe('ReactErrorBoundaries', function() {
 
@@ -48,8 +48,8 @@ describe('ReactErrorBoundaries', function() {
       }
     }
 
-    var EventPluginHub = require('EventPluginHub');
-    var container = document.createElement('div');
+    const EventPluginHub = require('EventPluginHub');
+    const container = document.createElement('div');
     EventPluginHub.putListener = jest.genMockFn();
     ReactDOM.render(<Boundary />, container);
     expect(EventPluginHub.putListener).not.toBeCalled();
@@ -89,7 +89,7 @@ describe('ReactErrorBoundaries', function() {
       }
     }
 
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(
       <ErrorBoundary>
         <BrokenUnmount />
@@ -118,8 +118,8 @@ describe('ReactErrorBoundaries', function() {
       }
     }
 
-    var EventPluginHub = require('EventPluginHub');
-    var container = document.createElement('div');
+    const EventPluginHub = require('EventPluginHub');
+    const container = document.createElement('div');
     EventPluginHub.putListener = jest.genMockFn();
     ReactDOM.render(<Boundary />, container);
     expect(EventPluginHub.putListener).toBeCalled();
@@ -152,7 +152,7 @@ describe('ReactErrorBoundaries', function() {
       return <div />;
     }
 
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(
       <ErrorBoundary><Broken /><Composite /></ErrorBoundary>,
       container
@@ -161,7 +161,7 @@ describe('ReactErrorBoundaries', function() {
   });
 
   it('catches errors from children', function() {
-    var log = [];
+    const log = [];
 
     class Box extends React.Component {
       constructor(props) {
@@ -174,7 +174,7 @@ describe('ReactErrorBoundaries', function() {
           return <div>Error: {this.state.errorMessage}</div>;
         }
         log.push('Box render');
-        var ref = function(x) {
+        const ref = function(x) {
           log.push('Inquisitive ref ' + x);
         };
         return (
@@ -221,7 +221,7 @@ describe('ReactErrorBoundaries', function() {
       }
     }
 
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<Box />, container);
     expect(container.textContent).toBe('Error: Please, do not render me.');
     ReactDOM.unmountComponentAtNode(container);

--- a/src/isomorphic/ReactIsomorphic.js
+++ b/src/isomorphic/ReactIsomorphic.js
@@ -11,21 +11,21 @@
 
 'use strict';
 
-var ReactChildren = require('ReactChildren');
-var ReactComponent = require('ReactComponent');
-var ReactClass = require('ReactClass');
-var ReactDOMFactories = require('ReactDOMFactories');
-var ReactElement = require('ReactElement');
-var ReactElementValidator = require('ReactElementValidator');
-var ReactPropTypes = require('ReactPropTypes');
-var ReactVersion = require('ReactVersion');
+const ReactChildren = require('ReactChildren');
+const ReactComponent = require('ReactComponent');
+const ReactClass = require('ReactClass');
+const ReactDOMFactories = require('ReactDOMFactories');
+const ReactElement = require('ReactElement');
+const ReactElementValidator = require('ReactElementValidator');
+const ReactPropTypes = require('ReactPropTypes');
+const ReactVersion = require('ReactVersion');
 
-var assign = require('Object.assign');
-var onlyChild = require('onlyChild');
+const assign = require('Object.assign');
+const onlyChild = require('onlyChild');
 
-var createElement = ReactElement.createElement;
-var createFactory = ReactElement.createFactory;
-var cloneElement = ReactElement.cloneElement;
+let createElement = ReactElement.createElement;
+let createFactory = ReactElement.createFactory;
+let cloneElement = ReactElement.cloneElement;
 
 if (__DEV__) {
   createElement = ReactElementValidator.createElement;
@@ -33,7 +33,7 @@ if (__DEV__) {
   cloneElement = ReactElementValidator.cloneElement;
 }
 
-var React = {
+const React = {
 
   // Modern
 

--- a/src/isomorphic/children/ReactChildren.js
+++ b/src/isomorphic/children/ReactChildren.js
@@ -11,17 +11,17 @@
 
 'use strict';
 
-var PooledClass = require('PooledClass');
-var ReactElement = require('ReactElement');
+const PooledClass = require('PooledClass');
+const ReactElement = require('ReactElement');
 
-var emptyFunction = require('emptyFunction');
-var traverseAllChildren = require('traverseAllChildren');
+const emptyFunction = require('emptyFunction');
+const traverseAllChildren = require('traverseAllChildren');
 
-var twoArgumentPooler = PooledClass.twoArgumentPooler;
-var fourArgumentPooler = PooledClass.fourArgumentPooler;
+const twoArgumentPooler = PooledClass.twoArgumentPooler;
+const fourArgumentPooler = PooledClass.fourArgumentPooler;
 
 
-var userProvidedKeyEscapeRegex = /\/+/g;
+const userProvidedKeyEscapeRegex = /\/+/g;
 function escapeUserProvidedKey(text) {
   return ('' + text).replace(userProvidedKeyEscapeRegex, '$&/');
 }
@@ -48,7 +48,7 @@ ForEachBookKeeping.prototype.destructor = function() {
 PooledClass.addPoolingTo(ForEachBookKeeping, twoArgumentPooler);
 
 function forEachSingleChild(bookKeeping, child, name) {
-  var {func, context} = bookKeeping;
+  const {func, context} = bookKeeping;
   func.call(context, child, bookKeeping.count++);
 }
 
@@ -66,7 +66,7 @@ function forEachChildren(children, forEachFunc, forEachContext) {
   if (children == null) {
     return children;
   }
-  var traverseContext =
+  const traverseContext =
     ForEachBookKeeping.getPooled(forEachFunc, forEachContext);
   traverseAllChildren(children, forEachSingleChild, traverseContext);
   ForEachBookKeeping.release(traverseContext);
@@ -99,9 +99,9 @@ MapBookKeeping.prototype.destructor = function() {
 PooledClass.addPoolingTo(MapBookKeeping, fourArgumentPooler);
 
 function mapSingleChildIntoContext(bookKeeping, child, childKey) {
-  var {result, keyPrefix, func, context} = bookKeeping;
+  const {result, keyPrefix, func, context} = bookKeeping;
 
-  var mappedChild = func.call(context, child, bookKeeping.count++);
+  let mappedChild = func.call(context, child, bookKeeping.count++);
   if (Array.isArray(mappedChild)) {
     mapIntoWithKeyPrefixInternal(
       mappedChild,
@@ -129,11 +129,11 @@ function mapSingleChildIntoContext(bookKeeping, child, childKey) {
 }
 
 function mapIntoWithKeyPrefixInternal(children, array, prefix, func, context) {
-  var escapedPrefix = '';
+  let escapedPrefix = '';
   if (prefix != null) {
     escapedPrefix = escapeUserProvidedKey(prefix) + '/';
   }
-  var traverseContext = MapBookKeeping.getPooled(
+  const traverseContext = MapBookKeeping.getPooled(
     array,
     escapedPrefix,
     func,
@@ -158,7 +158,7 @@ function mapChildren(children, func, context) {
   if (children == null) {
     return children;
   }
-  var result = [];
+  const result = [];
   mapIntoWithKeyPrefixInternal(children, result, null, func, context);
   return result;
 }
@@ -186,7 +186,7 @@ function countChildren(children, context) {
  * return an array with appropriately re-keyed children.
  */
 function toArray(children) {
-  var result = [];
+  const result = [];
   mapIntoWithKeyPrefixInternal(
     children,
     result,
@@ -197,7 +197,7 @@ function toArray(children) {
 }
 
 
-var ReactChildren = {
+const ReactChildren = {
   forEach: forEachChildren,
   map: mapChildren,
   mapIntoWithKeyPrefixInternal: mapIntoWithKeyPrefixInternal,

--- a/src/isomorphic/children/__tests__/ReactChildren-test.js
+++ b/src/isomorphic/children/__tests__/ReactChildren-test.js
@@ -12,9 +12,9 @@
 'use strict';
 
 describe('ReactChildren', function() {
-  var ReactChildren;
-  var React;
-  var ReactFragment;
+  let ReactChildren;
+  let React;
+  let ReactFragment;
 
   beforeEach(function() {
     ReactChildren = require('ReactChildren');
@@ -23,64 +23,64 @@ describe('ReactChildren', function() {
   });
 
   it('should support identity for simple', function() {
-    var callback = jasmine.createSpy().andCallFake(function(kid, index) {
+    const callback = jasmine.createSpy().andCallFake(function(kid, index) {
       return kid;
     });
 
-    var simpleKid = <span key="simple" />;
+    const simpleKid = <span key="simple" />;
 
     // First pass children into a component to fully simulate what happens when
     // using structures that arrive from transforms.
 
-    var instance = <div>{simpleKid}</div>;
+    const instance = <div>{simpleKid}</div>;
     ReactChildren.forEach(instance.props.children, callback);
     expect(callback).toHaveBeenCalledWith(simpleKid, 0);
     callback.reset();
-    var mappedChildren = ReactChildren.map(instance.props.children, callback);
+    const mappedChildren = ReactChildren.map(instance.props.children, callback);
     expect(callback).toHaveBeenCalledWith(simpleKid, 0);
     expect(mappedChildren[0]).toEqual(<span key=".$simple" />);
   });
 
   it('should treat single arrayless child as being in array', function() {
-    var callback = jasmine.createSpy().andCallFake(function(kid, index) {
+    const callback = jasmine.createSpy().andCallFake(function(kid, index) {
       return kid;
     });
 
-    var simpleKid = <span />;
-    var instance = <div>{simpleKid}</div>;
+    const simpleKid = <span />;
+    const instance = <div>{simpleKid}</div>;
     ReactChildren.forEach(instance.props.children, callback);
     expect(callback).toHaveBeenCalledWith(simpleKid, 0);
     callback.reset();
-    var mappedChildren = ReactChildren.map(instance.props.children, callback);
+    const mappedChildren = ReactChildren.map(instance.props.children, callback);
     expect(callback).toHaveBeenCalledWith(simpleKid, 0);
     expect(mappedChildren[0]).toEqual(<span key=".0" />);
   });
 
   it('should treat single child in array as expected', function() {
-    var callback = jasmine.createSpy().andCallFake(function(kid, index) {
+    const callback = jasmine.createSpy().andCallFake(function(kid, index) {
       return kid;
     });
 
-    var simpleKid = <span key="simple" />;
-    var instance = <div>{[simpleKid]}</div>;
+    const simpleKid = <span key="simple" />;
+    const instance = <div>{[simpleKid]}</div>;
     ReactChildren.forEach(instance.props.children, callback);
     expect(callback).toHaveBeenCalledWith(simpleKid, 0);
     callback.reset();
-    var mappedChildren = ReactChildren.map(instance.props.children, callback);
+    const mappedChildren = ReactChildren.map(instance.props.children, callback);
     expect(callback).toHaveBeenCalledWith(simpleKid, 0);
     expect(mappedChildren[0]).toEqual(<span key=".$simple" />);
 
   });
 
   it('should pass key to returned component', function() {
-    var mapFn = function(kid, index) {
+    const mapFn = function(kid, index) {
       return <div>{kid}</div>;
     };
 
-    var simpleKid = <span key="simple" />;
+    const simpleKid = <span key="simple" />;
 
-    var instance = <div>{simpleKid}</div>;
-    var mappedChildren = ReactChildren.map(instance.props.children, mapFn);
+    const instance = <div>{simpleKid}</div>;
+    const mappedChildren = ReactChildren.map(instance.props.children, mapFn);
 
     expect(ReactChildren.count(mappedChildren)).toBe(1);
     expect(mappedChildren[0]).not.toBe(simpleKid);
@@ -89,21 +89,21 @@ describe('ReactChildren', function() {
   });
 
   it('should invoke callback with the right context', function() {
-    var lastContext;
-    var callback = function(kid, index) {
+    let lastContext;
+    const callback = function(kid, index) {
       lastContext = this;
       return this;
     };
 
     // TODO: Use an object to test, after non-object fragments has fully landed.
-    var scopeTester = 'scope tester';
+    const scopeTester = 'scope tester';
 
-    var simpleKid = <span key="simple" />;
-    var instance = <div>{simpleKid}</div>;
+    const simpleKid = <span key="simple" />;
+    const instance = <div>{simpleKid}</div>;
     ReactChildren.forEach(instance.props.children, callback, scopeTester);
     expect(lastContext).toBe(scopeTester);
 
-    var mappedChildren =
+    const mappedChildren =
       ReactChildren.map(instance.props.children, callback, scopeTester);
 
     expect(ReactChildren.count(mappedChildren)).toBe(1);
@@ -111,24 +111,24 @@ describe('ReactChildren', function() {
   });
 
   it('should be called for each child', function() {
-    var zero = <div key="keyZero" />;
-    var one = null;
-    var two = <div key="keyTwo" />;
-    var three = null;
-    var four = <div key="keyFour" />;
+    const zero = <div key="keyZero" />;
+    const one = null;
+    const two = <div key="keyTwo" />;
+    const three = null;
+    const four = <div key="keyFour" />;
 
-    var mapped = [
+    const mapped = [
       <div key="giraffe" />,  // Key should be joined to obj key
       null,  // Key should be added even if we don't supply it!
       <div />,  // Key should be added even if not supplied!
       <span />, // Map from null to something.
       <div key="keyFour" />,
     ];
-    var callback = jasmine.createSpy().andCallFake(function(kid, index) {
+    const callback = jasmine.createSpy().andCallFake(function(kid, index) {
       return mapped[index];
     });
 
-    var instance = (
+    const instance = (
       <div>
         {zero}
         {one}
@@ -146,7 +146,7 @@ describe('ReactChildren', function() {
     expect(callback).toHaveBeenCalledWith(four, 4);
     callback.reset();
 
-    var mappedChildren =
+    const mappedChildren =
       ReactChildren.map(instance.props.children, callback);
     expect(callback.calls.length).toBe(5);
     expect(ReactChildren.count(mappedChildren)).toBe(4);
@@ -173,35 +173,35 @@ describe('ReactChildren', function() {
   });
 
   it('should be called for each child in nested structure', function() {
-    var zero = <div key="keyZero" />;
-    var one = null;
-    var two = <div key="keyTwo" />;
-    var three = null;
-    var four = <div key="keyFour" />;
-    var five = <div key="keyFiveInner" />;
+    const zero = <div key="keyZero" />;
+    const one = null;
+    const two = <div key="keyTwo" />;
+    const three = null;
+    const four = <div key="keyFour" />;
+    const five = <div key="keyFiveInner" />;
     // five is placed into a JS object with a key that is joined to the
     // component key attribute.
     // Precedence is as follows:
     // 1. If grouped in an Object, the object key combined with `key` prop
     // 2. If grouped in an Array, the `key` prop, falling back to array index
 
-    var zeroMapped = <div key="giraffe" />;  // Key should be overridden
-    var twoMapped = <div />;  // Key should be added even if not supplied!
-    var fourMapped = <div key="keyFour" />;
-    var fiveMapped = <div />;
+    const zeroMapped = <div key="giraffe" />;  // Key should be overridden
+    const twoMapped = <div />;  // Key should be added even if not supplied!
+    const fourMapped = <div key="keyFour" />;
+    const fiveMapped = <div />;
 
-    var callback = jasmine.createSpy().andCallFake(function(kid, index) {
+    const callback = jasmine.createSpy().andCallFake(function(kid, index) {
       return index === 0 ? zeroMapped :
         index === 1 ? twoMapped :
         index === 2 ? fourMapped : fiveMapped;
     });
 
-    var frag = ReactFragment.create({
+    const frag = ReactFragment.create({
       firstHalfKey: [zero, one, two],
       secondHalfKey: [three, four],
       keyFive: five,
     });
-    var instance = <div>{[frag]}</div>;
+    const instance = <div>{[frag]}</div>;
 
     expect([
       frag[0].key,
@@ -223,7 +223,7 @@ describe('ReactChildren', function() {
     expect(callback).toHaveBeenCalledWith(frag[3], 3);
     callback.reset();
 
-    var mappedChildren = ReactChildren.map(instance.props.children, callback);
+    const mappedChildren = ReactChildren.map(instance.props.children, callback);
     expect(callback.calls.length).toBe(4);
     expect(callback).toHaveBeenCalledWith(frag[0], 0);
     expect(callback).toHaveBeenCalledWith(frag[1], 1);
@@ -251,36 +251,36 @@ describe('ReactChildren', function() {
   });
 
   it('should retain key across two mappings', function() {
-    var zeroForceKey = <div key="keyZero" />;
-    var oneForceKey = <div key="keyOne" />;
+    const zeroForceKey = <div key="keyZero" />;
+    const oneForceKey = <div key="keyOne" />;
 
     // Key should be joined to object key
-    var zeroForceKeyMapped = <div key="giraffe" />;
+    const zeroForceKeyMapped = <div key="giraffe" />;
     // Key should be added even if we don't supply it!
-    var oneForceKeyMapped = <div />;
+    const oneForceKeyMapped = <div />;
 
-    var mapFn = function(kid, index) {
+    const mapFn = function(kid, index) {
       return index === 0 ? zeroForceKeyMapped : oneForceKeyMapped;
     };
 
-    var forcedKeys = (
+    const forcedKeys = (
       <div>
         {zeroForceKey}
         {oneForceKey}
       </div>
     );
 
-    var expectedForcedKeys = ['giraffe/.$keyZero', '.$keyOne'];
-    var mappedChildrenForcedKeys =
+    const expectedForcedKeys = ['giraffe/.$keyZero', '.$keyOne'];
+    const mappedChildrenForcedKeys =
       ReactChildren.map(forcedKeys.props.children, mapFn);
-    var mappedForcedKeys = mappedChildrenForcedKeys.map((c) => c.key);
+    const mappedForcedKeys = mappedChildrenForcedKeys.map((c) => c.key);
     expect(mappedForcedKeys).toEqual(expectedForcedKeys);
 
-    var expectedRemappedForcedKeys = [
+    const expectedRemappedForcedKeys = [
       'giraffe/.$giraffe/.$keyZero',
       '.$.$keyOne',
     ];
-    var remappedChildrenForcedKeys =
+    const remappedChildrenForcedKeys =
       ReactChildren.map(mappedChildrenForcedKeys, mapFn);
     expect(
       remappedChildrenForcedKeys.map((c) => c.key)
@@ -289,14 +289,14 @@ describe('ReactChildren', function() {
   });
 
   it('should not throw if key provided is a dupe with array key', function() {
-    var zero = <div />;
-    var one = <div key="0" />;
+    const zero = <div />;
+    const one = <div key="0" />;
 
-    var mapFn = function() {
+    const mapFn = function() {
       return null;
     };
 
-    var instance = (
+    const instance = (
       <div>
         {zero}
         {one}
@@ -309,18 +309,18 @@ describe('ReactChildren', function() {
   });
 
   it('should use the same key for a cloned element', function() {
-    var instance = (
+    const instance = (
       <div>
         <div />
       </div>
     );
 
-    var mapped = ReactChildren.map(
+    const mapped = ReactChildren.map(
       instance.props.children,
       element => element,
     );
 
-    var mappedWithClone = ReactChildren.map(
+    const mappedWithClone = ReactChildren.map(
       instance.props.children,
       element => React.cloneElement(element),
     );
@@ -329,18 +329,18 @@ describe('ReactChildren', function() {
   });
 
   it('should use the same key for a cloned element with key', function() {
-    var instance = (
+    const instance = (
       <div>
         <div key="unique" />
       </div>
     );
 
-    var mapped = ReactChildren.map(
+    const mapped = ReactChildren.map(
       instance.props.children,
       element => element,
     );
 
-    var mappedWithClone = ReactChildren.map(
+    const mappedWithClone = ReactChildren.map(
       instance.props.children,
       element => React.cloneElement(element, {key: 'unique'}),
     );
@@ -349,30 +349,30 @@ describe('ReactChildren', function() {
   });
 
   it('should return 0 for null children', function() {
-    var numberOfChildren = ReactChildren.count(null);
+    const numberOfChildren = ReactChildren.count(null);
     expect(numberOfChildren).toBe(0);
   });
 
   it('should return 0 for undefined children', function() {
-    var numberOfChildren = ReactChildren.count(undefined);
+    const numberOfChildren = ReactChildren.count(undefined);
     expect(numberOfChildren).toBe(0);
   });
 
   it('should return 1 for single child', function() {
-    var simpleKid = <span key="simple" />;
-    var instance = <div>{simpleKid}</div>;
-    var numberOfChildren = ReactChildren.count(instance.props.children);
+    const simpleKid = <span key="simple" />;
+    const instance = <div>{simpleKid}</div>;
+    const numberOfChildren = ReactChildren.count(instance.props.children);
     expect(numberOfChildren).toBe(1);
   });
 
   it('should count the number of children in flat structure', function() {
-    var zero = <div key="keyZero" />;
-    var one = null;
-    var two = <div key="keyTwo" />;
-    var three = null;
-    var four = <div key="keyFour" />;
+    const zero = <div key="keyZero" />;
+    const one = null;
+    const two = <div key="keyTwo" />;
+    const three = null;
+    const four = <div key="keyFour" />;
 
-    var instance = (
+    const instance = (
       <div>
         {zero}
         {one}
@@ -381,24 +381,24 @@ describe('ReactChildren', function() {
         {four}
       </div>
     );
-    var numberOfChildren = ReactChildren.count(instance.props.children);
+    const numberOfChildren = ReactChildren.count(instance.props.children);
     expect(numberOfChildren).toBe(5);
   });
 
   it('should count the number of children in nested structure', function() {
-    var zero = <div key="keyZero" />;
-    var one = null;
-    var two = <div key="keyTwo" />;
-    var three = null;
-    var four = <div key="keyFour" />;
-    var five = <div key="keyFiveInner" />;
+    const zero = <div key="keyZero" />;
+    const one = null;
+    const two = <div key="keyTwo" />;
+    const three = null;
+    const four = <div key="keyFour" />;
+    const five = <div key="keyFiveInner" />;
     // five is placed into a JS object with a key that is joined to the
     // component key attribute.
     // Precedence is as follows:
     // 1. If grouped in an Object, the object key combined with `key` prop
     // 2. If grouped in an Array, the `key` prop, falling back to array index
 
-    var instance = (
+    const instance = (
       <div>{
         [
           ReactFragment.create({
@@ -410,7 +410,7 @@ describe('ReactChildren', function() {
         ]
       }</div>
     );
-    var numberOfChildren = ReactChildren.count(instance.props.children);
+    const numberOfChildren = ReactChildren.count(instance.props.children);
     expect(numberOfChildren).toBe(5);
   });
 
@@ -426,7 +426,7 @@ describe('ReactChildren', function() {
       ReactChildren.toArray([<div />])[0].key
     );
 
-    var flattened = ReactChildren.toArray([
+    const flattened = ReactChildren.toArray([
       [<div key="apple" />, <div key="banana" />, <div key="camel" />],
       [<div key="banana" />, <div key="camel" />, <div key="deli" />],
     ]);
@@ -435,7 +435,7 @@ describe('ReactChildren', function() {
     expect(flattened[3].key).toContain('banana');
     expect(flattened[1].key).not.toBe(flattened[3].key);
 
-    var reversed = ReactChildren.toArray([
+    const reversed = ReactChildren.toArray([
       [<div key="camel" />, <div key="banana" />, <div key="apple" />],
       [<div key="deli" />, <div key="camel" />, <div key="banana" />],
     ]);

--- a/src/isomorphic/children/__tests__/onlyChild-test.js
+++ b/src/isomorphic/children/__tests__/onlyChild-test.js
@@ -13,10 +13,10 @@
 
 describe('onlyChild', function() {
 
-  var React;
-  var ReactFragment;
-  var onlyChild;
-  var WrapComponent;
+  let React;
+  let ReactFragment;
+  let onlyChild;
+  let WrapComponent;
 
   beforeEach(function() {
     React = require('React');
@@ -35,7 +35,7 @@ describe('onlyChild', function() {
 
   it('should fail when passed two children', function() {
     expect(function() {
-      var instance =
+      const instance =
         <WrapComponent>
           <div />
           <span />
@@ -46,7 +46,7 @@ describe('onlyChild', function() {
 
   it('should fail when passed nully values', function() {
     expect(function() {
-      var instance =
+      const instance =
         <WrapComponent>
           {null}
         </WrapComponent>;
@@ -54,7 +54,7 @@ describe('onlyChild', function() {
     }).toThrow();
 
     expect(function() {
-      var instance =
+      const instance =
         <WrapComponent>
           {undefined}
         </WrapComponent>;
@@ -64,7 +64,7 @@ describe('onlyChild', function() {
 
   it('should fail when key/value objects', function() {
     expect(function() {
-      var instance =
+      const instance =
         <WrapComponent>
           {ReactFragment.create({oneThing: <span />})}
         </WrapComponent>;
@@ -75,7 +75,7 @@ describe('onlyChild', function() {
 
   it('should not fail when passed interpolated single child', function() {
     expect(function() {
-      var instance =
+      const instance =
         <WrapComponent>
           {<span />}
         </WrapComponent>;
@@ -86,7 +86,7 @@ describe('onlyChild', function() {
 
   it('should return the only child', function() {
     expect(function() {
-      var instance =
+      const instance =
         <WrapComponent>
           <span />
         </WrapComponent>;

--- a/src/isomorphic/children/__tests__/sliceChildren-test.js
+++ b/src/isomorphic/children/__tests__/sliceChildren-test.js
@@ -13,9 +13,9 @@
 
 describe('sliceChildren', function() {
 
-  var React;
+  let React;
 
-  var sliceChildren;
+  let sliceChildren;
 
   beforeEach(function() {
     React = require('React');
@@ -24,12 +24,12 @@ describe('sliceChildren', function() {
   });
 
   it('should render the whole set if start zero is supplied', function() {
-    var fullSet = [
+    const fullSet = [
       <div key="A" />,
       <div key="B" />,
       <div key="C" />,
     ];
-    var children = sliceChildren(fullSet, 0);
+    const children = sliceChildren(fullSet, 0);
     expect(children).toEqual([
       <div key=".$A" />,
       <div key=".$B" />,
@@ -38,12 +38,12 @@ describe('sliceChildren', function() {
   });
 
   it('should render the remaining set if no end index is supplied', function() {
-    var fullSet = [
+    const fullSet = [
       <div key="A" />,
       <div key="B" />,
       <div key="C" />,
     ];
-    var children = sliceChildren(fullSet, 1);
+    const children = sliceChildren(fullSet, 1);
     expect(children).toEqual([
       <div key=".$B" />,
       <div key=".$C" />,
@@ -51,32 +51,32 @@ describe('sliceChildren', function() {
   });
 
   it('should exclude everything at or after the end index', function() {
-    var fullSet = [
+    const fullSet = [
       <div key="A" />,
       <div key="B" />,
       <div key="C" />,
       <div key="D" />,
     ];
-    var children = sliceChildren(fullSet, 1, 2);
+    const children = sliceChildren(fullSet, 1, 2);
     expect(children).toEqual([
       <div key=".$B" />,
     ]);
   });
 
   it('should allow static children to be sliced', function() {
-    var a = <a />;
-    var b = <b />;
-    var c = <i />;
+    const a = <a />;
+    const b = <b />;
+    const c = <i />;
 
-    var el = <div>{a}{b}{c}</div>;
-    var children = sliceChildren(el.props.children, 1, 2);
+    const el = <div>{a}{b}{c}</div>;
+    const children = sliceChildren(el.props.children, 1, 2);
     expect(children).toEqual([
       <b key=".1" />,
     ]);
   });
 
   it('should slice nested children', function() {
-    var fullSet = [
+    const fullSet = [
       <div key="A" />,
       [
         <div key="B" />,
@@ -84,7 +84,7 @@ describe('sliceChildren', function() {
       ],
       <div key="D" />,
     ];
-    var children = sliceChildren(fullSet, 1, 2);
+    const children = sliceChildren(fullSet, 1, 2);
     expect(children).toEqual([
       <div key=".1:$B" />,
     ]);

--- a/src/isomorphic/children/onlyChild.js
+++ b/src/isomorphic/children/onlyChild.js
@@ -10,9 +10,9 @@
  */
 'use strict';
 
-var ReactElement = require('ReactElement');
+const ReactElement = require('ReactElement');
 
-var invariant = require('invariant');
+const invariant = require('invariant');
 
 /**
  * Returns the first child in a collection of children and verifies that there

--- a/src/isomorphic/children/sliceChildren.js
+++ b/src/isomorphic/children/sliceChildren.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var ReactChildren = require('ReactChildren');
+const ReactChildren = require('ReactChildren');
 
 /**
  * Slice children that are typically specified as `props.children`. This version
@@ -27,7 +27,7 @@ function sliceChildren(children, start, end) {
     return children;
   }
 
-  var array = ReactChildren.toArray(children);
+  const array = ReactChildren.toArray(children);
   return array.slice(start, end);
 }
 

--- a/src/isomorphic/classic/__tests__/ReactContextValidator-test.js
+++ b/src/isomorphic/classic/__tests__/ReactContextValidator-test.js
@@ -17,11 +17,11 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
-var ReactTestUtils;
+let React;
+let ReactDOM;
+let ReactTestUtils;
 
-var reactComponentExpect;
+let reactComponentExpect;
 
 describe('ReactContextValidator', function() {
   beforeEach(function() {
@@ -39,7 +39,7 @@ describe('ReactContextValidator', function() {
   // ensure that this is not required for ES6 classes with Flow.
 
   it('should filter out context not in contextTypes', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       contextTypes: {
         foo: React.PropTypes.string,
       },
@@ -49,7 +49,7 @@ describe('ReactContextValidator', function() {
       },
     });
 
-    var ComponentInFooBarContext = React.createClass({
+    const ComponentInFooBarContext = React.createClass({
       childContextTypes: {
         foo: React.PropTypes.string,
         bar: React.PropTypes.number,
@@ -67,17 +67,17 @@ describe('ReactContextValidator', function() {
       },
     });
 
-    var instance = ReactTestUtils.renderIntoDocument(<ComponentInFooBarContext />);
+    const instance = ReactTestUtils.renderIntoDocument(<ComponentInFooBarContext />);
     reactComponentExpect(instance).expectRenderedChild().scalarContextEqual({foo: 'abc'});
   });
 
   it('should filter context properly in callbacks', function() {
-    var actualComponentWillReceiveProps;
-    var actualShouldComponentUpdate;
-    var actualComponentWillUpdate;
-    var actualComponentDidUpdate;
+    let actualComponentWillReceiveProps;
+    let actualShouldComponentUpdate;
+    let actualComponentWillUpdate;
+    let actualComponentDidUpdate;
 
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       childContextTypes: {
         foo: React.PropTypes.string.isRequired,
         bar: React.PropTypes.string.isRequired,
@@ -95,7 +95,7 @@ describe('ReactContextValidator', function() {
       },
     });
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       contextTypes: {
         foo: React.PropTypes.string,
       },
@@ -123,7 +123,7 @@ describe('ReactContextValidator', function() {
       },
     });
 
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<Parent foo="abc" />, container);
     ReactDOM.render(<Parent foo="def" />, container);
     expect(actualComponentWillReceiveProps).toEqual({foo: 'def'});
@@ -133,7 +133,7 @@ describe('ReactContextValidator', function() {
   });
 
   it('should check context types', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       contextTypes: {
         foo: React.PropTypes.string.isRequired,
       },
@@ -151,7 +151,7 @@ describe('ReactContextValidator', function() {
       'Required context `foo` was not specified in `Component`.'
     );
 
-    var ComponentInFooStringContext = React.createClass({
+    const ComponentInFooStringContext = React.createClass({
       childContextTypes: {
         foo: React.PropTypes.string,
       },
@@ -174,7 +174,7 @@ describe('ReactContextValidator', function() {
     // Previous call should not error
     expect(console.error.argsForCall.length).toBe(1);
 
-    var ComponentInFooNumberContext = React.createClass({
+    const ComponentInFooNumberContext = React.createClass({
       childContextTypes: {
         foo: React.PropTypes.number,
       },
@@ -202,7 +202,7 @@ describe('ReactContextValidator', function() {
   });
 
   it('should check child context types', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       childContextTypes: {
         foo: React.PropTypes.string.isRequired,
         bar: React.PropTypes.number,

--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -11,25 +11,25 @@
 
 'use strict';
 
-var ReactComponent = require('ReactComponent');
-var ReactElement = require('ReactElement');
-var ReactPropTypeLocations = require('ReactPropTypeLocations');
-var ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
-var ReactNoopUpdateQueue = require('ReactNoopUpdateQueue');
+const ReactComponent = require('ReactComponent');
+const ReactElement = require('ReactElement');
+const ReactPropTypeLocations = require('ReactPropTypeLocations');
+const ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
+const ReactNoopUpdateQueue = require('ReactNoopUpdateQueue');
 
-var assign = require('Object.assign');
-var emptyObject = require('emptyObject');
-var invariant = require('invariant');
-var keyMirror = require('keyMirror');
-var keyOf = require('keyOf');
-var warning = require('warning');
+const assign = require('Object.assign');
+const emptyObject = require('emptyObject');
+const invariant = require('invariant');
+const keyMirror = require('keyMirror');
+const keyOf = require('keyOf');
+const warning = require('warning');
 
-var MIXINS_KEY = keyOf({mixins: null});
+const MIXINS_KEY = keyOf({mixins: null});
 
 /**
  * Policies that describe methods in `ReactClassInterface`.
  */
-var SpecPolicy = keyMirror({
+const SpecPolicy = keyMirror({
   /**
    * These methods may be defined only once by the class specification or mixin.
    */
@@ -52,7 +52,7 @@ var SpecPolicy = keyMirror({
 });
 
 
-var injectedMixins = [];
+const injectedMixins = [];
 
 /**
  * Composite components are higher-level components that compose other composite
@@ -76,7 +76,7 @@ var injectedMixins = [];
  * @interface ReactClassInterface
  * @internal
  */
-var ReactClassInterface = {
+const ReactClassInterface = {
 
   /**
    * An array of Mixin objects to include when defining your component.
@@ -312,13 +312,13 @@ var ReactClassInterface = {
  * being static, they must be defined outside of the "statics" key under
  * which all other static methods are defined.
  */
-var RESERVED_SPEC_KEYS = {
+const RESERVED_SPEC_KEYS = {
   displayName: function(Constructor, displayName) {
     Constructor.displayName = displayName;
   },
   mixins: function(Constructor, mixins) {
     if (mixins) {
-      for (var i = 0; i < mixins.length; i++) {
+      for (let i = 0; i < mixins.length; i++) {
         mixSpecIntoComponent(Constructor, mixins[i]);
       }
     }
@@ -386,7 +386,7 @@ var RESERVED_SPEC_KEYS = {
 };
 
 function validateTypeDef(Constructor, typeDef, location) {
-  for (var propName in typeDef) {
+  for (let propName in typeDef) {
     if (typeDef.hasOwnProperty(propName)) {
       // use a warning instead of an invariant so components
       // don't show up in prod but only in __DEV__
@@ -403,7 +403,7 @@ function validateTypeDef(Constructor, typeDef, location) {
 }
 
 function validateMethodOverride(isAlreadyDefined, name) {
-  var specPolicy = ReactClassInterface.hasOwnProperty(name) ?
+  const specPolicy = ReactClassInterface.hasOwnProperty(name) ?
     ReactClassInterface[name] :
     null;
 
@@ -452,8 +452,8 @@ function mixSpecIntoComponent(Constructor, spec) {
     'use a component as a mixin. Instead, just use a regular object.'
   );
 
-  var proto = Constructor.prototype;
-  var autoBindPairs = proto.__reactAutoBindPairs;
+  const proto = Constructor.prototype;
+  const autoBindPairs = proto.__reactAutoBindPairs;
 
   // By handling mixins before any other properties, we ensure the same
   // chaining order is applied to methods with DEFINE_MANY policy, whether
@@ -462,7 +462,7 @@ function mixSpecIntoComponent(Constructor, spec) {
     RESERVED_SPEC_KEYS.mixins(Constructor, spec.mixins);
   }
 
-  for (var name in spec) {
+  for (let name in spec) {
     if (!spec.hasOwnProperty(name)) {
       continue;
     }
@@ -472,8 +472,8 @@ function mixSpecIntoComponent(Constructor, spec) {
       continue;
     }
 
-    var property = spec[name];
-    var isAlreadyDefined = proto.hasOwnProperty(name);
+    const property = spec[name];
+    const isAlreadyDefined = proto.hasOwnProperty(name);
     validateMethodOverride(isAlreadyDefined, name);
 
     if (RESERVED_SPEC_KEYS.hasOwnProperty(name)) {
@@ -483,10 +483,10 @@ function mixSpecIntoComponent(Constructor, spec) {
       // The following member methods should not be automatically bound:
       // 1. Expected ReactClass methods (in the "interface").
       // 2. Overridden methods (that were mixed in).
-      var isReactClassMethod =
+      const isReactClassMethod =
         ReactClassInterface.hasOwnProperty(name);
-      var isFunction = typeof property === 'function';
-      var shouldAutoBind =
+      const isFunction = typeof property === 'function';
+      const shouldAutoBind =
         isFunction &&
         !isReactClassMethod &&
         !isAlreadyDefined &&
@@ -497,7 +497,7 @@ function mixSpecIntoComponent(Constructor, spec) {
         proto[name] = property;
       } else {
         if (isAlreadyDefined) {
-          var specPolicy = ReactClassInterface[name];
+          const specPolicy = ReactClassInterface[name];
 
           // These cases should already be caught by validateMethodOverride.
           invariant(
@@ -537,13 +537,13 @@ function mixStaticSpecIntoComponent(Constructor, statics) {
   if (!statics) {
     return;
   }
-  for (var name in statics) {
-    var property = statics[name];
+  for (let name in statics) {
+    const property = statics[name];
     if (!statics.hasOwnProperty(name)) {
       continue;
     }
 
-    var isReserved = name in RESERVED_SPEC_KEYS;
+    const isReserved = name in RESERVED_SPEC_KEYS;
     invariant(
       !isReserved,
       'ReactClass: You are attempting to define a reserved ' +
@@ -553,7 +553,7 @@ function mixStaticSpecIntoComponent(Constructor, statics) {
       name
     );
 
-    var isInherited = name in Constructor;
+    const isInherited = name in Constructor;
     invariant(
       !isInherited,
       'ReactClass: You are attempting to define ' +
@@ -578,7 +578,7 @@ function mergeIntoWithNoDuplicateKeys(one, two) {
     'mergeIntoWithNoDuplicateKeys(): Cannot merge non-objects.'
   );
 
-  for (var key in two) {
+  for (let key in two) {
     if (two.hasOwnProperty(key)) {
       invariant(
         one[key] === undefined,
@@ -605,14 +605,14 @@ function mergeIntoWithNoDuplicateKeys(one, two) {
  */
 function createMergedResultFunction(one, two) {
   return function mergedResult() {
-    var a = one.apply(this, arguments);
-    var b = two.apply(this, arguments);
+    const a = one.apply(this, arguments);
+    const b = two.apply(this, arguments);
     if (a == null) {
       return b;
     } else if (b == null) {
       return a;
     }
-    var c = {};
+    const c = {};
     mergeIntoWithNoDuplicateKeys(c, a);
     mergeIntoWithNoDuplicateKeys(c, b);
     return c;
@@ -642,13 +642,13 @@ function createChainedFunction(one, two) {
  * @return {function} The bound method.
  */
 function bindAutoBindMethod(component, method) {
-  var boundMethod = method.bind(component);
+  const boundMethod = method.bind(component);
   if (__DEV__) {
     boundMethod.__reactBoundContext = component;
     boundMethod.__reactBoundMethod = method;
     boundMethod.__reactBoundArguments = null;
-    var componentName = component.constructor.displayName;
-    var _bind = boundMethod.bind;
+    const componentName = component.constructor.displayName;
+    const _bind = boundMethod.bind;
     boundMethod.bind = function(newThis, ...args) {
       // User is trying to bind() an autobound method; we effectively will
       // ignore the value of "this" that the user is trying to use, so
@@ -670,7 +670,7 @@ function bindAutoBindMethod(component, method) {
         );
         return boundMethod;
       }
-      var reboundMethod = _bind.apply(boundMethod, arguments);
+      const reboundMethod = _bind.apply(boundMethod, arguments);
       reboundMethod.__reactBoundContext = component;
       reboundMethod.__reactBoundMethod = method;
       reboundMethod.__reactBoundArguments = args;
@@ -686,10 +686,10 @@ function bindAutoBindMethod(component, method) {
  * @param {object} component Component whose method is going to be bound.
  */
 function bindAutoBindMethods(component) {
-  var pairs = component.__reactAutoBindPairs;
-  for (var i = 0; i < pairs.length; i += 2) {
-    var autoBindKey = pairs[i];
-    var method = pairs[i + 1];
+  const pairs = component.__reactAutoBindPairs;
+  for (let i = 0; i < pairs.length; i += 2) {
+    const autoBindKey = pairs[i];
+    const method = pairs[i + 1];
     component[autoBindKey] = bindAutoBindMethod(
       component,
       method
@@ -725,7 +725,7 @@ var ReactClassMixin = {
   },
 };
 
-var ReactClassComponent = function() {};
+const ReactClassComponent = function() {};
 assign(
   ReactClassComponent.prototype,
   ReactComponent.prototype,
@@ -737,7 +737,7 @@ assign(
  *
  * @class ReactClass
  */
-var ReactClass = {
+const ReactClass = {
 
   /**
    * Creates a composite component class given a class specification.
@@ -747,7 +747,7 @@ var ReactClass = {
    * @public
    */
   createClass: function(spec) {
-    var Constructor = function(props, context, updater) {
+    const Constructor = function(props, context, updater) {
       // This constructor gets overridden by mocks. The argument is used
       // by mocks to assert on what gets mounted.
 
@@ -774,7 +774,7 @@ var ReactClass = {
       // ReactClasses doesn't have constructors. Instead, they use the
       // getInitialState and componentWillMount methods for initialization.
 
-      var initialState = this.getInitialState ? this.getInitialState() : null;
+      let initialState = this.getInitialState ? this.getInitialState() : null;
       if (__DEV__) {
         // We allow auto-mocks to proceed as if they're returning null.
         if (initialState === undefined &&
@@ -843,7 +843,7 @@ var ReactClass = {
     }
 
     // Reduce time spent doing lookups by setting these on the prototype.
-    for (var methodName in ReactClassInterface) {
+    for (let methodName in ReactClassInterface) {
       if (!Constructor.prototype[methodName]) {
         Constructor.prototype[methodName] = null;
       }

--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -386,7 +386,7 @@ const RESERVED_SPEC_KEYS = {
 };
 
 function validateTypeDef(Constructor, typeDef, location) {
-  for (let propName in typeDef) {
+  for (const propName in typeDef) {
     if (typeDef.hasOwnProperty(propName)) {
       // use a warning instead of an invariant so components
       // don't show up in prod but only in __DEV__
@@ -462,7 +462,7 @@ function mixSpecIntoComponent(Constructor, spec) {
     RESERVED_SPEC_KEYS.mixins(Constructor, spec.mixins);
   }
 
-  for (let name in spec) {
+  for (const name in spec) {
     if (!spec.hasOwnProperty(name)) {
       continue;
     }
@@ -537,7 +537,7 @@ function mixStaticSpecIntoComponent(Constructor, statics) {
   if (!statics) {
     return;
   }
-  for (let name in statics) {
+  for (const name in statics) {
     const property = statics[name];
     if (!statics.hasOwnProperty(name)) {
       continue;
@@ -578,7 +578,7 @@ function mergeIntoWithNoDuplicateKeys(one, two) {
     'mergeIntoWithNoDuplicateKeys(): Cannot merge non-objects.'
   );
 
-  for (let key in two) {
+  for (const key in two) {
     if (two.hasOwnProperty(key)) {
       invariant(
         one[key] === undefined,
@@ -843,7 +843,7 @@ const ReactClass = {
     }
 
     // Reduce time spent doing lookups by setting these on the prototype.
-    for (let methodName in ReactClassInterface) {
+    for (const methodName in ReactClassInterface) {
       if (!Constructor.prototype[methodName]) {
         Constructor.prototype[methodName] = null;
       }

--- a/src/isomorphic/classic/class/__tests__/ReactBind-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactBind-test.js
@@ -11,20 +11,20 @@
 /*global global:true*/
 'use strict';
 
-var React = require('React');
-var ReactTestUtils = require('ReactTestUtils');
-var reactComponentExpect = require('reactComponentExpect');
+const React = require('React');
+const ReactTestUtils = require('ReactTestUtils');
+const reactComponentExpect = require('reactComponentExpect');
 
 // TODO: Test render and all stock methods.
 describe('autobinding', function() {
 
   it('Holds reference to instance', function() {
 
-    var mouseDidEnter = jest.genMockFn();
-    var mouseDidLeave = jest.genMockFn();
-    var mouseDidClick = jest.genMockFn();
+    const mouseDidEnter = jest.genMockFn();
+    const mouseDidLeave = jest.genMockFn();
+    const mouseDidClick = jest.genMockFn();
 
-    var TestBindComponent = React.createClass({
+    const TestBindComponent = React.createClass({
       getInitialState: function() {
         return {something: 'hi'};
       },
@@ -50,20 +50,20 @@ describe('autobinding', function() {
       },
     });
 
-    var instance1 = <TestBindComponent />;
-    var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
-    var rendered1 = reactComponentExpect(mountedInstance1)
+    const instance1 = <TestBindComponent />;
+    const mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
+    const rendered1 = reactComponentExpect(mountedInstance1)
       .expectRenderedChild()
       .instance();
 
-    var instance2 = <TestBindComponent />;
-    var mountedInstance2 = ReactTestUtils.renderIntoDocument(instance2);
-    var rendered2 = reactComponentExpect(mountedInstance2)
+    const instance2 = <TestBindComponent />;
+    const mountedInstance2 = ReactTestUtils.renderIntoDocument(instance2);
+    const rendered2 = reactComponentExpect(mountedInstance2)
       .expectRenderedChild()
       .instance();
 
     expect(function() {
-      var badIdea = instance1.badIdeas.badBind;
+      const badIdea = instance1.badIdeas.badBind;
       badIdea();
     }).toThrow();
 
@@ -95,13 +95,13 @@ describe('autobinding', function() {
   });
 
   it('works with mixins', function() {
-    var mouseDidClick = jest.genMockFn();
+    const mouseDidClick = jest.genMockFn();
 
-    var TestMixin = {
+    const TestMixin = {
       onClick: mouseDidClick,
     };
 
-    var TestBindComponent = React.createClass({
+    const TestBindComponent = React.createClass({
       mixins: [TestMixin],
 
       render: function() {
@@ -109,9 +109,9 @@ describe('autobinding', function() {
       },
     });
 
-    var instance1 = <TestBindComponent />;
-    var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
-    var rendered1 = reactComponentExpect(mountedInstance1)
+    const instance1 = <TestBindComponent />;
+    const mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
+    const rendered1 = reactComponentExpect(mountedInstance1)
       .expectRenderedChild()
       .instance();
 
@@ -123,7 +123,7 @@ describe('autobinding', function() {
   it('warns if you try to bind to this', function() {
     spyOn(console, 'error');
 
-    var TestBindComponent = React.createClass({
+    const TestBindComponent = React.createClass({
       handleClick: function() { },
       render: function() {
         return <div onClick={this.handleClick.bind(this)} />;
@@ -143,7 +143,7 @@ describe('autobinding', function() {
   it('does not warn if you pass an auto-bound method to setState', function() {
     spyOn(console, 'error');
 
-    var TestBindComponent = React.createClass({
+    const TestBindComponent = React.createClass({
       getInitialState: function() {
         return {foo: 1};
       },

--- a/src/isomorphic/classic/class/__tests__/ReactBindOptout-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactBindOptout-test.js
@@ -11,20 +11,20 @@
 /*global global:true*/
 'use strict';
 
-var React = require('React');
-var ReactTestUtils = require('ReactTestUtils');
-var reactComponentExpect = require('reactComponentExpect');
+const React = require('React');
+const ReactTestUtils = require('ReactTestUtils');
+const reactComponentExpect = require('reactComponentExpect');
 
 // TODO: Test render and all stock methods.
 describe('autobind optout', function() {
 
   it('should work with manual binding', function() {
 
-    var mouseDidEnter = jest.genMockFn();
-    var mouseDidLeave = jest.genMockFn();
-    var mouseDidClick = jest.genMockFn();
+    const mouseDidEnter = jest.genMockFn();
+    const mouseDidLeave = jest.genMockFn();
+    const mouseDidClick = jest.genMockFn();
 
-    var TestBindComponent = React.createClass({
+    const TestBindComponent = React.createClass({
       autobind: false,
       getInitialState: function() {
         return {something: 'hi'};
@@ -44,15 +44,15 @@ describe('autobind optout', function() {
       },
     });
 
-    var instance1 = <TestBindComponent />;
-    var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
-    var rendered1 = reactComponentExpect(mountedInstance1)
+    const instance1 = <TestBindComponent />;
+    const mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
+    const rendered1 = reactComponentExpect(mountedInstance1)
       .expectRenderedChild()
       .instance();
 
-    var instance2 = <TestBindComponent />;
-    var mountedInstance2 = ReactTestUtils.renderIntoDocument(instance2);
-    var rendered2 = reactComponentExpect(mountedInstance2)
+    const instance2 = <TestBindComponent />;
+    const mountedInstance2 = ReactTestUtils.renderIntoDocument(instance2);
+    const rendered2 = reactComponentExpect(mountedInstance2)
       .expectRenderedChild()
       .instance();
 
@@ -82,11 +82,11 @@ describe('autobind optout', function() {
   });
 
   it('should not hold reference to instance', function() {
-    var mouseDidClick = function() {
+    const mouseDidClick = function() {
       void this.state.something;
     };
 
-    var TestBindComponent = React.createClass({
+    const TestBindComponent = React.createClass({
       autobind: false,
       getInitialState: function() {
         return {something: 'hi'};
@@ -109,20 +109,20 @@ describe('autobind optout', function() {
       },
     });
 
-    var instance1 = <TestBindComponent />;
-    var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
-    var rendered1 = reactComponentExpect(mountedInstance1)
+    const instance1 = <TestBindComponent />;
+    const mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
+    const rendered1 = reactComponentExpect(mountedInstance1)
       .expectRenderedChild()
       .instance();
 
-    var instance2 = <TestBindComponent />;
-    var mountedInstance2 = ReactTestUtils.renderIntoDocument(instance2);
-    var rendered2 = reactComponentExpect(mountedInstance2)
+    const instance2 = <TestBindComponent />;
+    const mountedInstance2 = ReactTestUtils.renderIntoDocument(instance2);
+    const rendered2 = reactComponentExpect(mountedInstance2)
       .expectRenderedChild()
       .instance();
 
     expect(function() {
-      var badIdea = instance1.badIdeas.badBind;
+      const badIdea = instance1.badIdeas.badBind;
       badIdea();
     }).toThrow();
 
@@ -138,13 +138,13 @@ describe('autobind optout', function() {
   });
 
   it('works with mixins that have not opted out of autobinding', function() {
-    var mouseDidClick = jest.genMockFn();
+    const mouseDidClick = jest.genMockFn();
 
-    var TestMixin = {
+    const TestMixin = {
       onClick: mouseDidClick,
     };
 
-    var TestBindComponent = React.createClass({
+    const TestBindComponent = React.createClass({
       mixins: [TestMixin],
 
       render: function() {
@@ -152,9 +152,9 @@ describe('autobind optout', function() {
       },
     });
 
-    var instance1 = <TestBindComponent />;
-    var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
-    var rendered1 = reactComponentExpect(mountedInstance1)
+    const instance1 = <TestBindComponent />;
+    const mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
+    const rendered1 = reactComponentExpect(mountedInstance1)
       .expectRenderedChild()
       .instance();
 
@@ -164,14 +164,14 @@ describe('autobind optout', function() {
   });
 
   it('works with mixins that have opted out of autobinding', function() {
-    var mouseDidClick = jest.genMockFn();
+    const mouseDidClick = jest.genMockFn();
 
-    var TestMixin = {
+    const TestMixin = {
       autobind: false,
       onClick: mouseDidClick,
     };
 
-    var TestBindComponent = React.createClass({
+    const TestBindComponent = React.createClass({
       mixins: [TestMixin],
 
       render: function() {
@@ -179,9 +179,9 @@ describe('autobind optout', function() {
       },
     });
 
-    var instance1 = <TestBindComponent />;
-    var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
-    var rendered1 = reactComponentExpect(mountedInstance1)
+    const instance1 = <TestBindComponent />;
+    const mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
+    const rendered1 = reactComponentExpect(mountedInstance1)
       .expectRenderedChild()
       .instance();
 
@@ -193,7 +193,7 @@ describe('autobind optout', function() {
   it('does not warn if you try to bind to this', function() {
     spyOn(console, 'error');
 
-    var TestBindComponent = React.createClass({
+    const TestBindComponent = React.createClass({
       autobind: false,
       handleClick: function() { },
       render: function() {
@@ -209,7 +209,7 @@ describe('autobind optout', function() {
   it('does not warn if you pass an manually bound method to setState', function() {
     spyOn(console, 'error');
 
-    var TestBindComponent = React.createClass({
+    const TestBindComponent = React.createClass({
       autobind: false,
       getInitialState: function() {
         return {foo: 1};

--- a/src/isomorphic/classic/class/__tests__/ReactClass-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactClass-test.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
-var ReactTestUtils;
+let React;
+let ReactDOM;
+let ReactTestUtils;
 
 describe('ReactClass-spec', function() {
 
@@ -33,7 +33,7 @@ describe('ReactClass-spec', function() {
   });
 
   it('should copy `displayName` onto the Constructor', function() {
-    var TestComponent = React.createClass({
+    const TestComponent = React.createClass({
       render: function() {
         return <div />;
       },
@@ -44,8 +44,8 @@ describe('ReactClass-spec', function() {
   });
 
   it('should copy prop types onto the Constructor', function() {
-    var propValidator = jest.genMockFn();
-    var TestComponent = React.createClass({
+    const propValidator = jest.genMockFn();
+    const TestComponent = React.createClass({
       propTypes: {
         value: propValidator,
       },
@@ -60,7 +60,7 @@ describe('ReactClass-spec', function() {
   });
 
   it('should warn on invalid prop types', function() {
-    var warn = console.error;
+    const warn = console.error;
     console.error = jest.genMockFn();
     try {
 
@@ -84,7 +84,7 @@ describe('ReactClass-spec', function() {
   });
 
   it('should warn on invalid context types', function() {
-    var warn = console.error;
+    const warn = console.error;
     console.error = jest.genMockFn();
     try {
       React.createClass({
@@ -107,7 +107,7 @@ describe('ReactClass-spec', function() {
   });
 
   it('should throw on invalid child context types', function() {
-    var warn = console.error;
+    const warn = console.error;
     console.error = jest.genMockFn();
     try {
       React.createClass({
@@ -239,7 +239,7 @@ describe('ReactClass-spec', function() {
   });
 
   it('should support statics', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       statics: {
         abc: 'def',
         def: 0,
@@ -254,7 +254,7 @@ describe('ReactClass-spec', function() {
         return <span />;
       },
     });
-    var instance = <Component />;
+    let instance = <Component />;
     instance = ReactTestUtils.renderIntoDocument(instance);
     expect(instance.constructor.abc).toBe('def');
     expect(Component.abc).toBe('def');
@@ -269,7 +269,7 @@ describe('ReactClass-spec', function() {
   });
 
   it('should work with object getInitialState() return values', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       getInitialState: function() {
         return {
           occupation: 'clown',
@@ -279,13 +279,13 @@ describe('ReactClass-spec', function() {
         return <span />;
       },
     });
-    var instance = <Component />;
+    let instance = <Component />;
     instance = ReactTestUtils.renderIntoDocument(instance);
     expect(instance.state.occupation).toEqual('clown');
   });
 
   it('renders based on context getInitialState', function() {
-    var Foo = React.createClass({
+    const Foo = React.createClass({
       contextTypes: {
         className: React.PropTypes.string,
       },
@@ -297,7 +297,7 @@ describe('ReactClass-spec', function() {
       },
     });
 
-    var Outer = React.createClass({
+    const Outer = React.createClass({
       childContextTypes: {
         className: React.PropTypes.string,
       },
@@ -309,14 +309,14 @@ describe('ReactClass-spec', function() {
       },
     });
 
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<Outer />, container);
     expect(container.firstChild.className).toBe('foo');
   });
 
   it('should throw with non-object getInitialState() return values', function() {
     [['an array'], 'a string', 1234].forEach(function(state) {
-      var Component = React.createClass({
+      const Component = React.createClass({
         getInitialState: function() {
           return state;
         },
@@ -324,7 +324,7 @@ describe('ReactClass-spec', function() {
           return <span />;
         },
       });
-      var instance = <Component />;
+      let instance = <Component />;
       expect(function() {
         instance = ReactTestUtils.renderIntoDocument(instance);
       }).toThrow(
@@ -334,7 +334,7 @@ describe('ReactClass-spec', function() {
   });
 
   it('should work with a null getInitialState() return value', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       getInitialState: function() {
         return null;
       },
@@ -348,7 +348,7 @@ describe('ReactClass-spec', function() {
   });
 
   it('should throw when using legacy factories', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       render() {
         return <div />;
       },

--- a/src/isomorphic/classic/class/__tests__/ReactClassMixin-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactClassMixin-test.js
@@ -11,14 +11,14 @@
 
 'use strict';
 
-var React;
-var ReactTestUtils;
+let React;
+let ReactTestUtils;
 
-var TestComponent;
-var TestComponentWithPropTypes;
-var TestComponentWithReverseSpec;
-var mixinPropValidator;
-var componentPropValidator;
+let TestComponent;
+let TestComponentWithPropTypes;
+let TestComponentWithReverseSpec;
+let mixinPropValidator;
+let componentPropValidator;
 
 describe('ReactClass-mixin', function() {
 
@@ -28,7 +28,7 @@ describe('ReactClass-mixin', function() {
     mixinPropValidator = jest.genMockFn();
     componentPropValidator = jest.genMockFn();
 
-    var MixinA = {
+    const MixinA = {
       propTypes: {
         propA: function() {},
       },
@@ -37,7 +37,7 @@ describe('ReactClass-mixin', function() {
       },
     };
 
-    var MixinB = {
+    const MixinB = {
       mixins: [MixinA],
       propTypes: {
         propB: function() {},
@@ -47,14 +47,14 @@ describe('ReactClass-mixin', function() {
       },
     };
 
-    var MixinBWithReverseSpec = {
+    const MixinBWithReverseSpec = {
       componentDidMount: function() {
         this.props.listener('MixinBWithReverseSpec didMount');
       },
       mixins: [MixinA],
     };
 
-    var MixinC = {
+    const MixinC = {
       statics: {
         staticC: function() {},
       },
@@ -63,7 +63,7 @@ describe('ReactClass-mixin', function() {
       },
     };
 
-    var MixinD = {
+    const MixinD = {
       propTypes: {
         value: mixinPropValidator,
       },
@@ -107,11 +107,11 @@ describe('ReactClass-mixin', function() {
   });
 
   it('should support merging propTypes and statics', function() {
-    var listener = jest.genMockFn();
-    var instance = <TestComponent listener={listener} />;
+    const listener = jest.genMockFn();
+    let instance = <TestComponent listener={listener} />;
     instance = ReactTestUtils.renderIntoDocument(instance);
 
-    var instancePropTypes = instance.constructor.propTypes;
+    const instancePropTypes = instance.constructor.propTypes;
 
     expect('propA' in instancePropTypes).toBe(true);
     expect('propB' in instancePropTypes).toBe(true);
@@ -122,8 +122,8 @@ describe('ReactClass-mixin', function() {
   });
 
   it('should support chaining delegate functions', function() {
-    var listener = jest.genMockFn();
-    var instance = <TestComponent listener={listener} />;
+    const listener = jest.genMockFn();
+    let instance = <TestComponent listener={listener} />;
     instance = ReactTestUtils.renderIntoDocument(instance);
 
     expect(listener.mock.calls).toEqual([
@@ -135,8 +135,8 @@ describe('ReactClass-mixin', function() {
   });
 
   it('should chain functions regardless of spec property order', function() {
-    var listener = jest.genMockFn();
-    var instance = <TestComponentWithReverseSpec listener={listener} />;
+    const listener = jest.genMockFn();
+    let instance = <TestComponentWithReverseSpec listener={listener} />;
     instance = ReactTestUtils.renderIntoDocument(instance);
 
     expect(listener.mock.calls).toEqual([
@@ -167,12 +167,12 @@ describe('ReactClass-mixin', function() {
 
 
   it('should support mixins with getInitialState()', function() {
-    var Mixin = {
+    const Mixin = {
       getInitialState: function() {
         return {mixin: true};
       },
     };
-    var Component = React.createClass({
+    const Component = React.createClass({
       mixins: [Mixin],
       getInitialState: function() {
         return {component: true};
@@ -181,19 +181,19 @@ describe('ReactClass-mixin', function() {
         return <span />;
       },
     });
-    var instance = <Component />;
+    let instance = <Component />;
     instance = ReactTestUtils.renderIntoDocument(instance);
     expect(instance.state.component).toBe(true);
     expect(instance.state.mixin).toBe(true);
   });
 
   it('should throw with conflicting getInitialState() methods', function() {
-    var Mixin = {
+    const Mixin = {
       getInitialState: function() {
         return {x: true};
       },
     };
-    var Component = React.createClass({
+    const Component = React.createClass({
       mixins: [Mixin],
       getInitialState: function() {
         return {x: true};
@@ -202,7 +202,7 @@ describe('ReactClass-mixin', function() {
         return <span />;
       },
     });
-    var instance = <Component />;
+    let instance = <Component />;
     expect(function() {
       instance = ReactTestUtils.renderIntoDocument(instance);
     }).toThrow(
@@ -214,12 +214,12 @@ describe('ReactClass-mixin', function() {
   });
 
   it('should not mutate objects returned by getInitialState()', function() {
-    var Mixin = {
+    const Mixin = {
       getInitialState: function() {
         return Object.freeze({mixin: true});
       },
     };
-    var Component = React.createClass({
+    const Component = React.createClass({
       mixins: [Mixin],
       getInitialState: function() {
         return Object.freeze({component: true});
@@ -234,12 +234,12 @@ describe('ReactClass-mixin', function() {
   });
 
   it('should support statics in mixins', function() {
-    var Mixin = {
+    const Mixin = {
       statics: {
         foo: 'bar',
       },
     };
-    var Component = React.createClass({
+    const Component = React.createClass({
       mixins: [Mixin],
 
       statics: {
@@ -250,7 +250,7 @@ describe('ReactClass-mixin', function() {
         return <span />;
       },
     });
-    var instance = <Component />;
+    let instance = <Component />;
     instance = ReactTestUtils.renderIntoDocument(instance);
     expect(instance.constructor.foo).toBe('bar');
     expect(Component.foo).toBe('bar');
@@ -260,7 +260,7 @@ describe('ReactClass-mixin', function() {
 
   it("should throw if mixins override each others' statics", function() {
     expect(function() {
-      var Mixin = {
+      const Mixin = {
         statics: {
           abc: 'foo',
         },
@@ -284,7 +284,7 @@ describe('ReactClass-mixin', function() {
 
   it('should throw if mixins override functions in statics', function() {
     expect(function() {
-      var Mixin = {
+      const Mixin = {
         statics: {
           abc: function() {
             console.log('foo');
@@ -327,7 +327,7 @@ describe('ReactClass-mixin', function() {
 
   it('should throw if the mixin is a React component class', function() {
     expect(function() {
-      var Component = React.createClass({
+      const Component = React.createClass({
         render: function() {
           return <span />;
         },
@@ -347,13 +347,13 @@ describe('ReactClass-mixin', function() {
   });
 
   it('should have bound the mixin methods to the component', function() {
-    var mixin = {
+    const mixin = {
       mixinFunc: function() {
         return this;
       },
     };
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       mixins: [mixin],
       componentDidMount: function() {
         expect(this.mixinFunc()).toBe(this);
@@ -362,17 +362,17 @@ describe('ReactClass-mixin', function() {
         return <span />;
       },
     });
-    var instance = <Component />;
+    let instance = <Component />;
     instance = ReactTestUtils.renderIntoDocument(instance);
   });
 
   it('should include the mixin keys in even if their values are falsy', function() {
-    var mixin = {
+    const mixin = {
       keyWithNullValue: null,
       randomCounter: 0,
     };
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       mixins: [mixin],
       componentDidMount: function() {
         expect(this.randomCounter).toBe(0);
@@ -382,15 +382,15 @@ describe('ReactClass-mixin', function() {
         return <span />;
       },
     });
-    var instance = <Component />;
+    let instance = <Component />;
     instance = ReactTestUtils.renderIntoDocument(instance);
   });
 
   it('should work with a null getInitialState return value and a mixin', () => {
-    var Component;
-    var instance;
+    let Component;
+    let instance;
 
-    var Mixin = {
+    const Mixin = {
       getInitialState: function() {
         return {foo: 'bar'};
       },
@@ -413,7 +413,7 @@ describe('ReactClass-mixin', function() {
     expect(instance.state).toEqual({foo: 'bar'});
 
     // Also the other way round should work
-    var Mixin2 = {
+    const Mixin2 = {
       getInitialState: function() {
         return null;
       },

--- a/src/isomorphic/classic/element/ReactCurrentOwner.js
+++ b/src/isomorphic/classic/element/ReactCurrentOwner.js
@@ -17,7 +17,7 @@
  * The current owner is the component who should own any components that are
  * currently being constructed.
  */
-var ReactCurrentOwner = {
+const ReactCurrentOwner = {
 
   /**
    * @internal

--- a/src/isomorphic/classic/element/ReactDOMFactories.js
+++ b/src/isomorphic/classic/element/ReactDOMFactories.js
@@ -11,10 +11,10 @@
 
 'use strict';
 
-var ReactElement = require('ReactElement');
-var ReactElementValidator = require('ReactElementValidator');
+const ReactElement = require('ReactElement');
+const ReactElementValidator = require('ReactElementValidator');
 
-var mapObject = require('mapObject');
+const mapObject = require('mapObject');
 
 /**
  * Create a factory that creates HTML tag elements.
@@ -35,7 +35,7 @@ function createDOMFactory(tag) {
  *
  * @public
  */
-var ReactDOMFactories = mapObject({
+const ReactDOMFactories = mapObject({
   a: 'a',
   abbr: 'abbr',
   address: 'address',

--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -11,26 +11,26 @@
 
 'use strict';
 
-var ReactCurrentOwner = require('ReactCurrentOwner');
+const ReactCurrentOwner = require('ReactCurrentOwner');
 
-var assign = require('Object.assign');
-var warning = require('warning');
-var canDefineProperty = require('canDefineProperty');
+const assign = require('Object.assign');
+const warning = require('warning');
+const canDefineProperty = require('canDefineProperty');
 
 // The Symbol used to tag the ReactElement type. If there is no native Symbol
 // nor polyfill, then a plain number is used for performance.
-var REACT_ELEMENT_TYPE =
+const REACT_ELEMENT_TYPE =
   (typeof Symbol === 'function' && Symbol.for && Symbol.for('react.element')) ||
   0xeac7;
 
-var RESERVED_PROPS = {
+const RESERVED_PROPS = {
   key: true,
   ref: true,
   __self: true,
   __source: true,
 };
 
-var specialPropKeyWarningShown, specialPropRefWarningShown;
+let specialPropKeyWarningShown, specialPropRefWarningShown;
 
 /**
  * Factory method to create a new React element. This no longer adheres to
@@ -52,8 +52,8 @@ var specialPropKeyWarningShown, specialPropRefWarningShown;
  * @param {*} props
  * @internal
  */
-var ReactElement = function(type, key, ref, self, source, owner, props) {
-  var element = {
+const ReactElement = function(type, key, ref, self, source, owner, props) {
+  const element = {
     // This tag allow us to uniquely identify this as a React Element
     $$typeof: REACT_ELEMENT_TYPE,
 
@@ -115,15 +115,15 @@ var ReactElement = function(type, key, ref, self, source, owner, props) {
 };
 
 ReactElement.createElement = function(type, config, children) {
-  var propName;
+  let propName;
 
   // Reserved names are extracted
-  var props = {};
+  const props = {};
 
-  var key = null;
-  var ref = null;
-  var self = null;
-  var source = null;
+  let key = null;
+  let ref = null;
+  let self = null;
+  let source = null;
 
   if (config != null) {
     if (__DEV__) {
@@ -148,12 +148,12 @@ ReactElement.createElement = function(type, config, children) {
 
   // Children can be more than one argument, and those are transferred onto
   // the newly allocated props object.
-  var childrenLength = arguments.length - 2;
+  const childrenLength = arguments.length - 2;
   if (childrenLength === 1) {
     props.children = children;
   } else if (childrenLength > 1) {
-    var childArray = Array(childrenLength);
-    for (var i = 0; i < childrenLength; i++) {
+    const childArray = Array(childrenLength);
+    for (let i = 0; i < childrenLength; i++) {
       childArray[i] = arguments[i + 2];
     }
     props.children = childArray;
@@ -225,7 +225,7 @@ ReactElement.createElement = function(type, config, children) {
 };
 
 ReactElement.createFactory = function(type) {
-  var factory = ReactElement.createElement.bind(null, type);
+  const factory = ReactElement.createElement.bind(null, type);
   // Expose the type on the factory and the prototype so that it can be
   // easily accessed on elements. E.g. `<Foo />.type === Foo`.
   // This should not be named `constructor` since this may not be the function
@@ -236,7 +236,7 @@ ReactElement.createFactory = function(type) {
 };
 
 ReactElement.cloneAndReplaceKey = function(oldElement, newKey) {
-  var newElement = ReactElement(
+  const newElement = ReactElement(
     oldElement.type,
     newKey,
     oldElement.ref,
@@ -250,7 +250,7 @@ ReactElement.cloneAndReplaceKey = function(oldElement, newKey) {
 };
 
 ReactElement.cloneAndReplaceProps = function(oldElement, newProps) {
-  var newElement = ReactElement(
+  const newElement = ReactElement(
     oldElement.type,
     oldElement.key,
     oldElement.ref,
@@ -269,23 +269,23 @@ ReactElement.cloneAndReplaceProps = function(oldElement, newProps) {
 };
 
 ReactElement.cloneElement = function(element, config, children) {
-  var propName;
+  let propName;
 
   // Original props are copied
-  var props = assign({}, element.props);
+  const props = assign({}, element.props);
 
   // Reserved names are extracted
-  var key = element.key;
-  var ref = element.ref;
+  let key = element.key;
+  let ref = element.ref;
   // Self is preserved since the owner is preserved.
-  var self = element._self;
+  const self = element._self;
   // Source is preserved since cloneElement is unlikely to be targeted by a
   // transpiler, and the original source is probably a better indicator of the
   // true owner.
-  var source = element._source;
+  const source = element._source;
 
   // Owner will be preserved, unless ref is overridden
-  var owner = element._owner;
+  let owner = element._owner;
 
   if (config != null) {
     if (config.ref !== undefined) {
@@ -297,7 +297,7 @@ ReactElement.cloneElement = function(element, config, children) {
       key = '' + config.key;
     }
     // Remaining properties override existing props
-    var defaultProps;
+    let defaultProps;
     if (element.type && element.type.defaultProps) {
       defaultProps = element.type.defaultProps;
     }
@@ -316,12 +316,12 @@ ReactElement.cloneElement = function(element, config, children) {
 
   // Children can be more than one argument, and those are transferred onto
   // the newly allocated props object.
-  var childrenLength = arguments.length - 2;
+  const childrenLength = arguments.length - 2;
   if (childrenLength === 1) {
     props.children = children;
   } else if (childrenLength > 1) {
-    var childArray = Array(childrenLength);
-    for (var i = 0; i < childrenLength; i++) {
+    const childArray = Array(childrenLength);
+    for (let i = 0; i < childrenLength; i++) {
       childArray[i] = arguments[i + 2];
     }
     props.children = childArray;

--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -178,7 +178,7 @@ function validateChildKeys(node, parentType) {
  * @private
  */
 function checkPropTypes(componentName, propTypes, props, location) {
-  for (let propName in propTypes) {
+  for (const propName in propTypes) {
     if (propTypes.hasOwnProperty(propName)) {
       let error;
       // Prop type validation may throw. In case they do, we don't want to

--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -18,19 +18,19 @@
 
 'use strict';
 
-var ReactElement = require('ReactElement');
-var ReactPropTypeLocations = require('ReactPropTypeLocations');
-var ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
-var ReactCurrentOwner = require('ReactCurrentOwner');
+const ReactElement = require('ReactElement');
+const ReactPropTypeLocations = require('ReactPropTypeLocations');
+const ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
+const ReactCurrentOwner = require('ReactCurrentOwner');
 
-var canDefineProperty = require('canDefineProperty');
-var getIteratorFn = require('getIteratorFn');
-var invariant = require('invariant');
-var warning = require('warning');
+const canDefineProperty = require('canDefineProperty');
+const getIteratorFn = require('getIteratorFn');
+const invariant = require('invariant');
+const warning = require('warning');
 
 function getDeclarationErrorAddendum() {
   if (ReactCurrentOwner.current) {
-    var name = ReactCurrentOwner.current.getName();
+    const name = ReactCurrentOwner.current.getName();
     if (name) {
       return ' Check the render method of `' + name + '`.';
     }
@@ -43,9 +43,9 @@ function getDeclarationErrorAddendum() {
  * object keys are not valid. This allows us to keep track of children between
  * updates.
  */
-var ownerHasKeyUseWarning = {};
+const ownerHasKeyUseWarning = {};
 
-var loggedTypeFailures = {};
+const loggedTypeFailures = {};
 
 /**
  * Warn if the element doesn't have an explicit key assigned to it.
@@ -63,7 +63,7 @@ function validateExplicitKey(element, parentType) {
   }
   element._store.validated = true;
 
-  var addenda = getAddendaForKeyUse('uniqueKey', element, parentType);
+  const addenda = getAddendaForKeyUse('uniqueKey', element, parentType);
   if (addenda === null) {
     // we already showed the warning
     return;
@@ -89,16 +89,16 @@ function validateExplicitKey(element, parentType) {
  * if the warning has already been shown before (and shouldn't be shown again).
  */
 function getAddendaForKeyUse(messageType, element, parentType) {
-  var addendum = getDeclarationErrorAddendum();
+  let addendum = getDeclarationErrorAddendum();
   if (!addendum) {
-    var parentName = typeof parentType === 'string' ?
+    const parentName = typeof parentType === 'string' ?
       parentType : parentType.displayName || parentType.name;
     if (parentName) {
       addendum = ` Check the top-level render call using <${parentName}>.`;
     }
   }
 
-  var memoizer = ownerHasKeyUseWarning[messageType] || (
+  const memoizer = ownerHasKeyUseWarning[messageType] || (
     ownerHasKeyUseWarning[messageType] = {}
   );
   if (memoizer[addendum]) {
@@ -106,7 +106,7 @@ function getAddendaForKeyUse(messageType, element, parentType) {
   }
   memoizer[addendum] = true;
 
-  var addenda = {
+  const addenda = {
     parentOrOwner: addendum,
     url: ' See https://fb.me/react-warning-keys for more information.',
     childOwner: null,
@@ -140,8 +140,8 @@ function validateChildKeys(node, parentType) {
     return;
   }
   if (Array.isArray(node)) {
-    for (var i = 0; i < node.length; i++) {
-      var child = node[i];
+    for (let i = 0; i < node.length; i++) {
+      const child = node[i];
       if (ReactElement.isValidElement(child)) {
         validateExplicitKey(child, parentType);
       }
@@ -152,12 +152,12 @@ function validateChildKeys(node, parentType) {
       node._store.validated = true;
     }
   } else if (node) {
-    var iteratorFn = getIteratorFn(node);
+    const iteratorFn = getIteratorFn(node);
     // Entry iterators provide implicit keys.
     if (iteratorFn) {
       if (iteratorFn !== node.entries) {
-        var iterator = iteratorFn.call(node);
-        var step;
+        const iterator = iteratorFn.call(node);
+        let step;
         while (!(step = iterator.next()).done) {
           if (ReactElement.isValidElement(step.value)) {
             validateExplicitKey(step.value, parentType);
@@ -178,9 +178,9 @@ function validateChildKeys(node, parentType) {
  * @private
  */
 function checkPropTypes(componentName, propTypes, props, location) {
-  for (var propName in propTypes) {
+  for (let propName in propTypes) {
     if (propTypes.hasOwnProperty(propName)) {
-      var error;
+      let error;
       // Prop type validation may throw. In case they do, we don't want to
       // fail the render phase where it didn't fail before. So we log it.
       // After these have been cleaned up, we'll let them throw.
@@ -216,7 +216,7 @@ function checkPropTypes(componentName, propTypes, props, location) {
         // same error.
         loggedTypeFailures[error.message] = true;
 
-        var addendum = getDeclarationErrorAddendum();
+        const addendum = getDeclarationErrorAddendum();
         warning(false, 'Failed propType: %s%s', error.message, addendum);
       }
     }
@@ -230,11 +230,11 @@ function checkPropTypes(componentName, propTypes, props, location) {
  * @param {ReactElement} element
  */
 function validatePropTypes(element) {
-  var componentClass = element.type;
+  const componentClass = element.type;
   if (typeof componentClass !== 'function') {
     return;
   }
-  var name = componentClass.displayName || componentClass.name;
+  const name = componentClass.displayName || componentClass.name;
   if (componentClass.propTypes) {
     checkPropTypes(
       name,
@@ -252,10 +252,10 @@ function validatePropTypes(element) {
   }
 }
 
-var ReactElementValidator = {
+const ReactElementValidator = {
 
   createElement: function(type, props, children) {
-    var validType = typeof type === 'string' || typeof type === 'function';
+    const validType = typeof type === 'string' || typeof type === 'function';
     // We warn in this case but don't throw. We expect the element creation to
     // succeed and there will likely be errors in render.
     warning(
@@ -266,7 +266,7 @@ var ReactElementValidator = {
       getDeclarationErrorAddendum()
     );
 
-    var element = ReactElement.createElement.apply(this, arguments);
+    const element = ReactElement.createElement.apply(this, arguments);
 
     // The result can be nullish if a mock or a custom function is used.
     // TODO: Drop this when these are no longer allowed as the type argument.
@@ -280,7 +280,7 @@ var ReactElementValidator = {
     // (Rendering will throw with a helpful message and as soon as the type is
     // fixed, the key warnings will appear.)
     if (validType) {
-      for (var i = 2; i < arguments.length; i++) {
+      for (let i = 2; i < arguments.length; i++) {
         validateChildKeys(arguments[i], type);
       }
     }
@@ -291,7 +291,7 @@ var ReactElementValidator = {
   },
 
   createFactory: function(type) {
-    var validatedFactory = ReactElementValidator.createElement.bind(
+    const validatedFactory = ReactElementValidator.createElement.bind(
       null,
       type
     );
@@ -326,8 +326,8 @@ var ReactElementValidator = {
   },
 
   cloneElement: function(element, props, children) {
-    var newElement = ReactElement.cloneElement.apply(this, arguments);
-    for (var i = 2; i < arguments.length; i++) {
+    const newElement = ReactElement.cloneElement.apply(this, arguments);
+    for (let i = 2; i < arguments.length; i++) {
       validateChildKeys(arguments[i], newElement.type);
     }
     validatePropTypes(newElement);

--- a/src/isomorphic/classic/element/__tests__/ReactElement-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElement-test.js
@@ -14,13 +14,13 @@
 // NOTE: We're explicitly not using JSX in this file. This is intended to test
 // classic JS without JSX.
 
-var React;
-var ReactDOM;
-var ReactTestUtils;
+let React;
+let ReactDOM;
+let ReactTestUtils;
 
 describe('ReactElement', function() {
-  var ComponentClass;
-  var originalSymbol;
+  let ComponentClass;
+  let originalSymbol;
 
   beforeEach(function() {
     jest.resetModuleRegistry();
@@ -49,24 +49,24 @@ describe('ReactElement', function() {
   });
 
   it('returns a complete element according to spec', function() {
-    var element = React.createFactory(ComponentClass)();
+    const element = React.createFactory(ComponentClass)();
     expect(element.type).toBe(ComponentClass);
     expect(element.key).toBe(null);
     expect(element.ref).toBe(null);
-    var expectation = {};
+    const expectation = {};
     Object.freeze(expectation);
     expect(element.props).toEqual(expectation);
   });
 
   it('should warn when `key` is being accessed', function() {
     spyOn(console, 'error');
-    var container = document.createElement('div');
-    var Child = React.createClass({
+    const container = document.createElement('div');
+    const Child = React.createClass({
       render: function() {
         return <div> {this.props.key} </div>;
       },
     });
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       render: function() {
         return (
           <div>
@@ -90,13 +90,13 @@ describe('ReactElement', function() {
 
   it('should warn when `ref` is being accessed', function() {
     spyOn(console, 'error');
-    var container = document.createElement('div');
-    var Child = React.createClass({
+    const container = document.createElement('div');
+    const Child = React.createClass({
       render: function() {
         return <div> {this.props.ref} </div>;
       },
     });
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       render: function() {
         return (
           <div>
@@ -117,30 +117,30 @@ describe('ReactElement', function() {
   });
 
   it('allows a string to be passed as the type', function() {
-    var element = React.createFactory('div')();
+    const element = React.createFactory('div')();
     expect(element.type).toBe('div');
     expect(element.key).toBe(null);
     expect(element.ref).toBe(null);
-    var expectation = {};
+    const expectation = {};
     Object.freeze(expectation);
     expect(element.props).toEqual(expectation);
   });
 
   it('returns an immutable element', function() {
-    var element = React.createFactory(ComponentClass)();
+    const element = React.createFactory(ComponentClass)();
     expect(() => element.type = 'div').toThrow();
   });
 
   it('does not reuse the original config object', function() {
-    var config = {foo: 1};
-    var element = React.createFactory(ComponentClass)(config);
+    const config = {foo: 1};
+    const element = React.createFactory(ComponentClass)(config);
     expect(element.props.foo).toBe(1);
     config.foo = 2;
     expect(element.props.foo).toBe(1);
   });
 
   it('extracts key and ref from the config', function() {
-    var element = React.createFactory(ComponentClass)({
+    const element = React.createFactory(ComponentClass)({
       key: '12',
       ref: '34',
       foo: '56',
@@ -148,36 +148,36 @@ describe('ReactElement', function() {
     expect(element.type).toBe(ComponentClass);
     expect(element.key).toBe('12');
     expect(element.ref).toBe('34');
-    var expectation = {foo:'56'};
+    const expectation = {foo:'56'};
     Object.freeze(expectation);
     expect(element.props).toEqual(expectation);
   });
 
   it('coerces the key to a string', function() {
-    var element = React.createFactory(ComponentClass)({
+    const element = React.createFactory(ComponentClass)({
       key: 12,
       foo: '56',
     });
     expect(element.type).toBe(ComponentClass);
     expect(element.key).toBe('12');
     expect(element.ref).toBe(null);
-    var expectation = {foo:'56'};
+    const expectation = {foo:'56'};
     Object.freeze(expectation);
     expect(element.props).toEqual(expectation);
   });
 
   it('preserves the owner on the element', function() {
-    var Component = React.createFactory(ComponentClass);
-    var element;
+    const Component = React.createFactory(ComponentClass);
+    let element;
 
-    var Wrapper = React.createClass({
+    const Wrapper = React.createClass({
       render: function() {
         element = Component();
         return element;
       },
     });
 
-    var instance = ReactTestUtils.renderIntoDocument(
+    const instance = ReactTestUtils.renderIntoDocument(
       React.createElement(Wrapper)
     );
 
@@ -186,8 +186,8 @@ describe('ReactElement', function() {
 
   it('merges an additional argument onto the children prop', function() {
     spyOn(console, 'error');
-    var a = 1;
-    var element = React.createFactory(ComponentClass)({
+    const a = 1;
+    const element = React.createFactory(ComponentClass)({
       children: 'text',
     }, a);
     expect(element.props.children).toBe(a);
@@ -196,7 +196,7 @@ describe('ReactElement', function() {
 
   it('does not override children if no rest args are provided', function() {
     spyOn(console, 'error');
-    var element = React.createFactory(ComponentClass)({
+    const element = React.createFactory(ComponentClass)({
       children: 'text',
     });
     expect(element.props.children).toBe('text');
@@ -205,7 +205,7 @@ describe('ReactElement', function() {
 
   it('overrides children if null is provided as an argument', function() {
     spyOn(console, 'error');
-    var element = React.createFactory(ComponentClass)({
+    const element = React.createFactory(ComponentClass)({
       children: 'text',
     }, null);
     expect(element.props.children).toBe(null);
@@ -214,10 +214,10 @@ describe('ReactElement', function() {
 
   it('merges rest arguments onto the children prop in an array', function() {
     spyOn(console, 'error');
-    var a = 1;
-    var b = 2;
-    var c = 3;
-    var element = React.createFactory(ComponentClass)(null, a, b, c);
+    const a = 1;
+    const b = 2;
+    const c = 3;
+    const element = React.createFactory(ComponentClass)(null, a, b, c);
     expect(element.props.children).toEqual([1, 2, 3]);
     expect(console.error.argsForCall.length).toBe(0);
   });
@@ -225,7 +225,7 @@ describe('ReactElement', function() {
   it('allows static methods to be called using the type property', function() {
     spyOn(console, 'error');
 
-    var StaticMethodComponentClass = React.createClass({
+    const StaticMethodComponentClass = React.createClass({
       statics: {
         someStaticMethod: function() {
           return 'someReturnValue';
@@ -239,13 +239,13 @@ describe('ReactElement', function() {
       },
     });
 
-    var element = React.createElement(StaticMethodComponentClass);
+    const element = React.createElement(StaticMethodComponentClass);
     expect(element.type.someStaticMethod()).toBe('someReturnValue');
     expect(console.error.argsForCall.length).toBe(0);
   });
 
   it('identifies valid elements', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         return React.createElement('div');
       },
@@ -264,7 +264,7 @@ describe('ReactElement', function() {
     expect(React.isValidElement(Component)).toEqual(false);
     expect(React.isValidElement({ type: 'div', props: {} })).toEqual(false);
 
-    var jsonElement = JSON.stringify(React.createElement('div'));
+    const jsonElement = JSON.stringify(React.createElement('div'));
     expect(React.isValidElement(JSON.parse(jsonElement))).toBe(true);
   });
 
@@ -272,7 +272,7 @@ describe('ReactElement', function() {
     // TODO: This test was added to cover a special case where we proxied
     // methods. However, we don't do that any more so this test can probably
     // be removed. Leaving it in classic as a safety precaution.
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: () => null,
       statics: {
         specialType: React.PropTypes.shape({monkey: React.PropTypes.any}),
@@ -284,13 +284,13 @@ describe('ReactElement', function() {
   });
 
   it('is indistinguishable from a plain object', function() {
-    var element = React.createElement('div', {className: 'foo'});
-    var object = {};
+    const element = React.createElement('div', {className: 'foo'});
+    const object = {};
     expect(element.constructor).toBe(object.constructor);
   });
 
   it('should use default prop value when removing a prop', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       getDefaultProps: function() {
         return {fruit: 'persimmon'};
       },
@@ -299,8 +299,8 @@ describe('ReactElement', function() {
       },
     });
 
-    var container = document.createElement('div');
-    var instance = ReactDOM.render(
+    const container = document.createElement('div');
+    const instance = ReactDOM.render(
       React.createElement(Component, {fruit: 'mango'}),
       container
     );
@@ -311,7 +311,7 @@ describe('ReactElement', function() {
   });
 
   it('should normalize props with default values', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       getDefaultProps: function() {
         return {prop: 'testKey'};
       },
@@ -320,19 +320,19 @@ describe('ReactElement', function() {
       },
     });
 
-    var instance = ReactTestUtils.renderIntoDocument(
+    const instance = ReactTestUtils.renderIntoDocument(
       React.createElement(Component)
     );
     expect(instance.props.prop).toBe('testKey');
 
-    var inst2 = ReactTestUtils.renderIntoDocument(
+    const inst2 = ReactTestUtils.renderIntoDocument(
       React.createElement(Component, {prop: null})
     );
     expect(inst2.props.prop).toBe(null);
   });
 
   it('should normalize props with default values in cloning', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       getDefaultProps: function() {
         return {prop: 'testKey'};
       },
@@ -341,23 +341,23 @@ describe('ReactElement', function() {
       },
     });
 
-    var instance = React.createElement(Component);
-    var clonedInstance = React.cloneElement(instance, {prop: undefined});
+    const instance = React.createElement(Component);
+    const clonedInstance = React.cloneElement(instance, {prop: undefined});
     expect(clonedInstance.props.prop).toBe('testKey');
-    var clonedInstance2 = React.cloneElement(instance, {prop: null});
+    const clonedInstance2 = React.cloneElement(instance, {prop: null});
     expect(clonedInstance2.props.prop).toBe(null);
 
-    var instance2 = React.createElement(Component, {prop: 'newTestKey'});
-    var cloneInstance3 = React.cloneElement(instance2, {prop: undefined});
+    const instance2 = React.createElement(Component, {prop: 'newTestKey'});
+    const cloneInstance3 = React.cloneElement(instance2, {prop: undefined});
     expect(cloneInstance3.props.prop).toBe('testKey');
-    var cloneInstance4 = React.cloneElement(instance2, {});
+    const cloneInstance4 = React.cloneElement(instance2, {});
     expect(cloneInstance4.props.prop).toBe('newTestKey');
   });
 
   it('throws when changing a prop (in dev) after element creation', function() {
-    var Outer = React.createClass({
+    const Outer = React.createClass({
       render: function() {
-        var el = <div className="moo" />;
+        const el = <div className="moo" />;
 
         expect(function() {
           el.props.className = 'quack';
@@ -367,16 +367,16 @@ describe('ReactElement', function() {
         return el;
       },
     });
-    var outer = ReactTestUtils.renderIntoDocument(<Outer color="orange" />);
+    const outer = ReactTestUtils.renderIntoDocument(<Outer color="orange" />);
     expect(ReactDOM.findDOMNode(outer).className).toBe('moo');
   });
 
   it('throws when adding a prop (in dev) after element creation', function() {
-    var container = document.createElement('div');
-    var Outer = React.createClass({
+    const container = document.createElement('div');
+    const Outer = React.createClass({
       getDefaultProps: () => ({sound: 'meow'}),
       render: function() {
-        var el = <div>{this.props.sound}</div>;
+        const el = <div>{this.props.sound}</div>;
 
         expect(function() {
           el.props.className = 'quack';
@@ -387,19 +387,19 @@ describe('ReactElement', function() {
         return el;
       },
     });
-    var outer = ReactDOM.render(<Outer />, container);
+    const outer = ReactDOM.render(<Outer />, container);
     expect(ReactDOM.findDOMNode(outer).textContent).toBe('meow');
     expect(ReactDOM.findDOMNode(outer).className).toBe('');
   });
 
   it('does not warn for NaN props', function() {
     spyOn(console, 'error');
-    var Test = React.createClass({
+    const Test = React.createClass({
       render: function() {
         return <div />;
       },
     });
-    var test = ReactTestUtils.renderIntoDocument(<Test value={+undefined} />);
+    const test = ReactTestUtils.renderIntoDocument(<Test value={+undefined} />);
     expect(test.props.value).toBeNaN();
     expect(console.error.argsForCall.length).toBe(0);
   });
@@ -408,8 +408,8 @@ describe('ReactElement', function() {
     // Rudimentary polyfill
     // Once all jest engines support Symbols natively we can swap this to test
     // WITH native Symbols by default.
-    var REACT_ELEMENT_TYPE = function() {}; // fake Symbol
-    var OTHER_SYMBOL = function() {}; // another fake Symbol
+    const REACT_ELEMENT_TYPE = function() {}; // fake Symbol
+    const OTHER_SYMBOL = function() {}; // another fake Symbol
     global.Symbol = function(name) {
       return OTHER_SYMBOL;
     };
@@ -424,7 +424,7 @@ describe('ReactElement', function() {
 
     React = require('React');
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         return React.createElement('div');
       },
@@ -443,14 +443,14 @@ describe('ReactElement', function() {
     expect(React.isValidElement(Component)).toEqual(false);
     expect(React.isValidElement({ type: 'div', props: {} })).toEqual(false);
 
-    var jsonElement = JSON.stringify(React.createElement('div'));
+    const jsonElement = JSON.stringify(React.createElement('div'));
     expect(React.isValidElement(JSON.parse(jsonElement))).toBe(false);
   });
 
 });
 
 describe('comparing jsx vs .createFactory() vs .createElement()', function() {
-  var Child;
+  let Child;
 
   beforeEach(function() {
     jest.resetModuleRegistry();
@@ -462,7 +462,7 @@ describe('comparing jsx vs .createFactory() vs .createElement()', function() {
 
 
   describe('when using jsx only', function() {
-    var Parent, instance;
+    let Parent, instance;
     beforeEach(function() {
       Parent = React.createClass({
         render: function() {
@@ -477,7 +477,7 @@ describe('comparing jsx vs .createFactory() vs .createElement()', function() {
     });
 
     it('should scry children but cannot', function() {
-      var children = ReactTestUtils.scryRenderedComponentsWithType(instance, Child);
+      const children = ReactTestUtils.scryRenderedComponentsWithType(instance, Child);
       expect(children.length).toBe(1);
     });
 
@@ -491,10 +491,10 @@ describe('comparing jsx vs .createFactory() vs .createElement()', function() {
   });
 
   describe('when using parent that uses .createFactory()', function() {
-    var factory, instance;
+    let factory, instance;
     beforeEach(function() {
-      var childFactory = React.createFactory(Child);
-      var Parent = React.createClass({
+      const childFactory = React.createFactory(Child);
+      const Parent = React.createClass({
         render: function() {
           return React.DOM.div({}, childFactory({ ref: 'child', foo: 'foo value' }, 'children value'));
         },
@@ -504,7 +504,7 @@ describe('comparing jsx vs .createFactory() vs .createElement()', function() {
     });
 
     it('can properly scry children', function() {
-      var children = ReactTestUtils.scryRenderedComponentsWithType(instance, Child);
+      const children = ReactTestUtils.scryRenderedComponentsWithType(instance, Child);
       expect(children.length).toBe(1);
     });
 
@@ -518,9 +518,9 @@ describe('comparing jsx vs .createFactory() vs .createElement()', function() {
   });
 
   describe('when using parent that uses .createElement()', function() {
-    var factory, instance;
+    let factory, instance;
     beforeEach(function() {
-      var Parent = React.createClass({
+      const Parent = React.createClass({
         render: function() {
           return React.DOM.div({}, React.createElement(Child, { ref: 'child', foo: 'foo value' }, 'children value'));
         },
@@ -530,7 +530,7 @@ describe('comparing jsx vs .createFactory() vs .createElement()', function() {
     });
 
     it('should scry children but cannot', function() {
-      var children = ReactTestUtils.scryRenderedComponentsWithType(instance, Child);
+      const children = ReactTestUtils.scryRenderedComponentsWithType(instance, Child);
       expect(children.length).toBe(1);
     });
 

--- a/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
-var ReactTestUtils;
+let React;
+let ReactDOM;
+let ReactTestUtils;
 
 describe('ReactElementClone', function() {
 
@@ -24,12 +24,12 @@ describe('ReactElementClone', function() {
   });
 
   it('should clone a DOM component with new props', function() {
-    var Grandparent = React.createClass({
+    const Grandparent = React.createClass({
       render: function() {
         return <Parent child={<div className="child" />} />;
       },
     });
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       render: function() {
         return (
           <div className="parent">
@@ -38,22 +38,22 @@ describe('ReactElementClone', function() {
         );
       },
     });
-    var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
+    const component = ReactTestUtils.renderIntoDocument(<Grandparent />);
     expect(ReactDOM.findDOMNode(component).childNodes[0].className).toBe('xyz');
   });
 
   it('should clone a composite component with new props', function() {
-    var Child = React.createClass({
+    const Child = React.createClass({
       render: function() {
         return <div className={this.props.className} />;
       },
     });
-    var Grandparent = React.createClass({
+    const Grandparent = React.createClass({
       render: function() {
         return <Parent child={<Child className="child" />} />;
       },
     });
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       render: function() {
         return (
           <div className="parent">
@@ -62,18 +62,18 @@ describe('ReactElementClone', function() {
         );
       },
     });
-    var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
+    const component = ReactTestUtils.renderIntoDocument(<Grandparent />);
     expect(ReactDOM.findDOMNode(component).childNodes[0].className).toBe('xyz');
   });
 
   it('should keep the original ref if it is not overridden', function() {
-    var Grandparent = React.createClass({
+    const Grandparent = React.createClass({
       render: function() {
         return <Parent child={<div ref="yolo" />} />;
       },
     });
 
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       render: function() {
         return (
           <div>
@@ -83,22 +83,22 @@ describe('ReactElementClone', function() {
       },
     });
 
-    var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
+    const component = ReactTestUtils.renderIntoDocument(<Grandparent />);
     expect(component.refs.yolo.tagName).toBe('DIV');
   });
 
   it('should transfer the key property', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         return null;
       },
     });
-    var clone = React.cloneElement(<Component />, {key: 'xyz'});
+    const clone = React.cloneElement(<Component />, {key: 'xyz'});
     expect(clone.key).toBe('xyz');
   });
 
   it('should transfer children', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         expect(this.props.children).toBe('xyz');
         return <div />;
@@ -111,7 +111,7 @@ describe('ReactElementClone', function() {
   });
 
   it('should shallow clone children', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         expect(this.props.children).toBe('xyz');
         return <div />;
@@ -124,13 +124,13 @@ describe('ReactElementClone', function() {
   });
 
   it('should accept children as rest arguments', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         return null;
       },
     });
 
-    var clone = React.cloneElement(
+    const clone = React.cloneElement(
       <Component>xyz</Component>,
       { children: <Component /> },
       <div />,
@@ -144,9 +144,9 @@ describe('ReactElementClone', function() {
   });
 
   it('should support keys and refs', function() {
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       render: function() {
-        var clone =
+        const clone =
           React.cloneElement(this.props.children, {key: 'xyz', ref: 'xyz'});
         expect(clone.key).toBe('xyz');
         expect(clone.ref).toBe('xyz');
@@ -154,37 +154,37 @@ describe('ReactElementClone', function() {
       },
     });
 
-    var Grandparent = React.createClass({
+    const Grandparent = React.createClass({
       render: function() {
         return <Parent ref="parent"><span key="abc" /></Parent>;
       },
     });
 
-    var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
+    const component = ReactTestUtils.renderIntoDocument(<Grandparent />);
     expect(component.refs.parent.refs.xyz.tagName).toBe('SPAN');
   });
 
   it('should steal the ref if a new ref is specified', function() {
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       render: function() {
-        var clone = React.cloneElement(this.props.children, {ref: 'xyz'});
+        const clone = React.cloneElement(this.props.children, {ref: 'xyz'});
         return <div>{clone}</div>;
       },
     });
 
-    var Grandparent = React.createClass({
+    const Grandparent = React.createClass({
       render: function() {
         return <Parent ref="parent"><span ref="child" /></Parent>;
       },
     });
 
-    var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
+    const component = ReactTestUtils.renderIntoDocument(<Grandparent />);
     expect(component.refs.child).toBeUndefined();
     expect(component.refs.parent.refs.xyz.tagName).toBe('SPAN');
   });
 
   it('should overwrite props', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         expect(this.props.myprop).toBe('xyz');
         return <div />;
@@ -233,7 +233,7 @@ describe('ReactElementClone', function() {
 
   it('should check declared prop types after clone', function() {
     spyOn(console, 'error');
-    var Component = React.createClass({
+    const Component = React.createClass({
       propTypes: {
         color: React.PropTypes.string.isRequired,
       },
@@ -241,12 +241,12 @@ describe('ReactElementClone', function() {
         return React.createElement('div', null, 'My color is ' + this.color);
       },
     });
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       render: function() {
         return React.cloneElement(this.props.child, {color: 123});
       },
     });
-    var GrandParent = React.createClass({
+    const GrandParent = React.createClass({
       render: function() {
         return React.createElement(
           Parent,

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -14,12 +14,12 @@
 // NOTE: We're explicitly not using JSX in this file. This is intended to test
 // classic JS without JSX.
 
-var React;
-var ReactDOM;
-var ReactTestUtils;
+let React;
+let ReactDOM;
+let ReactTestUtils;
 
 describe('ReactElementValidator', function() {
-  var ComponentClass;
+  let ComponentClass;
 
   beforeEach(function() {
     jest.resetModuleRegistry();
@@ -36,7 +36,7 @@ describe('ReactElementValidator', function() {
 
   it('warns for keys for arrays of elements in rest args', function() {
     spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
+    const Component = React.createFactory(ComponentClass);
 
     Component(null, [Component(), Component()]);
 
@@ -48,18 +48,18 @@ describe('ReactElementValidator', function() {
 
   it('warns for keys for arrays of elements with owner info', function() {
     spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
+    const Component = React.createFactory(ComponentClass);
 
-    var InnerClass = React.createClass({
+    const InnerClass = React.createClass({
       displayName: 'InnerClass',
       render: function() {
         return Component(null, this.props.childSet);
       },
     });
 
-    var InnerComponent = React.createFactory(InnerClass);
+    const InnerComponent = React.createFactory(InnerClass);
 
-    var ComponentWrapper = React.createClass({
+    const ComponentWrapper = React.createClass({
       displayName: 'ComponentWrapper',
       render: function() {
         return InnerComponent({childSet: [Component(), Component()] });
@@ -81,14 +81,14 @@ describe('ReactElementValidator', function() {
   it('warns for keys for arrays with no owner or parent info', function() {
     spyOn(console, 'error');
 
-    var Anonymous = React.createClass({
+    const Anonymous = React.createClass({
       displayName: undefined,
       render: function() {
         return <div />;
       },
     });
 
-    var divs = [
+    const divs = [
       <div />,
       <div />,
     ];
@@ -104,7 +104,7 @@ describe('ReactElementValidator', function() {
   it('warns for keys for arrays of elements with no owner info', function() {
     spyOn(console, 'error');
 
-    var divs = [
+    const divs = [
       <div />,
       <div />,
     ];
@@ -121,7 +121,7 @@ describe('ReactElementValidator', function() {
   it('does not warn for keys when passing children down', function() {
     spyOn(console, 'error');
 
-    var Wrapper = React.createClass({
+    const Wrapper = React.createClass({
       render: function() {
         return (
           <div>
@@ -144,14 +144,14 @@ describe('ReactElementValidator', function() {
 
   it('warns for keys for iterables of elements in rest args', function() {
     spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
+    const Component = React.createFactory(ComponentClass);
 
-    var iterable = {
+    const iterable = {
       '@@iterator': function() {
-        var i = 0;
+        let i = 0;
         return {
           next: function() {
-            var done = ++i > 2;
+            const done = ++i > 2;
             return {value: done ? undefined : Component(), done: done};
           },
         };
@@ -168,7 +168,7 @@ describe('ReactElementValidator', function() {
 
   it('does not warns for arrays of elements with keys', function() {
     spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
+    const Component = React.createFactory(ComponentClass);
 
     Component(null, [Component({key: '#1'}), Component({key: '#2'})]);
 
@@ -177,14 +177,14 @@ describe('ReactElementValidator', function() {
 
   it('does not warns for iterable elements with keys', function() {
     spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
+    const Component = React.createFactory(ComponentClass);
 
-    var iterable = {
+    const iterable = {
       '@@iterator': function() {
-        var i = 0;
+        let i = 0;
         return {
           next: function() {
-            var done = ++i > 2;
+            const done = ++i > 2;
             return {
               value: done ? undefined : Component({key: '#' + i}),
               done: done,
@@ -201,7 +201,7 @@ describe('ReactElementValidator', function() {
 
   it('does not warn when the element is directly in rest args', function() {
     spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
+    const Component = React.createFactory(ComponentClass);
 
     Component(null, Component(), Component());
 
@@ -210,7 +210,7 @@ describe('ReactElementValidator', function() {
 
   it('does not warn when the array contains a non-element', function() {
     spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
+    const Component = React.createFactory(ComponentClass);
 
     Component(null, [{}, {}]);
 
@@ -225,7 +225,7 @@ describe('ReactElementValidator', function() {
     // component, we give a small hint as to which parent instantiated that
     // component as per warnings about key usage in ReactElementValidator.
     spyOn(console, 'error');
-    var MyComp = React.createClass({
+    const MyComp = React.createClass({
       propTypes: {
         color: React.PropTypes.string,
       },
@@ -233,7 +233,7 @@ describe('ReactElementValidator', function() {
         return React.createElement('div', null, 'My color is ' + this.color);
       },
     });
-    var ParentComp = React.createClass({
+    const ParentComp = React.createClass({
       render: function() {
         return React.createElement(MyComp, {color: 123});
       },
@@ -279,7 +279,7 @@ describe('ReactElementValidator', function() {
 
   it('includes the owner name when passing null, undefined, boolean, or number', function() {
     spyOn(console, 'error');
-    var ParentComp = React.createClass({
+    const ParentComp = React.createClass({
       render: function() {
         return React.createElement(null);
       },
@@ -303,7 +303,7 @@ describe('ReactElementValidator', function() {
   it('should check default prop values', function() {
     spyOn(console, 'error');
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       propTypes: {prop: React.PropTypes.string.isRequired},
       getDefaultProps: function() {
         return {prop: null};
@@ -325,7 +325,7 @@ describe('ReactElementValidator', function() {
   it('should not check the default for explicit null', function() {
     spyOn(console, 'error');
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       propTypes: {prop: React.PropTypes.string.isRequired},
       getDefaultProps: function() {
         return {prop: 'text'};
@@ -349,7 +349,7 @@ describe('ReactElementValidator', function() {
   it('should check declared prop types', function() {
     spyOn(console, 'error');
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       propTypes: {
         prop: React.PropTypes.string.isRequired,
       },
@@ -388,7 +388,7 @@ describe('ReactElementValidator', function() {
   it('should warn if a PropType creator is used as a PropType', function() {
     spyOn(console, 'error');
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       propTypes: {
         myProp: React.PropTypes.shape,
       },
@@ -413,12 +413,12 @@ describe('ReactElementValidator', function() {
 
   it('should warn when accessing .type on an element factory', function() {
     spyOn(console, 'error');
-    var TestComponent = React.createClass({
+    const TestComponent = React.createClass({
       render: function() {
         return <div />;
       },
     });
-    var TestFactory = React.createFactory(TestComponent);
+    const TestFactory = React.createFactory(TestComponent);
     expect(TestFactory.type).toBe(TestComponent);
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toBe(
@@ -432,7 +432,7 @@ describe('ReactElementValidator', function() {
 
   it('does not warn when using DOM node as children', function() {
     spyOn(console, 'error');
-    var DOMContainer = React.createClass({
+    const DOMContainer = React.createClass({
       render: function() {
         return <div />;
       },
@@ -441,7 +441,7 @@ describe('ReactElementValidator', function() {
       },
     });
 
-    var node = document.createElement('div');
+    const node = document.createElement('div');
     // This shouldn't cause a stack overflow or any other problems (#3883)
     ReactTestUtils.renderIntoDocument(<DOMContainer>{node}</DOMContainer>);
     expect(console.error.argsForCall.length).toBe(0);
@@ -471,7 +471,7 @@ describe('ReactElementValidator', function() {
     // We don't suggest this since it silences all sorts of warnings, but we
     // shouldn't blow up either.
 
-    var child = {
+    const child = {
       $$typeof: (<div />).$$typeof,
       type: 'span',
       key: null,
@@ -485,7 +485,7 @@ describe('ReactElementValidator', function() {
 
   it('does not blow up on key warning with undefined type', function() {
     spyOn(console, 'error');
-    var Foo = undefined;
+    const Foo = undefined;
     void <Foo>{[<div />]}</Foo>;
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toBe(

--- a/src/isomorphic/classic/types/ReactPropTypeLocationNames.js
+++ b/src/isomorphic/classic/types/ReactPropTypeLocationNames.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var ReactPropTypeLocationNames = {};
+let ReactPropTypeLocationNames = {};
 
 if (__DEV__) {
   ReactPropTypeLocationNames = {

--- a/src/isomorphic/classic/types/ReactPropTypeLocations.js
+++ b/src/isomorphic/classic/types/ReactPropTypeLocations.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-var keyMirror = require('keyMirror');
+const keyMirror = require('keyMirror');
 
-var ReactPropTypeLocations = keyMirror({
+const ReactPropTypeLocations = keyMirror({
   prop: null,
   context: null,
   childContext: null,

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -249,7 +249,7 @@ function createObjectOfTypeChecker(typeChecker) {
         `\`${propType}\` supplied to \`${componentName}\`, expected an object.`
       );
     }
-    for (let key in propValue) {
+    for (const key in propValue) {
       if (propValue.hasOwnProperty(key)) {
         const error = typeChecker(
           propValue,
@@ -321,7 +321,7 @@ function createShapeTypeChecker(shapeTypes) {
         `supplied to \`${componentName}\`, expected \`object\`.`
       );
     }
-    for (let key in shapeTypes) {
+    for (const key in shapeTypes) {
       const checker = shapeTypes[key];
       if (!checker) {
         continue;

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-var ReactElement = require('ReactElement');
-var ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
+const ReactElement = require('ReactElement');
+const ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
 
-var emptyFunction = require('emptyFunction');
-var getIteratorFn = require('getIteratorFn');
+const emptyFunction = require('emptyFunction');
+const getIteratorFn = require('getIteratorFn');
 
 /**
  * Collection of methods that allow declaration and validation of props that are
@@ -64,9 +64,9 @@ var getIteratorFn = require('getIteratorFn');
  * @internal
  */
 
-var ANONYMOUS = '<<anonymous>>';
+const ANONYMOUS = '<<anonymous>>';
 
-var ReactPropTypes = {
+const ReactPropTypes = {
   array: createPrimitiveTypeChecker('array'),
   bool: createPrimitiveTypeChecker('boolean'),
   func: createPrimitiveTypeChecker('function'),
@@ -97,7 +97,7 @@ function createChainableTypeChecker(validate) {
     componentName = componentName || ANONYMOUS;
     propFullName = propFullName || propName;
     if (props[propName] == null) {
-      var locationName = ReactPropTypeLocationNames[location];
+      const locationName = ReactPropTypeLocationNames[location];
       if (isRequired) {
         return new Error(
           `Required ${locationName} \`${propFullName}\` was not specified in ` +
@@ -110,7 +110,7 @@ function createChainableTypeChecker(validate) {
     }
   }
 
-  var chainedCheckType = checkType.bind(null, false);
+  const chainedCheckType = checkType.bind(null, false);
   chainedCheckType.isRequired = checkType.bind(null, true);
 
   return chainedCheckType;
@@ -118,14 +118,14 @@ function createChainableTypeChecker(validate) {
 
 function createPrimitiveTypeChecker(expectedType) {
   function validate(props, propName, componentName, location, propFullName) {
-    var propValue = props[propName];
-    var propType = getPropType(propValue);
+    const propValue = props[propName];
+    const propType = getPropType(propValue);
     if (propType !== expectedType) {
-      var locationName = ReactPropTypeLocationNames[location];
+      const locationName = ReactPropTypeLocationNames[location];
       // `propValue` being instance of, say, date/regexp, pass the 'object'
       // check, but we can offer a more precise error message here rather than
       // 'of type `object`'.
-      var preciseType = getPreciseType(propValue);
+      const preciseType = getPreciseType(propValue);
 
       return new Error(
         `Invalid ${locationName} \`${propFullName}\` of type ` +
@@ -149,17 +149,17 @@ function createArrayOfTypeChecker(typeChecker) {
         `Property \`${propFullName}\` of component \`${componentName}\` has invalid PropType notation inside arrayOf.`
       );
     }
-    var propValue = props[propName];
+    const propValue = props[propName];
     if (!Array.isArray(propValue)) {
-      var locationName = ReactPropTypeLocationNames[location];
-      var propType = getPropType(propValue);
+      const locationName = ReactPropTypeLocationNames[location];
+      const propType = getPropType(propValue);
       return new Error(
         `Invalid ${locationName} \`${propFullName}\` of type ` +
         `\`${propType}\` supplied to \`${componentName}\`, expected an array.`
       );
     }
-    for (var i = 0; i < propValue.length; i++) {
-      var error = typeChecker(
+    for (let i = 0; i < propValue.length; i++) {
+      const error = typeChecker(
         propValue,
         i,
         componentName,
@@ -178,7 +178,7 @@ function createArrayOfTypeChecker(typeChecker) {
 function createElementTypeChecker() {
   function validate(props, propName, componentName, location, propFullName) {
     if (!ReactElement.isValidElement(props[propName])) {
-      var locationName = ReactPropTypeLocationNames[location];
+      const locationName = ReactPropTypeLocationNames[location];
       return new Error(
         `Invalid ${locationName} \`${propFullName}\` supplied to ` +
         `\`${componentName}\`, expected a single ReactElement.`
@@ -192,9 +192,9 @@ function createElementTypeChecker() {
 function createInstanceTypeChecker(expectedClass) {
   function validate(props, propName, componentName, location, propFullName) {
     if (!(props[propName] instanceof expectedClass)) {
-      var locationName = ReactPropTypeLocationNames[location];
-      var expectedClassName = expectedClass.name || ANONYMOUS;
-      var actualClassName = getClassName(props[propName]);
+      const locationName = ReactPropTypeLocationNames[location];
+      const expectedClassName = expectedClass.name || ANONYMOUS;
+      const actualClassName = getClassName(props[propName]);
       return new Error(
         `Invalid ${locationName} \`${propFullName}\` of type ` +
         `\`${actualClassName}\` supplied to \`${componentName}\`, expected ` +
@@ -216,15 +216,15 @@ function createEnumTypeChecker(expectedValues) {
   }
 
   function validate(props, propName, componentName, location, propFullName) {
-    var propValue = props[propName];
-    for (var i = 0; i < expectedValues.length; i++) {
+    const propValue = props[propName];
+    for (let i = 0; i < expectedValues.length; i++) {
       if (propValue === expectedValues[i]) {
         return null;
       }
     }
 
-    var locationName = ReactPropTypeLocationNames[location];
-    var valuesString = JSON.stringify(expectedValues);
+    const locationName = ReactPropTypeLocationNames[location];
+    const valuesString = JSON.stringify(expectedValues);
     return new Error(
       `Invalid ${locationName} \`${propFullName}\` of value \`${propValue}\` ` +
       `supplied to \`${componentName}\`, expected one of ${valuesString}.`
@@ -240,18 +240,18 @@ function createObjectOfTypeChecker(typeChecker) {
         `Property \`${propFullName}\` of component \`${componentName}\` has invalid PropType notation inside objectOf.`
       );
     }
-    var propValue = props[propName];
-    var propType = getPropType(propValue);
+    const propValue = props[propName];
+    const propType = getPropType(propValue);
     if (propType !== 'object') {
-      var locationName = ReactPropTypeLocationNames[location];
+      const locationName = ReactPropTypeLocationNames[location];
       return new Error(
         `Invalid ${locationName} \`${propFullName}\` of type ` +
         `\`${propType}\` supplied to \`${componentName}\`, expected an object.`
       );
     }
-    for (var key in propValue) {
+    for (let key in propValue) {
       if (propValue.hasOwnProperty(key)) {
-        var error = typeChecker(
+        const error = typeChecker(
           propValue,
           key,
           componentName,
@@ -278,8 +278,8 @@ function createUnionTypeChecker(arrayOfTypeCheckers) {
   }
 
   function validate(props, propName, componentName, location, propFullName) {
-    for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
-      var checker = arrayOfTypeCheckers[i];
+    for (let i = 0; i < arrayOfTypeCheckers.length; i++) {
+      const checker = arrayOfTypeCheckers[i];
       if (
         checker(props, propName, componentName, location, propFullName) == null
       ) {
@@ -287,7 +287,7 @@ function createUnionTypeChecker(arrayOfTypeCheckers) {
       }
     }
 
-    var locationName = ReactPropTypeLocationNames[location];
+    const locationName = ReactPropTypeLocationNames[location];
     return new Error(
       `Invalid ${locationName} \`${propFullName}\` supplied to ` +
       `\`${componentName}\`.`
@@ -299,7 +299,7 @@ function createUnionTypeChecker(arrayOfTypeCheckers) {
 function createNodeChecker() {
   function validate(props, propName, componentName, location, propFullName) {
     if (!isNode(props[propName])) {
-      var locationName = ReactPropTypeLocationNames[location];
+      const locationName = ReactPropTypeLocationNames[location];
       return new Error(
         `Invalid ${locationName} \`${propFullName}\` supplied to ` +
         `\`${componentName}\`, expected a ReactNode.`
@@ -312,21 +312,21 @@ function createNodeChecker() {
 
 function createShapeTypeChecker(shapeTypes) {
   function validate(props, propName, componentName, location, propFullName) {
-    var propValue = props[propName];
-    var propType = getPropType(propValue);
+    const propValue = props[propName];
+    const propType = getPropType(propValue);
     if (propType !== 'object') {
-      var locationName = ReactPropTypeLocationNames[location];
+      const locationName = ReactPropTypeLocationNames[location];
       return new Error(
         `Invalid ${locationName} \`${propFullName}\` of type \`${propType}\` ` +
         `supplied to \`${componentName}\`, expected \`object\`.`
       );
     }
-    for (var key in shapeTypes) {
-      var checker = shapeTypes[key];
+    for (let key in shapeTypes) {
+      const checker = shapeTypes[key];
       if (!checker) {
         continue;
       }
-      var error = checker(
+      const error = checker(
         propValue,
         key,
         componentName,
@@ -358,10 +358,10 @@ function isNode(propValue) {
         return true;
       }
 
-      var iteratorFn = getIteratorFn(propValue);
+      const iteratorFn = getIteratorFn(propValue);
       if (iteratorFn) {
-        var iterator = iteratorFn.call(propValue);
-        var step;
+        const iterator = iteratorFn.call(propValue);
+        let step;
         if (iteratorFn !== propValue.entries) {
           while (!(step = iterator.next()).done) {
             if (!isNode(step.value)) {
@@ -371,7 +371,7 @@ function isNode(propValue) {
         } else {
           // Iterator will provide entry [k,v] tuples rather than values.
           while (!(step = iterator.next()).done) {
-            var entry = step.value;
+            const entry = step.value;
             if (entry) {
               if (!isNode(entry[1])) {
                 return false;
@@ -391,7 +391,7 @@ function isNode(propValue) {
 
 // Equivalent of `typeof` but with special handling for array and regexp.
 function getPropType(propValue) {
-  var propType = typeof propValue;
+  const propType = typeof propValue;
   if (Array.isArray(propValue)) {
     return 'array';
   }
@@ -407,7 +407,7 @@ function getPropType(propValue) {
 // This handles more types than `getPropType`. Only used for error messages.
 // See `createPrimitiveTypeChecker`.
 function getPreciseType(propValue) {
-  var propType = getPropType(propValue);
+  const propType = getPropType(propValue);
   if (propType === 'object') {
     if (propValue instanceof Date) {
       return 'date';

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -11,20 +11,20 @@
 
 'use strict';
 
-var PropTypes;
-var React;
-var ReactFragment;
-var ReactPropTypeLocations;
-var ReactTestUtils;
+let PropTypes;
+let React;
+let ReactFragment;
+let ReactPropTypeLocations;
+let ReactTestUtils;
 
-var Component;
-var MyComponent;
-var requiredMessage =
+let Component;
+let MyComponent;
+const requiredMessage =
   'Required prop `testProp` was not specified in `testComponent`.';
 
 function typeCheckFail(declaration, value, message) {
-  var props = {testProp: value};
-  var error = declaration(
+  const props = {testProp: value};
+  const error = declaration(
     props,
     'testProp',
     'testComponent',
@@ -35,8 +35,8 @@ function typeCheckFail(declaration, value, message) {
 }
 
 function typeCheckPass(declaration, value) {
-  var props = {testProp: value};
-  var error = declaration(
+  const props = {testProp: value};
+  const error = declaration(
     props,
     'testProp',
     'testComponent',
@@ -176,7 +176,7 @@ describe('ReactPropTypes', function() {
 
     it('should warn with invalid complex types', function() {
       function Thing() {}
-      var name = Thing.name || '<<anonymous>>';
+      const name = Thing.name || '<<anonymous>>';
 
       typeCheckFail(
         PropTypes.arrayOf(PropTypes.instanceOf(Thing)),
@@ -249,7 +249,7 @@ describe('ReactPropTypes', function() {
     });
 
     it('should not support multiple components or scalar values', () => {
-      var message = 'Invalid prop `testProp` supplied to `testComponent`, ' +
+      const message = 'Invalid prop `testProp` supplied to `testComponent`, ' +
         'expected a single ReactElement.';
       typeCheckFail(PropTypes.element, [<div />, <div />], message);
       typeCheckFail(PropTypes.element, 123, message);
@@ -258,14 +258,14 @@ describe('ReactPropTypes', function() {
     });
 
     it('should be able to define a single child as label', () => {
-      var instance = <Component label={<div />} />;
+      let instance = <Component label={<div />} />;
       instance = ReactTestUtils.renderIntoDocument(instance);
 
       expect(console.error.argsForCall.length).toBe(0);
     });
 
     it('should warn when passing no label and isRequired is set', () => {
-      var instance = <Component />;
+      let instance = <Component />;
       instance = ReactTestUtils.renderIntoDocument(instance);
 
       expect(console.error.argsForCall.length).toBe(1);
@@ -286,9 +286,9 @@ describe('ReactPropTypes', function() {
     it('should warn for invalid instances', function() {
       function Person() {}
       function Cat() {}
-      var personName = Person.name || '<<anonymous>>';
-      var dateName = Date.name || '<<anonymous>>';
-      var regExpName = RegExp.name || '<<anonymous>>';
+      const personName = Person.name || '<<anonymous>>';
+      const dateName = Date.name || '<<anonymous>>';
+      const regExpName = RegExp.name || '<<anonymous>>';
 
       typeCheckFail(
         PropTypes.instanceOf(Person),
@@ -371,7 +371,7 @@ describe('ReactPropTypes', function() {
     });
 
     it('should warn for invalid values', function() {
-      var failMessage = 'Invalid prop `testProp` supplied to ' +
+      const failMessage = 'Invalid prop `testProp` supplied to ' +
         '`testComponent`, expected a ReactNode.';
       typeCheckFail(PropTypes.node, true, failMessage);
       typeCheckFail(PropTypes.node, function() {}, failMessage);
@@ -396,7 +396,7 @@ describe('ReactPropTypes', function() {
       ]);
 
       // Object of renderable things
-      var frag = ReactFragment.create;
+      const frag = ReactFragment.create;
       typeCheckPass(PropTypes.node, frag({
         k0: 123,
         k1: 'Some string',
@@ -413,12 +413,12 @@ describe('ReactPropTypes', function() {
     });
 
     it('should not warn for iterables', function() {
-      var iterable = {
+      const iterable = {
         '@@iterator': function() {
-          var i = 0;
+          let i = 0;
           return {
             next: function() {
-              var done = ++i > 2;
+              const done = ++i > 2;
               return {value: done ? undefined : <MyComponent />, done: done};
             },
           };
@@ -429,12 +429,12 @@ describe('ReactPropTypes', function() {
     });
 
     it('should not warn for entry iterables', function() {
-      var iterable = {
+      const iterable = {
         '@@iterator': function() {
-          var i = 0;
+          let i = 0;
           return {
             next: function() {
-              var done = ++i > 2;
+              const done = ++i > 2;
               return {value: done ? undefined : ['#' + i, <MyComponent />], done: done};
             },
           };
@@ -513,7 +513,7 @@ describe('ReactPropTypes', function() {
 
     it('should warn with invalid complex types', function() {
       function Thing() {}
-      var name = Thing.name || '<<anonymous>>';
+      const name = Thing.name || '<<anonymous>>';
 
       typeCheckFail(
         PropTypes.objectOf(PropTypes.instanceOf(Thing)),
@@ -643,7 +643,7 @@ describe('ReactPropTypes', function() {
         'Invalid prop `testProp` supplied to `testComponent`.'
       );
 
-      var checker = PropTypes.oneOfType([
+      const checker = PropTypes.oneOfType([
         PropTypes.shape({a: PropTypes.number.isRequired}),
         PropTypes.shape({b: PropTypes.number.isRequired}),
       ]);
@@ -655,7 +655,7 @@ describe('ReactPropTypes', function() {
     });
 
     it('should not warn if one of the types are valid', function() {
-      var checker = PropTypes.oneOfType([
+      let checker = PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number,
       ]);
@@ -785,7 +785,7 @@ describe('ReactPropTypes', function() {
     });
 
     it('should have been called with the right params', function() {
-      var spy = jasmine.createSpy();
+      const spy = jasmine.createSpy();
       Component = React.createClass({
         propTypes: {num: spy},
 
@@ -794,7 +794,7 @@ describe('ReactPropTypes', function() {
         },
       });
 
-      var instance = <Component num={5} />;
+      let instance = <Component num={5} />;
       instance = ReactTestUtils.renderIntoDocument(instance);
 
       expect(spy.argsForCall.length).toBe(2); // temp double validation
@@ -803,7 +803,7 @@ describe('ReactPropTypes', function() {
     });
 
     it('should have been called even if the prop is not present', function() {
-      var spy = jasmine.createSpy();
+      const spy = jasmine.createSpy();
       Component = React.createClass({
         propTypes: {num: spy},
 
@@ -812,14 +812,14 @@ describe('ReactPropTypes', function() {
         },
       });
 
-      var instance = <Component bla={5} />;
+      let instance = <Component bla={5} />;
       instance = ReactTestUtils.renderIntoDocument(instance);
 
       expect(spy.argsForCall.length).toBe(2); // temp double validation
     });
 
     it('should have received the validator\'s return value', function() {
-      var spy = jasmine.createSpy().andCallFake(
+      const spy = jasmine.createSpy().andCallFake(
         function(props, propName, componentName) {
           if (props[propName] !== 5) {
             return new Error('num must be 5!');
@@ -834,7 +834,7 @@ describe('ReactPropTypes', function() {
         },
       });
 
-      var instance = <Component num={6} />;
+      let instance = <Component num={6} />;
       instance = ReactTestUtils.renderIntoDocument(instance);
       expect(console.error.argsForCall.length).toBe(1);
       expect(console.error.argsForCall[0][0]).toBe(
@@ -844,7 +844,7 @@ describe('ReactPropTypes', function() {
 
     it('should not warn if the validator returned null',
       function() {
-        var spy = jasmine.createSpy().andCallFake(
+        const spy = jasmine.createSpy().andCallFake(
           function(props, propName, componentName) {
             return null;
           }
@@ -857,7 +857,7 @@ describe('ReactPropTypes', function() {
           },
         });
 
-        var instance = <Component num={5} />;
+        let instance = <Component num={5} />;
         instance = ReactTestUtils.renderIntoDocument(instance);
         expect(console.error.argsForCall.length).toBe(0);
       }

--- a/src/isomorphic/deprecated/OrderedMap.js
+++ b/src/isomorphic/deprecated/OrderedMap.js
@@ -237,7 +237,7 @@ const OrderedMapMethods = {
     let i = 0;
     assertValidRangeIndices(start, length, this.length);
     const end = start + length - 1;
-    for (let key in thisSet) {
+    for (const key in thisSet) {
       if (thisSet.hasOwnProperty(key)) {
         if (i >= start) {
           if (i > end) {
@@ -295,7 +295,7 @@ const OrderedMapMethods = {
     const thisSet = this._normalizedObj;
     let i = 0;
     const end = start + length - 1;
-    for (let key in thisSet) {
+    for (const key in thisSet) {
       if (thisSet.hasOwnProperty(key)) {
         if (i >= start) {
           if (i > end) {
@@ -423,7 +423,7 @@ const OrderedMapMethods = {
   toArray: function() {
     const result = [];
     const thisSet = this._normalizedObj;
-    for (let key in thisSet) {
+    for (const key in thisSet) {
       if (thisSet.hasOwnProperty(key)) {
         result.push(thisSet[key]);
       }
@@ -465,7 +465,7 @@ const OrderedMapMethods = {
     var indexByKey = this._computedPositions.indexByKey;
     let index = 0;
     const thisSet = this._normalizedObj;
-    for (let key in thisSet) {
+    for (const key in thisSet) {
       if (thisSet.hasOwnProperty(key)) {
         keyByIndex[index] = key;
         indexByKey[key] = index;

--- a/src/isomorphic/deprecated/OrderedMap.js
+++ b/src/isomorphic/deprecated/OrderedMap.js
@@ -11,10 +11,10 @@
 
 'use strict';
 
-var assign = require('Object.assign');
-var invariant = require('invariant');
+const assign = require('Object.assign');
+const invariant = require('invariant');
 
-var PREFIX = 'key:';
+const PREFIX = 'key:';
 
 /**
  * Utility to extract a backing object from an initialization `Array`, allowing
@@ -28,12 +28,12 @@ var PREFIX = 'key:';
  * @throws Exception if the initialization array has duplicate extracted keys.
  */
 function extractObjectFromArray(arr, keyExtractor) {
-  var normalizedObj = {};
-  for (var i = 0; i < arr.length; i++) {
-    var item = arr[i];
-    var key = keyExtractor(item);
+  const normalizedObj = {};
+  for (let i = 0; i < arr.length; i++) {
+    const item = arr[i];
+    const key = keyExtractor(item);
     assertValidPublicKey(key);
-    var normalizedKey = PREFIX + key;
+    const normalizedKey = PREFIX + key;
     invariant(
       !(normalizedKey in normalizedObj),
       'OrderedMap: IDs returned by the key extraction function must be unique.'
@@ -126,9 +126,9 @@ function _fromNormalizedObjects(a, b) {
     'OrderedMap: Corrupted instance of OrderedMap detected.'
   );
 
-  var newSet = {};
-  var length = 0;
-  var key;
+  const newSet = {};
+  let length = 0;
+  let key;
   for (key in a) {
     if (a.hasOwnProperty(key)) {
       newSet[key] = a[key];
@@ -158,7 +158,7 @@ function _fromNormalizedObjects(a, b) {
  * TODO: Create faster implementation of merging/mapping from original Array,
  * without having to first create an object - simply for the sake of merging.
  */
-var OrderedMapMethods = {
+const OrderedMapMethods = {
 
   /**
    * Returns whether or not a given key is present in the map.
@@ -169,7 +169,7 @@ var OrderedMapMethods = {
    */
   has: function(key) {
     assertValidPublicKey(key);
-    var normalizedKey = PREFIX + key;
+    const normalizedKey = PREFIX + key;
     return normalizedKey in this._normalizedObj;
   },
 
@@ -183,7 +183,7 @@ var OrderedMapMethods = {
    */
   get: function(key) {
     assertValidPublicKey(key);
-    var normalizedKey = PREFIX + key;
+    const normalizedKey = PREFIX + key;
     return this.has(key) ? this._normalizedObj[normalizedKey] : undefined;
   },
 
@@ -232,18 +232,18 @@ var OrderedMapMethods = {
    * @return {OrderedMap} OrderedMap resulting from mapping the range.
    */
   mapRange: function(cb, start, length, context) {
-    var thisSet = this._normalizedObj;
-    var newSet = {};
-    var i = 0;
+    const thisSet = this._normalizedObj;
+    const newSet = {};
+    let i = 0;
     assertValidRangeIndices(start, length, this.length);
-    var end = start + length - 1;
-    for (var key in thisSet) {
+    const end = start + length - 1;
+    for (let key in thisSet) {
       if (thisSet.hasOwnProperty(key)) {
         if (i >= start) {
           if (i > end) {
             break;
           }
-          var item = thisSet[key];
+          const item = thisSet[key];
           newSet[key] = cb.call(context, item, key.substr(PREFIX.length), i);
         }
         i++;
@@ -274,11 +274,11 @@ var OrderedMapMethods = {
    * @return {OrderedMap} OrderedMap resulting from filtering the range.
    */
   filterRange: function(cb, start, length, context) {
-    var newSet = {};
-    var newSetLength = 0;
+    const newSet = {};
+    let newSetLength = 0;
     this.forEachRange(function(item, key, originalIndex) {
       if (cb.call(context, item, key, originalIndex)) {
-        var normalizedKey = PREFIX + key;
+        const normalizedKey = PREFIX + key;
         newSet[normalizedKey] = item;
         newSetLength++;
       }
@@ -292,16 +292,16 @@ var OrderedMapMethods = {
 
   forEachRange: function(cb, start, length, context) {
     assertValidRangeIndices(start, length, this.length);
-    var thisSet = this._normalizedObj;
-    var i = 0;
-    var end = start + length - 1;
-    for (var key in thisSet) {
+    const thisSet = this._normalizedObj;
+    let i = 0;
+    const end = start + length - 1;
+    for (let key in thisSet) {
       if (thisSet.hasOwnProperty(key)) {
         if (i >= start) {
           if (i > end) {
             break;
           }
-          var item = thisSet[key];
+          const item = thisSet[key];
           cb.call(context, item, key.substr(PREFIX.length), i);
         }
         i++;
@@ -316,8 +316,8 @@ var OrderedMapMethods = {
    * zero in terms of two keys and that is confusing.
    */
   mapKeyRange: function(cb, startKey, endKey, context) {
-    var startIndex = this.indexOfKey(startKey);
-    var endIndex = this.indexOfKey(endKey);
+    const startIndex = this.indexOfKey(startKey);
+    const endIndex = this.indexOfKey(endKey);
     invariant(
       startIndex !== undefined && endIndex !== undefined,
       'mapKeyRange must be given keys that are present.'
@@ -330,8 +330,8 @@ var OrderedMapMethods = {
   },
 
   forEachKeyRange: function(cb, startKey, endKey, context) {
-    var startIndex = this.indexOfKey(startKey);
-    var endIndex = this.indexOfKey(endKey);
+    const startIndex = this.indexOfKey(startKey);
+    const endIndex = this.indexOfKey(endKey);
     invariant(
       startIndex !== undefined && endIndex !== undefined,
       'forEachKeyRange must be given keys that are present.'
@@ -350,8 +350,8 @@ var OrderedMapMethods = {
    * not in map.
    */
   keyAtIndex: function(pos) {
-    var computedPositions = this._getOrComputePositions();
-    var keyAtPos = computedPositions.keyByIndex[pos];
+    const computedPositions = this._getOrComputePositions();
+    const keyAtPos = computedPositions.keyByIndex[pos];
     return keyAtPos ? keyAtPos.substr(PREFIX.length) : undefined;
   },
 
@@ -383,7 +383,7 @@ var OrderedMapMethods = {
    * @throws Error if `key` is not in this `OrderedMap`.
    */
   nthKeyAfter: function(key, n) {
-    var curIndex = this.indexOfKey(key);
+    const curIndex = this.indexOfKey(key);
     invariant(
       curIndex !== undefined,
       'OrderedMap.nthKeyAfter: The key `%s` does not exist in this instance.',
@@ -410,9 +410,9 @@ var OrderedMapMethods = {
    */
   indexOfKey: function(key) {
     assertValidPublicKey(key);
-    var normalizedKey = PREFIX + key;
-    var computedPositions = this._getOrComputePositions();
-    var computedPosition = computedPositions.indexByKey[normalizedKey];
+    const normalizedKey = PREFIX + key;
+    const computedPositions = this._getOrComputePositions();
+    const computedPosition = computedPositions.indexByKey[normalizedKey];
     // Just writing it this way to make it clear this is intentional.
     return computedPosition === undefined ? undefined : computedPosition;
   },
@@ -421,9 +421,9 @@ var OrderedMapMethods = {
    * @return {Array} An ordered array of this object's values.
    */
   toArray: function() {
-    var result = [];
-    var thisSet = this._normalizedObj;
-    for (var key in thisSet) {
+    const result = [];
+    const thisSet = this._normalizedObj;
+    for (let key in thisSet) {
       if (thisSet.hasOwnProperty(key)) {
         result.push(thisSet[key]);
       }
@@ -444,7 +444,7 @@ var OrderedMapMethods = {
   _getOrComputePositions: function() {
     // TODO: Entertain computing this at construction time in some less
     // performance critical paths.
-    var computedPositions = this._computedPositions;
+    const computedPositions = this._computedPositions;
     if (!computedPositions) {
       this._computePositions();
     }
@@ -463,9 +463,9 @@ var OrderedMapMethods = {
     };
     var keyByIndex = this._computedPositions.keyByIndex;
     var indexByKey = this._computedPositions.indexByKey;
-    var index = 0;
-    var thisSet = this._normalizedObj;
-    for (var key in thisSet) {
+    let index = 0;
+    const thisSet = this._normalizedObj;
+    for (let key in thisSet) {
       if (thisSet.hasOwnProperty(key)) {
         keyByIndex[index] = key;
         indexByKey[key] = index;
@@ -477,7 +477,7 @@ var OrderedMapMethods = {
 
 assign(OrderedMapImpl.prototype, OrderedMapMethods);
 
-var OrderedMap = {
+const OrderedMap = {
   from: function(orderedMap) {
     invariant(
       orderedMap instanceof OrderedMapImpl,

--- a/src/isomorphic/deprecated/ReactPropTransferer.js
+++ b/src/isomorphic/deprecated/ReactPropTransferer.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-var assign = require('Object.assign');
-var emptyFunction = require('emptyFunction');
-var joinClasses = require('joinClasses');
+const assign = require('Object.assign');
+const emptyFunction = require('emptyFunction');
+const joinClasses = require('joinClasses');
 
 /**
  * Creates a transfer strategy that will merge prop values using the supplied
@@ -32,7 +32,7 @@ function createTransferStrategy(mergeStrategy) {
   };
 }
 
-var transferStrategyMerge = createTransferStrategy(function(a, b) {
+const transferStrategyMerge = createTransferStrategy(function(a, b) {
   // `merge` overrides the first object's (`props[key]` above) keys using the
   // second object's (`value`) keys. An object's style's existing `propA` would
   // get overridden. Flip the order here.
@@ -44,7 +44,7 @@ var transferStrategyMerge = createTransferStrategy(function(a, b) {
  * NOTE: if you add any more exceptions to this list you should be sure to
  * update `cloneWithProps()` accordingly.
  */
-var TransferStrategies = {
+const TransferStrategies = {
   /**
    * Never transfer `children`.
    */
@@ -68,12 +68,12 @@ var TransferStrategies = {
  * @return {object}
  */
 function transferInto(props, newProps) {
-  for (var thisKey in newProps) {
+  for (let thisKey in newProps) {
     if (!newProps.hasOwnProperty(thisKey)) {
       continue;
     }
 
-    var transferStrategy = TransferStrategies[thisKey];
+    const transferStrategy = TransferStrategies[thisKey];
 
     if (transferStrategy && TransferStrategies.hasOwnProperty(thisKey)) {
       transferStrategy(props, thisKey, newProps[thisKey]);
@@ -90,7 +90,7 @@ function transferInto(props, newProps) {
  *
  * @class ReactPropTransferer
  */
-var ReactPropTransferer = {
+const ReactPropTransferer = {
 
   /**
    * Merge two props objects using TransferStrategies.

--- a/src/isomorphic/deprecated/ReactPropTransferer.js
+++ b/src/isomorphic/deprecated/ReactPropTransferer.js
@@ -68,7 +68,7 @@ const TransferStrategies = {
  * @return {object}
  */
 function transferInto(props, newProps) {
-  for (let thisKey in newProps) {
+  for (const thisKey in newProps) {
     if (!newProps.hasOwnProperty(thisKey)) {
       continue;
     }

--- a/src/isomorphic/modern/class/ReactComponent.js
+++ b/src/isomorphic/modern/class/ReactComponent.js
@@ -11,12 +11,12 @@
 
 'use strict';
 
-var ReactNoopUpdateQueue = require('ReactNoopUpdateQueue');
+const ReactNoopUpdateQueue = require('ReactNoopUpdateQueue');
 
-var canDefineProperty = require('canDefineProperty');
-var emptyObject = require('emptyObject');
-var invariant = require('invariant');
-var warning = require('warning');
+const canDefineProperty = require('canDefineProperty');
+const emptyObject = require('emptyObject');
+const invariant = require('invariant');
+const warning = require('warning');
 
 /**
  * Base class helpers for the updating state of a component.
@@ -105,7 +105,7 @@ ReactComponent.prototype.forceUpdate = function(callback) {
  * modern base class. Instead, we define a getter that warns if it's accessed.
  */
 if (__DEV__) {
-  var deprecatedAPIs = {
+  const deprecatedAPIs = {
     isMounted: [
       'isMounted',
       'Instead, make sure to clean up subscriptions and pending requests in ' +
@@ -117,7 +117,7 @@ if (__DEV__) {
       'https://github.com/facebook/react/issues/3236).',
     ],
   };
-  var defineDeprecationWarning = function(methodName, info) {
+  const defineDeprecationWarning = function(methodName, info) {
     if (canDefineProperty) {
       Object.defineProperty(ReactComponent.prototype, methodName, {
         get: function() {
@@ -132,7 +132,7 @@ if (__DEV__) {
       });
     }
   };
-  for (var fnName in deprecatedAPIs) {
+  for (let fnName in deprecatedAPIs) {
     if (deprecatedAPIs.hasOwnProperty(fnName)) {
       defineDeprecationWarning(fnName, deprecatedAPIs[fnName]);
     }

--- a/src/isomorphic/modern/class/ReactComponent.js
+++ b/src/isomorphic/modern/class/ReactComponent.js
@@ -132,7 +132,7 @@ if (__DEV__) {
       });
     }
   };
-  for (let fnName in deprecatedAPIs) {
+  for (const fnName in deprecatedAPIs) {
     if (deprecatedAPIs.hasOwnProperty(fnName)) {
       defineDeprecationWarning(fnName, deprecatedAPIs[fnName]);
     }

--- a/src/isomorphic/modern/class/ReactNoopUpdateQueue.js
+++ b/src/isomorphic/modern/class/ReactNoopUpdateQueue.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var warning = require('warning');
+const warning = require('warning');
 
 function warnTDZ(publicInstance, callerName) {
   if (__DEV__) {
@@ -30,7 +30,7 @@ function warnTDZ(publicInstance, callerName) {
 /**
  * This is the abstract API for an update queue.
  */
-var ReactNoopUpdateQueue = {
+const ReactNoopUpdateQueue = {
 
   /**
    * Checks whether or not this composite component is mounted.

--- a/src/isomorphic/modern/class/__tests__/ReactClassEquivalence-test.js
+++ b/src/isomorphic/modern/class/__tests__/ReactClassEquivalence-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var MetaMatchers = require('MetaMatchers');
+const MetaMatchers = require('MetaMatchers');
 
 describe('ReactClassEquivalence', function() {
 
@@ -19,9 +19,9 @@ describe('ReactClassEquivalence', function() {
     this.addMatchers(MetaMatchers);
   });
 
-  var es6 = () => require('./ReactES6Class-test.js');
-  var coffee = () => require('./ReactCoffeeScriptClass-test.coffee');
-  var ts = () => require('./ReactTypeScriptClass-test.ts');
+  const es6 = () => require('./ReactES6Class-test.js');
+  const coffee = () => require('./ReactCoffeeScriptClass-test.coffee');
+  const ts = () => require('./ReactTypeScriptClass-test.ts');
 
   it('tests the same thing for es6 classes and CoffeeScript', function() {
     expect(coffee).toEqualSpecsIn(es6);

--- a/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
+++ b/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
@@ -11,19 +11,19 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
+let React;
+let ReactDOM;
 
 describe('ReactES6Class', function() {
 
-  var container;
-  var freeze = function(expectation) {
+  let container;
+  const freeze = function(expectation) {
     Object.freeze(expectation);
     return expectation;
   };
-  var Inner;
-  var attachedListener = null;
-  var renderedName = null;
+  let Inner;
+  let attachedListener = null;
+  let renderedName = null;
 
   beforeEach(function() {
     React = require('React');
@@ -44,7 +44,7 @@ describe('ReactES6Class', function() {
   });
 
   function test(element, expectedTag, expectedClassName) {
-    var instance = ReactDOM.render(element, container);
+    const instance = ReactDOM.render(element, container);
     expect(container.firstChild).not.toBeNull();
     expect(container.firstChild.tagName).toBe(expectedTag);
     expect(container.firstChild.className).toBe(expectedClassName);
@@ -107,7 +107,7 @@ describe('ReactES6Class', function() {
         return <span className={this.state.bar} />;
       }
     }
-    var instance = test(<Foo initialValue="foo" />, 'DIV', 'foo');
+    const instance = test(<Foo initialValue="foo" />, 'DIV', 'foo');
     instance.changeState();
     test(<Foo />, 'SPAN', 'bar');
   });
@@ -119,7 +119,7 @@ describe('ReactES6Class', function() {
         this.state = {tag: context.tag, className: this.context.className};
       }
       render() {
-        var Tag = this.state.tag;
+        const Tag = this.state.tag;
         return <Tag className={this.state.className} />;
       }
     }
@@ -144,7 +144,7 @@ describe('ReactES6Class', function() {
   });
 
   it('renders only once when setting state in componentWillMount', function() {
-    var renderCount = 0;
+    let renderCount = 0;
     class Foo extends React.Component {
       constructor(props) {
         super(props);
@@ -262,7 +262,7 @@ describe('ReactES6Class', function() {
   });
 
   it('will call all the normal life cycle methods', function() {
-    var lifeCycles = [];
+    let lifeCycles = [];
     class Foo extends React.Component {
       constructor() {
         super();
@@ -316,8 +316,8 @@ describe('ReactES6Class', function() {
 
   it('warns when classic properties are defined on the instance, but does not invoke them.', function() {
     spyOn(console, 'error');
-    var getDefaultPropsWasCalled = false;
-    var getInitialStateWasCalled = false;
+    let getDefaultPropsWasCalled = false;
+    let getInitialStateWasCalled = false;
     class Foo extends React.Component {
       constructor() {
         super();
@@ -399,7 +399,7 @@ describe('ReactES6Class', function() {
 
   it('should throw AND warn when trying to access classic APIs', function() {
     spyOn(console, 'error');
-    var instance = test(<Inner name="foo" />, 'DIV', 'foo');
+    const instance = test(<Inner name="foo" />, 'DIV', 'foo');
     expect(() => instance.replaceState({})).toThrow();
     expect(() => instance.isMounted()).toThrow();
     expect(() => instance.setProps({name: 'bar'})).toThrow();
@@ -438,13 +438,13 @@ describe('ReactES6Class', function() {
         return <Inner name="foo" ref="inner" />;
       }
     }
-    var instance = test(<Foo />, 'DIV', 'foo');
+    const instance = test(<Foo />, 'DIV', 'foo');
     expect(instance.refs.inner.getName()).toBe('foo');
   });
 
   it('supports drilling through to the DOM using findDOMNode', function() {
-    var instance = test(<Inner name="foo" />, 'DIV', 'foo');
-    var node = ReactDOM.findDOMNode(instance);
+    const instance = test(<Inner name="foo" />, 'DIV', 'foo');
+    const node = ReactDOM.findDOMNode(instance);
     expect(node).toBe(container.firstChild);
   });
 

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElement-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElement-test.js
@@ -11,12 +11,12 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
-var ReactTestUtils;
+let React;
+let ReactDOM;
+let ReactTestUtils;
 
 describe('ReactJSXElement', function() {
-  var Component;
+  let Component;
 
   beforeEach(function() {
     jest.resetModuleRegistry();
@@ -32,97 +32,97 @@ describe('ReactJSXElement', function() {
   });
 
   it('returns a complete element according to spec', function() {
-    var element = <Component />;
+    const element = <Component />;
     expect(element.type).toBe(Component);
     expect(element.key).toBe(null);
     expect(element.ref).toBe(null);
-    var expectation = {};
+    const expectation = {};
     Object.freeze(expectation);
     expect(element.props).toEqual(expectation);
   });
 
   it('allows a lower-case to be passed as the string type', function() {
-    var element = <div />;
+    const element = <div />;
     expect(element.type).toBe('div');
     expect(element.key).toBe(null);
     expect(element.ref).toBe(null);
-    var expectation = {};
+    const expectation = {};
     Object.freeze(expectation);
     expect(element.props).toEqual(expectation);
   });
 
   it('allows a string to be passed as the type', function() {
-    var TagName = 'div';
-    var element = <TagName />;
+    const TagName = 'div';
+    const element = <TagName />;
     expect(element.type).toBe('div');
     expect(element.key).toBe(null);
     expect(element.ref).toBe(null);
-    var expectation = {};
+    const expectation = {};
     Object.freeze(expectation);
     expect(element.props).toEqual(expectation);
   });
 
   it('returns an immutable element', function() {
-    var element = <Component />;
+    const element = <Component />;
     expect(() => element.type = 'div').toThrow();
   });
 
   it('does not reuse the object that is spread into props', function() {
-    var config = {foo: 1};
-    var element = <Component {...config} />;
+    const config = {foo: 1};
+    const element = <Component {...config} />;
     expect(element.props.foo).toBe(1);
     config.foo = 2;
     expect(element.props.foo).toBe(1);
   });
 
   it('extracts key and ref from the rest of the props', function() {
-    var element = <Component key="12" ref="34" foo="56" />;
+    const element = <Component key="12" ref="34" foo="56" />;
     expect(element.type).toBe(Component);
     expect(element.key).toBe('12');
     expect(element.ref).toBe('34');
-    var expectation = {foo:'56'};
+    const expectation = {foo:'56'};
     Object.freeze(expectation);
     expect(element.props).toEqual(expectation);
   });
 
   it('coerces the key to a string', function() {
-    var element = <Component key={12} foo="56" />;
+    const element = <Component key={12} foo="56" />;
     expect(element.type).toBe(Component);
     expect(element.key).toBe('12');
     expect(element.ref).toBe(null);
-    var expectation = {foo:'56'};
+    const expectation = {foo:'56'};
     Object.freeze(expectation);
     expect(element.props).toEqual(expectation);
   });
 
   it('merges JSX children onto the children prop', function() {
     spyOn(console, 'error');
-    var a = 1;
-    var element = <Component children="text">{a}</Component>;
+    const a = 1;
+    const element = <Component children="text">{a}</Component>;
     expect(element.props.children).toBe(a);
     expect(console.error.argsForCall.length).toBe(0);
   });
 
   it('does not override children if no JSX children are provided', function() {
     spyOn(console, 'error');
-    var element = <Component children="text" />;
+    const element = <Component children="text" />;
     expect(element.props.children).toBe('text');
     expect(console.error.argsForCall.length).toBe(0);
   });
 
   it('overrides children if null is provided as a JSX child', function() {
     spyOn(console, 'error');
-    var element = <Component children="text">{null}</Component>;
+    const element = <Component children="text">{null}</Component>;
     expect(element.props.children).toBe(null);
     expect(console.error.argsForCall.length).toBe(0);
   });
 
   it('merges JSX children onto the children prop in an array', function() {
     spyOn(console, 'error');
-    var a = 1;
-    var b = 2;
-    var c = 3;
-    var element = <Component>{a}{b}{c}</Component>;
+    const a = 1;
+    const b = 2;
+    const c = 3;
+    const element = <Component>{a}{b}{c}</Component>;
     expect(element.props.children).toEqual([1, 2, 3]);
     expect(console.error.argsForCall.length).toBe(0);
   });
@@ -139,7 +139,7 @@ describe('ReactJSXElement', function() {
       }
     }
 
-    var element = <StaticMethodComponent />;
+    const element = <StaticMethodComponent />;
     expect(element.type.someStaticMethod()).toBe('someReturnValue');
     expect(console.error.argsForCall.length).toBe(0);
   });
@@ -157,16 +157,16 @@ describe('ReactJSXElement', function() {
   });
 
   it('is indistinguishable from a plain object', function() {
-    var element = <div className="foo" />;
-    var object = {};
+    const element = <div className="foo" />;
+    const object = {};
     expect(element.constructor).toBe(object.constructor);
   });
 
   it('should use default prop value when removing a prop', function() {
     Component.defaultProps = {fruit: 'persimmon'};
 
-    var container = document.createElement('div');
-    var instance = ReactDOM.render(
+    const container = document.createElement('div');
+    const instance = ReactDOM.render(
       <Component fruit="mango" />,
       container
     );
@@ -184,10 +184,10 @@ describe('ReactJSXElement', function() {
     }
     NormalizingComponent.defaultProps = {prop: 'testKey'};
 
-    var instance = ReactTestUtils.renderIntoDocument(<NormalizingComponent />);
+    const instance = ReactTestUtils.renderIntoDocument(<NormalizingComponent />);
     expect(instance.props.prop).toBe('testKey');
 
-    var inst2 =
+    const inst2 =
       ReactTestUtils.renderIntoDocument(<NormalizingComponent prop={null} />);
     expect(inst2.props.prop).toBe(null);
   });

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -14,12 +14,12 @@
 // TODO: All these warnings should become static errors using Flow instead
 // of dynamic errors when using JSX with Flow.
 
-var React;
-var ReactTestUtils;
+let React;
+let ReactTestUtils;
 
 describe('ReactJSXElementValidator', function() {
-  var Component;
-  var RequiredPropComponent;
+  let Component;
+  let RequiredPropComponent;
 
   beforeEach(function() {
     jest.resetModuleRegistry();
@@ -85,12 +85,12 @@ describe('ReactJSXElementValidator', function() {
   it('warns for keys for iterables of elements in rest args', function() {
     spyOn(console, 'error');
 
-    var iterable = {
+    const iterable = {
       '@@iterator': function() {
-        var i = 0;
+        let i = 0;
         return {
           next: function() {
-            var done = ++i > 2;
+            const done = ++i > 2;
             return {value: done ? undefined : <Component />, done: done};
           },
         };
@@ -116,12 +116,12 @@ describe('ReactJSXElementValidator', function() {
   it('does not warns for iterable elements with keys', function() {
     spyOn(console, 'error');
 
-    var iterable = {
+    const iterable = {
       '@@iterator': function() {
-        var i = 0;
+        let i = 0;
         return {
           next: function() {
-            var done = ++i > 2;
+            const done = ++i > 2;
             return {
               value: done ? undefined : <Component key={'#' + i} />,
               done: done,
@@ -139,12 +139,12 @@ describe('ReactJSXElementValidator', function() {
   it('does not warn for numeric keys in entry iterable as a child', function() {
     spyOn(console, 'error');
 
-    var iterable = {
+    const iterable = {
       '@@iterator': function() {
-        var i = 0;
+        let i = 0;
         return {
           next: function() {
-            var done = ++i > 2;
+            const done = ++i > 2;
             return {value: done ? undefined : [i, <Component />], done: done};
           },
         };
@@ -203,11 +203,11 @@ describe('ReactJSXElementValidator', function() {
   });
 
   it('gives a helpful error when passing null, undefined, or boolean', () => {
-    var Undefined = undefined;
-    var Null = null;
-    var True = true;
-    var Num = 123;
-    var Div = 'div';
+    const Undefined = undefined;
+    const Null = null;
+    const True = true;
+    const Num = 123;
+    const Div = 'div';
     spyOn(console, 'error');
     void <Undefined />;
     void <Null />;

--- a/src/renderers/dom/ReactDOM.js
+++ b/src/renderers/dom/ReactDOM.js
@@ -13,24 +13,24 @@
 
 'use strict';
 
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var ReactDefaultInjection = require('ReactDefaultInjection');
-var ReactMount = require('ReactMount');
-var ReactPerf = require('ReactPerf');
-var ReactReconciler = require('ReactReconciler');
-var ReactUpdates = require('ReactUpdates');
-var ReactVersion = require('ReactVersion');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
+const ReactDefaultInjection = require('ReactDefaultInjection');
+const ReactMount = require('ReactMount');
+const ReactPerf = require('ReactPerf');
+const ReactReconciler = require('ReactReconciler');
+const ReactUpdates = require('ReactUpdates');
+const ReactVersion = require('ReactVersion');
 
-var findDOMNode = require('findDOMNode');
-var getNativeComponentFromComposite = require('getNativeComponentFromComposite');
-var renderSubtreeIntoContainer = require('renderSubtreeIntoContainer');
-var warning = require('warning');
+const findDOMNode = require('findDOMNode');
+const getNativeComponentFromComposite = require('getNativeComponentFromComposite');
+const renderSubtreeIntoContainer = require('renderSubtreeIntoContainer');
+const warning = require('warning');
 
 ReactDefaultInjection.inject();
 
-var render = ReactPerf.measure('React', 'render', ReactMount.render);
+const render = ReactPerf.measure('React', 'render', ReactMount.render);
 
-var React = {
+const React = {
   findDOMNode: findDOMNode,
   render: render,
   unmountComponentAtNode: ReactMount.unmountComponentAtNode,
@@ -69,7 +69,7 @@ if (
 }
 
 if (__DEV__) {
-  var ExecutionEnvironment = require('ExecutionEnvironment');
+  const ExecutionEnvironment = require('ExecutionEnvironment');
   if (ExecutionEnvironment.canUseDOM && window.top === window.self) {
 
     // First check if devtools is not installed
@@ -79,7 +79,7 @@ if (__DEV__) {
           navigator.userAgent.indexOf('Edge') === -1) ||
           navigator.userAgent.indexOf('Firefox') > -1) {
         // Firefox does not have the issue with devtools loaded over file://
-        var showFileUrlMessage = window.location.protocol.indexOf('http') === -1 &&
+        const showFileUrlMessage = window.location.protocol.indexOf('http') === -1 &&
           navigator.userAgent.indexOf('Firefox') === -1;
         console.debug(
           'Download the React DevTools ' +
@@ -90,7 +90,7 @@ if (__DEV__) {
       }
     }
 
-    var testFunc = function testFn() {};
+    const testFunc = function testFn() {};
     warning(
       (testFunc.name || testFunc.toString()).indexOf('testFn') !== -1,
       'It looks like you\'re using a minified copy of the development build ' +
@@ -101,7 +101,7 @@ if (__DEV__) {
 
     // If we're in IE8, check to see if we are in compatibility mode and provide
     // information on preventing compatibility mode
-    var ieCompatibilityMode =
+    const ieCompatibilityMode =
       document.documentMode && document.documentMode < 8;
 
     warning(
@@ -111,7 +111,7 @@ if (__DEV__) {
       '<meta http-equiv="X-UA-Compatible" content="IE=edge" />'
     );
 
-    var expectedFeatures = [
+    const expectedFeatures = [
       // shims
       Array.isArray,
       Array.prototype.every,
@@ -125,7 +125,7 @@ if (__DEV__) {
       String.prototype.trim,
     ];
 
-    for (var i = 0; i < expectedFeatures.length; i++) {
+    for (let i = 0; i < expectedFeatures.length; i++) {
       if (!expectedFeatures[i]) {
         warning(
           false,

--- a/src/renderers/dom/ReactDOMServer.js
+++ b/src/renderers/dom/ReactDOMServer.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-var ReactDefaultInjection = require('ReactDefaultInjection');
-var ReactServerRendering = require('ReactServerRendering');
-var ReactVersion = require('ReactVersion');
+const ReactDefaultInjection = require('ReactDefaultInjection');
+const ReactServerRendering = require('ReactServerRendering');
+const ReactVersion = require('ReactVersion');
 
 ReactDefaultInjection.inject();
 
-var ReactDOMServer = {
+const ReactDOMServer = {
   renderToString: ReactServerRendering.renderToString,
   renderToStaticMarkup: ReactServerRendering.renderToStaticMarkup,
   version: ReactVersion,

--- a/src/renderers/dom/__tests__/ReactDOMProduction-test.js
+++ b/src/renderers/dom/__tests__/ReactDOMProduction-test.js
@@ -12,10 +12,10 @@
 'use strict';
 
 describe('ReactDOMProduction', function() {
-  var oldProcess;
+  let oldProcess;
 
-  var React;
-  var ReactDOM;
+  let React;
+  let ReactDOM;
 
   beforeEach(function() {
     __DEV__ = true;
@@ -33,7 +33,7 @@ describe('ReactDOMProduction', function() {
   });
 
   it('should use prod fbjs', function() {
-    var warning = require('warning');
+    const warning = require('warning');
 
     spyOn(console, 'error');
     warning(false, 'Do cows go moo?');
@@ -50,14 +50,14 @@ describe('ReactDOMProduction', function() {
   });
 
   it('should handle a simple flow', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         return <span>{this.props.children}</span>;
       },
     });
 
-    var container = document.createElement('div');
-    var inst = ReactDOM.render(
+    const container = document.createElement('div');
+    const inst = ReactDOM.render(
       <div className="blue">
         <Component key={1}>A</Component>
         <Component key={2}>B</Component>

--- a/src/renderers/dom/client/ReactBrowserEventEmitter.js
+++ b/src/renderers/dom/client/ReactBrowserEventEmitter.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-var EventConstants = require('EventConstants');
-var EventPluginRegistry = require('EventPluginRegistry');
-var ReactEventEmitterMixin = require('ReactEventEmitterMixin');
-var ViewportMetrics = require('ViewportMetrics');
+const EventConstants = require('EventConstants');
+const EventPluginRegistry = require('EventPluginRegistry');
+const ReactEventEmitterMixin = require('ReactEventEmitterMixin');
+const ViewportMetrics = require('ViewportMetrics');
 
-var assign = require('Object.assign');
-var isEventSupported = require('isEventSupported');
+const assign = require('Object.assign');
+const isEventSupported = require('isEventSupported');
 
 /**
  * Summary of `ReactBrowserEventEmitter` event handling:
@@ -74,14 +74,14 @@ var isEventSupported = require('isEventSupported');
  *    React Core     .  General Purpose Event Plugin System
  */
 
-var alreadyListeningTo = {};
-var isMonitoringScrollValue = false;
-var reactTopListenersCounter = 0;
+const alreadyListeningTo = {};
+let isMonitoringScrollValue = false;
+let reactTopListenersCounter = 0;
 
 // For events like 'submit' which don't consistently bubble (which we trap at a
 // lower node than `document`), binding at `document` would cause duplicate
 // events so we don't include them here
-var topEventMapping = {
+const topEventMapping = {
   topAbort: 'abort',
   topBlur: 'blur',
   topCanPlay: 'canplay',
@@ -147,7 +147,7 @@ var topEventMapping = {
 /**
  * To ensure no conflicts with other potential React instances on the page
  */
-var topListenersIDKey = '_reactListenersID' + String(Math.random()).slice(2);
+const topListenersIDKey = '_reactListenersID' + String(Math.random()).slice(2);
 
 function getListeningForDocument(mountAt) {
   // In IE8, `mountAt` is a host object and doesn't have `hasOwnProperty`
@@ -169,7 +169,7 @@ function getListeningForDocument(mountAt) {
  *
  * @internal
  */
-var ReactBrowserEventEmitter = assign({}, ReactEventEmitterMixin, {
+const ReactBrowserEventEmitter = assign({}, ReactEventEmitterMixin, {
 
   /**
    * Injectable event backend
@@ -231,14 +231,14 @@ var ReactBrowserEventEmitter = assign({}, ReactEventEmitterMixin, {
    * @param {object} contentDocumentHandle Document which owns the container
    */
   listenTo: function(registrationName, contentDocumentHandle) {
-    var mountAt = contentDocumentHandle;
-    var isListening = getListeningForDocument(mountAt);
-    var dependencies =
+    const mountAt = contentDocumentHandle;
+    const isListening = getListeningForDocument(mountAt);
+    const dependencies =
       EventPluginRegistry.registrationNameDependencies[registrationName];
 
-    var topLevelTypes = EventConstants.topLevelTypes;
-    for (var i = 0; i < dependencies.length; i++) {
-      var dependency = dependencies[i];
+    const topLevelTypes = EventConstants.topLevelTypes;
+    for (let i = 0; i < dependencies.length; i++) {
+      const dependency = dependencies[i];
       if (!(
             isListening.hasOwnProperty(dependency) &&
             isListening[dependency]
@@ -351,7 +351,7 @@ var ReactBrowserEventEmitter = assign({}, ReactEventEmitterMixin, {
    */
   ensureScrollValueMonitoring: function() {
     if (!isMonitoringScrollValue) {
-      var refresh = ViewportMetrics.refreshScrollValues;
+      const refresh = ViewportMetrics.refreshScrollValues;
       ReactBrowserEventEmitter.ReactEventListener.monitorScrollValue(refresh);
       isMonitoringScrollValue = true;
     }

--- a/src/renderers/dom/client/ReactDOMComponentTree.js
+++ b/src/renderers/dom/client/ReactDOMComponentTree.js
@@ -11,15 +11,15 @@
 
 'use strict';
 
-var DOMProperty = require('DOMProperty');
-var ReactDOMComponentFlags = require('ReactDOMComponentFlags');
+const DOMProperty = require('DOMProperty');
+const ReactDOMComponentFlags = require('ReactDOMComponentFlags');
 
-var invariant = require('invariant');
+const invariant = require('invariant');
 
-var ATTR_NAME = DOMProperty.ID_ATTRIBUTE_NAME;
-var Flags = ReactDOMComponentFlags;
+const ATTR_NAME = DOMProperty.ID_ATTRIBUTE_NAME;
+const Flags = ReactDOMComponentFlags;
 
-var internalInstanceKey =
+const internalInstanceKey =
   '__reactInternalInstance$' + Math.random().toString(36).slice(2);
 
 /**
@@ -30,7 +30,7 @@ var internalInstanceKey =
  * for `_renderedChildren`.
  */
 function getRenderedNativeOrTextFromComponent(component) {
-  var rendered;
+  let rendered;
   while ((rendered = component._renderedComponent)) {
     component = rendered;
   }
@@ -42,13 +42,13 @@ function getRenderedNativeOrTextFromComponent(component) {
  * DOM node. The passed `inst` can be a composite.
  */
 function precacheNode(inst, node) {
-  var nativeInst = getRenderedNativeOrTextFromComponent(inst);
+  const nativeInst = getRenderedNativeOrTextFromComponent(inst);
   nativeInst._nativeNode = node;
   node[internalInstanceKey] = nativeInst;
 }
 
 function uncacheNode(inst) {
-  var node = inst._nativeNode;
+  const node = inst._nativeNode;
   if (node) {
     delete node[internalInstanceKey];
     inst._nativeNode = null;
@@ -73,14 +73,14 @@ function precacheChildNodes(inst, node) {
   if (inst._flags & Flags.hasCachedChildNodes) {
     return;
   }
-  var children = inst._renderedChildren;
-  var childNode = node.firstChild;
-  outer: for (var name in children) {
+  const children = inst._renderedChildren;
+  let childNode = node.firstChild;
+  outer: for (let name in children) {
     if (!children.hasOwnProperty(name)) {
       continue;
     }
-    var childInst = children[name];
-    var childID = getRenderedNativeOrTextFromComponent(childInst)._domID;
+    const childInst = children[name];
+    const childID = getRenderedNativeOrTextFromComponent(childInst)._domID;
     if (childID == null) {
       // We're currently unmounting this child in ReactMultiChild; skip it.
       continue;
@@ -113,7 +113,7 @@ function getClosestInstanceFromNode(node) {
   }
 
   // Walk up the tree until we find an ancestor whose instance we have cached.
-  var parents = [];
+  const parents = [];
   while (!node[internalInstanceKey]) {
     parents.push(node);
     if (node.parentNode) {
@@ -125,8 +125,8 @@ function getClosestInstanceFromNode(node) {
     }
   }
 
-  var closest;
-  var inst;
+  let closest;
+  let inst;
   for (; node && (inst = node[internalInstanceKey]); node = parents.pop()) {
     closest = inst;
     if (parents.length) {
@@ -142,7 +142,7 @@ function getClosestInstanceFromNode(node) {
  * instance, or null if the node was not rendered by this React.
  */
 function getInstanceFromNode(node) {
-  var inst = getClosestInstanceFromNode(node);
+  const inst = getClosestInstanceFromNode(node);
   if (inst != null && inst._nativeNode === node) {
     return inst;
   } else {
@@ -167,7 +167,7 @@ function getNodeFromInstance(inst) {
   }
 
   // Walk up the tree until we find an ancestor whose DOM node we have cached.
-  var parents = [];
+  const parents = [];
   while (!inst._nativeNode) {
     parents.push(inst);
     invariant(
@@ -186,7 +186,7 @@ function getNodeFromInstance(inst) {
   return inst._nativeNode;
 }
 
-var ReactDOMComponentTree = {
+const ReactDOMComponentTree = {
   getClosestInstanceFromNode: getClosestInstanceFromNode,
   getInstanceFromNode: getInstanceFromNode,
   getNodeFromInstance: getNodeFromInstance,

--- a/src/renderers/dom/client/ReactDOMComponentTree.js
+++ b/src/renderers/dom/client/ReactDOMComponentTree.js
@@ -75,7 +75,7 @@ function precacheChildNodes(inst, node) {
   }
   const children = inst._renderedChildren;
   let childNode = node.firstChild;
-  outer: for (let name in children) {
+  outer: for (const name in children) {
     if (!children.hasOwnProperty(name)) {
       continue;
     }

--- a/src/renderers/dom/client/ReactDOMIDOperations.js
+++ b/src/renderers/dom/client/ReactDOMIDOperations.js
@@ -11,14 +11,14 @@
 
 'use strict';
 
-var DOMChildrenOperations = require('DOMChildrenOperations');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var ReactPerf = require('ReactPerf');
+const DOMChildrenOperations = require('DOMChildrenOperations');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
+const ReactPerf = require('ReactPerf');
 
 /**
  * Operations used to process updates to DOM nodes.
  */
-var ReactDOMIDOperations = {
+const ReactDOMIDOperations = {
 
   /**
    * Updates a component's children by processing a series of updates.
@@ -27,7 +27,7 @@ var ReactDOMIDOperations = {
    * @internal
    */
   dangerouslyProcessChildrenUpdates: function(parentInst, updates) {
-    var node = ReactDOMComponentTree.getNodeFromInstance(parentInst);
+    const node = ReactDOMComponentTree.getNodeFromInstance(parentInst);
     DOMChildrenOperations.processUpdates(node, updates);
   },
 };

--- a/src/renderers/dom/client/ReactDOMSelection.js
+++ b/src/renderers/dom/client/ReactDOMSelection.js
@@ -11,10 +11,10 @@
 
 'use strict';
 
-var ExecutionEnvironment = require('ExecutionEnvironment');
+const ExecutionEnvironment = require('ExecutionEnvironment');
 
-var getNodeForCharacterOffset = require('getNodeForCharacterOffset');
-var getTextContentAccessor = require('getTextContentAccessor');
+const getNodeForCharacterOffset = require('getNodeForCharacterOffset');
+const getTextContentAccessor = require('getTextContentAccessor');
 
 /**
  * While `isCollapsed` is available on the Selection object and `collapsed`
@@ -40,17 +40,17 @@ function isCollapsed(anchorNode, anchorOffset, focusNode, focusOffset) {
  * @return {object}
  */
 function getIEOffsets(node) {
-  var selection = document.selection;
-  var selectedRange = selection.createRange();
-  var selectedLength = selectedRange.text.length;
+  const selection = document.selection;
+  const selectedRange = selection.createRange();
+  const selectedLength = selectedRange.text.length;
 
   // Duplicate selection so we can move range without breaking user selection.
-  var fromStart = selectedRange.duplicate();
+  const fromStart = selectedRange.duplicate();
   fromStart.moveToElementText(node);
   fromStart.setEndPoint('EndToStart', selectedRange);
 
-  var startOffset = fromStart.text.length;
-  var endOffset = startOffset + selectedLength;
+  const startOffset = fromStart.text.length;
+  const endOffset = startOffset + selectedLength;
 
   return {
     start: startOffset,
@@ -63,18 +63,18 @@ function getIEOffsets(node) {
  * @return {?object}
  */
 function getModernOffsets(node) {
-  var selection = window.getSelection && window.getSelection();
+  const selection = window.getSelection && window.getSelection();
 
   if (!selection || selection.rangeCount === 0) {
     return null;
   }
 
-  var anchorNode = selection.anchorNode;
-  var anchorOffset = selection.anchorOffset;
-  var focusNode = selection.focusNode;
-  var focusOffset = selection.focusOffset;
+  const anchorNode = selection.anchorNode;
+  const anchorOffset = selection.anchorOffset;
+  const focusNode = selection.focusNode;
+  const focusOffset = selection.focusOffset;
 
-  var currentRange = selection.getRangeAt(0);
+  const currentRange = selection.getRangeAt(0);
 
   // In Firefox, range.startContainer and range.endContainer can be "anonymous
   // divs", e.g. the up/down buttons on an <input type="number">. Anonymous
@@ -95,34 +95,34 @@ function getModernOffsets(node) {
   // If the node and offset values are the same, the selection is collapsed.
   // `Selection.isCollapsed` is available natively, but IE sometimes gets
   // this value wrong.
-  var isSelectionCollapsed = isCollapsed(
+  const isSelectionCollapsed = isCollapsed(
     selection.anchorNode,
     selection.anchorOffset,
     selection.focusNode,
     selection.focusOffset
   );
 
-  var rangeLength = isSelectionCollapsed ? 0 : currentRange.toString().length;
+  const rangeLength = isSelectionCollapsed ? 0 : currentRange.toString().length;
 
-  var tempRange = currentRange.cloneRange();
+  const tempRange = currentRange.cloneRange();
   tempRange.selectNodeContents(node);
   tempRange.setEnd(currentRange.startContainer, currentRange.startOffset);
 
-  var isTempRangeCollapsed = isCollapsed(
+  const isTempRangeCollapsed = isCollapsed(
     tempRange.startContainer,
     tempRange.startOffset,
     tempRange.endContainer,
     tempRange.endOffset
   );
 
-  var start = isTempRangeCollapsed ? 0 : tempRange.toString().length;
-  var end = start + rangeLength;
+  const start = isTempRangeCollapsed ? 0 : tempRange.toString().length;
+  const end = start + rangeLength;
 
   // Detect whether the selection is backward.
-  var detectionRange = document.createRange();
+  const detectionRange = document.createRange();
   detectionRange.setStart(anchorNode, anchorOffset);
   detectionRange.setEnd(focusNode, focusOffset);
-  var isBackward = detectionRange.collapsed;
+  const isBackward = detectionRange.collapsed;
 
   return {
     start: isBackward ? end : start,
@@ -135,8 +135,8 @@ function getModernOffsets(node) {
  * @param {object} offsets
  */
 function setIEOffsets(node, offsets) {
-  var range = document.selection.createRange().duplicate();
-  var start, end;
+  const range = document.selection.createRange().duplicate();
+  let start, end;
 
   if (offsets.end === undefined) {
     start = offsets.start;
@@ -173,25 +173,25 @@ function setModernOffsets(node, offsets) {
     return;
   }
 
-  var selection = window.getSelection();
-  var length = node[getTextContentAccessor()].length;
-  var start = Math.min(offsets.start, length);
-  var end = offsets.end === undefined ?
+  const selection = window.getSelection();
+  const length = node[getTextContentAccessor()].length;
+  let start = Math.min(offsets.start, length);
+  let end = offsets.end === undefined ?
             start : Math.min(offsets.end, length);
 
   // IE 11 uses modern selection, but doesn't support the extend method.
   // Flip backward selections, so we can set with a single range.
   if (!selection.extend && start > end) {
-    var temp = end;
+    const temp = end;
     end = start;
     start = temp;
   }
 
-  var startMarker = getNodeForCharacterOffset(node, start);
-  var endMarker = getNodeForCharacterOffset(node, end);
+  const startMarker = getNodeForCharacterOffset(node, start);
+  const endMarker = getNodeForCharacterOffset(node, end);
 
   if (startMarker && endMarker) {
-    var range = document.createRange();
+    const range = document.createRange();
     range.setStart(startMarker.node, startMarker.offset);
     selection.removeAllRanges();
 
@@ -205,13 +205,13 @@ function setModernOffsets(node, offsets) {
   }
 }
 
-var useIEOffsets = (
+const useIEOffsets = (
   ExecutionEnvironment.canUseDOM &&
   'selection' in document &&
   !('getSelection' in window)
 );
 
-var ReactDOMSelection = {
+const ReactDOMSelection = {
   /**
    * @param {DOMElement} node
    */

--- a/src/renderers/dom/client/ReactDOMTreeTraversal.js
+++ b/src/renderers/dom/client/ReactDOMTreeTraversal.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var invariant = require('invariant');
+const invariant = require('invariant');
 
 /**
  * Return the lowest common ancestor of A and B, or null if they are in
@@ -21,12 +21,12 @@ function getLowestCommonAncestor(instA, instB) {
   invariant('_nativeNode' in instA, 'getNodeFromInstance: Invalid argument.');
   invariant('_nativeNode' in instB, 'getNodeFromInstance: Invalid argument.');
 
-  var depthA = 0;
-  for (var tempA = instA; tempA; tempA = tempA._nativeParent) {
+  let depthA = 0;
+  for (let tempA = instA; tempA; tempA = tempA._nativeParent) {
     depthA++;
   }
-  var depthB = 0;
-  for (var tempB = instB; tempB; tempB = tempB._nativeParent) {
+  let depthB = 0;
+  for (let tempB = instB; tempB; tempB = tempB._nativeParent) {
     depthB++;
   }
 
@@ -43,7 +43,7 @@ function getLowestCommonAncestor(instA, instB) {
   }
 
   // Walk in lockstep until we find a match.
-  var depth = depthA;
+  let depth = depthA;
   while (depth--) {
     if (instA === instB) {
       return instA;
@@ -83,12 +83,12 @@ function getParentInstance(inst) {
  * Simulates the traversal of a two-phase, capture/bubble event dispatch.
  */
 function traverseTwoPhase(inst, fn, arg) {
-  var path = [];
+  const path = [];
   while (inst) {
     path.push(inst);
     inst = inst._nativeParent;
   }
-  var i;
+  let i;
   for (i = path.length; i-- > 0;) {
     fn(path[i], false, arg);
   }
@@ -105,18 +105,18 @@ function traverseTwoPhase(inst, fn, arg) {
  * "entered" or "left" that element.
  */
 function traverseEnterLeave(from, to, fn, argFrom, argTo) {
-  var common = from && to ? getLowestCommonAncestor(from, to) : null;
-  var pathFrom = [];
+  const common = from && to ? getLowestCommonAncestor(from, to) : null;
+  const pathFrom = [];
   while (from && from !== common) {
     pathFrom.push(from);
     from = from._nativeParent;
   }
-  var pathTo = [];
+  const pathTo = [];
   while (to && to !== common) {
     pathTo.push(to);
     to = to._nativeParent;
   }
-  var i;
+  let i;
   for (i = 0; i < pathFrom.length; i++) {
     fn(pathFrom[i], true, argFrom);
   }

--- a/src/renderers/dom/client/ReactEventListener.js
+++ b/src/renderers/dom/client/ReactEventListener.js
@@ -11,15 +11,15 @@
 
 'use strict';
 
-var EventListener = require('EventListener');
-var ExecutionEnvironment = require('ExecutionEnvironment');
-var PooledClass = require('PooledClass');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var ReactUpdates = require('ReactUpdates');
+const EventListener = require('EventListener');
+const ExecutionEnvironment = require('ExecutionEnvironment');
+const PooledClass = require('PooledClass');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
+const ReactUpdates = require('ReactUpdates');
 
-var assign = require('Object.assign');
-var getEventTarget = require('getEventTarget');
-var getUnboundedScrollPosition = require('getUnboundedScrollPosition');
+const assign = require('Object.assign');
+const getEventTarget = require('getEventTarget');
+const getUnboundedScrollPosition = require('getUnboundedScrollPosition');
 
 /**
  * Find the deepest React component completely containing the root of the
@@ -33,8 +33,8 @@ function findParent(inst) {
   while (inst._nativeParent) {
     inst = inst._nativeParent;
   }
-  var rootNode = ReactDOMComponentTree.getNodeFromInstance(inst);
-  var container = rootNode.parentNode;
+  const rootNode = ReactDOMComponentTree.getNodeFromInstance(inst);
+  const container = rootNode.parentNode;
   return ReactDOMComponentTree.getClosestInstanceFromNode(container);
 }
 
@@ -57,8 +57,8 @@ PooledClass.addPoolingTo(
 );
 
 function handleTopLevelImpl(bookKeeping) {
-  var nativeEventTarget = getEventTarget(bookKeeping.nativeEvent);
-  var targetInst = ReactDOMComponentTree.getClosestInstanceFromNode(
+  const nativeEventTarget = getEventTarget(bookKeeping.nativeEvent);
+  let targetInst = ReactDOMComponentTree.getClosestInstanceFromNode(
     nativeEventTarget
   );
 
@@ -66,13 +66,13 @@ function handleTopLevelImpl(bookKeeping) {
   // It's important that we build the array of ancestors before calling any
   // event handlers, because event handlers can modify the DOM, leading to
   // inconsistencies with ReactMount's node cache. See #1105.
-  var ancestor = targetInst;
+  let ancestor = targetInst;
   do {
     bookKeeping.ancestors.push(ancestor);
     ancestor = ancestor && findParent(ancestor);
   } while (ancestor);
 
-  for (var i = 0; i < bookKeeping.ancestors.length; i++) {
+  for (let i = 0; i < bookKeeping.ancestors.length; i++) {
     targetInst = bookKeeping.ancestors[i];
     ReactEventListener._handleTopLevel(
       bookKeeping.topLevelType,
@@ -84,7 +84,7 @@ function handleTopLevelImpl(bookKeeping) {
 }
 
 function scrollValueMonitor(cb) {
-  var scrollPosition = getUnboundedScrollPosition(window);
+  const scrollPosition = getUnboundedScrollPosition(window);
   cb(scrollPosition);
 }
 
@@ -118,7 +118,7 @@ var ReactEventListener = {
    * @internal
    */
   trapBubbledEvent: function(topLevelType, handlerBaseName, handle) {
-    var element = handle;
+    const element = handle;
     if (!element) {
       return null;
     }
@@ -140,7 +140,7 @@ var ReactEventListener = {
    * @internal
    */
   trapCapturedEvent: function(topLevelType, handlerBaseName, handle) {
-    var element = handle;
+    const element = handle;
     if (!element) {
       return null;
     }
@@ -152,7 +152,7 @@ var ReactEventListener = {
   },
 
   monitorScrollValue: function(refresh) {
-    var callback = scrollValueMonitor.bind(null, refresh);
+    const callback = scrollValueMonitor.bind(null, refresh);
     EventListener.listen(window, 'scroll', callback);
   },
 
@@ -161,7 +161,7 @@ var ReactEventListener = {
       return;
     }
 
-    var bookKeeping = TopLevelCallbackBookKeeping.getPooled(
+    const bookKeeping = TopLevelCallbackBookKeeping.getPooled(
       topLevelType,
       nativeEvent
     );

--- a/src/renderers/dom/client/ReactInputSelection.js
+++ b/src/renderers/dom/client/ReactInputSelection.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-var ReactDOMSelection = require('ReactDOMSelection');
+const ReactDOMSelection = require('ReactDOMSelection');
 
-var containsNode = require('containsNode');
-var focusNode = require('focusNode');
-var getActiveElement = require('getActiveElement');
+const containsNode = require('containsNode');
+const focusNode = require('focusNode');
+const getActiveElement = require('getActiveElement');
 
 function isInDocument(node) {
   return containsNode(document.documentElement, node);
@@ -27,10 +27,10 @@ function isInDocument(node) {
  * assume buttons have range selections allowed).
  * Input selection module for React.
  */
-var ReactInputSelection = {
+const ReactInputSelection = {
 
   hasSelectionCapabilities: function(elem) {
-    var nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
+    const nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
     return nodeName && (
       (nodeName === 'input' && elem.type === 'text') ||
       nodeName === 'textarea' ||
@@ -39,7 +39,7 @@ var ReactInputSelection = {
   },
 
   getSelectionInformation: function() {
-    var focusedElem = getActiveElement();
+    const focusedElem = getActiveElement();
     return {
       focusedElem: focusedElem,
       selectionRange:
@@ -55,9 +55,9 @@ var ReactInputSelection = {
    * nodes and place them back in, resulting in focus being lost.
    */
   restoreSelection: function(priorSelectionInformation) {
-    var curFocusedElem = getActiveElement();
-    var priorFocusedElem = priorSelectionInformation.focusedElem;
-    var priorSelectionRange = priorSelectionInformation.selectionRange;
+    const curFocusedElem = getActiveElement();
+    const priorFocusedElem = priorSelectionInformation.focusedElem;
+    const priorSelectionRange = priorSelectionInformation.selectionRange;
     if (curFocusedElem !== priorFocusedElem &&
         isInDocument(priorFocusedElem)) {
       if (ReactInputSelection.hasSelectionCapabilities(priorFocusedElem)) {
@@ -77,7 +77,7 @@ var ReactInputSelection = {
    * -@return {start: selectionStart, end: selectionEnd}
    */
   getSelection: function(input) {
-    var selection;
+    let selection;
 
     if ('selectionStart' in input) {
       // Modern browser with input or textarea.
@@ -88,7 +88,7 @@ var ReactInputSelection = {
     } else if (document.selection &&
         (input.nodeName && input.nodeName.toLowerCase() === 'input')) {
       // IE8 input.
-      var range = document.selection.createRange();
+      const range = document.selection.createRange();
       // There can only be one selection per document in IE, so it must
       // be in our element.
       if (range.parentElement() === input) {
@@ -112,8 +112,8 @@ var ReactInputSelection = {
    * -@offsets   Object of same form that is returned from get*
    */
   setSelection: function(input, offsets) {
-    var start = offsets.start;
-    var end = offsets.end;
+    const start = offsets.start;
+    let end = offsets.end;
     if (end === undefined) {
       end = start;
     }
@@ -123,7 +123,7 @@ var ReactInputSelection = {
       input.selectionEnd = Math.min(end, input.value.length);
     } else if (document.selection &&
         (input.nodeName && input.nodeName.toLowerCase() === 'input')) {
-      var range = input.createTextRange();
+      const range = input.createTextRange();
       range.collapse(true);
       range.moveStart('character', start);
       range.moveEnd('character', end - start);

--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -11,36 +11,36 @@
 
 'use strict';
 
-var DOMLazyTree = require('DOMLazyTree');
-var DOMProperty = require('DOMProperty');
-var ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
-var ReactCurrentOwner = require('ReactCurrentOwner');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var ReactDOMContainerInfo = require('ReactDOMContainerInfo');
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
-var ReactElement = require('ReactElement');
-var ReactFeatureFlags = require('ReactFeatureFlags');
-var ReactMarkupChecksum = require('ReactMarkupChecksum');
-var ReactPerf = require('ReactPerf');
-var ReactReconciler = require('ReactReconciler');
-var ReactUpdateQueue = require('ReactUpdateQueue');
-var ReactUpdates = require('ReactUpdates');
+const DOMLazyTree = require('DOMLazyTree');
+const DOMProperty = require('DOMProperty');
+const ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
+const ReactCurrentOwner = require('ReactCurrentOwner');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
+const ReactDOMContainerInfo = require('ReactDOMContainerInfo');
+const ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
+const ReactElement = require('ReactElement');
+const ReactFeatureFlags = require('ReactFeatureFlags');
+const ReactMarkupChecksum = require('ReactMarkupChecksum');
+const ReactPerf = require('ReactPerf');
+const ReactReconciler = require('ReactReconciler');
+const ReactUpdateQueue = require('ReactUpdateQueue');
+const ReactUpdates = require('ReactUpdates');
 
-var emptyObject = require('emptyObject');
-var instantiateReactComponent = require('instantiateReactComponent');
-var invariant = require('invariant');
-var setInnerHTML = require('setInnerHTML');
-var shouldUpdateReactComponent = require('shouldUpdateReactComponent');
-var warning = require('warning');
+const emptyObject = require('emptyObject');
+const instantiateReactComponent = require('instantiateReactComponent');
+const invariant = require('invariant');
+const setInnerHTML = require('setInnerHTML');
+const shouldUpdateReactComponent = require('shouldUpdateReactComponent');
+const warning = require('warning');
 
-var ATTR_NAME = DOMProperty.ID_ATTRIBUTE_NAME;
-var ROOT_ATTR_NAME = DOMProperty.ROOT_ATTRIBUTE_NAME;
+const ATTR_NAME = DOMProperty.ID_ATTRIBUTE_NAME;
+const ROOT_ATTR_NAME = DOMProperty.ROOT_ATTRIBUTE_NAME;
 
-var ELEMENT_NODE_TYPE = 1;
-var DOC_NODE_TYPE = 9;
-var DOCUMENT_FRAGMENT_NODE_TYPE = 11;
+const ELEMENT_NODE_TYPE = 1;
+const DOC_NODE_TYPE = 9;
+const DOCUMENT_FRAGMENT_NODE_TYPE = 11;
 
-var instancesByReactRootID = {};
+const instancesByReactRootID = {};
 
 /**
  * Finds the index of the first character
@@ -49,8 +49,8 @@ var instancesByReactRootID = {};
  * @return {number} the index of the character where the strings diverge
  */
 function firstDifferenceIndex(string1, string2) {
-  var minLen = Math.min(string1.length, string2.length);
-  for (var i = 0; i < minLen; i++) {
+  const minLen = Math.min(string1.length, string2.length);
+  for (let i = 0; i < minLen; i++) {
     if (string1.charAt(i) !== string2.charAt(i)) {
       return i;
     }
@@ -97,10 +97,10 @@ function mountComponentIntoNode(
   shouldReuseMarkup,
   context
 ) {
-  var markerName;
+  let markerName;
   if (ReactFeatureFlags.logTopLevelRenders) {
-    var wrappedElement = wrapperInstance._currentElement.props;
-    var type = wrappedElement.type;
+    const wrappedElement = wrapperInstance._currentElement.props;
+    const type = wrappedElement.type;
     markerName = 'React mount: ' + (
       typeof type === 'string' ? type :
       type.displayName || type.name
@@ -108,7 +108,7 @@ function mountComponentIntoNode(
     console.time(markerName);
   }
 
-  var markup = ReactReconciler.mountComponent(
+  const markup = ReactReconciler.mountComponent(
     wrapperInstance,
     transaction,
     null,
@@ -143,7 +143,7 @@ function batchedMountComponentIntoNode(
   shouldReuseMarkup,
   context
 ) {
-  var transaction = ReactUpdates.ReactReconcileTransaction.getPooled(
+  const transaction = ReactUpdates.ReactReconcileTransaction.getPooled(
     /* useCreateElement */
     !shouldReuseMarkup && ReactDOMFeatureFlags.useCreateElement
   );
@@ -192,16 +192,16 @@ function unmountComponentFromNode(instance, container, safely) {
  * @internal
  */
 function hasNonRootReactChild(container) {
-  var rootEl = getReactRootElementInContainer(container);
+  const rootEl = getReactRootElementInContainer(container);
   if (rootEl) {
-    var inst = ReactDOMComponentTree.getInstanceFromNode(rootEl);
+    const inst = ReactDOMComponentTree.getInstanceFromNode(rootEl);
     return !!(inst && inst._nativeParent);
   }
 }
 
 function getNativeRootInstanceInContainer(container) {
-  var rootEl = getReactRootElementInContainer(container);
-  var prevNativeInstance =
+  const rootEl = getReactRootElementInContainer(container);
+  const prevNativeInstance =
     rootEl && ReactDOMComponentTree.getInstanceFromNode(rootEl);
   return (
     prevNativeInstance && !prevNativeInstance._nativeParent ?
@@ -210,7 +210,7 @@ function getNativeRootInstanceInContainer(container) {
 }
 
 function getTopLevelWrapperInContainer(container) {
-  var root = getNativeRootInstanceInContainer(container);
+  const root = getNativeRootInstanceInContainer(container);
   return root ? root._nativeContainerInfo._topLevelWrapper : null;
 }
 
@@ -219,8 +219,8 @@ function getTopLevelWrapperInContainer(container) {
  * composites instead of having to worry about different types of components
  * here.
  */
-var topLevelRootCounter = 1;
-var TopLevelWrapper = function() {
+let topLevelRootCounter = 1;
+const TopLevelWrapper = function() {
   this.rootID = topLevelRootCounter++;
 };
 TopLevelWrapper.prototype.isReactComponent = {};
@@ -330,7 +330,7 @@ var ReactMount = {
     );
 
     ReactBrowserEventEmitter.ensureScrollValueMonitoring();
-    var componentInstance = instantiateReactComponent(nextElement);
+    const componentInstance = instantiateReactComponent(nextElement);
 
     // The initial render is synchronous but any updates that happen during
     // rendering, in componentWillMount or componentDidMount, will be batched
@@ -344,7 +344,7 @@ var ReactMount = {
       context
     );
 
-    var wrapperID = componentInstance._instance.rootID;
+    const wrapperID = componentInstance._instance.rootID;
     instancesByReactRootID[wrapperID] = componentInstance;
 
     return componentInstance;
@@ -405,7 +405,7 @@ var ReactMount = {
       'for your app.'
     );
 
-    var nextWrappedElement = ReactElement(
+    const nextWrappedElement = ReactElement(
       TopLevelWrapper,
       null,
       null,
@@ -415,14 +415,14 @@ var ReactMount = {
       nextElement
     );
 
-    var prevComponent = getTopLevelWrapperInContainer(container);
+    const prevComponent = getTopLevelWrapperInContainer(container);
 
     if (prevComponent) {
-      var prevWrappedElement = prevComponent._currentElement;
-      var prevElement = prevWrappedElement.props;
+      const prevWrappedElement = prevComponent._currentElement;
+      const prevElement = prevWrappedElement.props;
       if (shouldUpdateReactComponent(prevElement, nextElement)) {
-        var publicInst = prevComponent._renderedComponent.getPublicInstance();
-        var updatedCallback = callback && function() {
+        const publicInst = prevComponent._renderedComponent.getPublicInstance();
+        const updatedCallback = callback && function() {
           callback.call(publicInst);
         };
         ReactMount._updateRootComponent(
@@ -437,10 +437,10 @@ var ReactMount = {
       }
     }
 
-    var reactRootElement = getReactRootElementInContainer(container);
-    var containerHasReactMarkup =
+    const reactRootElement = getReactRootElementInContainer(container);
+    const containerHasReactMarkup =
       reactRootElement && !!internalGetID(reactRootElement);
-    var containerHasNonRootReactChild = hasNonRootReactChild(container);
+    const containerHasNonRootReactChild = hasNonRootReactChild(container);
 
     if (__DEV__) {
       warning(
@@ -452,7 +452,7 @@ var ReactMount = {
       );
 
       if (!containerHasReactMarkup || reactRootElement.nextSibling) {
-        var rootElementSibling = reactRootElement;
+        let rootElementSibling = reactRootElement;
         while (rootElementSibling) {
           if (internalGetID(rootElementSibling)) {
             warning(
@@ -468,11 +468,11 @@ var ReactMount = {
       }
     }
 
-    var shouldReuseMarkup =
+    const shouldReuseMarkup =
       containerHasReactMarkup &&
       !prevComponent &&
       !containerHasNonRootReactChild;
-    var component = ReactMount._renderNewRootComponent(
+    const component = ReactMount._renderNewRootComponent(
       nextWrappedElement,
       container,
       shouldReuseMarkup,
@@ -536,14 +536,14 @@ var ReactMount = {
       'unmountComponentAtNode(...): Target container is not a DOM element.'
     );
 
-    var prevComponent = getTopLevelWrapperInContainer(container);
+    const prevComponent = getTopLevelWrapperInContainer(container);
     if (!prevComponent) {
       // Check if the node being unmounted was rendered by React, but isn't a
       // root node.
-      var containerHasNonRootReactChild = hasNonRootReactChild(container);
+      const containerHasNonRootReactChild = hasNonRootReactChild(container);
 
       // Check if the container itself is a React root node.
-      var isContainerReactRoot =
+      const isContainerReactRoot =
         container.nodeType === 1 && container.hasAttribute(ROOT_ATTR_NAME);
 
       if (__DEV__) {
@@ -590,29 +590,29 @@ var ReactMount = {
     );
 
     if (shouldReuseMarkup) {
-      var rootElement = getReactRootElementInContainer(container);
+      const rootElement = getReactRootElementInContainer(container);
       if (ReactMarkupChecksum.canReuseMarkup(markup, rootElement)) {
         ReactDOMComponentTree.precacheNode(instance, rootElement);
         return;
       } else {
-        var checksum = rootElement.getAttribute(
+        const checksum = rootElement.getAttribute(
           ReactMarkupChecksum.CHECKSUM_ATTR_NAME
         );
         rootElement.removeAttribute(ReactMarkupChecksum.CHECKSUM_ATTR_NAME);
 
-        var rootMarkup = rootElement.outerHTML;
+        const rootMarkup = rootElement.outerHTML;
         rootElement.setAttribute(
           ReactMarkupChecksum.CHECKSUM_ATTR_NAME,
           checksum
         );
 
-        var normalizedMarkup = markup;
+        let normalizedMarkup = markup;
         if (__DEV__) {
           // because rootMarkup is retrieved from the DOM, various normalizations
           // will have occurred which will not be present in `markup`. Here,
           // insert markup into a <div> or <iframe> depending on the container
           // type to perform the same normalizations before comparing.
-          var normalizer;
+          let normalizer;
           if (container.nodeType === ELEMENT_NODE_TYPE) {
             normalizer = document.createElement('div');
             normalizer.innerHTML = markup;
@@ -626,8 +626,8 @@ var ReactMount = {
           }
         }
 
-        var diffIndex = firstDifferenceIndex(normalizedMarkup, rootMarkup);
-        var difference = ' (client) ' +
+        const diffIndex = firstDifferenceIndex(normalizedMarkup, rootMarkup);
+        const difference = ' (client) ' +
           normalizedMarkup.substring(diffIndex - 20, diffIndex + 20) +
           '\n (server) ' + rootMarkup.substring(diffIndex - 20, diffIndex + 20);
 

--- a/src/renderers/dom/client/ReactReconcileTransaction.js
+++ b/src/renderers/dom/client/ReactReconcileTransaction.js
@@ -11,19 +11,19 @@
 
 'use strict';
 
-var CallbackQueue = require('CallbackQueue');
-var PooledClass = require('PooledClass');
-var ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
-var ReactInputSelection = require('ReactInputSelection');
-var Transaction = require('Transaction');
+const CallbackQueue = require('CallbackQueue');
+const PooledClass = require('PooledClass');
+const ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
+const ReactInputSelection = require('ReactInputSelection');
+const Transaction = require('Transaction');
 
-var assign = require('Object.assign');
+const assign = require('Object.assign');
 
 /**
  * Ensures that, when possible, the selection range (currently selected text
  * input) is not disturbed by performing the transaction.
  */
-var SELECTION_RESTORATION = {
+const SELECTION_RESTORATION = {
   /**
    * @return {Selection} Selection information.
    */
@@ -39,13 +39,13 @@ var SELECTION_RESTORATION = {
  * high level DOM manipulations (like temporarily removing a text input from the
  * DOM).
  */
-var EVENT_SUPPRESSION = {
+const EVENT_SUPPRESSION = {
   /**
    * @return {boolean} The enabled status of `ReactBrowserEventEmitter` before
    * the reconciliation.
    */
   initialize: function() {
-    var currentlyEnabled = ReactBrowserEventEmitter.isEnabled();
+    const currentlyEnabled = ReactBrowserEventEmitter.isEnabled();
     ReactBrowserEventEmitter.setEnabled(false);
     return currentlyEnabled;
   },
@@ -64,7 +64,7 @@ var EVENT_SUPPRESSION = {
  * Provides a queue for collecting `componentDidMount` and
  * `componentDidUpdate` callbacks during the transaction.
  */
-var ON_DOM_READY_QUEUEING = {
+const ON_DOM_READY_QUEUEING = {
   /**
    * Initializes the internal `onDOMReady` queue.
    */
@@ -85,7 +85,7 @@ var ON_DOM_READY_QUEUEING = {
  * being member methods, but with an implied ordering while being isolated from
  * each other.
  */
-var TRANSACTION_WRAPPERS = [
+const TRANSACTION_WRAPPERS = [
   SELECTION_RESTORATION,
   EVENT_SUPPRESSION,
   ON_DOM_READY_QUEUEING,
@@ -117,7 +117,7 @@ function ReactReconcileTransaction(useCreateElement) {
   this.useCreateElement = useCreateElement;
 }
 
-var Mixin = {
+const Mixin = {
   /**
    * @see Transaction
    * @abstract

--- a/src/renderers/dom/client/__tests__/ReactBrowserEventEmitter-test.js
+++ b/src/renderers/dom/client/__tests__/ReactBrowserEventEmitter-test.js
@@ -11,43 +11,43 @@
 
 'use strict';
 
-var keyOf = require('keyOf');
+const keyOf = require('keyOf');
 
-var EventListener;
-var EventPluginHub;
-var EventPluginRegistry;
-var React;
-var ReactBrowserEventEmitter;
-var ReactDOMComponentTree;
-var ReactTestUtils;
-var TapEventPlugin;
+let EventListener;
+let EventPluginHub;
+let EventPluginRegistry;
+let React;
+let ReactBrowserEventEmitter;
+let ReactDOMComponentTree;
+let ReactTestUtils;
+let TapEventPlugin;
 
-var tapMoveThreshold;
-var idCallOrder;
-var recordID = function(id) {
+let tapMoveThreshold;
+let idCallOrder;
+const recordID = function(id) {
   idCallOrder.push(id);
 };
-var recordIDAndStopPropagation = function(id, event) {
+const recordIDAndStopPropagation = function(id, event) {
   recordID(id);
   event.stopPropagation();
 };
-var recordIDAndReturnFalse = function(id, event) {
+const recordIDAndReturnFalse = function(id, event) {
   recordID(id);
   return false;
 };
-var LISTENER = jest.genMockFn();
-var ON_CLICK_KEY = keyOf({onClick: null});
-var ON_TOUCH_TAP_KEY = keyOf({onTouchTap: null});
-var ON_CHANGE_KEY = keyOf({onChange: null});
-var ON_MOUSE_ENTER_KEY = keyOf({onMouseEnter: null});
+const LISTENER = jest.genMockFn();
+const ON_CLICK_KEY = keyOf({onClick: null});
+const ON_TOUCH_TAP_KEY = keyOf({onTouchTap: null});
+const ON_CHANGE_KEY = keyOf({onChange: null});
+const ON_MOUSE_ENTER_KEY = keyOf({onMouseEnter: null});
 
-var GRANDPARENT;
-var PARENT;
-var CHILD;
+let GRANDPARENT;
+let PARENT;
+let CHILD;
 
 function registerSimpleTestHandler() {
   EventPluginHub.putListener(getInternal(CHILD), ON_CLICK_KEY, LISTENER);
-  var listener = EventPluginHub.getListener(getInternal(CHILD), ON_CLICK_KEY);
+  const listener = EventPluginHub.getListener(getInternal(CHILD), ON_CLICK_KEY);
   expect(listener).toEqual(LISTENER);
   return EventPluginHub.getListener(getInternal(CHILD), ON_CLICK_KEY);
 }
@@ -87,20 +87,20 @@ describe('ReactBrowserEventEmitter', function() {
 
   it('should store a listener correctly', function() {
     registerSimpleTestHandler();
-    var listener = EventPluginHub.getListener(getInternal(CHILD), ON_CLICK_KEY);
+    const listener = EventPluginHub.getListener(getInternal(CHILD), ON_CLICK_KEY);
     expect(listener).toBe(LISTENER);
   });
 
   it('should retrieve a listener correctly', function() {
     registerSimpleTestHandler();
-    var listener = EventPluginHub.getListener(getInternal(CHILD), ON_CLICK_KEY);
+    const listener = EventPluginHub.getListener(getInternal(CHILD), ON_CLICK_KEY);
     expect(listener).toEqual(LISTENER);
   });
 
   it('should clear all handlers when asked to', function() {
     registerSimpleTestHandler();
     EventPluginHub.deleteAllListeners(getInternal(CHILD));
-    var listener = EventPluginHub.getListener(getInternal(CHILD), ON_CLICK_KEY);
+    const listener = EventPluginHub.getListener(getInternal(CHILD), ON_CLICK_KEY);
     expect(listener).toBe(undefined);
   });
 
@@ -284,8 +284,8 @@ describe('ReactBrowserEventEmitter', function() {
    */
 
   it('should invoke handlers that were removed while bubbling', function() {
-    var handleParentClick = jest.genMockFn();
-    var handleChildClick = function(event) {
+    const handleParentClick = jest.genMockFn();
+    const handleChildClick = function(event) {
       EventPluginHub.deleteAllListeners(getInternal(PARENT));
     };
     EventPluginHub.putListener(
@@ -303,8 +303,8 @@ describe('ReactBrowserEventEmitter', function() {
   });
 
   it('should not invoke newly inserted handlers while bubbling', function() {
-    var handleParentClick = jest.genMockFn();
-    var handleChildClick = function(event) {
+    const handleParentClick = jest.genMockFn();
+    const handleChildClick = function(event) {
       EventPluginHub.putListener(
         getInternal(PARENT),
         ON_CLICK_KEY,
@@ -405,9 +405,9 @@ describe('ReactBrowserEventEmitter', function() {
 
     ReactBrowserEventEmitter.listenTo(ON_CHANGE_KEY, document);
 
-    var setEventListeners = [];
-    var listenCalls = EventListener.listen.argsForCall;
-    var captureCalls = EventListener.capture.argsForCall;
+    const setEventListeners = [];
+    const listenCalls = EventListener.listen.argsForCall;
+    const captureCalls = EventListener.capture.argsForCall;
     for (var i = 0; i < listenCalls.length; i++) {
       setEventListeners.push(listenCalls[i][1]);
     }
@@ -415,8 +415,8 @@ describe('ReactBrowserEventEmitter', function() {
       setEventListeners.push(captureCalls[i][1]);
     }
 
-    var module = EventPluginRegistry.registrationNameModules[ON_CHANGE_KEY];
-    var dependencies = module.eventTypes.change.dependencies;
+    const module = EventPluginRegistry.registrationNameModules[ON_CHANGE_KEY];
+    const dependencies = module.eventTypes.change.dependencies;
     expect(setEventListeners.length).toEqual(dependencies.length);
 
     for (i = 0; i < setEventListeners.length; i++) {

--- a/src/renderers/dom/client/__tests__/ReactDOM-test.js
+++ b/src/renderers/dom/client/__tests__/ReactDOM-test.js
@@ -11,10 +11,10 @@
 
 'use strict';
 
-var React = require('React');
-var ReactDOM = require('ReactDOM');
-var ReactTestUtils = require('ReactTestUtils');
-var div = React.createFactory('div');
+const React = require('React');
+const ReactDOM = require('ReactDOM');
+const ReactTestUtils = require('ReactTestUtils');
+const div = React.createFactory('div');
 
 describe('ReactDOM', function() {
   // TODO: uncomment this test once we can run in phantom, which
@@ -47,24 +47,24 @@ describe('ReactDOM', function() {
   */
 
   it('allows a DOM element to be used with a string', function() {
-    var element = React.createElement('div', {className: 'foo'});
-    var instance = ReactTestUtils.renderIntoDocument(element);
+    const element = React.createElement('div', {className: 'foo'});
+    const instance = ReactTestUtils.renderIntoDocument(element);
     expect(ReactDOM.findDOMNode(instance).tagName).toBe('DIV');
   });
 
   it('should allow children to be passed as an argument', function() {
-    var argDiv = ReactTestUtils.renderIntoDocument(
+    const argDiv = ReactTestUtils.renderIntoDocument(
       div(null, 'child')
     );
-    var argNode = ReactDOM.findDOMNode(argDiv);
+    const argNode = ReactDOM.findDOMNode(argDiv);
     expect(argNode.innerHTML).toBe('child');
   });
 
   it('should overwrite props.children with children argument', function() {
-    var conflictDiv = ReactTestUtils.renderIntoDocument(
+    const conflictDiv = ReactTestUtils.renderIntoDocument(
       div({children: 'fakechild'}, 'child')
     );
-    var conflictNode = ReactDOM.findDOMNode(conflictDiv);
+    const conflictNode = ReactDOM.findDOMNode(conflictDiv);
     expect(conflictNode.innerHTML).toBe('child');
   });
 
@@ -73,7 +73,7 @@ describe('ReactDOM', function() {
    * DOM, instead of a stale cache.
    */
   it('should purge the DOM cache when removing nodes', function() {
-    var myDiv = ReactTestUtils.renderIntoDocument(
+    let myDiv = ReactTestUtils.renderIntoDocument(
       <div>
         <div key="theDog" className="dog" />,
         <div key="theBird" className="bird" />
@@ -106,14 +106,14 @@ describe('ReactDOM', function() {
         <div key="theBird" className="bird" />,
       </div>
     );
-    var root = ReactDOM.findDOMNode(myDiv);
-    var dog = root.childNodes[0];
+    const root = ReactDOM.findDOMNode(myDiv);
+    const dog = root.childNodes[0];
     expect(dog.className).toBe('bigdog');
   });
 
   it('allow React.DOM factories to be called without warnings', function() {
     spyOn(console, 'error');
-    var element = React.DOM.div();
+    const element = React.DOM.div();
     expect(element.type).toBe('div');
     expect(console.error.argsForCall.length).toBe(0);
   });

--- a/src/renderers/dom/client/__tests__/ReactDOMComponentTree-test.js
+++ b/src/renderers/dom/client/__tests__/ReactDOMComponentTree-test.js
@@ -12,13 +12,13 @@
 'use strict';
 
 describe('ReactDOMComponentTree', function() {
-  var React;
-  var ReactDOM;
-  var ReactDOMComponentTree;
-  var ReactDOMServer;
+  let React;
+  let ReactDOM;
+  let ReactDOMComponentTree;
+  let ReactDOMServer;
 
   function renderMarkupIntoDocument(elt) {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     // Force server-rendering path:
     container.innerHTML = ReactDOMServer.renderToString(elt);
     return ReactDOM.render(elt, container);
@@ -35,9 +35,9 @@ describe('ReactDOMComponentTree', function() {
     // This is a little hard to test directly. But refs rely on it -- so we
     // check that we can find a ref at arbitrary points in the tree, even if
     // other nodes don't have a ref.
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
-        var toRef = this.props.toRef;
+        const toRef = this.props.toRef;
         return (
           <div ref={toRef === 'div' ? 'target' : null}>
             <h1 ref={toRef === 'h1' ? 'target' : null}>hello</h1>
@@ -51,7 +51,7 @@ describe('ReactDOMComponentTree', function() {
     });
 
     function renderAndGetRef(toRef) {
-      var inst = renderMarkupIntoDocument(<Component toRef={toRef} />);
+      const inst = renderMarkupIntoDocument(<Component toRef={toRef} />);
       return inst.refs.target.nodeName;
     }
 
@@ -62,7 +62,7 @@ describe('ReactDOMComponentTree', function() {
   });
 
   it('finds instances for nodes', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         return (
           <div>
@@ -78,7 +78,7 @@ describe('ReactDOMComponentTree', function() {
     });
 
     function renderAndQuery(sel) {
-      var root = renderMarkupIntoDocument(<section><Component /></section>);
+      const root = renderMarkupIntoDocument(<section><Component /></section>);
       return sel ? root.querySelector(sel) : root;
     }
 
@@ -101,7 +101,7 @@ describe('ReactDOMComponentTree', function() {
 
     // This one's a text component!
     var root = renderAndQuery(null);
-    var inst = ReactDOMComponentTree.getInstanceFromNode(root.children[0].childNodes[2]);
+    const inst = ReactDOMComponentTree.getInstanceFromNode(root.children[0].childNodes[2]);
     expect(inst._stringText).toBe('goodbye.');
 
     expect(renderAndGetClosest('b')._currentElement.type).toBe('main');

--- a/src/renderers/dom/client/__tests__/ReactDOMIDOperations-test.js
+++ b/src/renderers/dom/client/__tests__/ReactDOMIDOperations-test.js
@@ -12,12 +12,12 @@
 'use strict';
 
 describe('ReactDOMIDOperations', function() {
-  var ReactDOMIDOperations = require('ReactDOMIDOperations');
-  var ReactMultiChildUpdateTypes = require('ReactMultiChildUpdateTypes');
+  const ReactDOMIDOperations = require('ReactDOMIDOperations');
+  const ReactMultiChildUpdateTypes = require('ReactMultiChildUpdateTypes');
 
   it('should update innerHTML and preserve whitespace', function() {
-    var stubNode = document.createElement('div');
-    var html = '\n  \t  <span>  \n  testContent  \t  </span>  \n  \t';
+    const stubNode = document.createElement('div');
+    const html = '\n  \t  <span>  \n  testContent  \t  </span>  \n  \t';
 
     ReactDOMIDOperations.dangerouslyProcessChildrenUpdates(
       {_nativeNode: stubNode},

--- a/src/renderers/dom/client/__tests__/ReactDOMSVG-test.js
+++ b/src/renderers/dom/client/__tests__/ReactDOMSVG-test.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-var React;
-var ReactDOMServer;
+let React;
+let ReactDOMServer;
 
 describe('ReactDOMSVG', function() {
 
@@ -22,14 +22,14 @@ describe('ReactDOMSVG', function() {
   });
 
   it('creates initial markup for known hyphenated attributes', function() {
-    var markup = ReactDOMServer.renderToString(
+    const markup = ReactDOMServer.renderToString(
       <svg clip-path="url(#starlet)" />
     );
     expect(markup).toContain('clip-path="url(#starlet)"');
   });
 
   it('creates initial markup for camel case attributes', function() {
-    var markup = ReactDOMServer.renderToString(
+    const markup = ReactDOMServer.renderToString(
       <svg viewBox="0 0 100 100" />
     );
     expect(markup).toContain('viewBox="0 0 100 100"');
@@ -37,7 +37,7 @@ describe('ReactDOMSVG', function() {
 
   it('deprecates camel casing of hyphenated attributes', function() {
     spyOn(console, 'error');
-    var markup = ReactDOMServer.renderToString(
+    const markup = ReactDOMServer.renderToString(
       <svg clipPath="url(#starlet)" />
     );
     expect(markup).toContain('clip-path="url(#starlet)"');
@@ -47,21 +47,21 @@ describe('ReactDOMSVG', function() {
   });
 
   it('creates initial markup for unknown hyphenated attributes', function() {
-    var markup = ReactDOMServer.renderToString(
+    const markup = ReactDOMServer.renderToString(
       <svg the-word="the-bird" />
     );
     expect(markup).toContain('the-word="the-bird"');
   });
 
   it('creates initial markup for unknown camel case attributes', function() {
-    var markup = ReactDOMServer.renderToString(
+    const markup = ReactDOMServer.renderToString(
       <svg theWord="theBird" />
     );
     expect(markup).toContain('theWord="theBird"');
   });
 
   it('creates initial namespaced markup', function() {
-    var markup = ReactDOMServer.renderToString(
+    const markup = ReactDOMServer.renderToString(
       <svg>
         <image xlinkHref="http://i.imgur.com/w7GCRPb.png" />
       </svg>

--- a/src/renderers/dom/client/__tests__/ReactDOMTreeTraversal-test.js
+++ b/src/renderers/dom/client/__tests__/ReactDOMTreeTraversal-test.js
@@ -11,17 +11,17 @@
 
 'use strict';
 
-var React = require('React');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var ReactTestUtils = require('ReactTestUtils');
+const React = require('React');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
+const ReactTestUtils = require('ReactTestUtils');
 
 /**
  * Ensure that all callbacks are invoked, passing this unique argument.
  */
-var ARG = {arg: true};
-var ARG2 = {arg2: true};
+const ARG = {arg: true};
+const ARG2 = {arg2: true};
 
-var ChildComponent = React.createClass({
+const ChildComponent = React.createClass({
   render: function() {
     return (
       <div ref="DIV">
@@ -32,7 +32,7 @@ var ChildComponent = React.createClass({
   },
 });
 
-var ParentComponent = React.createClass({
+const ParentComponent = React.createClass({
   render: function() {
     return (
       <div ref="P">
@@ -51,9 +51,9 @@ function renderParentIntoDocument() {
 }
 
 describe('ReactDOMTreeTraversal', function() {
-  var ReactDOMTreeTraversal;
+  let ReactDOMTreeTraversal;
 
-  var aggregatedArgs;
+  let aggregatedArgs;
   function argAggregator(inst, isUp, arg) {
     aggregatedArgs.push({
       node: ReactDOMComponentTree.getNodeFromInstance(inst),
@@ -73,15 +73,15 @@ describe('ReactDOMTreeTraversal', function() {
 
   describe('traverseTwoPhase', function() {
     it('should not traverse when traversing outside DOM', function() {
-      var expectedAggregation = [];
+      const expectedAggregation = [];
       ReactDOMTreeTraversal.traverseTwoPhase(null, argAggregator, ARG);
       expect(aggregatedArgs).toEqual(expectedAggregation);
     });
 
     it('should traverse two phase across component boundary', function() {
-      var parent = renderParentIntoDocument();
-      var target = getInst(parent.refs.P_P1_C1.refs.DIV_1);
-      var expectedAggregation = [
+      const parent = renderParentIntoDocument();
+      const target = getInst(parent.refs.P_P1_C1.refs.DIV_1);
+      const expectedAggregation = [
         {node: parent.refs.P, isUp: false, arg: ARG},
         {node: parent.refs.P_P1, isUp: false, arg: ARG},
         {node: parent.refs.P_P1_C1.refs.DIV, isUp: false, arg: ARG},
@@ -97,9 +97,9 @@ describe('ReactDOMTreeTraversal', function() {
     });
 
     it('should traverse two phase at shallowest node', function() {
-      var parent = renderParentIntoDocument();
-      var target = getInst(parent.refs.P);
-      var expectedAggregation = [
+      const parent = renderParentIntoDocument();
+      const target = getInst(parent.refs.P);
+      const expectedAggregation = [
         {node: parent.refs.P, isUp: false, arg: ARG},
         {node: parent.refs.P, isUp: true, arg: ARG},
       ];
@@ -110,8 +110,8 @@ describe('ReactDOMTreeTraversal', function() {
 
   describe('traverseEnterLeave', function() {
     it('should not traverse when enter/leaving outside DOM', function() {
-      var target = null;
-      var expectedAggregation = [];
+      const target = null;
+      const expectedAggregation = [];
       ReactDOMTreeTraversal.traverseEnterLeave(
         target, target, argAggregator, ARG, ARG2
       );
@@ -119,10 +119,10 @@ describe('ReactDOMTreeTraversal', function() {
     });
 
     it('should not traverse if enter/leave the same node', function() {
-      var parent = renderParentIntoDocument();
-      var leave = getInst(parent.refs.P_P1_C1.refs.DIV_1);
-      var enter = getInst(parent.refs.P_P1_C1.refs.DIV_1);
-      var expectedAggregation = [];
+      const parent = renderParentIntoDocument();
+      const leave = getInst(parent.refs.P_P1_C1.refs.DIV_1);
+      const enter = getInst(parent.refs.P_P1_C1.refs.DIV_1);
+      const expectedAggregation = [];
       ReactDOMTreeTraversal.traverseEnterLeave(
         leave, enter, argAggregator, ARG, ARG2
       );
@@ -130,10 +130,10 @@ describe('ReactDOMTreeTraversal', function() {
     });
 
     it('should traverse enter/leave to sibling - avoids parent', function() {
-      var parent = renderParentIntoDocument();
-      var leave = getInst(parent.refs.P_P1_C1.refs.DIV_1);
-      var enter = getInst(parent.refs.P_P1_C1.refs.DIV_2);
-      var expectedAggregation = [
+      const parent = renderParentIntoDocument();
+      const leave = getInst(parent.refs.P_P1_C1.refs.DIV_1);
+      const enter = getInst(parent.refs.P_P1_C1.refs.DIV_2);
+      const expectedAggregation = [
         {node: parent.refs.P_P1_C1.refs.DIV_1, isUp: true, arg: ARG},
         // enter/leave shouldn't fire anything on the parent
         {node: parent.refs.P_P1_C1.refs.DIV_2, isUp: false, arg: ARG2},
@@ -145,10 +145,10 @@ describe('ReactDOMTreeTraversal', function() {
     });
 
     it('should traverse enter/leave to parent - avoids parent', function() {
-      var parent = renderParentIntoDocument();
-      var leave = getInst(parent.refs.P_P1_C1.refs.DIV_1);
-      var enter = getInst(parent.refs.P_P1_C1.refs.DIV);
-      var expectedAggregation = [
+      const parent = renderParentIntoDocument();
+      const leave = getInst(parent.refs.P_P1_C1.refs.DIV_1);
+      const enter = getInst(parent.refs.P_P1_C1.refs.DIV);
+      const expectedAggregation = [
         {node: parent.refs.P_P1_C1.refs.DIV_1, isUp: true, arg: ARG},
       ];
       ReactDOMTreeTraversal.traverseEnterLeave(
@@ -158,10 +158,10 @@ describe('ReactDOMTreeTraversal', function() {
     });
 
     it('should enter from the window', function() {
-      var parent = renderParentIntoDocument();
-      var leave = null; // From the window or outside of the React sandbox.
-      var enter = getInst(parent.refs.P_P1_C1.refs.DIV);
-      var expectedAggregation = [
+      const parent = renderParentIntoDocument();
+      const leave = null; // From the window or outside of the React sandbox.
+      const enter = getInst(parent.refs.P_P1_C1.refs.DIV);
+      const expectedAggregation = [
         {node: parent.refs.P, isUp: false, arg: ARG2},
         {node: parent.refs.P_P1, isUp: false, arg: ARG2},
         {node: parent.refs.P_P1_C1.refs.DIV, isUp: false, arg: ARG2},
@@ -173,10 +173,10 @@ describe('ReactDOMTreeTraversal', function() {
     });
 
     it('should enter from the window to the shallowest', function() {
-      var parent = renderParentIntoDocument();
-      var leave = null; // From the window or outside of the React sandbox.
-      var enter = getInst(parent.refs.P);
-      var expectedAggregation = [
+      const parent = renderParentIntoDocument();
+      const leave = null; // From the window or outside of the React sandbox.
+      const enter = getInst(parent.refs.P);
+      const expectedAggregation = [
         {node: parent.refs.P, isUp: false, arg: ARG2},
       ];
       ReactDOMTreeTraversal.traverseEnterLeave(
@@ -186,10 +186,10 @@ describe('ReactDOMTreeTraversal', function() {
     });
 
     it('should leave to the window', function() {
-      var parent = renderParentIntoDocument();
-      var enter = null; // From the window or outside of the React sandbox.
-      var leave = getInst(parent.refs.P_P1_C1.refs.DIV);
-      var expectedAggregation = [
+      const parent = renderParentIntoDocument();
+      const enter = null; // From the window or outside of the React sandbox.
+      const leave = getInst(parent.refs.P_P1_C1.refs.DIV);
+      const expectedAggregation = [
         {node: parent.refs.P_P1_C1.refs.DIV, isUp: true, arg: ARG},
         {node: parent.refs.P_P1, isUp: true, arg: ARG},
         {node: parent.refs.P, isUp: true, arg: ARG},
@@ -201,10 +201,10 @@ describe('ReactDOMTreeTraversal', function() {
     });
 
     it('should leave to the window from the shallowest', function() {
-      var parent = renderParentIntoDocument();
-      var enter = null; // From the window or outside of the React sandbox.
-      var leave = getInst(parent.refs.P_P1_C1.refs.DIV);
-      var expectedAggregation = [
+      const parent = renderParentIntoDocument();
+      const enter = null; // From the window or outside of the React sandbox.
+      const leave = getInst(parent.refs.P_P1_C1.refs.DIV);
+      const expectedAggregation = [
         {node: parent.refs.P_P1_C1.refs.DIV, isUp: true, arg: ARG},
         {node: parent.refs.P_P1, isUp: true, arg: ARG},
         {node: parent.refs.P, isUp: true, arg: ARG},
@@ -218,8 +218,8 @@ describe('ReactDOMTreeTraversal', function() {
 
   describe('getFirstCommonAncestor', function() {
     it('should determine the first common ancestor correctly', function() {
-      var parent = renderParentIntoDocument();
-      var ancestors = [
+      const parent = renderParentIntoDocument();
+      const ancestors = [
         // Common ancestor with self is self.
         {one: parent.refs.P_P1_C1.refs.DIV_1,
           two: parent.refs.P_P1_C1.refs.DIV_1,
@@ -258,10 +258,10 @@ describe('ReactDOMTreeTraversal', function() {
           com: parent.refs.P,
         },
       ];
-      var i;
+      let i;
       for (i = 0; i < ancestors.length; i++) {
-        var plan = ancestors[i];
-        var firstCommon = ReactDOMTreeTraversal.getLowestCommonAncestor(
+        const plan = ancestors[i];
+        const firstCommon = ReactDOMTreeTraversal.getLowestCommonAncestor(
           getInst(plan.one),
           getInst(plan.two)
         );

--- a/src/renderers/dom/client/__tests__/ReactEventIndependence-test.js
+++ b/src/renderers/dom/client/__tests__/ReactEventIndependence-test.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
-var ReactTestUtils;
+let React;
+let ReactDOM;
+let ReactTestUtils;
 
 describe('ReactEventIndependence', function() {
   beforeEach(function() {
@@ -25,8 +25,8 @@ describe('ReactEventIndependence', function() {
   });
 
   it('does not crash with other react inside', function() {
-    var clicks = 0;
-    var div = ReactTestUtils.renderIntoDocument(
+    let clicks = 0;
+    const div = ReactTestUtils.renderIntoDocument(
       <div
         onClick={() => clicks++}
         dangerouslySetInnerHTML={{
@@ -39,10 +39,10 @@ describe('ReactEventIndependence', function() {
   });
 
   it('does not crash with other react outside', function() {
-    var clicks = 0;
-    var outer = document.createElement('div');
+    let clicks = 0;
+    const outer = document.createElement('div');
     outer.setAttribute('data-reactid', '.z');
-    var inner = ReactDOM.render(
+    const inner = ReactDOM.render(
       <button onClick={() => clicks++}>click me</button>,
       outer
     );
@@ -51,9 +51,9 @@ describe('ReactEventIndependence', function() {
   });
 
   it('does not when event fired on unmounted tree', function() {
-    var clicks = 0;
-    var container = document.createElement('div');
-    var button = ReactDOM.render(
+    let clicks = 0;
+    const container = document.createElement('div');
+    const button = ReactDOM.render(
       <button onClick={() => clicks++}>click me</button>,
       container
     );

--- a/src/renderers/dom/client/__tests__/ReactEventListener-test.js
+++ b/src/renderers/dom/client/__tests__/ReactEventListener-test.js
@@ -12,15 +12,15 @@
 'use strict';
 
 
-var EVENT_TARGET_PARAM = 1;
+const EVENT_TARGET_PARAM = 1;
 
 describe('ReactEventListener', function() {
-  var React;
-  var ReactDOM;
-  var ReactDOMComponentTree;
-  var ReactEventListener;
-  var ReactTestUtils;
-  var handleTopLevel;
+  let React;
+  let ReactDOM;
+  let ReactDOMComponentTree;
+  let ReactEventListener;
+  let ReactTestUtils;
+  let handleTopLevel;
 
   beforeEach(function() {
     jest.resetModuleRegistry();
@@ -35,8 +35,8 @@ describe('ReactEventListener', function() {
   });
 
   it('should dispatch events from outside React tree', function() {
-    var otherNode = document.createElement('h1');
-    var component = ReactDOM.render(<div />, document.createElement('div'));
+    const otherNode = document.createElement('h1');
+    const component = ReactDOM.render(<div />, document.createElement('div'));
     expect(handleTopLevel.mock.calls.length).toBe(0);
     ReactEventListener.dispatchEvent(
       'topMouseOut',
@@ -56,21 +56,21 @@ describe('ReactEventListener', function() {
 
   describe('Propagation', function() {
     it('should propagate events one level down', function() {
-      var childContainer = document.createElement('div');
-      var childControl = <div>Child</div>;
-      var parentContainer = document.createElement('div');
-      var parentControl = <div>Parent</div>;
+      const childContainer = document.createElement('div');
+      let childControl = <div>Child</div>;
+      const parentContainer = document.createElement('div');
+      let parentControl = <div>Parent</div>;
       childControl = ReactDOM.render(childControl, childContainer);
       parentControl =
         ReactDOM.render(parentControl, parentContainer);
       ReactDOM.findDOMNode(parentControl).appendChild(childContainer);
 
-      var callback = ReactEventListener.dispatchEvent.bind(null, 'test');
+      const callback = ReactEventListener.dispatchEvent.bind(null, 'test');
       callback({
         target: ReactDOM.findDOMNode(childControl),
       });
 
-      var calls = handleTopLevel.mock.calls;
+      const calls = handleTopLevel.mock.calls;
       expect(calls.length).toBe(2);
       expect(calls[0][EVENT_TARGET_PARAM])
         .toBe(ReactDOMComponentTree.getInstanceFromNode(childControl));
@@ -79,12 +79,12 @@ describe('ReactEventListener', function() {
     });
 
     it('should propagate events two levels down', function() {
-      var childContainer = document.createElement('div');
-      var childControl = <div>Child</div>;
-      var parentContainer = document.createElement('div');
-      var parentControl = <div>Parent</div>;
-      var grandParentContainer = document.createElement('div');
-      var grandParentControl = <div>Parent</div>;
+      const childContainer = document.createElement('div');
+      let childControl = <div>Child</div>;
+      const parentContainer = document.createElement('div');
+      let parentControl = <div>Parent</div>;
+      const grandParentContainer = document.createElement('div');
+      let grandParentControl = <div>Parent</div>;
       childControl = ReactDOM.render(childControl, childContainer);
       parentControl =
         ReactDOM.render(parentControl, parentContainer);
@@ -93,12 +93,12 @@ describe('ReactEventListener', function() {
       ReactDOM.findDOMNode(parentControl).appendChild(childContainer);
       ReactDOM.findDOMNode(grandParentControl).appendChild(parentContainer);
 
-      var callback = ReactEventListener.dispatchEvent.bind(null, 'test');
+      const callback = ReactEventListener.dispatchEvent.bind(null, 'test');
       callback({
         target: ReactDOM.findDOMNode(childControl),
       });
 
-      var calls = handleTopLevel.mock.calls;
+      const calls = handleTopLevel.mock.calls;
       expect(calls.length).toBe(3);
       expect(calls[0][EVENT_TARGET_PARAM])
         .toBe(ReactDOMComponentTree.getInstanceFromNode(childControl));
@@ -109,10 +109,10 @@ describe('ReactEventListener', function() {
     });
 
     it('should not get confused by disappearing elements', function() {
-      var childContainer = document.createElement('div');
-      var childControl = <div>Child</div>;
-      var parentContainer = document.createElement('div');
-      var parentControl = <div>Parent</div>;
+      const childContainer = document.createElement('div');
+      let childControl = <div>Child</div>;
+      const parentContainer = document.createElement('div');
+      let parentControl = <div>Parent</div>;
       childControl = ReactDOM.render(childControl, childContainer);
       parentControl =
         ReactDOM.render(parentControl, parentContainer);
@@ -122,7 +122,7 @@ describe('ReactEventListener', function() {
       // target from the DOM. Here, we have handleTopLevel remove the
       // node when the first event handlers are called; we'll still
       // expect to receive a second call for the parent control.
-      var childNode = ReactDOM.findDOMNode(childControl);
+      const childNode = ReactDOM.findDOMNode(childControl);
       handleTopLevel.mockImplementation(
         function(topLevelType, topLevelTarget, topLevelTargetID, nativeEvent) {
           if (topLevelTarget === childNode) {
@@ -131,12 +131,12 @@ describe('ReactEventListener', function() {
         }
       );
 
-      var callback = ReactEventListener.dispatchEvent.bind(null, 'test');
+      const callback = ReactEventListener.dispatchEvent.bind(null, 'test');
       callback({
         target: childNode,
       });
 
-      var calls = handleTopLevel.mock.calls;
+      const calls = handleTopLevel.mock.calls;
       expect(calls.length).toBe(2);
       expect(calls[0][EVENT_TARGET_PARAM])
         .toBe(ReactDOMComponentTree.getInstanceFromNode(childNode));
@@ -145,13 +145,13 @@ describe('ReactEventListener', function() {
     });
 
     it('should batch between handlers from different roots', function() {
-      var childContainer = document.createElement('div');
-      var parentContainer = document.createElement('div');
-      var childControl = ReactDOM.render(
+      const childContainer = document.createElement('div');
+      const parentContainer = document.createElement('div');
+      const childControl = ReactDOM.render(
         <div>Child</div>,
         childContainer
       );
-      var parentControl = ReactDOM.render(
+      const parentControl = ReactDOM.render(
         <div>Parent</div>,
         parentContainer
       );
@@ -159,7 +159,7 @@ describe('ReactEventListener', function() {
 
       // Suppose an event handler in each root enqueues an update to the
       // childControl element -- the two updates should get batched together.
-      var childNode = ReactDOM.findDOMNode(childControl);
+      const childNode = ReactDOM.findDOMNode(childControl);
       handleTopLevel.mockImplementation(
         function(topLevelType, topLevelTarget, topLevelTargetID, nativeEvent) {
           ReactDOM.render(
@@ -171,40 +171,40 @@ describe('ReactEventListener', function() {
         }
       );
 
-      var callback =
+      const callback =
         ReactEventListener.dispatchEvent.bind(ReactEventListener, 'test');
       callback({
         target: childNode,
       });
 
-      var calls = handleTopLevel.mock.calls;
+      const calls = handleTopLevel.mock.calls;
       expect(calls.length).toBe(2);
       expect(childNode.textContent).toBe('2');
     });
   });
 
   it('should not fire duplicate events for a React DOM tree', function() {
-    var Wrapper = React.createClass({
+    const Wrapper = React.createClass({
 
       getInner: function() {
         return this.refs.inner;
       },
 
       render: function() {
-        var inner = <div ref="inner">Inner</div>;
+        const inner = <div ref="inner">Inner</div>;
         return <div><div id="outer">{inner}</div></div>;
       },
 
     });
 
-    var instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
+    const instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
 
-    var callback = ReactEventListener.dispatchEvent.bind(null, 'test');
+    const callback = ReactEventListener.dispatchEvent.bind(null, 'test');
     callback({
       target: ReactDOM.findDOMNode(instance.getInner()),
     });
 
-    var calls = handleTopLevel.mock.calls;
+    const calls = handleTopLevel.mock.calls;
     expect(calls.length).toBe(1);
     expect(calls[0][EVENT_TARGET_PARAM])
       .toBe(ReactDOMComponentTree.getInstanceFromNode(instance.getInner()));

--- a/src/renderers/dom/client/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMount-test.js
@@ -11,12 +11,12 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
-var ReactDOMServer;
-var ReactMount;
-var ReactTestUtils;
-var WebComponents;
+let React;
+let ReactDOM;
+let ReactDOMServer;
+let ReactMount;
+let ReactTestUtils;
+let WebComponents;
 
 describe('ReactMount', function() {
   beforeEach(function() {
@@ -41,7 +41,7 @@ describe('ReactMount', function() {
 
   describe('unmountComponentAtNode', function() {
     it('throws when given a non-node', function() {
-      var nodeArray = document.getElementsByTagName('div');
+      const nodeArray = document.getElementsByTagName('div');
       expect(function() {
         ReactDOM.unmountComponentAtNode(nodeArray);
       }).toThrow(
@@ -61,7 +61,7 @@ describe('ReactMount', function() {
   });
 
   it('throws when given a factory', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         return <div />;
       },
@@ -76,7 +76,7 @@ describe('ReactMount', function() {
   });
 
   it('should render different components in same root', function() {
-    var container = document.createElement('container');
+    const container = document.createElement('container');
     document.body.appendChild(container);
 
     ReactMount.render(<div></div>, container);
@@ -87,12 +87,12 @@ describe('ReactMount', function() {
   });
 
   it('should unmount and remount if the key changes', function() {
-    var container = document.createElement('container');
+    const container = document.createElement('container');
 
-    var mockMount = jest.genMockFn();
-    var mockUnmount = jest.genMockFn();
+    const mockMount = jest.genMockFn();
+    const mockUnmount = jest.genMockFn();
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       componentDidMount: mockMount,
       componentWillUnmount: mockUnmount,
       render: function() {
@@ -122,15 +122,15 @@ describe('ReactMount', function() {
   });
 
   it('should reuse markup if rendering to the same target twice', function() {
-    var container = document.createElement('container');
-    var instance1 = ReactDOM.render(<div />, container);
-    var instance2 = ReactDOM.render(<div />, container);
+    const container = document.createElement('container');
+    const instance1 = ReactDOM.render(<div />, container);
+    const instance2 = ReactDOM.render(<div />, container);
 
     expect(instance1 === instance2).toBe(true);
   });
 
   it('should warn if mounting into dirty rendered markup', function() {
-    var container = document.createElement('container');
+    const container = document.createElement('container');
     container.innerHTML = ReactDOMServer.renderToString(<div />) + ' ';
 
     spyOn(console, 'error');
@@ -144,7 +144,7 @@ describe('ReactMount', function() {
   });
 
   it('should not warn if mounting into non-empty node', function() {
-    var container = document.createElement('container');
+    const container = document.createElement('container');
     container.innerHTML = '<div></div>';
 
     spyOn(console, 'error');
@@ -153,7 +153,7 @@ describe('ReactMount', function() {
   });
 
   it('should warn when mounting into document.body', function() {
-    var iFrame = document.createElement('iframe');
+    const iFrame = document.createElement('iframe');
     document.body.appendChild(iFrame);
     spyOn(console, 'error');
 
@@ -166,8 +166,8 @@ describe('ReactMount', function() {
   });
 
   it('should account for escaping on a checksum mismatch', function() {
-    var div = document.createElement('div');
-    var markup = ReactDOMServer.renderToString(
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
       <div>This markup contains an nbsp entity: &nbsp; server text</div>);
     div.innerHTML = markup;
 
@@ -185,8 +185,8 @@ describe('ReactMount', function() {
 
   if (WebComponents !== undefined) {
     it('should allow mounting/unmounting to document fragment container', function() {
-      var shadowRoot;
-      var proto = Object.create(HTMLElement.prototype, {
+      let shadowRoot;
+      const proto = Object.create(HTMLElement.prototype, {
         createdCallback: {
           value: function() {
             shadowRoot = this.createShadowRoot();
@@ -201,14 +201,14 @@ describe('ReactMount', function() {
         ReactDOM.unmountComponentAtNode(shadowRoot);
       };
       document.registerElement('x-foo', {prototype: proto});
-      var element = document.createElement('x-foo');
+      const element = document.createElement('x-foo');
       element.unmount();
     });
   }
 
   it('should warn if render removes React-rendered children', function() {
-    var container = document.createElement('container');
-    var Component = React.createClass({
+    const container = document.createElement('container');
+    const Component = React.createClass({
       render: function() {
         return <div><div /></div>;
       },
@@ -217,7 +217,7 @@ describe('ReactMount', function() {
 
     // Test that blasting away children throws a warning
     spyOn(console, 'error');
-    var rootNode = container.firstChild;
+    const rootNode = container.firstChild;
     ReactDOM.render(<span />, rootNode);
     expect(console.error.calls.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toBe(
@@ -229,8 +229,8 @@ describe('ReactMount', function() {
   });
 
   it('passes the correct callback context', function() {
-    var container = document.createElement('div');
-    var calls = 0;
+    const container = document.createElement('div');
+    let calls = 0;
 
     ReactDOM.render(<div />, container, function() {
       expect(this.nodeName).toBe('DIV');
@@ -273,7 +273,7 @@ describe('ReactMount', function() {
     expect(Object.keys(ReactMount._instancesByReactRootID).length).toBe(0);
     ReactTestUtils.renderIntoDocument(<span />);
     expect(Object.keys(ReactMount._instancesByReactRootID).length).toBe(1);
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<span />, container);
     expect(Object.keys(ReactMount._instancesByReactRootID).length).toBe(2);
     ReactDOM.unmountComponentAtNode(container);
@@ -281,15 +281,15 @@ describe('ReactMount', function() {
   });
 
   it('marks top-level mounts', function() {
-    var ReactFeatureFlags = require('ReactFeatureFlags');
+    const ReactFeatureFlags = require('ReactFeatureFlags');
 
-    var Foo = React.createClass({
+    const Foo = React.createClass({
       render: function() {
         return <Bar />;
       },
     });
 
-    var Bar = React.createClass({
+    const Bar = React.createClass({
       render: function() {
         return <div />;
       },

--- a/src/renderers/dom/client/__tests__/ReactMountDestruction-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMountDestruction-test.js
@@ -11,21 +11,21 @@
 
 'use strict';
 
-var React = require('React');
-var ReactDOM = require('ReactDOM');
+const React = require('React');
+const ReactDOM = require('ReactDOM');
 
 describe('ReactMount', function() {
   it('should destroy a react root upon request', function() {
-    var mainContainerDiv = document.createElement('div');
+    const mainContainerDiv = document.createElement('div');
     document.body.appendChild(mainContainerDiv);
 
-    var instanceOne = <div className="firstReactDiv" />;
-    var firstRootDiv = document.createElement('div');
+    const instanceOne = <div className="firstReactDiv" />;
+    const firstRootDiv = document.createElement('div');
     mainContainerDiv.appendChild(firstRootDiv);
     ReactDOM.render(instanceOne, firstRootDiv);
 
-    var instanceTwo = <div className="secondReactDiv" />;
-    var secondRootDiv = document.createElement('div');
+    const instanceTwo = <div className="secondReactDiv" />;
+    const secondRootDiv = document.createElement('div');
     mainContainerDiv.appendChild(secondRootDiv);
     ReactDOM.render(instanceTwo, secondRootDiv);
 
@@ -41,16 +41,16 @@ describe('ReactMount', function() {
   });
 
   it('should warn when unmounting a non-container root node', function() {
-    var mainContainerDiv = document.createElement('div');
+    const mainContainerDiv = document.createElement('div');
 
-    var component =
+    const component =
       <div>
         <div />
       </div>;
     ReactDOM.render(component, mainContainerDiv);
 
     // Test that unmounting at a root node gives a helpful warning
-    var rootDiv = mainContainerDiv.firstChild;
+    const rootDiv = mainContainerDiv.firstChild;
     spyOn(console, 'error');
     ReactDOM.unmountComponentAtNode(rootDiv);
     expect(console.error.calls.length).toBe(1);
@@ -63,9 +63,9 @@ describe('ReactMount', function() {
   });
 
   it('should warn when unmounting a non-container, non-root node', function() {
-    var mainContainerDiv = document.createElement('div');
+    const mainContainerDiv = document.createElement('div');
 
-    var component =
+    const component =
       <div>
         <div>
           <div />
@@ -74,7 +74,7 @@ describe('ReactMount', function() {
     ReactDOM.render(component, mainContainerDiv);
 
     // Test that unmounting at a non-root node gives a different warning
-    var nonRootDiv = mainContainerDiv.firstChild.firstChild;
+    const nonRootDiv = mainContainerDiv.firstChild.firstChild;
     spyOn(console, 'error');
     ReactDOM.unmountComponentAtNode(nonRootDiv);
     expect(console.error.calls.length).toBe(1);

--- a/src/renderers/dom/client/__tests__/ReactRenderDocument-test.js
+++ b/src/renderers/dom/client/__tests__/ReactRenderDocument-test.js
@@ -11,15 +11,15 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
-var ReactDOMServer;
+let React;
+let ReactDOM;
+let ReactDOMServer;
 
-var getTestDocument;
+let getTestDocument;
 
-var testDocument;
+let testDocument;
 
-var UNMOUNT_INVARIANT_MESSAGE =
+const UNMOUNT_INVARIANT_MESSAGE =
   '<html> tried to unmount. ' +
   'Because of cross-browser quirks it is impossible to unmount some ' +
   'top-level components (eg <html>, <head>, and <body>) reliably and ' +
@@ -41,7 +41,7 @@ describe('rendering React components at document', function() {
   it('should be able to adopt server markup', function() {
     expect(testDocument).not.toBeUndefined();
 
-    var Root = React.createClass({
+    const Root = React.createClass({
       render: function() {
         return (
           <html>
@@ -56,9 +56,9 @@ describe('rendering React components at document', function() {
       },
     });
 
-    var markup = ReactDOMServer.renderToString(<Root hello="world" />);
+    const markup = ReactDOMServer.renderToString(<Root hello="world" />);
     testDocument = getTestDocument(markup);
-    var body = testDocument.body;
+    const body = testDocument.body;
 
     ReactDOM.render(<Root hello="world" />, testDocument);
     expect(testDocument.body.innerHTML).toBe('Hello world');
@@ -72,7 +72,7 @@ describe('rendering React components at document', function() {
   it('should not be able to unmount component from document node', function() {
     expect(testDocument).not.toBeUndefined();
 
-    var Root = React.createClass({
+    const Root = React.createClass({
       render: function() {
         return (
           <html>
@@ -87,7 +87,7 @@ describe('rendering React components at document', function() {
       },
     });
 
-    var markup = ReactDOMServer.renderToString(<Root />);
+    const markup = ReactDOMServer.renderToString(<Root />);
     testDocument = getTestDocument(markup);
     ReactDOM.render(<Root />, testDocument);
     expect(testDocument.body.innerHTML).toBe('Hello world');
@@ -102,7 +102,7 @@ describe('rendering React components at document', function() {
   it('should not be able to switch root constructors', function() {
     expect(testDocument).not.toBeUndefined();
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         return (
           <html>
@@ -117,7 +117,7 @@ describe('rendering React components at document', function() {
       },
     });
 
-    var Component2 = React.createClass({
+    const Component2 = React.createClass({
       render: function() {
         return (
           <html>
@@ -132,7 +132,7 @@ describe('rendering React components at document', function() {
       },
     });
 
-    var markup = ReactDOMServer.renderToString(<Component />);
+    const markup = ReactDOMServer.renderToString(<Component />);
     testDocument = getTestDocument(markup);
 
     ReactDOM.render(<Component />, testDocument);
@@ -150,7 +150,7 @@ describe('rendering React components at document', function() {
   it('should be able to mount into document', function() {
     expect(testDocument).not.toBeUndefined();
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         return (
           <html>
@@ -165,7 +165,7 @@ describe('rendering React components at document', function() {
       },
     });
 
-    var markup = ReactDOMServer.renderToString(
+    const markup = ReactDOMServer.renderToString(
       <Component text="Hello world" />
     );
     testDocument = getTestDocument(markup);
@@ -178,7 +178,7 @@ describe('rendering React components at document', function() {
   it('should give helpful errors on state desync', function() {
     expect(testDocument).not.toBeUndefined();
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         return (
           <html>
@@ -193,7 +193,7 @@ describe('rendering React components at document', function() {
       },
     });
 
-    var markup = ReactDOMServer.renderToString(
+    const markup = ReactDOMServer.renderToString(
       <Component text="Goodbye world" />
     );
     testDocument = getTestDocument(markup);
@@ -218,9 +218,9 @@ describe('rendering React components at document', function() {
   it('should throw on full document render w/ no markup', function() {
     expect(testDocument).not.toBeUndefined();
 
-    var container = testDocument;
+    const container = testDocument;
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         return (
           <html>
@@ -246,7 +246,7 @@ describe('rendering React components at document', function() {
   });
 
   it('supports findDOMNode on full-page components', function() {
-    var tree =
+    const tree =
       <html>
         <head>
           <title>Hello World</title>
@@ -256,9 +256,9 @@ describe('rendering React components at document', function() {
         </body>
       </html>;
 
-    var markup = ReactDOMServer.renderToString(tree);
+    const markup = ReactDOMServer.renderToString(tree);
     testDocument = getTestDocument(markup);
-    var component = ReactDOM.render(tree, testDocument);
+    const component = ReactDOM.render(tree, testDocument);
     expect(testDocument.body.innerHTML).toBe('Hello world');
     expect(ReactDOM.findDOMNode(component).tagName).toBe('HTML');
   });

--- a/src/renderers/dom/client/__tests__/findDOMNode-test.js
+++ b/src/renderers/dom/client/__tests__/findDOMNode-test.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-var React = require('React');
-var ReactDOM = require('ReactDOM');
-var ReactTestUtils = require('ReactTestUtils');
+const React = require('React');
+const ReactDOM = require('ReactDOM');
+const ReactTestUtils = require('ReactTestUtils');
 
 describe('findDOMNode', function() {
   it('findDOMNode should return null if passed null', function() {
@@ -21,15 +21,15 @@ describe('findDOMNode', function() {
   });
 
   it('findDOMNode should find dom element', function() {
-    var MyNode = React.createClass({
+    const MyNode = React.createClass({
       render: function() {
         return <div><span>Noise</span></div>;
       },
     });
 
-    var myNode = ReactTestUtils.renderIntoDocument(<MyNode />);
-    var myDiv = ReactDOM.findDOMNode(myNode);
-    var mySameDiv = ReactDOM.findDOMNode(myDiv);
+    const myNode = ReactTestUtils.renderIntoDocument(<MyNode />);
+    const myDiv = ReactDOM.findDOMNode(myNode);
+    const mySameDiv = ReactDOM.findDOMNode(myDiv);
     expect(myDiv.tagName).toBe('DIV');
     expect(mySameDiv).toBe(myDiv);
   });
@@ -43,14 +43,14 @@ describe('findDOMNode', function() {
   });
 
   it('findDOMNode should reject unmounted objects with render func', function() {
-    var Foo = React.createClass({
+    const Foo = React.createClass({
       render: function() {
         return <div />;
       },
     });
 
-    var container = document.createElement('div');
-    var inst = ReactDOM.render(<Foo />, container);
+    const container = document.createElement('div');
+    const inst = ReactDOM.render(<Foo />, container);
     ReactDOM.unmountComponentAtNode(container);
 
     expect(() => ReactDOM.findDOMNode(inst)).toThrow(

--- a/src/renderers/dom/client/__tests__/validateDOMNesting-test.js
+++ b/src/renderers/dom/client/__tests__/validateDOMNesting-test.js
@@ -11,10 +11,10 @@
 
 'use strict';
 
-var validateDOMNesting;
+let validateDOMNesting;
 
 // https://html.spec.whatwg.org/multipage/syntax.html#special
-var specialTags = [
+const specialTags = [
   'address', 'applet', 'area', 'article', 'aside', 'base', 'basefont',
   'bgsound', 'blockquote', 'body', 'br', 'button', 'caption', 'center', 'col',
   'colgroup', 'dd', 'details', 'dir', 'div', 'dl', 'dt', 'embed', 'fieldset',
@@ -28,14 +28,14 @@ var specialTags = [
 ];
 
 // https://html.spec.whatwg.org/multipage/syntax.html#formatting
-var formattingTags = [
+const formattingTags = [
   'a', 'b', 'big', 'code', 'em', 'font', 'i', 'nobr', 's', 'small', 'strike',
   'strong', 'tt', 'u',
 ];
 
 function isTagStackValid(stack) {
-  var ancestorInfo = null;
-  for (var i = 0; i < stack.length; i++) {
+  let ancestorInfo = null;
+  for (let i = 0; i < stack.length; i++) {
     if (!validateDOMNesting.isTagValidInContext(stack[i], ancestorInfo)) {
       return false;
     }
@@ -55,7 +55,7 @@ describe('ReactContextValidator', function() {
   it('allows any tag with no context', function() {
     // With renderToString (for example), we don't know where we're mounting the
     // tag so we must err on the side of leniency.
-    var allTags = [].concat(specialTags, formattingTags, ['mysterytag']);
+    const allTags = [].concat(specialTags, formattingTags, ['mysterytag']);
     allTags.forEach(function(tag) {
       expect(validateDOMNesting.isTagValidInContext(tag, null)).toBe(true);
     });

--- a/src/renderers/dom/client/eventPlugins/BeforeInputEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/BeforeInputEventPlugin.js
@@ -11,24 +11,24 @@
 
 'use strict';
 
-var EventConstants = require('EventConstants');
-var EventPropagators = require('EventPropagators');
-var ExecutionEnvironment = require('ExecutionEnvironment');
-var FallbackCompositionState = require('FallbackCompositionState');
-var SyntheticCompositionEvent = require('SyntheticCompositionEvent');
-var SyntheticInputEvent = require('SyntheticInputEvent');
+const EventConstants = require('EventConstants');
+const EventPropagators = require('EventPropagators');
+const ExecutionEnvironment = require('ExecutionEnvironment');
+const FallbackCompositionState = require('FallbackCompositionState');
+const SyntheticCompositionEvent = require('SyntheticCompositionEvent');
+const SyntheticInputEvent = require('SyntheticInputEvent');
 
-var keyOf = require('keyOf');
+const keyOf = require('keyOf');
 
-var END_KEYCODES = [9, 13, 27, 32]; // Tab, Return, Esc, Space
-var START_KEYCODE = 229;
+const END_KEYCODES = [9, 13, 27, 32]; // Tab, Return, Esc, Space
+const START_KEYCODE = 229;
 
-var canUseCompositionEvent = (
+const canUseCompositionEvent = (
   ExecutionEnvironment.canUseDOM &&
   'CompositionEvent' in window
 );
 
-var documentMode = null;
+let documentMode = null;
 if (ExecutionEnvironment.canUseDOM && 'documentMode' in document) {
   documentMode = document.documentMode;
 }
@@ -36,7 +36,7 @@ if (ExecutionEnvironment.canUseDOM && 'documentMode' in document) {
 // Webkit offers a very useful `textInput` event that can be used to
 // directly represent `beforeInput`. The IE `textinput` event is not as
 // useful, so we don't use it.
-var canUseTextInputEvent = (
+const canUseTextInputEvent = (
   ExecutionEnvironment.canUseDOM &&
   'TextEvent' in window &&
   !documentMode &&
@@ -46,7 +46,7 @@ var canUseTextInputEvent = (
 // In IE9+, we have access to composition events, but the data supplied
 // by the native compositionend event may be incorrect. Japanese ideographic
 // spaces, for instance (\u3000) are not recorded correctly.
-var useFallbackCompositionData = (
+const useFallbackCompositionData = (
   ExecutionEnvironment.canUseDOM &&
   (
     !canUseCompositionEvent ||
@@ -59,7 +59,7 @@ var useFallbackCompositionData = (
  * text input events. Rely on keypress instead.
  */
 function isPresto() {
-  var opera = window.opera;
+  const opera = window.opera;
   return (
     typeof opera === 'object' &&
     typeof opera.version === 'function' &&
@@ -67,13 +67,13 @@ function isPresto() {
   );
 }
 
-var SPACEBAR_CODE = 32;
-var SPACEBAR_CHAR = String.fromCharCode(SPACEBAR_CODE);
+const SPACEBAR_CODE = 32;
+const SPACEBAR_CHAR = String.fromCharCode(SPACEBAR_CODE);
 
-var topLevelTypes = EventConstants.topLevelTypes;
+const topLevelTypes = EventConstants.topLevelTypes;
 
 // Events and their corresponding property names.
-var eventTypes = {
+const eventTypes = {
   beforeInput: {
     phasedRegistrationNames: {
       bubbled: keyOf({onBeforeInput: null}),
@@ -131,7 +131,7 @@ var eventTypes = {
 };
 
 // Track whether we've ever handled a keypress on the space key.
-var hasSpaceKeypress = false;
+let hasSpaceKeypress = false;
 
 /**
  * Return whether a native keypress event is assumed to be a command.
@@ -215,7 +215,7 @@ function isFallbackCompositionEnd(topLevelType, nativeEvent) {
  * @return {?string}
  */
 function getDataFromCustomEvent(nativeEvent) {
-  var detail = nativeEvent.detail;
+  const detail = nativeEvent.detail;
   if (typeof detail === 'object' && 'data' in detail) {
     return detail.data;
   }
@@ -223,7 +223,7 @@ function getDataFromCustomEvent(nativeEvent) {
 }
 
 // Track the current IME composition fallback object, if any.
-var currentComposition = null;
+let currentComposition = null;
 
 /**
  * @return {?object} A SyntheticCompositionEvent.
@@ -234,8 +234,8 @@ function extractCompositionEvent(
   nativeEvent,
   nativeEventTarget
 ) {
-  var eventType;
-  var fallbackData;
+  let eventType;
+  let fallbackData;
 
   if (canUseCompositionEvent) {
     eventType = getCompositionEventType(topLevelType);
@@ -264,7 +264,7 @@ function extractCompositionEvent(
     }
   }
 
-  var event = SyntheticCompositionEvent.getPooled(
+  const event = SyntheticCompositionEvent.getPooled(
     eventType,
     targetInst,
     nativeEvent,
@@ -276,7 +276,7 @@ function extractCompositionEvent(
     // This matches the property of native CompositionEventInterface.
     event.data = fallbackData;
   } else {
-    var customData = getDataFromCustomEvent(nativeEvent);
+    const customData = getDataFromCustomEvent(nativeEvent);
     if (customData !== null) {
       event.data = customData;
     }
@@ -310,7 +310,7 @@ function getNativeBeforeInputChars(topLevelType, nativeEvent) {
        * To avoid this issue, use the keypress event as if no `textInput`
        * event is available.
        */
-      var which = nativeEvent.which;
+      const which = nativeEvent.which;
       if (which !== SPACEBAR_CODE) {
         return null;
       }
@@ -320,7 +320,7 @@ function getNativeBeforeInputChars(topLevelType, nativeEvent) {
 
     case topLevelTypes.topTextInput:
       // Record the characters to be added to the DOM.
-      var chars = nativeEvent.data;
+      const chars = nativeEvent.data;
 
       // If it's a spacebar character, assume that we have already handled
       // it at the keypress level and bail immediately. Android Chrome
@@ -353,7 +353,7 @@ function getFallbackBeforeInputChars(topLevelType, nativeEvent) {
       topLevelType === topLevelTypes.topCompositionEnd ||
       isFallbackCompositionEnd(topLevelType, nativeEvent)
     ) {
-      var chars = currentComposition.getData();
+      const chars = currentComposition.getData();
       FallbackCompositionState.release(currentComposition);
       currentComposition = null;
       return chars;
@@ -406,7 +406,7 @@ function extractBeforeInputEvent(
   nativeEvent,
   nativeEventTarget
 ) {
-  var chars;
+  let chars;
 
   if (canUseTextInputEvent) {
     chars = getNativeBeforeInputChars(topLevelType, nativeEvent);
@@ -420,7 +420,7 @@ function extractBeforeInputEvent(
     return null;
   }
 
-  var event = SyntheticInputEvent.getPooled(
+  const event = SyntheticInputEvent.getPooled(
     eventTypes.beforeInput,
     targetInst,
     nativeEvent,
@@ -450,7 +450,7 @@ function extractBeforeInputEvent(
  * allowing us to share composition fallback code for both `beforeInput` and
  * `composition` event types.
  */
-var BeforeInputEventPlugin = {
+const BeforeInputEventPlugin = {
 
   eventTypes: eventTypes,
 

--- a/src/renderers/dom/client/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/ChangeEventPlugin.js
@@ -11,22 +11,22 @@
 
 'use strict';
 
-var EventConstants = require('EventConstants');
-var EventPluginHub = require('EventPluginHub');
-var EventPropagators = require('EventPropagators');
-var ExecutionEnvironment = require('ExecutionEnvironment');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var ReactUpdates = require('ReactUpdates');
-var SyntheticEvent = require('SyntheticEvent');
+const EventConstants = require('EventConstants');
+const EventPluginHub = require('EventPluginHub');
+const EventPropagators = require('EventPropagators');
+const ExecutionEnvironment = require('ExecutionEnvironment');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
+const ReactUpdates = require('ReactUpdates');
+const SyntheticEvent = require('SyntheticEvent');
 
-var getEventTarget = require('getEventTarget');
-var isEventSupported = require('isEventSupported');
-var isTextInputElement = require('isTextInputElement');
-var keyOf = require('keyOf');
+const getEventTarget = require('getEventTarget');
+const isEventSupported = require('isEventSupported');
+const isTextInputElement = require('isTextInputElement');
+const keyOf = require('keyOf');
 
-var topLevelTypes = EventConstants.topLevelTypes;
+const topLevelTypes = EventConstants.topLevelTypes;
 
-var eventTypes = {
+const eventTypes = {
   change: {
     phasedRegistrationNames: {
       bubbled: keyOf({onChange: null}),
@@ -48,23 +48,23 @@ var eventTypes = {
 /**
  * For IE shims
  */
-var activeElement = null;
-var activeElementInst = null;
-var activeElementValue = null;
-var activeElementValueProp = null;
+let activeElement = null;
+let activeElementInst = null;
+let activeElementValue = null;
+let activeElementValueProp = null;
 
 /**
  * SECTION: handle `change` event
  */
 function shouldUseChangeEvent(elem) {
-  var nodeName = elem.nodeName && elem.nodeName.toLowerCase();
+  const nodeName = elem.nodeName && elem.nodeName.toLowerCase();
   return (
     nodeName === 'select' ||
     (nodeName === 'input' && elem.type === 'file')
   );
 }
 
-var doesChangeEventBubble = false;
+let doesChangeEventBubble = false;
 if (ExecutionEnvironment.canUseDOM) {
   // See `handleChange` comment below
   doesChangeEventBubble = isEventSupported('change') && (
@@ -73,7 +73,7 @@ if (ExecutionEnvironment.canUseDOM) {
 }
 
 function manualDispatchChangeEvent(nativeEvent) {
-  var event = SyntheticEvent.getPooled(
+  const event = SyntheticEvent.getPooled(
     eventTypes.change,
     activeElementInst,
     nativeEvent,
@@ -142,7 +142,7 @@ function handleEventsForChangeEventIE8(
 /**
  * SECTION: handle `input` event
  */
-var isInputEventSupported = false;
+let isInputEventSupported = false;
 if (ExecutionEnvironment.canUseDOM) {
   // IE9 claims to support the input event but fails to trigger it when
   // deleting text, so we ignore its input events.
@@ -157,7 +157,7 @@ if (ExecutionEnvironment.canUseDOM) {
  * (For IE <=11) Replacement getter/setter for the `value` property that gets
  * set on the active element.
  */
-var newValueProp = {
+const newValueProp = {
   get: function() {
     return activeElementValueProp.get.call(this);
   },
@@ -224,7 +224,7 @@ function handlePropertyChange(nativeEvent) {
   if (nativeEvent.propertyName !== 'value') {
     return;
   }
-  var value = nativeEvent.srcElement.value;
+  const value = nativeEvent.srcElement.value;
   if (value === activeElementValue) {
     return;
   }
@@ -331,7 +331,7 @@ function getTargetInstForClickEvent(
  * - textarea
  * - select
  */
-var ChangeEventPlugin = {
+const ChangeEventPlugin = {
 
   eventTypes: eventTypes,
 
@@ -341,10 +341,10 @@ var ChangeEventPlugin = {
     nativeEvent,
     nativeEventTarget
   ) {
-    var targetNode = targetInst ?
+    const targetNode = targetInst ?
       ReactDOMComponentTree.getNodeFromInstance(targetInst) : window;
 
-    var getTargetInstFunc, handleEventFunc;
+    let getTargetInstFunc, handleEventFunc;
     if (shouldUseChangeEvent(targetNode)) {
       if (doesChangeEventBubble) {
         getTargetInstFunc = getTargetInstForChangeEvent;
@@ -363,9 +363,9 @@ var ChangeEventPlugin = {
     }
 
     if (getTargetInstFunc) {
-      var inst = getTargetInstFunc(topLevelType, targetInst);
+      const inst = getTargetInstFunc(topLevelType, targetInst);
       if (inst) {
-        var event = SyntheticEvent.getPooled(
+        const event = SyntheticEvent.getPooled(
           eventTypes.change,
           inst,
           nativeEvent,

--- a/src/renderers/dom/client/eventPlugins/DefaultEventPluginOrder.js
+++ b/src/renderers/dom/client/eventPlugins/DefaultEventPluginOrder.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var keyOf = require('keyOf');
+const keyOf = require('keyOf');
 
 /**
  * Module that is injectable into `EventPluginHub`, that specifies a
@@ -22,7 +22,7 @@ var keyOf = require('keyOf');
  * `ResponderEventPlugin` must occur before `SimpleEventPlugin` so that
  * preventing default on events is convenient in `SimpleEventPlugin` handlers.
  */
-var DefaultEventPluginOrder = [
+const DefaultEventPluginOrder = [
   keyOf({ResponderEventPlugin: null}),
   keyOf({SimpleEventPlugin: null}),
   keyOf({TapEventPlugin: null}),

--- a/src/renderers/dom/client/eventPlugins/EnterLeaveEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/EnterLeaveEventPlugin.js
@@ -11,16 +11,16 @@
 
 'use strict';
 
-var EventConstants = require('EventConstants');
-var EventPropagators = require('EventPropagators');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var SyntheticMouseEvent = require('SyntheticMouseEvent');
+const EventConstants = require('EventConstants');
+const EventPropagators = require('EventPropagators');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
+const SyntheticMouseEvent = require('SyntheticMouseEvent');
 
-var keyOf = require('keyOf');
+const keyOf = require('keyOf');
 
-var topLevelTypes = EventConstants.topLevelTypes;
+const topLevelTypes = EventConstants.topLevelTypes;
 
-var eventTypes = {
+const eventTypes = {
   mouseEnter: {
     registrationName: keyOf({onMouseEnter: null}),
     dependencies: [
@@ -37,7 +37,7 @@ var eventTypes = {
   },
 };
 
-var EnterLeaveEventPlugin = {
+const EnterLeaveEventPlugin = {
 
   eventTypes: eventTypes,
 
@@ -64,13 +64,13 @@ var EnterLeaveEventPlugin = {
       return null;
     }
 
-    var win;
+    let win;
     if (nativeEventTarget.window === nativeEventTarget) {
       // `nativeEventTarget` is probably a window object.
       win = nativeEventTarget;
     } else {
       // TODO: Figure out why `ownerDocument` is sometimes undefined in IE8.
-      var doc = nativeEventTarget.ownerDocument;
+      const doc = nativeEventTarget.ownerDocument;
       if (doc) {
         win = doc.defaultView || doc.parentWindow;
       } else {
@@ -78,11 +78,11 @@ var EnterLeaveEventPlugin = {
       }
     }
 
-    var from;
-    var to;
+    let from;
+    let to;
     if (topLevelType === topLevelTypes.topMouseOut) {
       from = targetInst;
-      var related = nativeEvent.relatedTarget || nativeEvent.toElement;
+      const related = nativeEvent.relatedTarget || nativeEvent.toElement;
       to = related ?
         ReactDOMComponentTree.getClosestInstanceFromNode(related) : null;
     } else {
@@ -96,12 +96,12 @@ var EnterLeaveEventPlugin = {
       return null;
     }
 
-    var fromNode =
+    const fromNode =
       from == null ? win : ReactDOMComponentTree.getNodeFromInstance(from);
-    var toNode =
+    const toNode =
       to == null ? win : ReactDOMComponentTree.getNodeFromInstance(to);
 
-    var leave = SyntheticMouseEvent.getPooled(
+    const leave = SyntheticMouseEvent.getPooled(
       eventTypes.mouseLeave,
       from,
       nativeEvent,
@@ -111,7 +111,7 @@ var EnterLeaveEventPlugin = {
     leave.target = fromNode;
     leave.relatedTarget = toNode;
 
-    var enter = SyntheticMouseEvent.getPooled(
+    const enter = SyntheticMouseEvent.getPooled(
       eventTypes.mouseEnter,
       to,
       nativeEvent,

--- a/src/renderers/dom/client/eventPlugins/FallbackCompositionState.js
+++ b/src/renderers/dom/client/eventPlugins/FallbackCompositionState.js
@@ -11,10 +11,10 @@
 
 'use strict';
 
-var PooledClass = require('PooledClass');
+const PooledClass = require('PooledClass');
 
-var assign = require('Object.assign');
-var getTextContentAccessor = require('getTextContentAccessor');
+const assign = require('Object.assign');
+const getTextContentAccessor = require('getTextContentAccessor');
 
 /**
  * This helper class stores information about text content of a target node,
@@ -63,12 +63,12 @@ assign(FallbackCompositionState.prototype, {
       return this._fallbackText;
     }
 
-    var start;
-    var startValue = this._startText;
-    var startLength = startValue.length;
-    var end;
-    var endValue = this.getText();
-    var endLength = endValue.length;
+    let start;
+    const startValue = this._startText;
+    const startLength = startValue.length;
+    let end;
+    const endValue = this.getText();
+    const endLength = endValue.length;
 
     for (start = 0; start < startLength; start++) {
       if (startValue[start] !== endValue[start]) {
@@ -76,14 +76,14 @@ assign(FallbackCompositionState.prototype, {
       }
     }
 
-    var minEnd = startLength - start;
+    const minEnd = startLength - start;
     for (end = 1; end <= minEnd; end++) {
       if (startValue[startLength - end] !== endValue[endLength - end]) {
         break;
       }
     }
 
-    var sliceTail = end > 1 ? 1 - end : undefined;
+    const sliceTail = end > 1 ? 1 - end : undefined;
     this._fallbackText = endValue.slice(start, sliceTail);
     return this._fallbackText;
   },

--- a/src/renderers/dom/client/eventPlugins/SelectEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/SelectEventPlugin.js
@@ -11,27 +11,27 @@
 
 'use strict';
 
-var EventConstants = require('EventConstants');
-var EventPropagators = require('EventPropagators');
-var ExecutionEnvironment = require('ExecutionEnvironment');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var ReactInputSelection = require('ReactInputSelection');
-var SyntheticEvent = require('SyntheticEvent');
+const EventConstants = require('EventConstants');
+const EventPropagators = require('EventPropagators');
+const ExecutionEnvironment = require('ExecutionEnvironment');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
+const ReactInputSelection = require('ReactInputSelection');
+const SyntheticEvent = require('SyntheticEvent');
 
-var getActiveElement = require('getActiveElement');
-var isTextInputElement = require('isTextInputElement');
-var keyOf = require('keyOf');
-var shallowEqual = require('shallowEqual');
+const getActiveElement = require('getActiveElement');
+const isTextInputElement = require('isTextInputElement');
+const keyOf = require('keyOf');
+const shallowEqual = require('shallowEqual');
 
-var topLevelTypes = EventConstants.topLevelTypes;
+const topLevelTypes = EventConstants.topLevelTypes;
 
-var skipSelectionChangeEvent = (
+const skipSelectionChangeEvent = (
   ExecutionEnvironment.canUseDOM &&
   'documentMode' in document &&
   document.documentMode <= 11
 );
 
-var eventTypes = {
+const eventTypes = {
   select: {
     phasedRegistrationNames: {
       bubbled: keyOf({onSelect: null}),
@@ -49,15 +49,15 @@ var eventTypes = {
   },
 };
 
-var activeElement = null;
-var activeElementInst = null;
-var lastSelection = null;
-var mouseDown = false;
+let activeElement = null;
+let activeElementInst = null;
+let lastSelection = null;
+let mouseDown = false;
 
 // Track whether a listener exists for this plugin. If none exist, we do
 // not extract events. See #3639.
-var hasListener = false;
-var ON_SELECT_KEY = keyOf({onSelect: null});
+let hasListener = false;
+const ON_SELECT_KEY = keyOf({onSelect: null});
 
 /**
  * Get an object which is a unique representation of the current selection.
@@ -84,7 +84,7 @@ function getSelection(node) {
       focusOffset: selection.focusOffset,
     };
   } else if (document.selection) {
-    var range = document.selection.createRange();
+    const range = document.selection.createRange();
     return {
       parentElement: range.parentElement(),
       text: range.text,
@@ -112,11 +112,11 @@ function constructSelectEvent(nativeEvent, nativeEventTarget) {
   }
 
   // Only fire when selection has actually changed.
-  var currentSelection = getSelection(activeElement);
+  const currentSelection = getSelection(activeElement);
   if (!lastSelection || !shallowEqual(lastSelection, currentSelection)) {
     lastSelection = currentSelection;
 
-    var syntheticEvent = SyntheticEvent.getPooled(
+    const syntheticEvent = SyntheticEvent.getPooled(
       eventTypes.select,
       activeElementInst,
       nativeEvent,
@@ -148,7 +148,7 @@ function constructSelectEvent(nativeEvent, nativeEventTarget) {
  * - Fires for collapsed selection.
  * - Fires after user input.
  */
-var SelectEventPlugin = {
+const SelectEventPlugin = {
 
   eventTypes: eventTypes,
 
@@ -162,7 +162,7 @@ var SelectEventPlugin = {
       return null;
     }
 
-    var targetNode = targetInst ?
+    const targetNode = targetInst ?
       ReactDOMComponentTree.getNodeFromInstance(targetInst) : window;
 
     switch (topLevelType) {

--- a/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
@@ -446,7 +446,7 @@ const topLevelEventsToDispatchConfig = {
   topWheel:           eventTypes.wheel,
 };
 
-for (let type in topLevelEventsToDispatchConfig) {
+for (const type in topLevelEventsToDispatchConfig) {
   topLevelEventsToDispatchConfig[type].dependencies = [type];
 }
 

--- a/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
@@ -11,28 +11,28 @@
 
 'use strict';
 
-var EventConstants = require('EventConstants');
-var EventListener = require('EventListener');
-var EventPropagators = require('EventPropagators');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var SyntheticClipboardEvent = require('SyntheticClipboardEvent');
-var SyntheticEvent = require('SyntheticEvent');
-var SyntheticFocusEvent = require('SyntheticFocusEvent');
-var SyntheticKeyboardEvent = require('SyntheticKeyboardEvent');
-var SyntheticMouseEvent = require('SyntheticMouseEvent');
-var SyntheticDragEvent = require('SyntheticDragEvent');
-var SyntheticTouchEvent = require('SyntheticTouchEvent');
-var SyntheticUIEvent = require('SyntheticUIEvent');
-var SyntheticWheelEvent = require('SyntheticWheelEvent');
+const EventConstants = require('EventConstants');
+const EventListener = require('EventListener');
+const EventPropagators = require('EventPropagators');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
+const SyntheticClipboardEvent = require('SyntheticClipboardEvent');
+const SyntheticEvent = require('SyntheticEvent');
+const SyntheticFocusEvent = require('SyntheticFocusEvent');
+const SyntheticKeyboardEvent = require('SyntheticKeyboardEvent');
+const SyntheticMouseEvent = require('SyntheticMouseEvent');
+const SyntheticDragEvent = require('SyntheticDragEvent');
+const SyntheticTouchEvent = require('SyntheticTouchEvent');
+const SyntheticUIEvent = require('SyntheticUIEvent');
+const SyntheticWheelEvent = require('SyntheticWheelEvent');
 
-var emptyFunction = require('emptyFunction');
-var getEventCharCode = require('getEventCharCode');
-var invariant = require('invariant');
-var keyOf = require('keyOf');
+const emptyFunction = require('emptyFunction');
+const getEventCharCode = require('getEventCharCode');
+const invariant = require('invariant');
+const keyOf = require('keyOf');
 
-var topLevelTypes = EventConstants.topLevelTypes;
+const topLevelTypes = EventConstants.topLevelTypes;
 
-var eventTypes = {
+const eventTypes = {
   abort: {
     phasedRegistrationNames: {
       bubbled: keyOf({onAbort: true}),
@@ -385,7 +385,7 @@ var eventTypes = {
   },
 };
 
-var topLevelEventsToDispatchConfig = {
+const topLevelEventsToDispatchConfig = {
   topAbort:           eventTypes.abort,
   topBlur:            eventTypes.blur,
   topCanPlay:         eventTypes.canPlay,
@@ -446,14 +446,14 @@ var topLevelEventsToDispatchConfig = {
   topWheel:           eventTypes.wheel,
 };
 
-for (var type in topLevelEventsToDispatchConfig) {
+for (let type in topLevelEventsToDispatchConfig) {
   topLevelEventsToDispatchConfig[type].dependencies = [type];
 }
 
-var ON_CLICK_KEY = keyOf({onClick: null});
-var onClickListeners = {};
+const ON_CLICK_KEY = keyOf({onClick: null});
+const onClickListeners = {};
 
-var SimpleEventPlugin = {
+const SimpleEventPlugin = {
 
   eventTypes: eventTypes,
 
@@ -463,11 +463,11 @@ var SimpleEventPlugin = {
     nativeEvent,
     nativeEventTarget
   ) {
-    var dispatchConfig = topLevelEventsToDispatchConfig[topLevelType];
+    const dispatchConfig = topLevelEventsToDispatchConfig[topLevelType];
     if (!dispatchConfig) {
       return null;
     }
-    var EventConstructor;
+    let EventConstructor;
     switch (topLevelType) {
       case topLevelTypes.topAbort:
       case topLevelTypes.topCanPlay:
@@ -566,7 +566,7 @@ var SimpleEventPlugin = {
       'SimpleEventPlugin: Unhandled event type, `%s`.',
       topLevelType
     );
-    var event = EventConstructor.getPooled(
+    const event = EventConstructor.getPooled(
       dispatchConfig,
       targetInst,
       nativeEvent,
@@ -582,8 +582,8 @@ var SimpleEventPlugin = {
     // fire. The workaround for this bug involves attaching an empty click
     // listener on the target node.
     if (registrationName === ON_CLICK_KEY) {
-      var id = inst._rootNodeID;
-      var node = ReactDOMComponentTree.getNodeFromInstance(inst);
+      const id = inst._rootNodeID;
+      const node = ReactDOMComponentTree.getNodeFromInstance(inst);
       if (!onClickListeners[id]) {
         onClickListeners[id] = EventListener.listen(
           node,
@@ -596,7 +596,7 @@ var SimpleEventPlugin = {
 
   willDeleteListener: function(inst, registrationName) {
     if (registrationName === ON_CLICK_KEY) {
-      var id = inst._rootNodeID;
+      const id = inst._rootNodeID;
       onClickListeners[id].remove();
       delete onClickListeners[id];
     }

--- a/src/renderers/dom/client/eventPlugins/TapEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/TapEventPlugin.js
@@ -11,33 +11,33 @@
 
 'use strict';
 
-var EventConstants = require('EventConstants');
-var EventPluginUtils = require('EventPluginUtils');
-var EventPropagators = require('EventPropagators');
-var SyntheticUIEvent = require('SyntheticUIEvent');
-var TouchEventUtils = require('TouchEventUtils');
-var ViewportMetrics = require('ViewportMetrics');
+const EventConstants = require('EventConstants');
+const EventPluginUtils = require('EventPluginUtils');
+const EventPropagators = require('EventPropagators');
+const SyntheticUIEvent = require('SyntheticUIEvent');
+const TouchEventUtils = require('TouchEventUtils');
+const ViewportMetrics = require('ViewportMetrics');
 
-var keyOf = require('keyOf');
-var topLevelTypes = EventConstants.topLevelTypes;
+const keyOf = require('keyOf');
+const topLevelTypes = EventConstants.topLevelTypes;
 
-var isStartish = EventPluginUtils.isStartish;
-var isEndish = EventPluginUtils.isEndish;
+const isStartish = EventPluginUtils.isStartish;
+const isEndish = EventPluginUtils.isEndish;
 
 /**
  * Number of pixels that are tolerated in between a `touchStart` and `touchEnd`
  * in order to still be considered a 'tap' event.
  */
-var tapMoveThreshold = 10;
-var startCoords = {x: null, y: null};
+const tapMoveThreshold = 10;
+const startCoords = {x: null, y: null};
 
-var Axis = {
+const Axis = {
   x: {page: 'pageX', client: 'clientX', envScroll: 'currentPageScrollLeft'},
   y: {page: 'pageY', client: 'clientY', envScroll: 'currentPageScrollTop'},
 };
 
 function getAxisCoordOfEvent(axis, nativeEvent) {
-  var singleTouch = TouchEventUtils.extractSingleTouch(nativeEvent);
+  const singleTouch = TouchEventUtils.extractSingleTouch(nativeEvent);
   if (singleTouch) {
     return singleTouch[axis.page];
   }
@@ -47,28 +47,28 @@ function getAxisCoordOfEvent(axis, nativeEvent) {
 }
 
 function getDistance(coords, nativeEvent) {
-  var pageX = getAxisCoordOfEvent(Axis.x, nativeEvent);
-  var pageY = getAxisCoordOfEvent(Axis.y, nativeEvent);
+  const pageX = getAxisCoordOfEvent(Axis.x, nativeEvent);
+  const pageY = getAxisCoordOfEvent(Axis.y, nativeEvent);
   return Math.pow(
     Math.pow(pageX - coords.x, 2) + Math.pow(pageY - coords.y, 2),
     0.5
   );
 }
 
-var touchEvents = [
+const touchEvents = [
   topLevelTypes.topTouchStart,
   topLevelTypes.topTouchCancel,
   topLevelTypes.topTouchEnd,
   topLevelTypes.topTouchMove,
 ];
 
-var dependencies = [
+const dependencies = [
   topLevelTypes.topMouseDown,
   topLevelTypes.topMouseMove,
   topLevelTypes.topMouseUp,
 ].concat(touchEvents);
 
-var eventTypes = {
+const eventTypes = {
   touchTap: {
     phasedRegistrationNames: {
       bubbled: keyOf({onTouchTap: null}),
@@ -78,11 +78,11 @@ var eventTypes = {
   },
 };
 
-var usedTouch = false;
-var usedTouchTime = 0;
-var TOUCH_DELAY = 1000;
+let usedTouch = false;
+let usedTouchTime = 0;
+const TOUCH_DELAY = 1000;
 
-var TapEventPlugin = {
+const TapEventPlugin = {
 
   tapMoveThreshold: tapMoveThreshold,
 
@@ -108,8 +108,8 @@ var TapEventPlugin = {
         return null;
       }
     }
-    var event = null;
-    var distance = getDistance(startCoords, nativeEvent);
+    let event = null;
+    const distance = getDistance(startCoords, nativeEvent);
     if (isEndish(topLevelType) && distance < tapMoveThreshold) {
       event = SyntheticUIEvent.getPooled(
         eventTypes.touchTap,

--- a/src/renderers/dom/client/eventPlugins/__tests__/ChangeEventPlugin-test.js
+++ b/src/renderers/dom/client/eventPlugins/__tests__/ChangeEventPlugin-test.js
@@ -11,19 +11,19 @@
 
 'use strict';
 
-var React = require('React');
-var ReactTestUtils = require('ReactTestUtils');
+const React = require('React');
+const ReactTestUtils = require('ReactTestUtils');
 
 describe('ChangeEventPlugin', function() {
   it('should fire change for checkbox input', function() {
-    var called = 0;
+    let called = 0;
 
     function cb(e) {
       called = 1;
       expect(e.type).toBe('change');
     }
 
-    var input = ReactTestUtils.renderIntoDocument(<input type="checkbox" onChange={cb}/>);
+    const input = ReactTestUtils.renderIntoDocument(<input type="checkbox" onChange={cb}/>);
     ReactTestUtils.SimulateNative.click(input);
     expect(called).toBe(1);
   });

--- a/src/renderers/dom/client/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
+++ b/src/renderers/dom/client/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-var EnterLeaveEventPlugin;
-var EventConstants;
-var React;
-var ReactDOM;
-var ReactDOMComponentTree;
+let EnterLeaveEventPlugin;
+let EventConstants;
+let React;
+let ReactDOM;
+let ReactDOMComponentTree;
 
-var topLevelTypes;
+let topLevelTypes;
 
 describe('EnterLeaveEventPlugin', function() {
   beforeEach(function() {
@@ -33,20 +33,20 @@ describe('EnterLeaveEventPlugin', function() {
   });
 
   it('should set relatedTarget properly in iframe', function() {
-    var iframe = document.createElement('iframe');
+    const iframe = document.createElement('iframe');
     document.body.appendChild(iframe);
 
-    var iframeDocument = iframe.contentDocument;
+    const iframeDocument = iframe.contentDocument;
 
     iframeDocument.write(
       '<!DOCTYPE html><html><head></head><body><div></div></body></html>'
     );
     iframeDocument.close();
 
-    var component = ReactDOM.render(<div />, iframeDocument.body.getElementsByTagName('div')[0]);
+    const component = ReactDOM.render(<div />, iframeDocument.body.getElementsByTagName('div')[0]);
     var div = ReactDOM.findDOMNode(component);
 
-    var extracted = EnterLeaveEventPlugin.extractEvents(
+    const extracted = EnterLeaveEventPlugin.extractEvents(
       topLevelTypes.topMouseOver,
       ReactDOMComponentTree.getInstanceFromNode(div),
       {target: div},
@@ -54,8 +54,8 @@ describe('EnterLeaveEventPlugin', function() {
     );
     expect(extracted.length).toBe(2);
 
-    var leave = extracted[0];
-    var enter = extracted[1];
+    const leave = extracted[0];
+    const enter = extracted[1];
 
     expect(leave.target).toBe(iframe.contentWindow);
     expect(leave.relatedTarget).toBe(div);

--- a/src/renderers/dom/client/eventPlugins/__tests__/FallbackCompositionState-test.js
+++ b/src/renderers/dom/client/eventPlugins/__tests__/FallbackCompositionState-test.js
@@ -12,44 +12,44 @@
 'use strict';
 
 describe('FallbackCompositionState', function() {
-  var FallbackCompositionState;
+  let FallbackCompositionState;
 
-  var TEXT = 'Hello world';
+  const TEXT = 'Hello world';
 
   beforeEach(function() {
     FallbackCompositionState = require('FallbackCompositionState');
   });
 
   function getInput() {
-    var input = document.createElement('input');
+    const input = document.createElement('input');
     input.value = TEXT;
     return input;
   }
 
   function getTextarea() {
-    var textarea = document.createElement('textarea');
+    const textarea = document.createElement('textarea');
     textarea.value = TEXT;
     return textarea;
   }
 
   function getContentEditable() {
-    var editable = document.createElement('div');
-    var inner = document.createElement('span');
+    const editable = document.createElement('div');
+    const inner = document.createElement('span');
     inner.appendChild(document.createTextNode(TEXT));
     editable.appendChild(inner);
     return editable;
   }
 
   function assertExtractedData(modifiedValue, expectedData) {
-    var input = getInput();
-    var composition = FallbackCompositionState.getPooled(input);
+    const input = getInput();
+    const composition = FallbackCompositionState.getPooled(input);
     input.value = modifiedValue;
     expect(composition.getData()).toBe(expectedData);
     FallbackCompositionState.release(composition);
   }
 
   it('extracts value via `getText()`', function() {
-    var composition = FallbackCompositionState.getPooled(getInput());
+    let composition = FallbackCompositionState.getPooled(getInput());
     expect(composition.getText()).toBe(TEXT);
     FallbackCompositionState.release(composition);
 

--- a/src/renderers/dom/client/eventPlugins/__tests__/SelectEventPlugin-test.js
+++ b/src/renderers/dom/client/eventPlugins/__tests__/SelectEventPlugin-test.js
@@ -11,14 +11,14 @@
 
 'use strict';
 
-var EventConstants;
-var React;
-var ReactDOM;
-var ReactDOMComponentTree;
-var ReactTestUtils;
-var SelectEventPlugin;
+let EventConstants;
+let React;
+let ReactDOM;
+let ReactDOMComponentTree;
+let ReactTestUtils;
+let SelectEventPlugin;
 
-var topLevelTypes;
+let topLevelTypes;
 
 describe('SelectEventPlugin', function() {
   function extract(node, topLevelEvent) {
@@ -42,36 +42,36 @@ describe('SelectEventPlugin', function() {
   });
 
   it('should skip extraction if no listeners are present', function() {
-    var WithoutSelect = React.createClass({
+    const WithoutSelect = React.createClass({
       render: function() {
         return <input type="text" />;
       },
     });
 
-    var rendered = ReactTestUtils.renderIntoDocument(<WithoutSelect />);
-    var node = ReactDOM.findDOMNode(rendered);
+    const rendered = ReactTestUtils.renderIntoDocument(<WithoutSelect />);
+    const node = ReactDOM.findDOMNode(rendered);
     node.focus();
 
-    var mousedown = extract(node, topLevelTypes.topMouseDown);
+    const mousedown = extract(node, topLevelTypes.topMouseDown);
     expect(mousedown).toBe(null);
 
-    var mouseup = extract(node, topLevelTypes.topMouseUp);
+    const mouseup = extract(node, topLevelTypes.topMouseUp);
     expect(mouseup).toBe(null);
   });
 
   it('should extract if an `onSelect` listener is present', function() {
-    var WithSelect = React.createClass({
+    const WithSelect = React.createClass({
       render: function() {
         return <input type="text" onSelect={this.props.onSelect} />;
       },
     });
 
-    var cb = jest.genMockFn();
+    const cb = jest.genMockFn();
 
-    var rendered = ReactTestUtils.renderIntoDocument(
+    const rendered = ReactTestUtils.renderIntoDocument(
       <WithSelect onSelect={cb} />
     );
-    var node = ReactDOM.findDOMNode(rendered);
+    const node = ReactDOM.findDOMNode(rendered);
 
     node.selectionStart = 0;
     node.selectionEnd = 0;
@@ -80,10 +80,10 @@ describe('SelectEventPlugin', function() {
     var focus = extract(node, topLevelTypes.topFocus);
     expect(focus).toBe(null);
 
-    var mousedown = extract(node, topLevelTypes.topMouseDown);
+    const mousedown = extract(node, topLevelTypes.topMouseDown);
     expect(mousedown).toBe(null);
 
-    var mouseup = extract(node, topLevelTypes.topMouseUp);
+    const mouseup = extract(node, topLevelTypes.topMouseUp);
     expect(mouseup).not.toBe(null);
     expect(typeof mouseup).toBe('object');
     expect(mouseup.type).toBe('select');

--- a/src/renderers/dom/client/findDOMNode.js
+++ b/src/renderers/dom/client/findDOMNode.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-var ReactCurrentOwner = require('ReactCurrentOwner');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var ReactInstanceMap = require('ReactInstanceMap');
+const ReactCurrentOwner = require('ReactCurrentOwner');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
+const ReactInstanceMap = require('ReactInstanceMap');
 
-var getNativeComponentFromComposite = require('getNativeComponentFromComposite');
-var invariant = require('invariant');
-var warning = require('warning');
+const getNativeComponentFromComposite = require('getNativeComponentFromComposite');
+const invariant = require('invariant');
+const warning = require('warning');
 
 /**
  * Returns the DOM node rendered by this element.
@@ -27,7 +27,7 @@ var warning = require('warning');
  */
 function findDOMNode(componentOrElement) {
   if (__DEV__) {
-    var owner = ReactCurrentOwner.current;
+    const owner = ReactCurrentOwner.current;
     if (owner !== null) {
       warning(
         owner._warnedAboutRefsInRender,
@@ -48,7 +48,7 @@ function findDOMNode(componentOrElement) {
     return componentOrElement;
   }
 
-  var inst = ReactInstanceMap.get(componentOrElement);
+  let inst = ReactInstanceMap.get(componentOrElement);
   if (inst) {
     inst = getNativeComponentFromComposite(inst);
     return inst ? ReactDOMComponentTree.getNodeFromInstance(inst) : null;

--- a/src/renderers/dom/client/syntheticEvents/SyntheticClipboardEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticClipboardEvent.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-var SyntheticEvent = require('SyntheticEvent');
+const SyntheticEvent = require('SyntheticEvent');
 
 /**
  * @interface Event
  * @see http://www.w3.org/TR/clipboard-apis/
  */
-var ClipboardEventInterface = {
+const ClipboardEventInterface = {
   clipboardData: function(event) {
     return (
       'clipboardData' in event ?

--- a/src/renderers/dom/client/syntheticEvents/SyntheticCompositionEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticCompositionEvent.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-var SyntheticEvent = require('SyntheticEvent');
+const SyntheticEvent = require('SyntheticEvent');
 
 /**
  * @interface Event
  * @see http://www.w3.org/TR/DOM-Level-3-Events/#events-compositionevents
  */
-var CompositionEventInterface = {
+const CompositionEventInterface = {
   data: null,
 };
 

--- a/src/renderers/dom/client/syntheticEvents/SyntheticDragEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticDragEvent.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-var SyntheticMouseEvent = require('SyntheticMouseEvent');
+const SyntheticMouseEvent = require('SyntheticMouseEvent');
 
 /**
  * @interface DragEvent
  * @see http://www.w3.org/TR/DOM-Level-3-Events/
  */
-var DragEventInterface = {
+const DragEventInterface = {
   dataTransfer: null,
 };
 

--- a/src/renderers/dom/client/syntheticEvents/SyntheticEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticEvent.js
@@ -11,17 +11,17 @@
 
 'use strict';
 
-var PooledClass = require('PooledClass');
+const PooledClass = require('PooledClass');
 
-var assign = require('Object.assign');
-var emptyFunction = require('emptyFunction');
-var warning = require('warning');
+const assign = require('Object.assign');
+const emptyFunction = require('emptyFunction');
+const warning = require('warning');
 
 /**
  * @interface Event
  * @see http://www.w3.org/TR/DOM-Level-3-Events/
  */
-var EventInterface = {
+const EventInterface = {
   type: null,
   target: null,
   // currentTarget is set when dispatching; no use in copying it here
@@ -66,15 +66,15 @@ function SyntheticEvent(dispatchConfig, targetInst, nativeEvent, nativeEventTarg
   this._targetInst = targetInst;
   this.nativeEvent = nativeEvent;
 
-  var Interface = this.constructor.Interface;
-  for (var propName in Interface) {
+  const Interface = this.constructor.Interface;
+  for (let propName in Interface) {
     if (!Interface.hasOwnProperty(propName)) {
       continue;
     }
     if (__DEV__) {
       delete this[propName]; // this has a getter/setter for warnings
     }
-    var normalize = Interface[propName];
+    const normalize = Interface[propName];
     if (normalize) {
       this[propName] = normalize(nativeEvent);
     } else {
@@ -86,7 +86,7 @@ function SyntheticEvent(dispatchConfig, targetInst, nativeEvent, nativeEventTarg
     }
   }
 
-  var defaultPrevented = nativeEvent.defaultPrevented != null ?
+  const defaultPrevented = nativeEvent.defaultPrevented != null ?
     nativeEvent.defaultPrevented :
     nativeEvent.returnValue === false;
   if (defaultPrevented) {
@@ -101,7 +101,7 @@ assign(SyntheticEvent.prototype, {
 
   preventDefault: function() {
     this.defaultPrevented = true;
-    var event = this.nativeEvent;
+    const event = this.nativeEvent;
     if (!event) {
       return;
     }
@@ -115,7 +115,7 @@ assign(SyntheticEvent.prototype, {
   },
 
   stopPropagation: function() {
-    var event = this.nativeEvent;
+    const event = this.nativeEvent;
     if (!event) {
       return;
     }
@@ -148,8 +148,8 @@ assign(SyntheticEvent.prototype, {
    * `PooledClass` looks for `destructor` on each instance it releases.
    */
   destructor: function() {
-    var Interface = this.constructor.Interface;
-    for (var propName in Interface) {
+    const Interface = this.constructor.Interface;
+    for (let propName in Interface) {
       if (__DEV__) {
         Object.defineProperty(this, propName, getPooledWarningPropertyDefinition(propName, Interface[propName]));
       } else {
@@ -157,7 +157,7 @@ assign(SyntheticEvent.prototype, {
       }
     }
     if (__DEV__) {
-      var noop = require('emptyFunction');
+      const noop = require('emptyFunction');
       Object.defineProperty(this, 'nativeEvent', getPooledWarningPropertyDefinition('nativeEvent', null));
       Object.defineProperty(this, 'preventDefault', getPooledWarningPropertyDefinition('preventDefault', noop));
       Object.defineProperty(this, 'stopPropagation', getPooledWarningPropertyDefinition('stopPropagation', noop));
@@ -179,9 +179,9 @@ SyntheticEvent.Interface = EventInterface;
  * @param {?object} Interface
  */
 SyntheticEvent.augmentClass = function(Class, Interface) {
-  var Super = this;
+  const Super = this;
 
-  var E = function() {};
+  const E = function() {};
   E.prototype = Super.prototype;
   var prototype = new E();
 
@@ -207,7 +207,7 @@ module.exports = SyntheticEvent;
   * @return {object} defineProperty object
   */
 function getPooledWarningPropertyDefinition(propName, getVal) {
-  var isFunction = typeof getVal === 'function';
+  const isFunction = typeof getVal === 'function';
   return {
     configurable: true,
     set: set,
@@ -215,20 +215,20 @@ function getPooledWarningPropertyDefinition(propName, getVal) {
   };
 
   function set(val) {
-    var action = isFunction ? 'setting the method' : 'setting the property';
+    const action = isFunction ? 'setting the method' : 'setting the property';
     warn(action, 'This is effectively a no-op');
     return val;
   }
 
   function get() {
-    var action = isFunction ? 'accessing the method' : 'accessing the property';
-    var result = isFunction ? 'This is a no-op function' : 'This is set to null';
+    const action = isFunction ? 'accessing the method' : 'accessing the property';
+    const result = isFunction ? 'This is a no-op function' : 'This is set to null';
     warn(action, result);
     return getVal;
   }
 
   function warn(action, result) {
-    var warningCondition = false;
+    const warningCondition = false;
     warning(
       warningCondition,
       'This synthetic event is reused for performance reasons. If you\'re seeing this,' +

--- a/src/renderers/dom/client/syntheticEvents/SyntheticEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticEvent.js
@@ -57,7 +57,7 @@ const EventInterface = {
 function SyntheticEvent(dispatchConfig, targetInst, nativeEvent, nativeEventTarget) {
   if (__DEV__) {
     // these have a getter/setter for warnings
-    delete this.nativeEvent; 
+    delete this.nativeEvent;
     delete this.preventDefault;
     delete this.stopPropagation;
   }
@@ -67,7 +67,7 @@ function SyntheticEvent(dispatchConfig, targetInst, nativeEvent, nativeEventTarg
   this.nativeEvent = nativeEvent;
 
   const Interface = this.constructor.Interface;
-  for (let propName in Interface) {
+  for (const propName in Interface) {
     if (!Interface.hasOwnProperty(propName)) {
       continue;
     }
@@ -149,7 +149,7 @@ assign(SyntheticEvent.prototype, {
    */
   destructor: function() {
     const Interface = this.constructor.Interface;
-    for (let propName in Interface) {
+    for (const propName in Interface) {
       if (__DEV__) {
         Object.defineProperty(this, propName, getPooledWarningPropertyDefinition(propName, Interface[propName]));
       } else {

--- a/src/renderers/dom/client/syntheticEvents/SyntheticFocusEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticFocusEvent.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-var SyntheticUIEvent = require('SyntheticUIEvent');
+const SyntheticUIEvent = require('SyntheticUIEvent');
 
 /**
  * @interface FocusEvent
  * @see http://www.w3.org/TR/DOM-Level-3-Events/
  */
-var FocusEventInterface = {
+const FocusEventInterface = {
   relatedTarget: null,
 };
 

--- a/src/renderers/dom/client/syntheticEvents/SyntheticInputEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticInputEvent.js
@@ -11,14 +11,14 @@
 
 'use strict';
 
-var SyntheticEvent = require('SyntheticEvent');
+const SyntheticEvent = require('SyntheticEvent');
 
 /**
  * @interface Event
  * @see http://www.w3.org/TR/2013/WD-DOM-Level-3-Events-20131105
  *      /#events-inputevents
  */
-var InputEventInterface = {
+const InputEventInterface = {
   data: null,
 };
 

--- a/src/renderers/dom/client/syntheticEvents/SyntheticKeyboardEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticKeyboardEvent.js
@@ -11,17 +11,17 @@
 
 'use strict';
 
-var SyntheticUIEvent = require('SyntheticUIEvent');
+const SyntheticUIEvent = require('SyntheticUIEvent');
 
-var getEventCharCode = require('getEventCharCode');
-var getEventKey = require('getEventKey');
-var getEventModifierState = require('getEventModifierState');
+const getEventCharCode = require('getEventCharCode');
+const getEventKey = require('getEventKey');
+const getEventModifierState = require('getEventModifierState');
 
 /**
  * @interface KeyboardEvent
  * @see http://www.w3.org/TR/DOM-Level-3-Events/
  */
-var KeyboardEventInterface = {
+const KeyboardEventInterface = {
   key: getEventKey,
   location: null,
   ctrlKey: null,

--- a/src/renderers/dom/client/syntheticEvents/SyntheticMouseEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticMouseEvent.js
@@ -11,16 +11,16 @@
 
 'use strict';
 
-var SyntheticUIEvent = require('SyntheticUIEvent');
-var ViewportMetrics = require('ViewportMetrics');
+const SyntheticUIEvent = require('SyntheticUIEvent');
+const ViewportMetrics = require('ViewportMetrics');
 
-var getEventModifierState = require('getEventModifierState');
+const getEventModifierState = require('getEventModifierState');
 
 /**
  * @interface MouseEvent
  * @see http://www.w3.org/TR/DOM-Level-3-Events/
  */
-var MouseEventInterface = {
+const MouseEventInterface = {
   screenX: null,
   screenY: null,
   clientX: null,
@@ -34,7 +34,7 @@ var MouseEventInterface = {
     // Webkit, Firefox, IE9+
     // which:  1 2 3
     // button: 0 1 2 (standard)
-    var button = event.button;
+    const button = event.button;
     if ('which' in event) {
       return button;
     }

--- a/src/renderers/dom/client/syntheticEvents/SyntheticTouchEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticTouchEvent.js
@@ -11,15 +11,15 @@
 
 'use strict';
 
-var SyntheticUIEvent = require('SyntheticUIEvent');
+const SyntheticUIEvent = require('SyntheticUIEvent');
 
-var getEventModifierState = require('getEventModifierState');
+const getEventModifierState = require('getEventModifierState');
 
 /**
  * @interface TouchEvent
  * @see http://www.w3.org/TR/touch-events/
  */
-var TouchEventInterface = {
+const TouchEventInterface = {
   touches: null,
   targetTouches: null,
   changedTouches: null,

--- a/src/renderers/dom/client/syntheticEvents/SyntheticUIEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticUIEvent.js
@@ -11,27 +11,27 @@
 
 'use strict';
 
-var SyntheticEvent = require('SyntheticEvent');
+const SyntheticEvent = require('SyntheticEvent');
 
-var getEventTarget = require('getEventTarget');
+const getEventTarget = require('getEventTarget');
 
 /**
  * @interface UIEvent
  * @see http://www.w3.org/TR/DOM-Level-3-Events/
  */
-var UIEventInterface = {
+const UIEventInterface = {
   view: function(event) {
     if (event.view) {
       return event.view;
     }
 
-    var target = getEventTarget(event);
+    const target = getEventTarget(event);
     if (target != null && target.window === target) {
       // target is a window object
       return target;
     }
 
-    var doc = target.ownerDocument;
+    const doc = target.ownerDocument;
     // TODO: Figure out why `ownerDocument` is sometimes undefined in IE8.
     if (doc) {
       return doc.defaultView || doc.parentWindow;

--- a/src/renderers/dom/client/syntheticEvents/SyntheticWheelEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticWheelEvent.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-var SyntheticMouseEvent = require('SyntheticMouseEvent');
+const SyntheticMouseEvent = require('SyntheticMouseEvent');
 
 /**
  * @interface WheelEvent
  * @see http://www.w3.org/TR/DOM-Level-3-Events/
  */
-var WheelEventInterface = {
+const WheelEventInterface = {
   deltaX: function(event) {
     return (
       'deltaX' in event ? event.deltaX :

--- a/src/renderers/dom/client/syntheticEvents/__tests__/SyntheticEvent-test.js
+++ b/src/renderers/dom/client/syntheticEvents/__tests__/SyntheticEvent-test.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-var SyntheticEvent;
-var React;
-var ReactDOM;
-var ReactTestUtils;
+let SyntheticEvent;
+let React;
+let ReactDOM;
+let ReactTestUtils;
 
 describe('SyntheticEvent', function() {
-  var createEvent;
+  let createEvent;
 
   beforeEach(function() {
     SyntheticEvent = require('SyntheticEvent');
@@ -26,22 +26,22 @@ describe('SyntheticEvent', function() {
     ReactTestUtils = require('ReactTestUtils');
 
     createEvent = function(nativeEvent) {
-      var target = require('getEventTarget')(nativeEvent);
+      const target = require('getEventTarget')(nativeEvent);
       return SyntheticEvent.getPooled({}, '', nativeEvent, target);
     };
   });
 
   it('should normalize `target` from the nativeEvent', function() {
-    var target = document.createElement('div');
-    var syntheticEvent = createEvent({srcElement: target});
+    const target = document.createElement('div');
+    const syntheticEvent = createEvent({srcElement: target});
 
     expect(syntheticEvent.target).toBe(target);
     expect(syntheticEvent.type).toBe(undefined);
   });
 
   it('should be able to `preventDefault`', function() {
-    var nativeEvent = {};
-    var syntheticEvent = createEvent(nativeEvent);
+    const nativeEvent = {};
+    const syntheticEvent = createEvent(nativeEvent);
 
     expect(syntheticEvent.isDefaultPrevented()).toBe(false);
     syntheticEvent.preventDefault();
@@ -60,8 +60,8 @@ describe('SyntheticEvent', function() {
   });
 
   it('should be able to `stopPropagation`', function() {
-    var nativeEvent = {};
-    var syntheticEvent = createEvent(nativeEvent);
+    const nativeEvent = {};
+    const syntheticEvent = createEvent(nativeEvent);
 
     expect(syntheticEvent.isPropagationStopped()).toBe(false);
     syntheticEvent.stopPropagation();
@@ -71,7 +71,7 @@ describe('SyntheticEvent', function() {
   });
 
   it('should be able to `persist`', function() {
-    var syntheticEvent = createEvent({});
+    const syntheticEvent = createEvent({});
 
     expect(syntheticEvent.isPersistent()).toBe(false);
     syntheticEvent.persist();
@@ -80,8 +80,8 @@ describe('SyntheticEvent', function() {
 
   it('should be nullified if the synthetic event has called destructor and log warnings', function() {
     spyOn(console, 'error');
-    var target = document.createElement('div');
-    var syntheticEvent = createEvent({srcElement: target});
+    const target = document.createElement('div');
+    const syntheticEvent = createEvent({srcElement: target});
     syntheticEvent.destructor();
     expect(syntheticEvent.type).toBe(null);
     expect(syntheticEvent.nativeEvent).toBe(null);
@@ -97,8 +97,8 @@ describe('SyntheticEvent', function() {
 
   it('should warn when setting properties of a destructored synthetic event', function() {
     spyOn(console, 'error');
-    var target = document.createElement('div');
-    var syntheticEvent = createEvent({srcElement: target});
+    const target = document.createElement('div');
+    const syntheticEvent = createEvent({srcElement: target});
     syntheticEvent.destructor();
     expect(syntheticEvent.type = 'MouseEvent').toBe('MouseEvent');
     expect(console.error.calls.length).toBe(1);
@@ -112,7 +112,7 @@ describe('SyntheticEvent', function() {
 
   it('should warn if the synthetic event has been released when calling `preventDefault`', function() {
     spyOn(console, 'error');
-    var syntheticEvent = createEvent({});
+    const syntheticEvent = createEvent({});
     SyntheticEvent.release(syntheticEvent);
     syntheticEvent.preventDefault();
     expect(console.error.calls.length).toBe(1);
@@ -126,7 +126,7 @@ describe('SyntheticEvent', function() {
 
   it('should warn if the synthetic event has been released when calling `stopPropagation`', function() {
     spyOn(console, 'error');
-    var syntheticEvent = createEvent({});
+    const syntheticEvent = createEvent({});
     SyntheticEvent.release(syntheticEvent);
     syntheticEvent.stopPropagation();
     expect(console.error.calls.length).toBe(1);
@@ -140,12 +140,12 @@ describe('SyntheticEvent', function() {
 
   it('should properly log warnings when events simulated with rendered components', function() {
     spyOn(console, 'error');
-    var event;
-    var element = document.createElement('div');
+    let event;
+    const element = document.createElement('div');
     function assignEvent(e) {
       event = e;
     }
-    var instance = ReactDOM.render(<div onClick={assignEvent} />, element);
+    const instance = ReactDOM.render(<div onClick={assignEvent} />, element);
     ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(instance));
     expect(console.error.calls.length).toBe(0);
 

--- a/src/renderers/dom/client/syntheticEvents/__tests__/SyntheticWheelEvent-test.js
+++ b/src/renderers/dom/client/syntheticEvents/__tests__/SyntheticWheelEvent-test.js
@@ -11,23 +11,23 @@
 
 'use strict';
 
-var SyntheticWheelEvent;
+let SyntheticWheelEvent;
 
 describe('SyntheticWheelEvent', function() {
-  var createEvent;
+  let createEvent;
 
   beforeEach(function() {
     SyntheticWheelEvent = require('SyntheticWheelEvent');
 
     createEvent = function(nativeEvent) {
-      var target = require('getEventTarget')(nativeEvent);
+      const target = require('getEventTarget')(nativeEvent);
       return SyntheticWheelEvent.getPooled({}, '', nativeEvent, target);
     };
   });
 
   it('should normalize properties from the Event interface', function() {
-    var target = document.createElement('div');
-    var syntheticEvent = createEvent({srcElement: target});
+    const target = document.createElement('div');
+    const syntheticEvent = createEvent({srcElement: target});
 
     expect(syntheticEvent.target).toBe(target);
     expect(syntheticEvent.type).toBe(undefined);
@@ -38,18 +38,18 @@ describe('SyntheticWheelEvent', function() {
   });
 
   it('should normalize properties from the WheelEvent interface', function() {
-    var standardEvent = createEvent({deltaX: 10, deltaY: -50});
+    const standardEvent = createEvent({deltaX: 10, deltaY: -50});
     expect(standardEvent.deltaX).toBe(10);
     expect(standardEvent.deltaY).toBe(-50);
 
-    var webkitEvent = createEvent({wheelDeltaX: -10, wheelDeltaY: 50});
+    const webkitEvent = createEvent({wheelDeltaX: -10, wheelDeltaY: 50});
     expect(webkitEvent.deltaX).toBe(10);
     expect(webkitEvent.deltaY).toBe(-50);
   });
 
   it('should be able to `preventDefault` and `stopPropagation`', function() {
-    var nativeEvent = {};
-    var syntheticEvent = createEvent(nativeEvent);
+    const nativeEvent = {};
+    const syntheticEvent = createEvent(nativeEvent);
 
     expect(syntheticEvent.isDefaultPrevented()).toBe(false);
     syntheticEvent.preventDefault();
@@ -61,7 +61,7 @@ describe('SyntheticWheelEvent', function() {
   });
 
   it('should be able to `persist`', function() {
-    var syntheticEvent = createEvent({});
+    const syntheticEvent = createEvent({});
 
     expect(syntheticEvent.isPersistent()).toBe(false);
     syntheticEvent.persist();

--- a/src/renderers/dom/client/utils/DOMChildrenOperations.js
+++ b/src/renderers/dom/client/utils/DOMChildrenOperations.js
@@ -11,14 +11,14 @@
 
 'use strict';
 
-var DOMLazyTree = require('DOMLazyTree');
-var Danger = require('Danger');
-var ReactMultiChildUpdateTypes = require('ReactMultiChildUpdateTypes');
-var ReactPerf = require('ReactPerf');
+const DOMLazyTree = require('DOMLazyTree');
+const Danger = require('Danger');
+const ReactMultiChildUpdateTypes = require('ReactMultiChildUpdateTypes');
+const ReactPerf = require('ReactPerf');
 
-var createMicrosoftUnsafeLocalFunction = require('createMicrosoftUnsafeLocalFunction');
-var setInnerHTML = require('setInnerHTML');
-var setTextContent = require('setTextContent');
+const createMicrosoftUnsafeLocalFunction = require('createMicrosoftUnsafeLocalFunction');
+const setInnerHTML = require('setInnerHTML');
+const setTextContent = require('setTextContent');
 
 function getNodeAfter(parentNode, node) {
   // Special case for text components, which return [open, close] comments
@@ -37,7 +37,7 @@ function getNodeAfter(parentNode, node) {
  * @param {number} index Index at which to insert the child.
  * @internal
  */
-var insertChildAt = createMicrosoftUnsafeLocalFunction(
+const insertChildAt = createMicrosoftUnsafeLocalFunction(
   function(parentNode, childNode, referenceNode) {
     // We rely exclusively on `insertBefore(node, null)` instead of also using
     // `appendChild(node)`. (Using `undefined` is not allowed by all browsers so
@@ -60,7 +60,7 @@ function moveChild(parentNode, childNode, referenceNode) {
 
 function removeChild(parentNode, childNode) {
   if (Array.isArray(childNode)) {
-    var closingComment = childNode[1];
+    const closingComment = childNode[1];
     childNode = childNode[0];
     removeDelimitedText(parentNode, childNode, closingComment);
     parentNode.removeChild(closingComment);
@@ -74,9 +74,9 @@ function moveDelimitedText(
   closingComment,
   referenceNode
 ) {
-  var node = openingComment;
+  let node = openingComment;
   while (true) {
-    var nextNode = node.nextSibling;
+    const nextNode = node.nextSibling;
     insertChildAt(parentNode, node, referenceNode);
     if (node === closingComment) {
       break;
@@ -87,7 +87,7 @@ function moveDelimitedText(
 
 function removeDelimitedText(parentNode, startNode, closingComment) {
   while (true) {
-    var node = startNode.nextSibling;
+    const node = startNode.nextSibling;
     if (node === closingComment) {
       // The closing comment is removed by ReactMultiChild.
       break;
@@ -98,8 +98,8 @@ function removeDelimitedText(parentNode, startNode, closingComment) {
 }
 
 function replaceDelimitedText(openingComment, closingComment, stringText) {
-  var parentNode = openingComment.parentNode;
-  var nodeAfterComment = openingComment.nextSibling;
+  const parentNode = openingComment.parentNode;
+  const nodeAfterComment = openingComment.nextSibling;
   if (nodeAfterComment === closingComment) {
     // There are no text nodes between the opening and closing comments; insert
     // a new one if stringText isn't empty.
@@ -125,7 +125,7 @@ function replaceDelimitedText(openingComment, closingComment, stringText) {
 /**
  * Operations for updating with DOM children.
  */
-var DOMChildrenOperations = {
+const DOMChildrenOperations = {
 
   dangerouslyReplaceNodeWithMarkup: Danger.dangerouslyReplaceNodeWithMarkup,
 
@@ -141,8 +141,8 @@ var DOMChildrenOperations = {
    * @internal
    */
   processUpdates: function(parentNode, updates) {
-    for (var k = 0; k < updates.length; k++) {
-      var update = updates[k];
+    for (let k = 0; k < updates.length; k++) {
+      const update = updates[k];
       switch (update.type) {
         case ReactMultiChildUpdateTypes.INSERT_MARKUP:
           insertLazyTreeChildAt(

--- a/src/renderers/dom/client/utils/DOMLazyTree.js
+++ b/src/renderers/dom/client/utils/DOMLazyTree.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-var createMicrosoftUnsafeLocalFunction = require('createMicrosoftUnsafeLocalFunction');
-var setTextContent = require('setTextContent');
+const createMicrosoftUnsafeLocalFunction = require('createMicrosoftUnsafeLocalFunction');
+const setTextContent = require('setTextContent');
 
 /**
  * In IE (8-11) and Edge, appending nodes with no children is dramatically
@@ -25,7 +25,7 @@ var setTextContent = require('setTextContent');
  *
  * See https://github.com/spicyj/innerhtml-vs-createelement-vs-clonenode.
  */
-var enableLazy = (
+const enableLazy = (
   typeof document !== 'undefined' &&
   typeof document.documentMode === 'number'
   ||
@@ -38,10 +38,10 @@ function insertTreeChildren(tree) {
   if (!enableLazy) {
     return;
   }
-  var node = tree.node;
-  var children = tree.children;
+  const node = tree.node;
+  const children = tree.children;
   if (children.length) {
-    for (var i = 0; i < children.length; i++) {
+    for (let i = 0; i < children.length; i++) {
       insertTreeBefore(node, children[i], null);
     }
   } else if (tree.html != null) {

--- a/src/renderers/dom/client/utils/ViewportMetrics.js
+++ b/src/renderers/dom/client/utils/ViewportMetrics.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var ViewportMetrics = {
+const ViewportMetrics = {
 
   currentScrollLeft: 0,
 

--- a/src/renderers/dom/client/utils/__tests__/getNodeForCharacterOffset-test.js
+++ b/src/renderers/dom/client/utils/__tests__/getNodeForCharacterOffset-test.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-var getTestDocument = require('getTestDocument');
+const getTestDocument = require('getTestDocument');
 
-var getNodeForCharacterOffset = require('getNodeForCharacterOffset');
+const getNodeForCharacterOffset = require('getNodeForCharacterOffset');
 
 // Create node from HTML string
 function createNode(html) {
-  var node = (getTestDocument() || document).createElement('div');
+  const node = (getTestDocument() || document).createElement('div');
   node.innerHTML = html;
   return node;
 }
@@ -30,21 +30,21 @@ function expectNodeOffset(result, textContent, nodeOffset) {
 
 describe('getNodeForCharacterOffset', function() {
   it('should handle siblings', function() {
-    var node = createNode('<i>123</i><i>456</i><i>789</i>');
+    const node = createNode('<i>123</i><i>456</i><i>789</i>');
 
     expectNodeOffset(getNodeForCharacterOffset(node, 0), '123', 0);
     expectNodeOffset(getNodeForCharacterOffset(node, 4), '456', 1);
   });
 
   it('should handle trailing chars', function() {
-    var node = createNode('<i>123</i><i>456</i><i>789</i>');
+    const node = createNode('<i>123</i><i>456</i><i>789</i>');
 
     expectNodeOffset(getNodeForCharacterOffset(node, 3), '123', 3);
     expectNodeOffset(getNodeForCharacterOffset(node, 9), '789', 3);
   });
 
   it('should handle trees', function() {
-    var node = createNode(
+    const node = createNode(
       '<i>' +
         '<i>1</i>' +
         '<i>' +
@@ -66,7 +66,7 @@ describe('getNodeForCharacterOffset', function() {
   });
 
   it('should handle non-existent offset', function() {
-    var node = createNode('<i>123</i>');
+    const node = createNode('<i>123</i>');
 
     expect(getNodeForCharacterOffset(node, -1)).toBeUndefined();
     expect(getNodeForCharacterOffset(node, 4)).toBeUndefined();

--- a/src/renderers/dom/client/utils/createMicrosoftUnsafeLocalFunction.js
+++ b/src/renderers/dom/client/utils/createMicrosoftUnsafeLocalFunction.js
@@ -16,7 +16,7 @@
 /**
  * Create a function which has 'unsafe' privileges (required by windows8 apps)
  */
-var createMicrosoftUnsafeLocalFunction = function(func) {
+const createMicrosoftUnsafeLocalFunction = function(func) {
   if (typeof MSApp !== 'undefined' && MSApp.execUnsafeLocalFunction) {
     return function(arg0, arg1, arg2, arg3) {
       MSApp.execUnsafeLocalFunction(function() {

--- a/src/renderers/dom/client/utils/getEventCharCode.js
+++ b/src/renderers/dom/client/utils/getEventCharCode.js
@@ -22,8 +22,8 @@
  * @return {number} Normalized `charCode` property.
  */
 function getEventCharCode(nativeEvent) {
-  var charCode;
-  var keyCode = nativeEvent.keyCode;
+  let charCode;
+  const keyCode = nativeEvent.keyCode;
 
   if ('charCode' in nativeEvent) {
     charCode = nativeEvent.charCode;

--- a/src/renderers/dom/client/utils/getEventKey.js
+++ b/src/renderers/dom/client/utils/getEventKey.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-var getEventCharCode = require('getEventCharCode');
+const getEventCharCode = require('getEventCharCode');
 
 /**
  * Normalization of deprecated HTML5 `key` values
  * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Key_names
  */
-var normalizeKey = {
+const normalizeKey = {
   'Esc': 'Escape',
   'Spacebar': ' ',
   'Left': 'ArrowLeft',
@@ -37,7 +37,7 @@ var normalizeKey = {
  * Only special keys supported, all others depend on keyboard layout or browser
  * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Key_names
  */
-var translateToKey = {
+const translateToKey = {
   8: 'Backspace',
   9: 'Tab',
   12: 'Clear',
@@ -85,7 +85,7 @@ function getEventKey(nativeEvent) {
 
   // Browser does not implement `key`, polyfill as much of it as we can.
   if (nativeEvent.type === 'keypress') {
-    var charCode = getEventCharCode(nativeEvent);
+    const charCode = getEventCharCode(nativeEvent);
 
     // The enter-key is technically both printable and non-printable and can
     // thus be captured by `keypress`, no other non-printable key should.

--- a/src/renderers/dom/client/utils/getEventModifierState.js
+++ b/src/renderers/dom/client/utils/getEventModifierState.js
@@ -16,7 +16,7 @@
  * @see http://www.w3.org/TR/DOM-Level-3-Events/#keys-Modifiers
  */
 
-var modifierKeyToProp = {
+const modifierKeyToProp = {
   'Alt': 'altKey',
   'Control': 'ctrlKey',
   'Meta': 'metaKey',
@@ -27,12 +27,12 @@ var modifierKeyToProp = {
 // modifier keys exposed by the event itself, does not support Lock-keys.
 // Currently, all major browsers except Chrome seems to support Lock-keys.
 function modifierStateGetter(keyArg) {
-  var syntheticEvent = this;
-  var nativeEvent = syntheticEvent.nativeEvent;
+  const syntheticEvent = this;
+  const nativeEvent = syntheticEvent.nativeEvent;
   if (nativeEvent.getModifierState) {
     return nativeEvent.getModifierState(keyArg);
   }
-  var keyProp = modifierKeyToProp[keyArg];
+  const keyProp = modifierKeyToProp[keyArg];
   return keyProp ? !!nativeEvent[keyProp] : false;
 }
 

--- a/src/renderers/dom/client/utils/getEventTarget.js
+++ b/src/renderers/dom/client/utils/getEventTarget.js
@@ -19,7 +19,7 @@
  * @return {DOMEventTarget} Target node.
  */
 function getEventTarget(nativeEvent) {
-  var target = nativeEvent.target || nativeEvent.srcElement || window;
+  let target = nativeEvent.target || nativeEvent.srcElement || window;
 
   // Normalize SVG <use> element events #4963
   if (target.correspondingUseElement) {

--- a/src/renderers/dom/client/utils/getNodeForCharacterOffset.js
+++ b/src/renderers/dom/client/utils/getNodeForCharacterOffset.js
@@ -48,9 +48,9 @@ function getSiblingNode(node) {
  * @return {?object}
  */
 function getNodeForCharacterOffset(root, offset) {
-  var node = getLeafNode(root);
-  var nodeStart = 0;
-  var nodeEnd = 0;
+  let node = getLeafNode(root);
+  let nodeStart = 0;
+  let nodeEnd = 0;
 
   while (node) {
     if (node.nodeType === 3) {

--- a/src/renderers/dom/client/utils/getTextContentAccessor.js
+++ b/src/renderers/dom/client/utils/getTextContentAccessor.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-var ExecutionEnvironment = require('ExecutionEnvironment');
+const ExecutionEnvironment = require('ExecutionEnvironment');
 
-var contentKey = null;
+let contentKey = null;
 
 /**
  * Gets the key used to access text content on a DOM node.

--- a/src/renderers/dom/client/utils/isEventSupported.js
+++ b/src/renderers/dom/client/utils/isEventSupported.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-var ExecutionEnvironment = require('ExecutionEnvironment');
+const ExecutionEnvironment = require('ExecutionEnvironment');
 
-var useHasFeature;
+let useHasFeature;
 if (ExecutionEnvironment.canUseDOM) {
   useHasFeature =
     document.implementation &&
@@ -43,11 +43,11 @@ function isEventSupported(eventNameSuffix, capture) {
     return false;
   }
 
-  var eventName = 'on' + eventNameSuffix;
-  var isSupported = eventName in document;
+  const eventName = 'on' + eventNameSuffix;
+  let isSupported = eventName in document;
 
   if (!isSupported) {
-    var element = document.createElement('div');
+    const element = document.createElement('div');
     element.setAttribute(eventName, 'return;');
     isSupported = typeof element[eventName] === 'function';
   }

--- a/src/renderers/dom/client/utils/setInnerHTML.js
+++ b/src/renderers/dom/client/utils/setInnerHTML.js
@@ -11,12 +11,12 @@
 
 'use strict';
 
-var ExecutionEnvironment = require('ExecutionEnvironment');
+const ExecutionEnvironment = require('ExecutionEnvironment');
 
-var WHITESPACE_TEST = /^[ \r\n\t\f]/;
-var NONVISIBLE_TEST = /<(!--|link|noscript|meta|script|style)[ \r\n\t\f\/>]/;
+const WHITESPACE_TEST = /^[ \r\n\t\f]/;
+const NONVISIBLE_TEST = /<(!--|link|noscript|meta|script|style)[ \r\n\t\f\/>]/;
 
-var createMicrosoftUnsafeLocalFunction = require('createMicrosoftUnsafeLocalFunction');
+const createMicrosoftUnsafeLocalFunction = require('createMicrosoftUnsafeLocalFunction');
 
 /**
  * Set the innerHTML property of a node, ensuring that whitespace is preserved
@@ -26,7 +26,7 @@ var createMicrosoftUnsafeLocalFunction = require('createMicrosoftUnsafeLocalFunc
  * @param {string} html
  * @internal
  */
-var setInnerHTML = createMicrosoftUnsafeLocalFunction(
+let setInnerHTML = createMicrosoftUnsafeLocalFunction(
   function(node, html) {
     node.innerHTML = html;
   }
@@ -39,7 +39,7 @@ if (ExecutionEnvironment.canUseDOM) {
   // @see quirksmode.org/bugreports/archives/2004/11/innerhtml_and_t.html
 
   // Feature detection; only IE8 is known to behave improperly like this.
-  var testElement = document.createElement('div');
+  const testElement = document.createElement('div');
   testElement.innerHTML = ' ';
   if (testElement.innerHTML === '') {
     setInnerHTML = function(node, html) {
@@ -68,7 +68,7 @@ if (ExecutionEnvironment.canUseDOM) {
 
         // deleteData leaves an empty `TextNode` which offsets the index of all
         // children. Definitely want to avoid this.
-        var textNode = node.firstChild;
+        const textNode = node.firstChild;
         if (textNode.data.length === 1) {
           node.removeChild(textNode);
         } else {

--- a/src/renderers/dom/client/utils/setTextContent.js
+++ b/src/renderers/dom/client/utils/setTextContent.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-var ExecutionEnvironment = require('ExecutionEnvironment');
-var escapeTextContentForBrowser = require('escapeTextContentForBrowser');
-var setInnerHTML = require('setInnerHTML');
+const ExecutionEnvironment = require('ExecutionEnvironment');
+const escapeTextContentForBrowser = require('escapeTextContentForBrowser');
+const setInnerHTML = require('setInnerHTML');
 
 /**
  * Set the textContent property of a node, ensuring that whitespace is preserved
@@ -25,7 +25,7 @@ var setInnerHTML = require('setInnerHTML');
  * @param {string} text
  * @internal
  */
-var setTextContent = function(node, text) {
+let setTextContent = function(node, text) {
   node.textContent = text;
 };
 

--- a/src/renderers/dom/client/validateDOMNesting.js
+++ b/src/renderers/dom/client/validateDOMNesting.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-var assign = require('Object.assign');
-var emptyFunction = require('emptyFunction');
-var warning = require('warning');
+const assign = require('Object.assign');
+const emptyFunction = require('emptyFunction');
+const warning = require('warning');
 
-var validateDOMNesting = emptyFunction;
+let validateDOMNesting = emptyFunction;
 
 if (__DEV__) {
   // This validation code was written based on the HTML5 parsing spec:
@@ -30,7 +30,7 @@ if (__DEV__) {
   // first, causing a confusing mess.
 
   // https://html.spec.whatwg.org/multipage/syntax.html#special
-  var specialTags = [
+  const specialTags = [
     'address', 'applet', 'area', 'article', 'aside', 'base', 'basefont',
     'bgsound', 'blockquote', 'body', 'br', 'button', 'caption', 'center', 'col',
     'colgroup', 'dd', 'details', 'dir', 'div', 'dl', 'dt', 'embed', 'fieldset',
@@ -45,7 +45,7 @@ if (__DEV__) {
   ];
 
   // https://html.spec.whatwg.org/multipage/syntax.html#has-an-element-in-scope
-  var inScopeTags = [
+  const inScopeTags = [
     'applet', 'caption', 'html', 'table', 'td', 'th', 'marquee', 'object',
     'template',
 
@@ -56,13 +56,13 @@ if (__DEV__) {
   ];
 
   // https://html.spec.whatwg.org/multipage/syntax.html#has-an-element-in-button-scope
-  var buttonScopeTags = inScopeTags.concat(['button']);
+  const buttonScopeTags = inScopeTags.concat(['button']);
 
   // https://html.spec.whatwg.org/multipage/syntax.html#generate-implied-end-tags
-  var impliedEndTags =
+  const impliedEndTags =
     ['dd', 'dt', 'li', 'option', 'optgroup', 'p', 'rp', 'rt'];
 
-  var emptyAncestorInfo = {
+  const emptyAncestorInfo = {
     current: null,
 
     formTag: null,
@@ -75,9 +75,9 @@ if (__DEV__) {
     dlItemTagAutoclosing: null,
   };
 
-  var updatedAncestorInfo = function(oldInfo, tag, instance) {
-    var ancestorInfo = assign({}, oldInfo || emptyAncestorInfo);
-    var info = {tag: tag, instance: instance};
+  const updatedAncestorInfo = function(oldInfo, tag, instance) {
+    const ancestorInfo = assign({}, oldInfo || emptyAncestorInfo);
+    const info = {tag: tag, instance: instance};
 
     if (inScopeTags.indexOf(tag) !== -1) {
       ancestorInfo.aTagInScope = null;
@@ -128,7 +128,7 @@ if (__DEV__) {
   /**
    * Returns whether
    */
-  var isTagValidWithParent = function(tag, parentTag) {
+  const isTagValidWithParent = function(tag, parentTag) {
     // First, let's check if we're in an unusual parsing mode...
     switch (parentTag) {
       // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-inselect
@@ -234,7 +234,7 @@ if (__DEV__) {
   /**
    * Returns whether
    */
-  var findInvalidAncestorForTag = function(tag, ancestorInfo) {
+  const findInvalidAncestorForTag = function(tag, ancestorInfo) {
     switch (tag) {
       case 'address':
       case 'article':
@@ -307,12 +307,12 @@ if (__DEV__) {
    * Given a ReactCompositeComponent instance, return a list of its recursive
    * owners, starting at the root and ending with the instance itself.
    */
-  var findOwnerStack = function(instance) {
+  const findOwnerStack = function(instance) {
     if (!instance) {
       return [];
     }
 
-    var stack = [];
+    const stack = [];
     do {
       stack.push(instance);
     } while ((instance = instance._currentElement._owner));
@@ -320,34 +320,34 @@ if (__DEV__) {
     return stack;
   };
 
-  var didWarn = {};
+  const didWarn = {};
 
   validateDOMNesting = function(childTag, childInstance, ancestorInfo) {
     ancestorInfo = ancestorInfo || emptyAncestorInfo;
-    var parentInfo = ancestorInfo.current;
-    var parentTag = parentInfo && parentInfo.tag;
+    const parentInfo = ancestorInfo.current;
+    const parentTag = parentInfo && parentInfo.tag;
 
-    var invalidParent =
+    const invalidParent =
       isTagValidWithParent(childTag, parentTag) ? null : parentInfo;
-    var invalidAncestor =
+    const invalidAncestor =
       invalidParent ? null : findInvalidAncestorForTag(childTag, ancestorInfo);
-    var problematic = invalidParent || invalidAncestor;
+    const problematic = invalidParent || invalidAncestor;
 
     if (problematic) {
-      var ancestorTag = problematic.tag;
-      var ancestorInstance = problematic.instance;
+      const ancestorTag = problematic.tag;
+      const ancestorInstance = problematic.instance;
 
-      var childOwner = childInstance && childInstance._currentElement._owner;
-      var ancestorOwner =
+      const childOwner = childInstance && childInstance._currentElement._owner;
+      const ancestorOwner =
         ancestorInstance && ancestorInstance._currentElement._owner;
 
-      var childOwners = findOwnerStack(childOwner);
-      var ancestorOwners = findOwnerStack(ancestorOwner);
+      const childOwners = findOwnerStack(childOwner);
+      const ancestorOwners = findOwnerStack(ancestorOwner);
 
-      var minStackLen = Math.min(childOwners.length, ancestorOwners.length);
-      var i;
+      const minStackLen = Math.min(childOwners.length, ancestorOwners.length);
+      let i;
 
-      var deepestCommon = -1;
+      let deepestCommon = -1;
       for (i = 0; i < minStackLen; i++) {
         if (childOwners[i] === ancestorOwners[i]) {
           deepestCommon = i;
@@ -356,14 +356,14 @@ if (__DEV__) {
         }
       }
 
-      var UNKNOWN = '(unknown)';
-      var childOwnerNames = childOwners.slice(deepestCommon + 1).map(
+      const UNKNOWN = '(unknown)';
+      const childOwnerNames = childOwners.slice(deepestCommon + 1).map(
         (inst) => inst.getName() || UNKNOWN
       );
-      var ancestorOwnerNames = ancestorOwners.slice(deepestCommon + 1).map(
+      const ancestorOwnerNames = ancestorOwners.slice(deepestCommon + 1).map(
         (inst) => inst.getName() || UNKNOWN
       );
-      var ownerInfo = [].concat(
+      const ownerInfo = [].concat(
         // If the parent and child instances have a common owner ancestor, start
         // with that -- otherwise we just start with the parent's owners.
         deepestCommon !== -1 ?
@@ -377,20 +377,20 @@ if (__DEV__) {
         childTag
       ).join(' > ');
 
-      var warnKey =
+      const warnKey =
         !!invalidParent + '|' + childTag + '|' + ancestorTag + '|' + ownerInfo;
       if (didWarn[warnKey]) {
         return;
       }
       didWarn[warnKey] = true;
 
-      var tagDisplayName = childTag;
+      let tagDisplayName = childTag;
       if (childTag !== '#text') {
         tagDisplayName = '<' + childTag + '>';
       }
 
       if (invalidParent) {
-        var info = '';
+        let info = '';
         if (ancestorTag === 'table' && childTag === 'tr') {
           info +=
             ' Add a <tbody> to your code to match the DOM tree generated by ' +
@@ -423,8 +423,8 @@ if (__DEV__) {
   // For testing
   validateDOMNesting.isTagValidInContext = function(tag, ancestorInfo) {
     ancestorInfo = ancestorInfo || emptyAncestorInfo;
-    var parentInfo = ancestorInfo.current;
-    var parentTag = parentInfo && parentInfo.tag;
+    const parentInfo = ancestorInfo.current;
+    const parentTag = parentInfo && parentInfo.tag;
     return (
       isTagValidWithParent(tag, parentTag) &&
       !findInvalidAncestorForTag(tag, ancestorInfo)

--- a/src/renderers/dom/client/wrappers/AutoFocusUtils.js
+++ b/src/renderers/dom/client/wrappers/AutoFocusUtils.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
 
-var focusNode = require('focusNode');
+const focusNode = require('focusNode');
 
-var AutoFocusUtils = {
+const AutoFocusUtils = {
   focusDOMComponent: function() {
     focusNode(ReactDOMComponentTree.getNodeFromInstance(this));
   },

--- a/src/renderers/dom/client/wrappers/LinkedValueUtils.js
+++ b/src/renderers/dom/client/wrappers/LinkedValueUtils.js
@@ -103,7 +103,7 @@ function getDeclarationErrorAddendum(owner) {
  */
 const LinkedValueUtils = {
   checkPropTypes: function(tagName, props, owner) {
-    for (let propName in propTypes) {
+    for (const propName in propTypes) {
       if (propTypes.hasOwnProperty(propName)) {
         var error = propTypes[propName](
           props,

--- a/src/renderers/dom/client/wrappers/LinkedValueUtils.js
+++ b/src/renderers/dom/client/wrappers/LinkedValueUtils.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-var ReactPropTypes = require('ReactPropTypes');
-var ReactPropTypeLocations = require('ReactPropTypeLocations');
+const ReactPropTypes = require('ReactPropTypes');
+const ReactPropTypeLocations = require('ReactPropTypeLocations');
 
-var invariant = require('invariant');
-var warning = require('warning');
+const invariant = require('invariant');
+const warning = require('warning');
 
-var hasReadOnlyValue = {
+const hasReadOnlyValue = {
   'button': true,
   'checkbox': true,
   'image': true,
@@ -53,7 +53,7 @@ function _assertCheckedLink(inputProps) {
   );
 }
 
-var propTypes = {
+const propTypes = {
   value: function(props, propName, componentName) {
     if (!props[propName] ||
         hasReadOnlyValue[props.type] ||
@@ -86,10 +86,10 @@ var propTypes = {
   onChange: ReactPropTypes.func,
 };
 
-var loggedTypeFailures = {};
+const loggedTypeFailures = {};
 function getDeclarationErrorAddendum(owner) {
   if (owner) {
-    var name = owner.getName();
+    const name = owner.getName();
     if (name) {
       return ' Check the render method of `' + name + '`.';
     }
@@ -101,9 +101,9 @@ function getDeclarationErrorAddendum(owner) {
  * Provide a linked `value` attribute for controlled forms. You should not use
  * this outside of the ReactDOM controlled form components.
  */
-var LinkedValueUtils = {
+const LinkedValueUtils = {
   checkPropTypes: function(tagName, props, owner) {
-    for (var propName in propTypes) {
+    for (let propName in propTypes) {
       if (propTypes.hasOwnProperty(propName)) {
         var error = propTypes[propName](
           props,
@@ -117,7 +117,7 @@ var LinkedValueUtils = {
         // same error.
         loggedTypeFailures[error.message] = true;
 
-        var addendum = getDeclarationErrorAddendum(owner);
+        const addendum = getDeclarationErrorAddendum(owner);
         warning(false, 'Failed form propType: %s%s', error.message, addendum);
       }
     }

--- a/src/renderers/dom/client/wrappers/ReactDOMButton.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMButton.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var mouseListenerNames = {
+const mouseListenerNames = {
   onClick: true,
   onDoubleClick: true,
   onMouseDown: true,
@@ -29,15 +29,15 @@ var mouseListenerNames = {
  * Implements a <button> native component that does not receive mouse events
  * when `disabled` is set.
  */
-var ReactDOMButton = {
+const ReactDOMButton = {
   getNativeProps: function(inst, props) {
     if (!props.disabled) {
       return props;
     }
 
     // Copy the props, except the mouse listeners
-    var nativeProps = {};
-    for (var key in props) {
+    const nativeProps = {};
+    for (let key in props) {
       if (props.hasOwnProperty(key) && !mouseListenerNames[key]) {
         nativeProps[key] = props[key];
       }

--- a/src/renderers/dom/client/wrappers/ReactDOMButton.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMButton.js
@@ -37,7 +37,7 @@ const ReactDOMButton = {
 
     // Copy the props, except the mouse listeners
     const nativeProps = {};
-    for (let key in props) {
+    for (const key in props) {
       if (props.hasOwnProperty(key) && !mouseListenerNames[key]) {
         nativeProps[key] = props[key];
       }

--- a/src/renderers/dom/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMInput.js
@@ -11,22 +11,22 @@
 
 'use strict';
 
-var DOMPropertyOperations = require('DOMPropertyOperations');
-var LinkedValueUtils = require('LinkedValueUtils');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var ReactUpdates = require('ReactUpdates');
+const DOMPropertyOperations = require('DOMPropertyOperations');
+const LinkedValueUtils = require('LinkedValueUtils');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
+const ReactUpdates = require('ReactUpdates');
 
-var assign = require('Object.assign');
-var invariant = require('invariant');
-var warning = require('warning');
+const assign = require('Object.assign');
+const invariant = require('invariant');
+const warning = require('warning');
 
-var didWarnValueLink = false;
-var didWarnCheckedLink = false;
-var didWarnValueNull = false;
-var didWarnValueDefaultValue = false;
-var didWarnCheckedDefaultChecked = false;
-var didWarnControlledToUncontrolled = false;
-var didWarnUncontrolledToControlled = false;
+let didWarnValueLink = false;
+let didWarnCheckedLink = false;
+let didWarnValueNull = false;
+let didWarnValueDefaultValue = false;
+let didWarnCheckedDefaultChecked = false;
+let didWarnControlledToUncontrolled = false;
+let didWarnUncontrolledToControlled = false;
 
 function forceUpdateIfMounted() {
   if (this._rootNodeID) {
@@ -66,10 +66,10 @@ function warnIfValueIsNull(props) {
  */
 var ReactDOMInput = {
   getNativeProps: function(inst, props) {
-    var value = LinkedValueUtils.getValue(props);
-    var checked = LinkedValueUtils.getChecked(props);
+    const value = LinkedValueUtils.getValue(props);
+    const checked = LinkedValueUtils.getChecked(props);
 
-    var nativeProps = assign({
+    const nativeProps = assign({
       // Make sure we set .type before any other properties (setting .value
       // before .type means .value is lost in IE11 and below)
       type: undefined,
@@ -153,15 +153,15 @@ var ReactDOMInput = {
   },
 
   updateWrapper: function(inst) {
-    var props = inst._currentElement.props;
+    const props = inst._currentElement.props;
 
     if (__DEV__) {
       warnIfValueIsNull(props);
 
-      var initialValue = inst._wrapperState.initialChecked || inst._wrapperState.initialValue;
-      var defaultValue = props.defaultChecked || props.defaultValue;
-      var controlled = props.checked !== undefined || props.value !== undefined;
-      var owner = inst._currentElement._owner;
+      const initialValue = inst._wrapperState.initialChecked || inst._wrapperState.initialValue;
+      const defaultValue = props.defaultChecked || props.defaultValue;
+      const controlled = props.checked !== undefined || props.value !== undefined;
+      const owner = inst._currentElement._owner;
 
       if (
         (initialValue || !inst._wrapperState.controlled) &&
@@ -220,19 +220,19 @@ var ReactDOMInput = {
 };
 
 function _handleChange(event) {
-  var props = this._currentElement.props;
+  const props = this._currentElement.props;
 
-  var returnValue = LinkedValueUtils.executeOnChange(props, event);
+  const returnValue = LinkedValueUtils.executeOnChange(props, event);
 
   // Here we use asap to wait until all updates have propagated, which
   // is important when using controlled components within layers:
   // https://github.com/facebook/react/issues/1698
   ReactUpdates.asap(forceUpdateIfMounted, this);
 
-  var name = props.name;
+  const name = props.name;
   if (props.type === 'radio' && name != null) {
-    var rootNode = ReactDOMComponentTree.getNodeFromInstance(this);
-    var queryRoot = rootNode;
+    const rootNode = ReactDOMComponentTree.getNodeFromInstance(this);
+    let queryRoot = rootNode;
 
     while (queryRoot.parentNode) {
       queryRoot = queryRoot.parentNode;
@@ -244,11 +244,11 @@ function _handleChange(event) {
     // and won't include inputs that use the HTML5 `form=` attribute. Since
     // the input might not even be in a form, let's just use the global
     // `querySelectorAll` to ensure we don't miss anything.
-    var group = queryRoot.querySelectorAll(
+    const group = queryRoot.querySelectorAll(
       'input[name=' + JSON.stringify('' + name) + '][type="radio"]');
 
-    for (var i = 0; i < group.length; i++) {
-      var otherNode = group[i];
+    for (let i = 0; i < group.length; i++) {
+      const otherNode = group[i];
       if (otherNode === rootNode ||
           otherNode.form !== rootNode.form) {
         continue;
@@ -257,7 +257,7 @@ function _handleChange(event) {
       // and the same name are rendered into the same form (same as #1939).
       // That's probably okay; we don't support it just as we don't support
       // mixing React radio buttons with non-React ones.
-      var otherInstance = ReactDOMComponentTree.getInstanceFromNode(otherNode);
+      const otherInstance = ReactDOMComponentTree.getInstanceFromNode(otherNode);
       invariant(
         otherInstance,
         'ReactDOMInput: Mixing React and non-React radio inputs with the ' +

--- a/src/renderers/dom/client/wrappers/ReactDOMOption.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMOption.js
@@ -11,16 +11,16 @@
 
 'use strict';
 
-var ReactChildren = require('ReactChildren');
-var ReactDOMSelect = require('ReactDOMSelect');
+const ReactChildren = require('ReactChildren');
+const ReactDOMSelect = require('ReactDOMSelect');
 
-var assign = require('Object.assign');
-var warning = require('warning');
+const assign = require('Object.assign');
+const warning = require('warning');
 
 /**
  * Implements an <option> native component that warns when `selected` is set.
  */
-var ReactDOMOption = {
+const ReactDOMOption = {
   mountWrapper: function(inst, props, nativeParent) {
     // TODO (yungsters): Remove support for `selected` in <option>.
     if (__DEV__) {
@@ -32,7 +32,7 @@ var ReactDOMOption = {
     }
 
     // Look up whether this option is 'selected'
-    var selectValue = null;
+    let selectValue = null;
     if (nativeParent != null && nativeParent._tag === 'select') {
       selectValue = ReactDOMSelect.getSelectValueContext(nativeParent);
     }
@@ -44,7 +44,7 @@ var ReactDOMOption = {
       selected = false;
       if (Array.isArray(selectValue)) {
         // multiple
-        for (var i = 0; i < selectValue.length; i++) {
+        for (let i = 0; i < selectValue.length; i++) {
           if ('' + selectValue[i] === '' + props.value) {
             selected = true;
             break;
@@ -59,7 +59,7 @@ var ReactDOMOption = {
   },
 
   getNativeProps: function(inst, props) {
-    var nativeProps = assign({selected: undefined, children: undefined}, props);
+    const nativeProps = assign({selected: undefined, children: undefined}, props);
 
     // Read state only from initial mount because <select> updates value
     // manually; we need the initial state only for server rendering
@@ -67,7 +67,7 @@ var ReactDOMOption = {
       nativeProps.selected = inst._wrapperState.selected;
     }
 
-    var content = '';
+    let content = '';
 
     // Flatten children and warn if they aren't strings or numbers;
     // invalid types are ignored.

--- a/src/renderers/dom/client/wrappers/ReactDOMSelect.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMSelect.js
@@ -11,23 +11,23 @@
 
 'use strict';
 
-var LinkedValueUtils = require('LinkedValueUtils');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var ReactUpdates = require('ReactUpdates');
+const LinkedValueUtils = require('LinkedValueUtils');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
+const ReactUpdates = require('ReactUpdates');
 
-var assign = require('Object.assign');
-var warning = require('warning');
+const assign = require('Object.assign');
+const warning = require('warning');
 
-var didWarnValueLink = false;
-var didWarnValueNull = false;
-var didWarnValueDefaultValue = false;
+let didWarnValueLink = false;
+let didWarnValueNull = false;
+let didWarnValueDefaultValue = false;
 
 function updateOptionsIfPendingUpdateAndMounted() {
   if (this._rootNodeID && this._wrapperState.pendingUpdate) {
     this._wrapperState.pendingUpdate = false;
 
-    var props = this._currentElement.props;
-    var value = LinkedValueUtils.getValue(props);
+    const props = this._currentElement.props;
+    const value = LinkedValueUtils.getValue(props);
 
     if (value != null) {
       updateOptions(this, Boolean(props.multiple), value);
@@ -37,7 +37,7 @@ function updateOptionsIfPendingUpdateAndMounted() {
 
 function getDeclarationErrorAddendum(owner) {
   if (owner) {
-    var name = owner.getName();
+    const name = owner.getName();
     if (name) {
       return ' Check the render method of `' + name + '`.';
     }
@@ -58,14 +58,14 @@ function warnIfValueIsNull(props) {
   }
 }
 
-var valuePropNames = ['value', 'defaultValue'];
+const valuePropNames = ['value', 'defaultValue'];
 
 /**
  * Validation function for `value` and `defaultValue`.
  * @private
  */
 function checkSelectPropTypes(inst, props) {
-  var owner = inst._currentElement._owner;
+  const owner = inst._currentElement._owner;
   LinkedValueUtils.checkPropTypes(
     'select',
     props,
@@ -80,8 +80,8 @@ function checkSelectPropTypes(inst, props) {
     didWarnValueLink = true;
   }
 
-  for (var i = 0; i < valuePropNames.length; i++) {
-    var propName = valuePropNames[i];
+  for (let i = 0; i < valuePropNames.length; i++) {
+    const propName = valuePropNames[i];
     if (props[propName] == null) {
       continue;
     }
@@ -112,8 +112,8 @@ function checkSelectPropTypes(inst, props) {
  * @private
  */
 function updateOptions(inst, multiple, propValue) {
-  var selectedValue, i;
-  var options = ReactDOMComponentTree.getNodeFromInstance(inst).options;
+  let selectedValue, i;
+  const options = ReactDOMComponentTree.getNodeFromInstance(inst).options;
 
   if (multiple) {
     selectedValue = {};
@@ -157,7 +157,7 @@ function updateOptions(inst, multiple, propValue) {
  * If `defaultValue` is provided, any options with the supplied values will be
  * selected.
  */
-var ReactDOMSelect = {
+const ReactDOMSelect = {
   getNativeProps: function(inst, props) {
     return assign({}, props, {
       onChange: inst._wrapperState.onChange,
@@ -171,7 +171,7 @@ var ReactDOMSelect = {
       warnIfValueIsNull(props);
     }
 
-    var value = LinkedValueUtils.getValue(props);
+    const value = LinkedValueUtils.getValue(props);
     inst._wrapperState = {
       pendingUpdate: false,
       initialValue: value != null ? value : props.defaultValue,
@@ -204,7 +204,7 @@ var ReactDOMSelect = {
   },
 
   postUpdateWrapper: function(inst) {
-    var props = inst._currentElement.props;
+    const props = inst._currentElement.props;
     if (__DEV__) {
       warnIfValueIsNull(props);
     }
@@ -213,10 +213,10 @@ var ReactDOMSelect = {
     // this value down
     inst._wrapperState.initialValue = undefined;
 
-    var wasMultiple = inst._wrapperState.wasMultiple;
+    const wasMultiple = inst._wrapperState.wasMultiple;
     inst._wrapperState.wasMultiple = Boolean(props.multiple);
 
-    var value = LinkedValueUtils.getValue(props);
+    const value = LinkedValueUtils.getValue(props);
     if (value != null) {
       inst._wrapperState.pendingUpdate = false;
       updateOptions(inst, Boolean(props.multiple), value);
@@ -233,8 +233,8 @@ var ReactDOMSelect = {
 };
 
 function _handleChange(event) {
-  var props = this._currentElement.props;
-  var returnValue = LinkedValueUtils.executeOnChange(props, event);
+  const props = this._currentElement.props;
+  const returnValue = LinkedValueUtils.executeOnChange(props, event);
 
   if (this._rootNodeID) {
     this._wrapperState.pendingUpdate = true;

--- a/src/renderers/dom/client/wrappers/ReactDOMTextarea.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMTextarea.js
@@ -11,18 +11,18 @@
 
 'use strict';
 
-var DOMPropertyOperations = require('DOMPropertyOperations');
-var LinkedValueUtils = require('LinkedValueUtils');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var ReactUpdates = require('ReactUpdates');
+const DOMPropertyOperations = require('DOMPropertyOperations');
+const LinkedValueUtils = require('LinkedValueUtils');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
+const ReactUpdates = require('ReactUpdates');
 
-var assign = require('Object.assign');
-var invariant = require('invariant');
-var warning = require('warning');
+const assign = require('Object.assign');
+const invariant = require('invariant');
+const warning = require('warning');
 
-var didWarnValueLink = false;
-var didWarnValueNull = false;
-var didWarnValDefaultVal = false;
+let didWarnValueLink = false;
+let didWarnValueNull = false;
+let didWarnValDefaultVal = false;
 
 function forceUpdateIfMounted() {
   if (this._rootNodeID) {
@@ -68,7 +68,7 @@ var ReactDOMTextarea = {
 
     // Always set children to the same thing. In IE9, the selection range will
     // get reset if `textContent` is mutated.
-    var nativeProps = assign({}, props, {
+    const nativeProps = assign({}, props, {
       defaultValue: undefined,
       value: undefined,
       children: inst._wrapperState.initialValue,
@@ -112,7 +112,7 @@ var ReactDOMTextarea = {
 
     var defaultValue = props.defaultValue;
     // TODO (yungsters): Remove support for children content in <textarea>.
-    var children = props.children;
+    let children = props.children;
     if (children != null) {
       if (__DEV__) {
         warning(
@@ -151,13 +151,13 @@ var ReactDOMTextarea = {
   },
 
   updateWrapper: function(inst) {
-    var props = inst._currentElement.props;
+    const props = inst._currentElement.props;
 
     if (__DEV__) {
       warnIfValueIsNull(props);
     }
 
-    var value = LinkedValueUtils.getValue(props);
+    const value = LinkedValueUtils.getValue(props);
     if (value != null) {
       // Cast `value` to a string to ensure the value is set correctly. While
       // browsers typically do this as necessary, jsdom doesn't.
@@ -171,8 +171,8 @@ var ReactDOMTextarea = {
 };
 
 function _handleChange(event) {
-  var props = this._currentElement.props;
-  var returnValue = LinkedValueUtils.executeOnChange(props, event);
+  const props = this._currentElement.props;
+  const returnValue = LinkedValueUtils.executeOnChange(props, event);
   ReactUpdates.asap(forceUpdateIfMounted, this);
   return returnValue;
 }

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMButton-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMButton-test.js
@@ -13,11 +13,11 @@
 
 
 describe('ReactDOMButton', function() {
-  var React;
-  var ReactDOM;
-  var ReactTestUtils;
+  let React;
+  let ReactDOM;
+  let ReactTestUtils;
 
-  var onClick = jest.genMockFn();
+  const onClick = jest.genMockFn();
 
   function expectClickThru(button) {
     onClick.mockClear();
@@ -53,8 +53,8 @@ describe('ReactDOMButton', function() {
   });
 
   it('should forward clicks when it becomes not disabled', function() {
-    var container = document.createElement('div');
-    var btn = ReactDOM.render(
+    const container = document.createElement('div');
+    let btn = ReactDOM.render(
       <button disabled={true} onClick={onClick} />,
       container
     );
@@ -66,8 +66,8 @@ describe('ReactDOMButton', function() {
   });
 
   it('should not forward clicks when it becomes disabled', function() {
-    var container = document.createElement('div');
-    var btn = ReactDOM.render(
+    const container = document.createElement('div');
+    let btn = ReactDOM.render(
       <button onClick={onClick} />,
       container
     );
@@ -79,8 +79,8 @@ describe('ReactDOMButton', function() {
   });
 
   it('should work correctly if the listener is changed', function() {
-    var container = document.createElement('div');
-    var btn = ReactDOM.render(
+    const container = document.createElement('div');
+    let btn = ReactDOM.render(
       <button disabled={true} onClick={function() {}} />,
       container
     );

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMIframe-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMIframe-test.js
@@ -12,9 +12,9 @@
 'use strict';
 
 describe('ReactDOMIframe', function() {
-  var React;
-  var ReactDOM;
-  var ReactTestUtils;
+  let React;
+  let ReactDOM;
+  let ReactTestUtils;
 
   beforeEach(function() {
     React = require('React');
@@ -23,11 +23,11 @@ describe('ReactDOMIframe', function() {
   });
 
   it('should trigger load events', function() {
-    var onLoadSpy = jasmine.createSpy();
-    var iframe = React.createElement('iframe', {onLoad: onLoadSpy});
+    const onLoadSpy = jasmine.createSpy();
+    let iframe = React.createElement('iframe', {onLoad: onLoadSpy});
     iframe = ReactTestUtils.renderIntoDocument(iframe);
 
-    var loadEvent = document.createEvent('Event');
+    const loadEvent = document.createEvent('Event');
     loadEvent.initEvent('load', false, false);
 
     ReactDOM.findDOMNode(iframe).dispatchEvent(loadEvent);

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
@@ -12,15 +12,15 @@
 'use strict';
 
 
-var emptyFunction = require('emptyFunction');
+const emptyFunction = require('emptyFunction');
 
 describe('ReactDOMInput', function() {
-  var EventConstants;
-  var React;
-  var ReactDOM;
-  var ReactDOMFeatureFlags;
-  var ReactLink;
-  var ReactTestUtils;
+  let EventConstants;
+  let React;
+  let ReactDOM;
+  let ReactDOMFeatureFlags;
+  let ReactLink;
+  let ReactTestUtils;
 
   beforeEach(function() {
     jest.resetModuleRegistry();
@@ -34,56 +34,56 @@ describe('ReactDOMInput', function() {
   });
 
   it('should display `defaultValue` of number 0', function() {
-    var stub = <input type="text" defaultValue={0} />;
+    let stub = <input type="text" defaultValue={0} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('0');
   });
 
   it('should display "true" for `defaultValue` of `true`', function() {
-    var stub = <input type="text" defaultValue={true} />;
+    let stub = <input type="text" defaultValue={true} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('true');
   });
 
   it('should display "false" for `defaultValue` of `false`', function() {
-    var stub = <input type="text" defaultValue={false} />;
+    let stub = <input type="text" defaultValue={false} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('false');
   });
 
   it('should display "foobar" for `defaultValue` of `objToString`', function() {
-    var objToString = {
+    const objToString = {
       toString: function() {
         return 'foobar';
       },
     };
 
-    var stub = <input type="text" defaultValue={objToString} />;
+    let stub = <input type="text" defaultValue={objToString} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('foobar');
   });
 
   it('should display `value` of number 0', function() {
-    var stub = <input type="text" value={0} />;
+    let stub = <input type="text" value={0} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('0');
   });
 
   it('should allow setting `value` to `true`', function() {
-    var container = document.createElement('div');
-    var stub = <input type="text" value="yolo" onChange={emptyFunction} />;
+    const container = document.createElement('div');
+    let stub = <input type="text" value="yolo" onChange={emptyFunction} />;
     stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('yolo');
 
@@ -95,10 +95,10 @@ describe('ReactDOMInput', function() {
   });
 
   it('should allow setting `value` to `false`', function() {
-    var container = document.createElement('div');
-    var stub = <input type="text" value="yolo" onChange={emptyFunction} />;
+    const container = document.createElement('div');
+    let stub = <input type="text" value="yolo" onChange={emptyFunction} />;
     stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('yolo');
 
@@ -110,14 +110,14 @@ describe('ReactDOMInput', function() {
   });
 
   it('should allow setting `value` to `objToString`', function() {
-    var container = document.createElement('div');
-    var stub = <input type="text" value="foo" onChange={emptyFunction} />;
+    const container = document.createElement('div');
+    let stub = <input type="text" value="foo" onChange={emptyFunction} />;
     stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('foo');
 
-    var objToString = {
+    const objToString = {
       toString: function() {
         return 'foobar';
       },
@@ -130,9 +130,9 @@ describe('ReactDOMInput', function() {
   });
 
   it('should properly control a value of number `0`', function() {
-    var stub = <input type="text" value={0} onChange={emptyFunction} />;
+    let stub = <input type="text" value={0} onChange={emptyFunction} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     node.value = 'giraffe';
     ReactTestUtils.Simulate.change(node);
@@ -140,18 +140,18 @@ describe('ReactDOMInput', function() {
   });
 
   it('should have the correct target value', function() {
-    var handled = false;
-    var handler = function(event) {
+    let handled = false;
+    const handler = function(event) {
       expect(event.target.nodeName).toBe('INPUT');
       handled = true;
     };
-    var stub = <input type="text" value={0} onChange={handler} />;
-    var container = document.createElement('div');
-    var node = ReactDOM.render(stub, container);
+    const stub = <input type="text" value={0} onChange={handler} />;
+    const container = document.createElement('div');
+    const node = ReactDOM.render(stub, container);
 
     node.value = 'giraffe';
 
-    var fakeNativeEvent = new function() {};
+    const fakeNativeEvent = new function() {};
     fakeNativeEvent.target = node;
     fakeNativeEvent.path = [node, container];
     ReactTestUtils.simulateNativeEventOnNode(
@@ -164,9 +164,9 @@ describe('ReactDOMInput', function() {
   });
 
   it('should not set a value for submit buttons unnecessarily', function() {
-    var stub = <input type="submit" />;
+    let stub = <input type="submit" />;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     // The value shouldn't be '', or else the button will have no text; it
     // should have the default "Submit" or "Submit Query" label. Most browsers
@@ -178,7 +178,7 @@ describe('ReactDOMInput', function() {
   });
 
   it('should control radio buttons', function() {
-    var RadioGroup = React.createClass({
+    const RadioGroup = React.createClass({
       render: function() {
         return (
           <div>
@@ -210,10 +210,10 @@ describe('ReactDOMInput', function() {
       },
     });
 
-    var stub = ReactTestUtils.renderIntoDocument(<RadioGroup />);
-    var aNode = ReactDOM.findDOMNode(stub.refs.a);
-    var bNode = ReactDOM.findDOMNode(stub.refs.b);
-    var cNode = ReactDOM.findDOMNode(stub.refs.c);
+    const stub = ReactTestUtils.renderIntoDocument(<RadioGroup />);
+    const aNode = ReactDOM.findDOMNode(stub.refs.a);
+    const bNode = ReactDOM.findDOMNode(stub.refs.b);
+    const cNode = ReactDOM.findDOMNode(stub.refs.c);
 
     expect(aNode.checked).toBe(true);
     expect(bNode.checked).toBe(false);
@@ -236,8 +236,8 @@ describe('ReactDOMInput', function() {
   });
 
   it('should support ReactLink', function() {
-    var link = new ReactLink('yolo', jest.genMockFn());
-    var instance = <input type="text" valueLink={link} />;
+    const link = new ReactLink('yolo', jest.genMockFn());
+    let instance = <input type="text" valueLink={link} />;
 
     instance = ReactTestUtils.renderIntoDocument(instance);
 
@@ -253,7 +253,7 @@ describe('ReactDOMInput', function() {
   });
 
   it('should warn with value and no onChange handler', function() {
-    var link = new ReactLink('yolo', jest.genMockFn());
+    const link = new ReactLink('yolo', jest.genMockFn());
     ReactTestUtils.renderIntoDocument(<input type="text" valueLink={link} />);
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toContain(
@@ -281,20 +281,20 @@ describe('ReactDOMInput', function() {
   });
 
   it('should have a this value of undefined if bind is not used', function() {
-    var unboundInputOnChange = function() {
+    const unboundInputOnChange = function() {
       expect(this).toBe(undefined);
     };
 
-    var instance = <input type="text" onChange={unboundInputOnChange} />;
+    let instance = <input type="text" onChange={unboundInputOnChange} />;
     instance = ReactTestUtils.renderIntoDocument(instance);
 
     ReactTestUtils.Simulate.change(instance);
   });
 
   it('should throw if both value and valueLink are provided', function() {
-    var node = document.createElement('div');
-    var link = new ReactLink('yolo', jest.genMockFn());
-    var instance = <input type="text" valueLink={link} />;
+    const node = document.createElement('div');
+    const link = new ReactLink('yolo', jest.genMockFn());
+    let instance = <input type="text" valueLink={link} />;
 
     expect(() => ReactDOM.render(instance, node)).not.toThrow();
 
@@ -313,8 +313,8 @@ describe('ReactDOMInput', function() {
   });
 
   it('should support checkedLink', function() {
-    var link = new ReactLink(true, jest.genMockFn());
-    var instance = <input type="checkbox" checkedLink={link} />;
+    const link = new ReactLink(true, jest.genMockFn());
+    let instance = <input type="checkbox" checkedLink={link} />;
 
     instance = ReactTestUtils.renderIntoDocument(instance);
 
@@ -330,8 +330,8 @@ describe('ReactDOMInput', function() {
   });
 
   it('should warn with checked and no onChange handler', function() {
-    var node = document.createElement('div');
-    var link = new ReactLink(true, jest.genMockFn());
+    const node = document.createElement('div');
+    const link = new ReactLink(true, jest.genMockFn());
     ReactDOM.render(<input type="checkbox" checkedLink={link} />, node);
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toContain(
@@ -369,9 +369,9 @@ describe('ReactDOMInput', function() {
   });
 
   it('should throw if both checked and checkedLink are provided', function() {
-    var node = document.createElement('div');
-    var link = new ReactLink(true, jest.genMockFn());
-    var instance = <input type="checkbox" checkedLink={link} />;
+    const node = document.createElement('div');
+    const link = new ReactLink(true, jest.genMockFn());
+    let instance = <input type="checkbox" checkedLink={link} />;
 
     expect(() => ReactDOM.render(instance, node)).not.toThrow();
 
@@ -391,9 +391,9 @@ describe('ReactDOMInput', function() {
   });
 
   it('should throw if both checkedLink and valueLink are provided', function() {
-    var node = document.createElement('div');
-    var link = new ReactLink(true, jest.genMockFn());
-    var instance = <input type="checkbox" checkedLink={link} />;
+    const node = document.createElement('div');
+    const link = new ReactLink(true, jest.genMockFn());
+    let instance = <input type="checkbox" checkedLink={link} />;
 
     expect(() => ReactDOM.render(instance, node)).not.toThrow();
 
@@ -454,8 +454,8 @@ describe('ReactDOMInput', function() {
   });
 
   it('should warn if controlled input switches to uncontrolled', function() {
-    var stub = <input type="text" value="controlled" onChange={emptyFunction} />;
-    var container = document.createElement('div');
+    const stub = <input type="text" value="controlled" onChange={emptyFunction} />;
+    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     ReactDOM.render(<input type="text" />, container);
     expect(console.error.argsForCall.length).toBe(1);
@@ -468,8 +468,8 @@ describe('ReactDOMInput', function() {
   });
 
   it('should warn if controlled input switches to uncontrolled with defaultValue', function() {
-    var stub = <input type="text" value="controlled" onChange={emptyFunction} />;
-    var container = document.createElement('div');
+    const stub = <input type="text" value="controlled" onChange={emptyFunction} />;
+    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     ReactDOM.render(<input type="text" defaultValue="uncontrolled" />, container);
     expect(console.error.argsForCall.length).toBe(1);
@@ -482,8 +482,8 @@ describe('ReactDOMInput', function() {
   });
 
   it('should warn if uncontrolled input switches to controlled', function() {
-    var stub = <input type="text" />;
-    var container = document.createElement('div');
+    const stub = <input type="text" />;
+    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     ReactDOM.render(<input type="text" value="controlled" />, container);
     expect(console.error.argsForCall.length).toBe(1);
@@ -496,8 +496,8 @@ describe('ReactDOMInput', function() {
   });
 
   it('should warn if controlled checkbox switches to uncontrolled', function() {
-    var stub = <input type="checkbox" checked={true} onChange={emptyFunction} />;
-    var container = document.createElement('div');
+    const stub = <input type="checkbox" checked={true} onChange={emptyFunction} />;
+    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     ReactDOM.render(<input type="checkbox" />, container);
     expect(console.error.argsForCall.length).toBe(1);
@@ -510,8 +510,8 @@ describe('ReactDOMInput', function() {
   });
 
   it('should warn if controlled checkbox switches to uncontrolled with defaultChecked', function() {
-    var stub = <input type="checkbox" checked={true} onChange={emptyFunction} />;
-    var container = document.createElement('div');
+    const stub = <input type="checkbox" checked={true} onChange={emptyFunction} />;
+    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     ReactDOM.render(<input type="checkbox" defaultChecked={true} />, container);
     expect(console.error.argsForCall.length).toBe(1);
@@ -524,8 +524,8 @@ describe('ReactDOMInput', function() {
   });
 
   it('should warn if uncontrolled checkbox switches to controlled', function() {
-    var stub = <input type="checkbox" />;
-    var container = document.createElement('div');
+    const stub = <input type="checkbox" />;
+    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     ReactDOM.render(<input type="checkbox" checked={true} />, container);
     expect(console.error.argsForCall.length).toBe(1);
@@ -538,8 +538,8 @@ describe('ReactDOMInput', function() {
   });
 
   it('should warn if controlled radio switches to uncontrolled', function() {
-    var stub = <input type="radio" checked={true} onChange={emptyFunction} />;
-    var container = document.createElement('div');
+    const stub = <input type="radio" checked={true} onChange={emptyFunction} />;
+    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     ReactDOM.render(<input type="radio" />, container);
     expect(console.error.argsForCall.length).toBe(1);
@@ -552,8 +552,8 @@ describe('ReactDOMInput', function() {
   });
 
   it('should warn if controlled radio switches to uncontrolled with defaultChecked', function() {
-    var stub = <input type="radio" checked={true} onChange={emptyFunction} />;
-    var container = document.createElement('div');
+    const stub = <input type="radio" checked={true} onChange={emptyFunction} />;
+    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     ReactDOM.render(<input type="radio" defaultChecked={true} />, container);
     expect(console.error.argsForCall.length).toBe(1);
@@ -566,8 +566,8 @@ describe('ReactDOMInput', function() {
   });
 
   it('should warn if uncontrolled radio switches to controlled', function() {
-    var stub = <input type="radio" />;
-    var container = document.createElement('div');
+    const stub = <input type="radio" />;
+    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     ReactDOM.render(<input type="radio" checked={true} />, container);
     expect(console.error.argsForCall.length).toBe(1);
@@ -583,10 +583,10 @@ describe('ReactDOMInput', function() {
     if (!ReactDOMFeatureFlags.useCreateElement) {
       return;
     }
-    var log = [];
-    var originalCreateElement = document.createElement;
+    const log = [];
+    const originalCreateElement = document.createElement;
     spyOn(document, 'createElement').andCallFake(function(type) {
-      var el = originalCreateElement.apply(this, arguments);
+      const el = originalCreateElement.apply(this, arguments);
       if (type === 'input') {
         Object.defineProperty(el, 'value', {
           get: function() {},
@@ -611,7 +611,7 @@ describe('ReactDOMInput', function() {
   });
 
   it('sets value properly with type coming later in props', function() {
-    var input = ReactTestUtils.renderIntoDocument(
+    const input = ReactTestUtils.renderIntoDocument(
       <input value="hi" type="radio" />
     );
     expect(input.value).toBe('hi');

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMOption-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMOption-test.js
@@ -13,9 +13,9 @@
 
 
 describe('ReactDOMOption', function() {
-  var React;
-  var ReactDOM;
-  var ReactTestUtils;
+  let React;
+  let ReactDOM;
+  let ReactTestUtils;
 
   beforeEach(function() {
     React = require('React');
@@ -24,18 +24,18 @@ describe('ReactDOMOption', function() {
   });
 
   it('should flatten children to a string', function() {
-    var stub = <option>{1} {'foo'}</option>;
+    let stub = <option>{1} {'foo'}</option>;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.innerHTML).toBe('1 foo');
   });
 
   it('should ignore invalid children types', function() {
     spyOn(console, 'error');
-    var stub = <option>{1} <div /> {2}</option>;
+    let stub = <option>{1} <div /> {2}</option>;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.innerHTML).toBe('1  2');
     expect(console.error.calls.length).toBe(1);
@@ -43,7 +43,7 @@ describe('ReactDOMOption', function() {
   });
 
   it('should warn when passing invalid children', function() {
-    var stub = <option>{1} <div /></option>;
+    let stub = <option>{1} <div /></option>;
     spyOn(console, 'error');
     stub = ReactTestUtils.renderIntoDocument(stub);
 
@@ -54,21 +54,21 @@ describe('ReactDOMOption', function() {
   });
 
   it('should ignore null/undefined/false children without warning', function() {
-    var stub = <option>{1} {false}{true}{null}{undefined} {2}</option>;
+    let stub = <option>{1} {false}{true}{null}{undefined} {2}</option>;
     spyOn(console, 'error');
     stub = ReactTestUtils.renderIntoDocument(stub);
 
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(console.error.calls.length).toBe(0);
     expect(node.innerHTML).toBe('1  2');
   });
 
   it('should be able to use dangerouslySetInnerHTML on option', function() {
-    var stub = <option dangerouslySetInnerHTML={{ __html: 'foobar' }} />;
+    let stub = <option dangerouslySetInnerHTML={{ __html: 'foobar' }} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
 
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
     expect(node.innerHTML).toBe('foobar');
   });
 });

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMSelect-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMSelect-test.js
@@ -13,13 +13,13 @@
 
 
 describe('ReactDOMSelect', function() {
-  var React;
-  var ReactDOM;
-  var ReactDOMServer;
-  var ReactLink;
-  var ReactTestUtils;
+  let React;
+  let ReactDOM;
+  let ReactDOMServer;
+  let ReactLink;
+  let ReactTestUtils;
 
-  var noop = function() {};
+  const noop = function() {};
 
   beforeEach(function() {
     React = require('React');
@@ -30,16 +30,16 @@ describe('ReactDOMSelect', function() {
   });
 
   it('should allow setting `defaultValue`', function() {
-    var stub =
+    let stub =
       <select defaultValue="giraffe">
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    var options = stub.props.children;
-    var container = document.createElement('div');
+    const options = stub.props.children;
+    const container = document.createElement('div');
     stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('giraffe');
 
@@ -52,7 +52,7 @@ describe('ReactDOMSelect', function() {
   });
 
   it('should not throw with `defaultValue` and without children', function() {
-    var stub = <select defaultValue="dummy"></select>;
+    const stub = <select defaultValue="dummy"></select>;
 
     expect(() => {
       ReactTestUtils.renderIntoDocument(stub);
@@ -60,15 +60,15 @@ describe('ReactDOMSelect', function() {
   });
 
   it('should not control when using `defaultValue`', function() {
-    var el =
+    const el =
       <select defaultValue="giraffe">
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    var container = document.createElement('div');
-    var stub = ReactDOM.render(el, container);
-    var node = ReactDOM.findDOMNode(stub);
+    const container = document.createElement('div');
+    const stub = ReactDOM.render(el, container);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('giraffe');
 
@@ -79,16 +79,16 @@ describe('ReactDOMSelect', function() {
   });
 
   it('should allow setting `defaultValue` with multiple', function() {
-    var stub =
+    let stub =
       <select multiple={true} defaultValue={['giraffe', 'gorilla']}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    var options = stub.props.children;
-    var container = document.createElement('div');
+    const options = stub.props.children;
+    const container = document.createElement('div');
     stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -106,16 +106,16 @@ describe('ReactDOMSelect', function() {
   });
 
   it('should allow setting `value`', function() {
-    var stub =
+    let stub =
       <select value="giraffe" onChange={noop}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    var options = stub.props.children;
-    var container = document.createElement('div');
+    const options = stub.props.children;
+    const container = document.createElement('div');
     stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('giraffe');
 
@@ -128,7 +128,7 @@ describe('ReactDOMSelect', function() {
   });
 
   it('should not throw with `value` and without children', function() {
-    var stub = <select value="dummy" onChange={noop}></select>;
+    const stub = <select value="dummy" onChange={noop}></select>;
 
     expect(() => {
       ReactTestUtils.renderIntoDocument(stub);
@@ -136,16 +136,16 @@ describe('ReactDOMSelect', function() {
   });
 
   it('should allow setting `value` with multiple', function() {
-    var stub =
+    let stub =
       <select multiple={true} value={['giraffe', 'gorilla']} onChange={noop}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    var options = stub.props.children;
-    var container = document.createElement('div');
+    const options = stub.props.children;
+    const container = document.createElement('div');
     stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -165,14 +165,14 @@ describe('ReactDOMSelect', function() {
   });
 
   it('should not select other options automatically', function() {
-    var stub =
+    let stub =
       <select multiple={true} value={['12']} onChange={noop}>
         <option value="1">one</option>
         <option value="2">two</option>
         <option value="12">twelve</option>
       </select>;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.options[0].selected).toBe(false);  // one
     expect(node.options[1].selected).toBe(false);  // two
@@ -180,8 +180,8 @@ describe('ReactDOMSelect', function() {
   });
 
   it('should reset child options selected when they are changed and `value` is set', function() {
-    var stub = <select multiple={true} value={['a', 'b']} onChange={noop} />;
-    var container = document.createElement('div');
+    let stub = <select multiple={true} value={['a', 'b']} onChange={noop} />;
+    const container = document.createElement('div');
     stub = ReactDOM.render(stub, container);
 
     ReactDOM.render(
@@ -193,7 +193,7 @@ describe('ReactDOMSelect', function() {
       container
     );
 
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.options[0].selected).toBe(true);  // a
     expect(node.options[1].selected).toBe(true);  // b
@@ -201,22 +201,22 @@ describe('ReactDOMSelect', function() {
   });
 
   it('should allow setting `value` with `objectToString`', function() {
-    var objectToString = {
+    const objectToString = {
       animal: 'giraffe',
       toString: function() {
         return this.animal;
       },
     };
 
-    var el =
+    const el =
       <select multiple={true} value={[objectToString]} onChange={noop}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    var container = document.createElement('div');
-    var stub = ReactDOM.render(el, container);
-    var node = ReactDOM.findDOMNode(stub);
+    const container = document.createElement('div');
+    const stub = ReactDOM.render(el, container);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -225,7 +225,7 @@ describe('ReactDOMSelect', function() {
     // Changing the `value` prop should change the selected options.
     objectToString.animal = 'monkey';
 
-    var el2 =
+    const el2 =
       <select multiple={true} value={[objectToString]}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
@@ -239,16 +239,16 @@ describe('ReactDOMSelect', function() {
   });
 
   it('should allow switching to multiple', function() {
-    var stub =
+    let stub =
       <select defaultValue="giraffe">
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    var options = stub.props.children;
-    var container = document.createElement('div');
+    const options = stub.props.children;
+    const container = document.createElement('div');
     stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -268,16 +268,16 @@ describe('ReactDOMSelect', function() {
   });
 
   it('should allow switching from multiple', function() {
-    var stub =
+    let stub =
       <select multiple={true} defaultValue={['giraffe', 'gorilla']}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    var options = stub.props.children;
-    var container = document.createElement('div');
+    const options = stub.props.children;
+    const container = document.createElement('div');
     stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -297,16 +297,16 @@ describe('ReactDOMSelect', function() {
   });
 
   it('should remember value when switching to uncontrolled', function() {
-    var stub =
+    let stub =
       <select value={'giraffe'} onChange={noop}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    var options = stub.props.children;
-    var container = document.createElement('div');
+    const options = stub.props.children;
+    const container = document.createElement('div');
     stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -320,16 +320,16 @@ describe('ReactDOMSelect', function() {
   });
 
   it('should remember updated value when switching to uncontrolled', function() {
-    var stub =
+    let stub =
       <select value={'giraffe'} onChange={noop}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    var options = stub.props.children;
-    var container = document.createElement('div');
+    const options = stub.props.children;
+    const container = document.createElement('div');
     stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     ReactDOM.render(
       <select value="gorilla" onChange={noop}>{options}</select>,
@@ -348,8 +348,8 @@ describe('ReactDOMSelect', function() {
   });
 
   it('should support ReactLink', function() {
-    var link = new ReactLink('giraffe', jest.genMockFn());
-    var stub =
+    const link = new ReactLink('giraffe', jest.genMockFn());
+    let stub =
       <select valueLink={link}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
@@ -365,7 +365,7 @@ describe('ReactDOMSelect', function() {
       '`valueLink` prop on `select` is deprecated; set `value` and `onChange` instead.'
     );
 
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -382,48 +382,48 @@ describe('ReactDOMSelect', function() {
   });
 
   it('should support server-side rendering', function() {
-    var stub =
+    const stub =
       <select value="giraffe" onChange={noop}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    var markup = ReactDOMServer.renderToString(stub);
+    const markup = ReactDOMServer.renderToString(stub);
     expect(markup).toContain('<option selected="" value="giraffe"');
     expect(markup).not.toContain('<option selected="" value="monkey"');
     expect(markup).not.toContain('<option selected="" value="gorilla"');
   });
 
   it('should support server-side rendering with defaultValue', function() {
-    var stub =
+    const stub =
       <select defaultValue="giraffe">
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    var markup = ReactDOMServer.renderToString(stub);
+    const markup = ReactDOMServer.renderToString(stub);
     expect(markup).toContain('<option selected="" value="giraffe"');
     expect(markup).not.toContain('<option selected="" value="monkey"');
     expect(markup).not.toContain('<option selected="" value="gorilla"');
   });
 
   it('should support server-side rendering with multiple', function() {
-    var stub =
+    const stub =
       <select multiple={true} value={['giraffe', 'gorilla']} onChange={noop}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
-    var markup = ReactDOMServer.renderToString(stub);
+    const markup = ReactDOMServer.renderToString(stub);
     expect(markup).toContain('<option selected="" value="giraffe"');
     expect(markup).toContain('<option selected="" value="gorilla"');
     expect(markup).not.toContain('<option selected="" value="monkey"');
   });
 
   it('should not control defaultValue if readding options', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
 
-    var select = ReactDOM.render(
+    const select = ReactDOM.render(
       <select multiple={true} defaultValue={['giraffe']}>
         <option key="monkey" value="monkey">A monkey!</option>
         <option key="giraffe" value="giraffe">A giraffe!</option>
@@ -431,7 +431,7 @@ describe('ReactDOMSelect', function() {
       </select>,
       container
     );
-    var node = ReactDOM.findDOMNode(select);
+    const node = ReactDOM.findDOMNode(select);
 
     expect(node.options[0].selected).toBe(false);  // monkey
     expect(node.options[1].selected).toBe(true);  // giraffe
@@ -477,14 +477,14 @@ describe('ReactDOMSelect', function() {
   });
 
   it('should refresh state on change', function() {
-    var stub =
+    let stub =
       <select value="giraffe" onChange={noop}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
     stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     ReactTestUtils.Simulate.change(node);
 
@@ -524,14 +524,14 @@ describe('ReactDOMSelect', function() {
     }
 
     var container = document.createElement('div');
-    var stub =
+    let stub =
       <select value="giraffe" onChange={changeView}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
         <option value="gorilla">A gorilla!</option>
       </select>;
     stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(() => ReactTestUtils.Simulate.change(node)).not.toThrow(
       "Cannot set property 'pendingUpdate' of null"

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMTextarea-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMTextarea-test.js
@@ -11,15 +11,15 @@
 
 'use strict';
 
-var emptyFunction = require('emptyFunction');
+const emptyFunction = require('emptyFunction');
 
 describe('ReactDOMTextarea', function() {
-  var React;
-  var ReactDOM;
-  var ReactLink;
-  var ReactTestUtils;
+  let React;
+  let ReactDOM;
+  let ReactLink;
+  let ReactTestUtils;
 
-  var renderTextarea;
+  let renderTextarea;
 
   beforeEach(function() {
     React = require('React');
@@ -31,8 +31,8 @@ describe('ReactDOMTextarea', function() {
       if (!container) {
         container = document.createElement('div');
       }
-      var stub = ReactDOM.render(component, container);
-      var node = ReactDOM.findDOMNode(stub);
+      const stub = ReactDOM.render(component, container);
+      const node = ReactDOM.findDOMNode(stub);
       // Fixing jsdom's quirky behavior -- in reality, the parser should strip
       // off the leading newline but we need to do it by hand here.
       node.value = node.innerHTML.replace(/^\n/, '');
@@ -41,9 +41,9 @@ describe('ReactDOMTextarea', function() {
   });
 
   it('should allow setting `defaultValue`', function() {
-    var container = document.createElement('div');
-    var stub = renderTextarea(<textarea defaultValue="giraffe" />, container);
-    var node = ReactDOM.findDOMNode(stub);
+    const container = document.createElement('div');
+    let stub = renderTextarea(<textarea defaultValue="giraffe" />, container);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('giraffe');
 
@@ -53,56 +53,56 @@ describe('ReactDOMTextarea', function() {
   });
 
   it('should display `defaultValue` of number 0', function() {
-    var stub = <textarea defaultValue={0} />;
+    let stub = <textarea defaultValue={0} />;
     stub = renderTextarea(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('0');
   });
 
   it('should display "false" for `defaultValue` of `false`', function() {
-    var stub = <textarea defaultValue={false} />;
+    let stub = <textarea defaultValue={false} />;
     stub = renderTextarea(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('false');
   });
 
   it('should display "foobar" for `defaultValue` of `objToString`', function() {
-    var objToString = {
+    const objToString = {
       toString: function() {
         return 'foobar';
       },
     };
 
-    var stub = <textarea defaultValue={objToString} />;
+    let stub = <textarea defaultValue={objToString} />;
     stub = renderTextarea(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('foobar');
   });
 
   it('should not render value as an attribute', function() {
-    var stub = <textarea value="giraffe" onChange={emptyFunction} />;
+    let stub = <textarea value="giraffe" onChange={emptyFunction} />;
     stub = renderTextarea(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.getAttribute('value')).toBe(null);
   });
 
   it('should display `value` of number 0', function() {
-    var stub = <textarea value={0} />;
+    let stub = <textarea value={0} />;
     stub = renderTextarea(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('0');
   });
 
   it('should allow setting `value` to `giraffe`', function() {
-    var container = document.createElement('div');
-    var stub = <textarea value="giraffe" onChange={emptyFunction} />;
+    const container = document.createElement('div');
+    let stub = <textarea value="giraffe" onChange={emptyFunction} />;
     stub = renderTextarea(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('giraffe');
 
@@ -114,10 +114,10 @@ describe('ReactDOMTextarea', function() {
   });
 
   it('should allow setting `value` to `true`', function() {
-    var container = document.createElement('div');
-    var stub = <textarea value="giraffe" onChange={emptyFunction} />;
+    const container = document.createElement('div');
+    let stub = <textarea value="giraffe" onChange={emptyFunction} />;
     stub = renderTextarea(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('giraffe');
 
@@ -129,10 +129,10 @@ describe('ReactDOMTextarea', function() {
   });
 
   it('should allow setting `value` to `false`', function() {
-    var container = document.createElement('div');
-    var stub = <textarea value="giraffe" onChange={emptyFunction} />;
+    const container = document.createElement('div');
+    let stub = <textarea value="giraffe" onChange={emptyFunction} />;
     stub = renderTextarea(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('giraffe');
 
@@ -144,14 +144,14 @@ describe('ReactDOMTextarea', function() {
   });
 
   it('should allow setting `value` to `objToString`', function() {
-    var container = document.createElement('div');
-    var stub = <textarea value="giraffe" onChange={emptyFunction} />;
+    const container = document.createElement('div');
+    let stub = <textarea value="giraffe" onChange={emptyFunction} />;
     stub = renderTextarea(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(node.value).toBe('giraffe');
 
-    var objToString = {
+    const objToString = {
       toString: function() {
         return 'foo';
       },
@@ -164,9 +164,9 @@ describe('ReactDOMTextarea', function() {
   });
 
   it('should properly control a value of number `0`', function() {
-    var stub = <textarea value={0} onChange={emptyFunction} />;
+    let stub = <textarea value={0} onChange={emptyFunction} />;
     stub = renderTextarea(stub);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     node.value = 'giraffe';
     ReactTestUtils.Simulate.change(node);
@@ -176,10 +176,10 @@ describe('ReactDOMTextarea', function() {
   it('should treat children like `defaultValue`', function() {
     spyOn(console, 'error');
 
-    var container = document.createElement('div');
-    var stub = <textarea>giraffe</textarea>;
+    const container = document.createElement('div');
+    let stub = <textarea>giraffe</textarea>;
     stub = renderTextarea(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
 
     expect(console.error.argsForCall.length).toBe(1);
     expect(node.value).toBe('giraffe');
@@ -191,26 +191,26 @@ describe('ReactDOMTextarea', function() {
 
   it('should allow numbers as children', function() {
     spyOn(console, 'error');
-    var node = ReactDOM.findDOMNode(renderTextarea(<textarea>{17}</textarea>));
+    const node = ReactDOM.findDOMNode(renderTextarea(<textarea>{17}</textarea>));
     expect(console.error.argsForCall.length).toBe(1);
     expect(node.value).toBe('17');
   });
 
   it('should allow booleans as children', function() {
     spyOn(console, 'error');
-    var node = ReactDOM.findDOMNode(renderTextarea(<textarea>{false}</textarea>));
+    const node = ReactDOM.findDOMNode(renderTextarea(<textarea>{false}</textarea>));
     expect(console.error.argsForCall.length).toBe(1);
     expect(node.value).toBe('false');
   });
 
   it('should allow objects as children', function() {
     spyOn(console, 'error');
-    var obj = {
+    const obj = {
       toString: function() {
         return 'sharkswithlasers';
       },
     };
-    var node = ReactDOM.findDOMNode(renderTextarea(<textarea>{obj}</textarea>));
+    const node = ReactDOM.findDOMNode(renderTextarea(<textarea>{obj}</textarea>));
     expect(console.error.argsForCall.length).toBe(1);
     expect(node.value).toBe('sharkswithlasers');
   });
@@ -226,7 +226,7 @@ describe('ReactDOMTextarea', function() {
 
     expect(console.error.argsForCall.length).toBe(1);
 
-    var node;
+    let node;
     expect(function() {
       node = ReactDOM.findDOMNode(renderTextarea(<textarea><strong /></textarea>));
     }).not.toThrow();
@@ -237,8 +237,8 @@ describe('ReactDOMTextarea', function() {
   });
 
   it('should support ReactLink', function() {
-    var link = new ReactLink('yolo', jest.genMockFn());
-    var instance = <textarea valueLink={link} />;
+    const link = new ReactLink('yolo', jest.genMockFn());
+    let instance = <textarea valueLink={link} />;
 
     spyOn(console, 'error');
     instance = renderTextarea(instance);
@@ -260,7 +260,7 @@ describe('ReactDOMTextarea', function() {
   });
 
   it('should unmount', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     renderTextarea(<textarea />, container);
     ReactDOM.unmountComponentAtNode(container);
   });

--- a/src/renderers/dom/server/ReactMarkupChecksum.js
+++ b/src/renderers/dom/server/ReactMarkupChecksum.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-var adler32 = require('adler32');
+const adler32 = require('adler32');
 
-var TAG_END = /\/?>/;
+const TAG_END = /\/?>/;
 
-var ReactMarkupChecksum = {
+const ReactMarkupChecksum = {
   CHECKSUM_ATTR_NAME: 'data-react-checksum',
 
   /**
@@ -23,7 +23,7 @@ var ReactMarkupChecksum = {
    * @return {string} Markup string with checksum attribute attached
    */
   addChecksumToMarkup: function(markup) {
-    var checksum = adler32(markup);
+    const checksum = adler32(markup);
 
     // Add checksum (handle both parent tags and self-closing tags)
     return markup.replace(
@@ -38,11 +38,11 @@ var ReactMarkupChecksum = {
    * @returns {boolean} whether or not the markup is the same
    */
   canReuseMarkup: function(markup, element) {
-    var existingChecksum = element.getAttribute(
+    let existingChecksum = element.getAttribute(
       ReactMarkupChecksum.CHECKSUM_ATTR_NAME
     );
     existingChecksum = existingChecksum && parseInt(existingChecksum, 10);
-    var markupChecksum = adler32(markup);
+    const markupChecksum = adler32(markup);
     return markupChecksum === existingChecksum;
   },
 };

--- a/src/renderers/dom/server/ReactServerBatchingStrategy.js
+++ b/src/renderers/dom/server/ReactServerBatchingStrategy.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var ReactServerBatchingStrategy = {
+const ReactServerBatchingStrategy = {
   isBatchingUpdates: false,
   batchedUpdates: function(callback) {
     // Don't do anything here. During the server rendering we don't want to

--- a/src/renderers/dom/server/ReactServerRendering.js
+++ b/src/renderers/dom/server/ReactServerRendering.js
@@ -10,18 +10,18 @@
  */
 'use strict';
 
-var ReactDOMContainerInfo = require('ReactDOMContainerInfo');
-var ReactDefaultBatchingStrategy = require('ReactDefaultBatchingStrategy');
-var ReactElement = require('ReactElement');
-var ReactMarkupChecksum = require('ReactMarkupChecksum');
-var ReactServerBatchingStrategy = require('ReactServerBatchingStrategy');
-var ReactServerRenderingTransaction =
+const ReactDOMContainerInfo = require('ReactDOMContainerInfo');
+const ReactDefaultBatchingStrategy = require('ReactDefaultBatchingStrategy');
+const ReactElement = require('ReactElement');
+const ReactMarkupChecksum = require('ReactMarkupChecksum');
+const ReactServerBatchingStrategy = require('ReactServerBatchingStrategy');
+const ReactServerRenderingTransaction =
   require('ReactServerRenderingTransaction');
-var ReactUpdates = require('ReactUpdates');
+const ReactUpdates = require('ReactUpdates');
 
-var emptyObject = require('emptyObject');
-var instantiateReactComponent = require('instantiateReactComponent');
-var invariant = require('invariant');
+const emptyObject = require('emptyObject');
+const instantiateReactComponent = require('instantiateReactComponent');
+const invariant = require('invariant');
 
 /**
  * @param {ReactElement} element
@@ -33,15 +33,15 @@ function renderToStringImpl(element, makeStaticMarkup) {
     'renderToString(): You must pass a valid ReactElement.'
   );
 
-  var transaction;
+  let transaction;
   try {
     ReactUpdates.injection.injectBatchingStrategy(ReactServerBatchingStrategy);
 
     transaction = ReactServerRenderingTransaction.getPooled(makeStaticMarkup);
 
     return transaction.perform(function() {
-      var componentInstance = instantiateReactComponent(element);
-      var markup = componentInstance.mountComponent(
+      const componentInstance = instantiateReactComponent(element);
+      let markup = componentInstance.mountComponent(
         transaction,
         null,
         ReactDOMContainerInfo(),

--- a/src/renderers/dom/server/ReactServerRenderingTransaction.js
+++ b/src/renderers/dom/server/ReactServerRenderingTransaction.js
@@ -11,19 +11,19 @@
 
 'use strict';
 
-var PooledClass = require('PooledClass');
-var Transaction = require('Transaction');
+const PooledClass = require('PooledClass');
+const Transaction = require('Transaction');
 
-var assign = require('Object.assign');
+const assign = require('Object.assign');
 
 /**
  * Executed within the scope of the `Transaction` instance. Consider these as
  * being member methods, but with an implied ordering while being isolated from
  * each other.
  */
-var TRANSACTION_WRAPPERS = [];
+const TRANSACTION_WRAPPERS = [];
 
-var noopCallbackQueue = {
+const noopCallbackQueue = {
   enqueue: function() {},
 };
 
@@ -37,7 +37,7 @@ function ReactServerRenderingTransaction(renderToStaticMarkup) {
   this.useCreateElement = false;
 }
 
-var Mixin = {
+const Mixin = {
   /**
    * @see Transaction
    * @abstract

--- a/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
@@ -11,16 +11,16 @@
 
 'use strict';
 
-var ExecutionEnvironment;
-var React;
-var ReactDOM;
-var ReactMarkupChecksum;
-var ReactReconcileTransaction;
-var ReactTestUtils;
-var ReactServerRendering;
+let ExecutionEnvironment;
+let React;
+let ReactDOM;
+let ReactMarkupChecksum;
+let ReactReconcileTransaction;
+let ReactTestUtils;
+let ReactServerRendering;
 
-var ID_ATTRIBUTE_NAME;
-var ROOT_ATTRIBUTE_NAME;
+let ID_ATTRIBUTE_NAME;
+let ROOT_ATTRIBUTE_NAME;
 
 describe('ReactServerRendering', function() {
   beforeEach(function() {
@@ -35,14 +35,14 @@ describe('ReactServerRendering', function() {
     ExecutionEnvironment.canUseDOM = false;
     ReactServerRendering = require('ReactServerRendering');
 
-    var DOMProperty = require('DOMProperty');
+    const DOMProperty = require('DOMProperty');
     ID_ATTRIBUTE_NAME = DOMProperty.ID_ATTRIBUTE_NAME;
     ROOT_ATTRIBUTE_NAME = DOMProperty.ROOT_ATTRIBUTE_NAME;
   });
 
   describe('renderToString', function() {
     it('should generate simple markup', function() {
-      var response = ReactServerRendering.renderToString(
+      const response = ReactServerRendering.renderToString(
         <span>hello world</span>
       );
       expect(response).toMatch(
@@ -53,7 +53,7 @@ describe('ReactServerRendering', function() {
     });
 
     it('should generate simple markup for self-closing tags', function() {
-      var response = ReactServerRendering.renderToString(
+      const response = ReactServerRendering.renderToString(
         <img />
       );
       expect(response).toMatch(
@@ -64,7 +64,7 @@ describe('ReactServerRendering', function() {
     });
 
     it('should generate simple markup for attribute with `>` symbol', function() {
-      var response = ReactServerRendering.renderToString(
+      const response = ReactServerRendering.renderToString(
         <img data-attr=">" />
       );
       expect(response).toMatch(
@@ -75,8 +75,8 @@ describe('ReactServerRendering', function() {
     });
 
     it('should not register event listeners', function() {
-      var EventPluginHub = require('EventPluginHub');
-      var cb = jest.genMockFn();
+      const EventPluginHub = require('EventPluginHub');
+      const cb = jest.genMockFn();
 
       ReactServerRendering.renderToString(
         <span onClick={cb}>hello world</span>
@@ -85,17 +85,17 @@ describe('ReactServerRendering', function() {
     });
 
     it('should render composite components', function() {
-      var Parent = React.createClass({
+      const Parent = React.createClass({
         render: function() {
           return <div><Child name="child" /></div>;
         },
       });
-      var Child = React.createClass({
+      const Child = React.createClass({
         render: function() {
           return <span>My name is {this.props.name}</span>;
         },
       });
-      var response = ReactServerRendering.renderToString(
+      const response = ReactServerRendering.renderToString(
         <Parent />
       );
       expect(response).toMatch(
@@ -112,8 +112,8 @@ describe('ReactServerRendering', function() {
 
     it('should only execute certain lifecycle methods', function() {
       function runTest() {
-        var lifecycle = [];
-        var TestComponent = React.createClass({
+        const lifecycle = [];
+        const TestComponent = React.createClass({
           componentWillMount: function() {
             lifecycle.push('componentWillMount');
           },
@@ -145,7 +145,7 @@ describe('ReactServerRendering', function() {
           },
         });
 
-        var response = ReactServerRendering.renderToString(
+        const response = ReactServerRendering.renderToString(
           <TestComponent />
         );
 
@@ -173,10 +173,10 @@ describe('ReactServerRendering', function() {
       // This test is testing client-side behavior.
       ExecutionEnvironment.canUseDOM = true;
 
-      var mountCount = 0;
-      var numClicks = 0;
+      let mountCount = 0;
+      let numClicks = 0;
 
-      var TestComponent = React.createClass({
+      const TestComponent = React.createClass({
         componentDidMount: function() {
           mountCount++;
         },
@@ -190,10 +190,10 @@ describe('ReactServerRendering', function() {
         },
       });
 
-      var element = document.createElement('div');
+      const element = document.createElement('div');
       ReactDOM.render(<TestComponent />, element);
 
-      var lastMarkup = element.innerHTML;
+      let lastMarkup = element.innerHTML;
 
       // Exercise the update path. Markup should not change,
       // but some lifecycle methods should be run again.
@@ -232,7 +232,7 @@ describe('ReactServerRendering', function() {
       // warn but do the right thing.
       element.innerHTML = lastMarkup;
       spyOn(console, 'error');
-      var instance = ReactDOM.render(<TestComponent name="y" />, element);
+      const instance = ReactDOM.render(<TestComponent name="y" />, element);
       expect(mountCount).toEqual(4);
       expect(console.error.argsForCall.length).toBe(1);
       expect(element.innerHTML.length > 0).toBe(true);
@@ -258,19 +258,19 @@ describe('ReactServerRendering', function() {
 
   describe('renderToStaticMarkup', function() {
     it('should not put checksum and React ID on components', function() {
-      var NestedComponent = React.createClass({
+      const NestedComponent = React.createClass({
         render: function() {
           return <div>inner text</div>;
         },
       });
 
-      var TestComponent = React.createClass({
+      const TestComponent = React.createClass({
         render: function() {
           return <span><NestedComponent /></span>;
         },
       });
 
-      var response = ReactServerRendering.renderToStaticMarkup(
+      const response = ReactServerRendering.renderToStaticMarkup(
         <TestComponent />
       );
 
@@ -278,13 +278,13 @@ describe('ReactServerRendering', function() {
     });
 
     it('should not put checksum and React ID on text components', function() {
-      var TestComponent = React.createClass({
+      const TestComponent = React.createClass({
         render: function() {
           return <span>{'hello'} {'world'}</span>;
         },
       });
 
-      var response = ReactServerRendering.renderToStaticMarkup(
+      const response = ReactServerRendering.renderToStaticMarkup(
         <TestComponent />
       );
 
@@ -292,8 +292,8 @@ describe('ReactServerRendering', function() {
     });
 
     it('should not register event listeners', function() {
-      var EventPluginHub = require('EventPluginHub');
-      var cb = jest.genMockFn();
+      const EventPluginHub = require('EventPluginHub');
+      const cb = jest.genMockFn();
 
       ReactServerRendering.renderToString(
         <span onClick={cb}>hello world</span>
@@ -303,8 +303,8 @@ describe('ReactServerRendering', function() {
 
     it('should only execute certain lifecycle methods', function() {
       function runTest() {
-        var lifecycle = [];
-        var TestComponent = React.createClass({
+        const lifecycle = [];
+        const TestComponent = React.createClass({
           componentWillMount: function() {
             lifecycle.push('componentWillMount');
           },
@@ -336,7 +336,7 @@ describe('ReactServerRendering', function() {
           },
         });
 
-        var response = ReactServerRendering.renderToStaticMarkup(
+        const response = ReactServerRendering.renderToStaticMarkup(
           <TestComponent />
         );
 
@@ -365,7 +365,7 @@ describe('ReactServerRendering', function() {
     });
 
     it('allows setState in componentWillMount without using DOM', function() {
-      var Component = React.createClass({
+      const Component = React.createClass({
         componentWillMount: function() {
           this.setState({text: 'hello, world'});
         },
@@ -378,7 +378,7 @@ describe('ReactServerRendering', function() {
         // We shouldn't ever be calling this on the server
         throw new Error('Browser reconcile transaction should not be used');
       };
-      var markup = ReactServerRendering.renderToString(
+      const markup = ReactServerRendering.renderToString(
         <Component />
       );
       expect(markup.indexOf('hello, world') >= 0).toBe(true);

--- a/src/renderers/dom/shared/CSSProperty.js
+++ b/src/renderers/dom/shared/CSSProperty.js
@@ -14,7 +14,7 @@
 /**
  * CSS properties which accept numbers but are not in units of "px".
  */
-var isUnitlessNumber = {
+const isUnitlessNumber = {
   animationIterationCount: true,
   boxFlex: true,
   boxFlexGroup: true,
@@ -61,7 +61,7 @@ function prefixKey(prefix, key) {
  * Support style names that may come passed in prefixed by adding permutations
  * of vendor prefixes.
  */
-var prefixes = ['Webkit', 'ms', 'Moz', 'O'];
+const prefixes = ['Webkit', 'ms', 'Moz', 'O'];
 
 // Using Object.keys here, or else the vanilla for-in loop makes IE8 go into an
 // infinite loop, because it iterates over the newly added props too.
@@ -80,7 +80,7 @@ Object.keys(isUnitlessNumber).forEach(function(prop) {
  * behave without any problems. Curiously, list-style works too without any
  * special prodding.
  */
-var shorthandPropertyExpansions = {
+const shorthandPropertyExpansions = {
   background: {
     backgroundAttachment: true,
     backgroundColor: true,
@@ -133,7 +133,7 @@ var shorthandPropertyExpansions = {
   },
 };
 
-var CSSProperty = {
+const CSSProperty = {
   isUnitlessNumber: isUnitlessNumber,
   shorthandPropertyExpansions: shorthandPropertyExpansions,
 };

--- a/src/renderers/dom/shared/CSSPropertyOperations.js
+++ b/src/renderers/dom/shared/CSSPropertyOperations.js
@@ -11,24 +11,24 @@
 
 'use strict';
 
-var CSSProperty = require('CSSProperty');
-var ExecutionEnvironment = require('ExecutionEnvironment');
-var ReactPerf = require('ReactPerf');
+const CSSProperty = require('CSSProperty');
+const ExecutionEnvironment = require('ExecutionEnvironment');
+const ReactPerf = require('ReactPerf');
 
-var camelizeStyleName = require('camelizeStyleName');
-var dangerousStyleValue = require('dangerousStyleValue');
-var hyphenateStyleName = require('hyphenateStyleName');
-var memoizeStringOnly = require('memoizeStringOnly');
-var warning = require('warning');
+const camelizeStyleName = require('camelizeStyleName');
+const dangerousStyleValue = require('dangerousStyleValue');
+const hyphenateStyleName = require('hyphenateStyleName');
+const memoizeStringOnly = require('memoizeStringOnly');
+const warning = require('warning');
 
-var processStyleName = memoizeStringOnly(function(styleName) {
+const processStyleName = memoizeStringOnly(function(styleName) {
   return hyphenateStyleName(styleName);
 });
 
-var hasShorthandPropertyBug = false;
-var styleFloatAccessor = 'cssFloat';
+let hasShorthandPropertyBug = false;
+let styleFloatAccessor = 'cssFloat';
 if (ExecutionEnvironment.canUseDOM) {
-  var tempStyle = document.createElement('div').style;
+  const tempStyle = document.createElement('div').style;
   try {
     // IE8 throws "Invalid argument." if resetting shorthand style properties.
     tempStyle.font = '';
@@ -43,16 +43,16 @@ if (ExecutionEnvironment.canUseDOM) {
 
 if (__DEV__) {
   // 'msTransform' is correct, but the other prefixes should be capitalized
-  var badVendoredStyleNamePattern = /^(?:webkit|moz|o)[A-Z]/;
+  const badVendoredStyleNamePattern = /^(?:webkit|moz|o)[A-Z]/;
 
   // style values shouldn't contain a semicolon
-  var badStyleValueWithSemicolonPattern = /;\s*$/;
+  const badStyleValueWithSemicolonPattern = /;\s*$/;
 
-  var warnedStyleNames = {};
-  var warnedStyleValues = {};
-  var warnedForNaNValue = false;
+  const warnedStyleNames = {};
+  const warnedStyleValues = {};
+  let warnedForNaNValue = false;
 
-  var warnHyphenatedStyleName = function(name) {
+  const warnHyphenatedStyleName = function(name) {
     if (warnedStyleNames.hasOwnProperty(name) && warnedStyleNames[name]) {
       return;
     }
@@ -66,7 +66,7 @@ if (__DEV__) {
     );
   };
 
-  var warnBadVendoredStyleName = function(name) {
+  const warnBadVendoredStyleName = function(name) {
     if (warnedStyleNames.hasOwnProperty(name) && warnedStyleNames[name]) {
       return;
     }
@@ -80,7 +80,7 @@ if (__DEV__) {
     );
   };
 
-  var warnStyleValueWithSemicolon = function(name, value) {
+  const warnStyleValueWithSemicolon = function(name, value) {
     if (warnedStyleValues.hasOwnProperty(value) && warnedStyleValues[value]) {
       return;
     }
@@ -95,7 +95,7 @@ if (__DEV__) {
     );
   };
 
-  var warnStyleValueIsNaN = function(name, value) {
+  const warnStyleValueIsNaN = function(name, value) {
     if (warnedForNaNValue) {
       return;
     }
@@ -130,7 +130,7 @@ if (__DEV__) {
 /**
  * Operations for dealing with CSS properties.
  */
-var CSSPropertyOperations = {
+const CSSPropertyOperations = {
 
   /**
    * Serializes a mapping of style properties for use as inline styles:
@@ -146,12 +146,12 @@ var CSSPropertyOperations = {
    * @return {?string}
    */
   createMarkupForStyles: function(styles, component) {
-    var serialized = '';
-    for (var styleName in styles) {
+    let serialized = '';
+    for (let styleName in styles) {
       if (!styles.hasOwnProperty(styleName)) {
         continue;
       }
-      var styleValue = styles[styleName];
+      const styleValue = styles[styleName];
       if (__DEV__) {
         warnValidStyle(styleName, styleValue);
       }
@@ -172,15 +172,15 @@ var CSSPropertyOperations = {
    * @param {object} styles
    */
   setValueForStyles: function(node, styles, component) {
-    var style = node.style;
-    for (var styleName in styles) {
+    const style = node.style;
+    for (let styleName in styles) {
       if (!styles.hasOwnProperty(styleName)) {
         continue;
       }
       if (__DEV__) {
         warnValidStyle(styleName, styles[styleName]);
       }
-      var styleValue = dangerousStyleValue(
+      const styleValue = dangerousStyleValue(
         styleName,
         styles[styleName],
         component
@@ -191,13 +191,13 @@ var CSSPropertyOperations = {
       if (styleValue) {
         style[styleName] = styleValue;
       } else {
-        var expansion =
+        const expansion =
           hasShorthandPropertyBug &&
           CSSProperty.shorthandPropertyExpansions[styleName];
         if (expansion) {
           // Shorthand property that IE8 won't like unsetting, so unset each
           // component to placate it
-          for (var individualStyleName in expansion) {
+          for (let individualStyleName in expansion) {
             style[individualStyleName] = '';
           }
         } else {

--- a/src/renderers/dom/shared/CSSPropertyOperations.js
+++ b/src/renderers/dom/shared/CSSPropertyOperations.js
@@ -147,7 +147,7 @@ const CSSPropertyOperations = {
    */
   createMarkupForStyles: function(styles, component) {
     let serialized = '';
-    for (let styleName in styles) {
+    for (const styleName in styles) {
       if (!styles.hasOwnProperty(styleName)) {
         continue;
       }
@@ -197,7 +197,7 @@ const CSSPropertyOperations = {
         if (expansion) {
           // Shorthand property that IE8 won't like unsetting, so unset each
           // component to placate it
-          for (let individualStyleName in expansion) {
+          for (const individualStyleName in expansion) {
             style[individualStyleName] = '';
           }
         } else {

--- a/src/renderers/dom/shared/DOMNamespaces.js
+++ b/src/renderers/dom/shared/DOMNamespaces.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var DOMNamespaces = {
+const DOMNamespaces = {
   html: 'http://www.w3.org/1999/xhtml',
   mathml: 'http://www.w3.org/1998/Math/MathML',
   svg: 'http://www.w3.org/2000/svg',

--- a/src/renderers/dom/shared/DOMProperty.js
+++ b/src/renderers/dom/shared/DOMProperty.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-var invariant = require('invariant');
+const invariant = require('invariant');
 
 function checkMask(value, bitmask) {
   return (value & bitmask) === bitmask;
 }
 
-var DOMPropertyInjection = {
+const DOMPropertyInjection = {
   /**
    * Mapping from normalized, camelcased property names to a configuration that
    * specifies how the associated DOM property should be accessed or rendered.
@@ -58,12 +58,12 @@ var DOMPropertyInjection = {
    * @param {object} domPropertyConfig the config as described above.
    */
   injectDOMPropertyConfig: function(domPropertyConfig) {
-    var Injection = DOMPropertyInjection;
-    var Properties = domPropertyConfig.Properties || {};
-    var DOMAttributeNamespaces = domPropertyConfig.DOMAttributeNamespaces || {};
-    var DOMAttributeNames = domPropertyConfig.DOMAttributeNames || {};
-    var DOMPropertyNames = domPropertyConfig.DOMPropertyNames || {};
-    var DOMMutationMethods = domPropertyConfig.DOMMutationMethods || {};
+    const Injection = DOMPropertyInjection;
+    const Properties = domPropertyConfig.Properties || {};
+    const DOMAttributeNamespaces = domPropertyConfig.DOMAttributeNamespaces || {};
+    const DOMAttributeNames = domPropertyConfig.DOMAttributeNames || {};
+    const DOMPropertyNames = domPropertyConfig.DOMPropertyNames || {};
+    const DOMMutationMethods = domPropertyConfig.DOMMutationMethods || {};
 
     if (domPropertyConfig.isCustomAttribute) {
       DOMProperty._isCustomAttributeFunctions.push(
@@ -71,7 +71,7 @@ var DOMPropertyInjection = {
       );
     }
 
-    for (var propName in Properties) {
+    for (let propName in Properties) {
       invariant(
         !DOMProperty.properties.hasOwnProperty(propName),
         'injectDOMPropertyConfig(...): You\'re trying to inject DOM property ' +
@@ -81,10 +81,10 @@ var DOMPropertyInjection = {
         propName
       );
 
-      var lowerCased = propName.toLowerCase();
-      var propConfig = Properties[propName];
+      const lowerCased = propName.toLowerCase();
+      const propConfig = Properties[propName];
 
-      var propertyInfo = {
+      const propertyInfo = {
         attributeName: lowerCased,
         attributeNamespace: null,
         propertyName: propName,
@@ -142,7 +142,7 @@ var DOMPropertyInjection = {
   },
 };
 
-var ATTRIBUTE_NAME_START_CHAR = ':A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD';
+const ATTRIBUTE_NAME_START_CHAR = ':A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD';
 
 /**
  * DOMProperty exports lookup objects that can be used like functions:
@@ -217,8 +217,8 @@ var DOMProperty = {
    * @method
    */
   isCustomAttribute: function(attributeName) {
-    for (var i = 0; i < DOMProperty._isCustomAttributeFunctions.length; i++) {
-      var isCustomAttributeFn = DOMProperty._isCustomAttributeFunctions[i];
+    for (let i = 0; i < DOMProperty._isCustomAttributeFunctions.length; i++) {
+      const isCustomAttributeFn = DOMProperty._isCustomAttributeFunctions[i];
       if (isCustomAttributeFn(attributeName)) {
         return true;
       }

--- a/src/renderers/dom/shared/DOMProperty.js
+++ b/src/renderers/dom/shared/DOMProperty.js
@@ -71,7 +71,7 @@ const DOMPropertyInjection = {
       );
     }
 
-    for (let propName in Properties) {
+    for (const propName in Properties) {
       invariant(
         !DOMProperty.properties.hasOwnProperty(propName),
         'injectDOMPropertyConfig(...): You\'re trying to inject DOM property ' +

--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -11,16 +11,16 @@
 
 'use strict';
 
-var DOMProperty = require('DOMProperty');
-var ReactDOMInstrumentation = require('ReactDOMInstrumentation');
-var ReactPerf = require('ReactPerf');
+const DOMProperty = require('DOMProperty');
+const ReactDOMInstrumentation = require('ReactDOMInstrumentation');
+const ReactPerf = require('ReactPerf');
 
-var quoteAttributeValueForBrowser = require('quoteAttributeValueForBrowser');
-var warning = require('warning');
+const quoteAttributeValueForBrowser = require('quoteAttributeValueForBrowser');
+const warning = require('warning');
 
-var VALID_ATTRIBUTE_NAME_REGEX = new RegExp('^[' + DOMProperty.ATTRIBUTE_NAME_START_CHAR + '][' + DOMProperty.ATTRIBUTE_NAME_CHAR + ']*$');
-var illegalAttributeNameCache = {};
-var validatedAttributeNameCache = {};
+const VALID_ATTRIBUTE_NAME_REGEX = new RegExp('^[' + DOMProperty.ATTRIBUTE_NAME_START_CHAR + '][' + DOMProperty.ATTRIBUTE_NAME_CHAR + ']*$');
+const illegalAttributeNameCache = {};
+const validatedAttributeNameCache = {};
 
 function isAttributeNameSafe(attributeName) {
   if (validatedAttributeNameCache.hasOwnProperty(attributeName)) {
@@ -53,7 +53,7 @@ function shouldIgnoreValue(propertyInfo, value) {
 /**
  * Operations for dealing with DOM properties.
  */
-var DOMPropertyOperations = {
+const DOMPropertyOperations = {
 
   /**
    * Creates markup for the ID property.
@@ -89,13 +89,13 @@ var DOMPropertyOperations = {
     if (__DEV__) {
       ReactDOMInstrumentation.debugTool.onCreateMarkupForProperty(name, value);
     }
-    var propertyInfo = DOMProperty.properties.hasOwnProperty(name) ?
+    const propertyInfo = DOMProperty.properties.hasOwnProperty(name) ?
         DOMProperty.properties[name] : null;
     if (propertyInfo) {
       if (shouldIgnoreValue(propertyInfo, value)) {
         return '';
       }
-      var attributeName = propertyInfo.attributeName;
+      const attributeName = propertyInfo.attributeName;
       if (propertyInfo.hasBooleanValue ||
           (propertyInfo.hasOverloadedBooleanValue && value === true)) {
         return attributeName + '=""';
@@ -138,11 +138,11 @@ var DOMPropertyOperations = {
     if (!isAttributeNameSafe(name) || value == null) {
       return '';
     }
-    var propertyInfo = DOMProperty.properties.hasOwnProperty(name) ?
+    const propertyInfo = DOMProperty.properties.hasOwnProperty(name) ?
         DOMProperty.properties[name] : null;
     if (propertyInfo) {
       // Migration path for deprecated camelCase aliases for SVG attributes
-      var { attributeName } = propertyInfo;
+      const { attributeName } = propertyInfo;
       return attributeName + '=' + quoteAttributeValueForBrowser(value);
     } else {
       return name + '=' + quoteAttributeValueForBrowser(value);
@@ -160,16 +160,16 @@ var DOMPropertyOperations = {
     if (__DEV__) {
       ReactDOMInstrumentation.debugTool.onSetValueForProperty(node, name, value);
     }
-    var propertyInfo = DOMProperty.properties.hasOwnProperty(name) ?
+    const propertyInfo = DOMProperty.properties.hasOwnProperty(name) ?
         DOMProperty.properties[name] : null;
     if (propertyInfo) {
-      var mutationMethod = propertyInfo.mutationMethod;
+      const mutationMethod = propertyInfo.mutationMethod;
       if (mutationMethod) {
         mutationMethod(node, value);
       } else if (shouldIgnoreValue(propertyInfo, value)) {
         this.deleteValueForProperty(node, name);
       } else if (propertyInfo.mustUseProperty) {
-        var propName = propertyInfo.propertyName;
+        const propName = propertyInfo.propertyName;
         // Must explicitly cast values for HAS_SIDE_EFFECTS-properties to the
         // property type before comparing; only `value` does and is string.
         if (!propertyInfo.hasSideEffects ||
@@ -179,8 +179,8 @@ var DOMPropertyOperations = {
           node[propName] = value;
         }
       } else {
-        var attributeName = propertyInfo.attributeName;
-        var namespace = propertyInfo.attributeNamespace;
+        const attributeName = propertyInfo.attributeName;
+        const namespace = propertyInfo.attributeNamespace;
         // `setAttribute` with objects becomes only `[object]` in IE8/9,
         // ('' + value) makes it output the correct toString()-value.
         if (namespace) {
@@ -230,14 +230,14 @@ var DOMPropertyOperations = {
     if (__DEV__) {
       ReactDOMInstrumentation.debugTool.onDeleteValueForProperty(node, name);
     }
-    var propertyInfo = DOMProperty.properties.hasOwnProperty(name) ?
+    const propertyInfo = DOMProperty.properties.hasOwnProperty(name) ?
         DOMProperty.properties[name] : null;
     if (propertyInfo) {
-      var mutationMethod = propertyInfo.mutationMethod;
+      const mutationMethod = propertyInfo.mutationMethod;
       if (mutationMethod) {
         mutationMethod(node, undefined);
       } else if (propertyInfo.mustUseProperty) {
-        var propName = propertyInfo.propertyName;
+        const propName = propertyInfo.propertyName;
         if (propertyInfo.hasBooleanValue) {
           // No HAS_SIDE_EFFECTS logic here, only `value` has it and is string.
           node[propName] = false;
@@ -256,7 +256,7 @@ var DOMPropertyOperations = {
   },
 
   deleteValueForSVGAttribute: function(node, name) {
-    var propertyInfo = DOMProperty.properties.hasOwnProperty(name) ?
+    const propertyInfo = DOMProperty.properties.hasOwnProperty(name) ?
         DOMProperty.properties[name] : null;
     if (propertyInfo) {
       DOMPropertyOperations.deleteValueForProperty(node, name);

--- a/src/renderers/dom/shared/Danger.js
+++ b/src/renderers/dom/shared/Danger.js
@@ -11,16 +11,16 @@
 
 'use strict';
 
-var DOMLazyTree = require('DOMLazyTree');
-var ExecutionEnvironment = require('ExecutionEnvironment');
+const DOMLazyTree = require('DOMLazyTree');
+const ExecutionEnvironment = require('ExecutionEnvironment');
 
-var createNodesFromMarkup = require('createNodesFromMarkup');
-var emptyFunction = require('emptyFunction');
-var getMarkupWrap = require('getMarkupWrap');
-var invariant = require('invariant');
+const createNodesFromMarkup = require('createNodesFromMarkup');
+const emptyFunction = require('emptyFunction');
+const getMarkupWrap = require('getMarkupWrap');
+const invariant = require('invariant');
 
-var OPEN_TAG_NAME_EXP = /^(<[^ \/>]+)/;
-var RESULT_INDEX_ATTR = 'data-danger-index';
+const OPEN_TAG_NAME_EXP = /^(<[^ \/>]+)/;
+const RESULT_INDEX_ATTR = 'data-danger-index';
 
 /**
  * Extracts the `nodeName` from a string of markup.
@@ -37,7 +37,7 @@ function getNodeName(markup) {
   return markup.substring(1, markup.indexOf(' '));
 }
 
-var Danger = {
+const Danger = {
 
   /**
    * Renders markup into an array of nodes. The markup is expected to render
@@ -56,10 +56,10 @@ var Danger = {
       'before requiring React when unit testing or use ' +
       'ReactDOMServer.renderToString for server rendering.'
     );
-    var nodeName;
-    var markupByNodeName = {};
+    let nodeName;
+    const markupByNodeName = {};
     // Group markup by `nodeName` if a wrap is necessary, else by '*'.
-    for (var i = 0; i < markupList.length; i++) {
+    for (let i = 0; i < markupList.length; i++) {
       invariant(
         markupList[i],
         'dangerouslyRenderMarkup(...): Missing markup.'
@@ -69,21 +69,21 @@ var Danger = {
       markupByNodeName[nodeName] = markupByNodeName[nodeName] || [];
       markupByNodeName[nodeName][i] = markupList[i];
     }
-    var resultList = [];
-    var resultListAssignmentCount = 0;
+    const resultList = [];
+    let resultListAssignmentCount = 0;
     for (nodeName in markupByNodeName) {
       if (!markupByNodeName.hasOwnProperty(nodeName)) {
         continue;
       }
-      var markupListByNodeName = markupByNodeName[nodeName];
+      const markupListByNodeName = markupByNodeName[nodeName];
 
       // This for-in loop skips the holes of the sparse array. The order of
       // iteration should follow the order of assignment, which happens to match
       // numerical index order, but we don't rely on that.
-      var resultIndex;
+      let resultIndex;
       for (resultIndex in markupListByNodeName) {
         if (markupListByNodeName.hasOwnProperty(resultIndex)) {
-          var markup = markupListByNodeName[resultIndex];
+          const markup = markupListByNodeName[resultIndex];
 
           // Push the requested markup with an additional RESULT_INDEX_ATTR
           // attribute.  If the markup does not start with a < character, it
@@ -97,13 +97,13 @@ var Danger = {
       }
 
       // Render each group of markup with similar wrapping `nodeName`.
-      var renderNodes = createNodesFromMarkup(
+      const renderNodes = createNodesFromMarkup(
         markupListByNodeName.join(''),
         emptyFunction // Do nothing special with <script> tags.
       );
 
-      for (var j = 0; j < renderNodes.length; ++j) {
-        var renderNode = renderNodes[j];
+      for (let j = 0; j < renderNodes.length; ++j) {
+        const renderNode = renderNodes[j];
         if (renderNode.hasAttribute &&
             renderNode.hasAttribute(RESULT_INDEX_ATTR)) {
 
@@ -173,7 +173,7 @@ var Danger = {
     );
 
     if (typeof markup === 'string') {
-      var newChild = createNodesFromMarkup(markup, emptyFunction)[0];
+      const newChild = createNodesFromMarkup(markup, emptyFunction)[0];
       oldChild.parentNode.replaceChild(newChild, oldChild);
     } else {
       DOMLazyTree.replaceChildWithTree(oldChild, markup);

--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -11,18 +11,18 @@
 
 'use strict';
 
-var DOMProperty = require('DOMProperty');
+const DOMProperty = require('DOMProperty');
 
-var MUST_USE_PROPERTY = DOMProperty.injection.MUST_USE_PROPERTY;
-var HAS_BOOLEAN_VALUE = DOMProperty.injection.HAS_BOOLEAN_VALUE;
-var HAS_SIDE_EFFECTS = DOMProperty.injection.HAS_SIDE_EFFECTS;
-var HAS_NUMERIC_VALUE = DOMProperty.injection.HAS_NUMERIC_VALUE;
-var HAS_POSITIVE_NUMERIC_VALUE =
+const MUST_USE_PROPERTY = DOMProperty.injection.MUST_USE_PROPERTY;
+const HAS_BOOLEAN_VALUE = DOMProperty.injection.HAS_BOOLEAN_VALUE;
+const HAS_SIDE_EFFECTS = DOMProperty.injection.HAS_SIDE_EFFECTS;
+const HAS_NUMERIC_VALUE = DOMProperty.injection.HAS_NUMERIC_VALUE;
+const HAS_POSITIVE_NUMERIC_VALUE =
   DOMProperty.injection.HAS_POSITIVE_NUMERIC_VALUE;
-var HAS_OVERLOADED_BOOLEAN_VALUE =
+const HAS_OVERLOADED_BOOLEAN_VALUE =
   DOMProperty.injection.HAS_OVERLOADED_BOOLEAN_VALUE;
 
-var HTMLDOMPropertyConfig = {
+const HTMLDOMPropertyConfig = {
   isCustomAttribute: RegExp.prototype.test.bind(
     new RegExp('^(data|aria)-[' + DOMProperty.ATTRIBUTE_NAME_CHAR + ']*$')
   ),

--- a/src/renderers/dom/shared/ReactComponentBrowserEnvironment.js
+++ b/src/renderers/dom/shared/ReactComponentBrowserEnvironment.js
@@ -11,16 +11,16 @@
 
 'use strict';
 
-var DOMChildrenOperations = require('DOMChildrenOperations');
-var ReactDOMIDOperations = require('ReactDOMIDOperations');
-var ReactPerf = require('ReactPerf');
+const DOMChildrenOperations = require('DOMChildrenOperations');
+const ReactDOMIDOperations = require('ReactDOMIDOperations');
+const ReactPerf = require('ReactPerf');
 
 /**
  * Abstracts away all functionality of the reconciler that requires knowledge of
  * the browser context. TODO: These callers should be refactored to avoid the
  * need for this injection.
  */
-var ReactComponentBrowserEnvironment = {
+const ReactComponentBrowserEnvironment = {
 
   processChildrenUpdates:
     ReactDOMIDOperations.dangerouslyProcessChildrenUpdates,

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -13,55 +13,55 @@
 
 'use strict';
 
-var AutoFocusUtils = require('AutoFocusUtils');
-var CSSPropertyOperations = require('CSSPropertyOperations');
-var DOMLazyTree = require('DOMLazyTree');
-var DOMNamespaces = require('DOMNamespaces');
-var DOMProperty = require('DOMProperty');
-var DOMPropertyOperations = require('DOMPropertyOperations');
-var EventConstants = require('EventConstants');
-var EventPluginHub = require('EventPluginHub');
-var EventPluginRegistry = require('EventPluginRegistry');
-var ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
-var ReactComponentBrowserEnvironment =
+const AutoFocusUtils = require('AutoFocusUtils');
+const CSSPropertyOperations = require('CSSPropertyOperations');
+const DOMLazyTree = require('DOMLazyTree');
+const DOMNamespaces = require('DOMNamespaces');
+const DOMProperty = require('DOMProperty');
+const DOMPropertyOperations = require('DOMPropertyOperations');
+const EventConstants = require('EventConstants');
+const EventPluginHub = require('EventPluginHub');
+const EventPluginRegistry = require('EventPluginRegistry');
+const ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
+const ReactComponentBrowserEnvironment =
   require('ReactComponentBrowserEnvironment');
-var ReactDOMButton = require('ReactDOMButton');
-var ReactDOMComponentFlags = require('ReactDOMComponentFlags');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var ReactDOMInput = require('ReactDOMInput');
-var ReactDOMOption = require('ReactDOMOption');
-var ReactDOMSelect = require('ReactDOMSelect');
-var ReactDOMTextarea = require('ReactDOMTextarea');
-var ReactMultiChild = require('ReactMultiChild');
-var ReactPerf = require('ReactPerf');
+const ReactDOMButton = require('ReactDOMButton');
+const ReactDOMComponentFlags = require('ReactDOMComponentFlags');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
+const ReactDOMInput = require('ReactDOMInput');
+const ReactDOMOption = require('ReactDOMOption');
+const ReactDOMSelect = require('ReactDOMSelect');
+const ReactDOMTextarea = require('ReactDOMTextarea');
+const ReactMultiChild = require('ReactMultiChild');
+const ReactPerf = require('ReactPerf');
 
-var assign = require('Object.assign');
-var escapeTextContentForBrowser = require('escapeTextContentForBrowser');
-var invariant = require('invariant');
-var isEventSupported = require('isEventSupported');
-var keyOf = require('keyOf');
-var shallowEqual = require('shallowEqual');
-var validateDOMNesting = require('validateDOMNesting');
-var warning = require('warning');
+const assign = require('Object.assign');
+const escapeTextContentForBrowser = require('escapeTextContentForBrowser');
+const invariant = require('invariant');
+const isEventSupported = require('isEventSupported');
+const keyOf = require('keyOf');
+const shallowEqual = require('shallowEqual');
+const validateDOMNesting = require('validateDOMNesting');
+const warning = require('warning');
 
-var Flags = ReactDOMComponentFlags;
-var deleteListener = EventPluginHub.deleteListener;
-var getNode = ReactDOMComponentTree.getNodeFromInstance;
-var listenTo = ReactBrowserEventEmitter.listenTo;
-var registrationNameModules = EventPluginRegistry.registrationNameModules;
+const Flags = ReactDOMComponentFlags;
+const deleteListener = EventPluginHub.deleteListener;
+const getNode = ReactDOMComponentTree.getNodeFromInstance;
+const listenTo = ReactBrowserEventEmitter.listenTo;
+const registrationNameModules = EventPluginRegistry.registrationNameModules;
 
 // For quickly matching children type, to test if can be treated as content.
-var CONTENT_TYPES = {'string': true, 'number': true};
+const CONTENT_TYPES = {'string': true, 'number': true};
 
-var CHILDREN = keyOf({children: null});
-var STYLE = keyOf({style: null});
-var HTML = keyOf({__html: null});
+const CHILDREN = keyOf({children: null});
+const STYLE = keyOf({style: null});
+const HTML = keyOf({__html: null});
 
 function getDeclarationErrorAddendum(internalInstance) {
   if (internalInstance) {
-    var owner = internalInstance._currentElement._owner || null;
+    const owner = internalInstance._currentElement._owner || null;
     if (owner) {
-      var name = owner.getName();
+      const name = owner.getName();
       if (name) {
         return ' This DOM node was rendered by `' + name + '`.';
       }
@@ -75,10 +75,10 @@ function friendlyStringify(obj) {
     if (Array.isArray(obj)) {
       return '[' + obj.map(friendlyStringify).join(', ') + ']';
     } else {
-      var pairs = [];
-      for (var key in obj) {
+      const pairs = [];
+      for (let key in obj) {
         if (Object.prototype.hasOwnProperty.call(obj, key)) {
-          var keyEscaped = /^[a-z$_][\w$_]*$/i.test(key) ?
+          const keyEscaped = /^[a-z$_][\w$_]*$/i.test(key) ?
             key :
             JSON.stringify(key);
           pairs.push(keyEscaped + ': ' + friendlyStringify(obj[key]));
@@ -96,7 +96,7 @@ function friendlyStringify(obj) {
   return String(obj);
 }
 
-var styleMutationWarning = {};
+const styleMutationWarning = {};
 
 function checkAndWarnForMutatedStyle(style1, style2, component) {
   if (style1 == null || style2 == null) {
@@ -106,14 +106,14 @@ function checkAndWarnForMutatedStyle(style1, style2, component) {
     return;
   }
 
-  var componentName = component._tag;
-  var owner = component._currentElement._owner;
-  var ownerName;
+  const componentName = component._tag;
+  const owner = component._currentElement._owner;
+  let ownerName;
   if (owner) {
     ownerName = owner.getName();
   }
 
-  var hash = ownerName + '|' + componentName;
+  const hash = ownerName + '|' + componentName;
 
   if (styleMutationWarning.hasOwnProperty(hash)) {
     return;
@@ -199,8 +199,8 @@ function enqueuePutListener(inst, registrationName, listener, transaction) {
       'This browser doesn\'t support the `onScroll` event'
     );
   }
-  var containerInfo = inst._nativeContainerInfo;
-  var doc = containerInfo._ownerDocument;
+  const containerInfo = inst._nativeContainerInfo;
+  const doc = containerInfo._ownerDocument;
   if (!doc) {
     // Server rendering.
     return;
@@ -214,7 +214,7 @@ function enqueuePutListener(inst, registrationName, listener, transaction) {
 }
 
 function putListener() {
-  var listenerToPut = this;
+  const listenerToPut = this;
   EventPluginHub.putListener(
     listenerToPut.inst,
     listenerToPut.registrationName,
@@ -224,7 +224,7 @@ function putListener() {
 
 // There are so many media events, it makes sense to just
 // maintain a list rather than create a `trapBubbledEvent` for each
-var mediaEvents = {
+const mediaEvents = {
   topAbort: 'abort',
   topCanPlay: 'canplay',
   topCanPlayThrough: 'canplaythrough',
@@ -251,11 +251,11 @@ var mediaEvents = {
 };
 
 function trapBubbledEventsLocal() {
-  var inst = this;
+  const inst = this;
   // If a component renders to null or if another component fatals and causes
   // the state of the tree to be corrupted, `node` here can be null.
   invariant(inst._rootNodeID, 'Must be mounted to trap events');
-  var node = getNode(inst);
+  const node = getNode(inst);
   invariant(
     node,
     'trapBubbledEvent(...): Requires node to be rendered.'
@@ -276,7 +276,7 @@ function trapBubbledEventsLocal() {
 
       inst._wrapperState.listeners = [];
       // Create listener for each media event
-      for (var event in mediaEvents) {
+      for (let event in mediaEvents) {
         if (mediaEvents.hasOwnProperty(event)) {
           inst._wrapperState.listeners.push(
             ReactBrowserEventEmitter.trapBubbledEvent(
@@ -338,7 +338,7 @@ function postUpdateSelectWrapper() {
 // For HTML, certain tags should omit their close tag. We keep a whitelist for
 // those special-case tags.
 
-var omittedCloseTags = {
+const omittedCloseTags = {
   'area': true,
   'base': true,
   'br': true,
@@ -357,7 +357,7 @@ var omittedCloseTags = {
   // NOTE: menuitem's close tag should be omitted, but that causes problems.
 };
 
-var newlineEatingTags = {
+const newlineEatingTags = {
   'listing': true,
   'pre': true,
   'textarea': true,
@@ -374,8 +374,8 @@ var voidElementTags = assign({
 // HTML, we want to make sure that it's a safe tag.
 // http://www.w3.org/TR/REC-xml/#NT-Name
 
-var VALID_TAG_REGEX = /^[a-zA-Z][a-zA-Z:_\.\-\d]*$/; // Simplified subset
-var validatedTagCache = {};
+const VALID_TAG_REGEX = /^[a-zA-Z][a-zA-Z:_\.\-\d]*$/; // Simplified subset
+const validatedTagCache = {};
 var hasOwnProperty = {}.hasOwnProperty;
 
 function validateDangerousTag(tag) {
@@ -389,7 +389,7 @@ function isCustomComponent(tagName, props) {
   return tagName.indexOf('-') >= 0 || props.is != null;
 }
 
-var globalIdCounter = 1;
+let globalIdCounter = 1;
 
 /**
  * Creates a new React class that is idempotent and capable of containing other
@@ -406,7 +406,7 @@ var globalIdCounter = 1;
  * @extends ReactMultiChild
  */
 function ReactDOMComponent(element) {
-  var tag = element.type;
+  const tag = element.type;
   validateDangerousTag(tag);
   this._currentElement = element;
   this._tag = tag.toLowerCase();
@@ -453,7 +453,7 @@ ReactDOMComponent.Mixin = {
     this._nativeParent = nativeParent;
     this._nativeContainerInfo = nativeContainerInfo;
 
-    var props = this._currentElement.props;
+    let props = this._currentElement.props;
 
     switch (this._tag) {
       case 'iframe':
@@ -494,8 +494,8 @@ ReactDOMComponent.Mixin = {
 
     // We create tags in the namespace of their parent container, except HTML
     // tags get no namespace.
-    var namespaceURI;
-    var parentTag;
+    let namespaceURI;
+    let parentTag;
     if (nativeParent != null) {
       namespaceURI = nativeParent._namespaceURI;
       parentTag = nativeParent._tag;
@@ -517,7 +517,7 @@ ReactDOMComponent.Mixin = {
     this._namespaceURI = namespaceURI;
 
     if (__DEV__) {
-      var parentInfo;
+      let parentInfo;
       if (nativeParent != null) {
         parentInfo = nativeParent._ancestorInfo;
       } else if (nativeContainerInfo._tag) {
@@ -532,15 +532,15 @@ ReactDOMComponent.Mixin = {
         validateDOMNesting.updatedAncestorInfo(parentInfo, this._tag, this);
     }
 
-    var mountImage;
+    let mountImage;
     if (transaction.useCreateElement) {
-      var ownerDocument = nativeContainerInfo._ownerDocument;
-      var el;
+      const ownerDocument = nativeContainerInfo._ownerDocument;
+      let el;
       if (namespaceURI === DOMNamespaces.html) {
         if (this._tag === 'script') {
           // Create the script via .innerHTML so its "parser-inserted" flag is
           // set to true and it does not execute
-          var div = ownerDocument.createElement('div');
+          const div = ownerDocument.createElement('div');
           var type = this._currentElement.type;
           div.innerHTML = `<${type}></${type}>`;
           el = div.removeChild(div.firstChild);
@@ -559,12 +559,12 @@ ReactDOMComponent.Mixin = {
         DOMPropertyOperations.setAttributeForRoot(el);
       }
       this._updateDOMProperties(null, props, transaction);
-      var lazyTree = DOMLazyTree(el);
+      const lazyTree = DOMLazyTree(el);
       this._createInitialChildren(transaction, props, context, lazyTree);
       mountImage = lazyTree;
     } else {
-      var tagOpen = this._createOpenTagMarkupAndPutListeners(transaction, props);
-      var tagContent = this._createContentMarkup(transaction, props, context);
+      const tagOpen = this._createOpenTagMarkupAndPutListeners(transaction, props);
+      const tagContent = this._createContentMarkup(transaction, props, context);
       if (!tagContent && omittedCloseTags[this._tag]) {
         mountImage = tagOpen + '/>';
       } else {
@@ -604,13 +604,13 @@ ReactDOMComponent.Mixin = {
    * @return {string} Markup of opening tag.
    */
   _createOpenTagMarkupAndPutListeners: function(transaction, props) {
-    var ret = '<' + this._currentElement.type;
+    let ret = '<' + this._currentElement.type;
 
-    for (var propKey in props) {
+    for (let propKey in props) {
       if (!props.hasOwnProperty(propKey)) {
         continue;
       }
-      var propValue = props[propKey];
+      let propValue = props[propKey];
       if (propValue == null) {
         continue;
       }
@@ -629,7 +629,7 @@ ReactDOMComponent.Mixin = {
           }
           propValue = CSSPropertyOperations.createMarkupForStyles(propValue, this);
         }
-        var markup = null;
+        let markup = null;
         if (this._tag != null && isCustomComponent(this._tag, props)) {
           if (propKey !== CHILDREN) {
             markup = DOMPropertyOperations.createMarkupForCustomAttribute(propKey, propValue);
@@ -668,23 +668,23 @@ ReactDOMComponent.Mixin = {
    * @return {string} Content markup.
    */
   _createContentMarkup: function(transaction, props, context) {
-    var ret = '';
+    let ret = '';
 
     // Intentional use of != to avoid catching zero/false.
-    var innerHTML = props.dangerouslySetInnerHTML;
+    const innerHTML = props.dangerouslySetInnerHTML;
     if (innerHTML != null) {
       if (innerHTML.__html != null) {
         ret = innerHTML.__html;
       }
     } else {
-      var contentToUse =
+      const contentToUse =
         CONTENT_TYPES[typeof props.children] ? props.children : null;
-      var childrenToUse = contentToUse != null ? null : props.children;
+      const childrenToUse = contentToUse != null ? null : props.children;
       if (contentToUse != null) {
         // TODO: Validate that text is allowed as a child of this node
         ret = escapeTextContentForBrowser(contentToUse);
       } else if (childrenToUse != null) {
-        var mountImages = this.mountChildren(
+        const mountImages = this.mountChildren(
           childrenToUse,
           transaction,
           context
@@ -711,25 +711,25 @@ ReactDOMComponent.Mixin = {
 
   _createInitialChildren: function(transaction, props, context, lazyTree) {
     // Intentional use of != to avoid catching zero/false.
-    var innerHTML = props.dangerouslySetInnerHTML;
+    const innerHTML = props.dangerouslySetInnerHTML;
     if (innerHTML != null) {
       if (innerHTML.__html != null) {
         DOMLazyTree.queueHTML(lazyTree, innerHTML.__html);
       }
     } else {
-      var contentToUse =
+      const contentToUse =
         CONTENT_TYPES[typeof props.children] ? props.children : null;
-      var childrenToUse = contentToUse != null ? null : props.children;
+      const childrenToUse = contentToUse != null ? null : props.children;
       if (contentToUse != null) {
         // TODO: Validate that text is allowed as a child of this node
         DOMLazyTree.queueText(lazyTree, contentToUse);
       } else if (childrenToUse != null) {
-        var mountImages = this.mountChildren(
+        const mountImages = this.mountChildren(
           childrenToUse,
           transaction,
           context
         );
-        for (var i = 0; i < mountImages.length; i++) {
+        for (let i = 0; i < mountImages.length; i++) {
           DOMLazyTree.queueChild(lazyTree, mountImages[i]);
         }
       }
@@ -745,7 +745,7 @@ ReactDOMComponent.Mixin = {
    * @param {object} context
    */
   receiveComponent: function(nextElement, transaction, context) {
-    var prevElement = this._currentElement;
+    const prevElement = this._currentElement;
     this._currentElement = nextElement;
     this.updateComponent(transaction, prevElement, nextElement, context);
   },
@@ -761,8 +761,8 @@ ReactDOMComponent.Mixin = {
    * @overridable
    */
   updateComponent: function(transaction, prevElement, nextElement, context) {
-    var lastProps = prevElement.props;
-    var nextProps = this._currentElement.props;
+    let lastProps = prevElement.props;
+    let nextProps = this._currentElement.props;
 
     switch (this._tag) {
       case 'button':
@@ -822,9 +822,9 @@ ReactDOMComponent.Mixin = {
    * @param {?DOMElement} node
    */
   _updateDOMProperties: function(lastProps, nextProps, transaction) {
-    var propKey;
-    var styleName;
-    var styleUpdates;
+    let propKey;
+    let styleName;
+    let styleUpdates;
     for (propKey in lastProps) {
       if (nextProps.hasOwnProperty(propKey) ||
          !lastProps.hasOwnProperty(propKey) ||
@@ -832,7 +832,7 @@ ReactDOMComponent.Mixin = {
         continue;
       }
       if (propKey === STYLE) {
-        var lastStyle = this._previousStyleCopy;
+        const lastStyle = this._previousStyleCopy;
         for (styleName in lastStyle) {
           if (lastStyle.hasOwnProperty(styleName)) {
             styleUpdates = styleUpdates || {};
@@ -859,8 +859,8 @@ ReactDOMComponent.Mixin = {
       }
     }
     for (propKey in nextProps) {
-      var nextProp = nextProps[propKey];
-      var lastProp =
+      let nextProp = nextProps[propKey];
+      const lastProp =
         propKey === STYLE ? this._previousStyleCopy :
         lastProps != null ? lastProps[propKey] : undefined;
       if (!nextProps.hasOwnProperty(propKey) ||
@@ -927,7 +927,7 @@ ReactDOMComponent.Mixin = {
       } else if (
           DOMProperty.properties[propKey] ||
           DOMProperty.isCustomAttribute(propKey)) {
-        var node = getNode(this);
+        const node = getNode(this);
         // If we're updating to null or undefined, we should remove the property
         // from the DOM node instead of inadvertently setting to a string. This
         // brings us in line with the same behavior we have on initial render.
@@ -957,26 +957,26 @@ ReactDOMComponent.Mixin = {
    * @param {object} context
    */
   _updateDOMChildren: function(lastProps, nextProps, transaction, context) {
-    var lastContent =
+    const lastContent =
       CONTENT_TYPES[typeof lastProps.children] ? lastProps.children : null;
-    var nextContent =
+    const nextContent =
       CONTENT_TYPES[typeof nextProps.children] ? nextProps.children : null;
 
-    var lastHtml =
+    const lastHtml =
       lastProps.dangerouslySetInnerHTML &&
       lastProps.dangerouslySetInnerHTML.__html;
-    var nextHtml =
+    const nextHtml =
       nextProps.dangerouslySetInnerHTML &&
       nextProps.dangerouslySetInnerHTML.__html;
 
     // Note the use of `!=` which checks for null or undefined.
-    var lastChildren = lastContent != null ? null : lastProps.children;
-    var nextChildren = nextContent != null ? null : nextProps.children;
+    const lastChildren = lastContent != null ? null : lastProps.children;
+    const nextChildren = nextContent != null ? null : nextProps.children;
 
     // If we're switching from children to content/html or vice versa, remove
     // the old content
-    var lastHasContentOrHtml = lastContent != null || lastHtml != null;
-    var nextHasContentOrHtml = nextContent != null || nextHtml != null;
+    const lastHasContentOrHtml = lastContent != null || lastHtml != null;
+    const nextHasContentOrHtml = nextContent != null || nextHtml != null;
     if (lastChildren != null && nextChildren == null) {
       this.updateChildren(null, transaction, context);
     } else if (lastHasContentOrHtml && !nextHasContentOrHtml) {
@@ -1013,9 +1013,9 @@ ReactDOMComponent.Mixin = {
       case 'form':
       case 'video':
       case 'audio':
-        var listeners = this._wrapperState.listeners;
+        const listeners = this._wrapperState.listeners;
         if (listeners) {
-          for (var i = 0; i < listeners.length; i++) {
+          for (let i = 0; i < listeners.length; i++) {
             listeners[i].remove();
           }
         }

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -76,7 +76,7 @@ function friendlyStringify(obj) {
       return '[' + obj.map(friendlyStringify).join(', ') + ']';
     } else {
       const pairs = [];
-      for (let key in obj) {
+      for (const key in obj) {
         if (Object.prototype.hasOwnProperty.call(obj, key)) {
           const keyEscaped = /^[a-z$_][\w$_]*$/i.test(key) ?
             key :
@@ -276,7 +276,7 @@ function trapBubbledEventsLocal() {
 
       inst._wrapperState.listeners = [];
       // Create listener for each media event
-      for (let event in mediaEvents) {
+      for (const event in mediaEvents) {
         if (mediaEvents.hasOwnProperty(event)) {
           inst._wrapperState.listeners.push(
             ReactBrowserEventEmitter.trapBubbledEvent(
@@ -606,7 +606,7 @@ ReactDOMComponent.Mixin = {
   _createOpenTagMarkupAndPutListeners: function(transaction, props) {
     let ret = '<' + this._currentElement.type;
 
-    for (let propKey in props) {
+    for (const propKey in props) {
       if (!props.hasOwnProperty(propKey)) {
         continue;
       }

--- a/src/renderers/dom/shared/ReactDOMComponentFlags.js
+++ b/src/renderers/dom/shared/ReactDOMComponentFlags.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var ReactDOMComponentFlags = {
+const ReactDOMComponentFlags = {
   hasCachedChildNodes: 1 << 0,
 };
 

--- a/src/renderers/dom/shared/ReactDOMContainerInfo.js
+++ b/src/renderers/dom/shared/ReactDOMContainerInfo.js
@@ -11,12 +11,12 @@
 
 'use strict';
 
-var validateDOMNesting = require('validateDOMNesting');
+const validateDOMNesting = require('validateDOMNesting');
 
-var DOC_NODE_TYPE = 9;
+const DOC_NODE_TYPE = 9;
 
 function ReactDOMContainerInfo(topLevelWrapper, node) {
-  var info = {
+  const info = {
     _topLevelWrapper: topLevelWrapper,
     _idCounter: 1,
     _ownerDocument: node ?

--- a/src/renderers/dom/shared/ReactDOMDebugTool.js
+++ b/src/renderers/dom/shared/ReactDOMDebugTool.js
@@ -11,14 +11,14 @@
 
 'use strict';
 
-var ReactDOMUnknownPropertyDevtool = require('ReactDOMUnknownPropertyDevtool');
-var ReactDOMSVGDeprecatedAttributeDevtool =
+const ReactDOMUnknownPropertyDevtool = require('ReactDOMUnknownPropertyDevtool');
+const ReactDOMSVGDeprecatedAttributeDevtool =
   require('ReactDOMSVGDeprecatedAttributeDevtool');
 
-var warning = require('warning');
+const warning = require('warning');
 
-var eventHandlers = [];
-var handlerDoesThrowForEvent = {};
+const eventHandlers = [];
+const handlerDoesThrowForEvent = {};
 
 function emitEvent(handlerFunctionName, arg1, arg2, arg3, arg4, arg5) {
   if (__DEV__) {
@@ -40,12 +40,12 @@ function emitEvent(handlerFunctionName, arg1, arg2, arg3, arg4, arg5) {
   }
 }
 
-var ReactDOMDebugTool = {
+const ReactDOMDebugTool = {
   addDevtool(devtool) {
     eventHandlers.push(devtool);
   },
   removeDevtool(devtool) {
-    for (var i = 0; i < eventHandlers.length; i++) {
+    for (let i = 0; i < eventHandlers.length; i++) {
       if (eventHandlers[i] === devtool) {
         eventHandlers.splice(i, 1);
         i--;

--- a/src/renderers/dom/shared/ReactDOMEmptyComponent.js
+++ b/src/renderers/dom/shared/ReactDOMEmptyComponent.js
@@ -11,12 +11,12 @@
 
 'use strict';
 
-var DOMLazyTree = require('DOMLazyTree');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
+const DOMLazyTree = require('DOMLazyTree');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
 
-var assign = require('Object.assign');
+const assign = require('Object.assign');
 
-var ReactDOMEmptyComponent = function(instantiate) {
+const ReactDOMEmptyComponent = function(instantiate) {
   // ReactCompositeComponent uses this:
   this._currentElement = null;
   // ReactDOMComponentTree uses these:
@@ -32,15 +32,15 @@ assign(ReactDOMEmptyComponent.prototype, {
     nativeContainerInfo,
     context
   ) {
-    var domID = nativeContainerInfo._idCounter++;
+    const domID = nativeContainerInfo._idCounter++;
     this._domID = domID;
     this._nativeParent = nativeParent;
     this._nativeContainerInfo = nativeContainerInfo;
 
-    var nodeValue = ' react-empty: ' + this._domID + ' ';
+    const nodeValue = ' react-empty: ' + this._domID + ' ';
     if (transaction.useCreateElement) {
-      var ownerDocument = nativeContainerInfo._ownerDocument;
-      var node = ownerDocument.createComment(nodeValue);
+      const ownerDocument = nativeContainerInfo._ownerDocument;
+      const node = ownerDocument.createComment(nodeValue);
       ReactDOMComponentTree.precacheNode(this, node);
       return DOMLazyTree(node);
     } else {

--- a/src/renderers/dom/shared/ReactDOMFeatureFlags.js
+++ b/src/renderers/dom/shared/ReactDOMFeatureFlags.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var ReactDOMFeatureFlags = {
+const ReactDOMFeatureFlags = {
   useCreateElement: true,
 };
 

--- a/src/renderers/dom/shared/ReactDOMInstrumentation.js
+++ b/src/renderers/dom/shared/ReactDOMInstrumentation.js
@@ -11,6 +11,6 @@
 
 'use strict';
 
-var ReactDOMDebugTool = require('ReactDOMDebugTool');
+const ReactDOMDebugTool = require('ReactDOMDebugTool');
 
 module.exports = {debugTool: ReactDOMDebugTool};

--- a/src/renderers/dom/shared/ReactDOMTextComponent.js
+++ b/src/renderers/dom/shared/ReactDOMTextComponent.js
@@ -11,15 +11,15 @@
 
 'use strict';
 
-var DOMChildrenOperations = require('DOMChildrenOperations');
-var DOMLazyTree = require('DOMLazyTree');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var ReactPerf = require('ReactPerf');
+const DOMChildrenOperations = require('DOMChildrenOperations');
+const DOMLazyTree = require('DOMLazyTree');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
+const ReactPerf = require('ReactPerf');
 
-var assign = require('Object.assign');
-var escapeTextContentForBrowser = require('escapeTextContentForBrowser');
-var invariant = require('invariant');
-var validateDOMNesting = require('validateDOMNesting');
+const assign = require('Object.assign');
+const escapeTextContentForBrowser = require('escapeTextContentForBrowser');
+const invariant = require('invariant');
+const validateDOMNesting = require('validateDOMNesting');
 
 /**
  * Text nodes violate a couple assumptions that React makes about components:
@@ -36,7 +36,7 @@ var validateDOMNesting = require('validateDOMNesting');
  * @extends ReactComponent
  * @internal
  */
-var ReactDOMTextComponent = function(text) {
+const ReactDOMTextComponent = function(text) {
   // TODO: This is really a ReactText (ReactNode), not a ReactElement
   this._currentElement = text;
   this._stringText = '' + text;
@@ -68,7 +68,7 @@ assign(ReactDOMTextComponent.prototype, {
     context
   ) {
     if (__DEV__) {
-      var parentInfo;
+      let parentInfo;
       if (nativeParent != null) {
         parentInfo = nativeParent._ancestorInfo;
       } else if (nativeContainerInfo != null) {
@@ -81,16 +81,16 @@ assign(ReactDOMTextComponent.prototype, {
       }
     }
 
-    var domID = nativeContainerInfo._idCounter++;
-    var openingValue = ' react-text: ' + domID + ' ';
-    var closingValue = ' /react-text ';
+    const domID = nativeContainerInfo._idCounter++;
+    const openingValue = ' react-text: ' + domID + ' ';
+    const closingValue = ' /react-text ';
     this._domID = domID;
     this._nativeParent = nativeParent;
     if (transaction.useCreateElement) {
-      var ownerDocument = nativeContainerInfo._ownerDocument;
-      var openingComment = ownerDocument.createComment(openingValue);
-      var closingComment = ownerDocument.createComment(closingValue);
-      var lazyTree = DOMLazyTree(ownerDocument.createDocumentFragment());
+      const ownerDocument = nativeContainerInfo._ownerDocument;
+      const openingComment = ownerDocument.createComment(openingValue);
+      const closingComment = ownerDocument.createComment(closingValue);
+      const lazyTree = DOMLazyTree(ownerDocument.createDocumentFragment());
       DOMLazyTree.queueChild(lazyTree, DOMLazyTree(openingComment));
       if (this._stringText) {
         DOMLazyTree.queueChild(
@@ -103,7 +103,7 @@ assign(ReactDOMTextComponent.prototype, {
       this._closingComment = closingComment;
       return lazyTree;
     } else {
-      var escapedText = escapeTextContentForBrowser(this._stringText);
+      const escapedText = escapeTextContentForBrowser(this._stringText);
 
       if (transaction.renderToStaticMarkup) {
         // Normally we'd wrap this between comment nodes for the reasons stated
@@ -129,13 +129,13 @@ assign(ReactDOMTextComponent.prototype, {
   receiveComponent: function(nextText, transaction) {
     if (nextText !== this._currentElement) {
       this._currentElement = nextText;
-      var nextStringText = '' + nextText;
+      const nextStringText = '' + nextText;
       if (nextStringText !== this._stringText) {
         // TODO: Save this as pending props and use performUpdateIfNecessary
         // and/or updateComponent to do the actual update for consistency with
         // other component types?
         this._stringText = nextStringText;
-        var commentNodes = this.getNativeNode();
+        const commentNodes = this.getNativeNode();
         DOMChildrenOperations.replaceDelimitedText(
           commentNodes[0],
           commentNodes[1],
@@ -146,13 +146,13 @@ assign(ReactDOMTextComponent.prototype, {
   },
 
   getNativeNode: function() {
-    var nativeNode = this._commentNodes;
+    let nativeNode = this._commentNodes;
     if (nativeNode) {
       return nativeNode;
     }
     if (!this._closingComment) {
-      var openingComment = ReactDOMComponentTree.getNodeFromInstance(this);
-      var node = openingComment.nextSibling;
+      const openingComment = ReactDOMComponentTree.getNodeFromInstance(this);
+      let node = openingComment.nextSibling;
       while (true) {
         invariant(
           node != null,

--- a/src/renderers/dom/shared/ReactDefaultInjection.js
+++ b/src/renderers/dom/shared/ReactDefaultInjection.js
@@ -11,28 +11,28 @@
 
 'use strict';
 
-var BeforeInputEventPlugin = require('BeforeInputEventPlugin');
-var ChangeEventPlugin = require('ChangeEventPlugin');
-var DefaultEventPluginOrder = require('DefaultEventPluginOrder');
-var EnterLeaveEventPlugin = require('EnterLeaveEventPlugin');
-var ExecutionEnvironment = require('ExecutionEnvironment');
-var HTMLDOMPropertyConfig = require('HTMLDOMPropertyConfig');
-var ReactComponentBrowserEnvironment =
+const BeforeInputEventPlugin = require('BeforeInputEventPlugin');
+const ChangeEventPlugin = require('ChangeEventPlugin');
+const DefaultEventPluginOrder = require('DefaultEventPluginOrder');
+const EnterLeaveEventPlugin = require('EnterLeaveEventPlugin');
+const ExecutionEnvironment = require('ExecutionEnvironment');
+const HTMLDOMPropertyConfig = require('HTMLDOMPropertyConfig');
+const ReactComponentBrowserEnvironment =
   require('ReactComponentBrowserEnvironment');
-var ReactDOMComponent = require('ReactDOMComponent');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var ReactDOMEmptyComponent = require('ReactDOMEmptyComponent');
-var ReactDOMTreeTraversal = require('ReactDOMTreeTraversal');
-var ReactDOMTextComponent = require('ReactDOMTextComponent');
-var ReactDefaultBatchingStrategy = require('ReactDefaultBatchingStrategy');
-var ReactEventListener = require('ReactEventListener');
-var ReactInjection = require('ReactInjection');
-var ReactReconcileTransaction = require('ReactReconcileTransaction');
-var SVGDOMPropertyConfig = require('SVGDOMPropertyConfig');
-var SelectEventPlugin = require('SelectEventPlugin');
-var SimpleEventPlugin = require('SimpleEventPlugin');
+const ReactDOMComponent = require('ReactDOMComponent');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
+const ReactDOMEmptyComponent = require('ReactDOMEmptyComponent');
+const ReactDOMTreeTraversal = require('ReactDOMTreeTraversal');
+const ReactDOMTextComponent = require('ReactDOMTextComponent');
+const ReactDefaultBatchingStrategy = require('ReactDefaultBatchingStrategy');
+const ReactEventListener = require('ReactEventListener');
+const ReactInjection = require('ReactInjection');
+const ReactReconcileTransaction = require('ReactReconcileTransaction');
+const SVGDOMPropertyConfig = require('SVGDOMPropertyConfig');
+const SelectEventPlugin = require('SelectEventPlugin');
+const SimpleEventPlugin = require('SimpleEventPlugin');
 
-var alreadyInjected = false;
+let alreadyInjected = false;
 
 function inject() {
   if (alreadyInjected) {
@@ -93,9 +93,9 @@ function inject() {
   ReactInjection.Component.injectEnvironment(ReactComponentBrowserEnvironment);
 
   if (__DEV__) {
-    var url = (ExecutionEnvironment.canUseDOM && window.location.href) || '';
+    const url = (ExecutionEnvironment.canUseDOM && window.location.href) || '';
     if ((/[?&]react_perf\b/).test(url)) {
-      var ReactDefaultPerf = require('ReactDefaultPerf');
+      const ReactDefaultPerf = require('ReactDefaultPerf');
       ReactDefaultPerf.start();
     }
   }

--- a/src/renderers/dom/shared/ReactInjection.js
+++ b/src/renderers/dom/shared/ReactInjection.js
@@ -11,18 +11,18 @@
 
 'use strict';
 
-var DOMProperty = require('DOMProperty');
-var EventPluginHub = require('EventPluginHub');
-var EventPluginUtils = require('EventPluginUtils');
-var ReactComponentEnvironment = require('ReactComponentEnvironment');
-var ReactClass = require('ReactClass');
-var ReactEmptyComponent = require('ReactEmptyComponent');
-var ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
-var ReactNativeComponent = require('ReactNativeComponent');
-var ReactPerf = require('ReactPerf');
-var ReactUpdates = require('ReactUpdates');
+const DOMProperty = require('DOMProperty');
+const EventPluginHub = require('EventPluginHub');
+const EventPluginUtils = require('EventPluginUtils');
+const ReactComponentEnvironment = require('ReactComponentEnvironment');
+const ReactClass = require('ReactClass');
+const ReactEmptyComponent = require('ReactEmptyComponent');
+const ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
+const ReactNativeComponent = require('ReactNativeComponent');
+const ReactPerf = require('ReactPerf');
+const ReactUpdates = require('ReactUpdates');
 
-var ReactInjection = {
+const ReactInjection = {
   Component: ReactComponentEnvironment.injection,
   Class: ReactClass.injection,
   DOMProperty: DOMProperty.injection,

--- a/src/renderers/dom/shared/SVGDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/SVGDOMPropertyConfig.js
@@ -11,12 +11,12 @@
 
 'use strict';
 
-var NS = {
+const NS = {
   xlink: 'http://www.w3.org/1999/xlink',
   xml: 'http://www.w3.org/XML/1998/namespace',
 };
 
-var SVGDOMPropertyConfig = {
+const SVGDOMPropertyConfig = {
   Properties: {
     clipPath: null,
     fillOpacity: null,

--- a/src/renderers/dom/shared/__tests__/CSSProperty-test.js
+++ b/src/renderers/dom/shared/__tests__/CSSProperty-test.js
@@ -12,7 +12,7 @@
 'use strict';
 
 describe('CSSProperty', function() {
-  var CSSProperty;
+  let CSSProperty;
 
   beforeEach(function() {
     jest.resetModuleRegistry();

--- a/src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
@@ -11,12 +11,12 @@
 
 'use strict';
 
-var React = require('React');
-var ReactDOM = require('ReactDOM');
-var ReactDOMServer = require('ReactDOMServer');
+const React = require('React');
+const ReactDOM = require('ReactDOM');
+const ReactDOMServer = require('ReactDOMServer');
 
 describe('CSSPropertyOperations', function() {
-  var CSSPropertyOperations;
+  let CSSPropertyOperations;
 
   beforeEach(function() {
     jest.resetModuleRegistry();
@@ -69,10 +69,10 @@ describe('CSSPropertyOperations', function() {
   });
 
   it('should not append `px` to styles that might need a number', function() {
-    var CSSProperty = require('CSSProperty');
-    var unitlessProperties = Object.keys(CSSProperty.isUnitlessNumber);
+    const CSSProperty = require('CSSProperty');
+    const unitlessProperties = Object.keys(CSSProperty.isUnitlessNumber);
     unitlessProperties.forEach(function(property) {
-      var styles = {};
+      const styles = {};
       styles[property] = 1;
       expect(CSSPropertyOperations.createMarkupForStyles(styles))
         .toMatch(/:1;$/);
@@ -87,23 +87,23 @@ describe('CSSPropertyOperations', function() {
   });
 
   it('should set style attribute when styles exist', function() {
-    var styles = {
+    const styles = {
       backgroundColor: '#000',
       display: 'none',
     };
-    var div = <div style={styles} />;
-    var root = document.createElement('div');
+    let div = <div style={styles} />;
+    const root = document.createElement('div');
     div = ReactDOM.render(div, root);
     expect(/style=".*"/.test(root.innerHTML)).toBe(true);
   });
 
   it('should not set style attribute when no styles exist', function() {
-    var styles = {
+    const styles = {
       backgroundColor: null,
       display: null,
     };
-    var div = <div style={styles} />;
-    var html = ReactDOMServer.renderToString(div);
+    const div = <div style={styles} />;
+    const html = ReactDOMServer.renderToString(div);
     expect(/style=/.test(html)).toBe(false);
   });
 
@@ -121,8 +121,8 @@ describe('CSSPropertyOperations', function() {
   it('should warn when updating hyphenated style names', function() {
     spyOn(console, 'error');
 
-    var root = document.createElement('div');
-    var styles = {
+    const root = document.createElement('div');
+    const styles = {
       '-ms-transform': 'translate3d(0, 0, 0)',
       '-webkit-transform': 'translate3d(0, 0, 0)',
     };

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -12,12 +12,12 @@
 'use strict';
 
 describe('DOMPropertyOperations', function() {
-  var DOMPropertyOperations;
-  var DOMProperty;
+  let DOMPropertyOperations;
+  let DOMProperty;
 
   beforeEach(function() {
     jest.resetModuleRegistry();
-    var ReactDefaultInjection = require('ReactDefaultInjection');
+    const ReactDefaultInjection = require('ReactDefaultInjection');
     ReactDefaultInjection.inject();
 
     DOMPropertyOperations = require('DOMPropertyOperations');
@@ -171,7 +171,7 @@ describe('DOMPropertyOperations', function() {
   });
 
   describe('setValueForProperty', function() {
-    var stubNode;
+    let stubNode;
 
     beforeEach(function() {
       stubNode = document.createElement('div');
@@ -212,7 +212,7 @@ describe('DOMPropertyOperations', function() {
     it('should convert attribute values to string first', function() {
       // Browsers default to this behavior, but some test environments do not.
       // This ensures that we have consistent behavior.
-      var obj = {
+      const obj = {
         toString: function() {
           return '<html>';
         },
@@ -246,7 +246,7 @@ describe('DOMPropertyOperations', function() {
     });
 
     it('should use mutation method where applicable', function() {
-      var foobarSetter = jest.genMockFn();
+      const foobarSetter = jest.genMockFn();
       // inject foobar DOM property
       DOMProperty.injection.injectDOMPropertyConfig({
         Properties: {foobar: null},
@@ -334,7 +334,7 @@ describe('DOMPropertyOperations', function() {
   });
 
   describe('deleteValueForProperty', function() {
-    var stubNode;
+    let stubNode;
 
     beforeEach(function() {
       stubNode = document.createElement('div');

--- a/src/renderers/dom/shared/__tests__/Danger-test.js
+++ b/src/renderers/dom/shared/__tests__/Danger-test.js
@@ -14,7 +14,7 @@
 describe('Danger', function() {
 
   describe('dangerouslyRenderMarkup', function() {
-    var Danger;
+    let Danger;
 
     beforeEach(function() {
       jest.resetModuleRegistry();
@@ -22,29 +22,29 @@ describe('Danger', function() {
     });
 
     it('should render markup', function() {
-      var markup = '<div data-reactid=".rX"></div>';
-      var output = Danger.dangerouslyRenderMarkup([markup])[0];
+      const markup = '<div data-reactid=".rX"></div>';
+      const output = Danger.dangerouslyRenderMarkup([markup])[0];
 
       expect(output.nodeName).toBe('DIV');
     });
 
     it('should render markup with props', function() {
-      var markup = '<div class="foo" data-reactid=".rX"></div>';
-      var output = Danger.dangerouslyRenderMarkup([markup])[0];
+      const markup = '<div class="foo" data-reactid=".rX"></div>';
+      const output = Danger.dangerouslyRenderMarkup([markup])[0];
 
       expect(output.nodeName).toBe('DIV');
       expect(output.className).toBe('foo');
     });
 
     it('should render wrapped markup', function() {
-      var markup = '<th data-reactid=".rX"></th>';
-      var output = Danger.dangerouslyRenderMarkup([markup])[0];
+      const markup = '<th data-reactid=".rX"></th>';
+      const output = Danger.dangerouslyRenderMarkup([markup])[0];
 
       expect(output.nodeName).toBe('TH');
     });
 
     it('should render lists of markup with similar `nodeName`', function() {
-      var renderedMarkup = Danger.dangerouslyRenderMarkup(
+      const renderedMarkup = Danger.dangerouslyRenderMarkup(
         ['<p id="A">1</p>', '<p id="B">2</p>', '<p id="C">3</p>']
       );
 
@@ -60,7 +60,7 @@ describe('Danger', function() {
     });
 
     it('should render lists of markup with different `nodeName`', function() {
-      var renderedMarkup = Danger.dangerouslyRenderMarkup(
+      const renderedMarkup = Danger.dangerouslyRenderMarkup(
         ['<p id="A">1</p>', '<td id="B">2</td>', '<p id="C">3</p>']
       );
 
@@ -84,8 +84,8 @@ describe('Danger', function() {
 
       spyOn(console, 'error');
 
-      var renderedMarkup = Danger.dangerouslyRenderMarkup(['<p></p><p></p>']);
-      var args = console.error.argsForCall[0];
+      const renderedMarkup = Danger.dangerouslyRenderMarkup(['<p></p><p></p>']);
+      const args = console.error.argsForCall[0];
 
       expect(renderedMarkup.length).toBe(1);
       expect(renderedMarkup[0].nodeName).toBe('P');

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -11,14 +11,14 @@
 
 'use strict';
 
-var assign = require('Object.assign');
+const assign = require('Object.assign');
 
 describe('ReactDOMComponent', function() {
-  var React;
+  let React;
 
-  var ReactDOM;
-  var ReactDOMFeatureFlags;
-  var ReactDOMServer;
+  let ReactDOM;
+  let ReactDOMFeatureFlags;
+  let ReactDOMServer;
 
   beforeEach(function() {
     jest.resetModuleRegistry();
@@ -29,14 +29,14 @@ describe('ReactDOMComponent', function() {
   });
 
   describe('updateDOM', function() {
-    var ReactTestUtils;
+    let ReactTestUtils;
 
     beforeEach(function() {
       ReactTestUtils = require('ReactTestUtils');
     });
 
     it('should handle className', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(<div style={{}} />, container);
 
       ReactDOM.render(<div className={'foo'} />, container);
@@ -48,19 +48,19 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should gracefully handle various style value types', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(<div style={{}} />, container);
-      var stubStyle = container.firstChild.style;
+      const stubStyle = container.firstChild.style;
 
       // set initial style
-      var setup = {display: 'block', left: '1px', top: 2, fontFamily: 'Arial'};
+      const setup = {display: 'block', left: '1px', top: 2, fontFamily: 'Arial'};
       ReactDOM.render(<div style={setup} />, container);
       expect(stubStyle.display).toEqual('block');
       expect(stubStyle.left).toEqual('1px');
       expect(stubStyle.fontFamily).toEqual('Arial');
 
       // reset the style to their default state
-      var reset = {display: '', left: null, top: false, fontFamily: true};
+      const reset = {display: '', left: null, top: false, fontFamily: true};
       ReactDOM.render(<div style={reset} />, container);
       expect(stubStyle.display).toEqual('');
       expect(stubStyle.left).toEqual('');
@@ -73,11 +73,11 @@ describe('ReactDOMComponent', function() {
       // not actually used. Just to suppress the style mutation warning
       spyOn(console, 'error');
 
-      var styles = {display: 'none', fontFamily: 'Arial', lineHeight: 1.2};
-      var container = document.createElement('div');
+      const styles = {display: 'none', fontFamily: 'Arial', lineHeight: 1.2};
+      const container = document.createElement('div');
       ReactDOM.render(<div style={styles} />, container);
 
-      var stubStyle = container.firstChild.style;
+      const stubStyle = container.firstChild.style;
       stubStyle.display = styles.display;
       stubStyle.fontFamily = styles.fontFamily;
 
@@ -111,8 +111,8 @@ describe('ReactDOMComponent', function() {
     it('should warn when mutating style', function() {
       spyOn(console, 'error');
 
-      var style = {border: '1px solid black'};
-      var App = React.createClass({
+      let style = {border: '1px solid black'};
+      const App = React.createClass({
         getInitialState: function() {
           return {style: style};
         },
@@ -121,7 +121,7 @@ describe('ReactDOMComponent', function() {
         },
       });
 
-      var stub = ReactTestUtils.renderIntoDocument(<App />);
+      let stub = ReactTestUtils.renderIntoDocument(<App />);
       style.position = 'absolute';
       stub.setState({style: style});
       expect(console.error.argsForCall.length).toBe(1);
@@ -141,7 +141,7 @@ describe('ReactDOMComponent', function() {
       expect(console.error.argsForCall.length).toBe(1);
 
       style = {background: 'red'};
-      var div = document.createElement('div');
+      const div = document.createElement('div');
       ReactDOM.render(<span style={style}></span>, div);
       style.background = 'blue';
       ReactDOM.render(<span style={style}></span>, div);
@@ -151,15 +151,15 @@ describe('ReactDOMComponent', function() {
     it('should warn about styles with numeric string values for non-unitless properties', function() {
       spyOn(console, 'error');
 
-      var div = document.createElement('div');
-      var One = React.createClass({
+      const div = document.createElement('div');
+      const One = React.createClass({
         render: function() {
           return this.props.inline ?
             <span style={{fontSize: '1'}} /> :
             <div style={{fontSize: '1'}} />;
         },
       });
-      var Two = React.createClass({
+      const Two = React.createClass({
         render: function() {
           return <div style={{fontSize: '1'}} />;
         },
@@ -193,8 +193,8 @@ describe('ReactDOMComponent', function() {
     it('should warn semi-nicely about NaN in style', function() {
       spyOn(console, 'error');
 
-      var style = {fontSize: NaN};
-      var div = document.createElement('div');
+      const style = {fontSize: NaN};
+      const div = document.createElement('div');
       ReactDOM.render(<span style={style}></span>, div);
       ReactDOM.render(<span style={style}></span>, div);
 
@@ -211,11 +211,11 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should update styles if initially null', function() {
-      var styles = null;
-      var container = document.createElement('div');
+      let styles = null;
+      const container = document.createElement('div');
       ReactDOM.render(<div style={styles} />, container);
 
-      var stubStyle = container.firstChild.style;
+      const stubStyle = container.firstChild.style;
 
       styles = {display: 'block'};
 
@@ -224,12 +224,12 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should update styles if updated to null multiple times', function() {
-      var styles = null;
-      var container = document.createElement('div');
+      let styles = null;
+      const container = document.createElement('div');
       ReactDOM.render(<div style={styles} />, container);
 
       styles = {display: 'block'};
-      var stubStyle = container.firstChild.style;
+      const stubStyle = container.firstChild.style;
 
       ReactDOM.render(<div style={styles} />, container);
       expect(stubStyle.display).toEqual('block');
@@ -245,7 +245,7 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should skip child object attribute on web components', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
 
       // Test initial render to null
       ReactDOM.render(<my-component children={['foo']} />, container);
@@ -257,7 +257,7 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should remove attributes', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(<img height="17" />, container);
 
       expect(container.firstChild.hasAttribute('height')).toBe(true);
@@ -266,7 +266,7 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should remove known SVG camel case attributes', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(<svg viewBox="0 0 100 100" />, container);
 
       expect(container.firstChild.hasAttribute('viewBox')).toBe(true);
@@ -275,7 +275,7 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should remove known SVG hyphenated attributes', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(<svg clip-path="0 0 100 100" />, container);
 
       expect(container.firstChild.hasAttribute('clip-path')).toBe(true);
@@ -284,7 +284,7 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should remove arbitrary SVG hyphenated attributes', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(<svg the-word="the-bird" />, container);
 
       expect(container.firstChild.hasAttribute('the-word')).toBe(true);
@@ -293,7 +293,7 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should remove arbitrary SVG camel case attributes', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(<svg theWord="theBird" />, container);
 
       if (ReactDOMFeatureFlags.useCreateElement) {
@@ -307,7 +307,7 @@ describe('ReactDOMComponent', function() {
 
     it('should remove SVG attributes that should have been hyphenated', function() {
       spyOn(console, 'error');
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(<svg clipPath="0 0 100 100" />, container);
       expect(console.error.argsForCall.length).toBe(1);
       expect(console.error.argsForCall[0][0]).toContain('clipPath');
@@ -319,7 +319,7 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should remove namespaced SVG attributes', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(
         <svg>
           <image xlinkHref="http://i.imgur.com/w7GCRPb.png" />
@@ -339,7 +339,7 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should remove properties', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(<div className="monkey" />, container);
 
       expect(container.firstChild.className).toEqual('monkey');
@@ -348,11 +348,11 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should clear a single style prop when changing `style`', function() {
-      var styles = {display: 'none', color: 'red'};
-      var container = document.createElement('div');
+      let styles = {display: 'none', color: 'red'};
+      const container = document.createElement('div');
       ReactDOM.render(<div style={styles} />, container);
 
-      var stubStyle = container.firstChild.style;
+      const stubStyle = container.firstChild.style;
 
       styles = {color: 'green'};
       ReactDOM.render(<div style={styles} />, container);
@@ -362,9 +362,9 @@ describe('ReactDOMComponent', function() {
 
     it('should reject attribute key injection attack on markup', function() {
       spyOn(console, 'error');
-      for (var i = 0; i < 3; i++) {
-        var container = document.createElement('div');
-        var element = React.createElement(
+      for (let i = 0; i < 3; i++) {
+        const container = document.createElement('div');
+        const element = React.createElement(
           'x-foo-component',
           {'blah" onclick="beevil" noise="hi': 'selected'},
           null
@@ -379,12 +379,12 @@ describe('ReactDOMComponent', function() {
 
     it('should reject attribute key injection attack on update', function() {
       spyOn(console, 'error');
-      for (var i = 0; i < 3; i++) {
-        var container = document.createElement('div');
-        var beforeUpdate = React.createElement('x-foo-component', {}, null);
+      for (let i = 0; i < 3; i++) {
+        const container = document.createElement('div');
+        const beforeUpdate = React.createElement('x-foo-component', {}, null);
         ReactDOM.render(beforeUpdate, container);
 
-        var afterUpdate = React.createElement(
+        const afterUpdate = React.createElement(
           'x-foo-component',
           {'blah" onclick="beevil" noise="hi': 'selected'},
           null
@@ -398,24 +398,24 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should update arbitrary attributes for tags containing dashes', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
 
-      var beforeUpdate = React.createElement('x-foo-component', {}, null);
+      const beforeUpdate = React.createElement('x-foo-component', {}, null);
       ReactDOM.render(beforeUpdate, container);
 
-      var afterUpdate = <x-foo-component myattr="myval" />;
+      const afterUpdate = <x-foo-component myattr="myval" />;
       ReactDOM.render(afterUpdate, container);
 
       expect(container.childNodes[0].getAttribute('myattr')).toBe('myval');
     });
 
     it('should update known hyphenated attributes for SVG tags', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
 
-      var beforeUpdate = <svg />;
+      const beforeUpdate = <svg />;
       ReactDOM.render(beforeUpdate, container);
 
-      var afterUpdate = <svg clip-path="url(#starlet)" />;
+      const afterUpdate = <svg clip-path="url(#starlet)" />;
       ReactDOM.render(afterUpdate, container);
 
       expect(container.childNodes[0].getAttribute('clip-path')).toBe(
@@ -424,12 +424,12 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should update camel case attributes for SVG tags', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
 
-      var beforeUpdate = <svg />;
+      const beforeUpdate = <svg />;
       ReactDOM.render(beforeUpdate, container);
 
-      var afterUpdate = <svg viewBox="0 0 100 100" />;
+      const afterUpdate = <svg viewBox="0 0 100 100" />;
       ReactDOM.render(afterUpdate, container);
 
       expect(container.childNodes[0].getAttribute('viewBox')).toBe(
@@ -439,12 +439,12 @@ describe('ReactDOMComponent', function() {
 
     it('should warn camel casing hyphenated attributes for SVG tags', function() {
       spyOn(console, 'error');
-      var container = document.createElement('div');
+      const container = document.createElement('div');
 
-      var beforeUpdate = <svg />;
+      const beforeUpdate = <svg />;
       ReactDOM.render(beforeUpdate, container);
 
-      var afterUpdate = <svg clipPath="url(#starlet)" />;
+      const afterUpdate = <svg clipPath="url(#starlet)" />;
       ReactDOM.render(afterUpdate, container);
 
       expect(container.childNodes[0].getAttribute('clip-path')).toBe(
@@ -456,40 +456,40 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should update arbitrary hyphenated attributes for SVG tags', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
 
-      var beforeUpdate = <svg />;
+      const beforeUpdate = <svg />;
       ReactDOM.render(beforeUpdate, container);
 
-      var afterUpdate = <svg the-word="the-bird" />;
+      const afterUpdate = <svg the-word="the-bird" />;
       ReactDOM.render(afterUpdate, container);
 
       expect(container.childNodes[0].getAttribute('the-word')).toBe('the-bird');
     });
 
     it('should update arbitrary camel case attributes for SVG tags', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
 
-      var beforeUpdate = <svg />;
+      const beforeUpdate = <svg />;
       ReactDOM.render(beforeUpdate, container);
 
-      var afterUpdate = <svg theWord="theBird" />;
+      const afterUpdate = <svg theWord="theBird" />;
       ReactDOM.render(afterUpdate, container);
 
       expect(container.childNodes[0].getAttribute('theWord')).toBe('theBird');
     });
 
     it('should update namespaced SVG attributes', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
 
-      var beforeUpdate = (
+      const beforeUpdate = (
         <svg>
           <image xlinkHref="http://i.imgur.com/w7GCRPb.png" />
         </svg>
       );
       ReactDOM.render(beforeUpdate, container);
 
-      var afterUpdate = (
+      const afterUpdate = (
         <svg>
           <image xlinkHref="http://i.imgur.com/JvqCM2p.png" />
         </svg>
@@ -503,11 +503,11 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should clear all the styles when removing `style`', function() {
-      var styles = {display: 'none', color: 'red'};
-      var container = document.createElement('div');
+      const styles = {display: 'none', color: 'red'};
+      const container = document.createElement('div');
       ReactDOM.render(<div style={styles} />, container);
 
-      var stubStyle = container.firstChild.style;
+      const stubStyle = container.firstChild.style;
 
       ReactDOM.render(<div />, container);
       expect(stubStyle.display).toEqual('');
@@ -515,18 +515,18 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should update styles when `style` changes from null to object', function() {
-      var container = document.createElement('div');
-      var styles = {color: 'red'};
+      const container = document.createElement('div');
+      const styles = {color: 'red'};
       ReactDOM.render(<div style={styles} />, container);
       ReactDOM.render(<div />, container);
       ReactDOM.render(<div style={styles} />, container);
 
-      var stubStyle = container.firstChild.style;
+      const stubStyle = container.firstChild.style;
       expect(stubStyle.color).toEqual('red');
     });
 
     it('should empty element when removing innerHTML', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(<div dangerouslySetInnerHTML={{__html: ':)'}} />, container);
 
       expect(container.firstChild.innerHTML).toEqual(':)');
@@ -535,7 +535,7 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should transition from string content to innerHTML', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(<div>hello</div>, container);
 
       expect(container.firstChild.innerHTML).toEqual('hello');
@@ -547,7 +547,7 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should transition from innerHTML to string content', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(
         <div dangerouslySetInnerHTML={{__html: 'bonjour'}} />,
         container
@@ -559,7 +559,7 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should transition from innerHTML to children in nested el', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(
         <div><div dangerouslySetInnerHTML={{__html: 'bonjour'}} /></div>,
         container
@@ -571,7 +571,7 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should transition from children to innerHTML in nested el', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(<div><div><span>adieu</span></div></div>, container);
 
       expect(container.textContent).toEqual('adieu');
@@ -583,15 +583,15 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should not incur unnecessary DOM mutations for attributes', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(<div id="" />, container);
 
-      var node = container.firstChild;
-      var nodeSetAttribute = node.setAttribute;
+      const node = container.firstChild;
+      const nodeSetAttribute = node.setAttribute;
       node.setAttribute = jest.genMockFn();
       node.setAttribute.mockImpl(nodeSetAttribute);
 
-      var nodeRemoveAttribute = node.removeAttribute;
+      const nodeRemoveAttribute = node.removeAttribute;
       node.removeAttribute = jest.genMockFn();
       node.removeAttribute.mockImpl(nodeRemoveAttribute);
 
@@ -621,12 +621,12 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should not incur unnecessary DOM mutations for string properties', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(<div value="" />, container);
 
-      var node = container.firstChild;
-      var nodeValue = ''; // node.value always returns undefined
-      var nodeValueSetter = jest.genMockFn();
+      const node = container.firstChild;
+      let nodeValue = ''; // node.value always returns undefined
+      const nodeValueSetter = jest.genMockFn();
       Object.defineProperty(node, 'value', {
         get: function() {
           return nodeValue;
@@ -659,12 +659,12 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should not incur unnecessary DOM mutations for boolean properties', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(<div checked={true} />, container);
 
-      var node = container.firstChild;
-      var nodeValue = true;
-      var nodeValueSetter = jest.genMockFn();
+      const node = container.firstChild;
+      let nodeValue = true;
+      const nodeValueSetter = jest.genMockFn();
       Object.defineProperty(node, 'checked', {
         get: function() {
           return nodeValue;
@@ -688,16 +688,16 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should ignore attribute whitelist for elements with the "is: attribute', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(<button is="test" cowabunga="chevynova"/>, container);
       expect(container.firstChild.hasAttribute('cowabunga')).toBe(true);
     });
 
     it('should not update when switching between null/undefined', function() {
-      var container = document.createElement('div');
-      var node = ReactDOM.render(<div />, container);
+      const container = document.createElement('div');
+      const node = ReactDOM.render(<div />, container);
 
-      var setter = jest.genMockFn();
+      const setter = jest.genMockFn();
       node.setAttribute = setter;
 
       ReactDOM.render(<div dir={null} />, container);
@@ -712,7 +712,7 @@ describe('ReactDOMComponent', function() {
       // This test might look like it's just testing ReactMultiChild but the
       // last bug in this was actually in DOMChildrenOperations so this test
       // needs to be in some DOM-specific test file.
-      var container = document.createElement('div');
+      const container = document.createElement('div');
 
       // ABCD
       ReactDOM.render(
@@ -744,27 +744,27 @@ describe('ReactDOMComponent', function() {
   });
 
   describe('createOpenTagMarkup', function() {
-    var genMarkup;
+    let genMarkup;
 
     function quoteRegexp(str) {
       return (str + '').replace(/([.?*+\^$\[\]\\(){}|-])/g, '\\$1');
     }
 
     beforeEach(function() {
-      var ReactDefaultInjection = require('ReactDefaultInjection');
+      const ReactDefaultInjection = require('ReactDefaultInjection');
       ReactDefaultInjection.inject();
 
-      var ReactDOMComponent = require('ReactDOMComponent');
-      var ReactReconcileTransaction = require('ReactReconcileTransaction');
+      const ReactDOMComponent = require('ReactDOMComponent');
+      const ReactReconcileTransaction = require('ReactReconcileTransaction');
 
-      var NodeStub = function(initialProps) {
+      const NodeStub = function(initialProps) {
         this._currentElement = {props: initialProps};
         this._rootNodeID = 'test';
       };
       assign(NodeStub.prototype, ReactDOMComponent.Mixin);
 
       genMarkup = function(props) {
-        var transaction = new ReactReconcileTransaction();
+        const transaction = new ReactReconcileTransaction();
         return (new NodeStub(props))._createOpenTagMarkupAndPutListeners(
           transaction,
           props
@@ -773,7 +773,7 @@ describe('ReactDOMComponent', function() {
 
       this.addMatchers({
         toHaveAttribute: function(attr, value) {
-          var expected = '(?:^|\\s)' + attr + '=[\\\'"]';
+          let expected = '(?:^|\\s)' + attr + '=[\\\'"]';
           if (typeof value !== 'undefined') {
             expected += quoteRegexp(value) + '[\\\'"]';
           }
@@ -796,24 +796,24 @@ describe('ReactDOMComponent', function() {
   });
 
   describe('createContentMarkup', function() {
-    var genMarkup;
+    let genMarkup;
 
     function quoteRegexp(str) {
       return (str + '').replace(/([.?*+\^$\[\]\\(){}|-])/g, '\\$1');
     }
 
     beforeEach(function() {
-      var ReactDOMComponent = require('ReactDOMComponent');
-      var ReactReconcileTransaction = require('ReactReconcileTransaction');
+      const ReactDOMComponent = require('ReactDOMComponent');
+      const ReactReconcileTransaction = require('ReactReconcileTransaction');
 
-      var NodeStub = function(initialProps) {
+      const NodeStub = function(initialProps) {
         this._currentElement = {props: initialProps};
         this._rootNodeID = 'test';
       };
       assign(NodeStub.prototype, ReactDOMComponent.Mixin);
 
       genMarkup = function(props) {
-        var transaction = new ReactReconcileTransaction();
+        const transaction = new ReactReconcileTransaction();
         return (new NodeStub(props))._createContentMarkup(
           transaction,
           props,
@@ -823,14 +823,14 @@ describe('ReactDOMComponent', function() {
 
       this.addMatchers({
         toHaveInnerhtml: function(html) {
-          var expected = '^' + quoteRegexp(html) + '$';
+          const expected = '^' + quoteRegexp(html) + '$';
           return this.actual.match(new RegExp(expected));
         },
       });
     });
 
     it('should handle dangerouslySetInnerHTML', function() {
-      var innerHTML = {__html: 'testContent'};
+      const innerHTML = {__html: 'testContent'};
       expect(
         genMarkup({dangerouslySetInnerHTML: innerHTML})
       ).toHaveInnerhtml('testContent');
@@ -838,27 +838,27 @@ describe('ReactDOMComponent', function() {
   });
 
   describe('mountComponent', function() {
-    var mountComponent;
+    let mountComponent;
 
     beforeEach(function() {
       mountComponent = function(props) {
-        var container = document.createElement('div');
+        const container = document.createElement('div');
         ReactDOM.render(<div {...props} />, container);
       };
     });
 
     it('should not duplicate uppercased selfclosing tags', function() {
-      var Container = React.createClass({
+      const Container = React.createClass({
         render: function() {
           return React.createElement('BR', null);
         },
       });
-      var returnedValue = ReactDOMServer.renderToString(<Container/>);
+      const returnedValue = ReactDOMServer.renderToString(<Container/>);
       expect(returnedValue).not.toContain('</BR>');
     });
 
     it('should warn against children for void elements', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
 
       expect(function() {
         ReactDOM.render(<input>children</input>, container);
@@ -869,7 +869,7 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should warn against dangerouslySetInnerHTML for void elements', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
 
       expect(function() {
         ReactDOM.render(
@@ -883,9 +883,9 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should treat menuitem as a void element but still create the closing tag', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
 
-      var returnedValue = ReactDOMServer.renderToString(<menu><menuitem /></menu>);
+      const returnedValue = ReactDOMServer.renderToString(<menu><menuitem /></menu>);
 
       expect(returnedValue).toContain('</menuitem>');
 
@@ -958,12 +958,12 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should execute custom event plugin listening behavior', function() {
-      var SimpleEventPlugin = require('SimpleEventPlugin');
+      const SimpleEventPlugin = require('SimpleEventPlugin');
 
       SimpleEventPlugin.didPutListener = jest.genMockFn();
       SimpleEventPlugin.willDeleteListener = jest.genMockFn();
 
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(
         <div onClick={() => true} />,
         container
@@ -977,11 +977,11 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should handle null and missing properly with event hooks', function() {
-      var SimpleEventPlugin = require('SimpleEventPlugin');
+      const SimpleEventPlugin = require('SimpleEventPlugin');
 
       SimpleEventPlugin.didPutListener = jest.genMockFn();
       SimpleEventPlugin.willDeleteListener = jest.genMockFn();
-      var container = document.createElement('div');
+      const container = document.createElement('div');
 
       ReactDOM.render(<div onClick={false} />, container);
       expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(0);
@@ -1013,13 +1013,13 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should warn for children on void elements', function() {
-      var X = React.createClass({
+      const X = React.createClass({
         render: function() {
           return <input>moo</input>;
         },
       });
 
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       expect(function() {
         ReactDOM.render(<X />, container);
       }).toThrow(
@@ -1030,7 +1030,7 @@ describe('ReactDOMComponent', function() {
   });
 
   describe('updateComponent', function() {
-    var container;
+    let container;
 
     beforeEach(function() {
       container = document.createElement('div');
@@ -1097,7 +1097,7 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should report component containing invalid styles', function() {
-      var Animal = React.createClass({
+      const Animal = React.createClass({
         render: function() {
           return <div style={1}></div>;
         },
@@ -1132,18 +1132,18 @@ describe('ReactDOMComponent', function() {
 
   describe('unmountComponent', function() {
     it('should clean up listeners', function() {
-      var EventPluginHub = require('EventPluginHub');
-      var ReactDOMComponentTree = require('ReactDOMComponentTree');
+      const EventPluginHub = require('EventPluginHub');
+      const ReactDOMComponentTree = require('ReactDOMComponentTree');
 
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       document.body.appendChild(container);
 
-      var callback = function() {};
-      var instance = <div onClick={callback} />;
+      const callback = function() {};
+      let instance = <div onClick={callback} />;
       instance = ReactDOM.render(instance, container);
 
-      var rootNode = ReactDOM.findDOMNode(instance);
-      var inst = ReactDOMComponentTree.getInstanceFromNode(rootNode);
+      const rootNode = ReactDOM.findDOMNode(instance);
+      const inst = ReactDOMComponentTree.getInstanceFromNode(rootNode);
       expect(
         EventPluginHub.getListener(inst, 'onClick')
       ).toBe(callback);
@@ -1157,7 +1157,7 @@ describe('ReactDOMComponent', function() {
     });
 
     it('unmounts children before unsetting DOM node info', function() {
-      var Inner = React.createClass({
+      const Inner = React.createClass({
         render: function() {
           return <span />;
         },
@@ -1167,7 +1167,7 @@ describe('ReactDOMComponent', function() {
         },
       });
 
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(<div><Inner /></div>, container);
       ReactDOM.unmountComponentAtNode(container);
     });
@@ -1179,10 +1179,10 @@ describe('ReactDOMComponent', function() {
       // before React so it's pre-mocked before React would require it.
       jest.resetModuleRegistry()
         .mock('isEventSupported');
-      var isEventSupported = require('isEventSupported');
+      const isEventSupported = require('isEventSupported');
       isEventSupported.mockReturnValueOnce(false);
 
-      var ReactTestUtils = require('ReactTestUtils');
+      const ReactTestUtils = require('ReactTestUtils');
 
       spyOn(console, 'error');
       ReactTestUtils.renderIntoDocument(<div onScroll={function() {}} />);
@@ -1195,8 +1195,8 @@ describe('ReactDOMComponent', function() {
 
   describe('tag sanitization', function() {
     it('should throw when an invalid tag name is used', () => {
-      var ReactTestUtils = require('ReactTestUtils');
-      var hackzor = React.createElement('script tag');
+      const ReactTestUtils = require('ReactTestUtils');
+      const hackzor = React.createElement('script tag');
       expect(
         () => ReactTestUtils.renderIntoDocument(hackzor)
       ).toThrow(
@@ -1205,8 +1205,8 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should throw when an attack vector is used', () => {
-      var ReactTestUtils = require('ReactTestUtils');
-      var hackzor = React.createElement('div><img /><div');
+      const ReactTestUtils = require('ReactTestUtils');
+      const hackzor = React.createElement('div><img /><div');
       expect(
         () => ReactTestUtils.renderIntoDocument(hackzor)
       ).toThrow(
@@ -1216,7 +1216,7 @@ describe('ReactDOMComponent', function() {
   });
 
   describe('nesting validation', function() {
-    var ReactTestUtils;
+    let ReactTestUtils;
 
     beforeEach(function() {
       ReactTestUtils = require('ReactTestUtils');
@@ -1235,7 +1235,7 @@ describe('ReactDOMComponent', function() {
 
     it('warns on invalid nesting at root', () => {
       spyOn(console, 'error');
-      var p = document.createElement('p');
+      const p = document.createElement('p');
       ReactDOM.render(<span><p /></span>, p);
 
       expect(console.error.calls.length).toBe(1);
@@ -1247,12 +1247,12 @@ describe('ReactDOMComponent', function() {
 
     it('warns nicely for table rows', () => {
       spyOn(console, 'error');
-      var Row = React.createClass({
+      const Row = React.createClass({
         render: function() {
           return <tr />;
         },
       });
-      var Foo = React.createClass({
+      const Foo = React.createClass({
         render: function() {
           return <table><Row /> </table>;
         },
@@ -1273,27 +1273,27 @@ describe('ReactDOMComponent', function() {
 
     it('gives useful context in warnings', () => {
       spyOn(console, 'error');
-      var Row = React.createClass({
+      const Row = React.createClass({
         render: () => <tr />,
       });
-      var FancyRow = React.createClass({
+      const FancyRow = React.createClass({
         render: () => <Row />,
       });
-      var Table = React.createClass({
+      const Table = React.createClass({
         render: function() {
           return <table>{this.props.children}</table>;
         },
       });
-      var FancyTable = React.createClass({
+      const FancyTable = React.createClass({
         render: function() {
           return <Table>{this.props.children}</Table>;
         },
       });
 
-      var Viz1 = React.createClass({
+      const Viz1 = React.createClass({
         render: () => <table><FancyRow /></table>,
       });
-      var App1 = React.createClass({
+      const App1 = React.createClass({
         render: () => <Viz1 />,
       });
       ReactTestUtils.renderIntoDocument(<App1 />);
@@ -1302,10 +1302,10 @@ describe('ReactDOMComponent', function() {
         'See Viz1 > table > FancyRow > Row > tr.'
       );
 
-      var Viz2 = React.createClass({
+      const Viz2 = React.createClass({
         render: () => <FancyTable><FancyRow /></FancyTable>,
       });
-      var App2 = React.createClass({
+      const App2 = React.createClass({
         render: () => <Viz2 />,
       });
       ReactTestUtils.renderIntoDocument(<App2 />);
@@ -1332,7 +1332,7 @@ describe('ReactDOMComponent', function() {
         'See FancyTable > Table > table > tr.'
       );
 
-      var Link = React.createClass({
+      const Link = React.createClass({
         render: function() {
           return <a>{this.props.children}</a>;
         },

--- a/src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
-var ReactDOMServer;
+let React;
+let ReactDOM;
+let ReactDOMServer;
 
 describe('ReactDOMTextComponent', function() {
   beforeEach(function() {
@@ -23,11 +23,11 @@ describe('ReactDOMTextComponent', function() {
   });
 
   it('updates a mounted text component in place', function() {
-    var el = document.createElement('div');
-    var inst = ReactDOM.render(<div><span />{'foo'}{'bar'}</div>, el);
+    const el = document.createElement('div');
+    let inst = ReactDOM.render(<div><span />{'foo'}{'bar'}</div>, el);
 
-    var foo = ReactDOM.findDOMNode(inst).childNodes[2];
-    var bar = ReactDOM.findDOMNode(inst).childNodes[5];
+    const foo = ReactDOM.findDOMNode(inst).childNodes[2];
+    const bar = ReactDOM.findDOMNode(inst).childNodes[5];
     expect(foo.data).toBe('foo');
     expect(bar.data).toBe('bar');
 
@@ -41,11 +41,11 @@ describe('ReactDOMTextComponent', function() {
   });
 
   it('can be toggled in and out of the markup', function() {
-    var el = document.createElement('div');
-    var inst = ReactDOM.render(<div>{'foo'}<div />{'bar'}</div>, el);
+    const el = document.createElement('div');
+    let inst = ReactDOM.render(<div>{'foo'}<div />{'bar'}</div>, el);
 
-    var container = ReactDOM.findDOMNode(inst);
-    var childDiv = container.childNodes[3];
+    let container = ReactDOM.findDOMNode(inst);
+    const childDiv = container.childNodes[3];
     var childNodes;
 
     inst = ReactDOM.render(<div>{null}<div />{null}</div>, el);
@@ -64,10 +64,10 @@ describe('ReactDOMTextComponent', function() {
   });
 
   it('can reconcile text merged by Node.normalize()', function() {
-    var el = document.createElement('div');
-    var inst = ReactDOM.render(<div>{'foo'}{'bar'}{'baz'}</div>, el);
+    const el = document.createElement('div');
+    let inst = ReactDOM.render(<div>{'foo'}{'bar'}{'baz'}</div>, el);
 
-    var container = ReactDOM.findDOMNode(inst);
+    let container = ReactDOM.findDOMNode(inst);
     container.normalize();
 
     inst = ReactDOM.render(<div>{'bar'}{'baz'}{'qux'}</div>, el);
@@ -76,8 +76,8 @@ describe('ReactDOMTextComponent', function() {
   });
 
   it('can reconcile text from pre-rendered markup', function() {
-    var el = document.createElement('div');
-    var reactEl = <div>{'foo'}{'bar'}{'baz'}</div>;
+    const el = document.createElement('div');
+    let reactEl = <div>{'foo'}{'bar'}{'baz'}</div>;
     el.innerHTML = ReactDOMServer.renderToString(reactEl);
 
     ReactDOM.render(reactEl, el);
@@ -91,12 +91,12 @@ describe('ReactDOMTextComponent', function() {
   });
 
   it('can reconcile text arbitrarily split into multiple nodes', function() {
-    var el = document.createElement('div');
-    var inst = ReactDOM.render(<div><span />{'foobarbaz'}</div>, el);
+    const el = document.createElement('div');
+    let inst = ReactDOM.render(<div><span />{'foobarbaz'}</div>, el);
 
-    var container = ReactDOM.findDOMNode(inst);
-    var childNodes = container.childNodes;
-    var textNode = childNodes[2];
+    let container = ReactDOM.findDOMNode(inst);
+    const childNodes = container.childNodes;
+    const textNode = childNodes[2];
     textNode.textContent = 'foo';
     container.insertBefore(document.createTextNode('bar'), childNodes[3]);
     container.insertBefore(document.createTextNode('baz'), childNodes[3]);

--- a/src/renderers/dom/shared/__tests__/escapeTextContentForBrowser-test.js
+++ b/src/renderers/dom/shared/__tests__/escapeTextContentForBrowser-test.js
@@ -13,7 +13,7 @@
 
 describe('escapeTextContentForBrowser', function() {
 
-  var escapeTextContentForBrowser = require('escapeTextContentForBrowser');
+  const escapeTextContentForBrowser = require('escapeTextContentForBrowser');
 
   it('should escape boolean to string', function() {
     expect(escapeTextContentForBrowser(true)).toBe('true');
@@ -21,7 +21,7 @@ describe('escapeTextContentForBrowser', function() {
   });
 
   it('should escape object to string', function() {
-    var escaped = escapeTextContentForBrowser({
+    const escaped = escapeTextContentForBrowser({
       toString: function() {
         return 'ponys';
       },
@@ -35,7 +35,7 @@ describe('escapeTextContentForBrowser', function() {
   });
 
   it('should escape string', function() {
-    var escaped = escapeTextContentForBrowser('<script type=\'\' src=""></script>');
+    let escaped = escapeTextContentForBrowser('<script type=\'\' src=""></script>');
     expect(escaped).not.toContain('<');
     expect(escaped).not.toContain('>');
     expect(escaped).not.toContain('\'');

--- a/src/renderers/dom/shared/__tests__/quoteAttributeValueForBrowser-test.js
+++ b/src/renderers/dom/shared/__tests__/quoteAttributeValueForBrowser-test.js
@@ -13,7 +13,7 @@
 
 describe('quoteAttributeValueForBrowser', function() {
 
-  var quoteAttributeValueForBrowser = require('quoteAttributeValueForBrowser');
+  const quoteAttributeValueForBrowser = require('quoteAttributeValueForBrowser');
 
   it('should escape boolean to string', function() {
     expect(quoteAttributeValueForBrowser(true)).toBe('"true"');
@@ -21,7 +21,7 @@ describe('quoteAttributeValueForBrowser', function() {
   });
 
   it('should escape object to string', function() {
-    var escaped = quoteAttributeValueForBrowser({
+    const escaped = quoteAttributeValueForBrowser({
       toString: function() {
         return 'ponys';
       },
@@ -35,7 +35,7 @@ describe('quoteAttributeValueForBrowser', function() {
   });
 
   it('should escape string', function() {
-    var escaped = quoteAttributeValueForBrowser('<script type=\'\' src=""></script>');
+    let escaped = quoteAttributeValueForBrowser('<script type=\'\' src=""></script>');
     expect(escaped).not.toContain('<');
     expect(escaped).not.toContain('>');
     expect(escaped).not.toContain('\'');

--- a/src/renderers/dom/shared/dangerousStyleValue.js
+++ b/src/renderers/dom/shared/dangerousStyleValue.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-var CSSProperty = require('CSSProperty');
-var warning = require('warning');
+const CSSProperty = require('CSSProperty');
+const warning = require('warning');
 
-var isUnitlessNumber = CSSProperty.isUnitlessNumber;
-var styleWarnings = {};
+const isUnitlessNumber = CSSProperty.isUnitlessNumber;
+const styleWarnings = {};
 
 /**
  * Convert a value into the proper css writable value. The style name `name`
@@ -38,12 +38,12 @@ function dangerousStyleValue(name, value, component) {
   // which has lead to a greater discussion about how we're going to
   // trust URLs moving forward. See #2115901
 
-  var isEmpty = value == null || typeof value === 'boolean' || value === '';
+  const isEmpty = value == null || typeof value === 'boolean' || value === '';
   if (isEmpty) {
     return '';
   }
 
-  var isNonNumeric = isNaN(value);
+  const isNonNumeric = isNaN(value);
   if (isNonNumeric || value === 0 ||
       isUnitlessNumber.hasOwnProperty(name) && isUnitlessNumber[name]) {
     return '' + value; // cast to string
@@ -52,14 +52,14 @@ function dangerousStyleValue(name, value, component) {
   if (typeof value === 'string') {
     if (__DEV__) {
       if (component) {
-        var owner = component._currentElement._owner;
-        var ownerName = owner ? owner.getName() : null;
+        const owner = component._currentElement._owner;
+        const ownerName = owner ? owner.getName() : null;
         if (ownerName && !styleWarnings[ownerName]) {
           styleWarnings[ownerName] = {};
         }
-        var warned = false;
+        let warned = false;
         if (ownerName) {
-          var warnings = styleWarnings[ownerName];
+          const warnings = styleWarnings[ownerName];
           warned = warnings[name];
           if (!warned) {
             warnings[name] = true;

--- a/src/renderers/dom/shared/devtools/ReactDOMSVGDeprecatedAttributeDevtool.js
+++ b/src/renderers/dom/shared/devtools/ReactDOMSVGDeprecatedAttributeDevtool.js
@@ -11,18 +11,18 @@
 
 'use strict';
 
-var DOMProperty = require('DOMProperty');
+const DOMProperty = require('DOMProperty');
 
-var warning = require('warning');
+const warning = require('warning');
 
 if (__DEV__) {
-  var reactProps = {
+  const reactProps = {
     children: true,
     dangerouslySetInnerHTML: true,
     key: true,
     ref: true,
   };
-  var warnedSVGAttributes = {};
+  const warnedSVGAttributes = {};
 
   var warnDeprecatedSVGAttribute = function(name) {
     if (!DOMProperty.properties.hasOwnProperty(name)) {
@@ -34,7 +34,7 @@ if (__DEV__) {
       return;
     }
 
-    var { attributeName, attributeNamespace } = DOMProperty.properties[name];
+    const { attributeName, attributeNamespace } = DOMProperty.properties[name];
     if (attributeNamespace || name === attributeName) {
       return;
     }
@@ -49,7 +49,7 @@ if (__DEV__) {
   };
 }
 
-var ReactDOMSVGDeprecatedAttributeDevtool = {
+const ReactDOMSVGDeprecatedAttributeDevtool = {
   onCreateMarkupForSVGAttribute(name, value) {
     warnDeprecatedSVGAttribute(name);
   },

--- a/src/renderers/dom/shared/devtools/ReactDOMUnknownPropertyDevtool.js
+++ b/src/renderers/dom/shared/devtools/ReactDOMUnknownPropertyDevtool.js
@@ -11,19 +11,19 @@
 
 'use strict';
 
-var DOMProperty = require('DOMProperty');
-var EventPluginRegistry = require('EventPluginRegistry');
+const DOMProperty = require('DOMProperty');
+const EventPluginRegistry = require('EventPluginRegistry');
 
-var warning = require('warning');
+const warning = require('warning');
 
 if (__DEV__) {
-  var reactProps = {
+  const reactProps = {
     children: true,
     dangerouslySetInnerHTML: true,
     key: true,
     ref: true,
   };
-  var warnedProperties = {};
+  const warnedProperties = {};
 
   var warnUnknownProperty = function(name) {
     if (DOMProperty.properties.hasOwnProperty(name) || DOMProperty.isCustomAttribute(name)) {
@@ -35,10 +35,10 @@ if (__DEV__) {
     }
 
     warnedProperties[name] = true;
-    var lowerCasedName = name.toLowerCase();
+    const lowerCasedName = name.toLowerCase();
 
     // data-* attributes should be lowercase; suggest the lowercase version
-    var standardName = (
+    const standardName = (
       DOMProperty.isCustomAttribute(lowerCasedName) ?
         lowerCasedName :
       DOMProperty.getPossibleStandardName.hasOwnProperty(lowerCasedName) ?
@@ -55,7 +55,7 @@ if (__DEV__) {
       standardName
     );
 
-    var registrationName = (
+    const registrationName = (
       EventPluginRegistry.possibleRegistrationNames.hasOwnProperty(
         lowerCasedName
       ) ?
@@ -72,7 +72,7 @@ if (__DEV__) {
   };
 }
 
-var ReactDOMUnknownPropertyDevtool = {
+const ReactDOMUnknownPropertyDevtool = {
   onCreateMarkupForProperty(name, value) {
     warnUnknownProperty(name);
   },

--- a/src/renderers/dom/shared/escapeTextContentForBrowser.js
+++ b/src/renderers/dom/shared/escapeTextContentForBrowser.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var ESCAPE_LOOKUP = {
+const ESCAPE_LOOKUP = {
   '&': '&amp;',
   '>': '&gt;',
   '<': '&lt;',
@@ -19,7 +19,7 @@ var ESCAPE_LOOKUP = {
   '\'': '&#x27;',
 };
 
-var ESCAPE_REGEX = /[&><"']/g;
+const ESCAPE_REGEX = /[&><"']/g;
 
 function escaper(match) {
   return ESCAPE_LOOKUP[match];

--- a/src/renderers/dom/shared/quoteAttributeValueForBrowser.js
+++ b/src/renderers/dom/shared/quoteAttributeValueForBrowser.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var escapeTextContentForBrowser = require('escapeTextContentForBrowser');
+const escapeTextContentForBrowser = require('escapeTextContentForBrowser');
 
 /**
  * Escapes attribute value to prevent scripting attacks.

--- a/src/renderers/shared/event/EventConstants.js
+++ b/src/renderers/shared/event/EventConstants.js
@@ -11,14 +11,14 @@
 
 'use strict';
 
-var keyMirror = require('keyMirror');
+const keyMirror = require('keyMirror');
 
-var PropagationPhases = keyMirror({bubbled: null, captured: null});
+const PropagationPhases = keyMirror({bubbled: null, captured: null});
 
 /**
  * Types of raw signals from the browser caught at the top level.
  */
-var topLevelTypes = keyMirror({
+const topLevelTypes = keyMirror({
   topAbort: null,
   topBlur: null,
   topCanPlay: null,
@@ -85,7 +85,7 @@ var topLevelTypes = keyMirror({
   topWheel: null,
 });
 
-var EventConstants = {
+const EventConstants = {
   topLevelTypes: topLevelTypes,
   PropagationPhases: PropagationPhases,
 };

--- a/src/renderers/shared/event/EventPluginHub.js
+++ b/src/renderers/shared/event/EventPluginHub.js
@@ -156,7 +156,7 @@ const EventPluginHub = {
    * @param {object} inst The instance, which is the source of events.
    */
   deleteAllListeners: function(inst) {
-    for (let registrationName in listenerBank) {
+    for (const registrationName in listenerBank) {
       if (!listenerBank[registrationName][inst._rootNodeID]) {
         continue;
       }

--- a/src/renderers/shared/event/EventPluginHub.js
+++ b/src/renderers/shared/event/EventPluginHub.js
@@ -11,24 +11,24 @@
 
 'use strict';
 
-var EventPluginRegistry = require('EventPluginRegistry');
-var EventPluginUtils = require('EventPluginUtils');
-var ReactErrorUtils = require('ReactErrorUtils');
+const EventPluginRegistry = require('EventPluginRegistry');
+const EventPluginUtils = require('EventPluginUtils');
+const ReactErrorUtils = require('ReactErrorUtils');
 
-var accumulateInto = require('accumulateInto');
-var forEachAccumulated = require('forEachAccumulated');
-var invariant = require('invariant');
+const accumulateInto = require('accumulateInto');
+const forEachAccumulated = require('forEachAccumulated');
+const invariant = require('invariant');
 
 /**
  * Internal store for event listeners
  */
-var listenerBank = {};
+let listenerBank = {};
 
 /**
  * Internal queue of events that have accumulated their dispatches and are
  * waiting to have their dispatches executed.
  */
-var eventQueue = null;
+let eventQueue = null;
 
 /**
  * Dispatches an event and releases it back into the pool, unless persistent.
@@ -37,7 +37,7 @@ var eventQueue = null;
  * @param {boolean} simulated If the event is simulated (changes exn behavior)
  * @private
  */
-var executeDispatchesAndRelease = function(event, simulated) {
+const executeDispatchesAndRelease = function(event, simulated) {
   if (event) {
     EventPluginUtils.executeDispatchesInOrder(event, simulated);
 
@@ -46,10 +46,10 @@ var executeDispatchesAndRelease = function(event, simulated) {
     }
   }
 };
-var executeDispatchesAndReleaseSimulated = function(e) {
+const executeDispatchesAndReleaseSimulated = function(e) {
   return executeDispatchesAndRelease(e, true);
 };
-var executeDispatchesAndReleaseTopLevel = function(e) {
+const executeDispatchesAndReleaseTopLevel = function(e) {
   return executeDispatchesAndRelease(e, false);
 };
 
@@ -75,7 +75,7 @@ var executeDispatchesAndReleaseTopLevel = function(e) {
  *
  * @public
  */
-var EventPluginHub = {
+const EventPluginHub = {
 
   /**
    * Methods for injecting dependencies.
@@ -109,11 +109,11 @@ var EventPluginHub = {
       registrationName, typeof listener
     );
 
-    var bankForRegistrationName =
+    const bankForRegistrationName =
       listenerBank[registrationName] || (listenerBank[registrationName] = {});
     bankForRegistrationName[inst._rootNodeID] = listener;
 
-    var PluginModule =
+    const PluginModule =
       EventPluginRegistry.registrationNameModules[registrationName];
     if (PluginModule && PluginModule.didPutListener) {
       PluginModule.didPutListener(inst, registrationName, listener);
@@ -126,7 +126,7 @@ var EventPluginHub = {
    * @return {?function} The stored callback.
    */
   getListener: function(inst, registrationName) {
-    var bankForRegistrationName = listenerBank[registrationName];
+    const bankForRegistrationName = listenerBank[registrationName];
     return bankForRegistrationName && bankForRegistrationName[inst._rootNodeID];
   },
 
@@ -137,13 +137,13 @@ var EventPluginHub = {
    * @param {string} registrationName Name of listener (e.g. `onClick`).
    */
   deleteListener: function(inst, registrationName) {
-    var PluginModule =
+    const PluginModule =
       EventPluginRegistry.registrationNameModules[registrationName];
     if (PluginModule && PluginModule.willDeleteListener) {
       PluginModule.willDeleteListener(inst, registrationName);
     }
 
-    var bankForRegistrationName = listenerBank[registrationName];
+    const bankForRegistrationName = listenerBank[registrationName];
     // TODO: This should never be null -- when is it?
     if (bankForRegistrationName) {
       delete bankForRegistrationName[inst._rootNodeID];
@@ -156,12 +156,12 @@ var EventPluginHub = {
    * @param {object} inst The instance, which is the source of events.
    */
   deleteAllListeners: function(inst) {
-    for (var registrationName in listenerBank) {
+    for (let registrationName in listenerBank) {
       if (!listenerBank[registrationName][inst._rootNodeID]) {
         continue;
       }
 
-      var PluginModule =
+      const PluginModule =
         EventPluginRegistry.registrationNameModules[registrationName];
       if (PluginModule && PluginModule.willDeleteListener) {
         PluginModule.willDeleteListener(inst, registrationName);
@@ -183,13 +183,13 @@ var EventPluginHub = {
       targetInst,
       nativeEvent,
       nativeEventTarget) {
-    var events;
-    var plugins = EventPluginRegistry.plugins;
-    for (var i = 0; i < plugins.length; i++) {
+    let events;
+    const plugins = EventPluginRegistry.plugins;
+    for (let i = 0; i < plugins.length; i++) {
       // Not every plugin in the ordering may be loaded at runtime.
-      var possiblePlugin = plugins[i];
+      const possiblePlugin = plugins[i];
       if (possiblePlugin) {
-        var extractedEvents = possiblePlugin.extractEvents(
+        const extractedEvents = possiblePlugin.extractEvents(
           topLevelType,
           targetInst,
           nativeEvent,
@@ -224,7 +224,7 @@ var EventPluginHub = {
   processEventQueue: function(simulated) {
     // Set `eventQueue` to null before processing it so that we can tell if more
     // events get enqueued while processing.
-    var processingEventQueue = eventQueue;
+    const processingEventQueue = eventQueue;
     eventQueue = null;
     if (simulated) {
       forEachAccumulated(

--- a/src/renderers/shared/event/EventPluginRegistry.js
+++ b/src/renderers/shared/event/EventPluginRegistry.js
@@ -11,17 +11,17 @@
 
 'use strict';
 
-var invariant = require('invariant');
+const invariant = require('invariant');
 
 /**
  * Injectable ordering of event plugins.
  */
-var EventPluginOrder = null;
+let EventPluginOrder = null;
 
 /**
  * Injectable mapping from names to event plugin modules.
  */
-var namesToPlugins = {};
+const namesToPlugins = {};
 
 /**
  * Recomputes the plugin list using the injected plugins and plugin ordering.
@@ -33,9 +33,9 @@ function recomputePluginOrdering() {
     // Wait until an `EventPluginOrder` is injected.
     return;
   }
-  for (var pluginName in namesToPlugins) {
-    var PluginModule = namesToPlugins[pluginName];
-    var pluginIndex = EventPluginOrder.indexOf(pluginName);
+  for (let pluginName in namesToPlugins) {
+    const PluginModule = namesToPlugins[pluginName];
+    const pluginIndex = EventPluginOrder.indexOf(pluginName);
     invariant(
       pluginIndex > -1,
       'EventPluginRegistry: Cannot inject event plugins that do not exist in ' +
@@ -52,8 +52,8 @@ function recomputePluginOrdering() {
       pluginName
     );
     EventPluginRegistry.plugins[pluginIndex] = PluginModule;
-    var publishedEvents = PluginModule.eventTypes;
-    for (var eventName in publishedEvents) {
+    const publishedEvents = PluginModule.eventTypes;
+    for (let eventName in publishedEvents) {
       invariant(
         publishEventForPlugin(
           publishedEvents[eventName],
@@ -85,11 +85,11 @@ function publishEventForPlugin(dispatchConfig, PluginModule, eventName) {
   );
   EventPluginRegistry.eventNameDispatchConfigs[eventName] = dispatchConfig;
 
-  var phasedRegistrationNames = dispatchConfig.phasedRegistrationNames;
+  const phasedRegistrationNames = dispatchConfig.phasedRegistrationNames;
   if (phasedRegistrationNames) {
-    for (var phaseName in phasedRegistrationNames) {
+    for (let phaseName in phasedRegistrationNames) {
       if (phasedRegistrationNames.hasOwnProperty(phaseName)) {
-        var phasedRegistrationName = phasedRegistrationNames[phaseName];
+        const phasedRegistrationName = phasedRegistrationNames[phaseName];
         publishRegistrationName(
           phasedRegistrationName,
           PluginModule,
@@ -129,7 +129,7 @@ function publishRegistrationName(registrationName, PluginModule, eventName) {
     PluginModule.eventTypes[eventName].dependencies;
 
   if (__DEV__) {
-    var lowerCasedName = registrationName.toLowerCase();
+    const lowerCasedName = registrationName.toLowerCase();
     EventPluginRegistry.possibleRegistrationNames[lowerCasedName] =
       registrationName;
   }
@@ -201,12 +201,12 @@ var EventPluginRegistry = {
    * @see {EventPluginHub.injection.injectEventPluginsByName}
    */
   injectEventPluginsByName: function(injectedNamesToPlugins) {
-    var isOrderingDirty = false;
-    for (var pluginName in injectedNamesToPlugins) {
+    let isOrderingDirty = false;
+    for (let pluginName in injectedNamesToPlugins) {
       if (!injectedNamesToPlugins.hasOwnProperty(pluginName)) {
         continue;
       }
-      var PluginModule = injectedNamesToPlugins[pluginName];
+      const PluginModule = injectedNamesToPlugins[pluginName];
       if (!namesToPlugins.hasOwnProperty(pluginName) ||
           namesToPlugins[pluginName] !== PluginModule) {
         invariant(
@@ -232,17 +232,17 @@ var EventPluginRegistry = {
    * @internal
    */
   getPluginModuleForEvent: function(event) {
-    var dispatchConfig = event.dispatchConfig;
+    const dispatchConfig = event.dispatchConfig;
     if (dispatchConfig.registrationName) {
       return EventPluginRegistry.registrationNameModules[
         dispatchConfig.registrationName
       ] || null;
     }
-    for (var phase in dispatchConfig.phasedRegistrationNames) {
+    for (let phase in dispatchConfig.phasedRegistrationNames) {
       if (!dispatchConfig.phasedRegistrationNames.hasOwnProperty(phase)) {
         continue;
       }
-      var PluginModule = EventPluginRegistry.registrationNameModules[
+      const PluginModule = EventPluginRegistry.registrationNameModules[
         dispatchConfig.phasedRegistrationNames[phase]
       ];
       if (PluginModule) {
@@ -258,31 +258,31 @@ var EventPluginRegistry = {
    */
   _resetEventPlugins: function() {
     EventPluginOrder = null;
-    for (var pluginName in namesToPlugins) {
+    for (let pluginName in namesToPlugins) {
       if (namesToPlugins.hasOwnProperty(pluginName)) {
         delete namesToPlugins[pluginName];
       }
     }
     EventPluginRegistry.plugins.length = 0;
 
-    var eventNameDispatchConfigs = EventPluginRegistry.eventNameDispatchConfigs;
-    for (var eventName in eventNameDispatchConfigs) {
+    const eventNameDispatchConfigs = EventPluginRegistry.eventNameDispatchConfigs;
+    for (let eventName in eventNameDispatchConfigs) {
       if (eventNameDispatchConfigs.hasOwnProperty(eventName)) {
         delete eventNameDispatchConfigs[eventName];
       }
     }
 
-    var registrationNameModules = EventPluginRegistry.registrationNameModules;
-    for (var registrationName in registrationNameModules) {
+    const registrationNameModules = EventPluginRegistry.registrationNameModules;
+    for (let registrationName in registrationNameModules) {
       if (registrationNameModules.hasOwnProperty(registrationName)) {
         delete registrationNameModules[registrationName];
       }
     }
 
     if (__DEV__) {
-      var possibleRegistrationNames =
+      const possibleRegistrationNames =
         EventPluginRegistry.possibleRegistrationNames;
-      for (var lowerCasedName in possibleRegistrationNames) {
+      for (let lowerCasedName in possibleRegistrationNames) {
         if (possibleRegistrationNames.hasOwnProperty(lowerCasedName)) {
           delete possibleRegistrationNames[lowerCasedName];
         }

--- a/src/renderers/shared/event/EventPluginRegistry.js
+++ b/src/renderers/shared/event/EventPluginRegistry.js
@@ -33,7 +33,7 @@ function recomputePluginOrdering() {
     // Wait until an `EventPluginOrder` is injected.
     return;
   }
-  for (let pluginName in namesToPlugins) {
+  for (const pluginName in namesToPlugins) {
     const PluginModule = namesToPlugins[pluginName];
     const pluginIndex = EventPluginOrder.indexOf(pluginName);
     invariant(
@@ -53,7 +53,7 @@ function recomputePluginOrdering() {
     );
     EventPluginRegistry.plugins[pluginIndex] = PluginModule;
     const publishedEvents = PluginModule.eventTypes;
-    for (let eventName in publishedEvents) {
+    for (const eventName in publishedEvents) {
       invariant(
         publishEventForPlugin(
           publishedEvents[eventName],
@@ -87,7 +87,7 @@ function publishEventForPlugin(dispatchConfig, PluginModule, eventName) {
 
   const phasedRegistrationNames = dispatchConfig.phasedRegistrationNames;
   if (phasedRegistrationNames) {
-    for (let phaseName in phasedRegistrationNames) {
+    for (const phaseName in phasedRegistrationNames) {
       if (phasedRegistrationNames.hasOwnProperty(phaseName)) {
         const phasedRegistrationName = phasedRegistrationNames[phaseName];
         publishRegistrationName(
@@ -202,7 +202,7 @@ var EventPluginRegistry = {
    */
   injectEventPluginsByName: function(injectedNamesToPlugins) {
     let isOrderingDirty = false;
-    for (let pluginName in injectedNamesToPlugins) {
+    for (const pluginName in injectedNamesToPlugins) {
       if (!injectedNamesToPlugins.hasOwnProperty(pluginName)) {
         continue;
       }
@@ -238,7 +238,7 @@ var EventPluginRegistry = {
         dispatchConfig.registrationName
       ] || null;
     }
-    for (let phase in dispatchConfig.phasedRegistrationNames) {
+    for (const phase in dispatchConfig.phasedRegistrationNames) {
       if (!dispatchConfig.phasedRegistrationNames.hasOwnProperty(phase)) {
         continue;
       }
@@ -258,7 +258,7 @@ var EventPluginRegistry = {
    */
   _resetEventPlugins: function() {
     EventPluginOrder = null;
-    for (let pluginName in namesToPlugins) {
+    for (const pluginName in namesToPlugins) {
       if (namesToPlugins.hasOwnProperty(pluginName)) {
         delete namesToPlugins[pluginName];
       }
@@ -266,14 +266,14 @@ var EventPluginRegistry = {
     EventPluginRegistry.plugins.length = 0;
 
     const eventNameDispatchConfigs = EventPluginRegistry.eventNameDispatchConfigs;
-    for (let eventName in eventNameDispatchConfigs) {
+    for (const eventName in eventNameDispatchConfigs) {
       if (eventNameDispatchConfigs.hasOwnProperty(eventName)) {
         delete eventNameDispatchConfigs[eventName];
       }
     }
 
     const registrationNameModules = EventPluginRegistry.registrationNameModules;
-    for (let registrationName in registrationNameModules) {
+    for (const registrationName in registrationNameModules) {
       if (registrationNameModules.hasOwnProperty(registrationName)) {
         delete registrationNameModules[registrationName];
       }
@@ -282,7 +282,7 @@ var EventPluginRegistry = {
     if (__DEV__) {
       const possibleRegistrationNames =
         EventPluginRegistry.possibleRegistrationNames;
-      for (let lowerCasedName in possibleRegistrationNames) {
+      for (const lowerCasedName in possibleRegistrationNames) {
         if (possibleRegistrationNames.hasOwnProperty(lowerCasedName)) {
           delete possibleRegistrationNames[lowerCasedName];
         }

--- a/src/renderers/shared/event/EventPluginUtils.js
+++ b/src/renderers/shared/event/EventPluginUtils.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-var EventConstants = require('EventConstants');
-var ReactErrorUtils = require('ReactErrorUtils');
+const EventConstants = require('EventConstants');
+const ReactErrorUtils = require('ReactErrorUtils');
 
-var invariant = require('invariant');
-var warning = require('warning');
+const invariant = require('invariant');
+const warning = require('warning');
 
 /**
  * Injected dependencies:
@@ -25,9 +25,9 @@ var warning = require('warning');
  * - `ComponentTree`: [required] Module that can convert between React instances
  *   and actual node references.
  */
-var ComponentTree;
-var TreeTraversal;
-var injection = {
+let ComponentTree;
+let TreeTraversal;
+const injection = {
   injectComponentTree: function(Injected) {
     ComponentTree = Injected;
     if (__DEV__) {
@@ -52,7 +52,7 @@ var injection = {
   },
 };
 
-var topLevelTypes = EventConstants.topLevelTypes;
+const topLevelTypes = EventConstants.topLevelTypes;
 
 function isEndish(topLevelType) {
   return topLevelType === topLevelTypes.topMouseUp ||
@@ -70,19 +70,19 @@ function isStartish(topLevelType) {
 }
 
 
-var validateEventDispatches;
+let validateEventDispatches;
 if (__DEV__) {
   validateEventDispatches = function(event) {
-    var dispatchListeners = event._dispatchListeners;
-    var dispatchInstances = event._dispatchInstances;
+    const dispatchListeners = event._dispatchListeners;
+    const dispatchInstances = event._dispatchInstances;
 
-    var listenersIsArr = Array.isArray(dispatchListeners);
-    var listenersLen = listenersIsArr ?
+    const listenersIsArr = Array.isArray(dispatchListeners);
+    const listenersLen = listenersIsArr ?
       dispatchListeners.length :
       dispatchListeners ? 1 : 0;
 
-    var instancesIsArr = Array.isArray(dispatchInstances);
-    var instancesLen = instancesIsArr ?
+    const instancesIsArr = Array.isArray(dispatchInstances);
+    const instancesLen = instancesIsArr ?
       dispatchInstances.length :
       dispatchInstances ? 1 : 0;
 
@@ -101,7 +101,7 @@ if (__DEV__) {
  * @param {*} inst Internal component instance
  */
 function executeDispatch(event, simulated, listener, inst) {
-  var type = event.type || 'unknown-event';
+  const type = event.type || 'unknown-event';
   event.currentTarget = EventPluginUtils.getNodeFromInstance(inst);
   if (simulated) {
     ReactErrorUtils.invokeGuardedCallbackWithCatch(
@@ -119,13 +119,13 @@ function executeDispatch(event, simulated, listener, inst) {
  * Standard/simple iteration through an event's collected dispatches.
  */
 function executeDispatchesInOrder(event, simulated) {
-  var dispatchListeners = event._dispatchListeners;
-  var dispatchInstances = event._dispatchInstances;
+  const dispatchListeners = event._dispatchListeners;
+  const dispatchInstances = event._dispatchInstances;
   if (__DEV__) {
     validateEventDispatches(event);
   }
   if (Array.isArray(dispatchListeners)) {
-    for (var i = 0; i < dispatchListeners.length; i++) {
+    for (let i = 0; i < dispatchListeners.length; i++) {
       if (event.isPropagationStopped()) {
         break;
       }
@@ -152,13 +152,13 @@ function executeDispatchesInOrder(event, simulated) {
  * true, or null if no listener returned true.
  */
 function executeDispatchesInOrderStopAtTrueImpl(event) {
-  var dispatchListeners = event._dispatchListeners;
-  var dispatchInstances = event._dispatchInstances;
+  const dispatchListeners = event._dispatchListeners;
+  const dispatchInstances = event._dispatchInstances;
   if (__DEV__) {
     validateEventDispatches(event);
   }
   if (Array.isArray(dispatchListeners)) {
-    for (var i = 0; i < dispatchListeners.length; i++) {
+    for (let i = 0; i < dispatchListeners.length; i++) {
       if (event.isPropagationStopped()) {
         break;
       }
@@ -179,7 +179,7 @@ function executeDispatchesInOrderStopAtTrueImpl(event) {
  * @see executeDispatchesInOrderStopAtTrueImpl
  */
 function executeDispatchesInOrderStopAtTrue(event) {
-  var ret = executeDispatchesInOrderStopAtTrueImpl(event);
+  const ret = executeDispatchesInOrderStopAtTrueImpl(event);
   event._dispatchInstances = null;
   event._dispatchListeners = null;
   return ret;
@@ -198,14 +198,14 @@ function executeDirectDispatch(event) {
   if (__DEV__) {
     validateEventDispatches(event);
   }
-  var dispatchListener = event._dispatchListeners;
-  var dispatchInstance = event._dispatchInstances;
+  const dispatchListener = event._dispatchListeners;
+  const dispatchInstance = event._dispatchInstances;
   invariant(
     !Array.isArray(dispatchListener),
     'executeDirectDispatch(...): Invalid `event`.'
   );
   event.currentTarget = EventPluginUtils.getNodeFromInstance(dispatchInstance);
-  var res = dispatchListener ? dispatchListener(event) : null;
+  const res = dispatchListener ? dispatchListener(event) : null;
   event.curentTarget = null;
   event._dispatchListeners = null;
   event._dispatchInstances = null;

--- a/src/renderers/shared/event/EventPropagators.js
+++ b/src/renderers/shared/event/EventPropagators.js
@@ -11,23 +11,23 @@
 
 'use strict';
 
-var EventConstants = require('EventConstants');
-var EventPluginHub = require('EventPluginHub');
-var EventPluginUtils = require('EventPluginUtils');
+const EventConstants = require('EventConstants');
+const EventPluginHub = require('EventPluginHub');
+const EventPluginUtils = require('EventPluginUtils');
 
-var accumulateInto = require('accumulateInto');
-var forEachAccumulated = require('forEachAccumulated');
-var warning = require('warning');
+const accumulateInto = require('accumulateInto');
+const forEachAccumulated = require('forEachAccumulated');
+const warning = require('warning');
 
-var PropagationPhases = EventConstants.PropagationPhases;
-var getListener = EventPluginHub.getListener;
+const PropagationPhases = EventConstants.PropagationPhases;
+const getListener = EventPluginHub.getListener;
 
 /**
  * Some event types have a notion of different registration names for different
  * "phases" of propagation. This finds listeners by a given phase.
  */
 function listenerAtPhase(inst, event, propagationPhase) {
-  var registrationName =
+  const registrationName =
     event.dispatchConfig.phasedRegistrationNames[propagationPhase];
   return getListener(inst, registrationName);
 }
@@ -45,8 +45,8 @@ function accumulateDirectionalDispatches(inst, upwards, event) {
       'Dispatching inst must not be null'
     );
   }
-  var phase = upwards ? PropagationPhases.bubbled : PropagationPhases.captured;
-  var listener = listenerAtPhase(inst, event, phase);
+  const phase = upwards ? PropagationPhases.bubbled : PropagationPhases.captured;
+  const listener = listenerAtPhase(inst, event, phase);
   if (listener) {
     event._dispatchListeners =
       accumulateInto(event._dispatchListeners, listener);
@@ -76,8 +76,8 @@ function accumulateTwoPhaseDispatchesSingle(event) {
  */
 function accumulateTwoPhaseDispatchesSingleSkipTarget(event) {
   if (event && event.dispatchConfig.phasedRegistrationNames) {
-    var targetInst = event._targetInst;
-    var parentInst =
+    const targetInst = event._targetInst;
+    const parentInst =
       targetInst ? EventPluginUtils.getParentInstance(targetInst) : null;
     EventPluginUtils.traverseTwoPhase(
       parentInst,
@@ -96,7 +96,7 @@ function accumulateTwoPhaseDispatchesSingleSkipTarget(event) {
 function accumulateDispatches(inst, ignoredDirection, event) {
   if (event && event.dispatchConfig.registrationName) {
     var registrationName = event.dispatchConfig.registrationName;
-    var listener = getListener(inst, registrationName);
+    const listener = getListener(inst, registrationName);
     if (listener) {
       event._dispatchListeners =
         accumulateInto(event._dispatchListeners, listener);
@@ -152,7 +152,7 @@ function accumulateDirectDispatches(events) {
  *
  * @constructor EventPropagators
  */
-var EventPropagators = {
+const EventPropagators = {
   accumulateTwoPhaseDispatches: accumulateTwoPhaseDispatches,
   accumulateTwoPhaseDispatchesSkipTarget: accumulateTwoPhaseDispatchesSkipTarget,
   accumulateDirectDispatches: accumulateDirectDispatches,

--- a/src/renderers/shared/event/__tests__/EventPluginHub-test.js
+++ b/src/renderers/shared/event/__tests__/EventPluginHub-test.js
@@ -16,8 +16,8 @@ jest
   .mock('isEventSupported');
 
 describe('EventPluginHub', function() {
-  var EventPluginHub;
-  var isEventSupported;
+  let EventPluginHub;
+  let isEventSupported;
 
   beforeEach(function() {
     jest.resetModuleRegistry();

--- a/src/renderers/shared/event/__tests__/EventPluginRegistry-test.js
+++ b/src/renderers/shared/event/__tests__/EventPluginRegistry-test.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-var assign = require('Object.assign');
+const assign = require('Object.assign');
 
 describe('EventPluginRegistry', function() {
-  var EventPluginRegistry;
-  var createPlugin;
+  let EventPluginRegistry;
+  let createPlugin;
 
   beforeEach(function() {
     EventPluginRegistry = require('EventPluginRegistry');
@@ -27,9 +27,9 @@ describe('EventPluginRegistry', function() {
   });
 
   it('should be able to inject ordering before plugins', function() {
-    var OnePlugin = createPlugin();
-    var TwoPlugin = createPlugin();
-    var ThreePlugin = createPlugin();
+    const OnePlugin = createPlugin();
+    const TwoPlugin = createPlugin();
+    const ThreePlugin = createPlugin();
 
     EventPluginRegistry.injectEventPluginOrder(['one', 'two', 'three']);
     EventPluginRegistry.injectEventPluginsByName({
@@ -47,9 +47,9 @@ describe('EventPluginRegistry', function() {
   });
 
   it('should be able to inject plugins before and after ordering', function() {
-    var OnePlugin = createPlugin();
-    var TwoPlugin = createPlugin();
-    var ThreePlugin = createPlugin();
+    const OnePlugin = createPlugin();
+    const TwoPlugin = createPlugin();
+    const ThreePlugin = createPlugin();
 
     EventPluginRegistry.injectEventPluginsByName({
       one: OnePlugin,
@@ -67,9 +67,9 @@ describe('EventPluginRegistry', function() {
   });
 
   it('should be able to inject repeated plugins and out-of-order', function() {
-    var OnePlugin = createPlugin();
-    var TwoPlugin = createPlugin();
-    var ThreePlugin = createPlugin();
+    const OnePlugin = createPlugin();
+    const TwoPlugin = createPlugin();
+    const ThreePlugin = createPlugin();
 
     EventPluginRegistry.injectEventPluginsByName({
       one: OnePlugin,
@@ -88,7 +88,7 @@ describe('EventPluginRegistry', function() {
   });
 
   it('should throw if plugin does not implement `extractEvents`', function() {
-    var BadPlugin = {};
+    const BadPlugin = {};
 
     EventPluginRegistry.injectEventPluginOrder(['bad']);
 
@@ -103,8 +103,8 @@ describe('EventPluginRegistry', function() {
   });
 
   it('should throw if plugin does not exist in ordering', function() {
-    var OnePlugin = createPlugin();
-    var RandomPlugin = createPlugin();
+    const OnePlugin = createPlugin();
+    const RandomPlugin = createPlugin();
 
     EventPluginRegistry.injectEventPluginOrder(['one']);
 
@@ -120,7 +120,7 @@ describe('EventPluginRegistry', function() {
   });
 
   it('should throw if ordering is injected more than once', function() {
-    var pluginOrdering = [];
+    const pluginOrdering = [];
 
     EventPluginRegistry.injectEventPluginOrder(pluginOrdering);
 
@@ -133,8 +133,8 @@ describe('EventPluginRegistry', function() {
   });
 
   it('should throw if different plugins injected using same name', function() {
-    var OnePlugin = createPlugin();
-    var TwoPlugin = createPlugin();
+    const OnePlugin = createPlugin();
+    const TwoPlugin = createPlugin();
 
     EventPluginRegistry.injectEventPluginsByName({same: OnePlugin});
 
@@ -147,13 +147,13 @@ describe('EventPluginRegistry', function() {
   });
 
   it('should publish registration names of injected plugins', function() {
-    var OnePlugin = createPlugin({
+    const OnePlugin = createPlugin({
       eventTypes: {
         click: {registrationName: 'onClick'},
         focus: {registrationName: 'onFocus'},
       },
     });
-    var TwoPlugin = createPlugin({
+    const TwoPlugin = createPlugin({
       eventTypes: {
         magic: {
           phasedRegistrationNames: {
@@ -181,12 +181,12 @@ describe('EventPluginRegistry', function() {
   });
 
   it('should throw if multiple registration names collide', function() {
-    var OnePlugin = createPlugin({
+    const OnePlugin = createPlugin({
       eventTypes: {
         photoCapture: {registrationName: 'onPhotoCapture'},
       },
     });
-    var TwoPlugin = createPlugin({
+    const TwoPlugin = createPlugin({
       eventTypes: {
         photo: {
           phasedRegistrationNames: {
@@ -211,7 +211,7 @@ describe('EventPluginRegistry', function() {
   });
 
   it('should throw if an invalid event is published', function() {
-    var OnePlugin = createPlugin({
+    const OnePlugin = createPlugin({
       eventTypes: {
         badEvent: {/* missing configuration */},
       },
@@ -228,25 +228,25 @@ describe('EventPluginRegistry', function() {
   });
 
   it('should be able to get the plugin from synthetic events', function() {
-    var clickDispatchConfig = {
+    const clickDispatchConfig = {
       registrationName: 'onClick',
     };
-    var magicDispatchConfig = {
+    const magicDispatchConfig = {
       phasedRegistrationNames: {
         bubbled: 'onMagicBubble',
         captured: 'onMagicCapture',
       },
     };
 
-    var OnePlugin = createPlugin({
+    const OnePlugin = createPlugin({
       eventTypes: {
         click: clickDispatchConfig,
         magic: magicDispatchConfig,
       },
     });
 
-    var clickEvent = {dispatchConfig: clickDispatchConfig};
-    var magicEvent = {dispatchConfig: magicDispatchConfig};
+    const clickEvent = {dispatchConfig: clickDispatchConfig};
+    const magicEvent = {dispatchConfig: magicDispatchConfig};
 
     expect(EventPluginRegistry.getPluginModuleForEvent(clickEvent)).toBe(null);
     expect(EventPluginRegistry.getPluginModuleForEvent(magicEvent)).toBe(null);

--- a/src/renderers/shared/event/eventPlugins/ResponderSyntheticEvent.js
+++ b/src/renderers/shared/event/eventPlugins/ResponderSyntheticEvent.js
@@ -11,14 +11,14 @@
 
 'use strict';
 
-var SyntheticEvent = require('SyntheticEvent');
+const SyntheticEvent = require('SyntheticEvent');
 
 /**
  * `touchHistory` isn't actually on the native event, but putting it in the
  * interface will ensure that it is cleaned up when pooled/destroyed. The
  * `ResponderEventPlugin` will populate it appropriately.
  */
-var ResponderEventInterface = {
+const ResponderEventInterface = {
   touchHistory: function(nativeEvent) {
     return null; // Actually doesn't even look at the native event.
   },

--- a/src/renderers/shared/event/eventPlugins/ResponderTouchHistoryStore.js
+++ b/src/renderers/shared/event/eventPlugins/ResponderTouchHistoryStore.js
@@ -11,15 +11,15 @@
 
 'use strict';
 
-var EventPluginUtils = require('EventPluginUtils');
+const EventPluginUtils = require('EventPluginUtils');
 
-var invariant = require('invariant');
+const invariant = require('invariant');
 
-var isMoveish = EventPluginUtils.isMoveish;
-var isStartish = EventPluginUtils.isStartish;
-var isEndish = EventPluginUtils.isEndish;
+const isMoveish = EventPluginUtils.isMoveish;
+const isStartish = EventPluginUtils.isStartish;
+const isEndish = EventPluginUtils.isEndish;
 
-var MAX_TOUCH_BANK = 20;
+const MAX_TOUCH_BANK = 20;
 
 /**
  * Touch position/time tracking information by touchID. Typically, we'll only
@@ -36,7 +36,7 @@ var MAX_TOUCH_BANK = 20;
  *   currentTimeStamp: number
  * }
  */
-var touchHistory = {
+const touchHistory = {
   touchBank: [],
   numberActiveTouches: 0,
   // If there is only one active touch, we remember its location. This prevents
@@ -46,7 +46,7 @@ var touchHistory = {
   mostRecentTimeStamp: 0,
 };
 
-var timestampForTouch = function(touch) {
+const timestampForTouch = function(touch) {
   // The legacy internal implementation provides "timeStamp", which has been
   // renamed to "timestamp". Let both work for now while we iron it out
   // TODO (evv): rename timeStamp to timestamp in internal code
@@ -58,7 +58,7 @@ var timestampForTouch = function(touch) {
  * include a built in velocity computation that can be reused globally.
  * @param {Touch} touch Native touch object.
  */
-var initializeTouchData = function(touch) {
+const initializeTouchData = function(touch) {
   return {
     touchActive: true,
     startTimeStamp: timestampForTouch(touch),
@@ -73,7 +73,7 @@ var initializeTouchData = function(touch) {
   };
 };
 
-var reinitializeTouchTrack = function(touchTrack, touch) {
+const reinitializeTouchTrack = function(touchTrack, touch) {
   touchTrack.touchActive = true;
   touchTrack.startTimeStamp = timestampForTouch(touch);
   touchTrack.startPageX = touch.pageX;
@@ -86,8 +86,8 @@ var reinitializeTouchTrack = function(touchTrack, touch) {
   touchTrack.previousTimeStamp = timestampForTouch(touch);
 };
 
-var validateTouch = function(touch) {
-  var identifier = touch.identifier;
+const validateTouch = function(touch) {
+  const identifier = touch.identifier;
   invariant(identifier != null, 'Touch object is missing identifier');
   if (identifier > MAX_TOUCH_BANK) {
     console.warn(
@@ -98,10 +98,10 @@ var validateTouch = function(touch) {
   }
 };
 
-var recordStartTouchData = function(touch) {
-  var touchBank = touchHistory.touchBank;
-  var identifier = touch.identifier;
-  var touchTrack = touchBank[identifier];
+const recordStartTouchData = function(touch) {
+  const touchBank = touchHistory.touchBank;
+  const identifier = touch.identifier;
+  const touchTrack = touchBank[identifier];
   if (__DEV__) {
     validateTouch(touch);
   }
@@ -113,9 +113,9 @@ var recordStartTouchData = function(touch) {
   touchHistory.mostRecentTimeStamp = timestampForTouch(touch);
 };
 
-var recordMoveTouchData = function(touch) {
-  var touchBank = touchHistory.touchBank;
-  var touchTrack = touchBank[touch.identifier];
+const recordMoveTouchData = function(touch) {
+  const touchBank = touchHistory.touchBank;
+  const touchTrack = touchBank[touch.identifier];
   if (__DEV__) {
     validateTouch(touch);
     invariant(touchTrack, 'Touch data should have been recorded on start');
@@ -130,9 +130,9 @@ var recordMoveTouchData = function(touch) {
   touchHistory.mostRecentTimeStamp = timestampForTouch(touch);
 };
 
-var recordEndTouchData = function(touch) {
-  var touchBank = touchHistory.touchBank;
-  var touchTrack = touchBank[touch.identifier];
+const recordEndTouchData = function(touch) {
+  const touchBank = touchHistory.touchBank;
+  const touchTrack = touchBank[touch.identifier];
   if (__DEV__) {
     validateTouch(touch);
     invariant(touchTrack, 'Touch data should have been recorded on start');
@@ -147,9 +147,9 @@ var recordEndTouchData = function(touch) {
   touchHistory.mostRecentTimeStamp = timestampForTouch(touch);
 };
 
-var ResponderTouchHistoryStore = {
+const ResponderTouchHistoryStore = {
   recordTouchTrack: function(topLevelType, nativeEvent) {
-    var touchBank = touchHistory.touchBank;
+    const touchBank = touchHistory.touchBank;
     if (isMoveish(topLevelType)) {
       nativeEvent.changedTouches.forEach(recordMoveTouchData);
     } else if (isStartish(topLevelType)) {
@@ -162,16 +162,16 @@ var ResponderTouchHistoryStore = {
       nativeEvent.changedTouches.forEach(recordEndTouchData);
       touchHistory.numberActiveTouches = nativeEvent.touches.length;
       if (touchHistory.numberActiveTouches === 1) {
-        for (var i = 0; i < touchBank.length; i++) {
-          var touchTrackToCheck = touchBank[i];
+        for (let i = 0; i < touchBank.length; i++) {
+          const touchTrackToCheck = touchBank[i];
           if (touchTrackToCheck != null && touchTrackToCheck.touchActive) {
             touchHistory.indexOfSingleActiveTouch = i;
             break;
           }
         }
         if (__DEV__) {
-          var activeTouchData = touchBank[touchHistory.indexOfSingleActiveTouch];
-          var foundActive = activeTouchData != null && !!activeTouchData.touchActive;
+          const activeTouchData = touchBank[touchHistory.indexOfSingleActiveTouch];
+          const foundActive = activeTouchData != null && !!activeTouchData.touchActive;
           invariant(foundActive, 'Cannot find single active touch');
         }
       }

--- a/src/renderers/shared/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
+++ b/src/renderers/shared/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
@@ -11,15 +11,15 @@
 
 'use strict';
 
-var EventPluginHub;
-var EventConstants;
-var ReactInstanceHandles;
-var ResponderEventPlugin;
-var EventPluginUtils;
+let EventPluginHub;
+let EventConstants;
+let ReactInstanceHandles;
+let ResponderEventPlugin;
+let EventPluginUtils;
 
-var topLevelTypes;
+let topLevelTypes;
 
-var touch = function(nodeHandle, i) {
+const touch = function(nodeHandle, i) {
   return {target: nodeHandle, identifier: i};
 };
 
@@ -30,7 +30,7 @@ var touch = function(nodeHandle, i) {
  * @return {TouchEvent} Model of a touch event that is compliant with responder
  * system plugin.
  */
-var touchEvent = function(nodeHandle, touches, changedTouches) {
+const touchEvent = function(nodeHandle, touches, changedTouches) {
   return {
     target: nodeHandle,
     changedTouches: changedTouches,
@@ -38,18 +38,18 @@ var touchEvent = function(nodeHandle, touches, changedTouches) {
   };
 };
 
-var subsequence = function(arr, indices) {
-  var ret = [];
-  for (var i = 0; i < indices.length; i++) {
-    var index = indices[i];
+const subsequence = function(arr, indices) {
+  const ret = [];
+  for (let i = 0; i < indices.length; i++) {
+    const index = indices[i];
     ret.push(arr[index]);
   }
   return ret;
 };
 
-var antiSubsequence = function(arr, indices) {
-  var ret = [];
-  for (var i = 0; i < arr.length; i++) {
+const antiSubsequence = function(arr, indices) {
+  const ret = [];
+  for (let i = 0; i < arr.length; i++) {
     if (indices.indexOf(i) === -1) {
       ret.push(arr[i]);
     }
@@ -61,16 +61,16 @@ var antiSubsequence = function(arr, indices) {
  * Helper for creating touch test config data.
  * @param allTouchHandles
  */
-var _touchConfig = function(
+const _touchConfig = function(
   topType,
   targetNodeHandle,
   allTouchHandles,
   changedIndices,
   eventTarget
 ) {
-  var allTouchObjects = allTouchHandles.map(touch);
-  var changedTouchObjects = subsequence(allTouchObjects, changedIndices);
-  var activeTouchObjects =
+  const allTouchObjects = allTouchHandles.map(touch);
+  const changedTouchObjects = subsequence(allTouchObjects, changedIndices);
+  const activeTouchObjects =
     topType === 'topTouchStart' ? allTouchObjects :
     topType === 'topTouchMove' ? allTouchObjects :
     topType === 'topTouchEnd' ? antiSubsequence(allTouchObjects, changedIndices) :
@@ -106,7 +106,7 @@ var _touchConfig = function(
  * @return {object} Config data used by test cases for extracting responder
  * events.
  */
-var startConfig = function(nodeHandle, allTouchHandles, changedIndices) {
+const startConfig = function(nodeHandle, allTouchHandles, changedIndices) {
   return _touchConfig(
     topLevelTypes.topTouchStart,
     nodeHandle,
@@ -119,7 +119,7 @@ var startConfig = function(nodeHandle, allTouchHandles, changedIndices) {
 /**
  * @see `startConfig`
  */
-var moveConfig = function(nodeHandle, allTouchHandles, changedIndices) {
+const moveConfig = function(nodeHandle, allTouchHandles, changedIndices) {
   return _touchConfig(
     topLevelTypes.topTouchMove,
     nodeHandle,
@@ -132,7 +132,7 @@ var moveConfig = function(nodeHandle, allTouchHandles, changedIndices) {
 /**
  * @see `startConfig`
  */
-var endConfig = function(nodeHandle, allTouchHandles, changedIndices) {
+const endConfig = function(nodeHandle, allTouchHandles, changedIndices) {
   return _touchConfig(
     topLevelTypes.topTouchEnd,
     nodeHandle,
@@ -169,9 +169,9 @@ var endConfig = function(nodeHandle, allTouchHandles, changedIndices) {
  * ever invoked).
  *
  */
-var NA = -1;
-var oneEventLoopTestConfig = function(readableIDToID) {
-  var ret = {
+const NA = -1;
+const oneEventLoopTestConfig = function(readableIDToID) {
+  const ret = {
     // Negotiation
     scrollShouldSetResponder: {bubbled:  {}, captured: {}},
     startShouldSetResponder: {bubbled:  {}, captured: {}},
@@ -187,8 +187,8 @@ var oneEventLoopTestConfig = function(readableIDToID) {
     responderEnd:       {},
     responderRelease:   {},
   };
-  for (var eventName in ret) {
-    for (var readableNodeName in readableIDToID) {
+  for (let eventName in ret) {
+    for (let readableNodeName in readableIDToID) {
       if (ret[eventName].bubbled) {
         // Two phase
         ret[eventName].bubbled[readableNodeName] =
@@ -208,9 +208,9 @@ var oneEventLoopTestConfig = function(readableIDToID) {
  * @param {object} eventTestConfig
  * @param {object} readableIDToID
  */
-var registerTestHandlers = function(eventTestConfig, readableIDToID) {
-  var runs = {dispatchCount: 0};
-  var neverFire = function(readableID, registrationName) {
+const registerTestHandlers = function(eventTestConfig, readableIDToID) {
+  const runs = {dispatchCount: 0};
+  const neverFire = function(readableID, registrationName) {
     runs.dispatchCount++;
     expect('').toBe(
       'Event type: ' + registrationName +
@@ -219,11 +219,11 @@ var registerTestHandlers = function(eventTestConfig, readableIDToID) {
     );
   };
 
-  var registerOneEventType = function(registrationName, eventTypeTestConfig) {
-    for (var readableID in eventTypeTestConfig) {
-      var nodeConfig = eventTypeTestConfig[readableID];
-      var id = readableIDToID[readableID];
-      var handler = nodeConfig.order === NA ? neverFire.bind(null, readableID, registrationName) :
+  const registerOneEventType = function(registrationName, eventTypeTestConfig) {
+    for (let readableID in eventTypeTestConfig) {
+      const nodeConfig = eventTypeTestConfig[readableID];
+      const id = readableIDToID[readableID];
+      const handler = nodeConfig.order === NA ? neverFire.bind(null, readableID, registrationName) :
         // We partially apply readableID and nodeConfig, as they change in the
         // parent closure across iterations.
         function(rID, config, e) {
@@ -240,9 +240,9 @@ var registerTestHandlers = function(eventTestConfig, readableIDToID) {
       EventPluginHub.putListener(idToInstance[id], registrationName, handler);
     }
   };
-  for (var eventName in eventTestConfig) {
-    var oneEventTypeTestConfig = eventTestConfig[eventName];
-    var hasTwoPhase = !!oneEventTypeTestConfig.bubbled;
+  for (let eventName in eventTestConfig) {
+    const oneEventTypeTestConfig = eventTestConfig[eventName];
+    const hasTwoPhase = !!oneEventTypeTestConfig.bubbled;
     if (hasTwoPhase) {
       registerOneEventType(
         ResponderEventPlugin.eventTypes[eventName].phasedRegistrationNames.bubbled,
@@ -265,16 +265,16 @@ var registerTestHandlers = function(eventTestConfig, readableIDToID) {
 
 
 
-var run = function(config, hierarchyConfig, nativeEventConfig) {
-  var max = NA;
-  var searchForMax = function(nodeConfig) {
-    for (var readableID in nodeConfig) {
-      var order = nodeConfig[readableID].order;
+const run = function(config, hierarchyConfig, nativeEventConfig) {
+  let max = NA;
+  const searchForMax = function(nodeConfig) {
+    for (let readableID in nodeConfig) {
+      const order = nodeConfig[readableID].order;
       max = order > max ? order : max;
     }
   };
-  for (var eventName in config) {
-    var eventConfig = config[eventName];
+  for (let eventName in config) {
+    const eventConfig = config[eventName];
     if (eventConfig.bubbled) {
       searchForMax(eventConfig.bubbled);
       searchForMax(eventConfig.captured);
@@ -284,10 +284,10 @@ var run = function(config, hierarchyConfig, nativeEventConfig) {
   }
 
   // Register the handlers
-  var runData = registerTestHandlers(config, hierarchyConfig);
+  const runData = registerTestHandlers(config, hierarchyConfig);
 
   // Trigger the event
-  var extractedEvents = ResponderEventPlugin.extractEvents(
+  const extractedEvents = ResponderEventPlugin.extractEvents(
     nativeEventConfig.topLevelType,
     nativeEventConfig.targetInst,
     nativeEventConfig.nativeEvent,
@@ -308,23 +308,23 @@ var run = function(config, hierarchyConfig, nativeEventConfig) {
   ); // +1 for extra ++
 };
 
-var GRANDPARENT_ID = '.0';
-var PARENT_ID = '.0.0';
-var CHILD_ID = '.0.0.0';
-var CHILD_ID2 = '.0.0.1';
+const GRANDPARENT_ID = '.0';
+const PARENT_ID = '.0.0';
+const CHILD_ID = '.0.0.0';
+const CHILD_ID2 = '.0.0.1';
 
 var idToInstance = {};
 [GRANDPARENT_ID, PARENT_ID, CHILD_ID, CHILD_ID2].forEach(function(id) {
   idToInstance[id] = {_rootNodeID: id};
 });
 
-var three = {
+const three = {
   grandParent: GRANDPARENT_ID,
   parent: PARENT_ID,
   child: CHILD_ID,
 };
 
-var siblings = {
+const siblings = {
   parent: PARENT_ID,
   childOne: CHILD_ID,
   childTwo: CHILD_ID2,
@@ -360,15 +360,15 @@ describe('ResponderEventPlugin', function() {
         if (!a || !b) {
           return null;
         }
-        var commonID = ReactInstanceHandles.getFirstCommonAncestorID(
+        const commonID = ReactInstanceHandles.getFirstCommonAncestorID(
           a._rootNodeID,
           b._rootNodeID
         );
         return idToInstance[commonID] || null;
       },
       getParentInstance: function(inst) {
-        var id = inst._rootNodeID;
-        var parentID = id.substr(0, id.lastIndexOf('.'));
+        const id = inst._rootNodeID;
+        const parentID = id.substr(0, id.lastIndexOf('.'));
         return idToInstance[parentID] || null;
       },
       traverseTwoPhase: function(target, fn, arg) {
@@ -385,7 +385,7 @@ describe('ResponderEventPlugin', function() {
   });
 
   it('should do nothing when no one wants to respond', function() {
-    var config = oneEventLoopTestConfig(three);
+    let config = oneEventLoopTestConfig(three);
     config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
     config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
     config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
@@ -409,7 +409,7 @@ describe('ResponderEventPlugin', function() {
 
 
   it('should grant responder grandParent while capturing', () => {
-    var config = oneEventLoopTestConfig(three);
+    let config = oneEventLoopTestConfig(three);
     config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: true};
     config.responderGrant.grandParent = {order: 1};
     config.responderStart.grandParent = {order: 2};
@@ -424,7 +424,7 @@ describe('ResponderEventPlugin', function() {
   });
 
   it('should grant responder parent while capturing', () => {
-    var config = oneEventLoopTestConfig(three);
+    let config = oneEventLoopTestConfig(three);
     config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
     config.startShouldSetResponder.captured.parent = {order: 1, returnVal: true};
     config.responderGrant.parent = {order: 2};
@@ -440,7 +440,7 @@ describe('ResponderEventPlugin', function() {
   });
 
   it('should grant responder child while capturing', () => {
-    var config = oneEventLoopTestConfig(three);
+    let config = oneEventLoopTestConfig(three);
     config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
     config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
     config.startShouldSetResponder.captured.child = {order: 2, returnVal: true};
@@ -457,7 +457,7 @@ describe('ResponderEventPlugin', function() {
   });
 
   it('should grant responder child while bubbling', () => {
-    var config = oneEventLoopTestConfig(three);
+    let config = oneEventLoopTestConfig(three);
     config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
     config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
     config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
@@ -475,7 +475,7 @@ describe('ResponderEventPlugin', function() {
   });
 
   it('should grant responder parent while bubbling', () => {
-    var config = oneEventLoopTestConfig(three);
+    let config = oneEventLoopTestConfig(three);
     config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
     config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
     config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
@@ -494,7 +494,7 @@ describe('ResponderEventPlugin', function() {
   });
 
   it('should grant responder grandParent while bubbling', () => {
-    var config = oneEventLoopTestConfig(three);
+    let config = oneEventLoopTestConfig(three);
     config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
     config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
     config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
@@ -521,7 +521,7 @@ describe('ResponderEventPlugin', function() {
    */
 
   it('should grant responder grandParent while capturing move', () => {
-    var config = oneEventLoopTestConfig(three);
+    let config = oneEventLoopTestConfig(three);
 
     config.startShouldSetResponder.captured.grandParent = {order: 0};
     config.startShouldSetResponder.captured.parent = {order: 1};
@@ -546,7 +546,7 @@ describe('ResponderEventPlugin', function() {
   });
 
   it('should grant responder parent while capturing move', () => {
-    var config = oneEventLoopTestConfig(three);
+    let config = oneEventLoopTestConfig(three);
 
     config.startShouldSetResponder.captured.grandParent = {order: 0};
     config.startShouldSetResponder.captured.parent = {order: 1};
@@ -572,7 +572,7 @@ describe('ResponderEventPlugin', function() {
   });
 
   it('should grant responder child while capturing move', () => {
-    var config = oneEventLoopTestConfig(three);
+    let config = oneEventLoopTestConfig(three);
 
     config.startShouldSetResponder.captured.grandParent = {order: 0};
     config.startShouldSetResponder.captured.parent = {order: 1};
@@ -599,7 +599,7 @@ describe('ResponderEventPlugin', function() {
   });
 
   it('should grant responder child while bubbling move', () => {
-    var config = oneEventLoopTestConfig(three);
+    let config = oneEventLoopTestConfig(three);
 
     config.startShouldSetResponder.captured.grandParent = {order: 0};
     config.startShouldSetResponder.captured.parent = {order: 1};
@@ -627,7 +627,7 @@ describe('ResponderEventPlugin', function() {
   });
 
   it('should grant responder parent while bubbling move', () => {
-    var config = oneEventLoopTestConfig(three);
+    let config = oneEventLoopTestConfig(three);
 
     config.startShouldSetResponder.captured.grandParent = {order: 0};
     config.startShouldSetResponder.captured.parent = {order: 1};
@@ -656,7 +656,7 @@ describe('ResponderEventPlugin', function() {
   });
 
   it('should grant responder grandParent while bubbling move', () => {
-    var config = oneEventLoopTestConfig(three);
+    let config = oneEventLoopTestConfig(three);
 
     config.startShouldSetResponder.captured.grandParent = {order: 0};
     config.startShouldSetResponder.captured.parent = {order: 1};
@@ -692,7 +692,7 @@ describe('ResponderEventPlugin', function() {
    */
 
   it('should bubble negotiation to first common ancestor of responder', () => {
-    var config = oneEventLoopTestConfig(three);
+    let config = oneEventLoopTestConfig(three);
     config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
     config.startShouldSetResponder.captured.parent = {order: 1, returnVal: true};
     config.responderGrant.parent = {order: 2};
@@ -718,7 +718,7 @@ describe('ResponderEventPlugin', function() {
   });
 
   it('should bubble negotiation to first common ancestor of responder then transfer', () => {
-    var config = oneEventLoopTestConfig(three);
+    let config = oneEventLoopTestConfig(three);
     config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
     config.startShouldSetResponder.captured.parent = {order: 1, returnVal: true};
     config.responderGrant.parent = {order: 2};
@@ -756,7 +756,7 @@ describe('ResponderEventPlugin', function() {
    */
   it('should negotiate with deepest target on second touch if nothing is responder', () => {
     // Initially nothing wants to become the responder
-    var config = oneEventLoopTestConfig(three);
+    let config = oneEventLoopTestConfig(three);
     config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
     config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
     config.startShouldSetResponder.bubbled.parent = {order: 2, returnVal: false};
@@ -838,7 +838,7 @@ describe('ResponderEventPlugin', function() {
    */
   it('should negotiate until first common ancestor when there are siblings', () => {
     // Initially nothing wants to become the responder
-    var config = oneEventLoopTestConfig(siblings);
+    let config = oneEventLoopTestConfig(siblings);
     config.startShouldSetResponder.captured.parent = {order: 0, returnVal: false};
     config.startShouldSetResponder.captured.childOne = {order: 1, returnVal: false};
     config.startShouldSetResponder.bubbled.childOne = {order: 2, returnVal: true};
@@ -856,7 +856,7 @@ describe('ResponderEventPlugin', function() {
     config.startShouldSetResponder.bubbled.parent = {order: 1, returnVal: false};
     config.responderStart.childOne = {order: 2};
 
-    var touchConfig =
+    const touchConfig =
       startConfig(siblings.childTwo, [siblings.childOne, siblings.childTwo], [1]);
     run(config, siblings, touchConfig);
     expect(ResponderEventPlugin._getResponderID()).toBe(siblings.childOne);
@@ -883,7 +883,7 @@ describe('ResponderEventPlugin', function() {
 
   it('should notify of being rejected. responderStart/Move happens on current responder', () => {
     // Initially nothing wants to become the responder
-    var config = oneEventLoopTestConfig(three);
+    let config = oneEventLoopTestConfig(three);
     config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
     config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
     config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
@@ -905,7 +905,7 @@ describe('ResponderEventPlugin', function() {
     // The start/move should occur on the original responder if new one is rejected
     config.responderMove.child = {order: 6};
 
-    var touchConfig =
+    let touchConfig =
       moveConfig(three.child, [three.child], [0]);
     run(config, three, touchConfig);
     expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
@@ -930,7 +930,7 @@ describe('ResponderEventPlugin', function() {
 
   it('should negotiate scroll', () => {
     // Initially nothing wants to become the responder
-    var config = oneEventLoopTestConfig(three);
+    let config = oneEventLoopTestConfig(three);
     config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
     config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
     config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
@@ -981,7 +981,7 @@ describe('ResponderEventPlugin', function() {
 
   it('should cancel correctly', () => {
     // Initially our child becomes responder
-    var config = oneEventLoopTestConfig(three);
+    let config = oneEventLoopTestConfig(three);
     config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
     config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
     config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
@@ -996,7 +996,7 @@ describe('ResponderEventPlugin', function() {
     config.responderEnd.child = {order: 0};
     config.responderTerminate.child = {order: 1};
 
-    var nativeEvent = _touchConfig(
+    const nativeEvent = _touchConfig(
       topLevelTypes.topTouchCancel,
       three.child,
       [three.child],

--- a/src/renderers/shared/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
+++ b/src/renderers/shared/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
@@ -187,8 +187,8 @@ const oneEventLoopTestConfig = function(readableIDToID) {
     responderEnd:       {},
     responderRelease:   {},
   };
-  for (let eventName in ret) {
-    for (let readableNodeName in readableIDToID) {
+  for (const eventName in ret) {
+    for (const readableNodeName in readableIDToID) {
       if (ret[eventName].bubbled) {
         // Two phase
         ret[eventName].bubbled[readableNodeName] =
@@ -220,7 +220,7 @@ const registerTestHandlers = function(eventTestConfig, readableIDToID) {
   };
 
   const registerOneEventType = function(registrationName, eventTypeTestConfig) {
-    for (let readableID in eventTypeTestConfig) {
+    for (const readableID in eventTypeTestConfig) {
       const nodeConfig = eventTypeTestConfig[readableID];
       const id = readableIDToID[readableID];
       const handler = nodeConfig.order === NA ? neverFire.bind(null, readableID, registrationName) :
@@ -240,7 +240,7 @@ const registerTestHandlers = function(eventTestConfig, readableIDToID) {
       EventPluginHub.putListener(idToInstance[id], registrationName, handler);
     }
   };
-  for (let eventName in eventTestConfig) {
+  for (const eventName in eventTestConfig) {
     const oneEventTypeTestConfig = eventTestConfig[eventName];
     const hasTwoPhase = !!oneEventTypeTestConfig.bubbled;
     if (hasTwoPhase) {
@@ -268,12 +268,12 @@ const registerTestHandlers = function(eventTestConfig, readableIDToID) {
 const run = function(config, hierarchyConfig, nativeEventConfig) {
   let max = NA;
   const searchForMax = function(nodeConfig) {
-    for (let readableID in nodeConfig) {
+    for (const readableID in nodeConfig) {
       const order = nodeConfig[readableID].order;
       max = order > max ? order : max;
     }
   };
-  for (let eventName in config) {
+  for (const eventName in config) {
     const eventConfig = config[eventName];
     if (eventConfig.bubbled) {
       searchForMax(eventConfig.bubbled);

--- a/src/renderers/shared/reconciler/ReactChildReconciler.js
+++ b/src/renderers/shared/reconciler/ReactChildReconciler.js
@@ -126,7 +126,7 @@ const ReactChildReconciler = {
    * @internal
    */
   unmountChildren: function(renderedChildren, safely) {
-    for (let name in renderedChildren) {
+    for (const name in renderedChildren) {
       if (renderedChildren.hasOwnProperty(name)) {
         const renderedChild = renderedChildren[name];
         ReactReconciler.unmountComponent(renderedChild, safely);

--- a/src/renderers/shared/reconciler/ReactChildReconciler.js
+++ b/src/renderers/shared/reconciler/ReactChildReconciler.js
@@ -11,16 +11,16 @@
 
 'use strict';
 
-var ReactReconciler = require('ReactReconciler');
+const ReactReconciler = require('ReactReconciler');
 
-var instantiateReactComponent = require('instantiateReactComponent');
-var shouldUpdateReactComponent = require('shouldUpdateReactComponent');
-var traverseAllChildren = require('traverseAllChildren');
-var warning = require('warning');
+const instantiateReactComponent = require('instantiateReactComponent');
+const shouldUpdateReactComponent = require('shouldUpdateReactComponent');
+const traverseAllChildren = require('traverseAllChildren');
+const warning = require('warning');
 
 function instantiateChild(childInstances, child, name) {
   // We found a component instance.
-  var keyUnique = (childInstances[name] === undefined);
+  const keyUnique = (childInstances[name] === undefined);
   if (__DEV__) {
     warning(
       keyUnique,
@@ -40,7 +40,7 @@ function instantiateChild(childInstances, child, name) {
  * children. Its output is suitable for passing it onto ReactMultiChild which
  * does diffed reordering and insertion.
  */
-var ReactChildReconciler = {
+const ReactChildReconciler = {
   /**
    * Generates a "mount image" for each of the supplied children. In the case
    * of `ReactDOMComponent`, a mount image is a string of markup.
@@ -53,7 +53,7 @@ var ReactChildReconciler = {
     if (nestedChildNodes == null) {
       return null;
     }
-    var childInstances = {};
+    const childInstances = {};
     traverseAllChildren(nestedChildNodes, instantiateChild, childInstances);
     return childInstances;
   },
@@ -82,15 +82,15 @@ var ReactChildReconciler = {
     if (!nextChildren && !prevChildren) {
       return;
     }
-    var name;
-    var prevChild;
+    let name;
+    let prevChild;
     for (name in nextChildren) {
       if (!nextChildren.hasOwnProperty(name)) {
         continue;
       }
       prevChild = prevChildren && prevChildren[name];
-      var prevElement = prevChild && prevChild._currentElement;
-      var nextElement = nextChildren[name];
+      const prevElement = prevChild && prevChild._currentElement;
+      const nextElement = nextChildren[name];
       if (prevChild != null &&
           shouldUpdateReactComponent(prevElement, nextElement)) {
         ReactReconciler.receiveComponent(
@@ -103,7 +103,7 @@ var ReactChildReconciler = {
           ReactReconciler.unmountComponent(prevChild, false);
         }
         // The child must be instantiated before it's mounted.
-        var nextChildInstance = instantiateReactComponent(nextElement);
+        const nextChildInstance = instantiateReactComponent(nextElement);
         nextChildren[name] = nextChildInstance;
       }
     }
@@ -126,9 +126,9 @@ var ReactChildReconciler = {
    * @internal
    */
   unmountChildren: function(renderedChildren, safely) {
-    for (var name in renderedChildren) {
+    for (let name in renderedChildren) {
       if (renderedChildren.hasOwnProperty(name)) {
-        var renderedChild = renderedChildren[name];
+        const renderedChild = renderedChildren[name];
         ReactReconciler.unmountComponent(renderedChild, safely);
       }
     }

--- a/src/renderers/shared/reconciler/ReactComponentEnvironment.js
+++ b/src/renderers/shared/reconciler/ReactComponentEnvironment.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-var invariant = require('invariant');
+const invariant = require('invariant');
 
-var injected = false;
+let injected = false;
 
-var ReactComponentEnvironment = {
+const ReactComponentEnvironment = {
 
   /**
    * Optionally injectable environment dependent cleanup hook. (server vs.

--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -459,7 +459,7 @@ const ReactCompositeComponentMixin = {
       return emptyObject;
     }
     const maskedContext = {};
-    for (let contextName in contextTypes) {
+    for (const contextName in contextTypes) {
       maskedContext[contextName] = context[contextName];
     }
     return maskedContext;
@@ -511,7 +511,7 @@ const ReactCompositeComponentMixin = {
           ReactPropTypeLocations.childContext
         );
       }
-      for (let name in childContext) {
+      for (const name in childContext) {
         invariant(
           name in Component.childContextTypes,
           '%s.getChildContext(): key "%s" is not defined in childContextTypes.',
@@ -559,7 +559,7 @@ const ReactCompositeComponentMixin = {
     // TODO: Stop validating prop types here and only use the element
     // validation.
     const componentName = this.getName();
-    for (let propName in propTypes) {
+    for (const propName in propTypes) {
       if (propTypes.hasOwnProperty(propName)) {
         let error;
         try {

--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -11,28 +11,28 @@
 
 'use strict';
 
-var ReactComponentEnvironment = require('ReactComponentEnvironment');
-var ReactCurrentOwner = require('ReactCurrentOwner');
-var ReactElement = require('ReactElement');
-var ReactErrorUtils = require('ReactErrorUtils');
-var ReactInstanceMap = require('ReactInstanceMap');
-var ReactNodeTypes = require('ReactNodeTypes');
-var ReactPerf = require('ReactPerf');
-var ReactPropTypeLocations = require('ReactPropTypeLocations');
-var ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
-var ReactReconciler = require('ReactReconciler');
-var ReactUpdateQueue = require('ReactUpdateQueue');
+const ReactComponentEnvironment = require('ReactComponentEnvironment');
+const ReactCurrentOwner = require('ReactCurrentOwner');
+const ReactElement = require('ReactElement');
+const ReactErrorUtils = require('ReactErrorUtils');
+const ReactInstanceMap = require('ReactInstanceMap');
+const ReactNodeTypes = require('ReactNodeTypes');
+const ReactPerf = require('ReactPerf');
+const ReactPropTypeLocations = require('ReactPropTypeLocations');
+const ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
+const ReactReconciler = require('ReactReconciler');
+const ReactUpdateQueue = require('ReactUpdateQueue');
 
-var assign = require('Object.assign');
-var emptyObject = require('emptyObject');
-var invariant = require('invariant');
-var shouldUpdateReactComponent = require('shouldUpdateReactComponent');
-var warning = require('warning');
+const assign = require('Object.assign');
+const emptyObject = require('emptyObject');
+const invariant = require('invariant');
+const shouldUpdateReactComponent = require('shouldUpdateReactComponent');
+const warning = require('warning');
 
 function getDeclarationErrorAddendum(component) {
-  var owner = component._currentElement._owner || null;
+  const owner = component._currentElement._owner || null;
   if (owner) {
-    var name = owner.getName();
+    const name = owner.getName();
     if (name) {
       return ' Check the render method of `' + name + '`.';
     }
@@ -43,8 +43,8 @@ function getDeclarationErrorAddendum(component) {
 function StatelessComponent(Component) {
 }
 StatelessComponent.prototype.render = function() {
-  var Component = ReactInstanceMap.get(this)._currentElement.type;
-  var element = Component(this.props, this.context, this.updater);
+  const Component = ReactInstanceMap.get(this)._currentElement.type;
+  const element = Component(this.props, this.context, this.updater);
   warnIfInvalidElement(Component, element);
   return element;
 };
@@ -93,12 +93,12 @@ function warnIfInvalidElement(Component, element) {
  *
  * @private
  */
-var nextMountID = 1;
+let nextMountID = 1;
 
 /**
  * @lends {ReactCompositeComponent.prototype}
  */
-var ReactCompositeComponentMixin = {
+const ReactCompositeComponentMixin = {
 
   /**
    * Base constructor for all composite component.
@@ -152,14 +152,14 @@ var ReactCompositeComponentMixin = {
     this._nativeParent = nativeParent;
     this._nativeContainerInfo = nativeContainerInfo;
 
-    var publicProps = this._processProps(this._currentElement.props);
-    var publicContext = this._processContext(context);
+    const publicProps = this._processProps(this._currentElement.props);
+    const publicContext = this._processContext(context);
 
-    var Component = this._currentElement.type;
+    const Component = this._currentElement.type;
 
     // Initialize the public class
-    var inst;
-    var renderedElement;
+    let inst;
+    let renderedElement;
 
     if (Component.prototype && Component.prototype.isReactComponent) {
       if (__DEV__) {
@@ -210,8 +210,8 @@ var ReactCompositeComponentMixin = {
         );
       }
 
-      var propsMutated = inst.props !== publicProps;
-      var componentName =
+      const propsMutated = inst.props !== publicProps;
+      const componentName =
         Component.displayName || Component.name || 'Component';
 
       warning(
@@ -289,7 +289,7 @@ var ReactCompositeComponentMixin = {
       );
     }
 
-    var initialState = inst.state;
+    let initialState = inst.state;
     if (initialState === undefined) {
       inst.state = initialState = null;
     }
@@ -303,7 +303,7 @@ var ReactCompositeComponentMixin = {
     this._pendingReplaceState = false;
     this._pendingForceUpdate = false;
 
-    var markup;
+    let markup;
     if (inst.unstable_handleError) {
       markup = this.performInitialMountWithErrorHandling(
         renderedElement,
@@ -330,8 +330,8 @@ var ReactCompositeComponentMixin = {
     transaction,
     context
   ) {
-    var markup;
-    var checkpoint = transaction.checkpoint();
+    let markup;
+    let checkpoint = transaction.checkpoint();
     try {
       markup = this.performInitialMount(renderedElement, nativeParent, nativeContainerInfo, transaction, context);
     } catch (e) {
@@ -354,7 +354,7 @@ var ReactCompositeComponentMixin = {
   },
 
   performInitialMount: function(renderedElement, nativeParent, nativeContainerInfo, transaction, context) {
-    var inst = this._instance;
+    const inst = this._instance;
     if (inst.componentWillMount) {
       inst.componentWillMount();
       // When mounting, calls to `setState` by `componentWillMount` will set
@@ -374,7 +374,7 @@ var ReactCompositeComponentMixin = {
       renderedElement
     );
 
-    var markup = ReactReconciler.mountComponent(
+    const markup = ReactReconciler.mountComponent(
       this._renderedComponent,
       transaction,
       nativeParent,
@@ -399,11 +399,11 @@ var ReactCompositeComponentMixin = {
     if (!this._renderedComponent) {
       return;
     }
-    var inst = this._instance;
+    const inst = this._instance;
 
     if (inst.componentWillUnmount) {
       if (safely) {
-        var name = this.getName() + '.componentWillUnmount()';
+        const name = this.getName() + '.componentWillUnmount()';
         ReactErrorUtils.invokeGuardedCallback(name, inst.componentWillUnmount.bind(inst));
       } else {
         inst.componentWillUnmount();
@@ -453,13 +453,13 @@ var ReactCompositeComponentMixin = {
    * @private
    */
   _maskContext: function(context) {
-    var Component = this._currentElement.type;
-    var contextTypes = Component.contextTypes;
+    const Component = this._currentElement.type;
+    const contextTypes = Component.contextTypes;
     if (!contextTypes) {
       return emptyObject;
     }
-    var maskedContext = {};
-    for (var contextName in contextTypes) {
+    const maskedContext = {};
+    for (let contextName in contextTypes) {
       maskedContext[contextName] = context[contextName];
     }
     return maskedContext;
@@ -474,9 +474,9 @@ var ReactCompositeComponentMixin = {
    * @private
    */
   _processContext: function(context) {
-    var maskedContext = this._maskContext(context);
+    const maskedContext = this._maskContext(context);
     if (__DEV__) {
-      var Component = this._currentElement.type;
+      const Component = this._currentElement.type;
       if (Component.contextTypes) {
         this._checkPropTypes(
           Component.contextTypes,
@@ -494,9 +494,9 @@ var ReactCompositeComponentMixin = {
    * @private
    */
   _processChildContext: function(currentContext) {
-    var Component = this._currentElement.type;
-    var inst = this._instance;
-    var childContext = inst.getChildContext && inst.getChildContext();
+    const Component = this._currentElement.type;
+    const inst = this._instance;
+    const childContext = inst.getChildContext && inst.getChildContext();
     if (childContext) {
       invariant(
         typeof Component.childContextTypes === 'object',
@@ -511,7 +511,7 @@ var ReactCompositeComponentMixin = {
           ReactPropTypeLocations.childContext
         );
       }
-      for (var name in childContext) {
+      for (let name in childContext) {
         invariant(
           name in Component.childContextTypes,
           '%s.getChildContext(): key "%s" is not defined in childContextTypes.',
@@ -535,7 +535,7 @@ var ReactCompositeComponentMixin = {
    */
   _processProps: function(newProps) {
     if (__DEV__) {
-      var Component = this._currentElement.type;
+      const Component = this._currentElement.type;
       if (Component.propTypes) {
         this._checkPropTypes(
           Component.propTypes,
@@ -558,10 +558,10 @@ var ReactCompositeComponentMixin = {
   _checkPropTypes: function(propTypes, props, location) {
     // TODO: Stop validating prop types here and only use the element
     // validation.
-    var componentName = this.getName();
-    for (var propName in propTypes) {
+    const componentName = this.getName();
+    for (let propName in propTypes) {
       if (propTypes.hasOwnProperty(propName)) {
-        var error;
+        let error;
         try {
           // This is intentionally an invariant that gets caught. It's the same
           // behavior as without this statement except with a better message.
@@ -581,7 +581,7 @@ var ReactCompositeComponentMixin = {
           // We may want to extend this logic for similar errors in
           // top-level render calls, so I'm abstracting it away into
           // a function to minimize refactoring in the future
-          var addendum = getDeclarationErrorAddendum(this);
+          const addendum = getDeclarationErrorAddendum(this);
 
           if (location === ReactPropTypeLocations.prop) {
             // Preface gives us something to blacklist in warning module
@@ -605,8 +605,8 @@ var ReactCompositeComponentMixin = {
   },
 
   receiveComponent: function(nextElement, transaction, nextContext) {
-    var prevElement = this._currentElement;
-    var prevContext = this._context;
+    const prevElement = this._currentElement;
+    const prevContext = this._context;
 
     this._pendingElement = null;
 
@@ -669,10 +669,10 @@ var ReactCompositeComponentMixin = {
     prevUnmaskedContext,
     nextUnmaskedContext
   ) {
-    var inst = this._instance;
-    var willReceive = false;
-    var nextContext;
-    var nextProps;
+    const inst = this._instance;
+    let willReceive = false;
+    let nextContext;
+    let nextProps;
 
     // Determine if the context has changed or not
     if (this._context === nextUnmaskedContext) {
@@ -699,9 +699,9 @@ var ReactCompositeComponentMixin = {
       inst.componentWillReceiveProps(nextProps, nextContext);
     }
 
-    var nextState = this._processPendingState(nextProps, nextContext);
+    const nextState = this._processPendingState(nextProps, nextContext);
 
-    var shouldUpdate =
+    const shouldUpdate =
       this._pendingForceUpdate ||
       !inst.shouldComponentUpdate ||
       inst.shouldComponentUpdate(nextProps, nextState, nextContext);
@@ -738,9 +738,9 @@ var ReactCompositeComponentMixin = {
   },
 
   _processPendingState: function(props, context) {
-    var inst = this._instance;
-    var queue = this._pendingStateQueue;
-    var replace = this._pendingReplaceState;
+    const inst = this._instance;
+    const queue = this._pendingStateQueue;
+    const replace = this._pendingReplaceState;
     this._pendingReplaceState = false;
     this._pendingStateQueue = null;
 
@@ -752,9 +752,9 @@ var ReactCompositeComponentMixin = {
       return queue[0];
     }
 
-    var nextState = assign({}, replace ? queue[0] : inst.state);
-    for (var i = replace ? 1 : 0; i < queue.length; i++) {
-      var partial = queue[i];
+    const nextState = assign({}, replace ? queue[0] : inst.state);
+    for (let i = replace ? 1 : 0; i < queue.length; i++) {
+      const partial = queue[i];
       assign(
         nextState,
         typeof partial === 'function' ?
@@ -786,12 +786,12 @@ var ReactCompositeComponentMixin = {
     transaction,
     unmaskedContext
   ) {
-    var inst = this._instance;
+    const inst = this._instance;
 
-    var hasComponentDidUpdate = Boolean(inst.componentDidUpdate);
-    var prevProps;
-    var prevState;
-    var prevContext;
+    const hasComponentDidUpdate = Boolean(inst.componentDidUpdate);
+    let prevProps;
+    let prevState;
+    let prevContext;
     if (hasComponentDidUpdate) {
       prevProps = inst.props;
       prevState = inst.state;
@@ -825,9 +825,9 @@ var ReactCompositeComponentMixin = {
    * @internal
    */
   _updateRenderedComponent: function(transaction, context) {
-    var prevComponentInstance = this._renderedComponent;
-    var prevRenderedElement = prevComponentInstance._currentElement;
-    var nextRenderedElement = this._renderValidatedComponent();
+    const prevComponentInstance = this._renderedComponent;
+    const prevRenderedElement = prevComponentInstance._currentElement;
+    const nextRenderedElement = this._renderValidatedComponent();
     if (shouldUpdateReactComponent(prevRenderedElement, nextRenderedElement)) {
       ReactReconciler.receiveComponent(
         prevComponentInstance,
@@ -836,14 +836,14 @@ var ReactCompositeComponentMixin = {
         this._processChildContext(context)
       );
     } else {
-      var oldNativeNode = ReactReconciler.getNativeNode(prevComponentInstance);
+      const oldNativeNode = ReactReconciler.getNativeNode(prevComponentInstance);
       ReactReconciler.unmountComponent(prevComponentInstance, false);
 
       this._renderedNodeType = ReactNodeTypes.getType(nextRenderedElement);
       this._renderedComponent = this._instantiateReactComponent(
         nextRenderedElement
       );
-      var nextMarkup = ReactReconciler.mountComponent(
+      const nextMarkup = ReactReconciler.mountComponent(
         this._renderedComponent,
         transaction,
         this._nativeParent,
@@ -870,8 +870,8 @@ var ReactCompositeComponentMixin = {
    * @protected
    */
   _renderValidatedComponentWithoutOwnerOrContext: function() {
-    var inst = this._instance;
-    var renderedComponent = inst.render();
+    const inst = this._instance;
+    let renderedComponent = inst.render();
     if (__DEV__) {
       // We allow auto-mocks to proceed as if they're returning null.
       if (renderedComponent === undefined &&
@@ -889,7 +889,7 @@ var ReactCompositeComponentMixin = {
    * @private
    */
   _renderValidatedComponent: function() {
-    var renderedComponent;
+    let renderedComponent;
     ReactCurrentOwner.current = this;
     try {
       renderedComponent =
@@ -917,11 +917,11 @@ var ReactCompositeComponentMixin = {
    * @private
    */
   attachRef: function(ref, component) {
-    var inst = this.getPublicInstance();
+    const inst = this.getPublicInstance();
     invariant(inst != null, 'Stateless function components cannot have refs.');
-    var publicComponentInstance = component.getPublicInstance();
+    const publicComponentInstance = component.getPublicInstance();
     if (__DEV__) {
-      var componentName = component && component.getName ?
+      const componentName = component && component.getName ?
         component.getName() : 'a component';
       warning(publicComponentInstance != null,
         'Stateless function components cannot be given refs ' +
@@ -932,7 +932,7 @@ var ReactCompositeComponentMixin = {
         this.getName()
       );
     }
-    var refs = inst.refs === emptyObject ? (inst.refs = {}) : inst.refs;
+    const refs = inst.refs === emptyObject ? (inst.refs = {}) : inst.refs;
     refs[ref] = publicComponentInstance;
   },
 
@@ -944,7 +944,7 @@ var ReactCompositeComponentMixin = {
    * @private
    */
   detachRef: function(ref) {
-    var refs = this.getPublicInstance().refs;
+    const refs = this.getPublicInstance().refs;
     delete refs[ref];
   },
 
@@ -955,8 +955,8 @@ var ReactCompositeComponentMixin = {
    * @internal
    */
   getName: function() {
-    var type = this._currentElement.type;
-    var constructor = this._instance && this._instance.constructor;
+    const type = this._currentElement.type;
+    const constructor = this._instance && this._instance.constructor;
     return (
       type.displayName || (constructor && constructor.displayName) ||
       type.name || (constructor && constructor.name) ||
@@ -973,7 +973,7 @@ var ReactCompositeComponentMixin = {
    * @internal
    */
   getPublicInstance: function() {
-    var inst = this._instance;
+    const inst = this._instance;
     if (inst instanceof StatelessComponent) {
       return null;
     }
@@ -995,7 +995,7 @@ ReactPerf.measureMethods(
   }
 );
 
-var ReactCompositeComponent = {
+const ReactCompositeComponent = {
 
   Mixin: ReactCompositeComponentMixin,
 

--- a/src/renderers/shared/reconciler/ReactDefaultBatchingStrategy.js
+++ b/src/renderers/shared/reconciler/ReactDefaultBatchingStrategy.js
@@ -11,25 +11,25 @@
 
 'use strict';
 
-var ReactUpdates = require('ReactUpdates');
-var Transaction = require('Transaction');
+const ReactUpdates = require('ReactUpdates');
+const Transaction = require('Transaction');
 
-var assign = require('Object.assign');
-var emptyFunction = require('emptyFunction');
+const assign = require('Object.assign');
+const emptyFunction = require('emptyFunction');
 
-var RESET_BATCHED_UPDATES = {
+const RESET_BATCHED_UPDATES = {
   initialize: emptyFunction,
   close: function() {
     ReactDefaultBatchingStrategy.isBatchingUpdates = false;
   },
 };
 
-var FLUSH_BATCHED_UPDATES = {
+const FLUSH_BATCHED_UPDATES = {
   initialize: emptyFunction,
   close: ReactUpdates.flushBatchedUpdates.bind(ReactUpdates),
 };
 
-var TRANSACTION_WRAPPERS = [FLUSH_BATCHED_UPDATES, RESET_BATCHED_UPDATES];
+const TRANSACTION_WRAPPERS = [FLUSH_BATCHED_UPDATES, RESET_BATCHED_UPDATES];
 
 function ReactDefaultBatchingStrategyTransaction() {
   this.reinitializeTransaction();
@@ -45,7 +45,7 @@ assign(
   }
 );
 
-var transaction = new ReactDefaultBatchingStrategyTransaction();
+const transaction = new ReactDefaultBatchingStrategyTransaction();
 
 var ReactDefaultBatchingStrategy = {
   isBatchingUpdates: false,
@@ -55,7 +55,7 @@ var ReactDefaultBatchingStrategy = {
    * and friends are batched such that components aren't updated unnecessarily.
    */
   batchedUpdates: function(callback, a, b, c, d, e) {
-    var alreadyBatchingUpdates = ReactDefaultBatchingStrategy.isBatchingUpdates;
+    const alreadyBatchingUpdates = ReactDefaultBatchingStrategy.isBatchingUpdates;
 
     ReactDefaultBatchingStrategy.isBatchingUpdates = true;
 

--- a/src/renderers/shared/reconciler/ReactEmptyComponent.js
+++ b/src/renderers/shared/reconciler/ReactEmptyComponent.js
@@ -11,15 +11,15 @@
 
 'use strict';
 
-var emptyComponentFactory;
+let emptyComponentFactory;
 
-var ReactEmptyComponentInjection = {
+const ReactEmptyComponentInjection = {
   injectEmptyComponentFactory: function(factory) {
     emptyComponentFactory = factory;
   },
 };
 
-var ReactEmptyComponent = {
+const ReactEmptyComponent = {
   create: function(instantiate) {
     return emptyComponentFactory(instantiate);
   },

--- a/src/renderers/shared/reconciler/ReactEventEmitterMixin.js
+++ b/src/renderers/shared/reconciler/ReactEventEmitterMixin.js
@@ -11,14 +11,14 @@
 
 'use strict';
 
-var EventPluginHub = require('EventPluginHub');
+const EventPluginHub = require('EventPluginHub');
 
 function runEventQueueInBatch(events) {
   EventPluginHub.enqueueEvents(events);
   EventPluginHub.processEventQueue(false);
 }
 
-var ReactEventEmitterMixin = {
+const ReactEventEmitterMixin = {
 
   /**
    * Streams a fired top-level event to `EventPluginHub` where plugins have the
@@ -29,7 +29,7 @@ var ReactEventEmitterMixin = {
       targetInst,
       nativeEvent,
       nativeEventTarget) {
-    var events = EventPluginHub.extractEvents(
+    const events = EventPluginHub.extractEvents(
       topLevelType,
       targetInst,
       nativeEvent,

--- a/src/renderers/shared/reconciler/ReactInstanceHandles.js
+++ b/src/renderers/shared/reconciler/ReactInstanceHandles.js
@@ -11,15 +11,15 @@
 
 'use strict';
 
-var invariant = require('invariant');
+const invariant = require('invariant');
 
-var SEPARATOR = '.';
-var SEPARATOR_LENGTH = SEPARATOR.length;
+const SEPARATOR = '.';
+const SEPARATOR_LENGTH = SEPARATOR.length;
 
 /**
  * Maximum depth of traversals before we consider the possibility of a bad ID.
  */
-var MAX_TREE_DEPTH = 10000;
+const MAX_TREE_DEPTH = 10000;
 
 /**
  * Creates a DOM ID prefix to use when mounting React components.
@@ -111,8 +111,8 @@ function getNextDescendantID(ancestorID, destinationID) {
   }
   // Skip over the ancestor and the immediate separator. Traverse until we hit
   // another separator or we reach the end of `destinationID`.
-  var start = ancestorID.length + SEPARATOR_LENGTH;
-  var i;
+  const start = ancestorID.length + SEPARATOR_LENGTH;
+  let i;
   for (i = start; i < destinationID.length; i++) {
     if (isBoundary(destinationID, i)) {
       break;
@@ -133,20 +133,20 @@ function getNextDescendantID(ancestorID, destinationID) {
  * @private
  */
 function getFirstCommonAncestorID(oneID, twoID) {
-  var minLength = Math.min(oneID.length, twoID.length);
+  const minLength = Math.min(oneID.length, twoID.length);
   if (minLength === 0) {
     return '';
   }
-  var lastCommonMarkerIndex = 0;
+  let lastCommonMarkerIndex = 0;
   // Use `<=` to traverse until the "EOL" of the shorter string.
-  for (var i = 0; i <= minLength; i++) {
+  for (let i = 0; i <= minLength; i++) {
     if (isBoundary(oneID, i) && isBoundary(twoID, i)) {
       lastCommonMarkerIndex = i;
     } else if (oneID.charAt(i) !== twoID.charAt(i)) {
       break;
     }
   }
-  var longestCommonID = oneID.substr(0, lastCommonMarkerIndex);
+  const longestCommonID = oneID.substr(0, lastCommonMarkerIndex);
   invariant(
     isValidID(longestCommonID),
     'getFirstCommonAncestorID(%s, %s): Expected a valid React DOM ID: %s',
@@ -178,7 +178,7 @@ function traverseParentPath(start, stop, cb, arg, skipFirst, skipLast) {
     'traverseParentPath(...): Cannot traverse from and to the same ID, `%s`.',
     start
   );
-  var traverseUp = isAncestorIDOf(stop, start);
+  const traverseUp = isAncestorIDOf(stop, start);
   invariant(
     traverseUp || isAncestorIDOf(start, stop),
     'traverseParentPath(%s, %s, ...): Cannot traverse from two IDs that do ' +
@@ -187,10 +187,10 @@ function traverseParentPath(start, stop, cb, arg, skipFirst, skipLast) {
     stop
   );
   // Traverse from `start` to `stop` one depth at a time.
-  var depth = 0;
-  var traverse = traverseUp ? getParentID : getNextDescendantID;
-  for (var id = start; /* until break */; id = traverse(id, stop)) {
-    var ret;
+  let depth = 0;
+  const traverse = traverseUp ? getParentID : getNextDescendantID;
+  for (let id = start; /* until break */; id = traverse(id, stop)) {
+    let ret;
     if ((!skipFirst || id !== start) && (!skipLast || id !== stop)) {
       ret = cb(id, traverseUp, arg);
     }
@@ -214,7 +214,7 @@ function traverseParentPath(start, stop, cb, arg, skipFirst, skipLast) {
  *
  * @internal
  */
-var ReactInstanceHandles = {
+const ReactInstanceHandles = {
 
   /**
    * Constructs a React root ID
@@ -247,7 +247,7 @@ var ReactInstanceHandles = {
    */
   getReactRootIDFromNodeID: function(id) {
     if (id && id.charAt(0) === SEPARATOR && id.length > 1) {
-      var index = id.indexOf(SEPARATOR, 1);
+      const index = id.indexOf(SEPARATOR, 1);
       return index > -1 ? id.substr(0, index) : id;
     }
     return null;
@@ -268,7 +268,7 @@ var ReactInstanceHandles = {
    * @internal
    */
   traverseEnterLeave: function(leaveID, enterID, cb, upArg, downArg) {
-    var ancestorID = getFirstCommonAncestorID(leaveID, enterID);
+    const ancestorID = getFirstCommonAncestorID(leaveID, enterID);
     if (ancestorID !== leaveID) {
       traverseParentPath(leaveID, ancestorID, cb, upArg, false, true);
     }

--- a/src/renderers/shared/reconciler/ReactInstanceMap.js
+++ b/src/renderers/shared/reconciler/ReactInstanceMap.js
@@ -19,7 +19,7 @@
  */
 
 // TODO: Replace this with ES6: var ReactInstanceMap = new Map();
-var ReactInstanceMap = {
+const ReactInstanceMap = {
 
   /**
    * This API should be called `delete` but we'd have to make sure to always

--- a/src/renderers/shared/reconciler/ReactMultiChild.js
+++ b/src/renderers/shared/reconciler/ReactMultiChild.js
@@ -11,15 +11,15 @@
 
 'use strict';
 
-var ReactComponentEnvironment = require('ReactComponentEnvironment');
-var ReactMultiChildUpdateTypes = require('ReactMultiChildUpdateTypes');
+const ReactComponentEnvironment = require('ReactComponentEnvironment');
+const ReactMultiChildUpdateTypes = require('ReactMultiChildUpdateTypes');
 
-var ReactCurrentOwner = require('ReactCurrentOwner');
-var ReactReconciler = require('ReactReconciler');
-var ReactChildReconciler = require('ReactChildReconciler');
+const ReactCurrentOwner = require('ReactCurrentOwner');
+const ReactReconciler = require('ReactReconciler');
+const ReactChildReconciler = require('ReactChildReconciler');
 
-var flattenChildren = require('flattenChildren');
-var invariant = require('invariant');
+const flattenChildren = require('flattenChildren');
+const invariant = require('invariant');
 
 /**
  * Make an update for markup to be rendered and inserted at a supplied index.
@@ -143,7 +143,7 @@ function processQueue(inst, updateQueue) {
  * @class ReactMultiChild
  * @internal
  */
-var ReactMultiChild = {
+const ReactMultiChild = {
 
   /**
    * Provides common functionality for components that must reconcile multiple
@@ -179,7 +179,7 @@ var ReactMultiChild = {
       transaction,
       context
     ) {
-      var nextChildren;
+      let nextChildren;
       if (__DEV__) {
         if (this._currentElement) {
           try {
@@ -210,16 +210,16 @@ var ReactMultiChild = {
      * @internal
      */
     mountChildren: function(nestedChildren, transaction, context) {
-      var children = this._reconcilerInstantiateChildren(
+      const children = this._reconcilerInstantiateChildren(
         nestedChildren, transaction, context
       );
       this._renderedChildren = children;
-      var mountImages = [];
-      var index = 0;
-      for (var name in children) {
+      const mountImages = [];
+      let index = 0;
+      for (let name in children) {
         if (children.hasOwnProperty(name)) {
-          var child = children[name];
-          var mountImage = ReactReconciler.mountComponent(
+          const child = children[name];
+          const mountImage = ReactReconciler.mountComponent(
             child,
             transaction,
             this,
@@ -240,16 +240,16 @@ var ReactMultiChild = {
      * @internal
      */
     updateTextContent: function(nextContent) {
-      var prevChildren = this._renderedChildren;
+      const prevChildren = this._renderedChildren;
       // Remove any rendered children.
       ReactChildReconciler.unmountChildren(prevChildren, false);
-      for (var name in prevChildren) {
+      for (let name in prevChildren) {
         if (prevChildren.hasOwnProperty(name)) {
           invariant(false, 'updateTextContent called on non-empty component.');
         }
       }
       // Set new text content.
-      var updates = [makeTextContent(nextContent)];
+      const updates = [makeTextContent(nextContent)];
       processQueue(this, updates);
     },
 
@@ -260,15 +260,15 @@ var ReactMultiChild = {
      * @internal
      */
     updateMarkup: function(nextMarkup) {
-      var prevChildren = this._renderedChildren;
+      const prevChildren = this._renderedChildren;
       // Remove any rendered children.
       ReactChildReconciler.unmountChildren(prevChildren, false);
-      for (var name in prevChildren) {
+      for (let name in prevChildren) {
         if (prevChildren.hasOwnProperty(name)) {
           invariant(false, 'updateTextContent called on non-empty component.');
         }
       }
-      var updates = [makeSetMarkup(nextMarkup)];
+      const updates = [makeSetMarkup(nextMarkup)];
       processQueue(this, updates);
     },
 
@@ -291,9 +291,9 @@ var ReactMultiChild = {
      * @protected
      */
     _updateChildren: function(nextNestedChildrenElements, transaction, context) {
-      var prevChildren = this._renderedChildren;
-      var removedNodes = {};
-      var nextChildren = this._reconcilerUpdateChildren(
+      const prevChildren = this._renderedChildren;
+      const removedNodes = {};
+      const nextChildren = this._reconcilerUpdateChildren(
         prevChildren,
         nextNestedChildrenElements,
         removedNodes,
@@ -303,19 +303,19 @@ var ReactMultiChild = {
       if (!nextChildren && !prevChildren) {
         return;
       }
-      var updates = null;
-      var name;
+      let updates = null;
+      let name;
       // `nextIndex` will increment for each child in `nextChildren`, but
       // `lastIndex` will be the last index visited in `prevChildren`.
-      var lastIndex = 0;
-      var nextIndex = 0;
-      var lastPlacedNode = null;
+      let lastIndex = 0;
+      let nextIndex = 0;
+      let lastPlacedNode = null;
       for (name in nextChildren) {
         if (!nextChildren.hasOwnProperty(name)) {
           continue;
         }
-        var prevChild = prevChildren && prevChildren[name];
-        var nextChild = nextChildren[name];
+        const prevChild = prevChildren && prevChildren[name];
+        const nextChild = nextChildren[name];
         if (prevChild === nextChild) {
           updates = enqueue(
             updates,
@@ -367,7 +367,7 @@ var ReactMultiChild = {
      * @internal
      */
     unmountChildren: function(safely) {
-      var renderedChildren = this._renderedChildren;
+      const renderedChildren = this._renderedChildren;
       ReactChildReconciler.unmountChildren(renderedChildren, safely);
       this._renderedChildren = null;
     },
@@ -427,7 +427,7 @@ var ReactMultiChild = {
       index,
       transaction,
       context) {
-      var mountImage = ReactReconciler.mountComponent(
+      const mountImage = ReactReconciler.mountComponent(
         child,
         transaction,
         this,
@@ -447,7 +447,7 @@ var ReactMultiChild = {
      * @private
      */
     _unmountChild: function(child, node) {
-      var update = this.removeChild(child, node);
+      const update = this.removeChild(child, node);
       child._mountIndex = null;
       return update;
     },

--- a/src/renderers/shared/reconciler/ReactMultiChild.js
+++ b/src/renderers/shared/reconciler/ReactMultiChild.js
@@ -216,7 +216,7 @@ const ReactMultiChild = {
       this._renderedChildren = children;
       const mountImages = [];
       let index = 0;
-      for (let name in children) {
+      for (const name in children) {
         if (children.hasOwnProperty(name)) {
           const child = children[name];
           const mountImage = ReactReconciler.mountComponent(
@@ -243,7 +243,7 @@ const ReactMultiChild = {
       const prevChildren = this._renderedChildren;
       // Remove any rendered children.
       ReactChildReconciler.unmountChildren(prevChildren, false);
-      for (let name in prevChildren) {
+      for (const name in prevChildren) {
         if (prevChildren.hasOwnProperty(name)) {
           invariant(false, 'updateTextContent called on non-empty component.');
         }
@@ -263,7 +263,7 @@ const ReactMultiChild = {
       const prevChildren = this._renderedChildren;
       // Remove any rendered children.
       ReactChildReconciler.unmountChildren(prevChildren, false);
-      for (let name in prevChildren) {
+      for (const name in prevChildren) {
         if (prevChildren.hasOwnProperty(name)) {
           invariant(false, 'updateTextContent called on non-empty component.');
         }

--- a/src/renderers/shared/reconciler/ReactMultiChildUpdateTypes.js
+++ b/src/renderers/shared/reconciler/ReactMultiChildUpdateTypes.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var keyMirror = require('keyMirror');
+const keyMirror = require('keyMirror');
 
 /**
  * When a component's children are updated, a series of update configuration
@@ -21,7 +21,7 @@ var keyMirror = require('keyMirror');
  *
  * @internal
  */
-var ReactMultiChildUpdateTypes = keyMirror({
+const ReactMultiChildUpdateTypes = keyMirror({
   INSERT_MARKUP: null,
   MOVE_EXISTING: null,
   REMOVE_NODE: null,

--- a/src/renderers/shared/reconciler/ReactNativeComponent.js
+++ b/src/renderers/shared/reconciler/ReactNativeComponent.js
@@ -11,16 +11,16 @@
 
 'use strict';
 
-var assign = require('Object.assign');
-var invariant = require('invariant');
+const assign = require('Object.assign');
+const invariant = require('invariant');
 
-var autoGenerateWrapperClass = null;
-var genericComponentClass = null;
+const autoGenerateWrapperClass = null;
+let genericComponentClass = null;
 // This registry keeps track of wrapper classes around native tags.
-var tagToComponentClass = {};
-var textComponentClass = null;
+const tagToComponentClass = {};
+let textComponentClass = null;
 
-var ReactNativeComponentInjection = {
+const ReactNativeComponentInjection = {
   // This accepts a class that receives the tag string. This is a catch all
   // that can render any kind of tag.
   injectGenericComponentClass: function(componentClass) {
@@ -48,8 +48,8 @@ function getComponentClassForElement(element) {
   if (typeof element.type === 'function') {
     return element.type;
   }
-  var tag = element.type;
-  var componentClass = tagToComponentClass[tag];
+  const tag = element.type;
+  let componentClass = tagToComponentClass[tag];
   if (componentClass == null) {
     tagToComponentClass[tag] = componentClass = autoGenerateWrapperClass(tag);
   }
@@ -87,7 +87,7 @@ function isTextComponent(component) {
   return component instanceof textComponentClass;
 }
 
-var ReactNativeComponent = {
+const ReactNativeComponent = {
   getComponentClassForElement: getComponentClassForElement,
   createInternalComponent: createInternalComponent,
   createInstanceForText: createInstanceForText,

--- a/src/renderers/shared/reconciler/ReactOwner.js
+++ b/src/renderers/shared/reconciler/ReactOwner.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var invariant = require('invariant');
+const invariant = require('invariant');
 
 /**
  * ReactOwners are capable of storing references to owned components.
@@ -43,7 +43,7 @@ var invariant = require('invariant');
  *
  * @class ReactOwner
  */
-var ReactOwner = {
+const ReactOwner = {
 
   /**
    * @param {?object} object

--- a/src/renderers/shared/reconciler/ReactReconciler.js
+++ b/src/renderers/shared/reconciler/ReactReconciler.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var ReactRef = require('ReactRef');
+const ReactRef = require('ReactRef');
 
 /**
  * Helper to call ReactRef.attachRefs with this composite component, split out
@@ -21,7 +21,7 @@ function attachRefs() {
   ReactRef.attachRefs(this, this._currentElement);
 }
 
-var ReactReconciler = {
+const ReactReconciler = {
 
   /**
    * Initializes the component, renders markup, and registers event listeners.
@@ -41,7 +41,7 @@ var ReactReconciler = {
     nativeContainerInfo,
     context
   ) {
-    var markup = internalInstance.mountComponent(
+    const markup = internalInstance.mountComponent(
       transaction,
       nativeParent,
       nativeContainerInfo,
@@ -85,7 +85,7 @@ var ReactReconciler = {
   receiveComponent: function(
     internalInstance, nextElement, transaction, context
   ) {
-    var prevElement = internalInstance._currentElement;
+    const prevElement = internalInstance._currentElement;
 
     if (nextElement === prevElement &&
         context === internalInstance._context
@@ -103,7 +103,7 @@ var ReactReconciler = {
       return;
     }
 
-    var refsChanged = ReactRef.shouldUpdateRefs(
+    const refsChanged = ReactRef.shouldUpdateRefs(
       prevElement,
       nextElement
     );

--- a/src/renderers/shared/reconciler/ReactRef.js
+++ b/src/renderers/shared/reconciler/ReactRef.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-var ReactOwner = require('ReactOwner');
+const ReactOwner = require('ReactOwner');
 
-var ReactRef = {};
+const ReactRef = {};
 
 function attachRef(ref, component, owner) {
   if (typeof ref === 'function') {
@@ -37,7 +37,7 @@ ReactRef.attachRefs = function(instance, element) {
   if (element === null || element === false) {
     return;
   }
-  var ref = element.ref;
+  const ref = element.ref;
   if (ref != null) {
     attachRef(ref, instance, element._owner);
   }
@@ -56,8 +56,8 @@ ReactRef.shouldUpdateRefs = function(prevElement, nextElement) {
   // is made. It probably belongs where the key checking and
   // instantiateReactComponent is done.
 
-  var prevEmpty = prevElement === null || prevElement === false;
-  var nextEmpty = nextElement === null || nextElement === false;
+  const prevEmpty = prevElement === null || prevElement === false;
+  const nextEmpty = nextElement === null || nextElement === false;
 
   return (
     // This has a few false positives w/r/t empty components.
@@ -71,7 +71,7 @@ ReactRef.detachRefs = function(instance, element) {
   if (element === null || element === false) {
     return;
   }
-  var ref = element.ref;
+  const ref = element.ref;
   if (ref != null) {
     detachRef(ref, instance, element._owner);
   }

--- a/src/renderers/shared/reconciler/ReactSimpleEmptyComponent.js
+++ b/src/renderers/shared/reconciler/ReactSimpleEmptyComponent.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-var ReactReconciler = require('ReactReconciler');
+const ReactReconciler = require('ReactReconciler');
 
-var assign = require('Object.assign');
+const assign = require('Object.assign');
 
-var ReactSimpleEmptyComponent = function(placeholderElement, instantiate) {
+const ReactSimpleEmptyComponent = function(placeholderElement, instantiate) {
   this._currentElement = null;
   this._renderedComponent = instantiate(placeholderElement);
 };

--- a/src/renderers/shared/reconciler/ReactStateSetters.js
+++ b/src/renderers/shared/reconciler/ReactStateSetters.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var ReactStateSetters = {
+const ReactStateSetters = {
   /**
    * Returns a function that calls the provided function, and uses the result
    * of that to set the component's state.
@@ -24,7 +24,7 @@ var ReactStateSetters = {
    */
   createStateSetter: function(component, funcReturningState) {
     return function(a, b, c, d, e, f) {
-      var partialState = funcReturningState.call(component, a, b, c, d, e, f);
+      const partialState = funcReturningState.call(component, a, b, c, d, e, f);
       if (partialState) {
         component.setState(partialState);
       }
@@ -44,7 +44,7 @@ var ReactStateSetters = {
    */
   createStateKeySetter: function(component, key) {
     // Memoize the setters.
-    var cache = component.__keySetters || (component.__keySetters = {});
+    const cache = component.__keySetters || (component.__keySetters = {});
     return cache[key] || (cache[key] = createStateKeySetter(component, key));
   },
 };
@@ -53,7 +53,7 @@ function createStateKeySetter(component, key) {
   // Partial state is allocated outside of the function closure so it can be
   // reused with every call, avoiding memory allocation when this function
   // is called.
-  var partialState = {};
+  const partialState = {};
   return function stateKeySetter(value) {
     partialState[key] = value;
     component.setState(partialState);

--- a/src/renderers/shared/reconciler/ReactUpdateQueue.js
+++ b/src/renderers/shared/reconciler/ReactUpdateQueue.js
@@ -11,21 +11,21 @@
 
 'use strict';
 
-var ReactCurrentOwner = require('ReactCurrentOwner');
-var ReactElement = require('ReactElement');
-var ReactInstanceMap = require('ReactInstanceMap');
-var ReactUpdates = require('ReactUpdates');
+const ReactCurrentOwner = require('ReactCurrentOwner');
+const ReactElement = require('ReactElement');
+const ReactInstanceMap = require('ReactInstanceMap');
+const ReactUpdates = require('ReactUpdates');
 
-var assign = require('Object.assign');
-var invariant = require('invariant');
-var warning = require('warning');
+const assign = require('Object.assign');
+const invariant = require('invariant');
+const warning = require('warning');
 
 function enqueueUpdate(internalInstance) {
   ReactUpdates.enqueueUpdate(internalInstance);
 }
 
 function getInternalInstanceReadyForUpdate(publicInstance, callerName) {
-  var internalInstance = ReactInstanceMap.get(publicInstance);
+  const internalInstance = ReactInstanceMap.get(publicInstance);
   if (!internalInstance) {
     if (__DEV__) {
       // Only warn when we have a callerName. Otherwise we should be silent.
@@ -63,7 +63,7 @@ function getInternalInstanceReadyForUpdate(publicInstance, callerName) {
  * ReactUpdateQueue allows for state updates to be scheduled into a later
  * reconciliation step.
  */
-var ReactUpdateQueue = {
+const ReactUpdateQueue = {
 
   /**
    * Checks whether or not this composite component is mounted.
@@ -74,7 +74,7 @@ var ReactUpdateQueue = {
    */
   isMounted: function(publicInstance) {
     if (__DEV__) {
-      var owner = ReactCurrentOwner.current;
+      const owner = ReactCurrentOwner.current;
       if (owner !== null) {
         warning(
           owner._warnedAboutRefsInRender,
@@ -88,7 +88,7 @@ var ReactUpdateQueue = {
         owner._warnedAboutRefsInRender = true;
       }
     }
-    var internalInstance = ReactInstanceMap.get(publicInstance);
+    const internalInstance = ReactInstanceMap.get(publicInstance);
     if (internalInstance) {
       // During componentWillMount and render this will still be null but after
       // that will always render to something. At least for now. So we can use
@@ -116,7 +116,7 @@ var ReactUpdateQueue = {
       typeof callback === 'object' && Object.keys(callback).length && Object.keys(callback).length < 20 ?
         typeof callback + ' (keys: ' + Object.keys(callback) + ')' : typeof callback
     );
-    var internalInstance = getInternalInstanceReadyForUpdate(publicInstance);
+    const internalInstance = getInternalInstanceReadyForUpdate(publicInstance);
 
     // Previously we would throw an error if we didn't have an internal
     // instance. Since we want to make it a no-op instead, we mirror the same
@@ -170,7 +170,7 @@ var ReactUpdateQueue = {
    * @internal
    */
   enqueueForceUpdate: function(publicInstance) {
-    var internalInstance = getInternalInstanceReadyForUpdate(
+    const internalInstance = getInternalInstanceReadyForUpdate(
       publicInstance,
       'forceUpdate'
     );
@@ -196,7 +196,7 @@ var ReactUpdateQueue = {
    * @internal
    */
   enqueueReplaceState: function(publicInstance, completeState) {
-    var internalInstance = getInternalInstanceReadyForUpdate(
+    const internalInstance = getInternalInstanceReadyForUpdate(
       publicInstance,
       'replaceState'
     );
@@ -222,7 +222,7 @@ var ReactUpdateQueue = {
    * @internal
    */
   enqueueSetState: function(publicInstance, partialState) {
-    var internalInstance = getInternalInstanceReadyForUpdate(
+    const internalInstance = getInternalInstanceReadyForUpdate(
       publicInstance,
       'setState'
     );
@@ -231,7 +231,7 @@ var ReactUpdateQueue = {
       return;
     }
 
-    var queue =
+    const queue =
       internalInstance._pendingStateQueue ||
       (internalInstance._pendingStateQueue = []);
     queue.push(partialState);
@@ -247,7 +247,7 @@ var ReactUpdateQueue = {
    * @internal
    */
   enqueueSetProps: function(publicInstance, partialProps) {
-    var internalInstance = getInternalInstanceReadyForUpdate(
+    const internalInstance = getInternalInstanceReadyForUpdate(
       publicInstance,
       'setProps'
     );
@@ -258,7 +258,7 @@ var ReactUpdateQueue = {
   },
 
   enqueueSetPropsInternal: function(internalInstance, partialProps) {
-    var topLevelWrapper = internalInstance._topLevelWrapper;
+    const topLevelWrapper = internalInstance._topLevelWrapper;
     invariant(
       topLevelWrapper,
       'setProps(...): You called `setProps` on a ' +
@@ -270,9 +270,9 @@ var ReactUpdateQueue = {
 
     // Merge with the pending element if it exists, otherwise with existing
     // element props.
-    var wrapElement = topLevelWrapper._pendingElement ||
+    const wrapElement = topLevelWrapper._pendingElement ||
                       topLevelWrapper._currentElement;
-    var element = wrapElement.props;
+    const element = wrapElement.props;
     var props = assign({}, element.props, partialProps);
     topLevelWrapper._pendingElement = ReactElement.cloneAndReplaceProps(
       wrapElement,
@@ -290,7 +290,7 @@ var ReactUpdateQueue = {
    * @internal
    */
   enqueueReplaceProps: function(publicInstance, props) {
-    var internalInstance = getInternalInstanceReadyForUpdate(
+    const internalInstance = getInternalInstanceReadyForUpdate(
       publicInstance,
       'replaceProps'
     );
@@ -301,7 +301,7 @@ var ReactUpdateQueue = {
   },
 
   enqueueReplacePropsInternal: function(internalInstance, props) {
-    var topLevelWrapper = internalInstance._topLevelWrapper;
+    const topLevelWrapper = internalInstance._topLevelWrapper;
     invariant(
       topLevelWrapper,
       'replaceProps(...): You called `replaceProps` on a ' +
@@ -313,9 +313,9 @@ var ReactUpdateQueue = {
 
     // Merge with the pending element if it exists, otherwise with existing
     // element props.
-    var wrapElement = topLevelWrapper._pendingElement ||
+    const wrapElement = topLevelWrapper._pendingElement ||
                       topLevelWrapper._currentElement;
-    var element = wrapElement.props;
+    const element = wrapElement.props;
     topLevelWrapper._pendingElement = ReactElement.cloneAndReplaceProps(
       wrapElement,
       ReactElement.cloneAndReplaceProps(element, props)

--- a/src/renderers/shared/reconciler/ReactUpdates.js
+++ b/src/renderers/shared/reconciler/ReactUpdates.js
@@ -11,21 +11,21 @@
 
 'use strict';
 
-var CallbackQueue = require('CallbackQueue');
-var PooledClass = require('PooledClass');
-var ReactFeatureFlags = require('ReactFeatureFlags');
-var ReactPerf = require('ReactPerf');
-var ReactReconciler = require('ReactReconciler');
-var Transaction = require('Transaction');
+const CallbackQueue = require('CallbackQueue');
+const PooledClass = require('PooledClass');
+const ReactFeatureFlags = require('ReactFeatureFlags');
+const ReactPerf = require('ReactPerf');
+const ReactReconciler = require('ReactReconciler');
+const Transaction = require('Transaction');
 
-var assign = require('Object.assign');
-var invariant = require('invariant');
+const assign = require('Object.assign');
+const invariant = require('invariant');
 
-var dirtyComponents = [];
-var asapCallbackQueue = CallbackQueue.getPooled();
-var asapEnqueued = false;
+const dirtyComponents = [];
+let asapCallbackQueue = CallbackQueue.getPooled();
+let asapEnqueued = false;
 
-var batchingStrategy = null;
+let batchingStrategy = null;
 
 function ensureInjected() {
   invariant(
@@ -35,7 +35,7 @@ function ensureInjected() {
   );
 }
 
-var NESTED_UPDATES = {
+const NESTED_UPDATES = {
   initialize: function() {
     this.dirtyComponentsLength = dirtyComponents.length;
   },
@@ -54,7 +54,7 @@ var NESTED_UPDATES = {
   },
 };
 
-var UPDATE_QUEUEING = {
+const UPDATE_QUEUEING = {
   initialize: function() {
     this.callbackQueue.reset();
   },
@@ -63,7 +63,7 @@ var UPDATE_QUEUEING = {
   },
 };
 
-var TRANSACTION_WRAPPERS = [NESTED_UPDATES, UPDATE_QUEUEING];
+const TRANSACTION_WRAPPERS = [NESTED_UPDATES, UPDATE_QUEUEING];
 
 function ReactUpdatesFlushTransaction() {
   this.reinitializeTransaction();
@@ -124,7 +124,7 @@ function mountOrderComparator(c1, c2) {
 }
 
 function runBatchedUpdates(transaction) {
-  var len = transaction.dirtyComponentsLength;
+  const len = transaction.dirtyComponentsLength;
   invariant(
     len === dirtyComponents.length,
     'Expected flush transaction\'s stored dirty-components length (%s) to ' +
@@ -138,21 +138,21 @@ function runBatchedUpdates(transaction) {
   // them before their children by sorting the array.
   dirtyComponents.sort(mountOrderComparator);
 
-  for (var i = 0; i < len; i++) {
+  for (let i = 0; i < len; i++) {
     // If a component is unmounted before pending changes apply, it will still
     // be here, but we assume that it has cleared its _pendingCallbacks and
     // that performUpdateIfNecessary is a noop.
-    var component = dirtyComponents[i];
+    const component = dirtyComponents[i];
 
     // If performUpdateIfNecessary happens to enqueue any new updates, we
     // shouldn't execute the callbacks until the next render happens, so
     // stash the callbacks first
-    var callbacks = component._pendingCallbacks;
+    const callbacks = component._pendingCallbacks;
     component._pendingCallbacks = null;
 
-    var markerName;
+    let markerName;
     if (ReactFeatureFlags.logTopLevelRenders) {
-      var namedComponent = component;
+      let namedComponent = component;
       // Duck type TopLevelWrapper. This is probably always true.
       if (
         component._currentElement.props ===
@@ -174,7 +174,7 @@ function runBatchedUpdates(transaction) {
     }
 
     if (callbacks) {
-      for (var j = 0; j < callbacks.length; j++) {
+      for (let j = 0; j < callbacks.length; j++) {
         transaction.callbackQueue.enqueue(
           callbacks[j],
           component.getPublicInstance()
@@ -191,14 +191,14 @@ var flushBatchedUpdates = function() {
   // updates enqueued by setState callbacks and asap calls.
   while (dirtyComponents.length || asapEnqueued) {
     if (dirtyComponents.length) {
-      var transaction = ReactUpdatesFlushTransaction.getPooled();
+      const transaction = ReactUpdatesFlushTransaction.getPooled();
       transaction.perform(runBatchedUpdates, null, transaction);
       ReactUpdatesFlushTransaction.release(transaction);
     }
 
     if (asapEnqueued) {
       asapEnqueued = false;
-      var queue = asapCallbackQueue;
+      const queue = asapCallbackQueue;
       asapCallbackQueue = CallbackQueue.getPooled();
       queue.notifyAll();
       CallbackQueue.release(queue);
@@ -246,7 +246,7 @@ function asap(callback, context) {
   asapEnqueued = true;
 }
 
-var ReactUpdatesInjection = {
+const ReactUpdatesInjection = {
   injectReconcileTransaction: function(ReconcileTransaction) {
     invariant(
       ReconcileTransaction,

--- a/src/renderers/shared/reconciler/__tests__/ReactComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactComponent-test.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
-var ReactTestUtils;
+let React;
+let ReactDOM;
+let ReactTestUtils;
 
 describe('ReactComponent', function() {
   beforeEach(function() {
@@ -23,7 +23,7 @@ describe('ReactComponent', function() {
   });
 
   it('should throw on invalid render targets', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     // jQuery objects are basically arrays; people often pass them in by mistake
     expect(function() {
       ReactDOM.render(<div></div>, [container]);
@@ -39,17 +39,17 @@ describe('ReactComponent', function() {
   });
 
   it('should throw when supplying a ref outside of render method', function() {
-    var instance = <div ref="badDiv" />;
+    let instance = <div ref="badDiv" />;
     expect(function() {
       instance = ReactTestUtils.renderIntoDocument(instance);
     }).toThrow();
   });
 
   it('should support refs on owned components', function() {
-    var innerObj = {};
-    var outerObj = {};
+    const innerObj = {};
+    const outerObj = {};
 
-    var Wrapper = React.createClass({
+    const Wrapper = React.createClass({
 
       getObject: function() {
         return this.props.object;
@@ -61,10 +61,10 @@ describe('ReactComponent', function() {
 
     });
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
-        var inner = <Wrapper object={innerObj} ref="inner" />;
-        var outer = <Wrapper object={outerObj} ref="outer">{inner}</Wrapper>;
+        const inner = <Wrapper object={innerObj} ref="inner" />;
+        const outer = <Wrapper object={outerObj} ref="outer">{inner}</Wrapper>;
         return outer;
       },
       componentDidMount: function() {
@@ -73,12 +73,12 @@ describe('ReactComponent', function() {
       },
     });
 
-    var instance = <Component />;
+    let instance = <Component />;
     instance = ReactTestUtils.renderIntoDocument(instance);
   });
 
   it('should not have refs on unmounted components', function() {
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       render: function() {
         return <Child><div ref="test" /></Child>;
       },
@@ -86,21 +86,21 @@ describe('ReactComponent', function() {
         expect(this.refs && this.refs.test).toEqual(undefined);
       },
     });
-    var Child = React.createClass({
+    const Child = React.createClass({
       render: function() {
         return <div />;
       },
     });
 
-    var instance = <Parent child={<span />} />;
+    let instance = <Parent child={<span />} />;
     instance = ReactTestUtils.renderIntoDocument(instance);
   });
 
   it('should support new-style refs', function() {
-    var innerObj = {};
-    var outerObj = {};
+    const innerObj = {};
+    const outerObj = {};
 
-    var Wrapper = React.createClass({
+    const Wrapper = React.createClass({
       getObject: function() {
         return this.props.object;
       },
@@ -109,11 +109,11 @@ describe('ReactComponent', function() {
       },
     });
 
-    var mounted = false;
-    var Component = React.createClass({
+    let mounted = false;
+    const Component = React.createClass({
       render: function() {
-        var inner = <Wrapper object={innerObj} ref={(c) => this.innerRef = c} />;
-        var outer = (
+        const inner = <Wrapper object={innerObj} ref={(c) => this.innerRef = c} />;
+        const outer = (
           <Wrapper object={outerObj} ref={(c) => this.outerRef = c}>
             {inner}
           </Wrapper>
@@ -127,13 +127,13 @@ describe('ReactComponent', function() {
       },
     });
 
-    var instance = <Component />;
+    let instance = <Component />;
     instance = ReactTestUtils.renderIntoDocument(instance);
     expect(mounted).toBe(true);
   });
 
   it('should support new-style refs with mixed-up owners', function() {
-    var Wrapper = React.createClass({
+    const Wrapper = React.createClass({
       getTitle: function() {
         return this.props.title;
       },
@@ -142,8 +142,8 @@ describe('ReactComponent', function() {
       },
     });
 
-    var mounted = false;
-    var Component = React.createClass({
+    let mounted = false;
+    const Component = React.createClass({
       getInner: function() {
         // (With old-style refs, it's impossible to get a ref to this div
         // because Wrapper is the current owner when this function is called.)
@@ -166,15 +166,15 @@ describe('ReactComponent', function() {
       },
     });
 
-    var instance = <Component />;
+    let instance = <Component />;
     instance = ReactTestUtils.renderIntoDocument(instance);
     expect(mounted).toBe(true);
   });
 
   it('should call refs at the correct time', function() {
-    var log = [];
+    const log = [];
 
-    var Inner = React.createClass({
+    const Inner = React.createClass({
       render: function() {
         log.push(`inner ${this.props.id} render`);
         return <div />;
@@ -190,7 +190,7 @@ describe('ReactComponent', function() {
       },
     });
 
-    var Outer = React.createClass({
+    const Outer = React.createClass({
       render: function() {
         return (
           <div>
@@ -215,7 +215,7 @@ describe('ReactComponent', function() {
     });
 
     // mount, update, unmount
-    var el = document.createElement('div');
+    const el = document.createElement('div');
     log.push('start mount');
     ReactDOM.render(<Outer />, el);
     log.push('start update');
@@ -255,8 +255,8 @@ describe('ReactComponent', function() {
   });
 
   it('fires the callback after a component is rendered', function() {
-    var callback = jest.genMockFn();
-    var container = document.createElement('div');
+    const callback = jest.genMockFn();
+    const container = document.createElement('div');
     ReactDOM.render(<div />, container, callback);
     expect(callback.mock.calls.length).toBe(1);
     ReactDOM.render(<div className="foo" />, container, callback);
@@ -268,19 +268,19 @@ describe('ReactComponent', function() {
   it('throws usefully when rendering badly-typed elements', function() {
     spyOn(console, 'error');
 
-    var X = undefined;
+    const X = undefined;
     expect(() => ReactTestUtils.renderIntoDocument(<X />)).toThrow(
       'Element type is invalid: expected a string (for built-in components) ' +
       'or a class/function (for composite components) but got: undefined.'
     );
 
-    var Y = null;
+    const Y = null;
     expect(() => ReactTestUtils.renderIntoDocument(<Y />)).toThrow(
       'Element type is invalid: expected a string (for built-in components) ' +
       'or a class/function (for composite components) but got: null.'
     );
 
-    var Z = {};
+    const Z = {};
     expect(() => ReactTestUtils.renderIntoDocument(<Z />)).toThrow(
       'Element type is invalid: expected a string (for built-in components) ' +
       'or a class/function (for composite components) but got: object.'

--- a/src/renderers/shared/reconciler/__tests__/ReactComponentLifeCycle-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactComponentLifeCycle-test.js
@@ -11,54 +11,54 @@
 
 'use strict';
 
-var keyMirror = require('keyMirror');
+const keyMirror = require('keyMirror');
 
-var React;
-var ReactDOM;
-var ReactInstanceMap;
-var ReactTestUtils;
+let React;
+let ReactDOM;
+let ReactInstanceMap;
+let ReactTestUtils;
 
-var clone = function(o) {
+const clone = function(o) {
   return JSON.parse(JSON.stringify(o));
 };
 
 
-var GET_INIT_STATE_RETURN_VAL = {
+const GET_INIT_STATE_RETURN_VAL = {
   hasWillMountCompleted: false,
   hasRenderCompleted: false,
   hasDidMountCompleted: false,
   hasWillUnmountCompleted: false,
 };
 
-var INIT_RENDER_STATE = {
+const INIT_RENDER_STATE = {
   hasWillMountCompleted: true,
   hasRenderCompleted: false,
   hasDidMountCompleted: false,
   hasWillUnmountCompleted: false,
 };
 
-var DID_MOUNT_STATE = {
+const DID_MOUNT_STATE = {
   hasWillMountCompleted: true,
   hasRenderCompleted: true,
   hasDidMountCompleted: false,
   hasWillUnmountCompleted: false,
 };
 
-var NEXT_RENDER_STATE = {
+const NEXT_RENDER_STATE = {
   hasWillMountCompleted: true,
   hasRenderCompleted: true,
   hasDidMountCompleted: true,
   hasWillUnmountCompleted: false,
 };
 
-var WILL_UNMOUNT_STATE = {
+const WILL_UNMOUNT_STATE = {
   hasWillMountCompleted: true,
   hasDidMountCompleted: true,
   hasRenderCompleted: true,
   hasWillUnmountCompleted: false,
 };
 
-var POST_WILL_UNMOUNT_STATE = {
+const POST_WILL_UNMOUNT_STATE = {
   hasWillMountCompleted: true,
   hasDidMountCompleted: true,
   hasRenderCompleted: true,
@@ -68,7 +68,7 @@ var POST_WILL_UNMOUNT_STATE = {
 /**
  * Every React component is in one of these life cycles.
  */
-var ComponentLifeCycle = keyMirror({
+const ComponentLifeCycle = keyMirror({
   /**
    * Mounted components have a DOM node representation and are capable of
    * receiving new props.
@@ -81,7 +81,7 @@ var ComponentLifeCycle = keyMirror({
 });
 
 function getLifeCycleState(instance) {
-  var internalInstance = ReactInstanceMap.get(instance);
+  const internalInstance = ReactInstanceMap.get(instance);
   // Once a component gets mounted, it has an internal instance, once it
   // gets unmounted, it loses that internal instance.
   return internalInstance ?
@@ -106,8 +106,8 @@ describe('ReactComponentLifeCycle', function() {
   });
 
   it('should not reuse an instance when it has been unmounted', function() {
-    var container = document.createElement('div');
-    var StatefulComponent = React.createClass({
+    const container = document.createElement('div');
+    const StatefulComponent = React.createClass({
       getInitialState: function() {
         return {};
       },
@@ -117,10 +117,10 @@ describe('ReactComponentLifeCycle', function() {
         );
       },
     });
-    var element = <StatefulComponent />;
-    var firstInstance = ReactDOM.render(element, container);
+    const element = <StatefulComponent />;
+    const firstInstance = ReactDOM.render(element, container);
     ReactDOM.unmountComponentAtNode(container);
-    var secondInstance = ReactDOM.render(element, container);
+    const secondInstance = ReactDOM.render(element, container);
     expect(firstInstance).not.toBe(secondInstance);
   });
 
@@ -130,9 +130,9 @@ describe('ReactComponentLifeCycle', function() {
    */
   it('it should fire onDOMReady when already in onDOMReady', function() {
 
-    var _testJournal = [];
+    const _testJournal = [];
 
-    var Child = React.createClass({
+    const Child = React.createClass({
       componentDidMount: function() {
         _testJournal.push('Child:onDOMReady');
       },
@@ -141,7 +141,7 @@ describe('ReactComponentLifeCycle', function() {
       },
     });
 
-    var SwitcherParent = React.createClass({
+    const SwitcherParent = React.createClass({
       getInitialState: function() {
         _testJournal.push('SwitcherParent:getInitialState');
         return {showHasOnDOMReadyComponent: false};
@@ -164,7 +164,7 @@ describe('ReactComponentLifeCycle', function() {
       },
     });
 
-    var instance = <SwitcherParent />;
+    let instance = <SwitcherParent />;
     instance = ReactTestUtils.renderIntoDocument(instance);
     expect(_testJournal).toEqual([
       'SwitcherParent:getInitialState',
@@ -176,7 +176,7 @@ describe('ReactComponentLifeCycle', function() {
   // You could assign state here, but not access members of it, unless you
   // had provided a getInitialState method.
   it('throws when accessing state in componentWillMount', function() {
-    var StatefulComponent = React.createClass({
+    const StatefulComponent = React.createClass({
       componentWillMount: function() {
         void this.state.yada;
       },
@@ -186,14 +186,14 @@ describe('ReactComponentLifeCycle', function() {
         );
       },
     });
-    var instance = <StatefulComponent />;
+    let instance = <StatefulComponent />;
     expect(function() {
       instance = ReactTestUtils.renderIntoDocument(instance);
     }).toThrow();
   });
 
   it('should allow update state inside of componentWillMount', function() {
-    var StatefulComponent = React.createClass({
+    const StatefulComponent = React.createClass({
       componentWillMount: function() {
         this.setState({stateField: 'something'});
       },
@@ -203,7 +203,7 @@ describe('ReactComponentLifeCycle', function() {
         );
       },
     });
-    var instance = <StatefulComponent />;
+    let instance = <StatefulComponent />;
     expect(function() {
       instance = ReactTestUtils.renderIntoDocument(instance);
     }).not.toThrow();
@@ -211,7 +211,7 @@ describe('ReactComponentLifeCycle', function() {
 
   it('should not allow update state inside of getInitialState', function() {
     spyOn(console, 'error');
-    var StatefulComponent = React.createClass({
+    const StatefulComponent = React.createClass({
       getInitialState: function() {
         this.setState({stateField: 'something'});
 
@@ -235,7 +235,7 @@ describe('ReactComponentLifeCycle', function() {
 
   it('should correctly determine if a component is mounted', function() {
     spyOn(console, 'error');
-    var Component = React.createClass({
+    const Component = React.createClass({
       componentWillMount: function() {
         expect(this.isMounted()).toBeFalsy();
       },
@@ -248,9 +248,9 @@ describe('ReactComponentLifeCycle', function() {
       },
     });
 
-    var element = <Component />;
+    const element = <Component />;
 
-    var instance = ReactTestUtils.renderIntoDocument(element);
+    const instance = ReactTestUtils.renderIntoDocument(element);
     expect(instance.isMounted()).toBeTruthy();
 
     expect(console.error.argsForCall.length).toBe(1);
@@ -261,7 +261,7 @@ describe('ReactComponentLifeCycle', function() {
 
   it('should correctly determine if a null component is mounted', function() {
     spyOn(console, 'error');
-    var Component = React.createClass({
+    const Component = React.createClass({
       componentWillMount: function() {
         expect(this.isMounted()).toBeFalsy();
       },
@@ -274,9 +274,9 @@ describe('ReactComponentLifeCycle', function() {
       },
     });
 
-    var element = <Component />;
+    const element = <Component />;
 
-    var instance = ReactTestUtils.renderIntoDocument(element);
+    const instance = ReactTestUtils.renderIntoDocument(element);
     expect(instance.isMounted()).toBeTruthy();
 
     expect(console.error.argsForCall.length).toBe(1);
@@ -286,14 +286,14 @@ describe('ReactComponentLifeCycle', function() {
   });
 
   it('isMounted should return false when unmounted', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         return <div/>;
       },
     });
 
-    var container = document.createElement('div');
-    var instance = ReactDOM.render(<Component />, container);
+    const container = document.createElement('div');
+    const instance = ReactDOM.render(<Component />, container);
 
     expect(instance.isMounted()).toBe(true);
 
@@ -304,7 +304,7 @@ describe('ReactComponentLifeCycle', function() {
 
   it('warns if findDOMNode is used inside render', function() {
     spyOn(console, 'error');
-    var Component = React.createClass({
+    const Component = React.createClass({
       getInitialState: function() {
         return {isMounted: false};
       },
@@ -327,10 +327,10 @@ describe('ReactComponentLifeCycle', function() {
   });
 
   it('should carry through each of the phases of setup', function() {
-    var LifeCycleComponent = React.createClass({
+    const LifeCycleComponent = React.createClass({
       getInitialState: function() {
         this._testJournal = {};
-        var initState = {
+        const initState = {
           hasWillMountCompleted: false,
           hasDidMountCompleted: false,
           hasRenderCompleted: false,
@@ -357,7 +357,7 @@ describe('ReactComponentLifeCycle', function() {
       },
 
       render: function() {
-        var isInitialRender = !this.state.hasRenderCompleted;
+        const isInitialRender = !this.state.hasRenderCompleted;
         if (isInitialRender) {
           this._testJournal.stateInInitialRender = clone(this.state);
           this._testJournal.lifeCycleInInitialRender = getLifeCycleState(this);
@@ -385,8 +385,8 @@ describe('ReactComponentLifeCycle', function() {
     // A component that is merely "constructed" (as in "constructor") but not
     // yet initialized, or rendered.
     //
-    var container = document.createElement('div');
-    var instance = ReactDOM.render(<LifeCycleComponent />, container);
+    const container = document.createElement('div');
+    const instance = ReactDOM.render(<LifeCycleComponent />, container);
 
     // getInitialState
     expect(instance._testJournal.returnedFromGetInitialState).toEqual(
@@ -445,7 +445,7 @@ describe('ReactComponentLifeCycle', function() {
   });
 
   it('should not throw when updating an auxiliary component', function() {
-    var Tooltip = React.createClass({
+    const Tooltip = React.createClass({
       render: function() {
         return <div>{this.props.children}</div>;
       },
@@ -462,7 +462,7 @@ describe('ReactComponentLifeCycle', function() {
         ReactDOM.render(this.props.tooltip, this.container);
       },
     });
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         return (
           <Tooltip
@@ -474,7 +474,7 @@ describe('ReactComponentLifeCycle', function() {
       },
     });
 
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(
       <Component text="uno" tooltipText="one" />,
       container
@@ -492,7 +492,7 @@ describe('ReactComponentLifeCycle', function() {
     /**
      * calls setState in an componentDidMount.
      */
-    var SetStateInComponentDidMount = React.createClass({
+    const SetStateInComponentDidMount = React.createClass({
       getInitialState: function() {
         return {
           stateField: this.props.valueToUseInitially,
@@ -505,7 +505,7 @@ describe('ReactComponentLifeCycle', function() {
         return (<div></div>);
       },
     });
-    var instance =
+    let instance =
       <SetStateInComponentDidMount
         valueToUseInitially="hello"
         valueToUseInOnDOMReady="goodbye"
@@ -515,15 +515,15 @@ describe('ReactComponentLifeCycle', function() {
   });
 
   it('should call nested lifecycle methods in the right order', function() {
-    var log;
-    var logger = function(msg) {
+    let log;
+    const logger = function(msg) {
       return function() {
         // return true for shouldComponentUpdate
         log.push(msg);
         return true;
       };
     };
-    var Outer = React.createClass({
+    const Outer = React.createClass({
       render: function() {
         return <div><Inner x={this.props.x} /></div>;
       },
@@ -535,7 +535,7 @@ describe('ReactComponentLifeCycle', function() {
       componentDidUpdate: logger('outer componentDidUpdate'),
       componentWillUnmount: logger('outer componentWillUnmount'),
     });
-    var Inner = React.createClass({
+    const Inner = React.createClass({
       render: function() {
         return <span>{this.props.x}</span>;
       },
@@ -549,7 +549,7 @@ describe('ReactComponentLifeCycle', function() {
     });
 
 
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     log = [];
     ReactDOM.render(<Outer x={17} />, container);
     expect(log).toEqual([

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -11,17 +11,17 @@
 
 'use strict';
 
-var ChildUpdates;
-var MorphingComponent;
-var React;
-var ReactDOM;
-var ReactCurrentOwner;
-var ReactPropTypes;
-var ReactServerRendering;
-var ReactTestUtils;
-var ReactUpdates;
+let ChildUpdates;
+let MorphingComponent;
+let React;
+let ReactDOM;
+let ReactCurrentOwner;
+let ReactPropTypes;
+let ReactServerRendering;
+let ReactTestUtils;
+let ReactUpdates;
 
-var reactComponentExpect;
+let reactComponentExpect;
 
 describe('ReactCompositeComponent', function() {
 
@@ -46,7 +46,7 @@ describe('ReactCompositeComponent', function() {
       },
 
       render: function() {
-        var toggleActivatedState = this._toggleActivatedState;
+        const toggleActivatedState = this._toggleActivatedState;
         return !this.state.activated ?
           <a ref="x" onClick={toggleActivatedState} /> :
           <b ref="x" onClick={toggleActivatedState} />;
@@ -62,7 +62,7 @@ describe('ReactCompositeComponent', function() {
         return this.refs.anch;
       },
       render: function() {
-        var className = this.props.anchorClassOn ? 'anchorClass' : '';
+        const className = this.props.anchorClassOn ? 'anchorClass' : '';
         return this.props.renderAnchor ?
           <a ref="anch" className={className}></a> :
           <b></b>;
@@ -81,14 +81,14 @@ describe('ReactCompositeComponent', function() {
       };
     }
 
-    var el = document.createElement('div');
+    const el = document.createElement('div');
     ReactDOM.render(<Child test="test" />, el);
 
     expect(el.textContent).toBe('test');
   });
 
   it('should support rendering to different child types over time', function() {
-    var instance = <MorphingComponent />;
+    let instance = <MorphingComponent />;
     instance = ReactTestUtils.renderIntoDocument(instance);
 
     reactComponentExpect(instance)
@@ -107,19 +107,19 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should not thrash a server rendered layout with client side one', () => {
-    var Child = React.createClass({
+    const Child = React.createClass({
       render: function() {
         return null;
       },
     });
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       render: function() {
         return <div><Child /></div>;
       },
     });
 
-    var markup = ReactServerRendering.renderToString(<Parent />);
-    var container = document.createElement('div');
+    const markup = ReactServerRendering.renderToString(<Parent />);
+    const container = document.createElement('div');
     container.innerHTML = markup;
 
     ReactDOM.render(<Parent />, container);
@@ -127,10 +127,10 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should react to state changes from callbacks', function() {
-    var instance = <MorphingComponent />;
+    let instance = <MorphingComponent />;
     instance = ReactTestUtils.renderIntoDocument(instance);
 
-    var renderedChild = reactComponentExpect(instance)
+    const renderedChild = reactComponentExpect(instance)
       .expectRenderedChild()
       .instance();
 
@@ -141,7 +141,7 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should rewire refs when rendering to different child types', function() {
-    var instance = <MorphingComponent />;
+    let instance = <MorphingComponent />;
     instance = ReactTestUtils.renderIntoDocument(instance);
 
     expect(ReactDOM.findDOMNode(instance.refs.x).tagName).toBe('A');
@@ -152,8 +152,8 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should not cache old DOM nodes when switching constructors', function() {
-    var container = document.createElement('div');
-    var instance = ReactDOM.render(
+    const container = document.createElement('div');
+    const instance = ReactDOM.render(
       <ChildUpdates renderAnchor={true} anchorClassOn={false}/>,
       container
     );
@@ -173,7 +173,7 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should auto bind methods and values correctly', function() {
-    var ComponentClass = React.createClass({
+    const ComponentClass = React.createClass({
       getInitialState: function() {
         return {valueToReturn: 'hi'};
       },
@@ -187,11 +187,11 @@ describe('ReactCompositeComponent', function() {
         return <div></div>;
       },
     });
-    var instance = <ComponentClass />;
+    const instance = <ComponentClass />;
 
     // Next, prove that once mounted, the scope is bound correctly to the actual
     // component.
-    var mountedInstance = ReactTestUtils.renderIntoDocument(instance);
+    const mountedInstance = ReactTestUtils.renderIntoDocument(instance);
 
     expect(function() {
       mountedInstance.methodToBeExplicitlyBound.bind(instance)();
@@ -201,13 +201,13 @@ describe('ReactCompositeComponent', function() {
     }).not.toThrow();
 
     expect(console.error.argsForCall.length).toBe(1);
-    var explicitlyBound = mountedInstance.methodToBeExplicitlyBound.bind(
+    const explicitlyBound = mountedInstance.methodToBeExplicitlyBound.bind(
       mountedInstance
     );
     expect(console.error.argsForCall.length).toBe(2);
-    var autoBound = mountedInstance.methodAutoBound;
+    const autoBound = mountedInstance.methodAutoBound;
 
-    var context = {};
+    const context = {};
     expect(explicitlyBound.call(context)).toBe(mountedInstance);
     expect(autoBound.call(context)).toBe(mountedInstance);
 
@@ -217,7 +217,7 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should not pass this to getDefaultProps', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       getDefaultProps: function() {
         expect(this.render).not.toBeDefined();
         return {};
@@ -230,7 +230,7 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should use default values for undefined props', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       getDefaultProps: function() {
         return {prop: 'testKey'};
       },
@@ -239,21 +239,21 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var instance1 = <Component />;
+    let instance1 = <Component />;
     instance1 = ReactTestUtils.renderIntoDocument(instance1);
     reactComponentExpect(instance1).scalarPropsEqual({prop: 'testKey'});
 
-    var instance2 = <Component prop={undefined} />;
+    let instance2 = <Component prop={undefined} />;
     instance2 = ReactTestUtils.renderIntoDocument(instance2);
     reactComponentExpect(instance2).scalarPropsEqual({prop: 'testKey'});
 
-    var instance3 = <Component prop={null} />;
+    let instance3 = <Component prop={null} />;
     instance3 = ReactTestUtils.renderIntoDocument(instance3);
     reactComponentExpect(instance3).scalarPropsEqual({prop: null});
   });
 
   it('should not mutate passed-in props object', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       getDefaultProps: function() {
         return {prop: 'testKey'};
       },
@@ -262,8 +262,8 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var inputProps = {};
-    var instance1 = <Component {...inputProps} />;
+    const inputProps = {};
+    let instance1 = <Component {...inputProps} />;
     instance1 = ReactTestUtils.renderIntoDocument(instance1);
     expect(instance1.props.prop).toBe('testKey');
 
@@ -273,16 +273,16 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should warn about `forceUpdate` on unmounted components', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     document.body.appendChild(container);
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         return <div />;
       },
     });
 
-    var instance = <Component />;
+    let instance = <Component />;
     expect(instance.forceUpdate).not.toBeDefined();
 
     instance = ReactDOM.render(instance, container);
@@ -303,12 +303,12 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should warn about `setState` on unmounted components', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     document.body.appendChild(container);
 
-    var renders = 0;
+    let renders = 0;
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       getInitialState: function() {
         return {value: 0};
       },
@@ -318,7 +318,7 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var instance = <Component />;
+    let instance = <Component />;
     expect(instance.setState).not.toBeDefined();
 
     instance = ReactDOM.render(instance, container);
@@ -346,11 +346,11 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should silently allow `setState`, not call cb on unmounting components', function() {
-    var cbCalled = false;
-    var container = document.createElement('div');
+    let cbCalled = false;
+    const container = document.createElement('div');
     document.body.appendChild(container);
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       getInitialState: function() {
         return {value: 0};
       },
@@ -366,7 +366,7 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var instance = ReactDOM.render(<Component />, container);
+    const instance = ReactDOM.render(<Component />, container);
 
     instance.setState({value: 1});
     expect(console.error.calls.length).toBe(0);
@@ -378,12 +378,12 @@ describe('ReactCompositeComponent', function() {
 
 
   it('should warn about `setState` in render', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
 
-    var renderedState = -1;
-    var renderPasses = 0;
+    let renderedState = -1;
+    let renderPasses = 0;
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       getInitialState: function() {
         return {value: 0};
       },
@@ -399,7 +399,7 @@ describe('ReactCompositeComponent', function() {
 
     expect(console.error.calls.length).toBe(0);
 
-    var instance = ReactDOM.render(<Component />, container);
+    const instance = ReactDOM.render(<Component />, container);
 
     expect(console.error.calls.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toBe(
@@ -418,19 +418,19 @@ describe('ReactCompositeComponent', function() {
     expect(instance.state.value).toBe(1);
 
     // Forcing a rerender anywhere will cause the update to happen.
-    var instance2 = ReactDOM.render(<Component prop={123} />, container);
+    const instance2 = ReactDOM.render(<Component prop={123} />, container);
     expect(instance).toBe(instance2);
     expect(renderedState).toBe(1);
     expect(instance2.state.value).toBe(1);
   });
 
   it('should cleanup even if render() fatals', function() {
-    var BadComponent = React.createClass({
+    const BadComponent = React.createClass({
       render: function() {
         throw new Error();
       },
     });
-    var instance = <BadComponent />;
+    let instance = <BadComponent />;
 
     expect(ReactCurrentOwner.current).toBe(null);
 
@@ -442,10 +442,10 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should call componentWillUnmount before unmounting', function() {
-    var container = document.createElement('div');
-    var innerUnmounted = false;
+    const container = document.createElement('div');
+    let innerUnmounted = false;
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         return (
           <div>
@@ -455,7 +455,7 @@ describe('ReactCompositeComponent', function() {
         );
       },
     });
-    var Inner = React.createClass({
+    const Inner = React.createClass({
       componentWillUnmount: function() {
         innerUnmounted = true;
       },
@@ -470,7 +470,7 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should warn when shouldComponentUpdate() returns undefined', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       getInitialState: function() {
         return {bogus: false};
       },
@@ -484,7 +484,7 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var instance = ReactTestUtils.renderIntoDocument(<Component />);
+    const instance = ReactTestUtils.renderIntoDocument(<Component />);
     instance.setState({bogus: true});
 
     expect(console.error.argsForCall.length).toBe(1);
@@ -495,7 +495,7 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should warn when componentDidUnmount method is defined', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       componentDidUnmount: function() {
       },
 
@@ -515,13 +515,13 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should pass context to children when not owner', function() {
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       render: function() {
         return <Child><Grandchild /></Child>;
       },
     });
 
-    var Child = React.createClass({
+    const Child = React.createClass({
       childContextTypes: {
         foo: ReactPropTypes.string,
       },
@@ -537,7 +537,7 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var Grandchild = React.createClass({
+    const Grandchild = React.createClass({
       contextTypes: {
         foo: ReactPropTypes.string,
       },
@@ -547,27 +547,27 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var component = ReactTestUtils.renderIntoDocument(<Parent />);
+    const component = ReactTestUtils.renderIntoDocument(<Parent />);
     expect(ReactDOM.findDOMNode(component).innerHTML).toBe('bar');
   });
 
   it('should skip update when rerendering element in container', function() {
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       render: function() {
         return <div>{this.props.children}</div>;
       },
     });
 
-    var childRenders = 0;
-    var Child = React.createClass({
+    let childRenders = 0;
+    const Child = React.createClass({
       render: function() {
         childRenders++;
         return <div />;
       },
     });
 
-    var container = document.createElement('div');
-    var child = <Child />;
+    const container = document.createElement('div');
+    const child = <Child />;
 
     ReactDOM.render(<Parent>{child}</Parent>, container);
     ReactDOM.render(<Parent>{child}</Parent>, container);
@@ -575,10 +575,10 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should pass context when re-rendered for static child', function() {
-    var parentInstance = null;
-    var childInstance = null;
+    let parentInstance = null;
+    let childInstance = null;
 
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       childContextTypes: {
         foo: ReactPropTypes.string,
         flag: ReactPropTypes.bool,
@@ -602,13 +602,13 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var Middle = React.createClass({
+    const Middle = React.createClass({
       render: function() {
         return this.props.children;
       },
     });
 
-    var Child = React.createClass({
+    const Child = React.createClass({
       contextTypes: {
         foo: ReactPropTypes.string,
         flag: ReactPropTypes.bool,
@@ -636,7 +636,7 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should pass context when re-rendered for static child within a composite component', function() {
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       childContextTypes: {
         flag: ReactPropTypes.bool,
       },
@@ -659,7 +659,7 @@ describe('ReactCompositeComponent', function() {
 
     });
 
-    var Child = React.createClass({
+    const Child = React.createClass({
       contextTypes: {
         flag: ReactPropTypes.bool,
       },
@@ -669,7 +669,7 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var Wrapper = React.createClass({
+    const Wrapper = React.createClass({
       render() {
         return (
           <Parent ref="parent">
@@ -680,7 +680,7 @@ describe('ReactCompositeComponent', function() {
     });
 
 
-    var wrapper = ReactTestUtils.renderIntoDocument(
+    const wrapper = ReactTestUtils.renderIntoDocument(
       <Wrapper />
     );
 
@@ -698,10 +698,10 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should pass context transitively', function() {
-    var childInstance = null;
-    var grandchildInstance = null;
+    let childInstance = null;
+    let grandchildInstance = null;
 
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       childContextTypes: {
         foo: ReactPropTypes.string,
         depth: ReactPropTypes.number,
@@ -719,7 +719,7 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var Child = React.createClass({
+    const Child = React.createClass({
       contextTypes: {
         foo: ReactPropTypes.string,
         depth: ReactPropTypes.number,
@@ -741,7 +741,7 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var Grandchild = React.createClass({
+    const Grandchild = React.createClass({
       contextTypes: {
         foo: ReactPropTypes.string,
         depth: ReactPropTypes.number,
@@ -759,10 +759,10 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should pass context when re-rendered', function() {
-    var parentInstance = null;
-    var childInstance = null;
+    let parentInstance = null;
+    let childInstance = null;
 
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       childContextTypes: {
         foo: ReactPropTypes.string,
         depth: ReactPropTypes.number,
@@ -782,7 +782,7 @@ describe('ReactCompositeComponent', function() {
       },
 
       render: function() {
-        var output = <Child />;
+        let output = <Child />;
         if (!this.state.flag) {
           output = <span>Child</span>;
         }
@@ -790,7 +790,7 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var Child = React.createClass({
+    const Child = React.createClass({
       contextTypes: {
         foo: ReactPropTypes.string,
         depth: ReactPropTypes.number,
@@ -818,7 +818,7 @@ describe('ReactCompositeComponent', function() {
 
   it('unmasked context propagates through updates', function() {
 
-    var Leaf = React.createClass({
+    const Leaf = React.createClass({
       contextTypes: {
         foo: ReactPropTypes.string.isRequired,
       },
@@ -841,7 +841,7 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var Intermediary = React.createClass({
+    const Intermediary = React.createClass({
 
       componentWillReceiveProps: function(nextProps, nextContext) {
         expect('foo' in nextContext).toBe(false);
@@ -861,7 +861,7 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       childContextTypes: {
         foo: ReactPropTypes.string,
       },
@@ -877,7 +877,7 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var div = document.createElement('div');
+    const div = document.createElement('div');
     ReactDOM.render(<Parent cntxt="noise" />, div);
     expect(div.children[0].innerHTML).toBe('noise');
     div.children[0].innerHTML = 'aliens';
@@ -890,10 +890,10 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should trigger componentWillReceiveProps for context changes', function() {
-    var contextChanges = 0;
-    var propChanges = 0;
+    let contextChanges = 0;
+    let propChanges = 0;
 
-    var GrandChild = React.createClass({
+    const GrandChild = React.createClass({
       contextTypes: {
         foo: ReactPropTypes.string.isRequired,
       },
@@ -915,7 +915,7 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var ChildWithContext = React.createClass({
+    const ChildWithContext = React.createClass({
       contextTypes: {
         foo: ReactPropTypes.string.isRequired,
       },
@@ -937,7 +937,7 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var ChildWithoutContext = React.createClass({
+    const ChildWithoutContext = React.createClass({
       componentWillReceiveProps: function(nextProps, nextContext) {
         expect('foo' in nextContext).toBe(false);
 
@@ -955,7 +955,7 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       childContextTypes: {
         foo: ReactPropTypes.string,
       },
@@ -983,7 +983,7 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var div = document.createElement('div');
+    const div = document.createElement('div');
 
     ReactDOM.render(
       <Parent>
@@ -1007,12 +1007,12 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should disallow nested render calls', function() {
-    var Inner = React.createClass({
+    const Inner = React.createClass({
       render: function() {
         return <div />;
       },
     });
-    var Outer = React.createClass({
+    const Outer = React.createClass({
       render: function() {
         ReactTestUtils.renderIntoDocument(<Inner />);
         return <div />;
@@ -1030,8 +1030,8 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('only renders once if updated in componentWillReceiveProps', function() {
-    var renders = 0;
-    var Component = React.createClass({
+    let renders = 0;
+    const Component = React.createClass({
       getInitialState: function() {
         return {updated: false};
       },
@@ -1045,8 +1045,8 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var container = document.createElement('div');
-    var instance = ReactDOM.render(<Component update={0} />, container);
+    const container = document.createElement('div');
+    const instance = ReactDOM.render(<Component update={0} />, container);
     expect(renders).toBe(1);
     expect(instance.state.updated).toBe(false);
     ReactDOM.render(<Component update={1} />, container);
@@ -1055,7 +1055,7 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should update refs if shouldComponentUpdate gives false', function() {
-    var Static = React.createClass({
+    const Static = React.createClass({
       shouldComponentUpdate: function() {
         return false;
       },
@@ -1063,7 +1063,7 @@ describe('ReactCompositeComponent', function() {
         return <div>{this.props.children}</div>;
       },
     });
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         if (this.props.flipped) {
           return (
@@ -1083,8 +1083,8 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var container = document.createElement('div');
-    var comp = ReactDOM.render(<Component flipped={false} />, container);
+    const container = document.createElement('div');
+    const comp = ReactDOM.render(<Component flipped={false} />, container);
     expect(ReactDOM.findDOMNode(comp.refs.static0).textContent).toBe('A');
     expect(ReactDOM.findDOMNode(comp.refs.static1).textContent).toBe('B');
 
@@ -1096,9 +1096,9 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should allow access to findDOMNode in componentWillUnmount', function() {
-    var a = null;
-    var b = null;
-    var Component = React.createClass({
+    let a = null;
+    let b = null;
+    const Component = React.createClass({
       componentDidMount: function() {
         a = ReactDOM.findDOMNode(this);
         expect(a).not.toBe(null);
@@ -1111,7 +1111,7 @@ describe('ReactCompositeComponent', function() {
         return <div />;
       },
     });
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     expect(a).toBe(container.firstChild);
     ReactDOM.render(<Component />, container);
     ReactDOM.unmountComponentAtNode(container);
@@ -1119,7 +1119,7 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('context should be passed down from the parent', function() {
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       childContextTypes: {
         foo: ReactPropTypes.string,
       },
@@ -1135,7 +1135,7 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       contextTypes: {
         foo: ReactPropTypes.string.isRequired,
       },
@@ -1145,14 +1145,14 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var div = document.createElement('div');
+    const div = document.createElement('div');
     ReactDOM.render(<Parent><Component /></Parent>, div);
 
     expect(console.error.argsForCall.length).toBe(0);
   });
 
   it('should replace state', function() {
-    var Moo = React.createClass({
+    const Moo = React.createClass({
       getInitialState: function() {
         return {x: 1};
       },
@@ -1161,20 +1161,20 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var moo = ReactTestUtils.renderIntoDocument(<Moo />);
+    const moo = ReactTestUtils.renderIntoDocument(<Moo />);
     moo.replaceState({y: 2});
     expect('x' in moo.state).toBe(false);
     expect(moo.state.y).toBe(2);
   });
 
   it('should support objects with prototypes as state', function() {
-    var NotActuallyImmutable = function(str) {
+    const NotActuallyImmutable = function(str) {
       this.str = str;
     };
     NotActuallyImmutable.prototype.amIImmutable = function() {
       return true;
     };
-    var Moo = React.createClass({
+    const Moo = React.createClass({
       getInitialState: function() {
         return new NotActuallyImmutable('first');
       },
@@ -1183,11 +1183,11 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var moo = ReactTestUtils.renderIntoDocument(<Moo />);
+    const moo = ReactTestUtils.renderIntoDocument(<Moo />);
     expect(moo.state.str).toBe('first');
     expect(moo.state.amIImmutable()).toBe(true);
 
-    var secondState = new NotActuallyImmutable('second');
+    const secondState = new NotActuallyImmutable('second');
     moo.replaceState(secondState);
     expect(moo.state.str).toBe('second');
     expect(moo.state.amIImmutable()).toBe(true);
@@ -1199,7 +1199,7 @@ describe('ReactCompositeComponent', function() {
     expect(moo.state.amIImmutable).toBe(undefined);
 
     // When more than one state update is enqueued, we have the same behavior
-    var fifthState = new NotActuallyImmutable('fifth');
+    const fifthState = new NotActuallyImmutable('fifth');
     ReactUpdates.batchedUpdates(function() {
       moo.setState({str: 'fourth'});
       moo.replaceState(fifthState);
@@ -1207,7 +1207,7 @@ describe('ReactCompositeComponent', function() {
     expect(moo.state).toBe(fifthState);
 
     // When more than one state update is enqueued, we have the same behavior
-    var sixthState = new NotActuallyImmutable('sixth');
+    const sixthState = new NotActuallyImmutable('sixth');
     ReactUpdates.batchedUpdates(function() {
       moo.replaceState(sixthState);
       moo.setState({str: 'seventh'});
@@ -1217,10 +1217,10 @@ describe('ReactCompositeComponent', function() {
   });
 
   it('should not warn about unmounting during unmounting', function() {
-    var container = document.createElement('div');
-    var layer = document.createElement('div');
+    const container = document.createElement('div');
+    const layer = document.createElement('div');
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       componentWillMount: function() {
         ReactDOM.render(<div />, layer);
       },
@@ -1234,7 +1234,7 @@ describe('ReactCompositeComponent', function() {
       },
     });
 
-    var Outer = React.createClass({
+    const Outer = React.createClass({
       render: function() {
         return <div>{this.props.children}</div>;
       },
@@ -1251,11 +1251,11 @@ describe('ReactCompositeComponent', function() {
 
   it('should warn when mutated props are passed', function() {
 
-    var container = document.createElement('div');
+    const container = document.createElement('div');
 
     class Foo extends React.Component {
       constructor(props) {
-        var _props = { idx: props.idx + '!' };
+        const _props = { idx: props.idx + '!' };
         super(_props);
       }
 

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentDOMMinimalism-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentDOMMinimalism-test.js
@@ -12,15 +12,15 @@
 'use strict';
 
 // Requires
-var React;
-var ReactTestUtils;
-var reactComponentExpect;
+let React;
+let ReactTestUtils;
+let reactComponentExpect;
 
 // Test components
-var LowerLevelComposite;
-var MyCompositeComponent;
+let LowerLevelComposite;
+let MyCompositeComponent;
 
-var expectSingleChildlessDiv;
+let expectSingleChildlessDiv;
 
 /**
  * Integration test, testing the combination of JSX with our unit of
@@ -65,7 +65,7 @@ describe('ReactCompositeComponentDOMMinimalism', function() {
   });
 
   it('should not render extra nodes for non-interpolated text', function() {
-    var instance = (
+    let instance = (
       <MyCompositeComponent>
         A string child
       </MyCompositeComponent>
@@ -75,7 +75,7 @@ describe('ReactCompositeComponentDOMMinimalism', function() {
   });
 
   it('should not render extra nodes for non-interpolated text', function() {
-    var instance = (
+    let instance = (
       <MyCompositeComponent>
         {'Interpolated String Child'}
       </MyCompositeComponent>
@@ -85,7 +85,7 @@ describe('ReactCompositeComponentDOMMinimalism', function() {
   });
 
   it('should not render extra nodes for non-interpolated text', function() {
-    var instance = (
+    let instance = (
       <MyCompositeComponent>
         <ul>
           This text causes no children in ul, just innerHTML

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentNestedState-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentNestedState-test.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
-var ReactTestUtils;
+let React;
+let ReactDOM;
+let ReactTestUtils;
 
 describe('ReactCompositeComponentNestedState-state', function() {
 
@@ -24,7 +24,7 @@ describe('ReactCompositeComponentNestedState-state', function() {
   });
 
   it('should provide up to date values for props', function() {
-    var ParentComponent = React.createClass({
+    const ParentComponent = React.createClass({
       getInitialState: function() {
         return {color: 'blue'};
       },
@@ -48,7 +48,7 @@ describe('ReactCompositeComponentNestedState-state', function() {
       },
     });
 
-    var ChildComponent = React.createClass({
+    const ChildComponent = React.createClass({
       getInitialState: function() {
         this.props.logger('getInitialState', this.props.color);
         return {hue: 'dark ' + this.props.color};
@@ -87,10 +87,10 @@ describe('ReactCompositeComponentNestedState-state', function() {
       },
     });
 
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     document.body.appendChild(container);
 
-    var logger = jest.genMockFn();
+    const logger = jest.genMockFn();
 
     void ReactDOM.render(
       <ParentComponent logger={logger} />,

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentState-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentState-test.js
@@ -11,10 +11,10 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
+let React;
+let ReactDOM;
 
-var TestComponent;
+let TestComponent;
 
 describe('ReactCompositeComponent-state', function() {
 
@@ -127,11 +127,11 @@ describe('ReactCompositeComponent-state', function() {
   });
 
   it('should support setting state', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     document.body.appendChild(container);
 
-    var stateListener = jest.genMockFn();
-    var instance = ReactDOM.render(
+    const stateListener = jest.genMockFn();
+    const instance = ReactDOM.render(
       <TestComponent stateListener={stateListener} />,
       container,
       function peekAtInitialCallback() {
@@ -217,8 +217,8 @@ describe('ReactCompositeComponent-state', function() {
   });
 
   it('should batch unmounts', function() {
-    var outer;
-    var Inner = React.createClass({
+    let outer;
+    const Inner = React.createClass({
       render: function() {
         return <div />;
       },
@@ -228,7 +228,7 @@ describe('ReactCompositeComponent-state', function() {
         outer.setState({showInner: false});
       },
     });
-    var Outer = React.createClass({
+    const Outer = React.createClass({
       getInitialState: function() {
         return {showInner: true};
       },
@@ -237,7 +237,7 @@ describe('ReactCompositeComponent-state', function() {
       },
     });
 
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     outer = ReactDOM.render(<Outer />, container);
     expect(() => {
       ReactDOM.unmountComponentAtNode(container);

--- a/src/renderers/shared/reconciler/__tests__/ReactEmptyComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactEmptyComponent-test.js
@@ -11,14 +11,14 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
-var ReactTestUtils;
-var TogglingComponent;
+let React;
+let ReactDOM;
+let ReactTestUtils;
+let TogglingComponent;
 
-var reactComponentExpect;
+let reactComponentExpect;
 
-var log;
+let log;
 
 describe('ReactEmptyComponent', function() {
   beforeEach(function() {
@@ -44,26 +44,26 @@ describe('ReactEmptyComponent', function() {
         log(ReactDOM.findDOMNode(this));
       },
       render: function() {
-        var Component = this.state.component;
+        const Component = this.state.component;
         return Component ? <Component /> : null;
       },
     });
   });
 
   it('should render null and false as a noscript tag under the hood', () => {
-    var Component1 = React.createClass({
+    const Component1 = React.createClass({
       render: function() {
         return null;
       },
     });
-    var Component2 = React.createClass({
+    const Component2 = React.createClass({
       render: function() {
         return false;
       },
     });
 
-    var instance1 = ReactTestUtils.renderIntoDocument(<Component1 />);
-    var instance2 = ReactTestUtils.renderIntoDocument(<Component2 />);
+    const instance1 = ReactTestUtils.renderIntoDocument(<Component1 />);
+    const instance2 = ReactTestUtils.renderIntoDocument(<Component2 />);
     reactComponentExpect(instance1)
       .expectRenderedChild()
       .toBeEmptyComponent();
@@ -73,7 +73,7 @@ describe('ReactEmptyComponent', function() {
   });
 
   it('should still throw when rendering to undefined', () => {
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {},
     });
     expect(function() {
@@ -85,12 +85,12 @@ describe('ReactEmptyComponent', function() {
   });
 
   it('should be able to switch between rendering null and a normal tag', () => {
-    var instance1 =
+    const instance1 =
       <TogglingComponent
         firstComponent={null}
         secondComponent={'div'}
       />;
-    var instance2 =
+    const instance2 =
       <TogglingComponent
         firstComponent={'div'}
         secondComponent={null}
@@ -107,7 +107,7 @@ describe('ReactEmptyComponent', function() {
   });
 
   it('should be able to switch in a list of children', () => {
-    var instance1 =
+    const instance1 =
       <TogglingComponent
         firstComponent={null}
         secondComponent={'div'}
@@ -132,12 +132,12 @@ describe('ReactEmptyComponent', function() {
 
   it('should distinguish between a script placeholder and an actual script tag',
     () => {
-      var instance1 =
+      const instance1 =
         <TogglingComponent
           firstComponent={null}
           secondComponent={'script'}
         />;
-      var instance2 =
+      const instance2 =
         <TogglingComponent
           firstComponent={'script'}
           secondComponent={null}
@@ -161,24 +161,24 @@ describe('ReactEmptyComponent', function() {
   it('should have findDOMNode return null when multiple layers of composite ' +
     'components render to the same null placeholder',
     () => {
-      var GrandChild = React.createClass({
+      const GrandChild = React.createClass({
         render: function() {
           return null;
         },
       });
 
-      var Child = React.createClass({
+      const Child = React.createClass({
         render: function() {
           return <GrandChild />;
         },
       });
 
-      var instance1 =
+      const instance1 =
         <TogglingComponent
           firstComponent={'div'}
           secondComponent={Child}
         />;
-      var instance2 =
+      const instance2 =
         <TogglingComponent
           firstComponent={Child}
           secondComponent={'div'}
@@ -200,8 +200,8 @@ describe('ReactEmptyComponent', function() {
   );
 
   it('works when switching components', function() {
-    var assertions = 0;
-    var Inner = React.createClass({
+    let assertions = 0;
+    const Inner = React.createClass({
       render: function() {
         return <span />;
       },
@@ -218,14 +218,14 @@ describe('ReactEmptyComponent', function() {
         assertions++;
       },
     });
-    var Wrapper = React.createClass({
+    const Wrapper = React.createClass({
       render: function() {
         return this.props.showInner ? <Inner /> : null;
       },
     });
 
-    var el = document.createElement('div');
-    var component;
+    const el = document.createElement('div');
+    let component;
 
     // Render the <Inner /> component...
     component = ReactDOM.render(<Wrapper showInner={true} />, el);
@@ -244,7 +244,7 @@ describe('ReactEmptyComponent', function() {
 
   it('throws when rendering null at the top level', function() {
     // TODO: This should actually work since `null` is a valid ReactNode
-    var div = document.createElement('div');
+    const div = document.createElement('div');
     expect(function() {
       ReactDOM.render(null, div);
     }).toThrow(
@@ -253,7 +253,7 @@ describe('ReactEmptyComponent', function() {
   });
 
   it('does not break when updating during mount', function() {
-    var Child = React.createClass({
+    const Child = React.createClass({
       componentDidMount() {
         if (this.props.onMount) {
           this.props.onMount();
@@ -268,7 +268,7 @@ describe('ReactEmptyComponent', function() {
       },
     });
 
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       update() {
         this.forceUpdate();
       },
@@ -289,21 +289,21 @@ describe('ReactEmptyComponent', function() {
   });
 
   it('preserves the dom node during updates', function() {
-    var Empty = React.createClass({
+    const Empty = React.createClass({
       render: function() {
         return null;
       },
     });
 
-    var container = document.createElement('div');
+    const container = document.createElement('div');
 
     ReactDOM.render(<Empty />, container);
-    var noscript1 = container.firstChild;
+    const noscript1 = container.firstChild;
     expect(noscript1.nodeName).toBe('#comment');
 
     // This update shouldn't create a DOM node
     ReactDOM.render(<Empty />, container);
-    var noscript2 = container.firstChild;
+    const noscript2 = container.firstChild;
     expect(noscript2.nodeName).toBe('#comment');
 
     expect(noscript1).toBe(noscript2);

--- a/src/renderers/shared/reconciler/__tests__/ReactIdentity-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactIdentity-test.js
@@ -11,10 +11,10 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
-var ReactFragment;
-var ReactTestUtils;
+let React;
+let ReactDOM;
+let ReactFragment;
+let ReactTestUtils;
 
 describe('ReactIdentity', function() {
 
@@ -31,33 +31,33 @@ describe('ReactIdentity', function() {
   }
 
   it('should allow key property to express identity', function() {
-    var node;
-    var Component = (props) =>
+    let node;
+    const Component = (props) =>
       <div ref={(c) => node = c}>
         <div key={props.swap ? 'banana' : 'apple'} />
         <div key={props.swap ? 'apple' : 'banana'} />
       </div>;
 
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<Component />, container);
-    var origChildren = Array.from(node.childNodes);
+    const origChildren = Array.from(node.childNodes);
     ReactDOM.render(<Component swap={true} />, container);
-    var newChildren = Array.from(node.childNodes);
+    const newChildren = Array.from(node.childNodes);
     expect(origChildren[0]).toBe(newChildren[1]);
     expect(origChildren[1]).toBe(newChildren[0]);
   });
 
   it('should use composite identity', function() {
 
-    var Wrapper = React.createClass({
+    const Wrapper = React.createClass({
       render: function() {
         return <a>{this.props.children}</a>;
       },
     });
 
-    var container = document.createElement('div');
-    var node1;
-    var node2;
+    const container = document.createElement('div');
+    let node1;
+    let node2;
     ReactDOM.render(
       <Wrapper key="wrap1"><span ref={(c) => node1 = c} /></Wrapper>,
       container
@@ -72,29 +72,29 @@ describe('ReactIdentity', function() {
 
   function renderAComponentWithKeyIntoContainer(key, container) {
 
-    var Wrapper = React.createClass({
+    const Wrapper = React.createClass({
 
       render: function() {
-        var s1 = <span ref="span1" key={key} />;
-        var s2 = <span ref="span2" />;
+        const s1 = <span ref="span1" key={key} />;
+        const s2 = <span ref="span2" />;
 
-        var map = {};
+        const map = {};
         map[key] = s2;
         return <div>{[s1, frag(map)]}</div>;
       },
 
     });
 
-    var instance = ReactDOM.render(<Wrapper />, container);
-    var span1 = instance.refs.span1;
-    var span2 = instance.refs.span2;
+    const instance = ReactDOM.render(<Wrapper />, container);
+    const span1 = instance.refs.span1;
+    const span2 = instance.refs.span2;
 
     expect(ReactDOM.findDOMNode(span1)).not.toBe(null);
     expect(ReactDOM.findDOMNode(span2)).not.toBe(null);
   }
 
   it('should allow any character as a key, in a detached parent', function() {
-    var detachedContainer = document.createElement('div');
+    const detachedContainer = document.createElement('div');
     renderAComponentWithKeyIntoContainer(
       "<'WEIRD/&\\key'>",
       detachedContainer
@@ -104,7 +104,7 @@ describe('ReactIdentity', function() {
   it('should allow any character as a key, in an attached parent', function() {
     // This test exists to protect against implementation details that
     // incorrectly query escaped IDs using DOM tools like getElementById.
-    var attachedContainer = document.createElement('div');
+    const attachedContainer = document.createElement('div');
     document.body.appendChild(attachedContainer);
 
     renderAComponentWithKeyIntoContainer(
@@ -116,10 +116,10 @@ describe('ReactIdentity', function() {
   });
 
   it('should not allow scripts in keys to execute', function() {
-    var h4x0rKey =
+    const h4x0rKey =
       '"><script>window[\'YOUVEBEENH4X0RED\']=true;</script><div id="';
 
-    var attachedContainer = document.createElement('div');
+    const attachedContainer = document.createElement('div');
     document.body.appendChild(attachedContainer);
 
     renderAComponentWithKeyIntoContainer(h4x0rKey, attachedContainer);
@@ -131,11 +131,11 @@ describe('ReactIdentity', function() {
   });
 
   it('should let restructured components retain their uniqueness', function() {
-    var instance0 = <span />;
-    var instance1 = <span />;
-    var instance2 = <span />;
+    const instance0 = <span />;
+    const instance1 = <span />;
+    const instance2 = <span />;
 
-    var TestComponent = React.createClass({
+    const TestComponent = React.createClass({
       render: function() {
         return (
           <div>
@@ -147,7 +147,7 @@ describe('ReactIdentity', function() {
       },
     });
 
-    var TestContainer = React.createClass({
+    const TestContainer = React.createClass({
 
       render: function() {
         return <TestComponent>{instance0}{instance1}</TestComponent>;
@@ -163,11 +163,11 @@ describe('ReactIdentity', function() {
   });
 
   it('should let nested restructures retain their uniqueness', function() {
-    var instance0 = <span />;
-    var instance1 = <span />;
-    var instance2 = <span />;
+    const instance0 = <span />;
+    const instance1 = <span />;
+    const instance2 = <span />;
 
-    var TestComponent = React.createClass({
+    const TestComponent = React.createClass({
       render: function() {
         return (
           <div>
@@ -179,7 +179,7 @@ describe('ReactIdentity', function() {
       },
     });
 
-    var TestContainer = React.createClass({
+    const TestContainer = React.createClass({
 
       render: function() {
         return (
@@ -199,13 +199,13 @@ describe('ReactIdentity', function() {
   });
 
   it('should let text nodes retain their uniqueness', function() {
-    var TestComponent = React.createClass({
+    const TestComponent = React.createClass({
       render: function() {
         return <div>{this.props.children}<span /></div>;
       },
     });
 
-    var TestContainer = React.createClass({
+    const TestContainer = React.createClass({
 
       render: function() {
         return (
@@ -227,13 +227,13 @@ describe('ReactIdentity', function() {
 
   it('should retain key during updates in composite components', function() {
 
-    var TestComponent = React.createClass({
+    const TestComponent = React.createClass({
       render: function() {
         return <div>{this.props.children}</div>;
       },
     });
 
-    var TestContainer = React.createClass({
+    const TestContainer = React.createClass({
 
       getInitialState: function() {
         return {swapped: false};
@@ -254,19 +254,19 @@ describe('ReactIdentity', function() {
 
     });
 
-    var instance0 = <span key="A" />;
-    var instance1 = <span key="B" />;
+    const instance0 = <span key="A" />;
+    const instance1 = <span key="B" />;
 
-    var wrapped = <TestContainer first={instance0} second={instance1} />;
+    let wrapped = <TestContainer first={instance0} second={instance1} />;
 
     wrapped = ReactDOM.render(wrapped, document.createElement('div'));
-    var div = ReactDOM.findDOMNode(wrapped);
+    const div = ReactDOM.findDOMNode(wrapped);
 
-    var beforeA = div.childNodes[0];
-    var beforeB = div.childNodes[1];
+    const beforeA = div.childNodes[0];
+    const beforeB = div.childNodes[1];
     wrapped.swap();
-    var afterA = div.childNodes[1];
-    var afterB = div.childNodes[0];
+    const afterA = div.childNodes[1];
+    const afterB = div.childNodes[0];
 
     expect(beforeA).toBe(afterA);
     expect(beforeB).toBe(afterB);
@@ -274,7 +274,7 @@ describe('ReactIdentity', function() {
   });
 
   it('should not allow implicit and explicit keys to collide', function() {
-    var component =
+    const component =
       <div>
         <span />
         <span key="0" />

--- a/src/renderers/shared/reconciler/__tests__/ReactMockedComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactMockedComponent-test.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-var React;
-var ReactTestUtils;
+let React;
+let ReactTestUtils;
 
-var AutoMockedComponent;
-var MockedComponent;
+let AutoMockedComponent;
+let MockedComponent;
 
 describe('ReactMockedComponent', function() {
 
@@ -36,7 +36,7 @@ describe('ReactMockedComponent', function() {
   });
 
   it('should allow an implicitly mocked component to be updated', () => {
-    var Wrapper = React.createClass({
+    const Wrapper = React.createClass({
 
       getInitialState: function() {
         return {foo: 1};
@@ -52,9 +52,9 @@ describe('ReactMockedComponent', function() {
 
     });
 
-    var instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
+    const instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
 
-    var found = ReactTestUtils.findRenderedComponentWithType(
+    const found = ReactTestUtils.findRenderedComponentWithType(
       instance,
       AutoMockedComponent
     );
@@ -64,7 +64,7 @@ describe('ReactMockedComponent', function() {
   });
 
   it('has custom methods on the implicitly mocked component', () => {
-    var instance = ReactTestUtils.renderIntoDocument(<AutoMockedComponent />);
+    const instance = ReactTestUtils.renderIntoDocument(<AutoMockedComponent />);
     expect(typeof instance.hasCustomMethod).toBe('function');
   });
 
@@ -73,7 +73,7 @@ describe('ReactMockedComponent', function() {
   });
 
   it('should allow an explicitly mocked component to be updated', () => {
-    var Wrapper = React.createClass({
+    const Wrapper = React.createClass({
 
       getInitialState: function() {
         return {foo: 1};
@@ -88,9 +88,9 @@ describe('ReactMockedComponent', function() {
       },
 
     });
-    var instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
+    const instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
 
-    var found = ReactTestUtils.findRenderedComponentWithType(
+    const found = ReactTestUtils.findRenderedComponentWithType(
       instance,
       MockedComponent
     );
@@ -100,7 +100,7 @@ describe('ReactMockedComponent', function() {
   });
 
   it('has custom methods on the explicitly mocked component', () => {
-    var instance = ReactTestUtils.renderIntoDocument(<MockedComponent />);
+    const instance = ReactTestUtils.renderIntoDocument(<MockedComponent />);
     expect(typeof instance.hasCustomMethod).toBe('function');
   });
 

--- a/src/renderers/shared/reconciler/__tests__/ReactMultiChild-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactMultiChild-test.js
@@ -12,9 +12,9 @@
 'use strict';
 
 describe('ReactMultiChild', function() {
-  var React;
+  let React;
 
-  var ReactDOM;
+  let ReactDOM;
 
   beforeEach(function() {
     jest.resetModuleRegistry();
@@ -24,13 +24,13 @@ describe('ReactMultiChild', function() {
 
   describe('reconciliation', function() {
     it('should update children when possible', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
 
-      var mockMount = jest.genMockFn();
-      var mockUpdate = jest.genMockFn();
-      var mockUnmount = jest.genMockFn();
+      const mockMount = jest.genMockFn();
+      const mockUpdate = jest.genMockFn();
+      const mockUnmount = jest.genMockFn();
 
-      var MockComponent = React.createClass({
+      const MockComponent = React.createClass({
         componentDidMount: mockMount,
         componentDidUpdate: mockUpdate,
         componentWillUnmount: mockUnmount,
@@ -57,12 +57,12 @@ describe('ReactMultiChild', function() {
     });
 
     it('should replace children with different constructors', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
 
-      var mockMount = jest.genMockFn();
-      var mockUnmount = jest.genMockFn();
+      const mockMount = jest.genMockFn();
+      const mockUnmount = jest.genMockFn();
 
-      var MockComponent = React.createClass({
+      const MockComponent = React.createClass({
         componentDidMount: mockMount,
         componentWillUnmount: mockUnmount,
         render: function() {
@@ -85,12 +85,12 @@ describe('ReactMultiChild', function() {
     });
 
     it('should NOT replace children with different owners', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
 
-      var mockMount = jest.genMockFn();
-      var mockUnmount = jest.genMockFn();
+      const mockMount = jest.genMockFn();
+      const mockUnmount = jest.genMockFn();
 
-      var MockComponent = React.createClass({
+      const MockComponent = React.createClass({
         componentDidMount: mockMount,
         componentWillUnmount: mockUnmount,
         render: function() {
@@ -98,7 +98,7 @@ describe('ReactMultiChild', function() {
         },
       });
 
-      var WrapperComponent = React.createClass({
+      const WrapperComponent = React.createClass({
         render: function() {
           return this.props.children || <MockComponent />;
         },
@@ -122,12 +122,12 @@ describe('ReactMultiChild', function() {
     });
 
     it('should replace children with different keys', function() {
-      var container = document.createElement('div');
+      const container = document.createElement('div');
 
-      var mockMount = jest.genMockFn();
-      var mockUnmount = jest.genMockFn();
+      const mockMount = jest.genMockFn();
+      const mockUnmount = jest.genMockFn();
 
-      var MockComponent = React.createClass({
+      const MockComponent = React.createClass({
         componentDidMount: mockMount,
         componentWillUnmount: mockUnmount,
         render: function() {

--- a/src/renderers/shared/reconciler/__tests__/ReactMultiChildReconcile-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactMultiChildReconcile-test.js
@@ -11,16 +11,16 @@
 
 'use strict';
 
-var React = require('React');
-var ReactDOM = require('ReactDOM');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var ReactInstanceMap = require('ReactInstanceMap');
+const React = require('React');
+const ReactDOM = require('ReactDOM');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
+const ReactInstanceMap = require('ReactInstanceMap');
 
-var mapObject = require('mapObject');
+const mapObject = require('mapObject');
 
-var stripEmptyValues = function(obj) {
-  var ret = {};
-  var name;
+const stripEmptyValues = function(obj) {
+  const ret = {};
+  let name;
   for (name in obj) {
     if (!obj.hasOwnProperty(name)) {
       continue;
@@ -36,8 +36,8 @@ var stripEmptyValues = function(obj) {
  * Child key names are wrapped like '.$key:0'. We strip the extra chars out
  * here. This relies on an implementation detail of the rendering system.
  */
-var getOriginalKey = function(childName) {
-  var match = childName.match(/^\.\$([^.]+)$/);
+const getOriginalKey = function(childName) {
+  const match = childName.match(/^\.\$([^.]+)$/);
   expect(match).not.toBeNull();
   return match[1];
 };
@@ -47,7 +47,7 @@ var getOriginalKey = function(childName) {
  * existing children won't reinitialize components, when moving children -
  * reusing existing DOM/memory resources.
  */
-var StatusDisplay = React.createClass({
+const StatusDisplay = React.createClass({
   getInitialState: function() {
     return {internalState: Math.random()};
   },
@@ -72,7 +72,7 @@ var StatusDisplay = React.createClass({
 /**
  * Displays friends statuses.
  */
-var FriendsStatusDisplay = React.createClass({
+const FriendsStatusDisplay = React.createClass({
   /**
    * Retrieves the rendered children in a nice format for comparing to the input
    * `this.props.usernameToStatus`. Gets the order directly from each rendered
@@ -80,34 +80,34 @@ var FriendsStatusDisplay = React.createClass({
    * neither is `this._renderedChildren` (surprisingly).
    */
   getStatusDisplays: function() {
-    var name;
-    var orderOfUsernames = [];
+    let name;
+    const orderOfUsernames = [];
     // TODO: Update this to a better test that doesn't rely so much on internal
     // implementation details.
-    var statusDisplays =
+    const statusDisplays =
       ReactInstanceMap.get(this)
       ._renderedComponent
       ._renderedChildren;
     for (name in statusDisplays) {
-      var child = statusDisplays[name];
-      var isPresent = !!child;
+      const child = statusDisplays[name];
+      const isPresent = !!child;
       if (isPresent) {
         orderOfUsernames[child._mountIndex] = getOriginalKey(name);
       }
     }
-    var res = {};
-    var i;
+    const res = {};
+    let i;
     for (i = 0; i < orderOfUsernames.length; i++) {
-      var key = orderOfUsernames[i];
+      const key = orderOfUsernames[i];
       res[key] = this.refs[key];
     }
     return res;
   },
   render: function() {
-    var children = [];
-    var key;
+    const children = [];
+    let key;
     for (key in this.props.usernameToStatus) {
-      var status = this.props.usernameToStatus[key];
+      const status = this.props.usernameToStatus[key];
       children.push(
         !status ? null :
         <StatusDisplay key={key} ref={key} status={status} />
@@ -134,9 +134,9 @@ function getInternalStateByUserName(statusDisplays) {
  * message as well as the order of them.
  */
 function verifyStatuses(statusDisplays, props) {
-  var nonEmptyStatusDisplays = stripEmptyValues(statusDisplays);
-  var nonEmptyStatusProps = stripEmptyValues(props.usernameToStatus);
-  var username;
+  const nonEmptyStatusDisplays = stripEmptyValues(statusDisplays);
+  const nonEmptyStatusProps = stripEmptyValues(props.usernameToStatus);
+  let username;
   expect(Object.keys(nonEmptyStatusDisplays).length)
     .toEqual(Object.keys(nonEmptyStatusProps).length);
   for (username in nonEmptyStatusDisplays) {
@@ -167,7 +167,7 @@ function verifyStatuses(statusDisplays, props) {
  * movements.
  */
 function verifyStatesPreserved(lastInternalStates, statusDisplays) {
-  var key;
+  let key;
   for (key in statusDisplays) {
     if (!statusDisplays.hasOwnProperty(key)) {
       continue;
@@ -185,22 +185,22 @@ function verifyStatesPreserved(lastInternalStates, statusDisplays) {
  * accurately reflects what is in the DOM.
  */
 function verifyDomOrderingAccurate(parentInstance, statusDisplays) {
-  var containerNode = ReactDOM.findDOMNode(parentInstance);
-  var statusDisplayNodes = containerNode.childNodes;
-  var i;
-  var orderedDomIDs = [];
+  const containerNode = ReactDOM.findDOMNode(parentInstance);
+  const statusDisplayNodes = containerNode.childNodes;
+  let i;
+  const orderedDomIDs = [];
   for (i = 0; i < statusDisplayNodes.length; i++) {
-    var inst = ReactDOMComponentTree.getInstanceFromNode(statusDisplayNodes[i]);
+    const inst = ReactDOMComponentTree.getInstanceFromNode(statusDisplayNodes[i]);
     orderedDomIDs.push(inst._rootNodeID);
   }
 
-  var orderedLogicalIDs = [];
-  var username;
+  const orderedLogicalIDs = [];
+  let username;
   for (username in statusDisplays) {
     if (!statusDisplays.hasOwnProperty(username)) {
       continue;
     }
-    var statusDisplay = statusDisplays[username];
+    const statusDisplay = statusDisplays[username];
     orderedLogicalIDs.push(
       ReactInstanceMap.get(statusDisplay)._renderedComponent._rootNodeID
     );
@@ -212,14 +212,14 @@ function verifyDomOrderingAccurate(parentInstance, statusDisplays) {
  * Todo: Check that internal state is preserved across transitions
  */
 function testPropsSequence(sequence) {
-  var i;
-  var container = document.createElement('div');
-  var parentInstance = ReactDOM.render(
+  let i;
+  const container = document.createElement('div');
+  const parentInstance = ReactDOM.render(
     <FriendsStatusDisplay {...sequence[0]} />,
     container
   );
-  var statusDisplays = parentInstance.getStatusDisplays();
-  var lastInternalStates = getInternalStateByUserName(statusDisplays);
+  let statusDisplays = parentInstance.getStatusDisplays();
+  let lastInternalStates = getInternalStateByUserName(statusDisplays);
   verifyStatuses(statusDisplays, sequence[0]);
 
   for (i = 1; i < sequence.length; i++) {
@@ -243,19 +243,19 @@ describe('ReactMultiChildReconcile', function() {
 
   it('should reset internal state if removed then readded', function() {
     // Test basics.
-    var props = {
+    const props = {
       usernameToStatus: {
         jcw: 'jcwStatus',
       },
     };
 
-    var container = document.createElement('div');
-    var parentInstance = ReactDOM.render(
+    const container = document.createElement('div');
+    const parentInstance = ReactDOM.render(
       <FriendsStatusDisplay {...props} />,
       container
     );
-    var statusDisplays = parentInstance.getStatusDisplays();
-    var startingInternalState = statusDisplays.jcw.getInternalState();
+    let statusDisplays = parentInstance.getStatusDisplays();
+    const startingInternalState = statusDisplays.jcw.getInternalState();
 
     // Now remove the child.
     ReactDOM.render(
@@ -278,7 +278,7 @@ describe('ReactMultiChildReconcile', function() {
 
   it('should create unique identity', function() {
     // Test basics.
-    var usernameToStatus = {
+    const usernameToStatus = {
       jcw: 'jcwStatus',
       awalke: 'awalkeStatus',
       bob: 'bobStatus',
@@ -288,7 +288,7 @@ describe('ReactMultiChildReconcile', function() {
   });
 
   it('should preserve order if children order has not changed', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {
         usernameToStatus: {
           jcw: 'jcwStatus',
@@ -306,7 +306,7 @@ describe('ReactMultiChildReconcile', function() {
   });
 
   it('should transition from zero to one children correctly', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {usernameToStatus: {} },
       {
         usernameToStatus: {
@@ -318,7 +318,7 @@ describe('ReactMultiChildReconcile', function() {
   });
 
   it('should transition from one to zero children correctly', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {
         usernameToStatus: {
           first: 'firstStatus',
@@ -376,7 +376,7 @@ describe('ReactMultiChildReconcile', function() {
    * of `FriendsStatusDisplay`, nothing related to React or these test cases.
    */
   it('should remove nulled out children at the beginning', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {
         usernameToStatus: {
           jcw: 'jcwStatus',
@@ -394,7 +394,7 @@ describe('ReactMultiChildReconcile', function() {
   });
 
   it('should remove nulled out children at the end', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {
         usernameToStatus: {
           jcw: 'jcwStatus',
@@ -412,7 +412,7 @@ describe('ReactMultiChildReconcile', function() {
   });
 
   it('should reverse the order of two children', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {
         usernameToStatus: {
           userOne: 'userOneStatus',
@@ -430,7 +430,7 @@ describe('ReactMultiChildReconcile', function() {
   });
 
   it('should reverse the order of more than two children', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {
         usernameToStatus: {
           userOne: 'userOneStatus',
@@ -450,7 +450,7 @@ describe('ReactMultiChildReconcile', function() {
   });
 
   it('should cycle order correctly', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {
         usernameToStatus: {
           userOne: 'userOneStatus',
@@ -496,7 +496,7 @@ describe('ReactMultiChildReconcile', function() {
   });
 
   it('should cycle order correctly in the other direction', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {
         usernameToStatus: {
           userOne: 'userOneStatus',
@@ -543,7 +543,7 @@ describe('ReactMultiChildReconcile', function() {
 
 
   it('should remove nulled out children and ignore new null children', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {
         usernameToStatus: {
           jcw: 'jcwStatus',
@@ -562,7 +562,7 @@ describe('ReactMultiChildReconcile', function() {
   });
 
   it('should remove nulled out children and reorder remaining', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {
         usernameToStatus: {
           jcw: 'jcwStatus',
@@ -583,7 +583,7 @@ describe('ReactMultiChildReconcile', function() {
   });
 
   it('should append children to the end', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {
         usernameToStatus: {
           jcw: 'jcwStatus',
@@ -602,7 +602,7 @@ describe('ReactMultiChildReconcile', function() {
   });
 
   it('should append multiple children to the end', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {
         usernameToStatus: {
           jcw: 'jcwStatus',
@@ -622,7 +622,7 @@ describe('ReactMultiChildReconcile', function() {
   });
 
   it('should prepend children to the beginning', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {
         usernameToStatus: {
           jcw: 'jcwStatus',
@@ -641,7 +641,7 @@ describe('ReactMultiChildReconcile', function() {
   });
 
   it('should prepend multiple children to the beginning', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {
         usernameToStatus: {
           jcw: 'jcwStatus',
@@ -661,7 +661,7 @@ describe('ReactMultiChildReconcile', function() {
   });
 
   it('should not prepend an empty child to the beginning', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {
         usernameToStatus: {
           jcw: 'jcwStatus',
@@ -680,7 +680,7 @@ describe('ReactMultiChildReconcile', function() {
   });
 
   it('should not append an empty child to the end', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {
         usernameToStatus: {
           jcw: 'jcwStatus',
@@ -699,7 +699,7 @@ describe('ReactMultiChildReconcile', function() {
   });
 
   it('should not insert empty children in the middle', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {
         usernameToStatus: {
           jcw: 'jcwStatus',
@@ -720,7 +720,7 @@ describe('ReactMultiChildReconcile', function() {
   });
 
   it('should insert one new child in the middle', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {
         usernameToStatus: {
           jcw: 'jcwStatus',
@@ -739,7 +739,7 @@ describe('ReactMultiChildReconcile', function() {
   });
 
   it('should insert multiple new truthy children in the middle', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {
         usernameToStatus: {
           jcw: 'jcwStatus',
@@ -760,7 +760,7 @@ describe('ReactMultiChildReconcile', function() {
   });
 
   it('should insert non-empty children in middle where nulls were', function() {
-    var PROPS_SEQUENCE = [
+    const PROPS_SEQUENCE = [
       {
         usernameToStatus: {
           jcw: 'jcwStatus',

--- a/src/renderers/shared/reconciler/__tests__/ReactMultiChildText-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactMultiChildText-test.js
@@ -11,22 +11,22 @@
 
 'use strict';
 
-var React = require('React');
-var ReactDOM = require('ReactDOM');
-var ReactTestUtils = require('ReactTestUtils');
+const React = require('React');
+const ReactDOM = require('ReactDOM');
+const ReactTestUtils = require('ReactTestUtils');
 
 // Helpers
-var testAllPermutations = function(testCases) {
-  for (var i = 0; i < testCases.length; i += 2) {
-    var renderWithChildren = testCases[i];
-    var expectedResultAfterRender = testCases[i + 1];
+const testAllPermutations = function(testCases) {
+  for (let i = 0; i < testCases.length; i += 2) {
+    const renderWithChildren = testCases[i];
+    const expectedResultAfterRender = testCases[i + 1];
 
-    for (var j = 0; j < testCases.length; j += 2) {
-      var updateWithChildren = testCases[j];
-      var expectedResultAfterUpdate = testCases[j + 1];
+    for (let j = 0; j < testCases.length; j += 2) {
+      const updateWithChildren = testCases[j];
+      const expectedResultAfterUpdate = testCases[j + 1];
 
-      var container = document.createElement('div');
-      var d = ReactDOM.render(<div>{renderWithChildren}</div>, container);
+      const container = document.createElement('div');
+      let d = ReactDOM.render(<div>{renderWithChildren}</div>, container);
       expectChildren(d, expectedResultAfterRender);
 
       d = ReactDOM.render(<div>{updateWithChildren}</div>, container);
@@ -36,8 +36,8 @@ var testAllPermutations = function(testCases) {
 };
 
 var expectChildren = function(d, children) {
-  var outerNode = ReactDOM.findDOMNode(d);
-  var textNode;
+  const outerNode = ReactDOM.findDOMNode(d);
+  let textNode;
   if (typeof children === 'string') {
     textNode = outerNode.firstChild;
 
@@ -49,12 +49,12 @@ var expectChildren = function(d, children) {
       expect(textNode.data).toBe('' + children);
     }
   } else {
-    var openingCommentNode;
-    var closingCommentNode;
-    var mountIndex = 0;
+    let openingCommentNode;
+    let closingCommentNode;
+    let mountIndex = 0;
 
-    for (var i = 0; i < children.length; i++) {
-      var child = children[i];
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
 
       if (typeof child === 'string') {
         openingCommentNode = outerNode.childNodes[mountIndex];
@@ -80,7 +80,7 @@ var expectChildren = function(d, children) {
         expect(closingCommentNode.nodeType).toBe(8);
         expect(closingCommentNode.nodeValue).toBe(' /react-text ');
       } else {
-        var elementDOMNode = outerNode.childNodes[mountIndex];
+        const elementDOMNode = outerNode.childNodes[mountIndex];
         expect(elementDOMNode.tagName).toBe('DIV');
         mountIndex++;
       }
@@ -214,19 +214,19 @@ describe('ReactMultiChildText', function() {
   it('should reorder keyed text nodes', function() {
     spyOn(console, 'error');
 
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(
       <div>{new Map([['a', 'alpha'], ['b', 'beta']])}</div>,
       container
     );
 
-    var childNodes = container.firstChild.childNodes;
-    var alpha1 = childNodes[0];
-    var alpha2 = childNodes[1];
-    var alpha3 = childNodes[2];
-    var beta1 = childNodes[3];
-    var beta2 = childNodes[4];
-    var beta3 = childNodes[5];
+    let childNodes = container.firstChild.childNodes;
+    const alpha1 = childNodes[0];
+    const alpha2 = childNodes[1];
+    const alpha3 = childNodes[2];
+    const beta1 = childNodes[3];
+    const beta2 = childNodes[4];
+    const beta3 = childNodes[5];
 
     ReactDOM.render(
       <div>{new Map([['b', 'beta'], ['a', 'alpha']])}</div>,

--- a/src/renderers/shared/reconciler/__tests__/ReactStateSetters-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactStateSetters-test.js
@@ -11,12 +11,12 @@
 
 'use strict';
 
-var React = require('React');
-var ReactStateSetters = require('ReactStateSetters');
-var ReactTestUtils = require('ReactTestUtils');
+const React = require('React');
+const ReactStateSetters = require('ReactStateSetters');
+const ReactTestUtils = require('ReactTestUtils');
 
-var TestComponent;
-var TestComponentWithMixin;
+let TestComponent;
+let TestComponentWithMixin;
 
 describe('ReactStateSetters', function() {
   beforeEach(function() {
@@ -46,11 +46,11 @@ describe('ReactStateSetters', function() {
   });
 
   it('createStateSetter should update state', function() {
-    var instance = <TestComponent />;
+    let instance = <TestComponent />;
     instance = ReactTestUtils.renderIntoDocument(instance);
     expect(instance.state).toEqual({foo: 'foo'});
 
-    var setter = ReactStateSetters.createStateSetter(
+    const setter = ReactStateSetters.createStateSetter(
       instance,
       function(a, b, c) {
         return {
@@ -69,11 +69,11 @@ describe('ReactStateSetters', function() {
   });
 
   it('createStateKeySetter should update state', function() {
-    var instance = <TestComponent />;
+    let instance = <TestComponent />;
     instance = ReactTestUtils.renderIntoDocument(instance);
     expect(instance.state).toEqual({foo: 'foo'});
 
-    var setter = ReactStateSetters.createStateKeySetter(instance, 'foo');
+    const setter = ReactStateSetters.createStateKeySetter(instance, 'foo');
 
     expect(instance.state).toEqual({foo: 'foo'});
 
@@ -85,26 +85,26 @@ describe('ReactStateSetters', function() {
   });
 
   it('createStateKeySetter is memoized', function() {
-    var instance = <TestComponent />;
+    let instance = <TestComponent />;
     instance = ReactTestUtils.renderIntoDocument(instance);
     expect(instance.state).toEqual({foo: 'foo'});
 
-    var foo1 = ReactStateSetters.createStateKeySetter(instance, 'foo');
-    var bar1 = ReactStateSetters.createStateKeySetter(instance, 'bar');
+    const foo1 = ReactStateSetters.createStateKeySetter(instance, 'foo');
+    const bar1 = ReactStateSetters.createStateKeySetter(instance, 'bar');
 
-    var foo2 = ReactStateSetters.createStateKeySetter(instance, 'foo');
-    var bar2 = ReactStateSetters.createStateKeySetter(instance, 'bar');
+    const foo2 = ReactStateSetters.createStateKeySetter(instance, 'foo');
+    const bar2 = ReactStateSetters.createStateKeySetter(instance, 'bar');
 
     expect(foo2).toBe(foo1);
     expect(bar2).toBe(bar1);
   });
 
   it('createStateSetter should update state from mixin', function() {
-    var instance = <TestComponentWithMixin />;
+    let instance = <TestComponentWithMixin />;
     instance = ReactTestUtils.renderIntoDocument(instance);
     expect(instance.state).toEqual({foo: 'foo'});
 
-    var setter = instance.createStateSetter(
+    const setter = instance.createStateSetter(
       function(a, b, c) {
         return {
           foo: a + b + c,
@@ -122,11 +122,11 @@ describe('ReactStateSetters', function() {
   });
 
   it('createStateKeySetter should update state with mixin', function() {
-    var instance = <TestComponentWithMixin />;
+    let instance = <TestComponentWithMixin />;
     instance = ReactTestUtils.renderIntoDocument(instance);
     expect(instance.state).toEqual({foo: 'foo'});
 
-    var setter = instance.createStateKeySetter('foo');
+    const setter = instance.createStateKeySetter('foo');
 
     expect(instance.state).toEqual({foo: 'foo'});
 
@@ -138,15 +138,15 @@ describe('ReactStateSetters', function() {
   });
 
   it('createStateKeySetter is memoized with mixin', function() {
-    var instance = <TestComponentWithMixin />;
+    let instance = <TestComponentWithMixin />;
     instance = ReactTestUtils.renderIntoDocument(instance);
     expect(instance.state).toEqual({foo: 'foo'});
 
-    var foo1 = instance.createStateKeySetter('foo');
-    var bar1 = instance.createStateKeySetter('bar');
+    const foo1 = instance.createStateKeySetter('foo');
+    const bar1 = instance.createStateKeySetter('bar');
 
-    var foo2 = instance.createStateKeySetter('foo');
-    var bar2 = instance.createStateKeySetter('bar');
+    const foo2 = instance.createStateKeySetter('foo');
+    const bar2 = instance.createStateKeySetter('bar');
 
     expect(foo2).toBe(foo1);
     expect(bar2).toBe(bar1);

--- a/src/renderers/shared/reconciler/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactStatelessComponent-test.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
-var ReactTestUtils;
+let React;
+let ReactDOM;
+let ReactTestUtils;
 
 function StatelessComponent(props) {
   return <div>{props.name}</div>;
@@ -28,20 +28,20 @@ describe('ReactStatelessComponent', function() {
   });
 
   it('should render stateless component', function() {
-    var el = document.createElement('div');
+    const el = document.createElement('div');
     ReactDOM.render(<StatelessComponent name="A" />, el);
 
     expect(el.textContent).toBe('A');
   });
 
   it('should update stateless component', function() {
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       render() {
         return <StatelessComponent {...this.props} />;
       },
     });
 
-    var el = document.createElement('div');
+    const el = document.createElement('div');
     ReactDOM.render(<Parent name="A" />, el);
     expect(el.textContent).toBe('A');
 
@@ -50,7 +50,7 @@ describe('ReactStatelessComponent', function() {
   });
 
   it('should unmount stateless component', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
 
     ReactDOM.render(<StatelessComponent name="A" />, container);
     expect(container.textContent).toBe('A');
@@ -60,7 +60,7 @@ describe('ReactStatelessComponent', function() {
   });
 
   it('should pass context thru stateless component', function() {
-    var Child = React.createClass({
+    const Child = React.createClass({
       contextTypes: {
         test: React.PropTypes.string.isRequired,
       },
@@ -74,7 +74,7 @@ describe('ReactStatelessComponent', function() {
       return <Child />;
     }
 
-    var GrandParent = React.createClass({
+    const GrandParent = React.createClass({
       childContextTypes: {
         test: React.PropTypes.string.isRequired,
       },
@@ -88,7 +88,7 @@ describe('ReactStatelessComponent', function() {
       },
     });
 
-    var el = document.createElement('div');
+    const el = document.createElement('div');
     ReactDOM.render(<GrandParent test="test" />, el);
 
     expect(el.textContent).toBe('test');
@@ -128,7 +128,7 @@ describe('ReactStatelessComponent', function() {
   it('should warn when given a ref', function() {
     spyOn(console, 'error');
 
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       displayName: 'Parent',
       render: function() {
         return <StatelessComponent name="A" ref="stateless"/>;
@@ -149,7 +149,7 @@ describe('ReactStatelessComponent', function() {
       return <div />;
     }
 
-    var comp = ReactTestUtils.renderIntoDocument(<Child />);
+    const comp = ReactTestUtils.renderIntoDocument(<Child />);
     expect(comp).toBe(null);
   });
 
@@ -182,7 +182,7 @@ describe('ReactStatelessComponent', function() {
   });
 
   it('should receive context', function() {
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       childContextTypes: {
         lang: React.PropTypes.string,
       },
@@ -198,13 +198,13 @@ describe('ReactStatelessComponent', function() {
     }
     Child.contextTypes = {lang: React.PropTypes.string};
 
-    var el = document.createElement('div');
+    const el = document.createElement('div');
     ReactDOM.render(<Parent />, el);
     expect(el.textContent).toBe('en');
   });
 
   it('should work with arrow functions', function() {
-    var Child = function() {
+    let Child = function() {
       return <div />;
     };
     // Will create a new bound function without a prototype, much like a native
@@ -215,7 +215,7 @@ describe('ReactStatelessComponent', function() {
   });
 
   it('should allow simple functions to return null', function() {
-    var Child = function() {
+    const Child = function() {
       return null;
     };
     expect(() => ReactTestUtils.renderIntoDocument(<Child />)).not.toThrow();

--- a/src/renderers/shared/reconciler/__tests__/ReactUpdates-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactUpdates-test.js
@@ -11,10 +11,10 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
-var ReactTestUtils;
-var ReactUpdates;
+let React;
+let ReactDOM;
+let ReactTestUtils;
+let ReactUpdates;
 
 describe('ReactUpdates', function() {
   beforeEach(function() {
@@ -25,8 +25,8 @@ describe('ReactUpdates', function() {
   });
 
   it('should batch state when updating state twice', function() {
-    var updateCount = 0;
-    var Component = React.createClass({
+    let updateCount = 0;
+    const Component = React.createClass({
       getInitialState: function() {
         return {x: 0};
       },
@@ -38,7 +38,7 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var instance = ReactTestUtils.renderIntoDocument(<Component />);
+    const instance = ReactTestUtils.renderIntoDocument(<Component />);
     expect(instance.state.x).toBe(0);
 
     ReactUpdates.batchedUpdates(function() {
@@ -53,8 +53,8 @@ describe('ReactUpdates', function() {
   });
 
   it('should batch state when updating two different state keys', function() {
-    var updateCount = 0;
-    var Component = React.createClass({
+    let updateCount = 0;
+    const Component = React.createClass({
       getInitialState: function() {
         return {x: 0, y: 0};
       },
@@ -66,7 +66,7 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var instance = ReactTestUtils.renderIntoDocument(<Component />);
+    const instance = ReactTestUtils.renderIntoDocument(<Component />);
     expect(instance.state.x).toBe(0);
     expect(instance.state.y).toBe(0);
 
@@ -84,8 +84,8 @@ describe('ReactUpdates', function() {
   });
 
   it('should batch state and props together', function() {
-    var updateCount = 0;
-    var Component = React.createClass({
+    let updateCount = 0;
+    const Component = React.createClass({
       getInitialState: function() {
         return {y: 0};
       },
@@ -97,8 +97,8 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var container = document.createElement('div');
-    var instance = ReactDOM.render(<Component x={0} />, container);
+    const container = document.createElement('div');
+    const instance = ReactDOM.render(<Component x={0} />, container);
     expect(instance.props.x).toBe(0);
     expect(instance.state.y).toBe(0);
 
@@ -116,8 +116,8 @@ describe('ReactUpdates', function() {
   });
 
   it('should batch parent/child state updates together', function() {
-    var parentUpdateCount = 0;
-    var Parent = React.createClass({
+    let parentUpdateCount = 0;
+    const Parent = React.createClass({
       getInitialState: function() {
         return {x: 0};
       },
@@ -128,8 +128,8 @@ describe('ReactUpdates', function() {
         return <div><Child ref="child" x={this.state.x} /></div>;
       },
     });
-    var childUpdateCount = 0;
-    var Child = React.createClass({
+    let childUpdateCount = 0;
+    const Child = React.createClass({
       getInitialState: function() {
         return {y: 0};
       },
@@ -141,8 +141,8 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var instance = ReactTestUtils.renderIntoDocument(<Parent />);
-    var child = instance.refs.child;
+    const instance = ReactTestUtils.renderIntoDocument(<Parent />);
+    const child = instance.refs.child;
     expect(instance.state.x).toBe(0);
     expect(child.state.y).toBe(0);
 
@@ -162,8 +162,8 @@ describe('ReactUpdates', function() {
   });
 
   it('should batch child/parent state updates together', function() {
-    var parentUpdateCount = 0;
-    var Parent = React.createClass({
+    let parentUpdateCount = 0;
+    const Parent = React.createClass({
       getInitialState: function() {
         return {x: 0};
       },
@@ -174,8 +174,8 @@ describe('ReactUpdates', function() {
         return <div><Child ref="child" x={this.state.x} /></div>;
       },
     });
-    var childUpdateCount = 0;
-    var Child = React.createClass({
+    let childUpdateCount = 0;
+    const Child = React.createClass({
       getInitialState: function() {
         return {y: 0};
       },
@@ -187,8 +187,8 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var instance = ReactTestUtils.renderIntoDocument(<Parent />);
-    var child = instance.refs.child;
+    const instance = ReactTestUtils.renderIntoDocument(<Parent />);
+    const child = instance.refs.child;
     expect(instance.state.x).toBe(0);
     expect(child.state.y).toBe(0);
 
@@ -210,8 +210,8 @@ describe('ReactUpdates', function() {
   });
 
   it('should support chained state updates', function() {
-    var updateCount = 0;
-    var Component = React.createClass({
+    let updateCount = 0;
+    const Component = React.createClass({
       getInitialState: function() {
         return {x: 0};
       },
@@ -223,10 +223,10 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var instance = ReactTestUtils.renderIntoDocument(<Component />);
+    const instance = ReactTestUtils.renderIntoDocument(<Component />);
     expect(instance.state.x).toBe(0);
 
-    var innerCallbackRun = false;
+    let innerCallbackRun = false;
     ReactUpdates.batchedUpdates(function() {
       instance.setState({x: 1}, function() {
         instance.setState({x: 2}, function() {
@@ -248,9 +248,9 @@ describe('ReactUpdates', function() {
   });
 
   it('should batch forceUpdate together', function() {
-    var shouldUpdateCount = 0;
-    var updateCount = 0;
-    var Component = React.createClass({
+    let shouldUpdateCount = 0;
+    let updateCount = 0;
+    const Component = React.createClass({
       getInitialState: function() {
         return {x: 0};
       },
@@ -265,10 +265,10 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var instance = ReactTestUtils.renderIntoDocument(<Component />);
+    const instance = ReactTestUtils.renderIntoDocument(<Component />);
     expect(instance.state.x).toBe(0);
 
-    var callbacksRun = 0;
+    let callbacksRun = 0;
     ReactUpdates.batchedUpdates(function() {
       instance.setState({x: 1}, function() {
         callbacksRun++;
@@ -288,10 +288,10 @@ describe('ReactUpdates', function() {
   });
 
   it('should update children even if parent blocks updates', function() {
-    var parentRenderCount = 0;
-    var childRenderCount = 0;
+    let parentRenderCount = 0;
+    let childRenderCount = 0;
 
-    var Parent = React.createClass({
+    const Parent = React.createClass({
       shouldComponentUpdate: function() {
         return false;
       },
@@ -302,7 +302,7 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var Child = React.createClass({
+    const Child = React.createClass({
       render: function() {
         childRenderCount++;
         return <div />;
@@ -312,7 +312,7 @@ describe('ReactUpdates', function() {
     expect(parentRenderCount).toBe(0);
     expect(childRenderCount).toBe(0);
 
-    var instance = <Parent />;
+    let instance = <Parent />;
     instance = ReactTestUtils.renderIntoDocument(instance);
 
     expect(parentRenderCount).toBe(1);
@@ -334,16 +334,16 @@ describe('ReactUpdates', function() {
   });
 
   it('should not reconcile children passed via props', function() {
-    var numMiddleRenders = 0;
-    var numBottomRenders = 0;
+    let numMiddleRenders = 0;
+    let numBottomRenders = 0;
 
-    var Top = React.createClass({
+    const Top = React.createClass({
       render: function() {
         return <Middle><Bottom /></Middle>;
       },
     });
 
-    var Middle = React.createClass({
+    const Middle = React.createClass({
       componentDidMount: function() {
         this.forceUpdate();
       },
@@ -354,7 +354,7 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var Bottom = React.createClass({
+    const Bottom = React.createClass({
       render: function() {
         numBottomRenders++;
         return null;
@@ -367,10 +367,10 @@ describe('ReactUpdates', function() {
   });
 
   it('should flow updates correctly', function() {
-    var willUpdates = [];
-    var didUpdates = [];
+    let willUpdates = [];
+    let didUpdates = [];
 
-    var UpdateLoggingMixin = {
+    const UpdateLoggingMixin = {
       componentWillUpdate: function() {
         willUpdates.push(this.constructor.displayName);
       },
@@ -379,7 +379,7 @@ describe('ReactUpdates', function() {
       },
     };
 
-    var Box = React.createClass({
+    const Box = React.createClass({
       mixins: [UpdateLoggingMixin],
 
       render: function() {
@@ -387,7 +387,7 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var Child = React.createClass({
+    const Child = React.createClass({
       mixins: [UpdateLoggingMixin],
 
       render: function() {
@@ -395,7 +395,7 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var Switcher = React.createClass({
+    const Switcher = React.createClass({
       mixins: [UpdateLoggingMixin],
 
       getInitialState: function() {
@@ -403,7 +403,7 @@ describe('ReactUpdates', function() {
       },
 
       render: function() {
-        var child = this.props.children;
+        const child = this.props.children;
 
         return (
           <Box ref="box">
@@ -419,7 +419,7 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var App = React.createClass({
+    const App = React.createClass({
       mixins: [UpdateLoggingMixin],
 
       render: function() {
@@ -431,11 +431,11 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var root = <App />;
+    let root = <App />;
     root = ReactTestUtils.renderIntoDocument(root);
 
     function expectUpdates(desiredWillUpdates, desiredDidUpdates) {
-      var i;
+      let i;
       for (i = 0; i < desiredWillUpdates; i++) {
         expect(willUpdates).toContain(desiredWillUpdates[i]);
       }
@@ -451,7 +451,7 @@ describe('ReactUpdates', function() {
     }
 
     function testUpdates(components, desiredWillUpdates, desiredDidUpdates) {
-      var i;
+      let i;
 
       ReactUpdates.batchedUpdates(function() {
         for (i = 0; i < components.length; i++) {
@@ -494,17 +494,17 @@ describe('ReactUpdates', function() {
   });
 
   it('should share reconcile transaction across different roots', function() {
-    var ReconcileTransaction = ReactUpdates.ReactReconcileTransaction;
+    const ReconcileTransaction = ReactUpdates.ReactReconcileTransaction;
     spyOn(ReconcileTransaction, 'getPooled').andCallThrough();
 
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         return <div>{this.props.text}</div>;
       },
     });
 
-    var containerA = document.createElement('div');
-    var containerB = document.createElement('div');
+    const containerA = document.createElement('div');
+    const containerB = document.createElement('div');
 
     // Initial renders aren't batched together yet...
     ReactUpdates.batchedUpdates(function() {
@@ -527,12 +527,12 @@ describe('ReactUpdates', function() {
     // componentDidUpdate handlers is called, B's DOM should already have been
     // updated.
 
-    var a;
-    var b;
+    let a;
+    let b;
 
-    var aUpdated = false;
+    let aUpdated = false;
 
-    var A = React.createClass({
+    const A = React.createClass({
       getInitialState: function() {
         return {x: 0};
       },
@@ -545,7 +545,7 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var B = React.createClass({
+    const B = React.createClass({
       getInitialState: function() {
         return {x: 0};
       },
@@ -566,8 +566,8 @@ describe('ReactUpdates', function() {
   });
 
   it('should flush updates in the correct order', function() {
-    var updates = [];
-    var Outer = React.createClass({
+    const updates = [];
+    const Outer = React.createClass({
       getInitialState: function() {
         return {x: 0};
       },
@@ -576,7 +576,7 @@ describe('ReactUpdates', function() {
         return <div><Inner x={this.state.x} ref="inner" /></div>;
       },
       componentDidUpdate: function() {
-        var x = this.state.x;
+        const x = this.state.x;
         updates.push('Outer-didUpdate-' + x);
         updates.push('Inner-setState-' + x);
         this.refs.inner.setState({x: x}, function() {
@@ -584,7 +584,7 @@ describe('ReactUpdates', function() {
         });
       },
     });
-    var Inner = React.createClass({
+    const Inner = React.createClass({
       getInitialState: function() {
         return {x: 0};
       },
@@ -597,7 +597,7 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var instance = ReactTestUtils.renderIntoDocument(<Outer />);
+    const instance = ReactTestUtils.renderIntoDocument(<Outer />);
 
     updates.push('Outer-setState-1');
     instance.setState({x: 1}, function() {
@@ -639,10 +639,10 @@ describe('ReactUpdates', function() {
   });
 
   it('should flush updates in the correct order across roots', function() {
-    var instances = [];
-    var updates = [];
+    const instances = [];
+    const updates = [];
 
-    var MockComponent = React.createClass({
+    const MockComponent = React.createClass({
       render: function() {
         updates.push(this.props.depth);
         return <div />;
@@ -678,7 +678,7 @@ describe('ReactUpdates', function() {
   it('should queue nested updates', function() {
     // See https://github.com/facebook/react/issues/1147
 
-    var X = React.createClass({
+    const X = React.createClass({
       getInitialState: function() {
         return {s: 0};
       },
@@ -700,7 +700,7 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var Y = React.createClass({
+    const Y = React.createClass({
       render: function() {
         return (
           <div>
@@ -710,7 +710,7 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var Z = React.createClass({
+    const Z = React.createClass({
       render: function() {
         return <div />;
       },
@@ -719,8 +719,8 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var x;
-    var y;
+    let x;
+    let y;
 
     x = ReactTestUtils.renderIntoDocument(<X />);
     y = ReactTestUtils.renderIntoDocument(<Y />);
@@ -732,9 +732,9 @@ describe('ReactUpdates', function() {
 
   it('should queue updates from during mount', function() {
     // See https://github.com/facebook/react/issues/1353
-    var a;
+    let a;
 
-    var A = React.createClass({
+    const A = React.createClass({
       getInitialState: function() {
         return {x: 0};
       },
@@ -746,7 +746,7 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var B = React.createClass({
+    const B = React.createClass({
       componentWillMount: function() {
         a.setState({x: 1});
       },
@@ -769,13 +769,13 @@ describe('ReactUpdates', function() {
   });
 
   it('calls componentWillReceiveProps setState callback properly', function() {
-    var callbackCount = 0;
-    var A = React.createClass({
+    let callbackCount = 0;
+    const A = React.createClass({
       getInitialState: function() {
         return {x: this.props.x};
       },
       componentWillReceiveProps: function(nextProps) {
-        var newX = nextProps.x;
+        const newX = nextProps.x;
         this.setState({x: newX}, function() {
           // State should have updated by the time this callback gets called
           expect(this.state.x).toBe(newX);
@@ -787,15 +787,15 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<A x={1} />, container);
     ReactDOM.render(<A x={2} />, container);
     expect(callbackCount).toBe(1);
   });
 
   it('calls asap callbacks properly', function() {
-    var callbackCount = 0;
-    var A = React.createClass({
+    let callbackCount = 0;
+    const A = React.createClass({
       render: function() {
         return <div />;
       },
@@ -812,14 +812,14 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var component = ReactTestUtils.renderIntoDocument(<A />);
+    const component = ReactTestUtils.renderIntoDocument(<A />);
     component.forceUpdate();
     expect(callbackCount).toBe(2);
   });
 
   it('calls asap callbacks with queued updates', function() {
-    var log = [];
-    var A = React.createClass({
+    const log = [];
+    const A = React.createClass({
       getInitialState: () => ({updates: 0}),
       render: function() {
         log.push('render-' + this.state.updates);
@@ -845,7 +845,7 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var component = ReactTestUtils.renderIntoDocument(<A />);
+    const component = ReactTestUtils.renderIntoDocument(<A />);
     component.setState({updates: 1});
     expect(log).toEqual([
       'render-0',
@@ -867,10 +867,10 @@ describe('ReactUpdates', function() {
 
   it('does not call render after a component as been deleted', function() {
 
-    var renderCount = 0;
-    var componentB = null;
+    let renderCount = 0;
+    let componentB = null;
 
-    var B = React.createClass({
+    const B = React.createClass({
       getInitialState: function() {
         return {updates: 0};
       },
@@ -883,7 +883,7 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var A = React.createClass({
+    const A = React.createClass({
       getInitialState: function() {
         return {showB: true};
       },
@@ -892,7 +892,7 @@ describe('ReactUpdates', function() {
       },
     });
 
-    var component = ReactTestUtils.renderIntoDocument(<A />);
+    const component = ReactTestUtils.renderIntoDocument(<A />);
 
     ReactUpdates.batchedUpdates(function() {
       // B will have scheduled an update but the batching should ensure that its
@@ -905,21 +905,21 @@ describe('ReactUpdates', function() {
   });
 
   it('marks top-level updates', function() {
-    var ReactFeatureFlags = require('ReactFeatureFlags');
+    const ReactFeatureFlags = require('ReactFeatureFlags');
 
-    var Foo = React.createClass({
+    const Foo = React.createClass({
       render: function() {
         return <Bar />;
       },
     });
 
-    var Bar = React.createClass({
+    const Bar = React.createClass({
       render: function() {
         return <div />;
       },
     });
 
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<Foo />, container);
 
     try {

--- a/src/renderers/shared/reconciler/__tests__/refs-destruction-test.js
+++ b/src/renderers/shared/reconciler/__tests__/refs-destruction-test.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
-var ReactTestUtils;
+let React;
+let ReactDOM;
+let ReactTestUtils;
 
-var TestComponent;
+let TestComponent;
 
 describe('refs-destruction', function() {
   beforeEach(function() {
@@ -41,8 +41,8 @@ describe('refs-destruction', function() {
   });
 
   it('should remove refs when destroying the parent', function() {
-    var container = document.createElement('div');
-    var testInstance = ReactDOM.render(<TestComponent />, container);
+    const container = document.createElement('div');
+    const testInstance = ReactDOM.render(<TestComponent />, container);
     expect(ReactTestUtils.isDOMComponent(testInstance.refs.theInnerDiv))
       .toBe(true);
     expect(Object.keys(testInstance.refs || {}).length).toEqual(1);
@@ -51,8 +51,8 @@ describe('refs-destruction', function() {
   });
 
   it('should remove refs when destroying the child', function() {
-    var container = document.createElement('div');
-    var testInstance = ReactDOM.render(<TestComponent />, container);
+    const container = document.createElement('div');
+    const testInstance = ReactDOM.render(<TestComponent />, container);
     expect(ReactTestUtils.isDOMComponent(testInstance.refs.theInnerDiv))
       .toBe(true);
     expect(Object.keys(testInstance.refs || {}).length).toEqual(1);

--- a/src/renderers/shared/reconciler/__tests__/refs-test.js
+++ b/src/renderers/shared/reconciler/__tests__/refs-test.js
@@ -11,17 +11,17 @@
 
 'use strict';
 
-var React = require('React');
-var ReactTestUtils = require('ReactTestUtils');
+const React = require('React');
+const ReactTestUtils = require('ReactTestUtils');
 
-var reactComponentExpect = require('reactComponentExpect');
+const reactComponentExpect = require('reactComponentExpect');
 
 
 /**
  * Counts clicks and has a renders an item for each click. Each item rendered
  * has a ref of the form "clickLogN".
  */
-var ClickCounter = React.createClass({
+const ClickCounter = React.createClass({
   getInitialState: function() {
     return {count: this.props.initialCount};
   },
@@ -32,8 +32,8 @@ var ClickCounter = React.createClass({
     this.setState({count: this.state.count + 1});
   },
   render: function() {
-    var children = [];
-    var i;
+    const children = [];
+    let i;
     for (i = 0; i < this.state.count; i++) {
       children.push(
         <div
@@ -56,7 +56,7 @@ var ClickCounter = React.createClass({
  * component that is injected down several layers. Ref systems are difficult to
  * build in such a way that ownership is maintained in an airtight manner.
  */
-var GeneralContainerComponent = React.createClass({
+const GeneralContainerComponent = React.createClass({
   render: function() {
     return <div>{this.props.children}</div>;
   },
@@ -66,7 +66,7 @@ var GeneralContainerComponent = React.createClass({
  * Notice how refs ownership is maintained even when injecting a component
  * into a different parent.
  */
-var TestRefsComponent = React.createClass({
+const TestRefsComponent = React.createClass({
   doReset: function() {
     this.refs.myCounter.triggerReset();
   },
@@ -87,15 +87,15 @@ var TestRefsComponent = React.createClass({
 /**
  * Render a TestRefsComponent and ensure that the main refs are wired up.
  */
-var renderTestRefsComponent = function() {
-  var testRefsComponent =
+const renderTestRefsComponent = function() {
+  const testRefsComponent =
       ReactTestUtils.renderIntoDocument(<TestRefsComponent />);
 
   reactComponentExpect(testRefsComponent)
       .toBeCompositeComponentWithType(TestRefsComponent);
 
-  var generalContainer = testRefsComponent.refs.myContainer;
-  var counter = testRefsComponent.refs.myCounter;
+  const generalContainer = testRefsComponent.refs.myContainer;
+  const counter = testRefsComponent.refs.myCounter;
 
   reactComponentExpect(generalContainer)
       .toBeCompositeComponentWithType(GeneralContainerComponent);
@@ -106,8 +106,8 @@ var renderTestRefsComponent = function() {
 };
 
 
-var expectClickLogsLengthToBe = function(instance, length) {
-  var clickLogs =
+const expectClickLogsLengthToBe = function(instance, length) {
+  const clickLogs =
     ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'clickLogDiv');
   expect(clickLogs.length).toBe(length);
   expect(Object.keys(instance.refs.myCounter.refs).length).toBe(length);
@@ -123,8 +123,8 @@ describe('reactiverefs', function() {
    * perspective of the injected ClickCounter component.
    */
   it('Should increase refs with an increase in divs', function() {
-    var testRefsComponent = renderTestRefsComponent();
-    var clickIncrementer =
+    const testRefsComponent = renderTestRefsComponent();
+    const clickIncrementer =
       ReactTestUtils.findRenderedDOMComponentWithClass(
         testRefsComponent,
         'clickIncrementer'
@@ -161,7 +161,7 @@ describe('ref swapping', function() {
     jest.resetModuleRegistry();
   });
 
-  var RefHopsAround = React.createClass({
+  const RefHopsAround = React.createClass({
     getInitialState: function() {
       return {count: 0};
     },
@@ -169,7 +169,7 @@ describe('ref swapping', function() {
       this.setState({count: this.state.count + 1});
     },
     render: function() {
-      var count = this.state.count;
+      const count = this.state.count;
       /**
        * What we have here, is three divs with refs (div1/2/3), but a single
        * moving cursor ref `hopRef` that "hops" around the three. We'll call the
@@ -196,13 +196,13 @@ describe('ref swapping', function() {
   });
 
   it('Allow refs to hop around children correctly', function() {
-    var refHopsAround = ReactTestUtils.renderIntoDocument(<RefHopsAround />);
+    const refHopsAround = ReactTestUtils.renderIntoDocument(<RefHopsAround />);
 
-    var firstDiv =
+    const firstDiv =
       ReactTestUtils.findRenderedDOMComponentWithClass(refHopsAround, 'first');
-    var secondDiv =
+    const secondDiv =
       ReactTestUtils.findRenderedDOMComponentWithClass(refHopsAround, 'second');
-    var thirdDiv =
+    const thirdDiv =
       ReactTestUtils.findRenderedDOMComponentWithClass(refHopsAround, 'third');
 
     expect(refHopsAround.refs.hopRef).toEqual(firstDiv);
@@ -231,13 +231,13 @@ describe('ref swapping', function() {
 
 
   it('always has a value for this.refs', function() {
-    var Component = React.createClass({
+    const Component = React.createClass({
       render: function() {
         return <div />;
       },
     });
 
-    var instance = ReactTestUtils.renderIntoDocument(<Component />);
+    const instance = ReactTestUtils.renderIntoDocument(<Component />);
     expect(!!instance.refs).toBe(true);
   });
 });

--- a/src/renderers/shared/reconciler/instantiateReactComponent.js
+++ b/src/renderers/shared/reconciler/instantiateReactComponent.js
@@ -11,16 +11,16 @@
 
 'use strict';
 
-var ReactCompositeComponent = require('ReactCompositeComponent');
-var ReactEmptyComponent = require('ReactEmptyComponent');
-var ReactNativeComponent = require('ReactNativeComponent');
+const ReactCompositeComponent = require('ReactCompositeComponent');
+const ReactEmptyComponent = require('ReactEmptyComponent');
+const ReactNativeComponent = require('ReactNativeComponent');
 
-var assign = require('Object.assign');
-var invariant = require('invariant');
-var warning = require('warning');
+const assign = require('Object.assign');
+const invariant = require('invariant');
+const warning = require('warning');
 
 // To avoid a cyclic dependency, we create the final class in this module
-var ReactCompositeComponentWrapper = function(element) {
+const ReactCompositeComponentWrapper = function(element) {
   this.construct(element);
 };
 assign(
@@ -33,7 +33,7 @@ assign(
 
 function getDeclarationErrorAddendum(owner) {
   if (owner) {
-    var name = owner.getName();
+    const name = owner.getName();
     if (name) {
       return ' Check the render method of `' + name + '`.';
     }
@@ -65,12 +65,12 @@ function isInternalComponentType(type) {
  * @protected
  */
 function instantiateReactComponent(node) {
-  var instance;
+  let instance;
 
   if (node === null || node === false) {
     instance = ReactEmptyComponent.create(instantiateReactComponent);
   } else if (typeof node === 'object') {
-    var element = node;
+    const element = node;
     invariant(
       element && (typeof element.type === 'function' ||
                   typeof element.type === 'string'),

--- a/src/renderers/shared/reconciler/shouldUpdateReactComponent.js
+++ b/src/renderers/shared/reconciler/shouldUpdateReactComponent.js
@@ -23,14 +23,14 @@
  * @protected
  */
 function shouldUpdateReactComponent(prevElement, nextElement) {
-  var prevEmpty = prevElement === null || prevElement === false;
-  var nextEmpty = nextElement === null || nextElement === false;
+  const prevEmpty = prevElement === null || prevElement === false;
+  const nextEmpty = nextElement === null || nextElement === false;
   if (prevEmpty || nextEmpty) {
     return prevEmpty === nextEmpty;
   }
 
-  var prevType = typeof prevElement;
-  var nextType = typeof nextElement;
+  const prevType = typeof prevElement;
+  const nextType = typeof nextElement;
   if (prevType === 'string' || prevType === 'number') {
     return (nextType === 'string' || nextType === 'number');
   } else {

--- a/src/shared/stubs/Object.assign.js
+++ b/src/shared/stubs/Object.assign.js
@@ -18,23 +18,23 @@ function assign(target, sources) {
     throw new TypeError('Object.assign target cannot be null or undefined');
   }
 
-  var to = Object(target);
-  var hasOwnProperty = Object.prototype.hasOwnProperty;
+  const to = Object(target);
+  const hasOwnProperty = Object.prototype.hasOwnProperty;
 
-  for (var nextIndex = 1; nextIndex < arguments.length; nextIndex++) {
-    var nextSource = arguments[nextIndex];
+  for (let nextIndex = 1; nextIndex < arguments.length; nextIndex++) {
+    const nextSource = arguments[nextIndex];
     if (nextSource == null) {
       continue;
     }
 
-    var from = Object(nextSource);
+    const from = Object(nextSource);
 
     // We don't currently support accessors nor proxies. Therefore this
     // copy cannot throw. If we ever supported this then we must handle
     // exceptions and side-effects. We don't support symbols so they won't
     // be transferred.
 
-    for (var key in from) {
+    for (let key in from) {
       if (hasOwnProperty.call(from, key)) {
         to[key] = from[key];
       }

--- a/src/shared/stubs/Object.assign.js
+++ b/src/shared/stubs/Object.assign.js
@@ -34,7 +34,7 @@ function assign(target, sources) {
     // exceptions and side-effects. We don't support symbols so they won't
     // be transferred.
 
-    for (let key in from) {
+    for (const key in from) {
       if (hasOwnProperty.call(from, key)) {
         to[key] = from[key];
       }

--- a/src/shared/utils/CallbackQueue.js
+++ b/src/shared/utils/CallbackQueue.js
@@ -11,10 +11,10 @@
 
 'use strict';
 
-var PooledClass = require('PooledClass');
+const PooledClass = require('PooledClass');
 
-var assign = require('Object.assign');
-var invariant = require('invariant');
+const assign = require('Object.assign');
+const invariant = require('invariant');
 
 /**
  * A specialized pseudo-event module to help keep track of components waiting to
@@ -55,8 +55,8 @@ assign(CallbackQueue.prototype, {
    * @internal
    */
   notifyAll: function() {
-    var callbacks = this._callbacks;
-    var contexts = this._contexts;
+    const callbacks = this._callbacks;
+    const contexts = this._contexts;
     if (callbacks) {
       invariant(
         callbacks.length === contexts.length,
@@ -64,7 +64,7 @@ assign(CallbackQueue.prototype, {
       );
       this._callbacks = null;
       this._contexts = null;
-      for (var i = 0; i < callbacks.length; i++) {
+      for (let i = 0; i < callbacks.length; i++) {
         callbacks[i].call(contexts[i]);
       }
       callbacks.length = 0;

--- a/src/shared/utils/PooledClass.js
+++ b/src/shared/utils/PooledClass.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var invariant = require('invariant');
+const invariant = require('invariant');
 
 /**
  * Static poolers. Several custom versions for each potential number of
@@ -20,10 +20,10 @@ var invariant = require('invariant');
  * the Class itself, not an instance. If any others are needed, simply add them
  * here, or in their own files.
  */
-var oneArgumentPooler = function(copyFieldsFrom) {
-  var Klass = this;
+const oneArgumentPooler = function(copyFieldsFrom) {
+  const Klass = this;
   if (Klass.instancePool.length) {
-    var instance = Klass.instancePool.pop();
+    const instance = Klass.instancePool.pop();
     Klass.call(instance, copyFieldsFrom);
     return instance;
   } else {
@@ -31,10 +31,10 @@ var oneArgumentPooler = function(copyFieldsFrom) {
   }
 };
 
-var twoArgumentPooler = function(a1, a2) {
-  var Klass = this;
+const twoArgumentPooler = function(a1, a2) {
+  const Klass = this;
   if (Klass.instancePool.length) {
-    var instance = Klass.instancePool.pop();
+    const instance = Klass.instancePool.pop();
     Klass.call(instance, a1, a2);
     return instance;
   } else {
@@ -42,10 +42,10 @@ var twoArgumentPooler = function(a1, a2) {
   }
 };
 
-var threeArgumentPooler = function(a1, a2, a3) {
-  var Klass = this;
+const threeArgumentPooler = function(a1, a2, a3) {
+  const Klass = this;
   if (Klass.instancePool.length) {
-    var instance = Klass.instancePool.pop();
+    const instance = Klass.instancePool.pop();
     Klass.call(instance, a1, a2, a3);
     return instance;
   } else {
@@ -53,10 +53,10 @@ var threeArgumentPooler = function(a1, a2, a3) {
   }
 };
 
-var fourArgumentPooler = function(a1, a2, a3, a4) {
-  var Klass = this;
+const fourArgumentPooler = function(a1, a2, a3, a4) {
+  const Klass = this;
   if (Klass.instancePool.length) {
-    var instance = Klass.instancePool.pop();
+    const instance = Klass.instancePool.pop();
     Klass.call(instance, a1, a2, a3, a4);
     return instance;
   } else {
@@ -64,10 +64,10 @@ var fourArgumentPooler = function(a1, a2, a3, a4) {
   }
 };
 
-var fiveArgumentPooler = function(a1, a2, a3, a4, a5) {
-  var Klass = this;
+const fiveArgumentPooler = function(a1, a2, a3, a4, a5) {
+  const Klass = this;
   if (Klass.instancePool.length) {
-    var instance = Klass.instancePool.pop();
+    const instance = Klass.instancePool.pop();
     Klass.call(instance, a1, a2, a3, a4, a5);
     return instance;
   } else {
@@ -75,8 +75,8 @@ var fiveArgumentPooler = function(a1, a2, a3, a4, a5) {
   }
 };
 
-var standardReleaser = function(instance) {
-  var Klass = this;
+const standardReleaser = function(instance) {
+  const Klass = this;
   invariant(
     instance instanceof Klass,
     'Trying to release an instance into a pool of a different type.'
@@ -87,8 +87,8 @@ var standardReleaser = function(instance) {
   }
 };
 
-var DEFAULT_POOL_SIZE = 10;
-var DEFAULT_POOLER = oneArgumentPooler;
+const DEFAULT_POOL_SIZE = 10;
+const DEFAULT_POOLER = oneArgumentPooler;
 
 /**
  * Augments `CopyConstructor` to be a poolable class, augmenting only the class
@@ -99,8 +99,8 @@ var DEFAULT_POOLER = oneArgumentPooler;
  * @param {Function} CopyConstructor Constructor that can be used to reset.
  * @param {Function} pooler Customizable pooler.
  */
-var addPoolingTo = function(CopyConstructor, pooler) {
-  var NewKlass = CopyConstructor;
+const addPoolingTo = function(CopyConstructor, pooler) {
+  const NewKlass = CopyConstructor;
   NewKlass.instancePool = [];
   NewKlass.getPooled = pooler || DEFAULT_POOLER;
   if (!NewKlass.poolSize) {
@@ -110,7 +110,7 @@ var addPoolingTo = function(CopyConstructor, pooler) {
   return NewKlass;
 };
 
-var PooledClass = {
+const PooledClass = {
   addPoolingTo: addPoolingTo,
   oneArgumentPooler: oneArgumentPooler,
   twoArgumentPooler: twoArgumentPooler,

--- a/src/shared/utils/ReactErrorUtils.js
+++ b/src/shared/utils/ReactErrorUtils.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var caughtError = null;
+let caughtError = null;
 
 /**
  * Call a function while guarding against errors that happens within it.
@@ -32,7 +32,7 @@ function invokeGuardedCallback(name, func, a, b) {
   }
 }
 
-var ReactErrorUtils = {
+const ReactErrorUtils = {
   invokeGuardedCallback: invokeGuardedCallback,
 
   /**
@@ -47,7 +47,7 @@ var ReactErrorUtils = {
    */
   rethrowCaughtError: function() {
     if (caughtError) {
-      var error = caughtError;
+      const error = caughtError;
       caughtError = null;
       throw error;
     }
@@ -63,12 +63,12 @@ if (__DEV__) {
       typeof window.dispatchEvent === 'function' &&
       typeof document !== 'undefined' &&
       typeof document.createEvent === 'function') {
-    var fakeNode = document.createElement('react');
+    const fakeNode = document.createElement('react');
     ReactErrorUtils.invokeGuardedCallback = function(name, func, a, b) {
-      var boundFunc = func.bind(null, a, b);
-      var evtType = `react-${name}`;
+      const boundFunc = func.bind(null, a, b);
+      const evtType = `react-${name}`;
       fakeNode.addEventListener(evtType, boundFunc, false);
-      var evt = document.createEvent('Event');
+      const evt = document.createEvent('Event');
       evt.initEvent(evtType, false, false);
       fakeNode.dispatchEvent(evt);
       fakeNode.removeEventListener(evtType, boundFunc, false);

--- a/src/shared/utils/ReactFeatureFlags.js
+++ b/src/shared/utils/ReactFeatureFlags.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var ReactFeatureFlags = {
+const ReactFeatureFlags = {
   // When true, call console.time() before and .timeEnd() after each top-level
   // render (both initial renders and updates). Useful when looking at prod-mode
   // timeline profiles in Chrome, for example.

--- a/src/shared/utils/ReactNodeTypes.js
+++ b/src/shared/utils/ReactNodeTypes.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-var ReactElement = require('ReactElement');
+const ReactElement = require('ReactElement');
 
-var invariant = require('invariant');
+const invariant = require('invariant');
 
-var ReactNodeTypes = {
+const ReactNodeTypes = {
   NATIVE: 0,
   COMPOSITE: 1,
   EMPTY: 2,

--- a/src/shared/utils/Transaction.js
+++ b/src/shared/utils/Transaction.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var invariant = require('invariant');
+const invariant = require('invariant');
 
 /**
  * `Transaction` creates a black box that is able to wrap any method such that
@@ -74,7 +74,7 @@ var invariant = require('invariant');
  *
  * @class Transaction
  */
-var Mixin = {
+const Mixin = {
   /**
    * Sets up this instance so that it is prepared for collecting metrics. Does
    * so such that this setup method may be used on an instance that is already
@@ -127,8 +127,8 @@ var Mixin = {
       'Transaction.perform(...): Cannot initialize a transaction when there ' +
       'is already an outstanding transaction.'
     );
-    var errorThrown;
-    var ret;
+    let errorThrown;
+    let ret;
     try {
       this._isInTransaction = true;
       // Catching errors makes debugging more difficult, so we start with
@@ -161,9 +161,9 @@ var Mixin = {
   },
 
   initializeAll: function(startIndex) {
-    var transactionWrappers = this.transactionWrappers;
-    for (var i = startIndex; i < transactionWrappers.length; i++) {
-      var wrapper = transactionWrappers[i];
+    const transactionWrappers = this.transactionWrappers;
+    for (let i = startIndex; i < transactionWrappers.length; i++) {
+      const wrapper = transactionWrappers[i];
       try {
         // Catching errors makes debugging more difficult, so we start with the
         // OBSERVED_ERROR state before overwriting it with the real return value
@@ -198,11 +198,11 @@ var Mixin = {
       this.isInTransaction(),
       'Transaction.closeAll(): Cannot close transaction when none are open.'
     );
-    var transactionWrappers = this.transactionWrappers;
-    for (var i = startIndex; i < transactionWrappers.length; i++) {
-      var wrapper = transactionWrappers[i];
-      var initData = this.wrapperInitData[i];
-      var errorThrown;
+    const transactionWrappers = this.transactionWrappers;
+    for (let i = startIndex; i < transactionWrappers.length; i++) {
+      const wrapper = transactionWrappers[i];
+      const initData = this.wrapperInitData[i];
+      let errorThrown;
       try {
         // Catching errors makes debugging more difficult, so we start with
         // errorThrown set to true before setting it to false after calling

--- a/src/shared/utils/__tests__/OrderedMap-test.js
+++ b/src/shared/utils/__tests__/OrderedMap-test.js
@@ -11,12 +11,12 @@
 
 'use strict';
 
-var OrderedMap;
+let OrderedMap;
 
 /**
  * Shared, reusable objects.
  */
-var hasEmptyStringKey = {
+const hasEmptyStringKey = {
   'thisKeyIsFine': {data: []},
   '': {thisShouldCauseAFailure: []},
   'thisKeyIsAlsoFine': {data: []},
@@ -25,7 +25,7 @@ var hasEmptyStringKey = {
 /**
  * Used as map/forEach callback.
  */
-var duplicate = function(itm, key, count) {
+const duplicate = function(itm, key, count) {
   return {
     uniqueID: itm.uniqueID,
     val: itm.val + key + count + this.justToTestScope,
@@ -34,101 +34,101 @@ var duplicate = function(itm, key, count) {
 
 // Should not be allowed - because then null/'null' become impossible to
 // distinguish. Every key MUST be a string period!
-var hasNullAndUndefStringKey = [
+const hasNullAndUndefStringKey = [
   {uniqueID: 'undefined', val: 'thisIsUndefined'},
   {uniqueID: 'null', val: 'thisIsNull'},
 ];
-var hasNullKey = [
+const hasNullKey = [
   {uniqueID: 'thisKeyIsFine', data: []},
   {uniqueID: 'thisKeyIsAlsoFine', data: []},
   {uniqueID: null, data: []},
 ];
 
-var hasObjectKey = [
+const hasObjectKey = [
   {uniqueID: 'thisKeyIsFine', data: []},
   {uniqueID: 'thisKeyIsAlsoFine', data: []},
   {uniqueID: {}, data: []},
 ];
 
-var hasArrayKey = [
+const hasArrayKey = [
   {uniqueID: 'thisKeyIsFine', data: []},
   {uniqueID: 'thisKeyIsAlsoFine', data: []},
   {uniqueID: [], data: []},
 ];
 
 // This should be allowed
-var hasNullStringKey = [
+const hasNullStringKey = [
   {uniqueID: 'thisKeyIsFine', data: []},
   {uniqueID: 'thisKeyIsAlsoFine', data: []},
   {uniqueID: 'null', data: []},
 ];
 
-var hasUndefinedKey = [
+const hasUndefinedKey = [
   {uniqueID: 'thisKeyIsFine', data: []},
   {uniqueID: 'thisKeyIsAlsoFine', data: []},
   {uniqueID: undefined, data: []},
 ];
 
-var hasUndefinedStringKey = [
+const hasUndefinedStringKey = [
   {uniqueID: 'thisKeyIsFine', data: []},
   {uniqueID: 'thisKeyIsAlsoFine', data: []},
   {uniqueID: 'undefined', data: []},
 ];
 
-var hasPositiveNumericKey = [
+const hasPositiveNumericKey = [
   {uniqueID: 'notANumber', data: []},
   {uniqueID: '5', data: []},
   {uniqueID: 'notAnotherNumber', data: []},
 ];
 
-var hasZeroStringKey = [
+const hasZeroStringKey = [
   {uniqueID: 'greg', data: 'grego'},
   {uniqueID: '0', data: '0o'},
   {uniqueID: 'tom', data: 'tomo'},
 ];
 
-var hasZeroNumberKey = [
+const hasZeroNumberKey = [
   {uniqueID: 'greg', data: 'grego'},
   {uniqueID: 0, data: '0o'},
   {uniqueID: 'tom', data: 'tomo'},
 ];
 
-var hasAllNumericStringKeys = [
+const hasAllNumericStringKeys = [
   {uniqueID: '0', name: 'Gregory'},
   {uniqueID: '2', name: 'James'},
   {uniqueID: '1', name: 'Tom'},
 ];
 
-var hasAllNumericKeys = [
+const hasAllNumericKeys = [
   {uniqueID: 0, name: 'Gregory'},
   {uniqueID: 2, name: 'James'},
   {uniqueID: 1, name: 'Tom'},
 ];
 
-var hasAllValidKeys = [
+const hasAllValidKeys = [
   {uniqueID: 'keyOne', value: 'valueOne'},
   {uniqueID: 'keyTwo', value: 'valueTwo'},
 ];
 
-var hasDuplicateKeys = [
+const hasDuplicateKeys = [
   {uniqueID: 'keyOne', value: 'valueOne'},
   {uniqueID: 'keyTwo', value: 'valueTwo'},
   {uniqueID: 'keyOne', value: 'valueThree'},
 ];
 
-var idEntities = [
+const idEntities = [
   {uniqueID: 'greg', name: 'Gregory'},
   {uniqueID: 'james', name: 'James'},
   {uniqueID: 'tom', name: 'Tom'},
 ];
 
-var hasEmptyKey = [
+const hasEmptyKey = [
   {uniqueID: 'greg', name: 'Gregory'},
   {uniqueID: '', name: 'James'},
   {uniqueID: 'tom', name: 'Tom'},
 ];
 
-var extractUniqueID = function(entity) {
+const extractUniqueID = function(entity) {
   return entity.uniqueID;
 };
 
@@ -169,7 +169,7 @@ describe('OrderedMap', function() {
 
   it('should not throw when a key is the string "undefined" or "null"',
     function() {
-      var om = OrderedMap.fromArray(hasNullAndUndefStringKey, extractUniqueID);
+      const om = OrderedMap.fromArray(hasNullAndUndefStringKey, extractUniqueID);
       expect(om.length).toBe(2);
       expect(om.indexOfKey('undefined')).toBe(0);
       expect(om.indexOfKey('null')).toBe(1);
@@ -187,7 +187,7 @@ describe('OrderedMap', function() {
    * Numeric keys are cast to strings.
    */
   it('should not throw when a key is the number zero', function() {
-    var om = OrderedMap.fromArray(hasZeroNumberKey, extractUniqueID);
+    const om = OrderedMap.fromArray(hasZeroNumberKey, extractUniqueID);
     expect(om.length).toBe(3);
     expect(om.indexOfKey('0')).toBe(1);
     expect(om.indexOfKey(0)).toBe(1);
@@ -234,7 +234,7 @@ describe('OrderedMap', function() {
   });
 
   it('should not throw when a key is the string "0"', function() {
-    var verifyOM = function(om) {
+    const verifyOM = function(om) {
       expect(om.length).toBe(3);
       expect(om.indexOfKey('greg')).toBe(0);
       expect(om.indexOfKey('0')).toBe(1);
@@ -257,7 +257,7 @@ describe('OrderedMap', function() {
   });
 
   it('should throw when getting invalid public key', function() {
-    var om = OrderedMap.fromArray(hasAllValidKeys, extractUniqueID);
+    const om = OrderedMap.fromArray(hasAllValidKeys, extractUniqueID);
     expect(function() {
       om.has(undefined);
     }).toThrow();
@@ -296,7 +296,7 @@ describe('OrderedMap', function() {
   it('should throw when fromArray is passed crazy args', function() {
     // Test passing another OrderedMap (when it expects a plain object.)
     // This is probably not what you meant to do! We should error.
-    var validOM = OrderedMap.fromArray(hasAllValidKeys, extractUniqueID);
+    const validOM = OrderedMap.fromArray(hasAllValidKeys, extractUniqueID);
     expect(function() {
       OrderedMap.fromArray({uniqueID: 'asdf'}, extractUniqueID);
     }).toThrow();
@@ -355,7 +355,7 @@ describe('OrderedMap', function() {
   });
 
   it('should throw when accessing key before/after of non-key', function() {
-    var om = OrderedMap.fromArray(
+    const om = OrderedMap.fromArray(
       [
         {uniqueID: 'first'},
         {uniqueID: 'two'},
@@ -377,7 +377,7 @@ describe('OrderedMap', function() {
 
   it('should throw passing invalid/not-present-keys to before/after',
     function() {
-      var om = OrderedMap.fromArray([
+      const om = OrderedMap.fromArray([
         {uniqueID: 'one', val: 'first'},
         {uniqueID: 'two', val: 'second'},
         {uniqueID: 'three', val: 'third'},
@@ -438,7 +438,7 @@ describe('OrderedMap', function() {
     });
 
   it('should correctly determine the nth key after before', function() {
-    var om = OrderedMap.fromArray([
+    const om = OrderedMap.fromArray([
       {uniqueID: 'one', val: 'first'},
       {uniqueID: 'two', val: 'second'},
       {uniqueID: 'three', val: 'third'},
@@ -472,7 +472,7 @@ describe('OrderedMap', function() {
   });
 
   it('should compute key indices correctly', function() {
-    var om = OrderedMap.fromArray([
+    const om = OrderedMap.fromArray([
       {uniqueID: 'one', val: 'first'},
       {uniqueID: 'two', val: 'second'},
     ], extractUniqueID);
@@ -494,7 +494,7 @@ describe('OrderedMap', function() {
   });
 
   it('should compute indices on array that extracted numeric ids', function() {
-    var som = OrderedMap.fromArray(hasZeroStringKey, extractUniqueID);
+    const som = OrderedMap.fromArray(hasZeroStringKey, extractUniqueID);
     expect(som.keyAtIndex(0)).toBe('greg');
     expect(som.keyAtIndex(1)).toBe('0');
     expect(som.keyAtIndex(2)).toBe('tom');
@@ -503,7 +503,7 @@ describe('OrderedMap', function() {
     expect(som.indexOfKey('tom')).toBe(2);
 
 
-    var verifyNumericKeys = function(nom) {
+    const verifyNumericKeys = function(nom) {
       expect(nom.keyAtIndex(0)).toBe('0');
       expect(nom.keyAtIndex(1)).toBe('2');
       expect(nom.keyAtIndex(2)).toBe('1');
@@ -511,23 +511,23 @@ describe('OrderedMap', function() {
       expect(nom.indexOfKey('2')).toBe(1); // Prove these are not ordered by
       expect(nom.indexOfKey('1')).toBe(2); // their keys
     };
-    var omStringNumberKeys =
+    const omStringNumberKeys =
       OrderedMap.fromArray(hasAllNumericStringKeys, extractUniqueID);
     verifyNumericKeys(omStringNumberKeys);
-    var omNumericKeys =
+    const omNumericKeys =
       OrderedMap.fromArray(hasAllNumericKeys, extractUniqueID);
     verifyNumericKeys(omNumericKeys);
   });
 
   it('should compute indices on mutually exclusive merge', function() {
-    var om = OrderedMap.fromArray([
+    const om = OrderedMap.fromArray([
       {uniqueID: 'one', val: 'first'},
       {uniqueID: 'two', val: 'second'},
     ], extractUniqueID);
-    var om2 = OrderedMap.fromArray([
+    const om2 = OrderedMap.fromArray([
       {uniqueID: 'three', val: 'third'},
     ], extractUniqueID);
-    var res = om.merge(om2);
+    const res = om.merge(om2);
 
     expect(res.length).toBe(3);
 
@@ -553,12 +553,12 @@ describe('OrderedMap', function() {
   });
 
   it('should compute indices on intersected merge', function() {
-    var oneTwo = OrderedMap.fromArray([
+    const oneTwo = OrderedMap.fromArray([
       {uniqueID: 'one', val: 'first'},
       {uniqueID: 'two', val: 'secondOM1'},
     ], extractUniqueID);
 
-    var testOneTwoMergedWithTwoThree = function(res) {
+    const testOneTwoMergedWithTwoThree = function(res) {
       expect(res.length).toBe(3);
       expect(res.keyAtIndex(0)).toBe('one');
       expect(res.keyAtIndex(1)).toBe('two');
@@ -578,7 +578,7 @@ describe('OrderedMap', function() {
       expect(res.get('dog')).toBe(undefined);
     };
 
-    var result =
+    let result =
       oneTwo.merge(OrderedMap.fromArray([
         {uniqueID: 'two', val: 'secondOM2'},
         {uniqueID: 'three', val: 'third'},
@@ -596,7 +596,7 @@ describe('OrderedMap', function() {
     testOneTwoMergedWithTwoThree(result);
 
 
-    var testTwoThreeMergedWithOneTwo = function(res) {
+    const testTwoThreeMergedWithOneTwo = function(res) {
       expect(res.length).toBe(3);
       expect(res.keyAtIndex(0)).toBe('two');
       expect(res.keyAtIndex(1)).toBe('three');
@@ -624,27 +624,27 @@ describe('OrderedMap', function() {
   });
 
   it('should merge mutually exclusive keys to the end.', function() {
-    var om = OrderedMap.fromArray([
+    const om = OrderedMap.fromArray([
       {uniqueID: 'one', val: 'first'},
       {uniqueID: 'two', val: 'second'},
     ], extractUniqueID);
-    var om2 = OrderedMap.fromArray([
+    const om2 = OrderedMap.fromArray([
       {uniqueID: 'three', val: 'first'},
       {uniqueID: 'four', val: 'second'},
     ], extractUniqueID);
-    var res = om.merge(om2);
+    const res = om.merge(om2);
     expect(res.length).toBe(4);
 
   });
 
   it('should map correctly', function() {
-    var om = OrderedMap.fromArray([
+    const om = OrderedMap.fromArray([
       {uniqueID: 'x', val: 'xx'},
       {uniqueID: 'y', val: 'yy'},
       {uniqueID: 'z', val: 'zz'},
     ], extractUniqueID);
-    var scope = {justToTestScope: 'justTestingScope'};
-    var verifyResult = function(omResult) {
+    const scope = {justToTestScope: 'justTestingScope'};
+    const verifyResult = function(omResult) {
       expect(omResult.length).toBe(3);
       expect(omResult.keyAtIndex(0)).toBe('x');
       expect(omResult.keyAtIndex(1)).toBe('y');
@@ -653,7 +653,7 @@ describe('OrderedMap', function() {
       expect(omResult.get('y').val).toBe('yyy1justTestingScope');
       expect(omResult.get('z').val).toBe('zzz2justTestingScope');
     };
-    var resultOM = om.map(function(itm, key, count) {
+    let resultOM = om.map(function(itm, key, count) {
       return {
         uniqueID: itm.uniqueID,
         val: itm.val + key + count + this.justToTestScope,
@@ -661,7 +661,7 @@ describe('OrderedMap', function() {
     }, scope);
     verifyResult(resultOM);
 
-    var resArray = [];
+    const resArray = [];
     om.forEach(function(itm, key, count) {
       resArray.push({
         uniqueID: itm.uniqueID,
@@ -673,14 +673,14 @@ describe('OrderedMap', function() {
   });
 
   it('should filter correctly', function() {
-    var om = OrderedMap.fromArray([
+    const om = OrderedMap.fromArray([
       {uniqueID: 'x', val: 'xx'},
       {uniqueID: 'y', val: 'yy'},
       {uniqueID: 'z', val: 'zz'},
     ], extractUniqueID);
-    var scope = {justToTestScope: 'justTestingScope'};
+    const scope = {justToTestScope: 'justTestingScope'};
 
-    var filteringCallback = function(item, key, indexInOriginal) {
+    const filteringCallback = function(item, key, indexInOriginal) {
       expect(this).toBe(scope);
       expect(key === 'x' || key === 'y' || key === 'z').toBe(true);
       if (key === 'x') {
@@ -698,7 +698,7 @@ describe('OrderedMap', function() {
       }
     };
 
-    var verifyResult = function(omResult) {
+    const verifyResult = function(omResult) {
       expect(omResult.length).toBe(2);
       expect(omResult.keyAtIndex(0)).toBe('y');
       expect(omResult.keyAtIndex(1)).toBe('z');
@@ -709,17 +709,17 @@ describe('OrderedMap', function() {
       expect(omResult.get('y').val).toBe('yy');
     };
 
-    var resultOM = om.filter(filteringCallback, scope);
+    const resultOM = om.filter(filteringCallback, scope);
     verifyResult(resultOM);
   });
 
   it('should throw when providing invalid ranges to ranging', function() {
-    var om = OrderedMap.fromArray([
+    const om = OrderedMap.fromArray([
       {uniqueID: 'x', val: 'xx'},
       {uniqueID: 'y', val: 'yy'},
       {uniqueID: 'z', val: 'zz'},
     ], extractUniqueID);
-    var scope = {justToTestScope: 'justTestingScope'};
+    const scope = {justToTestScope: 'justTestingScope'};
 
     expect(function() {
       om.mapRange(duplicate, 0, 3, scope);
@@ -849,13 +849,13 @@ describe('OrderedMap', function() {
   // TEST length zero map, or keyrange start===end
 
   it('should map range correctly', function() {
-    var om = OrderedMap.fromArray([
+    const om = OrderedMap.fromArray([
       {uniqueID: 'x', val: 'xx'},
       {uniqueID: 'y', val: 'yy'},
       {uniqueID: 'z', val: 'zz'},
     ], extractUniqueID);
-    var scope = {justToTestScope: 'justTestingScope'};
-    var verifyThreeItems = function(omResult) {
+    const scope = {justToTestScope: 'justTestingScope'};
+    const verifyThreeItems = function(omResult) {
       expect(omResult.length).toBe(3);
       expect(omResult.keyAtIndex(0)).toBe('x');
       expect(omResult.keyAtIndex(1)).toBe('y');
@@ -864,7 +864,7 @@ describe('OrderedMap', function() {
       expect(omResult.get('y').val).toBe('yyy1justTestingScope');
       expect(omResult.get('z').val).toBe('zzz2justTestingScope');
     };
-    var verifyFirstTwoItems = function(omResult) {
+    const verifyFirstTwoItems = function(omResult) {
       expect(omResult.length).toBe(2);
       expect(omResult.keyAtIndex(0)).toBe('x');
       expect(omResult.keyAtIndex(1)).toBe('y');
@@ -872,7 +872,7 @@ describe('OrderedMap', function() {
       expect(omResult.get('y').val).toBe('yyy1justTestingScope');
     };
 
-    var verifyLastTwoItems = function(omResult) {
+    const verifyLastTwoItems = function(omResult) {
       expect(omResult.length).toBe(2);
       expect(omResult.keyAtIndex(0)).toBe('y');
       expect(omResult.keyAtIndex(1)).toBe('z');
@@ -880,20 +880,20 @@ describe('OrderedMap', function() {
       expect(omResult.get('z').val).toBe('zzz2justTestingScope');
     };
 
-    var verifyMiddleItem = function(omResult) {
+    const verifyMiddleItem = function(omResult) {
       expect(omResult.length).toBe(1);
       expect(omResult.keyAtIndex(0)).toBe('y');
       expect(omResult.get('y').val).toBe('yyy1justTestingScope');
     };
 
-    var verifyEmpty = function(omResult) {
+    const verifyEmpty = function(omResult) {
       expect(omResult.length).toBe(0);
     };
 
-    var omResultThree = om.mapRange(duplicate, 0, 3, scope);
+    let omResultThree = om.mapRange(duplicate, 0, 3, scope);
     verifyThreeItems(omResultThree);
-    var resArray = [];
-    var pushToResArray = function(itm, key, count) {
+    let resArray = [];
+    const pushToResArray = function(itm, key, count) {
       resArray.push({
         uniqueID: itm.uniqueID,
         val: itm.val + key + count + this.justToTestScope,
@@ -904,38 +904,38 @@ describe('OrderedMap', function() {
     omResultThree = OrderedMap.fromArray(resArray, extractUniqueID);
     verifyThreeItems(omResultThree);
 
-    var omResultFirstTwo = om.mapRange(duplicate, 0, 2, scope);
+    let omResultFirstTwo = om.mapRange(duplicate, 0, 2, scope);
     verifyFirstTwoItems(omResultFirstTwo);
     resArray = [];
     om.forEachRange(pushToResArray, 0, 2, scope);
     omResultFirstTwo = OrderedMap.fromArray(resArray, extractUniqueID);
     verifyFirstTwoItems(omResultFirstTwo);
 
-    var omResultLastTwo = om.mapRange(duplicate, 1, 2, scope);
+    let omResultLastTwo = om.mapRange(duplicate, 1, 2, scope);
     verifyLastTwoItems(omResultLastTwo);
     resArray = [];
     om.forEachRange(pushToResArray, 1, 2, scope);
     omResultLastTwo = OrderedMap.fromArray(resArray, extractUniqueID);
     verifyLastTwoItems(omResultLastTwo);
 
-    var omResultMiddle = om.mapRange(duplicate, 1, 1, scope);
+    let omResultMiddle = om.mapRange(duplicate, 1, 1, scope);
     verifyMiddleItem(omResultMiddle);
     resArray = [];
     om.forEachRange(pushToResArray, 1, 1, scope);
     omResultMiddle = OrderedMap.fromArray(resArray, extractUniqueID);
     verifyMiddleItem(omResultMiddle);
 
-    var omResultNone = om.mapRange(duplicate, 1, 0, scope);
+    const omResultNone = om.mapRange(duplicate, 1, 0, scope);
     verifyEmpty(omResultNone);
   });
 
   it('should extract the original array correctly', function() {
-    var sourceArray = [
+    const sourceArray = [
       {uniqueID: 'x', val: 'xx'},
       {uniqueID: 'y', val: 'yy'},
       {uniqueID: 'z', val: 'zz'},
     ];
-    var om = OrderedMap.fromArray(sourceArray, extractUniqueID);
+    const om = OrderedMap.fromArray(sourceArray, extractUniqueID);
     expect(om.toArray()).toEqual(sourceArray);
   });
 });

--- a/src/shared/utils/__tests__/PooledClass-test.js
+++ b/src/shared/utils/__tests__/PooledClass-test.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-var PooledClass;
-var PoolableClass;
+let PooledClass;
+let PoolableClass;
 
 describe('Pooled class', function() {
   beforeEach(function() {
@@ -27,13 +27,13 @@ describe('Pooled class', function() {
   });
 
   it('should return a new instance when the pool is empty', function() {
-    var instance = PoolableClass.getPooled();
+    const instance = PoolableClass.getPooled();
     expect(instance instanceof PoolableClass).toBe(true);
   });
 
   it('should return the instance back into the pool when it gets released',
     function() {
-      var instance = PoolableClass.getPooled();
+      const instance = PoolableClass.getPooled();
       PoolableClass.release(instance);
       expect(PoolableClass.instancePool.length).toBe(1);
       expect(PoolableClass.instancePool[0]).toBe(instance);
@@ -41,27 +41,27 @@ describe('Pooled class', function() {
   );
 
   it('should return an old instance if available in the pool', function() {
-    var instance = PoolableClass.getPooled();
+    const instance = PoolableClass.getPooled();
     PoolableClass.release(instance);
-    var instance2 = PoolableClass.getPooled();
+    const instance2 = PoolableClass.getPooled();
     expect(instance).toBe(instance2);
   });
 
   it('should call the destructor when instance gets released', function() {
-    var log = [];
-    var PoolableClassWithDestructor = function() {};
+    const log = [];
+    const PoolableClassWithDestructor = function() {};
     PoolableClassWithDestructor.prototype.destructor = function() {
       log.push('released');
     };
     PooledClass.addPoolingTo(PoolableClassWithDestructor);
-    var instance = PoolableClassWithDestructor.getPooled();
+    const instance = PoolableClassWithDestructor.getPooled();
     PoolableClassWithDestructor.release(instance);
     expect(log).toEqual(['released']);
   });
 
   it('should accept poolers with different arguments', function() {
-    var log = [];
-    var PoolableClassWithMultiArguments = function(a, b) {
+    const log = [];
+    const PoolableClassWithMultiArguments = function(a, b) {
       log.push(a, b);
     };
     PoolableClassWithMultiArguments.prototype.destructor = function() {};
@@ -74,8 +74,8 @@ describe('Pooled class', function() {
   });
 
   it('should call a new constructor with arguments', function() {
-    var log = [];
-    var PoolableClassWithOneArgument = function(a) {
+    const log = [];
+    const PoolableClassWithOneArgument = function(a) {
       log.push(a);
     };
     PoolableClassWithOneArgument.prototype.destructor = function() {};
@@ -87,15 +87,15 @@ describe('Pooled class', function() {
   });
 
   it('should call an old constructor with arguments', function() {
-    var log = [];
-    var PoolableClassWithOneArgument = function(a) {
+    const log = [];
+    const PoolableClassWithOneArgument = function(a) {
       log.push(a);
     };
     PoolableClassWithOneArgument.prototype.destructor = function() {};
     PooledClass.addPoolingTo(
       PoolableClassWithOneArgument
     );
-    var instance = PoolableClassWithOneArgument.getPooled('new');
+    const instance = PoolableClassWithOneArgument.getPooled('new');
     PoolableClassWithOneArgument.release(instance);
     PoolableClassWithOneArgument.getPooled('old');
     expect(log).toEqual(['new', 'old']);
@@ -103,10 +103,10 @@ describe('Pooled class', function() {
 
   it('should throw when the class releases an instance of a different type',
     function() {
-      var RandomClass = function() {};
+      const RandomClass = function() {};
       RandomClass.prototype.destructor = function() {};
       PooledClass.addPoolingTo(RandomClass);
-      var randomInstance = RandomClass.getPooled();
+      const randomInstance = RandomClass.getPooled();
       PoolableClass.getPooled();
       expect(function() {
         PoolableClass.release(randomInstance);
@@ -117,9 +117,9 @@ describe('Pooled class', function() {
   );
 
   it('should throw if no destructor is defined', function() {
-    var ImmortalClass = function() {};
+    const ImmortalClass = function() {};
     PooledClass.addPoolingTo(ImmortalClass);
-    var inst = ImmortalClass.getPooled();
+    const inst = ImmortalClass.getPooled();
     expect(function() {
       ImmortalClass.release(inst);
     }).toThrow();

--- a/src/shared/utils/__tests__/Transaction-test.js
+++ b/src/shared/utils/__tests__/Transaction-test.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-var assign = require('Object.assign');
+const assign = require('Object.assign');
 
-var Transaction;
+let Transaction;
 
-var INIT_ERRORED = 'initErrored';     // Just a dummy value to check for.
+const INIT_ERRORED = 'initErrored';     // Just a dummy value to check for.
 describe('Transaction', function() {
   beforeEach(function() {
     jest.resetModuleRegistry();
@@ -28,19 +28,19 @@ describe('Transaction', function() {
    * invoke the actual method when any of the initializers fail.
    */
   it('should invoke closers with/only-with init returns', function() {
-    var throwInInit = function() {
+    const throwInInit = function() {
       throw new Error('close[0] should receive Transaction.OBSERVED_ERROR');
     };
 
-    var performSideEffect;
-    var dontPerformThis = function() {
+    let performSideEffect;
+    const dontPerformThis = function() {
       performSideEffect = 'This should never be set to this';
     };
 
     /**
      * New test Transaction subclass.
      */
-    var TestTransaction = function() {
+    const TestTransaction = function() {
       this.reinitializeTransaction();
       this.firstCloseParam = INIT_ERRORED;   // WON'T be set to something else
       this.secondCloseParam = INIT_ERRORED;  // WILL be set to something else
@@ -72,7 +72,7 @@ describe('Transaction', function() {
       ];
     };
 
-    var transaction = new TestTransaction();
+    const transaction = new TestTransaction();
 
     expect(function() {
       transaction.perform(dontPerformThis);
@@ -87,11 +87,11 @@ describe('Transaction', function() {
 
   it('should invoke closers and wrapped method when inits success', function() {
 
-    var performSideEffect;
+    let performSideEffect;
     /**
      * New test Transaction subclass.
      */
-    var TestTransaction = function() {
+    const TestTransaction = function() {
       this.reinitializeTransaction();
       this.firstCloseParam = INIT_ERRORED;   // WILL be set to something else
       this.secondCloseParam = INIT_ERRORED;  // WILL be set to something else
@@ -127,7 +127,7 @@ describe('Transaction', function() {
       ];
     };
 
-    var transaction = new TestTransaction();
+    const transaction = new TestTransaction();
 
     transaction.perform(function() {
       performSideEffect = 'SIDE_EFFECT';
@@ -148,11 +148,11 @@ describe('Transaction', function() {
    */
   it('should throw when wrapped operation throws', function() {
 
-    var performSideEffect;
+    let performSideEffect;
     /**
      * New test Transaction subclass.
      */
-    var TestTransaction = function() {
+    const TestTransaction = function() {
       this.reinitializeTransaction();
       this.firstCloseParam = INIT_ERRORED;   // WILL be set to something else
       this.secondCloseParam = INIT_ERRORED;  // WILL be set to something else
@@ -197,10 +197,10 @@ describe('Transaction', function() {
       ];
     };
 
-    var transaction = new TestTransaction();
+    const transaction = new TestTransaction();
 
     expect(function() {
-      var isTypeError = false;
+      let isTypeError = false;
       try {
         transaction.perform(function() {
           throw new TypeError('Thrown in main wrapped operation');
@@ -219,11 +219,11 @@ describe('Transaction', function() {
   });
 
   it('should throw errors in transaction close', function() {
-    var TestTransaction = function() {
+    const TestTransaction = function() {
       this.reinitializeTransaction();
     };
     assign(TestTransaction.prototype, Transaction.Mixin);
-    var exceptionMsg = 'This exception should throw.';
+    const exceptionMsg = 'This exception should throw.';
     TestTransaction.prototype.getTransactionWrappers = function() {
       return [
         {
@@ -234,7 +234,7 @@ describe('Transaction', function() {
       ];
     };
 
-    var transaction = new TestTransaction();
+    const transaction = new TestTransaction();
     expect(function() {
       transaction.perform(function() {});
     }).toThrow(exceptionMsg);
@@ -242,12 +242,12 @@ describe('Transaction', function() {
   });
 
   it('should allow nesting of transactions', function() {
-    var performSideEffect;
-    var nestedPerformSideEffect;
+    let performSideEffect;
+    let nestedPerformSideEffect;
     /**
      * New test Transaction subclass.
      */
-    var TestTransaction = function() {
+    const TestTransaction = function() {
       this.reinitializeTransaction();
       this.firstCloseParam = INIT_ERRORED; // WILL be set to something else
     };
@@ -276,7 +276,7 @@ describe('Transaction', function() {
       ];
     };
 
-    var NestedTransaction = function() {
+    const NestedTransaction = function() {
       this.reinitializeTransaction();
     };
     assign(NestedTransaction.prototype, Transaction.Mixin);
@@ -293,7 +293,7 @@ describe('Transaction', function() {
       ];
     };
 
-    var transaction = new TestTransaction();
+    const transaction = new TestTransaction();
 
     transaction.perform(function() {
       performSideEffect = 'SIDE_EFFECT';

--- a/src/shared/utils/__tests__/accumulateInto-test.js
+++ b/src/shared/utils/__tests__/accumulateInto-test.js
@@ -14,7 +14,7 @@
 jest
   .dontMock('accumulateInto');
 
-var accumulateInto;
+let accumulateInto;
 
 describe('accumulateInto', function() {
 
@@ -31,23 +31,23 @@ describe('accumulateInto', function() {
   });
 
   it('returns the second item if first is null', function() {
-    var a = [];
+    const a = [];
     expect(accumulateInto(null, a)).toBe(a);
   });
 
   it('merges the second into the first if first item is an array', function() {
-    var a = [1, 2];
-    var b = [3, 4];
+    const a = [1, 2];
+    const b = [3, 4];
     accumulateInto(a, b);
     expect(a).toEqual([1, 2, 3, 4]);
     expect(b).toEqual([3, 4]);
-    var c = [1];
+    const c = [1];
     accumulateInto(c, 2);
     expect(c).toEqual([1, 2]);
   });
 
   it('returns a new array if first or both items are scalar', function() {
-    var a = [2];
+    const a = [2];
     expect(accumulateInto(1, a)).toEqual([1, 2]);
     expect(a).toEqual([2]);
     expect(accumulateInto(1, 2)).toEqual([1, 2]);

--- a/src/shared/utils/__tests__/adler32-test.js
+++ b/src/shared/utils/__tests__/adler32-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var adler32 = require('adler32');
+const adler32 = require('adler32');
 
 describe('adler32', function() {
   it('generates differing checksums', function() {
@@ -27,15 +27,15 @@ describe('adler32', function() {
   });
 
   it('doesn\'t barf on large inputs', function() {
-    var str = '';
-    for (var i = 0; i < 100000; i++) {
+    let str = '';
+    for (let i = 0; i < 100000; i++) {
       str += 'This will be repeated to be very large indeed. ';
     }
     expect(adler32(str)).toBe(692898118);
   });
 
   it('doesn\'t barf on international inputs', function() {
-    var str = 'Linux 是一個真棒操作系統!';
+    const str = 'Linux 是一個真棒操作系統!';
     expect(adler32(str)).toBe(-1183804097);
   });
 });

--- a/src/shared/utils/__tests__/traverseAllChildren-test.js
+++ b/src/shared/utils/__tests__/traverseAllChildren-test.js
@@ -12,9 +12,9 @@
 'use strict';
 
 describe('traverseAllChildren', function() {
-  var traverseAllChildren;
-  var React;
-  var ReactFragment;
+  let traverseAllChildren;
+  let React;
+  let ReactFragment;
   beforeEach(function() {
     jest.resetModuleRegistry();
     traverseAllChildren = require('traverseAllChildren');
@@ -27,16 +27,16 @@ describe('traverseAllChildren', function() {
   }
 
   it('should support identity for simple', function() {
-    var traverseContext = [];
-    var traverseFn =
+    const traverseContext = [];
+    const traverseFn =
       jasmine.createSpy().andCallFake(function(context, kid, key, index) {
         context.push(true);
       });
 
-    var simpleKid = <span key="simple" />;
+    const simpleKid = <span key="simple" />;
 
     // Jasmine doesn't provide a way to test that the fn was invoked with scope.
-    var instance = <div>{simpleKid}</div>;
+    const instance = <div>{simpleKid}</div>;
     traverseAllChildren(instance.props.children, traverseFn, traverseContext);
     expect(traverseFn).toHaveBeenCalledWith(
       traverseContext,
@@ -47,14 +47,14 @@ describe('traverseAllChildren', function() {
   });
 
   it('should treat single arrayless child as being in array', function() {
-    var traverseContext = [];
-    var traverseFn =
+    const traverseContext = [];
+    const traverseFn =
       jasmine.createSpy().andCallFake(function(context, kid, key, index) {
         context.push(true);
       });
 
-    var simpleKid = <span />;
-    var instance = <div>{simpleKid}</div>;
+    const simpleKid = <span />;
+    const instance = <div>{simpleKid}</div>;
     traverseAllChildren(instance.props.children, traverseFn, traverseContext);
     expect(traverseFn).toHaveBeenCalledWith(
       traverseContext,
@@ -66,14 +66,14 @@ describe('traverseAllChildren', function() {
 
   it('should treat single child in array as expected', function() {
     spyOn(console, 'error');
-    var traverseContext = [];
-    var traverseFn =
+    const traverseContext = [];
+    const traverseFn =
       jasmine.createSpy().andCallFake(function(context, kid, key, index) {
         context.push(true);
       });
 
-    var simpleKid = <span />;
-    var instance = <div>{[simpleKid]}</div>;
+    const simpleKid = <span />;
+    const instance = <div>{[simpleKid]}</div>;
     traverseAllChildren(instance.props.children, traverseFn, traverseContext);
     expect(traverseFn).toHaveBeenCalledWith(
       traverseContext,
@@ -86,19 +86,19 @@ describe('traverseAllChildren', function() {
   });
 
   it('should be called for each child', function() {
-    var zero = <div key="keyZero" />;
-    var one = null;
-    var two = <div key="keyTwo" />;
-    var three = null;
-    var four = <div key="keyFour" />;
+    const zero = <div key="keyZero" />;
+    const one = null;
+    const two = <div key="keyTwo" />;
+    const three = null;
+    const four = <div key="keyFour" />;
 
-    var traverseContext = [];
-    var traverseFn =
+    const traverseContext = [];
+    const traverseFn =
       jasmine.createSpy().andCallFake(function(context, kid, key, index) {
         context.push(true);
       });
 
-    var instance = (
+    const instance = (
       <div>
         {zero}
         {one}
@@ -129,17 +129,17 @@ describe('traverseAllChildren', function() {
   });
 
   it('should traverse children of different kinds', function() {
-    var div = <div key="divNode" />;
-    var span = <span key="spanNode" />;
-    var a = <a key="aNode" />;
+    const div = <div key="divNode" />;
+    const span = <span key="spanNode" />;
+    const a = <a key="aNode" />;
 
-    var traverseContext = [];
-    var traverseFn =
+    const traverseContext = [];
+    const traverseFn =
       jasmine.createSpy().andCallFake(function(context, kid, key, index) {
         context.push(true);
       });
 
-    var instance = (
+    const instance = (
       <div>
         {div}
         {[frag({span})]}
@@ -188,12 +188,12 @@ describe('traverseAllChildren', function() {
   });
 
   it('should be called for each child in nested structure', function() {
-    var zero = <div key="keyZero" />;
-    var one = null;
-    var two = <div key="keyTwo" />;
-    var three = null;
-    var four = <div key="keyFour" />;
-    var five = <div key="keyFiveInner" />;
+    const zero = <div key="keyZero" />;
+    const one = null;
+    const two = <div key="keyTwo" />;
+    const three = null;
+    const four = <div key="keyFour" />;
+    const five = <div key="keyFiveInner" />;
     // five is placed into a JS object with a key that is joined to the
     // component key attribute.
     // Precedence is as follows:
@@ -201,13 +201,13 @@ describe('traverseAllChildren', function() {
     // 2. If grouped in an Array, the `key` prop, falling back to array index
 
 
-    var traverseContext = [];
-    var traverseFn =
+    const traverseContext = [];
+    const traverseFn =
       jasmine.createSpy().andCallFake(function(context, kid, key, index) {
         context.push(true);
       });
 
-    var instance = (
+    const instance = (
       <div>{
         [
           frag({
@@ -248,15 +248,15 @@ describe('traverseAllChildren', function() {
   });
 
   it('should retain key across two mappings', function() {
-    var zeroForceKey = <div key="keyZero" />;
-    var oneForceKey = <div key="keyOne" />;
-    var traverseContext = [];
-    var traverseFn =
+    const zeroForceKey = <div key="keyZero" />;
+    const oneForceKey = <div key="keyOne" />;
+    const traverseContext = [];
+    const traverseFn =
       jasmine.createSpy().andCallFake(function(context, kid, key, index) {
         context.push(true);
       });
 
-    var forcedKeys = (
+    const forcedKeys = (
       <div>
         {zeroForceKey}
         {oneForceKey}
@@ -279,9 +279,9 @@ describe('traverseAllChildren', function() {
 
   it('should be called for each child in an iterable without keys', function() {
     spyOn(console, 'error');
-    var threeDivIterable = {
+    const threeDivIterable = {
       '@@iterator': function() {
-        var i = 0;
+        let i = 0;
         return {
           next: function() {
             if (i++ < 3) {
@@ -294,13 +294,13 @@ describe('traverseAllChildren', function() {
       },
     };
 
-    var traverseContext = [];
-    var traverseFn =
+    const traverseContext = [];
+    const traverseFn =
       jasmine.createSpy().andCallFake(function(context, kid, key, index) {
         context.push(kid);
       });
 
-    var instance = (
+    const instance = (
       <div>
         {threeDivIterable}
       </div>
@@ -330,9 +330,9 @@ describe('traverseAllChildren', function() {
   });
 
   it('should be called for each child in an iterable with keys', function() {
-    var threeDivIterable = {
+    const threeDivIterable = {
       '@@iterator': function() {
-        var i = 0;
+        let i = 0;
         return {
           next: function() {
             if (i++ < 3) {
@@ -345,13 +345,13 @@ describe('traverseAllChildren', function() {
       },
     };
 
-    var traverseContext = [];
-    var traverseFn =
+    const traverseContext = [];
+    const traverseFn =
       jasmine.createSpy().andCallFake(function(context, kid, key, index) {
         context.push(kid);
       });
 
-    var instance = (
+    const instance = (
       <div>
         {threeDivIterable}
       </div>
@@ -380,9 +380,9 @@ describe('traverseAllChildren', function() {
   it('should use keys from entry iterables', function() {
     spyOn(console, 'error');
 
-    var threeDivEntryIterable = {
+    const threeDivEntryIterable = {
       '@@iterator': function() {
-        var i = 0;
+        let i = 0;
         return {
           next: function() {
             if (i++ < 3) {
@@ -396,13 +396,13 @@ describe('traverseAllChildren', function() {
     };
     threeDivEntryIterable.entries = threeDivEntryIterable['@@iterator'];
 
-    var traverseContext = [];
-    var traverseFn =
+    const traverseContext = [];
+    const traverseFn =
       jasmine.createSpy().andCallFake(function(context, kid, key, index) {
         context.push(kid);
       });
 
-    var instance = (
+    const instance = (
       <div>
         {threeDivEntryIterable}
       </div>
@@ -443,7 +443,7 @@ describe('traverseAllChildren', function() {
     /*eslint-enable no-extend-native */
 
     try {
-      var instance = (
+      const instance = (
         <div>
           {5}
           {12}
@@ -451,7 +451,7 @@ describe('traverseAllChildren', function() {
         </div>
       );
 
-      var traverseFn = jasmine.createSpy();
+      const traverseFn = jasmine.createSpy();
 
       traverseAllChildren(instance.props.children, traverseFn, null);
       expect(traverseFn.calls.length).toBe(3);
@@ -482,14 +482,14 @@ describe('traverseAllChildren', function() {
     Number.prototype.key = 'rocks';
     /*eslint-enable no-extend-native */
 
-    var instance = (
+    const instance = (
       <div>
         {'a'}
         {13}
       </div>
     );
 
-    var traverseFn = jasmine.createSpy();
+    const traverseFn = jasmine.createSpy();
 
     traverseAllChildren(instance.props.children, traverseFn, null);
     expect(traverseFn.calls.length).toBe(2);

--- a/src/shared/utils/accumulate.js
+++ b/src/shared/utils/accumulate.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var invariant = require('invariant');
+const invariant = require('invariant');
 
 /**
  * Accumulates items that must not be null or undefined.
@@ -30,8 +30,8 @@ function accumulate(current, next) {
   } else {
     // Both are not empty. Warning: Never call x.concat(y) when you are not
     // certain that x is an Array (x could be a string with concat method).
-    var currentIsArray = Array.isArray(current);
-    var nextIsArray = Array.isArray(next);
+    const currentIsArray = Array.isArray(current);
+    const nextIsArray = Array.isArray(next);
     if (currentIsArray) {
       return current.concat(next);
     } else {

--- a/src/shared/utils/accumulateInto.js
+++ b/src/shared/utils/accumulateInto.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var invariant = require('invariant');
+const invariant = require('invariant');
 
 /**
  *
@@ -38,8 +38,8 @@ function accumulateInto(current, next) {
 
   // Both are not empty. Warning: Never call x.concat(y) when you are not
   // certain that x is an Array (x could be a string with concat method).
-  var currentIsArray = Array.isArray(current);
-  var nextIsArray = Array.isArray(next);
+  const currentIsArray = Array.isArray(current);
+  const nextIsArray = Array.isArray(next);
 
   if (currentIsArray && nextIsArray) {
     current.push.apply(current, next);

--- a/src/shared/utils/adler32.js
+++ b/src/shared/utils/adler32.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var MOD = 65521;
+const MOD = 65521;
 
 // adler32 is not cryptographically strong, and is only used to sanity check that
 // markup generated on the server matches the markup generated on the client.
@@ -19,13 +19,13 @@ var MOD = 65521;
 // for our use case, at the expense of conforming to the adler32 specification
 // for non-ascii inputs.
 function adler32(data) {
-  var a = 1;
-  var b = 0;
-  var i = 0;
-  var l = data.length;
-  var m = l & ~0x3;
+  let a = 1;
+  let b = 0;
+  let i = 0;
+  const l = data.length;
+  const m = l & ~0x3;
   while (i < m) {
-    var n = Math.min(i + 4096, m);
+    const n = Math.min(i + 4096, m);
     for (; i < n; i += 4) {
       b += (
         (a += data.charCodeAt(i)) +

--- a/src/shared/utils/canDefineProperty.js
+++ b/src/shared/utils/canDefineProperty.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var canDefineProperty = false;
+let canDefineProperty = false;
 if (__DEV__) {
   try {
     Object.defineProperty({}, 'x', {get: function() {}});

--- a/src/shared/utils/deprecated.js
+++ b/src/shared/utils/deprecated.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-var assign = require('Object.assign');
-var warning = require('warning');
+const assign = require('Object.assign');
+const warning = require('warning');
 
 /**
  * This will log a single deprecation notice per function and forward the call
@@ -26,9 +26,9 @@ var warning = require('warning');
  * @return {function} The function that will warn once and then call fn
  */
 function deprecated(fnName, newModule, newPackage, ctx, fn) {
-  var warned = false;
+  let warned = false;
   if (__DEV__) {
-    var newFn = function() {
+    const newFn = function() {
       warning(
         warned,
         // Require examples in this string must be split to prevent React's

--- a/src/shared/utils/flattenChildren.js
+++ b/src/shared/utils/flattenChildren.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-var traverseAllChildren = require('traverseAllChildren');
-var warning = require('warning');
+const traverseAllChildren = require('traverseAllChildren');
+const warning = require('warning');
 
 /**
  * @param {function} traverseContext Context passed through traversal.
@@ -21,8 +21,8 @@ var warning = require('warning');
  */
 function flattenSingleChildIntoContext(traverseContext, child, name) {
   // We found a component instance.
-  var result = traverseContext;
-  var keyUnique = (result[name] === undefined);
+  const result = traverseContext;
+  const keyUnique = (result[name] === undefined);
   if (__DEV__) {
     warning(
       keyUnique,
@@ -46,7 +46,7 @@ function flattenChildren(children) {
   if (children == null) {
     return children;
   }
-  var result = {};
+  const result = {};
   traverseAllChildren(children, flattenSingleChildIntoContext, result);
   return result;
 }

--- a/src/shared/utils/forEachAccumulated.js
+++ b/src/shared/utils/forEachAccumulated.js
@@ -18,7 +18,7 @@
  * handling the case when there is exactly one item (and we do not need to
  * allocate an array).
  */
-var forEachAccumulated = function(arr, cb, scope) {
+const forEachAccumulated = function(arr, cb, scope) {
   if (Array.isArray(arr)) {
     arr.forEach(cb, scope);
   } else if (arr) {

--- a/src/shared/utils/getIteratorFn.js
+++ b/src/shared/utils/getIteratorFn.js
@@ -12,8 +12,8 @@
 'use strict';
 
 /* global Symbol */
-var ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
-var FAUX_ITERATOR_SYMBOL = '@@iterator'; // Before Symbol spec.
+const ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
+const FAUX_ITERATOR_SYMBOL = '@@iterator'; // Before Symbol spec.
 
 /**
  * Returns the iterator method function contained on the iterable object.
@@ -30,7 +30,7 @@ var FAUX_ITERATOR_SYMBOL = '@@iterator'; // Before Symbol spec.
  * @return {?function}
  */
 function getIteratorFn(maybeIterable) {
-  var iteratorFn = maybeIterable && (
+  const iteratorFn = maybeIterable && (
     (ITERATOR_SYMBOL && maybeIterable[ITERATOR_SYMBOL]) ||
     maybeIterable[FAUX_ITERATOR_SYMBOL]
   );

--- a/src/shared/utils/getNativeComponentFromComposite.js
+++ b/src/shared/utils/getNativeComponentFromComposite.js
@@ -11,10 +11,10 @@
 
 'use strict';
 
-var ReactNodeTypes = require('ReactNodeTypes');
+const ReactNodeTypes = require('ReactNodeTypes');
 
 function getNativeComponentFromComposite(inst) {
-  var type;
+  let type;
 
   while ((type = inst._renderedNodeType) === ReactNodeTypes.COMPOSITE) {
     inst = inst._renderedComponent;

--- a/src/shared/utils/isTextInputElement.js
+++ b/src/shared/utils/isTextInputElement.js
@@ -14,7 +14,7 @@
 /**
  * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/the-input-element.html#input-type-attr-summary
  */
-var supportedInputTypes = {
+const supportedInputTypes = {
   'color': true,
   'date': true,
   'datetime': true,
@@ -33,7 +33,7 @@ var supportedInputTypes = {
 };
 
 function isTextInputElement(elem) {
-  var nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
+  const nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
   return nodeName && (
     (nodeName === 'input' && supportedInputTypes[elem.type]) ||
     nodeName === 'textarea'

--- a/src/shared/utils/traverseAllChildren.js
+++ b/src/shared/utils/traverseAllChildren.js
@@ -11,29 +11,29 @@
 
 'use strict';
 
-var ReactCurrentOwner = require('ReactCurrentOwner');
-var ReactElement = require('ReactElement');
+const ReactCurrentOwner = require('ReactCurrentOwner');
+const ReactElement = require('ReactElement');
 
-var getIteratorFn = require('getIteratorFn');
-var invariant = require('invariant');
-var warning = require('warning');
+const getIteratorFn = require('getIteratorFn');
+const invariant = require('invariant');
+const warning = require('warning');
 
-var SEPARATOR = '.';
-var SUBSEPARATOR = ':';
+const SEPARATOR = '.';
+const SUBSEPARATOR = ':';
 
 /**
  * TODO: Test that a single child and an array with one item have the same key
  * pattern.
  */
 
-var userProvidedKeyEscaperLookup = {
+const userProvidedKeyEscaperLookup = {
   '=': '=0',
   ':': '=2',
 };
 
-var userProvidedKeyEscapeRegex = /[=:]/g;
+const userProvidedKeyEscapeRegex = /[=:]/g;
 
-var didWarnAboutMaps = false;
+let didWarnAboutMaps = false;
 
 function userProvidedKeyEscaper(match) {
   return userProvidedKeyEscaperLookup[match];
@@ -95,7 +95,7 @@ function traverseAllChildrenImpl(
   callback,
   traverseContext
 ) {
-  var type = typeof children;
+  const type = typeof children;
 
   if (type === 'undefined' || type === 'boolean') {
     // All of the above are perceived as null.
@@ -116,13 +116,13 @@ function traverseAllChildrenImpl(
     return 1;
   }
 
-  var child;
-  var nextName;
-  var subtreeCount = 0; // Count of children found in the current subtree.
-  var nextNamePrefix = nameSoFar === '' ? SEPARATOR : nameSoFar + SUBSEPARATOR;
+  let child;
+  let nextName;
+  let subtreeCount = 0; // Count of children found in the current subtree.
+  const nextNamePrefix = nameSoFar === '' ? SEPARATOR : nameSoFar + SUBSEPARATOR;
 
   if (Array.isArray(children)) {
-    for (var i = 0; i < children.length; i++) {
+    for (let i = 0; i < children.length; i++) {
       child = children[i];
       nextName = nextNamePrefix + getComponentKey(child, i);
       subtreeCount += traverseAllChildrenImpl(
@@ -133,12 +133,12 @@ function traverseAllChildrenImpl(
       );
     }
   } else {
-    var iteratorFn = getIteratorFn(children);
+    const iteratorFn = getIteratorFn(children);
     if (iteratorFn) {
-      var iterator = iteratorFn.call(children);
-      var step;
+      const iterator = iteratorFn.call(children);
+      let step;
       if (iteratorFn !== children.entries) {
-        var ii = 0;
+        let ii = 0;
         while (!(step = iterator.next()).done) {
           child = step.value;
           nextName = nextNamePrefix + getComponentKey(child, ii++);
@@ -161,7 +161,7 @@ function traverseAllChildrenImpl(
         }
         // Iterator will provide entry [k,v] tuples rather than values.
         while (!(step = iterator.next()).done) {
-          var entry = step.value;
+          const entry = step.value;
           if (entry) {
             child = entry[1];
             nextName = (
@@ -179,7 +179,7 @@ function traverseAllChildrenImpl(
         }
       }
     } else if (type === 'object') {
-      var addendum = '';
+      let addendum = '';
       if (__DEV__) {
         addendum =
           ' If you meant to render a collection of children, use an array ' +
@@ -191,13 +191,13 @@ function traverseAllChildrenImpl(
             'version of React. Make sure to use only one copy of React.';
         }
         if (ReactCurrentOwner.current) {
-          var name = ReactCurrentOwner.current.getName();
+          const name = ReactCurrentOwner.current.getName();
           if (name) {
             addendum += ' Check the render method of `' + name + '`.';
           }
         }
       }
-      var childrenString = String(children);
+      const childrenString = String(children);
       invariant(
         false,
         'Objects are not valid as a React child (found: %s).%s',

--- a/src/shared/vendor/third_party/webcomponents.js
+++ b/src/shared/vendor/third_party/webcomponents.js
@@ -13,8 +13,8 @@ window.WebComponents = window.WebComponents || {};
 
 (function(scope) {
   var flags = scope.flags || {};
-  var file = "webcomponents.js";
-  var script = document.querySelector('script[src*="' + file + '"]');
+  const file = "webcomponents.js";
+  const script = document.querySelector('script[src*="' + file + '"]');
   var flags = {};
   if (!flags.noOpts) {
     location.search.slice(1).split("&").forEach(function(o) {
@@ -22,14 +22,14 @@ window.WebComponents = window.WebComponents || {};
       o[0] && (flags[o[0]] = o[1] || true);
     });
     if (script) {
-      for (var i = 0, a; a = script.attributes[i]; i++) {
+      for (let i = 0, a; a = script.attributes[i]; i++) {
         if (a.name !== "src") {
           flags[a.name] = a.value || true;
         }
       }
     }
     if (flags.log) {
-      var parts = flags.log.split(",");
+      const parts = flags.log.split(",");
       flags.log = {};
       parts.forEach(function(f) {
         flags.log[f] = true;
@@ -56,14 +56,14 @@ window.WebComponents = window.WebComponents || {};
 if (WebComponents.flags.shadow) {
   if (typeof WeakMap === "undefined") {
     (function() {
-      var defineProperty = Object.defineProperty;
-      var counter = Date.now() % 1e9;
-      var WeakMap = function() {
+      const defineProperty = Object.defineProperty;
+      let counter = Date.now() % 1e9;
+      const WeakMap = function() {
         this.name = "__st" + (Math.random() * 1e9 >>> 0) + (counter++ + "__");
       };
       WeakMap.prototype = {
         set: function(key, value) {
-          var entry = key[this.name];
+          const entry = key[this.name];
           if (entry && entry[0] === key) entry[1] = value; else defineProperty(key, this.name, {
             value: [ key, value ],
             writable: true
@@ -71,17 +71,17 @@ if (WebComponents.flags.shadow) {
           return this;
         },
         get: function(key) {
-          var entry;
+          let entry;
           return (entry = key[this.name]) && entry[0] === key ? entry[1] : undefined;
         },
         "delete": function(key) {
-          var entry = key[this.name];
+          const entry = key[this.name];
           if (!entry || entry[0] !== key) return false;
           entry[0] = entry[1] = undefined;
           return true;
         },
         has: function(key) {
-          var entry = key[this.name];
+          const entry = key[this.name];
           if (!entry) return false;
           return entry[0] === key;
         }
@@ -92,9 +92,9 @@ if (WebComponents.flags.shadow) {
   window.ShadowDOMPolyfill = {};
   (function(scope) {
     "use strict";
-    var constructorTable = new WeakMap();
-    var nativePrototypeTable = new WeakMap();
-    var wrappers = Object.create(null);
+    const constructorTable = new WeakMap();
+    const nativePrototypeTable = new WeakMap();
+    const wrappers = Object.create(null);
     function detectEval() {
       if (typeof chrome !== "undefined" && chrome.app && chrome.app.runtime) {
         return false;
@@ -103,31 +103,31 @@ if (WebComponents.flags.shadow) {
         return false;
       }
       try {
-        var f = new Function("return true;");
+        const f = new Function("return true;");
         return f();
       } catch (ex) {
         return false;
       }
     }
-    var hasEval = detectEval();
+    const hasEval = detectEval();
     function assert(b) {
       if (!b) throw new Error("Assertion failed");
     }
-    var defineProperty = Object.defineProperty;
-    var getOwnPropertyNames = Object.getOwnPropertyNames;
-    var getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+    const defineProperty = Object.defineProperty;
+    const getOwnPropertyNames = Object.getOwnPropertyNames;
+    const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
     function mixin(to, from) {
-      var names = getOwnPropertyNames(from);
-      for (var i = 0; i < names.length; i++) {
-        var name = names[i];
+      const names = getOwnPropertyNames(from);
+      for (let i = 0; i < names.length; i++) {
+        const name = names[i];
         defineProperty(to, name, getOwnPropertyDescriptor(from, name));
       }
       return to;
     }
     function mixinStatics(to, from) {
-      var names = getOwnPropertyNames(from);
-      for (var i = 0; i < names.length; i++) {
-        var name = names[i];
+      const names = getOwnPropertyNames(from);
+      for (let i = 0; i < names.length; i++) {
+        const name = names[i];
         switch (name) {
          case "arguments":
          case "caller":
@@ -142,11 +142,11 @@ if (WebComponents.flags.shadow) {
       return to;
     }
     function oneOf(object, propertyNames) {
-      for (var i = 0; i < propertyNames.length; i++) {
+      for (let i = 0; i < propertyNames.length; i++) {
         if (propertyNames[i] in object) return propertyNames[i];
       }
     }
-    var nonEnumerableDataDescriptor = {
+    const nonEnumerableDataDescriptor = {
       value: undefined,
       configurable: true,
       enumerable: false,
@@ -158,11 +158,11 @@ if (WebComponents.flags.shadow) {
     }
     getOwnPropertyNames(window);
     function getWrapperConstructor(node) {
-      var nativePrototype = node.__proto__ || Object.getPrototypeOf(node);
-      var wrapperConstructor = constructorTable.get(nativePrototype);
+      const nativePrototype = node.__proto__ || Object.getPrototypeOf(node);
+      const wrapperConstructor = constructorTable.get(nativePrototype);
       if (wrapperConstructor) return wrapperConstructor;
-      var parentWrapperConstructor = getWrapperConstructor(nativePrototype);
-      var GeneratedWrapper = createWrapperConstructor(parentWrapperConstructor);
+      const parentWrapperConstructor = getWrapperConstructor(nativePrototype);
+      const GeneratedWrapper = createWrapperConstructor(parentWrapperConstructor);
       registerInternal(nativePrototype, GeneratedWrapper, node);
       return GeneratedWrapper;
     }
@@ -173,7 +173,7 @@ if (WebComponents.flags.shadow) {
       installProperty(instanceObject, wrapperPrototype, false);
     }
     var isFirefox = /Firefox/.test(navigator.userAgent);
-    var dummyDescriptor = {
+    const dummyDescriptor = {
       get: function() {},
       set: function(v) {},
       configurable: true,
@@ -208,26 +208,26 @@ if (WebComponents.flags.shadow) {
       }
     }
     var isBrokenSafari = function() {
-      var descr = Object.getOwnPropertyDescriptor(Node.prototype, "nodeType");
+      const descr = Object.getOwnPropertyDescriptor(Node.prototype, "nodeType");
       return descr && !descr.get && !descr.set;
     }();
     function installProperty(source, target, allowMethod, opt_blacklist) {
-      var names = getOwnPropertyNames(source);
-      for (var i = 0; i < names.length; i++) {
-        var name = names[i];
+      const names = getOwnPropertyNames(source);
+      for (let i = 0; i < names.length; i++) {
+        const name = names[i];
         if (name === "polymerBlackList_") continue;
         if (name in target) continue;
         if (source.polymerBlackList_ && source.polymerBlackList_[name]) continue;
         if (isFirefox) {
           source.__lookupGetter__(name);
         }
-        var descriptor = getDescriptor(source, name);
-        var getter, setter;
+        const descriptor = getDescriptor(source, name);
+        let getter, setter;
         if (allowMethod && typeof descriptor.value === "function") {
           target[name] = getMethod(name);
           continue;
         }
-        var isEvent = isEventHandlerName(name);
+        const isEvent = isEventHandlerName(name);
         if (isEvent) getter = scope.getEventHandlerGetter(name); else getter = getGetter(name);
         if (descriptor.writable || descriptor.set || isBrokenSafari) {
           if (isEvent) setter = scope.getEventHandlerSetter(name); else setter = getSetter(name);
@@ -241,12 +241,12 @@ if (WebComponents.flags.shadow) {
       }
     }
     function register(nativeConstructor, wrapperConstructor, opt_instance) {
-      var nativePrototype = nativeConstructor.prototype;
+      const nativePrototype = nativeConstructor.prototype;
       registerInternal(nativePrototype, wrapperConstructor, opt_instance);
       mixinStatics(wrapperConstructor, nativeConstructor);
     }
     function registerInternal(nativePrototype, wrapperConstructor, opt_instance) {
-      var wrapperPrototype = wrapperConstructor.prototype;
+      const wrapperPrototype = wrapperConstructor.prototype;
       assert(constructorTable.get(nativePrototype) === undefined);
       constructorTable.set(nativePrototype, wrapperConstructor);
       nativePrototypeTable.set(wrapperPrototype, nativePrototype);
@@ -259,9 +259,9 @@ if (WebComponents.flags.shadow) {
       return constructorTable.get(nativeConstructor.prototype) === wrapperConstructor;
     }
     function registerObject(object) {
-      var nativePrototype = Object.getPrototypeOf(object);
-      var superWrapperConstructor = getWrapperConstructor(nativePrototype);
-      var GeneratedWrapper = createWrapperConstructor(superWrapperConstructor);
+      const nativePrototype = Object.getPrototypeOf(object);
+      const superWrapperConstructor = getWrapperConstructor(nativePrototype);
+      const GeneratedWrapper = createWrapperConstructor(superWrapperConstructor);
       registerInternal(nativePrototype, GeneratedWrapper, object);
       return GeneratedWrapper;
     }
@@ -269,7 +269,7 @@ if (WebComponents.flags.shadow) {
       function GeneratedWrapper(node) {
         superWrapperConstructor.call(this, node);
       }
-      var p = Object.create(superWrapperConstructor.prototype);
+      const p = Object.create(superWrapperConstructor.prototype);
       p.constructor = GeneratedWrapper;
       GeneratedWrapper.prototype = p;
       return GeneratedWrapper;
@@ -309,7 +309,7 @@ if (WebComponents.flags.shadow) {
       assert(wrapper === undefined || isWrapper(wrapper));
       node.__wrapper8e3dd93a60__ = wrapper;
     }
-    var getterDescriptor = {
+    const getterDescriptor = {
       get: undefined,
       configurable: true,
       enumerable: true
@@ -327,7 +327,7 @@ if (WebComponents.flags.shadow) {
       constructors.forEach(function(constructor) {
         names.forEach(function(name) {
           constructor.prototype[name] = function() {
-            var w = wrapIfNeeded(this);
+            const w = wrapIfNeeded(this);
             return w[name].apply(w, arguments);
           };
         });
@@ -363,16 +363,16 @@ if (WebComponents.flags.shadow) {
         addedCount: addedCount
       };
     }
-    var EDIT_LEAVE = 0;
-    var EDIT_UPDATE = 1;
-    var EDIT_ADD = 2;
-    var EDIT_DELETE = 3;
+    const EDIT_LEAVE = 0;
+    const EDIT_UPDATE = 1;
+    const EDIT_ADD = 2;
+    const EDIT_DELETE = 3;
     function ArraySplice() {}
     ArraySplice.prototype = {
       calcEditDistances: function(current, currentStart, currentEnd, old, oldStart, oldEnd) {
-        var rowCount = oldEnd - oldStart + 1;
-        var columnCount = currentEnd - currentStart + 1;
-        var distances = new Array(rowCount);
+        const rowCount = oldEnd - oldStart + 1;
+        const columnCount = currentEnd - currentStart + 1;
+        const distances = new Array(rowCount);
         for (var i = 0; i < rowCount; i++) {
           distances[i] = new Array(columnCount);
           distances[i][0] = i;
@@ -381,8 +381,8 @@ if (WebComponents.flags.shadow) {
         for (var i = 1; i < rowCount; i++) {
           for (var j = 1; j < columnCount; j++) {
             if (this.equals(current[currentStart + j - 1], old[oldStart + i - 1])) distances[i][j] = distances[i - 1][j - 1]; else {
-              var north = distances[i - 1][j] + 1;
-              var west = distances[i][j - 1] + 1;
+              const north = distances[i - 1][j] + 1;
+              const west = distances[i][j - 1] + 1;
               distances[i][j] = north < west ? north : west;
             }
           }
@@ -390,10 +390,10 @@ if (WebComponents.flags.shadow) {
         return distances;
       },
       spliceOperationsFromEditDistances: function(distances) {
-        var i = distances.length - 1;
-        var j = distances[0].length - 1;
-        var current = distances[i][j];
-        var edits = [];
+        let i = distances.length - 1;
+        let j = distances[0].length - 1;
+        let current = distances[i][j];
+        const edits = [];
         while (i > 0 || j > 0) {
           if (i == 0) {
             edits.push(EDIT_ADD);
@@ -405,10 +405,10 @@ if (WebComponents.flags.shadow) {
             i--;
             continue;
           }
-          var northWest = distances[i - 1][j - 1];
-          var west = distances[i - 1][j];
-          var north = distances[i][j - 1];
-          var min;
+          const northWest = distances[i - 1][j - 1];
+          const west = distances[i - 1][j];
+          const north = distances[i][j - 1];
+          let min;
           if (west < north) min = west < northWest ? west : northWest; else min = north < northWest ? north : northWest;
           if (min == northWest) {
             if (northWest == current) {
@@ -433,9 +433,9 @@ if (WebComponents.flags.shadow) {
         return edits;
       },
       calcSplices: function(current, currentStart, currentEnd, old, oldStart, oldEnd) {
-        var prefixCount = 0;
-        var suffixCount = 0;
-        var minLength = Math.min(currentEnd - currentStart, oldEnd - oldStart);
+        let prefixCount = 0;
+        let suffixCount = 0;
+        const minLength = Math.min(currentEnd - currentStart, oldEnd - oldStart);
         if (currentStart == 0 && oldStart == 0) prefixCount = this.sharedPrefix(current, old, minLength);
         if (currentEnd == current.length && oldEnd == old.length) suffixCount = this.sharedSuffix(current, old, minLength - prefixCount);
         currentStart += prefixCount;
@@ -448,12 +448,12 @@ if (WebComponents.flags.shadow) {
           while (oldStart < oldEnd) splice.removed.push(old[oldStart++]);
           return [ splice ];
         } else if (oldStart == oldEnd) return [ newSplice(currentStart, [], currentEnd - currentStart) ];
-        var ops = this.spliceOperationsFromEditDistances(this.calcEditDistances(current, currentStart, currentEnd, old, oldStart, oldEnd));
+        const ops = this.spliceOperationsFromEditDistances(this.calcEditDistances(current, currentStart, currentEnd, old, oldStart, oldEnd));
         var splice = undefined;
-        var splices = [];
-        var index = currentStart;
-        var oldIndex = oldStart;
-        for (var i = 0; i < ops.length; i++) {
+        const splices = [];
+        let index = currentStart;
+        let oldIndex = oldStart;
+        for (let i = 0; i < ops.length; i++) {
           switch (ops[i]) {
            case EDIT_LEAVE:
             if (splice) {
@@ -491,13 +491,13 @@ if (WebComponents.flags.shadow) {
         return splices;
       },
       sharedPrefix: function(current, old, searchLength) {
-        for (var i = 0; i < searchLength; i++) if (!this.equals(current[i], old[i])) return i;
+        for (let i = 0; i < searchLength; i++) if (!this.equals(current[i], old[i])) return i;
         return searchLength;
       },
       sharedSuffix: function(current, old, searchLength) {
-        var index1 = current.length;
-        var index2 = old.length;
-        var count = 0;
+        let index1 = current.length;
+        let index2 = old.length;
+        let count = 0;
         while (count < searchLength && this.equals(current[--index1], old[--index2])) count++;
         return count;
       },
@@ -512,22 +512,22 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(context) {
     "use strict";
-    var OriginalMutationObserver = window.MutationObserver;
-    var callbacks = [];
-    var pending = false;
-    var timerFunc;
+    const OriginalMutationObserver = window.MutationObserver;
+    let callbacks = [];
+    let pending = false;
+    let timerFunc;
     function handle() {
       pending = false;
-      var copies = callbacks.slice(0);
+      const copies = callbacks.slice(0);
       callbacks = [];
-      for (var i = 0; i < copies.length; i++) {
+      for (let i = 0; i < copies.length; i++) {
         (0, copies[i])();
       }
     }
     if (OriginalMutationObserver) {
-      var counter = 1;
-      var observer = new OriginalMutationObserver(handle);
-      var textNode = document.createTextNode(counter);
+      let counter = 1;
+      const observer = new OriginalMutationObserver(handle);
+      const textNode = document.createTextNode(counter);
       observer.observe(textNode, {
         characterData: true
       });
@@ -548,12 +548,12 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var setEndOfMicrotask = scope.setEndOfMicrotask;
-    var wrapIfNeeded = scope.wrapIfNeeded;
-    var wrappers = scope.wrappers;
-    var registrationsTable = new WeakMap();
-    var globalMutationObservers = [];
-    var isScheduled = false;
+    const setEndOfMicrotask = scope.setEndOfMicrotask;
+    const wrapIfNeeded = scope.wrapIfNeeded;
+    const wrappers = scope.wrappers;
+    const registrationsTable = new WeakMap();
+    let globalMutationObservers = [];
+    let isScheduled = false;
     function scheduleCallback(observer) {
       if (observer.scheduled_) return;
       observer.scheduled_ = true;
@@ -565,15 +565,15 @@ if (WebComponents.flags.shadow) {
     function notifyObservers() {
       isScheduled = false;
       while (globalMutationObservers.length) {
-        var notifyList = globalMutationObservers;
+        const notifyList = globalMutationObservers;
         globalMutationObservers = [];
         notifyList.sort(function(x, y) {
           return x.uid_ - y.uid_;
         });
-        for (var i = 0; i < notifyList.length; i++) {
-          var mo = notifyList[i];
+        for (let i = 0; i < notifyList.length; i++) {
+          const mo = notifyList[i];
           mo.scheduled_ = false;
-          var queue = mo.takeRecords();
+          const queue = mo.takeRecords();
           removeTransientObserversFor(mo);
           if (queue.length) {
             mo.callback_(queue, mo);
@@ -594,34 +594,34 @@ if (WebComponents.flags.shadow) {
     }
     function registerTransientObservers(ancestor, node) {
       for (;ancestor; ancestor = ancestor.parentNode) {
-        var registrations = registrationsTable.get(ancestor);
+        const registrations = registrationsTable.get(ancestor);
         if (!registrations) continue;
-        for (var i = 0; i < registrations.length; i++) {
-          var registration = registrations[i];
+        for (let i = 0; i < registrations.length; i++) {
+          const registration = registrations[i];
           if (registration.options.subtree) registration.addTransientObserver(node);
         }
       }
     }
     function removeTransientObserversFor(observer) {
-      for (var i = 0; i < observer.nodes_.length; i++) {
-        var node = observer.nodes_[i];
-        var registrations = registrationsTable.get(node);
+      for (let i = 0; i < observer.nodes_.length; i++) {
+        const node = observer.nodes_[i];
+        const registrations = registrationsTable.get(node);
         if (!registrations) return;
-        for (var j = 0; j < registrations.length; j++) {
-          var registration = registrations[j];
+        for (let j = 0; j < registrations.length; j++) {
+          const registration = registrations[j];
           if (registration.observer === observer) registration.removeTransientObservers();
         }
       }
     }
     function enqueueMutation(target, type, data) {
-      var interestedObservers = Object.create(null);
-      var associatedStrings = Object.create(null);
-      for (var node = target; node; node = node.parentNode) {
-        var registrations = registrationsTable.get(node);
+      const interestedObservers = Object.create(null);
+      const associatedStrings = Object.create(null);
+      for (let node = target; node; node = node.parentNode) {
+        const registrations = registrationsTable.get(node);
         if (!registrations) continue;
-        for (var j = 0; j < registrations.length; j++) {
-          var registration = registrations[j];
-          var options = registration.options;
+        for (let j = 0; j < registrations.length; j++) {
+          const registration = registrations[j];
+          const options = registration.options;
           if (node !== target && !options.subtree) continue;
           if (type === "attributes" && !options.attributes) continue;
           if (type === "attributes" && options.attributeFilter && (data.namespace !== null || options.attributeFilter.indexOf(data.name) === -1)) {
@@ -636,9 +636,9 @@ if (WebComponents.flags.shadow) {
           }
         }
       }
-      for (var uid in interestedObservers) {
+      for (let uid in interestedObservers) {
         var observer = interestedObservers[uid];
-        var record = new MutationRecord(type, target);
+        const record = new MutationRecord(type, target);
         if ("name" in data && "namespace" in data) {
           record.attributeName = data.name;
           record.attributeNamespace = data.namespace;
@@ -652,7 +652,7 @@ if (WebComponents.flags.shadow) {
         observer.records_.push(record);
       }
     }
-    var slice = Array.prototype.slice;
+    const slice = Array.prototype.slice;
     function MutationObserverOptions(options) {
       this.childList = !!options.childList;
       this.subtree = !!options.subtree;
@@ -677,7 +677,7 @@ if (WebComponents.flags.shadow) {
         this.attributeFilter = null;
       }
     }
-    var uidCounter = 0;
+    let uidCounter = 0;
     function MutationObserver(callback) {
       this.callback_ = callback;
       this.nodes_ = [];
@@ -689,11 +689,11 @@ if (WebComponents.flags.shadow) {
       constructor: MutationObserver,
       observe: function(target, options) {
         target = wrapIfNeeded(target);
-        var newOptions = new MutationObserverOptions(options);
-        var registration;
-        var registrations = registrationsTable.get(target);
+        const newOptions = new MutationObserverOptions(options);
+        let registration;
+        let registrations = registrationsTable.get(target);
         if (!registrations) registrationsTable.set(target, registrations = []);
-        for (var i = 0; i < registrations.length; i++) {
+        for (let i = 0; i < registrations.length; i++) {
           if (registrations[i].observer === this) {
             registration = registrations[i];
             registration.removeTransientObservers();
@@ -708,9 +708,9 @@ if (WebComponents.flags.shadow) {
       },
       disconnect: function() {
         this.nodes_.forEach(function(node) {
-          var registrations = registrationsTable.get(node);
-          for (var i = 0; i < registrations.length; i++) {
-            var registration = registrations[i];
+          const registrations = registrationsTable.get(node);
+          for (let i = 0; i < registrations.length; i++) {
+            const registration = registrations[i];
             if (registration.observer === this) {
               registrations.splice(i, 1);
               break;
@@ -720,7 +720,7 @@ if (WebComponents.flags.shadow) {
         this.records_ = [];
       },
       takeRecords: function() {
-        var copyOfRecords = this.records_;
+        const copyOfRecords = this.records_;
         this.records_ = [];
         return copyOfRecords;
       }
@@ -736,17 +736,17 @@ if (WebComponents.flags.shadow) {
         if (node === this.target) return;
         scheduleCallback(this.observer);
         this.transientObservedNodes.push(node);
-        var registrations = registrationsTable.get(node);
+        let registrations = registrationsTable.get(node);
         if (!registrations) registrationsTable.set(node, registrations = []);
         registrations.push(this);
       },
       removeTransientObservers: function() {
-        var transientObservedNodes = this.transientObservedNodes;
+        const transientObservedNodes = this.transientObservedNodes;
         this.transientObservedNodes = [];
-        for (var i = 0; i < transientObservedNodes.length; i++) {
-          var node = transientObservedNodes[i];
-          var registrations = registrationsTable.get(node);
-          for (var j = 0; j < registrations.length; j++) {
+        for (let i = 0; i < transientObservedNodes.length; i++) {
+          const node = transientObservedNodes[i];
+          const registrations = registrationsTable.get(node);
+          for (let j = 0; j < registrations.length; j++) {
             if (registrations[j] === this) {
               registrations.splice(j, 1);
               break;
@@ -783,10 +783,10 @@ if (WebComponents.flags.shadow) {
     function setTreeScope(node, treeScope) {
       if (node.treeScope_ !== treeScope) {
         node.treeScope_ = treeScope;
-        for (var sr = node.shadowRoot; sr; sr = sr.olderShadowRoot) {
+        for (let sr = node.shadowRoot; sr; sr = sr.olderShadowRoot) {
           sr.treeScope_.parent = treeScope;
         }
-        for (var child = node.firstChild; child; child = child.nextSibling) {
+        for (let child = node.firstChild; child; child = child.nextSibling) {
           setTreeScope(child, treeScope);
         }
       }
@@ -796,8 +796,8 @@ if (WebComponents.flags.shadow) {
         debugger;
       }
       if (node.treeScope_) return node.treeScope_;
-      var parent = node.parentNode;
-      var treeScope;
+      const parent = node.parentNode;
+      let treeScope;
       if (parent) treeScope = getTreeScope(parent); else treeScope = new TreeScope(node, null);
       return node.treeScope_ = treeScope;
     }
@@ -807,27 +807,27 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var forwardMethodsToWrapper = scope.forwardMethodsToWrapper;
-    var getTreeScope = scope.getTreeScope;
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
-    var setWrapper = scope.setWrapper;
-    var unsafeUnwrap = scope.unsafeUnwrap;
-    var unwrap = scope.unwrap;
-    var wrap = scope.wrap;
-    var wrappers = scope.wrappers;
-    var wrappedFuns = new WeakMap();
-    var listenersTable = new WeakMap();
-    var handledEventsTable = new WeakMap();
-    var currentlyDispatchingEvents = new WeakMap();
-    var targetTable = new WeakMap();
-    var currentTargetTable = new WeakMap();
-    var relatedTargetTable = new WeakMap();
-    var eventPhaseTable = new WeakMap();
-    var stopPropagationTable = new WeakMap();
-    var stopImmediatePropagationTable = new WeakMap();
-    var eventHandlersTable = new WeakMap();
-    var eventPathTable = new WeakMap();
+    const forwardMethodsToWrapper = scope.forwardMethodsToWrapper;
+    const getTreeScope = scope.getTreeScope;
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
+    const setWrapper = scope.setWrapper;
+    const unsafeUnwrap = scope.unsafeUnwrap;
+    const unwrap = scope.unwrap;
+    const wrap = scope.wrap;
+    const wrappers = scope.wrappers;
+    const wrappedFuns = new WeakMap();
+    const listenersTable = new WeakMap();
+    const handledEventsTable = new WeakMap();
+    const currentlyDispatchingEvents = new WeakMap();
+    const targetTable = new WeakMap();
+    const currentTargetTable = new WeakMap();
+    const relatedTargetTable = new WeakMap();
+    const eventPhaseTable = new WeakMap();
+    const stopPropagationTable = new WeakMap();
+    const stopImmediatePropagationTable = new WeakMap();
+    const eventHandlersTable = new WeakMap();
+    const eventPathTable = new WeakMap();
     function isShadowRoot(node) {
       return node instanceof wrappers.ShadowRoot;
     }
@@ -835,17 +835,17 @@ if (WebComponents.flags.shadow) {
       return getTreeScope(node).root;
     }
     function getEventPath(node, event) {
-      var path = [];
-      var current = node;
+      const path = [];
+      let current = node;
       path.push(current);
       while (current) {
-        var destinationInsertionPoints = getDestinationInsertionPoints(current);
+        const destinationInsertionPoints = getDestinationInsertionPoints(current);
         if (destinationInsertionPoints && destinationInsertionPoints.length > 0) {
-          for (var i = 0; i < destinationInsertionPoints.length; i++) {
-            var insertionPoint = destinationInsertionPoints[i];
+          for (let i = 0; i < destinationInsertionPoints.length; i++) {
+            const insertionPoint = destinationInsertionPoints[i];
             if (isShadowInsertionPoint(insertionPoint)) {
-              var shadowRoot = rootOfNode(insertionPoint);
-              var olderShadowRoot = shadowRoot.olderShadowRoot;
+              const shadowRoot = rootOfNode(insertionPoint);
+              const olderShadowRoot = shadowRoot.olderShadowRoot;
               if (olderShadowRoot) path.push(olderShadowRoot);
             }
             path.push(insertionPoint);
@@ -891,30 +891,30 @@ if (WebComponents.flags.shadow) {
     function eventRetargetting(path, currentTarget) {
       if (path.length === 0) return currentTarget;
       if (currentTarget instanceof wrappers.Window) currentTarget = currentTarget.document;
-      var currentTargetTree = getTreeScope(currentTarget);
-      var originalTarget = path[0];
-      var originalTargetTree = getTreeScope(originalTarget);
-      var relativeTargetTree = lowestCommonInclusiveAncestor(currentTargetTree, originalTargetTree);
-      for (var i = 0; i < path.length; i++) {
-        var node = path[i];
+      const currentTargetTree = getTreeScope(currentTarget);
+      const originalTarget = path[0];
+      const originalTargetTree = getTreeScope(originalTarget);
+      const relativeTargetTree = lowestCommonInclusiveAncestor(currentTargetTree, originalTargetTree);
+      for (let i = 0; i < path.length; i++) {
+        const node = path[i];
         if (getTreeScope(node) === relativeTargetTree) return node;
       }
       return path[path.length - 1];
     }
     function getTreeScopeAncestors(treeScope) {
-      var ancestors = [];
+      const ancestors = [];
       for (;treeScope; treeScope = treeScope.parent) {
         ancestors.push(treeScope);
       }
       return ancestors;
     }
     function lowestCommonInclusiveAncestor(tsA, tsB) {
-      var ancestorsA = getTreeScopeAncestors(tsA);
-      var ancestorsB = getTreeScopeAncestors(tsB);
-      var result = null;
+      const ancestorsA = getTreeScopeAncestors(tsA);
+      const ancestorsB = getTreeScopeAncestors(tsB);
+      let result = null;
       while (ancestorsA.length > 0 && ancestorsB.length > 0) {
-        var a = ancestorsA.pop();
-        var b = ancestorsB.pop();
+        const a = ancestorsA.pop();
+        const b = ancestorsB.pop();
         if (a === b) result = a; else break;
       }
       return result;
@@ -925,16 +925,16 @@ if (WebComponents.flags.shadow) {
     }
     function relatedTargetResolution(event, currentTarget, relatedTarget) {
       if (currentTarget instanceof wrappers.Window) currentTarget = currentTarget.document;
-      var currentTargetTree = getTreeScope(currentTarget);
-      var relatedTargetTree = getTreeScope(relatedTarget);
-      var relatedTargetEventPath = getEventPath(relatedTarget, event);
+      const currentTargetTree = getTreeScope(currentTarget);
+      const relatedTargetTree = getTreeScope(relatedTarget);
+      const relatedTargetEventPath = getEventPath(relatedTarget, event);
       var lowestCommonAncestorTree;
       var lowestCommonAncestorTree = lowestCommonInclusiveAncestor(currentTargetTree, relatedTargetTree);
       if (!lowestCommonAncestorTree) lowestCommonAncestorTree = relatedTargetTree.root;
-      for (var commonAncestorTree = lowestCommonAncestorTree; commonAncestorTree; commonAncestorTree = commonAncestorTree.parent) {
-        var adjustedRelatedTarget;
-        for (var i = 0; i < relatedTargetEventPath.length; i++) {
-          var node = relatedTargetEventPath[i];
+      for (let commonAncestorTree = lowestCommonAncestorTree; commonAncestorTree; commonAncestorTree = commonAncestorTree.parent) {
+        let adjustedRelatedTarget;
+        for (let i = 0; i < relatedTargetEventPath.length; i++) {
+          const node = relatedTargetEventPath[i];
           if (getTreeScope(node) === commonAncestorTree) return node;
         }
       }
@@ -943,17 +943,17 @@ if (WebComponents.flags.shadow) {
     function inSameTree(a, b) {
       return getTreeScope(a) === getTreeScope(b);
     }
-    var NONE = 0;
-    var CAPTURING_PHASE = 1;
-    var AT_TARGET = 2;
-    var BUBBLING_PHASE = 3;
-    var pendingError;
+    const NONE = 0;
+    const CAPTURING_PHASE = 1;
+    const AT_TARGET = 2;
+    const BUBBLING_PHASE = 3;
+    let pendingError;
     function dispatchOriginalEvent(originalEvent) {
       if (handledEventsTable.get(originalEvent)) return;
       handledEventsTable.set(originalEvent, true);
       dispatchEvent(wrap(originalEvent), wrap(originalEvent.target));
       if (pendingError) {
-        var err = pendingError;
+        const err = pendingError;
         pendingError = null;
         throw err;
       }
@@ -971,9 +971,9 @@ if (WebComponents.flags.shadow) {
       if (currentlyDispatchingEvents.get(event)) throw new Error("InvalidStateError");
       currentlyDispatchingEvents.set(event, true);
       scope.renderAllPending();
-      var eventPath;
-      var overrideTarget;
-      var win;
+      let eventPath;
+      let overrideTarget;
+      let win;
       if (isLoadLikeEvent(event) && !event.bubbles) {
         var doc = originalWrapperTarget;
         if (doc instanceof wrappers.Document && (win = doc.defaultView)) {
@@ -1005,23 +1005,23 @@ if (WebComponents.flags.shadow) {
       return event.defaultPrevented;
     }
     function dispatchCapturing(event, eventPath, win, overrideTarget) {
-      var phase = CAPTURING_PHASE;
+      const phase = CAPTURING_PHASE;
       if (win) {
         if (!invoke(win, event, phase, eventPath, overrideTarget)) return false;
       }
-      for (var i = eventPath.length - 1; i > 0; i--) {
+      for (let i = eventPath.length - 1; i > 0; i--) {
         if (!invoke(eventPath[i], event, phase, eventPath, overrideTarget)) return false;
       }
       return true;
     }
     function dispatchAtTarget(event, eventPath, win, overrideTarget) {
-      var phase = AT_TARGET;
-      var currentTarget = eventPath[0] || win;
+      const phase = AT_TARGET;
+      const currentTarget = eventPath[0] || win;
       return invoke(currentTarget, event, phase, eventPath, overrideTarget);
     }
     function dispatchBubbling(event, eventPath, win, overrideTarget) {
-      var phase = BUBBLING_PHASE;
-      for (var i = 1; i < eventPath.length; i++) {
+      const phase = BUBBLING_PHASE;
+      for (let i = 1; i < eventPath.length; i++) {
         if (!invoke(eventPath[i], event, phase, eventPath, overrideTarget)) return;
       }
       if (win && eventPath.length > 0) {
@@ -1029,9 +1029,9 @@ if (WebComponents.flags.shadow) {
       }
     }
     function invoke(currentTarget, event, phase, eventPath, overrideTarget) {
-      var listeners = listenersTable.get(currentTarget);
+      const listeners = listenersTable.get(currentTarget);
       if (!listeners) return true;
-      var target = overrideTarget || eventRetargetting(eventPath, currentTarget);
+      const target = overrideTarget || eventRetargetting(eventPath, currentTarget);
       if (target === currentTarget) {
         if (phase === CAPTURING_PHASE) return true;
         if (phase === BUBBLING_PHASE) phase = AT_TARGET;
@@ -1039,8 +1039,8 @@ if (WebComponents.flags.shadow) {
         return true;
       }
       if ("relatedTarget" in event) {
-        var originalEvent = unwrap(event);
-        var unwrappedRelatedTarget = originalEvent.relatedTarget;
+        const originalEvent = unwrap(event);
+        const unwrappedRelatedTarget = originalEvent.relatedTarget;
         if (unwrappedRelatedTarget) {
           if (unwrappedRelatedTarget instanceof Object && unwrappedRelatedTarget.addEventListener) {
             var relatedTarget = wrap(unwrappedRelatedTarget);
@@ -1053,13 +1053,13 @@ if (WebComponents.flags.shadow) {
         }
       }
       eventPhaseTable.set(event, phase);
-      var type = event.type;
-      var anyRemoved = false;
+      const type = event.type;
+      let anyRemoved = false;
       targetTable.set(event, target);
       currentTargetTable.set(event, currentTarget);
       listeners.depth++;
       for (var i = 0, len = listeners.length; i < len; i++) {
-        var listener = listeners[i];
+        const listener = listeners[i];
         if (listener.removed) {
           anyRemoved = true;
           continue;
@@ -1076,7 +1076,7 @@ if (WebComponents.flags.shadow) {
       }
       listeners.depth--;
       if (anyRemoved && listeners.depth === 0) {
-        var copy = listeners.slice();
+        const copy = listeners.slice();
         listeners.length = 0;
         for (var i = 0; i < copy.length; i++) {
           if (!copy[i].removed) listeners.push(copy[i]);
@@ -1100,14 +1100,14 @@ if (WebComponents.flags.shadow) {
         this.handler = null;
       }
     };
-    var OriginalEvent = window.Event;
+    const OriginalEvent = window.Event;
     OriginalEvent.prototype.polymerBlackList_ = {
       returnValue: true,
       keyLocation: true
     };
     function Event(type, options) {
       if (type instanceof OriginalEvent) {
-        var impl = type;
+        const impl = type;
         if (!OriginalBeforeUnloadEvent && impl.type === "beforeunload" && !(this instanceof BeforeUnloadEvent)) {
           return new BeforeUnloadEvent(impl);
         }
@@ -1127,7 +1127,7 @@ if (WebComponents.flags.shadow) {
         return eventPhaseTable.get(this);
       },
       get path() {
-        var eventPath = eventPathTable.get(this);
+        const eventPath = eventPathTable.get(this);
         if (!eventPath) return [];
         return eventPath.slice();
       },
@@ -1149,8 +1149,8 @@ if (WebComponents.flags.shadow) {
       });
     }
     function registerGenericEvent(name, SuperEvent, prototype) {
-      var OriginalEvent = window[name];
-      var GenericEvent = function(type, options) {
+      const OriginalEvent = window[name];
+      const GenericEvent = function(type, options) {
         if (type instanceof OriginalEvent) setWrapper(type, this); else return wrap(constructEvent(OriginalEvent, name, type, options));
       };
       GenericEvent.prototype = Object.create(SuperEvent.prototype);
@@ -1164,11 +1164,11 @@ if (WebComponents.flags.shadow) {
       }
       return GenericEvent;
     }
-    var UIEvent = registerGenericEvent("UIEvent", Event);
-    var CustomEvent = registerGenericEvent("CustomEvent", Event);
-    var relatedTargetProto = {
+    const UIEvent = registerGenericEvent("UIEvent", Event);
+    const CustomEvent = registerGenericEvent("CustomEvent", Event);
+    const relatedTargetProto = {
       get relatedTarget() {
-        var relatedTarget = relatedTargetTable.get(this);
+        const relatedTarget = relatedTargetTable.get(this);
         if (relatedTarget !== undefined) return relatedTarget;
         return wrap(unwrap(this).relatedTarget);
       }
@@ -1176,18 +1176,18 @@ if (WebComponents.flags.shadow) {
     function getInitFunction(name, relatedTargetIndex) {
       return function() {
         arguments[relatedTargetIndex] = unwrap(arguments[relatedTargetIndex]);
-        var impl = unwrap(this);
+        const impl = unwrap(this);
         impl[name].apply(impl, arguments);
       };
     }
-    var mouseEventProto = mixin({
+    const mouseEventProto = mixin({
       initMouseEvent: getInitFunction("initMouseEvent", 14)
     }, relatedTargetProto);
-    var focusEventProto = mixin({
+    const focusEventProto = mixin({
       initFocusEvent: getInitFunction("initFocusEvent", 5)
     }, relatedTargetProto);
-    var MouseEvent = registerGenericEvent("MouseEvent", UIEvent, mouseEventProto);
-    var FocusEvent = registerGenericEvent("FocusEvent", UIEvent, focusEventProto);
+    const MouseEvent = registerGenericEvent("MouseEvent", UIEvent, mouseEventProto);
+    const FocusEvent = registerGenericEvent("FocusEvent", UIEvent, focusEventProto);
     var defaultInitDicts = Object.create(null);
     var supportsEventConstructors = function() {
       try {
@@ -1199,11 +1199,11 @@ if (WebComponents.flags.shadow) {
     }();
     function constructEvent(OriginalEvent, name, type, options) {
       if (supportsEventConstructors) return new OriginalEvent(type, unwrapOptions(options));
-      var event = unwrap(document.createEvent(name));
-      var defaultDict = defaultInitDicts[name];
-      var args = [ type ];
+      const event = unwrap(document.createEvent(name));
+      const defaultDict = defaultInitDicts[name];
+      const args = [ type ];
       Object.keys(defaultDict).forEach(function(key) {
-        var v = options != null && key in options ? options[key] : defaultDict[key];
+        let v = options != null && key in options ? options[key] : defaultDict[key];
         if (key === "relatedTarget") v = unwrap(v);
         args.push(v);
       });
@@ -1211,9 +1211,9 @@ if (WebComponents.flags.shadow) {
       return event;
     }
     if (!supportsEventConstructors) {
-      var configureEventConstructor = function(name, initDict, superName) {
+      const configureEventConstructor = function(name, initDict, superName) {
         if (superName) {
-          var superDict = defaultInitDicts[superName];
+          const superDict = defaultInitDicts[superName];
           initDict = mixin(mixin({}, superDict), initDict);
         }
         defaultInitDicts[name] = initDict;
@@ -1278,13 +1278,13 @@ if (WebComponents.flags.shadow) {
       }
       return false;
     }
-    var OriginalEventTarget = window.EventTarget;
+    const OriginalEventTarget = window.EventTarget;
     function EventTarget(impl) {
       setWrapper(impl, this);
     }
-    var methodNames = [ "addEventListener", "removeEventListener", "dispatchEvent" ];
+    const methodNames = [ "addEventListener", "removeEventListener", "dispatchEvent" ];
     [ Node, Window ].forEach(function(constructor) {
-      var p = constructor.prototype;
+      const p = constructor.prototype;
       methodNames.forEach(function(name) {
         Object.defineProperty(p, name + "_", {
           value: p[name]
@@ -1298,27 +1298,27 @@ if (WebComponents.flags.shadow) {
     EventTarget.prototype = {
       addEventListener: function(type, fun, capture) {
         if (!isValidListener(fun) || isMutationEvent(type)) return;
-        var listener = new Listener(type, fun, capture);
-        var listeners = listenersTable.get(this);
+        const listener = new Listener(type, fun, capture);
+        let listeners = listenersTable.get(this);
         if (!listeners) {
           listeners = [];
           listeners.depth = 0;
           listenersTable.set(this, listeners);
         } else {
-          for (var i = 0; i < listeners.length; i++) {
+          for (let i = 0; i < listeners.length; i++) {
             if (listener.equals(listeners[i])) return;
           }
         }
         listeners.push(listener);
-        var target = getTargetToListenAt(this);
+        const target = getTargetToListenAt(this);
         target.addEventListener_(type, dispatchOriginalEvent, true);
       },
       removeEventListener: function(type, fun, capture) {
         capture = Boolean(capture);
-        var listeners = listenersTable.get(this);
+        const listeners = listenersTable.get(this);
         if (!listeners) return;
-        var count = 0, found = false;
-        for (var i = 0; i < listeners.length; i++) {
+        let count = 0, found = false;
+        for (let i = 0; i < listeners.length; i++) {
           if (listeners[i].type === type && listeners[i].capture === capture) {
             count++;
             if (listeners[i].handler === fun) {
@@ -1328,16 +1328,16 @@ if (WebComponents.flags.shadow) {
           }
         }
         if (found && count === 1) {
-          var target = getTargetToListenAt(this);
+          const target = getTargetToListenAt(this);
           target.removeEventListener_(type, dispatchOriginalEvent, true);
         }
       },
       dispatchEvent: function(event) {
-        var nativeEvent = unwrap(event);
-        var eventType = nativeEvent.type;
+        const nativeEvent = unwrap(event);
+        const eventType = nativeEvent.type;
         handledEventsTable.set(nativeEvent, false);
         scope.renderAllPending();
-        var tempListener;
+        let tempListener;
         if (!hasListenerInAncestors(this, eventType)) {
           tempListener = function() {};
           this.addEventListener(eventType, tempListener, true);
@@ -1350,16 +1350,16 @@ if (WebComponents.flags.shadow) {
       }
     };
     function hasListener(node, type) {
-      var listeners = listenersTable.get(node);
+      const listeners = listenersTable.get(node);
       if (listeners) {
-        for (var i = 0; i < listeners.length; i++) {
+        for (let i = 0; i < listeners.length; i++) {
           if (!listeners[i].removed && listeners[i].type === type) return true;
         }
       }
       return false;
     }
     function hasListenerInAncestors(target, type) {
-      for (var node = unwrap(target); node; node = node.parentNode) {
+      for (let node = unwrap(target); node; node = node.parentNode) {
         if (hasListener(wrap(node), type)) return true;
       }
       return false;
@@ -1368,35 +1368,35 @@ if (WebComponents.flags.shadow) {
     function wrapEventTargetMethods(constructors) {
       forwardMethodsToWrapper(constructors, methodNames);
     }
-    var originalElementFromPoint = document.elementFromPoint;
+    const originalElementFromPoint = document.elementFromPoint;
     function elementFromPoint(self, document, x, y) {
       scope.renderAllPending();
-      var element = wrap(originalElementFromPoint.call(unsafeUnwrap(document), x, y));
+      const element = wrap(originalElementFromPoint.call(unsafeUnwrap(document), x, y));
       if (!element) return null;
-      var path = getEventPath(element, null);
-      var idx = path.lastIndexOf(self);
+      let path = getEventPath(element, null);
+      const idx = path.lastIndexOf(self);
       if (idx == -1) return null; else path = path.slice(0, idx);
       return eventRetargetting(path, self);
     }
     function getEventHandlerGetter(name) {
       return function() {
-        var inlineEventHandlers = eventHandlersTable.get(this);
+        const inlineEventHandlers = eventHandlersTable.get(this);
         return inlineEventHandlers && inlineEventHandlers[name] && inlineEventHandlers[name].value || null;
       };
     }
     function getEventHandlerSetter(name) {
-      var eventType = name.slice(2);
+      const eventType = name.slice(2);
       return function(value) {
-        var inlineEventHandlers = eventHandlersTable.get(this);
+        let inlineEventHandlers = eventHandlersTable.get(this);
         if (!inlineEventHandlers) {
           inlineEventHandlers = Object.create(null);
           eventHandlersTable.set(this, inlineEventHandlers);
         }
-        var old = inlineEventHandlers[name];
+        const old = inlineEventHandlers[name];
         if (old) this.removeEventListener(eventType, old.wrapped, false);
         if (typeof value === "function") {
           var wrapped = function(e) {
-            var rv = value.call(this, e);
+            const rv = value.call(this, e);
             if (rv === false) e.preventDefault(); else if (name === "onbeforeunload" && typeof rv === "string") e.returnValue = rv;
           };
           this.addEventListener(eventType, wrapped, false);
@@ -1421,21 +1421,21 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var UIEvent = scope.wrappers.UIEvent;
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
-    var setWrapper = scope.setWrapper;
-    var unsafeUnwrap = scope.unsafeUnwrap;
-    var wrap = scope.wrap;
-    var OriginalTouchEvent = window.TouchEvent;
+    const UIEvent = scope.wrappers.UIEvent;
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
+    const setWrapper = scope.setWrapper;
+    const unsafeUnwrap = scope.unsafeUnwrap;
+    const wrap = scope.wrap;
+    const OriginalTouchEvent = window.TouchEvent;
     if (!OriginalTouchEvent) return;
-    var nativeEvent;
+    let nativeEvent;
     try {
       nativeEvent = document.createEvent("TouchEvent");
     } catch (ex) {
       return;
     }
-    var nonEnumDescriptor = {
+    const nonEnumDescriptor = {
       enumerable: false
     };
     function nonEnum(obj, prop) {
@@ -1449,7 +1449,7 @@ if (WebComponents.flags.shadow) {
         return wrap(unsafeUnwrap(this).target);
       }
     };
-    var descr = {
+    const descr = {
       configurable: true,
       enumerable: true,
       get: null
@@ -1470,7 +1470,7 @@ if (WebComponents.flags.shadow) {
       }
     };
     function wrapTouchList(nativeTouchList) {
-      var list = new TouchList();
+      const list = new TouchList();
       for (var i = 0; i < nativeTouchList.length; i++) {
         list[i] = new Touch(nativeTouchList[i]);
       }
@@ -1502,9 +1502,9 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var unsafeUnwrap = scope.unsafeUnwrap;
-    var wrap = scope.wrap;
-    var nonEnumDescriptor = {
+    const unsafeUnwrap = scope.unsafeUnwrap;
+    const wrap = scope.wrap;
+    const nonEnumDescriptor = {
       enumerable: false
     };
     function nonEnum(obj, prop) {
@@ -1522,7 +1522,7 @@ if (WebComponents.flags.shadow) {
     nonEnum(NodeList.prototype, "item");
     function wrapNodeList(list) {
       if (list == null) return list;
-      var wrapperList = new NodeList();
+      const wrapperList = new NodeList();
       for (var i = 0, length = list.length; i < length; i++) {
         wrapperList[i] = wrap(list[i]);
       }
@@ -1545,34 +1545,34 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var EventTarget = scope.wrappers.EventTarget;
-    var NodeList = scope.wrappers.NodeList;
-    var TreeScope = scope.TreeScope;
-    var assert = scope.assert;
-    var defineWrapGetter = scope.defineWrapGetter;
-    var enqueueMutation = scope.enqueueMutation;
-    var getTreeScope = scope.getTreeScope;
-    var isWrapper = scope.isWrapper;
-    var mixin = scope.mixin;
-    var registerTransientObservers = scope.registerTransientObservers;
-    var registerWrapper = scope.registerWrapper;
-    var setTreeScope = scope.setTreeScope;
-    var unsafeUnwrap = scope.unsafeUnwrap;
-    var unwrap = scope.unwrap;
-    var unwrapIfNeeded = scope.unwrapIfNeeded;
-    var wrap = scope.wrap;
-    var wrapIfNeeded = scope.wrapIfNeeded;
+    const EventTarget = scope.wrappers.EventTarget;
+    const NodeList = scope.wrappers.NodeList;
+    const TreeScope = scope.TreeScope;
+    const assert = scope.assert;
+    const defineWrapGetter = scope.defineWrapGetter;
+    const enqueueMutation = scope.enqueueMutation;
+    const getTreeScope = scope.getTreeScope;
+    const isWrapper = scope.isWrapper;
+    const mixin = scope.mixin;
+    const registerTransientObservers = scope.registerTransientObservers;
+    const registerWrapper = scope.registerWrapper;
+    const setTreeScope = scope.setTreeScope;
+    const unsafeUnwrap = scope.unsafeUnwrap;
+    const unwrap = scope.unwrap;
+    const unwrapIfNeeded = scope.unwrapIfNeeded;
+    const wrap = scope.wrap;
+    const wrapIfNeeded = scope.wrapIfNeeded;
     var wrappers = scope.wrappers;
     function assertIsNodeWrapper(node) {
       assert(node instanceof Node);
     }
     function createOneElementNodeList(node) {
-      var nodes = new NodeList();
+      const nodes = new NodeList();
       nodes[0] = node;
       nodes.length = 1;
       return nodes;
     }
-    var surpressMutations = false;
+    let surpressMutations = false;
     function enqueueRemovalForInsertedNodes(node, parent, nodes) {
       enqueueMutation(parent, "childList", {
         removedNodes: nodes,
@@ -1603,7 +1603,7 @@ if (WebComponents.flags.shadow) {
         return nodes;
       }
       var nodes = createOneElementNodeList(node);
-      var oldParent = node.parentNode;
+      const oldParent = node.parentNode;
       if (oldParent) {
         oldParent.removeChild(node);
       }
@@ -1616,15 +1616,15 @@ if (WebComponents.flags.shadow) {
     }
     function collectNodesNative(node) {
       if (node instanceof DocumentFragment) return collectNodesForDocumentFragment(node);
-      var nodes = createOneElementNodeList(node);
-      var oldParent = node.parentNode;
+      const nodes = createOneElementNodeList(node);
+      const oldParent = node.parentNode;
       if (oldParent) enqueueRemovalForInsertedNodes(node, oldParent, nodes);
       return nodes;
     }
     function collectNodesForDocumentFragment(node) {
-      var nodes = new NodeList();
-      var i = 0;
-      for (var child = node.firstChild; child; child = child.nextSibling) {
+      const nodes = new NodeList();
+      let i = 0;
+      for (let child = node.firstChild; child; child = child.nextSibling) {
         nodes[i++] = child;
       }
       nodes.length = i;
@@ -1639,8 +1639,8 @@ if (WebComponents.flags.shadow) {
       node.nodeIsInserted_();
     }
     function nodesWereAdded(nodes, parent) {
-      var treeScope = getTreeScope(parent);
-      for (var i = 0; i < nodes.length; i++) {
+      const treeScope = getTreeScope(parent);
+      for (let i = 0; i < nodes.length; i++) {
         nodeWasAdded(nodes[i], treeScope);
       }
     }
@@ -1648,37 +1648,37 @@ if (WebComponents.flags.shadow) {
       setTreeScope(node, new TreeScope(node, null));
     }
     function nodesWereRemoved(nodes) {
-      for (var i = 0; i < nodes.length; i++) {
+      for (let i = 0; i < nodes.length; i++) {
         nodeWasRemoved(nodes[i]);
       }
     }
     function ensureSameOwnerDocument(parent, child) {
-      var ownerDoc = parent.nodeType === Node.DOCUMENT_NODE ? parent : parent.ownerDocument;
+      const ownerDoc = parent.nodeType === Node.DOCUMENT_NODE ? parent : parent.ownerDocument;
       if (ownerDoc !== child.ownerDocument) ownerDoc.adoptNode(child);
     }
     function adoptNodesIfNeeded(owner, nodes) {
       if (!nodes.length) return;
-      var ownerDoc = owner.ownerDocument;
+      const ownerDoc = owner.ownerDocument;
       if (ownerDoc === nodes[0].ownerDocument) return;
-      for (var i = 0; i < nodes.length; i++) {
+      for (let i = 0; i < nodes.length; i++) {
         scope.adoptNodeNoRemove(nodes[i], ownerDoc);
       }
     }
     function unwrapNodesForInsertion(owner, nodes) {
       adoptNodesIfNeeded(owner, nodes);
-      var length = nodes.length;
+      const length = nodes.length;
       if (length === 1) return unwrap(nodes[0]);
-      var df = unwrap(owner.ownerDocument.createDocumentFragment());
-      for (var i = 0; i < length; i++) {
+      const df = unwrap(owner.ownerDocument.createDocumentFragment());
+      for (let i = 0; i < length; i++) {
         df.appendChild(unwrap(nodes[i]));
       }
       return df;
     }
     function clearChildNodes(wrapper) {
       if (wrapper.firstChild_ !== undefined) {
-        var child = wrapper.firstChild_;
+        let child = wrapper.firstChild_;
         while (child) {
-          var tmp = child;
+          const tmp = child;
           child = child.nextSibling_;
           tmp.parentNode_ = tmp.previousSibling_ = tmp.nextSibling_ = undefined;
         }
@@ -1687,11 +1687,11 @@ if (WebComponents.flags.shadow) {
     }
     function removeAllChildNodes(wrapper) {
       if (wrapper.invalidateShadowRenderer()) {
-        var childWrapper = wrapper.firstChild;
+        let childWrapper = wrapper.firstChild;
         while (childWrapper) {
           assert(childWrapper.parentNode === wrapper);
           var nextSibling = childWrapper.nextSibling;
-          var childNode = unwrap(childWrapper);
+          const childNode = unwrap(childWrapper);
           var parentNode = childNode.parentNode;
           if (parentNode) originalRemoveChild.call(parentNode, childNode);
           childWrapper.previousSibling_ = childWrapper.nextSibling_ = childWrapper.parentNode_ = null;
@@ -1699,8 +1699,8 @@ if (WebComponents.flags.shadow) {
         }
         wrapper.firstChild_ = wrapper.lastChild_ = null;
       } else {
-        var node = unwrap(wrapper);
-        var child = node.firstChild;
+        const node = unwrap(wrapper);
+        let child = node.firstChild;
         var nextSibling;
         while (child) {
           nextSibling = child.nextSibling;
@@ -1710,26 +1710,26 @@ if (WebComponents.flags.shadow) {
       }
     }
     function invalidateParent(node) {
-      var p = node.parentNode;
+      const p = node.parentNode;
       return p && p.invalidateShadowRenderer();
     }
     function cleanupNodes(nodes) {
-      for (var i = 0, n; i < nodes.length; i++) {
+      for (let i = 0, n; i < nodes.length; i++) {
         n = nodes[i];
         n.parentNode.removeChild(n);
       }
     }
-    var originalImportNode = document.importNode;
-    var originalCloneNode = window.Node.prototype.cloneNode;
+    const originalImportNode = document.importNode;
+    const originalCloneNode = window.Node.prototype.cloneNode;
     function cloneNode(node, deep, opt_doc) {
-      var clone;
+      let clone;
       if (opt_doc) clone = wrap(originalImportNode.call(opt_doc, unsafeUnwrap(node), false)); else clone = wrap(originalCloneNode.call(unsafeUnwrap(node), false));
       if (deep) {
         for (var child = node.firstChild; child; child = child.nextSibling) {
           clone.appendChild(cloneNode(child, true, opt_doc));
         }
         if (node instanceof wrappers.HTMLTemplateElement) {
-          var cloneContent = clone.content;
+          const cloneContent = clone.content;
           for (var child = node.content.firstChild; child; child = child.nextSibling) {
             cloneContent.appendChild(cloneNode(child, true, opt_doc));
           }
@@ -1739,7 +1739,7 @@ if (WebComponents.flags.shadow) {
     }
     function contains(self, child) {
       if (!child || getTreeScope(self) !== getTreeScope(child)) return false;
-      for (var node = child; node; node = node.parentNode) {
+      for (let node = child; node; node = node.parentNode) {
         if (node === self) return true;
       }
       return false;
@@ -1755,14 +1755,14 @@ if (WebComponents.flags.shadow) {
       this.previousSibling_ = undefined;
       this.treeScope_ = undefined;
     }
-    var OriginalDocumentFragment = window.DocumentFragment;
-    var originalAppendChild = OriginalNode.prototype.appendChild;
-    var originalCompareDocumentPosition = OriginalNode.prototype.compareDocumentPosition;
-    var originalInsertBefore = OriginalNode.prototype.insertBefore;
+    const OriginalDocumentFragment = window.DocumentFragment;
+    const originalAppendChild = OriginalNode.prototype.appendChild;
+    const originalCompareDocumentPosition = OriginalNode.prototype.compareDocumentPosition;
+    const originalInsertBefore = OriginalNode.prototype.insertBefore;
     var originalRemoveChild = OriginalNode.prototype.removeChild;
-    var originalReplaceChild = OriginalNode.prototype.replaceChild;
-    var isIe = /Trident/.test(navigator.userAgent);
-    var removeChildOriginalHelper = isIe ? function(parent, child) {
+    const originalReplaceChild = OriginalNode.prototype.replaceChild;
+    const isIe = /Trident/.test(navigator.userAgent);
+    const removeChildOriginalHelper = isIe ? function(parent, child) {
       try {
         originalRemoveChild.call(parent, child);
       } catch (ex) {
@@ -1778,7 +1778,7 @@ if (WebComponents.flags.shadow) {
       },
       insertBefore: function(childWrapper, refWrapper) {
         assertIsNodeWrapper(childWrapper);
-        var refNode;
+        let refNode;
         if (refWrapper) {
           if (isWrapper(refWrapper)) {
             refNode = unwrap(refWrapper);
@@ -1791,9 +1791,9 @@ if (WebComponents.flags.shadow) {
           refNode = null;
         }
         refWrapper && assert(refWrapper.parentNode === this);
-        var nodes;
-        var previousNode = refWrapper ? refWrapper.previousSibling : this.lastChild;
-        var useNative = !this.invalidateShadowRenderer() && !invalidateParent(childWrapper);
+        let nodes;
+        const previousNode = refWrapper ? refWrapper.previousSibling : this.lastChild;
+        const useNative = !this.invalidateShadowRenderer() && !invalidateParent(childWrapper);
         if (useNative) nodes = collectNodesNative(childWrapper); else nodes = collectNodes(childWrapper, this, previousNode, refWrapper);
         if (useNative) {
           ensureSameOwnerDocument(this, childWrapper);
@@ -1823,9 +1823,9 @@ if (WebComponents.flags.shadow) {
       removeChild: function(childWrapper) {
         assertIsNodeWrapper(childWrapper);
         if (childWrapper.parentNode !== this) {
-          var found = false;
-          var childNodes = this.childNodes;
-          for (var ieChild = this.firstChild; ieChild; ieChild = ieChild.nextSibling) {
+          let found = false;
+          const childNodes = this.childNodes;
+          for (let ieChild = this.firstChild; ieChild; ieChild = ieChild.nextSibling) {
             if (ieChild === childWrapper) {
               found = true;
               break;
@@ -1835,12 +1835,12 @@ if (WebComponents.flags.shadow) {
             throw new Error("NotFoundError");
           }
         }
-        var childNode = unwrap(childWrapper);
-        var childWrapperNextSibling = childWrapper.nextSibling;
-        var childWrapperPreviousSibling = childWrapper.previousSibling;
+        const childNode = unwrap(childWrapper);
+        const childWrapperNextSibling = childWrapper.nextSibling;
+        const childWrapperPreviousSibling = childWrapper.previousSibling;
         if (this.invalidateShadowRenderer()) {
-          var thisFirstChild = this.firstChild;
-          var thisLastChild = this.lastChild;
+          const thisFirstChild = this.firstChild;
+          const thisLastChild = this.lastChild;
           var parentNode = childNode.parentNode;
           if (parentNode) removeChildOriginalHelper(parentNode, childNode);
           if (thisFirstChild === childWrapper) this.firstChild_ = childWrapperNextSibling;
@@ -1866,7 +1866,7 @@ if (WebComponents.flags.shadow) {
       },
       replaceChild: function(newChildWrapper, oldChildWrapper) {
         assertIsNodeWrapper(newChildWrapper);
-        var oldChildNode;
+        let oldChildNode;
         if (isWrapper(oldChildWrapper)) {
           oldChildNode = unwrap(oldChildWrapper);
         } else {
@@ -1876,10 +1876,10 @@ if (WebComponents.flags.shadow) {
         if (oldChildWrapper.parentNode !== this) {
           throw new Error("NotFoundError");
         }
-        var nextNode = oldChildWrapper.nextSibling;
-        var previousNode = oldChildWrapper.previousSibling;
-        var nodes;
-        var useNative = !this.invalidateShadowRenderer() && !invalidateParent(newChildWrapper);
+        let nextNode = oldChildWrapper.nextSibling;
+        const previousNode = oldChildWrapper.previousSibling;
+        let nodes;
+        const useNative = !this.invalidateShadowRenderer() && !invalidateParent(newChildWrapper);
         if (useNative) {
           nodes = collectNodesNative(newChildWrapper);
         } else {
@@ -1909,7 +1909,7 @@ if (WebComponents.flags.shadow) {
         return oldChildWrapper;
       },
       nodeIsInserted_: function() {
-        for (var child = this.firstChild; child; child = child.nextSibling) {
+        for (let child = this.firstChild; child; child = child.nextSibling) {
           child.nodeIsInserted_();
         }
       },
@@ -1932,15 +1932,15 @@ if (WebComponents.flags.shadow) {
         return this.previousSibling_ !== undefined ? this.previousSibling_ : wrap(unsafeUnwrap(this).previousSibling);
       },
       get parentElement() {
-        var p = this.parentNode;
+        let p = this.parentNode;
         while (p && p.nodeType !== Node.ELEMENT_NODE) {
           p = p.parentNode;
         }
         return p;
       },
       get textContent() {
-        var s = "";
-        for (var child = this.firstChild; child; child = child.nextSibling) {
+        let s = "";
+        for (let child = this.firstChild; child; child = child.nextSibling) {
           if (child.nodeType != Node.COMMENT_NODE) {
             s += child.textContent;
           }
@@ -1949,18 +1949,18 @@ if (WebComponents.flags.shadow) {
       },
       set textContent(textContent) {
         if (textContent == null) textContent = "";
-        var removedNodes = snapshotNodeList(this.childNodes);
+        const removedNodes = snapshotNodeList(this.childNodes);
         if (this.invalidateShadowRenderer()) {
           removeAllChildNodes(this);
           if (textContent !== "") {
-            var textNode = unsafeUnwrap(this).ownerDocument.createTextNode(textContent);
+            const textNode = unsafeUnwrap(this).ownerDocument.createTextNode(textContent);
             this.appendChild(textNode);
           }
         } else {
           clearChildNodes(this);
           unsafeUnwrap(this).textContent = textContent;
         }
-        var addedNodes = snapshotNodeList(this.childNodes);
+        const addedNodes = snapshotNodeList(this.childNodes);
         enqueueMutation(this, "childList", {
           addedNodes: addedNodes,
           removedNodes: removedNodes
@@ -1969,9 +1969,9 @@ if (WebComponents.flags.shadow) {
         nodesWereAdded(addedNodes, this);
       },
       get childNodes() {
-        var wrapperList = new NodeList();
-        var i = 0;
-        for (var child = this.firstChild; child; child = child.nextSibling) {
+        const wrapperList = new NodeList();
+        let i = 0;
+        for (let child = this.firstChild; child; child = child.nextSibling) {
           wrapperList[i++] = child;
         }
         wrapperList.length = i;
@@ -1987,11 +1987,11 @@ if (WebComponents.flags.shadow) {
         return originalCompareDocumentPosition.call(unsafeUnwrap(this), unwrapIfNeeded(otherNode));
       },
       normalize: function() {
-        var nodes = snapshotNodeList(this.childNodes);
-        var remNodes = [];
-        var s = "";
-        var modNode;
-        for (var i = 0, n; i < nodes.length; i++) {
+        const nodes = snapshotNodeList(this.childNodes);
+        let remNodes = [];
+        let s = "";
+        let modNode;
+        for (let i = 0, n; i < nodes.length; i++) {
           n = nodes[i];
           if (n.nodeType === Node.TEXT_NODE) {
             if (!modNode && !n.data.length) this.removeNode(n); else if (!modNode) modNode = n; else {
@@ -2032,25 +2032,25 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var HTMLCollection = scope.wrappers.HTMLCollection;
-    var NodeList = scope.wrappers.NodeList;
-    var getTreeScope = scope.getTreeScope;
-    var unsafeUnwrap = scope.unsafeUnwrap;
-    var wrap = scope.wrap;
-    var originalDocumentQuerySelector = document.querySelector;
-    var originalElementQuerySelector = document.documentElement.querySelector;
-    var originalDocumentQuerySelectorAll = document.querySelectorAll;
-    var originalElementQuerySelectorAll = document.documentElement.querySelectorAll;
-    var originalDocumentGetElementsByTagName = document.getElementsByTagName;
-    var originalElementGetElementsByTagName = document.documentElement.getElementsByTagName;
-    var originalDocumentGetElementsByTagNameNS = document.getElementsByTagNameNS;
-    var originalElementGetElementsByTagNameNS = document.documentElement.getElementsByTagNameNS;
-    var OriginalElement = window.Element;
-    var OriginalDocument = window.HTMLDocument || window.Document;
+    const HTMLCollection = scope.wrappers.HTMLCollection;
+    const NodeList = scope.wrappers.NodeList;
+    const getTreeScope = scope.getTreeScope;
+    const unsafeUnwrap = scope.unsafeUnwrap;
+    const wrap = scope.wrap;
+    const originalDocumentQuerySelector = document.querySelector;
+    const originalElementQuerySelector = document.documentElement.querySelector;
+    const originalDocumentQuerySelectorAll = document.querySelectorAll;
+    const originalElementQuerySelectorAll = document.documentElement.querySelectorAll;
+    const originalDocumentGetElementsByTagName = document.getElementsByTagName;
+    const originalElementGetElementsByTagName = document.documentElement.getElementsByTagName;
+    const originalDocumentGetElementsByTagNameNS = document.getElementsByTagNameNS;
+    const originalElementGetElementsByTagNameNS = document.documentElement.getElementsByTagNameNS;
+    const OriginalElement = window.Element;
+    const OriginalDocument = window.HTMLDocument || window.Document;
     function filterNodeList(list, index, result, deep) {
-      var wrappedItem = null;
-      var root = null;
-      for (var i = 0, length = list.length; i < length; i++) {
+      let wrappedItem = null;
+      let root = null;
+      for (let i = 0, length = list.length; i < length; i++) {
         wrappedItem = wrap(list[i]);
         if (!deep && (root = getTreeScope(wrappedItem).root)) {
           if (root instanceof scope.wrappers.ShadowRoot) {
@@ -2065,7 +2065,7 @@ if (WebComponents.flags.shadow) {
       return String(selector).replace(/\/deep\//g, " ");
     }
     function findOne(node, selector) {
-      var m, el = node.firstElementChild;
+      let m, el = node.firstElementChild;
       while (el) {
         if (el.matches(selector)) return el;
         m = findOne(el, selector);
@@ -2077,9 +2077,9 @@ if (WebComponents.flags.shadow) {
     function matchesSelector(el, selector) {
       return el.matches(selector);
     }
-    var XHTML_NS = "http://www.w3.org/1999/xhtml";
+    const XHTML_NS = "http://www.w3.org/1999/xhtml";
     function matchesTagName(el, localName, localNameLowerCase) {
-      var ln = el.localName;
+      const ln = el.localName;
       return ln === localName || ln === localNameLowerCase && el.namespaceURI === XHTML_NS;
     }
     function matchesEveryThing() {
@@ -2095,7 +2095,7 @@ if (WebComponents.flags.shadow) {
       return el.namespaceURI === ns && el.localName === localName;
     }
     function findElements(node, index, result, p, arg0, arg1) {
-      var el = node.firstElementChild;
+      let el = node.firstElementChild;
       while (el) {
         if (p(el, arg0, arg1)) result[index++] = el;
         index = findElements(el, index, result, p, arg0, arg1);
@@ -2104,9 +2104,9 @@ if (WebComponents.flags.shadow) {
       return index;
     }
     function querySelectorAllFiltered(p, index, result, selector, deep) {
-      var target = unsafeUnwrap(this);
-      var list;
-      var root = getTreeScope(this).root;
+      const target = unsafeUnwrap(this);
+      let list;
+      const root = getTreeScope(this).root;
       if (root instanceof scope.wrappers.ShadowRoot) {
         return findElements(this, index, result, p, selector, null);
       } else if (target instanceof OriginalElement) {
@@ -2118,14 +2118,14 @@ if (WebComponents.flags.shadow) {
       }
       return filterNodeList(list, index, result, deep);
     }
-    var SelectorsInterface = {
+    const SelectorsInterface = {
       querySelector: function(selector) {
-        var shimmed = shimSelector(selector);
-        var deep = shimmed !== selector;
+        const shimmed = shimSelector(selector);
+        const deep = shimmed !== selector;
         selector = shimmed;
-        var target = unsafeUnwrap(this);
-        var wrappedItem;
-        var root = getTreeScope(this).root;
+        const target = unsafeUnwrap(this);
+        let wrappedItem;
+        let root = getTreeScope(this).root;
         if (root instanceof scope.wrappers.ShadowRoot) {
           return findOne(this, selector);
         } else if (target instanceof OriginalElement) {
@@ -2145,18 +2145,18 @@ if (WebComponents.flags.shadow) {
         return wrappedItem;
       },
       querySelectorAll: function(selector) {
-        var shimmed = shimSelector(selector);
-        var deep = shimmed !== selector;
+        const shimmed = shimSelector(selector);
+        const deep = shimmed !== selector;
         selector = shimmed;
-        var result = new NodeList();
+        const result = new NodeList();
         result.length = querySelectorAllFiltered.call(this, matchesSelector, 0, result, selector, deep);
         return result;
       }
     };
     function getElementsByTagNameFiltered(p, index, result, localName, lowercase) {
-      var target = unsafeUnwrap(this);
-      var list;
-      var root = getTreeScope(this).root;
+      const target = unsafeUnwrap(this);
+      let list;
+      const root = getTreeScope(this).root;
       if (root instanceof scope.wrappers.ShadowRoot) {
         return findElements(this, index, result, p, localName, lowercase);
       } else if (target instanceof OriginalElement) {
@@ -2169,9 +2169,9 @@ if (WebComponents.flags.shadow) {
       return filterNodeList(list, index, result, false);
     }
     function getElementsByTagNameNSFiltered(p, index, result, ns, localName) {
-      var target = unsafeUnwrap(this);
-      var list;
-      var root = getTreeScope(this).root;
+      const target = unsafeUnwrap(this);
+      let list;
+      const root = getTreeScope(this).root;
       if (root instanceof scope.wrappers.ShadowRoot) {
         return findElements(this, index, result, p, ns, localName);
       } else if (target instanceof OriginalElement) {
@@ -2183,10 +2183,10 @@ if (WebComponents.flags.shadow) {
       }
       return filterNodeList(list, index, result, false);
     }
-    var GetElementsByInterface = {
+    const GetElementsByInterface = {
       getElementsByTagName: function(localName) {
-        var result = new HTMLCollection();
-        var match = localName === "*" ? matchesEveryThing : matchesTagName;
+        const result = new HTMLCollection();
+        const match = localName === "*" ? matchesEveryThing : matchesTagName;
         result.length = getElementsByTagNameFiltered.call(this, match, 0, result, localName, localName.toLowerCase());
         return result;
       },
@@ -2194,8 +2194,8 @@ if (WebComponents.flags.shadow) {
         return this.querySelectorAll("." + className);
       },
       getElementsByTagNameNS: function(ns, localName) {
-        var result = new HTMLCollection();
-        var match = null;
+        const result = new HTMLCollection();
+        let match = null;
         if (ns === "*") {
           match = localName === "*" ? matchesEveryThing : matchesLocalNameOnly;
         } else {
@@ -2210,7 +2210,7 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var NodeList = scope.wrappers.NodeList;
+    const NodeList = scope.wrappers.NodeList;
     function forwardElement(node) {
       while (node && node.nodeType !== Node.ELEMENT_NODE) {
         node = node.nextSibling;
@@ -2223,7 +2223,7 @@ if (WebComponents.flags.shadow) {
       }
       return node;
     }
-    var ParentNodeInterface = {
+    const ParentNodeInterface = {
       get firstElementChild() {
         return forwardElement(this.firstChild);
       },
@@ -2231,27 +2231,27 @@ if (WebComponents.flags.shadow) {
         return backwardsElement(this.lastChild);
       },
       get childElementCount() {
-        var count = 0;
-        for (var child = this.firstElementChild; child; child = child.nextElementSibling) {
+        let count = 0;
+        for (let child = this.firstElementChild; child; child = child.nextElementSibling) {
           count++;
         }
         return count;
       },
       get children() {
-        var wrapperList = new NodeList();
-        var i = 0;
-        for (var child = this.firstElementChild; child; child = child.nextElementSibling) {
+        const wrapperList = new NodeList();
+        let i = 0;
+        for (let child = this.firstElementChild; child; child = child.nextElementSibling) {
           wrapperList[i++] = child;
         }
         wrapperList.length = i;
         return wrapperList;
       },
       remove: function() {
-        var p = this.parentNode;
+        const p = this.parentNode;
         if (p) p.removeChild(this);
       }
     };
-    var ChildNodeInterface = {
+    const ChildNodeInterface = {
       get nextElementSibling() {
         return forwardElement(this.nextSibling);
       },
@@ -2264,13 +2264,13 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var ChildNodeInterface = scope.ChildNodeInterface;
-    var Node = scope.wrappers.Node;
-    var enqueueMutation = scope.enqueueMutation;
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
-    var unsafeUnwrap = scope.unsafeUnwrap;
-    var OriginalCharacterData = window.CharacterData;
+    const ChildNodeInterface = scope.ChildNodeInterface;
+    const Node = scope.wrappers.Node;
+    const enqueueMutation = scope.enqueueMutation;
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
+    const unsafeUnwrap = scope.unsafeUnwrap;
+    const OriginalCharacterData = window.CharacterData;
     function CharacterData(node) {
       Node.call(this, node);
     }
@@ -2286,7 +2286,7 @@ if (WebComponents.flags.shadow) {
         return unsafeUnwrap(this).data;
       },
       set data(value) {
-        var oldValue = unsafeUnwrap(this).data;
+        const oldValue = unsafeUnwrap(this).data;
         enqueueMutation(this, "characterData", {
           oldValue: oldValue
         });
@@ -2299,14 +2299,14 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var CharacterData = scope.wrappers.CharacterData;
-    var enqueueMutation = scope.enqueueMutation;
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
+    const CharacterData = scope.wrappers.CharacterData;
+    const enqueueMutation = scope.enqueueMutation;
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
     function toUInt32(x) {
       return x >>> 0;
     }
-    var OriginalText = window.Text;
+    const OriginalText = window.Text;
     function Text(node) {
       CharacterData.call(this, node);
     }
@@ -2314,12 +2314,12 @@ if (WebComponents.flags.shadow) {
     mixin(Text.prototype, {
       splitText: function(offset) {
         offset = toUInt32(offset);
-        var s = this.data;
+        const s = this.data;
         if (offset > s.length) throw new Error("IndexSizeError");
-        var head = s.slice(0, offset);
-        var tail = s.slice(offset);
+        const head = s.slice(0, offset);
+        const tail = s.slice(offset);
         this.data = head;
-        var newTextNode = this.ownerDocument.createTextNode(tail);
+        const newTextNode = this.ownerDocument.createTextNode(tail);
         if (this.parentNode) this.parentNode.insertBefore(newTextNode, this.nextSibling);
         return newTextNode;
       }
@@ -2329,8 +2329,8 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var setWrapper = scope.setWrapper;
-    var unsafeUnwrap = scope.unsafeUnwrap;
+    const setWrapper = scope.setWrapper;
+    const unsafeUnwrap = scope.unsafeUnwrap;
     function invalidateClass(el) {
       scope.invalidateRendererBasedOnAttribute(el, "class");
     }
@@ -2358,7 +2358,7 @@ if (WebComponents.flags.shadow) {
         invalidateClass(this.ownerElement_);
       },
       toggle: function(token) {
-        var rv = unsafeUnwrap(this).toggle.apply(unsafeUnwrap(this), arguments);
+        const rv = unsafeUnwrap(this).toggle.apply(unsafeUnwrap(this), arguments);
         invalidateClass(this.ownerElement_);
         return rv;
       },
@@ -2370,29 +2370,29 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var ChildNodeInterface = scope.ChildNodeInterface;
-    var GetElementsByInterface = scope.GetElementsByInterface;
-    var Node = scope.wrappers.Node;
-    var DOMTokenList = scope.wrappers.DOMTokenList;
-    var ParentNodeInterface = scope.ParentNodeInterface;
-    var SelectorsInterface = scope.SelectorsInterface;
-    var addWrapNodeListMethod = scope.addWrapNodeListMethod;
-    var enqueueMutation = scope.enqueueMutation;
-    var mixin = scope.mixin;
-    var oneOf = scope.oneOf;
-    var registerWrapper = scope.registerWrapper;
-    var unsafeUnwrap = scope.unsafeUnwrap;
+    const ChildNodeInterface = scope.ChildNodeInterface;
+    const GetElementsByInterface = scope.GetElementsByInterface;
+    const Node = scope.wrappers.Node;
+    const DOMTokenList = scope.wrappers.DOMTokenList;
+    const ParentNodeInterface = scope.ParentNodeInterface;
+    const SelectorsInterface = scope.SelectorsInterface;
+    const addWrapNodeListMethod = scope.addWrapNodeListMethod;
+    const enqueueMutation = scope.enqueueMutation;
+    const mixin = scope.mixin;
+    const oneOf = scope.oneOf;
+    const registerWrapper = scope.registerWrapper;
+    const unsafeUnwrap = scope.unsafeUnwrap;
     var wrappers = scope.wrappers;
-    var OriginalElement = window.Element;
-    var matchesNames = [ "matches", "mozMatchesSelector", "msMatchesSelector", "webkitMatchesSelector" ].filter(function(name) {
+    const OriginalElement = window.Element;
+    const matchesNames = [ "matches", "mozMatchesSelector", "msMatchesSelector", "webkitMatchesSelector" ].filter(function(name) {
       return OriginalElement.prototype[name];
     });
-    var matchesName = matchesNames[0];
-    var originalMatches = OriginalElement.prototype[matchesName];
+    const matchesName = matchesNames[0];
+    const originalMatches = OriginalElement.prototype[matchesName];
     function invalidateRendererBasedOnAttribute(element, name) {
-      var p = element.parentNode;
+      const p = element.parentNode;
       if (!p || !p.shadowRoot) return;
-      var renderer = scope.getRendererForHost(p);
+      const renderer = scope.getRendererForHost(p);
       if (renderer.dependsOnAttribute(name)) renderer.invalidate();
     }
     function enqueAttributeChange(element, name, oldValue) {
@@ -2402,16 +2402,16 @@ if (WebComponents.flags.shadow) {
         oldValue: oldValue
       });
     }
-    var classListTable = new WeakMap();
+    const classListTable = new WeakMap();
     function Element(node) {
       Node.call(this, node);
     }
     Element.prototype = Object.create(Node.prototype);
     mixin(Element.prototype, {
       createShadowRoot: function() {
-        var newShadowRoot = new wrappers.ShadowRoot(this);
+        const newShadowRoot = new wrappers.ShadowRoot(this);
         unsafeUnwrap(this).polymerShadowRoot_ = newShadowRoot;
-        var renderer = scope.getRendererForHost(this);
+        const renderer = scope.getRendererForHost(this);
         renderer.invalidate();
         return newShadowRoot;
       },
@@ -2419,13 +2419,13 @@ if (WebComponents.flags.shadow) {
         return unsafeUnwrap(this).polymerShadowRoot_ || null;
       },
       setAttribute: function(name, value) {
-        var oldValue = unsafeUnwrap(this).getAttribute(name);
+        const oldValue = unsafeUnwrap(this).getAttribute(name);
         unsafeUnwrap(this).setAttribute(name, value);
         enqueAttributeChange(this, name, oldValue);
         invalidateRendererBasedOnAttribute(this, name);
       },
       removeAttribute: function(name) {
-        var oldValue = unsafeUnwrap(this).getAttribute(name);
+        const oldValue = unsafeUnwrap(this).getAttribute(name);
         unsafeUnwrap(this).removeAttribute(name);
         enqueAttributeChange(this, name, oldValue);
         invalidateRendererBasedOnAttribute(this, name);
@@ -2434,7 +2434,7 @@ if (WebComponents.flags.shadow) {
         return originalMatches.call(unsafeUnwrap(this), selector);
       },
       get classList() {
-        var list = classListTable.get(this);
+        let list = classListTable.get(this);
         if (!list) {
           classListTable.set(this, list = new DOMTokenList(unsafeUnwrap(this).classList, this));
         }
@@ -2474,20 +2474,20 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var Element = scope.wrappers.Element;
-    var defineGetter = scope.defineGetter;
-    var enqueueMutation = scope.enqueueMutation;
-    var mixin = scope.mixin;
-    var nodesWereAdded = scope.nodesWereAdded;
-    var nodesWereRemoved = scope.nodesWereRemoved;
-    var registerWrapper = scope.registerWrapper;
-    var snapshotNodeList = scope.snapshotNodeList;
-    var unsafeUnwrap = scope.unsafeUnwrap;
-    var unwrap = scope.unwrap;
-    var wrap = scope.wrap;
+    const Element = scope.wrappers.Element;
+    const defineGetter = scope.defineGetter;
+    const enqueueMutation = scope.enqueueMutation;
+    const mixin = scope.mixin;
+    const nodesWereAdded = scope.nodesWereAdded;
+    const nodesWereRemoved = scope.nodesWereRemoved;
+    const registerWrapper = scope.registerWrapper;
+    const snapshotNodeList = scope.snapshotNodeList;
+    const unsafeUnwrap = scope.unsafeUnwrap;
+    const unwrap = scope.unwrap;
+    const wrap = scope.wrap;
     var wrappers = scope.wrappers;
-    var escapeAttrRegExp = /[&\u00A0"]/g;
-    var escapeDataRegExp = /[&\u00A0<>]/g;
+    const escapeAttrRegExp = /[&\u00A0"]/g;
+    const escapeDataRegExp = /[&\u00A0<>]/g;
     function escapeReplace(c) {
       switch (c) {
        case "&":
@@ -2513,21 +2513,21 @@ if (WebComponents.flags.shadow) {
       return s.replace(escapeDataRegExp, escapeReplace);
     }
     function makeSet(arr) {
-      var set = {};
-      for (var i = 0; i < arr.length; i++) {
+      const set = {};
+      for (let i = 0; i < arr.length; i++) {
         set[arr[i]] = true;
       }
       return set;
     }
-    var voidElements = makeSet([ "area", "base", "br", "col", "command", "embed", "hr", "img", "input", "keygen", "link", "meta", "param", "source", "track", "wbr" ]);
-    var plaintextParents = makeSet([ "style", "script", "xmp", "iframe", "noembed", "noframes", "plaintext", "noscript" ]);
+    const voidElements = makeSet([ "area", "base", "br", "col", "command", "embed", "hr", "img", "input", "keygen", "link", "meta", "param", "source", "track", "wbr" ]);
+    const plaintextParents = makeSet([ "style", "script", "xmp", "iframe", "noembed", "noframes", "plaintext", "noscript" ]);
     function getOuterHTML(node, parentNode) {
       switch (node.nodeType) {
        case Node.ELEMENT_NODE:
-        var tagName = node.tagName.toLowerCase();
-        var s = "<" + tagName;
-        var attrs = node.attributes;
-        for (var i = 0, attr; attr = attrs[i]; i++) {
+        const tagName = node.tagName.toLowerCase();
+        let s = "<" + tagName;
+        const attrs = node.attributes;
+        for (let i = 0, attr; attr = attrs[i]; i++) {
           s += " " + attr.name + '="' + escapeAttr(attr.value) + '"';
         }
         s += ">";
@@ -2549,25 +2549,25 @@ if (WebComponents.flags.shadow) {
     }
     function getInnerHTML(node) {
       if (node instanceof wrappers.HTMLTemplateElement) node = node.content;
-      var s = "";
-      for (var child = node.firstChild; child; child = child.nextSibling) {
+      let s = "";
+      for (let child = node.firstChild; child; child = child.nextSibling) {
         s += getOuterHTML(child, node);
       }
       return s;
     }
     function setInnerHTML(node, value, opt_tagName) {
-      var tagName = opt_tagName || "div";
+      const tagName = opt_tagName || "div";
       node.textContent = "";
-      var tempElement = unwrap(node.ownerDocument.createElement(tagName));
+      const tempElement = unwrap(node.ownerDocument.createElement(tagName));
       tempElement.innerHTML = value;
-      var firstChild;
+      let firstChild;
       while (firstChild = tempElement.firstChild) {
         node.appendChild(wrap(firstChild));
       }
     }
-    var oldIe = /MSIE/.test(navigator.userAgent);
-    var OriginalHTMLElement = window.HTMLElement;
-    var OriginalHTMLTemplateElement = window.HTMLTemplateElement;
+    const oldIe = /MSIE/.test(navigator.userAgent);
+    const OriginalHTMLElement = window.HTMLElement;
+    const OriginalHTMLTemplateElement = window.HTMLTemplateElement;
     function HTMLElement(node) {
       Element.call(this, node);
     }
@@ -2581,7 +2581,7 @@ if (WebComponents.flags.shadow) {
           this.textContent = value;
           return;
         }
-        var removedNodes = snapshotNodeList(this.childNodes);
+        const removedNodes = snapshotNodeList(this.childNodes);
         if (this.invalidateShadowRenderer()) {
           if (this instanceof wrappers.HTMLTemplateElement) setInnerHTML(this.content, value); else setInnerHTML(this, value, this.tagName);
         } else if (!OriginalHTMLTemplateElement && this instanceof wrappers.HTMLTemplateElement) {
@@ -2589,7 +2589,7 @@ if (WebComponents.flags.shadow) {
         } else {
           unsafeUnwrap(this).innerHTML = value;
         }
-        var addedNodes = snapshotNodeList(this.childNodes);
+        const addedNodes = snapshotNodeList(this.childNodes);
         enqueueMutation(this, "childList", {
           addedNodes: addedNodes,
           removedNodes: removedNodes
@@ -2601,15 +2601,15 @@ if (WebComponents.flags.shadow) {
         return getOuterHTML(this, this.parentNode);
       },
       set outerHTML(value) {
-        var p = this.parentNode;
+        const p = this.parentNode;
         if (p) {
           p.invalidateShadowRenderer();
-          var df = frag(p, value);
+          const df = frag(p, value);
           p.replaceChild(df, this);
         }
       },
       insertAdjacentHTML: function(position, text) {
-        var contextElement, refNode;
+        let contextElement, refNode;
         switch (String(position).toLowerCase()) {
          case "beforebegin":
           contextElement = this.parentNode;
@@ -2634,7 +2634,7 @@ if (WebComponents.flags.shadow) {
          default:
           return;
         }
-        var df = frag(contextElement, text);
+        const df = frag(contextElement, text);
         contextElement.insertBefore(df, refNode);
       },
       get hidden() {
@@ -2649,10 +2649,10 @@ if (WebComponents.flags.shadow) {
       }
     });
     function frag(contextElement, html) {
-      var p = unwrap(contextElement.cloneNode(false));
+      const p = unwrap(contextElement.cloneNode(false));
       p.innerHTML = html;
-      var df = unwrap(document.createDocumentFragment());
-      var c;
+      const df = unwrap(document.createDocumentFragment());
+      let c;
       while (c = p.firstChild) {
         df.appendChild(c);
       }
@@ -2698,19 +2698,19 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var HTMLElement = scope.wrappers.HTMLElement;
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
-    var unsafeUnwrap = scope.unsafeUnwrap;
-    var wrap = scope.wrap;
-    var OriginalHTMLCanvasElement = window.HTMLCanvasElement;
+    const HTMLElement = scope.wrappers.HTMLElement;
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
+    const unsafeUnwrap = scope.unsafeUnwrap;
+    const wrap = scope.wrap;
+    const OriginalHTMLCanvasElement = window.HTMLCanvasElement;
     function HTMLCanvasElement(node) {
       HTMLElement.call(this, node);
     }
     HTMLCanvasElement.prototype = Object.create(HTMLElement.prototype);
     mixin(HTMLCanvasElement.prototype, {
       getContext: function() {
-        var context = unsafeUnwrap(this).getContext.apply(unsafeUnwrap(this), arguments);
+        const context = unsafeUnwrap(this).getContext.apply(unsafeUnwrap(this), arguments);
         return context && wrap(context);
       }
     });
@@ -2719,10 +2719,10 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var HTMLElement = scope.wrappers.HTMLElement;
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
-    var OriginalHTMLContentElement = window.HTMLContentElement;
+    const HTMLElement = scope.wrappers.HTMLElement;
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
+    const OriginalHTMLContentElement = window.HTMLContentElement;
     function HTMLContentElement(node) {
       HTMLElement.call(this, node);
     }
@@ -2745,12 +2745,12 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var HTMLElement = scope.wrappers.HTMLElement;
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
-    var wrapHTMLCollection = scope.wrapHTMLCollection;
-    var unwrap = scope.unwrap;
-    var OriginalHTMLFormElement = window.HTMLFormElement;
+    const HTMLElement = scope.wrappers.HTMLElement;
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
+    const wrapHTMLCollection = scope.wrapHTMLCollection;
+    const unwrap = scope.unwrap;
+    const OriginalHTMLFormElement = window.HTMLFormElement;
     function HTMLFormElement(node) {
       HTMLElement.call(this, node);
     }
@@ -2765,11 +2765,11 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var HTMLElement = scope.wrappers.HTMLElement;
-    var registerWrapper = scope.registerWrapper;
-    var unwrap = scope.unwrap;
-    var rewrap = scope.rewrap;
-    var OriginalHTMLImageElement = window.HTMLImageElement;
+    const HTMLElement = scope.wrappers.HTMLElement;
+    const registerWrapper = scope.registerWrapper;
+    const unwrap = scope.unwrap;
+    const rewrap = scope.rewrap;
+    const OriginalHTMLImageElement = window.HTMLImageElement;
     function HTMLImageElement(node) {
       HTMLElement.call(this, node);
     }
@@ -2779,7 +2779,7 @@ if (WebComponents.flags.shadow) {
       if (!(this instanceof Image)) {
         throw new TypeError("DOM object constructor cannot be called as a function.");
       }
-      var node = unwrap(document.createElement("img"));
+      const node = unwrap(document.createElement("img"));
       HTMLElement.call(this, node);
       rewrap(node, this);
       if (width !== undefined) node.width = width;
@@ -2791,11 +2791,11 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var HTMLElement = scope.wrappers.HTMLElement;
-    var mixin = scope.mixin;
-    var NodeList = scope.wrappers.NodeList;
-    var registerWrapper = scope.registerWrapper;
-    var OriginalHTMLShadowElement = window.HTMLShadowElement;
+    const HTMLElement = scope.wrappers.HTMLElement;
+    const mixin = scope.mixin;
+    const NodeList = scope.wrappers.NodeList;
+    const registerWrapper = scope.registerWrapper;
+    const OriginalHTMLShadowElement = window.HTMLShadowElement;
     function HTMLShadowElement(node) {
       HTMLElement.call(this, node);
     }
@@ -2806,17 +2806,17 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var HTMLElement = scope.wrappers.HTMLElement;
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
-    var unsafeUnwrap = scope.unsafeUnwrap;
-    var unwrap = scope.unwrap;
-    var wrap = scope.wrap;
-    var contentTable = new WeakMap();
-    var templateContentsOwnerTable = new WeakMap();
+    const HTMLElement = scope.wrappers.HTMLElement;
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
+    const unsafeUnwrap = scope.unsafeUnwrap;
+    const unwrap = scope.unwrap;
+    const wrap = scope.wrap;
+    const contentTable = new WeakMap();
+    const templateContentsOwnerTable = new WeakMap();
     function getTemplateContentsOwner(doc) {
       if (!doc.defaultView) return doc;
-      var d = templateContentsOwnerTable.get(doc);
+      let d = templateContentsOwnerTable.get(doc);
       if (!d) {
         d = doc.implementation.createHTMLDocument("");
         while (d.lastChild) {
@@ -2827,19 +2827,19 @@ if (WebComponents.flags.shadow) {
       return d;
     }
     function extractContent(templateElement) {
-      var doc = getTemplateContentsOwner(templateElement.ownerDocument);
-      var df = unwrap(doc.createDocumentFragment());
-      var child;
+      const doc = getTemplateContentsOwner(templateElement.ownerDocument);
+      const df = unwrap(doc.createDocumentFragment());
+      let child;
       while (child = templateElement.firstChild) {
         df.appendChild(child);
       }
       return df;
     }
-    var OriginalHTMLTemplateElement = window.HTMLTemplateElement;
+    const OriginalHTMLTemplateElement = window.HTMLTemplateElement;
     function HTMLTemplateElement(node) {
       HTMLElement.call(this, node);
       if (!OriginalHTMLTemplateElement) {
-        var content = extractContent(node);
+        const content = extractContent(node);
         contentTable.set(this, wrap(content));
       }
     }
@@ -2856,9 +2856,9 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var HTMLElement = scope.wrappers.HTMLElement;
-    var registerWrapper = scope.registerWrapper;
-    var OriginalHTMLMediaElement = window.HTMLMediaElement;
+    const HTMLElement = scope.wrappers.HTMLElement;
+    const registerWrapper = scope.registerWrapper;
+    const OriginalHTMLMediaElement = window.HTMLMediaElement;
     if (!OriginalHTMLMediaElement) return;
     function HTMLMediaElement(node) {
       HTMLElement.call(this, node);
@@ -2869,11 +2869,11 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var HTMLMediaElement = scope.wrappers.HTMLMediaElement;
-    var registerWrapper = scope.registerWrapper;
-    var unwrap = scope.unwrap;
-    var rewrap = scope.rewrap;
-    var OriginalHTMLAudioElement = window.HTMLAudioElement;
+    const HTMLMediaElement = scope.wrappers.HTMLMediaElement;
+    const registerWrapper = scope.registerWrapper;
+    const unwrap = scope.unwrap;
+    const rewrap = scope.rewrap;
+    const OriginalHTMLAudioElement = window.HTMLAudioElement;
     if (!OriginalHTMLAudioElement) return;
     function HTMLAudioElement(node) {
       HTMLMediaElement.call(this, node);
@@ -2884,7 +2884,7 @@ if (WebComponents.flags.shadow) {
       if (!(this instanceof Audio)) {
         throw new TypeError("DOM object constructor cannot be called as a function.");
       }
-      var node = unwrap(document.createElement("audio"));
+      const node = unwrap(document.createElement("audio"));
       HTMLMediaElement.call(this, node);
       rewrap(node, this);
       node.setAttribute("preload", "auto");
@@ -2896,13 +2896,13 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var HTMLElement = scope.wrappers.HTMLElement;
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
-    var rewrap = scope.rewrap;
-    var unwrap = scope.unwrap;
-    var wrap = scope.wrap;
-    var OriginalHTMLOptionElement = window.HTMLOptionElement;
+    const HTMLElement = scope.wrappers.HTMLElement;
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
+    const rewrap = scope.rewrap;
+    const unwrap = scope.unwrap;
+    const wrap = scope.wrap;
+    const OriginalHTMLOptionElement = window.HTMLOptionElement;
     function trimText(s) {
       return s.replace(/\s+/g, " ").trim();
     }
@@ -2926,7 +2926,7 @@ if (WebComponents.flags.shadow) {
       if (!(this instanceof Option)) {
         throw new TypeError("DOM object constructor cannot be called as a function.");
       }
-      var node = unwrap(document.createElement("option"));
+      const node = unwrap(document.createElement("option"));
       HTMLElement.call(this, node);
       rewrap(node, this);
       if (text !== undefined) node.text = text;
@@ -2940,12 +2940,12 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var HTMLElement = scope.wrappers.HTMLElement;
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
-    var unwrap = scope.unwrap;
-    var wrap = scope.wrap;
-    var OriginalHTMLSelectElement = window.HTMLSelectElement;
+    const HTMLElement = scope.wrappers.HTMLElement;
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
+    const unwrap = scope.unwrap;
+    const wrap = scope.wrap;
+    const OriginalHTMLSelectElement = window.HTMLSelectElement;
     function HTMLSelectElement(node) {
       HTMLElement.call(this, node);
     }
@@ -2972,13 +2972,13 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var HTMLElement = scope.wrappers.HTMLElement;
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
-    var unwrap = scope.unwrap;
-    var wrap = scope.wrap;
-    var wrapHTMLCollection = scope.wrapHTMLCollection;
-    var OriginalHTMLTableElement = window.HTMLTableElement;
+    const HTMLElement = scope.wrappers.HTMLElement;
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
+    const unwrap = scope.unwrap;
+    const wrap = scope.wrap;
+    const wrapHTMLCollection = scope.wrapHTMLCollection;
+    const OriginalHTMLTableElement = window.HTMLTableElement;
     function HTMLTableElement(node) {
       HTMLElement.call(this, node);
     }
@@ -3020,13 +3020,13 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var HTMLElement = scope.wrappers.HTMLElement;
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
-    var wrapHTMLCollection = scope.wrapHTMLCollection;
-    var unwrap = scope.unwrap;
-    var wrap = scope.wrap;
-    var OriginalHTMLTableSectionElement = window.HTMLTableSectionElement;
+    const HTMLElement = scope.wrappers.HTMLElement;
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
+    const wrapHTMLCollection = scope.wrapHTMLCollection;
+    const unwrap = scope.unwrap;
+    const wrap = scope.wrap;
+    const OriginalHTMLTableSectionElement = window.HTMLTableSectionElement;
     function HTMLTableSectionElement(node) {
       HTMLElement.call(this, node);
     }
@@ -3045,13 +3045,13 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var HTMLElement = scope.wrappers.HTMLElement;
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
-    var wrapHTMLCollection = scope.wrapHTMLCollection;
-    var unwrap = scope.unwrap;
-    var wrap = scope.wrap;
-    var OriginalHTMLTableRowElement = window.HTMLTableRowElement;
+    const HTMLElement = scope.wrappers.HTMLElement;
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
+    const wrapHTMLCollection = scope.wrapHTMLCollection;
+    const unwrap = scope.unwrap;
+    const wrap = scope.wrap;
+    const OriginalHTMLTableRowElement = window.HTMLTableRowElement;
     function HTMLTableRowElement(node) {
       HTMLElement.call(this, node);
     }
@@ -3069,13 +3069,13 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var HTMLContentElement = scope.wrappers.HTMLContentElement;
-    var HTMLElement = scope.wrappers.HTMLElement;
-    var HTMLShadowElement = scope.wrappers.HTMLShadowElement;
-    var HTMLTemplateElement = scope.wrappers.HTMLTemplateElement;
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
-    var OriginalHTMLUnknownElement = window.HTMLUnknownElement;
+    const HTMLContentElement = scope.wrappers.HTMLContentElement;
+    const HTMLElement = scope.wrappers.HTMLElement;
+    const HTMLShadowElement = scope.wrappers.HTMLShadowElement;
+    const HTMLTemplateElement = scope.wrappers.HTMLTemplateElement;
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
+    const OriginalHTMLUnknownElement = window.HTMLUnknownElement;
     function HTMLUnknownElement(node) {
       switch (node.localName) {
        case "content":
@@ -3095,15 +3095,15 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var Element = scope.wrappers.Element;
-    var HTMLElement = scope.wrappers.HTMLElement;
-    var registerObject = scope.registerObject;
-    var SVG_NS = "http://www.w3.org/2000/svg";
-    var svgTitleElement = document.createElementNS(SVG_NS, "title");
-    var SVGTitleElement = registerObject(svgTitleElement);
-    var SVGElement = Object.getPrototypeOf(SVGTitleElement.prototype).constructor;
+    const Element = scope.wrappers.Element;
+    const HTMLElement = scope.wrappers.HTMLElement;
+    const registerObject = scope.registerObject;
+    const SVG_NS = "http://www.w3.org/2000/svg";
+    const svgTitleElement = document.createElementNS(SVG_NS, "title");
+    const SVGTitleElement = registerObject(svgTitleElement);
+    const SVGElement = Object.getPrototypeOf(SVGTitleElement.prototype).constructor;
     if (!("classList" in svgTitleElement)) {
-      var descr = Object.getOwnPropertyDescriptor(Element.prototype, "classList");
+      const descr = Object.getOwnPropertyDescriptor(Element.prototype, "classList");
       Object.defineProperty(HTMLElement.prototype, "classList", descr);
       delete Element.prototype.classList;
     }
@@ -3111,16 +3111,16 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
-    var unwrap = scope.unwrap;
-    var wrap = scope.wrap;
-    var OriginalSVGUseElement = window.SVGUseElement;
-    var SVG_NS = "http://www.w3.org/2000/svg";
-    var gWrapper = wrap(document.createElementNS(SVG_NS, "g"));
-    var useElement = document.createElementNS(SVG_NS, "use");
-    var SVGGElement = gWrapper.constructor;
-    var parentInterfacePrototype = Object.getPrototypeOf(SVGGElement.prototype);
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
+    const unwrap = scope.unwrap;
+    const wrap = scope.wrap;
+    const OriginalSVGUseElement = window.SVGUseElement;
+    const SVG_NS = "http://www.w3.org/2000/svg";
+    const gWrapper = wrap(document.createElementNS(SVG_NS, "g"));
+    const useElement = document.createElementNS(SVG_NS, "use");
+    const SVGGElement = gWrapper.constructor;
+    const parentInterfacePrototype = Object.getPrototypeOf(SVGGElement.prototype);
     var parentInterface = parentInterfacePrototype.constructor;
     function SVGUseElement(impl) {
       parentInterface.call(this, impl);
@@ -3141,12 +3141,12 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var EventTarget = scope.wrappers.EventTarget;
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
-    var unsafeUnwrap = scope.unsafeUnwrap;
-    var wrap = scope.wrap;
-    var OriginalSVGElementInstance = window.SVGElementInstance;
+    const EventTarget = scope.wrappers.EventTarget;
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
+    const unsafeUnwrap = scope.unsafeUnwrap;
+    const wrap = scope.wrap;
+    const OriginalSVGElementInstance = window.SVGElementInstance;
     if (!OriginalSVGElementInstance) return;
     function SVGElementInstance(impl) {
       EventTarget.call(this, impl);
@@ -3183,14 +3183,14 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
-    var setWrapper = scope.setWrapper;
-    var unsafeUnwrap = scope.unsafeUnwrap;
-    var unwrap = scope.unwrap;
-    var unwrapIfNeeded = scope.unwrapIfNeeded;
-    var wrap = scope.wrap;
-    var OriginalCanvasRenderingContext2D = window.CanvasRenderingContext2D;
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
+    const setWrapper = scope.setWrapper;
+    const unsafeUnwrap = scope.unsafeUnwrap;
+    const unwrap = scope.unwrap;
+    const unwrapIfNeeded = scope.unwrapIfNeeded;
+    const wrap = scope.wrap;
+    const OriginalCanvasRenderingContext2D = window.CanvasRenderingContext2D;
     function CanvasRenderingContext2D(impl) {
       setWrapper(impl, this);
     }
@@ -3212,13 +3212,13 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
-    var setWrapper = scope.setWrapper;
-    var unsafeUnwrap = scope.unsafeUnwrap;
-    var unwrapIfNeeded = scope.unwrapIfNeeded;
-    var wrap = scope.wrap;
-    var OriginalWebGLRenderingContext = window.WebGLRenderingContext;
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
+    const setWrapper = scope.setWrapper;
+    const unsafeUnwrap = scope.unsafeUnwrap;
+    const unwrapIfNeeded = scope.unwrapIfNeeded;
+    const wrap = scope.wrap;
+    const OriginalWebGLRenderingContext = window.WebGLRenderingContext;
     if (!OriginalWebGLRenderingContext) return;
     function WebGLRenderingContext(impl) {
       setWrapper(impl, this);
@@ -3236,7 +3236,7 @@ if (WebComponents.flags.shadow) {
         unsafeUnwrap(this).texSubImage2D.apply(unsafeUnwrap(this), arguments);
       }
     });
-    var instanceProperties = /WebKit/.test(navigator.userAgent) ? {
+    const instanceProperties = /WebKit/.test(navigator.userAgent) ? {
       drawingBufferHeight: null,
       drawingBufferWidth: null
     } : {};
@@ -3245,13 +3245,13 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var registerWrapper = scope.registerWrapper;
-    var setWrapper = scope.setWrapper;
-    var unsafeUnwrap = scope.unsafeUnwrap;
-    var unwrap = scope.unwrap;
-    var unwrapIfNeeded = scope.unwrapIfNeeded;
-    var wrap = scope.wrap;
-    var OriginalRange = window.Range;
+    const registerWrapper = scope.registerWrapper;
+    const setWrapper = scope.setWrapper;
+    const unsafeUnwrap = scope.unsafeUnwrap;
+    const unwrap = scope.unwrap;
+    const unwrapIfNeeded = scope.unwrapIfNeeded;
+    const wrap = scope.wrap;
+    const OriginalRange = window.Range;
     function Range(impl) {
       setWrapper(impl, this);
     }
@@ -3330,39 +3330,39 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var GetElementsByInterface = scope.GetElementsByInterface;
-    var ParentNodeInterface = scope.ParentNodeInterface;
-    var SelectorsInterface = scope.SelectorsInterface;
-    var mixin = scope.mixin;
-    var registerObject = scope.registerObject;
-    var DocumentFragment = registerObject(document.createDocumentFragment());
+    const GetElementsByInterface = scope.GetElementsByInterface;
+    const ParentNodeInterface = scope.ParentNodeInterface;
+    const SelectorsInterface = scope.SelectorsInterface;
+    const mixin = scope.mixin;
+    const registerObject = scope.registerObject;
+    const DocumentFragment = registerObject(document.createDocumentFragment());
     mixin(DocumentFragment.prototype, ParentNodeInterface);
     mixin(DocumentFragment.prototype, SelectorsInterface);
     mixin(DocumentFragment.prototype, GetElementsByInterface);
-    var Comment = registerObject(document.createComment(""));
+    const Comment = registerObject(document.createComment(""));
     scope.wrappers.Comment = Comment;
     scope.wrappers.DocumentFragment = DocumentFragment;
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var DocumentFragment = scope.wrappers.DocumentFragment;
-    var TreeScope = scope.TreeScope;
-    var elementFromPoint = scope.elementFromPoint;
-    var getInnerHTML = scope.getInnerHTML;
-    var getTreeScope = scope.getTreeScope;
-    var mixin = scope.mixin;
-    var rewrap = scope.rewrap;
-    var setInnerHTML = scope.setInnerHTML;
-    var unsafeUnwrap = scope.unsafeUnwrap;
-    var unwrap = scope.unwrap;
-    var shadowHostTable = new WeakMap();
-    var nextOlderShadowTreeTable = new WeakMap();
-    var spaceCharRe = /[ \t\n\r\f]/;
+    const DocumentFragment = scope.wrappers.DocumentFragment;
+    const TreeScope = scope.TreeScope;
+    const elementFromPoint = scope.elementFromPoint;
+    const getInnerHTML = scope.getInnerHTML;
+    const getTreeScope = scope.getTreeScope;
+    const mixin = scope.mixin;
+    const rewrap = scope.rewrap;
+    const setInnerHTML = scope.setInnerHTML;
+    const unsafeUnwrap = scope.unsafeUnwrap;
+    const unwrap = scope.unwrap;
+    const shadowHostTable = new WeakMap();
+    const nextOlderShadowTreeTable = new WeakMap();
+    const spaceCharRe = /[ \t\n\r\f]/;
     function ShadowRoot(hostWrapper) {
-      var node = unwrap(unsafeUnwrap(hostWrapper).ownerDocument.createDocumentFragment());
+      const node = unwrap(unsafeUnwrap(hostWrapper).ownerDocument.createDocumentFragment());
       DocumentFragment.call(this, node);
       rewrap(node, this);
-      var oldShadowRoot = hostWrapper.shadowRoot;
+      const oldShadowRoot = hostWrapper.shadowRoot;
       nextOlderShadowTreeTable.set(this, oldShadowRoot);
       this.treeScope_ = new TreeScope(this, getTreeScope(oldShadowRoot || hostWrapper));
       shadowHostTable.set(this, hostWrapper);
@@ -3398,19 +3398,19 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var Element = scope.wrappers.Element;
-    var HTMLContentElement = scope.wrappers.HTMLContentElement;
-    var HTMLShadowElement = scope.wrappers.HTMLShadowElement;
-    var Node = scope.wrappers.Node;
-    var ShadowRoot = scope.wrappers.ShadowRoot;
-    var assert = scope.assert;
-    var getTreeScope = scope.getTreeScope;
-    var mixin = scope.mixin;
-    var oneOf = scope.oneOf;
-    var unsafeUnwrap = scope.unsafeUnwrap;
-    var unwrap = scope.unwrap;
-    var wrap = scope.wrap;
-    var ArraySplice = scope.ArraySplice;
+    const Element = scope.wrappers.Element;
+    const HTMLContentElement = scope.wrappers.HTMLContentElement;
+    const HTMLShadowElement = scope.wrappers.HTMLShadowElement;
+    const Node = scope.wrappers.Node;
+    const ShadowRoot = scope.wrappers.ShadowRoot;
+    const assert = scope.assert;
+    const getTreeScope = scope.getTreeScope;
+    const mixin = scope.mixin;
+    const oneOf = scope.oneOf;
+    const unsafeUnwrap = scope.unsafeUnwrap;
+    const unwrap = scope.unwrap;
+    const wrap = scope.wrap;
+    const ArraySplice = scope.ArraySplice;
     function updateWrapperUpAndSideways(wrapper) {
       wrapper.previousSibling_ = wrapper.previousSibling;
       wrapper.nextSibling_ = wrapper.nextSibling;
@@ -3422,21 +3422,21 @@ if (WebComponents.flags.shadow) {
     }
     function updateAllChildNodes(parentNodeWrapper) {
       assert(parentNodeWrapper instanceof Node);
-      for (var childWrapper = parentNodeWrapper.firstChild; childWrapper; childWrapper = childWrapper.nextSibling) {
+      for (let childWrapper = parentNodeWrapper.firstChild; childWrapper; childWrapper = childWrapper.nextSibling) {
         updateWrapperUpAndSideways(childWrapper);
       }
       updateWrapperDown(parentNodeWrapper);
     }
     function insertBefore(parentNodeWrapper, newChildWrapper, refChildWrapper) {
-      var parentNode = unwrap(parentNodeWrapper);
-      var newChild = unwrap(newChildWrapper);
-      var refChild = refChildWrapper ? unwrap(refChildWrapper) : null;
+      const parentNode = unwrap(parentNodeWrapper);
+      const newChild = unwrap(newChildWrapper);
+      const refChild = refChildWrapper ? unwrap(refChildWrapper) : null;
       remove(newChildWrapper);
       updateWrapperUpAndSideways(newChildWrapper);
       if (!refChildWrapper) {
         parentNodeWrapper.lastChild_ = parentNodeWrapper.lastChild;
         if (parentNodeWrapper.lastChild === parentNodeWrapper.firstChild) parentNodeWrapper.firstChild_ = parentNodeWrapper.firstChild;
-        var lastChildWrapper = wrap(parentNode.lastChild);
+        const lastChildWrapper = wrap(parentNode.lastChild);
         if (lastChildWrapper) lastChildWrapper.nextSibling_ = lastChildWrapper.nextSibling;
       } else {
         if (parentNodeWrapper.firstChild === refChildWrapper) parentNodeWrapper.firstChild_ = refChildWrapper;
@@ -3445,10 +3445,10 @@ if (WebComponents.flags.shadow) {
       scope.originalInsertBefore.call(parentNode, newChild, refChild);
     }
     function remove(nodeWrapper) {
-      var node = unwrap(nodeWrapper);
-      var parentNode = node.parentNode;
+      const node = unwrap(nodeWrapper);
+      const parentNode = node.parentNode;
       if (!parentNode) return;
-      var parentNodeWrapper = wrap(parentNode);
+      const parentNodeWrapper = wrap(parentNode);
       updateWrapperUpAndSideways(nodeWrapper);
       if (nodeWrapper.previousSibling) nodeWrapper.previousSibling.nextSibling_ = nodeWrapper;
       if (nodeWrapper.nextSibling) nodeWrapper.nextSibling.previousSibling_ = nodeWrapper;
@@ -3456,31 +3456,31 @@ if (WebComponents.flags.shadow) {
       if (parentNodeWrapper.firstChild === nodeWrapper) parentNodeWrapper.firstChild_ = nodeWrapper;
       scope.originalRemoveChild.call(parentNode, node);
     }
-    var distributedNodesTable = new WeakMap();
-    var destinationInsertionPointsTable = new WeakMap();
-    var rendererForHostTable = new WeakMap();
+    const distributedNodesTable = new WeakMap();
+    const destinationInsertionPointsTable = new WeakMap();
+    const rendererForHostTable = new WeakMap();
     function resetDistributedNodes(insertionPoint) {
       distributedNodesTable.set(insertionPoint, []);
     }
     function getDistributedNodes(insertionPoint) {
-      var rv = distributedNodesTable.get(insertionPoint);
+      let rv = distributedNodesTable.get(insertionPoint);
       if (!rv) distributedNodesTable.set(insertionPoint, rv = []);
       return rv;
     }
     function getChildNodesSnapshot(node) {
-      var result = [], i = 0;
-      for (var child = node.firstChild; child; child = child.nextSibling) {
+      let result = [], i = 0;
+      for (let child = node.firstChild; child; child = child.nextSibling) {
         result[i++] = child;
       }
       return result;
     }
-    var request = oneOf(window, [ "requestAnimationFrame", "mozRequestAnimationFrame", "webkitRequestAnimationFrame", "setTimeout" ]);
-    var pendingDirtyRenderers = [];
-    var renderTimer;
+    const request = oneOf(window, [ "requestAnimationFrame", "mozRequestAnimationFrame", "webkitRequestAnimationFrame", "setTimeout" ]);
+    let pendingDirtyRenderers = [];
+    let renderTimer;
     function renderAllPending() {
-      for (var i = 0; i < pendingDirtyRenderers.length; i++) {
-        var renderer = pendingDirtyRenderers[i];
-        var parentRenderer = renderer.parentRenderer;
+      for (let i = 0; i < pendingDirtyRenderers.length; i++) {
+        const renderer = pendingDirtyRenderers[i];
+        const parentRenderer = renderer.parentRenderer;
         if (parentRenderer && parentRenderer.dirty) continue;
         renderer.render();
       }
@@ -3491,7 +3491,7 @@ if (WebComponents.flags.shadow) {
       renderAllPending();
     }
     function getRendererForHost(host) {
-      var renderer = rendererForHostTable.get(host);
+      let renderer = rendererForHostTable.get(host);
       if (!renderer) {
         renderer = new ShadowRenderer(host);
         rendererForHostTable.set(host, renderer);
@@ -3499,14 +3499,14 @@ if (WebComponents.flags.shadow) {
       return renderer;
     }
     function getShadowRootAncestor(node) {
-      var root = getTreeScope(node).root;
+      const root = getTreeScope(node).root;
       if (root instanceof ShadowRoot) return root;
       return null;
     }
     function getRendererForShadowRoot(shadowRoot) {
       return getRendererForHost(shadowRoot.host);
     }
-    var spliceDiff = new ArraySplice();
+    const spliceDiff = new ArraySplice();
     spliceDiff.equals = function(renderNode, rawNode) {
       return unwrap(renderNode.node) === rawNode;
     };
@@ -3517,35 +3517,35 @@ if (WebComponents.flags.shadow) {
     }
     RenderNode.prototype = {
       append: function(node) {
-        var rv = new RenderNode(node);
+        const rv = new RenderNode(node);
         this.childNodes.push(rv);
         return rv;
       },
       sync: function(opt_added) {
         if (this.skip) return;
-        var nodeWrapper = this.node;
-        var newChildren = this.childNodes;
-        var oldChildren = getChildNodesSnapshot(unwrap(nodeWrapper));
-        var added = opt_added || new WeakMap();
-        var splices = spliceDiff.calculateSplices(newChildren, oldChildren);
-        var newIndex = 0, oldIndex = 0;
-        var lastIndex = 0;
+        const nodeWrapper = this.node;
+        const newChildren = this.childNodes;
+        const oldChildren = getChildNodesSnapshot(unwrap(nodeWrapper));
+        const added = opt_added || new WeakMap();
+        const splices = spliceDiff.calculateSplices(newChildren, oldChildren);
+        let newIndex = 0, oldIndex = 0;
+        let lastIndex = 0;
         for (var i = 0; i < splices.length; i++) {
-          var splice = splices[i];
+          const splice = splices[i];
           for (;lastIndex < splice.index; lastIndex++) {
             oldIndex++;
             newChildren[newIndex++].sync(added);
           }
-          var removedCount = splice.removed.length;
+          const removedCount = splice.removed.length;
           for (var j = 0; j < removedCount; j++) {
-            var wrapper = wrap(oldChildren[oldIndex++]);
+            const wrapper = wrap(oldChildren[oldIndex++]);
             if (!added.get(wrapper)) remove(wrapper);
           }
-          var addedCount = splice.addedCount;
-          var refNode = oldChildren[oldIndex] && wrap(oldChildren[oldIndex]);
+          const addedCount = splice.addedCount;
+          const refNode = oldChildren[oldIndex] && wrap(oldChildren[oldIndex]);
           for (var j = 0; j < addedCount; j++) {
-            var newChildRenderNode = newChildren[newIndex++];
-            var newChildWrapper = newChildRenderNode.node;
+            const newChildRenderNode = newChildren[newIndex++];
+            const newChildWrapper = newChildRenderNode.node;
             insertBefore(nodeWrapper, newChildWrapper, refNode);
             added.set(newChildWrapper, true);
             newChildRenderNode.sync(added);
@@ -3567,11 +3567,11 @@ if (WebComponents.flags.shadow) {
       render: function(opt_renderNode) {
         if (!this.dirty) return;
         this.invalidateAttributes();
-        var host = this.host;
+        const host = this.host;
         this.distribution(host);
-        var renderNode = opt_renderNode || new RenderNode(host);
+        const renderNode = opt_renderNode || new RenderNode(host);
         this.buildRenderTree(renderNode, host);
-        var topMostRenderer = !opt_renderNode;
+        const topMostRenderer = !opt_renderNode;
         if (topMostRenderer) renderNode.sync();
         this.dirty = false;
       },
@@ -3581,7 +3581,7 @@ if (WebComponents.flags.shadow) {
       invalidate: function() {
         if (!this.dirty) {
           this.dirty = true;
-          var parentRenderer = this.parentRenderer;
+          const parentRenderer = this.parentRenderer;
           if (parentRenderer) parentRenderer.invalidate();
           pendingDirtyRenderers.push(this);
           if (renderTimer) return;
@@ -3597,7 +3597,7 @@ if (WebComponents.flags.shadow) {
         this.resetAllSubtrees(node);
       },
       resetAllSubtrees: function(node) {
-        for (var child = node.firstChild; child; child = child.nextSibling) {
+        for (let child = node.firstChild; child; child = child.nextSibling) {
           this.resetAll(child);
         }
         if (node.shadowRoot) this.resetAll(node.shadowRoot);
@@ -3605,38 +3605,38 @@ if (WebComponents.flags.shadow) {
       },
       distributionResolution: function(node) {
         if (isShadowHost(node)) {
-          var shadowHost = node;
-          var pool = poolPopulation(shadowHost);
-          var shadowTrees = getShadowTrees(shadowHost);
+          const shadowHost = node;
+          let pool = poolPopulation(shadowHost);
+          const shadowTrees = getShadowTrees(shadowHost);
           for (var i = 0; i < shadowTrees.length; i++) {
             this.poolDistribution(shadowTrees[i], pool);
           }
           for (var i = shadowTrees.length - 1; i >= 0; i--) {
-            var shadowTree = shadowTrees[i];
-            var shadow = getShadowInsertionPoint(shadowTree);
+            const shadowTree = shadowTrees[i];
+            const shadow = getShadowInsertionPoint(shadowTree);
             if (shadow) {
-              var olderShadowRoot = shadowTree.olderShadowRoot;
+              const olderShadowRoot = shadowTree.olderShadowRoot;
               if (olderShadowRoot) {
                 pool = poolPopulation(olderShadowRoot);
               }
-              for (var j = 0; j < pool.length; j++) {
+              for (let j = 0; j < pool.length; j++) {
                 destributeNodeInto(pool[j], shadow);
               }
             }
             this.distributionResolution(shadowTree);
           }
         }
-        for (var child = node.firstChild; child; child = child.nextSibling) {
+        for (let child = node.firstChild; child; child = child.nextSibling) {
           this.distributionResolution(child);
         }
       },
       poolDistribution: function(node, pool) {
         if (node instanceof HTMLShadowElement) return;
         if (node instanceof HTMLContentElement) {
-          var content = node;
+          const content = node;
           this.updateDependentAttributes(content.getAttribute("select"));
-          var anyDistributed = false;
-          for (var i = 0; i < pool.length; i++) {
+          let anyDistributed = false;
+          for (let i = 0; i < pool.length; i++) {
             var node = pool[i];
             if (!node) continue;
             if (matches(node, content)) {
@@ -3657,26 +3657,26 @@ if (WebComponents.flags.shadow) {
         }
       },
       buildRenderTree: function(renderNode, node) {
-        var children = this.compose(node);
-        for (var i = 0; i < children.length; i++) {
-          var child = children[i];
-          var childRenderNode = renderNode.append(child);
+        const children = this.compose(node);
+        for (let i = 0; i < children.length; i++) {
+          const child = children[i];
+          const childRenderNode = renderNode.append(child);
           this.buildRenderTree(childRenderNode, child);
         }
         if (isShadowHost(node)) {
-          var renderer = getRendererForHost(node);
+          const renderer = getRendererForHost(node);
           renderer.dirty = false;
         }
       },
       compose: function(node) {
-        var children = [];
-        var p = node.shadowRoot || node;
-        for (var child = p.firstChild; child; child = child.nextSibling) {
+        const children = [];
+        const p = node.shadowRoot || node;
+        for (let child = p.firstChild; child; child = child.nextSibling) {
           if (isInsertionPoint(child)) {
             this.associateNode(p);
-            var distributedNodes = getDistributedNodes(child);
-            for (var j = 0; j < distributedNodes.length; j++) {
-              var distributedNode = distributedNodes[j];
+            const distributedNodes = getDistributedNodes(child);
+            for (let j = 0; j < distributedNodes.length; j++) {
+              const distributedNode = distributedNodes[j];
               if (isFinalDestination(child, distributedNode)) children.push(distributedNode);
             }
           } else {
@@ -3690,7 +3690,7 @@ if (WebComponents.flags.shadow) {
       },
       updateDependentAttributes: function(selector) {
         if (!selector) return;
-        var attributes = this.attributes;
+        const attributes = this.attributes;
         if (/\.\w+/.test(selector)) attributes["class"] = true;
         if (/#\w+/.test(selector)) attributes["id"] = true;
         selector.replace(/\[\s*([^\s=\|~\]]+)/g, function(_, name) {
@@ -3705,8 +3705,8 @@ if (WebComponents.flags.shadow) {
       }
     };
     function poolPopulation(node) {
-      var pool = [];
-      for (var child = node.firstChild; child; child = child.nextSibling) {
+      const pool = [];
+      for (let child = node.firstChild; child; child = child.nextSibling) {
         if (isInsertionPoint(child)) {
           pool.push.apply(pool, getDistributedNodes(child));
         } else {
@@ -3718,15 +3718,15 @@ if (WebComponents.flags.shadow) {
     function getShadowInsertionPoint(node) {
       if (node instanceof HTMLShadowElement) return node;
       if (node instanceof HTMLContentElement) return null;
-      for (var child = node.firstChild; child; child = child.nextSibling) {
-        var res = getShadowInsertionPoint(child);
+      for (let child = node.firstChild; child; child = child.nextSibling) {
+        const res = getShadowInsertionPoint(child);
         if (res) return res;
       }
       return null;
     }
     function destributeNodeInto(child, insertionPoint) {
       getDistributedNodes(insertionPoint).push(child);
-      var points = destinationInsertionPointsTable.get(child);
+      const points = destinationInsertionPointsTable.get(child);
       if (!points) destinationInsertionPointsTable.set(child, [ insertionPoint ]); else points.push(insertionPoint);
     }
     function getDestinationInsertionPoints(node) {
@@ -3737,7 +3737,7 @@ if (WebComponents.flags.shadow) {
     }
     var selectorStartCharRe = /^(:not\()?[*.#[a-zA-Z_|]/;
     function matches(node, contentElement) {
-      var select = contentElement.getAttribute("select");
+      let select = contentElement.getAttribute("select");
       if (!select) return true;
       select = select.trim();
       if (!select) return true;
@@ -3750,7 +3750,7 @@ if (WebComponents.flags.shadow) {
       }
     }
     function isFinalDestination(insertionPoint, node) {
-      var points = getDestinationInsertionPoints(node);
+      const points = getDestinationInsertionPoints(node);
       return points && points[points.length - 1] === insertionPoint;
     }
     function isInsertionPoint(node) {
@@ -3760,8 +3760,8 @@ if (WebComponents.flags.shadow) {
       return shadowHost.shadowRoot;
     }
     function getShadowTrees(host) {
-      var trees = [];
-      for (var tree = host.shadowRoot; tree; tree = tree.olderShadowRoot) {
+      const trees = [];
+      for (let tree = host.shadowRoot; tree; tree = tree.olderShadowRoot) {
         trees.push(tree);
       }
       return trees;
@@ -3770,7 +3770,7 @@ if (WebComponents.flags.shadow) {
       new ShadowRenderer(host).render();
     }
     Node.prototype.invalidateShadowRenderer = function(force) {
-      var renderer = unsafeUnwrap(this).polymerShadowRenderer_;
+      const renderer = unsafeUnwrap(this).polymerShadowRenderer_;
       if (renderer) {
         renderer.invalidate();
         return true;
@@ -3787,8 +3787,8 @@ if (WebComponents.flags.shadow) {
     };
     HTMLContentElement.prototype.nodeIsInserted_ = HTMLShadowElement.prototype.nodeIsInserted_ = function() {
       this.invalidateShadowRenderer();
-      var shadowRoot = getShadowRootAncestor(this);
-      var renderer;
+      const shadowRoot = getShadowRootAncestor(this);
+      let renderer;
       if (shadowRoot) renderer = getRendererForShadowRoot(shadowRoot);
       unsafeUnwrap(this).polymerShadowRenderer_ = renderer;
       if (renderer) renderer.invalidate();
@@ -3804,17 +3804,17 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var HTMLElement = scope.wrappers.HTMLElement;
-    var assert = scope.assert;
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
-    var unwrap = scope.unwrap;
-    var wrap = scope.wrap;
-    var elementsWithFormProperty = [ "HTMLButtonElement", "HTMLFieldSetElement", "HTMLInputElement", "HTMLKeygenElement", "HTMLLabelElement", "HTMLLegendElement", "HTMLObjectElement", "HTMLOutputElement", "HTMLTextAreaElement" ];
+    const HTMLElement = scope.wrappers.HTMLElement;
+    const assert = scope.assert;
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
+    const unwrap = scope.unwrap;
+    const wrap = scope.wrap;
+    const elementsWithFormProperty = [ "HTMLButtonElement", "HTMLFieldSetElement", "HTMLInputElement", "HTMLKeygenElement", "HTMLLabelElement", "HTMLLegendElement", "HTMLObjectElement", "HTMLOutputElement", "HTMLTextAreaElement" ];
     function createWrapperConstructor(name) {
       if (!window[name]) return;
       assert(!scope.wrappers[name]);
-      var GeneratedWrapper = function(node) {
+      const GeneratedWrapper = function(node) {
         HTMLElement.call(this, node);
       };
       GeneratedWrapper.prototype = Object.create(HTMLElement.prototype);
@@ -3830,13 +3830,13 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var registerWrapper = scope.registerWrapper;
-    var setWrapper = scope.setWrapper;
-    var unsafeUnwrap = scope.unsafeUnwrap;
-    var unwrap = scope.unwrap;
-    var unwrapIfNeeded = scope.unwrapIfNeeded;
-    var wrap = scope.wrap;
-    var OriginalSelection = window.Selection;
+    const registerWrapper = scope.registerWrapper;
+    const setWrapper = scope.setWrapper;
+    const unsafeUnwrap = scope.unsafeUnwrap;
+    const unwrap = scope.unwrap;
+    const unwrapIfNeeded = scope.unwrapIfNeeded;
+    const wrap = scope.wrap;
+    const OriginalSelection = window.Selection;
     function Selection(impl) {
       setWrapper(impl, this);
     }
@@ -3877,29 +3877,29 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var GetElementsByInterface = scope.GetElementsByInterface;
-    var Node = scope.wrappers.Node;
-    var ParentNodeInterface = scope.ParentNodeInterface;
-    var Selection = scope.wrappers.Selection;
-    var SelectorsInterface = scope.SelectorsInterface;
-    var ShadowRoot = scope.wrappers.ShadowRoot;
-    var TreeScope = scope.TreeScope;
-    var cloneNode = scope.cloneNode;
-    var defineWrapGetter = scope.defineWrapGetter;
-    var elementFromPoint = scope.elementFromPoint;
-    var forwardMethodsToWrapper = scope.forwardMethodsToWrapper;
-    var matchesNames = scope.matchesNames;
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
-    var renderAllPending = scope.renderAllPending;
-    var rewrap = scope.rewrap;
-    var setWrapper = scope.setWrapper;
-    var unsafeUnwrap = scope.unsafeUnwrap;
-    var unwrap = scope.unwrap;
-    var wrap = scope.wrap;
-    var wrapEventTargetMethods = scope.wrapEventTargetMethods;
-    var wrapNodeList = scope.wrapNodeList;
-    var implementationTable = new WeakMap();
+    const GetElementsByInterface = scope.GetElementsByInterface;
+    const Node = scope.wrappers.Node;
+    const ParentNodeInterface = scope.ParentNodeInterface;
+    const Selection = scope.wrappers.Selection;
+    const SelectorsInterface = scope.SelectorsInterface;
+    const ShadowRoot = scope.wrappers.ShadowRoot;
+    const TreeScope = scope.TreeScope;
+    const cloneNode = scope.cloneNode;
+    const defineWrapGetter = scope.defineWrapGetter;
+    const elementFromPoint = scope.elementFromPoint;
+    const forwardMethodsToWrapper = scope.forwardMethodsToWrapper;
+    const matchesNames = scope.matchesNames;
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
+    const renderAllPending = scope.renderAllPending;
+    const rewrap = scope.rewrap;
+    const setWrapper = scope.setWrapper;
+    const unsafeUnwrap = scope.unsafeUnwrap;
+    const unwrap = scope.unwrap;
+    const wrap = scope.wrap;
+    const wrapEventTargetMethods = scope.wrapEventTargetMethods;
+    const wrapNodeList = scope.wrapNodeList;
+    const implementationTable = new WeakMap();
     function Document(node) {
       Node.call(this, node);
       this.treeScope_ = new TreeScope(this, null);
@@ -3909,13 +3909,13 @@ if (WebComponents.flags.shadow) {
     defineWrapGetter(Document, "body");
     defineWrapGetter(Document, "head");
     function wrapMethod(name) {
-      var original = document[name];
+      const original = document[name];
       Document.prototype[name] = function() {
         return wrap(original.apply(unsafeUnwrap(this), arguments));
       };
     }
     [ "createComment", "createDocumentFragment", "createElement", "createElementNS", "createEvent", "createEventNS", "createRange", "createTextNode", "getElementById" ].forEach(wrapMethod);
-    var originalAdoptNode = document.adoptNode;
+    const originalAdoptNode = document.adoptNode;
     function adoptNodeNoRemove(node, doc) {
       originalAdoptNode.call(unsafeUnwrap(doc), unwrap(node));
       adoptSubtree(node, doc);
@@ -3923,15 +3923,15 @@ if (WebComponents.flags.shadow) {
     function adoptSubtree(node, doc) {
       if (node.shadowRoot) doc.adoptNode(node.shadowRoot);
       if (node instanceof ShadowRoot) adoptOlderShadowRoots(node, doc);
-      for (var child = node.firstChild; child; child = child.nextSibling) {
+      for (let child = node.firstChild; child; child = child.nextSibling) {
         adoptSubtree(child, doc);
       }
     }
     function adoptOlderShadowRoots(shadowRoot, doc) {
-      var oldShadowRoot = shadowRoot.olderShadowRoot;
+      const oldShadowRoot = shadowRoot.olderShadowRoot;
       if (oldShadowRoot) doc.adoptNode(oldShadowRoot);
     }
-    var originalGetSelection = document.getSelection;
+    const originalGetSelection = document.getSelection;
     mixin(Document.prototype, {
       adoptNode: function(node) {
         if (node.parentNode) node.parentNode.removeChild(node);
@@ -3953,9 +3953,9 @@ if (WebComponents.flags.shadow) {
       }
     });
     if (document.registerElement) {
-      var originalRegisterElement = document.registerElement;
+      const originalRegisterElement = document.registerElement;
       Document.prototype.registerElement = function(tagName, object) {
-        var prototype, extendsOption;
+        let prototype, extendsOption;
         if (object !== undefined) {
           prototype = object.prototype;
           extendsOption = object.extends;
@@ -3964,9 +3964,9 @@ if (WebComponents.flags.shadow) {
         if (scope.nativePrototypeTable.get(prototype)) {
           throw new Error("NotSupportedError");
         }
-        var proto = Object.getPrototypeOf(prototype);
-        var nativePrototype;
-        var prototypes = [];
+        let proto = Object.getPrototypeOf(prototype);
+        let nativePrototype;
+        const prototypes = [];
         while (proto) {
           nativePrototype = scope.nativePrototypeTable.get(proto);
           if (nativePrototype) break;
@@ -3976,12 +3976,12 @@ if (WebComponents.flags.shadow) {
         if (!nativePrototype) {
           throw new Error("NotSupportedError");
         }
-        var newPrototype = Object.create(nativePrototype);
-        for (var i = prototypes.length - 1; i >= 0; i--) {
+        let newPrototype = Object.create(nativePrototype);
+        for (let i = prototypes.length - 1; i >= 0; i--) {
           newPrototype = Object.create(newPrototype);
         }
         [ "createdCallback", "attachedCallback", "detachedCallback", "attributeChangedCallback" ].forEach(function(name) {
-          var f = prototype[name];
+          const f = prototype[name];
           if (!f) return;
           newPrototype[name] = function() {
             if (!(wrap(this) instanceof CustomElementConstructor)) {
@@ -3990,7 +3990,7 @@ if (WebComponents.flags.shadow) {
             f.apply(wrap(this), arguments);
           };
         });
-        var p = {
+        const p = {
           prototype: newPrototype
         };
         if (extendsOption) p.extends = extendsOption;
@@ -4008,7 +4008,7 @@ if (WebComponents.flags.shadow) {
         CustomElementConstructor.prototype.constructor = CustomElementConstructor;
         scope.constructorTable.set(newPrototype, CustomElementConstructor);
         scope.nativePrototypeTable.set(prototype, newPrototype);
-        var nativeConstructor = originalRegisterElement.call(unwrap(this), tagName, p);
+        const nativeConstructor = originalRegisterElement.call(unwrap(this), tagName, p);
         return CustomElementConstructor;
       };
       forwardMethodsToWrapper([ window.HTMLDocument || window.Document ], [ "registerElement" ]);
@@ -4020,7 +4020,7 @@ if (WebComponents.flags.shadow) {
     mixin(Document.prototype, SelectorsInterface);
     mixin(Document.prototype, {
       get implementation() {
-        var implementation = implementationTable.get(this);
+        let implementation = implementationTable.get(this);
         if (implementation) return implementation;
         implementation = new DOMImplementation(unwrap(this).implementation);
         implementationTable.set(this, implementation);
@@ -4037,13 +4037,13 @@ if (WebComponents.flags.shadow) {
       setWrapper(impl, this);
     }
     function wrapImplMethod(constructor, name) {
-      var original = document.implementation[name];
+      const original = document.implementation[name];
       constructor.prototype[name] = function() {
         return wrap(original.apply(unsafeUnwrap(this), arguments));
       };
     }
     function forwardImplMethod(constructor, name) {
-      var original = document.implementation[name];
+      const original = document.implementation[name];
       constructor.prototype[name] = function() {
         return original.apply(unsafeUnwrap(this), arguments);
       };
@@ -4060,18 +4060,18 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var EventTarget = scope.wrappers.EventTarget;
-    var Selection = scope.wrappers.Selection;
-    var mixin = scope.mixin;
-    var registerWrapper = scope.registerWrapper;
-    var renderAllPending = scope.renderAllPending;
-    var unwrap = scope.unwrap;
-    var unwrapIfNeeded = scope.unwrapIfNeeded;
-    var wrap = scope.wrap;
-    var OriginalWindow = window.Window;
-    var originalGetComputedStyle = window.getComputedStyle;
-    var originalGetDefaultComputedStyle = window.getDefaultComputedStyle;
-    var originalGetSelection = window.getSelection;
+    const EventTarget = scope.wrappers.EventTarget;
+    const Selection = scope.wrappers.Selection;
+    const mixin = scope.mixin;
+    const registerWrapper = scope.registerWrapper;
+    const renderAllPending = scope.renderAllPending;
+    const unwrap = scope.unwrap;
+    const unwrapIfNeeded = scope.unwrapIfNeeded;
+    const wrap = scope.wrap;
+    const OriginalWindow = window.Window;
+    const originalGetComputedStyle = window.getComputedStyle;
+    const originalGetDefaultComputedStyle = window.getDefaultComputedStyle;
+    const originalGetSelection = window.getSelection;
     function Window(impl) {
       EventTarget.call(this, impl);
     }
@@ -4092,7 +4092,7 @@ if (WebComponents.flags.shadow) {
     delete window.getSelection;
     [ "addEventListener", "removeEventListener", "dispatchEvent" ].forEach(function(name) {
       OriginalWindow.prototype[name] = function() {
-        var w = wrap(this || window);
+        const w = wrap(this || window);
         return w[name].apply(w, arguments);
       };
       delete window[name];
@@ -4121,9 +4121,9 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var unwrap = scope.unwrap;
-    var OriginalDataTransfer = window.DataTransfer || window.Clipboard;
-    var OriginalDataTransferSetDragImage = OriginalDataTransfer.prototype.setDragImage;
+    const unwrap = scope.unwrap;
+    const OriginalDataTransfer = window.DataTransfer || window.Clipboard;
+    const OriginalDataTransferSetDragImage = OriginalDataTransfer.prototype.setDragImage;
     if (OriginalDataTransferSetDragImage) {
       OriginalDataTransfer.prototype.setDragImage = function(image, x, y) {
         OriginalDataTransferSetDragImage.call(this, unwrap(image), x, y);
@@ -4132,13 +4132,13 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var registerWrapper = scope.registerWrapper;
-    var setWrapper = scope.setWrapper;
-    var unwrap = scope.unwrap;
-    var OriginalFormData = window.FormData;
+    const registerWrapper = scope.registerWrapper;
+    const setWrapper = scope.setWrapper;
+    const unwrap = scope.unwrap;
+    const OriginalFormData = window.FormData;
     if (!OriginalFormData) return;
     function FormData(formElement) {
-      var impl;
+      let impl;
       if (formElement instanceof OriginalFormData) {
         impl = formElement;
       } else {
@@ -4151,16 +4151,16 @@ if (WebComponents.flags.shadow) {
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var unwrapIfNeeded = scope.unwrapIfNeeded;
-    var originalSend = XMLHttpRequest.prototype.send;
+    const unwrapIfNeeded = scope.unwrapIfNeeded;
+    const originalSend = XMLHttpRequest.prototype.send;
     XMLHttpRequest.prototype.send = function(obj) {
       return originalSend.call(this, unwrapIfNeeded(obj));
     };
   })(window.ShadowDOMPolyfill);
   (function(scope) {
     "use strict";
-    var isWrapperFor = scope.isWrapperFor;
-    var elements = {
+    const isWrapperFor = scope.isWrapperFor;
+    const elements = {
       a: "HTMLAnchorElement",
       area: "HTMLAreaElement",
       audio: "HTMLAudioElement",
@@ -4231,11 +4231,11 @@ if (WebComponents.flags.shadow) {
       video: "HTMLVideoElement"
     };
     function overrideConstructor(tagName) {
-      var nativeConstructorName = elements[tagName];
-      var nativeConstructor = window[nativeConstructorName];
+      const nativeConstructorName = elements[tagName];
+      const nativeConstructor = window[nativeConstructorName];
       if (!nativeConstructor) return;
-      var element = document.createElement(tagName);
-      var wrapperConstructor = element.constructor;
+      const element = document.createElement(tagName);
+      const wrapperConstructor = element.constructor;
       window[nativeConstructorName] = wrapperConstructor;
     }
     Object.keys(elements).forEach(overrideConstructor);
@@ -4244,14 +4244,14 @@ if (WebComponents.flags.shadow) {
     });
   })(window.ShadowDOMPolyfill);
   (function(scope) {
-    var ShadowCSS = {
+    const ShadowCSS = {
       strictStyling: false,
       registry: {},
       shimStyling: function(root, name, extendsName) {
-        var scopeStyles = this.prepareRoot(root, name, extendsName);
-        var typeExtension = this.isTypeExtension(extendsName);
-        var scopeSelector = this.makeScopeSelector(name, typeExtension);
-        var cssText = stylesToCssText(scopeStyles, true);
+        const scopeStyles = this.prepareRoot(root, name, extendsName);
+        const typeExtension = this.isTypeExtension(extendsName);
+        const scopeSelector = this.makeScopeSelector(name, typeExtension);
+        let cssText = stylesToCssText(scopeStyles, true);
         cssText = this.scopeCssText(cssText, scopeSelector);
         if (root) {
           root.shimmedStyle = cssText;
@@ -4275,7 +4275,7 @@ if (WebComponents.flags.shadow) {
         return extendsName && extendsName.indexOf("-") < 0;
       },
       prepareRoot: function(root, name, extendsName) {
-        var def = this.registerRoot(root, name, extendsName);
+        const def = this.registerRoot(root, name, extendsName);
         this.replaceTextInStyles(def.rootStyles, this.insertDirectives);
         this.removeStyles(root, def.rootStyles);
         if (this.strictStyling) {
@@ -4284,20 +4284,20 @@ if (WebComponents.flags.shadow) {
         return def.scopeStyles;
       },
       removeStyles: function(root, styles) {
-        for (var i = 0, l = styles.length, s; i < l && (s = styles[i]); i++) {
+        for (let i = 0, l = styles.length, s; i < l && (s = styles[i]); i++) {
           s.parentNode.removeChild(s);
         }
       },
       registerRoot: function(root, name, extendsName) {
-        var def = this.registry[name] = {
+        const def = this.registry[name] = {
           root: root,
           name: name,
           extendsName: extendsName
         };
-        var styles = this.findStyles(root);
+        const styles = this.findStyles(root);
         def.rootStyles = styles;
         def.scopeStyles = def.rootStyles;
-        var extendee = this.registry[def.extendsName];
+        const extendee = this.registry[def.extendsName];
         if (extendee) {
           def.scopeStyles = extendee.scopeStyles.concat(def.scopeStyles);
         }
@@ -4307,7 +4307,7 @@ if (WebComponents.flags.shadow) {
         if (!root) {
           return [];
         }
-        var styles = root.querySelectorAll("style");
+        const styles = root.querySelectorAll("style");
         return Array.prototype.filter.call(styles, function(s) {
           return !s.hasAttribute(NO_SHIM_ATTRIBUTE);
         });
@@ -4339,12 +4339,12 @@ if (WebComponents.flags.shadow) {
           return p1.slice(0, -1);
         });
         return cssText.replace(cssContentRuleRe, function(match, p1, p2, p3) {
-          var rule = match.replace(p1, "").replace(p2, "");
+          const rule = match.replace(p1, "").replace(p2, "");
           return p3 + rule;
         });
       },
       scopeCssText: function(cssText, scopeSelector) {
-        var unscoped = this.extractUnscopedRulesFromCssText(cssText);
+        const unscoped = this.extractUnscopedRulesFromCssText(cssText);
         cssText = this.insertPolyfillHostInCssText(cssText);
         cssText = this.convertColonHost(cssText);
         cssText = this.convertColonHostContext(cssText);
@@ -4359,7 +4359,7 @@ if (WebComponents.flags.shadow) {
         return cssText.trim();
       },
       extractUnscopedRulesFromCssText: function(cssText) {
-        var r = "", m;
+        let r = "", m;
         while (m = cssCommentUnscopedRuleRe.exec(cssText)) {
           r += m[1].slice(0, -1) + "\n\n";
         }
@@ -4378,8 +4378,8 @@ if (WebComponents.flags.shadow) {
         return cssText.replace(regExp, function(m, p1, p2, p3) {
           p1 = polyfillHostNoCombinator;
           if (p2) {
-            var parts = p2.split(","), r = [];
-            for (var i = 0, l = parts.length, p; i < l && (p = parts[i]); i++) {
+            const parts = p2.split(","), r = [];
+            for (let i = 0, l = parts.length, p; i < l && (p = parts[i]); i++) {
               p = p.trim();
               r.push(partReplacer(p1, p, p3));
             }
@@ -4400,13 +4400,13 @@ if (WebComponents.flags.shadow) {
         return host + part.replace(polyfillHost, "") + suffix;
       },
       convertShadowDOMSelectors: function(cssText) {
-        for (var i = 0; i < shadowDOMSelectorsRe.length; i++) {
+        for (let i = 0; i < shadowDOMSelectorsRe.length; i++) {
           cssText = cssText.replace(shadowDOMSelectorsRe[i], " ");
         }
         return cssText;
       },
       scopeRules: function(cssRules, scopeSelector) {
-        var cssText = "";
+        let cssText = "";
         if (cssRules) {
           Array.prototype.forEach.call(cssRules, function(rule) {
             if (rule.selectorText && (rule.style && rule.style.cssText !== undefined)) {
@@ -4432,7 +4432,7 @@ if (WebComponents.flags.shadow) {
         return cssText;
       },
       ieSafeCssTextFromKeyFrameRule: function(rule) {
-        var cssText = "@keyframes " + rule.name + " {";
+        let cssText = "@keyframes " + rule.name + " {";
         Array.prototype.forEach.call(rule.cssRules, function(rule) {
           cssText += " " + rule.keyText + " {" + rule.style.cssText + "}";
         });
@@ -4440,7 +4440,7 @@ if (WebComponents.flags.shadow) {
         return cssText;
       },
       scopeSelector: function(selector, scopeSelector, strict) {
-        var r = [], parts = selector.split(",");
+        const r = [], parts = selector.split(",");
         parts.forEach(function(p) {
           p = p.trim();
           if (this.selectorNeedsScoping(p, scopeSelector)) {
@@ -4454,7 +4454,7 @@ if (WebComponents.flags.shadow) {
         if (Array.isArray(scopeSelector)) {
           return true;
         }
-        var re = this.makeScopeMatcher(scopeSelector);
+        const re = this.makeScopeMatcher(scopeSelector);
         return !selector.match(re);
       },
       makeScopeMatcher: function(scopeSelector) {
@@ -4465,8 +4465,8 @@ if (WebComponents.flags.shadow) {
         return Array.isArray(selectorScope) ? this.applySelectorScopeList(selector, selectorScope) : this.applySimpleSelectorScope(selector, selectorScope);
       },
       applySelectorScopeList: function(selector, scopeSelectorList) {
-        var r = [];
-        for (var i = 0, s; s = scopeSelectorList[i]; i++) {
+        const r = [];
+        for (let i = 0, s; s = scopeSelectorList[i]; i++) {
           r.push(this.applySimpleSelectorScope(selector, s));
         }
         return r.join(", ");
@@ -4481,11 +4481,11 @@ if (WebComponents.flags.shadow) {
       },
       applyStrictSelectorScope: function(selector, scopeSelector) {
         scopeSelector = scopeSelector.replace(/\[is=([^\]]*)\]/g, "$1");
-        var splits = [ " ", ">", "+", "~" ], scoped = selector, attrName = "[" + scopeSelector + "]";
+        let splits = [ " ", ">", "+", "~" ], scoped = selector, attrName = "[" + scopeSelector + "]";
         splits.forEach(function(sep) {
-          var parts = scoped.split(sep);
+          const parts = scoped.split(sep);
           scoped = parts.map(function(p) {
-            var t = p.trim().replace(polyfillHostRe, "");
+            const t = p.trim().replace(polyfillHostRe, "");
             if (t && splits.indexOf(t) < 0 && t.indexOf(attrName) < 0) {
               p = t.replace(/([^:]*)(:*)(.*)/, "$1" + attrName + "$2$3");
             }
@@ -4498,12 +4498,12 @@ if (WebComponents.flags.shadow) {
         return selector.replace(colonHostContextRe, polyfillHostContext).replace(colonHostRe, polyfillHost);
       },
       propertiesFromRule: function(rule) {
-        var cssText = rule.style.cssText;
+        let cssText = rule.style.cssText;
         if (rule.style.content && !rule.style.content.match(/['"]+|attr/)) {
           cssText = cssText.replace(/content:[^;]*;/g, "content: '" + rule.style.content + "';");
         }
         var style = rule.style;
-        for (var i in style) {
+        for (let i in style) {
           if (style[i] === "initial") {
             cssText += i + ": initial; ";
           }
@@ -4529,9 +4529,9 @@ if (WebComponents.flags.shadow) {
       }
     };
     var selectorRe = /([^{]*)({[\s\S]*?})/gim, cssCommentRe = /\/\*[^*]*\*+([^/*][^*]*\*+)*\//gim, cssCommentNextSelectorRe = /\/\*\s*@polyfill ([^*]*\*+([^/*][^*]*\*+)*\/)([^{]*?){/gim, cssContentNextSelectorRe = /polyfill-next-selector[^}]*content\:[\s]*?['"](.*?)['"][;\s]*}([^{]*?){/gim, cssCommentRuleRe = /\/\*\s@polyfill-rule([^*]*\*+([^/*][^*]*\*+)*)\//gim, cssContentRuleRe = /(polyfill-rule)[^}]*(content\:[\s]*['"](.*?)['"])[;\s]*[^}]*}/gim, cssCommentUnscopedRuleRe = /\/\*\s@polyfill-unscoped-rule([^*]*\*+([^/*][^*]*\*+)*)\//gim, cssContentUnscopedRuleRe = /(polyfill-unscoped-rule)[^}]*(content\:[\s]*['"](.*?)['"])[;\s]*[^}]*}/gim, cssPseudoRe = /::(x-[^\s{,(]*)/gim, cssPartRe = /::part\(([^)]*)\)/gim, polyfillHost = "-shadowcsshost", polyfillHostContext = "-shadowcsscontext", parenSuffix = ")(?:\\((" + "(?:\\([^)(]*\\)|[^)(]*)+?" + ")\\))?([^,{]*)";
-    var cssColonHostRe = new RegExp("(" + polyfillHost + parenSuffix, "gim"), cssColonHostContextRe = new RegExp("(" + polyfillHostContext + parenSuffix, "gim"), selectorReSuffix = "([>\\s~+[.,{:][\\s\\S]*)?$", colonHostRe = /\:host/gim, colonHostContextRe = /\:host-context/gim, polyfillHostNoCombinator = polyfillHost + "-no-combinator", polyfillHostRe = new RegExp(polyfillHost, "gim"), polyfillHostContextRe = new RegExp(polyfillHostContext, "gim"), shadowDOMSelectorsRe = [ /\^\^/g, /\^/g, /\/shadow\//g, /\/shadow-deep\//g, /::shadow/g, /\/deep\//g, /::content/g ];
+    const cssColonHostRe = new RegExp("(" + polyfillHost + parenSuffix, "gim"), cssColonHostContextRe = new RegExp("(" + polyfillHostContext + parenSuffix, "gim"), selectorReSuffix = "([>\\s~+[.,{:][\\s\\S]*)?$", colonHostRe = /\:host/gim, colonHostContextRe = /\:host-context/gim, polyfillHostNoCombinator = polyfillHost + "-no-combinator", polyfillHostRe = new RegExp(polyfillHost, "gim"), polyfillHostContextRe = new RegExp(polyfillHostContext, "gim"), shadowDOMSelectorsRe = [ /\^\^/g, /\^/g, /\/shadow\//g, /\/shadow-deep\//g, /::shadow/g, /\/deep\//g, /::content/g ];
     function stylesToCssText(styles, preserveComments) {
-      var cssText = "";
+      let cssText = "";
       Array.prototype.forEach.call(styles, function(s) {
         cssText += s.textContent + "\n\n";
       });
@@ -4541,14 +4541,14 @@ if (WebComponents.flags.shadow) {
       return cssText;
     }
     function cssTextToStyle(cssText) {
-      var style = document.createElement("style");
+      const style = document.createElement("style");
       style.textContent = cssText;
       return style;
     }
     function cssToRules(cssText) {
-      var style = cssTextToStyle(cssText);
+      const style = cssTextToStyle(cssText);
       document.head.appendChild(style);
-      var rules = [];
+      let rules = [];
       if (style.sheet) {
         try {
           rules = style.sheet.cssRules;
@@ -4559,13 +4559,13 @@ if (WebComponents.flags.shadow) {
       style.parentNode.removeChild(style);
       return rules;
     }
-    var frame = document.createElement("iframe");
+    const frame = document.createElement("iframe");
     frame.style.display = "none";
     function initFrame() {
       frame.initialized = true;
       document.body.appendChild(frame);
-      var doc = frame.contentDocument;
-      var base = doc.createElement("base");
+      const doc = frame.contentDocument;
+      const base = doc.createElement("base");
       base.href = document.baseURI;
       doc.head.appendChild(base);
     }
@@ -4582,9 +4582,9 @@ if (WebComponents.flags.shadow) {
       if (!callback) {
         return;
       }
-      var rules;
+      let rules;
       if (cssText.match("@import") && isChrome) {
-        var style = cssTextToStyle(cssText);
+        const style = cssTextToStyle(cssText);
         inFrame(function(doc) {
           doc.head.appendChild(style.impl);
           rules = Array.prototype.slice.call(style.sheet.cssRules, 0);
@@ -4607,14 +4607,14 @@ if (WebComponents.flags.shadow) {
       }
     }
     function addOwnSheet(cssText, name) {
-      var style = cssTextToStyle(cssText);
+      const style = cssTextToStyle(cssText);
       style.setAttribute(name, "");
       style.setAttribute(SHIMMED_ATTRIBUTE, "");
       document.head.appendChild(style);
     }
-    var SHIM_ATTRIBUTE = "shim-shadowdom";
+    const SHIM_ATTRIBUTE = "shim-shadowdom";
     var SHIMMED_ATTRIBUTE = "shim-shadowdom-css";
-    var NO_SHIM_ATTRIBUTE = "no-shim";
+    const NO_SHIM_ATTRIBUTE = "no-shim";
     var sheet;
     function getSheet() {
       if (!sheet) {
@@ -4630,19 +4630,19 @@ if (WebComponents.flags.shadow) {
       var head = doc.querySelector("head");
       head.insertBefore(getSheet(), head.childNodes[0]);
       document.addEventListener("DOMContentLoaded", function() {
-        var urlResolver = scope.urlResolver;
+        const urlResolver = scope.urlResolver;
         if (window.HTMLImports && !HTMLImports.useNative) {
-          var SHIM_SHEET_SELECTOR = "link[rel=stylesheet]" + "[" + SHIM_ATTRIBUTE + "]";
-          var SHIM_STYLE_SELECTOR = "style[" + SHIM_ATTRIBUTE + "]";
+          const SHIM_SHEET_SELECTOR = "link[rel=stylesheet]" + "[" + SHIM_ATTRIBUTE + "]";
+          const SHIM_STYLE_SELECTOR = "style[" + SHIM_ATTRIBUTE + "]";
           HTMLImports.importer.documentPreloadSelectors += "," + SHIM_SHEET_SELECTOR;
           HTMLImports.importer.importsPreloadSelectors += "," + SHIM_SHEET_SELECTOR;
           HTMLImports.parser.documentSelectors = [ HTMLImports.parser.documentSelectors, SHIM_SHEET_SELECTOR, SHIM_STYLE_SELECTOR ].join(",");
-          var originalParseGeneric = HTMLImports.parser.parseGeneric;
+          const originalParseGeneric = HTMLImports.parser.parseGeneric;
           HTMLImports.parser.parseGeneric = function(elt) {
             if (elt[SHIMMED_ATTRIBUTE]) {
               return;
             }
-            var style = elt.__importElement || elt;
+            let style = elt.__importElement || elt;
             if (!style.hasAttribute(SHIM_ATTRIBUTE)) {
               originalParseGeneric.call(this, elt);
               return;
@@ -4667,7 +4667,7 @@ if (WebComponents.flags.shadow) {
             this.markParsingComplete(elt);
             this.parseNext();
           };
-          var hasResource = HTMLImports.parser.hasResource;
+          const hasResource = HTMLImports.parser.hasResource;
           HTMLImports.parser.hasResource = function(node) {
             if (node.localName === "link" && node.rel === "stylesheet" && node.hasAttribute(SHIM_ATTRIBUTE)) {
               return node.__resource;
@@ -4694,18 +4694,18 @@ if (WebComponents.flags.shadow) {
 })(window.WebComponents);
 
 (function(global) {
-  var registrationsTable = new WeakMap();
-  var setImmediate;
+  const registrationsTable = new WeakMap();
+  let setImmediate;
   if (/Trident/.test(navigator.userAgent)) {
     setImmediate = setTimeout;
   } else if (window.setImmediate) {
     setImmediate = window.setImmediate;
   } else {
-    var setImmediateQueue = [];
-    var sentinel = String(Math.random());
+    let setImmediateQueue = [];
+    const sentinel = String(Math.random());
     window.addEventListener("message", function(e) {
       if (e.data === sentinel) {
-        var queue = setImmediateQueue;
+        const queue = setImmediateQueue;
         setImmediateQueue = [];
         queue.forEach(function(func) {
           func();
@@ -4717,8 +4717,8 @@ if (WebComponents.flags.shadow) {
       window.postMessage(sentinel, "*");
     };
   }
-  var isScheduled = false;
-  var scheduledObservers = [];
+  let isScheduled = false;
+  let scheduledObservers = [];
   function scheduleCallback(observer) {
     scheduledObservers.push(observer);
     if (!isScheduled) {
@@ -4731,14 +4731,14 @@ if (WebComponents.flags.shadow) {
   }
   function dispatchCallbacks() {
     isScheduled = false;
-    var observers = scheduledObservers;
+    const observers = scheduledObservers;
     scheduledObservers = [];
     observers.sort(function(o1, o2) {
       return o1.uid_ - o2.uid_;
     });
-    var anyNonEmpty = false;
+    let anyNonEmpty = false;
     observers.forEach(function(observer) {
-      var queue = observer.takeRecords();
+      const queue = observer.takeRecords();
       removeTransientObserversFor(observer);
       if (queue.length) {
         observer.callback_(queue, observer);
@@ -4749,7 +4749,7 @@ if (WebComponents.flags.shadow) {
   }
   function removeTransientObserversFor(observer) {
     observer.nodes_.forEach(function(node) {
-      var registrations = registrationsTable.get(node);
+      const registrations = registrationsTable.get(node);
       if (!registrations) return;
       registrations.forEach(function(registration) {
         if (registration.observer === observer) registration.removeTransientObservers();
@@ -4757,20 +4757,20 @@ if (WebComponents.flags.shadow) {
     });
   }
   function forEachAncestorAndObserverEnqueueRecord(target, callback) {
-    for (var node = target; node; node = node.parentNode) {
-      var registrations = registrationsTable.get(node);
+    for (let node = target; node; node = node.parentNode) {
+      const registrations = registrationsTable.get(node);
       if (registrations) {
-        for (var j = 0; j < registrations.length; j++) {
-          var registration = registrations[j];
-          var options = registration.options;
+        for (let j = 0; j < registrations.length; j++) {
+          const registration = registrations[j];
+          const options = registration.options;
           if (node !== target && !options.subtree) continue;
-          var record = callback(options);
+          const record = callback(options);
           if (record) registration.enqueue(record);
         }
       }
     }
   }
-  var uidCounter = 0;
+  let uidCounter = 0;
   function JsMutationObserver(callback) {
     this.callback_ = callback;
     this.nodes_ = [];
@@ -4783,10 +4783,10 @@ if (WebComponents.flags.shadow) {
       if (!options.childList && !options.attributes && !options.characterData || options.attributeOldValue && !options.attributes || options.attributeFilter && options.attributeFilter.length && !options.attributes || options.characterDataOldValue && !options.characterData) {
         throw new SyntaxError();
       }
-      var registrations = registrationsTable.get(target);
+      let registrations = registrationsTable.get(target);
       if (!registrations) registrationsTable.set(target, registrations = []);
-      var registration;
-      for (var i = 0; i < registrations.length; i++) {
+      let registration;
+      for (let i = 0; i < registrations.length; i++) {
         if (registrations[i].observer === this) {
           registration = registrations[i];
           registration.removeListeners();
@@ -4803,9 +4803,9 @@ if (WebComponents.flags.shadow) {
     },
     disconnect: function() {
       this.nodes_.forEach(function(node) {
-        var registrations = registrationsTable.get(node);
-        for (var i = 0; i < registrations.length; i++) {
-          var registration = registrations[i];
+        const registrations = registrationsTable.get(node);
+        for (let i = 0; i < registrations.length; i++) {
+          const registration = registrations[i];
           if (registration.observer === this) {
             registration.removeListeners();
             registrations.splice(i, 1);
@@ -4816,7 +4816,7 @@ if (WebComponents.flags.shadow) {
       this.records_ = [];
     },
     takeRecords: function() {
-      var copyOfRecords = this.records_;
+      const copyOfRecords = this.records_;
       this.records_ = [];
       return copyOfRecords;
     }
@@ -4833,7 +4833,7 @@ if (WebComponents.flags.shadow) {
     this.oldValue = null;
   }
   function copyMutationRecord(original) {
-    var record = new MutationRecord(original.type, original.target);
+    const record = new MutationRecord(original.type, original.target);
     record.addedNodes = original.addedNodes.slice();
     record.removedNodes = original.removedNodes.slice();
     record.previousSibling = original.previousSibling;
@@ -4843,7 +4843,7 @@ if (WebComponents.flags.shadow) {
     record.oldValue = original.oldValue;
     return record;
   }
-  var currentRecord, recordWithOldValue;
+  let currentRecord, recordWithOldValue;
   function getRecord(type, target) {
     return currentRecord = new MutationRecord(type, target);
   }
@@ -4872,11 +4872,11 @@ if (WebComponents.flags.shadow) {
   }
   Registration.prototype = {
     enqueue: function(record) {
-      var records = this.observer.records_;
-      var length = records.length;
+      const records = this.observer.records_;
+      const length = records.length;
       if (records.length > 0) {
-        var lastRecord = records[length - 1];
-        var recordToReplaceLast = selectRecord(lastRecord, record);
+        const lastRecord = records[length - 1];
+        const recordToReplaceLast = selectRecord(lastRecord, record);
         if (recordToReplaceLast) {
           records[length - 1] = recordToReplaceLast;
           return;
@@ -4890,7 +4890,7 @@ if (WebComponents.flags.shadow) {
       this.addListeners_(this.target);
     },
     addListeners_: function(node) {
-      var options = this.options;
+      const options = this.options;
       if (options.attributes) node.addEventListener("DOMAttrModified", this, true);
       if (options.characterData) node.addEventListener("DOMCharacterDataModified", this, true);
       if (options.childList) node.addEventListener("DOMNodeInserted", this, true);
@@ -4900,7 +4900,7 @@ if (WebComponents.flags.shadow) {
       this.removeListeners_(this.target);
     },
     removeListeners_: function(node) {
-      var options = this.options;
+      const options = this.options;
       if (options.attributes) node.removeEventListener("DOMAttrModified", this, true);
       if (options.characterData) node.removeEventListener("DOMCharacterDataModified", this, true);
       if (options.childList) node.removeEventListener("DOMNodeInserted", this, true);
@@ -4910,17 +4910,17 @@ if (WebComponents.flags.shadow) {
       if (node === this.target) return;
       this.addListeners_(node);
       this.transientObservedNodes.push(node);
-      var registrations = registrationsTable.get(node);
+      let registrations = registrationsTable.get(node);
       if (!registrations) registrationsTable.set(node, registrations = []);
       registrations.push(this);
     },
     removeTransientObservers: function() {
-      var transientObservedNodes = this.transientObservedNodes;
+      const transientObservedNodes = this.transientObservedNodes;
       this.transientObservedNodes = [];
       transientObservedNodes.forEach(function(node) {
         this.removeListeners_(node);
-        var registrations = registrationsTable.get(node);
-        for (var i = 0; i < registrations.length; i++) {
+        const registrations = registrationsTable.get(node);
+        for (let i = 0; i < registrations.length; i++) {
           if (registrations[i] === this) {
             registrations.splice(i, 1);
             break;
@@ -4932,8 +4932,8 @@ if (WebComponents.flags.shadow) {
       e.stopImmediatePropagation();
       switch (e.type) {
        case "DOMAttrModified":
-        var name = e.attrName;
-        var namespace = e.relatedNode.namespaceURI;
+        const name = e.attrName;
+        const namespace = e.relatedNode.namespaceURI;
         var target = e.target;
         var record = new getRecord("attributes", target);
         record.attributeName = name;
@@ -4965,8 +4965,8 @@ if (WebComponents.flags.shadow) {
 
        case "DOMNodeInserted":
         var target = e.relatedNode;
-        var changedNode = e.target;
-        var addedNodes, removedNodes;
+        const changedNode = e.target;
+        let addedNodes, removedNodes;
         if (e.type === "DOMNodeInserted") {
           addedNodes = [ changedNode ];
           removedNodes = [];
@@ -4974,8 +4974,8 @@ if (WebComponents.flags.shadow) {
           addedNodes = [];
           removedNodes = [ changedNode ];
         }
-        var previousSibling = changedNode.previousSibling;
-        var nextSibling = changedNode.nextSibling;
+        const previousSibling = changedNode.previousSibling;
+        const nextSibling = changedNode.nextSibling;
         var record = getRecord("childList", target);
         record.addedNodes = addedNodes;
         record.removedNodes = removedNodes;
@@ -4998,23 +4998,23 @@ window.HTMLImports = window.HTMLImports || {
 };
 
 (function(scope) {
-  var IMPORT_LINK_TYPE = "import";
-  var useNative = Boolean(IMPORT_LINK_TYPE in document.createElement("link"));
-  var hasShadowDOMPolyfill = Boolean(window.ShadowDOMPolyfill);
-  var wrap = function(node) {
+  const IMPORT_LINK_TYPE = "import";
+  const useNative = Boolean(IMPORT_LINK_TYPE in document.createElement("link"));
+  const hasShadowDOMPolyfill = Boolean(window.ShadowDOMPolyfill);
+  const wrap = function(node) {
     return hasShadowDOMPolyfill ? ShadowDOMPolyfill.wrapIfNeeded(node) : node;
   };
-  var rootDocument = wrap(document);
-  var currentScriptDescriptor = {
+  const rootDocument = wrap(document);
+  const currentScriptDescriptor = {
     get: function() {
-      var script = HTMLImports.currentScript || document.currentScript || (document.readyState !== "complete" ? document.scripts[document.scripts.length - 1] : null);
+      const script = HTMLImports.currentScript || document.currentScript || (document.readyState !== "complete" ? document.scripts[document.scripts.length - 1] : null);
       return wrap(script);
     },
     configurable: true
   };
   Object.defineProperty(document, "_currentScript", currentScriptDescriptor);
   Object.defineProperty(rootDocument, "_currentScript", currentScriptDescriptor);
-  var isIE = /Trident/.test(navigator.userAgent);
+  const isIE = /Trident/.test(navigator.userAgent);
   function whenReady(callback, doc) {
     doc = doc || rootDocument;
     whenDocumentReady(function() {
@@ -5028,7 +5028,7 @@ window.HTMLImports = window.HTMLImports || {
   }
   function whenDocumentReady(callback, doc) {
     if (!isDocumentReady(doc)) {
-      var checkReady = function() {
+      const checkReady = function() {
         if (doc.readyState === "complete" || doc.readyState === requiredReadyState) {
           doc.removeEventListener(READY_EVENT, checkReady);
           whenDocumentReady(callback, doc);
@@ -5043,8 +5043,8 @@ window.HTMLImports = window.HTMLImports || {
     event.target.__loaded = true;
   }
   function watchImportsLoad(callback, doc) {
-    var imports = doc.querySelectorAll("link[rel=import]");
-    var loaded = 0, l = imports.length;
+    const imports = doc.querySelectorAll("link[rel=import]");
+    let loaded = 0, l = imports.length;
     function checkDone(d) {
       if (loaded == l && callback) {
         callback();
@@ -5056,7 +5056,7 @@ window.HTMLImports = window.HTMLImports || {
       checkDone();
     }
     if (l) {
-      for (var i = 0, imp; i < l && (imp = imports[i]); i++) {
+      for (let i = 0, imp; i < l && (imp = imports[i]); i++) {
         if (isImportLoaded(imp)) {
           loadedImport.call(imp, {
             target: imp
@@ -5075,7 +5075,7 @@ window.HTMLImports = window.HTMLImports || {
   }
   if (useNative) {
     new MutationObserver(function(mxns) {
-      for (var i = 0, l = mxns.length, m; i < l && (m = mxns[i]); i++) {
+      for (let i = 0, l = mxns.length, m; i < l && (m = mxns[i]); i++) {
         if (m.addedNodes) {
           handleImports(m.addedNodes);
         }
@@ -5084,7 +5084,7 @@ window.HTMLImports = window.HTMLImports || {
       childList: true
     });
     function handleImports(nodes) {
-      for (var i = 0, l = nodes.length, n; i < l && (n = nodes[i]); i++) {
+      for (let i = 0, l = nodes.length, n; i < l && (n = nodes[i]); i++) {
         if (isImport(n)) {
           handleImport(n);
         }
@@ -5094,7 +5094,7 @@ window.HTMLImports = window.HTMLImports || {
       return element.localName === "link" && element.rel === "import";
     }
     function handleImport(element) {
-      var loaded = element.import;
+      const loaded = element.import;
       if (loaded) {
         markTargetLoaded({
           target: element
@@ -5106,8 +5106,8 @@ window.HTMLImports = window.HTMLImports || {
     }
     (function() {
       if (document.readyState === "loading") {
-        var imports = document.querySelectorAll("link[rel=import]");
-        for (var i = 0, l = imports.length, imp; i < l && (imp = imports[i]); i++) {
+        const imports = document.querySelectorAll("link[rel=import]");
+        for (let i = 0, l = imports.length, imp; i < l && (imp = imports[i]); i++) {
           handleImport(imp);
         }
       }
@@ -5128,11 +5128,11 @@ window.HTMLImports = window.HTMLImports || {
 })(HTMLImports);
 
 (function(scope) {
-  var modules = [];
-  var addModule = function(module) {
+  const modules = [];
+  const addModule = function(module) {
     modules.push(module);
   };
-  var initializeModules = function() {
+  const initializeModules = function() {
     modules.forEach(function(module) {
       module(scope);
     });
@@ -5142,23 +5142,23 @@ window.HTMLImports = window.HTMLImports || {
 })(HTMLImports);
 
 HTMLImports.addModule(function(scope) {
-  var CSS_URL_REGEXP = /(url\()([^)]*)(\))/g;
-  var CSS_IMPORT_REGEXP = /(@import[\s]+(?!url\())([^;]*)(;)/g;
-  var path = {
+  const CSS_URL_REGEXP = /(url\()([^)]*)(\))/g;
+  const CSS_IMPORT_REGEXP = /(@import[\s]+(?!url\())([^;]*)(;)/g;
+  const path = {
     resolveUrlsInStyle: function(style) {
-      var doc = style.ownerDocument;
-      var resolver = doc.createElement("a");
+      const doc = style.ownerDocument;
+      const resolver = doc.createElement("a");
       style.textContent = this.resolveUrlsInCssText(style.textContent, resolver);
       return style;
     },
     resolveUrlsInCssText: function(cssText, urlObj) {
-      var r = this.replaceUrls(cssText, urlObj, CSS_URL_REGEXP);
+      let r = this.replaceUrls(cssText, urlObj, CSS_URL_REGEXP);
       r = this.replaceUrls(r, urlObj, CSS_IMPORT_REGEXP);
       return r;
     },
     replaceUrls: function(text, urlObj, regexp) {
       return text.replace(regexp, function(m, pre, url, post) {
-        var urlPath = url.replace(/["']/g, "");
+        let urlPath = url.replace(/["']/g, "");
         urlObj.href = urlPath;
         urlPath = urlObj.href;
         return pre + "'" + urlPath + "'" + post;
@@ -5175,14 +5175,14 @@ HTMLImports.addModule(function(scope) {
       return request.status >= 200 && request.status < 300 || request.status === 304 || request.status === 0;
     },
     load: function(url, next, nextContext) {
-      var request = new XMLHttpRequest();
+      const request = new XMLHttpRequest();
       if (scope.flags.debug || scope.flags.bust) {
         url += "?" + Math.random();
       }
       request.open("GET", url, xhr.async);
       request.addEventListener("readystatechange", function(e) {
         if (request.readyState === 4) {
-          var locationHeader = request.getResponseHeader("Location");
+          const locationHeader = request.getResponseHeader("Location");
           var redirectedUrl = null;
           if (locationHeader) {
             var redirectedUrl = locationHeader.substr(0, 1) === "/" ? location.origin + locationHeader : locationHeader;
@@ -5201,9 +5201,9 @@ HTMLImports.addModule(function(scope) {
 });
 
 HTMLImports.addModule(function(scope) {
-  var xhr = scope.xhr;
-  var flags = scope.flags;
-  var Loader = function(onLoad, onComplete) {
+  const xhr = scope.xhr;
+  const flags = scope.flags;
+  const Loader = function(onLoad, onComplete) {
     this.cache = {};
     this.onload = onLoad;
     this.oncomplete = onComplete;
@@ -5213,7 +5213,7 @@ HTMLImports.addModule(function(scope) {
   Loader.prototype = {
     addNodes: function(nodes) {
       this.inflight += nodes.length;
-      for (var i = 0, l = nodes.length, n; i < l && (n = nodes[i]); i++) {
+      for (let i = 0, l = nodes.length, n; i < l && (n = nodes[i]); i++) {
         this.require(n);
       }
       this.checkDone();
@@ -5224,7 +5224,7 @@ HTMLImports.addModule(function(scope) {
       this.checkDone();
     },
     require: function(elt) {
-      var url = elt.src || elt.href;
+      const url = elt.src || elt.href;
       elt.__nodeUrl = url;
       if (!this.dedupe(url, elt)) {
         this.fetch(url, elt);
@@ -5235,7 +5235,7 @@ HTMLImports.addModule(function(scope) {
         this.pending[url].push(elt);
         return true;
       }
-      var resource;
+      let resource;
       if (this.cache[url]) {
         this.onload(url, elt, this.cache[url]);
         this.tail();
@@ -5247,9 +5247,9 @@ HTMLImports.addModule(function(scope) {
     fetch: function(url, elt) {
       flags.load && console.log("fetch", url, elt);
       if (url.match(/^data:/)) {
-        var pieces = url.split(",");
-        var header = pieces[0];
-        var body = pieces[1];
+        const pieces = url.split(",");
+        const header = pieces[0];
+        let body = pieces[1];
         if (header.indexOf(";base64") > -1) {
           body = atob(body);
         } else {
@@ -5259,7 +5259,7 @@ HTMLImports.addModule(function(scope) {
           this.receive(url, elt, null, body);
         }.bind(this), 0);
       } else {
-        var receiveXhr = function(err, resource, redirectedUrl) {
+        const receiveXhr = function(err, resource, redirectedUrl) {
           this.receive(url, elt, err, resource, redirectedUrl);
         }.bind(this);
         xhr.load(url, receiveXhr);
@@ -5267,8 +5267,8 @@ HTMLImports.addModule(function(scope) {
     },
     receive: function(url, elt, err, resource, redirectedUrl) {
       this.cache[url] = resource;
-      var $p = this.pending[url];
-      for (var i = 0, l = $p.length, p; i < l && (p = $p[i]); i++) {
+      const $p = this.pending[url];
+      for (let i = 0, l = $p.length, p; i < l && (p = $p[i]); i++) {
         this.onload(url, p, resource, err, redirectedUrl);
         this.tail();
       }
@@ -5288,13 +5288,13 @@ HTMLImports.addModule(function(scope) {
 });
 
 HTMLImports.addModule(function(scope) {
-  var Observer = function(addCallback) {
+  const Observer = function(addCallback) {
     this.addCallback = addCallback;
     this.mo = new MutationObserver(this.handler.bind(this));
   };
   Observer.prototype = {
     handler: function(mutations) {
-      for (var i = 0, l = mutations.length, m; i < l && (m = mutations[i]); i++) {
+      for (let i = 0, l = mutations.length, m; i < l && (m = mutations[i]); i++) {
         if (m.type === "childList" && m.addedNodes.length) {
           this.addedNodes(m.addedNodes);
         }
@@ -5304,7 +5304,7 @@ HTMLImports.addModule(function(scope) {
       if (this.addCallback) {
         this.addCallback(nodes);
       }
-      for (var i = 0, l = nodes.length, n, loading; i < l && (n = nodes[i]); i++) {
+      for (let i = 0, l = nodes.length, n, loading; i < l && (n = nodes[i]); i++) {
         if (n.children && n.children.length) {
           this.addedNodes(n.children);
         }
@@ -5321,13 +5321,13 @@ HTMLImports.addModule(function(scope) {
 });
 
 HTMLImports.addModule(function(scope) {
-  var path = scope.path;
-  var rootDocument = scope.rootDocument;
-  var flags = scope.flags;
-  var isIE = scope.isIE;
-  var IMPORT_LINK_TYPE = scope.IMPORT_LINK_TYPE;
-  var IMPORT_SELECTOR = "link[rel=" + IMPORT_LINK_TYPE + "]";
-  var importParser = {
+  const path = scope.path;
+  const rootDocument = scope.rootDocument;
+  const flags = scope.flags;
+  const isIE = scope.isIE;
+  const IMPORT_LINK_TYPE = scope.IMPORT_LINK_TYPE;
+  const IMPORT_SELECTOR = "link[rel=" + IMPORT_LINK_TYPE + "]";
+  const importParser = {
     documentSelectors: IMPORT_SELECTOR,
     importsSelectors: [ IMPORT_SELECTOR, "link[rel=stylesheet]", "style", "script:not([type])", 'script[type="text/javascript"]' ].join(","),
     map: {
@@ -5337,7 +5337,7 @@ HTMLImports.addModule(function(scope) {
     },
     dynamicElements: [],
     parseNext: function() {
-      var next = this.nextToParse();
+      const next = this.nextToParse();
       if (next) {
         this.parse(next);
       }
@@ -5347,7 +5347,7 @@ HTMLImports.addModule(function(scope) {
         flags.parse && console.log("[%s] is already parsed", elt.localName);
         return;
       }
-      var fn = this[this.map[elt.localName]];
+      const fn = this[this.map[elt.localName]];
       if (fn) {
         this.markParsing(elt);
         fn.call(this, elt);
@@ -5374,7 +5374,7 @@ HTMLImports.addModule(function(scope) {
       flags.parse && console.log("completed", elt);
     },
     markDynamicParsingComplete: function(elt) {
-      var i = this.dynamicElements.indexOf(elt);
+      const i = this.dynamicElements.indexOf(elt);
       if (i >= 0) {
         this.dynamicElements.splice(i, 1);
       }
@@ -5397,7 +5397,7 @@ HTMLImports.addModule(function(scope) {
         }));
       }
       if (elt.__pending) {
-        var fn;
+        let fn;
         while (elt.__pending.length) {
           fn = elt.__pending.shift();
           if (fn) {
@@ -5418,7 +5418,7 @@ HTMLImports.addModule(function(scope) {
       }
     },
     parseStyle: function(elt) {
-      var src = elt;
+      const src = elt;
       elt = cloneStyle(elt);
       elt.__importElement = src;
       this.parseGeneric(elt);
@@ -5428,24 +5428,24 @@ HTMLImports.addModule(function(scope) {
       this.addElementToDocument(elt);
     },
     rootImportForElement: function(elt) {
-      var n = elt;
+      let n = elt;
       while (n.ownerDocument.__importLink) {
         n = n.ownerDocument.__importLink;
       }
       return n;
     },
     addElementToDocument: function(elt) {
-      var port = this.rootImportForElement(elt.__importElement || elt);
-      var l = port.__insertedElements = port.__insertedElements || 0;
-      var refNode = port.nextElementSibling;
-      for (var i = 0; i < l; i++) {
+      const port = this.rootImportForElement(elt.__importElement || elt);
+      const l = port.__insertedElements = port.__insertedElements || 0;
+      let refNode = port.nextElementSibling;
+      for (let i = 0; i < l; i++) {
         refNode = refNode && refNode.nextElementSibling;
       }
       port.parentNode.insertBefore(elt, refNode);
     },
     trackElement: function(elt, callback) {
-      var self = this;
-      var done = function(e) {
+      const self = this;
+      const done = function(e) {
         if (callback) {
           callback(e);
         }
@@ -5455,14 +5455,14 @@ HTMLImports.addModule(function(scope) {
       elt.addEventListener("load", done);
       elt.addEventListener("error", done);
       if (isIE && elt.localName === "style") {
-        var fakeLoad = false;
+        let fakeLoad = false;
         if (elt.textContent.indexOf("@import") == -1) {
           fakeLoad = true;
         } else if (elt.sheet) {
           fakeLoad = true;
-          var csr = elt.sheet.cssRules;
-          var len = csr ? csr.length : 0;
-          for (var i = 0, r; i < len && (r = csr[i]); i++) {
+          const csr = elt.sheet.cssRules;
+          const len = csr ? csr.length : 0;
+          for (let i = 0, r; i < len && (r = csr[i]); i++) {
             if (r.type === CSSRule.IMPORT_RULE) {
               fakeLoad = fakeLoad && Boolean(r.styleSheet);
             }
@@ -5476,7 +5476,7 @@ HTMLImports.addModule(function(scope) {
       }
     },
     parseScript: function(scriptElt) {
-      var script = document.createElement("script");
+      const script = document.createElement("script");
       script.__importElement = scriptElt;
       script.src = scriptElt.src ? scriptElt.src : generateScriptDataUrl(scriptElt);
       scope.currentScript = scriptElt;
@@ -5493,8 +5493,8 @@ HTMLImports.addModule(function(scope) {
     nextToParseInDoc: function(doc, link) {
       if (doc && this._mayParse.indexOf(doc) < 0) {
         this._mayParse.push(doc);
-        var nodes = doc.querySelectorAll(this.parseSelectorsForNode(doc));
-        for (var i = 0, l = nodes.length, p = 0, n; i < l && (n = nodes[i]); i++) {
+        const nodes = doc.querySelectorAll(this.parseSelectorsForNode(doc));
+        for (let i = 0, l = nodes.length, p = 0, n; i < l && (n = nodes[i]); i++) {
           if (!this.isParsed(n)) {
             if (this.hasResource(n)) {
               return nodeIsImport(n) ? this.nextToParseInDoc(n.import, n) : n;
@@ -5510,7 +5510,7 @@ HTMLImports.addModule(function(scope) {
       return this.dynamicElements[0];
     },
     parseSelectorsForNode: function(node) {
-      var doc = node.ownerDocument || node;
+      const doc = node.ownerDocument || node;
       return doc === rootDocument ? this.documentSelectors : this.importsSelectors;
     },
     isParsed: function(node) {
@@ -5530,22 +5530,22 @@ HTMLImports.addModule(function(scope) {
     return elt.localName === "link" && elt.rel === IMPORT_LINK_TYPE;
   }
   function generateScriptDataUrl(script) {
-    var scriptContent = generateScriptContent(script);
+    const scriptContent = generateScriptContent(script);
     return "data:text/javascript;charset=utf-8," + encodeURIComponent(scriptContent);
   }
   function generateScriptContent(script) {
     return script.textContent + generateSourceMapHint(script);
   }
   function generateSourceMapHint(script) {
-    var owner = script.ownerDocument;
+    const owner = script.ownerDocument;
     owner.__importedScripts = owner.__importedScripts || 0;
-    var moniker = script.ownerDocument.baseURI;
-    var num = owner.__importedScripts ? "-" + owner.__importedScripts : "";
+    const moniker = script.ownerDocument.baseURI;
+    const num = owner.__importedScripts ? "-" + owner.__importedScripts : "";
     owner.__importedScripts++;
     return "\n//# sourceURL=" + moniker + num + ".js\n";
   }
   function cloneStyle(style) {
-    var clone = style.ownerDocument.createElement("style");
+    const clone = style.ownerDocument.createElement("style");
     clone.textContent = style.textContent;
     path.resolveUrlsInStyle(clone);
     return clone;
@@ -5555,14 +5555,14 @@ HTMLImports.addModule(function(scope) {
 });
 
 HTMLImports.addModule(function(scope) {
-  var flags = scope.flags;
-  var IMPORT_LINK_TYPE = scope.IMPORT_LINK_TYPE;
-  var IMPORT_SELECTOR = scope.IMPORT_SELECTOR;
-  var rootDocument = scope.rootDocument;
-  var Loader = scope.Loader;
-  var Observer = scope.Observer;
-  var parser = scope.parser;
-  var importer = {
+  const flags = scope.flags;
+  const IMPORT_LINK_TYPE = scope.IMPORT_LINK_TYPE;
+  const IMPORT_SELECTOR = scope.IMPORT_SELECTOR;
+  const rootDocument = scope.rootDocument;
+  const Loader = scope.Loader;
+  const Observer = scope.Observer;
+  const parser = scope.parser;
+  const importer = {
     documents: {},
     documentPreloadSelectors: IMPORT_SELECTOR,
     importsPreloadSelectors: [ IMPORT_SELECTOR ].join(","),
@@ -5570,14 +5570,14 @@ HTMLImports.addModule(function(scope) {
       importLoader.addNode(node);
     },
     loadSubtree: function(parent) {
-      var nodes = this.marshalNodes(parent);
+      const nodes = this.marshalNodes(parent);
       importLoader.addNodes(nodes);
     },
     marshalNodes: function(parent) {
       return parent.querySelectorAll(this.loadSelectorsForNode(parent));
     },
     loadSelectorsForNode: function(node) {
-      var doc = node.ownerDocument || node;
+      const doc = node.ownerDocument || node;
       return doc === rootDocument ? this.documentPreloadSelectors : this.importsPreloadSelectors;
     },
     loaded: function(url, elt, resource, err, redirectedUrl) {
@@ -5585,7 +5585,7 @@ HTMLImports.addModule(function(scope) {
       elt.__resource = resource;
       elt.__error = err;
       if (isImportLink(elt)) {
-        var doc = this.documents[url];
+        let doc = this.documents[url];
         if (doc === undefined) {
           doc = err ? null : makeDocument(resource, redirectedUrl || url);
           if (doc) {
@@ -5607,7 +5607,7 @@ HTMLImports.addModule(function(scope) {
       parser.parseNext();
     }
   };
-  var importLoader = new Loader(importer.loaded.bind(importer), importer.loadedAll.bind(importer));
+  const importLoader = new Loader(importer.loaded.bind(importer), importer.loadedAll.bind(importer));
   importer.observer = new Observer();
   function isImportLink(elt) {
     return isLinkRel(elt, IMPORT_LINK_TYPE);
@@ -5616,14 +5616,14 @@ HTMLImports.addModule(function(scope) {
     return elt.localName === "link" && elt.getAttribute("rel") === rel;
   }
   function makeDocument(resource, url) {
-    var doc = document.implementation.createHTMLDocument(IMPORT_LINK_TYPE);
+    const doc = document.implementation.createHTMLDocument(IMPORT_LINK_TYPE);
     doc._URL = url;
-    var base = doc.createElement("base");
+    const base = doc.createElement("base");
     base.setAttribute("href", url);
     if (!doc.baseURI) {
       doc.baseURI = url;
     }
-    var meta = doc.createElement("meta");
+    const meta = doc.createElement("meta");
     meta.setAttribute("charset", "utf-8");
     doc.head.appendChild(meta);
     doc.head.appendChild(base);
@@ -5634,9 +5634,9 @@ HTMLImports.addModule(function(scope) {
     return doc;
   }
   if (!document.baseURI) {
-    var baseURIDescriptor = {
+    const baseURIDescriptor = {
       get: function() {
-        var base = document.querySelector("base");
+        const base = document.querySelector("base");
         return base ? base.href : window.location.href;
       },
       configurable: true
@@ -5649,12 +5649,12 @@ HTMLImports.addModule(function(scope) {
 });
 
 HTMLImports.addModule(function(scope) {
-  var parser = scope.parser;
-  var importer = scope.importer;
-  var dynamic = {
+  const parser = scope.parser;
+  const importer = scope.importer;
+  const dynamic = {
     added: function(nodes) {
-      var owner, parsed;
-      for (var i = 0, l = nodes.length, n; i < l && (n = nodes[i]); i++) {
+      let owner, parsed;
+      for (let i = 0, l = nodes.length, n; i < l && (n = nodes[i]); i++) {
         if (!owner) {
           owner = n.ownerDocument;
           parsed = parser.isParsed(owner);
@@ -5676,7 +5676,7 @@ HTMLImports.addModule(function(scope) {
     }
   };
   importer.observer.addCallback = dynamic.added.bind(dynamic);
-  var matches = HTMLElement.prototype.matches || HTMLElement.prototype.matchesSelector || HTMLElement.prototype.webkitMatchesSelector || HTMLElement.prototype.mozMatchesSelector || HTMLElement.prototype.msMatchesSelector;
+  const matches = HTMLElement.prototype.matches || HTMLElement.prototype.matchesSelector || HTMLElement.prototype.webkitMatchesSelector || HTMLElement.prototype.mozMatchesSelector || HTMLElement.prototype.msMatchesSelector;
 });
 
 (function(scope) {
@@ -5686,13 +5686,13 @@ HTMLImports.addModule(function(scope) {
   }
   if (typeof window.CustomEvent !== "function") {
     window.CustomEvent = function(inType, dictionary) {
-      var e = document.createEvent("HTMLEvents");
+      const e = document.createEvent("HTMLEvents");
       e.initEvent(inType, dictionary.bubbles === false ? false : true, dictionary.cancelable === false ? false : true, dictionary.detail);
       return e;
     };
   }
   initializeModules();
-  var rootDocument = scope.rootDocument;
+  const rootDocument = scope.rootDocument;
   function bootstrap() {
     HTMLImports.importer.bootDocument(rootDocument);
   }
@@ -5708,12 +5708,12 @@ window.CustomElements = window.CustomElements || {
 };
 
 (function(scope) {
-  var flags = scope.flags;
-  var modules = [];
-  var addModule = function(module) {
+  const flags = scope.flags;
+  const modules = [];
+  const addModule = function(module) {
     modules.push(module);
   };
-  var initializeModules = function() {
+  const initializeModules = function() {
     modules.forEach(function(module) {
       module(scope);
     });
@@ -5725,7 +5725,7 @@ window.CustomElements = window.CustomElements || {
 })(CustomElements);
 
 CustomElements.addModule(function(scope) {
-  var IMPORT_LINK_TYPE = window.HTMLImports ? HTMLImports.IMPORT_LINK_TYPE : "none";
+  const IMPORT_LINK_TYPE = window.HTMLImports ? HTMLImports.IMPORT_LINK_TYPE : "none";
   function forSubtree(node, cb) {
     findAllElements(node, function(e) {
       if (cb(e)) {
@@ -5736,7 +5736,7 @@ CustomElements.addModule(function(scope) {
     forRoots(node, cb);
   }
   function findAllElements(node, find, data) {
-    var e = node.firstElementChild;
+    let e = node.firstElementChild;
     if (!e) {
       e = node.firstChild;
       while (e && e.nodeType !== Node.ELEMENT_NODE) {
@@ -5752,13 +5752,13 @@ CustomElements.addModule(function(scope) {
     return null;
   }
   function forRoots(node, cb) {
-    var root = node.shadowRoot;
+    let root = node.shadowRoot;
     while (root) {
       forSubtree(root, cb);
       root = root.olderShadowRoot;
     }
   }
-  var processingDocuments;
+  let processingDocuments;
   function forDocumentTree(doc, cb) {
     processingDocuments = [];
     _forDocumentTree(doc, cb);
@@ -5770,8 +5770,8 @@ CustomElements.addModule(function(scope) {
       return;
     }
     processingDocuments.push(doc);
-    var imports = doc.querySelectorAll("link[rel=" + IMPORT_LINK_TYPE + "]");
-    for (var i = 0, l = imports.length, n; i < l && (n = imports[i]); i++) {
+    const imports = doc.querySelectorAll("link[rel=" + IMPORT_LINK_TYPE + "]");
+    for (let i = 0, l = imports.length, n; i < l && (n = imports[i]); i++) {
       if (n.import) {
         _forDocumentTree(n.import, cb);
       }
@@ -5783,9 +5783,9 @@ CustomElements.addModule(function(scope) {
 });
 
 CustomElements.addModule(function(scope) {
-  var flags = scope.flags;
-  var forSubtree = scope.forSubtree;
-  var forDocumentTree = scope.forDocumentTree;
+  const flags = scope.flags;
+  const forSubtree = scope.forSubtree;
+  const forDocumentTree = scope.forDocumentTree;
   function addedNode(node) {
     return added(node) || addedSubtree(node);
   }
@@ -5812,8 +5812,8 @@ CustomElements.addModule(function(scope) {
   }
   var hasPolyfillMutations = !window.MutationObserver || window.MutationObserver === window.JsMutationObserver;
   scope.hasPolyfillMutations = hasPolyfillMutations;
-  var isPendingMutations = false;
-  var pendingMutations = [];
+  let isPendingMutations = false;
+  let pendingMutations = [];
   function deferMutation(fn) {
     pendingMutations.push(fn);
     if (!isPendingMutations) {
@@ -5823,8 +5823,8 @@ CustomElements.addModule(function(scope) {
   }
   function takeMutations() {
     isPendingMutations = false;
-    var $p = pendingMutations;
-    for (var i = 0, l = $p.length, p; i < l && (p = $p[i]); i++) {
+    const $p = pendingMutations;
+    for (let i = 0, l = $p.length, p; i < l && (p = $p[i]); i++) {
       p();
     }
     pendingMutations = [];
@@ -5874,8 +5874,8 @@ CustomElements.addModule(function(scope) {
     }
   }
   function inDocument(element) {
-    var p = element;
-    var doc = wrap(document);
+    let p = element;
+    const doc = wrap(document);
     while (p) {
       if (p == doc) {
         return true;
@@ -5886,7 +5886,7 @@ CustomElements.addModule(function(scope) {
   function watchShadow(node) {
     if (node.shadowRoot && !node.shadowRoot.__watched) {
       flags.dom && console.log("watching shadow-root for: ", node.localName);
-      var root = node.shadowRoot;
+      let root = node.shadowRoot;
       while (root) {
         observe(root);
         root = root.olderShadowRoot;
@@ -5895,10 +5895,10 @@ CustomElements.addModule(function(scope) {
   }
   function handler(mutations) {
     if (flags.dom) {
-      var mx = mutations[0];
+      const mx = mutations[0];
       if (mx && mx.type === "childList" && mx.addedNodes) {
         if (mx.addedNodes) {
-          var d = mx.addedNodes[0];
+          let d = mx.addedNodes[0];
           while (d && d !== document && !d.host) {
             d = d.parentNode;
           }
@@ -5934,7 +5934,7 @@ CustomElements.addModule(function(scope) {
     while (node.parentNode) {
       node = node.parentNode;
     }
-    var observer = node.__observer;
+    const observer = node.__observer;
     if (observer) {
       handler(observer.takeRecords());
       takeMutations();
@@ -5945,7 +5945,7 @@ CustomElements.addModule(function(scope) {
     if (inRoot.__observer) {
       return;
     }
-    var observer = new MutationObserver(handler);
+    const observer = new MutationObserver(handler);
     observer.observe(inRoot, {
       childList: true,
       subtree: true
@@ -5962,9 +5962,9 @@ CustomElements.addModule(function(scope) {
   function upgradeDocumentTree(doc) {
     forDocumentTree(doc, upgradeDocument);
   }
-  var originalCreateShadowRoot = Element.prototype.createShadowRoot;
+  const originalCreateShadowRoot = Element.prototype.createShadowRoot;
   Element.prototype.createShadowRoot = function() {
-    var root = originalCreateShadowRoot.call(this);
+    const root = originalCreateShadowRoot.call(this);
     CustomElements.watchShadow(this);
     return root;
   };
@@ -5977,11 +5977,11 @@ CustomElements.addModule(function(scope) {
 });
 
 CustomElements.addModule(function(scope) {
-  var flags = scope.flags;
+  const flags = scope.flags;
   function upgrade(node) {
     if (!node.__upgraded__ && node.nodeType === Node.ELEMENT_NODE) {
-      var is = node.getAttribute("is");
-      var definition = scope.getRegisteredDefinition(is || node.localName);
+      const is = node.getAttribute("is");
+      const definition = scope.getRegisteredDefinition(is || node.localName);
       if (definition) {
         if (is && definition.tag == node.localName) {
           return upgradeWithDefinition(node, definition);
@@ -6013,11 +6013,11 @@ CustomElements.addModule(function(scope) {
     }
   }
   function customMixin(inTarget, inSrc, inNative) {
-    var used = {};
-    var p = inSrc;
+    const used = {};
+    let p = inSrc;
     while (p !== inNative && p !== HTMLElement.prototype) {
-      var keys = Object.getOwnPropertyNames(p);
-      for (var i = 0, k; k = keys[i]; i++) {
+      const keys = Object.getOwnPropertyNames(p);
+      for (let i = 0, k; k = keys[i]; i++) {
         if (!used[k]) {
           Object.defineProperty(inTarget, k, Object.getOwnPropertyDescriptor(p, k));
           used[k] = 1;
@@ -6037,13 +6037,13 @@ CustomElements.addModule(function(scope) {
 });
 
 CustomElements.addModule(function(scope) {
-  var upgradeDocumentTree = scope.upgradeDocumentTree;
-  var upgrade = scope.upgrade;
-  var upgradeWithDefinition = scope.upgradeWithDefinition;
-  var implementPrototype = scope.implementPrototype;
-  var useNative = scope.useNative;
+  const upgradeDocumentTree = scope.upgradeDocumentTree;
+  const upgrade = scope.upgrade;
+  const upgradeWithDefinition = scope.upgradeWithDefinition;
+  const implementPrototype = scope.implementPrototype;
+  const useNative = scope.useNative;
   function register(name, options) {
-    var definition = options || {};
+    const definition = options || {};
     if (!name) {
       throw new Error("document.registerElement: first argument `name` must not be empty");
     }
@@ -6082,7 +6082,7 @@ CustomElements.addModule(function(scope) {
     prototype.setAttribute = function(name, value) {
       changeAttribute.call(this, name, value, setAttribute);
     };
-    var removeAttribute = prototype.removeAttribute;
+    const removeAttribute = prototype.removeAttribute;
     prototype.removeAttribute = function(name) {
       changeAttribute.call(this, name, null, removeAttribute);
     };
@@ -6090,15 +6090,15 @@ CustomElements.addModule(function(scope) {
   }
   function changeAttribute(name, value, operation) {
     name = name.toLowerCase();
-    var oldValue = this.getAttribute(name);
+    const oldValue = this.getAttribute(name);
     operation.apply(this, arguments);
-    var newValue = this.getAttribute(name);
+    const newValue = this.getAttribute(name);
     if (this.attributeChangedCallback && newValue !== oldValue) {
       this.attributeChangedCallback(name, oldValue, newValue);
     }
   }
   function isReservedTag(name) {
-    for (var i = 0; i < reservedTagList.length; i++) {
+    for (let i = 0; i < reservedTagList.length; i++) {
       if (name === reservedTagList[i]) {
         return true;
       }
@@ -6106,15 +6106,15 @@ CustomElements.addModule(function(scope) {
   }
   var reservedTagList = [ "annotation-xml", "color-profile", "font-face", "font-face-src", "font-face-uri", "font-face-format", "font-face-name", "missing-glyph" ];
   function ancestry(extnds) {
-    var extendee = getRegisteredDefinition(extnds);
+    const extendee = getRegisteredDefinition(extnds);
     if (extendee) {
       return ancestry(extendee.extends).concat([ extendee ]);
     }
     return [];
   }
   function resolveTagName(definition) {
-    var baseTag = definition.extends;
-    for (var i = 0, a; a = definition.ancestry[i]; i++) {
+    let baseTag = definition.extends;
+    for (let i = 0, a; a = definition.ancestry[i]; i++) {
       baseTag = a.is && a.tag;
     }
     definition.tag = baseTag || definition.__name;
@@ -6124,15 +6124,15 @@ CustomElements.addModule(function(scope) {
   }
   function resolvePrototypeChain(definition) {
     if (!Object.__proto__) {
-      var nativePrototype = HTMLElement.prototype;
+      let nativePrototype = HTMLElement.prototype;
       if (definition.is) {
-        var inst = document.createElement(definition.tag);
-        var expectedPrototype = Object.getPrototypeOf(inst);
+        const inst = document.createElement(definition.tag);
+        const expectedPrototype = Object.getPrototypeOf(inst);
         if (expectedPrototype === definition.prototype) {
           nativePrototype = expectedPrototype;
         }
       }
-      var proto = definition.prototype, ancestor;
+      let proto = definition.prototype, ancestor;
       while (proto && proto !== nativePrototype) {
         ancestor = Object.getPrototypeOf(proto);
         proto.__proto__ = ancestor;
@@ -6158,7 +6158,7 @@ CustomElements.addModule(function(scope) {
       return instantiate(definition);
     };
   }
-  var HTML_NAMESPACE = "http://www.w3.org/1999/xhtml";
+  const HTML_NAMESPACE = "http://www.w3.org/1999/xhtml";
   function createElementNS(namespace, tag, typeExtension) {
     if (namespace === HTML_NAMESPACE) {
       return createElement(tag, typeExtension);
@@ -6167,7 +6167,7 @@ CustomElements.addModule(function(scope) {
     }
   }
   function createElement(tag, typeExtension) {
-    var definition = getRegisteredDefinition(typeExtension || tag);
+    const definition = getRegisteredDefinition(typeExtension || tag);
     if (definition) {
       if (tag == definition.tag && typeExtension == definition.is) {
         return new definition.ctor();
@@ -6176,7 +6176,7 @@ CustomElements.addModule(function(scope) {
         return new definition.ctor();
       }
     }
-    var element;
+    let element;
     if (typeExtension) {
       element = createElement(tag);
       element.setAttribute("is", typeExtension);
@@ -6189,17 +6189,17 @@ CustomElements.addModule(function(scope) {
     return element;
   }
   function cloneNode(deep) {
-    var n = domCloneNode.call(this, deep);
+    const n = domCloneNode.call(this, deep);
     upgrade(n);
     return n;
   }
   var domCreateElement = document.createElement.bind(document);
   var domCreateElementNS = document.createElementNS.bind(document);
   var domCloneNode = Node.prototype.cloneNode;
-  var isInstance;
+  let isInstance;
   if (!Object.__proto__ && !useNative) {
     isInstance = function(obj, ctor) {
-      var p = obj;
+      let p = obj;
       while (p) {
         if (p === ctor.prototype) {
           return true;
@@ -6225,10 +6225,10 @@ CustomElements.addModule(function(scope) {
 });
 
 (function(scope) {
-  var useNative = scope.useNative;
-  var initializeModules = scope.initializeModules;
+  const useNative = scope.useNative;
+  const initializeModules = scope.initializeModules;
   if (useNative) {
-    var nop = function() {};
+    const nop = function() {};
     scope.watchShadow = nop;
     scope.upgrade = nop;
     scope.upgradeAll = nop;
@@ -6273,7 +6273,7 @@ CustomElements.addModule(function(scope) {
   if (typeof window.CustomEvent !== "function") {
     window.CustomEvent = function(inType, params) {
       params = params || {};
-      var e = document.createEvent("CustomEvent");
+      const e = document.createEvent("CustomEvent");
       e.initCustomEvent(inType, Boolean(params.bubbles), Boolean(params.cancelable), params.detail);
       return e;
     };
@@ -6284,7 +6284,7 @@ CustomElements.addModule(function(scope) {
   } else if (document.readyState === "interactive" && !window.attachEvent && (!window.HTMLImports || window.HTMLImports.ready)) {
     bootstrap();
   } else {
-    var loadEvent = window.HTMLImports && !HTMLImports.ready ? "HTMLImportsLoaded" : "DOMContentLoaded";
+    const loadEvent = window.HTMLImports && !HTMLImports.ready ? "HTMLImportsLoaded" : "DOMContentLoaded";
     window.addEventListener(loadEvent, bootstrap);
   }
 })(window.CustomElements);
@@ -6292,10 +6292,10 @@ CustomElements.addModule(function(scope) {
 (function(scope) {
   if (!Function.prototype.bind) {
     Function.prototype.bind = function(scope) {
-      var self = this;
-      var args = Array.prototype.slice.call(arguments, 1);
+      const self = this;
+      const args = Array.prototype.slice.call(arguments, 1);
       return function() {
-        var args2 = args.slice();
+        const args2 = args.slice();
         args2.push.apply(args2, arguments);
         return self.apply(scope, args2);
       };
@@ -6306,7 +6306,7 @@ CustomElements.addModule(function(scope) {
 (function(scope) {
   "use strict";
   if (!window.performance) {
-    var start = Date.now();
+    const start = Date.now();
     window.performance = {
       now: function() {
         return Date.now() - start;
@@ -6315,7 +6315,7 @@ CustomElements.addModule(function(scope) {
   }
   if (!window.requestAnimationFrame) {
     window.requestAnimationFrame = function() {
-      var nativeRaf = window.webkitRequestAnimationFrame || window.mozRequestAnimationFrame;
+      const nativeRaf = window.webkitRequestAnimationFrame || window.mozRequestAnimationFrame;
       return nativeRaf ? function(callback) {
         return nativeRaf(function() {
           callback(performance.now());
@@ -6332,8 +6332,8 @@ CustomElements.addModule(function(scope) {
       };
     }();
   }
-  var elementDeclarations = [];
-  var polymerStub = function(name, dictionary) {
+  let elementDeclarations = [];
+  const polymerStub = function(name, dictionary) {
     if (typeof name !== "string" && arguments.length === 1) {
       Array.prototype.push.call(arguments, document._currentScript);
     }
@@ -6364,9 +6364,9 @@ CustomElements.addModule(function(scope) {
 })(window.WebComponents);
 
 (function(scope) {
-  var style = document.createElement("style");
+  const style = document.createElement("style");
   style.textContent = "" + "body {" + "transition: opacity ease-in 0.2s;" + " } \n" + "body[unresolved] {" + "opacity: 0; display: block; overflow: hidden; position: relative;" + " } \n";
-  var head = document.querySelector("head");
+  const head = document.querySelector("head");
   head.insertBefore(style, head.firstChild);
 })(window.WebComponents);
 

--- a/src/test/MetaMatchers.js
+++ b/src/test/MetaMatchers.js
@@ -24,15 +24,15 @@ function getRunnerWithResults(describeFunction) {
     return describeFunction._cachedRunner;
   }
   // Patch the current global environment.
-  var env = new jasmine.Env();
+  const env = new jasmine.Env();
   // Execute the tests synchronously.
   env.updateInterval = 0;
-  var outerGetEnv = jasmine.getEnv;
+  const outerGetEnv = jasmine.getEnv;
   jasmine.getEnv = function() {
     return env;
   };
   // TODO: Bring over matchers from the existing environment.
-  var runner = env.currentRunner();
+  const runner = env.currentRunner();
   try {
     env.describe('', describeFunction);
     env.execute();
@@ -56,7 +56,7 @@ function compareSpec(actual, expected) {
 }
 
 function includesDescription(specs, description, startIndex) {
-  for (var i = startIndex; i < specs.length; i++) {
+  for (let i = startIndex; i < specs.length; i++) {
     if (specs[i].description === description) {
       return true;
     }
@@ -66,10 +66,10 @@ function includesDescription(specs, description, startIndex) {
 
 function compareSpecs(actualSpecs, expectedSpecs) {
   for (var i = 0; i < actualSpecs.length && i < expectedSpecs.length; i++) {
-    var actual = actualSpecs[i];
-    var expected = expectedSpecs[i];
+    const actual = actualSpecs[i];
+    const expected = expectedSpecs[i];
     if (actual.description === expected.description) {
-      var errorMessage = compareSpec(actual, expected);
+      const errorMessage = compareSpec(actual, expected);
       if (errorMessage) {
         return errorMessage;
       }
@@ -103,9 +103,9 @@ function compareRunners(actual, expected) {
   );
 }
 
-var MetaMatchers = {
+const MetaMatchers = {
   toEqualSpecsIn: function(expectedDescribeFunction) {
-    var actualDescribeFunction = this.actual;
+    const actualDescribeFunction = this.actual;
     if (typeof actualDescribeFunction !== 'function') {
       throw Error('toEqualSpecsIn() should be used on a describe function');
     }
@@ -113,8 +113,8 @@ var MetaMatchers = {
       throw Error('toEqualSpecsIn() should be passed a describe function');
     }
     var actual = getRunnerWithResults(actualDescribeFunction);
-    var expected = getRunnerWithResults(expectedDescribeFunction);
-    var errorMessage = compareRunners(actual, expected);
+    const expected = getRunnerWithResults(expectedDescribeFunction);
+    const errorMessage = compareRunners(actual, expected);
     this.message = function() {
       return [
         errorMessage,

--- a/src/test/ReactDefaultPerf.js
+++ b/src/test/ReactDefaultPerf.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-var DOMProperty = require('DOMProperty');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var ReactDefaultPerfAnalysis = require('ReactDefaultPerfAnalysis');
-var ReactMount = require('ReactMount');
-var ReactPerf = require('ReactPerf');
+const DOMProperty = require('DOMProperty');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
+const ReactDefaultPerfAnalysis = require('ReactDefaultPerfAnalysis');
+const ReactMount = require('ReactMount');
+const ReactPerf = require('ReactPerf');
 
-var performanceNow = require('performanceNow');
+const performanceNow = require('performanceNow');
 
 function roundFloat(val) {
   return Math.floor(val * 100) / 100;
@@ -28,8 +28,8 @@ function addValue(obj, key, val) {
 }
 
 // Composite/text components don't have any built-in ID: we have to make our own
-var compositeIDMap;
-var compositeIDCounter = 17000;
+let compositeIDMap;
+let compositeIDCounter = 17000;
 function getIDOfComposite(inst) {
   if (!compositeIDMap) {
     compositeIDMap = new WeakMap();
@@ -37,7 +37,7 @@ function getIDOfComposite(inst) {
   if (compositeIDMap.has(inst)) {
     return compositeIDMap.get(inst);
   } else {
-    var id = compositeIDCounter++;
+    const id = compositeIDCounter++;
     compositeIDMap.set(inst, id);
     return id;
   }
@@ -51,7 +51,7 @@ function getID(inst) {
   }
 }
 
-var ReactDefaultPerf = {
+const ReactDefaultPerf = {
   _allMeasurements: [], // last item in the list is the current one
   _mountStack: [0],
   _compositeStack: [],
@@ -76,7 +76,7 @@ var ReactDefaultPerf = {
 
   printExclusive: function(measurements) {
     measurements = measurements || ReactDefaultPerf._allMeasurements;
-    var summary = ReactDefaultPerfAnalysis.getExclusiveSummary(measurements);
+    const summary = ReactDefaultPerfAnalysis.getExclusiveSummary(measurements);
     console.table(summary.map(function(item) {
       return {
         'Component class name': item.componentName,
@@ -94,7 +94,7 @@ var ReactDefaultPerf = {
 
   printInclusive: function(measurements) {
     measurements = measurements || ReactDefaultPerf._allMeasurements;
-    var summary = ReactDefaultPerfAnalysis.getInclusiveSummary(measurements);
+    const summary = ReactDefaultPerfAnalysis.getInclusiveSummary(measurements);
     console.table(summary.map(function(item) {
       return {
         'Owner > component': item.componentName,
@@ -109,7 +109,7 @@ var ReactDefaultPerf = {
   },
 
   getMeasurementsSummaryMap: function(measurements) {
-    var summary = ReactDefaultPerfAnalysis.getInclusiveSummary(
+    const summary = ReactDefaultPerfAnalysis.getInclusiveSummary(
       measurements,
       true
     );
@@ -133,9 +133,9 @@ var ReactDefaultPerf = {
 
   printDOM: function(measurements) {
     measurements = measurements || ReactDefaultPerf._allMeasurements;
-    var summary = ReactDefaultPerfAnalysis.getDOMSummary(measurements);
+    const summary = ReactDefaultPerfAnalysis.getDOMSummary(measurements);
     console.table(summary.map(function(item) {
-      var result = {};
+      const result = {};
       result[DOMProperty.ID_ATTRIBUTE_NAME] = item.id;
       result.type = item.type;
       result.args = JSON.stringify(item.args);
@@ -149,10 +149,10 @@ var ReactDefaultPerf = {
 
   _recordWrite: function(id, fnName, totalTime, args) {
     // TODO: totalTime isn't that useful since it doesn't count paints/reflows
-    var entry =
+    const entry =
       ReactDefaultPerf
         ._allMeasurements[ReactDefaultPerf._allMeasurements.length - 1];
-    var writes = entry.writes;
+    const writes = entry.writes;
     writes[id] = writes[id] || [];
     writes[id].push({
       type: fnName,
@@ -163,11 +163,11 @@ var ReactDefaultPerf = {
 
   measure: function(moduleName, fnName, func) {
     return function(...args) {
-      var totalTime;
-      var rv;
-      var start;
+      let totalTime;
+      let rv;
+      let start;
 
-      var entry = ReactDefaultPerf._allMeasurements[
+      let entry = ReactDefaultPerf._allMeasurements[
         ReactDefaultPerf._allMeasurements.length - 1
       ];
 
@@ -207,7 +207,7 @@ var ReactDefaultPerf = {
         } else if (fnName === 'dangerouslyProcessChildrenUpdates') {
           // special format
           args[1].forEach(function(update) {
-            var writeArgs = {};
+            const writeArgs = {};
             if (update.fromIndex !== null) {
               writeArgs.fromIndex = update.fromIndex;
             }
@@ -226,7 +226,7 @@ var ReactDefaultPerf = {
           });
         } else {
           // basic format
-          var id = args[0];
+          let id = args[0];
           if (moduleName === 'EventPluginHub') {
             id = id._rootNodeID;
           } else if (fnName === 'replaceNodeWithMarkup') {
@@ -254,11 +254,11 @@ var ReactDefaultPerf = {
           return func.apply(this, args);
         }
 
-        var rootNodeID = getIDOfComposite(this);
-        var isRender = fnName === '_renderValidatedComponent';
-        var isMount = fnName === 'mountComponent';
+        const rootNodeID = getIDOfComposite(this);
+        const isRender = fnName === '_renderValidatedComponent';
+        const isMount = fnName === 'mountComponent';
 
-        var mountStack = ReactDefaultPerf._mountStack;
+        const mountStack = ReactDefaultPerf._mountStack;
 
         if (isRender) {
           addValue(entry.counts, rootNodeID, 1);
@@ -278,7 +278,7 @@ var ReactDefaultPerf = {
         if (isRender) {
           addValue(entry.render, rootNodeID, totalTime);
         } else if (isMount) {
-          var subMountTime = mountStack.pop();
+          const subMountTime = mountStack.pop();
           mountStack[mountStack.length - 1] += totalTime;
           addValue(entry.exclusive, rootNodeID, totalTime - subMountTime);
           addValue(entry.inclusive, rootNodeID, totalTime);

--- a/src/test/ReactDefaultPerfAnalysis.js
+++ b/src/test/ReactDefaultPerfAnalysis.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-var assign = require('Object.assign');
+const assign = require('Object.assign');
 
 // Don't try to save users less than 1.2ms (a number I made up)
-var DONT_CARE_THRESHOLD = 1.2;
-var DOM_OPERATION_TYPES = {
+const DONT_CARE_THRESHOLD = 1.2;
+const DOM_OPERATION_TYPES = {
   '_mountImageIntoNode': 'set innerHTML',
   INSERT_MARKUP: 'set innerHTML',
   MOVE_EXISTING: 'move',
@@ -36,16 +36,16 @@ function getTotalTime(measurements) {
   // TODO: measure dropped frames after reconcile?
   // TODO: log total time of each reconcile and the top-level component
   // class that triggered it.
-  var totalTime = 0;
-  for (var i = 0; i < measurements.length; i++) {
-    var measurement = measurements[i];
+  let totalTime = 0;
+  for (let i = 0; i < measurements.length; i++) {
+    const measurement = measurements[i];
     totalTime += measurement.totalTime;
   }
   return totalTime;
 }
 
 function getDOMSummary(measurements) {
-  var items = [];
+  const items = [];
   measurements.forEach(function(measurement) {
     Object.keys(measurement.writes).forEach(function(id) {
       measurement.writes[id].forEach(function(write) {
@@ -61,18 +61,18 @@ function getDOMSummary(measurements) {
 }
 
 function getExclusiveSummary(measurements) {
-  var candidates = {};
-  var displayName;
+  const candidates = {};
+  let displayName;
 
-  for (var i = 0; i < measurements.length; i++) {
-    var measurement = measurements[i];
-    var allIDs = assign(
+  for (let i = 0; i < measurements.length; i++) {
+    const measurement = measurements[i];
+    const allIDs = assign(
       {},
       measurement.exclusive,
       measurement.inclusive
     );
 
-    for (var id in allIDs) {
+    for (let id in allIDs) {
       displayName = measurement.displayNames[id].current;
 
       candidates[displayName] = candidates[displayName] || {
@@ -98,7 +98,7 @@ function getExclusiveSummary(measurements) {
   }
 
   // Now make a sorted array with the results.
-  var arr = [];
+  const arr = [];
   for (displayName in candidates) {
     if (candidates[displayName].exclusive >= DONT_CARE_THRESHOLD) {
       arr.push(candidates[displayName]);
@@ -113,28 +113,28 @@ function getExclusiveSummary(measurements) {
 }
 
 function getInclusiveSummary(measurements, onlyClean) {
-  var candidates = {};
-  var inclusiveKey;
+  const candidates = {};
+  let inclusiveKey;
 
-  for (var i = 0; i < measurements.length; i++) {
-    var measurement = measurements[i];
-    var allIDs = assign(
+  for (let i = 0; i < measurements.length; i++) {
+    const measurement = measurements[i];
+    const allIDs = assign(
       {},
       measurement.exclusive,
       measurement.inclusive
     );
-    var cleanComponents;
+    let cleanComponents;
 
     if (onlyClean) {
       cleanComponents = getUnchangedComponents(measurement);
     }
 
-    for (var id in allIDs) {
+    for (let id in allIDs) {
       if (onlyClean && !cleanComponents[id]) {
         continue;
       }
 
-      var displayName = measurement.displayNames[id];
+      const displayName = measurement.displayNames[id];
 
       // Inclusive time is not useful for many components without knowing where
       // they are instantiated. So we aggregate inclusive time with both the
@@ -157,7 +157,7 @@ function getInclusiveSummary(measurements, onlyClean) {
   }
 
   // Now make a sorted array with the results.
-  var arr = [];
+  const arr = [];
   for (inclusiveKey in candidates) {
     if (candidates[inclusiveKey].time >= DONT_CARE_THRESHOLD) {
       arr.push(candidates[inclusiveKey]);
@@ -175,9 +175,9 @@ function getUnchangedComponents(measurement) {
   // For a given reconcile, look at which components did not actually
   // render anything to the DOM and return a mapping of their ID to
   // the amount of time it took to render the entire subtree.
-  var cleanComponents = {};
-  var writes = measurement.writes;
-  var dirtyComposites = {};
+  const cleanComponents = {};
+  const writes = measurement.writes;
+  const dirtyComposites = {};
   Object.keys(writes).forEach(function(id) {
     writes[id].forEach(function(write) {
       // Root mounting (innerHTML set) is recorded with an ID of ''
@@ -186,10 +186,10 @@ function getUnchangedComponents(measurement) {
       }
     });
   });
-  var allIDs = assign({}, measurement.exclusive, measurement.inclusive);
+  const allIDs = assign({}, measurement.exclusive, measurement.inclusive);
 
-  for (var id in allIDs) {
-    var isDirty = false;
+  for (let id in allIDs) {
+    let isDirty = false;
     // See if any of the DOM operations applied to this component's subtree.
     if (dirtyComposites[id]) {
       isDirty = true;
@@ -205,7 +205,7 @@ function getUnchangedComponents(measurement) {
   return cleanComponents;
 }
 
-var ReactDefaultPerfAnalysis = {
+const ReactDefaultPerfAnalysis = {
   getExclusiveSummary: getExclusiveSummary,
   getInclusiveSummary: getInclusiveSummary,
   getDOMSummary: getDOMSummary,

--- a/src/test/ReactDefaultPerfAnalysis.js
+++ b/src/test/ReactDefaultPerfAnalysis.js
@@ -72,7 +72,7 @@ function getExclusiveSummary(measurements) {
       measurement.inclusive
     );
 
-    for (let id in allIDs) {
+    for (const id in allIDs) {
       displayName = measurement.displayNames[id].current;
 
       candidates[displayName] = candidates[displayName] || {
@@ -129,7 +129,7 @@ function getInclusiveSummary(measurements, onlyClean) {
       cleanComponents = getUnchangedComponents(measurement);
     }
 
-    for (let id in allIDs) {
+    for (const id in allIDs) {
       if (onlyClean && !cleanComponents[id]) {
         continue;
       }
@@ -188,7 +188,7 @@ function getUnchangedComponents(measurement) {
   });
   const allIDs = assign({}, measurement.exclusive, measurement.inclusive);
 
-  for (let id in allIDs) {
+  for (const id in allIDs) {
     let isDirty = false;
     // See if any of the DOM operations applied to this component's subtree.
     if (dirtyComposites[id]) {

--- a/src/test/ReactPerf.js
+++ b/src/test/ReactPerf.js
@@ -15,7 +15,7 @@
  * ReactPerf is a general AOP system designed to measure performance. This
  * module only has the hooks: see ReactDefaultPerf for the analysis tool.
  */
-var ReactPerf = {
+const ReactPerf = {
   /**
    * Boolean to enable/disable measurement. Set to false by default to prevent
    * accidental logging and perf loss.
@@ -35,7 +35,7 @@ var ReactPerf = {
    */
   measureMethods: function(object, objectName, methodNames) {
     if (__DEV__) {
-      for (var key in methodNames) {
+      for (let key in methodNames) {
         if (!methodNames.hasOwnProperty(key)) {
           continue;
         }
@@ -58,8 +58,8 @@ var ReactPerf = {
    */
   measure: function(objName, fnName, func) {
     if (__DEV__) {
-      var measuredFunc = null;
-      var wrapper = function() {
+      let measuredFunc = null;
+      const wrapper = function() {
         if (ReactPerf.enableMeasure) {
           if (!measuredFunc) {
             measuredFunc = ReactPerf.storedMeasure(objName, fnName, func);

--- a/src/test/ReactPerf.js
+++ b/src/test/ReactPerf.js
@@ -35,7 +35,7 @@ const ReactPerf = {
    */
   measureMethods: function(object, objectName, methodNames) {
     if (__DEV__) {
-      for (let key in methodNames) {
+      for (const key in methodNames) {
         if (!methodNames.hasOwnProperty(key)) {
           continue;
         }

--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -11,26 +11,26 @@
 
 'use strict';
 
-var EventConstants = require('EventConstants');
-var EventPluginHub = require('EventPluginHub');
-var EventPluginRegistry = require('EventPluginRegistry');
-var EventPropagators = require('EventPropagators');
-var React = require('React');
-var ReactDOM = require('ReactDOM');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var ReactElement = require('ReactElement');
-var ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
-var ReactCompositeComponent = require('ReactCompositeComponent');
-var ReactInstanceMap = require('ReactInstanceMap');
-var ReactUpdates = require('ReactUpdates');
-var SyntheticEvent = require('SyntheticEvent');
+const EventConstants = require('EventConstants');
+const EventPluginHub = require('EventPluginHub');
+const EventPluginRegistry = require('EventPluginRegistry');
+const EventPropagators = require('EventPropagators');
+const React = require('React');
+const ReactDOM = require('ReactDOM');
+const ReactDOMComponentTree = require('ReactDOMComponentTree');
+const ReactElement = require('ReactElement');
+const ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
+const ReactCompositeComponent = require('ReactCompositeComponent');
+const ReactInstanceMap = require('ReactInstanceMap');
+const ReactUpdates = require('ReactUpdates');
+const SyntheticEvent = require('SyntheticEvent');
 
-var assign = require('Object.assign');
-var emptyObject = require('emptyObject');
-var findDOMNode = require('findDOMNode');
-var invariant = require('invariant');
+const assign = require('Object.assign');
+const emptyObject = require('emptyObject');
+const findDOMNode = require('findDOMNode');
+const invariant = require('invariant');
 
-var topLevelTypes = EventConstants.topLevelTypes;
+const topLevelTypes = EventConstants.topLevelTypes;
 
 function Event(suffix) {}
 
@@ -42,12 +42,12 @@ function findAllInRenderedTreeInternal(inst, test) {
   if (!inst || !inst.getPublicInstance) {
     return [];
   }
-  var publicInst = inst.getPublicInstance();
-  var ret = test(publicInst) ? [publicInst] : [];
-  var currentElement = inst._currentElement;
+  const publicInst = inst.getPublicInstance();
+  let ret = test(publicInst) ? [publicInst] : [];
+  const currentElement = inst._currentElement;
   if (ReactTestUtils.isDOMComponent(publicInst)) {
-    var renderedChildren = inst._renderedChildren;
-    var key;
+    const renderedChildren = inst._renderedChildren;
+    let key;
     for (key in renderedChildren) {
       if (!renderedChildren.hasOwnProperty(key)) {
         continue;
@@ -77,7 +77,7 @@ function findAllInRenderedTreeInternal(inst, test) {
  */
 var ReactTestUtils = {
   renderIntoDocument: function(instance) {
-    var div = document.createElement('div');
+    const div = document.createElement('div');
     // None of our tests actually require attaching the container to the
     // DOM, and doing so creates a mess that we rely on test isolation to
     // clean up, so we're going to stop honoring the name of this method
@@ -122,8 +122,8 @@ var ReactTestUtils = {
     if (!ReactTestUtils.isCompositeComponent(inst)) {
       return false;
     }
-    var internalInstance = ReactInstanceMap.get(inst);
-    var constructor = internalInstance
+    const internalInstance = ReactInstanceMap.get(inst);
+    const constructor = internalInstance
       ._currentElement
       .type;
 
@@ -136,7 +136,7 @@ var ReactTestUtils = {
     }
     // We check the prototype of the type that will get mounted, not the
     // instance itself. This is a future proof way of duck typing.
-    var prototype = inst.type.prototype;
+    const prototype = inst.type.prototype;
     return (
       typeof prototype.render === 'function' &&
       typeof prototype.setState === 'function'
@@ -144,8 +144,8 @@ var ReactTestUtils = {
   },
 
   isCompositeComponentElementWithType: function(inst, type) {
-    var internalInstance = ReactInstanceMap.get(inst);
-    var constructor = internalInstance
+    const internalInstance = ReactInstanceMap.get(inst);
+    const constructor = internalInstance
       ._currentElement
       .type;
 
@@ -157,7 +157,7 @@ var ReactTestUtils = {
     if (!ReactTestUtils.isCompositeComponent(inst)) {
       return null;
     }
-    var internalInstance = ReactInstanceMap.get(inst);
+    const internalInstance = ReactInstanceMap.get(inst);
     return internalInstance._renderedComponent.getPublicInstance();
   },
 
@@ -183,12 +183,12 @@ var ReactTestUtils = {
     }
     return ReactTestUtils.findAllInRenderedTree(root, function(inst) {
       if (ReactTestUtils.isDOMComponent(inst)) {
-        var className = inst.className;
+        let className = inst.className;
         if (typeof className !== 'string') {
           // SVG, probably.
           className = inst.getAttribute('class') || '';
         }
-        var classList = className.split(/\s+/);
+        const classList = className.split(/\s+/);
         return classNames.every(function(name) {
           return classList.indexOf(name) !== -1;
         });
@@ -204,7 +204,7 @@ var ReactTestUtils = {
    * @return {!ReactDOMComponent} The one match.
    */
   findRenderedDOMComponentWithClass: function(root, className) {
-    var all =
+    const all =
       ReactTestUtils.scryRenderedDOMComponentsWithClass(root, className);
     if (all.length !== 1) {
       throw new Error(
@@ -235,7 +235,7 @@ var ReactTestUtils = {
    * @return {!ReactDOMComponent} The one match.
    */
   findRenderedDOMComponentWithTag: function(root, tagName) {
-    var all = ReactTestUtils.scryRenderedDOMComponentsWithTag(root, tagName);
+    const all = ReactTestUtils.scryRenderedDOMComponentsWithTag(root, tagName);
     if (all.length !== 1) {
       throw new Error(
         'Did not find exactly one match (found: ' + all.length + ') ' +
@@ -266,7 +266,7 @@ var ReactTestUtils = {
    * @return {!ReactComponent} The one match.
    */
   findRenderedComponentWithType: function(root, componentType) {
-    var all = ReactTestUtils.scryRenderedComponentsWithType(
+    const all = ReactTestUtils.scryRenderedComponentsWithType(
       root,
       componentType
     );
@@ -366,7 +366,7 @@ ReactShallowRenderer.prototype.getMountedInstance = function() {
   return this._instance ? this._instance._instance : null;
 };
 
-var NoopInternalComponent = function(element) {
+const NoopInternalComponent = function(element) {
   this._renderedOutput = element;
   this._currentElement = element;
 };
@@ -393,7 +393,7 @@ NoopInternalComponent.prototype = {
   },
 };
 
-var ShallowComponentWrapper = function(element) {
+const ShallowComponentWrapper = function(element) {
   this.construct(element);
 };
 assign(
@@ -435,7 +435,7 @@ ReactShallowRenderer.prototype.render = function(element, context) {
 };
 
 function _batchedRender(renderer, element, context) {
-  var transaction = ReactUpdates.ReactReconcileTransaction.getPooled(true);
+  const transaction = ReactUpdates.ReactReconcileTransaction.getPooled(true);
   renderer._render(element, transaction, context);
   ReactUpdates.ReactReconcileTransaction.release(transaction);
 }
@@ -458,7 +458,7 @@ ReactShallowRenderer.prototype._render = function(element, transaction, context)
   if (this._instance) {
     this._instance.receiveComponent(element, transaction, context);
   } else {
-    var instance = new ShallowComponentWrapper(element);
+    const instance = new ShallowComponentWrapper(element);
     instance.mountComponent(transaction, null, null, context);
     this._instance = instance;
   }
@@ -474,7 +474,7 @@ ReactShallowRenderer.prototype._render = function(element, transaction, context)
  */
 function makeSimulator(eventType) {
   return function(domComponentOrNode, eventData) {
-    var node;
+    let node;
     invariant(
       !React.isValidElement(domComponentOrNode),
       'TestUtils.Simulate expects a component instance and not a ReactElement.' +
@@ -486,14 +486,14 @@ function makeSimulator(eventType) {
       node = domComponentOrNode;
     }
 
-    var dispatchConfig =
+    const dispatchConfig =
       EventPluginRegistry.eventNameDispatchConfigs[eventType];
 
-    var fakeNativeEvent = new Event();
+    const fakeNativeEvent = new Event();
     fakeNativeEvent.target = node;
     // We don't use SyntheticEvent.getPooled in order to not have to worry about
     // properly destroying any properties assigned from `eventData` upon release
-    var event = new SyntheticEvent(
+    const event = new SyntheticEvent(
       dispatchConfig,
       ReactDOMComponentTree.getInstanceFromNode(node),
       fakeNativeEvent,
@@ -517,7 +517,7 @@ function makeSimulator(eventType) {
 function buildSimulators() {
   ReactTestUtils.Simulate = {};
 
-  var eventType;
+  let eventType;
   for (eventType in EventPluginRegistry.eventNameDispatchConfigs) {
     /**
      * @param {!Element|ReactDOMComponent} domComponentOrNode
@@ -528,12 +528,12 @@ function buildSimulators() {
 }
 
 // Rebuild ReactTestUtils.Simulate whenever event plugins are injected
-var oldInjectEventPluginOrder = EventPluginHub.injection.injectEventPluginOrder;
+const oldInjectEventPluginOrder = EventPluginHub.injection.injectEventPluginOrder;
 EventPluginHub.injection.injectEventPluginOrder = function() {
   oldInjectEventPluginOrder.apply(this, arguments);
   buildSimulators();
 };
-var oldInjectEventPlugins = EventPluginHub.injection.injectEventPluginsByName;
+const oldInjectEventPlugins = EventPluginHub.injection.injectEventPluginsByName;
 EventPluginHub.injection.injectEventPluginsByName = function() {
   oldInjectEventPlugins.apply(this, arguments);
   buildSimulators();
@@ -559,7 +559,7 @@ buildSimulators();
 
 function makeNativeSimulator(eventType) {
   return function(domComponentOrNode, nativeEventData) {
-    var fakeNativeEvent = new Event(eventType);
+    const fakeNativeEvent = new Event(eventType);
     assign(fakeNativeEvent, nativeEventData);
     if (ReactTestUtils.isDOMComponent(domComponentOrNode)) {
       ReactTestUtils.simulateNativeEventOnDOMComponent(
@@ -580,7 +580,7 @@ function makeNativeSimulator(eventType) {
 
 Object.keys(topLevelTypes).forEach(function(eventType) {
   // Event type is stored as 'topClick' - we transform that to 'click'
-  var convenienceName = eventType.indexOf('top') === 0 ?
+  const convenienceName = eventType.indexOf('top') === 0 ?
     eventType.charAt(3).toLowerCase() + eventType.substr(4) : eventType;
   /**
    * @param {!Element|ReactDOMComponent} domComponentOrNode

--- a/src/test/__tests__/MetaMatchers-test.js
+++ b/src/test/__tests__/MetaMatchers-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var MetaMatchers = require('MetaMatchers');
+const MetaMatchers = require('MetaMatchers');
 
 describe('meta-matchers', function() {
 

--- a/src/test/__tests__/ReactDefaultPerf-test.js
+++ b/src/test/__tests__/ReactDefaultPerf-test.js
@@ -12,18 +12,18 @@
 'use strict';
 
 describe('ReactDefaultPerf', function() {
-  var React;
-  var ReactDOM;
-  var ReactDefaultPerf;
-  var ReactTestUtils;
-  var ReactDefaultPerfAnalysis;
+  let React;
+  let ReactDOM;
+  let ReactDefaultPerf;
+  let ReactTestUtils;
+  let ReactDefaultPerfAnalysis;
 
-  var App;
-  var Box;
-  var Div;
+  let App;
+  let Box;
+  let Div;
 
   beforeEach(function() {
-    var now = 0;
+    let now = 0;
     jest.setMock('fbjs/lib/performanceNow', function() {
       return now++;
     });
@@ -62,13 +62,13 @@ describe('ReactDefaultPerf', function() {
   }
 
   it('should count no-op update as waste', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<App />, container);
-    var measurements = measure(() => {
+    const measurements = measure(() => {
       ReactDOM.render(<App />, container);
     });
 
-    var summary = ReactDefaultPerf.getMeasurementsSummaryMap(measurements);
+    const summary = ReactDefaultPerf.getMeasurementsSummaryMap(measurements);
     expect(summary.length).toBe(2);
 
     /*eslint-disable dot-notation */
@@ -85,16 +85,16 @@ describe('ReactDefaultPerf', function() {
   });
 
   it('should count no-op update in child as waste', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<App />, container);
 
     // Here, we add a Box -- two of the <Box /> updates are wasted time (but the
     // addition of the third is not)
-    var measurements = measure(() => {
+    const measurements = measure(() => {
       ReactDOM.render(<App flipSecond={true} />, container);
     });
 
-    var summary = ReactDefaultPerf.getMeasurementsSummaryMap(measurements);
+    const summary = ReactDefaultPerf.getMeasurementsSummaryMap(measurements);
     expect(summary.length).toBe(1);
 
     /*eslint-disable dot-notation */
@@ -107,8 +107,8 @@ describe('ReactDefaultPerf', function() {
   });
 
   function expectNoWaste(fn) {
-    var measurements = measure(fn);
-    var summary = ReactDefaultPerf.getMeasurementsSummaryMap(measurements);
+    const measurements = measure(fn);
+    const summary = ReactDefaultPerf.getMeasurementsSummaryMap(measurements);
     expect(summary).toEqual([]);
   }
 
@@ -119,7 +119,7 @@ describe('ReactDefaultPerf', function() {
   });
 
   it('should not count unmount as waste', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<Div>hello</Div>, container);
     expectNoWaste(() => {
       ReactDOM.unmountComponentAtNode(container);
@@ -127,7 +127,7 @@ describe('ReactDefaultPerf', function() {
   });
 
   it('should not count content update as waste', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<Div>hello</Div>, container);
     expectNoWaste(() => {
       ReactDOM.render(<Div>hello world</Div>, container);
@@ -135,7 +135,7 @@ describe('ReactDefaultPerf', function() {
   });
 
   it('should not count child addition as waste', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<Div><span /></Div>, container);
     expectNoWaste(() => {
       ReactDOM.render(<Div><span /><span /></Div>, container);
@@ -143,7 +143,7 @@ describe('ReactDefaultPerf', function() {
   });
 
   it('should not count child removal as waste', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<Div><span /><span /></Div>, container);
     expectNoWaste(() => {
       ReactDOM.render(<Div><span /></Div>, container);
@@ -151,7 +151,7 @@ describe('ReactDefaultPerf', function() {
   });
 
   it('should not count property update as waste', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<Div className="yellow">hey</Div>, container);
     expectNoWaste(() => {
       ReactDOM.render(<Div className="blue">hey</Div>, container);
@@ -159,7 +159,7 @@ describe('ReactDefaultPerf', function() {
   });
 
   it('should not count style update as waste', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<Div style={{color: 'yellow'}}>hey</Div>, container);
     expectNoWaste(() => {
       ReactDOM.render(<Div style={{color: 'blue'}}>hey</Div>, container);
@@ -167,7 +167,7 @@ describe('ReactDefaultPerf', function() {
   });
 
   it('should not count property removal as waste', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<Div className="yellow">hey</Div>, container);
     expectNoWaste(() => {
       ReactDOM.render(<Div>hey</Div>, container);
@@ -175,7 +175,7 @@ describe('ReactDefaultPerf', function() {
   });
 
   it('should not count raw HTML update as waste', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(
       <Div dangerouslySetInnerHTML={{__html: 'me'}} />,
       container
@@ -189,7 +189,7 @@ describe('ReactDefaultPerf', function() {
   });
 
   it('should not count child reordering as waste', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<Div><div key="A" /><div key="B" /></Div>, container);
     expectNoWaste(() => {
       ReactDOM.render(<Div><div key="B" /><div key="A" /></Div>, container);
@@ -197,7 +197,7 @@ describe('ReactDefaultPerf', function() {
   });
 
   it('should not count text update as waste', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<Div>{'hello'}{'world'}</Div>, container);
     expectNoWaste(() => {
       ReactDOM.render(<Div>{'hello'}{'friend'}</Div>, container);
@@ -205,24 +205,24 @@ describe('ReactDefaultPerf', function() {
   });
 
   it('putListener should not be instrumented', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<Div onClick={function() {}}>hey</Div>, container);
-    var measurements = measure(() => {
+    const measurements = measure(() => {
       ReactDOM.render(<Div onClick={function() {}}>hey</Div>, container);
     });
 
-    var summary = ReactDefaultPerfAnalysis.getDOMSummary(measurements);
+    const summary = ReactDefaultPerfAnalysis.getDOMSummary(measurements);
     expect(summary).toEqual([]);
   });
 
   it('deleteListener should not be instrumented', function() {
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<Div onClick={function() {}}>hey</Div>, container);
-    var measurements = measure(() => {
+    const measurements = measure(() => {
       ReactDOM.render(<Div>hey</Div>, container);
     });
 
-    var summary = ReactDefaultPerfAnalysis.getDOMSummary(measurements);
+    const summary = ReactDefaultPerfAnalysis.getDOMSummary(measurements);
     expect(summary).toEqual([]);
   });
 

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -11,10 +11,10 @@
 
 'use strict';
 
-var React;
-var ReactDOM;
-var ReactDOMServer;
-var ReactTestUtils;
+let React;
+let ReactDOM;
+let ReactDOMServer;
+let ReactTestUtils;
 
 describe('ReactTestUtils', function() {
 
@@ -26,7 +26,7 @@ describe('ReactTestUtils', function() {
   });
 
   it('should have shallow rendering', function() {
-    var SomeComponent = React.createClass({
+    const SomeComponent = React.createClass({
       render: function() {
         return (
           <div>
@@ -37,8 +37,8 @@ describe('ReactTestUtils', function() {
       },
     });
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    var result = shallowRenderer.render(<SomeComponent />);
+    const shallowRenderer = ReactTestUtils.createRenderer();
+    const result = shallowRenderer.render(<SomeComponent />);
 
     expect(result.type).toBe('div');
     expect(result.props.children).toEqual([
@@ -48,13 +48,13 @@ describe('ReactTestUtils', function() {
   });
 
   it('should throw for invalid elements', function() {
-    var SomeComponent = React.createClass({
+    const SomeComponent = React.createClass({
       render: function() {
         return <div />;
       },
     });
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
+    const shallowRenderer = ReactTestUtils.createRenderer();
     expect(() => shallowRenderer.render(SomeComponent)).toThrow(
       'ReactShallowRenderer render(): Invalid component element. Instead of ' +
       'passing a component class, make sure to instantiate it by passing it ' +
@@ -69,16 +69,16 @@ describe('ReactTestUtils', function() {
   });
 
   it('should have shallow unmounting', function() {
-    var componentWillUnmount = jest.genMockFn();
+    const componentWillUnmount = jest.genMockFn();
 
-    var SomeComponent = React.createClass({
+    const SomeComponent = React.createClass({
       render: function() {
         return <div />;
       },
       componentWillUnmount,
     });
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
+    const shallowRenderer = ReactTestUtils.createRenderer();
     shallowRenderer.render(<SomeComponent />);
     shallowRenderer.unmount();
 
@@ -86,32 +86,32 @@ describe('ReactTestUtils', function() {
   });
 
   it('can shallow render to null', function() {
-    var SomeComponent = React.createClass({
+    const SomeComponent = React.createClass({
       render: function() {
         return null;
       },
     });
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    var result = shallowRenderer.render(<SomeComponent />);
+    const shallowRenderer = ReactTestUtils.createRenderer();
+    const result = shallowRenderer.render(<SomeComponent />);
 
     expect(result).toBe(null);
   });
 
   it('can shallow render with a ref', function() {
-    var SomeComponent = React.createClass({
+    const SomeComponent = React.createClass({
       render: function() {
         return <div ref="hello" />;
       },
     });
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
+    const shallowRenderer = ReactTestUtils.createRenderer();
     // Shouldn't crash.
     shallowRenderer.render(<SomeComponent />);
   });
 
   it('lets you update shallowly rendered components', function() {
-    var SomeComponent = React.createClass({
+    const SomeComponent = React.createClass({
       getInitialState: function() {
         return {clicked: false};
       },
@@ -121,7 +121,7 @@ describe('ReactTestUtils', function() {
       },
 
       render: function() {
-        var className = this.state.clicked ? 'was-clicked' : '';
+        const className = this.state.clicked ? 'was-clicked' : '';
 
         if (this.props.aNew === 'prop') {
           return (
@@ -143,27 +143,27 @@ describe('ReactTestUtils', function() {
       },
     });
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    var result = shallowRenderer.render(<SomeComponent />);
+    const shallowRenderer = ReactTestUtils.createRenderer();
+    const result = shallowRenderer.render(<SomeComponent />);
     expect(result.type).toBe('div');
     expect(result.props.children).toEqual([
       <span className="child1" />,
       <span className="child2" />,
     ]);
 
-    var updatedResult = shallowRenderer.render(<SomeComponent aNew="prop" />);
+    const updatedResult = shallowRenderer.render(<SomeComponent aNew="prop" />);
     expect(updatedResult.type).toBe('a');
 
-    var mockEvent = {};
+    const mockEvent = {};
     updatedResult.props.onClick(mockEvent);
 
-    var updatedResultCausedByClick = shallowRenderer.getRenderOutput();
+    const updatedResultCausedByClick = shallowRenderer.getRenderOutput();
     expect(updatedResultCausedByClick.type).toBe('a');
     expect(updatedResultCausedByClick.props.className).toBe('was-clicked');
   });
 
   it('can access the mounted component instance', function() {
-    var SimpleComponent = React.createClass({
+    const SimpleComponent = React.createClass({
       someMethod: function() {
         return this.props.n;
       },
@@ -172,13 +172,13 @@ describe('ReactTestUtils', function() {
       },
     });
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
+    const shallowRenderer = ReactTestUtils.createRenderer();
     shallowRenderer.render(<SimpleComponent n={5} />);
     expect(shallowRenderer.getMountedInstance().someMethod()).toEqual(5);
   });
 
   it('can shallowly render components with contextTypes', function() {
-    var SimpleComponent = React.createClass({
+    const SimpleComponent = React.createClass({
       contextTypes: {
         name: React.PropTypes.string,
       },
@@ -187,13 +187,13 @@ describe('ReactTestUtils', function() {
       },
     });
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    var result = shallowRenderer.render(<SimpleComponent />);
+    const shallowRenderer = ReactTestUtils.createRenderer();
+    const result = shallowRenderer.render(<SimpleComponent />);
     expect(result).toEqual(<div />);
   });
 
   it('can shallowly render components with ref as function', function() {
-    var SimpleComponent = React.createClass({
+    const SimpleComponent = React.createClass({
       getInitialState: function() {
         return {clicked: false};
       },
@@ -205,9 +205,9 @@ describe('ReactTestUtils', function() {
       },
     });
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
+    const shallowRenderer = ReactTestUtils.createRenderer();
     shallowRenderer.render(<SimpleComponent />);
-    var result = shallowRenderer.getRenderOutput();
+    let result = shallowRenderer.getRenderOutput();
     expect(result.type).toEqual('div');
     expect(result.props.className).toEqual('');
     result.props.onClick();
@@ -218,7 +218,7 @@ describe('ReactTestUtils', function() {
   });
 
   it('can setState in componentWillMount when shallow rendering', function() {
-    var SimpleComponent = React.createClass({
+    const SimpleComponent = React.createClass({
       componentWillMount() {
         this.setState({groovy: 'doovy'});
       },
@@ -227,13 +227,13 @@ describe('ReactTestUtils', function() {
       },
     });
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    var result = shallowRenderer.render(<SimpleComponent />);
+    const shallowRenderer = ReactTestUtils.createRenderer();
+    const result = shallowRenderer.render(<SimpleComponent />);
     expect(result).toEqual(<div>doovy</div>);
   });
 
   it('can pass context when shallowly rendering', function() {
-    var SimpleComponent = React.createClass({
+    const SimpleComponent = React.createClass({
       contextTypes: {
         name: React.PropTypes.string,
       },
@@ -242,21 +242,21 @@ describe('ReactTestUtils', function() {
       },
     });
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    var result = shallowRenderer.render(<SimpleComponent />, {
+    const shallowRenderer = ReactTestUtils.createRenderer();
+    const result = shallowRenderer.render(<SimpleComponent />, {
       name: 'foo',
     });
     expect(result).toEqual(<div>foo</div>);
   });
 
   it('can scryRenderedDOMComponentsWithClass with TextComponent', function() {
-    var Wrapper = React.createClass({
+    const Wrapper = React.createClass({
       render: function() {
         return <div>Hello <span>Jim</span></div>;
       },
     });
-    var renderedComponent = ReactTestUtils.renderIntoDocument(<Wrapper />);
-    var scryResults = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+    const renderedComponent = ReactTestUtils.renderIntoDocument(<Wrapper />);
+    const scryResults = ReactTestUtils.scryRenderedDOMComponentsWithClass(
       renderedComponent,
       'NonExistentClass'
     );
@@ -264,13 +264,13 @@ describe('ReactTestUtils', function() {
   });
 
   it('can scryRenderedDOMComponentsWithClass with className contains \\n', function() {
-    var Wrapper = React.createClass({
+    const Wrapper = React.createClass({
       render: function() {
         return <div>Hello <span className={'x\ny'}>Jim</span></div>;
       },
     });
-    var renderedComponent = ReactTestUtils.renderIntoDocument(<Wrapper />);
-    var scryResults = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+    const renderedComponent = ReactTestUtils.renderIntoDocument(<Wrapper />);
+    const scryResults = ReactTestUtils.scryRenderedDOMComponentsWithClass(
       renderedComponent,
       'x'
     );
@@ -278,25 +278,25 @@ describe('ReactTestUtils', function() {
   });
 
   it('can scryRenderedDOMComponentsWithClass with multiple classes', function() {
-    var Wrapper = React.createClass({
+    const Wrapper = React.createClass({
       render: function() {
         return <div>Hello <span className={'x y z'}>Jim</span></div>;
       },
     });
-    var renderedComponent = ReactTestUtils.renderIntoDocument(<Wrapper />);
-    var scryResults1 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+    const renderedComponent = ReactTestUtils.renderIntoDocument(<Wrapper />);
+    const scryResults1 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
       renderedComponent,
       'x y'
     );
     expect(scryResults1.length).toBe(1);
 
-    var scryResults2 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+    const scryResults2 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
       renderedComponent,
       'x z'
     );
     expect(scryResults2.length).toBe(1);
 
-    var scryResults3 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+    const scryResults3 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
       renderedComponent,
       ['x', 'y']
     );
@@ -305,13 +305,13 @@ describe('ReactTestUtils', function() {
     expect(scryResults1[0]).toBe(scryResults2[0]);
     expect(scryResults1[0]).toBe(scryResults3[0]);
 
-    var scryResults4 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+    const scryResults4 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
       renderedComponent,
       ['x', 'a']
     );
     expect(scryResults4.length).toBe(0);
 
-    var scryResults5 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+    const scryResults5 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
       renderedComponent,
       ['x a']
     );
@@ -319,13 +319,13 @@ describe('ReactTestUtils', function() {
   });
 
   it('traverses children in the correct order', function() {
-    var Wrapper = React.createClass({
+    const Wrapper = React.createClass({
       render: function() {
         return <div>{this.props.children}</div>;
       },
     });
 
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(
       <Wrapper>
         {null}
@@ -333,7 +333,7 @@ describe('ReactTestUtils', function() {
       </Wrapper>,
       container
     );
-    var tree = ReactDOM.render(
+    const tree = ReactDOM.render(
       <Wrapper>
         <div>orange</div>
         <div>purple</div>
@@ -341,7 +341,7 @@ describe('ReactTestUtils', function() {
       container
     );
 
-    var log = [];
+    const log = [];
     ReactTestUtils.findAllInRenderedTree(tree, function(child) {
       if (ReactTestUtils.isDOMComponent(child)) {
         log.push(ReactDOM.findDOMNode(child).textContent);
@@ -353,9 +353,9 @@ describe('ReactTestUtils', function() {
   });
 
   it('should support injected wrapper components as DOM components', function() {
-    var getTestDocument = require('getTestDocument');
+    const getTestDocument = require('getTestDocument');
 
-    var injectedDOMComponents = [
+    const injectedDOMComponents = [
       'button',
       'form',
       'iframe',
@@ -367,7 +367,7 @@ describe('ReactTestUtils', function() {
     ];
 
     injectedDOMComponents.forEach(function(type) {
-      var testComponent = ReactTestUtils.renderIntoDocument(
+      const testComponent = ReactTestUtils.renderIntoDocument(
         React.createElement(type)
       );
       expect(testComponent.tagName).toBe(type.toUpperCase());
@@ -376,7 +376,7 @@ describe('ReactTestUtils', function() {
 
     // Full-page components (html, head, body) can't be rendered into a div
     // directly...
-    var Root = React.createClass({
+    const Root = React.createClass({
       render: function() {
         return (
           <html ref="html">
@@ -391,9 +391,9 @@ describe('ReactTestUtils', function() {
       },
     });
 
-    var markup = ReactDOMServer.renderToString(<Root />);
-    var testDocument = getTestDocument(markup);
-    var component = ReactDOM.render(<Root />, testDocument);
+    const markup = ReactDOMServer.renderToString(<Root />);
+    const testDocument = getTestDocument(markup);
+    const component = ReactDOM.render(<Root />, testDocument);
 
     expect(component.refs.html.tagName).toBe('HTML');
     expect(component.refs.head.tagName).toBe('HEAD');
@@ -404,16 +404,16 @@ describe('ReactTestUtils', function() {
   });
 
   it('should change the value of an input field', function() {
-    var obj = {
+    const obj = {
       handler: function(e) {
         e.persist();
       },
     };
     spyOn(obj, 'handler').andCallThrough();
-    var container = document.createElement('div');
-    var instance = ReactDOM.render(<input type="text" onChange={obj.handler} />, container);
+    const container = document.createElement('div');
+    const instance = ReactDOM.render(<input type="text" onChange={obj.handler} />, container);
 
-    var node = ReactDOM.findDOMNode(instance);
+    const node = ReactDOM.findDOMNode(instance);
     node.value = 'giraffe';
     ReactTestUtils.Simulate.change(node);
 
@@ -421,7 +421,7 @@ describe('ReactTestUtils', function() {
   });
 
   it('should change the value of an input field in a component', function() {
-    var SomeComponent = React.createClass({
+    const SomeComponent = React.createClass({
       render: function() {
         return (
           <div>
@@ -431,16 +431,16 @@ describe('ReactTestUtils', function() {
       },
     });
 
-    var obj = {
+    const obj = {
       handler: function(e) {
         e.persist();
       },
     };
     spyOn(obj, 'handler').andCallThrough();
-    var container = document.createElement('div');
-    var instance = ReactDOM.render(<SomeComponent handleChange={obj.handler} />, container);
+    const container = document.createElement('div');
+    const instance = ReactDOM.render(<SomeComponent handleChange={obj.handler} />, container);
 
-    var node = ReactDOM.findDOMNode(instance.refs.input);
+    const node = ReactDOM.findDOMNode(instance.refs.input);
     node.value = 'zebra';
     ReactTestUtils.Simulate.change(node);
 
@@ -448,7 +448,7 @@ describe('ReactTestUtils', function() {
   });
 
   it('should throw when attempting to use ReactTestUtils.Simulate with shallow rendering', function() {
-    var SomeComponent = React.createClass({
+    const SomeComponent = React.createClass({
       render: function() {
         return (
           <div onClick={this.props.handleClick}>
@@ -457,9 +457,9 @@ describe('ReactTestUtils', function() {
         );
       },
     });
-    var handler = jasmine.createSpy('spy');
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    var result = shallowRenderer.render(<SomeComponent handleClick={handler} />);
+    const handler = jasmine.createSpy('spy');
+    const shallowRenderer = ReactTestUtils.createRenderer();
+    const result = shallowRenderer.render(<SomeComponent handleClick={handler} />);
 
     expect(() => ReactTestUtils.Simulate.click(result)).toThrow(
       'TestUtils.Simulate expects a component instance and not a ReactElement.' +
@@ -469,8 +469,8 @@ describe('ReactTestUtils', function() {
   });
 
   it('can scry with stateless components involved', function() {
-    var Stateless = () => <div><hr /></div>;
-    var SomeComponent = React.createClass({
+    const Stateless = () => <div><hr /></div>;
+    const SomeComponent = React.createClass({
       render: function() {
         return (
           <div>
@@ -481,8 +481,8 @@ describe('ReactTestUtils', function() {
       },
     });
 
-    var inst = ReactTestUtils.renderIntoDocument(<SomeComponent />);
-    var hrs = ReactTestUtils.scryRenderedDOMComponentsWithTag(inst, 'hr');
+    const inst = ReactTestUtils.renderIntoDocument(<SomeComponent />);
+    const hrs = ReactTestUtils.scryRenderedDOMComponentsWithTag(inst, 'hr');
     expect(hrs.length).toBe(2);
   });
 

--- a/src/test/__tests__/reactComponentExpect-test.js
+++ b/src/test/__tests__/reactComponentExpect-test.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-var React;
-var ReactTestUtils;
-var reactComponentExpect;
+let React;
+let ReactTestUtils;
+let reactComponentExpect;
 
 describe('reactComponentExpect', function() {
 
@@ -24,7 +24,7 @@ describe('reactComponentExpect', function() {
   });
 
   it('should detect text components', function() {
-    var SomeComponent = React.createClass({
+    const SomeComponent = React.createClass({
       render: function() {
         return (
           <div>
@@ -35,7 +35,7 @@ describe('reactComponentExpect', function() {
       },
     });
 
-    var component = ReactTestUtils.renderIntoDocument(<SomeComponent />);
+    const component = ReactTestUtils.renderIntoDocument(<SomeComponent />);
 
     reactComponentExpect(component)
       .expectRenderedChild()

--- a/src/test/createHierarchyRenderer.js
+++ b/src/test/createHierarchyRenderer.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var React = require('React');
+const React = require('React');
 
 /**
  * Creates a render method that makes it easier to create, render, and inspect a
@@ -53,10 +53,10 @@ var React = require('React');
  * @return {function}
  */
 function createHierarchyRenderer(...renderMethods) {
-  var instances;
-  var Components = renderMethods.reduceRight(
+  let instances;
+  const Components = renderMethods.reduceRight(
     function(ComponentsAccumulator, renderMethod, depth) {
-      var Component = React.createClass({
+      const Component = React.createClass({
         displayName: renderMethod.name,
         render: function() {
           instances[depth].push(this);

--- a/src/test/reactComponentExpect.js
+++ b/src/test/reactComponentExpect.js
@@ -12,11 +12,11 @@
 
 'use strict';
 
-var ReactInstanceMap = require('ReactInstanceMap');
-var ReactTestUtils = require('ReactTestUtils');
+const ReactInstanceMap = require('ReactInstanceMap');
+const ReactTestUtils = require('ReactTestUtils');
 
-var assign = require('Object.assign');
-var invariant = require('invariant');
+const assign = require('Object.assign');
+const invariant = require('invariant');
 
 function reactComponentExpect(instance) {
   if (instance instanceof reactComponentExpectInternal) {
@@ -34,7 +34,7 @@ function reactComponentExpect(instance) {
     ReactTestUtils.isCompositeComponent(instance),
     'reactComponentExpect(...): instance must be a composite component'
   );
-  var internalInstance = ReactInstanceMap.get(instance);
+  const internalInstance = ReactInstanceMap.get(instance);
 
   expect(typeof internalInstance).toBe('object');
   expect(typeof internalInstance.constructor).toBe('function');
@@ -73,7 +73,7 @@ assign(reactComponentExpectInternal.prototype, {
    */
   expectRenderedChild: function() {
     this.toBeCompositeComponent();
-    var child = this._instance._renderedComponent;
+    const child = this._instance._renderedComponent;
     // TODO: Hide ReactEmptyComponent instances here?
     return new reactComponentExpectInternal(child);
   },
@@ -85,9 +85,9 @@ assign(reactComponentExpectInternal.prototype, {
     // Currently only dom components have arrays of children, but that will
     // change soon.
     this.toBeDOMComponent();
-    var renderedChildren =
+    const renderedChildren =
       this._instance._renderedChildren || {};
-    for (var name in renderedChildren) {
+    for (let name in renderedChildren) {
       if (!renderedChildren.hasOwnProperty(name)) {
         continue;
       }
@@ -102,7 +102,7 @@ assign(reactComponentExpectInternal.prototype, {
 
   toBeDOMComponentWithChildCount: function(count) {
     this.toBeDOMComponent();
-    var renderedChildren = this._instance._renderedChildren;
+    const renderedChildren = this._instance._renderedChildren;
     expect(renderedChildren).toBeTruthy();
     expect(Object.keys(renderedChildren).length).toBe(count);
     return this;
@@ -144,14 +144,14 @@ assign(reactComponentExpectInternal.prototype, {
   },
 
   toBeTextComponentWithValue: function(val) {
-    var elementType = typeof this._instance._currentElement;
+    const elementType = typeof this._instance._currentElement;
     expect(elementType === 'string' || elementType === 'number').toBe(true);
     expect(this._instance._stringText).toBe(val);
     return this;
   },
 
   toBeEmptyComponent: function() {
-    var element = this._instance._currentElement;
+    const element = this._instance._currentElement;
     return element === null || element === false;
   },
 
@@ -184,7 +184,7 @@ assign(reactComponentExpectInternal.prototype, {
    */
   scalarStateEqual: function(stateNameToExpectedValue) {
     expect(this.instance()).toBeTruthy();
-    for (var stateName in stateNameToExpectedValue) {
+    for (let stateName in stateNameToExpectedValue) {
       if (!stateNameToExpectedValue.hasOwnProperty(stateName)) {
         continue;
       }
@@ -200,7 +200,7 @@ assign(reactComponentExpectInternal.prototype, {
    */
   scalarPropsEqual: function(propNameToExpectedValue) {
     expect(this.instance()).toBeTruthy();
-    for (var propName in propNameToExpectedValue) {
+    for (let propName in propNameToExpectedValue) {
       if (!propNameToExpectedValue.hasOwnProperty(propName)) {
         continue;
       }
@@ -216,7 +216,7 @@ assign(reactComponentExpectInternal.prototype, {
    */
   scalarContextEqual: function(contextNameToExpectedValue) {
     expect(this.instance()).toBeTruthy();
-    for (var contextName in contextNameToExpectedValue) {
+    for (let contextName in contextNameToExpectedValue) {
       if (!contextNameToExpectedValue.hasOwnProperty(contextName)) {
         continue;
       }

--- a/src/test/reactComponentExpect.js
+++ b/src/test/reactComponentExpect.js
@@ -87,7 +87,7 @@ assign(reactComponentExpectInternal.prototype, {
     this.toBeDOMComponent();
     const renderedChildren =
       this._instance._renderedChildren || {};
-    for (let name in renderedChildren) {
+    for (const name in renderedChildren) {
       if (!renderedChildren.hasOwnProperty(name)) {
         continue;
       }
@@ -184,7 +184,7 @@ assign(reactComponentExpectInternal.prototype, {
    */
   scalarStateEqual: function(stateNameToExpectedValue) {
     expect(this.instance()).toBeTruthy();
-    for (let stateName in stateNameToExpectedValue) {
+    for (const stateName in stateNameToExpectedValue) {
       if (!stateNameToExpectedValue.hasOwnProperty(stateName)) {
         continue;
       }
@@ -200,7 +200,7 @@ assign(reactComponentExpectInternal.prototype, {
    */
   scalarPropsEqual: function(propNameToExpectedValue) {
     expect(this.instance()).toBeTruthy();
-    for (let propName in propNameToExpectedValue) {
+    for (const propName in propNameToExpectedValue) {
       if (!propNameToExpectedValue.hasOwnProperty(propName)) {
         continue;
       }
@@ -216,7 +216,7 @@ assign(reactComponentExpectInternal.prototype, {
    */
   scalarContextEqual: function(contextNameToExpectedValue) {
     expect(this.instance()).toBeTruthy();
-    for (let contextName in contextNameToExpectedValue) {
+    for (const contextName in contextNameToExpectedValue) {
       if (!contextNameToExpectedValue.hasOwnProperty(contextName)) {
         continue;
       }


### PR DESCRIPTION
Talked to @zpao about sending a PR for this. We prefer the React team have a discussion first whether they want to merge this.

We ran this transform quite successfully internally at Facebook and I figured it is time to convert React as well. I'm doing a talk in Tokyo (right now!) and figured it is a good time to do it live. Why the hell not?

All the tests are passing. I'm assuming the code in the React repo isn't clowny so eslint and the conservative codemod should handle all cases correctly. This is an RFC. I'm fine with any decision the React team is making with regards to the code style they want to enforce in this repo – feel free to either merge or close this. To people following along I will ask them to not start a bikeshedding discussion please but instead recommend running the codemod on your own projects yourself. If you do, please report any issues you find!

* ran: `jscodeshift -t ../js-codemod/transforms/no-vars.js src`
* transform: https://github.com/cpojer/js-codemod/blob/master/transforms/no-vars.js (thanks @iamdustan and @forbeslindesay)
* jscodeshift: https://github.com/facebook/jscodeshift
