### PR TITLE
Add basic issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,9 @@
+**Do you want to request a *feature* or report a *bug*?**
+
+**What is the current behavior?**
+
+**If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem via https://jsfiddle.net or similar (template: https://jsfiddle.net/reactjs/69z2wepo/).**
+
+**What is the expected behavior?**
+
+**Which versions of React, and which browser / OS are affected by this issue? Did this work in previous versions of React?**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+*Before* submitting a pull request, please make sure the following is done...
+
+1. Fork the repo and create your branch from `master`.
+2. If you've added code that should be tested, add tests!
+3. If you've changed APIs, update the documentation.
+4. Ensure the test suite passes (`grunt test`).
+5. Make sure your code lints (`grunt lint`) - we've done our best to make sure these rules match our internal linting guidelines.
+6. If you haven't already, complete the [CLA](https://code.facebook.com/cla).


### PR DESCRIPTION
Happy to discuss and tweak the templates, as desired. This PR is more to get the general subject of adding GitHub issue and PR templates on the table.

I adapted the issue template from the [Angular](https://github.com/angular/angular.js/blob/master/.github/ISSUE_TEMPLATE.md) one, and adapted the PR template from the PR guidelines in CONTRIBUTING.md.