### PR TITLE
Move shared logic into AbstractReconcileTransaction to avoid mistakes

### DIFF
--- a/src/renderers/dom/client/ReactReconcileTransaction.js
+++ b/src/renderers/dom/client/ReactReconcileTransaction.js
@@ -11,14 +11,12 @@
 
 'use strict';
 
+var AbstractReconcileTransaction = require('AbstractReconcileTransaction');
 var CallbackQueue = require('CallbackQueue');
 var PooledClass = require('PooledClass');
 var ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
 var ReactInputSelection = require('ReactInputSelection');
 var ReactInstrumentation = require('ReactInstrumentation');
-var Transaction = require('Transaction');
-var ReactUpdateQueue = require('ReactUpdateQueue');
-
 
 /**
  * Ensures that, when possible, the selection range (currently selected text
@@ -136,46 +134,14 @@ var Mixin = {
   getTransactionWrappers: function() {
     return TRANSACTION_WRAPPERS;
   },
-
-  /**
-   * @return {object} The queue to collect `onDOMReady` callbacks with.
-   */
-  getReactMountReady: function() {
-    return this.reactMountReady;
-  },
-
-  /**
-   * @return {object} The queue to collect React async events.
-   */
-  getUpdateQueue: function() {
-    return ReactUpdateQueue;
-  },
-
-  /**
-   * Save current transaction state -- if the return value from this method is
-   * passed to `rollback`, the transaction will be reset to that state.
-   */
-  checkpoint: function() {
-    // reactMountReady is the our only stateful wrapper
-    return this.reactMountReady.checkpoint();
-  },
-
-  rollback: function(checkpoint) {
-    this.reactMountReady.rollback(checkpoint);
-  },
-
-  /**
-   * `PooledClass` looks for this, and will invoke this before allowing this
-   * instance to be reused.
-   */
-  destructor: function() {
-    CallbackQueue.release(this.reactMountReady);
-    this.reactMountReady = null;
-  },
 };
 
 
-Object.assign(ReactReconcileTransaction.prototype, Transaction.Mixin, Mixin);
+Object.assign(
+  ReactReconcileTransaction.prototype,
+  AbstractReconcileTransaction.Mixin,
+  Mixin
+);
 
 PooledClass.addPoolingTo(ReactReconcileTransaction);
 

--- a/src/renderers/native/ReactNativeReconcileTransaction.js
+++ b/src/renderers/native/ReactNativeReconcileTransaction.js
@@ -11,11 +11,10 @@
  */
 'use strict';
 
+var AbstractReconcileTransaction = require('AbstractReconcileTransaction');
 var CallbackQueue = require('CallbackQueue');
 var PooledClass = require('PooledClass');
-var Transaction = require('Transaction');
 var ReactInstrumentation = require('ReactInstrumentation');
-var ReactUpdateQueue = require('ReactUpdateQueue');
 
 /**
  * Provides a `CallbackQueue` queue for collecting `onDOMReady` callbacks during
@@ -81,36 +80,11 @@ var Mixin = {
   getTransactionWrappers: function() {
     return TRANSACTION_WRAPPERS;
   },
-
-  /**
-   * @return {object} The queue to collect `onDOMReady` callbacks with.
-   *   TODO: convert to ReactMountReady
-   */
-  getReactMountReady: function() {
-    return this.reactMountReady;
-  },
-
-  /**
-   * @return {object} The queue to collect React async events.
-   */
-  getUpdateQueue: function() {
-    return ReactUpdateQueue;
-  },
-
-  /**
-   * `PooledClass` looks for this, and will invoke this before allowing this
-   * instance to be reused.
-   */
-  destructor: function() {
-    CallbackQueue.release(this.reactMountReady);
-    this.reactMountReady = null;
-  },
 };
 
 Object.assign(
   ReactNativeReconcileTransaction.prototype,
-  Transaction.Mixin,
-  ReactNativeReconcileTransaction,
+  AbstractReconcileTransaction.Mixin,
   Mixin
 );
 

