### PR TITLE
Make TestUtils format in documentation more consistent

### DIFF
--- a/docs/docs/10.4-test-utils.md
+++ b/docs/docs/10.4-test-utils.md
@@ -142,7 +142,8 @@ Traverse all components in `tree` and accumulate all components where `test(comp
 
 ```javascript
 array scryRenderedDOMComponentsWithClass(
-  ReactComponent tree, string className
+  ReactComponent tree, 
+  string className
 )
 ```
 
@@ -196,7 +197,8 @@ Finds all instances of components with type equal to `componentClass`.
 
 ```javascript
 ReactComponent findRenderedComponentWithType(
-  ReactComponent tree, function componentClass
+  ReactComponent tree, 
+  function componentClass
 )
 ```
 


### PR DESCRIPTION
Hey I noticed that in the TestUtils documentation that the the format of a couple of the function definitions weren't quite consistent with the rest of the function definitions format so I made them more consistent to increase readability. :)