### PR TITLE
added several new unitless properties

### DIFF
--- a/src/renderers/dom/shared/CSSProperty.js
+++ b/src/renderers/dom/shared/CSSProperty.js
@@ -17,6 +17,8 @@
 var isUnitlessNumber = {
   animationIterationCount: true,
   borderImageOutset: true,
+  borderImageSlice: true,
+  borderImageWidth: true,
   boxFlex: true,
   boxFlexGroup: true,
   boxOrdinalGroup: true,
@@ -42,8 +44,11 @@ var isUnitlessNumber = {
 
   // SVG-related properties
   fillOpacity: true,
+  floodOpacity: true,
   stopOpacity: true,
+  strokeDasharray: true,
   strokeDashoffset: true,
+  strokeMiterlimit: true,
   strokeOpacity: true,
   strokeWidth: true,
 };


### PR DESCRIPTION
I again added some properties to the list of unitless properties, which I found get a `px` added but allow unitless values. I might find even more from time to time as I am excessively collecting data on CSS properties to build a bulletproof JS style linter.

* [borderImageWidth](https://drafts.csswg.org/css-backgrounds-3/#border-image-width)
* [borderImageSlice](https://drafts.csswg.org/css-backgrounds-3/#border-image-slice)

### SVG
* [floodOpacity](http://www.w3.org/TR/SVG/filters.html#FloodOpacityProperty)
* [strokeDasharray](http://www.w3.org/TR/SVG/painting.html#StrokeDasharrayProperty) *([Example Line 9](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray#Example))*
* [strokeMiterlimit](http://www.w3.org/TR/SVG11/painting.html#StrokeMiterlimitProperty)