### PR TITLE
[Docs] Add instruction for downloading babel-browser

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ Use Jekyll to serve the website locally (by default, at `http://localhost:4000`)
 ```sh
 $ cd react/docs
 $ bundle exec rake
+$ bundle exec rake fetch_remotes
 $ bundle exec jekyll serve -w
 $ open http://localhost:4000/react/
 ```


### PR DESCRIPTION
We could also consider switching from `babel-browser (5.8)` to [babel-standalone](https://github.com/Daniel15/babel-standalone) since the former has been deprecated.