### PR TITLE
Ignore events fired on missing React Native instances

### DIFF
--- a/src/renderers/native/ReactNative/ReactNativeEventEmitter.js
+++ b/src/renderers/native/ReactNative/ReactNativeEventEmitter.js
@@ -120,6 +120,11 @@ var ReactNativeEventEmitter = merge(ReactEventEmitterMixin, {
   ) {
     var nativeEvent = nativeEventParam || EMPTY_NATIVE_EVENT;
     var inst = ReactNativeComponentTree.getInstanceFromNode(rootNodeID);
+    if (!inst) {
+      // If the original instance is already gone, we don't have to dispatch
+      // any events.
+      return;
+    }
     ReactUpdates.batchedUpdates(function() {
       ReactNativeEventEmitter.handleTopLevel(
         topLevelType,


### PR DESCRIPTION
This can happen if something gets unmounted before the event gets
dispatched. I'm not sure how this works out exactly but this
preserves previous behavior in this scenario.