### PR TITLE
Fix IE11 placeholder textContent value bug.

### DIFF
--- a/src/renderers/dom/client/wrappers/ReactDOMTextarea.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMTextarea.js
@@ -187,7 +187,9 @@ var ReactDOMTextarea = {
     // This is in postMount because we need access to the DOM node, which is not
     // available until after the component has mounted.
     var node = ReactDOMComponentTree.getNodeFromInstance(inst);
-    node.value = node.value; // Detach value from defaultValue
+
+    // Warning: node.value may be the empty string at this point (IE11) if placeholder is set.
+    node.value = node.textContent; // Detach value from defaultValue
   },
 };
 


### PR DESCRIPTION
Fix IE11 placeholder textContent value bug.

Pop quiz: What does IE11 give you if...
```
var node = document.createElement('textarea');
node.placeholder = 'placeholder';
node.textContent = 'textContent';
assert(typeof node.value === 'string');
alert((typeof node.value)+':'+node.value);
```

Apparently placeholder detaches `value`, or something.

In case you're wondering, no, this bug shows up in 15.0.1, so it was not caused by my recent value change.  It was something else introduced prior to v15.

Fixes https://github.com/facebook/react/issues/6984
