### PR TITLE
add prs welcome badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [React](https://facebook.github.io/react/) [![Build Status](https://img.shields.io/travis/facebook/react/master.svg?style=flat)](https://travis-ci.org/facebook/react) [![Coverage Status](https://img.shields.io/coveralls/facebook/react/master.svg?style=flat)](https://coveralls.io/github/facebook/react?branch=master) [![npm version](https://img.shields.io/npm/v/react.svg?style=flat)](https://www.npmjs.com/package/react)
+# [React](https://facebook.github.io/react/) [![Build Status](https://img.shields.io/travis/facebook/react/master.svg?style=flat)](https://travis-ci.org/facebook/react) [![Coverage Status](https://img.shields.io/coveralls/facebook/react/master.svg?style=flat)](https://coveralls.io/github/facebook/react?branch=master) [![npm version](https://img.shields.io/npm/v/react.svg?style=flat)](https://www.npmjs.com/package/react) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md#pull-requests)
 
 React is a JavaScript library for building user interfaces.
 


### PR DESCRIPTION
As referenced in #6332, this adds the `PRs | Welcome` badge to the README which links to a free beginner friendly resource teaching how to get started contributing to open source.

Here's before:

<img width="567" alt="screen shot 2016-03-24 at 1 26 41 pm" src="https://cloud.githubusercontent.com/assets/1500684/14028816/3418ee18-f1c4-11e5-917b-debc5f4dac91.png">

Here's after:

<img width="554" alt="screen shot 2016-03-24 at 1 26 33 pm" src="https://cloud.githubusercontent.com/assets/1500684/14028809/29782e88-f1c4-11e5-8580-ed8c4fa374ec.png">

Happy to make any changes. Just want to get the conversation going.