### PR TITLE
[Docs] Left-hand nav fixed position

### DIFF
--- a/docs/_js/fixed-nav.js
+++ b/docs/_js/fixed-nav.js
@@ -1,0 +1,34 @@
+/**
+ * Persist the scroll position of the left-hand nav
+ * when loading a new page
+ */
+
+ready(function() {
+  if (typeof Storage === "undefined") return;
+  var fixedPanel = document.querySelector('.nav-docs');
+  var links = document.querySelectorAll('.nav-docs a');
+  var scrollTop = localStorage.getItem('navScrollPosition');
+  var prevSecs = localStorage.getItem('navScrollPositionTime');
+  var nowSecs = getTimeInSeconds();
+  if (scrollTop && prevSecs && (nowSecs - prevSecs) < 10) {
+    fixedPanel.scrollTop = scrollTop;
+  }
+  for (var i = 0; i < links.length; ++i) {
+    links[i].addEventListener('click', function() {
+      localStorage.setItem('navScrollPosition', fixedPanel.scrollTop);
+      localStorage.setItem('navScrollPositionTime', getTimeInSeconds());
+    });
+  }
+});
+
+function getTimeInSeconds() {
+  return Math.round(new Date().getTime() / 1000);
+}
+
+function ready(fn) {
+ if (document.readyState != 'loading') {
+  fn();
+ } else {
+  document.addEventListener('DOMContentLoaded', fn);
+ }
+}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -34,48 +34,53 @@
   <script src="/react/js/react-dom.js"></script>
   <script src="/react/js/babel-browser.min.js"></script>
   <script src="/react/js/live_editor.js"></script>
+  <script src="/react/js/fixed-nav.js"></script>
 </head>
 <body>
 
   <div class="container">
 
-    <div class="nav-main">
-      <div class="wrap">
-        <a class="nav-home" href="/react/index.html">
-          <img class="nav-logo" src="/react/img/logo.svg" width="36" height="36">
-          React
-        </a>
-        <ul class="nav-site nav-site-internal">
-          <li><a href="/react/docs/getting-started.html"{% if page.sectionid == 'docs' or page.sectionid == 'tips' %} class="active"{% endif %}>Docs</a></li>
-          <li><a href="/react/support.html"{% if page.id == 'support' %} class="active"{% endif %}>Support</a></li>
-          <li><a href="/react/downloads.html"{% if page.id == 'downloads' %} class="active"{% endif %}>Download</a></li>
-          <li><a href="/react/blog/"{% if page.sectionid == 'blog' %} class="active"{% endif %}>Blog</a></li>
-        </ul>
+    <div class="main">
 
-        <ul class="nav-site nav-site-external">
-          <li><a href="https://github.com/facebook/react">GitHub</a></li>
-          <li><a href="https://facebook.github.io/react-native/">React Native</a></li>
-        </ul>
-      </div>
-    </div>
+      <div class="nav-main">
+        <div class="wrap">
+          <a class="nav-home" href="/react/index.html">
+            <img class="nav-logo" src="/react/img/logo.svg" width="36" height="36">
+            React
+          </a>
+          <ul class="nav-site nav-site-internal">
+            <li><a href="/react/docs/getting-started.html"{% if page.sectionid == 'docs' or page.sectionid == 'tips' %} class="active"{% endif %}>Docs</a></li>
+            <li><a href="/react/support.html"{% if page.id == 'support' %} class="active"{% endif %}>Support</a></li>
+            <li><a href="/react/downloads.html"{% if page.id == 'downloads' %} class="active"{% endif %}>Download</a></li>
+            <li><a href="/react/blog/"{% if page.sectionid == 'blog' %} class="active"{% endif %}>Blog</a></li>
+          </ul>
 
