### PR TITLE
properly handling invalid scryRenderedDOMComponentsWithClass args

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -178,9 +178,6 @@ var ReactTestUtils = {
    * @return {array} an array of all the matches.
    */
   scryRenderedDOMComponentsWithClass: function(root, classNames) {
-    if (!Array.isArray(classNames)) {
-      classNames = classNames.split(/\s+/);
-    }
     return ReactTestUtils.findAllInRenderedTree(root, function(inst) {
       if (ReactTestUtils.isDOMComponent(inst)) {
         var className = inst.className;
@@ -189,6 +186,15 @@ var ReactTestUtils = {
           className = inst.getAttribute('class') || '';
         }
         var classList = className.split(/\s+/);
+
+        if (!Array.isArray(classNames)) {
+          invariant(
+            classNames !== undefined,
+            'TestUtils.scryRenderedDOMComponentsWithClass expects a ' +
+            'className as a second argument.'
+          );
+          classNames = classNames.split(/\s+/);
+        }
         return classNames.every(function(name) {
           return classList.indexOf(name) !== -1;
         });


### PR DESCRIPTION
Fixes [#6493](https://github.com/facebook/react/issues/6493)

If one argument is passed in to `scryRenderedDOMComponentsWithClass` and it's not a valid instance of a react component, you will still get the standard `Invariant Violation: findAllInRenderedTree(...): instance must be a composite component` error message as usual.

If a valid instance of a component is passed in as the first argument but a `className` is not passed in as a second argument, the user will be presented with this error message:  `Invariant Violation: TestUtils.scryRenderedDOMComponentsWithClass expects a className a second argument`.