### PR TITLE
Rename ReactPerf methods to match the upcoming ReactPerf revamp

### DIFF
--- a/docs/docs/10.9-perf.md
+++ b/docs/docs/10.9-perf.md
@@ -41,10 +41,14 @@ Prints the overall time taken. If no argument's passed, defaults to all the meas
 
 ![](/react/img/docs/perf-wasted.png)
 
-### `Perf.printDOM(measurements)`
+### `Perf.printOperations(measurements)`
 Prints the underlying DOM manipulations, e.g. "set innerHTML" and "remove".
 
 ![](/react/img/docs/perf-dom.png)
+
+### `Perf.printDOM(measurements)`
+
+This method has been renamed to `printOperations()` which is described in the previous paragraph. Currently `printDOM()` still exists as an alias but it prints a deprecation warning and will eventually be removed.
 
 ## Advanced API
 

--- a/src/test/ReactDefaultPerf.js
+++ b/src/test/ReactDefaultPerf.js
@@ -18,6 +18,7 @@ var ReactMount = require('ReactMount');
 var ReactPerf = require('ReactPerf');
 
 var performanceNow = require('performanceNow');
+var warning = require('warning');
 
 function roundFloat(val) {
   return Math.floor(val * 100) / 100;
@@ -61,6 +62,9 @@ function wrapLegacyMeasurements(measurements) {
 function unwrapLegacyMeasurements(measurements) {
   return measurements && measurements.__unstable_this_format_will_change || measurements;
 }
+
+var warnedAboutPrintDOM = false;
+var warnedAboutGetMeasurementsSummaryMap = false;
 
 var ReactDefaultPerf = {
   _allMeasurements: [], // last item in the list is the current one
@@ -120,6 +124,16 @@ var ReactDefaultPerf = {
   },
 
   getMeasurementsSummaryMap: function(measurements) {
+    warning(
+      warnedAboutGetMeasurementsSummaryMap,
+      '`ReactPerf.getMeasurementsSummaryMap(...)` is deprecated. Use ' +
+      '`ReactPerf.getWasted(...)` instead.'
+    );
+    warnedAboutGetMeasurementsSummaryMap = true;
+    return ReactDefaultPerf.getWasted(measurements);
+  },
+
+  getWasted: function(measurements) {
     measurements = unwrapLegacyMeasurements(measurements);
     var summary = ReactDefaultPerfAnalysis.getInclusiveSummary(
       measurements,
@@ -136,7 +150,7 @@ var ReactDefaultPerf = {
 
   printWasted: function(measurements) {
     measurements = unwrapLegacyMeasurements(measurements || ReactDefaultPerf._allMeasurements);
-    console.table(ReactDefaultPerf.getMeasurementsSummaryMap(measurements));
+    console.table(ReactDefaultPerf.getWasted(measurements));
     console.log(
       'Total time:',
       ReactDefaultPerfAnalysis.getTotalTime(measurements).toFixed(2) + ' ms'
@@ -144,6 +158,16 @@ var ReactDefaultPerf = {
   },
 
   printDOM: function(measurements) {
+    warning(
+      warnedAboutPrintDOM,
+      '`ReactPerf.printDOM(...)` is deprecated. Use ' +
+      '`ReactPerf.printOperations(...)` instead.'
+    );
+    warnedAboutPrintDOM = true;
+    return ReactDefaultPerf.printOperations(measurements);
+  },
+
+  printOperations: function(measurements) {
     measurements = unwrapLegacyMeasurements(measurements || ReactDefaultPerf._allMeasurements);
     var summary = ReactDefaultPerfAnalysis.getDOMSummary(measurements);
     console.table(summary.map(function(item) {

--- a/src/test/__tests__/ReactDefaultPerf-test.js
+++ b/src/test/__tests__/ReactDefaultPerf-test.js
@@ -28,6 +28,11 @@ describe('ReactDefaultPerf', function() {
       return now++;
     });
 
+    if (typeof console.table !== 'function') {
+      console.table = () => {};
+      console.table.isFake = true;
+    }
+
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactDefaultPerf = require('ReactDefaultPerf');
@@ -54,6 +59,12 @@ describe('ReactDefaultPerf', function() {
     });
   });
 
+  afterEach(function() {
+    if (console.table.isFake) {
+      delete console.table;
+    }
+  });
+
   function measure(fn) {
     ReactDefaultPerf.start();
     fn();
@@ -68,7 +79,7 @@ describe('ReactDefaultPerf', function() {
       ReactDOM.render(<App />, container);
     });
 
-    var summary = ReactDefaultPerf.getMeasurementsSummaryMap(measurements);
+    var summary = ReactDefaultPerf.getWasted(measurements);
     expect(summary.length).toBe(2);
 
     /*eslint-disable dot-notation */
@@ -94,7 +105,7 @@ describe('ReactDefaultPerf', function() {
       ReactDOM.render(<App flipSecond={true} />, container);
     });
 
-    var summary = ReactDefaultPerf.getMeasurementsSummaryMap(measurements);
+    var summary = ReactDefaultPerf.getWasted(measurements);
     expect(summary.length).toBe(1);
 
     /*eslint-disable dot-notation */
@@ -108,7 +119,7 @@ describe('ReactDefaultPerf', function() {
 
   function expectNoWaste(fn) {
     var measurements = measure(fn);
-    var summary = ReactDefaultPerf.getMeasurementsSummaryMap(measurements);
+    var summary = ReactDefaultPerf.getWasted(measurements);
     expect(summary).toEqual([]);
   }
 
@@ -224,6 +235,34 @@ describe('ReactDefaultPerf', function() {
 
     var summary = ReactDefaultPerfAnalysis.getDOMSummary(measurements);
     expect(summary).toEqual([]);
+  });
+
+  it('warns once when using getMeasurementsSummaryMap', function() {
+    var measurements = measure(() => {});
+    spyOn(console, 'error');
+    ReactDefaultPerf.getMeasurementsSummaryMap(measurements);
+    expect(console.error.calls.length).toBe(1);
+    expect(console.error.argsForCall[0][0]).toContain(
+      '`ReactPerf.getMeasurementsSummaryMap(...)` is deprecated. Use ' +
+      '`ReactPerf.getWasted(...)` instead.'
+    );
+
+    ReactDefaultPerf.getMeasurementsSummaryMap(measurements);
+    expect(console.error.calls.length).toBe(1);
+  });
+
+  it('warns once when using printDOM', function() {
+    var measurements = measure(() => {});
+    spyOn(console, 'error');
+    ReactDefaultPerf.printDOM(measurements);
+    expect(console.error.calls.length).toBe(1);
+    expect(console.error.argsForCall[0][0]).toContain(
+      '`ReactPerf.printDOM(...)` is deprecated. Use ' +
+      '`ReactPerf.printOperations(...)` instead.'
+    );
+
+    ReactDefaultPerf.printDOM(measurements);
+    expect(console.error.calls.length).toBe(1);
   });
 
 });


### PR DESCRIPTION
I’m not feeling strong about this but I would like to get these two methods renamed before 15.0.

### `printDOM()` → `printOperations()`

`printDOM()` is really popular one but since `ReactPerf` can be used together with React Native, the name doesn’t really do it justice. In #6046, we let renderers emit arbitrary `NATIVE_OPERATION` events so React Native won’t be confined to the [current list of “DOM operations”](https://github.com/facebook/react/blob/8046cbda10fc024bc3f12b39923736df78c8ffe5/src/test/ReactDefaultPerfAnalysis.js#L18-L32) either. This is why I’m renaming `printDOM()` to `printOperations()`.

### `getMeasurementsSummaryMap()` → `getWasted()`

The second rename concerns `getMeasurementsSummaryMap()` which was added in #2219. Its name is already somewhat confusing because it doesn’t actually return a map—it returns an array. Additionally, it sounds very generic but it actually corresponds to a very specific dataset: the table printed by `printWasted()`.

In #6046 I plan to expose a `get*` method for every `print*` method so it makes sense that `getWasted()` exists as a match to `printWasted()` in 15.0, complemented by other `get*()` methods such as `getInclusive()` and `getOperations()` when #6046 ships some time during 15.x.

One thing I’m not sure about is whether `getWasted()` invites an unnecessary connotation for fluent English speakers. I’m open to improvements that offer another way of maintaining consistency with the upcoming changes, e.g. `getWastedStats()`, `getInclusiveStats()`, etc.

### Why Do This Now

This is our opportunity to rename some methods on the API that’s going to significantly change internally, and I think it’s worth doing it before shipping 15.0. Since people rely on `getMeasurementsSummaryMap()` for things like CI (#2219), in my opinion it would be unwise to introduce a deprecation warning in something other than a major release, as a new warning can potentially break CIs.

### Deprecation Strategy

We will keep the old method name working in v15 with a deprecation warning, and remove it during or after v16 when most tutorials have been updated.

### Reviewers

@sebmarkbage @jimfb 