### PR TITLE
fix mouse events when multiple ReactDOM.render

### DIFF
--- a/src/renderers/dom/client/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
+++ b/src/renderers/dom/client/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
@@ -62,4 +62,42 @@ describe('EnterLeaveEventPlugin', function() {
     expect(enter.target).toBe(div);
     expect(enter.relatedTarget).toBe(iframe.contentWindow);
   });
+
+  it('should works across mount points', function() {
+    var Inner = React.createClass({
+      render() {
+        return (<div id="inner" />);
+      },
+    });
+    var App = React.createClass({
+      componentDidMount() {
+        ReactDOM.render(<Inner />, this.refs.container);
+      },
+      onMouseLeave() {
+      },
+      render() {
+        return (<div
+          id="outer"
+          onMouseLeave={this.onMouseLeave}
+          >
+          <div ref="container" />
+        </div>);
+      },
+    });
+    var div = document.createElement('div');
+    document.body.appendChild(div);
+    ReactDOM.render(<App />, div);
+    var target = document.getElementById('outer');
+    var relatedTarget = document.getElementById('inner');
+    var extracted = EnterLeaveEventPlugin.extractEvents(
+      topLevelTypes.topMouseOut,
+      ReactDOMComponentTree.getInstanceFromNode(target),
+      {
+        target: target,
+        relatedTarget: relatedTarget,
+      },
+      target
+    );
+    expect(!!extracted[0]._dispatchListeners).toBe(false);
+  });
 });


### PR DESCRIPTION
reproducible demo: https://jsfiddle.net/yiminghe/69z2wepo/41347/
moving mouse `from` outer to `inner` will trigger mouseleave event which is wrong.

when exists multiple ReactDOM.render, native dom traversal is needed.

