### PR TITLE
Check for defaultProps in a component's prototype

### DIFF
--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -196,8 +196,8 @@ ReactElement.createElement = function(type, config, children) {
   }
 
   // Resolve default props
-  if (type && type.defaultProps) {
-    var defaultProps = type.defaultProps;
+  if (type && (type.defaultProps || (type.prototype && type.prototype.defaultProps))) {
+    var defaultProps = type.defaultProps || type.prototype.defaultProps;
     for (propName in defaultProps) {
       if (props[propName] === undefined) {
         props[propName] = defaultProps[propName];


### PR DESCRIPTION
This is a workaround for `defaultProp` resolution on IE10 when using ES6 class inheritance. Due to the nature of babel's class transform and IE10 weirdness, static properties like `defaultProps` and `propTypes` aren't inherited by subclasses (see example below). This change allows us to set allows devs to workaround the issue by setting `BaseComponent.prototype.defaultProps = {...}` instead of `BaseComponent.defaultProps = {...}`.

**Related issue:** #6929

cc @jimfb @hzoo 