### PR TITLE
docs: re-position comments to account for code sample width

### DIFF
--- a/docs/docs/ref-05-events.md
+++ b/docs/docs/ref-05-events.md
@@ -50,8 +50,11 @@ function onClick(event) {
     console.log(eventType); // => "click"
   }, 0);
 
-  this.setState({clickEvent: event}); // Won't work. this.state.clickEvent will only contain null values.
-  this.setState({eventType: event.type}); // You can still export event properties.
+  // Won't work. this.state.clickEvent will only contain null values.
+  this.setState({clickEvent: event});
+
+  // You can still export event properties.
+  this.setState({eventType: event.type});
 }
 ```
 


### PR DESCRIPTION
This addresses the issue where these comments are running off the screen:
![2016-08-29-102338_681x318_scrot](https://cloud.githubusercontent.com/assets/59292/18054660/bc53b850-6dd2-11e6-9a1a-17d42f946701.png)
