### PR TITLE
Refactor ReactComponentTreeDevtool test

### DIFF
--- a/src/test/ReactComponentTreeTestUtils.js
+++ b/src/test/ReactComponentTreeTestUtils.js
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactComponentTreeTestUtils
+ */
+
+'use strict';
+
+var ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
+
+function getRootDisplayNames() {
+  return ReactComponentTreeDevtool.getRootIDs()
+    .map(ReactComponentTreeDevtool.getDisplayName);
+}
+
+function getRegisteredDisplayNames() {
+  return ReactComponentTreeDevtool.getRegisteredIDs()
+    .map(ReactComponentTreeDevtool.getDisplayName);
+}
+
+function expectTree(rootID, expectedTree, parentPath = '') {
+  var displayName = ReactComponentTreeDevtool.getDisplayName(rootID);
+  var ownerID = ReactComponentTreeDevtool.getOwnerID(rootID);
+  var parentID = ReactComponentTreeDevtool.getParentID(rootID);
+  var childIDs = ReactComponentTreeDevtool.getChildIDs(rootID);
+  var text = ReactComponentTreeDevtool.getText(rootID);
+  var path = parentPath ? `${parentPath} > ${displayName}` : displayName;
+
+  function expectEqual(actual, expected, name) {
+    // Get Jasmine to print descriptive error messages.
+    // We pass path so that we know where the mismatch occurred.
+    expect({
+      path,
+      [name]: actual,
+    }).toEqual({
+      path,
+      [name]: expected,
+    });
+  }
+
+  if (expectedTree.parentDisplayName !== undefined) {
+    expectEqual(
+      ReactComponentTreeDevtool.getDisplayName(parentID),
+      expectedTree.parentDisplayName,
+      'parentDisplayName'
+    );
+  }
+  if (expectedTree.ownerDisplayName !== undefined) {
+    expectEqual(
+      ReactComponentTreeDevtool.getDisplayName(ownerID),
+      expectedTree.ownerDisplayName,
+      'ownerDisplayName'
+    );
+  }
+  if (expectedTree.parentID !== undefined) {
+    expectEqual(parentID, expectedTree.parentID, 'parentID');
+  }
+  if (expectedTree.text !== undefined) {
+    expectEqual(text, expectedTree.text, 'text');
+  } else {
+    expectEqual(text, null, 'text');
+  }
+  if (expectedTree.children !== undefined) {
+    expectEqual(
+      childIDs.length,
+      expectedTree.children.length,
+      'children.length'
+    );
+    for (var i = 0; i < childIDs.length; i++) {
+      expectTree(
+        childIDs[i],
+        {parentID: rootID, ...expectedTree.children[i]},
+        path
+      );
+    }
+  } else {
+    expectEqual(childIDs, [], 'childIDs');
+  }
+}
+
+var ReactComponentTreeTestUtils = {
+  expectTree,
+  getRootDisplayNames,
+  getRegisteredDisplayNames,
+};
+
+module.exports = ReactComponentTreeTestUtils;


### PR DESCRIPTION
We extract common logic between DOM and native tests so they don't diverge.

Also, rather than build a tree object in advance for testing, we will walk the tree on the go.
This lets us have much more specific error messages with a clear path when something goes wrong.

Example test error before this change:

<img width="798" alt="screen shot 2016-05-17 at 20 49 29" src="https://cloud.githubusercontent.com/assets/810438/15337030/628e805a-1c71-11e6-83fd-a9ccb7f25cb0.png">

Example test error after this change:

<img width="922" alt="screen shot 2016-05-17 at 20 48 14" src="https://cloud.githubusercontent.com/assets/810438/15337033/69f22f90-1c71-11e6-8a5d-dd79fc403ff4.png">

@spicyj @jimfb 