### PR TITLE
Warn about deprecated SVG attributes only once

### DIFF
--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -539,6 +539,39 @@ describe('ReactDOMComponent', function() {
       expect(console.error.argsForCall[0][0]).toContain('clip-path');
     });
 
+    it('should only warn once about deprecated SVG attributes', function() {
+      spyOn(console, 'error');
+      var container = document.createElement('div');
+      ReactDOM.render(
+        <svg clipPath="0 0 100 100">
+          <rect strokeWidth={1} />
+          <rect strokeWidth={10} />
+        </svg>,
+        container
+      );
+      expect(console.error.argsForCall.length).toBe(2);
+      expect(console.error.argsForCall[0][0]).toContain('clipPath');
+      expect(console.error.argsForCall[0][0]).toContain('clip-path');
+      expect(console.error.argsForCall[1][0]).toContain('strokeWidth');
+      expect(console.error.argsForCall[1][0]).toContain('stroke-width');
+
+      ReactDOM.render(
+        <svg clipPath="0 0 100 100">
+          <rect strokeWidth={1} strokeOpacity={0.5} />
+          <rect strokeWidth={10} />
+          <rect strokeWidth={100} />
+        </svg>,
+        container
+      );
+      expect(console.error.argsForCall.length).toBe(3);
+      expect(console.error.argsForCall[0][0]).toContain('clipPath');
+      expect(console.error.argsForCall[0][0]).toContain('clip-path');
+      expect(console.error.argsForCall[1][0]).toContain('strokeWidth');
+      expect(console.error.argsForCall[1][0]).toContain('stroke-width');
+      expect(console.error.argsForCall[2][0]).toContain('strokeOpacity');
+      expect(console.error.argsForCall[2][0]).toContain('stroke-opacity');
+    });
+
     it('should update arbitrary hyphenated attributes for SVG tags', function() {
       var container = document.createElement('div');
 

--- a/src/renderers/dom/shared/devtools/ReactDOMSVGDeprecatedAttributeDevtool.js
+++ b/src/renderers/dom/shared/devtools/ReactDOMSVGDeprecatedAttributeDevtool.js
@@ -25,19 +25,22 @@ if (__DEV__) {
   var warnedSVGAttributes = {};
 
   var warnDeprecatedSVGAttribute = function(name) {
+    if (reactProps.hasOwnProperty(name) && reactProps[name]) {
+      return;
+    }
+
     if (!DOMProperty.properties.hasOwnProperty(name)) {
       return;
     }
-
-    if (reactProps.hasOwnProperty(name) && reactProps[name] ||
-        warnedSVGAttributes.hasOwnProperty(name) && warnedSVGAttributes[name]) {
-      return;
-    }
-
     var { attributeName, attributeNamespace } = DOMProperty.properties[name];
     if (attributeNamespace || name === attributeName) {
       return;
     }
+
+    if (warnedSVGAttributes.hasOwnProperty(name) && warnedSVGAttributes[name]) {
+      return;
+    }
+    warnedSVGAttributes[name] = true;
 
     warning(
       false,


### PR DESCRIPTION
This fixes a missing assignment in #5714 that caused tons of extraneous warnings.

## Before

<img width="704" alt="screen shot 2016-03-04 at 15 59 58" src="https://cloud.githubusercontent.com/assets/810438/13532368/17f581b6-e223-11e5-952b-c197d6f02d77.png">

## After

<img width="610" alt="screen shot 2016-03-04 at 16 08 03" src="https://cloud.githubusercontent.com/assets/810438/13532415/5370113e-e223-11e5-8c54-d62530058cb7.png">


Reviewers: @zpao 