### PR TITLE
Fix componentWillUnmount() not counted by ReactPerf

### DIFF
--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -169,7 +169,13 @@ function batchedMountComponentIntoNode(
  * @see {ReactMount.unmountComponentAtNode}
  */
 function unmountComponentFromNode(instance, container, safely) {
+  if (__DEV__) {
+    ReactInstrumentation.debugTool.onBeginFlush();
+  }
   ReactReconciler.unmountComponent(instance, safely);
+  if (__DEV__) {
+    ReactInstrumentation.debugTool.onEndFlush();
+  }
 
   if (container.nodeType === DOC_NODE_TYPE) {
     container = container.documentElement;

--- a/src/renderers/shared/__tests__/ReactPerf-test.js
+++ b/src/renderers/shared/__tests__/ReactPerf-test.js
@@ -229,7 +229,7 @@ describe('ReactPerf', function() {
     });
   });
 
-  it('should not count replacing null with a native as waste', function() {
+  it('should not count replacing null with a host as waste', function() {
     var element = null;
     function Foo() {
       return element;
@@ -242,7 +242,7 @@ describe('ReactPerf', function() {
     });
   });
 
-  it('should not count replacing a native with null as waste', function() {
+  it('should not count replacing a host with null as waste', function() {
     var element = <div />;
     function Foo() {
       return element;
@@ -273,35 +273,36 @@ describe('ReactPerf', function() {
   it('should include lifecycle methods in measurements', function() {
     var container = document.createElement('div');
     var measurements = measure(() => {
+      var instance = ReactDOM.render(<LifeCycle />, container);
       ReactDOM.render(<LifeCycle />, container);
-      ReactDOM.render(<LifeCycle />, container);
+      instance.setState({});
       ReactDOM.unmountComponentAtNode(container);
     });
     expect(ReactPerf.getExclusive(measurements)).toEqual([{
       key: 'LifeCycle',
       instanceCount: 1,
-      totalDuration: 10,
+      totalDuration: 14,
       counts: {
         ctor: 1,
-        shouldComponentUpdate: 1,
+        shouldComponentUpdate: 2,
         componentWillMount: 1,
         componentDidMount: 1,
         componentWillReceiveProps: 1,
-        componentWillUpdate: 1,
-        componentDidUpdate: 1,
+        componentWillUpdate: 2,
+        componentDidUpdate: 2,
         componentWillUnmount: 1,
-        render: 2,
+        render: 3,
       },
       durations: {
         ctor: 1,
-        shouldComponentUpdate: 1,
+        shouldComponentUpdate: 2,
         componentWillMount: 1,
         componentDidMount: 1,
         componentWillReceiveProps: 1,
-        componentWillUpdate: 1,
-        componentDidUpdate: 1,
+        componentWillUpdate: 2,
+        componentDidUpdate: 2,
         componentWillUnmount: 1,
-        render: 2,
+        render: 3,
       },
     }]);
   });

--- a/src/renderers/shared/__tests__/ReactPerf-test.js
+++ b/src/renderers/shared/__tests__/ReactPerf-test.js
@@ -16,10 +16,12 @@ describe('ReactPerf', function() {
   var ReactDOM;
   var ReactPerf;
   var ReactTestUtils;
+  var emptyFunction;
 
   var App;
   var Box;
   var Div;
+  var LifeCycle;
 
   beforeEach(function() {
     var now = 0;
@@ -36,6 +38,7 @@ describe('ReactPerf', function() {
     ReactDOM = require('ReactDOM');
     ReactPerf = require('ReactPerf');
     ReactTestUtils = require('ReactTestUtils');
+    emptyFunction = require('emptyFunction');
 
     App = React.createClass({
       render: function() {
@@ -54,6 +57,17 @@ describe('ReactPerf', function() {
       render: function() {
         return <div {...this.props} />;
       },
+    });
+
+    LifeCycle = React.createClass({
+      shouldComponentUpdate: emptyFunction.thatReturnsTrue,
+      componentWillMount: emptyFunction,
+      componentDidMount: emptyFunction,
+      componentWillReceiveProps: emptyFunction,
+      componentWillUpdate: emptyFunction,
+      componentDidUpdate: emptyFunction,
+      componentWillUnmount: emptyFunction,
+      render: emptyFunction.thatReturnsNull,
     });
   });
 
@@ -253,6 +267,42 @@ describe('ReactPerf', function() {
       counts: { ctor: 3, render: 4 },
       durations: { ctor: 3, render: 4 },
       totalDuration: 7,
+    }]);
+  });
+
+  it('should include lifecycle methods in measurements', function() {
+    var container = document.createElement('div');
+    var measurements = measure(() => {
+      ReactDOM.render(<LifeCycle />, container);
+      ReactDOM.render(<LifeCycle />, container);
+      ReactDOM.unmountComponentAtNode(container);
+    });
+    expect(ReactPerf.getExclusive(measurements)).toEqual([{
+      key: 'LifeCycle',
+      instanceCount: 1,
+      totalDuration: 10,
+      counts: {
+        ctor: 1,
+        shouldComponentUpdate: 1,
+        componentWillMount: 1,
+        componentDidMount: 1,
+        componentWillReceiveProps: 1,
+        componentWillUpdate: 1,
+        componentDidUpdate: 1,
+        componentWillUnmount: 1,
+        render: 2,
+      },
+      durations: {
+        ctor: 1,
+        shouldComponentUpdate: 1,
+        componentWillMount: 1,
+        componentDidMount: 1,
+        componentWillReceiveProps: 1,
+        componentWillUpdate: 1,
+        componentDidUpdate: 1,
+        componentWillUnmount: 1,
+        render: 2,
+      },
     }]);
   });
 

--- a/src/renderers/shared/__tests__/ReactPerf-test.js
+++ b/src/renderers/shared/__tests__/ReactPerf-test.js
@@ -306,6 +306,28 @@ describe('ReactPerf', function() {
     }]);
   });
 
+  it('should include render time of functional components', function() {
+    function Foo() {
+      return null;
+    }
+
+    var container = document.createElement('div');
+    var measurements = measure(() => {
+      ReactDOM.render(<Foo />, container);
+    });
+    expect(ReactPerf.getExclusive(measurements)).toEqual([{
+      key: 'Foo',
+      instanceCount: 1,
+      totalDuration: 1,
+      counts: {
+        render: 1,
+      },
+      durations: {
+        render: 1,
+      },
+    }]);
+  });
+
   it('warns once when using getMeasurementsSummaryMap', function() {
     var measurements = measure(() => {});
     spyOn(console, 'error');


### PR DESCRIPTION
This fixes `componentWillUnmount()` not being measured because `ReactDebugTool` doesn’t realize there is a flush going on. Also adding tests to check that all lifecycle methods are instrumented.