### PR TITLE
Remove comment about PooledClass destructors being optional

### DIFF
--- a/src/shared/utils/PooledClass.js
+++ b/src/shared/utils/PooledClass.js
@@ -94,7 +94,7 @@ var DEFAULT_POOLER = oneArgumentPooler;
  * Augments `CopyConstructor` to be a poolable class, augmenting only the class
  * itself (statically) not adding any prototypical fields. Any CopyConstructor
  * you give this may have a `poolSize` property, and will look for a
- * prototypical `destructor` on instances (optional).
+ * prototypical `destructor` on instances.
  *
  * @param {Function} CopyConstructor Constructor that can be used to reset.
  * @param {Function} pooler Customizable pooler.


### PR DESCRIPTION
They are no longer optional since #4720