### PR TITLE
[fix] key/ref warnings incorrectly throw on DOM Elements

### DIFF
--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -184,7 +184,7 @@ ReactElement.createElement = function(type, config, children) {
                   'in `undefined` being returned. If you need to access the same ' +
                   'value within the child component, you should pass it as a different ' +
                   'prop. (https://fb.me/react-special-props)',
-                'displayName' in type ? type.displayName: 'Element'
+                typeof type === 'function' && 'displayName' in type ? type.displayName : 'Element'
               );
             }
             return undefined;
@@ -203,7 +203,7 @@ ReactElement.createElement = function(type, config, children) {
                   'in `undefined` being returned. If you need to access the same ' +
                   'value within the child component, you should pass it as a different ' +
                   'prop. (https://fb.me/react-special-props)',
-                'displayName' in type ? type.displayName: 'Element'
+                typeof type === 'function' && 'displayName' in type ? type.displayName : 'Element'
               );
             }
             return undefined;


### PR DESCRIPTION
We found this bug when getting Enzyme compatible with React 15.

The warnings added as getters to ref/key props are helpful, but will actually throw on DOM Elements like `'div'`, because you can't use the `in` operator on strings.