### PR TITLE
First-Class Custom PropType Checker

### DIFF
--- a/docs/docs/05-reusable-components.it-IT.md
+++ b/docs/docs/05-reusable-components.it-IT.md
@@ -70,11 +70,13 @@ React.createClass({
     // oggetto di tipo Error se la validazione fallisce. Non lanciare eccezioni
     // o utilizzare `console.warn`, in quanto non funzionerebbe all'interno di
     // `oneOfType`.
-    customProp: function(props, propName, componentName) {
-      if (!/matchme/.test(props[propName])) {
-        return new Error('Validazione fallita!');
+    requiredCustomProp: React.PropTypes.custom(
+      function(props, propName, componentName) {
+        if (!/matchme/.test(props[propName])) {
+          return new Error('Validazione fallita!');
+        }
       }
-    }
+    ).isRequired,
   },
   /* ... */
 });

--- a/docs/docs/05-reusable-components.ja-JP.md
+++ b/docs/docs/05-reusable-components.ja-JP.md
@@ -66,11 +66,13 @@ React.createClass({
     // バリデータをカスタマイズすることもできます。
     // 以下はバリデーションが落ちた時にはエラーを返します。
     // `oneOfType` の中で動かなくなるので、 `console.warn` や throw はしないでください。
-    customProp: function(props, propName, componentName) {
-      if (!/matchme/.test(props[propName])) {
-        return new Error('Validation failed!');
+    requiredCustomProp: React.PropTypes.custom(
+      function(props, propName, componentName) {
+        if (!/matchme/.test(props[propName])) {
+          return new Error('Validation failed!');
+        }
       }
-    }
+    ).isRequired,
   },
   /* ... */
 });

--- a/docs/docs/05-reusable-components.ko-KR.md
+++ b/docs/docs/05-reusable-components.ko-KR.md
@@ -67,11 +67,13 @@ React.createClass({
     // 물론 사용자 정의 검증자도 지정할 수 있습니다. 이는 검증이 실패했을 때
     // Error 객체를 리턴해야합니다. `console.warn`을 이나 throw를 하면 안됩니다.
     // 그렇게하면 `oneOfType` 안에서 작동하지 않습니다.
-    customProp: function(props, propName, componentName) {
-      if (!/matchme/.test(props[propName])) {
-        return new Error('Validation failed!');
+    requiredCustomProp: React.PropTypes.custom(
+      function(props, propName, componentName) {
+        if (!/matchme/.test(props[propName])) {
+          return new Error('Validation failed!');
+        }
       }
-    }
+    ).isRequired,
   },
   /* ... */
 });

--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -68,11 +68,13 @@ React.createClass({
     // You can also specify a custom validator. It should return an Error
     // object if the validation fails. Don't `console.warn` or throw, as this
     // won't work inside `oneOfType`.
-    customProp: function(props, propName, componentName) {
-      if (!/matchme/.test(props[propName])) {
-        return new Error('Validation failed!');
+    requiredCustomProp: React.PropTypes.custom(
+      function(props, propName, componentName) {
+        if (!/matchme/.test(props[propName])) {
+          return new Error('Validation failed!');
+        }
       }
-    }
+    ).isRequired,
   },
   /* ... */
 });

