### PR TITLE
Fix slow performance of PropTypes.oneOfType() on misses

### DIFF
--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -232,8 +232,6 @@ describe('ReactPropTypes', function() {
       expectWarningInDevelopment(PropTypes.object.isRequired, null);
       expectWarningInDevelopment(PropTypes.object.isRequired, undefined);
     });
-
-
   });
 
   describe('Any type', function() {
@@ -259,7 +257,6 @@ describe('ReactPropTypes', function() {
       expectWarningInDevelopment(PropTypes.any.isRequired, null);
       expectWarningInDevelopment(PropTypes.any.isRequired, undefined);
     });
-
   });
 
   describe('ArrayOf Type', function() {


### PR DESCRIPTION
It used to be slow whenever a type miss occurred because expensive `Error` objects were being created. For example, with `oneOfType([number, data])`, passing a date would create an `Error` object in `number` typechecker for every item.

The savings depend on how much commonly you used `oneOfType()`, and how often it had “misses”. If you used it heavily, you might see 1.5x to 2x performance improvements in `__DEV__` after this fix.

Thanks to @spicyj @sebmarkbage for ideas on how to fix this.