### PR TITLE
Inline dev-only requires

### DIFF
--- a/src/isomorphic/classic/types/checkReactTypeSpec.js
+++ b/src/isomorphic/classic/types/checkReactTypeSpec.js
@@ -11,7 +11,6 @@
 
 'use strict';
 
-var ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
 var ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
 
 var invariant = require('invariant');
@@ -72,10 +71,13 @@ function checkReactTypeSpec(typeSpecs, values, location, componentName, element,
 
         var componentStackInfo = '';
 
-        if (debugID !== null) {
-          componentStackInfo = ReactComponentTreeDevtool.getStackAddendumByID(debugID);
-        } else if (element !== null) {
-          componentStackInfo = ReactComponentTreeDevtool.getCurrentStackAddendum(element);
+        if (__DEV__) {
+          var ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
+          if (debugID !== null) {
+            componentStackInfo = ReactComponentTreeDevtool.getStackAddendumByID(debugID);
+          } else if (element !== null) {
+            componentStackInfo = ReactComponentTreeDevtool.getCurrentStackAddendum(element);
+          }
         }
 
         warning(

--- a/src/renderers/dom/shared/ReactDOMDebugTool.js
+++ b/src/renderers/dom/shared/ReactDOMDebugTool.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-var ReactDOMNullInputValuePropDevtool = require('ReactDOMNullInputValuePropDevtool');
-var ReactDOMUnknownPropertyDevtool = require('ReactDOMUnknownPropertyDevtool');
 var ReactDebugTool = require('ReactDebugTool');
 
 var warning = require('warning');
@@ -68,7 +66,11 @@ var ReactDOMDebugTool = {
   },
 };
 
-ReactDOMDebugTool.addDevtool(ReactDOMUnknownPropertyDevtool);
-ReactDOMDebugTool.addDevtool(ReactDOMNullInputValuePropDevtool);
+if (__DEV__) {
+  var ReactDOMNullInputValuePropDevtool = require('ReactDOMNullInputValuePropDevtool');
+  var ReactDOMUnknownPropertyDevtool = require('ReactDOMUnknownPropertyDevtool');
+  ReactDOMDebugTool.addDevtool(ReactDOMUnknownPropertyDevtool);
+  ReactDOMDebugTool.addDevtool(ReactDOMNullInputValuePropDevtool);
+}
 
 module.exports = ReactDOMDebugTool;

--- a/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
+++ b/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
@@ -13,7 +13,6 @@
 
 var ReactReconciler = require('ReactReconciler');
 
-var ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
 var instantiateReactComponent = require('instantiateReactComponent');
 var KeyEscapeUtils = require('KeyEscapeUtils');
 var shouldUpdateReactComponent = require('shouldUpdateReactComponent');
@@ -24,6 +23,7 @@ function instantiateChild(childInstances, child, name, selfDebugID) {
   // We found a component instance.
   var keyUnique = (childInstances[name] === undefined);
   if (__DEV__) {
+    var ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
     warning(
       keyUnique,
       'flattenChildren(...): Encountered two children with the same key, ' +

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactMultiChildReconcile-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactMultiChildReconcile-test.js
@@ -278,6 +278,12 @@ function testPropsSequence(sequence) {
 describe('ReactMultiChildReconcile', function() {
   beforeEach(function() {
     jest.resetModuleRegistry();
+
+    React = require('React');
+    ReactDOM = require('ReactDOM');
+    ReactDOMComponentTree = require('ReactDOMComponentTree');
+    ReactInstanceMap = require('ReactInstanceMap');
+    mapObject = require('mapObject');
   });
 
   it('should reset internal state if removed then readded', function() {

--- a/src/renderers/shared/stack/reconciler/__tests__/refs-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/refs-test.js
@@ -116,6 +116,10 @@ var expectClickLogsLengthToBe = function(instance, length) {
 describe('reactiverefs', function() {
   beforeEach(function() {
     jest.resetModuleRegistry();
+
+    React = require('React');
+    ReactTestUtils = require('ReactTestUtils');
+    reactComponentExpect = require('reactComponentExpect');
   });
 
   /**
@@ -159,6 +163,10 @@ describe('reactiverefs', function() {
 describe('ref swapping', function() {
   beforeEach(function() {
     jest.resetModuleRegistry();
+
+    React = require('React');
+    ReactTestUtils = require('ReactTestUtils');
+    reactComponentExpect = require('reactComponentExpect');
   });
 
   var RefHopsAround = React.createClass({
@@ -275,4 +283,3 @@ describe('ref swapping', function() {
     __DEV__ = originalDev;
   });
 });
-

--- a/src/shared/utils/flattenChildren.js
+++ b/src/shared/utils/flattenChildren.js
@@ -12,7 +12,6 @@
 
 'use strict';
 
-var ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
 var KeyEscapeUtils = require('KeyEscapeUtils');
 var traverseAllChildren = require('traverseAllChildren');
 var warning = require('warning');
@@ -34,6 +33,7 @@ function flattenSingleChildIntoContext(
     const result = traverseContext;
     const keyUnique = (result[name] === undefined);
     if (__DEV__) {
+      var ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
       warning(
         keyUnique,
         'flattenChildren(...): Encountered two children with the same key, ' +


### PR DESCRIPTION
This is inspired by @keyanzhang’s work in #7178 but without Rollup.
He noticed `ReactComponentTreeDevtool` and some other devtools get included into prod build.
This fixes it:

```
   raw     gz Compared to master @ 7d0801e1a085ef7c52b0cc0212404335fa75c717    
     =      = build/react-dom-server.js                                        
     =      = build/react-dom-server.min.js                                    
     =      = build/react-dom.js                                               
     =      = build/react-dom.min.js                                           
  +133    +22 build/react-with-addons.js                                       
 -3715  -1088 build/react-with-addons.min.js                                   
  +133    +18 build/react.js                                                   
 -3694  -1133 build/react.min.js  
```

Unfortunately it’s way too easy to regress on this. Maybe we should have a way of marking certain files as dev-only and then failing the build if they end up in production bundle?