### PR TITLE
[Fiber] Add support for simple updates and fiber pooling

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -34,6 +34,7 @@ function transferOutput(child : ?Fiber, parent : Fiber) {
   // avoid unnecessary traversal. When we have multiple output, we just pass
   // the linked list of fibers that has the individual output values.
   parent.output = (child && !child.sibling) ? child.output : child;
+  parent.memoizedInput = parent.input;
 }
 
 function recursivelyFillYields(yields, output : ?Fiber | ?ReifiedYield) {
@@ -64,6 +65,8 @@ function moveCoroutineToHandlerPhase(unitOfWork : Fiber) {
   // single component, or at least tail call optimize nested ones. Currently
   // that requires additional fields that we don't want to add to the fiber.
   // So this requires nested handlers.
+  // Note: This doesn't mutate the alternate node. I don't think it needs to
+  // since this stage is reset for every pass.
   unitOfWork.tag = CoroutineHandlerPhase;
 
   // Build up the yields.

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -49,23 +49,23 @@ module.exports = function<T, P, I>(config : HostConfig<T, P, I>) : Reconciler {
 
   let nextUnitOfWork : ?Fiber = null;
 
-  function completeUnitOfWork(unitOfWork : Fiber) : ?Fiber {
+  function completeUnitOfWork(workInProgress : Fiber) : ?Fiber {
     while (true) {
-      var next = completeWork(unitOfWork);
+      var next = completeWork(workInProgress);
       if (next) {
         // If completing this work spawned new work, do that next.
         return next;
-      } else if (unitOfWork.sibling) {
+      } else if (workInProgress.sibling) {
         // If there is more work to do in this parent, do that next.
-        return unitOfWork.sibling;
-      } else if (unitOfWork.parent) {
+        return workInProgress.sibling;
+      } else if (workInProgress.parent) {
         // If there's no more work in this parent. Complete the parent.
         // TODO: Stop using the parent for this purpose. I think this will break
         // down in edge cases because when nodes are reused during bailouts, we
         // don't know which of two parents was used. Instead we should maintain
         // a temporary manual stack.
         // $FlowFixMe: This downcast is not safe. It is intentionally an error.
-        unitOfWork = unitOfWork.parent;
+        workInProgress = workInProgress.parent;
       } else {
         // If we're at the root, there's no more work to do.
         return null;
@@ -73,14 +73,14 @@ module.exports = function<T, P, I>(config : HostConfig<T, P, I>) : Reconciler {
     }
   }
 
-  function performUnitOfWork(unitOfWork : Fiber) : ?Fiber {
-    var next = beginWork(unitOfWork);
+  function performUnitOfWork(workInProgress : Fiber) : ?Fiber {
+    var next = beginWork(workInProgress);
     if (next) {
       // If this spawns new work, do that next.
       return next;
     } else {
       // Otherwise, complete the current work.
-      return completeUnitOfWork(unitOfWork);
+      return completeUnitOfWork(workInProgress);
     }
   }
 

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -60,6 +60,11 @@ module.exports = function<T, P, I>(config : HostConfig<T, P, I>) : Reconciler {
         return unitOfWork.sibling;
       } else if (unitOfWork.parent) {
         // If there's no more work in this parent. Complete the parent.
+        // TODO: Stop using the parent for this purpose. I think this will break
+        // down in edge cases because when nodes are reused during bailouts, we
+        // don't know which of two parents was used. Instead we should maintain
+        // a temporary manual stack.
+        // $FlowFixMe: This downcast is not safe. It is intentionally an error.
         unitOfWork = unitOfWork.parent;
       } else {
         // If we're at the root, there's no more work to do.
@@ -107,13 +112,23 @@ module.exports = function<T, P, I>(config : HostConfig<T, P, I>) : Reconciler {
   }
   */
 
+  let rootFiber : ?Fiber = null;
+
   return {
 
     mountNewRoot(element : ReactElement<any>) : OpaqueID {
 
       ensureLowPriIsScheduled();
 
-      nextUnitOfWork = ReactFiber.createFiberFromElement(element);
+      // TODO: Unify this with ReactChildFiber. We can't now because the parent
+      // is passed. Should be doable though. Might require a wrapper don't know.
+      if (rootFiber && rootFiber.type === element.type && rootFiber.key === element.key) {
+        nextUnitOfWork = rootFiber;
+        rootFiber.input = element.props;
+        return {};
+      }
+
+      nextUnitOfWork = rootFiber = ReactFiber.createFiberFromElement(element);
 
       return {};
     },

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -66,4 +66,53 @@ describe('ReactIncremental', function() {
     expect(barCalled).toBe(true);
   });
 
+  it('updates a previous render', function() {
+
+    var ops = [];
+
+    function Header() {
+      ops.push('Header');
+      return <h1>Hi</h1>;
+    }
+
+    function Content(props) {
+      ops.push('Content');
+      return <div>{props.children}</div>;
+    }
+
+    function Footer() {
+      ops.push('Footer');
+      return <footer>Bye</footer>;
+    }
+
+    var header = <Header />;
+    var footer = <Footer />;
+
+    function Foo(props) {
+      ops.push('Foo');
+      return (
+        <div>
+          {header}
+          <Content>{props.text}</Content>
+          {footer}
+        </div>
+      );
+    }
+
+    ReactNoop.render(<Foo text="foo" />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual(['Foo', 'Header', 'Content', 'Footer']);
+
+    ops = [];
+
+    ReactNoop.render(<Foo text="bar" />);
+    ReactNoop.flush();
+
+    // Since this is an update, it should bail out and reuse the work from
+    // Header and Content.
+    expect(ops).toEqual(['Foo', 'Content']);
+
+  });
+
 });


### PR DESCRIPTION
This splits the Fiber type into Fiber and Instance. This could be two different object instances to save memory. However, to avoid GC thrash I merge them into one.

When ReactChildFiber reconciles children, it clones the previous fiber. This creates a new tree for work-in-progress. The idea is that once flushed, this new tree will be used at the root.

However, we know that we'll never need more than two trees at a time. Therefore my clone function stores the clone on the original. Effectively this creates a fiber pool.

Ideally, the .alternate field shouldn't be used outside of clone so that everything can work with pure immutability. I cheat a bit for now so I don't have to pass both trees everywhere.

ReactChildFiber is a bit hacky for reuse and doesn't solve all cases. Will fix that once I try to get parity.

I currently still use `.parent` to backtrack through the work in progress. This is probably not going to work though. Probably need a parent stack for reconciliation purposes even if we keep the parent pointers for other purposes.

A separate commit renames unitOfWork -> workInProgress.