### PR TITLE
Listen DOM events in each React container

### DIFF
--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -63,10 +63,6 @@ var RESERVED_PROPS = {
   suppressContentEditableWarning: null,
 };
 
-// Node type for document fragments (Node.DOCUMENT_FRAGMENT_NODE).
-var DOC_FRAGMENT_TYPE = 11;
-
-
 function getDeclarationErrorAddendum(internalInstance) {
   if (internalInstance) {
     var owner = internalInstance._currentElement._owner || null;
@@ -222,9 +218,7 @@ function enqueuePutListener(inst, registrationName, listener, transaction) {
     );
   }
   var containerInfo = inst._hostContainerInfo;
-  var isDocumentFragment = containerInfo._node && containerInfo._node.nodeType === DOC_FRAGMENT_TYPE;
-  var doc = isDocumentFragment ? containerInfo._node : containerInfo._ownerDocument;
-  listenTo(registrationName, doc);
+  listenTo(registrationName, containerInfo._node);
   transaction.getReactMountReady().enqueue(putListener, {
     inst: inst,
     registrationName: registrationName,


### PR DESCRIPTION
Current React implementation is attaching events to `document` level.
This is breaking bubbling DOM behaviour not letting users to play
properly with methods like `stopPropagation`.

Also attaching events to containers instead of `document` integrates
better with other Javascript frameworks.

With this change we start attaching events at container level.

Fixes:
https://github.com/facebook/react/issues/2043
https://github.com/facebook/react/issues/4335

Related:
https://github.com/facebook/react/pull/2050
https://github.com/facebook/react/pull/1696
