### PR TITLE
Don't warn when style value is '0'

### DIFF
--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -190,6 +190,18 @@ describe('ReactDOMComponent', function() {
       expect(console.error.calls.length).toBe(2);
     });
 
+    it('should not warn for "0" as a unitless style value', function() {
+      spyOn(console, 'error');
+      var Component = React.createClass({
+        render: function() {
+          return <div style={{margin: '0'}} />;
+        },
+      });
+
+      ReactTestUtils.renderIntoDocument(<Component />);
+      expect(console.error.calls.length).toBe(0);
+    });
+
     it('should warn nicely about NaN in style', function() {
       spyOn(console, 'error');
 

--- a/src/renderers/dom/shared/dangerousStyleValue.js
+++ b/src/renderers/dom/shared/dangerousStyleValue.js
@@ -44,7 +44,7 @@ function dangerousStyleValue(name, value, component) {
   }
 
   var isNonNumeric = isNaN(value);
-  if (isNonNumeric || value === 0 || value === '0' ||
+  if (isNonNumeric || value === 0 ||
       isUnitlessNumber.hasOwnProperty(name) && isUnitlessNumber[name]) {
     return '' + value; // cast to string
   }

--- a/src/renderers/dom/shared/dangerousStyleValue.js
+++ b/src/renderers/dom/shared/dangerousStyleValue.js
@@ -51,7 +51,9 @@ function dangerousStyleValue(name, value, component) {
 
   if (typeof value === 'string') {
     if (__DEV__) {
-      if (component) {
+      // Allow '0' to pass through without warning. 0 is already special and
+      // doesn't require units, so we don't need to warn about it.
+      if (component && value !== '0') {
         var owner = component._currentElement._owner;
         var ownerName = owner ? owner.getName() : null;
         if (ownerName && !styleWarnings[ownerName]) {


### PR DESCRIPTION
This reverts #6458 and then implements the goal of that PR without affecting the output.

While I agree that #6458 is "safe", it's a subtle behavior change in the generated output and I think we shouldn't take it in the branch. In `master` we should make the change to stop appending `px` to all strings (not just `'0'`).