### PR TITLE
Add a warning for adding properties into ResponderSyntheticEvent

### DIFF
--- a/src/renderers/shared/event/eventPlugins/ResponderSyntheticEvent.js
+++ b/src/renderers/shared/event/eventPlugins/ResponderSyntheticEvent.js
@@ -31,7 +31,7 @@ var ResponderEventInterface = {
  * @extends {SyntheticEvent}
  */
 function ResponderSyntheticEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget) {
-  SyntheticEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
+  return SyntheticEvent.call(this, dispatchConfig, dispatchMarker, nativeEvent, nativeEventTarget);
 }
 
 SyntheticEvent.augmentClass(ResponderSyntheticEvent, ResponderEventInterface);


### PR DESCRIPTION
@jimfb This is a additional work for #5947. I missed ResponderSyntheticEvent :bow: