### PR TITLE
Fix typo

### DIFF
--- a/src/renderers/shared/event/EventPluginUtils.js
+++ b/src/renderers/shared/event/EventPluginUtils.js
@@ -206,7 +206,7 @@ function executeDirectDispatch(event) {
   );
   event.currentTarget = EventPluginUtils.getNodeFromInstance(dispatchInstance);
   var res = dispatchListener ? dispatchListener(event) : null;
-  event.curentTarget = null;
+  event.currentTarget = null;
   event._dispatchListeners = null;
   event._dispatchInstances = null;
   return res;


### PR DESCRIPTION
Resets currentTarget on the pooled event instead of adding an expando.
