### PR TITLE
Use ES6 Map in ReactComponentTreeHook if available

### DIFF
--- a/src/isomorphic/hooks/ReactComponentTreeHook.js
+++ b/src/isomorphic/hooks/ReactComponentTreeHook.js
@@ -16,10 +16,38 @@ var ReactCurrentOwner = require('ReactCurrentOwner');
 var invariant = require('invariant');
 var warning = require('warning');
 
+function isNative(fn) {
+  // Based on isNative() from Lodash
+  var funcToString = Function.prototype.toString;
+  var hasOwnProperty = Object.prototype.hasOwnProperty;
+  var reIsNative = RegExp('^' + funcToString
+    // Take an example native function source for comparison
+    .call(hasOwnProperty)
+    // Strip regex characters so we can use it for regex
+    .replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')
+    // Remove hasOwnProperty from the template to make it generic
+    .replace(
+      /hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g,
+      '$1.*?'
+    ) + '$'
+  );
+  try {
+    var source = funcToString.call(fn);
+    return reIsNative.test(source);
+  } catch (err) {
+    return false;
+  }
+}
+
 var itemMap;
 var itemByKey;
 
-var canUseMap = typeof Map === 'function' && typeof Array.from === 'function';
+var canUseMap = (
+  typeof Array.from === 'function' &&
+  typeof Map === 'function' &&
+  isNative(Map)
+);
+
 if (canUseMap) {
   itemMap = new Map();
 } else {

--- a/src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.js
+++ b/src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.js
@@ -46,14 +46,19 @@ describe('ReactComponentTreeHook', () => {
       }
     }
 
-    function expectWrapperTreeToEqual(expectedTree) {
+    function expectWrapperTreeToEqual(expectedTree, andStayMounted) {
       ReactComponentTreeTestUtils.expectTree(rootInstance._debugID, {
         displayName: 'Wrapper',
         children: expectedTree ? [expectedTree] : [],
       });
+      var rootDisplayNames = ReactComponentTreeTestUtils.getRootDisplayNames();
+      var registeredDisplayNames = ReactComponentTreeTestUtils.getRegisteredDisplayNames();
       if (!expectedTree) {
-        expect(ReactComponentTreeTestUtils.getRootDisplayNames()).toEqual([]);
-        expect(ReactComponentTreeTestUtils.getRegisteredDisplayNames()).toEqual([]);
+        expect(rootDisplayNames).toEqual([]);
+        expect(registeredDisplayNames).toEqual([]);
+      } else if (andStayMounted) {
+        expect(rootDisplayNames).toContain('Wrapper');
+        expect(registeredDisplayNames).toContain('Wrapper');
       }
     }
 
@@ -64,12 +69,12 @@ describe('ReactComponentTreeHook', () => {
 
       // Mount a new tree or update the existing tree.
       ReactDOM.render(<Wrapper />, node);
-      expectWrapperTreeToEqual(expectedTree);
+      expectWrapperTreeToEqual(expectedTree, true);
 
       // Purging should have no effect
       // on the tree we expect to see.
       ReactComponentTreeHook.purgeUnmountedComponents();
-      expectWrapperTreeToEqual(expectedTree);
+      expectWrapperTreeToEqual(expectedTree, true);
     });
 
     // Unmounting the root node should purge
@@ -1852,6 +1857,109 @@ describe('ReactComponentTreeHook', () => {
         }
       }
       ReactDOM.render(<Foo />, el);
+    });
+  });
+
+  describe('in environment without Map and Array.from', () => {
+    var realMap;
+    var realArrayFrom;
+
+    beforeEach(() => {
+      realMap = global.Map;
+      realArrayFrom = Array.from;
+
+      global.Map = undefined;
+      Array.from = undefined;
+
+      jest.resetModuleRegistry();
+
+      React = require('React');
+      ReactDOM = require('ReactDOM');
+      ReactDOMServer = require('ReactDOMServer');
+      ReactInstanceMap = require('ReactInstanceMap');
+      ReactComponentTreeHook = require('ReactComponentTreeHook');
+      ReactComponentTreeTestUtils = require('ReactComponentTreeTestUtils');
+    });
+
+    afterEach(() => {
+      global.Map = realMap;
+      Array.from = realArrayFrom;
+    });
+
+    it('works', () => {
+      class Qux extends React.Component {
+        render() {
+          return null;
+        }
+      }
+
+      function Foo() {
+        return {
+          render() {
+            return <Qux />;
+          },
+        };
+      }
+      function Bar({children}) {
+        return <h1>{children}</h1>;
+      }
+      class Baz extends React.Component {
+        render() {
+          return (
+            <div>
+              <Foo />
+              <Bar>
+                <span>Hi,</span>
+                Mom
+              </Bar>
+              <a href="#">Click me.</a>
+            </div>
+          );
+        }
+      }
+
+      var element = <Baz />;
+      var tree = {
+        displayName: 'Baz',
+        element,
+        children: [{
+          displayName: 'div',
+          children: [{
+            displayName: 'Foo',
+            element: <Foo />,
+            children: [{
+              displayName: 'Qux',
+              element: <Qux />,
+              children: [],
+            }],
+          }, {
+            displayName: 'Bar',
+            children: [{
+              displayName: 'h1',
+              children: [{
+                displayName: 'span',
+                children: [{
+                  displayName: '#text',
+                  element: 'Hi,',
+                  text: 'Hi,',
+                }],
+              }, {
+                displayName: '#text',
+                text: 'Mom',
+                element: 'Mom',
+              }],
+            }],
+          }, {
+            displayName: 'a',
+            children: [{
+              displayName: '#text',
+              text: 'Click me.',
+              element: 'Click me.',
+            }],
+          }],
+        }],
+      };
+      assertTreeMatches([element, tree]);
     });
   });
 });

