### PR TITLE
Remove keyMirror in ReactPropTypeLocations

### DIFF
--- a/src/addons/link/__tests__/ReactLinkPropTypes-test.js
+++ b/src/addons/link/__tests__/ReactLinkPropTypes-test.js
@@ -14,7 +14,6 @@
 var emptyFunction = require('emptyFunction');
 var LinkPropTypes = require('ReactLink').PropTypes;
 var React = require('React');
-var ReactPropTypeLocations = require('ReactPropTypeLocations');
 var ReactPropTypesSecret = require('ReactPropTypesSecret');
 
 var invalidMessage = 'Invalid prop `testProp` supplied to `testComponent`.';
@@ -27,7 +26,7 @@ function typeCheckFail(declaration, value, message) {
     props,
     'testProp',
     'testComponent',
-    ReactPropTypeLocations.prop,
+    'prop',
     null,
     ReactPropTypesSecret
   );
@@ -41,7 +40,7 @@ function typeCheckPass(declaration, value) {
     props,
     'testProp',
     'testComponent',
-    ReactPropTypeLocations.prop,
+    'prop',
     null,
     ReactPropTypesSecret
   );

--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -13,7 +13,6 @@
 
 var ReactComponent = require('ReactComponent');
 var ReactElement = require('ReactElement');
-var ReactPropTypeLocations = require('ReactPropTypeLocations');
 var ReactPropTypeLocationNames = require('ReactPropTypeLocationNames');
 var ReactNoopUpdateQueue = require('ReactNoopUpdateQueue');
 
@@ -22,6 +21,8 @@ var invariant = require('invariant');
 var keyMirror = require('keyMirror');
 var keyOf = require('keyOf');
 var warning = require('warning');
+
+import type { ReactPropTypeLocations } from 'ReactPropTypeLocations';
 
 var MIXINS_KEY = keyOf({mixins: null});
 
