### PR TITLE
Integrated warning on returning null

### DIFF
--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -778,8 +778,11 @@ var ReactClass = {
         // We allow auto-mocks to proceed as if they're returning null.
         if (initialState === undefined &&
             this.getInitialState._isMockFunction) {
-          // This is probably bad practice. Consider warning here and
-          // deprecating this convenience.
+          warning(
+            typeof initialState === 'object' && initialState == null && !Array.isArray(initialState),
+             '%s.getInitialState(): should return an object, instead returned null',
+             Constructor.displayName || 'ReactCompositeComponent'
+             );
           initialState = null;
         }
       }


### PR DESCRIPTION
## Warns if user returns null to initialstate ( hopefully )

### Things I don't know about this PR.

- **Integration with jest**
- **If we should warn at all**

***

- [ ] check if the equal comparison is correct. 

- [ ] Integrate unit test / manually test this? 

_Feel free to close this PR if this change is not appropriate( @jimfb )_ 😆 