### PR TITLE
Added elementOf checker to ReactPropTypes.

### DIFF
--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -78,6 +78,7 @@ var ReactPropTypes = {
   any: createAnyTypeChecker(),
   arrayOf: createArrayOfTypeChecker,
   element: createElementTypeChecker(),
+  elementOf: createElementOfTypeChecker,
   instanceOf: createInstanceTypeChecker,
   node: createNodeChecker(),
   objectOf: createObjectOfTypeChecker,
@@ -200,6 +201,29 @@ function createElementTypeChecker() {
       return new Error(
         `Invalid ${locationName} \`${propFullName}\` supplied to ` +
         `\`${componentName}\`, expected a single ReactElement.`
+      );
+    }
+    return null;
+  }
+  return createChainableTypeChecker(validate);
+}
+
+function createElementOfTypeChecker(expectedType) {
+  function validate(props, propName, componentName, location, propFullName) {
+    var error = createElementTypeChecker()(
+      props, propName, componentName, location, propFullName
+    );
+    if (error) {
+      return error;
+    }
+    var propType = props[propName].type;
+    var actualType = propType.displayName || propType.name || propType;
+    if (actualType !== expectedType) {
+      var locationName = ReactPropTypeLocationNames[location];
+      return new Error(
+        `Invalid ${locationName} \`${propFullName}\` of type ` +
+        `\`${actualType}\` supplied to \`${componentName}\`, expected ` +
+        `type of \`${expectedType}\`.`
       );
     }
     return null;

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -294,6 +294,45 @@ describe('ReactPropTypes', function() {
     });
   });
 
+  describe('ElementOf Type', function() {
+    it('should warn for invalid instances', function() {
+      typeCheckFail(
+        PropTypes.elementOf('svg'),
+        [<svg />, <svg />],
+        'Invalid prop `testProp` supplied to ' +
+        '`testComponent`, expected a single ReactElement.'
+      );
+      typeCheckFail(
+        PropTypes.elementOf('svg'),
+        123,
+        'Invalid prop `testProp` supplied to ' +
+        '`testComponent`, expected a single ReactElement.'
+      );
+      typeCheckFail(
+        PropTypes.elementOf('svg'),
+        'foo',
+        'Invalid prop `testProp` supplied to ' +
+        '`testComponent`, expected a single ReactElement.'
+      );
+      typeCheckFail(
+        PropTypes.elementOf('svg'),
+        false,
+        'Invalid prop `testProp` supplied to ' +
+        '`testComponent`, expected a single ReactElement.'
+      );
+      typeCheckFail(
+        PropTypes.elementOf('svg'),
+        <span />,
+        'Invalid prop `testProp` of type `span` supplied to ' +
+        '`testComponent`, expected type of `svg`.'
+      );
+    });
+
+    it('should not warn for valid values', function() {
+      typeCheckPass(PropTypes.elementOf('svg'), <svg />);
+    });
+  });
+
   describe('Instance Types', function() {
     it('should warn for invalid instances', function() {
       function Person() {}


### PR DESCRIPTION
In short, this PR aims to provide support for Single Child of a given type.

From the official [ReactJS docs page](https://facebook.github.io/react/docs/reusable-components.html#single-child) we can use `React.PropTypes.element` to validate a single child.

> With React.PropTypes.element you can specify that only a single child can be passed to a component as children.

I tried to find something that would validate the type of the given element, but it seems that it is not possible as of today.

With this PR you can do:

```
Component.propTypes = {
  testProp: React.PropTypes.elementOfType('svg').isRequired
};
```