### PR TITLE
Request to allow controlled checkboxes to remove checked when assigned `null`

### DIFF
--- a/src/renderers/dom/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMInput.js
@@ -75,7 +75,7 @@ var ReactDOMInput = {
       defaultChecked: undefined,
       defaultValue: undefined,
       value: value != null ? value : inst._wrapperState.initialValue,
-      checked: checked != null ? checked : inst._wrapperState.initialChecked,
+      checked: checked !== undefined ? checked : inst._wrapperState.initialChecked,
       onChange: inst._wrapperState.onChange,
     });
 
@@ -146,7 +146,7 @@ var ReactDOMInput = {
 
     var defaultValue = props.defaultValue;
     inst._wrapperState = {
-      initialChecked: props.checked != null ? props.checked : props.defaultChecked,
+      initialChecked: props.checked !== undefined ? props.checked : props.defaultChecked,
       initialValue: props.value != null ? props.value : defaultValue,
       listeners: null,
       onChange: _handleChange.bind(inst),
@@ -192,7 +192,7 @@ var ReactDOMInput = {
 
     // TODO: Shouldn't this be getChecked(props)?
     var checked = props.checked;
-    if (checked != null) {
+    if (checked !== undefined) {
       DOMPropertyOperations.setValueForProperty(
         ReactDOMComponentTree.getNodeFromInstance(inst),
         'checked',

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
@@ -843,4 +843,26 @@ describe('ReactDOMInput', function() {
       'node.setAttribute("checked", "")',
     ]);
   });
+
+  it('removes the checked state when assigned null after initially rendering true', function() {
+    var Input = React.createClass({
+      getInitialState() {
+        return { checked: true };
+      },
+
+      render() {
+        return (
+          <form>
+            <input ref="input" type="checkbox" checked={this.state.checked} />
+          </form>
+        );
+      }
+    });
+
+    var el = ReactTestUtils.renderIntoDocument(<Input />);
+
+    el.setState({ checked: null })
+
+    expect(el.refs.input.checked).toBe(false);
+  });
 });

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
@@ -856,12 +856,12 @@ describe('ReactDOMInput', function() {
             <input ref="input" type="checkbox" checked={this.state.checked} />
           </form>
         );
-      }
+      },
     });
 
     var el = ReactTestUtils.renderIntoDocument(<Input />);
 
-    el.setState({ checked: null })
+    el.setState({ checked: null });
 
     expect(el.refs.input.checked).toBe(false);
   });


### PR DESCRIPTION
We hit a snag on a project where a piece of state backing a checkbox was set to `null` instead of `false`, and the checkbox checked state was not reflected in the UI.

**Steps to reproduce**:

1. Visit https://jsfiddle.net/69z2wepo/53315/
2. Click "toggle" to show the checkbox
3. Check the checkbox
4. Click "toggle" to hide the checkbox
5. Click "toggle" to show the checkbox (it should be checked)
6. Click "Reset"

**Expected:** The checkbox is no longer checked
**Actual:** The checkbox is checked

Here's a recording of the behavior:

![toggle](https://cloud.githubusercontent.com/assets/590904/17814610/a2803e84-65fe-11e6-9cd7-db2a34987440.gif)

It looks like this happens because `null` returns a controlled input to the initial checked state (inst._wrapperState.initialChecked) it was mounted with:

https://github.com/facebook/react/blob/master/src/renderers/dom/client/wrappers/ReactDOMInput.js#L78

To me, this is inconsistent with the behavior of other attributes. If given `null`, [the attribute is removed](https://github.com/facebook/react/blob/master/src/renderers/dom/shared/ReactDOMComponent.js#L1064). Additionally, if `input.checked` is assigned `null` directly, it becomes unchecked. 

This PR configures `ReactDOMInput` to respect `null` for controlled checkboxes. It will only ever fallback to initial mounted value on `undefined`.

If a change like this is impossible, could there be a warning or additional documentation along the lines of [tips/controlled-input-null-value](https://facebook.github.io/react/tips/controlled-input-null-value.html)? I'm happy to follow up with an issue if so (I'll even write the docs, if given a formal stance).



