### PR TITLE
Handle NaNs in quadratic example formula

### DIFF
--- a/examples/quadratic/example.js
+++ b/examples/quadratic/example.js
@@ -25,8 +25,8 @@ var QuadraticCalculator = React.createClass({
     var c = this.state.c;
     var root = Math.sqrt(Math.pow(b, 2) - 4 * a * c);
     var denominator = 2 * a;
-    var x1 = (-b + root) / denominator;
-    var x2 = (-b - root) / denominator;
+    var x1 = isNaN(root) ? 'NaN' : (-b + root) / denominator;
+    var x2 = isNaN(root) ? 'NaN' : (-b - root) / denominator;
     return (
       <div>
         <strong>


### PR DESCRIPTION
When there are no real roots (a=1, b=3, c=3), NaN values cause warning in the console: "Warning: Component's children should not be mutated."
