### PR TITLE
Warn when setState called within getChildContext

### DIFF
--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -119,6 +119,7 @@ var ReactCompositeComponentMixin = {
     this._pendingStateQueue = null;
     this._pendingReplaceState = false;
     this._pendingForceUpdate = false;
+    this._processingChildContext = false;
 
     this._renderedNodeType = null;
     this._renderedComponent = null;
@@ -496,7 +497,9 @@ var ReactCompositeComponentMixin = {
   _processChildContext: function(currentContext) {
     var Component = this._currentElement.type;
     var inst = this._instance;
+    this._processingChildContext = true;
     var childContext = inst.getChildContext && inst.getChildContext();
+    this._processingChildContext = false;
     if (childContext) {
       invariant(
         typeof Component.childContextTypes === 'object',

--- a/src/renderers/shared/reconciler/ReactUpdateQueue.js
+++ b/src/renderers/shared/reconciler/ReactUpdateQueue.js
@@ -44,6 +44,12 @@ function getInternalInstanceReadyForUpdate(publicInstance, callerName) {
 
   if (__DEV__) {
     warning(
+      !internalInstance._processingChildContext,
+      '%s(...): Cannot update during processing child context.',
+      callerName
+    );
+
+    warning(
       ReactCurrentOwner.current == null,
       '%s(...): Cannot update during an existing state transition (such as ' +
       'within `render` or another component\'s constructor). Render methods ' +

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -469,6 +469,32 @@ describe('ReactCompositeComponent', function() {
     expect(innerUnmounted).toBe(true);
   });
 
+  it('should warn when setState() called within getChildContext()', function() {
+    var Component = React.createClass({
+      childContextTypes: {
+        bogus: ReactPropTypes.bool.isRequired,
+      },
+
+      getChildContext: function() {
+        this.setState({a: 1});
+        return {bogus: false};
+      },
+
+      render: function() {
+        return <div />;
+      },
+    });
+
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(<Component />);
+    }).toThrow('Maximum call stack size exceeded');
+
+    expect(console.error.argsForCall.length).toBeGreaterThan(0);
+    expect(console.error.argsForCall[0][0]).toBe(
+      'Warning: setState(...): Cannot update during processing child context.'
+    );
+  });
+
   it('should warn when shouldComponentUpdate() returns undefined', function() {
     var Component = React.createClass({
       getInitialState: function() {


### PR DESCRIPTION
Fix for #6114

I guess that we should reject update to prevent "maximum call stack" error.
@jimfb what are you think?