### PR TITLE
change tutorial script (success & error is deprecated )

### DIFF
--- a/docs/docs/tutorial.it-IT.md
+++ b/docs/docs/tutorial.it-IT.md
@@ -408,10 +408,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -438,10 +438,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -545,10 +545,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -614,10 +614,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -628,10 +628,10 @@ var CommentBox = React.createClass({
       dataType: 'json',
       type: 'POST',
       data: comment,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -667,10 +667,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -684,10 +684,10 @@ var CommentBox = React.createClass({
       dataType: 'json',
       type: 'POST',
       data: comment,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         this.setState({data: comments});
         console.error(this.props.url, status, err.toString());
       }.bind(this)

--- a/docs/docs/tutorial.ja-JP.md
+++ b/docs/docs/tutorial.ja-JP.md
@@ -409,10 +409,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -439,10 +439,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -605,10 +605,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -691,10 +691,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -705,10 +705,10 @@ var CommentBox = React.createClass({
       dataType: 'json',
       type: 'POST',
       data: comment,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -744,10 +744,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -765,10 +765,10 @@ var CommentBox = React.createClass({
       dataType: 'json',
       type: 'POST',
       data: comment,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         this.setState({data: comments});
         console.error(this.props.url, status, err.toString());
       }.bind(this)

--- a/docs/docs/tutorial.ko-KR.md
+++ b/docs/docs/tutorial.ko-KR.md
@@ -413,10 +413,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -443,10 +443,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -550,10 +550,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -619,10 +619,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -633,10 +633,10 @@ var CommentBox = React.createClass({
       dataType: 'json',
       type: 'POST',
       data: comment,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -672,10 +672,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -689,10 +689,10 @@ var CommentBox = React.createClass({
       dataType: 'json',
       type: 'POST',
       data: comment,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         this.setState({data: comments});
         console.error(this.props.url, status, err.toString());
       }.bind(this)

--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -398,10 +398,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -428,10 +428,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -594,10 +594,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -680,10 +680,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -694,10 +694,10 @@ var CommentBox = React.createClass({
       dataType: 'json',
       type: 'POST',
       data: comment,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -733,10 +733,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -754,10 +754,10 @@ var CommentBox = React.createClass({
       dataType: 'json',
       type: 'POST',
       data: comment,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         this.setState({data: comments});
         console.error(this.props.url, status, err.toString());
       }.bind(this)

--- a/docs/docs/tutorial.zh-CN.md
+++ b/docs/docs/tutorial.zh-CN.md
@@ -399,10 +399,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -429,10 +429,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -593,10 +593,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -679,10 +679,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -693,10 +693,10 @@ var CommentBox = React.createClass({
       dataType: 'json',
       type: 'POST',
       data: comment,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -732,10 +732,10 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
       }.bind(this)
     });
@@ -753,10 +753,10 @@ var CommentBox = React.createClass({
       dataType: 'json',
       type: 'POST',
       data: comment,
-      success: function(data) {
+      done: function(data) {
         this.setState({data: data});
       }.bind(this),
-      error: function(xhr, status, err) {
+      fail: function(xhr, status, err) {
         this.setState({data: comments});
         console.error(this.props.url, status, err.toString());
       }.bind(this)


### PR DESCRIPTION
tutorial script included following jQuery script
- success()
- error()

There are deprecated in jQuery 1.8, so I replaced them.
- success() -> done()
- error() -> fail()