### PR TITLE
Stop passing null as second argument to document.createElement()

### DIFF
--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -622,7 +622,8 @@ ReactDOMComponent.Mixin = {
           div.innerHTML = `<${type}></${type}>`;
           el = div.removeChild(div.firstChild);
         } else {
-          el = ownerDocument.createElement(this._currentElement.type, props.is || null);
+          el = props.is ? ownerDocument.createElement(this._currentElement.type, props.is) :
+            ownerDocument.createElement(this._currentElement.type);
         }
       } else {
         el = ownerDocument.createElementNS(

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -621,9 +621,10 @@ ReactDOMComponent.Mixin = {
           var type = this._currentElement.type;
           div.innerHTML = `<${type}></${type}>`;
           el = div.removeChild(div.firstChild);
+        } else if (props.is) {
+          el = ownerDocument.createElement(this._currentElement.type, props.is);
         } else {
-          el = props.is ? ownerDocument.createElement(this._currentElement.type, props.is) :
-            ownerDocument.createElement(this._currentElement.type);
+          el = ownerDocument.createElement(this._currentElement.type);
         }
       } else {
         el = ownerDocument.createElementNS(


### PR DESCRIPTION
When using the two-parameter variant of `document.createElement()` (which is used for [Custom Elements](http://w3c.github.io/webcomponents/spec/custom/)), if `null` is passed as the second parameter then Firefox will stringify it to the DOM as an `is="null"` attribute. I don't believe that this causes any manner of problem, but it is surprising (as exemplified in [this discussion thread](https://discuss.reactjs.org/t/is-null-attribute-on-every-tag/4032).

This change simply changes the call to avoid passing `null`.

