### PR TITLE
Check for shady-dom

### DIFF
--- a/src/renderers/dom/ReactDOM.js
+++ b/src/renderers/dom/ReactDOM.js
@@ -135,11 +135,14 @@ if (__DEV__) {
   }
 
   // Check if using Polymer and we are not using native shadow
-  var shadyDom = window.Polymer !== undefined && !window.Polymer.useNativeShadow;
-  warning(
-    !shadyDom,
-    'It looks like you are using the shady-dom. Careful things might break!'
-  );
+  if (ExecutionEnvironment.canUseDOM) {
+    var shadyDom = window.Polymer != null &&
+      (window.Polymer.wantShadow && !window.Polymer.nativeShadow);
+    warning(
+      !shadyDom,
+      'Using the shady-dom with React may cause subtle problems.'
+    );
+  }
 }
 
 if (__DEV__) {

--- a/src/renderers/dom/ReactDOM.js
+++ b/src/renderers/dom/ReactDOM.js
@@ -133,6 +133,13 @@ if (__DEV__) {
       }
     }
   }
+
+  // Check if using Polymer and we are not using native shadow
+  var shadyDom = window.Polymer !== undefined && !window.Polymer.useNativeShadow;
+  warning(
+    !shadyDom,
+    'It looks like you are using the shady-dom. Careful things might break!'
+  );
 }
 
 if (__DEV__) {


### PR DESCRIPTION
Long time lurker, first time contributor — go easy on me! 😜

Closes #7325.

This checks to see if Polymer is using shady-dom by looking into the `useNativeShadow` property [exposed by Polymer](https://github.com/Polymer/polymer/blob/bd456e5b27f1447de5f4cd47d1c794886dd0aa82/src/lib/settings.html#L44). The property is set if the user requests to use the shadow DOM and the browser they are using supports it. Polymer uses [a similar check](https://github.com/Polymer/polymer/blob/edb59eb6283074ce54f374b30b884c9f9fcf9f5f/test/unit/polymer-dom-content.html#L308) in their test suite for shady dom.

cc: @gaearon 