### PR TITLE
Fix issues introduced by createElement() warning

### DIFF
--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -34,16 +34,20 @@ var specialPropKeyWarningShown, specialPropRefWarningShown;
 
 function hasValidRef(config) {
   if (__DEV__) {
-    return hasOwnProperty.call(config, 'ref') &&
-      !Object.getOwnPropertyDescriptor(config, 'ref').get;
+    if (hasOwnProperty.call(config, 'ref') &&
+        Object.getOwnPropertyDescriptor(config, 'ref').get) {
+      return false;
+    }
   }
   return config.ref !== undefined;
 }
 
 function hasValidKey(config) {
   if (__DEV__) {
-    return hasOwnProperty.call(config, 'key') &&
-      !Object.getOwnPropertyDescriptor(config, 'key').get;
+    if (hasOwnProperty.call(config, 'key') &&
+        Object.getOwnPropertyDescriptor(config, 'key').get) {
+      return false;
+    }
   }
   return config.key !== undefined;
 }

--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -32,6 +32,19 @@ var RESERVED_PROPS = {
 
 var specialPropKeyWarningShown, specialPropRefWarningShown;
 
+function isValidConfigRefOrKey(config, name) {
+  if (__DEV__) {
+    return hasOwnProperty.call(config, name) &&
+      !Object.getOwnPropertyDescriptor(config, name).get;
+  }
+
+  return config[name] !== undefined;
+}
+
+function getConfigKey(config) {
+  return '' + config.key;
+}
+
 /**
  * Factory method to create a new React element. This no longer adheres to
  * the class pattern, so do not use new to call it. Also, no instanceof check
@@ -138,14 +151,16 @@ ReactElement.createElement = function(type, config, children) {
         'React.createElement(...): Expected props argument to be a plain object. ' +
         'Properties defined in its prototype chain will be ignored.'
       );
-      ref = !hasOwnProperty.call(config, 'ref') ||
-        Object.getOwnPropertyDescriptor(config, 'ref').get ? null : config.ref;
-      key = !hasOwnProperty.call(config, 'key') ||
-        Object.getOwnPropertyDescriptor(config, 'key').get ? null : '' + config.key;
-    } else {
-      ref = config.ref === undefined ? null : config.ref;
-      key = config.key === undefined ? null : '' + config.key;
     }
+
+    if (isValidConfigRefOrKey(config, 'ref')) {
+      ref = config.ref;
+    }
+
+    if (isValidConfigRefOrKey(config, 'key')) {
+      key = getConfigKey(config);
+    }
+
     self = config.__self === undefined ? null : config.__self;
     source = config.__source === undefined ? null : config.__source;
     // Remaining properties are added to a new props object
@@ -297,14 +312,17 @@ ReactElement.cloneElement = function(element, config, children) {
         'Properties defined in its prototype chain will be ignored.'
       );
     }
-    if (config.ref !== undefined) {
+
+    if (isValidConfigRefOrKey(config, 'ref')) {
       // Silently steal the ref from the parent.
       ref = config.ref;
       owner = ReactCurrentOwner.current;
     }
-    if (config.key !== undefined) {
-      key = '' + config.key;
+
+    if (isValidConfigRefOrKey(config, 'key')) {
+      key = getConfigKey(config);
     }
+
     // Remaining properties override existing props
     var defaultProps;
     if (element.type && element.type.defaultProps) {

--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -32,17 +32,20 @@ var RESERVED_PROPS = {
 
 var specialPropKeyWarningShown, specialPropRefWarningShown;
 
-function isValidConfigRefOrKey(config, name) {
+function hasValidRef(config) {
   if (__DEV__) {
-    return hasOwnProperty.call(config, name) &&
-      !Object.getOwnPropertyDescriptor(config, name).get;
+    return hasOwnProperty.call(config, 'ref') &&
+      !Object.getOwnPropertyDescriptor(config, 'ref').get;
   }
-
-  return config[name] !== undefined;
+  return config.ref !== undefined;
 }
 
-function getConfigKey(config) {
-  return '' + config.key;
+function hasValidKey(config) {
+  if (__DEV__) {
+    return hasOwnProperty.call(config, 'key') &&
+      !Object.getOwnPropertyDescriptor(config, 'key').get;
+  }
+  return config.key !== undefined;
 }
 
 /**
@@ -153,12 +156,11 @@ ReactElement.createElement = function(type, config, children) {
       );
     }
 
-    if (isValidConfigRefOrKey(config, 'ref')) {
+    if (hasValidRef(config)) {
       ref = config.ref;
     }
-
-    if (isValidConfigRefOrKey(config, 'key')) {
-      key = getConfigKey(config);
+    if (hasValidKey(config)) {
+      key = '' + config.key;
     }
 
     self = config.__self === undefined ? null : config.__self;
@@ -313,14 +315,13 @@ ReactElement.cloneElement = function(element, config, children) {
       );
     }
 
-    if (isValidConfigRefOrKey(config, 'ref')) {
+    if (hasValidRef(config)) {
       // Silently steal the ref from the parent.
       ref = config.ref;
       owner = ReactCurrentOwner.current;
     }
-
-    if (isValidConfigRefOrKey(config, 'key')) {
-      key = getConfigKey(config);
+    if (hasValidKey(config)) {
+      key = '' + config.key;
     }
 
     // Remaining properties override existing props

--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -205,6 +205,10 @@ ReactElement.createElement = function(type, config, children) {
     }
   }
   if (__DEV__) {
+    var displayName = typeof type === 'function' ?
+      (type.displayName || type.name || 'Unknown') :
+      type;
+
     // Create dummy `key` and `ref` property to `props` to warn users against its use
     function warnAboutAccessingKey() {
       if (!specialPropKeyWarningShown) {
@@ -215,7 +219,7 @@ ReactElement.createElement = function(type, config, children) {
           'in `undefined` being returned. If you need to access the same ' +
           'value within the child component, you should pass it as a different ' +
           'prop. (https://fb.me/react-special-props)',
-          typeof type === 'function' && 'displayName' in type ? type.displayName : 'Element'
+          displayName
         );
       }
       return undefined;
@@ -231,7 +235,7 @@ ReactElement.createElement = function(type, config, children) {
           'in `undefined` being returned. If you need to access the same ' +
           'value within the child component, you should pass it as a different ' +
           'prop. (https://fb.me/react-special-props)',
-          typeof type === 'function' && 'displayName' in type ? type.displayName : 'Element'
+          displayName
         );
       }
       return undefined;

--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -34,9 +34,11 @@ var specialPropKeyWarningShown, specialPropRefWarningShown;
 
 function hasValidRef(config) {
   if (__DEV__) {
-    if (hasOwnProperty.call(config, 'ref') &&
-        Object.getOwnPropertyDescriptor(config, 'ref').get) {
-      return false;
+    if (hasOwnProperty.call(config, 'ref')) {
+      var getter = Object.getOwnPropertyDescriptor(config, 'ref').get;
+      if (getter && getter.isReactWarning) {
+        return false;
+      }
     }
   }
   return config.ref !== undefined;
@@ -44,9 +46,11 @@ function hasValidRef(config) {
 
 function hasValidKey(config) {
   if (__DEV__) {
-    if (hasOwnProperty.call(config, 'key') &&
-        Object.getOwnPropertyDescriptor(config, 'key').get) {
-      return false;
+    if (hasOwnProperty.call(config, 'key')) {
+      var getter = Object.getOwnPropertyDescriptor(config, 'key').get;
+      if (getter && getter.isReactWarning) {
+        return false;
+      }
     }
   }
   return config.key !== undefined;
@@ -201,45 +205,50 @@ ReactElement.createElement = function(type, config, children) {
     }
   }
   if (__DEV__) {
-    // Create dummy `key` and `ref` property to `props` to warn users
-    // against its use
+    // Create dummy `key` and `ref` property to `props` to warn users against its use
+    function warnAboutAccessingKey() {
+      if (!specialPropKeyWarningShown) {
+        specialPropKeyWarningShown = true;
+        warning(
+          false,
+          '%s: `key` is not a prop. Trying to access it will result ' +
+          'in `undefined` being returned. If you need to access the same ' +
+          'value within the child component, you should pass it as a different ' +
+          'prop. (https://fb.me/react-special-props)',
+          typeof type === 'function' && 'displayName' in type ? type.displayName : 'Element'
+        );
+      }
+      return undefined;
+    }
+    warnAboutAccessingKey.isReactWarning = true;
+
+    function warnAboutAccessingRef() {
+      if (!specialPropRefWarningShown) {
+        specialPropRefWarningShown = true;
+        warning(
+          false,
+          '%s: `ref` is not a prop. Trying to access it will result ' +
+          'in `undefined` being returned. If you need to access the same ' +
+          'value within the child component, you should pass it as a different ' +
+          'prop. (https://fb.me/react-special-props)',
+          typeof type === 'function' && 'displayName' in type ? type.displayName : 'Element'
+        );
+      }
+      return undefined;
+    }
+    warnAboutAccessingRef.isReactWarning = true;
+
     if (typeof props.$$typeof === 'undefined' ||
         props.$$typeof !== REACT_ELEMENT_TYPE) {
       if (!props.hasOwnProperty('key')) {
         Object.defineProperty(props, 'key', {
-          get: function() {
-            if (!specialPropKeyWarningShown) {
-              specialPropKeyWarningShown = true;
-              warning(
-                false,
-                '%s: `key` is not a prop. Trying to access it will result ' +
-                  'in `undefined` being returned. If you need to access the same ' +
-                  'value within the child component, you should pass it as a different ' +
-                  'prop. (https://fb.me/react-special-props)',
-                typeof type === 'function' && 'displayName' in type ? type.displayName : 'Element'
-              );
-            }
-            return undefined;
-          },
+          get: warnAboutAccessingKey,
           configurable: true,
         });
       }
       if (!props.hasOwnProperty('ref')) {
         Object.defineProperty(props, 'ref', {
-          get: function() {
-            if (!specialPropRefWarningShown) {
-              specialPropRefWarningShown = true;
-              warning(
-                false,
-                '%s: `ref` is not a prop. Trying to access it will result ' +
-                  'in `undefined` being returned. If you need to access the same ' +
-                  'value within the child component, you should pass it as a different ' +
-                  'prop. (https://fb.me/react-special-props)',
-                typeof type === 'function' && 'displayName' in type ? type.displayName : 'Element'
-              );
-            }
-            return undefined;
-          },
+          get: warnAboutAccessingRef,
           configurable: true,
         });
       }

--- a/src/isomorphic/classic/element/__tests__/ReactElement-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElement-test.js
@@ -170,6 +170,86 @@ describe('ReactElement', function() {
     expect(element.props).toEqual(expectation);
   });
 
+  it('should not extract key and ref getters from the config when creating an element', function() {
+    var props = {
+      foo: '56',
+    };
+
+    Object.defineProperty(props, 'key', {
+      get: function() {
+        return '12';
+      },
+    });
+
+    Object.defineProperty(props, 'ref', {
+      get: function() {
+        return '34';
+      },
+    });
+
+    var element = React.createFactory(ComponentClass)(props);
+    expect(element.type).toBe(ComponentClass);
+    expect(element.key).toBe(null);
+    expect(element.ref).toBe(null);
+    var expectation = {foo:'56'};
+    Object.freeze(expectation);
+    expect(element.props).toEqual(expectation);
+  });
+
+  it('should not extract key and ref getters from the config when cloning an element', function() {
+    var element = React.createFactory(ComponentClass)({
+      key: '12',
+      ref: '34',
+      foo: '56',
+    });
+
+    var props = {
+      foo: 'ef',
+    };
+
+    Object.defineProperty(props, 'key', {
+      get: function() {
+        return 'ab';
+      },
+    });
+
+    Object.defineProperty(props, 'ref', {
+      get: function() {
+        return 'cd';
+      },
+    });
+
+    var clone = React.cloneElement(element, props);
+    expect(clone.type).toBe(ComponentClass);
+    expect(clone.key).toBe('12');
+    expect(clone.ref).toBe('34');
+    var expectation = {foo:'ef'};
+    Object.freeze(expectation);
+    expect(clone.props).toEqual(expectation);
+  });
+
+  it('should allow null key and ref values when cloning an element', function() {
+    var element = React.createFactory(ComponentClass)({
+      key: '12',
+      ref: '34',
+      foo: '56',
+    });
+
+    var props = {
+      key: null,
+      ref: null,
+      foo: 'ef',
+    };
+
+    var clone = React.cloneElement(element, props);
+    expect(clone.type).toBe(ComponentClass);
+    expect(clone.key).toBe('null');
+    expect(clone.ref).toBe(null);
+    var expectation = {foo:'ef'};
+    Object.freeze(expectation);
+    expect(clone.props).toEqual(expectation);
+  });
+
   it('coerces the key to a string', function() {
     var element = React.createFactory(ComponentClass)({
       key: 12,

--- a/src/isomorphic/classic/element/__tests__/ReactElement-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElement-test.js
@@ -170,7 +170,7 @@ describe('ReactElement', function() {
     expect(element.props).toEqual(expectation);
   });
 
-  it('extracts null key and ref values when creating an element', function() {
+  it('extracts null key and ref', function() {
     var element = React.createFactory(ComponentClass)({
       key: null,
       ref: null,
@@ -184,7 +184,7 @@ describe('ReactElement', function() {
     expect(element.props).toEqual(expectation);
   });
 
-  it('ignores undefined key and ref when creating an element', function() {
+  it('ignores undefined key and ref', function() {
     var props = {
       foo: '56',
       key: undefined,
@@ -199,7 +199,7 @@ describe('ReactElement', function() {
     expect(element.props).toEqual(expectation);
   });
 
-  it('ignores key and ref getters when creating an element', function() {
+  it('ignores key and ref getters', function() {
     var props = {
       foo: '56',
     };
@@ -220,74 +220,6 @@ describe('ReactElement', function() {
     var expectation = {foo: '56'};
     Object.freeze(expectation);
     expect(element.props).toEqual(expectation);
-  });
-
-  it('ignores key and ref getters when cloning an element', function() {
-    var element = React.createFactory(ComponentClass)({
-      key: '12',
-      ref: '34',
-      foo: '56',
-    });
-    var props = {
-      foo: 'ef',
-    };
-    Object.defineProperty(props, 'key', {
-      get: function() {
-        return 'ab';
-      },
-    });
-    Object.defineProperty(props, 'ref', {
-      get: function() {
-        return 'cd';
-      },
-    });
-    var clone = React.cloneElement(element, props);
-    expect(clone.type).toBe(ComponentClass);
-    expect(clone.key).toBe('12');
-    expect(clone.ref).toBe('34');
-    var expectation = {foo: 'ef'};
-    Object.freeze(expectation);
-    expect(clone.props).toEqual(expectation);
-  });
-
-  it('ignores undefined key and ref values when cloning an element', function() {
-    var element = React.createFactory(ComponentClass)({
-      key: '12',
-      ref: '34',
-      foo: '56',
-    });
-    var props = {
-      key: undefined,
-      ref: undefined,
-      foo: 'ef',
-    };
-    var clone = React.cloneElement(element, props);
-    expect(clone.type).toBe(ComponentClass);
-    expect(clone.key).toBe('12');
-    expect(clone.ref).toBe('34');
-    var expectation = {foo: 'ef'};
-    Object.freeze(expectation);
-    expect(clone.props).toEqual(expectation);
-  });
-
-  it('extracts null key and ref values when cloning an element', function() {
-    var element = React.createFactory(ComponentClass)({
-      key: '12',
-      ref: '34',
-      foo: '56',
-    });
-    var props = {
-      key: null,
-      ref: null,
-      foo: 'ef',
-    };
-    var clone = React.cloneElement(element, props);
-    expect(clone.type).toBe(ComponentClass);
-    expect(clone.key).toBe('null');
-    expect(clone.ref).toBe(null);
-    var expectation = {foo: 'ef'};
-    Object.freeze(expectation);
-    expect(clone.props).toEqual(expectation);
   });
 
   it('coerces the key to a string', function() {
@@ -347,18 +279,6 @@ describe('ReactElement', function() {
     }, null);
     expect(element.props.children).toBe(null);
     expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('overrides children if undefined is provided as an argument', function() {
-    var element = React.createElement(ComponentClass, {
-      children: 'text',
-    }, undefined);
-    expect(element.props.children).toBe(undefined);
-
-    var element2 = React.cloneElement(React.createElement(ComponentClass, {
-      children: 'text',
-    }), {}, undefined);
-    expect(element2.props.children).toBe(undefined);
   });
 
   it('merges rest arguments onto the children prop in an array', function() {
@@ -488,29 +408,6 @@ describe('ReactElement', function() {
       React.createElement(Component, {prop: null})
     );
     expect(inst2.props.prop).toBe(null);
-  });
-
-  it('should normalize props with default values in cloning', function() {
-    var Component = React.createClass({
-      getDefaultProps: function() {
-        return {prop: 'testKey'};
-      },
-      render: function() {
-        return <span />;
-      },
-    });
-
-    var instance = React.createElement(Component);
-    var clonedInstance = React.cloneElement(instance, {prop: undefined});
-    expect(clonedInstance.props.prop).toBe('testKey');
-    var clonedInstance2 = React.cloneElement(instance, {prop: null});
-    expect(clonedInstance2.props.prop).toBe(null);
-
-    var instance2 = React.createElement(Component, {prop: 'newTestKey'});
-    var cloneInstance3 = React.cloneElement(instance2, {prop: undefined});
-    expect(cloneInstance3.props.prop).toBe('testKey');
-    var cloneInstance4 = React.cloneElement(instance2, {});
-    expect(cloneInstance4.props.prop).toBe('newTestKey');
   });
 
   it('throws when changing a prop (in dev) after element creation', function() {
@@ -703,4 +600,5 @@ describe('comparing jsx vs .createFactory() vs .createElement()', function() {
       expect(Child.mock.calls[0][0]).toEqual({ foo: 'foo value', children: 'children value' });
     });
   });
+
 });

--- a/src/isomorphic/classic/element/__tests__/ReactElement-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElement-test.js
@@ -52,10 +52,9 @@ describe('ReactElement', function() {
     expect(element.type).toBe(ComponentClass);
     expect(element.key).toBe(null);
     expect(element.ref).toBe(null);
-    var expectation = {};
     expect(Object.isFrozen(element)).toBe(true);
     expect(Object.isFrozen(element.props)).toBe(true);
-    expect(element.props).toEqual(expectation);
+    expect(element.props).toEqual({});
   });
 
   it('should warn when `key` is being accessed on createClass element', function() {
@@ -165,10 +164,9 @@ describe('ReactElement', function() {
     expect(element.type).toBe('div');
     expect(element.key).toBe(null);
     expect(element.ref).toBe(null);
-    var expectation = {};
     expect(Object.isFrozen(element)).toBe(true);
     expect(Object.isFrozen(element.props)).toBe(true);
-    expect(element.props).toEqual(expectation);
+    expect(element.props).toEqual({});
   });
 
   it('returns an immutable element', function() {
@@ -211,10 +209,9 @@ describe('ReactElement', function() {
     expect(element.type).toBe(ComponentClass);
     expect(element.key).toBe('12');
     expect(element.ref).toBe('34');
-    var expectation = {foo: '56'};
     expect(Object.isFrozen(element)).toBe(true);
     expect(Object.isFrozen(element.props)).toBe(true);
-    expect(element.props).toEqual(expectation);
+    expect(element.props).toEqual({foo: '56'});
   });
 
   it('extracts null key and ref', function() {
@@ -226,10 +223,9 @@ describe('ReactElement', function() {
     expect(element.type).toBe(ComponentClass);
     expect(element.key).toBe('null');
     expect(element.ref).toBe(null);
-    var expectation = {foo: '12'};
     expect(Object.isFrozen(element)).toBe(true);
     expect(Object.isFrozen(element.props)).toBe(true);
-    expect(element.props).toEqual(expectation);
+    expect(element.props).toEqual({foo: '12'});
   });
 
   it('ignores undefined key and ref', function() {
@@ -242,10 +238,9 @@ describe('ReactElement', function() {
     expect(element.type).toBe(ComponentClass);
     expect(element.key).toBe(null);
     expect(element.ref).toBe(null);
-    var expectation = {foo: '56'};
     expect(Object.isFrozen(element)).toBe(true);
     expect(Object.isFrozen(element.props)).toBe(true);
-    expect(element.props).toEqual(expectation);
+    expect(element.props).toEqual({foo: '56'});
   });
 
   it('ignores key and ref warning getters', function() {
@@ -263,10 +258,9 @@ describe('ReactElement', function() {
     expect(element.type).toBe(ComponentClass);
     expect(element.key).toBe('12');
     expect(element.ref).toBe(null);
-    var expectation = {foo: '56'};
     expect(Object.isFrozen(element)).toBe(true);
     expect(Object.isFrozen(element.props)).toBe(true);
-    expect(element.props).toEqual(expectation);
+    expect(element.props).toEqual({foo: '56'});
   });
 
   it('preserves the owner on the element', function() {

--- a/src/isomorphic/classic/element/__tests__/ReactElement-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElement-test.js
@@ -199,27 +199,11 @@ describe('ReactElement', function() {
     expect(element.props).toEqual(expectation);
   });
 
-  it('ignores key and ref getters', function() {
-    var props = {
-      foo: '56',
-    };
-    Object.defineProperty(props, 'key', {
-      get: function() {
-        return '12';
-      },
-    });
-    Object.defineProperty(props, 'ref', {
-      get: function() {
-        return '34';
-      },
-    });
-    var element = React.createFactory(ComponentClass)(props);
-    expect(element.type).toBe(ComponentClass);
-    expect(element.key).toBe(null);
-    expect(element.ref).toBe(null);
-    var expectation = {foo: '56'};
-    Object.freeze(expectation);
-    expect(element.props).toEqual(expectation);
+  it('ignores key and ref warning getters', function() {
+    var elementA = React.createElement('div');
+    var elementB = React.createElement('div', elementA.props);
+    expect(elementB.key).toBe(null);
+    expect(elementB.ref).toBe(null);
   });
 
   it('coerces the key to a string', function() {

--- a/src/isomorphic/classic/element/__tests__/ReactElement-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElement-test.js
@@ -170,23 +170,26 @@ describe('ReactElement', function() {
     expect(element.props).toEqual(expectation);
   });
 
-  it('should not extract key and ref getters from the config when creating an element', function() {
+  it('extracts null key and ref values when creating an element', function() {
+    var element = React.createFactory(ComponentClass)({
+      key: null,
+      ref: null,
+      foo: '12',
+    });
+    expect(element.type).toBe(ComponentClass);
+    expect(element.key).toBe('null');
+    expect(element.ref).toBe(null);
+    var expectation = {foo: '12'};
+    Object.freeze(expectation);
+    expect(element.props).toEqual(expectation);
+  });
+
+  it('ignores undefined key and ref when creating an element', function() {
     var props = {
       foo: '56',
+      key: undefined,
+      ref: undefined,
     };
-
-    Object.defineProperty(props, 'key', {
-      get: function() {
-        return '12';
-      },
-    });
-
-    Object.defineProperty(props, 'ref', {
-      get: function() {
-        return '34';
-      },
-    });
-
     var element = React.createFactory(ComponentClass)(props);
     expect(element.type).toBe(ComponentClass);
     expect(element.key).toBe(null);
@@ -196,29 +199,48 @@ describe('ReactElement', function() {
     expect(element.props).toEqual(expectation);
   });
 
-  it('should not extract key and ref getters from the config when cloning an element', function() {
+  it('ignores key and ref getters when creating an element', function() {
+    var props = {
+      foo: '56',
+    };
+    Object.defineProperty(props, 'key', {
+      get: function() {
+        return '12';
+      },
+    });
+    Object.defineProperty(props, 'ref', {
+      get: function() {
+        return '34';
+      },
+    });
+    var element = React.createFactory(ComponentClass)(props);
+    expect(element.type).toBe(ComponentClass);
+    expect(element.key).toBe(null);
+    expect(element.ref).toBe(null);
+    var expectation = {foo: '56'};
+    Object.freeze(expectation);
+    expect(element.props).toEqual(expectation);
+  });
+
+  it('ignores key and ref getters when cloning an element', function() {
     var element = React.createFactory(ComponentClass)({
       key: '12',
       ref: '34',
       foo: '56',
     });
-
     var props = {
       foo: 'ef',
     };
-
     Object.defineProperty(props, 'key', {
       get: function() {
         return 'ab';
       },
     });
-
     Object.defineProperty(props, 'ref', {
       get: function() {
         return 'cd';
       },
     });
-
     var clone = React.cloneElement(element, props);
     expect(clone.type).toBe(ComponentClass);
     expect(clone.key).toBe('12');
@@ -228,19 +250,37 @@ describe('ReactElement', function() {
     expect(clone.props).toEqual(expectation);
   });
 
-  it('should allow null key and ref values when cloning an element', function() {
+  it('ignores undefined key and ref values when cloning an element', function() {
     var element = React.createFactory(ComponentClass)({
       key: '12',
       ref: '34',
       foo: '56',
     });
+    var props = {
+      key: undefined,
+      ref: undefined,
+      foo: 'ef',
+    };
+    var clone = React.cloneElement(element, props);
+    expect(clone.type).toBe(ComponentClass);
+    expect(clone.key).toBe('12');
+    expect(clone.ref).toBe('34');
+    var expectation = {foo: 'ef'};
+    Object.freeze(expectation);
+    expect(clone.props).toEqual(expectation);
+  });
 
+  it('extracts null key and ref values when cloning an element', function() {
+    var element = React.createFactory(ComponentClass)({
+      key: '12',
+      ref: '34',
+      foo: '56',
+    });
     var props = {
       key: null,
       ref: null,
       foo: 'ef',
     };
-
     var clone = React.cloneElement(element, props);
     expect(clone.type).toBe(ComponentClass);
     expect(clone.key).toBe('null');

--- a/src/isomorphic/classic/element/__tests__/ReactElement-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElement-test.js
@@ -58,7 +58,7 @@ describe('ReactElement', function() {
     expect(element.props).toEqual(expectation);
   });
 
-  it('should warn when `key` is being accessed', function() {
+  it('should warn when `key` is being accessed on createClass element', function() {
     spyOn(console, 'error');
     var container = document.createElement('div');
     var Child = React.createClass({
@@ -82,6 +82,50 @@ describe('ReactElement', function() {
     expect(console.error.calls.count()).toBe(1);
     expect(console.error.calls.argsFor(0)[0]).toContain(
       'Child: `key` is not a prop. Trying to access it will result ' +
+      'in `undefined` being returned. If you need to access the same ' +
+      'value within the child component, you should pass it as a different ' +
+      'prop. (https://fb.me/react-special-props)'
+    );
+  });
+
+  it('should warn when `key` is being accessed on ES class element', function() {
+    spyOn(console, 'error');
+    var container = document.createElement('div');
+    class Child extends React.Component {
+      render() {
+        return <div> {this.props.key} </div>;
+      }
+    }
+    var Parent = React.createClass({
+      render: function() {
+        return (
+          <div>
+            <Child key="0" />
+            <Child key="1" />
+            <Child key="2" />
+          </div>
+        );
+      },
+    });
+    expect(console.error.calls.count()).toBe(0);
+    ReactDOM.render(<Parent />, container);
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toContain(
+      'Child: `key` is not a prop. Trying to access it will result ' +
+      'in `undefined` being returned. If you need to access the same ' +
+      'value within the child component, you should pass it as a different ' +
+      'prop. (https://fb.me/react-special-props)'
+    );
+  });
+
+  it('should warn when `key` is being accessed on a host element', function() {
+    spyOn(console, 'error');
+    var element = <div key="3" />;
+    expect(console.error.calls.count()).toBe(0);
+    void element.props.key;
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toContain(
+      'div: `key` is not a prop. Trying to access it will result ' +
       'in `undefined` being returned. If you need to access the same ' +
       'value within the child component, you should pass it as a different ' +
       'prop. (https://fb.me/react-special-props)'

--- a/src/isomorphic/classic/element/__tests__/ReactElement-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElement-test.js
@@ -165,7 +165,7 @@ describe('ReactElement', function() {
     expect(element.type).toBe(ComponentClass);
     expect(element.key).toBe('12');
     expect(element.ref).toBe('34');
-    var expectation = {foo:'56'};
+    var expectation = {foo: '56'};
     Object.freeze(expectation);
     expect(element.props).toEqual(expectation);
   });
@@ -191,7 +191,7 @@ describe('ReactElement', function() {
     expect(element.type).toBe(ComponentClass);
     expect(element.key).toBe(null);
     expect(element.ref).toBe(null);
-    var expectation = {foo:'56'};
+    var expectation = {foo: '56'};
     Object.freeze(expectation);
     expect(element.props).toEqual(expectation);
   });
@@ -223,7 +223,7 @@ describe('ReactElement', function() {
     expect(clone.type).toBe(ComponentClass);
     expect(clone.key).toBe('12');
     expect(clone.ref).toBe('34');
-    var expectation = {foo:'ef'};
+    var expectation = {foo: 'ef'};
     Object.freeze(expectation);
     expect(clone.props).toEqual(expectation);
   });
@@ -245,7 +245,7 @@ describe('ReactElement', function() {
     expect(clone.type).toBe(ComponentClass);
     expect(clone.key).toBe('null');
     expect(clone.ref).toBe(null);
-    var expectation = {foo:'ef'};
+    var expectation = {foo: 'ef'};
     Object.freeze(expectation);
     expect(clone.props).toEqual(expectation);
   });
@@ -258,7 +258,7 @@ describe('ReactElement', function() {
     expect(element.type).toBe(ComponentClass);
     expect(element.key).toBe('12');
     expect(element.ref).toBe(null);
-    var expectation = {foo:'56'};
+    var expectation = {foo: '56'};
     Object.freeze(expectation);
     expect(element.props).toEqual(expectation);
   });

--- a/src/isomorphic/classic/element/__tests__/ReactElement-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElement-test.js
@@ -53,7 +53,8 @@ describe('ReactElement', function() {
     expect(element.key).toBe(null);
     expect(element.ref).toBe(null);
     var expectation = {};
-    Object.freeze(expectation);
+    expect(Object.isFrozen(element)).toBe(true);
+    expect(Object.isFrozen(element.props)).toBe(true);
     expect(element.props).toEqual(expectation);
   });
 
@@ -121,7 +122,8 @@ describe('ReactElement', function() {
     expect(element.key).toBe(null);
     expect(element.ref).toBe(null);
     var expectation = {};
-    Object.freeze(expectation);
+    expect(Object.isFrozen(element)).toBe(true);
+    expect(Object.isFrozen(element.props)).toBe(true);
     expect(element.props).toEqual(expectation);
   });
 
@@ -166,7 +168,8 @@ describe('ReactElement', function() {
     expect(element.key).toBe('12');
     expect(element.ref).toBe('34');
     var expectation = {foo: '56'};
-    Object.freeze(expectation);
+    expect(Object.isFrozen(element)).toBe(true);
+    expect(Object.isFrozen(element.props)).toBe(true);
     expect(element.props).toEqual(expectation);
   });
 
@@ -180,7 +183,8 @@ describe('ReactElement', function() {
     expect(element.key).toBe('null');
     expect(element.ref).toBe(null);
     var expectation = {foo: '12'};
-    Object.freeze(expectation);
+    expect(Object.isFrozen(element)).toBe(true);
+    expect(Object.isFrozen(element.props)).toBe(true);
     expect(element.props).toEqual(expectation);
   });
 
@@ -195,7 +199,8 @@ describe('ReactElement', function() {
     expect(element.key).toBe(null);
     expect(element.ref).toBe(null);
     var expectation = {foo: '56'};
-    Object.freeze(expectation);
+    expect(Object.isFrozen(element)).toBe(true);
+    expect(Object.isFrozen(element.props)).toBe(true);
     expect(element.props).toEqual(expectation);
   });
 
@@ -215,7 +220,8 @@ describe('ReactElement', function() {
     expect(element.key).toBe('12');
     expect(element.ref).toBe(null);
     var expectation = {foo: '56'};
-    Object.freeze(expectation);
+    expect(Object.isFrozen(element)).toBe(true);
+    expect(Object.isFrozen(element.props)).toBe(true);
     expect(element.props).toEqual(expectation);
   });
 

--- a/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
@@ -345,7 +345,8 @@ describe('ReactElementClone', function() {
     expect(clone.key).toBe('12');
     expect(clone.ref).toBe('34');
     var expectation = {foo: 'ef'};
-    Object.freeze(expectation);
+    expect(Object.isFrozen(element)).toBe(true);
+    expect(Object.isFrozen(element.props)).toBe(true);
     expect(clone.props).toEqual(expectation);
   });
 
@@ -365,7 +366,8 @@ describe('ReactElementClone', function() {
     expect(clone.key).toBe('null');
     expect(clone.ref).toBe(null);
     var expectation = {foo: 'ef'};
-    Object.freeze(expectation);
+    expect(Object.isFrozen(element)).toBe(true);
+    expect(Object.isFrozen(element.props)).toBe(true);
     expect(clone.props).toEqual(expectation);
   });
 

--- a/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
@@ -344,10 +344,9 @@ describe('ReactElementClone', function() {
     expect(clone.type).toBe(ComponentClass);
     expect(clone.key).toBe('12');
     expect(clone.ref).toBe('34');
-    var expectation = {foo: 'ef'};
     expect(Object.isFrozen(element)).toBe(true);
     expect(Object.isFrozen(element.props)).toBe(true);
-    expect(clone.props).toEqual(expectation);
+    expect(clone.props).toEqual({foo: 'ef'});
   });
 
   it('should extract null key and ref', function() {
@@ -365,10 +364,9 @@ describe('ReactElementClone', function() {
     expect(clone.type).toBe(ComponentClass);
     expect(clone.key).toBe('null');
     expect(clone.ref).toBe(null);
-    var expectation = {foo: 'ef'};
     expect(Object.isFrozen(element)).toBe(true);
     expect(Object.isFrozen(element.props)).toBe(true);
-    expect(clone.props).toEqual(expectation);
+    expect(clone.props).toEqual({foo: 'ef'});
   });
 
 });

--- a/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
@@ -322,32 +322,11 @@ describe('ReactElementClone', function() {
     );
   });
 
-  it('should ignore key and ref getters', function() {
-    var element = React.createFactory(ComponentClass)({
-      key: '12',
-      ref: '34',
-      foo: '56',
-    });
-    var props = {
-      foo: 'ef',
-    };
-    Object.defineProperty(props, 'key', {
-      get: function() {
-        return 'ab';
-      },
-    });
-    Object.defineProperty(props, 'ref', {
-      get: function() {
-        return 'cd';
-      },
-    });
-    var clone = React.cloneElement(element, props);
-    expect(clone.type).toBe(ComponentClass);
-    expect(clone.key).toBe('12');
-    expect(clone.ref).toBe('34');
-    var expectation = {foo: 'ef'};
-    Object.freeze(expectation);
-    expect(clone.props).toEqual(expectation);
+  it('should ignore key and ref warning getters', function() {
+    var elementA = React.createElement('div');
+    var elementB = React.cloneElement(elementA, elementA.props);
+    expect(elementB.key).toBe(null);
+    expect(elementB.ref).toBe(null);
   });
 
   it('should ignore undefined key and ref', function() {


### PR DESCRIPTION
This builds on top of #6268.

I fixed a few style nits and indirection in it, and later I realized it introduces a bug in `cloneElement()`. As I was tracing this bug, I found that it already existed in `createElement()` in 15.x (#6879).

So I fixed the bug for both cases, added more tests, and shuffled them around to sit in the corresponding files.