### PR TITLE
Fix ReactComponentTreeHook.getRegisteredIDs() to work with inlined components

### DIFF
--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -259,7 +259,8 @@ if (__DEV__) {
   setContentChildForInstrumentation = function(content) {
     var hasExistingContent = this._contentDebugID != null;
     var debugID = this._debugID;
-    var contentDebugID = debugID + '#text';
+    // This ID represents the inlined child that has no backing instance:
+    var contentDebugID = -debugID;
 
     if (content == null) {
       if (hasExistingContent) {

--- a/src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.js
+++ b/src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.js
@@ -1721,6 +1721,16 @@ describe('ReactComponentTreeHook', () => {
     expect(ReactComponentTreeTestUtils.getRegisteredDisplayNames()).toEqual([]);
   });
 
+  it('registers inlined text nodes', () => {
+    var node = document.createElement('div');
+
+    ReactDOM.render(<div>hi</div>, node);
+    expect(ReactComponentTreeTestUtils.getRegisteredDisplayNames()).toEqual(['div', '#text']);
+
+    ReactDOM.unmountComponentAtNode(node);
+    expect(ReactComponentTreeTestUtils.getRegisteredDisplayNames()).toEqual([]);
+  });
+
   describe('stack addenda', () => {
     it('gets created', () => {
       function getAddendum(element) {


### PR DESCRIPTION
I broke this in #7463: `parseInt()` cuts off `#text` at the end.
Changing to just use negative numbers instead.