### PR TITLE
fix batchedUpdates return value

### DIFF
--- a/src/renderers/shared/stack/reconciler/ReactDefaultBatchingStrategy.js
+++ b/src/renderers/shared/stack/reconciler/ReactDefaultBatchingStrategy.js
@@ -60,9 +60,9 @@ var ReactDefaultBatchingStrategy = {
 
     // The code is written this way to avoid extra allocations
     if (alreadyBatchingUpdates) {
-      callback(a, b, c, d, e);
+      return callback(a, b, c, d, e);
     } else {
-      transaction.perform(callback, null, a, b, c, d, e);
+      return transaction.perform(callback, null, a, b, c, d, e);
     }
   },
 };

--- a/src/renderers/shared/stack/reconciler/ReactUpdates.js
+++ b/src/renderers/shared/stack/reconciler/ReactUpdates.js
@@ -108,7 +108,7 @@ PooledClass.addPoolingTo(ReactUpdatesFlushTransaction);
 
 function batchedUpdates(callback, a, b, c, d, e) {
   ensureInjected();
-  batchingStrategy.batchedUpdates(callback, a, b, c, d, e);
+  return batchingStrategy.batchedUpdates(callback, a, b, c, d, e);
 }
 
 /**

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactUpdates-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactUpdates-test.js
@@ -1147,4 +1147,10 @@ describe('ReactUpdates', function() {
     ReactDOM.render(<App />, document.createElement('div'));
   });
 
+  it('unstable_batchedUpdates should return value from a callback', function() {
+    var result = ReactDOM.unstable_batchedUpdates(function() {
+      return 42
+    });
+    expect(result).toEqual(42);
+  })
 });

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactUpdates-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactUpdates-test.js
@@ -1149,8 +1149,8 @@ describe('ReactUpdates', function() {
 
   it('unstable_batchedUpdates should return value from a callback', function() {
     var result = ReactDOM.unstable_batchedUpdates(function() {
-      return 42
+      return 42;
     });
     expect(result).toEqual(42);
-  })
+  });
 });


### PR DESCRIPTION
When I used ReactDOM.unstable_batchedUpdates with redux middleware to fix this issue (https://github.com/reactjs/react-redux/issues/292) it breaks redux middleware return value. 