### PR TITLE
Prevent performance regression in DEV due to warning arguments

### DIFF
--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -188,13 +188,15 @@ var ReactElementValidator = {
                     (type !== null && typeof type === 'object');
     // We warn in this case but don't throw. We expect the element creation to
     // succeed and there will likely be errors in render.
-    warning(
-      validType,
-      'React.createElement: type should not be null, undefined, boolean, or ' +
-        'number. It should be a string (for DOM elements) or a ReactClass ' +
-        '(for composite components).%s',
-      getDeclarationErrorAddendum()
-    );
+    if (!validType) {
+      warning(
+        false,
+        'React.createElement: type should not be null, undefined, boolean, or ' +
+          'number. It should be a string (for DOM elements) or a ReactClass ' +
+          '(for composite components).%s',
+        getDeclarationErrorAddendum()
+      );
+    }
 
     var element = ReactElement.createElement.apply(this, arguments);
 

--- a/src/renderers/dom/client/wrappers/ReactDOMSelect.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMSelect.js
@@ -71,17 +71,18 @@ function checkSelectPropTypes(inst, props) {
     if (props[propName] == null) {
       continue;
     }
-    if (props.multiple) {
+    var isArray = Array.isArray(props[propName]);
+    if (props.multiple && !isArray) {
       warning(
-        Array.isArray(props[propName]),
+        false,
         'The `%s` prop supplied to <select> must be an array if ' +
         '`multiple` is true.%s',
         propName,
         getDeclarationErrorAddendum(owner)
       );
-    } else {
+    } else if (!props.multiple && isArray) {
       warning(
-        !Array.isArray(props[propName]),
+        false,
         'The `%s` prop supplied to <select> must be a scalar ' +
         'value if `multiple` is false.%s',
         propName,

--- a/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
+++ b/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
@@ -69,7 +69,7 @@ if (__DEV__) {
 
     if (standardName != null) {
       warning(
-        standardName == null,
+        false,
         'Unknown DOM property %s. Did you mean %s?%s',
         name,
         standardName,
@@ -78,7 +78,7 @@ if (__DEV__) {
       return true;
     } else if (registrationName != null) {
       warning(
-        registrationName == null,
+        false,
         'Unknown event handler property %s. Did you mean `%s`?%s',
         name,
         registrationName,

--- a/src/renderers/shared/ReactDebugTool.js
+++ b/src/renderers/shared/ReactDebugTool.js
@@ -104,7 +104,9 @@ function resetMeasurements() {
 }
 
 function checkDebugID(debugID) {
-  warning(debugID, 'ReactDebugTool: debugID may not be empty.');
+  if (!debugID) {
+    warning(false, 'ReactDebugTool: debugID may not be empty.');
+  }
 }
 
 function beginLifeCycleTimer(debugID, timerType) {

--- a/src/renderers/shared/hooks/ReactChildrenMutationWarningHook.js
+++ b/src/renderers/shared/hooks/ReactChildrenMutationWarningHook.js
@@ -39,11 +39,13 @@ function handleElement(debugID, element) {
       isMutated = true;
     }
   }
-  warning(
-    Array.isArray(element._shadowChildren) && !isMutated,
-    'Component\'s children should not be mutated.%s',
-    ReactComponentTreeHook.getStackAddendumByID(debugID),
-  );
+  if (!Array.isArray(element._shadowChildren) || isMutated) {
+    warning(
+      false,
+      'Component\'s children should not be mutated.%s',
+      ReactComponentTreeHook.getStackAddendumByID(debugID),
+    );
+  }
 }
 
 var ReactDOMUnknownPropertyHook = {

--- a/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
+++ b/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
@@ -41,14 +41,16 @@ function instantiateChild(childInstances, child, name, selfDebugID) {
     if (!ReactComponentTreeHook) {
       ReactComponentTreeHook = require('ReactComponentTreeHook');
     }
-    warning(
-      keyUnique,
-      'flattenChildren(...): Encountered two children with the same key, ' +
-      '`%s`. Child keys must be unique; when two children share a key, only ' +
-      'the first child will be used.%s',
-      KeyEscapeUtils.unescape(name),
-      ReactComponentTreeHook.getStackAddendumByID(selfDebugID)
-    );
+    if (!keyUnique) {
+      warning(
+        false,
+        'flattenChildren(...): Encountered two children with the same key, ' +
+        '`%s`. Child keys must be unique; when two children share a key, only ' +
+        'the first child will be used.%s',
+        KeyEscapeUtils.unescape(name),
+        ReactComponentTreeHook.getStackAddendumByID(selfDebugID)
+      );
+    }
   }
   if (child != null && keyUnique) {
     childInstances[name] = instantiateReactComponent(child, true);

--- a/src/shared/utils/flattenChildren.js
+++ b/src/shared/utils/flattenChildren.js
@@ -51,14 +51,16 @@ function flattenSingleChildIntoContext(
       if (!ReactComponentTreeHook) {
         ReactComponentTreeHook = require('ReactComponentTreeHook');
       }
-      warning(
-        keyUnique,
-        'flattenChildren(...): Encountered two children with the same key, ' +
-        '`%s`. Child keys must be unique; when two children share a key, only ' +
-        'the first child will be used.%s',
-        KeyEscapeUtils.unescape(name),
-        ReactComponentTreeHook.getStackAddendumByID(selfDebugID)
-      );
+      if (!keyUnique) {
+        warning(
+          false,
+          'flattenChildren(...): Encountered two children with the same key, ' +
+          '`%s`. Child keys must be unique; when two children share a key, only ' +
+          'the first child will be used.%s',
+          KeyEscapeUtils.unescape(name),
+          ReactComponentTreeHook.getStackAddendumByID(selfDebugID)
+        );
+      }
     }
     if (keyUnique && child != null) {
       result[name] = child;


### PR DESCRIPTION
Expensive arguments shouldn’t be calculated if the warning doesn't fire.
This fixes a few cases where that calculation might be more expensive than usually.

In my testing, this brings down average row click time in Power Editor from ~300ms to ~220ms in `__DEV__` (vs ~40ms in prod).