### PR TITLE
Don't define key or ref dummy props if none were provided

### DIFF
--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -52,6 +52,50 @@ function hasValidKey(config) {
   return config.key !== undefined;
 }
 
+function defineKeyPropWarningGetter(props, displayName) {
+  var warnAboutAccessingKey = function() {
+    if (!specialPropKeyWarningShown) {
+      specialPropKeyWarningShown = true;
+      warning(
+        false,
+        '%s: `key` is not a prop. Trying to access it will result ' +
+        'in `undefined` being returned. If you need to access the same ' +
+        'value within the child component, you should pass it as a different ' +
+        'prop. (https://fb.me/react-special-props)',
+        displayName
+      );
+    }
+    return undefined;
+  };
+  warnAboutAccessingKey.isReactWarning = true;
+  Object.defineProperty(props, 'key', {
+    get: warnAboutAccessingKey,
+    configurable: true,
+  });
+}
+
+function defineRefPropWarningGetter(props, displayName) {
+  var warnAboutAccessingRef = function() {
+    if (!specialPropRefWarningShown) {
+      specialPropRefWarningShown = true;
+      warning(
+        false,
+        '%s: `ref` is not a prop. Trying to access it will result ' +
+        'in `undefined` being returned. If you need to access the same ' +
+        'value within the child component, you should pass it as a different ' +
+        'prop. (https://fb.me/react-special-props)',
+        displayName
+      );
+    }
+    return undefined;
+  };
+  warnAboutAccessingRef.isReactWarning = true;
+  Object.defineProperty(props, 'ref', {
+    get: warnAboutAccessingRef,
+    configurable: true,
+  });
+}
+
 /**
  * Factory method to create a new React element. This no longer adheres to
  * the class pattern, so do not use new to call it. Also, no instanceof check
@@ -209,56 +253,18 @@ ReactElement.createElement = function(type, config, children) {
     }
   }
   if (__DEV__) {
-    var displayName = typeof type === 'function' ?
-      (type.displayName || type.name || 'Unknown') :
-      type;
-
-    // Create dummy `key` and `ref` property to `props` to warn users against its use
-    var warnAboutAccessingKey = function() {
-      if (!specialPropKeyWarningShown) {
-        specialPropKeyWarningShown = true;
-        warning(
-          false,
-          '%s: `key` is not a prop. Trying to access it will result ' +
-          'in `undefined` being returned. If you need to access the same ' +
-          'value within the child component, you should pass it as a different ' +
-          'prop. (https://fb.me/react-special-props)',
-          displayName
-        );
-      }
-      return undefined;
-    };
-    warnAboutAccessingKey.isReactWarning = true;
-
-    var warnAboutAccessingRef = function() {
-      if (!specialPropRefWarningShown) {
-        specialPropRefWarningShown = true;
-        warning(
-          false,
-          '%s: `ref` is not a prop. Trying to access it will result ' +
-          'in `undefined` being returned. If you need to access the same ' +
-          'value within the child component, you should pass it as a different ' +
-          'prop. (https://fb.me/react-special-props)',
-          displayName
-        );
-      }
-      return undefined;
-    };
-    warnAboutAccessingRef.isReactWarning = true;
-
-    if (typeof props.$$typeof === 'undefined' ||
-        props.$$typeof !== REACT_ELEMENT_TYPE) {
-      if (!props.hasOwnProperty('key')) {
-        Object.defineProperty(props, 'key', {
-          get: warnAboutAccessingKey,
-          configurable: true,
-        });
-      }
-      if (!props.hasOwnProperty('ref')) {
-        Object.defineProperty(props, 'ref', {
-          get: warnAboutAccessingRef,
-          configurable: true,
-        });
+    if (key || ref) {
+      if (typeof props.$$typeof === 'undefined' ||
+          props.$$typeof !== REACT_ELEMENT_TYPE) {
+        var displayName = typeof type === 'function' ?
+          (type.displayName || type.name || 'Unknown') :
+          type;
+        if (key) {
+          defineKeyPropWarningGetter(props, displayName);
+        }
+        if (ref) {
+          defineRefPropWarningGetter(props, displayName);
+        }
       }
     }
   }

--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -65,7 +65,6 @@ function defineKeyPropWarningGetter(props, displayName) {
         displayName
       );
     }
-    return undefined;
   };
   warnAboutAccessingKey.isReactWarning = true;
   Object.defineProperty(props, 'key', {
@@ -87,7 +86,6 @@ function defineRefPropWarningGetter(props, displayName) {
         displayName
       );
     }
-    return undefined;
   };
   warnAboutAccessingRef.isReactWarning = true;
   Object.defineProperty(props, 'ref', {


### PR DESCRIPTION
This fixes another DEV-only performance regression introduced in 15.x.

The idea here is that extra `defineProperty` getters are slow. Let’s only add them when we *know* user supplied `key` (or `ref`). Otherwise the user wouldn’t expect to find them in `props` anyway.

Chrome (before):

```
create 10k rows: 6596
update 1k rows: 1447
update 1k rows: 1362
update 1k rows: 1385
clear 10k rows: 1094

create 10k rows: 6403
update 1k rows: 1428
update 1k rows: 1321
update 1k rows: 1393
clear 10k rows: 1182
```

Chrome (after):

```
create 10k rows: 5373
update 1k rows: 1294
update 1k rows: 1313
update 1k rows: 1246
clear 10k rows: 1060

create 10k rows: 5446
update 1k rows: 1326
update 1k rows: 1233
update 1k rows: 1268
clear 10k rows: 1102
```

Firefox (before):

```
create 10k rows: 10431
update 1k rows: 1664
update 1k rows: 896
update 1k rows: 853
clear 10k rows: 4157

create 10k rows: 10044
update 1k rows: 1091
update 1k rows: 1197
update 1k rows: 847
clear 10k rows: 3225
```

Firefox (after):

```
create 10k rows: 8241
update 1k rows: 858
update 1k rows: 715
update 1k rows: 725
clear 10k rows: 3877

create 10k rows: 8200
update 1k rows: 831
update 1k rows: 775
update 1k rows: 720
clear 10k rows: 4239
```

I’m too lazy to format Safari results but they show similar improvements although smaller.