### PR TITLE
s/npmcdn/unpkg/g

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ You'll notice that we used an HTML-like syntax; [we call it JSX](https://faceboo
 
 ## Installation
 
-The fastest way to get started is to serve JavaScript from a CDN. We're using [npmcdn](https://npmcdn.com/) below but React is also available on [cdnjs](https://cdnjs.com/libraries/react) and [jsdelivr](https://www.jsdelivr.com/projects/react):
+The fastest way to get started is to serve JavaScript from a CDN. We're using [unpkg](https://unpkg.com/) below but React is also available on [cdnjs](https://cdnjs.com/libraries/react) and [jsdelivr](https://www.jsdelivr.com/projects/react):
 
 ```html
 <!-- The core React library -->
-<script src="https://npmcdn.com/react@15.3.1/dist/react.js"></script>
+<script src="https://unpkg.com/react@15.3.1/dist/react.js"></script>
 <!-- The ReactDOM Library -->
-<script src="https://npmcdn.com/react-dom@15.3.1/dist/react-dom.js"></script>
+<script src="https://unpkg.com/react-dom@15.3.1/dist/react-dom.js"></script>
 ```
 
 We've also built a [starter kit](https://facebook.github.io/react/downloads/react-15.3.1.zip) which might be useful if this is your first time using React. It includes a webpage with an example of using React with live code.

--- a/docs/docs/02-displaying-data.it-IT.md
+++ b/docs/docs/02-displaying-data.it-IT.md
@@ -19,9 +19,9 @@ Diamo un'occhiata ad un esempio davvero semplice. Creiamo un file dal nome `hell
   <head>
     <meta charset="UTF-8" />
     <title>Hello React</title>
-    <script src="https://npmcdn.com/react@{{site.react_version}}/dist/react.js"></script>
-    <script src="https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
-    <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
+    <script src="https://unpkg.com/react@{{site.react_version}}/dist/react.js"></script>
+    <script src="https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
+    <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
   </head>
   <body>
     <div id="example"></div>

--- a/docs/docs/02-displaying-data.ja-JP.md
+++ b/docs/docs/02-displaying-data.ja-JP.md
@@ -19,9 +19,9 @@ UIについて、最も基本的なことは、いくつかのデータを表示
   <head>
     <meta charset="UTF-8" />
     <title>Hello React</title>
-    <script src="https://npmcdn.com/react@{{site.react_version}}/dist/react.js"></script>
-    <script src="https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
-    <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
+    <script src="https://unpkg.com/react@{{site.react_version}}/dist/react.js"></script>
+    <script src="https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
+    <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
   </head>
   <body>
     <div id="example"></div>

--- a/docs/docs/02-displaying-data.ko-KR.md
+++ b/docs/docs/02-displaying-data.ko-KR.md
@@ -18,9 +18,9 @@ UI를 가지고 할 수 있는 가장 기초적인 것은 데이터를 표시하
   <head>
     <meta charset="UTF-8" />
     <title>Hello React</title>
-    <script src="https://npmcdn.com/react@{{site.react_version}}/dist/react.js"></script>
-    <script src="https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
-    <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
+    <script src="https://unpkg.com/react@{{site.react_version}}/dist/react.js"></script>
+    <script src="https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
+    <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
   </head>
   <body>
     <div id="example"></div>

--- a/docs/docs/02-displaying-data.md
+++ b/docs/docs/02-displaying-data.md
@@ -18,9 +18,9 @@ Let's look at a really simple example. Create a `hello-react.html` file with the
   <head>
     <meta charset="UTF-8" />
     <title>Hello React</title>
-    <script src="https://npmcdn.com/react@{{site.react_version}}/dist/react.js"></script>
-    <script src="https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
-    <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
+    <script src="https://unpkg.com/react@{{site.react_version}}/dist/react.js"></script>
+    <script src="https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
+    <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
   </head>
   <body>
     <div id="example"></div>

