### PR TITLE
Changed to !document.documentMode

### DIFF
--- a/src/renderers/dom/client/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/ChangeEventPlugin.js
@@ -81,7 +81,7 @@ var doesChangeEventBubble = false;
 if (ExecutionEnvironment.canUseDOM) {
   // See `handleChange` comment below
   doesChangeEventBubble = isEventSupported('change') && (
-    !('documentMode' in document) || document.documentMode > 8
+    !document.documentMode || document.documentMode > 8
   );
 }
 
@@ -165,7 +165,7 @@ if (ExecutionEnvironment.canUseDOM) {
   // IE9 claims to support the input event but fails to trigger it when
   // deleting text, so we ignore its input events.
   isInputEventSupported = isEventSupported('input') && (
-    !('documentMode' in document) || document.documentMode > 9
+    !document.documentMode || document.documentMode > 9
   );
 }
 


### PR DESCRIPTION
Line 124 of ChangeEventPlugin.js

isInputEventSupported = isEventSupported('input') && (!('documentMode' in document) || document.documentMode > 11);

Is incorrectly returning false in non-IE browsers when paired with some 3rd party code, specifically

!('documentMode' in document)

Is returning false because Google Tag Manager in this case is setting document.documentMode to undefined. This is causing these errors on input fields

Uncaught TypeError: activeElement.detachEvent is not a function
TypeError·Uncaught TypeError: Cannot delete property 'value' of #<HTMLInputElement>

A better check in this case is

!document.documentMode

As this would still accomplish the intended check while minimizing conflicts with other codebases

I have found a couple of other instances of this issue:
#7421
#5920


