### PR TITLE
Add component instance to ReactDebugTool's onStateUpdated

### DIFF
--- a/src/isomorphic/ReactDebugTool.js
+++ b/src/isomorphic/ReactDebugTool.js
@@ -55,7 +55,7 @@ var ReactDebugTool = {
   onEndProcessingChildContext() {
     emitEvent('onEndProcessingChildContext');
   },
-  onSetState(componentInstance = null) {
+  onSetState(componentInstance) {
     emitEvent('onSetState', componentInstance);
   },
   onMountRootComponent(internalInstance) {

--- a/src/isomorphic/ReactDebugTool.js
+++ b/src/isomorphic/ReactDebugTool.js
@@ -55,8 +55,8 @@ var ReactDebugTool = {
   onEndProcessingChildContext() {
     emitEvent('onEndProcessingChildContext');
   },
-  onSetState() {
-    emitEvent('onSetState');
+  onSetState(componentInstance = null) {
+    emitEvent('onSetState', componentInstance);
   },
   onMountRootComponent(internalInstance) {
     emitEvent('onMountRootComponent', internalInstance);

--- a/src/isomorphic/modern/class/ReactComponent.js
+++ b/src/isomorphic/modern/class/ReactComponent.js
@@ -67,7 +67,7 @@ ReactComponent.prototype.setState = function(partialState, callback) {
     'function which returns an object of state variables.'
   );
   if (__DEV__) {
-    ReactInstrumentation.debugTool.onSetState();
+    ReactInstrumentation.debugTool.onSetState(this);
     warning(
       partialState != null,
       'setState(...): You passed an undefined or null state object; ' +


### PR DESCRIPTION
For sniffing state, it would be nice to actually get the component instance that has raised the onSetState event using ReactDebugTool