### PR TITLE
Warn when React DOM modified by not-React

### DIFF
--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -15,6 +15,7 @@ var DOMLazyTree = require('DOMLazyTree');
 var DOMProperty = require('DOMProperty');
 var ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
 var ReactCurrentOwner = require('ReactCurrentOwner');
+var DOMChildrenOperations = require('DOMChildrenOperations'); 
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var ReactDOMContainerInfo = require('ReactDOMContainerInfo');
 var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
@@ -129,6 +130,10 @@ function mountComponentIntoNode(
     shouldReuseMarkup,
     transaction
   );
+
+  if (__DEV__) {
+    DOMChildrenOperations.startObservation()
+  }
 }
 
 /**

--- a/src/renderers/dom/client/ReactMount.js
+++ b/src/renderers/dom/client/ReactMount.js
@@ -132,7 +132,7 @@ function mountComponentIntoNode(
   );
 
   if (__DEV__) {
-    DOMChildrenOperations.startObservation()
+    DOMChildrenOperations.startObservation();
   }
 }
 

--- a/src/renderers/dom/client/utils/DOMChildrenOperations.js
+++ b/src/renderers/dom/client/utils/DOMChildrenOperations.js
@@ -13,7 +13,7 @@
 
 var DOMLazyTree = require('DOMLazyTree');
 var Danger = require('Danger');
-// var warning = require('warning'); 
+var warning = require('warning'); 
 var ReactMultiChildUpdateTypes = require('ReactMultiChildUpdateTypes');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var ReactInstrumentation = require('ReactInstrumentation');
@@ -248,6 +248,7 @@ var DOMChildrenOperations = {
     }
   },
 
+  // Potentially unnecessary as it's not called anywhere
   endObservation: function() {
     observer.disconnect();
   },
@@ -255,8 +256,8 @@ var DOMChildrenOperations = {
   startObservation: function() { 
     var config = { attributes: false, childList: true, characterData: false, subtree: true };
     var MutationObserver = window.MutationObserver || function() {}
-    MutationObserver.prototype.observe = MutationObserver.observe || function() {}      
-    MutationObserver.prototype.disconnect = MutationObserver.disconnect || function() {}      
+    MutationObserver.prototype.observe = MutationObserver.prototype.observe || function() {}      
+    MutationObserver.prototype.disconnect = MutationObserver.prototype.disconnect || function() {}      
 
     var observer = new MutationObserver(function(mutations) {
       for (var i = 0; i < mutations.length; i++) { 

--- a/src/renderers/dom/client/utils/DOMChildrenOperations.js
+++ b/src/renderers/dom/client/utils/DOMChildrenOperations.js
@@ -248,35 +248,30 @@ var DOMChildrenOperations = {
     }
   },
 
-  // Potentially unnecessary as it's not called anywhere
-  endObservation: function() {
-    observer.disconnect();
-  },
-
   startObservation: function() { 
     var config = { attributes: false, childList: true, characterData: false, subtree: true };
-    var MutationObserver = window.MutationObserver || function() {}
-    MutationObserver.prototype.observe = MutationObserver.prototype.observe || function() {}      
-    MutationObserver.prototype.disconnect = MutationObserver.prototype.disconnect || function() {}      
+    var MutationObserver = window.MutationObserver || function() {};
+    MutationObserver.prototype.observe = MutationObserver.prototype.observe || function() {};      
+    MutationObserver.prototype.disconnect = MutationObserver.prototype.disconnect || function() {};      
 
     var observer = new MutationObserver(function(mutations) {
       for (var i = 0; i < mutations.length; i++) { 
-        var mutation = mutations[i]
+        var mutation = mutations[i];
 
         if (mutation.addedNodes.length > 0) {
           warning(false, 'Warning, an outside source is mutating the DOM');
-          break
+          break;
         }
         if (mutation.removedNodes.length > 0) {
           warning(false, 'Warning, an outside source is mutating the DOM');
-          break
+          break;
         }
       }
     });   
 
     // Find all the elements with data-reactid attributes and data-reactroot attributes.
-    var reactIds = document.querySelectorAll('[data-reactid]')
-    var reactRoots = document.querySelectorAll('[data-reactroot]')
+    var reactIds = document.querySelectorAll('[data-reactid]');
+    var reactRoots = document.querySelectorAll('[data-reactroot]');
 
     for (var i = 0; i < reactIds.length; i++) {
       observer.observe(reactIds[i].parentNode, config);
@@ -284,7 +279,7 @@ var DOMChildrenOperations = {
     for (var i = 0; i < reactRoots.length; i++) {
       observer.observe(reactRoots[i].parentNode, config);
     }
-  }
+  },
 
 };
 

--- a/src/renderers/dom/client/utils/DOMChildrenOperations.js
+++ b/src/renderers/dom/client/utils/DOMChildrenOperations.js
@@ -13,6 +13,7 @@
 
 var DOMLazyTree = require('DOMLazyTree');
 var Danger = require('Danger');
+// var warning = require('warning'); 
 var ReactMultiChildUpdateTypes = require('ReactMultiChildUpdateTypes');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var ReactInstrumentation = require('ReactInstrumentation');
@@ -246,6 +247,43 @@ var DOMChildrenOperations = {
       }
     }
   },
+
+  endObservation: function() {
+    observer.disconnect();
+  },
+
+  startObservation: function() { 
+    var config = { attributes: false, childList: true, characterData: false, subtree: true };
+    var MutationObserver = window.MutationObserver || function() {}
+    MutationObserver.prototype.observe = MutationObserver.observe || function() {}      
+    MutationObserver.prototype.disconnect = MutationObserver.disconnect || function() {}      
+
+    var observer = new MutationObserver(function(mutations) {
+      for (var i = 0; i < mutations.length; i++) { 
+        var mutation = mutations[i]
+
+        if (mutation.addedNodes.length > 0) {
+          warning(false, 'Warning, an outside source is mutating the DOM');
+          break
+        }
+        if (mutation.removedNodes.length > 0) {
+          warning(false, 'Warning, an outside source is mutating the DOM');
+          break
+        }
+      }
+    });   
+
+    // Find all the elements with data-reactid attributes and data-reactroot attributes.
+    var reactIds = document.querySelectorAll('[data-reactid]')
+    var reactRoots = document.querySelectorAll('[data-reactroot]')
+
+    for (var i = 0; i < reactIds.length; i++) {
+      observer.observe(reactIds[i].parentNode, config);
+    }
+    for (var i = 0; i < reactRoots.length; i++) {
+      observer.observe(reactRoots[i].parentNode, config);
+    }
+  }
 
 };
 


### PR DESCRIPTION
This pull request addresses: Warn when React DOM modified by not-React #3218 

One issue I had was whether to write tests. I would think I need to but I could not find tests for DOMChildrenOperation. Another issue was that currently jsdom does not currently mock out window.MutationObserver that's defined in the browser so for the purpose of making the tests pass, I used `var MutationObserver = window.MutationObserver || function() {};` that would simply do nothing if window.MutationObserver is not found. 