### PR TITLE
Require modules from React Native as node modules.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,27 +29,21 @@ var paths = {
   },
 };
 
-var fbjsModuleMap = require('fbjs/module-map');
-var moduleMap = {};
-for (var key in fbjsModuleMap) {
-  moduleMap[key] = fbjsModuleMap[key];
-}
-var whiteListNames = [
-  'deepDiffer',
-  'deepFreezeAndThrowOnMutationInDev',
-  'flattenStyle',
-  'InitializeJavaScriptAppEngine',
-  'RCTEventEmitter',
-  'TextInputState',
-  'UIManager',
-  'View',
-];
-
-whiteListNames.forEach(function(name) {
-  moduleMap[name] = name;
-});
-
-moduleMap['object-assign'] = 'object-assign';
+var moduleMap = Object.assign(
+  {'object-assign': 'object-assign'},
+  require('fbjs/module-map'),
+  {
+    deepDiffer: 'react-native/lib/deepDiffer',
+    deepFreezeAndThrowOnMutationInDev: 'react-native/lib/deepFreezeAndThrowOnMutationInDev',
+    flattenStyle: 'react-native/lib/flattenStyle',
+    InitializeJavaScriptAppEngine: 'react-native/lib/InitializeJavaScriptAppEngine',
+    RCTEventEmitter: 'react-native/lib/RCTEventEmitter',
+    TextInputState: 'react-native/lib/TextInputState',
+    UIManager: 'react-native/lib/UIManager',
+    UIManagerStatTracker: 'react-native/lib/UIManagerStatTracker',
+    View: 'react-native/lib/View',
+  }
+);
 
 var babelOpts = {
   plugins: [


### PR DESCRIPTION
This is one puzzle piece to remove the special handling of `node_modules/react` in React Native’s packager.

It changes all requires into React Native from `@providesModule` to the node.js resolution algorithm.

I tested our internal use case by building the v15.0.3-dev branch with this patch applied and running an app.