### PR TITLE
Remove 'unitless number' warning for 'content' style properties

### DIFF
--- a/src/renderers/dom/shared/CSSProperty.js
+++ b/src/renderers/dom/shared/CSSProperty.js
@@ -23,6 +23,7 @@ var isUnitlessNumber = {
   boxFlexGroup: true,
   boxOrdinalGroup: true,
   columnCount: true,
+  content: true,
   flex: true,
   flexGrow: true,
   flexPositive: true,

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -228,6 +228,18 @@ describe('ReactDOMComponent', function() {
       expect(console.error.calls.count()).toBe(0);
     });
 
+    it('should not warn for "content" style values', function() {
+      spyOn(console, 'error');
+      var Component = React.createClass({
+        render: function() {
+          return <div style={{content: ' '}}><span style={{content: '1'}}></span></div>;
+        },
+      });
+
+      ReactTestUtils.renderIntoDocument(<Component />);
+      expect(console.error.calls.count()).toBe(0);
+    });
+
     it('should warn nicely about NaN in style', function() {
       spyOn(console, 'error');
 


### PR DESCRIPTION
The 'content' style allows a multitude of value formats, some of which
would classify as unitless numbers, so we should not issue a
warning for this property.