### PR TITLE
Add more specific error messages for bad callback in setState, replaceState, and ReactDOM.render

### DIFF
--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -710,7 +710,7 @@ var ReactClassMixin = {
   replaceState: function(newState, callback) {
     this.updater.enqueueReplaceState(this, newState);
     if (callback) {
-      this.updater.enqueueCallback(this, callback);
+      this.updater.enqueueCallback(this, callback, 'replaceState');
     }
   },
 

--- a/src/isomorphic/modern/class/ReactComponent.js
+++ b/src/isomorphic/modern/class/ReactComponent.js
@@ -76,7 +76,7 @@ ReactComponent.prototype.setState = function(partialState, callback) {
   }
   this.updater.enqueueSetState(this, partialState);
   if (callback) {
-    this.updater.enqueueCallback(this, callback);
+    this.updater.enqueueCallback(this, callback, 'setState');
   }
 };
 
@@ -97,7 +97,7 @@ ReactComponent.prototype.setState = function(partialState, callback) {
 ReactComponent.prototype.forceUpdate = function(callback) {
   this.updater.enqueueForceUpdate(this);
   if (callback) {
-    this.updater.enqueueCallback(this, callback);
+    this.updater.enqueueCallback(this, callback, 'forceUpdate');
   }
 };
 

--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -382,6 +382,7 @@ var ReactMount = {
   },
 
   _renderSubtreeIntoContainer: function(parentComponent, nextElement, container, callback) {
+    ReactUpdateQueue.validateCallback(callback, 'ReactDOM.render');
     invariant(
       ReactElement.isValidElement(nextElement),
       'ReactDOM.render(): Invalid component element.%s',

--- a/src/renderers/dom/client/__tests__/ReactDOM-test.js
+++ b/src/renderers/dom/client/__tests__/ReactDOM-test.js
@@ -134,16 +134,16 @@ describe('ReactDOM', function() {
 
     var myDiv = document.createElement('div');
     expect(() => ReactDOM.render(<A />, myDiv, 'no')).toThrow(
-      'You called `ReactDOM.render` with the last argument of type string. ' +
-      'When specified, its last `callback` argument must be a function.'
+      'ReactDOM.render(...): Expected the last optional `callback` argument ' +
+      'to be a function. Instead received: string.'
     );
     expect(() => ReactDOM.render(<A />, myDiv, {})).toThrow(
-      'You called `ReactDOM.render` with the last argument of type Object. ' +
-      'When specified, its last `callback` argument must be a function.'
+      'ReactDOM.render(...): Expected the last optional `callback` argument ' +
+      'to be a function. Instead received: Object.'
     );
     expect(() => ReactDOM.render(<A />, myDiv, new Foo())).toThrow(
-      'You called `ReactDOM.render` with the last argument of type Foo (keys: a, b). ' +
-      'When specified, its last `callback` argument must be a function.'
+      'ReactDOM.render(...): Expected the last optional `callback` argument ' +
+      'to be a function. Instead received: Foo (keys: a, b).'
     );
   });
 
@@ -165,16 +165,16 @@ describe('ReactDOM', function() {
     ReactDOM.render(<A />, myDiv);
 
     expect(() => ReactDOM.render(<A />, myDiv, 'no')).toThrow(
-      'You called `ReactDOM.render` with the last argument of type string. ' +
-      'When specified, its last `callback` argument must be a function.'
+      'ReactDOM.render(...): Expected the last optional `callback` argument ' +
+      'to be a function. Instead received: string.'
     );
     expect(() => ReactDOM.render(<A />, myDiv, {})).toThrow(
-      'You called `ReactDOM.render` with the last argument of type Object. ' +
-      'When specified, its last `callback` argument must be a function.'
+      'ReactDOM.render(...): Expected the last optional `callback` argument ' +
+      'to be a function. Instead received: Object.'
     );
     expect(() => ReactDOM.render(<A />, myDiv, new Foo())).toThrow(
-      'You called `ReactDOM.render` with the last argument of type Foo (keys: a, b). ' +
-      'When specified, its last `callback` argument must be a function.'
+      'ReactDOM.render(...): Expected the last optional `callback` argument ' +
+      'to be a function. Instead received: Foo (keys: a, b).'
     );
   });
 });

--- a/src/renderers/dom/client/__tests__/ReactDOM-test.js
+++ b/src/renderers/dom/client/__tests__/ReactDOM-test.js
@@ -118,4 +118,63 @@ describe('ReactDOM', function() {
     expect(console.error.argsForCall.length).toBe(0);
   });
 
+  it('throws in render() if the mount callback is not a function', function() {
+    function Foo() {
+      this.a = 1;
+      this.b = 2;
+    }
+    var A = React.createClass({
+      getInitialState: function() {
+        return {};
+      },
+      render: function() {
+        return <div />;
+      },
+    });
+
+    var myDiv = document.createElement('div');
+    expect(() => ReactDOM.render(<A />, myDiv, 'no')).toThrow(
+      'You called `ReactDOM.render` with the last argument of type string. ' +
+      'When specified, its last `callback` argument must be a function.'
+    );
+    expect(() => ReactDOM.render(<A />, myDiv, {})).toThrow(
+      'You called `ReactDOM.render` with the last argument of type Object. ' +
+      'When specified, its last `callback` argument must be a function.'
+    );
+    expect(() => ReactDOM.render(<A />, myDiv, new Foo())).toThrow(
+      'You called `ReactDOM.render` with the last argument of type Foo (keys: a, b). ' +
+      'When specified, its last `callback` argument must be a function.'
+    );
+  });
+
+  it('throws in render() if the update callback is not a function', function() {
+    function Foo() {
+      this.a = 1;
+      this.b = 2;
+    }
+    var A = React.createClass({
+      getInitialState: function() {
+        return {};
+      },
+      render: function() {
+        return <div />;
+      },
+    });
+
+    var myDiv = document.createElement('div');
+    ReactDOM.render(<A />, myDiv);
+
+    expect(() => ReactDOM.render(<A />, myDiv, 'no')).toThrow(
+      'You called `ReactDOM.render` with the last argument of type string. ' +
+      'When specified, its last `callback` argument must be a function.'
+    );
+    expect(() => ReactDOM.render(<A />, myDiv, {})).toThrow(
+      'You called `ReactDOM.render` with the last argument of type Object. ' +
+      'When specified, its last `callback` argument must be a function.'
+    );
+    expect(() => ReactDOM.render(<A />, myDiv, new Foo())).toThrow(
+      'You called `ReactDOM.render` with the last argument of type Foo (keys: a, b). ' +
+      'When specified, its last `callback` argument must be a function.'
+    );
+  });
 });

