### PR TITLE
Make ReactPerf.start() work during reconciliation

### DIFF
--- a/src/renderers/art/ReactART.js
+++ b/src/renderers/art/ReactART.js
@@ -21,7 +21,6 @@ const Mode = require('art/modes/current');
 const React = require('React');
 const ReactDOM = require('ReactDOM');
 const ReactInstanceMap = require('ReactInstanceMap');
-const ReactInstrumentation = require('ReactInstrumentation');
 const ReactMultiChild = require('ReactMultiChild');
 const ReactUpdates = require('ReactUpdates');
 
@@ -187,9 +186,6 @@ const Surface = React.createClass({
 
     this.node = Mode.Surface(+this.props.width, +this.props.height, domNode);
 
-    if (__DEV__) {
-      ReactInstrumentation.debugTool.onBeginFlush();
-    }
     const transaction = ReactUpdates.ReactReconcileTransaction.getPooled();
     transaction.perform(
       this.mountAndInjectChildren,
@@ -199,9 +195,6 @@ const Surface = React.createClass({
       ReactInstanceMap.get(this)._context
     );
     ReactUpdates.ReactReconcileTransaction.release(transaction);
-    if (__DEV__) {
-      ReactInstrumentation.debugTool.onEndFlush();
-    }
   },
 
   componentDidUpdate: function(oldProps) {
@@ -211,9 +204,6 @@ const Surface = React.createClass({
       node.resize(+this.props.width, +this.props.height);
     }
 
-    if (__DEV__) {
-      ReactInstrumentation.debugTool.onBeginFlush();
-    }
     const transaction = ReactUpdates.ReactReconcileTransaction.getPooled();
     transaction.perform(
       this.updateChildren,
@@ -223,9 +213,6 @@ const Surface = React.createClass({
       ReactInstanceMap.get(this)._context
     );
     ReactUpdates.ReactReconcileTransaction.release(transaction);
-    if (__DEV__) {
-      ReactInstrumentation.debugTool.onEndFlush();
-    }
 
     if (node.render) {
       node.render();

--- a/src/renderers/art/ReactART.js
+++ b/src/renderers/art/ReactART.js
@@ -21,6 +21,7 @@ const Mode = require('art/modes/current');
 const React = require('React');
 const ReactDOM = require('ReactDOM');
 const ReactInstanceMap = require('ReactInstanceMap');
+const ReactInstrumentation = require('ReactInstrumentation');
 const ReactMultiChild = require('ReactMultiChild');
 const ReactUpdates = require('ReactUpdates');
 
@@ -186,6 +187,9 @@ const Surface = React.createClass({
 
     this.node = Mode.Surface(+this.props.width, +this.props.height, domNode);
 
+    if (__DEV__) {
+      ReactInstrumentation.debugTool.onBeginFlush();
+    }
     const transaction = ReactUpdates.ReactReconcileTransaction.getPooled();
     transaction.perform(
       this.mountAndInjectChildren,
@@ -195,6 +199,9 @@ const Surface = React.createClass({
       ReactInstanceMap.get(this)._context
     );
     ReactUpdates.ReactReconcileTransaction.release(transaction);
+    if (__DEV__) {
+      ReactInstrumentation.debugTool.onEndFlush();
+    }
   },
 
   componentDidUpdate: function(oldProps) {
@@ -204,6 +211,9 @@ const Surface = React.createClass({
       node.resize(+this.props.width, +this.props.height);
     }
 
+    if (__DEV__) {
+      ReactInstrumentation.debugTool.onBeginFlush();
+    }
     const transaction = ReactUpdates.ReactReconcileTransaction.getPooled();
     transaction.perform(
       this.updateChildren,
@@ -213,6 +223,9 @@ const Surface = React.createClass({
       ReactInstanceMap.get(this)._context
     );
     ReactUpdates.ReactReconcileTransaction.release(transaction);
+    if (__DEV__) {
+      ReactInstrumentation.debugTool.onEndFlush();
+    }
 
     if (node.render) {
       node.render();

--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -315,10 +315,6 @@ var ReactMount = {
     shouldReuseMarkup,
     context
   ) {
-    if (__DEV__) {
-      ReactInstrumentation.debugTool.onBeginFlush();
-    }
-
     // Various parts of our code (such as ReactCompositeComponent's
     // _renderValidatedComponent) assume that calls to render aren't nested;
     // verify that that's the case.
@@ -364,7 +360,6 @@ var ReactMount = {
       ReactInstrumentation.debugTool.onMountRootComponent(
         componentInstance._renderedComponent._debugID
       );
-      ReactInstrumentation.debugTool.onEndFlush();
     }
 
     return componentInstance;

--- a/src/renderers/dom/client/ReactReconcileTransaction.js
+++ b/src/renderers/dom/client/ReactReconcileTransaction.js
@@ -15,6 +15,7 @@ var CallbackQueue = require('CallbackQueue');
 var PooledClass = require('PooledClass');
 var ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
 var ReactInputSelection = require('ReactInputSelection');
+var ReactInstrumentation = require('ReactInstrumentation');
 var Transaction = require('Transaction');
 var ReactUpdateQueue = require('ReactUpdateQueue');
 
@@ -90,6 +91,13 @@ var TRANSACTION_WRAPPERS = [
   EVENT_SUPPRESSION,
   ON_DOM_READY_QUEUEING,
 ];
+
+if (__DEV__) {
+  TRANSACTION_WRAPPERS.push({
+    initialize: ReactInstrumentation.debugTool.onBeginFlush,
+    close: ReactInstrumentation.debugTool.onEndFlush,
+  });
+}
 
 /**
  * Currently:

--- a/src/renderers/dom/server/ReactServerRendering.js
+++ b/src/renderers/dom/server/ReactServerRendering.js
@@ -37,9 +37,6 @@ function renderToStringImpl(element, makeStaticMarkup) {
     transaction = ReactServerRenderingTransaction.getPooled(makeStaticMarkup);
 
     return transaction.perform(function() {
-      if (__DEV__) {
-        ReactInstrumentation.debugTool.onBeginFlush();
-      }
       var componentInstance = instantiateReactComponent(element, true);
       var markup = ReactReconciler.mountComponent(
         componentInstance,
@@ -52,7 +49,6 @@ function renderToStringImpl(element, makeStaticMarkup) {
         ReactInstrumentation.debugTool.onUnmountComponent(
           componentInstance._debugID
         );
-        ReactInstrumentation.debugTool.onEndFlush();
       }
       if (!makeStaticMarkup) {
         markup = ReactMarkupChecksum.addChecksumToMarkup(markup);

--- a/src/renderers/dom/server/ReactServerRenderingTransaction.js
+++ b/src/renderers/dom/server/ReactServerRenderingTransaction.js
@@ -13,6 +13,7 @@
 
 var PooledClass = require('PooledClass');
 var Transaction = require('Transaction');
+var ReactInstrumentation = require('ReactInstrumentation');
 var ReactServerUpdateQueue = require('ReactServerUpdateQueue');
 
 
@@ -22,6 +23,13 @@ var ReactServerUpdateQueue = require('ReactServerUpdateQueue');
  * each other.
  */
 var TRANSACTION_WRAPPERS = [];
+
+if (__DEV__) {
+  TRANSACTION_WRAPPERS.push({
+    initialize: ReactInstrumentation.debugTool.onBeginFlush,
+    close: ReactInstrumentation.debugTool.onEndFlush,
+  });
+}
 
 var noopCallbackQueue = {
   enqueue: function() {},

--- a/src/renderers/native/ReactNativeMount.js
+++ b/src/renderers/native/ReactNativeMount.js
@@ -138,10 +138,6 @@ var ReactNativeMount = {
     var instance = instantiateReactComponent(nextWrappedElement, false);
     ReactNativeMount._instancesByContainerID[containerTag] = instance;
 
-    if (__DEV__) {
-      ReactInstrumentation.debugTool.onBeginFlush();
-    }
-
     // The initial render is synchronous but any updates that happen during
     // rendering, in componentWillMount or componentDidMount, will be batched
     // according to the current batching strategy.
@@ -156,7 +152,6 @@ var ReactNativeMount = {
       ReactInstrumentation.debugTool.onMountRootComponent(
         instance._renderedComponent._debugID
       );
-      ReactInstrumentation.debugTool.onEndFlush();
     }
     var component = instance.getPublicInstance();
     if (callback) {

--- a/src/renderers/native/ReactNativeReconcileTransaction.js
+++ b/src/renderers/native/ReactNativeReconcileTransaction.js
@@ -14,6 +14,7 @@
 var CallbackQueue = require('CallbackQueue');
 var PooledClass = require('PooledClass');
 var Transaction = require('Transaction');
+var ReactInstrumentation = require('ReactInstrumentation');
 var ReactUpdateQueue = require('ReactUpdateQueue');
 
 /**
@@ -42,6 +43,13 @@ var ON_DOM_READY_QUEUEING = {
  * each other.
  */
 var TRANSACTION_WRAPPERS = [ON_DOM_READY_QUEUEING];
+
+if (__DEV__) {
+  TRANSACTION_WRAPPERS.push({
+    initialize: ReactInstrumentation.debugTool.onBeginFlush,
+    close: ReactInstrumentation.debugTool.onEndFlush,
+  });
+}
 
 /**
  * Currently:

--- a/src/renderers/shared/ReactDebugTool.js
+++ b/src/renderers/shared/ReactDebugTool.js
@@ -196,6 +196,7 @@ var ReactDebugTool = {
     isProfiling = true;
     flushHistory.length = 0;
     resetMeasurements();
+    ReactDebugTool.addDevtool(ReactHostOperationHistoryDevtool);
   },
   endProfiling() {
     if (!isProfiling) {
@@ -204,6 +205,7 @@ var ReactDebugTool = {
 
     isProfiling = false;
     resetMeasurements();
+    ReactDebugTool.removeDevtool(ReactHostOperationHistoryDevtool);
   },
   getFlushHistory() {
     return flushHistory;
@@ -311,7 +313,6 @@ var ReactDebugTool = {
 
 ReactDebugTool.addDevtool(ReactInvalidSetStateWarningDevTool);
 ReactDebugTool.addDevtool(ReactComponentTreeDevtool);
-ReactDebugTool.addDevtool(ReactHostOperationHistoryDevtool);
 ReactDebugTool.addDevtool(ReactChildrenMutationWarningDevtool);
 var url = (ExecutionEnvironment.canUseDOM && window.location.href) || '';
 if ((/[?&]react_perf\b/).test(url)) {

--- a/src/renderers/shared/ReactDebugTool.js
+++ b/src/renderers/shared/ReactDebugTool.js
@@ -79,7 +79,7 @@ function resetMeasurements() {
   var previousMeasurements = currentFlushMeasurements || [];
   var previousOperations = ReactHostOperationHistoryDevtool.getHistory();
 
-  if (!isProfiling || currentFlushNesting === 0) {
+  if (currentFlushNesting === 0) {
     currentFlushStartTime = null;
     currentFlushMeasurements = null;
     clearHistory();
@@ -106,7 +106,7 @@ function checkDebugID(debugID) {
 }
 
 function beginLifeCycleTimer(debugID, timerType) {
-  if (!isProfiling || currentFlushNesting === 0) {
+  if (currentFlushNesting === 0) {
     return;
   }
   warning(
@@ -125,7 +125,7 @@ function beginLifeCycleTimer(debugID, timerType) {
 }
 
 function endLifeCycleTimer(debugID, timerType) {
-  if (!isProfiling || currentFlushNesting === 0) {
+  if (currentFlushNesting === 0) {
     return;
   }
   warning(
@@ -137,11 +137,13 @@ function endLifeCycleTimer(debugID, timerType) {
     currentTimerType || 'no',
     (debugID === currentTimerDebugID) ? 'the same' : 'another'
   );
-  currentFlushMeasurements.push({
-    timerType,
-    instanceID: debugID,
-    duration: performanceNow() - currentTimerStartTime - currentTimerNestedFlushDuration,
-  });
+  if (isProfiling) {
+    currentFlushMeasurements.push({
+      timerType,
+      instanceID: debugID,
+      duration: performanceNow() - currentTimerStartTime - currentTimerNestedFlushDuration,
+    });
+  }
   currentTimerStartTime = null;
   currentTimerNestedFlushDuration = null;
   currentTimerDebugID = null;

--- a/src/renderers/shared/ReactDebugTool.js
+++ b/src/renderers/shared/ReactDebugTool.js
@@ -240,6 +240,12 @@ var ReactDebugTool = {
     checkDebugID(debugID);
     emitEvent('onEndReconcilerTimer', debugID, timerType);
   },
+  onError(debugID) {
+    if (currentTimerDebugID != null) {
+      endLifeCycleTimer(currentTimerDebugID, currentTimerType);
+    }
+    emitEvent('onError', debugID);
+  },
   onBeginProcessingChildContext() {
     emitEvent('onBeginProcessingChildContext');
   },

--- a/src/renderers/shared/__tests__/ReactPerf-test.js
+++ b/src/renderers/shared/__tests__/ReactPerf-test.js
@@ -467,5 +467,29 @@ describe('ReactPerf', function() {
     expect(console.error.calls.count()).toBe(1);
 
     __DEV__ = true;
-  })
+  });
+
+  it('should not warn when wrapped in a component', () => {
+    spyOn(console, 'error');
+
+    return new Promise((resolve) => {
+      var Wrapper = React.createClass({
+        componentDidMount() {
+          ReactPerf.start();
+          this.setState({testProp: 'hello'});
+        },
+        componentDidUpdate() {
+          ReactPerf.stop();
+          resolve();
+        },
+        render() {
+          return this.props.children;
+        },
+      });
+      var container = document.createElement('div');
+      ReactDOM.render(<Wrapper><App /></Wrapper>, container);
+    }).then(() => {
+      expect(console.error.calls.count()).toBe(0, 'Instead got: ' + console.error.calls.argsFor(0)[0]);
+    });
+  });
 });

--- a/src/renderers/shared/__tests__/ReactPerf-test.js
+++ b/src/renderers/shared/__tests__/ReactPerf-test.js
@@ -475,11 +475,11 @@ describe('ReactPerf', function() {
       componentWillMount() {
         ReactPerf.start();
       },
-      componentWillUpdate() {
-        ReactPerf.start();
-      },
       componentDidMount() {
         ReactPerf.stop();
+      },
+      componentWillUpdate() {
+        ReactPerf.start();
       },
       componentDidUpdate() {
         ReactPerf.stop();

--- a/src/renderers/shared/devtools/__tests__/ReactHostOperationHistoryDevtool-test.js
+++ b/src/renderers/shared/devtools/__tests__/ReactHostOperationHistoryDevtool-test.js
@@ -13,6 +13,7 @@
 
 describe('ReactHostOperationHistoryDevtool', () => {
   var React;
+  var ReactPerf;
   var ReactDOM;
   var ReactDOMComponentTree;
   var ReactDOMFeatureFlags;
@@ -22,11 +23,18 @@ describe('ReactHostOperationHistoryDevtool', () => {
     jest.resetModuleRegistry();
 
     React = require('React');
+    ReactPerf = require('ReactPerf');
     ReactDOM = require('ReactDOM');
     ReactDOMComponentTree = require('ReactDOMComponentTree');
     ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
     ReactHostOperationHistoryDevtool = require('ReactHostOperationHistoryDevtool');
+
+    ReactPerf.start();
   });
+
+  afterEach(() => {
+    ReactPerf.stop();
+  })
 
   function assertHistoryMatches(expectedHistory) {
     var actualHistory = ReactHostOperationHistoryDevtool.getHistory();

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -423,6 +423,11 @@ var ReactCompositeComponentMixin = {
     try {
       markup = this.performInitialMount(renderedElement, hostParent, hostContainerInfo, transaction, context);
     } catch (e) {
+      if (__DEV__) {
+        if (this._debugID !== 0) {
+          ReactInstrumentation.debugTool.onError();
+        }
+      }
       // Roll back to checkpoint, handle error (which may add items to the transaction), and take a new checkpoint
       transaction.rollback(checkpoint);
       this._instance.unstable_handleError(e);

--- a/src/renderers/shared/stack/reconciler/ReactUpdates.js
+++ b/src/renderers/shared/stack/reconciler/ReactUpdates.js
@@ -14,7 +14,6 @@
 var CallbackQueue = require('CallbackQueue');
 var PooledClass = require('PooledClass');
 var ReactFeatureFlags = require('ReactFeatureFlags');
-var ReactInstrumentation = require('ReactInstrumentation');
 var ReactReconciler = require('ReactReconciler');
 var Transaction = require('Transaction');
 
@@ -193,10 +192,6 @@ function runBatchedUpdates(transaction) {
 }
 
 var flushBatchedUpdates = function() {
-  if (__DEV__) {
-    ReactInstrumentation.debugTool.onBeginFlush();
-  }
-
   // ReactUpdatesFlushTransaction's wrappers will clear the dirtyComponents
   // array and perform any updates enqueued by mount-ready handlers (i.e.,
   // componentDidUpdate) but we need to check here too in order to catch
@@ -215,10 +210,6 @@ var flushBatchedUpdates = function() {
       queue.notifyAll();
       CallbackQueue.release(queue);
     }
-  }
-
-  if (__DEV__) {
-    ReactInstrumentation.debugTool.onEndFlush();
   }
 };
 

--- a/src/renderers/testing/ReactTestMount.js
+++ b/src/renderers/testing/ReactTestMount.js
@@ -122,10 +122,6 @@ var ReactHostMount = {
 
     var instance = instantiateReactComponent(nextWrappedElement, false);
 
-    if (__DEV__) {
-      ReactInstrumentation.debugTool.onBeginFlush();
-    }
-
     // The initial render is synchronous but any updates that happen during
     // rendering, in componentWillMount or componentDidMount, will be batched
     // according to the current batching strategy.
@@ -139,7 +135,6 @@ var ReactHostMount = {
       ReactInstrumentation.debugTool.onMountRootComponent(
         instance._renderedComponent._debugID
       );
-      ReactInstrumentation.debugTool.onEndFlush();
     }
     return new ReactTestInstance(instance);
   },


### PR DESCRIPTION
Currently `ReactPerf.start()` and `ReactPerf.stop()` calls don’t work correctly during reconciliation.
As far as I know this was occasionally the case before 15.x too—they weren’t working reliably.

Generally we advise that people call `ReactPerf` methods from the console but React components for this appears to be a popular pattern so it’s best we support it.

I took the failing test from #7191 and built this PR on top of it.
This should fix the problem so people can write “measurer” components like this:

```js
    var Measurer = React.createClass({
      componentWillMount() {
        ReactPerf.start();
      },
      componentDidMount() {
        ReactPerf.stop();
      },
      componentWillUpdate() {
        ReactPerf.start();
      },
      componentDidUpdate() {
        ReactPerf.stop();
      },
      render() {
        // Force reconciliation despite constant element
        return React.cloneElement(this.props.children);
      },
    });

    var container = document.createElement('div');
    ReactDOM.render(<Measurer><App /></Measurer>, container);
    expect(ReactPerf.getWasted()).toEqual([]);

    ReactDOM.render(<Measurer><App /></Measurer>, container);
    expect(ReactPerf.getWasted()).toEqual(/* ... */);
```

Why didn’t this work before? We used to only start and stop timers while `isProfiling` is true. However this doesn’t work correctly if the user flips `isProfiling` **during** reconciliation. Then we have mismatching `begin`/`end` timer calls.

To fix this, I decided to always measure methods regardless of whether we are in profiling mode. I suppose calls to `performanceNow()` can’t be expensive, can they? And we are only doing this in `__DEV__` anyway.

The logic is changed so that we **don’t record** the measurements if `isProfiling` is `false`. So we just make them and throw them away (without pushing them into the array). This lets us avoid writing the logic to recover from `isProfiling` flipping in the middle of reconciliation.

I also changed the host history tool to only record DOM operations while profiling. Previously they were recorded into an array before being discarded at the end of the flush.

Finally, I fixed a few places (ART and error boundaries) where warning assertions weren’t true. They started firing because we now measure regardless of `isProfiling`. This is actually good because it means we’re testing that ReactPerf doesn’t get confused by bad event ordering during our whole test suite.