### PR TITLE
set value property explicitly for "option" element even if value is empty

### DIFF
--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -174,15 +174,12 @@ var DOMPropertyOperations = {
         var propName = propertyInfo.propertyName;
         // Must explicitly cast values for HAS_SIDE_EFFECTS-properties to the
         // property type before comparing; only `value` does and is string.
+        // Must set `value` property if it is not null and not yet set.
         if (!propertyInfo.hasSideEffects ||
-            ('' + node[propName]) !== ('' + value)) {
+            ('' + node[propName]) !== ('' + value) ||
+            !node.hasAttribute(propertyInfo.attributeName)) {
           // Contrary to `setAttribute`, object properties are properly
           // `toString`ed by IE8/9.
-          node[propName] = value;
-        } else if (node.nodeName && node.nodeName.toLowerCase() === 'option' &&
-            !node.hasAttribute('value')) {
-          // set empty "value" attribute to OPTION element
-          // if it is provided, but not yet set
           node[propName] = value;
         }
       } else {

--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -179,6 +179,11 @@ var DOMPropertyOperations = {
           // Contrary to `setAttribute`, object properties are properly
           // `toString`ed by IE8/9.
           node[propName] = value;
+        } else if (node.nodeName && node.nodeName.toLowerCase() === 'option' &&
+            !node.hasAttribute('value')) {
+          // set empty "value" attribute to OPTION element
+          // if it is provided, but not yet set
+          node[propName] = value;
         }
       } else {
         var attributeName = propertyInfo.attributeName;

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -221,6 +221,14 @@ describe('DOMPropertyOperations', function() {
       expect(stubNode.getAttribute('role')).toBe('<html>');
     });
 
+    it('should not remove empty attributes for special properties', function() {
+      stubNode = document.createElement('input');
+      DOMPropertyOperations.setValueForProperty(stubNode, 'value', '');
+      // JSDOM does not behave correctly for attributes/properties
+      //expect(stubNode.getAttribute('value')).toBe('');
+      expect(stubNode.value).toBe('');
+    });
+
     it('should remove for falsey boolean properties', function() {
       DOMPropertyOperations.setValueForProperty(
         stubNode,

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -763,10 +763,10 @@ describe('ReactDOMComponent', function() {
       expect(nodeValueSetter.mock.calls.length).toBe(2);
 
       ReactDOM.render(<div value="" />, container);
-      expect(nodeValueSetter.mock.calls.length).toBe(2);
+      expect(nodeValueSetter.mock.calls.length).toBe(3);
 
       ReactDOM.render(<div />, container);
-      expect(nodeValueSetter.mock.calls.length).toBe(2);
+      expect(nodeValueSetter.mock.calls.length).toBe(3);
     });
 
     it('should not incur unnecessary DOM mutations for boolean properties', function() {


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/6219

* if `option` element has empty string as `value`, it should be used
* if `option` has no `value` attribute, the contents of the `option` tag should be used