### PR TITLE
Update Jest’s grunt task.

### DIFF
--- a/grunt/tasks/jest.js
+++ b/grunt/tasks/jest.js
@@ -1,9 +1,3 @@
-// We run our own grunt task instead of using grunt-jest so that we can have
-// more control. Specifically we want to set NODE_ENV and make sure stdio is
-// inherited. We also run with --harmony directly so that we don't have to
-// respawn immediately. We should be able to reduce some of this complexity
-// when jest 0.5 is run on top of iojs.
-
 'use strict';
 
 var async = require('async');
@@ -52,8 +46,10 @@ function getJestConfig(callback) {
   getCollectCoverageOnlyFrom(function(err, data) {
     callback(err, Object.assign({}, config, {
       rootDir: rootDir,
+      name: 'react',
       collectCoverage: true,
       collectCoverageOnlyFrom: data,
+      watchman: false,
     }));
   });
 }
@@ -75,9 +71,9 @@ function writeTempConfig(callback) {
 }
 
 function run(done, configPath) {
-  grunt.log.writeln('running jest (this may take a while)');
+  grunt.log.writeln('running jest');
 
-  var args = ['--harmony', path.join('node_modules', 'jest-cli', 'bin', 'jest'), '--runInBand'];
+  var args = [path.join('node_modules', 'jest-cli', 'bin', 'jest'), '--runInBand'];
   if (configPath) {
     args.push('--config', configPath);
   }


### PR DESCRIPTION
Jest had one minor behavior change in that it now always demands a `name` for a config file. This is not part of the `jest` object from package.json and we do some config copying in react (which I didn't know) so I broke travis. This should help fix it.