### PR TITLE
Remove unused export from DOMChildrenOperations

### DIFF
--- a/src/renderers/dom/client/utils/DOMChildrenOperations.js
+++ b/src/renderers/dom/client/utils/DOMChildrenOperations.js
@@ -129,8 +129,6 @@ var DOMChildrenOperations = {
 
   dangerouslyReplaceNodeWithMarkup: Danger.dangerouslyReplaceNodeWithMarkup,
 
-  updateTextContent: setTextContent,
-
   replaceDelimitedText: replaceDelimitedText,
 
   /**
@@ -180,7 +178,6 @@ var DOMChildrenOperations = {
 };
 
 ReactPerf.measureMethods(DOMChildrenOperations, 'DOMChildrenOperations', {
-  updateTextContent: 'updateTextContent',
   replaceDelimitedText: 'replaceDelimitedText',
 });
 

--- a/src/test/ReactDefaultPerfAnalysis.js
+++ b/src/test/ReactDefaultPerfAnalysis.js
@@ -28,7 +28,6 @@ var DOM_OPERATION_TYPES = {
   'setValueForStyles': 'update styles',
   'replaceNodeWithMarkup': 'replace',
   'replaceDelimitedText': 'replace',
-  'updateTextContent': 'set textContent',
 };
 
 function getTotalTime(measurements) {


### PR DESCRIPTION
It appears that the only usage of `DOMChildrenOperations.updateTextContent()` was [removed](https://github.com/facebook/react/pull/5753/files#diff-44b5be52eab53fed9630bb5010d82d80L128) in #5753. More specifically, #5753 [started using `replaceDelimitedText()` instead](https://github.com/facebook/react/pull/5753/files#diff-44b5be52eab53fed9630bb5010d82d80R138), which it added in the same commit.

`setTextContent()` itself is [still used](https://github.com/facebook/react/blob/2f24f89111f957e536f574759409197a1e0377af/src/renderers/dom/client/utils/DOMChildrenOperations.js#L168-L171) inside `DOMChildrenOperations.processUpdates()`—it’s just that there is no need to re-export it from `DOMChildrenOperations` now.

### Due Diligence

No `DOMChildrenOperations.updateTextContent` calls in the codebase:

```
Searching 541 files for "DOMChildrenOperations." (case sensitive)

/Users/dan/p/react/src/renderers/dom/client/ReactDOMIDOperations.js:
   29    dangerouslyProcessChildrenUpdates: function(parentInst, updates) {
   30      var node = ReactDOMComponentTree.getNodeFromInstance(parentInst);
   31:     DOMChildrenOperations.processUpdates(node, updates);
   32    },
   33  };

/Users/dan/p/react/src/renderers/dom/shared/ReactComponentBrowserEnvironment.js:
   27  
   28    replaceNodeWithMarkup:
   29:     DOMChildrenOperations.dangerouslyReplaceNodeWithMarkup,
   30  
   31    /**

/Users/dan/p/react/src/renderers/dom/shared/ReactDOMTextComponent.js:
  137          this._stringText = nextStringText;
  138          var commentNodes = this.getNativeNode();
  139:         DOMChildrenOperations.replaceDelimitedText(
  140            commentNodes[0],
  141            commentNodes[1],

3 matches across 3 files
```

Existing matches of `updateTextContent` refer to a function defined on `ReactMultiChild` rather than the one exported from `DOMChildrenOperations`:

```
Searching 541 files for "updateTextContent" (case sensitive)

/Users/dan/p/react/src/renderers/dom/shared/ReactDOMComponent.js:
  976        this.updateChildren(null, transaction, context);
  977      } else if (lastHasContentOrHtml && !nextHasContentOrHtml) {
  978:       this.updateTextContent('');
  979      }
  980  
  981      if (nextContent != null) {
  982        if (lastContent !== nextContent) {
  983:         this.updateTextContent('' + nextContent);
  984        }
  985      } else if (nextHtml != null) {

/Users/dan/p/react/src/renderers/shared/reconciler/ReactMultiChild.js:
  240       * @internal
  241       */
  242:     updateTextContent: function(nextContent) {
  243        var prevChildren = this._renderedChildren;
  244        // Remove any rendered children.
  ...
  246        for (var name in prevChildren) {
  247          if (prevChildren.hasOwnProperty(name)) {
  248:           invariant(false, 'updateTextContent called on non-empty component.');
  249          }
  250        }
  ...
  266        for (var name in prevChildren) {
  267          if (prevChildren.hasOwnProperty(name)) {
  268:           invariant(false, 'updateTextContent called on non-empty component.');
  269          }
  270        }

5 matches across 2 files
```

It appears that this is safe to remove.

### Reviewers

@sebmarkbage @spicyj 