### PR TITLE
Removed unnecessary null check

### DIFF
--- a/src/renderers/dom/client/syntheticEvents/SyntheticUIEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticUIEvent.js
@@ -26,7 +26,7 @@ var UIEventInterface = {
     }
 
     var target = getEventTarget(event);
-    if (target != null && target.window === target) {
+    if (target.window === target) {
       // target is a window object
       return target;
     }


### PR DESCRIPTION
Fixes #6840.  `target` is always non-null, but this extra null check makes the code harder to read (confusing), burns CPU cycles, and increases byte size, and causes static analyzers to complain - so we might as well just remove it.

cc @spicyj 