### PR TITLE
[docs] keep position of "Edit on GitHub" link fixed

### DIFF
--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -7,9 +7,9 @@ sectionid: docs
   {% include nav_docs.html %}
 
   <div class="inner-content">
+    <a class="edit-page-link" href="https://github.com/facebook/react/tree/master/docs/{{ page.path }}" target="_blank">Edit on GitHub</a>
     <h1>
       {{ page.title }}
-      <a class="edit-page-link" href="https://github.com/facebook/react/tree/master/docs/{{ page.path }}" target="_blank">Edit on GitHub</a>
     </h1>
     <div class="subHeader">{{ page.description }}</div>
 


### PR DESCRIPTION
When a doc page has a long title it will push the "Edit on GitHub" link down. This change moves the link before the header so it stays fixed in the upper right.

[Example page](https://facebook.github.io/react/docs/glossary.html)

Proposed change:
![screen shot 2016-03-04 at 3 33 58 pm](https://cloud.githubusercontent.com/assets/2499332/13543281/8e803358-e21e-11e5-8b80-fdab4f81c726.png)