### PR TITLE
Clarify placeholders in docs

### DIFF
--- a/docs/docs/02.1-jsx-in-depth.it-IT.md
+++ b/docs/docs/02.1-jsx-in-depth.it-IT.md
@@ -135,11 +135,11 @@ var App = (
 Per fare ciò, devi semplicemente creare i tuoi *"sub-componenti"* come proprietà del componente principale:
 
 ```javascript
-var MyFormComponent = React.createClass({ ... });
+var MyFormComponent = React.createClass({ /*...*/ });
 
-MyFormComponent.Row = React.createClass({ ... });
-MyFormComponent.Label = React.createClass({ ... });
-MyFormComponent.Input = React.createClass({ ... });
+MyFormComponent.Row = React.createClass({ /*...*/ });
+MyFormComponent.Label = React.createClass({ /*...*/ });
+MyFormComponent.Input = React.createClass({ /*...*/ });
 ```
 
 JSX gestirà il tutto correttamente al momento di compilare il tuo codice.

--- a/docs/docs/02.1-jsx-in-depth.ja-JP.md
+++ b/docs/docs/02.1-jsx-in-depth.ja-JP.md
@@ -128,11 +128,11 @@ var App = (
 これを行うためには、以下のようにメインコンポーネントの付属物として、「サブコンポーネント」を作るだけで大丈夫です。
 
 ```javascript
-var MyFormComponent = React.createClass({ ... });
+var MyFormComponent = React.createClass({ /*...*/ });
 
-MyFormComponent.Row = React.createClass({ ... });
-MyFormComponent.Label = React.createClass({ ... });
-MyFormComponent.Input = React.createClass({ ... });
+MyFormComponent.Row = React.createClass({ /*...*/ });
+MyFormComponent.Label = React.createClass({ /*...*/ });
+MyFormComponent.Input = React.createClass({ /*...*/ });
 ```
 
 JSXはコードをコンパイルする際にこのプロパティをハンドルします。

--- a/docs/docs/02.1-jsx-in-depth.ko-KR.md
+++ b/docs/docs/02.1-jsx-in-depth.ko-KR.md
@@ -132,11 +132,11 @@ var App = (
 이렇게 하려면, *"sub-components"*를 메인 컴포넌트의 어트리뷰트로 만들 필요가 있습니다.
 
 ```javascript
-var MyFormComponent = React.createClass({ ... });
+var MyFormComponent = React.createClass({ /*...*/ });
 
-MyFormComponent.Row = React.createClass({ ... });
-MyFormComponent.Label = React.createClass({ ... });
-MyFormComponent.Input = React.createClass({ ... });
+MyFormComponent.Row = React.createClass({ /*...*/ });
+MyFormComponent.Label = React.createClass({ /*...*/ });
+MyFormComponent.Input = React.createClass({ /*...*/ });
 ```
 
 코드를 컴파일할 때 JSX는 이것을 제대로 처리해 줍니다.

--- a/docs/docs/02.1-jsx-in-depth.md
+++ b/docs/docs/02.1-jsx-in-depth.md
@@ -132,11 +132,11 @@ var App = (
 To do this, you just need to create your *"sub-components"* as attributes of the main component:
 
 ```javascript
-var MyFormComponent = React.createClass({ ... });
+var MyFormComponent = React.createClass({ /*...*/ });
 
-MyFormComponent.Row = React.createClass({ ... });
-MyFormComponent.Label = React.createClass({ ... });
-MyFormComponent.Input = React.createClass({ ... });
+MyFormComponent.Row = React.createClass({ /*...*/ });
+MyFormComponent.Label = React.createClass({ /*...*/ });
+MyFormComponent.Input = React.createClass({ /*...*/ });
 ```
 
 JSX will handle this properly when compiling your code.

--- a/docs/docs/02.1-jsx-in-depth.zh-CN.md
+++ b/docs/docs/02.1-jsx-in-depth.zh-CN.md
@@ -132,11 +132,11 @@ var App = (
 要做到这一点，你只需要把你的*"子组件"*创建为主组件的属性。
 
 ```javascript
-var MyFormComponent = React.createClass({ ... });
+var MyFormComponent = React.createClass({ /*...*/ });
 
-MyFormComponent.Row = React.createClass({ ... });
-MyFormComponent.Label = React.createClass({ ... });
-MyFormComponent.Input = React.createClass({ ... });
+MyFormComponent.Row = React.createClass({ /*...*/ });
+MyFormComponent.Label = React.createClass({ /*...*/ });
+MyFormComponent.Input = React.createClass({ /*...*/ });
 ```
 
 当编译你的代码时，JSX会恰当的进行处理。


### PR DESCRIPTION
This accomplishes https://github.com/facebook/react/issues/7413.

Note that there were a few posts that used a similar placeholder syntax, namely `/docs/_posts/2015-03-19-building-the-facebook-news-feed-with-relay.md`, `/docs/_posts/2014-07-17-react-v0.11.md`, `/docs/_posts/2014-10-28-react-v0.12.md`, and `/docs/_posts/2015-12-16-ismounted-antipattern.md`. My assumption is that these posts should not be edited, but I'm happy to go through and clarify them as well if requested.