### PR TITLE
Update tutorial.md

### DIFF
--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -57,7 +57,7 @@ For this tutorial, we're going to make it as easy as possible. Included in the s
 </html>
 ```
 
-For the remainder of this tutorial, we'll be writing our JavaScript code in this script tag. We don't have any advanced live-reloading so you'll need to refresh your browser to see updates after saving. Follow your progress by opening `http://localhost:3000` in your browser (after starting the server). When you load this for the first time without any changes, you'll see the finished product of what we're going to build. When you're ready to start working, just delete the preceding `<script>` tag and then you can continue.
+For the remainder of this tutorial, we'll be writing our JavaScript code in this script tag. We don't have any advanced live-reloading so you'll need to refresh your browser to see updates after saving. Follow your progress by opening `http://localhost:3000` in your browser (after starting the server). When you load this for the first time without any changes, you'll see the finished product of what we're going to build. When you're ready to start working, just delete the preceding `<script type="text/babel" src="scripts/example.js"></script>` tags and then you can continue.
 
 > Note:
 >


### PR DESCRIPTION
Changed the directions in the Getting Started to be more clear on which `<script>` tag to remove. A number of students in our coding bootcamp were not clear about this and missed the reference. I believe this helps clarify by being more specific.