### PR TITLE
Add xmlNS and xmlnsXlink SVG Attributes

### DIFF
--- a/src/renderers/dom/shared/SVGDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/SVGDOMPropertyConfig.js
@@ -13,7 +13,7 @@
 
 var NS = {
   xlink: 'http://www.w3.org/1999/xlink',
-  xml: 'http://www.w3.org/XML/1998/namespace',
+  xml: 'http://www.w3.org/2000/svg',
 };
 
 // We use attributes for everything SVG so let's avoid some duplication and run
@@ -264,7 +264,9 @@ var ATTRS = {
   xlinkType: 'xlink:type',
   xmlBase: 'xml:base',
   xmlLang: 'xml:lang',
+  xmlNS: 'xmlns',
   xmlSpace: 'xml:space',
+  xmlnsXlink: 'xmlns:xlink',
   y: 0,
   y1: 0,
   y2: 0,


### PR DESCRIPTION
- Since is a good practice to include all the commonly used namespace declarations when creating `<svg>`, specially when used as external `.svg` files to help the users agents recognise the content, it is necessary to have at least those attributes available.

- Change the `xml` namespace into the String standard most used.

Specify syntax and change `xml` namespace based on #6471