### PR TITLE
Kill React.__spread

### DIFF
--- a/src/isomorphic/React.js
+++ b/src/isomorphic/React.js
@@ -65,9 +65,6 @@ var React = {
   DOM: ReactDOMFactories,
 
   version: ReactVersion,
-
-  // Hook for JSX spread, don't use this for anything else.
-  __spread: Object.assign,
 };
 
 module.exports = React;


### PR DESCRIPTION
This was only used by JSTransform which has been deprecated for a while. An early version of Babel used it as well.