### PR TITLE
[WIP] Strip Multiple Warning messages 

### DIFF
--- a/src/renderers/shared/stack/reconciler/ReactUpdateQueue.js
+++ b/src/renderers/shared/stack/reconciler/ReactUpdateQueue.js
@@ -59,8 +59,8 @@ function getInternalInstanceReadyForUpdate(publicInstance, callerName) {
   }
 
   if (__DEV__) {
-    if(warnedOnce === false) {
-      warnedOnce = true
+    if (warnedOnce === false) {
+      warnedOnce = true;
       warning(
         ReactCurrentOwner.current == null,
         '%s(...): Cannot update during an existing state transition (such as ' +

--- a/src/renderers/shared/stack/reconciler/ReactUpdateQueue.js
+++ b/src/renderers/shared/stack/reconciler/ReactUpdateQueue.js
@@ -18,6 +18,7 @@ var ReactUpdates = require('ReactUpdates');
 
 var invariant = require('invariant');
 var warning = require('warning');
+var warnedOnce = false;
 
 function enqueueUpdate(internalInstance) {
   ReactUpdates.enqueueUpdate(internalInstance);
@@ -58,15 +59,18 @@ function getInternalInstanceReadyForUpdate(publicInstance, callerName) {
   }
 
   if (__DEV__) {
-    warning(
-      ReactCurrentOwner.current == null,
-      '%s(...): Cannot update during an existing state transition (such as ' +
-      'within `render` or another component\'s constructor). Render methods ' +
-      'should be a pure function of props and state; constructor ' +
-      'side-effects are an anti-pattern, but can be moved to ' +
-      '`componentWillMount`.',
-      callerName
-    );
+    if(warnedOnce === false) {
+      warnedOnce = true
+      warning(
+        ReactCurrentOwner.current == null,
+        '%s(...): Cannot update during an existing state transition (such as ' +
+        'within `render` or another component\'s constructor). Render methods ' +
+        'should be a pure function of props and state; constructor ' +
+        'side-effects are an anti-pattern, but can be moved to ' +
+        '`componentWillMount`.',
+        callerName
+      );
+    }
   }
 
   return internalInstance;


### PR DESCRIPTION
This is work in progress, as you already see, and there's some parts left. I dunno how you want this to be internal-wise. Right now, we are making an global var to check if the warning has rendered once, but I don't like the solution. If we were to do this at similar places where we output hundreds of warning messages, it will easily be polluted. Any input on this? 

So far we need to do make warnings warn once on every warning or call that warns on each render. I'm not 100% known with the internal build yet, if someone could link me videos/podcasts where they go through everything in the React build, I'd be very thankful. 

Furthermore, as mentioned earlier, I don't like to make warning messages as this. I don't know if React has a way of figuring out if we already have rendered, if that is `isMounted` or not. Despite that, I've looked some places, and it says that you are planning to depreciate this. 

I'd very much like help from people, if they want to join inn on this! Previously I said that I wanted to do this alone, but as this is open-source, help is always great! 

I've just started, so what is left is the following:

- Perhaps create another module, which will render an warning once based on the arguments from `getInternalInstanceReadyForUpdate`
- This module will compare against `callerName` and every callerName to see if, say setState has been called already in render
- This module has to be universal, so perhaps, double checking that createClass uses similar methods, would be good
- If not, we'll do something similar to what I've started on/something else

Cheers! 