--- a/docs/docs/05-reusable-components.zh-CN.md
+++ b/docs/docs/05-reusable-components.zh-CN.md
@@ -68,11 +68,13 @@ React.createClass({
     // 你可以自定义一个验证器。如果验证失败需要返回一个 Error 对象。
     // 不要直接使用 `console.warn` 或抛异常，
     // 因为这在 `oneOfType` 里不起作用。
-    customProp: function(props, propName, componentName) {
-      if (!/matchme/.test(props[propName])) {
-        return new Error('Validation failed!');
+    requiredCustomProp: React.PropTypes.custom(
+      function(props, propName, componentName) {
+        if (!/matchme/.test(props[propName])) {
+          return new Error('Validation failed!');
+        }
       }
-    }
+    ).isRequired,
   },
   /* ... */
 });

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -115,8 +115,8 @@ function createChainableTypeChecker(validate) {
     componentName = componentName || ANONYMOUS;
     propFullName = propFullName || propName;
     if (props[propName] == null) {
-      var locationName = ReactPropTypeLocationNames[location];
       if (isRequired) {
+        var locationName = ReactPropTypeLocationNames[location];
         return new Error(
           `Required ${locationName} \`${propFullName}\` was not specified in ` +
           `\`${componentName}\`.`

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -83,6 +83,7 @@ var ReactPropTypes = {
   oneOf: createEnumTypeChecker,
   oneOfType: createUnionTypeChecker,
   shape: createShapeTypeChecker,
+  custom: createCustomTypeChecker,
 };
 
 /**
@@ -357,6 +358,10 @@ function createShapeTypeChecker(shapeTypes) {
     return null;
   }
   return createChainableTypeChecker(validate);
+}
+
+function createCustomTypeChecker(customChecker) {
+  return createChainableTypeChecker(customChecker);
 }
 
 function isNode(propValue) {

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -22,6 +22,13 @@ var MyComponent;
 var requiredMessage =
   'Required prop `testProp` was not specified in `testComponent`.';
 
+/**
+ * Asserts a failing propType check.
+ *
+ * @param {function} declaration A propType function for checking a prop.
+ * @param {*} value A value whose type to check.
+ * @param {string} message The expected Error message from the failed assertion.
+ */
 function typeCheckFail(declaration, value, message) {
   var props = {testProp: value};
   var error = declaration(
@@ -34,6 +41,12 @@ function typeCheckFail(declaration, value, message) {
   expect(error.message).toBe(message);
 }
 
+/**
+ * Asserts a passing propType check.
+ *
+ * @param {function} declaration A propType function for checking a prop.
+ * @param {*} value A value whose type to check.
+ */
 function typeCheckPass(declaration, value) {
   var props = {testProp: value};
   var error = declaration(
@@ -142,7 +155,8 @@ describe('ReactPropTypes', function() {
       typeCheckFail(
         PropTypes.arrayOf({ foo: PropTypes.string }),
         { foo: 'bar' },
-        'Property `testProp` of component `testComponent` has invalid PropType notation inside arrayOf.'
+        'Property `testProp` of component `testComponent`' +
+        ' has invalid PropType notation inside arrayOf.'
       );
     });
 

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -802,7 +802,7 @@ describe('ReactPropTypes', function() {
     it('should have been called with the right params', function() {
       var spy = jasmine.createSpy();
       Component = React.createClass({
-        propTypes: {num: spy},
+        propTypes: {num: PropTypes.custom(spy)},
 
         render: function() {
           return <div />;
@@ -817,22 +817,6 @@ describe('ReactPropTypes', function() {
       expect(spy.argsForCall[0][2]).toBe('Component');
     });
 
-    it('should have been called even if the prop is not present', function() {
-      var spy = jasmine.createSpy();
-      Component = React.createClass({
-        propTypes: {num: spy},
-
-        render: function() {
-          return <div />;
-        },
-      });
-
-      var instance = <Component bla={5} />;
-      instance = ReactTestUtils.renderIntoDocument(instance);
-
-      expect(spy.argsForCall.length).toBe(2); // temp double validation
-    });
-
     it('should have received the validator\'s return value', function() {
       var spy = jasmine.createSpy().andCallFake(
         function(props, propName, componentName) {
@@ -842,7 +826,7 @@ describe('ReactPropTypes', function() {
         }
       );
       Component = React.createClass({
-        propTypes: {num: spy},
+        propTypes: {num: PropTypes.custom(spy)},
 
         render: function() {
           return <div />;
@@ -865,7 +849,7 @@ describe('ReactPropTypes', function() {
           }
         );
         Component = React.createClass({
-          propTypes: {num: spy},
+          propTypes: {num: PropTypes.custom(spy)},
 
           render: function() {
             return <div />;
@@ -877,5 +861,24 @@ describe('ReactPropTypes', function() {
         expect(console.error.argsForCall.length).toBe(0);
       }
     );
+
+    it('should be implicitly optional and not warn without values', function() {
+      typeCheckPass(PropTypes.custom(jasmine.createSpy()), null);
+      typeCheckPass(PropTypes.custom(jasmine.createSpy()), undefined);
+    });
+
+    it('should warn for missing required values', function() {
+      typeCheckFail(
+        PropTypes.custom(jasmine.createSpy()).isRequired,
+        null,
+        requiredMessage
+      );
+      typeCheckFail(
+        PropTypes.custom(jasmine.createSpy()).isRequired,
+        undefined,
+        requiredMessage
+      );
+    });
+
   });
 });


### PR DESCRIPTION
I'm not sure if this is a desired feature, but I thought it would be nice to have an easy way to make custom `propType` validators required or optional. This patch essentially adds a new property to `ReactPropTypes` called `custom`. You pass it a custom validator function, and it just wraps that validator in `createChainableTypeChecker`.

```javascript
propTypes: {
  warning: React.PropTypes.custom(
    function (props, propName) {
      if (!props[propName].startsWith('WARNING: ')) {
        return new Error('`warning` prop must start with \'WARNING: \'');
      }
    }
  ).isRequired,
},
```

On the one hand, it requires you to add a little more code since you're no longer just passing a raw function, but I think it adds the nice benefit of making it simple to enforce required custom-validated `props`. Should passing an unwrapped function still be supported?

As I write this, it occurs to me (after writing the implementation and tests, sigh) that if you want to make a required custom validator, you can add an `if (!props[propName])` conditional to the body, heh. But this solution makes it a little more idiomatic...?

What do you all think?