### PR TITLE
Add note about refs on stateless components

### DIFF
--- a/docs/docs/08.1-more-about-refs.md
+++ b/docs/docs/08.1-more-about-refs.md
@@ -9,6 +9,10 @@ After building your component, you may find yourself wanting to "reach out" and 
 
 Let's look at how to get a ref, and then dive into a complete example.
 
+> Important:
+>
+> `ref` attributes do **not work** on [stateless/functional components](/react/docs/reusable-components.html#stateless-functions)
+
 ## The ref returned from ReactDOM.render
 
 Not to be confused with the `render()` function that you define on your component (and which returns a virtual DOM element), [ReactDOM.render()](/react/docs/top-level-api.html#reactdom.render) will return a reference to your component's **backing instance** (or `null` for [stateless components](/react/docs/reusable-components.html#stateless-functions)).

--- a/docs/docs/08.1-more-about-refs.md
+++ b/docs/docs/08.1-more-about-refs.md
@@ -11,7 +11,7 @@ Let's look at how to get a ref, and then dive into a complete example.
 
 > Important:
 >
-> `ref` attributes do **not work** on [stateless/functional components](/react/docs/reusable-components.html#stateless-functions)
+> `ref` attributes do **not work** on [stateless functional components](/react/docs/reusable-components.html#stateless-functions)
 
 ## The ref returned from ReactDOM.render
 


### PR DESCRIPTION
It was not mentioned that `ref` on stateless components does not work.

`<MyComp ref={element => this.listElement = element}/>`

If `MyComp` is a stateless/functional component then the `ref` method is always only ever called with `null`. 
No warning is issued by react. See https://github.com/facebook/react/issues/7267