### PR TITLE
[Fiber] Transfer everything from Element onto the Fiber and use Tag instead of Stage

### DIFF
--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -35,7 +35,17 @@ export type Fiber = {
   child: ?Fiber,
   sibling: ?Fiber,
 
-  // Input is the data coming into process this fiber. Arguments.
+  // Unique identifier of this child.
+  key: ?string,
+
+  // The function/class/module associated with this fiber.
+  type: any,
+
+  // The ref last used to attach this node.
+  // I'll avoid adding an owner field for prod and model that as functions.
+  ref: null | (handle : ?Object) => void,
+
+  // Input is the data coming into process this fiber. Arguments. Props.
   input: any, // This type will be more specific once we overload the tag.
   // Output is the return value of this fiber, or a linked list of return values
   // if this returns multiple values. Such as a fragment.
@@ -52,7 +62,7 @@ export type Fiber = {
 
 };
 
-var createFiber = function(tag : number) : Fiber {
+var createFiber = function(tag : number, key : null | string) : Fiber {
   return {
 
     tag: tag,
@@ -60,6 +70,10 @@ var createFiber = function(tag : number) : Fiber {
     parent: null,
     child: null,
     sibling: null,
+
+    key: key,
+    type: null,
+    ref: null,
 
     input: null,
     output: null,
@@ -78,23 +92,21 @@ function shouldConstruct(Component) {
 }
 
 exports.createFiberFromElement = function(element : ReactElement) {
-  const fiber = exports.createFiberFromElementType(element.type);
-  if (typeof element.type === 'object') {
-    // Hacky McHack
-    element = ReactElement(fiber.input, null, element.ref, null, null, null, element.props);
-  }
-  fiber.input = element;
+  const fiber = exports.createFiberFromElementType(element.type, element.key);
+  fiber.input = element.props;
   return fiber;
 };
 
-exports.createFiberFromElementType = function(type : mixed) {
+exports.createFiberFromElementType = function(type : mixed, key : null | string) {
   let fiber;
   if (typeof type === 'function') {
     fiber = shouldConstruct(type) ?
-      createFiber(ClassComponent) :
-      createFiber(IndeterminateComponent);
+      createFiber(ClassComponent, key) :
+      createFiber(IndeterminateComponent, key);
+    fiber.type = type;
   } else if (typeof type === 'string') {
-    fiber = createFiber(HostComponent);
+    fiber = createFiber(HostComponent, key);
+    fiber.type = type;
   } else if (typeof type === 'object' && type !== null) {
     // Currently assumed to be a continuation and therefore is a fiber already.
     fiber = type;
@@ -105,12 +117,13 @@ exports.createFiberFromElementType = function(type : mixed) {
 };
 
 exports.createFiberFromCoroutine = function(coroutine : ReactCoroutine) {
-  const fiber = createFiber(CoroutineComponent);
+  const fiber = createFiber(CoroutineComponent, coroutine.key);
+  fiber.type = coroutine.handler;
   fiber.input = coroutine;
   return fiber;
 };
 
 exports.createFiberFromYield = function(yieldNode : ReactYield) {
-  const fiber = createFiber(YieldComponent);
+  const fiber = createFiber(YieldComponent, yieldNode.key);
   return fiber;
 };

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -51,9 +51,6 @@ export type Fiber = {
   // if this returns multiple values. Such as a fragment.
   output: any, // This type will be more specific once we overload the tag.
 
-  // Used by multi-stage coroutines.
-  stage: number, // Consider reusing the tag field instead.
-
   // This will be used to quickly determine if a subtree has no pending changes.
   hasPendingChanges: bool,
 
@@ -77,8 +74,6 @@ var createFiber = function(tag : number, key : null | string) : Fiber {
 
     input: null,
     output: null,
-
-    stage: 0,
 
     hasPendingChanges: true,
 

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -26,18 +26,9 @@ var {
   YieldComponent,
 } = ReactTypesOfWork;
 
-function getElement(unitOfWork) : ReactElement {
-  var element = unitOfWork.input;
-  if (!element) {
-    throw new Error('Should be resolved by now');
-  }
-  return (element : ReactElement);
-}
-
 function updateFunctionalComponent(unitOfWork) {
-  var element = getElement(unitOfWork);
-  var fn = element.type;
-  var props = element.props;
+  var fn = unitOfWork.type;
+  var props = unitOfWork.input;
   console.log('perform work on:', fn.name);
   var nextChildren = fn(props);
 
@@ -49,10 +40,9 @@ function updateFunctionalComponent(unitOfWork) {
 }
 
 function updateHostComponent(unitOfWork) {
-  var element = getElement(unitOfWork);
-  console.log('host component', element.type, typeof element.props.children === 'string' ? element.props.children : '');
+  console.log('host component', unitOfWork.type, typeof unitOfWork.input.children === 'string' ? unitOfWork.input.children : '');
 
-  var nextChildren = element.props.children;
+  var nextChildren = unitOfWork.input.children;
   unitOfWork.child = ReactChildFiber.reconcileChildFibers(
     unitOfWork,
     unitOfWork.child,
@@ -61,9 +51,8 @@ function updateHostComponent(unitOfWork) {
 }
 
 function mountIndeterminateComponent(unitOfWork) {
-  var element = getElement(unitOfWork);
-  var fn = element.type;
-  var props = element.props;
+  var fn = unitOfWork.type;
+  var props = unitOfWork.input;
   var value = fn(props);
   if (typeof value === 'object' && value && typeof value.render === 'function') {
     console.log('performed work on class:', fn.name);
@@ -86,7 +75,7 @@ function updateCoroutineComponent(unitOfWork) {
   if (!coroutine) {
     throw new Error('Should be resolved by now');
   }
-  console.log('begin coroutine', coroutine.handler.name);
+  console.log('begin coroutine', unitOfWork.type.name);
   unitOfWork.child = ReactChildFiber.reconcileChildFibers(
     unitOfWork,
     unitOfWork.child,

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -23,6 +23,7 @@ var {
   ClassComponent,
   HostComponent,
   CoroutineComponent,
+  CoroutineHandlerPhase,
   YieldComponent,
 } = ReactTypesOfWork;
 
@@ -97,9 +98,11 @@ function beginWork(unitOfWork : Fiber) : ?Fiber {
     case HostComponent:
       updateHostComponent(unitOfWork);
       break;
+    case CoroutineHandlerPhase:
+      // This is a restart. Reset the tag to the initial phase.
+      unitOfWork.tag = CoroutineComponent;
+      // Intentionally fall through since this is now the same.
     case CoroutineComponent:
-      // Reset the stage to zero.
-      unitOfWork.stage = 0;
       updateCoroutineComponent(unitOfWork);
       // This doesn't take arbitrary time so we could synchronously just begin
       // eagerly do the work of unitOfWork.child as an optimization.

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -94,15 +94,15 @@ function handleCoroutine(unitOfWork : Fiber) {
 exports.completeWork = function(unitOfWork : Fiber) : ?Fiber {
   switch (unitOfWork.tag) {
     case FunctionalComponent:
-      console.log('/functional component', unitOfWork.input.type.name);
+      console.log('/functional component', unitOfWork.type.name);
       transferOutput(unitOfWork.child, unitOfWork);
       break;
     case ClassComponent:
-      console.log('/class component', unitOfWork.input.type.name);
+      console.log('/class component', unitOfWork.type.name);
       transferOutput(unitOfWork.child, unitOfWork);
       break;
     case HostComponent:
-      console.log('/host component', unitOfWork.input.type);
+      console.log('/host component', unitOfWork.type);
       break;
     case CoroutineComponent:
       console.log('/coroutine component', unitOfWork.input.handler.name);

--- a/src/renderers/shared/fiber/ReactReifiedYield.js
+++ b/src/renderers/shared/fiber/ReactReifiedYield.js
@@ -20,9 +20,10 @@ var ReactFiber = require('ReactFiber');
 export type ReifiedYield = { continuation: Fiber, props: Object };
 
 exports.createReifiedYield = function(yieldNode : ReactYield) : ReifiedYield {
-  var fiber = ReactFiber.createFiberFromElementType(yieldNode.continuation);
-  // Hacky way to store the continuation
-  fiber.input = yieldNode.continuation;
+  var fiber = ReactFiber.createFiberFromElementType(
+    yieldNode.continuation,
+    yieldNode.key
+  );
   return {
     continuation: fiber,
     props: yieldNode.props,

--- a/src/renderers/shared/fiber/ReactTypesOfWork.js
+++ b/src/renderers/shared/fiber/ReactTypesOfWork.js
@@ -18,7 +18,8 @@ var TypesOfWork = {
   ClassComponent: 2,
   HostComponent: 3,
   CoroutineComponent: 4,
-  YieldComponent: 5,
+  CoroutineHandlerPhase: 5,
+  YieldComponent: 6,
 };
 
 module.exports = TypesOfWork;

--- a/src/renderers/shared/fiber/isomorphic/ReactCoroutine.js
+++ b/src/renderers/shared/fiber/isomorphic/ReactCoroutine.js
@@ -29,7 +29,7 @@ type CoroutineHandler<T> = (props: T, yields: Array<ReifiedYield>) => ReactNodeL
 
 export type ReactCoroutine = {
   $$typeof: Symbol | number,
-  key: ?string,
+  key: null | string,
   children: any,
   // This should be a more specific CoroutineHandler
   handler: (props: any, yields: Array<ReifiedYield>) => ReactNodeList,
@@ -37,7 +37,7 @@ export type ReactCoroutine = {
 };
 export type ReactYield = {
   $$typeof: Symbol | number,
-  key: ?string,
+  key: null | string,
   props: Object,
   continuation: mixed
 };


### PR DESCRIPTION
This has a few benefits:

1) This allows the element to always remain on the young generation.
2) The key can be accessed on the fiber which is easier to keep as the
same class and is directly accessible in the child reconciliation of every
object.
3) This conveniently means that we don't have to create a fake element for
continuations which was really hacky.

We can still do the quick bailout of rerendered things using the props
object which is also unique.

Also I added a commit to use Tag instead of Stage for the coroutine
phase.