### PR TITLE
Transform keyMirror to object literal

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -22,6 +22,7 @@
     "transform-es2015-modules-commonjs",
     "transform-es3-member-expression-literals",
     "transform-es3-property-literals",
+    "./scripts/babel/key-mirror-to-literal",
     "./scripts/babel/transform-object-assign-require",
     "transform-react-jsx-source"
   ]

--- a/scripts/babel/key-mirror-to-literal.js
+++ b/scripts/babel/key-mirror-to-literal.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+module.exports = function keyMirrorToLiteral(babel) {
+  const t = babel.types;
+
+  function isKeyMirrorRequireCall(node) {
+    return (
+      node &&
+      node.type === 'CallExpression' &&
+      node.callee.type === 'Identifier' &&
+      node.callee.name === 'require' &&
+      node.arguments.length === 1 &&
+      node.arguments[0].type === 'StringLiteral' &&
+      (
+        node.arguments[0].value === 'fbjs/lib/keyMirror' ||
+        node.arguments[0].value === 'keyMirror'
+      )
+    );
+  }
+
+  return {
+    visitor: {
+      Program(path, file) {
+        const binding = path.scope.getBinding('keyMirror');
+        if (binding == null) {
+          return;
+        }
+        const initNode = binding.path.get('init').node;
+        if (!isKeyMirrorRequireCall(initNode)) {
+          return;
+        }
+        for (const reference of binding.referencePaths) {
+          if (!reference.parentPath.isCallExpression()) {
+            throw reference.buildCodeFrameError('Expected keyMirror function call.');
+          }
+          const argPath = reference.parentPath.get('arguments.0');
+          if (!argPath.isObjectExpression()) {
+            throw argPath.buildCodeFrameError('Expected object literal.');
+          }
+          for (const prop of argPath.get('properties')) {
+            const value = prop.get('value');
+            if (value.isNullLiteral()) {
+              const name = prop.get('key.name').node;
+              value.replaceWith(t.stringLiteral(name));
+            } else {
+              throw value.buildCodeFrameError('Expected null value for key.');
+            }
+          }
+          reference.parentPath.replaceWith(argPath);
+        }
+        binding.path.remove();
+      },
+    },
+  };
+};


### PR DESCRIPTION
I was hoping that avoiding `keyMirror` during load would have a more dramatic effect, but I can't tell if it's noise or not. The p90 didn't move, and I'm always reluctant to sell something solely based on averages.

Results using the same [benchmark](https://gist.github.com/zertosh/e05e708262ee499626fc4998646c79a0) from #7493 with 100 iterations:

| engine | build | before: avg / p90 (ms) | after: avg / p90 (ms) |
| ------ | ----- | -------------: | -------------: |
| node | react.js (development) | 22.67 / 23 | 22.32 / 23 |
| node | react.js (production) | 20.41 / 21 | 19.83 / 21 |
| node | dist/react-with-addons.js | 26.79 / 29 | 26.20 / 27 |
| node | dist/react-with-addons.min.js | 18.17 / 19.5 | 18.03 / 19 |
| node | dist/react.js | 18.73 / 19 | 18.02 / 19 |
| node | dist/react.min.js | 12.87 / 13 | 12.48 / 13 |

It does result in some modest size improvements:

```
   raw     gz Compared to master @ e5f9ae27058052e72d6fb6d89c6ca93075e4089a
     =      = build/react-dom-fiber.js
     =      = build/react-dom-fiber.min.js
  -745    -92 build/react-dom-server.js
  +453     +7 build/react-dom-server.min.js
  -745    -98 build/react-dom.js
  +454     -5 build/react-dom.min.js
 -1322   -337 build/react-with-addons.js
  -166    -39 build/react-with-addons.min.js
 -1322   -339 build/react.js
  -166    -50 build/react.min.js
```

Given the low-impact of this PR, it won't hurt my feelings if it doesn't get merged.