### PR TITLE
remove unintended words from comment

### DIFF
--- a/src/renderers/shared/stack/reconciler/ReactUpdates.js
+++ b/src/renderers/shared/stack/reconciler/ReactUpdates.js
@@ -232,7 +232,7 @@ function enqueueUpdate(component) {
   // Various parts of our code (such as ReactCompositeComponent's
   // _renderValidatedComponent) assume that calls to render aren't nested;
   // verify that that's the case. (This is called by each top-level update
-  // function, like setProps, setState, forceUpdate, etc.; creation and
+  // function, like setState, forceUpdate, etc.; creation and
   // destruction of top-level components is guarded in ReactMount.)
 
   if (!batchingStrategy.isBatchingUpdates) {


### PR DESCRIPTION
Looks like it was unintendedly added after merging https://github.com/facebook/react/commit/731e42998a4dc7e4506b86eefd1117ba18b68969 and https://github.com/facebook/react/commit/6e8c2fb828ca448854ce434bbd319968a84f5c4d to master