### PR TITLE
[DOCS] Pass arguments to super in ES6.

### DIFF
--- a/docs/docs/05-reusable-components.ja-JP.md
+++ b/docs/docs/05-reusable-components.ja-JP.md
@@ -203,7 +203,7 @@ APIは `getInitialState` という例外を除き、 `React.createClass` と同�
 ```javascript
 export class Counter extends React.Component {
   constructor(props) {
-    super(props);
+    super(arguments);
     this.state = {count: props.initialCount};
   }
   tick() {

--- a/docs/docs/05-reusable-components.ko-KR.md
+++ b/docs/docs/05-reusable-components.ko-KR.md
@@ -203,7 +203,7 @@ API는 `getInitialState`를 제외하고 `React.createClass`와 유사합니다.
 ```javascript
 export class Counter extends React.Component {
   constructor(props) {
-    super(props);
+    super(arguments);
     this.state = {count: props.initialCount};
   }
   tick() {

--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -203,7 +203,7 @@ Another difference is that `propTypes` and `defaultProps` are defined as propert
 ```javascript
 export class Counter extends React.Component {
   constructor(props) {
-    super(props);
+    super(arguments);
     this.state = {count: props.initialCount};
   }
   tick() {

--- a/docs/docs/05-reusable-components.zh-CN.md
+++ b/docs/docs/05-reusable-components.zh-CN.md
@@ -203,7 +203,7 @@ API近似于 `React.createClass` 除了 `getInitialState`。 你应该在构造�
 ```javascript
 export class Counter extends React.Component {
   constructor(props) {
-    super(props);
+    super(arguments);
     this.state = {count: props.initialCount};
   }
   tick() {


### PR DESCRIPTION
Better practice to pass `arguments` to `super` (in case of using context):

```js
export class Counter extends React.Component {
   constructor(props) {
     super(arguments);
     this.state = {count: props.initialCount};
   }
}
```