### PR TITLE
Preserve order in `mergeChildMappings`

### DIFF
--- a/src/addons/transitions/ReactTransitionChildMapping.js
+++ b/src/addons/transitions/ReactTransitionChildMapping.js
@@ -75,6 +75,11 @@ var ReactTransitionChildMapping = {
 
     var i;
     var childMapping = {};
+
+    for (i = 0; i < pendingKeys.length; i++) {
+      childMapping[pendingKeys[i]] = getValueForKey(pendingKeys[i]);
+    }
+
     for (var nextKey in next) {
       if (nextKeysPending.hasOwnProperty(nextKey)) {
         for (i = 0; i < nextKeysPending[nextKey].length; i++) {
@@ -87,10 +92,6 @@ var ReactTransitionChildMapping = {
       childMapping[nextKey] = getValueForKey(nextKey);
     }
 
-    // Finally, add the keys which didn't appear before any key in `next`
-    for (i = 0; i < pendingKeys.length; i++) {
-      childMapping[pendingKeys[i]] = getValueForKey(pendingKeys[i]);
-    }
 
     return childMapping;
   },

--- a/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
@@ -90,8 +90,8 @@ describe('ReactCSSTransitionGroup', function() {
       container
     );
     expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(2);
-    expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('two');
-    expect(ReactDOM.findDOMNode(a).childNodes[1].id).toBe('one');
+    expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('one');
+    expect(ReactDOM.findDOMNode(a).childNodes[1].id).toBe('two');
 
     // For some reason jst is adding extra setTimeout()s and grunt test isn't,
     // so we need to do this disgusting hack.
@@ -125,8 +125,8 @@ describe('ReactCSSTransitionGroup', function() {
       container
     );
     expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(2);
-    expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('two');
-    expect(ReactDOM.findDOMNode(a).childNodes[1].id).toBe('one');
+    expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('one');
+    expect(ReactDOM.findDOMNode(a).childNodes[1].id).toBe('two');
   });
 
   it('should switch transitionLeave from false to true', function() {
@@ -160,8 +160,8 @@ describe('ReactCSSTransitionGroup', function() {
       container
     );
     expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(2);
-    expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('three');
-    expect(ReactDOM.findDOMNode(a).childNodes[1].id).toBe('two');
+    expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('two');
+    expect(ReactDOM.findDOMNode(a).childNodes[1].id).toBe('three');
   });
 
   it('should work with no children', function() {

--- a/src/addons/transitions/__tests__/ReactTransitionChildMapping-test.js
+++ b/src/addons/transitions/__tests__/ReactTransitionChildMapping-test.js
@@ -109,6 +109,51 @@ describe('ReactTransitionChildMapping', function() {
     });
   });
 
+  it('should preserve order when overlapping insertions and deletions are iterated on', function() {
+    var prev = {
+      one: true,
+      two: true,
+      four: true,
+      five: true,
+    };
+    var next = {
+      one: true,
+      two: true,
+      three: true,
+      five: true,
+    };
+    var childMappingsKeys = Object.keys(ReactTransitionChildMapping.mergeChildMappings(prev, next));
+    expect(childMappingsKeys).toEqual([
+      'one',
+      'two',
+      'three',
+      'four',
+      'five',
+    ]);
+  });
+
+  it('should preserve order when non-overlapping insertions are iterated on', function() {
+    var prev = {
+      one: true,
+      two: true,
+      three: true,
+    };
+    var next = {
+      four: true,
+      five: true,
+      six: true,
+    };
+    var childMappingsKeys = Object.keys(ReactTransitionChildMapping.mergeChildMappings(prev, next));
+    expect(childMappingsKeys).toEqual([
+      'one',
+      'two',
+      'three',
+      'four',
+      'five',
+      'six',
+    ]);
+  });
+
   it('should support mergeChildMappings with undefined input', function() {
     var prev = {
       one: true,


### PR DESCRIPTION
This relates to the issue described here: https://github.com/facebook/react/issues/6142

I believe this fixes the intended behavior - unless I have misunderstood the old implementations comment and prepending was the desired behavior. It certainly fixes an issue I was having with this when the children are completely replaced with a new array of children.

`mergeChildMappings` now preserves the order so that new children are appended rather than prepended when *all* old nodes are removed.

I've also added tests and updated a couple of `CSSTransitionGroup` tests to reflect this.