### PR TITLE
added useAddEventListener helper to avoid conflicts in patched IE8

### DIFF
--- a/src/renderers/dom/client/utils/isEventSupported.js
+++ b/src/renderers/dom/client/utils/isEventSupported.js
@@ -12,6 +12,7 @@
 'use strict';
 
 var ExecutionEnvironment = require('ExecutionEnvironment');
+var useAddEventListener = require('useAddEventListener');
 
 var useHasFeature;
 if (ExecutionEnvironment.canUseDOM) {
@@ -39,7 +40,7 @@ if (ExecutionEnvironment.canUseDOM) {
  */
 function isEventSupported(eventNameSuffix, capture) {
   if (!ExecutionEnvironment.canUseDOM ||
-      capture && !('addEventListener' in document)) {
+      capture && !useAddEventListener(document)) {
     return false;
   }
 

--- a/src/renderers/dom/client/utils/useAddEventListener.js
+++ b/src/renderers/dom/client/utils/useAddEventListener.js
@@ -12,7 +12,7 @@
 'use strict';
 
 /**
- * Checks if a target has addEventListener but not 'attachEvent'.
+ * Checks if a target has 'addEventListener' but not 'attachEvent'.
  *
  * NOTE: This fixes problems with other libraries that tries to normalize IE8.
  *
@@ -23,8 +23,11 @@
  * @internal
  */
 function useAddEventListener(target) {
-  return typeof opera === 'undefined' ?
-    !('attachEvent' in target) : ('addEventListener' in target);
+          // verify the most common case first
+  return  'addEventListener' in target &&
+          // be sure there's no 'attachEvent'
+          // if there is one, be sure it's not an old version of opera
+          !('attachEvent' in target && typeof opera === 'undefined');
 }
 
 module.exports = useAddEventListener;

--- a/src/renderers/dom/client/utils/useAddEventListener.js
+++ b/src/renderers/dom/client/utils/useAddEventListener.js
@@ -31,7 +31,7 @@ var hasEventListener = 'addEventListener' in document;
  */
 function useAddEventListener(target) {
   // avoid conflicts with runtime patched environments
-  return hasEventListener && target.addEventListener;
+  return hasEventListener && !!target.addEventListener;
 }
 
 module.exports = useAddEventListener;

--- a/src/renderers/dom/client/utils/useAddEventListener.js
+++ b/src/renderers/dom/client/utils/useAddEventListener.js
@@ -16,7 +16,7 @@
 // 'addEventListener' ability
 // so that no patched IE8 will ever
 // sufffer dual logic or runtime checks
-var hasEventListener = 'addEventListener' in document;
+var hasEventListener = 'addEventListener' in global;
 
 /**
  * Checks if a target has 'addEventListener' but not 'attachEvent'.

--- a/src/renderers/dom/client/utils/useAddEventListener.js
+++ b/src/renderers/dom/client/utils/useAddEventListener.js
@@ -23,11 +23,11 @@
  * @internal
  */
 function useAddEventListener(target) {
-          // verify the most common case first
-  return  'addEventListener' in target &&
-          // be sure there's no 'attachEvent'
-          // if there is one, be sure it's not an old version of opera
-          !('attachEvent' in target && typeof opera === 'undefined');
+         // verify the most common case first
+  return 'addEventListener' in target &&
+         // be sure there's no 'attachEvent'
+         // if there is one, be sure it's not an old version of opera
+         !('attachEvent' in target && typeof opera === 'undefined');
 }
 
 module.exports = useAddEventListener;

--- a/src/renderers/dom/client/utils/useAddEventListener.js
+++ b/src/renderers/dom/client/utils/useAddEventListener.js
@@ -7,9 +7,16 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule useAddEventListener
+ * @typechecks
  */
 
 'use strict';
+
+// feature detect ASAP and *once*
+// 'addEventListener' ability
+// so that no patched IE8 will ever
+// sufffer dual logic or runtime checks
+var hasEventListener = 'addEventListener' in document;
 
 /**
  * Checks if a target has 'addEventListener' but not 'attachEvent'.
@@ -23,11 +30,8 @@
  * @internal
  */
 function useAddEventListener(target) {
-         // verify the most common case first
-  return 'addEventListener' in target &&
-         // be sure there's no 'attachEvent'
-         // if there is one, be sure it's not an old version of opera
-         !('attachEvent' in target && typeof opera === 'undefined');
+  // avoid conflicts with runtime patched environments
+  return hasEventListener && target.addEventListener;
 }
 
 module.exports = useAddEventListener;

--- a/src/renderers/dom/client/utils/useAddEventListener.js
+++ b/src/renderers/dom/client/utils/useAddEventListener.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule useAddEventListener
+ */
+
+'use strict';
+
+/**
+ * Checks if a target has addEventListener but not 'attachEvent'.
+ *
+ * NOTE: This fixes problems with other libraries that tries to normalize IE8.
+ *
+ * Brought in by Andrea Giammarchi for the sake of https://github.com/WebReflection/ie8
+ *
+ * @param {DOMElement} node
+ * @return {boolean} True if 'addEventListener' should be used.
+ * @internal
+ */
+function useAddEventListener(target) {
+  return typeof opera === 'undefined' ?
+    !('attachEvent' in target) : ('addEventListener' in target);
+}
+
+module.exports = useAddEventListener;


### PR DESCRIPTION
In order to solve [this issue](https://github.com/facebook/react/issues/3131), which ended up raising [this bug](https://github.com/WebReflection/ie8/issues/29), and since [the future version of React won't support IE8](http://facebook.github.io/react/blog/2016/01/12/discontinuing-ie8-support.html) but developers stuck in 0.14 would like to keep using it and also move on with the browser, this push aim is to resolve conflicts with patched IE8 environments, either via my [ie8.js](https://github.com/WebReflection/ie8) library or others, so that React 0.14 won't wrongly assume that if there is an `addEventListener`, that's what should be used as if it's native.

This PR has been pushed together with [the following fbjs one](https://github.com/facebook/fbjs/pull/126).

I hope this change will be considered small enough to land separately in these two repositories.