### PR TITLE
Add support for movementX/Y in SyntheticMouseEvent

### DIFF
--- a/src/renderers/dom/client/syntheticEvents/SyntheticMouseEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticMouseEvent.js
@@ -13,6 +13,7 @@
 
 var SyntheticUIEvent = require('SyntheticUIEvent');
 var ViewportMetrics = require('ViewportMetrics');
+var MouseMetrics = require('MouseMetrics');
 
 var getEventModifierState = require('getEventModifierState');
 
@@ -62,6 +63,28 @@ var MouseEventInterface = {
     return 'pageY' in event ?
       event.pageY :
       event.clientY + ViewportMetrics.currentScrollTop;
+  },
+  movementX: function(event) {
+    if ('movementX' in event) {
+      return event.movementX;
+    }
+    var previousScreenX = MouseMetrics.previousScreenX;
+    MouseMetrics.setPreviousScreenX(event.screenX);
+    if (previousScreenX === null) {
+      return 0;
+    }
+    return event.screenX - previousScreenX;
+  },
+  movementY: function(event) {
+    if ('movementY' in event) {
+      return event.movementY;
+    }
+    var previousScreenY = MouseMetrics.previousScreenY;
+    MouseMetrics.setPreviousScreenY(event.screenY);
+    if (previousScreenY === null) {
+      return 0;
+    }
+    return event.screenY - previousScreenY;
   },
 };
 

--- a/src/renderers/dom/client/utils/MouseMetrics.js
+++ b/src/renderers/dom/client/utils/MouseMetrics.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule MouseMetrics
+ */
+
+'use strict';
+
+var MouseMetrics = {
+
+  previousScreenX: null,
+
+  previousScreenY: null,
+
+  setPreviousScreenX: function(value) {
+    MouseMetrics.previousScreenX = value;
+  },
+
+  setPreviousScreenY: function(value) {
+    MouseMetrics.previousScreenY = value;
+  },
+
+};
+
+module.exports = MouseMetrics;


### PR DESCRIPTION
Resolves #6723

So there's still work that needs to be done here, but I wanted to open the PR so I could get feedback early on. I have a couple questions:
1. To polyfill `movementX`/`movementY` you need the previous mouse event's `screenX`/`screenY`. I implemented a `MouseMetrics` here similar to `ViewportMetrics`. Is that the right approach?

1a. If `MouseMetrics` is an acceptable, is there a better place in the code path where I should register the new `previousScreen{X,Y}` values?
1. I don't see any tests for `SyntheticMouseEvents`, am I just not seeing them or do they not exist? Where should I add tests for this?
