### PR TITLE
Make ReactPerf.start() work during reconciliation

### DIFF
--- a/src/renderers/shared/ReactDebugTool.js
+++ b/src/renderers/shared/ReactDebugTool.js
@@ -79,7 +79,7 @@ function resetMeasurements() {
   var previousMeasurements = currentFlushMeasurements || [];
   var previousOperations = ReactHostOperationHistoryDevtool.getHistory();
 
-  if (!isProfiling || currentFlushNesting === 0) {
+  if (currentFlushNesting === 0) {
     currentFlushStartTime = null;
     currentFlushMeasurements = null;
     clearHistory();
@@ -106,7 +106,7 @@ function checkDebugID(debugID) {
 }
 
 function beginLifeCycleTimer(debugID, timerType) {
-  if (!isProfiling || currentFlushNesting === 0) {
+  if (currentFlushNesting === 0) {
     return;
   }
   warning(
@@ -125,7 +125,7 @@ function beginLifeCycleTimer(debugID, timerType) {
 }
 
 function endLifeCycleTimer(debugID, timerType) {
-  if (!isProfiling || currentFlushNesting === 0) {
+  if (currentFlushNesting === 0) {
     return;
   }
   warning(
@@ -137,11 +137,13 @@ function endLifeCycleTimer(debugID, timerType) {
     currentTimerType || 'no',
     (debugID === currentTimerDebugID) ? 'the same' : 'another'
   );
-  currentFlushMeasurements.push({
-    timerType,
-    instanceID: debugID,
-    duration: performanceNow() - currentTimerStartTime - currentTimerNestedFlushDuration,
-  });
+  if (isProfiling) {
+    currentFlushMeasurements.push({
+      timerType,
+      instanceID: debugID,
+      duration: performanceNow() - currentTimerStartTime - currentTimerNestedFlushDuration,
+    });
+  }
   currentTimerStartTime = null;
   currentTimerNestedFlushDuration = null;
   currentTimerDebugID = null;

--- a/src/renderers/shared/__tests__/ReactPerf-test.js
+++ b/src/renderers/shared/__tests__/ReactPerf-test.js
@@ -467,5 +467,29 @@ describe('ReactPerf', function() {
     expect(console.error.calls.count()).toBe(1);
 
     __DEV__ = true;
-  })
+  });
+
+  it('should not warn when wrapped in a component', () => {
+    spyOn(console, 'error');
+
+    return new Promise((resolve) => {
+      var Wrapper = React.createClass({
+        componentDidMount() {
+          ReactPerf.start();
+          this.setState({testProp: 'hello'});
+        },
+        componentDidUpdate() {
+          ReactPerf.stop();
+          resolve();
+        },
+        render() {
+          return this.props.children;
+        },
+      });
+      var container = document.createElement('div');
+      ReactDOM.render(<Wrapper><App /></Wrapper>, container);
+    }).then(() => {
+      expect(console.error.calls.count()).toBe(0, 'Instead got: ' + console.error.calls.argsFor(0)[0]);
+    });
+  });
 });

--- a/src/renderers/shared/__tests__/ReactPerf-test.js
+++ b/src/renderers/shared/__tests__/ReactPerf-test.js
@@ -475,11 +475,11 @@ describe('ReactPerf', function() {
       componentWillMount() {
         ReactPerf.start();
       },
-      componentWillUpdate() {
-        ReactPerf.start();
-      },
       componentDidMount() {
         ReactPerf.stop();
+      },
+      componentWillUpdate() {
+        ReactPerf.start();
       },
       componentDidUpdate() {
         ReactPerf.stop();


### PR DESCRIPTION
Currently `ReactPerf.start()` and `ReactPerf.stop()` calls don’t work correctly during reconciliation.
As far as I know this was occasionally the case before 15.x too—they weren’t working reliably.

Generally we advise that people call `ReactPerf` methods from the console but React components for this appears to be a popular pattern so it’s best we support it.

I took the failing test from #7191 and built this PR on top of it.
This should fix the problem so people can write “measurer” components like this:

```js
    var Measurer = React.createClass({
      componentWillMount() {
        ReactPerf.start();
      },
      componentDidMount() {
        ReactPerf.stop();
      },
      componentWillUpdate() {
        ReactPerf.start();
      },
      componentDidUpdate() {
        ReactPerf.stop();
      },
      render() {
        // Force reconciliation despite constant element
        return React.cloneElement(this.props.children);
      },
    });

    var container = document.createElement('div');
    ReactDOM.render(<Measurer><App /></Measurer>, container);
    expect(ReactPerf.getWasted()).toEqual([]);

    ReactDOM.render(<Measurer><App /></Measurer>, container);
    expect(ReactPerf.getWasted()).toEqual(/* ... */);
```

Why didn’t this work before? We used to only start and stop timers while `isProfiling` is true. However this doesn’t work correctly if the user flips `isProfiling` **during** reconciliation. Then we have mismatching `begin`/`end` timer calls.

To fix this, I decided to always measure methods regardless of whether we are in profiling mode. I suppose calls to `performanceNow()` can’t be expensive, can they? And we are only doing this in `__DEV__` anyway.

The logic is changed so that we **don’t record** the measurements if `isProfiling` is `false`. So we just make them and throw them away. This lets us avoid writing the logic to recover from `isProfiling` flipping in the middle of reconciliation.