### PR TITLE
Use Node.contains in lowestCommonAncestor Tree Traversal

### DIFF
--- a/src/renderers/dom/client/ReactDOMTreeTraversal.js
+++ b/src/renderers/dom/client/ReactDOMTreeTraversal.js
@@ -21,36 +21,14 @@ function getLowestCommonAncestor(instA, instB) {
   invariant('_nativeNode' in instA, 'getNodeFromInstance: Invalid argument.');
   invariant('_nativeNode' in instB, 'getNodeFromInstance: Invalid argument.');
 
-  var depthA = 0;
-  for (var tempA = instA; tempA; tempA = tempA._nativeParent) {
-    depthA++;
-  }
-  var depthB = 0;
-  for (var tempB = instB; tempB; tempB = tempB._nativeParent) {
-    depthB++;
-  }
-
-  // If A is deeper, crawl up.
-  while (depthA - depthB > 0) {
-    instA = instA._nativeParent;
-    depthA--;
-  }
-
-  // If B is deeper, crawl up.
-  while (depthB - depthA > 0) {
-    instB = instB._nativeParent;
-    depthB--;
-  }
-
-  // Walk in lockstep until we find a match.
-  var depth = depthA;
-  while (depth--) {
-    if (instA === instB) {
-      return instA;
+  while (instA) {
+    if (isAncestor(instA, instB)) {
+      return instA
     }
-    instA = instA._nativeParent;
-    instB = instB._nativeParent;
+
+    instA = instA._nativeParent
   }
+
   return null;
 }
 

--- a/src/renderers/dom/client/ReactDOMTreeTraversal.js
+++ b/src/renderers/dom/client/ReactDOMTreeTraversal.js
@@ -61,13 +61,7 @@ function isAncestor(instA, instB) {
   invariant('_nativeNode' in instA, 'isAncestor: Invalid argument.');
   invariant('_nativeNode' in instB, 'isAncestor: Invalid argument.');
 
-  while (instB) {
-    if (instB === instA) {
-      return true;
-    }
-    instB = instB._nativeParent;
-  }
-  return false;
+  return instA._nativeNode.contains(instB._nativeNode);
 }
 
 /**


### PR DESCRIPTION
This is a follow-up to my other pull-request: #6349. Using `Node.contains` appears to be extremely efficient, and took some time to explore its use in the `lowestCommonAncestor` function. 

Like the other PR, I did some profiling. [`Node.contains`](https://developer.mozilla.org/en-US/docs/Web/API/Node/contains) is surprisingly fast. I'm sure there are flaws in the benchmark itself. However I think it's still compelling.

https://github.com/nhunzaker/lowest-common-ancestor-bench

### Chrome 49

```
Depth method x 3,088,855 ops/sec ±3.50% (56 runs sampled)
Contains method x 3,295,131 ops/sec ±0.95% (58 runs sampled)
Fastest is Contains method
```

### Safari 9

```
Depth method x 1,940,537 ops/sec ±8.66% (31 runs sampled) (index.html, line 82)
Contains method x 3,980,743 ops/sec ±8.51% (33 runs sampled) (index.html, line 82)
Fastest is Contains method
```

### Firefox 45

```
Depth method x 1,875,566 ops/sec ±1.19% (61 runs sampled)
Contains method x 5,839,094 ops/sec ±0.96% (58 runs sampled)
Fastest is Contains method
```