### PR TITLE
[Docs] Remove babel-browser link

### DIFF
--- a/docs/docs/09-tooling-integration.md
+++ b/docs/docs/09-tooling-integration.md
@@ -22,7 +22,7 @@ We have instructions for building from `master` [in our GitHub repository](https
 
 ### In-browser JSX Transform
 
-If you like using JSX, Babel provides an [in-browser ES6 and JSX transformer for development](http://babeljs.io/docs/usage/browser/) called browser.js that can be included from a `babel-core` npm release or from [CDNJS](http://cdnjs.com/libraries/babel-core). Include a `<script type="text/babel">` tag to engage the JSX transformer.
+If you like using JSX, Babel 5 provided an in-browser ES6 and JSX transformer for development called browser.js that can be included from [CDNJS](http://cdnjs.com/libraries/babel-core/5.8.34). Include a `<script type="text/babel">` tag to engage the JSX transformer.
 
 > Note:
 >


### PR DESCRIPTION
babel-browser is deprecated and no longer available on the babel website: http://babeljs.io/docs/usage/browser/

This PR keeps the CDNJS link to browser.js but specifies 5.8.34 as it is still technically the best solution out right now since JSXTransformer was deprecated from facebook as well.

Other options may soon be available such as [babel-standalone](https://github.com/Daniel15/babel-standalone) or [react-towel](https://github.com/danmartinez101/react-towel), but are not quite there yet. See #5497 for details