### PR TITLE
PropTypes: distinguish nullable from optional object field

### DIFF
--- a/src/addons/link/__tests__/ReactLinkPropTypes-test.js
+++ b/src/addons/link/__tests__/ReactLinkPropTypes-test.js
@@ -68,7 +68,8 @@ describe('ReactLink', function() {
     typeCheckFail(
       LinkPropTypes.link(React.PropTypes.any),
       {value: null, requestChange: null},
-      'Required prop `testProp.value` was not specified in `testComponent`.'
+      'Required prop `testProp.value` was specified in `testComponent`, but ' +
+        'its value is `null`.'
     );
   });
 
@@ -122,12 +123,14 @@ describe('ReactLink', function() {
   });
 
   it('should warn for missing required values', function() {
-    typeCheckFail(LinkPropTypes.link().isRequired, null, requiredMessage);
+    var specifiedButIsNullMsg = 'Required prop `testProp` was specified in ' +
+      '`testComponent`, but its value is `null`.';
+    typeCheckFail(LinkPropTypes.link().isRequired, null, specifiedButIsNullMsg);
     typeCheckFail(LinkPropTypes.link().isRequired, undefined, requiredMessage);
     typeCheckFail(
       LinkPropTypes.link(React.PropTypes.string).isRequired,
       null,
-      requiredMessage
+      specifiedButIsNullMsg
     );
     typeCheckFail(
       LinkPropTypes.link(React.PropTypes.string).isRequired,

--- a/src/addons/link/__tests__/ReactLinkPropTypes-test.js
+++ b/src/addons/link/__tests__/ReactLinkPropTypes-test.js
@@ -18,8 +18,8 @@ var ReactPropTypeLocations = require('ReactPropTypeLocations');
 var ReactPropTypesSecret = require('ReactPropTypesSecret');
 
 var invalidMessage = 'Invalid prop `testProp` supplied to `testComponent`.';
-var requiredMessage =
-  'Required prop `testProp` was not specified in `testComponent`.';
+var requiredMessage = 'The prop `testProp` is marked as required in ' +
+  '`testComponent`, but its value is `undefined`.';
 
 function typeCheckFail(declaration, value, message) {
   var props = {testProp: value};
@@ -53,23 +53,26 @@ describe('ReactLink', function() {
     typeCheckFail(
       LinkPropTypes.link(React.PropTypes.any),
       {},
-      'Required prop `testProp.value` was not specified in `testComponent`.'
+      'The prop `testProp.value` is marked as required in `testComponent`, ' +
+        'but its value is `undefined`.'
     );
     typeCheckFail(
       LinkPropTypes.link(React.PropTypes.any),
       {value: 123},
-      'Required prop `testProp.requestChange` was not specified in `testComponent`.'
+      'The prop `testProp.requestChange` is marked as required in ' +
+        '`testComponent`, but its value is `undefined`.'
     );
     typeCheckFail(
       LinkPropTypes.link(React.PropTypes.any),
       {requestChange: emptyFunction},
-      'Required prop `testProp.value` was not specified in `testComponent`.'
+      'The prop `testProp.value` is marked as required in `testComponent`, ' +
+        'but its value is `undefined`.'
     );
     typeCheckFail(
       LinkPropTypes.link(React.PropTypes.any),
       {value: null, requestChange: null},
-      'Required prop `testProp.value` was specified in `testComponent`, but ' +
-        'its value is `null`.'
+      'The prop `testProp.value` is marked as required in `testComponent`, ' +
+        'but its value is `null`.'
     );
   });
 
@@ -123,8 +126,8 @@ describe('ReactLink', function() {
   });
 
   it('should warn for missing required values', function() {
-    var specifiedButIsNullMsg = 'Required prop `testProp` was specified in ' +
-      '`testComponent`, but its value is `null`.';
+    var specifiedButIsNullMsg = 'The prop `testProp` is marked as required ' +
+      'in `testComponent`, but its value is `null`.';
     typeCheckFail(LinkPropTypes.link().isRequired, null, specifiedButIsNullMsg);
     typeCheckFail(LinkPropTypes.link().isRequired, undefined, requiredMessage);
     typeCheckFail(

--- a/src/isomorphic/classic/__tests__/ReactContextValidator-test.js
+++ b/src/isomorphic/classic/__tests__/ReactContextValidator-test.js
@@ -152,7 +152,8 @@ describe('ReactContextValidator', function() {
     expect(console.error.calls.count()).toBe(1);
     expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
       'Warning: Failed context type: ' +
-      'Required context `foo` was not specified in `Component`.\n' +
+      'The context `foo` is marked as required in `Component`, but its value ' +
+      'is `undefined`.\n' +
       '    in Component (at **)'
     );
 
@@ -229,7 +230,8 @@ describe('ReactContextValidator', function() {
     expect(console.error.calls.count()).toBe(1);
     expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
       'Warning: Failed childContext type: ' +
-      'Required child context `foo` was not specified in `Component`.\n' +
+      'The child context `foo` is marked as required in `Component`, but its ' +
+      'value is `undefined`.\n' +
       '    in Component (at **)'
     );
 

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -360,8 +360,8 @@ describe('ReactElementValidator', function() {
 
     expect(console.error.calls.count()).toBe(1);
     expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: Failed prop type: ' +
-      'Required prop `prop` was not specified in `Component`.\n' +
+      'Warning: Failed prop type: Required prop `prop` was specified in ' +
+      '`Component`, but its value is `null`.\n' +
       '    in Component'
     );
   });
@@ -385,8 +385,8 @@ describe('ReactElementValidator', function() {
 
     expect(console.error.calls.count()).toBe(1);
     expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: Failed prop type: ' +
-      'Required prop `prop` was not specified in `Component`.\n' +
+      'Warning: Failed prop type: Required prop `prop` was specified in ' +
+      '`Component`, but its value is `null`.\n' +
       '    in Component'
     );
   });

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -360,7 +360,7 @@ describe('ReactElementValidator', function() {
 
     expect(console.error.calls.count()).toBe(1);
     expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: Failed prop type: Required prop `prop` was specified in ' +
+      'Warning: Failed prop type: The prop `prop` is marked as required in ' +
       '`Component`, but its value is `null`.\n' +
       '    in Component'
     );
@@ -385,7 +385,7 @@ describe('ReactElementValidator', function() {
 
     expect(console.error.calls.count()).toBe(1);
     expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: Failed prop type: Required prop `prop` was specified in ' +
+      'Warning: Failed prop type: The prop `prop` is marked as required in ' +
       '`Component`, but its value is `null`.\n' +
       '    in Component'
     );
@@ -413,7 +413,8 @@ describe('ReactElementValidator', function() {
     expect(console.error.calls.count()).toBe(2);
     expect(console.error.calls.argsFor(0)[0]).toBe(
       'Warning: Failed prop type: ' +
-      'Required prop `prop` was not specified in `Component`.\n' +
+      'The prop `prop` is marked as required in `Component`, but its value ' +
+      'is `undefined`.\n' +
       '    in Component'
     );
 

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -146,13 +146,13 @@ function createChainableTypeChecker(validate) {
       if (isRequired) {
         if (props[propName] === null) {
           return new Error(
-            `Required ${locationName} \`${propFullName}\` was specified in ` +
-            `\`${componentName}\`, but its value is \`null\`.`
+            `The ${locationName} \`${propFullName}\` is marked as required ` +
+            `in \`${componentName}\`, but its value is \`null\`.`
           );
         }
         return new Error(
-          `Required ${locationName} \`${propFullName}\` was not specified in ` +
-          `\`${componentName}\`.`
+          `The ${locationName} \`${propFullName}\` is marked as required in ` +
+          `\`${componentName}\`, but its value is \`undefined\`.`
         );
       }
       return null;

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -144,6 +144,12 @@ function createChainableTypeChecker(validate) {
     if (props[propName] == null) {
       var locationName = ReactPropTypeLocationNames[location];
       if (isRequired) {
+        if (props[propName] === null) {
+          return new Error(
+            `Required ${locationName} \`${propFullName}\` was specified in ` +
+            `\`${componentName}\`, but its value is \`null\`.`
+          );
+        }
         return new Error(
           `Required ${locationName} \`${propFullName}\` was not specified in ` +
           `\`${componentName}\`.`

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -36,10 +36,10 @@ function typeCheckFail(declaration, value, message) {
 }
 
 function typeCheckFailRequiredValues(declaration) {
-  var specifiedButIsNullMsg = 'Required prop `testProp` was specified in ' +
-  '`testComponent`, but its value is `null`.';
-  var unspecifiedMsg =
-    'Required prop `testProp` was not specified in `testComponent`.';
+  var specifiedButIsNullMsg = 'The prop `testProp` is marked as required in ' +
+    '`testComponent`, but its value is `null`.';
+  var unspecifiedMsg = 'The prop `testProp` is marked as required in ' +
+    '`testComponent`, but its value is \`undefined\`.';
   var props1 = {testProp: null};
   var error1 = declaration(
     props1,
@@ -941,7 +941,8 @@ describe('ReactPropTypes', function() {
       typeCheckFail(
         PropTypes.shape({key: PropTypes.number.isRequired}),
         {},
-        'Required prop `testProp.key` was not specified in `testComponent`.'
+        'The prop `testProp.key` is marked as required in `testComponent`, ' +
+          'but its value is `undefined`.'
       );
     });
 
@@ -952,7 +953,8 @@ describe('ReactPropTypes', function() {
           secondKey: PropTypes.number.isRequired,
         }),
         {},
-        'Required prop `testProp.key` was not specified in `testComponent`.'
+        'The prop `testProp.key` is marked as required in `testComponent`, ' +
+          'but its value is `undefined`.'
       );
     });
 

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -49,6 +49,7 @@ function typeCheckFailRequiredValues(declaration) {
     null,
     ReactPropTypesSecret
   );
+  expect(error1 instanceof Error).toBe(true);
   expect(error1.message).toBe(specifiedButIsNullMsg);
   var props2 = {testProp: undefined};
   var error2 = declaration(

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -20,8 +20,6 @@ var ReactPropTypesSecret;
 
 var Component;
 var MyComponent;
-var requiredMessage =
-  'Required prop `testProp` was not specified in `testComponent`.';
 
 function typeCheckFail(declaration, value, message) {
   var props = {testProp: value};
@@ -35,6 +33,45 @@ function typeCheckFail(declaration, value, message) {
   );
   expect(error instanceof Error).toBe(true);
   expect(error.message).toBe(message);
+}
+
+function typeCheckFailRequiredValues(declaration) {
+  var specifiedButIsNullMsg = 'Required prop `testProp` was specified in ' +
+  '`testComponent`, but its value is `null`.';
+  var unspecifiedMsg =
+    'Required prop `testProp` was not specified in `testComponent`.';
+  var props1 = {testProp: null};
+  var error1 = declaration(
+    props1,
+    'testProp',
+    'testComponent',
+    ReactPropTypeLocations.prop,
+    null,
+    ReactPropTypesSecret
+  );
+  expect(error1.message).toBe(specifiedButIsNullMsg);
+  var props2 = {testProp: undefined};
+  var error2 = declaration(
+    props2,
+    'testProp',
+    'testComponent',
+    ReactPropTypeLocations.prop,
+    null,
+    ReactPropTypesSecret
+  );
+  expect(error2 instanceof Error).toBe(true);
+  expect(error2.message).toBe(unspecifiedMsg);
+  var props3 = {};
+  var error3 = declaration(
+    props3,
+    'testProp',
+    'testComponent',
+    ReactPropTypeLocations.prop,
+    null,
+    ReactPropTypesSecret
+  );
+  expect(error3 instanceof Error).toBe(true);
+  expect(error3.message).toBe(unspecifiedMsg);
 }
 
 function typeCheckPass(declaration, value) {
@@ -146,8 +183,7 @@ describe('ReactPropTypes', function() {
     });
 
     it('should warn for missing required values', function() {
-      typeCheckFail(PropTypes.string.isRequired, null, requiredMessage);
-      typeCheckFail(PropTypes.string.isRequired, undefined, requiredMessage);
+      typeCheckFailRequiredValues(PropTypes.string.isRequired);
     });
 
     it('should warn if called manually in development', function() {
@@ -213,8 +249,7 @@ describe('ReactPropTypes', function() {
     });
 
     it('should warn for missing required values', function() {
-      typeCheckFail(PropTypes.any.isRequired, null, requiredMessage);
-      typeCheckFail(PropTypes.any.isRequired, undefined, requiredMessage);
+      typeCheckFailRequiredValues(PropTypes.any.isRequired);
     });
 
     it('should warn if called manually in development', function() {
@@ -307,15 +342,8 @@ describe('ReactPropTypes', function() {
     });
 
     it('should warn for missing required values', function() {
-      typeCheckFail(
-        PropTypes.arrayOf(PropTypes.number).isRequired,
-        null,
-        requiredMessage
-      );
-      typeCheckFail(
-        PropTypes.arrayOf(PropTypes.number).isRequired,
-        undefined,
-        requiredMessage
+      typeCheckFailRequiredValues(
+        PropTypes.arrayOf(PropTypes.number).isRequired
       );
     });
 
@@ -406,8 +434,7 @@ describe('ReactPropTypes', function() {
     });
 
     it('should warn for missing required values', function() {
-      typeCheckFail(PropTypes.element.isRequired, null, requiredMessage);
-      typeCheckFail(PropTypes.element.isRequired, undefined, requiredMessage);
+      typeCheckFailRequiredValues(PropTypes.element.isRequired);
     });
 
     it('should warn if called manually in development', function() {
@@ -493,12 +520,7 @@ describe('ReactPropTypes', function() {
     });
 
     it('should warn for missing required values', function() {
-      typeCheckFail(
-        PropTypes.instanceOf(String).isRequired, null, requiredMessage
-      );
-      typeCheckFail(
-        PropTypes.instanceOf(String).isRequired, undefined, requiredMessage
-      );
+      typeCheckFailRequiredValues(PropTypes.instanceOf(String).isRequired);
     });
 
     it('should warn if called manually in development', function() {
@@ -601,16 +623,7 @@ describe('ReactPropTypes', function() {
     });
 
     it('should warn for missing required values', function() {
-      typeCheckFail(
-        PropTypes.node.isRequired,
-        null,
-        'Required prop `testProp` was not specified in `testComponent`.'
-      );
-      typeCheckFail(
-        PropTypes.node.isRequired,
-        undefined,
-        'Required prop `testProp` was not specified in `testComponent`.'
-      );
+      typeCheckFailRequiredValues(PropTypes.node.isRequired);
     });
 
     it('should accept empty array for required props', function() {
@@ -724,15 +737,8 @@ describe('ReactPropTypes', function() {
     });
 
     it('should warn for missing required values', function() {
-      typeCheckFail(
-        PropTypes.objectOf(PropTypes.number).isRequired,
-        null,
-        requiredMessage
-      );
-      typeCheckFail(
-        PropTypes.objectOf(PropTypes.number).isRequired,
-        undefined,
-        requiredMessage
+      typeCheckFailRequiredValues(
+        PropTypes.objectOf(PropTypes.number).isRequired
       );
     });
 
@@ -804,16 +810,7 @@ describe('ReactPropTypes', function() {
     });
 
     it('should warn for missing required values', function() {
-      typeCheckFail(
-        PropTypes.oneOf(['red', 'blue']).isRequired,
-        null,
-        requiredMessage
-      );
-      typeCheckFail(
-        PropTypes.oneOf(['red', 'blue']).isRequired,
-        undefined,
-        requiredMessage
-      );
+      typeCheckFailRequiredValues(PropTypes.oneOf(['red', 'blue']).isRequired);
     });
 
     it('should warn if called manually in development', function() {
@@ -882,15 +879,8 @@ describe('ReactPropTypes', function() {
     });
 
     it('should warn for missing required values', function() {
-      typeCheckFail(
-        PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-        null,
-        requiredMessage
-      );
-      typeCheckFail(
-        PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-        undefined,
-        requiredMessage
+      typeCheckFailRequiredValues(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
       );
     });
 
@@ -983,15 +973,8 @@ describe('ReactPropTypes', function() {
     });
 
     it('should warn for missing required values', function() {
-      typeCheckFail(
-        PropTypes.shape({key: PropTypes.number}).isRequired,
-        null,
-        requiredMessage
-      );
-      typeCheckFail(
-        PropTypes.shape({key: PropTypes.number}).isRequired,
-        undefined,
-        requiredMessage
+      typeCheckFailRequiredValues(
+        PropTypes.shape({key: PropTypes.number}).isRequired
       );
     });
 

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -249,8 +249,8 @@ describe('ReactJSXElementValidator', function() {
     expect(
       console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
     ).toBe(
-      'Warning: Failed prop type: ' +
-      'Required prop `prop` was not specified in `RequiredPropComponent`.\n' +
+      'Warning: Failed prop type: Required prop `prop` was specified in ' +
+      '`RequiredPropComponent`, but its value is `null`.\n' +
       '    in RequiredPropComponent (at **)'
     );
   });
@@ -264,8 +264,8 @@ describe('ReactJSXElementValidator', function() {
     expect(
       console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
     ).toBe(
-      'Warning: Failed prop type: ' +
-      'Required prop `prop` was not specified in `RequiredPropComponent`.\n' +
+      'Warning: Failed prop type: Required prop `prop` was specified in ' +
+      '`RequiredPropComponent`, but its value is `null`.\n' +
       '    in RequiredPropComponent (at **)'
     );
   });

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -249,7 +249,7 @@ describe('ReactJSXElementValidator', function() {
     expect(
       console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
     ).toBe(
-      'Warning: Failed prop type: Required prop `prop` was specified in ' +
+      'Warning: Failed prop type: The prop `prop` is marked as required in ' +
       '`RequiredPropComponent`, but its value is `null`.\n' +
       '    in RequiredPropComponent (at **)'
     );
@@ -264,7 +264,7 @@ describe('ReactJSXElementValidator', function() {
     expect(
       console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
     ).toBe(
-      'Warning: Failed prop type: Required prop `prop` was specified in ' +
+      'Warning: Failed prop type: The prop `prop` is marked as required in ' +
       '`RequiredPropComponent`, but its value is `null`.\n' +
       '    in RequiredPropComponent (at **)'
     );
@@ -281,7 +281,8 @@ describe('ReactJSXElementValidator', function() {
       console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
     ).toBe(
       'Warning: Failed prop type: ' +
-      'Required prop `prop` was not specified in `RequiredPropComponent`.\n' +
+      'The prop `prop` is marked as required in `RequiredPropComponent`, but ' +
+      'its value is `undefined`.\n' +
       '    in RequiredPropComponent (at **)'
     );
 

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -296,8 +296,8 @@ describe('ReactTestUtils', function() {
     expect(
       console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
     ).toBe(
-      'Warning: Failed context type: Required context `name` was not ' +
-      'specified in `SimpleComponent`.\n' +
+      'Warning: Failed context type: The context `name` is marked as ' +
+      'required in `SimpleComponent`, but its value is `undefined`.\n' +
       '    in SimpleComponent (at **)'
     );
   });


### PR DESCRIPTION
This gives a more precise message (no type semantics change) to the case of passing a field in an object, but whose value is `null`:

Before:

```js
propTypes: {
  foo: React.PropTypes.number.isRequired
}
```

Would scream "Required prop `foo` was not specified in `MyComp`".

Now it'll be "Required prop `foo` was specified in `MyComp`, but its value is `null`.".

Works as expected in nested objects.

This fixes the issue of a component transitively passing a `null`, specifying the correct field to the child but have the child tell it that it didn't provide the prop.

Optional field and nullable are two different things anyway.