### PR TITLE
Allow custom attributes by default

### DIFF
--- a/docs/warnings/unknown-prop.md
+++ b/docs/warnings/unknown-prop.md
@@ -3,7 +3,7 @@ title: Unknown Prop Warning
 layout: single
 permalink: warnings/unknown-prop.html
 ---
-The unknown-prop warning will fire if you attempt to render a DOM element with a prop that is not recognized by React as a legal DOM attribute/property. You should ensure that your DOM elements do not have spurious props floating around.
+The unknown-prop warning will fire if you attempt to render a DOM element with a prop that is either unrecognized by React as a legal DOM attribute/property, or is not a string, number, or boolean value. You should ensure that your DOM elements do not have spurious props floating around.
 
 There are a couple of likely reasons this warning could be appearing:
 

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -231,10 +231,7 @@ function setInitialDOMProperties(
       }
     } else if (isCustomComponentTag) {
       DOMPropertyOperations.setValueForAttribute(domElement, propKey, nextProp);
-    } else if (
-      DOMProperty.properties[propKey] ||
-      DOMProperty.isCustomAttribute(propKey)
-    ) {
+    } else if (DOMProperty.isWriteableAttribute(propKey)) {
       // If we're updating to null or undefined, we should remove the property
       // from the DOM node instead of inadvertently setting to a string. This
       // brings us in line with the same behavior we have on initial render.
@@ -275,10 +272,7 @@ function updateDOMProperties(
       } else {
         DOMPropertyOperations.deleteValueForAttribute(domElement, propKey);
       }
-    } else if (
-      DOMProperty.properties[propKey] ||
-      DOMProperty.isCustomAttribute(propKey)
-    ) {
+    } else if (DOMProperty.isWriteableAttribute(propKey)) {
       // If we're updating to null or undefined, we should remove the property
       // from the DOM node instead of inadvertently setting to a string. This
       // brings us in line with the same behavior we have on initial render.
@@ -1019,28 +1013,27 @@ var ReactDOMFiberComponent = {
           if (expectedStyle !== serverValue) {
             warnForPropDifference(propKey, serverValue, expectedStyle);
           }
-        } else if (
-          isCustomComponentTag ||
-          DOMProperty.isCustomAttribute(propKey)
-        ) {
-          // $FlowFixMe - Should be inferred as not undefined.
-          extraAttributeNames.delete(propKey);
-          serverValue = DOMPropertyOperations.getValueForAttribute(
-            domElement,
-            propKey,
-            nextProp,
-          );
-          if (nextProp !== serverValue) {
-            warnForPropDifference(propKey, serverValue, nextProp);
+        } else if (DOMProperty.isWriteableAttribute(propKey)) {
+          propertyInfo = DOMProperty.properties[propKey];
+
+          if (!isCustomComponentTag && propertyInfo) {
+            // $FlowFixMe - Should be inferred as not undefined.
+            extraAttributeNames.delete(propertyInfo.attributeName);
+            serverValue = DOMPropertyOperations.getValueForProperty(
+              domElement,
+              propKey,
+              nextProp,
+            );
+          } else {
+            // $FlowFixMe - Should be inferred as not undefined.
+            extraAttributeNames.delete(propKey);
+            serverValue = DOMPropertyOperations.getValueForAttribute(
+              domElement,
+              propKey,
+              nextProp,
+            );
           }
-        } else if ((propertyInfo = DOMProperty.properties[propKey])) {
-          // $FlowFixMe - Should be inferred as not undefined.
-          extraAttributeNames.delete(propertyInfo.attributeName);
-          serverValue = DOMPropertyOperations.getValueForProperty(
-            domElement,
-            propKey,
-            nextProp,
-          );
+
           if (nextProp !== serverValue) {
             warnForPropDifference(propKey, serverValue, nextProp);
           }

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -231,7 +231,7 @@ function setInitialDOMProperties(
       }
     } else if (isCustomComponentTag) {
       DOMPropertyOperations.setValueForAttribute(domElement, propKey, nextProp);
-    } else if (DOMProperty.isWriteable(propKey, nextProp)) {
+    } else if (DOMProperty.shouldSetAttribute(propKey, nextProp)) {
       // If we're updating to null or undefined, we should remove the property
       // from the DOM node instead of inadvertently setting to a string. This
       // brings us in line with the same behavior we have on initial render.
@@ -272,7 +272,7 @@ function updateDOMProperties(
       } else {
         DOMPropertyOperations.deleteValueForAttribute(domElement, propKey);
       }
-    } else if (DOMProperty.isWriteable(propKey, propValue)) {
+    } else if (DOMProperty.shouldSetAttribute(propKey, propValue)) {
       // If we're updating to null or undefined, we should remove the property
       // from the DOM node instead of inadvertently setting to a string. This
       // brings us in line with the same behavior we have on initial render.
@@ -1013,7 +1013,7 @@ var ReactDOMFiberComponent = {
           if (expectedStyle !== serverValue) {
             warnForPropDifference(propKey, serverValue, expectedStyle);
           }
-        } else if (DOMProperty.isWriteable(propKey, nextProp)) {
+        } else if (DOMProperty.shouldSetAttribute(propKey, nextProp)) {
           propertyInfo = DOMProperty.properties[propKey];
 
           if (!isCustomComponentTag && propertyInfo) {

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -231,7 +231,7 @@ function setInitialDOMProperties(
       }
     } else if (isCustomComponentTag) {
       DOMPropertyOperations.setValueForAttribute(domElement, propKey, nextProp);
-    } else if (DOMProperty.isWriteableAttribute(propKey)) {
+    } else if (DOMProperty.isWriteable(propKey, nextProp)) {
       // If we're updating to null or undefined, we should remove the property
       // from the DOM node instead of inadvertently setting to a string. This
       // brings us in line with the same behavior we have on initial render.
@@ -272,7 +272,7 @@ function updateDOMProperties(
       } else {
         DOMPropertyOperations.deleteValueForAttribute(domElement, propKey);
       }
-    } else if (DOMProperty.isWriteableAttribute(propKey)) {
+    } else if (DOMProperty.isWriteable(propKey, propValue)) {
       // If we're updating to null or undefined, we should remove the property
       // from the DOM node instead of inadvertently setting to a string. This
       // brings us in line with the same behavior we have on initial render.
@@ -1013,7 +1013,7 @@ var ReactDOMFiberComponent = {
           if (expectedStyle !== serverValue) {
             warnForPropDifference(propKey, serverValue, expectedStyle);
           }
-        } else if (DOMProperty.isWriteableAttribute(propKey)) {
+        } else if (DOMProperty.isWriteable(propKey, nextProp)) {
           propertyInfo = DOMProperty.properties[propKey];
 
           if (!isCustomComponentTag && propertyInfo) {

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -1015,7 +1015,7 @@ var ReactDOMFiberComponent = {
           }
         } else if (isCustomComponentTag) {
           // $FlowFixMe - Should be inferred as not undefined.
-          extraAttributeNames.delete(propKey);
+          extraAttributeNames.delete(propKey.toLowerCase());
           serverValue = DOMPropertyOperations.getValueForAttribute(
             domElement,
             propKey,

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -922,8 +922,7 @@ var ReactDOMFiberComponent = {
       var extraAttributeNames: Set<string> = new Set();
       var attributes = domElement.attributes;
       for (var i = 0; i < attributes.length; i++) {
-        // TODO: Do we need to lower case this to get case insensitive matches?
-        var name = attributes[i].name;
+        var name = attributes[i].name.toLowerCase();
         switch (name) {
           // Built-in attributes are whitelisted
           // TODO: Once these are gone from the server renderer, we don't need

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -1013,10 +1013,20 @@ var ReactDOMFiberComponent = {
           if (expectedStyle !== serverValue) {
             warnForPropDifference(propKey, serverValue, expectedStyle);
           }
-        } else if (DOMProperty.shouldSetAttribute(propKey, nextProp)) {
-          propertyInfo = DOMProperty.properties[propKey];
+        } else if (isCustomComponentTag) {
+          // $FlowFixMe - Should be inferred as not undefined.
+          extraAttributeNames.delete(propKey);
+          serverValue = DOMPropertyOperations.getValueForAttribute(
+            domElement,
+            propKey,
+            nextProp,
+          );
 
-          if (!isCustomComponentTag && propertyInfo) {
+          if (nextProp !== serverValue) {
+            warnForPropDifference(propKey, serverValue, nextProp);
+          }
+        } else if (DOMProperty.shouldSetAttribute(propKey, nextProp)) {
+          if ((propertyInfo = DOMProperty.properties[propKey])) {
             // $FlowFixMe - Should be inferred as not undefined.
             extraAttributeNames.delete(propertyInfo.attributeName);
             serverValue = DOMPropertyOperations.getValueForProperty(

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -1036,7 +1036,7 @@ var ReactDOMFiberComponent = {
             );
           } else {
             // $FlowFixMe - Should be inferred as not undefined.
-            extraAttributeNames.delete(propKey);
+            extraAttributeNames.delete(propKey.toLowerCase());
             serverValue = DOMPropertyOperations.getValueForAttribute(
               domElement,
               propKey,

--- a/src/renderers/dom/shared/DOMMarkupOperations.js
+++ b/src/renderers/dom/shared/DOMMarkupOperations.js
@@ -103,7 +103,7 @@ var DOMMarkupOperations = {
         return attributeName + '=""';
       }
       return attributeName + '=' + quoteAttributeValueForBrowser(value);
-    } else if (DOMProperty.isCustomAttribute(name)) {
+    } else if (DOMProperty.isWriteableAttribute(name)) {
       if (value == null) {
         return '';
       }

--- a/src/renderers/dom/shared/DOMMarkupOperations.js
+++ b/src/renderers/dom/shared/DOMMarkupOperations.js
@@ -103,7 +103,7 @@ var DOMMarkupOperations = {
         return attributeName + '=""';
       }
       return attributeName + '=' + quoteAttributeValueForBrowser(value);
-    } else if (DOMProperty.isWriteableAttribute(name)) {
+    } else if (DOMProperty.isWriteable(name, value)) {
       if (value == null) {
         return '';
       }

--- a/src/renderers/dom/shared/DOMMarkupOperations.js
+++ b/src/renderers/dom/shared/DOMMarkupOperations.js
@@ -103,7 +103,7 @@ var DOMMarkupOperations = {
         return attributeName + '=""';
       }
       return attributeName + '=' + quoteAttributeValueForBrowser(value);
-    } else if (DOMProperty.isWriteable(name, value)) {
+    } else if (DOMProperty.shouldSetAttribute(name, value)) {
       if (value == null) {
         return '';
       }

--- a/src/renderers/dom/shared/DOMProperty.js
+++ b/src/renderers/dom/shared/DOMProperty.js
@@ -16,9 +16,6 @@ var invariant = require('fbjs/lib/invariant');
 var RESERVED_PROPS = {
   children: true,
   dangerouslySetInnerHTML: true,
-  key: true,
-  ref: true,
-
   autoFocus: true,
   defaultValue: true,
   defaultChecked: true,

--- a/src/renderers/dom/shared/DOMProperty.js
+++ b/src/renderers/dom/shared/DOMProperty.js
@@ -11,7 +11,6 @@
 
 'use strict';
 
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 var invariant = require('fbjs/lib/invariant');
 
 var RESERVED_PROPS = {
@@ -47,11 +46,6 @@ var DOMPropertyInjection = {
   /**
    * Inject some specialized knowledge about the DOM. This takes a config object
    * with the following properties:
-   *
-   * isCustomAttribute: function that given an attribute name will return true
-   * if it can be inserted into the DOM verbatim. Useful for data-* or aria-*
-   * attributes where it's impossible to enumerate all of the possible
-   * attribute names,
    *
    * Properties: object mapping DOM property name to one of the
    * DOMPropertyInjection constants or null. If your attribute isn't in here,
@@ -246,19 +240,20 @@ var DOMProperty = {
    * Checks whether a property name is a writeable attribute.
    * @method
    */
-  isWriteableAttribute: function(attributeName) {
-    if (DOMProperty.isReservedProp(attributeName)) {
+  isWriteable: function(name, value) {
+    if (DOMProperty.isReservedProp(name)) {
       return false;
     }
 
-    if (
-      ReactDOMFeatureFlags.allowCustomAttributes ||
-      DOMProperty.properties[attributeName]
-    ) {
+    if (value == null || DOMProperty.properties.hasOwnProperty(name)) {
       return true;
     }
 
-    return this.isCustomAttribute(attributeName);
+    if (DOMProperty.isCustomAttribute(name)) {
+      return true;
+    }
+
+    return typeof value === 'string';
   },
 
   /**

--- a/src/renderers/dom/shared/DOMProperty.js
+++ b/src/renderers/dom/shared/DOMProperty.js
@@ -11,7 +11,23 @@
 
 'use strict';
 
+var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 var invariant = require('fbjs/lib/invariant');
+
+var RESERVED_PROPS = {
+  children: true,
+  dangerouslySetInnerHTML: true,
+  key: true,
+  ref: true,
+
+  autoFocus: true,
+  defaultValue: true,
+  defaultChecked: true,
+  innerHTML: true,
+  suppressContentEditableWarning: true,
+  onFocusIn: true,
+  onFocusOut: true,
+};
 
 function checkMask(value, bitmask) {
   return (value & bitmask) === bitmask;
@@ -224,6 +240,38 @@ var DOMProperty = {
       }
     }
     return false;
+  },
+
+  /**
+   * Checks whether a property name is a writeable attribute.
+   * @method
+   */
+  isWriteableAttribute: function(attributeName) {
+    if (DOMProperty.isReservedProp(attributeName)) {
+      return false;
+    }
+
+    if (
+      ReactDOMFeatureFlags.allowCustomAttributes ||
+      DOMProperty.properties[attributeName]
+    ) {
+      return true;
+    }
+
+    return this.isCustomAttribute(attributeName);
+  },
+
+  /**
+   * Checks to see if a property name is within the list of properties
+   * reserved for internal React operations. These properties should
+   * not be set on an HTML element.
+   *
+   * @private
+   * @param {string} name
+   * @return {boolean} If the name is within reserved props
+   */
+  isReservedProp(name) {
+    return RESERVED_PROPS.hasOwnProperty(name);
   },
 
   injection: DOMPropertyInjection,

--- a/src/renderers/dom/shared/DOMProperty.js
+++ b/src/renderers/dom/shared/DOMProperty.js
@@ -220,13 +220,24 @@ var DOMProperty = {
       return false;
     }
 
-    if (value == null || DOMProperty.properties.hasOwnProperty(name)) {
+    let type = typeof value;
+
+    if (
+      value === null ||
+      type === 'undefined' ||
+      DOMProperty.properties.hasOwnProperty(name)
+    ) {
       return true;
     }
 
-    let type = typeof value;
-
-    return type !== 'function' && type !== 'object';
+    switch (type) {
+      case 'boolean':
+      case 'number':
+      case 'string':
+        return true;
+      default:
+        return false;
+    }
   },
 
   /**

--- a/src/renderers/dom/shared/DOMProperty.js
+++ b/src/renderers/dom/shared/DOMProperty.js
@@ -215,7 +215,7 @@ var DOMProperty = {
    * Checks whether a property name is a writeable attribute.
    * @method
    */
-  isWriteable: function(name, value) {
+  shouldSetAttribute: function(name, value) {
     if (DOMProperty.isReservedProp(name)) {
       return false;
     }

--- a/src/renderers/dom/shared/DOMProperty.js
+++ b/src/renderers/dom/shared/DOMProperty.js
@@ -74,12 +74,6 @@ var DOMPropertyInjection = {
     var DOMPropertyNames = domPropertyConfig.DOMPropertyNames || {};
     var DOMMutationMethods = domPropertyConfig.DOMMutationMethods || {};
 
-    if (domPropertyConfig.isCustomAttribute) {
-      DOMProperty._isCustomAttributeFunctions.push(
-        domPropertyConfig.isCustomAttribute,
-      );
-    }
-
     for (var propName in Properties) {
       invariant(
         !DOMProperty.properties.hasOwnProperty(propName),
@@ -218,25 +212,6 @@ var DOMProperty = {
   getPossibleStandardName: __DEV__ ? {autofocus: 'autoFocus'} : null,
 
   /**
-   * All of the isCustomAttribute() functions that have been injected.
-   */
-  _isCustomAttributeFunctions: [],
-
-  /**
-   * Checks whether a property name is a custom attribute.
-   * @method
-   */
-  isCustomAttribute: function(attributeName) {
-    for (var i = 0; i < DOMProperty._isCustomAttributeFunctions.length; i++) {
-      var isCustomAttributeFn = DOMProperty._isCustomAttributeFunctions[i];
-      if (isCustomAttributeFn(attributeName)) {
-        return true;
-      }
-    }
-    return false;
-  },
-
-  /**
    * Checks whether a property name is a writeable attribute.
    * @method
    */
@@ -249,11 +224,9 @@ var DOMProperty = {
       return true;
     }
 
-    if (DOMProperty.isCustomAttribute(name)) {
-      return true;
-    }
+    let type = typeof value;
 
-    return typeof value === 'string';
+    return type !== 'function' && type !== 'object';
   },
 
   /**

--- a/src/renderers/dom/shared/DOMProperty.js
+++ b/src/renderers/dom/shared/DOMProperty.js
@@ -230,17 +230,20 @@ var DOMProperty = {
       return false;
     }
 
-    let type = typeof value;
-
-    if (
-      value === null ||
-      type === 'undefined' ||
-      DOMProperty.properties.hasOwnProperty(name)
-    ) {
+    if (DOMProperty.properties.hasOwnProperty(name)) {
       return true;
     }
 
-    switch (type) {
+    if (value === null) {
+      return true;
+    }
+
+    if (name.toLowerCase() !== name) {
+      return false;
+    }
+
+    switch (typeof value) {
+      case 'undefined':
       case 'boolean':
       case 'number':
       case 'string':

--- a/src/renderers/dom/shared/DOMProperty.js
+++ b/src/renderers/dom/shared/DOMProperty.js
@@ -119,7 +119,11 @@ var DOMPropertyInjection = {
       if (DOMAttributeNames.hasOwnProperty(propName)) {
         var attributeName = DOMAttributeNames[propName];
 
-        DOMProperty.aliases[attributeName] = true;
+        DOMProperty.aliases[attributeName.toLowerCase()] = true;
+
+        if (lowerCased !== attributeName) {
+          DOMProperty.aliases[lowerCased] = true;
+        }
 
         propertyInfo.attributeName = attributeName;
         if (__DEV__) {
@@ -236,10 +240,6 @@ var DOMProperty = {
 
     if (value === null) {
       return true;
-    }
-
-    if (name.toLowerCase() !== name) {
-      return false;
     }
 
     switch (typeof value) {

--- a/src/renderers/dom/shared/DOMProperty.js
+++ b/src/renderers/dom/shared/DOMProperty.js
@@ -118,6 +118,9 @@ var DOMPropertyInjection = {
 
       if (DOMAttributeNames.hasOwnProperty(propName)) {
         var attributeName = DOMAttributeNames[propName];
+
+        DOMProperty.aliases[attributeName] = true;
+
         propertyInfo.attributeName = attributeName;
         if (__DEV__) {
           DOMProperty.getPossibleStandardName[attributeName] = propName;
@@ -198,6 +201,13 @@ var DOMProperty = {
   properties: {},
 
   /**
+   * Some attributes are aliased for easier use within React. We don't
+   * allow direct use of these attributes. See DOMAttributeNames in
+   * HTMLPropertyConfig and SVGPropertyConfig.
+   */
+  aliases: {},
+
+  /**
    * Mapping from lowercase property names to the properly cased version, used
    * to warn in the case of missing properties. Available only in __DEV__.
    *
@@ -213,7 +223,10 @@ var DOMProperty = {
    * @method
    */
   shouldSetAttribute: function(name, value) {
-    if (DOMProperty.isReservedProp(name)) {
+    if (
+      DOMProperty.isReservedProp(name) ||
+      DOMProperty.aliases.hasOwnProperty(name)
+    ) {
       return false;
     }
 

--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -194,7 +194,7 @@ var DOMPropertyOperations = {
           node.setAttribute(attributeName, '' + value);
         }
       }
-    } else if (DOMProperty.isWriteableAttribute(name)) {
+    } else if (DOMProperty.isWriteable(name, value)) {
       DOMPropertyOperations.setValueForAttribute(node, name, value);
       return;
     }
@@ -272,7 +272,7 @@ var DOMPropertyOperations = {
       } else {
         node.removeAttribute(propertyInfo.attributeName);
       }
-    } else if (DOMProperty.isWriteableAttribute(name)) {
+    } else {
       node.removeAttribute(name);
     }
 

--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -194,7 +194,7 @@ var DOMPropertyOperations = {
           node.setAttribute(attributeName, '' + value);
         }
       }
-    } else if (DOMProperty.isWriteable(name, value)) {
+    } else if (DOMProperty.shouldSetAttribute(name, value)) {
       DOMPropertyOperations.setValueForAttribute(node, name, value);
       return;
     }

--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -194,7 +194,7 @@ var DOMPropertyOperations = {
           node.setAttribute(attributeName, '' + value);
         }
       }
-    } else if (DOMProperty.isCustomAttribute(name)) {
+    } else if (DOMProperty.isWriteableAttribute(name)) {
       DOMPropertyOperations.setValueForAttribute(node, name, value);
       return;
     }
@@ -272,7 +272,7 @@ var DOMPropertyOperations = {
       } else {
         node.removeAttribute(propertyInfo.attributeName);
       }
-    } else if (DOMProperty.isCustomAttribute(name)) {
+    } else if (DOMProperty.isWriteableAttribute(name)) {
       node.removeAttribute(name);
     }
 

--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -22,9 +22,6 @@ var HAS_OVERLOADED_BOOLEAN_VALUE =
   DOMProperty.injection.HAS_OVERLOADED_BOOLEAN_VALUE;
 
 var HTMLDOMPropertyConfig = {
-  isCustomAttribute: RegExp.prototype.test.bind(
-    new RegExp('^(data|aria)-[' + DOMProperty.ATTRIBUTE_NAME_CHAR + ']*$'),
-  ),
   Properties: {
     /**
      * Standard Properties

--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -202,6 +202,9 @@ var HTMLDOMPropertyConfig = {
     security: 0,
     // IE-only attribute that controls focus behavior
     unselectable: 0,
+    // Facebook internal attribute. Listed to avoid dependency on custom
+    // property injections
+    ajaxify: MUST_USE_PROPERTY,
   },
   DOMAttributeNames: {
     acceptCharset: 'accept-charset',

--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -202,9 +202,9 @@ var HTMLDOMPropertyConfig = {
     security: 0,
     // IE-only attribute that controls focus behavior
     unselectable: 0,
-    // Facebook internal attribute. Listed to avoid dependency on custom
-    // property injections
-    ajaxify: MUST_USE_PROPERTY,
+    // Facebook internal attribute. This is an object attribute that
+    // impliments a custom toString() method
+    ajaxify: 0,
   },
   DOMAttributeNames: {
     acceptCharset: 'accept-charset',

--- a/src/renderers/dom/shared/ReactDOMFeatureFlags.js
+++ b/src/renderers/dom/shared/ReactDOMFeatureFlags.js
@@ -14,6 +14,7 @@
 var ReactDOMFeatureFlags = {
   fiberAsyncScheduling: false,
   useFiber: true,
+  allowCustomAttributes: true,
 };
 
 module.exports = ReactDOMFeatureFlags;

--- a/src/renderers/dom/shared/ReactDOMFeatureFlags.js
+++ b/src/renderers/dom/shared/ReactDOMFeatureFlags.js
@@ -14,7 +14,6 @@
 var ReactDOMFeatureFlags = {
   fiberAsyncScheduling: false,
   useFiber: true,
-  allowCustomAttributes: true,
 };
 
 module.exports = ReactDOMFeatureFlags;

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -142,27 +142,29 @@ describe('ReactDOMComponent', () => {
       expectDev(() => (style.position = 'absolute')).toThrow();
     });
 
-    it('should warn for unknown prop', () => {
-      spyOn(console, 'error');
-      var container = document.createElement('div');
-      ReactDOM.render(<div foo="bar" />, container);
-      expectDev(console.error.calls.count(0)).toBe(1);
-      expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Unknown prop `foo` on <div> tag. Remove this prop from the element. ' +
-          'For details, see https://fb.me/react-unknown-prop\n    in div (at **)',
-      );
-    });
+    if (ReactDOMFeatureFlags.allowCustomAttributes !== true) {
+      it('should warn for unknown prop', () => {
+        spyOn(console, 'error');
+        var container = document.createElement('div');
+        ReactDOM.render(<div foo="bar" />, container);
+        expectDev(console.error.calls.count(0)).toBe(1);
+        expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+          'Warning: Unknown prop `foo` on <div> tag. Remove this prop from the element. ' +
+            'For details, see https://fb.me/react-unknown-prop\n    in div (at **)',
+        );
+      });
 
-    it('should group multiple unknown prop warnings together', () => {
-      spyOn(console, 'error');
-      var container = document.createElement('div');
-      ReactDOM.render(<div foo="bar" baz="qux" />, container);
-      expectDev(console.error.calls.count(0)).toBe(1);
-      expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Unknown props `foo`, `baz` on <div> tag. Remove these props from the element. ' +
-          'For details, see https://fb.me/react-unknown-prop\n    in div (at **)',
-      );
-    });
+      it('should group multiple unknown prop warnings together', () => {
+        spyOn(console, 'error');
+        var container = document.createElement('div');
+        ReactDOM.render(<div foo="bar" baz="qux" />, container);
+        expectDev(console.error.calls.count(0)).toBe(1);
+        expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+          'Warning: Unknown props `foo`, `baz` on <div> tag. Remove these props from the element. ' +
+            'For details, see https://fb.me/react-unknown-prop\n    in div (at **)',
+        );
+      });
+    }
 
     it('should warn for onDblClick prop', () => {
       spyOn(console, 'error');
@@ -1872,6 +1874,56 @@ describe('ReactDOMComponent', () => {
       ReactDOM.render(elem2, container);
 
       expect(container.firstChild.innerHTML).toBe(html2);
+    });
+  });
+
+  describe('allowCustomAttributes feature flag', function() {
+    const originalValue = ReactDOMFeatureFlags.allowCustomAttributes;
+
+    afterEach(function() {
+      ReactDOMFeatureFlags.allowCustomAttributes = originalValue;
+    });
+
+    describe('when set to false', function() {
+      beforeEach(function() {
+        ReactDOMFeatureFlags.allowCustomAttributes = false;
+      });
+
+      it('does not allow assignment of custom attributes to elements', function() {
+        spyOn(console, 'error');
+
+        var el = ReactTestUtils.renderIntoDocument(<div whatever="30" />);
+
+        expect(el.hasAttribute('whatever')).toBe(false);
+
+        expect(console.error).toHaveBeenCalledTimes(1);
+      });
+
+      it('allows data attributes', function() {
+        var el = ReactTestUtils.renderIntoDocument(<div data-whatever="30" />);
+
+        expect(el.hasAttribute('data-whatever')).toBe(true);
+      });
+    });
+
+    describe('when set to true', function() {
+      beforeEach(function() {
+        ReactDOMFeatureFlags.allowCustomAttributes = true;
+      });
+
+      it('allows assignment of custom attributes to elements', function() {
+        var el = ReactTestUtils.renderIntoDocument(<div whatever="30" />);
+
+        expect(el.hasAttribute('whatever')).toBe(true);
+      });
+
+      it('warns on bad casing', function() {
+        spyOn(console, 'error');
+
+        ReactTestUtils.renderIntoDocument(<div autofocus="30" />);
+
+        expect(console.error).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -148,8 +148,10 @@ describe('ReactDOMComponent', () => {
       ReactDOM.render(<div foo={() => {}} />, container);
       expectDev(console.error.calls.count(0)).toBe(1);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Unknown prop `foo` on <div> tag. Remove this prop from the element. ' +
-          'For details, see https://fb.me/react-unknown-prop\n    in div (at **)',
+        'Warning: Unknown prop `foo` on <div> tag. Either remove this prop ' +
+          'from the element, or pass a string, number, or boolean value to keep ' +
+          'it in the DOM. For details, see https://fb.me/react-unknown-prop' +
+          '\n    in div (at **)',
       );
     });
 
@@ -159,8 +161,10 @@ describe('ReactDOMComponent', () => {
       ReactDOM.render(<div foo={() => {}} baz={{}} />, container);
       expectDev(console.error.calls.count(0)).toBe(1);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Unknown props `foo`, `baz` on <div> tag. Remove these props from the element. ' +
-          'For details, see https://fb.me/react-unknown-prop\n    in div (at **)',
+        'Warning: Unknown props `foo`, `baz` on <div> tag. Either remove these ' +
+          'props from the element, or pass a string, number, or boolean value to keep ' +
+          'them in the DOM. For details, see https://fb.me/react-unknown-prop' +
+          '\n    in div (at **)',
       );
     });
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -156,7 +156,7 @@ describe('ReactDOMComponent', () => {
     it('should group multiple unknown prop warnings together', () => {
       spyOn(console, 'error');
       var container = document.createElement('div');
-      ReactDOM.render(<div foo={() => {}} baz={() => {}} />, container);
+      ReactDOM.render(<div foo={() => {}} baz={{}} />, container);
       expectDev(console.error.calls.count(0)).toBe(1);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
         'Warning: Unknown props `foo`, `baz` on <div> tag. Remove these props from the element. ' +

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -1894,36 +1894,30 @@ describe('ReactDOMComponent', () => {
       expect(container.firstChild.hasAttribute('whatever')).toBe(false);
     });
 
-    it('will not assign a boolean custom attributes', function() {
-      spyOn(console, 'error');
-
+    it('assigns a boolean custom attributes as a string', function() {
       var el = ReactTestUtils.renderIntoDocument(<div whatever={true} />);
 
-      expect(el.hasAttribute('whatever')).toBe(false);
-
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Unknown prop `whatever` on <div> tag',
-      );
+      expect(el.getAttribute('whatever')).toBe('true');
     });
 
-    it('will not assign a numeric custom attributes', function() {
-      spyOn(console, 'error');
-
-      var el = ReactTestUtils.renderIntoDocument(<div whatever={3} />);
-
-      expect(el.hasAttribute('whatever')).toBe(false);
-
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Unknown prop `whatever` on <div> tag',
-      );
-    });
-
-    it('will not assign an implicit boolean custom attributes', function() {
-      spyOn(console, 'error');
-
+    it('assigns an implicit boolean custom attributes as a string', function() {
       // eslint-disable-next-line react/jsx-boolean-value
       var el = ReactTestUtils.renderIntoDocument(<div whatever />);
 
+      expect(el.getAttribute('whatever')).toBe('true');
+    });
+
+    it('assigns a numeric custom attributes as a string', function() {
+      var el = ReactTestUtils.renderIntoDocument(<div whatever={3} />);
+
+      expect(el.getAttribute('whatever')).toBe('3');
+    });
+
+    it('will not assign a function custom attributes', function() {
+      spyOn(console, 'error');
+
+      var el = ReactTestUtils.renderIntoDocument(<div whatever={() => {}} />);
+
       expect(el.hasAttribute('whatever')).toBe(false);
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
@@ -1931,46 +1925,16 @@ describe('ReactDOMComponent', () => {
       );
     });
 
-    describe('data attributes', function() {
-      it('allows boolean data-attributes', function() {
-        var el = ReactTestUtils.renderIntoDocument(<div data-test={true} />);
+    it('will not assign an object custom attributes', function() {
+      spyOn(console, 'error');
 
-        expect(el.getAttribute('data-test')).toBe('true');
-      });
+      var el = ReactTestUtils.renderIntoDocument(<div whatever={{}} />);
 
-      it('allows numeric data-attributes', function() {
-        var el = ReactTestUtils.renderIntoDocument(<div data-test={1} />);
+      expect(el.hasAttribute('whatever')).toBe(false);
 
-        expect(el.getAttribute('data-test')).toBe('1');
-      });
-
-      it('allows implicit boolean data-attributes', function() {
-        // eslint-disable-next-line react/jsx-boolean-value
-        var el = ReactTestUtils.renderIntoDocument(<div data-test />);
-
-        expect(el.getAttribute('data-test')).toBe('true');
-      });
-    });
-
-    describe('aria attributes', function() {
-      it('allows boolean aria-attributes', function() {
-        var el = ReactTestUtils.renderIntoDocument(<div aria-hidden={true} />);
-
-        expect(el.getAttribute('aria-hidden')).toBe('true');
-      });
-
-      it('allows numeric aria-attributes', function() {
-        var el = ReactTestUtils.renderIntoDocument(<div aria-hidden={1} />);
-
-        expect(el.getAttribute('aria-hidden')).toBe('1');
-      });
-
-      it('allows implicit boolean aria-attributes', function() {
-        // eslint-disable-next-line react/jsx-boolean-value
-        var el = ReactTestUtils.renderIntoDocument(<div aria-hidden />);
-
-        expect(el.getAttribute('aria-hidden')).toBe('true');
-      });
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        'Warning: Unknown prop `whatever` on <div> tag',
+      );
     });
   });
 });

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -148,7 +148,7 @@ describe('ReactDOMComponent', () => {
       ReactDOM.render(<div foo={() => {}} />, container);
       expectDev(console.error.calls.count(0)).toBe(1);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Unknown prop `foo` on <div> tag. Either remove this prop ' +
+        'Warning: Invalid prop `foo` on <div> tag. Either remove this prop ' +
           'from the element, or pass a string, number, or boolean value to keep ' +
           'it in the DOM. For details, see https://fb.me/react-unknown-prop' +
           '\n    in div (at **)',
@@ -161,7 +161,7 @@ describe('ReactDOMComponent', () => {
       ReactDOM.render(<div foo={() => {}} baz={{}} />, container);
       expectDev(console.error.calls.count(0)).toBe(1);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Unknown props `foo`, `baz` on <div> tag. Either remove these ' +
+        'Warning: Invalid props `foo`, `baz` on <div> tag. Either remove these ' +
           'props from the element, or pass a string, number, or boolean value to keep ' +
           'them in the DOM. For details, see https://fb.me/react-unknown-prop' +
           '\n    in div (at **)',
@@ -174,7 +174,7 @@ describe('ReactDOMComponent', () => {
       ReactDOM.render(<div onDblClick={() => {}} />, container);
       expectDev(console.error.calls.count(0)).toBe(1);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Unknown event handler property onDblClick. Did you mean `onDoubleClick`?\n    in div (at **)',
+        'Warning: Unknown event handler property `onDblClick`. Did you mean `onDoubleClick`?\n    in div (at **)',
       );
     });
 
@@ -1615,10 +1615,10 @@ describe('ReactDOMComponent', () => {
       ReactTestUtils.renderIntoDocument(<input type="text" onclick="1" />);
       expectDev(console.error.calls.count()).toBe(2);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Unknown DOM property class. Did you mean className?\n    in div (at **)',
+        'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
       );
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
-        'Warning: Unknown event handler property onclick. Did you mean ' +
+        'Warning: Unknown event handler property `onclick`. Did you mean ' +
           '`onClick`?\n    in input (at **)',
       );
     });
@@ -1629,10 +1629,10 @@ describe('ReactDOMComponent', () => {
       ReactDOMServer.renderToString(<input type="text" onclick="1" />);
       expectDev(console.error.calls.count()).toBe(2);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Unknown DOM property class. Did you mean className?\n    in div (at **)',
+        'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
       );
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
-        'Warning: Unknown event handler property onclick. Did you mean ' +
+        'Warning: Unknown event handler property `onclick`. Did you mean ' +
           '`onClick`?\n    in input (at **)',
       );
     });
@@ -1647,7 +1647,7 @@ describe('ReactDOMComponent', () => {
       ReactTestUtils.renderIntoDocument(<div class="paladin" />, container);
       expectDev(console.error.calls.count()).toBe(1);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Unknown DOM property class. Did you mean className?\n    in div (at **)',
+        'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
       );
     });
 
@@ -1825,11 +1825,11 @@ describe('ReactDOMComponent', () => {
       expectDev(console.error.calls.count()).toBe(2);
 
       expectDev(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: Unknown DOM property for. Did you mean htmlFor?\n    in label',
+        'Warning: Invalid DOM property `for`. Did you mean `htmlFor`?\n    in label',
       );
 
       expectDev(console.error.calls.argsFor(1)[0]).toBe(
-        'Warning: Unknown DOM property autofocus. Did you mean autoFocus?\n    in input',
+        'Warning: Invalid DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
       );
     });
 
@@ -1846,11 +1846,11 @@ describe('ReactDOMComponent', () => {
       expectDev(console.error.calls.count()).toBe(2);
 
       expectDev(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: Unknown DOM property for. Did you mean htmlFor?\n    in label',
+        'Warning: Invalid DOM property `for`. Did you mean `htmlFor`?\n    in label',
       );
 
       expectDev(console.error.calls.argsFor(1)[0]).toBe(
-        'Warning: Unknown DOM property autofocus. Did you mean autoFocus?\n    in input',
+        'Warning: Invalid DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
       );
     });
   });
@@ -1888,7 +1888,7 @@ describe('ReactDOMComponent', () => {
       expect(el.className).toBe('');
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Unknown DOM property class. Did you mean className?',
+        'Warning: Invalid DOM property `class`. Did you mean `className`?',
       );
     });
 
@@ -1903,7 +1903,7 @@ describe('ReactDOMComponent', () => {
       expect(text.getAttribute('arabic-form')).toBe(null);
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Unknown DOM property arabic-form. Did you mean arabicForm?',
+        'Warning: Invalid DOM property `arabic-form`. Did you mean `arabicForm`?',
       );
     });
 
@@ -1969,7 +1969,7 @@ describe('ReactDOMComponent', () => {
       expect(el.hasAttribute('whatever')).toBe(false);
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Unknown prop `whatever` on <div> tag',
+        'Warning: Invalid prop `whatever` on <div> tag',
       );
     });
 
@@ -1981,7 +1981,7 @@ describe('ReactDOMComponent', () => {
       expect(el.hasAttribute('whatever')).toBe(false);
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Unknown prop `whatever` on <div> tag',
+        'Warning: Invalid prop `whatever` on <div> tag.',
       );
     });
 
@@ -1990,6 +1990,32 @@ describe('ReactDOMComponent', () => {
       var el = ReactTestUtils.renderIntoDocument(<div ajaxify={options} />);
 
       expect(el.getAttribute('ajaxify')).toBe('ajaxy');
+    });
+
+    it('only allows lower-case data attributes', function() {
+      spyOn(console, 'error');
+
+      var el = ReactTestUtils.renderIntoDocument(<div data-fooBar="true" />);
+
+      expect(el.hasAttribute('data-foobar')).toBe(false);
+
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        'Warning: Invalid DOM property `data-fooBar`. Custom attributes ' +
+          'and data attributes must be lower case. Instead use `data-foobar`',
+      );
+    });
+
+    it('only allows lower-case custom attributes', function() {
+      spyOn(console, 'error');
+
+      var el = ReactTestUtils.renderIntoDocument(<div fooBar="true" />);
+
+      expect(el.hasAttribute('foobar')).toBe(false);
+
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        'Warning: Invalid DOM property `fooBar`. Custom attributes ' +
+          'and data attributes must be lower case. Instead use `foobar`',
+      );
     });
   });
 });

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -1940,5 +1940,12 @@ describe('ReactDOMComponent', () => {
         'Warning: Unknown prop `whatever` on <div> tag',
       );
     });
+
+    it('assigns ajaxify (an important internal FB attribute)', function() {
+      var options = {};
+      var el = ReactTestUtils.renderIntoDocument(<div ajaxify={options} />);
+
+      expect(el.ajaxify).toBe(options);
+    });
   });
 });

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -1908,29 +1908,19 @@ describe('ReactDOMComponent', () => {
     });
 
     it('sets aliased attributes on custom elements', function() {
-      spyOn(console, 'error');
-
       var el = ReactTestUtils.renderIntoDocument(
         <div is="custom-element" class="test" />,
       );
 
       expect(el.getAttribute('class')).toBe('test');
-
-      expectDev(console.error).not.toHaveBeenCalled();
     });
 
     it('updates aliased attributes on custom elements', function() {
       var container = document.createElement('div');
-
-      spyOn(console, 'error');
-
       ReactDOM.render(<div is="custom-element" class="foo" />, container);
-
       ReactDOM.render(<div is="custom-element" class="bar" />, container);
 
       expect(container.firstChild.getAttribute('class')).toBe('bar');
-
-      expectDev(console.error).not.toHaveBeenCalled();
     });
   });
 
@@ -1943,7 +1933,6 @@ describe('ReactDOMComponent', () => {
 
     it('removes custom attributes', function() {
       const container = document.createElement('div');
-
       ReactDOM.render(<div whatever="30" />, container);
 
       expect(container.firstChild.getAttribute('whatever')).toBe('30');

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -1879,6 +1879,35 @@ describe('ReactDOMComponent', () => {
     });
   });
 
+  describe('Attributes with aliases', function() {
+    it('does not set aliased attributes on DOM elements', function() {
+      spyOn(console, 'error');
+
+      var el = ReactTestUtils.renderIntoDocument(<div class="test" />);
+
+      expect(el.className).toBe('');
+
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        'Warning: Unknown DOM property class. Did you mean className?',
+      );
+    });
+
+    it('does not set aliased attributes on SVG elements', function() {
+      spyOn(console, 'error');
+
+      var el = ReactTestUtils.renderIntoDocument(
+        <svg><text arabic-form="initial" /></svg>,
+      );
+      var text = el.querySelector('text');
+
+      expect(text.getAttribute('arabic-form')).toBe(null);
+
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        'Warning: Unknown DOM property arabic-form. Did you mean arabicForm?',
+      );
+    });
+  });
+
   describe('Custom attributes', function() {
     it('allows assignment of custom attributes with string values', function() {
       var el = ReactTestUtils.renderIntoDocument(<div whatever="30" />);

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -1912,7 +1912,7 @@ describe('ReactDOMComponent', () => {
     it('allows assignment of custom attributes with string values', function() {
       var el = ReactTestUtils.renderIntoDocument(<div whatever="30" />);
 
-      expect(el.hasAttribute('whatever')).toBe(true);
+      expect(el.getAttribute('whatever')).toBe("30");
     });
 
     it('removes custom attributes', function() {

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -1942,10 +1942,10 @@ describe('ReactDOMComponent', () => {
     });
 
     it('assigns ajaxify (an important internal FB attribute)', function() {
-      var options = {};
+      var options = {toString: () => 'ajaxy'};
       var el = ReactTestUtils.renderIntoDocument(<div ajaxify={options} />);
 
-      expect(el.ajaxify).toBe(options);
+      expect(el.getAttribute('ajaxify')).toBe('ajaxy');
     });
   });
 });

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -1906,13 +1906,39 @@ describe('ReactDOMComponent', () => {
         'Warning: Unknown DOM property arabic-form. Did you mean arabicForm?',
       );
     });
+
+    it('sets aliased attributes on custom elements', function() {
+      spyOn(console, 'error');
+
+      var el = ReactTestUtils.renderIntoDocument(
+        <div is="custom-element" class="test" />,
+      );
+
+      expect(el.getAttribute('class')).toBe('test');
+
+      expectDev(console.error).not.toHaveBeenCalled();
+    });
+
+    it('updates aliased attributes on custom elements', function() {
+      var container = document.createElement('div');
+
+      spyOn(console, 'error');
+
+      ReactDOM.render(<div is="custom-element" class="foo" />, container);
+
+      ReactDOM.render(<div is="custom-element" class="bar" />, container);
+
+      expect(container.firstChild.getAttribute('class')).toBe('bar');
+
+      expectDev(console.error).not.toHaveBeenCalled();
+    });
   });
 
   describe('Custom attributes', function() {
     it('allows assignment of custom attributes with string values', function() {
       var el = ReactTestUtils.renderIntoDocument(<div whatever="30" />);
 
-      expect(el.getAttribute('whatever')).toBe("30");
+      expect(el.getAttribute('whatever')).toBe('30');
     });
 
     it('removes custom attributes', function() {

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -1992,30 +1992,14 @@ describe('ReactDOMComponent', () => {
       expect(el.getAttribute('ajaxify')).toBe('ajaxy');
     });
 
-    it('only allows lower-case data attributes', function() {
-      spyOn(console, 'error');
-
+    it('allows cased data attributes', function() {
       var el = ReactTestUtils.renderIntoDocument(<div data-fooBar="true" />);
-
-      expect(el.hasAttribute('data-foobar')).toBe(false);
-
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Invalid DOM property `data-fooBar`. Custom attributes ' +
-          'and data attributes must be lower case. Instead use `data-foobar`',
-      );
+      expect(el.getAttribute('data-foobar')).toBe('true');
     });
 
-    it('only allows lower-case custom attributes', function() {
-      spyOn(console, 'error');
-
+    it('allows cased custom attributes', function() {
       var el = ReactTestUtils.renderIntoDocument(<div fooBar="true" />);
-
-      expect(el.hasAttribute('foobar')).toBe(false);
-
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Invalid DOM property `fooBar`. Custom attributes ' +
-          'and data attributes must be lower case. Instead use `foobar`',
-      );
+      expect(el.getAttribute('foobar')).toBe('true');
     });
   });
 });

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -780,13 +780,8 @@ describe('ReactDOMServerIntegration', () => {
 
     describe('unknown attributes', function() {
       itRenders('unknown attributes', async render => {
-        const e = await render(
-          <div foo="bar" />,
-          ReactDOMFeatureFlags.allowCustomAttributes ? 0 : 1,
-        );
-        expect(e.getAttribute('foo')).toBe(
-          ReactDOMFeatureFlags.allowCustomAttributes ? 'bar' : null,
-        );
+        const e = await render(<div foo="bar" />, 0);
+        expect(e.getAttribute('foo')).toBe('bar');
       });
 
       itRenders('unknown data- attributes', async render => {
@@ -802,13 +797,8 @@ describe('ReactDOMServerIntegration', () => {
       itRenders(
         'no unknown attributes for non-standard elements',
         async render => {
-          const e = await render(
-            <nonstandard foo="bar" />,
-            ReactDOMFeatureFlags.allowCustomAttributes ? 0 : 1,
-          );
-          expect(e.getAttribute('foo')).toBe(
-            ReactDOMFeatureFlags.allowCustomAttributes ? 'bar' : null,
-          );
+          const e = await render(<nonstandard foo="bar" />, 0);
+          expect(e.getAttribute('foo')).toBe('bar');
         },
       );
 
@@ -2582,35 +2572,5 @@ describe('ReactDOMServerIntegration', () => {
         <div dangerouslySetInnerHTML={{__html: "<span id='child1'/>"}} />,
         <div dangerouslySetInnerHTML={{__html: "<span id='child2'/>"}} />,
       ));
-  });
-
-  describe('dynamic injection', () => {
-    beforeEach(() => {
-      // HACK: we reset modules several times during the test which breaks
-      // dynamic injection. So we resort to telling resetModules() to run
-      // our custom init code every time after resetting. We could have a nicer
-      // way to do this, but this is the only test that needs it, and it will
-      // be removed anyway when we switch to static injection.
-      onAfterResetModules = () => {
-        const DOMProperty = require('DOMProperty');
-        DOMProperty.injection.injectDOMPropertyConfig({
-          isCustomAttribute: function(name) {
-            return name.indexOf('foo-') === 0;
-          },
-          Properties: {foobar: null},
-        });
-      };
-      resetModules();
-    });
-
-    afterEach(() => {
-      onAfterResetModules = null;
-    });
-
-    itRenders('injected attributes', async render => {
-      const e = await render(<div foobar="simple" foo-xyz="simple" />, 0);
-      expect(e.getAttribute('foobar')).toBe('simple');
-      expect(e.getAttribute('foo-xyz')).toBe('simple');
-    });
   });
 });

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -614,6 +614,16 @@ describe('ReactDOMServerIntegration', () => {
         const e = await render(<div className={null} />);
         expect(e.hasAttribute('className')).toBe(false);
       });
+
+      itRenders('no className prop when given the alias', async render => {
+        const e = await render(<div class="test" />, 1);
+        expect(e.className).toBe('');
+      });
+
+      itRenders('class for custom elements', async render => {
+        const e = await render(<x-custom class="test" />, 0);
+        expect(e.getAttribute('class')).toBe('test');
+      });
     });
 
     describe('htmlFor property', function() {

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -312,10 +312,6 @@ function expectMarkupMismatch(serverElement, clientElement) {
   return testMarkupMatch(serverElement, clientElement, false);
 }
 
-// TODO: this is a hack for testing dynamic injection. Remove this when we decide
-// how to do static injection instead.
-let onAfterResetModules = null;
-
 // When there is a test that renders on server and then on client and expects a logged
 // error, you want to see the error show up both on server and client. Unfortunately,
 // React refuses to issue the same error twice to avoid clogging up the console.
@@ -323,9 +319,6 @@ let onAfterResetModules = null;
 function resetModules() {
   // First, reset the modules to load the client renderer.
   jest.resetModuleRegistry();
-  if (typeof onAfterResetModules === 'function') {
-    onAfterResetModules();
-  }
 
   // TODO: can we express this test with only public API?
   ExecutionEnvironment = require('ExecutionEnvironment');
@@ -341,9 +334,6 @@ function resetModules() {
   // Resetting is important because we want to avoid any shared state
   // influencing the tests.
   jest.resetModuleRegistry();
-  if (typeof onAfterResetModules === 'function') {
-    onAfterResetModules();
-  }
   require('ReactFeatureFlags').disableNewFiberFeatures = false;
   ReactDOMServer = require('react-dom/server');
 }

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -2573,4 +2573,34 @@ describe('ReactDOMServerIntegration', () => {
         <div dangerouslySetInnerHTML={{__html: "<span id='child2'/>"}} />,
       ));
   });
+
+  describe('dynamic injection', () => {
+    beforeEach(() => {
+      // HACK: we reset modules several times during the test which breaks
+      // dynamic injection. So we resort to telling resetModules() to run
+      // our custom init code every time after resetting. We could have a nicer
+      // way to do this, but this is the only test that needs it, and it will
+      // be removed anyway when we switch to static injection.
+      onAfterResetModules = () => {
+        const DOMProperty = require('DOMProperty');
+        DOMProperty.injection.injectDOMPropertyConfig({
+          Properties: {foobar: 0},
+          DOMAttributeNames: {
+            foobar: 'foo-bar',
+          },
+        });
+      };
+      resetModules();
+    });
+
+    afterEach(() => {
+      onAfterResetModules = null;
+    });
+
+    itRenders('injected attributes', async render => {
+      const e = await render(<div foobar="test" />);
+
+      expect(e.getAttribute('foo-bar')).toEqual('test');
+    });
+  });
 });

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -795,7 +795,7 @@ describe('ReactDOMServerIntegration', () => {
       });
 
       itRenders(
-        'no unknown attributes for non-standard elements',
+        'custom attributes for non-standard elements',
         async render => {
           const e = await render(<nonstandard foo="bar" />, 0);
           expect(e.getAttribute('foo')).toBe('bar');

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -794,13 +794,10 @@ describe('ReactDOMServerIntegration', () => {
         expect(e.hasAttribute('data-foo')).toBe(false);
       });
 
-      itRenders(
-        'custom attributes for non-standard elements',
-        async render => {
-          const e = await render(<nonstandard foo="bar" />, 0);
-          expect(e.getAttribute('foo')).toBe('bar');
-        },
-      );
+      itRenders('custom attributes for non-standard elements', async render => {
+        const e = await render(<nonstandard foo="bar" />, 0);
+        expect(e.getAttribute('foo')).toBe('bar');
+      });
 
       itRenders('unknown attributes for custom elements', async render => {
         const e = await render(<custom-element foo="bar" />);
@@ -2572,35 +2569,5 @@ describe('ReactDOMServerIntegration', () => {
         <div dangerouslySetInnerHTML={{__html: "<span id='child1'/>"}} />,
         <div dangerouslySetInnerHTML={{__html: "<span id='child2'/>"}} />,
       ));
-  });
-
-  describe('dynamic injection', () => {
-    beforeEach(() => {
-      // HACK: we reset modules several times during the test which breaks
-      // dynamic injection. So we resort to telling resetModules() to run
-      // our custom init code every time after resetting. We could have a nicer
-      // way to do this, but this is the only test that needs it, and it will
-      // be removed anyway when we switch to static injection.
-      onAfterResetModules = () => {
-        const DOMProperty = require('DOMProperty');
-        DOMProperty.injection.injectDOMPropertyConfig({
-          Properties: {foobar: 0},
-          DOMAttributeNames: {
-            foobar: 'foo-bar',
-          },
-        });
-      };
-      resetModules();
-    });
-
-    afterEach(() => {
-      onAfterResetModules = null;
-    });
-
-    itRenders('injected attributes', async render => {
-      const e = await render(<div foobar="test" />);
-
-      expect(e.getAttribute('foo-bar')).toEqual('test');
-    });
   });
 });

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -842,6 +842,11 @@ describe('ReactDOMServerIntegration', () => {
           expect(e.hasAttribute('foo')).toBe(false);
         },
       );
+
+      itRenders('custom attributes with special casing', async render => {
+        const e = await render(<div fooBar="test" />);
+        expect(e.getAttribute('fooBar')).toBe('test');
+      });
     });
 
     itRenders('no HTML events', async render => {

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -615,6 +615,12 @@ describe('ReactDOMServerIntegration', () => {
         expect(e.hasAttribute('className')).toBe(false);
       });
 
+      itRenders('no classname prop', async render => {
+        const e = await render(<div classname="test" />, 1);
+        expect(e.hasAttribute('class')).toBe(false);
+        expect(e.hasAttribute('classname')).toBe(false);
+      });
+
       itRenders('no className prop when given the alias', async render => {
         const e = await render(<div class="test" />, 1);
         expect(e.className).toBe('');
@@ -793,9 +799,35 @@ describe('ReactDOMServerIntegration', () => {
       });
     });
 
+    describe('cased attributes', function() {
+      itRenders('no badly cased aliased HTML attribute', async render => {
+        const e = await render(<meta httpequiv="refresh" />, 1);
+        expect(e.hasAttribute('http-equiv')).toBe(false);
+        expect(e.hasAttribute('httpequiv')).toBe(false);
+      });
+
+      itRenders('no badly cased SVG attribute', async render => {
+        const e = await render(<text textlength="10" />, 1);
+        expect(e.hasAttribute('textLength')).toBe(false);
+      });
+
+      itRenders('no badly cased aliased SVG attribute', async render => {
+        const e = await render(<text strokedasharray="10 10" />, 1);
+        expect(e.hasAttribute('strokedasharray')).toBe(false);
+      });
+
+      itRenders(
+        'no badly cased original SVG attribute that is aliased',
+        async render => {
+          const e = await render(<text stroke-dasharray="10 10" />, 1);
+          expect(e.hasAttribute('stroke-dasharray')).toBe(false);
+        },
+      );
+    });
+
     describe('unknown attributes', function() {
       itRenders('unknown attributes', async render => {
-        const e = await render(<div foo="bar" />, 0);
+        const e = await render(<div foo="bar" />);
         expect(e.getAttribute('foo')).toBe('bar');
       });
 
@@ -809,13 +841,21 @@ describe('ReactDOMServerIntegration', () => {
         expect(e.hasAttribute('data-foo')).toBe(false);
       });
 
-      itRenders('no unknown data- attributes with casing', async render => {
-        const e = await render(<div data-fooBar={null} />, 1);
-        expect(e.hasAttribute('data-foobar')).toBe(false);
+      itRenders('unknown data- attributes with casing', async render => {
+        const e = await render(<div data-fooBar="true" />);
+        expect(e.getAttribute('data-fooBar')).toBe('true');
       });
 
+      itRenders(
+        'no unknown data- attributes with casing and null value',
+        async render => {
+          const e = await render(<div data-fooBar={null} />);
+          expect(e.hasAttribute('data-fooBar')).toBe(false);
+        },
+      );
+
       itRenders('custom attributes for non-standard elements', async render => {
-        const e = await render(<nonstandard foo="bar" />, 0);
+        const e = await render(<nonstandard foo="bar" />);
         expect(e.getAttribute('foo')).toBe('bar');
       });
 
@@ -848,9 +888,9 @@ describe('ReactDOMServerIntegration', () => {
         },
       );
 
-      itRenders('no cased custom attributes', async render => {
-        const e = await render(<div fooBar="test" />, 1);
-        expect(e.hasAttribute('fooBar')).toBe(false);
+      itRenders('cased custom attributes', async render => {
+        const e = await render(<div fooBar="test" />);
+        expect(e.getAttribute('fooBar')).toBe('test');
       });
     });
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -779,9 +779,14 @@ describe('ReactDOMServerIntegration', () => {
     });
 
     describe('unknown attributes', function() {
-      itRenders('no unknown attributes', async render => {
-        const e = await render(<div foo="bar" />, 1);
-        expect(e.getAttribute('foo')).toBe(null);
+      itRenders('unknown attributes', async render => {
+        const e = await render(
+          <div foo="bar" />,
+          ReactDOMFeatureFlags.allowCustomAttributes ? 0 : 1,
+        );
+        expect(e.getAttribute('foo')).toBe(
+          ReactDOMFeatureFlags.allowCustomAttributes ? 'bar' : null,
+        );
       });
 
       itRenders('unknown data- attributes', async render => {
@@ -797,8 +802,13 @@ describe('ReactDOMServerIntegration', () => {
       itRenders(
         'no unknown attributes for non-standard elements',
         async render => {
-          const e = await render(<nonstandard foo="bar" />, 1);
-          expect(e.getAttribute('foo')).toBe(null);
+          const e = await render(
+            <nonstandard foo="bar" />,
+            ReactDOMFeatureFlags.allowCustomAttributes ? 0 : 1,
+          );
+          expect(e.getAttribute('foo')).toBe(
+            ReactDOMFeatureFlags.allowCustomAttributes ? 'bar' : null,
+          );
         },
       );
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -809,6 +809,11 @@ describe('ReactDOMServerIntegration', () => {
         expect(e.hasAttribute('data-foo')).toBe(false);
       });
 
+      itRenders('no unknown data- attributes with casing', async render => {
+        const e = await render(<div data-fooBar={null} />, 1);
+        expect(e.hasAttribute('data-foobar')).toBe(false);
+      });
+
       itRenders('custom attributes for non-standard elements', async render => {
         const e = await render(<nonstandard foo="bar" />, 0);
         expect(e.getAttribute('foo')).toBe('bar');
@@ -843,9 +848,9 @@ describe('ReactDOMServerIntegration', () => {
         },
       );
 
-      itRenders('custom attributes with special casing', async render => {
-        const e = await render(<div fooBar="test" />);
-        expect(e.getAttribute('fooBar')).toBe('test');
+      itRenders('no cased custom attributes', async render => {
+        const e = await render(<div fooBar="test" />, 1);
+        expect(e.hasAttribute('fooBar')).toBe(false);
       });
     });
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -621,8 +621,13 @@ describe('ReactDOMServerIntegration', () => {
       });
 
       itRenders('class for custom elements', async render => {
-        const e = await render(<x-custom class="test" />, 0);
+        const e = await render(<div is="custom-element" class="test" />, 0);
         expect(e.getAttribute('class')).toBe('test');
+      });
+
+      itRenders('className for custom elements', async render => {
+        const e = await render(<div is="custom-element" className="test" />, 0);
+        expect(e.getAttribute('className')).toBe('test');
       });
     });
 
@@ -652,6 +657,16 @@ describe('ReactDOMServerIntegration', () => {
       itRenders('no htmlFor prop with null value', async render => {
         const e = await render(<div htmlFor={null} />);
         expect(e.hasAttribute('htmlFor')).toBe(false);
+      });
+
+      itRenders('htmlFor attribute on custom elements', async render => {
+        const e = await render(<div is="custom-element" htmlFor="test" />);
+        expect(e.getAttribute('htmlFor')).toBe('test');
+      });
+
+      itRenders('for attribute on custom elements', async render => {
+        const e = await render(<div is="custom-element" for="test" />);
+        expect(e.getAttribute('for')).toBe('test');
       });
     });
 

--- a/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
+++ b/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
@@ -38,7 +38,7 @@ if (__DEV__) {
   var warnedProperties = {};
   var EVENT_NAME_REGEX = /^on[A-Z]/;
 
-  var validateProperty = function(tagName, name, debugID) {
+  var validateProperty = function(tagName, name, value, debugID) {
     var lowerCasedName = name.toLowerCase();
 
     if (warnedProperties.hasOwnProperty(name) && warnedProperties[name]) {
@@ -84,7 +84,7 @@ if (__DEV__) {
 
     var hasBadCasing = standardName != null && standardName !== name;
 
-    if (DOMProperty.isWriteableAttribute(name) && !hasBadCasing) {
+    if (DOMProperty.isWriteable(name, value) && !hasBadCasing) {
       return true;
     }
 
@@ -106,7 +106,7 @@ if (__DEV__) {
 var warnUnknownProperties = function(type, props, debugID) {
   var unknownProps = [];
   for (var key in props) {
-    var isValid = validateProperty(type, key, debugID);
+    var isValid = validateProperty(type, key, props[key], debugID);
     if (!isValid) {
       unknownProps.push(key);
     }

--- a/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
+++ b/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
@@ -117,7 +117,8 @@ var warnUnknownProperties = function(type, props, debugID) {
   if (unknownProps.length === 1) {
     warning(
       false,
-      'Unknown prop %s on <%s> tag. Remove this prop from the element. ' +
+      'Unknown prop %s on <%s> tag. Either remove this prop from the element, ' +
+        'or pass a string, number, or boolean value to keep it in the DOM. ' +
         'For details, see https://fb.me/react-unknown-prop%s',
       unknownPropString,
       type,
@@ -126,7 +127,8 @@ var warnUnknownProperties = function(type, props, debugID) {
   } else if (unknownProps.length > 1) {
     warning(
       false,
-      'Unknown props %s on <%s> tag. Remove these props from the element. ' +
+      'Unknown props %s on <%s> tag. Either remove these props from the element, ' +
+        'or pass a string, number, or boolean value to keep them in the DOM. ' +
         'For details, see https://fb.me/react-unknown-prop%s',
       unknownPropString,
       type,

--- a/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
+++ b/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
@@ -84,7 +84,7 @@ if (__DEV__) {
 
     var hasBadCasing = standardName != null && standardName !== name;
 
-    if (DOMProperty.isWriteable(name, value) && !hasBadCasing) {
+    if (DOMProperty.shouldSetAttribute(name, value) && !hasBadCasing) {
       return true;
     }
 

--- a/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
+++ b/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
@@ -101,20 +101,6 @@ if (__DEV__) {
       return true;
     }
 
-    // Otherwise, we have a custom attribute. Custom attributes should always
-    // be lowercase.
-    if (lowerCasedName !== name) {
-      warning(
-        false,
-        'Invalid DOM property `%s`. Custom attributes and data attributes ' +
-          'must be lower case. Instead use `%s`.%s',
-        name,
-        lowerCasedName,
-        getStackAddendum(debugID),
-      );
-      return true;
-    }
-
     return DOMProperty.shouldSetAttribute(name, value);
   };
 }

--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -1021,7 +1021,7 @@ ReactDOMComponent.Mixin = {
             nextProp,
           );
         }
-      } else if (DOMProperty.isWriteable(propKey, nextProp)) {
+      } else if (DOMProperty.shouldSetAttribute(propKey, nextProp)) {
         var node = getNode(this);
         // If we're updating to null or undefined, we should remove the property
         // from the DOM node instead of inadvertently setting to a string. This

--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -57,11 +57,6 @@ var CONTENT_TYPES = {string: true, number: true};
 
 var STYLE = 'style';
 var HTML = '__html';
-var RESERVED_PROPS = {
-  children: null,
-  dangerouslySetInnerHTML: null,
-  suppressContentEditableWarning: null,
-};
 
 function getDeclarationErrorAddendum(internalInstance) {
   if (internalInstance) {
@@ -710,7 +705,7 @@ ReactDOMComponent.Mixin = {
         }
         var markup = null;
         if (this._tag != null && isCustomComponent(this._tag, props)) {
-          if (!RESERVED_PROPS.hasOwnProperty(propKey)) {
+          if (!DOMProperty.isReservedProp(propKey)) {
             markup = DOMMarkupOperations.createMarkupForCustomAttribute(
               propKey,
               propValue,
@@ -966,13 +961,10 @@ ReactDOMComponent.Mixin = {
       } else if (registrationNameModules.hasOwnProperty(propKey)) {
         // Do nothing for event names.
       } else if (isCustomComponent(this._tag, lastProps)) {
-        if (!RESERVED_PROPS.hasOwnProperty(propKey)) {
+        if (!DOMProperty.isReservedProp(propKey)) {
           DOMPropertyOperations.deleteValueForAttribute(getNode(this), propKey);
         }
-      } else if (
-        DOMProperty.properties[propKey] ||
-        DOMProperty.isCustomAttribute(propKey)
-      ) {
+      } else if (DOMProperty.isWriteableAttribute(propKey)) {
         DOMPropertyOperations.deleteValueForProperty(getNode(this), propKey);
       }
     }
@@ -1022,17 +1014,14 @@ ReactDOMComponent.Mixin = {
           ensureListeningTo(this, propKey, transaction);
         }
       } else if (isCustomComponentTag) {
-        if (!RESERVED_PROPS.hasOwnProperty(propKey)) {
+        if (!DOMProperty.isReservedProp(propKey)) {
           DOMPropertyOperations.setValueForAttribute(
             getNode(this),
             propKey,
             nextProp,
           );
         }
-      } else if (
-        DOMProperty.properties[propKey] ||
-        DOMProperty.isCustomAttribute(propKey)
-      ) {
+      } else if (DOMProperty.isWriteableAttribute(propKey)) {
         var node = getNode(this);
         // If we're updating to null or undefined, we should remove the property
         // from the DOM node instead of inadvertently setting to a string. This

--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -960,12 +960,12 @@ ReactDOMComponent.Mixin = {
         }
       } else if (registrationNameModules.hasOwnProperty(propKey)) {
         // Do nothing for event names.
-      } else if (isCustomComponent(this._tag, lastProps)) {
-        if (!DOMProperty.isReservedProp(propKey)) {
+      } else if (!DOMProperty.isReservedProp(propKey)) {
+        if (isCustomComponent(this._tag, lastProps)) {
           DOMPropertyOperations.deleteValueForAttribute(getNode(this), propKey);
+        } else {
+          DOMPropertyOperations.deleteValueForProperty(getNode(this), propKey);
         }
-      } else if (DOMProperty.isWriteableAttribute(propKey)) {
-        DOMPropertyOperations.deleteValueForProperty(getNode(this), propKey);
       }
     }
     for (propKey in nextProps) {
@@ -1021,7 +1021,7 @@ ReactDOMComponent.Mixin = {
             nextProp,
           );
         }
-      } else if (DOMProperty.isWriteableAttribute(propKey)) {
+      } else if (DOMProperty.isWriteable(propKey, nextProp)) {
         var node = getNode(this);
         // If we're updating to null or undefined, we should remove the property
         // from the DOM node instead of inadvertently setting to a string. This


### PR DESCRIPTION
This is a resubmission of pull request #6459. Just to recap...

The addition of the unsupported property warning (#6800) reminded my old PR (#6459) and I was curious about reopening it... So here we are.

This pull request configures DOMPropertyOperations to allow all attributes to pass through. It maintains the whitelist only for attributes that need special behavior, such as boolean props and name translations (like `className`).

While I was at it, I also eliminated the duplicated list of "reserved props" between `ReactDOMUnknownPropertyDevtool` and `ReactDOMComponent` through a new `isReservedProp` method on `DOMProperty`.

**Related Issues:**

- https://github.com/facebook/react/issues/9594
- https://github.com/facebook/react/issues/9477