### PR TITLE
Reset Jest to use Jasmine1 so tests pass again

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "scriptPreprocessor": "scripts/jest/preprocessor.js",
     "setupEnvScriptFile": "scripts/jest/environment.js",
     "setupTestFrameworkScriptFile": "scripts/jest/test-framework-setup.js",
+    "testRunner": "jasmine1",
     "testFileExtensions": [
       "coffee",
       "js",


### PR DESCRIPTION
fixes #6198

I think there may also be a babel 6 related issue, the `eslint-rules\__tests__\warning-and-invariant-args-test.js` tests throw, not being able to find the es2015 preset, But I don't think it has anything to do with the original issue here

@jimfb 