### PR TITLE
dont mutate event type name, just pass it through

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -525,7 +525,7 @@ function makeSimulator(eventType) {
 
     var fakeNativeEvent = new Event();
     fakeNativeEvent.target = node;
-    fakeNativeEvent.type = eventType.toLowerCase();
+    fakeNativeEvent.type = eventType.toString();
 
     // We don't use SyntheticEvent.getPooled in order to not have to worry about
     // properly destroying any properties assigned from `eventData` upon release

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -582,8 +582,8 @@ describe('ReactTestUtils', function() {
 
       ReactTestUtils.Simulate.keyDown(node);
 
-      expect(event.type).toBe('keydown');
-      expect(event.nativeEvent.type).toBe('keydown');
+      expect(event.type).toBe('keyDown');
+      expect(event.nativeEvent.type).toBe('keyDown');
     });
   });
 


### PR DESCRIPTION
This resolves an issue with mutating the type string that was causing some third party test failures

Closes #7418