### PR TITLE
Ensure babelrc file gets packaged for starter kit

### DIFF
--- a/grunt/tasks/release.js
+++ b/grunt/tasks/release.js
@@ -16,7 +16,7 @@ var BOWER_FILES = [
 ];
 
 var EXAMPLES_PATH = 'examples/';
-var EXAMPLES_GLOB = [EXAMPLES_PATH + '**/*.*'];
+var EXAMPLES_GLOB = [EXAMPLES_PATH + '**/*.*', EXAMPLES_PATH + '**/.babelrc'];
 
 var STARTER_PATH = 'starter/';
 var STARTER_GLOB = [STARTER_PATH + '/**/*.*'];


### PR DESCRIPTION
This will make it so that npm install && npm run build will actually work in the compiled starter kit. It was only tested in the path in the repo previously.