### PR TITLE
Cleaner way to declare the mixin noop

### DIFF
--- a/src/isomorphic/React.js
+++ b/src/isomorphic/React.js
@@ -73,10 +73,8 @@ var React = {
   PropTypes: ReactPropTypes,
   createClass: ReactClass.createClass,
   createFactory: createFactory,
-  createMixin: function(mixin) {
-    // Currently a noop. Will be used to validate and trace mixins.
-    return mixin;
-  },
+  //Currently a noop. Will be used to validate and trace mixins.
+  createMixin: () => mixin,
 
   // This looks DOM specific but these are actually isomorphic helpers
   // since they are just generating DOM strings.


### PR DESCRIPTION
Cleaner way to declare the mixin noop in one line

Contradicts code style a bit, but it pays off in terms of clean, structured code.