### PR TITLE
Add-Ons: Two-way binding helpers with ES6 examples

### DIFF
--- a/docs/docs/10.2-form-input-binding-sugar.md
+++ b/docs/docs/10.2-form-input-binding-sugar.md
@@ -29,15 +29,15 @@ Two-way binding -- implicitly enforcing that some value in the DOM is always con
 Here's a simple form example without using `ReactLink`:
 
 ```javascript
-var NoLink = React.createClass({
-  getInitialState: function() {
+const NoLink = React.createClass({
+  getInitialState() {
     return {message: 'Hello!'};
   },
-  handleChange: function(event) {
+  handleChange(event) {
     this.setState({message: event.target.value});
   },
-  render: function() {
-    var message = this.state.message;
+  render() {
+    const message = this.state.message;
     return <input type="text" value={message} onChange={this.handleChange} />;
   }
 });
@@ -46,14 +46,14 @@ var NoLink = React.createClass({
 This works really well and it's very clear how data is flowing, however, with a lot of form fields it could get a bit verbose. Let's use `ReactLink` to save us some typing:
 
 ```javascript{4,9}
-var LinkedStateMixin = require('react-addons-linked-state-mixin');
+const LinkedStateMixin = require('react-addons-linked-state-mixin');
 
-var WithLink = React.createClass({
+const WithLink = React.createClass({
   mixins: [LinkedStateMixin],
-  getInitialState: function() {
+  getInitialState() {
     return {message: 'Hello!'};
   },
-  render: function() {
+  render() {
     return <input type="text" valueLink={this.linkState('message')} />;
   }
 });
@@ -75,15 +75,15 @@ There are two sides to `ReactLink`: the place where you create the `ReactLink` i
 ### ReactLink Without LinkedStateMixin
 
 ```javascript{5-7,9-12}
-var WithoutMixin = React.createClass({
-  getInitialState: function() {
+const WithoutMixin = React.createClass({
+  getInitialState() {
     return {message: 'Hello!'};
   },
-  handleChange: function(newValue) {
+  handleChange(newValue) {
     this.setState({message: newValue});
   },
-  render: function() {
-    var valueLink = {
+  render() {
+    const valueLink = {
       value: this.state.message,
       requestChange: this.handleChange
     };
@@ -97,16 +97,16 @@ As you can see, `ReactLink` objects are very simple objects that just have a `va
 ### ReactLink Without valueLink
 
 ```javascript
-var LinkedStateMixin = require('react-addons-linked-state-mixin');
+const LinkedStateMixin = require('react-addons-linked-state-mixin');
 
-var WithoutLink = React.createClass({
+const WithoutLink = React.createClass({
   mixins: [LinkedStateMixin],
-  getInitialState: function() {
+  getInitialState() {
     return {message: 'Hello!'};
   },
-  render: function() {
-    var valueLink = this.linkState('message');
-    var handleChange = function(e) {
+  render() {
+    const valueLink = this.linkState('message');
+    const handleChange = (e) => {
       valueLink.requestChange(e.target.value);
     };
     return <input type="text" value={valueLink.value} onChange={handleChange} />;


### PR DESCRIPTION
This doesn't introduce ES6 class components as the section involves mixins. Just some ES6 syntax added. Please close if not helpful.

