### PR TITLE
Fix return type in onlyChild's JSDoc

### DIFF
--- a/src/isomorphic/children/onlyChild.js
+++ b/src/isomorphic/children/onlyChild.js
@@ -22,7 +22,7 @@ var invariant = require('invariant');
  * of children.
  *
  * @param {?object} children Child collection structure.
- * @return {ReactComponent} The first and only `ReactComponent` contained in the
+ * @return {ReactElement} The first and only `ReactElement` contained in the
  * structure.
  */
 function onlyChild(children) {


### PR DESCRIPTION
The return type is a `ReactElement` instead of a `ReactComponent`.