### PR TITLE
DOMLazyTree, populate <object> before insertion into DOM

### DIFF
--- a/src/renderers/dom/client/utils/DOMLazyTree.js
+++ b/src/renderers/dom/client/utils/DOMLazyTree.js
@@ -11,8 +11,13 @@
 
 'use strict';
 
+var DOMNamespaces = require('DOMNamespaces');
+
 var createMicrosoftUnsafeLocalFunction = require('createMicrosoftUnsafeLocalFunction');
 var setTextContent = require('setTextContent');
+
+var ELEMENT_NODE_TYPE = 1;
+var DOCUMENT_FRAGMENT_NODE_TYPE = 11;
 
 /**
  * In IE (8-11) and Edge, appending nodes with no children is dramatically
@@ -56,8 +61,15 @@ var insertTreeBefore = createMicrosoftUnsafeLocalFunction(
     // DocumentFragments aren't actually part of the DOM after insertion so
     // appending children won't update the DOM. We need to ensure the fragment
     // is properly populated first, breaking out of our lazy approach for just
-    // this level.
-    if (tree.node.nodeType === 11) {
+    // this level. Also, some <object> plugins (like Flash Player) will read
+    // <param> nodes immediately upon insertion into the DOM, so <object>
+    // must also be populated prior to insertion into the DOM.
+    if (tree.node.nodeType === DOCUMENT_FRAGMENT_NODE_TYPE
+        ||
+        tree.node.nodeType === ELEMENT_NODE_TYPE &&
+        tree.node.nodeName.toLowerCase() === 'object' &&
+        (tree.node.namespaceURI == null ||
+         tree.node.namespaceURI === DOMNamespaces.html)) {
       insertTreeChildren(tree);
       parentNode.insertBefore(tree.node, referenceNode);
     } else {


### PR DESCRIPTION
Fix for #6629 and replaces the broken PR #6640.

Again, real-life performance implications unknown. As far as I can tell and understand it, it works as intended and considering the simplicity I fail to see how this could break anything.