### PR TITLE
Update to jest 0.9.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "gulp-babel": "^6.0.0",
     "gulp-flatten": "^0.2.0",
     "gzip-js": "~0.3.2",
-    "jest-cli": "^0.9.0-fb1",
+    "jest-cli": "^0.9.0",
     "platform": "^1.1.0",
     "run-sequence": "^1.1.4",
     "through2": "^2.0.0",


### PR DESCRIPTION
This brings us back to the release branch from the pre-release `fb-x` versions :)