### PR TITLE
Improve error message for components in bad states (missing instance)

### DIFF
--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -741,6 +741,13 @@ var ReactCompositeComponentMixin = {
     nextUnmaskedContext
   ) {
     var inst = this._instance;
+    invariant(
+      inst != null,
+      'Attempted to update component `%s` that has already been unmounted ' +
+      '(or failed to mount).',
+      this.getName() || 'ReactCompositeComponent'
+    );
+
     var willReceive = false;
     var nextContext;
     var nextProps;


### PR DESCRIPTION
In unknown circumstances (possible due to errors thrown elsewhere), it is possible for React components to enter a bad state where `this._instance` is unset but component state change can continue to happen. This leads to unhelpful error messages like:

````
null is not an object (evaluating 'a.componentWillReceiveProps')
```

This adds invariants that assert `this._instance` exists. If the component is in a bad state, we will now instead warn with a more descriptive error message and — more importantly — the component's name.