--- a/src/renderers/shared/stack/reconciler/AbstractReconcileTransaction.js
+++ b/src/renderers/shared/stack/reconciler/AbstractReconcileTransaction.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule AbstractReconcileTransaction
+ * @flow
+ */
+'use strict';
+
+var CallbackQueue = require('CallbackQueue');
+var ReactUpdateQueue = require('ReactUpdateQueue');
+var Transaction = require('Transaction');
+
+var Mixin = {
+  /**
+   * @return {object} The queue to collect `onDOMReady` callbacks with.
+   */
+  getReactMountReady: function() {
+    return this.reactMountReady;
+  },
+
+  /**
+   * @return {object} The queue to collect React async events.
+   */
+  getUpdateQueue: function() {
+    return ReactUpdateQueue;
+  },
+
+  /**
+   * Save current transaction state -- if the return value from this method is
+   * passed to `rollback`, the transaction will be reset to that state.
+   */
+  checkpoint: function() {
+    // reactMountReady is the our only stateful wrapper
+    return this.reactMountReady.checkpoint();
+  },
+
+  rollback: function(checkpoint) {
+    this.reactMountReady.rollback(checkpoint);
+  },
+
+  /**
+   * `PooledClass` looks for this, and will invoke this before allowing this
+   * instance to be reused.
+   */
+  destructor: function() {
+    CallbackQueue.release(this.reactMountReady);
+    this.reactMountReady = null;
+  },
+};
+
+Object.assign(
+  Mixin,
+  Transaction.Mixin,
+);
+
+var AbstractReconcileTransaction = {
+
+  Mixin: Mixin,
+
+};
+
+module.exports = AbstractReconcileTransaction;

--- a/src/renderers/testing/ReactTestReconcileTransaction.js
+++ b/src/renderers/testing/ReactTestReconcileTransaction.js
@@ -11,10 +11,9 @@
  */
 'use strict';
 
+var AbstractReconcileTransaction = require('AbstractReconcileTransaction');
 var CallbackQueue = require('CallbackQueue');
 var PooledClass = require('PooledClass');
-var Transaction = require('Transaction');
-var ReactUpdateQueue = require('ReactUpdateQueue');
 
 /**
  * Provides a `CallbackQueue` queue for collecting `onDOMReady` callbacks during
@@ -73,49 +72,11 @@ var Mixin = {
   getTransactionWrappers: function() {
     return TRANSACTION_WRAPPERS;
   },
-
-  /**
-   * @return {object} The queue to collect `onDOMReady` callbacks with.
-   *   TODO: convert to ReactMountReady
-   */
-  getReactMountReady: function() {
-    return this.reactMountReady;
-  },
-
-  /**
-   * @return {object} The queue to collect React async events.
-   */
-  getUpdateQueue: function() {
-    return ReactUpdateQueue;
-  },
-
-  /**
-   * Save current transaction state -- if the return value from this method is
-   * passed to `rollback`, the transaction will be reset to that state.
-   */
-  checkpoint: function() {
-    // reactMountReady is the our only stateful wrapper
-    return this.reactMountReady.checkpoint();
-  },
-
-  rollback: function(checkpoint) {
-    this.reactMountReady.rollback(checkpoint);
-  },
-
-  /**
-   * `PooledClass` looks for this, and will invoke this before allowing this
-   * instance to be reused.
-   */
-  destructor: function() {
-    CallbackQueue.release(this.reactMountReady);
-    this.reactMountReady = null;
-  },
 };
 
 Object.assign(
   ReactTestReconcileTransaction.prototype,
-  Transaction.Mixin,
-  ReactTestReconcileTransaction,
+  AbstractReconcileTransaction.Mixin,
   Mixin
 );
 


### PR DESCRIPTION
not the first time that someone forgets to implement `checkpoint` and `rollback` on a `ReconcileTransaction` (see #7558 and #6689) so I decided it was worth moving the shared logic into an `AbstractReconcileTransaction`

I kinda followed the same pattern used on [Transaction.js](https://github.com/facebook/react/blob/master/src/renderers/shared/utils/Transaction.js) (export a `Mixin` property) but in this case a plain object would probably be fine.

Note that the `ReactNativeReconcileTransaction` was also missing the `checkpoint` and `rollback`, not sure if intentional or not (not familiar with the React codebase).

PS: maybe someone have a better name for it and/or knows a better folder to place it.

/cc @spicyj 
