### PR TITLE
SyntheticClipboardEvent unit tests

### DIFF
--- a/src/renderers/dom/client/syntheticEvents/__tests__/SyntheticClipboardEvent-test.js
+++ b/src/renderers/dom/client/syntheticEvents/__tests__/SyntheticClipboardEvent-test.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var SyntheticClipboardEvent;
+
+describe('SyntheticClipboardEvent', function() {
+  var createEvent;
+
+  beforeEach(function() {
+    SyntheticClipboardEvent = require('SyntheticClipboardEvent');
+    createEvent = function(nativeEvent) {
+      var target = require('getEventTarget')(nativeEvent);
+      return SyntheticClipboardEvent.getPooled({}, '', nativeEvent, target);
+    };
+  });
+
+  describe('ClipboardEvent interface', function() {
+    describe('clipboardData', function() {
+      describe('when event has clipboardData', function() {
+        it("returns event's clipboardData", function() {
+          // Mock clipboardData since native implementation doesn't have a constructor
+          var clipboardData = jasmine.createSpyObj(
+            'clipboardData',
+            ['dropEffect', 'effectAllowed', 'files', 'items', 'types']
+          );
+          var clipboardEvent = createEvent({clipboardData: clipboardData});
+          
+          expect(clipboardEvent.clipboardData).toBe(clipboardData);
+        });
+      });
+    });
+  });
+
+  describe('EventInterface', function() {
+    it('normalizes properties from the Event interface', function() {
+      var target = document.createElement('div');
+      var syntheticEvent = createEvent({srcElement: target});
+
+      expect(syntheticEvent.target).toBe(target);
+      expect(syntheticEvent.type).toBe(undefined);
+    });
+
+    it('is able to `preventDefault` and `stopPropagation`', function() {
+      var nativeEvent = {};
+      var syntheticEvent = createEvent(nativeEvent);
+
+      expect(syntheticEvent.isDefaultPrevented()).toBe(false);
+      syntheticEvent.preventDefault();
+      expect(syntheticEvent.isDefaultPrevented()).toBe(true);
+
+      expect(syntheticEvent.isPropagationStopped()).toBe(false);
+      syntheticEvent.stopPropagation();
+      expect(syntheticEvent.isPropagationStopped()).toBe(true);
+    });
+
+    it('is able to `persist`', function() {
+      var syntheticEvent = createEvent({});
+
+      expect(syntheticEvent.isPersistent()).toBe(false);
+      syntheticEvent.persist();
+      expect(syntheticEvent.isPersistent()).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Adds unit tests for a SyntheticClipboardEvent.

## Before
<img width="730" alt="2016-03-30 23 07 11" src="https://cloud.githubusercontent.com/assets/1615659/14155938/967d7382-f6cc-11e5-94da-cf54ecd3c961.png">
<img width="738" alt="2016-03-30 23 07 50" src="https://cloud.githubusercontent.com/assets/1615659/14155939/967f9e6e-f6cc-11e5-8260-6c53202fa202.png">

## After
<img width="731" alt="2016-03-30 23 07 37" src="https://cloud.githubusercontent.com/assets/1615659/14155942/99314a0e-f6cc-11e5-9805-513c74d5faa9.png">
<img width="741" alt="2016-03-30 23 07 57" src="https://cloud.githubusercontent.com/assets/1615659/14155943/9935214c-f6cc-11e5-957b-63a55c94a646.png">

P.S. Unfortunately, I could not find a way to mock `window.clipboardData`, as when I put a value inside `window.clipboardData` in a spec I can't read it in the tested file. Does anybody know a way to tell `window` object inside a tested file to return a `clipboardData` value specified inside a spec? If there is a way or there are any errors, I will update the PR swiftly.