### PR TITLE
Update PureRenderMixin docs, adding ES6 example

### DIFF
--- a/docs/docs/10.8-pure-render-mixin.md
+++ b/docs/docs/10.8-pure-render-mixin.md
@@ -21,6 +21,22 @@ React.createClass({
 });
 ```
 
+Example using ES6 class syntax:
+
+```js
+import PureRenderMixin from 'react-addons-pure-render-mixin';
+class FooComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
+  }
+
+  render() {
+    return <div className={this.props.className}>foo</div>;
+  }
+}
+```
+
 Under the hood, the mixin implements [shouldComponentUpdate](/react/docs/component-specs.html#updating-shouldcomponentupdate), in which it compares the current props and state with the next ones and returns `false` if the equalities pass.
 
 > Note:


### PR DESCRIPTION
I found this non-obvious, so thought it'd be good to document.
Decided to say ES6 rather than ES2015 since the rest of the docs say ES6.