### PR TITLE
Support onLoad event on link element

### DIFF
--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -519,12 +519,13 @@ ReactDOMComponent.Mixin = {
     var props = this._currentElement.props;
 
     switch (this._tag) {
-      case 'iframe':
-      case 'object':
-      case 'img':
-      case 'form':
-      case 'video':
       case 'audio':
+      case 'form':
+      case 'iframe':
+      case 'img':
+      case 'link':
+      case 'object':
+      case 'video':
         this._wrapperState = {
           listeners: null,
         };
@@ -1091,12 +1092,13 @@ ReactDOMComponent.Mixin = {
    */
   unmountComponent: function(safely) {
     switch (this._tag) {
-      case 'iframe':
-      case 'object':
-      case 'img':
-      case 'form':
-      case 'video':
       case 'audio':
+      case 'form':
+      case 'iframe':
+      case 'img':
+      case 'link':
+      case 'object':
+      case 'video':
         var listeners = this._wrapperState.listeners;
         if (listeners) {
           for (var i = 0; i < listeners.length; i++) {


### PR DESCRIPTION
According to the spec
https://developer.mozilla.org/en/docs/Web/HTML/Element/link

We should be able to use `onload` and `onerror` for link element.
http://codepen.io/anon/pen/mPZXMM

By adding the feature, we can support link attribute `preload` (w3c draft)
https://w3c.github.io/preload/ 

