### PR TITLE
facebook/react#6863 test case

### DIFF
--- a/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
@@ -51,6 +51,40 @@ describe('ReactElementClone', function() {
     expect(ReactDOM.findDOMNode(component).childNodes[0].className).toBe('xyz');
   });
 
+  it('should clone a DOM component with function props', function() {
+    var SimpleEventPlugin = require('SimpleEventPlugin');
+
+    SimpleEventPlugin.didPutListener = jest.fn();
+
+    var Child = React.createClass({
+      render: function() {
+        return <a onClick={this.props.clickHandler} />;
+      },
+    });
+
+    var Grandparent = React.createClass({
+      render: function() {
+        return (<Parent>
+                  <Child />
+                </Parent>);
+      },
+    });
+
+    var Parent = React.createClass({
+      clickHandler: function() {},
+      render: function() {
+        return (
+          <div className="parent">
+            {React.cloneElement(this.props.children, { clickHandler: this.clickHandler})}
+          </div>
+        );
+      },
+    });
+
+    ReactTestUtils.renderIntoDocument(<Grandparent />);
+    expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(1);
+  });
+
   it('should clone a composite component with new props', function() {
     var Child = React.createClass({
       render: function() {


### PR DESCRIPTION
In #6863 @fedgrant complains of props not getting passed into cloned elements. This test case clarifies that props with function values implemented on the cloning element are passed just as well as any other prop.

#reactEurope-hackathon