### PR TITLE
Add currentTarget property to SyntheticTouchEvents

### DIFF
--- a/src/renderers/dom/client/syntheticEvents/SyntheticTouchEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticTouchEvent.js
@@ -15,14 +15,52 @@ var SyntheticUIEvent = require('SyntheticUIEvent');
 
 var getEventModifierState = require('getEventModifierState');
 
+var currentTargetDict = {};
+
+/**
+ * Set the currentTarget for each Touch in the touches.
+ * @param {TouchList} touches
+ * @param {Boolean} changed - true for changedTouches, false otherwise
+ */
+function addCurrentTarget(touches, changed) {
+  for (var i = 0; i < touches.length; i++) {
+    var touch = touches[i];
+    if (changed) {
+      var currentTarget = document.elementFromPoint(touch.clientX, touch.clientY);
+      touch.currentTarget = currentTarget;
+      if (touch.type === 'touchend' || touch.type === 'touchcancel') {
+        delete currentTargetDict[touch.identifier];
+      } else {
+        currentTargetDict[touch.identifier] = currentTarget;
+      }
+    } else {
+      touch.currentTarget = currentTargetDict[touch.identifier];
+    }
+  }
+}
+
 /**
  * @interface TouchEvent
  * @see http://www.w3.org/TR/touch-events/
  */
 var TouchEventInterface = {
-  touches: null,
-  targetTouches: null,
-  changedTouches: null,
+  // changedTouches should appear first so that its normalize function can
+  // update currentTargetDict first before the normalize functions for touches
+  // and targetTouches is called.  It would be nice to not have this dependency,
+  // but calling elementFromPoint to get the current target is expensive so we
+  // cache the results the changedTouches' normalize function.
+  changedTouches: function(nativeEvent) {
+    addCurrentTarget(nativeEvent.changedTouches, true);
+    return nativeEvent.changedTouches;
+  },
+  touches: function(nativeEvent) {
+    addCurrentTarget(nativeEvent.touches, false);
+    return nativeEvent.touches;
+  },
+  targetTouches: function(nativeEvent) {
+    addCurrentTarget(nativeEvent.targetTouches, false);
+    return nativeEvent.targetTouches;
+  },
   altKey: null,
   metaKey: null,
   ctrlKey: null,


### PR DESCRIPTION
Touch events only include the target of the initial touchstart
in all subsequent events for that touch.  This makes it quite
difficult to implement UIs where a single touch needs to interact
with multiple elements on the screen.  An example of this would
be an onscreen keypad where you want a user to be able to press
a key and then drag to another key so that they can correct a
mistake before lifting their finger to activate the key.

This diff adds a currentTarget property to all Touch objects
in changedTouches, touches, and targetTouches.  The currentTarget
is the DOM element at clientX, clientY for each touch.  This may
or may not be the original target.

This currently, breaks some of the tests in ReactBrowserEventEmitter-test.js.
I'd like to get some feedback on the idea of adding `currentTarget` to 
touch events before fixing the failures and writing new tests.

TODO:
- [ ] write unit tests
- [ ] fix failures in ReactBrowserEventEmitter-test.js