### PR TITLE
Added description for context parameter in render

### DIFF
--- a/docs/docs/10.4-test-utils.md
+++ b/docs/docs/10.4-test-utils.md
@@ -210,11 +210,12 @@ Call this in your tests to create a shallow renderer. You can think of this as a
 
 ```javascript
 shallowRenderer.render(
-  ReactElement element
+  ReactElement element,
+  object context
 )
 ```
 
-Similar to `ReactDOM.render`.
+Similar to `ReactDOM.render`, but have additional parameter `context`, in which you can specify properties for context object, which will be used during rendering of component.
 
 ```javascript
 ReactElement shallowRenderer.getRenderOutput()

--- a/docs/docs/10.4-test-utils.md
+++ b/docs/docs/10.4-test-utils.md
@@ -215,7 +215,7 @@ shallowRenderer.render(
 )
 ```
 
-Similar to `ReactDOM.render`, but have additional parameter `context`, in which you can specify properties for context object, which will be used during rendering of component.
+Similar to `ReactDOM.render`, but have additional parameter `context`, in which you can specify properties for context object, which will be used during rendering of `element`.
 
 ```javascript
 ReactElement shallowRenderer.getRenderOutput()


### PR DESCRIPTION
Due to code in https://github.com/facebook/react/blob/master/src/test/ReactTestUtils.js#L412, there is second parameter 'context', which was previously not described in this doc.