### PR TITLE
Add Symbol prop type

### DIFF
--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -363,7 +363,7 @@ function createShapeTypeChecker(shapeTypes) {
 function createSymbolTypeChecker() {
   function validate(props, propName, componentName, location, propFullName) {
     var propValue = props[propName];
-    var propType = getPropType(propValue)
+    var propType = getPropType(propValue);
 
     // If it behaves like a Symbol, it is a Symbol.
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -83,6 +83,7 @@ var ReactPropTypes = {
   oneOf: createEnumTypeChecker,
   oneOfType: createUnionTypeChecker,
   shape: createShapeTypeChecker,
+  symbol: createSymbolTypeChecker(),
 };
 
 /**
@@ -358,6 +359,26 @@ function createShapeTypeChecker(shapeTypes) {
   }
   return createChainableTypeChecker(validate);
 }
+
+function createSymbolTypeChecker() {
+  function validate(props, propName, componentName, location, propFullName) {
+    var propValue = props[propName];
+    var propType = getPropType(propValue)
+
+    // If it behaves like a Symbol, it is a Symbol.
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol
+    if ((propType !== 'symbol') && (propValue['@@toStringTag'] !== 'Symbol')) {
+      return new Error(
+        `Invalid ${locationName} \`${propFullName}\` of type \`${propType}\` ` +
+        `supplied to \`${componentName}\`, expected \`symbol\`.`
+      );
+    }
+
+    return null;
+  }
+  return createChainableTypeChecker(validate);
+}
+
 
 function isNode(propValue) {
   switch (typeof propValue) {

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -369,7 +369,7 @@ function createSymbolTypeChecker() {
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol
     if ((propType !== 'symbol') && (propValue['@@toStringTag'] !== 'Symbol')) {
       return new Error(
-        `Invalid ${locationName} \`${propFullName}\` of type \`${propType}\` ` +
+        `Invalid ${location} \`${propFullName}\` of type \`${propType}\` ` +
         `supplied to \`${componentName}\`, expected \`symbol\`.`
       );
     }


### PR DESCRIPTION
Hi there,

As it seemed that no one took #4917, here is my pull request for it.

Some rationale behind the choice as Symbols are essentially polyfilled / transpiled:

- If the typeof is Symbol -- native support or Babel plugin, then it is a Symbol.
- If it behaves like a Symbol (according to Mozilla doc) -- polyfill / no native support, then it is a Symbol.

Is there any case that I could have missed? Let me know if I need to work on it to get it accepted!
Thanks!