### PR TITLE
Update to Jest 12. Codemod to new Jest APIs.

### DIFF
--- a/grunt/tasks/jest.js
+++ b/grunt/tasks/jest.js
@@ -77,7 +77,7 @@ function writeTempConfig(callback) {
 function run(done, configPath) {
   grunt.log.writeln('running jest (this may take a while)');
 
-  var args = ['--harmony', path.join('node_modules', 'jest-cli', 'bin', 'jest')];
+  var args = ['--harmony', path.join('node_modules', 'jest-cli', 'bin', 'jest'), '--runInBand'];
   if (configPath) {
     args.push('--config', configPath);
   }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "gulp-babel": "^6.0.0",
     "gulp-flatten": "^0.2.0",
     "gzip-js": "~0.3.2",
-    "jest-cli": "^0.9.0",
+    "jest-cli": "^12.0.2",
     "loose-envify": "^1.1.0",
     "object-assign": "^4.0.1",
     "platform": "^1.1.0",

--- a/src/core/__tests__/ReactErrorBoundaries-test.js
+++ b/src/core/__tests__/ReactErrorBoundaries-test.js
@@ -50,7 +50,7 @@ describe('ReactErrorBoundaries', function() {
 
     var EventPluginHub = require('EventPluginHub');
     var container = document.createElement('div');
-    EventPluginHub.putListener = jest.genMockFn();
+    EventPluginHub.putListener = jest.fn();
     ReactDOM.render(<Boundary />, container);
     expect(EventPluginHub.putListener).not.toBeCalled();
   });
@@ -120,7 +120,7 @@ describe('ReactErrorBoundaries', function() {
 
     var EventPluginHub = require('EventPluginHub');
     var container = document.createElement('div');
-    EventPluginHub.putListener = jest.genMockFn();
+    EventPluginHub.putListener = jest.fn();
     ReactDOM.render(<Boundary />, container);
     expect(EventPluginHub.putListener).toBeCalled();
   });

--- a/src/isomorphic/classic/class/__tests__/ReactBind-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactBind-test.js
@@ -20,9 +20,9 @@ describe('autobinding', function() {
 
   it('Holds reference to instance', function() {
 
-    var mouseDidEnter = jest.genMockFn();
-    var mouseDidLeave = jest.genMockFn();
-    var mouseDidClick = jest.genMockFn();
+    var mouseDidEnter = jest.fn();
+    var mouseDidLeave = jest.fn();
+    var mouseDidClick = jest.fn();
 
     var TestBindComponent = React.createClass({
       getInitialState: function() {
@@ -95,7 +95,7 @@ describe('autobinding', function() {
   });
 
   it('works with mixins', function() {
-    var mouseDidClick = jest.genMockFn();
+    var mouseDidClick = jest.fn();
 
     var TestMixin = {
       onClick: mouseDidClick,

--- a/src/isomorphic/classic/class/__tests__/ReactBindOptout-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactBindOptout-test.js
@@ -20,9 +20,9 @@ describe('autobind optout', function() {
 
   it('should work with manual binding', function() {
 
-    var mouseDidEnter = jest.genMockFn();
-    var mouseDidLeave = jest.genMockFn();
-    var mouseDidClick = jest.genMockFn();
+    var mouseDidEnter = jest.fn();
+    var mouseDidLeave = jest.fn();
+    var mouseDidClick = jest.fn();
 
     var TestBindComponent = React.createClass({
       autobind: false,
@@ -138,7 +138,7 @@ describe('autobind optout', function() {
   });
 
   it('works with mixins that have not opted out of autobinding', function() {
-    var mouseDidClick = jest.genMockFn();
+    var mouseDidClick = jest.fn();
 
     var TestMixin = {
       onClick: mouseDidClick,
@@ -164,7 +164,7 @@ describe('autobind optout', function() {
   });
 
   it('works with mixins that have opted out of autobinding', function() {
-    var mouseDidClick = jest.genMockFn();
+    var mouseDidClick = jest.fn();
 
     var TestMixin = {
       autobind: false,

--- a/src/isomorphic/classic/class/__tests__/ReactClass-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactClass-test.js
@@ -43,7 +43,7 @@ describe('ReactClass-spec', function() {
   });
 
   it('should copy prop types onto the Constructor', function() {
-    var propValidator = jest.genMockFn();
+    var propValidator = jest.fn();
     var TestComponent = React.createClass({
       propTypes: {
         value: propValidator,

--- a/src/isomorphic/classic/class/__tests__/ReactClassMixin-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactClassMixin-test.js
@@ -25,8 +25,8 @@ describe('ReactClass-mixin', function() {
   beforeEach(function() {
     React = require('React');
     ReactTestUtils = require('ReactTestUtils');
-    mixinPropValidator = jest.genMockFn();
-    componentPropValidator = jest.genMockFn();
+    mixinPropValidator = jest.fn();
+    componentPropValidator = jest.fn();
 
     var MixinA = {
       propTypes: {
@@ -107,7 +107,7 @@ describe('ReactClass-mixin', function() {
   });
 
   it('should support merging propTypes and statics', function() {
-    var listener = jest.genMockFn();
+    var listener = jest.fn();
     var instance = <TestComponent listener={listener} />;
     instance = ReactTestUtils.renderIntoDocument(instance);
 
@@ -122,7 +122,7 @@ describe('ReactClass-mixin', function() {
   });
 
   it('should support chaining delegate functions', function() {
-    var listener = jest.genMockFn();
+    var listener = jest.fn();
     var instance = <TestComponent listener={listener} />;
     instance = ReactTestUtils.renderIntoDocument(instance);
 
@@ -135,7 +135,7 @@ describe('ReactClass-mixin', function() {
   });
 
   it('should chain functions regardless of spec property order', function() {
-    var listener = jest.genMockFn();
+    var listener = jest.fn();
     var instance = <TestComponentWithReverseSpec listener={listener} />;
     instance = ReactTestUtils.renderIntoDocument(instance);
 

--- a/src/renderers/dom/client/__tests__/ReactBrowserEventEmitter-test.js
+++ b/src/renderers/dom/client/__tests__/ReactBrowserEventEmitter-test.js
@@ -35,7 +35,7 @@ var recordIDAndReturnFalse = function(id, event) {
   recordID(id);
   return false;
 };
-var LISTENER = jest.genMockFn();
+var LISTENER = jest.fn();
 var ON_CLICK_KEY = keyOf({onClick: null});
 var ON_TOUCH_TAP_KEY = keyOf({onTouchTap: null});
 var ON_CHANGE_KEY = keyOf({onChange: null});
@@ -284,7 +284,7 @@ describe('ReactBrowserEventEmitter', function() {
    */
 
   it('should invoke handlers that were removed while bubbling', function() {
-    var handleParentClick = jest.genMockFn();
+    var handleParentClick = jest.fn();
     var handleChildClick = function(event) {
       EventPluginHub.deleteAllListeners(getInternal(PARENT));
     };
@@ -303,7 +303,7 @@ describe('ReactBrowserEventEmitter', function() {
   });
 
   it('should not invoke newly inserted handlers while bubbling', function() {
-    var handleParentClick = jest.genMockFn();
+    var handleParentClick = jest.fn();
     var handleChildClick = function(event) {
       EventPluginHub.putListener(
         getInternal(PARENT),

--- a/src/renderers/dom/client/__tests__/ReactEventListener-test.js
+++ b/src/renderers/dom/client/__tests__/ReactEventListener-test.js
@@ -30,7 +30,7 @@ describe('ReactEventListener', function() {
     ReactEventListener = require('ReactEventListener');
     ReactTestUtils = require('ReactTestUtils');
 
-    handleTopLevel = jest.genMockFn();
+    handleTopLevel = jest.fn();
     ReactEventListener._handleTopLevel = handleTopLevel;
   });
 

--- a/src/renderers/dom/client/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMount-test.js
@@ -87,8 +87,8 @@ describe('ReactMount', function() {
   it('should unmount and remount if the key changes', function() {
     var container = document.createElement('container');
 
-    var mockMount = jest.genMockFn();
-    var mockUnmount = jest.genMockFn();
+    var mockMount = jest.fn();
+    var mockUnmount = jest.fn();
 
     var Component = React.createClass({
       componentDidMount: mockMount,

--- a/src/renderers/dom/client/eventPlugins/__tests__/SelectEventPlugin-test.js
+++ b/src/renderers/dom/client/eventPlugins/__tests__/SelectEventPlugin-test.js
@@ -66,7 +66,7 @@ describe('SelectEventPlugin', function() {
       },
     });
 
-    var cb = jest.genMockFn();
+    var cb = jest.fn();
 
     var rendered = ReactTestUtils.renderIntoDocument(
       <WithSelect onSelect={cb} />

--- a/src/renderers/dom/client/wrappers/__tests__/DisabledInputUtil-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/DisabledInputUtil-test.js
@@ -36,7 +36,7 @@ describe('DisabledInputUtils', function() {
     return element;
   }
 
-  var onClick = jest.genMockFn();
+  var onClick = jest.fn();
 
   elements.forEach(function(tagName) {
 

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
@@ -245,7 +245,7 @@ describe('ReactDOMInput', function() {
   });
 
   it('should support ReactLink', function() {
-    var link = new ReactLink('yolo', jest.genMockFn());
+    var link = new ReactLink('yolo', jest.fn());
     var instance = <input type="text" valueLink={link} />;
 
     instance = ReactTestUtils.renderIntoDocument(instance);
@@ -262,7 +262,7 @@ describe('ReactDOMInput', function() {
   });
 
   it('should warn with value and no onChange handler', function() {
-    var link = new ReactLink('yolo', jest.genMockFn());
+    var link = new ReactLink('yolo', jest.fn());
     ReactTestUtils.renderIntoDocument(<input type="text" valueLink={link} />);
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toContain(
@@ -270,7 +270,7 @@ describe('ReactDOMInput', function() {
     );
 
     ReactTestUtils.renderIntoDocument(
-      <input type="text" value="zoink" onChange={jest.genMockFn()} />
+      <input type="text" value="zoink" onChange={jest.fn()} />
     );
     expect(console.error.argsForCall.length).toBe(1);
     ReactTestUtils.renderIntoDocument(<input type="text" value="zoink" />);
@@ -302,7 +302,7 @@ describe('ReactDOMInput', function() {
 
   it('should throw if both value and valueLink are provided', function() {
     var node = document.createElement('div');
-    var link = new ReactLink('yolo', jest.genMockFn());
+    var link = new ReactLink('yolo', jest.fn());
     var instance = <input type="text" valueLink={link} />;
 
     expect(() => ReactDOM.render(instance, node)).not.toThrow();
@@ -322,7 +322,7 @@ describe('ReactDOMInput', function() {
   });
 
   it('should support checkedLink', function() {
-    var link = new ReactLink(true, jest.genMockFn());
+    var link = new ReactLink(true, jest.fn());
     var instance = <input type="checkbox" checkedLink={link} />;
 
     instance = ReactTestUtils.renderIntoDocument(instance);
@@ -340,7 +340,7 @@ describe('ReactDOMInput', function() {
 
   it('should warn with checked and no onChange handler', function() {
     var node = document.createElement('div');
-    var link = new ReactLink(true, jest.genMockFn());
+    var link = new ReactLink(true, jest.fn());
     ReactDOM.render(<input type="checkbox" checkedLink={link} />, node);
     expect(console.error.argsForCall.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toContain(
@@ -351,7 +351,7 @@ describe('ReactDOMInput', function() {
       <input
         type="checkbox"
         checked="false"
-        onChange={jest.genMockFn()}
+        onChange={jest.fn()}
       />
     );
     expect(console.error.argsForCall.length).toBe(1);
@@ -379,7 +379,7 @@ describe('ReactDOMInput', function() {
 
   it('should throw if both checked and checkedLink are provided', function() {
     var node = document.createElement('div');
-    var link = new ReactLink(true, jest.genMockFn());
+    var link = new ReactLink(true, jest.fn());
     var instance = <input type="checkbox" checkedLink={link} />;
 
     expect(() => ReactDOM.render(instance, node)).not.toThrow();
@@ -401,7 +401,7 @@ describe('ReactDOMInput', function() {
 
   it('should throw if both checkedLink and valueLink are provided', function() {
     var node = document.createElement('div');
-    var link = new ReactLink(true, jest.genMockFn());
+    var link = new ReactLink(true, jest.fn());
     var instance = <input type="checkbox" checkedLink={link} />;
 
     expect(() => ReactDOM.render(instance, node)).not.toThrow();

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMSelect-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMSelect-test.js
@@ -348,7 +348,7 @@ describe('ReactDOMSelect', function() {
   });
 
   it('should support ReactLink', function() {
-    var link = new ReactLink('giraffe', jest.genMockFn());
+    var link = new ReactLink('giraffe', jest.fn());
     var stub =
       <select valueLink={link}>
         <option value="monkey">A monkey!</option>

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMTextarea-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMTextarea-test.js
@@ -237,7 +237,7 @@ describe('ReactDOMTextarea', function() {
   });
 
   it('should support ReactLink', function() {
-    var link = new ReactLink('yolo', jest.genMockFn());
+    var link = new ReactLink('yolo', jest.fn());
     var instance = <textarea valueLink={link} />;
 
     spyOn(console, 'error');

--- a/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
@@ -86,7 +86,7 @@ describe('ReactServerRendering', function() {
 
     it('should not register event listeners', function() {
       var EventPluginHub = require('EventPluginHub');
-      var cb = jest.genMockFn();
+      var cb = jest.fn();
 
       ReactServerRendering.renderToString(
         <span onClick={cb}>hello world</span>
@@ -303,7 +303,7 @@ describe('ReactServerRendering', function() {
 
     it('should not register event listeners', function() {
       var EventPluginHub = require('EventPluginHub');
-      var cb = jest.genMockFn();
+      var cb = jest.fn();
 
       ReactServerRendering.renderToString(
         <span onClick={cb}>hello world</span>

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -259,7 +259,7 @@ describe('DOMPropertyOperations', function() {
     });
 
     it('should use mutation method where applicable', function() {
-      var foobarSetter = jest.genMockFn();
+      var foobarSetter = jest.fn();
       // inject foobar DOM property
       DOMProperty.injection.injectDOMPropertyConfig({
         Properties: {foobar: null},

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -450,11 +450,11 @@ describe('ReactDOMComponent', function() {
 
       var node = container.firstChild;
       var nodeSetAttribute = node.setAttribute;
-      node.setAttribute = jest.genMockFn();
+      node.setAttribute = jest.fn();
       node.setAttribute.mockImpl(nodeSetAttribute);
 
       var nodeRemoveAttribute = node.removeAttribute;
-      node.removeAttribute = jest.genMockFn();
+      node.removeAttribute = jest.fn();
       node.removeAttribute.mockImpl(nodeRemoveAttribute);
 
       ReactDOM.render(<div id="" />, container);
@@ -488,7 +488,7 @@ describe('ReactDOMComponent', function() {
 
       var node = container.firstChild;
       var nodeValue = ''; // node.value always returns undefined
-      var nodeValueSetter = jest.genMockFn();
+      var nodeValueSetter = jest.fn();
       Object.defineProperty(node, 'value', {
         get: function() {
           return nodeValue;
@@ -519,7 +519,7 @@ describe('ReactDOMComponent', function() {
 
       var node = container.firstChild;
       var nodeValue = true;
-      var nodeValueSetter = jest.genMockFn();
+      var nodeValueSetter = jest.fn();
       Object.defineProperty(node, 'checked', {
         get: function() {
           return nodeValue;
@@ -552,7 +552,7 @@ describe('ReactDOMComponent', function() {
       var container = document.createElement('div');
       var node = ReactDOM.render(<div />, container);
 
-      var setter = jest.genMockFn();
+      var setter = jest.fn();
       node.setAttribute = setter;
 
       ReactDOM.render(<div dir={null} />, container);
@@ -839,8 +839,8 @@ describe('ReactDOMComponent', function() {
     it('should execute custom event plugin listening behavior', function() {
       var SimpleEventPlugin = require('SimpleEventPlugin');
 
-      SimpleEventPlugin.didPutListener = jest.genMockFn();
-      SimpleEventPlugin.willDeleteListener = jest.genMockFn();
+      SimpleEventPlugin.didPutListener = jest.fn();
+      SimpleEventPlugin.willDeleteListener = jest.fn();
 
       var container = document.createElement('div');
       ReactDOM.render(
@@ -858,8 +858,8 @@ describe('ReactDOMComponent', function() {
     it('should handle null and missing properly with event hooks', function() {
       var SimpleEventPlugin = require('SimpleEventPlugin');
 
-      SimpleEventPlugin.didPutListener = jest.genMockFn();
-      SimpleEventPlugin.willDeleteListener = jest.genMockFn();
+      SimpleEventPlugin.didPutListener = jest.fn();
+      SimpleEventPlugin.willDeleteListener = jest.fn();
       var container = document.createElement('div');
 
       ReactDOM.render(<div onClick={false} />, container);

--- a/src/renderers/native/ReactNative/__mocks__/UIManager.js
+++ b/src/renderers/native/ReactNative/__mocks__/UIManager.js
@@ -12,10 +12,10 @@
 // Mock of the Native Hooks
 
 var RCTUIManager = {
-  createView: jest.genMockFunction(),
-  setChildren: jest.genMockFunction(),
-  manageChildren: jest.genMockFunction(),
-  updateView: jest.genMockFunction(),
+  createView: jest.fn(),
+  setChildren: jest.fn(),
+  manageChildren: jest.fn(),
+  updateView: jest.fn(),
 };
 
 module.exports = RCTUIManager;

--- a/src/renderers/native/ReactNative/__tests__/ReactNativeAttributePayload-test.js
+++ b/src/renderers/native/ReactNative/__tests__/ReactNativeAttributePayload-test.js
@@ -9,8 +9,8 @@
  */
 'use strict';
 
-jest.dontMock('ReactNativeAttributePayload');
-jest.dontMock('ReactNativePropRegistry');
+jest.unmock('ReactNativeAttributePayload');
+jest.unmock('ReactNativePropRegistry');
 // jest.dontMock('deepDiffer');
 // jest.dontMock('flattenStyle');
 
@@ -62,8 +62,8 @@ describe('ReactNativeAttributePayload', function() {
   });
 
   it('should use the diff attribute', () => {
-    var diffA = jest.genMockFunction().mockImpl((a, b) => true);
-    var diffB = jest.genMockFunction().mockImpl((a, b) => false);
+    var diffA = jest.fn((a, b) => true);
+    var diffB = jest.fn((a, b) => false);
     expect(diff(
       {a: [1], b: [3]},
       {a: [2], b: [4]},
@@ -74,8 +74,8 @@ describe('ReactNativeAttributePayload', function() {
   });
 
   it('should not use the diff attribute on addition/removal', () => {
-    var diffA = jest.genMockFunction();
-    var diffB = jest.genMockFunction();
+    var diffA = jest.fn();
+    var diffB = jest.fn();
     expect(diff(
       {a: [1]},
       {b: [2]},

--- a/src/renderers/shared/event/__tests__/EventPluginHub-test.js
+++ b/src/renderers/shared/event/__tests__/EventPluginHub-test.js
@@ -12,7 +12,7 @@
 'use strict';
 
 jest
-  .dontMock('EventPluginHub')
+  .unmock('EventPluginHub')
   .mock('isEventSupported');
 
 describe('EventPluginHub', function() {

--- a/src/renderers/shared/reconciler/__tests__/ReactComponent-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactComponent-test.js
@@ -255,7 +255,7 @@ describe('ReactComponent', function() {
   });
 
   it('fires the callback after a component is rendered', function() {
-    var callback = jest.genMockFn();
+    var callback = jest.fn();
     var container = document.createElement('div');
     ReactDOM.render(<div />, container, callback);
     expect(callback.mock.calls.length).toBe(1);

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentNestedState-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentNestedState-test.js
@@ -90,7 +90,7 @@ describe('ReactCompositeComponentNestedState-state', function() {
     var container = document.createElement('div');
     document.body.appendChild(container);
 
-    var logger = jest.genMockFn();
+    var logger = jest.fn();
 
     void ReactDOM.render(
       <ParentComponent logger={logger} />,

--- a/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentState-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactCompositeComponentState-test.js
@@ -130,7 +130,7 @@ describe('ReactCompositeComponent-state', function() {
     var container = document.createElement('div');
     document.body.appendChild(container);
 
-    var stateListener = jest.genMockFn();
+    var stateListener = jest.fn();
     var instance = ReactDOM.render(
       <TestComponent stateListener={stateListener} />,
       container,

--- a/src/renderers/shared/reconciler/__tests__/ReactMultiChild-test.js
+++ b/src/renderers/shared/reconciler/__tests__/ReactMultiChild-test.js
@@ -26,9 +26,9 @@ describe('ReactMultiChild', function() {
     it('should update children when possible', function() {
       var container = document.createElement('div');
 
-      var mockMount = jest.genMockFn();
-      var mockUpdate = jest.genMockFn();
-      var mockUnmount = jest.genMockFn();
+      var mockMount = jest.fn();
+      var mockUpdate = jest.fn();
+      var mockUnmount = jest.fn();
 
       var MockComponent = React.createClass({
         componentDidMount: mockMount,
@@ -59,8 +59,8 @@ describe('ReactMultiChild', function() {
     it('should replace children with different constructors', function() {
       var container = document.createElement('div');
 
-      var mockMount = jest.genMockFn();
-      var mockUnmount = jest.genMockFn();
+      var mockMount = jest.fn();
+      var mockUnmount = jest.fn();
 
       var MockComponent = React.createClass({
         componentDidMount: mockMount,
@@ -87,8 +87,8 @@ describe('ReactMultiChild', function() {
     it('should NOT replace children with different owners', function() {
       var container = document.createElement('div');
 
-      var mockMount = jest.genMockFn();
-      var mockUnmount = jest.genMockFn();
+      var mockMount = jest.fn();
+      var mockUnmount = jest.fn();
 
       var MockComponent = React.createClass({
         componentDidMount: mockMount,
@@ -124,8 +124,8 @@ describe('ReactMultiChild', function() {
     it('should replace children with different keys', function() {
       var container = document.createElement('div');
 
-      var mockMount = jest.genMockFn();
-      var mockUnmount = jest.genMockFn();
+      var mockMount = jest.fn();
+      var mockUnmount = jest.fn();
 
       var MockComponent = React.createClass({
         componentDidMount: mockMount,

--- a/src/shared/utils/__tests__/accumulateInto-test.js
+++ b/src/shared/utils/__tests__/accumulateInto-test.js
@@ -12,7 +12,7 @@
 'use strict';
 
 jest
-  .dontMock('accumulateInto');
+  .unmock('accumulateInto');
 
 var accumulateInto;
 

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -89,7 +89,7 @@ describe('ReactTestUtils', function() {
   });
 
   it('should have shallow unmounting', function() {
-    var componentWillUnmount = jest.genMockFn();
+    var componentWillUnmount = jest.fn();
 
     var SomeComponent = React.createClass({
       render: function() {


### PR DESCRIPTION
There is one test failing right now. Pretty sure it is because we updated to jsdom 8. Will look into this tomorrow unless anyone has some ideas – seems like the multiple defaultValues test is failing in ReactDOMSelect – is this a bug in React or jsdom?