### PR TITLE
Fix undefined DOM element at transition group

### DIFF
--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -111,9 +111,10 @@ var ReactCSSTransitionGroupChild = React.createClass({
   },
 
   flushClassNameQueue: function() {
-    if (this.isMounted()) {
+    var DOMNode = ReactDOM.findDOMNode(this);
+    if (DOMNode) {
       this.classNameQueue.forEach(
-        CSSCore.addClass.bind(CSSCore, ReactDOM.findDOMNode(this))
+        CSSCore.addClass.bind(CSSCore, DOMNode)
       );
     }
     this.classNameQueue.length = 0;


### PR DESCRIPTION
It relates to #6619. Since isMounted() 'will likely be removed entirely in a future version of React' (according to [this](https://github.com/facebook/react/blob/15-stable/docs/docs/ref-02-component-api.md#ismounted)) maybe it would be better use findDOMNode to check whether element has node or not.

findDOMNode returns null if in render method we return null or false (e.g. to hide element), otherwise we have node to make some manipulation with it.