### PR TITLE
Revert "Bug fix for issue 5202"

### DIFF
--- a/src/renderers/dom/client/ReactBrowserEventEmitter.js
+++ b/src/renderers/dom/client/ReactBrowserEventEmitter.js
@@ -287,23 +287,12 @@ var ReactBrowserEventEmitter = assign({}, ReactEventEmitterMixin, {
             );
           }
         } else if (dependency === topLevelTypes.topFocus ||
-            dependency === topLevelTypes.topBlur || dependency === topLevelTypes.topFocusIn ||
-            dependency === topLevelTypes.topFocusOut) {
+            dependency === topLevelTypes.topBlur) {
 
           if (isEventSupported('focus', true)) {
             ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
               topLevelTypes.topFocus,
               'focus',
-              mountAt
-            );
-            ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
-              topLevelTypes.topFocusIn,
-              'focusin',
-              mountAt
-            );
-            ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
-              topLevelTypes.topFocusOut,
-              'focusout',
               mountAt
             );
             ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
@@ -329,8 +318,6 @@ var ReactBrowserEventEmitter = assign({}, ReactEventEmitterMixin, {
           // to make sure blur and focus event listeners are only attached once
           isListening[topLevelTypes.topBlur] = true;
           isListening[topLevelTypes.topFocus] = true;
-          isListening[topLevelTypes.topFocusIn] = true;
-          isListening[topLevelTypes.topFocusOut] = true;
         } else if (topEventMapping.hasOwnProperty(dependency)) {
           ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(
             dependency,

--- a/src/renderers/dom/client/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/ChangeEventPlugin.js
@@ -37,8 +37,6 @@ var eventTypes = {
       topLevelTypes.topChange,
       topLevelTypes.topClick,
       topLevelTypes.topFocus,
-      topLevelTypes.topFocusIn,
-      topLevelTypes.topFocusOut,
       topLevelTypes.topInput,
       topLevelTypes.topKeyDown,
       topLevelTypes.topKeyUp,

--- a/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
@@ -191,18 +191,6 @@ var eventTypes = {
       captured: keyOf({onFocusCapture: true}),
     },
   },
-  focusOut: {
-    phasedRegistrationNames: {
-      bubbled: keyOf({onFocusOut: true}),
-      captured: keyOf({onFocusOutCapture: true}),
-    },
-  },
-  focusIn: {
-    phasedRegistrationNames: {
-      bubbled: keyOf({onFocusIn: true}),
-      captured: keyOf({onFocusInCapture: true}),
-    },
-  },
   input: {
     phasedRegistrationNames: {
       bubbled: keyOf({onInput: true}),
@@ -450,8 +438,6 @@ var topLevelEventsToDispatchConfig = {
   topEnded:           eventTypes.ended,
   topError:           eventTypes.error,
   topFocus:           eventTypes.focus,
-  topFocusOut:        eventTypes.focusOut,
-  topFocusIn:         eventTypes.focusIn,
   topInput:           eventTypes.input,
   topInvalid:         eventTypes.invalid,
   topKeyDown:         eventTypes.keyDown,
@@ -559,8 +545,6 @@ var SimpleEventPlugin = {
         break;
       case topLevelTypes.topBlur:
       case topLevelTypes.topFocus:
-      case topLevelTypes.topFocusIn:
-      case topLevelTypes.topFocusOut:
         EventConstructor = SyntheticFocusEvent;
         break;
       case topLevelTypes.topClick:

--- a/src/renderers/shared/event/EventConstants.js
+++ b/src/renderers/shared/event/EventConstants.js
@@ -49,8 +49,6 @@ var topLevelTypes = keyMirror({
   topEnded: null,
   topError: null,
   topFocus: null,
-  topFocusIn: null,
-  topFocusOut: null,
   topInput: null,
   topInvalid: null,
   topKeyDown: null,


### PR DESCRIPTION
This reverts facebook/react#6226 per discussion in https://github.com/facebook/react/pull/6226#issuecomment-197521538 and below.

The user should have been using `onFocus` and `onBlur` events instead because we normalize them across browsers. We should probably add a warning later when user tries to use `onFocusIn`, but there is no point to supporting it explicitly.