### PR TITLE
Fix #6970, make document of test utils up to date

### DIFF
--- a/docs/docs/10.4-test-utils.md
+++ b/docs/docs/10.4-test-utils.md
@@ -147,12 +147,12 @@ array scryRenderedDOMComponentsWithClass(
 )
 ```
 
-Finds all instances of components in the rendered tree that are DOM components with the class name matching `className`.
+Finds all DOM elements of components in the rendered tree that are DOM components with the class name matching `className`.
 
 ### findRenderedDOMComponentWithClass
 
 ```javascript
-ReactComponent findRenderedDOMComponentWithClass(
+DOMElement findRenderedDOMComponentWithClass(
   ReactComponent tree,
   string className
 )
@@ -169,12 +169,12 @@ array scryRenderedDOMComponentsWithTag(
 )
 ```
 
-Finds all instances of components in the rendered tree that are DOM components with the tag name matching `tagName`.
+Finds all DOM elements of components in the rendered tree that are DOM components with the tag name matching `tagName`.
 
 ### findRenderedDOMComponentWithTag
 
 ```javascript
-ReactComponent findRenderedDOMComponentWithTag(
+DOMElement findRenderedDOMComponentWithTag(
   ReactComponent tree,
   string tagName
 )


### PR DESCRIPTION
The find/scry methods which returns DOM component in react@0.13 now returns DOMElement in react@0.14 and later.