### PR TITLE
Wait for pending transactions from ReactServerRenderingTransaction

### DIFF
--- a/src/renderers/dom/server/ReactServerRendering.js
+++ b/src/renderers/dom/server/ReactServerRendering.js
@@ -25,6 +25,8 @@ var emptyObject = require('emptyObject');
 var instantiateReactComponent = require('instantiateReactComponent');
 var invariant = require('invariant');
 
+var pendingTransactions = 0;
+
 /**
  * @param {ReactElement} element
  * @return {string} the HTML markup
@@ -35,6 +37,8 @@ function renderToStringImpl(element, makeStaticMarkup) {
     ReactUpdates.injection.injectBatchingStrategy(ReactServerBatchingStrategy);
 
     transaction = ReactServerRenderingTransaction.getPooled(makeStaticMarkup);
+
+    pendingTransactions++;
 
     return transaction.perform(function() {
       if (__DEV__) {
@@ -60,10 +64,15 @@ function renderToStringImpl(element, makeStaticMarkup) {
       return markup;
     }, null);
   } finally {
+    pendingTransactions--;
     ReactServerRenderingTransaction.release(transaction);
     // Revert to the DOM batching strategy since these two renderers
     // currently share these stateful modules.
-    ReactUpdates.injection.injectBatchingStrategy(ReactDefaultBatchingStrategy);
+    if (!pendingTransactions) {
+      ReactUpdates.injection.injectBatchingStrategy(
+        ReactDefaultBatchingStrategy
+      );
+    }
   }
 }
 

--- a/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
@@ -399,5 +399,36 @@ describe('ReactServerRendering', function() {
       );
       expect(markup.indexOf('hello, world') >= 0).toBe(true);
     });
+
+    it('renders components with different batching strategies', function() {
+      var StaticComponent = React.createClass({
+        render: function() {
+          const staticContent = ReactServerRendering.renderToStaticMarkup(
+            <div>
+              <img src="foo-bar.jpg" />
+            </div>
+          );
+          return <div dangerouslySetInnerHTML={{__html: staticContent}} />;
+        },
+      });
+
+      var Component = React.createClass({
+        componentWillMount: function() {
+          this.setState({text: 'hello, world'});
+        },
+        render: function() {
+          return <div>{this.state.text}</div>;
+        },
+      });
+      expect(
+        ReactServerRendering.renderToString.bind(
+          ReactServerRendering,
+          <div>
+            <StaticComponent />
+            <Component />
+          </div>
+        )
+      ).not.toThrow();
+    });
   });
 });


### PR DESCRIPTION
Resolves https://github.com/facebook/react/issues/6423

The issue I found with #6423 was that there were pending actions from a `ReactServerRenderingTransaction`, so after it reverted the batching strategy after the first transaction any updates that the pending transaction(s) may have had queued were batched with `ReactDefaultBatchingStrategy` which caused it to fail.

This PR simply tracks the number of pending `ReactServerRenderingTransaction` instances and only reverts the batching strategy once the final transaction has finished.