### PR TITLE
Update typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "run-sequence": "^1.1.4",
     "through2": "^2.0.0",
     "tmp": "~0.0.28",
-    "typescript": "~1.4.0",
+    "typescript": "~1.8.10",
     "uglify-js": "^2.5.0",
     "uglifyify": "^3.0.1"
   },

--- a/scripts/jest/ts-preprocessor.js
+++ b/scripts/jest/ts-preprocessor.js
@@ -31,11 +31,13 @@ function compile(content, contentFilename) {
         path.join('/', '(?:React|ReactDOM)(?:\.d)?\.ts$')
       );
 
+      var jestRegex = /jest\.d\.ts/;
+
       if (filename === 'lib.d.ts') {
         source = fs.readFileSync(
           require.resolve('typescript/lib/lib.d.ts')
         ).toString();
-      } else if (filename === 'jest.d.ts') {
+      } else if (filename.match(jestRegex)) {
         source = fs.readFileSync(
           path.join(__dirname, 'jest.d.ts')
         ).toString();

--- a/scripts/jest/ts-preprocessor.js
+++ b/scripts/jest/ts-preprocessor.js
@@ -4,12 +4,15 @@ var fs = require('fs');
 var path = require('path');
 var ts = require('typescript');
 
-var tsOptions = {module: 'commonjs'};
+var tsOptions = {
+  module: ts.ModuleKind.CommonJS,
+  jsx: ts.JsxEmit.React,
+};
 
 function formatErrorMessage(error) {
   return (
     error.file.filename + '(' +
-    error.file.getLineAndCharacterFromPosition(error.start).line +
+    error.file.getLineAndCharacterOfPosition(error.start).line +
     '): ' +
     error.messageText
   );
@@ -18,7 +21,7 @@ function formatErrorMessage(error) {
 function compile(content, contentFilename) {
   var output = null;
   var compilerHost = {
-    getSourceFile: function(filename, languageVersion) {
+    getSourceFile(filename, languageVersion) {
       var source;
 
       // `path.normalize` and `path.join` are used to turn forward slashes in
@@ -30,7 +33,7 @@ function compile(content, contentFilename) {
 
       if (filename === 'lib.d.ts') {
         source = fs.readFileSync(
-          require.resolve('typescript/bin/lib.d.ts')
+          require.resolve('typescript/lib/lib.d.ts')
         ).toString();
       } else if (filename === 'jest.d.ts') {
         source = fs.readFileSync(
@@ -55,21 +58,27 @@ function compile(content, contentFilename) {
       }
       return ts.createSourceFile(filename, source, 'ES5', '0');
     },
-    writeFile: function(name, text, writeByteOrderMark) {
+    writeFile(name, text, writeByteOrderMark) {
       if (output === null) {
         output = text;
       } else {
         throw new Error('Expected only one dependency.');
       }
     },
-    getCanonicalFileName: function(filename) {
+    getCanonicalFileName(filename) {
       return filename;
     },
-    getCurrentDirectory: function() {
+    getCurrentDirectory() {
       return '';
     },
-    getNewLine: function() {
+    getNewLine() {
       return '\n';
+    },
+    fileExists(filename) {
+      return ts.sys.fileExists(filename);
+    },
+    useCaseSensitiveFileNames() {
+      return ts.sys.useCaseSensitiveFileNames;
     },
   };
   var program = ts.createProgram([
@@ -77,12 +86,8 @@ function compile(content, contentFilename) {
     'jest.d.ts',
     contentFilename,
   ], tsOptions, compilerHost);
-  var errors = program.getDiagnostics();
-  if (!errors.length) {
-    var checker = program.getTypeChecker(true);
-    errors = checker.getDiagnostics();
-    checker.emitFiles();
-  }
+  var emitResult = program.emit();
+  var errors = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
   if (errors.length) {
     throw new Error(errors.map(formatErrorMessage).join('\n'));
   }

--- a/src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
+++ b/src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
@@ -1,3 +1,6 @@
+/// <reference path="../React.d.ts" />
+/// <reference path="../ReactDOM.d.ts" />
+
 /*!
  * Copyright 2015-present, Facebook, Inc.
  * All rights reserved.


### PR DESCRIPTION
based on https://github.com/facebook/react/pull/6686

all i did is matched the `jest.d.ts` by regex and not string comparison (https://github.com/facebook/react/commit/cdc6e2acc7c985b6317f104aa8bdef68f4d6c35f)
the path that comes in is an absolute resolved path, so it never met the condition

i tested it with errors in type definitions and it failed (keep in mind that ts compiler has some sort of caching and to make it recompile you need to change the test file by adding whitespace or whatever)
<img width="495" alt="screen shot 2016-05-18 at 9 53 29 pm" src="https://cloud.githubusercontent.com/assets/940133/15382911/5e1d267a-1d43-11e6-9636-52814d641261.png">
<img width="1186" alt="screen shot 2016-05-18 at 9 53 46 pm" src="https://cloud.githubusercontent.com/assets/940133/15382913/62812ac2-1d43-11e6-8261-2258097d88cc.png">

will that resolve the issue?

ts compiler throws `undefined(linenumber)` errors, but i've no idea how to deal with that
cc @zpao @chicoxyzzy 