### PR TITLE
[flow] isTextInputElement

### DIFF
--- a/src/shared/utils/isTextInputElement.js
+++ b/src/shared/utils/isTextInputElement.js
@@ -32,12 +32,20 @@ var supportedInputTypes = {
   'week': true,
 };
 
-function isTextInputElement(elem) {
-  var nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
-  return nodeName && (
-    (nodeName === 'input' && supportedInputTypes[elem.type]) ||
-    nodeName === 'textarea'
-  );
+function isTextInputElement(elem: ?HTMLElement): bool {
+  if (!elem) {
+    return false;
+  }
+
+  if (elem.nodeName === 'INPUT') {
+    return !!supportedInputTypes[(elem: HTMLInputElement).type];
+  }
+
+  if (elem.nodeName === 'TEXTAREA') {
+    return true;
+  }
+
+  return false;
 }
 
 module.exports = isTextInputElement;


### PR DESCRIPTION
Flow doesn't keep track of the fact that elem exists if nodeName is truthy, so I had to rewrite it a bit.

We don't actually need to .toLowerCase() as we can check against the upper case. According to jresig in 2009, both input and textinput are always capitalized so this should be a safe change. http://ejohn.org/blog/nodename-case-sensitivity/

It also minifies into a smaller code:

```js
function isTextInputElement(a){var b=a&&a.nodeName&&a.nodeName.toLowerCase();return b&&("input"===b&&supportedInputTypes[a.type]||"textarea"===b)}
function isTextInputElement(e){return e?"INPUT"===e.nodeName?!!supportedInputTypes[e.type]:"TEXTAREA"===e.nodeName:!1}
```

Test Plan:
npm run flow
Careful inspection of the code

Reviewers: @zpao @spicyj