### PR TITLE
[flow] type KeyEscapeUtils

### DIFF
--- a/src/shared/utils/KeyEscapeUtils.js
+++ b/src/shared/utils/KeyEscapeUtils.js
@@ -7,6 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule KeyEscapeUtils
+ * @flow
  */
 
 'use strict';
@@ -14,10 +15,10 @@
 /**
  * Escape and wrap key so it is safe to use as a reactid
  *
- * @param {*} key to be escaped.
+ * @param {string} key to be escaped.
  * @return {string} the escaped key.
  */
-function escape(key) {
+function escape(key: string): string {
   var escapeRegex = /[=:]/g;
   var escaperLookup = {
     '=': '=0',
@@ -39,7 +40,7 @@ function escape(key) {
  * @param {string} key to unescape.
  * @return {string} the unescaped key.
  */
-function unescape(key) {
+function unescape(key: string): string {
   var unescapeRegex = /(=0|=2)/g;
   var unescaperLookup = {
     '=0': '=',


### PR DESCRIPTION
The only call site ensures that the value is not null: https://github.com/facebook/react/blob/dc6fc8cc0726458a14f0544a30514af208d0098b/src/shared/utils/traverseAllChildren.js#L44

key is stringified inside of createElement, so we are guaranteed to receive a string right now: https://github.com/facebook/react/blob/dc6fc8cc0726458a14f0544a30514af208d0098b/src/isomorphic/classic/element/ReactElement.js#L142

Test Plan:
npm run flow

Reviewers: @zpao @spicyj