### PR TITLE
Keep reference equality if possible in update()

### DIFF
--- a/src/addons/__tests__/update-test.js
+++ b/src/addons/__tests__/update-test.js
@@ -115,13 +115,12 @@ describe('update', function() {
       update(obj, {$set: {c: 'd'}});
       expect(obj).toEqual({a: 'b'});
     });
+    it('keeps reference equality when possible', function() {
+      var original = {a: 1};
+      expect(update(original, {a: {$set: 1}})).toBe(original);
+    });
   });
   
-  it('should keep reference equality when possible with set', function() {
-    var original = {a: 1};
-    expect(update(original, {a: {$set: 1}})).toBe(original);
-  });
-
   describe('$apply', function() {
     var applier = function(node) {
       return {v: node.v * 2};
@@ -139,46 +138,47 @@ describe('update', function() {
         'update(): expected spec of $apply to be a function; got 123.'
       );
     });
-  });
-  
-  it('should keep reference equality when possible with apply', function() {
-    var original = {a: {b: {}}};
-    function identity(val) {
-      return val;
-    }
-    expect(update(original, {a: {$apply: identity}})).toBe(original);
+    it('keeps reference equality when possible', function() {
+      var original = {a: {b: {}}};
+      function identity(val) {
+        return val;
+      }
+      expect(update(original, {a: {$apply: identity}})).toBe(original);
+    });
   });
 
-  it('should support deep updates', function() {
-    expect(update({
-      a: 'b',
-      c: {
-        d: 'e',
-        f: [1],
-        g: [2],
-        h: [3],
-        i: {j: 'k'},
-        l: 4,
-      },
-    }, {
-      c: {
-        d: {$set: 'm'},
-        f: {$push: [5]},
-        g: {$unshift: [6]},
-        h: {$splice: [[0, 1, 7]]},
-        i: {$merge: {n: 'o'}},
-        l: {$apply: (x) => x * 2},
-      },
-    })).toEqual({
-      a: 'b',
-      c: {
-        d: 'm',
-        f: [1, 5],
-        g: [6, 2],
-        h: [7],
-        i: {j: 'k', n: 'o'},
-        l: 8,
-      },
+  describe('deep update', function() {
+    it('should work', function() {
+      expect(update({
+        a: 'b',
+        c: {
+          d: 'e',
+          f: [1],
+          g: [2],
+          h: [3],
+          i: {j: 'k'},
+          l: 4,
+        },
+      }, {
+        c: {
+          d: {$set: 'm'},
+          f: {$push: [5]},
+          g: {$unshift: [6]},
+          h: {$splice: [[0, 1, 7]]},
+          i: {$merge: {n: 'o'}},
+          l: {$apply: (x) => x * 2},
+        },
+      })).toEqual({
+        a: 'b',
+        c: {
+          d: 'm',
+          f: [1, 5],
+          g: [6, 2],
+          h: [7],
+          i: {j: 'k', n: 'o'},
+          l: 8,
+        },
+      });
     });
   });
 

--- a/src/addons/__tests__/update-test.js
+++ b/src/addons/__tests__/update-test.js
@@ -118,9 +118,10 @@ describe('update', function() {
     it('keeps reference equality when possible', function() {
       var original = {a: 1};
       expect(update(original, {a: {$set: 1}})).toBe(original);
+      expect(update(original, {a: {$set: 2}})).toNotBe(original);
     });
   });
-  
+
   describe('$apply', function() {
     var applier = function(node) {
       return {v: node.v * 2};
@@ -144,11 +145,12 @@ describe('update', function() {
         return val;
       }
       expect(update(original, {a: {$apply: identity}})).toBe(original);
+      expect(update(original, {a: {$apply: applier}})).toNotBe(original);
     });
   });
 
   describe('deep update', function() {
-    it('should work', function() {
+    it('works', function() {
       expect(update({
         a: 'b',
         c: {
@@ -179,6 +181,40 @@ describe('update', function() {
           l: 8,
         },
       });
+    });
+    it('keeps reference equality when possible', function() {
+      var original = {a: {b: 1}, c: {d: {e: 1}}};
+
+      expect(update(original, {a: {b: {$set: 1}}})).toBe(original);
+      expect(update(original, {a: {b: {$set: 1}}}).a).toBe(original.a);
+
+      expect(update(original, {c: {d: {e: {$set: 1}}}})).toBe(original);
+      expect(update(original, {c: {d: {e: {$set: 1}}}}).c).toBe(original.c);
+      expect(update(original, {c: {d: {e: {$set: 1}}}}).c.d).toBe(original.c.d);
+
+      expect(update(original, {
+        a: {b: {$set: 1}},
+        c: {d: {e: {$set: 1}}},
+      })).toBe(original);
+      expect(update(original, {
+        a: {b: {$set: 1}},
+        c: {d: {e: {$set: 1}}},
+      }).a).toBe(original.a);
+      expect(update(original, {
+        a: {b: {$set: 1}},
+        c: {d: {e: {$set: 1}}},
+      }).c).toBe(original.c);
+      expect(update(original, {
+        a: {b: {$set: 1}},
+        c: {d: {e: {$set: 1}}},
+      }).c.d).toBe(original.c.d);
+
+      expect(update(original, {a: {b: {$set: 2}}})).toNotBe(original);
+      expect(update(original, {a: {b: {$set: 2}}}).a).toNotBe(original.a);
+      expect(update(original, {a: {b: {$set: 2}}}).a.b).toNotBe(original.a.b);
+
+      expect(update(original, {a: {b: {$set: 2}}}).c).toBe(original.c);
+      expect(update(original, {a: {b: {$set: 2}}}).c.d).toBe(original.c.d);
     });
   });
 

--- a/src/addons/update.js
+++ b/src/addons/update.js
@@ -82,7 +82,7 @@ function update(value, spec) {
       'Cannot have more than one key in an object with %s',
       COMMAND_SET
     );
-    return spec[COMMAND_SET] === value ? value : spec[COMMAND_SET];
+    return spec[COMMAND_SET];
   }
 
   // Make sure to shallowCopy() it before mutations


### PR DESCRIPTION
I merged #4968 locally and then made a few changes on top that I thought would be welcome:

* I added a little more testing code to verify the new behavior
* I refactored the code in #4968 to avoid function allocations in favor of some code repetition

I figured I’d run this by Travis as well so I’m submitting it as a PR.

Credits for making this change happen go to @davidmason, I’m just tweaking minor things.
I intend this to land in 15 RC3.