### PR TITLE
Remove deprecated function from tests

### DIFF
--- a/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -91,17 +91,17 @@ describe('ReactCompositeComponent', function() {
 
     reactComponentExpect(instance)
       .expectRenderedChild()
-      .toBeDOMComponentWithTag('a');
+      .toBeComponentOfType('a');
 
     instance._toggleActivatedState();
     reactComponentExpect(instance)
       .expectRenderedChild()
-      .toBeDOMComponentWithTag('b');
+      .toBeComponentOfType('b');
 
     instance._toggleActivatedState();
     reactComponentExpect(instance)
       .expectRenderedChild()
-      .toBeDOMComponentWithTag('a');
+      .toBeComponentOfType('a');
   });
 
   it('should not thrash a server rendered layout with client side one', () => {
@@ -134,7 +134,7 @@ describe('ReactCompositeComponent', function() {
     ReactTestUtils.Simulate.click(renderedChild);
     reactComponentExpect(instance)
       .expectRenderedChild()
-      .toBeDOMComponentWithTag('b');
+      .toBeComponentOfType('b');
   });
 
   it('should rewire refs when rendering to different child types', function() {

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponentDOMMinimalism-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponentDOMMinimalism-test.js
@@ -59,7 +59,7 @@ describe('ReactCompositeComponentDOMMinimalism', function() {
         .expectRenderedChild()
         .toBeCompositeComponentWithType(LowerLevelComposite)
           .expectRenderedChild()
-          .toBeDOMComponentWithTag('div')
+          .toBeComponentOfType('div')
           .toBeDOMComponentWithNoChildren();
     };
   });
@@ -97,10 +97,10 @@ describe('ReactCompositeComponentDOMMinimalism', function() {
       .expectRenderedChild()
       .toBeCompositeComponentWithType(LowerLevelComposite)
         .expectRenderedChild()
-        .toBeDOMComponentWithTag('div')
+        .toBeComponentOfType('div')
         .toBeDOMComponentWithChildCount(1)
         .expectRenderedChildAt(0)
-          .toBeDOMComponentWithTag('ul')
+          .toBeComponentOfType('ul')
           .toBeDOMComponentWithNoChildren();
   });
 

--- a/src/test/reactComponentExpect.js
+++ b/src/test/reactComponentExpect.js
@@ -168,16 +168,6 @@ Object.assign(reactComponentExpectInternal.prototype, {
   },
 
   /**
-   * @deprecated
-   * @see toBeComponentOfType
-   */
-  toBeDOMComponentWithTag: function(tag) {
-    this.toBeDOMComponent();
-    expect(this.instance().tagName).toBe(tag.toUpperCase());
-    return this;
-  },
-
-  /**
    * Check that internal state values are equal to a state of expected values.
    */
   scalarStateEqual: function(stateNameToExpectedValue) {


### PR DESCRIPTION
This has been deprecated since 2013 so it's about time to remove it.