### PR TITLE
fix ReactDOM.render return type

### DIFF
--- a/docs/docs/ref-01-top-level-api.md
+++ b/docs/docs/ref-01-top-level-api.md
@@ -139,7 +139,7 @@ The `react-dom` package provides DOM-specific methods that can be used at the to
 ### ReactDOM.render
 
 ```javascript
-render(
+void render(
   ReactElement element,
   DOMElement container,
   [function callback]


### PR DESCRIPTION
and make it consistent with another docs pages
issue was introduced in https://github.com/facebook/react/pull/6400