### PR TITLE
Embed JSX filename paths relative to repo root

### DIFF
--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -54,7 +54,10 @@ module.exports = {
     ) {
       return babel.transform(
         src,
-        Object.assign({filename: filePath}, babelOptions)
+        Object.assign(
+          {filename: path.relative(process.cwd(), filePath)},
+          babelOptions
+        )
       ).code;
     }
     return src;


### PR DESCRIPTION
Test Plan: Changed the preprocessor to log the output of babel.transform and saw

```
var _jsxFileName = 'src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js';
```

in the resulting output, instead of an absolute path.

@zpao