### PR TITLE
Add React.PureComponent, inherit purity for functional components

### DIFF
--- a/src/isomorphic/React.js
+++ b/src/isomorphic/React.js
@@ -13,6 +13,7 @@
 
 var ReactChildren = require('ReactChildren');
 var ReactComponent = require('ReactComponent');
+var ReactPureComponent = require('ReactPureComponent');
 var ReactClass = require('ReactClass');
 var ReactDOMFactories = require('ReactDOMFactories');
 var ReactElement = require('ReactElement');
@@ -63,6 +64,7 @@ var React = {
   },
 
   Component: ReactComponent,
+  PureComponent: ReactPureComponent,
 
   createElement: createElement,
   cloneElement: cloneElement,

--- a/src/isomorphic/modern/class/ReactPureComponent.js
+++ b/src/isomorphic/modern/class/ReactPureComponent.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactPureComponent
+ */
+
+'use strict';
+
+var ReactComponent = require('ReactComponent');
+
+/**
+ * Base class helpers for the updating state of a component.
+ */
+function ReactPureComponent(props, context, updater) {
+  ReactComponent.call(this, props, context, updater);
+}
+
+Object.assign(ReactPureComponent.prototype, ReactComponent.prototype);
+ReactPureComponent.prototype.isPureReactComponent = true;
+
+module.exports = ReactPureComponent;

