### PR TITLE
Eagerly evaluate inline requires in Jest

### DIFF
--- a/grunt/tasks/browserify.js
+++ b/grunt/tasks/browserify.js
@@ -25,6 +25,16 @@ module.exports = function() {
     entries: entries,
     debug: config.debug, // sourcemaps
     standalone: config.standalone, // global
+    insertGlobalVars: {
+      // We can remove this when we remove the few direct
+      // process.env.NODE_ENV checks against "test".
+      // The intention is to avoid embedding Browserify's `process` shim
+      // because we don't really need it.
+      // See https://github.com/facebook/react/pull/7245 for context.
+      process: function() {
+        return 'undefined';
+      },
+    },
   };
 
   var bundle = browserify(options);

--- a/src/isomorphic/classic/types/checkReactTypeSpec.js
+++ b/src/isomorphic/classic/types/checkReactTypeSpec.js
@@ -19,7 +19,11 @@ var warning = require('warning');
 
 var ReactComponentTreeDevtool;
 
-if (process.env.NODE_ENV === 'test') {
+if (
+  typeof process !== 'undefined' &&
+  process.env &&
+  process.env.NODE_ENV === 'test'
+) {
   // Temporary hack.
   // Inline requires don't work well with Jest:
   // https://github.com/facebook/react/issues/7240

--- a/src/isomorphic/classic/types/checkReactTypeSpec.js
+++ b/src/isomorphic/classic/types/checkReactTypeSpec.js
@@ -17,6 +17,17 @@ var ReactPropTypesSecret = require('ReactPropTypesSecret');
 var invariant = require('invariant');
 var warning = require('warning');
 
+var ReactComponentTreeDevtool;
+
+if (process.env.NODE_ENV === 'test') {
+  // Temporary hack.
+  // Inline requires don't work well with Jest:
+  // https://github.com/facebook/react/issues/7240
+  // Remove the inline requires when we don't need them anymore:
+  // https://github.com/facebook/react/pull/7178
+  ReactComponentTreeDevtool = require('ReactComponentTreeDevtool')
+}
+
 var loggedTypeFailures = {};
 
 /**
@@ -73,7 +84,9 @@ function checkReactTypeSpec(typeSpecs, values, location, componentName, element,
         var componentStackInfo = '';
 
         if (__DEV__) {
-          var ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
+          if (!ReactComponentTreeDevtool) {
+            ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
+          }
           if (debugID !== null) {
             componentStackInfo = ReactComponentTreeDevtool.getStackAddendumByID(debugID);
           } else if (element !== null) {

--- a/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
+++ b/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
@@ -19,11 +19,24 @@ var shouldUpdateReactComponent = require('shouldUpdateReactComponent');
 var traverseAllChildren = require('traverseAllChildren');
 var warning = require('warning');
 
+var ReactComponentTreeDevtool;
+
+if (process.env.NODE_ENV === 'test') {
+  // Temporary hack.
+  // Inline requires don't work well with Jest:
+  // https://github.com/facebook/react/issues/7240
+  // Remove the inline requires when we don't need them anymore:
+  // https://github.com/facebook/react/pull/7178
+  ReactComponentTreeDevtool = require('ReactComponentTreeDevtool')
+}
+
 function instantiateChild(childInstances, child, name, selfDebugID) {
   // We found a component instance.
   var keyUnique = (childInstances[name] === undefined);
   if (__DEV__) {
-    var ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
+    if (!ReactComponentTreeDevtool) {
+      ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
+    }
     warning(
       keyUnique,
       'flattenChildren(...): Encountered two children with the same key, ' +

--- a/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
+++ b/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
@@ -21,7 +21,11 @@ var warning = require('warning');
 
 var ReactComponentTreeDevtool;
 
-if (process.env.NODE_ENV === 'test') {
+if (
+  typeof process !== 'undefined' &&
+  process.env &&
+  process.env.NODE_ENV === 'test'
+) {
   // Temporary hack.
   // Inline requires don't work well with Jest:
   // https://github.com/facebook/react/issues/7240

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactMultiChildReconcile-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactMultiChildReconcile-test.js
@@ -278,12 +278,6 @@ function testPropsSequence(sequence) {
 describe('ReactMultiChildReconcile', function() {
   beforeEach(function() {
     jest.resetModuleRegistry();
-
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactDOMComponentTree = require('ReactDOMComponentTree');
-    ReactInstanceMap = require('ReactInstanceMap');
-    mapObject = require('mapObject');
   });
 
   it('should reset internal state if removed then readded', function() {

--- a/src/renderers/shared/stack/reconciler/__tests__/refs-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/refs-test.js
@@ -116,10 +116,6 @@ var expectClickLogsLengthToBe = function(instance, length) {
 describe('reactiverefs', function() {
   beforeEach(function() {
     jest.resetModuleRegistry();
-
-    React = require('React');
-    ReactTestUtils = require('ReactTestUtils');
-    reactComponentExpect = require('reactComponentExpect');
   });
 
   /**
@@ -163,10 +159,6 @@ describe('reactiverefs', function() {
 describe('ref swapping', function() {
   beforeEach(function() {
     jest.resetModuleRegistry();
-
-    React = require('React');
-    ReactTestUtils = require('ReactTestUtils');
-    reactComponentExpect = require('reactComponentExpect');
   });
 
   var RefHopsAround = React.createClass({

--- a/src/shared/utils/flattenChildren.js
+++ b/src/shared/utils/flattenChildren.js
@@ -18,7 +18,11 @@ var warning = require('warning');
 
 var ReactComponentTreeDevtool;
 
-if (process.env.NODE_ENV === 'test') {
+if (
+  typeof process !== 'undefined' &&
+  process.env &&
+  process.env.NODE_ENV === 'test'
+) {
   // Temporary hack.
   // Inline requires don't work well with Jest:
   // https://github.com/facebook/react/issues/7240

--- a/src/shared/utils/flattenChildren.js
+++ b/src/shared/utils/flattenChildren.js
@@ -16,6 +16,17 @@ var KeyEscapeUtils = require('KeyEscapeUtils');
 var traverseAllChildren = require('traverseAllChildren');
 var warning = require('warning');
 
+var ReactComponentTreeDevtool;
+
+if (process.env.NODE_ENV === 'test') {
+  // Temporary hack.
+  // Inline requires don't work well with Jest:
+  // https://github.com/facebook/react/issues/7240
+  // Remove the inline requires when we don't need them anymore:
+  // https://github.com/facebook/react/pull/7178
+  ReactComponentTreeDevtool = require('ReactComponentTreeDevtool')
+}
+
 /**
  * @param {function} traverseContext Context passed through traversal.
  * @param {?ReactComponent} child React child component.
@@ -33,7 +44,9 @@ function flattenSingleChildIntoContext(
     const result = traverseContext;
     const keyUnique = (result[name] === undefined);
     if (__DEV__) {
-      var ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
+      if (!ReactComponentTreeDevtool) {
+        ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
+      }
       warning(
         keyUnique,
         'flattenChildren(...): Encountered two children with the same key, ' +


### PR DESCRIPTION
I inlined some requires in #7188 to fix the build size regression.
However this caused an issue with Jest due to it resetting module registry between tests.

This is a temporary fix to #7240.
It should be reverted as part of #7178.

Test plan:

1. Verify #7240 is fixed by following its repro instructions. You would need to build React and copy `build/modules/*` into its `node_modules/react/lib/`.

2. Verify a React example (e.g. `basic-click-counter`) in the repo runs with minified and unminified React.

3. Check that the minified build size has not increased.

Reviewers: @zpao @keyanzhang 

(Yes I know it’s super ugly. The upside is I know Jest a little better now!)