### PR TITLE
[flow] isTextInputElement

### DIFF
--- a/src/renderers/shared/utils/isTextInputElement.js
+++ b/src/renderers/shared/utils/isTextInputElement.js
@@ -7,6 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule isTextInputElement
+ * @flow
  */
 
 'use strict';
@@ -14,7 +15,7 @@
 /**
  * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/the-input-element.html#input-type-attr-summary
  */
-var supportedInputTypes = {
+var supportedInputTypes: {[key: string]: true | void} = {
   'color': true,
   'date': true,
   'datetime': true,
@@ -32,12 +33,18 @@ var supportedInputTypes = {
   'week': true,
 };
 
-function isTextInputElement(elem) {
+function isTextInputElement(elem: ?HTMLElement): bool {
   var nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
-  return nodeName && (
-    (nodeName === 'input' && supportedInputTypes[elem.type]) ||
-    nodeName === 'textarea'
-  );
+
+  if (nodeName === 'input') {
+    return !!supportedInputTypes[((elem: any): HTMLInputElement).type];
+  }
+
+  if (nodeName === 'textarea') {
+    return true;
+  }
+
+  return false;
 }
 
 module.exports = isTextInputElement;


### PR DESCRIPTION
I had to cast into any because flow doesn't think that checking the lowercase version of nodeName is a valid way to refine the variable from HTMLElement to HTMLInputElement. I'm also not confident enough in changing the implementation to an instanceof HTMLInputElement to please flow. It also takes care of the null check in the process.

The `nodeName &&` condition wasn't useful since the two branches are checking it against concrete values and actually makes the type different since nodeName is not a boolean per se. I replaced them with if conditions to make it clearer what it actually did instead of doing boolean logic tricks.

It is unclear why I had to type supportedInputTypes, see this internal post for a discussion: https://www.facebook.com/groups/flowtype/permalink/1084168611631753/

The only difference in behavior is that I now explicitely convert to boolean the object dereference via `!!`.

Test Plan:
npm run flow
Careful inspection of the code

Reviewers: @zpao @spicyj