### PR TITLE
Avoid "Member not found exception" in IE10

### DIFF
--- a/src/renderers/dom/client/syntheticEvents/SyntheticEvent.js
+++ b/src/renderers/dom/client/syntheticEvents/SyntheticEvent.js
@@ -135,9 +135,15 @@ Object.assign(SyntheticEvent.prototype, {
 
     if (event.stopPropagation) {
       event.stopPropagation();
-    } else {
+    } else if (typeof event.cancelBubble !== 'unknown') { // eslint-disable-line valid-typeof
+      // The ChangeEventPlugin registers a "propertychange" event for
+      // IE. This event does not support bubbling or cancelling, and
+      // any references to cancelBubble throw "Member not found".  A
+      // typeof check of "unknown" circumvents this issue (and is also
+      // IE specific).
       event.cancelBubble = true;
     }
+
     this.isPropagationStopped = emptyFunction.thatReturnsTrue;
   },
 


### PR DESCRIPTION
In <= IE10, custom change events raise "Member not found" when accessing 'cancelBubble' . To circumvent this, the SyntheticEvent class now checks for "typeof event.cancelBubble !== 'unknown'". This eliminates this exception and maintains the expected bubbling functionality.

I'd never heard of `typeof x === 'unknown'` before, but it seems to be a goofy JScript thing. I discovered it in the jQuery issue tracker:

https://bugs.jquery.com/ticket/10004

I've confirmed that this preserves bubbling functionality from IE9-11, Safari, Chrome, and Firefox. 

This technically is not a problem on `master`, but it fixes the issue for `15-stable` and I'm sort of curious what other events have this same issue.