### PR TITLE
Use aliasify everywhere instead of browserify-global-shim

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,7 @@ var paths = {
     src: [
       'src/umd/ReactUMDEntry.js',
       'src/umd/ReactWithAddonsUMDEntry.js',
-      'src/umd/shims/ReactAddonsDOMDependenciesUMDShim.js',
+      'src/umd/shims/**/*.js',
 
       'src/isomorphic/**/*.js',
       'src/addons/**/*.js',

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "babel-traverse": "^6.9.0",
     "babylon": "6.8.0",
     "browserify": "^13.0.0",
-    "browserify-global-shim": "^1.0.3",
     "bundle-collapser": "^1.1.1",
     "coffee-script": "^1.8.0",
     "core-js": "^2.2.1",

--- a/src/umd/shims/ReactComponentTreeHookUMDShim.js
+++ b/src/umd/shims/ReactComponentTreeHookUMDShim.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactComponentTreeHookUMDShim
+ */
+
+/* globals React */
+
+'use strict';
+
+var ReactInternals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+
+module.exports = ReactInternals.ReactComponentTreeHook;

--- a/src/umd/shims/ReactCurrentOwnerUMDShim.js
+++ b/src/umd/shims/ReactCurrentOwnerUMDShim.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactCurrentOwnerUMDShim
+ */
+
+/* globals React */
+
+'use strict';
+
+var ReactInternals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+
+module.exports = ReactInternals.ReactCurrentOwner;

--- a/src/umd/shims/ReactUMDShim.js
+++ b/src/umd/shims/ReactUMDShim.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactUMDShim
+ */
+
+/* globals React */
+
+'use strict';
+
+module.exports = React;


### PR DESCRIPTION
I already had to aliasify to have better control over the requires so we might as well do it everywhere for consistency.

This probably makes it easier to rebase the rollup work too. Aliases seems to be how you solve this in that world, since you can't just swap out the expression in an ES import.