### PR TITLE
Warn if using React.unmountComponentAtNode on a different React instance's tree.

### DIFF
--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -227,7 +227,11 @@ function nodeIsRenderedByOtherInstance(container) {
  * @internal
  */
 function isNodeElement(node) {
-  return !!(node && (node.nodeType === ELEMENT_NODE_TYPE || node.nodeType === DOC_NODE_TYPE || node.nodeType === DOCUMENT_FRAGMENT_NODE_TYPE));
+  return !!(node && (
+    node.nodeType === ELEMENT_NODE_TYPE ||
+    node.nodeType === DOC_NODE_TYPE ||
+    node.nodeType === DOCUMENT_FRAGMENT_NODE_TYPE
+  ));
 }
 
 /**

--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -208,10 +208,10 @@ function hasNonRootReactChild(container) {
 
 /**
  * True if the supplied DOM node is a React DOM element and
- * it has been rendered by a different React instance.
+ * it has been rendered by another copy of React.
  *
  * @param {?DOMElement} node The candidate DOM node.
- * @return {boolean} True if the DOM has been rendered by a different React instance
+ * @return {boolean} True if the DOM has been rendered by another copy of React
  * @internal
  */
 function nodeIsRenderedByOtherInstance(container) {
@@ -226,7 +226,7 @@ function nodeIsRenderedByOtherInstance(container) {
  * @return {boolean} True if the DOM is a valid DOM node.
  * @internal
  */
-function isNodeElement(node) {
+function isValidContainer(node) {
   return !!(node && (
     node.nodeType === ELEMENT_NODE_TYPE ||
     node.nodeType === DOC_NODE_TYPE ||
@@ -242,7 +242,7 @@ function isNodeElement(node) {
  * @internal
  */
 function isReactNode(node) {
-  return isNodeElement(node) && (node.hasAttribute(ROOT_ATTR_NAME) || node.hasAttribute(ATTR_NAME));
+  return isValidContainer(node) && (node.hasAttribute(ROOT_ATTR_NAME) || node.hasAttribute(ATTR_NAME));
 }
 
 function getHostRootInstanceInContainer(container) {
@@ -368,7 +368,7 @@ var ReactMount = {
     );
 
     invariant(
-      isNodeElement(container),
+      isValidContainer(container),
       '_registerComponent(...): Target container is not a DOM element.'
     );
 
@@ -581,7 +581,7 @@ var ReactMount = {
     );
 
     invariant(
-      isNodeElement(container),
+      isValidContainer(container),
       'unmountComponentAtNode(...): Target container is not a DOM element.'
     );
 
@@ -589,7 +589,7 @@ var ReactMount = {
       warning(
         !nodeIsRenderedByOtherInstance(container),
         'unmountComponentAtNode(): The node you\'re attempting to unmount ' +
-        'was rendered by another React instance.'
+        'was rendered by another copy of React.'
       );
     }
 
@@ -638,7 +638,7 @@ var ReactMount = {
     transaction
   ) {
     invariant(
-      isNodeElement(container),
+      isValidContainer(container),
       'mountComponentIntoNode(...): Target container is not valid.'
     );
 

--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -206,6 +206,41 @@ function hasNonRootReactChild(container) {
   }
 }
 
+/**
+ * True if the supplied DOM node is a React DOM element and
+ * it has been rendered by a different React instance.
+ *
+ * @param {?DOMElement} node The candidate DOM node.
+ * @return {boolean} True if the DOM has been rendered by a different React instance
+ * @internal
+ */
+function nodeIsRenderedByOtherInstance(container) {
+  var rootEl = getReactRootElementInContainer(container);
+  return !!(rootEl && isReactNode(rootEl) && !ReactDOMComponentTree.getInstanceFromNode(rootEl));
+}
+
+/**
+ * True if the supplied DOM node is a valid node element.
+ *
+ * @param {?DOMElement} node The candidate DOM node.
+ * @return {boolean} True if the DOM is a valid DOM node.
+ * @internal
+ */
+function isNodeElement(node) {
+  return !!(node && (node.nodeType === ELEMENT_NODE_TYPE || node.nodeType === DOC_NODE_TYPE || node.nodeType === DOCUMENT_FRAGMENT_NODE_TYPE));
+}
+
+/**
+ * True if the supplied DOM node is a valid React node element.
+ *
+ * @param {?DOMElement} node The candidate DOM node.
+ * @return {boolean} True if the DOM is a valid React DOM node.
+ * @internal
+ */
+function isReactNode(node) {
+  return isNodeElement(node) && (node.hasAttribute(ROOT_ATTR_NAME) || node.hasAttribute(ATTR_NAME));
+}
+
 function getHostRootInstanceInContainer(container) {
   var rootEl = getReactRootElementInContainer(container);
   var prevHostInstance =
@@ -329,11 +364,7 @@ var ReactMount = {
     );
 
     invariant(
-      container && (
-        container.nodeType === ELEMENT_NODE_TYPE ||
-        container.nodeType === DOC_NODE_TYPE ||
-        container.nodeType === DOCUMENT_FRAGMENT_NODE_TYPE
-      ),
+      isNodeElement(container),
       '_registerComponent(...): Target container is not a DOM element.'
     );
 
@@ -546,13 +577,17 @@ var ReactMount = {
     );
 
     invariant(
-      container && (
-        container.nodeType === ELEMENT_NODE_TYPE ||
-        container.nodeType === DOC_NODE_TYPE ||
-        container.nodeType === DOCUMENT_FRAGMENT_NODE_TYPE
-      ),
+      isNodeElement(container),
       'unmountComponentAtNode(...): Target container is not a DOM element.'
     );
+
+    if (__DEV__) {
+      warning(
+        !nodeIsRenderedByOtherInstance(container),
+        'unmountComponentAtNode(): The node you\'re attempting to unmount ' +
+        'was rendered by another React instance.'
+      );
+    }
 
     var prevComponent = getTopLevelWrapperInContainer(container);
     if (!prevComponent) {
@@ -599,11 +634,7 @@ var ReactMount = {
     transaction
   ) {
     invariant(
-      container && (
-        container.nodeType === ELEMENT_NODE_TYPE ||
-        container.nodeType === DOC_NODE_TYPE ||
-        container.nodeType === DOCUMENT_FRAGMENT_NODE_TYPE
-      ),
+      isNodeElement(container),
       'mountComponentIntoNode(...): Target container is not valid.'
     );
 

--- a/src/renderers/dom/client/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMount-test.js
@@ -229,10 +229,10 @@ describe('ReactMount', function() {
     );
   });
 
-  it('should warn if the unmounted node was rendered by another instance', function() {
+  it('should warn if the unmounted node was rendered by another copy of React', function() {
     jest.resetModuleRegistry();
     var ReactDOMOther = require('ReactDOM');
-    var container = document.createElement('container');
+    var container = document.createElement('div');
 
     class Component extends React.Component {
       render() {
@@ -241,7 +241,7 @@ describe('ReactMount', function() {
     }
 
     ReactDOM.render(<Component />, container);
-    // Make sure ReactDOM and ReactDOMOther are different instances
+    // Make sure ReactDOM and ReactDOMOther are different copies
     expect(ReactDOM).not.toEqual(ReactDOMOther);
 
     spyOn(console, 'error');
@@ -249,10 +249,10 @@ describe('ReactMount', function() {
     expect(console.error.calls.count()).toBe(1);
     expect(console.error.calls.argsFor(0)[0]).toBe(
       'Warning: unmountComponentAtNode(): The node you\'re attempting to unmount ' +
-      'was rendered by another React instance.'
+      'was rendered by another copy of React.'
     );
 
-    // Don't throw a warning if the correct React instance unmounts the node
+    // Don't throw a warning if the correct React copy unmounts the node
     ReactDOM.unmountComponentAtNode(container);
     expect(console.error.calls.count()).toBe(1);
   });

--- a/src/renderers/dom/client/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMount-test.js
@@ -229,6 +229,34 @@ describe('ReactMount', function() {
     );
   });
 
+  it('should warn if the unmounted node was rendered by another instance', function() {
+    jest.resetModuleRegistry();
+    var ReactDOMOther = require('ReactDOM');
+    var container = document.createElement('container');
+
+    class Component extends React.Component {
+      render() {
+        return <div><div /></div>;
+      }
+    }
+
+    ReactDOM.render(<Component />, container);
+    // Make sure ReactDOM and ReactDOMOther are different instances
+    expect(ReactDOM).not.toEqual(ReactDOMOther);
+
+    spyOn(console, 'error');
+    ReactDOMOther.unmountComponentAtNode(container);
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toBe(
+      'Warning: unmountComponentAtNode(): The node you\'re attempting to unmount ' +
+      'was rendered by another React instance.'
+    );
+
+    // Don't throw a warning if the correct React instance unmounts the node
+    ReactDOM.unmountComponentAtNode(container);
+    expect(console.error.calls.count()).toBe(1);
+  });
+
   it('passes the correct callback context', function() {
     var container = document.createElement('div');
     var calls = 0;


### PR DESCRIPTION
As https://github.com/facebook/react/pull/3819 has been closed, I tried to provide a fix for https://github.com/facebook/react/issues/3787.

1) If the node is a valid DOM node (e.g.: is of type `Node.ELEMENT_NODE`, `Node.DOCUMENT_NODE` or `Node.DOCUMENT_FRAGMENT_NODE`, see [1]);
2) and if the node has been rendered by React (e.g.: has the `data-reactid` or `data-reactroot` attribute, see https://github.com/facebook/react/issues/3787#issue-72004747);
3) and if `ReactDOMComponentTree.getInstanceFromNode` returns `null`;
4) then, this element has been rendered by a different React instance and we show a warning.

[1] https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType