### PR TITLE
Clarify that ReactPerf.getLastMeasurements() is now opaque

### DIFF
--- a/docs/docs/10.9-perf.md
+++ b/docs/docs/10.9-perf.md
@@ -57,24 +57,6 @@ This method has been renamed to `printOperations()` which is described in the pr
 The above print methods use `Perf.getLastMeasurements()` to pretty-print the result.
 
 ### `Perf.getLastMeasurements()`
-Get the measurements array from the last start-stop session. The array contains objects, each of which looks like this:
+Get the opaque data structure describing measurements from the last start-stop session. You can save it and pass it to the methods above to analyze past measurements.
 
-```js
-{
-  // The term "inclusive" and "exclusive" are explained below
-  "exclusive": {},
-  // '.0.0' is the React ID of the node
-  "inclusive": {".0.0": 0.0670000008540228, ".0": 0.3259999939473346},
-  "render": {".0": 0.036999990697950125, ".0.0": 0.010000003385357559},
-  // Number of instances
-  "counts": {".0": 1, ".0.0": 1},
-  // DOM touches
-  "writes": {},
-  // Extra debugging info
-  "displayNames": {
-    ".0": {"current": "App", "owner": "<root>"},
-    ".0.0": {"current": "Box", "owner": "App"}
-  },
-  "totalTime": 0.48499999684281647
-}
-```
+Don't rely on the exact format of the return value because it may change in minor releases. We will update the documentation if the return value format becomes a supported part of the public API.


### PR DESCRIPTION
This documents changes from #6286 and should be up on the website when 15 is released.