### PR TITLE
Change warning text: 'a uncontrolled' --> 'an uncontrolled'

### DIFF
--- a/docs/js/react.js
+++ b/docs/js/react.js
@@ -7966,7 +7966,7 @@ var ReactDOMInput = {
       var owner = inst._currentElement._owner;
 
       if ((initialValue || !inst._wrapperState.controlled) && controlled && !didWarnUncontrolledToControlled) {
-        "development" !== 'production' ? warning(false, '%s is changing a uncontrolled input of type %s to be controlled. ' + 'Input elements should not switch from uncontrolled to controlled (or vice versa). ' + 'Decide between using a controlled or uncontrolled input ' + 'element for the lifetime of the component. More info: https://fb.me/react-controlled-components', owner && owner.getName() || 'A component', props.type) : void 0;
+        "development" !== 'production' ? warning(false, '%s is changing an uncontrolled input of type %s to be controlled. ' + 'Input elements should not switch from uncontrolled to controlled (or vice versa). ' + 'Decide between using a controlled or uncontrolled input ' + 'element for the lifetime of the component. More info: https://fb.me/react-controlled-components', owner && owner.getName() || 'A component', props.type) : void 0;
         didWarnUncontrolledToControlled = true;
       }
       if (inst._wrapperState.controlled && (defaultValue || !controlled) && !didWarnControlledToUncontrolled) {

--- a/src/renderers/dom/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMInput.js
@@ -177,7 +177,7 @@ var ReactDOMInput = {
       ) {
         warning(
           false,
-          '%s is changing a uncontrolled input of type %s to be controlled. ' +
+          '%s is changing an uncontrolled input of type %s to be controlled. ' +
           'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
           'Decide between using a controlled or uncontrolled input ' +
           'element for the lifetime of the component. More info: https://fb.me/react-controlled-components',

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
@@ -499,7 +499,7 @@ describe('ReactDOMInput', function() {
     ReactDOM.render(<input type="text" value="controlled" />, container);
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toContain(
-      'A component is changing a uncontrolled input of type text to be controlled. ' +
+      'A component is changing an uncontrolled input of type text to be controlled. ' +
       'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
       'Decide between using a controlled or uncontrolled input ' +
       'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
@@ -541,7 +541,7 @@ describe('ReactDOMInput', function() {
     ReactDOM.render(<input type="checkbox" checked={true} />, container);
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toContain(
-      'A component is changing a uncontrolled input of type checkbox to be controlled. ' +
+      'A component is changing an uncontrolled input of type checkbox to be controlled. ' +
       'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
       'Decide between using a controlled or uncontrolled input ' +
       'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
@@ -583,7 +583,7 @@ describe('ReactDOMInput', function() {
     ReactDOM.render(<input type="radio" checked={true} />, container);
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toContain(
-      'A component is changing a uncontrolled input of type radio to be controlled. ' +
+      'A component is changing an uncontrolled input of type radio to be controlled. ' +
       'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
       'Decide between using a controlled or uncontrolled input ' +
       'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'


### PR DESCRIPTION
Changes new React 15 warning regarding controlled component status switching to properly use "an" rather than "a" before "uncontrolled," which begins with a vowel sound.