### PR TITLE
Change `trackedTouchCount` invariant into a console.error

### DIFF
--- a/src/renderers/shared/stack/event/eventPlugins/ResponderEventPlugin.js
+++ b/src/renderers/shared/stack/event/eventPlugins/ResponderEventPlugin.js
@@ -494,7 +494,7 @@ var ResponderEventPlugin = {
         console.error(
           'Ended a touch event which was not counted in `trackedTouchCount`.'
         );
-        return;
+        return null;
       }
     }
 

--- a/src/renderers/shared/stack/event/eventPlugins/ResponderEventPlugin.js
+++ b/src/renderers/shared/stack/event/eventPlugins/ResponderEventPlugin.js
@@ -18,7 +18,6 @@ var ResponderSyntheticEvent = require('ResponderSyntheticEvent');
 var ResponderTouchHistoryStore = require('ResponderTouchHistoryStore');
 
 var accumulate = require('accumulate');
-var invariant = require('invariant');
 var keyOf = require('keyOf');
 
 var isStartish = EventPluginUtils.isStartish;
@@ -489,11 +488,14 @@ var ResponderEventPlugin = {
     if (isStartish(topLevelType)) {
       trackedTouchCount += 1;
     } else if (isEndish(topLevelType)) {
-      trackedTouchCount -= 1;
-      invariant(
-        trackedTouchCount >= 0,
-        'Ended a touch event which was not counted in trackedTouchCount.'
-      );
+      if (trackedTouchCount >= 0) {
+        trackedTouchCount -= 1;
+      } else {
+        console.error(
+          'Ended a touch event which was not counted in `trackedTouchCount`.'
+        );
+        return;
+      }
     }
 
     ResponderTouchHistoryStore.recordTouchTrack(topLevelType, nativeEvent);


### PR DESCRIPTION
Doing to `ResponderEventPlugin` what #7143 did to `ResponderTouchHistoryStore`. This changes the invariant that currently fatals React Native environments when touch events are misfired to instead fail gracefully via `console.error`.

**Reviewers:** @spicyj, @jingc

**Test Plan:**
Ran `grunt test` and `flow ./src` successfully.