### PR TITLE
Fix ReactTestInstance::toJSON() with empty top-level components

### DIFF
--- a/src/renderers/testing/ReactTestMount.js
+++ b/src/renderers/testing/ReactTestMount.js
@@ -122,6 +122,9 @@ ReactTestInstance.prototype.unmount = function(nextElement) {
 };
 ReactTestInstance.prototype.toJSON = function() {
   var inst = getHostComponentFromComposite(this._component);
+  if (inst === null) {
+    return null;
+  }
   return inst.toJSON();
 };
 

--- a/src/renderers/testing/__tests__/ReactTestRenderer-test.js
+++ b/src/renderers/testing/__tests__/ReactTestRenderer-test.js
@@ -28,6 +28,14 @@ describe('ReactTestRenderer', function() {
     });
   });
 
+  it('renders a top-level empty component', function() {
+    function Empty() {
+      return null;
+    }
+    var renderer = ReactTestRenderer.create(<Empty />);
+    expect(renderer.toJSON()).toEqual(null);
+  });
+
   it('exposes a type flag', function() {
     function Link() {
       return <a role="link" />;


### PR DESCRIPTION
Since `ReactTestInstance::toJSON()` doesn't support the case where `getHostComponentFromComposite` returns `null` (The component has rendered an empty node), the following code throws:

```js
function Empty() {
  return null;
}
ReactTestRenderer.create(<Empty />).toJSON();
```

This patch makes `ReactTestInstance::toJSON()` return `null` when the top-level component has rendered an empty node.