### PR TITLE
Add back React.__spread and make it warn

### DIFF
--- a/src/isomorphic/React.js
+++ b/src/isomorphic/React.js
@@ -21,6 +21,7 @@ var ReactPropTypes = require('ReactPropTypes');
 var ReactVersion = require('ReactVersion');
 
 var onlyChild = require('onlyChild');
+var warning = require('warning');
 
 var createElement = ReactElement.createElement;
 var createFactory = ReactElement.createFactory;
@@ -30,6 +31,23 @@ if (__DEV__) {
   createElement = ReactElementValidator.createElement;
   createFactory = ReactElementValidator.createFactory;
   cloneElement = ReactElementValidator.cloneElement;
+}
+
+var __spread = Object.assign;
+
+if (__DEV__) {
+  var warned = false;
+  __spread = function() {
+    warning(
+      warned,
+      'React.__spread is deprecated and should not be used. Use ' +
+      'Object.assign directly or another helper function with similar ' +
+      'semantics. You may be seeing this warning due to your compiler. ' +
+      'See https://fb.me/react-spread-deprecation for more details.'
+    );
+    warned = true;
+    return Object.assign.apply(null, arguments);
+  };
 }
 
 var React = {
@@ -66,8 +84,8 @@ var React = {
 
   version: ReactVersion,
 
-  // Hook for JSX spread, don't use this for anything else.
-  __spread: Object.assign,
+  // Deprecated hook for JSX spread, don't use this for anything.
+  __spread: __spread,
 };
 
 module.exports = React;

--- a/src/isomorphic/React.js
+++ b/src/isomorphic/React.js
@@ -65,6 +65,9 @@ var React = {
   DOM: ReactDOMFactories,
 
   version: ReactVersion,
+
+  // Hook for JSX spread, don't use this for anything else.
+  __spread: Object.assign,
 };
 
 module.exports = React;


### PR DESCRIPTION
This API was removed because it was undocumented and existed solely for our JSXTransformer/react-tools, which haven't been supported for a year. However it turns out TypeScript is still using this API in their TSX compilation and it kind of sucks to break people who want to upgrade React but not the rest of their toolchain.

~~Note: this doesn't quite (read at all) work with the `Object.assign` -> `object-assign` transform I wrote so would need to fix that too.~~