### PR TITLE
Revise ResponderTouchHistoryStore Error Handling

### DIFF
--- a/src/renderers/shared/stack/event/eventPlugins/ResponderEventPlugin.js
+++ b/src/renderers/shared/stack/event/eventPlugins/ResponderEventPlugin.js
@@ -496,7 +496,7 @@ var ResponderEventPlugin = {
       );
     }
 
-    ResponderTouchHistoryStore.recordTouchTrack(topLevelType, nativeEvent, nativeEventTarget);
+    ResponderTouchHistoryStore.recordTouchTrack(topLevelType, nativeEvent);
 
     var extracted = canTriggerTransfer(topLevelType, targetInst, nativeEvent) ?
       setResponderAndExtractTransfer(

--- a/src/renderers/shared/stack/event/eventPlugins/ResponderTouchHistoryStore.js
+++ b/src/renderers/shared/stack/event/eventPlugins/ResponderTouchHistoryStore.js
@@ -104,7 +104,7 @@ function resetTouchRecord(touchRecord: TouchRecord, touch: Touch): void {
 }
 
 function getTouchIdentifier({identifier}: Touch): number {
-  invariant(identifier != null, 'Touch object is missing identifier');
+  invariant(identifier != null, 'Touch object is missing identifier.');
   warning(
     identifier <= MAX_TOUCH_BANK,
     'Touch identifier %s is greater than maximum supported %s which causes ' +


### PR DESCRIPTION
Touch behavior is inconsistent across different platforms, and `ResponderTouchHistoryStore` currently fatals when assumptions are broken. In addition, the behavior differs between development and production.

This pull request does a few things to make `ResponderTouchHistoryStore` easier to deal with:

- Adds Flow to keep the `TouchEvent`, `Touch`, and `TouchRecord` types straight.
- Changes behavior to be consistent across environments. This means either always throwing or never throwing (and making use of `warning` and `console.error` as appropriate).
- When an orphaned move or end event is received, print debug information and ignore it instead of crashing and burning.

**Reviewers:** @spicyj

**Test Plan:**
Ran `grunt test` and `flow ./src` successfully.
Verified touch gestures continue to work in production apps.