### PR TITLE
Link to "No Autobinding" section for ES6 classes.

### DIFF
--- a/docs/docs/03-interactivity-and-dynamic-uis.md
+++ b/docs/docs/03-interactivity-and-dynamic-uis.md
@@ -42,7 +42,7 @@ With React you simply pass your event handler as a camelCased prop similar to ho
 
 Under the hood, React does a few things to keep your code performant and easy to understand.
 
-**Autobinding:** When creating callbacks in JavaScript, you usually need to explicitly bind a method to its instance such that the value of `this` is correct. With React, every method is automatically bound to its component instance (except when using ES6 class syntax). React caches the bound method such that it's extremely CPU and memory efficient. It's also less typing!
+**Autobinding:** When creating callbacks in JavaScript, you usually need to explicitly bind a method to its instance such that the value of `this` is correct. With React, every method is automatically bound to its component instance ([except when using ES6 class syntax](/react/docs/reusable-components.html#no-autobinding). React caches the bound method such that it's extremely CPU and memory efficient. It's also less typing!
 
 **Event delegation:** React doesn't actually attach event handlers to the nodes themselves. When React starts up, it starts listening for all events at the top level using a single event listener. When a component is mounted or unmounted, the event handlers are simply added or removed from an internal mapping. When an event occurs, React knows how to dispatch it using this mapping. When there are no event handlers left in the mapping, React's event handlers are simple no-ops. To learn more about why this is fast, see [David Walsh's excellent blog post](http://davidwalsh.name/event-delegate).
 


### PR DESCRIPTION
There's a more descriptive section about the lack of Autobinding in ES6 classes and suggestions around it, so this commit adds a link to that section.