### PR TITLE
Pin babylon at 6.8.0 for ESLint to work

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "babel-plugin-transform-react-jsx-source": "^6.8.0",
     "babel-preset-react": "^6.5.0",
     "babel-traverse": "^6.9.0",
-    "babylon": "^6.8.0",
+    "babylon": "6.8.0",
     "browserify": "^13.0.0",
     "bundle-collapser": "^1.1.1",
     "coffee-script": "^1.8.0",


### PR DESCRIPTION
babel/babylon#25 broke our linter (`Error: Unknown node type TypeParameter.`). Upgrading ESLint to 2.x would be the right way to go, but we can just pin `babylon` at 6.8.0 to do a quick fix.

CC @zpao @hzoo @kittens 