### PR TITLE
Add more specific link to react-addons-shallow-compare readme

### DIFF
--- a/grunt/tasks/npm-react-addons.js
+++ b/grunt/tasks/npm-react-addons.js
@@ -52,6 +52,7 @@ var addons = {
     peerDependency: 'react',
     module: 'shallowCompare',
     name: 'shallow-compare',
+    docs: 'shallow-compare',
   },
   updates: {
     peerDependency: 'react',


### PR DESCRIPTION
This simply makes sure we link to the specific docs in the readme that we generate for npm.

I was reminded in #5378 that we added this page.