### PR TITLE
Fix #6950, work around IE missing innerHTML on SVG nodes

### DIFF
--- a/src/renderers/dom/client/utils/DOMLazyTree.js
+++ b/src/renderers/dom/client/utils/DOMLazyTree.js
@@ -12,6 +12,7 @@
 'use strict';
 
 var DOMNamespaces = require('DOMNamespaces');
+var setInnerHTML = require('setInnerHTML');
 
 var createMicrosoftUnsafeLocalFunction = require('createMicrosoftUnsafeLocalFunction');
 var setTextContent = require('setTextContent');
@@ -50,7 +51,7 @@ function insertTreeChildren(tree) {
       insertTreeBefore(node, children[i], null);
     }
   } else if (tree.html != null) {
-    node.innerHTML = tree.html;
+    setInnerHTML(node, tree.html);
   } else if (tree.text != null) {
     setTextContent(node, tree.text);
   }
@@ -96,7 +97,7 @@ function queueHTML(tree, html) {
   if (enableLazy) {
     tree.html = html;
   } else {
-    tree.node.innerHTML = html;
+    setInnerHTML(tree.node, html);
   }
 }
 

--- a/src/renderers/dom/client/utils/__tests__/setInnerHTML.js
+++ b/src/renderers/dom/client/utils/__tests__/setInnerHTML.js
@@ -26,13 +26,14 @@ describe('setInnerHTML', function() {
   // SVGElements on IE don't have innerHTML
   describe('when the node does not innerHTML property', () => {
     it('sets innerHTML on it', function() {
-      var node = document.createElement('svg');
-      Object.defineProperty(node, 'innerHTML', { get: function() {} });
+      // Create a mock node that lacks innerHTML
+      var node = { appendChild: jasmine.createSpy() };
 
-      var html = '<circle cx="0" cy="6" r="5"></circle>';
+      var html = '<circle></circle><rect></rect>';
       setInnerHTML(node, html);
 
-      expect(node.outerHTML).toBe('<svg>' + html + '</svg>');
+      expect(node.appendChild.calls.argsFor(0)[0].outerHTML).toBe('<circle></circle>');
+      expect(node.appendChild.calls.argsFor(1)[0].outerHTML).toBe('<rect></rect>');
     });
   });
 });

--- a/src/renderers/dom/client/utils/__tests__/setInnerHTML.js
+++ b/src/renderers/dom/client/utils/__tests__/setInnerHTML.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var setInnerHTML = require('setInnerHTML');
+
+describe('setInnerHTML', function() {
+  describe('when the node has innerHTML property', () => {
+    it('sets innerHTML on it', function() {
+      var node = document.createElement('div');
+      var html = '<h1>hello</h1>';
+      setInnerHTML(node, html);
+      expect(node.innerHTML).toBe(html);
+    });
+  });
+
+  // SVGElements on IE don't have innerHTML
+  describe('when the node does not innerHTML property', () => {
+    it('sets innerHTML on it', function() {
+      var node = document.createElement('svg');
+      delete node.innerHTML;
+      var html = '<circle cx="0" cy="6" r="5"></circle>';
+      setInnerHTML(node, html);
+      expect(node.innerHTML).toBe(html);
+    });
+  });
+});

--- a/src/renderers/dom/client/utils/__tests__/setInnerHTML.js
+++ b/src/renderers/dom/client/utils/__tests__/setInnerHTML.js
@@ -27,10 +27,12 @@ describe('setInnerHTML', function() {
   describe('when the node does not innerHTML property', () => {
     it('sets innerHTML on it', function() {
       var node = document.createElement('svg');
-      delete node.innerHTML;
+      Object.defineProperty(node, 'innerHTML', { get: function() {} });
+
       var html = '<circle cx="0" cy="6" r="5"></circle>';
       setInnerHTML(node, html);
-      expect(node.innerHTML).toBe(html);
+
+      expect(node.outerHTML).toBe('<svg>' + html + '</svg>');
     });
   });
 });

--- a/src/renderers/dom/client/utils/__tests__/setInnerHTML.js
+++ b/src/renderers/dom/client/utils/__tests__/setInnerHTML.js
@@ -12,6 +12,7 @@
 'use strict';
 
 var setInnerHTML = require('setInnerHTML');
