### PR TITLE
Add nodes to DocumentFragments before attaching

### DIFF
--- a/src/renderers/dom/client/utils/DOMLazyTree.js
+++ b/src/renderers/dom/client/utils/DOMLazyTree.js
@@ -53,8 +53,16 @@ function insertTreeChildren(tree) {
 
 var insertTreeBefore = createMicrosoftUnsafeLocalFunction(
   function(parentNode, tree, referenceNode) {
-    parentNode.insertBefore(tree.node, referenceNode);
-    insertTreeChildren(tree);
+    // Document Fragments in IE11, Edge (and possibly others) won't update
+    // correctly if they are already inserted. So we have to break out of our
+    // lazy approach and append children to the fragment before inserting it.
+    if (tree.node.nodeType === 11) {
+      insertTreeChildren(tree);
+      parentNode.insertBefore(tree.node, referenceNode);
+    } else {
+      parentNode.insertBefore(tree.node, referenceNode);
+      insertTreeChildren(tree);
+    }
   }
 );
 


### PR DESCRIPTION
This is based on a quick chat with @spicyj. I haven't tested in IE11 yet (setting that up now), but after ensuring Firefox is running in lazy mode here, this does do what Ben was thinking, at least for the insert case. I need to do some more testing and see if this is an issue with updates (I think we should be ok there but will check).

Fixes #6246.