### PR TITLE
Remove context masking to allow pure intermediate components to implement a context aware shouldComponentUpdate

### DIFF
--- a/src/isomorphic/classic/__tests__/ReactContextValidator-test.js
+++ b/src/isomorphic/classic/__tests__/ReactContextValidator-test.js
@@ -128,10 +128,10 @@ describe('ReactContextValidator', function() {
     var container = document.createElement('div');
     ReactDOM.render(<Parent foo="abc" />, container);
     ReactDOM.render(<Parent foo="def" />, container);
-    expect(actualComponentWillReceiveProps).toEqual({foo: 'def'});
-    expect(actualShouldComponentUpdate).toEqual({foo: 'def'});
-    expect(actualComponentWillUpdate).toEqual({foo: 'def'});
-    expect(actualComponentDidUpdate).toEqual({foo: 'abc'});
+    expect(actualComponentWillReceiveProps).toEqual({foo: 'def', bar: 'bar'});
+    expect(actualShouldComponentUpdate).toEqual({foo: 'def', bar: 'bar'});
+    expect(actualComponentWillUpdate).toEqual({foo: 'def', bar: 'bar'});
+    expect(actualComponentDidUpdate).toEqual({foo: 'abc', bar: 'bar'});
   });
 
   it('should check context types', function() {

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -631,25 +631,24 @@ var ReactCompositeComponentMixin = {
 
   /**
    * Asserts that the context object contains the keys specified in 
-   * `contextTypes`, and asserts that they are valid.
+   * `contextTypes`, and that they are valid.
    *
    * @param {object} context
-   * @return {?object}
+   * @return {object}
    * @private
    */
   _processContext: function(context) {
-    var maskedContext = context;
     if (__DEV__) {
       var Component = this._currentElement.type;
       if (Component.contextTypes) {
         this._checkContextTypes(
           Component.contextTypes,
-          maskedContext,
+          context,
           ReactPropTypeLocations.context
         );
       }
     }
-    return maskedContext;
+    return context;
   },
 
   /**

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -630,28 +630,7 @@ var ReactCompositeComponentMixin = {
   },
 
   /**
-   * Filters the context object to only contain keys specified in
-   * `contextTypes`
-   *
-   * @param {object} context
-   * @return {?object}
-   * @private
-   */
-  _maskContext: function(context) {
-    var Component = this._currentElement.type;
-    var contextTypes = Component.contextTypes;
-    if (!contextTypes) {
-      return emptyObject;
-    }
-    var maskedContext = {};
-    for (var contextName in contextTypes) {
-      maskedContext[contextName] = context[contextName];
-    }
-    return maskedContext;
-  },
-
-  /**
-   * Filters the context object to only contain keys specified in
+   * Asserts that the context object contains the keys specified in 
    * `contextTypes`, and asserts that they are valid.
    *
    * @param {object} context
@@ -659,7 +638,7 @@ var ReactCompositeComponentMixin = {
    * @private
    */
   _processContext: function(context) {
-    var maskedContext = this._maskContext(context);
+    var maskedContext = context;
     if (__DEV__) {
       var Component = this._currentElement.type;
       if (Component.contextTypes) {

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -875,15 +875,15 @@ describe('ReactCompositeComponent', function() {
     var Intermediary = React.createClass({
 
       componentWillReceiveProps: function(nextProps, nextContext) {
-        expect('foo' in nextContext).toBe(false);
+        expect('foo' in nextContext).toBe(true);
       },
 
       componentDidUpdate: function(prevProps, prevState, prevContext) {
-        expect('foo' in prevContext).toBe(false);
+        expect('foo' in prevContext).toBe(true);
       },
 
       shouldComponentUpdate: function(nextProps, nextState, nextContext) {
-        expect('foo' in nextContext).toBe(false);
+        expect('foo' in nextContext).toBe(true);
         return true;
       },
 
@@ -970,7 +970,7 @@ describe('ReactCompositeComponent', function() {
 
     var ChildWithoutContext = React.createClass({
       componentWillReceiveProps: function(nextProps, nextContext) {
-        expect('foo' in nextContext).toBe(false);
+        expect('foo' in nextContext).toBe(true);
 
         if (nextProps !== this.props) {
           propChanges++;
@@ -1034,7 +1034,7 @@ describe('ReactCompositeComponent', function() {
     ReactTestUtils.Simulate.click(div.childNodes[0]);
 
     expect(propChanges).toBe(0);
-    expect(contextChanges).toBe(3); // ChildWithContext, GrandChild x 2
+    expect(contextChanges).toBe(4); // ChildWithContext, ChildWithoutContext, GrandChild x 2
   });
 
   it('should disallow nested render calls', function() {


### PR DESCRIPTION
Same as #7213 but this time on master

I am using contexts to propagate locale and routing information. My problem is that some pure components stop subtree rendering when the context changes (because pure components only check state and props). This is a problem for many people as per issue #2517.

I reasoned that not masking the context for intermediate components would be better than masking, and the defined contextTypes would only be used for validating, not for filtering. For properties, components define propTypes, but they can still get properties that they do not define. The same reasoning can be applied to contexts, whereby through contextTypes, a component defines what it expects to be in the context, but not implying that nothing else can be in the context. i have updated the tests to reflect this update.

Since components that are not interested in context would typically not use the context argument, not masking the context would not cause any existing component to break, unless said components explicitly are checking that the context param is undefined. This would, however, create an opportunity for a refinement of pure component, say a ContextAwarePureComponent which would compare state, props and context in shouldComponentUpdate, allowing context updates to cause re-renders of pure components.

I am currently running in development with this patch, using radium and some react-bootstrap components, and did not experience any issue