### PR TITLE
Strip complex values from ReactPerf.printDOM() output

### DIFF
--- a/src/test/ReactDefaultPerf.js
+++ b/src/test/ReactDefaultPerf.js
@@ -52,6 +52,17 @@ function getID(inst) {
   }
 }
 
+function stripComplexValues(key, value) {
+  if (typeof value !== 'object' || Array.isArray(value) || value == null) {
+    return value;
+  }
+  var prototype = Object.getPrototypeOf(value);
+  if (!prototype || prototype === Object.prototype) {
+    return value;
+  }
+  return '<not serializable>';
+}
+
 // This implementation of ReactPerf is going away some time mid 15.x.
 // While we plan to keep most of the API, the actual format of measurements
 // will change dramatically. To signal this, we wrap them into an opaque-ish
@@ -174,7 +185,7 @@ var ReactDefaultPerf = {
       var result = {};
       result[DOMProperty.ID_ATTRIBUTE_NAME] = item.id;
       result.type = item.type;
-      result.args = JSON.stringify(item.args);
+      result.args = JSON.stringify(item.args, stripComplexValues);
       return result;
     }));
     console.log(

--- a/src/test/__tests__/ReactDefaultPerf-test.js
+++ b/src/test/__tests__/ReactDefaultPerf-test.js
@@ -237,6 +237,21 @@ describe('ReactDefaultPerf', function() {
     expect(summary).toEqual([]);
   });
 
+  it('should print a table after calling printOperations', function() {
+    var container = document.createElement('div');
+    var measurements = measure(() => {
+      ReactDOM.render(<Div>hey</Div>, container);
+    });
+    spyOn(console, 'table');
+    ReactDefaultPerf.printOperations(measurements);
+    expect(console.table.calls.length).toBe(1);
+    expect(console.table.argsForCall[0][0]).toEqual([{
+      'data-reactid': '',
+      type: 'set innerHTML',
+      args: '{"node":"<not serializable>","children":[],"html":null,"text":null}',
+    }]);
+  });
+
   it('warns once when using getMeasurementsSummaryMap', function() {
     var measurements = measure(() => {});
     spyOn(console, 'error');


### PR DESCRIPTION
This fixes #6288 by stripping any complex values (objects that don’t seem to be plain objects) in `ReactPerf.printOperations()` (aka `printDOM()`) output. This is a temporary solution until #6046 in which we won’t pass problematic values in the first place.

## Test Plan

Added a new test and manually ran on an example app. `printOperations()` now works again.

<img width="804" alt="screen shot 2016-03-17 at 21 16 40" src="https://cloud.githubusercontent.com/assets/810438/13861739/f169255c-ec86-11e5-8b82-7ea543714478.png">


## Reviewers

@sebmarkbage @jimfb 