### PR TITLE
Usage of `.name|.displayName` to identify stateless functional components

### DIFF
--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -248,7 +248,7 @@ ReactDOM.render(<HelloMessage name="Sebastian" />, mountNode);
 ```
 
 This simplified component API is intended for components that are pure functions of their props. These components must not retain internal state, do not have backing instances, and do not have the component lifecycle methods. They are pure functional transforms of their input, with zero boilerplate.
-However, you may still specify `.propTypes` and `.defaultProps` by setting them as properties on the function, just as you would set them on an ES6 class.
+However, you may still specify `.propTypes`, `.defaultProps`, and `.displayName` by setting them as properties on the function, just as you would set them on an ES6 class. `.displayName` or `.name` may be used as the name of the component within debug messages if it's a non-empty string. `.displayName` would take precedence over `.name` when calculating the component name.
 
 > NOTE:
 >

--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -16,6 +16,7 @@ var ReactCurrentOwner = require('ReactCurrentOwner');
 var assign = require('Object.assign');
 var warning = require('warning');
 var canDefineProperty = require('canDefineProperty');
+var getComponentName = require('getComponentName');
 
 // The Symbol used to tag the ReactElement type. If there is no native Symbol
 // nor polyfill, then a plain number is used for performance.
@@ -184,7 +185,7 @@ ReactElement.createElement = function(type, config, children) {
                   'in `undefined` being returned. If you need to access the same ' +
                   'value within the child component, you should pass it as a different ' +
                   'prop. (https://fb.me/react-special-props)',
-                'displayName' in type ? type.displayName: 'Element'
+                getComponentName(type) || 'Element'
               );
             }
             return undefined;

--- a/src/shared/utils/__tests__/getComponentName-test.js
+++ b/src/shared/utils/__tests__/getComponentName-test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var getComponentName = require('getComponentName');
+var React = require('React');
+
+describe('getComponentName', function() {
+  it('should prefer `displayName`', function() {
+    var displayName = 'Else';
+
+    var Something = function Something() {};
+    Something.displayName = displayName;
+
+    expect(getComponentName(Something)).toBe(displayName);
+
+    Something = React.createClass({
+      render: function() {},
+      displayName: displayName,
+    });
+
+    expect(getComponentName(Something)).toBe(displayName);
+  });
+
+  it('should fall back on `name`', function() {
+    function Something() {}
+
+    expect(getComponentName(Something)).toBe(Something.name);
+  });
+});

--- a/src/shared/utils/getComponentName.js
+++ b/src/shared/utils/getComponentName.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule getComponentName
+ */
+
+'use strict';
+
+/**
+ * Returns the component name, if any.
+ *
+ * This is to provide consistent logic for choosing the name: prefer
+ * `displayName` and fall back on `name`.
+ *
+ * @param {ReactComponent} component
+ * @return {?string} Name, if any.
+ */
+function getComponentName(component) {
+  return component && (component.displayName || component.name);
+}
+
+module.exports = getComponentName;


### PR DESCRIPTION
This is WIP. I want to see if this is something you're interested in and if so I can clean everything up.
1. Can support for `displayName` on stateless functional components be documented? (It would seem so from https://github.com/facebook/react/issues/4915#issuecomment-166032807.)
2. There seems to be some inconsistent application of `.displayName` / `.name` and I think there may be some holes (I'm only positive of one right now, the one in the failing test added here for the `key` warning on a stateless component with only `.name`.) Are you interested in patching up those holes?
3. If so, are you interested in consolidating that logic so it's applied consistently everywhere it's needed? That's the idea behind the `getComponentName` added here.
