### PR TITLE
Update componentWillReceiveProps docs

### DIFF
--- a/docs/docs/ref-03-component-specs.md
+++ b/docs/docs/ref-03-component-specs.md
@@ -140,9 +140,11 @@ Use this as an opportunity to react to a prop transition before `render()` is ca
 
 ```javascript
 componentWillReceiveProps: function(nextProps) {
-  this.setState({
-    likesIncreasing: nextProps.likeCount > this.props.likeCount
-  });
+  if (nextProps.initialLikeCount !== this.props.initialLikeCount) {
+    this.setState({
+      likeCount: nextProps.initialLikeCount
+    });
+  }
 }
 ```
 


### PR DESCRIPTION
The previous example shows a incorrect use case for state. `likesIncreasing` is a good candidate to be calculated on `render()` or in a custom method instead being saved as state.