### PR TITLE
Maybe fix IE autocomplete misses

### DIFF
--- a/src/renderers/dom/client/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/ChangeEventPlugin.js
@@ -273,16 +273,20 @@ function handleEventsForInputEventIE(
   }
 }
 
-// For IE8 and IE9.
+// For <=IE11.
 function getTargetInstForInputEventIE(
   topLevelType,
   targetInst
 ) {
   if (topLevelType === topLevelTypes.topSelectionChange ||
       topLevelType === topLevelTypes.topKeyUp ||
-      topLevelType === topLevelTypes.topKeyDown) {
+      topLevelType === topLevelTypes.topKeyDown ||
+      topLevelType === topLevelTypes.topChange) {
     // On the selectionchange event, the target is just document which isn't
     // helpful for us so just check activeElement instead.
+    //
+    // The onChange event catches autocomplete changes for IE11 where
+    // onpropertychange doesn't fire.
     //
     // 99% of the time, keydown and keyup aren't necessary. IE8 fails to fire
     // propertychange on the first input event after setting `value` from a


### PR DESCRIPTION
Quick attempt to fix #6614

I HAVE NOT TESTED THIS, needs someone to confirm it actually works
instead of creating an endless event loop

It listens for the top level onChange, which is a bit dangerous
(maybe?) since the other events will fire a top level Change event,
Presumably tho the value won’t differ and it will be a loop.
Alternatively we could listen to onInput but you might get the noise
again, depending on how well the deduping is working