### PR TITLE
Cleanup ReactErrorUtils

### DIFF
--- a/src/renderers/shared/utils/ReactErrorUtils.js
+++ b/src/renderers/shared/utils/ReactErrorUtils.js
@@ -22,19 +22,17 @@ var caughtError = null;
  * @param {*} a First argument
  * @param {*} b Second argument
  */
-function invokeGuardedCallback<A, B, C>(
+function invokeGuardedCallback<A>(
   name: string,
-  func: (a: A, b: B) => C,
+  func: (a: A) => void,
   a: A,
-  b: B,
-): ?C {
+): void {
   try {
-    return func(a, b);
+    func(a);
   } catch (x) {
     if (caughtError === null) {
       caughtError = x;
     }
-    return undefined;
   }
 }
 
@@ -70,13 +68,12 @@ if (__DEV__) {
       typeof document !== 'undefined' &&
       typeof document.createEvent === 'function') {
     var fakeNode = document.createElement('react');
-    ReactErrorUtils.invokeGuardedCallback = function<A, B, C>(
+    ReactErrorUtils.invokeGuardedCallback = function<A>(
       name: string,
-      func: (a: A, b: B) => C,
+      func: (a: A) => void,
       a: A,
-      b: B,
-    ): ?C {
-      var boundFunc = func.bind(null, a, b);
+    ): void {
+      var boundFunc = func.bind(null, a);
       var evtType = `react-${name}`;
       fakeNode.addEventListener(evtType, boundFunc, false);
       var evt = document.createEvent('Event');


### PR DESCRIPTION
I'm pretty far from completely understanding what this is doing but generally I think it's something like this…

1. Brings both implementations of `invokeGuardedCallback` in line. We don't return the return value. Nobody uses it and when we were using events, it wasn't happening anyway.
2. Flow got unhappy that we weren't passing an `EventListener` as the 2nd arg to add/removeEventListener. Seems that making that return type `void` helped it believe the right thing.

This seems to make Flow happy internally (not sure what the difference for that is…). This still might not be technically right though - we should make sure it is.

cc @spicyj @vjeux 