--- a/src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.native.js
+++ b/src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.native.js
@@ -70,14 +70,19 @@ describe('ReactComponentTreeHook', () => {
       }
     }
 
-    function expectWrapperTreeToEqual(expectedTree) {
+    function expectWrapperTreeToEqual(expectedTree, andStayMounted) {
       ReactComponentTreeTestUtils.expectTree(rootInstance._debugID, {
         displayName: 'Wrapper',
         children: expectedTree ? [expectedTree] : [],
       });
+      var rootDisplayNames = ReactComponentTreeTestUtils.getRootDisplayNames();
+      var registeredDisplayNames = ReactComponentTreeTestUtils.getRegisteredDisplayNames();
       if (!expectedTree) {
-        expect(ReactComponentTreeTestUtils.getRootDisplayNames()).toEqual([]);
-        expect(ReactComponentTreeTestUtils.getRegisteredDisplayNames()).toEqual([]);
+        expect(rootDisplayNames).toEqual([]);
+        expect(registeredDisplayNames).toEqual([]);
+      } else if (andStayMounted) {
+        expect(rootDisplayNames).toContain('Wrapper');
+        expect(registeredDisplayNames).toContain('Wrapper');
       }
     }
 
@@ -88,12 +93,12 @@ describe('ReactComponentTreeHook', () => {
 
       // Mount a new tree or update the existing tree.
       ReactNative.render(<Wrapper />, 1);
-      expectWrapperTreeToEqual(expectedTree);
+      expectWrapperTreeToEqual(expectedTree, true);
 
       // Purging should have no effect
       // on the tree we expect to see.
       ReactComponentTreeHook.purgeUnmountedComponents();
-      expectWrapperTreeToEqual(expectedTree);
+      expectWrapperTreeToEqual(expectedTree, true);
     });
 
     // Unmounting the root node should purge


### PR DESCRIPTION
This makes **DEV unmounting** consistently faster in Chrome, Firefox, and Safari.
It’s because `purgeUnmountedComponent` becomes less intensive and doesn’t use `delete`s.

Browsers that don’t have `Map` or `Array.from` will fall back to using objects.
We may want to try the same pattern for other global maps that we write/read often.

Chrome (before)

```
mount: 2678
update: 480
update: 463
update: 443
unmount: 594

mount: 2674
update: 506
update: 456
update: 453
unmount: 600

mount: 2833
update: 464
update: 445
update: 447
unmount: 648
```

Chrome (after)

```
mount: 2457
update: 470
update: 436
update: 438
unmount: 518

mount: 2542
update: 447
update: 444
update: 438
unmount: 570

mount: 2616
update: 454
update: 454
update: 448
unmount: 552
```

Firefox (before)

```
mount: 3942
update: 293
update: 276
update: 309
unmount: 714

mount: 3965
update: 291
update: 250
update: 320
unmount: 689

mount: 3953
update: 311
update: 252
update: 319
unmount: 687
```

Firefox (after):

```
mount: 3777
update: 316
update: 200
update: 172
unmount: 507

mount: 3700
update: 357
update: 189
update: 164
unmount: 490

mount: 4482
update: 282
update: 193
update: 175
unmount: 521
```

Safari (before)

```
mount: 4050
update: 337
update: 328
update: 308
unmount: 947

mount: 3864
update: 383
update: 309
update: 312
unmount: 899

mount: 3931
update: 434
update: 395
update: 334
unmount: 814
```

Safari (after)

```

mount: 4221
update: 388
update: 298
update: 393
unmount: 732

mount: 3765
update: 358
update: 300
update: 284
unmount: 723

mount: 3634
update: 355
update: 328
update: 304
unmount: 658
```
