### PR TITLE
Should not rely on synchronous return value of renderIntoDocument

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,7 @@
   "plugins": [
     "fbjs-scripts/babel-6/dev-expression",
     "syntax-trailing-function-commas",
+    "babel-plugin-transform-async-to-generator",
     "babel-plugin-transform-object-rest-spread",
     "transform-es2015-template-literals",
     "transform-es2015-literals",

--- a/package.json
+++ b/package.json
@@ -101,5 +101,9 @@
     "unmockedModulePathPatterns": [
       ""
     ]
+  },
+  "dependencies": {
+    "babel-plugin-syntax-async-functions": "^6.8.0",
+    "babel-plugin-transform-async-to-generator": "^6.8.0"
   }
 }

--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -80,14 +80,38 @@ function findAllInRenderedTreeInternal(inst, test) {
  * @lends ReactTestUtils
  */
 var ReactTestUtils = {
-  renderIntoDocument: function(instance) {
+  renderIntoDocument: function(element) {
     var div = document.createElement('div');
     // None of our tests actually require attaching the container to the
     // DOM, and doing so creates a mess that we rely on test isolation to
     // clean up, so we're going to stop honoring the name of this method
     // (and probably rename it eventually) if no problems arise.
     // document.documentElement.appendChild(div);
-    return ReactDOM.render(instance, div);
+    return ReactDOM.render(element, div);
+  },
+
+  renderIntoDocumentAsync: function(element) {
+    invariant(typeof element.ref !== 'string',
+      'String refs can not be used at the top-level element of a render.'
+    );
+    var promise = new Promise(function(fulfill, reject) {
+      var div = document.createElement('div');
+      // None of our tests actually require attaching the container to the
+      // DOM, and doing so creates a mess that we rely on test isolation to
+      // clean up, so we're going to stop honoring the name of this method
+      // (and probably rename it eventually) if no problems arise.
+      // document.documentElement.appendChild(div);
+      var oldRef = element.ref;
+      var newRef = (instance) => {
+        if (oldRef) {
+          oldRef(instance);
+        }
+        fulfill(instance);
+      };
+      element = React.cloneElement(element, {ref: newRef});
+      ReactDOM.render(element, div);
+    });
+    return promise;
   },
 
   isElement: function(element) {

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -535,4 +535,29 @@ describe('ReactTestUtils', function() {
     expect(hrs.length).toBe(2);
   });
 
+  pit('will reject string refs in renderIntoDocumentAsync', async function() {
+    try {
+      // String refs are illegal at the top level.
+      await ReactTestUtils.renderIntoDocumentAsync(<div ref="foo" />);
+      fail('this code should not be reachable');
+    } catch (e) {
+      expect(e.message).toBe('String refs can not be used at the top-level element of a render.');
+    }
+  });
+
+  pit('will fire a callback ref in renderIntoDocumentAsync', async function() {
+    var count = 0;
+    function ref(instance) {
+      count++;
+      expect(instance.tagName).toBe('DIV');
+    }
+    var instance = await ReactTestUtils.renderIntoDocumentAsync(<div ref={ref} />);
+    expect(instance.tagName).toBe('DIV');
+    expect(count).toBe(1);
+  });
+
+  pit('will not die if no ref in renderIntoDocumentAsync', async function() {
+    var instance = await ReactTestUtils.renderIntoDocumentAsync(<div />);
+    expect(instance.tagName).toBe('DIV');
+  });
 });


### PR DESCRIPTION
Previously, `renderIntoDocument` relied on the synchronous return value of render.  As per https://github.com/facebook/react/issues/6397, we want to start moving away from relying on this synchronous return value.  This PR takes the first step toward that goal, by providing a `renderIntoDocumentAsync` method, which makes it easy to render into a document and wait on the return value for the purposes of unit testing.  Long term, the `renderIntoDocumentAsync` is intended to replace `renderIntoDocument` for all intents and purposes.

The primary motivation for this PR is that it brings our unit tests closer to matching the semantics of an incremental reconciler, thereby allowing us to iterate on our incremental reconciler without failing all the unit tests.

cc @sebmarkbage @spicyj @zpao 
