### PR TITLE
Remove tick and flush pending styles in ReactCSSTransitionGroup

### DIFF
--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -19,8 +19,6 @@ var ReactTransitionEvents = require('ReactTransitionEvents');
 
 var onlyChild = require('onlyChild');
 
-var TICK = 17;
-
 var ReactCSSTransitionGroupChild = React.createClass({
   displayName: 'ReactCSSTransitionGroupChild',
 
@@ -88,6 +86,9 @@ var ReactCSSTransitionGroupChild = React.createClass({
 
     CSSCore.addClass(node, className);
 
+    // Flush pending styles
+    this.flush = node.offsetWidth;
+
     // Need to do this to actually trigger a transition.
     this.queueClassAndNode(activeClassName, node);
 
@@ -108,9 +109,7 @@ var ReactCSSTransitionGroupChild = React.createClass({
       node: node,
     });
 
-    if (!this.timeout) {
-      this.timeout = setTimeout(this.flushClassNameAndNodeQueue, TICK);
-    }
+    this.flushClassNameAndNodeQueue();
   },
 
   flushClassNameAndNodeQueue: function() {


### PR DESCRIPTION
I believe the *tick* variable in ReactCSSTransitionGroupChild is there because it is approximately the period of a 60hz frequency. The process to apply a transition using ReactCSSTransition is:

a. Add the base css class
b. Wait for 17ms
c. Add the active class

If the frame rate is slow (less than 60hz) the tick of 17ms will not work because the browsers will discard the style changes in "a" and just apply "c". Browsers batch the styles as an optimisation so maybe there are other cases where the timeout will not work.

To fix that we can force the browser to flush the pending styles (calling a property that needs the styles to be computed, or calling getComputedStyle().someProperty). This actually removes the need for the *tick* timeout.

Doing that we also remove the need for this queueClass approach. To be honest, maybe even with the current approach there will never be more than one element in this queue because the next phase (appear, enter, leave) will just be activated once the callback passed to componentWillAppear(Enter, Leave) is called.

So if you think that this solution is plausible I can continue and remove the queue.

Obs: As pointed in #6495 we would be able to solve the same problem using requestAnimationFrame because then the browser know that needs to compute the styles before the next repaint, but then we would still need to keep track of the frame id to cancel it when the component is unmounting. Flushing the styles manually can simplify the code.