### PR TITLE
Fix for #5468: Validate proptype definitions sooner

### DIFF
--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -16,6 +16,7 @@ var ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
 
 var emptyFunction = require('emptyFunction');
 var getIteratorFn = require('getIteratorFn');
+var warning = require('warning');
 
 /**
  * Collection of methods that allow declaration and validation of props that are
@@ -226,6 +227,9 @@ function createInstanceTypeChecker(expectedClass) {
 
 function createEnumTypeChecker(expectedValues) {
   if (!Array.isArray(expectedValues)) {
+    if (__DEV__) {
+      warning(false, 'Invalid argument supplied to oneOf, expected an instance of array.');
+    }
     return createChainableTypeChecker(function() {
       return new Error(
         `Invalid argument supplied to oneOf, expected an instance of array.`
@@ -288,6 +292,9 @@ function createObjectOfTypeChecker(typeChecker) {
 
 function createUnionTypeChecker(arrayOfTypeCheckers) {
   if (!Array.isArray(arrayOfTypeCheckers)) {
+    if (__DEV__) {
+      warning(false, 'Invalid argument supplied to oneOfType, expected an instance of array.');
+    }
     return createChainableTypeChecker(function() {
       return new Error(
         `Invalid argument supplied to oneOfType, expected an instance of array.`

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -227,16 +227,8 @@ function createInstanceTypeChecker(expectedClass) {
 
 function createEnumTypeChecker(expectedValues) {
   if (!Array.isArray(expectedValues)) {
-    if (__DEV__) {
-      warning(false, 'Invalid argument supplied to oneOf, expected an instance of array.');
-      return emptyFunction.thatReturnsNull;
-    } else {
-      return createChainableTypeChecker(function() {
-        return new Error(
-          `Invalid argument supplied to oneOf, expected an instance of array.`
-        );
-      });
-    }
+    warning(false, 'Invalid argument supplied to oneOf, expected an instance of array.');
+    return emptyFunction.thatReturnsNull;
   }
 
   function validate(props, propName, componentName, location, propFullName) {
@@ -294,16 +286,8 @@ function createObjectOfTypeChecker(typeChecker) {
 
 function createUnionTypeChecker(arrayOfTypeCheckers) {
   if (!Array.isArray(arrayOfTypeCheckers)) {
-    if (__DEV__) {
-      warning(false, 'Invalid argument supplied to oneOfType, expected an instance of array.');
-      return emptyFunction.thatReturnsNull;
-    } else {
-      return createChainableTypeChecker(function() {
-        return new Error(
-          `Invalid argument supplied to oneOfType, expected an instance of array.`
-        );
-      });
-    }
+    warning(false, 'Invalid argument supplied to oneOfType, expected an instance of array.');
+    return emptyFunction.thatReturnsNull;
   }
 
   function validate(props, propName, componentName, location, propFullName) {

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -229,7 +229,7 @@ function createEnumTypeChecker(expectedValues) {
   if (!Array.isArray(expectedValues)) {
     if (__DEV__) {
       warning(false, 'Invalid argument supplied to oneOf, expected an instance of array.');
-      return function() {};
+      return emptyFunction.thatReturnsNull;
     } else {
       return createChainableTypeChecker(function() {
         return new Error(
@@ -296,7 +296,7 @@ function createUnionTypeChecker(arrayOfTypeCheckers) {
   if (!Array.isArray(arrayOfTypeCheckers)) {
     if (__DEV__) {
       warning(false, 'Invalid argument supplied to oneOfType, expected an instance of array.');
-      return function() {};
+      return emptyFunction.thatReturnsNull;
     } else {
       return createChainableTypeChecker(function() {
         return new Error(

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -229,6 +229,7 @@ function createEnumTypeChecker(expectedValues) {
   if (!Array.isArray(expectedValues)) {
     if (__DEV__) {
       warning(false, 'Invalid argument supplied to oneOf, expected an instance of array.');
+      return function() {};
     } else {
       return createChainableTypeChecker(function() {
         return new Error(
@@ -295,6 +296,7 @@ function createUnionTypeChecker(arrayOfTypeCheckers) {
   if (!Array.isArray(arrayOfTypeCheckers)) {
     if (__DEV__) {
       warning(false, 'Invalid argument supplied to oneOfType, expected an instance of array.');
+      return function() {};
     } else {
       return createChainableTypeChecker(function() {
         return new Error(

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -229,12 +229,13 @@ function createEnumTypeChecker(expectedValues) {
   if (!Array.isArray(expectedValues)) {
     if (__DEV__) {
       warning(false, 'Invalid argument supplied to oneOf, expected an instance of array.');
+    } else {
+      return createChainableTypeChecker(function() {
+        return new Error(
+          `Invalid argument supplied to oneOf, expected an instance of array.`
+        );
+      });
     }
-    return createChainableTypeChecker(function() {
-      return new Error(
-        `Invalid argument supplied to oneOf, expected an instance of array.`
-      );
-    });
   }
 
   function validate(props, propName, componentName, location, propFullName) {
@@ -294,12 +295,13 @@ function createUnionTypeChecker(arrayOfTypeCheckers) {
   if (!Array.isArray(arrayOfTypeCheckers)) {
     if (__DEV__) {
       warning(false, 'Invalid argument supplied to oneOfType, expected an instance of array.');
+    } else {
+      return createChainableTypeChecker(function() {
+        return new Error(
+          `Invalid argument supplied to oneOfType, expected an instance of array.`
+        );
+      });
     }
-    return createChainableTypeChecker(function() {
-      return new Error(
-        `Invalid argument supplied to oneOfType, expected an instance of array.`
-      );
-    });
   }
 
   function validate(props, propName, componentName, location, propFullName) {

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -590,14 +590,16 @@ describe('ReactPropTypes', function() {
   });
 
   describe('OneOf Types', function() {
-    it('should fail for invalid argument', function() {
-      spyOn(console, ['error']);
+    it('should warn but not error for invalid argument', function() {
+      spyOn(console, 'error');
 
       PropTypes.oneOf('red', 'blue');
 
       expect(console.error).toHaveBeenCalled();
       expect(console.error.calls.argsFor(0)[0])
         .toContain('Invalid argument supplied to oneOf, expected an instance of array.');
+
+      typeCheckPass(PropTypes.oneOf('red', 'blue'), 'red');
     });
 
     it('should warn for invalid values', function() {
@@ -653,14 +655,16 @@ describe('ReactPropTypes', function() {
   });
 
   describe('Union Types', function() {
-    it('should fail for invalid argument', function() {
-      spyOn(console, ['error']);
+    it('should warn but not error for invalid argument', function() {
+      spyOn(console, 'error');
 
       PropTypes.oneOfType(PropTypes.string, PropTypes.number);
 
       expect(console.error).toHaveBeenCalled();
       expect(console.error.calls.argsFor(0)[0])
         .toContain('Invalid argument supplied to oneOfType, expected an instance of array.');
+
+      typeCheckPass(PropTypes.oneOf(PropTypes.string, PropTypes.number), []);
     });
 
     it('should warn if none of the types are valid', function() {

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -45,13 +45,6 @@ function typeCheckPass(declaration, value) {
   expect(error).toBe(null);
 }
 
-function typeCheckWarn(propTypeFunc, message) { 
-  spyOn(console, ['error']);
-  propTypeFunc();
-  expect(console.error).toHaveBeenCalled();
-  expect(console.error.argsForCall[0][0]).toContain(message);
-}
-
 describe('ReactPropTypes', function() {
   beforeEach(function() {
     PropTypes = require('ReactPropTypes');
@@ -598,17 +591,12 @@ describe('ReactPropTypes', function() {
 
   describe('OneOf Types', function() {
     it('should fail for invalid argument', function() {
-      typeCheckWarn(
-        function() { 
-          PropTypes.oneOf('red', 'blue');
-        },
-        'Invalid argument supplied to oneOf, expected an instance of array.'
-      );
-      typeCheckFail(
-        PropTypes.oneOf('red', 'blue'),
-        'red',
-        'Invalid argument supplied to oneOf, expected an instance of array.'
-      );
+      spyOn(console, ['error']);
+
+      PropTypes.oneOf('red', 'blue');
+
+      expect(console.error).toHaveBeenCalled();
+      expect(console.error.calls.argsFor(0)[0]).toContain('Invalid argument supplied to oneOf, expected an instance of array.');
     });
 
     it('should warn for invalid values', function() {
@@ -665,17 +653,12 @@ describe('ReactPropTypes', function() {
 
   describe('Union Types', function() {
     it('should fail for invalid argument', function() {
-      typeCheckWarn(
-        function() { 
-          PropTypes.oneOfType(PropTypes.string, PropTypes.number);
-        },
-        'Invalid argument supplied to oneOfType, expected an instance of array.'
-      );
-      typeCheckFail(
-        PropTypes.oneOfType(PropTypes.string, PropTypes.number),
-        'red',
-        'Invalid argument supplied to oneOfType, expected an instance of array.'
-      );
+      spyOn(console, ['error']);
+
+      PropTypes.oneOfType(PropTypes.string, PropTypes.number);
+
+      expect(console.error).toHaveBeenCalled();
+      expect(console.error.calls.argsFor(0)[0]).toContain('Invalid argument supplied to oneOfType, expected an instance of array.');
     });
 
     it('should warn if none of the types are valid', function() {

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -596,7 +596,8 @@ describe('ReactPropTypes', function() {
       PropTypes.oneOf('red', 'blue');
 
       expect(console.error).toHaveBeenCalled();
-      expect(console.error.calls.argsFor(0)[0]).toContain('Invalid argument supplied to oneOf, expected an instance of array.');
+      expect(console.error.calls.argsFor(0)[0])
+        .toContain('Invalid argument supplied to oneOf, expected an instance of array.');
     });
 
     it('should warn for invalid values', function() {
@@ -658,7 +659,8 @@ describe('ReactPropTypes', function() {
       PropTypes.oneOfType(PropTypes.string, PropTypes.number);
 
       expect(console.error).toHaveBeenCalled();
-      expect(console.error.calls.argsFor(0)[0]).toContain('Invalid argument supplied to oneOfType, expected an instance of array.');
+      expect(console.error.calls.argsFor(0)[0])
+        .toContain('Invalid argument supplied to oneOfType, expected an instance of array.');
     });
 
     it('should warn if none of the types are valid', function() {

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -45,6 +45,13 @@ function typeCheckPass(declaration, value) {
   expect(error).toBe(null);
 }
 
+function typeCheckWarn(propTypeFunc, message) { 
+  spyOn(console, ['error']);
+  propTypeFunc();
+  expect(console.error).toHaveBeenCalled();
+  expect(console.error.argsForCall[0][0]).toContain(message);
+}
+
 describe('ReactPropTypes', function() {
   beforeEach(function() {
     PropTypes = require('ReactPropTypes');
@@ -591,6 +598,12 @@ describe('ReactPropTypes', function() {
 
   describe('OneOf Types', function() {
     it('should fail for invalid argument', function() {
+      typeCheckWarn(
+        function() { 
+          PropTypes.oneOf('red', 'blue');
+        },
+        'Invalid argument supplied to oneOf, expected an instance of array.'
+      );
       typeCheckFail(
         PropTypes.oneOf('red', 'blue'),
         'red',
@@ -652,6 +665,12 @@ describe('ReactPropTypes', function() {
 
   describe('Union Types', function() {
     it('should fail for invalid argument', function() {
+      typeCheckWarn(
+        function() { 
+          PropTypes.oneOfType(PropTypes.string, PropTypes.number);
+        },
+        'Invalid argument supplied to oneOfType, expected an instance of array.'
+      );
       typeCheckFail(
         PropTypes.oneOfType(PropTypes.string, PropTypes.number),
         'red',


### PR DESCRIPTION
Fix for #5468

Added `typeCheckWarn()` func and updated the oneOf/oneOfType tests
Added warning for invalid oneOf/OneOfType args

_This is my first contribution to React, any feedback is appreciated. :)_