### PR TITLE
import 'React' -> 'react' in ReactCSSTranstiionGroup.js

### DIFF
--- a/src/addons/transitions/ReactCSSTransitionGroup.js
+++ b/src/addons/transitions/ReactCSSTransitionGroup.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-var React = require('React');
+var React = require('react');
 
 var assign = require('Object.assign');
 


### PR DESCRIPTION
In most examples and user source I've read it's commonly seen to import the package name as such we commonly see `import React from 'react';` or 'require('react')`. However, because of this minor detail bundling tools like Browserify may interpret `React` differently from `react` and thus options to exclude `react` from builds fail and the source gets bundled anyway which causes the following error: 

```
Invariant Violation: addComponentAsRefTo(...): Only a ReactOwner can have refs. You might be adding a ref to a component that was not created inside a component's `render` method, or you have multiple copies of React loaded.
```

So this minor change will fix that issue.