### PR TITLE
Warn for functional refs on stateless functional components

### DIFF
--- a/src/renderers/shared/stack/reconciler/ReactRef.js
+++ b/src/renderers/shared/stack/reconciler/ReactRef.js
@@ -13,6 +13,7 @@
 'use strict';
 
 var ReactOwner = require('ReactOwner');
+var warning = require('warning');
 
 import type { ReactInstance } from 'ReactInstanceType';
 import type { ReactElement } from 'ReactElementType';
@@ -21,7 +22,12 @@ var ReactRef = {};
 
 function attachRef(ref, component, owner) {
   if (typeof ref === 'function') {
-    ref(component.getPublicInstance());
+    var instance = component.getPublicInstance();
+    warning(
+      instance !== null,
+      'Stateless function components cannot have refs.'
+    );
+    ref(instance);
   } else {
     // Legacy ref
     ReactOwner.addComponentAsRefTo(

--- a/src/renderers/shared/stack/reconciler/ReactRef.js
+++ b/src/renderers/shared/stack/reconciler/ReactRef.js
@@ -23,10 +23,16 @@ var ReactRef = {};
 function attachRef(ref, component, owner) {
   if (typeof ref === 'function') {
     var instance = component.getPublicInstance();
-    warning(
-      instance !== null,
-      'Stateless function components cannot have refs.'
-    );
+    if (__DEV__) {
+      var componentName = component && component.getName ?
+        component.getName() : 'a component';
+      warning(instance != null,
+        'Stateless function components cannot be given refs ' +
+        '(See %s%s).',
+        componentName,
+        owner ? ' created by ' + owner.getName() : ''
+      );
+    }
     ref(instance);
   } else {
     // Legacy ref

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactStatelessComponent-test.js
@@ -149,9 +149,9 @@ describe('ReactStatelessComponent', () => {
   it('should warn for functional refs in pure functions', function() {
     spyOn(console, 'error');
     function Child() {
-      return <div ref={node => {}} />;
+      return <div/>;
     }
-    ReactTestUtils.renderIntoDocument(<Child test="test" />);
+    ReactTestUtils.renderIntoDocument(<Child ref={node => {}} />);
     expect(console.error.calls.count()).toBe(1);
     expect(console.error.calls.argsFor(0)[0]).toContain(
       'Stateless function components cannot have refs.'

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactStatelessComponent-test.js
@@ -146,7 +146,19 @@ describe('ReactStatelessComponent', () => {
     );
   });
 
-  it('should warn when given a ref', () => {
+  it('should warn for functional refs in pure functions', function() {
+    spyOn(console, 'error');
+    function Child() {
+      return <div ref={node => {}} />;
+    }
+    ReactTestUtils.renderIntoDocument(<Child test="test" />);
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toContain(
+      'Stateless function components cannot have refs.'
+    );
+  });
+
+  it('should warn when given a ref', function() {
     spyOn(console, 'error');
 
     class Parent extends React.Component {

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactStatelessComponent-test.js
@@ -148,13 +148,19 @@ describe('ReactStatelessComponent', () => {
 
   it('should warn for functional refs in pure functions', function() {
     spyOn(console, 'error');
-    function Child() {
-      return <div/>;
-    }
-    ReactTestUtils.renderIntoDocument(<Child ref={node => {}} />);
+
+    var Parent = React.createClass({
+      displayName: 'Parent',
+      render: function() {
+        return <StatelessComponent name="A" ref={() => {}}/>;
+      },
+    });
+
+    ReactTestUtils.renderIntoDocument(<Parent />);
     expect(console.error.calls.count()).toBe(1);
     expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Stateless function components cannot have refs.'
+      'Stateless function components cannot be given refs ' +
+      '(See StatelessComponent created by Parent).',
     );
   });
 


### PR DESCRIPTION
Resolves https://github.com/facebook/react/issues/7267

Currently React warns if you do:

``` js
<StatelessComponent ref='foo' />
```

But it doesn't warn if you do

``` js
<StatelessComponent ref={node => { /* ... */ }} />
```

It seems like a generally good idea to have a consistent warning when using `refs` with any SFC.
