### PR TITLE
Fix TestUtils crash with NODE_ENV=production

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -410,9 +410,11 @@ NoopInternalComponent.prototype = {
 
 var ShallowComponentWrapper = function(element) {
   // TODO: Consolidate with instantiateReactComponent
-  this._debugID = nextDebugID++;
-  var displayName = element.type.displayName || element.type.name || 'Unknown';
-  ReactInstrumentation.debugTool.onSetDisplayName(this._debugID, displayName);
+  if (__DEV__) {
+    this._debugID = nextDebugID++;
+    var displayName = element.type.displayName || element.type.name || 'Unknown';
+    ReactInstrumentation.debugTool.onSetDisplayName(this._debugID, displayName);
+  }
 
   this.construct(element);
 };


### PR DESCRIPTION
I caused it with #7189.

We generally don’t recommend running TestUtils in production environment but this is technically a regression.

Fixes #7231.