### PR TITLE
Rename Devtool to Hook

### DIFF
--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -19,7 +19,7 @@
 'use strict';
 
 var ReactCurrentOwner = require('ReactCurrentOwner');
-var ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
+var ReactComponentTreeHook = require('ReactComponentTreeHook');
 var ReactElement = require('ReactElement');
 var ReactPropTypeLocations = require('ReactPropTypeLocations');
 
@@ -104,7 +104,7 @@ function validateExplicitKey(element, parentType) {
     '%s%s See https://fb.me/react-warning-keys for more information.%s',
     currentComponentErrorInfo,
     childOwner,
-    ReactComponentTreeDevtool.getCurrentStackAddendum(element)
+    ReactComponentTreeHook.getCurrentStackAddendum(element)
   );
 }
 

--- a/src/isomorphic/classic/types/checkReactTypeSpec.js
+++ b/src/isomorphic/classic/types/checkReactTypeSpec.js
@@ -17,7 +17,7 @@ var ReactPropTypesSecret = require('ReactPropTypesSecret');
 var invariant = require('invariant');
 var warning = require('warning');
 
-var ReactComponentTreeDevtool;
+var ReactComponentTreeHook;
 
 if (
   typeof process !== 'undefined' &&
@@ -29,7 +29,7 @@ if (
   // https://github.com/facebook/react/issues/7240
   // Remove the inline requires when we don't need them anymore:
   // https://github.com/facebook/react/pull/7178
-  ReactComponentTreeDevtool = require('ReactComponentTreeDevtool')
+  ReactComponentTreeHook = require('ReactComponentTreeHook')
 }
 
 var loggedTypeFailures = {};
@@ -88,13 +88,13 @@ function checkReactTypeSpec(typeSpecs, values, location, componentName, element,
         var componentStackInfo = '';
 
         if (__DEV__) {
-          if (!ReactComponentTreeDevtool) {
-            ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
+          if (!ReactComponentTreeHook) {
+            ReactComponentTreeHook = require('ReactComponentTreeHook');
           }
           if (debugID !== null) {
-            componentStackInfo = ReactComponentTreeDevtool.getStackAddendumByID(debugID);
+            componentStackInfo = ReactComponentTreeHook.getStackAddendumByID(debugID);
           } else if (element !== null) {
-            componentStackInfo = ReactComponentTreeDevtool.getCurrentStackAddendum(element);
+            componentStackInfo = ReactComponentTreeHook.getCurrentStackAddendum(element);
           }
         }
 

--- a/src/isomorphic/hooks/ReactComponentTreeDevtool.js
+++ b/src/isomorphic/hooks/ReactComponentTreeDevtool.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactComponentTreeDevtool
+ */
+'use strict';
+
+// TODO remove this proxy when RN/www gets updated
+module.exports = require('ReactComponentTreeHook');

--- a/src/isomorphic/hooks/ReactComponentTreeHook.js
+++ b/src/isomorphic/hooks/ReactComponentTreeHook.js
@@ -86,7 +86,7 @@ var ReactComponentTreeHook = {
         var nextChild = tree[nextChildID];
         invariant(
           nextChild,
-          'Expected devtool events to fire for the child ' +
+          'Expected hook events to fire for the child ' +
           'before its parent includes it in onSetChildren().'
         );
         invariant(

--- a/src/isomorphic/hooks/ReactComponentTreeHook.js
+++ b/src/isomorphic/hooks/ReactComponentTreeHook.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule ReactComponentTreeDevtool
+ * @providesModule ReactComponentTreeHook
  */
 
 'use strict';
@@ -57,23 +57,23 @@ function describeComponentFrame(name, source, ownerName) {
 }
 
 function describeID(id) {
-  var name = ReactComponentTreeDevtool.getDisplayName(id);
-  var element = ReactComponentTreeDevtool.getElement(id);
-  var ownerID = ReactComponentTreeDevtool.getOwnerID(id);
+  var name = ReactComponentTreeHook.getDisplayName(id);
+  var element = ReactComponentTreeHook.getElement(id);
+  var ownerID = ReactComponentTreeHook.getOwnerID(id);
   var ownerName;
   if (ownerID) {
-    ownerName = ReactComponentTreeDevtool.getDisplayName(ownerID);
+    ownerName = ReactComponentTreeHook.getDisplayName(ownerID);
   }
   warning(
     element,
-    'ReactComponentTreeDevtool: Missing React element for debugID %s when ' +
+    'ReactComponentTreeHook: Missing React element for debugID %s when ' +
     'building stack',
     id
   );
   return describeComponentFrame(name, element && element._source, ownerName);
 }
 
-var ReactComponentTreeDevtool = {
+var ReactComponentTreeHook = {
   onSetDisplayName(id, displayName) {
     updateTree(id, item => item.displayName = displayName);
   },
@@ -161,7 +161,7 @@ var ReactComponentTreeDevtool = {
   },
 
   purgeUnmountedComponents() {
-    if (ReactComponentTreeDevtool._preventPurging) {
+    if (ReactComponentTreeHook._preventPurging) {
       // Should only be used for testing.
       return;
     }
@@ -195,7 +195,7 @@ var ReactComponentTreeDevtool = {
     var currentOwner = ReactCurrentOwner.current;
     var id = currentOwner && currentOwner._debugID;
 
-    info += ReactComponentTreeDevtool.getStackAddendumByID(id);
+    info += ReactComponentTreeHook.getStackAddendumByID(id);
     return info;
   },
 
@@ -203,7 +203,7 @@ var ReactComponentTreeDevtool = {
     var info = '';
     while (id) {
       info += describeID(id);
-      id = ReactComponentTreeDevtool.getParentID(id);
+      id = ReactComponentTreeHook.getParentID(id);
     }
     return info;
   },
@@ -259,4 +259,4 @@ var ReactComponentTreeDevtool = {
   },
 };
 
-module.exports = ReactComponentTreeDevtool;
+module.exports = ReactComponentTreeHook;

--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -302,7 +302,7 @@ var ReactMount = {
   },
 
   /**
-   * Render a new component into the DOM. Hooked by devtools!
+   * Render a new component into the DOM. Hooked by hooks!
    *
    * @param {ReactElement} nextElement element to render
    * @param {DOMElement} container container to render into

--- a/src/renderers/dom/shared/ReactDOMDebugTool.js
+++ b/src/renderers/dom/shared/ReactDOMDebugTool.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-var ReactDOMNullInputValuePropDevtool = require('ReactDOMNullInputValuePropDevtool');
-var ReactDOMUnknownPropertyDevtool = require('ReactDOMUnknownPropertyDevtool');
+var ReactDOMNullInputValuePropHook = require('ReactDOMNullInputValuePropHook');
+var ReactDOMUnknownPropertyHook = require('ReactDOMUnknownPropertyHook');
 var ReactDebugTool = require('ReactDebugTool');
 
 var warning = require('warning');
@@ -66,7 +66,7 @@ var ReactDOMDebugTool = {
   },
 };
 
-ReactDOMDebugTool.addDevtool(ReactDOMUnknownPropertyDevtool);
-ReactDOMDebugTool.addDevtool(ReactDOMNullInputValuePropDevtool);
+ReactDOMDebugTool.addDevtool(ReactDOMUnknownPropertyHook);
+ReactDOMDebugTool.addDevtool(ReactDOMNullInputValuePropHook);
 
 module.exports = ReactDOMDebugTool;

--- a/src/renderers/dom/shared/ReactDOMDebugTool.js
+++ b/src/renderers/dom/shared/ReactDOMDebugTool.js
@@ -29,7 +29,7 @@ function emitEvent(handlerFunctionName, arg1, arg2, arg3, arg4, arg5) {
     } catch (e) {
       warning(
         handlerDoesThrowForEvent[handlerFunctionName],
-        'exception thrown by devtool while handling %s: %s',
+        'exception thrown by hook while handling %s: %s',
         handlerFunctionName,
         e + '\n' + e.stack
       );
@@ -39,14 +39,14 @@ function emitEvent(handlerFunctionName, arg1, arg2, arg3, arg4, arg5) {
 }
 
 var ReactDOMDebugTool = {
-  addDevtool(devtool) {
-    ReactDebugTool.addDevtool(devtool);
-    eventHandlers.push(devtool);
+  addHook(hook) {
+    ReactDebugTool.addHook(hook);
+    eventHandlers.push(hook);
   },
-  removeDevtool(devtool) {
-    ReactDebugTool.removeDevtool(devtool);
+  removeHook(hook) {
+    ReactDebugTool.removeHook(hook);
     for (var i = 0; i < eventHandlers.length; i++) {
-      if (eventHandlers[i] === devtool) {
+      if (eventHandlers[i] === hook) {
         eventHandlers.splice(i, 1);
         i--;
       }
@@ -66,7 +66,7 @@ var ReactDOMDebugTool = {
   },
 };
 
-ReactDOMDebugTool.addDevtool(ReactDOMUnknownPropertyHook);
-ReactDOMDebugTool.addDevtool(ReactDOMNullInputValuePropHook);
+ReactDOMDebugTool.addHook(ReactDOMUnknownPropertyHook);
+ReactDOMDebugTool.addHook(ReactDOMNullInputValuePropHook);
 
 module.exports = ReactDOMDebugTool;

--- a/src/renderers/dom/shared/__tests__/ReactDOMDebugTool-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMDebugTool-test.js
@@ -19,13 +19,13 @@ describe('ReactDOMDebugTool', function() {
     ReactDOMDebugTool = require('ReactDOMDebugTool');
   });
 
-  it('should add and remove devtools', () => {
+  it('should add and remove hooks', () => {
     var handler1 = jasmine.createSpy('spy');
     var handler2 = jasmine.createSpy('spy');
-    var devtool1 = {onTestEvent: handler1};
-    var devtool2 = {onTestEvent: handler2};
+    var hook1 = {onTestEvent: handler1};
+    var hook2 = {onTestEvent: handler2};
 
-    ReactDOMDebugTool.addDevtool(devtool1);
+    ReactDOMDebugTool.addHook(hook1);
     ReactDOMDebugTool.onTestEvent();
     expect(handler1.calls.count()).toBe(1);
     expect(handler2.calls.count()).toBe(0);
@@ -34,7 +34,7 @@ describe('ReactDOMDebugTool', function() {
     expect(handler1.calls.count()).toBe(2);
     expect(handler2.calls.count()).toBe(0);
 
-    ReactDOMDebugTool.addDevtool(devtool2);
+    ReactDOMDebugTool.addHook(hook2);
     ReactDOMDebugTool.onTestEvent();
     expect(handler1.calls.count()).toBe(3);
     expect(handler2.calls.count()).toBe(1);
@@ -43,20 +43,20 @@ describe('ReactDOMDebugTool', function() {
     expect(handler1.calls.count()).toBe(4);
     expect(handler2.calls.count()).toBe(2);
 
-    ReactDOMDebugTool.removeDevtool(devtool1);
+    ReactDOMDebugTool.removeHook(hook1);
     ReactDOMDebugTool.onTestEvent();
     expect(handler1.calls.count()).toBe(4);
     expect(handler2.calls.count()).toBe(3);
 
-    ReactDOMDebugTool.removeDevtool(devtool2);
+    ReactDOMDebugTool.removeHook(hook2);
     ReactDOMDebugTool.onTestEvent();
     expect(handler1.calls.count()).toBe(4);
     expect(handler2.calls.count()).toBe(3);
   });
 
-  it('warns once when an error is thrown in devtool', () => {
+  it('warns once when an error is thrown in hook', () => {
     spyOn(console, 'error');
-    ReactDOMDebugTool.addDevtool({
+    ReactDOMDebugTool.addHook({
       onTestEvent() {
         throw new Error('Hi.');
       },
@@ -65,7 +65,7 @@ describe('ReactDOMDebugTool', function() {
     ReactDOMDebugTool.onTestEvent();
     expect(console.error.calls.count()).toBe(1);
     expect(console.error.calls.argsFor(0)[0]).toContain(
-      'exception thrown by devtool while handling ' +
+      'exception thrown by hook while handling ' +
       'onTestEvent: Error: Hi.'
     );
 

--- a/src/renderers/dom/shared/hooks/ReactDOMNullInputValuePropHook.js
+++ b/src/renderers/dom/shared/hooks/ReactDOMNullInputValuePropHook.js
@@ -6,12 +6,12 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule ReactDOMNullInputValuePropDevtool
+ * @providesModule ReactDOMNullInputValuePropHook
  */
 
 'use strict';
 
-var ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
+var ReactComponentTreeHook = require('ReactComponentTreeHook');
 
 var warning = require('warning');
 
@@ -31,14 +31,14 @@ function handleElement(debugID, element) {
       'Consider using the empty string to clear the component or `undefined` ' +
       'for uncontrolled components.%s',
       element.type,
-      ReactComponentTreeDevtool.getStackAddendumByID(debugID)
+      ReactComponentTreeHook.getStackAddendumByID(debugID)
     );
 
     didWarnValueNull = true;
   }
 }
 
-var ReactDOMUnknownPropertyDevtool = {
+var ReactDOMNullInputValuePropHook = {
   onBeforeMountComponent(debugID, element) {
     handleElement(debugID, element);
   },
@@ -47,4 +47,4 @@ var ReactDOMUnknownPropertyDevtool = {
   },
 };
 
-module.exports = ReactDOMUnknownPropertyDevtool;
+module.exports = ReactDOMNullInputValuePropHook;

--- a/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
+++ b/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
@@ -6,14 +6,14 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule ReactDOMUnknownPropertyDevtool
+ * @providesModule ReactDOMUnknownPropertyHook
  */
 
 'use strict';
 
 var DOMProperty = require('DOMProperty');
 var EventPluginRegistry = require('EventPluginRegistry');
-var ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
+var ReactComponentTreeHook = require('ReactComponentTreeHook');
 
 var warning = require('warning');
 
@@ -73,7 +73,7 @@ if (__DEV__) {
         'Unknown DOM property %s. Did you mean %s?%s',
         name,
         standardName,
-        ReactComponentTreeDevtool.getStackAddendumByID(debugID)
+        ReactComponentTreeHook.getStackAddendumByID(debugID)
       );
       return true;
     } else if (registrationName != null) {
@@ -82,7 +82,7 @@ if (__DEV__) {
         'Unknown event handler property %s. Did you mean `%s`?%s',
         name,
         registrationName,
-        ReactComponentTreeDevtool.getStackAddendumByID(debugID)
+        ReactComponentTreeHook.getStackAddendumByID(debugID)
       );
       return true;
     } else {
@@ -115,7 +115,7 @@ var warnUnknownProperties = function(debugID, element) {
       'For details, see https://fb.me/react-unknown-prop%s',
       unknownPropString,
       element.type,
-      ReactComponentTreeDevtool.getStackAddendumByID(debugID)
+      ReactComponentTreeHook.getStackAddendumByID(debugID)
     );
   } else if (unknownProps.length > 1) {
     warning(
@@ -124,7 +124,7 @@ var warnUnknownProperties = function(debugID, element) {
       'For details, see https://fb.me/react-unknown-prop%s',
       unknownPropString,
       element.type,
-      ReactComponentTreeDevtool.getStackAddendumByID(debugID)
+      ReactComponentTreeHook.getStackAddendumByID(debugID)
     );
   }
 };
@@ -139,7 +139,7 @@ function handleElement(debugID, element) {
   warnUnknownProperties(debugID, element);
 }
 
-var ReactDOMUnknownPropertyDevtool = {
+var ReactDOMUnknownPropertyHook = {
   onBeforeMountComponent(debugID, element) {
     handleElement(debugID, element);
   },
@@ -148,4 +148,4 @@ var ReactDOMUnknownPropertyDevtool = {
   },
 };
 
-module.exports = ReactDOMUnknownPropertyDevtool;
+module.exports = ReactDOMUnknownPropertyHook;

--- a/src/renderers/shared/ReactDebugTool.js
+++ b/src/renderers/shared/ReactDebugTool.js
@@ -32,7 +32,7 @@ function emitEvent(handlerFunctionName, arg1, arg2, arg3, arg4, arg5) {
     } catch (e) {
       warning(
         handlerDoesThrowForEvent[handlerFunctionName],
-        'exception thrown by devtool while handling %s: %s',
+        'exception thrown by hook while handling %s: %s',
         handlerFunctionName,
         e + '\n' + e.stack
       );
@@ -182,12 +182,12 @@ function resumeCurrentLifeCycleTimer() {
 }
 
 var ReactDebugTool = {
-  addDevtool(devtool) {
-    eventHandlers.push(devtool);
+  addHook(hook) {
+    eventHandlers.push(hook);
   },
-  removeDevtool(devtool) {
+  removeHook(hook) {
     for (var i = 0; i < eventHandlers.length; i++) {
-      if (eventHandlers[i] === devtool) {
+      if (eventHandlers[i] === hook) {
         eventHandlers.splice(i, 1);
         i--;
       }
@@ -204,7 +204,7 @@ var ReactDebugTool = {
     isProfiling = true;
     flushHistory.length = 0;
     resetMeasurements();
-    ReactDebugTool.addDevtool(ReactHostOperationHistoryHook);
+    ReactDebugTool.addHook(ReactHostOperationHistoryHook);
   },
   endProfiling() {
     if (!isProfiling) {
@@ -213,7 +213,7 @@ var ReactDebugTool = {
 
     isProfiling = false;
     resetMeasurements();
-    ReactDebugTool.removeDevtool(ReactHostOperationHistoryHook);
+    ReactDebugTool.removeHook(ReactHostOperationHistoryHook);
   },
   getFlushHistory() {
     return flushHistory;
@@ -325,9 +325,9 @@ var ReactDebugTool = {
   },
 };
 
-ReactDebugTool.addDevtool(ReactInvalidSetStateWarningHook);
-ReactDebugTool.addDevtool(ReactComponentTreeHook);
-ReactDebugTool.addDevtool(ReactChildrenMutationWarningHook);
+ReactDebugTool.addHook(ReactInvalidSetStateWarningHook);
+ReactDebugTool.addHook(ReactComponentTreeHook);
+ReactDebugTool.addHook(ReactChildrenMutationWarningHook);
 var url = (ExecutionEnvironment.canUseDOM && window.location.href) || '';
 if ((/[?&]react_perf\b/).test(url)) {
   ReactDebugTool.beginProfiling();

--- a/src/renderers/shared/ReactDebugTool.js
+++ b/src/renderers/shared/ReactDebugTool.js
@@ -325,6 +325,10 @@ var ReactDebugTool = {
   },
 };
 
+// TODO remove these when RN/www gets updated
+ReactDebugTool.addDevtool = ReactDebugTool.addHook;
+ReactDebugTool.removeDevtool = ReactDebugTool.removeHook;
+
 ReactDebugTool.addHook(ReactInvalidSetStateWarningHook);
 ReactDebugTool.addHook(ReactComponentTreeHook);
 ReactDebugTool.addHook(ReactChildrenMutationWarningHook);

--- a/src/renderers/shared/ReactDebugTool.js
+++ b/src/renderers/shared/ReactDebugTool.js
@@ -11,10 +11,10 @@
 
 'use strict';
 
-var ReactInvalidSetStateWarningDevTool = require('ReactInvalidSetStateWarningDevTool');
-var ReactHostOperationHistoryDevtool = require('ReactHostOperationHistoryDevtool');
-var ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
-var ReactChildrenMutationWarningDevtool = require('ReactChildrenMutationWarningDevtool');
+var ReactInvalidSetStateWarningHook = require('ReactInvalidSetStateWarningHook');
+var ReactHostOperationHistoryHook = require('ReactHostOperationHistoryHook');
+var ReactComponentTreeHook = require('ReactComponentTreeHook');
+var ReactChildrenMutationWarningHook = require('ReactChildrenMutationWarningHook');
 var ExecutionEnvironment = require('ExecutionEnvironment');
 
 var performanceNow = require('performanceNow');
@@ -55,21 +55,21 @@ var currentTimerType = null;
 var lifeCycleTimerHasWarned = false;
 
 function clearHistory() {
-  ReactComponentTreeDevtool.purgeUnmountedComponents();
-  ReactHostOperationHistoryDevtool.clearHistory();
+  ReactComponentTreeHook.purgeUnmountedComponents();
+  ReactHostOperationHistoryHook.clearHistory();
 }
 
 function getTreeSnapshot(registeredIDs) {
   return registeredIDs.reduce((tree, id) => {
-    var ownerID = ReactComponentTreeDevtool.getOwnerID(id);
-    var parentID = ReactComponentTreeDevtool.getParentID(id);
+    var ownerID = ReactComponentTreeHook.getOwnerID(id);
+    var parentID = ReactComponentTreeHook.getParentID(id);
     tree[id] = {
-      displayName: ReactComponentTreeDevtool.getDisplayName(id),
-      text: ReactComponentTreeDevtool.getText(id),
-      updateCount: ReactComponentTreeDevtool.getUpdateCount(id),
-      childIDs: ReactComponentTreeDevtool.getChildIDs(id),
+      displayName: ReactComponentTreeHook.getDisplayName(id),
+      text: ReactComponentTreeHook.getText(id),
+      updateCount: ReactComponentTreeHook.getUpdateCount(id),
+      childIDs: ReactComponentTreeHook.getChildIDs(id),
       // Text nodes don't have owners but this is close enough.
-      ownerID: ownerID || ReactComponentTreeDevtool.getOwnerID(parentID),
+      ownerID: ownerID || ReactComponentTreeHook.getOwnerID(parentID),
       parentID,
     };
     return tree;
@@ -79,7 +79,7 @@ function getTreeSnapshot(registeredIDs) {
 function resetMeasurements() {
   var previousStartTime = currentFlushStartTime;
   var previousMeasurements = currentFlushMeasurements || [];
-  var previousOperations = ReactHostOperationHistoryDevtool.getHistory();
+  var previousOperations = ReactHostOperationHistoryHook.getHistory();
 
   if (currentFlushNesting === 0) {
     currentFlushStartTime = null;
@@ -89,7 +89,7 @@ function resetMeasurements() {
   }
 
   if (previousMeasurements.length || previousOperations.length) {
-    var registeredIDs = ReactComponentTreeDevtool.getRegisteredIDs();
+    var registeredIDs = ReactComponentTreeHook.getRegisteredIDs();
     flushHistory.push({
       duration: performanceNow() - previousStartTime,
       measurements: previousMeasurements || [],
@@ -204,7 +204,7 @@ var ReactDebugTool = {
     isProfiling = true;
     flushHistory.length = 0;
     resetMeasurements();
-    ReactDebugTool.addDevtool(ReactHostOperationHistoryDevtool);
+    ReactDebugTool.addDevtool(ReactHostOperationHistoryHook);
   },
   endProfiling() {
     if (!isProfiling) {
@@ -213,7 +213,7 @@ var ReactDebugTool = {
 
     isProfiling = false;
     resetMeasurements();
-    ReactDebugTool.removeDevtool(ReactHostOperationHistoryDevtool);
+    ReactDebugTool.removeDevtool(ReactHostOperationHistoryHook);
   },
   getFlushHistory() {
     return flushHistory;
@@ -325,9 +325,9 @@ var ReactDebugTool = {
   },
 };
 
-ReactDebugTool.addDevtool(ReactInvalidSetStateWarningDevTool);
-ReactDebugTool.addDevtool(ReactComponentTreeDevtool);
-ReactDebugTool.addDevtool(ReactChildrenMutationWarningDevtool);
+ReactDebugTool.addDevtool(ReactInvalidSetStateWarningHook);
+ReactDebugTool.addDevtool(ReactComponentTreeHook);
+ReactDebugTool.addDevtool(ReactChildrenMutationWarningHook);
 var url = (ExecutionEnvironment.canUseDOM && window.location.href) || '';
 if ((/[?&]react_perf\b/).test(url)) {
   ReactDebugTool.beginProfiling();

--- a/src/renderers/shared/__tests__/ReactDebugTool-test.js
+++ b/src/renderers/shared/__tests__/ReactDebugTool-test.js
@@ -19,13 +19,13 @@ describe('ReactDebugTool', function() {
     ReactDebugTool = require('ReactDebugTool');
   });
 
-  it('should add and remove devtools', () => {
+  it('should add and remove hooks', () => {
     var handler1 = jasmine.createSpy('spy');
     var handler2 = jasmine.createSpy('spy');
-    var devtool1 = {onTestEvent: handler1};
-    var devtool2 = {onTestEvent: handler2};
+    var hook1 = {onTestEvent: handler1};
+    var hook2 = {onTestEvent: handler2};
 
-    ReactDebugTool.addDevtool(devtool1);
+    ReactDebugTool.addHook(hook1);
     ReactDebugTool.onTestEvent();
     expect(handler1.calls.count()).toBe(1);
     expect(handler2.calls.count()).toBe(0);
@@ -34,7 +34,7 @@ describe('ReactDebugTool', function() {
     expect(handler1.calls.count()).toBe(2);
     expect(handler2.calls.count()).toBe(0);
 
-    ReactDebugTool.addDevtool(devtool2);
+    ReactDebugTool.addHook(hook2);
     ReactDebugTool.onTestEvent();
     expect(handler1.calls.count()).toBe(3);
     expect(handler2.calls.count()).toBe(1);
@@ -43,20 +43,20 @@ describe('ReactDebugTool', function() {
     expect(handler1.calls.count()).toBe(4);
     expect(handler2.calls.count()).toBe(2);
 
-    ReactDebugTool.removeDevtool(devtool1);
+    ReactDebugTool.removeHook(hook1);
     ReactDebugTool.onTestEvent();
     expect(handler1.calls.count()).toBe(4);
     expect(handler2.calls.count()).toBe(3);
 
-    ReactDebugTool.removeDevtool(devtool2);
+    ReactDebugTool.removeHook(hook2);
     ReactDebugTool.onTestEvent();
     expect(handler1.calls.count()).toBe(4);
     expect(handler2.calls.count()).toBe(3);
   });
 
-  it('warns once when an error is thrown in devtool', () => {
+  it('warns once when an error is thrown in hook', () => {
     spyOn(console, 'error');
-    ReactDebugTool.addDevtool({
+    ReactDebugTool.addHook({
       onTestEvent() {
         throw new Error('Hi.');
       },
@@ -65,7 +65,7 @@ describe('ReactDebugTool', function() {
     ReactDebugTool.onTestEvent();
     expect(console.error.calls.count()).toBe(1);
     expect(console.error.calls.argsFor(0)[0]).toContain(
-      'exception thrown by devtool while handling ' +
+      'exception thrown by hook while handling ' +
       'onTestEvent: Error: Hi.'
     );
 

--- a/src/renderers/shared/hooks/ReactChildrenMutationWarningHook.js
+++ b/src/renderers/shared/hooks/ReactChildrenMutationWarningHook.js
@@ -6,12 +6,12 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule ReactChildrenMutationWarningDevtool
+ * @providesModule ReactChildrenMutationWarningHook
  */
 
 'use strict';
 
-var ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
+var ReactComponentTreeHook = require('ReactComponentTreeHook');
 
 var warning = require('warning');
 
@@ -42,11 +42,11 @@ function handleElement(debugID, element) {
   warning(
     Array.isArray(element._shadowChildren) && !isMutated,
     'Component\'s children should not be mutated.%s',
-    ReactComponentTreeDevtool.getStackAddendumByID(debugID),
+    ReactComponentTreeHook.getStackAddendumByID(debugID),
   );
 }
 
-var ReactDOMUnknownPropertyDevtool = {
+var ReactDOMUnknownPropertyHook = {
   onBeforeMountComponent(debugID, element) {
     elements[debugID] = element;
   },
@@ -63,4 +63,4 @@ var ReactDOMUnknownPropertyDevtool = {
   },
 };
 
-module.exports = ReactDOMUnknownPropertyDevtool;
+module.exports = ReactDOMUnknownPropertyHook;

--- a/src/renderers/shared/hooks/ReactHostOperationHistoryHook.js
+++ b/src/renderers/shared/hooks/ReactHostOperationHistoryHook.js
@@ -6,14 +6,14 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule ReactHostOperationHistoryDevtool
+ * @providesModule ReactHostOperationHistoryHook
  */
 
 'use strict';
 
 var history = [];
 
-var ReactHostOperationHistoryDevtool = {
+var ReactHostOperationHistoryHook = {
   onHostOperation(debugID, type, payload) {
     history.push({
       instanceID: debugID,
@@ -23,7 +23,7 @@ var ReactHostOperationHistoryDevtool = {
   },
 
   clearHistory() {
-    if (ReactHostOperationHistoryDevtool._preventClearing) {
+    if (ReactHostOperationHistoryHook._preventClearing) {
       // Should only be used for tests.
       return;
     }
@@ -36,4 +36,4 @@ var ReactHostOperationHistoryDevtool = {
   },
 };
 
-module.exports = ReactHostOperationHistoryDevtool;
+module.exports = ReactHostOperationHistoryHook;

--- a/src/renderers/shared/hooks/ReactInvalidSetStateWarningHook.js
+++ b/src/renderers/shared/hooks/ReactInvalidSetStateWarningHook.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule ReactInvalidSetStateWarningDevTool
+ * @providesModule ReactInvalidSetStateWarningHook
  */
 
 'use strict';
@@ -24,7 +24,7 @@ if (__DEV__) {
   };
 }
 
-var ReactInvalidSetStateWarningDevTool = {
+var ReactInvalidSetStateWarningHook = {
   onBeginProcessingChildContext() {
     processingChildContext = true;
   },
@@ -36,4 +36,4 @@ var ReactInvalidSetStateWarningDevTool = {
   },
 };
 
-module.exports = ReactInvalidSetStateWarningDevTool;
+module.exports = ReactInvalidSetStateWarningHook;

--- a/src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.js
+++ b/src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.js
@@ -87,7 +87,7 @@ describe('ReactComponentTreeHook', () => {
       ReactDOMServer.renderToString(<Wrapper />);
       expectWrapperTreeToEqual(null);
 
-      // To test it, we tell the devtool to ignore next purge
+      // To test it, we tell the hook to ignore next purge
       // so the cleanup request by ReactDebugTool is ignored.
       // This lets us make assertions on the actual tree.
       ReactComponentTreeHook._preventPurging = true;

--- a/src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.js
+++ b/src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.js
@@ -11,55 +11,31 @@
 
 'use strict';
 
-describe('ReactComponentTreeDevtool', () => {
+describe('ReactComponentTreeHook', () => {
   var React;
-  var ReactNative;
+  var ReactDOM;
+  var ReactDOMServer;
   var ReactInstanceMap;
-  var ReactComponentTreeDevtool;
+  var ReactComponentTreeHook;
   var ReactComponentTreeTestUtils;
-  var createReactNativeComponentClass;
-  var View;
-  var Image;
-  var Text;
 
   beforeEach(() => {
     jest.resetModuleRegistry();
 
     React = require('React');
-    ReactNative = require('ReactNative');
+    ReactDOM = require('ReactDOM');
+    ReactDOMServer = require('ReactDOMServer');
     ReactInstanceMap = require('ReactInstanceMap');
-    ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
+    ReactComponentTreeHook = require('ReactComponentTreeHook');
     ReactComponentTreeTestUtils = require('ReactComponentTreeTestUtils');
-    View = require('View');
-    createReactNativeComponentClass = require('createReactNativeComponentClass');
-    Image = createReactNativeComponentClass({
-      validAttributes: {},
-      uiViewClassName: 'Image',
-    });
-    var RCText = createReactNativeComponentClass({
-      validAttributes: {},
-      uiViewClassName: 'RCText',
-    });
-    Text = class extends React.Component {
-      static childContextTypes = {
-        isInAParentText: React.PropTypes.bool,
-      };
-
-      getChildContext() {
-        return {isInAParentText: true};
-      }
-
-      render() {
-        return <RCText {...this.props} />;
-      }
-    };
   });
 
-  function assertTreeMatches(pairs, options) {
+  function assertTreeMatches(pairs) {
     if (!Array.isArray(pairs[0])) {
       pairs = [pairs];
     }
 
+    var node = document.createElement('div');
     var currentElement;
     var rootInstance;
 
@@ -87,31 +63,40 @@ describe('ReactComponentTreeDevtool', () => {
       currentElement = element;
 
       // Mount a new tree or update the existing tree.
-      ReactNative.render(<Wrapper />, 1);
+      ReactDOM.render(<Wrapper />, node);
       expectWrapperTreeToEqual(expectedTree);
 
       // Purging should have no effect
       // on the tree we expect to see.
-      ReactComponentTreeDevtool.purgeUnmountedComponents();
+      ReactComponentTreeHook.purgeUnmountedComponents();
       expectWrapperTreeToEqual(expectedTree);
     });
 
     // Unmounting the root node should purge
     // the whole subtree automatically.
-    ReactNative.unmountComponentAtNode(1);
+    ReactDOM.unmountComponentAtNode(node);
     expectWrapperTreeToEqual(null);
 
-    // Mount and unmount for every pair.
+    // Server render every pair.
     // Ensure the tree is correct on every step.
     pairs.forEach(([element, expectedTree]) => {
       currentElement = element;
 
-      // Mount a new tree.
-      ReactNative.render(<Wrapper />, 1);
+      // Rendering to string should not produce any entries
+      // because ReactDebugTool purges it when the flush ends.
+      ReactDOMServer.renderToString(<Wrapper />);
+      expectWrapperTreeToEqual(null);
+
+      // To test it, we tell the devtool to ignore next purge
+      // so the cleanup request by ReactDebugTool is ignored.
+      // This lets us make assertions on the actual tree.
+      ReactComponentTreeHook._preventPurging = true;
+      ReactDOMServer.renderToString(<Wrapper />);
+      ReactComponentTreeHook._preventPurging = false;
       expectWrapperTreeToEqual(expectedTree);
 
-      // Unmounting should clean it up.
-      ReactNative.unmountComponentAtNode(1);
+      // Purge manually since we skipped the automatic purge.
+      ReactComponentTreeHook.purgeUnmountedComponents();
       expectWrapperTreeToEqual(null);
     });
   }
@@ -140,10 +125,9 @@ describe('ReactComponentTreeDevtool', () => {
 
       delete Qux.displayName;
 
-      var element = <View><Foo /><Baz /><Qux /></View>;
+      var element = <div><Foo /><Baz /><Qux /></div>;
       var tree = {
-        displayName: 'View',
-        element,
+        displayName: 'div',
         children: [{
           displayName: 'Bar',
           children: [],
@@ -177,9 +161,10 @@ describe('ReactComponentTreeDevtool', () => {
       }
       delete Qux.name;
 
-      var element = <View><Foo /><Baz /><Qux /></View>;
+      var element = <div><Foo /><Baz /><Qux /></div>;
       var tree = {
-        displayName: 'View',
+        displayName: 'div',
+        element,
         children: [{
           displayName: 'Bar',
           children: [],
@@ -220,9 +205,10 @@ describe('ReactComponentTreeDevtool', () => {
       }
       delete Qux.name;
 
-      var element = <View><Foo /><Baz /><Qux /></View>;
+      var element = <div><Foo /><Baz /><Qux /></div>;
       var tree = {
-        displayName: 'View',
+        displayName: 'div',
+        element,
         children: [{
           displayName: 'Bar',
           children: [],
@@ -250,9 +236,10 @@ describe('ReactComponentTreeDevtool', () => {
       }
       delete Qux.name;
 
-      var element = <View><Foo /><Baz /><Qux /></View>;
+      var element = <div><Foo /><Baz /><Qux /></div>;
       var tree = {
-        displayName: 'View',
+        displayName: 'div',
+        element,
         children: [{
           displayName: 'Bar',
           children: [],
@@ -269,34 +256,33 @@ describe('ReactComponentTreeDevtool', () => {
 
     it('reports a host tree correctly', () => {
       var element = (
-        <View>
-          <View>
-            <Text>
+        <div>
+          <p>
+            <span>
               Hi!
-            </Text>
-          </View>
-          <Image />
-        </View>
+            </span>
+            Wow.
+          </p>
+          <hr />
+        </div>
       );
       var tree = {
-        displayName: 'View',
-        element,
+        displayName: 'div',
         children: [{
-          displayName: 'View',
+          displayName: 'p',
           children: [{
-            displayName: 'Text',
+            displayName: 'span',
             children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                element: 'Hi!',
-                text: 'Hi!',
-              }],
+              displayName: '#text',
+              text: 'Hi!',
             }],
+          }, {
+            displayName: '#text',
+            text: 'Wow.',
           }],
         }, {
-          displayName: 'Image',
-          element: <Image />,
+          displayName: 'hr',
+          element: <hr />,
           children: [],
         }],
       };
@@ -306,7 +292,7 @@ describe('ReactComponentTreeDevtool', () => {
     it('reports a simple tree with composites correctly', () => {
       class Foo extends React.Component {
         render() {
-          return <Image />;
+          return <div />;
         }
       }
 
@@ -315,8 +301,8 @@ describe('ReactComponentTreeDevtool', () => {
         displayName: 'Foo',
         element,
         children: [{
-          displayName: 'Image',
-          element: <Image />,
+          displayName: 'div',
+          element: <div />,
           children: [],
         }],
       };
@@ -338,18 +324,19 @@ describe('ReactComponentTreeDevtool', () => {
         };
       }
       function Bar({children}) {
-        return <View>{children}</View>;
+        return <h1>{children}</h1>;
       }
       class Baz extends React.Component {
         render() {
           return (
-            <View>
+            <div>
               <Foo />
               <Bar>
-                <Text>Hi,</Text>
+                <span>Hi,</span>
+                Mom
               </Bar>
-              <Image />
-            </View>
+              <a href="#">Click me.</a>
+            </div>
           );
         }
       }
@@ -359,7 +346,7 @@ describe('ReactComponentTreeDevtool', () => {
         displayName: 'Baz',
         element,
         children: [{
-          displayName: 'View',
+          displayName: 'div',
           children: [{
             displayName: 'Foo',
             element: <Foo />,
@@ -371,23 +358,27 @@ describe('ReactComponentTreeDevtool', () => {
           }, {
             displayName: 'Bar',
             children: [{
-              displayName: 'View',
+              displayName: 'h1',
               children: [{
-                displayName: 'Text',
+                displayName: 'span',
                 children: [{
-                  displayName: 'RCText',
-                  children: [{
-                    displayName: '#text',
-                    element: 'Hi,',
-                    text: 'Hi,',
-                  }],
+                  displayName: '#text',
+                  element: 'Hi,',
+                  text: 'Hi,',
                 }],
+              }, {
+                displayName: '#text',
+                text: 'Mom',
+                element: 'Mom',
               }],
             }],
           }, {
-            displayName: 'Image',
-            element: <Image />,
-            children: [],
+            displayName: 'a',
+            children: [{
+              displayName: '#text',
+              text: 'Click me.',
+              element: 'Click me.',
+            }],
           }],
         }],
       };
@@ -423,63 +414,55 @@ describe('ReactComponentTreeDevtool', () => {
     });
 
     it('reports text nodes as children', () => {
-      var element = <Text>{'1'}{2}</Text>;
+      var element = <div>{'1'}{2}</div>;
       var tree = {
-        displayName: 'Text',
+        displayName: 'div',
+        element,
         children: [{
-          displayName: 'RCText',
-          children: [{
-            displayName: '#text',
-            text: '1',
-          }, {
-            displayName: '#text',
-            text: '2',
-          }],
+          displayName: '#text',
+          text: '1',
+        }, {
+          displayName: '#text',
+          text: '2',
         }],
       };
       assertTreeMatches([element, tree]);
     });
 
     it('reports a single text node as a child', () => {
-      var element = <Text>{'1'}</Text>;
+      var element = <div>{'1'}</div>;
       var tree = {
-        displayName: 'Text',
+        displayName: 'div',
+        element,
         children: [{
-          displayName: 'RCText',
-          children: [{
-            displayName: '#text',
-            text: '1',
-          }],
+          displayName: '#text',
+          text: '1',
         }],
       };
       assertTreeMatches([element, tree]);
     });
 
     it('reports a single number node as a child', () => {
-      var element = <Text>{42}</Text>;
+      var element = <div>{42}</div>;
       var tree = {
-        displayName: 'Text',
+        displayName: 'div',
+        element,
         children: [{
-          displayName: 'RCText',
-          children: [{
-            displayName: '#text',
-            text: '42',
-          }],
+          displayName: '#text',
+          text: '42',
         }],
       };
       assertTreeMatches([element, tree]);
     });
 
     it('reports a zero as a child', () => {
-      var element = <Text>{0}</Text>;
+      var element = <div>{0}</div>;
       var tree = {
-        displayName: 'Text',
+        displayName: 'div',
+        element,
         children: [{
-          displayName: 'RCText',
-          children: [{
-            displayName: '#text',
-            text: '0',
-          }],
+          displayName: '#text',
+          text: '0',
         }],
       };
       assertTreeMatches([element, tree]);
@@ -487,36 +470,46 @@ describe('ReactComponentTreeDevtool', () => {
 
     it('skips empty nodes for multiple children', () => {
       function Foo() {
-        return <Image />;
+        return <div />;
       }
       var element = (
-        <View>
+        <div>
+          {'hi'}
           {false}
-          <Foo />
+          {42}
           {null}
           <Foo />
-        </View>
+        </div>
       );
       var tree = {
-        displayName: 'View',
+        displayName: 'div',
         element,
         children: [{
-          displayName: 'Foo',
-          element: <Foo />,
-          children: [{
-            displayName: 'Image',
-            element: <Image />,
-            children: [],
-          }],
+          displayName: '#text',
+          text: 'hi',
+          element: 'hi',
+        }, {
+          displayName: '#text',
+          text: '42',
+          element: 42,
         }, {
           displayName: 'Foo',
           element: <Foo />,
           children: [{
-            displayName: 'Image',
-            element: <Image />,
+            displayName: 'div',
+            element: <div />,
             children: [],
           }],
         }],
+      };
+      assertTreeMatches([element, tree]);
+    });
+
+    it('reports html content as no children', () => {
+      var element = <div dangerouslySetInnerHTML={{__html: 'Bye.'}} />;
+      var tree = {
+        displayName: 'div',
+        children: [],
       };
       assertTreeMatches([element, tree]);
     });
@@ -525,27 +518,21 @@ describe('ReactComponentTreeDevtool', () => {
   describe('update', () => {
     describe('host component', () => {
       it('updates text of a single text child', () => {
-        var elementBefore = <Text>Hi.</Text>;
+        var elementBefore = <div>Hi.</div>;
         var treeBefore = {
-          displayName: 'Text',
+          displayName: 'div',
           children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }],
+            displayName: '#text',
+            text: 'Hi.',
           }],
         };
 
-        var elementAfter = <Text>Bye.</Text>;
+        var elementAfter = <div>Bye.</div>;
         var treeAfter = {
-          displayName: 'Text',
+          displayName: 'div',
           children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Bye.',
-            }],
+            displayName: '#text',
+            text: 'Bye.',
           }],
         };
 
@@ -556,24 +543,18 @@ describe('ReactComponentTreeDevtool', () => {
       });
 
       it('updates from no children to a single text child', () => {
-        var elementBefore = <Text />;
+        var elementBefore = <div />;
         var treeBefore = {
-          displayName: 'Text',
-          children: [{
-            displayName: 'RCText',
-            children: [],
-          }],
+          displayName: 'div',
+          children: [],
         };
 
-        var elementAfter = <Text>Hi.</Text>;
+        var elementAfter = <div>Hi.</div>;
         var treeAfter = {
-          displayName: 'Text',
+          displayName: 'div',
           children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }],
+            displayName: '#text',
+            text: 'Hi.',
           }],
         };
 
@@ -584,24 +565,40 @@ describe('ReactComponentTreeDevtool', () => {
       });
 
       it('updates from a single text child to no children', () => {
-        var elementBefore = <Text>Hi.</Text>;
+        var elementBefore = <div>Hi.</div>;
         var treeBefore = {
-          displayName: 'Text',
+          displayName: 'div',
           children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }],
+            displayName: '#text',
+            text: 'Hi.',
           }],
         };
 
-        var elementAfter = <Text />;
+        var elementAfter = <div />;
         var treeAfter = {
-          displayName: 'Text',
+          displayName: 'div',
+          children: [],
+        };
+
+        assertTreeMatches([
+          [elementBefore, treeBefore],
+          [elementAfter, treeAfter],
+        ]);
+      });
+
+      it('updates from html content to a single text child', () => {
+        var elementBefore = <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />;
+        var treeBefore = {
+          displayName: 'div',
+          children: [],
+        };
+
+        var elementAfter = <div>Hi.</div>;
+        var treeAfter = {
+          displayName: 'div',
           children: [{
-            displayName: 'RCText',
-            children: [],
+            displayName: '#text',
+            text: 'Hi.',
           }],
         };
 
@@ -611,28 +608,44 @@ describe('ReactComponentTreeDevtool', () => {
         ]);
       });
 
-      it('updates from no children to multiple text children', () => {
-        var elementBefore = <Text />;
+      it('updates from a single text child to html content', () => {
+        var elementBefore = <div>Hi.</div>;
         var treeBefore = {
-          displayName: 'Text',
+          displayName: 'div',
           children: [{
-            displayName: 'RCText',
-            children: [],
+            displayName: '#text',
+            text: 'Hi.',
           }],
         };
 
-        var elementAfter = <Text>{'Hi.'}{'Bye.'}</Text>;
+        var elementAfter = <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />;
         var treeAfter = {
-          displayName: 'Text',
+          displayName: 'div',
+          children: [],
+        };
+
+        assertTreeMatches([
+          [elementBefore, treeBefore],
+          [elementAfter, treeAfter],
+        ]);
+      });
+
+      it('updates from no children to multiple text children', () => {
+        var elementBefore = <div />;
+        var treeBefore = {
+          displayName: 'div',
+          children: [],
+        };
+
+        var elementAfter = <div>{'Hi.'}{'Bye.'}</div>;
+        var treeAfter = {
+          displayName: 'div',
           children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }, {
-              displayName: '#text',
-              text: 'Bye.',
-            }],
+            displayName: '#text',
+            text: 'Hi.',
+          }, {
+            displayName: '#text',
+            text: 'Bye.',
           }],
         };
 
@@ -643,29 +656,112 @@ describe('ReactComponentTreeDevtool', () => {
       });
 
       it('updates from multiple text children to no children', () => {
-        var elementBefore = <Text>{'Hi.'}{'Bye.'}</Text>;
+        var elementBefore = <div>{'Hi.'}{'Bye.'}</div>;
         var treeBefore = {
-          displayName: 'Text',
+          displayName: 'div',
           children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }, {
-              displayName: '#text',
-              text: 'Bye.',
-            }],
+            displayName: '#text',
+            text: 'Hi.',
+          }, {
+            displayName: '#text',
+            text: 'Bye.',
           }],
         };
 
-        var elementAfter = <Text />;
+        var elementAfter = <div />;
         var treeAfter = {
-          displayName: 'Text',
+          displayName: 'div',
+          children: [],
+        };
+
+        assertTreeMatches([
+          [elementBefore, treeBefore],
+          [elementAfter, treeAfter],
+        ]);
+      });
+
+      it('updates from html content to multiple text children', () => {
+        var elementBefore = <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />;
+        var treeBefore = {
+          displayName: 'div',
+          children: [],
+        };
+
+        var elementAfter = <div>{'Hi.'}{'Bye.'}</div>;
+        var treeAfter = {
+          displayName: 'div',
           children: [{
-            displayName: 'RCText',
-            children: [],
+            displayName: '#text',
+            text: 'Hi.',
+          }, {
+            displayName: '#text',
+            text: 'Bye.',
           }],
         };
+
+        assertTreeMatches([
+          [elementBefore, treeBefore],
+          [elementAfter, treeAfter],
+        ]);
+      });
+
+      it('updates from multiple text children to html content', () => {
+        var elementBefore = <div>{'Hi.'}{'Bye.'}</div>;
+        var treeBefore = {
+          displayName: 'div',
+          children: [{
+            displayName: '#text',
+            text: 'Hi.',
+          }, {
+            displayName: '#text',
+            text: 'Bye.',
+          }],
+        };
+
+        var elementAfter = <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />;
+        var treeAfter = {
+          displayName: 'div',
+          children: [],
+        };
+
+        assertTreeMatches([
+          [elementBefore, treeBefore],
+          [elementAfter, treeAfter],
+        ]);
+      });
+
+      it('updates from html content to no children', () => {
+        var elementBefore = <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />;
+        var treeBefore = {
+          displayName: 'div',
+          children: [],
+        };
+
+        var elementAfter = <div />;
+        var treeAfter = {
+          displayName: 'div',
+          children: [],
+        };
+
+        assertTreeMatches([
+          [elementBefore, treeBefore],
+          [elementAfter, treeAfter],
+        ]);
+      });
+
+      it('updates from no children to html content', () => {
+        var elementBefore = <div />;
+        var treeBefore = {
+          displayName: 'div',
+          children: [],
+        };
+
+        var elementAfter = <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />;
+        var treeAfter = {
+          displayName: 'div',
+          children: [],
+        };
+
         assertTreeMatches([
           [elementBefore, treeBefore],
           [elementAfter, treeAfter],
@@ -673,30 +769,24 @@ describe('ReactComponentTreeDevtool', () => {
       });
 
       it('updates from one text child to multiple text children', () => {
-        var elementBefore = <Text>Hi.</Text>;
+        var elementBefore = <div>Hi.</div>;
         var treeBefore = {
-          displayName: 'Text',
+          displayName: 'div',
           children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }],
+            displayName: '#text',
+            text: 'Hi.',
           }],
         };
 
-        var elementAfter = <Text>{'Hi.'}{'Bye.'}</Text>;
+        var elementAfter = <div>{'Hi.'}{'Bye.'}</div>;
         var treeAfter = {
-          displayName: 'Text',
+          displayName: 'div',
           children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }, {
-              displayName: '#text',
-              text: 'Bye.',
-            }],
+            displayName: '#text',
+            text: 'Hi.',
+          }, {
+            displayName: '#text',
+            text: 'Bye.',
           }],
         };
 
@@ -707,30 +797,24 @@ describe('ReactComponentTreeDevtool', () => {
       });
 
       it('updates from multiple text children to one text child', () => {
-        var elementBefore = <Text>{'Hi.'}{'Bye.'}</Text>;
+        var elementBefore = <div>{'Hi.'}{'Bye.'}</div>;
         var treeBefore = {
-          displayName: 'Text',
+          displayName: 'div',
           children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }, {
-              displayName: '#text',
-              text: 'Bye.',
-            }],
+            displayName: '#text',
+            text: 'Hi.',
+          }, {
+            displayName: '#text',
+            text: 'Bye.',
           }],
         };
 
-        var elementAfter = <Text>Hi.</Text>;
+        var elementAfter = <div>Hi.</div>;
         var treeAfter = {
-          displayName: 'Text',
+          displayName: 'div',
           children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }],
+            displayName: '#text',
+            text: 'Hi.',
           }],
         };
         assertTreeMatches([
@@ -740,33 +824,27 @@ describe('ReactComponentTreeDevtool', () => {
       });
 
       it('updates text nodes when reordering', () => {
-        var elementBefore = <Text>{'Hi.'}{'Bye.'}</Text>;
+        var elementBefore = <div>{'Hi.'}{'Bye.'}</div>;
         var treeBefore = {
-          displayName: 'Text',
+          displayName: 'div',
           children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }, {
-              displayName: '#text',
-              text: 'Bye.',
-            }],
+            displayName: '#text',
+            text: 'Hi.',
+          }, {
+            displayName: '#text',
+            text: 'Bye.',
           }],
         };
 
-        var elementAfter = <Text>{'Bye.'}{'Hi.'}</Text>;
+        var elementAfter = <div>{'Bye.'}{'Hi.'}</div>;
         var treeAfter = {
-          displayName: 'Text',
+          displayName: 'div',
           children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Bye.',
-            }, {
-              displayName: '#text',
-              text: 'Hi.',
-            }],
+            displayName: '#text',
+            text: 'Bye.',
+          }, {
+            displayName: '#text',
+            text: 'Hi.',
           }],
         };
         assertTreeMatches([
@@ -777,59 +855,47 @@ describe('ReactComponentTreeDevtool', () => {
 
       it('updates host nodes when reordering with keys', () => {
         var elementBefore = (
-          <View>
-            <Text key="a">Hi.</Text>
-            <Text key="b">Bye.</Text>
-          </View>
+          <div>
+            <div key="a">Hi.</div>
+            <div key="b">Bye.</div>
+          </div>
         );
         var treeBefore = {
-          displayName: 'View',
+          displayName: 'div',
           children: [{
-            displayName: 'Text',
+            displayName: 'div',
             children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: 'Hi.',
-              }],
+              displayName: '#text',
+              text: 'Hi.',
             }],
           }, {
-            displayName: 'Text',
+            displayName: 'div',
             children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: 'Bye.',
-              }],
+              displayName: '#text',
+              text: 'Bye.',
             }],
           }],
         };
 
         var elementAfter = (
-          <View>
-            <Text key="b">Bye.</Text>
-            <Text key="a">Hi.</Text>
-          </View>
+          <div>
+            <div key="b">Bye.</div>
+            <div key="a">Hi.</div>
+          </div>
         );
         var treeAfter = {
-          displayName: 'View',
+          displayName: 'div',
           children: [{
-            displayName: 'Text',
+            displayName: 'div',
             children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: 'Bye.',
-              }],
+              displayName: '#text',
+              text: 'Bye.',
             }],
           }, {
-            displayName: 'Text',
+            displayName: 'div',
             children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: 'Hi.',
-              }],
+              displayName: '#text',
+              text: 'Hi.',
             }],
           }],
         };
@@ -840,61 +906,49 @@ describe('ReactComponentTreeDevtool', () => {
         ]);
       });
 
-      it('updates host nodes when reordering with keys', () => {
+      it('updates host nodes when reordering without keys', () => {
         var elementBefore = (
-          <View>
-            <Text>Hi.</Text>
-            <Text>Bye.</Text>
-          </View>
+          <div>
+            <div>Hi.</div>
+            <div>Bye.</div>
+          </div>
         );
         var treeBefore = {
-          displayName: 'View',
+          displayName: 'div',
           children: [{
-            displayName: 'Text',
+            displayName: 'div',
             children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: 'Hi.',
-              }],
+              displayName: '#text',
+              text: 'Hi.',
             }],
           }, {
-            displayName: 'Text',
+            displayName: 'div',
             children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: 'Bye.',
-              }],
+              displayName: '#text',
+              text: 'Bye.',
             }],
           }],
         };
 
         var elementAfter = (
-          <View>
-            <Text>Bye.</Text>
-            <Text>Hi.</Text>
-          </View>
+          <div>
+            <div>Bye.</div>
+            <div>Hi.</div>
+          </div>
         );
         var treeAfter = {
-          displayName: 'View',
+          displayName: 'div',
           children: [{
-            displayName: 'Text',
+            displayName: 'div',
             children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: 'Bye.',
-              }],
+              displayName: '#text',
+              text: 'Bye.',
             }],
           }, {
-            displayName: 'Text',
+            displayName: 'div',
             children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: 'Hi.',
-              }],
+              displayName: '#text',
+              text: 'Hi.',
             }],
           }],
         };
@@ -914,18 +968,18 @@ describe('ReactComponentTreeDevtool', () => {
           return null;
         }
 
-        var elementBefore = <View><Foo /></View>;
+        var elementBefore = <div><Foo /></div>;
         var treeBefore = {
-          displayName: 'View',
+          displayName: 'div',
           children: [{
             displayName: 'Foo',
             children: [],
           }],
         };
 
-        var elementAfter = <View><Bar /></View>;
+        var elementAfter = <div><Bar /></div>;
         var treeAfter = {
-          displayName: 'View',
+          displayName: 'div',
           children: [{
             displayName: 'Bar',
             children: [],
@@ -943,25 +997,25 @@ describe('ReactComponentTreeDevtool', () => {
           return children;
         }
 
-        var elementBefore = <View><Foo><View /></Foo></View>;
+        var elementBefore = <div><Foo><div /></Foo></div>;
         var treeBefore = {
-          displayName: 'View',
+          displayName: 'div',
           children: [{
             displayName: 'Foo',
             children: [{
-              displayName: 'View',
+              displayName: 'div',
               children: [],
             }],
           }],
         };
 
-        var elementAfter = <View><Foo><Image /></Foo></View>;
+        var elementAfter = <div><Foo><span /></Foo></div>;
         var treeAfter = {
-          displayName: 'View',
+          displayName: 'div',
           children: [{
             displayName: 'Foo',
             children: [{
-              displayName: 'Image',
+              displayName: 'span',
               children: [],
             }],
           }],
@@ -978,15 +1032,15 @@ describe('ReactComponentTreeDevtool', () => {
           return null;
         }
 
-        var elementBefore = <View />;
+        var elementBefore = <div />;
         var treeBefore = {
-          displayName: 'View',
+          displayName: 'div',
           children: [],
         };
 
-        var elementAfter = <View><Foo /></View>;
+        var elementAfter = <div><Foo /></div>;
         var treeAfter = {
-          displayName: 'View',
+          displayName: 'div',
           children: [{
             displayName: 'Foo',
             children: [],
@@ -1004,18 +1058,18 @@ describe('ReactComponentTreeDevtool', () => {
           return null;
         }
 
-        var elementBefore = <View><Foo /></View>;
+        var elementBefore = <div><Foo /></div>;
         var treeBefore = {
-          displayName: 'View',
+          displayName: 'div',
           children: [{
             displayName: 'Foo',
             children: [],
           }],
         };
 
-        var elementAfter = <View />;
+        var elementAfter = <div />;
         var treeAfter = {
-          displayName: 'View',
+          displayName: 'div',
           children: [],
         };
 
@@ -1027,85 +1081,67 @@ describe('ReactComponentTreeDevtool', () => {
 
       it('updates mixed children', () => {
         function Foo() {
-          return <View />;
+          return <div />;
         }
         var element1 = (
-          <View>
-            <Text>hi</Text>
+          <div>
+            {'hi'}
             {false}
-            <Text>{42}</Text>
+            {42}
             {null}
             <Foo />
-          </View>
+          </div>
         );
         var tree1 = {
-          displayName: 'View',
+          displayName: 'div',
           children: [{
-            displayName: 'Text',
-            children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: 'hi',
-              }],
-            }],
+            displayName: '#text',
+            text: 'hi',
           }, {
-            displayName: 'Text',
-            children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: '42',
-              }],
-            }],
+            displayName: '#text',
+            text: '42',
           }, {
             displayName: 'Foo',
             children: [{
-              displayName: 'View',
+              displayName: 'div',
               children: [],
             }],
           }],
         };
 
         var element2 = (
-          <View>
+          <div>
             <Foo />
             {false}
-            <Text>hi</Text>
+            {'hi'}
             {null}
-          </View>
+          </div>
         );
         var tree2 = {
-          displayName: 'View',
+          displayName: 'div',
           children: [{
             displayName: 'Foo',
             children: [{
-              displayName: 'View',
+              displayName: 'div',
               children: [],
             }],
           }, {
-            displayName: 'Text',
-            children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: 'hi',
-              }],
-            }],
+            displayName: '#text',
+            text: 'hi',
           }],
         };
 
         var element3 = (
-          <View>
+          <div>
             <Foo />
-          </View>
+          </div>
         );
         var tree3 = {
-          displayName: 'View',
+          displayName: 'div',
           children: [{
             displayName: 'Foo',
             children: [{
-              displayName: 'View',
+              displayName: 'div',
               children: [],
             }],
           }],
@@ -1125,20 +1161,20 @@ describe('ReactComponentTreeDevtool', () => {
           return children;
         }
 
-        var elementBefore = <Foo><View /></Foo>;
+        var elementBefore = <Foo><div /></Foo>;
         var treeBefore = {
           displayName: 'Foo',
           children: [{
-            displayName: 'View',
+            displayName: 'div',
             children: [],
           }],
         };
 
-        var elementAfter = <Foo><Image /></Foo>;
+        var elementAfter = <Foo><span /></Foo>;
         var treeAfter = {
           displayName: 'Foo',
           children: [{
-            displayName: 'Image',
+            displayName: 'span',
             children: [],
           }],
         };
@@ -1160,11 +1196,11 @@ describe('ReactComponentTreeDevtool', () => {
           children: [],
         };
 
-        var elementAfter = <Foo><View /></Foo>;
+        var elementAfter = <Foo><div /></Foo>;
         var treeAfter = {
           displayName: 'Foo',
           children: [{
-            displayName: 'View',
+            displayName: 'div',
             children: [],
           }],
         };
@@ -1180,11 +1216,11 @@ describe('ReactComponentTreeDevtool', () => {
           return children;
         }
 
-        var elementBefore = <Foo><View /></Foo>;
+        var elementBefore = <Foo><div /></Foo>;
         var treeBefore = {
           displayName: 'Foo',
           children: [{
-            displayName: 'View',
+            displayName: 'div',
             children: [],
           }],
         };
@@ -1210,11 +1246,11 @@ describe('ReactComponentTreeDevtool', () => {
           return children;
         }
 
-        var elementBefore = <Foo><View /></Foo>;
+        var elementBefore = <Foo><div /></Foo>;
         var treeBefore = {
           displayName: 'Foo',
           children: [{
-            displayName: 'View',
+            displayName: 'div',
             children: [],
           }],
         };
@@ -1252,11 +1288,11 @@ describe('ReactComponentTreeDevtool', () => {
           }],
         };
 
-        var elementAfter = <Foo><View /></Foo>;
+        var elementAfter = <Foo><div /></Foo>;
         var treeAfter = {
           displayName: 'Foo',
           children: [{
-            displayName: 'View',
+            displayName: 'div',
             children: [],
           }],
         };
@@ -1336,20 +1372,20 @@ describe('ReactComponentTreeDevtool', () => {
           }
         }
 
-        var elementBefore = <Foo><View /></Foo>;
+        var elementBefore = <Foo><div /></Foo>;
         var treeBefore = {
           displayName: 'Foo',
           children: [{
-            displayName: 'View',
+            displayName: 'div',
             children: [],
           }],
         };
 
-        var elementAfter = <Foo><Image /></Foo>;
+        var elementAfter = <Foo><span /></Foo>;
         var treeAfter = {
           displayName: 'Foo',
           children: [{
-            displayName: 'Image',
+            displayName: 'span',
             children: [],
           }],
         };
@@ -1373,11 +1409,11 @@ describe('ReactComponentTreeDevtool', () => {
           children: [],
         };
 
-        var elementAfter = <Foo><View /></Foo>;
+        var elementAfter = <Foo><div /></Foo>;
         var treeAfter = {
           displayName: 'Foo',
           children: [{
-            displayName: 'View',
+            displayName: 'div',
             children: [],
           }],
         };
@@ -1395,11 +1431,11 @@ describe('ReactComponentTreeDevtool', () => {
           }
         }
 
-        var elementBefore = <Foo><View /></Foo>;
+        var elementBefore = <Foo><div /></Foo>;
         var treeBefore = {
           displayName: 'Foo',
           children: [{
-            displayName: 'View',
+            displayName: 'div',
             children: [],
           }],
         };
@@ -1429,11 +1465,11 @@ describe('ReactComponentTreeDevtool', () => {
           }
         }
 
-        var elementBefore = <Foo><View /></Foo>;
+        var elementBefore = <Foo><div /></Foo>;
         var treeBefore = {
           displayName: 'Foo',
           children: [{
-            displayName: 'View',
+            displayName: 'div',
             children: [],
           }],
         };
@@ -1475,11 +1511,11 @@ describe('ReactComponentTreeDevtool', () => {
           }],
         };
 
-        var elementAfter = <Foo><View /></Foo>;
+        var elementAfter = <Foo><div /></Foo>;
         var treeAfter = {
           displayName: 'Foo',
           children: [{
-            displayName: 'View',
+            displayName: 'div',
             children: [],
           }],
         };
@@ -1563,57 +1599,46 @@ describe('ReactComponentTreeDevtool', () => {
   it('tracks owner correctly', () => {
     class Foo extends React.Component {
       render() {
-        return <Bar><Text>Hi.</Text></Bar>;
+        return <Bar><h1>Hi.</h1></Bar>;
       }
     }
     function Bar({children}) {
-      return <View>{children}<Text>Mom</Text></View>;
+      return <div>{children} Mom</div>;
     }
 
     // Note that owner is not calculated for text nodes
     // because they are not created from real elements.
-    var element = <View><Foo /></View>;
+    var element = <article><Foo /></article>;
     var tree = {
-      displayName: 'View',
+      displayName: 'article',
       children: [{
         displayName: 'Foo',
         children: [{
           displayName: 'Bar',
           ownerDisplayName: 'Foo',
           children: [{
-            displayName: 'View',
+            displayName: 'div',
             ownerDisplayName: 'Bar',
             children: [{
-              displayName: 'Text',
+              displayName: 'h1',
               ownerDisplayName: 'Foo',
               children: [{
-                displayName: 'RCText',
-                ownerDisplayName: 'Text',
-                children: [{
-                  displayName: '#text',
-                  text: 'Hi.',
-                }],
+                displayName: '#text',
+                text: 'Hi.',
               }],
             }, {
-              displayName: 'Text',
-              ownerDisplayName: 'Bar',
-              children: [{
-                displayName: 'RCText',
-                ownerDisplayName: 'Text',
-                children: [{
-                  displayName: '#text',
-                  text: 'Mom',
-                }],
-              }],
+              displayName: '#text',
+              text: ' Mom',
             }],
           }],
         }],
       }],
     };
-    assertTreeMatches([element, tree], {includeOwnerDisplayName: true});
+    assertTreeMatches([element, tree]);
   });
 
   it('purges unmounted components automatically', () => {
+    var node = document.createElement('div');
     var renderBar = true;
     var fooInstance;
     var barInstance;
@@ -1632,7 +1657,7 @@ describe('ReactComponentTreeDevtool', () => {
       }
     }
 
-    ReactNative.render(<Foo />, 1);
+    ReactDOM.render(<Foo />, node);
     ReactComponentTreeTestUtils.expectTree(barInstance._debugID, {
       displayName: 'Bar',
       parentDisplayName: 'Foo',
@@ -1641,14 +1666,15 @@ describe('ReactComponentTreeDevtool', () => {
     }, 'Foo');
 
     renderBar = false;
-    ReactNative.render(<Foo />, 1);
+    ReactDOM.render(<Foo />, node);
+    ReactDOM.render(<Foo />, node);
     ReactComponentTreeTestUtils.expectTree(barInstance._debugID, {
       displayName: 'Unknown',
       children: [],
       parentID: null,
     }, 'Foo');
 
-    ReactNative.unmountComponentAtNode(1);
+    ReactDOM.unmountComponentAtNode(node);
     ReactComponentTreeTestUtils.expectTree(barInstance._debugID, {
       displayName: 'Unknown',
       children: [],
@@ -1657,37 +1683,175 @@ describe('ReactComponentTreeDevtool', () => {
   });
 
   it('reports update counts', () => {
-    ReactNative.render(<View />, 1);
-    var viewID = ReactComponentTreeDevtool.getRootIDs()[0];
-    expect(ReactComponentTreeDevtool.getUpdateCount(viewID)).toEqual(0);
+    var node = document.createElement('div');
 
-    ReactNative.render(<Image />, 1);
-    var imageID = ReactComponentTreeDevtool.getRootIDs()[0];
-    expect(ReactComponentTreeDevtool.getUpdateCount(viewID)).toEqual(0);
-    expect(ReactComponentTreeDevtool.getUpdateCount(imageID)).toEqual(0);
+    ReactDOM.render(<div className="a" />, node);
+    var divID = ReactComponentTreeHook.getRootIDs()[0];
+    expect(ReactComponentTreeHook.getUpdateCount(divID)).toEqual(0);
 
-    ReactNative.render(<Image />, 1);
-    expect(ReactComponentTreeDevtool.getUpdateCount(viewID)).toEqual(0);
-    expect(ReactComponentTreeDevtool.getUpdateCount(imageID)).toEqual(1);
+    ReactDOM.render(<span className="a" />, node);
+    var spanID = ReactComponentTreeHook.getRootIDs()[0];
+    expect(ReactComponentTreeHook.getUpdateCount(divID)).toEqual(0);
+    expect(ReactComponentTreeHook.getUpdateCount(spanID)).toEqual(0);
 
-    ReactNative.render(<Image />, 1);
-    expect(ReactComponentTreeDevtool.getUpdateCount(viewID)).toEqual(0);
-    expect(ReactComponentTreeDevtool.getUpdateCount(imageID)).toEqual(2);
+    ReactDOM.render(<span className="b" />, node);
+    expect(ReactComponentTreeHook.getUpdateCount(divID)).toEqual(0);
+    expect(ReactComponentTreeHook.getUpdateCount(spanID)).toEqual(1);
 
-    ReactNative.unmountComponentAtNode(1);
-    expect(ReactComponentTreeDevtool.getUpdateCount(viewID)).toEqual(0);
-    expect(ReactComponentTreeDevtool.getUpdateCount(imageID)).toEqual(0);
+    ReactDOM.render(<span className="c" />, node);
+    expect(ReactComponentTreeHook.getUpdateCount(divID)).toEqual(0);
+    expect(ReactComponentTreeHook.getUpdateCount(spanID)).toEqual(2);
+
+    ReactDOM.unmountComponentAtNode(node);
+    expect(ReactComponentTreeHook.getUpdateCount(divID)).toEqual(0);
+    expect(ReactComponentTreeHook.getUpdateCount(spanID)).toEqual(0);
   });
 
   it('does not report top-level wrapper as a root', () => {
-    ReactNative.render(<View><Image /></View>, 1);
-    expect(ReactComponentTreeTestUtils.getRootDisplayNames()).toEqual(['View']);
+    var node = document.createElement('div');
 
-    ReactNative.render(<View><Text /></View>, 1);
-    expect(ReactComponentTreeTestUtils.getRootDisplayNames()).toEqual(['View']);
+    ReactDOM.render(<div className="a" />, node);
+    expect(ReactComponentTreeTestUtils.getRootDisplayNames()).toEqual(['div']);
 
-    ReactNative.unmountComponentAtNode(1);
+    ReactDOM.render(<div className="b" />, node);
+    expect(ReactComponentTreeTestUtils.getRootDisplayNames()).toEqual(['div']);
+
+    ReactDOM.unmountComponentAtNode(node);
     expect(ReactComponentTreeTestUtils.getRootDisplayNames()).toEqual([]);
     expect(ReactComponentTreeTestUtils.getRegisteredDisplayNames()).toEqual([]);
+  });
+
+  describe('stack addenda', () => {
+    it('gets created', () => {
+      function getAddendum(element) {
+        var addendum = ReactComponentTreeHook.getCurrentStackAddendum(element);
+        return addendum.replace(/\(at .+?:\d+\)/g, '(at **)');
+      }
+
+      var Anon = React.createClass({displayName: null, render: () => null});
+      var Orange = React.createClass({render: () => null});
+
+      expect(getAddendum()).toBe(
+        ''
+      );
+      expect(getAddendum(<div />)).toBe(
+        '\n    in div (at **)'
+      );
+      expect(getAddendum(<Anon />)).toBe(
+        '\n    in Unknown (at **)'
+      );
+      expect(getAddendum(<Orange />)).toBe(
+        '\n    in Orange (at **)'
+      );
+      expect(getAddendum(React.createElement(Orange))).toBe(
+        '\n    in Orange'
+      );
+
+      var renders = 0;
+      var rOwnedByQ;
+
+      function Q() {
+        return (rOwnedByQ = React.createElement(R));
+      }
+      function R() {
+        return <div><S /></div>;
+      }
+      class S extends React.Component {
+        componentDidMount() {
+          // Check that the parent path is still fetched when only S itself is on
+          // the stack.
+          this.forceUpdate();
+        }
+        render() {
+          expect(getAddendum()).toBe(
+            '\n    in S (at **)' +
+            '\n    in div (at **)' +
+            '\n    in R (created by Q)' +
+            '\n    in Q (at **)'
+          );
+          expect(getAddendum(<span />)).toBe(
+            '\n    in span (at **)' +
+            '\n    in S (at **)' +
+            '\n    in div (at **)' +
+            '\n    in R (created by Q)' +
+            '\n    in Q (at **)'
+          );
+          expect(getAddendum(React.createElement('span'))).toBe(
+            '\n    in span (created by S)' +
+            '\n    in S (at **)' +
+            '\n    in div (at **)' +
+            '\n    in R (created by Q)' +
+            '\n    in Q (at **)'
+          );
+          renders++;
+          return null;
+        }
+      }
+      ReactDOM.render(<Q />, document.createElement('div'));
+      expect(renders).toBe(2);
+
+      // Make sure owner is fetched for the top element too.
+      expect(getAddendum(rOwnedByQ)).toBe(
+        '\n    in R (created by Q)'
+      );
+    });
+
+    it('can be retrieved by ID', () => {
+      function getAddendum(id) {
+        var addendum = ReactComponentTreeHook.getStackAddendumByID(id);
+        return addendum.replace(/\(at .+?:\d+\)/g, '(at **)');
+      }
+
+      class Q extends React.Component {
+        render() {
+          return null;
+        }
+      }
+
+      var q = ReactDOM.render(<Q />, document.createElement('div'));
+      expect(getAddendum(ReactInstanceMap.get(q)._debugID)).toBe(
+        '\n    in Q (at **)'
+      );
+
+      spyOn(console, 'error');
+      getAddendum(-17);
+      expect(console.error.calls.count()).toBe(1);
+      expect(console.error.calls.argsFor(0)[0]).toBe(
+        'Warning: ReactComponentTreeHook: Missing React element for ' +
+        'debugID -17 when building stack'
+      );
+    });
+
+    it('is created during mounting', () => {
+      // https://github.com/facebook/react/issues/7187
+      var el = document.createElement('div');
+      var portalEl = document.createElement('div');
+      class Foo extends React.Component {
+        componentWillMount() {
+          ReactDOM.render(<div />, portalEl);
+        }
+        render() {
+          return <div><div /></div>;
+        }
+      }
+      ReactDOM.render(<Foo />, el);
+    });
+
+    it('is created when calling renderToString during render', () => {
+      // https://github.com/facebook/react/issues/7190
+      var el = document.createElement('div');
+      class Foo extends React.Component {
+        render() {
+          return (
+            <div>
+              <div>
+                {ReactDOMServer.renderToString(<div />)}
+              </div>
+            </div>
+          );
+        }
+      }
+      ReactDOM.render(<Foo />, el);
+    });
   });
 });

--- a/src/renderers/shared/hooks/__tests__/ReactHostOperationHistoryHook-test.js
+++ b/src/renderers/shared/hooks/__tests__/ReactHostOperationHistoryHook-test.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-describe('ReactHostOperationHistoryDevtool', () => {
+describe('ReactHostOperationHistoryHook', () => {
   var React;
   var ReactPerf;
   var ReactDOM;
   var ReactDOMComponentTree;
   var ReactDOMFeatureFlags;
-  var ReactHostOperationHistoryDevtool;
+  var ReactHostOperationHistoryHook;
 
   beforeEach(() => {
     jest.resetModuleRegistry();
@@ -27,7 +27,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
     ReactDOM = require('ReactDOM');
     ReactDOMComponentTree = require('ReactDOMComponentTree');
     ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
-    ReactHostOperationHistoryDevtool = require('ReactHostOperationHistoryDevtool');
+    ReactHostOperationHistoryHook = require('ReactHostOperationHistoryHook');
 
     ReactPerf.start();
   });
@@ -37,14 +37,14 @@ describe('ReactHostOperationHistoryDevtool', () => {
   });
 
   function assertHistoryMatches(expectedHistory) {
-    var actualHistory = ReactHostOperationHistoryDevtool.getHistory();
+    var actualHistory = ReactHostOperationHistoryHook.getHistory();
     expect(actualHistory).toEqual(expectedHistory);
   }
 
   describe('mount', () => {
     it('gets recorded for host roots', () => {
       var node = document.createElement('div');
-      ReactHostOperationHistoryDevtool._preventClearing = true;
+      ReactHostOperationHistoryHook._preventClearing = true;
       ReactDOM.render(<div><p>Hi.</p></div>, node);
 
       var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
@@ -63,7 +63,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
       }
       var node = document.createElement('div');
 
-      ReactHostOperationHistoryDevtool._preventClearing = true;
+      ReactHostOperationHistoryHook._preventClearing = true;
       ReactDOM.render(<Foo />, node);
 
       var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
@@ -83,7 +83,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
       }
       var node = document.createElement('div');
 
-      ReactHostOperationHistoryDevtool._preventClearing = true;
+      ReactHostOperationHistoryHook._preventClearing = true;
       ReactDOM.render(<Foo />, node);
 
       // Empty DOM components should be invisible to devtools.
@@ -96,7 +96,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
         return element;
       }
 
-      ReactHostOperationHistoryDevtool._preventClearing = true;
+      ReactHostOperationHistoryHook._preventClearing = true;
 
       var node = document.createElement('div');
       element = null;
@@ -120,7 +120,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
     it('gets recorded during mount', () => {
       var node = document.createElement('div');
 
-      ReactHostOperationHistoryDevtool._preventClearing = true;
+      ReactHostOperationHistoryHook._preventClearing = true;
       ReactDOM.render(<div style={{
         color: 'red',
         backgroundColor: 'yellow',
@@ -155,7 +155,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
       ReactDOM.render(<div />, node);
       var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
-      ReactHostOperationHistoryDevtool._preventClearing = true;
+      ReactHostOperationHistoryHook._preventClearing = true;
       ReactDOM.render(<div style={{ color: 'red' }} />, node);
       ReactDOM.render(<div style={{
         color: 'blue',
@@ -188,7 +188,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
       ReactDOM.render(<div />, node);
       var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
-      ReactHostOperationHistoryDevtool._preventClearing = true;
+      ReactHostOperationHistoryHook._preventClearing = true;
       ReactDOM.render(<div style={{
         color: 'red',
         backgroundColor: 'yellow',
@@ -214,7 +214,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
       it('gets recorded during mount', () => {
         var node = document.createElement('div');
 
-        ReactHostOperationHistoryDevtool._preventClearing = true;
+        ReactHostOperationHistoryHook._preventClearing = true;
         ReactDOM.render(<div className="rad" tabIndex={42} />, node);
 
         var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
@@ -247,7 +247,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
         ReactDOM.render(<div />, node);
         var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
-        ReactHostOperationHistoryDevtool._preventClearing = true;
+        ReactHostOperationHistoryHook._preventClearing = true;
         ReactDOM.render(<div className="rad" />, node);
         ReactDOM.render(<div className="mad" tabIndex={42} />, node);
         ReactDOM.render(<div tabIndex={43} />, node);
@@ -282,7 +282,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
         ReactDOM.render(<div />, node);
         var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
-        ReactHostOperationHistoryDevtool._preventClearing = true;
+        ReactHostOperationHistoryHook._preventClearing = true;
         ReactDOM.render(<div disabled={true} />, node);
         ReactDOM.render(<div disabled={false} />, node);
 
@@ -302,7 +302,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
       it('gets recorded during mount', () => {
         var node = document.createElement('div');
 
-        ReactHostOperationHistoryDevtool._preventClearing = true;
+        ReactHostOperationHistoryHook._preventClearing = true;
         ReactDOM.render(<div data-x="rad" data-y={42} />, node);
 
         var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
@@ -335,7 +335,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
         ReactDOM.render(<div />, node);
         var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
-        ReactHostOperationHistoryDevtool._preventClearing = true;
+        ReactHostOperationHistoryHook._preventClearing = true;
         ReactDOM.render(<div data-x="rad" />, node);
         ReactDOM.render(<div data-x="mad" data-y={42} />, node);
         ReactDOM.render(<div data-y={43} />, node);
@@ -368,7 +368,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
       it('gets recorded during mount', () => {
         var node = document.createElement('div');
 
-        ReactHostOperationHistoryDevtool._preventClearing = true;
+        ReactHostOperationHistoryHook._preventClearing = true;
         ReactDOM.render(<my-component className="rad" tabIndex={42} />, node);
 
         var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
@@ -401,7 +401,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
         ReactDOM.render(<my-component />, node);
         var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
-        ReactHostOperationHistoryDevtool._preventClearing = true;
+        ReactHostOperationHistoryHook._preventClearing = true;
         ReactDOM.render(<my-component className="rad" />, node);
         ReactDOM.render(<my-component className="mad" tabIndex={42} />, node);
         ReactDOM.render(<my-component tabIndex={43} />, node);
@@ -438,7 +438,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
         ReactDOM.render(<div>Hi.</div>, node);
         var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
-        ReactHostOperationHistoryDevtool._preventClearing = true;
+        ReactHostOperationHistoryHook._preventClearing = true;
         ReactDOM.render(<div>Bye.</div>, node);
 
         assertHistoryMatches([{
@@ -453,7 +453,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
         ReactDOM.render(<div dangerouslySetInnerHTML={{__html: 'Hi.'}} />, node);
         var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
-        ReactHostOperationHistoryDevtool._preventClearing = true;
+        ReactHostOperationHistoryHook._preventClearing = true;
         ReactDOM.render(<div>Bye.</div>, node);
 
         assertHistoryMatches([{
@@ -468,7 +468,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
         ReactDOM.render(<div><span /><p /></div>, node);
         var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
-        ReactHostOperationHistoryDevtool._preventClearing = true;
+        ReactHostOperationHistoryHook._preventClearing = true;
         ReactDOM.render(<div>Bye.</div>, node);
 
         assertHistoryMatches([{
@@ -490,7 +490,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
         var node = document.createElement('div');
         ReactDOM.render(<div>Hi.</div>, node);
 
-        ReactHostOperationHistoryDevtool._preventClearing = true;
+        ReactHostOperationHistoryHook._preventClearing = true;
         ReactDOM.render(<div>Hi.</div>, node);
 
         assertHistoryMatches([]);
@@ -504,7 +504,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
         var inst1 = ReactDOMComponentTree.getInstanceFromNode(node.firstChild.childNodes[0]);
         var inst2 = ReactDOMComponentTree.getInstanceFromNode(node.firstChild.childNodes[3]);
 
-        ReactHostOperationHistoryDevtool._preventClearing = true;
+        ReactHostOperationHistoryHook._preventClearing = true;
         ReactDOM.render(<div>{'Bye.'}{43}</div>, node);
 
         assertHistoryMatches([{
@@ -522,7 +522,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
         var node = document.createElement('div');
         ReactDOM.render(<div>{'Hi.'}{42}</div>, node);
 
-        ReactHostOperationHistoryDevtool._preventClearing = true;
+        ReactHostOperationHistoryHook._preventClearing = true;
         ReactDOM.render(<div>{'Hi.'}{42}</div>, node);
 
         assertHistoryMatches([]);
@@ -544,7 +544,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
 
       element = <span />;
 
-      ReactHostOperationHistoryDevtool._preventClearing = true;
+      ReactHostOperationHistoryHook._preventClearing = true;
       ReactDOM.render(<Foo />, node);
 
       assertHistoryMatches([{
@@ -567,7 +567,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
       var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
       element = null;
 
-      ReactHostOperationHistoryDevtool._preventClearing = true;
+      ReactHostOperationHistoryHook._preventClearing = true;
       ReactDOM.render(<Foo />, node);
 
       assertHistoryMatches([{
@@ -589,7 +589,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
 
       element = <div />;
 
-      ReactHostOperationHistoryDevtool._preventClearing = true;
+      ReactHostOperationHistoryHook._preventClearing = true;
       ReactDOM.render(<Foo />, node);
 
       assertHistoryMatches([]);
@@ -602,7 +602,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
       ReactDOM.render(<div>Hi.</div>, node);
       var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
-      ReactHostOperationHistoryDevtool._preventClearing = true;
+      ReactHostOperationHistoryHook._preventClearing = true;
       ReactDOM.render(
         <div dangerouslySetInnerHTML={{__html: 'Bye.'}} />,
         node
@@ -623,7 +623,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
       );
       var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
-      ReactHostOperationHistoryDevtool._preventClearing = true;
+      ReactHostOperationHistoryHook._preventClearing = true;
       ReactDOM.render(
         <div dangerouslySetInnerHTML={{__html: 'Bye.'}} />,
         node
@@ -641,7 +641,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
       ReactDOM.render(<div><span /><p /></div>, node);
       var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
-      ReactHostOperationHistoryDevtool._preventClearing = true;
+      ReactHostOperationHistoryHook._preventClearing = true;
       ReactDOM.render(
         <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />,
         node
@@ -669,7 +669,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
         node
       );
 
-      ReactHostOperationHistoryDevtool._preventClearing = true;
+      ReactHostOperationHistoryHook._preventClearing = true;
       ReactDOM.render(
         <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />,
         node
@@ -685,7 +685,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
       ReactDOM.render(<div><span /></div>, node);
       var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
-      ReactHostOperationHistoryDevtool._preventClearing = true;
+      ReactHostOperationHistoryHook._preventClearing = true;
       ReactDOM.render(<div><span /><p /></div>, node);
 
       assertHistoryMatches([{
@@ -702,7 +702,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
       ReactDOM.render(<div><span key="a" /><p key="b" /></div>, node);
       var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
-      ReactHostOperationHistoryDevtool._preventClearing = true;
+      ReactHostOperationHistoryHook._preventClearing = true;
       ReactDOM.render(<div><p key="b" /><span key="a" /></div>, node);
 
       assertHistoryMatches([{
@@ -719,7 +719,7 @@ describe('ReactHostOperationHistoryDevtool', () => {
       ReactDOM.render(<div><span key="a" /><p key="b" /></div>, node);
       var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
-      ReactHostOperationHistoryDevtool._preventClearing = true;
+      ReactHostOperationHistoryHook._preventClearing = true;
       ReactDOM.render(<div><span key="a" /></div>, node);
 
       assertHistoryMatches([{

--- a/src/renderers/shared/hooks/__tests__/ReactHostOperationHistoryHook-test.js
+++ b/src/renderers/shared/hooks/__tests__/ReactHostOperationHistoryHook-test.js
@@ -86,7 +86,7 @@ describe('ReactHostOperationHistoryHook', () => {
       ReactHostOperationHistoryHook._preventClearing = true;
       ReactDOM.render(<Foo />, node);
 
-      // Empty DOM components should be invisible to devtools.
+      // Empty DOM components should be invisible to hooks.
       assertHistoryMatches([]);
     });
 
@@ -106,7 +106,7 @@ describe('ReactHostOperationHistoryHook', () => {
       ReactDOM.render(<Foo />, node);
       var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
-      // Since empty components should be invisible to devtools,
+      // Since empty components should be invisible to hooks,
       // we record a "mount" event rather than a "replace with".
       assertHistoryMatches([{
         instanceID: inst._debugID,

--- a/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
+++ b/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
@@ -19,7 +19,7 @@ var shouldUpdateReactComponent = require('shouldUpdateReactComponent');
 var traverseAllChildren = require('traverseAllChildren');
 var warning = require('warning');
 
-var ReactComponentTreeDevtool;
+var ReactComponentTreeHook;
 
 if (
   typeof process !== 'undefined' &&
@@ -31,15 +31,15 @@ if (
   // https://github.com/facebook/react/issues/7240
   // Remove the inline requires when we don't need them anymore:
   // https://github.com/facebook/react/pull/7178
-  ReactComponentTreeDevtool = require('ReactComponentTreeDevtool')
+  ReactComponentTreeHook = require('ReactComponentTreeHook')
 }
 
 function instantiateChild(childInstances, child, name, selfDebugID) {
   // We found a component instance.
   var keyUnique = (childInstances[name] === undefined);
   if (__DEV__) {
-    if (!ReactComponentTreeDevtool) {
-      ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
+    if (!ReactComponentTreeHook) {
+      ReactComponentTreeHook = require('ReactComponentTreeHook');
     }
     warning(
       keyUnique,
@@ -47,7 +47,7 @@ function instantiateChild(childInstances, child, name, selfDebugID) {
       '`%s`. Child keys must be unique; when two children share a key, only ' +
       'the first child will be used.%s',
       KeyEscapeUtils.unescape(name),
-      ReactComponentTreeDevtool.getStackAddendumByID(selfDebugID)
+      ReactComponentTreeHook.getStackAddendumByID(selfDebugID)
     );
   }
   if (child != null && keyUnique) {

--- a/src/shared/utils/flattenChildren.js
+++ b/src/shared/utils/flattenChildren.js
@@ -16,7 +16,7 @@ var KeyEscapeUtils = require('KeyEscapeUtils');
 var traverseAllChildren = require('traverseAllChildren');
 var warning = require('warning');
 
-var ReactComponentTreeDevtool;
+var ReactComponentTreeHook;
 
 if (
   typeof process !== 'undefined' &&
@@ -28,7 +28,7 @@ if (
   // https://github.com/facebook/react/issues/7240
   // Remove the inline requires when we don't need them anymore:
   // https://github.com/facebook/react/pull/7178
-  ReactComponentTreeDevtool = require('ReactComponentTreeDevtool')
+  ReactComponentTreeHook = require('ReactComponentTreeHook')
 }
 
 /**
@@ -48,8 +48,8 @@ function flattenSingleChildIntoContext(
     const result = traverseContext;
     const keyUnique = (result[name] === undefined);
     if (__DEV__) {
-      if (!ReactComponentTreeDevtool) {
-        ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
+      if (!ReactComponentTreeHook) {
+        ReactComponentTreeHook = require('ReactComponentTreeHook');
       }
       warning(
         keyUnique,
@@ -57,7 +57,7 @@ function flattenSingleChildIntoContext(
         '`%s`. Child keys must be unique; when two children share a key, only ' +
         'the first child will be used.%s',
         KeyEscapeUtils.unescape(name),
-        ReactComponentTreeDevtool.getStackAddendumByID(selfDebugID)
+        ReactComponentTreeHook.getStackAddendumByID(selfDebugID)
       );
     }
     if (keyUnique && child != null) {

--- a/src/test/ReactComponentTreeTestUtils.js
+++ b/src/test/ReactComponentTreeTestUtils.js
@@ -11,25 +11,25 @@
 
 'use strict';
 
-var ReactComponentTreeDevtool = require('ReactComponentTreeDevtool');
+var ReactComponentTreeHook = require('ReactComponentTreeHook');
 
 function getRootDisplayNames() {
-  return ReactComponentTreeDevtool.getRootIDs()
-    .map(ReactComponentTreeDevtool.getDisplayName);
+  return ReactComponentTreeHook.getRootIDs()
+    .map(ReactComponentTreeHook.getDisplayName);
 }
 
 function getRegisteredDisplayNames() {
-  return ReactComponentTreeDevtool.getRegisteredIDs()
-    .map(ReactComponentTreeDevtool.getDisplayName);
+  return ReactComponentTreeHook.getRegisteredIDs()
+    .map(ReactComponentTreeHook.getDisplayName);
 }
 
 function expectTree(rootID, expectedTree, parentPath) {
-  var displayName = ReactComponentTreeDevtool.getDisplayName(rootID);
-  var ownerID = ReactComponentTreeDevtool.getOwnerID(rootID);
-  var parentID = ReactComponentTreeDevtool.getParentID(rootID);
-  var childIDs = ReactComponentTreeDevtool.getChildIDs(rootID);
-  var text = ReactComponentTreeDevtool.getText(rootID);
-  var element = ReactComponentTreeDevtool.getElement(rootID);
+  var displayName = ReactComponentTreeHook.getDisplayName(rootID);
+  var ownerID = ReactComponentTreeHook.getOwnerID(rootID);
+  var parentID = ReactComponentTreeHook.getParentID(rootID);
+  var childIDs = ReactComponentTreeHook.getChildIDs(rootID);
+  var text = ReactComponentTreeHook.getText(rootID);
+  var element = ReactComponentTreeHook.getElement(rootID);
   var path = parentPath ? `${parentPath} > ${displayName}` : displayName;
 
   function expectEqual(actual, expected, name) {
@@ -46,14 +46,14 @@ function expectTree(rootID, expectedTree, parentPath) {
 
   if (expectedTree.parentDisplayName !== undefined) {
     expectEqual(
-      ReactComponentTreeDevtool.getDisplayName(parentID),
+      ReactComponentTreeHook.getDisplayName(parentID),
       expectedTree.parentDisplayName,
       'parentDisplayName'
     );
   }
   if (expectedTree.ownerDisplayName !== undefined) {
     expectEqual(
-      ReactComponentTreeDevtool.getDisplayName(ownerID),
+      ReactComponentTreeHook.getDisplayName(ownerID),
       expectedTree.ownerDisplayName,
       'ownerDisplayName'
     );


### PR DESCRIPTION
Now `devtool` stands for our [chrome extension](https://github.com/facebook/react-devtools/) and our internal stuff are called `hook`s.

Module name changes:
```
ReactComponentTreeDevtool -> ReactComponentTreeHook
ReactDOMNullInputValuePropDevtool -> ReactDOMNullInputValuePropHook
ReactDOMUnknownPropertyDevtool -> ReactDOMUnknownPropertyHook
ReactChildrenMutationWarningDevtool -> ReactChildrenMutationWarningHook
ReactHostOperationHistoryDevtool -> ReactHostOperationHistoryHook
ReactInvalidSetStateWarningDevTool -> ReactInvalidSetStateWarningHook
```

Internal API changes:
```
ReactDebugTool.addDevtool -> ReactDOMDebugTool.addHook
ReactDebugTool.removeDevtool -> ReactDOMDebugTool.removeHook
ReactDOMDebugTool.addDevtool -> ReactDOMDebugTool.addHook
ReactDOMDebugTool.removeDevtool -> ReactDOMDebugTool.removeHook
```

Note: https://github.com/facebook/react/pull/7381/commits/bba0d992d8f4ecf9cf6677817a1218e7f48a8a77 is a temporary compatibility fix for React Native/www.