-    {% if page.id == 'home' %}
-    <div class="hero">
-      <div class="wrap">
-        <div class="text"><strong>React</strong></div>
-        <div class="minitext">
-          A JavaScript library for building user interfaces
-        </div>
-
-        <div class="buttons-unit">
-          <a href="/react/docs/getting-started.html" class="button">Get Started</a>
-          <a href="/react/downloads.html" class="button">Download React v{{site.react_version}}</a>
+          <ul class="nav-site nav-site-external">
+            <li><a href="https://github.com/facebook/react">GitHub</a></li>
+            <li><a href="https://facebook.github.io/react-native/">React Native</a></li>
+          </ul>
         </div>
       </div>
-    </div>
-    {% endif %}
 
-    {{ content }}
+      {% if page.id == 'home' %}
+      <div class="hero">
+        <div class="wrap">
+          <div class="text"><strong>React</strong></div>
+          <div class="minitext">
+            A JavaScript library for building user interfaces
+          </div>
+
+          <div class="buttons-unit">
+            <a href="/react/docs/getting-started.html" class="button">Get Started</a>
+            <a href="/react/downloads.html" class="button">Download React v{{site.react_version}}</a>
+          </div>
+        </div>
+      </div>
+      {% endif %}
+
+      {{ content }}
+
+    </div>
 
     <footer class="wrap">
       <div class="left">

--- a/docs/css/react.scss
+++ b/docs/css/react.scss
@@ -33,8 +33,6 @@ html {
   background: $pageBg;
 }
 
-
-
 .left {
   float: left;
 }
@@ -229,7 +227,12 @@ h1, h2, h3, h4, h5, h6 {
 .nav-docs {
   color: $darkColor;
   font-size: 14px;
-  // position: fixed;
+  position: fixed;
+  width: inherit;
+  bottom: 0;
+  top: 50px;
+  padding: 20px 20px 0 0;
+  overflow-y: auto;
   float: left;
   width: 210px;
 
@@ -273,8 +276,8 @@ h1, h2, h3, h4, h5, h6 {
     }
 
     &:last-child {
-      padding-bottom: 0;
       border-bottom: 0;
+      padding-bottom: 100px;
     }
   }
 
@@ -431,12 +434,29 @@ h1, h2, h3, h4, h5, h6 {
   float: right;
 }
 
+/**
+ * "Sticky" footer
+ */
+
+html, body, .container {
+  height: 100%;
+}
+
+.main {
+  min-height: 100%;
+  margin-bottom: -90px;
+  overflow: hidden;
+}
+
 footer {
   font-size: 13px;
   font-weight: 600;
-  margin-top: 36px;
-  margin-bottom: 18px;
+  padding-top: 36px;
+  padding-bottom: 18px;
   overflow: auto;
+  background: $pageBg;
+  position: relative;
+  height: 90px;
 }
 
 section.black content {


### PR DESCRIPTION
- Fixes the position left-hand nav when scrolling
- Persists the scroll position of the navigation when clicking through the pages (10 second timeout) using localStorage.
- Uses the "sticky footer" technique on the main footer, so the footer doesn't clash with shorter pages. 
## Rationale
- Easier to access the navigation when scrolled on a long page
- Easier to traverse between Docs pages within a given category
## Notable changes
- `.nav-docs` is now position: fixed 
- Added a new `main` div which wrap the site contents, except for the footer (for sticky footer)
- Added a new `fixed-nav.js` file and included in the `<head />` 
## Notes
- I think this might have been an intention early on for the site, as `position: fixed` is [commented-out](https://github.com/facebook/react/blob/master/docs/css/react.scss#L232). Not sure why it never made it into the initial release of the site, but this implementation is more than just CSS.
- Tested in latest FF, Safari, Chrome, Edge and IE11.
- **Question**: I noticed there's a `javascript.js` inside of the ignored `js` folder, but can't find where this is built from? Was thinking I could use that file instead of creating `fixed-nav.js`

![bk6j0nlxaw](https://cloud.githubusercontent.com/assets/24449/13291697/a366ac1c-db10-11e5-8c06-8f29ec15054d.gif)
