### PR TITLE
Docs external sidebar followup

### DIFF
--- a/docs/_layouts/redirect.html
+++ b/docs/_layouts/redirect.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting...</title>
+<link rel=canonical href="{{ page.dest_url }}">
+<meta http-equiv=refresh content="0; url={{ page.dest_url }}">
+<h1>Redirecting...</h1>
+<a href="{{ page.dest_url }}">Click here if you are not redirected.</a>
+<script>location="{{ page.dest_url }}"</script>

--- a/docs/_plugins/sidebar_item.rb
+++ b/docs/_plugins/sidebar_item.rb
@@ -11,7 +11,7 @@ module Jekyll
       if item["href"]
         classes.push("external")
       end
-      className = classes.size ? "class=\"#{classes.join(' ')}\"" : "";
+      className = classes.size > 0  ? " class=\"#{classes.join(' ')}\"" : ""
 
       return "<a href=\"#{href}\"#{className}>#{item["title"]}</a>"
     end

--- a/docs/docs/complementary-tools.it-IT.md
+++ b/docs/docs/complementary-tools.it-IT.md
@@ -1,9 +1,5 @@
 ---
-id: complementary-tools-it-IT
-title: Strumenti Complementari
 permalink: complementary-tools-it-IT.html
-prev: videos-it-IT.html
-next: examples-it-IT.html
+layout: redirect
+dest_url: https://github.com/facebook/react/wiki/Complementary-Tools
 ---
-
-Questa pagina è stata spostata sul [wiki di GitHub](https://github.com/facebook/react/wiki/Complementary-Tools).

--- a/docs/docs/complementary-tools.ko-KR.md
+++ b/docs/docs/complementary-tools.ko-KR.md
@@ -1,9 +1,5 @@
 ---
-id: complementary-tools-ko-KR
-title: 상호 보완적인 도구들
 permalink: complementary-tools-ko-KR.html
-prev: videos-ko-KR.html
-next: examples-ko-KR.html
+layout: redirect
+dest_url: https://github.com/facebook/react/wiki/Complementary-Tools
 ---
-
-이 페이지는 이동되었습니다. [GitHub wiki](https://github.com/facebook/react/wiki/Complementary-Tools).

--- a/docs/docs/complementary-tools.md
+++ b/docs/docs/complementary-tools.md
@@ -1,9 +1,5 @@
 ---
-id: complementary-tools
-title: Complementary Tools
 permalink: complementary-tools.html
-prev: videos.html
-next: examples.html
+layout: redirect
+dest_url: https://github.com/facebook/react/wiki/Complementary-Tools
 ---
-
-This page has moved to the [GitHub wiki](https://github.com/facebook/react/wiki/Complementary-Tools).

--- a/docs/docs/complementary-tools.zh-CN.md
+++ b/docs/docs/complementary-tools.zh-CN.md
@@ -1,9 +1,5 @@
 ---
-id: complementary-tools-zh-CN
-title: 补充工具
 permalink: complementary-tools-zh-CN.html
-prev: videos-zh-CN.html
-next: examples-zh-CN.html
+layout: redirect
+dest_url: https://github.com/facebook/react/wiki/Complementary-Tools
 ---
-
-本页被移到了 [GitHub wiki](https://github.com/facebook/react/wiki/Complementary-Tools)。

--- a/docs/docs/examples.it-IT.md
+++ b/docs/docs/examples.it-IT.md
@@ -1,8 +1,5 @@
 ---
-id: examples-it-IT
-title: Esempi
 permalink: examples-it-IT.html
-prev: complementary-tools-it-IT.html
+layout: redirect
+dest_url: https://github.com/facebook/react/wiki/Examples
 ---
-
-Questa pagina è stata spostata sul [wiki di GitHub](https://github.com/facebook/react/wiki/Examples).

--- a/docs/docs/examples.ko-KR.md
+++ b/docs/docs/examples.ko-KR.md
@@ -1,8 +1,5 @@
 ---
-id: examples-ko-KR
-title: 예제들
 permalink: examples-ko-KR.html
-prev: complementary-tools-ko-KR.html
+layout: redirect
+dest_url: https://github.com/facebook/react/wiki/Examples
 ---
-
-이 페이지는 이동되었습니다. [GitHub wiki](https://github.com/facebook/react/wiki/Examples).

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -1,8 +1,5 @@
 ---
-id: examples
-title: Examples
 permalink: examples.html
-prev: complementary-tools.html
+layout: redirect
+dest_url: https://github.com/facebook/react/wiki/Examples
 ---
-
-This page has moved to the [GitHub wiki](https://github.com/facebook/react/wiki/Examples).

--- a/docs/docs/examples.zh-CN.md
+++ b/docs/docs/examples.zh-CN.md
@@ -1,8 +1,5 @@
 ---
-id: examples-zh-CN
-title: 示例
 permalink: examples-zh-CN.html
-prev: complementary-tools-zh-CN.html
+layout: redirect
+dest_url: https://github.com/facebook/react/wiki/Examples
 ---
-
-本页被移到了 [GitHub wiki](https://github.com/facebook/react/wiki/Examples)。


### PR DESCRIPTION
Followup to #6090

- Fixes the extraneous `class=""`
- Adds actual redirect in case those pages are linked to (as best as we can do on GH pages). I didn't use the built-in functionality of the redirect_from gem because it seems to generate pages in the wrong place so had to do the layout manually (also why I used the more awkward `dest_url` key).