### PR TITLE
Add PropTypes for `map`, `set`, `weakMap`, `weakSet`, `setOf`

### DIFF
--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -66,8 +66,17 @@ var getIteratorFn = require('getIteratorFn');
 
 var ANONYMOUS = '<<anonymous>>';
 
+const SET_TAG = '[object Set]';
+const MAP_TAG = '[object Map]';
+const WEAKSET_TAG = '[object WeakSet]';
+const WEAKMAP_TAG = '[object WeakMap]';
+
 var ReactPropTypes = {
   array: createPrimitiveTypeChecker('array'),
+  set: createPrimitiveTypeChecker('set'),
+  weakSet: createPrimitiveTypeChecker('weakSet'),
+  map: createPrimitiveTypeChecker('map'),
+  weakMap: createPrimitiveTypeChecker('weakMap'),
   bool: createPrimitiveTypeChecker('boolean'),
   func: createPrimitiveTypeChecker('function'),
   number: createPrimitiveTypeChecker('number'),
@@ -77,6 +86,7 @@ var ReactPropTypes = {
 
   any: createAnyTypeChecker(),
   arrayOf: createArrayOfTypeChecker,
+  setOf: createSetOfTypeChecker,
   element: createElementTypeChecker(),
   instanceOf: createInstanceTypeChecker,
   node: createNodeChecker(),
@@ -158,6 +168,39 @@ function createPrimitiveTypeChecker(expectedType) {
 
 function createAnyTypeChecker() {
   return createChainableTypeChecker(emptyFunction.thatReturns(null));
+}
+
+function createSetOfTypeChecker(typeChecker) {
+  function validate(props, propName, componentName, location, propFullName) {
+    if (typeof typeChecker !== 'function') {
+      return new Error(
+        `Property \`${propFullName}\` of component \`${componentName}\` has invalid PropType notation inside setOf.`
+      );
+    }
+    var propValue = props[propName];
+    if (!isSet(propValue)) {
+      var locationName = ReactPropTypeLocationNames[location];
+      var propType = getPropType(propValue);
+      return new Error(
+        `Invalid ${locationName} \`${propFullName}\` of type ` +
+        `\`${propType}\` supplied to \`${componentName}\`, expected a set.`
+      );
+    }
+    for (var i = 0, values = Array.from(propValue); i < values.length; i++) {
+      var error = typeChecker(
+        values,
+        i,
+        componentName,
+        location,
+        `${propFullName}[${i}]`
+      );
+      if (error instanceof Error) {
+        return error;
+      }
+    }
+    return null;
+  }
+  return createChainableTypeChecker(validate);
 }
 
 function createArrayOfTypeChecker(typeChecker) {
@@ -426,6 +469,22 @@ function isSymbol(propType, propValue) {
   return false;
 }
 
+function isSet(propValue) {
+  return propValue.toString() === SET_TAG;
+}
+
+function isMap(propValue) {
+  return propValue.toString() === MAP_TAG;
+}
+
+function isWeakSet(propValue) {
+  return propValue.toString() === WEAKSET_TAG;
+}
+
+function isWeakMap(propValue) {
+  return propValue.toString() === WEAKMAP_TAG;
+}
+
 // Equivalent of `typeof` but with special handling for array and regexp.
 function getPropType(propValue) {
   var propType = typeof propValue;
@@ -440,6 +499,18 @@ function getPropType(propValue) {
   }
   if (isSymbol(propType, propValue)) {
     return 'symbol';
+  }
+  if (isSet(propValue)) {
+    return 'set';
+  }
+  if (isMap(propValue)) {
+    return 'map';
+  }
+  if (isWeakSet(propValue)) {
+    return 'weakSet';
+  }
+  if (isWeakMap(propValue)) {
+    return 'weakMap';
   }
   return propType;
 }

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -86,6 +86,30 @@ describe('ReactPropTypes', function() {
         'Invalid prop `testProp` of type `symbol` supplied to ' +
         '`testComponent`, expected `string`.'
       );
+      typeCheckFail(
+        PropTypes.string,
+        new Set(),
+        'Invalid prop `testProp` of type `set` supplied to ' +
+        '`testComponent`, expected `string`.'
+      );
+      typeCheckFail(
+        PropTypes.string,
+        new Map(),
+        'Invalid prop `testProp` of type `map` supplied to ' +
+        '`testComponent`, expected `string`.'
+      );
+      typeCheckFail(
+        PropTypes.string,
+        new WeakSet(),
+        'Invalid prop `testProp` of type `weakSet` supplied to ' +
+        '`testComponent`, expected `string`.'
+      );
+      typeCheckFail(
+        PropTypes.string,
+        new WeakMap(),
+        'Invalid prop `testProp` of type `weakMap` supplied to ' +
+        '`testComponent`, expected `string`.'
+      );
     });
 
     it('should fail date and regexp correctly', function() {
@@ -113,6 +137,10 @@ describe('ReactPropTypes', function() {
       typeCheckPass(PropTypes.object, new Date());
       typeCheckPass(PropTypes.object, /please/);
       typeCheckPass(PropTypes.symbol, Symbol());
+      typeCheckPass(PropTypes.set, new Set());
+      typeCheckPass(PropTypes.map, new Map());
+      typeCheckPass(PropTypes.weakSet, new WeakSet());
+      typeCheckPass(PropTypes.weakMap, new WeakMap());
     });
 
     it('should be implicitly optional and not warn without values', function() {
@@ -132,6 +160,10 @@ describe('ReactPropTypes', function() {
       typeCheckPass(PropTypes.any, 'str');
       typeCheckPass(PropTypes.any, []);
       typeCheckPass(PropTypes.any, Symbol());
+      typeCheckPass(PropTypes.any, new Set());
+      typeCheckPass(PropTypes.any, new Map());
+      typeCheckPass(PropTypes.any, new WeakSet());
+      typeCheckPass(PropTypes.any, new WeakMap());
     });
 
     it('should be implicitly optional and not warn without values', function() {
@@ -159,6 +191,10 @@ describe('ReactPropTypes', function() {
       typeCheckPass(PropTypes.arrayOf(PropTypes.string), ['a', 'b', 'c']);
       typeCheckPass(PropTypes.arrayOf(PropTypes.oneOf(['a', 'b'])), ['a', 'b']);
       typeCheckPass(PropTypes.arrayOf(PropTypes.symbol), [Symbol(), Symbol()]);
+      typeCheckPass(PropTypes.arrayOf(PropTypes.set), [new Set(), new Set()]);
+      typeCheckPass(PropTypes.arrayOf(PropTypes.map), [new Map(), new Map()]);
+      typeCheckPass(PropTypes.arrayOf(PropTypes.weakSet), [new WeakSet(), new WeakSet()]);
+      typeCheckPass(PropTypes.arrayOf(PropTypes.weakMap), [new WeakMap(), new WeakMap()]);
     });
 
     it('should support arrayOf with complex types', function() {
@@ -233,6 +269,99 @@ describe('ReactPropTypes', function() {
       );
       typeCheckFail(
         PropTypes.arrayOf(PropTypes.number).isRequired,
+        undefined,
+        requiredMessage
+      );
+    });
+  });
+
+  describe('SetOf Type', function() {
+    it('should fail for invalid argument', function() {
+      typeCheckFail(
+        PropTypes.setOf({ foo: PropTypes.string }),
+        { foo: 'bar' },
+        'Property `testProp` of component `testComponent` has invalid PropType notation inside setOf.'
+      );
+    });
+
+    it('should support the setOf propTypes', function() {
+      typeCheckPass(PropTypes.setOf(PropTypes.number), new Set([1, 2, 3]));
+      typeCheckPass(PropTypes.setOf(PropTypes.string), new Set(['a', 'b', 'c']));
+      typeCheckPass(PropTypes.setOf(PropTypes.oneOf(['a', 'b']), new Set(['a', 'b'])));
+      typeCheckPass(PropTypes.setOf(PropTypes.symbol), new Set([Symbol(), Symbol()]));
+      typeCheckPass(PropTypes.setOf(PropTypes.set), new Set([new Set(), new Set()]));
+      typeCheckPass(PropTypes.setOf(PropTypes.map), new Set([new Map(), new Map()]));
+      typeCheckPass(PropTypes.setOf(PropTypes.weakSet), new Set([new WeakSet(), new WeakSet()]));
+      typeCheckPass(PropTypes.setOf(PropTypes.weakMap), new Set([new WeakMap(), new WeakMap()]));
+      typeCheckPass(PropTypes.setOf(PropTypes.array), new Set([['a', 'b', 'c'], ['d', 'e', 'f']]));
+    });
+
+    it('should support setOf with complex types', function() {
+      typeCheckPass(
+        PropTypes.setOf(PropTypes.shape({a: PropTypes.number.isRequired})),
+        new Set([{a: 1}, {a: 2}])
+      );
+
+      function Thing() {}
+      typeCheckPass(
+        PropTypes.setOf(PropTypes.instanceOf(Thing)),
+        new Set([new Thing(), new Thing()])
+      );
+    });
+
+    it('should warn with invalid items in the set', function() {
+      typeCheckFail(
+        PropTypes.setOf(PropTypes.number),
+        new Set([1, 2, 'b']),
+        'Invalid prop `testProp[2]` of type `string` supplied to ' +
+        '`testComponent`, expected `number`.'
+      );
+    });
+
+    it('should warn with invalid complex types', function() {
+      function Thing() {}
+      var name = Thing.name || '<<anonymous>>';
+
+      typeCheckFail(
+        PropTypes.setOf(PropTypes.instanceOf(Thing)),
+        new Set([new Thing(), 'xyz']),
+        'Invalid prop `testProp[1]` of type `String` supplied to ' +
+        '`testComponent`, expected instance of `' + name + '`.'
+      );
+    });
+
+    it('should warn when passed something other than a set', function() {
+      typeCheckFail(
+        PropTypes.setOf(PropTypes.number),
+        123,
+        'Invalid prop `testProp` of type `number` supplied to ' +
+        '`testComponent`, expected a set.'
+      );
+      typeCheckFail(
+        PropTypes.setOf(PropTypes.number),
+        'string',
+        'Invalid prop `testProp` of type `string` supplied to ' +
+        '`testComponent`, expected a set.'
+      );
+    });
+
+    it('should not warn when passing an empty set', function() {
+      typeCheckPass(PropTypes.setOf(PropTypes.number), new Set());
+    });
+
+    it('should be implicitly optional and not warn without values', function() {
+      typeCheckPass(PropTypes.setOf(PropTypes.number), null);
+      typeCheckPass(PropTypes.setOf(PropTypes.number), undefined);
+    });
+
+    it('should warn for missing required values', function() {
+      typeCheckFail(
+        PropTypes.setOf(PropTypes.number).isRequired,
+        null,
+        requiredMessage
+      );
+      typeCheckFail(
+        PropTypes.setOf(PropTypes.number).isRequired,
         undefined,
         requiredMessage
       );
@@ -828,6 +957,110 @@ describe('ReactPropTypes', function() {
     it('should not warn for a polyfilled Symbol', function() {
       var CoreSymbol = require('core-js/library/es6/symbol');
       typeCheckPass(PropTypes.symbol, CoreSymbol('core-js'));
+    });
+  });
+
+  describe('Set Type', function() {
+    it('should warn for non-set', function() {
+      typeCheckFail(
+        PropTypes.set,
+        'hello',
+        'Invalid prop `testProp` of type `string` supplied to ' +
+        '`testComponent`, expected `set`.'
+      );
+      typeCheckFail(
+        PropTypes.set,
+        function() { },
+        'Invalid prop `testProp` of type `function` supplied to ' +
+        '`testComponent`, expected `set`.'
+      );
+      typeCheckFail(
+        PropTypes.set,
+        {
+          '@@iterator': 'Katana',
+        },
+        'Invalid prop `testProp` of type `object` supplied to ' +
+        '`testComponent`, expected `set`.'
+      );
+    });
+
+    it('should not warn for a polyfilled Set', function() {
+      var CoreSet = require('core-js/library/es6/set');
+      typeCheckPass(PropTypes.set, new CoreSet());
+    });
+  });
+
+  describe('WeakSet Type', function() {
+    it('should warn for non-weakSet', function() {
+      typeCheckFail(
+        PropTypes.weakSet,
+        'hello',
+        'Invalid prop `testProp` of type `string` supplied to ' +
+        '`testComponent`, expected `weakSet`.'
+      );
+      typeCheckFail(
+        PropTypes.weakSet,
+        function() { },
+        'Invalid prop `testProp` of type `function` supplied to ' +
+        '`testComponent`, expected `weakSet`.'
+      );
+    });
+
+    it('should not warn for a polyfilled WeakSet', function() {
+      var CoreWeakSet = require('core-js/library/es6/weak-set');
+      typeCheckPass(PropTypes.weakSet, new CoreWeakSet());
+    });
+  });
+
+  describe('Map Type', function() {
+    it('should warn for non-map', function() {
+      typeCheckFail(
+        PropTypes.map,
+        'hello',
+        'Invalid prop `testProp` of type `string` supplied to ' +
+        '`testComponent`, expected `map`.'
+      );
+      typeCheckFail(
+        PropTypes.map,
+        function() { },
+        'Invalid prop `testProp` of type `function` supplied to ' +
+        '`testComponent`, expected `map`.'
+      );
+      typeCheckFail(
+        PropTypes.map,
+        {
+          '@@iterator': 'Katana',
+        },
+        'Invalid prop `testProp` of type `object` supplied to ' +
+        '`testComponent`, expected `map`.'
+      );
+    });
+
+    it('should not warn for a polyfilled Map', function() {
+      var CoreMap = require('core-js/library/es6/map');
+      typeCheckPass(PropTypes.map, new CoreMap());
+    });
+  });
+
+  describe('WeakMap Type', function() {
+    it('should warn for non-weakMap', function() {
+      typeCheckFail(
+        PropTypes.weakMap,
+        'hello',
+        'Invalid prop `testProp` of type `string` supplied to ' +
+        '`testComponent`, expected `weakMap`.'
+      );
+      typeCheckFail(
+        PropTypes.weakMap,
+        function() { },
+        'Invalid prop `testProp` of type `function` supplied to ' +
+        '`testComponent`, expected `weakMap`.'
+      );
+    });
+
+    it('should not warn for a polyfilled WeakMap', function() {
+      var CoreWeakMap = require('core-js/library/es6/weak-map');
+      typeCheckPass(PropTypes.weakMap, new CoreWeakMap());
     });
   });
 


### PR DESCRIPTION
I think that's not fair that only [Symbol was added](https://github.com/facebook/react/pull/6377/files) as PropType from ES2015 spec.

So here are
- `PropTypes.set`
- `PropTypes.weakSet`
- `PropTypes.map`
- `PropTypes.weakMap`
- `PropTypes.setOf`