### PR TITLE
Show component stack in PropTypes warnings

### DIFF
--- a/src/isomorphic/ReactDebugTool.js
+++ b/src/isomorphic/ReactDebugTool.js
@@ -236,6 +236,10 @@ var ReactDebugTool = {
     checkDebugID(debugID);
     emitEvent('onSetOwner', debugID, ownerDebugID);
   },
+  onSetParent(debugID, parentDebugID) {
+    checkDebugID(debugID);
+    emitEvent('onSetParent', debugID, parentDebugID);
+  },
   onSetText(debugID, text) {
     checkDebugID(debugID);
     emitEvent('onSetText', debugID, text);

--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -18,10 +18,11 @@
 
 'use strict';
 
-var ReactElement = require('ReactElement');
-var ReactPropTypeLocations = require('ReactPropTypeLocations');
-var ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
 var ReactCurrentOwner = require('ReactCurrentOwner');
+var ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
+var ReactElement = require('ReactElement');
+var ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
+var ReactPropTypeLocations = require('ReactPropTypeLocations');
 
 var canDefineProperty = require('canDefineProperty');
 var getIteratorFn = require('getIteratorFn');
@@ -171,13 +172,14 @@ function validateChildKeys(node, parentType) {
 /**
  * Assert that the props are valid
  *
+ * @param {object} element
  * @param {string} componentName Name of the component for error messages.
  * @param {object} propTypes Map of prop name to a ReactPropType
- * @param {object} props
  * @param {string} location e.g. "prop", "context", "child context"
  * @private
  */
-function checkPropTypes(componentName, propTypes, props, location) {
+function checkPropTypes(element, componentName, propTypes, location) {
+  var props = element.props;
   for (var propName in propTypes) {
     if (propTypes.hasOwnProperty(propName)) {
       var error;
@@ -216,8 +218,12 @@ function checkPropTypes(componentName, propTypes, props, location) {
         // same error.
         loggedTypeFailures[error.message] = true;
 
-        var addendum = getDeclarationErrorAddendum();
-        warning(false, 'Failed propType: %s%s', error.message, addendum);
+        warning(
+          false,
+          'Failed propType: %s%s',
+          error.message,
+          ReactComponentTreeDevtool.getCurrentStackAddendum(element)
+        );
       }
     }
   }
@@ -237,9 +243,9 @@ function validatePropTypes(element) {
   var name = componentClass.displayName || componentClass.name;
   if (componentClass.propTypes) {
     checkPropTypes(
+      element,
       name,
       componentClass.propTypes,
-      element.props,
       ReactPropTypeLocations.prop
     );
   }

--- a/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
@@ -271,7 +271,10 @@ describe('ReactElementClone', function() {
     expect(console.error.argsForCall[0][0]).toBe(
       'Warning: Failed propType: ' +
       'Invalid prop `color` of type `number` supplied to `Component`, ' +
-      'expected `string`. Check the render method of `Parent`.'
+      'expected `string`.\n' +
+      '    in Component (created by GrandParent)\n' +
+      '    in Parent (created by GrandParent)\n' +
+      '    in GrandParent'
     );
   });
 

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -242,7 +242,9 @@ describe('ReactElementValidator', function() {
     expect(console.error.argsForCall[0][0]).toBe(
       'Warning: Failed propType: ' +
       'Invalid prop `color` of type `number` supplied to `MyComp`, ' +
-      'expected `string`. Check the render method of `ParentComp`.'
+      'expected `string`.\n' +
+      '    in MyComp (created by ParentComp)\n' +
+      '    in ParentComp'
     );
   });
 
@@ -318,7 +320,8 @@ describe('ReactElementValidator', function() {
     expect(console.error.calls.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toBe(
       'Warning: Failed propType: ' +
-      'Required prop `prop` was not specified in `Component`.'
+      'Required prop `prop` was not specified in `Component`.\n' +
+      '    in Component'
     );
   });
 
@@ -342,7 +345,8 @@ describe('ReactElementValidator', function() {
     expect(console.error.calls.length).toBe(1);
     expect(console.error.argsForCall[0][0]).toBe(
       'Warning: Failed propType: ' +
-      'Required prop `prop` was not specified in `Component`.'
+      'Required prop `prop` was not specified in `Component`.\n' +
+      '    in Component'
     );
   });
 
@@ -368,13 +372,15 @@ describe('ReactElementValidator', function() {
     expect(console.error.calls.length).toBe(2);
     expect(console.error.argsForCall[0][0]).toBe(
       'Warning: Failed propType: ' +
-      'Required prop `prop` was not specified in `Component`.'
+      'Required prop `prop` was not specified in `Component`.\n' +
+      '    in Component'
     );
 
     expect(console.error.argsForCall[1][0]).toBe(
       'Warning: Failed propType: ' +
       'Invalid prop `prop` of type `number` supplied to ' +
-      '`Component`, expected `string`.'
+      '`Component`, expected `string`.\n' +
+      '    in Component'
     );
 
     ReactTestUtils.renderIntoDocument(

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -891,8 +891,11 @@ describe('ReactPropTypes', function() {
       var instance = <Component num={6} />;
       instance = ReactTestUtils.renderIntoDocument(instance);
       expect(console.error.argsForCall.length).toBe(1);
-      expect(console.error.argsForCall[0][0]).toBe(
-        'Warning: Failed propType: num must be 5!'
+      expect(
+        console.error.argsForCall[0][0].replace(/\(at .+?:\d+\)/g, '(at **)')
+      ).toBe(
+        'Warning: Failed propType: num must be 5!\n' +
+        '    in Component (at **)'
       );
     });
 

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -195,10 +195,14 @@ describe('ReactJSXElementValidator', function() {
       }
     }
     ReactTestUtils.renderIntoDocument(<ParentComp />);
-    expect(console.error.argsForCall[0][0]).toBe(
+    expect(
+      console.error.argsForCall[0][0].replace(/\(at .+?:\d+\)/g, '(at **)')
+    ).toBe(
       'Warning: Failed propType: ' +
       'Invalid prop `color` of type `number` supplied to `MyComp`, ' +
-      'expected `string`. Check the render method of `ParentComp`.'
+      'expected `string`.\n' +
+      '    in MyComp (at **)\n' +
+      '    in ParentComp (at **)'
     );
   });
 
@@ -242,9 +246,12 @@ describe('ReactJSXElementValidator', function() {
     ReactTestUtils.renderIntoDocument(<RequiredPropComponent />);
 
     expect(console.error.calls.length).toBe(1);
-    expect(console.error.argsForCall[0][0]).toBe(
+    expect(
+      console.error.argsForCall[0][0].replace(/\(at .+?:\d+\)/g, '(at **)')
+    ).toBe(
       'Warning: Failed propType: ' +
-      'Required prop `prop` was not specified in `RequiredPropComponent`.'
+      'Required prop `prop` was not specified in `RequiredPropComponent`.\n' +
+      '    in RequiredPropComponent (at **)'
     );
   });
 
@@ -254,9 +261,12 @@ describe('ReactJSXElementValidator', function() {
     ReactTestUtils.renderIntoDocument(<RequiredPropComponent prop={null} />);
 
     expect(console.error.calls.length).toBe(1);
-    expect(console.error.argsForCall[0][0]).toBe(
+    expect(
+      console.error.argsForCall[0][0].replace(/\(at .+?:\d+\)/g, '(at **)')
+    ).toBe(
       'Warning: Failed propType: ' +
-      'Required prop `prop` was not specified in `RequiredPropComponent`.'
+      'Required prop `prop` was not specified in `RequiredPropComponent`.\n' +
+      '    in RequiredPropComponent (at **)'
     );
   });
 
@@ -267,15 +277,21 @@ describe('ReactJSXElementValidator', function() {
     ReactTestUtils.renderIntoDocument(<RequiredPropComponent prop={42} />);
 
     expect(console.error.calls.length).toBe(2);
-    expect(console.error.argsForCall[0][0]).toBe(
+    expect(
+      console.error.argsForCall[0][0].replace(/\(at .+?:\d+\)/g, '(at **)')
+    ).toBe(
       'Warning: Failed propType: ' +
-      'Required prop `prop` was not specified in `RequiredPropComponent`.'
+      'Required prop `prop` was not specified in `RequiredPropComponent`.\n' +
+      '    in RequiredPropComponent (at **)'
     );
 
-    expect(console.error.argsForCall[1][0]).toBe(
+    expect(
+      console.error.argsForCall[1][0].replace(/\(at .+?:\d+\)/g, '(at **)')
+    ).toBe(
       'Warning: Failed propType: ' +
       'Invalid prop `prop` of type `number` supplied to ' +
-      '`RequiredPropComponent`, expected `string`.'
+      '`RequiredPropComponent`, expected `string`.\n' +
+      '    in RequiredPropComponent (at **)'
     );
 
     ReactTestUtils.renderIntoDocument(<RequiredPropComponent prop="string" />);

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -253,6 +253,8 @@ if (__DEV__) {
     var contentDebugID = debugID + '#text';
     this._contentDebugID = contentDebugID;
     ReactInstrumentation.debugTool.onSetDisplayName(contentDebugID, '#text');
+    ReactInstrumentation.debugTool.onSetParent(contentDebugID, debugID);
+    ReactInstrumentation.debugTool.onBeforeMountComponent(contentDebugID);
     ReactInstrumentation.debugTool.onSetText(contentDebugID, '' + contentToUse);
     ReactInstrumentation.debugTool.onMountComponent(contentDebugID);
     ReactInstrumentation.debugTool.onSetChildren(debugID, [contentDebugID]);

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -471,12 +471,21 @@ var ReactCompositeComponentMixin = {
     }
 
     this._renderedNodeType = ReactNodeTypes.getType(renderedElement);
-    this._renderedComponent = this._instantiateReactComponent(
+    var child = this._instantiateReactComponent(
       renderedElement
     );
+    this._renderedComponent = child;
+    if (__DEV__) {
+      if (child._debugID !== 0 && this._debugID !== 0) {
+        ReactInstrumentation.debugTool.onSetParent(
+          child._debugID,
+          this._debugID
+        );
+      }
+    }
 
     var markup = ReactReconciler.mountComponent(
-      this._renderedComponent,
+      child,
       transaction,
       hostParent,
       hostContainerInfo,
@@ -487,9 +496,7 @@ var ReactCompositeComponentMixin = {
       if (this._debugID !== 0) {
         ReactInstrumentation.debugTool.onSetChildren(
           this._debugID,
-          this._renderedComponent._debugID !== 0 ?
-            [this._renderedComponent._debugID] :
-            []
+          child._debugID !== 0 ? [child._debugID] : []
         );
       }
     }
@@ -1031,12 +1038,21 @@ var ReactCompositeComponentMixin = {
       ReactReconciler.unmountComponent(prevComponentInstance, false);
 
       this._renderedNodeType = ReactNodeTypes.getType(nextRenderedElement);
-      this._renderedComponent = this._instantiateReactComponent(
+      var child = this._instantiateReactComponent(
         nextRenderedElement
       );
+      this._renderedComponent = child;
+      if (__DEV__) {
+        if (child._debugID !== 0 && this._debugID !== 0) {
+          ReactInstrumentation.debugTool.onSetParent(
+            child._debugID,
+            this._debugID
+          );
+        }
+      }
 
       var nextMarkup = ReactReconciler.mountComponent(
-        this._renderedComponent,
+        child,
         transaction,
         this._hostParent,
         this._hostContainerInfo,
@@ -1047,9 +1063,7 @@ var ReactCompositeComponentMixin = {
         if (this._debugID !== 0) {
           ReactInstrumentation.debugTool.onSetChildren(
             this._debugID,
-            this._renderedComponent._debugID !== 0 ?
-              [this._renderedComponent._debugID] :
-              []
+            child._debugID !== 0 ? [child._debugID] : []
           );
         }
       }

--- a/src/renderers/shared/stack/reconciler/ReactMultiChild.js
+++ b/src/renderers/shared/stack/reconciler/ReactMultiChild.js
@@ -139,8 +139,14 @@ function processQueue(inst, updateQueue) {
   );
 }
 
+var setParentForInstrumentation = emptyFunction;
 var setChildrenForInstrumentation = emptyFunction;
 if (__DEV__) {
+  setParentForInstrumentation = function(child) {
+    if (child._debugID !== 0) {
+      ReactInstrumentation.debugTool.onSetParent(child._debugID, this._debugID);
+    }
+  };
   setChildrenForInstrumentation = function(children) {
     ReactInstrumentation.debugTool.onSetChildren(
       this._debugID,
@@ -232,6 +238,9 @@ var ReactMultiChild = {
       for (var name in children) {
         if (children.hasOwnProperty(name)) {
           var child = children[name];
+          if (__DEV__) {
+            setParentForInstrumentation.call(this, child);
+          }
           var mountImage = ReactReconciler.mountComponent(
             child,
             transaction,

--- a/src/renderers/shared/stack/reconciler/ReactReconciler.js
+++ b/src/renderers/shared/stack/reconciler/ReactReconciler.js
@@ -222,6 +222,10 @@ var ReactReconciler = {
           internalInstance._debugID,
           'performUpdateIfNecessary'
         );
+        ReactInstrumentation.debugTool.onBeforeUpdateComponent(
+          internalInstance._debugID,
+          internalInstance._currentElement
+        );
       }
     }
     internalInstance.performUpdateIfNecessary(transaction);

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactStatelessComponent-test.js
@@ -175,9 +175,12 @@ describe('ReactStatelessComponent', function() {
     spyOn(console, 'error');
     ReactTestUtils.renderIntoDocument(<Child />);
     expect(console.error.argsForCall.length).toBe(1);
-    expect(console.error.argsForCall[0][0]).toBe(
+    expect(
+      console.error.argsForCall[0][0].replace(/\(at .+?:\d+\)/g, '(at **)')
+    ).toBe(
       'Warning: Failed propType: Invalid prop `test` of type `number` ' +
-      'supplied to `Child`, expected `string`.'
+      'supplied to `Child`, expected `string`.\n' +
+      '    in Child (at **)'
     );
   });
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/6820/15267642/f7392460-197b-11e6-8009-f2204aaee487.png)

This works pretty well, even if you don't have source info compiled in – it falls back to annotating with owner info. The weirdest thing I noticed is that if A renders `<section><B /></section>` and B renders `<div><C /></div>` and C gives a warning, then the stack will be

```
in C (created by B)
in B (created by A)
in section (created by A)
in A
```

and makes no mention of the div that should live between B and C: it can't, because that element hasn't been created yet. I think this probably won't be too confusing in practice but I wonder if there's something we can do to make it clearer.

cc @facebook/react-core