### PR TITLE
Add failing test demonstrating a ReactPerf warning

### DIFF
--- a/src/renderers/shared/__tests__/ReactPerf-test.js
+++ b/src/renderers/shared/__tests__/ReactPerf-test.js
@@ -467,5 +467,29 @@ describe('ReactPerf', function() {
     expect(console.error.calls.count()).toBe(1);
 
     __DEV__ = true;
-  })
+  });
+
+  it('should not warn when wrapped in a component', () => {
+    spyOn(console, 'error');
+
+    return new Promise((resolve) => {
+      var Wrapper = React.createClass({
+        componentDidMount() {
+          ReactPerf.start();
+          this.setState({testProp: 'hello'});
+        },
+        componentDidUpdate() {
+          ReactPerf.stop();
+          resolve();
+        },
+        render() {
+          return this.props.children;
+        },
+      });
+      var container = document.createElement('div');
+      ReactDOM.render(<Wrapper><App /></Wrapper>, container);
+    }).then(() => {
+      expect(console.error.calls.count()).toBe(0, 'Instead got: ' + console.error.calls.argsFor(0)[0]);
+    });
+  });
 });


### PR DESCRIPTION
Related issue: #6949 

When using ReactPerf from a component, I'm getting results back from `Perf.getWasted(measurements)` but I'm seeing this warning crop up too:

```
Warning: There is an internal error in the React performance measurement code. We did not expect componentDidMount timer to stop while no timer is still in progress for another instance. Please report this as a bug in React.
```

cc @gaearon 

I simplified the component that I [shared in the issue](https://github.com/facebook/react/issues/6949#issuecomment-230371009) for this failing test. The use case that led me to stumble into this is using a react component as a test fixture to benchmark re-render performance programatically. 

The simplified test component cycles through a single state change and resolves in `componentDidUpdate` before checking the console error output. The warning is actually firing in the `componentDidMount` hook as soon as `ReactPerf.start();` is called.

(here's another jsfiddle with the simplified version: https://jsfiddle.net/69z2wepo/47901/)

