### PR TITLE
getEventKey unit tests

### DIFF
--- a/src/renderers/dom/client/utils/__tests__/getEventKey-test.js
+++ b/src/renderers/dom/client/utils/__tests__/getEventKey-test.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var getEventKey = require('getEventKey');
+
+describe('getEventKey', function() {
+  describe('when key is implemented in a browser', function() {
+    describe('when key is not normalized', function() {
+      it('returns a normalized value', function() {
+        var nativeEvent = new KeyboardEvent('keypress', {key: 'Del'});
+
+        expect(getEventKey(nativeEvent)).toBe('Delete');
+      });
+    });
+
+    describe('when key is normalized', function() {
+      it('returns a key', function() {
+        var nativeEvent = new KeyboardEvent('keypress', {key: 'f'});
+
+        expect(getEventKey(nativeEvent)).toBe('f');
+      });
+    });
+  });
+
+  describe('when key is not implemented in a browser', function() {
+    describe('when event type is keypress', function() {
+      describe('when charCode is 13', function() {
+        it("returns 'Enter'", function() {
+          var nativeEvent = new KeyboardEvent('keypress', {charCode: 13});
+
+          expect(getEventKey(nativeEvent)).toBe('Enter');
+        });
+      });
+
+      describe('when charCode is not 13', function() {
+        it('returns a string from a charCode', function() {
+          var nativeEvent = new KeyboardEvent('keypress', {charCode: 65});
+
+          expect(getEventKey(nativeEvent)).toBe('A');
+        });
+      });
+    });
+
+    describe('when event type is keydown or keyup', function() {
+      describe('when keyCode is recognized', function() {
+        it('returns a translated key', function() {
+          var nativeEvent = new KeyboardEvent('keydown', {keyCode: 45});
+
+          expect(getEventKey(nativeEvent)).toBe('Insert');
+        });
+      });
+
+      describe('when keyCode is not recognized', function() {
+        it('returns Unidentified', function() {
+          var nativeEvent = new KeyboardEvent('keydown', {keyCode: 1337});
+
+          expect(getEventKey(nativeEvent)).toBe('Unidentified');
+        });
+      });
+    });
+
+    describe('when event type is unknown', function() {
+      it('returns an empty string', function() {
+        var nativeEvent = new KeyboardEvent('keysmack');
+
+        expect(getEventKey(nativeEvent)).toBe('');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds unit tests to getEventKey function.

I have noticed that getEventKey lacks test coverage - here is the fix.

### Test coverage before
<img width="715" alt="2016-03-16 22 03 57" src="https://cloud.githubusercontent.com/assets/1615659/13825578/3454b78c-ebc4-11e5-9a24-64028aa70997.png">
<img width="738" alt="2016-03-16 22 04 11" src="https://cloud.githubusercontent.com/assets/1615659/13825581/345aff5c-ebc4-11e5-9f1e-464cdf1c81e0.png">

### Test coverage after
<img width="726" alt="2016-03-16 22 05 46" src="https://cloud.githubusercontent.com/assets/1615659/13825579/34556db2-ebc4-11e5-8c7b-c95672529e34.png">
<img width="745" alt="2016-03-16 22 05 36" src="https://cloud.githubusercontent.com/assets/1615659/13825580/3456baaa-ebc4-11e5-8d3d-c3e299fe9896.png">

P.S.
This is my first **ever** contribution to an open source project. If improving test coverage is wanted by a React team - I would be glad to open more pull requests. Obviously, if I made an error somewhere - please tell me, I am ready to fix it [: