### PR TITLE
update-shallowCompare-doc-for-es7-function-bind

### DIFF
--- a/docs/docs/10.10-shallow-compare.md
+++ b/docs/docs/10.10-shallow-compare.md
@@ -30,3 +30,11 @@ It does this by iterating on the keys of the objects being compared and returnin
 
 `shallowCompare` returns `true` if the shallow comparison for props or state fails and therefore the component should update.  
 `shallowCompare` returns `false` if the shallow comparison for props and state both pass and therefore the component does not need to update.
+
+> Note:
+>
+> Do not use ES7-function-bind `::this.functionA` syntax to assign props to components that are intended to be pure. The syntax effectively calls `function.prototype.bind` every time render() gets called in the parent component. Ultimately when doing shallow compare, the `===` operator will always return false when comparing the functions since they do not reference the same function instance, therefore breaking shallowCompare. In short, mixing `::this.functionA` with `shallowCompare` will most likely have **no affect** in terms of performance gain comparing to non-pure components. Pure or not, `render()` method will always get called.  
+> 
+>Please keep using this.functionA = this.functionA.bind(this); in the constructor methods of the parent component forall pure components.
+>
+>


### PR DESCRIPTION
ES7-function-bind breaks the functionality of shallowCompare. Both the language feature and the shallowCompare function are behaving as designed.   Unfortunately they just don't work well together and I am not sure if anything should be changed. I believe the only sensible thing to do here is to specifically warn devs to not use the syntax for now.