### PR TITLE
Remove keyMirror in TopLevelTypes

### DIFF
--- a/src/renderers/dom/client/ReactBrowserEventEmitter.js
+++ b/src/renderers/dom/client/ReactBrowserEventEmitter.js
@@ -11,7 +11,6 @@
 
 'use strict';
 
-var EventConstants = require('EventConstants');
 var EventPluginRegistry = require('EventPluginRegistry');
 var ReactEventEmitterMixin = require('ReactEventEmitterMixin');
 var ViewportMetrics = require('ViewportMetrics');
@@ -241,23 +240,22 @@ var ReactBrowserEventEmitter = Object.assign({}, ReactEventEmitterMixin, {
     var dependencies =
       EventPluginRegistry.registrationNameDependencies[registrationName];
 
-    var topLevelTypes = EventConstants.topLevelTypes;
     for (var i = 0; i < dependencies.length; i++) {
       var dependency = dependencies[i];
       if (!(
             isListening.hasOwnProperty(dependency) &&
             isListening[dependency]
           )) {
-        if (dependency === topLevelTypes.topWheel) {
+        if (dependency === 'topWheel') {
           if (isEventSupported('wheel')) {
             ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(
-              topLevelTypes.topWheel,
+              'topWheel',
               'wheel',
               mountAt
             );
           } else if (isEventSupported('mousewheel')) {
             ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(
-              topLevelTypes.topWheel,
+              'topWheel',
               'mousewheel',
               mountAt
             );
@@ -265,37 +263,37 @@ var ReactBrowserEventEmitter = Object.assign({}, ReactEventEmitterMixin, {
             // Firefox needs to capture a different mouse scroll event.
             // @see http://www.quirksmode.org/dom/events/tests/scroll.html
             ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(
-              topLevelTypes.topWheel,
+              'topWheel',
               'DOMMouseScroll',
               mountAt
             );
           }
-        } else if (dependency === topLevelTypes.topScroll) {
+        } else if (dependency === 'topScroll') {
 
           if (isEventSupported('scroll', true)) {
             ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
-              topLevelTypes.topScroll,
+              'topScroll',
               'scroll',
               mountAt
             );
           } else {
             ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(
-              topLevelTypes.topScroll,
+              'topScroll',
               'scroll',
               ReactBrowserEventEmitter.ReactEventListener.WINDOW_HANDLE
             );
           }
-        } else if (dependency === topLevelTypes.topFocus ||
-            dependency === topLevelTypes.topBlur) {
+        } else if (dependency === 'topFocus' ||
+            dependency === 'topBlur') {
 
           if (isEventSupported('focus', true)) {
             ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
-              topLevelTypes.topFocus,
+              'topFocus',
               'focus',
               mountAt
             );
             ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
-              topLevelTypes.topBlur,
+              'topBlur',
               'blur',
               mountAt
             );
@@ -303,20 +301,20 @@ var ReactBrowserEventEmitter = Object.assign({}, ReactEventEmitterMixin, {
             // IE has `focusin` and `focusout` events which bubble.
             // @see http://www.quirksmode.org/blog/archives/2008/04/delegating_the.html
             ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(
-              topLevelTypes.topFocus,
+              'topFocus',
               'focusin',
               mountAt
             );
             ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(
-              topLevelTypes.topBlur,
+              'topBlur',
               'focusout',
               mountAt
             );
           }
 
           // to make sure blur and focus event listeners are only attached once
-          isListening[topLevelTypes.topBlur] = true;
-          isListening[topLevelTypes.topFocus] = true;
+          isListening.topBlur = true;
+          isListening.topFocus = true;
         } else if (topEventMapping.hasOwnProperty(dependency)) {
           ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(
             dependency,

--- a/src/renderers/dom/client/eventPlugins/BeforeInputEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/BeforeInputEventPlugin.js
@@ -11,7 +11,6 @@
 
 'use strict';
 
-var EventConstants = require('EventConstants');
 var EventPropagators = require('EventPropagators');
 var ExecutionEnvironment = require('ExecutionEnvironment');
 var FallbackCompositionState = require('FallbackCompositionState');
@@ -19,6 +18,8 @@ var SyntheticCompositionEvent = require('SyntheticCompositionEvent');
 var SyntheticInputEvent = require('SyntheticInputEvent');
 
 var keyOf = require('keyOf');
+
+import type { TopLevelTypes } from 'EventConstants';
 
 var END_KEYCODES = [9, 13, 27, 32]; // Tab, Return, Esc, Space
 var START_KEYCODE = 229;
@@ -70,8 +71,6 @@ function isPresto() {
 var SPACEBAR_CODE = 32;
 var SPACEBAR_CHAR = String.fromCharCode(SPACEBAR_CODE);
 
-var topLevelTypes = EventConstants.topLevelTypes;
-
 // Events and their corresponding property names.
 var eventTypes = {
   beforeInput: {
@@ -80,10 +79,10 @@ var eventTypes = {
       captured: keyOf({onBeforeInputCapture: null}),
     },
     dependencies: [
-      topLevelTypes.topCompositionEnd,
-      topLevelTypes.topKeyPress,
-      topLevelTypes.topTextInput,
-      topLevelTypes.topPaste,
+      'topCompositionEnd',
+      'topKeyPress',
+      'topTextInput',
+      'topPaste',
     ],
   },
   compositionEnd: {
@@ -92,12 +91,12 @@ var eventTypes = {
       captured: keyOf({onCompositionEndCapture: null}),
     },
     dependencies: [
-      topLevelTypes.topBlur,
-      topLevelTypes.topCompositionEnd,
-      topLevelTypes.topKeyDown,
-      topLevelTypes.topKeyPress,
-      topLevelTypes.topKeyUp,
-      topLevelTypes.topMouseDown,
+      'topBlur',
+      'topCompositionEnd',
+      'topKeyDown',
+      'topKeyPress',
+      'topKeyUp',
+      'topMouseDown',
     ],
   },
   compositionStart: {
@@ -106,12 +105,12 @@ var eventTypes = {
       captured: keyOf({onCompositionStartCapture: null}),
     },
     dependencies: [
-      topLevelTypes.topBlur,
-      topLevelTypes.topCompositionStart,
-      topLevelTypes.topKeyDown,
-      topLevelTypes.topKeyPress,
-      topLevelTypes.topKeyUp,
-      topLevelTypes.topMouseDown,
+      'topBlur',
+      'topCompositionStart',
+      'topKeyDown',
+      'topKeyPress',
+      'topKeyUp',
+      'topMouseDown',
     ],
   },
   compositionUpdate: {
@@ -120,12 +119,12 @@ var eventTypes = {
       captured: keyOf({onCompositionUpdateCapture: null}),
     },
     dependencies: [
-      topLevelTypes.topBlur,
-      topLevelTypes.topCompositionUpdate,
-      topLevelTypes.topKeyDown,
-      topLevelTypes.topKeyPress,
-      topLevelTypes.topKeyUp,
-      topLevelTypes.topMouseDown,
+      'topBlur',
+      'topCompositionUpdate',
+      'topKeyDown',
+      'topKeyPress',
+      'topKeyUp',
+      'topMouseDown',
     ],
   },
 };
@@ -155,11 +154,11 @@ function isKeypressCommand(nativeEvent) {
  */
 function getCompositionEventType(topLevelType) {
   switch (topLevelType) {
-    case topLevelTypes.topCompositionStart:
+    case 'topCompositionStart':
       return eventTypes.compositionStart;
-    case topLevelTypes.topCompositionEnd:
+    case 'topCompositionEnd':
       return eventTypes.compositionEnd;
-    case topLevelTypes.topCompositionUpdate:
+    case 'topCompositionUpdate':
       return eventTypes.compositionUpdate;
   }
 }
@@ -174,7 +173,7 @@ function getCompositionEventType(topLevelType) {
  */
 function isFallbackCompositionStart(topLevelType, nativeEvent) {
   return (
-    topLevelType === topLevelTypes.topKeyDown &&
+    topLevelType === 'topKeyDown' &&
     nativeEvent.keyCode === START_KEYCODE
   );
 }
@@ -188,16 +187,16 @@ function isFallbackCompositionStart(topLevelType, nativeEvent) {
  */
 function isFallbackCompositionEnd(topLevelType, nativeEvent) {
   switch (topLevelType) {
-    case topLevelTypes.topKeyUp:
+    case 'topKeyUp':
       // Command keys insert or clear IME input.
       return (END_KEYCODES.indexOf(nativeEvent.keyCode) !== -1);
-    case topLevelTypes.topKeyDown:
+    case 'topKeyDown':
       // Expect IME keyCode on each keydown. If we get any other
       // code we must have exited earlier.
       return (nativeEvent.keyCode !== START_KEYCODE);
-    case topLevelTypes.topKeyPress:
-    case topLevelTypes.topMouseDown:
-    case topLevelTypes.topBlur:
+    case 'topKeyPress':
+    case 'topMouseDown':
+    case 'topBlur':
       // Events are not possible without cancelling IME.
       return true;
     default:
@@ -291,11 +290,11 @@ function extractCompositionEvent(
  * @param {object} nativeEvent Native browser event.
  * @return {?string} The string corresponding to this `beforeInput` event.
  */
-function getNativeBeforeInputChars(topLevelType, nativeEvent) {
+function getNativeBeforeInputChars(topLevelType: TopLevelTypes, nativeEvent) {
   switch (topLevelType) {
-    case topLevelTypes.topCompositionEnd:
+    case 'topCompositionEnd':
       return getDataFromCustomEvent(nativeEvent);
-    case topLevelTypes.topKeyPress:
+    case 'topKeyPress':
       /**
        * If native `textInput` events are available, our goal is to make
        * use of them. However, there is a special case: the spacebar key.
@@ -318,7 +317,7 @@ function getNativeBeforeInputChars(topLevelType, nativeEvent) {
       hasSpaceKeypress = true;
       return SPACEBAR_CHAR;
 
-    case topLevelTypes.topTextInput:
+    case 'topTextInput':
       // Record the characters to be added to the DOM.
       var chars = nativeEvent.data;
 
@@ -345,12 +344,12 @@ function getNativeBeforeInputChars(topLevelType, nativeEvent) {
  * @param {object} nativeEvent Native browser event.
  * @return {?string} The fallback string for this `beforeInput` event.
  */
-function getFallbackBeforeInputChars(topLevelType, nativeEvent) {
+function getFallbackBeforeInputChars(topLevelType: TopLevelTypes, nativeEvent) {
   // If we are currently composing (IME) and using a fallback to do so,
   // try to extract the composed characters from the fallback object.
   if (currentComposition) {
     if (
-      topLevelType === topLevelTypes.topCompositionEnd ||
+      topLevelType === 'topCompositionEnd' ||
       isFallbackCompositionEnd(topLevelType, nativeEvent)
     ) {
       var chars = currentComposition.getData();
@@ -362,11 +361,11 @@ function getFallbackBeforeInputChars(topLevelType, nativeEvent) {
   }
 
   switch (topLevelType) {
-    case topLevelTypes.topPaste:
+    case 'topPaste':
       // If a paste event occurs after a keypress, throw out the input
       // chars. Paste events should not lead to BeforeInput events.
       return null;
-    case topLevelTypes.topKeyPress:
+    case 'topKeyPress':
       /**
        * As of v27, Firefox may fire keypress events even when no character
        * will be inserted. A few possibilities:
@@ -387,7 +386,7 @@ function getFallbackBeforeInputChars(topLevelType, nativeEvent) {
         return String.fromCharCode(nativeEvent.which);
       }
       return null;
-    case topLevelTypes.topCompositionEnd:
+    case 'topCompositionEnd':
       return useFallbackCompositionData ? null : nativeEvent.data;
     default:
       return null;

--- a/src/renderers/dom/client/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/ChangeEventPlugin.js
@@ -11,7 +11,6 @@
 
 'use strict';
 
-var EventConstants = require('EventConstants');
 var EventPluginHub = require('EventPluginHub');
 var EventPropagators = require('EventPropagators');
 var ExecutionEnvironment = require('ExecutionEnvironment');
@@ -25,8 +24,6 @@ var isEventSupported = require('isEventSupported');
 var isTextInputElement = require('isTextInputElement');
 var keyOf = require('keyOf');
 
-var topLevelTypes = EventConstants.topLevelTypes;
-
 
 var eventTypes = {
   change: {
@@ -35,14 +32,14 @@ var eventTypes = {
       captured: keyOf({onChangeCapture: null}),
     },
     dependencies: [
-      topLevelTypes.topBlur,
-      topLevelTypes.topChange,
-      topLevelTypes.topClick,
-      topLevelTypes.topFocus,
-      topLevelTypes.topInput,
-      topLevelTypes.topKeyDown,
-      topLevelTypes.topKeyUp,
-      topLevelTypes.topSelectionChange,
+      'topBlur',
+      'topChange',
+      'topClick',
+      'topFocus',
+      'topInput',
+      'topKeyDown',
+      'topKeyUp',
+      'topSelectionChange',
     ],
   },
 };
@@ -136,7 +133,7 @@ function getTargetInstForChangeEvent(
   topLevelType,
   targetInst
 ) {
-  if (topLevelType === topLevelTypes.topChange) {
+  if (topLevelType === 'topChange') {
     return targetInst;
   }
 }
@@ -146,12 +143,12 @@ function handleEventsForChangeEventIE8(
   target,
   targetInst
 ) {
-  if (topLevelType === topLevelTypes.topFocus) {
+  if (topLevelType === 'topFocus') {
     // stopWatching() should be a noop here but we call it just in case we
     // missed a blur event somehow.
     stopWatchingForChangeEventIE8();
     startWatchingForChangeEventIE8(target, targetInst);
-  } else if (topLevelType === topLevelTypes.topBlur) {
+  } else if (topLevelType === 'topBlur') {
     stopWatchingForChangeEventIE8();
   }
 }
@@ -212,7 +209,7 @@ function handleEventsForInputEventPolyfill(
   target,
   targetInst
 ) {
-  if (topLevelType === topLevelTypes.topFocus) {
+  if (topLevelType === 'topFocus') {
     // In IE8, we can capture almost all .value changes by adding a
     // propertychange handler and looking for events with propertyName
     // equal to 'value'
@@ -228,7 +225,7 @@ function handleEventsForInputEventPolyfill(
     // missed a blur event somehow.
     stopWatchingForValueChange();
     startWatchingForValueChange(target, targetInst);
-  } else if (topLevelType === topLevelTypes.topBlur) {
+  } else if (topLevelType === 'topBlur') {
     stopWatchingForValueChange();
   }
 }
@@ -238,9 +235,9 @@ function getTargetInstForInputEventPolyfill(
   topLevelType,
   targetInst
 ) {
-  if (topLevelType === topLevelTypes.topSelectionChange ||
-      topLevelType === topLevelTypes.topKeyUp ||
-      topLevelType === topLevelTypes.topKeyDown) {
+  if (topLevelType === 'topSelectionChange' ||
+      topLevelType === 'topKeyUp' ||
+      topLevelType === 'topKeyDown') {
     // On the selectionchange event, the target is just document which isn't
     // helpful for us so just check activeElement instead.
     //
@@ -274,7 +271,7 @@ function getTargetInstForClickEvent(
   topLevelType,
   targetInst
 ) {
-  if (topLevelType === topLevelTypes.topClick) {
+  if (topLevelType === 'topClick') {
     return getInstIfValueChanged(targetInst);
   }
 }
@@ -284,8 +281,8 @@ function getTargetInstForInputOrChangeEvent(
   targetInst
 ) {
   if (
-    topLevelType === topLevelTypes.topInput ||
-    topLevelType === topLevelTypes.topChange
+    topLevelType === 'topInput' ||
+    topLevelType === 'topChange'
   ) {
     return getInstIfValueChanged(targetInst);
   }

--- a/src/renderers/dom/client/eventPlugins/EnterLeaveEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/EnterLeaveEventPlugin.js
@@ -11,28 +11,25 @@
 
 'use strict';
 
-var EventConstants = require('EventConstants');
 var EventPropagators = require('EventPropagators');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var SyntheticMouseEvent = require('SyntheticMouseEvent');
 
 var keyOf = require('keyOf');
 
-var topLevelTypes = EventConstants.topLevelTypes;
-
 var eventTypes = {
   mouseEnter: {
     registrationName: keyOf({onMouseEnter: null}),
     dependencies: [
-      topLevelTypes.topMouseOut,
-      topLevelTypes.topMouseOver,
+      'topMouseOut',
+      'topMouseOver',
     ],
   },
   mouseLeave: {
     registrationName: keyOf({onMouseLeave: null}),
     dependencies: [
-      topLevelTypes.topMouseOut,
-      topLevelTypes.topMouseOver,
+      'topMouseOut',
+      'topMouseOver',
     ],
   },
 };
@@ -54,12 +51,12 @@ var EnterLeaveEventPlugin = {
     nativeEvent,
     nativeEventTarget
   ) {
-    if (topLevelType === topLevelTypes.topMouseOver &&
+    if (topLevelType === 'topMouseOver' &&
         (nativeEvent.relatedTarget || nativeEvent.fromElement)) {
       return null;
     }
-    if (topLevelType !== topLevelTypes.topMouseOut &&
-        topLevelType !== topLevelTypes.topMouseOver) {
+    if (topLevelType !== 'topMouseOut' &&
+        topLevelType !== 'topMouseOver') {
       // Must not be a mouse in or mouse out - ignoring.
       return null;
     }
@@ -80,7 +77,7 @@ var EnterLeaveEventPlugin = {
 
     var from;
     var to;
-    if (topLevelType === topLevelTypes.topMouseOut) {
+    if (topLevelType === 'topMouseOut') {
       from = targetInst;
       var related = nativeEvent.relatedTarget || nativeEvent.toElement;
       to = related ?

--- a/src/renderers/dom/client/eventPlugins/SelectEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/SelectEventPlugin.js
@@ -11,7 +11,6 @@
 
 'use strict';
 
-var EventConstants = require('EventConstants');
 var EventPropagators = require('EventPropagators');
 var ExecutionEnvironment = require('ExecutionEnvironment');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
@@ -22,8 +21,6 @@ var getActiveElement = require('getActiveElement');
 var isTextInputElement = require('isTextInputElement');
 var keyOf = require('keyOf');
 var shallowEqual = require('shallowEqual');
-
-var topLevelTypes = EventConstants.topLevelTypes;
 
 var skipSelectionChangeEvent = (
   ExecutionEnvironment.canUseDOM &&
@@ -38,14 +35,14 @@ var eventTypes = {
       captured: keyOf({onSelectCapture: null}),
     },
     dependencies: [
-      topLevelTypes.topBlur,
-      topLevelTypes.topContextMenu,
-      topLevelTypes.topFocus,
-      topLevelTypes.topKeyDown,
-      topLevelTypes.topKeyUp,
-      topLevelTypes.topMouseDown,
-      topLevelTypes.topMouseUp,
-      topLevelTypes.topSelectionChange,
+      'topBlur',
+      'topContextMenu',
+      'topFocus',
+      'topKeyDown',
+      'topKeyUp',
+      'topMouseDown',
+      'topMouseUp',
+      'topSelectionChange',
     ],
   },
 };
@@ -168,7 +165,7 @@ var SelectEventPlugin = {
 
     switch (topLevelType) {
       // Track the input node that has focus.
-      case topLevelTypes.topFocus:
+      case 'topFocus':
         if (isTextInputElement(targetNode) ||
             targetNode.contentEditable === 'true') {
           activeElement = targetNode;
@@ -176,7 +173,7 @@ var SelectEventPlugin = {
           lastSelection = null;
         }
         break;
-      case topLevelTypes.topBlur:
+      case 'topBlur':
         activeElement = null;
         activeElementInst = null;
         lastSelection = null;
@@ -184,11 +181,11 @@ var SelectEventPlugin = {
 
       // Don't fire the event while the user is dragging. This matches the
       // semantics of the native select event.
-      case topLevelTypes.topMouseDown:
+      case 'topMouseDown':
         mouseDown = true;
         break;
-      case topLevelTypes.topContextMenu:
-      case topLevelTypes.topMouseUp:
+      case 'topContextMenu':
+      case 'topMouseUp':
         mouseDown = false;
         return constructSelectEvent(nativeEvent, nativeEventTarget);
 
@@ -201,13 +198,13 @@ var SelectEventPlugin = {
       // keyup, but we check on keydown as well in the case of holding down a
       // key, when multiple keydown events are fired but only one keyup is.
       // This is also our approach for IE handling, for the reason above.
-      case topLevelTypes.topSelectionChange:
+      case 'topSelectionChange':
         if (skipSelectionChangeEvent) {
           break;
         }
         // falls through
-      case topLevelTypes.topKeyDown:
-      case topLevelTypes.topKeyUp:
+      case 'topKeyDown':
+      case 'topKeyUp':
         return constructSelectEvent(nativeEvent, nativeEventTarget);
     }
 

--- a/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
@@ -11,7 +11,6 @@
 
 'use strict';
 
-var EventConstants = require('EventConstants');
 var EventListener = require('EventListener');
 var EventPropagators = require('EventPropagators');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
@@ -31,8 +30,6 @@ var emptyFunction = require('emptyFunction');
 var getEventCharCode = require('getEventCharCode');
 var invariant = require('invariant');
 var keyOf = require('keyOf');
-
-var topLevelTypes = EventConstants.topLevelTypes;
 
 var eventTypes = {
   abort: {
@@ -505,39 +502,39 @@ var SimpleEventPlugin = {
     }
     var EventConstructor;
     switch (topLevelType) {
-      case topLevelTypes.topAbort:
-      case topLevelTypes.topCanPlay:
-      case topLevelTypes.topCanPlayThrough:
-      case topLevelTypes.topDurationChange:
-      case topLevelTypes.topEmptied:
-      case topLevelTypes.topEncrypted:
-      case topLevelTypes.topEnded:
-      case topLevelTypes.topError:
-      case topLevelTypes.topInput:
-      case topLevelTypes.topInvalid:
-      case topLevelTypes.topLoad:
-      case topLevelTypes.topLoadedData:
-      case topLevelTypes.topLoadedMetadata:
-      case topLevelTypes.topLoadStart:
-      case topLevelTypes.topPause:
-      case topLevelTypes.topPlay:
-      case topLevelTypes.topPlaying:
-      case topLevelTypes.topProgress:
-      case topLevelTypes.topRateChange:
-      case topLevelTypes.topReset:
-      case topLevelTypes.topSeeked:
-      case topLevelTypes.topSeeking:
-      case topLevelTypes.topStalled:
-      case topLevelTypes.topSubmit:
-      case topLevelTypes.topSuspend:
-      case topLevelTypes.topTimeUpdate:
-      case topLevelTypes.topVolumeChange:
-      case topLevelTypes.topWaiting:
+      case 'topAbort':
+      case 'topCanPlay':
+      case 'topCanPlayThrough':
+      case 'topDurationChange':
+      case 'topEmptied':
+      case 'topEncrypted':
+      case 'topEnded':
+      case 'topError':
+      case 'topInput':
+      case 'topInvalid':
+      case 'topLoad':
+      case 'topLoadedData':
+      case 'topLoadedMetadata':
+      case 'topLoadStart':
+      case 'topPause':
+      case 'topPlay':
+      case 'topPlaying':
+      case 'topProgress':
+      case 'topRateChange':
+      case 'topReset':
+      case 'topSeeked':
+      case 'topSeeking':
+      case 'topStalled':
+      case 'topSubmit':
+      case 'topSuspend':
+      case 'topTimeUpdate':
+      case 'topVolumeChange':
+      case 'topWaiting':
         // HTML Events
         // @see http://www.w3.org/TR/html5/index.html#events-0
         EventConstructor = SyntheticEvent;
         break;
-      case topLevelTypes.topKeyPress:
+      case 'topKeyPress':
         // Firefox creates a keypress event for function keys too. This removes
         // the unwanted keypress events. Enter is however both printable and
         // non-printable. One would expect Tab to be as well (but it isn't).
@@ -545,63 +542,63 @@ var SimpleEventPlugin = {
           return null;
         }
         /* falls through */
-      case topLevelTypes.topKeyDown:
-      case topLevelTypes.topKeyUp:
+      case 'topKeyDown':
+      case 'topKeyUp':
         EventConstructor = SyntheticKeyboardEvent;
         break;
-      case topLevelTypes.topBlur:
-      case topLevelTypes.topFocus:
+      case 'topBlur':
+      case 'topFocus':
         EventConstructor = SyntheticFocusEvent;
         break;
-      case topLevelTypes.topClick:
+      case 'topClick':
         // Firefox creates a click event on right mouse clicks. This removes the
         // unwanted click events.
         if (nativeEvent.button === 2) {
           return null;
         }
         /* falls through */
-      case topLevelTypes.topContextMenu:
-      case topLevelTypes.topDoubleClick:
-      case topLevelTypes.topMouseDown:
-      case topLevelTypes.topMouseMove:
-      case topLevelTypes.topMouseOut:
-      case topLevelTypes.topMouseOver:
-      case topLevelTypes.topMouseUp:
+      case 'topContextMenu':
+      case 'topDoubleClick':
+      case 'topMouseDown':
+      case 'topMouseMove':
+      case 'topMouseOut':
+      case 'topMouseOver':
+      case 'topMouseUp':
         EventConstructor = SyntheticMouseEvent;
         break;
-      case topLevelTypes.topDrag:
-      case topLevelTypes.topDragEnd:
-      case topLevelTypes.topDragEnter:
-      case topLevelTypes.topDragExit:
-      case topLevelTypes.topDragLeave:
-      case topLevelTypes.topDragOver:
-      case topLevelTypes.topDragStart:
-      case topLevelTypes.topDrop:
+      case 'topDrag':
+      case 'topDragEnd':
+      case 'topDragEnter':
+      case 'topDragExit':
+      case 'topDragLeave':
+      case 'topDragOver':
+      case 'topDragStart':
+      case 'topDrop':
         EventConstructor = SyntheticDragEvent;
         break;
-      case topLevelTypes.topTouchCancel:
-      case topLevelTypes.topTouchEnd:
-      case topLevelTypes.topTouchMove:
-      case topLevelTypes.topTouchStart:
+      case 'topTouchCancel':
+      case 'topTouchEnd':
+      case 'topTouchMove':
+      case 'topTouchStart':
         EventConstructor = SyntheticTouchEvent;
         break;
-      case topLevelTypes.topAnimationEnd:
-      case topLevelTypes.topAnimationIteration:
-      case topLevelTypes.topAnimationStart:
+      case 'topAnimationEnd':
+      case 'topAnimationIteration':
+      case 'topAnimationStart':
         EventConstructor = SyntheticAnimationEvent;
         break;
-      case topLevelTypes.topTransitionEnd:
+      case 'topTransitionEnd':
         EventConstructor = SyntheticTransitionEvent;
         break;
-      case topLevelTypes.topScroll:
+      case 'topScroll':
         EventConstructor = SyntheticUIEvent;
         break;
-      case topLevelTypes.topWheel:
+      case 'topWheel':
         EventConstructor = SyntheticWheelEvent;
         break;
-      case topLevelTypes.topCopy:
-      case topLevelTypes.topCut:
-      case topLevelTypes.topPaste:
+      case 'topCopy':
+      case 'topCut':
+      case 'topPaste':
         EventConstructor = SyntheticClipboardEvent;
         break;
     }

--- a/src/renderers/dom/client/eventPlugins/TapEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/TapEventPlugin.js
@@ -11,7 +11,6 @@
 
 'use strict';
 
-var EventConstants = require('EventConstants');
 var EventPluginUtils = require('EventPluginUtils');
 var EventPropagators = require('EventPropagators');
 var SyntheticUIEvent = require('SyntheticUIEvent');
@@ -19,7 +18,6 @@ var TouchEventUtils = require('TouchEventUtils');
 var ViewportMetrics = require('ViewportMetrics');
 
 var keyOf = require('keyOf');
-var topLevelTypes = EventConstants.topLevelTypes;
 
 var isStartish = EventPluginUtils.isStartish;
 var isEndish = EventPluginUtils.isEndish;
@@ -56,16 +54,16 @@ function getDistance(coords, nativeEvent) {
 }
 
 var touchEvents = [
-  topLevelTypes.topTouchStart,
-  topLevelTypes.topTouchCancel,
-  topLevelTypes.topTouchEnd,
-  topLevelTypes.topTouchMove,
+  'topTouchStart',
+  'topTouchCancel',
+  'topTouchEnd',
+  'topTouchMove',
 ];
 
 var dependencies = [
-  topLevelTypes.topMouseDown,
-  topLevelTypes.topMouseMove,
-  topLevelTypes.topMouseUp,
+  'topMouseDown',
+  'topMouseMove',
+  'topMouseUp',
 ].concat(touchEvents);
 
 var eventTypes = {

--- a/src/renderers/dom/client/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
+++ b/src/renderers/dom/client/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
@@ -12,24 +12,18 @@
 'use strict';
 
 var EnterLeaveEventPlugin;
-var EventConstants;
 var React;
 var ReactDOM;
 var ReactDOMComponentTree;
-
-var topLevelTypes;
 
 describe('EnterLeaveEventPlugin', function() {
   beforeEach(function() {
     jest.resetModuleRegistry();
 
     EnterLeaveEventPlugin = require('EnterLeaveEventPlugin');
-    EventConstants = require('EventConstants');
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactDOMComponentTree = require('ReactDOMComponentTree');
-
-    topLevelTypes = EventConstants.topLevelTypes;
   });
 
   it('should set relatedTarget properly in iframe', function() {
@@ -47,7 +41,7 @@ describe('EnterLeaveEventPlugin', function() {
     var div = ReactDOM.findDOMNode(component);
 
     var extracted = EnterLeaveEventPlugin.extractEvents(
-      topLevelTypes.topMouseOver,
+      'topMouseOver',
       ReactDOMComponentTree.getInstanceFromNode(div),
       {target: div},
       div

--- a/src/renderers/dom/client/eventPlugins/__tests__/SelectEventPlugin-test.js
+++ b/src/renderers/dom/client/eventPlugins/__tests__/SelectEventPlugin-test.js
@@ -11,14 +11,11 @@
 
 'use strict';
 
-var EventConstants;
 var React;
 var ReactDOM;
 var ReactDOMComponentTree;
 var ReactTestUtils;
 var SelectEventPlugin;
-
-var topLevelTypes;
 
 describe('SelectEventPlugin', function() {
   function extract(node, topLevelEvent) {
@@ -31,14 +28,11 @@ describe('SelectEventPlugin', function() {
   }
 
   beforeEach(function() {
-    EventConstants = require('EventConstants');
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactDOMComponentTree = require('ReactDOMComponentTree');
     ReactTestUtils = require('ReactTestUtils');
     SelectEventPlugin = require('SelectEventPlugin');
-
-    topLevelTypes = EventConstants.topLevelTypes;
   });
 
   it('should skip extraction if no listeners are present', function() {
@@ -52,10 +46,10 @@ describe('SelectEventPlugin', function() {
     var node = ReactDOM.findDOMNode(rendered);
     node.focus();
 
-    var mousedown = extract(node, topLevelTypes.topMouseDown);
+    var mousedown = extract(node, 'topMouseDown');
     expect(mousedown).toBe(null);
 
-    var mouseup = extract(node, topLevelTypes.topMouseUp);
+    var mouseup = extract(node, 'topMouseUp');
     expect(mouseup).toBe(null);
   });
 
@@ -77,13 +71,13 @@ describe('SelectEventPlugin', function() {
     node.selectionEnd = 0;
     node.focus();
 
-    var focus = extract(node, topLevelTypes.topFocus);
+    var focus = extract(node, 'topFocus');
     expect(focus).toBe(null);
 
-    var mousedown = extract(node, topLevelTypes.topMouseDown);
+    var mousedown = extract(node, 'topMouseDown');
     expect(mousedown).toBe(null);
 
-    var mouseup = extract(node, topLevelTypes.topMouseUp);
+    var mouseup = extract(node, 'topMouseUp');
     expect(mouseup).not.toBe(null);
     expect(typeof mouseup).toBe('object');
     expect(mouseup.type).toBe('select');

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
@@ -15,7 +15,6 @@
 var emptyFunction = require('emptyFunction');
 
 describe('ReactDOMInput', function() {
-  var EventConstants;
   var React;
   var ReactDOM;
   var ReactDOMServer;
@@ -33,7 +32,6 @@ describe('ReactDOMInput', function() {
 
   beforeEach(function() {
     jest.resetModuleRegistry();
-    EventConstants = require('EventConstants');
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactDOMServer = require('ReactDOMServer');
@@ -273,7 +271,7 @@ describe('ReactDOMInput', function() {
     fakeNativeEvent.target = node;
     fakeNativeEvent.path = [node, container];
     ReactTestUtils.simulateNativeEventOnNode(
-      EventConstants.topLevelTypes.topInput,
+      'topInput',
       node,
       fakeNativeEvent
     );

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -19,7 +19,6 @@ var DOMLazyTree = require('DOMLazyTree');
 var DOMNamespaces = require('DOMNamespaces');
 var DOMProperty = require('DOMProperty');
 var DOMPropertyOperations = require('DOMPropertyOperations');
-var EventConstants = require('EventConstants');
 var EventPluginHub = require('EventPluginHub');
 var EventPluginRegistry = require('EventPluginRegistry');
 var ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
@@ -331,7 +330,7 @@ function trapBubbledEventsLocal() {
     case 'object':
       inst._wrapperState.listeners = [
         ReactBrowserEventEmitter.trapBubbledEvent(
-          EventConstants.topLevelTypes.topLoad,
+          'topLoad',
           'load',
           node
         ),
@@ -346,7 +345,7 @@ function trapBubbledEventsLocal() {
         if (mediaEvents.hasOwnProperty(event)) {
           inst._wrapperState.listeners.push(
             ReactBrowserEventEmitter.trapBubbledEvent(
-              EventConstants.topLevelTypes[event],
+              event,
               mediaEvents[event],
               node
             )
@@ -357,7 +356,7 @@ function trapBubbledEventsLocal() {
     case 'source':
       inst._wrapperState.listeners = [
         ReactBrowserEventEmitter.trapBubbledEvent(
-          EventConstants.topLevelTypes.topError,
+          'topError',
           'error',
           node
         ),
@@ -366,12 +365,12 @@ function trapBubbledEventsLocal() {
     case 'img':
       inst._wrapperState.listeners = [
         ReactBrowserEventEmitter.trapBubbledEvent(
-          EventConstants.topLevelTypes.topError,
+          'topError',
           'error',
           node
         ),
         ReactBrowserEventEmitter.trapBubbledEvent(
-          EventConstants.topLevelTypes.topLoad,
+          'topLoad',
           'load',
           node
         ),
@@ -380,12 +379,12 @@ function trapBubbledEventsLocal() {
     case 'form':
       inst._wrapperState.listeners = [
         ReactBrowserEventEmitter.trapBubbledEvent(
-          EventConstants.topLevelTypes.topReset,
+          'topReset',
           'reset',
           node
         ),
         ReactBrowserEventEmitter.trapBubbledEvent(
-          EventConstants.topLevelTypes.topSubmit,
+          'topSubmit',
           'submit',
           node
         ),
@@ -396,7 +395,7 @@ function trapBubbledEventsLocal() {
     case 'textarea':
       inst._wrapperState.listeners = [
         ReactBrowserEventEmitter.trapBubbledEvent(
-          EventConstants.topLevelTypes.topInvalid,
+          'topInvalid',
           'invalid',
           node
         ),

--- a/src/renderers/native/ReactNativeEventEmitter.js
+++ b/src/renderers/native/ReactNativeEventEmitter.js
@@ -11,7 +11,6 @@
  */
 'use strict';
 
-var EventConstants = require('EventConstants');
 var EventPluginHub = require('EventPluginHub');
 var EventPluginRegistry = require('EventPluginRegistry');
 var ReactEventEmitterMixin = require('ReactEventEmitterMixin');
@@ -20,8 +19,6 @@ var ReactNativeTagHandles = require('ReactNativeTagHandles');
 var ReactUpdates = require('ReactUpdates');
 
 var warning = require('warning');
-
-var topLevelTypes = EventConstants.topLevelTypes;
 
 /**
  * Version of `ReactBrowserEventEmitter` that works on the receiving side of a
@@ -186,8 +183,8 @@ var ReactNativeEventEmitter = {
     changedIndices: Array<number>
   ) {
     var changedTouches =
-      eventTopLevelType === topLevelTypes.topTouchEnd ||
-      eventTopLevelType === topLevelTypes.topTouchCancel ?
+      eventTopLevelType === 'topTouchEnd' ||
+      eventTopLevelType === 'topTouchCancel' ?
       removeTouchesAtIndices(touches, changedIndices) :
       touchSubsequence(touches, changedIndices);
 

--- a/src/renderers/shared/stack/event/EventConstants.js
+++ b/src/renderers/shared/stack/event/EventConstants.js
@@ -11,14 +11,12 @@
 
 'use strict';
 
-var keyMirror = require('keyMirror');
-
 export type PropagationPhases = 'bubbled' | 'captured';
 
 /**
  * Types of raw signals from the browser caught at the top level.
  */
-var topLevelTypes = keyMirror({
+var topLevelTypes = {
   topAbort: null,
   topAnimationEnd: null,
   topAnimationIteration: null,
@@ -87,10 +85,12 @@ var topLevelTypes = keyMirror({
   topVolumeChange: null,
   topWaiting: null,
   topWheel: null,
-});
+};
+
+export type TopLevelTypes = $Enum<typeof topLevelTypes>;
 
 var EventConstants = {
-  topLevelTypes: topLevelTypes,
+  topLevelTypes,
 };
 
 module.exports = EventConstants;

--- a/src/renderers/shared/stack/event/EventPluginUtils.js
+++ b/src/renderers/shared/stack/event/EventPluginUtils.js
@@ -11,7 +11,6 @@
 
 'use strict';
 
-var EventConstants = require('EventConstants');
 var ReactErrorUtils = require('ReactErrorUtils');
 
 var invariant = require('invariant');
@@ -52,21 +51,19 @@ var injection = {
   },
 };
 
-var topLevelTypes = EventConstants.topLevelTypes;
-
 function isEndish(topLevelType) {
-  return topLevelType === topLevelTypes.topMouseUp ||
-         topLevelType === topLevelTypes.topTouchEnd ||
-         topLevelType === topLevelTypes.topTouchCancel;
+  return topLevelType === 'topMouseUp' ||
+         topLevelType === 'topTouchEnd' ||
+         topLevelType === 'topTouchCancel';
 }
 
 function isMoveish(topLevelType) {
-  return topLevelType === topLevelTypes.topMouseMove ||
-         topLevelType === topLevelTypes.topTouchMove;
+  return topLevelType === 'topMouseMove' ||
+         topLevelType === 'topTouchMove';
 }
 function isStartish(topLevelType) {
-  return topLevelType === topLevelTypes.topMouseDown ||
-         topLevelType === topLevelTypes.topTouchStart;
+  return topLevelType === 'topMouseDown' ||
+         topLevelType === 'topTouchStart';
 }
 
 

--- a/src/renderers/shared/stack/event/eventPlugins/ResponderEventPlugin.js
+++ b/src/renderers/shared/stack/event/eventPlugins/ResponderEventPlugin.js
@@ -11,7 +11,6 @@
 
 'use strict';
 
-var EventConstants = require('EventConstants');
 var EventPluginUtils = require('EventPluginUtils');
 var EventPropagators = require('EventPropagators');
 var ResponderSyntheticEvent = require('ResponderSyntheticEvent');
@@ -326,7 +325,7 @@ function setResponderAndExtractTransfer(
   var shouldSetEventType =
     isStartish(topLevelType) ? eventTypes.startShouldSetResponder :
     isMoveish(topLevelType) ? eventTypes.moveShouldSetResponder :
-    topLevelType === EventConstants.topLevelTypes.topSelectionChange ?
+    topLevelType === 'topSelectionChange' ?
       eventTypes.selectionChangeShouldSetResponder :
     eventTypes.scrollShouldSetResponder;
 
@@ -429,10 +428,10 @@ function canTriggerTransfer(topLevelType, topLevelInst, nativeEvent) {
     // responderIgnoreScroll: We are trying to migrate away from specifically
     // tracking native scroll events here and responderIgnoreScroll indicates we
     // will send topTouchCancel to handle canceling touch events instead
-    (topLevelType === EventConstants.topLevelTypes.topScroll &&
+    (topLevelType === 'topScroll' &&
       !nativeEvent.responderIgnoreScroll) ||
     (trackedTouchCount > 0 &&
-      topLevelType === EventConstants.topLevelTypes.topSelectionChange) ||
+      topLevelType === 'topSelectionChange') ||
     isStartish(topLevelType) ||
     isMoveish(topLevelType)
   );
@@ -541,7 +540,7 @@ var ResponderEventPlugin = {
 
     var isResponderTerminate =
       responderInst &&
-      topLevelType === EventConstants.topLevelTypes.topTouchCancel;
+      topLevelType === 'topTouchCancel';
     var isResponderRelease =
       responderInst &&
       !isResponderTerminate &&

--- a/src/renderers/shared/stack/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
+++ b/src/renderers/shared/stack/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
@@ -12,12 +12,9 @@
 'use strict';
 
 var EventPluginHub;
-var EventConstants;
 var ReactInstanceHandles;
 var ResponderEventPlugin;
 var EventPluginUtils;
-
-var topLevelTypes;
 
 var touch = function(nodeHandle, i) {
   return {target: nodeHandle, identifier: i};
@@ -108,7 +105,7 @@ var _touchConfig = function(
  */
 var startConfig = function(nodeHandle, allTouchHandles, changedIndices) {
   return _touchConfig(
-    topLevelTypes.topTouchStart,
+    'topTouchStart',
     nodeHandle,
     allTouchHandles,
     changedIndices,
@@ -121,7 +118,7 @@ var startConfig = function(nodeHandle, allTouchHandles, changedIndices) {
  */
 var moveConfig = function(nodeHandle, allTouchHandles, changedIndices) {
   return _touchConfig(
-    topLevelTypes.topTouchMove,
+    'topTouchMove',
     nodeHandle,
     allTouchHandles,
     changedIndices,
@@ -134,7 +131,7 @@ var moveConfig = function(nodeHandle, allTouchHandles, changedIndices) {
  */
 var endConfig = function(nodeHandle, allTouchHandles, changedIndices) {
   return _touchConfig(
-    topLevelTypes.topTouchEnd,
+    'topTouchEnd',
     nodeHandle,
     allTouchHandles,
     changedIndices,
@@ -334,7 +331,6 @@ describe('ResponderEventPlugin', function() {
   beforeEach(function() {
     jest.resetModuleRegistry();
 
-    EventConstants = require('EventConstants');
     EventPluginHub = require('EventPluginHub');
     EventPluginUtils = require('EventPluginUtils');
     ReactInstanceHandles = require('ReactInstanceHandles');
@@ -380,8 +376,6 @@ describe('ResponderEventPlugin', function() {
         );
       },
     });
-
-    topLevelTypes = EventConstants.topLevelTypes;
   });
 
   it('should do nothing when no one wants to respond', function() {
@@ -953,7 +947,7 @@ describe('ResponderEventPlugin', function() {
     config.responderReject.parent = {order: 5};
 
     run(config, three, {
-      topLevelType: topLevelTypes.topScroll,
+      topLevelType: 'topScroll',
       targetInst: idToInstance[three.parent],
       nativeEvent: {},
     });
@@ -970,7 +964,7 @@ describe('ResponderEventPlugin', function() {
     config.responderTerminate.child = {order: 5};
 
     run(config, three, {
-      topLevelType: topLevelTypes.topScroll,
+      topLevelType: 'topScroll',
       targetInst: idToInstance[three.parent],
       nativeEvent: {},
     });
@@ -997,7 +991,7 @@ describe('ResponderEventPlugin', function() {
     config.responderTerminate.child = {order: 1};
 
     var nativeEvent = _touchConfig(
-      topLevelTypes.topTouchCancel,
+      'topTouchCancel',
       three.child,
       [three.child],
       [0]


### PR DESCRIPTION
This is the last callsite of keyMirror! It removes 0.5k gzipped :)

The only trick with this one is that ReactTestUtils actually iterates over the list of all the events. Instead of duplicating the logic, I used the $Enum feature of flow that lets us statically extract out the type from the dynamic value. Inside of react-dom we're no longer requiring the file directly so it doesn't bloat the file size, and we still get to have static typing, best of both worlds!

<img width="531" alt="screen shot 2016-08-28 at 11 19 50 am" src="https://cloud.githubusercontent.com/assets/197597/18035899/1cde15c2-6d14-11e6-960b-571b5b3132ed.png">
