### PR TITLE
Don't warn about `onScroll` for SSR

### DIFF
--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -35,6 +35,7 @@ var ReactDOMTextarea = require('ReactDOMTextarea');
 var ReactInstrumentation = require('ReactInstrumentation');
 var ReactMultiChild = require('ReactMultiChild');
 var ReactPerf = require('ReactPerf');
+var ReactServerRenderingTransaction = require('ReactServerRenderingTransaction');
 
 var emptyFunction = require('emptyFunction');
 var escapeTextContentForBrowser = require('escapeTextContentForBrowser');
@@ -210,6 +211,9 @@ function assertValidProps(component, props) {
 }
 
 function enqueuePutListener(inst, registrationName, listener, transaction) {
+  if (transaction instanceof ReactServerRenderingTransaction) {
+    return;
+  }
   if (__DEV__) {
     // IE8 has no API for event capturing and the `onScroll` event doesn't
     // bubble.
@@ -221,10 +225,6 @@ function enqueuePutListener(inst, registrationName, listener, transaction) {
   var containerInfo = inst._nativeContainerInfo;
   var isDocumentFragment = containerInfo._node && containerInfo._node.nodeType === DOC_FRAGMENT_TYPE;
   var doc = isDocumentFragment ? containerInfo._node : containerInfo._ownerDocument;
-  if (!doc) {
-    // Server rendering.
-    return;
-  }
   listenTo(registrationName, doc);
   transaction.getReactMountReady().enqueue(putListener, {
     inst: inst,

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -1107,6 +1107,12 @@ describe('ReactDOMComponent', function() {
         'Warning: This browser doesn\'t support the `onScroll` event'
       );
     });
+
+    it('should not warn when server-side rendering `onScroll`', function() {
+      spyOn(console, 'error');
+      ReactDOMServer.renderToString(<div onScroll={() => {}}/>);
+      expect(console.error).not.toHaveBeenCalled();
+    });
   });
 
   describe('tag sanitization', function() {


### PR DESCRIPTION
Fixes #6626 

@zpao using `instanceof` seems to work fine for identifying `ReactServerRenderingTransaction` instances, so if that works for you this should resolve it.