### PR TITLE
Update CommonJS example to use Babel 6

### DIFF
--- a/examples/basic-commonjs/.babelrc
+++ b/examples/basic-commonjs/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "react"]
+}

--- a/examples/basic-commonjs/package.json
+++ b/examples/basic-commonjs/package.json
@@ -3,10 +3,12 @@
   "description": "Basic example of using React with CommonJS",
   "main": "index.js",
   "dependencies": {
-    "babelify": "^6.3.0",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react": "^6.5.0",
+    "babelify": "^7.2.0",
     "browserify": "^11.0.1",
-    "react": "^0.14.0-rc1",
-    "react-dom": "^0.14.0-rc1",
+    "react": "^15.0.0-rc.2",
+    "react-dom": "^15.0.0-rc.2",
     "watchify": "^3.4.0"
   },
   "scripts": {


### PR DESCRIPTION
Initially I tried updating the version of React but this caused Node to resolve it to the parent directory, and Babel started failing because it didn’t recognize the `presets` option. To fix this, I updated Babel as well. I had to add the presets explicitly since Babel 6 requires that. While we don’t explicitly use ES6 in the example I figured that adding a preset to it would cause less confusion than omitting it.

Both `npm start` and `npm run build` work correctly in my testing.

Reviewers: @zpao 