### PR TITLE
Use the correct SyntheticEvent for TestUtils.Simulate

### DIFF
--- a/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
@@ -487,7 +487,7 @@ var SimpleEventPlugin = {
 
   eventTypes: eventTypes,
 
-  extractEvents: function(
+  extractEventConstructor: function(
     topLevelType,
     targetInst,
     nativeEvent,
@@ -604,8 +604,27 @@ var SimpleEventPlugin = {
       'SimpleEventPlugin: Unhandled event type, `%s`.',
       topLevelType
     );
+    return EventConstructor;
+  },
+
+  extractEvents: function(
+    topLevelType,
+    targetInst,
+    nativeEvent,
+    nativeEventTarget
+  ) {
+    var EventConstructor = SimpleEventPlugin.extractEventConstructor(
+      topLevelType,
+      targetInst,
+      nativeEvent,
+      nativeEventTarget
+    );
+    if (!EventConstructor) {
+      return null;
+    }
+
     var event = EventConstructor.getPooled(
-      dispatchConfig,
+      topLevelEventsToDispatchConfig[topLevelType],
       targetInst,
       nativeEvent,
       nativeEventTarget

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -474,6 +474,29 @@ describe('ReactTestUtils', function() {
     expect(handler).not.toHaveBeenCalled();
   });
 
+  it('should not warn when simulating events with extra properties', function() {
+    spyOn(console, 'error');
+
+    var CLIENT_X = 100;
+
+    var Component = React.createClass({
+      handleClick: function(e) {
+        expect(e.clientX).toBe(CLIENT_X);
+      },
+      render: function() {
+        return <div onClick={this.handleClick} />;
+      },
+    });
+
+    var element = document.createElement('div');
+    var instance = ReactDOM.render(<Component />, element);
+    ReactTestUtils.Simulate.click(
+      ReactDOM.findDOMNode(instance),
+      {clientX: CLIENT_X}
+    );
+    expect(console.error.calls.length).toBe(0);
+  });
+
   it('can scry with stateless components involved', function() {
     var Stateless = () => <div><hr /></div>;
     var SomeComponent = React.createClass({


### PR DESCRIPTION
This is currently an RFC as a different approach to #6380, doing what I proposed in a comment - to use the correct synthetic event for the given event. This ensures that the correct properties from the native event are copied and we won't trigger that warning. This is better than what I did in 6380 in that this will leave runtime and testing more inline and triggering the same warnings for setting extra properties after the event is created, as opposed to silencing those warnings blindly.

cc @spicyj 

TODO:
- [ ] Update the other event plugins so the API is consistent and all of the tests can actually pass
