### PR TITLE
[Fiber] Host Container Fiber and Priority Levels

### DIFF
--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -91,27 +91,16 @@ var ReactNoop = {
       console.log('Nothing rendered yet.');
       return;
     }
-    let fiber : Fiber = (root.stateNode : any).current;
-    let depth = 0;
-    while (fiber) {
+    function logFiber(fiber : Fiber, depth) {
       console.log('  '.repeat(depth) + '- ' + (fiber.type ? fiber.type.name || fiber.type : '[root]'), '[' + fiber.pendingWorkPriority + (fiber.pendingProps ? '*' : '') + ']');
       if (fiber.child) {
-        fiber = fiber.child;
-        depth++;
-        continue;
-      } else {
-        while (!fiber.sibling) {
-          if (!fiber.parent) {
-            return;
-          } else {
-            // $FlowFixMe: This downcast is not safe. It is intentionally an error.
-            fiber = fiber.parent;
-          }
-          depth--;
-        }
-        fiber = fiber.sibling;
+        logFiber(fiber.child, depth + 1);
+      }
+      if (fiber.sibling) {
+        logFiber(fiber.sibling, depth);
       }
     }
+    logFiber((root.stateNode : any).current, 0);
   },
 
 };

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -19,6 +19,8 @@
 
 'use strict';
 
+import type { Fiber } from 'ReactFiber';
+
 var ReactFiberReconciler = require('ReactFiberReconciler');
 
 var scheduledHighPriCallback = null;
@@ -81,6 +83,35 @@ var ReactNoop = {
   flush() {
     ReactNoop.flushHighPri();
     ReactNoop.flushLowPri();
+  },
+
+  // Logs the current state of the tree.
+  dumpTree() {
+    if (!root) {
+      console.log('Nothing rendered yet.');
+      return;
+    }
+    let fiber : Fiber = (root.stateNode : any).current;
+    let depth = 0;
+    while (fiber) {
+      console.log('  '.repeat(depth) + '- ' + (fiber.type ? fiber.type.name || fiber.type : '[root]'), '[' + fiber.pendingWorkPriority + (fiber.pendingProps ? '*' : '') + ']');
+      if (fiber.child) {
+        fiber = fiber.child;
+        depth++;
+        continue;
+      } else {
+        while (!fiber.sibling) {
+          if (!fiber.parent) {
+            return;
+          } else {
+            // $FlowFixMe: This downcast is not safe. It is intentionally an error.
+            fiber = fiber.parent;
+          }
+          depth--;
+        }
+        fiber = fiber.sibling;
+      }
+    }
   },
 
 };

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -38,12 +38,16 @@ var NoopRenderer = ReactFiberReconciler({
 
 });
 
