### PR TITLE
Remove injectMixin

### DIFF
--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -51,8 +51,6 @@ var SpecPolicy = keyMirror({
 });
 
 
-var injectedMixins = [];
-
 /**
  * Composite components are higher-level components that compose other composite
  * or host components.
@@ -796,10 +794,6 @@ var ReactClass = {
     Constructor.prototype.constructor = Constructor;
     Constructor.prototype.__reactAutoBindPairs = [];
 
-    injectedMixins.forEach(
-      mixSpecIntoComponent.bind(null, Constructor)
-    );
-
     mixSpecIntoComponent(Constructor, spec);
 
     // Initialize the defaultProps property after all mixins have been merged.
@@ -850,12 +844,6 @@ var ReactClass = {
     }
 
     return Constructor;
-  },
-
-  injection: {
-    injectMixin: function(mixin) {
-      injectedMixins.push(mixin);
-    },
   },
 
 };


### PR DESCRIPTION
The only callsite left was removed here: https://github.com/facebook/react/commit/e8af100849932387643977587ccd7a4c1a981470#commitcomment-17570210 but the code to handle it remained.

Test Plan:
tbgs and ibgs, make sure there's no callsites.

Reviewers: @jimfb, @spicyj, @sebmarkbage