### PR TITLE
Include React itself in the list of build shims

### DIFF
--- a/grunt/config/browserify.js
+++ b/grunt/config/browserify.js
@@ -22,6 +22,7 @@ var shimSharedModules = globalShim.configure({
   // The methods we used here are exposed on the main React export.
   // TODO: Change all renderer code to require the isomorphic React directly
   // instead of these internals.
+  './React': 'React',
   './ReactElement': 'React',
   './ReactPropTypes': 'React.PropTypes',
   './ReactChildren': 'React.Children',


### PR DESCRIPTION
Without this we end up bundling all of the isomorphic React into the DOM bundle. This was fixed in #7168 too but I'll just do an early fix to ensure that #7168 is purely an npm change.