### PR TITLE
Fix renderToStaticMarkup() invariant

### DIFF
--- a/src/renderers/dom/server/ReactServerRendering.js
+++ b/src/renderers/dom/server/ReactServerRendering.js
@@ -28,11 +28,6 @@ var invariant = require('invariant');
  * @return {string} the HTML markup
  */
 function renderToStringImpl(element, makeStaticMarkup) {
-  invariant(
-    ReactElement.isValidElement(element),
-    'renderToString(): You must pass a valid ReactElement.'
-  );
-
   var transaction;
   try {
     ReactUpdates.injection.injectBatchingStrategy(ReactServerBatchingStrategy);
@@ -61,10 +56,18 @@ function renderToStringImpl(element, makeStaticMarkup) {
 }
 
 function renderToString(element) {
+  invariant(
+    ReactElement.isValidElement(element),
+    'renderToString(): You must pass a valid ReactElement.'
+  );
   return renderToStringImpl(element, false);
 }
 
 function renderToStaticMarkup(element) {
+  invariant(
+    ReactElement.isValidElement(element),
+    'renderToStaticMarkup(): You must pass a valid ReactElement.'
+  );
   return renderToStringImpl(element, true);
 }
 

--- a/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
@@ -360,7 +360,7 @@ describe('ReactServerRendering', function() {
           'not a component'
         )
       ).toThrow(
-        'renderToString(): You must pass a valid ReactElement.'
+        'renderToStaticMarkup(): You must pass a valid ReactElement.'
       );
     });
 


### PR DESCRIPTION
In d4420eca8a527c22317d06ad166c74e8495c3a3a @spicyj combined the `renderToStaticMarkup()` and `renderToString()` functions and removing the duplicate code.

In the process the invariant got moved, and both functions would throw the same invariant saying "renderToString(): You must pass a valid ReactElement."

This PR fixes that so `renderToStaticMarkup()` now should show "renderToStaticMarkup(): You must pass a valid ReactElement." again.