### PR TITLE
Fix #6153: Warning for PropTypes with the wrong case.

### DIFF
--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -12,6 +12,7 @@
 'use strict';
 
 var ReactElement = require('ReactElement');
+var ReactInstrumentation = require('ReactInstrumentation');
 var ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
 
 var emptyFunction = require('emptyFunction');
@@ -114,6 +115,9 @@ function createChainableTypeChecker(validate) {
   ) {
     componentName = componentName || ANONYMOUS;
     propFullName = propFullName || propName;
+    ReactInstrumentation.debugTool.onCreateChainableTypeChecker(componentName,
+                                                               props,
+                                                               propName);
     if (props[propName] == null) {
       var locationName = ReactPropTypeLocationNames[location];
       if (isRequired) {

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -13,6 +13,7 @@
 
 var PropTypes;
 var React;
+var ReactDOM;
 var ReactFragment;
 var ReactPropTypeLocations;
 var ReactTestUtils;
@@ -49,6 +50,7 @@ describe('ReactPropTypes', function() {
   beforeEach(function() {
     PropTypes = require('ReactPropTypes');
     React = require('React');
+    ReactDOM = require('ReactDOM');
     ReactFragment = require('ReactFragment');
     ReactPropTypeLocations = require('ReactPropTypeLocations');
     ReactTestUtils = require('ReactTestUtils');
@@ -919,5 +921,27 @@ describe('ReactPropTypes', function() {
         expect(console.error.calls.count()).toBe(0);
       }
     );
+  });
+
+  describe('Catching Typos', function() {
+    it('should warn if propType spelled with a different case', function() {
+      spyOn(console, 'error');
+
+      Component = React.createClass({
+        propTypes: {'testProp': PropTypes.string},
+
+        render: function() {
+          return <div/>;
+        },
+      });
+
+      var container = document.createElement('div');
+      ReactDOM.render(<Component testprop=""/>, container);
+
+      expect(console.error.calls.count()).toBe(1);
+      expect(console.error.calls.argsFor(0)[0]).toBe(
+        'Warning: Did you miscapitalize testProp as testprop in Component?'
+      );
+    });
   });
 });

--- a/src/renderers/shared/ReactDebugTool.js
+++ b/src/renderers/shared/ReactDebugTool.js
@@ -307,6 +307,12 @@ var ReactDebugTool = {
     checkDebugID(debugID);
     emitEvent('onUnmountComponent', debugID);
   },
+  onCreateChainableTypeChecker(componentName, props, propName) {
+    emitEvent('onCreateChainableTypeChecker',
+              componentName,
+              props,
+              propName);
+  },
   onTestEvent() {
     emitEvent('onTestEvent');
   },
@@ -314,9 +320,11 @@ var ReactDebugTool = {
 
 if (__DEV__) {
   var ReactInvalidSetStateWarningDevTool = require('ReactInvalidSetStateWarningDevTool');
+  var ReactMiscapitalizedPropNameWarningDevTool = require('ReactMiscapitalizedPropNameWarningDevTool');
   var ReactHostOperationHistoryDevtool = require('ReactHostOperationHistoryDevtool');
   var ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
   ReactDebugTool.addDevtool(ReactInvalidSetStateWarningDevTool);
+  ReactDebugTool.addDevtool(ReactMiscapitalizedPropNameWarningDevTool);
   ReactDebugTool.addDevtool(ReactComponentTreeDevtool);
   ReactDebugTool.addDevtool(ReactHostOperationHistoryDevtool);
   var url = (ExecutionEnvironment.canUseDOM && window.location.href) || '';

--- a/src/renderers/shared/devtools/ReactMiscapitalizedPropNameWarningDevTool.js
+++ b/src/renderers/shared/devtools/ReactMiscapitalizedPropNameWarningDevTool.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactMiscapitalizedPropNameWarningDevTool
+ */
+
+'use strict';
+
+var warning = require('warning');
+
+if (__DEV__) {
+
+
+  var warnMiscapitalizedPropName = function(
+                                     componentName,
+                                     allPropNames,
+                                     missingPropName
+                                   ) {
+    var missingPropNameLowerCase = missingPropName.toLowerCase();
+
+    for (var propName of allPropNames) {
+      if (propName !== missingPropName &&
+         propName.toLowerCase() === missingPropNameLowerCase) {
+        warning(
+          false,
+          'Did you miscapitalize %s as %s in %s?',
+          missingPropName,
+          propName,
+          componentName
+        );
+      }
+    }
+  };
+}
+
+var ReactMiscapitalizedPropNameWarningDevTool = {
+  onCreateChainableTypeChecker(componentName, props, propName) {
+    if (props[propName] == null) {
+      warnMiscapitalizedPropName(componentName, Object.keys(props), propName);
+    }
+  },
+};
+
+module.exports = ReactMiscapitalizedPropNameWarningDevTool;


### PR DESCRIPTION
Re-based code from #6255

The warning outputting twice issue in that PR has since been fixed in react itself.

The cache that he added has been removed as it would hit a lot of false positives (multiple components using the same proptypes).