### PR TITLE
Add checkpoint/rollback to ReactNativeReconcileTransaction

### DIFF
--- a/src/renderers/native/ReactNativeReconcileTransaction.js
+++ b/src/renderers/native/ReactNativeReconcileTransaction.js
@@ -98,6 +98,19 @@ var Mixin = {
   },
 
   /**
+   * Save current transaction state -- if the return value from this method is
+   * passed to `rollback`, the transaction will be reset to that state.
+   */
+  checkpoint: function() {
+    // reactMountReady is the our only stateful wrapper
+    return this.reactMountReady.checkpoint();
+  },
+
+  rollback: function(checkpoint) {
+    this.reactMountReady.rollback(checkpoint);
+  },
+
+  /**
    * `PooledClass` looks for this, and will invoke this before allowing this
    * instance to be reused.
    */


### PR DESCRIPTION
kinda of a follow up to #7558 and #7567

I could not find a way to easily add tests for it - [createReactNativeComponentClass.js](https://github.com/facebook/react/blob/master/src/renderers/native/createReactNativeComponentClass.js) doesn't allow passing the lifecycle methods, would have to shave too many yaks and I'm busy with other tasks... but I believe this is the expected behavior.

/cc @spicyj