### PR TITLE
Fix <input> with type date/time/etc. issue on mobile browsers

### DIFF
--- a/src/renderers/dom/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMInput.js
@@ -230,8 +230,24 @@ var ReactDOMInput = {
     // are not resetable nodes so this operation doesn't matter and actually
     // removes browser-default values (eg "Submit Query") when no value is
     // provided.
-    if (props.type !== 'submit' && props.type !== 'reset') {
-      node.value = node.value;
+
+    switch (props.type) {
+      case 'submit':
+      case 'reset':
+        break;
+      case 'date':
+      case 'datetime':
+      case 'datetime-local':
+      case 'month':
+      case 'time':
+      case 'week':
+        // this fixes the no-show issue on iOS Safari: https://github.com/facebook/react/issues/7233
+        node.value = '';
+        node.value = node.defaultValue;
+        break;
+      default:
+        node.value = node.value;
+        break;
     }
 
     // Normally, we'd just do `node.checked = node.checked` upon initial mount, less this bug

--- a/src/renderers/dom/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMInput.js
@@ -235,13 +235,15 @@ var ReactDOMInput = {
       case 'submit':
       case 'reset':
         break;
+      case 'color':
       case 'date':
       case 'datetime':
       case 'datetime-local':
       case 'month':
       case 'time':
       case 'week':
-        // this fixes the no-show issue on iOS Safari: https://github.com/facebook/react/issues/7233
+        // This fixes the no-show issue on iOS Safari and Android Chrome:
+        // https://github.com/facebook/react/issues/7233
         node.value = '';
         node.value = node.defaultValue;
         break;

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
@@ -82,6 +82,21 @@ describe('ReactDOMInput', function() {
     expect(node.defaultValue).toBe('1');
   });
 
+  it('should update `defaultValue` for uncontrolled date/time input', function() {
+    var container = document.createElement('div');
+
+    var node = ReactDOM.render(<input type="date" defaultValue="1980-01-01" />, container);
+
+    expect(node.value).toBe('1980-01-01');
+
+    ReactDOM.render(<input type="date" defaultValue="2000-01-01" />, container);
+
+    expect(node.value).toBe('1980-01-01');
+    expect(node.defaultValue).toBe('2000-01-01');
+
+    ReactDOM.render(<input type="date" />, container);
+  });
+
   it('should take `defaultValue` when changing to uncontrolled input', function() {
     var container = document.createElement('div');
 
@@ -790,4 +805,42 @@ describe('ReactDOMInput', function() {
     expect(node.value).toEqual('Test');
   });
 
+  it('resets value of date/time input to fix bugs in iOS Safari', function() {
+    // https://github.com/facebook/react/issues/7233
+    if (!ReactDOMFeatureFlags.useCreateElement) {
+      return;
+    }
+
+    function strify(x) {
+      return JSON.stringify(x, null, 2);
+    }
+
+    var log = [];
+    var originalCreateElement = document.createElement;
+    spyOn(document, 'createElement').and.callFake(function(type) {
+      var el = originalCreateElement.apply(this, arguments);
+      if (type === 'input') {
+        Object.defineProperty(el, 'value', {
+          set: function(val) {
+            log.push(`node.value = ${strify(val)}`);
+          },
+        });
+        spyOn(el, 'setAttribute').and.callFake(function(name, val) {
+          log.push(`node.setAttribute(${strify(name)}, ${strify(val)})`);
+        });
+      }
+      return el;
+    });
+
+    ReactTestUtils.renderIntoDocument(<input type="date" defaultValue="1980-01-01" />);
+    expect(log).toEqual([
+      'node.setAttribute("data-reactroot", "")',
+      'node.setAttribute("type", "date")',
+      'node.setAttribute("value", "1980-01-01")',
+      'node.value = ""',
+      'node.value = ""',
+      'node.setAttribute("checked", "")',
+      'node.setAttribute("checked", "")',
+    ]);
+  });
 });


### PR DESCRIPTION
Fixes #7233. 

In short, iOS Safari acts weird when dealing with HTML5 input types: assigning `node.defaultValue` doesn't let the browser update the UI, so we'll need to set `node.value` to a dummy value then reset it. 

Reviewers: @spicyj @jimfb 

Test Plan:
https://jsbin.com/sefihic/edit?js,output should work on iOS Safari and other mobile browsers (I tested with iOS Safari, iOS Chrome, and Android Browser)

