### PR TITLE
Use context parameter of $.ajax in documentation

### DIFF
--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -399,12 +399,13 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
+      context: this,
       success: function(data) {
         this.setState({data: data});
-      }.bind(this),
+      }
       error: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
-      }.bind(this)
+      }
     });
   },
   render: function() {
@@ -429,12 +430,13 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
+      context: this,
       success: function(data) {
         this.setState({data: data});
-      }.bind(this),
+      }
       error: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
-      }.bind(this)
+      }
     });
   },
   getInitialState: function() {
@@ -595,12 +597,13 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
+      context: this,
       success: function(data) {
         this.setState({data: data});
-      }.bind(this),
+      }
       error: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
-      }.bind(this)
+      }
     });
   },
   handleCommentSubmit: function(comment) {
@@ -681,12 +684,13 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
+      context: this,
       success: function(data) {
         this.setState({data: data});
-      }.bind(this),
+      }
       error: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
-      }.bind(this)
+      }
     });
   },
   handleCommentSubmit: function(comment) {
@@ -695,12 +699,13 @@ var CommentBox = React.createClass({
       dataType: 'json',
       type: 'POST',
       data: comment,
+      context: this,
       success: function(data) {
         this.setState({data: data});
-      }.bind(this),
+      }
       error: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
-      }.bind(this)
+      }
     });
   },
   getInitialState: function() {
@@ -734,12 +739,13 @@ var CommentBox = React.createClass({
       url: this.props.url,
       dataType: 'json',
       cache: false,
+      context: this,
       success: function(data) {
         this.setState({data: data});
-      }.bind(this),
+      }
       error: function(xhr, status, err) {
         console.error(this.props.url, status, err.toString());
-      }.bind(this)
+      }
     });
   },
   handleCommentSubmit: function(comment) {
@@ -755,13 +761,14 @@ var CommentBox = React.createClass({
       dataType: 'json',
       type: 'POST',
       data: comment,
+      context: this,
       success: function(data) {
         this.setState({data: data});
-      }.bind(this),
+      }
       error: function(xhr, status, err) {
         this.setState({data: comments});
         console.error(this.props.url, status, err.toString());
-      }.bind(this)
+      }
     });
   },
   getInitialState: function() {


### PR DESCRIPTION
This is essentially synonymous with the current code, but adds clarity. Setting `context: this` as a parameter of $.ajax has the same effect as calling `.bind(this)` on both success and error, while being a bit more explicit. Plus it only needs to be written in one place instead of two.