### PR TITLE
Add note on how to submit a form

### DIFF
--- a/docs/docs/07-forms.md
+++ b/docs/docs/07-forms.md
@@ -166,3 +166,8 @@ To make an uncontrolled component, `defaultValue` is used instead.
 > Note:
 >
 > You can pass an array into the `value` attribute, allowing you to select multiple options in a `select` tag: `<select multiple={true} value={['B', 'C']}>`.
+
+### Imperative operations
+
+If you need to imperatively perform an operation, you have to obtain a [reference to the DOM node](/react/docs/more-about-refs.html#the-ref-callback-attribute).
+For instance, if you want to imperatively submit a form, one approach would be to attach a `ref` to the `form` element and manually call `form.submit()`.


### PR DESCRIPTION
This is just me overthinking it coming from jQuery, but googling how to submit a form gave me nothing, so I thought I'd add this.

Our use case was solved when I took a step back and just put a submit button into the form (which is why I included that example as well), but I can see use cases for programmatically doing it, in all cases when a form is submitted without user input, or at least where the input is not pressing a button/link. And as mentioned, googling didn't give me anything.