### PR TITLE
Add unknown property warning for use of `autofocus`

### DIFF
--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -39,7 +39,7 @@ var HTMLDOMPropertyConfig = {
     async: HAS_BOOLEAN_VALUE,
     autoComplete: 0,
     // autoFocus is polyfilled/normalized by AutoFocusUtils
-    // autoFocus: HAS_BOOLEAN_VALUE,
+    autoFocus: HAS_BOOLEAN_VALUE,
     autoPlay: HAS_BOOLEAN_VALUE,
     capture: HAS_BOOLEAN_VALUE,
     cellPadding: 0,
@@ -202,6 +202,7 @@ var HTMLDOMPropertyConfig = {
   },
   DOMAttributeNames: {
     acceptCharset: 'accept-charset',
+    autoFocus: 'autofocus',
     className: 'class',
     htmlFor: 'for',
     httpEquiv: 'http-equiv',

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -724,7 +724,7 @@ describe('ReactDOMComponent', function() {
     });
 
     it('should work error event on <source> element', function() {
-      spyOn(console, 'error');  
+      spyOn(console, 'error');
       var container = document.createElement('div');
       ReactDOM.render(
         <video>
@@ -1469,6 +1469,23 @@ describe('ReactDOMComponent', function() {
       //since hard coding the line number would make test too brittle
       expect(parseInt(previousLine, 10) + 12).toBe(parseInt(currentLine, 10));
 
+    });
+
+    it('should suggest property name if available', () => {
+      spyOn(console, 'error');
+
+      ReactTestUtils.renderIntoDocument(React.createElement('label', {for: 'test'}));
+      ReactTestUtils.renderIntoDocument(React.createElement('input', {type: 'text', autofocus: true}));
+
+      expect(console.error.calls.count()).toBe(2);
+
+      expect(console.error.calls.argsFor(0)[0]).toBe(
+        'Warning: Unknown DOM property for. Did you mean htmlFor?\n    in label'
+      );
+
+      expect(console.error.calls.argsFor(1)[0]).toBe(
+        'Warning: Unknown DOM property autofocus. Did you mean autoFocus?\n    in input'
+      );
     });
   });
 });


### PR DESCRIPTION
Resolves #3248

This PR also:
  * Resurrects property warnings when `ReactDOMFeatureFlags.useCreateElement` is on
  * Adds property validity event to debug tool

I wrote some tests for this work, but didn't notice any other `__DEV__` specific warnings being tested. I can include them with this PR if they're wanted.