### PR TITLE
Ignore DOM writes outside the batch in ReactPerf

### DIFF
--- a/src/test/ReactDefaultPerfAnalysis.js
+++ b/src/test/ReactDefaultPerfAnalysis.js
@@ -175,12 +175,13 @@ function getUnchangedComponents(measurement) {
   // the amount of time it took to render the entire subtree.
   var cleanComponents = {};
   var writes = measurement.writes;
+  var hierarchy = measurement.hierarchy;
   var dirtyComposites = {};
   Object.keys(writes).forEach(function(id) {
     writes[id].forEach(function(write) {
       // Root mounting (innerHTML set) is recorded with an ID of ''
-      if (id !== '') {
-        measurement.hierarchy[id].forEach((c) => dirtyComposites[c] = true);
+      if (id !== '' && hierarchy.hasOwnProperty(id)) {
+        hierarchy[id].forEach((c) => dirtyComposites[c] = true);
       }
     });
   });

--- a/src/test/__tests__/ReactDefaultPerf-test.js
+++ b/src/test/__tests__/ReactDefaultPerf-test.js
@@ -239,6 +239,18 @@ describe('ReactDefaultPerf', function() {
     expect(summary).toEqual([]);
   });
 
+  it('should not fail on input change events', function() {
+    var container = document.createElement('div');
+    var onChange = () => {};
+    var input = ReactDOM.render(
+      <input checked={true} onChange={onChange} />,
+      container
+    );
+    expectNoWaste(() => {
+      ReactTestUtils.Simulate.change(input);
+    });
+  });
+
   it('should print a table after calling printOperations', function() {
     var container = document.createElement('div');
     var measurements = measure(() => {


### PR DESCRIPTION
`ReactDOMInput` and a few other classes handle change event by [scheduling `updateWrapper()` in an `asap()`](https://github.com/facebook/react/blob/6a8c7518d39d8f1a03543e23aa0c6060a44772e6/src/renderers/dom/client/wrappers/ReactDOMInput.js#L235-L238). It gets executed after the batch, which confuses `ReactPerf` that expects all DOM writes to happen during a batch.

This causes it to throw when calculating `printWasted()` if you interacted with an input before taking the measurement: https://github.com/facebook/react/issues/5548.

Since this implementation of `ReactPerf` relying on the stack is [going away](https://github.com/facebook/react/pull/6046), let's plug the hole temporarily by ignoring DOM writes that occur during postponed `updateWrapper()`. In any case, they have no relation to actual calculations of wasted renders, as they don't occur due to `updateComponent()`, but rather due to `onChange()` special DOM behavior.

This fixes #5548. Thanks to @Danita for her [help investigating the issue](https://github.com/facebook/react/issues/5548#issuecomment-210096490) which allowed me to find the minimal case to repro this.