### PR TITLE
Test to verify findDOMNode does not throw in willMount

### DIFF
--- a/src/renderers/dom/client/__tests__/findDOMNode-test.js
+++ b/src/renderers/dom/client/__tests__/findDOMNode-test.js
@@ -58,4 +58,17 @@ describe('findDOMNode', function() {
     );
   });
 
+  it('findDOMNode should not throw an error when called within a component that is not mounted', function() {
+    var Bar = React.createClass({
+      componentWillMount: function() {
+        expect(ReactDOM.findDOMNode(this)).toBeNull();
+      },
+      render: function() {
+        return <div/>;
+      },
+    });
+
+    expect(() => ReactTestUtils.renderIntoDocument(<Bar/>)).not.toThrow();
+  });
+
 });


### PR DESCRIPTION
Adds a test to prevent a regression of throwing an error when
calling `findDOMNode(this)` in a component's `componentWillMount`
function. This previously used to throw an invariant violation but
now does not any more.

Fixes https://github.com/facebook/react/issues/4999