### PR TITLE
Allow custom render function for ReactTransitionGroup

### DIFF
--- a/docs/docs/10.1-animation.md
+++ b/docs/docs/10.1-animation.md
@@ -247,3 +247,31 @@ Any additional, user-defined, properties will become properties of the rendered 
   ...
 </ReactTransitionGroup>
 ```
+
+### Using a Custom Render Function
+
+Rather than just specifying a different component wrapper with the `component` prop, you can also specify a custom render function with the `render` prop. This function takes an array of children as an argument.
+
+To render only the first child you could do something like:
+
+```javascript{1}
+function renderFirstChildOnly(children) {
+  return children[0];
+}
+
+<ReactTransitionGroup render={renderFirstChildOnly}>
+  ...
+</ReactTransitionGroup>
+```
+
+The following is the default render function that is used if you do not pass in a custom `render` prop:
+
+```javascript{1}
+  function defaultRender(children) {
+    return React.createElement(
+      this.props.component,
+      this.props,
+      children
+    );
+  }
+```

--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -17,18 +17,28 @@ var ReactTransitionChildMapping = require('ReactTransitionChildMapping');
 var assign = require('Object.assign');
 var emptyFunction = require('emptyFunction');
 
+function _defaultRender(childrenToRender) {
+  return React.createElement(
+    this.props.component,
+    this.props,
+    childrenToRender
+  );
+}
+
 var ReactTransitionGroup = React.createClass({
   displayName: 'ReactTransitionGroup',
 
   propTypes: {
     component: React.PropTypes.any,
     childFactory: React.PropTypes.func,
+    render: React.PropTypes.func,
   },
 
   getDefaultProps: function() {
     return {
       component: 'span',
       childFactory: emptyFunction.thatReturnsArgument,
+      render: _defaultRender,
     };
   },
 
@@ -203,6 +213,7 @@ var ReactTransitionGroup = React.createClass({
   render: function() {
     // TODO: we could get rid of the need for the wrapper node
     // by cloning a single child
+    var render = this.props.render.bind(this);
     var childrenToRender = [];
     for (var key in this.state.children) {
       var child = this.state.children[key];
@@ -218,11 +229,7 @@ var ReactTransitionGroup = React.createClass({
         ));
       }
     }
-    return React.createElement(
-      this.props.component,
-      this.props,
-      childrenToRender
-    );
+    return render(childrenToRender);
   },
 });
 

--- a/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
@@ -291,4 +291,24 @@ describe('ReactCSSTransitionGroup', function() {
     // Testing that no exception is thrown here, as the timeout has been cleared.
     jest.runAllTimers();
   });
+
+  it('should handle a custom render function', function() {
+    var Component = React.createClass({
+      render: function() {
+        return (
+          <ReactCSSTransitionGroup
+            transitionEnterTimeout={500}
+            render={children => children[0]}>
+            {this.props.children}
+          </ReactCSSTransitionGroup>
+        );
+      },
+    });
+
+    var instance = ReactDOM.render(<Component><span id="one"/></Component>, container);
+    expect(ReactDOM.findDOMNode(instance).childNodes.length).toBe(0);
+    expect(ReactDOM.findDOMNode(instance).id).toBe('one');
+
+    ReactDOM.unmountComponentAtNode(container);
+  });
 });

--- a/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
@@ -269,4 +269,20 @@ describe('ReactTransitionGroup', function() {
       'willLeave2', 'didLeave2', 'willUnmount0', 'willUnmount1', 'willUnmount2',
     ]);
   });
+
+  it('should handle a custom render function', function() {
+    var WrapperLessComponent = React.createClass({
+      render: function() {
+        return (
+          <ReactTransitionGroup render={children => children[0]}>
+            <div id="one" />
+          </ReactTransitionGroup>
+        );
+      },
+    });
+
+    var instance = ReactDOM.render(<WrapperLessComponent />, container);
+    expect(ReactDOM.findDOMNode(instance).childNodes.length).toBe(0);
+    expect(ReactDOM.findDOMNode(instance).id).toBe('one');
+  });
 });


### PR DESCRIPTION
Allow a custom render function to be passed in as the `render` prop in ReactTransitionGroup.

This is an alternative strategy to https://github.com/facebook/react/pull/5408, based on a suggestion from @gaearon 