### PR TITLE
tutorial.md: Corrects bug commentNodes not defined

### DIFF
--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -325,7 +325,7 @@ var CommentList = React.createClass({
     });
     return (
       <div className="commentList">
-        {commentNodes}
+        {this.commentNodes()}
       </div>
     );
   }


### PR DESCRIPTION
I can't believe no one has mentioned this before(?) but maybe people are just reading along versus typing along and aren't actually triggering the bug.

When I run the status quo code I see:

<img width="394" alt="screen shot 2016-08-30 at 4 51 54 am" src="https://cloud.githubusercontent.com/assets/50019/18082745/2c9f2766-6e6e-11e6-99ec-dd2653e41e44.png">

It's possible I've erred; I'm reading the tutorial after all. For the code, as written, to work violates my principle of least surprise radar. Why would the JSX know to throw to the right context *and* know that when the sought name is not a property to treat it as a function without some level of interface on top of the JS primitives (e.g. `get()` or `set()`).