### PR TITLE
#6809 - Added warning for using onDblClick instead of onDoubleClick

### DIFF
--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -163,6 +163,17 @@ describe('ReactDOMComponent', function() {
       );
     });
 
+    it('should warn for onDblClick prop', function() {
+      spyOn(console, 'error');
+      var container = document.createElement('div');
+      ReactDOM.render(<div onDblClick={() => {}} />, container);
+      expect(console.error.calls.count(0)).toBe(1);
+      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+        'Warning: Unknown event handler property onDblClick. Did you mean `onDoubleClick`?\n    in div (at **)'
+      );
+    });
+
+
     it('should warn about styles with numeric string values for non-unitless properties', function() {
       spyOn(console, 'error');
 

--- a/src/renderers/shared/stack/event/EventPluginRegistry.js
+++ b/src/renderers/shared/stack/event/EventPluginRegistry.js
@@ -132,6 +132,11 @@ function publishRegistrationName(registrationName, PluginModule, eventName) {
     var lowerCasedName = registrationName.toLowerCase();
     EventPluginRegistry.possibleRegistrationNames[lowerCasedName] =
       registrationName;
+
+
+    if (registrationName === 'onDoubleClick') {
+      EventPluginRegistry.possibleRegistrationNames.ondblclick = registrationName;
+    }
   }
 }
 


### PR DESCRIPTION
There's already a warning for unsupported props, I just added a more specific warning for using onDblClick.