### PR TITLE
onAnimationIteration only available from v15 and up

### DIFF
--- a/docs/docs/ref-05-events.md
+++ b/docs/docs/ref-05-events.md
@@ -268,6 +268,8 @@ onLoad onError
 
 ### Animation Events
 
+Introduced in React v 15.0.0
+
 Event names:
 
 ```


### PR DESCRIPTION
This PR makes it clear that onAnimationIteration is only available from React v15 and up, as this not clear unless you go digging through the release logs.