### PR TITLE
Track source more generically in ReactComponentTreeDevtool

### DIFF
--- a/src/isomorphic/ReactDebugTool.js
+++ b/src/isomorphic/ReactDebugTool.js
@@ -241,9 +241,17 @@ var ReactDebugTool = {
     checkDebugID(debugID);
     emitEvent('onMountRootComponent', debugID);
   },
+  onBeforeMountComponent(debugID, element) {
+    checkDebugID(debugID);
+    emitEvent('onBeforeMountComponent', debugID, element);
+  },
   onMountComponent(debugID) {
     checkDebugID(debugID);
     emitEvent('onMountComponent', debugID);
+  },
+  onBeforeUpdateComponent(debugID, element) {
+    checkDebugID(debugID);
+    emitEvent('onBeforeUpdateComponent', debugID, element);
   },
   onUpdateComponent(debugID) {
     checkDebugID(debugID);

--- a/src/isomorphic/devtools/ReactComponentTreeDevtool.js
+++ b/src/isomorphic/devtools/ReactComponentTreeDevtool.js
@@ -19,6 +19,7 @@ var rootIDs = [];
 function updateTree(id, update) {
   if (!tree[id]) {
     tree[id] = {
+      element: null,
       parentID: null,
       ownerID: null,
       text: null,
@@ -88,6 +89,14 @@ var ReactComponentTreeDevtool = {
     updateTree(id, item => item.text = text);
   },
 
+  onBeforeMountComponent(id, element) {
+    updateTree(id, item => item.element = element);
+  },
+
+  onBeforeUpdateComponent(id, element) {
+    updateTree(id, item => item.element = element);
+  },
+
   onMountComponent(id) {
     updateTree(id, item => item.isMounted = true);
   },
@@ -139,6 +148,13 @@ var ReactComponentTreeDevtool = {
   getParentID(id) {
     var item = tree[id];
     return item ? item.parentID : null;
+  },
+
+  getSource(id) {
+    var item = tree[id];
+    var element = item ? item.element : null;
+    var source = element != null ? element._source : null;
+    return source;
   },
 
   getText(id) {

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -29,7 +29,6 @@ var ReactDOMButton = require('ReactDOMButton');
 var ReactDOMComponentFlags = require('ReactDOMComponentFlags');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var ReactDOMInput = require('ReactDOMInput');
-var ReactDOMInstrumentation = require('ReactDOMInstrumentation');
 var ReactDOMOption = require('ReactDOMOption');
 var ReactDOMSelect = require('ReactDOMSelect');
 var ReactDOMTextarea = require('ReactDOMTextarea');
@@ -579,10 +578,6 @@ ReactDOMComponent.Mixin = {
         validateDOMNesting.updatedAncestorInfo(parentInfo, this._tag, this);
     }
 
-    if (__DEV__) {
-      ReactDOMInstrumentation.debugTool.onMountDOMComponent(this._debugID, this._currentElement);
-    }
-
     var mountImage;
     if (transaction.useCreateElement) {
       var ownerDocument = hostContainerInfo._ownerDocument;
@@ -857,10 +852,6 @@ ReactDOMComponent.Mixin = {
       transaction,
       context
     );
-
-    if (__DEV__) {
-      ReactDOMInstrumentation.debugTool.onUpdateDOMComponent(this._debugID, this._currentElement);
-    }
 
     if (this._tag === 'select') {
       // <select> value update needs to occur after <option> children

--- a/src/renderers/dom/shared/ReactDOMDebugTool.js
+++ b/src/renderers/dom/shared/ReactDOMDebugTool.js
@@ -12,6 +12,7 @@
 'use strict';
 
 var ReactDOMUnknownPropertyDevtool = require('ReactDOMUnknownPropertyDevtool');
+var ReactDebugTool = require('ReactDebugTool');
 
 var warning = require('warning');
 
@@ -40,9 +41,11 @@ function emitEvent(handlerFunctionName, arg1, arg2, arg3, arg4, arg5) {
 
 var ReactDOMDebugTool = {
   addDevtool(devtool) {
+    ReactDebugTool.addDevtool(devtool);
     eventHandlers.push(devtool);
   },
   removeDevtool(devtool) {
+    ReactDebugTool.removeDevtool(devtool);
     for (var i = 0; i < eventHandlers.length; i++) {
       if (eventHandlers[i] === devtool) {
         eventHandlers.splice(i, 1);
@@ -61,12 +64,6 @@ var ReactDOMDebugTool = {
   },
   onTestEvent() {
     emitEvent('onTestEvent');
-  },
-  onMountDOMComponent(debugID, element) {
-    emitEvent('onMountDOMComponent', debugID, element);
-  },
-  onUpdateDOMComponent(debugID, element) {
-    emitEvent('onMountDOMComponent', debugID, element);
   },
 };
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -1306,8 +1306,17 @@ describe('ReactDOMComponent', function() {
       ReactDOMServer.renderToString(<div class="paladin"/>);
       ReactDOMServer.renderToString(<input type="text" onclick="1"/>);
       expect(console.error.argsForCall.length).toBe(2);
-      expect(console.error.argsForCall[0][0]).toMatch(/.*className.*\(.*:\d+\)/);
-      expect(console.error.argsForCall[1][0]).toMatch(/.*onClick.*\(.*:\d+\)/);
+      expect(
+        console.error.argsForCall[0][0].replace(/\(.+?:\d+\)/g, '(**:*)')
+      ).toBe(
+        'Warning: Unknown DOM property class. Did you mean className? (**:*)'
+      );
+      expect(
+        console.error.argsForCall[1][0].replace(/\(.+?:\d+\)/g, '(**:*)')
+      ).toBe(
+        'Warning: Unknown event handler property onclick. Did you mean ' +
+        '`onClick`? (**:*)'
+      );
     });
 
     it('gives source code refs for unknown prop warning for update render', function() {
@@ -1319,7 +1328,11 @@ describe('ReactDOMComponent', function() {
 
       ReactDOMServer.renderToString(<div class="paladin" />, container);
       expect(console.error.argsForCall.length).toBe(1);
-      expect(console.error.argsForCall[0][0]).toMatch(/.*className.*\(.*:\d+\)/);
+      expect(
+        console.error.argsForCall[0][0].replace(/\(.+?:\d+\)/g, '(**:*)')
+      ).toBe(
+        'Warning: Unknown DOM property class. Did you mean className? (**:*)'
+      );
     });
 
     it('gives source code refs for unknown prop warning for exact elements ', function() {

--- a/src/renderers/shared/stack/reconciler/ReactReconciler.js
+++ b/src/renderers/shared/stack/reconciler/ReactReconciler.js
@@ -50,6 +50,10 @@ var ReactReconciler = {
           internalInstance._debugID,
           'mountComponent'
         );
+        ReactInstrumentation.debugTool.onBeforeMountComponent(
+          internalInstance._debugID,
+          internalInstance._currentElement
+        );
       }
     }
     var markup = internalInstance.mountComponent(
@@ -149,6 +153,10 @@ var ReactReconciler = {
         ReactInstrumentation.debugTool.onBeginReconcilerTimer(
           internalInstance._debugID,
           'receiveComponent'
+        );
+        ReactInstrumentation.debugTool.onBeforeUpdateComponent(
+          internalInstance._debugID,
+          internalInstance._currentElement
         );
       }
     }


### PR DESCRIPTION
Being able to get the source for your parent components seems useful, and ReactComponentTreeDevtool is best poised to be able to do that.

I'm also not sure it makes sense to have separate DOM-specific `onMountDOMComponent` and `onUpdateDOMComponent` events, so I removed them for now. Even if we want them, their timing seemed sort of arbitrary.

I also made it so DOM devtools can listen to non-DOM events too. Willing to change that if people think it's ugly though.

Reviewers: @gaearon