### PR TITLE
Eliminate all lint warnings

### DIFF
--- a/src/isomorphic/classic/types/checkReactTypeSpec.js
+++ b/src/isomorphic/classic/types/checkReactTypeSpec.js
@@ -29,7 +29,7 @@ if (
   // https://github.com/facebook/react/issues/7240
   // Remove the inline requires when we don't need them anymore:
   // https://github.com/facebook/react/pull/7178
-  ReactComponentTreeHook = require('ReactComponentTreeHook')
+  ReactComponentTreeHook = require('ReactComponentTreeHook');
 }
 
 var loggedTypeFailures = {};

--- a/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
+++ b/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
@@ -31,7 +31,7 @@ if (
   // https://github.com/facebook/react/issues/7240
   // Remove the inline requires when we don't need them anymore:
   // https://github.com/facebook/react/pull/7178
-  ReactComponentTreeHook = require('ReactComponentTreeHook')
+  ReactComponentTreeHook = require('ReactComponentTreeHook');
 }
 
 function instantiateChild(childInstances, child, name, selfDebugID) {

--- a/src/shared/utils/flattenChildren.js
+++ b/src/shared/utils/flattenChildren.js
@@ -28,7 +28,7 @@ if (
   // https://github.com/facebook/react/issues/7240
   // Remove the inline requires when we don't need them anymore:
   // https://github.com/facebook/react/pull/7178
-  ReactComponentTreeHook = require('ReactComponentTreeHook')
+  ReactComponentTreeHook = require('ReactComponentTreeHook');
 }
 
 /**


### PR DESCRIPTION
No huge deal if this is rejected for `git blame` reasons, but I saw these warnings from `grunt lint` enough that I figured I would send out a PR killing the noise.