--- a/docs/docs/02-displaying-data.ru-RU.md
+++ b/docs/docs/02-displaying-data.ru-RU.md
@@ -18,9 +18,9 @@ next: jsx-in-depth.html
   <head>
     <meta charset="UTF-8" />
     <title>Hello React</title>
-    <script src="https://npmcdn.com/react@{{site.react_version}}/dist/react.js"></script>
-    <script src="https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
-    <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
+    <script src="https://unpkg.com/react@{{site.react_version}}/dist/react.js"></script>
+    <script src="https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
+    <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
   </head>
   <body>
     <div id="example"></div>

--- a/docs/docs/02-displaying-data.zh-CN.md
+++ b/docs/docs/02-displaying-data.zh-CN.md
@@ -18,9 +18,9 @@ next: jsx-in-depth-zh-CN.html
   <head>
     <meta charset="UTF-8" />
     <title>Hello React</title>
-    <script src="https://npmcdn.com/react@{{site.react_version}}/dist/react.js"></script>
-    <script src="https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
-    <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
+    <script src="https://unpkg.com/react@{{site.react_version}}/dist/react.js"></script>
+    <script src="https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
+    <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
   </head>
   <body>
     <div id="example"></div>

--- a/docs/docs/02-displaying-data.zh-TW.md
+++ b/docs/docs/02-displaying-data.zh-TW.md
@@ -18,9 +18,9 @@ next: jsx-in-depth-zh-TW.html
   <head>
     <meta charset="UTF-8" />
     <title>Hello React</title>
-    <script src="https://npmcdn.com/react@{{site.react_version}}/dist/react.js"></script>
-    <script src="https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
-    <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
+    <script src="https://unpkg.com/react@{{site.react_version}}/dist/react.js"></script>
+    <script src="https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
+    <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
   </head>
   <body>
     <div id="example"></div>

--- a/docs/docs/09.2-package-management.md
+++ b/docs/docs/09.2-package-management.md
@@ -102,7 +102,7 @@ bower install --save react
     <title>Hello React!</title>
     <script src="bower_components/react/react.js"></script>
     <script src="bower_components/react/react-dom.js"></script>
-    <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
+    <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
   </head>
   <body>
     <div id="example"></div>

--- a/docs/docs/getting-started.it-IT.md
+++ b/docs/docs/getting-started.it-IT.md
@@ -32,7 +32,7 @@ Nella directory principale dello starter kit, crea `helloworld.html` con il segu
     <meta charset="UTF-8" />
     <title>Ciao React!</title>
     <script src="build/react.js"></script>
-    <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
+    <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
   </head>
   <body>
     <div id="example"></div>

--- a/docs/docs/getting-started.ja-JP.md
+++ b/docs/docs/getting-started.ja-JP.md
@@ -32,7 +32,7 @@ React でのハッキングを始めるにあたり、一番簡単なものと�
     <meta charset="UTF-8" />
     <title>Hello React!</title>
     <script src="build/react.js"></script>
-    <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
+    <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
   </head>
   <body>
     <div id="example"></div>

--- a/docs/docs/getting-started.ko-KR.md
+++ b/docs/docs/getting-started.ko-KR.md
@@ -59,7 +59,7 @@ $ browserify -t [ babelify --presets [ react ] ] main.js -o bundle.js
     <title>Hello React!</title>
     <script src="build/react.js"></script>
     <script src="build/react-dom.js"></script>
-    <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
+    <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
   </head>
   <body>
     <div id="example"></div>

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -34,7 +34,7 @@ In the root directory of the starter kit, create a `helloworld.html` with the fo
     <title>Hello React!</title>
     <script src="build/react.js"></script>
     <script src="build/react-dom.js"></script>
-    <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
+    <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
   </head>
   <body>
     <div id="example"></div>

