### PR TITLE
Type ReactInstrumentation

### DIFF
--- a/src/renderers/shared/ReactInstrumentation.js
+++ b/src/renderers/shared/ReactInstrumentation.js
@@ -7,11 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule ReactInstrumentation
+ * @flow
  */
 
 'use strict';
 
-var debugTool = null;
+// Trust the developer to only use ReactInstrumentation with a __DEV__ check
+var debugTool = ((null: any): typeof ReactDebugTool);
 
 if (__DEV__) {
   var ReactDebugTool = require('ReactDebugTool');


### PR DESCRIPTION
Flow doesn't really support the concept of variables that are non-null but only inside of a `__DEV__` block. There's an internal post about it ( https://www.facebook.com/groups/flowtype/permalink/1132437726804841/ ) and the conclusion is that we should force it to be non-null and trust the developer to put the proper DEV checks in place.