### PR TITLE
ReactMultiChild: Extract mountIndex onto a wrapper object

### DIFF
--- a/src/renderers/dom/client/ReactDOMComponentTree.js
+++ b/src/renderers/dom/client/ReactDOMComponentTree.js
@@ -79,7 +79,7 @@ function precacheChildNodes(inst, node) {
     if (!children.hasOwnProperty(name)) {
       continue;
     }
-    var childInst = children[name];
+    var childInst = children[name].instance;
     var childID = getRenderedHostOrTextFromComponent(childInst)._domID;
     if (childID === 0) {
       // We're currently unmounting this child in ReactMultiChild; skip it.

--- a/src/renderers/dom/shared/ReactDOMTextComponent.js
+++ b/src/renderers/dom/shared/ReactDOMTextComponent.js
@@ -44,7 +44,6 @@ var ReactDOMTextComponent = function(text) {
 
   // Properties
   this._domID = 0;
-  this._mountIndex = 0;
   this._closingComment = null;
   this._commentNodes = null;
 };

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactMultiChildReconcile-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactMultiChildReconcile-test.js
@@ -95,7 +95,7 @@ class FriendsStatusDisplay extends React.Component {
       var child = statusDisplays[name];
       var isPresent = !!child;
       if (isPresent) {
-        originalKeys[child._mountIndex] = getOriginalKey(name);
+        originalKeys[child.mountIndex] = getOriginalKey(name);
       }
     }
     return originalKeys;

--- a/src/renderers/shared/stack/reconciler/instantiateReactComponent.js
+++ b/src/renderers/shared/stack/reconciler/instantiateReactComponent.js
@@ -118,12 +118,6 @@ function instantiateReactComponent(node, shouldHaveDebugID) {
     );
   }
 
-  // These two fields are used by the DOM and ART diffing algorithms
-  // respectively. Instead of using expandos on components, we should be
-  // storing the state needed by the diffing algorithms elsewhere.
-  instance._mountIndex = 0;
-  instance._mountImage = null;
-
   if (__DEV__) {
     instance._debugID = shouldHaveDebugID ? nextDebugID++ : 0;
   }

--- a/src/renderers/testing/ReactTestRenderer.js
+++ b/src/renderers/testing/ReactTestRenderer.js
@@ -71,7 +71,7 @@ ReactTestComponent.prototype.toJSON = function() {
   var {children, ...props} = this._currentElement.props;
   var childrenJSON = [];
   for (var key in this._renderedChildren) {
-    var inst = this._renderedChildren[key];
+    var inst = this._renderedChildren[key].instance;
     inst = getRenderedHostOrTextFromComponent(inst);
     var json = inst.toJSON();
     if (json !== undefined) {

--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -54,7 +54,7 @@ function findAllInRenderedTreeInternal(inst, test) {
       }
       ret = ret.concat(
         findAllInRenderedTreeInternal(
-          renderedChildren[key],
+          renderedChildren[key].instance,
           test
         )
       );

--- a/src/test/reactComponentExpect.js
+++ b/src/test/reactComponentExpect.js
@@ -90,8 +90,10 @@ Object.assign(reactComponentExpectInternal.prototype, {
         continue;
       }
       if (renderedChildren[name]) {
-        if (renderedChildren[name]._mountIndex === childIndex) {
-          return new reactComponentExpectInternal(renderedChildren[name]);
+        if (renderedChildren[name].mountIndex === childIndex) {
+          return new reactComponentExpectInternal(
+            renderedChildren[name].instance
+          );
         }
       }
     }


### PR DESCRIPTION
With an extra field for `_mountImage` that React ART still uses (its `mountAndInjectChildren` sets `_renderedChildren[key]._mountImage`. We can get rid of that in the next major.

@sebmarkbage
