### PR TITLE
Improve error boundaries tests

### DIFF
--- a/src/renderers/testing/__tests__/ReactTestRenderer-test.js
+++ b/src/renderers/testing/__tests__/ReactTestRenderer-test.js
@@ -207,9 +207,17 @@ describe('ReactTestRenderer', function() {
   });
 
   it('supports error boundaries', function() {
+    var log = [];
     class Angry extends React.Component {
       render() {
+        log.push('Angry render');
         throw new Error('Please, do not render me.');
+      }
+      componentDidMount() {
+        log.push('Angry componentDidMount');
+      }
+      componentWillUnmount() {
+        log.push('Angry componentWillUnmount');
       }
     }
 
@@ -219,11 +227,20 @@ describe('ReactTestRenderer', function() {
         this.state = {error: false};
       }
       render() {
+        log.push('Boundary render');
         if (!this.state.error) {
-          return (<div><button onClick={this.onClick}>ClickMe</button><Angry /></div>);
+          return (
+            <div><button onClick={this.onClick}>ClickMe</button><Angry /></div>
+          );
         } else {
-          return (<div>Happy Birthday!</div>);
+          return <div>Happy Birthday!</div>;
         }
+      }
+      componentDidMount() {
+        log.push('Boundary componentDidMount');
+      }
+      componentWillUnmount() {
+        log.push('Boundary componentWillUnmount');
       }
       onClick() {
         /* do nothing */
@@ -233,15 +250,18 @@ describe('ReactTestRenderer', function() {
       }
     }
 
-    var EventPluginHub = require('EventPluginHub');
-    EventPluginHub.putListener = jest.fn();
     var renderer = ReactTestRenderer.create(<Boundary />);
     expect(renderer.toJSON()).toEqual({
       type: 'div',
       props: {},
       children: ['Happy Birthday!'],
     });
-    expect(EventPluginHub.putListener).not.toBeCalled();
+    expect(log).toEqual([
+      'Boundary render',
+      'Angry render',
+      'Boundary render',
+      'Boundary componentDidMount',
+    ]);
   });
 
 });


### PR DESCRIPTION
this is kinda of a follow up to #7558 where @spicyj said:

> Can you make a custom componentDidMount instead of mocking putListener? This current test won't verify that the queue is reset if we were to refactor the events system and how putListener works. Also, no need for the parens within render.
> https://github.com/facebook/react/pull/7558#issuecomment-242525014

the new tests makes sure the methods are executed in the proper order and don't rely on `EventPluginHub` anymore - the `'does not register event handlers for unmounted children'` test still uses `EventPluginHub` since it looks like it makes sense to leave that check there...

also removed some parentheses and wrapped some lines.