### PR TITLE
Correctly select options when nested inside an optgroup

### DIFF
--- a/src/renderers/dom/client/wrappers/ReactDOMOption.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMOption.js
@@ -39,7 +39,7 @@ var ReactDOMOption = {
         selectParent = selectParent._nativeParent;
       }
 
-      if (selectParent._tag === 'select') {
+      if (selectParent != null && selectParent._tag === 'select') {
         selectValue = ReactDOMSelect.getSelectValueContext(selectParent);
       }
     }

--- a/src/renderers/dom/client/wrappers/ReactDOMOption.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMOption.js
@@ -32,8 +32,16 @@ var ReactDOMOption = {
 
     // Look up whether this option is 'selected'
     var selectValue = null;
-    if (nativeParent != null && nativeParent._tag === 'select') {
-      selectValue = ReactDOMSelect.getSelectValueContext(nativeParent);
+    if (nativeParent != null) {
+      var selectParent = nativeParent;
+
+      if (selectParent._tag === 'optgroup') {
+        selectParent = selectParent._nativeParent;
+      }
+
+      if (selectParent._tag === 'select') {
+        selectValue = ReactDOMSelect.getSelectValueContext(selectParent);
+      }
     }
 
     // If the value is null (e.g., no specified value or after initial mount)

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMSelect-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMSelect-test.js
@@ -537,4 +537,22 @@ describe('ReactDOMSelect', function() {
       "Cannot set property 'pendingUpdate' of null"
     );
   });
+
+  it('should select grandchild options nested inside an optgroup', function() {
+    var stub =
+      <select value="b" onChange={noop}>
+        <optgroup label="group">
+          <option value="a">a</option>
+          <option value="b">b</option>
+          <option value="c">c</option>
+        </optgroup>
+      </select>;
+    var container = document.createElement('div');
+    stub = ReactDOM.render(stub, container);
+    var node = ReactDOM.findDOMNode(stub);
+
+    expect(node.options[0].selected).toBe(false);  // a
+    expect(node.options[1].selected).toBe(true);   // b
+    expect(node.options[2].selected).toBe(false);  // c
+  });
 });

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMSelect-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMSelect-test.js
@@ -548,8 +548,7 @@ describe('ReactDOMSelect', function() {
         </optgroup>
       </select>;
     var container = document.createElement('div');
-    stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+    var node = ReactDOM.render(stub, container);
 
     expect(node.options[0].selected).toBe(false);  // a
     expect(node.options[1].selected).toBe(true);   // b


### PR DESCRIPTION
I took a stab at fixing #6440. As far as I can tell, `<option>` can't have any native parents other than `<optgroup>` or `<select>`. If this isn't the case, would we want to crawl up through the chain of parents looking for `<select>` or would it be better to rely on context again like the older implementation?