### PR TITLE
Skip all special props when setting attributes on web components

### DIFF
--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -53,9 +53,14 @@ var registrationNameModules = EventPluginRegistry.registrationNameModules;
 // For quickly matching children type, to test if can be treated as content.
 var CONTENT_TYPES = {'string': true, 'number': true};
 
-var CHILDREN = keyOf({children: null});
 var STYLE = keyOf({style: null});
 var HTML = keyOf({__html: null});
+var RESERVED_PROPS = {
+  children: null,
+  dangerouslySetInnerHTML: null,
+  suppressContentEditableWarning: null,
+};
+
 
 function getDeclarationErrorAddendum(internalInstance) {
   if (internalInstance) {
@@ -635,7 +640,7 @@ ReactDOMComponent.Mixin = {
         }
         var markup = null;
         if (this._tag != null && isCustomComponent(this._tag, props)) {
-          if (propKey !== CHILDREN) {
+          if (!RESERVED_PROPS.hasOwnProperty(propKey)) {
             markup = DOMPropertyOperations.createMarkupForCustomAttribute(propKey, propValue);
           }
         } else {
@@ -907,14 +912,13 @@ ReactDOMComponent.Mixin = {
           deleteListener(this, propKey);
         }
       } else if (isCustomComponent(this._tag, nextProps)) {
-        if (propKey === CHILDREN) {
-          nextProp = null;
+        if (!RESERVED_PROPS.hasOwnProperty(propKey)) {
+          DOMPropertyOperations.setValueForAttribute(
+            getNode(this),
+            propKey,
+            nextProp
+          );
         }
-        DOMPropertyOperations.setValueForAttribute(
-          getNode(this),
-          propKey,
-          nextProp
-        );
       } else if (
           DOMProperty.properties[propKey] ||
           DOMProperty.isCustomAttribute(propKey)) {

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -236,16 +236,52 @@ describe('ReactDOMComponent', function() {
       expect(stubStyle.display).toEqual('');
     });
 
-    it('should skip child object attribute on web components', function() {
+    it('should skip reserved props on web components', function() {
       var container = document.createElement('div');
 
-      // Test initial render to null
-      ReactDOM.render(<my-component children={['foo']} />, container);
+      ReactDOM.render(
+        <my-component
+          children={['foo']}
+          suppressContentEditableWarning={true}
+        />,
+        container
+      );
       expect(container.firstChild.hasAttribute('children')).toBe(false);
+      expect(
+        container.firstChild.hasAttribute('suppressContentEditableWarning')
+      ).toBe(false);
 
-      // Test updates to null
-      ReactDOM.render(<my-component children={['foo']} />, container);
+      ReactDOM.render(
+        <my-component
+          children={['bar']}
+          suppressContentEditableWarning={false}
+        />,
+        container
+      );
       expect(container.firstChild.hasAttribute('children')).toBe(false);
+      expect(
+        container.firstChild.hasAttribute('suppressContentEditableWarning')
+      ).toBe(false);
+    });
+
+    it('should skip dangerouslySetInnerHTML on web components', function() {
+      var container = document.createElement('div');
+
+      ReactDOM.render(
+        <my-component dangerouslySetInnerHTML={{__html: 'hi'}} />,
+        container
+      );
+      expect(
+        container.firstChild.hasAttribute('dangerouslySetInnerHTML')
+      ).toBe(false);
+
+      ReactDOM.render(
+        <my-component dangerouslySetInnerHTML={{__html: 'bye'}} />,
+        container
+      );
+      expect(
+        container.firstChild.hasAttribute('dangerouslySetInnerHTML')
+      ).toBe(false);
     });
 
     it('should remove attributes', function() {


### PR DESCRIPTION
This was introduced as part of #6164 and approved by @spicyj but got reverted in #6243 by accident.
I believe the web component part of it is still relevant (I should’ve split that PR to signal that):

<img width="389" alt="screen shot 2016-03-16 at 21 12 40" src="https://cloud.githubusercontent.com/assets/810438/13828875/d82bb832-ebbb-11e5-9ee2-85d23fc1a347.png">

This PR just applies the part of #6164 that is still relevant (for web components only).

Test plan: when `dangerouslySetInnerHTML` is specified, it is no longer copied as an attribute.

<img width="207" alt="screen shot 2016-03-16 at 21 15 25" src="https://cloud.githubusercontent.com/assets/810438/13828940/3a652178-ebbc-11e5-8eec-1bf0968acc49.png">

## Reviewers

@sebmarkbage 