@@ -325,7 +326,7 @@ var RESERVED_SPEC_KEYS = {
       validateTypeDef(
         Constructor,
         childContextTypes,
-        ReactPropTypeLocations.childContext
+        'childContext'
       );
     }
     Constructor.childContextTypes = Object.assign(
@@ -339,7 +340,7 @@ var RESERVED_SPEC_KEYS = {
       validateTypeDef(
         Constructor,
         contextTypes,
-        ReactPropTypeLocations.context
+        'context'
       );
     }
     Constructor.contextTypes = Object.assign(
@@ -367,7 +368,7 @@ var RESERVED_SPEC_KEYS = {
       validateTypeDef(
         Constructor,
         propTypes,
-        ReactPropTypeLocations.prop
+        'prop'
       );
     }
     Constructor.propTypes = Object.assign(
@@ -382,7 +383,11 @@ var RESERVED_SPEC_KEYS = {
   autobind: function() {}, // noop
 };
 
-function validateTypeDef(Constructor, typeDef, location) {
+function validateTypeDef(
+  Constructor,
+  typeDef,
+  location: ReactPropTypeLocations,
+) {
   for (var propName in typeDef) {
     if (typeDef.hasOwnProperty(propName)) {
       // use a warning instead of an invariant so components

--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -21,7 +21,6 @@
 var ReactCurrentOwner = require('ReactCurrentOwner');
 var ReactComponentTreeHook = require('ReactComponentTreeHook');
 var ReactElement = require('ReactElement');
-var ReactPropTypeLocations = require('ReactPropTypeLocations');
 
 var checkReactTypeSpec = require('checkReactTypeSpec');
 
@@ -166,7 +165,7 @@ function validatePropTypes(element) {
     checkReactTypeSpec(
       componentClass.propTypes,
       element.props,
-      ReactPropTypeLocations.prop,
+      'prop',
       name,
       element,
       null

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -14,7 +14,6 @@
 var PropTypes;
 var React;
 var ReactFragment;
-var ReactPropTypeLocations;
 var ReactTestUtils;
 var ReactPropTypesSecret;
 
@@ -27,7 +26,7 @@ function typeCheckFail(declaration, value, message) {
     props,
     'testProp',
     'testComponent',
-    ReactPropTypeLocations.prop,
+    'prop',
     null,
     ReactPropTypesSecret
   );
@@ -45,7 +44,7 @@ function typeCheckFailRequiredValues(declaration) {
     props1,
     'testProp',
     'testComponent',
-    ReactPropTypeLocations.prop,
+    'prop',
     null,
     ReactPropTypesSecret
   );
@@ -56,7 +55,7 @@ function typeCheckFailRequiredValues(declaration) {
     props2,
     'testProp',
     'testComponent',
-    ReactPropTypeLocations.prop,
+    'prop',
     null,
     ReactPropTypesSecret
   );
@@ -67,7 +66,7 @@ function typeCheckFailRequiredValues(declaration) {
     props3,
     'testProp',
     'testComponent',
-    ReactPropTypeLocations.prop,
+    'prop',
     null,
     ReactPropTypesSecret
   );
@@ -81,7 +80,7 @@ function typeCheckPass(declaration, value) {
     props,
     'testProp',
     'testComponent',
-    ReactPropTypeLocations.prop,
+    'prop',
     null,
     ReactPropTypesSecret
   );
@@ -112,7 +111,6 @@ describe('ReactPropTypes', function() {
     PropTypes = require('ReactPropTypes');
     React = require('React');
     ReactFragment = require('ReactFragment');
-    ReactPropTypeLocations = require('ReactPropTypeLocations');
     ReactTestUtils = require('ReactTestUtils');
     ReactPropTypesSecret = require('ReactPropTypesSecret');
   });

--- a/src/renderers/dom/client/wrappers/LinkedValueUtils.js
+++ b/src/renderers/dom/client/wrappers/LinkedValueUtils.js
@@ -12,7 +12,6 @@
 'use strict';
 
 var React = require('React');
-var ReactPropTypeLocations = require('ReactPropTypeLocations');
 var ReactPropTypesSecret = require('ReactPropTypesSecret');
 
 var invariant = require('invariant');
@@ -110,7 +109,7 @@ var LinkedValueUtils = {
           props,
           propName,
           tagName,
-          ReactPropTypeLocations.prop,
+          'prop',
           null,
           ReactPropTypesSecret
         );

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -21,7 +21,6 @@ var ReactNodeTypes = require('ReactNodeTypes');
 var ReactReconciler = require('ReactReconciler');
 
 if (__DEV__) {
-  var ReactPropTypeLocations = require('ReactPropTypeLocations');
   var checkReactTypeSpec = require('checkReactTypeSpec');
 }
 
@@ -30,6 +29,8 @@ var invariant = require('invariant');
 var shallowEqual = require('shallowEqual');
 var shouldUpdateReactComponent = require('shouldUpdateReactComponent');
 var warning = require('warning');
+
+import type { ReactPropTypeLocations } from 'ReactPropTypeLocations';
 
 var CompositeTypes = {
   ImpureClass: 0,
@@ -617,7 +618,7 @@ var ReactCompositeComponentMixin = {
         this._checkContextTypes(
           Component.contextTypes,
           maskedContext,
-          ReactPropTypeLocations.context
+          'context'
         );
       }
     }
@@ -658,7 +659,7 @@ var ReactCompositeComponentMixin = {
         this._checkContextTypes(
           Component.childContextTypes,
           childContext,
-          ReactPropTypeLocations.childContext
+          'childContext'
         );
       }
       for (var name in childContext) {
@@ -682,7 +683,11 @@ var ReactCompositeComponentMixin = {
    * @param {string} location e.g. "prop", "context", "child context"
    * @private
    */
-  _checkContextTypes: function(typeSpecs, values, location) {
+  _checkContextTypes: function(
+    typeSpecs,
+    values,
+    location: ReactPropTypeLocations,
+  ) {
     if (__DEV__) {
       checkReactTypeSpec(
         typeSpecs,

--- a/src/shared/types/ReactPropTypeLocationNames.js
+++ b/src/shared/types/ReactPropTypeLocationNames.js
@@ -12,14 +12,18 @@
 
 'use strict';
 
+import type { ReactPropTypeLocations } from 'ReactPropTypeLocations';
+
+type NamesType = {[key: ReactPropTypeLocations]: string};
+
 var ReactPropTypeLocationNames = {};
 
 if (__DEV__) {
-  ReactPropTypeLocationNames = {
+  ReactPropTypeLocationNames = ({
     prop: 'prop',
     context: 'context',
     childContext: 'child context',
-  };
+  }: NamesType);
 }
 
 module.exports = ReactPropTypeLocationNames;

--- a/src/shared/types/ReactPropTypeLocations.js
+++ b/src/shared/types/ReactPropTypeLocations.js
@@ -12,12 +12,7 @@
 
 'use strict';
 
-var keyMirror = require('keyMirror');
-
-var ReactPropTypeLocations = keyMirror({
-  prop: null,
-  context: null,
-  childContext: null,
-});
-
-module.exports = ReactPropTypeLocations;
+export type ReactPropTypeLocations =
+  'prop' |
+  'context' |
+  'childContext';

--- a/src/shared/types/checkReactTypeSpec.js
+++ b/src/shared/types/checkReactTypeSpec.js
@@ -17,6 +17,8 @@ var ReactPropTypesSecret = require('ReactPropTypesSecret');
 var invariant = require('invariant');
 var warning = require('warning');
 
+import type { ReactPropTypeLocations } from 'ReactPropTypeLocations';
+
 var ReactComponentTreeHook;
 
 if (
@@ -46,7 +48,14 @@ var loggedTypeFailures = {};
  * @param {?number} debugID The React component instance that is being type-checked
  * @private
  */
-function checkReactTypeSpec(typeSpecs, values, location, componentName, element, debugID) {
+function checkReactTypeSpec(
+  typeSpecs,
+  values,
+  location: ReactPropTypeLocations,
+  componentName,
+  element,
+  debugID,
+) {
   for (var typeSpecName in typeSpecs) {
     if (typeSpecs.hasOwnProperty(typeSpecName)) {
       var error;


### PR DESCRIPTION
This one involves a bit more work as I added "phantom" flow types to a bunch of places where the type is a ReactPropTypeLocations even though those files are not `@flow` yet.

A good side effect is that `ReactPropTypeLocationNames` keys are now correctly typed, this means that they cannot go out of sync without breaking flow :)

<img width="532" alt="screen shot 2016-08-27 at 8 31 21 pm" src="https://cloud.githubusercontent.com/assets/197597/18031448/16762cc0-6c96-11e6-9df4-d1c12667d822.png">
