### PR TITLE
webcomponents should use attachedCallback instead of createdCallback.

### DIFF
--- a/docs/docs/ref-09-webcomponents.md
+++ b/docs/docs/ref-09-webcomponents.md
@@ -36,7 +36,7 @@ class HelloMessage extends React.Component{
 
 ```javascript
 var proto = Object.create(HTMLElement.prototype, {
-  createdCallback: {
+  attachedCallback: {
     value: function() {
       var mountPoint = document.createElement('span');
       this.createShadowRoot().appendChild(mountPoint);

--- a/docs/docs/ref-09-webcomponents.zh-CN.md
+++ b/docs/docs/ref-09-webcomponents.zh-CN.md
@@ -36,7 +36,7 @@ class HelloMessage extends React.Component{
 
 ```javascript
 var proto = Object.create(HTMLElement.prototype, {
-  createdCallback: {
+  attachedCallback: {
     value: function() {
       var mountPoint = document.createElement('span');
       this.createShadowRoot().appendChild(mountPoint);


### PR DESCRIPTION
I think `createdCallback` worked with the webcomponents polyfill, but not with the actual browser?  Or maybe the spec/behavior changed in some subtle way.  Anyway, `attachedCallback` seems to work in Chrome but `createdCallback` does not work anymore, so we should update the docs.