### PR TITLE
Make it clearer that string refs are considered legacy

### DIFF
--- a/docs/docs/08.1-more-about-refs.md
+++ b/docs/docs/08.1-more-about-refs.md
@@ -68,7 +68,11 @@ Note that when the referenced component is unmounted and whenever the ref change
 
 ## The ref String Attribute
 
-React also supports using a string (instead of a callback) as a ref prop on any component, although this approach is mostly legacy at this point.
+> Note:
+>
+> Although string refs are not deprecated, they are considered legacy, and will likely be deprecated at some point in the future. Callback refs are preferred.
+
+React also supports using a string (instead of a callback) as a ref prop on any component.
 
 1. Assign a `ref` attribute to anything returned from `render` such as:
 


### PR DESCRIPTION
Anecdotally, it's my impression that most people aren't aware that string refs are considered legacy. The docs mention it, but it's easy to miss. As an example, I brought this up on Twitter and @ryanflorence (whom no one can accuse of being a React newbie) noted that he [hadn't bothered to look into callback refs yet](https://twitter.com/ryanflorence/status/727252198678110208).

This PR places the legacy warning in a stylized "Note" box, like similar warnings throughout the docs.

<img width="670" alt="screen shot 2016-05-03 at 2 42 21 pm" src="https://cloud.githubusercontent.com/assets/3624098/14999315/5041e124-113d-11e6-8276-e7eddcffd25e.png">

It might also be nice to link to a resource (perhaps a blog post?) that explains the disadvantages of string refs, but the only one I'm aware of is [this old GitHub issue](https://github.com/facebook/react/issues/1373).