### PR TITLE
Don't detach value from defaultValue for submit/reset inputs

### DIFF
--- a/src/renderers/dom/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMInput.js
@@ -216,10 +216,20 @@ var ReactDOMInput = {
   },
 
   postMountWrapper: function(inst) {
+    var props = inst._currentElement.props;
+
     // This is in postMount because we need access to the DOM node, which is not
     // available until after the component has mounted.
     var node = ReactDOMComponentTree.getNodeFromInstance(inst);
-    node.value = node.value; // Detach value from defaultValue
+
+    // Detach value from defaultValue. We won't do anything if we're working on
+    // submit or reset inputs as those values & defaultValues are linked. They
+    // are not resetable nodes so this operation doesn't matter and actually
+    // removes browser-default values (eg "Submit Query") when no value is
+    // provided.
+    if (props.type !== 'submit' && props.type !== 'reset') {
+      node.value = node.value;
+    }
 
     // Normally, we'd just do `node.checked = node.checked` upon initial mount, less this bug
     // this is needed to work around a chrome bug where setting defaultChecked


### PR DESCRIPTION
Fixes #7179

This intentionally ignores both submit and reset inputs from the value detaching code. I'm mostly certain that the only result of the code there for these input types was to set the value to an empty string (if no value was provided). This is because that's what the value was, however browsers do show a default text for value-less inputs of those types (since they are actions). These default values aren't actually accessible the DOM afaict so we don't have a good indication apart from looking at the value in props. But since it doesn't appear to matter, I just skip this step entirely.

Test Plan: jsfiddle in #7179 no longer shows empty submit input.

cc @jimfb, @spicyj 