### PR TITLE
build: ReactTestRenderer package

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -90,6 +90,10 @@ module.exports = function(grunt) {
   grunt.registerTask('npm-react-addons:release', npmReactAddonsTasks.buildReleases);
   grunt.registerTask('npm-react-addons:pack', npmReactAddonsTasks.packReleases);
 
+  var npmReactTestRendererTasks = require('./grunt/tasks/npm-react-test');
+  grunt.registerTask('npm-react-test:release', npmReactTestRendererTasks.buildRelease);
+  grunt.registerTask('npm-react-test:pack', npmReactTestRendererTasks.packRelease);
+
   grunt.registerTask('version-check', function() {
     // Use gulp here.
     spawnGulp(['version-check'], null, this.async());
@@ -146,6 +150,8 @@ module.exports = function(grunt) {
     'npm-react-native:pack',
     'npm-react-addons:release',
     'npm-react-addons:pack',
+    'npm-react-test:release',
+    'npm-react-test:pack',
     'compare_size',
   ]);
 

--- a/grunt/tasks/npm-react-test.js
+++ b/grunt/tasks/npm-react-test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var fs = require('fs');
+var grunt = require('grunt');
+
+var src = 'packages/react-test-renderer/';
+var dest = 'build/packages/react-test-renderer/';
+
+function buildRelease() {
+  if (grunt.file.exists(dest)) {
+    grunt.file.delete(dest);
+  }
+
+  // Copy to build/packages/react-native-renderer
+  var mappings = [].concat(
+    grunt.file.expandMapping('**/*', dest, {cwd: src}),
+    grunt.file.expandMapping('{LICENSE,PATENTS}', dest)
+  );
+  mappings.forEach(function(mapping) {
+    var mappingSrc = mapping.src[0];
+    var mappingDest = mapping.dest;
+    if (grunt.file.isDir(mappingSrc)) {
+      grunt.file.mkdir(mappingDest);
+    } else {
+      grunt.file.copy(mappingSrc, mappingDest);
+    }
+  });
+}
+
+function packRelease() {
+  var done = this.async();
+  var spawnCmd = {
+    cmd: 'npm',
+    args: ['pack', 'packages/react-test-renderer'],
+  };
+  grunt.util.spawn(spawnCmd, function() {
+    var buildSrc = 'react-test-renderer-' + grunt.config.data.pkg.version + '.tgz';
+    var buildDest = 'build/packages/react-test-renderer.tgz';
+    fs.rename(buildSrc, buildDest, done);
+  });
+}
+
+module.exports = {
+  buildRelease: buildRelease,
+  packRelease: packRelease,
+};

--- a/gulp/tasks/version-check.js
+++ b/gulp/tasks/version-check.js
@@ -27,6 +27,8 @@ module.exports = function(gulp, plugins) {
       'packages/react-addons/package.json (react dependency)':
         // Get the "version" without the range bit
         addonsData.peerDependencies.react.slice(1),
+      'packages/react-test-renderer/package.json':
+        require('../../packages/react-test-renderer/package.json').version,
       'src/ReactVersion.js': require('../../src/ReactVersion'),
     };
 

--- a/packages/react-test-renderer/README.md
+++ b/packages/react-test-renderer/README.md
@@ -1,0 +1,22 @@
+# `react-test-renderer`
+
+This package provides an experimental React renderer that can be used to render React components to pure JavaScript objects, without depending on the DOM or a native mobile environment.
+
+Essentially, this package makes it easy to grab a snapshot of the "DOM tree" rendered by a React DOM or React Native component without using a browser or jsdom.
+
+Usage:
+
+```jsx
+const ReactTestRenderer = require('react-test-renderer');
+
+const renderer = ReactTestRenderer.create(
+  <Link page="https://www.facebook.com/">Facebook</Link>
+);
+
+console.log(renderer.toJSON());
+// { type: 'a',
+//   props: { href: 'https://www.facebook.com/' },
+//   children: [ 'Facebook' ] }
+```
+
+You can also use Jest's snapshot testing feature to automatically save a copy of the JSON tree to a file and check in your tests that it hasn't changed: http://facebook.github.io/jest/blog/2016/07/27/jest-14.html.

--- a/packages/react-test-renderer/index.js
+++ b/packages/react-test-renderer/index.js
@@ -1,0 +1,4 @@
+
+'use strict';
+
+module.exports = require('react/lib/ReactTestRenderer');

--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "react-test-renderer",
+  "version": "16.0.0-alpha",
+  "description": "React package for snapshot testing.",
+  "main": "index.js",
+  "repository": "facebook/react",
+  "keywords": [
+    "react",
+    "react-native",
+    "react-testing"
+  ],
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/facebook/react/issues"
+  },
+  "homepage": "https://facebook.github.io/react/",
+  "peerDependencies": {
+    "react": "^16.0.0-alpha"
+  }
+}
+


### PR DESCRIPTION
Reading @cpojer’s blog post on Jest 14 this morning (http://facebook.github.io/jest/blog/2016/07/27/jest-14.html) and the import from React internals stuck out to me. The goal is that we can change the public blog post to the following sooner rather than later:

```diff
- import renderer from 'react/lib/ReactTestRenderer';
+ import renderer from 'react-test-renderer';
```