### PR TITLE
Attach display name to method

### DIFF
--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -531,7 +531,6 @@ function mixSpecIntoComponent(Constructor, spec, isFromMixin) {
           }
 
           if (__DEV__) {
-            var displayName;
             if (isFromMixin) {
               displayName = 'mixin';
             } else {
@@ -547,7 +546,6 @@ function mixSpecIntoComponent(Constructor, spec, isFromMixin) {
         } else {
           proto[name] = property;
           if (__DEV__) {
-            var displayName;
             if (isFromMixin) {
               displayName = 'mixin';
             } else {

--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -495,17 +495,6 @@ function mixSpecIntoComponent(Constructor, spec, isFromMixin) {
       if (shouldAutoBind) {
         autoBindPairs.push(name, property);
         proto[name] = property;
-        if (__DEV__) {
-          var displayName;
-          if (isFromMixin) {
-            displayName = 'mixin';
-          } else {
-            displayName = Constructor.displayName || 'anonymous';
-          }
-          if (typeof property === 'function') {
-            property.displayName = displayName + '_' + name;
-          }
-        }
       } else {
         if (isAlreadyDefined) {
           var specPolicy = ReactClassInterface[name];
@@ -529,32 +518,18 @@ function mixSpecIntoComponent(Constructor, spec, isFromMixin) {
           } else if (specPolicy === SpecPolicy.DEFINE_MANY) {
             proto[name] = createChainedFunction(proto[name], property);
           }
-
-          if (__DEV__) {
-            if (isFromMixin) {
-              displayName = 'mixin';
-            } else {
-              displayName = Constructor.displayName || 'anonymous';
-            }
-            if (typeof property === 'function') {
-              // `proto[name]` might not === `property` if the former is a
-              // chained/merged method.
-              proto[name].displayName = displayName + '_' + name;
-              property.displayName = displayName + '_' + name;
-            }
-          }
         } else {
           proto[name] = property;
-          if (__DEV__) {
-            if (isFromMixin) {
-              displayName = 'mixin';
-            } else {
-              displayName = Constructor.displayName || 'anonymous';
-            }
-            if (typeof property === 'function') {
-              property.displayName = displayName + '_' + name;
-            }
-          }
+        }
+      }
+
+      if (__DEV__) {
+        var displayName = isFromMixin ?
+          'mixin' :
+          Constructor.displayName || 'anonymous';
+        if (typeof property === 'function') {
+          proto[name].displayName = displayName + '_' + name;
+          property.displayName = displayName + '_' + name;
         }
       }
     }

--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -319,7 +319,7 @@ var RESERVED_SPEC_KEYS = {
   mixins: function(Constructor, mixins) {
     if (mixins) {
       for (var i = 0; i < mixins.length; i++) {
-        mixSpecIntoComponent(Constructor, mixins[i]);
+        mixSpecIntoComponent(Constructor, mixins[i], true);
       }
     }
   },
@@ -435,7 +435,7 @@ function validateMethodOverride(isAlreadyDefined, name) {
  * Mixin helper which handles policy validation and reserved
  * specification keys when building React classes.
  */
-function mixSpecIntoComponent(Constructor, spec) {
+function mixSpecIntoComponent(Constructor, spec, isFromMixin) {
   if (!spec) {
     return;
   }
@@ -495,6 +495,17 @@ function mixSpecIntoComponent(Constructor, spec) {
       if (shouldAutoBind) {
         autoBindPairs.push(name, property);
         proto[name] = property;
+        if (__DEV__) {
+          var displayName;
+          if (isFromMixin) {
+            displayName = 'mixin';
+          } else {
+            displayName = Constructor.displayName || 'anonymous';
+          }
+          if (typeof property === 'function') {
+            property.displayName = displayName + '_' + name;
+          }
+        }
       } else {
         if (isAlreadyDefined) {
           var specPolicy = ReactClassInterface[name];
@@ -518,13 +529,32 @@ function mixSpecIntoComponent(Constructor, spec) {
           } else if (specPolicy === SpecPolicy.DEFINE_MANY) {
             proto[name] = createChainedFunction(proto[name], property);
           }
+
+          if (__DEV__) {
+            var displayName;
+            if (isFromMixin) {
+              displayName = 'mixin';
+            } else {
+              displayName = Constructor.displayName || 'anonymous';
+            }
+            if (typeof property === 'function') {
+              // `proto[name]` might not === `property` if the former is a
+              // chained/merged method.
+              proto[name].displayName = displayName + '_' + name;
+              property.displayName = displayName + '_' + name;
+            }
+          }
         } else {
           proto[name] = property;
           if (__DEV__) {
-            // Add verbose displayName to the function, which helps when looking
-            // at profiling tools.
-            if (typeof property === 'function' && spec.displayName) {
-              proto[name].displayName = spec.displayName + '_' + name;
+            var displayName;
+            if (isFromMixin) {
+              displayName = 'mixin';
+            } else {
+              displayName = Constructor.displayName || 'anonymous';
+            }
+            if (typeof property === 'function') {
+              property.displayName = displayName + '_' + name;
             }
           }
         }
@@ -800,7 +830,7 @@ var ReactClass = {
       mixSpecIntoComponent.bind(null, Constructor)
     );
 
-    mixSpecIntoComponent(Constructor, spec);
+    mixSpecIntoComponent(Constructor, spec, false);
 
     // Initialize the defaultProps property after all mixins have been merged.
     if (Constructor.getDefaultProps) {

--- a/src/isomorphic/classic/class/__tests__/ReactClass-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactClass-test.js
@@ -58,6 +58,52 @@ describe('ReactClass-spec', function() {
       .toBe(propValidator);
   });
 
+    it('gives methods a displayName for testing purposes', function() {
+    var a = function() {};
+    var b = function() {};
+    var c = function() {};
+    var d = function() {return <div />;};
+    var e = function() {return null};
+    var f = function() {return null};
+    var g = function() {};
+    var mixin = {
+      getInitialState: f,
+      componentDidMount: g,
+    };
+    var Component = React.createClass({
+      mixins: [mixin],
+      componentDidMount: a, // DEFINE_MANY
+      onClick: b,
+      random: c,
+      render: d,
+      getInitialState: e, // DEFINE_MANY_MERGED
+    });
+
+    var instance = (<Component />);
+    ReactTestUtils.renderIntoDocument(instance);
+
+    expect(Component.displayName).toBe('Component');
+    // componentDidMount on component
+    expect(a.displayName).toBe('Component_componentDidMount');
+    expect(b.displayName).toBe('Component_onClick');
+    expect(c.displayName).toBe('Component_random');
+    expect(d.displayName).toBe('Component_render');
+    // getInitialState on component
+    expect(e.displayName).toBe('Component_getInitialState');
+    // both on mixin
+    expect(f.displayName).toBe('mixin_getInitialState');
+    expect(g.displayName).toBe('mixin_componentDidMount');
+    // DEFINE_MANY and DEFINE_MANY_MERGED specs create new chained/merged
+    // functions, test those too
+    expect(Component.prototype.getInitialState.displayName).toBe('Component_getInitialState');
+    expect(Component.prototype.componentDidMount.displayName).toBe('Component_componentDidMount');
+
+    React.createClass({
+      render: d,
+    });
+    expect(d.displayName).toBe('anonymous_render');
+  });
+
   it('should warn on invalid prop types', function() {
     spyOn(console, 'error');
     React.createClass({

--- a/src/isomorphic/classic/class/__tests__/ReactClass-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactClass-test.js
@@ -58,13 +58,19 @@ describe('ReactClass-spec', function() {
       .toBe(propValidator);
   });
 
-    it('gives methods a displayName for testing purposes', function() {
+  it('gives methods a displayName for testing purposes', function() {
     var a = function() {};
     var b = function() {};
     var c = function() {};
-    var d = function() {return <div />;};
-    var e = function() {return null};
-    var f = function() {return null};
+    var d = function() {
+      return <div />;
+    };
+    var e = function() {
+      return null;
+    };
+    var f = function() {
+      return null;
+    };
     var g = function() {};
     var mixin = {
       getInitialState: f,


### PR DESCRIPTION
This fixes issue #3173, and is a refactoring of pr #6404.  I know `createClass` is going out of fashion, but thought it might as well get in now! #reactEurope-hackathon
