### PR TITLE
Fix ReactMarkupChecksum.addChecksumToMarkup() adds checksum to comments

### DIFF
--- a/src/renderers/dom/server/ReactMarkupChecksum.js
+++ b/src/renderers/dom/server/ReactMarkupChecksum.js
@@ -14,6 +14,8 @@
 var adler32 = require('adler32');
 
 var TAG_END = /\/?>/;
+var COMMENT_START = /^<\!\-\-/;
+
 
 var ReactMarkupChecksum = {
   CHECKSUM_ATTR_NAME: 'data-react-checksum',
@@ -25,11 +27,15 @@ var ReactMarkupChecksum = {
   addChecksumToMarkup: function(markup) {
     var checksum = adler32(markup);
 
-    // Add checksum (handle both parent tags and self-closing tags)
-    return markup.replace(
-      TAG_END,
-      ' ' + ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="' + checksum + '"$&'
-    );
+    // Add checksum (handle both parent tags, comments and self-closing tags)
+    if (markup.test(COMMENT_START)) {
+      return markup;
+    } else {
+      return markup.replace(
+        TAG_END,
+        ' ' + ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="' + checksum + '"$&'
+      );
+    }
   },
 
   /**

--- a/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
@@ -74,6 +74,16 @@ describe('ReactServerRendering', function() {
       );
     });
 
+    it('should generate comment markup for component returns null', function() {
+      var NullComponent = React.createClass({
+        render: function() {
+          return null;
+        },
+      });
+      var response = ReactServerRendering.renderToString(<NullComponent />);
+      expect(response).toBe('<!-- react-empty: 1 -->');
+    });
+
     it('should not register event listeners', function() {
       var EventPluginHub = require('EventPluginHub');
       var cb = jest.genMockFn();


### PR DESCRIPTION
`ReactMarkupChecksum.addChecksumToMarkup()` should not add checksum to
comment markup, which is generated from components returns null. This
fixes #6209.