### PR TITLE
Standardise format of the three "state" questions.

### DIFF
--- a/docs/docs/thinking-in-react.md
+++ b/docs/docs/thinking-in-react.md
@@ -93,7 +93,7 @@ Think of all of the pieces of data in our example application. We have:
 Let's go through each one and figure out which one is state. Simply ask three questions about each piece of data:
 
   1. Is it passed in from a parent via props? If so, it probably isn't state.
-  2. Does it remain the same over time? If so, it probably isn't state.
+  2. Does it remain unchanged over time? If so, it probably isn't state.
   3. Can you compute it based on any other state or props in your component? If so, it isn't state.
 
 The original list of products is passed in as props, so that's not state. The search text and the checkbox seem to be state since they change over time and can't be computed from anything. And finally, the filtered list of products isn't state because it can be computed by combining the original list of products with the search text and value of the checkbox.

--- a/docs/docs/thinking-in-react.md
+++ b/docs/docs/thinking-in-react.md
@@ -93,8 +93,8 @@ Think of all of the pieces of data in our example application. We have:
 Let's go through each one and figure out which one is state. Simply ask three questions about each piece of data:
 
   1. Is it passed in from a parent via props? If so, it probably isn't state.
-  2. Does it change over time? If not, it probably isn't state.
-  3. Can you compute it based on any other state or props in your component? If so, it's not state.
+  2. Does it remain the same over time? If so, it probably isn't state.
+  3. Can you compute it based on any other state or props in your component? If so, it isn't state.
 
 The original list of products is passed in as props, so that's not state. The search text and the checkbox seem to be state since they change over time and can't be computed from anything. And finally, the filtered list of products isn't state because it can be computed by combining the original list of products with the search text and value of the checkbox.
 


### PR DESCRIPTION
The original format follows the template:

 > 1. x? if `x` then probably **isn't** state
 > 2. y? if `!y` then probably **is** state
 > 3. z? if `z` then **it's not** state

This caused both me and a hallway tester to do a double take.

The proposed reformulation allows the answers to follow the same template.

In the same spirit, it uses the same contraction pattern in the last answer (`it's not state`-> `it isn't state`). This has the welcome side effect to make the lack of "probably" stand out more.