### PR TITLE
Fix styles to prevent subtle diffing bugs, add support for vendor prefixing

### DIFF
--- a/src/isomorphic/devtools/__tests__/ReactNativeOperationHistoryDevtool-test.js
+++ b/src/isomorphic/devtools/__tests__/ReactNativeOperationHistoryDevtool-test.js
@@ -94,10 +94,9 @@ describe('ReactNativeOperationHistoryDevtool', () => {
       if (ReactDOMFeatureFlags.useCreateElement) {
         assertHistoryMatches([{
           instanceID: inst._debugID,
-          type: 'update styles',
+          type: 'update attribute',
           payload: {
-            color: 'red',
-            backgroundColor: 'yellow',
+            style: 'color:red;background-color:yellow;',
           },
         }, {
           instanceID: inst._debugID,
@@ -130,20 +129,20 @@ describe('ReactNativeOperationHistoryDevtool', () => {
 
       assertHistoryMatches([{
         instanceID: inst._debugID,
-        type: 'update styles',
-        payload: { color: 'red' },
+        type: 'update attribute',
+        payload: { style: 'color:red;' },
       }, {
         instanceID: inst._debugID,
-        type: 'update styles',
-        payload: { color: 'blue', backgroundColor: 'yellow' },
+        type: 'update attribute',
+        payload: { style: 'color:blue;background-color:yellow;' },
       }, {
         instanceID: inst._debugID,
-        type: 'update styles',
-        payload: { color: '', backgroundColor: 'green' },
+        type: 'update attribute',
+        payload: { style: 'background-color:green;' },
       }, {
         instanceID: inst._debugID,
-        type: 'update styles',
-        payload: { backgroundColor: '' },
+        type: 'update attribute',
+        payload: { style: null },
       }]);
     });
 
@@ -164,10 +163,9 @@ describe('ReactNativeOperationHistoryDevtool', () => {
 
       assertHistoryMatches([{
         instanceID: inst._debugID,
-        type: 'update styles',
+        type: 'update attribute',
         payload: {
-          color: 'red',
-          backgroundColor: 'yellow',
+          style: 'color:red;background-color:yellow;',
         },
       }]);
     });

--- a/src/renderers/dom/ReactDOM.js
+++ b/src/renderers/dom/ReactDOM.js
@@ -13,6 +13,7 @@
 
 'use strict';
 
+var CSSPropertyOperations = require('CSSPropertyOperations');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var ReactDefaultInjection = require('ReactDefaultInjection');
 var ReactMount = require('ReactMount');
@@ -35,6 +36,10 @@ var React = {
   render: render,
   unmountComponentAtNode: ReactMount.unmountComponentAtNode,
   version: ReactVersion,
+
+  CSS: {
+    multi: CSSPropertyOperations.multi,
+  },
 
   /* eslint-disable camelcase */
   unstable_batchedUpdates: ReactUpdates.batchedUpdates,

--- a/src/renderers/dom/shared/CSSPropertyOperations.js
+++ b/src/renderers/dom/shared/CSSPropertyOperations.js
@@ -172,13 +172,26 @@ var CSSPropertyOperations = {
         continue;
       }
       var styleValue = styles[styleName];
-      if (__DEV__) {
-        warnValidStyle(styleName, styleValue, component);
-      }
+      var processedStyleName = processStyleName(styleName);
       if (styleValue != null) {
-        serialized += processStyleName(styleName) + ':';
-        serialized +=
-          dangerousStyleValue(styleName, styleValue, component) + ';';
+        if (styleValue.__isMultiCssValue) {
+          for (var i = 0; i < styleValue.length; i++) {
+            var elem = styleValue[i];
+            if (__DEV__) {
+              warnValidStyle(styleName, elem, component);
+            }
+            serialized += processedStyleName + ':';
+            serialized +=
+              dangerousStyleValue(styleName, elem, component) + ';';
+          }
+        } else {
+          if (__DEV__) {
+            warnValidStyle(styleName, styleValue, component);
+          }
+          serialized += processedStyleName + ':';
+          serialized +=
+            dangerousStyleValue(styleName, styleValue, component) + ';';
+        }
       }
     }
     return serialized || null;
@@ -236,6 +249,14 @@ var CSSPropertyOperations = {
     }
   },
 
+  multi: function() {
+    var args = new Array(arguments.length);
+    for(var i = 0; i < args.length; i++) {
+        args[i] = arguments[i];
+    }
+    args.__isMultiCssValue = true;
+    return args;
+  },
 };
 
 ReactPerf.measureMethods(CSSPropertyOperations, 'CSSPropertyOperations', {

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -39,6 +39,7 @@ var ReactPerf = require('ReactPerf');
 var ReactServerRenderingTransaction = require('ReactServerRenderingTransaction');
 
 var emptyFunction = require('emptyFunction');
+var emptyObject = require('emptyObject');
 var escapeTextContentForBrowser = require('escapeTextContentForBrowser');
 var invariant = require('invariant');
 var isEventSupported = require('isEventSupported');
@@ -992,10 +993,14 @@ ReactDOMComponent.Mixin = {
       }
     }
     if (styleUpdates) {
-      CSSPropertyOperations.setValueForStyles(
+      var nextStyles = emptyObject;
+      if (nextProps != null && nextProps[STYLE] != null) {
+        nextStyles = nextProps[STYLE];
+      }
+      DOMPropertyOperations.setValueForAttribute(
         getNode(this),
-        styleUpdates,
-        this
+        'style',
+        CSSPropertyOperations.createMarkupForStyles(nextStyles, this)
       );
     }
   },

--- a/src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
@@ -177,6 +177,25 @@ describe('CSSPropertyOperations', function() {
     );
   });
 
+  it('should allow array of vendor prefixed values', function() {
+    var styles = {
+      padding: 0,
+      margin: 0,
+      listStyle: 'none',
+      display: ReactDOM.CSS.multi('-webkit-box', '-moz-box', '-ms-flexbox', '-webkit-flex'),
+      WebkitFlexFlow: 'row wrap',
+      justifyContent: 'space-around',
+    };
+
+    var markup = ReactDOMServer.renderToString(
+      <div style={styles} />
+    );
+
+    expect(markup).toContain('-ms-flexbox');
+    expect(markup).toContain('-webkit-flex');
+    expect(markup).toContain('-webkit-box');
+  });
+
   it('should warn about style having a trailing semicolon', function() {
     var Comp = React.createClass({
       displayName: 'Comp',


### PR DESCRIPTION
We have several minor/subtle issues with styles, all of which get knocked out by this PR.

For instance, `initial render` of a component should be identical to [`initial render`, `different render`, `initial render` again].  That is, the only thing that SHOULD matter is the most recent render.  However, if with our old code, there are edge cases where this is untrue (eg. when specifying a general style and a more specific style).  Example: http://jsfiddle.net/0861av29/  Historically, we've told people "don't do that", but that's not a good answer.  For users, the old code made it hard to solve in general, because this situation often arrises when a parent clones a child and append an additional (more specific) style.  This creates complex interactions between components that are difficult to debug.  Solved by this PR.

Another big fix, this PR also enables vendor prefix for css values, which has been a popular request for a long time.  Syntax looks like this:

```
var styles = {
  padding: 0,
  margin: 0,
  listStyle: 'none',
  display: ['-webkit-box', '-moz-box', '-ms-flexbox', '-webkit-flex'],
  WebkitFlexFlow: 'row wrap',
  justifyContent: 'space-around',
};
```
