### PR TITLE
Add more properties to the SVG whitelist

### DIFF
--- a/src/renderers/dom/shared/SVGDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/SVGDOMPropertyConfig.js
@@ -239,6 +239,7 @@ var ATTRS = {
   vIdeographic: 'v-ideographic',
   vMathematical: 'v-mathematical',
   values: 0,
+  vectorEffect: 'vector-effect',
   version: 0,
   vertAdvY: 'vert-adv-y',
   vertOriginX: 'vert-origin-x',

--- a/src/renderers/dom/shared/SVGDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/SVGDOMPropertyConfig.js
@@ -94,6 +94,7 @@ var ATTRS = {
   filterUnits: 'filterUnits',
   floodColor: 'flood-color',
   floodOpacity: 'flood-opacity',
+  focusable: 0,
   fontFamily: 'font-family',
   fontSize: 'font-size',
   fontSizeAdjust: 'font-size-adjust',


### PR DESCRIPTION
This adds two more requested properties to the SVG whitelist:

* `focusable` (https://github.com/facebook/react/issues/6212)
* `vector-effect`(https://github.com/facebook/react/issues/1657#issuecomment-72539816, https://github.com/facebook/react/issues/1657#issuecomment-146212191, https://github.com/facebook/react/issues/1657#issuecomment-148420568)