### PR TITLE
Add documentation about empty functional components

### DIFF
--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -301,6 +301,6 @@ However, you may still specify `.propTypes` and `.defaultProps` by setting them 
 
 > NOTE:
 >
-> Due to some implementation details, returning `null` or `false` to indicate you don't want to render anything won't work in a functional component (see [react/4599](https://github.com/facebook/react/issues/4599) for details). Consider returning `<noscript />` instead.
+> In React v0.14, stateless functional components were not permitted to return `null` or `false` (a workaround is to return a `<noscript />` instead). This was fixed in React v15, and stateless functional components are now permitted to return `null`.
 
 In an ideal world, most of your components would be stateless functions because in the future we’ll also be able to make performance optimizations specific to these components by avoiding unnecessary checks and memory allocations. This is the recommended pattern, when possible.

--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -299,4 +299,8 @@ However, you may still specify `.propTypes` and `.defaultProps` by setting them 
 >
 > Because stateless functions don't have a backing instance, you can't attach a ref to a stateless function component. Normally this isn't an issue, since stateless functions do not provide an imperative API. Without an imperative API, there isn't much you could do with an instance anyway. However, if a user wants to find the DOM node of a stateless function component, they must wrap the component in a stateful component (eg. ES6 class component) and attach the ref to the stateful wrapper component.
 
+> NOTE:
+>
+> Due to some implementation details, returning `null` or `false` to indicate you don't want to render anything won't work in a functional component (see [react/4599](https://github.com/facebook/react/issues/4599) for details). Consider returning `<noscript />` instead.
+
 In an ideal world, most of your components would be stateless functions because in the future we’ll also be able to make performance optimizations specific to these components by avoiding unnecessary checks and memory allocations. This is the recommended pattern, when possible.


### PR DESCRIPTION
The dev build has a warning about this, but there's no obvious course of action to actually make it work. Also, I think adding this to the docs makes migrating existing components easier.