### PR TITLE
Remove the Mixin layer of indirection on ReactCompositeComponent

### DIFF
--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -126,7 +126,7 @@ var nextMountID = 1;
 /**
  * @lends {ReactCompositeComponent.prototype}
  */
-var ReactCompositeComponentMixin = {
+var ReactCompositeComponent = {
 
   /**
    * Base constructor for all composite component.
@@ -1166,12 +1166,6 @@ var ReactCompositeComponentMixin = {
 
   // Stub
   _instantiateReactComponent: null,
-
-};
-
-var ReactCompositeComponent = {
-
-  Mixin: ReactCompositeComponentMixin,
 
 };
 

--- a/src/renderers/shared/stack/reconciler/instantiateReactComponent.js
+++ b/src/renderers/shared/stack/reconciler/instantiateReactComponent.js
@@ -24,7 +24,7 @@ var ReactCompositeComponentWrapper = function(element) {
 };
 Object.assign(
   ReactCompositeComponentWrapper.prototype,
-  ReactCompositeComponent.Mixin,
+  ReactCompositeComponent,
   {
     _instantiateReactComponent: instantiateReactComponent,
   }

--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -419,15 +419,15 @@ var ShallowComponentWrapper = function(element) {
 };
 Object.assign(
   ShallowComponentWrapper.prototype,
-  ReactCompositeComponent.Mixin, {
+  ReactCompositeComponent, {
     _constructComponent:
-      ReactCompositeComponent.Mixin._constructComponentWithoutOwner,
+      ReactCompositeComponent._constructComponentWithoutOwner,
     _instantiateReactComponent: function(element) {
       return new NoopInternalComponent(element);
     },
     _replaceNodeWithMarkup: function() {},
     _renderValidatedComponent:
-      ReactCompositeComponent.Mixin
+      ReactCompositeComponent
         ._renderValidatedComponentWithoutOwnerOrContext,
   }
 );


### PR DESCRIPTION
As mentioned in https://github.com/facebook/react/pull/7581#issuecomment-242952042 we can remove the Mixin layer of indirection as it only exports a Mixin and I find it confusing.