### PR TITLE
Add test logic to test events when rendering on top of SSR markup

### DIFF
--- a/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
@@ -232,9 +232,15 @@ describe('ReactServerRendering', function() {
       ExecutionEnvironment.canUseDOM = true;
       element.innerHTML = lastMarkup;
 
-      ReactDOM.render(<TestComponent name="x" />, element);
+      var instance = ReactDOM.render(<TestComponent name="x" />, element);
       expect(mountCount).toEqual(3);
       expect(element.innerHTML).toBe(lastMarkup);
+
+      // Ensure the events system works after mount into server markup
+      expect(numClicks).toEqual(0);
+      ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(instance.refs.span));
+      expect(numClicks).toEqual(1);
+
       ReactDOM.unmountComponentAtNode(element);
       expect(element.innerHTML).toEqual('');
 
@@ -242,16 +248,16 @@ describe('ReactServerRendering', function() {
       // warn but do the right thing.
       element.innerHTML = lastMarkup;
       spyOn(console, 'error');
-      var instance = ReactDOM.render(<TestComponent name="y" />, element);
+      instance = ReactDOM.render(<TestComponent name="y" />, element);
       expect(mountCount).toEqual(4);
       expect(console.error.argsForCall.length).toBe(1);
       expect(element.innerHTML.length > 0).toBe(true);
       expect(element.innerHTML).not.toEqual(lastMarkup);
 
-      // Ensure the events system works
-      expect(numClicks).toEqual(0);
-      ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(instance.refs.span));
+      // Ensure the events system works after markup mismatch.
       expect(numClicks).toEqual(1);
+      ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(instance.refs.span));
+      expect(numClicks).toEqual(2);
     });
 
     it('should throw with silly args', function() {


### PR DESCRIPTION
In the middle of working on #6618, I broke all events when rendering on top of server-generated markup, but no unit test failed. I looked into it, and I think that there is a test case that is intended to test this, but it has a bug. This PR attempts to fix that.

The test `should have the correct mounting behavior` in `ReactServerRendering-test.js` runs through a bunch of cases with client rendering and server-generated markup, and at the end, it tests a simple click event to make sure that events work on the client. Unfortunately, what it does right before that is test out a markup mismatch. This means that the client-generated rendering at that point did not actually follow the SSR code path; it found a checksum mismatch and then followed the non-SSR/useCreateElement code path.

This is a pretty simple PR that tests the click event after the test renders on top of server-generated markup and **doesn't** get a markup mismatch.

Thanks!