### PR TITLE
support error boundaries on ReactTestRenderer

### DIFF
--- a/src/renderers/testing/ReactTestReconcileTransaction.js
+++ b/src/renderers/testing/ReactTestReconcileTransaction.js
@@ -90,6 +90,19 @@ var Mixin = {
   },
 
   /**
+   * Save current transaction state -- if the return value from this method is
+   * passed to `rollback`, the transaction will be reset to that state.
+   */
+  checkpoint: function() {
+    // reactMountReady is the our only stateful wrapper
+    return this.reactMountReady.checkpoint();
+  },
+
+  rollback: function(checkpoint) {
+    this.reactMountReady.rollback(checkpoint);
+  },
+
+  /**
    * `PooledClass` looks for this, and will invoke this before allowing this
    * instance to be reused.
    */

--- a/src/renderers/testing/__tests__/ReactTestRenderer-test.js
+++ b/src/renderers/testing/__tests__/ReactTestRenderer-test.js
@@ -206,4 +206,42 @@ describe('ReactTestRenderer', function() {
     expect(log).toEqual([null]);
   });
 
+  it('supports error boundaries', function() {
+    class Angry extends React.Component {
+      render() {
+        throw new Error('Please, do not render me.');
+      }
+    }
+
+    class Boundary extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {error: false};
+      }
+      render() {
+        if (!this.state.error) {
+          return (<div><button onClick={this.onClick}>ClickMe</button><Angry /></div>);
+        } else {
+          return (<div>Happy Birthday!</div>);
+        }
+      }
+      onClick() {
+        /* do nothing */
+      }
+      unstable_handleError() {
+        this.setState({error: true});
+      }
+    }
+
+    var EventPluginHub = require('EventPluginHub');
+    EventPluginHub.putListener = jest.fn();
+    var renderer = ReactTestRenderer.create(<Boundary />);
+    expect(renderer.toJSON()).toEqual({
+      type: 'div',
+      props: {},
+      children: ['Happy Birthday!'],
+    });
+    expect(EventPluginHub.putListener).not.toBeCalled();
+  });
+
 });


### PR DESCRIPTION
`transaction.checkpoint()` and `transaction.rollback()` was missing from `ReactTestReconcileTransaction`; so every time I tried to generate [snapshots tests with jest](https://facebook.github.io/jest/blog/2016/07/27/jest-14.html) for components that implemented `unstable_handleError` I would get the following error:

```
  TypeError: transaction.checkpoint is not a function

      at ReactCompositeComponentWrapper.performInitialMountWithErrorHandling (react/renderers/shared/stack/reconciler/ReactCompositeComponent.js:434:28)
      at ReactCompositeComponentWrapper.mountComponent (react/renderers/shared/stack/reconciler/ReactCompositeComponent.js:337:13)
      at Object.mountComponent (react/renderers/shared/stack/reconciler/ReactReconciler.js:57:29)
      at ReactTestComponent.mountChildren (react/renderers/shared/stack/reconciler/ReactMultiChild.js:275:43)
      at ReactTestComponent.mountComponent (react/renderers/testing/ReactTestRenderer.js:53:6)
      at Object.mountComponent (react/renderers/shared/stack/reconciler/ReactReconciler.js:57:29)
      at ReactTestComponent.mountChildren (react/renderers/shared/stack/reconciler/ReactMultiChild.js:275:43)
      at ReactTestComponent.mountComponent (react/renderers/testing/ReactTestRenderer.js:53:6)
      at Object.mountComponent (react/renderers/shared/stack/reconciler/ReactReconciler.js:57:29)
      at ReactTestComponent.mountChildren (react/renderers/shared/stack/reconciler/ReactMultiChild.js:275:43)
      at ReactTestComponent.mountComponent (react/renderers/testing/ReactTestRenderer.js:53:6)
      at Object.mountComponent (react/renderers/shared/stack/reconciler/ReactReconciler.js:57:29)
      at ReactCompositeComponentWrapper.performInitialMount (react/renderers/shared/stack/reconciler/ReactCompositeComponent.js:494:39)
      at ReactCompositeComponentWrapper.mountComponent (react/renderers/shared/stack/reconciler/ReactCompositeComponent.js:345:13)
      at Object.mountComponent (react/renderers/shared/stack/reconciler/ReactReconciler.js:57:29)
      at ReactCompositeComponentWrapper.performInitialMount (react/renderers/shared/stack/reconciler/ReactCompositeComponent.js:494:39)
      at ReactCompositeComponentWrapper.mountComponent (react/renderers/shared/stack/reconciler/ReactCompositeComponent.js:345:13)
      at Object.mountComponent (react/renderers/shared/stack/reconciler/ReactReconciler.js:57:29)
      at mountComponentIntoNode (react/renderers/testing/ReactTestMount.js:49:38)
      at ReactTestReconcileTransaction.perform (react/renderers/shared/utils/Transaction.js:140:12)
      at batchedMountComponentIntoNode (react/renderers/testing/ReactTestMount.js:70:23)
      at ReactDefaultBatchingStrategyTransaction.perform (react/renderers/shared/utils/Transaction.js:140:12)
      at Object.batchedUpdates (react/renderers/shared/stack/reconciler/ReactDefaultBatchingStrategy.js:65:20)
      at Object.batchedUpdates (react/renderers/shared/stack/reconciler/ReactUpdates.js:111:25)
      at Object.render (react/renderers/testing/ReactTestMount.js:151:25)
```

this diff fixes the error