### PR TITLE
[RFC] Queue callbacks between render and componentDidUpdate functions.

### DIFF
--- a/src/renderers/dom/ReactDOM.js
+++ b/src/renderers/dom/ReactDOM.js
@@ -35,6 +35,7 @@ var React = {
 
   /* eslint-disable camelcase */
   unstable_batchedUpdates: ReactUpdates.batchedUpdates,
+  unstable_asap: ReactUpdates.asap,
   unstable_renderSubtreeIntoContainer: renderSubtreeIntoContainer,
   /* eslint-enable camelcase */
 };

--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -108,6 +108,8 @@ function mountComponentIntoNode(
     console.time(markerName);
   }
 
+  transaction.getReactMountReady().enqueue(ReactUpdates.notifyAsapCallbacks);
+
   var markup = ReactReconciler.mountComponent(
     wrapperInstance,
     transaction,

--- a/src/renderers/shared/stack/reconciler/ReactUpdates.js
+++ b/src/renderers/shared/stack/reconciler/ReactUpdates.js
@@ -208,13 +208,7 @@ var flushBatchedUpdates = function() {
       ReactUpdatesFlushTransaction.release(transaction);
     }
 
-    if (asapEnqueued) {
-      asapEnqueued = false;
-      var queue = asapCallbackQueue;
-      asapCallbackQueue = CallbackQueue.getPooled();
-      queue.notifyAll();
-      CallbackQueue.release(queue);
-    }
+    notifyAsapCallbacks();
   }
 
   if (__DEV__) {
@@ -260,6 +254,16 @@ function asap(callback, context) {
   asapEnqueued = true;
 }
 
+function notifyAsapCallbacks() {
+  if (asapEnqueued) {
+    asapEnqueued = false;
+    var queue = asapCallbackQueue;
+    asapCallbackQueue = CallbackQueue.getPooled();
+    queue.notifyAll();
+    CallbackQueue.release(queue);
+  }
+}
+
 var ReactUpdatesInjection = {
   injectReconcileTransaction: function(ReconcileTransaction) {
     invariant(
@@ -300,6 +304,8 @@ var ReactUpdates = {
   flushBatchedUpdates: flushBatchedUpdates,
   injection: ReactUpdatesInjection,
   asap: asap,
+
+  notifyAsapCallbacks: notifyAsapCallbacks,
 };
 
 module.exports = ReactUpdates;


### PR DESCRIPTION
I'm experimenting with [aphrodite](https://github.com/Khan/aphrodite) in my current project. Aphrodite works well but has one flaw comparing to inline styles and css. It uses [asap](https://github.com/kriskowal/asap) to inject styles in the next tick after render functions.

Like this:
Component.render()
Component.componentDidMount/componentDidUpdate()
injectCss()
browser's render

The problem with this is than we can't measure dom in `componentDidUpdate` as css-styles are not applied yet (unless they were injected after past renders). It would be cool if there was a way to still buffer styles in all render functions but flush them before `componentDidUpdate`.

This PR is just a guess how it might look like (I haven't dug into react src much). Not intended to be merged :)