### PR TITLE
7128 - React document listener memory leak fix.

### DIFF
--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -19,6 +19,7 @@ var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var ReactDOMContainerInfo = require('ReactDOMContainerInfo');
 var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 var ReactElement = require('ReactElement');
+var ReactEventListener = require('ReactEventListener');
 var ReactFeatureFlags = require('ReactFeatureFlags');
 var ReactInstanceMap = require('ReactInstanceMap');
 var ReactInstrumentation = require('ReactInstrumentation');
@@ -593,6 +594,10 @@ var ReactMount = {
       container,
       false
     );
+
+    if (Object.keys(instancesByReactRootID).length===0) {
+      ReactEventListener.resetDocument(container.ownerDocument);
+    }
     return true;
   },
 

--- a/src/renderers/dom/client/__tests__/ReactEventListener-test.js
+++ b/src/renderers/dom/client/__tests__/ReactEventListener-test.js
@@ -209,4 +209,52 @@ describe('ReactEventListener', function() {
     expect(calls[0][EVENT_TARGET_PARAM])
       .toBe(ReactDOMComponentTree.getInstanceFromNode(instance.getInner()));
   });
+
+  it('documentResetCallback called when resetDocument called with provided document', function() {
+    var iframe =document.createElement('iframe');
+    var doc = iframe.contentDocument;
+    var resetCalled = false;
+    ReactEventListener.setDocumentResetCallback(function(d) {
+      expect(d).toBe(doc);
+      resetCalled = true;
+    });
+    ReactEventListener.resetDocument(doc);
+    expect(resetCalled).toBe(true);
+  });
+
+  it('document event remover called once and removed upon first resetDocument', function() {
+    var removed = false;
+    ReactEventListener.addDocumentEventListenerRemover(function() {
+      expect(removed).toBe(false);
+      removed = true;
+    });
+    ReactEventListener.resetDocument(document);
+    expect(removed).toBe(true);
+    ReactEventListener.resetDocument(document);
+    ReactEventListener.resetDocument(document);
+  });
+
+  it('multiple document event removers each called once and removed upon first resetDocument call', function() {
+    var i = false;
+    ReactEventListener.addDocumentEventListenerRemover(function() {
+      expect(i).toBe(false);
+      i = true;
+    });
+    var j = false;
+    ReactEventListener.addDocumentEventListenerRemover(function() {
+      expect(j).toBe(false);
+      j = true;
+    });
+    var k = false;
+    ReactEventListener.addDocumentEventListenerRemover(function() {
+      expect(k).toBe(false);
+      k = true;
+    });
+    ReactEventListener.resetDocument(document);
+    expect(i).toBe(true);
+    expect(j).toBe(true);
+    expect(k).toBe(true);
+    ReactEventListener.resetDocument(document);
+    ReactEventListener.resetDocument(document);
+  });
 });

--- a/src/renderers/dom/client/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMount-test.js
@@ -14,6 +14,7 @@
 var React;
 var ReactDOM;
 var ReactDOMServer;
+var ReactEventListener;
 var ReactMount;
 var ReactTestUtils;
 var WebComponents;
@@ -25,6 +26,7 @@ describe('ReactMount', function() {
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactDOMServer = require('ReactDOMServer');
+    ReactEventListener = require('ReactEventListener');
     ReactMount = require('ReactMount');
     ReactTestUtils = require('ReactTestUtils');
 
@@ -276,6 +278,71 @@ describe('ReactMount', function() {
     expect(Object.keys(ReactMount._instancesByReactRootID).length).toBe(2);
     ReactDOM.unmountComponentAtNode(container);
     expect(Object.keys(ReactMount._instancesByReactRootID).length).toBe(1);
+  });
+
+  it('only calls ReactEventListener.resetDocument when without any roots', function() {
+    var mustResetNow = false;
+    var documentResetted = false;
+
+    ReactEventListener.setDocumentResetCallback(function() {
+      expect(mustResetNow).toBe(true);
+      documentResetted = true;
+    });
+
+    var container = document.createElement('div');
+    document.body.appendChild(container);
+    ReactDOM.render(<span />, container);
+
+    mustResetNow = true;
+    ReactDOM.unmountComponentAtNode(container);
+    expect(documentResetted).toBe(true);
+
+    // second time...
+    mustResetNow = false;
+    documentResetted=false;
+    ReactDOM.render(<span />, container);
+
+    mustResetNow = true;
+    ReactDOM.unmountComponentAtNode(container);
+    expect(documentResetted).toBe(true);
+  });
+
+  it('multiple containers only calls ReactEventListener.resetDocument when without any roots', function() {
+    var mustResetNow = false;
+    var documentResetted = false;
+    ReactEventListener.setDocumentResetCallback(function() {
+      expect(mustResetNow).toBe(true);
+      documentResetted = true;
+    });
+
+    var container1 = document.createElement('div');
+    document.body.appendChild(container1);
+    ReactDOM.render(<span />, container1);
+
+    var container2 = document.createElement('div');
+    document.body.appendChild(container2);
+    ReactDOM.render(<span />, container2);
+
+    ReactDOM.unmountComponentAtNode(container1);
+
+    mustResetNow = true;
+    ReactDOM.unmountComponentAtNode(container2);
+    expect(documentResetted).toBe(true);
+  });
+
+  it('only calls ReactEventListener.resetDocument when without any roots #2', function() {
+    var documentResetted = false;
+    ReactEventListener.setDocumentResetCallback(function() {
+      documentResetted=true;
+    });
+
+    var container = document.createElement('div');
+    document.body.appendChild(container);
+    ReactDOM.render(<div />, container);
+    ReactDOM.render(<span />, container);
+
+    ReactDOM.unmountComponentAtNode(container);
+    expect(documentResetted).toBe(true);
   });
 
   it('marks top-level mounts', function() {

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -32,6 +32,7 @@ var ReactDOMInput = require('ReactDOMInput');
 var ReactDOMOption = require('ReactDOMOption');
 var ReactDOMSelect = require('ReactDOMSelect');
 var ReactDOMTextarea = require('ReactDOMTextarea');
+var ReactEventListener = require('ReactEventListener');
 var ReactInstrumentation = require('ReactInstrumentation');
 var ReactMultiChild = require('ReactMultiChild');
 var ReactServerRenderingTransaction = require('ReactServerRenderingTransaction');
@@ -224,7 +225,11 @@ function enqueuePutListener(inst, registrationName, listener, transaction) {
   var containerInfo = inst._hostContainerInfo;
   var isDocumentFragment = containerInfo._node && containerInfo._node.nodeType === DOC_FRAGMENT_TYPE;
   var doc = isDocumentFragment ? containerInfo._node : containerInfo._ownerDocument;
-  listenTo(registrationName, doc);
+  var listenerRemover = listenTo(registrationName, doc, !isDocumentFragment);
+  if (!isDocumentFragment) {
+    ReactEventListener.addDocumentEventListenerRemover(listenerRemover);
+  }
+
   transaction.getReactMountReady().enqueue(putListener, {
     inst: inst,
     registrationName: registrationName,


### PR DESCRIPTION
This captures global (document) added event listeners, and saves them. When the last component is removed these "saved" listeners are also removed, and the object on document that keeps track of document state(mostly tracks which event listeners have already been added) is also "reset".
