### PR TITLE
Fix flow

### DIFF
--- a/src/renderers/testing/ReactTestMount.js
+++ b/src/renderers/testing/ReactTestMount.js
@@ -132,8 +132,8 @@ ReactTestInstance.prototype.toJSON = function() {
 var ReactTestMount = {
 
   render: function(
-    nextElement: ReactElement
-  ): ?ReactElement<any, any, any> {
+    nextElement: ReactElement<any>
+  ): ReactTestInstance {
     var nextWrappedElement = React.createElement(
       TopLevelWrapper,
       { child: nextElement }


### PR DESCRIPTION
ReactElement requires a generic argument now and the return function of render is a ReactTestInstance and not a ReactElement.


Test Plan:
```
npm install
npm run flow
> react-build@16.0.0-alpha flow /Users/vjeux/random/react
> flow

No errors!
```