### PR TITLE
Fix the typo in the documentaion pages for shallowCompare

### DIFF
--- a/docs/docs/10.10-shallow-compare.md
+++ b/docs/docs/10.10-shallow-compare.md
@@ -26,7 +26,7 @@ export class SampleComponent extends React.Component {
 ```
 
 `shallowCompare` performs a shallow equality check on the current `props` and `nextProps` objects as well as the current `state` and `nextState` objects.  
-It does this by iterating on the keys of the objects being compared and returning true when the value of a key in each object are not strictly equal.
+It does this by iterating on the keys of the objects being compared and returning true when the values of a key in each object are not strictly equal.
 
 `shallowCompare` returns `true` if the shallow comparison for props or state fails and therefore the component should update.  
 `shallowCompare` returns `false` if the shallow comparison for props and state both pass and therefore the component does not need to update.

--- a/docs/docs/10.10-shallow-compare.md
+++ b/docs/docs/10.10-shallow-compare.md
@@ -26,7 +26,7 @@ export class SampleComponent extends React.Component {
 ```
 
 `shallowCompare` performs a shallow equality check on the current `props` and `nextProps` objects as well as the current `state` and `nextState` objects.  
-It does this by iterating on the keys of the objects being compared and returning false when the value of a key in each object are not strictly equal.
+It does this by iterating on the keys of the objects being compared and returning true when the value of a key in each object are not strictly equal.
 
 `shallowCompare` returns `true` if the shallow comparison for props or state fails and therefore the component should update.  
 `shallowCompare` returns `false` if the shallow comparison for props and state both pass and therefore the component does not need to update.


### PR DESCRIPTION
Hi, this is to fix a typo in the documentation pages for shallowCompare at:
https://facebook.github.io/react/docs/shallow-compare.html

>It does this by iterating on the keys of the objects being compared and returning ~~false~~ **true** when the value of a key in each object are not strictly equal.