### PR TITLE
Test renderer traversal

### DIFF
--- a/src/renderers/testing/ReactTestRenderer.js
+++ b/src/renderers/testing/ReactTestRenderer.js
@@ -39,6 +39,7 @@ function getRenderedHostOrTextFromComponent(component) {
 // =============================================================================
 
 var ReactTestComponent = function(element) {
+  this._unmounted = false;
   this._currentElement = element;
   this._renderedChildren = null;
   this._topLevelWrapper = null;
@@ -66,7 +67,10 @@ ReactTestComponent.prototype.getPublicInstance = function() {
   // Maybe we'll revise later if someone has a good use case.
   return null;
 };
-ReactTestComponent.prototype.unmountComponent = function() {};
+ReactTestComponent.prototype.unmountComponent = function() {
+  this._unmounted = true;
+  this.unmountChildren(/* safely */ false);
+};
 ReactTestComponent.prototype.toJSON = function() {
   var {children, ...props} = this._currentElement.props;
   var childrenJSON = [];
@@ -93,6 +97,7 @@ Object.assign(ReactTestComponent.prototype, ReactMultiChild.Mixin);
 // =============================================================================
 
 var ReactTestTextComponent = function(element) {
+  this._unmounted = false;
   this._currentElement = element;
 };
 ReactTestTextComponent.prototype.mountComponent = function() {};
@@ -100,7 +105,9 @@ ReactTestTextComponent.prototype.receiveComponent = function(nextElement) {
   this._currentElement = nextElement;
 };
 ReactTestTextComponent.prototype.getHostNode = function() {};
-ReactTestTextComponent.prototype.unmountComponent = function() {};
+ReactTestTextComponent.prototype.unmountComponent = function() {
+  this._unmounted = true;
+};
 ReactTestTextComponent.prototype.toJSON = function() {
   return this._currentElement;
 };
@@ -108,12 +115,15 @@ ReactTestTextComponent.prototype.toJSON = function() {
 // =============================================================================
 
 var ReactTestEmptyComponent = function(element) {
+  this._unmounted = false;
   this._currentElement = null;
 };
 ReactTestEmptyComponent.prototype.mountComponent = function() {};
 ReactTestEmptyComponent.prototype.receiveComponent = function() {};
 ReactTestEmptyComponent.prototype.getHostNode = function() {};
-ReactTestEmptyComponent.prototype.unmountComponent = function() {};
+ReactTestEmptyComponent.prototype.unmountComponent = function() {
+  this._unmounted = true;
+};
 ReactTestEmptyComponent.prototype.toJSON = function() {};
 
 // =============================================================================

--- a/src/renderers/testing/__tests__/ReactTestRenderer-test.js
+++ b/src/renderers/testing/__tests__/ReactTestRenderer-test.js
@@ -111,7 +111,9 @@ describe('ReactTestRenderer', function() {
     });
   });
 
-  it('updates types', function() {
+  it('updates types with a warning', function() {
+    spyOn(console, 'error');
+
     var renderer = ReactTestRenderer.create(<div>mouse</div>);
     expect(renderer.toJSON()).toEqual({
       type: 'div',
@@ -125,6 +127,18 @@ describe('ReactTestRenderer', function() {
       props: {},
       children: ['mice'],
     });
+
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toEqual(
+      'Warning: ReactTestRenderer: Component type and key must be preserved ' +
+      'when updating. If necessary, call ReactTestRenderer.create again ' +
+      'instead.'
+    );
+
+    expect(() => renderer.getType()).toThrow(new Error(
+      'ReactTestRenderer: Can\'t inspect or traverse after changing ' +
+      'component type or key. Fix the earlier warning and try again.'
+    ));
   });
 
   it('updates children', function() {
@@ -178,16 +192,20 @@ describe('ReactTestRenderer', function() {
       }
     }
 
-    var renderer = ReactTestRenderer.create(<Log key="foo" name="Foo" />);
-    renderer.update(<Log key="bar" name="Bar" />);
+    var renderer = ReactTestRenderer.create(
+      <div><Log key="foo" name="Foo" /></div>
+    );
+    renderer.update(<div><Log key="bar" name="Bar" /></div>);
     renderer.unmount();
 
     expect(log).toEqual([
       'render Foo',
       'mount Foo',
-      'unmount Foo',
+
       'render Bar',
+      'unmount Foo',
       'mount Bar',
+
       'unmount Bar',
     ]);
   });


### PR DESCRIPTION
If you do

```
x = ReactTestRenderer.create(<a />);
x.update(<b />);
x.getType();
```

then you probably expect to get `'b'` back. But if you were to do

```
div = ReactTestRenderer.create(<div><a /></div>);
x = div.getChildren()[0];
div.update(<div><b /></div>);
x.getType();
```

then since `x` points directly to the original `<a />` child, there's no possible way we could return `'b'`. So rather than have a confusing inconsistency between the top-level node and all the lower ones, @gaearon suggested outlawing changing type and key so that you always have the same instance.

I'm not actually sure I like this. It might make more sense to distinguish between the top-level instance and the children in the API -- since it also makes sense to call .update and .unmount at the top but nowhere else.

cc @sebmarkbage @rafeca #7148
