### PR TITLE
Copy all SVG child nodes when using setting innerHTML in IE

### DIFF
--- a/src/renderers/dom/client/utils/__tests__/setInnerHTML-test.js
+++ b/src/renderers/dom/client/utils/__tests__/setInnerHTML-test.js
@@ -25,7 +25,9 @@ describe('setInnerHTML', function() {
   });
 
   describe('when the node does not have an innerHTML property', () => {
-    it('sets innerHTML on it', function() {
+    // Disabled. JSDOM doesn't seem to remove nodes when using appendChild to
+    // move existing nodes.
+    xit('sets innerHTML on it', function() {
       // Create a mock node that looks like an SVG in IE (without innerHTML)
       var node = {
         namespaceURI: DOMNamespaces.svg,

--- a/src/renderers/dom/client/utils/setInnerHTML.js
+++ b/src/renderers/dom/client/utils/setInnerHTML.js
@@ -38,9 +38,9 @@ var setInnerHTML = createMicrosoftUnsafeLocalFunction(
     if (node.namespaceURI === DOMNamespaces.svg && !('innerHTML' in node)) {
       reusableSVGContainer = reusableSVGContainer || document.createElement('div');
       reusableSVGContainer.innerHTML = '<svg>' + html + '</svg>';
-      var newNodes = reusableSVGContainer.firstChild.childNodes;
-      for (var i = 0; i < newNodes.length; i++) {
-        node.appendChild(newNodes[i]);
+      var svgNode = reusableSVGContainer.firstChild;
+      while (svgNode.firstChild) {
+        node.appendChild(svgNode.firstChild);
       }
     } else {
       node.innerHTML = html;


### PR DESCRIPTION
This is a followup to #6982, which missed half the nodes. We missed this because the test that was written depended on broken JSDOM behavior (will report shortly).

Test Plan:
- https://jsfiddle.net/ra8xrruh/1/ is broken in IE11 (currently using 15.3.1) - only see every other bar.
- http://playground.zpao.com/tmp/react_7358/ works (same code, patch applied, on master)

I also renamed the test file to fit our convention.