### PR TITLE
Build React DOM Fiber package

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -137,6 +137,16 @@ module.exports = function(grunt) {
     'version-check',
     'browserify:domServerMin',
   ]);
+  grunt.registerTask('build:dom-fiber', [
+    'build-modules',
+    'version-check',
+    'browserify:domFiber',
+  ]);
+  grunt.registerTask('build:dom-fiber-min', [
+    'build-modules',
+    'version-check',
+    'browserify:domFiberMin',
+  ]);
   grunt.registerTask('build:npm-react', [
     'version-check',
     'build-modules',
@@ -164,6 +174,8 @@ module.exports = function(grunt) {
     'browserify:domMin',
     'browserify:domServer',
     'browserify:domServerMin',
+    'browserify:domFiber',
+    'browserify:domFiberMin',
     'npm-react:release',
     'npm-react:pack',
     'npm-react-dom:release',

--- a/examples/fiber/index.html
+++ b/examples/fiber/index.html
@@ -18,7 +18,7 @@
       </p>
     </div>
     <script src="../../build/react.js"></script>
-    <script src="../../build/react-dom.js"></script>
+    <script src="../../build/react-dom-fiber.js"></script>
     <script>
       function ExampleApplication(props) {
         var elapsed = Math.round(props.elapsed  / 100);
@@ -34,7 +34,7 @@
 
       var start = new Date().getTime();
       setInterval(function() {
-        ReactDOM.render(
+        ReactDOMFiber.render(
           ExampleApplicationFactory({elapsed: new Date().getTime() - start}),
           document.getElementById('container')
         );

--- a/packages/react-dom/fiber.js
+++ b/packages/react-dom/fiber.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./lib/ReactDOMFiber');

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -16,6 +16,8 @@ import type { HostChildren } from 'ReactFiberReconciler';
 
 var ReactFiberReconciler = require('ReactFiberReconciler');
 
+var warning = require('warning');
+
 type DOMContainerElement = Element & { _reactRootContainer: ?Object };
 
 type Container = Element;
@@ -56,9 +58,9 @@ var DOMRenderer = ReactFiberReconciler({
   },
 
   prepareUpdate(
-    domElement : Instance, 
-    oldProps : Props, 
-    newProps : Props, 
+    domElement : Instance,
+    oldProps : Props,
+    newProps : Props,
     children : HostChildren<Instance>
   ) : boolean {
     return true;
@@ -82,9 +84,21 @@ var DOMRenderer = ReactFiberReconciler({
 
 });
 
+var warned = false;
+
+function warnAboutUnstableUse() {
+  warning(
+    warned,
+    'You are using React DOM Fiber which is an experimental renderer. ' +
+    'It is likely to have bugs, breaking changes and is unsupported.'
+  );
+  warned = true;
+}
+
 var ReactDOM = {
 
   render(element : ReactElement<any>, container : DOMContainerElement) {
+    warnAboutUnstableUse();
     if (!container._reactRootContainer) {
       container._reactRootContainer = DOMRenderer.mountContainer(element, container);
     } else {
@@ -93,6 +107,7 @@ var ReactDOM = {
   },
 
   unmountComponentAtNode(container : DOMContainerElement) {
+    warnAboutUnstableUse();
     const root = container._reactRootContainer;
     if (root) {
       // TODO: Is it safe to reset this now or should I wait since this


### PR DESCRIPTION
Builds on top of #7164

This builds a `react-dom-fiber.js` bundle which exposes ReactDOMFiber. This allows early experiments with the new Fiber reconciler. I now enable it in the Fiber example.

I also expose it in the npm package through `react-dom/fiber`.
