### PR TITLE
Restore coverage in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,14 +71,8 @@ script:
       fi
     elif [ "$TEST_TYPE" = test ]; then
       set -e
-      # Disabling coverage because it's broken:
-      # https://travis-ci.org/facebook/react/jobs/128163922
-      if false; then
-        ./node_modules/.bin/grunt jest:coverage
-        cat ./coverage/lcov.info | ./node_modules/.bin/coveralls
-      else
-        ./node_modules/.bin/grunt jest:normal
-      fi
+      ./node_modules/.bin/grunt jest:coverage
+      cat ./coverage/lcov.info | ./node_modules/.bin/coveralls
       echo 'Testing in server-render (HTML generation) mode...'
       printf '\nmodule.exports.useCreateElement = false;\n' \
         >> src/renderers/dom/shared/ReactDOMFeatureFlags.js

--- a/grunt/tasks/jest.js
+++ b/grunt/tasks/jest.js
@@ -1,84 +1,16 @@
 'use strict';
 
-var async = require('async');
-var fs = require('fs');
-var glob = require('glob');
 var grunt = require('grunt');
 var path = require('path');
 
-var rootPath = path.resolve('.');
-var buildPath = path.join(rootPath, 'build');
-var tempConfigPath = path.join(buildPath, 'jest-config.json');
-
-var config = require(path.join(rootPath, 'package.json')).jest;
-
-var collectCoverageOnlyFrom = {
-  'src/**/*.js': {
-    ignore: [
-      'src/**/__tests__/*.js',
-      'src/shared/vendor/third_party/*.js',
-      'src/test/*.js',
-    ],
-  },
-};
-
-function getCollectCoverageOnlyFrom(callback) {
-  var patterns = Object.keys(collectCoverageOnlyFrom);
-  var result = {};
-
-  async.each(patterns, function(pattern) {
-    var options = Object.assign({ nodir: true }, collectCoverageOnlyFrom[pattern]);
-    glob(pattern, options, function(err, files) {
-      (files || []).reduce(function(object, key) {
-        object[key] = true;
-        return object;
-      }, result);
-
-      callback(err);
-    });
-  }, function(err) {
-    callback(err, result);
-  });
-}
-
-function getJestConfig(callback) {
-  var rootDir = path.resolve(buildPath, path.resolve(config.rootDir));
-  getCollectCoverageOnlyFrom(function(err, data) {
-    callback(err, Object.assign({}, config, {
-      rootDir: rootDir,
-      name: 'react',
-      collectCoverage: true,
-      collectCoverageOnlyFrom: data,
-    }));
-  });
-}
-
-function onError(err) {
-  grunt.log.error('jest failed');
-  grunt.log.error(err);
-}
-
-function writeTempConfig(callback) {
-  getJestConfig(function(err, data) {
-    if (err) {
-      callback(err);
-    } else {
-      grunt.file.mkdir(buildPath);
-      fs.writeFile(tempConfigPath, JSON.stringify(data, null, '  '), 'utf8', callback);
-    }
-  });
-}
-
-function run(done, configPath) {
+function run(done, coverage) {
   grunt.log.writeln('running jest');
 
   var args = [
     path.join('node_modules', 'jest', 'bin', 'jest'),
-    '--runInBand',
-    '--no-watchman',
   ];
-  if (configPath) {
-    args.push('--config', configPath);
+  if (coverage) {
+    args.push('--coverage');
   }
   grunt.util.spawn({
     cmd: 'node',
@@ -91,7 +23,8 @@ function run(done, configPath) {
     },
   }, function(spawnErr, result, code) {
     if (spawnErr) {
-      onError(spawnErr);
+      grunt.log.error('jest failed');
+      grunt.log.error(spawnErr);
     } else {
       grunt.log.ok('jest passed');
     }
@@ -108,15 +41,7 @@ function runJestNormally() {
 
 function runJestWithCoverage() {
   var done = this.async();
-
-  writeTempConfig(function(writeErr) {
-    if (writeErr) {
-      onError(writeErr);
-      return;
-    }
-
-    run(done, tempConfigPath);
-  });
+  run(done, /* coverage */ true);
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "gulp-load-plugins": "^1.2.4",
     "gulp-util": "^3.0.7",
     "gzip-js": "~0.3.2",
-    "jest": "^15.0.1",
+    "jest": "^15.0.2",
     "loose-envify": "^1.1.0",
     "merge-stream": "^1.0.0",
     "object-assign": "^4.1.0",
@@ -110,6 +110,12 @@
       "<rootDir>/scripts",
       "<rootDir>/src",
       "node_modules/fbjs"
+    ],
+    "collectCoverageFrom": [
+      "src/**/*.js",
+      "!src/**/__tests__/*.js",
+      "!src/shared/vendor/third_party/*.js",
+      "!src/test/*.js"
     ],
     "timers": "fake"
   }


### PR DESCRIPTION
We disabled coverage in Travis because the implementation was crashing ( https://github.com/facebook/react/issues/6290 ). Since we upgraded to Jest 15, the entire coverage implementation is brand new so we should give it another try.