### PR TITLE
[website] Fix jump on the header

### DIFF
--- a/docs/css/react.scss
+++ b/docs/css/react.scss
@@ -870,6 +870,8 @@ input#algolia-doc-search {
   background: transparent url('/react/img/search.png') no-repeat 10px center;
   background-size: 16px 16px;
 
+  position: relative;
+  vertical-align: top;
   margin-left: 10px;
   padding: 0 10px;
   padding-left: 35px;


### PR DESCRIPTION
Algolia adds two inline styles

```css
  position: relative;
  vertical-align: top;
```

to the element once the script inserted at the end of the page runs which super slightly moves the header. The fix is to always apply those two rules this way it doesn't jump. I did not notice it on my machine because it doesn't move when custom fonts are not being used.

Test Plan:
- Open two tabs: reactjs.com and localhost:4000/react
- Click around on reactjs.com to prime the cache with the fonts
- Switch tabs and click around on localhost (but do not force refresh!)
- Now you get custom fonts loaded locally and it doesn't jump when you change tabs