### PR TITLE
refs documentation: refer to correct example

### DIFF
--- a/docs/docs/08.1-more-about-refs.md
+++ b/docs/docs/08.1-more-about-refs.md
@@ -64,7 +64,7 @@ or using an ES6 arrow function:
 
 When attaching a ref to a DOM component like `<div />`, you get the DOM node back; when attaching a ref to a composite component like `<TextInput />`, you'll get the React class instance. In the latter case, you can call methods on that component if any are exposed in its class definition.
 
-Note that when the referenced component is unmounted and whenever the ref changes, the old ref will be called with `null` as an argument. This prevents memory leaks in the case that the instance is stored, as in the first example. Also note that when writing refs with inline function expressions as in the examples here, React sees a different function object each time so on every update, ref will be called with `null` immediately before it's called with the component instance.
+Note that when the referenced component is unmounted and whenever the ref changes, the old ref will be called with `null` as an argument. This prevents memory leaks in the case that the instance is stored, as in the second example. Also note that when writing refs with inline function expressions as in the examples here, React sees a different function object each time so on every update, ref will be called with `null` immediately before it's called with the component instance.
 
 ## The ref String Attribute
 


### PR DESCRIPTION
I *think* this should refer to the second example, where the instance to the ref is stored. In any case please can someone confirm for my own understanding?