### PR TITLE
Call componentDidLeave after setState in ReactTransitionGroup

### DIFF
--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -208,10 +208,6 @@ var ReactTransitionGroup = React.createClass({
   _handleDoneLeaving: function(key) {
     var component = this.refs[key];
 
-    if (component.componentDidLeave) {
-      component.componentDidLeave();
-    }
-
     delete this.currentlyTransitioningKeys[key];
 
     var currentChildMapping;
@@ -235,6 +231,10 @@ var ReactTransitionGroup = React.createClass({
         delete newChildren[key];
         return {children: newChildren};
       });
+    }
+
+    if (component.componentDidLeave) {
+      component.componentDidLeave();
     }
   },
 

--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -208,6 +208,10 @@ var ReactTransitionGroup = React.createClass({
   _handleDoneLeaving: function(key) {
     var component = this.refs[key];
 
+    if (component.componentDidLeave) {
+      component.componentDidLeave();
+    }
+
     delete this.currentlyTransitioningKeys[key];
 
     var currentChildMapping;
@@ -226,15 +230,13 @@ var ReactTransitionGroup = React.createClass({
       // This entered again before it fully left. Add it again.
       this.performEnter(key);
     } else {
-      this.setState(function(state) {
-        var newChildren = Object.assign({}, state.children);
-        delete newChildren[key];
-        return {children: newChildren};
-      });
-    }
-
-    if (component.componentDidLeave) {
-      component.componentDidLeave();
+      if (this.isMounted()) {
+        this.setState(function(state) {
+          var newChildren = Object.assign({}, state.children);
+          delete newChildren[key];
+          return {children: newChildren};
+        });
+      }
     }
   },
 


### PR DESCRIPTION
If the developer uses the componentDidLeave hook to call setState() and remove the react transition group component, then the setState in _handleDoneLeaving() in ReactTransitionGroup.js will generate the warning:

> Warning: setState(...): Can only update a mounted or mounting component.

To fix that we just need to place componentDidLeave() call after the setState in _handleDoneLeaving() so any setState called by the user will be placed in the queue after the setState in _handleDoneLeaving() or use isMounted().