### PR TITLE
Updated confusing sentence in thinking-in-react.md

### DIFF
--- a/docs/docs/thinking-in-react.md
+++ b/docs/docs/thinking-in-react.md
@@ -136,7 +136,7 @@ So far, we've built an app that renders correctly as a function of props and sta
 
 React makes this data flow explicit to make it easy to understand how your program works, but it does require a little more typing than traditional two-way data binding. React provides an add-on called `ReactLink` to make this pattern as convenient as two-way binding, but for the purpose of this post, we'll keep everything explicit.
 
-If you try to type or check the box in the current version of the example, you'll see that React ignores your input. This is intentional, as we've set the `value` prop of the `input` to always be equal to the `state` passed in from `FilterableProductTable`.
+If you tried to type or check the box in the last version of the example, you would see that React ignored your input. This is intentional, as we've set the `value` prop of the `input` to always be equal to the `state` passed in from `FilterableProductTable`.
 
 Let's think about what we want to happen. We want to make sure that whenever the user changes the form, we update the state to reflect the user input. Since components should only update their own state, `FilterableProductTable` will pass a callback to `SearchBar` that will fire whenever the state should be updated. We can use the `onChange` event on the inputs to be notified of it. And the callback passed by `FilterableProductTable` will call `setState()`, and the app will be updated.
 


### PR DESCRIPTION
In the text, it used to say that the "current version of the example" ignores the input. But since the new version of the code is shown before this text, this is confusing. If I try to input a search using the code shown after the headline in step 5, it will not ignore my input. It is the code from the previous step that behaves this way. It is confusing for the reader to first see the code in step 5 (that has inverse data flow added to it), and then after that read that it will ignore the input.