### PR TITLE
Improve DEV performance in Chrome

### DIFF
--- a/src/renderers/dom/client/ReactDOMComponentTree.js
+++ b/src/renderers/dom/client/ReactDOMComponentTree.js
@@ -81,7 +81,7 @@ function precacheChildNodes(inst, node) {
     }
     var childInst = children[name];
     var childID = getRenderedHostOrTextFromComponent(childInst)._domID;
-    if (childID == null) {
+    if (childID === 0) {
       // We're currently unmounting this child in ReactMultiChild; skip it.
       continue;
     }

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -489,7 +489,7 @@ function ReactDOMComponent(element) {
   this._hostNode = null;
   this._hostParent = null;
   this._rootNodeID = null;
-  this._domID = null;
+  this._domID = 0;
   this._hostContainerInfo = null;
   this._wrapperState = null;
   this._topLevelWrapper = null;
@@ -1191,7 +1191,7 @@ ReactDOMComponent.Mixin = {
     ReactDOMComponentTree.uncacheNode(this);
     EventPluginHub.deleteAllListeners(this);
     this._rootNodeID = null;
-    this._domID = null;
+    this._domID = 0;
     this._wrapperState = null;
 
     if (__DEV__) {

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -488,7 +488,7 @@ function ReactDOMComponent(element) {
   this._previousStyleCopy = null;
   this._hostNode = null;
   this._hostParent = null;
-  this._rootNodeID = null;
+  this._rootNodeID = 0;
   this._domID = 0;
   this._hostContainerInfo = null;
   this._wrapperState = null;
@@ -1190,7 +1190,7 @@ ReactDOMComponent.Mixin = {
     this.unmountChildren(safely);
     ReactDOMComponentTree.uncacheNode(this);
     EventPluginHub.deleteAllListeners(this);
-    this._rootNodeID = null;
+    this._rootNodeID = 0;
     this._domID = 0;
     this._wrapperState = null;
 

--- a/src/renderers/dom/shared/ReactDOMEmptyComponent.js
+++ b/src/renderers/dom/shared/ReactDOMEmptyComponent.js
@@ -22,7 +22,7 @@ var ReactDOMEmptyComponent = function(instantiate) {
   this._hostNode = null;
   this._hostParent = null;
   this._hostContainerInfo = null;
-  this._domID = null;
+  this._domID = 0;
 };
 Object.assign(ReactDOMEmptyComponent.prototype, {
   mountComponent: function(

--- a/src/renderers/dom/shared/ReactDOMTextComponent.js
+++ b/src/renderers/dom/shared/ReactDOMTextComponent.js
@@ -43,7 +43,7 @@ var ReactDOMTextComponent = function(text) {
   this._hostParent = null;
 
   // Properties
-  this._domID = null;
+  this._domID = 0;
   this._mountIndex = 0;
   this._closingComment = null;
   this._commentNodes = null;

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -634,7 +634,7 @@ describe('ReactDOMComponent', function() {
 
       var NodeStub = function(initialProps) {
         this._currentElement = {props: initialProps};
-        this._rootNodeID = 'test';
+        this._rootNodeID = 1;
       };
       Object.assign(NodeStub.prototype, ReactDOMComponent.Mixin);
 
@@ -690,7 +690,7 @@ describe('ReactDOMComponent', function() {
 
       var NodeStub = function(initialProps) {
         this._currentElement = {props: initialProps};
-        this._rootNodeID = 'test';
+        this._rootNodeID = 1;
       };
       Object.assign(NodeStub.prototype, ReactDOMComponent.Mixin);
 

--- a/src/renderers/native/ReactNativeBaseComponent.js
+++ b/src/renderers/native/ReactNativeBaseComponent.js
@@ -59,7 +59,7 @@ ReactNativeBaseComponent.Mixin = {
     ReactNativeComponentTree.uncacheNode(this);
     deleteAllListeners(this);
     this.unmountChildren();
-    this._rootNodeID = null;
+    this._rootNodeID = 0;
   },
 
   /**

--- a/src/renderers/native/ReactNativeTextComponent.js
+++ b/src/renderers/native/ReactNativeTextComponent.js
@@ -22,7 +22,7 @@ var ReactNativeTextComponent = function(text) {
   this._currentElement = text;
   this._stringText = '' + text;
   this._hostParent = null;
-  this._rootNodeID = null;
+  this._rootNodeID = 0;
 };
 
 Object.assign(ReactNativeTextComponent.prototype, {
@@ -73,7 +73,7 @@ Object.assign(ReactNativeTextComponent.prototype, {
     ReactNativeComponentTree.uncacheNode(this);
     this._currentElement = null;
     this._stringText = null;
-    this._rootNodeID = null;
+    this._rootNodeID = 0;
   },
 
 });

--- a/src/renderers/native/createReactNativeComponentClass.js
+++ b/src/renderers/native/createReactNativeComponentClass.js
@@ -33,7 +33,7 @@ var createReactNativeComponentClass = function(
     this._topLevelWrapper = null;
     this._hostParent = null;
     this._hostContainerInfo = null;
-    this._rootNodeID = null;
+    this._rootNodeID = 0;
     this._renderedChildren = null;
   };
   Constructor.displayName = viewConfig.uiViewClassName;

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -153,7 +153,7 @@ var ReactCompositeComponentMixin = {
    */
   construct: function(element) {
     this._currentElement = element;
-    this._rootNodeID = null;
+    this._rootNodeID = 0;
     this._compositeType = null;
     this._instance = null;
     this._hostParent = null;
@@ -612,7 +612,7 @@ var ReactCompositeComponentMixin = {
     // These fields do not really need to be reset since this object is no
     // longer accessible.
     this._context = null;
-    this._rootNodeID = null;
+    this._rootNodeID = 0;
     this._topLevelWrapper = null;
 
     // Delete the reference from the instance to this internal representation


### PR DESCRIPTION
This consistently improves DEV performance in Chrome.

Before this change:

```
create 10k rows: 7861
update 1k rows: 1405
update 1k rows: 1337
update 1k rows: 1373
update 1k rows: 1340
update 1k rows: 1381
clear 10k rows: 1603

create 10k rows: 7799
update 1k rows: 1391
update 1k rows: 1339
update 1k rows: 1324
update 1k rows: 1338
clear 10k rows: 1567
```

After this change:

```
create 10k rows: 6460
update 1k rows: 1312
update 1k rows: 1237
update 1k rows: 1231
update 1k rows: 1263
update 1k rows: 1248
clear 10k rows: 1083

create 10k rows: 6326
update 1k rows: 1298
update 1k rows: 1233
update 1k rows: 1245
update 1k rows: 536
update 1k rows: 1058
update 1k rows: 1299
clear 10k rows: 1104
```

This only seems to help DEV in Chrome. I did not observe any significant difference in PROD in Chrome, or in either build in Firefox or Safari.

Normally it would be too much dogscience but I feel the wins for Chrome DEV (most common use case) are significant, they are consistently reproducible, and it kinda makes sense to use numbers anyway.