--- a/src/renderers/shared/reconciler/ReactUpdateQueue.js
+++ b/src/renderers/shared/reconciler/ReactUpdateQueue.js
@@ -22,6 +22,19 @@ function enqueueUpdate(internalInstance) {
   ReactUpdates.enqueueUpdate(internalInstance);
 }
 
+function formatUnexpectedArgument(arg) {
+  var type = typeof arg;
+  if (type !== 'object') {
+    return type;
+  }
+  var displayName = arg.constructor && arg.constructor.name || type;
+  var keys = Object.keys(arg);
+  if (keys.length > 0 && keys.length < 20) {
+    return `${displayName} (keys: ${keys.join(', ')})`;
+  }
+  return displayName;
+}
+
 function getInternalInstanceReadyForUpdate(publicInstance, callerName) {
   var internalInstance = ReactInstanceMap.get(publicInstance);
   if (!internalInstance) {
@@ -108,11 +121,10 @@ var ReactUpdateQueue = {
   enqueueCallback: function(publicInstance, callback) {
     invariant(
       typeof callback === 'function',
-      'enqueueCallback(...): You called `setProps`, `replaceProps`, ' +
-      '`setState`, `replaceState`, or `forceUpdate` with a callback of type ' +
-      '%s. A function is expected',
-      typeof callback === 'object' && Object.keys(callback).length && Object.keys(callback).length < 20 ?
-        typeof callback + ' (keys: ' + Object.keys(callback) + ')' : typeof callback
+      'enqueueCallback(...): You called `setState`, `replaceState`, or ' +
+      '`forceUpdate` with the last argument of type %s. When specified, ' +
+      'their last `callback` argument is expected to be a function.',
+      formatUnexpectedArgument(callback)
     );
     var internalInstance = getInternalInstanceReadyForUpdate(publicInstance);
 
@@ -140,11 +152,10 @@ var ReactUpdateQueue = {
   enqueueCallbackInternal: function(internalInstance, callback) {
     invariant(
       typeof callback === 'function',
-      'enqueueCallback(...): You called `setProps`, `replaceProps`, ' +
-      '`setState`, `replaceState`, or `forceUpdate` with a callback of type ' +
-      '%s. A function is expected',
-      typeof callback === 'object' && Object.keys(callback).length && Object.keys(callback).length < 20 ?
-        typeof callback + ' (keys: ' + Object.keys(callback) + ')' : typeof callback
+      'enqueueCallback(...): You called `setState`, `replaceState`, or ' +
+      '`forceUpdate` with the last argument of type %s. When specified, ' +
+      'their last `callback` argument is expected to be a function.',
+      formatUnexpectedArgument(callback)
     );
     if (internalInstance._pendingCallbacks) {
       internalInstance._pendingCallbacks.push(callback);

--- a/src/renderers/shared/reconciler/ReactUpdateQueue.js
+++ b/src/renderers/shared/reconciler/ReactUpdateQueue.js
@@ -116,14 +116,15 @@ var ReactUpdateQueue = {
    *
    * @param {ReactClass} publicInstance The instance to use as `this` context.
    * @param {?function} callback Called after state is updated.
+   * @param {string} callerName Name of the calling function in the public API.
    * @internal
    */
-  enqueueCallback: function(publicInstance, callback) {
+  enqueueCallback: function(publicInstance, callback, callerName) {
     invariant(
       typeof callback === 'function',
-      'enqueueCallback(...): You called `setState`, `replaceState`, or ' +
-      '`forceUpdate` with the last argument of type %s. When specified, ' +
-      'their last `callback` argument is expected to be a function.',
+      'enqueueCallback(...): You called `%s` with the last argument of type ' +
+      '%s. When specified, its last `callback` argument must be a function.',
+      callerName,
       formatUnexpectedArgument(callback)
     );
     var internalInstance = getInternalInstanceReadyForUpdate(publicInstance);

--- a/src/renderers/shared/reconciler/ReactUpdateQueue.js
+++ b/src/renderers/shared/reconciler/ReactUpdateQueue.js
@@ -244,8 +244,8 @@ var ReactUpdateQueue = {
   validateCallback: function(callback, callerName) {
     invariant(
       !callback || typeof callback === 'function',
-      'You called `%s` with the last argument of type %s. ' +
-      'When specified, its last `callback` argument must be a function.',
+      '%s(...): Expected the last optional `callback` argument to be a ' +
+      'function. Instead received: %s.',
       callerName,
       formatUnexpectedArgument(callback)
     );

--- a/src/renderers/shared/reconciler/ReactUpdateQueue.js
+++ b/src/renderers/shared/reconciler/ReactUpdateQueue.js
@@ -120,13 +120,7 @@ var ReactUpdateQueue = {
    * @internal
    */
   enqueueCallback: function(publicInstance, callback, callerName) {
-    invariant(
-      typeof callback === 'function',
-      'enqueueCallback(...): You called `%s` with the last argument of type ' +
-      '%s. When specified, its last `callback` argument must be a function.',
-      callerName,
-      formatUnexpectedArgument(callback)
-    );
+    ReactUpdateQueue.validateCallback(callback, callerName);
     var internalInstance = getInternalInstanceReadyForUpdate(publicInstance);
 
     // Previously we would throw an error if we didn't have an internal
@@ -151,13 +145,6 @@ var ReactUpdateQueue = {
   },
 
   enqueueCallbackInternal: function(internalInstance, callback) {
-    invariant(
-      typeof callback === 'function',
-      'enqueueCallback(...): You called `setState`, `replaceState`, or ' +
-      '`forceUpdate` with the last argument of type %s. When specified, ' +
-      'their last `callback` argument is expected to be a function.',
-      formatUnexpectedArgument(callback)
-    );
     if (internalInstance._pendingCallbacks) {
       internalInstance._pendingCallbacks.push(callback);
     } else {
@@ -252,6 +239,16 @@ var ReactUpdateQueue = {
   enqueueElementInternal: function(internalInstance, newElement) {
     internalInstance._pendingElement = newElement;
     enqueueUpdate(internalInstance);
+  },
+
+  validateCallback: function(callback, callerName) {
+    invariant(
+      !callback || typeof callback === 'function',
+      'You called `%s` with the last argument of type %s. ' +
+      'When specified, its last `callback` argument must be a function.',
+      callerName,
+      formatUnexpectedArgument(callback)
+    );
   },
 
 };

--- a/src/renderers/shared/reconciler/__tests__/ReactUpdates-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactUpdates-test.js
@@ -938,7 +938,7 @@ describe('ReactUpdates', function() {
     }
   });
 
-  it('throws when the update callback is not a function', function() {
+  it('throws in setState if the update callback is not a function', function() {
     function Foo() {
       this.a = 1;
       this.b = 2;
@@ -953,28 +953,84 @@ describe('ReactUpdates', function() {
     });
     var component = ReactTestUtils.renderIntoDocument(<A />);
 
-    var stringMessage =
-      'enqueueCallback(...): You called `setState`, `replaceState`, or '+
-      '`forceUpdate` with the last argument of type string. When specified, ' +
-      'their last `callback` argument is expected to be a function.';
-    expect(() => component.setState({}, 'no')).toThrow(stringMessage);
-    expect(() => component.replaceState({}, 'no')).toThrow(stringMessage);
-    expect(() => component.forceUpdate('no')).toThrow(stringMessage);
+    expect(() => component.setState({}, 'no')).toThrow(
+      'enqueueCallback(...): You called `setState` with the last argument of ' +
+      'type string. When specified, its last `callback` argument must be a ' +
+      'function.'
+    );
+    expect(() => component.setState({}, {})).toThrow(
+      'enqueueCallback(...): You called `setState` with the last argument of ' +
+      'type Object. When specified, its last `callback` argument must be a ' +
+      'function.'
+    );
+    expect(() => component.setState({}, new Foo())).toThrow(
+      'enqueueCallback(...): You called `setState` with the last argument of ' +
+      'type Foo (keys: a, b). When specified, its last `callback` argument ' +
+      'must be a function.'
+    );
+  });
 
-    var objectMessage =
-      'enqueueCallback(...): You called `setState`, `replaceState`, or '+
-      '`forceUpdate` with the last argument of type Object. When specified, ' +
-      'their last `callback` argument is expected to be a function.';
-    expect(() => component.setState({}, {})).toThrow(objectMessage);
-    expect(() => component.replaceState({}, {})).toThrow(objectMessage);
-    expect(() => component.forceUpdate({})).toThrow(objectMessage);
+  it('throws in replaceState if the update callback is not a function', function() {
+    function Foo() {
+      this.a = 1;
+      this.b = 2;
+    }
+    var A = React.createClass({
+      getInitialState: function() {
+        return {};
+      },
+      render: function() {
+        return <div />;
+      },
+    });
+    var component = ReactTestUtils.renderIntoDocument(<A />);
 
-    var fooMessage =
-      'enqueueCallback(...): You called `setState`, `replaceState`, or '+
-      '`forceUpdate` with the last argument of type Foo (keys: a, b). When ' +
-      'specified, their last `callback` argument is expected to be a function.';
-    expect(() => component.setState({}, new Foo())).toThrow(fooMessage);
-    expect(() => component.replaceState({}, new Foo())).toThrow(fooMessage);
-    expect(() => component.forceUpdate(new Foo())).toThrow(fooMessage);
+    expect(() => component.replaceState({}, 'no')).toThrow(
+      'enqueueCallback(...): You called `replaceState` with the last ' +
+      'argument of type string. When specified, its last `callback` argument ' +
+      'must be a function.'
+    );
+    expect(() => component.replaceState({}, {})).toThrow(
+      'enqueueCallback(...): You called `replaceState` with the last ' +
+      'argument of type Object. When specified, its last `callback` argument ' +
+      'must be a function.'
+    );
+    expect(() => component.replaceState({}, new Foo())).toThrow(
+      'enqueueCallback(...): You called `replaceState` with the last ' +
+      'argument of type Foo (keys: a, b). When specified, its last ' +
+      '`callback` argument must be a function.'
+    );
+  });
+
+  it('throws in forceUpdate if the update callback is not a function', function() {
+    function Foo() {
+      this.a = 1;
+      this.b = 2;
+    }
+    var A = React.createClass({
+      getInitialState: function() {
+        return {};
+      },
+      render: function() {
+        return <div />;
+      },
+    });
+    var component = ReactTestUtils.renderIntoDocument(<A />);
+
+    expect(() => component.forceUpdate('no')).toThrow(
+      'enqueueCallback(...): You called `forceUpdate` with the last ' +
+      'argument of type string. When specified, its last `callback` argument ' +
+      'must be a function.'
+    );
+    expect(() => component.forceUpdate({})).toThrow(
+      'enqueueCallback(...): You called `forceUpdate` with the last ' +
+      'argument of type Object. When specified, its last `callback` argument ' +
+      'must be a function.'
+    );
+    expect(() => component.forceUpdate(new Foo())).toThrow(
+      'enqueueCallback(...): You called `forceUpdate` with the last ' +
+      'argument of type Foo (keys: a, b). When specified, its last ' +
+      '`callback` argument must be a function.'
+    );
   });
 });

--- a/src/renderers/shared/reconciler/__tests__/ReactUpdates-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactUpdates-test.js
@@ -937,4 +937,44 @@ describe('ReactUpdates', function() {
       ReactFeatureFlags.logTopLevelRenders = false;
     }
   });
+
+  it('throws when the update callback is not a function', function() {
+    function Foo() {
+      this.a = 1;
+      this.b = 2;
+    }
+    var A = React.createClass({
+      getInitialState: function() {
+        return {};
+      },
+      render: function() {
+        return <div />;
+      },
+    });
+    var component = ReactTestUtils.renderIntoDocument(<A />);
+
+    var stringMessage =
+      'enqueueCallback(...): You called `setState`, `replaceState`, or '+
+      '`forceUpdate` with the last argument of type string. When specified, ' +
+      'their last `callback` argument is expected to be a function.';
+    expect(() => component.setState({}, 'no')).toThrow(stringMessage);
+    expect(() => component.replaceState({}, 'no')).toThrow(stringMessage);
+    expect(() => component.forceUpdate('no')).toThrow(stringMessage);
+
+    var objectMessage =
+      'enqueueCallback(...): You called `setState`, `replaceState`, or '+
+      '`forceUpdate` with the last argument of type Object. When specified, ' +
+      'their last `callback` argument is expected to be a function.';
+    expect(() => component.setState({}, {})).toThrow(objectMessage);
+    expect(() => component.replaceState({}, {})).toThrow(objectMessage);
+    expect(() => component.forceUpdate({})).toThrow(objectMessage);
+
+    var fooMessage =
+      'enqueueCallback(...): You called `setState`, `replaceState`, or '+
+      '`forceUpdate` with the last argument of type Foo (keys: a, b). When ' +
+      'specified, their last `callback` argument is expected to be a function.';
+    expect(() => component.setState({}, new Foo())).toThrow(fooMessage);
+    expect(() => component.replaceState({}, new Foo())).toThrow(fooMessage);
+    expect(() => component.forceUpdate(new Foo())).toThrow(fooMessage);
+  });
 });

--- a/src/renderers/shared/reconciler/__tests__/ReactUpdates-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactUpdates-test.js
@@ -954,16 +954,16 @@ describe('ReactUpdates', function() {
     var component = ReactTestUtils.renderIntoDocument(<A />);
 
     expect(() => component.setState({}, 'no')).toThrow(
-      'You called `setState` with the last argument of type string. ' +
-      'When specified, its last `callback` argument must be a function.'
+      'setState(...): Expected the last optional `callback` argument ' +
+      'to be a function. Instead received: string.'
     );
     expect(() => component.setState({}, {})).toThrow(
-      'You called `setState` with the last argument of type Object. ' +
-      'When specified, its last `callback` argument must be a function.'
+      'setState(...): Expected the last optional `callback` argument ' +
+      'to be a function. Instead received: Object.'
     );
     expect(() => component.setState({}, new Foo())).toThrow(
-      'You called `setState` with the last argument of type Foo (keys: a, b). ' +
-      'When specified, its last `callback` argument must be a function.'
+      'setState(...): Expected the last optional `callback` argument ' +
+      'to be a function. Instead received: Foo (keys: a, b).'
     );
   });
 
@@ -983,16 +983,16 @@ describe('ReactUpdates', function() {
     var component = ReactTestUtils.renderIntoDocument(<A />);
 
     expect(() => component.replaceState({}, 'no')).toThrow(
-      'You called `replaceState` with the last argument of type string. ' +
-      'When specified, its last `callback` argument must be a function.'
+      'replaceState(...): Expected the last optional `callback` argument ' +
+      'to be a function. Instead received: string.'
     );
     expect(() => component.replaceState({}, {})).toThrow(
-      'You called `replaceState` with the last argument of type Object. ' +
-      'When specified, its last `callback` argument must be a function.'
+      'replaceState(...): Expected the last optional `callback` argument ' +
+      'to be a function. Instead received: Object.'
     );
     expect(() => component.replaceState({}, new Foo())).toThrow(
-      'You called `replaceState` with the last argument of type Foo (keys: a, b). ' +
-      'When specified, its last `callback` argument must be a function.'
+      'replaceState(...): Expected the last optional `callback` argument ' +
+      'to be a function. Instead received: Foo (keys: a, b).'
     );
   });
 
@@ -1012,16 +1012,16 @@ describe('ReactUpdates', function() {
     var component = ReactTestUtils.renderIntoDocument(<A />);
 
     expect(() => component.forceUpdate('no')).toThrow(
-      'You called `forceUpdate` with the last argument of type string. ' +
-      'When specified, its last `callback` argument must be a function.'
+      'forceUpdate(...): Expected the last optional `callback` argument ' +
+      'to be a function. Instead received: string.'
     );
     expect(() => component.forceUpdate({})).toThrow(
-      'You called `forceUpdate` with the last argument of type Object. ' +
-      'When specified, its last `callback` argument must be a function.'
+      'forceUpdate(...): Expected the last optional `callback` argument ' +
+      'to be a function. Instead received: Object.'
     );
     expect(() => component.forceUpdate(new Foo())).toThrow(
-      'You called `forceUpdate` with the last argument of type Foo (keys: a, b). ' +
-      'When specified, its last `callback` argument must be a function.'
+      'forceUpdate(...): Expected the last optional `callback` argument ' +
+      'to be a function. Instead received: Foo (keys: a, b).'
     );
   });
 });

--- a/src/renderers/shared/reconciler/__tests__/ReactUpdates-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactUpdates-test.js
@@ -954,19 +954,16 @@ describe('ReactUpdates', function() {
     var component = ReactTestUtils.renderIntoDocument(<A />);
 
     expect(() => component.setState({}, 'no')).toThrow(
-      'enqueueCallback(...): You called `setState` with the last argument of ' +
-      'type string. When specified, its last `callback` argument must be a ' +
-      'function.'
+      'You called `setState` with the last argument of type string. ' +
+      'When specified, its last `callback` argument must be a function.'
     );
     expect(() => component.setState({}, {})).toThrow(
-      'enqueueCallback(...): You called `setState` with the last argument of ' +
-      'type Object. When specified, its last `callback` argument must be a ' +
-      'function.'
+      'You called `setState` with the last argument of type Object. ' +
+      'When specified, its last `callback` argument must be a function.'
     );
     expect(() => component.setState({}, new Foo())).toThrow(
-      'enqueueCallback(...): You called `setState` with the last argument of ' +
-      'type Foo (keys: a, b). When specified, its last `callback` argument ' +
-      'must be a function.'
+      'You called `setState` with the last argument of type Foo (keys: a, b). ' +
+      'When specified, its last `callback` argument must be a function.'
     );
   });
 
@@ -986,19 +983,16 @@ describe('ReactUpdates', function() {
     var component = ReactTestUtils.renderIntoDocument(<A />);
 
     expect(() => component.replaceState({}, 'no')).toThrow(
-      'enqueueCallback(...): You called `replaceState` with the last ' +
-      'argument of type string. When specified, its last `callback` argument ' +
-      'must be a function.'
+      'You called `replaceState` with the last argument of type string. ' +
+      'When specified, its last `callback` argument must be a function.'
     );
     expect(() => component.replaceState({}, {})).toThrow(
-      'enqueueCallback(...): You called `replaceState` with the last ' +
-      'argument of type Object. When specified, its last `callback` argument ' +
-      'must be a function.'
+      'You called `replaceState` with the last argument of type Object. ' +
+      'When specified, its last `callback` argument must be a function.'
     );
     expect(() => component.replaceState({}, new Foo())).toThrow(
-      'enqueueCallback(...): You called `replaceState` with the last ' +
-      'argument of type Foo (keys: a, b). When specified, its last ' +
-      '`callback` argument must be a function.'
+      'You called `replaceState` with the last argument of type Foo (keys: a, b). ' +
+      'When specified, its last `callback` argument must be a function.'
     );
   });
 
@@ -1018,19 +1012,16 @@ describe('ReactUpdates', function() {
     var component = ReactTestUtils.renderIntoDocument(<A />);
 
     expect(() => component.forceUpdate('no')).toThrow(
-      'enqueueCallback(...): You called `forceUpdate` with the last ' +
-      'argument of type string. When specified, its last `callback` argument ' +
-      'must be a function.'
+      'You called `forceUpdate` with the last argument of type string. ' +
+      'When specified, its last `callback` argument must be a function.'
     );
     expect(() => component.forceUpdate({})).toThrow(
-      'enqueueCallback(...): You called `forceUpdate` with the last ' +
-      'argument of type Object. When specified, its last `callback` argument ' +
-      'must be a function.'
+      'You called `forceUpdate` with the last argument of type Object. ' +
+      'When specified, its last `callback` argument must be a function.'
     );
     expect(() => component.forceUpdate(new Foo())).toThrow(
-      'enqueueCallback(...): You called `forceUpdate` with the last ' +
-      'argument of type Foo (keys: a, b). When specified, its last ' +
-      '`callback` argument must be a function.'
+      'You called `forceUpdate` with the last argument of type Foo (keys: a, b). ' +
+      'When specified, its last `callback` argument must be a function.'
     );
   });
 });


### PR DESCRIPTION
This builds on #5193 and introduces an important, in my opinion, detail (constructor function name) that makes issues like #6306 more easily identified.

Additionally, this removes the mention of methods that have been removed (`setProps` and `replaceProps`).

When using `onClick={this.setState.bind(this, nextState)}` by mistake, the error message says:

### 0.14

>Uncaught Invariant Violation: enqueueCallback(...): You called `setProps`, `replaceProps`, `setState`, `replaceState`, or `forceUpdate` with a callback that isn't callable.

### After #5193 

>Uncaught Invariant Violation: enqueueCallback(...): You called `setProps`, `replaceProps`, `setState`, `replaceState`, or `forceUpdate` with a callback of type object. A function is expected

### After this PR

>Uncaught Invariant Violation: setState(...): Expected the last optional `callback` argument to be a function. Instead received: SyntheticMouseEvent.

-----

## Why?

* We don’t need to mention the APIs we removed (`setProps`, `replaceProps`).
* `enqueueCallback()` is an implementation detail and is confusing to the user.
* We have enough information to print the actual public API method name.
* We need to make it clear what “callback” is. Many people don’t know these functions accept a callback. We need to tell them it’s the last optional argument.
* Printing the constructor name (e.g. `SyntheticMouseEvent`) makes it much more clear why you get issues like #6306.
* This error should also be enabled for `ReactDOM.render()` instead of just failing with a TypeError.
* This adds tests.