### PR TITLE
Update 04-multiple-components.md

### DIFF
--- a/docs/docs/04-multiple-components.md
+++ b/docs/docs/04-multiple-components.md
@@ -124,7 +124,7 @@ The situation gets more complicated when the children are shuffled around (as in
 
 When React reconciles the keyed children, it will ensure that any child with `key` will be reordered (instead of clobbered) or destroyed (instead of reused).
 
-The `key` should *always* be supplied directly to the components in the array, not to the container HTML child of each component in the array:
+The `key` should *always* be supplied directly to the elements or components in the array, not to the container HTML child of each component in the array:
 
 ```javascript
 // WRONG!


### PR DESCRIPTION
Just had a discussion about this on reactiflux, and the use of "component" here to mean potentially both ReactElement and ReactComponent has already caused some confusion about assigning keys to ReactElements within loops. If the word component is intended to be a catch-all term, the glossary should provide explicit guidance on this.