### PR TITLE
Add permalink

### DIFF
--- a/docs/docs/tutorial.zh-CN.md
+++ b/docs/docs/tutorial.zh-CN.md
@@ -1,6 +1,7 @@
 ---
 id: tutorial-zh-CN
 title: 教程
+permalink: tutorial-zh-CN.html
 prev: getting-started-zh-CN.html
 next: thinking-in-react-zh-CN.html
 ---


### PR DESCRIPTION
Add permalink to docs, so we can access with 'prev' and 'next'
without it we can only access this doc use http://facebook.github.io/react/docs/**tutorial.zh-CN.html**
however in the file which named getting-start.zh-CN.md has designed like this:
```
---
id: getting-started-zh-CN
title: 入门教程
permalink: getting-started-zh-CN.html
next: tutorial-zh-CN.html
redirect_from: "docs/index-zh-CN.html"
---
```