### PR TITLE
Upgrade to fbjs v0.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint": "1.10.3",
     "eslint-plugin-react": "4.1.0",
     "eslint-plugin-react-internal": "file:eslint-rules",
-    "fbjs": "^0.8.1",
+    "fbjs": "^0.8.4",
     "fbjs-scripts": "^0.6.0",
     "flow-bin": "^0.27.0",
     "glob": "^6.0.1",

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://facebook.github.io/react/",
   "dependencies": {
-    "fbjs": "^0.8.1",
+    "fbjs": "^0.8.4",
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.0"
   },

--- a/packages/react-native-renderer/package.json
+++ b/packages/react-native-renderer/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://facebook.github.io/react-native/",
   "dependencies": {
-    "fbjs": "^0.8.1",
+    "fbjs": "^0.8.4",
     "object-assign": "^4.1.0"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,7 +23,7 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "fbjs": "^0.8.1",
+    "fbjs": "^0.8.4",
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.0"
   },


### PR DESCRIPTION
While this will happen naturally for fresh installs, we want to ensure this is the minimum version.