### PR TITLE
Improve proptypes oneof warnings  - Fixes #1919

### DIFF
--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -240,7 +240,7 @@ function createEnumTypeChecker(expectedValues) {
       if (is(propValue, expectedValues[i])) {
         return null;
       }
-      if (getPropType(expectedValues[i]) === 'function' && expectedValues[i].name === "bound checkType") {
+      if (getPropType(expectedValues[i]) === 'function' && expectedValues[i].name === 'bound checkType') {
         isOneOfPropType = true;
       }
     }

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -235,18 +235,37 @@ function createEnumTypeChecker(expectedValues) {
 
   function validate(props, propName, componentName, location, propFullName) {
     var propValue = props[propName];
+    var isOneOfPropType = false;
     for (var i = 0; i < expectedValues.length; i++) {
       if (is(propValue, expectedValues[i])) {
         return null;
       }
+      if (getPropType(expectedValues[i]) === 'function' && expectedValues[i].name === "bound checkType") {
+        isOneOfPropType = true;
+      }
     }
 
     var locationName = ReactPropTypeLocationNames[location];
-    var valuesString = JSON.stringify(expectedValues);
+    if (isOneOfPropType) {
+      return new Error(
+        `Invalid ${locationName} \`${propFullName}\` of value \`${propValue}\` supplied to \`${componentName}\`.\n` +
+        `Possibly expected to use \`oneOfType\` instead of \`oneOf\`.`
+      );
+    }
+    var valuesString = JSON.stringify(expectedValues, functionPrettifier);
     return new Error(
       `Invalid ${locationName} \`${propFullName}\` of value \`${propValue}\` ` +
       `supplied to \`${componentName}\`, expected one of ${valuesString}.`
     );
+  }
+
+  function functionPrettifier(name, values) {
+    for (var i = 0; i< values.length; i++) {
+      if (getPropType(values[i]) === 'function') {
+        values[i] = values[i].toString();
+      }
+    }
+    return values;
   }
   return createChainableTypeChecker(validate);
 }


### PR DESCRIPTION
Fixes issue #1919 

As I see there is two problems:
1) If oneOf uses function in array - so they will be stringified as null - so I add functionPrettifier method as argument to JSON.stringify
2) Possibly mismatch oneOf and oneOfType - if checks do not pass and one of the function is one of React.PropTypes - proper warning will be shown

Welcome to your suggestions

#reactEurope-hackathon