### PR TITLE
Remove String.prototype.split polyfill warning

### DIFF
--- a/src/renderers/dom/ReactDOM.js
+++ b/src/renderers/dom/ReactDOM.js
@@ -118,7 +118,6 @@ if (__DEV__) {
       Date.now,
       Function.prototype.bind,
       Object.keys,
-      String.prototype.split,
       String.prototype.trim,
     ];
 


### PR DESCRIPTION
`String.prototype.split` is a ubiquitous part of the ES3 spec. Tracking back (https://github.com/facebook/react/pull/1516), I can't see a specific reason to include it in the required polyfills.

@syranide: did I miss anything?