### PR TITLE
Specify "files" field for npm packages

### DIFF
--- a/packages/react-addons/package.json
+++ b/packages/react-addons/package.json
@@ -11,5 +11,11 @@
   "dependencies": {},
   "peerDependencies": {
     "react": "^16.0.0-alpha"
-  }
+  },
+  "files": [
+    "LICENSE",
+    "PATENTS",
+    "README.md",
+    "index.js"
+  ],
 }

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -15,5 +15,13 @@
   "dependencies": {},
   "peerDependencies": {
     "react": "^16.0.0-alpha"
-  }
+  },
+  "files": [
+    "LICENSE",
+    "PATENTS",
+    "README.md",
+    "dist/",
+    "index.js",
+    "server.js"
+  ]
 }

--- a/packages/react-native-renderer/package.json
+++ b/packages/react-native-renderer/package.json
@@ -15,5 +15,11 @@
   "homepage": "https://facebook.github.io/react-native/",
   "dependencies": {
     "react": "^16.0.0-alpha"
-  }
+  },
+  "files": [
+    "LICENSE",
+    "PATENTS",
+    "README.md",
+    "index.js"
+  ]
 }

--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -16,6 +16,11 @@
   "homepage": "https://facebook.github.io/react/",
   "peerDependencies": {
     "react": "^16.0.0-alpha"
-  }
+  },
+  "files": [
+    "LICENSE",
+    "PATENTS",
+    "README.md",
+    "index.js"
+  ]
 }
-


### PR DESCRIPTION
I had some rogue `.rej` files get published last release. I cleaned those up but for the future, this is good regardless.