### PR TITLE
Fix Chrome number input backspace and invalid input issue

### DIFF
--- a/fixtures/dom/src/components/Header.js
+++ b/fixtures/dom/src/components/Header.js
@@ -44,6 +44,7 @@ const Header = React.createClass({
               <option value="/">Select a Fixture</option>
               <option value="/range-inputs">Range Inputs</option>
               <option value="/text-inputs">Text Inputs</option>
+              <option value="/number-inputs">Number Input</option>
               <option value="/selects">Selects</option>
               <option value="/textareas">Textareas</option>
               <option value="/input-change-events">Input change events</option>

--- a/fixtures/dom/src/components/fixtures/index.js
+++ b/fixtures/dom/src/components/fixtures/index.js
@@ -4,6 +4,7 @@ import TextInputFixtures from './text-inputs';
 import SelectFixtures from './selects';
 import TextAreaFixtures from './textareas';
 import InputChangeEvents from './input-change-events';
+import NumberInputFixtures from './number-inputs/';
 
 /**
  * A simple routing component that renders the appropriate
@@ -22,6 +23,8 @@ const FixturesPage = React.createClass({
         return <TextAreaFixtures />;
       case '/input-change-events':
         return <InputChangeEvents />;
+      case '/number-inputs':
+        return <NumberInputFixtures />;
       default:
         return <p>Please select a test fixture.</p>;
     }

--- a/fixtures/dom/src/components/fixtures/number-inputs/NumberTestCase.js
+++ b/fixtures/dom/src/components/fixtures/number-inputs/NumberTestCase.js
@@ -1,0 +1,37 @@
+const React = window.React;
+
+import Fixture from '../../Fixture';
+
+const NumberTestCase = React.createClass({
+  getInitialState() {
+    return { value: '' };
+  },
+  onChange(event) {
+    const parsed = parseFloat(event.target.value, 10)
+    const value = isNaN(parsed) ? '' : parsed
+
+    this.setState({ value })
+  },
+  render() {
+    return (
+      <Fixture>
+        <div>{this.props.children}</div>
+
+        <div className="control-box">
+          <fieldset>
+            <legend>Controlled</legend>
+            <input type="number" value={this.state.value} onChange={this.onChange} />
+            <span className="hint"> Value: {JSON.stringify(this.state.value)}</span>
+          </fieldset>
+
+          <fieldset>
+            <legend>Uncontrolled</legend>
+            <input type="number" defaultValue={0.5} />
+          </fieldset>
+        </div>
+      </Fixture>
+    );
+  },
+});
+
+export default NumberTestCase;

--- a/fixtures/dom/src/components/fixtures/number-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/number-inputs/index.js
@@ -94,10 +94,6 @@ const NumberInputs = React.createClass({
             <li>Press "e", so that the value reads "3.14e"</li>
             <li>The field should read "3.14e"</li>
           </ol>
-          <p className="footnote">
-            <b>Notes:</b> IE does not allow bad input typed into the end of the number.
-            This makes it impossible to type "3.14e".
-          </p>
         </TestCase>
 
         <TestCase>
@@ -110,10 +106,6 @@ const NumberInputs = React.createClass({
             <li>Press "e" twice, so that the value reads "3.ee14"</li>
             <li>The field should read "3.ee14"</li>
           </ol>
-          <p className="footnote">
-            <b>Notes:</b> IE does not allow bad input typed into the middle of the number.
-            This makes it impossible to type "3.ee14".
-          </p>
         </TestCase>
 
         <TestCase>

--- a/fixtures/dom/src/components/fixtures/number-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/number-inputs/index.js
@@ -1,58 +1,33 @@
 const React = window.React;
 
-const TestCase = React.createClass({
-  getInitialState() {
-    return { value: '' };
-  },
-  onChange(event) {
-    const parsed = parseFloat(event.target.value, 10)
-    const value = isNaN(parsed) ? '' : parsed
-
-    this.setState({ value })
-  },
-  render() {
-    return (
-      <section className="test-case">
-        <div>{this.props.children}</div>
-
-        <div className="control-box">
-          <fieldset>
-            <legend>Controlled</legend>
-            <input type="number" value={this.state.value} onChange={this.onChange} />
-            <span className="hint"> Value: {JSON.stringify(this.state.value)}</span>
-          </fieldset>
-
-          <fieldset>
-            <legend>Uncontrolled</legend>
-            <input type="number" defaultValue={0.5} />
-          </fieldset>
-        </div>
-      </section>
-    );
-  },
-});
+import Fixture from '../../Fixture';
+import FixtureSet from '../../FixtureSet';
+import TestCase from '../../TestCase';
+import NumberTestCase from './NumberTestCase';
 
 const NumberInputs = React.createClass({
   render() {
     return (
-      <form>
-        <h1>Number inputs</h1>
-        <p>
-          Number inputs inconsistently assign and report the value
-          property depending on the browser.
-        </p>
-
-        <TestCase>
-          <h2 className="type-subheading">
-            The decimal place should not be lost when backspacing from
-            "3.1" to "3."?
-          </h2>
-
-          <ol>
+      <FixtureSet
+          title="Number inputs"
+          description="Number inputs inconsistently assign and report the value
+                       property depending on the browser."
+      >
+        <TestCase
+            title="Backspacing"
+            description="The decimal place should not be lost"
+        >
+          <TestCase.Steps>
             <li>Type "3.1"</li>
             <li>Press backspace, eliminating the "1"</li>
-            <li>The field should read "3.", preserving the decimal place</li>
-          </ol>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            The field should read "3.", preserving the decimal place
+          </TestCase.ExpectedResult>
+
+          <NumberTestCase />
+
           <p className="footnote">
             <b>Notes:</b> Chrome and Safari clear trailing
             decimals on blur. React makes this concession so that the
@@ -60,76 +35,101 @@ const NumberInputs = React.createClass({
           </p>
         </TestCase>
 
-        <TestCase>
-          <h2 className="type-subheading">
-            Supports decimal precision greater than 2 places
-          </h2>
-
-          <ol>
+        <TestCase
+            title="Decimal precision"
+            description="Supports decimal precision greater than 2 places"
+        >
+          <TestCase.Steps>
             <li>Type "0.01"</li>
-            <li>The field should read "0.01"</li>
-          </ol>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            The field should read "0.01"
+          </TestCase.ExpectedResult>
+
+          <NumberTestCase />
         </TestCase>
 
-        <TestCase>
-          <h2 className="type-subheading">
-            Supports exponent form ("2e4")
-          </h2>
-
-          <ol>
+        <TestCase
+            title="Exponent form"
+            description="Supports exponent form ('2e4')"
+        >
+          <TestCase.Steps>
             <li>Type "2e"</li>
-            <li>The field should read "2e"</li>
             <li>Type 4, to read "2e4"</li>
-            <li>The field should read "2e4"</li>
-            <li>The value should read "20000"</li>
-          </ol>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            The field should read "2e4". The parsed value should read "20000"
+          </TestCase.ExpectedResult>
+
+          <NumberTestCase />
         </TestCase>
 
-        <TestCase>
-          <h2 className="type-subheading">
-            Pressing "e" at the end of a number does not reset the value
-          </h2>
-          <ol>
+        <TestCase
+            title="Exponent Form"
+            description="Pressing 'e' at the end"
+        >
+          <TestCase.Steps>
             <li>Type "3.14"</li>
-            <li>Press "e", so that the value reads "3.14e"</li>
-            <li>The field should read "3.14e"</li>
-          </ol>
+            <li>Press "e", so that the input reads "3.14e"</li>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            The field should read "3.14e", the parsed value should be empty
+          </TestCase.ExpectedResult>
+
+          <NumberTestCase />
         </TestCase>
 
-        <TestCase>
-          <h2 className="type-subheading">
-            Pressing "ee" in the middle of a number does not clear the display value
-          </h2>
-          <ol>
+        <TestCase
+            title="Exponent Form"
+            description="Supports pressing 'ee' in the middle of a number"
+        >
+          <TestCase.Steps>
             <li>Type "3.14"</li>
             <li>Move the text cursor to after the decimal place</li>
             <li>Press "e" twice, so that the value reads "3.ee14"</li>
-            <li>The field should read "3.ee14"</li>
-          </ol>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            The field should read "3.ee14"
+          </TestCase.ExpectedResult>
+
+          <NumberTestCase />
         </TestCase>
 
-        <TestCase>
-          <h2 className="type-subheading">
-            Typing "3.0" preserves the trailing zero
-          </h2>
-          <ol>
+        <TestCase
+            title="Trailing Zeroes"
+            description="Typing '3.0' preserves the trailing zero"
+        >
+          <TestCase.Steps>
             <li>Type "3.0"</li>
-            <li>The field should read "3.0"</li>
-          </ol>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            The field should read "3.0"
+          </TestCase.ExpectedResult>
+
+          <NumberTestCase />
         </TestCase>
 
-        <TestCase>
-          <h2 className="type-subheading">
-            Inserting a decimal in to "300" maintains the trailing zeroes
-          </h2>
-          <ol>
+        <TestCase
+            title="Inserting decimals precision"
+            description="Inserting '.' in to '300' maintains the trailing zeroes"
+        >
+          <TestCase.Steps>
             <li>Type "300"</li>
             <li>Move the cursor to after the "3"</li>
             <li>Type "."</li>
-            <li>The field should read "3.00", not "3"</li>
-          </ol>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            The field should read "3.00", not "3"
+          </TestCase.ExpectedResult>
+          <NumberTestCase />
         </TestCase>
-      </form>
+      </FixtureSet>
     );
   },
 });

--- a/fixtures/dom/src/components/fixtures/number-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/number-inputs/index.js
@@ -5,7 +5,10 @@ const TestCase = React.createClass({
     return { value: '' };
   },
   onChange(event) {
-    this.setState({ value: event.target.value });
+    const parsed = parseFloat(event.target.value, 10)
+    const value = isNaN(parsed) ? '' : parsed
+
+    this.setState({ value: value })
   },
   render() {
     return (
@@ -66,11 +69,6 @@ const NumberInputs = React.createClass({
             <li>Type "0.01"</li>
             <li>The field should read "0.01"</li>
           </ol>
-          <p className="footnote">
-            <b>Notes:</b> Chrome and Safari clear trailing
-            decimals on blur. React makes this concession so that the
-            value attribute remains in sync with the value property.
-          </p>
         </TestCase>
 
         <TestCase>

--- a/fixtures/dom/src/components/fixtures/number-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/number-inputs/index.js
@@ -8,7 +8,7 @@ const TestCase = React.createClass({
     const parsed = parseFloat(event.target.value, 10)
     const value = isNaN(parsed) ? '' : parsed
 
-    this.setState({ value: value })
+    this.setState({ value })
   },
   render() {
     return (
@@ -68,6 +68,20 @@ const NumberInputs = React.createClass({
           <ol>
             <li>Type "0.01"</li>
             <li>The field should read "0.01"</li>
+          </ol>
+        </TestCase>
+
+        <TestCase>
+          <h2 className="type-subheading">
+            Supports exponent form ("2e4")
+          </h2>
+
+          <ol>
+            <li>Type "2e"</li>
+            <li>The field should read "2e"</li>
+            <li>Type 4, to read "2e4"</li>
+            <li>The field should read "2e4"</li>
+            <li>The value should read "20000"</li>
           </ol>
         </TestCase>
 

--- a/fixtures/dom/src/components/fixtures/number-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/number-inputs/index.js
@@ -1,6 +1,5 @@
 const React = window.React;
 
-import Fixture from '../../Fixture';
 import FixtureSet from '../../FixtureSet';
 import TestCase from '../../TestCase';
 import NumberTestCase from './NumberTestCase';
@@ -126,6 +125,36 @@ const NumberInputs = React.createClass({
 
           <TestCase.ExpectedResult>
             The field should read "3.00", not "3"
+          </TestCase.ExpectedResult>
+          <NumberTestCase />
+        </TestCase>
+
+        <TestCase
+            title="Appending -"
+            description="Adding '-' to the end of '3' maintains the trailing dash"
+        >
+          <TestCase.Steps>
+            <li>Type "3"</li>
+            <li>Type '-'</li>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            The field should read "3-", not "3"
+          </TestCase.ExpectedResult>
+          <NumberTestCase />
+        </TestCase>
+
+        <TestCase
+            title="Negative numbers"
+            description="Typing minus when inserting a negative number should work"
+        >
+          <TestCase.Steps>
+            <li>Type "-"</li>
+            <li>Type '3'</li>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            The field should read "-3".
           </TestCase.ExpectedResult>
           <NumberTestCase />
         </TestCase>

--- a/fixtures/dom/src/components/fixtures/number-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/number-inputs/index.js
@@ -130,16 +130,17 @@ const NumberInputs = React.createClass({
         </TestCase>
 
         <TestCase
-            title="Appending -"
-            description="Adding '-' to the end of '3' maintains the trailing dash"
+            title="Replacing numbers with -"
+            description="Replacing a number with the '-' sign should not clear the value"
         >
           <TestCase.Steps>
             <li>Type "3"</li>
-            <li>Type '-'</li>
+            <li>Select the entire value"</li>
+            <li>Type '-' to replace '3' with '-'</li>
           </TestCase.Steps>
 
           <TestCase.ExpectedResult>
-            The field should read "3-", not "3"
+            The field should read "-", not be blank.
           </TestCase.ExpectedResult>
           <NumberTestCase />
         </TestCase>

--- a/fixtures/dom/src/components/fixtures/number-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/number-inputs/index.js
@@ -1,0 +1,133 @@
+const React = window.React;
+
+const TestCase = React.createClass({
+  getInitialState() {
+    return { value: '' };
+  },
+  onChange(event) {
+    this.setState({ value: event.target.value });
+  },
+  render() {
+    return (
+      <section className="test-case">
+        <div>{this.props.children}</div>
+
+        <div className="control-box">
+          <fieldset>
+            <legend>Controlled</legend>
+            <input type="number" value={this.state.value} onChange={this.onChange} />
+            <span className="hint"> Value: {JSON.stringify(this.state.value)}</span>
+          </fieldset>
+
+          <fieldset>
+            <legend>Uncontrolled</legend>
+            <input type="number" defaultValue={0.5} />
+          </fieldset>
+        </div>
+      </section>
+    );
+  },
+});
+
+const NumberInputs = React.createClass({
+  render() {
+    return (
+      <form>
+        <h1>Number inputs</h1>
+        <p>
+          Number inputs inconsistently assign and report the value
+          property depending on the browser.
+        </p>
+
+        <TestCase>
+          <h2 className="type-subheading">
+            The decimal place should not be lost when backspacing from
+            "3.1" to "3."?
+          </h2>
+
+          <ol>
+            <li>Type "3.1"</li>
+            <li>Press backspace, eliminating the "1"</li>
+            <li>The field should read "3.", preserving the decimal place</li>
+          </ol>
+          <p className="footnote">
+            <b>Notes:</b> Chrome and Safari clear trailing
+            decimals on blur. React makes this concession so that the
+            value attribute remains in sync with the value property.
+          </p>
+        </TestCase>
+
+        <TestCase>
+          <h2 className="type-subheading">
+            Supports decimal precision greater than 2 places
+          </h2>
+
+          <ol>
+            <li>Type "0.01"</li>
+            <li>The field should read "0.01"</li>
+          </ol>
+          <p className="footnote">
+            <b>Notes:</b> Chrome and Safari clear trailing
+            decimals on blur. React makes this concession so that the
+            value attribute remains in sync with the value property.
+          </p>
+        </TestCase>
+
+        <TestCase>
+          <h2 className="type-subheading">
+            Pressing "e" at the end of a number does not reset the value
+          </h2>
+          <ol>
+            <li>Type "3.14"</li>
+            <li>Press "e", so that the value reads "3.14e"</li>
+            <li>The field should read "3.14e"</li>
+          </ol>
+          <p className="footnote">
+            <b>Notes:</b> IE does not allow bad input typed into the end of the number.
+            This makes it impossible to type "3.14e".
+          </p>
+        </TestCase>
+
+        <TestCase>
+          <h2 className="type-subheading">
+            Pressing "ee" in the middle of a number does not clear the display value
+          </h2>
+          <ol>
+            <li>Type "3.14"</li>
+            <li>Move the text cursor to after the decimal place</li>
+            <li>Press "e" twice, so that the value reads "3.ee14"</li>
+            <li>The field should read "3.ee14"</li>
+          </ol>
+          <p className="footnote">
+            <b>Notes:</b> IE does not allow bad input typed into the middle of the number.
+            This makes it impossible to type "3.ee14".
+          </p>
+        </TestCase>
+
+        <TestCase>
+          <h2 className="type-subheading">
+            Typing "3.0" preserves the trailing zero
+          </h2>
+          <ol>
+            <li>Type "3.0"</li>
+            <li>The field should read "3.0"</li>
+          </ol>
+        </TestCase>
+
+        <TestCase>
+          <h2 className="type-subheading">
+            Inserting a decimal in to "300" maintains the trailing zeroes
+          </h2>
+          <ol>
+            <li>Type "300"</li>
+            <li>Move the cursor to after the "3"</li>
+            <li>Type "."</li>
+            <li>The field should read "3.00", not "3"</li>
+          </ol>
+        </TestCase>
+      </form>
+    );
+  },
+});
+
+export default NumberInputs;

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1445,6 +1445,9 @@ src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
 * sets value properly with type coming later in props
 * does not raise a validation warning when it switches types
 * resets value of date/time input to fix bugs in iOS Safari
+* always sets the attribute when values change on text inputs
+* does not set the value attribute on number inputs if focused
+* sets the value attribute on number inputs on blur
 
 src/renderers/dom/shared/wrappers/__tests__/ReactDOMOption-test.js
 * should flatten children to a string

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1411,7 +1411,10 @@ src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
 * should allow setting `value` to `objToString`
 * should not incur unnecessary DOM mutations
 * should properly control a value of number `0`
+* should properly control 0.0 for a text input
+* should properly control 0.0 for a number input
 * should properly transition from an empty value to 0
+* should properly transition from 0 to an empty value
 * should have the correct target value
 * should not set a value for submit buttons unnecessarily
 * should control radio buttons

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -837,6 +837,8 @@ src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
 * should set className to empty string instead of null
 * should remove property properly for boolean properties
 * should remove property properly even with different name
+* should update an empty attribute to zero
+* should always assign the value attribute for non-inputs
 * should remove attributes for normal properties
 * should not remove attributes for special properties
 * should not leave all options selected when deleting multiple
@@ -1409,6 +1411,7 @@ src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
 * should allow setting `value` to `objToString`
 * should not incur unnecessary DOM mutations
 * should properly control a value of number `0`
+* should properly transition from an empty value to 0
 * should have the correct target value
 * should not set a value for submit buttons unnecessarily
 * should control radio buttons

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1448,6 +1448,8 @@ src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
 * always sets the attribute when values change on text inputs
 * does not set the value attribute on number inputs if focused
 * sets the value attribute on number inputs on blur
+* an uncontrolled number input will not update the value attribute on blur
+* an uncontrolled text input will not update the value attribute on blur
 
 src/renderers/dom/shared/wrappers/__tests__/ReactDOMOption-test.js
 * should flatten children to a string

--- a/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
+++ b/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
@@ -199,12 +199,14 @@ var ReactDOMInput = {
         // Simulate `input.valueAsNumber`. IE9 does not support it
         var valueAsNumber = parseFloat(node.value, 10) || 0;
 
-        if (value != valueAsNumber) { // eslint-disable-line
+        // eslint-disable-next-line
+        if (value != valueAsNumber) {
           // Cast `value` to a string to ensure the value is set correctly. While
           // browsers typically do this as necessary, jsdom doesn't.
           node.value = '' + value;
         }
-      } else if (value != node.value) { // eslint-disable-line
+        // eslint-disable-next-line
+      } else if (value != node.value) {
         // Cast `value` to a string to ensure the value is set correctly. While
         // browsers typically do this as necessary, jsdom doesn't.
         node.value = '' + value;

--- a/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
+++ b/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
@@ -138,7 +138,7 @@ var ReactDOMInput = {
         ? props.checked
         : props.defaultChecked,
       initialValue: props.value != null ? props.value : defaultValue,
-      controlled: isControlled(props)
+      controlled: isControlled(props),
     };
   },
 

--- a/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
+++ b/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
@@ -138,11 +138,8 @@ var ReactDOMInput = {
         ? props.checked
         : props.defaultChecked,
       initialValue: props.value != null ? props.value : defaultValue,
+      controlled: isControlled(props)
     };
-
-    if (__DEV__) {
-      node._wrapperState.controlled = isControlled(props);
-    }
   },
 
   updateWrapper: function(element: Element, props: Object) {

--- a/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
+++ b/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
@@ -192,13 +192,22 @@ var ReactDOMInput = {
 
     var value = props.value;
     if (value != null) {
-      // Cast `value` to a string to ensure the value is set correctly. While
-      // browsers typically do this as necessary, jsdom doesn't.
-      var newValue = '' + value;
+      if (value === 0 && node.value === '') {
+        node.value = '0';
+        // Note: IE9 reports a number inputs as 'text', so check props instead.
+      } else if (props.type === 'number') {
+        // Simulate `input.valueAsNumber`. IE9 does not support it
+        var valueAsNumber = parseFloat(node.value, 10) || 0;
 
-      // To avoid side effects (such as losing text selection), only set value if changed
-      if (newValue !== node.value) {
-        node.value = newValue;
+        if (value != valueAsNumber) { // eslint-disable-line
+          // Cast `value` to a string to ensure the value is set correctly. While
+          // browsers typically do this as necessary, jsdom doesn't.
+          node.value = '' + value;
+        }
+      } else if (value != node.value) { // eslint-disable-line
+        // Cast `value` to a string to ensure the value is set correctly. While
+        // browsers typically do this as necessary, jsdom doesn't.
+        node.value = '' + value;
       }
     } else {
       if (props.value == null && props.defaultValue != null) {

--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -160,8 +160,8 @@ var DOMPropertyOperations = {
           (propertyInfo.hasOverloadedBooleanValue && value === true)
         ) {
           node.setAttribute(attributeName, '');
-        } else if (attributeName === 'value') {
-          if (node.value !== value) {
+        } else if (attributeName === 'value' && node.hasAttribute('value')) {
+          if (node.value != value) {
             node.setAttribute(attributeName, '' + value);
           }
         } else {

--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -161,7 +161,9 @@ var DOMPropertyOperations = {
         ) {
           node.setAttribute(attributeName, '');
         } else if (attributeName === 'value' && node.hasAttribute('value')) {
-          if (node.value != value) {
+          // Use loose coercion to prevent replacement on comparisons like
+          // '3e1' == 30 in Chrome (~52).
+          if (node.value != value) { // eslint-disable-line
             node.setAttribute(attributeName, '' + value);
           }
         } else {

--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -160,12 +160,6 @@ var DOMPropertyOperations = {
           (propertyInfo.hasOverloadedBooleanValue && value === true)
         ) {
           node.setAttribute(attributeName, '');
-        } else if (attributeName === 'value' && node.hasAttribute('value')) {
-          // Use loose coercion to prevent replacement on comparisons like
-          // '3e1' == 30 in Chrome (~52).
-          if (node.value != value) { // eslint-disable-line
-            node.setAttribute(attributeName, '' + value);
-          }
         } else {
           node.setAttribute(attributeName, '' + value);
         }

--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -160,6 +160,10 @@ var DOMPropertyOperations = {
           (propertyInfo.hasOverloadedBooleanValue && value === true)
         ) {
           node.setAttribute(attributeName, '');
+        } else if (attributeName === 'value') {
+          if (node.value != value) {
+            node.value = '' + value;
+          }
         } else {
           node.setAttribute(attributeName, '' + value);
         }

--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -161,8 +161,8 @@ var DOMPropertyOperations = {
         ) {
           node.setAttribute(attributeName, '');
         } else if (attributeName === 'value') {
-          if (node.value != value) {
-            node.value = '' + value;
+          if (node.value !== value) {
+            node.setAttribute(attributeName, '' + value);
           }
         } else {
           node.setAttribute(attributeName, '' + value);

--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -210,6 +210,23 @@ var HTMLDOMPropertyConfig = {
     httpEquiv: 'http-equiv',
   },
   DOMPropertyNames: {},
+  DOMMutationMethods: {
+    value: function (node, value) {
+      if (value == null) {
+        return node.removeAttribute('value');
+      }
+
+      if (node.hasAttribute('value')) {
+        // Use loose coercion to prevent replacement on comparisons like
+        // '3e1' == 30 in Chrome (~52).
+        if (node.value == value) { // eslint-disable-line
+          return;
+        }
+      }
+
+      node.setAttribute('value', '' + value);
+    }
+  }
 };
 
 module.exports = HTMLDOMPropertyConfig;

--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -221,9 +221,11 @@ var HTMLDOMPropertyConfig = {
       // https://github.com/facebook/react/issues/7253#issuecomment-236074326
       if (node.type !== 'number' || node.hasAttribute('value') === false) {
         node.setAttribute('value', '' + value);
-      } else if (node.validity &&
-                 !node.validity.badInput &&
-                 node.ownerDocument.activeElement !== node) {
+      } else if (
+        node.validity &&
+        !node.validity.badInput &&
+        node.ownerDocument.activeElement !== node
+      ) {
         // Don't assign an attribute if validation reports bad
         // input. Chrome will clear the value. Additionally, don't
         // operate on inputs that have focus, otherwise Chrome might

--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -211,22 +211,27 @@ var HTMLDOMPropertyConfig = {
   },
   DOMPropertyNames: {},
   DOMMutationMethods: {
-    value: function (node, value) {
+    value: function(node, value) {
       if (value == null) {
         return node.removeAttribute('value');
       }
 
       if (node.hasAttribute('value')) {
+        if (value === 0) {
+          // Since we use loose type checking below, zero is
+          // falsy, so we need to manually cover it
+          value = '0';
+        }
         // Use loose coercion to prevent replacement on comparisons like
         // '3e1' == 30 in Chrome (~52).
         if (node.value == value) { // eslint-disable-line
-          return;
+          return false;
         }
       }
 
       node.setAttribute('value', '' + value);
-    }
-  }
+    },
+  },
 };
 
 module.exports = HTMLDOMPropertyConfig;

--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -216,20 +216,11 @@ var HTMLDOMPropertyConfig = {
         return node.removeAttribute('value');
       }
 
-      if (node.hasAttribute('value')) {
-        if (value === 0) {
-          // Since we use loose type checking below, zero is
-          // falsy, so we need to manually cover it
-          value = '0';
-        }
-        // Use loose coercion to prevent replacement on comparisons like
-        // '3e1' == 30 in Chrome (~52).
-        if (node.value == value) { // eslint-disable-line
-          return false;
-        }
+      // Don't update number inputs inputs if they have bad input.
+      // Chrome clears bad input and drops trailing decimal places
+      if (node.type !== 'number' || node.validity.badInput === false) {
+        node.setAttribute('value', '' + value);
       }
-
-      node.setAttribute('value', '' + value);
     },
   },
 };

--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -219,7 +219,7 @@ var HTMLDOMPropertyConfig = {
       // Number inputs get special treatment due to some edge cases in
       // Chrome. Let everything else assign the value attribute as normal.
       // https://github.com/facebook/react/issues/7253#issuecomment-236074326
-      if (node.type !== 'number') {
+      if (node.type !== 'number' || node.hasAttribute('value') === false) {
         node.setAttribute('value', '' + value);
       } else if (node.validity &&
                  !node.validity.badInput &&

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -295,7 +295,14 @@ describe('DOMPropertyOperations', () => {
       expect(stubNode.className).toBe('');
     });
 
+  });
+
+  describe('value mutation method', function() {
     it('should not update numeric values when the input.value is loosely the same', function() {
+      var stubNode = document.createElement('input');
+      var stubInstance = {_debugID: 1};
+      ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
+
       stubNode.setAttribute('type', 'number');
       stubNode.setAttribute('value', '3e1');
       // Keep in sync. The comparison occurs between setAttribute and value.
@@ -307,6 +314,34 @@ describe('DOMPropertyOperations', () => {
 
       expect(stubNode.setAttribute.calls.count()).toBe(0);
     });
+
+    it('should update an empty attribute to zero', function() {
+      var stubNode = document.createElement('input');
+      var stubInstance = {_debugID: 1};
+      ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
+
+      stubNode.setAttribute('type', 'radio')
+
+      DOMPropertyOperations.setValueForProperty(stubNode, 'value', '');
+      spyOn(stubNode, 'setAttribute');
+      DOMPropertyOperations.setValueForProperty(stubNode, 'value', 0);
+
+      expect(stubNode.setAttribute.calls.count()).toBe(1);
+    });
+
+    it('should always assign the value attribute for non-inputs', function() {
+      var stubNode = document.createElement('progress');
+      var stubInstance = {_debugID: 1};
+      ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
+
+      spyOn(stubNode, 'setAttribute');
+
+      DOMPropertyOperations.setValueForProperty(stubNode, 'value', 30);
+      DOMPropertyOperations.setValueForProperty(stubNode, 'value', '30');
+
+      expect(stubNode.setAttribute.calls.count()).toBe(2);
+    });
+
   });
 
   describe('deleteValueForProperty', () => {

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -294,6 +294,19 @@ describe('DOMPropertyOperations', () => {
       // some browsers)
       expect(stubNode.className).toBe('');
     });
+
+    it('should not update numeric values when the input.value is loosely the same', function() {
+      stubNode.setAttribute('type', 'number');
+      stubNode.setAttribute('value', '3e1');
+      // Keep in sync. The comparison occurs between setAttribute and value.
+      stubNode.value = '3e1';
+
+      spyOn(stubNode, 'setAttribute');
+
+      DOMPropertyOperations.setValueForProperty(stubNode, 'value', 30);
+
+      expect(stubNode.setAttribute.calls.count()).toBe(0);
+    });
   });
 
   describe('deleteValueForProperty', () => {

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -320,7 +320,7 @@ describe('DOMPropertyOperations', () => {
       var stubInstance = {_debugID: 1};
       ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
 
-      stubNode.setAttribute('type', 'radio')
+      stubNode.setAttribute('type', 'radio');
 
       DOMPropertyOperations.setValueForProperty(stubNode, 'value', '');
       spyOn(stubNode, 'setAttribute');

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -298,23 +298,6 @@ describe('DOMPropertyOperations', () => {
   });
 
   describe('value mutation method', function() {
-    it('should not update numeric values when the input.value is loosely the same', function() {
-      var stubNode = document.createElement('input');
-      var stubInstance = {_debugID: 1};
-      ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
-
-      stubNode.setAttribute('type', 'number');
-      stubNode.setAttribute('value', '3e1');
-      // Keep in sync. The comparison occurs between setAttribute and value.
-      stubNode.value = '3e1';
-
-      spyOn(stubNode, 'setAttribute');
-
-      DOMPropertyOperations.setValueForProperty(stubNode, 'value', 30);
-
-      expect(stubNode.setAttribute.calls.count()).toBe(0);
-    });
-
     it('should update an empty attribute to zero', function() {
       var stubNode = document.createElement('input');
       var stubInstance = {_debugID: 1};

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -294,7 +294,6 @@ describe('DOMPropertyOperations', () => {
       // some browsers)
       expect(stubNode.className).toBe('');
     });
-
   });
 
   describe('value mutation method', function() {
@@ -324,7 +323,6 @@ describe('DOMPropertyOperations', () => {
 
       expect(stubNode.setAttribute.calls.count()).toBe(2);
     });
-
   });
 
   describe('deleteValueForProperty', () => {

--- a/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
@@ -258,6 +258,16 @@ function getTargetInstForInputOrChangeEvent(topLevelType, targetInst) {
   }
 }
 
+function handleControlledInputBlur(inst, node) {
+  if (node.type !== 'number') {
+    return;
+  }
+
+  if (inst._currentElement && inst._currentElement.props.hasOwnProperty('value')) {
+    node.setAttribute('value', '' + node.value);
+  }
+}
+
 /**
  * This plugin creates an `onChange` event that normalizes change events
  * across form elements. This event fires at a time when it's possible to
@@ -318,8 +328,8 @@ var ChangeEventPlugin = {
     }
 
     // When blurring, set the value attribute for number inputs
-    if (topLevelType === 'topBlur' && targetNode.type === 'number') {
-      targetNode.setAttribute('value', targetNode.value);
+    if (topLevelType === 'topBlur') {
+      handleControlledInputBlur(targetInst, targetNode);
     }
   },
 };

--- a/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
@@ -267,7 +267,10 @@ function handleControlledInputBlur(inst, node) {
   }
 
   // If controlled, assign the value attribute to the current value on blur
-  node.setAttribute('value', '' + node.value);
+  let value = '' + node.value;
+  if (node.getAttribute('value') !== value) {
+    node.setAttribute('value', value);
+  }
 }
 
 /**

--- a/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
@@ -318,7 +318,7 @@ var ChangeEventPlugin = {
     }
 
     // When blurring, set the value attribute for number inputs
-    if (topLevelType === 'topBlur') {
+    if (topLevelType === 'topBlur' && targetNode.type === 'number') {
       targetNode.setAttribute('value', targetNode.value);
     }
   },

--- a/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
@@ -262,7 +262,7 @@ function handleControlledInputBlur(inst, node) {
   // Fiber and ReactDOM keep wrapper state in separate places
   let state = inst._wrapperState || node._wrapperState;
 
-  if (!state || node.type !== 'number' || !state.controlled) {
+  if (!state || !state.controlled || node.type !== 'number') {
     return;
   }
 

--- a/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
@@ -259,13 +259,15 @@ function getTargetInstForInputOrChangeEvent(topLevelType, targetInst) {
 }
 
 function handleControlledInputBlur(inst, node) {
-  if (node.type !== 'number') {
+  // Fiber and ReactDOM keep wrapper state in separate places
+  let state = inst._wrapperState || node._wrapperState;
+
+  if (!state || node.type !== 'number' || !state.controlled) {
     return;
   }
 
-  if (inst._currentElement && inst._currentElement.props.hasOwnProperty('value')) {
-    node.setAttribute('value', '' + node.value);
-  }
+  // If controlled, assign the value attribute to the current value on blur
+  node.setAttribute('value', '' + node.value);
 }
 
 /**

--- a/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
@@ -259,6 +259,11 @@ function getTargetInstForInputOrChangeEvent(topLevelType, targetInst) {
 }
 
 function handleControlledInputBlur(inst, node) {
+  // TODO: In IE, inst is occasionally null. Why?
+  if (inst == null) {
+    return;
+  }
+
   // Fiber and ReactDOM keep wrapper state in separate places
   let state = inst._wrapperState || node._wrapperState;
 

--- a/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
@@ -316,6 +316,11 @@ var ChangeEventPlugin = {
     if (handleEventFunc) {
       handleEventFunc(topLevelType, targetNode, targetInst);
     }
+
+    // When blurring, set the value attribute for number inputs
+    if (topLevelType === 'topBlur') {
+      targetNode.setAttribute('value', targetNode.value);
+    }
   },
 };
 

--- a/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
@@ -423,6 +423,17 @@ describe('ReactDOMInput', () => {
     expect(node.value).toBe('0');
   });
 
+  it('should properly transition from an empty value to 0', function() {
+    var container = document.createElement('div');
+
+    ReactDOM.render(<input type="text" value="" />, container);
+    ReactDOM.render(<input type="text" value={0} />, container);
+
+    var node = container.firstChild;
+
+    expect(node.value).toBe('0');
+  });
+
   it('should have the correct target value', () => {
     var handled = false;
     var handler = function(event) {

--- a/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
@@ -1138,6 +1138,17 @@ describe('ReactDOMInput', () => {
 
       expect(node.getAttribute('value')).toBe('2');
     });
+
+    it('an uncontrolled input will not update the value attribute on blur', () => {
+      var stub = ReactTestUtils.renderIntoDocument(<input type="number" defaultValue="1" />);
+      var node = ReactDOM.findDOMNode(stub);
+
+      node.value = 4;
+
+      ReactTestUtils.SimulateNative.blur(node);
+
+      expect(node.getAttribute('value')).toBe('1');
+    });
   });
 
 });

--- a/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
@@ -1085,4 +1085,61 @@ describe('ReactDOMInput', () => {
       'node.setAttribute("checked", "")',
     ]);
   });
+
+  describe('assigning the value attribute on controlled inputs', function() {
+    function getTestInput() {
+      return React.createClass({
+        getInitialState: function() {
+          return {
+            value: this.props.value == null ? '' : this.props.value
+          };
+        },
+        onChange: function(event) {
+          this.setState({ value: event.target.value });
+        },
+        render: function() {
+          var type = this.props.type;
+          var value = this.state.value;
+
+          return (<input type={type} value={value} onChange={this.onChange} />);
+        }
+      });
+    }
+
+    it('always sets the attribute when values change on text inputs', function() {
+      var Input = getTestInput()
+      var stub = ReactTestUtils.renderIntoDocument(<Input type="text" />);
+      var node = ReactDOM.findDOMNode(stub);
+
+      ReactTestUtils.Simulate.change(node, { target: { value: '2'} });
+
+      expect(node.getAttribute('value')).toBe('2');
+    })
+
+    it('does not set the value attribute on number inputs if focused', () => {
+      var Input = getTestInput()
+      var stub = ReactTestUtils.renderIntoDocument(<Input type="number" value="1" />);
+      var node = ReactDOM.findDOMNode(stub);
+
+      node.focus();
+
+      ReactTestUtils.Simulate.change(node, { target: { value: '2'} });
+
+      expect(node.getAttribute('value')).toBe('1');
+    });
+
+    it('sets the value attribute on number inputs on blur', () => {
+      var Input = getTestInput()
+      var stub = ReactTestUtils.renderIntoDocument(<Input type="number" value="1" />);
+      var node = ReactDOM.findDOMNode(stub);
+
+      node.focus();
+
+      ReactTestUtils.Simulate.change(node, { target: { value: '2'} });
+      ReactTestUtils.SimulateNative.blur(node)
+
+      expect(node.getAttribute('value')).toBe('2');
+    });
+  });
+
 });

--- a/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
@@ -423,6 +423,16 @@ describe('ReactDOMInput', () => {
     expect(node.value).toBe('0');
   });
 
+  it('should properly control a value of number `0.0`', () => {
+    var stub = <input type="text" value={0} onChange={emptyFunction} />;
+    stub = ReactTestUtils.renderIntoDocument(stub);
+    var node = ReactDOM.findDOMNode(stub);
+
+    node.value = '0.0';
+    ReactTestUtils.Simulate.change(node, { target: { value: '0.0' }});
+    expect(node.value).toBe('0.0');
+  });
+
   it('should properly transition from an empty value to 0', function() {
     var container = document.createElement('div');
 
@@ -432,6 +442,17 @@ describe('ReactDOMInput', () => {
     var node = container.firstChild;
 
     expect(node.value).toBe('0');
+  });
+
+  it('should properly transition from 0 to an empty value', function() {
+    var container = document.createElement('div');
+
+    ReactDOM.render(<input type="text" value={0} />, container);
+    ReactDOM.render(<input type="text" value="" />, container);
+
+    var node = container.firstChild;
+
+    expect(node.value).toBe('');
   });
 
   it('should have the correct target value', () => {

--- a/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
@@ -1091,7 +1091,7 @@ describe('ReactDOMInput', () => {
       return React.createClass({
         getInitialState: function() {
           return {
-            value: this.props.value == null ? '' : this.props.value
+            value: this.props.value == null ? '' : this.props.value,
           };
         },
         onChange: function(event) {
@@ -1102,22 +1102,22 @@ describe('ReactDOMInput', () => {
           var value = this.state.value;
 
           return (<input type={type} value={value} onChange={this.onChange} />);
-        }
+        },
       });
     }
 
     it('always sets the attribute when values change on text inputs', function() {
-      var Input = getTestInput()
+      var Input = getTestInput();
       var stub = ReactTestUtils.renderIntoDocument(<Input type="text" />);
       var node = ReactDOM.findDOMNode(stub);
 
       ReactTestUtils.Simulate.change(node, { target: { value: '2'} });
 
       expect(node.getAttribute('value')).toBe('2');
-    })
+    });
 
     it('does not set the value attribute on number inputs if focused', () => {
-      var Input = getTestInput()
+      var Input = getTestInput();
       var stub = ReactTestUtils.renderIntoDocument(<Input type="number" value="1" />);
       var node = ReactDOM.findDOMNode(stub);
 
@@ -1129,14 +1129,12 @@ describe('ReactDOMInput', () => {
     });
 
     it('sets the value attribute on number inputs on blur', () => {
-      var Input = getTestInput()
+      var Input = getTestInput();
       var stub = ReactTestUtils.renderIntoDocument(<Input type="number" value="1" />);
       var node = ReactDOM.findDOMNode(stub);
 
-      node.focus();
-
       ReactTestUtils.Simulate.change(node, { target: { value: '2'} });
-      ReactTestUtils.SimulateNative.blur(node)
+      ReactTestUtils.SimulateNative.blur(node);
 
       expect(node.getAttribute('value')).toBe('2');
     });

--- a/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
@@ -1139,8 +1139,19 @@ describe('ReactDOMInput', () => {
       expect(node.getAttribute('value')).toBe('2');
     });
 
-    it('an uncontrolled input will not update the value attribute on blur', () => {
+    it('an uncontrolled number input will not update the value attribute on blur', () => {
       var stub = ReactTestUtils.renderIntoDocument(<input type="number" defaultValue="1" />);
+      var node = ReactDOM.findDOMNode(stub);
+
+      node.value = 4;
+
+      ReactTestUtils.SimulateNative.blur(node);
+
+      expect(node.getAttribute('value')).toBe('1');
+    });
+
+    it('an uncontrolled text input will not update the value attribute on blur', () => {
+      var stub = ReactTestUtils.renderIntoDocument(<input type="text" defaultValue="1" />);
       var node = ReactDOM.findDOMNode(stub);
 
       node.value = 4;

--- a/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
@@ -423,8 +423,18 @@ describe('ReactDOMInput', () => {
     expect(node.value).toBe('0');
   });
 
-  it('should properly control a value of number `0.0`', () => {
+  it('should properly control 0.0 for a text input', () => {
     var stub = <input type="text" value={0} onChange={emptyFunction} />;
+    stub = ReactTestUtils.renderIntoDocument(stub);
+    var node = ReactDOM.findDOMNode(stub);
+
+    node.value = '0.0';
+    ReactTestUtils.Simulate.change(node, { target: { value: '0.0' }});
+    expect(node.value).toBe('0.0');
+  });
+
+  it('should properly control 0.0 for a number input', () => {
+    var stub = <input type="number" value={0} onChange={emptyFunction} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
     var node = ReactDOM.findDOMNode(stub);
 

--- a/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
@@ -429,7 +429,7 @@ describe('ReactDOMInput', () => {
     var node = ReactDOM.findDOMNode(stub);
 
     node.value = '0.0';
-    ReactTestUtils.Simulate.change(node, { target: { value: '0.0' }});
+    ReactTestUtils.Simulate.change(node, {target: {value: '0.0'}});
     expect(node.value).toBe('0.0');
   });
 
@@ -439,7 +439,7 @@ describe('ReactDOMInput', () => {
     var node = ReactDOM.findDOMNode(stub);
 
     node.value = '0.0';
-    ReactTestUtils.Simulate.change(node, { target: { value: '0.0' }});
+    ReactTestUtils.Simulate.change(node, {target: {value: '0.0'}});
     expect(node.value).toBe('0.0');
   });
 
@@ -1126,13 +1126,13 @@ describe('ReactDOMInput', () => {
           };
         },
         onChange: function(event) {
-          this.setState({ value: event.target.value });
+          this.setState({value: event.target.value});
         },
         render: function() {
           var type = this.props.type;
           var value = this.state.value;
 
-          return (<input type={type} value={value} onChange={this.onChange} />);
+          return <input type={type} value={value} onChange={this.onChange} />;
         },
       });
     }
@@ -1142,36 +1142,42 @@ describe('ReactDOMInput', () => {
       var stub = ReactTestUtils.renderIntoDocument(<Input type="text" />);
       var node = ReactDOM.findDOMNode(stub);
 
-      ReactTestUtils.Simulate.change(node, { target: { value: '2'} });
+      ReactTestUtils.Simulate.change(node, {target: {value: '2'}});
 
       expect(node.getAttribute('value')).toBe('2');
     });
 
     it('does not set the value attribute on number inputs if focused', () => {
       var Input = getTestInput();
-      var stub = ReactTestUtils.renderIntoDocument(<Input type="number" value="1" />);
+      var stub = ReactTestUtils.renderIntoDocument(
+        <Input type="number" value="1" />,
+      );
       var node = ReactDOM.findDOMNode(stub);
 
       node.focus();
 
-      ReactTestUtils.Simulate.change(node, { target: { value: '2'} });
+      ReactTestUtils.Simulate.change(node, {target: {value: '2'}});
 
       expect(node.getAttribute('value')).toBe('1');
     });
 
     it('sets the value attribute on number inputs on blur', () => {
       var Input = getTestInput();
-      var stub = ReactTestUtils.renderIntoDocument(<Input type="number" value="1" />);
+      var stub = ReactTestUtils.renderIntoDocument(
+        <Input type="number" value="1" />,
+      );
       var node = ReactDOM.findDOMNode(stub);
 
-      ReactTestUtils.Simulate.change(node, { target: { value: '2'} });
+      ReactTestUtils.Simulate.change(node, {target: {value: '2'}});
       ReactTestUtils.SimulateNative.blur(node);
 
       expect(node.getAttribute('value')).toBe('2');
     });
 
     it('an uncontrolled number input will not update the value attribute on blur', () => {
-      var stub = ReactTestUtils.renderIntoDocument(<input type="number" defaultValue="1" />);
+      var stub = ReactTestUtils.renderIntoDocument(
+        <input type="number" defaultValue="1" />,
+      );
       var node = ReactDOM.findDOMNode(stub);
 
       node.value = 4;
@@ -1182,7 +1188,9 @@ describe('ReactDOMInput', () => {
     });
 
     it('an uncontrolled text input will not update the value attribute on blur', () => {
-      var stub = ReactTestUtils.renderIntoDocument(<input type="text" defaultValue="1" />);
+      var stub = ReactTestUtils.renderIntoDocument(
+        <input type="text" defaultValue="1" />,
+      );
       var node = ReactDOM.findDOMNode(stub);
 
       node.value = 4;
@@ -1192,5 +1200,4 @@ describe('ReactDOMInput', () => {
       expect(node.getAttribute('value')).toBe('1');
     });
   });
-
 });

--- a/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
@@ -49,27 +49,24 @@ var ReactDOMInput = {
     var value = props.value;
     var checked = props.checked;
 
-    var hostProps = Object.assign(
-      {
-        // Make sure we set .type before any other properties (setting .value
-        // before .type means .value is lost in IE11 and below)
-        type: undefined,
-        // Make sure we set .step before .value (setting .value before .step
-        // means .value is rounded on mount, based upon step precision)
-        step: undefined,
-        // Make sure we set .min & .max before .value (to ensure proper order
-        // in corner cases such as min or max deriving from value, e.g. Issue #7170)
-        min: undefined,
-        max: undefined,
-      },
-      props,
-      {
-        defaultChecked: undefined,
-        defaultValue: undefined,
-        value: value != null ? value : inst._wrapperState.initialValue,
-        checked: checked != null ? checked : inst._wrapperState.initialChecked,
-      },
-    );
+    var hostProps = Object.assign({
+      // Make sure we set .type before any other properties (setting .value
+      // before .type means .value is lost in IE11 and below)
+      type: undefined,
+      // Make sure we set .step before .value (setting .value before .step
+      // means .value is rounded on mount, based upon step precision)
+      step: undefined,
+      // Make sure we set .min & .max before .value (to ensure proper order
+      // in corner cases such as min or max deriving from value, e.g. Issue #7170)
+      min: undefined,
+      max: undefined,
+    }, props, {
+      defaultChecked: undefined,
+      defaultValue: undefined,
+      value: value != null ? value : inst._wrapperState.initialValue,
+      checked: checked != null ? checked : inst._wrapperState.initialChecked,
+      onBlurCapture: inst._wrapperState.onBlur,
+    });
 
     return hostProps;
   },
@@ -128,6 +125,7 @@ var ReactDOMInput = {
         : props.defaultChecked,
       initialValue: props.value != null ? props.value : defaultValue,
       listeners: null,
+      onBlur: _handleBlur.bind(inst),
     };
 
     if (__DEV__) {
@@ -279,6 +277,23 @@ var ReactDOMInput = {
     updateNamedCousins(inst, props);
   },
 };
+
+function _handleBlur(event) {
+  var props = this._currentElement.props;
+  var value = LinkedValueUtils.getValue(props);
+
+  if (value != null) {
+    DOMPropertyOperations.setValueForProperty(
+      ReactDOMComponentTree.getNodeFromInstance(this),
+      'value',
+      value
+    );
+  }
+
+  if (props.onBlur) {
+    return props.onBlur.call(undefined, event);
+  }
+}
 
 function updateNamedCousins(thisInstance, props) {
   var name = props.name;

--- a/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
@@ -124,11 +124,8 @@ var ReactDOMInput = {
         : props.defaultChecked,
       initialValue: props.value != null ? props.value : defaultValue,
       listeners: null,
+      controlled: isControlled(props)
     };
-
-    if (__DEV__) {
-      inst._wrapperState.controlled = isControlled(props);
-    }
   },
 
   updateWrapper: function(inst) {

--- a/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
@@ -211,7 +211,7 @@ var ReactDOMInput = {
         //
         // https://github.com/facebook/react/issues/7253
         if (node.defaultValue !== '' + props.defaultValue) {
-          node.defaultValue = !!props.defaultValue;
+          node.defaultValue = '' + props.defaultValue;
         }
       }
       if (props.checked == null && props.defaultChecked != null) {

--- a/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
@@ -124,7 +124,7 @@ var ReactDOMInput = {
         : props.defaultChecked,
       initialValue: props.value != null ? props.value : defaultValue,
       listeners: null,
-      controlled: isControlled(props)
+      controlled: isControlled(props),
     };
   },
 

--- a/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
@@ -49,23 +49,27 @@ var ReactDOMInput = {
     var value = props.value;
     var checked = props.checked;
 
-    var hostProps = Object.assign({
-      // Make sure we set .type before any other properties (setting .value
-      // before .type means .value is lost in IE11 and below)
-      type: undefined,
-      // Make sure we set .step before .value (setting .value before .step
-      // means .value is rounded on mount, based upon step precision)
-      step: undefined,
-      // Make sure we set .min & .max before .value (to ensure proper order
-      // in corner cases such as min or max deriving from value, e.g. Issue #7170)
-      min: undefined,
-      max: undefined,
-    }, props, {
-      defaultChecked: undefined,
-      defaultValue: undefined,
-      value: value != null ? value : inst._wrapperState.initialValue,
-      checked: checked != null ? checked : inst._wrapperState.initialChecked,
-    });
+    var hostProps = Object.assign(
+      {
+        // Make sure we set .type before any other properties (setting .value
+        // before .type means .value is lost in IE11 and below)
+        type: undefined,
+        // Make sure we set .step before .value (setting .value before .step
+        // means .value is rounded on mount, based upon step precision)
+        step: undefined,
+        // Make sure we set .min & .max before .value (to ensure proper order
+        // in corner cases such as min or max deriving from value, e.g. Issue #7170)
+        min: undefined,
+        max: undefined,
+      },
+      props,
+      {
+        defaultChecked: undefined,
+        defaultValue: undefined,
+        value: value != null ? value : inst._wrapperState.initialValue,
+        checked: checked != null ? checked : inst._wrapperState.initialChecked,
+      },
+    );
 
     return hostProps;
   },
@@ -188,12 +192,14 @@ var ReactDOMInput = {
         // Simulate `input.valueAsNumber`. IE9 does not support it
         var valueAsNumber = parseFloat(node.value, 10) || 0;
 
-        if (value != valueAsNumber) { // eslint-disable-line
+        // eslint-disable-next-line
+        if (value != valueAsNumber) {
           // Cast `value` to a string to ensure the value is set correctly. While
           // browsers typically do this as necessary, jsdom doesn't.
           node.value = '' + value;
         }
-      } else if (value != node.value) { // eslint-disable-line
+        // eslint-disable-next-line
+      } else if (value != node.value) {
         // Cast `value` to a string to ensure the value is set correctly. While
         // browsers typically do this as necessary, jsdom doesn't.
         node.value = '' + value;

--- a/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
@@ -188,13 +188,11 @@ var ReactDOMInput = {
     var node = ReactDOMComponentTree.getNodeFromInstance(inst);
     var value = props.value;
     if (value != null) {
-      // Cast `value` to a string to ensure the value is set correctly. While
-      // browsers typically do this as necessary, jsdom doesn't.
-      var newValue = '' + value;
-
       // To avoid side effects (such as losing text selection), only set value if changed
-      if (newValue !== node.value) {
-        node.value = newValue;
+      if (value != node.value) {
+        // Cast `value` to a string to ensure the value is set correctly. While
+        // browsers typically do this as necessary, jsdom doesn't.
+        node.value = '' + value;
       }
     } else {
       if (props.value == null && props.defaultValue != null) {

--- a/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
@@ -181,14 +181,11 @@ var ReactDOMInput = {
     var node = ReactDOMComponentTree.getNodeFromInstance(inst);
     var value = props.value;
     if (value != null) {
-      if (value === 0) {
-        // Since we use loose type checking below, zero is
-        // falsy, so we need to manually cover it
-        value = '0';
-      }
-      // Use loose coercion to prevent replacement on comparisons like
-      // '3e1' == 30 in Chrome (~52).
-      if (value != node.value) { // eslint-disable-line
+      if (value === 0 && node.value === '') {
+        node.value = '0';
+      } else if (value != node.value) { // eslint-disable-line
+        // Use loose coercion to prevent replacement on comparisons like
+        // '3e1' == 30 in Chrome (~52).
         // Cast `value` to a string to ensure the value is set correctly. While
         // browsers typically do this as necessary, jsdom doesn't.
         node.value = '' + value;

--- a/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
@@ -280,7 +280,7 @@ var ReactDOMInput = {
 
 function _handleBlur(event) {
   var props = this._currentElement.props;
-  var value = LinkedValueUtils.getValue(props);
+  var value = props.value
 
   if (value != null) {
     DOMPropertyOperations.setValueForProperty(

--- a/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
@@ -183,9 +183,17 @@ var ReactDOMInput = {
     if (value != null) {
       if (value === 0 && node.value === '') {
         node.value = '0';
+        // Note: IE9 reports a number inputs as 'text', so check props instead.
+      } else if (props.type === 'number') {
+        // Simulate `input.valueAsNumber`. IE9 does not support it
+        var valueAsNumber = parseFloat(node.value, 10) || 0;
+
+        if (value != valueAsNumber) { // eslint-disable-line
+          // Cast `value` to a string to ensure the value is set correctly. While
+          // browsers typically do this as necessary, jsdom doesn't.
+          node.value = '' + value;
+        }
       } else if (value != node.value) { // eslint-disable-line
-        // Use loose coercion to prevent replacement on comparisons like
-        // '3e1' == 30 in Chrome (~52).
         // Cast `value` to a string to ensure the value is set correctly. While
         // browsers typically do this as necessary, jsdom doesn't.
         node.value = '' + value;

--- a/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
@@ -188,6 +188,11 @@ var ReactDOMInput = {
     var node = ReactDOMComponentTree.getNodeFromInstance(inst);
     var value = props.value;
     if (value != null) {
+      if (value === 0) {
+        // Since we use loose type checking below, zero is
+        // falsy, so we need to manually cover it
+        value = '0';
+      }
       // Use loose coercion to prevent replacement on comparisons like
       // '3e1' == 30 in Chrome (~52).
       if (value != node.value) { // eslint-disable-line

--- a/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
@@ -207,8 +207,11 @@ var ReactDOMInput = {
         //
         // https://github.com/facebook/react/issues/7253
         if (node.defaultValue !== '' + props.defaultValue) {
-          node.defaultChecked = !!props.defaultChecked;
+          node.defaultValue = !!props.defaultValue;
         }
+      }
+      if (props.checked == null && props.defaultChecked != null) {
+        node.defaultChecked = !!props.defaultChecked;
       }
     }
   },

--- a/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
@@ -188,8 +188,9 @@ var ReactDOMInput = {
     var node = ReactDOMComponentTree.getNodeFromInstance(inst);
     var value = props.value;
     if (value != null) {
-      // To avoid side effects (such as losing text selection), only set value if changed
-      if (value != node.value) {
+      // Use loose coercion to prevent replacement on comparisons like
+      // '3e1' == 30 in Chrome (~52).
+      if (value != node.value) { // eslint-disable-line
         // Cast `value` to a string to ensure the value is set correctly. While
         // browsers typically do this as necessary, jsdom doesn't.
         node.value = '' + value;

--- a/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
@@ -65,7 +65,6 @@ var ReactDOMInput = {
       defaultValue: undefined,
       value: value != null ? value : inst._wrapperState.initialValue,
       checked: checked != null ? checked : inst._wrapperState.initialChecked,
-      onBlurCapture: inst._wrapperState.onBlur,
     });
 
     return hostProps;
@@ -125,7 +124,6 @@ var ReactDOMInput = {
         : props.defaultChecked,
       initialValue: props.value != null ? props.value : defaultValue,
       listeners: null,
-      onBlur: _handleBlur.bind(inst),
     };
 
     if (__DEV__) {
@@ -277,23 +275,6 @@ var ReactDOMInput = {
     updateNamedCousins(inst, props);
   },
 };
-
-function _handleBlur(event) {
-  var props = this._currentElement.props;
-  var value = props.value
-
-  if (value != null) {
-    DOMPropertyOperations.setValueForProperty(
-      ReactDOMComponentTree.getNodeFromInstance(this),
-      'value',
-      value
-    );
-  }
-
-  if (props.onBlur) {
-    return props.onBlur.call(undefined, event);
-  }
-}
 
 function updateNamedCousins(thisInstance, props) {
   var name = props.name;

--- a/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
@@ -207,10 +207,8 @@ var ReactDOMInput = {
         //
         // https://github.com/facebook/react/issues/7253
         if (node.defaultValue !== '' + props.defaultValue) {
+          node.defaultChecked = !!props.defaultChecked;
         }
-      }
-      if (props.checked == null && props.defaultChecked != null) {
-        node.defaultChecked = !!props.defaultChecked;
       }
     }
   },

--- a/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
@@ -207,7 +207,6 @@ var ReactDOMInput = {
         //
         // https://github.com/facebook/react/issues/7253
         if (node.defaultValue !== '' + props.defaultValue) {
-          node.defaultValue = '' + props.defaultValue;
         }
       }
       if (props.checked == null && props.defaultChecked != null) {


### PR DESCRIPTION
In Google Chrome, backspacing an controlled and uncontrolled number inputs causes an unexpected behavior:

![backspace](https://cloud.githubusercontent.com/assets/590904/17160637/6dfbca3a-5374-11e6-9a0d-0a2c52813eea.gif)

More cases (and what fixes look like) here: https://github.com/facebook/react/issues/7253#issuecomment-236074326
## Issues with uncontrolled inputs

This is because assigning `defaultValue` causes side-effects on `value`. It seems to trigger validation on `value` as if it were directly assigned itself. 

This Codepen provides a step by step reproduction case:

http://codepen.io/nhunzaker/pen/zBaokp

![wat](https://cloud.githubusercontent.com/assets/590904/17160341/4d3acf64-5372-11e6-9871-64c6063b23b0.gif)

This PR wraps the `defaultValue` assignment in a conditional so that it will only ever be assigned if the defaultValue has changed.
## Issues with controlled inputs

It looks like the issue here is that value is being assigned using the standard React method of updating attributes when the props get passed in here:

https://github.com/facebook/react/blob/master/src/renderers/dom/shared/ReactDOMComponent.js#L926

There is some logic in ReactDOMInput to prevent duplicate values from being assigned here:

https://github.com/facebook/react/blob/master/src/renderers/dom/client/wrappers/ReactDOMInput.js#L201-L210

Unfortunately the new value has already been assigned.

This PR adds a check for the `value` prop, and only assigns it if is different. It never assigns the value attribute if it hasn't changed:

I don't really know why this works. I didn't think node.setAttribute('value', value) was meaningful. What do you think?

---

Related to https://github.com/facebook/react/issues/7253
