### PR TITLE
Remove keyMirror in ReactMultiChildUpdateTypes

### DIFF
--- a/src/renderers/dom/client/__tests__/ReactDOMIDOperations-test.js
+++ b/src/renderers/dom/client/__tests__/ReactDOMIDOperations-test.js
@@ -14,7 +14,6 @@
 describe('ReactDOMIDOperations', function() {
   var ReactDOMComponentTree = require('ReactDOMComponentTree');
   var ReactDOMIDOperations = require('ReactDOMIDOperations');
-  var ReactMultiChildUpdateTypes = require('ReactMultiChildUpdateTypes');
 
   it('should update innerHTML and preserve whitespace', function() {
     var stubNode = document.createElement('div');
@@ -25,7 +24,7 @@ describe('ReactDOMIDOperations', function() {
     ReactDOMIDOperations.dangerouslyProcessChildrenUpdates(
       stubInstance,
       [{
-        type: ReactMultiChildUpdateTypes.SET_MARKUP,
+        type: 'SET_MARKUP',
         content: html,
         fromIndex: null,
         toIndex: null,

--- a/src/renderers/dom/client/utils/DOMChildrenOperations.js
+++ b/src/renderers/dom/client/utils/DOMChildrenOperations.js
@@ -13,7 +13,6 @@
 
 var DOMLazyTree = require('DOMLazyTree');
 var Danger = require('Danger');
-var ReactMultiChildUpdateTypes = require('ReactMultiChildUpdateTypes');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var ReactInstrumentation = require('ReactInstrumentation');
 
@@ -179,7 +178,7 @@ var DOMChildrenOperations = {
     for (var k = 0; k < updates.length; k++) {
       var update = updates[k];
       switch (update.type) {
-        case ReactMultiChildUpdateTypes.INSERT_MARKUP:
+        case 'INSERT_MARKUP':
           insertLazyTreeChildAt(
             parentNode,
             update.content,
@@ -193,7 +192,7 @@ var DOMChildrenOperations = {
             );
           }
           break;
-        case ReactMultiChildUpdateTypes.MOVE_EXISTING:
+        case 'MOVE_EXISTING':
           moveChild(
             parentNode,
             update.fromNode,
@@ -207,7 +206,7 @@ var DOMChildrenOperations = {
             );
           }
           break;
-        case ReactMultiChildUpdateTypes.SET_MARKUP:
+        case 'SET_MARKUP':
           setInnerHTML(
             parentNode,
             update.content
@@ -220,7 +219,7 @@ var DOMChildrenOperations = {
             );
           }
           break;
-        case ReactMultiChildUpdateTypes.TEXT_CONTENT:
+        case 'TEXT_CONTENT':
           setTextContent(
             parentNode,
             update.content
@@ -233,7 +232,7 @@ var DOMChildrenOperations = {
             );
           }
           break;
-        case ReactMultiChildUpdateTypes.REMOVE_NODE:
+        case 'REMOVE_NODE':
           removeChild(parentNode, update.fromNode);
           if (__DEV__) {
             ReactInstrumentation.debugTool.onHostOperation(

--- a/src/renderers/native/ReactNativeDOMIDOperations.js
+++ b/src/renderers/native/ReactNativeDOMIDOperations.js
@@ -11,7 +11,6 @@
 'use strict';
 
 var ReactNativeComponentTree = require('ReactNativeComponentTree');
-var ReactMultiChildUpdateTypes = require('ReactMultiChildUpdateTypes');
 var UIManager = require('UIManager');
 
 /**
@@ -41,12 +40,12 @@ var dangerouslyProcessChildrenUpdates = function(inst, childrenUpdates) {
 
   for (var i = 0; i < childrenUpdates.length; i++) {
     var update = childrenUpdates[i];
-    if (update.type === ReactMultiChildUpdateTypes.MOVE_EXISTING) {
+    if (update.type === 'MOVE_EXISTING') {
       (moveFromIndices || (moveFromIndices = [])).push(update.fromIndex);
       (moveToIndices || (moveToIndices = [])).push(update.toIndex);
-    } else if (update.type === ReactMultiChildUpdateTypes.REMOVE_NODE) {
+    } else if (update.type === 'REMOVE_NODE') {
       (removeAtIndices || (removeAtIndices = [])).push(update.fromIndex);
-    } else if (update.type === ReactMultiChildUpdateTypes.INSERT_MARKUP) {
+    } else if (update.type === 'INSERT_MARKUP') {
       var mountImage = update.content;
       var tag = mountImage;
       (addAtIndices || (addAtIndices = [])).push(update.toIndex);

--- a/src/renderers/shared/stack/reconciler/ReactMultiChild.js
+++ b/src/renderers/shared/stack/reconciler/ReactMultiChild.js
@@ -14,7 +14,6 @@
 var ReactComponentEnvironment = require('ReactComponentEnvironment');
 var ReactInstanceMap = require('ReactInstanceMap');
 var ReactInstrumentation = require('ReactInstrumentation');
-var ReactMultiChildUpdateTypes = require('ReactMultiChildUpdateTypes');
 
 var ReactCurrentOwner = require('ReactCurrentOwner');
 var ReactReconciler = require('ReactReconciler');
@@ -34,7 +33,7 @@ var invariant = require('invariant');
 function makeInsertMarkup(markup, afterNode, toIndex) {
   // NOTE: Null values reduce hidden classes.
   return {
-    type: ReactMultiChildUpdateTypes.INSERT_MARKUP,
+    type: 'INSERT_MARKUP',
     content: markup,
     fromIndex: null,
     fromNode: null,
@@ -53,7 +52,7 @@ function makeInsertMarkup(markup, afterNode, toIndex) {
 function makeMove(child, afterNode, toIndex) {
   // NOTE: Null values reduce hidden classes.
   return {
-    type: ReactMultiChildUpdateTypes.MOVE_EXISTING,
+    type: 'MOVE_EXISTING',
     content: null,
     fromIndex: child._mountIndex,
     fromNode: ReactReconciler.getHostNode(child),
@@ -71,7 +70,7 @@ function makeMove(child, afterNode, toIndex) {
 function makeRemove(child, node) {
   // NOTE: Null values reduce hidden classes.
   return {
-    type: ReactMultiChildUpdateTypes.REMOVE_NODE,
+    type: 'REMOVE_NODE',
     content: null,
     fromIndex: child._mountIndex,
     fromNode: node,
@@ -89,7 +88,7 @@ function makeRemove(child, node) {
 function makeSetMarkup(markup) {
   // NOTE: Null values reduce hidden classes.
   return {
-    type: ReactMultiChildUpdateTypes.SET_MARKUP,
+    type: 'SET_MARKUP',
     content: markup,
     fromIndex: null,
     fromNode: null,
@@ -107,7 +106,7 @@ function makeSetMarkup(markup) {
 function makeTextContent(textContent) {
   // NOTE: Null values reduce hidden classes.
   return {
-    type: ReactMultiChildUpdateTypes.TEXT_CONTENT,
+    type: 'TEXT_CONTENT',
     content: textContent,
     fromIndex: null,
     fromNode: null,

--- a/src/renderers/shared/stack/reconciler/ReactMultiChildUpdateTypes.js
+++ b/src/renderers/shared/stack/reconciler/ReactMultiChildUpdateTypes.js
@@ -11,22 +11,15 @@
 
 'use strict';
 
-var keyMirror = require('keyMirror');
-
 /**
  * When a component's children are updated, a series of update configuration
  * objects are created in order to batch and serialize the required changes.
  *
  * Enumerates all the possible types of update configurations.
- *
- * @internal
  */
-var ReactMultiChildUpdateTypes = keyMirror({
-  INSERT_MARKUP: null,
-  MOVE_EXISTING: null,
-  REMOVE_NODE: null,
-  SET_MARKUP: null,
-  TEXT_CONTENT: null,
-});
-
-module.exports = ReactMultiChildUpdateTypes;
+export type ReactMultiChildUpdateTypes =
+  'INSERT_MARKUP' |
+  'MOVE_EXISTING' |
+  'REMOVE_NODE' |
+  'SET_MARKUP' |
+  'TEXT_CONTENT';


### PR DESCRIPTION
As mentioned in https://www.facebook.com/groups/2003630259862046/permalink/2097088000516271/ I'm going to kill this instance of keyMirror and use a plain string instead with a type union.

The current type union is unused right now but when I type ReactMultiChild I will use it.