### PR TITLE
Ensure default injection is injected for test utils

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -16,6 +16,7 @@ var EventPluginHub = require('EventPluginHub');
 var EventPluginRegistry = require('EventPluginRegistry');
 var EventPropagators = require('EventPropagators');
 var React = require('React');
+var ReactDefaultInjection = require('ReactDefaultInjection');
 var ReactDOM = require('ReactDOM');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var ReactElement = require('ReactElement');
@@ -409,6 +410,11 @@ Object.assign(
 );
 
 ReactShallowRenderer.prototype.render = function(element, context) {
+  // Ensure we've done the default injections. This might not be true in the
+  // case of a simple test that only requires React and the TestUtils in
+  // conjunction with an inline-requires transform.
+  ReactDefaultInjection.inject();
+
   invariant(
     ReactElement.isValidElement(element),
     'ReactShallowRenderer render(): Invalid component element.%s',


### PR DESCRIPTION
This is perfectly safe as that method will not throw if already injected. Some environments use an inline-requires transform and would be impacted if we don't do this. Otherwise it's not necessary as this injections happens when ReactDOM is required.