+var root = null;
+
 var ReactNoop = {
 
   render(element : ReactElement<any>) {
-
-    NoopRenderer.mountNewRoot(element);
-
+    if (!root) {
+      root = NoopRenderer.mountContainer(element, null);
+    } else {
+      NoopRenderer.updateContainer(element, root);
+    }
   },
 
   flushHighPri() {

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -14,6 +14,7 @@
 
 import type { ReactCoroutine, ReactYield } from 'ReactCoroutine';
 import type { Fiber } from 'ReactFiber';
+import type { PriorityLevel } from 'ReactPriorityLevel';
 
 import type { ReactNodeList } from 'ReactTypes';
 
@@ -28,7 +29,7 @@ var {
 var ReactFiber = require('ReactFiber');
 var ReactReifiedYield = require('ReactReifiedYield');
 
-function createSubsequentChild(parent : Fiber, existingChild : ?Fiber, previousSibling : Fiber, newChildren) : Fiber {
+function createSubsequentChild(parent : Fiber, existingChild : ?Fiber, previousSibling : Fiber, newChildren, priority : PriorityLevel) : Fiber {
   if (typeof newChildren !== 'object' || newChildren === null) {
     return previousSibling;
   }
@@ -41,14 +42,14 @@ function createSubsequentChild(parent : Fiber, existingChild : ?Fiber, previousS
           element.key === existingChild.key) {
         // TODO: This is not sufficient since previous siblings could be new.
         // Will fix reconciliation properly later.
-        const clone = ReactFiber.cloneFiber(existingChild);
+        const clone = ReactFiber.cloneFiber(existingChild, priority);
         clone.pendingProps = element.props;
         clone.child = existingChild.child;
         clone.sibling = null;
         previousSibling.sibling = clone;
         return clone;
       }
-      const child = ReactFiber.createFiberFromElement(element);
+      const child = ReactFiber.createFiberFromElement(element, priority);
       previousSibling.sibling = child;
       child.parent = parent;
       return child;
@@ -56,7 +57,7 @@ function createSubsequentChild(parent : Fiber, existingChild : ?Fiber, previousS
 
     case REACT_COROUTINE_TYPE: {
       const coroutine = (newChildren : ReactCoroutine);
-      const child = ReactFiber.createFiberFromCoroutine(coroutine);
+      const child = ReactFiber.createFiberFromCoroutine(coroutine, priority);
       previousSibling.sibling = child;
       child.parent = parent;
       return child;
@@ -65,7 +66,7 @@ function createSubsequentChild(parent : Fiber, existingChild : ?Fiber, previousS
     case REACT_YIELD_TYPE: {
       const yieldNode = (newChildren : ReactYield);
       const reifiedYield = ReactReifiedYield.createReifiedYield(yieldNode);
-      const child = ReactFiber.createFiberFromYield(yieldNode);
+      const child = ReactFiber.createFiberFromYield(yieldNode, priority);
       child.output = reifiedYield;
       previousSibling.sibling = child;
       child.parent = parent;
@@ -77,7 +78,7 @@ function createSubsequentChild(parent : Fiber, existingChild : ?Fiber, previousS
     let prev : Fiber = previousSibling;
     let existing : ?Fiber = existingChild;
     for (var i = 0; i < newChildren.length; i++) {
-      prev = createSubsequentChild(parent, existing, prev, newChildren[i]);
+      prev = createSubsequentChild(parent, existing, prev, newChildren[i], priority);
       if (prev && existing) {
         // TODO: This is not correct because there could've been more
         // than one sibling consumed but I don't want to return a tuple.
@@ -91,7 +92,7 @@ function createSubsequentChild(parent : Fiber, existingChild : ?Fiber, previousS
   }
 }
 
-function createFirstChild(parent, existingChild, newChildren) {
+function createFirstChild(parent, existingChild, newChildren, priority) {
   if (typeof newChildren !== 'object' || newChildren === null) {
     return null;
   }
@@ -103,20 +104,20 @@ function createFirstChild(parent, existingChild, newChildren) {
           element.type === existingChild.type &&
           element.key === existingChild.key) {
         // Get the clone of the existing fiber.
-        const clone = ReactFiber.cloneFiber(existingChild);
+        const clone = ReactFiber.cloneFiber(existingChild, priority);
         clone.pendingProps = element.props;
         clone.child = existingChild.child;
         clone.sibling = null;
         return clone;
       }
-      const child = ReactFiber.createFiberFromElement(element);
+      const child = ReactFiber.createFiberFromElement(element, priority);
       child.parent = parent;
       return child;
     }
 
     case REACT_COROUTINE_TYPE: {
       const coroutine = (newChildren : ReactCoroutine);
-      const child = ReactFiber.createFiberFromCoroutine(coroutine);
+      const child = ReactFiber.createFiberFromCoroutine(coroutine, priority);
       child.parent = parent;
       return child;
     }
@@ -127,7 +128,7 @@ function createFirstChild(parent, existingChild, newChildren) {
       // the fragment.
       const yieldNode = (newChildren : ReactYield);
       const reifiedYield = ReactReifiedYield.createReifiedYield(yieldNode);
-      const child = ReactFiber.createFiberFromYield(yieldNode);
+      const child = ReactFiber.createFiberFromYield(yieldNode, priority);
       child.output = reifiedYield;
       child.parent = parent;
       return child;
@@ -140,10 +141,10 @@ function createFirstChild(parent, existingChild, newChildren) {
     var existing : ?Fiber = existingChild;
     for (var i = 0; i < newChildren.length; i++) {
       if (prev == null) {
-        prev = createFirstChild(parent, existing, newChildren[i]);
+        prev = createFirstChild(parent, existing, newChildren[i], priority);
         first = prev;
       } else {
-        prev = createSubsequentChild(parent, existing, prev, newChildren[i]);
+        prev = createSubsequentChild(parent, existing, prev, newChildren[i], priority);
       }
       if (prev && existing) {
         // TODO: This is not correct because there could've been more
@@ -160,6 +161,6 @@ function createFirstChild(parent, existingChild, newChildren) {
 
 // TODO: This API won't work because we'll need to transfer the side-effects of
 // unmounting children to the parent.
-exports.reconcileChildFibers = function(parent : Fiber, currentFirstChild : ?Fiber, newChildren : ReactNodeList) : ?Fiber {
-  return createFirstChild(parent, currentFirstChild, newChildren);
+exports.reconcileChildFibers = function(parent : Fiber, currentFirstChild : ?Fiber, newChildren : ReactNodeList, priority : PriorityLevel) : ?Fiber {
+  return createFirstChild(parent, currentFirstChild, newChildren, priority);
 };

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -46,6 +46,7 @@ function createSubsequentChild(parent : Fiber, existingChild : ?Fiber, previousS
         clone.pendingProps = element.props;
         clone.child = existingChild.child;
         clone.sibling = null;
+        clone.parent = parent;
         previousSibling.sibling = clone;
         return clone;
       }
@@ -108,6 +109,7 @@ function createFirstChild(parent, existingChild, newChildren, priority) {
         clone.pendingProps = element.props;
         clone.child = existingChild.child;
         clone.sibling = null;
+        clone.parent = parent;
         return clone;
       }
       const child = ReactFiber.createFiberFromElement(element, priority);

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -158,6 +158,8 @@ function createFirstChild(parent, existingChild, newChildren) {
   }
 }
 
+// TODO: This API won't work because we'll need to transfer the side-effects of
+// unmounting children to the parent.
 exports.reconcileChildFibers = function(parent : Fiber, currentFirstChild : ?Fiber, newChildren : ReactNodeList) : ?Fiber {
   return createFirstChild(parent, currentFirstChild, newChildren);
 };

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -42,7 +42,7 @@ function createSubsequentChild(parent : Fiber, existingChild : ?Fiber, previousS
         // TODO: This is not sufficient since previous siblings could be new.
         // Will fix reconciliation properly later.
         const clone = ReactFiber.cloneFiber(existingChild);
-        clone.input = element.props;
+        clone.pendingProps = element.props;
         clone.child = existingChild.child;
         clone.sibling = null;
         previousSibling.sibling = clone;
@@ -104,7 +104,7 @@ function createFirstChild(parent, existingChild, newChildren) {
           element.key === existingChild.key) {
         // Get the clone of the existing fiber.
         const clone = ReactFiber.cloneFiber(existingChild);
-        clone.input = element.props;
+        clone.pendingProps = element.props;
         clone.child = existingChild.child;
         clone.sibling = null;
         return clone;

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -193,5 +193,6 @@ exports.createFiberFromCoroutine = function(coroutine : ReactCoroutine, priority
 
 exports.createFiberFromYield = function(yieldNode : ReactYield, priorityLevel : PriorityLevel) {
   const fiber = createFiber(YieldComponent, yieldNode.key);
+  fiber.pendingProps = {};
   return fiber;
 };

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -19,6 +19,7 @@ var ReactTypeOfWork = require('ReactTypeOfWork');
 var {
   IndeterminateComponent,
   ClassComponent,
+  HostContainer,
   HostComponent,
   CoroutineComponent,
   YieldComponent,
@@ -145,6 +146,12 @@ exports.cloneFiber = function(fiber : Fiber) : Fiber {
   alt.alternate = fiber;
   fiber.alternate = alt;
   return alt;
+};
+
+exports.createHostContainerFiber = function(containerInfo : ?Object) {
+  const fiber = createFiber(HostContainer, null);
+  fiber.stateNode = containerInfo;
+  return fiber;
 };
 
 exports.createFiberFromElement = function(element : ReactElement) {

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -66,9 +66,9 @@ export type Fiber = Instance & {
   ref: null | (handle : ?Object) => void,
 
   // Input is the data coming into process this fiber. Arguments. Props.
-  input: any, // This type will be more specific once we overload the tag.
-  // TODO: I think that there is a way to merge input and memoizedInput somehow.
-  memoizedInput: any, // The input used to create the output.
+  pendingProps: any, // This type will be more specific once we overload the tag.
+  // TODO: I think that there is a way to merge input and memoizedProps somehow.
+  memoizedProps: any, // The input used to create the output.
   // Output is the return value of this fiber, or a linked list of return values
   // if this returns multiple values. Such as a fragment.
   output: any, // This type will be more specific once we overload the tag.
@@ -105,8 +105,8 @@ var createFiber = function(tag : TypeOfWork, key : null | string) : Fiber {
 
     ref: null,
 
-    input: null,
-    memoizedInput: null,
+    pendingProps: null,
+    memoizedProps: null,
     output: null,
 
     pendingWorkPriority: 0,
@@ -149,7 +149,7 @@ exports.cloneFiber = function(fiber : Fiber) : Fiber {
 
 exports.createFiberFromElement = function(element : ReactElement) {
   const fiber = exports.createFiberFromElementType(element.type, element.key);
-  fiber.input = element.props;
+  fiber.pendingProps = element.props;
   return fiber;
 };
 
@@ -175,7 +175,7 @@ exports.createFiberFromElementType = function(type : mixed, key : null | string)
 exports.createFiberFromCoroutine = function(coroutine : ReactCoroutine) {
   const fiber = createFiber(CoroutineComponent, coroutine.key);
   fiber.type = coroutine.handler;
-  fiber.input = coroutine;
+  fiber.pendingProps = coroutine;
   return fiber;
 };
 

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -12,6 +12,7 @@
 
 'use strict';
 
+import type { ReactCoroutine, ReactYield } from 'ReactCoroutine';
 import type { TypeOfWork } from 'ReactTypeOfWork';
 import type { PriorityLevel } from 'ReactPriorityLevel';
 
@@ -27,7 +28,9 @@ var {
 
 var ReactElement = require('ReactElement');
 
-import type { ReactCoroutine, ReactYield } from 'ReactCoroutine';
+var {
+  NoWork,
+} = require('ReactPriorityLevel');
 
 // An Instance is shared between all versions of a component. We can easily
 // break this out into a separate object to avoid copying so much to the
@@ -121,7 +124,7 @@ var createFiber = function(tag : TypeOfWork, key : null | string) : Fiber {
     memoizedProps: null,
     output: null,
 
-    pendingWorkPriority: 0,
+    pendingWorkPriority: NoWork,
 
     alternate: null,
 

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -12,14 +12,17 @@
 
 'use strict';
 
-var ReactTypesOfWork = require('ReactTypesOfWork');
+import type { TypeOfWork } from 'ReactTypeOfWork';
+import type { PriorityLevel } from 'ReactPriorityLevel';
+
+var ReactTypeOfWork = require('ReactTypeOfWork');
 var {
   IndeterminateComponent,
   ClassComponent,
   HostComponent,
   CoroutineComponent,
   YieldComponent,
-} = ReactTypesOfWork;
+} = ReactTypeOfWork;
 
 var ReactElement = require('ReactElement');
 
@@ -32,7 +35,7 @@ import type { ReactCoroutine, ReactYield } from 'ReactCoroutine';
 type Instance = {
 
   // Tag identifying the type of fiber.
-  tag: number,
+  tag: TypeOfWork,
 
   // The parent Fiber used to create this one. The type is constrained to the
   // Instance part of the Fiber since it is not safe to traverse the tree from
@@ -71,7 +74,7 @@ export type Fiber = Instance & {
   output: any, // This type will be more specific once we overload the tag.
 
   // This will be used to quickly determine if a subtree has no pending changes.
-  hasPendingChanges: bool,
+  pendingWorkPriority: PriorityLevel,
 
   // This is a pooled version of a Fiber. Every fiber that gets updated will
   // eventually have a pair. There are cases when we can clean up pairs to save
@@ -80,7 +83,7 @@ export type Fiber = Instance & {
 
 };
 
-var createFiber = function(tag : number, key : null | string) : Fiber {
+var createFiber = function(tag : TypeOfWork, key : null | string) : Fiber {
   return {
 
     // Instance
@@ -106,7 +109,7 @@ var createFiber = function(tag : number, key : null | string) : Fiber {
     memoizedInput: null,
     output: null,
 
-    hasPendingChanges: true,
+    pendingWorkPriority: 0,
 
     alternate: null,
 

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -140,6 +140,11 @@ exports.cloneFiber = function(fiber : Fiber, priorityLevel : PriorityLevel) : Fi
     // Stop using the alternates of parents once we have a parent stack.
     // $FlowFixMe: This downcast is not safe. It is intentionally an error.
     alt.parent = fiber.parent.alternate;
+    if (!alt.parent) {
+      // TODO: There needs to be a "work in progress" tree all the way up to
+      // the final root.
+      throw new Error('The parent must have an alternate already.');
+    }
   }
 
   alt.type = fiber.type;
@@ -150,10 +155,8 @@ exports.cloneFiber = function(fiber : Fiber, priorityLevel : PriorityLevel) : Fi
   return alt;
 };
 
-exports.createHostContainerFiber = function(containerInfo : ?Object, priorityLevel : PriorityLevel) {
+exports.createHostContainerFiber = function() {
   const fiber = createFiber(HostContainer, null);
-  fiber.stateNode = containerInfo;
-  fiber.pendingWorkPriority = priorityLevel;
   return fiber;
 };
 

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -41,11 +41,6 @@ type Instance = {
   // Tag identifying the type of fiber.
   tag: TypeOfWork,
 
-  // The parent Fiber used to create this one. The type is constrained to the
-  // Instance part of the Fiber since it is not safe to traverse the tree from
-  // the instance.
-  parent: ?Instance, // Consider a regenerated temporary parent stack instead.
-
   // Unique identifier of this child.
   key: null | string,
 
@@ -55,11 +50,21 @@ type Instance = {
   // The local state associated with this fiber.
   stateNode: ?Object,
 
+  // Conceptual aliases
+  // parent : Instance -> return The parent happens to be the same as the
+  // return fiber since we've merged the fiber and instance.
+
 };
 
 // A Fiber is work on a Component that needs to be done or was done. There can
 // be more than one per component.
 export type Fiber = Instance & {
+
+  // The Fiber to return to after finishing processing this one.
+  // This is effectively the parent, but there can be multiple parents (two)
+  // so this is only the parent of the thing we're currently processing.
+  // It is conceptually the same as the return address of a stack frame.
+  return: ?Fiber,
 
   // Singly Linked List Tree Structure.
   child: ?Fiber,
@@ -71,8 +76,8 @@ export type Fiber = Instance & {
 
   // Input is the data coming into process this fiber. Arguments. Props.
   pendingProps: any, // This type will be more specific once we overload the tag.
-  // TODO: I think that there is a way to merge input and memoizedProps somehow.
-  memoizedProps: any, // The input used to create the output.
+  // TODO: I think that there is a way to merge pendingProps and memoizedProps.
+  memoizedProps: any, // The props used to create the output.
   // Output is the return value of this fiber, or a linked list of return values
   // if this returns multiple values. Such as a fragment.
   output: any, // This type will be more specific once we overload the tag.
@@ -93,8 +98,8 @@ export type Fiber = Instance & {
   hasWorkInProgress: bool,
 
   // Conceptual aliases
-  // parent : Instance -> returnFiber The parent happens to be the same as the return fiber.
-  // workInProgress : Fiber ->  alternate The alternate used for reuse happens to be the same as work in progress.
+  // workInProgress : Fiber ->  alternate The alternate used for reuse happens
+  // to be the same as work in progress.
 
 };
 
@@ -105,8 +110,6 @@ var createFiber = function(tag : TypeOfWork, key : null | string) : Fiber {
 
     tag: tag,
 
-    parent: null,
-
     key: key,
 
     type: null,
@@ -114,6 +117,8 @@ var createFiber = function(tag : TypeOfWork, key : null | string) : Fiber {
     stateNode: null,
 
     // Fiber
+
+    return: null,
 
     child: null,
     sibling: null,
@@ -126,9 +131,9 @@ var createFiber = function(tag : TypeOfWork, key : null | string) : Fiber {
 
     pendingWorkPriority: NoWork,
 
-    alternate: null,
-
     hasWorkInProgress: false,
+
+    alternate: null,
 
   };
 };

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -82,6 +82,13 @@ export type Fiber = Instance & {
   // memory if we need to.
   alternate: ?Fiber,
 
+  // Keeps track if we've completed this node or if we're currently in the
+  // middle of processing it. We really should know this based on pendingProps
+  // or something else. We could also reuse the tag for this purpose. However,
+  // I'm not really sure so I'll use a flag for now.
+  // TODO: Find another way to infer this flag.
+  hasWorkInProgress: bool,
+
   // Conceptual aliases
   // parent : Instance -> returnFiber The parent happens to be the same as the return fiber.
   // workInProgress : Fiber ->  alternate The alternate used for reuse happens to be the same as work in progress.
@@ -117,6 +124,8 @@ var createFiber = function(tag : TypeOfWork, key : null | string) : Fiber {
     pendingWorkPriority: 0,
 
     alternate: null,
+
+    hasWorkInProgress: false,
 
   };
 };

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -122,13 +122,14 @@ function shouldConstruct(Component) {
 }
 
 // This is used to create an alternate fiber to do work on.
-exports.cloneFiber = function(fiber : Fiber) : Fiber {
+exports.cloneFiber = function(fiber : Fiber, priorityLevel : PriorityLevel) : Fiber {
   // We use a double buffering pooling technique because we know that we'll only
   // ever need at most two versions of a tree. We pool the "other" unused node
   // that we're free to reuse. This is lazily created to avoid allocating extra
   // objects for things that are never updated. It also allow us to reclaim the
   // extra memory if needed.
   if (fiber.alternate) {
+    fiber.alternate.pendingWorkPriority = priorityLevel;
     return fiber.alternate;
   }
   // This should not have an alternate already
@@ -144,19 +145,22 @@ exports.cloneFiber = function(fiber : Fiber) : Fiber {
   alt.type = fiber.type;
   alt.stateNode = fiber.stateNode;
   alt.alternate = fiber;
+  alt.pendingWorkPriority = priorityLevel;
   fiber.alternate = alt;
   return alt;
 };
 
-exports.createHostContainerFiber = function(containerInfo : ?Object) {
+exports.createHostContainerFiber = function(containerInfo : ?Object, priorityLevel : PriorityLevel) {
   const fiber = createFiber(HostContainer, null);
   fiber.stateNode = containerInfo;
+  fiber.pendingWorkPriority = priorityLevel;
   return fiber;
 };
 
-exports.createFiberFromElement = function(element : ReactElement) {
+exports.createFiberFromElement = function(element : ReactElement, priorityLevel : PriorityLevel) {
   const fiber = exports.createFiberFromElementType(element.type, element.key);
   fiber.pendingProps = element.props;
+  fiber.pendingWorkPriority = priorityLevel;
   return fiber;
 };
 
@@ -179,14 +183,15 @@ exports.createFiberFromElementType = function(type : mixed, key : null | string)
   return fiber;
 };
 
-exports.createFiberFromCoroutine = function(coroutine : ReactCoroutine) {
+exports.createFiberFromCoroutine = function(coroutine : ReactCoroutine, priorityLevel : PriorityLevel) {
   const fiber = createFiber(CoroutineComponent, coroutine.key);
   fiber.type = coroutine.handler;
   fiber.pendingProps = coroutine;
+  fiber.pendingWorkPriority = priorityLevel;
   return fiber;
 };
 
-exports.createFiberFromYield = function(yieldNode : ReactYield) {
+exports.createFiberFromYield = function(yieldNode : ReactYield, priorityLevel : PriorityLevel) {
   const fiber = createFiber(YieldComponent, yieldNode.key);
   return fiber;
 };

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -16,7 +16,7 @@ import type { ReactCoroutine } from 'ReactCoroutine';
 import type { Fiber } from 'ReactFiber';
 
 var ReactChildFiber = require('ReactChildFiber');
-var ReactTypesOfWork = require('ReactTypesOfWork');
+var ReactTypeOfWork = require('ReactTypeOfWork');
 var {
   IndeterminateComponent,
   FunctionalComponent,
@@ -25,7 +25,7 @@ var {
   CoroutineComponent,
   CoroutineHandlerPhase,
   YieldComponent,
-} = ReactTypesOfWork;
+} = ReactTypeOfWork;
 
 function reconcileChildren(current, workInProgress, nextChildren) {
   workInProgress.child = ReactChildFiber.reconcileChildFibers(

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -21,6 +21,7 @@ var {
   IndeterminateComponent,
   FunctionalComponent,
   ClassComponent,
+  HostContainer,
   HostComponent,
   CoroutineComponent,
   CoroutineHandlerPhase,
@@ -104,6 +105,17 @@ function beginWork(current : ?Fiber, workInProgress : Fiber) : ?Fiber {
     case ClassComponent:
       console.log('class component', workInProgress.pendingProps.type.name);
       return workInProgress.child;
+    case HostContainer:
+      reconcileChildren(current, workInProgress, workInProgress.pendingProps);
+      // A yield component is just a placeholder, we can just run through the
+      // next one immediately.
+      if (workInProgress.child) {
+        return beginWork(
+          workInProgress.child.alternate,
+          workInProgress.child
+        );
+      }
+      return null;
     case HostComponent:
       updateHostComponent(current, workInProgress);
       return workInProgress.child;

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -37,22 +37,22 @@ function reconcileChildren(current, workInProgress, nextChildren) {
 
 function updateFunctionalComponent(current, workInProgress) {
   var fn = workInProgress.type;
-  var props = workInProgress.input;
+  var props = workInProgress.pendingProps;
   console.log('update fn:', fn.name);
   var nextChildren = fn(props);
   reconcileChildren(current, workInProgress, nextChildren);
 }
 
 function updateHostComponent(current, workInProgress) {
-  console.log('host component', workInProgress.type, typeof workInProgress.input.children === 'string' ? workInProgress.input.children : '');
+  console.log('host component', workInProgress.type, typeof workInProgress.pendingProps.children === 'string' ? workInProgress.pendingProps.children : '');
 
-  var nextChildren = workInProgress.input.children;
+  var nextChildren = workInProgress.pendingProps.children;
   reconcileChildren(current, workInProgress, nextChildren);
 }
 
 function mountIndeterminateComponent(current, workInProgress) {
   var fn = workInProgress.type;
-  var props = workInProgress.input;
+  var props = workInProgress.pendingProps;
   var value = fn(props);
   if (typeof value === 'object' && value && typeof value.render === 'function') {
     console.log('performed work on class:', fn.name);
@@ -67,7 +67,7 @@ function mountIndeterminateComponent(current, workInProgress) {
 }
 
 function updateCoroutineComponent(current, workInProgress) {
-  var coroutine = (workInProgress.input : ?ReactCoroutine);
+  var coroutine = (workInProgress.pendingProps : ?ReactCoroutine);
   if (!coroutine) {
     throw new Error('Should be resolved by now');
   }
@@ -80,18 +80,18 @@ function beginWork(current : ?Fiber, workInProgress : Fiber) : ?Fiber {
   // Ideally nothing should rely on this, but relying on it here
   // means that we don't need an additional field on the work in
   // progress.
-  if (current && workInProgress.input === current.memoizedInput) {
+  if (current && workInProgress.pendingProps === current.memoizedProps) {
     // The most likely scenario is that the previous copy of the tree contains
-    // the same input as the new one. In that case, we can just copy the output
+    // the same props as the new one. In that case, we can just copy the output
     // and children from that node.
     workInProgress.output = current.output;
     workInProgress.child = current.child;
     workInProgress.stateNode = current.stateNode;
     return null;
   }
-  if (workInProgress.input === workInProgress.memoizedInput) {
+  if (workInProgress.pendingProps === workInProgress.memoizedProps) {
     // In a ping-pong scenario, this version could actually contain the
-    // old input. In that case, we can just bail out.
+    // old props. In that case, we can just bail out.
     return null;
   }
   switch (workInProgress.tag) {
@@ -102,7 +102,7 @@ function beginWork(current : ?Fiber, workInProgress : Fiber) : ?Fiber {
       updateFunctionalComponent(current, workInProgress);
       return workInProgress.child;
     case ClassComponent:
-      console.log('class component', workInProgress.input.type.name);
+      console.log('class component', workInProgress.pendingProps.type.name);
       return workInProgress.child;
     case HostComponent:
       updateHostComponent(current, workInProgress);

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -29,10 +29,12 @@ var {
 } = ReactTypeOfWork;
 
 function reconcileChildren(current, workInProgress, nextChildren) {
+  const priority = workInProgress.pendingWorkPriority;
   workInProgress.child = ReactChildFiber.reconcileChildFibers(
     workInProgress,
     current ? current.child : null,
-    nextChildren
+    nextChildren,
+    priority
   );
 }
 

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -125,6 +125,9 @@ function beginWork(current : ?Fiber, workInProgress : Fiber) : ?Fiber {
     // and children from that node.
     workInProgress.output = current.output;
     workInProgress.child = current.child;
+    if (workInProgress.child) {
+      workInProgress.child.parent = workInProgress;
+    }
     workInProgress.stateNode = current.stateNode;
     workInProgress.pendingWorkPriority = NoWork;
     return null;

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -115,22 +115,22 @@ function updateCoroutineComponent(current, workInProgress) {
   workInProgress.pendingWorkPriority = NoWork;
 }
 
-function reuseChildren(newParent : Fiber, firstChild : Fiber) {
+function reuseChildren(returnFiber : Fiber, firstChild : Fiber) {
   // TODO: None of this should be necessary if structured better.
-  // The parent pointer only needs to be updated when we walk into this child
+  // The returnFiber pointer only needs to be updated when we walk into this child
   // which we don't do right now. If the pending work priority indicated only
   // if a child has work rather than if the node has work, then we would know
   // by a single lookup on workInProgress rather than having to go through
   // each child.
   let child = firstChild;
   do {
-    // Update the parent of the child to the newest fiber.
-    child.parent = newParent;
+    // Update the returnFiber of the child to the newest fiber.
+    child.return = returnFiber;
     // Retain the priority if there's any work left to do in the children.
     if (child.pendingWorkPriority !== NoWork &&
-        (newParent.pendingWorkPriority === NoWork ||
-        newParent.pendingWorkPriority > child.pendingWorkPriority)) {
-      newParent.pendingWorkPriority = child.pendingWorkPriority;
+        (returnFiber.pendingWorkPriority === NoWork ||
+        returnFiber.pendingWorkPriority > child.pendingWorkPriority)) {
+      returnFiber.pendingWorkPriority = child.pendingWorkPriority;
     }
   } while (child = child.sibling);
 }

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -107,6 +107,7 @@ exports.completeWork = function(current : ?Fiber, workInProgress : Fiber) : ?Fib
     case HostContainer:
       return null;
     case HostComponent:
+      transferOutput(workInProgress.child, workInProgress);
       console.log('/host component', workInProgress.type);
       return null;
     case CoroutineComponent:

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -30,12 +30,12 @@ var {
   YieldComponent,
 } = ReactTypeOfWork;
 
-function transferOutput(child : ?Fiber, parent : Fiber) {
+function transferOutput(child : ?Fiber, returnFiber : Fiber) {
   // If we have a single result, we just pass that through as the output to
   // avoid unnecessary traversal. When we have multiple output, we just pass
   // the linked list of fibers that has the individual output values.
-  parent.output = (child && !child.sibling) ? child.output : child;
-  parent.memoizedProps = parent.pendingProps;
+  returnFiber.output = (child && !child.sibling) ? child.output : child;
+  returnFiber.memoizedProps = returnFiber.pendingProps;
 }
 
 function recursivelyFillYields(yields, output : ?Fiber | ?ReifiedYield) {
@@ -83,7 +83,7 @@ function moveCoroutineToHandlerPhase(current : ?Fiber, workInProgress : Fiber) {
   var nextChildren = fn(props, yields);
 
   var currentFirstChild = current ? current.stateNode : null;
-  // Inherit the priority of the parent.
+  // Inherit the priority of the returnFiber.
   const priority = workInProgress.pendingWorkPriority;
   workInProgress.stateNode = ReactChildFiber.reconcileChildFibers(
     workInProgress,

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -95,14 +95,14 @@ exports.completeWork = function(current : ?Fiber, workInProgress : Fiber) : ?Fib
     case FunctionalComponent:
       console.log('/functional component', workInProgress.type.name);
       transferOutput(workInProgress.child, workInProgress);
-      break;
+      return null;
     case ClassComponent:
       console.log('/class component', workInProgress.type.name);
       transferOutput(workInProgress.child, workInProgress);
-      break;
+      return null;
     case HostComponent:
       console.log('/host component', workInProgress.type);
-      break;
+      return null;
     case CoroutineComponent:
       console.log('/coroutine component', workInProgress.input.handler.name);
       return moveCoroutineToHandlerPhase(current, workInProgress);
@@ -110,10 +110,10 @@ exports.completeWork = function(current : ?Fiber, workInProgress : Fiber) : ?Fib
       transferOutput(workInProgress.stateNode, workInProgress);
       // Reset the tag to now be a first phase coroutine.
       workInProgress.tag = CoroutineComponent;
-      break;
+      return null;
     case YieldComponent:
       // Does nothing.
-      break;
+      return null;
 
     // Error cases
     case IndeterminateComponent:
@@ -121,5 +121,4 @@ exports.completeWork = function(current : ?Fiber, workInProgress : Fiber) : ?Fib
     default:
       throw new Error('Unknown unit of work tag');
   }
-  return null;
 };

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -34,7 +34,7 @@ function transferOutput(child : ?Fiber, parent : Fiber) {
   // avoid unnecessary traversal. When we have multiple output, we just pass
   // the linked list of fibers that has the individual output values.
   parent.output = (child && !child.sibling) ? child.output : child;
-  parent.memoizedInput = parent.input;
+  parent.memoizedProps = parent.pendingProps;
 }
 
 function recursivelyFillYields(yields, output : ?Fiber | ?ReifiedYield) {
@@ -55,7 +55,7 @@ function recursivelyFillYields(yields, output : ?Fiber | ?ReifiedYield) {
 }
 
 function moveCoroutineToHandlerPhase(current : ?Fiber, workInProgress : Fiber) {
-  var coroutine = (workInProgress.input : ?ReactCoroutine);
+  var coroutine = (workInProgress.pendingProps : ?ReactCoroutine);
   if (!coroutine) {
     throw new Error('Should be resolved by now');
   }
@@ -104,7 +104,7 @@ exports.completeWork = function(current : ?Fiber, workInProgress : Fiber) : ?Fib
       console.log('/host component', workInProgress.type);
       return null;
     case CoroutineComponent:
-      console.log('/coroutine component', workInProgress.input.handler.name);
+      console.log('/coroutine component', workInProgress.pendingProps.handler.name);
       return moveCoroutineToHandlerPhase(current, workInProgress);
     case CoroutineHandlerPhase:
       transferOutput(workInProgress.stateNode, workInProgress);

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -18,7 +18,7 @@ import type { Fiber } from 'ReactFiber';
 import type { ReifiedYield } from 'ReactReifiedYield';
 
 var ReactChildFiber = require('ReactChildFiber');
-var ReactTypesOfWork = require('ReactTypesOfWork');
+var ReactTypeOfWork = require('ReactTypeOfWork');
 var {
   IndeterminateComponent,
   FunctionalComponent,
@@ -27,7 +27,7 @@ var {
   CoroutineComponent,
   CoroutineHandlerPhase,
   YieldComponent,
-} = ReactTypesOfWork;
+} = ReactTypeOfWork;
 
 function transferOutput(child : ?Fiber, parent : Fiber) {
   // If we have a single result, we just pass that through as the output to

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -23,6 +23,7 @@ var {
   IndeterminateComponent,
   FunctionalComponent,
   ClassComponent,
+  HostContainer,
   HostComponent,
   CoroutineComponent,
   CoroutineHandlerPhase,
@@ -99,6 +100,8 @@ exports.completeWork = function(current : ?Fiber, workInProgress : Fiber) : ?Fib
     case ClassComponent:
       console.log('/class component', workInProgress.type.name);
       transferOutput(workInProgress.child, workInProgress);
+      return null;
+    case HostContainer:
       return null;
     case HostComponent:
       console.log('/host component', workInProgress.type);

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -83,10 +83,13 @@ function moveCoroutineToHandlerPhase(current : ?Fiber, workInProgress : Fiber) {
   var nextChildren = fn(props, yields);
 
   var currentFirstChild = current ? current.stateNode : null;
+  // Inherit the priority of the parent.
+  const priority = workInProgress.pendingWorkPriority;
   workInProgress.stateNode = ReactChildFiber.reconcileChildFibers(
     workInProgress,
     currentFirstChild,
-    nextChildren
+    nextChildren,
+    priority
   );
   return workInProgress.stateNode;
 }

--- a/src/renderers/shared/fiber/ReactFiberPendingWork.js
+++ b/src/renderers/shared/fiber/ReactFiberPendingWork.js
@@ -73,9 +73,6 @@ exports.findNextUnitOfWorkAtPriority = function(currentRoot : Fiber, priorityLev
       current.pendingWorkPriority = NoWork;
     }
     if (current === currentRoot) {
-      if (current.pendingWorkPriority <= priorityLevel) {
-        current.pendingWorkPriority = NoWork;
-      }
       return null;
     }
     while (!current.sibling) {

--- a/src/renderers/shared/fiber/ReactFiberPendingWork.js
+++ b/src/renderers/shared/fiber/ReactFiberPendingWork.js
@@ -21,14 +21,14 @@ var {
   NoWork,
 } = require('ReactPriorityLevel');
 
-function cloneSiblings(current : Fiber, workInProgress : Fiber, parent : Fiber) {
+function cloneSiblings(current : Fiber, workInProgress : Fiber, returnFiber : Fiber) {
   while (current.sibling) {
     current = current.sibling;
     workInProgress = workInProgress.sibling = ReactFiber.cloneFiber(
       current,
       current.pendingWorkPriority
     );
-    workInProgress.parent = parent;
+    workInProgress.return = returnFiber;
   }
   workInProgress.sibling = null;
 }
@@ -63,7 +63,7 @@ exports.findNextUnitOfWorkAtPriority = function(currentRoot : Fiber, priorityLev
         }
         workInProgress.pendingWorkPriority = current.pendingWorkPriority;
         workInProgress.child = ReactFiber.cloneFiber(currentChild, NoWork);
-        workInProgress.child.parent = workInProgress;
+        workInProgress.child.return = workInProgress;
         cloneSiblings(currentChild, workInProgress.child, workInProgress);
         current = current.child;
         continue;
@@ -79,9 +79,7 @@ exports.findNextUnitOfWorkAtPriority = function(currentRoot : Fiber, priorityLev
       return null;
     }
     while (!current.sibling) {
-      // TODO: Stop using parent here. See below.
-      // $FlowFixMe: This downcast is not safe. It is intentionally an error.
-      current = current.parent;
+      current = current.return;
       if (!current) {
         return null;
       }
@@ -95,4 +93,4 @@ exports.findNextUnitOfWorkAtPriority = function(currentRoot : Fiber, priorityLev
     current = current.sibling;
   }
   return null;
-}
+};

--- a/src/renderers/shared/fiber/ReactFiberPendingWork.js
+++ b/src/renderers/shared/fiber/ReactFiberPendingWork.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactFiberPendingWork
+ * @flow
+ */
+
+'use strict';
+
+import type { Fiber } from 'ReactFiber';
+import type { PriorityLevel } from 'ReactPriorityLevel';
+
+var ReactFiber = require('ReactFiber');
+
+var {
+  NoWork,
+} = require('ReactPriorityLevel');
+
+function cloneSiblings(current : Fiber, workInProgress : Fiber, parent : Fiber) {
+  while (current.sibling) {
+    current = current.sibling;
+    workInProgress = workInProgress.sibling = ReactFiber.cloneFiber(
+      current,
+      current.pendingWorkPriority
+    );
+    workInProgress.parent = parent;
+  }
+  workInProgress.sibling = null;
+}
+
+exports.findNextUnitOfWorkAtPriority = function(currentRoot : Fiber, priorityLevel : PriorityLevel) : ?Fiber {
+  let current = currentRoot;
+  while (current) {
+    if (current.pendingWorkPriority !== NoWork &&
+        current.pendingWorkPriority <= priorityLevel) {
+      // This node has work to do that fits our priority level criteria.
+      if (current.pendingProps !== null) {
+        // We found some work to do. We need to return the "work in progress"
+        // of this node which will be the alternate.
+        const workInProgress = current.alternate;
+        if (!workInProgress) {
+          throw new Error('Should have wip now');
+        }
+        workInProgress.pendingProps = current.pendingProps;
+        return workInProgress;
+      }
+      // If we have a child let's see if any of our children has work to do.
+      // Only bother doing this at all if the current priority level matches
+      // because it is the highest priority for the whole subtree.
+      // TODO: Coroutines can have work in their stateNode which is another
+      // type of child that needs to be searched for work.
+      if (current.child) {
+        // Ensure we have a work in progress copy to backtrack through.
+        let currentChild = current.child;
+        let workInProgress = current.alternate;
+        if (!workInProgress) {
+          throw new Error('Should have wip now');
+        }
+        workInProgress.pendingWorkPriority = current.pendingWorkPriority;
+        workInProgress.child = ReactFiber.cloneFiber(currentChild, NoWork);
+        workInProgress.child.parent = workInProgress;
+        cloneSiblings(currentChild, workInProgress.child, workInProgress);
+        current = current.child;
+        continue;
+      }
+      // If we match the priority but has no child and no work to do,
+      // then we can safely reset the flag.
+      current.pendingWorkPriority = NoWork;
+    }
+    if (current === currentRoot) {
+      if (current.pendingWorkPriority <= priorityLevel) {
+        current.pendingWorkPriority = NoWork;
+      }
+      return null;
+    }
+    while (!current.sibling) {
+      // TODO: Stop using parent here. See below.
+      // $FlowFixMe: This downcast is not safe. It is intentionally an error.
+      current = current.parent;
+      if (!current) {
+        return null;
+      }
+      if (current.pendingWorkPriority <= priorityLevel) {
+        // If this subtree had work left to do, we would have returned it by
+        // now. This could happen if a child with pending work gets cleaned up
+        // but we don't clear the flag then. It is safe to reset it now.
+        current.pendingWorkPriority = NoWork;
+      }
+    }
+    current = current.sibling;
+  }
+  return null;
+}

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -219,10 +219,9 @@ module.exports = function<T, P, I>(config : HostConfig<T, P, I>) : Reconciler {
   return {
 
     mountContainer(element : ReactElement<any>, containerInfo : ?Object) : OpaqueNode {
-      const container = ReactFiber.createHostContainerFiber(containerInfo);
+      const container = ReactFiber.createHostContainerFiber(containerInfo, LowPriority);
       container.alternate = container;
       container.pendingProps = element;
-      container.pendingWorkPriority = LowPriority;
 
       scheduleLowPriWork(container);
 

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -13,19 +13,13 @@
 'use strict';
 
 import type { Fiber } from 'ReactFiber';
-import type { PriorityLevel } from 'ReactPriorityLevel';
 import type { FiberRoot } from 'ReactFiberRoot';
 
-var ReactFiber = require('ReactFiber');
-var { beginWork } = require('ReactFiberBeginWork');
-var { completeWork } = require('ReactFiberCompleteWork');
 var { createFiberRoot } = require('ReactFiberRoot');
+var ReactFiberScheduler = require('ReactFiberScheduler');
 
 var {
-  NoWork,
-  HighPriority,
   LowPriority,
-  OffscreenPriority,
 } = require('ReactPriorityLevel');
 
 type ReactHostElement<T, P> = {
@@ -36,8 +30,6 @@ type ReactHostElement<T, P> = {
 type Deadline = {
   timeRemaining : () => number
 };
-
-var timeHeuristicForUnitOfWork = 1;
 
 export type HostConfig<T, P, I> = {
 
@@ -60,222 +52,7 @@ export type Reconciler = {
 
 module.exports = function<T, P, I>(config : HostConfig<T, P, I>) : Reconciler {
 
-  // const scheduleHighPriCallback = config.scheduleHighPriCallback;
-  const scheduleLowPriCallback = config.scheduleLowPriCallback;
-
-  // The next work in progress fiber that we're currently working on.
-  let nextUnitOfWork : ?Fiber = null;
-
-  // Linked list of roots with scheduled work on them.
-  let nextScheduledRoot : ?FiberRoot = null;
-  let lastScheduledRoot : ?FiberRoot = null;
-
-  function findNextUnitOfWorkAtPriority(root : FiberRoot, priorityLevel : PriorityLevel) : ?Fiber {
-    let current = root.current;
-    while (current) {
-      if (current.pendingWorkPriority !== 0 &&
-          current.pendingWorkPriority <= priorityLevel) {
-        // This node has work to do that fits our priority level criteria.
-        if (current.pendingProps !== null) {
-          // We found some work to do. We need to return the "work in progress"
-          // of this node which will be the alternate.
-          const clone = ReactFiber.cloneFiber(current, current.pendingWorkPriority);
-          clone.pendingProps = current.pendingProps;
-          return clone;
-        }
-        // If we have a child let's see if any of our children has work to do.
-        // Only bother doing this at all if the current priority level matches
-        // because it is the highest priority for the whole subtree.
-        // TODO: Coroutines can have work in their stateNode which is another
-        // type of child that needs to be searched for work.
-        if (current.child) {
-          // Ensure we have a work in progress copy to backtrack through.
-          ReactFiber.cloneFiber(current, NoWork);
-          current = current.child;
-          continue;
-        }
-        // If we match the priority but has no child and no work to do,
-        // then we can safely reset the flag.
-        current.pendingWorkPriority = NoWork;
-      }
-      while (!current.sibling) {
-        // TODO: Stop using parent here. See below.
-        // $FlowFixMe: This downcast is not safe. It is intentionally an error.
-        current = current.parent;
-        if (!current) {
-          return null;
-        }
-        if (current.pendingWorkPriority <= priorityLevel) {
-          // If this subtree had work left to do, we would have returned it by
-          // now. This could happen if a child with pending work gets cleaned up
-          // but we don't clear the flag then. It is safe to reset it now.
-          current.pendingWorkPriority = NoWork;
-        }
-      }
-      current = current.sibling;
-    }
-    return null;
-  }
-
-  function findNextUnitOfWork() {
-    // Clear out roots with no more work on them.
-    while (nextScheduledRoot && nextScheduledRoot.current.pendingWorkPriority === NoWork) {
-      nextScheduledRoot.isScheduled = false;
-      if (nextScheduledRoot === lastScheduledRoot) {
-        nextScheduledRoot = null;
-        lastScheduledRoot = null;
-        return null;
-      }
-      nextScheduledRoot = nextScheduledRoot.nextScheduledRoot;
-    }
-    let root = nextScheduledRoot;
-    while (root) {
-      // Find the highest possible priority work to do.
-      // This loop is unrolled just to satisfy Flow's enum constraint.
-      // We could make arbitrary many idle priority levels but having
-      // too many just means flushing changes too often.
-      let work = findNextUnitOfWorkAtPriority(root, HighPriority);
-      if (work) {
-        return work;
-      }
-      work = findNextUnitOfWorkAtPriority(root, LowPriority);
-      if (work) {
-        return work;
-      }
-      work = findNextUnitOfWorkAtPriority(root, OffscreenPriority);
-      if (work) {
-        return work;
-      }
-      // We didn't find anything to do in this root, so let's try the next one.
-      root = root.nextScheduledRoot;
-    }
-    return null;
-  }
-
-  function completeUnitOfWork(workInProgress : Fiber) : ?Fiber {
-    while (true) {
-      // The current, flushed, state of this fiber is the alternate.
-      // Ideally nothing should rely on this, but relying on it here
-      // means that we don't need an additional field on the work in
-      // progress.
-      const current = workInProgress.alternate;
-      const next = completeWork(current, workInProgress);
-
-      // The work is now done. We don't need this anymore. This flags
-      // to the system not to redo any work here.
-      workInProgress.pendingProps = null;
-
-      // TODO: Stop using the parent for this purpose. I think this will break
-      // down in edge cases because when nodes are reused during bailouts, we
-      // don't know which of two parents was used. Instead we should maintain
-      // a temporary manual stack.
-      // $FlowFixMe: This downcast is not safe. It is intentionally an error.
-      const parent = workInProgress.parent;
-
-      // Ensure that remaining work priority bubbles up.
-      if (parent && workInProgress.pendingWorkPriority !== NoWork &&
-          (parent.pendingWorkPriority === NoWork ||
-          parent.pendingWorkPriority > workInProgress.pendingWorkPriority)) {
-        parent.pendingWorkPriority = workInProgress.pendingWorkPriority;
-      }
-
-      if (next) {
-        // If completing this work spawned new work, do that next.
-        return next;
-      } else if (workInProgress.sibling) {
-        // If there is more work to do in this parent, do that next.
-        return workInProgress.sibling;
-      } else if (parent) {
-        // If there's no more work in this parent. Complete the parent.
-        workInProgress = parent;
-      } else {
-        // If we're at the root, there's no more work to do. We can flush it.
-        const root : FiberRoot = (workInProgress.stateNode : any);
-        root.current = workInProgress;
-        console.log('completed one root flush with remaining work at priority', workInProgress.pendingWorkPriority);
-        const hasMoreWork = workInProgress.pendingWorkPriority !== NoWork;
-        // TODO: We can be smarter here and only look for more work in the
-        // "next" scheduled work since we've already scanned passed. That
-        // also ensures that work scheduled during reconciliation gets deferred.
-        const nextWork = findNextUnitOfWork();
-        if (!nextWork && hasMoreWork) {
-          throw new Error('FiberRoots should not have flagged more work if there is none.');
-        }
-        return nextWork;
-      }
-    }
-  }
-
-  function performUnitOfWork(workInProgress : Fiber) : ?Fiber {
-    // Ignore work if there is nothing to do.
-    if (workInProgress.pendingProps === null) {
-      return null;
-    }
-    // The current, flushed, state of this fiber is the alternate.
-    // Ideally nothing should rely on this, but relying on it here
-    // means that we don't need an additional field on the work in
-    // progress.
-    const current = workInProgress.alternate;
-    const next = beginWork(current, workInProgress);
-    if (next) {
-      // If this spawns new work, do that next.
-      return next;
-    } else {
-      // Otherwise, complete the current work.
-      return completeUnitOfWork(workInProgress);
-    }
-  }
-
-  function performLowPriWork(deadline : Deadline) {
-    if (!nextUnitOfWork) {
-      nextUnitOfWork = findNextUnitOfWork();
-    }
-    while (nextUnitOfWork) {
-      if (deadline.timeRemaining() > timeHeuristicForUnitOfWork) {
-        nextUnitOfWork = performUnitOfWork(nextUnitOfWork);
-        if (!nextUnitOfWork) {
-          // Find more work. We might have time to complete some more.
-          nextUnitOfWork = findNextUnitOfWork();
-        }
-      } else {
-        scheduleLowPriCallback(performLowPriWork);
-        return;
-      }
-    }
-  }
-
-  function scheduleLowPriWork(root : FiberRoot) {
-    // We must reset the current unit of work pointer so that we restart the
-    // search from the root during the next tick, in case there is now higher
-    // priority work somewhere earlier than before.
-    nextUnitOfWork = null;
-
-    if (root.isScheduled) {
-      // If we're already scheduled, we can bail out.
-      return;
-    }
-    root.isScheduled = true;
-    if (lastScheduledRoot) {
-      // Schedule ourselves to the end.
-      lastScheduledRoot.nextScheduledRoot = root;
-      lastScheduledRoot = root;
-    } else {
-      // We're the only work scheduled.
-      nextScheduledRoot = root;
-      lastScheduledRoot = root;
-      scheduleLowPriCallback(performLowPriWork);
-    }
-  }
-
-  /*
-  function performHighPriWork() {
-    // There is no such thing as high pri work yet.
-  }
-
-  function ensureHighPriIsScheduled() {
-    scheduleHighPriCallback(performHighPriWork);
-  }
-  */
+  var { scheduleLowPriWork } = ReactFiberScheduler(config);
 
   return {
 

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -134,7 +134,7 @@ module.exports = function<T, P, I>(config : HostConfig<T, P, I>) : Reconciler {
       // is passed. Should be doable though. Might require a wrapper don't know.
       if (rootFiber && rootFiber.type === element.type && rootFiber.key === element.key) {
         nextUnitOfWork = ReactFiber.cloneFiber(rootFiber);
-        nextUnitOfWork.input = element.props;
+        nextUnitOfWork.pendingProps = element.props;
         return {};
       }
 

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactFiberRoot
+ * @flow
+ */
+
+'use strict';
+
+import type { Fiber } from 'ReactFiber';
+
+const { createHostContainerFiber } = require('ReactFiber');
+
+export type FiberRoot = {
+  // Any additional information from the host associated with this root.
+  containerInfo: ?Object,
+  // The currently active root fiber. This is the mutable root of the tree.
+  current: Fiber,
+  // Determines if this root has already been added to the schedule for work.
+  isScheduled: bool,
+  // The work schedule is a linked list.
+  nextScheduledRoot: ?FiberRoot,
+};
+
+exports.createFiberRoot = function(containerInfo : ?Object) : FiberRoot {
+  // Cyclic construction. This cheats the type system right now because
+  // stateNode is any.
+  const uninitializedFiber = createHostContainerFiber();
+  const root = {
+    current: uninitializedFiber,
+    containerInfo: containerInfo,
+    isScheduled: false,
+    nextScheduledRoot: null,
+  };
+  uninitializedFiber.stateNode = root;
+  return root;
+};

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -90,6 +90,9 @@ module.exports = function<T, P, I>(config : HostConfig<T, P, I>) {
       // The work is now done. We don't need this anymore. This flags
       // to the system not to redo any work here.
       workInProgress.pendingProps = null;
+      if (workInProgress.pendingWorkPriority === NoWork) {
+        workInProgress.hasWorkInProgress = false;
+      }
 
       // TODO: Stop using the parent for this purpose. I think this will break
       // down in edge cases because when nodes are reused during bailouts, we

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -157,6 +157,10 @@ module.exports = function<T, P, I>(config : HostConfig<T, P, I>) {
       const current = workInProgress.alternate;
       const next = completeWork(current, workInProgress);
 
+      // TODO: If workInProgress returns null but still has work with the
+      // current priority in its subtree, we need to go find it right now.
+      // If we don't, we won't flush it until the next tick.
+
       // The work is now done. We don't need this anymore. This flags
       // to the system not to redo any work here.
       workInProgress.pendingProps = null;
@@ -192,6 +196,7 @@ module.exports = function<T, P, I>(config : HostConfig<T, P, I>) {
         // "next" scheduled work since we've already scanned passed. That
         // also ensures that work scheduled during reconciliation gets deferred.
         // const hasMoreWork = workInProgress.pendingWorkPriority !== NoWork;
+        console.log('----- COMPLETED with remaining work:', workInProgress.pendingWorkPriority);
         const nextWork = findNextUnitOfWork();
         // if (!nextWork && hasMoreWork) {
           // TODO: This can happen when some deep work completes and we don't

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -94,29 +94,24 @@ module.exports = function<T, P, I>(config : HostConfig<T, P, I>) {
         workInProgress.hasWorkInProgress = false;
       }
 
-      // TODO: Stop using the parent for this purpose. I think this will break
-      // down in edge cases because when nodes are reused during bailouts, we
-      // don't know which of two parents was used. Instead we should maintain
-      // a temporary manual stack.
-      // $FlowFixMe: This downcast is not safe. It is intentionally an error.
-      const parent = workInProgress.parent;
+      const returnFiber = workInProgress.return;
 
       // Ensure that remaining work priority bubbles up.
-      if (parent && workInProgress.pendingWorkPriority !== NoWork &&
-          (parent.pendingWorkPriority === NoWork ||
-          parent.pendingWorkPriority > workInProgress.pendingWorkPriority)) {
-        parent.pendingWorkPriority = workInProgress.pendingWorkPriority;
+      if (returnFiber && workInProgress.pendingWorkPriority !== NoWork &&
+          (returnFiber.pendingWorkPriority === NoWork ||
+          returnFiber.pendingWorkPriority > workInProgress.pendingWorkPriority)) {
+        returnFiber.pendingWorkPriority = workInProgress.pendingWorkPriority;
       }
 
       if (next) {
         // If completing this work spawned new work, do that next.
         return next;
       } else if (workInProgress.sibling) {
-        // If there is more work to do in this parent, do that next.
+        // If there is more work to do in this returnFiber, do that next.
         return workInProgress.sibling;
-      } else if (parent) {
-        // If there's no more work in this parent. Complete the parent.
-        workInProgress = parent;
+      } else if (returnFiber) {
+        // If there's no more work in this returnFiber. Complete the returnFiber.
+        workInProgress = returnFiber;
       } else {
         // If we're at the root, there's no more work to do. We can flush it.
         const root : FiberRoot = (workInProgress.stateNode : any);

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -1,0 +1,255 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactFiberScheduler
+ * @flow
+ */
+
+'use strict';
+
+import type { Fiber } from 'ReactFiber';
+import type { PriorityLevel } from 'ReactPriorityLevel';
+import type { FiberRoot } from 'ReactFiberRoot';
+import type { HostConfig } from 'ReactFiberReconciler';
+
+var ReactFiber = require('ReactFiber');
+var { beginWork } = require('ReactFiberBeginWork');
+var { completeWork } = require('ReactFiberCompleteWork');
+
+var {
+  NoWork,
+  HighPriority,
+  LowPriority,
+  OffscreenPriority,
+} = require('ReactPriorityLevel');
+
+var timeHeuristicForUnitOfWork = 1;
+
+module.exports = function<T, P, I>(config : HostConfig<T, P, I>) {
+
+  // const scheduleHighPriCallback = config.scheduleHighPriCallback;
+  const scheduleLowPriCallback = config.scheduleLowPriCallback;
+
+  // The next work in progress fiber that we're currently working on.
+  let nextUnitOfWork : ?Fiber = null;
+
+  // Linked list of roots with scheduled work on them.
+  let nextScheduledRoot : ?FiberRoot = null;
+  let lastScheduledRoot : ?FiberRoot = null;
+
+  function findNextUnitOfWorkAtPriority(root : FiberRoot, priorityLevel : PriorityLevel) : ?Fiber {
+    let current = root.current;
+    while (current) {
+      if (current.pendingWorkPriority !== 0 &&
+          current.pendingWorkPriority <= priorityLevel) {
+        // This node has work to do that fits our priority level criteria.
+        if (current.pendingProps !== null) {
+          // We found some work to do. We need to return the "work in progress"
+          // of this node which will be the alternate.
+          const clone = ReactFiber.cloneFiber(current, current.pendingWorkPriority);
+          clone.pendingProps = current.pendingProps;
+          return clone;
+        }
+        // If we have a child let's see if any of our children has work to do.
+        // Only bother doing this at all if the current priority level matches
+        // because it is the highest priority for the whole subtree.
+        // TODO: Coroutines can have work in their stateNode which is another
+        // type of child that needs to be searched for work.
+        if (current.child) {
+          // Ensure we have a work in progress copy to backtrack through.
+          ReactFiber.cloneFiber(current, NoWork);
+          current = current.child;
+          continue;
+        }
+        // If we match the priority but has no child and no work to do,
+        // then we can safely reset the flag.
+        current.pendingWorkPriority = NoWork;
+      }
+      while (!current.sibling) {
+        // TODO: Stop using parent here. See below.
+        // $FlowFixMe: This downcast is not safe. It is intentionally an error.
+        current = current.parent;
+        if (!current) {
+          return null;
+        }
+        if (current.pendingWorkPriority <= priorityLevel) {
+          // If this subtree had work left to do, we would have returned it by
+          // now. This could happen if a child with pending work gets cleaned up
+          // but we don't clear the flag then. It is safe to reset it now.
+          current.pendingWorkPriority = NoWork;
+        }
+      }
+      current = current.sibling;
+    }
+    return null;
+  }
+
+  function findNextUnitOfWork() {
+    // Clear out roots with no more work on them.
+    while (nextScheduledRoot && nextScheduledRoot.current.pendingWorkPriority === NoWork) {
+      nextScheduledRoot.isScheduled = false;
+      if (nextScheduledRoot === lastScheduledRoot) {
+        nextScheduledRoot = null;
+        lastScheduledRoot = null;
+        return null;
+      }
+      nextScheduledRoot = nextScheduledRoot.nextScheduledRoot;
+    }
+    let root = nextScheduledRoot;
+    while (root) {
+      // Find the highest possible priority work to do.
+      // This loop is unrolled just to satisfy Flow's enum constraint.
+      // We could make arbitrary many idle priority levels but having
+      // too many just means flushing changes too often.
+      let work = findNextUnitOfWorkAtPriority(root, HighPriority);
+      if (work) {
+        return work;
+      }
+      work = findNextUnitOfWorkAtPriority(root, LowPriority);
+      if (work) {
+        return work;
+      }
+      work = findNextUnitOfWorkAtPriority(root, OffscreenPriority);
+      if (work) {
+        return work;
+      }
+      // We didn't find anything to do in this root, so let's try the next one.
+      root = root.nextScheduledRoot;
+    }
+    return null;
+  }
+
+  function completeUnitOfWork(workInProgress : Fiber) : ?Fiber {
+    while (true) {
+      // The current, flushed, state of this fiber is the alternate.
+      // Ideally nothing should rely on this, but relying on it here
+      // means that we don't need an additional field on the work in
+      // progress.
+      const current = workInProgress.alternate;
+      const next = completeWork(current, workInProgress);
+
+      // The work is now done. We don't need this anymore. This flags
+      // to the system not to redo any work here.
+      workInProgress.pendingProps = null;
+
+      // TODO: Stop using the parent for this purpose. I think this will break
+      // down in edge cases because when nodes are reused during bailouts, we
+      // don't know which of two parents was used. Instead we should maintain
+      // a temporary manual stack.
+      // $FlowFixMe: This downcast is not safe. It is intentionally an error.
+      const parent = workInProgress.parent;
+
+      // Ensure that remaining work priority bubbles up.
+      if (parent && workInProgress.pendingWorkPriority !== NoWork &&
+          (parent.pendingWorkPriority === NoWork ||
+          parent.pendingWorkPriority > workInProgress.pendingWorkPriority)) {
+        parent.pendingWorkPriority = workInProgress.pendingWorkPriority;
+      }
+
+      if (next) {
+        // If completing this work spawned new work, do that next.
+        return next;
+      } else if (workInProgress.sibling) {
+        // If there is more work to do in this parent, do that next.
+        return workInProgress.sibling;
+      } else if (parent) {
+        // If there's no more work in this parent. Complete the parent.
+        workInProgress = parent;
+      } else {
+        // If we're at the root, there's no more work to do. We can flush it.
+        const root : FiberRoot = (workInProgress.stateNode : any);
+        root.current = workInProgress;
+        console.log('completed one root flush with remaining work at priority', workInProgress.pendingWorkPriority);
+        const hasMoreWork = workInProgress.pendingWorkPriority !== NoWork;
+        // TODO: We can be smarter here and only look for more work in the
+        // "next" scheduled work since we've already scanned passed. That
+        // also ensures that work scheduled during reconciliation gets deferred.
+        const nextWork = findNextUnitOfWork();
+        if (!nextWork && hasMoreWork) {
+          throw new Error('FiberRoots should not have flagged more work if there is none.');
+        }
+        return nextWork;
+      }
+    }
+  }
+
+  function performUnitOfWork(workInProgress : Fiber) : ?Fiber {
+    // Ignore work if there is nothing to do.
+    if (workInProgress.pendingProps === null) {
+      return null;
+    }
+    // The current, flushed, state of this fiber is the alternate.
+    // Ideally nothing should rely on this, but relying on it here
+    // means that we don't need an additional field on the work in
+    // progress.
+    const current = workInProgress.alternate;
+    const next = beginWork(current, workInProgress);
+    if (next) {
+      // If this spawns new work, do that next.
+      return next;
+    } else {
+      // Otherwise, complete the current work.
+      return completeUnitOfWork(workInProgress);
+    }
+  }
+
+  function performLowPriWork(deadline) {
+    if (!nextUnitOfWork) {
+      nextUnitOfWork = findNextUnitOfWork();
+    }
+    while (nextUnitOfWork) {
+      if (deadline.timeRemaining() > timeHeuristicForUnitOfWork) {
+        nextUnitOfWork = performUnitOfWork(nextUnitOfWork);
+        if (!nextUnitOfWork) {
+          // Find more work. We might have time to complete some more.
+          nextUnitOfWork = findNextUnitOfWork();
+        }
+      } else {
+        scheduleLowPriCallback(performLowPriWork);
+        return;
+      }
+    }
+  }
+
+  function scheduleLowPriWork(root : FiberRoot) {
+    // We must reset the current unit of work pointer so that we restart the
+    // search from the root during the next tick, in case there is now higher
+    // priority work somewhere earlier than before.
+    nextUnitOfWork = null;
+
+    if (root.isScheduled) {
+      // If we're already scheduled, we can bail out.
+      return;
+    }
+    root.isScheduled = true;
+    if (lastScheduledRoot) {
+      // Schedule ourselves to the end.
+      lastScheduledRoot.nextScheduledRoot = root;
+      lastScheduledRoot = root;
+    } else {
+      // We're the only work scheduled.
+      nextScheduledRoot = root;
+      lastScheduledRoot = root;
+      scheduleLowPriCallback(performLowPriWork);
+    }
+  }
+
+  /*
+  function performHighPriWork() {
+    // There is no such thing as high pri work yet.
+  }
+
+  function ensureHighPriIsScheduled() {
+    scheduleHighPriCallback(performHighPriWork);
+  }
+  */
+
+  return {
+    scheduleLowPriWork: scheduleLowPriWork,
+  };
+};

--- a/src/renderers/shared/fiber/ReactPriorityLevel.js
+++ b/src/renderers/shared/fiber/ReactPriorityLevel.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactPriorityLevel
+ * @flow
+ */
+
+'use strict';
+
+export type PriorityLevel = 0 | 1 | 2 | 3 | 4 | 5;
+
+module.exports = {
+  NoWork: 0, // No work is pending.
+  SynchronousPriority: 1, // For controlled text inputs. Synchronous side-effects.
+  AnimationPriority: 2, // Needs to complete before the next frame.
+  HighPriority: 3, // Interaction that needs to complete pretty soon to feel responsive.
+  LowPriority: 4, // Data fetching, or result from updating stores.
+  OffscreenPriority: 5, // Won't be visible but do the work in case it becomes visible.
+};

--- a/src/renderers/shared/fiber/ReactTypeOfWork.js
+++ b/src/renderers/shared/fiber/ReactTypeOfWork.js
@@ -12,14 +12,15 @@
 
 'use strict';
 
-export type TypeOfWork = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+export type TypeOfWork = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
 
 module.exports = {
   IndeterminateComponent: 0, // Before we know whether it is functional or class
   FunctionalComponent: 1,
   ClassComponent: 2,
-  HostComponent: 3,
-  CoroutineComponent: 4,
-  CoroutineHandlerPhase: 5,
-  YieldComponent: 6,
+  HostContainer: 3, // Root of a host tree. Could be nested inside another node.
+  HostComponent: 4,
+  CoroutineComponent: 5,
+  CoroutineHandlerPhase: 6,
+  YieldComponent: 7,
 };

--- a/src/renderers/shared/fiber/ReactTypeOfWork.js
+++ b/src/renderers/shared/fiber/ReactTypeOfWork.js
@@ -6,13 +6,15 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule ReactTypesOfWork
+ * @providesModule ReactTypeOfWork
  * @flow
  */
 
 'use strict';
 
-var TypesOfWork = {
+export type TypeOfWork = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+module.exports = {
   IndeterminateComponent: 0, // Before we know whether it is functional or class
   FunctionalComponent: 1,
   ClassComponent: 2,
@@ -21,5 +23,3 @@ var TypesOfWork = {
   CoroutineHandlerPhase: 5,
   YieldComponent: 6,
 };
-
-module.exports = TypesOfWork;

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -161,7 +161,56 @@ describe('ReactIncremental', function() {
 
     expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
 
-    // TODO: Test the ability for a subtree to resume if it has lower priority.
+  });
+
+  it('can deprioritize unfinished work and resume it later', function() {
+
+    var ops = [];
+
+    function Bar(props) {
+      ops.push('Bar');
+      return <div>{props.children}</div>;
+    }
+
+    function Middle(props) {
+      ops.push('Middle');
+      return <span>{props.children}</span>;
+    }
+
+    function Foo(props) {
+      ops.push('Foo');
+      return (
+        <div>
+          <Bar>{props.text}</Bar>
+          <div hidden={true}>
+            <span>
+            <Middle>{props.text}</Middle>
+            </span>
+          </div>
+          <Bar>{props.text}</Bar>
+        </div>
+      );
+    }
+
+    // Init
+    ReactNoop.render(<Foo text="foo" />);
+    ReactNoop.flush();
+
+    ops = [];
+
+    // Render part of the work. This should be enough to flush everything except
+    // the middle which has lower priority.
+    ReactNoop.render(<Foo text="bar" />);
+    ReactNoop.flushLowPri(40);
+
+    expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
+
+    ops = [];
+
+    // Flush only the remaining work
+    ReactNoop.flush();
+
+    expect(ops).toEqual(['Middle']);
 
   });
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -182,12 +182,13 @@ describe('ReactIncremental', function() {
       return (
         <div>
           <Bar>{props.text}</Bar>
-          <div hidden={true}>
-            <span>
+          <content hidden={true}>
             <Middle>{props.text}</Middle>
-            </span>
-          </div>
+          </content>
           <Bar>{props.text}</Bar>
+          <footer hidden={true}>
+            <Middle>Footer</Middle>
+          </footer>
         </div>
       );
     }
@@ -196,7 +197,7 @@ describe('ReactIncremental', function() {
     ReactNoop.render(<Foo text="foo" />);
     ReactNoop.flush();
 
-    expect(ops).toEqual(['Foo', 'Bar', 'Bar', 'Middle']);
+    expect(ops).toEqual(['Foo', 'Bar', 'Bar', 'Middle', 'Middle']);
 
     ops = [];
 
@@ -212,7 +213,7 @@ describe('ReactIncremental', function() {
     // Flush only the remaining work
     ReactNoop.flush();
 
-    expect(ops).toEqual(['Middle']);
+    expect(ops).toEqual(['Middle', 'Middle']);
 
   });
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -196,6 +196,8 @@ describe('ReactIncremental', function() {
     ReactNoop.render(<Foo text="foo" />);
     ReactNoop.flush();
 
+    expect(ops).toEqual(['Foo', 'Bar', 'Bar', 'Middle']);
+
     ops = [];
 
     // Render part of the work. This should be enough to flush everything except


### PR DESCRIPTION
Basically I'm working on the top level nodes. I use a fiber for that. That's nice because it allow us to nest them inside the tree for things like portals. It also allows me to reuse the child reconciliation for the top level.

The current thing won't quite work because there needs to be two fibers even at the top level. Work in progress. I might just to another mutable top level node that's not a fiber.

It also has a priority feature which searches the __current__ tree (not the work in progress since that no long exists after a flush) for the highest priority work to do next. This is a key component of this architecture. The priority flag represents the highest priority in the subtree.

Pending state updates will have priority associated with themselves on the fiber itself.

There is currently no priority associated with the pending props themselves which means that they get the same priority as anything deep in the tree. Pending props is kind of an edge case. I think that the only time that happens is if you have a high priority update which leads to update a lower priority tree so that the update in that tree gets deprioritized. But I'm not completely sure how this will work yet. Maybe they should only ever exists on the "work in progress" nodes.

When a new change comes in we reset and rescan the tree. That change could've been a higher priority or higher/earlier in the tree than what we're currently working on. We can probably avoid this reset+rescan for new changes which has lower priority.

Currently this reset throws out the work already done to the tree, so we'll need to start look at the "alternate" tree to see if there was already any work done there that we can reuse. We can use pending props for that.