### PR TITLE
[TestUtils] Implement type property in Simulate.<eventName>

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -491,6 +491,8 @@ function makeSimulator(eventType) {
 
     var fakeNativeEvent = new Event();
     fakeNativeEvent.target = node;
+    fakeNativeEvent.type = eventType.toLowerCase();
+
     // We don't use SyntheticEvent.getPooled in order to not have to worry about
     // properly destroying any properties assigned from `eventData` upon release
     var event = new SyntheticEvent(

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -486,4 +486,23 @@ describe('ReactTestUtils', function() {
     expect(hrs.length).toBe(2);
   });
 
+  describe('Simulate', () => {
+    it('should set the type of the event', () => {
+      let event;
+      const stub = jest.genMockFn().mockImpl((e) => {
+        e.persist();
+        event = e;
+      });
+
+      const container = document.createElement('div');
+      const instance = ReactDOM.render(<div onKeyDown={stub} />, container);
+      const node = ReactDOM.findDOMNode(instance);
+
+      ReactTestUtils.Simulate.keyDown(node);
+
+      expect(event.type).toBe('keydown');
+      expect(event.nativeEvent.type).toBe('keydown');
+    });
+  });
+
 });


### PR DESCRIPTION
Although it is unreasonable to set every possible property for simulated events, `type` is useful for shared event handlers that have different behaviors.

Closes #6100 