### PR TITLE
Make dependencies of react package optional

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,7 +22,7 @@
   "engines": {
     "node": ">=0.10.0"
   },
-  "dependencies": {
+  "optionalDependencies": {
     "envify": "^3.0.0",
     "fbjs": "^0.8.0-alpha.2"
   },


### PR DESCRIPTION
Rationale: The package is entirely usable without the envify and fbjs dependencies.

This change might affect projects using `npm install --no-optional`.