### PR TITLE
Use ReactPerf from react-native-renderer when in React Native

### DIFF
--- a/grunt/tasks/npm-react-addons.js
+++ b/grunt/tasks/npm-react-addons.js
@@ -19,6 +19,7 @@ var addons = {
   },
   Perf: {
     peerDependency: 'react-dom',
+    nativeDependency: 'react-native-renderer',
     module: 'ReactPerf',
     name: 'perf',
     docs: 'perf',
@@ -61,10 +62,10 @@ var addons = {
   },
 };
 
-function generateSource(info) {
+function generateSource(info, packageName) {
   var pieces = [
     'module.exports = require(\'',
-    info.peerDependency,
+    packageName,
     '/lib/',
     info.module,
     '\')',
@@ -98,7 +99,10 @@ function buildReleases() {
     grunt.file.mkdir(destDir);
     var link = info.docs ? info.docs : 'addons';
     link = `https://facebook.github.io/react/docs/${link}.html`;
-    fs.writeFileSync(path.join(destDir, 'index.js'), generateSource(info));
+    fs.writeFileSync(path.join(destDir, 'index.js'), generateSource(info, info.peerDependency));
+    if (info.nativeDependency) {
+      fs.writeFileSync(path.join(destDir, 'index.native.js'), generateSource(info, info.nativeDependency));
+    }
     fs.writeFileSync(path.join(destDir, 'package.json'), JSON.stringify(pkgData, null, 2));
     grunt.file.copy('LICENSE', destLicense);
     grunt.file.copy('PATENTS', destPatents);


### PR DESCRIPTION
The public API for ReactPref is the react-addons-perf package.
However, that doesn't say anything if we're using it to debug
react-dom, react-native or another renderer. Ideally this should
work with any and all renderers but since we don't have that yet
let's just auto-detect using the .native.js trick for now.
If we land react-native-renderer as checked into React Native we
will need to update this path.