### PR TITLE
Flip __DEV__ assignments in ReactDOMProduction-test

### DIFF
--- a/src/renderers/dom/__tests__/ReactDOMProduction-test.js
+++ b/src/renderers/dom/__tests__/ReactDOMProduction-test.js
@@ -18,7 +18,7 @@ describe('ReactDOMProduction', function() {
   var ReactDOM;
 
   beforeEach(function() {
-    __DEV__ = true;
+    __DEV__ = false;
     oldProcess = process;
     global.process = {env: {NODE_ENV: 'production'}};
 
@@ -28,7 +28,7 @@ describe('ReactDOMProduction', function() {
   });
 
   afterEach(function() {
-    __DEV__ = false;
+    __DEV__ = true;
     global.process = oldProcess;
   });
 


### PR DESCRIPTION
I think these two appear assignments need to be flipped around.

This test works correctly because today it only relies on fbjs `warning`s which are not affected by `__DEV__` global and read from `process.env.NODE_ENV` which is set [a few lines below](https://github.com/facebook/react/blob/a5c164dacad2597a1685a3ab401b1a3b7ff1f3eb/src/renderers/dom/__tests__/ReactDOMProduction-test.js#L23).

In my testing, adding another test that actually relies on `__DEV__` shows that the current behavior is incorrect.