### PR TITLE
Don’t bundle DebugTool in production

### DIFF
--- a/src/renderers/dom/shared/ReactDOMDebugTool.js
+++ b/src/renderers/dom/shared/ReactDOMDebugTool.js
@@ -11,6 +11,8 @@
 
 'use strict';
 
+var ReactDOMNullInputValuePropDevtool = require('ReactDOMNullInputValuePropDevtool');
+var ReactDOMUnknownPropertyDevtool = require('ReactDOMUnknownPropertyDevtool');
 var ReactDebugTool = require('ReactDebugTool');
 
 var warning = require('warning');
@@ -19,23 +21,21 @@ var eventHandlers = [];
 var handlerDoesThrowForEvent = {};
 
 function emitEvent(handlerFunctionName, arg1, arg2, arg3, arg4, arg5) {
-  if (__DEV__) {
-    eventHandlers.forEach(function(handler) {
-      try {
-        if (handler[handlerFunctionName]) {
-          handler[handlerFunctionName](arg1, arg2, arg3, arg4, arg5);
-        }
-      } catch (e) {
-        warning(
-          handlerDoesThrowForEvent[handlerFunctionName],
-          'exception thrown by devtool while handling %s: %s',
-          handlerFunctionName,
-          e + '\n' + e.stack
-        );
-        handlerDoesThrowForEvent[handlerFunctionName] = true;
+  eventHandlers.forEach(function(handler) {
+    try {
+      if (handler[handlerFunctionName]) {
+        handler[handlerFunctionName](arg1, arg2, arg3, arg4, arg5);
       }
-    });
-  }
+    } catch (e) {
+      warning(
+        handlerDoesThrowForEvent[handlerFunctionName],
+        'exception thrown by devtool while handling %s: %s',
+        handlerFunctionName,
+        e + '\n' + e.stack
+      );
+      handlerDoesThrowForEvent[handlerFunctionName] = true;
+    }
+  });
 }
 
 var ReactDOMDebugTool = {
@@ -66,11 +66,7 @@ var ReactDOMDebugTool = {
   },
 };
 
-if (__DEV__) {
-  var ReactDOMNullInputValuePropDevtool = require('ReactDOMNullInputValuePropDevtool');
-  var ReactDOMUnknownPropertyDevtool = require('ReactDOMUnknownPropertyDevtool');
-  ReactDOMDebugTool.addDevtool(ReactDOMUnknownPropertyDevtool);
-  ReactDOMDebugTool.addDevtool(ReactDOMNullInputValuePropDevtool);
-}
+ReactDOMDebugTool.addDevtool(ReactDOMUnknownPropertyDevtool);
+ReactDOMDebugTool.addDevtool(ReactDOMNullInputValuePropDevtool);
 
 module.exports = ReactDOMDebugTool;

--- a/src/renderers/dom/shared/ReactDOMInstrumentation.js
+++ b/src/renderers/dom/shared/ReactDOMInstrumentation.js
@@ -11,6 +11,11 @@
 
 'use strict';
 
-var ReactDOMDebugTool = require('ReactDOMDebugTool');
+var debugTool = null;
 
-module.exports = {debugTool: ReactDOMDebugTool};
+if (__DEV__) {
+  var ReactDOMDebugTool = require('ReactDOMDebugTool');
+  debugTool = ReactDOMDebugTool;
+}
+
+module.exports = {debugTool};

--- a/src/renderers/shared/ReactInstrumentation.js
+++ b/src/renderers/shared/ReactInstrumentation.js
@@ -11,6 +11,11 @@
 
 'use strict';
 
-var ReactDebugTool = require('ReactDebugTool');
+var debugTool = null;
 
-module.exports = {debugTool: ReactDebugTool};
+if (__DEV__) {
+  var ReactDebugTool = require('ReactDebugTool');
+  debugTool = ReactDebugTool;
+}
+
+module.exports = {debugTool};


### PR DESCRIPTION
Most of this diff is indentation.

I am removing all `__DEV__` checks from `ReactDebugTool` and `ReactDOMDebugTool` code. Instead, I am conditionally requiring them—**in production, `ReactInstrumentation.debugTool` and `ReactDOMInstrumentation.debugTool` would now be `null` after this change.**

Why I am doing this:

1. Debug tools are not currently used in production at all. All calls to `.debugTool.*` are guarded by `__DEV__`.
2. When we add a `__PROFILE__` build, we can change the same condition to include `__PROFILE__`. There’s nothing here that would make it harder in the future.
3. We are currently bundling unnecessary noops with method names and strings in production, and as we add more events, they will keep growing:

<img width="1280" alt="screen shot 2016-07-05 at 18 40 10" src="https://cloud.githubusercontent.com/assets/810438/16593990/faaa169e-42df-11e6-93c3-d8b51494757d.png">

In the future, we *might* allow attaching devtools in production. Let’s do it when we actually have a use case for it. Right now it’s weird because we have these constraints that don’t actually end up getting used. This makes debug tool architecture more confusing to whoever who will be adding the `__PROFILE__` build.

Even when we allow this, it is likely that the actual DebugTool would be external code. There is no need for it to live inside React. The default “broadcasting” DebugTools are good for development but I don’t see why they are useful in prod.

Let’s just keep it simple for now and let the code reflect our real usage. Debug tools are only called in development environment now.

This reduces build size a bit:

```
     =      = build/react-dom-server.js                                        
     =      = build/react-dom-server.min.js                                    
     =      = build/react-dom.js                                               
     =      = build/react-dom.min.js                                           
  -471     -4 build/react-with-addons.js                                       
 -2732   -620 build/react-with-addons.min.js                                   
  -471     -9 build/react.js                                                   
 -2733   -583 build/react.min.js 
```

If we are concerned about stray `.debugTool.*` calls that would blow up in production, we can lint against using `.debugTool.` outside a `__DEV__` block. We don’t add new calls very often though so I’m not sure if it’s worth it.