### PR TITLE
Remove getDOMNode from docs

### DIFF
--- a/docs/docs/ref-02-component-api.it-IT.md
+++ b/docs/docs/ref-02-component-api.it-IT.md
@@ -81,21 +81,6 @@ Chiamare `forceUpdate()` causerà la chiamata di `render()` sul componente, salt
 Normalmente dovresti cercare di evitare l'uso di `forceUpdate()` e leggere soltanto `this.props` e `this.state` all'interno di `render()`. Ciò rende il tuo componente "puro" e la tua applicazione molto più semplice ed efficiente.
 
 
-### getDOMNode
-
-```javascript
-DOMElement getDOMNode()
-```
-
-Se questo componente è stato montato nel DOM, restituisce il corrispondente elemento DOM nativo del browser. Questo metodo è utile per leggere valori dal DOM, come valori dei campi dei moduli ed effettuare misure sul DOM. Quando `render` restituisce `null` o `false`, `this.getDOMNode()` restituisce `null`.
-
-> Nota:
->
-> getDOMNode è deprecato ed è stato sostituito da [ReactDOM.findDOMNode()](/react/docs/top-level-api.html#reactdom.finddomnode).
->
-> Questo metodo non è disponibile il componenti `class` ES6 che estendono `React.Component`. Potrebbe essere eliminato del tutto in una versione futura di React.
-
-
 ### isMounted
 
 ```javascript

--- a/docs/docs/ref-02-component-api.ko-KR.md
+++ b/docs/docs/ref-02-component-api.ko-KR.md
@@ -15,7 +15,7 @@ React 컴포넌트의 인스턴스는 React가 렌더링 시에 내부적으로 
 
 ```javascript
 void setState(
-  function|object nextState, 
+  function|object nextState,
   [function callback]
 )
 ```
@@ -55,7 +55,7 @@ setState(function(previousState, currentProps) {
 
 ```javascript
 void replaceState(
-  object nextState, 
+  object nextState,
   [function callback]
 )
 ```
@@ -82,21 +82,6 @@ void forceUpdate(
 특별한 경우가 아니면 `forceUpdate()`는 되도록 피하시고 `render()`에서는 `this.props`와 `this.state`에서만 읽어오세요. 그렇게 하는 것이 컴포넌트를 "순수"하게 하고 애플리케이션을 훨씬 단순하고 효율적으로 만들어줍니다.
 
 
-### getDOMNode
-
-```javascript
-DOMElement getDOMNode()
-```
-
-이 컴포넌트가 DOM에 마운트된 경우 해당하는 네이티브 브라우저 DOM 엘리먼트를 리턴합니다. 이 메소드는 폼 필드의 값이나 DOM의 크기/위치 등 DOM에서 정보를 읽을 때 유용합니다. `render`가 `null`이나 `false`를 리턴하였다면 `this.getDOMNode()`는 `null`을 리턴합니다.
-
-> 주의:
->
-> getDOMNode는 [ReactDOM.findDOMNode()](/react/docs/top-level-api.html#reactdom.finddomnode)로 교체되었습니다.
->
-> 이 메소드는 `React.Component`를 확장한 ES6 `class` 컴포넌트에서는 사용할 수 없습니다. React의 미래 버전에서 이는 완전히 사라지게 될 것입니다.
-
-
 ### isMounted
 
 ```javascript
@@ -114,7 +99,7 @@ boolean isMounted()
 
 ```javascript
 void setProps(
-  object nextProps, 
+  object nextProps,
   [function callback]
 )
 ```
@@ -136,7 +121,7 @@ void setProps(
 
 ```javascript
 void replaceProps(
-  object nextProps, 
+  object nextProps,
   function callback]
 )
 ```

--- a/docs/docs/ref-02-component-api.md
+++ b/docs/docs/ref-02-component-api.md
@@ -81,21 +81,6 @@ Calling `forceUpdate()` will cause `render()` to be called on the component, ski
 Normally you should try to avoid all uses of `forceUpdate()` and only read from `this.props` and `this.state` in `render()`. This makes your component "pure" and your application much simpler and more efficient.
 
 
-### getDOMNode
-
-```javascript
-DOMElement getDOMNode()
-```
-
-If this component has been mounted into the DOM, this returns the corresponding native browser DOM element. This method is useful for reading values out of the DOM, such as form field values and performing DOM measurements. When `render` returns `null` or `false`, `this.getDOMNode()` returns `null`.
-
-> Note:
->
-> getDOMNode is deprecated and has been replaced with [ReactDOM.findDOMNode()](/react/docs/top-level-api.html#reactdom.finddomnode).
->
-> This method is not available on ES6 `class` components that extend `React.Component`. It may be removed entirely in a future version of React.
-
-
 ### isMounted
 
 ```javascript

--- a/docs/docs/ref-02-component-api.zh-CN.md
+++ b/docs/docs/ref-02-component-api.zh-CN.md
@@ -81,21 +81,6 @@ void forceUpdate(
 通常你应该试着避免所有对 `forceUpdate()` 的使用并且在 `render()` 里只从 `this.props` 和 `this.state` 读取。这会使你的组件 "纯粹" 并且你的组件会更简单和高效。
 
 
-### getDOMNode
-
-```javascript
-DOMElement getDOMNode()
-```
-
-如果这个组件已经被挂载到了 DOM，它返回相应的浏览器原生的 DOM 元素。这个方法对于读取 DOM 的值很有用，比如表单域的值和执行 DOM 的测量。如果 `render` 返回 `null` 或者 `false` 的时候，`this.getDOMNode()` 返回 `null`。
-
-> Note:
->
-> getDOMNode 被废弃了，已经被 [ReactDOM.findDOMNode()] 替换(/react/docs/top-level-api-zh-CN.html#reactdom.finddomnode).
->
-> 这个方法在从 `React.Component` 扩展的 ES6 `class` 组件里不可用。它也许会在未来的 React 版本中被完全移除。
-
-
 ### isMounted
 
 ```javascript


### PR DESCRIPTION
`getDOMNode` was removed completely on v15.0.