### PR TITLE
Added a check and warning in case shadyRoot property is present in a …

### DIFF
--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -642,16 +642,15 @@ ReactDOMComponent.Mixin = {
           this._currentElement.type
         );
       }
-			// Check if the component is using shady-dom
-			// see discussion in https://github.com/facebook/react/issues/7325
-			if(__DEV__) {
-				warning(
-		      !el.shadyRoot,
-		      `Element ${this._currentElement.type} is using shady-dom. ` +
-					'React is not special-cased to support shady-root. Use shadow-dom instead. ' +
-					'see https://github.com/facebook/react/issues/7325 for more info.'
-		    );
-			}
+      // Check if the component is using shady-dom
+      // see discussion in https://github.com/facebook/react/issues/7325
+      if (__DEV__) {
+        warning(
+        !el.shadyRoot,
+        'Element  `%s` is using shady-dom. React is not special-cased to support shady-root. Use shadow-dom instead. ',
+        this._currentElement.type
+        );
+      }
       ReactDOMComponentTree.precacheNode(this, el);
       this._flags |= Flags.hasCachedChildNodes;
       if (!this._hostParent) {

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -642,6 +642,16 @@ ReactDOMComponent.Mixin = {
           this._currentElement.type
         );
       }
+			// Check if the component is using shady-dom
+			// see discussion in https://github.com/facebook/react/issues/7325
+			if(__DEV__) {
+				warning(
+		      !el.shadyRoot,
+		      `Element ${this._currentElement.type} is using shady-dom. ` +
+					'React is not special-cased to support shady-root. Use shadow-dom instead. ' +
+					'see https://github.com/facebook/react/issues/7325 for more info.'
+		    );
+			}
       ReactDOMComponentTree.precacheNode(this, el);
       this._flags |= Flags.hasCachedChildNodes;
       if (!this._hostParent) {


### PR DESCRIPTION
... newly created element

The check is added right after creating the dom element.

This commit is meant to fix: [#7325](https://github.com/facebook/react/issues/7325)

I would like to ask for some guidance on how to test that the warning is actually emitted because the mountComponent function uses document.createElement to create the polymer component.