### PR TITLE
Ensure validateDOMNesting catches nested body elements

### DIFF
--- a/src/renderers/dom/client/__tests__/validateDOMNesting-test.js
+++ b/src/renderers/dom/client/__tests__/validateDOMNesting-test.js
@@ -83,5 +83,7 @@ describe('ReactContextValidator', function() {
     expect(isTagStackValid(['table', 'tr'])).toBe(false);
     expect(isTagStackValid(['div', 'ul', 'li', 'div', 'li'])).toBe(false);
     expect(isTagStackValid(['div', 'html'])).toBe(false);
+    expect(isTagStackValid(['body', 'body'])).toBe(false);
+    expect(isTagStackValid(['svg', 'foreignObject', 'body', 'p'])).toBe(false);
   });
 });

--- a/src/renderers/dom/client/validateDOMNesting.js
+++ b/src/renderers/dom/client/validateDOMNesting.js
@@ -208,6 +208,7 @@ if (__DEV__) {
       case 'rt':
         return impliedEndTags.indexOf(parentTag) === -1;
 
+      case 'body':
       case 'caption':
       case 'col':
       case 'colgroup':


### PR DESCRIPTION
This commit fixes #6280. 

Instead of adding a new list of rules to handle `foreignObject`, I think the actual problem is that we don't have a clause that handles another `body` in "in body" parsing mode (e.g., pass [this html snippet](https://gist.github.com/keyanzhang/cbaff654eecd5c04f278df71d40cc2bc) to the [W3C validator](https://validator.w3.org/) to see the error message: "Start tag `body` seen but an element of the same type was already open"). 

Thanks for reviewing! I could be totally wrong so any feedback is greatly appreciated.

cc @spicyj @toddgeist