### PR TITLE
Add PropTypes.symbol to reusable components doc

### DIFF
--- a/docs/docs/05-reusable-components.it-IT.md
+++ b/docs/docs/05-reusable-components.it-IT.md
@@ -24,6 +24,7 @@ React.createClass({
     optionalNumber: React.PropTypes.number,
     optionalObject: React.PropTypes.object,
     optionalString: React.PropTypes.string,
+    optionalSymbol: React.PropTypes.symbol,
 
     // Tutto ciò che può essere mostrato: numeri, stringhe, elementi, o un array
     // (o frammento) contenente questi tipi.

--- a/docs/docs/05-reusable-components.ja-JP.md
+++ b/docs/docs/05-reusable-components.ja-JP.md
@@ -23,6 +23,7 @@ React.createClass({
     optionalNumber: React.PropTypes.number,
     optionalObject: React.PropTypes.object,
     optionalString: React.PropTypes.string,
+    optionalSymbol: React.PropTypes.symbol,
 
     // 何でもレンダリングできます。number、string、要素やそれらを含む配列など。
     optionalNode: React.PropTypes.node,

--- a/docs/docs/05-reusable-components.ko-KR.md
+++ b/docs/docs/05-reusable-components.ko-KR.md
@@ -23,6 +23,7 @@ React.createClass({
     optionalNumber: React.PropTypes.number,
     optionalObject: React.PropTypes.object,
     optionalString: React.PropTypes.string,
+    optionalSymbol: React.PropTypes.symbol,
 
     // 렌더링될 수 있는 모든 것: 숫자, 문자열, 요소
     // 이것들을 포함하는 배열(이나 프래그먼트)

--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -23,6 +23,7 @@ React.createClass({
     optionalNumber: React.PropTypes.number,
     optionalObject: React.PropTypes.object,
     optionalString: React.PropTypes.string,
+    optionalSymbol: React.PropTypes.symbol,
 
     // Anything that can be rendered: numbers, strings, elements or an array
     // (or fragment) containing these types.

--- a/docs/docs/05-reusable-components.zh-CN.md
+++ b/docs/docs/05-reusable-components.zh-CN.md
@@ -23,6 +23,7 @@ React.createClass({
     optionalNumber: React.PropTypes.number,
     optionalObject: React.PropTypes.object,
     optionalString: React.PropTypes.string,
+    optionalSymbol: React.PropTypes.symbol,
 
     // 所有可以被渲染的对象：数字，
     // 字符串，DOM 元素或包含这些类型的数组(or fragment) 。


### PR DESCRIPTION
`React.PropTypes.symbol` was added in 15.2.0.