### PR TITLE
Fixed typo in reconciliation docs.

### DIFF
--- a/docs/docs/ref-08-reconciliation.md
+++ b/docs/docs/ref-08-reconciliation.md
@@ -76,7 +76,7 @@ After the attributes have been updated, we recurse on all the children.
 
 ### Custom Components
 
-We decided that the two custom components are the same. Since components are stateful, we cannot just use the new component and call it a day. React takes all the attributes from the new component and calls `component[Will/Did]ReceiveProps()` on the previous one.
+We decided that the two custom components are the same. Since components are stateful, we cannot just use the new component and call it a day. React takes all the attributes from the new component and calls `componentWillReceiveProps()` and `componentWillUpdate()` on the previous one.
 
 The previous component is now operational. Its `render()` method is called and the diff algorithm restarts with the new result and the previous result.
 


### PR DESCRIPTION
Fixed typo in reconciliation docs (https://github.com/facebook/react/issues/6181).