--- a/src/isomorphic/modern/class/__tests__/ReactPureComponent-test.js
+++ b/src/isomorphic/modern/class/__tests__/ReactPureComponent-test.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var React;
+var ReactDOM;
+
+describe('ReactPureComponent', function() {
+  beforeEach(function() {
+    React = require('React');
+    ReactDOM = require('ReactDOM');
+  });
+
+  it('should render', function() {
+    var renders = 0;
+    class Component extends React.PureComponent {
+      constructor() {
+        super();
+        this.state = {type: 'mushrooms'};
+      }
+      render() {
+        renders++;
+        return <div>{this.props.text[0]}</div>;
+      }
+    }
+
+    var container = document.createElement('div');
+    var text;
+    var component;
+
+    text = ['porcini'];
+    component = ReactDOM.render(<Component text={text} />, container);
+    expect(container.textContent).toBe('porcini');
+    expect(renders).toBe(1);
+
+    text = ['morel'];
+    component = ReactDOM.render(<Component text={text} />, container);
+    expect(container.textContent).toBe('morel');
+    expect(renders).toBe(2);
+
+    text[0] = 'portobello';
+    component = ReactDOM.render(<Component text={text} />, container);
+    expect(container.textContent).toBe('morel');
+    expect(renders).toBe(2);
+
+    // Setting state, even with the same values, causes a rerender.
+    component.setState({type: 'mushrooms'});
+    expect(container.textContent).toBe('portobello');
+    expect(renders).toBe(3);
+  });
+
+  it('can override shouldComponentUpdate', function() {
+    var renders = 0;
+    class Component extends React.PureComponent {
+      render() {
+        renders++;
+        return <div />;
+      }
+      shouldComponentUpdate() {
+        return true;
+      }
+    }
+    var container = document.createElement('div');
+    ReactDOM.render(<Component />, container);
+    ReactDOM.render(<Component />, container);
+    expect(renders).toBe(2);
+  });
+
+});

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -846,10 +846,16 @@ ReactDOMComponent.Mixin = {
    * @param {ReactReconcileTransaction|ReactServerRenderingTransaction} transaction
    * @param {object} context
    */
-  receiveComponent: function(nextElement, transaction, context) {
+  receiveComponent: function(nextElement, transaction, context, isParentPure) {
     var prevElement = this._currentElement;
     this._currentElement = nextElement;
-    this.updateComponent(transaction, prevElement, nextElement, context);
+    this.updateComponent(
+      transaction,
+      prevElement,
+      nextElement,
+      context,
+      isParentPure
+    );
   },
 
   /**
@@ -862,7 +868,13 @@ ReactDOMComponent.Mixin = {
    * @internal
    * @overridable
    */
-  updateComponent: function(transaction, prevElement, nextElement, context) {
+  updateComponent: function(
+    transaction,
+    prevElement,
+    nextElement,
+    context,
+    isParentPure
+  ) {
     var lastProps = prevElement.props;
     var nextProps = this._currentElement.props;
 
@@ -897,7 +909,8 @@ ReactDOMComponent.Mixin = {
       lastProps,
       nextProps,
       transaction,
-      context
+      context,
+      isParentPure
     );
 
     if (this._tag === 'select') {
@@ -1053,7 +1066,13 @@ ReactDOMComponent.Mixin = {
    * @param {ReactReconcileTransaction} transaction
    * @param {object} context
    */
-  _updateDOMChildren: function(lastProps, nextProps, transaction, context) {
+  _updateDOMChildren: function(
+    lastProps,
+    nextProps,
+    transaction,
+    context,
+    isParentPure
+  ) {
     var lastContent =
       CONTENT_TYPES[typeof lastProps.children] ? lastProps.children : null;
     var nextContent =
@@ -1075,7 +1094,7 @@ ReactDOMComponent.Mixin = {
     var lastHasContentOrHtml = lastContent != null || lastHtml != null;
     var nextHasContentOrHtml = nextContent != null || nextHtml != null;
     if (lastChildren != null && nextChildren == null) {
-      this.updateChildren(null, transaction, context);
+      this.updateChildren(null, transaction, context, isParentPure);
     } else if (lastHasContentOrHtml && !nextHasContentOrHtml) {
       this.updateTextContent('');
       if (__DEV__) {
@@ -1102,7 +1121,7 @@ ReactDOMComponent.Mixin = {
         setContentChildForInstrumentation.call(this, null);
       }
 
-      this.updateChildren(nextChildren, transaction, context);
+      this.updateChildren(nextChildren, transaction, context, isParentPure);
     }
   },
 

--- a/src/renderers/dom/shared/ReactDOMEmptyComponent.js
+++ b/src/renderers/dom/shared/ReactDOMEmptyComponent.js
@@ -52,7 +52,7 @@ Object.assign(ReactDOMEmptyComponent.prototype, {
       return '<!--' + nodeValue + '-->';
     }
   },
-  receiveComponent: function() {
+  receiveComponent: function(nextElement, transaction, context, isParentPure) {
   },
   getHostNode: function() {
     return ReactDOMComponentTree.getNodeFromInstance(this);

--- a/src/renderers/dom/shared/ReactDOMTextComponent.js
+++ b/src/renderers/dom/shared/ReactDOMTextComponent.js
@@ -127,7 +127,7 @@ Object.assign(ReactDOMTextComponent.prototype, {
    * @param {ReactReconcileTransaction} transaction
    * @internal
    */
-  receiveComponent: function(nextText, transaction) {
+  receiveComponent: function(nextText, transaction, context, isParentPure) {
     if (nextText !== this._currentElement) {
       this._currentElement = nextText;
       var nextStringText = '' + nextText;

--- a/src/renderers/native/ReactNativeBaseComponent.js
+++ b/src/renderers/native/ReactNativeBaseComponent.js
@@ -97,7 +97,7 @@ ReactNativeBaseComponent.Mixin = {
    * @param {object} context
    * @internal
    */
-  receiveComponent: function(nextElement, transaction, context) {
+  receiveComponent: function(nextElement, transaction, context, isParentPure) {
     var prevElement = this._currentElement;
     this._currentElement = nextElement;
 
@@ -127,7 +127,12 @@ ReactNativeBaseComponent.Mixin = {
       prevElement.props,
       nextElement.props
     );
-    this.updateChildren(nextElement.props.children, transaction, context);
+    this.updateChildren(
+      nextElement.props.children,
+      transaction,
+      context,
+      isParentPure
+    );
   },
 
   /**

--- a/src/renderers/native/ReactNativeTextComponent.js
+++ b/src/renderers/native/ReactNativeTextComponent.js
@@ -59,7 +59,7 @@ Object.assign(ReactNativeTextComponent.prototype, {
     return this._rootNodeID;
   },
 
-  receiveComponent: function(nextText, transaction, context) {
+  receiveComponent: function(nextText, transaction, context, isParentPure) {
     if (nextText !== this._currentElement) {
       this._currentElement = nextText;
       var nextStringText = '' + nextText;

--- a/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
+++ b/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
@@ -95,7 +95,8 @@ var ReactChildReconciler = {
     nextChildren,
     removedNodes,
     transaction,
-    context) {
+    context,
+    isParentPure) {
     // We currently don't have a way to track moves here but if we use iterators
     // instead of for..in we can zip the iterators and check if an item has
     // moved.
@@ -116,7 +117,7 @@ var ReactChildReconciler = {
       if (prevChild != null &&
           shouldUpdateReactComponent(prevElement, nextElement)) {
         ReactReconciler.receiveComponent(
-          prevChild, nextElement, transaction, context
+          prevChild, nextElement, transaction, context, isParentPure
         );
         nextChildren[name] = prevChild;
       } else {

--- a/src/renderers/shared/stack/reconciler/ReactMultiChild.js
+++ b/src/renderers/shared/stack/reconciler/ReactMultiChild.js
@@ -209,7 +209,8 @@ var ReactMultiChild = {
       nextNestedChildrenElements,
       removedNodes,
       transaction,
-      context
+      context,
+      isParentPure
     ) {
       var nextChildren;
       if (__DEV__) {
@@ -221,14 +222,24 @@ var ReactMultiChild = {
             ReactCurrentOwner.current = null;
           }
           ReactChildReconciler.updateChildren(
-            prevChildren, nextChildren, removedNodes, transaction, context
+            prevChildren,
+            nextChildren,
+            removedNodes,
+            transaction,
+            context,
+            isParentPure
           );
           return nextChildren;
         }
       }
       nextChildren = flattenChildren(nextNestedChildrenElements);
       ReactChildReconciler.updateChildren(
-        prevChildren, nextChildren, removedNodes, transaction, context
+        prevChildren,
+        nextChildren,
+        removedNodes,
+        transaction,
+        context,
+        isParentPure
       );
       return nextChildren;
     },
@@ -320,9 +331,19 @@ var ReactMultiChild = {
      * @param {ReactReconcileTransaction} transaction
      * @internal
      */
-    updateChildren: function(nextNestedChildrenElements, transaction, context) {
+    updateChildren: function(
+      nextNestedChildrenElements,
+      transaction,
+      context,
+      isParentPure
+    ) {
       // Hook used by React ART
-      this._updateChildren(nextNestedChildrenElements, transaction, context);
+      this._updateChildren(
+        nextNestedChildrenElements,
+        transaction,
+        context,
+        isParentPure
+      );
     },
 
     /**
@@ -331,7 +352,12 @@ var ReactMultiChild = {
      * @final
      * @protected
      */
-    _updateChildren: function(nextNestedChildrenElements, transaction, context) {
+    _updateChildren: function(
+      nextNestedChildrenElements,
+      transaction,
+      context,
+      isParentPure
+    ) {
       var prevChildren = this._renderedChildren;
       var removedNodes = {};
       var nextChildren = this._reconcilerUpdateChildren(
@@ -339,7 +365,8 @@ var ReactMultiChild = {
         nextNestedChildrenElements,
         removedNodes,
         transaction,
-        context
+        context,
+        isParentPure
       );
       if (!nextChildren && !prevChildren) {
         return;

--- a/src/renderers/shared/stack/reconciler/ReactReconciler.js
+++ b/src/renderers/shared/stack/reconciler/ReactReconciler.js
@@ -128,7 +128,7 @@ var ReactReconciler = {
    * @internal
    */
   receiveComponent: function(
-    internalInstance, nextElement, transaction, context
+    internalInstance, nextElement, transaction, context, isParentPure
   ) {
     var prevElement = internalInstance._currentElement;
 
@@ -170,7 +170,12 @@ var ReactReconciler = {
       ReactRef.detachRefs(internalInstance, prevElement);
     }
 
-    internalInstance.receiveComponent(nextElement, transaction, context);
+    internalInstance.receiveComponent(
+      nextElement,
+      transaction,
+      context,
+      isParentPure
+    );
 
     if (refsChanged &&
         internalInstance._currentElement &&

--- a/src/renderers/shared/stack/reconciler/ReactSimpleEmptyComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactSimpleEmptyComponent.js
@@ -33,7 +33,7 @@ Object.assign(ReactSimpleEmptyComponent.prototype, {
       context
     );
   },
-  receiveComponent: function() {
+  receiveComponent: function(nextElement, transaction, context, isParentPure) {
   },
   getHostNode: function() {
     return ReactReconciler.getHostNode(this._renderedComponent);

--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -391,7 +391,7 @@ NoopInternalComponent.prototype = {
   mountComponent: function() {
   },
 
-  receiveComponent: function(element) {
+  receiveComponent: function(element, transaction, context, isParentPure) {
     this._renderedOutput = element;
     this._currentElement = element;
   },
@@ -487,7 +487,8 @@ ReactShallowRenderer.prototype._render = function(element, transaction, context)
       this._instance,
       element,
       transaction,
-      context
+      context,
+      /* isParentPure: */ false
     );
   } else {
     var instance = new ShallowComponentWrapper(element);


### PR DESCRIPTION
## React.PureComponent

This provides an easy way to indicate that components should only rerender when given new props, like PureRenderMixin. If you rely on mutation in your React components, you can continue to use `React.Component`.

Inheriting from `React.PureComponent` indicates to React that your component doesn't need to rerender when the props are unchanged. We'll compare the old and new props before each render and short-circuit if they're unchanged. It's like an automatic shouldComponentUpdate, but it also affects the behavior of functional children that are rendered:
## Functional components

We've heard clearly that most React users intend for their functional components to be pure and to produce different output only if the component's props have changed (https://mobile.twitter.com/reactjs/status/736412808372314114). However, a significant fraction of users still rely on mutation in their apps; when used with mutation, comparing props on each render could lead to components not updating even when the data is changed.

Therefore, we're changing functional components to behave as pure when they're used inside a React.PureComponent but to rerender unconditionally when contained in a React.Component:

``` js
class Post extends React.PureComponent {  // or React.Component
  render() {
    return (
      <div className="post">
        <PostHeader model={this.props.model} />
        <PostBody model={this.props.model} />
      </div>
    );
  }
}

function PostHeader(props) {
  // ...
}

function PostBody(props) {
  // ...
}
```

In this example, the functional components PostHeader and PostBody will be treated as pure because they're rendered by a pure parent component (Post). If our app used mutable models instead, Post should extend React.Component, which would cause PostHeader and PostBody to rerender whenever Post does, even if the model object is the same.

We anticipate that this behavior will work well in real-world apps: if you use immutable data, your class-based components can extend React.PureComponent and your functional components will be pure too; if you use mutable data, your class-based components will extend React.Component and your functional components will update accordingly.

In the future, we might adjust these heuristics to improve performance. For example, we might do runtime detection of components like

``` js
function FancyButton(props) {
  return <Button style="fancy" text={props.text} />;
}
```

and optimize them to "inline" the child Button component and call it immediately, so that React doesn't need to store the props for Button nor allocate a backing instance for it -- causing less work to be performed and reducing GC pressure.
