### PR TITLE
Add JSDoc comment to keep license when compiling production code

### DIFF
--- a/grunt/data/header-template-extended.txt
+++ b/grunt/data/header-template-extended.txt
@@ -1,6 +1,7 @@
 /**
- * <%= package %> v<%= version %>
- *
+ * @module <%= package %>
+ * @version <%= version %>
+ * @license
  * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *

--- a/grunt/data/header-template-extended.txt
+++ b/grunt/data/header-template-extended.txt
@@ -1,6 +1,5 @@
 /**
- * @module <%= package %>
- * @version <%= version %>
+ * <%= package %> v<%= version %>
  * @license
  * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.

--- a/src/isomorphic/React.js
+++ b/src/isomorphic/React.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *


### PR DESCRIPTION
When using React in a project along with a module compiler like [webpack](https://webpack.github.io/) with [UglifyJs](https://github.com/mishoo/UglifyJS2) to remove comments in code. The current license comment in React is removed as it doesn't conform to [JSDoc](http://usejsdoc.org/) [@license](http://usejsdoc.org/tags-license.html).

I suggest this is added so the license doesnt get removed by default and so people don't have to implement a work around to keep the license in a project.
