### PR TITLE
Add Learning Resources section to the Community Resources on the website

### DIFF
--- a/docs/_data/nav_docs.yml
+++ b/docs/_data/nav_docs.yml
@@ -8,6 +8,8 @@
     title: Thinking in React
 - title: Community Resources
   items:
+  - id: learning-resources
+    title: Learning Resources
   - id: conferences
     title: Conferences
   - id: videos

--- a/docs/docs/conferences.md
+++ b/docs/docs/conferences.md
@@ -2,7 +2,7 @@
 id: conferences
 title: Conferences
 permalink: conferences.html
-prev: thinking-in-react.html
+prev: learning-resources.html
 next: videos.html
 ---
 

--- a/docs/docs/learning-resources.md
+++ b/docs/docs/learning-resources.md
@@ -1,0 +1,11 @@
+---
+id: learning-resources
+title: Learning Resources
+permalink: learning-resources.md
+prev: thinking-in-react.html
+next: conferences.html
+---
+
+### [React.js Fundamentals Course](http://courses.reactjsprogram.com/courses/reactjsfundamentals)
+
+The modularity of the React ecosystem is extremely powerful for building applications. However, this can be a difficult when you're first starting out. To get a React app up and running you typically need the right combination of React, Webpack, and Babel. In this course you'll start from a blank folder and you'll learn to build an application that encompasses everything you need to get started building a production ready application with React (including Routing, Ajax requests, and more). This course is a combination of videos, text, quizzes, and curriculum.

--- a/docs/docs/thinking-in-react.md
+++ b/docs/docs/thinking-in-react.md
@@ -2,7 +2,7 @@
 id: thinking-in-react
 title: Thinking in React
 prev: tutorial.html
-next: conferences.html
+next: learning-resources.html
 redirect_from: 'blog/2013/11/05/thinking-in-react.html'
 ---
 


### PR DESCRIPTION
This PR is in regards to @gaearon's [tweet](https://twitter.com/dan_abramov/status/746419224541691904) and I'd like to open dialog before this is merged about the best way to approach utilizing community learning resources in the official docs. 

My concern with this "Learning Resources" approach is that it could easily become a link dump which would be both ineffective and overwhelming for beginners. The way to avoid a link dump would be to have some form of quality check. However, that may lead to too much effort needed by the core team to keep up with PRs. 