### PR TITLE
Remove the Flow experimental.strict_type_args option

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -21,8 +21,6 @@ module.system=haste
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
 
-experimental.strict_type_args=true
-
 munge_underscores=false
 
 suppress_type=$FlowIssue


### PR DESCRIPTION
Remove the `experimental.strict_type_args`, since it is defaulted to `true` https://github.com/facebook/flow/blob/f4d61e664cdd55230aa979cdd324a501dbb73120/src/common/flowConfig.ml#L142 , and should be removed in the future from what I understood.