### PR TITLE
consistent owner for stateless component

### DIFF
--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -1117,12 +1117,17 @@ var ReactCompositeComponentMixin = {
    */
   _renderValidatedComponent: function() {
     var renderedComponent;
-    ReactCurrentOwner.current = this;
-    try {
+    if (__DEV__ || !(this._instance instanceof StatelessComponent)) {
+      ReactCurrentOwner.current = this;
+      try {
+        renderedComponent =
+          this._renderValidatedComponentWithoutOwnerOrContext();
+      } finally {
+        ReactCurrentOwner.current = null;
+      }
+    } else {
       renderedComponent =
         this._renderValidatedComponentWithoutOwnerOrContext();
-    } finally {
-      ReactCurrentOwner.current = null;
     }
     invariant(
       // TODO: An `isValidNode` function would probably be more appropriate

--- a/src/renderers/shared/stack/reconciler/__tests__/refs-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/refs-test.js
@@ -240,5 +240,39 @@ describe('ref swapping', function() {
     var instance = ReactTestUtils.renderIntoDocument(<Component />);
     expect(!!instance.refs).toBe(true);
   });
+
+  function testRefCall() {
+    var refCalled = 0;
+    function Inner(props) {
+      return <a ref={props.saveA} />;
+    }
+    var Outer = React.createClass({
+      saveA() {
+        refCalled++;
+      },
+      componentDidMount() {
+        this.setState({});
+      },
+      render() {
+        return <Inner saveA={this.saveA} />;
+      },
+    });
+    ReactTestUtils.renderIntoDocument(<Outer />);
+    expect(refCalled).toBe(1);
+  }
+
+  it('ref called correctly for stateless component when __DEV__ = false', function() {
+    var originalDev = __DEV__;
+    __DEV__ = false;
+    testRefCall();
+    __DEV__ = originalDev;
+  });
+
+  it('ref called correctly for stateless component when __DEV__ = true', function() {
+    var originalDev = __DEV__;
+    __DEV__ = true;
+    testRefCall();
+    __DEV__ = originalDev;
+  });
 });
 


### PR DESCRIPTION
component should not have owner for both create and update lifecycle when in production.(not consistent will cause ref function call)

https://github.com/facebook/react/blob/dc6fc8cc0726458a14f0544a30514af208d0098b/src/renderers/shared/reconciler/ReactRef.js#L65