### PR TITLE
Another fix for #4876, TransitionGroup errors

### DIFF
--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -117,7 +117,7 @@ var ReactTransitionGroup = React.createClass({
 
   _handleDoneAppearing: function(key) {
     var component = this.refs[key];
-    if (component.componentDidAppear) {
+    if (component && component.componentDidAppear) {
       component.componentDidAppear();
     }
 
@@ -182,7 +182,7 @@ var ReactTransitionGroup = React.createClass({
   _handleDoneLeaving: function(key) {
     var component = this.refs[key];
 
-    if (component.componentDidLeave) {
+    if (component && component.componentDidLeave) {
       component.componentDidLeave();
     }
 


### PR DESCRIPTION
If the component has unmounted before a transition completes, sometimes the ref is undefined therefore it will throw. By adding a check to make sure we actually successfully got the ref, we avoid the error.

This is a fix for [4876](https://github.com/facebook/react/issues/4876)