+var DOMNamespaces = require('DOMNamespaces');
 
 describe('setInnerHTML', function() {
   describe('when the node has innerHTML property', () => {
@@ -23,11 +24,13 @@ describe('setInnerHTML', function() {
     });
   });
 
-  // SVGElements on IE don't have innerHTML
-  describe('when the node does not innerHTML property', () => {
+  describe('when the node does not have an innerHTML property', () => {
     it('sets innerHTML on it', function() {
-      // Create a mock node that lacks innerHTML
-      var node = { appendChild: jasmine.createSpy() };
+      // Create a mock node that looks like an SVG in IE (without innerHTML)
+      var node = {
+        namespaceURI: DOMNamespaces.svg,
+        appendChild: jasmine.createSpy(),
+      };
 
       var html = '<circle></circle><rect></rect>';
       setInnerHTML(node, html);

--- a/src/renderers/dom/client/utils/setInnerHTML.js
+++ b/src/renderers/dom/client/utils/setInnerHTML.js
@@ -34,15 +34,15 @@ var setInnerHTML = createMicrosoftUnsafeLocalFunction(
     // IE does not have innerHTML for SVG nodes, so instead we inject the
     // new markup in a temp node and then move the child nodes across into
     // the target node
-    if (typeof SVGElement !== 'undefined' && node instanceof SVGElement) {
+    if (node.innerHTML) {
+      node.innerHTML = html;
+    } else {
       reusableSVGContainer = reusableSVGContainer || document.createElement('div');
       reusableSVGContainer.innerHTML = '<svg>' + html + '</svg>';
       var svg = reusableSVGContainer.firstChild;
       while (svg.firstChild) {
         node.appendChild(svg.firstChild);
       }
-    } else {
-      node.innerHTML = html;
     }
   }
 );

--- a/src/renderers/dom/client/utils/setInnerHTML.js
+++ b/src/renderers/dom/client/utils/setInnerHTML.js
@@ -31,7 +31,7 @@ var reusableSVGContainer;
  */
 var setInnerHTML = createMicrosoftUnsafeLocalFunction(
   function(node, html) {
-    if ('innerHTML' in node) {
+    if (typeof node.innerHTML !== 'undefined') {
       node.innerHTML = html;
 
     // IE does not have innerHTML for SVG nodes, so instead we inject the

--- a/src/renderers/dom/client/utils/setInnerHTML.js
+++ b/src/renderers/dom/client/utils/setInnerHTML.js
@@ -31,11 +31,12 @@ var reusableSVGContainer;
  */
 var setInnerHTML = createMicrosoftUnsafeLocalFunction(
   function(node, html) {
+    if ('innerHTML' in node) {
+      node.innerHTML = html;
+
     // IE does not have innerHTML for SVG nodes, so instead we inject the
     // new markup in a temp node and then move the child nodes across into
     // the target node
-    if (node.innerHTML) {
-      node.innerHTML = html;
     } else {
       reusableSVGContainer = reusableSVGContainer || document.createElement('div');
       reusableSVGContainer.innerHTML = '<svg>' + html + '</svg>';

--- a/src/renderers/dom/client/utils/setInnerHTML.js
+++ b/src/renderers/dom/client/utils/setInnerHTML.js
@@ -12,6 +12,7 @@
 'use strict';
 
 var ExecutionEnvironment = require('ExecutionEnvironment');
+var DOMNamespaces = require('DOMNamespaces');
 
 var WHITESPACE_TEST = /^[ \r\n\t\f]/;
 var NONVISIBLE_TEST = /<(!--|link|noscript|meta|script|style)[ \r\n\t\f\/>]/;
@@ -31,19 +32,18 @@ var reusableSVGContainer;
  */
 var setInnerHTML = createMicrosoftUnsafeLocalFunction(
   function(node, html) {
-    if ('innerHTML' in node) {
-      node.innerHTML = html;
-
     // IE does not have innerHTML for SVG nodes, so instead we inject the
     // new markup in a temp node and then move the child nodes across into
     // the target node
-    } else {
+    if (node.namespaceURI === DOMNamespaces.svg && !('innerHTML' in node)) {
       reusableSVGContainer = reusableSVGContainer || document.createElement('div');
       reusableSVGContainer.innerHTML = '<svg>' + html + '</svg>';
       var newNodes = reusableSVGContainer.firstChild.childNodes;
       for (var i = 0; i < newNodes.length; i++) {
         node.appendChild(newNodes[i]);
       }
+    } else {
+      node.innerHTML = html;
     }
   }
 );

--- a/src/renderers/dom/client/utils/setInnerHTML.js
+++ b/src/renderers/dom/client/utils/setInnerHTML.js
@@ -31,7 +31,7 @@ var reusableSVGContainer;
  */
 var setInnerHTML = createMicrosoftUnsafeLocalFunction(
   function(node, html) {
-    if (typeof node.innerHTML !== 'undefined') {
+    if ('innerHTML' in node) {
       node.innerHTML = html;
 
     // IE does not have innerHTML for SVG nodes, so instead we inject the
@@ -40,9 +40,9 @@ var setInnerHTML = createMicrosoftUnsafeLocalFunction(
     } else {
       reusableSVGContainer = reusableSVGContainer || document.createElement('div');
       reusableSVGContainer.innerHTML = '<svg>' + html + '</svg>';
-      var svg = reusableSVGContainer.firstChild;
-      while (svg.firstChild) {
-        node.appendChild(svg.firstChild);
+      var newNodes = reusableSVGContainer.firstChild.childNodes;
+      for (var i = 0; i < newNodes.length; i++) {
+        node.appendChild(newNodes[i]);
       }
     }
   }


### PR DESCRIPTION
Fixes #6950, where `dangerouslySetInnerHTML` doesn't work on any SVG tag. I updated `setInnerHTML` to use the method hashed out by @spicyj, and updated DOMLazyTree's use of `node.innerHTML` to use `setInnerHTML` instead.

I was hesitant about updating DOMLazyTree to use the `setInnerHTML` util, but it seemed to make the most sense. If it's not appropriate I'll just make the workaround local to DOMLazyTree.

If this looks good I'll go ahead and add some tests to make sure it continues to work.

> 1. Fork the repo and create your branch from `master`. ✅ 
> 2. If you've added code that should be tested, add tests! ✅
> 3. If you've changed APIs, update the documentation.  
> 4. Ensure the test suite passes (`grunt test`). ✅ 
> 5. Make sure your code lints (`grunt lint`) - we've done our best to make sure these rules match our internal linting guidelines. ✅ 
> 6. If you haven't already, complete the [CLA](https://code.facebook.com/cla). ✅ 