### PR TITLE
Warn if childContextType is defined on SFC

### DIFF
--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -46,6 +46,11 @@ function warnIfInvalidElement(Component, element) {
       'returned undefined, an array or some other invalid object.',
       Component.displayName || Component.name || 'Component'
     );
+    warning(
+      !Component.childContextTypes,
+      '%s(...): childContextTypes cannot be defined on a functional component.',
+      Component.displayName || Component.name || 'Component'
+    );
   }
 }
 

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactStatelessComponent-test.js
@@ -98,6 +98,27 @@ describe('ReactStatelessComponent', function() {
     expect(el.textContent).toBe('mest');
   });
 
+  it('should warn for childContextTypes on a functional component', () => {
+    spyOn(console, 'error');
+    function StatelessComponentWithChildContext(props) {
+      return <div>{props.name}</div>;
+    }
+
+    StatelessComponentWithChildContext.childContextTypes = {
+      foo: React.PropTypes.string,
+    };
+
+    var container = document.createElement('div');
+
+    ReactDOM.render(<StatelessComponentWithChildContext name="A" />, container);
+
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toContain(
+      'StatelessComponentWithChildContext(...): childContextTypes cannot ' +
+      'be defined on a functional component.'
+    );
+  });
+
   it('should warn when stateless component returns array', function() {
     spyOn(console, 'error');
     function NotAComponent() {


### PR DESCRIPTION
Resolves https://github.com/facebook/react/issues/6926

Per the discussion there, this only warns for `childContextTypes` for now.

#reactEurope-hackathon