### PR TITLE
Move ReactElementValidator to __DEV__ block

### DIFF
--- a/src/isomorphic/React.js
+++ b/src/isomorphic/React.js
@@ -16,7 +16,6 @@ var ReactComponent = require('ReactComponent');
 var ReactClass = require('ReactClass');
 var ReactDOMFactories = require('ReactDOMFactories');
 var ReactElement = require('ReactElement');
-var ReactElementValidator = require('ReactElementValidator');
 var ReactPropTypes = require('ReactPropTypes');
 var ReactVersion = require('ReactVersion');
 
@@ -28,6 +27,7 @@ var createFactory = ReactElement.createFactory;
 var cloneElement = ReactElement.cloneElement;
 
 if (__DEV__) {
+  var ReactElementValidator = require('ReactElementValidator');
   createElement = ReactElementValidator.createElement;
   createFactory = ReactElementValidator.createFactory;
   cloneElement = ReactElementValidator.cloneElement;

--- a/src/isomorphic/classic/element/ReactDOMFactories.js
+++ b/src/isomorphic/classic/element/ReactDOMFactories.js
@@ -12,7 +12,6 @@
 'use strict';
 
 var ReactElement = require('ReactElement');
-var ReactElementValidator = require('ReactElementValidator');
 
 var mapObject = require('mapObject');
 
@@ -24,6 +23,7 @@ var mapObject = require('mapObject');
  */
 function createDOMFactory(tag) {
   if (__DEV__) {
+    var ReactElementValidator = require('ReactElementValidator');
     return ReactElementValidator.createFactory(tag);
   }
   return ReactElement.createFactory(tag);


### PR DESCRIPTION
It saves some more bytes in production mode.

```
   raw     gz Compared to master @ fd589fc8dd5c8f987c6496b203f7f45f1f1fbb2e    
     =      = build/react-dom-server.js                                        
     =      = build/react-dom-server.min.js                                    
     =      = build/react-dom.js                                               
     =      = build/react-dom.min.js                                           
    +6     +1 build/react-with-addons.js                                       
 -1880   -660 build/react-with-addons.min.js                                   
    +6     -2 build/react.js                                                   
 -1875   -592 build/react.min.js       
```