### PR TITLE
Fix race condition in ResponderTouchHistoryStore

### DIFF
--- a/src/renderers/shared/event/eventPlugins/ResponderTouchHistoryStore.js
+++ b/src/renderers/shared/event/eventPlugins/ResponderTouchHistoryStore.js
@@ -116,6 +116,11 @@ var recordStartTouchData = function(touch) {
 var recordMoveTouchData = function(touch) {
   var touchBank = touchHistory.touchBank;
   var touchTrack = touchBank[touch.identifier];
+  if (touchTrack) {
+    reinitializeTouchTrack(touchTrack, touch);
+  } else {
+    touchBank[touch.identifier] = initializeTouchData(touch);
+  }
   if (__DEV__) {
     validateTouch(touch);
     invariant(touchTrack, 'Touch data should have been recorded on start');


### PR DESCRIPTION
On a cold boot of my React Native app, if the first touch on the screen is a scroll on a ListView/ScrollView, there appears to be a race condition and `recordMoveTouchData` is called before `recordStartTouchData`, therefore `touchHistory.touchBank` is not properly initialized.

Upon the first call,
`var touchTrack = touchBank[touch.identifier];`
touchTrack is undefined here, causing the crash. This code change resolves the problem by properly initializing the touchBank. Not sure if this is the correct approach, because it's probably an indication of a deeper problem, but wanted to start a conversation about it.

