### PR TITLE
Fix unmounting performance regression in __DEV__

### DIFF
--- a/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
@@ -484,6 +484,8 @@ var ON_CLICK_KEY = keyOf({onClick: null});
 var onClickListeners = {};
 
 function getDictionaryKey(inst) {
+  // Prevents V8 performance issue:
+  // https://github.com/facebook/react/pull/7232
   return '.' + inst._rootNodeID;
 }
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMDebugTool-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMDebugTool-test.js
@@ -65,7 +65,7 @@ describe('ReactDOMDebugTool', function() {
     ReactDOMDebugTool.onTestEvent();
     expect(console.error.calls.count()).toBe(1);
     expect(console.error.calls.argsFor(0)[0]).toContain(
-      'exception thrown by hook while handling ' +
+      'Exception thrown by hook while handling ' +
       'onTestEvent: Error: Hi.'
     );
 

--- a/src/renderers/shared/ReactDebugTool.js
+++ b/src/renderers/shared/ReactDebugTool.js
@@ -20,25 +20,31 @@ var ExecutionEnvironment = require('ExecutionEnvironment');
 var performanceNow = require('performanceNow');
 var warning = require('warning');
 
-var eventHandlers = [];
-var handlerDoesThrowForEvent = {};
+var hooks = [];
+var didHookThrowForEvent = {};
 
-function emitEvent(handlerFunctionName, arg1, arg2, arg3, arg4, arg5) {
-  eventHandlers.forEach(function(handler) {
-    try {
-      if (handler[handlerFunctionName]) {
-        handler[handlerFunctionName](arg1, arg2, arg3, arg4, arg5);
-      }
-    } catch (e) {
-      warning(
-        handlerDoesThrowForEvent[handlerFunctionName],
-        'exception thrown by hook while handling %s: %s',
-        handlerFunctionName,
-        e + '\n' + e.stack
-      );
-      handlerDoesThrowForEvent[handlerFunctionName] = true;
+function callHook(event, fn, context, arg1, arg2, arg3, arg4, arg5) {
+  try {
+    fn.call(context, arg1, arg2, arg3, arg4, arg5);
+  } catch (e) {
+    warning(
+      didHookThrowForEvent[event],
+      'Exception thrown by hook while handling %s: %s',
+      event,
+      e + '\n' + e.stack
+    );
+    didHookThrowForEvent[event] = true;
+  }
+}
+
+function emitEvent(event, arg1, arg2, arg3, arg4, arg5) {
+  for (var i = 0; i < hooks.length; i++) {
+    var hook = hooks[i];
+    var fn = hook[event];
+    if (fn) {
+      callHook(event, fn, hook, arg1, arg2, arg3, arg4, arg5);
     }
-  });
+  }
 }
 
 var isProfiling = false;
@@ -183,12 +189,12 @@ function resumeCurrentLifeCycleTimer() {
 
 var ReactDebugTool = {
   addHook(hook) {
-    eventHandlers.push(hook);
+    hooks.push(hook);
   },
   removeHook(hook) {
-    for (var i = 0; i < eventHandlers.length; i++) {
-      if (eventHandlers[i] === hook) {
-        eventHandlers.splice(i, 1);
+    for (var i = 0; i < hooks.length; i++) {
+      if (hooks[i] === hook) {
+        hooks.splice(i, 1);
         i--;
       }
     }

--- a/src/renderers/shared/__tests__/ReactDebugTool-test.js
+++ b/src/renderers/shared/__tests__/ReactDebugTool-test.js
@@ -65,7 +65,7 @@ describe('ReactDebugTool', function() {
     ReactDebugTool.onTestEvent();
     expect(console.error.calls.count()).toBe(1);
     expect(console.error.calls.argsFor(0)[0]).toContain(
-      'exception thrown by hook while handling ' +
+      'Exception thrown by hook while handling ' +
       'onTestEvent: Error: Hi.'
     );
 

--- a/src/renderers/shared/stack/event/EventPluginHub.js
+++ b/src/renderers/shared/stack/event/EventPluginHub.js
@@ -54,6 +54,8 @@ var executeDispatchesAndReleaseTopLevel = function(e) {
 };
 
 var getDictionaryKey = function(inst) {
+  // Prevents V8 performance issue:
+  // https://github.com/facebook/react/pull/7232
   return '.' + inst._rootNodeID;
 };
 


### PR DESCRIPTION
This is the same issue as was previously fixed by #7232, but in `__DEV__`.
Test plan:

1. Grab https://github.com/gaearon/js-framework-benchmark/tree/master/react-v15.3.0
2. `npm run build-dev`
3. Mount 10K nodes, then “clear”

Before this change: ~6 seconds.
After this change: ~2 seconds.

This seems only relevant for Chrome.