### PR TITLE
Add prevProps, prevState and prevContext as properties to render method

### DIFF
--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -795,14 +795,9 @@ var ReactCompositeComponentMixin = {
     var inst = this._instance;
 
     var hasComponentDidUpdate = Boolean(inst.componentDidUpdate);
-    var prevProps;
-    var prevState;
-    var prevContext;
-    if (hasComponentDidUpdate) {
-      prevProps = inst.props;
-      prevState = inst.state;
-      prevContext = inst.context;
-    }
+    inst._prevProps = inst.props;
+    inst._prevState = inst.state;
+    inst._prevContext = inst.context;
 
     if (inst.componentWillUpdate) {
       inst.componentWillUpdate(nextProps, nextState, nextContext);
@@ -818,7 +813,7 @@ var ReactCompositeComponentMixin = {
 
     if (hasComponentDidUpdate) {
       transaction.getReactMountReady().enqueue(
-        inst.componentDidUpdate.bind(inst, prevProps, prevState, prevContext),
+        inst.componentDidUpdate.bind(inst, inst._prevProps, inst._prevState, inst._prevContext),
         inst
       );
     }
@@ -877,7 +872,7 @@ var ReactCompositeComponentMixin = {
    */
   _renderValidatedComponentWithoutOwnerOrContext: function() {
     var inst = this._instance;
-    var renderedComponent = inst.render();
+    var renderedComponent = inst.render(inst._prevProps, inst._prevState, inst._prevContext);
     if (__DEV__) {
       // We allow auto-mocks to proceed as if they're returning null.
       if (renderedComponent === undefined &&

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -1062,6 +1062,54 @@ describe('ReactCompositeComponent', function() {
     );
   });
 
+  it('should initially pass previous state, props and context to render', function() {
+    spyOn(console, 'error');
+
+    var render = jasmine.createSpy('render').andReturn(<div />);
+    var prevProps = {};
+    var prevState = {};
+    var prevContext = {};
+    var prevContext = {
+      foo: 'bar'
+    };
+
+    var Parent = React.createClass({
+      childContextTypes: {
+        foo: ReactPropTypes.string,
+      },
+
+      getChildContext: function() {
+        return prevContext;
+      },
+
+      render: function() {
+        return this.props.children;
+      },
+    });
+
+    var Child = React.createClass({
+      contextTypes: {
+        foo: ReactPropTypes.string
+      },
+
+      getInitialState() {
+        return prevState;
+      },
+      
+      getDefaultProps() {
+        return prevProps;
+      },
+      
+      render: render
+    });
+
+    var component = ReactTestUtils.renderIntoDocument(<Parent><Child /></Parent>);
+    expect(render).toHaveBeenCalledWith(undefined, undefined, undefined);
+    
+    component.forceUpdate();
+    expect(render).toHaveBeenCalledWith(prevProps, prevState, prevContext);
+  });
+
   it('only renders once if updated in componentWillReceiveProps', function() {
     var renders = 0;
     var Component = React.createClass({


### PR DESCRIPTION
This pull request adds prevProps, prevState and prevContext to the render method.  Here's an example:

```js
React.createClass({
  render: function(prevProps, prevState, prevContext) {
    return ...
  }
});
```

I think this will reduce the need to use either componentWillReceiveProps or componentDidUpdate in many cases and result in less code.  Here's an example I pulled partly from the docs for componentWillReceiveProps:

```js
// CURRENT APPROACH
React.createClass({
  componentWillReceiveProps: function(nextProps) {  
    this.setState({
      likesIncreasing: nextProps.likeCount > this.props.likeCount
    });
  },
  render: function() {
    return <div>{this.props.likesIncreasing ? 'Cool!' : 'Meh'}</div>
  }
});
```

Here's what the change looks like:

```js
// REVISED APPROACH
React.createClass({
  render: function(prevProps) {
    return <div>{this.props.likeCount > prevProps.likeCount ? 'Cool!' : 'Meh'}</div>
  }
});
```

Not in this pull request but a rad continuation of this idea would be stateless components getting previous props.  I wasn't able to easily identify where stateless components are created so any help pointing me to the right place would be cool.  Something like:

```js
module.exports = function(props, prevProps) {
  return <div>{props.likeCount > prevProps.likeCount ? 'Cool!' : 'Meh'}</div>
};
```

Previous state and context has also been added to render in order to match componentDidUpdate's signature but I think prevProps should be there at minimum.

Any feedback/thoughts would be appreciated!