### PR TITLE
Make ReactPerf.getLastMeasurements() opaque

### DIFF
--- a/src/test/ReactDefaultPerf.js
+++ b/src/test/ReactDefaultPerf.js
@@ -51,6 +51,17 @@ function getID(inst) {
   }
 }
 
+// This implementation of ReactPerf is going away some time mid 15.x.
+// While we plan to keep most of the API, the actual format of measurements
+// will change dramatically. To signal this, we wrap them into an opaque-ish
+// object to discourage reaching into it until the API stabilizes.
+function wrapLegacyMeasurements(measurements) {
+  return { __unstable_this_format_will_change: measurements };
+}
+function unwrapLegacyMeasurements(measurements) {
+  return measurements && measurements.__unstable_this_format_will_change || measurements;
+}
+
 var ReactDefaultPerf = {
   _allMeasurements: [], // last item in the list is the current one
   _mountStack: [0],
@@ -71,11 +82,11 @@ var ReactDefaultPerf = {
   },
 
   getLastMeasurements: function() {
-    return ReactDefaultPerf._allMeasurements;
+    return wrapLegacyMeasurements(ReactDefaultPerf._allMeasurements);
   },
 
   printExclusive: function(measurements) {
-    measurements = measurements || ReactDefaultPerf._allMeasurements;
+    measurements = unwrapLegacyMeasurements(measurements || ReactDefaultPerf._allMeasurements);
     var summary = ReactDefaultPerfAnalysis.getExclusiveSummary(measurements);
     console.table(summary.map(function(item) {
       return {
@@ -93,7 +104,7 @@ var ReactDefaultPerf = {
   },
 
   printInclusive: function(measurements) {
-    measurements = measurements || ReactDefaultPerf._allMeasurements;
+    measurements = unwrapLegacyMeasurements(measurements || ReactDefaultPerf._allMeasurements);
     var summary = ReactDefaultPerfAnalysis.getInclusiveSummary(measurements);
     console.table(summary.map(function(item) {
       return {
@@ -109,6 +120,7 @@ var ReactDefaultPerf = {
   },
 
   getMeasurementsSummaryMap: function(measurements) {
+    measurements = unwrapLegacyMeasurements(measurements);
     var summary = ReactDefaultPerfAnalysis.getInclusiveSummary(
       measurements,
       true
@@ -123,7 +135,7 @@ var ReactDefaultPerf = {
   },
 
   printWasted: function(measurements) {
-    measurements = measurements || ReactDefaultPerf._allMeasurements;
+    measurements = unwrapLegacyMeasurements(measurements || ReactDefaultPerf._allMeasurements);
     console.table(ReactDefaultPerf.getMeasurementsSummaryMap(measurements));
     console.log(
       'Total time:',
@@ -132,7 +144,7 @@ var ReactDefaultPerf = {
   },
 
   printDOM: function(measurements) {
-    measurements = measurements || ReactDefaultPerf._allMeasurements;
+    measurements = unwrapLegacyMeasurements(measurements || ReactDefaultPerf._allMeasurements);
     var summary = ReactDefaultPerfAnalysis.getDOMSummary(measurements);
     console.table(summary.map(function(item) {
       var result = {};


### PR DESCRIPTION
This is a temporary change I want to get into 15.0.

We intend to change the measurement format significantly in #6046. **In order to introduce the new `ReactPerf` with a different and more detailed measurement format during 15.x release cycle, I propose to make the measurement structure opaque-ish in 15.0.**

I searched the GitHub for usage of `ReactPerf.getLastMeasurements()` and couldn’t find any popular projects relying on its internal structure except React Native in [this single module](https://github.com/facebook/react-native/blob/14555063bb496973f19f198bf05a2802efbde4e4/Libraries/Utilities/RCTRenderingPerf.js#L53-L61). I left `__unstable_this_format_will_change` as a workaround in case RN makes a release with 15.0 before we ship 15.1 with the new `ReactPerf`, or if anyone else really needs reading those measurements in the raw form.

In any case I will be working on updating React Native to use the new `ReactPerf` later so I don’t think we should be held back by this. It’s likely that by the time React Native is ready to switch to 15, the new `ReactPerf` will be ready, but if not, `__unstable_this_format_will_change` covers their use case.

All existing methods continue to work with the measurements returned from `getLastMeasurements()` so we aren’t breaking the contract. We’re just signaling that the internal format of measurements is an implementation detail in 15.0 until we iron it out and present the new, more detailed one, in 15.1.

## Test Plan

Verify that `ReactPerf.printExclusive()`, `ReactPerf.printInclusive()`, `ReactPerf.printWasted()`, `ReactPerf.printDOM()` still work both with zero arguments and with a single argument obtained from `ReactPerf.getLastMeasurements()`. Verify that `ReactPerf.getMeasurementsSummaryMap()` still works with a single argument.

## Reviewers

@sebmarkbage 