### PR TITLE
Type EventPluginRegistry

### DIFF
--- a/src/renderers/shared/stack/event/ReactSyntheticEvent.js
+++ b/src/renderers/shared/stack/event/ReactSyntheticEvent.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * Flow type for SyntheticEvent class that includes private properties
+ *
+ * @providesModule ReactSyntheticEvent
+ * @flow
+ */
+
+'use strict';
+
+export type DispatchConfig = any;
+
+export class ReactSyntheticEvent extends SyntheticEvent {
+  dispatchConfig: DispatchConfig;
+};


### PR DESCRIPTION
This commit takes the first incremental step towards adding type checks
to the event code. A couple of issues came up.

There is an issue with the SyntheticEvent type: [Flow declares a
SyntheticEvent type](https://github.com/facebook/flow/blob/master/lib/react.js#L277-L293) that lacks the non-public properties which are
used in React internals. To solve this I declared a class that extends
SyntheticEvent. This class can be expanded as we add Flow types to more
places where SyntheticEvent instances are referenced.

I'm happy to change this if folks prefer a different approach.
Some options I considered:
- Override the SyntheticEvent declaration with our own declaration
  - Pro: We can use 'SyntheticEvent' as a type just like we are used to
    when working in any other codebase.
  - Pro: No need to import any type since it's a declaration
  - Pro: Only one version of SyntheticEvent; less confusion.
  - Con: Could get out of sync with real implementation.
  - Con: Duplicates part of the type declared in Flow.
- Import the SyntheticEvent class and use that as the type
  - Pro: Keeps type definition in sync with the real implementation.
  - Con: Declaration overrides implementation so I'm not sure this would
    work.
  - Con: Have to remember to import the type.
- Declare a separate type called ReactSyntheticEvent that extends
  SyntheticEvent
  - Pro: Stays in sync with the Flow SyntheticEvent type;
    less duplication.
  - Pro: Differentiates this type from the Flow SyntheticEvent type;
    less confusion.
  - Pro: No need to import any type since it's a declaration
  - Con: Could get out of sync with real implementation.

I also ran into an issue where a variable was only non-null when
'__DEV__' is true, similar to [PR #7586](https://github.com/facebook/react/pull/7586/commits/b99eb5087bc2df3bcb64d76a2d75953978f61f34). The work-around is to force
it to be typed non-null and add a comment documenting the reason. At
this time Flow doesn't have a better way to deal with the situation.

Next steps:
- Specific type for the 'dispatchConfig' property of SyntheticEvent
- More detailed types for PluginName and PluginModule

Lastly; note that I renamed some variables to follow the convention of
reserving PascalCase for classes, enums, and Flow types.