### PR TITLE
Make sure cloneElement() supports prototype-less config

### DIFF
--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -311,7 +311,7 @@ ReactElement.cloneElement = function(element, config, children) {
       defaultProps = element.type.defaultProps;
     }
     for (propName in config) {
-      if (config.hasOwnProperty(propName) &&
+      if (hasOwnProperty.call(config, propName) &&
           !RESERVED_PROPS.hasOwnProperty(propName)) {
         if (config[propName] === undefined && defaultProps !== undefined) {
           // Resolve default props

--- a/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
@@ -78,6 +78,11 @@ describe('ReactElementClone', function() {
     );
   });
 
+  it('does not fail if config has no prototype', function() {
+    var config = Object.create(null, {foo: {value: 1, enumerable: true}});
+    React.cloneElement(<div />, config);
+  });
+
   it('should keep the original ref if it is not overridden', function() {
     var Grandparent = React.createClass({
       render: function() {


### PR DESCRIPTION
This brings `createElement()` fix from #6855 to `cloneElement()`.