### PR TITLE
No unit-less CSS value warning for `value: "0"`

### DIFF
--- a/src/renderers/dom/shared/dangerousStyleValue.js
+++ b/src/renderers/dom/shared/dangerousStyleValue.js
@@ -44,7 +44,7 @@ function dangerousStyleValue(name, value, component) {
   }
 
   var isNonNumeric = isNaN(value);
-  if (isNonNumeric || value === 0 ||
+  if (isNonNumeric || value === 0 || value === '0' ||
       isUnitlessNumber.hasOwnProperty(name) && isUnitlessNumber[name]) {
     return '' + value; // cast to string
   }


### PR DESCRIPTION
After upgrading to React v15.0 I got a lot of warnings like:

```
Warning: a `div` tag (owner: `FooterComponent`) was passed a numeric string value for CSS property `left` (value: `0`) which will be treated as a unitless number in a future version of React.
```

I can avoid the warning by changing `"0"` to number `0` or `"0px"`. I like neither ways because:

1. It's a code convention in my team to write all CSS values in strings (and I believe it's good).
2. Adding a unit to a zero value does not make much sense. 

I believe this warning is overall a very good thing but I want to keep my current way of writing string zeros in CSS values.