### PR TITLE
[Fiber] Fix initial mount starvation problems

### DIFF
--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -65,6 +65,7 @@ function ChildReconciler(shouldClone) {
           // Will fix reconciliation properly later.
           const clone = shouldClone ? cloneFiber(existingChild, priority) : existingChild;
           if (!shouldClone) {
+            // TODO: This might be lowering the priority of nested unfinished work.
             clone.pendingWorkPriority = priority;
           }
           clone.pendingProps = element.props;
@@ -132,6 +133,7 @@ function ChildReconciler(shouldClone) {
           // Get the clone of the existing fiber.
           const clone = shouldClone ? cloneFiber(existingChild, priority) : existingChild;
           if (!shouldClone) {
+            // TODO: This might be lowering the priority of nested unfinished work.
             clone.pendingWorkPriority = priority;
           }
           clone.pendingProps = element.props;

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -170,6 +170,9 @@ exports.cloneFiber = function(fiber : Fiber, priorityLevel : PriorityLevel) : Fi
     alt.pendingProps = fiber.pendingProps;
     alt.pendingWorkPriority = priorityLevel;
 
+    alt.memoizedProps = fiber.memoizedProps;
+    alt.output = fiber.output;
+
     // Whenever we clone, we do so to get a new work in progress.
     // This ensures that we've reset these in the new tree.
     alt.nextEffect = null;
@@ -190,6 +193,9 @@ exports.cloneFiber = function(fiber : Fiber, priorityLevel : PriorityLevel) : Fi
   // pendingProps is here for symmetry but is unnecessary in practice for now.
   alt.pendingProps = fiber.pendingProps;
   alt.pendingWorkPriority = priorityLevel;
+
+  alt.memoizedProps = fiber.memoizedProps;
+  alt.output = fiber.output;
 
   alt.alternate = fiber;
   fiber.alternate = alt;

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -70,6 +70,8 @@ module.exports = function<T, P, I, C>(config : HostConfig<T, P, I, C>) : Reconci
       const root = createFiberRoot(containerInfo);
       const container = root.current;
       // TODO: Use pending work/state instead of props.
+      // TODO: This should not override the pendingWorkPriority if there is
+      // higher priority work in the subtree.
       container.pendingProps = element;
       container.pendingWorkPriority = LowPriority;
 

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -66,22 +66,25 @@ module.exports = function<T, P, I, C>(config : HostConfig<T, P, I, C>) {
     // roots for high priority work before moving on to lower priorities.
     let root = nextScheduledRoot;
     while (root) {
-      cloneFiber(root.current, root.current.pendingWorkPriority);
+      let rootInProgress = cloneFiber(
+        root.current,
+        root.current.pendingWorkPriority
+      );
       // Find the highest possible priority work to do.
       // This loop is unrolled just to satisfy Flow's enum constraint.
       // We could make arbitrary many idle priority levels but having
       // too many just means flushing changes too often.
-      let work = findNextUnitOfWorkAtPriority(root.current, HighPriority);
+      let work = findNextUnitOfWorkAtPriority(rootInProgress, HighPriority);
       if (work) {
         nextPriorityLevel = HighPriority;
         return work;
       }
-      work = findNextUnitOfWorkAtPriority(root.current, LowPriority);
+      work = findNextUnitOfWorkAtPriority(rootInProgress, LowPriority);
       if (work) {
         nextPriorityLevel = LowPriority;
         return work;
       }
-      work = findNextUnitOfWorkAtPriority(root.current, OffscreenPriority);
+      work = findNextUnitOfWorkAtPriority(rootInProgress, OffscreenPriority);
       if (work) {
         nextPriorityLevel = OffscreenPriority;
         return work;
@@ -114,6 +117,21 @@ module.exports = function<T, P, I, C>(config : HostConfig<T, P, I, C>) {
     }
   }
 
+  function resetWorkPriority(workInProgress : Fiber) {
+    let newPriority = NoWork;
+    let child = workInProgress.childInProgress || workInProgress.child;
+    while (child) {
+      // Ensure that remaining work priority bubbles up.
+      if (child.pendingWorkPriority !== NoWork &&
+          (newPriority === NoWork ||
+          newPriority > child.pendingWorkPriority)) {
+        newPriority = child.pendingWorkPriority;
+      }
+      child = child.sibling;
+    }
+    workInProgress.pendingWorkPriority = newPriority;
+  }
+
   function completeUnitOfWork(workInProgress : Fiber) : ?Fiber {
     while (true) {
       // The current, flushed, state of this fiber is the alternate.
@@ -123,6 +141,8 @@ module.exports = function<T, P, I, C>(config : HostConfig<T, P, I, C>) {
       const current = workInProgress.alternate;
       const next = completeWork(current, workInProgress);
 
+      resetWorkPriority(workInProgress);
+
       // The work is now done. We don't need this anymore. This flags
       // to the system not to redo any work here.
       workInProgress.pendingProps = null;
@@ -130,12 +150,6 @@ module.exports = function<T, P, I, C>(config : HostConfig<T, P, I, C>) {
       const returnFiber = workInProgress.return;
 
       if (returnFiber) {
-        // Ensure that remaining work priority bubbles up.
-        if (workInProgress.pendingWorkPriority !== NoWork &&
-            (returnFiber.pendingWorkPriority === NoWork ||
-            returnFiber.pendingWorkPriority > workInProgress.pendingWorkPriority)) {
-          returnFiber.pendingWorkPriority = workInProgress.pendingWorkPriority;
-        }
         // Ensure that the first and last effect of the parent corresponds
         // to the children's first and last effect. This probably relies on
         // children completing in order.


### PR DESCRIPTION
The priority level gets reset at the wrong time because I rely
on mutating it at the wrong point. This moves it to the end of
completed work as a second pass over the children to see what
the highest priority is. This is inefficient for large sets but
we can try to find a smarter way to do this later. E.g. passing
it down the stack.

This bug fix revealed another bug that I had flagged before that
we're finding work to do in the "current" tree instead of the
working tree. For trees that were paused, e.g. childInProgress
trees, this won't work since don't have a current tree to search.

Therefore I fixed findNextUnitOfWorkAtPriority to use
workInProgress instead of current.