### PR TITLE
Accept a Node engine of version 6.X.X

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "uglifyify": "^3.0.1"
   },
   "devEngines": {
-    "node": "4.x || 5.x",
+    "node": "4.x || 5.x || 6.x",
     "npm": "2.x || 3.x"
   },
   "commonerConfig": {


### PR DESCRIPTION
This should fix #6644 -- I ran the test suite with Node v6.0.0 and NPM v3.8.6, all the tests were passing.
Thanks in advance!