### PR TITLE
Add suppressContentEditableWarning

### DIFF
--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -174,7 +174,9 @@ function assertValidProps(component, props) {
       'For more information, lookup documentation on `dangerouslySetInnerHTML`.'
     );
     warning(
-      !props.contentEditable || props.children == null,
+      props.suppressContentEditableWarning ||
+      !props.contentEditable ||
+      props.children == null,
       'A component is `contentEditable` and contains `children` managed by ' +
       'React. It is now your responsibility to guarantee that none of ' +
       'those nodes are unexpectedly modified or duplicated. This is ' +

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -947,6 +947,12 @@ describe('ReactDOMComponent', function() {
       expect(console.error.argsForCall[0][0]).toContain('contentEditable');
     });
 
+    it('should respect suppressContentEditableWarning', function() {
+      spyOn(console, 'error');
+      mountComponent({contentEditable: true, children: '', suppressContentEditableWarning: true});
+      expect(console.error.argsForCall.length).toBe(0);
+    });
+
     it('should validate against invalid styles', function() {
       expect(function() {
         mountComponent({style: 'display: none'});


### PR DESCRIPTION
I went with `suppressContentEditableWarning` for now, but that's a quick change.

See #5837

/cc @jimfb @spicyj 