### PR TITLE
Docs: Explain usage of ES6 static get to define propTypes and defaultProps

### DIFF
--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -239,6 +239,23 @@ Counter.propTypes = { initialCount: React.PropTypes.number };
 Counter.defaultProps = { initialCount: 0 };
 ```
 
+Alternatively, you can define `propTypes` and `defaultProps` as static properties of the class.
+
+```javascript
+export class Counter extends React.Component {
+  static get propTypes() {
+    return {
+      initialCount: React.PropTypes.number
+    };
+  }
+  static get defaultProps() {
+    return {
+      initialCount: 0
+    };
+  }
+}
+```
+
 ### No Autobinding
 
 Methods follow the same semantics as regular ES6 classes, meaning that they don't automatically bind `this` to the instance. You'll have to explicitly use `.bind(this)` or [arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) `=>`:


### PR DESCRIPTION
I prefer using `static get` declarations inside a class to define `propTypes` and `defaultProps`. Other developers using ES6 may also prefer this style.