### PR TITLE
Make "unexpected batch number" a warning

### DIFF
--- a/src/renderers/shared/stack/reconciler/ReactReconciler.js
+++ b/src/renderers/shared/stack/reconciler/ReactReconciler.js
@@ -14,7 +14,7 @@
 var ReactRef = require('ReactRef');
 var ReactInstrumentation = require('ReactInstrumentation');
 
-var invariant = require('invariant');
+var warning = require('warning');
 
 /**
  * Helper to call ReactRef.attachRefs with this composite component, split out
@@ -206,7 +206,7 @@ var ReactReconciler = {
     if (internalInstance._updateBatchNumber !== updateBatchNumber) {
       // The component's enqueued batch number should always be the current
       // batch or the following one.
-      invariant(
+      warning(
         internalInstance._updateBatchNumber == null ||
         internalInstance._updateBatchNumber === updateBatchNumber + 1,
         'performUpdateIfNecessary: Unexpected batch number (current %s, ' +


### PR DESCRIPTION
This was added to catch internal errors in React but doesn't seem to be doing much good except frustrating people more when their apps throw (#6895, FB-internal t11950821). Until more proper error boundaries land, let's make this a warning.