### PR TITLE
Fixes #6153 Add case typechecking to provided props against propTypes 

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -312,6 +312,7 @@ src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
 * should not warn for valid values
 * should be implicitly optional and not warn without values
 * should warn for missing required values
+* should warn for mismatched case of passed values to types
 * should should accept any value
 * should be implicitly optional and not warn without values
 * should warn for missing required values

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -166,8 +166,10 @@ describe('ReactPropTypes', () => {
           return <div>{this.props.label}</div>;
         },
       });
-      var instance = <Component onaction={() => alert('hello')} label="HelloWorld" />;
-      instance = ReactTestUtils.renderIntoDocument(instance);
+      var node = <Component onaction={() => alert('hello')} label="HelloWorld" />;
+      var node2 = <Component onaction={() => alert('hello')} label="HelloWorld" />;
+      ReactTestUtils.renderIntoDocument(node);
+      ReactTestUtils.renderIntoDocument(node2);
       expect(console.error.calls.argsFor(0)[0]).toBe(
         'Warning: Provided prop onaction is not defined in propTypes, did you mean onAction?',
       );

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -153,6 +153,26 @@ describe('ReactPropTypes', () => {
     it('should warn for missing required values', () => {
       typeCheckFailRequiredValues(PropTypes.string.isRequired);
     });
+
+    it('should warn for mismatched case of passed values to types', function() {
+      spyOn(console, 'error');
+      Component = React.createClass({
+        propTypes: {
+          onAction: PropTypes.func,
+          label: PropTypes.string,
+        },
+
+        render: function() {
+          return <div>{this.props.label}</div>;
+        },
+      });
+      var instance = <Component onaction={() => alert('hello')} label="HelloWorld" />;
+      instance = ReactTestUtils.renderIntoDocument(instance);
+      expect(console.error.calls.argsFor(0)[0]).toBe(
+        'Warning: Provided prop onaction is not defined in propTypes, did you mean onAction?',
+      );
+      expect(console.error.calls.count()).toBe(1);
+    });
   });
 
   describe('Any type', () => {

--- a/src/shared/types/checkReactTypeSpec.js
+++ b/src/shared/types/checkReactTypeSpec.js
@@ -35,6 +35,8 @@ if (
 
 var loggedTypeFailures = {};
 
+// function checkReactTypeSpec(typeSpecs, values, location, componentName, element, debugID) {
+
 /**
  * Assert that the values match with the type specs.
  * Error messages are memorized and will only be shown once.
@@ -57,6 +59,10 @@ function checkReactTypeSpec(
   // only during reconciliation (begin and complete phase).
   workInProgressOrDebugID,
 ) {
+  const mismatched = Object.keys(values).filter(x => Object.keys(typeSpecs).indexOf(x) === -1)
+    .map(i => i.toLowerCase());
+  const mismatched = Object.keys(values).filter(x => Object.keys(typeSpecs).indexOf(x) === -1);
+  const lowercase = mismatched.map(i => i.toLowerCase());
   for (var typeSpecName in typeSpecs) {
     if (typeSpecs.hasOwnProperty(typeSpecName)) {
       var error;
@@ -124,6 +130,15 @@ function checkReactTypeSpec(
           location,
           error.message,
           componentStackInfo
+        );
+      }
+      if (lowercase.indexOf(typeSpecName.toLowerCase()) !== -1) {
+        const mismatch = mismatched[lowercase.indexOf(typeSpecName.toLowerCase())];
+        warning(
+          false,
+          'Provided prop %s is not defined in propTypes, did you mean %s?',
+          mismatch,
+          typeSpecName,
         );
       }
     }

--- a/src/shared/types/checkReactTypeSpec.js
+++ b/src/shared/types/checkReactTypeSpec.js
@@ -34,8 +34,7 @@ if (
 }
 
 var loggedTypeFailures = {};
-
-// function checkReactTypeSpec(typeSpecs, values, location, componentName, element, debugID) {
+var mistypedPropFailures = {};
 
 /**
  * Assert that the values match with the type specs.
@@ -59,9 +58,8 @@ function checkReactTypeSpec(
   // only during reconciliation (begin and complete phase).
   workInProgressOrDebugID,
 ) {
-  const mismatched = Object.keys(values).filter(x => Object.keys(typeSpecs).indexOf(x) === -1)
-    .map(i => i.toLowerCase());
-  const mismatched = Object.keys(values).filter(x => Object.keys(typeSpecs).indexOf(x) === -1);
+  // values can be undefined, at least in pre existing test cases, so default to empty array
+  const mismatched = values ? Object.keys(values).filter(x => Object.keys(typeSpecs).indexOf(x) === -1) : [];
   const lowercase = mismatched.map(i => i.toLowerCase());
   for (var typeSpecName in typeSpecs) {
     if (typeSpecs.hasOwnProperty(typeSpecName)) {
@@ -132,7 +130,7 @@ function checkReactTypeSpec(
           componentStackInfo
         );
       }
-      if (lowercase.indexOf(typeSpecName.toLowerCase()) !== -1) {
+      if (lowercase.indexOf(typeSpecName.toLowerCase()) !== -1 && !mistypedPropFailures[typeSpecName]) {
         const mismatch = mismatched[lowercase.indexOf(typeSpecName.toLowerCase())];
         warning(
           false,
@@ -140,6 +138,7 @@ function checkReactTypeSpec(
           mismatch,
           typeSpecName,
         );
+        mistypedPropFailures[typeSpecName] = true;
       }
     }
   }


### PR DESCRIPTION
Grabs mismatched values compared to PropTypes, can be used later to warn against props being provided that aren't defined in PropTypes.

It then uses toLowerCase to find similar props and warn if there is a defined propType with the same composition but difference case as a prop passed on the element. 

Warning follows the "did you mean %s?" type suggestions in other react warnings. 
# reactEurope-hackathon
