### PR TITLE
getEventCharCode unit tests

### DIFF
--- a/src/renderers/dom/client/utils/__tests__/getEventCharCode-test.js
+++ b/src/renderers/dom/client/utils/__tests__/getEventCharCode-test.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var getEventCharCode = require('getEventCharCode');
+
+describe('getEventCharCode', function() {
+  describe('when charCode is present in nativeEvent', function() {
+    describe('when charCode is 0 and keyCode is 13', function() {
+      it('returns 13', function() {
+        var nativeEvent = new KeyboardEvent(
+          'keypress', {charCode: 0, keyCode: 13}
+        );
+
+        expect(getEventCharCode(nativeEvent)).toBe(13);
+      });
+    });
+
+    describe('when charCode is not 0 and/or keyCode is not 13', function() {
+      describe('when charCode is 32 or bigger', function() {
+        it('returns charCode', function() {
+          var nativeEvent = new KeyboardEvent('keypress', {charCode: 32});
+
+          expect(getEventCharCode(nativeEvent)).toBe(32);
+        });
+      });
+
+      describe('when charCode is smaller than 32', function() {
+        describe('when charCode is 13', function() {
+          it('returns 13', function() {
+            var nativeEvent = new KeyboardEvent('keypress', {charCode: 13});
+
+            expect(getEventCharCode(nativeEvent)).toBe(13);
+          });
+        });
+
+        describe('when charCode is not 13', function() {
+          it('returns 0', function() {
+            var nativeEvent = new KeyboardEvent('keypress', {charCode: 31});
+
+            expect(getEventCharCode(nativeEvent)).toBe(0);
+          });
+        });
+      });
+    });
+  });
+
+  /**
+    nativeEvent is represented as a plain object here to ease testing, because
+    KeyboardEvent's 'charCode' event key cannot be deleted to simulate a missing
+    charCode key.
+  */
+  describe('when charCode is not present in nativeEvent', function() {
+    describe('when keyCode is 32 or bigger', function() {
+      it('returns keyCode', function() {
+        var nativeEvent = {'keyCode': 32};
+
+        expect(getEventCharCode(nativeEvent)).toBe(32);
+      });
+    });
+
+    describe('when keyCode is smaller than 32', function() {
+      describe('when keyCode is 13', function() {
+        it('returns 13', function() {
+          var nativeEvent = {'keyCode': 13};
+
+          expect(getEventCharCode(nativeEvent)).toBe(13);
+        });
+      });
+
+      describe('when keyCode is not 13', function() {
+        it('returns 0', function() {
+          var nativeEvent = {'keyCode': 31};
+
+          expect(getEventCharCode(nativeEvent)).toBe(0);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds unit tests to getEventCharCode.

getEventCharCode lacks test coverage, so here is a fix.

## Before
![2016-03-21 11 17 06](https://cloud.githubusercontent.com/assets/1615659/13914352/e68d9ba6-ef5e-11e5-87bf-b0d56f655efc.png)
![2016-03-21 12 16 23](https://cloud.githubusercontent.com/assets/1615659/13914353/e69176cc-ef5e-11e5-849f-1b1de7f12767.png)

## After
![2016-03-21 12 12 03](https://cloud.githubusercontent.com/assets/1615659/13914358/ecd36414-ef5e-11e5-8e2d-210c2efcdd41.png)
![2016-03-21 12 14 41](https://cloud.githubusercontent.com/assets/1615659/13914360/eceb18e8-ef5e-11e5-9cdc-8bf02c17eb8c.png)


Small but steady! If there are any issues with the code - feel free to point me to mistakes, I will be glad to fix them [: