### PR TITLE
Add permalink

### DIFF
--- a/docs/docs/thinking-in-react.zh-CN.md
+++ b/docs/docs/thinking-in-react.zh-CN.md
@@ -1,6 +1,7 @@
 ---
 id: thinking-in-react-zh-CN
 title: React 编程思想
+permalink: thinking-in-react-zh-CN.html
 prev: tutorial-zh-CN.html
 next: conferences-zh-CN.html
 redirect_from: 'blog/2013/11/05/thinking-in-react.html'


### PR DESCRIPTION
Add permalink to docs, so we can access with 'prev' and 'next'
without it we can only access this doc use [http://facebook.github.io/react/docs/thinking-in-react.zh-CN.html](http://facebook.github.io/react/docs/thinking-in-react.zh-CN.html)
however in the file which named tutorial-zh-CN.md has designed like this:
```
---
id: tutorial-zh-CN
title: 教程
permalink: tutorial-zh-CN.html
prev: getting-started-zh-CN.html
next: thinking-in-react-zh-CN.html
---
```