### PR TITLE
Warn when a DOM element has unsupported property

### DIFF
--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -391,16 +391,19 @@ describe('DOMPropertyOperations', function() {
   describe('injectDOMPropertyConfig', function() {
     it('should support custom attributes', function() {
       // foobar does not exist yet
+      spyOn(console, 'error');
       expect(DOMPropertyOperations.createMarkupForProperty(
         'foobar',
         'simple'
       )).toBe(null);
+      expect(console.error.argsForCall.length).toBe(1);
 
       // foo-* does not exist yet
       expect(DOMPropertyOperations.createMarkupForProperty(
         'foo-xyz',
         'simple'
       )).toBe(null);
+      expect(console.error.argsForCall.length).toBe(2);
 
       // inject foobar DOM property
       DOMProperty.injection.injectDOMPropertyConfig({

--- a/src/renderers/dom/shared/devtools/ReactDOMUnknownPropertyDevtool.js
+++ b/src/renderers/dom/shared/devtools/ReactDOMUnknownPropertyDevtool.js
@@ -19,6 +19,7 @@ var warning = require('warning');
 if (__DEV__) {
   var reactProps = {
     children: true,
+    defaultValue: true,
     dangerouslySetInnerHTML: true,
     key: true,
     ref: true,
@@ -46,11 +47,10 @@ if (__DEV__) {
         null
     );
 
-    // For now, only warn when we have a suggested correction. This prevents
-    // logging too much when using transferPropsTo.
+    // Suggest a property name correction if possible
     warning(
       standardName == null,
-      'Unknown DOM property %s. Did you mean %s?',
+      'Unable to assign unsupported DOM property %s. Did you mean %s?',
       name,
       standardName
     );
@@ -63,11 +63,19 @@ if (__DEV__) {
       null
     );
 
+    // Suggest an event name correction if possible
     warning(
       registrationName == null,
-      'Unknown event handler property %s. Did you mean `%s`?',
+      'Unable to register unsupported event handler property %s. Did you mean %s?',
       name,
       registrationName
+    );
+
+    // Otherwise at least make it clear that the attributes will be filtered out
+    warning(
+      standardName != null || registrationName != null,
+      'Unable to assign unsupported DOM property %s.',
+      name
     );
   };
 }


### PR DESCRIPTION
This commit updates the logic in ReactDOMUnknownPropertyDevTool such that it will warn when a DOM property not contained in the property whitelist is assigned to a React DOM element.

Basically a follow up to @jimfb's suggestion in https://github.com/facebook/react/pull/6459.