### PR TITLE
utilize unshift function

### DIFF
--- a/src/renderers/dom/client/validateDOMNesting.js
+++ b/src/renderers/dom/client/validateDOMNesting.js
@@ -314,9 +314,8 @@ if (__DEV__) {
 
     var stack = [];
     do {
-      stack.push(instance);
+      stack.unshift(instance);
     } while ((instance = instance._currentElement._owner));
-    stack.reverse();
     return stack;
   };
 


### PR DESCRIPTION
It seems simpler to use `unshift` rather than pushing all the elements and then reversing the array and probably faster. 