### PR TITLE
Re-added support for attaching events to document fragments

### DIFF
--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -60,6 +60,9 @@ var RESERVED_PROPS = {
   suppressContentEditableWarning: null,
 };
 
+// Node type for document fragments (Node.DOCUMENT_FRAGMENT_NODE).
+var DOC_FRAGMENT_TYPE = 11;
+
 
 function getDeclarationErrorAddendum(internalInstance) {
   if (internalInstance) {
@@ -213,7 +216,8 @@ function enqueuePutListener(inst, registrationName, listener, transaction) {
     );
   }
   var containerInfo = inst._nativeContainerInfo;
-  var doc = containerInfo._ownerDocument;
+  var isDocumentFragment = containerInfo._node && containerInfo._node.nodeType === DOC_FRAGMENT_TYPE;
+  var doc = isDocumentFragment ? containerInfo._node : containerInfo._ownerDocument;
   if (!doc) {
     // Server rendering.
     return;

--- a/src/renderers/dom/shared/ReactDOMContainerInfo.js
+++ b/src/renderers/dom/shared/ReactDOMContainerInfo.js
@@ -22,6 +22,7 @@ function ReactDOMContainerInfo(topLevelWrapper, node) {
     _ownerDocument: node ?
       node.nodeType === DOC_NODE_TYPE ? node : node.ownerDocument :
       null,
+    _node: node,
     _tag: node ? node.nodeName.toLowerCase() : null,
     _namespaceURI: node ? node.namespaceURI : null,
   };


### PR DESCRIPTION
I thought I'd jump straight in and make the change :+1:

In the [open issue](https://github.com/facebook/react/issues/6456#issuecomment-207527336) it was mentioned that @spicyj wrote this part of the code, so it would be awesome if he &mdash; or anybody else &mdash; could chime in about the optimal way of implementing this. Thanks!