### PR TITLE
Fix mapFunction parameters in mapChildren's JSDoc

### DIFF
--- a/src/isomorphic/children/ReactChildren.js
+++ b/src/isomorphic/children/ReactChildren.js
@@ -146,7 +146,7 @@ function mapIntoWithKeyPrefixInternal(children, array, prefix, func, context) {
 /**
  * Maps children that are typically specified as `props.children`.
  *
- * The provided mapFunction(child, key, index) will be called for each
+ * The provided mapFunction(child, index) will be called for each
  * leaf child.
  *
  * @param {?*} children Children tree container.


### PR DESCRIPTION
Remove `key` parameter from `mapFunction(child, key, index)`. It is no longer called with `key`.