### PR TITLE
Update shallowCompare to accept nextContext

### DIFF
--- a/src/addons/ReactComponentWithPureRenderMixin.js
+++ b/src/addons/ReactComponentWithPureRenderMixin.js
@@ -38,8 +38,8 @@ var shallowCompare = require('shallowCompare');
  * use `forceUpdate()` when you know deep data structures have changed.
  */
 var ReactComponentWithPureRenderMixin = {
-  shouldComponentUpdate: function(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
+  shouldComponentUpdate: function(nextProps, nextState, nextContext) {
+    return shallowCompare(this, nextProps, nextState, nextContext);
   },
 };
 

--- a/src/addons/shallowCompare.js
+++ b/src/addons/shallowCompare.js
@@ -21,7 +21,7 @@ function shallowCompare(instance, nextProps, nextState, nextContext) {
   return (
     !shallowEqual(instance.props, nextProps) ||
     !shallowEqual(instance.state, nextState) ||
-    (typeof nextContext !== 'undefined' && !shallowEqual(instance.context, nextContext))
+    !shallowEqual(instance.context, nextContext)
   );
 }
 


### PR DESCRIPTION
Across our application we are using immutable objects as properties and thus using shallowCompare for all our `shouldComponentUpdate`.  Because of this children with contextTypes don't get updates when the context on the parent changes.  Adding an additional comparison for context (when it is provided) fixes this problem.