--- a/docs/docs/getting-started.zh-CN.md
+++ b/docs/docs/getting-started.zh-CN.md
@@ -76,7 +76,7 @@ new webpack.DefinePlugin({
     <title>Hello React!</title>
     <script src="build/react.js"></script>
     <script src="build/react-dom.js"></script>
-    <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
+    <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
   </head>
   <body>
     <div id="example"></div>

--- a/docs/docs/tutorial.it-IT.md
+++ b/docs/docs/tutorial.it-IT.md
@@ -41,11 +41,11 @@ Per questo tutorial renderemo il tutto il più semplice possibile. Incluso nel p
   <head>
     <meta charset="utf-8" />
     <title>React Tutorial</title>
-    <script src="https://npmcdn.com/react@{{site.react_version}}/dist/react.js"></script>
-    <script src="https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
-    <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
-    <script src="https://npmcdn.com/jquery@3.1.0/dist/jquery.min.js"></script>
-    <script src="https://npmcdn.com/remarkable@1.6.2/dist/remarkable.min.js"></script>
+    <script src="https://unpkg.com/react@{{site.react_version}}/dist/react.js"></script>
+    <script src="https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
+    <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
+    <script src="https://unpkg.com/jquery@3.1.0/dist/jquery.min.js"></script>
+    <script src="https://unpkg.com/remarkable@1.6.2/dist/remarkable.min.js"></script>
   </head>
   <body>
     <div id="content"></div>
@@ -228,11 +228,11 @@ Per prima cosa, aggiungiamo la libreria di terze parti **marked** alla tua appli
 <head>
   <meta charset="utf-8" />
   <title>React Tutorial</title>
-  <script src="https://npmcdn.com/react@{{site.react_version}}/dist/react.js"></script>
-  <script src="https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
-  <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
-  <script src="https://npmcdn.com/jquery@3.1.0/dist/jquery.min.js"></script>
-  <script src="https://npmcdn.com/remarkable@1.6.2/dist/remarkable.min.js"></script>
+  <script src="https://unpkg.com/react@{{site.react_version}}/dist/react.js"></script>
+  <script src="https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
+  <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
+  <script src="https://unpkg.com/jquery@3.1.0/dist/jquery.min.js"></script>
+  <script src="https://unpkg.com/remarkable@1.6.2/dist/remarkable.min.js"></script>
 </head>
 ```
 

--- a/docs/docs/tutorial.ja-JP.md
+++ b/docs/docs/tutorial.ja-JP.md
@@ -41,11 +41,11 @@ next: thinking-in-react-ja-JP.html
   <head>
     <meta charset="UTF-8" />
     <title>React Tutorial</title>
-    <script src="https://npmcdn.com/react@{{site.react_version}}/dist/react.js"></script>
-    <script src="https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
-    <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
-    <script src="https://npmcdn.com/jquery@3.1.0/dist/jquery.min.js"></script>
-    <script src="https://npmcdn.com/remarkable@1.6.2/dist/remarkable.min.js"></script>
+    <script src="https://unpkg.com/react@{{site.react_version}}/dist/react.js"></script>
+    <script src="https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
+    <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
+    <script src="https://unpkg.com/jquery@3.1.0/dist/jquery.min.js"></script>
+    <script src="https://unpkg.com/remarkable@1.6.2/dist/remarkable.min.js"></script>
 
   </head>
   <body>
@@ -225,11 +225,11 @@ Markdown はインラインでテキストをフォーマットする簡単な�
 <head>
   <meta charset="UTF-8" />
   <title>Hello React</title>
-  <script src="https://npmcdn.com/react@{{site.react_version}}/dist/react.js"></script>
-  <script src="https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
-  <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
-  <script src="https://npmcdn.com/jquery@3.1.0/dist/jquery.min.js"></script>
-  <script src="https://npmcdn.com/remarkable@1.6.2/dist/remarkable.min.js"></script>
+  <script src="https://unpkg.com/react@{{site.react_version}}/dist/react.js"></script>
+  <script src="https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
+  <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
+  <script src="https://unpkg.com/jquery@3.1.0/dist/jquery.min.js"></script>
+  <script src="https://unpkg.com/remarkable@1.6.2/dist/remarkable.min.js"></script>
 </head>
 ```
 

--- a/docs/docs/tutorial.ko-KR.md
+++ b/docs/docs/tutorial.ko-KR.md
@@ -41,11 +41,11 @@ next: thinking-in-react-ko-KR.html
   <head>
     <meta charset="utf-8" />
     <title>React Tutorial</title>
-    <script src="https://npmcdn.com/react@{{site.react_version}}/dist/react.js"></script>
-    <script src="https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
-    <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
-    <script src="https://npmcdn.com/jquery@3.1.0/dist/jquery.min.js"></script>
-    <script src="https://npmcdn.com/remarkable@1.6.2/dist/remarkable.min.js"></script>
+    <script src="https://unpkg.com/react@{{site.react_version}}/dist/react.js"></script>
+    <script src="https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
+    <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
+    <script src="https://unpkg.com/jquery@3.1.0/dist/jquery.min.js"></script>
+    <script src="https://unpkg.com/remarkable@1.6.2/dist/remarkable.min.js"></script>
   </head>
   <body>
     <div id="content"></div>
@@ -231,11 +231,11 @@ Markdown은 텍스트를 포맷팅하는 간단한 방식입니다. 예를 들�
 <head>
   <meta charset="utf-8" />
   <title>React Tutorial</title>
-  <script src="https://npmcdn.com/react@{{site.react_version}}/dist/react.js"></script>
-  <script src="https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
-  <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
-  <script src="https://npmcdn.com/jquery@3.1.0/dist/jquery.min.js"></script>
-  <script src="https://npmcdn.com/remarkable@1.6.2/dist/remarkable.min.js"></script>
+  <script src="https://unpkg.com/react@{{site.react_version}}/dist/react.js"></script>
+  <script src="https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
+  <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
+  <script src="https://unpkg.com/jquery@3.1.0/dist/jquery.min.js"></script>
+  <script src="https://unpkg.com/remarkable@1.6.2/dist/remarkable.min.js"></script>
 </head>
 ```
 

--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -41,11 +41,11 @@ For this tutorial, we're going to make it as easy as possible. Included in the s
   <head>
     <meta charset="utf-8" />
     <title>React Tutorial</title>
-    <script src="https://npmcdn.com/react@{{site.react_version}}/dist/react.js"></script>
-    <script src="https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
-    <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
-    <script src="https://npmcdn.com/jquery@3.1.0/dist/jquery.min.js"></script>
-    <script src="https://npmcdn.com/remarkable@1.6.2/dist/remarkable.min.js"></script>
+    <script src="https://unpkg.com/react@{{site.react_version}}/dist/react.js"></script>
+    <script src="https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
+    <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
+    <script src="https://unpkg.com/jquery@3.1.0/dist/jquery.min.js"></script>
+    <script src="https://unpkg.com/remarkable@1.6.2/dist/remarkable.min.js"></script>
   </head>
   <body>
     <div id="content"></div>

--- a/docs/docs/tutorial.zh-CN.md
+++ b/docs/docs/tutorial.zh-CN.md
@@ -41,11 +41,11 @@ next: thinking-in-react-zh-CN.html
   <head>
     <meta charset="utf-8" />
     <title>React Tutorial</title>
-    <script src="https://npmcdn.com/react@{{site.react_version}}/dist/react.js"></script>
-    <script src="https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
-    <script src="https://npmcdn.com/babel-core@5.8.38/browser.min.js"></script>
-    <script src="https://npmcdn.com/jquery@3.1.0/dist/jquery.min.js"></script>
-    <script src="https://npmcdn.com/remarkable@1.6.2/dist/remarkable.min.js"></script>
+    <script src="https://unpkg.com/react@{{site.react_version}}/dist/react.js"></script>
+    <script src="https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
+    <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
+    <script src="https://unpkg.com/jquery@3.1.0/dist/jquery.min.js"></script>
+    <script src="https://unpkg.com/remarkable@1.6.2/dist/remarkable.min.js"></script>
   </head>
   <body>
     <div id="content"></div>

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -22,40 +22,40 @@ If you're just starting out, make sure to use the development version.
 ## Individual Downloads
 
 #### React {{site.react_version}} (development)
-The uncompressed, development version of [react.js](https://npmcdn.com/react@{{site.react_version}}/dist/react.js) and [react-dom.js](https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.js) with inline documentation (you need both files).
+The uncompressed, development version of [react.js](https://unpkg.com/react@{{site.react_version}}/dist/react.js) and [react-dom.js](https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.js) with inline documentation (you need both files).
 
 ```html
-<script src="https://npmcdn.com/react@{{site.react_version}}/dist/react.js"></script>
-<script src="https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
+<script src="https://unpkg.com/react@{{site.react_version}}/dist/react.js"></script>
+<script src="https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
 ```
 
 #### React {{site.react_version}} (production)
-The compressed, production version of [react.js](https://npmcdn.com/react@{{site.react_version}}/dist/react.min.js) and [react-dom.js](https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.min.js) (you need both).
+The compressed, production version of [react.js](https://unpkg.com/react@{{site.react_version}}/dist/react.min.js) and [react-dom.js](https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.min.js) (you need both).
 
 ```html
-<script src="https://npmcdn.com/react@{{site.react_version}}/dist/react.min.js"></script>
-<script src="https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.min.js"></script>
+<script src="https://unpkg.com/react@{{site.react_version}}/dist/react.min.js"></script>
+<script src="https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.min.js"></script>
 ```
 
 #### React with Add-Ons {{site.react_version}} (development)
 The uncompressed, development version of React with [optional add-ons](/react/docs/addons.html).
 
 ```html
-<script src="https://npmcdn.com/react@{{site.react_version}}/dist/react-with-addons.js"></script>
-<script src="https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
+<script src="https://unpkg.com/react@{{site.react_version}}/dist/react-with-addons.js"></script>
+<script src="https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.js"></script>
 ```
 
 #### React with Add-Ons {{site.react_version}} (production)
 The compressed, production version of React with [optional add-ons](/react/docs/addons.html).
 
 ```html
-<script src="https://npmcdn.com/react@{{site.react_version}}/dist/react-with-addons.min.js"></script>
-<script src="https://npmcdn.com/react-dom@{{site.react_version}}/dist/react-dom.min.js"></script>
+<script src="https://unpkg.com/react@{{site.react_version}}/dist/react-with-addons.min.js"></script>
+<script src="https://unpkg.com/react-dom@{{site.react_version}}/dist/react-dom.min.js"></script>
 ```
 
 > Note:
 >
-> We're using [npmcdn](https://npmcdn.com) to serve these files. This is a free service with the goal to provide a hassle-free CDN for npm package authors. React is also available on other free CDNs including [cdnjs](https://cdnjs.com/libraries/react/) and [jsDelivr](https://www.jsdelivr.com/projects/react). If you have concerns with relying on an external host, we always recommend that you download React and serve it from your own servers.
+> We're using [unpkg](https://unpkg.com) to serve these files. This is a free service with the goal to provide a hassle-free CDN for npm package authors. React is also available on other free CDNs including [cdnjs](https://cdnjs.com/libraries/react/) and [jsDelivr](https://www.jsdelivr.com/projects/react). If you have concerns with relying on an external host, we always recommend that you download React and serve it from your own servers.
 
 ## npm
 


### PR DESCRIPTION
[npmcdn.com is moving to unpkg.com](https://twitter.com/mjackson/status/770424625754939394). Same backend, one less letter in the domain name.

This is primarily to avoid any possible future naming disputes with npm, Inc. Also, unpkg.com runs on a bigger CloudFlare plan, so we have more room to grow.

Happy to answer any questions you may have. :)