### PR TITLE
Remove describe from tests

### DIFF
--- a/scripts/error-codes/__tests__/dev-expression-with-codes-test.js
+++ b/scripts/error-codes/__tests__/dev-expression-with-codes-test.js
@@ -25,18 +25,17 @@ function compare(input, output) {
 
 var oldEnv;
 
-describe('dev-expression', function() {
-  beforeEach(() => {
-    oldEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = '';
-  });
+beforeEach(() => {
+  oldEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = '';
+});
 
-  afterEach(() => {
-    process.env.NODE_ENV = oldEnv;
-  });
+afterEach(() => {
+  process.env.NODE_ENV = oldEnv;
+});
 
-  it('should replace __DEV__ in if', () => {
-    compare(
+it('should replace __DEV__ in if', () => {
+  compare(
 `
 if (__DEV__) {
   console.log('foo')
@@ -45,46 +44,46 @@ if (__DEV__) {
 if (process.env.NODE_ENV !== 'production') {
   console.log('foo');
 }`
-    );
-  });
+  );
+});
 
-  it('should replace warning calls', () => {
-    compare(
-      "warning(condition, 'a %s b', 'c');",
-      "process.env.NODE_ENV !== 'production' ? warning(condition, 'a %s b', 'c') : void 0;"
-    );
-  });
+it('should replace warning calls', () => {
+  compare(
+    "warning(condition, 'a %s b', 'c');",
+    "process.env.NODE_ENV !== 'production' ? warning(condition, 'a %s b', 'c') : void 0;"
+  );
+});
 
-  it("should add `reactProdInvariant` when it finds `require('invariant')`", () => {
-    compare(
+it("should add `reactProdInvariant` when it finds `require('invariant')`", () => {
+  compare(
 "var invariant = require('invariant');",
 
 `var _prodInvariant = require('reactProdInvariant');
 
 var invariant = require('invariant');`
-    );
-  });
+  );
+});
 
-  it('should replace simple invariant calls', () => {
-    compare(
-      "invariant(condition, 'Do not override existing functions.');",
-      "var _prodInvariant = require('reactProdInvariant');\n\n" +
-      "!condition ? " +
-      "process.env.NODE_ENV !== 'production' ? " +
-      "invariant(false, 'Do not override existing functions.') : " +
-      `_prodInvariant('16') : void 0;`
-    );
-  });
+it('should replace simple invariant calls', () => {
+  compare(
+    "invariant(condition, 'Do not override existing functions.');",
+    "var _prodInvariant = require('reactProdInvariant');\n\n" +
+    "!condition ? " +
+    "process.env.NODE_ENV !== 'production' ? " +
+    "invariant(false, 'Do not override existing functions.') : " +
+    `_prodInvariant('16') : void 0;`
+  );
+});
 
-  it("should only add `reactProdInvariant` once", () => {
-    var expectedInvariantTransformResult = (
-      "!condition ? " +
-      "process.env.NODE_ENV !== 'production' ? " +
-      "invariant(false, 'Do not override existing functions.') : " +
-      `_prodInvariant('16') : void 0;`
-    );
+it("should only add `reactProdInvariant` once", () => {
+  var expectedInvariantTransformResult = (
+    "!condition ? " +
+    "process.env.NODE_ENV !== 'production' ? " +
+    "invariant(false, 'Do not override existing functions.') : " +
+    `_prodInvariant('16') : void 0;`
+  );
 
-    compare(
+  compare(
 `var invariant = require('invariant');
 invariant(condition, 'Do not override existing functions.');
 invariant(condition, 'Do not override existing functions.');`,
@@ -94,52 +93,51 @@ invariant(condition, 'Do not override existing functions.');`,
 var invariant = require('invariant');
 ${expectedInvariantTransformResult}
 ${expectedInvariantTransformResult}`
-    );
-  });
+  );
+});
 
-  it('should support invariant calls with args', () => {
-    compare(
-      "invariant(condition, 'Expected %s target to be an array; got %s', 'foo', 'bar');",
-      "var _prodInvariant = require('reactProdInvariant');\n\n" +
-      "!condition ? " +
-      "process.env.NODE_ENV !== 'production' ? " +
-      "invariant(false, 'Expected %s target to be an array; got %s', 'foo', 'bar') : " +
-      `_prodInvariant('7', 'foo', 'bar') : void 0;`
-    );
-  });
+it('should support invariant calls with args', () => {
+  compare(
+    "invariant(condition, 'Expected %s target to be an array; got %s', 'foo', 'bar');",
+    "var _prodInvariant = require('reactProdInvariant');\n\n" +
+    "!condition ? " +
+    "process.env.NODE_ENV !== 'production' ? " +
+    "invariant(false, 'Expected %s target to be an array; got %s', 'foo', 'bar') : " +
+    `_prodInvariant('7', 'foo', 'bar') : void 0;`
+  );
+});
 
-  it('should support invariant calls with a concatenated template string and args', () => {
-    compare(
-      "invariant(condition, 'Expected a component class, ' + 'got %s.' + '%s', 'Foo', 'Bar');",
-      "var _prodInvariant = require('reactProdInvariant');\n\n" +
-      "!condition ? " +
-      "process.env.NODE_ENV !== 'production' ? " +
-      "invariant(false, 'Expected a component class, got %s.%s', 'Foo', 'Bar') : " +
-      `_prodInvariant('18', 'Foo', 'Bar') : void 0;`
-    );
-  });
+it('should support invariant calls with a concatenated template string and args', () => {
+  compare(
+    "invariant(condition, 'Expected a component class, ' + 'got %s.' + '%s', 'Foo', 'Bar');",
+    "var _prodInvariant = require('reactProdInvariant');\n\n" +
+    "!condition ? " +
+    "process.env.NODE_ENV !== 'production' ? " +
+    "invariant(false, 'Expected a component class, got %s.%s', 'Foo', 'Bar') : " +
+    `_prodInvariant('18', 'Foo', 'Bar') : void 0;`
+  );
+});
 
-  it('should warn in non-test envs if the error message cannot be found', () => {
-    spyOn(console, 'warn');
-    transform("invariant(condition, 'a %s b', 'c');");
+it('should warn in non-test envs if the error message cannot be found', () => {
+  spyOn(console, 'warn');
+  transform("invariant(condition, 'a %s b', 'c');");
 
-    expect(console.warn.calls.count()).toBe(1);
-    expect(console.warn.calls.argsFor(0)[0]).toBe(
-      'Error message "a %s b" ' +
-      'cannot be found. The current React version ' +
-      'and the error map are probably out of sync. ' +
-      'Please run `gulp react:extract-errors` before building React.'
-    );
-  });
+  expect(console.warn.calls.count()).toBe(1);
+  expect(console.warn.calls.argsFor(0)[0]).toBe(
+    'Error message "a %s b" ' +
+    'cannot be found. The current React version ' +
+    'and the error map are probably out of sync. ' +
+    'Please run `gulp react:extract-errors` before building React.'
+  );
+});
 
-  it('should not warn in test env if the error message cannot be found', () => {
-    process.env.NODE_ENV = 'test';
+it('should not warn in test env if the error message cannot be found', () => {
+  process.env.NODE_ENV = 'test';
 
-    spyOn(console, 'warn');
-    transform("invariant(condition, 'a %s b', 'c');");
+  spyOn(console, 'warn');
+  transform("invariant(condition, 'a %s b', 'c');");
 
-    expect(console.warn.calls.count()).toBe(0);
+  expect(console.warn.calls.count()).toBe(0);
 
-    process.env.NODE_ENV = '';
-  });
+  process.env.NODE_ENV = '';
 });

--- a/scripts/error-codes/__tests__/evalToString-test.js
+++ b/scripts/error-codes/__tests__/evalToString-test.js
@@ -17,20 +17,18 @@ var parse = (source) => babylon.parse(
 
 var parseAndEval = (source) => evalToString(parse(source));
 
-describe('evalToString', () => {
-  it('should support StringLiteral', () => {
-    expect(parseAndEval(`'foobar'`)).toBe('foobar');
-    expect(parseAndEval(`'yowassup'`)).toBe('yowassup');
-  });
+it('should support StringLiteral', () => {
+  expect(parseAndEval(`'foobar'`)).toBe('foobar');
+  expect(parseAndEval(`'yowassup'`)).toBe('yowassup');
+});
 
-  it('should support string concat (`+`)', () => {
-    expect(parseAndEval(`'foo ' + 'bar'`)).toBe('foo bar');
-  });
+it('should support string concat (`+`)', () => {
+  expect(parseAndEval(`'foo ' + 'bar'`)).toBe('foo bar');
+});
 
-  it('should throw when it finds other types', () => {
-    expect(() => parseAndEval(`'foo ' + true`)).toThrowError(/Unsupported type/);
-    expect(() => parseAndEval(`'foo ' + 3`)).toThrowError(/Unsupported type/);
-    expect(() => parseAndEval(`'foo ' + null`)).toThrowError(/Unsupported type/);
-    expect(() => parseAndEval(`'foo ' + undefined`)).toThrowError(/Unsupported type/);
-  });
+it('should throw when it finds other types', () => {
+  expect(() => parseAndEval(`'foo ' + true`)).toThrowError(/Unsupported type/);
+  expect(() => parseAndEval(`'foo ' + 3`)).toThrowError(/Unsupported type/);
+  expect(() => parseAndEval(`'foo ' + null`)).toThrowError(/Unsupported type/);
+  expect(() => parseAndEval(`'foo ' + undefined`)).toThrowError(/Unsupported type/);
 });

--- a/scripts/error-codes/__tests__/invertObject-test.js
+++ b/scripts/error-codes/__tests__/invertObject-test.js
@@ -12,43 +12,41 @@ var invertObject = require('../invertObject');
 
 var objectValues = (target) => Object.keys(target).map((key) => target[key]);
 
-describe('invertObject', () => {
-  it('should return an empty object for an empty input', () => {
-    expect(invertObject({})).toEqual({});
-  });
+it('should return an empty object for an empty input', () => {
+  expect(invertObject({})).toEqual({});
+});
 
-  it('should invert key-values', () => {
-    expect(invertObject({
-      a: '3',
-      b: '4',
-    })).toEqual({
-      3: 'a',
-      4: 'b',
-    });
+it('should invert key-values', () => {
+  expect(invertObject({
+    a: '3',
+    b: '4',
+  })).toEqual({
+    3: 'a',
+    4: 'b',
   });
+});
 
-  it('should take the last value when there\'re duplications in vals', () => {
-    expect(invertObject({
-      a: '3',
-      b: '4',
-      c: '3',
-    })).toEqual({
-      4: 'b',
-      3: 'c',
-    });
+it('should take the last value when there\'re duplications in vals', () => {
+  expect(invertObject({
+    a: '3',
+    b: '4',
+    c: '3',
+  })).toEqual({
+    4: 'b',
+    3: 'c',
   });
+});
 
-  it('should perserve the original order', () => {
-    expect(Object.keys(invertObject({
-      a: '3',
-      b: '4',
-      c: '3',
-    }))).toEqual(['3', '4']);
+it('should perserve the original order', () => {
+  expect(Object.keys(invertObject({
+    a: '3',
+    b: '4',
+    c: '3',
+  }))).toEqual(['3', '4']);
 
-    expect(objectValues(invertObject({
-      a: '3',
-      b: '4',
-      c: '3',
-    }))).toEqual(['c', 'b']);
-  });
+  expect(objectValues(invertObject({
+    a: '3',
+    b: '4',
+    c: '3',
+  }))).toEqual(['c', 'b']);
 });

--- a/src/addons/__tests__/ReactComponentWithPureRenderMixin-test.js
+++ b/src/addons/__tests__/ReactComponentWithPureRenderMixin-test.js
@@ -15,131 +15,127 @@ var React;
 var ReactComponentWithPureRenderMixin;
 var ReactTestUtils;
 
-describe('ReactComponentWithPureRenderMixin', function() {
+beforeEach(function() {
+  React = require('React');
+  ReactComponentWithPureRenderMixin =
+    require('ReactComponentWithPureRenderMixin');
+  ReactTestUtils = require('ReactTestUtils');
+});
 
-  beforeEach(function() {
-    React = require('React');
-    ReactComponentWithPureRenderMixin =
-      require('ReactComponentWithPureRenderMixin');
-    ReactTestUtils = require('ReactTestUtils');
-  });
-
-  it('provides a default shouldComponentUpdate implementation', function() {
-    var renderCalls = 0;
-    class PlasticWrap extends React.Component {
-      constructor(props, context) {
-        super(props, context);
-        this.state = {
-          color: 'green',
-        };
-      }
-
-      render() {
-        return (
-          <Apple
-            color={this.state.color}
-            ref="apple"
-          />
-        );
-      }
-    }
-
-    var Apple = React.createClass({
-      mixins: [ReactComponentWithPureRenderMixin],
-
-      getInitialState: function() {
-        return {
-          cut: false,
-          slices: 1,
-        };
-      },
-
-      cut: function() {
-        this.setState({
-          cut: true,
-          slices: 10,
-        });
-      },
-
-      eatSlice: function() {
-        this.setState({
-          slices: this.state.slices - 1,
-        });
-      },
-
-      render: function() {
-        renderCalls++;
-        return <div />;
-      },
-    });
-
-    var instance = ReactTestUtils.renderIntoDocument(<PlasticWrap />);
-    expect(renderCalls).toBe(1);
-
-    // Do not re-render based on props
-    instance.setState({color: 'green'});
-    expect(renderCalls).toBe(1);
-
-    // Re-render based on props
-    instance.setState({color: 'red'});
-    expect(renderCalls).toBe(2);
-
-    // Re-render base on state
-    instance.refs.apple.cut();
-    expect(renderCalls).toBe(3);
-
-    // No re-render based on state
-    instance.refs.apple.cut();
-    expect(renderCalls).toBe(3);
-
-    // Re-render based on state again
-    instance.refs.apple.eatSlice();
-    expect(renderCalls).toBe(4);
-  });
-
-  it('does not do a deep comparison', function() {
-    function getInitialState() {
-      return {
-        foo: [1, 2, 3],
-        bar: {a: 4, b: 5, c: 6},
+it('provides a default shouldComponentUpdate implementation', function() {
+  var renderCalls = 0;
+  class PlasticWrap extends React.Component {
+    constructor(props, context) {
+      super(props, context);
+      this.state = {
+        color: 'green',
       };
     }
 
-    var renderCalls = 0;
-    var initialSettings = getInitialState();
+    render() {
+      return (
+        <Apple
+          color={this.state.color}
+          ref="apple"
+        />
+      );
+    }
+  }
 
-    var Component = React.createClass({
-      mixins: [ReactComponentWithPureRenderMixin],
+  var Apple = React.createClass({
+    mixins: [ReactComponentWithPureRenderMixin],
 
-      getInitialState: function() {
-        return initialSettings;
-      },
+    getInitialState: function() {
+      return {
+        cut: false,
+        slices: 1,
+      };
+    },
 
-      render: function() {
-        renderCalls++;
-        return <div />;
-      },
-    });
+    cut: function() {
+      this.setState({
+        cut: true,
+        slices: 10,
+      });
+    },
 
-    var instance = ReactTestUtils.renderIntoDocument(<Component />);
-    expect(renderCalls).toBe(1);
+    eatSlice: function() {
+      this.setState({
+        slices: this.state.slices - 1,
+      });
+    },
 
-    // Do not re-render if state is equal
-    var settings = {
-      foo: initialSettings.foo,
-      bar: initialSettings.bar,
-    };
-    instance.setState(settings);
-    expect(renderCalls).toBe(1);
-
-    // Re-render because one field changed
-    initialSettings.foo = [1, 2, 3];
-    instance.setState(initialSettings);
-    expect(renderCalls).toBe(2);
-
-    // Re-render because the object changed
-    instance.setState(getInitialState());
-    expect(renderCalls).toBe(3);
+    render: function() {
+      renderCalls++;
+      return <div />;
+    },
   });
 
+  var instance = ReactTestUtils.renderIntoDocument(<PlasticWrap />);
+  expect(renderCalls).toBe(1);
+
+  // Do not re-render based on props
+  instance.setState({color: 'green'});
+  expect(renderCalls).toBe(1);
+
+  // Re-render based on props
+  instance.setState({color: 'red'});
+  expect(renderCalls).toBe(2);
+
+  // Re-render base on state
+  instance.refs.apple.cut();
+  expect(renderCalls).toBe(3);
+
+  // No re-render based on state
+  instance.refs.apple.cut();
+  expect(renderCalls).toBe(3);
+
+  // Re-render based on state again
+  instance.refs.apple.eatSlice();
+  expect(renderCalls).toBe(4);
+});
+
+it('does not do a deep comparison', function() {
+  function getInitialState() {
+    return {
+      foo: [1, 2, 3],
+      bar: {a: 4, b: 5, c: 6},
+    };
+  }
+
+  var renderCalls = 0;
+  var initialSettings = getInitialState();
+
+  var Component = React.createClass({
+    mixins: [ReactComponentWithPureRenderMixin],
+
+    getInitialState: function() {
+      return initialSettings;
+    },
+
+    render: function() {
+      renderCalls++;
+      return <div />;
+    },
+  });
+
+  var instance = ReactTestUtils.renderIntoDocument(<Component />);
+  expect(renderCalls).toBe(1);
+
+  // Do not re-render if state is equal
+  var settings = {
+    foo: initialSettings.foo,
+    bar: initialSettings.bar,
+  };
+  instance.setState(settings);
+  expect(renderCalls).toBe(1);
+
+  // Re-render because one field changed
+  initialSettings.foo = [1, 2, 3];
+  instance.setState(initialSettings);
+  expect(renderCalls).toBe(2);
+
+  // Re-render because the object changed
+  instance.setState(getInitialState());
+  expect(renderCalls).toBe(3);
 });

--- a/src/addons/__tests__/ReactFragment-test.js
+++ b/src/addons/__tests__/ReactFragment-test.js
@@ -15,98 +15,94 @@ var React;
 var ReactDOM;
 var ReactFragment;
 
-describe('ReactFragment', function() {
+beforeEach(function() {
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactFragment = require('ReactFragment');
+});
 
-  beforeEach(function() {
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactFragment = require('ReactFragment');
-  });
+it('should throw if a plain object is used as a child', function() {
+  var children = {
+    x: <span />,
+    y: <span />,
+    z: <span />,
+  };
+  var element = <div>{[children]}</div>;
+  var container = document.createElement('div');
+  expect(() => ReactDOM.render(element, container)).toThrowError(
+    'Objects are not valid as a React child (found: object with keys ' +
+    '{x, y, z}). If you meant to render a collection of children, use an ' +
+    'array instead or wrap the object using createFragment(object) from ' +
+    'the React add-ons.'
+  );
+});
 
-  it('should throw if a plain object is used as a child', function() {
-    var children = {
-      x: <span />,
-      y: <span />,
-      z: <span />,
-    };
-    var element = <div>{[children]}</div>;
-    var container = document.createElement('div');
-    expect(() => ReactDOM.render(element, container)).toThrowError(
-      'Objects are not valid as a React child (found: object with keys ' +
-      '{x, y, z}). If you meant to render a collection of children, use an ' +
-      'array instead or wrap the object using createFragment(object) from ' +
-      'the React add-ons.'
-    );
-  });
-
-  it('should throw if a plain object even if it is in an owner', function() {
-    class Foo extends React.Component {
-      render() {
-        var children = {
-          a: <span />,
-          b: <span />,
-          c: <span />,
-        };
-        return <div>{[children]}</div>;
-      }
+it('should throw if a plain object even if it is in an owner', function() {
+  class Foo extends React.Component {
+    render() {
+      var children = {
+        a: <span />,
+        b: <span />,
+        c: <span />,
+      };
+      return <div>{[children]}</div>;
     }
-    var container = document.createElement('div');
-    expect(() => ReactDOM.render(<Foo />, container)).toThrowError(
-      'Objects are not valid as a React child (found: object with keys ' +
-      '{a, b, c}). If you meant to render a collection of children, use an ' +
-      'array instead or wrap the object using createFragment(object) from ' +
-      'the React add-ons. Check the render method of `Foo`.'
-    );
-  });
+  }
+  var container = document.createElement('div');
+  expect(() => ReactDOM.render(<Foo />, container)).toThrowError(
+    'Objects are not valid as a React child (found: object with keys ' +
+    '{a, b, c}). If you meant to render a collection of children, use an ' +
+    'array instead or wrap the object using createFragment(object) from ' +
+    'the React add-ons. Check the render method of `Foo`.'
+  );
+});
 
-  it('should throw if a plain object looks like an old element', function() {
-    var oldEl = {_isReactElement: true, type: 'span', props: {}};
-    var container = document.createElement('div');
-    expect(() => ReactDOM.render(<div>{oldEl}</div>, container)).toThrowError(
-      'Objects are not valid as a React child (found: object with keys ' +
-      '{_isReactElement, type, props}). It looks like you\'re using an ' +
-      'element created by a different version of React. Make sure to use ' +
-      'only one copy of React.'
-    );
-  });
+it('should throw if a plain object looks like an old element', function() {
+  var oldEl = {_isReactElement: true, type: 'span', props: {}};
+  var container = document.createElement('div');
+  expect(() => ReactDOM.render(<div>{oldEl}</div>, container)).toThrowError(
+    'Objects are not valid as a React child (found: object with keys ' +
+    '{_isReactElement, type, props}). It looks like you\'re using an ' +
+    'element created by a different version of React. Make sure to use ' +
+    'only one copy of React.'
+  );
+});
 
-  it('warns for numeric keys on objects as children', function() {
-    spyOn(console, 'error');
+it('warns for numeric keys on objects as children', function() {
+  spyOn(console, 'error');
 
-    ReactFragment.create({1: <span />, 2: <span />});
+  ReactFragment.create({1: <span />, 2: <span />});
 
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Child objects should have non-numeric keys so ordering is preserved.'
-    );
-  });
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'Child objects should have non-numeric keys so ordering is preserved.'
+  );
+});
 
-  it('should warn if passing null to createFragment', function() {
-    spyOn(console, 'error');
-    ReactFragment.create(null);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'React.addons.createFragment only accepts a single object.'
-    );
-  });
+it('should warn if passing null to createFragment', function() {
+  spyOn(console, 'error');
+  ReactFragment.create(null);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'React.addons.createFragment only accepts a single object.'
+  );
+});
 
-  it('should warn if passing an array to createFragment', function() {
-    spyOn(console, 'error');
-    ReactFragment.create([]);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'React.addons.createFragment only accepts a single object.'
-    );
-  });
+it('should warn if passing an array to createFragment', function() {
+  spyOn(console, 'error');
+  ReactFragment.create([]);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'React.addons.createFragment only accepts a single object.'
+  );
+});
 
-  it('should warn if passing a ReactElement to createFragment', function() {
-    spyOn(console, 'error');
-    ReactFragment.create(<div />);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'React.addons.createFragment does not accept a ReactElement without a ' +
-      'wrapper object.'
-    );
-  });
-
+it('should warn if passing a ReactElement to createFragment', function() {
+  spyOn(console, 'error');
+  ReactFragment.create(<div />);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'React.addons.createFragment does not accept a ReactElement without a ' +
+    'wrapper object.'
+  );
 });

--- a/src/addons/__tests__/renderSubtreeIntoContainer-test.js
+++ b/src/addons/__tests__/renderSubtreeIntoContainer-test.js
@@ -16,181 +16,177 @@ var ReactDOM = require('ReactDOM');
 var ReactTestUtils = require('ReactTestUtils');
 var renderSubtreeIntoContainer = require('renderSubtreeIntoContainer');
 
-describe('renderSubtreeIntoContainer', function() {
+it('should pass context when rendering subtree elsewhere', function() {
+  var portal = document.createElement('div');
 
-  it('should pass context when rendering subtree elsewhere', function() {
-    var portal = document.createElement('div');
+  class Component extends React.Component {
+    static contextTypes = {
+      foo: React.PropTypes.string.isRequired,
+    };
 
-    class Component extends React.Component {
-      static contextTypes = {
-        foo: React.PropTypes.string.isRequired,
+    render() {
+      return <div>{this.context.foo}</div>;
+    }
+  }
+
+  class Parent extends React.Component {
+    static childContextTypes = {
+      foo: React.PropTypes.string.isRequired,
+    };
+
+    getChildContext() {
+      return {
+        foo: 'bar',
       };
-
-      render() {
-        return <div>{this.context.foo}</div>;
-      }
     }
 
-    class Parent extends React.Component {
-      static childContextTypes = {
-        foo: React.PropTypes.string.isRequired,
-      };
-
-      getChildContext() {
-        return {
-          foo: 'bar',
-        };
-      }
-
-      render() {
-        return null;
-      }
-
-      componentDidMount() {
-        expect(function() {
-          renderSubtreeIntoContainer(this, <Component />, portal);
-        }.bind(this)).not.toThrow();
-      }
+    render() {
+      return null;
     }
 
-    ReactTestUtils.renderIntoDocument(<Parent />);
-    expect(portal.firstChild.innerHTML).toBe('bar');
-  });
-
-  it('should throw if parentComponent is invalid', function() {
-    var portal = document.createElement('div');
-
-    class Component extends React.Component {
-      static contextTypes = {
-        foo: React.PropTypes.string.isRequired,
-      };
-
-      render() {
-        return <div>{this.context.foo}</div>;
-      }
-    }
-
-    class Parent extends React.Component {
-      static childContextTypes = {
-        foo: React.PropTypes.string.isRequired,
-      };
-
-      getChildContext() {
-        return {
-          foo: 'bar',
-        };
-      }
-
-      render() {
-        return null;
-      }
-
-      componentDidMount() {
-        expect(function() {
-          renderSubtreeIntoContainer(<Parent />, <Component />, portal);
-        }).toThrowError('parentComponentmust be a valid React Component');
-      }
-    }
-  });
-
-  it('should update context if it changes due to setState', function() {
-    var container = document.createElement('div');
-    document.body.appendChild(container);
-    var portal = document.createElement('div');
-
-    class Component extends React.Component {
-      static contextTypes = {
-        foo: React.PropTypes.string.isRequired,
-        getFoo: React.PropTypes.func.isRequired,
-      };
-
-      render() {
-        return <div>{this.context.foo + '-' + this.context.getFoo()}</div>;
-      }
-    }
-
-    class Parent extends React.Component {
-      static childContextTypes = {
-        foo: React.PropTypes.string.isRequired,
-        getFoo: React.PropTypes.func.isRequired,
-      };
-
-      state = {
-        bar: 'initial',
-      };
-
-      getChildContext() {
-        return {
-          foo: this.state.bar,
-          getFoo: () => this.state.bar,
-        };
-      }
-
-      render() {
-        return null;
-      }
-
-      componentDidMount() {
+    componentDidMount() {
+      expect(function() {
         renderSubtreeIntoContainer(this, <Component />, portal);
-      }
-
-      componentDidUpdate() {
-        renderSubtreeIntoContainer(this, <Component />, portal);
-      }
+      }.bind(this)).not.toThrow();
     }
+  }
 
-    var instance = ReactDOM.render(<Parent />, container);
-    expect(portal.firstChild.innerHTML).toBe('initial-initial');
-    instance.setState({bar: 'changed'});
-    expect(portal.firstChild.innerHTML).toBe('changed-changed');
-  });
+  ReactTestUtils.renderIntoDocument(<Parent />);
+  expect(portal.firstChild.innerHTML).toBe('bar');
+});
 
-  it('should update context if it changes due to re-render', function() {
-    var container = document.createElement('div');
-    document.body.appendChild(container);
-    var portal = document.createElement('div');
+it('should throw if parentComponent is invalid', function() {
+  var portal = document.createElement('div');
 
-    class Component extends React.Component {
-      static contextTypes = {
-        foo: React.PropTypes.string.isRequired,
-        getFoo: React.PropTypes.func.isRequired,
+  class Component extends React.Component {
+    static contextTypes = {
+      foo: React.PropTypes.string.isRequired,
+    };
+
+    render() {
+      return <div>{this.context.foo}</div>;
+    }
+  }
+
+  class Parent extends React.Component {
+    static childContextTypes = {
+      foo: React.PropTypes.string.isRequired,
+    };
+
+    getChildContext() {
+      return {
+        foo: 'bar',
       };
-
-      render() {
-        return <div>{this.context.foo + '-' + this.context.getFoo()}</div>;
-      }
     }
 
-    class Parent extends React.Component {
-      static childContextTypes = {
-        foo: React.PropTypes.string.isRequired,
-        getFoo: React.PropTypes.func.isRequired,
+    render() {
+      return null;
+    }
+
+    componentDidMount() {
+      expect(function() {
+        renderSubtreeIntoContainer(<Parent />, <Component />, portal);
+      }).toThrowError('parentComponentmust be a valid React Component');
+    }
+  }
+});
+
+it('should update context if it changes due to setState', function() {
+  var container = document.createElement('div');
+  document.body.appendChild(container);
+  var portal = document.createElement('div');
+
+  class Component extends React.Component {
+    static contextTypes = {
+      foo: React.PropTypes.string.isRequired,
+      getFoo: React.PropTypes.func.isRequired,
+    };
+
+    render() {
+      return <div>{this.context.foo + '-' + this.context.getFoo()}</div>;
+    }
+  }
+
+  class Parent extends React.Component {
+    static childContextTypes = {
+      foo: React.PropTypes.string.isRequired,
+      getFoo: React.PropTypes.func.isRequired,
+    };
+
+    state = {
+      bar: 'initial',
+    };
+
+    getChildContext() {
+      return {
+        foo: this.state.bar,
+        getFoo: () => this.state.bar,
       };
-
-      getChildContext() {
-        return {
-          foo: this.props.bar,
-          getFoo: () => this.props.bar,
-        };
-      }
-
-      render() {
-        return null;
-      }
-
-      componentDidMount() {
-        renderSubtreeIntoContainer(this, <Component />, portal);
-      }
-
-      componentDidUpdate() {
-        renderSubtreeIntoContainer(this, <Component />, portal);
-      }
     }
 
-    ReactDOM.render(<Parent bar="initial" />, container);
-    expect(portal.firstChild.innerHTML).toBe('initial-initial');
-    ReactDOM.render(<Parent bar="changed" />, container);
-    expect(portal.firstChild.innerHTML).toBe('changed-changed');
-  });
+    render() {
+      return null;
+    }
 
+    componentDidMount() {
+      renderSubtreeIntoContainer(this, <Component />, portal);
+    }
+
+    componentDidUpdate() {
+      renderSubtreeIntoContainer(this, <Component />, portal);
+    }
+  }
+
+  var instance = ReactDOM.render(<Parent />, container);
+  expect(portal.firstChild.innerHTML).toBe('initial-initial');
+  instance.setState({bar: 'changed'});
+  expect(portal.firstChild.innerHTML).toBe('changed-changed');
+});
+
+it('should update context if it changes due to re-render', function() {
+  var container = document.createElement('div');
+  document.body.appendChild(container);
+  var portal = document.createElement('div');
+
+  class Component extends React.Component {
+    static contextTypes = {
+      foo: React.PropTypes.string.isRequired,
+      getFoo: React.PropTypes.func.isRequired,
+    };
+
+    render() {
+      return <div>{this.context.foo + '-' + this.context.getFoo()}</div>;
+    }
+  }
+
+  class Parent extends React.Component {
+    static childContextTypes = {
+      foo: React.PropTypes.string.isRequired,
+      getFoo: React.PropTypes.func.isRequired,
+    };
+
+    getChildContext() {
+      return {
+        foo: this.props.bar,
+        getFoo: () => this.props.bar,
+      };
+    }
+
+    render() {
+      return null;
+    }
+
+    componentDidMount() {
+      renderSubtreeIntoContainer(this, <Component />, portal);
+    }
+
+    componentDidUpdate() {
+      renderSubtreeIntoContainer(this, <Component />, portal);
+    }
+  }
+
+  ReactDOM.render(<Parent bar="initial" />, container);
+  expect(portal.firstChild.innerHTML).toBe('initial-initial');
+  ReactDOM.render(<Parent bar="changed" />, container);
+  expect(portal.firstChild.innerHTML).toBe('changed-changed');
 });

--- a/src/addons/__tests__/update-test.js
+++ b/src/addons/__tests__/update-test.js
@@ -13,173 +13,170 @@
 
 var update = require('update');
 
-describe('update', function() {
-
-  describe('$push', function() {
-    it('pushes', function() {
-      expect(update([1], {$push: [7]})).toEqual([1, 7]);
-    });
-    it('does not mutate the original object', function() {
-      var obj = [1];
-      update(obj, {$push: [7]});
-      expect(obj).toEqual([1]);
-    });
-    it('only pushes an array', function() {
-      expect(update.bind(null, [], {$push: 7})).toThrowError(
-        'update(): expected spec of $push to be an array; got 7. Did you ' +
-        'forget to wrap your parameter in an array?'
-      );
-    });
-    it('only pushes unto an array', function() {
-      expect(update.bind(null, 1, {$push: 7})).toThrowError(
-        'update(): expected target of $push to be an array; got 1.'
-      );
-    });
+describe('$push', function() {
+  it('pushes', function() {
+    expect(update([1], {$push: [7]})).toEqual([1, 7]);
   });
-
-  describe('$unshift', function() {
-    it('unshifts', function() {
-      expect(update([1], {$unshift: [7]})).toEqual([7, 1]);
-    });
-    it('does not mutate the original object', function() {
-      var obj = [1];
-      update(obj, {$unshift: [7]});
-      expect(obj).toEqual([1]);
-    });
-    it('only unshifts an array', function() {
-      expect(update.bind(null, [], {$unshift: 7})).toThrowError(
-        'update(): expected spec of $unshift to be an array; got 7. Did you ' +
-        'forget to wrap your parameter in an array?'
-      );
-    });
-    it('only unshifts unto an array', function() {
-      expect(update.bind(null, 1, {$unshift: 7})).toThrowError(
-        'update(): expected target of $unshift to be an array; got 1.'
-      );
-    });
+  it('does not mutate the original object', function() {
+    var obj = [1];
+    update(obj, {$push: [7]});
+    expect(obj).toEqual([1]);
   });
-
-  describe('$splice', function() {
-    it('splices', function() {
-      expect(update([1, 4, 3], {$splice: [[1, 1, 2]]})).toEqual([1, 2, 3]);
-    });
-    it('does not mutate the original object', function() {
-      var obj = [1, 4, 3];
-      update(obj, {$splice: [[1, 1, 2]]});
-      expect(obj).toEqual([1, 4, 3]);
-    });
-    it('only splices an array of arrays', function() {
-      expect(update.bind(null, [], {$splice: 1})).toThrowError(
-        'update(): expected spec of $splice to be an array of arrays; got 1. ' +
-        'Did you forget to wrap your parameters in an array?'
-      );
-      expect(update.bind(null, [], {$splice: [1]})).toThrowError(
-        'update(): expected spec of $splice to be an array of arrays; got 1. ' +
-        'Did you forget to wrap your parameters in an array?'
-      );
-    });
-    it('only splices unto an array', function() {
-      expect(update.bind(null, 1, {$splice: 7})).toThrowError(
-        'Expected $splice target to be an array; got 1'
-      );
-    });
-  });
-
-  describe('$merge', function() {
-    it('merges', function() {
-      expect(update({a: 'b'}, {$merge: {c: 'd'}})).toEqual({a: 'b', c: 'd'});
-    });
-    it('does not mutate the original object', function() {
-      var obj = {a: 'b'};
-      update(obj, {$merge: {c: 'd'}});
-      expect(obj).toEqual({a: 'b'});
-    });
-    it('only merges with an object', function() {
-      expect(update.bind(null, {}, {$merge: 7})).toThrowError(
-        'update(): $merge expects a spec of type \'object\'; got 7'
-      );
-    });
-    it('only merges with an object', function() {
-      expect(update.bind(null, 7, {$merge: {a: 'b'}})).toThrowError(
-        'update(): $merge expects a target of type \'object\'; got 7'
-      );
-    });
-  });
-
-  describe('$set', function() {
-    it('sets', function() {
-      expect(update({a: 'b'}, {$set: {c: 'd'}})).toEqual({c: 'd'});
-    });
-    it('does not mutate the original object', function() {
-      var obj = {a: 'b'};
-      update(obj, {$set: {c: 'd'}});
-      expect(obj).toEqual({a: 'b'});
-    });
-  });
-
-  describe('$apply', function() {
-    var applier = function(node) {
-      return {v: node.v * 2};
-    };
-    it('applies', function() {
-      expect(update({v: 2}, {$apply: applier})).toEqual({v: 4});
-    });
-    it('does not mutate the original object', function() {
-      var obj = {v: 2};
-      update(obj, {$apply: applier});
-      expect(obj).toEqual({v: 2});
-    });
-    it('only applies a function', function() {
-      expect(update.bind(null, 2, {$apply: 123})).toThrowError(
-        'update(): expected spec of $apply to be a function; got 123.'
-      );
-    });
-  });
-
-  it('should support deep updates', function() {
-    expect(update({
-      a: 'b',
-      c: {
-        d: 'e',
-        f: [1],
-        g: [2],
-        h: [3],
-        i: {j: 'k'},
-        l: 4,
-      },
-    }, {
-      c: {
-        d: {$set: 'm'},
-        f: {$push: [5]},
-        g: {$unshift: [6]},
-        h: {$splice: [[0, 1, 7]]},
-        i: {$merge: {n: 'o'}},
-        l: {$apply: (x) => x * 2},
-      },
-    })).toEqual({
-      a: 'b',
-      c: {
-        d: 'm',
-        f: [1, 5],
-        g: [6, 2],
-        h: [7],
-        i: {j: 'k', n: 'o'},
-        l: 8,
-      },
-    });
-  });
-
-  it('should require a command', function() {
-    expect(update.bind(null, {a: 'b'}, {a: 'c'})).toThrowError(
-      'update(): You provided a key path to update() that did not contain ' +
-      'one of $push, $unshift, $splice, $set, $merge, $apply. Did you ' +
-      'forget to include {$set: ...}?'
+  it('only pushes an array', function() {
+    expect(update.bind(null, [], {$push: 7})).toThrowError(
+      'update(): expected spec of $push to be an array; got 7. Did you ' +
+      'forget to wrap your parameter in an array?'
     );
   });
+  it('only pushes unto an array', function() {
+    expect(update.bind(null, 1, {$push: 7})).toThrowError(
+      'update(): expected target of $push to be an array; got 1.'
+    );
+  });
+});
 
-  it('should perform safe hasOwnProperty check', function() {
-    expect(update({}, {'hasOwnProperty': {$set: 'a'}})).toEqual({
-      'hasOwnProperty': 'a',
-    });
+describe('$unshift', function() {
+  it('unshifts', function() {
+    expect(update([1], {$unshift: [7]})).toEqual([7, 1]);
+  });
+  it('does not mutate the original object', function() {
+    var obj = [1];
+    update(obj, {$unshift: [7]});
+    expect(obj).toEqual([1]);
+  });
+  it('only unshifts an array', function() {
+    expect(update.bind(null, [], {$unshift: 7})).toThrowError(
+      'update(): expected spec of $unshift to be an array; got 7. Did you ' +
+      'forget to wrap your parameter in an array?'
+    );
+  });
+  it('only unshifts unto an array', function() {
+    expect(update.bind(null, 1, {$unshift: 7})).toThrowError(
+      'update(): expected target of $unshift to be an array; got 1.'
+    );
+  });
+});
+
+describe('$splice', function() {
+  it('splices', function() {
+    expect(update([1, 4, 3], {$splice: [[1, 1, 2]]})).toEqual([1, 2, 3]);
+  });
+  it('does not mutate the original object', function() {
+    var obj = [1, 4, 3];
+    update(obj, {$splice: [[1, 1, 2]]});
+    expect(obj).toEqual([1, 4, 3]);
+  });
+  it('only splices an array of arrays', function() {
+    expect(update.bind(null, [], {$splice: 1})).toThrowError(
+      'update(): expected spec of $splice to be an array of arrays; got 1. ' +
+      'Did you forget to wrap your parameters in an array?'
+    );
+    expect(update.bind(null, [], {$splice: [1]})).toThrowError(
+      'update(): expected spec of $splice to be an array of arrays; got 1. ' +
+      'Did you forget to wrap your parameters in an array?'
+    );
+  });
+  it('only splices unto an array', function() {
+    expect(update.bind(null, 1, {$splice: 7})).toThrowError(
+      'Expected $splice target to be an array; got 1'
+    );
+  });
+});
+
+describe('$merge', function() {
+  it('merges', function() {
+    expect(update({a: 'b'}, {$merge: {c: 'd'}})).toEqual({a: 'b', c: 'd'});
+  });
+  it('does not mutate the original object', function() {
+    var obj = {a: 'b'};
+    update(obj, {$merge: {c: 'd'}});
+    expect(obj).toEqual({a: 'b'});
+  });
+  it('only merges with an object', function() {
+    expect(update.bind(null, {}, {$merge: 7})).toThrowError(
+      'update(): $merge expects a spec of type \'object\'; got 7'
+    );
+  });
+  it('only merges with an object', function() {
+    expect(update.bind(null, 7, {$merge: {a: 'b'}})).toThrowError(
+      'update(): $merge expects a target of type \'object\'; got 7'
+    );
+  });
+});
+
+describe('$set', function() {
+  it('sets', function() {
+    expect(update({a: 'b'}, {$set: {c: 'd'}})).toEqual({c: 'd'});
+  });
+  it('does not mutate the original object', function() {
+    var obj = {a: 'b'};
+    update(obj, {$set: {c: 'd'}});
+    expect(obj).toEqual({a: 'b'});
+  });
+});
+
+describe('$apply', function() {
+  var applier = function(node) {
+    return {v: node.v * 2};
+  };
+  it('applies', function() {
+    expect(update({v: 2}, {$apply: applier})).toEqual({v: 4});
+  });
+  it('does not mutate the original object', function() {
+    var obj = {v: 2};
+    update(obj, {$apply: applier});
+    expect(obj).toEqual({v: 2});
+  });
+  it('only applies a function', function() {
+    expect(update.bind(null, 2, {$apply: 123})).toThrowError(
+      'update(): expected spec of $apply to be a function; got 123.'
+    );
+  });
+});
+
+it('should support deep updates', function() {
+  expect(update({
+    a: 'b',
+    c: {
+      d: 'e',
+      f: [1],
+      g: [2],
+      h: [3],
+      i: {j: 'k'},
+      l: 4,
+    },
+  }, {
+    c: {
+      d: {$set: 'm'},
+      f: {$push: [5]},
+      g: {$unshift: [6]},
+      h: {$splice: [[0, 1, 7]]},
+      i: {$merge: {n: 'o'}},
+      l: {$apply: (x) => x * 2},
+    },
+  })).toEqual({
+    a: 'b',
+    c: {
+      d: 'm',
+      f: [1, 5],
+      g: [6, 2],
+      h: [7],
+      i: {j: 'k', n: 'o'},
+      l: 8,
+    },
+  });
+});
+
+it('should require a command', function() {
+  expect(update.bind(null, {a: 'b'}, {a: 'c'})).toThrowError(
+    'update(): You provided a key path to update() that did not contain ' +
+    'one of $push, $unshift, $splice, $set, $merge, $apply. Did you ' +
+    'forget to include {$set: ...}?'
+  );
+});
+
+it('should perform safe hasOwnProperty check', function() {
+  expect(update({}, {'hasOwnProperty': {$set: 'a'}})).toEqual({
+    'hasOwnProperty': 'a',
   });
 });

--- a/src/addons/link/__tests__/LinkedStateMixin-test.js
+++ b/src/addons/link/__tests__/LinkedStateMixin-test.js
@@ -12,35 +12,33 @@
 'use strict';
 
 
-describe('LinkedStateMixin', function() {
-  var LinkedStateMixin;
-  var React;
-  var ReactTestUtils;
+var LinkedStateMixin;
+var React;
+var ReactTestUtils;
 
-  beforeEach(function() {
-    LinkedStateMixin = require('LinkedStateMixin');
-    React = require('React');
-    ReactTestUtils = require('ReactTestUtils');
+beforeEach(function() {
+  LinkedStateMixin = require('LinkedStateMixin');
+  React = require('React');
+  ReactTestUtils = require('ReactTestUtils');
+});
+
+it('should create a ReactLink for state', function() {
+  var Component = React.createClass({
+    mixins: [LinkedStateMixin],
+
+    getInitialState: function() {
+      return {value: 'initial value'};
+    },
+
+    render: function() {
+      return <span>value is {this.state.value}</span>;
+    },
   });
-
-  it('should create a ReactLink for state', function() {
-    var Component = React.createClass({
-      mixins: [LinkedStateMixin],
-
-      getInitialState: function() {
-        return {value: 'initial value'};
-      },
-
-      render: function() {
-        return <span>value is {this.state.value}</span>;
-      },
-    });
-    var component = ReactTestUtils.renderIntoDocument(<Component />);
-    var link = component.linkState('value');
-    expect(component.state.value).toBe('initial value');
-    expect(link.value).toBe('initial value');
-    link.requestChange('new value');
-    expect(component.state.value).toBe('new value');
-    expect(component.linkState('value').value).toBe('new value');
-  });
+  var component = ReactTestUtils.renderIntoDocument(<Component />);
+  var link = component.linkState('value');
+  expect(component.state.value).toBe('initial value');
+  expect(link.value).toBe('initial value');
+  link.requestChange('new value');
+  expect(component.state.value).toBe('new value');
+  expect(component.linkState('value').value).toBe('new value');
 });

--- a/src/addons/link/__tests__/ReactLinkPropTypes-test.js
+++ b/src/addons/link/__tests__/ReactLinkPropTypes-test.js
@@ -47,118 +47,116 @@ function typeCheckPass(declaration, value) {
   expect(error).toBe(null);
 }
 
-describe('ReactLink', function() {
-  it('should fail if the argument does not implement the Link API', function() {
-    typeCheckFail(
-      LinkPropTypes.link(React.PropTypes.any),
-      {},
-      'The prop `testProp.value` is marked as required in `testComponent`, ' +
-        'but its value is `undefined`.'
-    );
-    typeCheckFail(
-      LinkPropTypes.link(React.PropTypes.any),
-      {value: 123},
-      'The prop `testProp.requestChange` is marked as required in ' +
-        '`testComponent`, but its value is `undefined`.'
-    );
-    typeCheckFail(
-      LinkPropTypes.link(React.PropTypes.any),
-      {requestChange: emptyFunction},
-      'The prop `testProp.value` is marked as required in `testComponent`, ' +
-        'but its value is `undefined`.'
-    );
-    typeCheckFail(
-      LinkPropTypes.link(React.PropTypes.any),
-      {value: null, requestChange: null},
-      'The prop `testProp.value` is marked as required in `testComponent`, ' +
-        'but its value is `null`.'
-    );
-  });
+it('should fail if the argument does not implement the Link API', function() {
+  typeCheckFail(
+    LinkPropTypes.link(React.PropTypes.any),
+    {},
+    'The prop `testProp.value` is marked as required in `testComponent`, ' +
+      'but its value is `undefined`.'
+  );
+  typeCheckFail(
+    LinkPropTypes.link(React.PropTypes.any),
+    {value: 123},
+    'The prop `testProp.requestChange` is marked as required in ' +
+      '`testComponent`, but its value is `undefined`.'
+  );
+  typeCheckFail(
+    LinkPropTypes.link(React.PropTypes.any),
+    {requestChange: emptyFunction},
+    'The prop `testProp.value` is marked as required in `testComponent`, ' +
+      'but its value is `undefined`.'
+  );
+  typeCheckFail(
+    LinkPropTypes.link(React.PropTypes.any),
+    {value: null, requestChange: null},
+    'The prop `testProp.value` is marked as required in `testComponent`, ' +
+      'but its value is `null`.'
+  );
+});
 
-  it('should allow valid links even if no type was specified', function() {
-    typeCheckPass(
-      LinkPropTypes.link(),
-      {value: 42, requestChange: emptyFunction}
-    );
-    typeCheckPass(
-      LinkPropTypes.link(),
-      {value: {}, requestChange: emptyFunction,
-    });
+it('should allow valid links even if no type was specified', function() {
+  typeCheckPass(
+    LinkPropTypes.link(),
+    {value: 42, requestChange: emptyFunction}
+  );
+  typeCheckPass(
+    LinkPropTypes.link(),
+    {value: {}, requestChange: emptyFunction,
   });
+});
 
-  it('should allow no link to be passed at all', function() {
-    typeCheckPass(
-      LinkPropTypes.link(React.PropTypes.string),
-      undefined
-    );
-  });
+it('should allow no link to be passed at all', function() {
+  typeCheckPass(
+    LinkPropTypes.link(React.PropTypes.string),
+    undefined
+  );
+});
 
-  it('should allow valid links with correct value format', function() {
-    typeCheckPass(
-      LinkPropTypes.link(React.PropTypes.any),
-      {value: 42, requestChange: emptyFunction}
-    );
-    typeCheckPass(
-      LinkPropTypes.link(React.PropTypes.number),
-      {value: 42, requestChange: emptyFunction}
-    );
-    typeCheckPass(
-      LinkPropTypes.link(React.PropTypes.node),
-      {value: 42, requestChange: emptyFunction}
-    );
-  });
+it('should allow valid links with correct value format', function() {
+  typeCheckPass(
+    LinkPropTypes.link(React.PropTypes.any),
+    {value: 42, requestChange: emptyFunction}
+  );
+  typeCheckPass(
+    LinkPropTypes.link(React.PropTypes.number),
+    {value: 42, requestChange: emptyFunction}
+  );
+  typeCheckPass(
+    LinkPropTypes.link(React.PropTypes.node),
+    {value: 42, requestChange: emptyFunction}
+  );
+});
 
-  it('should fail if the link`s value type does not match', function() {
-    typeCheckFail(
-      LinkPropTypes.link(React.PropTypes.string),
-      {value: 123, requestChange: emptyFunction},
-      'Invalid prop `testProp.value` of type `number` supplied to `testComponent`,' +
-      ' expected `string`.'
-    );
-  });
+it('should fail if the link`s value type does not match', function() {
+  typeCheckFail(
+    LinkPropTypes.link(React.PropTypes.string),
+    {value: 123, requestChange: emptyFunction},
+    'Invalid prop `testProp.value` of type `number` supplied to `testComponent`,' +
+    ' expected `string`.'
+  );
+});
 
-  it('should be implicitly optional and not warn without values', function() {
-    typeCheckPass(LinkPropTypes.link(), null);
-    typeCheckPass(LinkPropTypes.link(), undefined);
-    typeCheckPass(LinkPropTypes.link(React.PropTypes.string), null);
-    typeCheckPass(LinkPropTypes.link(React.PropTypes.string), undefined);
-  });
+it('should be implicitly optional and not warn without values', function() {
+  typeCheckPass(LinkPropTypes.link(), null);
+  typeCheckPass(LinkPropTypes.link(), undefined);
+  typeCheckPass(LinkPropTypes.link(React.PropTypes.string), null);
+  typeCheckPass(LinkPropTypes.link(React.PropTypes.string), undefined);
+});
 
-  it('should warn for missing required values', function() {
-    var specifiedButIsNullMsg = 'The prop `testProp` is marked as required ' +
-      'in `testComponent`, but its value is `null`.';
-    typeCheckFail(LinkPropTypes.link().isRequired, null, specifiedButIsNullMsg);
-    typeCheckFail(LinkPropTypes.link().isRequired, undefined, requiredMessage);
-    typeCheckFail(
-      LinkPropTypes.link(React.PropTypes.string).isRequired,
-      null,
-      specifiedButIsNullMsg
-    );
-    typeCheckFail(
-      LinkPropTypes.link(React.PropTypes.string).isRequired,
-      undefined,
-      requiredMessage
-    );
-  });
+it('should warn for missing required values', function() {
+  var specifiedButIsNullMsg = 'The prop `testProp` is marked as required ' +
+    'in `testComponent`, but its value is `null`.';
+  typeCheckFail(LinkPropTypes.link().isRequired, null, specifiedButIsNullMsg);
+  typeCheckFail(LinkPropTypes.link().isRequired, undefined, requiredMessage);
+  typeCheckFail(
+    LinkPropTypes.link(React.PropTypes.string).isRequired,
+    null,
+    specifiedButIsNullMsg
+  );
+  typeCheckFail(
+    LinkPropTypes.link(React.PropTypes.string).isRequired,
+    undefined,
+    requiredMessage
+  );
+});
 
-  it('should be compatible with React.PropTypes.oneOfType', function() {
-    typeCheckPass(
-      React.PropTypes.oneOfType([LinkPropTypes.link(React.PropTypes.number)]),
-      {value: 123, requestChange: emptyFunction}
-    );
-    typeCheckFail(
-      React.PropTypes.oneOfType([LinkPropTypes.link(React.PropTypes.number)]),
-      123,
-      invalidMessage
-    );
-    typeCheckPass(
-      LinkPropTypes.link(React.PropTypes.oneOfType([React.PropTypes.number])),
-      {value: 123, requestChange: emptyFunction}
-    );
-    typeCheckFail(
-      LinkPropTypes.link(React.PropTypes.oneOfType([React.PropTypes.number])),
-      {value: 'imastring', requestChange: emptyFunction},
-      'Invalid prop `testProp.value` supplied to `testComponent`.'
-    );
-  });
+it('should be compatible with React.PropTypes.oneOfType', function() {
+  typeCheckPass(
+    React.PropTypes.oneOfType([LinkPropTypes.link(React.PropTypes.number)]),
+    {value: 123, requestChange: emptyFunction}
+  );
+  typeCheckFail(
+    React.PropTypes.oneOfType([LinkPropTypes.link(React.PropTypes.number)]),
+    123,
+    invalidMessage
+  );
+  typeCheckPass(
+    LinkPropTypes.link(React.PropTypes.oneOfType([React.PropTypes.number])),
+    {value: 123, requestChange: emptyFunction}
+  );
+  typeCheckFail(
+    LinkPropTypes.link(React.PropTypes.oneOfType([React.PropTypes.number])),
+    {value: 'imastring', requestChange: emptyFunction},
+    'Invalid prop `testProp.value` supplied to `testComponent`.'
+  );
 });

--- a/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
@@ -17,314 +17,310 @@ var React;
 var ReactDOM;
 var ReactCSSTransitionGroup;
 
-// Most of the real functionality is covered in other unit tests, this just
-// makes sure we're wired up correctly.
-describe('ReactCSSTransitionGroup', function() {
-  var container;
+var container;
 
-  beforeEach(function() {
-    jest.resetModuleRegistry();
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactCSSTransitionGroup = require('ReactCSSTransitionGroup');
+beforeEach(function() {
+  jest.resetModuleRegistry();
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactCSSTransitionGroup = require('ReactCSSTransitionGroup');
 
-    container = document.createElement('div');
-    spyOn(console, 'error');
-  });
+  container = document.createElement('div');
+  spyOn(console, 'error');
+});
 
-  it('should warn if timeouts aren\'t specified', function() {
-    ReactDOM.render(
-      <ReactCSSTransitionGroup
-        transitionName="yolo"
-        transitionEnter={false}
-        transitionLeave={true}
-      >
-        <span key="one" id="one" />
-      </ReactCSSTransitionGroup>,
-      container
-    );
+it('should warn if timeouts aren\'t specified', function() {
+  ReactDOM.render(
+    <ReactCSSTransitionGroup
+      transitionName="yolo"
+      transitionEnter={false}
+      transitionLeave={true}
+    >
+      <span key="one" id="one" />
+    </ReactCSSTransitionGroup>,
+    container
+  );
 
-    // Warning about the missing transitionLeaveTimeout prop
-    expect(console.error.calls.count()).toBe(1);
-  });
+  // Warning about the missing transitionLeaveTimeout prop
+  expect(console.error.calls.count()).toBe(1);
+});
 
-  it('should not warn if timeouts is zero', function() {
-    ReactDOM.render(
-      <ReactCSSTransitionGroup
-        transitionName="yolo"
-        transitionEnter={false}
-        transitionLeave={true}
-        transitionLeaveTimeout={0}
-      >
-        <span key="one" id="one" />
-      </ReactCSSTransitionGroup>,
-      container
-    );
+it('should not warn if timeouts is zero', function() {
+  ReactDOM.render(
+    <ReactCSSTransitionGroup
+      transitionName="yolo"
+      transitionEnter={false}
+      transitionLeave={true}
+      transitionLeaveTimeout={0}
+    >
+      <span key="one" id="one" />
+    </ReactCSSTransitionGroup>,
+    container
+  );
 
-    expect(console.error.calls.count()).toBe(0);
-  });
+  expect(console.error.calls.count()).toBe(0);
+});
 
-  it('should clean-up silently after the timeout elapses', function() {
-    var a = ReactDOM.render(
-      <ReactCSSTransitionGroup
-        transitionName="yolo"
-        transitionEnter={false}
-        transitionLeaveTimeout={200}
-      >
-        <span key="one" id="one" />
-      </ReactCSSTransitionGroup>,
-      container
-    );
-    expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);
+it('should clean-up silently after the timeout elapses', function() {
+  var a = ReactDOM.render(
+    <ReactCSSTransitionGroup
+      transitionName="yolo"
+      transitionEnter={false}
+      transitionLeaveTimeout={200}
+    >
+      <span key="one" id="one" />
+    </ReactCSSTransitionGroup>,
+    container
+  );
+  expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);
 
-    setTimeout.mock.calls.length = 0;
+  setTimeout.mock.calls.length = 0;
 
-    ReactDOM.render(
-      <ReactCSSTransitionGroup
-        transitionName="yolo"
-        transitionEnter={false}
-        transitionLeaveTimeout={200}
-      >
-        <span key="two" id="two" />
-      </ReactCSSTransitionGroup>,
-      container
-    );
-    expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(2);
-    expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('two');
-    expect(ReactDOM.findDOMNode(a).childNodes[1].id).toBe('one');
+  ReactDOM.render(
+    <ReactCSSTransitionGroup
+      transitionName="yolo"
+      transitionEnter={false}
+      transitionLeaveTimeout={200}
+    >
+      <span key="two" id="two" />
+    </ReactCSSTransitionGroup>,
+    container
+  );
+  expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(2);
+  expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('two');
+  expect(ReactDOM.findDOMNode(a).childNodes[1].id).toBe('one');
 
-    // For some reason jst is adding extra setTimeout()s and grunt test isn't,
-    // so we need to do this disgusting hack.
-    for (var i = 0; i < setTimeout.mock.calls.length; i++) {
-      if (setTimeout.mock.calls[i][1] === 200) {
-        setTimeout.mock.calls[i][0]();
-        break;
-      }
+  // For some reason jst is adding extra setTimeout()s and grunt test isn't,
+  // so we need to do this disgusting hack.
+  for (var i = 0; i < setTimeout.mock.calls.length; i++) {
+    if (setTimeout.mock.calls[i][1] === 200) {
+      setTimeout.mock.calls[i][0]();
+      break;
     }
+  }
 
-    // No warnings
-    expect(console.error.calls.count()).toBe(0);
+  // No warnings
+  expect(console.error.calls.count()).toBe(0);
 
-    // The leaving child has been removed
-    expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);
-    expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('two');
-  });
+  // The leaving child has been removed
+  expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);
+  expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('two');
+});
 
-  it('should keep both sets of DOM nodes around', function() {
-    var a = ReactDOM.render(
-      <ReactCSSTransitionGroup transitionName="yolo">
-        <span key="one" id="one" />
-      </ReactCSSTransitionGroup>,
-      container
-    );
-    expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);
-    ReactDOM.render(
-      <ReactCSSTransitionGroup transitionName="yolo">
-        <span key="two" id="two" />
-      </ReactCSSTransitionGroup>,
-      container
-    );
-    expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(2);
-    expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('two');
-    expect(ReactDOM.findDOMNode(a).childNodes[1].id).toBe('one');
-  });
+it('should keep both sets of DOM nodes around', function() {
+  var a = ReactDOM.render(
+    <ReactCSSTransitionGroup transitionName="yolo">
+      <span key="one" id="one" />
+    </ReactCSSTransitionGroup>,
+    container
+  );
+  expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);
+  ReactDOM.render(
+    <ReactCSSTransitionGroup transitionName="yolo">
+      <span key="two" id="two" />
+    </ReactCSSTransitionGroup>,
+    container
+  );
+  expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(2);
+  expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('two');
+  expect(ReactDOM.findDOMNode(a).childNodes[1].id).toBe('one');
+});
 
-  it('should switch transitionLeave from false to true', function() {
-    var a = ReactDOM.render(
-      <ReactCSSTransitionGroup
+it('should switch transitionLeave from false to true', function() {
+  var a = ReactDOM.render(
+    <ReactCSSTransitionGroup
+        transitionName="yolo"
+        transitionEnter={false}
+        transitionLeave={false}>
+      <span key="one" id="one" />
+    </ReactCSSTransitionGroup>,
+    container
+  );
+  expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);
+  ReactDOM.render(
+    <ReactCSSTransitionGroup
+        transitionName="yolo"
+        transitionEnter={false}
+        transitionLeave={false}>
+      <span key="two" id="two" />
+    </ReactCSSTransitionGroup>,
+    container
+  );
+  expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);
+  ReactDOM.render(
+    <ReactCSSTransitionGroup
+        transitionName="yolo"
+        transitionEnter={false}
+        transitionLeave={true}>
+      <span key="three" id="three" />
+    </ReactCSSTransitionGroup>,
+    container
+  );
+  expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(2);
+  expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('three');
+  expect(ReactDOM.findDOMNode(a).childNodes[1].id).toBe('two');
+});
+
+it('should work with no children', function() {
+  ReactDOM.render(
+    <ReactCSSTransitionGroup transitionName="yolo" />,
+    container
+  );
+});
+
+it('should work with a null child', function() {
+  ReactDOM.render(
+    <ReactCSSTransitionGroup transitionName="yolo">
+      {[null]}
+    </ReactCSSTransitionGroup>,
+    container
+  );
+});
+
+it('should transition from one to null', function() {
+  var a = ReactDOM.render(
+    <ReactCSSTransitionGroup transitionName="yolo">
+      <span key="one" id="one" />
+    </ReactCSSTransitionGroup>,
+    container
+  );
+  expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);
+  ReactDOM.render(
+    <ReactCSSTransitionGroup transitionName="yolo">
+      {null}
+    </ReactCSSTransitionGroup>,
+    container
+  );
+  // (Here, we expect the original child to stick around but test that no
+  // exception is thrown)
+  expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);
+  expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('one');
+});
+
+it('should transition from false to one', function() {
+  var a = ReactDOM.render(
+    <ReactCSSTransitionGroup transitionName="yolo">
+      {false}
+    </ReactCSSTransitionGroup>,
+    container
+  );
+  expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(0);
+  ReactDOM.render(
+    <ReactCSSTransitionGroup transitionName="yolo">
+      <span key="one" id="one" />
+    </ReactCSSTransitionGroup>,
+    container
+  );
+  expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);
+  expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('one');
+});
+
+it('should use transition-type specific names when they\'re provided', function() {
+  var customTransitionNames = {
+    enter: 'custom-entering',
+    leave: 'custom-leaving',
+  };
+
+  var a = ReactDOM.render(
+    <ReactCSSTransitionGroup
+      transitionName={customTransitionNames}
+      transitionEnterTimeout={1}
+      transitionLeaveTimeout={1}
+    >
+      <span key="one" id="one" />
+    </ReactCSSTransitionGroup>,
+    container
+  );
+  expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);
+
+  // Add an element
+  ReactDOM.render(
+    <ReactCSSTransitionGroup
+      transitionName={customTransitionNames}
+      transitionEnterTimeout={1}
+      transitionLeaveTimeout={1}
+    >
+      <span key="one" id="one" />
+      <span key="two" id="two" />
+    </ReactCSSTransitionGroup>,
+    container
+  );
+  expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(2);
+
+  var enteringNode = ReactDOM.findDOMNode(a).childNodes[1];
+  expect(CSSCore.hasClass(enteringNode, 'custom-entering')).toBe(true);
+
+  // Remove an element
+  ReactDOM.render(
+    <ReactCSSTransitionGroup
+      transitionName={customTransitionNames}
+      transitionEnterTimeout={1}
+      transitionLeaveTimeout={1}
+    >
+      <span key="two" id="two" />
+    </ReactCSSTransitionGroup>,
+    container
+  );
+  expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(2);
+
+  var leavingNode = ReactDOM.findDOMNode(a).childNodes[0];
+  expect(CSSCore.hasClass(leavingNode, 'custom-leaving')).toBe(true);
+});
+
+it('should clear transition timeouts when unmounted', function() {
+  class Component extends React.Component {
+    render() {
+      return (
+        <ReactCSSTransitionGroup
           transitionName="yolo"
-          transitionEnter={false}
-          transitionLeave={false}>
-        <span key="one" id="one" />
-      </ReactCSSTransitionGroup>,
-      container
-    );
-    expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);
-    ReactDOM.render(
-      <ReactCSSTransitionGroup
+          transitionEnterTimeout={500}>
+          {this.props.children}
+        </ReactCSSTransitionGroup>
+      );
+    }
+  }
+
+  ReactDOM.render(<Component/>, container);
+  ReactDOM.render(<Component><span key="yolo" id="yolo"/></Component>, container);
+
+  ReactDOM.unmountComponentAtNode(container);
+
+  // Testing that no exception is thrown here, as the timeout has been cleared.
+  jest.runAllTimers();
+});
+
+it('should handle unmounted elements properly', function() {
+  class Child extends React.Component {
+    render() {
+      if (!this.props.show) {
+        return null;
+      }
+      return <div />;
+    }
+  }
+
+  class Component extends React.Component {
+    state = { showChild: true };
+
+    componentDidMount() {
+      this.setState({ showChild: false });
+    }
+
+    render() {
+      return (
+        <ReactCSSTransitionGroup
           transitionName="yolo"
-          transitionEnter={false}
-          transitionLeave={false}>
-        <span key="two" id="two" />
-      </ReactCSSTransitionGroup>,
-      container
-    );
-    expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);
-    ReactDOM.render(
-      <ReactCSSTransitionGroup
-          transitionName="yolo"
-          transitionEnter={false}
-          transitionLeave={true}>
-        <span key="three" id="three" />
-      </ReactCSSTransitionGroup>,
-      container
-    );
-    expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(2);
-    expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('three');
-    expect(ReactDOM.findDOMNode(a).childNodes[1].id).toBe('two');
-  });
-
-  it('should work with no children', function() {
-    ReactDOM.render(
-      <ReactCSSTransitionGroup transitionName="yolo" />,
-      container
-    );
-  });
-
-  it('should work with a null child', function() {
-    ReactDOM.render(
-      <ReactCSSTransitionGroup transitionName="yolo">
-        {[null]}
-      </ReactCSSTransitionGroup>,
-      container
-    );
-  });
-
-  it('should transition from one to null', function() {
-    var a = ReactDOM.render(
-      <ReactCSSTransitionGroup transitionName="yolo">
-        <span key="one" id="one" />
-      </ReactCSSTransitionGroup>,
-      container
-    );
-    expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);
-    ReactDOM.render(
-      <ReactCSSTransitionGroup transitionName="yolo">
-        {null}
-      </ReactCSSTransitionGroup>,
-      container
-    );
-    // (Here, we expect the original child to stick around but test that no
-    // exception is thrown)
-    expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);
-    expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('one');
-  });
-
-  it('should transition from false to one', function() {
-    var a = ReactDOM.render(
-      <ReactCSSTransitionGroup transitionName="yolo">
-        {false}
-      </ReactCSSTransitionGroup>,
-      container
-    );
-    expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(0);
-    ReactDOM.render(
-      <ReactCSSTransitionGroup transitionName="yolo">
-        <span key="one" id="one" />
-      </ReactCSSTransitionGroup>,
-      container
-    );
-    expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);
-    expect(ReactDOM.findDOMNode(a).childNodes[0].id).toBe('one');
-  });
-
-  it('should use transition-type specific names when they\'re provided', function() {
-    var customTransitionNames = {
-      enter: 'custom-entering',
-      leave: 'custom-leaving',
-    };
-
-    var a = ReactDOM.render(
-      <ReactCSSTransitionGroup
-        transitionName={customTransitionNames}
-        transitionEnterTimeout={1}
-        transitionLeaveTimeout={1}
-      >
-        <span key="one" id="one" />
-      </ReactCSSTransitionGroup>,
-      container
-    );
-    expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);
-
-    // Add an element
-    ReactDOM.render(
-      <ReactCSSTransitionGroup
-        transitionName={customTransitionNames}
-        transitionEnterTimeout={1}
-        transitionLeaveTimeout={1}
-      >
-        <span key="one" id="one" />
-        <span key="two" id="two" />
-      </ReactCSSTransitionGroup>,
-      container
-    );
-    expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(2);
-
-    var enteringNode = ReactDOM.findDOMNode(a).childNodes[1];
-    expect(CSSCore.hasClass(enteringNode, 'custom-entering')).toBe(true);
-
-    // Remove an element
-    ReactDOM.render(
-      <ReactCSSTransitionGroup
-        transitionName={customTransitionNames}
-        transitionEnterTimeout={1}
-        transitionLeaveTimeout={1}
-      >
-        <span key="two" id="two" />
-      </ReactCSSTransitionGroup>,
-      container
-    );
-    expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(2);
-
-    var leavingNode = ReactDOM.findDOMNode(a).childNodes[0];
-    expect(CSSCore.hasClass(leavingNode, 'custom-leaving')).toBe(true);
-  });
-
-  it('should clear transition timeouts when unmounted', function() {
-    class Component extends React.Component {
-      render() {
-        return (
-          <ReactCSSTransitionGroup
-            transitionName="yolo"
-            transitionEnterTimeout={500}>
-            {this.props.children}
-          </ReactCSSTransitionGroup>
-        );
-      }
+          transitionAppear={true}
+          transitionAppearTimeout={0}
+        >
+          <Child show={this.state.showChild} />
+        </ReactCSSTransitionGroup>
+      );
     }
+  }
 
-    ReactDOM.render(<Component/>, container);
-    ReactDOM.render(<Component><span key="yolo" id="yolo"/></Component>, container);
+  ReactDOM.render(<Component/>, container);
 
-    ReactDOM.unmountComponentAtNode(container);
-
-    // Testing that no exception is thrown here, as the timeout has been cleared.
-    jest.runAllTimers();
-  });
-
-  it('should handle unmounted elements properly', function() {
-    class Child extends React.Component {
-      render() {
-        if (!this.props.show) {
-          return null;
-        }
-        return <div />;
-      }
-    }
-
-    class Component extends React.Component {
-      state = { showChild: true };
-
-      componentDidMount() {
-        this.setState({ showChild: false });
-      }
-
-      render() {
-        return (
-          <ReactCSSTransitionGroup
-            transitionName="yolo"
-            transitionAppear={true}
-            transitionAppearTimeout={0}
-          >
-            <Child show={this.state.showChild} />
-          </ReactCSSTransitionGroup>
-        );
-      }
-    }
-
-    ReactDOM.render(<Component/>, container);
-
-    // Testing that no exception is thrown here, as the timeout has been cleared.
-    jest.runAllTimers();
-  });
+  // Testing that no exception is thrown here, as the timeout has been cleared.
+  jest.runAllTimers();
 });

--- a/src/addons/transitions/__tests__/ReactTransitionChildMapping-test.js
+++ b/src/addons/transitions/__tests__/ReactTransitionChildMapping-test.js
@@ -14,124 +14,122 @@
 var React;
 var ReactTransitionChildMapping;
 
-describe('ReactTransitionChildMapping', function() {
-  beforeEach(function() {
-    React = require('React');
-    ReactTransitionChildMapping = require('ReactTransitionChildMapping');
+beforeEach(function() {
+  React = require('React');
+  ReactTransitionChildMapping = require('ReactTransitionChildMapping');
+});
+
+it('should support getChildMapping', function() {
+  var oneone = <div key="oneone" />;
+  var onetwo = <div key="onetwo" />;
+  var one = <div key="one">{oneone}{onetwo}</div>;
+  var two = <div key="two" />;
+  var component = <div>{one}{two}</div>;
+  expect(
+    ReactTransitionChildMapping.getChildMapping(component.props.children)
+  ).toEqual({
+    '.$one': one,
+    '.$two': two,
+  });
+});
+
+it('should support mergeChildMappings for adding keys', function() {
+  var prev = {
+    one: true,
+    two: true,
+  };
+  var next = {
+    one: true,
+    two: true,
+    three: true,
+  };
+  expect(ReactTransitionChildMapping.mergeChildMappings(prev, next)).toEqual({
+    one: true,
+    two: true,
+    three: true,
+  });
+});
+
+it('should support mergeChildMappings for removing keys', function() {
+  var prev = {
+    one: true,
+    two: true,
+    three: true,
+  };
+  var next = {
+    one: true,
+    two: true,
+  };
+  expect(ReactTransitionChildMapping.mergeChildMappings(prev, next)).toEqual({
+    one: true,
+    two: true,
+    three: true,
+  });
+});
+
+it('should support mergeChildMappings for adding and removing', function() {
+  var prev = {
+    one: true,
+    two: true,
+    three: true,
+  };
+  var next = {
+    one: true,
+    two: true,
+    four: true,
+  };
+  expect(ReactTransitionChildMapping.mergeChildMappings(prev, next)).toEqual({
+    one: true,
+    two: true,
+    three: true,
+    four: true,
+  });
+});
+
+it('should reconcile overlapping insertions and deletions', function() {
+  var prev = {
+    one: true,
+    two: true,
+    four: true,
+    five: true,
+  };
+  var next = {
+    one: true,
+    two: true,
+    three: true,
+    five: true,
+  };
+  expect(ReactTransitionChildMapping.mergeChildMappings(prev, next)).toEqual({
+    one: true,
+    two: true,
+    three: true,
+    four: true,
+    five: true,
+  });
+});
+
+it('should support mergeChildMappings with undefined input', function() {
+  var prev = {
+    one: true,
+    two: true,
+  };
+
+  var next = undefined;
+
+  expect(ReactTransitionChildMapping.mergeChildMappings(prev, next)).toEqual({
+    one: true,
+    two: true,
   });
 
-  it('should support getChildMapping', function() {
-    var oneone = <div key="oneone" />;
-    var onetwo = <div key="onetwo" />;
-    var one = <div key="one">{oneone}{onetwo}</div>;
-    var two = <div key="two" />;
-    var component = <div>{one}{two}</div>;
-    expect(
-      ReactTransitionChildMapping.getChildMapping(component.props.children)
-    ).toEqual({
-      '.$one': one,
-      '.$two': two,
-    });
-  });
+  prev = undefined;
 
-  it('should support mergeChildMappings for adding keys', function() {
-    var prev = {
-      one: true,
-      two: true,
-    };
-    var next = {
-      one: true,
-      two: true,
-      three: true,
-    };
-    expect(ReactTransitionChildMapping.mergeChildMappings(prev, next)).toEqual({
-      one: true,
-      two: true,
-      three: true,
-    });
-  });
+  next = {
+    three: true,
+    four: true,
+  };
 
-  it('should support mergeChildMappings for removing keys', function() {
-    var prev = {
-      one: true,
-      two: true,
-      three: true,
-    };
-    var next = {
-      one: true,
-      two: true,
-    };
-    expect(ReactTransitionChildMapping.mergeChildMappings(prev, next)).toEqual({
-      one: true,
-      two: true,
-      three: true,
-    });
-  });
-
-  it('should support mergeChildMappings for adding and removing', function() {
-    var prev = {
-      one: true,
-      two: true,
-      three: true,
-    };
-    var next = {
-      one: true,
-      two: true,
-      four: true,
-    };
-    expect(ReactTransitionChildMapping.mergeChildMappings(prev, next)).toEqual({
-      one: true,
-      two: true,
-      three: true,
-      four: true,
-    });
-  });
-
-  it('should reconcile overlapping insertions and deletions', function() {
-    var prev = {
-      one: true,
-      two: true,
-      four: true,
-      five: true,
-    };
-    var next = {
-      one: true,
-      two: true,
-      three: true,
-      five: true,
-    };
-    expect(ReactTransitionChildMapping.mergeChildMappings(prev, next)).toEqual({
-      one: true,
-      two: true,
-      three: true,
-      four: true,
-      five: true,
-    });
-  });
-
-  it('should support mergeChildMappings with undefined input', function() {
-    var prev = {
-      one: true,
-      two: true,
-    };
-
-    var next = undefined;
-
-    expect(ReactTransitionChildMapping.mergeChildMappings(prev, next)).toEqual({
-      one: true,
-      two: true,
-    });
-
-    prev = undefined;
-
-    next = {
-      three: true,
-      four: true,
-    };
-
-    expect(ReactTransitionChildMapping.mergeChildMappings(prev, next)).toEqual({
-      three: true,
-      four: true,
-    });
+  expect(ReactTransitionChildMapping.mergeChildMappings(prev, next)).toEqual({
+    three: true,
+    four: true,
   });
 });

--- a/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
@@ -15,313 +15,309 @@ var React;
 var ReactDOM;
 var ReactTransitionGroup;
 
-// Most of the real functionality is covered in other unit tests, this just
-// makes sure we're wired up correctly.
-describe('ReactTransitionGroup', function() {
-  var container;
+var container;
 
-  function normalizeCodeLocInfo(str) {
-    return str.replace(/\(at .+?:\d+\)/g, '(at **)');
+function normalizeCodeLocInfo(str) {
+  return str.replace(/\(at .+?:\d+\)/g, '(at **)');
+}
+
+beforeEach(function() {
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactTransitionGroup = require('ReactTransitionGroup');
+
+  container = document.createElement('div');
+});
+
+
+it('should handle willEnter correctly', function() {
+  var log = [];
+
+  class Child extends React.Component {
+    componentDidMount() {
+      log.push('didMount');
+    }
+
+    componentWillAppear = (cb) => {
+      log.push('willAppear');
+      cb();
+    };
+
+    componentDidAppear = () => {
+      log.push('didAppear');
+    };
+
+    componentWillEnter = (cb) => {
+      log.push('willEnter');
+      cb();
+    };
+
+    componentDidEnter = () => {
+      log.push('didEnter');
+    };
+
+    componentWillLeave = (cb) => {
+      log.push('willLeave');
+      cb();
+    };
+
+    componentDidLeave = () => {
+      log.push('didLeave');
+    };
+
+    componentWillUnmount() {
+      log.push('willUnmount');
+    }
+
+    render() {
+      return <span />;
+    }
   }
 
-  beforeEach(function() {
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactTransitionGroup = require('ReactTransitionGroup');
+  class Component extends React.Component {
+    state = {count: 1};
 
-    container = document.createElement('div');
-  });
-
-
-  it('should handle willEnter correctly', function() {
-    var log = [];
-
-    class Child extends React.Component {
-      componentDidMount() {
-        log.push('didMount');
+    render() {
+      var children = [];
+      for (var i = 0; i < this.state.count; i++) {
+        children.push(<Child key={i} />);
       }
-
-      componentWillAppear = (cb) => {
-        log.push('willAppear');
-        cb();
-      };
-
-      componentDidAppear = () => {
-        log.push('didAppear');
-      };
-
-      componentWillEnter = (cb) => {
-        log.push('willEnter');
-        cb();
-      };
-
-      componentDidEnter = () => {
-        log.push('didEnter');
-      };
-
-      componentWillLeave = (cb) => {
-        log.push('willLeave');
-        cb();
-      };
-
-      componentDidLeave = () => {
-        log.push('didLeave');
-      };
-
-      componentWillUnmount() {
-        log.push('willUnmount');
-      }
-
-      render() {
-        return <span />;
-      }
+      return <ReactTransitionGroup>{children}</ReactTransitionGroup>;
     }
+  }
 
-    class Component extends React.Component {
-      state = {count: 1};
+  var instance = ReactDOM.render(<Component />, container);
+  expect(log).toEqual(['didMount', 'willAppear', 'didAppear']);
 
-      render() {
-        var children = [];
-        for (var i = 0; i < this.state.count; i++) {
-          children.push(<Child key={i} />);
-        }
-        return <ReactTransitionGroup>{children}</ReactTransitionGroup>;
-      }
-    }
-
-    var instance = ReactDOM.render(<Component />, container);
-    expect(log).toEqual(['didMount', 'willAppear', 'didAppear']);
+  log = [];
+  instance.setState({count: 2}, function() {
+    expect(log).toEqual(['didMount', 'willEnter', 'didEnter']);
 
     log = [];
-    instance.setState({count: 2}, function() {
-      expect(log).toEqual(['didMount', 'willEnter', 'didEnter']);
-
-      log = [];
-      instance.setState({count: 1}, function() {
-        expect(log).toEqual(['willLeave', 'didLeave', 'willUnmount']);
-      });
+    instance.setState({count: 1}, function() {
+      expect(log).toEqual(['willLeave', 'didLeave', 'willUnmount']);
     });
   });
+});
 
-  it('should handle enter/leave/enter/leave correctly', function() {
-    var log = [];
-    var willEnterCb;
+it('should handle enter/leave/enter/leave correctly', function() {
+  var log = [];
+  var willEnterCb;
 
-    class Child extends React.Component {
-      componentDidMount() {
-        log.push('didMount');
-      }
-
-      componentWillEnter = (cb) => {
-        log.push('willEnter');
-        willEnterCb = cb;
-      };
-
-      componentDidEnter = () => {
-        log.push('didEnter');
-      };
-
-      componentWillLeave = (cb) => {
-        log.push('willLeave');
-        cb();
-      };
-
-      componentDidLeave = () => {
-        log.push('didLeave');
-      };
-
-      componentWillUnmount() {
-        log.push('willUnmount');
-      }
-
-      render() {
-        return <span />;
-      }
+  class Child extends React.Component {
+    componentDidMount() {
+      log.push('didMount');
     }
 
-    class Component extends React.Component {
-      state = {count: 1};
+    componentWillEnter = (cb) => {
+      log.push('willEnter');
+      willEnterCb = cb;
+    };
 
-      render() {
-        var children = [];
-        for (var i = 0; i < this.state.count; i++) {
-          children.push(<Child key={i} />);
-        }
-        return <ReactTransitionGroup>{children}</ReactTransitionGroup>;
-      }
+    componentDidEnter = () => {
+      log.push('didEnter');
+    };
+
+    componentWillLeave = (cb) => {
+      log.push('willLeave');
+      cb();
+    };
+
+    componentDidLeave = () => {
+      log.push('didLeave');
+    };
+
+    componentWillUnmount() {
+      log.push('willUnmount');
     }
 
-    var instance = ReactDOM.render(<Component />, container);
-    expect(log).toEqual(['didMount']);
+    render() {
+      return <span />;
+    }
+  }
+
+  class Component extends React.Component {
+    state = {count: 1};
+
+    render() {
+      var children = [];
+      for (var i = 0; i < this.state.count; i++) {
+        children.push(<Child key={i} />);
+      }
+      return <ReactTransitionGroup>{children}</ReactTransitionGroup>;
+    }
+  }
+
+  var instance = ReactDOM.render(<Component />, container);
+  expect(log).toEqual(['didMount']);
+  instance.setState({count: 2});
+  expect(log).toEqual(['didMount', 'didMount', 'willEnter']);
+  for (var k = 0; k < 5; k++) {
     instance.setState({count: 2});
     expect(log).toEqual(['didMount', 'didMount', 'willEnter']);
-    for (var k = 0; k < 5; k++) {
-      instance.setState({count: 2});
-      expect(log).toEqual(['didMount', 'didMount', 'willEnter']);
-      instance.setState({count: 1});
-    }
-    // other animations are blocked until willEnterCb is called
-    willEnterCb();
-    expect(log).toEqual([
-      'didMount', 'didMount', 'willEnter',
-      'didEnter', 'willLeave', 'didLeave', 'willUnmount',
-    ]);
-  });
+    instance.setState({count: 1});
+  }
+  // other animations are blocked until willEnterCb is called
+  willEnterCb();
+  expect(log).toEqual([
+    'didMount', 'didMount', 'willEnter',
+    'didEnter', 'willLeave', 'didLeave', 'willUnmount',
+  ]);
+});
 
-  it('should handle enter/leave/enter correctly', function() {
-    var log = [];
-    var willEnterCb;
+it('should handle enter/leave/enter correctly', function() {
+  var log = [];
+  var willEnterCb;
 
-    class Child extends React.Component {
-      componentDidMount() {
-        log.push('didMount');
-      }
-
-      componentWillEnter = (cb) => {
-        log.push('willEnter');
-        willEnterCb = cb;
-      };
-
-      componentDidEnter = () => {
-        log.push('didEnter');
-      };
-
-      componentWillLeave = (cb) => {
-        log.push('willLeave');
-        cb();
-      };
-
-      componentDidLeave = () => {
-        log.push('didLeave');
-      };
-
-      componentWillUnmount() {
-        log.push('willUnmount');
-      }
-
-      render() {
-        return <span />;
-      }
+  class Child extends React.Component {
+    componentDidMount() {
+      log.push('didMount');
     }
 
-    class Component extends React.Component {
-      state = {count: 1};
+    componentWillEnter = (cb) => {
+      log.push('willEnter');
+      willEnterCb = cb;
+    };
 
-      render() {
-        var children = [];
-        for (var i = 0; i < this.state.count; i++) {
-          children.push(<Child key={i} />);
-        }
-        return <ReactTransitionGroup>{children}</ReactTransitionGroup>;
-      }
+    componentDidEnter = () => {
+      log.push('didEnter');
+    };
+
+    componentWillLeave = (cb) => {
+      log.push('willLeave');
+      cb();
+    };
+
+    componentDidLeave = () => {
+      log.push('didLeave');
+    };
+
+    componentWillUnmount() {
+      log.push('willUnmount');
     }
 
-    var instance = ReactDOM.render(<Component />, container);
-    expect(log).toEqual(['didMount']);
-    instance.setState({count: 2});
+    render() {
+      return <span />;
+    }
+  }
+
+  class Component extends React.Component {
+    state = {count: 1};
+
+    render() {
+      var children = [];
+      for (var i = 0; i < this.state.count; i++) {
+        children.push(<Child key={i} />);
+      }
+      return <ReactTransitionGroup>{children}</ReactTransitionGroup>;
+    }
+  }
+
+  var instance = ReactDOM.render(<Component />, container);
+  expect(log).toEqual(['didMount']);
+  instance.setState({count: 2});
+  expect(log).toEqual(['didMount', 'didMount', 'willEnter']);
+  for (var k = 0; k < 5; k++) {
+    instance.setState({count: 1});
     expect(log).toEqual(['didMount', 'didMount', 'willEnter']);
-    for (var k = 0; k < 5; k++) {
-      instance.setState({count: 1});
-      expect(log).toEqual(['didMount', 'didMount', 'willEnter']);
-      instance.setState({count: 2});
-    }
-    willEnterCb();
-    expect(log).toEqual([
-      'didMount', 'didMount', 'willEnter', 'didEnter',
-    ]);
-  });
+    instance.setState({count: 2});
+  }
+  willEnterCb();
+  expect(log).toEqual([
+    'didMount', 'didMount', 'willEnter', 'didEnter',
+  ]);
+});
 
-  it('should handle entering/leaving several elements at once', function() {
-    var log = [];
+it('should handle entering/leaving several elements at once', function() {
+  var log = [];
 
-    class Child extends React.Component {
-      componentDidMount() {
-        log.push('didMount' + this.props.id);
-      }
-
-      componentWillEnter = (cb) => {
-        log.push('willEnter' + this.props.id);
-        cb();
-      };
-
-      componentDidEnter = () => {
-        log.push('didEnter' + this.props.id);
-      };
-
-      componentWillLeave = (cb) => {
-        log.push('willLeave' + this.props.id);
-        cb();
-      };
-
-      componentDidLeave = () => {
-        log.push('didLeave' + this.props.id);
-      };
-
-      componentWillUnmount() {
-        log.push('willUnmount' + this.props.id);
-      }
-
-      render() {
-        return <span />;
-      }
+  class Child extends React.Component {
+    componentDidMount() {
+      log.push('didMount' + this.props.id);
     }
 
-    class Component extends React.Component {
-      state = {count: 1};
+    componentWillEnter = (cb) => {
+      log.push('willEnter' + this.props.id);
+      cb();
+    };
 
-      render() {
-        var children = [];
-        for (var i = 0; i < this.state.count; i++) {
-          children.push(<Child key={i} id={i} />);
-        }
-        return <ReactTransitionGroup>{children}</ReactTransitionGroup>;
-      }
+    componentDidEnter = () => {
+      log.push('didEnter' + this.props.id);
+    };
+
+    componentWillLeave = (cb) => {
+      log.push('willLeave' + this.props.id);
+      cb();
+    };
+
+    componentDidLeave = () => {
+      log.push('didLeave' + this.props.id);
+    };
+
+    componentWillUnmount() {
+      log.push('willUnmount' + this.props.id);
     }
 
-    var instance = ReactDOM.render(<Component />, container);
-    expect(log).toEqual(['didMount0']);
-    log = [];
-
-    instance.setState({count: 3});
-    expect(log).toEqual([
-      'didMount1', 'didMount2', 'willEnter1', 'didEnter1',
-      'willEnter2', 'didEnter2',
-    ]);
-    log = [];
-
-    instance.setState({count: 0});
-    expect(log).toEqual([
-      'willLeave0', 'didLeave0', 'willLeave1', 'didLeave1',
-      'willLeave2', 'didLeave2', 'willUnmount0', 'willUnmount1', 'willUnmount2',
-    ]);
-  });
-
-  it('should warn for duplicated keys with component stack info', function() {
-    spyOn(console, 'error');
-
-    class Component extends React.Component {
-      render() {
-        var children = [<div key="1"/>, <div key="1" />];
-        return <ReactTransitionGroup>{children}</ReactTransitionGroup>;
-      }
+    render() {
+      return <span />;
     }
+  }
 
-    ReactDOM.render(<Component />, container);
+  class Component extends React.Component {
+    state = {count: 1};
 
-    expect(console.error.calls.count()).toBe(2);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: flattenChildren(...): ' +
-      'Encountered two children with the same key, `1`. ' +
-      'Child keys must be unique; when two children share a key, ' +
-      'only the first child will be used.'
-    );
-    expect(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
-      'Warning: flattenChildren(...): ' +
-      'Encountered two children with the same key, `1`. ' +
-      'Child keys must be unique; when two children share a key, ' +
-      'only the first child will be used.\n' +
-      '    in ReactTransitionGroup (at **)\n' +
-      '    in Component (at **)'
-    );
-  });
+    render() {
+      var children = [];
+      for (var i = 0; i < this.state.count; i++) {
+        children.push(<Child key={i} id={i} />);
+      }
+      return <ReactTransitionGroup>{children}</ReactTransitionGroup>;
+    }
+  }
+
+  var instance = ReactDOM.render(<Component />, container);
+  expect(log).toEqual(['didMount0']);
+  log = [];
+
+  instance.setState({count: 3});
+  expect(log).toEqual([
+    'didMount1', 'didMount2', 'willEnter1', 'didEnter1',
+    'willEnter2', 'didEnter2',
+  ]);
+  log = [];
+
+  instance.setState({count: 0});
+  expect(log).toEqual([
+    'willLeave0', 'didLeave0', 'willLeave1', 'didLeave1',
+    'willLeave2', 'didLeave2', 'willUnmount0', 'willUnmount1', 'willUnmount2',
+  ]);
+});
+
+it('should warn for duplicated keys with component stack info', function() {
+  spyOn(console, 'error');
+
+  class Component extends React.Component {
+    render() {
+      var children = [<div key="1"/>, <div key="1" />];
+      return <ReactTransitionGroup>{children}</ReactTransitionGroup>;
+    }
+  }
+
+  ReactDOM.render(<Component />, container);
+
+  expect(console.error.calls.count()).toBe(2);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: flattenChildren(...): ' +
+    'Encountered two children with the same key, `1`. ' +
+    'Child keys must be unique; when two children share a key, ' +
+    'only the first child will be used.'
+  );
+  expect(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
+    'Warning: flattenChildren(...): ' +
+    'Encountered two children with the same key, `1`. ' +
+    'Child keys must be unique; when two children share a key, ' +
+    'only the first child will be used.\n' +
+    '    in ReactTransitionGroup (at **)\n' +
+    '    in Component (at **)'
+  );
 });

--- a/src/isomorphic/children/__tests__/ReactChildren-test.js
+++ b/src/isomorphic/children/__tests__/ReactChildren-test.js
@@ -11,445 +11,442 @@
 
 'use strict';
 
-describe('ReactChildren', function() {
-  var ReactChildren;
-  var React;
-  var ReactFragment;
+var ReactChildren;
+var React;
+var ReactFragment;
 
-  beforeEach(function() {
-    ReactChildren = require('ReactChildren');
-    React = require('React');
-    ReactFragment = require('ReactFragment');
+beforeEach(function() {
+  ReactChildren = require('ReactChildren');
+  React = require('React');
+  ReactFragment = require('ReactFragment');
+});
+
+it('should support identity for simple', function() {
+  var callback = jasmine.createSpy().and.callFake(function(kid, index) {
+    return kid;
   });
 
-  it('should support identity for simple', function() {
-    var callback = jasmine.createSpy().and.callFake(function(kid, index) {
-      return kid;
-    });
+  var simpleKid = <span key="simple" />;
 
-    var simpleKid = <span key="simple" />;
+  // First pass children into a component to fully simulate what happens when
+  // using structures that arrive from transforms.
 
-    // First pass children into a component to fully simulate what happens when
-    // using structures that arrive from transforms.
+  var instance = <div>{simpleKid}</div>;
+  ReactChildren.forEach(instance.props.children, callback);
+  expect(callback).toHaveBeenCalledWith(simpleKid, 0);
+  callback.calls.reset();
+  var mappedChildren = ReactChildren.map(instance.props.children, callback);
+  expect(callback).toHaveBeenCalledWith(simpleKid, 0);
+  expect(mappedChildren[0]).toEqual(<span key=".$simple" />);
+});
 
-    var instance = <div>{simpleKid}</div>;
-    ReactChildren.forEach(instance.props.children, callback);
-    expect(callback).toHaveBeenCalledWith(simpleKid, 0);
-    callback.calls.reset();
-    var mappedChildren = ReactChildren.map(instance.props.children, callback);
-    expect(callback).toHaveBeenCalledWith(simpleKid, 0);
-    expect(mappedChildren[0]).toEqual(<span key=".$simple" />);
+it('should treat single arrayless child as being in array', function() {
+  var callback = jasmine.createSpy().and.callFake(function(kid, index) {
+    return kid;
   });
 
-  it('should treat single arrayless child as being in array', function() {
-    var callback = jasmine.createSpy().and.callFake(function(kid, index) {
-      return kid;
-    });
+  var simpleKid = <span />;
+  var instance = <div>{simpleKid}</div>;
+  ReactChildren.forEach(instance.props.children, callback);
+  expect(callback).toHaveBeenCalledWith(simpleKid, 0);
+  callback.calls.reset();
+  var mappedChildren = ReactChildren.map(instance.props.children, callback);
+  expect(callback).toHaveBeenCalledWith(simpleKid, 0);
+  expect(mappedChildren[0]).toEqual(<span key=".0" />);
+});
 
-    var simpleKid = <span />;
-    var instance = <div>{simpleKid}</div>;
-    ReactChildren.forEach(instance.props.children, callback);
-    expect(callback).toHaveBeenCalledWith(simpleKid, 0);
-    callback.calls.reset();
-    var mappedChildren = ReactChildren.map(instance.props.children, callback);
-    expect(callback).toHaveBeenCalledWith(simpleKid, 0);
-    expect(mappedChildren[0]).toEqual(<span key=".0" />);
+it('should treat single child in array as expected', function() {
+  var callback = jasmine.createSpy().and.callFake(function(kid, index) {
+    return kid;
   });
 
-  it('should treat single child in array as expected', function() {
-    var callback = jasmine.createSpy().and.callFake(function(kid, index) {
-      return kid;
-    });
+  var simpleKid = <span key="simple" />;
+  var instance = <div>{[simpleKid]}</div>;
+  ReactChildren.forEach(instance.props.children, callback);
+  expect(callback).toHaveBeenCalledWith(simpleKid, 0);
+  callback.calls.reset();
+  var mappedChildren = ReactChildren.map(instance.props.children, callback);
+  expect(callback).toHaveBeenCalledWith(simpleKid, 0);
+  expect(mappedChildren[0]).toEqual(<span key=".$simple" />);
 
-    var simpleKid = <span key="simple" />;
-    var instance = <div>{[simpleKid]}</div>;
-    ReactChildren.forEach(instance.props.children, callback);
-    expect(callback).toHaveBeenCalledWith(simpleKid, 0);
-    callback.calls.reset();
-    var mappedChildren = ReactChildren.map(instance.props.children, callback);
-    expect(callback).toHaveBeenCalledWith(simpleKid, 0);
-    expect(mappedChildren[0]).toEqual(<span key=".$simple" />);
+});
 
+it('should pass key to returned component', function() {
+  var mapFn = function(kid, index) {
+    return <div>{kid}</div>;
+  };
+
+  var simpleKid = <span key="simple" />;
+
+  var instance = <div>{simpleKid}</div>;
+  var mappedChildren = ReactChildren.map(instance.props.children, mapFn);
+
+  expect(ReactChildren.count(mappedChildren)).toBe(1);
+  expect(mappedChildren[0]).not.toBe(simpleKid);
+  expect(mappedChildren[0].props.children).toBe(simpleKid);
+  expect(mappedChildren[0].key).toBe('.$simple');
+});
+
+it('should invoke callback with the right context', function() {
+  var lastContext;
+  var callback = function(kid, index) {
+    lastContext = this;
+    return this;
+  };
+
+  // TODO: Use an object to test, after non-object fragments has fully landed.
+  var scopeTester = 'scope tester';
+
+  var simpleKid = <span key="simple" />;
+  var instance = <div>{simpleKid}</div>;
+  ReactChildren.forEach(instance.props.children, callback, scopeTester);
+  expect(lastContext).toBe(scopeTester);
+
+  var mappedChildren =
+    ReactChildren.map(instance.props.children, callback, scopeTester);
+
+  expect(ReactChildren.count(mappedChildren)).toBe(1);
+  expect(mappedChildren[0]).toBe(scopeTester);
+});
+
+it('should be called for each child', function() {
+  var zero = <div key="keyZero" />;
+  var one = null;
+  var two = <div key="keyTwo" />;
+  var three = null;
+  var four = <div key="keyFour" />;
+
+  var mapped = [
+    <div key="giraffe" />,  // Key should be joined to obj key
+    null,  // Key should be added even if we don't supply it!
+    <div />,  // Key should be added even if not supplied!
+    <span />, // Map from null to something.
+    <div key="keyFour" />,
+  ];
+  var callback = jasmine.createSpy().and.callFake(function(kid, index) {
+    return mapped[index];
   });
 
-  it('should pass key to returned component', function() {
-    var mapFn = function(kid, index) {
-      return <div>{kid}</div>;
-    };
+  var instance = (
+    <div>
+      {zero}
+      {one}
+      {two}
+      {three}
+      {four}
+    </div>
+  );
 
-    var simpleKid = <span key="simple" />;
+  ReactChildren.forEach(instance.props.children, callback);
+  expect(callback).toHaveBeenCalledWith(zero, 0);
+  expect(callback).toHaveBeenCalledWith(one, 1);
+  expect(callback).toHaveBeenCalledWith(two, 2);
+  expect(callback).toHaveBeenCalledWith(three, 3);
+  expect(callback).toHaveBeenCalledWith(four, 4);
+  callback.calls.reset();
 
-    var instance = <div>{simpleKid}</div>;
-    var mappedChildren = ReactChildren.map(instance.props.children, mapFn);
+  var mappedChildren =
+    ReactChildren.map(instance.props.children, callback);
+  expect(callback.calls.count()).toBe(5);
+  expect(ReactChildren.count(mappedChildren)).toBe(4);
+  // Keys default to indices.
+  expect([
+    mappedChildren[0].key,
+    mappedChildren[1].key,
+    mappedChildren[2].key,
+    mappedChildren[3].key,
+  ]).toEqual(
+    ['giraffe/.$keyZero', '.$keyTwo', '.3', '.$keyFour']
+  );
 
-    expect(ReactChildren.count(mappedChildren)).toBe(1);
-    expect(mappedChildren[0]).not.toBe(simpleKid);
-    expect(mappedChildren[0].props.children).toBe(simpleKid);
-    expect(mappedChildren[0].key).toBe('.$simple');
+  expect(callback).toHaveBeenCalledWith(zero, 0);
+  expect(callback).toHaveBeenCalledWith(one, 1);
+  expect(callback).toHaveBeenCalledWith(two, 2);
+  expect(callback).toHaveBeenCalledWith(three, 3);
+  expect(callback).toHaveBeenCalledWith(four, 4);
+
+  expect(mappedChildren[0]).toEqual(<div key="giraffe/.$keyZero" />);
+  expect(mappedChildren[1]).toEqual(<div key=".$keyTwo" />);
+  expect(mappedChildren[2]).toEqual(<span key=".3" />);
+  expect(mappedChildren[3]).toEqual(<div key=".$keyFour" />);
+});
+
+it('should be called for each child in nested structure', function() {
+  var zero = <div key="keyZero" />;
+  var one = null;
+  var two = <div key="keyTwo" />;
+  var three = null;
+  var four = <div key="keyFour" />;
+  var five = <div key="keyFiveInner" />;
+  // five is placed into a JS object with a key that is joined to the
+  // component key attribute.
+  // Precedence is as follows:
+  // 1. If grouped in an Object, the object key combined with `key` prop
+  // 2. If grouped in an Array, the `key` prop, falling back to array index
+
+  var zeroMapped = <div key="giraffe" />;  // Key should be overridden
+  var twoMapped = <div />;  // Key should be added even if not supplied!
+  var fourMapped = <div key="keyFour" />;
+  var fiveMapped = <div />;
+
+  var callback = jasmine.createSpy().and.callFake(function(kid, index) {
+    return index === 0 ? zeroMapped :
+      index === 1 ? twoMapped :
+      index === 2 ? fourMapped : fiveMapped;
   });
 
-  it('should invoke callback with the right context', function() {
-    var lastContext;
-    var callback = function(kid, index) {
-      lastContext = this;
-      return this;
-    };
-
-    // TODO: Use an object to test, after non-object fragments has fully landed.
-    var scopeTester = 'scope tester';
-
-    var simpleKid = <span key="simple" />;
-    var instance = <div>{simpleKid}</div>;
-    ReactChildren.forEach(instance.props.children, callback, scopeTester);
-    expect(lastContext).toBe(scopeTester);
-
-    var mappedChildren =
-      ReactChildren.map(instance.props.children, callback, scopeTester);
-
-    expect(ReactChildren.count(mappedChildren)).toBe(1);
-    expect(mappedChildren[0]).toBe(scopeTester);
+  var frag = ReactFragment.create({
+    firstHalfKey: [zero, one, two],
+    secondHalfKey: [three, four],
+    keyFive: five,
   });
+  var instance = <div>{[frag]}</div>;
 
-  it('should be called for each child', function() {
-    var zero = <div key="keyZero" />;
-    var one = null;
-    var two = <div key="keyTwo" />;
-    var three = null;
-    var four = <div key="keyFour" />;
+  expect([
+    frag[0].key,
+    frag[1].key,
+    frag[2].key,
+    frag[3].key,
+  ]).toEqual([
+    'firstHalfKey/.$keyZero',
+    'firstHalfKey/.$keyTwo',
+    'secondHalfKey/.$keyFour',
+    'keyFive/.$keyFiveInner',
+  ]);
 
-    var mapped = [
-      <div key="giraffe" />,  // Key should be joined to obj key
-      null,  // Key should be added even if we don't supply it!
-      <div />,  // Key should be added even if not supplied!
-      <span />, // Map from null to something.
-      <div key="keyFour" />,
-    ];
-    var callback = jasmine.createSpy().and.callFake(function(kid, index) {
-      return mapped[index];
-    });
+  ReactChildren.forEach(instance.props.children, callback);
+  expect(callback.calls.count()).toBe(4);
+  expect(callback).toHaveBeenCalledWith(frag[0], 0);
+  expect(callback).toHaveBeenCalledWith(frag[1], 1);
+  expect(callback).toHaveBeenCalledWith(frag[2], 2);
+  expect(callback).toHaveBeenCalledWith(frag[3], 3);
+  callback.calls.reset();
 
-    var instance = (
-      <div>
-        {zero}
-        {one}
-        {two}
-        {three}
-        {four}
-      </div>
-    );
+  var mappedChildren = ReactChildren.map(instance.props.children, callback);
+  expect(callback.calls.count()).toBe(4);
+  expect(callback).toHaveBeenCalledWith(frag[0], 0);
+  expect(callback).toHaveBeenCalledWith(frag[1], 1);
+  expect(callback).toHaveBeenCalledWith(frag[2], 2);
+  expect(callback).toHaveBeenCalledWith(frag[3], 3);
 
-    ReactChildren.forEach(instance.props.children, callback);
-    expect(callback).toHaveBeenCalledWith(zero, 0);
-    expect(callback).toHaveBeenCalledWith(one, 1);
-    expect(callback).toHaveBeenCalledWith(two, 2);
-    expect(callback).toHaveBeenCalledWith(three, 3);
-    expect(callback).toHaveBeenCalledWith(four, 4);
-    callback.calls.reset();
+  expect(ReactChildren.count(mappedChildren)).toBe(4);
+  // Keys default to indices.
+  expect([
+    mappedChildren[0].key,
+    mappedChildren[1].key,
+    mappedChildren[2].key,
+    mappedChildren[3].key,
+  ]).toEqual([
+    'giraffe/.0:$firstHalfKey/.$keyZero',
+    '.0:$firstHalfKey/.$keyTwo',
+    'keyFour/.0:$secondHalfKey/.$keyFour',
+    '.0:$keyFive/.$keyFiveInner',
+  ]);
 
-    var mappedChildren =
-      ReactChildren.map(instance.props.children, callback);
-    expect(callback.calls.count()).toBe(5);
-    expect(ReactChildren.count(mappedChildren)).toBe(4);
-    // Keys default to indices.
-    expect([
-      mappedChildren[0].key,
-      mappedChildren[1].key,
-      mappedChildren[2].key,
-      mappedChildren[3].key,
-    ]).toEqual(
-      ['giraffe/.$keyZero', '.$keyTwo', '.3', '.$keyFour']
-    );
+  expect(mappedChildren[0]).toEqual(<div key="giraffe/.0:$firstHalfKey/.$keyZero" />);
+  expect(mappedChildren[1]).toEqual(<div key=".0:$firstHalfKey/.$keyTwo" />);
+  expect(mappedChildren[2]).toEqual(<div key="keyFour/.0:$secondHalfKey/.$keyFour" />);
+  expect(mappedChildren[3]).toEqual(<div key=".0:$keyFive/.$keyFiveInner" />);
+});
 
-    expect(callback).toHaveBeenCalledWith(zero, 0);
-    expect(callback).toHaveBeenCalledWith(one, 1);
-    expect(callback).toHaveBeenCalledWith(two, 2);
-    expect(callback).toHaveBeenCalledWith(three, 3);
-    expect(callback).toHaveBeenCalledWith(four, 4);
+it('should retain key across two mappings', function() {
+  var zeroForceKey = <div key="keyZero" />;
+  var oneForceKey = <div key="keyOne" />;
 
-    expect(mappedChildren[0]).toEqual(<div key="giraffe/.$keyZero" />);
-    expect(mappedChildren[1]).toEqual(<div key=".$keyTwo" />);
-    expect(mappedChildren[2]).toEqual(<span key=".3" />);
-    expect(mappedChildren[3]).toEqual(<div key=".$keyFour" />);
-  });
+  // Key should be joined to object key
+  var zeroForceKeyMapped = <div key="giraffe" />;
+  // Key should be added even if we don't supply it!
+  var oneForceKeyMapped = <div />;
 
-  it('should be called for each child in nested structure', function() {
-    var zero = <div key="keyZero" />;
-    var one = null;
-    var two = <div key="keyTwo" />;
-    var three = null;
-    var four = <div key="keyFour" />;
-    var five = <div key="keyFiveInner" />;
-    // five is placed into a JS object with a key that is joined to the
-    // component key attribute.
-    // Precedence is as follows:
-    // 1. If grouped in an Object, the object key combined with `key` prop
-    // 2. If grouped in an Array, the `key` prop, falling back to array index
+  var mapFn = function(kid, index) {
+    return index === 0 ? zeroForceKeyMapped : oneForceKeyMapped;
+  };
 
-    var zeroMapped = <div key="giraffe" />;  // Key should be overridden
-    var twoMapped = <div />;  // Key should be added even if not supplied!
-    var fourMapped = <div key="keyFour" />;
-    var fiveMapped = <div />;
+  var forcedKeys = (
+    <div>
+      {zeroForceKey}
+      {oneForceKey}
+    </div>
+  );
 
-    var callback = jasmine.createSpy().and.callFake(function(kid, index) {
-      return index === 0 ? zeroMapped :
-        index === 1 ? twoMapped :
-        index === 2 ? fourMapped : fiveMapped;
-    });
+  var expectedForcedKeys = ['giraffe/.$keyZero', '.$keyOne'];
+  var mappedChildrenForcedKeys =
+    ReactChildren.map(forcedKeys.props.children, mapFn);
+  var mappedForcedKeys = mappedChildrenForcedKeys.map((c) => c.key);
+  expect(mappedForcedKeys).toEqual(expectedForcedKeys);
 
-    var frag = ReactFragment.create({
-      firstHalfKey: [zero, one, two],
-      secondHalfKey: [three, four],
-      keyFive: five,
-    });
-    var instance = <div>{[frag]}</div>;
+  var expectedRemappedForcedKeys = [
+    'giraffe/.$giraffe/.$keyZero',
+    '.$.$keyOne',
+  ];
+  var remappedChildrenForcedKeys =
+    ReactChildren.map(mappedChildrenForcedKeys, mapFn);
+  expect(
+    remappedChildrenForcedKeys.map((c) => c.key)
+  ).toEqual(expectedRemappedForcedKeys);
 
-    expect([
-      frag[0].key,
-      frag[1].key,
-      frag[2].key,
-      frag[3].key,
-    ]).toEqual([
-      'firstHalfKey/.$keyZero',
-      'firstHalfKey/.$keyTwo',
-      'secondHalfKey/.$keyFour',
-      'keyFive/.$keyFiveInner',
-    ]);
+});
 
-    ReactChildren.forEach(instance.props.children, callback);
-    expect(callback.calls.count()).toBe(4);
-    expect(callback).toHaveBeenCalledWith(frag[0], 0);
-    expect(callback).toHaveBeenCalledWith(frag[1], 1);
-    expect(callback).toHaveBeenCalledWith(frag[2], 2);
-    expect(callback).toHaveBeenCalledWith(frag[3], 3);
-    callback.calls.reset();
+it('should not throw if key provided is a dupe with array key', function() {
+  var zero = <div />;
+  var one = <div key="0" />;
 
-    var mappedChildren = ReactChildren.map(instance.props.children, callback);
-    expect(callback.calls.count()).toBe(4);
-    expect(callback).toHaveBeenCalledWith(frag[0], 0);
-    expect(callback).toHaveBeenCalledWith(frag[1], 1);
-    expect(callback).toHaveBeenCalledWith(frag[2], 2);
-    expect(callback).toHaveBeenCalledWith(frag[3], 3);
+  var mapFn = function() {
+    return null;
+  };
 
-    expect(ReactChildren.count(mappedChildren)).toBe(4);
-    // Keys default to indices.
-    expect([
-      mappedChildren[0].key,
-      mappedChildren[1].key,
-      mappedChildren[2].key,
-      mappedChildren[3].key,
-    ]).toEqual([
-      'giraffe/.0:$firstHalfKey/.$keyZero',
-      '.0:$firstHalfKey/.$keyTwo',
-      'keyFour/.0:$secondHalfKey/.$keyFour',
-      '.0:$keyFive/.$keyFiveInner',
-    ]);
+  var instance = (
+    <div>
+      {zero}
+      {one}
+    </div>
+  );
 
-    expect(mappedChildren[0]).toEqual(<div key="giraffe/.0:$firstHalfKey/.$keyZero" />);
-    expect(mappedChildren[1]).toEqual(<div key=".0:$firstHalfKey/.$keyTwo" />);
-    expect(mappedChildren[2]).toEqual(<div key="keyFour/.0:$secondHalfKey/.$keyFour" />);
-    expect(mappedChildren[3]).toEqual(<div key=".0:$keyFive/.$keyFiveInner" />);
-  });
+  expect(function() {
+    ReactChildren.map(instance.props.children, mapFn);
+  }).not.toThrow();
+});
 
-  it('should retain key across two mappings', function() {
-    var zeroForceKey = <div key="keyZero" />;
-    var oneForceKey = <div key="keyOne" />;
+it('should use the same key for a cloned element', function() {
+  var instance = (
+    <div>
+      <div />
+    </div>
+  );
 
-    // Key should be joined to object key
-    var zeroForceKeyMapped = <div key="giraffe" />;
-    // Key should be added even if we don't supply it!
-    var oneForceKeyMapped = <div />;
+  var mapped = ReactChildren.map(
+    instance.props.children,
+    element => element,
+  );
 
-    var mapFn = function(kid, index) {
-      return index === 0 ? zeroForceKeyMapped : oneForceKeyMapped;
-    };
+  var mappedWithClone = ReactChildren.map(
+    instance.props.children,
+    element => React.cloneElement(element),
+  );
 
-    var forcedKeys = (
-      <div>
-        {zeroForceKey}
-        {oneForceKey}
-      </div>
-    );
+  expect(mapped[0].key).toBe(mappedWithClone[0].key);
+});
 
-    var expectedForcedKeys = ['giraffe/.$keyZero', '.$keyOne'];
-    var mappedChildrenForcedKeys =
-      ReactChildren.map(forcedKeys.props.children, mapFn);
-    var mappedForcedKeys = mappedChildrenForcedKeys.map((c) => c.key);
-    expect(mappedForcedKeys).toEqual(expectedForcedKeys);
+it('should use the same key for a cloned element with key', function() {
+  var instance = (
+    <div>
+      <div key="unique" />
+    </div>
+  );
 
-    var expectedRemappedForcedKeys = [
-      'giraffe/.$giraffe/.$keyZero',
-      '.$.$keyOne',
-    ];
-    var remappedChildrenForcedKeys =
-      ReactChildren.map(mappedChildrenForcedKeys, mapFn);
-    expect(
-      remappedChildrenForcedKeys.map((c) => c.key)
-    ).toEqual(expectedRemappedForcedKeys);
+  var mapped = ReactChildren.map(
+    instance.props.children,
+    element => element,
+  );
 
-  });
+  var mappedWithClone = ReactChildren.map(
+    instance.props.children,
+    element => React.cloneElement(element, {key: 'unique'}),
+  );
 
-  it('should not throw if key provided is a dupe with array key', function() {
-    var zero = <div />;
-    var one = <div key="0" />;
+  expect(mapped[0].key).toBe(mappedWithClone[0].key);
+});
 
-    var mapFn = function() {
-      return null;
-    };
+it('should return 0 for null children', function() {
+  var numberOfChildren = ReactChildren.count(null);
+  expect(numberOfChildren).toBe(0);
+});
 
-    var instance = (
-      <div>
-        {zero}
-        {one}
-      </div>
-    );
+it('should return 0 for undefined children', function() {
+  var numberOfChildren = ReactChildren.count(undefined);
+  expect(numberOfChildren).toBe(0);
+});
 
-    expect(function() {
-      ReactChildren.map(instance.props.children, mapFn);
-    }).not.toThrow();
-  });
+it('should return 1 for single child', function() {
+  var simpleKid = <span key="simple" />;
+  var instance = <div>{simpleKid}</div>;
+  var numberOfChildren = ReactChildren.count(instance.props.children);
+  expect(numberOfChildren).toBe(1);
+});
 
-  it('should use the same key for a cloned element', function() {
-    var instance = (
-      <div>
-        <div />
-      </div>
-    );
+it('should count the number of children in flat structure', function() {
+  var zero = <div key="keyZero" />;
+  var one = null;
+  var two = <div key="keyTwo" />;
+  var three = null;
+  var four = <div key="keyFour" />;
 
-    var mapped = ReactChildren.map(
-      instance.props.children,
-      element => element,
-    );
+  var instance = (
+    <div>
+      {zero}
+      {one}
+      {two}
+      {three}
+      {four}
+    </div>
+  );
+  var numberOfChildren = ReactChildren.count(instance.props.children);
+  expect(numberOfChildren).toBe(5);
+});
 
-    var mappedWithClone = ReactChildren.map(
-      instance.props.children,
-      element => React.cloneElement(element),
-    );
+it('should count the number of children in nested structure', function() {
+  var zero = <div key="keyZero" />;
+  var one = null;
+  var two = <div key="keyTwo" />;
+  var three = null;
+  var four = <div key="keyFour" />;
+  var five = <div key="keyFiveInner" />;
+  // five is placed into a JS object with a key that is joined to the
+  // component key attribute.
+  // Precedence is as follows:
+  // 1. If grouped in an Object, the object key combined with `key` prop
+  // 2. If grouped in an Array, the `key` prop, falling back to array index
 
-    expect(mapped[0].key).toBe(mappedWithClone[0].key);
-  });
+  var instance = (
+    <div>{
+      [
+        ReactFragment.create({
+          firstHalfKey: [zero, one, two],
+          secondHalfKey: [three, four],
+          keyFive: five,
+        }),
+        null,
+      ]
+    }</div>
+  );
+  var numberOfChildren = ReactChildren.count(instance.props.children);
+  expect(numberOfChildren).toBe(5);
+});
 
-  it('should use the same key for a cloned element with key', function() {
-    var instance = (
-      <div>
-        <div key="unique" />
-      </div>
-    );
+it('should flatten children to an array', function() {
+  expect(ReactChildren.toArray(undefined)).toEqual([]);
+  expect(ReactChildren.toArray(null)).toEqual([]);
 
-    var mapped = ReactChildren.map(
-      instance.props.children,
-      element => element,
-    );
+  expect(ReactChildren.toArray(<div />).length).toBe(1);
+  expect(ReactChildren.toArray([<div />]).length).toBe(1);
+  expect(
+    ReactChildren.toArray(<div />)[0].key
+  ).toBe(
+    ReactChildren.toArray([<div />])[0].key
+  );
 
-    var mappedWithClone = ReactChildren.map(
-      instance.props.children,
-      element => React.cloneElement(element, {key: 'unique'}),
-    );
+  var flattened = ReactChildren.toArray([
+    [<div key="apple" />, <div key="banana" />, <div key="camel" />],
+    [<div key="banana" />, <div key="camel" />, <div key="deli" />],
+  ]);
+  expect(flattened.length).toBe(6);
+  expect(flattened[1].key).toContain('banana');
+  expect(flattened[3].key).toContain('banana');
+  expect(flattened[1].key).not.toBe(flattened[3].key);
 
-    expect(mapped[0].key).toBe(mappedWithClone[0].key);
-  });
+  var reversed = ReactChildren.toArray([
+    [<div key="camel" />, <div key="banana" />, <div key="apple" />],
+    [<div key="deli" />, <div key="camel" />, <div key="banana" />],
+  ]);
+  expect(flattened[0].key).toBe(reversed[2].key);
+  expect(flattened[1].key).toBe(reversed[1].key);
+  expect(flattened[2].key).toBe(reversed[0].key);
+  expect(flattened[3].key).toBe(reversed[5].key);
+  expect(flattened[4].key).toBe(reversed[4].key);
+  expect(flattened[5].key).toBe(reversed[3].key);
 
-  it('should return 0 for null children', function() {
-    var numberOfChildren = ReactChildren.count(null);
-    expect(numberOfChildren).toBe(0);
-  });
-
-  it('should return 0 for undefined children', function() {
-    var numberOfChildren = ReactChildren.count(undefined);
-    expect(numberOfChildren).toBe(0);
-  });
-
-  it('should return 1 for single child', function() {
-    var simpleKid = <span key="simple" />;
-    var instance = <div>{simpleKid}</div>;
-    var numberOfChildren = ReactChildren.count(instance.props.children);
-    expect(numberOfChildren).toBe(1);
-  });
-
-  it('should count the number of children in flat structure', function() {
-    var zero = <div key="keyZero" />;
-    var one = null;
-    var two = <div key="keyTwo" />;
-    var three = null;
-    var four = <div key="keyFour" />;
-
-    var instance = (
-      <div>
-        {zero}
-        {one}
-        {two}
-        {three}
-        {four}
-      </div>
-    );
-    var numberOfChildren = ReactChildren.count(instance.props.children);
-    expect(numberOfChildren).toBe(5);
-  });
-
-  it('should count the number of children in nested structure', function() {
-    var zero = <div key="keyZero" />;
-    var one = null;
-    var two = <div key="keyTwo" />;
-    var three = null;
-    var four = <div key="keyFour" />;
-    var five = <div key="keyFiveInner" />;
-    // five is placed into a JS object with a key that is joined to the
-    // component key attribute.
-    // Precedence is as follows:
-    // 1. If grouped in an Object, the object key combined with `key` prop
-    // 2. If grouped in an Array, the `key` prop, falling back to array index
-
-    var instance = (
-      <div>{
-        [
-          ReactFragment.create({
-            firstHalfKey: [zero, one, two],
-            secondHalfKey: [three, four],
-            keyFive: five,
-          }),
-          null,
-        ]
-      }</div>
-    );
-    var numberOfChildren = ReactChildren.count(instance.props.children);
-    expect(numberOfChildren).toBe(5);
-  });
-
-  it('should flatten children to an array', function() {
-    expect(ReactChildren.toArray(undefined)).toEqual([]);
-    expect(ReactChildren.toArray(null)).toEqual([]);
-
-    expect(ReactChildren.toArray(<div />).length).toBe(1);
-    expect(ReactChildren.toArray([<div />]).length).toBe(1);
-    expect(
-      ReactChildren.toArray(<div />)[0].key
-    ).toBe(
-      ReactChildren.toArray([<div />])[0].key
-    );
-
-    var flattened = ReactChildren.toArray([
-      [<div key="apple" />, <div key="banana" />, <div key="camel" />],
-      [<div key="banana" />, <div key="camel" />, <div key="deli" />],
-    ]);
-    expect(flattened.length).toBe(6);
-    expect(flattened[1].key).toContain('banana');
-    expect(flattened[3].key).toContain('banana');
-    expect(flattened[1].key).not.toBe(flattened[3].key);
-
-    var reversed = ReactChildren.toArray([
-      [<div key="camel" />, <div key="banana" />, <div key="apple" />],
-      [<div key="deli" />, <div key="camel" />, <div key="banana" />],
-    ]);
-    expect(flattened[0].key).toBe(reversed[2].key);
-    expect(flattened[1].key).toBe(reversed[1].key);
-    expect(flattened[2].key).toBe(reversed[0].key);
-    expect(flattened[3].key).toBe(reversed[5].key);
-    expect(flattened[4].key).toBe(reversed[4].key);
-    expect(flattened[5].key).toBe(reversed[3].key);
-
-    // null/undefined/bool are all omitted
-    expect(ReactChildren.toArray([1, 'two', null, undefined, true])).toEqual(
-      [1, 'two']
-    );
-  });
-
+  // null/undefined/bool are all omitted
+  expect(ReactChildren.toArray([1, 'two', null, undefined, true])).toEqual(
+    [1, 'two']
+  );
 });

--- a/src/isomorphic/children/__tests__/onlyChild-test.js
+++ b/src/isomorphic/children/__tests__/onlyChild-test.js
@@ -11,87 +11,83 @@
 
 'use strict';
 
-describe('onlyChild', function() {
+var React;
+var ReactFragment;
+var onlyChild;
+var WrapComponent;
 
-  var React;
-  var ReactFragment;
-  var onlyChild;
-  var WrapComponent;
+beforeEach(function() {
+  React = require('React');
+  ReactFragment = require('ReactFragment');
+  onlyChild = require('onlyChild');
+  WrapComponent = class extends React.Component {
+    render() {
+      return (
+        <div>
+          {onlyChild(this.props.children, this.props.mapFn, this)}
+        </div>
+      );
+    }
+  };
+});
 
-  beforeEach(function() {
-    React = require('React');
-    ReactFragment = require('ReactFragment');
-    onlyChild = require('onlyChild');
-    WrapComponent = class extends React.Component {
-      render() {
-        return (
-          <div>
-            {onlyChild(this.props.children, this.props.mapFn, this)}
-          </div>
-        );
-      }
-    };
-  });
+it('should fail when passed two children', function() {
+  expect(function() {
+    var instance =
+      <WrapComponent>
+        <div />
+        <span />
+      </WrapComponent>;
+    onlyChild(instance.props.children);
+  }).toThrow();
+});
 
-  it('should fail when passed two children', function() {
-    expect(function() {
-      var instance =
-        <WrapComponent>
-          <div />
-          <span />
-        </WrapComponent>;
-      onlyChild(instance.props.children);
-    }).toThrow();
-  });
+it('should fail when passed nully values', function() {
+  expect(function() {
+    var instance =
+      <WrapComponent>
+        {null}
+      </WrapComponent>;
+    onlyChild(instance.props.children);
+  }).toThrow();
 
-  it('should fail when passed nully values', function() {
-    expect(function() {
-      var instance =
-        <WrapComponent>
-          {null}
-        </WrapComponent>;
-      onlyChild(instance.props.children);
-    }).toThrow();
+  expect(function() {
+    var instance =
+      <WrapComponent>
+        {undefined}
+      </WrapComponent>;
+    onlyChild(instance.props.children);
+  }).toThrow();
+});
 
-    expect(function() {
-      var instance =
-        <WrapComponent>
-          {undefined}
-        </WrapComponent>;
-      onlyChild(instance.props.children);
-    }).toThrow();
-  });
-
-  it('should fail when key/value objects', function() {
-    expect(function() {
-      var instance =
-        <WrapComponent>
-          {ReactFragment.create({oneThing: <span />})}
-        </WrapComponent>;
-      onlyChild(instance.props.children);
-    }).toThrow();
-  });
+it('should fail when key/value objects', function() {
+  expect(function() {
+    var instance =
+      <WrapComponent>
+        {ReactFragment.create({oneThing: <span />})}
+      </WrapComponent>;
+    onlyChild(instance.props.children);
+  }).toThrow();
+});
 
 
-  it('should not fail when passed interpolated single child', function() {
-    expect(function() {
-      var instance =
-        <WrapComponent>
-          {<span />}
-        </WrapComponent>;
-      onlyChild(instance.props.children);
-    }).not.toThrow();
-  });
+it('should not fail when passed interpolated single child', function() {
+  expect(function() {
+    var instance =
+      <WrapComponent>
+        {<span />}
+      </WrapComponent>;
+    onlyChild(instance.props.children);
+  }).not.toThrow();
+});
 
 
-  it('should return the only child', function() {
-    expect(function() {
-      var instance =
-        <WrapComponent>
-          <span />
-        </WrapComponent>;
-      onlyChild(instance.props.children);
-    }).not.toThrow();
-  });
-
+it('should return the only child', function() {
+  expect(function() {
+    var instance =
+      <WrapComponent>
+        <span />
+      </WrapComponent>;
+    onlyChild(instance.props.children);
+  }).not.toThrow();
 });

--- a/src/isomorphic/children/__tests__/sliceChildren-test.js
+++ b/src/isomorphic/children/__tests__/sliceChildren-test.js
@@ -11,83 +11,79 @@
 
 'use strict';
 
-describe('sliceChildren', function() {
+var React;
 
-  var React;
+var sliceChildren;
 
-  var sliceChildren;
+beforeEach(function() {
+  React = require('React');
 
-  beforeEach(function() {
-    React = require('React');
+  sliceChildren = require('sliceChildren');
+});
 
-    sliceChildren = require('sliceChildren');
-  });
+it('should render the whole set if start zero is supplied', function() {
+  var fullSet = [
+    <div key="A" />,
+    <div key="B" />,
+    <div key="C" />,
+  ];
+  var children = sliceChildren(fullSet, 0);
+  expect(children).toEqual([
+    <div key=".$A" />,
+    <div key=".$B" />,
+    <div key=".$C" />,
+  ]);
+});
 
-  it('should render the whole set if start zero is supplied', function() {
-    var fullSet = [
-      <div key="A" />,
+it('should render the remaining set if no end index is supplied', function() {
+  var fullSet = [
+    <div key="A" />,
+    <div key="B" />,
+    <div key="C" />,
+  ];
+  var children = sliceChildren(fullSet, 1);
+  expect(children).toEqual([
+    <div key=".$B" />,
+    <div key=".$C" />,
+  ]);
+});
+
+it('should exclude everything at or after the end index', function() {
+  var fullSet = [
+    <div key="A" />,
+    <div key="B" />,
+    <div key="C" />,
+    <div key="D" />,
+  ];
+  var children = sliceChildren(fullSet, 1, 2);
+  expect(children).toEqual([
+    <div key=".$B" />,
+  ]);
+});
+
+it('should allow static children to be sliced', function() {
+  var a = <a />;
+  var b = <b />;
+  var c = <i />;
+
+  var el = <div>{a}{b}{c}</div>;
+  var children = sliceChildren(el.props.children, 1, 2);
+  expect(children).toEqual([
+    <b key=".1" />,
+  ]);
+});
+
+it('should slice nested children', function() {
+  var fullSet = [
+    <div key="A" />,
+    [
       <div key="B" />,
       <div key="C" />,
-    ];
-    var children = sliceChildren(fullSet, 0);
-    expect(children).toEqual([
-      <div key=".$A" />,
-      <div key=".$B" />,
-      <div key=".$C" />,
-    ]);
-  });
-
-  it('should render the remaining set if no end index is supplied', function() {
-    var fullSet = [
-      <div key="A" />,
-      <div key="B" />,
-      <div key="C" />,
-    ];
-    var children = sliceChildren(fullSet, 1);
-    expect(children).toEqual([
-      <div key=".$B" />,
-      <div key=".$C" />,
-    ]);
-  });
-
-  it('should exclude everything at or after the end index', function() {
-    var fullSet = [
-      <div key="A" />,
-      <div key="B" />,
-      <div key="C" />,
-      <div key="D" />,
-    ];
-    var children = sliceChildren(fullSet, 1, 2);
-    expect(children).toEqual([
-      <div key=".$B" />,
-    ]);
-  });
-
-  it('should allow static children to be sliced', function() {
-    var a = <a />;
-    var b = <b />;
-    var c = <i />;
-
-    var el = <div>{a}{b}{c}</div>;
-    var children = sliceChildren(el.props.children, 1, 2);
-    expect(children).toEqual([
-      <b key=".1" />,
-    ]);
-  });
-
-  it('should slice nested children', function() {
-    var fullSet = [
-      <div key="A" />,
-      [
-        <div key="B" />,
-        <div key="C" />,
-      ],
-      <div key="D" />,
-    ];
-    var children = sliceChildren(fullSet, 1, 2);
-    expect(children).toEqual([
-      <div key=".1:$B" />,
-    ]);
-  });
-
+    ],
+    <div key="D" />,
+  ];
+  var children = sliceChildren(fullSet, 1, 2);
+  expect(children).toEqual([
+    <div key=".1:$B" />,
+  ]);
 });

--- a/src/isomorphic/classic/class/__tests__/ReactBind-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactBind-test.js
@@ -15,152 +15,147 @@ var React = require('React');
 var ReactTestUtils = require('ReactTestUtils');
 var reactComponentExpect = require('reactComponentExpect');
 
-// TODO: Test render and all stock methods.
-describe('autobinding', function() {
+it('Holds reference to instance', function() {
 
-  it('Holds reference to instance', function() {
+  var mouseDidEnter = jest.fn();
+  var mouseDidLeave = jest.fn();
+  var mouseDidClick = jest.fn();
 
-    var mouseDidEnter = jest.fn();
-    var mouseDidLeave = jest.fn();
-    var mouseDidClick = jest.fn();
+  var TestBindComponent = React.createClass({
+    getInitialState: function() {
+      return {something: 'hi'};
+    },
+    onMouseEnter: mouseDidEnter,
+    onMouseLeave: mouseDidLeave,
+    onClick: mouseDidClick,
 
-    var TestBindComponent = React.createClass({
-      getInitialState: function() {
-        return {something: 'hi'};
+    // auto binding only occurs on top level functions in class defs.
+    badIdeas: {
+      badBind: function() {
+        void this.state.something;
       },
-      onMouseEnter: mouseDidEnter,
-      onMouseLeave: mouseDidLeave,
-      onClick: mouseDidClick,
+    },
 
-      // auto binding only occurs on top level functions in class defs.
-      badIdeas: {
-        badBind: function() {
-          void this.state.something;
-        },
-      },
-
-      render: function() {
-        return (
-          <div
-            onMouseOver={this.onMouseEnter}
-            onMouseOut={this.onMouseLeave}
-            onClick={this.onClick}
-          />
-        );
-      },
-    });
-
-    var instance1 = <TestBindComponent />;
-    var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
-    var rendered1 = reactComponentExpect(mountedInstance1)
-      .expectRenderedChild()
-      .instance();
-
-    var instance2 = <TestBindComponent />;
-    var mountedInstance2 = ReactTestUtils.renderIntoDocument(instance2);
-    var rendered2 = reactComponentExpect(mountedInstance2)
-      .expectRenderedChild()
-      .instance();
-
-    expect(function() {
-      var badIdea = instance1.badIdeas.badBind;
-      badIdea();
-    }).toThrow();
-
-    expect(mountedInstance1.onClick).not.toBe(mountedInstance2.onClick);
-
-    ReactTestUtils.Simulate.click(rendered1);
-    expect(mouseDidClick.mock.instances.length).toBe(1);
-    expect(mouseDidClick.mock.instances[0]).toBe(mountedInstance1);
-
-    ReactTestUtils.Simulate.click(rendered2);
-    expect(mouseDidClick.mock.instances.length).toBe(2);
-    expect(mouseDidClick.mock.instances[1]).toBe(mountedInstance2);
-
-    ReactTestUtils.Simulate.mouseOver(rendered1);
-    expect(mouseDidEnter.mock.instances.length).toBe(1);
-    expect(mouseDidEnter.mock.instances[0]).toBe(mountedInstance1);
-
-    ReactTestUtils.Simulate.mouseOver(rendered2);
-    expect(mouseDidEnter.mock.instances.length).toBe(2);
-    expect(mouseDidEnter.mock.instances[1]).toBe(mountedInstance2);
-
-    ReactTestUtils.Simulate.mouseOut(rendered1);
-    expect(mouseDidLeave.mock.instances.length).toBe(1);
-    expect(mouseDidLeave.mock.instances[0]).toBe(mountedInstance1);
-
-    ReactTestUtils.Simulate.mouseOut(rendered2);
-    expect(mouseDidLeave.mock.instances.length).toBe(2);
-    expect(mouseDidLeave.mock.instances[1]).toBe(mountedInstance2);
+    render: function() {
+      return (
+        <div
+          onMouseOver={this.onMouseEnter}
+          onMouseOut={this.onMouseLeave}
+          onClick={this.onClick}
+        />
+      );
+    },
   });
 
-  it('works with mixins', function() {
-    var mouseDidClick = jest.fn();
+  var instance1 = <TestBindComponent />;
+  var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
+  var rendered1 = reactComponentExpect(mountedInstance1)
+    .expectRenderedChild()
+    .instance();
 
-    var TestMixin = {
-      onClick: mouseDidClick,
-    };
+  var instance2 = <TestBindComponent />;
+  var mountedInstance2 = ReactTestUtils.renderIntoDocument(instance2);
+  var rendered2 = reactComponentExpect(mountedInstance2)
+    .expectRenderedChild()
+    .instance();
 
-    var TestBindComponent = React.createClass({
-      mixins: [TestMixin],
+  expect(function() {
+    var badIdea = instance1.badIdeas.badBind;
+    badIdea();
+  }).toThrow();
 
-      render: function() {
-        return <div onClick={this.onClick} />;
-      },
-    });
+  expect(mountedInstance1.onClick).not.toBe(mountedInstance2.onClick);
 
-    var instance1 = <TestBindComponent />;
-    var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
-    var rendered1 = reactComponentExpect(mountedInstance1)
-      .expectRenderedChild()
-      .instance();
+  ReactTestUtils.Simulate.click(rendered1);
+  expect(mouseDidClick.mock.instances.length).toBe(1);
+  expect(mouseDidClick.mock.instances[0]).toBe(mountedInstance1);
 
-    ReactTestUtils.Simulate.click(rendered1);
-    expect(mouseDidClick.mock.instances.length).toBe(1);
-    expect(mouseDidClick.mock.instances[0]).toBe(mountedInstance1);
+  ReactTestUtils.Simulate.click(rendered2);
+  expect(mouseDidClick.mock.instances.length).toBe(2);
+  expect(mouseDidClick.mock.instances[1]).toBe(mountedInstance2);
+
+  ReactTestUtils.Simulate.mouseOver(rendered1);
+  expect(mouseDidEnter.mock.instances.length).toBe(1);
+  expect(mouseDidEnter.mock.instances[0]).toBe(mountedInstance1);
+
+  ReactTestUtils.Simulate.mouseOver(rendered2);
+  expect(mouseDidEnter.mock.instances.length).toBe(2);
+  expect(mouseDidEnter.mock.instances[1]).toBe(mountedInstance2);
+
+  ReactTestUtils.Simulate.mouseOut(rendered1);
+  expect(mouseDidLeave.mock.instances.length).toBe(1);
+  expect(mouseDidLeave.mock.instances[0]).toBe(mountedInstance1);
+
+  ReactTestUtils.Simulate.mouseOut(rendered2);
+  expect(mouseDidLeave.mock.instances.length).toBe(2);
+  expect(mouseDidLeave.mock.instances[1]).toBe(mountedInstance2);
+});
+
+it('works with mixins', function() {
+  var mouseDidClick = jest.fn();
+
+  var TestMixin = {
+    onClick: mouseDidClick,
+  };
+
+  var TestBindComponent = React.createClass({
+    mixins: [TestMixin],
+
+    render: function() {
+      return <div onClick={this.onClick} />;
+    },
   });
 
-  it('warns if you try to bind to this', function() {
-    spyOn(console, 'error');
+  var instance1 = <TestBindComponent />;
+  var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
+  var rendered1 = reactComponentExpect(mountedInstance1)
+    .expectRenderedChild()
+    .instance();
 
-    var TestBindComponent = React.createClass({
-      handleClick: function() { },
-      render: function() {
-        return <div onClick={this.handleClick.bind(this)} />;
-      },
-    });
+  ReactTestUtils.Simulate.click(rendered1);
+  expect(mouseDidClick.mock.instances.length).toBe(1);
+  expect(mouseDidClick.mock.instances[0]).toBe(mountedInstance1);
+});
 
-    ReactTestUtils.renderIntoDocument(<TestBindComponent />);
+it('warns if you try to bind to this', function() {
+  spyOn(console, 'error');
 
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: bind(): You are binding a component method to the component. ' +
-      'React does this for you automatically in a high-performance ' +
-      'way, so you can safely remove this call. See TestBindComponent'
-    );
+  var TestBindComponent = React.createClass({
+    handleClick: function() { },
+    render: function() {
+      return <div onClick={this.handleClick.bind(this)} />;
+    },
   });
 
-  it('does not warn if you pass an auto-bound method to setState', function() {
-    spyOn(console, 'error');
+  ReactTestUtils.renderIntoDocument(<TestBindComponent />);
 
-    var TestBindComponent = React.createClass({
-      getInitialState: function() {
-        return {foo: 1};
-      },
-      componentDidMount: function() {
-        this.setState({foo: 2}, this.handleUpdate);
-      },
-      handleUpdate: function() {
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: bind(): You are binding a component method to the component. ' +
+    'React does this for you automatically in a high-performance ' +
+    'way, so you can safely remove this call. See TestBindComponent'
+  );
+});
 
-      },
-      render: function() {
-        return <div onClick={this.handleClick} />;
-      },
-    });
+it('does not warn if you pass an auto-bound method to setState', function() {
+  spyOn(console, 'error');
 
-    ReactTestUtils.renderIntoDocument(<TestBindComponent />);
+  var TestBindComponent = React.createClass({
+    getInitialState: function() {
+      return {foo: 1};
+    },
+    componentDidMount: function() {
+      this.setState({foo: 2}, this.handleUpdate);
+    },
+    handleUpdate: function() {
 
-    expect(console.error.calls.count()).toBe(0);
+    },
+    render: function() {
+      return <div onClick={this.handleClick} />;
+    },
   });
 
+  ReactTestUtils.renderIntoDocument(<TestBindComponent />);
+
+  expect(console.error.calls.count()).toBe(0);
 });

--- a/src/isomorphic/classic/class/__tests__/ReactBindOptout-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactBindOptout-test.js
@@ -15,219 +15,214 @@ var React = require('React');
 var ReactTestUtils = require('ReactTestUtils');
 var reactComponentExpect = require('reactComponentExpect');
 
-// TODO: Test render and all stock methods.
-describe('autobind optout', function() {
+it('should work with manual binding', function() {
 
-  it('should work with manual binding', function() {
+  var mouseDidEnter = jest.fn();
+  var mouseDidLeave = jest.fn();
+  var mouseDidClick = jest.fn();
 
-    var mouseDidEnter = jest.fn();
-    var mouseDidLeave = jest.fn();
-    var mouseDidClick = jest.fn();
+  var TestBindComponent = React.createClass({
+    autobind: false,
+    getInitialState: function() {
+      return {something: 'hi'};
+    },
+    onMouseEnter: mouseDidEnter,
+    onMouseLeave: mouseDidLeave,
+    onClick: mouseDidClick,
 
-    var TestBindComponent = React.createClass({
-      autobind: false,
-      getInitialState: function() {
-        return {something: 'hi'};
-      },
-      onMouseEnter: mouseDidEnter,
-      onMouseLeave: mouseDidLeave,
-      onClick: mouseDidClick,
-
-      render: function() {
-        return (
-          <div
-            onMouseOver={this.onMouseEnter.bind(this)}
-            onMouseOut={this.onMouseLeave.bind(this)}
-            onClick={this.onClick.bind(this)}
-            />
-        );
-      },
-    });
-
-    var instance1 = <TestBindComponent />;
-    var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
-    var rendered1 = reactComponentExpect(mountedInstance1)
-      .expectRenderedChild()
-      .instance();
-
-    var instance2 = <TestBindComponent />;
-    var mountedInstance2 = ReactTestUtils.renderIntoDocument(instance2);
-    var rendered2 = reactComponentExpect(mountedInstance2)
-      .expectRenderedChild()
-      .instance();
-
-    ReactTestUtils.Simulate.click(rendered1);
-    expect(mouseDidClick.mock.instances.length).toBe(1);
-    expect(mouseDidClick.mock.instances[0]).toBe(mountedInstance1);
-
-    ReactTestUtils.Simulate.click(rendered2);
-    expect(mouseDidClick.mock.instances.length).toBe(2);
-    expect(mouseDidClick.mock.instances[1]).toBe(mountedInstance2);
-
-    ReactTestUtils.Simulate.mouseOver(rendered1);
-    expect(mouseDidEnter.mock.instances.length).toBe(1);
-    expect(mouseDidEnter.mock.instances[0]).toBe(mountedInstance1);
-
-    ReactTestUtils.Simulate.mouseOver(rendered2);
-    expect(mouseDidEnter.mock.instances.length).toBe(2);
-    expect(mouseDidEnter.mock.instances[1]).toBe(mountedInstance2);
-
-    ReactTestUtils.Simulate.mouseOut(rendered1);
-    expect(mouseDidLeave.mock.instances.length).toBe(1);
-    expect(mouseDidLeave.mock.instances[0]).toBe(mountedInstance1);
-
-    ReactTestUtils.Simulate.mouseOut(rendered2);
-    expect(mouseDidLeave.mock.instances.length).toBe(2);
-    expect(mouseDidLeave.mock.instances[1]).toBe(mountedInstance2);
-  });
-
-  it('should not hold reference to instance', function() {
-    var mouseDidClick = function() {
-      void this.state.something;
-    };
-
-    var TestBindComponent = React.createClass({
-      autobind: false,
-      getInitialState: function() {
-        return {something: 'hi'};
-      },
-      onClick: mouseDidClick,
-
-      // auto binding only occurs on top level functions in class defs.
-      badIdeas: {
-        badBind: function() {
-          void this.state.something;
-        },
-      },
-
-      render: function() {
-        return (
-          <div
-            onClick={this.onClick}
+    render: function() {
+      return (
+        <div
+          onMouseOver={this.onMouseEnter.bind(this)}
+          onMouseOut={this.onMouseLeave.bind(this)}
+          onClick={this.onClick.bind(this)}
           />
-        );
-      },
-    });
-
-    var instance1 = <TestBindComponent />;
-    var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
-    var rendered1 = reactComponentExpect(mountedInstance1)
-      .expectRenderedChild()
-      .instance();
-
-    var instance2 = <TestBindComponent />;
-    var mountedInstance2 = ReactTestUtils.renderIntoDocument(instance2);
-    var rendered2 = reactComponentExpect(mountedInstance2)
-      .expectRenderedChild()
-      .instance();
-
-    expect(function() {
-      var badIdea = instance1.badIdeas.badBind;
-      badIdea();
-    }).toThrow();
-
-    expect(mountedInstance1.onClick).toBe(mountedInstance2.onClick);
-
-    expect(function() {
-      ReactTestUtils.Simulate.click(rendered1);
-    }).toThrow();
-
-    expect(function() {
-      ReactTestUtils.Simulate.click(rendered2);
-    }).toThrow();
+      );
+    },
   });
 
-  it('works with mixins that have not opted out of autobinding', function() {
-    var mouseDidClick = jest.fn();
+  var instance1 = <TestBindComponent />;
+  var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
+  var rendered1 = reactComponentExpect(mountedInstance1)
+    .expectRenderedChild()
+    .instance();
 
-    var TestMixin = {
-      onClick: mouseDidClick,
-    };
+  var instance2 = <TestBindComponent />;
+  var mountedInstance2 = ReactTestUtils.renderIntoDocument(instance2);
+  var rendered2 = reactComponentExpect(mountedInstance2)
+    .expectRenderedChild()
+    .instance();
 
-    var TestBindComponent = React.createClass({
-      mixins: [TestMixin],
+  ReactTestUtils.Simulate.click(rendered1);
+  expect(mouseDidClick.mock.instances.length).toBe(1);
+  expect(mouseDidClick.mock.instances[0]).toBe(mountedInstance1);
 
-      render: function() {
-        return <div onClick={this.onClick} />;
+  ReactTestUtils.Simulate.click(rendered2);
+  expect(mouseDidClick.mock.instances.length).toBe(2);
+  expect(mouseDidClick.mock.instances[1]).toBe(mountedInstance2);
+
+  ReactTestUtils.Simulate.mouseOver(rendered1);
+  expect(mouseDidEnter.mock.instances.length).toBe(1);
+  expect(mouseDidEnter.mock.instances[0]).toBe(mountedInstance1);
+
+  ReactTestUtils.Simulate.mouseOver(rendered2);
+  expect(mouseDidEnter.mock.instances.length).toBe(2);
+  expect(mouseDidEnter.mock.instances[1]).toBe(mountedInstance2);
+
+  ReactTestUtils.Simulate.mouseOut(rendered1);
+  expect(mouseDidLeave.mock.instances.length).toBe(1);
+  expect(mouseDidLeave.mock.instances[0]).toBe(mountedInstance1);
+
+  ReactTestUtils.Simulate.mouseOut(rendered2);
+  expect(mouseDidLeave.mock.instances.length).toBe(2);
+  expect(mouseDidLeave.mock.instances[1]).toBe(mountedInstance2);
+});
+
+it('should not hold reference to instance', function() {
+  var mouseDidClick = function() {
+    void this.state.something;
+  };
+
+  var TestBindComponent = React.createClass({
+    autobind: false,
+    getInitialState: function() {
+      return {something: 'hi'};
+    },
+    onClick: mouseDidClick,
+
+    // auto binding only occurs on top level functions in class defs.
+    badIdeas: {
+      badBind: function() {
+        void this.state.something;
       },
-    });
+    },
 
-    var instance1 = <TestBindComponent />;
-    var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
-    var rendered1 = reactComponentExpect(mountedInstance1)
-      .expectRenderedChild()
-      .instance();
+    render: function() {
+      return (
+        <div
+          onClick={this.onClick}
+        />
+      );
+    },
+  });
 
+  var instance1 = <TestBindComponent />;
+  var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
+  var rendered1 = reactComponentExpect(mountedInstance1)
+    .expectRenderedChild()
+    .instance();
+
+  var instance2 = <TestBindComponent />;
+  var mountedInstance2 = ReactTestUtils.renderIntoDocument(instance2);
+  var rendered2 = reactComponentExpect(mountedInstance2)
+    .expectRenderedChild()
+    .instance();
+
+  expect(function() {
+    var badIdea = instance1.badIdeas.badBind;
+    badIdea();
+  }).toThrow();
+
+  expect(mountedInstance1.onClick).toBe(mountedInstance2.onClick);
+
+  expect(function() {
     ReactTestUtils.Simulate.click(rendered1);
-    expect(mouseDidClick.mock.instances.length).toBe(1);
-    expect(mouseDidClick.mock.instances[0]).toBe(mountedInstance1);
+  }).toThrow();
+
+  expect(function() {
+    ReactTestUtils.Simulate.click(rendered2);
+  }).toThrow();
+});
+
+it('works with mixins that have not opted out of autobinding', function() {
+  var mouseDidClick = jest.fn();
+
+  var TestMixin = {
+    onClick: mouseDidClick,
+  };
+
+  var TestBindComponent = React.createClass({
+    mixins: [TestMixin],
+
+    render: function() {
+      return <div onClick={this.onClick} />;
+    },
   });
 
-  it('works with mixins that have opted out of autobinding', function() {
-    var mouseDidClick = jest.fn();
+  var instance1 = <TestBindComponent />;
+  var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
+  var rendered1 = reactComponentExpect(mountedInstance1)
+    .expectRenderedChild()
+    .instance();
 
-    var TestMixin = {
-      autobind: false,
-      onClick: mouseDidClick,
-    };
+  ReactTestUtils.Simulate.click(rendered1);
+  expect(mouseDidClick.mock.instances.length).toBe(1);
+  expect(mouseDidClick.mock.instances[0]).toBe(mountedInstance1);
+});
 
-    var TestBindComponent = React.createClass({
-      mixins: [TestMixin],
+it('works with mixins that have opted out of autobinding', function() {
+  var mouseDidClick = jest.fn();
 
-      render: function() {
-        return <div onClick={this.onClick.bind(this)} />;
-      },
-    });
+  var TestMixin = {
+    autobind: false,
+    onClick: mouseDidClick,
+  };
 
-    var instance1 = <TestBindComponent />;
-    var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
-    var rendered1 = reactComponentExpect(mountedInstance1)
-      .expectRenderedChild()
-      .instance();
+  var TestBindComponent = React.createClass({
+    mixins: [TestMixin],
 
-    ReactTestUtils.Simulate.click(rendered1);
-    expect(mouseDidClick.mock.instances.length).toBe(1);
-    expect(mouseDidClick.mock.instances[0]).toBe(mountedInstance1);
+    render: function() {
+      return <div onClick={this.onClick.bind(this)} />;
+    },
   });
 
-  it('does not warn if you try to bind to this', function() {
-    spyOn(console, 'error');
+  var instance1 = <TestBindComponent />;
+  var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
+  var rendered1 = reactComponentExpect(mountedInstance1)
+    .expectRenderedChild()
+    .instance();
 
-    var TestBindComponent = React.createClass({
-      autobind: false,
-      handleClick: function() { },
-      render: function() {
-        return <div onClick={this.handleClick.bind(this)} />;
-      },
-    });
+  ReactTestUtils.Simulate.click(rendered1);
+  expect(mouseDidClick.mock.instances.length).toBe(1);
+  expect(mouseDidClick.mock.instances[0]).toBe(mountedInstance1);
+});
 
-    ReactTestUtils.renderIntoDocument(<TestBindComponent />);
+it('does not warn if you try to bind to this', function() {
+  spyOn(console, 'error');
 
-    expect(console.error.calls.count()).toBe(0);
+  var TestBindComponent = React.createClass({
+    autobind: false,
+    handleClick: function() { },
+    render: function() {
+      return <div onClick={this.handleClick.bind(this)} />;
+    },
   });
 
-  it('does not warn if you pass an manually bound method to setState', function() {
-    spyOn(console, 'error');
+  ReactTestUtils.renderIntoDocument(<TestBindComponent />);
 
-    var TestBindComponent = React.createClass({
-      autobind: false,
-      getInitialState: function() {
-        return {foo: 1};
-      },
-      componentDidMount: function() {
-        this.setState({foo: 2}, this.handleUpdate.bind(this));
-      },
-      handleUpdate: function() {
+  expect(console.error.calls.count()).toBe(0);
+});
 
-      },
-      render: function() {
-        return <div />;
-      },
-    });
+it('does not warn if you pass an manually bound method to setState', function() {
+  spyOn(console, 'error');
 
-    ReactTestUtils.renderIntoDocument(<TestBindComponent />);
+  var TestBindComponent = React.createClass({
+    autobind: false,
+    getInitialState: function() {
+      return {foo: 1};
+    },
+    componentDidMount: function() {
+      this.setState({foo: 2}, this.handleUpdate.bind(this));
+    },
+    handleUpdate: function() {
 
-    expect(console.error.calls.count()).toBe(0);
+    },
+    render: function() {
+      return <div />;
+    },
   });
 
+  ReactTestUtils.renderIntoDocument(<TestBindComponent />);
+
+  expect(console.error.calls.count()).toBe(0);
 });

--- a/src/isomorphic/classic/class/__tests__/ReactClass-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactClass-test.js
@@ -15,339 +15,335 @@ var React;
 var ReactDOM;
 var ReactTestUtils;
 
-describe('ReactClass-spec', function() {
+beforeEach(function() {
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactTestUtils = require('ReactTestUtils');
+});
 
-  beforeEach(function() {
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactTestUtils = require('ReactTestUtils');
+it('should throw when `render` is not specified', function() {
+  expect(function() {
+    React.createClass({});
+  }).toThrowError(
+    'createClass(...): Class specification must implement a `render` method.'
+  );
+});
+
+it('should copy `displayName` onto the Constructor', function() {
+  var TestComponent = React.createClass({
+    render: function() {
+      return <div />;
+    },
   });
 
-  it('should throw when `render` is not specified', function() {
-    expect(function() {
-      React.createClass({});
-    }).toThrowError(
-      'createClass(...): Class specification must implement a `render` method.'
-    );
+  expect(TestComponent.displayName)
+    .toBe('TestComponent');
+});
+
+it('should copy prop types onto the Constructor', function() {
+  var propValidator = jest.fn();
+  var TestComponent = React.createClass({
+    propTypes: {
+      value: propValidator,
+    },
+    render: function() {
+      return <div />;
+    },
   });
 
-  it('should copy `displayName` onto the Constructor', function() {
-    var TestComponent = React.createClass({
-      render: function() {
-        return <div />;
-      },
-    });
+  expect(TestComponent.propTypes).toBeDefined();
+  expect(TestComponent.propTypes.value)
+    .toBe(propValidator);
+});
 
-    expect(TestComponent.displayName)
-      .toBe('TestComponent');
+it('should warn on invalid prop types', function() {
+  spyOn(console, 'error');
+  React.createClass({
+    displayName: 'Component',
+    propTypes: {
+      prop: null,
+    },
+    render: function() {
+      return <span>{this.props.prop}</span>;
+    },
   });
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: Component: prop type `prop` is invalid; ' +
+    'it must be a function, usually from React.PropTypes.'
+  );
+});
 
-  it('should copy prop types onto the Constructor', function() {
-    var propValidator = jest.fn();
-    var TestComponent = React.createClass({
-      propTypes: {
-        value: propValidator,
-      },
-      render: function() {
-        return <div />;
-      },
-    });
-
-    expect(TestComponent.propTypes).toBeDefined();
-    expect(TestComponent.propTypes.value)
-      .toBe(propValidator);
+it('should warn on invalid context types', function() {
+  spyOn(console, 'error');
+  React.createClass({
+    displayName: 'Component',
+    contextTypes: {
+      prop: null,
+    },
+    render: function() {
+      return <span>{this.props.prop}</span>;
+    },
   });
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: Component: context type `prop` is invalid; ' +
+    'it must be a function, usually from React.PropTypes.'
+  );
+});
 
-  it('should warn on invalid prop types', function() {
-    spyOn(console, 'error');
+it('should throw on invalid child context types', function() {
+  spyOn(console, 'error');
+  React.createClass({
+    displayName: 'Component',
+    childContextTypes: {
+      prop: null,
+    },
+    render: function() {
+      return <span>{this.props.prop}</span>;
+    },
+  });
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: Component: child context type `prop` is invalid; ' +
+    'it must be a function, usually from React.PropTypes.'
+  );
+});
+
+it('should warn when mispelling shouldComponentUpdate', function() {
+  spyOn(console, 'error');
+
+  React.createClass({
+    componentShouldUpdate: function() {
+      return false;
+    },
+    render: function() {
+      return <div />;
+    },
+  });
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: A component has a method called componentShouldUpdate(). Did you ' +
+    'mean shouldComponentUpdate()? The name is phrased as a question ' +
+    'because the function is expected to return a value.'
+  );
+
+  React.createClass({
+    displayName: 'NamedComponent',
+    componentShouldUpdate: function() {
+      return false;
+    },
+    render: function() {
+      return <div />;
+    },
+  });
+  expect(console.error.calls.count()).toBe(2);
+  expect(console.error.calls.argsFor(1)[0]).toBe(
+    'Warning: NamedComponent has a method called componentShouldUpdate(). Did you ' +
+    'mean shouldComponentUpdate()? The name is phrased as a question ' +
+    'because the function is expected to return a value.'
+  );
+});
+
+it('should warn when mispelling componentWillReceiveProps', function() {
+  spyOn(console, 'error');
+  React.createClass({
+    componentWillRecieveProps: function() {
+      return false;
+    },
+    render: function() {
+      return <div />;
+    },
+  });
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: A component has a method called componentWillRecieveProps(). Did you ' +
+    'mean componentWillReceiveProps()?'
+  );
+});
+
+it('should throw if a reserved property is in statics', function() {
+  expect(function() {
     React.createClass({
-      displayName: 'Component',
-      propTypes: {
-        prop: null,
-      },
-      render: function() {
-        return <span>{this.props.prop}</span>;
-      },
-    });
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: Component: prop type `prop` is invalid; ' +
-      'it must be a function, usually from React.PropTypes.'
-    );
-  });
-
-  it('should warn on invalid context types', function() {
-    spyOn(console, 'error');
-    React.createClass({
-      displayName: 'Component',
-      contextTypes: {
-        prop: null,
-      },
-      render: function() {
-        return <span>{this.props.prop}</span>;
-      },
-    });
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: Component: context type `prop` is invalid; ' +
-      'it must be a function, usually from React.PropTypes.'
-    );
-  });
-
-  it('should throw on invalid child context types', function() {
-    spyOn(console, 'error');
-    React.createClass({
-      displayName: 'Component',
-      childContextTypes: {
-        prop: null,
-      },
-      render: function() {
-        return <span>{this.props.prop}</span>;
-      },
-    });
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: Component: child context type `prop` is invalid; ' +
-      'it must be a function, usually from React.PropTypes.'
-    );
-  });
-
-  it('should warn when mispelling shouldComponentUpdate', function() {
-    spyOn(console, 'error');
-
-    React.createClass({
-      componentShouldUpdate: function() {
-        return false;
-      },
-      render: function() {
-        return <div />;
-      },
-    });
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: A component has a method called componentShouldUpdate(). Did you ' +
-      'mean shouldComponentUpdate()? The name is phrased as a question ' +
-      'because the function is expected to return a value.'
-    );
-
-    React.createClass({
-      displayName: 'NamedComponent',
-      componentShouldUpdate: function() {
-        return false;
-      },
-      render: function() {
-        return <div />;
-      },
-    });
-    expect(console.error.calls.count()).toBe(2);
-    expect(console.error.calls.argsFor(1)[0]).toBe(
-      'Warning: NamedComponent has a method called componentShouldUpdate(). Did you ' +
-      'mean shouldComponentUpdate()? The name is phrased as a question ' +
-      'because the function is expected to return a value.'
-    );
-  });
-
-  it('should warn when mispelling componentWillReceiveProps', function() {
-    spyOn(console, 'error');
-    React.createClass({
-      componentWillRecieveProps: function() {
-        return false;
-      },
-      render: function() {
-        return <div />;
-      },
-    });
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: A component has a method called componentWillRecieveProps(). Did you ' +
-      'mean componentWillReceiveProps()?'
-    );
-  });
-
-  it('should throw if a reserved property is in statics', function() {
-    expect(function() {
-      React.createClass({
-        statics: {
-          getDefaultProps: function() {
-            return {
-              foo: 0,
-            };
-          },
-        },
-
-        render: function() {
-          return <span />;
-        },
-      });
-    }).toThrowError(
-      'ReactClass: You are attempting to define a reserved property, ' +
-      '`getDefaultProps`, that shouldn\'t be on the "statics" key. Define ' +
-      'it as an instance property instead; it will still be accessible on ' +
-      'the constructor.'
-    );
-  });
-
-  // TODO: Consider actually moving these to statics or drop this unit test.
-
-  xit('should warn when using deprecated non-static spec keys', function() {
-    spyOn(console, 'error');
-    React.createClass({
-      mixins: [{}],
-      propTypes: {
-        foo: React.PropTypes.string,
-      },
-      contextTypes: {
-        foo: React.PropTypes.string,
-      },
-      childContextTypes: {
-        foo: React.PropTypes.string,
-      },
-      render: function() {
-        return <div />;
-      },
-    });
-    expect(console.error.calls.count()).toBe(4);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'createClass(...): `mixins` is now a static property and should ' +
-      'be defined inside "statics".'
-    );
-    expect(console.error.calls.argsFor(1)[0]).toBe(
-      'createClass(...): `propTypes` is now a static property and should ' +
-      'be defined inside "statics".'
-    );
-    expect(console.error.calls.argsFor(2)[0]).toBe(
-      'createClass(...): `contextTypes` is now a static property and ' +
-      'should be defined inside "statics".'
-    );
-    expect(console.error.calls.argsFor(3)[0]).toBe(
-      'createClass(...): `childContextTypes` is now a static property and ' +
-      'should be defined inside "statics".'
-    );
-  });
-
-  it('should support statics', function() {
-    var Component = React.createClass({
       statics: {
-        abc: 'def',
-        def: 0,
-        ghi: null,
-        jkl: 'mno',
-        pqr: function() {
-          return this;
+        getDefaultProps: function() {
+          return {
+            foo: 0,
+          };
         },
       },
 
+      render: function() {
+        return <span />;
+      },
+    });
+  }).toThrowError(
+    'ReactClass: You are attempting to define a reserved property, ' +
+    '`getDefaultProps`, that shouldn\'t be on the "statics" key. Define ' +
+    'it as an instance property instead; it will still be accessible on ' +
+    'the constructor.'
+  );
+});
+
+// TODO: Consider actually moving these to statics or drop this unit test.
+
+xit('should warn when using deprecated non-static spec keys', function() {
+  spyOn(console, 'error');
+  React.createClass({
+    mixins: [{}],
+    propTypes: {
+      foo: React.PropTypes.string,
+    },
+    contextTypes: {
+      foo: React.PropTypes.string,
+    },
+    childContextTypes: {
+      foo: React.PropTypes.string,
+    },
+    render: function() {
+      return <div />;
+    },
+  });
+  expect(console.error.calls.count()).toBe(4);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'createClass(...): `mixins` is now a static property and should ' +
+    'be defined inside "statics".'
+  );
+  expect(console.error.calls.argsFor(1)[0]).toBe(
+    'createClass(...): `propTypes` is now a static property and should ' +
+    'be defined inside "statics".'
+  );
+  expect(console.error.calls.argsFor(2)[0]).toBe(
+    'createClass(...): `contextTypes` is now a static property and ' +
+    'should be defined inside "statics".'
+  );
+  expect(console.error.calls.argsFor(3)[0]).toBe(
+    'createClass(...): `childContextTypes` is now a static property and ' +
+    'should be defined inside "statics".'
+  );
+});
+
+it('should support statics', function() {
+  var Component = React.createClass({
+    statics: {
+      abc: 'def',
+      def: 0,
+      ghi: null,
+      jkl: 'mno',
+      pqr: function() {
+        return this;
+      },
+    },
+
+    render: function() {
+      return <span />;
+    },
+  });
+  var instance = <Component />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  expect(instance.constructor.abc).toBe('def');
+  expect(Component.abc).toBe('def');
+  expect(instance.constructor.def).toBe(0);
+  expect(Component.def).toBe(0);
+  expect(instance.constructor.ghi).toBe(null);
+  expect(Component.ghi).toBe(null);
+  expect(instance.constructor.jkl).toBe('mno');
+  expect(Component.jkl).toBe('mno');
+  expect(instance.constructor.pqr()).toBe(Component);
+  expect(Component.pqr()).toBe(Component);
+});
+
+it('should work with object getInitialState() return values', function() {
+  var Component = React.createClass({
+    getInitialState: function() {
+      return {
+        occupation: 'clown',
+      };
+    },
+    render: function() {
+      return <span />;
+    },
+  });
+  var instance = <Component />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  expect(instance.state.occupation).toEqual('clown');
+});
+
+it('renders based on context getInitialState', function() {
+  var Foo = React.createClass({
+    contextTypes: {
+      className: React.PropTypes.string,
+    },
+    getInitialState() {
+      return {className: this.context.className};
+    },
+    render() {
+      return <span className={this.state.className} />;
+    },
+  });
+
+  var Outer = React.createClass({
+    childContextTypes: {
+      className: React.PropTypes.string,
+    },
+    getChildContext() {
+      return {className: 'foo'};
+    },
+    render() {
+      return <Foo />;
+    },
+  });
+
+  var container = document.createElement('div');
+  ReactDOM.render(<Outer />, container);
+  expect(container.firstChild.className).toBe('foo');
+});
+
+it('should throw with non-object getInitialState() return values', function() {
+  [['an array'], 'a string', 1234].forEach(function(state) {
+    var Component = React.createClass({
+      getInitialState: function() {
+        return state;
+      },
       render: function() {
         return <span />;
       },
     });
     var instance = <Component />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-    expect(instance.constructor.abc).toBe('def');
-    expect(Component.abc).toBe('def');
-    expect(instance.constructor.def).toBe(0);
-    expect(Component.def).toBe(0);
-    expect(instance.constructor.ghi).toBe(null);
-    expect(Component.ghi).toBe(null);
-    expect(instance.constructor.jkl).toBe('mno');
-    expect(Component.jkl).toBe('mno');
-    expect(instance.constructor.pqr()).toBe(Component);
-    expect(Component.pqr()).toBe(Component);
-  });
-
-  it('should work with object getInitialState() return values', function() {
-    var Component = React.createClass({
-      getInitialState: function() {
-        return {
-          occupation: 'clown',
-        };
-      },
-      render: function() {
-        return <span />;
-      },
-    });
-    var instance = <Component />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-    expect(instance.state.occupation).toEqual('clown');
-  });
-
-  it('renders based on context getInitialState', function() {
-    var Foo = React.createClass({
-      contextTypes: {
-        className: React.PropTypes.string,
-      },
-      getInitialState() {
-        return {className: this.context.className};
-      },
-      render() {
-        return <span className={this.state.className} />;
-      },
-    });
-
-    var Outer = React.createClass({
-      childContextTypes: {
-        className: React.PropTypes.string,
-      },
-      getChildContext() {
-        return {className: 'foo'};
-      },
-      render() {
-        return <Foo />;
-      },
-    });
-
-    var container = document.createElement('div');
-    ReactDOM.render(<Outer />, container);
-    expect(container.firstChild.className).toBe('foo');
-  });
-
-  it('should throw with non-object getInitialState() return values', function() {
-    [['an array'], 'a string', 1234].forEach(function(state) {
-      var Component = React.createClass({
-        getInitialState: function() {
-          return state;
-        },
-        render: function() {
-          return <span />;
-        },
-      });
-      var instance = <Component />;
-      expect(function() {
-        instance = ReactTestUtils.renderIntoDocument(instance);
-      }).toThrowError(
-        'Component.getInitialState(): must return an object or null'
-      );
-    });
-  });
-
-  it('should work with a null getInitialState() return value', function() {
-    var Component = React.createClass({
-      getInitialState: function() {
-        return null;
-      },
-      render: function() {
-        return <span />;
-      },
-    });
-    expect(
-      () => ReactTestUtils.renderIntoDocument(<Component />)
-    ).not.toThrow();
-  });
-
-  it('should throw when using legacy factories', function() {
-    spyOn(console, 'error');
-    var Component = React.createClass({
-      render() {
-        return <div />;
-      },
-    });
-
-    expect(() => Component()).toThrow();
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: Something is calling a React component directly. Use a ' +
-      'factory or JSX instead. See: https://fb.me/react-legacyfactory'
+    expect(function() {
+      instance = ReactTestUtils.renderIntoDocument(instance);
+    }).toThrowError(
+      'Component.getInitialState(): must return an object or null'
     );
   });
+});
 
+it('should work with a null getInitialState() return value', function() {
+  var Component = React.createClass({
+    getInitialState: function() {
+      return null;
+    },
+    render: function() {
+      return <span />;
+    },
+  });
+  expect(
+    () => ReactTestUtils.renderIntoDocument(<Component />)
+  ).not.toThrow();
+});
+
+it('should throw when using legacy factories', function() {
+  spyOn(console, 'error');
+  var Component = React.createClass({
+    render() {
+      return <div />;
+    },
+  });
+
+  expect(() => Component()).toThrow();
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: Something is calling a React component directly. Use a ' +
+    'factory or JSX instead. See: https://fb.me/react-legacyfactory'
+  );
 });

--- a/src/isomorphic/classic/class/__tests__/ReactClassMixin-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactClassMixin-test.js
@@ -20,526 +20,522 @@ var TestComponentWithReverseSpec;
 var mixinPropValidator;
 var componentPropValidator;
 
-describe('ReactClass-mixin', function() {
+beforeEach(function() {
+  React = require('React');
+  ReactTestUtils = require('ReactTestUtils');
+  mixinPropValidator = jest.fn();
+  componentPropValidator = jest.fn();
 
-  beforeEach(function() {
-    React = require('React');
-    ReactTestUtils = require('ReactTestUtils');
-    mixinPropValidator = jest.fn();
-    componentPropValidator = jest.fn();
+  var MixinA = {
+    propTypes: {
+      propA: function() {},
+    },
+    componentDidMount: function() {
+      this.props.listener('MixinA didMount');
+    },
+  };
 
-    var MixinA = {
-      propTypes: {
-        propA: function() {},
-      },
-      componentDidMount: function() {
-        this.props.listener('MixinA didMount');
-      },
-    };
+  var MixinB = {
+    mixins: [MixinA],
+    propTypes: {
+      propB: function() {},
+    },
+    componentDidMount: function() {
+      this.props.listener('MixinB didMount');
+    },
+  };
 
-    var MixinB = {
-      mixins: [MixinA],
-      propTypes: {
-        propB: function() {},
-      },
-      componentDidMount: function() {
-        this.props.listener('MixinB didMount');
-      },
-    };
+  var MixinBWithReverseSpec = {
+    componentDidMount: function() {
+      this.props.listener('MixinBWithReverseSpec didMount');
+    },
+    mixins: [MixinA],
+  };
 
-    var MixinBWithReverseSpec = {
-      componentDidMount: function() {
-        this.props.listener('MixinBWithReverseSpec didMount');
-      },
-      mixins: [MixinA],
-    };
+  var MixinC = {
+    statics: {
+      staticC: function() {},
+    },
+    componentDidMount: function() {
+      this.props.listener('MixinC didMount');
+    },
+  };
 
-    var MixinC = {
-      statics: {
-        staticC: function() {},
-      },
-      componentDidMount: function() {
-        this.props.listener('MixinC didMount');
-      },
-    };
+  var MixinD = {
+    propTypes: {
+      value: mixinPropValidator,
+    },
+  };
 
-    var MixinD = {
-      propTypes: {
-        value: mixinPropValidator,
-      },
-    };
-
-    TestComponent = React.createClass({
-      mixins: [MixinB, MixinC, MixinD],
-      statics: {
-        staticComponent: function() {},
-      },
-      propTypes: {
-        propComponent: function() {},
-      },
-      componentDidMount: function() {
-        this.props.listener('Component didMount');
-      },
-      render: function() {
-        return <div />;
-      },
-    });
-
-    TestComponentWithReverseSpec = React.createClass({
-      render: function() {
-        return <div />;
-      },
-      componentDidMount: function() {
-        this.props.listener('Component didMount');
-      },
-      mixins: [MixinBWithReverseSpec, MixinC, MixinD],
-    });
-
-    TestComponentWithPropTypes = React.createClass({
-      mixins: [MixinD],
-      propTypes: {
-        value: componentPropValidator,
-      },
-      render: function() {
-        return <div />;
-      },
-    });
+  TestComponent = React.createClass({
+    mixins: [MixinB, MixinC, MixinD],
+    statics: {
+      staticComponent: function() {},
+    },
+    propTypes: {
+      propComponent: function() {},
+    },
+    componentDidMount: function() {
+      this.props.listener('Component didMount');
+    },
+    render: function() {
+      return <div />;
+    },
   });
 
-  it('should support merging propTypes and statics', function() {
-    var listener = jest.fn();
-    var instance = <TestComponent listener={listener} />;
+  TestComponentWithReverseSpec = React.createClass({
+    render: function() {
+      return <div />;
+    },
+    componentDidMount: function() {
+      this.props.listener('Component didMount');
+    },
+    mixins: [MixinBWithReverseSpec, MixinC, MixinD],
+  });
+
+  TestComponentWithPropTypes = React.createClass({
+    mixins: [MixinD],
+    propTypes: {
+      value: componentPropValidator,
+    },
+    render: function() {
+      return <div />;
+    },
+  });
+});
+
+it('should support merging propTypes and statics', function() {
+  var listener = jest.fn();
+  var instance = <TestComponent listener={listener} />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+
+  var instancePropTypes = instance.constructor.propTypes;
+
+  expect('propA' in instancePropTypes).toBe(true);
+  expect('propB' in instancePropTypes).toBe(true);
+  expect('propComponent' in instancePropTypes).toBe(true);
+
+  expect('staticC' in TestComponent).toBe(true);
+  expect('staticComponent' in TestComponent).toBe(true);
+});
+
+it('should support chaining delegate functions', function() {
+  var listener = jest.fn();
+  var instance = <TestComponent listener={listener} />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+
+  expect(listener.mock.calls).toEqual([
+    ['MixinA didMount'],
+    ['MixinB didMount'],
+    ['MixinC didMount'],
+    ['Component didMount'],
+  ]);
+});
+
+it('should chain functions regardless of spec property order', function() {
+  var listener = jest.fn();
+  var instance = <TestComponentWithReverseSpec listener={listener} />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+
+  expect(listener.mock.calls).toEqual([
+    ['MixinA didMount'],
+    ['MixinBWithReverseSpec didMount'],
+    ['MixinC didMount'],
+    ['Component didMount'],
+  ]);
+});
+
+it('should validate prop types via mixins', function() {
+  expect(TestComponent.propTypes).toBeDefined();
+  expect(TestComponent.propTypes.value)
+    .toBe(mixinPropValidator);
+});
+
+it('should override mixin prop types with class prop types', function() {
+  // Sanity check...
+  expect(componentPropValidator).not.toBe(mixinPropValidator);
+  // Actually check...
+  expect(TestComponentWithPropTypes.propTypes)
+    .toBeDefined();
+  expect(TestComponentWithPropTypes.propTypes.value)
+    .not.toBe(mixinPropValidator);
+  expect(TestComponentWithPropTypes.propTypes.value)
+    .toBe(componentPropValidator);
+});
+
+
+it('should support mixins with getInitialState()', function() {
+  var Mixin = {
+    getInitialState: function() {
+      return {mixin: true};
+    },
+  };
+  var Component = React.createClass({
+    mixins: [Mixin],
+    getInitialState: function() {
+      return {component: true};
+    },
+    render: function() {
+      return <span />;
+    },
+  });
+  var instance = <Component />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  expect(instance.state.component).toBe(true);
+  expect(instance.state.mixin).toBe(true);
+});
+
+it('should throw with conflicting getInitialState() methods', function() {
+  var Mixin = {
+    getInitialState: function() {
+      return {x: true};
+    },
+  };
+  var Component = React.createClass({
+    mixins: [Mixin],
+    getInitialState: function() {
+      return {x: true};
+    },
+    render: function() {
+      return <span />;
+    },
+  });
+  var instance = <Component />;
+  expect(function() {
     instance = ReactTestUtils.renderIntoDocument(instance);
+  }).toThrowError(
+    'mergeIntoWithNoDuplicateKeys(): Tried to merge two objects with the ' +
+    'same key: `x`. This conflict may be due to a mixin; in particular, ' +
+    'this may be caused by two getInitialState() or getDefaultProps() ' +
+    'methods returning objects with clashing keys.'
+  );
+});
 
-    var instancePropTypes = instance.constructor.propTypes;
-
-    expect('propA' in instancePropTypes).toBe(true);
-    expect('propB' in instancePropTypes).toBe(true);
-    expect('propComponent' in instancePropTypes).toBe(true);
-
-    expect('staticC' in TestComponent).toBe(true);
-    expect('staticComponent' in TestComponent).toBe(true);
+it('should not mutate objects returned by getInitialState()', function() {
+  var Mixin = {
+    getInitialState: function() {
+      return Object.freeze({mixin: true});
+    },
+  };
+  var Component = React.createClass({
+    mixins: [Mixin],
+    getInitialState: function() {
+      return Object.freeze({component: true});
+    },
+    render: function() {
+      return <span />;
+    },
   });
+  expect(() => {
+    ReactTestUtils.renderIntoDocument(<Component />);
+  }).not.toThrow();
+});
 
-  it('should support chaining delegate functions', function() {
-    var listener = jest.fn();
-    var instance = <TestComponent listener={listener} />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
+it('should support statics in mixins', function() {
+  var Mixin = {
+    statics: {
+      foo: 'bar',
+    },
+  };
+  var Component = React.createClass({
+    mixins: [Mixin],
 
-    expect(listener.mock.calls).toEqual([
-      ['MixinA didMount'],
-      ['MixinB didMount'],
-      ['MixinC didMount'],
-      ['Component didMount'],
-    ]);
+    statics: {
+      abc: 'def',
+    },
+
+    render: function() {
+      return <span />;
+    },
   });
+  var instance = <Component />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  expect(instance.constructor.foo).toBe('bar');
+  expect(Component.foo).toBe('bar');
+  expect(instance.constructor.abc).toBe('def');
+  expect(Component.abc).toBe('def');
+});
 
-  it('should chain functions regardless of spec property order', function() {
-    var listener = jest.fn();
-    var instance = <TestComponentWithReverseSpec listener={listener} />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-
-    expect(listener.mock.calls).toEqual([
-      ['MixinA didMount'],
-      ['MixinBWithReverseSpec didMount'],
-      ['MixinC didMount'],
-      ['Component didMount'],
-    ]);
-  });
-
-  it('should validate prop types via mixins', function() {
-    expect(TestComponent.propTypes).toBeDefined();
-    expect(TestComponent.propTypes.value)
-      .toBe(mixinPropValidator);
-  });
-
-  it('should override mixin prop types with class prop types', function() {
-    // Sanity check...
-    expect(componentPropValidator).not.toBe(mixinPropValidator);
-    // Actually check...
-    expect(TestComponentWithPropTypes.propTypes)
-      .toBeDefined();
-    expect(TestComponentWithPropTypes.propTypes.value)
-      .not.toBe(mixinPropValidator);
-    expect(TestComponentWithPropTypes.propTypes.value)
-      .toBe(componentPropValidator);
-  });
-
-
-  it('should support mixins with getInitialState()', function() {
+it("should throw if mixins override each others' statics", function() {
+  expect(function() {
     var Mixin = {
-      getInitialState: function() {
-        return {mixin: true};
+      statics: {
+        abc: 'foo',
       },
     };
-    var Component = React.createClass({
+    React.createClass({
       mixins: [Mixin],
-      getInitialState: function() {
-        return {component: true};
+
+      statics: {
+        abc: 'bar',
       },
+
       render: function() {
         return <span />;
       },
     });
-    var instance = <Component />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-    expect(instance.state.component).toBe(true);
-    expect(instance.state.mixin).toBe(true);
-  });
+  }).toThrowError(
+    'ReactClass: You are attempting to define `abc` on your component more ' +
+    'than once. This conflict may be due to a mixin.'
+  );
+});
 
-  it('should throw with conflicting getInitialState() methods', function() {
-    var Mixin = {
-      getInitialState: function() {
-        return {x: true};
-      },
-    };
-    var Component = React.createClass({
-      mixins: [Mixin],
-      getInitialState: function() {
-        return {x: true};
-      },
-      render: function() {
-        return <span />;
-      },
-    });
-    var instance = <Component />;
-    expect(function() {
-      instance = ReactTestUtils.renderIntoDocument(instance);
-    }).toThrowError(
-      'mergeIntoWithNoDuplicateKeys(): Tried to merge two objects with the ' +
-      'same key: `x`. This conflict may be due to a mixin; in particular, ' +
-      'this may be caused by two getInitialState() or getDefaultProps() ' +
-      'methods returning objects with clashing keys.'
-    );
-  });
-
-  it('should not mutate objects returned by getInitialState()', function() {
-    var Mixin = {
-      getInitialState: function() {
-        return Object.freeze({mixin: true});
-      },
-    };
-    var Component = React.createClass({
-      mixins: [Mixin],
-      getInitialState: function() {
-        return Object.freeze({component: true});
-      },
-      render: function() {
-        return <span />;
-      },
-    });
-    expect(() => {
-      ReactTestUtils.renderIntoDocument(<Component />);
-    }).not.toThrow();
-  });
-
-  it('should support statics in mixins', function() {
+it('should throw if mixins override functions in statics', function() {
+  expect(function() {
     var Mixin = {
       statics: {
-        foo: 'bar',
+        abc: function() {
+          console.log('foo');
+        },
       },
     };
-    var Component = React.createClass({
+    React.createClass({
       mixins: [Mixin],
 
       statics: {
-        abc: 'def',
+        abc: function() {
+          console.log('bar');
+        },
       },
 
       render: function() {
         return <span />;
       },
     });
-    var instance = <Component />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-    expect(instance.constructor.foo).toBe('bar');
-    expect(Component.foo).toBe('bar');
-    expect(instance.constructor.abc).toBe('def');
-    expect(Component.abc).toBe('def');
+  }).toThrowError(
+    'ReactClass: You are attempting to define `abc` on your component ' +
+    'more than once. This conflict may be due to a mixin.'
+  );
+});
+
+it('should warn if the mixin is undefined', function() {
+  spyOn(console, 'error');
+
+  React.createClass({
+    mixins: [undefined],
+
+    render: function() {
+      return <span />;
+    },
   });
 
-  it("should throw if mixins override each others' statics", function() {
-    expect(function() {
-      var Mixin = {
-        statics: {
-          abc: 'foo',
-        },
-      };
-      React.createClass({
-        mixins: [Mixin],
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: ReactClass: You\'re attempting to include a mixin that is ' +
+    'either null or not an object. Check the mixins included by the ' +
+    'component, as well as any mixins they include themselves. ' +
+    'Expected object but got undefined.'
+  );
+});
 
-        statics: {
-          abc: 'bar',
-        },
+it('should warn if the mixin is null', function() {
+  spyOn(console, 'error');
 
-        render: function() {
-          return <span />;
-        },
-      });
-    }).toThrowError(
-      'ReactClass: You are attempting to define `abc` on your component more ' +
-      'than once. This conflict may be due to a mixin.'
-    );
+  React.createClass({
+    mixins: [null],
+
+    render: function() {
+      return <span />;
+    },
   });
 
-  it('should throw if mixins override functions in statics', function() {
-    expect(function() {
-      var Mixin = {
-        statics: {
-          abc: function() {
-            console.log('foo');
-          },
-        },
-      };
-      React.createClass({
-        mixins: [Mixin],
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: ReactClass: You\'re attempting to include a mixin that is ' +
+    'either null or not an object. Check the mixins included by the ' +
+    'component, as well as any mixins they include themselves. ' +
+    'Expected object but got null.'
+  );
+});
 
-        statics: {
-          abc: function() {
-            console.log('bar');
-          },
-        },
+it('should warn if an undefined mixin is included in another mixin', function() {
+  spyOn(console, 'error');
 
-        render: function() {
-          return <span />;
-        },
-      });
-    }).toThrowError(
-      'ReactClass: You are attempting to define `abc` on your component ' +
-      'more than once. This conflict may be due to a mixin.'
-    );
+  var mixinA = {
+    mixins: [undefined],
+  };
+
+  React.createClass({
+    mixins: [mixinA],
+
+    render: function() {
+      return <span />;
+    },
   });
 
-  it('should warn if the mixin is undefined', function() {
-    spyOn(console, 'error');
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: ReactClass: You\'re attempting to include a mixin that is ' +
+    'either null or not an object. Check the mixins included by the ' +
+    'component, as well as any mixins they include themselves. ' +
+    'Expected object but got undefined.'
+  );
+});
+
+it('should warn if a null mixin is included in another mixin', function() {
+  spyOn(console, 'error');
+
+  var mixinA = {
+    mixins: [null],
+  };
+
+  React.createClass({
+    mixins: [mixinA],
+
+    render: function() {
+      return <span />;
+    },
+  });
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: ReactClass: You\'re attempting to include a mixin that is ' +
+    'either null or not an object. Check the mixins included by the ' +
+    'component, as well as any mixins they include themselves. ' +
+    'Expected object but got null.'
+  );
+});
+
+it('should throw if the mixin is a React component', function() {
+  expect(function() {
+    React.createClass({
+      mixins: [<div />],
+
+      render: function() {
+        return <span />;
+      },
+    });
+  }).toThrowError(
+    'ReactClass: You\'re attempting to use a component as a mixin. ' +
+    'Instead, just use a regular object.'
+  );
+});
+
+it('should throw if the mixin is a React component class', function() {
+  expect(function() {
+    var Component = React.createClass({
+      render: function() {
+        return <span />;
+      },
+    });
 
     React.createClass({
-      mixins: [undefined],
+      mixins: [Component],
 
       render: function() {
         return <span />;
       },
     });
+  }).toThrowError(
+    'ReactClass: You\'re attempting to use a component class or function ' +
+    'as a mixin. Instead, just use a regular object.'
+  );
+});
 
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: ReactClass: You\'re attempting to include a mixin that is ' +
-      'either null or not an object. Check the mixins included by the ' +
-      'component, as well as any mixins they include themselves. ' +
-      'Expected object but got undefined.'
-    );
+it('should have bound the mixin methods to the component', function() {
+  var mixin = {
+    mixinFunc: function() {
+      return this;
+    },
+  };
+
+  var Component = React.createClass({
+    mixins: [mixin],
+    componentDidMount: function() {
+      expect(this.mixinFunc()).toBe(this);
+    },
+    render: function() {
+      return <span />;
+    },
   });
+  var instance = <Component />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+});
 
-  it('should warn if the mixin is null', function() {
-    spyOn(console, 'error');
+it('should include the mixin keys in even if their values are falsy', function() {
+  var mixin = {
+    keyWithNullValue: null,
+    randomCounter: 0,
+  };
 
-    React.createClass({
-      mixins: [null],
-
-      render: function() {
-        return <span />;
-      },
-    });
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: ReactClass: You\'re attempting to include a mixin that is ' +
-      'either null or not an object. Check the mixins included by the ' +
-      'component, as well as any mixins they include themselves. ' +
-      'Expected object but got null.'
-    );
+  var Component = React.createClass({
+    mixins: [mixin],
+    componentDidMount: function() {
+      expect(this.randomCounter).toBe(0);
+      expect(this.keyWithNullValue).toBeNull();
+    },
+    render: function() {
+      return <span />;
+    },
   });
+  var instance = <Component />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+});
 
-  it('should warn if an undefined mixin is included in another mixin', function() {
-    spyOn(console, 'error');
+it('should work with a null getInitialState return value and a mixin', () => {
+  var Component;
+  var instance;
 
-    var mixinA = {
-      mixins: [undefined],
-    };
-
-    React.createClass({
-      mixins: [mixinA],
-
-      render: function() {
-        return <span />;
-      },
-    });
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: ReactClass: You\'re attempting to include a mixin that is ' +
-      'either null or not an object. Check the mixins included by the ' +
-      'component, as well as any mixins they include themselves. ' +
-      'Expected object but got undefined.'
-    );
+  var Mixin = {
+    getInitialState: function() {
+      return {foo: 'bar'};
+    },
+  };
+  Component = React.createClass({
+    mixins: [Mixin],
+    getInitialState: function() {
+      return null;
+    },
+    render: function() {
+      return <span />;
+    },
   });
+  expect(
+    () => ReactTestUtils.renderIntoDocument(<Component />)
+  ).not.toThrow();
 
-  it('should warn if a null mixin is included in another mixin', function() {
-    spyOn(console, 'error');
+  instance = <Component />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  expect(instance.state).toEqual({foo: 'bar'});
 
-    var mixinA = {
-      mixins: [null],
-    };
-
-    React.createClass({
-      mixins: [mixinA],
-
-      render: function() {
-        return <span />;
-      },
-    });
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: ReactClass: You\'re attempting to include a mixin that is ' +
-      'either null or not an object. Check the mixins included by the ' +
-      'component, as well as any mixins they include themselves. ' +
-      'Expected object but got null.'
-    );
+  // Also the other way round should work
+  var Mixin2 = {
+    getInitialState: function() {
+      return null;
+    },
+  };
+  Component = React.createClass({
+    mixins: [Mixin2],
+    getInitialState: function() {
+      return {foo: 'bar'};
+    },
+    render: function() {
+      return <span />;
+    },
   });
+  expect(
+    () => ReactTestUtils.renderIntoDocument(<Component />)
+  ).not.toThrow();
 
-  it('should throw if the mixin is a React component', function() {
-    expect(function() {
-      React.createClass({
-        mixins: [<div />],
+  instance = <Component />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  expect(instance.state).toEqual({foo: 'bar'});
 
-        render: function() {
-          return <span />;
-        },
-      });
-    }).toThrowError(
-      'ReactClass: You\'re attempting to use a component as a mixin. ' +
-      'Instead, just use a regular object.'
-    );
+  // Multiple mixins should be fine too
+  Component = React.createClass({
+    mixins: [Mixin, Mixin2],
+    getInitialState: function() {
+      return {x: true};
+    },
+    render: function() {
+      return <span />;
+    },
   });
+  expect(
+    () => ReactTestUtils.renderIntoDocument(<Component />)
+  ).not.toThrow();
 
-  it('should throw if the mixin is a React component class', function() {
-    expect(function() {
-      var Component = React.createClass({
-        render: function() {
-          return <span />;
-        },
-      });
-
-      React.createClass({
-        mixins: [Component],
-
-        render: function() {
-          return <span />;
-        },
-      });
-    }).toThrowError(
-      'ReactClass: You\'re attempting to use a component class or function ' +
-      'as a mixin. Instead, just use a regular object.'
-    );
-  });
-
-  it('should have bound the mixin methods to the component', function() {
-    var mixin = {
-      mixinFunc: function() {
-        return this;
-      },
-    };
-
-    var Component = React.createClass({
-      mixins: [mixin],
-      componentDidMount: function() {
-        expect(this.mixinFunc()).toBe(this);
-      },
-      render: function() {
-        return <span />;
-      },
-    });
-    var instance = <Component />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-  });
-
-  it('should include the mixin keys in even if their values are falsy', function() {
-    var mixin = {
-      keyWithNullValue: null,
-      randomCounter: 0,
-    };
-
-    var Component = React.createClass({
-      mixins: [mixin],
-      componentDidMount: function() {
-        expect(this.randomCounter).toBe(0);
-        expect(this.keyWithNullValue).toBeNull();
-      },
-      render: function() {
-        return <span />;
-      },
-    });
-    var instance = <Component />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-  });
-
-  it('should work with a null getInitialState return value and a mixin', () => {
-    var Component;
-    var instance;
-
-    var Mixin = {
-      getInitialState: function() {
-        return {foo: 'bar'};
-      },
-    };
-    Component = React.createClass({
-      mixins: [Mixin],
-      getInitialState: function() {
-        return null;
-      },
-      render: function() {
-        return <span />;
-      },
-    });
-    expect(
-      () => ReactTestUtils.renderIntoDocument(<Component />)
-    ).not.toThrow();
-
-    instance = <Component />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-    expect(instance.state).toEqual({foo: 'bar'});
-
-    // Also the other way round should work
-    var Mixin2 = {
-      getInitialState: function() {
-        return null;
-      },
-    };
-    Component = React.createClass({
-      mixins: [Mixin2],
-      getInitialState: function() {
-        return {foo: 'bar'};
-      },
-      render: function() {
-        return <span />;
-      },
-    });
-    expect(
-      () => ReactTestUtils.renderIntoDocument(<Component />)
-    ).not.toThrow();
-
-    instance = <Component />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-    expect(instance.state).toEqual({foo: 'bar'});
-
-    // Multiple mixins should be fine too
-    Component = React.createClass({
-      mixins: [Mixin, Mixin2],
-      getInitialState: function() {
-        return {x: true};
-      },
-      render: function() {
-        return <span />;
-      },
-    });
-    expect(
-      () => ReactTestUtils.renderIntoDocument(<Component />)
-    ).not.toThrow();
-
-    instance = <Component />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-    expect(instance.state).toEqual({foo: 'bar', x: true});
-  });
-
+  instance = <Component />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  expect(instance.state).toEqual({foo: 'bar', x: true});
 });

--- a/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
@@ -15,363 +15,360 @@ var React;
 var ReactDOM;
 var ReactTestUtils;
 
-describe('ReactElementClone', function() {
-  var ComponentClass;
+var ComponentClass;
 
-  beforeEach(function() {
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactTestUtils = require('ReactTestUtils');
+beforeEach(function() {
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactTestUtils = require('ReactTestUtils');
 
-    // NOTE: We're explicitly not using JSX here. This is intended to test
-    // classic JS without JSX.
-    ComponentClass = React.createClass({
-      render: function() {
-        return React.createElement('div');
-      },
-    });
+  // NOTE: We're explicitly not using JSX here. This is intended to test
+  // classic JS without JSX.
+  ComponentClass = React.createClass({
+    render: function() {
+      return React.createElement('div');
+    },
+  });
+});
+
+it('should clone a DOM component with new props', function() {
+  var Grandparent = React.createClass({
+    render: function() {
+      return <Parent child={<div className="child" />} />;
+    },
+  });
+  var Parent = React.createClass({
+    render: function() {
+      return (
+        <div className="parent">
+          {React.cloneElement(this.props.child, { className: 'xyz' })}
+        </div>
+      );
+    },
+  });
+  var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
+  expect(ReactDOM.findDOMNode(component).childNodes[0].className).toBe('xyz');
+});
+
+it('should clone a composite component with new props', function() {
+  var Child = React.createClass({
+    render: function() {
+      return <div className={this.props.className} />;
+    },
+  });
+  var Grandparent = React.createClass({
+    render: function() {
+      return <Parent child={<Child className="child" />} />;
+    },
+  });
+  var Parent = React.createClass({
+    render: function() {
+      return (
+        <div className="parent">
+          {React.cloneElement(this.props.child, { className: 'xyz' })}
+        </div>
+      );
+    },
+  });
+  var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
+  expect(ReactDOM.findDOMNode(component).childNodes[0].className).toBe('xyz');
+});
+
+it('should warn if the config object inherits from any type other than Object', function() {
+  spyOn(console, 'error');
+  React.cloneElement('div', {foo: 1});
+  expect(console.error).not.toHaveBeenCalled();
+  React.cloneElement('div', Object.create({foo: 1}));
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'React.cloneElement(...): Expected props argument to be a plain object. ' +
+    'Properties defined in its prototype chain will be ignored.'
+  );
+});
+
+it('does not fail if config has no prototype', function() {
+  var config = Object.create(null, {foo: {value: 1, enumerable: true}});
+  React.cloneElement(<div />, config);
+});
+
+it('should keep the original ref if it is not overridden', function() {
+  var Grandparent = React.createClass({
+    render: function() {
+      return <Parent child={<div ref="yolo" />} />;
+    },
   });
 
-  it('should clone a DOM component with new props', function() {
-    var Grandparent = React.createClass({
-      render: function() {
-        return <Parent child={<div className="child" />} />;
-      },
-    });
-    var Parent = React.createClass({
-      render: function() {
-        return (
-          <div className="parent">
-            {React.cloneElement(this.props.child, { className: 'xyz' })}
-          </div>
-        );
-      },
-    });
-    var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
-    expect(ReactDOM.findDOMNode(component).childNodes[0].className).toBe('xyz');
+  var Parent = React.createClass({
+    render: function() {
+      return (
+        <div>
+          {React.cloneElement(this.props.child, { className: 'xyz' })}
+        </div>
+      );
+    },
   });
 
-  it('should clone a composite component with new props', function() {
-    var Child = React.createClass({
-      render: function() {
-        return <div className={this.props.className} />;
-      },
-    });
-    var Grandparent = React.createClass({
-      render: function() {
-        return <Parent child={<Child className="child" />} />;
-      },
-    });
-    var Parent = React.createClass({
-      render: function() {
-        return (
-          <div className="parent">
-            {React.cloneElement(this.props.child, { className: 'xyz' })}
-          </div>
-        );
-      },
-    });
-    var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
-    expect(ReactDOM.findDOMNode(component).childNodes[0].className).toBe('xyz');
+  var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
+  expect(component.refs.yolo.tagName).toBe('DIV');
+});
+
+it('should transfer the key property', function() {
+  var Component = React.createClass({
+    render: function() {
+      return null;
+    },
+  });
+  var clone = React.cloneElement(<Component />, {key: 'xyz'});
+  expect(clone.key).toBe('xyz');
+});
+
+it('should transfer children', function() {
+  var Component = React.createClass({
+    render: function() {
+      expect(this.props.children).toBe('xyz');
+      return <div />;
+    },
   });
 
-  it('should warn if the config object inherits from any type other than Object', function() {
-    spyOn(console, 'error');
-    React.cloneElement('div', {foo: 1});
-    expect(console.error).not.toHaveBeenCalled();
-    React.cloneElement('div', Object.create({foo: 1}));
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'React.cloneElement(...): Expected props argument to be a plain object. ' +
-      'Properties defined in its prototype chain will be ignored.'
-    );
+  ReactTestUtils.renderIntoDocument(
+    React.cloneElement(<Component />, {children: 'xyz'})
+  );
+});
+
+it('should shallow clone children', function() {
+  var Component = React.createClass({
+    render: function() {
+      expect(this.props.children).toBe('xyz');
+      return <div />;
+    },
   });
 
-  it('does not fail if config has no prototype', function() {
-    var config = Object.create(null, {foo: {value: 1, enumerable: true}});
-    React.cloneElement(<div />, config);
+  ReactTestUtils.renderIntoDocument(
+    React.cloneElement(<Component>xyz</Component>, {})
+  );
+});
+
+it('should accept children as rest arguments', function() {
+  var Component = React.createClass({
+    render: function() {
+      return null;
+    },
   });
 
-  it('should keep the original ref if it is not overridden', function() {
-    var Grandparent = React.createClass({
-      render: function() {
-        return <Parent child={<div ref="yolo" />} />;
-      },
-    });
+  var clone = React.cloneElement(
+    <Component>xyz</Component>,
+    { children: <Component /> },
+    <div />,
+    <span />
+  );
 
-    var Parent = React.createClass({
-      render: function() {
-        return (
-          <div>
-            {React.cloneElement(this.props.child, { className: 'xyz' })}
-          </div>
-        );
-      },
-    });
+  expect(clone.props.children).toEqual([
+    <div />,
+    <span />,
+  ]);
+});
 
-    var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
-    expect(component.refs.yolo.tagName).toBe('DIV');
+it('should override children if undefined is provided as an argument', function() {
+  var element = React.createElement(ComponentClass, {
+    children: 'text',
+  }, undefined);
+  expect(element.props.children).toBe(undefined);
+
+  var element2 = React.cloneElement(React.createElement(ComponentClass, {
+    children: 'text',
+  }), {}, undefined);
+  expect(element2.props.children).toBe(undefined);
+});
+
+it('should support keys and refs', function() {
+  var Parent = React.createClass({
+    render: function() {
+      var clone =
+        React.cloneElement(this.props.children, {key: 'xyz', ref: 'xyz'});
+      expect(clone.key).toBe('xyz');
+      expect(clone.ref).toBe('xyz');
+      return <div>{clone}</div>;
+    },
   });
 
-  it('should transfer the key property', function() {
-    var Component = React.createClass({
-      render: function() {
-        return null;
-      },
-    });
-    var clone = React.cloneElement(<Component />, {key: 'xyz'});
-    expect(clone.key).toBe('xyz');
+  var Grandparent = React.createClass({
+    render: function() {
+      return <Parent ref="parent"><span key="abc" /></Parent>;
+    },
   });
 
-  it('should transfer children', function() {
-    var Component = React.createClass({
-      render: function() {
-        expect(this.props.children).toBe('xyz');
-        return <div />;
-      },
-    });
+  var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
+  expect(component.refs.parent.refs.xyz.tagName).toBe('SPAN');
+});
 
-    ReactTestUtils.renderIntoDocument(
-      React.cloneElement(<Component />, {children: 'xyz'})
-    );
+it('should steal the ref if a new ref is specified', function() {
+  var Parent = React.createClass({
+    render: function() {
+      var clone = React.cloneElement(this.props.children, {ref: 'xyz'});
+      return <div>{clone}</div>;
+    },
   });
 
-  it('should shallow clone children', function() {
-    var Component = React.createClass({
-      render: function() {
-        expect(this.props.children).toBe('xyz');
-        return <div />;
-      },
-    });
-
-    ReactTestUtils.renderIntoDocument(
-      React.cloneElement(<Component>xyz</Component>, {})
-    );
+  var Grandparent = React.createClass({
+    render: function() {
+      return <Parent ref="parent"><span ref="child" /></Parent>;
+    },
   });
 
-  it('should accept children as rest arguments', function() {
-    var Component = React.createClass({
-      render: function() {
-        return null;
-      },
-    });
+  var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
+  expect(component.refs.child).toBeUndefined();
+  expect(component.refs.parent.refs.xyz.tagName).toBe('SPAN');
+});
 
-    var clone = React.cloneElement(
-      <Component>xyz</Component>,
-      { children: <Component /> },
-      <div />,
-      <span />
-    );
-
-    expect(clone.props.children).toEqual([
-      <div />,
-      <span />,
-    ]);
+it('should overwrite props', function() {
+  var Component = React.createClass({
+    render: function() {
+      expect(this.props.myprop).toBe('xyz');
+      return <div />;
+    },
   });
 
-  it('should override children if undefined is provided as an argument', function() {
-    var element = React.createElement(ComponentClass, {
-      children: 'text',
-    }, undefined);
-    expect(element.props.children).toBe(undefined);
+  ReactTestUtils.renderIntoDocument(
+    React.cloneElement(<Component myprop="abc" />, {myprop: 'xyz'})
+  );
+});
 
-    var element2 = React.cloneElement(React.createElement(ComponentClass, {
-      children: 'text',
-    }), {}, undefined);
-    expect(element2.props.children).toBe(undefined);
+it('should normalize props with default values', function() {
+  var Component = React.createClass({
+    getDefaultProps: function() {
+      return {prop: 'testKey'};
+    },
+    render: function() {
+      return <span />;
+    },
   });
 
-  it('should support keys and refs', function() {
-    var Parent = React.createClass({
-      render: function() {
-        var clone =
-          React.cloneElement(this.props.children, {key: 'xyz', ref: 'xyz'});
-        expect(clone.key).toBe('xyz');
-        expect(clone.ref).toBe('xyz');
-        return <div>{clone}</div>;
-      },
-    });
+  var instance = React.createElement(Component);
+  var clonedInstance = React.cloneElement(instance, {prop: undefined});
+  expect(clonedInstance.props.prop).toBe('testKey');
+  var clonedInstance2 = React.cloneElement(instance, {prop: null});
+  expect(clonedInstance2.props.prop).toBe(null);
 
-    var Grandparent = React.createClass({
-      render: function() {
-        return <Parent ref="parent"><span key="abc" /></Parent>;
-      },
-    });
+  var instance2 = React.createElement(Component, {prop: 'newTestKey'});
+  var cloneInstance3 = React.cloneElement(instance2, {prop: undefined});
+  expect(cloneInstance3.props.prop).toBe('testKey');
+  var cloneInstance4 = React.cloneElement(instance2, {});
+  expect(cloneInstance4.props.prop).toBe('newTestKey');
+});
 
-    var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
-    expect(component.refs.parent.refs.xyz.tagName).toBe('SPAN');
+it('warns for keys for arrays of elements in rest args', function() {
+  spyOn(console, 'error');
+
+  React.cloneElement(<div />, null, [<div />, <div />]);
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'Each child in an array or iterator should have a unique "key" prop.'
+  );
+});
+
+it('does not warns for arrays of elements with keys', function() {
+  spyOn(console, 'error');
+
+  React.cloneElement(<div />, null, [<div key="#1" />, <div key="#2" />]);
+
+  expect(console.error.calls.count()).toBe(0);
+});
+
+it('does not warn when the element is directly in rest args', function() {
+  spyOn(console, 'error');
+
+  React.cloneElement(<div />, null, <div />, <div />);
+
+  expect(console.error.calls.count()).toBe(0);
+});
+
+it('does not warn when the array contains a non-element', function() {
+  spyOn(console, 'error');
+
+  React.cloneElement(<div />, null, [{}, {}]);
+
+  expect(console.error.calls.count()).toBe(0);
+});
+
+it('should check declared prop types after clone', function() {
+  spyOn(console, 'error');
+  var Component = React.createClass({
+    propTypes: {
+      color: React.PropTypes.string.isRequired,
+    },
+    render: function() {
+      return React.createElement('div', null, 'My color is ' + this.color);
+    },
   });
-
-  it('should steal the ref if a new ref is specified', function() {
-    var Parent = React.createClass({
-      render: function() {
-        var clone = React.cloneElement(this.props.children, {ref: 'xyz'});
-        return <div>{clone}</div>;
-      },
-    });
-
-    var Grandparent = React.createClass({
-      render: function() {
-        return <Parent ref="parent"><span ref="child" /></Parent>;
-      },
-    });
-
-    var component = ReactTestUtils.renderIntoDocument(<Grandparent />);
-    expect(component.refs.child).toBeUndefined();
-    expect(component.refs.parent.refs.xyz.tagName).toBe('SPAN');
+  var Parent = React.createClass({
+    render: function() {
+      return React.cloneElement(this.props.child, {color: 123});
+    },
   });
-
-  it('should overwrite props', function() {
-    var Component = React.createClass({
-      render: function() {
-        expect(this.props.myprop).toBe('xyz');
-        return <div />;
-      },
-    });
-
-    ReactTestUtils.renderIntoDocument(
-      React.cloneElement(<Component myprop="abc" />, {myprop: 'xyz'})
-    );
+  var GrandParent = React.createClass({
+    render: function() {
+      return React.createElement(
+        Parent,
+        { child: React.createElement(Component, {color: 'red'}) }
+      );
+    },
   });
+  ReactTestUtils.renderIntoDocument(React.createElement(GrandParent));
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: Failed prop type: ' +
+    'Invalid prop `color` of type `number` supplied to `Component`, ' +
+    'expected `string`.\n' +
+    '    in Component (created by GrandParent)\n' +
+    '    in Parent (created by GrandParent)\n' +
+    '    in GrandParent'
+  );
+});
 
-  it('should normalize props with default values', function() {
-    var Component = React.createClass({
-      getDefaultProps: function() {
-        return {prop: 'testKey'};
-      },
-      render: function() {
-        return <span />;
-      },
-    });
+it('should ignore key and ref warning getters', function() {
+  var elementA = React.createElement('div');
+  var elementB = React.cloneElement(elementA, elementA.props);
+  expect(elementB.key).toBe(null);
+  expect(elementB.ref).toBe(null);
+});
 
-    var instance = React.createElement(Component);
-    var clonedInstance = React.cloneElement(instance, {prop: undefined});
-    expect(clonedInstance.props.prop).toBe('testKey');
-    var clonedInstance2 = React.cloneElement(instance, {prop: null});
-    expect(clonedInstance2.props.prop).toBe(null);
-
-    var instance2 = React.createElement(Component, {prop: 'newTestKey'});
-    var cloneInstance3 = React.cloneElement(instance2, {prop: undefined});
-    expect(cloneInstance3.props.prop).toBe('testKey');
-    var cloneInstance4 = React.cloneElement(instance2, {});
-    expect(cloneInstance4.props.prop).toBe('newTestKey');
+it('should ignore undefined key and ref', function() {
+  var element = React.createFactory(ComponentClass)({
+    key: '12',
+    ref: '34',
+    foo: '56',
   });
+  var props = {
+    key: undefined,
+    ref: undefined,
+    foo: 'ef',
+  };
+  var clone = React.cloneElement(element, props);
+  expect(clone.type).toBe(ComponentClass);
+  expect(clone.key).toBe('12');
+  expect(clone.ref).toBe('34');
+  expect(Object.isFrozen(element)).toBe(true);
+  expect(Object.isFrozen(element.props)).toBe(true);
+  expect(clone.props).toEqual({foo: 'ef'});
+});
 
-  it('warns for keys for arrays of elements in rest args', function() {
-    spyOn(console, 'error');
-
-    React.cloneElement(<div />, null, [<div />, <div />]);
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Each child in an array or iterator should have a unique "key" prop.'
-    );
+it('should extract null key and ref', function() {
+  var element = React.createFactory(ComponentClass)({
+    key: '12',
+    ref: '34',
+    foo: '56',
   });
-
-  it('does not warns for arrays of elements with keys', function() {
-    spyOn(console, 'error');
-
-    React.cloneElement(<div />, null, [<div key="#1" />, <div key="#2" />]);
-
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('does not warn when the element is directly in rest args', function() {
-    spyOn(console, 'error');
-
-    React.cloneElement(<div />, null, <div />, <div />);
-
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('does not warn when the array contains a non-element', function() {
-    spyOn(console, 'error');
-
-    React.cloneElement(<div />, null, [{}, {}]);
-
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('should check declared prop types after clone', function() {
-    spyOn(console, 'error');
-    var Component = React.createClass({
-      propTypes: {
-        color: React.PropTypes.string.isRequired,
-      },
-      render: function() {
-        return React.createElement('div', null, 'My color is ' + this.color);
-      },
-    });
-    var Parent = React.createClass({
-      render: function() {
-        return React.cloneElement(this.props.child, {color: 123});
-      },
-    });
-    var GrandParent = React.createClass({
-      render: function() {
-        return React.createElement(
-          Parent,
-          { child: React.createElement(Component, {color: 'red'}) }
-        );
-      },
-    });
-    ReactTestUtils.renderIntoDocument(React.createElement(GrandParent));
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: Failed prop type: ' +
-      'Invalid prop `color` of type `number` supplied to `Component`, ' +
-      'expected `string`.\n' +
-      '    in Component (created by GrandParent)\n' +
-      '    in Parent (created by GrandParent)\n' +
-      '    in GrandParent'
-    );
-  });
-
-  it('should ignore key and ref warning getters', function() {
-    var elementA = React.createElement('div');
-    var elementB = React.cloneElement(elementA, elementA.props);
-    expect(elementB.key).toBe(null);
-    expect(elementB.ref).toBe(null);
-  });
-
-  it('should ignore undefined key and ref', function() {
-    var element = React.createFactory(ComponentClass)({
-      key: '12',
-      ref: '34',
-      foo: '56',
-    });
-    var props = {
-      key: undefined,
-      ref: undefined,
-      foo: 'ef',
-    };
-    var clone = React.cloneElement(element, props);
-    expect(clone.type).toBe(ComponentClass);
-    expect(clone.key).toBe('12');
-    expect(clone.ref).toBe('34');
-    expect(Object.isFrozen(element)).toBe(true);
-    expect(Object.isFrozen(element.props)).toBe(true);
-    expect(clone.props).toEqual({foo: 'ef'});
-  });
-
-  it('should extract null key and ref', function() {
-    var element = React.createFactory(ComponentClass)({
-      key: '12',
-      ref: '34',
-      foo: '56',
-    });
-    var props = {
-      key: null,
-      ref: null,
-      foo: 'ef',
-    };
-    var clone = React.cloneElement(element, props);
-    expect(clone.type).toBe(ComponentClass);
-    expect(clone.key).toBe('null');
-    expect(clone.ref).toBe(null);
-    expect(Object.isFrozen(element)).toBe(true);
-    expect(Object.isFrozen(element.props)).toBe(true);
-    expect(clone.props).toEqual({foo: 'ef'});
-  });
-
+  var props = {
+    key: null,
+    ref: null,
+    foo: 'ef',
+  };
+  var clone = React.cloneElement(element, props);
+  expect(clone.type).toBe(ComponentClass);
+  expect(clone.key).toBe('null');
+  expect(clone.ref).toBe(null);
+  expect(Object.isFrozen(element)).toBe(true);
+  expect(Object.isFrozen(element.props)).toBe(true);
+  expect(clone.props).toEqual({foo: 'ef'});
 });

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -18,529 +18,526 @@ var React;
 var ReactDOM;
 var ReactTestUtils;
 
-describe('ReactElementValidator', function() {
-  function normalizeCodeLocInfo(str) {
-    return str.replace(/\(at .+?:\d+\)/g, '(at **)');
-  }
+function normalizeCodeLocInfo(str) {
+  return str.replace(/\(at .+?:\d+\)/g, '(at **)');
+}
 
-  var ComponentClass;
+var ComponentClass;
 
-  beforeEach(function() {
-    jest.resetModuleRegistry();
+beforeEach(function() {
+  jest.resetModuleRegistry();
 
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactTestUtils = require('ReactTestUtils');
-    ComponentClass = React.createClass({
-      render: function() {
-        return React.createElement('div');
-      },
-    });
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactTestUtils = require('ReactTestUtils');
+  ComponentClass = React.createClass({
+    render: function() {
+      return React.createElement('div');
+    },
+  });
+});
+
+it('warns for keys for arrays of elements in rest args', function() {
+  spyOn(console, 'error');
+  var Component = React.createFactory(ComponentClass);
+
+  Component(null, [Component(), Component()]);
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'Each child in an array or iterator should have a unique "key" prop.'
+  );
+});
+
+it('warns for keys for arrays of elements with owner info', function() {
+  spyOn(console, 'error');
+  var Component = React.createFactory(ComponentClass);
+
+  var InnerClass = React.createClass({
+    displayName: 'InnerClass',
+    render: function() {
+      return Component(null, this.props.childSet);
+    },
   });
 
-  it('warns for keys for arrays of elements in rest args', function() {
-    spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
+  var InnerComponent = React.createFactory(InnerClass);
 
-    Component(null, [Component(), Component()]);
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Each child in an array or iterator should have a unique "key" prop.'
-    );
+  var ComponentWrapper = React.createClass({
+    displayName: 'ComponentWrapper',
+    render: function() {
+      return InnerComponent({childSet: [Component(), Component()] });
+    },
   });
 
-  it('warns for keys for arrays of elements with owner info', function() {
-    spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
+  ReactTestUtils.renderIntoDocument(
+    React.createElement(ComponentWrapper)
+  );
 
-    var InnerClass = React.createClass({
-      displayName: 'InnerClass',
-      render: function() {
-        return Component(null, this.props.childSet);
-      },
-    });
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'Each child in an array or iterator should have a unique "key" prop. ' +
+    'Check the render method of `InnerClass`. ' +
+    'It was passed a child from ComponentWrapper. '
+  );
+});
 
-    var InnerComponent = React.createFactory(InnerClass);
+it('warns for keys for arrays with no owner or parent info', function() {
+  spyOn(console, 'error');
 
-    var ComponentWrapper = React.createClass({
-      displayName: 'ComponentWrapper',
-      render: function() {
-        return InnerComponent({childSet: [Component(), Component()] });
-      },
-    });
-
-    ReactTestUtils.renderIntoDocument(
-      React.createElement(ComponentWrapper)
-    );
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Each child in an array or iterator should have a unique "key" prop. ' +
-      'Check the render method of `InnerClass`. ' +
-      'It was passed a child from ComponentWrapper. '
-    );
+  var Anonymous = React.createClass({
+    displayName: undefined,
+    render: function() {
+      return <div />;
+    },
   });
 
-  it('warns for keys for arrays with no owner or parent info', function() {
-    spyOn(console, 'error');
+  var divs = [
+    <div />,
+    <div />,
+  ];
+  ReactTestUtils.renderIntoDocument(<Anonymous>{divs}</Anonymous>);
 
-    var Anonymous = React.createClass({
-      displayName: undefined,
-      render: function() {
-        return <div />;
-      },
-    });
+  expect(console.error.calls.count()).toBe(1);
+  expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+    'Warning: Each child in an array or iterator should have a unique ' +
+    '"key" prop. See https://fb.me/react-warning-keys for more information.\n' +
+    '    in div (at **)'
+  );
+});
 
-    var divs = [
-      <div />,
-      <div />,
-    ];
-    ReactTestUtils.renderIntoDocument(<Anonymous>{divs}</Anonymous>);
+it('warns for keys for arrays of elements with no owner info', function() {
+  spyOn(console, 'error');
 
-    expect(console.error.calls.count()).toBe(1);
-    expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-      'Warning: Each child in an array or iterator should have a unique ' +
-      '"key" prop. See https://fb.me/react-warning-keys for more information.\n' +
-      '    in div (at **)'
-    );
+  var divs = [
+    <div />,
+    <div />,
+  ];
+  ReactTestUtils.renderIntoDocument(<div>{divs}</div>);
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+    'Warning: Each child in an array or iterator should have a unique ' +
+    '"key" prop. Check the top-level render call using <div>. See ' +
+    'https://fb.me/react-warning-keys for more information.\n' +
+    '    in div (at **)'
+  );
+});
+
+it('warns for keys with component stack info', function() {
+  spyOn(console, 'error');
+
+  var Component = React.createClass({
+    render: function() {
+      return <div>{[<div />, <div />]}</div>;
+    },
   });
 
-  it('warns for keys for arrays of elements with no owner info', function() {
-    spyOn(console, 'error');
-
-    var divs = [
-      <div />,
-      <div />,
-    ];
-    ReactTestUtils.renderIntoDocument(<div>{divs}</div>);
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-      'Warning: Each child in an array or iterator should have a unique ' +
-      '"key" prop. Check the top-level render call using <div>. See ' +
-      'https://fb.me/react-warning-keys for more information.\n' +
-      '    in div (at **)'
-    );
+  var Parent = React.createClass({
+    render: function() {
+      return React.cloneElement(this.props.child);
+    },
   });
 
-  it('warns for keys with component stack info', function() {
-    spyOn(console, 'error');
-
-    var Component = React.createClass({
-      render: function() {
-        return <div>{[<div />, <div />]}</div>;
-      },
-    });
-
-    var Parent = React.createClass({
-      render: function() {
-        return React.cloneElement(this.props.child);
-      },
-    });
-
-    var GrandParent = React.createClass({
-      render: function() {
-        return <Parent child={<Component />} />;
-      },
-    });
-
-    ReactTestUtils.renderIntoDocument(<GrandParent />);
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-      'Warning: Each child in an array or iterator should have a unique ' +
-      '"key" prop. Check the render method of `Component`. See ' +
-      'https://fb.me/react-warning-keys for more information.\n' +
-      '    in div (at **)\n' +
-      '    in Component (at **)\n' +
-      '    in Parent (at **)\n' +
-      '    in GrandParent (at **)'
-    );
+  var GrandParent = React.createClass({
+    render: function() {
+      return <Parent child={<Component />} />;
+    },
   });
 
-  it('does not warn for keys when passing children down', function() {
-    spyOn(console, 'error');
+  ReactTestUtils.renderIntoDocument(<GrandParent />);
 
-    var Wrapper = React.createClass({
-      render: function() {
-        return (
-          <div>
-            {this.props.children}
-            <footer />
-          </div>
-        );
-      },
-    });
+  expect(console.error.calls.count()).toBe(1);
+  expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+    'Warning: Each child in an array or iterator should have a unique ' +
+    '"key" prop. Check the render method of `Component`. See ' +
+    'https://fb.me/react-warning-keys for more information.\n' +
+    '    in div (at **)\n' +
+    '    in Component (at **)\n' +
+    '    in Parent (at **)\n' +
+    '    in GrandParent (at **)'
+  );
+});
 
-    ReactTestUtils.renderIntoDocument(
-      <Wrapper>
-        <span />
-        <span />
-      </Wrapper>
-    );
+it('does not warn for keys when passing children down', function() {
+  spyOn(console, 'error');
 
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('warns for keys for iterables of elements in rest args', function() {
-    spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
-
-    var iterable = {
-      '@@iterator': function() {
-        var i = 0;
-        return {
-          next: function() {
-            var done = ++i > 2;
-            return {value: done ? undefined : Component(), done: done};
-          },
-        };
-      },
-    };
-
-    Component(null, iterable);
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Each child in an array or iterator should have a unique "key" prop.'
-    );
-  });
-
-  it('does not warns for arrays of elements with keys', function() {
-    spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
-
-    Component(null, [Component({key: '#1'}), Component({key: '#2'})]);
-
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('does not warns for iterable elements with keys', function() {
-    spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
-
-    var iterable = {
-      '@@iterator': function() {
-        var i = 0;
-        return {
-          next: function() {
-            var done = ++i > 2;
-            return {
-              value: done ? undefined : Component({key: '#' + i}),
-              done: done,
-            };
-          },
-        };
-      },
-    };
-
-    Component(null, iterable);
-
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('does not warn when the element is directly in rest args', function() {
-    spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
-
-    Component(null, Component(), Component());
-
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('does not warn when the array contains a non-element', function() {
-    spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
-
-    Component(null, [{}, {}]);
-
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  // TODO: These warnings currently come from the composite component, but
-  // they should be moved into the ReactElementValidator.
-
-  it('should give context for PropType errors in nested components.', () => {
-    // In this test, we're making sure that if a proptype error is found in a
-    // component, we give a small hint as to which parent instantiated that
-    // component as per warnings about key usage in ReactElementValidator.
-    spyOn(console, 'error');
-    var MyComp = React.createClass({
-      propTypes: {
-        color: React.PropTypes.string,
-      },
-      render: function() {
-        return React.createElement('div', null, 'My color is ' + this.color);
-      },
-    });
-    var ParentComp = React.createClass({
-      render: function() {
-        return React.createElement(MyComp, {color: 123});
-      },
-    });
-    ReactTestUtils.renderIntoDocument(React.createElement(ParentComp));
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: Failed prop type: ' +
-      'Invalid prop `color` of type `number` supplied to `MyComp`, ' +
-      'expected `string`.\n' +
-      '    in MyComp (created by ParentComp)\n' +
-      '    in ParentComp'
-    );
-  });
-
-  it('gives a helpful error when passing null, undefined, boolean, or number', function() {
-    spyOn(console, 'error');
-    React.createElement(undefined);
-    React.createElement(null);
-    React.createElement(true);
-    React.createElement(123);
-    expect(console.error.calls.count()).toBe(4);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: React.createElement: type should not be null, undefined, ' +
-      'boolean, or number. It should be a string (for DOM elements) or a ' +
-      'ReactClass (for composite components).'
-    );
-    expect(console.error.calls.argsFor(1)[0]).toBe(
-      'Warning: React.createElement: type should not be null, undefined, ' +
-      'boolean, or number. It should be a string (for DOM elements) or a ' +
-      'ReactClass (for composite components).'
-    );
-    expect(console.error.calls.argsFor(2)[0]).toBe(
-      'Warning: React.createElement: type should not be null, undefined, ' +
-      'boolean, or number. It should be a string (for DOM elements) or a ' +
-      'ReactClass (for composite components).'
-    );
-    expect(console.error.calls.argsFor(3)[0]).toBe(
-      'Warning: React.createElement: type should not be null, undefined, ' +
-      'boolean, or number. It should be a string (for DOM elements) or a ' +
-      'ReactClass (for composite components).'
-    );
-    React.createElement('div');
-    expect(console.error.calls.count()).toBe(4);
-  });
-
-  it('includes the owner name when passing null, undefined, boolean, or number', function() {
-    spyOn(console, 'error');
-    var ParentComp = React.createClass({
-      render: function() {
-        return React.createElement(null);
-      },
-    });
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(React.createElement(ParentComp));
-    }).toThrowError(
-      'Element type is invalid: expected a string (for built-in components) ' +
-      'or a class/function (for composite components) but got: null. Check ' +
-      'the render method of `ParentComp`.'
-    );
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: React.createElement: type should not be null, undefined, ' +
-      'boolean, or number. It should be a string (for DOM elements) or a ' +
-      'ReactClass (for composite components). Check the render method of ' +
-      '`ParentComp`.'
-    );
-  });
-
-  it('should check default prop values', function() {
-    spyOn(console, 'error');
-
-    var Component = React.createClass({
-      propTypes: {prop: React.PropTypes.string.isRequired},
-      getDefaultProps: function() {
-        return {prop: null};
-      },
-      render: function() {
-        return React.createElement('span', null, this.props.prop);
-      },
-    });
-
-    ReactTestUtils.renderIntoDocument(React.createElement(Component));
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: Failed prop type: The prop `prop` is marked as required in ' +
-      '`Component`, but its value is `null`.\n' +
-      '    in Component'
-    );
-  });
-
-  it('should not check the default for explicit null', function() {
-    spyOn(console, 'error');
-
-    var Component = React.createClass({
-      propTypes: {prop: React.PropTypes.string.isRequired},
-      getDefaultProps: function() {
-        return {prop: 'text'};
-      },
-      render: function() {
-        return React.createElement('span', null, this.props.prop);
-      },
-    });
-
-    ReactTestUtils.renderIntoDocument(
-      React.createElement(Component, {prop:null})
-    );
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: Failed prop type: The prop `prop` is marked as required in ' +
-      '`Component`, but its value is `null`.\n' +
-      '    in Component'
-    );
-  });
-
-  it('should check declared prop types', function() {
-    spyOn(console, 'error');
-
-    var Component = React.createClass({
-      propTypes: {
-        prop: React.PropTypes.string.isRequired,
-      },
-      render: function() {
-        return React.createElement('span', null, this.props.prop);
-      },
-    });
-
-    ReactTestUtils.renderIntoDocument(
-      React.createElement(Component)
-    );
-    ReactTestUtils.renderIntoDocument(
-      React.createElement(Component, {prop: 42})
-    );
-
-    expect(console.error.calls.count()).toBe(2);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: Failed prop type: ' +
-      'The prop `prop` is marked as required in `Component`, but its value ' +
-      'is `undefined`.\n' +
-      '    in Component'
-    );
-
-    expect(console.error.calls.argsFor(1)[0]).toBe(
-      'Warning: Failed prop type: ' +
-      'Invalid prop `prop` of type `number` supplied to ' +
-      '`Component`, expected `string`.\n' +
-      '    in Component'
-    );
-
-    ReactTestUtils.renderIntoDocument(
-      React.createElement(Component, {prop: 'string'})
-    );
-
-    // Should not error for strings
-    expect(console.error.calls.count()).toBe(2);
-  });
-
-  it('should warn if a PropType creator is used as a PropType', function() {
-    spyOn(console, 'error');
-
-    var Component = React.createClass({
-      propTypes: {
-        myProp: React.PropTypes.shape,
-      },
-      render: function() {
-        return React.createElement('span', null, this.props.myProp.value);
-      },
-    });
-
-    ReactTestUtils.renderIntoDocument(
-      React.createElement(Component, {myProp: {value: 'hi'}})
-    );
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: Component: type specification of prop `myProp` is invalid; ' +
-      'the type checker function must return `null` or an `Error` but ' +
-      'returned a function. You may have forgotten to pass an argument to ' +
-      'the type checker creator (arrayOf, instanceOf, objectOf, oneOf, ' +
-      'oneOfType, and shape all require an argument).'
-    );
-  });
-
-  it('should warn when accessing .type on an element factory', function() {
-    spyOn(console, 'error');
-    var TestComponent = React.createClass({
-      render: function() {
-        return <div />;
-      },
-    });
-    var TestFactory = React.createFactory(TestComponent);
-    expect(TestFactory.type).toBe(TestComponent);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: Factory.type is deprecated. Access the class directly before ' +
-      'passing it to createFactory.'
-    );
-    // Warn once, not again
-    expect(TestFactory.type).toBe(TestComponent);
-    expect(console.error.calls.count()).toBe(1);
-  });
-
-  it('does not warn when using DOM node as children', function() {
-    spyOn(console, 'error');
-    var DOMContainer = React.createClass({
-      render: function() {
-        return <div />;
-      },
-      componentDidMount: function() {
-        ReactDOM.findDOMNode(this).appendChild(this.props.children);
-      },
-    });
-
-    var node = document.createElement('div');
-    // This shouldn't cause a stack overflow or any other problems (#3883)
-    ReactTestUtils.renderIntoDocument(<DOMContainer>{node}</DOMContainer>);
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('should not enumerate enumerable numbers (#4776)', function() {
-    /*eslint-disable no-extend-native */
-    Number.prototype['@@iterator'] = function() {
-      throw new Error('number iterator called');
-    };
-    /*eslint-enable no-extend-native */
-
-    try {
-      void (
+  var Wrapper = React.createClass({
+    render: function() {
+      return (
         <div>
-          {5}
-          {12}
-          {13}
+          {this.props.children}
+          <footer />
         </div>
       );
-    } finally {
-      delete Number.prototype['@@iterator'];
-    }
+    },
   });
 
-  it('does not blow up with inlined children', function() {
-    // We don't suggest this since it silences all sorts of warnings, but we
-    // shouldn't blow up either.
+  ReactTestUtils.renderIntoDocument(
+    <Wrapper>
+      <span />
+      <span />
+    </Wrapper>
+  );
 
-    var child = {
-      $$typeof: (<div />).$$typeof,
-      type: 'span',
-      key: null,
-      ref: null,
-      props: {},
-      _owner: null,
-    };
+  expect(console.error.calls.count()).toBe(0);
+});
 
-    void <div>{[child]}</div>;
+it('warns for keys for iterables of elements in rest args', function() {
+  spyOn(console, 'error');
+  var Component = React.createFactory(ComponentClass);
+
+  var iterable = {
+    '@@iterator': function() {
+      var i = 0;
+      return {
+        next: function() {
+          var done = ++i > 2;
+          return {value: done ? undefined : Component(), done: done};
+        },
+      };
+    },
+  };
+
+  Component(null, iterable);
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'Each child in an array or iterator should have a unique "key" prop.'
+  );
+});
+
+it('does not warns for arrays of elements with keys', function() {
+  spyOn(console, 'error');
+  var Component = React.createFactory(ComponentClass);
+
+  Component(null, [Component({key: '#1'}), Component({key: '#2'})]);
+
+  expect(console.error.calls.count()).toBe(0);
+});
+
+it('does not warns for iterable elements with keys', function() {
+  spyOn(console, 'error');
+  var Component = React.createFactory(ComponentClass);
+
+  var iterable = {
+    '@@iterator': function() {
+      var i = 0;
+      return {
+        next: function() {
+          var done = ++i > 2;
+          return {
+            value: done ? undefined : Component({key: '#' + i}),
+            done: done,
+          };
+        },
+      };
+    },
+  };
+
+  Component(null, iterable);
+
+  expect(console.error.calls.count()).toBe(0);
+});
+
+it('does not warn when the element is directly in rest args', function() {
+  spyOn(console, 'error');
+  var Component = React.createFactory(ComponentClass);
+
+  Component(null, Component(), Component());
+
+  expect(console.error.calls.count()).toBe(0);
+});
+
+it('does not warn when the array contains a non-element', function() {
+  spyOn(console, 'error');
+  var Component = React.createFactory(ComponentClass);
+
+  Component(null, [{}, {}]);
+
+  expect(console.error.calls.count()).toBe(0);
+});
+
+// TODO: These warnings currently come from the composite component, but
+// they should be moved into the ReactElementValidator.
+
+it('should give context for PropType errors in nested components.', () => {
+  // In this test, we're making sure that if a proptype error is found in a
+  // component, we give a small hint as to which parent instantiated that
+  // component as per warnings about key usage in ReactElementValidator.
+  spyOn(console, 'error');
+  var MyComp = React.createClass({
+    propTypes: {
+      color: React.PropTypes.string,
+    },
+    render: function() {
+      return React.createElement('div', null, 'My color is ' + this.color);
+    },
+  });
+  var ParentComp = React.createClass({
+    render: function() {
+      return React.createElement(MyComp, {color: 123});
+    },
+  });
+  ReactTestUtils.renderIntoDocument(React.createElement(ParentComp));
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: Failed prop type: ' +
+    'Invalid prop `color` of type `number` supplied to `MyComp`, ' +
+    'expected `string`.\n' +
+    '    in MyComp (created by ParentComp)\n' +
+    '    in ParentComp'
+  );
+});
+
+it('gives a helpful error when passing null, undefined, boolean, or number', function() {
+  spyOn(console, 'error');
+  React.createElement(undefined);
+  React.createElement(null);
+  React.createElement(true);
+  React.createElement(123);
+  expect(console.error.calls.count()).toBe(4);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: React.createElement: type should not be null, undefined, ' +
+    'boolean, or number. It should be a string (for DOM elements) or a ' +
+    'ReactClass (for composite components).'
+  );
+  expect(console.error.calls.argsFor(1)[0]).toBe(
+    'Warning: React.createElement: type should not be null, undefined, ' +
+    'boolean, or number. It should be a string (for DOM elements) or a ' +
+    'ReactClass (for composite components).'
+  );
+  expect(console.error.calls.argsFor(2)[0]).toBe(
+    'Warning: React.createElement: type should not be null, undefined, ' +
+    'boolean, or number. It should be a string (for DOM elements) or a ' +
+    'ReactClass (for composite components).'
+  );
+  expect(console.error.calls.argsFor(3)[0]).toBe(
+    'Warning: React.createElement: type should not be null, undefined, ' +
+    'boolean, or number. It should be a string (for DOM elements) or a ' +
+    'ReactClass (for composite components).'
+  );
+  React.createElement('div');
+  expect(console.error.calls.count()).toBe(4);
+});
+
+it('includes the owner name when passing null, undefined, boolean, or number', function() {
+  spyOn(console, 'error');
+  var ParentComp = React.createClass({
+    render: function() {
+      return React.createElement(null);
+    },
+  });
+  expect(function() {
+    ReactTestUtils.renderIntoDocument(React.createElement(ParentComp));
+  }).toThrowError(
+    'Element type is invalid: expected a string (for built-in components) ' +
+    'or a class/function (for composite components) but got: null. Check ' +
+    'the render method of `ParentComp`.'
+  );
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: React.createElement: type should not be null, undefined, ' +
+    'boolean, or number. It should be a string (for DOM elements) or a ' +
+    'ReactClass (for composite components). Check the render method of ' +
+    '`ParentComp`.'
+  );
+});
+
+it('should check default prop values', function() {
+  spyOn(console, 'error');
+
+  var Component = React.createClass({
+    propTypes: {prop: React.PropTypes.string.isRequired},
+    getDefaultProps: function() {
+      return {prop: null};
+    },
+    render: function() {
+      return React.createElement('span', null, this.props.prop);
+    },
   });
 
-  it('does not blow up on key warning with undefined type', function() {
-    spyOn(console, 'error');
-    var Foo = undefined;
-    void <Foo>{[<div />]}</Foo>;
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: React.createElement: type should not be null, undefined, ' +
-      'boolean, or number. It should be a string (for DOM elements) or a ' +
-      'ReactClass (for composite components).'
+  ReactTestUtils.renderIntoDocument(React.createElement(Component));
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: Failed prop type: The prop `prop` is marked as required in ' +
+    '`Component`, but its value is `null`.\n' +
+    '    in Component'
+  );
+});
+
+it('should not check the default for explicit null', function() {
+  spyOn(console, 'error');
+
+  var Component = React.createClass({
+    propTypes: {prop: React.PropTypes.string.isRequired},
+    getDefaultProps: function() {
+      return {prop: 'text'};
+    },
+    render: function() {
+      return React.createElement('span', null, this.props.prop);
+    },
+  });
+
+  ReactTestUtils.renderIntoDocument(
+    React.createElement(Component, {prop:null})
+  );
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: Failed prop type: The prop `prop` is marked as required in ' +
+    '`Component`, but its value is `null`.\n' +
+    '    in Component'
+  );
+});
+
+it('should check declared prop types', function() {
+  spyOn(console, 'error');
+
+  var Component = React.createClass({
+    propTypes: {
+      prop: React.PropTypes.string.isRequired,
+    },
+    render: function() {
+      return React.createElement('span', null, this.props.prop);
+    },
+  });
+
+  ReactTestUtils.renderIntoDocument(
+    React.createElement(Component)
+  );
+  ReactTestUtils.renderIntoDocument(
+    React.createElement(Component, {prop: 42})
+  );
+
+  expect(console.error.calls.count()).toBe(2);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: Failed prop type: ' +
+    'The prop `prop` is marked as required in `Component`, but its value ' +
+    'is `undefined`.\n' +
+    '    in Component'
+  );
+
+  expect(console.error.calls.argsFor(1)[0]).toBe(
+    'Warning: Failed prop type: ' +
+    'Invalid prop `prop` of type `number` supplied to ' +
+    '`Component`, expected `string`.\n' +
+    '    in Component'
+  );
+
+  ReactTestUtils.renderIntoDocument(
+    React.createElement(Component, {prop: 'string'})
+  );
+
+  // Should not error for strings
+  expect(console.error.calls.count()).toBe(2);
+});
+
+it('should warn if a PropType creator is used as a PropType', function() {
+  spyOn(console, 'error');
+
+  var Component = React.createClass({
+    propTypes: {
+      myProp: React.PropTypes.shape,
+    },
+    render: function() {
+      return React.createElement('span', null, this.props.myProp.value);
+    },
+  });
+
+  ReactTestUtils.renderIntoDocument(
+    React.createElement(Component, {myProp: {value: 'hi'}})
+  );
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: Component: type specification of prop `myProp` is invalid; ' +
+    'the type checker function must return `null` or an `Error` but ' +
+    'returned a function. You may have forgotten to pass an argument to ' +
+    'the type checker creator (arrayOf, instanceOf, objectOf, oneOf, ' +
+    'oneOfType, and shape all require an argument).'
+  );
+});
+
+it('should warn when accessing .type on an element factory', function() {
+  spyOn(console, 'error');
+  var TestComponent = React.createClass({
+    render: function() {
+      return <div />;
+    },
+  });
+  var TestFactory = React.createFactory(TestComponent);
+  expect(TestFactory.type).toBe(TestComponent);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: Factory.type is deprecated. Access the class directly before ' +
+    'passing it to createFactory.'
+  );
+  // Warn once, not again
+  expect(TestFactory.type).toBe(TestComponent);
+  expect(console.error.calls.count()).toBe(1);
+});
+
+it('does not warn when using DOM node as children', function() {
+  spyOn(console, 'error');
+  var DOMContainer = React.createClass({
+    render: function() {
+      return <div />;
+    },
+    componentDidMount: function() {
+      ReactDOM.findDOMNode(this).appendChild(this.props.children);
+    },
+  });
+
+  var node = document.createElement('div');
+  // This shouldn't cause a stack overflow or any other problems (#3883)
+  ReactTestUtils.renderIntoDocument(<DOMContainer>{node}</DOMContainer>);
+  expect(console.error.calls.count()).toBe(0);
+});
+
+it('should not enumerate enumerable numbers (#4776)', function() {
+  /*eslint-disable no-extend-native */
+  Number.prototype['@@iterator'] = function() {
+    throw new Error('number iterator called');
+  };
+  /*eslint-enable no-extend-native */
+
+  try {
+    void (
+      <div>
+        {5}
+        {12}
+        {13}
+      </div>
     );
-  });
+  } finally {
+    delete Number.prototype['@@iterator'];
+  }
+});
 
+it('does not blow up with inlined children', function() {
+  // We don't suggest this since it silences all sorts of warnings, but we
+  // shouldn't blow up either.
+
+  var child = {
+    $$typeof: (<div />).$$typeof,
+    type: 'span',
+    key: null,
+    ref: null,
+    props: {},
+    _owner: null,
+  };
+
+  void <div>{[child]}</div>;
+});
+
+it('does not blow up on key warning with undefined type', function() {
+  spyOn(console, 'error');
+  var Foo = undefined;
+  void <Foo>{[<div />]}</Foo>;
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: React.createElement: type should not be null, undefined, ' +
+    'boolean, or number. It should be a string (for DOM elements) or a ' +
+    'ReactClass (for composite components).'
+  );
 });

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -106,929 +106,996 @@ function expectWarningInDevelopment(declaration, value) {
   console.error.calls.reset();
 }
 
-describe('ReactPropTypes', function() {
-  beforeEach(function() {
-    PropTypes = require('ReactPropTypes');
-    React = require('React');
-    ReactFragment = require('ReactFragment');
-    ReactTestUtils = require('ReactTestUtils');
-    ReactPropTypesSecret = require('ReactPropTypesSecret');
+beforeEach(function() {
+  PropTypes = require('ReactPropTypes');
+  React = require('React');
+  ReactFragment = require('ReactFragment');
+  ReactTestUtils = require('ReactTestUtils');
+  ReactPropTypesSecret = require('ReactPropTypesSecret');
+});
+
+describe('Primitive Types', function() {
+  it('should warn for invalid strings', function() {
+    typeCheckFail(
+      PropTypes.string,
+      [],
+      'Invalid prop `testProp` of type `array` supplied to ' +
+      '`testComponent`, expected `string`.'
+    );
+    typeCheckFail(
+      PropTypes.string,
+      false,
+      'Invalid prop `testProp` of type `boolean` supplied to ' +
+      '`testComponent`, expected `string`.'
+    );
+    typeCheckFail(
+      PropTypes.string,
+      0,
+      'Invalid prop `testProp` of type `number` supplied to ' +
+      '`testComponent`, expected `string`.'
+    );
+    typeCheckFail(
+      PropTypes.string,
+      {},
+      'Invalid prop `testProp` of type `object` supplied to ' +
+      '`testComponent`, expected `string`.'
+    );
+    typeCheckFail(
+      PropTypes.string,
+      Symbol(),
+      'Invalid prop `testProp` of type `symbol` supplied to ' +
+      '`testComponent`, expected `string`.'
+    );
   });
 
-  describe('Primitive Types', function() {
-    it('should warn for invalid strings', function() {
-      typeCheckFail(
-        PropTypes.string,
-        [],
-        'Invalid prop `testProp` of type `array` supplied to ' +
-        '`testComponent`, expected `string`.'
-      );
-      typeCheckFail(
-        PropTypes.string,
-        false,
-        'Invalid prop `testProp` of type `boolean` supplied to ' +
-        '`testComponent`, expected `string`.'
-      );
-      typeCheckFail(
-        PropTypes.string,
-        0,
-        'Invalid prop `testProp` of type `number` supplied to ' +
-        '`testComponent`, expected `string`.'
-      );
-      typeCheckFail(
-        PropTypes.string,
-        {},
-        'Invalid prop `testProp` of type `object` supplied to ' +
-        '`testComponent`, expected `string`.'
-      );
-      typeCheckFail(
-        PropTypes.string,
-        Symbol(),
-        'Invalid prop `testProp` of type `symbol` supplied to ' +
-        '`testComponent`, expected `string`.'
-      );
-    });
-
-    it('should fail date and regexp correctly', function() {
-      typeCheckFail(
-        PropTypes.string,
-        new Date(),
-        'Invalid prop `testProp` of type `date` supplied to ' +
-        '`testComponent`, expected `string`.'
-      );
-      typeCheckFail(
-        PropTypes.string,
-        /please/,
-        'Invalid prop `testProp` of type `regexp` supplied to ' +
-        '`testComponent`, expected `string`.'
-      );
-    });
-
-    it('should not warn for valid values', function() {
-      typeCheckPass(PropTypes.array, []);
-      typeCheckPass(PropTypes.bool, false);
-      typeCheckPass(PropTypes.func, function() {});
-      typeCheckPass(PropTypes.number, 0);
-      typeCheckPass(PropTypes.string, '');
-      typeCheckPass(PropTypes.object, {});
-      typeCheckPass(PropTypes.object, new Date());
-      typeCheckPass(PropTypes.object, /please/);
-      typeCheckPass(PropTypes.symbol, Symbol());
-    });
-
-    it('should be implicitly optional and not warn without values', function() {
-      typeCheckPass(PropTypes.string, null);
-      typeCheckPass(PropTypes.string, undefined);
-    });
-
-    it('should warn for missing required values', function() {
-      typeCheckFailRequiredValues(PropTypes.string.isRequired);
-    });
-
-    it('should warn if called manually in development', function() {
-      spyOn(console, 'error');
-      expectWarningInDevelopment(PropTypes.array, /please/);
-      expectWarningInDevelopment(PropTypes.array, []);
-      expectWarningInDevelopment(PropTypes.array.isRequired, /please/);
-      expectWarningInDevelopment(PropTypes.array.isRequired, []);
-      expectWarningInDevelopment(PropTypes.array.isRequired, null);
-      expectWarningInDevelopment(PropTypes.array.isRequired, undefined);
-      expectWarningInDevelopment(PropTypes.bool, []);
-      expectWarningInDevelopment(PropTypes.bool, true);
-      expectWarningInDevelopment(PropTypes.bool.isRequired, []);
-      expectWarningInDevelopment(PropTypes.bool.isRequired, true);
-      expectWarningInDevelopment(PropTypes.bool.isRequired, null);
-      expectWarningInDevelopment(PropTypes.bool.isRequired, undefined);
-      expectWarningInDevelopment(PropTypes.func, false);
-      expectWarningInDevelopment(PropTypes.func, function() {});
-      expectWarningInDevelopment(PropTypes.func.isRequired, false);
-      expectWarningInDevelopment(PropTypes.func.isRequired, function() {});
-      expectWarningInDevelopment(PropTypes.func.isRequired, null);
-      expectWarningInDevelopment(PropTypes.func.isRequired, undefined);
-      expectWarningInDevelopment(PropTypes.number, function() {});
-      expectWarningInDevelopment(PropTypes.number, 42);
-      expectWarningInDevelopment(PropTypes.number.isRequired, function() {});
-      expectWarningInDevelopment(PropTypes.number.isRequired, 42);
-      expectWarningInDevelopment(PropTypes.number.isRequired, null);
-      expectWarningInDevelopment(PropTypes.number.isRequired, undefined);
-      expectWarningInDevelopment(PropTypes.string, 0);
-      expectWarningInDevelopment(PropTypes.string, 'foo');
-      expectWarningInDevelopment(PropTypes.string.isRequired, 0);
-      expectWarningInDevelopment(PropTypes.string.isRequired, 'foo');
-      expectWarningInDevelopment(PropTypes.string.isRequired, null);
-      expectWarningInDevelopment(PropTypes.string.isRequired, undefined);
-      expectWarningInDevelopment(PropTypes.symbol, 0);
-      expectWarningInDevelopment(PropTypes.symbol, Symbol('Foo'));
-      expectWarningInDevelopment(PropTypes.symbol.isRequired, 0);
-      expectWarningInDevelopment(PropTypes.symbol.isRequired, Symbol('Foo'));
-      expectWarningInDevelopment(PropTypes.symbol.isRequired, null);
-      expectWarningInDevelopment(PropTypes.symbol.isRequired, undefined);
-      expectWarningInDevelopment(PropTypes.object, '');
-      expectWarningInDevelopment(PropTypes.object, {foo: 'bar'});
-      expectWarningInDevelopment(PropTypes.object.isRequired, '');
-      expectWarningInDevelopment(PropTypes.object.isRequired, {foo: 'bar'});
-      expectWarningInDevelopment(PropTypes.object.isRequired, null);
-      expectWarningInDevelopment(PropTypes.object.isRequired, undefined);
-    });
+  it('should fail date and regexp correctly', function() {
+    typeCheckFail(
+      PropTypes.string,
+      new Date(),
+      'Invalid prop `testProp` of type `date` supplied to ' +
+      '`testComponent`, expected `string`.'
+    );
+    typeCheckFail(
+      PropTypes.string,
+      /please/,
+      'Invalid prop `testProp` of type `regexp` supplied to ' +
+      '`testComponent`, expected `string`.'
+    );
   });
 
-  describe('Any type', function() {
-    it('should should accept any value', function() {
-      typeCheckPass(PropTypes.any, 0);
-      typeCheckPass(PropTypes.any, 'str');
-      typeCheckPass(PropTypes.any, []);
-      typeCheckPass(PropTypes.any, Symbol());
-    });
-
-    it('should be implicitly optional and not warn without values', function() {
-      typeCheckPass(PropTypes.any, null);
-      typeCheckPass(PropTypes.any, undefined);
-    });
-
-    it('should warn for missing required values', function() {
-      typeCheckFailRequiredValues(PropTypes.any.isRequired);
-    });
-
-    it('should warn if called manually in development', function() {
-      spyOn(console, 'error');
-      expectWarningInDevelopment(PropTypes.any, null);
-      expectWarningInDevelopment(PropTypes.any.isRequired, null);
-      expectWarningInDevelopment(PropTypes.any.isRequired, undefined);
-    });
+  it('should not warn for valid values', function() {
+    typeCheckPass(PropTypes.array, []);
+    typeCheckPass(PropTypes.bool, false);
+    typeCheckPass(PropTypes.func, function() {});
+    typeCheckPass(PropTypes.number, 0);
+    typeCheckPass(PropTypes.string, '');
+    typeCheckPass(PropTypes.object, {});
+    typeCheckPass(PropTypes.object, new Date());
+    typeCheckPass(PropTypes.object, /please/);
+    typeCheckPass(PropTypes.symbol, Symbol());
   });
 
-  describe('ArrayOf Type', function() {
-    it('should fail for invalid argument', function() {
-      typeCheckFail(
-        PropTypes.arrayOf({ foo: PropTypes.string }),
-        { foo: 'bar' },
-        'Property `testProp` of component `testComponent` has invalid PropType notation inside arrayOf.'
-      );
-    });
+  it('should be implicitly optional and not warn without values', function() {
+    typeCheckPass(PropTypes.string, null);
+    typeCheckPass(PropTypes.string, undefined);
+  });
 
-    it('should support the arrayOf propTypes', function() {
-      typeCheckPass(PropTypes.arrayOf(PropTypes.number), [1, 2, 3]);
-      typeCheckPass(PropTypes.arrayOf(PropTypes.string), ['a', 'b', 'c']);
-      typeCheckPass(PropTypes.arrayOf(PropTypes.oneOf(['a', 'b'])), ['a', 'b']);
-      typeCheckPass(PropTypes.arrayOf(PropTypes.symbol), [Symbol(), Symbol()]);
-    });
+  it('should warn for missing required values', function() {
+    typeCheckFailRequiredValues(PropTypes.string.isRequired);
+  });
 
-    it('should support arrayOf with complex types', function() {
-      typeCheckPass(
-        PropTypes.arrayOf(PropTypes.shape({a: PropTypes.number.isRequired})),
-        [{a: 1}, {a: 2}]
-      );
+  it('should warn if called manually in development', function() {
+    spyOn(console, 'error');
+    expectWarningInDevelopment(PropTypes.array, /please/);
+    expectWarningInDevelopment(PropTypes.array, []);
+    expectWarningInDevelopment(PropTypes.array.isRequired, /please/);
+    expectWarningInDevelopment(PropTypes.array.isRequired, []);
+    expectWarningInDevelopment(PropTypes.array.isRequired, null);
+    expectWarningInDevelopment(PropTypes.array.isRequired, undefined);
+    expectWarningInDevelopment(PropTypes.bool, []);
+    expectWarningInDevelopment(PropTypes.bool, true);
+    expectWarningInDevelopment(PropTypes.bool.isRequired, []);
+    expectWarningInDevelopment(PropTypes.bool.isRequired, true);
+    expectWarningInDevelopment(PropTypes.bool.isRequired, null);
+    expectWarningInDevelopment(PropTypes.bool.isRequired, undefined);
+    expectWarningInDevelopment(PropTypes.func, false);
+    expectWarningInDevelopment(PropTypes.func, function() {});
+    expectWarningInDevelopment(PropTypes.func.isRequired, false);
+    expectWarningInDevelopment(PropTypes.func.isRequired, function() {});
+    expectWarningInDevelopment(PropTypes.func.isRequired, null);
+    expectWarningInDevelopment(PropTypes.func.isRequired, undefined);
+    expectWarningInDevelopment(PropTypes.number, function() {});
+    expectWarningInDevelopment(PropTypes.number, 42);
+    expectWarningInDevelopment(PropTypes.number.isRequired, function() {});
+    expectWarningInDevelopment(PropTypes.number.isRequired, 42);
+    expectWarningInDevelopment(PropTypes.number.isRequired, null);
+    expectWarningInDevelopment(PropTypes.number.isRequired, undefined);
+    expectWarningInDevelopment(PropTypes.string, 0);
+    expectWarningInDevelopment(PropTypes.string, 'foo');
+    expectWarningInDevelopment(PropTypes.string.isRequired, 0);
+    expectWarningInDevelopment(PropTypes.string.isRequired, 'foo');
+    expectWarningInDevelopment(PropTypes.string.isRequired, null);
+    expectWarningInDevelopment(PropTypes.string.isRequired, undefined);
+    expectWarningInDevelopment(PropTypes.symbol, 0);
+    expectWarningInDevelopment(PropTypes.symbol, Symbol('Foo'));
+    expectWarningInDevelopment(PropTypes.symbol.isRequired, 0);
+    expectWarningInDevelopment(PropTypes.symbol.isRequired, Symbol('Foo'));
+    expectWarningInDevelopment(PropTypes.symbol.isRequired, null);
+    expectWarningInDevelopment(PropTypes.symbol.isRequired, undefined);
+    expectWarningInDevelopment(PropTypes.object, '');
+    expectWarningInDevelopment(PropTypes.object, {foo: 'bar'});
+    expectWarningInDevelopment(PropTypes.object.isRequired, '');
+    expectWarningInDevelopment(PropTypes.object.isRequired, {foo: 'bar'});
+    expectWarningInDevelopment(PropTypes.object.isRequired, null);
+    expectWarningInDevelopment(PropTypes.object.isRequired, undefined);
+  });
+});
 
-      function Thing() {}
-      typeCheckPass(
-        PropTypes.arrayOf(PropTypes.instanceOf(Thing)),
-        [new Thing(), new Thing()]
-      );
-    });
+describe('Any type', function() {
+  it('should should accept any value', function() {
+    typeCheckPass(PropTypes.any, 0);
+    typeCheckPass(PropTypes.any, 'str');
+    typeCheckPass(PropTypes.any, []);
+    typeCheckPass(PropTypes.any, Symbol());
+  });
 
-    it('should warn with invalid items in the array', function() {
-      typeCheckFail(
-        PropTypes.arrayOf(PropTypes.number),
-        [1, 2, 'b'],
-        'Invalid prop `testProp[2]` of type `string` supplied to ' +
-        '`testComponent`, expected `number`.'
-      );
-    });
+  it('should be implicitly optional and not warn without values', function() {
+    typeCheckPass(PropTypes.any, null);
+    typeCheckPass(PropTypes.any, undefined);
+  });
 
-    it('should warn with invalid complex types', function() {
-      function Thing() {}
-      var name = Thing.name || '<<anonymous>>';
+  it('should warn for missing required values', function() {
+    typeCheckFailRequiredValues(PropTypes.any.isRequired);
+  });
 
-      typeCheckFail(
-        PropTypes.arrayOf(PropTypes.instanceOf(Thing)),
-        [new Thing(), 'xyz'],
-        'Invalid prop `testProp[1]` of type `String` supplied to ' +
-        '`testComponent`, expected instance of `' + name + '`.'
-      );
-    });
+  it('should warn if called manually in development', function() {
+    spyOn(console, 'error');
+    expectWarningInDevelopment(PropTypes.any, null);
+    expectWarningInDevelopment(PropTypes.any.isRequired, null);
+    expectWarningInDevelopment(PropTypes.any.isRequired, undefined);
+  });
+});
 
-    it('should warn when passed something other than an array', function() {
-      typeCheckFail(
-        PropTypes.arrayOf(PropTypes.number),
-        {'0': 'maybe-array', length: 1},
-        'Invalid prop `testProp` of type `object` supplied to ' +
-        '`testComponent`, expected an array.'
-      );
-      typeCheckFail(
-        PropTypes.arrayOf(PropTypes.number),
-        123,
-        'Invalid prop `testProp` of type `number` supplied to ' +
-        '`testComponent`, expected an array.'
-      );
-      typeCheckFail(
-        PropTypes.arrayOf(PropTypes.number),
-        'string',
-        'Invalid prop `testProp` of type `string` supplied to ' +
-        '`testComponent`, expected an array.'
-      );
-    });
-
-    it('should not warn when passing an empty array', function() {
-      typeCheckPass(PropTypes.arrayOf(PropTypes.number), []);
-    });
-
-    it('should be implicitly optional and not warn without values', function() {
-      typeCheckPass(PropTypes.arrayOf(PropTypes.number), null);
-      typeCheckPass(PropTypes.arrayOf(PropTypes.number), undefined);
-    });
-
-    it('should warn for missing required values', function() {
-      typeCheckFailRequiredValues(
-        PropTypes.arrayOf(PropTypes.number).isRequired
-      );
-    });
-
-    it('should warn if called manually in development', function() {
-      spyOn(console, 'error');
-      expectWarningInDevelopment(
+describe('ArrayOf Type', function() {
+  it('should fail for invalid argument', function() {
+    typeCheckFail(
       PropTypes.arrayOf({ foo: PropTypes.string }),
-        { foo: 'bar' }
-      );
-      expectWarningInDevelopment(
-        PropTypes.arrayOf(PropTypes.number),
-        [1, 2, 'b']
-      );
-      expectWarningInDevelopment(
-        PropTypes.arrayOf(PropTypes.number),
-        {'0': 'maybe-array', length: 1}
-      );
-      expectWarningInDevelopment(PropTypes.arrayOf(PropTypes.number).isRequired, null);
-      expectWarningInDevelopment(PropTypes.arrayOf(PropTypes.number).isRequired, undefined);
-    });
+      { foo: 'bar' },
+      'Property `testProp` of component `testComponent` has invalid PropType notation inside arrayOf.'
+    );
   });
 
-  describe('Component Type', function() {
-    beforeEach(function() {
-      Component = class extends React.Component {
-        static propTypes = {
-          label: PropTypes.element.isRequired,
+  it('should support the arrayOf propTypes', function() {
+    typeCheckPass(PropTypes.arrayOf(PropTypes.number), [1, 2, 3]);
+    typeCheckPass(PropTypes.arrayOf(PropTypes.string), ['a', 'b', 'c']);
+    typeCheckPass(PropTypes.arrayOf(PropTypes.oneOf(['a', 'b'])), ['a', 'b']);
+    typeCheckPass(PropTypes.arrayOf(PropTypes.symbol), [Symbol(), Symbol()]);
+  });
+
+  it('should support arrayOf with complex types', function() {
+    typeCheckPass(
+      PropTypes.arrayOf(PropTypes.shape({a: PropTypes.number.isRequired})),
+      [{a: 1}, {a: 2}]
+    );
+
+    function Thing() {}
+    typeCheckPass(
+      PropTypes.arrayOf(PropTypes.instanceOf(Thing)),
+      [new Thing(), new Thing()]
+    );
+  });
+
+  it('should warn with invalid items in the array', function() {
+    typeCheckFail(
+      PropTypes.arrayOf(PropTypes.number),
+      [1, 2, 'b'],
+      'Invalid prop `testProp[2]` of type `string` supplied to ' +
+      '`testComponent`, expected `number`.'
+    );
+  });
+
+  it('should warn with invalid complex types', function() {
+    function Thing() {}
+    var name = Thing.name || '<<anonymous>>';
+
+    typeCheckFail(
+      PropTypes.arrayOf(PropTypes.instanceOf(Thing)),
+      [new Thing(), 'xyz'],
+      'Invalid prop `testProp[1]` of type `String` supplied to ' +
+      '`testComponent`, expected instance of `' + name + '`.'
+    );
+  });
+
+  it('should warn when passed something other than an array', function() {
+    typeCheckFail(
+      PropTypes.arrayOf(PropTypes.number),
+      {'0': 'maybe-array', length: 1},
+      'Invalid prop `testProp` of type `object` supplied to ' +
+      '`testComponent`, expected an array.'
+    );
+    typeCheckFail(
+      PropTypes.arrayOf(PropTypes.number),
+      123,
+      'Invalid prop `testProp` of type `number` supplied to ' +
+      '`testComponent`, expected an array.'
+    );
+    typeCheckFail(
+      PropTypes.arrayOf(PropTypes.number),
+      'string',
+      'Invalid prop `testProp` of type `string` supplied to ' +
+      '`testComponent`, expected an array.'
+    );
+  });
+
+  it('should not warn when passing an empty array', function() {
+    typeCheckPass(PropTypes.arrayOf(PropTypes.number), []);
+  });
+
+  it('should be implicitly optional and not warn without values', function() {
+    typeCheckPass(PropTypes.arrayOf(PropTypes.number), null);
+    typeCheckPass(PropTypes.arrayOf(PropTypes.number), undefined);
+  });
+
+  it('should warn for missing required values', function() {
+    typeCheckFailRequiredValues(
+      PropTypes.arrayOf(PropTypes.number).isRequired
+    );
+  });
+
+  it('should warn if called manually in development', function() {
+    spyOn(console, 'error');
+    expectWarningInDevelopment(
+    PropTypes.arrayOf({ foo: PropTypes.string }),
+      { foo: 'bar' }
+    );
+    expectWarningInDevelopment(
+      PropTypes.arrayOf(PropTypes.number),
+      [1, 2, 'b']
+    );
+    expectWarningInDevelopment(
+      PropTypes.arrayOf(PropTypes.number),
+      {'0': 'maybe-array', length: 1}
+    );
+    expectWarningInDevelopment(PropTypes.arrayOf(PropTypes.number).isRequired, null);
+    expectWarningInDevelopment(PropTypes.arrayOf(PropTypes.number).isRequired, undefined);
+  });
+});
+
+describe('Component Type', function() {
+  beforeEach(function() {
+    Component = class extends React.Component {
+      static propTypes = {
+        label: PropTypes.element.isRequired,
+      };
+
+      render() {
+        return <div>{this.props.label}</div>;
+      }
+    };
+  });
+
+  it('should support components', () => {
+    typeCheckPass(PropTypes.element, <div />);
+  });
+
+  it('should not support multiple components or scalar values', () => {
+    typeCheckFail(
+      PropTypes.element,
+      [<div />, <div />],
+      'Invalid prop `testProp` of type `array` supplied to `testComponent`, ' +
+      'expected a single ReactElement.'
+    );
+    typeCheckFail(
+      PropTypes.element,
+      123,
+      'Invalid prop `testProp` of type `number` supplied to `testComponent`, ' +
+      'expected a single ReactElement.'
+    );
+    typeCheckFail(
+      PropTypes.element,
+      'foo',
+      'Invalid prop `testProp` of type `string` supplied to `testComponent`, ' +
+      'expected a single ReactElement.'
+    );
+    typeCheckFail(
+      PropTypes.element,
+      false,
+      'Invalid prop `testProp` of type `boolean` supplied to `testComponent`, ' +
+      'expected a single ReactElement.'
+    );
+  });
+
+  it('should be able to define a single child as label', () => {
+    spyOn(console, 'error');
+
+    var instance = <Component label={<div />} />;
+    instance = ReactTestUtils.renderIntoDocument(instance);
+
+    expect(console.error.calls.count()).toBe(0);
+  });
+
+  it('should warn when passing no label and isRequired is set', () => {
+    spyOn(console, 'error');
+
+    var instance = <Component />;
+    instance = ReactTestUtils.renderIntoDocument(instance);
+
+    expect(console.error.calls.count()).toBe(1);
+  });
+
+  it('should be implicitly optional and not warn without values', function() {
+    typeCheckPass(PropTypes.element, null);
+    typeCheckPass(PropTypes.element, undefined);
+  });
+
+  it('should warn for missing required values', function() {
+    typeCheckFailRequiredValues(PropTypes.element.isRequired);
+  });
+
+  it('should warn if called manually in development', function() {
+    spyOn(console, 'error');
+    expectWarningInDevelopment(PropTypes.element, [<div />, <div />]);
+    expectWarningInDevelopment(PropTypes.element, <div />);
+    expectWarningInDevelopment(PropTypes.element, 123);
+    expectWarningInDevelopment(PropTypes.element, 'foo');
+    expectWarningInDevelopment(PropTypes.element, false);
+    expectWarningInDevelopment(PropTypes.element.isRequired, null);
+    expectWarningInDevelopment(PropTypes.element.isRequired, undefined);
+  });
+
+});
+
+describe('Instance Types', function() {
+  it('should warn for invalid instances', function() {
+    function Person() {}
+    function Cat() {}
+    var personName = Person.name || '<<anonymous>>';
+    var dateName = Date.name || '<<anonymous>>';
+    var regExpName = RegExp.name || '<<anonymous>>';
+
+    typeCheckFail(
+      PropTypes.instanceOf(Person),
+      false,
+      'Invalid prop `testProp` of type `Boolean` supplied to ' +
+      '`testComponent`, expected instance of `' + personName + '`.'
+    );
+    typeCheckFail(
+      PropTypes.instanceOf(Person),
+      {},
+      'Invalid prop `testProp` of type `Object` supplied to ' +
+      '`testComponent`, expected instance of `' + personName + '`.'
+    );
+    typeCheckFail(
+      PropTypes.instanceOf(Person),
+      '',
+      'Invalid prop `testProp` of type `String` supplied to ' +
+      '`testComponent`, expected instance of `' + personName + '`.'
+    );
+    typeCheckFail(
+      PropTypes.instanceOf(Date),
+      {},
+      'Invalid prop `testProp` of type `Object` supplied to ' +
+      '`testComponent`, expected instance of `' + dateName + '`.'
+    );
+    typeCheckFail(
+      PropTypes.instanceOf(RegExp),
+      {},
+      'Invalid prop `testProp` of type `Object` supplied to ' +
+      '`testComponent`, expected instance of `' + regExpName + '`.'
+    );
+    typeCheckFail(
+      PropTypes.instanceOf(Person),
+      new Cat(),
+      'Invalid prop `testProp` of type `Cat` supplied to ' +
+      '`testComponent`, expected instance of `' + personName + '`.'
+    );
+    typeCheckFail(
+      PropTypes.instanceOf(Person),
+      Object.create(null),
+      'Invalid prop `testProp` of type `<<anonymous>>` supplied to ' +
+      '`testComponent`, expected instance of `' + personName + '`.'
+    );
+  });
+
+  it('should not warn for valid values', function() {
+    function Person() {}
+    function Engineer() {}
+    Engineer.prototype = new Person();
+
+    typeCheckPass(PropTypes.instanceOf(Person), new Person());
+    typeCheckPass(PropTypes.instanceOf(Person), new Engineer());
+
+    typeCheckPass(PropTypes.instanceOf(Date), new Date());
+    typeCheckPass(PropTypes.instanceOf(RegExp), /please/);
+  });
+
+  it('should be implicitly optional and not warn without values', function() {
+    typeCheckPass(PropTypes.instanceOf(String), null);
+    typeCheckPass(PropTypes.instanceOf(String), undefined);
+  });
+
+  it('should warn for missing required values', function() {
+    typeCheckFailRequiredValues(PropTypes.instanceOf(String).isRequired);
+  });
+
+  it('should warn if called manually in development', function() {
+    spyOn(console, 'error');
+    expectWarningInDevelopment(PropTypes.instanceOf(Date), {});
+    expectWarningInDevelopment(PropTypes.instanceOf(Date), new Date());
+    expectWarningInDevelopment(PropTypes.instanceOf(Date).isRequired, {});
+    expectWarningInDevelopment(PropTypes.instanceOf(Date).isRequired, new Date());
+  });
+
+});
+
+describe('React Component Types', function() {
+  beforeEach(function() {
+    MyComponent = class extends React.Component {
+      render() {
+        return <div />;
+      }
+    };
+  });
+
+  it('should warn for invalid values', function() {
+    var failMessage = 'Invalid prop `testProp` supplied to ' +
+      '`testComponent`, expected a ReactNode.';
+    typeCheckFail(PropTypes.node, true, failMessage);
+    typeCheckFail(PropTypes.node, function() {}, failMessage);
+    typeCheckFail(PropTypes.node, {key: function() {}}, failMessage);
+    typeCheckFail(PropTypes.node, {key: <div />}, failMessage);
+  });
+
+  it('should not warn for valid values', function() {
+    spyOn(console, 'error');
+    typeCheckPass(PropTypes.node, <div />);
+    typeCheckPass(PropTypes.node, false);
+    typeCheckPass(PropTypes.node, <MyComponent />);
+    typeCheckPass(PropTypes.node, 'Some string');
+    typeCheckPass(PropTypes.node, []);
+
+    typeCheckPass(PropTypes.node, [
+      123,
+      'Some string',
+      <div />,
+      ['Another string', [456], <span />, <MyComponent />],
+      <MyComponent />,
+    ]);
+
+    // Object of renderable things
+    var frag = ReactFragment.create;
+    typeCheckPass(PropTypes.node, frag({
+      k0: 123,
+      k1: 'Some string',
+      k2: <div />,
+      k3: frag({
+        k30: <MyComponent />,
+        k31: frag({k310: <a />}),
+        k32: 'Another string',
+      }),
+      k4: null,
+      k5: undefined,
+    }));
+    expect(console.error.calls.count()).toBe(0);
+  });
+
+  it('should not warn for iterables', function() {
+    var iterable = {
+      '@@iterator': function() {
+        var i = 0;
+        return {
+          next: function() {
+            var done = ++i > 2;
+            return {value: done ? undefined : <MyComponent />, done: done};
+          },
         };
+      },
+    };
 
-        render() {
-          return <div>{this.props.label}</div>;
+    typeCheckPass(PropTypes.node, iterable);
+  });
+
+  it('should not warn for entry iterables', function() {
+    var iterable = {
+      '@@iterator': function() {
+        var i = 0;
+        return {
+          next: function() {
+            var done = ++i > 2;
+            return {value: done ? undefined : ['#' + i, <MyComponent />], done: done};
+          },
+        };
+      },
+    };
+    iterable.entries = iterable['@@iterator'];
+
+    typeCheckPass(PropTypes.node, iterable);
+  });
+
+  it('should not warn for null/undefined if not required', function() {
+    typeCheckPass(PropTypes.node, null);
+    typeCheckPass(PropTypes.node, undefined);
+  });
+
+  it('should warn for missing required values', function() {
+    typeCheckFailRequiredValues(PropTypes.node.isRequired);
+  });
+
+  it('should accept empty array for required props', function() {
+    typeCheckPass(PropTypes.node.isRequired, []);
+  });
+
+  it('should warn if called manually in development', function() {
+    spyOn(console, 'error');
+    expectWarningInDevelopment(PropTypes.node, 'node');
+    expectWarningInDevelopment(PropTypes.node, {});
+    expectWarningInDevelopment(PropTypes.node.isRequired, 'node');
+    expectWarningInDevelopment(PropTypes.node.isRequired, undefined);
+    expectWarningInDevelopment(PropTypes.node.isRequired, undefined);
+  });
+
+});
+
+describe('ObjectOf Type', function() {
+  it('should fail for invalid argument', function() {
+    typeCheckFail(
+      PropTypes.objectOf({ foo: PropTypes.string }),
+      { foo: 'bar' },
+      'Property `testProp` of component `testComponent` has invalid PropType notation inside objectOf.'
+    );
+  });
+
+  it('should support the objectOf propTypes', function() {
+    typeCheckPass(PropTypes.objectOf(PropTypes.number), {a: 1, b: 2, c: 3});
+    typeCheckPass(
+      PropTypes.objectOf(PropTypes.string),
+      {a: 'a', b: 'b', c: 'c'}
+    );
+    typeCheckPass(
+      PropTypes.objectOf(PropTypes.oneOf(['a', 'b'])),
+      {a: 'a', b: 'b'}
+    );
+    typeCheckPass(
+      PropTypes.objectOf(PropTypes.symbol),
+      {a: Symbol(), b: Symbol(), c: Symbol()}
+    );
+  });
+
+  it('should support objectOf with complex types', function() {
+    typeCheckPass(
+      PropTypes.objectOf(PropTypes.shape({a: PropTypes.number.isRequired})),
+      {a: {a: 1}, b: {a: 2}}
+    );
+
+    function Thing() {}
+    typeCheckPass(
+      PropTypes.objectOf(PropTypes.instanceOf(Thing)),
+      {a: new Thing(), b: new Thing()}
+    );
+  });
+
+  it('should warn with invalid items in the object', function() {
+    typeCheckFail(
+      PropTypes.objectOf(PropTypes.number),
+      {a: 1, b: 2, c: 'b'},
+      'Invalid prop `testProp.c` of type `string` supplied to `testComponent`, ' +
+      'expected `number`.'
+    );
+  });
+
+  it('should warn with invalid complex types', function() {
+    function Thing() {}
+    var name = Thing.name || '<<anonymous>>';
+
+    typeCheckFail(
+      PropTypes.objectOf(PropTypes.instanceOf(Thing)),
+      {a: new Thing(), b: 'xyz'},
+      'Invalid prop `testProp.b` of type `String` supplied to ' +
+      '`testComponent`, expected instance of `' + name + '`.'
+    );
+  });
+
+  it('should warn when passed something other than an object', function() {
+    typeCheckFail(
+      PropTypes.objectOf(PropTypes.number),
+      [1, 2],
+      'Invalid prop `testProp` of type `array` supplied to ' +
+      '`testComponent`, expected an object.'
+    );
+    typeCheckFail(
+      PropTypes.objectOf(PropTypes.number),
+      123,
+      'Invalid prop `testProp` of type `number` supplied to ' +
+      '`testComponent`, expected an object.'
+    );
+    typeCheckFail(
+      PropTypes.objectOf(PropTypes.number),
+      'string',
+      'Invalid prop `testProp` of type `string` supplied to ' +
+      '`testComponent`, expected an object.'
+    );
+    typeCheckFail(
+      PropTypes.objectOf(PropTypes.symbol),
+      Symbol(),
+      'Invalid prop `testProp` of type `symbol` supplied to ' +
+      '`testComponent`, expected an object.'
+    );
+  });
+
+  it('should not warn when passing an empty object', function() {
+    typeCheckPass(PropTypes.objectOf(PropTypes.number), {});
+  });
+
+  it('should be implicitly optional and not warn without values', function() {
+    typeCheckPass(PropTypes.objectOf(PropTypes.number), null);
+    typeCheckPass(PropTypes.objectOf(PropTypes.number), undefined);
+  });
+
+  it('should warn for missing required values', function() {
+    typeCheckFailRequiredValues(
+      PropTypes.objectOf(PropTypes.number).isRequired
+    );
+  });
+
+  it('should warn if called manually in development', function() {
+    spyOn(console, 'error');
+    expectWarningInDevelopment(
+      PropTypes.objectOf({ foo: PropTypes.string }),
+      { foo: 'bar' }
+    );
+    expectWarningInDevelopment(
+      PropTypes.objectOf(PropTypes.number),
+      {a: 1, b: 2, c: 'b'}
+    );
+    expectWarningInDevelopment(PropTypes.objectOf(PropTypes.number), [1, 2]);
+    expectWarningInDevelopment(PropTypes.objectOf(PropTypes.number), null);
+    expectWarningInDevelopment(PropTypes.objectOf(PropTypes.number), undefined);
+  });
+});
+
+describe('OneOf Types', function() {
+  it('should warn but not error for invalid argument', function() {
+    spyOn(console, 'error');
+
+    PropTypes.oneOf('red', 'blue');
+
+    expect(console.error).toHaveBeenCalled();
+    expect(console.error.calls.argsFor(0)[0])
+      .toContain('Invalid argument supplied to oneOf, expected an instance of array.');
+
+    typeCheckPass(PropTypes.oneOf('red', 'blue'), 'red');
+  });
+
+  it('should warn for invalid values', function() {
+    typeCheckFail(
+      PropTypes.oneOf(['red', 'blue']),
+      true,
+      'Invalid prop `testProp` of value `true` supplied to ' +
+      '`testComponent`, expected one of ["red","blue"].'
+    );
+    typeCheckFail(
+      PropTypes.oneOf(['red', 'blue']),
+      [],
+      'Invalid prop `testProp` of value `` supplied to `testComponent`, ' +
+      'expected one of ["red","blue"].'
+    );
+    typeCheckFail(
+      PropTypes.oneOf(['red', 'blue']),
+      '',
+      'Invalid prop `testProp` of value `` supplied to `testComponent`, ' +
+      'expected one of ["red","blue"].'
+    );
+    typeCheckFail(
+      PropTypes.oneOf([0, 'false']),
+      false,
+      'Invalid prop `testProp` of value `false` supplied to ' +
+      '`testComponent`, expected one of [0,"false"].'
+    );
+  });
+
+  it('should not warn for valid values', function() {
+    typeCheckPass(PropTypes.oneOf(['red', 'blue']), 'red');
+    typeCheckPass(PropTypes.oneOf(['red', 'blue']), 'blue');
+    typeCheckPass(PropTypes.oneOf(['red', 'blue', NaN]), NaN);
+  });
+
+  it('should be implicitly optional and not warn without values', function() {
+    typeCheckPass(PropTypes.oneOf(['red', 'blue']), null);
+    typeCheckPass(PropTypes.oneOf(['red', 'blue']), undefined);
+  });
+
+  it('should warn for missing required values', function() {
+    typeCheckFailRequiredValues(PropTypes.oneOf(['red', 'blue']).isRequired);
+  });
+
+  it('should warn if called manually in development', function() {
+    spyOn(console, 'error');
+    expectWarningInDevelopment(PropTypes.oneOf(['red', 'blue']), true);
+    expectWarningInDevelopment(PropTypes.oneOf(['red', 'blue']), null);
+    expectWarningInDevelopment(PropTypes.oneOf(['red', 'blue']), undefined);
+  });
+});
+
+describe('Union Types', function() {
+  it('should warn but not error for invalid argument', function() {
+    spyOn(console, 'error');
+
+    PropTypes.oneOfType(PropTypes.string, PropTypes.number);
+
+    expect(console.error).toHaveBeenCalled();
+    expect(console.error.calls.argsFor(0)[0])
+      .toContain('Invalid argument supplied to oneOfType, expected an instance of array.');
+
+    typeCheckPass(PropTypes.oneOf(PropTypes.string, PropTypes.number), []);
+  });
+
+  it('should warn if none of the types are valid', function() {
+    typeCheckFail(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      [],
+      'Invalid prop `testProp` supplied to `testComponent`.'
+    );
+
+    var checker = PropTypes.oneOfType([
+      PropTypes.shape({a: PropTypes.number.isRequired}),
+      PropTypes.shape({b: PropTypes.number.isRequired}),
+    ]);
+    typeCheckFail(
+      checker,
+      {c: 1},
+      'Invalid prop `testProp` supplied to `testComponent`.'
+    );
+  });
+
+  it('should not warn if one of the types are valid', function() {
+    var checker = PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]);
+    typeCheckPass(checker, null);
+    typeCheckPass(checker, 'foo');
+    typeCheckPass(checker, 123);
+
+    checker = PropTypes.oneOfType([
+      PropTypes.shape({a: PropTypes.number.isRequired}),
+      PropTypes.shape({b: PropTypes.number.isRequired}),
+    ]);
+    typeCheckPass(checker, {a: 1});
+    typeCheckPass(checker, {b: 1});
+  });
+
+  it('should be implicitly optional and not warn without values', function() {
+    typeCheckPass(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number]), null
+    );
+    typeCheckPass(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number]), undefined
+    );
+  });
+
+  it('should warn for missing required values', function() {
+    typeCheckFailRequiredValues(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
+    );
+  });
+
+  it('should warn if called manually in development', function() {
+    spyOn(console, 'error');
+    expectWarningInDevelopment(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      []
+    );
+    expectWarningInDevelopment(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      null
+    );
+    expectWarningInDevelopment(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      undefined
+    );
+  });
+
+});
+
+describe('Shape Types', function() {
+  it('should warn for non objects', function() {
+    typeCheckFail(
+      PropTypes.shape({}),
+      'some string',
+      'Invalid prop `testProp` of type `string` supplied to ' +
+      '`testComponent`, expected `object`.'
+    );
+    typeCheckFail(
+      PropTypes.shape({}),
+      ['array'],
+      'Invalid prop `testProp` of type `array` supplied to ' +
+      '`testComponent`, expected `object`.'
+    );
+  });
+
+  it('should not warn for empty values', function() {
+    typeCheckPass(PropTypes.shape({}), undefined);
+    typeCheckPass(PropTypes.shape({}), null);
+    typeCheckPass(PropTypes.shape({}), {});
+  });
+
+  it('should not warn for an empty object', function() {
+    typeCheckPass(PropTypes.shape({}).isRequired, {});
+  });
+
+  it('should not warn for non specified types', function() {
+    typeCheckPass(PropTypes.shape({}), {key: 1});
+  });
+
+  it('should not warn for valid types', function() {
+    typeCheckPass(PropTypes.shape({key: PropTypes.number}), {key: 1});
+  });
+
+  it('should warn for required valid types', function() {
+    typeCheckFail(
+      PropTypes.shape({key: PropTypes.number.isRequired}),
+      {},
+      'The prop `testProp.key` is marked as required in `testComponent`, ' +
+        'but its value is `undefined`.'
+    );
+  });
+
+  it('should warn for the first required type', function() {
+    typeCheckFail(
+      PropTypes.shape({
+        key: PropTypes.number.isRequired,
+        secondKey: PropTypes.number.isRequired,
+      }),
+      {},
+      'The prop `testProp.key` is marked as required in `testComponent`, ' +
+        'but its value is `undefined`.'
+    );
+  });
+
+  it('should warn for invalid key types', function() {
+    typeCheckFail(PropTypes.shape({key: PropTypes.number}),
+      {key: 'abc'},
+      'Invalid prop `testProp.key` of type `string` supplied to `testComponent`, ' +
+      'expected `number`.'
+    );
+  });
+
+  it('should be implicitly optional and not warn without values', function() {
+    typeCheckPass(
+      PropTypes.shape(PropTypes.shape({key: PropTypes.number})), null
+    );
+    typeCheckPass(
+      PropTypes.shape(PropTypes.shape({key: PropTypes.number})), undefined
+    );
+  });
+
+  it('should warn for missing required values', function() {
+    typeCheckFailRequiredValues(
+      PropTypes.shape({key: PropTypes.number}).isRequired
+    );
+  });
+
+  it('should warn if called manually in development', function() {
+    spyOn(console, 'error');
+    expectWarningInDevelopment(PropTypes.shape({}), 'some string');
+    expectWarningInDevelopment(PropTypes.shape({ foo: PropTypes.number }), { foo: 42 });
+    expectWarningInDevelopment(
+      PropTypes.shape({key: PropTypes.number}).isRequired,
+      null
+    );
+    expectWarningInDevelopment(
+      PropTypes.shape({key: PropTypes.number}).isRequired,
+      undefined
+    );
+    expectWarningInDevelopment(PropTypes.element, <div />);
+  });
+});
+
+describe('Symbol Type', function() {
+  it('should warn for non-symbol', function() {
+    typeCheckFail(
+      PropTypes.symbol,
+      'hello',
+      'Invalid prop `testProp` of type `string` supplied to ' +
+      '`testComponent`, expected `symbol`.'
+    );
+    typeCheckFail(
+      PropTypes.symbol,
+      function() { },
+      'Invalid prop `testProp` of type `function` supplied to ' +
+      '`testComponent`, expected `symbol`.'
+    );
+    typeCheckFail(
+      PropTypes.symbol,
+      {
+        '@@toStringTag': 'Katana',
+      },
+      'Invalid prop `testProp` of type `object` supplied to ' +
+      '`testComponent`, expected `symbol`.'
+    );
+  });
+
+  it('should not warn for a polyfilled Symbol', function() {
+    var CoreSymbol = require('core-js/library/es6/symbol');
+    typeCheckPass(PropTypes.symbol, CoreSymbol('core-js'));
+  });
+});
+
+describe('Custom validator', function() {
+  beforeEach(function() {
+    jest.resetModuleRegistry();
+  });
+
+  it('should have been called with the right params', function() {
+    var spy = jasmine.createSpy();
+    Component = class extends React.Component {
+      static propTypes = {num: spy};
+
+      render() {
+        return <div />;
+      }
+    };
+
+    var instance = <Component num={5} />;
+    instance = ReactTestUtils.renderIntoDocument(instance);
+
+    expect(spy.calls.count()).toBe(1);
+    expect(spy.calls.argsFor(0)[1]).toBe('num');
+  });
+
+  it('should have been called even if the prop is not present', function() {
+    var spy = jasmine.createSpy();
+    Component = class extends React.Component {
+      static propTypes = {num: spy};
+
+      render() {
+        return <div />;
+      }
+    };
+
+    var instance = <Component bla={5} />;
+    instance = ReactTestUtils.renderIntoDocument(instance);
+
+    expect(spy.calls.count()).toBe(1);
+    expect(spy.calls.argsFor(0)[1]).toBe('num');
+  });
+
+  it('should have received the validator\'s return value', function() {
+    spyOn(console, 'error');
+    var spy = jasmine.createSpy().and.callFake(
+      function(props, propName, componentName) {
+        if (props[propName] !== 5) {
+          return new Error('num must be 5!');
         }
-      };
-    });
+      }
+    );
+    Component = class extends React.Component {
+      static propTypes = {num: spy};
 
-    it('should support components', () => {
-      typeCheckPass(PropTypes.element, <div />);
-    });
+      render() {
+        return <div />;
+      }
+    };
 
-    it('should not support multiple components or scalar values', () => {
-      typeCheckFail(
-        PropTypes.element,
-        [<div />, <div />],
-        'Invalid prop `testProp` of type `array` supplied to `testComponent`, ' +
-        'expected a single ReactElement.'
-      );
-      typeCheckFail(
-        PropTypes.element,
-        123,
-        'Invalid prop `testProp` of type `number` supplied to `testComponent`, ' +
-        'expected a single ReactElement.'
-      );
-      typeCheckFail(
-        PropTypes.element,
-        'foo',
-        'Invalid prop `testProp` of type `string` supplied to `testComponent`, ' +
-        'expected a single ReactElement.'
-      );
-      typeCheckFail(
-        PropTypes.element,
-        false,
-        'Invalid prop `testProp` of type `boolean` supplied to `testComponent`, ' +
-        'expected a single ReactElement.'
-      );
-    });
-
-    it('should be able to define a single child as label', () => {
-      spyOn(console, 'error');
-
-      var instance = <Component label={<div />} />;
-      instance = ReactTestUtils.renderIntoDocument(instance);
-
-      expect(console.error.calls.count()).toBe(0);
-    });
-
-    it('should warn when passing no label and isRequired is set', () => {
-      spyOn(console, 'error');
-
-      var instance = <Component />;
-      instance = ReactTestUtils.renderIntoDocument(instance);
-
-      expect(console.error.calls.count()).toBe(1);
-    });
-
-    it('should be implicitly optional and not warn without values', function() {
-      typeCheckPass(PropTypes.element, null);
-      typeCheckPass(PropTypes.element, undefined);
-    });
-
-    it('should warn for missing required values', function() {
-      typeCheckFailRequiredValues(PropTypes.element.isRequired);
-    });
-
-    it('should warn if called manually in development', function() {
-      spyOn(console, 'error');
-      expectWarningInDevelopment(PropTypes.element, [<div />, <div />]);
-      expectWarningInDevelopment(PropTypes.element, <div />);
-      expectWarningInDevelopment(PropTypes.element, 123);
-      expectWarningInDevelopment(PropTypes.element, 'foo');
-      expectWarningInDevelopment(PropTypes.element, false);
-      expectWarningInDevelopment(PropTypes.element.isRequired, null);
-      expectWarningInDevelopment(PropTypes.element.isRequired, undefined);
-    });
-
+    var instance = <Component num={6} />;
+    instance = ReactTestUtils.renderIntoDocument(instance);
+    expect(console.error.calls.count()).toBe(1);
+    expect(
+      console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
+    ).toBe(
+      'Warning: Failed prop type: num must be 5!\n' +
+      '    in Component (at **)'
+    );
   });
 
-  describe('Instance Types', function() {
-    it('should warn for invalid instances', function() {
-      function Person() {}
-      function Cat() {}
-      var personName = Person.name || '<<anonymous>>';
-      var dateName = Date.name || '<<anonymous>>';
-      var regExpName = RegExp.name || '<<anonymous>>';
-
-      typeCheckFail(
-        PropTypes.instanceOf(Person),
-        false,
-        'Invalid prop `testProp` of type `Boolean` supplied to ' +
-        '`testComponent`, expected instance of `' + personName + '`.'
-      );
-      typeCheckFail(
-        PropTypes.instanceOf(Person),
-        {},
-        'Invalid prop `testProp` of type `Object` supplied to ' +
-        '`testComponent`, expected instance of `' + personName + '`.'
-      );
-      typeCheckFail(
-        PropTypes.instanceOf(Person),
-        '',
-        'Invalid prop `testProp` of type `String` supplied to ' +
-        '`testComponent`, expected instance of `' + personName + '`.'
-      );
-      typeCheckFail(
-        PropTypes.instanceOf(Date),
-        {},
-        'Invalid prop `testProp` of type `Object` supplied to ' +
-        '`testComponent`, expected instance of `' + dateName + '`.'
-      );
-      typeCheckFail(
-        PropTypes.instanceOf(RegExp),
-        {},
-        'Invalid prop `testProp` of type `Object` supplied to ' +
-        '`testComponent`, expected instance of `' + regExpName + '`.'
-      );
-      typeCheckFail(
-        PropTypes.instanceOf(Person),
-        new Cat(),
-        'Invalid prop `testProp` of type `Cat` supplied to ' +
-        '`testComponent`, expected instance of `' + personName + '`.'
-      );
-      typeCheckFail(
-        PropTypes.instanceOf(Person),
-        Object.create(null),
-        'Invalid prop `testProp` of type `<<anonymous>>` supplied to ' +
-        '`testComponent`, expected instance of `' + personName + '`.'
-      );
-    });
-
-    it('should not warn for valid values', function() {
-      function Person() {}
-      function Engineer() {}
-      Engineer.prototype = new Person();
-
-      typeCheckPass(PropTypes.instanceOf(Person), new Person());
-      typeCheckPass(PropTypes.instanceOf(Person), new Engineer());
-
-      typeCheckPass(PropTypes.instanceOf(Date), new Date());
-      typeCheckPass(PropTypes.instanceOf(RegExp), /please/);
-    });
-
-    it('should be implicitly optional and not warn without values', function() {
-      typeCheckPass(PropTypes.instanceOf(String), null);
-      typeCheckPass(PropTypes.instanceOf(String), undefined);
-    });
-
-    it('should warn for missing required values', function() {
-      typeCheckFailRequiredValues(PropTypes.instanceOf(String).isRequired);
-    });
-
-    it('should warn if called manually in development', function() {
+  it('should not warn if the validator returned null',
+    function() {
       spyOn(console, 'error');
-      expectWarningInDevelopment(PropTypes.instanceOf(Date), {});
-      expectWarningInDevelopment(PropTypes.instanceOf(Date), new Date());
-      expectWarningInDevelopment(PropTypes.instanceOf(Date).isRequired, {});
-      expectWarningInDevelopment(PropTypes.instanceOf(Date).isRequired, new Date());
-    });
-
-  });
-
-  describe('React Component Types', function() {
-    beforeEach(function() {
-      MyComponent = class extends React.Component {
-        render() {
-          return <div />;
+      var spy = jasmine.createSpy().and.callFake(
+        function(props, propName, componentName) {
+          return null;
         }
-      };
-    });
-
-    it('should warn for invalid values', function() {
-      var failMessage = 'Invalid prop `testProp` supplied to ' +
-        '`testComponent`, expected a ReactNode.';
-      typeCheckFail(PropTypes.node, true, failMessage);
-      typeCheckFail(PropTypes.node, function() {}, failMessage);
-      typeCheckFail(PropTypes.node, {key: function() {}}, failMessage);
-      typeCheckFail(PropTypes.node, {key: <div />}, failMessage);
-    });
-
-    it('should not warn for valid values', function() {
-      spyOn(console, 'error');
-      typeCheckPass(PropTypes.node, <div />);
-      typeCheckPass(PropTypes.node, false);
-      typeCheckPass(PropTypes.node, <MyComponent />);
-      typeCheckPass(PropTypes.node, 'Some string');
-      typeCheckPass(PropTypes.node, []);
-
-      typeCheckPass(PropTypes.node, [
-        123,
-        'Some string',
-        <div />,
-        ['Another string', [456], <span />, <MyComponent />],
-        <MyComponent />,
-      ]);
-
-      // Object of renderable things
-      var frag = ReactFragment.create;
-      typeCheckPass(PropTypes.node, frag({
-        k0: 123,
-        k1: 'Some string',
-        k2: <div />,
-        k3: frag({
-          k30: <MyComponent />,
-          k31: frag({k310: <a />}),
-          k32: 'Another string',
-        }),
-        k4: null,
-        k5: undefined,
-      }));
-      expect(console.error.calls.count()).toBe(0);
-    });
-
-    it('should not warn for iterables', function() {
-      var iterable = {
-        '@@iterator': function() {
-          var i = 0;
-          return {
-            next: function() {
-              var done = ++i > 2;
-              return {value: done ? undefined : <MyComponent />, done: done};
-            },
-          };
-        },
-      };
-
-      typeCheckPass(PropTypes.node, iterable);
-    });
-
-    it('should not warn for entry iterables', function() {
-      var iterable = {
-        '@@iterator': function() {
-          var i = 0;
-          return {
-            next: function() {
-              var done = ++i > 2;
-              return {value: done ? undefined : ['#' + i, <MyComponent />], done: done};
-            },
-          };
-        },
-      };
-      iterable.entries = iterable['@@iterator'];
-
-      typeCheckPass(PropTypes.node, iterable);
-    });
-
-    it('should not warn for null/undefined if not required', function() {
-      typeCheckPass(PropTypes.node, null);
-      typeCheckPass(PropTypes.node, undefined);
-    });
-
-    it('should warn for missing required values', function() {
-      typeCheckFailRequiredValues(PropTypes.node.isRequired);
-    });
-
-    it('should accept empty array for required props', function() {
-      typeCheckPass(PropTypes.node.isRequired, []);
-    });
-
-    it('should warn if called manually in development', function() {
-      spyOn(console, 'error');
-      expectWarningInDevelopment(PropTypes.node, 'node');
-      expectWarningInDevelopment(PropTypes.node, {});
-      expectWarningInDevelopment(PropTypes.node.isRequired, 'node');
-      expectWarningInDevelopment(PropTypes.node.isRequired, undefined);
-      expectWarningInDevelopment(PropTypes.node.isRequired, undefined);
-    });
-
-  });
-
-  describe('ObjectOf Type', function() {
-    it('should fail for invalid argument', function() {
-      typeCheckFail(
-        PropTypes.objectOf({ foo: PropTypes.string }),
-        { foo: 'bar' },
-        'Property `testProp` of component `testComponent` has invalid PropType notation inside objectOf.'
       );
-    });
-
-    it('should support the objectOf propTypes', function() {
-      typeCheckPass(PropTypes.objectOf(PropTypes.number), {a: 1, b: 2, c: 3});
-      typeCheckPass(
-        PropTypes.objectOf(PropTypes.string),
-        {a: 'a', b: 'b', c: 'c'}
-      );
-      typeCheckPass(
-        PropTypes.objectOf(PropTypes.oneOf(['a', 'b'])),
-        {a: 'a', b: 'b'}
-      );
-      typeCheckPass(
-        PropTypes.objectOf(PropTypes.symbol),
-        {a: Symbol(), b: Symbol(), c: Symbol()}
-      );
-    });
-
-    it('should support objectOf with complex types', function() {
-      typeCheckPass(
-        PropTypes.objectOf(PropTypes.shape({a: PropTypes.number.isRequired})),
-        {a: {a: 1}, b: {a: 2}}
-      );
-
-      function Thing() {}
-      typeCheckPass(
-        PropTypes.objectOf(PropTypes.instanceOf(Thing)),
-        {a: new Thing(), b: new Thing()}
-      );
-    });
-
-    it('should warn with invalid items in the object', function() {
-      typeCheckFail(
-        PropTypes.objectOf(PropTypes.number),
-        {a: 1, b: 2, c: 'b'},
-        'Invalid prop `testProp.c` of type `string` supplied to `testComponent`, ' +
-        'expected `number`.'
-      );
-    });
-
-    it('should warn with invalid complex types', function() {
-      function Thing() {}
-      var name = Thing.name || '<<anonymous>>';
-
-      typeCheckFail(
-        PropTypes.objectOf(PropTypes.instanceOf(Thing)),
-        {a: new Thing(), b: 'xyz'},
-        'Invalid prop `testProp.b` of type `String` supplied to ' +
-        '`testComponent`, expected instance of `' + name + '`.'
-      );
-    });
-
-    it('should warn when passed something other than an object', function() {
-      typeCheckFail(
-        PropTypes.objectOf(PropTypes.number),
-        [1, 2],
-        'Invalid prop `testProp` of type `array` supplied to ' +
-        '`testComponent`, expected an object.'
-      );
-      typeCheckFail(
-        PropTypes.objectOf(PropTypes.number),
-        123,
-        'Invalid prop `testProp` of type `number` supplied to ' +
-        '`testComponent`, expected an object.'
-      );
-      typeCheckFail(
-        PropTypes.objectOf(PropTypes.number),
-        'string',
-        'Invalid prop `testProp` of type `string` supplied to ' +
-        '`testComponent`, expected an object.'
-      );
-      typeCheckFail(
-        PropTypes.objectOf(PropTypes.symbol),
-        Symbol(),
-        'Invalid prop `testProp` of type `symbol` supplied to ' +
-        '`testComponent`, expected an object.'
-      );
-    });
-
-    it('should not warn when passing an empty object', function() {
-      typeCheckPass(PropTypes.objectOf(PropTypes.number), {});
-    });
-
-    it('should be implicitly optional and not warn without values', function() {
-      typeCheckPass(PropTypes.objectOf(PropTypes.number), null);
-      typeCheckPass(PropTypes.objectOf(PropTypes.number), undefined);
-    });
-
-    it('should warn for missing required values', function() {
-      typeCheckFailRequiredValues(
-        PropTypes.objectOf(PropTypes.number).isRequired
-      );
-    });
-
-    it('should warn if called manually in development', function() {
-      spyOn(console, 'error');
-      expectWarningInDevelopment(
-        PropTypes.objectOf({ foo: PropTypes.string }),
-        { foo: 'bar' }
-      );
-      expectWarningInDevelopment(
-        PropTypes.objectOf(PropTypes.number),
-        {a: 1, b: 2, c: 'b'}
-      );
-      expectWarningInDevelopment(PropTypes.objectOf(PropTypes.number), [1, 2]);
-      expectWarningInDevelopment(PropTypes.objectOf(PropTypes.number), null);
-      expectWarningInDevelopment(PropTypes.objectOf(PropTypes.number), undefined);
-    });
-  });
-
-  describe('OneOf Types', function() {
-    it('should warn but not error for invalid argument', function() {
-      spyOn(console, 'error');
-
-      PropTypes.oneOf('red', 'blue');
-
-      expect(console.error).toHaveBeenCalled();
-      expect(console.error.calls.argsFor(0)[0])
-        .toContain('Invalid argument supplied to oneOf, expected an instance of array.');
-
-      typeCheckPass(PropTypes.oneOf('red', 'blue'), 'red');
-    });
-
-    it('should warn for invalid values', function() {
-      typeCheckFail(
-        PropTypes.oneOf(['red', 'blue']),
-        true,
-        'Invalid prop `testProp` of value `true` supplied to ' +
-        '`testComponent`, expected one of ["red","blue"].'
-      );
-      typeCheckFail(
-        PropTypes.oneOf(['red', 'blue']),
-        [],
-        'Invalid prop `testProp` of value `` supplied to `testComponent`, ' +
-        'expected one of ["red","blue"].'
-      );
-      typeCheckFail(
-        PropTypes.oneOf(['red', 'blue']),
-        '',
-        'Invalid prop `testProp` of value `` supplied to `testComponent`, ' +
-        'expected one of ["red","blue"].'
-      );
-      typeCheckFail(
-        PropTypes.oneOf([0, 'false']),
-        false,
-        'Invalid prop `testProp` of value `false` supplied to ' +
-        '`testComponent`, expected one of [0,"false"].'
-      );
-    });
-
-    it('should not warn for valid values', function() {
-      typeCheckPass(PropTypes.oneOf(['red', 'blue']), 'red');
-      typeCheckPass(PropTypes.oneOf(['red', 'blue']), 'blue');
-      typeCheckPass(PropTypes.oneOf(['red', 'blue', NaN]), NaN);
-    });
-
-    it('should be implicitly optional and not warn without values', function() {
-      typeCheckPass(PropTypes.oneOf(['red', 'blue']), null);
-      typeCheckPass(PropTypes.oneOf(['red', 'blue']), undefined);
-    });
-
-    it('should warn for missing required values', function() {
-      typeCheckFailRequiredValues(PropTypes.oneOf(['red', 'blue']).isRequired);
-    });
-
-    it('should warn if called manually in development', function() {
-      spyOn(console, 'error');
-      expectWarningInDevelopment(PropTypes.oneOf(['red', 'blue']), true);
-      expectWarningInDevelopment(PropTypes.oneOf(['red', 'blue']), null);
-      expectWarningInDevelopment(PropTypes.oneOf(['red', 'blue']), undefined);
-    });
-  });
-
-  describe('Union Types', function() {
-    it('should warn but not error for invalid argument', function() {
-      spyOn(console, 'error');
-
-      PropTypes.oneOfType(PropTypes.string, PropTypes.number);
-
-      expect(console.error).toHaveBeenCalled();
-      expect(console.error.calls.argsFor(0)[0])
-        .toContain('Invalid argument supplied to oneOfType, expected an instance of array.');
-
-      typeCheckPass(PropTypes.oneOf(PropTypes.string, PropTypes.number), []);
-    });
-
-    it('should warn if none of the types are valid', function() {
-      typeCheckFail(
-        PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-        [],
-        'Invalid prop `testProp` supplied to `testComponent`.'
-      );
-
-      var checker = PropTypes.oneOfType([
-        PropTypes.shape({a: PropTypes.number.isRequired}),
-        PropTypes.shape({b: PropTypes.number.isRequired}),
-      ]);
-      typeCheckFail(
-        checker,
-        {c: 1},
-        'Invalid prop `testProp` supplied to `testComponent`.'
-      );
-    });
-
-    it('should not warn if one of the types are valid', function() {
-      var checker = PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.number,
-      ]);
-      typeCheckPass(checker, null);
-      typeCheckPass(checker, 'foo');
-      typeCheckPass(checker, 123);
-
-      checker = PropTypes.oneOfType([
-        PropTypes.shape({a: PropTypes.number.isRequired}),
-        PropTypes.shape({b: PropTypes.number.isRequired}),
-      ]);
-      typeCheckPass(checker, {a: 1});
-      typeCheckPass(checker, {b: 1});
-    });
-
-    it('should be implicitly optional and not warn without values', function() {
-      typeCheckPass(
-        PropTypes.oneOfType([PropTypes.string, PropTypes.number]), null
-      );
-      typeCheckPass(
-        PropTypes.oneOfType([PropTypes.string, PropTypes.number]), undefined
-      );
-    });
-
-    it('should warn for missing required values', function() {
-      typeCheckFailRequiredValues(
-        PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
-      );
-    });
-
-    it('should warn if called manually in development', function() {
-      spyOn(console, 'error');
-      expectWarningInDevelopment(
-        PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-        []
-      );
-      expectWarningInDevelopment(
-        PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-        null
-      );
-      expectWarningInDevelopment(
-        PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-        undefined
-      );
-    });
-
-  });
-
-  describe('Shape Types', function() {
-    it('should warn for non objects', function() {
-      typeCheckFail(
-        PropTypes.shape({}),
-        'some string',
-        'Invalid prop `testProp` of type `string` supplied to ' +
-        '`testComponent`, expected `object`.'
-      );
-      typeCheckFail(
-        PropTypes.shape({}),
-        ['array'],
-        'Invalid prop `testProp` of type `array` supplied to ' +
-        '`testComponent`, expected `object`.'
-      );
-    });
-
-    it('should not warn for empty values', function() {
-      typeCheckPass(PropTypes.shape({}), undefined);
-      typeCheckPass(PropTypes.shape({}), null);
-      typeCheckPass(PropTypes.shape({}), {});
-    });
-
-    it('should not warn for an empty object', function() {
-      typeCheckPass(PropTypes.shape({}).isRequired, {});
-    });
-
-    it('should not warn for non specified types', function() {
-      typeCheckPass(PropTypes.shape({}), {key: 1});
-    });
-
-    it('should not warn for valid types', function() {
-      typeCheckPass(PropTypes.shape({key: PropTypes.number}), {key: 1});
-    });
-
-    it('should warn for required valid types', function() {
-      typeCheckFail(
-        PropTypes.shape({key: PropTypes.number.isRequired}),
-        {},
-        'The prop `testProp.key` is marked as required in `testComponent`, ' +
-          'but its value is `undefined`.'
-      );
-    });
-
-    it('should warn for the first required type', function() {
-      typeCheckFail(
-        PropTypes.shape({
-          key: PropTypes.number.isRequired,
-          secondKey: PropTypes.number.isRequired,
-        }),
-        {},
-        'The prop `testProp.key` is marked as required in `testComponent`, ' +
-          'but its value is `undefined`.'
-      );
-    });
-
-    it('should warn for invalid key types', function() {
-      typeCheckFail(PropTypes.shape({key: PropTypes.number}),
-        {key: 'abc'},
-        'Invalid prop `testProp.key` of type `string` supplied to `testComponent`, ' +
-        'expected `number`.'
-      );
-    });
-
-    it('should be implicitly optional and not warn without values', function() {
-      typeCheckPass(
-        PropTypes.shape(PropTypes.shape({key: PropTypes.number})), null
-      );
-      typeCheckPass(
-        PropTypes.shape(PropTypes.shape({key: PropTypes.number})), undefined
-      );
-    });
-
-    it('should warn for missing required values', function() {
-      typeCheckFailRequiredValues(
-        PropTypes.shape({key: PropTypes.number}).isRequired
-      );
-    });
-
-    it('should warn if called manually in development', function() {
-      spyOn(console, 'error');
-      expectWarningInDevelopment(PropTypes.shape({}), 'some string');
-      expectWarningInDevelopment(PropTypes.shape({ foo: PropTypes.number }), { foo: 42 });
-      expectWarningInDevelopment(
-        PropTypes.shape({key: PropTypes.number}).isRequired,
-        null
-      );
-      expectWarningInDevelopment(
-        PropTypes.shape({key: PropTypes.number}).isRequired,
-        undefined
-      );
-      expectWarningInDevelopment(PropTypes.element, <div />);
-    });
-  });
-
-  describe('Symbol Type', function() {
-    it('should warn for non-symbol', function() {
-      typeCheckFail(
-        PropTypes.symbol,
-        'hello',
-        'Invalid prop `testProp` of type `string` supplied to ' +
-        '`testComponent`, expected `symbol`.'
-      );
-      typeCheckFail(
-        PropTypes.symbol,
-        function() { },
-        'Invalid prop `testProp` of type `function` supplied to ' +
-        '`testComponent`, expected `symbol`.'
-      );
-      typeCheckFail(
-        PropTypes.symbol,
-        {
-          '@@toStringTag': 'Katana',
-        },
-        'Invalid prop `testProp` of type `object` supplied to ' +
-        '`testComponent`, expected `symbol`.'
-      );
-    });
-
-    it('should not warn for a polyfilled Symbol', function() {
-      var CoreSymbol = require('core-js/library/es6/symbol');
-      typeCheckPass(PropTypes.symbol, CoreSymbol('core-js'));
-    });
-  });
-
-  describe('Custom validator', function() {
-    beforeEach(function() {
-      jest.resetModuleRegistry();
-    });
-
-    it('should have been called with the right params', function() {
-      var spy = jasmine.createSpy();
       Component = class extends React.Component {
         static propTypes = {num: spy};
 
@@ -1039,76 +1106,7 @@ describe('ReactPropTypes', function() {
 
       var instance = <Component num={5} />;
       instance = ReactTestUtils.renderIntoDocument(instance);
-
-      expect(spy.calls.count()).toBe(1);
-      expect(spy.calls.argsFor(0)[1]).toBe('num');
-    });
-
-    it('should have been called even if the prop is not present', function() {
-      var spy = jasmine.createSpy();
-      Component = class extends React.Component {
-        static propTypes = {num: spy};
-
-        render() {
-          return <div />;
-        }
-      };
-
-      var instance = <Component bla={5} />;
-      instance = ReactTestUtils.renderIntoDocument(instance);
-
-      expect(spy.calls.count()).toBe(1);
-      expect(spy.calls.argsFor(0)[1]).toBe('num');
-    });
-
-    it('should have received the validator\'s return value', function() {
-      spyOn(console, 'error');
-      var spy = jasmine.createSpy().and.callFake(
-        function(props, propName, componentName) {
-          if (props[propName] !== 5) {
-            return new Error('num must be 5!');
-          }
-        }
-      );
-      Component = class extends React.Component {
-        static propTypes = {num: spy};
-
-        render() {
-          return <div />;
-        }
-      };
-
-      var instance = <Component num={6} />;
-      instance = ReactTestUtils.renderIntoDocument(instance);
-      expect(console.error.calls.count()).toBe(1);
-      expect(
-        console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
-      ).toBe(
-        'Warning: Failed prop type: num must be 5!\n' +
-        '    in Component (at **)'
-      );
-    });
-
-    it('should not warn if the validator returned null',
-      function() {
-        spyOn(console, 'error');
-        var spy = jasmine.createSpy().and.callFake(
-          function(props, propName, componentName) {
-            return null;
-          }
-        );
-        Component = class extends React.Component {
-          static propTypes = {num: spy};
-
-          render() {
-            return <div />;
-          }
-        };
-
-        var instance = <Component num={5} />;
-        instance = ReactTestUtils.renderIntoDocument(instance);
-        expect(console.error.calls.count()).toBe(0);
-      }
-    );
-  });
+      expect(console.error.calls.count()).toBe(0);
+    }
+  );
 });

--- a/src/isomorphic/modern/class/__tests__/ReactClassEquivalence-test.js
+++ b/src/isomorphic/modern/class/__tests__/ReactClassEquivalence-test.js
@@ -14,19 +14,16 @@
 var spawnSync = require('child_process').spawnSync;
 var path = require('path');
 
-describe('ReactClassEquivalence', function() {
-  it('tests the same thing for es6 classes and CoffeeScript', function() {
-    var result1 = runJest('ReactCoffeeScriptClass-test.coffee');
-    var result2 = runJest('ReactES6Class-test.js');
-    compareResults(result1, result2);
-  });
+it('tests the same thing for es6 classes and CoffeeScript', function() {
+  var result1 = runJest('ReactCoffeeScriptClass-test.coffee');
+  var result2 = runJest('ReactES6Class-test.js');
+  compareResults(result1, result2);
+});
 
-  it('tests the same thing for es6 classes and TypeScript', function() {
-    var result1 = runJest('ReactTypeScriptClass-test.ts');
-    var result2 = runJest('ReactES6Class-test.js');
-    compareResults(result1, result2);
-  });
-
+it('tests the same thing for es6 classes and TypeScript', function() {
+  var result1 = runJest('ReactTypeScriptClass-test.ts');
+  var result2 = runJest('ReactES6Class-test.js');
+  compareResults(result1, result2);
 });
 
 function runJest(testFile) {

--- a/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
+++ b/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
@@ -14,436 +14,432 @@
 var React;
 var ReactDOM;
 
-describe('ReactES6Class', function() {
+var container;
+var freeze = function(expectation) {
+  Object.freeze(expectation);
+  return expectation;
+};
+var Inner;
+var attachedListener = null;
+var renderedName = null;
 
-  var container;
-  var freeze = function(expectation) {
-    Object.freeze(expectation);
-    return expectation;
+beforeEach(function() {
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  container = document.createElement('div');
+  attachedListener = null;
+  renderedName = null;
+  Inner = class extends React.Component {
+    getName() {
+      return this.props.name;
+    }
+    render() {
+      attachedListener = this.props.onClick;
+      renderedName = this.props.name;
+      return <div className={this.props.name} />;
+    }
   };
-  var Inner;
-  var attachedListener = null;
-  var renderedName = null;
+});
 
-  beforeEach(function() {
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    container = document.createElement('div');
-    attachedListener = null;
-    renderedName = null;
-    Inner = class extends React.Component {
-      getName() {
-        return this.props.name;
-      }
-      render() {
-        attachedListener = this.props.onClick;
-        renderedName = this.props.name;
-        return <div className={this.props.name} />;
-      }
-    };
-  });
+function test(element, expectedTag, expectedClassName) {
+  var instance = ReactDOM.render(element, container);
+  expect(container.firstChild).not.toBeNull();
+  expect(container.firstChild.tagName).toBe(expectedTag);
+  expect(container.firstChild.className).toBe(expectedClassName);
+  return instance;
+}
 
-  function test(element, expectedTag, expectedClassName) {
-    var instance = ReactDOM.render(element, container);
-    expect(container.firstChild).not.toBeNull();
-    expect(container.firstChild.tagName).toBe(expectedTag);
-    expect(container.firstChild.className).toBe(expectedClassName);
-    return instance;
+it('preserves the name of the class for use in error messages', function() {
+  class Foo extends React.Component { }
+  expect(Foo.name).toBe('Foo');
+});
+
+it('throws if no render function is defined', function() {
+  spyOn(console, 'error');
+  class Foo extends React.Component { }
+  expect(() => ReactDOM.render(<Foo />, container)).toThrow();
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: Foo(...): No `render` method found on the returned component ' +
+    'instance: you may have forgotten to define `render`.'
+  );
+});
+
+it('renders a simple stateless component with prop', function() {
+  class Foo extends React.Component {
+    render() {
+      return <Inner name={this.props.bar} />;
+    }
   }
+  test(<Foo bar="foo" />, 'DIV', 'foo');
+  test(<Foo bar="bar" />, 'DIV', 'bar');
+});
 
-  it('preserves the name of the class for use in error messages', function() {
-    class Foo extends React.Component { }
-    expect(Foo.name).toBe('Foo');
-  });
-
-  it('throws if no render function is defined', function() {
-    spyOn(console, 'error');
-    class Foo extends React.Component { }
-    expect(() => ReactDOM.render(<Foo />, container)).toThrow();
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: Foo(...): No `render` method found on the returned component ' +
-      'instance: you may have forgotten to define `render`.'
-    );
-  });
-
-  it('renders a simple stateless component with prop', function() {
-    class Foo extends React.Component {
-      render() {
-        return <Inner name={this.props.bar} />;
-      }
+it('renders based on state using initial values in this.props', function() {
+  class Foo extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {bar: this.props.initialValue};
     }
-    test(<Foo bar="foo" />, 'DIV', 'foo');
-    test(<Foo bar="bar" />, 'DIV', 'bar');
-  });
-
-  it('renders based on state using initial values in this.props', function() {
-    class Foo extends React.Component {
-      constructor(props) {
-        super(props);
-        this.state = {bar: this.props.initialValue};
-      }
-      render() {
-        return <span className={this.state.bar} />;
-      }
+    render() {
+      return <span className={this.state.bar} />;
     }
-    test(<Foo initialValue="foo" />, 'SPAN', 'foo');
-  });
+  }
+  test(<Foo initialValue="foo" />, 'SPAN', 'foo');
+});
 
-  it('renders based on state using props in the constructor', function() {
-    class Foo extends React.Component {
-      constructor(props) {
-        super(props);
-        this.state = {bar: props.initialValue};
-      }
-      changeState() {
-        this.setState({bar: 'bar'});
-      }
-      render() {
-        if (this.state.bar === 'foo') {
-          return <div className="foo" />;
-        }
-        return <span className={this.state.bar} />;
-      }
+it('renders based on state using props in the constructor', function() {
+  class Foo extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {bar: props.initialValue};
     }
-    var instance = test(<Foo initialValue="foo" />, 'DIV', 'foo');
-    instance.changeState();
-    test(<Foo />, 'SPAN', 'bar');
-  });
-
-  it('renders based on context in the constructor', function() {
-    class Foo extends React.Component {
-      constructor(props, context) {
-        super(props, context);
-        this.state = {tag: context.tag, className: this.context.className};
-      }
-      render() {
-        var Tag = this.state.tag;
-        return <Tag className={this.state.className} />;
-      }
+    changeState() {
+      this.setState({bar: 'bar'});
     }
-    Foo.contextTypes = {
-      tag: React.PropTypes.string,
-      className: React.PropTypes.string,
-    };
-
-    class Outer extends React.Component {
-      getChildContext() {
-        return {tag: 'span', className: 'foo'};
+    render() {
+      if (this.state.bar === 'foo') {
+        return <div className="foo" />;
       }
-      render() {
-        return <Foo />;
-      }
+      return <span className={this.state.bar} />;
     }
-    Outer.childContextTypes = {
-      tag: React.PropTypes.string,
-      className: React.PropTypes.string,
-    };
-    test(<Outer />, 'SPAN', 'foo');
-  });
+  }
+  var instance = test(<Foo initialValue="foo" />, 'DIV', 'foo');
+  instance.changeState();
+  test(<Foo />, 'SPAN', 'bar');
+});
 
-  it('renders only once when setting state in componentWillMount', function() {
-    var renderCount = 0;
-    class Foo extends React.Component {
-      constructor(props) {
-        super(props);
-        this.state = {bar: props.initialValue};
-      }
-      componentWillMount() {
-        this.setState({bar: 'bar'});
-      }
-      render() {
-        renderCount++;
-        return <span className={this.state.bar} />;
-      }
+it('renders based on context in the constructor', function() {
+  class Foo extends React.Component {
+    constructor(props, context) {
+      super(props, context);
+      this.state = {tag: context.tag, className: this.context.className};
     }
-    test(<Foo initialValue="foo" />, 'SPAN', 'bar');
-    expect(renderCount).toBe(1);
-  });
+    render() {
+      var Tag = this.state.tag;
+      return <Tag className={this.state.className} />;
+    }
+  }
+  Foo.contextTypes = {
+    tag: React.PropTypes.string,
+    className: React.PropTypes.string,
+  };
 
-  it('should throw with non-object in the initial state property', function() {
-    [['an array'], 'a string', 1234].forEach(function(state) {
-      class Foo extends React.Component {
-        constructor() {
-          super();
-          this.state = state;
-        }
-        render() {
-          return <span />;
-        }
-      }
-      expect(() => test(<Foo />, 'span', '')).toThrowError(
-        'Foo.state: must be set to an object or null'
-      );
-    });
-  });
+  class Outer extends React.Component {
+    getChildContext() {
+      return {tag: 'span', className: 'foo'};
+    }
+    render() {
+      return <Foo />;
+    }
+  }
+  Outer.childContextTypes = {
+    tag: React.PropTypes.string,
+    className: React.PropTypes.string,
+  };
+  test(<Outer />, 'SPAN', 'foo');
+});
 
-  it('should render with null in the initial state property', function() {
+it('renders only once when setting state in componentWillMount', function() {
+  var renderCount = 0;
+  class Foo extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {bar: props.initialValue};
+    }
+    componentWillMount() {
+      this.setState({bar: 'bar'});
+    }
+    render() {
+      renderCount++;
+      return <span className={this.state.bar} />;
+    }
+  }
+  test(<Foo initialValue="foo" />, 'SPAN', 'bar');
+  expect(renderCount).toBe(1);
+});
+
+it('should throw with non-object in the initial state property', function() {
+  [['an array'], 'a string', 1234].forEach(function(state) {
     class Foo extends React.Component {
       constructor() {
         super();
-        this.state = null;
+        this.state = state;
       }
       render() {
         return <span />;
       }
     }
-    test(<Foo />, 'SPAN', '');
-  });
-
-  it('setState through an event handler', function() {
-    class Foo extends React.Component {
-      constructor(props) {
-        super(props);
-        this.state = {bar: props.initialValue};
-      }
-      handleClick() {
-        this.setState({bar: 'bar'});
-      }
-      render() {
-        return (
-          <Inner
-            name={this.state.bar}
-            onClick={this.handleClick.bind(this)}
-          />
-        );
-      }
-    }
-    test(<Foo initialValue="foo" />, 'DIV', 'foo');
-    attachedListener();
-    expect(renderedName).toBe('bar');
-  });
-
-  it('should not implicitly bind event handlers', function() {
-    class Foo extends React.Component {
-      constructor(props) {
-        super(props);
-        this.state = {bar: props.initialValue};
-      }
-      handleClick() {
-        this.setState({bar: 'bar'});
-      }
-      render() {
-        return (
-          <Inner
-            name={this.state.bar}
-            onClick={this.handleClick}
-          />
-        );
-      }
-    }
-    test(<Foo initialValue="foo" />, 'DIV', 'foo');
-    expect(attachedListener).toThrow();
-  });
-
-  it('renders using forceUpdate even when there is no state', function() {
-    class Foo extends React.Component {
-      constructor(props) {
-        super(props);
-        this.mutativeValue = props.initialValue;
-      }
-      handleClick() {
-        this.mutativeValue = 'bar';
-        this.forceUpdate();
-      }
-      render() {
-        return (
-          <Inner
-            name={this.mutativeValue}
-            onClick={this.handleClick.bind(this)}
-          />
-        );
-      }
-    }
-    test(<Foo initialValue="foo" />, 'DIV', 'foo');
-    attachedListener();
-    expect(renderedName).toBe('bar');
-  });
-
-  it('will call all the normal life cycle methods', function() {
-    var lifeCycles = [];
-    class Foo extends React.Component {
-      constructor() {
-        super();
-        this.state = {};
-      }
-      componentWillMount() {
-        lifeCycles.push('will-mount');
-      }
-      componentDidMount() {
-        lifeCycles.push('did-mount');
-      }
-      componentWillReceiveProps(nextProps) {
-        lifeCycles.push('receive-props', nextProps);
-      }
-      shouldComponentUpdate(nextProps, nextState) {
-        lifeCycles.push('should-update', nextProps, nextState);
-        return true;
-      }
-      componentWillUpdate(nextProps, nextState) {
-        lifeCycles.push('will-update', nextProps, nextState);
-      }
-      componentDidUpdate(prevProps, prevState) {
-        lifeCycles.push('did-update', prevProps, prevState);
-      }
-      componentWillUnmount() {
-        lifeCycles.push('will-unmount');
-      }
-      render() {
-        return <span className={this.props.value} />;
-      }
-    }
-    test(<Foo value="foo" />, 'SPAN', 'foo');
-    expect(lifeCycles).toEqual([
-      'will-mount',
-      'did-mount',
-    ]);
-    lifeCycles = []; // reset
-    test(<Foo value="bar" />, 'SPAN', 'bar');
-    expect(lifeCycles).toEqual([
-      'receive-props', freeze({value: 'bar'}),
-      'should-update', freeze({value: 'bar'}), {},
-      'will-update', freeze({value: 'bar'}), {},
-      'did-update', freeze({value: 'foo'}), {},
-    ]);
-    lifeCycles = []; // reset
-    ReactDOM.unmountComponentAtNode(container);
-    expect(lifeCycles).toEqual([
-      'will-unmount',
-    ]);
-  });
-
-  it('warns when classic properties are defined on the instance, but does not invoke them.', function() {
-    spyOn(console, 'error');
-    var getDefaultPropsWasCalled = false;
-    var getInitialStateWasCalled = false;
-    class Foo extends React.Component {
-      constructor() {
-        super();
-        this.contextTypes = {};
-        this.propTypes = {};
-      }
-      getInitialState() {
-        getInitialStateWasCalled = true;
-        return {};
-      }
-      getDefaultProps() {
-        getDefaultPropsWasCalled = true;
-        return {};
-      }
-      render() {
-        return <span className="foo" />;
-      }
-    }
-    test(<Foo />, 'SPAN', 'foo');
-    expect(getInitialStateWasCalled).toBe(false);
-    expect(getDefaultPropsWasCalled).toBe(false);
-    expect(console.error.calls.count()).toBe(4);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'getInitialState was defined on Foo, a plain JavaScript class.'
-    );
-    expect(console.error.calls.argsFor(1)[0]).toContain(
-      'getDefaultProps was defined on Foo, a plain JavaScript class.'
-    );
-    expect(console.error.calls.argsFor(2)[0]).toContain(
-      'propTypes was defined as an instance property on Foo.'
-    );
-    expect(console.error.calls.argsFor(3)[0]).toContain(
-      'contextTypes was defined as an instance property on Foo.'
+    expect(() => test(<Foo />, 'span', '')).toThrowError(
+      'Foo.state: must be set to an object or null'
     );
   });
+});
 
-  it('should warn when misspelling shouldComponentUpdate', function() {
-    spyOn(console, 'error');
-
-    class NamedComponent extends React.Component {
-      componentShouldUpdate() {
-        return false;
-      }
-      render() {
-        return <span className="foo" />;
-      }
+it('should render with null in the initial state property', function() {
+  class Foo extends React.Component {
+    constructor() {
+      super();
+      this.state = null;
     }
-    test(<NamedComponent />, 'SPAN', 'foo');
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: ' +
-      'NamedComponent has a method called componentShouldUpdate(). Did you ' +
-      'mean shouldComponentUpdate()? The name is phrased as a question ' +
-      'because the function is expected to return a value.'
-    );
-  });
-
-  it('should warn when misspelling componentWillReceiveProps', function() {
-    spyOn(console, 'error');
-
-    class NamedComponent extends React.Component {
-      componentWillRecieveProps() {
-        return false;
-      }
-      render() {
-        return <span className="foo" />;
-      }
+    render() {
+      return <span />;
     }
-    test(<NamedComponent />, 'SPAN', 'foo');
+  }
+  test(<Foo />, 'SPAN', '');
+});
 
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: ' +
-      'NamedComponent has a method called componentWillRecieveProps(). Did ' +
-      'you mean componentWillReceiveProps()?'
-    );
-  });
-
-  it('should throw AND warn when trying to access classic APIs', function() {
-    spyOn(console, 'error');
-    var instance = test(<Inner name="foo" />, 'DIV', 'foo');
-    expect(() => instance.replaceState({})).toThrow();
-    expect(() => instance.isMounted()).toThrow();
-    expect(console.error.calls.count()).toBe(2);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'replaceState(...) is deprecated in plain JavaScript React classes'
-    );
-    expect(console.error.calls.argsFor(1)[0]).toContain(
-      'isMounted(...) is deprecated in plain JavaScript React classes'
-    );
-  });
-
-  it('supports this.context passed via getChildContext', function() {
-    class Bar extends React.Component {
-      render() {
-        return <div className={this.context.bar} />;
-      }
+it('setState through an event handler', function() {
+  class Foo extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {bar: props.initialValue};
     }
-    Bar.contextTypes = {bar: React.PropTypes.string};
-    class Foo extends React.Component {
-      getChildContext() {
-        return {bar: 'bar-through-context'};
-      }
-      render() {
-        return <Bar />;
-      }
+    handleClick() {
+      this.setState({bar: 'bar'});
     }
-    Foo.childContextTypes = {bar: React.PropTypes.string};
-    test(<Foo />, 'DIV', 'bar-through-context');
-  });
-
-  it('supports classic refs', function() {
-    class Foo extends React.Component {
-      render() {
-        return <Inner name="foo" ref="inner" />;
-      }
+    render() {
+      return (
+        <Inner
+          name={this.state.bar}
+          onClick={this.handleClick.bind(this)}
+        />
+      );
     }
-    var instance = test(<Foo />, 'DIV', 'foo');
-    expect(instance.refs.inner.getName()).toBe('foo');
-  });
+  }
+  test(<Foo initialValue="foo" />, 'DIV', 'foo');
+  attachedListener();
+  expect(renderedName).toBe('bar');
+});
 
-  it('supports drilling through to the DOM using findDOMNode', function() {
-    var instance = test(<Inner name="foo" />, 'DIV', 'foo');
-    var node = ReactDOM.findDOMNode(instance);
-    expect(node).toBe(container.firstChild);
-  });
+it('should not implicitly bind event handlers', function() {
+  class Foo extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {bar: props.initialValue};
+    }
+    handleClick() {
+      this.setState({bar: 'bar'});
+    }
+    render() {
+      return (
+        <Inner
+          name={this.state.bar}
+          onClick={this.handleClick}
+        />
+      );
+    }
+  }
+  test(<Foo initialValue="foo" />, 'DIV', 'foo');
+  expect(attachedListener).toThrow();
+});
 
+it('renders using forceUpdate even when there is no state', function() {
+  class Foo extends React.Component {
+    constructor(props) {
+      super(props);
+      this.mutativeValue = props.initialValue;
+    }
+    handleClick() {
+      this.mutativeValue = 'bar';
+      this.forceUpdate();
+    }
+    render() {
+      return (
+        <Inner
+          name={this.mutativeValue}
+          onClick={this.handleClick.bind(this)}
+        />
+      );
+    }
+  }
+  test(<Foo initialValue="foo" />, 'DIV', 'foo');
+  attachedListener();
+  expect(renderedName).toBe('bar');
+});
+
+it('will call all the normal life cycle methods', function() {
+  var lifeCycles = [];
+  class Foo extends React.Component {
+    constructor() {
+      super();
+      this.state = {};
+    }
+    componentWillMount() {
+      lifeCycles.push('will-mount');
+    }
+    componentDidMount() {
+      lifeCycles.push('did-mount');
+    }
+    componentWillReceiveProps(nextProps) {
+      lifeCycles.push('receive-props', nextProps);
+    }
+    shouldComponentUpdate(nextProps, nextState) {
+      lifeCycles.push('should-update', nextProps, nextState);
+      return true;
+    }
+    componentWillUpdate(nextProps, nextState) {
+      lifeCycles.push('will-update', nextProps, nextState);
+    }
+    componentDidUpdate(prevProps, prevState) {
+      lifeCycles.push('did-update', prevProps, prevState);
+    }
+    componentWillUnmount() {
+      lifeCycles.push('will-unmount');
+    }
+    render() {
+      return <span className={this.props.value} />;
+    }
+  }
+  test(<Foo value="foo" />, 'SPAN', 'foo');
+  expect(lifeCycles).toEqual([
+    'will-mount',
+    'did-mount',
+  ]);
+  lifeCycles = []; // reset
+  test(<Foo value="bar" />, 'SPAN', 'bar');
+  expect(lifeCycles).toEqual([
+    'receive-props', freeze({value: 'bar'}),
+    'should-update', freeze({value: 'bar'}), {},
+    'will-update', freeze({value: 'bar'}), {},
+    'did-update', freeze({value: 'foo'}), {},
+  ]);
+  lifeCycles = []; // reset
+  ReactDOM.unmountComponentAtNode(container);
+  expect(lifeCycles).toEqual([
+    'will-unmount',
+  ]);
+});
+
+it('warns when classic properties are defined on the instance, but does not invoke them.', function() {
+  spyOn(console, 'error');
+  var getDefaultPropsWasCalled = false;
+  var getInitialStateWasCalled = false;
+  class Foo extends React.Component {
+    constructor() {
+      super();
+      this.contextTypes = {};
+      this.propTypes = {};
+    }
+    getInitialState() {
+      getInitialStateWasCalled = true;
+      return {};
+    }
+    getDefaultProps() {
+      getDefaultPropsWasCalled = true;
+      return {};
+    }
+    render() {
+      return <span className="foo" />;
+    }
+  }
+  test(<Foo />, 'SPAN', 'foo');
+  expect(getInitialStateWasCalled).toBe(false);
+  expect(getDefaultPropsWasCalled).toBe(false);
+  expect(console.error.calls.count()).toBe(4);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'getInitialState was defined on Foo, a plain JavaScript class.'
+  );
+  expect(console.error.calls.argsFor(1)[0]).toContain(
+    'getDefaultProps was defined on Foo, a plain JavaScript class.'
+  );
+  expect(console.error.calls.argsFor(2)[0]).toContain(
+    'propTypes was defined as an instance property on Foo.'
+  );
+  expect(console.error.calls.argsFor(3)[0]).toContain(
+    'contextTypes was defined as an instance property on Foo.'
+  );
+});
+
+it('should warn when misspelling shouldComponentUpdate', function() {
+  spyOn(console, 'error');
+
+  class NamedComponent extends React.Component {
+    componentShouldUpdate() {
+      return false;
+    }
+    render() {
+      return <span className="foo" />;
+    }
+  }
+  test(<NamedComponent />, 'SPAN', 'foo');
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: ' +
+    'NamedComponent has a method called componentShouldUpdate(). Did you ' +
+    'mean shouldComponentUpdate()? The name is phrased as a question ' +
+    'because the function is expected to return a value.'
+  );
+});
+
+it('should warn when misspelling componentWillReceiveProps', function() {
+  spyOn(console, 'error');
+
+  class NamedComponent extends React.Component {
+    componentWillRecieveProps() {
+      return false;
+    }
+    render() {
+      return <span className="foo" />;
+    }
+  }
+  test(<NamedComponent />, 'SPAN', 'foo');
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: ' +
+    'NamedComponent has a method called componentWillRecieveProps(). Did ' +
+    'you mean componentWillReceiveProps()?'
+  );
+});
+
+it('should throw AND warn when trying to access classic APIs', function() {
+  spyOn(console, 'error');
+  var instance = test(<Inner name="foo" />, 'DIV', 'foo');
+  expect(() => instance.replaceState({})).toThrow();
+  expect(() => instance.isMounted()).toThrow();
+  expect(console.error.calls.count()).toBe(2);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'replaceState(...) is deprecated in plain JavaScript React classes'
+  );
+  expect(console.error.calls.argsFor(1)[0]).toContain(
+    'isMounted(...) is deprecated in plain JavaScript React classes'
+  );
+});
+
+it('supports this.context passed via getChildContext', function() {
+  class Bar extends React.Component {
+    render() {
+      return <div className={this.context.bar} />;
+    }
+  }
+  Bar.contextTypes = {bar: React.PropTypes.string};
+  class Foo extends React.Component {
+    getChildContext() {
+      return {bar: 'bar-through-context'};
+    }
+    render() {
+      return <Bar />;
+    }
+  }
+  Foo.childContextTypes = {bar: React.PropTypes.string};
+  test(<Foo />, 'DIV', 'bar-through-context');
+});
+
+it('supports classic refs', function() {
+  class Foo extends React.Component {
+    render() {
+      return <Inner name="foo" ref="inner" />;
+    }
+  }
+  var instance = test(<Foo />, 'DIV', 'foo');
+  expect(instance.refs.inner.getName()).toBe('foo');
+});
+
+it('supports drilling through to the DOM using findDOMNode', function() {
+  var instance = test(<Inner name="foo" />, 'DIV', 'foo');
+  var node = ReactDOM.findDOMNode(instance);
+  expect(node).toBe(container.firstChild);
 });

--- a/src/isomorphic/modern/class/__tests__/ReactPureComponent-test.js
+++ b/src/isomorphic/modern/class/__tests__/ReactPureComponent-test.js
@@ -14,84 +14,81 @@
 var React;
 var ReactDOM;
 
-describe('ReactPureComponent', function() {
-  beforeEach(function() {
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-  });
+beforeEach(function() {
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+});
 
-  it('should render', function() {
-    var renders = 0;
-    class Component extends React.PureComponent {
-      constructor() {
-        super();
-        this.state = {type: 'mushrooms'};
-      }
-      render() {
-        renders++;
-        return <div>{this.props.text[0]}</div>;
-      }
+it('should render', function() {
+  var renders = 0;
+  class Component extends React.PureComponent {
+    constructor() {
+      super();
+      this.state = {type: 'mushrooms'};
     }
-
-    var container = document.createElement('div');
-    var text;
-    var component;
-
-    text = ['porcini'];
-    component = ReactDOM.render(<Component text={text} />, container);
-    expect(container.textContent).toBe('porcini');
-    expect(renders).toBe(1);
-
-    text = ['morel'];
-    component = ReactDOM.render(<Component text={text} />, container);
-    expect(container.textContent).toBe('morel');
-    expect(renders).toBe(2);
-
-    text[0] = 'portobello';
-    component = ReactDOM.render(<Component text={text} />, container);
-    expect(container.textContent).toBe('morel');
-    expect(renders).toBe(2);
-
-    // Setting state without changing it doesn't cause a rerender.
-    component.setState({type: 'mushrooms'});
-    expect(container.textContent).toBe('morel');
-    expect(renders).toBe(2);
-
-    // But changing state does.
-    component.setState({type: 'portobello mushrooms'});
-    expect(container.textContent).toBe('portobello');
-    expect(renders).toBe(3);
-  });
-
-  it('can override shouldComponentUpdate', function() {
-    var renders = 0;
-    class Component extends React.PureComponent {
-      render() {
-        renders++;
-        return <div />;
-      }
-      shouldComponentUpdate() {
-        return true;
-      }
+    render() {
+      renders++;
+      return <div>{this.props.text[0]}</div>;
     }
-    var container = document.createElement('div');
-    ReactDOM.render(<Component />, container);
-    ReactDOM.render(<Component />, container);
-    expect(renders).toBe(2);
-  });
+  }
 
-  it('extends React.Component', function() {
-    var renders = 0;
-    class Component extends React.PureComponent {
-      render() {
-        expect(this instanceof React.Component).toBe(true);
-        expect(this instanceof React.PureComponent).toBe(true);
-        renders++;
-        return <div />;
-      }
+  var container = document.createElement('div');
+  var text;
+  var component;
+
+  text = ['porcini'];
+  component = ReactDOM.render(<Component text={text} />, container);
+  expect(container.textContent).toBe('porcini');
+  expect(renders).toBe(1);
+
+  text = ['morel'];
+  component = ReactDOM.render(<Component text={text} />, container);
+  expect(container.textContent).toBe('morel');
+  expect(renders).toBe(2);
+
+  text[0] = 'portobello';
+  component = ReactDOM.render(<Component text={text} />, container);
+  expect(container.textContent).toBe('morel');
+  expect(renders).toBe(2);
+
+  // Setting state without changing it doesn't cause a rerender.
+  component.setState({type: 'mushrooms'});
+  expect(container.textContent).toBe('morel');
+  expect(renders).toBe(2);
+
+  // But changing state does.
+  component.setState({type: 'portobello mushrooms'});
+  expect(container.textContent).toBe('portobello');
+  expect(renders).toBe(3);
+});
+
+it('can override shouldComponentUpdate', function() {
+  var renders = 0;
+  class Component extends React.PureComponent {
+    render() {
+      renders++;
+      return <div />;
     }
-    ReactDOM.render(<Component />, document.createElement('div'));
-    expect(renders).toBe(1);
-  });
+    shouldComponentUpdate() {
+      return true;
+    }
+  }
+  var container = document.createElement('div');
+  ReactDOM.render(<Component />, container);
+  ReactDOM.render(<Component />, container);
+  expect(renders).toBe(2);
+});
 
+it('extends React.Component', function() {
+  var renders = 0;
+  class Component extends React.PureComponent {
+    render() {
+      expect(this instanceof React.Component).toBe(true);
+      expect(this instanceof React.PureComponent).toBe(true);
+      renders++;
+      return <div />;
+    }
+  }
+  ReactDOM.render(<Component />, document.createElement('div'));
+  expect(renders).toBe(1);
 });

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElement-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElement-test.js
@@ -15,193 +15,190 @@ var React;
 var ReactDOM;
 var ReactTestUtils;
 
-describe('ReactJSXElement', function() {
-  var Component;
+var Component;
 
-  beforeEach(function() {
-    jest.resetModuleRegistry();
+beforeEach(function() {
+  jest.resetModuleRegistry();
 
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactTestUtils = require('ReactTestUtils');
-    Component = class extends React.Component {
-      render() {
-        return <div />;
-      }
-    };
-  });
-
-  it('returns a complete element according to spec', function() {
-    var element = <Component />;
-    expect(element.type).toBe(Component);
-    expect(element.key).toBe(null);
-    expect(element.ref).toBe(null);
-    var expectation = {};
-    Object.freeze(expectation);
-    expect(element.props).toEqual(expectation);
-  });
-
-  it('allows a lower-case to be passed as the string type', function() {
-    var element = <div />;
-    expect(element.type).toBe('div');
-    expect(element.key).toBe(null);
-    expect(element.ref).toBe(null);
-    var expectation = {};
-    Object.freeze(expectation);
-    expect(element.props).toEqual(expectation);
-  });
-
-  it('allows a string to be passed as the type', function() {
-    var TagName = 'div';
-    var element = <TagName />;
-    expect(element.type).toBe('div');
-    expect(element.key).toBe(null);
-    expect(element.ref).toBe(null);
-    var expectation = {};
-    Object.freeze(expectation);
-    expect(element.props).toEqual(expectation);
-  });
-
-  it('returns an immutable element', function() {
-    var element = <Component />;
-    expect(() => element.type = 'div').toThrow();
-  });
-
-  it('does not reuse the object that is spread into props', function() {
-    var config = {foo: 1};
-    var element = <Component {...config} />;
-    expect(element.props.foo).toBe(1);
-    config.foo = 2;
-    expect(element.props.foo).toBe(1);
-  });
-
-  it('extracts key and ref from the rest of the props', function() {
-    var element = <Component key="12" ref="34" foo="56" />;
-    expect(element.type).toBe(Component);
-    expect(element.key).toBe('12');
-    expect(element.ref).toBe('34');
-    var expectation = {foo:'56'};
-    Object.freeze(expectation);
-    expect(element.props).toEqual(expectation);
-  });
-
-  it('coerces the key to a string', function() {
-    var element = <Component key={12} foo="56" />;
-    expect(element.type).toBe(Component);
-    expect(element.key).toBe('12');
-    expect(element.ref).toBe(null);
-    var expectation = {foo:'56'};
-    Object.freeze(expectation);
-    expect(element.props).toEqual(expectation);
-  });
-
-  it('merges JSX children onto the children prop', function() {
-    spyOn(console, 'error');
-    var a = 1;
-    var element = <Component children="text">{a}</Component>;
-    expect(element.props.children).toBe(a);
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('does not override children if no JSX children are provided', function() {
-    spyOn(console, 'error');
-    var element = <Component children="text" />;
-    expect(element.props.children).toBe('text');
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('overrides children if null is provided as a JSX child', function() {
-    spyOn(console, 'error');
-    var element = <Component children="text">{null}</Component>;
-    expect(element.props.children).toBe(null);
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('overrides children if undefined is provided as an argument', function() {
-    var element = <Component children="text">{undefined}</Component>;
-    expect(element.props.children).toBe(undefined);
-
-    var element2 = React.cloneElement(
-      <Component children="text" />,
-      {},
-      undefined
-    );
-    expect(element2.props.children).toBe(undefined);
-  });
-
-  it('merges JSX children onto the children prop in an array', function() {
-    spyOn(console, 'error');
-    var a = 1;
-    var b = 2;
-    var c = 3;
-    var element = <Component>{a}{b}{c}</Component>;
-    expect(element.props.children).toEqual([1, 2, 3]);
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('allows static methods to be called using the type property', function() {
-    spyOn(console, 'error');
-
-    class StaticMethodComponent {
-      static someStaticMethod() {
-        return 'someReturnValue';
-      }
-      render() {
-        return <div></div>;
-      }
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactTestUtils = require('ReactTestUtils');
+  Component = class extends React.Component {
+    render() {
+      return <div />;
     }
+  };
+});
 
-    var element = <StaticMethodComponent />;
-    expect(element.type.someStaticMethod()).toBe('someReturnValue');
-    expect(console.error.calls.count()).toBe(0);
-  });
+it('returns a complete element according to spec', function() {
+  var element = <Component />;
+  expect(element.type).toBe(Component);
+  expect(element.key).toBe(null);
+  expect(element.ref).toBe(null);
+  var expectation = {};
+  Object.freeze(expectation);
+  expect(element.props).toEqual(expectation);
+});
 
-  it('identifies valid elements', function() {
-    expect(React.isValidElement(<div />)).toEqual(true);
-    expect(React.isValidElement(<Component />)).toEqual(true);
+it('allows a lower-case to be passed as the string type', function() {
+  var element = <div />;
+  expect(element.type).toBe('div');
+  expect(element.key).toBe(null);
+  expect(element.ref).toBe(null);
+  var expectation = {};
+  Object.freeze(expectation);
+  expect(element.props).toEqual(expectation);
+});
 
-    expect(React.isValidElement(null)).toEqual(false);
-    expect(React.isValidElement(true)).toEqual(false);
-    expect(React.isValidElement({})).toEqual(false);
-    expect(React.isValidElement('string')).toEqual(false);
-    expect(React.isValidElement(Component)).toEqual(false);
-    expect(React.isValidElement({ type: 'div', props: {} })).toEqual(false);
-  });
+it('allows a string to be passed as the type', function() {
+  var TagName = 'div';
+  var element = <TagName />;
+  expect(element.type).toBe('div');
+  expect(element.key).toBe(null);
+  expect(element.ref).toBe(null);
+  var expectation = {};
+  Object.freeze(expectation);
+  expect(element.props).toEqual(expectation);
+});
 
-  it('is indistinguishable from a plain object', function() {
-    var element = <div className="foo" />;
-    var object = {};
-    expect(element.constructor).toBe(object.constructor);
-  });
+it('returns an immutable element', function() {
+  var element = <Component />;
+  expect(() => element.type = 'div').toThrow();
+});
 
-  it('should use default prop value when removing a prop', function() {
-    Component.defaultProps = {fruit: 'persimmon'};
+it('does not reuse the object that is spread into props', function() {
+  var config = {foo: 1};
+  var element = <Component {...config} />;
+  expect(element.props.foo).toBe(1);
+  config.foo = 2;
+  expect(element.props.foo).toBe(1);
+});
 
-    var container = document.createElement('div');
-    var instance = ReactDOM.render(
-      <Component fruit="mango" />,
-      container
-    );
-    expect(instance.props.fruit).toBe('mango');
+it('extracts key and ref from the rest of the props', function() {
+  var element = <Component key="12" ref="34" foo="56" />;
+  expect(element.type).toBe(Component);
+  expect(element.key).toBe('12');
+  expect(element.ref).toBe('34');
+  var expectation = {foo:'56'};
+  Object.freeze(expectation);
+  expect(element.props).toEqual(expectation);
+});
 
-    ReactDOM.render(<Component />, container);
-    expect(instance.props.fruit).toBe('persimmon');
-  });
+it('coerces the key to a string', function() {
+  var element = <Component key={12} foo="56" />;
+  expect(element.type).toBe(Component);
+  expect(element.key).toBe('12');
+  expect(element.ref).toBe(null);
+  var expectation = {foo:'56'};
+  Object.freeze(expectation);
+  expect(element.props).toEqual(expectation);
+});
 
-  it('should normalize props with default values', function() {
-    class NormalizingComponent extends React.Component {
-      render() {
-        return <span>{this.props.prop}</span>;
-      }
+it('merges JSX children onto the children prop', function() {
+  spyOn(console, 'error');
+  var a = 1;
+  var element = <Component children="text">{a}</Component>;
+  expect(element.props.children).toBe(a);
+  expect(console.error.calls.count()).toBe(0);
+});
+
+it('does not override children if no JSX children are provided', function() {
+  spyOn(console, 'error');
+  var element = <Component children="text" />;
+  expect(element.props.children).toBe('text');
+  expect(console.error.calls.count()).toBe(0);
+});
+
+it('overrides children if null is provided as a JSX child', function() {
+  spyOn(console, 'error');
+  var element = <Component children="text">{null}</Component>;
+  expect(element.props.children).toBe(null);
+  expect(console.error.calls.count()).toBe(0);
+});
+
+it('overrides children if undefined is provided as an argument', function() {
+  var element = <Component children="text">{undefined}</Component>;
+  expect(element.props.children).toBe(undefined);
+
+  var element2 = React.cloneElement(
+    <Component children="text" />,
+    {},
+    undefined
+  );
+  expect(element2.props.children).toBe(undefined);
+});
+
+it('merges JSX children onto the children prop in an array', function() {
+  spyOn(console, 'error');
+  var a = 1;
+  var b = 2;
+  var c = 3;
+  var element = <Component>{a}{b}{c}</Component>;
+  expect(element.props.children).toEqual([1, 2, 3]);
+  expect(console.error.calls.count()).toBe(0);
+});
+
+it('allows static methods to be called using the type property', function() {
+  spyOn(console, 'error');
+
+  class StaticMethodComponent {
+    static someStaticMethod() {
+      return 'someReturnValue';
     }
-    NormalizingComponent.defaultProps = {prop: 'testKey'};
+    render() {
+      return <div></div>;
+    }
+  }
 
-    var instance = ReactTestUtils.renderIntoDocument(<NormalizingComponent />);
-    expect(instance.props.prop).toBe('testKey');
+  var element = <StaticMethodComponent />;
+  expect(element.type.someStaticMethod()).toBe('someReturnValue');
+  expect(console.error.calls.count()).toBe(0);
+});
 
-    var inst2 =
-      ReactTestUtils.renderIntoDocument(<NormalizingComponent prop={null} />);
-    expect(inst2.props.prop).toBe(null);
-  });
+it('identifies valid elements', function() {
+  expect(React.isValidElement(<div />)).toEqual(true);
+  expect(React.isValidElement(<Component />)).toEqual(true);
 
+  expect(React.isValidElement(null)).toEqual(false);
+  expect(React.isValidElement(true)).toEqual(false);
+  expect(React.isValidElement({})).toEqual(false);
+  expect(React.isValidElement('string')).toEqual(false);
+  expect(React.isValidElement(Component)).toEqual(false);
+  expect(React.isValidElement({ type: 'div', props: {} })).toEqual(false);
+});
+
+it('is indistinguishable from a plain object', function() {
+  var element = <div className="foo" />;
+  var object = {};
+  expect(element.constructor).toBe(object.constructor);
+});
+
+it('should use default prop value when removing a prop', function() {
+  Component.defaultProps = {fruit: 'persimmon'};
+
+  var container = document.createElement('div');
+  var instance = ReactDOM.render(
+    <Component fruit="mango" />,
+    container
+  );
+  expect(instance.props.fruit).toBe('mango');
+
+  ReactDOM.render(<Component />, container);
+  expect(instance.props.fruit).toBe('persimmon');
+});
+
+it('should normalize props with default values', function() {
+  class NormalizingComponent extends React.Component {
+    render() {
+      return <span>{this.props.prop}</span>;
+    }
+  }
+  NormalizingComponent.defaultProps = {prop: 'testKey'};
+
+  var instance = ReactTestUtils.renderIntoDocument(<NormalizingComponent />);
+  expect(instance.props.prop).toBe('testKey');
+
+  var inst2 =
+    ReactTestUtils.renderIntoDocument(<NormalizingComponent prop={null} />);
+  expect(inst2.props.prop).toBe(null);
 });

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -17,346 +17,343 @@
 var React;
 var ReactTestUtils;
 
-describe('ReactJSXElementValidator', function() {
-  var Component;
-  var RequiredPropComponent;
+var Component;
+var RequiredPropComponent;
 
-  beforeEach(function() {
-    jest.resetModuleRegistry();
+beforeEach(function() {
+  jest.resetModuleRegistry();
 
-    React = require('React');
-    ReactTestUtils = require('ReactTestUtils');
+  React = require('React');
+  ReactTestUtils = require('ReactTestUtils');
 
-    Component = class extends React.Component {
-      render() {
-        return <div />;
-      }
-    };
-
-    RequiredPropComponent = class extends React.Component {
-      render() {
-        return <span>{this.props.prop}</span>;
-      }
-    };
-    RequiredPropComponent.displayName = 'RequiredPropComponent';
-    RequiredPropComponent.propTypes = {prop: React.PropTypes.string.isRequired};
-  });
-
-  it('warns for keys for arrays of elements in children position', function() {
-    spyOn(console, 'error');
-
-    void <Component>{[<Component />, <Component />]}</Component>;
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Each child in an array or iterator should have a unique "key" prop.'
-    );
-  });
-
-  it('warns for keys for arrays of elements with owner info', function() {
-    spyOn(console, 'error');
-
-    class InnerComponent extends React.Component {
-      render() {
-        return <Component>{this.props.childSet}</Component>;
-      }
+  Component = class extends React.Component {
+    render() {
+      return <div />;
     }
+  };
 
-    class ComponentWrapper extends React.Component {
-      render() {
-        return (
-          <InnerComponent
-            childSet={[<Component />, <Component />]}
-          />
-        );
-      }
+  RequiredPropComponent = class extends React.Component {
+    render() {
+      return <span>{this.props.prop}</span>;
     }
+  };
+  RequiredPropComponent.displayName = 'RequiredPropComponent';
+  RequiredPropComponent.propTypes = {prop: React.PropTypes.string.isRequired};
+});
 
-    ReactTestUtils.renderIntoDocument(<ComponentWrapper />);
+it('warns for keys for arrays of elements in children position', function() {
+  spyOn(console, 'error');
 
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Each child in an array or iterator should have a unique "key" prop. ' +
-      'Check the render method of `InnerComponent`. ' +
-      'It was passed a child from ComponentWrapper. '
-    );
-  });
+  void <Component>{[<Component />, <Component />]}</Component>;
 
-  it('warns for keys for iterables of elements in rest args', function() {
-    spyOn(console, 'error');
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'Each child in an array or iterator should have a unique "key" prop.'
+  );
+});
 
-    var iterable = {
-      '@@iterator': function() {
-        var i = 0;
-        return {
-          next: function() {
-            var done = ++i > 2;
-            return {value: done ? undefined : <Component />, done: done};
-          },
-        };
-      },
-    };
+it('warns for keys for arrays of elements with owner info', function() {
+  spyOn(console, 'error');
 
-    void <Component>{iterable}</Component>;
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Each child in an array or iterator should have a unique "key" prop.'
-    );
-  });
-
-  it('does not warns for arrays of elements with keys', function() {
-    spyOn(console, 'error');
-
-    void <Component>{[<Component key="#1" />, <Component key="#2" />]}</Component>;
-
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('does not warns for iterable elements with keys', function() {
-    spyOn(console, 'error');
-
-    var iterable = {
-      '@@iterator': function() {
-        var i = 0;
-        return {
-          next: function() {
-            var done = ++i > 2;
-            return {
-              value: done ? undefined : <Component key={'#' + i} />,
-              done: done,
-            };
-          },
-        };
-      },
-    };
-
-    void <Component>{iterable}</Component>;
-
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('does not warn for numeric keys in entry iterable as a child', function() {
-    spyOn(console, 'error');
-
-    var iterable = {
-      '@@iterator': function() {
-        var i = 0;
-        return {
-          next: function() {
-            var done = ++i > 2;
-            return {value: done ? undefined : [i, <Component />], done: done};
-          },
-        };
-      },
-    };
-    iterable.entries = iterable['@@iterator'];
-
-    void <Component>{iterable}</Component>;
-
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('does not warn when the element is directly as children', function() {
-    spyOn(console, 'error');
-
-    void <Component><Component /><Component /></Component>;
-
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('does not warn when the child array contains non-elements', function() {
-    spyOn(console, 'error');
-
-    void <Component>{[{}, {}]}</Component>;
-
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  // TODO: These warnings currently come from the composite component, but
-  // they should be moved into the ReactElementValidator.
-
-  it('should give context for PropType errors in nested components.', () => {
-    // In this test, we're making sure that if a proptype error is found in a
-    // component, we give a small hint as to which parent instantiated that
-    // component as per warnings about key usage in ReactElementValidator.
-    spyOn(console, 'error');
-    class MyComp extends React.Component {
-      render() {
-        return <div>My color is {this.color}</div>;
-      }
+  class InnerComponent extends React.Component {
+    render() {
+      return <Component>{this.props.childSet}</Component>;
     }
-    MyComp.propTypes = {
-      color: React.PropTypes.string,
-    };
-    class ParentComp extends React.Component {
-      render() {
-        return <MyComp color={123} />;
-      }
+  }
+
+  class ComponentWrapper extends React.Component {
+    render() {
+      return (
+        <InnerComponent
+          childSet={[<Component />, <Component />]}
+        />
+      );
     }
-    ReactTestUtils.renderIntoDocument(<ParentComp />);
-    expect(
-      console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
-    ).toBe(
-      'Warning: Failed prop type: ' +
-      'Invalid prop `color` of type `number` supplied to `MyComp`, ' +
-      'expected `string`.\n' +
-      '    in MyComp (at **)\n' +
-      '    in ParentComp (at **)'
-    );
-  });
+  }
 
-  it('gives a helpful error when passing null, undefined, or boolean', () => {
-    var Undefined = undefined;
-    var Null = null;
-    var True = true;
-    var Num = 123;
-    var Div = 'div';
-    spyOn(console, 'error');
-    void <Undefined />;
-    void <Null />;
-    void <True />;
-    void <Num />;
-    expect(console.error.calls.count()).toBe(4);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'type should not be null, undefined, boolean, or number. It should be ' +
-      'a string (for DOM elements) or a ReactClass (for composite components).'
-    );
-    expect(console.error.calls.argsFor(1)[0]).toContain(
-      'type should not be null, undefined, boolean, or number. It should be ' +
-      'a string (for DOM elements) or a ReactClass (for composite components).'
-    );
-    expect(console.error.calls.argsFor(2)[0]).toContain(
-      'type should not be null, undefined, boolean, or number. It should be ' +
-      'a string (for DOM elements) or a ReactClass (for composite components).'
-    );
-    expect(console.error.calls.argsFor(3)[0]).toContain(
-      'type should not be null, undefined, boolean, or number. It should be ' +
-      'a string (for DOM elements) or a ReactClass (for composite components).'
-    );
-    void <Div />;
-    expect(console.error.calls.count()).toBe(4);
-  });
+  ReactTestUtils.renderIntoDocument(<ComponentWrapper />);
 
-  it('should check default prop values', function() {
-    spyOn(console, 'error');
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'Each child in an array or iterator should have a unique "key" prop. ' +
+    'Check the render method of `InnerComponent`. ' +
+    'It was passed a child from ComponentWrapper. '
+  );
+});
 
-    RequiredPropComponent.defaultProps = {prop: null};
+it('warns for keys for iterables of elements in rest args', function() {
+  spyOn(console, 'error');
 
-    ReactTestUtils.renderIntoDocument(<RequiredPropComponent />);
+  var iterable = {
+    '@@iterator': function() {
+      var i = 0;
+      return {
+        next: function() {
+          var done = ++i > 2;
+          return {value: done ? undefined : <Component />, done: done};
+        },
+      };
+    },
+  };
 
-    expect(console.error.calls.count()).toBe(1);
-    expect(
-      console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
-    ).toBe(
-      'Warning: Failed prop type: The prop `prop` is marked as required in ' +
-      '`RequiredPropComponent`, but its value is `null`.\n' +
-      '    in RequiredPropComponent (at **)'
-    );
-  });
+  void <Component>{iterable}</Component>;
 
-  it('should not check the default for explicit null', function() {
-    spyOn(console, 'error');
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'Each child in an array or iterator should have a unique "key" prop.'
+  );
+});
 
-    ReactTestUtils.renderIntoDocument(<RequiredPropComponent prop={null} />);
+it('does not warns for arrays of elements with keys', function() {
+  spyOn(console, 'error');
 
-    expect(console.error.calls.count()).toBe(1);
-    expect(
-      console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
-    ).toBe(
-      'Warning: Failed prop type: The prop `prop` is marked as required in ' +
-      '`RequiredPropComponent`, but its value is `null`.\n' +
-      '    in RequiredPropComponent (at **)'
-    );
-  });
+  void <Component>{[<Component key="#1" />, <Component key="#2" />]}</Component>;
 
-  it('should check declared prop types', function() {
-    spyOn(console, 'error');
+  expect(console.error.calls.count()).toBe(0);
+});
 
-    ReactTestUtils.renderIntoDocument(<RequiredPropComponent />);
-    ReactTestUtils.renderIntoDocument(<RequiredPropComponent prop={42} />);
+it('does not warns for iterable elements with keys', function() {
+  spyOn(console, 'error');
 
-    expect(console.error.calls.count()).toBe(2);
-    expect(
-      console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
-    ).toBe(
-      'Warning: Failed prop type: ' +
-      'The prop `prop` is marked as required in `RequiredPropComponent`, but ' +
-      'its value is `undefined`.\n' +
-      '    in RequiredPropComponent (at **)'
-    );
+  var iterable = {
+    '@@iterator': function() {
+      var i = 0;
+      return {
+        next: function() {
+          var done = ++i > 2;
+          return {
+            value: done ? undefined : <Component key={'#' + i} />,
+            done: done,
+          };
+        },
+      };
+    },
+  };
 
-    expect(
-      console.error.calls.argsFor(1)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
-    ).toBe(
-      'Warning: Failed prop type: ' +
-      'Invalid prop `prop` of type `number` supplied to ' +
-      '`RequiredPropComponent`, expected `string`.\n' +
-      '    in RequiredPropComponent (at **)'
-    );
+  void <Component>{iterable}</Component>;
 
-    ReactTestUtils.renderIntoDocument(<RequiredPropComponent prop="string" />);
+  expect(console.error.calls.count()).toBe(0);
+});
 
-    // Should not error for strings
-    expect(console.error.calls.count()).toBe(2);
-  });
+it('does not warn for numeric keys in entry iterable as a child', function() {
+  spyOn(console, 'error');
 
-  it('should warn on invalid prop types', function() {
-    // Since there is no prevalidation step for ES6 classes, there is no hook
-    // for us to issue a warning earlier than element creation when the error
-    // actually occurs. Since this step is skipped in production, we should just
-    // warn instead of throwing for this case.
-    spyOn(console, 'error');
-    class NullPropTypeComponent extends React.Component {
-      render() {
-        return <span>{this.props.prop}</span>;
-      }
+  var iterable = {
+    '@@iterator': function() {
+      var i = 0;
+      return {
+        next: function() {
+          var done = ++i > 2;
+          return {value: done ? undefined : [i, <Component />], done: done};
+        },
+      };
+    },
+  };
+  iterable.entries = iterable['@@iterator'];
+
+  void <Component>{iterable}</Component>;
+
+  expect(console.error.calls.count()).toBe(0);
+});
+
+it('does not warn when the element is directly as children', function() {
+  spyOn(console, 'error');
+
+  void <Component><Component /><Component /></Component>;
+
+  expect(console.error.calls.count()).toBe(0);
+});
+
+it('does not warn when the child array contains non-elements', function() {
+  spyOn(console, 'error');
+
+  void <Component>{[{}, {}]}</Component>;
+
+  expect(console.error.calls.count()).toBe(0);
+});
+
+// TODO: These warnings currently come from the composite component, but
+// they should be moved into the ReactElementValidator.
+
+it('should give context for PropType errors in nested components.', () => {
+  // In this test, we're making sure that if a proptype error is found in a
+  // component, we give a small hint as to which parent instantiated that
+  // component as per warnings about key usage in ReactElementValidator.
+  spyOn(console, 'error');
+  class MyComp extends React.Component {
+    render() {
+      return <div>My color is {this.color}</div>;
     }
-    NullPropTypeComponent.propTypes = {
-      prop: null,
-    };
-    ReactTestUtils.renderIntoDocument(<NullPropTypeComponent />);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'NullPropTypeComponent: prop type `prop` is invalid; it must be a ' +
-      'function, usually from React.PropTypes.'
-    );
-  });
-
-  it('should warn on invalid context types', function() {
-    spyOn(console, 'error');
-    class NullContextTypeComponent extends React.Component {
-      render() {
-        return <span>{this.props.prop}</span>;
-      }
+  }
+  MyComp.propTypes = {
+    color: React.PropTypes.string,
+  };
+  class ParentComp extends React.Component {
+    render() {
+      return <MyComp color={123} />;
     }
-    NullContextTypeComponent.contextTypes = {
-      prop: null,
-    };
-    ReactTestUtils.renderIntoDocument(<NullContextTypeComponent />);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'NullContextTypeComponent: context type `prop` is invalid; it must ' +
-      'be a function, usually from React.PropTypes.'
-    );
-  });
+  }
+  ReactTestUtils.renderIntoDocument(<ParentComp />);
+  expect(
+    console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
+  ).toBe(
+    'Warning: Failed prop type: ' +
+    'Invalid prop `color` of type `number` supplied to `MyComp`, ' +
+    'expected `string`.\n' +
+    '    in MyComp (at **)\n' +
+    '    in ParentComp (at **)'
+  );
+});
 
-  it('should warn if getDefaultProps is specificed on the class', function() {
-    spyOn(console, 'error');
-    class GetDefaultPropsComponent extends React.Component {
-      render() {
-        return <span>{this.props.prop}</span>;
-      }
+it('gives a helpful error when passing null, undefined, or boolean', () => {
+  var Undefined = undefined;
+  var Null = null;
+  var True = true;
+  var Num = 123;
+  var Div = 'div';
+  spyOn(console, 'error');
+  void <Undefined />;
+  void <Null />;
+  void <True />;
+  void <Num />;
+  expect(console.error.calls.count()).toBe(4);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'type should not be null, undefined, boolean, or number. It should be ' +
+    'a string (for DOM elements) or a ReactClass (for composite components).'
+  );
+  expect(console.error.calls.argsFor(1)[0]).toContain(
+    'type should not be null, undefined, boolean, or number. It should be ' +
+    'a string (for DOM elements) or a ReactClass (for composite components).'
+  );
+  expect(console.error.calls.argsFor(2)[0]).toContain(
+    'type should not be null, undefined, boolean, or number. It should be ' +
+    'a string (for DOM elements) or a ReactClass (for composite components).'
+  );
+  expect(console.error.calls.argsFor(3)[0]).toContain(
+    'type should not be null, undefined, boolean, or number. It should be ' +
+    'a string (for DOM elements) or a ReactClass (for composite components).'
+  );
+  void <Div />;
+  expect(console.error.calls.count()).toBe(4);
+});
+
+it('should check default prop values', function() {
+  spyOn(console, 'error');
+
+  RequiredPropComponent.defaultProps = {prop: null};
+
+  ReactTestUtils.renderIntoDocument(<RequiredPropComponent />);
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(
+    console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
+  ).toBe(
+    'Warning: Failed prop type: The prop `prop` is marked as required in ' +
+    '`RequiredPropComponent`, but its value is `null`.\n' +
+    '    in RequiredPropComponent (at **)'
+  );
+});
+
+it('should not check the default for explicit null', function() {
+  spyOn(console, 'error');
+
+  ReactTestUtils.renderIntoDocument(<RequiredPropComponent prop={null} />);
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(
+    console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
+  ).toBe(
+    'Warning: Failed prop type: The prop `prop` is marked as required in ' +
+    '`RequiredPropComponent`, but its value is `null`.\n' +
+    '    in RequiredPropComponent (at **)'
+  );
+});
+
+it('should check declared prop types', function() {
+  spyOn(console, 'error');
+
+  ReactTestUtils.renderIntoDocument(<RequiredPropComponent />);
+  ReactTestUtils.renderIntoDocument(<RequiredPropComponent prop={42} />);
+
+  expect(console.error.calls.count()).toBe(2);
+  expect(
+    console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
+  ).toBe(
+    'Warning: Failed prop type: ' +
+    'The prop `prop` is marked as required in `RequiredPropComponent`, but ' +
+    'its value is `undefined`.\n' +
+    '    in RequiredPropComponent (at **)'
+  );
+
+  expect(
+    console.error.calls.argsFor(1)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
+  ).toBe(
+    'Warning: Failed prop type: ' +
+    'Invalid prop `prop` of type `number` supplied to ' +
+    '`RequiredPropComponent`, expected `string`.\n' +
+    '    in RequiredPropComponent (at **)'
+  );
+
+  ReactTestUtils.renderIntoDocument(<RequiredPropComponent prop="string" />);
+
+  // Should not error for strings
+  expect(console.error.calls.count()).toBe(2);
+});
+
+it('should warn on invalid prop types', function() {
+  // Since there is no prevalidation step for ES6 classes, there is no hook
+  // for us to issue a warning earlier than element creation when the error
+  // actually occurs. Since this step is skipped in production, we should just
+  // warn instead of throwing for this case.
+  spyOn(console, 'error');
+  class NullPropTypeComponent extends React.Component {
+    render() {
+      return <span>{this.props.prop}</span>;
     }
-    GetDefaultPropsComponent.getDefaultProps = () => ({
-      prop: 'foo',
-    });
-    ReactTestUtils.renderIntoDocument(<GetDefaultPropsComponent />);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'getDefaultProps is only used on classic React.createClass definitions.' +
-      ' Use a static property named `defaultProps` instead.'
-    );
-  });
+  }
+  NullPropTypeComponent.propTypes = {
+    prop: null,
+  };
+  ReactTestUtils.renderIntoDocument(<NullPropTypeComponent />);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'NullPropTypeComponent: prop type `prop` is invalid; it must be a ' +
+    'function, usually from React.PropTypes.'
+  );
+});
 
+it('should warn on invalid context types', function() {
+  spyOn(console, 'error');
+  class NullContextTypeComponent extends React.Component {
+    render() {
+      return <span>{this.props.prop}</span>;
+    }
+  }
+  NullContextTypeComponent.contextTypes = {
+    prop: null,
+  };
+  ReactTestUtils.renderIntoDocument(<NullContextTypeComponent />);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'NullContextTypeComponent: context type `prop` is invalid; it must ' +
+    'be a function, usually from React.PropTypes.'
+  );
+});
+
+it('should warn if getDefaultProps is specificed on the class', function() {
+  spyOn(console, 'error');
+  class GetDefaultPropsComponent extends React.Component {
+    render() {
+      return <span>{this.props.prop}</span>;
+    }
+  }
+  GetDefaultPropsComponent.getDefaultProps = () => ({
+    prop: 'foo',
+  });
+  ReactTestUtils.renderIntoDocument(<GetDefaultPropsComponent />);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'getDefaultProps is only used on classic React.createClass definitions.' +
+    ' Use a static property named `defaultProps` instead.'
+  );
 });

--- a/src/renderers/art/__tests__/ReactART-test.js
+++ b/src/renderers/art/__tests__/ReactART-test.js
@@ -48,251 +48,247 @@ function testDOMNodeStructure(domNode, expectedStructure) {
   }
 }
 
-describe('ReactART', function() {
+beforeEach(function() {
+  ARTCurrentMode.setCurrent(ARTSVGMode);
 
-  beforeEach(function() {
-    ARTCurrentMode.setCurrent(ARTSVGMode);
+  Group = ReactART.Group;
+  Shape = ReactART.Shape;
+  Surface = ReactART.Surface;
 
-    Group = ReactART.Group;
-    Shape = ReactART.Shape;
-    Surface = ReactART.Surface;
+  TestComponent = class extends React.Component {
+    render() {
 
-    TestComponent = class extends React.Component {
-      render() {
+      var a =
+        <Shape
+          d="M0,0l50,0l0,50l-50,0z"
+          fill={new ReactART.LinearGradient(["black", "white"])}
+          key="a"
+          width={50} height={50}
+          x={50} y={50}
+          opacity={0.1}
+        />;
 
-        var a =
-          <Shape
-            d="M0,0l50,0l0,50l-50,0z"
-            fill={new ReactART.LinearGradient(["black", "white"])}
-            key="a"
-            width={50} height={50}
-            x={50} y={50}
-            opacity={0.1}
-          />;
+      var b =
+        <Shape
+          fill="#3C5A99"
+          key="b"
+          scale={0.5}
+          x={50} y={50}
+          title="This is an F"
+          cursor="pointer">
+          M64.564,38.583H54l0.008-5.834c0-3.035,0.293-4.666,4.657-4.666
+          h5.833V16.429h-9.33c-11.213,0-15.159,5.654-15.159,15.16v6.994
+          h-6.99v11.652h6.99v33.815H54V50.235h9.331L64.564,38.583z
+        </Shape>;
 
-        var b =
-          <Shape
-            fill="#3C5A99"
-            key="b"
-            scale={0.5}
-            x={50} y={50}
-            title="This is an F"
-            cursor="pointer">
-            M64.564,38.583H54l0.008-5.834c0-3.035,0.293-4.666,4.657-4.666
-            h5.833V16.429h-9.33c-11.213,0-15.159,5.654-15.159,15.16v6.994
-            h-6.99v11.652h6.99v33.815H54V50.235h9.331L64.564,38.583z
-          </Shape>;
+      var c = <Group key="c" />;
 
-        var c = <Group key="c" />;
+      return (
+        <Surface width={150} height={200}>
+          <Group ref="group">
+            {this.props.flipped ? [b, a, c] : [a, b, c]}
+          </Group>
+        </Surface>
+      );
+    }
+  };
+});
 
-        return (
-          <Surface width={150} height={200}>
-            <Group ref="group">
-              {this.props.flipped ? [b, a, c] : [a, b, c]}
-            </Group>
-          </Surface>
-        );
+it('should have the correct lifecycle state', function() {
+  var instance = <TestComponent />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  var group = instance.refs.group;
+  // Duck type test for an ART group
+  expect(typeof group.indicate).toBe('function');
+});
+
+it('should render a reasonable SVG structure in SVG mode', function() {
+  var instance = <TestComponent />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+
+  var expectedStructure = {
+    nodeName: 'svg',
+    width: '150',
+    height: '200',
+    children: [
+      { nodeName: 'defs' },
+      {
+        nodeName: 'g',
+        children: [
+          {
+            nodeName: 'defs',
+            children: [
+              { nodeName: 'linearGradient' }
+            ]
+          },
+          { nodeName: 'path' },
+          { nodeName: 'path' },
+          { nodeName: 'g' }
+        ]
       }
-    };
-  });
+    ]
+  };
 
-  it('should have the correct lifecycle state', function() {
-    var instance = <TestComponent />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-    var group = instance.refs.group;
-    // Duck type test for an ART group
-    expect(typeof group.indicate).toBe('function');
-  });
+  var realNode = ReactDOM.findDOMNode(instance);
+  testDOMNodeStructure(realNode, expectedStructure);
+});
 
-  it('should render a reasonable SVG structure in SVG mode', function() {
-    var instance = <TestComponent />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
+it('should be able to reorder components', function() {
+  var container = document.createElement('div');
+  var instance = ReactDOM.render(<TestComponent flipped={false} />, container);
 
-    var expectedStructure = {
-      nodeName: 'svg',
-      width: '150',
-      height: '200',
-      children: [
-        { nodeName: 'defs' },
-        {
-          nodeName: 'g',
-          children: [
-            {
-              nodeName: 'defs',
-              children: [
-                { nodeName: 'linearGradient' }
-              ]
-            },
-            { nodeName: 'path' },
-            { nodeName: 'path' },
-            { nodeName: 'g' }
-          ]
-        }
-      ]
-    };
-
-    var realNode = ReactDOM.findDOMNode(instance);
-    testDOMNodeStructure(realNode, expectedStructure);
-  });
-
-  it('should be able to reorder components', function() {
-    var container = document.createElement('div');
-    var instance = ReactDOM.render(<TestComponent flipped={false} />, container);
-
-    var expectedStructure = {
-      nodeName: 'svg',
-      children: [
-        { nodeName: 'defs' },
-        {
-          nodeName: 'g',
-          children: [
-            { nodeName: 'defs' },
-            { nodeName: 'path', opacity: '0.1' },
-            { nodeName: 'path', opacity: Missing },
-            { nodeName: 'g' }
-          ]
-        }
-      ]
-    };
-
-    var realNode = ReactDOM.findDOMNode(instance);
-    testDOMNodeStructure(realNode, expectedStructure);
-
-    ReactDOM.render(<TestComponent flipped={true} />, container);
-
-    var expectedNewStructure = {
-      nodeName: 'svg',
-      children: [
-        { nodeName: 'defs' },
-        {
-          nodeName: 'g',
-          children: [
-            { nodeName: 'defs' },
-            { nodeName: 'path', opacity: Missing },
-            { nodeName: 'path', opacity: '0.1' },
-            { nodeName: 'g' }
-          ]
-        }
-      ]
-    };
-
-    testDOMNodeStructure(realNode, expectedNewStructure);
-  });
-
-  it('should be able to reorder many components', function() {
-    var container = document.createElement('div');
-
-    class Component extends React.Component {
-      render() {
-        var chars = this.props.chars.split('');
-        return (
-          <Surface>
-            {chars.map((text) => <Shape key={text} title={text} />)}
-          </Surface>
-        );
+  var expectedStructure = {
+    nodeName: 'svg',
+    children: [
+      { nodeName: 'defs' },
+      {
+        nodeName: 'g',
+        children: [
+          { nodeName: 'defs' },
+          { nodeName: 'path', opacity: '0.1' },
+          { nodeName: 'path', opacity: Missing },
+          { nodeName: 'g' }
+        ]
       }
+    ]
+  };
+
+  var realNode = ReactDOM.findDOMNode(instance);
+  testDOMNodeStructure(realNode, expectedStructure);
+
+  ReactDOM.render(<TestComponent flipped={true} />, container);
+
+  var expectedNewStructure = {
+    nodeName: 'svg',
+    children: [
+      { nodeName: 'defs' },
+      {
+        nodeName: 'g',
+        children: [
+          { nodeName: 'defs' },
+          { nodeName: 'path', opacity: Missing },
+          { nodeName: 'path', opacity: '0.1' },
+          { nodeName: 'g' }
+        ]
+      }
+    ]
+  };
+
+  testDOMNodeStructure(realNode, expectedNewStructure);
+});
+
+it('should be able to reorder many components', function() {
+  var container = document.createElement('div');
+
+  class Component extends React.Component {
+    render() {
+      var chars = this.props.chars.split('');
+      return (
+        <Surface>
+          {chars.map((text) => <Shape key={text} title={text} />)}
+        </Surface>
+      );
+    }
+  }
+
+  // Mini multi-child stress test: lots of reorders, some adds, some removes.
+  var before = 'abcdefghijklmnopqrst';
+  var after = 'mxhpgwfralkeoivcstzy';
+
+  var instance = ReactDOM.render(<Component chars={before} />, container);
+  var realNode = ReactDOM.findDOMNode(instance);
+  expect(realNode.textContent).toBe(before);
+
+  instance = ReactDOM.render(<Component chars={after} />, container);
+  expect(realNode.textContent).toBe(after);
+
+  ReactDOM.unmountComponentAtNode(container);
+});
+
+it('renders composite with lifecycle inside group', function() {
+  var mounted = false;
+
+  class CustomShape extends React.Component {
+    render() {
+      return <Shape />;
     }
 
-    // Mini multi-child stress test: lots of reorders, some adds, some removes.
-    var before = 'abcdefghijklmnopqrst';
-    var after = 'mxhpgwfralkeoivcstzy';
+    componentDidMount() {
+      mounted = true;
+    }
+  }
 
-    var instance = ReactDOM.render(<Component chars={before} />, container);
-    var realNode = ReactDOM.findDOMNode(instance);
-    expect(realNode.textContent).toBe(before);
+  ReactTestUtils.renderIntoDocument(
+    <Surface>
+      <Group>
+        <CustomShape />
+      </Group>
+    </Surface>
+  );
+  expect(mounted).toBe(true);
+});
 
-    instance = ReactDOM.render(<Component chars={after} />, container);
-    expect(realNode.textContent).toBe(after);
+it('resolves refs before componentDidMount', function() {
+  class CustomShape extends React.Component {
+    render() {
+      return <Shape />;
+    }
+  }
 
-    ReactDOM.unmountComponentAtNode(container);
-  });
+  var ref = null;
 
-  it('renders composite with lifecycle inside group', function() {
-    var mounted = false;
-
-    class CustomShape extends React.Component {
-      render() {
-        return <Shape />;
-      }
-
-      componentDidMount() {
-        mounted = true;
-      }
+  class Outer extends React.Component {
+    componentDidMount() {
+      ref = this.refs.test;
     }
 
-    ReactTestUtils.renderIntoDocument(
-      <Surface>
-        <Group>
-          <CustomShape />
-        </Group>
-      </Surface>
-    );
-    expect(mounted).toBe(true);
-  });
+    render() {
+      return (
+        <Surface>
+          <Group>
+            <CustomShape ref="test" />
+          </Group>
+        </Surface>
+      );
+    }
+  }
 
-  it('resolves refs before componentDidMount', function() {
-    class CustomShape extends React.Component {
-      render() {
-        return <Shape />;
-      }
+  ReactTestUtils.renderIntoDocument(<Outer />);
+  expect(ref.constructor).toBe(CustomShape);
+});
+
+it('resolves refs before componentDidUpdate', function() {
+  class CustomShape extends React.Component {
+    render() {
+      return <Shape />;
+    }
+  }
+
+  var ref = {};
+
+  class Outer extends React.Component {
+    componentDidMount() {
+      ref = this.refs.test;
     }
 
-    var ref = null;
-
-    class Outer extends React.Component {
-      componentDidMount() {
-        ref = this.refs.test;
-      }
-
-      render() {
-        return (
-          <Surface>
-            <Group>
-              <CustomShape ref="test" />
-            </Group>
-          </Surface>
-        );
-      }
+    componentDidUpdate() {
+      ref = this.refs.test;
     }
 
-    ReactTestUtils.renderIntoDocument(<Outer />);
-    expect(ref.constructor).toBe(CustomShape);
-  });
-
-  it('resolves refs before componentDidUpdate', function() {
-    class CustomShape extends React.Component {
-      render() {
-        return <Shape />;
-      }
+    render() {
+      return (
+        <Surface>
+          <Group>
+            {this.props.mountCustomShape && <CustomShape ref="test" />}
+          </Group>
+        </Surface>
+      );
     }
+  }
 
-    var ref = {};
-
-    class Outer extends React.Component {
-      componentDidMount() {
-        ref = this.refs.test;
-      }
-
-      componentDidUpdate() {
-        ref = this.refs.test;
-      }
-
-      render() {
-        return (
-          <Surface>
-            <Group>
-              {this.props.mountCustomShape && <CustomShape ref="test" />}
-            </Group>
-          </Surface>
-        );
-      }
-    }
-
-    var container = document.createElement('div');
-    ReactDOM.render(<Outer />, container);
-    expect(ref).not.toBeDefined();
-    ReactDOM.render(<Outer mountCustomShape={true} />, container);
-    expect(ref.constructor).toBe(CustomShape);
-  });
-
+  var container = document.createElement('div');
+  ReactDOM.render(<Outer />, container);
+  expect(ref).not.toBeDefined();
+  ReactDOM.render(<Outer mountCustomShape={true} />, container);
+  expect(ref.constructor).toBe(CustomShape);
 });

--- a/src/renderers/dom/__tests__/ReactDOMProduction-test.js
+++ b/src/renderers/dom/__tests__/ReactDOMProduction-test.js
@@ -10,185 +10,183 @@
  */
 'use strict';
 
-describe('ReactDOMProduction', function() {
-  var oldProcess;
+var oldProcess;
 
-  var React;
-  var ReactDOM;
+var React;
+var ReactDOM;
 
-  beforeEach(function() {
-    __DEV__ = false;
-    oldProcess = process;
-    global.process = {env: {NODE_ENV: 'production'}};
+beforeEach(function() {
+  __DEV__ = false;
+  oldProcess = process;
+  global.process = {env: {NODE_ENV: 'production'}};
 
-    jest.resetModuleRegistry();
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-  });
+  jest.resetModuleRegistry();
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+});
 
-  afterEach(function() {
-    __DEV__ = true;
-    global.process = oldProcess;
-  });
+afterEach(function() {
+  __DEV__ = true;
+  global.process = oldProcess;
+});
 
-  it('should use prod fbjs', function() {
-    var warning = require('warning');
+it('should use prod fbjs', function() {
+  var warning = require('warning');
 
-    spyOn(console, 'error');
-    warning(false, 'Do cows go moo?');
-    expect(console.error.calls.count()).toBe(0);
-  });
+  spyOn(console, 'error');
+  warning(false, 'Do cows go moo?');
+  expect(console.error.calls.count()).toBe(0);
+});
 
-  it('should use prod React', function() {
-    spyOn(console, 'error');
+it('should use prod React', function() {
+  spyOn(console, 'error');
 
-    // no key warning
-    void <div>{[<span />]}</div>;
+  // no key warning
+  void <div>{[<span />]}</div>;
 
-    expect(console.error.calls.count()).toBe(0);
-  });
+  expect(console.error.calls.count()).toBe(0);
+});
 
-  it('should handle a simple flow', function() {
+it('should handle a simple flow', function() {
+  class Component extends React.Component {
+    render() {
+      return <span>{this.props.children}</span>;
+    }
+  }
+
+  var container = document.createElement('div');
+  var inst = ReactDOM.render(
+    <div className="blue">
+      <Component key={1}>A</Component>
+      <Component key={2}>B</Component>
+      <Component key={3}>C</Component>
+    </div>,
+    container
+  );
+
+  expect(container.firstChild).toBe(inst);
+  expect(inst.className).toBe('blue');
+  expect(inst.textContent).toBe('ABC');
+
+  ReactDOM.render(
+    <div className="red">
+      <Component key={2}>B</Component>
+      <Component key={1}>A</Component>
+      <Component key={3}>C</Component>
+    </div>,
+    container
+  );
+
+  expect(inst.className).toBe('red');
+  expect(inst.textContent).toBe('BAC');
+
+  ReactDOM.unmountComponentAtNode(container);
+
+  expect(container.childNodes.length).toBe(0);
+});
+
+it('should call lifecycle methods', function() {
+  var log = [];
+  class Component extends React.Component {
+    state = {y: 1};
+    shouldComponentUpdate(nextProps, nextState) {
+      log.push(['shouldComponentUpdate', nextProps, nextState]);
+      return nextProps.x !== this.props.x || nextState.y !== this.state.y;
+    }
+    componentWillMount() {
+      log.push(['componentWillMount']);
+    }
+    componentDidMount() {
+      log.push(['componentDidMount']);
+    }
+    componentWillReceiveProps(nextProps) {
+      log.push(['componentWillReceiveProps', nextProps]);
+    }
+    componentWillUpdate(nextProps, nextState) {
+      log.push(['componentWillUpdate', nextProps, nextState]);
+    }
+    componentDidUpdate(prevProps, prevState) {
+      log.push(['componentDidUpdate', prevProps, prevState]);
+    }
+    componentWillUnmount() {
+      log.push(['componentWillUnmount']);
+    }
+    render() {
+      log.push(['render']);
+      return null;
+    }
+  }
+
+  var container = document.createElement('div');
+  var inst = ReactDOM.render(
+    <Component x={1} />,
+    container
+  );
+  expect(log).toEqual([
+    ['componentWillMount'],
+    ['render'],
+    ['componentDidMount'],
+  ]);
+  log = [];
+
+  inst.setState({y: 2});
+  expect(log).toEqual([
+    ['shouldComponentUpdate', {x: 1}, {y: 2}],
+    ['componentWillUpdate', {x: 1}, {y: 2}],
+    ['render'],
+    ['componentDidUpdate', {x: 1}, {y: 1}],
+  ]);
+  log = [];
+
+  inst.setState({y: 2});
+  expect(log).toEqual([
+    ['shouldComponentUpdate', {x: 1}, {y: 2}],
+  ]);
+  log = [];
+
+  ReactDOM.render(
+    <Component x={2} />,
+    container
+  );
+  expect(log).toEqual([
+    ['componentWillReceiveProps', {x: 2}],
+    ['shouldComponentUpdate', {x: 2}, {y: 2}],
+    ['componentWillUpdate', {x: 2}, {y: 2}],
+    ['render'],
+    ['componentDidUpdate', {x: 1}, {y: 2}],
+  ]);
+  log = [];
+
+  ReactDOM.render(
+    <Component x={2} />,
+    container
+  );
+  expect(log).toEqual([
+    ['componentWillReceiveProps', {x: 2}],
+    ['shouldComponentUpdate', {x: 2}, {y: 2}],
+  ]);
+  log = [];
+
+  ReactDOM.unmountComponentAtNode(container);
+  expect(log).toEqual([
+    ['componentWillUnmount'],
+  ]);
+});
+
+it('should throw with an error code in production', function() {
+  expect(function() {
     class Component extends React.Component {
       render() {
-        return <span>{this.props.children}</span>;
+        return ['this is wrong'];
       }
     }
 
     var container = document.createElement('div');
-    var inst = ReactDOM.render(
-      <div className="blue">
-        <Component key={1}>A</Component>
-        <Component key={2}>B</Component>
-        <Component key={3}>C</Component>
-      </div>,
-      container
-    );
-
-    expect(container.firstChild).toBe(inst);
-    expect(inst.className).toBe('blue');
-    expect(inst.textContent).toBe('ABC');
-
-    ReactDOM.render(
-      <div className="red">
-        <Component key={2}>B</Component>
-        <Component key={1}>A</Component>
-        <Component key={3}>C</Component>
-      </div>,
-      container
-    );
-
-    expect(inst.className).toBe('red');
-    expect(inst.textContent).toBe('BAC');
-
-    ReactDOM.unmountComponentAtNode(container);
-
-    expect(container.childNodes.length).toBe(0);
-  });
-
-  it('should call lifecycle methods', function() {
-    var log = [];
-    class Component extends React.Component {
-      state = {y: 1};
-      shouldComponentUpdate(nextProps, nextState) {
-        log.push(['shouldComponentUpdate', nextProps, nextState]);
-        return nextProps.x !== this.props.x || nextState.y !== this.state.y;
-      }
-      componentWillMount() {
-        log.push(['componentWillMount']);
-      }
-      componentDidMount() {
-        log.push(['componentDidMount']);
-      }
-      componentWillReceiveProps(nextProps) {
-        log.push(['componentWillReceiveProps', nextProps]);
-      }
-      componentWillUpdate(nextProps, nextState) {
-        log.push(['componentWillUpdate', nextProps, nextState]);
-      }
-      componentDidUpdate(prevProps, prevState) {
-        log.push(['componentDidUpdate', prevProps, prevState]);
-      }
-      componentWillUnmount() {
-        log.push(['componentWillUnmount']);
-      }
-      render() {
-        log.push(['render']);
-        return null;
-      }
-    }
-
-    var container = document.createElement('div');
-    var inst = ReactDOM.render(
-      <Component x={1} />,
-      container
-    );
-    expect(log).toEqual([
-      ['componentWillMount'],
-      ['render'],
-      ['componentDidMount'],
-    ]);
-    log = [];
-
-    inst.setState({y: 2});
-    expect(log).toEqual([
-      ['shouldComponentUpdate', {x: 1}, {y: 2}],
-      ['componentWillUpdate', {x: 1}, {y: 2}],
-      ['render'],
-      ['componentDidUpdate', {x: 1}, {y: 1}],
-    ]);
-    log = [];
-
-    inst.setState({y: 2});
-    expect(log).toEqual([
-      ['shouldComponentUpdate', {x: 1}, {y: 2}],
-    ]);
-    log = [];
-
-    ReactDOM.render(
-      <Component x={2} />,
-      container
-    );
-    expect(log).toEqual([
-      ['componentWillReceiveProps', {x: 2}],
-      ['shouldComponentUpdate', {x: 2}, {y: 2}],
-      ['componentWillUpdate', {x: 2}, {y: 2}],
-      ['render'],
-      ['componentDidUpdate', {x: 1}, {y: 2}],
-    ]);
-    log = [];
-
-    ReactDOM.render(
-      <Component x={2} />,
-      container
-    );
-    expect(log).toEqual([
-      ['componentWillReceiveProps', {x: 2}],
-      ['shouldComponentUpdate', {x: 2}, {y: 2}],
-    ]);
-    log = [];
-
-    ReactDOM.unmountComponentAtNode(container);
-    expect(log).toEqual([
-      ['componentWillUnmount'],
-    ]);
-  });
-
-  it('should throw with an error code in production', function() {
-    expect(function() {
-      class Component extends React.Component {
-        render() {
-          return ['this is wrong'];
-        }
-      }
-
-      var container = document.createElement('div');
-      ReactDOM.render(<Component />, container);
-    }).toThrowError(
-      'Minified React error #109; visit ' +
-      'http://facebook.github.io/react/docs/error-decoder.html?invariant=109&args[]=Component' +
-      ' for the full message or use the non-minified dev environment' +
-      ' for full errors and additional helpful warnings.'
-    );
-  });
+    ReactDOM.render(<Component />, container);
+  }).toThrowError(
+    'Minified React error #109; visit ' +
+    'http://facebook.github.io/react/docs/error-decoder.html?invariant=109&args[]=Component' +
+    ' for the full message or use the non-minified dev environment' +
+    ' for full errors and additional helpful warnings.'
+  );
 });

--- a/src/renderers/dom/client/__tests__/ReactBrowserEventEmitter-test.js
+++ b/src/renderers/dom/client/__tests__/ReactBrowserEventEmitter-test.js
@@ -55,417 +55,414 @@ function getInternal(node) {
 }
 
 
-describe('ReactBrowserEventEmitter', function() {
-  beforeEach(function() {
-    jest.resetModuleRegistry();
-    LISTENER.mockClear();
-    EventListener = require('EventListener');
-    EventPluginHub = require('EventPluginHub');
-    EventPluginRegistry = require('EventPluginRegistry');
-    React = require('React');
-    ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
-    ReactDOMComponentTree = require('ReactDOMComponentTree');
-    ReactTestUtils = require('ReactTestUtils');
-    TapEventPlugin = require('TapEventPlugin');
+beforeEach(function() {
+  jest.resetModuleRegistry();
+  LISTENER.mockClear();
+  EventListener = require('EventListener');
+  EventPluginHub = require('EventPluginHub');
+  EventPluginRegistry = require('EventPluginRegistry');
+  React = require('React');
+  ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
+  ReactDOMComponentTree = require('ReactDOMComponentTree');
+  ReactTestUtils = require('ReactTestUtils');
+  TapEventPlugin = require('TapEventPlugin');
 
-    ReactTestUtils.renderIntoDocument(
-      <div ref={(c) => GRANDPARENT = c}>
-        <div ref={(c) => PARENT = c}>
-          <div ref={(c) => CHILD = c} />
-        </div>
+  ReactTestUtils.renderIntoDocument(
+    <div ref={(c) => GRANDPARENT = c}>
+      <div ref={(c) => PARENT = c}>
+        <div ref={(c) => CHILD = c} />
       </div>
-    );
-
-    idCallOrder = [];
-    tapMoveThreshold = TapEventPlugin.tapMoveThreshold;
-    EventPluginHub.injection.injectEventPluginsByName({
-      TapEventPlugin: TapEventPlugin,
-    });
-  });
-
-  it('should store a listener correctly', function() {
-    registerSimpleTestHandler();
-    var listener = EventPluginHub.getListener(getInternal(CHILD), ON_CLICK_KEY);
-    expect(listener).toBe(LISTENER);
-  });
-
-  it('should retrieve a listener correctly', function() {
-    registerSimpleTestHandler();
-    var listener = EventPluginHub.getListener(getInternal(CHILD), ON_CLICK_KEY);
-    expect(listener).toEqual(LISTENER);
-  });
-
-  it('should clear all handlers when asked to', function() {
-    registerSimpleTestHandler();
-    EventPluginHub.deleteAllListeners(getInternal(CHILD));
-    var listener = EventPluginHub.getListener(getInternal(CHILD), ON_CLICK_KEY);
-    expect(listener).toBe(undefined);
-  });
-
-  it('should invoke a simple handler registered on a node', function() {
-    registerSimpleTestHandler();
-    ReactTestUtils.Simulate.click(CHILD);
-    expect(LISTENER.mock.calls.length).toBe(1);
-  });
-
-  it(
-    'should not invoke handlers if ReactBrowserEventEmitter is disabled',
-    function() {
-      registerSimpleTestHandler();
-      ReactBrowserEventEmitter.setEnabled(false);
-      ReactTestUtils.SimulateNative.click(CHILD);
-      expect(LISTENER.mock.calls.length).toBe(0);
-      ReactBrowserEventEmitter.setEnabled(true);
-      ReactTestUtils.SimulateNative.click(CHILD);
-      expect(LISTENER.mock.calls.length).toBe(1);
-    }
+    </div>
   );
 
-  it('should bubble simply', function() {
-    EventPluginHub.putListener(
-      getInternal(CHILD),
-      ON_CLICK_KEY,
-      recordID.bind(null, getInternal(CHILD))
-    );
-    EventPluginHub.putListener(
-      getInternal(PARENT),
-      ON_CLICK_KEY,
-      recordID.bind(null, getInternal(PARENT))
-    );
-    EventPluginHub.putListener(
-      getInternal(GRANDPARENT),
-      ON_CLICK_KEY,
-      recordID.bind(null, getInternal(GRANDPARENT))
-    );
+  idCallOrder = [];
+  tapMoveThreshold = TapEventPlugin.tapMoveThreshold;
+  EventPluginHub.injection.injectEventPluginsByName({
+    TapEventPlugin: TapEventPlugin,
+  });
+});
+
+it('should store a listener correctly', function() {
+  registerSimpleTestHandler();
+  var listener = EventPluginHub.getListener(getInternal(CHILD), ON_CLICK_KEY);
+  expect(listener).toBe(LISTENER);
+});
+
+it('should retrieve a listener correctly', function() {
+  registerSimpleTestHandler();
+  var listener = EventPluginHub.getListener(getInternal(CHILD), ON_CLICK_KEY);
+  expect(listener).toEqual(LISTENER);
+});
+
+it('should clear all handlers when asked to', function() {
+  registerSimpleTestHandler();
+  EventPluginHub.deleteAllListeners(getInternal(CHILD));
+  var listener = EventPluginHub.getListener(getInternal(CHILD), ON_CLICK_KEY);
+  expect(listener).toBe(undefined);
+});
+
+it('should invoke a simple handler registered on a node', function() {
+  registerSimpleTestHandler();
+  ReactTestUtils.Simulate.click(CHILD);
+  expect(LISTENER.mock.calls.length).toBe(1);
+});
+
+it(
+  'should not invoke handlers if ReactBrowserEventEmitter is disabled',
+  function() {
+    registerSimpleTestHandler();
+    ReactBrowserEventEmitter.setEnabled(false);
+    ReactTestUtils.SimulateNative.click(CHILD);
+    expect(LISTENER.mock.calls.length).toBe(0);
+    ReactBrowserEventEmitter.setEnabled(true);
+    ReactTestUtils.SimulateNative.click(CHILD);
+    expect(LISTENER.mock.calls.length).toBe(1);
+  }
+);
+
+it('should bubble simply', function() {
+  EventPluginHub.putListener(
+    getInternal(CHILD),
+    ON_CLICK_KEY,
+    recordID.bind(null, getInternal(CHILD))
+  );
+  EventPluginHub.putListener(
+    getInternal(PARENT),
+    ON_CLICK_KEY,
+    recordID.bind(null, getInternal(PARENT))
+  );
+  EventPluginHub.putListener(
+    getInternal(GRANDPARENT),
+    ON_CLICK_KEY,
+    recordID.bind(null, getInternal(GRANDPARENT))
+  );
+  ReactTestUtils.Simulate.click(CHILD);
+  expect(idCallOrder.length).toBe(3);
+  expect(idCallOrder[0]).toBe(getInternal(CHILD));
+  expect(idCallOrder[1]).toBe(getInternal(PARENT));
+  expect(idCallOrder[2]).toBe(getInternal(GRANDPARENT));
+});
+
+it('should continue bubbling if an error is thrown', function() {
+  EventPluginHub.putListener(
+    getInternal(CHILD),
+    ON_CLICK_KEY,
+    recordID.bind(null, getInternal(CHILD))
+  );
+  EventPluginHub.putListener(
+    getInternal(PARENT),
+    ON_CLICK_KEY,
+    function() {
+      recordID(getInternal(PARENT));
+      throw new Error('Handler interrupted');
+    }
+  );
+  EventPluginHub.putListener(
+    getInternal(GRANDPARENT),
+    ON_CLICK_KEY,
+    recordID.bind(null, getInternal(GRANDPARENT))
+  );
+  expect(function() {
     ReactTestUtils.Simulate.click(CHILD);
-    expect(idCallOrder.length).toBe(3);
-    expect(idCallOrder[0]).toBe(getInternal(CHILD));
-    expect(idCallOrder[1]).toBe(getInternal(PARENT));
-    expect(idCallOrder[2]).toBe(getInternal(GRANDPARENT));
-  });
+  }).toThrow();
+  expect(idCallOrder.length).toBe(3);
+  expect(idCallOrder[0]).toBe(getInternal(CHILD));
+  expect(idCallOrder[1]).toBe(getInternal(PARENT));
+  expect(idCallOrder[2]).toBe(getInternal(GRANDPARENT));
+});
 
-  it('should continue bubbling if an error is thrown', function() {
-    EventPluginHub.putListener(
-      getInternal(CHILD),
-      ON_CLICK_KEY,
-      recordID.bind(null, getInternal(CHILD))
-    );
-    EventPluginHub.putListener(
-      getInternal(PARENT),
-      ON_CLICK_KEY,
-      function() {
-        recordID(getInternal(PARENT));
-        throw new Error('Handler interrupted');
-      }
-    );
-    EventPluginHub.putListener(
-      getInternal(GRANDPARENT),
-      ON_CLICK_KEY,
-      recordID.bind(null, getInternal(GRANDPARENT))
-    );
-    expect(function() {
-      ReactTestUtils.Simulate.click(CHILD);
-    }).toThrow();
-    expect(idCallOrder.length).toBe(3);
-    expect(idCallOrder[0]).toBe(getInternal(CHILD));
-    expect(idCallOrder[1]).toBe(getInternal(PARENT));
-    expect(idCallOrder[2]).toBe(getInternal(GRANDPARENT));
-  });
+it('should set currentTarget', function() {
+  EventPluginHub.putListener(
+    getInternal(CHILD),
+    ON_CLICK_KEY,
+    function(event) {
+      recordID(getInternal(CHILD));
+      expect(event.currentTarget).toBe(CHILD);
+    }
+  );
+  EventPluginHub.putListener(
+    getInternal(PARENT),
+    ON_CLICK_KEY,
+    function(event) {
+      recordID(getInternal(PARENT));
+      expect(event.currentTarget).toBe(PARENT);
+    }
+  );
+  EventPluginHub.putListener(
+    getInternal(GRANDPARENT),
+    ON_CLICK_KEY,
+    function(event) {
+      recordID(getInternal(GRANDPARENT));
+      expect(event.currentTarget).toBe(GRANDPARENT);
+    }
+  );
+  ReactTestUtils.Simulate.click(CHILD);
+  expect(idCallOrder.length).toBe(3);
+  expect(idCallOrder[0]).toBe(getInternal(CHILD));
+  expect(idCallOrder[1]).toBe(getInternal(PARENT));
+  expect(idCallOrder[2]).toBe(getInternal(GRANDPARENT));
+});
 
-  it('should set currentTarget', function() {
-    EventPluginHub.putListener(
-      getInternal(CHILD),
-      ON_CLICK_KEY,
-      function(event) {
-        recordID(getInternal(CHILD));
-        expect(event.currentTarget).toBe(CHILD);
-      }
-    );
-    EventPluginHub.putListener(
-      getInternal(PARENT),
-      ON_CLICK_KEY,
-      function(event) {
-        recordID(getInternal(PARENT));
-        expect(event.currentTarget).toBe(PARENT);
-      }
-    );
-    EventPluginHub.putListener(
-      getInternal(GRANDPARENT),
-      ON_CLICK_KEY,
-      function(event) {
-        recordID(getInternal(GRANDPARENT));
-        expect(event.currentTarget).toBe(GRANDPARENT);
-      }
-    );
-    ReactTestUtils.Simulate.click(CHILD);
-    expect(idCallOrder.length).toBe(3);
-    expect(idCallOrder[0]).toBe(getInternal(CHILD));
-    expect(idCallOrder[1]).toBe(getInternal(PARENT));
-    expect(idCallOrder[2]).toBe(getInternal(GRANDPARENT));
-  });
+it('should support stopPropagation()', function() {
+  EventPluginHub.putListener(
+    getInternal(CHILD),
+    ON_CLICK_KEY,
+    recordID.bind(null, getInternal(CHILD))
+  );
+  EventPluginHub.putListener(
+    getInternal(PARENT),
+    ON_CLICK_KEY,
+    recordIDAndStopPropagation.bind(null, getInternal(PARENT))
+  );
+  EventPluginHub.putListener(
+    getInternal(GRANDPARENT),
+    ON_CLICK_KEY,
+    recordID.bind(null, getInternal(GRANDPARENT))
+  );
+  ReactTestUtils.Simulate.click(CHILD);
+  expect(idCallOrder.length).toBe(2);
+  expect(idCallOrder[0]).toBe(getInternal(CHILD));
+  expect(idCallOrder[1]).toBe(getInternal(PARENT));
+});
 
-  it('should support stopPropagation()', function() {
-    EventPluginHub.putListener(
-      getInternal(CHILD),
-      ON_CLICK_KEY,
-      recordID.bind(null, getInternal(CHILD))
-    );
-    EventPluginHub.putListener(
-      getInternal(PARENT),
-      ON_CLICK_KEY,
-      recordIDAndStopPropagation.bind(null, getInternal(PARENT))
-    );
-    EventPluginHub.putListener(
-      getInternal(GRANDPARENT),
-      ON_CLICK_KEY,
-      recordID.bind(null, getInternal(GRANDPARENT))
-    );
-    ReactTestUtils.Simulate.click(CHILD);
-    expect(idCallOrder.length).toBe(2);
-    expect(idCallOrder[0]).toBe(getInternal(CHILD));
-    expect(idCallOrder[1]).toBe(getInternal(PARENT));
-  });
+it('should stop after first dispatch if stopPropagation', function() {
+  EventPluginHub.putListener(
+    getInternal(CHILD),
+    ON_CLICK_KEY,
+    recordIDAndStopPropagation.bind(null, getInternal(CHILD))
+  );
+  EventPluginHub.putListener(
+    getInternal(PARENT),
+    ON_CLICK_KEY,
+    recordID.bind(null, getInternal(PARENT))
+  );
+  EventPluginHub.putListener(
+    getInternal(GRANDPARENT),
+    ON_CLICK_KEY,
+    recordID.bind(null, getInternal(GRANDPARENT))
+  );
+  ReactTestUtils.Simulate.click(CHILD);
+  expect(idCallOrder.length).toBe(1);
+  expect(idCallOrder[0]).toBe(getInternal(CHILD));
+});
 
-  it('should stop after first dispatch if stopPropagation', function() {
-    EventPluginHub.putListener(
-      getInternal(CHILD),
-      ON_CLICK_KEY,
-      recordIDAndStopPropagation.bind(null, getInternal(CHILD))
-    );
-    EventPluginHub.putListener(
-      getInternal(PARENT),
-      ON_CLICK_KEY,
-      recordID.bind(null, getInternal(PARENT))
-    );
-    EventPluginHub.putListener(
-      getInternal(GRANDPARENT),
-      ON_CLICK_KEY,
-      recordID.bind(null, getInternal(GRANDPARENT))
-    );
-    ReactTestUtils.Simulate.click(CHILD);
-    expect(idCallOrder.length).toBe(1);
-    expect(idCallOrder[0]).toBe(getInternal(CHILD));
-  });
+it('should not stopPropagation if false is returned', function() {
+  EventPluginHub.putListener(
+    getInternal(CHILD),
+    ON_CLICK_KEY,
+    recordIDAndReturnFalse.bind(null, getInternal(CHILD))
+  );
+  EventPluginHub.putListener(
+    getInternal(PARENT),
+    ON_CLICK_KEY,
+    recordID.bind(null, getInternal(PARENT))
+  );
+  EventPluginHub.putListener(
+    getInternal(GRANDPARENT),
+    ON_CLICK_KEY,
+    recordID.bind(null, getInternal(GRANDPARENT))
+  );
+  spyOn(console, 'error');
+  ReactTestUtils.Simulate.click(CHILD);
+  expect(idCallOrder.length).toBe(3);
+  expect(idCallOrder[0]).toBe(getInternal(CHILD));
+  expect(idCallOrder[1]).toBe(getInternal(PARENT));
+  expect(idCallOrder[2]).toBe(getInternal(GRANDPARENT));
+  expect(console.error.calls.count()).toEqual(0);
+});
 
-  it('should not stopPropagation if false is returned', function() {
-    EventPluginHub.putListener(
-      getInternal(CHILD),
-      ON_CLICK_KEY,
-      recordIDAndReturnFalse.bind(null, getInternal(CHILD))
-    );
-    EventPluginHub.putListener(
-      getInternal(PARENT),
-      ON_CLICK_KEY,
-      recordID.bind(null, getInternal(PARENT))
-    );
-    EventPluginHub.putListener(
-      getInternal(GRANDPARENT),
-      ON_CLICK_KEY,
-      recordID.bind(null, getInternal(GRANDPARENT))
-    );
-    spyOn(console, 'error');
-    ReactTestUtils.Simulate.click(CHILD);
-    expect(idCallOrder.length).toBe(3);
-    expect(idCallOrder[0]).toBe(getInternal(CHILD));
-    expect(idCallOrder[1]).toBe(getInternal(PARENT));
-    expect(idCallOrder[2]).toBe(getInternal(GRANDPARENT));
-    expect(console.error.calls.count()).toEqual(0);
-  });
+/**
+ * The entire event registration state of the world should be "locked-in" at
+ * the time the event occurs. This is to resolve many edge cases that come
+ * about from a listener on a lower-in-DOM node causing structural changes at
+ * places higher in the DOM. If this lower-in-DOM node causes new content to
+ * be rendered at a place higher-in-DOM, we need to be careful not to invoke
+ * these new listeners.
+ */
 
-  /**
-   * The entire event registration state of the world should be "locked-in" at
-   * the time the event occurs. This is to resolve many edge cases that come
-   * about from a listener on a lower-in-DOM node causing structural changes at
-   * places higher in the DOM. If this lower-in-DOM node causes new content to
-   * be rendered at a place higher-in-DOM, we need to be careful not to invoke
-   * these new listeners.
-   */
+it('should invoke handlers that were removed while bubbling', function() {
+  var handleParentClick = jest.fn();
+  var handleChildClick = function(event) {
+    EventPluginHub.deleteAllListeners(getInternal(PARENT));
+  };
+  EventPluginHub.putListener(
+    getInternal(CHILD),
+    ON_CLICK_KEY,
+    handleChildClick
+  );
+  EventPluginHub.putListener(
+    getInternal(PARENT),
+    ON_CLICK_KEY,
+    handleParentClick
+  );
+  ReactTestUtils.Simulate.click(CHILD);
+  expect(handleParentClick.mock.calls.length).toBe(1);
+});
 
-  it('should invoke handlers that were removed while bubbling', function() {
-    var handleParentClick = jest.fn();
-    var handleChildClick = function(event) {
-      EventPluginHub.deleteAllListeners(getInternal(PARENT));
-    };
-    EventPluginHub.putListener(
-      getInternal(CHILD),
-      ON_CLICK_KEY,
-      handleChildClick
-    );
+it('should not invoke newly inserted handlers while bubbling', function() {
+  var handleParentClick = jest.fn();
+  var handleChildClick = function(event) {
     EventPluginHub.putListener(
       getInternal(PARENT),
       ON_CLICK_KEY,
       handleParentClick
     );
-    ReactTestUtils.Simulate.click(CHILD);
-    expect(handleParentClick.mock.calls.length).toBe(1);
-  });
+  };
+  EventPluginHub.putListener(
+    getInternal(CHILD),
+    ON_CLICK_KEY,
+    handleChildClick
+  );
+  ReactTestUtils.Simulate.click(CHILD);
+  expect(handleParentClick.mock.calls.length).toBe(0);
+});
 
-  it('should not invoke newly inserted handlers while bubbling', function() {
-    var handleParentClick = jest.fn();
-    var handleChildClick = function(event) {
-      EventPluginHub.putListener(
-        getInternal(PARENT),
-        ON_CLICK_KEY,
-        handleParentClick
-      );
-    };
-    EventPluginHub.putListener(
-      getInternal(CHILD),
-      ON_CLICK_KEY,
-      handleChildClick
-    );
-    ReactTestUtils.Simulate.click(CHILD);
-    expect(handleParentClick.mock.calls.length).toBe(0);
-  });
+it('should have mouse enter simulated by test utils', function() {
+  EventPluginHub.putListener(
+    getInternal(CHILD),
+    ON_MOUSE_ENTER_KEY,
+    recordID.bind(null, getInternal(CHILD))
+  );
+  ReactTestUtils.Simulate.mouseEnter(CHILD);
+  expect(idCallOrder.length).toBe(1);
+  expect(idCallOrder[0]).toBe(getInternal(CHILD));
+});
 
-  it('should have mouse enter simulated by test utils', function() {
-    EventPluginHub.putListener(
-      getInternal(CHILD),
-      ON_MOUSE_ENTER_KEY,
-      recordID.bind(null, getInternal(CHILD))
-    );
-    ReactTestUtils.Simulate.mouseEnter(CHILD);
-    expect(idCallOrder.length).toBe(1);
-    expect(idCallOrder[0]).toBe(getInternal(CHILD));
-  });
+it('should infer onTouchTap from a touchStart/End', function() {
+  EventPluginHub.putListener(
+    getInternal(CHILD),
+    ON_TOUCH_TAP_KEY,
+    recordID.bind(null, getInternal(CHILD))
+  );
+  ReactTestUtils.SimulateNative.touchStart(
+    CHILD,
+    ReactTestUtils.nativeTouchData(0, 0)
+  );
+  ReactTestUtils.SimulateNative.touchEnd(
+    CHILD,
+    ReactTestUtils.nativeTouchData(0, 0)
+  );
+  expect(idCallOrder.length).toBe(1);
+  expect(idCallOrder[0]).toBe(getInternal(CHILD));
+});
 
-  it('should infer onTouchTap from a touchStart/End', function() {
-    EventPluginHub.putListener(
-      getInternal(CHILD),
-      ON_TOUCH_TAP_KEY,
-      recordID.bind(null, getInternal(CHILD))
-    );
-    ReactTestUtils.SimulateNative.touchStart(
-      CHILD,
-      ReactTestUtils.nativeTouchData(0, 0)
-    );
-    ReactTestUtils.SimulateNative.touchEnd(
-      CHILD,
-      ReactTestUtils.nativeTouchData(0, 0)
-    );
-    expect(idCallOrder.length).toBe(1);
-    expect(idCallOrder[0]).toBe(getInternal(CHILD));
-  });
+it('should infer onTouchTap from when dragging below threshold', function() {
+  EventPluginHub.putListener(
+    getInternal(CHILD),
+    ON_TOUCH_TAP_KEY,
+    recordID.bind(null, getInternal(CHILD))
+  );
+  ReactTestUtils.SimulateNative.touchStart(
+    CHILD,
+    ReactTestUtils.nativeTouchData(0, 0)
+  );
+  ReactTestUtils.SimulateNative.touchEnd(
+    CHILD,
+    ReactTestUtils.nativeTouchData(0, tapMoveThreshold - 1)
+  );
+  expect(idCallOrder.length).toBe(1);
+  expect(idCallOrder[0]).toBe(getInternal(CHILD));
+});
 
-  it('should infer onTouchTap from when dragging below threshold', function() {
-    EventPluginHub.putListener(
-      getInternal(CHILD),
-      ON_TOUCH_TAP_KEY,
-      recordID.bind(null, getInternal(CHILD))
-    );
-    ReactTestUtils.SimulateNative.touchStart(
-      CHILD,
-      ReactTestUtils.nativeTouchData(0, 0)
-    );
-    ReactTestUtils.SimulateNative.touchEnd(
-      CHILD,
-      ReactTestUtils.nativeTouchData(0, tapMoveThreshold - 1)
-    );
-    expect(idCallOrder.length).toBe(1);
-    expect(idCallOrder[0]).toBe(getInternal(CHILD));
-  });
+it('should not onTouchTap from when dragging beyond threshold', function() {
+  EventPluginHub.putListener(
+    getInternal(CHILD),
+    ON_TOUCH_TAP_KEY,
+    recordID.bind(null, getInternal(CHILD))
+  );
+  ReactTestUtils.SimulateNative.touchStart(
+    CHILD,
+    ReactTestUtils.nativeTouchData(0, 0)
+  );
+  ReactTestUtils.SimulateNative.touchEnd(
+    CHILD,
+    ReactTestUtils.nativeTouchData(0, tapMoveThreshold + 1)
+  );
+  expect(idCallOrder.length).toBe(0);
+});
 
-  it('should not onTouchTap from when dragging beyond threshold', function() {
-    EventPluginHub.putListener(
-      getInternal(CHILD),
-      ON_TOUCH_TAP_KEY,
-      recordID.bind(null, getInternal(CHILD))
-    );
-    ReactTestUtils.SimulateNative.touchStart(
-      CHILD,
-      ReactTestUtils.nativeTouchData(0, 0)
-    );
-    ReactTestUtils.SimulateNative.touchEnd(
-      CHILD,
-      ReactTestUtils.nativeTouchData(0, tapMoveThreshold + 1)
-    );
-    expect(idCallOrder.length).toBe(0);
-  });
+it('should listen to events only once', function() {
+  spyOn(EventListener, 'listen');
+  ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
+  ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
+  expect(EventListener.listen.calls.count()).toBe(1);
+});
 
-  it('should listen to events only once', function() {
-    spyOn(EventListener, 'listen');
-    ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
-    ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
-    expect(EventListener.listen.calls.count()).toBe(1);
-  });
+it('should work with event plugins without dependencies', function() {
+  spyOn(EventListener, 'listen');
 
-  it('should work with event plugins without dependencies', function() {
-    spyOn(EventListener, 'listen');
+  ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
 
-    ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
+  expect(EventListener.listen.calls.argsFor(0)[1]).toBe('click');
+});
 
-    expect(EventListener.listen.calls.argsFor(0)[1]).toBe('click');
-  });
+it('should work with event plugins with dependencies', function() {
+  spyOn(EventListener, 'listen');
+  spyOn(EventListener, 'capture');
 
-  it('should work with event plugins with dependencies', function() {
-    spyOn(EventListener, 'listen');
-    spyOn(EventListener, 'capture');
+  ReactBrowserEventEmitter.listenTo(ON_CHANGE_KEY, document);
 
-    ReactBrowserEventEmitter.listenTo(ON_CHANGE_KEY, document);
+  var setEventListeners = [];
+  var listenCalls = EventListener.listen.calls.allArgs();
+  var captureCalls = EventListener.capture.calls.allArgs();
+  for (var i = 0; i < listenCalls.length; i++) {
+    setEventListeners.push(listenCalls[i][1]);
+  }
+  for (i = 0; i < captureCalls.length; i++) {
+    setEventListeners.push(captureCalls[i][1]);
+  }
 
-    var setEventListeners = [];
-    var listenCalls = EventListener.listen.calls.allArgs();
-    var captureCalls = EventListener.capture.calls.allArgs();
-    for (var i = 0; i < listenCalls.length; i++) {
-      setEventListeners.push(listenCalls[i][1]);
-    }
-    for (i = 0; i < captureCalls.length; i++) {
-      setEventListeners.push(captureCalls[i][1]);
-    }
+  var module = EventPluginRegistry.registrationNameModules[ON_CHANGE_KEY];
+  var dependencies = module.eventTypes.change.dependencies;
+  expect(setEventListeners.length).toEqual(dependencies.length);
 
-    var module = EventPluginRegistry.registrationNameModules[ON_CHANGE_KEY];
-    var dependencies = module.eventTypes.change.dependencies;
-    expect(setEventListeners.length).toEqual(dependencies.length);
+  for (i = 0; i < setEventListeners.length; i++) {
+    expect(dependencies.indexOf(setEventListeners[i])).toBeTruthy();
+  }
+});
 
-    for (i = 0; i < setEventListeners.length; i++) {
-      expect(dependencies.indexOf(setEventListeners[i])).toBeTruthy();
-    }
-  });
+it('should bubble onTouchTap', function() {
+  EventPluginHub.putListener(
+    getInternal(CHILD),
+    ON_TOUCH_TAP_KEY,
+    recordID.bind(null, getInternal(CHILD))
+  );
+  EventPluginHub.putListener(
+    getInternal(PARENT),
+    ON_TOUCH_TAP_KEY,
+    recordID.bind(null, getInternal(PARENT))
+  );
+  EventPluginHub.putListener(
+    getInternal(GRANDPARENT),
+    ON_TOUCH_TAP_KEY,
+    recordID.bind(null, getInternal(GRANDPARENT))
+  );
+  ReactTestUtils.SimulateNative.touchStart(
+    CHILD,
+    ReactTestUtils.nativeTouchData(0, 0)
+  );
+  ReactTestUtils.SimulateNative.touchEnd(
+    CHILD,
+    ReactTestUtils.nativeTouchData(0, 0)
+  );
+  expect(idCallOrder.length).toBe(3);
+  expect(idCallOrder[0]).toBe(getInternal(CHILD));
+  expect(idCallOrder[1]).toBe(getInternal(PARENT));
+  expect(idCallOrder[2]).toBe(getInternal(GRANDPARENT));
+});
 
-  it('should bubble onTouchTap', function() {
-    EventPluginHub.putListener(
-      getInternal(CHILD),
-      ON_TOUCH_TAP_KEY,
-      recordID.bind(null, getInternal(CHILD))
-    );
-    EventPluginHub.putListener(
-      getInternal(PARENT),
-      ON_TOUCH_TAP_KEY,
-      recordID.bind(null, getInternal(PARENT))
-    );
-    EventPluginHub.putListener(
-      getInternal(GRANDPARENT),
-      ON_TOUCH_TAP_KEY,
-      recordID.bind(null, getInternal(GRANDPARENT))
-    );
-    ReactTestUtils.SimulateNative.touchStart(
-      CHILD,
-      ReactTestUtils.nativeTouchData(0, 0)
-    );
-    ReactTestUtils.SimulateNative.touchEnd(
-      CHILD,
-      ReactTestUtils.nativeTouchData(0, 0)
-    );
-    expect(idCallOrder.length).toBe(3);
-    expect(idCallOrder[0]).toBe(getInternal(CHILD));
-    expect(idCallOrder[1]).toBe(getInternal(PARENT));
-    expect(idCallOrder[2]).toBe(getInternal(GRANDPARENT));
-  });
+it('should not crash ensureScrollValueMonitoring when createEvent returns null', function() {
+  var originalCreateEvent = document.createEvent;
+  document.createEvent = function() {
+    return null;
+  };
+  spyOn(document, 'createEvent');
 
-  it('should not crash ensureScrollValueMonitoring when createEvent returns null', function() {
-    var originalCreateEvent = document.createEvent;
-    document.createEvent = function() {
-      return null;
-    };
-    spyOn(document, 'createEvent');
-
-    try {
-      var hasEventPageXY = ReactBrowserEventEmitter.supportsEventPageXY();
-      expect(document.createEvent.calls.count()).toBe(1);
-      expect(hasEventPageXY).toBe(false);
-    } finally {
-      document.createEvent = originalCreateEvent;
-    }
-  });
-
+  try {
+    var hasEventPageXY = ReactBrowserEventEmitter.supportsEventPageXY();
+    expect(document.createEvent.calls.count()).toBe(1);
+    expect(hasEventPageXY).toBe(false);
+  } finally {
+    document.createEvent = originalCreateEvent;
+  }
 });

--- a/src/renderers/dom/client/__tests__/ReactDOM-test.js
+++ b/src/renderers/dom/client/__tests__/ReactDOM-test.js
@@ -16,165 +16,163 @@ var ReactDOM = require('ReactDOM');
 var ReactTestUtils = require('ReactTestUtils');
 var div = React.createFactory('div');
 
-describe('ReactDOM', function() {
-  // TODO: uncomment this test once we can run in phantom, which
-  // supports real submit events.
-  /*
-  it('should bubble onSubmit', function() {
-    var count = 0;
-    var form;
-    var Parent = React.createClass({
-      handleSubmit: function() {
-        count++;
-        return false;
-      },
-      render: function() {
-        return <Child />;
-      }
-    });
-    var Child = React.createClass({
-      render: function() {
-        return <form><input type="submit" value="Submit" /></form>;
-      },
-      componentDidMount: function() {
-        form = ReactDOM.findDOMNode(this);
-      }
-    });
-    var instance = ReactTestUtils.renderIntoDocument(<Parent />);
-    form.submit();
-    expect(count).toEqual(1);
-  });
-  */
-
-  it('allows a DOM element to be used with a string', function() {
-    var element = React.createElement('div', {className: 'foo'});
-    var instance = ReactTestUtils.renderIntoDocument(element);
-    expect(ReactDOM.findDOMNode(instance).tagName).toBe('DIV');
-  });
-
-  it('should allow children to be passed as an argument', function() {
-    var argDiv = ReactTestUtils.renderIntoDocument(
-      div(null, 'child')
-    );
-    var argNode = ReactDOM.findDOMNode(argDiv);
-    expect(argNode.innerHTML).toBe('child');
-  });
-
-  it('should overwrite props.children with children argument', function() {
-    var conflictDiv = ReactTestUtils.renderIntoDocument(
-      div({children: 'fakechild'}, 'child')
-    );
-    var conflictNode = ReactDOM.findDOMNode(conflictDiv);
-    expect(conflictNode.innerHTML).toBe('child');
-  });
-
-  /**
-   * We need to make sure that updates occur to the actual node that's in the
-   * DOM, instead of a stale cache.
-   */
-  it('should purge the DOM cache when removing nodes', function() {
-    var myDiv = ReactTestUtils.renderIntoDocument(
-      <div>
-        <div key="theDog" className="dog" />,
-        <div key="theBird" className="bird" />
-      </div>
-    );
-    // Warm the cache with theDog
-    myDiv = ReactTestUtils.renderIntoDocument(
-      <div>
-        <div key="theDog" className="dogbeforedelete" />,
-        <div key="theBird" className="bird" />,
-      </div>
-    );
-    // Remove theDog - this should purge the cache
-    myDiv = ReactTestUtils.renderIntoDocument(
-      <div>
-        <div key="theBird" className="bird" />,
-      </div>
-    );
-    // Now, put theDog back. It's now a different DOM node.
-    myDiv = ReactTestUtils.renderIntoDocument(
-      <div>
-        <div key="theDog" className="dog" />,
-        <div key="theBird" className="bird" />,
-      </div>
-    );
-    // Change the className of theDog. It will use the same element
-    myDiv = ReactTestUtils.renderIntoDocument(
-      <div>
-        <div key="theDog" className="bigdog" />,
-        <div key="theBird" className="bird" />,
-      </div>
-    );
-    var root = ReactDOM.findDOMNode(myDiv);
-    var dog = root.childNodes[0];
-    expect(dog.className).toBe('bigdog');
-  });
-
-  it('allow React.DOM factories to be called without warnings', function() {
-    spyOn(console, 'error');
-    var element = React.DOM.div();
-    expect(element.type).toBe('div');
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('throws in render() if the mount callback is not a function', function() {
-    function Foo() {
-      this.a = 1;
-      this.b = 2;
+// TODO: uncomment this test once we can run in phantom, which
+// supports real submit events.
+/*
+it('should bubble onSubmit', function() {
+  var count = 0;
+  var form;
+  var Parent = React.createClass({
+    handleSubmit: function() {
+      count++;
+      return false;
+    },
+    render: function() {
+      return <Child />;
     }
-
-    class A extends React.Component {
-      state = {};
-
-      render() {
-        return <div />;
-      }
-    }
-
-    var myDiv = document.createElement('div');
-    expect(() => ReactDOM.render(<A />, myDiv, 'no')).toThrowError(
-      'ReactDOM.render(...): Expected the last optional `callback` argument ' +
-      'to be a function. Instead received: string.'
-    );
-    expect(() => ReactDOM.render(<A />, myDiv, {})).toThrowError(
-      'ReactDOM.render(...): Expected the last optional `callback` argument ' +
-      'to be a function. Instead received: Object.'
-    );
-    expect(() => ReactDOM.render(<A />, myDiv, new Foo())).toThrowError(
-      'ReactDOM.render(...): Expected the last optional `callback` argument ' +
-      'to be a function. Instead received: Foo (keys: a, b).'
-    );
   });
-
-  it('throws in render() if the update callback is not a function', function() {
-    function Foo() {
-      this.a = 1;
-      this.b = 2;
+  var Child = React.createClass({
+    render: function() {
+      return <form><input type="submit" value="Submit" /></form>;
+    },
+    componentDidMount: function() {
+      form = ReactDOM.findDOMNode(this);
     }
-
-    class A extends React.Component {
-      state = {};
-
-      render() {
-        return <div />;
-      }
-    }
-
-    var myDiv = document.createElement('div');
-    ReactDOM.render(<A />, myDiv);
-
-    expect(() => ReactDOM.render(<A />, myDiv, 'no')).toThrowError(
-      'ReactDOM.render(...): Expected the last optional `callback` argument ' +
-      'to be a function. Instead received: string.'
-    );
-    expect(() => ReactDOM.render(<A />, myDiv, {})).toThrowError(
-      'ReactDOM.render(...): Expected the last optional `callback` argument ' +
-      'to be a function. Instead received: Object.'
-    );
-    expect(() => ReactDOM.render(<A />, myDiv, new Foo())).toThrowError(
-      'ReactDOM.render(...): Expected the last optional `callback` argument ' +
-      'to be a function. Instead received: Foo (keys: a, b).'
-    );
   });
+  var instance = ReactTestUtils.renderIntoDocument(<Parent />);
+  form.submit();
+  expect(count).toEqual(1);
+});
+*/
+
+it('allows a DOM element to be used with a string', function() {
+  var element = React.createElement('div', {className: 'foo'});
+  var instance = ReactTestUtils.renderIntoDocument(element);
+  expect(ReactDOM.findDOMNode(instance).tagName).toBe('DIV');
+});
+
+it('should allow children to be passed as an argument', function() {
+  var argDiv = ReactTestUtils.renderIntoDocument(
+    div(null, 'child')
+  );
+  var argNode = ReactDOM.findDOMNode(argDiv);
+  expect(argNode.innerHTML).toBe('child');
+});
+
+it('should overwrite props.children with children argument', function() {
+  var conflictDiv = ReactTestUtils.renderIntoDocument(
+    div({children: 'fakechild'}, 'child')
+  );
+  var conflictNode = ReactDOM.findDOMNode(conflictDiv);
+  expect(conflictNode.innerHTML).toBe('child');
+});
+
+/**
+ * We need to make sure that updates occur to the actual node that's in the
+ * DOM, instead of a stale cache.
+ */
+it('should purge the DOM cache when removing nodes', function() {
+  var myDiv = ReactTestUtils.renderIntoDocument(
+    <div>
+      <div key="theDog" className="dog" />,
+      <div key="theBird" className="bird" />
+    </div>
+  );
+  // Warm the cache with theDog
+  myDiv = ReactTestUtils.renderIntoDocument(
+    <div>
+      <div key="theDog" className="dogbeforedelete" />,
+      <div key="theBird" className="bird" />,
+    </div>
+  );
+  // Remove theDog - this should purge the cache
+  myDiv = ReactTestUtils.renderIntoDocument(
+    <div>
+      <div key="theBird" className="bird" />,
+    </div>
+  );
+  // Now, put theDog back. It's now a different DOM node.
+  myDiv = ReactTestUtils.renderIntoDocument(
+    <div>
+      <div key="theDog" className="dog" />,
+      <div key="theBird" className="bird" />,
+    </div>
+  );
+  // Change the className of theDog. It will use the same element
+  myDiv = ReactTestUtils.renderIntoDocument(
+    <div>
+      <div key="theDog" className="bigdog" />,
+      <div key="theBird" className="bird" />,
+    </div>
+  );
+  var root = ReactDOM.findDOMNode(myDiv);
+  var dog = root.childNodes[0];
+  expect(dog.className).toBe('bigdog');
+});
+
+it('allow React.DOM factories to be called without warnings', function() {
+  spyOn(console, 'error');
+  var element = React.DOM.div();
+  expect(element.type).toBe('div');
+  expect(console.error.calls.count()).toBe(0);
+});
+
+it('throws in render() if the mount callback is not a function', function() {
+  function Foo() {
+    this.a = 1;
+    this.b = 2;
+  }
+
+  class A extends React.Component {
+    state = {};
+
+    render() {
+      return <div />;
+    }
+  }
+
+  var myDiv = document.createElement('div');
+  expect(() => ReactDOM.render(<A />, myDiv, 'no')).toThrowError(
+    'ReactDOM.render(...): Expected the last optional `callback` argument ' +
+    'to be a function. Instead received: string.'
+  );
+  expect(() => ReactDOM.render(<A />, myDiv, {})).toThrowError(
+    'ReactDOM.render(...): Expected the last optional `callback` argument ' +
+    'to be a function. Instead received: Object.'
+  );
+  expect(() => ReactDOM.render(<A />, myDiv, new Foo())).toThrowError(
+    'ReactDOM.render(...): Expected the last optional `callback` argument ' +
+    'to be a function. Instead received: Foo (keys: a, b).'
+  );
+});
+
+it('throws in render() if the update callback is not a function', function() {
+  function Foo() {
+    this.a = 1;
+    this.b = 2;
+  }
+
+  class A extends React.Component {
+    state = {};
+
+    render() {
+      return <div />;
+    }
+  }
+
+  var myDiv = document.createElement('div');
+  ReactDOM.render(<A />, myDiv);
+
+  expect(() => ReactDOM.render(<A />, myDiv, 'no')).toThrowError(
+    'ReactDOM.render(...): Expected the last optional `callback` argument ' +
+    'to be a function. Instead received: string.'
+  );
+  expect(() => ReactDOM.render(<A />, myDiv, {})).toThrowError(
+    'ReactDOM.render(...): Expected the last optional `callback` argument ' +
+    'to be a function. Instead received: Object.'
+  );
+  expect(() => ReactDOM.render(<A />, myDiv, new Foo())).toThrowError(
+    'ReactDOM.render(...): Expected the last optional `callback` argument ' +
+    'to be a function. Instead received: Foo (keys: a, b).'
+  );
 });

--- a/src/renderers/dom/client/__tests__/ReactDOMComponentTree-test.js
+++ b/src/renderers/dom/client/__tests__/ReactDOMComponentTree-test.js
@@ -11,101 +11,98 @@
 
 'use strict';
 
-describe('ReactDOMComponentTree', function() {
-  var React;
-  var ReactDOM;
-  var ReactDOMComponentTree;
-  var ReactDOMServer;
+var React;
+var ReactDOM;
+var ReactDOMComponentTree;
+var ReactDOMServer;
 
-  function renderMarkupIntoDocument(elt) {
-    var container = document.createElement('div');
-    // Force server-rendering path:
-    container.innerHTML = ReactDOMServer.renderToString(elt);
-    return ReactDOM.render(elt, container);
-  }
+function renderMarkupIntoDocument(elt) {
+  var container = document.createElement('div');
+  // Force server-rendering path:
+  container.innerHTML = ReactDOMServer.renderToString(elt);
+  return ReactDOM.render(elt, container);
+}
 
-  beforeEach(function() {
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactDOMComponentTree = require('ReactDOMComponentTree');
-    ReactDOMServer = require('ReactDOMServer');
-  });
+beforeEach(function() {
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactDOMComponentTree = require('ReactDOMComponentTree');
+  ReactDOMServer = require('ReactDOMServer');
+});
 
-  it('finds nodes for instances', function() {
-    // This is a little hard to test directly. But refs rely on it -- so we
-    // check that we can find a ref at arbitrary points in the tree, even if
-    // other nodes don't have a ref.
-    class Component extends React.Component {
-      render() {
-        var toRef = this.props.toRef;
-        return (
-          <div ref={toRef === 'div' ? 'target' : null}>
-            <h1 ref={toRef === 'h1' ? 'target' : null}>hello</h1>
-            <p ref={toRef === 'p' ? 'target' : null}>
-              <input ref={toRef === 'input' ? 'target' : null} />
-            </p>
-            goodbye.
-          </div>
-        );
-      }
-    }
-
-    function renderAndGetRef(toRef) {
-      var inst = renderMarkupIntoDocument(<Component toRef={toRef} />);
-      return inst.refs.target.nodeName;
-    }
-
-    expect(renderAndGetRef('div')).toBe('DIV');
-    expect(renderAndGetRef('h1')).toBe('H1');
-    expect(renderAndGetRef('p')).toBe('P');
-    expect(renderAndGetRef('input')).toBe('INPUT');
-  });
-
-  it('finds instances for nodes', function() {
-    class Component extends React.Component {
-      render() {
-        return (
-          <div>
-            <h1>hello</h1>
-            <p>
-              <input />
-            </p>
-            goodbye.
-            <main dangerouslySetInnerHTML={{__html: '<b><img></b>'}} />
-          </div>
-        );
-      }
-    }
-
-    function renderAndQuery(sel) {
-      var root = renderMarkupIntoDocument(<section><Component /></section>);
-      return sel ? root.querySelector(sel) : root;
-    }
-
-    function renderAndGetInstance(sel) {
-      return ReactDOMComponentTree.getInstanceFromNode(renderAndQuery(sel));
-    }
-
-    function renderAndGetClosest(sel) {
-      return ReactDOMComponentTree.getClosestInstanceFromNode(
-        renderAndQuery(sel)
+it('finds nodes for instances', function() {
+  // This is a little hard to test directly. But refs rely on it -- so we
+  // check that we can find a ref at arbitrary points in the tree, even if
+  // other nodes don't have a ref.
+  class Component extends React.Component {
+    render() {
+      var toRef = this.props.toRef;
+      return (
+        <div ref={toRef === 'div' ? 'target' : null}>
+          <h1 ref={toRef === 'h1' ? 'target' : null}>hello</h1>
+          <p ref={toRef === 'p' ? 'target' : null}>
+            <input ref={toRef === 'input' ? 'target' : null} />
+          </p>
+          goodbye.
+        </div>
       );
     }
+  }
 
-    expect(renderAndGetInstance(null)._currentElement.type).toBe('section');
-    expect(renderAndGetInstance('div')._currentElement.type).toBe('div');
-    expect(renderAndGetInstance('h1')._currentElement.type).toBe('h1');
-    expect(renderAndGetInstance('p')._currentElement.type).toBe('p');
-    expect(renderAndGetInstance('input')._currentElement.type).toBe('input');
-    expect(renderAndGetInstance('main')._currentElement.type).toBe('main');
+  function renderAndGetRef(toRef) {
+    var inst = renderMarkupIntoDocument(<Component toRef={toRef} />);
+    return inst.refs.target.nodeName;
+  }
 
-    // This one's a text component!
-    var root = renderAndQuery(null);
-    var inst = ReactDOMComponentTree.getInstanceFromNode(root.children[0].childNodes[2]);
-    expect(inst._stringText).toBe('goodbye.');
+  expect(renderAndGetRef('div')).toBe('DIV');
+  expect(renderAndGetRef('h1')).toBe('H1');
+  expect(renderAndGetRef('p')).toBe('P');
+  expect(renderAndGetRef('input')).toBe('INPUT');
+});
 
-    expect(renderAndGetClosest('b')._currentElement.type).toBe('main');
-    expect(renderAndGetClosest('img')._currentElement.type).toBe('main');
-  });
+it('finds instances for nodes', function() {
+  class Component extends React.Component {
+    render() {
+      return (
+        <div>
+          <h1>hello</h1>
+          <p>
+            <input />
+          </p>
+          goodbye.
+          <main dangerouslySetInnerHTML={{__html: '<b><img></b>'}} />
+        </div>
+      );
+    }
+  }
 
+  function renderAndQuery(sel) {
+    var root = renderMarkupIntoDocument(<section><Component /></section>);
+    return sel ? root.querySelector(sel) : root;
+  }
+
+  function renderAndGetInstance(sel) {
+    return ReactDOMComponentTree.getInstanceFromNode(renderAndQuery(sel));
+  }
+
+  function renderAndGetClosest(sel) {
+    return ReactDOMComponentTree.getClosestInstanceFromNode(
+      renderAndQuery(sel)
+    );
+  }
+
+  expect(renderAndGetInstance(null)._currentElement.type).toBe('section');
+  expect(renderAndGetInstance('div')._currentElement.type).toBe('div');
+  expect(renderAndGetInstance('h1')._currentElement.type).toBe('h1');
+  expect(renderAndGetInstance('p')._currentElement.type).toBe('p');
+  expect(renderAndGetInstance('input')._currentElement.type).toBe('input');
+  expect(renderAndGetInstance('main')._currentElement.type).toBe('main');
+
+  // This one's a text component!
+  var root = renderAndQuery(null);
+  var inst = ReactDOMComponentTree.getInstanceFromNode(root.children[0].childNodes[2]);
+  expect(inst._stringText).toBe('goodbye.');
+
+  expect(renderAndGetClosest('b')._currentElement.type).toBe('main');
+  expect(renderAndGetClosest('img')._currentElement.type).toBe('main');
 });

--- a/src/renderers/dom/client/__tests__/ReactDOMIDOperations-test.js
+++ b/src/renderers/dom/client/__tests__/ReactDOMIDOperations-test.js
@@ -11,27 +11,25 @@
 
 'use strict';
 
-describe('ReactDOMIDOperations', function() {
-  var ReactDOMComponentTree = require('ReactDOMComponentTree');
-  var ReactDOMIDOperations = require('ReactDOMIDOperations');
+var ReactDOMComponentTree = require('ReactDOMComponentTree');
+var ReactDOMIDOperations = require('ReactDOMIDOperations');
 
-  it('should update innerHTML and preserve whitespace', function() {
-    var stubNode = document.createElement('div');
-    var stubInstance = {_debugID: 1};
-    ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
+it('should update innerHTML and preserve whitespace', function() {
+  var stubNode = document.createElement('div');
+  var stubInstance = {_debugID: 1};
+  ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
 
-    var html = '\n  \t  <span>  \n  testContent  \t  </span>  \n  \t';
-    ReactDOMIDOperations.dangerouslyProcessChildrenUpdates(
-      stubInstance,
-      [{
-        type: 'SET_MARKUP',
-        content: html,
-        fromIndex: null,
-        toIndex: null,
-      }],
-      []
-    );
+  var html = '\n  \t  <span>  \n  testContent  \t  </span>  \n  \t';
+  ReactDOMIDOperations.dangerouslyProcessChildrenUpdates(
+    stubInstance,
+    [{
+      type: 'SET_MARKUP',
+      content: html,
+      fromIndex: null,
+      toIndex: null,
+    }],
+    []
+  );
 
-    expect(stubNode.innerHTML).toBe(html);
-  });
+  expect(stubNode.innerHTML).toBe(html);
 });

--- a/src/renderers/dom/client/__tests__/ReactDOMSVG-test.js
+++ b/src/renderers/dom/client/__tests__/ReactDOMSVG-test.js
@@ -14,20 +14,16 @@
 var React;
 var ReactDOMServer;
 
-describe('ReactDOMSVG', function() {
+beforeEach(function() {
+  React = require('React');
+  ReactDOMServer = require('ReactDOMServer');
+});
 
-  beforeEach(function() {
-    React = require('React');
-    ReactDOMServer = require('ReactDOMServer');
-  });
-
-  it('creates initial namespaced markup', function() {
-    var markup = ReactDOMServer.renderToString(
-      <svg>
-        <image xlinkHref="http://i.imgur.com/w7GCRPb.png" />
-      </svg>
-    );
-    expect(markup).toContain('xlink:href="http://i.imgur.com/w7GCRPb.png"');
-  });
-
+it('creates initial namespaced markup', function() {
+  var markup = ReactDOMServer.renderToString(
+    <svg>
+      <image xlinkHref="http://i.imgur.com/w7GCRPb.png" />
+    </svg>
+  );
+  expect(markup).toContain('xlink:href="http://i.imgur.com/w7GCRPb.png"');
 });

--- a/src/renderers/dom/client/__tests__/ReactDOMTreeTraversal-test.js
+++ b/src/renderers/dom/client/__tests__/ReactDOMTreeTraversal-test.js
@@ -50,224 +50,221 @@ function renderParentIntoDocument() {
   return ReactTestUtils.renderIntoDocument(<ParentComponent />);
 }
 
-describe('ReactDOMTreeTraversal', function() {
-  var ReactDOMTreeTraversal;
+var ReactDOMTreeTraversal;
 
-  var aggregatedArgs;
-  function argAggregator(inst, isUp, arg) {
-    aggregatedArgs.push({
-      node: ReactDOMComponentTree.getNodeFromInstance(inst),
-      isUp: isUp,
-      arg: arg,
-    });
-  }
+var aggregatedArgs;
+function argAggregator(inst, isUp, arg) {
+  aggregatedArgs.push({
+    node: ReactDOMComponentTree.getNodeFromInstance(inst),
+    isUp: isUp,
+    arg: arg,
+  });
+}
 
-  function getInst(node) {
-    return ReactDOMComponentTree.getInstanceFromNode(node);
-  }
+function getInst(node) {
+  return ReactDOMComponentTree.getInstanceFromNode(node);
+}
 
-  beforeEach(function() {
-    ReactDOMTreeTraversal = require('ReactDOMTreeTraversal');
-    aggregatedArgs = [];
+beforeEach(function() {
+  ReactDOMTreeTraversal = require('ReactDOMTreeTraversal');
+  aggregatedArgs = [];
+});
+
+describe('traverseTwoPhase', function() {
+  it('should not traverse when traversing outside DOM', function() {
+    var expectedAggregation = [];
+    ReactDOMTreeTraversal.traverseTwoPhase(null, argAggregator, ARG);
+    expect(aggregatedArgs).toEqual(expectedAggregation);
   });
 
-  describe('traverseTwoPhase', function() {
-    it('should not traverse when traversing outside DOM', function() {
-      var expectedAggregation = [];
-      ReactDOMTreeTraversal.traverseTwoPhase(null, argAggregator, ARG);
-      expect(aggregatedArgs).toEqual(expectedAggregation);
-    });
+  it('should traverse two phase across component boundary', function() {
+    var parent = renderParentIntoDocument();
+    var target = getInst(parent.refs.P_P1_C1.refs.DIV_1);
+    var expectedAggregation = [
+      {node: parent.refs.P, isUp: false, arg: ARG},
+      {node: parent.refs.P_P1, isUp: false, arg: ARG},
+      {node: parent.refs.P_P1_C1.refs.DIV, isUp: false, arg: ARG},
+      {node: parent.refs.P_P1_C1.refs.DIV_1, isUp: false, arg: ARG},
 
-    it('should traverse two phase across component boundary', function() {
-      var parent = renderParentIntoDocument();
-      var target = getInst(parent.refs.P_P1_C1.refs.DIV_1);
-      var expectedAggregation = [
-        {node: parent.refs.P, isUp: false, arg: ARG},
-        {node: parent.refs.P_P1, isUp: false, arg: ARG},
-        {node: parent.refs.P_P1_C1.refs.DIV, isUp: false, arg: ARG},
-        {node: parent.refs.P_P1_C1.refs.DIV_1, isUp: false, arg: ARG},
-
-        {node: parent.refs.P_P1_C1.refs.DIV_1, isUp: true, arg: ARG},
-        {node: parent.refs.P_P1_C1.refs.DIV, isUp: true, arg: ARG},
-        {node: parent.refs.P_P1, isUp: true, arg: ARG},
-        {node: parent.refs.P, isUp: true, arg: ARG},
-      ];
-      ReactDOMTreeTraversal.traverseTwoPhase(target, argAggregator, ARG);
-      expect(aggregatedArgs).toEqual(expectedAggregation);
-    });
-
-    it('should traverse two phase at shallowest node', function() {
-      var parent = renderParentIntoDocument();
-      var target = getInst(parent.refs.P);
-      var expectedAggregation = [
-        {node: parent.refs.P, isUp: false, arg: ARG},
-        {node: parent.refs.P, isUp: true, arg: ARG},
-      ];
-      ReactDOMTreeTraversal.traverseTwoPhase(target, argAggregator, ARG);
-      expect(aggregatedArgs).toEqual(expectedAggregation);
-    });
+      {node: parent.refs.P_P1_C1.refs.DIV_1, isUp: true, arg: ARG},
+      {node: parent.refs.P_P1_C1.refs.DIV, isUp: true, arg: ARG},
+      {node: parent.refs.P_P1, isUp: true, arg: ARG},
+      {node: parent.refs.P, isUp: true, arg: ARG},
+    ];
+    ReactDOMTreeTraversal.traverseTwoPhase(target, argAggregator, ARG);
+    expect(aggregatedArgs).toEqual(expectedAggregation);
   });
 
-  describe('traverseEnterLeave', function() {
-    it('should not traverse when enter/leaving outside DOM', function() {
-      var target = null;
-      var expectedAggregation = [];
-      ReactDOMTreeTraversal.traverseEnterLeave(
-        target, target, argAggregator, ARG, ARG2
-      );
-      expect(aggregatedArgs).toEqual(expectedAggregation);
-    });
+  it('should traverse two phase at shallowest node', function() {
+    var parent = renderParentIntoDocument();
+    var target = getInst(parent.refs.P);
+    var expectedAggregation = [
+      {node: parent.refs.P, isUp: false, arg: ARG},
+      {node: parent.refs.P, isUp: true, arg: ARG},
+    ];
+    ReactDOMTreeTraversal.traverseTwoPhase(target, argAggregator, ARG);
+    expect(aggregatedArgs).toEqual(expectedAggregation);
+  });
+});
 
-    it('should not traverse if enter/leave the same node', function() {
-      var parent = renderParentIntoDocument();
-      var leave = getInst(parent.refs.P_P1_C1.refs.DIV_1);
-      var enter = getInst(parent.refs.P_P1_C1.refs.DIV_1);
-      var expectedAggregation = [];
-      ReactDOMTreeTraversal.traverseEnterLeave(
-        leave, enter, argAggregator, ARG, ARG2
-      );
-      expect(aggregatedArgs).toEqual(expectedAggregation);
-    });
-
-    it('should traverse enter/leave to sibling - avoids parent', function() {
-      var parent = renderParentIntoDocument();
-      var leave = getInst(parent.refs.P_P1_C1.refs.DIV_1);
-      var enter = getInst(parent.refs.P_P1_C1.refs.DIV_2);
-      var expectedAggregation = [
-        {node: parent.refs.P_P1_C1.refs.DIV_1, isUp: true, arg: ARG},
-        // enter/leave shouldn't fire anything on the parent
-        {node: parent.refs.P_P1_C1.refs.DIV_2, isUp: false, arg: ARG2},
-      ];
-      ReactDOMTreeTraversal.traverseEnterLeave(
-        leave, enter, argAggregator, ARG, ARG2
-      );
-      expect(aggregatedArgs).toEqual(expectedAggregation);
-    });
-
-    it('should traverse enter/leave to parent - avoids parent', function() {
-      var parent = renderParentIntoDocument();
-      var leave = getInst(parent.refs.P_P1_C1.refs.DIV_1);
-      var enter = getInst(parent.refs.P_P1_C1.refs.DIV);
-      var expectedAggregation = [
-        {node: parent.refs.P_P1_C1.refs.DIV_1, isUp: true, arg: ARG},
-      ];
-      ReactDOMTreeTraversal.traverseEnterLeave(
-        leave, enter, argAggregator, ARG, ARG2
-      );
-      expect(aggregatedArgs).toEqual(expectedAggregation);
-    });
-
-    it('should enter from the window', function() {
-      var parent = renderParentIntoDocument();
-      var leave = null; // From the window or outside of the React sandbox.
-      var enter = getInst(parent.refs.P_P1_C1.refs.DIV);
-      var expectedAggregation = [
-        {node: parent.refs.P, isUp: false, arg: ARG2},
-        {node: parent.refs.P_P1, isUp: false, arg: ARG2},
-        {node: parent.refs.P_P1_C1.refs.DIV, isUp: false, arg: ARG2},
-      ];
-      ReactDOMTreeTraversal.traverseEnterLeave(
-        leave, enter, argAggregator, ARG, ARG2
-      );
-      expect(aggregatedArgs).toEqual(expectedAggregation);
-    });
-
-    it('should enter from the window to the shallowest', function() {
-      var parent = renderParentIntoDocument();
-      var leave = null; // From the window or outside of the React sandbox.
-      var enter = getInst(parent.refs.P);
-      var expectedAggregation = [
-        {node: parent.refs.P, isUp: false, arg: ARG2},
-      ];
-      ReactDOMTreeTraversal.traverseEnterLeave(
-        leave, enter, argAggregator, ARG, ARG2
-      );
-      expect(aggregatedArgs).toEqual(expectedAggregation);
-    });
-
-    it('should leave to the window', function() {
-      var parent = renderParentIntoDocument();
-      var enter = null; // From the window or outside of the React sandbox.
-      var leave = getInst(parent.refs.P_P1_C1.refs.DIV);
-      var expectedAggregation = [
-        {node: parent.refs.P_P1_C1.refs.DIV, isUp: true, arg: ARG},
-        {node: parent.refs.P_P1, isUp: true, arg: ARG},
-        {node: parent.refs.P, isUp: true, arg: ARG},
-      ];
-      ReactDOMTreeTraversal.traverseEnterLeave(
-        leave, enter, argAggregator, ARG, ARG2
-      );
-      expect(aggregatedArgs).toEqual(expectedAggregation);
-    });
-
-    it('should leave to the window from the shallowest', function() {
-      var parent = renderParentIntoDocument();
-      var enter = null; // From the window or outside of the React sandbox.
-      var leave = getInst(parent.refs.P_P1_C1.refs.DIV);
-      var expectedAggregation = [
-        {node: parent.refs.P_P1_C1.refs.DIV, isUp: true, arg: ARG},
-        {node: parent.refs.P_P1, isUp: true, arg: ARG},
-        {node: parent.refs.P, isUp: true, arg: ARG},
-      ];
-      ReactDOMTreeTraversal.traverseEnterLeave(
-        leave, enter, argAggregator, ARG, ARG2
-      );
-      expect(aggregatedArgs).toEqual(expectedAggregation);
-    });
+describe('traverseEnterLeave', function() {
+  it('should not traverse when enter/leaving outside DOM', function() {
+    var target = null;
+    var expectedAggregation = [];
+    ReactDOMTreeTraversal.traverseEnterLeave(
+      target, target, argAggregator, ARG, ARG2
+    );
+    expect(aggregatedArgs).toEqual(expectedAggregation);
   });
 
-  describe('getFirstCommonAncestor', function() {
-    it('should determine the first common ancestor correctly', function() {
-      var parent = renderParentIntoDocument();
-      var ancestors = [
-        // Common ancestor with self is self.
-        {one: parent.refs.P_P1_C1.refs.DIV_1,
-          two: parent.refs.P_P1_C1.refs.DIV_1,
-          com: parent.refs.P_P1_C1.refs.DIV_1,
-        },
-        // Common ancestor with self is self - even if topmost DOM.
-        {one: parent.refs.P, two: parent.refs.P, com: parent.refs.P},
-        // Siblings
-        {
-          one: parent.refs.P_P1_C1.refs.DIV_1,
-          two: parent.refs.P_P1_C1.refs.DIV_2,
-          com: parent.refs.P_P1_C1.refs.DIV,
-        },
-        // Common ancestor with parent is the parent.
-        {
-          one: parent.refs.P_P1_C1.refs.DIV_1,
-          two: parent.refs.P_P1_C1.refs.DIV,
-          com: parent.refs.P_P1_C1.refs.DIV,
-        },
-        // Common ancestor with grandparent is the grandparent.
-        {
-          one: parent.refs.P_P1_C1.refs.DIV_1,
-          two: parent.refs.P_P1,
-          com: parent.refs.P_P1,
-        },
-        // Grandparent across subcomponent boundaries.
-        {
-          one: parent.refs.P_P1_C1.refs.DIV_1,
-          two: parent.refs.P_P1_C2.refs.DIV_1,
-          com: parent.refs.P_P1,
-        },
-        // Something deep with something one-off.
-        {
-          one: parent.refs.P_P1_C1.refs.DIV_1,
-          two: parent.refs.P_OneOff,
-          com: parent.refs.P,
-        },
-      ];
-      var i;
-      for (i = 0; i < ancestors.length; i++) {
-        var plan = ancestors[i];
-        var firstCommon = ReactDOMTreeTraversal.getLowestCommonAncestor(
-          getInst(plan.one),
-          getInst(plan.two)
-        );
-        expect(firstCommon).toBe(getInst(plan.com));
-      }
-    });
+  it('should not traverse if enter/leave the same node', function() {
+    var parent = renderParentIntoDocument();
+    var leave = getInst(parent.refs.P_P1_C1.refs.DIV_1);
+    var enter = getInst(parent.refs.P_P1_C1.refs.DIV_1);
+    var expectedAggregation = [];
+    ReactDOMTreeTraversal.traverseEnterLeave(
+      leave, enter, argAggregator, ARG, ARG2
+    );
+    expect(aggregatedArgs).toEqual(expectedAggregation);
   });
 
+  it('should traverse enter/leave to sibling - avoids parent', function() {
+    var parent = renderParentIntoDocument();
+    var leave = getInst(parent.refs.P_P1_C1.refs.DIV_1);
+    var enter = getInst(parent.refs.P_P1_C1.refs.DIV_2);
+    var expectedAggregation = [
+      {node: parent.refs.P_P1_C1.refs.DIV_1, isUp: true, arg: ARG},
+      // enter/leave shouldn't fire anything on the parent
+      {node: parent.refs.P_P1_C1.refs.DIV_2, isUp: false, arg: ARG2},
+    ];
+    ReactDOMTreeTraversal.traverseEnterLeave(
+      leave, enter, argAggregator, ARG, ARG2
+    );
+    expect(aggregatedArgs).toEqual(expectedAggregation);
+  });
+
+  it('should traverse enter/leave to parent - avoids parent', function() {
+    var parent = renderParentIntoDocument();
+    var leave = getInst(parent.refs.P_P1_C1.refs.DIV_1);
+    var enter = getInst(parent.refs.P_P1_C1.refs.DIV);
+    var expectedAggregation = [
+      {node: parent.refs.P_P1_C1.refs.DIV_1, isUp: true, arg: ARG},
+    ];
+    ReactDOMTreeTraversal.traverseEnterLeave(
+      leave, enter, argAggregator, ARG, ARG2
+    );
+    expect(aggregatedArgs).toEqual(expectedAggregation);
+  });
+
+  it('should enter from the window', function() {
+    var parent = renderParentIntoDocument();
+    var leave = null; // From the window or outside of the React sandbox.
+    var enter = getInst(parent.refs.P_P1_C1.refs.DIV);
+    var expectedAggregation = [
+      {node: parent.refs.P, isUp: false, arg: ARG2},
+      {node: parent.refs.P_P1, isUp: false, arg: ARG2},
+      {node: parent.refs.P_P1_C1.refs.DIV, isUp: false, arg: ARG2},
+    ];
+    ReactDOMTreeTraversal.traverseEnterLeave(
+      leave, enter, argAggregator, ARG, ARG2
+    );
+    expect(aggregatedArgs).toEqual(expectedAggregation);
+  });
+
+  it('should enter from the window to the shallowest', function() {
+    var parent = renderParentIntoDocument();
+    var leave = null; // From the window or outside of the React sandbox.
+    var enter = getInst(parent.refs.P);
+    var expectedAggregation = [
+      {node: parent.refs.P, isUp: false, arg: ARG2},
+    ];
+    ReactDOMTreeTraversal.traverseEnterLeave(
+      leave, enter, argAggregator, ARG, ARG2
+    );
+    expect(aggregatedArgs).toEqual(expectedAggregation);
+  });
+
+  it('should leave to the window', function() {
+    var parent = renderParentIntoDocument();
+    var enter = null; // From the window or outside of the React sandbox.
+    var leave = getInst(parent.refs.P_P1_C1.refs.DIV);
+    var expectedAggregation = [
+      {node: parent.refs.P_P1_C1.refs.DIV, isUp: true, arg: ARG},
+      {node: parent.refs.P_P1, isUp: true, arg: ARG},
+      {node: parent.refs.P, isUp: true, arg: ARG},
+    ];
+    ReactDOMTreeTraversal.traverseEnterLeave(
+      leave, enter, argAggregator, ARG, ARG2
+    );
+    expect(aggregatedArgs).toEqual(expectedAggregation);
+  });
+
+  it('should leave to the window from the shallowest', function() {
+    var parent = renderParentIntoDocument();
+    var enter = null; // From the window or outside of the React sandbox.
+    var leave = getInst(parent.refs.P_P1_C1.refs.DIV);
+    var expectedAggregation = [
+      {node: parent.refs.P_P1_C1.refs.DIV, isUp: true, arg: ARG},
+      {node: parent.refs.P_P1, isUp: true, arg: ARG},
+      {node: parent.refs.P, isUp: true, arg: ARG},
+    ];
+    ReactDOMTreeTraversal.traverseEnterLeave(
+      leave, enter, argAggregator, ARG, ARG2
+    );
+    expect(aggregatedArgs).toEqual(expectedAggregation);
+  });
+});
+
+describe('getFirstCommonAncestor', function() {
+  it('should determine the first common ancestor correctly', function() {
+    var parent = renderParentIntoDocument();
+    var ancestors = [
+      // Common ancestor with self is self.
+      {one: parent.refs.P_P1_C1.refs.DIV_1,
+        two: parent.refs.P_P1_C1.refs.DIV_1,
+        com: parent.refs.P_P1_C1.refs.DIV_1,
+      },
+      // Common ancestor with self is self - even if topmost DOM.
+      {one: parent.refs.P, two: parent.refs.P, com: parent.refs.P},
+      // Siblings
+      {
+        one: parent.refs.P_P1_C1.refs.DIV_1,
+        two: parent.refs.P_P1_C1.refs.DIV_2,
+        com: parent.refs.P_P1_C1.refs.DIV,
+      },
+      // Common ancestor with parent is the parent.
+      {
+        one: parent.refs.P_P1_C1.refs.DIV_1,
+        two: parent.refs.P_P1_C1.refs.DIV,
+        com: parent.refs.P_P1_C1.refs.DIV,
+      },
+      // Common ancestor with grandparent is the grandparent.
+      {
+        one: parent.refs.P_P1_C1.refs.DIV_1,
+        two: parent.refs.P_P1,
+        com: parent.refs.P_P1,
+      },
+      // Grandparent across subcomponent boundaries.
+      {
+        one: parent.refs.P_P1_C1.refs.DIV_1,
+        two: parent.refs.P_P1_C2.refs.DIV_1,
+        com: parent.refs.P_P1,
+      },
+      // Something deep with something one-off.
+      {
+        one: parent.refs.P_P1_C1.refs.DIV_1,
+        two: parent.refs.P_OneOff,
+        com: parent.refs.P,
+      },
+    ];
+    var i;
+    for (i = 0; i < ancestors.length; i++) {
+      var plan = ancestors[i];
+      var firstCommon = ReactDOMTreeTraversal.getLowestCommonAncestor(
+        getInst(plan.one),
+        getInst(plan.two)
+      );
+      expect(firstCommon).toBe(getInst(plan.com));
+    }
+  });
 });

--- a/src/renderers/dom/client/__tests__/ReactEventIndependence-test.js
+++ b/src/renderers/dom/client/__tests__/ReactEventIndependence-test.js
@@ -15,56 +15,53 @@ var React;
 var ReactDOM;
 var ReactTestUtils;
 
-describe('ReactEventIndependence', function() {
-  beforeEach(function() {
-    jest.resetModuleRegistry();
+beforeEach(function() {
+  jest.resetModuleRegistry();
 
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactTestUtils = require('ReactTestUtils');
-  });
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactTestUtils = require('ReactTestUtils');
+});
 
-  it('does not crash with other react inside', function() {
-    var clicks = 0;
-    var div = ReactTestUtils.renderIntoDocument(
-      <div
-        onClick={() => clicks++}
-        dangerouslySetInnerHTML={{
-          __html: '<button data-reactid=".z">click me</div>',
-        }}
-      />
-    );
-    ReactTestUtils.SimulateNative.click(div.firstChild);
-    expect(clicks).toBe(1);
-  });
+it('does not crash with other react inside', function() {
+  var clicks = 0;
+  var div = ReactTestUtils.renderIntoDocument(
+    <div
+      onClick={() => clicks++}
+      dangerouslySetInnerHTML={{
+        __html: '<button data-reactid=".z">click me</div>',
+      }}
+    />
+  );
+  ReactTestUtils.SimulateNative.click(div.firstChild);
+  expect(clicks).toBe(1);
+});
 
-  it('does not crash with other react outside', function() {
-    var clicks = 0;
-    var outer = document.createElement('div');
-    outer.setAttribute('data-reactid', '.z');
-    var inner = ReactDOM.render(
-      <button onClick={() => clicks++}>click me</button>,
-      outer
-    );
-    ReactTestUtils.SimulateNative.click(inner);
-    expect(clicks).toBe(1);
-  });
+it('does not crash with other react outside', function() {
+  var clicks = 0;
+  var outer = document.createElement('div');
+  outer.setAttribute('data-reactid', '.z');
+  var inner = ReactDOM.render(
+    <button onClick={() => clicks++}>click me</button>,
+    outer
+  );
+  ReactTestUtils.SimulateNative.click(inner);
+  expect(clicks).toBe(1);
+});
 
-  it('does not when event fired on unmounted tree', function() {
-    var clicks = 0;
-    var container = document.createElement('div');
-    var button = ReactDOM.render(
-      <button onClick={() => clicks++}>click me</button>,
-      container
-    );
+it('does not when event fired on unmounted tree', function() {
+  var clicks = 0;
+  var container = document.createElement('div');
+  var button = ReactDOM.render(
+    <button onClick={() => clicks++}>click me</button>,
+    container
+  );
 
-    // Now we unmount the component, as if caused by a non-React event handler
-    // for the same click we're about to simulate, like closing a layer:
-    ReactDOM.unmountComponentAtNode(container);
-    ReactTestUtils.SimulateNative.click(button);
+  // Now we unmount the component, as if caused by a non-React event handler
+  // for the same click we're about to simulate, like closing a layer:
+  ReactDOM.unmountComponentAtNode(container);
+  ReactTestUtils.SimulateNative.click(button);
 
-    // Since the tree is unmounted, we don't dispatch the click event.
-    expect(clicks).toBe(0);
-  });
-
+  // Since the tree is unmounted, we don't dispatch the click event.
+  expect(clicks).toBe(0);
 });

--- a/src/renderers/dom/client/__tests__/ReactEventListener-test.js
+++ b/src/renderers/dom/client/__tests__/ReactEventListener-test.js
@@ -14,197 +14,195 @@
 
 var EVENT_TARGET_PARAM = 1;
 
-describe('ReactEventListener', function() {
-  var React;
-  var ReactDOM;
-  var ReactDOMComponentTree;
-  var ReactEventListener;
-  var ReactTestUtils;
-  var handleTopLevel;
+var React;
+var ReactDOM;
+var ReactDOMComponentTree;
+var ReactEventListener;
+var ReactTestUtils;
+var handleTopLevel;
 
-  beforeEach(function() {
-    jest.resetModuleRegistry();
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactDOMComponentTree = require('ReactDOMComponentTree');
-    ReactEventListener = require('ReactEventListener');
-    ReactTestUtils = require('ReactTestUtils');
+beforeEach(function() {
+  jest.resetModuleRegistry();
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactDOMComponentTree = require('ReactDOMComponentTree');
+  ReactEventListener = require('ReactEventListener');
+  ReactTestUtils = require('ReactTestUtils');
 
-    handleTopLevel = jest.fn();
-    ReactEventListener._handleTopLevel = handleTopLevel;
-  });
+  handleTopLevel = jest.fn();
+  ReactEventListener._handleTopLevel = handleTopLevel;
+});
 
-  it('should dispatch events from outside React tree', function() {
-    var otherNode = document.createElement('h1');
-    var component = ReactDOM.render(<div />, document.createElement('div'));
-    expect(handleTopLevel.mock.calls.length).toBe(0);
-    ReactEventListener.dispatchEvent(
-      'topMouseOut',
-      {
-        type: 'mouseout',
-        fromElement: otherNode,
-        target: otherNode,
-        srcElement: otherNode,
-        toElement: ReactDOM.findDOMNode(component),
-        relatedTarget: ReactDOM.findDOMNode(component),
-        view: window,
-        path: [otherNode, otherNode],
-      },
-    );
-    expect(handleTopLevel.mock.calls.length).toBe(1);
-  });
+it('should dispatch events from outside React tree', function() {
+  var otherNode = document.createElement('h1');
+  var component = ReactDOM.render(<div />, document.createElement('div'));
+  expect(handleTopLevel.mock.calls.length).toBe(0);
+  ReactEventListener.dispatchEvent(
+    'topMouseOut',
+    {
+      type: 'mouseout',
+      fromElement: otherNode,
+      target: otherNode,
+      srcElement: otherNode,
+      toElement: ReactDOM.findDOMNode(component),
+      relatedTarget: ReactDOM.findDOMNode(component),
+      view: window,
+      path: [otherNode, otherNode],
+    },
+  );
+  expect(handleTopLevel.mock.calls.length).toBe(1);
+});
 
-  describe('Propagation', function() {
-    it('should propagate events one level down', function() {
-      var childContainer = document.createElement('div');
-      var childControl = <div>Child</div>;
-      var parentContainer = document.createElement('div');
-      var parentControl = <div>Parent</div>;
-      childControl = ReactDOM.render(childControl, childContainer);
-      parentControl =
-        ReactDOM.render(parentControl, parentContainer);
-      ReactDOM.findDOMNode(parentControl).appendChild(childContainer);
-
-      var callback = ReactEventListener.dispatchEvent.bind(null, 'test');
-      callback({
-        target: ReactDOM.findDOMNode(childControl),
-      });
-
-      var calls = handleTopLevel.mock.calls;
-      expect(calls.length).toBe(2);
-      expect(calls[0][EVENT_TARGET_PARAM])
-        .toBe(ReactDOMComponentTree.getInstanceFromNode(childControl));
-      expect(calls[1][EVENT_TARGET_PARAM])
-        .toBe(ReactDOMComponentTree.getInstanceFromNode(parentControl));
-    });
-
-    it('should propagate events two levels down', function() {
-      var childContainer = document.createElement('div');
-      var childControl = <div>Child</div>;
-      var parentContainer = document.createElement('div');
-      var parentControl = <div>Parent</div>;
-      var grandParentContainer = document.createElement('div');
-      var grandParentControl = <div>Parent</div>;
-      childControl = ReactDOM.render(childControl, childContainer);
-      parentControl =
-        ReactDOM.render(parentControl, parentContainer);
-      grandParentControl =
-        ReactDOM.render(grandParentControl, grandParentContainer);
-      ReactDOM.findDOMNode(parentControl).appendChild(childContainer);
-      ReactDOM.findDOMNode(grandParentControl).appendChild(parentContainer);
-
-      var callback = ReactEventListener.dispatchEvent.bind(null, 'test');
-      callback({
-        target: ReactDOM.findDOMNode(childControl),
-      });
-
-      var calls = handleTopLevel.mock.calls;
-      expect(calls.length).toBe(3);
-      expect(calls[0][EVENT_TARGET_PARAM])
-        .toBe(ReactDOMComponentTree.getInstanceFromNode(childControl));
-      expect(calls[1][EVENT_TARGET_PARAM])
-        .toBe(ReactDOMComponentTree.getInstanceFromNode(parentControl));
-      expect(calls[2][EVENT_TARGET_PARAM])
-        .toBe(ReactDOMComponentTree.getInstanceFromNode(grandParentControl));
-    });
-
-    it('should not get confused by disappearing elements', function() {
-      var childContainer = document.createElement('div');
-      var childControl = <div>Child</div>;
-      var parentContainer = document.createElement('div');
-      var parentControl = <div>Parent</div>;
-      childControl = ReactDOM.render(childControl, childContainer);
-      parentControl =
-        ReactDOM.render(parentControl, parentContainer);
-      ReactDOM.findDOMNode(parentControl).appendChild(childContainer);
-
-      // ReactBrowserEventEmitter.handleTopLevel might remove the
-      // target from the DOM. Here, we have handleTopLevel remove the
-      // node when the first event handlers are called; we'll still
-      // expect to receive a second call for the parent control.
-      var childNode = ReactDOM.findDOMNode(childControl);
-      handleTopLevel.mockImplementation(
-        function(topLevelType, topLevelTarget, topLevelTargetID, nativeEvent) {
-          if (topLevelTarget === childNode) {
-            ReactDOM.unmountComponentAtNode(childContainer);
-          }
-        }
-      );
-
-      var callback = ReactEventListener.dispatchEvent.bind(null, 'test');
-      callback({
-        target: childNode,
-      });
-
-      var calls = handleTopLevel.mock.calls;
-      expect(calls.length).toBe(2);
-      expect(calls[0][EVENT_TARGET_PARAM])
-        .toBe(ReactDOMComponentTree.getInstanceFromNode(childNode));
-      expect(calls[1][EVENT_TARGET_PARAM])
-        .toBe(ReactDOMComponentTree.getInstanceFromNode(parentControl));
-    });
-
-    it('should batch between handlers from different roots', function() {
-      var childContainer = document.createElement('div');
-      var parentContainer = document.createElement('div');
-      var childControl = ReactDOM.render(
-        <div>Child</div>,
-        childContainer
-      );
-      var parentControl = ReactDOM.render(
-        <div>Parent</div>,
-        parentContainer
-      );
-      ReactDOM.findDOMNode(parentControl).appendChild(childContainer);
-
-      // Suppose an event handler in each root enqueues an update to the
-      // childControl element -- the two updates should get batched together.
-      var childNode = ReactDOM.findDOMNode(childControl);
-      handleTopLevel.mockImplementation(
-        function(topLevelType, topLevelTarget, topLevelTargetID, nativeEvent) {
-          ReactDOM.render(
-            <div>{topLevelTarget === childNode ? '1' : '2'}</div>,
-            childContainer
-          );
-          // Since we're batching, neither update should yet have gone through.
-          expect(childNode.textContent).toBe('Child');
-        }
-      );
-
-      var callback =
-        ReactEventListener.dispatchEvent.bind(ReactEventListener, 'test');
-      callback({
-        target: childNode,
-      });
-
-      var calls = handleTopLevel.mock.calls;
-      expect(calls.length).toBe(2);
-      expect(childNode.textContent).toBe('2');
-    });
-  });
-
-  it('should not fire duplicate events for a React DOM tree', function() {
-    class Wrapper extends React.Component {
-      getInner = () => {
-        return this.refs.inner;
-      };
-
-      render() {
-        var inner = <div ref="inner">Inner</div>;
-        return <div><div id="outer">{inner}</div></div>;
-      }
-    }
-
-    var instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
+describe('Propagation', function() {
+  it('should propagate events one level down', function() {
+    var childContainer = document.createElement('div');
+    var childControl = <div>Child</div>;
+    var parentContainer = document.createElement('div');
+    var parentControl = <div>Parent</div>;
+    childControl = ReactDOM.render(childControl, childContainer);
+    parentControl =
+      ReactDOM.render(parentControl, parentContainer);
+    ReactDOM.findDOMNode(parentControl).appendChild(childContainer);
 
     var callback = ReactEventListener.dispatchEvent.bind(null, 'test');
     callback({
-      target: ReactDOM.findDOMNode(instance.getInner()),
+      target: ReactDOM.findDOMNode(childControl),
     });
 
     var calls = handleTopLevel.mock.calls;
-    expect(calls.length).toBe(1);
+    expect(calls.length).toBe(2);
     expect(calls[0][EVENT_TARGET_PARAM])
-      .toBe(ReactDOMComponentTree.getInstanceFromNode(instance.getInner()));
+      .toBe(ReactDOMComponentTree.getInstanceFromNode(childControl));
+    expect(calls[1][EVENT_TARGET_PARAM])
+      .toBe(ReactDOMComponentTree.getInstanceFromNode(parentControl));
   });
+
+  it('should propagate events two levels down', function() {
+    var childContainer = document.createElement('div');
+    var childControl = <div>Child</div>;
+    var parentContainer = document.createElement('div');
+    var parentControl = <div>Parent</div>;
+    var grandParentContainer = document.createElement('div');
+    var grandParentControl = <div>Parent</div>;
+    childControl = ReactDOM.render(childControl, childContainer);
+    parentControl =
+      ReactDOM.render(parentControl, parentContainer);
+    grandParentControl =
+      ReactDOM.render(grandParentControl, grandParentContainer);
+    ReactDOM.findDOMNode(parentControl).appendChild(childContainer);
+    ReactDOM.findDOMNode(grandParentControl).appendChild(parentContainer);
+
+    var callback = ReactEventListener.dispatchEvent.bind(null, 'test');
+    callback({
+      target: ReactDOM.findDOMNode(childControl),
+    });
+
+    var calls = handleTopLevel.mock.calls;
+    expect(calls.length).toBe(3);
+    expect(calls[0][EVENT_TARGET_PARAM])
+      .toBe(ReactDOMComponentTree.getInstanceFromNode(childControl));
+    expect(calls[1][EVENT_TARGET_PARAM])
+      .toBe(ReactDOMComponentTree.getInstanceFromNode(parentControl));
+    expect(calls[2][EVENT_TARGET_PARAM])
+      .toBe(ReactDOMComponentTree.getInstanceFromNode(grandParentControl));
+  });
+
+  it('should not get confused by disappearing elements', function() {
+    var childContainer = document.createElement('div');
+    var childControl = <div>Child</div>;
+    var parentContainer = document.createElement('div');
+    var parentControl = <div>Parent</div>;
+    childControl = ReactDOM.render(childControl, childContainer);
+    parentControl =
+      ReactDOM.render(parentControl, parentContainer);
+    ReactDOM.findDOMNode(parentControl).appendChild(childContainer);
+
+    // ReactBrowserEventEmitter.handleTopLevel might remove the
+    // target from the DOM. Here, we have handleTopLevel remove the
+    // node when the first event handlers are called; we'll still
+    // expect to receive a second call for the parent control.
+    var childNode = ReactDOM.findDOMNode(childControl);
+    handleTopLevel.mockImplementation(
+      function(topLevelType, topLevelTarget, topLevelTargetID, nativeEvent) {
+        if (topLevelTarget === childNode) {
+          ReactDOM.unmountComponentAtNode(childContainer);
+        }
+      }
+    );
+
+    var callback = ReactEventListener.dispatchEvent.bind(null, 'test');
+    callback({
+      target: childNode,
+    });
+
+    var calls = handleTopLevel.mock.calls;
+    expect(calls.length).toBe(2);
+    expect(calls[0][EVENT_TARGET_PARAM])
+      .toBe(ReactDOMComponentTree.getInstanceFromNode(childNode));
+    expect(calls[1][EVENT_TARGET_PARAM])
+      .toBe(ReactDOMComponentTree.getInstanceFromNode(parentControl));
+  });
+
+  it('should batch between handlers from different roots', function() {
+    var childContainer = document.createElement('div');
+    var parentContainer = document.createElement('div');
+    var childControl = ReactDOM.render(
+      <div>Child</div>,
+      childContainer
+    );
+    var parentControl = ReactDOM.render(
+      <div>Parent</div>,
+      parentContainer
+    );
+    ReactDOM.findDOMNode(parentControl).appendChild(childContainer);
+
+    // Suppose an event handler in each root enqueues an update to the
+    // childControl element -- the two updates should get batched together.
+    var childNode = ReactDOM.findDOMNode(childControl);
+    handleTopLevel.mockImplementation(
+      function(topLevelType, topLevelTarget, topLevelTargetID, nativeEvent) {
+        ReactDOM.render(
+          <div>{topLevelTarget === childNode ? '1' : '2'}</div>,
+          childContainer
+        );
+        // Since we're batching, neither update should yet have gone through.
+        expect(childNode.textContent).toBe('Child');
+      }
+    );
+
+    var callback =
+      ReactEventListener.dispatchEvent.bind(ReactEventListener, 'test');
+    callback({
+      target: childNode,
+    });
+
+    var calls = handleTopLevel.mock.calls;
+    expect(calls.length).toBe(2);
+    expect(childNode.textContent).toBe('2');
+  });
+});
+
+it('should not fire duplicate events for a React DOM tree', function() {
+  class Wrapper extends React.Component {
+    getInner = () => {
+      return this.refs.inner;
+    };
+
+    render() {
+      var inner = <div ref="inner">Inner</div>;
+      return <div><div id="outer">{inner}</div></div>;
+    }
+  }
+
+  var instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
+
+  var callback = ReactEventListener.dispatchEvent.bind(null, 'test');
+  callback({
+    target: ReactDOM.findDOMNode(instance.getInner()),
+  });
+
+  var calls = handleTopLevel.mock.calls;
+  expect(calls.length).toBe(1);
+  expect(calls[0][EVENT_TARGET_PARAM])
+    .toBe(ReactDOMComponentTree.getInstanceFromNode(instance.getInner()));
 });

--- a/src/renderers/dom/client/__tests__/ReactMountDestruction-test.js
+++ b/src/renderers/dom/client/__tests__/ReactMountDestruction-test.js
@@ -14,75 +14,73 @@
 var React = require('React');
 var ReactDOM = require('ReactDOM');
 
-describe('ReactMount', function() {
-  it('should destroy a react root upon request', function() {
-    var mainContainerDiv = document.createElement('div');
-    document.body.appendChild(mainContainerDiv);
+it('should destroy a react root upon request', function() {
+  var mainContainerDiv = document.createElement('div');
+  document.body.appendChild(mainContainerDiv);
 
-    var instanceOne = <div className="firstReactDiv" />;
-    var firstRootDiv = document.createElement('div');
-    mainContainerDiv.appendChild(firstRootDiv);
-    ReactDOM.render(instanceOne, firstRootDiv);
+  var instanceOne = <div className="firstReactDiv" />;
+  var firstRootDiv = document.createElement('div');
+  mainContainerDiv.appendChild(firstRootDiv);
+  ReactDOM.render(instanceOne, firstRootDiv);
 
-    var instanceTwo = <div className="secondReactDiv" />;
-    var secondRootDiv = document.createElement('div');
-    mainContainerDiv.appendChild(secondRootDiv);
-    ReactDOM.render(instanceTwo, secondRootDiv);
+  var instanceTwo = <div className="secondReactDiv" />;
+  var secondRootDiv = document.createElement('div');
+  mainContainerDiv.appendChild(secondRootDiv);
+  ReactDOM.render(instanceTwo, secondRootDiv);
 
-    // Test that two react roots are rendered in isolation
-    expect(firstRootDiv.firstChild.className).toBe('firstReactDiv');
-    expect(secondRootDiv.firstChild.className).toBe('secondReactDiv');
+  // Test that two react roots are rendered in isolation
+  expect(firstRootDiv.firstChild.className).toBe('firstReactDiv');
+  expect(secondRootDiv.firstChild.className).toBe('secondReactDiv');
 
-    // Test that after unmounting each, they are no longer in the document.
-    ReactDOM.unmountComponentAtNode(firstRootDiv);
-    expect(firstRootDiv.firstChild).toBeNull();
-    ReactDOM.unmountComponentAtNode(secondRootDiv);
-    expect(secondRootDiv.firstChild).toBeNull();
-  });
+  // Test that after unmounting each, they are no longer in the document.
+  ReactDOM.unmountComponentAtNode(firstRootDiv);
+  expect(firstRootDiv.firstChild).toBeNull();
+  ReactDOM.unmountComponentAtNode(secondRootDiv);
+  expect(secondRootDiv.firstChild).toBeNull();
+});
 
-  it('should warn when unmounting a non-container root node', function() {
-    var mainContainerDiv = document.createElement('div');
+it('should warn when unmounting a non-container root node', function() {
+  var mainContainerDiv = document.createElement('div');
 
-    var component =
+  var component =
+    <div>
+      <div />
+    </div>;
+  ReactDOM.render(component, mainContainerDiv);
+
+  // Test that unmounting at a root node gives a helpful warning
+  var rootDiv = mainContainerDiv.firstChild;
+  spyOn(console, 'error');
+  ReactDOM.unmountComponentAtNode(rootDiv);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: unmountComponentAtNode(): The node you\'re attempting to ' +
+    'unmount was rendered by React and is not a top-level container. You ' +
+    'may have accidentally passed in a React root node instead of its ' +
+    'container.'
+  );
+});
+
+it('should warn when unmounting a non-container, non-root node', function() {
+  var mainContainerDiv = document.createElement('div');
+
+  var component =
+    <div>
       <div>
         <div />
-      </div>;
-    ReactDOM.render(component, mainContainerDiv);
+      </div>
+    </div>;
+  ReactDOM.render(component, mainContainerDiv);
 
-    // Test that unmounting at a root node gives a helpful warning
-    var rootDiv = mainContainerDiv.firstChild;
-    spyOn(console, 'error');
-    ReactDOM.unmountComponentAtNode(rootDiv);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: unmountComponentAtNode(): The node you\'re attempting to ' +
-      'unmount was rendered by React and is not a top-level container. You ' +
-      'may have accidentally passed in a React root node instead of its ' +
-      'container.'
-    );
-  });
-
-  it('should warn when unmounting a non-container, non-root node', function() {
-    var mainContainerDiv = document.createElement('div');
-
-    var component =
-      <div>
-        <div>
-          <div />
-        </div>
-      </div>;
-    ReactDOM.render(component, mainContainerDiv);
-
-    // Test that unmounting at a non-root node gives a different warning
-    var nonRootDiv = mainContainerDiv.firstChild.firstChild;
-    spyOn(console, 'error');
-    ReactDOM.unmountComponentAtNode(nonRootDiv);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: unmountComponentAtNode(): The node you\'re attempting to ' +
-      'unmount was rendered by React and is not a top-level container. ' +
-      'Instead, have the parent component update its state and rerender in ' +
-      'order to remove this component.'
-    );
-  });
+  // Test that unmounting at a non-root node gives a different warning
+  var nonRootDiv = mainContainerDiv.firstChild.firstChild;
+  spyOn(console, 'error');
+  ReactDOM.unmountComponentAtNode(nonRootDiv);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: unmountComponentAtNode(): The node you\'re attempting to ' +
+    'unmount was rendered by React and is not a top-level container. ' +
+    'Instead, have the parent component update its state and rerender in ' +
+    'order to remove this component.'
+  );
 });

--- a/src/renderers/dom/client/__tests__/ReactRenderDocument-test.js
+++ b/src/renderers/dom/client/__tests__/ReactRenderDocument-test.js
@@ -26,240 +26,238 @@ var UNMOUNT_INVARIANT_MESSAGE =
   'efficiently. To fix this, have a single top-level component that ' +
   'never unmounts render these elements.';
 
-describe('rendering React components at document', function() {
-  beforeEach(function() {
-    jest.resetModuleRegistry();
+beforeEach(function() {
+  jest.resetModuleRegistry();
 
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactDOMServer = require('ReactDOMServer');
-    getTestDocument = require('getTestDocument');
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactDOMServer = require('ReactDOMServer');
+  getTestDocument = require('getTestDocument');
 
-    testDocument = getTestDocument();
-  });
+  testDocument = getTestDocument();
+});
 
-  it('should be able to adopt server markup', function() {
-    expect(testDocument).not.toBeUndefined();
+it('should be able to adopt server markup', function() {
+  expect(testDocument).not.toBeUndefined();
 
-    class Root extends React.Component {
-      render() {
-        return (
-          <html>
-            <head>
-              <title>Hello World</title>
-            </head>
-            <body>
-              {'Hello ' + this.props.hello}
-            </body>
-          </html>
-        );
-      }
+  class Root extends React.Component {
+    render() {
+      return (
+        <html>
+          <head>
+            <title>Hello World</title>
+          </head>
+          <body>
+            {'Hello ' + this.props.hello}
+          </body>
+        </html>
+      );
     }
+  }
 
-    var markup = ReactDOMServer.renderToString(<Root hello="world" />);
-    testDocument = getTestDocument(markup);
-    var body = testDocument.body;
+  var markup = ReactDOMServer.renderToString(<Root hello="world" />);
+  testDocument = getTestDocument(markup);
+  var body = testDocument.body;
 
-    ReactDOM.render(<Root hello="world" />, testDocument);
-    expect(testDocument.body.innerHTML).toBe('Hello world');
+  ReactDOM.render(<Root hello="world" />, testDocument);
+  expect(testDocument.body.innerHTML).toBe('Hello world');
 
-    ReactDOM.render(<Root hello="moon" />, testDocument);
-    expect(testDocument.body.innerHTML).toBe('Hello moon');
+  ReactDOM.render(<Root hello="moon" />, testDocument);
+  expect(testDocument.body.innerHTML).toBe('Hello moon');
 
-    expect(body).toBe(testDocument.body);
-  });
+  expect(body).toBe(testDocument.body);
+});
 
-  it('should not be able to unmount component from document node', function() {
-    expect(testDocument).not.toBeUndefined();
+it('should not be able to unmount component from document node', function() {
+  expect(testDocument).not.toBeUndefined();
 
-    class Root extends React.Component {
-      render() {
-        return (
-          <html>
-            <head>
-              <title>Hello World</title>
-            </head>
-            <body>
-              Hello world
-            </body>
-          </html>
-        );
-      }
+  class Root extends React.Component {
+    render() {
+      return (
+        <html>
+          <head>
+            <title>Hello World</title>
+          </head>
+          <body>
+            Hello world
+          </body>
+        </html>
+      );
     }
+  }
 
-    var markup = ReactDOMServer.renderToString(<Root />);
-    testDocument = getTestDocument(markup);
-    ReactDOM.render(<Root />, testDocument);
-    expect(testDocument.body.innerHTML).toBe('Hello world');
+  var markup = ReactDOMServer.renderToString(<Root />);
+  testDocument = getTestDocument(markup);
+  ReactDOM.render(<Root />, testDocument);
+  expect(testDocument.body.innerHTML).toBe('Hello world');
 
-    expect(function() {
-      ReactDOM.unmountComponentAtNode(testDocument);
-    }).toThrowError(UNMOUNT_INVARIANT_MESSAGE);
+  expect(function() {
+    ReactDOM.unmountComponentAtNode(testDocument);
+  }).toThrowError(UNMOUNT_INVARIANT_MESSAGE);
 
-    expect(testDocument.body.innerHTML).toBe('Hello world');
-  });
+  expect(testDocument.body.innerHTML).toBe('Hello world');
+});
 
-  it('should not be able to switch root constructors', function() {
-    expect(testDocument).not.toBeUndefined();
+it('should not be able to switch root constructors', function() {
+  expect(testDocument).not.toBeUndefined();
 
-    class Component extends React.Component {
-      render() {
-        return (
-          <html>
-            <head>
-              <title>Hello World</title>
-            </head>
-            <body>
-              Hello world
-            </body>
-          </html>
-        );
-      }
+  class Component extends React.Component {
+    render() {
+      return (
+        <html>
+          <head>
+            <title>Hello World</title>
+          </head>
+          <body>
+            Hello world
+          </body>
+        </html>
+      );
     }
+  }
 
-    class Component2 extends React.Component {
-      render() {
-        return (
-          <html>
-            <head>
-              <title>Hello World</title>
-            </head>
-            <body>
-              Goodbye world
-            </body>
-          </html>
-        );
-      }
+  class Component2 extends React.Component {
+    render() {
+      return (
+        <html>
+          <head>
+            <title>Hello World</title>
+          </head>
+          <body>
+            Goodbye world
+          </body>
+        </html>
+      );
     }
+  }
 
-    var markup = ReactDOMServer.renderToString(<Component />);
-    testDocument = getTestDocument(markup);
+  var markup = ReactDOMServer.renderToString(<Component />);
+  testDocument = getTestDocument(markup);
 
-    ReactDOM.render(<Component />, testDocument);
+  ReactDOM.render(<Component />, testDocument);
 
-    expect(testDocument.body.innerHTML).toBe('Hello world');
+  expect(testDocument.body.innerHTML).toBe('Hello world');
 
-    // Reactive update
-    expect(function() {
-      ReactDOM.render(<Component2 />, testDocument);
-    }).toThrowError(UNMOUNT_INVARIANT_MESSAGE);
+  // Reactive update
+  expect(function() {
+    ReactDOM.render(<Component2 />, testDocument);
+  }).toThrowError(UNMOUNT_INVARIANT_MESSAGE);
 
-    expect(testDocument.body.innerHTML).toBe('Hello world');
-  });
+  expect(testDocument.body.innerHTML).toBe('Hello world');
+});
 
-  it('should be able to mount into document', function() {
-    expect(testDocument).not.toBeUndefined();
+it('should be able to mount into document', function() {
+  expect(testDocument).not.toBeUndefined();
 
-    class Component extends React.Component {
-      render() {
-        return (
-          <html>
-            <head>
-              <title>Hello World</title>
-            </head>
-            <body>
-              {this.props.text}
-            </body>
-          </html>
-        );
-      }
+  class Component extends React.Component {
+    render() {
+      return (
+        <html>
+          <head>
+            <title>Hello World</title>
+          </head>
+          <body>
+            {this.props.text}
+          </body>
+        </html>
+      );
     }
+  }
 
-    var markup = ReactDOMServer.renderToString(
-      <Component text="Hello world" />
-    );
-    testDocument = getTestDocument(markup);
+  var markup = ReactDOMServer.renderToString(
+    <Component text="Hello world" />
+  );
+  testDocument = getTestDocument(markup);
 
+  ReactDOM.render(<Component text="Hello world" />, testDocument);
+
+  expect(testDocument.body.innerHTML).toBe('Hello world');
+});
+
+it('should give helpful errors on state desync', function() {
+  expect(testDocument).not.toBeUndefined();
+
+  class Component extends React.Component {
+    render() {
+      return (
+        <html>
+          <head>
+            <title>Hello World</title>
+          </head>
+          <body>
+            {this.props.text}
+          </body>
+        </html>
+      );
+    }
+  }
+
+  var markup = ReactDOMServer.renderToString(
+    <Component text="Goodbye world" />
+  );
+  testDocument = getTestDocument(markup);
+
+  expect(function() {
+    // Notice the text is different!
     ReactDOM.render(<Component text="Hello world" />, testDocument);
+  }).toThrowError(
+    'You\'re trying to render a component to the document using ' +
+    'server rendering but the checksum was invalid. This usually ' +
+    'means you rendered a different component type or props on ' +
+    'the client from the one on the server, or your render() methods ' +
+    'are impure. React cannot handle this case due to cross-browser ' +
+    'quirks by rendering at the document root. You should look for ' +
+    'environment dependent code in your components and ensure ' +
+    'the props are the same client and server side:\n' +
+    ' (client) dy data-reactid="4">Hello world</body></\n' +
+    ' (server) dy data-reactid="4">Goodbye world</body>'
+  );
+});
 
-    expect(testDocument.body.innerHTML).toBe('Hello world');
-  });
+it('should throw on full document render w/ no markup', function() {
+  expect(testDocument).not.toBeUndefined();
 
-  it('should give helpful errors on state desync', function() {
-    expect(testDocument).not.toBeUndefined();
+  var container = testDocument;
 
-    class Component extends React.Component {
-      render() {
-        return (
-          <html>
-            <head>
-              <title>Hello World</title>
-            </head>
-            <body>
-              {this.props.text}
-            </body>
-          </html>
-        );
-      }
+  class Component extends React.Component {
+    render() {
+      return (
+        <html>
+          <head>
+            <title>Hello World</title>
+          </head>
+          <body>
+            {this.props.text}
+          </body>
+        </html>
+      );
     }
+  }
 
-    var markup = ReactDOMServer.renderToString(
-      <Component text="Goodbye world" />
-    );
-    testDocument = getTestDocument(markup);
+  expect(function() {
+    ReactDOM.render(<Component />, container);
+  }).toThrowError(
+    'You\'re trying to render a component to the document but you didn\'t ' +
+    'use server rendering. We can\'t do this without using server ' +
+    'rendering due to cross-browser quirks. See ' +
+    'ReactDOMServer.renderToString() for server rendering.'
+  );
+});
 
-    expect(function() {
-      // Notice the text is different!
-      ReactDOM.render(<Component text="Hello world" />, testDocument);
-    }).toThrowError(
-      'You\'re trying to render a component to the document using ' +
-      'server rendering but the checksum was invalid. This usually ' +
-      'means you rendered a different component type or props on ' +
-      'the client from the one on the server, or your render() methods ' +
-      'are impure. React cannot handle this case due to cross-browser ' +
-      'quirks by rendering at the document root. You should look for ' +
-      'environment dependent code in your components and ensure ' +
-      'the props are the same client and server side:\n' +
-      ' (client) dy data-reactid="4">Hello world</body></\n' +
-      ' (server) dy data-reactid="4">Goodbye world</body>'
-    );
-  });
+it('supports findDOMNode on full-page components', function() {
+  var tree =
+    <html>
+      <head>
+        <title>Hello World</title>
+      </head>
+      <body>
+        Hello world
+      </body>
+    </html>;
 
-  it('should throw on full document render w/ no markup', function() {
-    expect(testDocument).not.toBeUndefined();
-
-    var container = testDocument;
-
-    class Component extends React.Component {
-      render() {
-        return (
-          <html>
-            <head>
-              <title>Hello World</title>
-            </head>
-            <body>
-              {this.props.text}
-            </body>
-          </html>
-        );
-      }
-    }
-
-    expect(function() {
-      ReactDOM.render(<Component />, container);
-    }).toThrowError(
-      'You\'re trying to render a component to the document but you didn\'t ' +
-      'use server rendering. We can\'t do this without using server ' +
-      'rendering due to cross-browser quirks. See ' +
-      'ReactDOMServer.renderToString() for server rendering.'
-    );
-  });
-
-  it('supports findDOMNode on full-page components', function() {
-    var tree =
-      <html>
-        <head>
-          <title>Hello World</title>
-        </head>
-        <body>
-          Hello world
-        </body>
-      </html>;
-
-    var markup = ReactDOMServer.renderToString(tree);
-    testDocument = getTestDocument(markup);
-    var component = ReactDOM.render(tree, testDocument);
-    expect(testDocument.body.innerHTML).toBe('Hello world');
-    expect(ReactDOM.findDOMNode(component).tagName).toBe('HTML');
-  });
+  var markup = ReactDOMServer.renderToString(tree);
+  testDocument = getTestDocument(markup);
+  var component = ReactDOM.render(tree, testDocument);
+  expect(testDocument.body.innerHTML).toBe('Hello world');
+  expect(ReactDOM.findDOMNode(component).tagName).toBe('HTML');
 });

--- a/src/renderers/dom/client/__tests__/findDOMNode-test.js
+++ b/src/renderers/dom/client/__tests__/findDOMNode-test.js
@@ -15,61 +15,58 @@ var React = require('React');
 var ReactDOM = require('ReactDOM');
 var ReactTestUtils = require('ReactTestUtils');
 
-describe('findDOMNode', function() {
-  it('findDOMNode should return null if passed null', function() {
-    expect(ReactDOM.findDOMNode(null)).toBe(null);
-  });
+it('findDOMNode should return null if passed null', function() {
+  expect(ReactDOM.findDOMNode(null)).toBe(null);
+});
 
-  it('findDOMNode should find dom element', function() {
-    class MyNode extends React.Component {
-      render() {
-        return <div><span>Noise</span></div>;
-      }
+it('findDOMNode should find dom element', function() {
+  class MyNode extends React.Component {
+    render() {
+      return <div><span>Noise</span></div>;
+    }
+  }
+
+  var myNode = ReactTestUtils.renderIntoDocument(<MyNode />);
+  var myDiv = ReactDOM.findDOMNode(myNode);
+  var mySameDiv = ReactDOM.findDOMNode(myDiv);
+  expect(myDiv.tagName).toBe('DIV');
+  expect(mySameDiv).toBe(myDiv);
+});
+
+it('findDOMNode should reject random objects', function() {
+  expect(function() {
+    ReactDOM.findDOMNode({foo: 'bar'});
+  }).toThrowError(
+    'Element appears to be neither ReactComponent nor DOMNode (keys: foo)'
+  );
+});
+
+it('findDOMNode should reject unmounted objects with render func', function() {
+  class Foo extends React.Component {
+    render() {
+      return <div />;
+    }
+  }
+
+  var container = document.createElement('div');
+  var inst = ReactDOM.render(<Foo />, container);
+  ReactDOM.unmountComponentAtNode(container);
+
+  expect(() => ReactDOM.findDOMNode(inst)).toThrowError(
+    'findDOMNode was called on an unmounted component.'
+  );
+});
+
+it('findDOMNode should not throw an error when called within a component that is not mounted', function() {
+  class Bar extends React.Component {
+    componentWillMount() {
+      expect(ReactDOM.findDOMNode(this)).toBeNull();
     }
 
-    var myNode = ReactTestUtils.renderIntoDocument(<MyNode />);
-    var myDiv = ReactDOM.findDOMNode(myNode);
-    var mySameDiv = ReactDOM.findDOMNode(myDiv);
-    expect(myDiv.tagName).toBe('DIV');
-    expect(mySameDiv).toBe(myDiv);
-  });
-
-  it('findDOMNode should reject random objects', function() {
-    expect(function() {
-      ReactDOM.findDOMNode({foo: 'bar'});
-    }).toThrowError(
-      'Element appears to be neither ReactComponent nor DOMNode (keys: foo)'
-    );
-  });
-
-  it('findDOMNode should reject unmounted objects with render func', function() {
-    class Foo extends React.Component {
-      render() {
-        return <div />;
-      }
+    render() {
+      return <div/>;
     }
+  }
 
-    var container = document.createElement('div');
-    var inst = ReactDOM.render(<Foo />, container);
-    ReactDOM.unmountComponentAtNode(container);
-
-    expect(() => ReactDOM.findDOMNode(inst)).toThrowError(
-      'findDOMNode was called on an unmounted component.'
-    );
-  });
-
-  it('findDOMNode should not throw an error when called within a component that is not mounted', function() {
-    class Bar extends React.Component {
-      componentWillMount() {
-        expect(ReactDOM.findDOMNode(this)).toBeNull();
-      }
-
-      render() {
-        return <div/>;
-      }
-    }
-
-    expect(() => ReactTestUtils.renderIntoDocument(<Bar/>)).not.toThrow();
-  });
-
+  expect(() => ReactTestUtils.renderIntoDocument(<Bar/>)).not.toThrow();
 });

--- a/src/renderers/dom/client/__tests__/inputValueTracking-test.js
+++ b/src/renderers/dom/client/__tests__/inputValueTracking-test.js
@@ -14,152 +14,150 @@ var React = require('React');
 var ReactTestUtils = require('ReactTestUtils');
 var inputValueTracking = require('inputValueTracking');
 
-describe('inputValueTracking', function() {
-  var input, checkbox, mockComponent;
+var input, checkbox, mockComponent;
 
-  beforeEach(function() {
-    input = document.createElement('input');
-    input.type = 'text';
-    checkbox = document.createElement('input');
-    checkbox.type = 'checkbox';
-    mockComponent = { _hostNode: input, _wrapperState: {} };
-  });
+beforeEach(function() {
+  input = document.createElement('input');
+  input.type = 'text';
+  checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  mockComponent = { _hostNode: input, _wrapperState: {} };
+});
 
-  it('should attach tracker to wrapper state', function() {
-    inputValueTracking.track(mockComponent);
+it('should attach tracker to wrapper state', function() {
+  inputValueTracking.track(mockComponent);
 
-    expect(
-      mockComponent._wrapperState.hasOwnProperty('valueTracker')
-    ).toBe(true);
-  });
+  expect(
+    mockComponent._wrapperState.hasOwnProperty('valueTracker')
+  ).toBe(true);
+});
 
-  it('should define `value` on the instance node', function() {
-    inputValueTracking.track(mockComponent);
+it('should define `value` on the instance node', function() {
+  inputValueTracking.track(mockComponent);
 
-    expect(
-      input.hasOwnProperty('value')
-    ).toBe(true);
-  });
+  expect(
+    input.hasOwnProperty('value')
+  ).toBe(true);
+});
 
-  it('should define `checked` on the instance node', function() {
-    mockComponent._hostNode = checkbox;
-    inputValueTracking.track(mockComponent);
+it('should define `checked` on the instance node', function() {
+  mockComponent._hostNode = checkbox;
+  inputValueTracking.track(mockComponent);
 
-    expect(checkbox.hasOwnProperty('checked')).toBe(true);
-  });
+  expect(checkbox.hasOwnProperty('checked')).toBe(true);
+});
 
-  it('should initialize with the current value', function() {
-    input.value ='foo';
+it('should initialize with the current value', function() {
+  input.value ='foo';
 
-    inputValueTracking.track(mockComponent);
+  inputValueTracking.track(mockComponent);
 
-    var tracker = mockComponent._wrapperState.valueTracker;
+  var tracker = mockComponent._wrapperState.valueTracker;
 
-    expect(tracker.getValue()).toEqual('foo');
-  });
+  expect(tracker.getValue()).toEqual('foo');
+});
 
-  it('should initialize with the current `checked`', function() {
-    mockComponent._hostNode = checkbox;
-    checkbox.checked = true;
-    inputValueTracking.track(mockComponent);
+it('should initialize with the current `checked`', function() {
+  mockComponent._hostNode = checkbox;
+  checkbox.checked = true;
+  inputValueTracking.track(mockComponent);
 
-    var tracker = mockComponent._wrapperState.valueTracker;
+  var tracker = mockComponent._wrapperState.valueTracker;
 
-    expect(tracker.getValue()).toEqual('true');
-  });
+  expect(tracker.getValue()).toEqual('true');
+});
 
-  it('should track value changes', function() {
-    input.value ='foo';
+it('should track value changes', function() {
+  input.value ='foo';
 
-    inputValueTracking.track(mockComponent);
+  inputValueTracking.track(mockComponent);
 
-    var tracker = mockComponent._wrapperState.valueTracker;
+  var tracker = mockComponent._wrapperState.valueTracker;
 
-    input.value ='bar';
-    expect(tracker.getValue()).toEqual('bar');
-  });
+  input.value ='bar';
+  expect(tracker.getValue()).toEqual('bar');
+});
 
-  it('should tracked`checked` changes', function() {
-    mockComponent._hostNode = checkbox;
-    checkbox.checked = true;
-    inputValueTracking.track(mockComponent);
+it('should tracked`checked` changes', function() {
+  mockComponent._hostNode = checkbox;
+  checkbox.checked = true;
+  inputValueTracking.track(mockComponent);
 
-    var tracker = mockComponent._wrapperState.valueTracker;
+  var tracker = mockComponent._wrapperState.valueTracker;
 
-    checkbox.checked = false;
-    expect(tracker.getValue()).toEqual('false');
-  });
+  checkbox.checked = false;
+  expect(tracker.getValue()).toEqual('false');
+});
 
-  it('should update value manually', function() {
-    input.value ='foo';
-    inputValueTracking.track(mockComponent);
+it('should update value manually', function() {
+  input.value ='foo';
+  inputValueTracking.track(mockComponent);
 
-    var tracker = mockComponent._wrapperState.valueTracker;
+  var tracker = mockComponent._wrapperState.valueTracker;
 
-    tracker.setValue('bar');
-    expect(tracker.getValue()).toEqual('bar');
-  });
+  tracker.setValue('bar');
+  expect(tracker.getValue()).toEqual('bar');
+});
 
-  it('should coerce value to a string', function() {
-    input.value ='foo';
-    inputValueTracking.track(mockComponent);
+it('should coerce value to a string', function() {
+  input.value ='foo';
+  inputValueTracking.track(mockComponent);
 
-    var tracker = mockComponent._wrapperState.valueTracker;
+  var tracker = mockComponent._wrapperState.valueTracker;
 
-    tracker.setValue(500);
-    expect(tracker.getValue()).toEqual('500');
-  });
+  tracker.setValue(500);
+  expect(tracker.getValue()).toEqual('500');
+});
 
-  it('should update value if it changed and return result', function() {
-    inputValueTracking.track(mockComponent);
-    input.value ='foo';
+it('should update value if it changed and return result', function() {
+  inputValueTracking.track(mockComponent);
+  input.value ='foo';
 
-    var tracker = mockComponent._wrapperState.valueTracker;
+  var tracker = mockComponent._wrapperState.valueTracker;
 
-    expect(
-      inputValueTracking.updateValueIfChanged(mockComponent)
-    ).toBe(false);
+  expect(
+    inputValueTracking.updateValueIfChanged(mockComponent)
+  ).toBe(false);
 
-    tracker.setValue('bar');
+  tracker.setValue('bar');
 
-    expect(
-      inputValueTracking.updateValueIfChanged(mockComponent)
-    ).toBe(true);
+  expect(
+    inputValueTracking.updateValueIfChanged(mockComponent)
+  ).toBe(true);
 
-    expect(tracker.getValue()).toEqual('foo');
-  });
+  expect(tracker.getValue()).toEqual('foo');
+});
 
-  it('should track value and return true when updating untracked instance', function() {
-    input.value ='foo';
+it('should track value and return true when updating untracked instance', function() {
+  input.value ='foo';
 
-    expect(
-      inputValueTracking.updateValueIfChanged(mockComponent)
-    )
-    .toBe(true);
+  expect(
+    inputValueTracking.updateValueIfChanged(mockComponent)
+  )
+  .toBe(true);
 
-    var tracker = mockComponent._wrapperState.valueTracker;
-    expect(tracker.getValue()).toEqual('foo');
-  });
+  var tracker = mockComponent._wrapperState.valueTracker;
+  expect(tracker.getValue()).toEqual('foo');
+});
 
-  it('should return tracker from node', function() {
-    var node = ReactTestUtils.renderIntoDocument(<input type="text" defaultValue="foo" />);
-    var tracker = inputValueTracking._getTrackerFromNode(node);
-    expect(tracker.getValue()).toEqual('foo');
-  });
+it('should return tracker from node', function() {
+  var node = ReactTestUtils.renderIntoDocument(<input type="text" defaultValue="foo" />);
+  var tracker = inputValueTracking._getTrackerFromNode(node);
+  expect(tracker.getValue()).toEqual('foo');
+});
 
-  it('should stop tracking', function() {
-    inputValueTracking.track(mockComponent);
+it('should stop tracking', function() {
+  inputValueTracking.track(mockComponent);
 
-    expect(
-      mockComponent._wrapperState.hasOwnProperty('valueTracker')
-    ).toBe(true);
+  expect(
+    mockComponent._wrapperState.hasOwnProperty('valueTracker')
+  ).toBe(true);
 
-    inputValueTracking.stopTracking(mockComponent);
+  inputValueTracking.stopTracking(mockComponent);
 
-    expect(
-      mockComponent._wrapperState.hasOwnProperty('valueTracker')
-    ).toBe(false);
+  expect(
+    mockComponent._wrapperState.hasOwnProperty('valueTracker')
+  ).toBe(false);
 
-    expect(input.hasOwnProperty('value')).toBe(false);
-  });
+  expect(input.hasOwnProperty('value')).toBe(false);
 });

--- a/src/renderers/dom/client/__tests__/validateDOMNesting-test.js
+++ b/src/renderers/dom/client/__tests__/validateDOMNesting-test.js
@@ -45,45 +45,43 @@ function isTagStackValid(stack) {
   return true;
 }
 
-describe('ReactContextValidator', function() {
-  beforeEach(function() {
-    jest.resetModuleRegistry();
+beforeEach(function() {
+  jest.resetModuleRegistry();
 
-    validateDOMNesting = require('validateDOMNesting');
+  validateDOMNesting = require('validateDOMNesting');
+});
+
+it('allows any tag with no context', function() {
+  // With renderToString (for example), we don't know where we're mounting the
+  // tag so we must err on the side of leniency.
+  var allTags = [].concat(specialTags, formattingTags, ['mysterytag']);
+  allTags.forEach(function(tag) {
+    expect(validateDOMNesting.isTagValidInContext(tag, null)).toBe(true);
   });
+});
 
-  it('allows any tag with no context', function() {
-    // With renderToString (for example), we don't know where we're mounting the
-    // tag so we must err on the side of leniency.
-    var allTags = [].concat(specialTags, formattingTags, ['mysterytag']);
-    allTags.forEach(function(tag) {
-      expect(validateDOMNesting.isTagValidInContext(tag, null)).toBe(true);
-    });
-  });
+it('allows valid nestings', function() {
+  expect(isTagStackValid(['table', 'tbody', 'tr', 'td', 'b'])).toBe(true);
+  expect(isTagStackValid(['body', 'datalist', 'option'])).toBe(true);
+  expect(isTagStackValid(['div', 'a', 'object', 'a'])).toBe(true);
+  expect(isTagStackValid(['div', 'p', 'button', 'p'])).toBe(true);
+  expect(isTagStackValid(['p', 'svg', 'foreignObject', 'p'])).toBe(true);
+  expect(isTagStackValid(['html', 'body', 'div'])).toBe(true);
 
-  it('allows valid nestings', function() {
-    expect(isTagStackValid(['table', 'tbody', 'tr', 'td', 'b'])).toBe(true);
-    expect(isTagStackValid(['body', 'datalist', 'option'])).toBe(true);
-    expect(isTagStackValid(['div', 'a', 'object', 'a'])).toBe(true);
-    expect(isTagStackValid(['div', 'p', 'button', 'p'])).toBe(true);
-    expect(isTagStackValid(['p', 'svg', 'foreignObject', 'p'])).toBe(true);
-    expect(isTagStackValid(['html', 'body', 'div'])).toBe(true);
+  // Invalid, but not changed by browser parsing so we allow them
+  expect(isTagStackValid(['div', 'ul', 'ul', 'li'])).toBe(true);
+  expect(isTagStackValid(['div', 'label', 'div'])).toBe(true);
+  expect(isTagStackValid(['div', 'ul', 'li', 'section', 'li'])).toBe(true);
+  expect(isTagStackValid(['div', 'ul', 'li', 'dd', 'li'])).toBe(true);
+});
 
-    // Invalid, but not changed by browser parsing so we allow them
-    expect(isTagStackValid(['div', 'ul', 'ul', 'li'])).toBe(true);
-    expect(isTagStackValid(['div', 'label', 'div'])).toBe(true);
-    expect(isTagStackValid(['div', 'ul', 'li', 'section', 'li'])).toBe(true);
-    expect(isTagStackValid(['div', 'ul', 'li', 'dd', 'li'])).toBe(true);
-  });
-
-  it('prevents problematic nestings', function() {
-    expect(isTagStackValid(['a', 'a'])).toBe(false);
-    expect(isTagStackValid(['form', 'form'])).toBe(false);
-    expect(isTagStackValid(['p', 'p'])).toBe(false);
-    expect(isTagStackValid(['table', 'tr'])).toBe(false);
-    expect(isTagStackValid(['div', 'ul', 'li', 'div', 'li'])).toBe(false);
-    expect(isTagStackValid(['div', 'html'])).toBe(false);
-    expect(isTagStackValid(['body', 'body'])).toBe(false);
-    expect(isTagStackValid(['svg', 'foreignObject', 'body', 'p'])).toBe(false);
-  });
+it('prevents problematic nestings', function() {
+  expect(isTagStackValid(['a', 'a'])).toBe(false);
+  expect(isTagStackValid(['form', 'form'])).toBe(false);
+  expect(isTagStackValid(['p', 'p'])).toBe(false);
+  expect(isTagStackValid(['table', 'tr'])).toBe(false);
+  expect(isTagStackValid(['div', 'ul', 'li', 'div', 'li'])).toBe(false);
+  expect(isTagStackValid(['div', 'html'])).toBe(false);
+  expect(isTagStackValid(['body', 'body'])).toBe(false);
+  expect(isTagStackValid(['svg', 'foreignObject', 'body', 'p'])).toBe(false);
 });

--- a/src/renderers/dom/client/eventPlugins/__tests__/ChangeEventPlugin-test.js
+++ b/src/renderers/dom/client/eventPlugins/__tests__/ChangeEventPlugin-test.js
@@ -39,177 +39,175 @@ function setUntrackedValue(elem, value) {
   tracker.setValue(current);
 }
 
-describe('ChangeEventPlugin', function() {
-  it('should fire change for checkbox input', function() {
-    var called = 0;
+it('should fire change for checkbox input', function() {
+  var called = 0;
 
-    function cb(e) {
-      called = 1;
-      expect(e.type).toBe('change');
-    }
+  function cb(e) {
+    called = 1;
+    expect(e.type).toBe('change');
+  }
 
-    var input = ReactTestUtils.renderIntoDocument(<input type="checkbox" onChange={cb}/>);
+  var input = ReactTestUtils.renderIntoDocument(<input type="checkbox" onChange={cb}/>);
 
-    setUntrackedValue(input, true);
-    ReactTestUtils.SimulateNative.click(input);
+  setUntrackedValue(input, true);
+  ReactTestUtils.SimulateNative.click(input);
 
-    expect(called).toBe(1);
-  });
+  expect(called).toBe(1);
+});
 
-  it('should catch setting the value programmatically', function() {
-    var input = ReactTestUtils.renderIntoDocument(
-      <input type="text" defaultValue="foo"/>
-    );
+it('should catch setting the value programmatically', function() {
+  var input = ReactTestUtils.renderIntoDocument(
+    <input type="text" defaultValue="foo"/>
+  );
 
-    input.value = 'bar';
-    expect(getTrackedValue(input)).toBe('bar');
-  });
+  input.value = 'bar';
+  expect(getTrackedValue(input)).toBe('bar');
+});
 
-  it('should not fire change when setting the value programmatically', function() {
-    var called = 0;
+it('should not fire change when setting the value programmatically', function() {
+  var called = 0;
 
-    function cb(e) {
-      called += 1;
-      expect(e.type).toBe('change');
-    }
+  function cb(e) {
+    called += 1;
+    expect(e.type).toBe('change');
+  }
 
-    var input = ReactTestUtils.renderIntoDocument(
-      <input type="text" onChange={cb} defaultValue="foo"/>
-    );
+  var input = ReactTestUtils.renderIntoDocument(
+    <input type="text" onChange={cb} defaultValue="foo"/>
+  );
 
-    input.value = 'bar';
+  input.value = 'bar';
+  ReactTestUtils.SimulateNative.change(input);
+  expect(called).toBe(0);
+
+  setUntrackedValue(input, 'foo');
+  ReactTestUtils.SimulateNative.change(input);
+
+  expect(called).toBe(1);
+});
+
+it('should not fire change when setting checked programmatically', function() {
+  var called = 0;
+
+  function cb(e) {
+    called += 1;
+    expect(e.type).toBe('change');
+  }
+
+  var input = ReactTestUtils.renderIntoDocument(
+    <input type="checkbox" onChange={cb} defaultChecked={true} />
+  );
+
+  input.checked = true;
+  ReactTestUtils.SimulateNative.click(input);
+  expect(called).toBe(0);
+
+  input.checked = false;
+  setTrackedValue(input, undefined);
+  ReactTestUtils.SimulateNative.click(input);
+
+  expect(called).toBe(1);
+});
+
+it('should unmount', function() {
+  var container = document.createElement('div');
+  var input = ReactDOM.render(<input />, container);
+
+  ReactDOM.unmountComponentAtNode(container);
+});
+
+it('should only fire change for checked radio button once', function() {
+  var called = 0;
+
+  function cb(e) {
+    called += 1;
+  }
+
+  var input = ReactTestUtils.renderIntoDocument(<input type="radio" onChange={cb}/>);
+  setUntrackedValue(input, true);
+  ReactTestUtils.SimulateNative.click(input);
+  ReactTestUtils.SimulateNative.click(input);
+  expect(called).toBe(1);
+});
+
+it('should deduplicate input value change events', function() {
+  var input;
+  var called = 0;
+
+  function cb(e) {
+    called += 1;
+    expect(e.type).toBe('change');
+  }
+
+  [
+    <input type="text" onChange={cb}/>,
+    <input type="number" onChange={cb}/>,
+    <input type="range" onChange={cb}/>,
+  ].forEach(function(element) {
+    called = 0;
+    input = ReactTestUtils.renderIntoDocument(element);
+
+    setUntrackedValue(input, '40');
     ReactTestUtils.SimulateNative.change(input);
-    expect(called).toBe(0);
-
-    setUntrackedValue(input, 'foo');
     ReactTestUtils.SimulateNative.change(input);
-
     expect(called).toBe(1);
-  });
 
-  it('should not fire change when setting checked programmatically', function() {
-    var called = 0;
-
-    function cb(e) {
-      called += 1;
-      expect(e.type).toBe('change');
-    }
-
-    var input = ReactTestUtils.renderIntoDocument(
-      <input type="checkbox" onChange={cb} defaultChecked={true} />
-    );
-
-    input.checked = true;
-    ReactTestUtils.SimulateNative.click(input);
-    expect(called).toBe(0);
-
-    input.checked = false;
-    setTrackedValue(input, undefined);
-    ReactTestUtils.SimulateNative.click(input);
-
-    expect(called).toBe(1);
-  });
-
-  it('should unmount', function() {
-    var container = document.createElement('div');
-    var input = ReactDOM.render(<input />, container);
-
-    ReactDOM.unmountComponentAtNode(container);
-  });
-
-  it('should only fire change for checked radio button once', function() {
-    var called = 0;
-
-    function cb(e) {
-      called += 1;
-    }
-
-    var input = ReactTestUtils.renderIntoDocument(<input type="radio" onChange={cb}/>);
-    setUntrackedValue(input, true);
-    ReactTestUtils.SimulateNative.click(input);
-    ReactTestUtils.SimulateNative.click(input);
-    expect(called).toBe(1);
-  });
-
-  it('should deduplicate input value change events', function() {
-    var input;
-    var called = 0;
-
-    function cb(e) {
-      called += 1;
-      expect(e.type).toBe('change');
-    }
-
-    [
-      <input type="text" onChange={cb}/>,
-      <input type="number" onChange={cb}/>,
-      <input type="range" onChange={cb}/>,
-    ].forEach(function(element) {
-      called = 0;
-      input = ReactTestUtils.renderIntoDocument(element);
-
-      setUntrackedValue(input, '40');
-      ReactTestUtils.SimulateNative.change(input);
-      ReactTestUtils.SimulateNative.change(input);
-      expect(called).toBe(1);
-
-      called = 0;
-      input = ReactTestUtils.renderIntoDocument(element);
-      setUntrackedValue(input, '40');
-      ReactTestUtils.SimulateNative.input(input);
-      ReactTestUtils.SimulateNative.input(input);
-      expect(called).toBe(1);
-
-      called = 0;
-      input = ReactTestUtils.renderIntoDocument(element);
-      setUntrackedValue(input, '40');
-      ReactTestUtils.SimulateNative.input(input);
-      ReactTestUtils.SimulateNative.change(input);
-      expect(called).toBe(1);
-    });
-  });
-
-  it('should listen for both change and input events when supported', function() {
-    var called = 0;
-
-    function cb(e) {
-      called += 1;
-      expect(e.type).toBe('change');
-    }
-
-    if (!ChangeEventPlugin._isInputEventSupported) {
-      return;
-    }
-
-    var input = ReactTestUtils.renderIntoDocument(<input type="range" onChange={cb}/>);
-    setUntrackedValue(input, 'bar');
-
+    called = 0;
+    input = ReactTestUtils.renderIntoDocument(element);
+    setUntrackedValue(input, '40');
     ReactTestUtils.SimulateNative.input(input);
+    ReactTestUtils.SimulateNative.input(input);
+    expect(called).toBe(1);
 
-    setUntrackedValue(input, 'foo');
-
-    ReactTestUtils.SimulateNative.change(input);
-
-    expect(called).toBe(2);
-  });
-
-  it('should only fire events when the value changes for range inputs', function() {
-    var called = 0;
-
-    function cb(e) {
-      called += 1;
-      expect(e.type).toBe('change');
-    }
-
-    var input = ReactTestUtils.renderIntoDocument(<input type="range" onChange={cb}/>);
+    called = 0;
+    input = ReactTestUtils.renderIntoDocument(element);
     setUntrackedValue(input, '40');
     ReactTestUtils.SimulateNative.input(input);
     ReactTestUtils.SimulateNative.change(input);
-
-    setUntrackedValue(input, 'foo');
-
-    ReactTestUtils.SimulateNative.input(input);
-    ReactTestUtils.SimulateNative.change(input);
-    expect(called).toBe(2);
+    expect(called).toBe(1);
   });
+});
+
+it('should listen for both change and input events when supported', function() {
+  var called = 0;
+
+  function cb(e) {
+    called += 1;
+    expect(e.type).toBe('change');
+  }
+
+  if (!ChangeEventPlugin._isInputEventSupported) {
+    return;
+  }
+
+  var input = ReactTestUtils.renderIntoDocument(<input type="range" onChange={cb}/>);
+  setUntrackedValue(input, 'bar');
+
+  ReactTestUtils.SimulateNative.input(input);
+
+  setUntrackedValue(input, 'foo');
+
+  ReactTestUtils.SimulateNative.change(input);
+
+  expect(called).toBe(2);
+});
+
+it('should only fire events when the value changes for range inputs', function() {
+  var called = 0;
+
+  function cb(e) {
+    called += 1;
+    expect(e.type).toBe('change');
+  }
+
+  var input = ReactTestUtils.renderIntoDocument(<input type="range" onChange={cb}/>);
+  setUntrackedValue(input, '40');
+  ReactTestUtils.SimulateNative.input(input);
+  ReactTestUtils.SimulateNative.change(input);
+
+  setUntrackedValue(input, 'foo');
+
+  ReactTestUtils.SimulateNative.input(input);
+  ReactTestUtils.SimulateNative.change(input);
+  expect(called).toBe(2);
 });

--- a/src/renderers/dom/client/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
+++ b/src/renderers/dom/client/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
@@ -16,44 +16,42 @@ var React;
 var ReactDOM;
 var ReactDOMComponentTree;
 
-describe('EnterLeaveEventPlugin', function() {
-  beforeEach(function() {
-    jest.resetModuleRegistry();
+beforeEach(function() {
+  jest.resetModuleRegistry();
 
-    EnterLeaveEventPlugin = require('EnterLeaveEventPlugin');
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactDOMComponentTree = require('ReactDOMComponentTree');
-  });
+  EnterLeaveEventPlugin = require('EnterLeaveEventPlugin');
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactDOMComponentTree = require('ReactDOMComponentTree');
+});
 
-  it('should set relatedTarget properly in iframe', function() {
-    var iframe = document.createElement('iframe');
-    document.body.appendChild(iframe);
+it('should set relatedTarget properly in iframe', function() {
+  var iframe = document.createElement('iframe');
+  document.body.appendChild(iframe);
 
-    var iframeDocument = iframe.contentDocument;
+  var iframeDocument = iframe.contentDocument;
 
-    iframeDocument.write(
-      '<!DOCTYPE html><html><head></head><body><div></div></body></html>'
-    );
-    iframeDocument.close();
+  iframeDocument.write(
+    '<!DOCTYPE html><html><head></head><body><div></div></body></html>'
+  );
+  iframeDocument.close();
 
-    var component = ReactDOM.render(<div />, iframeDocument.body.getElementsByTagName('div')[0]);
-    var div = ReactDOM.findDOMNode(component);
+  var component = ReactDOM.render(<div />, iframeDocument.body.getElementsByTagName('div')[0]);
+  var div = ReactDOM.findDOMNode(component);
 
-    var extracted = EnterLeaveEventPlugin.extractEvents(
-      'topMouseOver',
-      ReactDOMComponentTree.getInstanceFromNode(div),
-      {target: div},
-      div
-    );
-    expect(extracted.length).toBe(2);
+  var extracted = EnterLeaveEventPlugin.extractEvents(
+    'topMouseOver',
+    ReactDOMComponentTree.getInstanceFromNode(div),
+    {target: div},
+    div
+  );
+  expect(extracted.length).toBe(2);
 
-    var leave = extracted[0];
-    var enter = extracted[1];
+  var leave = extracted[0];
+  var enter = extracted[1];
 
-    expect(leave.target).toBe(iframe.contentWindow);
-    expect(leave.relatedTarget).toBe(div);
-    expect(enter.target).toBe(div);
-    expect(enter.relatedTarget).toBe(iframe.contentWindow);
-  });
+  expect(leave.target).toBe(iframe.contentWindow);
+  expect(leave.relatedTarget).toBe(div);
+  expect(enter.target).toBe(div);
+  expect(enter.relatedTarget).toBe(iframe.contentWindow);
 });

--- a/src/renderers/dom/client/eventPlugins/__tests__/FallbackCompositionState-test.js
+++ b/src/renderers/dom/client/eventPlugins/__tests__/FallbackCompositionState-test.js
@@ -11,82 +11,80 @@
 
 'use strict';
 
-describe('FallbackCompositionState', function() {
-  var FallbackCompositionState;
+var FallbackCompositionState;
 
-  var TEXT = 'Hello world';
+var TEXT = 'Hello world';
 
-  beforeEach(function() {
-    FallbackCompositionState = require('FallbackCompositionState');
+beforeEach(function() {
+  FallbackCompositionState = require('FallbackCompositionState');
+});
+
+function getInput() {
+  var input = document.createElement('input');
+  input.value = TEXT;
+  return input;
+}
+
+function getTextarea() {
+  var textarea = document.createElement('textarea');
+  textarea.value = TEXT;
+  return textarea;
+}
+
+function getContentEditable() {
+  var editable = document.createElement('div');
+  var inner = document.createElement('span');
+  inner.appendChild(document.createTextNode(TEXT));
+  editable.appendChild(inner);
+  return editable;
+}
+
+function assertExtractedData(modifiedValue, expectedData) {
+  var input = getInput();
+  var composition = FallbackCompositionState.getPooled(input);
+  input.value = modifiedValue;
+  expect(composition.getData()).toBe(expectedData);
+  FallbackCompositionState.release(composition);
+}
+
+it('extracts value via `getText()`', function() {
+  var composition = FallbackCompositionState.getPooled(getInput());
+  expect(composition.getText()).toBe(TEXT);
+  FallbackCompositionState.release(composition);
+
+  composition = FallbackCompositionState.getPooled(getTextarea());
+  expect(composition.getText()).toBe(TEXT);
+  FallbackCompositionState.release(composition);
+
+  composition = FallbackCompositionState.getPooled(getContentEditable());
+  expect(composition.getText()).toBe(TEXT);
+  FallbackCompositionState.release(composition);
+});
+
+describe('Extract fallback data inserted at collapsed cursor', function() {
+  it('extracts when inserted at start of text', function() {
+    assertExtractedData('XXXHello world', 'XXX');
   });
 
-  function getInput() {
-    var input = document.createElement('input');
-    input.value = TEXT;
-    return input;
-  }
-
-  function getTextarea() {
-    var textarea = document.createElement('textarea');
-    textarea.value = TEXT;
-    return textarea;
-  }
-
-  function getContentEditable() {
-    var editable = document.createElement('div');
-    var inner = document.createElement('span');
-    inner.appendChild(document.createTextNode(TEXT));
-    editable.appendChild(inner);
-    return editable;
-  }
-
-  function assertExtractedData(modifiedValue, expectedData) {
-    var input = getInput();
-    var composition = FallbackCompositionState.getPooled(input);
-    input.value = modifiedValue;
-    expect(composition.getData()).toBe(expectedData);
-    FallbackCompositionState.release(composition);
-  }
-
-  it('extracts value via `getText()`', function() {
-    var composition = FallbackCompositionState.getPooled(getInput());
-    expect(composition.getText()).toBe(TEXT);
-    FallbackCompositionState.release(composition);
-
-    composition = FallbackCompositionState.getPooled(getTextarea());
-    expect(composition.getText()).toBe(TEXT);
-    FallbackCompositionState.release(composition);
-
-    composition = FallbackCompositionState.getPooled(getContentEditable());
-    expect(composition.getText()).toBe(TEXT);
-    FallbackCompositionState.release(composition);
+  it('extracts when inserted within text', function() {
+    assertExtractedData('Hello XXXworld', 'XXX');
   });
 
-  describe('Extract fallback data inserted at collapsed cursor', function() {
-    it('extracts when inserted at start of text', function() {
-      assertExtractedData('XXXHello world', 'XXX');
-    });
+  it('extracts when inserted at end of text', function() {
+    assertExtractedData('Hello worldXXX', 'XXX');
+  });
+});
 
-    it('extracts when inserted within text', function() {
-      assertExtractedData('Hello XXXworld', 'XXX');
-    });
-
-    it('extracts when inserted at end of text', function() {
-      assertExtractedData('Hello worldXXX', 'XXX');
-    });
+describe('Extract fallback data for non-collapsed range', function() {
+  it('extracts when inserted at start of text', function() {
+    assertExtractedData('XXX world', 'XXX');
   });
 
-  describe('Extract fallback data for non-collapsed range', function() {
-    it('extracts when inserted at start of text', function() {
-      assertExtractedData('XXX world', 'XXX');
-    });
+  it('extracts when inserted within text', function() {
+    assertExtractedData('HelXXXrld', 'XXX');
+  });
 
-    it('extracts when inserted within text', function() {
-      assertExtractedData('HelXXXrld', 'XXX');
-    });
-
-    it('extracts when inserted at end of text', function() {
-      assertExtractedData('Hello XXX', 'XXX');
-    });
+  it('extracts when inserted at end of text', function() {
+    assertExtractedData('Hello XXX', 'XXX');
   });
 });

--- a/src/renderers/dom/client/syntheticEvents/__tests__/SyntheticClipboardEvent-test.js
+++ b/src/renderers/dom/client/syntheticEvents/__tests__/SyntheticClipboardEvent-test.js
@@ -13,62 +13,60 @@
 
 var SyntheticClipboardEvent;
 
-describe('SyntheticClipboardEvent', function() {
-  var createEvent;
+var createEvent;
 
-  beforeEach(function() {
-    SyntheticClipboardEvent = require('SyntheticClipboardEvent');
-    createEvent = function(nativeEvent) {
-      var target = require('getEventTarget')(nativeEvent);
-      return SyntheticClipboardEvent.getPooled({}, '', nativeEvent, target);
-    };
-  });
+beforeEach(function() {
+  SyntheticClipboardEvent = require('SyntheticClipboardEvent');
+  createEvent = function(nativeEvent) {
+    var target = require('getEventTarget')(nativeEvent);
+    return SyntheticClipboardEvent.getPooled({}, '', nativeEvent, target);
+  };
+});
 
-  describe('ClipboardEvent interface', function() {
-    describe('clipboardData', function() {
-      describe('when event has clipboardData', function() {
-        it("returns event's clipboardData", function() {
-          // Mock clipboardData since native implementation doesn't have a constructor
-          var clipboardData = jasmine.createSpyObj(
-            'clipboardData',
-            ['dropEffect', 'effectAllowed', 'files', 'items', 'types']
-          );
-          var clipboardEvent = createEvent({clipboardData: clipboardData});
-          
-          expect(clipboardEvent.clipboardData).toBe(clipboardData);
-        });
+describe('ClipboardEvent interface', function() {
+  describe('clipboardData', function() {
+    describe('when event has clipboardData', function() {
+      it("returns event's clipboardData", function() {
+        // Mock clipboardData since native implementation doesn't have a constructor
+        var clipboardData = jasmine.createSpyObj(
+          'clipboardData',
+          ['dropEffect', 'effectAllowed', 'files', 'items', 'types']
+        );
+        var clipboardEvent = createEvent({clipboardData: clipboardData});
+        
+        expect(clipboardEvent.clipboardData).toBe(clipboardData);
       });
     });
   });
+});
 
-  describe('EventInterface', function() {
-    it('normalizes properties from the Event interface', function() {
-      var target = document.createElement('div');
-      var syntheticEvent = createEvent({srcElement: target});
+describe('EventInterface', function() {
+  it('normalizes properties from the Event interface', function() {
+    var target = document.createElement('div');
+    var syntheticEvent = createEvent({srcElement: target});
 
-      expect(syntheticEvent.target).toBe(target);
-      expect(syntheticEvent.type).toBe(undefined);
-    });
+    expect(syntheticEvent.target).toBe(target);
+    expect(syntheticEvent.type).toBe(undefined);
+  });
 
-    it('is able to `preventDefault` and `stopPropagation`', function() {
-      var nativeEvent = {};
-      var syntheticEvent = createEvent(nativeEvent);
+  it('is able to `preventDefault` and `stopPropagation`', function() {
+    var nativeEvent = {};
+    var syntheticEvent = createEvent(nativeEvent);
 
-      expect(syntheticEvent.isDefaultPrevented()).toBe(false);
-      syntheticEvent.preventDefault();
-      expect(syntheticEvent.isDefaultPrevented()).toBe(true);
+    expect(syntheticEvent.isDefaultPrevented()).toBe(false);
+    syntheticEvent.preventDefault();
+    expect(syntheticEvent.isDefaultPrevented()).toBe(true);
 
-      expect(syntheticEvent.isPropagationStopped()).toBe(false);
-      syntheticEvent.stopPropagation();
-      expect(syntheticEvent.isPropagationStopped()).toBe(true);
-    });
+    expect(syntheticEvent.isPropagationStopped()).toBe(false);
+    syntheticEvent.stopPropagation();
+    expect(syntheticEvent.isPropagationStopped()).toBe(true);
+  });
 
-    it('is able to `persist`', function() {
-      var syntheticEvent = createEvent({});
+  it('is able to `persist`', function() {
+    var syntheticEvent = createEvent({});
 
-      expect(syntheticEvent.isPersistent()).toBe(false);
-      syntheticEvent.persist();
-      expect(syntheticEvent.isPersistent()).toBe(true);
-    });
+    expect(syntheticEvent.isPersistent()).toBe(false);
+    syntheticEvent.persist();
+    expect(syntheticEvent.isPersistent()).toBe(true);
   });
 });

--- a/src/renderers/dom/client/syntheticEvents/__tests__/SyntheticEvent-test.js
+++ b/src/renderers/dom/client/syntheticEvents/__tests__/SyntheticEvent-test.js
@@ -16,177 +16,175 @@ var React;
 var ReactDOM;
 var ReactTestUtils;
 
-describe('SyntheticEvent', function() {
-  var createEvent;
+var createEvent;
 
-  beforeEach(function() {
-    SyntheticEvent = require('SyntheticEvent');
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactTestUtils = require('ReactTestUtils');
+beforeEach(function() {
+  SyntheticEvent = require('SyntheticEvent');
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactTestUtils = require('ReactTestUtils');
 
-    createEvent = function(nativeEvent) {
-      var target = require('getEventTarget')(nativeEvent);
-      return SyntheticEvent.getPooled({}, '', nativeEvent, target);
-    };
-  });
+  createEvent = function(nativeEvent) {
+    var target = require('getEventTarget')(nativeEvent);
+    return SyntheticEvent.getPooled({}, '', nativeEvent, target);
+  };
+});
 
-  it('should normalize `target` from the nativeEvent', function() {
-    var target = document.createElement('div');
-    var syntheticEvent = createEvent({srcElement: target});
+it('should normalize `target` from the nativeEvent', function() {
+  var target = document.createElement('div');
+  var syntheticEvent = createEvent({srcElement: target});
 
-    expect(syntheticEvent.target).toBe(target);
-    expect(syntheticEvent.type).toBe(undefined);
-  });
+  expect(syntheticEvent.target).toBe(target);
+  expect(syntheticEvent.type).toBe(undefined);
+});
 
-  it('should be able to `preventDefault`', function() {
-    var nativeEvent = {};
-    var syntheticEvent = createEvent(nativeEvent);
+it('should be able to `preventDefault`', function() {
+  var nativeEvent = {};
+  var syntheticEvent = createEvent(nativeEvent);
 
-    expect(syntheticEvent.isDefaultPrevented()).toBe(false);
-    syntheticEvent.preventDefault();
-    expect(syntheticEvent.isDefaultPrevented()).toBe(true);
+  expect(syntheticEvent.isDefaultPrevented()).toBe(false);
+  syntheticEvent.preventDefault();
+  expect(syntheticEvent.isDefaultPrevented()).toBe(true);
 
-    expect(syntheticEvent.defaultPrevented).toBe(true);
+  expect(syntheticEvent.defaultPrevented).toBe(true);
 
-    expect(nativeEvent.returnValue).toBe(false);
-  });
+  expect(nativeEvent.returnValue).toBe(false);
+});
 
-  it('should be prevented if nativeEvent is prevented', function() {
-    expect(
-      createEvent({defaultPrevented: true}).isDefaultPrevented()
-    ).toBe(true);
-    expect(createEvent({returnValue: false}).isDefaultPrevented()).toBe(true);
-  });
+it('should be prevented if nativeEvent is prevented', function() {
+  expect(
+    createEvent({defaultPrevented: true}).isDefaultPrevented()
+  ).toBe(true);
+  expect(createEvent({returnValue: false}).isDefaultPrevented()).toBe(true);
+});
 
-  it('should be able to `stopPropagation`', function() {
-    var nativeEvent = {};
-    var syntheticEvent = createEvent(nativeEvent);
+it('should be able to `stopPropagation`', function() {
+  var nativeEvent = {};
+  var syntheticEvent = createEvent(nativeEvent);
 
-    expect(syntheticEvent.isPropagationStopped()).toBe(false);
-    syntheticEvent.stopPropagation();
-    expect(syntheticEvent.isPropagationStopped()).toBe(true);
+  expect(syntheticEvent.isPropagationStopped()).toBe(false);
+  syntheticEvent.stopPropagation();
+  expect(syntheticEvent.isPropagationStopped()).toBe(true);
 
-    expect(nativeEvent.cancelBubble).toBe(true);
-  });
+  expect(nativeEvent.cancelBubble).toBe(true);
+});
 
-  it('should be able to `persist`', function() {
-    var syntheticEvent = createEvent({});
+it('should be able to `persist`', function() {
+  var syntheticEvent = createEvent({});
 
-    expect(syntheticEvent.isPersistent()).toBe(false);
-    syntheticEvent.persist();
-    expect(syntheticEvent.isPersistent()).toBe(true);
-  });
+  expect(syntheticEvent.isPersistent()).toBe(false);
+  syntheticEvent.persist();
+  expect(syntheticEvent.isPersistent()).toBe(true);
+});
 
-  it('should be nullified if the synthetic event has called destructor and log warnings', function() {
-    spyOn(console, 'error');
-    var target = document.createElement('div');
-    var syntheticEvent = createEvent({srcElement: target});
-    syntheticEvent.destructor();
-    expect(syntheticEvent.type).toBe(null);
-    expect(syntheticEvent.nativeEvent).toBe(null);
-    expect(syntheticEvent.target).toBe(null);
-    // once for each property accessed
-    expect(console.error.calls.count()).toBe(3);
-    // assert the first warning for accessing `type`
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: This synthetic event is reused for performance reasons. If ' +
-      'you\'re seeing this, you\'re accessing the property `type` on a ' +
-      'released/nullified synthetic event. This is set to null. If you must ' +
-      'keep the original synthetic event around, use event.persist(). ' +
-      'See https://fb.me/react-event-pooling for more information.'
-    );
-  });
+it('should be nullified if the synthetic event has called destructor and log warnings', function() {
+  spyOn(console, 'error');
+  var target = document.createElement('div');
+  var syntheticEvent = createEvent({srcElement: target});
+  syntheticEvent.destructor();
+  expect(syntheticEvent.type).toBe(null);
+  expect(syntheticEvent.nativeEvent).toBe(null);
+  expect(syntheticEvent.target).toBe(null);
+  // once for each property accessed
+  expect(console.error.calls.count()).toBe(3);
+  // assert the first warning for accessing `type`
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: This synthetic event is reused for performance reasons. If ' +
+    'you\'re seeing this, you\'re accessing the property `type` on a ' +
+    'released/nullified synthetic event. This is set to null. If you must ' +
+    'keep the original synthetic event around, use event.persist(). ' +
+    'See https://fb.me/react-event-pooling for more information.'
+  );
+});
 
-  it('should warn when setting properties of a destructored synthetic event', function() {
-    spyOn(console, 'error');
-    var target = document.createElement('div');
-    var syntheticEvent = createEvent({srcElement: target});
-    syntheticEvent.destructor();
-    expect(syntheticEvent.type = 'MouseEvent').toBe('MouseEvent');
+it('should warn when setting properties of a destructored synthetic event', function() {
+  spyOn(console, 'error');
+  var target = document.createElement('div');
+  var syntheticEvent = createEvent({srcElement: target});
+  syntheticEvent.destructor();
+  expect(syntheticEvent.type = 'MouseEvent').toBe('MouseEvent');
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: This synthetic event is reused for performance reasons. If ' +
+    'you\'re seeing this, you\'re setting the property `type` on a ' +
+    'released/nullified synthetic event. This is effectively a no-op. If you must ' +
+    'keep the original synthetic event around, use event.persist(). ' +
+    'See https://fb.me/react-event-pooling for more information.'
+  );
+});
+
+it('should warn if the synthetic event has been released when calling `preventDefault`', function() {
+  spyOn(console, 'error');
+  var syntheticEvent = createEvent({});
+  SyntheticEvent.release(syntheticEvent);
+  syntheticEvent.preventDefault();
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: This synthetic event is reused for performance reasons. If ' +
+    'you\'re seeing this, you\'re accessing the method `preventDefault` on a ' +
+    'released/nullified synthetic event. This is a no-op function. If you must ' +
+    'keep the original synthetic event around, use event.persist(). ' +
+    'See https://fb.me/react-event-pooling for more information.'
+  );
+});
+
+it('should warn if the synthetic event has been released when calling `stopPropagation`', function() {
+  spyOn(console, 'error');
+  var syntheticEvent = createEvent({});
+  SyntheticEvent.release(syntheticEvent);
+  syntheticEvent.stopPropagation();
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: This synthetic event is reused for performance reasons. If ' +
+    'you\'re seeing this, you\'re accessing the method `stopPropagation` on a ' +
+    'released/nullified synthetic event. This is a no-op function. If you must ' +
+    'keep the original synthetic event around, use event.persist(). ' +
+    'See https://fb.me/react-event-pooling for more information.'
+  );
+});
+
+// TODO: reenable this test. We are currently silencing these warnings when
+// using TestUtils.Simulate to avoid spurious warnings that result from the
+// way we simulate events.
+xit('should properly log warnings when events simulated with rendered components', function() {
+  spyOn(console, 'error');
+  var event;
+  var element = document.createElement('div');
+  function assignEvent(e) {
+    event = e;
+  }
+  var instance = ReactDOM.render(<div onClick={assignEvent} />, element);
+  ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(instance));
+  expect(console.error.calls.count()).toBe(0);
+
+  // access a property to cause the warning
+  event.nativeEvent; // eslint-disable-line no-unused-expressions
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: This synthetic event is reused for performance reasons. If ' +
+    'you\'re seeing this, you\'re accessing the property `nativeEvent` on a ' +
+    'released/nullified synthetic event. This is set to null. If you must ' +
+    'keep the original synthetic event around, use event.persist(). ' +
+    'See https://fb.me/react-event-pooling for more information.'
+  );
+});
+
+it('should warn if Proxy is supported and the synthetic event is added a property', function() {
+  spyOn(console, 'error');
+  var syntheticEvent = createEvent({});
+  syntheticEvent.foo = 'bar';
+  SyntheticEvent.release(syntheticEvent);
+  expect(syntheticEvent.foo).toBe('bar');
+  if (typeof Proxy === 'function') {
     expect(console.error.calls.count()).toBe(1);
     expect(console.error.calls.argsFor(0)[0]).toBe(
       'Warning: This synthetic event is reused for performance reasons. If ' +
-      'you\'re seeing this, you\'re setting the property `type` on a ' +
-      'released/nullified synthetic event. This is effectively a no-op. If you must ' +
-      'keep the original synthetic event around, use event.persist(). ' +
+      'you\'re seeing this, you\'re adding a new property in the synthetic ' +
+      'event object. The property is never released. ' +
       'See https://fb.me/react-event-pooling for more information.'
     );
-  });
-
-  it('should warn if the synthetic event has been released when calling `preventDefault`', function() {
-    spyOn(console, 'error');
-    var syntheticEvent = createEvent({});
-    SyntheticEvent.release(syntheticEvent);
-    syntheticEvent.preventDefault();
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: This synthetic event is reused for performance reasons. If ' +
-      'you\'re seeing this, you\'re accessing the method `preventDefault` on a ' +
-      'released/nullified synthetic event. This is a no-op function. If you must ' +
-      'keep the original synthetic event around, use event.persist(). ' +
-      'See https://fb.me/react-event-pooling for more information.'
-    );
-  });
-
-  it('should warn if the synthetic event has been released when calling `stopPropagation`', function() {
-    spyOn(console, 'error');
-    var syntheticEvent = createEvent({});
-    SyntheticEvent.release(syntheticEvent);
-    syntheticEvent.stopPropagation();
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: This synthetic event is reused for performance reasons. If ' +
-      'you\'re seeing this, you\'re accessing the method `stopPropagation` on a ' +
-      'released/nullified synthetic event. This is a no-op function. If you must ' +
-      'keep the original synthetic event around, use event.persist(). ' +
-      'See https://fb.me/react-event-pooling for more information.'
-    );
-  });
-
-  // TODO: reenable this test. We are currently silencing these warnings when
-  // using TestUtils.Simulate to avoid spurious warnings that result from the
-  // way we simulate events.
-  xit('should properly log warnings when events simulated with rendered components', function() {
-    spyOn(console, 'error');
-    var event;
-    var element = document.createElement('div');
-    function assignEvent(e) {
-      event = e;
-    }
-    var instance = ReactDOM.render(<div onClick={assignEvent} />, element);
-    ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(instance));
+  } else {
     expect(console.error.calls.count()).toBe(0);
-
-    // access a property to cause the warning
-    event.nativeEvent; // eslint-disable-line no-unused-expressions
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: This synthetic event is reused for performance reasons. If ' +
-      'you\'re seeing this, you\'re accessing the property `nativeEvent` on a ' +
-      'released/nullified synthetic event. This is set to null. If you must ' +
-      'keep the original synthetic event around, use event.persist(). ' +
-      'See https://fb.me/react-event-pooling for more information.'
-    );
-  });
-
-  it('should warn if Proxy is supported and the synthetic event is added a property', function() {
-    spyOn(console, 'error');
-    var syntheticEvent = createEvent({});
-    syntheticEvent.foo = 'bar';
-    SyntheticEvent.release(syntheticEvent);
-    expect(syntheticEvent.foo).toBe('bar');
-    if (typeof Proxy === 'function') {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: This synthetic event is reused for performance reasons. If ' +
-        'you\'re seeing this, you\'re adding a new property in the synthetic ' +
-        'event object. The property is never released. ' +
-        'See https://fb.me/react-event-pooling for more information.'
-      );
-    } else {
-      expect(console.error.calls.count()).toBe(0);
-    }
-  });
+  }
 });

--- a/src/renderers/dom/client/syntheticEvents/__tests__/SyntheticKeyboardEvent-test.js
+++ b/src/renderers/dom/client/syntheticEvents/__tests__/SyntheticKeyboardEvent-test.js
@@ -14,110 +14,108 @@
 var SyntheticKeyboardEvent;
 var getEventCharCode;
 
-describe('SyntheticKeyboardEvent', function() {
-  var createEvent;
+var createEvent;
 
-  beforeEach(function() {
-    // Mock getEventCharCode for proper unit testing
-    jest.mock('getEventCharCode');
-    getEventCharCode = require('getEventCharCode');
+beforeEach(function() {
+  // Mock getEventCharCode for proper unit testing
+  jest.mock('getEventCharCode');
+  getEventCharCode = require('getEventCharCode');
 
-    SyntheticKeyboardEvent = require('SyntheticKeyboardEvent');
-    createEvent = function(nativeEvent) {
-      var target = require('getEventTarget')(nativeEvent);
-      return SyntheticKeyboardEvent.getPooled({}, '', nativeEvent, target);
-    };
-  });
+  SyntheticKeyboardEvent = require('SyntheticKeyboardEvent');
+  createEvent = function(nativeEvent) {
+    var target = require('getEventTarget')(nativeEvent);
+    return SyntheticKeyboardEvent.getPooled({}, '', nativeEvent, target);
+  };
+});
 
-  describe('KeyboardEvent interface', function() {
-    describe('charCode', function() {
-      describe('when event is `keypress`', function() {
-        it('returns whatever getEventCharCode returns', function() {
-          getEventCharCode.mockReturnValue(100500);
-          var keyboardEvent = createEvent({type: 'keypress', charCode: 50});
+describe('KeyboardEvent interface', function() {
+  describe('charCode', function() {
+    describe('when event is `keypress`', function() {
+      it('returns whatever getEventCharCode returns', function() {
+        getEventCharCode.mockReturnValue(100500);
+        var keyboardEvent = createEvent({type: 'keypress', charCode: 50});
 
-          expect(keyboardEvent.charCode).toBe(100500);
-        });
-      });
-
-      describe('when event is not `keypress`', function() {
-        it('returns 0', function() {
-          var keyboardEvent = createEvent({type: 'keyup', charCode: 50});
-          expect(keyboardEvent.charCode).toBe(0);
-        });
+        expect(keyboardEvent.charCode).toBe(100500);
       });
     });
 
-    describe('keyCode', function() {
-      describe('when event is `keydown` or `keyup`', function() {
-        it('returns a passed keyCode', function() {
-          var keyboardEvent = createEvent({type: 'keyup', keyCode: 40});
-          expect(keyboardEvent.keyCode).toBe(40);
-        });
-      });
-
-      describe('when event is `keypress`', function() {
-        it('returns 0', function() {
-          var keyboardEvent = createEvent({type: 'keypress', charCode: 40});
-          expect(keyboardEvent.keyCode).toBe(0);
-        });
-      });
-    });
-
-    describe('which', function() {
-      describe('when event is `keypress`', function() {
-        it('returns whatever getEventCharCode returns', function() {
-          getEventCharCode.mockReturnValue(9001);
-          var keyboardEvent = createEvent({type: 'keypress', charCode: 50});
-
-          expect(keyboardEvent.which).toBe(9001);
-        });
-      });
-
-      describe('when event is `keydown` or `keyup`', function() {
-        it('returns a passed keyCode', function() {
-          var keyboardEvent = createEvent({type: 'keyup', keyCode: 40});
-          expect(keyboardEvent.which).toBe(40);
-        });
-      });
-
-      describe('when event type is unknown', function() {
-        it('returns 0', function() {
-          var keyboardEvent = createEvent({type: 'keysmack', keyCode: 40});
-          expect(keyboardEvent.which).toBe(0);
-        });
+    describe('when event is not `keypress`', function() {
+      it('returns 0', function() {
+        var keyboardEvent = createEvent({type: 'keyup', charCode: 50});
+        expect(keyboardEvent.charCode).toBe(0);
       });
     });
   });
 
-  describe('EventInterface', function() {
-    it('normalizes properties from the Event interface', function() {
-      var target = document.createElement('div');
-      var syntheticEvent = createEvent({srcElement: target});
-
-      expect(syntheticEvent.target).toBe(target);
-      expect(syntheticEvent.type).toBe(undefined);
+  describe('keyCode', function() {
+    describe('when event is `keydown` or `keyup`', function() {
+      it('returns a passed keyCode', function() {
+        var keyboardEvent = createEvent({type: 'keyup', keyCode: 40});
+        expect(keyboardEvent.keyCode).toBe(40);
+      });
     });
 
-    it('is able to `preventDefault` and `stopPropagation`', function() {
-      var nativeEvent = {};
-      var syntheticEvent = createEvent(nativeEvent);
+    describe('when event is `keypress`', function() {
+      it('returns 0', function() {
+        var keyboardEvent = createEvent({type: 'keypress', charCode: 40});
+        expect(keyboardEvent.keyCode).toBe(0);
+      });
+    });
+  });
 
-      expect(syntheticEvent.isDefaultPrevented()).toBe(false);
-      syntheticEvent.preventDefault();
-      expect(syntheticEvent.isDefaultPrevented()).toBe(true);
+  describe('which', function() {
+    describe('when event is `keypress`', function() {
+      it('returns whatever getEventCharCode returns', function() {
+        getEventCharCode.mockReturnValue(9001);
+        var keyboardEvent = createEvent({type: 'keypress', charCode: 50});
 
-      expect(syntheticEvent.isPropagationStopped()).toBe(false);
-      syntheticEvent.stopPropagation();
-      expect(syntheticEvent.isPropagationStopped()).toBe(true);
+        expect(keyboardEvent.which).toBe(9001);
+      });
     });
 
-    it('is able to `persist`', function() {
-      var syntheticEvent = createEvent({});
-
-      expect(syntheticEvent.isPersistent()).toBe(false);
-      syntheticEvent.persist();
-      expect(syntheticEvent.isPersistent()).toBe(true);
+    describe('when event is `keydown` or `keyup`', function() {
+      it('returns a passed keyCode', function() {
+        var keyboardEvent = createEvent({type: 'keyup', keyCode: 40});
+        expect(keyboardEvent.which).toBe(40);
+      });
     });
+
+    describe('when event type is unknown', function() {
+      it('returns 0', function() {
+        var keyboardEvent = createEvent({type: 'keysmack', keyCode: 40});
+        expect(keyboardEvent.which).toBe(0);
+      });
+    });
+  });
+});
+
+describe('EventInterface', function() {
+  it('normalizes properties from the Event interface', function() {
+    var target = document.createElement('div');
+    var syntheticEvent = createEvent({srcElement: target});
+
+    expect(syntheticEvent.target).toBe(target);
+    expect(syntheticEvent.type).toBe(undefined);
+  });
+
+  it('is able to `preventDefault` and `stopPropagation`', function() {
+    var nativeEvent = {};
+    var syntheticEvent = createEvent(nativeEvent);
+
+    expect(syntheticEvent.isDefaultPrevented()).toBe(false);
+    syntheticEvent.preventDefault();
+    expect(syntheticEvent.isDefaultPrevented()).toBe(true);
+
+    expect(syntheticEvent.isPropagationStopped()).toBe(false);
+    syntheticEvent.stopPropagation();
+    expect(syntheticEvent.isPropagationStopped()).toBe(true);
+  });
+
+  it('is able to `persist`', function() {
+    var syntheticEvent = createEvent({});
+
+    expect(syntheticEvent.isPersistent()).toBe(false);
+    syntheticEvent.persist();
+    expect(syntheticEvent.isPersistent()).toBe(true);
   });
 });

--- a/src/renderers/dom/client/syntheticEvents/__tests__/SyntheticWheelEvent-test.js
+++ b/src/renderers/dom/client/syntheticEvents/__tests__/SyntheticWheelEvent-test.js
@@ -13,59 +13,56 @@
 
 var SyntheticWheelEvent;
 
-describe('SyntheticWheelEvent', function() {
-  var createEvent;
+var createEvent;
 
-  beforeEach(function() {
-    SyntheticWheelEvent = require('SyntheticWheelEvent');
+beforeEach(function() {
+  SyntheticWheelEvent = require('SyntheticWheelEvent');
 
-    createEvent = function(nativeEvent) {
-      var target = require('getEventTarget')(nativeEvent);
-      return SyntheticWheelEvent.getPooled({}, '', nativeEvent, target);
-    };
-  });
+  createEvent = function(nativeEvent) {
+    var target = require('getEventTarget')(nativeEvent);
+    return SyntheticWheelEvent.getPooled({}, '', nativeEvent, target);
+  };
+});
 
-  it('should normalize properties from the Event interface', function() {
-    var target = document.createElement('div');
-    var syntheticEvent = createEvent({srcElement: target});
+it('should normalize properties from the Event interface', function() {
+  var target = document.createElement('div');
+  var syntheticEvent = createEvent({srcElement: target});
 
-    expect(syntheticEvent.target).toBe(target);
-    expect(syntheticEvent.type).toBe(undefined);
-  });
+  expect(syntheticEvent.target).toBe(target);
+  expect(syntheticEvent.type).toBe(undefined);
+});
 
-  it('should normalize properties from the MouseEvent interface', function() {
-    expect(createEvent({which: 2, button: 1}).button).toBe(1);
-  });
+it('should normalize properties from the MouseEvent interface', function() {
+  expect(createEvent({which: 2, button: 1}).button).toBe(1);
+});
 
-  it('should normalize properties from the WheelEvent interface', function() {
-    var standardEvent = createEvent({deltaX: 10, deltaY: -50});
-    expect(standardEvent.deltaX).toBe(10);
-    expect(standardEvent.deltaY).toBe(-50);
+it('should normalize properties from the WheelEvent interface', function() {
+  var standardEvent = createEvent({deltaX: 10, deltaY: -50});
+  expect(standardEvent.deltaX).toBe(10);
+  expect(standardEvent.deltaY).toBe(-50);
 
-    var webkitEvent = createEvent({wheelDeltaX: -10, wheelDeltaY: 50});
-    expect(webkitEvent.deltaX).toBe(10);
-    expect(webkitEvent.deltaY).toBe(-50);
-  });
+  var webkitEvent = createEvent({wheelDeltaX: -10, wheelDeltaY: 50});
+  expect(webkitEvent.deltaX).toBe(10);
+  expect(webkitEvent.deltaY).toBe(-50);
+});
 
-  it('should be able to `preventDefault` and `stopPropagation`', function() {
-    var nativeEvent = {};
-    var syntheticEvent = createEvent(nativeEvent);
+it('should be able to `preventDefault` and `stopPropagation`', function() {
+  var nativeEvent = {};
+  var syntheticEvent = createEvent(nativeEvent);
 
-    expect(syntheticEvent.isDefaultPrevented()).toBe(false);
-    syntheticEvent.preventDefault();
-    expect(syntheticEvent.isDefaultPrevented()).toBe(true);
+  expect(syntheticEvent.isDefaultPrevented()).toBe(false);
+  syntheticEvent.preventDefault();
+  expect(syntheticEvent.isDefaultPrevented()).toBe(true);
 
-    expect(syntheticEvent.isPropagationStopped()).toBe(false);
-    syntheticEvent.stopPropagation();
-    expect(syntheticEvent.isPropagationStopped()).toBe(true);
-  });
+  expect(syntheticEvent.isPropagationStopped()).toBe(false);
+  syntheticEvent.stopPropagation();
+  expect(syntheticEvent.isPropagationStopped()).toBe(true);
+});
 
-  it('should be able to `persist`', function() {
-    var syntheticEvent = createEvent({});
+it('should be able to `persist`', function() {
+  var syntheticEvent = createEvent({});
 
-    expect(syntheticEvent.isPersistent()).toBe(false);
-    syntheticEvent.persist();
-    expect(syntheticEvent.isPersistent()).toBe(true);
-  });
-
+  expect(syntheticEvent.isPersistent()).toBe(false);
+  syntheticEvent.persist();
+  expect(syntheticEvent.isPersistent()).toBe(true);
 });

--- a/src/renderers/dom/client/utils/__tests__/getEventCharCode-test.js
+++ b/src/renderers/dom/client/utils/__tests__/getEventCharCode-test.js
@@ -13,76 +13,74 @@
 
 var getEventCharCode = require('getEventCharCode');
 
-describe('getEventCharCode', function() {
-  describe('when charCode is present in nativeEvent', function() {
-    describe('when charCode is 0 and keyCode is 13', function() {
-      it('returns 13', function() {
-        var nativeEvent = new KeyboardEvent(
-          'keypress', {charCode: 0, keyCode: 13}
-        );
+describe('when charCode is present in nativeEvent', function() {
+  describe('when charCode is 0 and keyCode is 13', function() {
+    it('returns 13', function() {
+      var nativeEvent = new KeyboardEvent(
+        'keypress', {charCode: 0, keyCode: 13}
+      );
 
-        expect(getEventCharCode(nativeEvent)).toBe(13);
-      });
-    });
-
-    describe('when charCode is not 0 and/or keyCode is not 13', function() {
-      describe('when charCode is 32 or bigger', function() {
-        it('returns charCode', function() {
-          var nativeEvent = new KeyboardEvent('keypress', {charCode: 32});
-
-          expect(getEventCharCode(nativeEvent)).toBe(32);
-        });
-      });
-
-      describe('when charCode is smaller than 32', function() {
-        describe('when charCode is 13', function() {
-          it('returns 13', function() {
-            var nativeEvent = new KeyboardEvent('keypress', {charCode: 13});
-
-            expect(getEventCharCode(nativeEvent)).toBe(13);
-          });
-        });
-
-        describe('when charCode is not 13', function() {
-          it('returns 0', function() {
-            var nativeEvent = new KeyboardEvent('keypress', {charCode: 31});
-
-            expect(getEventCharCode(nativeEvent)).toBe(0);
-          });
-        });
-      });
+      expect(getEventCharCode(nativeEvent)).toBe(13);
     });
   });
 
-  /**
-    nativeEvent is represented as a plain object here to ease testing, because
-    KeyboardEvent's 'charCode' event key cannot be deleted to simulate a missing
-    charCode key.
-  */
-  describe('when charCode is not present in nativeEvent', function() {
-    describe('when keyCode is 32 or bigger', function() {
-      it('returns keyCode', function() {
-        var nativeEvent = {'keyCode': 32};
+  describe('when charCode is not 0 and/or keyCode is not 13', function() {
+    describe('when charCode is 32 or bigger', function() {
+      it('returns charCode', function() {
+        var nativeEvent = new KeyboardEvent('keypress', {charCode: 32});
 
         expect(getEventCharCode(nativeEvent)).toBe(32);
       });
     });
 
-    describe('when keyCode is smaller than 32', function() {
-      describe('when keyCode is 13', function() {
+    describe('when charCode is smaller than 32', function() {
+      describe('when charCode is 13', function() {
         it('returns 13', function() {
-          var nativeEvent = {'keyCode': 13};
+          var nativeEvent = new KeyboardEvent('keypress', {charCode: 13});
 
           expect(getEventCharCode(nativeEvent)).toBe(13);
         });
       });
 
-      describe('when keyCode is not 13', function() {
+      describe('when charCode is not 13', function() {
         it('returns 0', function() {
-          var nativeEvent = {'keyCode': 31};
+          var nativeEvent = new KeyboardEvent('keypress', {charCode: 31});
 
           expect(getEventCharCode(nativeEvent)).toBe(0);
         });
+      });
+    });
+  });
+});
+
+/**
+  nativeEvent is represented as a plain object here to ease testing, because
+  KeyboardEvent's 'charCode' event key cannot be deleted to simulate a missing
+  charCode key.
+*/
+describe('when charCode is not present in nativeEvent', function() {
+  describe('when keyCode is 32 or bigger', function() {
+    it('returns keyCode', function() {
+      var nativeEvent = {'keyCode': 32};
+
+      expect(getEventCharCode(nativeEvent)).toBe(32);
+    });
+  });
+
+  describe('when keyCode is smaller than 32', function() {
+    describe('when keyCode is 13', function() {
+      it('returns 13', function() {
+        var nativeEvent = {'keyCode': 13};
+
+        expect(getEventCharCode(nativeEvent)).toBe(13);
+      });
+    });
+
+    describe('when keyCode is not 13', function() {
+      it('returns 0', function() {
+        var nativeEvent = {'keyCode': 31};
+
+        expect(getEventCharCode(nativeEvent)).toBe(0);
       });
     });
   });

--- a/src/renderers/dom/client/utils/__tests__/getEventKey-test.js
+++ b/src/renderers/dom/client/utils/__tests__/getEventKey-test.js
@@ -13,68 +13,66 @@
 
 var getEventKey = require('getEventKey');
 
-describe('getEventKey', function() {
-  describe('when key is implemented in a browser', function() {
-    describe('when key is not normalized', function() {
-      it('returns a normalized value', function() {
-        var nativeEvent = new KeyboardEvent('keypress', {key: 'Del'});
+describe('when key is implemented in a browser', function() {
+  describe('when key is not normalized', function() {
+    it('returns a normalized value', function() {
+      var nativeEvent = new KeyboardEvent('keypress', {key: 'Del'});
 
-        expect(getEventKey(nativeEvent)).toBe('Delete');
+      expect(getEventKey(nativeEvent)).toBe('Delete');
+    });
+  });
+
+  describe('when key is normalized', function() {
+    it('returns a key', function() {
+      var nativeEvent = new KeyboardEvent('keypress', {key: 'f'});
+
+      expect(getEventKey(nativeEvent)).toBe('f');
+    });
+  });
+});
+
+describe('when key is not implemented in a browser', function() {
+  describe('when event type is keypress', function() {
+    describe('when charCode is 13', function() {
+      it("returns 'Enter'", function() {
+        var nativeEvent = new KeyboardEvent('keypress', {charCode: 13});
+
+        expect(getEventKey(nativeEvent)).toBe('Enter');
       });
     });
 
-    describe('when key is normalized', function() {
-      it('returns a key', function() {
-        var nativeEvent = new KeyboardEvent('keypress', {key: 'f'});
+    describe('when charCode is not 13', function() {
+      it('returns a string from a charCode', function() {
+        var nativeEvent = new KeyboardEvent('keypress', {charCode: 65});
 
-        expect(getEventKey(nativeEvent)).toBe('f');
+        expect(getEventKey(nativeEvent)).toBe('A');
       });
     });
   });
 
-  describe('when key is not implemented in a browser', function() {
-    describe('when event type is keypress', function() {
-      describe('when charCode is 13', function() {
-        it("returns 'Enter'", function() {
-          var nativeEvent = new KeyboardEvent('keypress', {charCode: 13});
+  describe('when event type is keydown or keyup', function() {
+    describe('when keyCode is recognized', function() {
+      it('returns a translated key', function() {
+        var nativeEvent = new KeyboardEvent('keydown', {keyCode: 45});
 
-          expect(getEventKey(nativeEvent)).toBe('Enter');
-        });
-      });
-
-      describe('when charCode is not 13', function() {
-        it('returns a string from a charCode', function() {
-          var nativeEvent = new KeyboardEvent('keypress', {charCode: 65});
-
-          expect(getEventKey(nativeEvent)).toBe('A');
-        });
+        expect(getEventKey(nativeEvent)).toBe('Insert');
       });
     });
 
-    describe('when event type is keydown or keyup', function() {
-      describe('when keyCode is recognized', function() {
-        it('returns a translated key', function() {
-          var nativeEvent = new KeyboardEvent('keydown', {keyCode: 45});
+    describe('when keyCode is not recognized', function() {
+      it('returns Unidentified', function() {
+        var nativeEvent = new KeyboardEvent('keydown', {keyCode: 1337});
 
-          expect(getEventKey(nativeEvent)).toBe('Insert');
-        });
-      });
-
-      describe('when keyCode is not recognized', function() {
-        it('returns Unidentified', function() {
-          var nativeEvent = new KeyboardEvent('keydown', {keyCode: 1337});
-
-          expect(getEventKey(nativeEvent)).toBe('Unidentified');
-        });
+        expect(getEventKey(nativeEvent)).toBe('Unidentified');
       });
     });
+  });
 
-    describe('when event type is unknown', function() {
-      it('returns an empty string', function() {
-        var nativeEvent = new KeyboardEvent('keysmack');
+  describe('when event type is unknown', function() {
+    it('returns an empty string', function() {
+      var nativeEvent = new KeyboardEvent('keysmack');
 
-        expect(getEventKey(nativeEvent)).toBe('');
-      });
+      expect(getEventKey(nativeEvent)).toBe('');
     });
   });
 });

--- a/src/renderers/dom/client/utils/__tests__/getNodeForCharacterOffset-test.js
+++ b/src/renderers/dom/client/utils/__tests__/getNodeForCharacterOffset-test.js
@@ -28,47 +28,45 @@ function expectNodeOffset(result, textContent, nodeOffset) {
   expect(result.offset).toBe(nodeOffset);
 }
 
-describe('getNodeForCharacterOffset', function() {
-  it('should handle siblings', function() {
-    var node = createNode('<i>123</i><i>456</i><i>789</i>');
+it('should handle siblings', function() {
+  var node = createNode('<i>123</i><i>456</i><i>789</i>');
 
-    expectNodeOffset(getNodeForCharacterOffset(node, 0), '123', 0);
-    expectNodeOffset(getNodeForCharacterOffset(node, 4), '456', 1);
-  });
+  expectNodeOffset(getNodeForCharacterOffset(node, 0), '123', 0);
+  expectNodeOffset(getNodeForCharacterOffset(node, 4), '456', 1);
+});
 
-  it('should handle trailing chars', function() {
-    var node = createNode('<i>123</i><i>456</i><i>789</i>');
+it('should handle trailing chars', function() {
+  var node = createNode('<i>123</i><i>456</i><i>789</i>');
 
-    expectNodeOffset(getNodeForCharacterOffset(node, 3), '123', 3);
-    expectNodeOffset(getNodeForCharacterOffset(node, 9), '789', 3);
-  });
+  expectNodeOffset(getNodeForCharacterOffset(node, 3), '123', 3);
+  expectNodeOffset(getNodeForCharacterOffset(node, 9), '789', 3);
+});
 
-  it('should handle trees', function() {
-    var node = createNode(
+it('should handle trees', function() {
+  var node = createNode(
+    '<i>' +
+      '<i>1</i>' +
       '<i>' +
-        '<i>1</i>' +
         '<i>' +
-          '<i>' +
-            '<i>2</i>' +
-            '<i></i>' +
-          '</i>' +
+          '<i>2</i>' +
+          '<i></i>' +
         '</i>' +
-        '<i>' +
-          '3' +
-          '<i>45</i>' +
-        '</i>' +
-      '</i>'
-    );
+      '</i>' +
+      '<i>' +
+        '3' +
+        '<i>45</i>' +
+      '</i>' +
+    '</i>'
+  );
 
-    expectNodeOffset(getNodeForCharacterOffset(node, 3), '3', 1);
-    expectNodeOffset(getNodeForCharacterOffset(node, 5), '45', 2);
-    expect(getNodeForCharacterOffset(node, 10)).toBeUndefined();
-  });
+  expectNodeOffset(getNodeForCharacterOffset(node, 3), '3', 1);
+  expectNodeOffset(getNodeForCharacterOffset(node, 5), '45', 2);
+  expect(getNodeForCharacterOffset(node, 10)).toBeUndefined();
+});
 
-  it('should handle non-existent offset', function() {
-    var node = createNode('<i>123</i>');
+it('should handle non-existent offset', function() {
+  var node = createNode('<i>123</i>');
 
-    expect(getNodeForCharacterOffset(node, -1)).toBeUndefined();
-    expect(getNodeForCharacterOffset(node, 4)).toBeUndefined();
-  });
+  expect(getNodeForCharacterOffset(node, -1)).toBeUndefined();
+  expect(getNodeForCharacterOffset(node, 4)).toBeUndefined();
 });

--- a/src/renderers/dom/client/utils/__tests__/setInnerHTML-test.js
+++ b/src/renderers/dom/client/utils/__tests__/setInnerHTML-test.js
@@ -14,31 +14,29 @@
 var setInnerHTML = require('setInnerHTML');
 var DOMNamespaces = require('DOMNamespaces');
 
-describe('setInnerHTML', function() {
-  describe('when the node has innerHTML property', () => {
-    it('sets innerHTML on it', function() {
-      var node = document.createElement('div');
-      var html = '<h1>hello</h1>';
-      setInnerHTML(node, html);
-      expect(node.innerHTML).toBe(html);
-    });
+describe('when the node has innerHTML property', () => {
+  it('sets innerHTML on it', function() {
+    var node = document.createElement('div');
+    var html = '<h1>hello</h1>';
+    setInnerHTML(node, html);
+    expect(node.innerHTML).toBe(html);
   });
+});
 
-  describe('when the node does not have an innerHTML property', () => {
-    // Disabled. JSDOM doesn't seem to remove nodes when using appendChild to
-    // move existing nodes.
-    xit('sets innerHTML on it', function() {
-      // Create a mock node that looks like an SVG in IE (without innerHTML)
-      var node = {
-        namespaceURI: DOMNamespaces.svg,
-        appendChild: jasmine.createSpy(),
-      };
+describe('when the node does not have an innerHTML property', () => {
+  // Disabled. JSDOM doesn't seem to remove nodes when using appendChild to
+  // move existing nodes.
+  xit('sets innerHTML on it', function() {
+    // Create a mock node that looks like an SVG in IE (without innerHTML)
+    var node = {
+      namespaceURI: DOMNamespaces.svg,
+      appendChild: jasmine.createSpy(),
+    };
 
-      var html = '<circle></circle><rect></rect>';
-      setInnerHTML(node, html);
+    var html = '<circle></circle><rect></rect>';
+    setInnerHTML(node, html);
 
-      expect(node.appendChild.calls.argsFor(0)[0].outerHTML).toBe('<circle></circle>');
-      expect(node.appendChild.calls.argsFor(1)[0].outerHTML).toBe('<rect></rect>');
-    });
+    expect(node.appendChild.calls.argsFor(0)[0].outerHTML).toBe('<circle></circle>');
+    expect(node.appendChild.calls.argsFor(1)[0].outerHTML).toBe('<rect></rect>');
   });
 });

--- a/src/renderers/dom/client/wrappers/__tests__/DisabledInputUtil-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/DisabledInputUtil-test.js
@@ -12,97 +12,95 @@
 'use strict';
 
 
-describe('DisabledInputUtils', function() {
-  var React;
-  var ReactDOM;
-  var ReactTestUtils;
+var React;
+var ReactDOM;
+var ReactTestUtils;
 
-  var elements = ['button', 'input', 'select', 'textarea'];
+var elements = ['button', 'input', 'select', 'textarea'];
 
-  function expectClickThru(element) {
-    onClick.mockClear();
-    ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(element));
-    expect(onClick.mock.calls.length).toBe(1);
-  }
+function expectClickThru(element) {
+  onClick.mockClear();
+  ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(element));
+  expect(onClick.mock.calls.length).toBe(1);
+}
 
-  function expectNoClickThru(element) {
-    onClick.mockClear();
-    ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(element));
-    expect(onClick.mock.calls.length).toBe(0);
-  }
+function expectNoClickThru(element) {
+  onClick.mockClear();
+  ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(element));
+  expect(onClick.mock.calls.length).toBe(0);
+}
 
-  function mounted(element) {
-    element = ReactTestUtils.renderIntoDocument(element);
-    return element;
-  }
+function mounted(element) {
+  element = ReactTestUtils.renderIntoDocument(element);
+  return element;
+}
 
-  var onClick = jest.fn();
+var onClick = jest.fn();
 
-  elements.forEach(function(tagName) {
+elements.forEach(function(tagName) {
 
-    describe(tagName, function() {
+  describe(tagName, function() {
 
-      beforeEach(function() {
-        React = require('React');
-        ReactDOM = require('ReactDOM');
-        ReactTestUtils = require('ReactTestUtils');
+    beforeEach(function() {
+      React = require('React');
+      ReactDOM = require('ReactDOM');
+      ReactTestUtils = require('ReactTestUtils');
+    });
+
+    it('should forward clicks when it starts out not disabled', function() {
+      var element = React.createElement(tagName, {
+        onClick: onClick,
       });
 
-      it('should forward clicks when it starts out not disabled', function() {
-        var element = React.createElement(tagName, {
-          onClick: onClick,
-        });
+      expectClickThru(mounted(element));
+    });
 
-        expectClickThru(mounted(element));
+    it('should not forward clicks when it starts out disabled', function() {
+      var element = React.createElement(tagName, {
+        onClick: onClick,
+        disabled: true,
       });
 
-      it('should not forward clicks when it starts out disabled', function() {
-        var element = React.createElement(tagName, {
-          onClick: onClick,
-          disabled: true,
-        });
+      expectNoClickThru(mounted(element));
+    });
 
-        expectNoClickThru(mounted(element));
-      });
+    it('should forward clicks when it becomes not disabled', function() {
+      var container = document.createElement('div');
+      var element = ReactDOM.render(
+        React.createElement(tagName, { onClick: onClick, disabled: true }),
+        container
+      );
+      element = ReactDOM.render(
+        React.createElement(tagName, { onClick: onClick }),
+        container
+      );
+      expectClickThru(element);
+    });
 
-      it('should forward clicks when it becomes not disabled', function() {
-        var container = document.createElement('div');
-        var element = ReactDOM.render(
-          React.createElement(tagName, { onClick: onClick, disabled: true }),
-          container
-        );
-        element = ReactDOM.render(
-          React.createElement(tagName, { onClick: onClick }),
-          container
-        );
-        expectClickThru(element);
-      });
+    it('should not forward clicks when it becomes disabled', function() {
+      var container = document.createElement('div');
+      var element = ReactDOM.render(
+        React.createElement(tagName, { onClick: onClick }),
+        container
+      );
+      element = ReactDOM.render(
+        React.createElement(tagName, { onClick: onClick, disabled: true }),
+        container
+      );
+      expectNoClickThru(element);
+    });
 
-      it('should not forward clicks when it becomes disabled', function() {
-        var container = document.createElement('div');
-        var element = ReactDOM.render(
-          React.createElement(tagName, { onClick: onClick }),
-          container
-        );
-        element = ReactDOM.render(
-          React.createElement(tagName, { onClick: onClick, disabled: true }),
-          container
-        );
-        expectNoClickThru(element);
-      });
-
-      it('should work correctly if the listener is changed', function() {
-        var container = document.createElement('div');
-        var element = ReactDOM.render(
-          React.createElement(tagName, { onClick: onClick, disabled: true }),
-          container
-        );
-        element = ReactDOM.render(
-          React.createElement(tagName, { onClick: onClick, disabled: false }),
-          container
-        );
-        expectClickThru(element);
-      });
+    it('should work correctly if the listener is changed', function() {
+      var container = document.createElement('div');
+      var element = ReactDOM.render(
+        React.createElement(tagName, { onClick: onClick, disabled: true }),
+        container
+      );
+      element = ReactDOM.render(
+        React.createElement(tagName, { onClick: onClick, disabled: false }),
+        container
+      );
+      expectClickThru(element);
     });
   });
 });

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMIframe-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMIframe-test.js
@@ -11,27 +11,25 @@
 
 'use strict';
 
-describe('ReactDOMIframe', function() {
-  var React;
-  var ReactDOM;
-  var ReactTestUtils;
+var React;
+var ReactDOM;
+var ReactTestUtils;
 
-  beforeEach(function() {
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactTestUtils = require('ReactTestUtils');
-  });
+beforeEach(function() {
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactTestUtils = require('ReactTestUtils');
+});
 
-  it('should trigger load events', function() {
-    var onLoadSpy = jasmine.createSpy();
-    var iframe = React.createElement('iframe', {onLoad: onLoadSpy});
-    iframe = ReactTestUtils.renderIntoDocument(iframe);
+it('should trigger load events', function() {
+  var onLoadSpy = jasmine.createSpy();
+  var iframe = React.createElement('iframe', {onLoad: onLoadSpy});
+  iframe = ReactTestUtils.renderIntoDocument(iframe);
 
-    var loadEvent = document.createEvent('Event');
-    loadEvent.initEvent('load', false, false);
+  var loadEvent = document.createEvent('Event');
+  loadEvent.initEvent('load', false, false);
 
-    ReactDOM.findDOMNode(iframe).dispatchEvent(loadEvent);
+  ReactDOM.findDOMNode(iframe).dispatchEvent(loadEvent);
 
-    expect(onLoadSpy).toHaveBeenCalled();
-  });
+  expect(onLoadSpy).toHaveBeenCalled();
 });

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMInput-test.js
@@ -14,915 +14,913 @@
 
 var emptyFunction = require('emptyFunction');
 
-describe('ReactDOMInput', function() {
-  var React;
-  var ReactDOM;
-  var ReactDOMServer;
-  var ReactDOMFeatureFlags;
-  var ReactLink;
-  var ReactTestUtils;
-  var inputValueTracking;
+var React;
+var ReactDOM;
+var ReactDOMServer;
+var ReactDOMFeatureFlags;
+var ReactLink;
+var ReactTestUtils;
+var inputValueTracking;
 
-  function setUntrackedValue(elem, value) {
-    var tracker = inputValueTracking._getTrackerFromNode(elem);
-    var current = tracker.getValue();
-    elem.value = value;
-    tracker.setValue(current);
+function setUntrackedValue(elem, value) {
+  var tracker = inputValueTracking._getTrackerFromNode(elem);
+  var current = tracker.getValue();
+  elem.value = value;
+  tracker.setValue(current);
+}
+
+beforeEach(function() {
+  jest.resetModuleRegistry();
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactDOMServer = require('ReactDOMServer');
+  ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
+  ReactLink = require('ReactLink');
+  ReactTestUtils = require('ReactTestUtils');
+  inputValueTracking = require('inputValueTracking');
+  spyOn(console, 'error');
+});
+
+it('should display `defaultValue` of number 0', function() {
+  var stub = <input type="text" defaultValue={0} />;
+  stub = ReactTestUtils.renderIntoDocument(stub);
+  var node = ReactDOM.findDOMNode(stub);
+
+  expect(node.getAttribute('value')).toBe('0');
+  expect(node.value).toBe('0');
+});
+
+it('should display "true" for `defaultValue` of `true`', function() {
+  var stub = <input type="text" defaultValue={true} />;
+  stub = ReactTestUtils.renderIntoDocument(stub);
+  var node = ReactDOM.findDOMNode(stub);
+
+  expect(node.value).toBe('true');
+});
+
+it('should display "false" for `defaultValue` of `false`', function() {
+  var stub = <input type="text" defaultValue={false} />;
+  stub = ReactTestUtils.renderIntoDocument(stub);
+  var node = ReactDOM.findDOMNode(stub);
+
+  expect(node.value).toBe('false');
+});
+
+it('should update `defaultValue` for uncontrolled input', function() {
+  var container = document.createElement('div');
+
+  var node = ReactDOM.render(<input type="text" defaultValue="0" />, container);
+
+  expect(node.value).toBe('0');
+
+  ReactDOM.render(<input type="text" defaultValue="1" />, container);
+
+  expect(node.value).toBe('0');
+  expect(node.defaultValue).toBe('1');
+});
+
+it('should update `defaultValue` for uncontrolled date/time input', function() {
+  var container = document.createElement('div');
+
+  var node = ReactDOM.render(<input type="date" defaultValue="1980-01-01" />, container);
+
+  expect(node.value).toBe('1980-01-01');
+
+  ReactDOM.render(<input type="date" defaultValue="2000-01-01" />, container);
+
+  expect(node.value).toBe('1980-01-01');
+  expect(node.defaultValue).toBe('2000-01-01');
+
+  ReactDOM.render(<input type="date" />, container);
+});
+
+it('should take `defaultValue` when changing to uncontrolled input', function() {
+  var container = document.createElement('div');
+
+  var node = ReactDOM.render(<input type="text" value="0" readOnly="true" />, container);
+
+  expect(node.value).toBe('0');
+
+  ReactDOM.render(<input type="text" defaultValue="1" />, container);
+
+  expect(node.value).toBe('0');
+});
+
+it('should render defaultValue for SSR', function() {
+  var markup = ReactDOMServer.renderToString(<input type="text" defaultValue="1" />);
+  var div = document.createElement('div');
+  div.innerHTML = markup;
+  expect(div.firstChild.getAttribute('value')).toBe('1');
+  expect(div.firstChild.getAttribute('defaultValue')).toBe(null);
+});
+
+it('should render value for SSR', function() {
+  var element = <input type="text" value="1" onChange={function() {}} />;
+  var markup = ReactDOMServer.renderToString(element);
+  var div = document.createElement('div');
+  div.innerHTML = markup;
+  expect(div.firstChild.getAttribute('value')).toBe('1');
+  expect(div.firstChild.getAttribute('defaultValue')).toBe(null);
+});
+
+it('should render name attribute if it is supplied', function() {
+  var container = document.createElement('div');
+  var node = ReactDOM.render(<input type="text" name="name" />, container);
+  expect(node.name).toBe('name');
+  expect(container.firstChild.getAttribute('name')).toBe('name');
+});
+
+it('should render name attribute if it is supplied for SSR', function() {
+  var element = <input type="text" name="name" />;
+  var markup = ReactDOMServer.renderToString(element);
+  var div = document.createElement('div');
+  div.innerHTML = markup;
+  expect(div.firstChild.getAttribute('name')).toBe('name');
+});
+
+it('should not render name attribute if it is not supplied', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(<input type="text" />, container);
+  expect(container.firstChild.getAttribute('name')).toBe(null);
+});
+
+it('should not render name attribute if it is not supplied for SSR', function() {
+  var element = <input type="text" />;
+  var markup = ReactDOMServer.renderToString(element);
+  var div = document.createElement('div');
+  div.innerHTML = markup;
+  expect(div.firstChild.getAttribute('name')).toBe(null);
+});
+
+it('should display "foobar" for `defaultValue` of `objToString`', function() {
+  var objToString = {
+    toString: function() {
+      return 'foobar';
+    },
+  };
+
+  var stub = <input type="text" defaultValue={objToString} />;
+  stub = ReactTestUtils.renderIntoDocument(stub);
+  var node = ReactDOM.findDOMNode(stub);
+
+  expect(node.value).toBe('foobar');
+});
+
+it('should display `value` of number 0', function() {
+  var stub = <input type="text" value={0} />;
+  stub = ReactTestUtils.renderIntoDocument(stub);
+  var node = ReactDOM.findDOMNode(stub);
+
+  expect(node.value).toBe('0');
+});
+
+it('should allow setting `value` to `true`', function() {
+  var container = document.createElement('div');
+  var stub = <input type="text" value="yolo" onChange={emptyFunction} />;
+  var node = ReactDOM.render(stub, container);
+
+  expect(node.value).toBe('yolo');
+
+  stub = ReactDOM.render(
+    <input type="text" value={true} onChange={emptyFunction} />,
+    container
+  );
+  expect(node.value).toEqual('true');
+});
+
+it('should allow setting `value` to `false`', function() {
+  var container = document.createElement('div');
+  var stub = <input type="text" value="yolo" onChange={emptyFunction} />;
+  var node = ReactDOM.render(stub, container);
+
+  expect(node.value).toBe('yolo');
+
+  stub = ReactDOM.render(
+    <input type="text" value={false} onChange={emptyFunction} />,
+    container
+  );
+  expect(node.value).toEqual('false');
+});
+
+it('should allow setting `value` to `objToString`', function() {
+  var container = document.createElement('div');
+  var stub = <input type="text" value="foo" onChange={emptyFunction} />;
+  var node = ReactDOM.render(stub, container);
+
+  expect(node.value).toBe('foo');
+
+  var objToString = {
+    toString: function() {
+      return 'foobar';
+    },
+  };
+  stub = ReactDOM.render(
+    <input type="text" value={objToString} onChange={emptyFunction} />,
+    container
+  );
+  expect(node.value).toEqual('foobar');
+});
+
+it('should not incur unnecessary DOM mutations', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(<input value="a" />, container);
+
+  var node = container.firstChild;
+  var nodeValue = 'a';
+  var nodeValueSetter = jest.genMockFn();
+  Object.defineProperty(node, 'value', {
+    get: function() {
+      return nodeValue;
+    },
+    set: nodeValueSetter.mockImplementation(function(newValue) {
+      nodeValue = newValue;
+    }),
+  });
+
+  ReactDOM.render(<input value="a" />, container);
+  expect(nodeValueSetter.mock.calls.length).toBe(0);
+
+  ReactDOM.render(<input value="b"/>, container);
+  expect(nodeValueSetter.mock.calls.length).toBe(1);
+});
+
+it('should properly control a value of number `0`', function() {
+  var stub = <input type="text" value={0} onChange={emptyFunction} />;
+  stub = ReactTestUtils.renderIntoDocument(stub);
+  var node = ReactDOM.findDOMNode(stub);
+
+  node.value = 'giraffe';
+  ReactTestUtils.Simulate.change(node);
+  expect(node.value).toBe('0');
+});
+
+it('should have the correct target value', function() {
+  var handled = false;
+  var handler = function(event) {
+    expect(event.target.nodeName).toBe('INPUT');
+    handled = true;
+  };
+  var stub = <input type="text" value={0} onChange={handler} />;
+  var container = document.createElement('div');
+  var node = ReactDOM.render(stub, container);
+
+  setUntrackedValue(node, 'giraffe');
+
+  var fakeNativeEvent = new function() {};
+  fakeNativeEvent.target = node;
+  fakeNativeEvent.path = [node, container];
+  ReactTestUtils.simulateNativeEventOnNode(
+    'topInput',
+    node,
+    fakeNativeEvent
+  );
+
+  expect(handled).toBe(true);
+});
+
+it('should not set a value for submit buttons unnecessarily', function() {
+  var stub = <input type="submit" />;
+  stub = ReactTestUtils.renderIntoDocument(stub);
+  var node = ReactDOM.findDOMNode(stub);
+
+  // The value shouldn't be '', or else the button will have no text; it
+  // should have the default "Submit" or "Submit Query" label. Most browsers
+  // report this as not having a `value` attribute at all; IE reports it as
+  // the actual label that the user sees.
+  expect(
+    !node.hasAttribute('value') || node.getAttribute('value').length > 0
+  ).toBe(true);
+});
+
+it('should control radio buttons', function() {
+  class RadioGroup extends React.Component {
+    render() {
+      return (
+        <div>
+          <input
+            ref="a"
+            type="radio"
+            name="fruit"
+            checked={true}
+            onChange={emptyFunction}
+          />A
+          <input
+            ref="b"
+            type="radio"
+            name="fruit"
+            onChange={emptyFunction}
+          />B
+
+          <form>
+            <input
+              ref="c"
+              type="radio"
+              name="fruit"
+              defaultChecked={true}
+              onChange={emptyFunction}
+            />
+          </form>
+        </div>
+      );
+    }
   }
 
-  beforeEach(function() {
-    jest.resetModuleRegistry();
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactDOMServer = require('ReactDOMServer');
-    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
-    ReactLink = require('ReactLink');
-    ReactTestUtils = require('ReactTestUtils');
-    inputValueTracking = require('inputValueTracking');
-    spyOn(console, 'error');
-  });
+  var stub = ReactTestUtils.renderIntoDocument(<RadioGroup />);
+  var aNode = ReactDOM.findDOMNode(stub.refs.a);
+  var bNode = ReactDOM.findDOMNode(stub.refs.b);
+  var cNode = ReactDOM.findDOMNode(stub.refs.c);
 
-  it('should display `defaultValue` of number 0', function() {
-    var stub = <input type="text" defaultValue={0} />;
-    stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
+  expect(aNode.checked).toBe(true);
+  expect(bNode.checked).toBe(false);
+  // c is in a separate form and shouldn't be affected at all here
+  expect(cNode.checked).toBe(true);
 
-    expect(node.getAttribute('value')).toBe('0');
-    expect(node.value).toBe('0');
-  });
+  bNode.checked = true;
+  // This next line isn't necessary in a proper browser environment, but
+  // jsdom doesn't uncheck the others in a group (which makes this whole test
+  // a little less effective)
+  aNode.checked = false;
+  expect(cNode.checked).toBe(true);
 
-  it('should display "true" for `defaultValue` of `true`', function() {
-    var stub = <input type="text" defaultValue={true} />;
-    stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
+  // Now let's run the actual ReactDOMInput change event handler
+  ReactTestUtils.Simulate.change(bNode);
 
-    expect(node.value).toBe('true');
-  });
+  // The original state should have been restored
+  expect(aNode.checked).toBe(true);
+  expect(cNode.checked).toBe(true);
+});
 
-  it('should display "false" for `defaultValue` of `false`', function() {
-    var stub = <input type="text" defaultValue={false} />;
-    stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
+it('should support ReactLink', function() {
+  var link = new ReactLink('yolo', jest.fn());
+  var instance = <input type="text" valueLink={link} />;
 
-    expect(node.value).toBe('false');
-  });
+  instance = ReactTestUtils.renderIntoDocument(instance);
 
-  it('should update `defaultValue` for uncontrolled input', function() {
-    var container = document.createElement('div');
+  expect(ReactDOM.findDOMNode(instance).value).toBe('yolo');
+  expect(link.value).toBe('yolo');
+  expect(link.requestChange.mock.calls.length).toBe(0);
 
-    var node = ReactDOM.render(<input type="text" defaultValue="0" />, container);
+  ReactDOM.findDOMNode(instance).value = 'test';
+  ReactTestUtils.Simulate.change(ReactDOM.findDOMNode(instance));
 
-    expect(node.value).toBe('0');
+  expect(link.requestChange.mock.calls.length).toBe(1);
+  expect(link.requestChange.mock.calls[0][0]).toEqual('test');
+});
 
-    ReactDOM.render(<input type="text" defaultValue="1" />, container);
+it('should warn with value and no onChange handler', function() {
+  var link = new ReactLink('yolo', jest.fn());
+  ReactTestUtils.renderIntoDocument(<input type="text" valueLink={link} />);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    '`valueLink` prop on `input` is deprecated; set `value` and `onChange` instead.'
+  );
 
-    expect(node.value).toBe('0');
-    expect(node.defaultValue).toBe('1');
-  });
+  ReactTestUtils.renderIntoDocument(
+    <input type="text" value="zoink" onChange={jest.fn()} />
+  );
+  expect(console.error.calls.count()).toBe(1);
+  ReactTestUtils.renderIntoDocument(<input type="text" value="zoink" />);
+  expect(console.error.calls.count()).toBe(2);
+});
 
-  it('should update `defaultValue` for uncontrolled date/time input', function() {
-    var container = document.createElement('div');
+it('should warn with value and no onChange handler and readOnly specified', function() {
+  ReactTestUtils.renderIntoDocument(
+    <input type="text" value="zoink" readOnly={true} />
+  );
+  expect(console.error.calls.count()).toBe(0);
 
-    var node = ReactDOM.render(<input type="date" defaultValue="1980-01-01" />, container);
+  ReactTestUtils.renderIntoDocument(
+    <input type="text" value="zoink" readOnly={false} />
+  );
+  expect(console.error.calls.count()).toBe(1);
+});
 
-    expect(node.value).toBe('1980-01-01');
+it('should have a this value of undefined if bind is not used', function() {
+  var unboundInputOnChange = function() {
+    expect(this).toBe(undefined);
+  };
 
-    ReactDOM.render(<input type="date" defaultValue="2000-01-01" />, container);
+  var instance = <input type="text" onChange={unboundInputOnChange} />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
 
-    expect(node.value).toBe('1980-01-01');
-    expect(node.defaultValue).toBe('2000-01-01');
+  ReactTestUtils.Simulate.change(instance);
+});
 
-    ReactDOM.render(<input type="date" />, container);
-  });
+it('should throw if both value and valueLink are provided', function() {
+  var node = document.createElement('div');
+  var link = new ReactLink('yolo', jest.fn());
+  var instance = <input type="text" valueLink={link} />;
 
-  it('should take `defaultValue` when changing to uncontrolled input', function() {
-    var container = document.createElement('div');
+  expect(() => ReactDOM.render(instance, node)).not.toThrow();
 
-    var node = ReactDOM.render(<input type="text" value="0" readOnly="true" />, container);
+  instance =
+    <input
+      type="text"
+      valueLink={link}
+      value="test"
+      onChange={emptyFunction}
+    />;
+  expect(() => ReactDOM.render(instance, node)).toThrow();
 
-    expect(node.value).toBe('0');
+  instance = <input type="text" valueLink={link} onChange={emptyFunction} />;
+  expect(() => ReactDOM.render(instance, node)).toThrow();
 
-    ReactDOM.render(<input type="text" defaultValue="1" />, container);
+});
 
-    expect(node.value).toBe('0');
-  });
+it('should support checkedLink', function() {
+  var link = new ReactLink(true, jest.fn());
+  var instance = <input type="checkbox" checkedLink={link} />;
 
-  it('should render defaultValue for SSR', function() {
-    var markup = ReactDOMServer.renderToString(<input type="text" defaultValue="1" />);
-    var div = document.createElement('div');
-    div.innerHTML = markup;
-    expect(div.firstChild.getAttribute('value')).toBe('1');
-    expect(div.firstChild.getAttribute('defaultValue')).toBe(null);
-  });
+  instance = ReactTestUtils.renderIntoDocument(instance);
 
-  it('should render value for SSR', function() {
-    var element = <input type="text" value="1" onChange={function() {}} />;
-    var markup = ReactDOMServer.renderToString(element);
-    var div = document.createElement('div');
-    div.innerHTML = markup;
-    expect(div.firstChild.getAttribute('value')).toBe('1');
-    expect(div.firstChild.getAttribute('defaultValue')).toBe(null);
-  });
+  expect(ReactDOM.findDOMNode(instance).checked).toBe(true);
+  expect(link.value).toBe(true);
+  expect(link.requestChange.mock.calls.length).toBe(0);
 
-  it('should render name attribute if it is supplied', function() {
-    var container = document.createElement('div');
-    var node = ReactDOM.render(<input type="text" name="name" />, container);
-    expect(node.name).toBe('name');
-    expect(container.firstChild.getAttribute('name')).toBe('name');
-  });
+  ReactDOM.findDOMNode(instance).checked = false;
+  ReactTestUtils.Simulate.change(ReactDOM.findDOMNode(instance));
 
-  it('should render name attribute if it is supplied for SSR', function() {
-    var element = <input type="text" name="name" />;
-    var markup = ReactDOMServer.renderToString(element);
-    var div = document.createElement('div');
-    div.innerHTML = markup;
-    expect(div.firstChild.getAttribute('name')).toBe('name');
-  });
+  expect(link.requestChange.mock.calls.length).toBe(1);
+  expect(link.requestChange.mock.calls[0][0]).toEqual(false);
+});
 
-  it('should not render name attribute if it is not supplied', function() {
-    var container = document.createElement('div');
-    ReactDOM.render(<input type="text" />, container);
-    expect(container.firstChild.getAttribute('name')).toBe(null);
-  });
+it('should warn with checked and no onChange handler', function() {
+  var node = document.createElement('div');
+  var link = new ReactLink(true, jest.fn());
+  ReactDOM.render(<input type="checkbox" checkedLink={link} />, node);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    '`checkedLink` prop on `input` is deprecated; set `value` and `onChange` instead.'
+  );
 
-  it('should not render name attribute if it is not supplied for SSR', function() {
-    var element = <input type="text" />;
-    var markup = ReactDOMServer.renderToString(element);
-    var div = document.createElement('div');
-    div.innerHTML = markup;
-    expect(div.firstChild.getAttribute('name')).toBe(null);
-  });
+  ReactTestUtils.renderIntoDocument(
+    <input
+      type="checkbox"
+      checked="false"
+      onChange={jest.fn()}
+    />
+  );
+  expect(console.error.calls.count()).toBe(1);
 
-  it('should display "foobar" for `defaultValue` of `objToString`', function() {
-    var objToString = {
-      toString: function() {
-        return 'foobar';
-      },
-    };
+  ReactTestUtils.renderIntoDocument(
+    <input type="checkbox" checked="false" readOnly={true} />
+  );
+  expect(console.error.calls.count()).toBe(1);
 
-    var stub = <input type="text" defaultValue={objToString} />;
-    stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
+  ReactTestUtils.renderIntoDocument(<input type="checkbox" checked="false" />);
+  expect(console.error.calls.count()).toBe(2);
+});
 
-    expect(node.value).toBe('foobar');
-  });
+it('should warn with checked and no onChange handler with readOnly specified', function() {
+  ReactTestUtils.renderIntoDocument(
+    <input type="checkbox" checked="false" readOnly={true} />
+  );
+  expect(console.error.calls.count()).toBe(0);
 
-  it('should display `value` of number 0', function() {
-    var stub = <input type="text" value={0} />;
-    stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
+  ReactTestUtils.renderIntoDocument(
+    <input type="checkbox" checked="false" readOnly={false} />
+  );
+  expect(console.error.calls.count()).toBe(1);
+});
 
-    expect(node.value).toBe('0');
-  });
+it('should throw if both checked and checkedLink are provided', function() {
+  var node = document.createElement('div');
+  var link = new ReactLink(true, jest.fn());
+  var instance = <input type="checkbox" checkedLink={link} />;
 
-  it('should allow setting `value` to `true`', function() {
-    var container = document.createElement('div');
-    var stub = <input type="text" value="yolo" onChange={emptyFunction} />;
-    var node = ReactDOM.render(stub, container);
+  expect(() => ReactDOM.render(instance, node)).not.toThrow();
 
-    expect(node.value).toBe('yolo');
+  instance =
+    <input
+      type="checkbox"
+      checkedLink={link}
+      checked="false"
+      onChange={emptyFunction}
+    />;
+  expect(() => ReactDOM.render(instance, node)).toThrow();
 
-    stub = ReactDOM.render(
-      <input type="text" value={true} onChange={emptyFunction} />,
-      container
-    );
-    expect(node.value).toEqual('true');
-  });
+  instance =
+    <input type="checkbox" checkedLink={link} onChange={emptyFunction} />;
+  expect(() => ReactDOM.render(instance, node)).toThrow();
 
-  it('should allow setting `value` to `false`', function() {
-    var container = document.createElement('div');
-    var stub = <input type="text" value="yolo" onChange={emptyFunction} />;
-    var node = ReactDOM.render(stub, container);
+});
 
-    expect(node.value).toBe('yolo');
+it('should update defaultValue to empty string', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(<input type="text" defaultValue={'foo'} />, container);
+  ReactDOM.render(<input type="text" defaultValue={''} />, container);
+  expect(container.firstChild.defaultValue).toBe('');
+});
 
-    stub = ReactDOM.render(
-      <input type="text" value={false} onChange={emptyFunction} />,
-      container
-    );
-    expect(node.value).toEqual('false');
-  });
+it('should throw if both checkedLink and valueLink are provided', function() {
+  var node = document.createElement('div');
+  var link = new ReactLink(true, jest.fn());
+  var instance = <input type="checkbox" checkedLink={link} />;
 
-  it('should allow setting `value` to `objToString`', function() {
-    var container = document.createElement('div');
-    var stub = <input type="text" value="foo" onChange={emptyFunction} />;
-    var node = ReactDOM.render(stub, container);
+  expect(() => ReactDOM.render(instance, node)).not.toThrow();
 
-    expect(node.value).toBe('foo');
+  instance = <input type="checkbox" valueLink={link} />;
+  expect(() => ReactDOM.render(instance, node)).not.toThrow();
 
-    var objToString = {
-      toString: function() {
-        return 'foobar';
-      },
-    };
-    stub = ReactDOM.render(
-      <input type="text" value={objToString} onChange={emptyFunction} />,
-      container
-    );
-    expect(node.value).toEqual('foobar');
-  });
+  instance =
+    <input type="checkbox" checkedLink={link} valueLink={emptyFunction} />;
+  expect(() => ReactDOM.render(instance, node)).toThrow();
+});
 
-  it('should not incur unnecessary DOM mutations', function() {
-    var container = document.createElement('div');
-    ReactDOM.render(<input value="a" />, container);
+it('should warn if value is null', function() {
+  ReactTestUtils.renderIntoDocument(<input type="text" value={null} />);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    '`value` prop on `input` should not be null. ' +
+    'Consider using the empty string to clear the component or `undefined` ' +
+    'for uncontrolled components.'
+  );
 
-    var node = container.firstChild;
-    var nodeValue = 'a';
-    var nodeValueSetter = jest.genMockFn();
-    Object.defineProperty(node, 'value', {
-      get: function() {
-        return nodeValue;
-      },
-      set: nodeValueSetter.mockImplementation(function(newValue) {
-        nodeValue = newValue;
-      }),
-    });
+  ReactTestUtils.renderIntoDocument(<input type="text" value={null} />);
+  expect(console.error.calls.count()).toBe(1);
+});
 
-    ReactDOM.render(<input value="a" />, container);
-    expect(nodeValueSetter.mock.calls.length).toBe(0);
+it('should warn if checked and defaultChecked props are specified', function() {
+  ReactTestUtils.renderIntoDocument(
+    <input type="radio" checked={true} defaultChecked={true} readOnly={true} />
+  );
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'A component contains an input of type radio with both checked and defaultChecked props. ' +
+    'Input elements must be either controlled or uncontrolled ' +
+    '(specify either the checked prop, or the defaultChecked prop, but not ' +
+    'both). Decide between using a controlled or uncontrolled input ' +
+    'element and remove one of these props. More info: ' +
+    'https://fb.me/react-controlled-components'
+  );
 
-    ReactDOM.render(<input value="b"/>, container);
-    expect(nodeValueSetter.mock.calls.length).toBe(1);
-  });
+  ReactTestUtils.renderIntoDocument(
+    <input type="radio" checked={true} defaultChecked={true} readOnly={true} />
+  );
+  expect(console.error.calls.count()).toBe(1);
+});
 
-  it('should properly control a value of number `0`', function() {
-    var stub = <input type="text" value={0} onChange={emptyFunction} />;
-    stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
+it('should warn if value and defaultValue props are specified', function() {
+  ReactTestUtils.renderIntoDocument(
+    <input type="text" value="foo" defaultValue="bar" readOnly={true} />
+  );
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'A component contains an input of type text with both value and defaultValue props. ' +
+    'Input elements must be either controlled or uncontrolled ' +
+    '(specify either the value prop, or the defaultValue prop, but not ' +
+    'both). Decide between using a controlled or uncontrolled input ' +
+    'element and remove one of these props. More info: ' +
+    'https://fb.me/react-controlled-components'
+  );
 
-    node.value = 'giraffe';
-    ReactTestUtils.Simulate.change(node);
-    expect(node.value).toBe('0');
-  });
+  ReactTestUtils.renderIntoDocument(
+    <input type="text" value="foo" defaultValue="bar" readOnly={true} />
+  );
+  expect(console.error.calls.count()).toBe(1);
+});
 
-  it('should have the correct target value', function() {
-    var handled = false;
-    var handler = function(event) {
-      expect(event.target.nodeName).toBe('INPUT');
-      handled = true;
-    };
-    var stub = <input type="text" value={0} onChange={handler} />;
-    var container = document.createElement('div');
-    var node = ReactDOM.render(stub, container);
+it('should warn if controlled input switches to uncontrolled (value is undefined)', function() {
+  var stub = <input type="text" value="controlled" onChange={emptyFunction} />;
+  var container = document.createElement('div');
+  ReactDOM.render(stub, container);
+  ReactDOM.render(<input type="text" />, container);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'A component is changing a controlled input of type text to be uncontrolled. ' +
+    'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
+    'Decide between using a controlled or uncontrolled input ' +
+    'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
+  );
+});
 
-    setUntrackedValue(node, 'giraffe');
+it('should warn if controlled input switches to uncontrolled (value is null)', function() {
+  var stub = <input type="text" value="controlled" onChange={emptyFunction} />;
+  var container = document.createElement('div');
+  ReactDOM.render(stub, container);
+  ReactDOM.render(<input type="text" value={null} />, container);
+  expect(console.error.calls.count()).toBeGreaterThan(0);
+  expect(console.error.calls.argsFor(1)[0]).toContain(
+    'A component is changing a controlled input of type text to be uncontrolled. ' +
+    'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
+    'Decide between using a controlled or uncontrolled input ' +
+    'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
+  );
+});
 
-    var fakeNativeEvent = new function() {};
-    fakeNativeEvent.target = node;
-    fakeNativeEvent.path = [node, container];
-    ReactTestUtils.simulateNativeEventOnNode(
-      'topInput',
-      node,
-      fakeNativeEvent
-    );
+it('should warn if controlled input switches to uncontrolled with defaultValue', function() {
+  var stub = <input type="text" value="controlled" onChange={emptyFunction} />;
+  var container = document.createElement('div');
+  ReactDOM.render(stub, container);
+  ReactDOM.render(<input type="text" defaultValue="uncontrolled" />, container);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'A component is changing a controlled input of type text to be uncontrolled. ' +
+    'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
+    'Decide between using a controlled or uncontrolled input ' +
+    'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
+  );
+});
 
-    expect(handled).toBe(true);
-  });
+it('should warn if uncontrolled input (value is undefined) switches to controlled', function() {
+  var stub = <input type="text" />;
+  var container = document.createElement('div');
+  ReactDOM.render(stub, container);
+  ReactDOM.render(<input type="text" value="controlled" />, container);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'A component is changing an uncontrolled input of type text to be controlled. ' +
+    'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
+    'Decide between using a controlled or uncontrolled input ' +
+    'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
+  );
+});
 
-  it('should not set a value for submit buttons unnecessarily', function() {
-    var stub = <input type="submit" />;
-    stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
+it('should warn if uncontrolled input (value is null) switches to controlled', function() {
+  var stub = <input type="text" value={null} />;
+  var container = document.createElement('div');
+  ReactDOM.render(stub, container);
+  ReactDOM.render(<input type="text" value="controlled" />, container);
+  expect(console.error.calls.count()).toBeGreaterThan(0);
+  expect(console.error.calls.argsFor(1)[0]).toContain(
+    'A component is changing an uncontrolled input of type text to be controlled. ' +
+    'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
+    'Decide between using a controlled or uncontrolled input ' +
+    'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
+  );
+});
 
-    // The value shouldn't be '', or else the button will have no text; it
-    // should have the default "Submit" or "Submit Query" label. Most browsers
-    // report this as not having a `value` attribute at all; IE reports it as
-    // the actual label that the user sees.
-    expect(
-      !node.hasAttribute('value') || node.getAttribute('value').length > 0
-    ).toBe(true);
-  });
+it('should warn if controlled checkbox switches to uncontrolled (checked is undefined)', function() {
+  var stub = <input type="checkbox" checked={true} onChange={emptyFunction} />;
+  var container = document.createElement('div');
+  ReactDOM.render(stub, container);
+  ReactDOM.render(<input type="checkbox" />, container);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'A component is changing a controlled input of type checkbox to be uncontrolled. ' +
+    'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
+    'Decide between using a controlled or uncontrolled input ' +
+    'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
+  );
+});
 
-  it('should control radio buttons', function() {
-    class RadioGroup extends React.Component {
-      render() {
-        return (
-          <div>
-            <input
-              ref="a"
-              type="radio"
-              name="fruit"
-              checked={true}
-              onChange={emptyFunction}
-            />A
-            <input
-              ref="b"
-              type="radio"
-              name="fruit"
-              onChange={emptyFunction}
-            />B
+it('should warn if controlled checkbox switches to uncontrolled (checked is null)', function() {
+  var stub = <input type="checkbox" checked={true} onChange={emptyFunction} />;
+  var container = document.createElement('div');
+  ReactDOM.render(stub, container);
+  ReactDOM.render(<input type="checkbox" checked={null} />, container);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'A component is changing a controlled input of type checkbox to be uncontrolled. ' +
+    'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
+    'Decide between using a controlled or uncontrolled input ' +
+    'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
+  );
+});
 
-            <form>
-              <input
-                ref="c"
-                type="radio"
-                name="fruit"
-                defaultChecked={true}
-                onChange={emptyFunction}
-              />
-            </form>
-          </div>
-        );
-      }
+it('should warn if controlled checkbox switches to uncontrolled with defaultChecked', function() {
+  var stub = <input type="checkbox" checked={true} onChange={emptyFunction} />;
+  var container = document.createElement('div');
+  ReactDOM.render(stub, container);
+  ReactDOM.render(<input type="checkbox" defaultChecked={true} />, container);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'A component is changing a controlled input of type checkbox to be uncontrolled. ' +
+    'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
+    'Decide between using a controlled or uncontrolled input ' +
+    'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
+  );
+});
+
+it('should warn if uncontrolled checkbox (checked is undefined) switches to controlled', function() {
+  var stub = <input type="checkbox" />;
+  var container = document.createElement('div');
+  ReactDOM.render(stub, container);
+  ReactDOM.render(<input type="checkbox" checked={true} />, container);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'A component is changing an uncontrolled input of type checkbox to be controlled. ' +
+    'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
+    'Decide between using a controlled or uncontrolled input ' +
+    'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
+  );
+});
+
+it('should warn if uncontrolled checkbox (checked is null) switches to controlled', function() {
+  var stub = <input type="checkbox" checked={null} />;
+  var container = document.createElement('div');
+  ReactDOM.render(stub, container);
+  ReactDOM.render(<input type="checkbox" checked={true} />, container);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'A component is changing an uncontrolled input of type checkbox to be controlled. ' +
+    'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
+    'Decide between using a controlled or uncontrolled input ' +
+    'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
+  );
+});
+
+it('should warn if controlled radio switches to uncontrolled (checked is undefined)', function() {
+  var stub = <input type="radio" checked={true} onChange={emptyFunction} />;
+  var container = document.createElement('div');
+  ReactDOM.render(stub, container);
+  ReactDOM.render(<input type="radio" />, container);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'A component is changing a controlled input of type radio to be uncontrolled. ' +
+    'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
+    'Decide between using a controlled or uncontrolled input ' +
+    'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
+  );
+});
+
+it('should warn if controlled radio switches to uncontrolled (checked is null)', function() {
+  var stub = <input type="radio" checked={true} onChange={emptyFunction} />;
+  var container = document.createElement('div');
+  ReactDOM.render(stub, container);
+  ReactDOM.render(<input type="radio" checked={null} />, container);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'A component is changing a controlled input of type radio to be uncontrolled. ' +
+    'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
+    'Decide between using a controlled or uncontrolled input ' +
+    'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
+  );
+});
+
+it('should warn if controlled radio switches to uncontrolled with defaultChecked', function() {
+  var stub = <input type="radio" checked={true} onChange={emptyFunction} />;
+  var container = document.createElement('div');
+  ReactDOM.render(stub, container);
+  ReactDOM.render(<input type="radio" defaultChecked={true} />, container);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'A component is changing a controlled input of type radio to be uncontrolled. ' +
+    'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
+    'Decide between using a controlled or uncontrolled input ' +
+    'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
+  );
+});
+
+it('should warn if uncontrolled radio (checked is undefined) switches to controlled', function() {
+  var stub = <input type="radio" />;
+  var container = document.createElement('div');
+  ReactDOM.render(stub, container);
+  ReactDOM.render(<input type="radio" checked={true} />, container);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'A component is changing an uncontrolled input of type radio to be controlled. ' +
+    'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
+    'Decide between using a controlled or uncontrolled input ' +
+    'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
+  );
+});
+
+it('should warn if uncontrolled radio (checked is null) switches to controlled', function() {
+  var stub = <input type="radio" checked={null} />;
+  var container = document.createElement('div');
+  ReactDOM.render(stub, container);
+  ReactDOM.render(<input type="radio" checked={true} />, container);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'A component is changing an uncontrolled input of type radio to be controlled. ' +
+    'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
+    'Decide between using a controlled or uncontrolled input ' +
+    'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
+  );
+});
+
+it('should not warn if radio value changes but never becomes controlled', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(<input type="radio" value="value" />, container);
+  ReactDOM.render(<input type="radio" />, container);
+  ReactDOM.render(<input type="radio" value="value" defaultChecked={true} />, container);
+  ReactDOM.render(<input type="radio" value="value" onChange={() => null} />, container);
+  ReactDOM.render(<input type="radio" />, container);
+  expect(console.error.calls.count()).toBe(0);
+});
+
+it('should not warn if radio value changes but never becomes uncontrolled', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(<input type="radio" checked={false} onChange={() => null} />, container);
+  ReactDOM.render(
+    <input
+      type="radio"
+      value="value"
+      defaultChecked={true}
+      checked={false}
+      onChange={() => null}
+    />, container);
+  expect(console.error.calls.count()).toBe(0);
+});
+
+it('should warn if radio checked false changes to become uncontrolled', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(<input type="radio" value="value" checked={false} onChange={() => null} />, container);
+  ReactDOM.render(<input type="radio" value="value" />, container);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'A component is changing a controlled input of type radio to be uncontrolled. ' +
+    'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
+    'Decide between using a controlled or uncontrolled input ' +
+    'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
+  );
+});
+
+it('sets type, step, min, max before value always', function() {
+  if (!ReactDOMFeatureFlags.useCreateElement) {
+    return;
+  }
+  var log = [];
+  var originalCreateElement = document.createElement;
+  spyOn(document, 'createElement').and.callFake(function(type) {
+    var el = originalCreateElement.apply(this, arguments);
+    if (type === 'input') {
+      Object.defineProperty(el, 'value', {
+        get: function() {},
+        set: function() {
+          log.push('set value');
+        },
+      });
+      spyOn(el, 'setAttribute').and.callFake(function(name, value) {
+        log.push('set ' + name);
+      });
     }
-
-    var stub = ReactTestUtils.renderIntoDocument(<RadioGroup />);
-    var aNode = ReactDOM.findDOMNode(stub.refs.a);
-    var bNode = ReactDOM.findDOMNode(stub.refs.b);
-    var cNode = ReactDOM.findDOMNode(stub.refs.c);
-
-    expect(aNode.checked).toBe(true);
-    expect(bNode.checked).toBe(false);
-    // c is in a separate form and shouldn't be affected at all here
-    expect(cNode.checked).toBe(true);
-
-    bNode.checked = true;
-    // This next line isn't necessary in a proper browser environment, but
-    // jsdom doesn't uncheck the others in a group (which makes this whole test
-    // a little less effective)
-    aNode.checked = false;
-    expect(cNode.checked).toBe(true);
-
-    // Now let's run the actual ReactDOMInput change event handler
-    ReactTestUtils.Simulate.change(bNode);
-
-    // The original state should have been restored
-    expect(aNode.checked).toBe(true);
-    expect(cNode.checked).toBe(true);
+    return el;
   });
 
-  it('should support ReactLink', function() {
-    var link = new ReactLink('yolo', jest.fn());
-    var instance = <input type="text" valueLink={link} />;
+  ReactTestUtils.renderIntoDocument(<input value="0" type="range" min="0" max="100" step="1" />);
+  expect(log).toEqual([
+    'set data-reactroot',
+    'set type',
+    'set step',
+    'set min',
+    'set max',
+    'set value',
+    'set value',
+    'set checked',
+    'set checked',
+  ]);
+});
 
-    instance = ReactTestUtils.renderIntoDocument(instance);
+it('sets value properly with type coming later in props', function() {
+  var input = ReactTestUtils.renderIntoDocument(
+    <input value="hi" type="radio" />
+  );
+  expect(input.value).toBe('hi');
+});
 
-    expect(ReactDOM.findDOMNode(instance).value).toBe('yolo');
-    expect(link.value).toBe('yolo');
-    expect(link.requestChange.mock.calls.length).toBe(0);
-
-    ReactDOM.findDOMNode(instance).value = 'test';
-    ReactTestUtils.Simulate.change(ReactDOM.findDOMNode(instance));
-
-    expect(link.requestChange.mock.calls.length).toBe(1);
-    expect(link.requestChange.mock.calls[0][0]).toEqual('test');
+it('does not raise a validation warning when it switches types', function() {
+  var Input = React.createClass({
+    getInitialState() {
+      return { type: 'number', value: 1000 };
+    },
+    render() {
+      var { value, type } = this.state;
+      return (<input onChange={() => {}} type={type} value={value} />);
+    },
   });
 
-  it('should warn with value and no onChange handler', function() {
-    var link = new ReactLink('yolo', jest.fn());
-    ReactTestUtils.renderIntoDocument(<input type="text" valueLink={link} />);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      '`valueLink` prop on `input` is deprecated; set `value` and `onChange` instead.'
-    );
+  var input = ReactTestUtils.renderIntoDocument(<Input />);
+  var node = ReactDOM.findDOMNode(input);
 
-    ReactTestUtils.renderIntoDocument(
-      <input type="text" value="zoink" onChange={jest.fn()} />
-    );
-    expect(console.error.calls.count()).toBe(1);
-    ReactTestUtils.renderIntoDocument(<input type="text" value="zoink" />);
-    expect(console.error.calls.count()).toBe(2);
-  });
+  // If the value is set before the type, a validation warning will raise and
+  // the value will not be assigned.
+  input.setState({ type: 'text', value: 'Test' });
+  expect(node.value).toEqual('Test');
+});
 
-  it('should warn with value and no onChange handler and readOnly specified', function() {
-    ReactTestUtils.renderIntoDocument(
-      <input type="text" value="zoink" readOnly={true} />
-    );
-    expect(console.error.calls.count()).toBe(0);
+it('resets value of date/time input to fix bugs in iOS Safari', function() {
+  // https://github.com/facebook/react/issues/7233
+  if (!ReactDOMFeatureFlags.useCreateElement) {
+    return;
+  }
 
-    ReactTestUtils.renderIntoDocument(
-      <input type="text" value="zoink" readOnly={false} />
-    );
-    expect(console.error.calls.count()).toBe(1);
-  });
+  function strify(x) {
+    return JSON.stringify(x, null, 2);
+  }
 
-  it('should have a this value of undefined if bind is not used', function() {
-    var unboundInputOnChange = function() {
-      expect(this).toBe(undefined);
-    };
-
-    var instance = <input type="text" onChange={unboundInputOnChange} />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-
-    ReactTestUtils.Simulate.change(instance);
-  });
-
-  it('should throw if both value and valueLink are provided', function() {
-    var node = document.createElement('div');
-    var link = new ReactLink('yolo', jest.fn());
-    var instance = <input type="text" valueLink={link} />;
-
-    expect(() => ReactDOM.render(instance, node)).not.toThrow();
-
-    instance =
-      <input
-        type="text"
-        valueLink={link}
-        value="test"
-        onChange={emptyFunction}
-      />;
-    expect(() => ReactDOM.render(instance, node)).toThrow();
-
-    instance = <input type="text" valueLink={link} onChange={emptyFunction} />;
-    expect(() => ReactDOM.render(instance, node)).toThrow();
-
-  });
-
-  it('should support checkedLink', function() {
-    var link = new ReactLink(true, jest.fn());
-    var instance = <input type="checkbox" checkedLink={link} />;
-
-    instance = ReactTestUtils.renderIntoDocument(instance);
-
-    expect(ReactDOM.findDOMNode(instance).checked).toBe(true);
-    expect(link.value).toBe(true);
-    expect(link.requestChange.mock.calls.length).toBe(0);
-
-    ReactDOM.findDOMNode(instance).checked = false;
-    ReactTestUtils.Simulate.change(ReactDOM.findDOMNode(instance));
-
-    expect(link.requestChange.mock.calls.length).toBe(1);
-    expect(link.requestChange.mock.calls[0][0]).toEqual(false);
-  });
-
-  it('should warn with checked and no onChange handler', function() {
-    var node = document.createElement('div');
-    var link = new ReactLink(true, jest.fn());
-    ReactDOM.render(<input type="checkbox" checkedLink={link} />, node);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      '`checkedLink` prop on `input` is deprecated; set `value` and `onChange` instead.'
-    );
-
-    ReactTestUtils.renderIntoDocument(
-      <input
-        type="checkbox"
-        checked="false"
-        onChange={jest.fn()}
-      />
-    );
-    expect(console.error.calls.count()).toBe(1);
-
-    ReactTestUtils.renderIntoDocument(
-      <input type="checkbox" checked="false" readOnly={true} />
-    );
-    expect(console.error.calls.count()).toBe(1);
-
-    ReactTestUtils.renderIntoDocument(<input type="checkbox" checked="false" />);
-    expect(console.error.calls.count()).toBe(2);
-  });
-
-  it('should warn with checked and no onChange handler with readOnly specified', function() {
-    ReactTestUtils.renderIntoDocument(
-      <input type="checkbox" checked="false" readOnly={true} />
-    );
-    expect(console.error.calls.count()).toBe(0);
-
-    ReactTestUtils.renderIntoDocument(
-      <input type="checkbox" checked="false" readOnly={false} />
-    );
-    expect(console.error.calls.count()).toBe(1);
-  });
-
-  it('should throw if both checked and checkedLink are provided', function() {
-    var node = document.createElement('div');
-    var link = new ReactLink(true, jest.fn());
-    var instance = <input type="checkbox" checkedLink={link} />;
-
-    expect(() => ReactDOM.render(instance, node)).not.toThrow();
-
-    instance =
-      <input
-        type="checkbox"
-        checkedLink={link}
-        checked="false"
-        onChange={emptyFunction}
-      />;
-    expect(() => ReactDOM.render(instance, node)).toThrow();
-
-    instance =
-      <input type="checkbox" checkedLink={link} onChange={emptyFunction} />;
-    expect(() => ReactDOM.render(instance, node)).toThrow();
-
-  });
-
-  it('should update defaultValue to empty string', function() {
-    var container = document.createElement('div');
-    ReactDOM.render(<input type="text" defaultValue={'foo'} />, container);
-    ReactDOM.render(<input type="text" defaultValue={''} />, container);
-    expect(container.firstChild.defaultValue).toBe('');
-  });
-
-  it('should throw if both checkedLink and valueLink are provided', function() {
-    var node = document.createElement('div');
-    var link = new ReactLink(true, jest.fn());
-    var instance = <input type="checkbox" checkedLink={link} />;
-
-    expect(() => ReactDOM.render(instance, node)).not.toThrow();
-
-    instance = <input type="checkbox" valueLink={link} />;
-    expect(() => ReactDOM.render(instance, node)).not.toThrow();
-
-    instance =
-      <input type="checkbox" checkedLink={link} valueLink={emptyFunction} />;
-    expect(() => ReactDOM.render(instance, node)).toThrow();
-  });
-
-  it('should warn if value is null', function() {
-    ReactTestUtils.renderIntoDocument(<input type="text" value={null} />);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      '`value` prop on `input` should not be null. ' +
-      'Consider using the empty string to clear the component or `undefined` ' +
-      'for uncontrolled components.'
-    );
-
-    ReactTestUtils.renderIntoDocument(<input type="text" value={null} />);
-    expect(console.error.calls.count()).toBe(1);
-  });
-
-  it('should warn if checked and defaultChecked props are specified', function() {
-    ReactTestUtils.renderIntoDocument(
-      <input type="radio" checked={true} defaultChecked={true} readOnly={true} />
-    );
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'A component contains an input of type radio with both checked and defaultChecked props. ' +
-      'Input elements must be either controlled or uncontrolled ' +
-      '(specify either the checked prop, or the defaultChecked prop, but not ' +
-      'both). Decide between using a controlled or uncontrolled input ' +
-      'element and remove one of these props. More info: ' +
-      'https://fb.me/react-controlled-components'
-    );
-
-    ReactTestUtils.renderIntoDocument(
-      <input type="radio" checked={true} defaultChecked={true} readOnly={true} />
-    );
-    expect(console.error.calls.count()).toBe(1);
-  });
-
-  it('should warn if value and defaultValue props are specified', function() {
-    ReactTestUtils.renderIntoDocument(
-      <input type="text" value="foo" defaultValue="bar" readOnly={true} />
-    );
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'A component contains an input of type text with both value and defaultValue props. ' +
-      'Input elements must be either controlled or uncontrolled ' +
-      '(specify either the value prop, or the defaultValue prop, but not ' +
-      'both). Decide between using a controlled or uncontrolled input ' +
-      'element and remove one of these props. More info: ' +
-      'https://fb.me/react-controlled-components'
-    );
-
-    ReactTestUtils.renderIntoDocument(
-      <input type="text" value="foo" defaultValue="bar" readOnly={true} />
-    );
-    expect(console.error.calls.count()).toBe(1);
-  });
-
-  it('should warn if controlled input switches to uncontrolled (value is undefined)', function() {
-    var stub = <input type="text" value="controlled" onChange={emptyFunction} />;
-    var container = document.createElement('div');
-    ReactDOM.render(stub, container);
-    ReactDOM.render(<input type="text" />, container);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'A component is changing a controlled input of type text to be uncontrolled. ' +
-      'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
-      'Decide between using a controlled or uncontrolled input ' +
-      'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
-    );
-  });
-
-  it('should warn if controlled input switches to uncontrolled (value is null)', function() {
-    var stub = <input type="text" value="controlled" onChange={emptyFunction} />;
-    var container = document.createElement('div');
-    ReactDOM.render(stub, container);
-    ReactDOM.render(<input type="text" value={null} />, container);
-    expect(console.error.calls.count()).toBeGreaterThan(0);
-    expect(console.error.calls.argsFor(1)[0]).toContain(
-      'A component is changing a controlled input of type text to be uncontrolled. ' +
-      'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
-      'Decide between using a controlled or uncontrolled input ' +
-      'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
-    );
-  });
-
-  it('should warn if controlled input switches to uncontrolled with defaultValue', function() {
-    var stub = <input type="text" value="controlled" onChange={emptyFunction} />;
-    var container = document.createElement('div');
-    ReactDOM.render(stub, container);
-    ReactDOM.render(<input type="text" defaultValue="uncontrolled" />, container);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'A component is changing a controlled input of type text to be uncontrolled. ' +
-      'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
-      'Decide between using a controlled or uncontrolled input ' +
-      'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
-    );
-  });
-
-  it('should warn if uncontrolled input (value is undefined) switches to controlled', function() {
-    var stub = <input type="text" />;
-    var container = document.createElement('div');
-    ReactDOM.render(stub, container);
-    ReactDOM.render(<input type="text" value="controlled" />, container);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'A component is changing an uncontrolled input of type text to be controlled. ' +
-      'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
-      'Decide between using a controlled or uncontrolled input ' +
-      'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
-    );
-  });
-
-  it('should warn if uncontrolled input (value is null) switches to controlled', function() {
-    var stub = <input type="text" value={null} />;
-    var container = document.createElement('div');
-    ReactDOM.render(stub, container);
-    ReactDOM.render(<input type="text" value="controlled" />, container);
-    expect(console.error.calls.count()).toBeGreaterThan(0);
-    expect(console.error.calls.argsFor(1)[0]).toContain(
-      'A component is changing an uncontrolled input of type text to be controlled. ' +
-      'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
-      'Decide between using a controlled or uncontrolled input ' +
-      'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
-    );
-  });
-
-  it('should warn if controlled checkbox switches to uncontrolled (checked is undefined)', function() {
-    var stub = <input type="checkbox" checked={true} onChange={emptyFunction} />;
-    var container = document.createElement('div');
-    ReactDOM.render(stub, container);
-    ReactDOM.render(<input type="checkbox" />, container);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'A component is changing a controlled input of type checkbox to be uncontrolled. ' +
-      'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
-      'Decide between using a controlled or uncontrolled input ' +
-      'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
-    );
-  });
-
-  it('should warn if controlled checkbox switches to uncontrolled (checked is null)', function() {
-    var stub = <input type="checkbox" checked={true} onChange={emptyFunction} />;
-    var container = document.createElement('div');
-    ReactDOM.render(stub, container);
-    ReactDOM.render(<input type="checkbox" checked={null} />, container);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'A component is changing a controlled input of type checkbox to be uncontrolled. ' +
-      'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
-      'Decide between using a controlled or uncontrolled input ' +
-      'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
-    );
-  });
-
-  it('should warn if controlled checkbox switches to uncontrolled with defaultChecked', function() {
-    var stub = <input type="checkbox" checked={true} onChange={emptyFunction} />;
-    var container = document.createElement('div');
-    ReactDOM.render(stub, container);
-    ReactDOM.render(<input type="checkbox" defaultChecked={true} />, container);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'A component is changing a controlled input of type checkbox to be uncontrolled. ' +
-      'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
-      'Decide between using a controlled or uncontrolled input ' +
-      'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
-    );
-  });
-
-  it('should warn if uncontrolled checkbox (checked is undefined) switches to controlled', function() {
-    var stub = <input type="checkbox" />;
-    var container = document.createElement('div');
-    ReactDOM.render(stub, container);
-    ReactDOM.render(<input type="checkbox" checked={true} />, container);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'A component is changing an uncontrolled input of type checkbox to be controlled. ' +
-      'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
-      'Decide between using a controlled or uncontrolled input ' +
-      'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
-    );
-  });
-
-  it('should warn if uncontrolled checkbox (checked is null) switches to controlled', function() {
-    var stub = <input type="checkbox" checked={null} />;
-    var container = document.createElement('div');
-    ReactDOM.render(stub, container);
-    ReactDOM.render(<input type="checkbox" checked={true} />, container);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'A component is changing an uncontrolled input of type checkbox to be controlled. ' +
-      'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
-      'Decide between using a controlled or uncontrolled input ' +
-      'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
-    );
-  });
-
-  it('should warn if controlled radio switches to uncontrolled (checked is undefined)', function() {
-    var stub = <input type="radio" checked={true} onChange={emptyFunction} />;
-    var container = document.createElement('div');
-    ReactDOM.render(stub, container);
-    ReactDOM.render(<input type="radio" />, container);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'A component is changing a controlled input of type radio to be uncontrolled. ' +
-      'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
-      'Decide between using a controlled or uncontrolled input ' +
-      'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
-    );
-  });
-
-  it('should warn if controlled radio switches to uncontrolled (checked is null)', function() {
-    var stub = <input type="radio" checked={true} onChange={emptyFunction} />;
-    var container = document.createElement('div');
-    ReactDOM.render(stub, container);
-    ReactDOM.render(<input type="radio" checked={null} />, container);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'A component is changing a controlled input of type radio to be uncontrolled. ' +
-      'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
-      'Decide between using a controlled or uncontrolled input ' +
-      'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
-    );
-  });
-
-  it('should warn if controlled radio switches to uncontrolled with defaultChecked', function() {
-    var stub = <input type="radio" checked={true} onChange={emptyFunction} />;
-    var container = document.createElement('div');
-    ReactDOM.render(stub, container);
-    ReactDOM.render(<input type="radio" defaultChecked={true} />, container);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'A component is changing a controlled input of type radio to be uncontrolled. ' +
-      'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
-      'Decide between using a controlled or uncontrolled input ' +
-      'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
-    );
-  });
-
-  it('should warn if uncontrolled radio (checked is undefined) switches to controlled', function() {
-    var stub = <input type="radio" />;
-    var container = document.createElement('div');
-    ReactDOM.render(stub, container);
-    ReactDOM.render(<input type="radio" checked={true} />, container);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'A component is changing an uncontrolled input of type radio to be controlled. ' +
-      'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
-      'Decide between using a controlled or uncontrolled input ' +
-      'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
-    );
-  });
-
-  it('should warn if uncontrolled radio (checked is null) switches to controlled', function() {
-    var stub = <input type="radio" checked={null} />;
-    var container = document.createElement('div');
-    ReactDOM.render(stub, container);
-    ReactDOM.render(<input type="radio" checked={true} />, container);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'A component is changing an uncontrolled input of type radio to be controlled. ' +
-      'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
-      'Decide between using a controlled or uncontrolled input ' +
-      'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
-    );
-  });
-
-  it('should not warn if radio value changes but never becomes controlled', function() {
-    var container = document.createElement('div');
-    ReactDOM.render(<input type="radio" value="value" />, container);
-    ReactDOM.render(<input type="radio" />, container);
-    ReactDOM.render(<input type="radio" value="value" defaultChecked={true} />, container);
-    ReactDOM.render(<input type="radio" value="value" onChange={() => null} />, container);
-    ReactDOM.render(<input type="radio" />, container);
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('should not warn if radio value changes but never becomes uncontrolled', function() {
-    var container = document.createElement('div');
-    ReactDOM.render(<input type="radio" checked={false} onChange={() => null} />, container);
-    ReactDOM.render(
-      <input
-        type="radio"
-        value="value"
-        defaultChecked={true}
-        checked={false}
-        onChange={() => null}
-      />, container);
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('should warn if radio checked false changes to become uncontrolled', function() {
-    var container = document.createElement('div');
-    ReactDOM.render(<input type="radio" value="value" checked={false} onChange={() => null} />, container);
-    ReactDOM.render(<input type="radio" value="value" />, container);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'A component is changing a controlled input of type radio to be uncontrolled. ' +
-      'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
-      'Decide between using a controlled or uncontrolled input ' +
-      'element for the lifetime of the component. More info: https://fb.me/react-controlled-components'
-    );
-  });
-
-  it('sets type, step, min, max before value always', function() {
-    if (!ReactDOMFeatureFlags.useCreateElement) {
-      return;
+  var log = [];
+  var originalCreateElement = document.createElement;
+  spyOn(document, 'createElement').and.callFake(function(type) {
+    var el = originalCreateElement.apply(this, arguments);
+    if (type === 'input') {
+      Object.defineProperty(el, 'value', {
+        set: function(val) {
+          log.push(`node.value = ${strify(val)}`);
+        },
+      });
+      spyOn(el, 'setAttribute').and.callFake(function(name, val) {
+        log.push(`node.setAttribute(${strify(name)}, ${strify(val)})`);
+      });
     }
-    var log = [];
-    var originalCreateElement = document.createElement;
-    spyOn(document, 'createElement').and.callFake(function(type) {
-      var el = originalCreateElement.apply(this, arguments);
-      if (type === 'input') {
-        Object.defineProperty(el, 'value', {
-          get: function() {},
-          set: function() {
-            log.push('set value');
-          },
-        });
-        spyOn(el, 'setAttribute').and.callFake(function(name, value) {
-          log.push('set ' + name);
-        });
-      }
-      return el;
-    });
-
-    ReactTestUtils.renderIntoDocument(<input value="0" type="range" min="0" max="100" step="1" />);
-    expect(log).toEqual([
-      'set data-reactroot',
-      'set type',
-      'set step',
-      'set min',
-      'set max',
-      'set value',
-      'set value',
-      'set checked',
-      'set checked',
-    ]);
+    return el;
   });
 
-  it('sets value properly with type coming later in props', function() {
-    var input = ReactTestUtils.renderIntoDocument(
-      <input value="hi" type="radio" />
-    );
-    expect(input.value).toBe('hi');
-  });
-
-  it('does not raise a validation warning when it switches types', function() {
-    var Input = React.createClass({
-      getInitialState() {
-        return { type: 'number', value: 1000 };
-      },
-      render() {
-        var { value, type } = this.state;
-        return (<input onChange={() => {}} type={type} value={value} />);
-      },
-    });
-
-    var input = ReactTestUtils.renderIntoDocument(<Input />);
-    var node = ReactDOM.findDOMNode(input);
-
-    // If the value is set before the type, a validation warning will raise and
-    // the value will not be assigned.
-    input.setState({ type: 'text', value: 'Test' });
-    expect(node.value).toEqual('Test');
-  });
-
-  it('resets value of date/time input to fix bugs in iOS Safari', function() {
-    // https://github.com/facebook/react/issues/7233
-    if (!ReactDOMFeatureFlags.useCreateElement) {
-      return;
-    }
-
-    function strify(x) {
-      return JSON.stringify(x, null, 2);
-    }
-
-    var log = [];
-    var originalCreateElement = document.createElement;
-    spyOn(document, 'createElement').and.callFake(function(type) {
-      var el = originalCreateElement.apply(this, arguments);
-      if (type === 'input') {
-        Object.defineProperty(el, 'value', {
-          set: function(val) {
-            log.push(`node.value = ${strify(val)}`);
-          },
-        });
-        spyOn(el, 'setAttribute').and.callFake(function(name, val) {
-          log.push(`node.setAttribute(${strify(name)}, ${strify(val)})`);
-        });
-      }
-      return el;
-    });
-
-    ReactTestUtils.renderIntoDocument(<input type="date" defaultValue="1980-01-01" />);
-    expect(log).toEqual([
-      'node.setAttribute("data-reactroot", "")',
-      'node.setAttribute("type", "date")',
-      'node.setAttribute("value", "1980-01-01")',
-      'node.value = ""',
-      'node.value = ""',
-      'node.setAttribute("checked", "")',
-      'node.setAttribute("checked", "")',
-    ]);
-  });
+  ReactTestUtils.renderIntoDocument(<input type="date" defaultValue="1980-01-01" />);
+  expect(log).toEqual([
+    'node.setAttribute("data-reactroot", "")',
+    'node.setAttribute("type", "date")',
+    'node.setAttribute("value", "1980-01-01")',
+    'node.value = ""',
+    'node.value = ""',
+    'node.setAttribute("checked", "")',
+    'node.setAttribute("checked", "")',
+  ]);
 });

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMOption-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMOption-test.js
@@ -12,86 +12,84 @@
 'use strict';
 
 
-describe('ReactDOMOption', function() {
-  var React;
-  var ReactDOM;
-  var ReactTestUtils;
+var React;
+var ReactDOM;
+var ReactTestUtils;
 
-  beforeEach(function() {
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactTestUtils = require('ReactTestUtils');
-  });
+beforeEach(function() {
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactTestUtils = require('ReactTestUtils');
+});
 
-  it('should flatten children to a string', function() {
-    var stub = <option>{1} {'foo'}</option>;
-    stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
+it('should flatten children to a string', function() {
+  var stub = <option>{1} {'foo'}</option>;
+  stub = ReactTestUtils.renderIntoDocument(stub);
+  var node = ReactDOM.findDOMNode(stub);
 
-    expect(node.innerHTML).toBe('1 foo');
-  });
+  expect(node.innerHTML).toBe('1 foo');
+});
 
-  it('should ignore and warn invalid children types', function() {
-    spyOn(console, 'error');
-    var stub = <option>{1} <div /> {2}</option>;
-    stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
-    expect(node.innerHTML).toBe('1  2');
-    ReactTestUtils.renderIntoDocument(<option>{1} <div /> {2}</option>);
-    // only warn once
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain('Only strings and numbers are supported as <option> children.');
-  });
+it('should ignore and warn invalid children types', function() {
+  spyOn(console, 'error');
+  var stub = <option>{1} <div /> {2}</option>;
+  stub = ReactTestUtils.renderIntoDocument(stub);
+  var node = ReactDOM.findDOMNode(stub);
+  expect(node.innerHTML).toBe('1  2');
+  ReactTestUtils.renderIntoDocument(<option>{1} <div /> {2}</option>);
+  // only warn once
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain('Only strings and numbers are supported as <option> children.');
+});
 
-  it('should ignore null/undefined/false children without warning', function() {
-    var stub = <option>{1} {false}{true}{null}{undefined} {2}</option>;
-    spyOn(console, 'error');
-    stub = ReactTestUtils.renderIntoDocument(stub);
+it('should ignore null/undefined/false children without warning', function() {
+  var stub = <option>{1} {false}{true}{null}{undefined} {2}</option>;
+  spyOn(console, 'error');
+  stub = ReactTestUtils.renderIntoDocument(stub);
 
-    var node = ReactDOM.findDOMNode(stub);
+  var node = ReactDOM.findDOMNode(stub);
 
-    expect(console.error.calls.count()).toBe(0);
-    expect(node.innerHTML).toBe('1  2');
-  });
+  expect(console.error.calls.count()).toBe(0);
+  expect(node.innerHTML).toBe('1  2');
+});
 
-  it('should be able to use dangerouslySetInnerHTML on option', function() {
-    var stub = <option dangerouslySetInnerHTML={{ __html: 'foobar' }} />;
-    stub = ReactTestUtils.renderIntoDocument(stub);
+it('should be able to use dangerouslySetInnerHTML on option', function() {
+  var stub = <option dangerouslySetInnerHTML={{ __html: 'foobar' }} />;
+  stub = ReactTestUtils.renderIntoDocument(stub);
 
-    var node = ReactDOM.findDOMNode(stub);
-    expect(node.innerHTML).toBe('foobar');
-  });
+  var node = ReactDOM.findDOMNode(stub);
+  expect(node.innerHTML).toBe('foobar');
+});
 
-  it('should set attribute for empty value', function() {
-    var container = document.createElement('div');
-    var option = ReactDOM.render(<option value="" />, container);
-    expect(option.hasAttribute('value')).toBe(true);
-    expect(option.getAttribute('value')).toBe('');
+it('should set attribute for empty value', function() {
+  var container = document.createElement('div');
+  var option = ReactDOM.render(<option value="" />, container);
+  expect(option.hasAttribute('value')).toBe(true);
+  expect(option.getAttribute('value')).toBe('');
 
-    ReactDOM.render(<option value="lava" />, container);
-    expect(option.hasAttribute('value')).toBe(true);
-    expect(option.getAttribute('value')).toBe('lava');
-  });
+  ReactDOM.render(<option value="lava" />, container);
+  expect(option.hasAttribute('value')).toBe(true);
+  expect(option.getAttribute('value')).toBe('lava');
+});
 
-  it('should allow ignoring `value` on option', function() {
-    var a = 'a';
-    var stub =
-      <select value="giraffe" onChange={() => {}}>
-        <option>monkey</option>
-        <option>gir{a}ffe</option>
-        <option>gorill{a}</option>
-      </select>;
-    var options = stub.props.children;
-    var container = document.createElement('div');
-    stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+it('should allow ignoring `value` on option', function() {
+  var a = 'a';
+  var stub =
+    <select value="giraffe" onChange={() => {}}>
+      <option>monkey</option>
+      <option>gir{a}ffe</option>
+      <option>gorill{a}</option>
+    </select>;
+  var options = stub.props.children;
+  var container = document.createElement('div');
+  stub = ReactDOM.render(stub, container);
+  var node = ReactDOM.findDOMNode(stub);
 
-    expect(node.selectedIndex).toBe(1);
+  expect(node.selectedIndex).toBe(1);
 
-    ReactDOM.render(
-      <select value="gorilla">{options}</select>,
-      container
-    );
-    expect(node.selectedIndex).toEqual(2);
-  });
+  ReactDOM.render(
+    <select value="gorilla">{options}</select>,
+    container
+  );
+  expect(node.selectedIndex).toEqual(2);
 });

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMSelect-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMSelect-test.js
@@ -12,546 +12,544 @@
 'use strict';
 
 
-describe('ReactDOMSelect', function() {
-  var React;
-  var ReactDOM;
-  var ReactDOMServer;
-  var ReactLink;
-  var ReactTestUtils;
+var React;
+var ReactDOM;
+var ReactDOMServer;
+var ReactLink;
+var ReactTestUtils;
 
-  var noop = function() {};
+var noop = function() {};
 
-  beforeEach(function() {
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactDOMServer = require('ReactDOMServer');
-    ReactLink = require('ReactLink');
-    ReactTestUtils = require('ReactTestUtils');
-  });
+beforeEach(function() {
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactDOMServer = require('ReactDOMServer');
+  ReactLink = require('ReactLink');
+  ReactTestUtils = require('ReactTestUtils');
+});
 
-  it('should allow setting `defaultValue`', function() {
-    var stub =
-      <select defaultValue="giraffe">
-        <option value="monkey">A monkey!</option>
-        <option value="giraffe">A giraffe!</option>
-        <option value="gorilla">A gorilla!</option>
-      </select>;
-    var options = stub.props.children;
-    var container = document.createElement('div');
-    stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+it('should allow setting `defaultValue`', function() {
+  var stub =
+    <select defaultValue="giraffe">
+      <option value="monkey">A monkey!</option>
+      <option value="giraffe">A giraffe!</option>
+      <option value="gorilla">A gorilla!</option>
+    </select>;
+  var options = stub.props.children;
+  var container = document.createElement('div');
+  stub = ReactDOM.render(stub, container);
+  var node = ReactDOM.findDOMNode(stub);
 
-    expect(node.value).toBe('giraffe');
+  expect(node.value).toBe('giraffe');
 
-    // Changing `defaultValue` should do nothing.
-    ReactDOM.render(
-      <select defaultValue="gorilla">{options}</select>,
-      container
-    );
-    expect(node.value).toEqual('giraffe');
-  });
+  // Changing `defaultValue` should do nothing.
+  ReactDOM.render(
+    <select defaultValue="gorilla">{options}</select>,
+    container
+  );
+  expect(node.value).toEqual('giraffe');
+});
 
-  it('should not throw with `defaultValue` and without children', function() {
-    var stub = <select defaultValue="dummy"></select>;
+it('should not throw with `defaultValue` and without children', function() {
+  var stub = <select defaultValue="dummy"></select>;
 
-    expect(() => {
-      ReactTestUtils.renderIntoDocument(stub);
-    }).not.toThrow();
-  });
+  expect(() => {
+    ReactTestUtils.renderIntoDocument(stub);
+  }).not.toThrow();
+});
 
-  it('should not control when using `defaultValue`', function() {
-    var el =
-      <select defaultValue="giraffe">
-        <option value="monkey">A monkey!</option>
-        <option value="giraffe">A giraffe!</option>
-        <option value="gorilla">A gorilla!</option>
-      </select>;
-    var container = document.createElement('div');
-    var stub = ReactDOM.render(el, container);
-    var node = ReactDOM.findDOMNode(stub);
+it('should not control when using `defaultValue`', function() {
+  var el =
+    <select defaultValue="giraffe">
+      <option value="monkey">A monkey!</option>
+      <option value="giraffe">A giraffe!</option>
+      <option value="gorilla">A gorilla!</option>
+    </select>;
+  var container = document.createElement('div');
+  var stub = ReactDOM.render(el, container);
+  var node = ReactDOM.findDOMNode(stub);
 
-    expect(node.value).toBe('giraffe');
+  expect(node.value).toBe('giraffe');
 
-    node.value = 'monkey';
-    ReactDOM.render(el, container);
-    // Uncontrolled selects shouldn't change the value after first mounting
-    expect(node.value).toEqual('monkey');
-  });
+  node.value = 'monkey';
+  ReactDOM.render(el, container);
+  // Uncontrolled selects shouldn't change the value after first mounting
+  expect(node.value).toEqual('monkey');
+});
 
-  it('should allow setting `defaultValue` with multiple', function() {
-    var stub =
-      <select multiple={true} defaultValue={['giraffe', 'gorilla']}>
-        <option value="monkey">A monkey!</option>
-        <option value="giraffe">A giraffe!</option>
-        <option value="gorilla">A gorilla!</option>
-      </select>;
-    var options = stub.props.children;
-    var container = document.createElement('div');
-    stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+it('should allow setting `defaultValue` with multiple', function() {
+  var stub =
+    <select multiple={true} defaultValue={['giraffe', 'gorilla']}>
+      <option value="monkey">A monkey!</option>
+      <option value="giraffe">A giraffe!</option>
+      <option value="gorilla">A gorilla!</option>
+    </select>;
+  var options = stub.props.children;
+  var container = document.createElement('div');
+  stub = ReactDOM.render(stub, container);
+  var node = ReactDOM.findDOMNode(stub);
 
-    expect(node.options[0].selected).toBe(false);  // monkey
-    expect(node.options[1].selected).toBe(true);  // giraffe
-    expect(node.options[2].selected).toBe(true);  // gorilla
+  expect(node.options[0].selected).toBe(false);  // monkey
+  expect(node.options[1].selected).toBe(true);  // giraffe
+  expect(node.options[2].selected).toBe(true);  // gorilla
 
-    // Changing `defaultValue` should do nothing.
-    ReactDOM.render(
-      <select multiple={true} defaultValue={['monkey']}>{options}</select>,
-      container
-    );
+  // Changing `defaultValue` should do nothing.
+  ReactDOM.render(
+    <select multiple={true} defaultValue={['monkey']}>{options}</select>,
+    container
+  );
 
-    expect(node.options[0].selected).toBe(false);  // monkey
-    expect(node.options[1].selected).toBe(true);  // giraffe
-    expect(node.options[2].selected).toBe(true);  // gorilla
-  });
+  expect(node.options[0].selected).toBe(false);  // monkey
+  expect(node.options[1].selected).toBe(true);  // giraffe
+  expect(node.options[2].selected).toBe(true);  // gorilla
+});
 
-  it('should allow setting `value`', function() {
-    var stub =
-      <select value="giraffe" onChange={noop}>
-        <option value="monkey">A monkey!</option>
-        <option value="giraffe">A giraffe!</option>
-        <option value="gorilla">A gorilla!</option>
-      </select>;
-    var options = stub.props.children;
-    var container = document.createElement('div');
-    stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+it('should allow setting `value`', function() {
+  var stub =
+    <select value="giraffe" onChange={noop}>
+      <option value="monkey">A monkey!</option>
+      <option value="giraffe">A giraffe!</option>
+      <option value="gorilla">A gorilla!</option>
+    </select>;
+  var options = stub.props.children;
+  var container = document.createElement('div');
+  stub = ReactDOM.render(stub, container);
+  var node = ReactDOM.findDOMNode(stub);
 
-    expect(node.value).toBe('giraffe');
+  expect(node.value).toBe('giraffe');
 
-    // Changing the `value` prop should change the selected option.
-    ReactDOM.render(
-      <select value="gorilla" onChange={noop}>{options}</select>,
-      container
-    );
-    expect(node.value).toEqual('gorilla');
-  });
+  // Changing the `value` prop should change the selected option.
+  ReactDOM.render(
+    <select value="gorilla" onChange={noop}>{options}</select>,
+    container
+  );
+  expect(node.value).toEqual('gorilla');
+});
 
-  it('should not throw with `value` and without children', function() {
-    var stub = <select value="dummy" onChange={noop}></select>;
+it('should not throw with `value` and without children', function() {
+  var stub = <select value="dummy" onChange={noop}></select>;
 
-    expect(() => {
-      ReactTestUtils.renderIntoDocument(stub);
-    }).not.toThrow();
-  });
+  expect(() => {
+    ReactTestUtils.renderIntoDocument(stub);
+  }).not.toThrow();
+});
 
-  it('should allow setting `value` with multiple', function() {
-    var stub =
-      <select multiple={true} value={['giraffe', 'gorilla']} onChange={noop}>
-        <option value="monkey">A monkey!</option>
-        <option value="giraffe">A giraffe!</option>
-        <option value="gorilla">A gorilla!</option>
-      </select>;
-    var options = stub.props.children;
-    var container = document.createElement('div');
-    stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
+it('should allow setting `value` with multiple', function() {
+  var stub =
+    <select multiple={true} value={['giraffe', 'gorilla']} onChange={noop}>
+      <option value="monkey">A monkey!</option>
+      <option value="giraffe">A giraffe!</option>
+      <option value="gorilla">A gorilla!</option>
+    </select>;
+  var options = stub.props.children;
+  var container = document.createElement('div');
+  stub = ReactDOM.render(stub, container);
+  var node = ReactDOM.findDOMNode(stub);
 
-    expect(node.options[0].selected).toBe(false);  // monkey
-    expect(node.options[1].selected).toBe(true);  // giraffe
-    expect(node.options[2].selected).toBe(true);  // gorilla
+  expect(node.options[0].selected).toBe(false);  // monkey
+  expect(node.options[1].selected).toBe(true);  // giraffe
+  expect(node.options[2].selected).toBe(true);  // gorilla
 
-    // Changing the `value` prop should change the selected options.
-    ReactDOM.render(
-      <select multiple={true} value={['monkey']} onChange={noop}>
-        {options}
-      </select>,
-      container
-    );
+  // Changing the `value` prop should change the selected options.
+  ReactDOM.render(
+    <select multiple={true} value={['monkey']} onChange={noop}>
+      {options}
+    </select>,
+    container
+  );
 
-    expect(node.options[0].selected).toBe(true);  // monkey
-    expect(node.options[1].selected).toBe(false);  // giraffe
-    expect(node.options[2].selected).toBe(false);  // gorilla
-  });
+  expect(node.options[0].selected).toBe(true);  // monkey
+  expect(node.options[1].selected).toBe(false);  // giraffe
+  expect(node.options[2].selected).toBe(false);  // gorilla
+});
 
-  it('should not select other options automatically', function() {
-    var stub =
-      <select multiple={true} value={['12']} onChange={noop}>
-        <option value="1">one</option>
-        <option value="2">two</option>
-        <option value="12">twelve</option>
-      </select>;
-    stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
+it('should not select other options automatically', function() {
+  var stub =
+    <select multiple={true} value={['12']} onChange={noop}>
+      <option value="1">one</option>
+      <option value="2">two</option>
+      <option value="12">twelve</option>
+    </select>;
+  stub = ReactTestUtils.renderIntoDocument(stub);
+  var node = ReactDOM.findDOMNode(stub);
 
-    expect(node.options[0].selected).toBe(false);  // one
-    expect(node.options[1].selected).toBe(false);  // two
-    expect(node.options[2].selected).toBe(true);  // twelve
-  });
+  expect(node.options[0].selected).toBe(false);  // one
+  expect(node.options[1].selected).toBe(false);  // two
+  expect(node.options[2].selected).toBe(true);  // twelve
+});
 
-  it('should reset child options selected when they are changed and `value` is set', function() {
-    var stub = <select multiple={true} value={['a', 'b']} onChange={noop} />;
-    var container = document.createElement('div');
-    stub = ReactDOM.render(stub, container);
+it('should reset child options selected when they are changed and `value` is set', function() {
+  var stub = <select multiple={true} value={['a', 'b']} onChange={noop} />;
+  var container = document.createElement('div');
+  stub = ReactDOM.render(stub, container);
 
-    ReactDOM.render(
-      <select multiple={true} value={['a', 'b']} onChange={noop}>
+  ReactDOM.render(
+    <select multiple={true} value={['a', 'b']} onChange={noop}>
+      <option value="a">a</option>
+      <option value="b">b</option>
+      <option value="c">c</option>
+    </select>,
+    container
+  );
+
+  var node = ReactDOM.findDOMNode(stub);
+
+  expect(node.options[0].selected).toBe(true);  // a
+  expect(node.options[1].selected).toBe(true);  // b
+  expect(node.options[2].selected).toBe(false);  // c
+});
+
+it('should allow setting `value` with `objectToString`', function() {
+  var objectToString = {
+    animal: 'giraffe',
+    toString: function() {
+      return this.animal;
+    },
+  };
+
+  var el =
+    <select multiple={true} value={[objectToString]} onChange={noop}>
+      <option value="monkey">A monkey!</option>
+      <option value="giraffe">A giraffe!</option>
+      <option value="gorilla">A gorilla!</option>
+    </select>;
+  var container = document.createElement('div');
+  var stub = ReactDOM.render(el, container);
+  var node = ReactDOM.findDOMNode(stub);
+
+  expect(node.options[0].selected).toBe(false);  // monkey
+  expect(node.options[1].selected).toBe(true);  // giraffe
+  expect(node.options[2].selected).toBe(false);  // gorilla
+
+  // Changing the `value` prop should change the selected options.
+  objectToString.animal = 'monkey';
+
+  var el2 =
+    <select multiple={true} value={[objectToString]}>
+      <option value="monkey">A monkey!</option>
+      <option value="giraffe">A giraffe!</option>
+      <option value="gorilla">A gorilla!</option>
+    </select>;
+  ReactDOM.render(el2, container);
+
+  expect(node.options[0].selected).toBe(true);  // monkey
+  expect(node.options[1].selected).toBe(false);  // giraffe
+  expect(node.options[2].selected).toBe(false);  // gorilla
+});
+
+it('should allow switching to multiple', function() {
+  var stub =
+    <select defaultValue="giraffe">
+      <option value="monkey">A monkey!</option>
+      <option value="giraffe">A giraffe!</option>
+      <option value="gorilla">A gorilla!</option>
+    </select>;
+  var options = stub.props.children;
+  var container = document.createElement('div');
+  stub = ReactDOM.render(stub, container);
+  var node = ReactDOM.findDOMNode(stub);
+
+  expect(node.options[0].selected).toBe(false);  // monkey
+  expect(node.options[1].selected).toBe(true);  // giraffe
+  expect(node.options[2].selected).toBe(false);  // gorilla
+
+  // When making it multiple, giraffe and gorilla should be selected
+  ReactDOM.render(
+    <select multiple={true} defaultValue={['giraffe', 'gorilla']}>
+      {options}
+    </select>,
+    container
+  );
+
+  expect(node.options[0].selected).toBe(false);  // monkey
+  expect(node.options[1].selected).toBe(true);  // giraffe
+  expect(node.options[2].selected).toBe(true);  // gorilla
+});
+
+it('should allow switching from multiple', function() {
+  var stub =
+    <select multiple={true} defaultValue={['giraffe', 'gorilla']}>
+      <option value="monkey">A monkey!</option>
+      <option value="giraffe">A giraffe!</option>
+      <option value="gorilla">A gorilla!</option>
+    </select>;
+  var options = stub.props.children;
+  var container = document.createElement('div');
+  stub = ReactDOM.render(stub, container);
+  var node = ReactDOM.findDOMNode(stub);
+
+  expect(node.options[0].selected).toBe(false);  // monkey
+  expect(node.options[1].selected).toBe(true);  // giraffe
+  expect(node.options[2].selected).toBe(true);  // gorilla
+
+  // When removing multiple, defaultValue is applied again, being omitted
+  // means that "monkey" will be selected
+  ReactDOM.render(
+    <select defaultValue="gorilla">{options}</select>,
+    container
+  );
+
+
+  expect(node.options[0].selected).toBe(false);  // monkey
+  expect(node.options[1].selected).toBe(false);  // giraffe
+  expect(node.options[2].selected).toBe(true);  // gorilla
+});
+
+it('should remember value when switching to uncontrolled', function() {
+  var stub =
+    <select value={'giraffe'} onChange={noop}>
+      <option value="monkey">A monkey!</option>
+      <option value="giraffe">A giraffe!</option>
+      <option value="gorilla">A gorilla!</option>
+    </select>;
+  var options = stub.props.children;
+  var container = document.createElement('div');
+  stub = ReactDOM.render(stub, container);
+  var node = ReactDOM.findDOMNode(stub);
+
+  expect(node.options[0].selected).toBe(false);  // monkey
+  expect(node.options[1].selected).toBe(true);  // giraffe
+  expect(node.options[2].selected).toBe(false);  // gorilla
+
+  ReactDOM.render(<select>{options}</select>, container);
+
+  expect(node.options[0].selected).toBe(false);  // monkey
+  expect(node.options[1].selected).toBe(true);  // giraffe
+  expect(node.options[2].selected).toBe(false);  // gorilla
+});
+
+it('should remember updated value when switching to uncontrolled', function() {
+  var stub =
+    <select value={'giraffe'} onChange={noop}>
+      <option value="monkey">A monkey!</option>
+      <option value="giraffe">A giraffe!</option>
+      <option value="gorilla">A gorilla!</option>
+    </select>;
+  var options = stub.props.children;
+  var container = document.createElement('div');
+  stub = ReactDOM.render(stub, container);
+  var node = ReactDOM.findDOMNode(stub);
+
+  ReactDOM.render(
+    <select value="gorilla" onChange={noop}>{options}</select>,
+    container
+  );
+
+  expect(node.options[0].selected).toBe(false);  // monkey
+  expect(node.options[1].selected).toBe(false);  // giraffe
+  expect(node.options[2].selected).toBe(true);  // gorilla
+
+  ReactDOM.render(<select>{options}</select>, container);
+
+  expect(node.options[0].selected).toBe(false);  // monkey
+  expect(node.options[1].selected).toBe(false);  // giraffe
+  expect(node.options[2].selected).toBe(true);  // gorilla
+});
+
+it('should support ReactLink', function() {
+  var link = new ReactLink('giraffe', jest.fn());
+  var stub =
+    <select valueLink={link}>
+      <option value="monkey">A monkey!</option>
+      <option value="giraffe">A giraffe!</option>
+      <option value="gorilla">A gorilla!</option>
+    </select>;
+
+  spyOn(console, 'error');
+
+  stub = ReactTestUtils.renderIntoDocument(stub);
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    '`valueLink` prop on `select` is deprecated; set `value` and `onChange` instead.'
+  );
+
+  var node = ReactDOM.findDOMNode(stub);
+
+  expect(node.options[0].selected).toBe(false);  // monkey
+  expect(node.options[1].selected).toBe(true);  // giraffe
+  expect(node.options[2].selected).toBe(false);  // gorilla
+  expect(link.requestChange.mock.calls.length).toBe(0);
+
+  node.options[1].selected = false;
+  node.options[2].selected = true;
+  ReactTestUtils.Simulate.change(node);
+
+  expect(link.requestChange.mock.calls.length).toBe(1);
+  expect(link.requestChange.mock.calls[0][0]).toEqual('gorilla');
+
+});
+
+it('should support server-side rendering', function() {
+  var stub =
+    <select value="giraffe" onChange={noop}>
+      <option value="monkey">A monkey!</option>
+      <option value="giraffe">A giraffe!</option>
+      <option value="gorilla">A gorilla!</option>
+    </select>;
+  var markup = ReactDOMServer.renderToString(stub);
+  expect(markup).toContain('<option selected="" value="giraffe"');
+  expect(markup).not.toContain('<option selected="" value="monkey"');
+  expect(markup).not.toContain('<option selected="" value="gorilla"');
+});
+
+it('should support server-side rendering with defaultValue', function() {
+  var stub =
+    <select defaultValue="giraffe">
+      <option value="monkey">A monkey!</option>
+      <option value="giraffe">A giraffe!</option>
+      <option value="gorilla">A gorilla!</option>
+    </select>;
+  var markup = ReactDOMServer.renderToString(stub);
+  expect(markup).toContain('<option selected="" value="giraffe"');
+  expect(markup).not.toContain('<option selected="" value="monkey"');
+  expect(markup).not.toContain('<option selected="" value="gorilla"');
+});
+
+it('should support server-side rendering with multiple', function() {
+  var stub =
+    <select multiple={true} value={['giraffe', 'gorilla']} onChange={noop}>
+      <option value="monkey">A monkey!</option>
+      <option value="giraffe">A giraffe!</option>
+      <option value="gorilla">A gorilla!</option>
+    </select>;
+  var markup = ReactDOMServer.renderToString(stub);
+  expect(markup).toContain('<option selected="" value="giraffe"');
+  expect(markup).toContain('<option selected="" value="gorilla"');
+  expect(markup).not.toContain('<option selected="" value="monkey"');
+});
+
+it('should not control defaultValue if readding options', function() {
+  var container = document.createElement('div');
+
+  var select = ReactDOM.render(
+    <select multiple={true} defaultValue={['giraffe']}>
+      <option key="monkey" value="monkey">A monkey!</option>
+      <option key="giraffe" value="giraffe">A giraffe!</option>
+      <option key="gorilla" value="gorilla">A gorilla!</option>
+    </select>,
+    container
+  );
+  var node = ReactDOM.findDOMNode(select);
+
+  expect(node.options[0].selected).toBe(false);  // monkey
+  expect(node.options[1].selected).toBe(true);  // giraffe
+  expect(node.options[2].selected).toBe(false);  // gorilla
+
+  ReactDOM.render(
+    <select multiple={true} defaultValue={['giraffe']}>
+      <option key="monkey" value="monkey">A monkey!</option>
+      <option key="gorilla" value="gorilla">A gorilla!</option>
+    </select>,
+    container
+  );
+
+  expect(node.options[0].selected).toBe(false);  // monkey
+  expect(node.options[1].selected).toBe(false);  // gorilla
+
+  ReactDOM.render(
+    <select multiple={true} defaultValue={['giraffe']}>
+      <option key="monkey" value="monkey">A monkey!</option>
+      <option key="giraffe" value="giraffe">A giraffe!</option>
+      <option key="gorilla" value="gorilla">A gorilla!</option>
+    </select>,
+    container
+  );
+
+  expect(node.options[0].selected).toBe(false);  // monkey
+  expect(node.options[1].selected).toBe(false);  // giraffe
+  expect(node.options[2].selected).toBe(false);  // gorilla
+});
+
+it('should warn if value is null', function() {
+  spyOn(console, 'error');
+
+  ReactTestUtils.renderIntoDocument(<select value={null}><option value="test"/></select>);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    '`value` prop on `select` should not be null. ' +
+    'Consider using the empty string to clear the component or `undefined` ' +
+    'for uncontrolled components.'
+  );
+
+  ReactTestUtils.renderIntoDocument(<select value={null}><option value="test"/></select>);
+  expect(console.error.calls.count()).toBe(1);
+});
+
+it('should refresh state on change', function() {
+  var stub =
+    <select value="giraffe" onChange={noop}>
+      <option value="monkey">A monkey!</option>
+      <option value="giraffe">A giraffe!</option>
+      <option value="gorilla">A gorilla!</option>
+    </select>;
+  stub = ReactTestUtils.renderIntoDocument(stub);
+  var node = ReactDOM.findDOMNode(stub);
+
+  ReactTestUtils.Simulate.change(node);
+
+  expect(node.value).toBe('giraffe');
+});
+
+it('should warn if value and defaultValue props are specified', function() {
+  spyOn(console, 'error');
+  ReactTestUtils.renderIntoDocument(
+    <select value="giraffe" defaultValue="giraffe" readOnly={true}>
+      <option value="monkey">A monkey!</option>
+      <option value="giraffe">A giraffe!</option>
+      <option value="gorilla">A gorilla!</option>
+    </select>
+  );
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'Select elements must be either controlled or uncontrolled ' +
+    '(specify either the value prop, or the defaultValue prop, but not ' +
+    'both). Decide between using a controlled or uncontrolled select ' +
+    'element and remove one of these props. More info: ' +
+    'https://fb.me/react-controlled-components'
+  );
+
+  ReactTestUtils.renderIntoDocument(
+    <select value="giraffe" defaultValue="giraffe" readOnly={true}>
+      <option value="monkey">A monkey!</option>
+      <option value="giraffe">A giraffe!</option>
+      <option value="gorilla">A gorilla!</option>
+    </select>
+  );
+  expect(console.error.calls.count()).toBe(1);
+});
+
+it('should be able to safely remove select onChange', function() {
+  function changeView() {
+    ReactDOM.unmountComponentAtNode(container);
+  }
+
+  var container = document.createElement('div');
+  var stub =
+    <select value="giraffe" onChange={changeView}>
+      <option value="monkey">A monkey!</option>
+      <option value="giraffe">A giraffe!</option>
+      <option value="gorilla">A gorilla!</option>
+    </select>;
+  stub = ReactDOM.render(stub, container);
+  var node = ReactDOM.findDOMNode(stub);
+
+  expect(() => ReactTestUtils.Simulate.change(node)).not.toThrow(
+    "Cannot set property 'pendingUpdate' of null"
+  );
+});
+
+it('should select grandchild options nested inside an optgroup', function() {
+  var stub =
+    <select value="b" onChange={noop}>
+      <optgroup label="group">
         <option value="a">a</option>
         <option value="b">b</option>
         <option value="c">c</option>
-      </select>,
-      container
-    );
+      </optgroup>
+    </select>;
+  var container = document.createElement('div');
+  var node = ReactDOM.render(stub, container);
 
-    var node = ReactDOM.findDOMNode(stub);
-
-    expect(node.options[0].selected).toBe(true);  // a
-    expect(node.options[1].selected).toBe(true);  // b
-    expect(node.options[2].selected).toBe(false);  // c
-  });
-
-  it('should allow setting `value` with `objectToString`', function() {
-    var objectToString = {
-      animal: 'giraffe',
-      toString: function() {
-        return this.animal;
-      },
-    };
-
-    var el =
-      <select multiple={true} value={[objectToString]} onChange={noop}>
-        <option value="monkey">A monkey!</option>
-        <option value="giraffe">A giraffe!</option>
-        <option value="gorilla">A gorilla!</option>
-      </select>;
-    var container = document.createElement('div');
-    var stub = ReactDOM.render(el, container);
-    var node = ReactDOM.findDOMNode(stub);
-
-    expect(node.options[0].selected).toBe(false);  // monkey
-    expect(node.options[1].selected).toBe(true);  // giraffe
-    expect(node.options[2].selected).toBe(false);  // gorilla
-
-    // Changing the `value` prop should change the selected options.
-    objectToString.animal = 'monkey';
-
-    var el2 =
-      <select multiple={true} value={[objectToString]}>
-        <option value="monkey">A monkey!</option>
-        <option value="giraffe">A giraffe!</option>
-        <option value="gorilla">A gorilla!</option>
-      </select>;
-    ReactDOM.render(el2, container);
-
-    expect(node.options[0].selected).toBe(true);  // monkey
-    expect(node.options[1].selected).toBe(false);  // giraffe
-    expect(node.options[2].selected).toBe(false);  // gorilla
-  });
-
-  it('should allow switching to multiple', function() {
-    var stub =
-      <select defaultValue="giraffe">
-        <option value="monkey">A monkey!</option>
-        <option value="giraffe">A giraffe!</option>
-        <option value="gorilla">A gorilla!</option>
-      </select>;
-    var options = stub.props.children;
-    var container = document.createElement('div');
-    stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
-
-    expect(node.options[0].selected).toBe(false);  // monkey
-    expect(node.options[1].selected).toBe(true);  // giraffe
-    expect(node.options[2].selected).toBe(false);  // gorilla
-
-    // When making it multiple, giraffe and gorilla should be selected
-    ReactDOM.render(
-      <select multiple={true} defaultValue={['giraffe', 'gorilla']}>
-        {options}
-      </select>,
-      container
-    );
-
-    expect(node.options[0].selected).toBe(false);  // monkey
-    expect(node.options[1].selected).toBe(true);  // giraffe
-    expect(node.options[2].selected).toBe(true);  // gorilla
-  });
-
-  it('should allow switching from multiple', function() {
-    var stub =
-      <select multiple={true} defaultValue={['giraffe', 'gorilla']}>
-        <option value="monkey">A monkey!</option>
-        <option value="giraffe">A giraffe!</option>
-        <option value="gorilla">A gorilla!</option>
-      </select>;
-    var options = stub.props.children;
-    var container = document.createElement('div');
-    stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
-
-    expect(node.options[0].selected).toBe(false);  // monkey
-    expect(node.options[1].selected).toBe(true);  // giraffe
-    expect(node.options[2].selected).toBe(true);  // gorilla
-
-    // When removing multiple, defaultValue is applied again, being omitted
-    // means that "monkey" will be selected
-    ReactDOM.render(
-      <select defaultValue="gorilla">{options}</select>,
-      container
-    );
-
-
-    expect(node.options[0].selected).toBe(false);  // monkey
-    expect(node.options[1].selected).toBe(false);  // giraffe
-    expect(node.options[2].selected).toBe(true);  // gorilla
-  });
-
-  it('should remember value when switching to uncontrolled', function() {
-    var stub =
-      <select value={'giraffe'} onChange={noop}>
-        <option value="monkey">A monkey!</option>
-        <option value="giraffe">A giraffe!</option>
-        <option value="gorilla">A gorilla!</option>
-      </select>;
-    var options = stub.props.children;
-    var container = document.createElement('div');
-    stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
-
-    expect(node.options[0].selected).toBe(false);  // monkey
-    expect(node.options[1].selected).toBe(true);  // giraffe
-    expect(node.options[2].selected).toBe(false);  // gorilla
-
-    ReactDOM.render(<select>{options}</select>, container);
-
-    expect(node.options[0].selected).toBe(false);  // monkey
-    expect(node.options[1].selected).toBe(true);  // giraffe
-    expect(node.options[2].selected).toBe(false);  // gorilla
-  });
-
-  it('should remember updated value when switching to uncontrolled', function() {
-    var stub =
-      <select value={'giraffe'} onChange={noop}>
-        <option value="monkey">A monkey!</option>
-        <option value="giraffe">A giraffe!</option>
-        <option value="gorilla">A gorilla!</option>
-      </select>;
-    var options = stub.props.children;
-    var container = document.createElement('div');
-    stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
-
-    ReactDOM.render(
-      <select value="gorilla" onChange={noop}>{options}</select>,
-      container
-    );
-
-    expect(node.options[0].selected).toBe(false);  // monkey
-    expect(node.options[1].selected).toBe(false);  // giraffe
-    expect(node.options[2].selected).toBe(true);  // gorilla
-
-    ReactDOM.render(<select>{options}</select>, container);
-
-    expect(node.options[0].selected).toBe(false);  // monkey
-    expect(node.options[1].selected).toBe(false);  // giraffe
-    expect(node.options[2].selected).toBe(true);  // gorilla
-  });
-
-  it('should support ReactLink', function() {
-    var link = new ReactLink('giraffe', jest.fn());
-    var stub =
-      <select valueLink={link}>
-        <option value="monkey">A monkey!</option>
-        <option value="giraffe">A giraffe!</option>
-        <option value="gorilla">A gorilla!</option>
-      </select>;
-
-    spyOn(console, 'error');
-
-    stub = ReactTestUtils.renderIntoDocument(stub);
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      '`valueLink` prop on `select` is deprecated; set `value` and `onChange` instead.'
-    );
-
-    var node = ReactDOM.findDOMNode(stub);
-
-    expect(node.options[0].selected).toBe(false);  // monkey
-    expect(node.options[1].selected).toBe(true);  // giraffe
-    expect(node.options[2].selected).toBe(false);  // gorilla
-    expect(link.requestChange.mock.calls.length).toBe(0);
-
-    node.options[1].selected = false;
-    node.options[2].selected = true;
-    ReactTestUtils.Simulate.change(node);
-
-    expect(link.requestChange.mock.calls.length).toBe(1);
-    expect(link.requestChange.mock.calls[0][0]).toEqual('gorilla');
-
-  });
-
-  it('should support server-side rendering', function() {
-    var stub =
-      <select value="giraffe" onChange={noop}>
-        <option value="monkey">A monkey!</option>
-        <option value="giraffe">A giraffe!</option>
-        <option value="gorilla">A gorilla!</option>
-      </select>;
-    var markup = ReactDOMServer.renderToString(stub);
-    expect(markup).toContain('<option selected="" value="giraffe"');
-    expect(markup).not.toContain('<option selected="" value="monkey"');
-    expect(markup).not.toContain('<option selected="" value="gorilla"');
-  });
-
-  it('should support server-side rendering with defaultValue', function() {
-    var stub =
-      <select defaultValue="giraffe">
-        <option value="monkey">A monkey!</option>
-        <option value="giraffe">A giraffe!</option>
-        <option value="gorilla">A gorilla!</option>
-      </select>;
-    var markup = ReactDOMServer.renderToString(stub);
-    expect(markup).toContain('<option selected="" value="giraffe"');
-    expect(markup).not.toContain('<option selected="" value="monkey"');
-    expect(markup).not.toContain('<option selected="" value="gorilla"');
-  });
-
-  it('should support server-side rendering with multiple', function() {
-    var stub =
-      <select multiple={true} value={['giraffe', 'gorilla']} onChange={noop}>
-        <option value="monkey">A monkey!</option>
-        <option value="giraffe">A giraffe!</option>
-        <option value="gorilla">A gorilla!</option>
-      </select>;
-    var markup = ReactDOMServer.renderToString(stub);
-    expect(markup).toContain('<option selected="" value="giraffe"');
-    expect(markup).toContain('<option selected="" value="gorilla"');
-    expect(markup).not.toContain('<option selected="" value="monkey"');
-  });
-
-  it('should not control defaultValue if readding options', function() {
-    var container = document.createElement('div');
-
-    var select = ReactDOM.render(
-      <select multiple={true} defaultValue={['giraffe']}>
-        <option key="monkey" value="monkey">A monkey!</option>
-        <option key="giraffe" value="giraffe">A giraffe!</option>
-        <option key="gorilla" value="gorilla">A gorilla!</option>
-      </select>,
-      container
-    );
-    var node = ReactDOM.findDOMNode(select);
-
-    expect(node.options[0].selected).toBe(false);  // monkey
-    expect(node.options[1].selected).toBe(true);  // giraffe
-    expect(node.options[2].selected).toBe(false);  // gorilla
-
-    ReactDOM.render(
-      <select multiple={true} defaultValue={['giraffe']}>
-        <option key="monkey" value="monkey">A monkey!</option>
-        <option key="gorilla" value="gorilla">A gorilla!</option>
-      </select>,
-      container
-    );
-
-    expect(node.options[0].selected).toBe(false);  // monkey
-    expect(node.options[1].selected).toBe(false);  // gorilla
-
-    ReactDOM.render(
-      <select multiple={true} defaultValue={['giraffe']}>
-        <option key="monkey" value="monkey">A monkey!</option>
-        <option key="giraffe" value="giraffe">A giraffe!</option>
-        <option key="gorilla" value="gorilla">A gorilla!</option>
-      </select>,
-      container
-    );
-
-    expect(node.options[0].selected).toBe(false);  // monkey
-    expect(node.options[1].selected).toBe(false);  // giraffe
-    expect(node.options[2].selected).toBe(false);  // gorilla
-  });
-
-  it('should warn if value is null', function() {
-    spyOn(console, 'error');
-
-    ReactTestUtils.renderIntoDocument(<select value={null}><option value="test"/></select>);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      '`value` prop on `select` should not be null. ' +
-      'Consider using the empty string to clear the component or `undefined` ' +
-      'for uncontrolled components.'
-    );
-
-    ReactTestUtils.renderIntoDocument(<select value={null}><option value="test"/></select>);
-    expect(console.error.calls.count()).toBe(1);
-  });
-
-  it('should refresh state on change', function() {
-    var stub =
-      <select value="giraffe" onChange={noop}>
-        <option value="monkey">A monkey!</option>
-        <option value="giraffe">A giraffe!</option>
-        <option value="gorilla">A gorilla!</option>
-      </select>;
-    stub = ReactTestUtils.renderIntoDocument(stub);
-    var node = ReactDOM.findDOMNode(stub);
-
-    ReactTestUtils.Simulate.change(node);
-
-    expect(node.value).toBe('giraffe');
-  });
-
-  it('should warn if value and defaultValue props are specified', function() {
-    spyOn(console, 'error');
-    ReactTestUtils.renderIntoDocument(
-      <select value="giraffe" defaultValue="giraffe" readOnly={true}>
-        <option value="monkey">A monkey!</option>
-        <option value="giraffe">A giraffe!</option>
-        <option value="gorilla">A gorilla!</option>
-      </select>
-    );
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Select elements must be either controlled or uncontrolled ' +
-      '(specify either the value prop, or the defaultValue prop, but not ' +
-      'both). Decide between using a controlled or uncontrolled select ' +
-      'element and remove one of these props. More info: ' +
-      'https://fb.me/react-controlled-components'
-    );
-
-    ReactTestUtils.renderIntoDocument(
-      <select value="giraffe" defaultValue="giraffe" readOnly={true}>
-        <option value="monkey">A monkey!</option>
-        <option value="giraffe">A giraffe!</option>
-        <option value="gorilla">A gorilla!</option>
-      </select>
-    );
-    expect(console.error.calls.count()).toBe(1);
-  });
-
-  it('should be able to safely remove select onChange', function() {
-    function changeView() {
-      ReactDOM.unmountComponentAtNode(container);
-    }
-
-    var container = document.createElement('div');
-    var stub =
-      <select value="giraffe" onChange={changeView}>
-        <option value="monkey">A monkey!</option>
-        <option value="giraffe">A giraffe!</option>
-        <option value="gorilla">A gorilla!</option>
-      </select>;
-    stub = ReactDOM.render(stub, container);
-    var node = ReactDOM.findDOMNode(stub);
-
-    expect(() => ReactTestUtils.Simulate.change(node)).not.toThrow(
-      "Cannot set property 'pendingUpdate' of null"
-    );
-  });
-
-  it('should select grandchild options nested inside an optgroup', function() {
-    var stub =
-      <select value="b" onChange={noop}>
-        <optgroup label="group">
-          <option value="a">a</option>
-          <option value="b">b</option>
-          <option value="c">c</option>
-        </optgroup>
-      </select>;
-    var container = document.createElement('div');
-    var node = ReactDOM.render(stub, container);
-
-    expect(node.options[0].selected).toBe(false);  // a
-    expect(node.options[1].selected).toBe(true);   // b
-    expect(node.options[2].selected).toBe(false);  // c
-  });
+  expect(node.options[0].selected).toBe(false);  // a
+  expect(node.options[1].selected).toBe(true);   // b
+  expect(node.options[2].selected).toBe(false);  // c
 });

--- a/src/renderers/dom/client/wrappers/__tests__/ReactDOMTextarea-test.js
+++ b/src/renderers/dom/client/wrappers/__tests__/ReactDOMTextarea-test.js
@@ -13,393 +13,390 @@
 
 var emptyFunction = require('emptyFunction');
 
-describe('ReactDOMTextarea', function() {
-  var React;
-  var ReactDOM;
-  var ReactDOMServer;
-  var ReactLink;
-  var ReactTestUtils;
+var React;
+var ReactDOM;
+var ReactDOMServer;
+var ReactLink;
+var ReactTestUtils;
 
-  var renderTextarea;
+var renderTextarea;
 
-  beforeEach(function() {
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactDOMServer = require('ReactDOMServer');
-    ReactLink = require('ReactLink');
-    ReactTestUtils = require('ReactTestUtils');
+beforeEach(function() {
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactDOMServer = require('ReactDOMServer');
+  ReactLink = require('ReactLink');
+  ReactTestUtils = require('ReactTestUtils');
 
-    renderTextarea = function(component, container) {
-      if (!container) {
-        container = document.createElement('div');
-      }
-      var node = ReactDOM.render(component, container);
+  renderTextarea = function(component, container) {
+    if (!container) {
+      container = document.createElement('div');
+    }
+    var node = ReactDOM.render(component, container);
 
-      // Fixing jsdom's quirky behavior -- in reality, the parser should strip
-      // off the leading newline but we need to do it by hand here.
-      node.defaultValue = node.innerHTML.replace(/^\n/, '');
-      return node;
-    };
+    // Fixing jsdom's quirky behavior -- in reality, the parser should strip
+    // off the leading newline but we need to do it by hand here.
+    node.defaultValue = node.innerHTML.replace(/^\n/, '');
+    return node;
+  };
+});
+
+it('should allow setting `defaultValue`', function() {
+  var container = document.createElement('div');
+  var node = renderTextarea(<textarea defaultValue="giraffe" />, container);
+
+  expect(node.value).toBe('giraffe');
+
+  // Changing `defaultValue` should do nothing.
+  renderTextarea(<textarea defaultValue="gorilla" />, container);
+  expect(node.value).toEqual('giraffe');
+
+  node.value = 'cat';
+
+  renderTextarea(<textarea defaultValue="monkey" />, container);
+  expect(node.value).toEqual('cat');
+});
+
+it('should display `defaultValue` of number 0', function() {
+  var stub = <textarea defaultValue={0} />;
+  var node = renderTextarea(stub);
+
+  expect(node.value).toBe('0');
+});
+
+it('should display "false" for `defaultValue` of `false`', function() {
+  var stub = <textarea defaultValue={false} />;
+  var node = renderTextarea(stub);
+
+  expect(node.value).toBe('false');
+});
+
+it('should display "foobar" for `defaultValue` of `objToString`', function() {
+  var objToString = {
+    toString: function() {
+      return 'foobar';
+    },
+  };
+
+  var stub = <textarea defaultValue={objToString} />;
+  var node = renderTextarea(stub);
+
+  expect(node.value).toBe('foobar');
+});
+
+it('should set defaultValue', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(<textarea defaultValue="foo" />, container);
+  ReactDOM.render(<textarea defaultValue="bar" />, container);
+  ReactDOM.render(<textarea defaultValue="noise" />, container);
+  expect(container.firstChild.defaultValue).toBe('noise');
+});
+
+it('should not render value as an attribute', function() {
+  var stub = <textarea value="giraffe" onChange={emptyFunction} />;
+  var node = renderTextarea(stub);
+
+  expect(node.getAttribute('value')).toBe(null);
+});
+
+it('should display `value` of number 0', function() {
+  var stub = <textarea value={0} />;
+  var node = renderTextarea(stub);
+
+  expect(node.value).toBe('0');
+});
+
+it('should update defaultValue to empty string', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(<textarea defaultValue={'foo'} />, container);
+  ReactDOM.render(<textarea defaultValue={''} />, container);
+  expect(container.firstChild.defaultValue).toBe('');
+});
+
+it('should allow setting `value` to `giraffe`', function() {
+  var container = document.createElement('div');
+  var stub = <textarea value="giraffe" onChange={emptyFunction} />;
+  var node = renderTextarea(stub, container);
+
+  expect(node.value).toBe('giraffe');
+
+  stub = ReactDOM.render(
+    <textarea value="gorilla" onChange={emptyFunction} />,
+    container
+  );
+  expect(node.value).toEqual('gorilla');
+});
+
+it('should render defaultValue for SSR', function() {
+  var markup = ReactDOMServer.renderToString(<textarea defaultValue="1" />);
+  var div = document.createElement('div');
+  div.innerHTML = markup;
+  expect(div.firstChild.innerHTML).toBe('1');
+  expect(div.firstChild.getAttribute('defaultValue')).toBe(null);
+});
+
+it('should render value for SSR', function() {
+  var element = <textarea value="1" onChange={function() {}} />;
+  var markup = ReactDOMServer.renderToString(element);
+  var div = document.createElement('div');
+  div.innerHTML = markup;
+  expect(div.firstChild.innerHTML).toBe('1');
+  expect(div.firstChild.getAttribute('defaultValue')).toBe(null);
+});
+
+it('should allow setting `value` to `true`', function() {
+  var container = document.createElement('div');
+  var stub = <textarea value="giraffe" onChange={emptyFunction} />;
+  var node = renderTextarea(stub, container);
+
+  expect(node.value).toBe('giraffe');
+
+  stub = ReactDOM.render(
+    <textarea value={true} onChange={emptyFunction} />,
+    container
+  );
+  expect(node.value).toEqual('true');
+});
+
+it('should allow setting `value` to `false`', function() {
+  var container = document.createElement('div');
+  var stub = <textarea value="giraffe" onChange={emptyFunction} />;
+  var node = renderTextarea(stub, container);
+
+  expect(node.value).toBe('giraffe');
+
+  stub = ReactDOM.render(
+    <textarea value={false} onChange={emptyFunction} />,
+    container
+  );
+  expect(node.value).toEqual('false');
+});
+
+it('should allow setting `value` to `objToString`', function() {
+  var container = document.createElement('div');
+  var stub = <textarea value="giraffe" onChange={emptyFunction} />;
+  var node = renderTextarea(stub, container);
+
+  expect(node.value).toBe('giraffe');
+
+  var objToString = {
+    toString: function() {
+      return 'foo';
+    },
+  };
+  stub = ReactDOM.render(
+    <textarea value={objToString} onChange={emptyFunction} />,
+    container
+  );
+  expect(node.value).toEqual('foo');
+});
+
+it('should take updates to `defaultValue` for uncontrolled textarea', function() {
+  var container = document.createElement('div');
+
+  var node = ReactDOM.render(<textarea defaultValue="0" />, container);
+
+  expect(node.value).toBe('0');
+
+  ReactDOM.render(<textarea defaultValue="1" />, container);
+
+  expect(node.value).toBe('0');
+});
+
+it('should take updates to children in lieu of `defaultValue` for uncontrolled textarea', function() {
+  var container = document.createElement('div');
+
+  var node = ReactDOM.render(<textarea defaultValue="0" />, container);
+
+  expect(node.value).toBe('0');
+
+  spyOn(console, 'error'); // deprecation warning for `children` content
+
+  ReactDOM.render(<textarea>1</textarea>, container);
+
+  expect(node.value).toBe('0');
+});
+
+it('should not incur unnecessary DOM mutations', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(<textarea value="a" onChange={emptyFunction} />, container);
+
+  var node = container.firstChild;
+  var nodeValue = 'a';
+  var nodeValueSetter = jest.genMockFn();
+  Object.defineProperty(node, 'value', {
+    get: function() {
+      return nodeValue;
+    },
+    set: nodeValueSetter.mockImplementation(function(newValue) {
+      nodeValue = newValue;
+    }),
   });
 
-  it('should allow setting `defaultValue`', function() {
-    var container = document.createElement('div');
-    var node = renderTextarea(<textarea defaultValue="giraffe" />, container);
-
-    expect(node.value).toBe('giraffe');
-
-    // Changing `defaultValue` should do nothing.
-    renderTextarea(<textarea defaultValue="gorilla" />, container);
-    expect(node.value).toEqual('giraffe');
-
-    node.value = 'cat';
-
-    renderTextarea(<textarea defaultValue="monkey" />, container);
-    expect(node.value).toEqual('cat');
-  });
-
-  it('should display `defaultValue` of number 0', function() {
-    var stub = <textarea defaultValue={0} />;
-    var node = renderTextarea(stub);
-
-    expect(node.value).toBe('0');
-  });
-
-  it('should display "false" for `defaultValue` of `false`', function() {
-    var stub = <textarea defaultValue={false} />;
-    var node = renderTextarea(stub);
-
-    expect(node.value).toBe('false');
-  });
-
-  it('should display "foobar" for `defaultValue` of `objToString`', function() {
-    var objToString = {
-      toString: function() {
-        return 'foobar';
-      },
-    };
-
-    var stub = <textarea defaultValue={objToString} />;
-    var node = renderTextarea(stub);
-
-    expect(node.value).toBe('foobar');
-  });
-
-  it('should set defaultValue', function() {
-    var container = document.createElement('div');
-    ReactDOM.render(<textarea defaultValue="foo" />, container);
-    ReactDOM.render(<textarea defaultValue="bar" />, container);
-    ReactDOM.render(<textarea defaultValue="noise" />, container);
-    expect(container.firstChild.defaultValue).toBe('noise');
-  });
-
-  it('should not render value as an attribute', function() {
-    var stub = <textarea value="giraffe" onChange={emptyFunction} />;
-    var node = renderTextarea(stub);
-
-    expect(node.getAttribute('value')).toBe(null);
-  });
-
-  it('should display `value` of number 0', function() {
-    var stub = <textarea value={0} />;
-    var node = renderTextarea(stub);
-
-    expect(node.value).toBe('0');
-  });
-
-  it('should update defaultValue to empty string', function() {
-    var container = document.createElement('div');
-    ReactDOM.render(<textarea defaultValue={'foo'} />, container);
-    ReactDOM.render(<textarea defaultValue={''} />, container);
-    expect(container.firstChild.defaultValue).toBe('');
-  });
-
-  it('should allow setting `value` to `giraffe`', function() {
-    var container = document.createElement('div');
-    var stub = <textarea value="giraffe" onChange={emptyFunction} />;
-    var node = renderTextarea(stub, container);
-
-    expect(node.value).toBe('giraffe');
-
-    stub = ReactDOM.render(
-      <textarea value="gorilla" onChange={emptyFunction} />,
-      container
-    );
-    expect(node.value).toEqual('gorilla');
-  });
-
-  it('should render defaultValue for SSR', function() {
-    var markup = ReactDOMServer.renderToString(<textarea defaultValue="1" />);
-    var div = document.createElement('div');
-    div.innerHTML = markup;
-    expect(div.firstChild.innerHTML).toBe('1');
-    expect(div.firstChild.getAttribute('defaultValue')).toBe(null);
-  });
-
-  it('should render value for SSR', function() {
-    var element = <textarea value="1" onChange={function() {}} />;
-    var markup = ReactDOMServer.renderToString(element);
-    var div = document.createElement('div');
-    div.innerHTML = markup;
-    expect(div.firstChild.innerHTML).toBe('1');
-    expect(div.firstChild.getAttribute('defaultValue')).toBe(null);
-  });
-
-  it('should allow setting `value` to `true`', function() {
-    var container = document.createElement('div');
-    var stub = <textarea value="giraffe" onChange={emptyFunction} />;
-    var node = renderTextarea(stub, container);
-
-    expect(node.value).toBe('giraffe');
-
-    stub = ReactDOM.render(
-      <textarea value={true} onChange={emptyFunction} />,
-      container
-    );
-    expect(node.value).toEqual('true');
-  });
+  ReactDOM.render(<textarea value="a" onChange={emptyFunction} />, container);
+  expect(nodeValueSetter.mock.calls.length).toBe(0);
 
-  it('should allow setting `value` to `false`', function() {
-    var container = document.createElement('div');
-    var stub = <textarea value="giraffe" onChange={emptyFunction} />;
-    var node = renderTextarea(stub, container);
-
-    expect(node.value).toBe('giraffe');
+  ReactDOM.render(<textarea value="b" onChange={emptyFunction} />, container);
+  expect(nodeValueSetter.mock.calls.length).toBe(1);
+});
 
-    stub = ReactDOM.render(
-      <textarea value={false} onChange={emptyFunction} />,
-      container
-    );
-    expect(node.value).toEqual('false');
-  });
+it('should properly control a value of number `0`', function() {
+  var stub = <textarea value={0} onChange={emptyFunction} />;
+  var node = renderTextarea(stub);
 
-  it('should allow setting `value` to `objToString`', function() {
-    var container = document.createElement('div');
-    var stub = <textarea value="giraffe" onChange={emptyFunction} />;
-    var node = renderTextarea(stub, container);
+  node.value = 'giraffe';
+  ReactTestUtils.Simulate.change(node);
+  expect(node.value).toBe('0');
+});
 
-    expect(node.value).toBe('giraffe');
+it('should treat children like `defaultValue`', function() {
+  spyOn(console, 'error');
 
-    var objToString = {
-      toString: function() {
-        return 'foo';
-      },
-    };
-    stub = ReactDOM.render(
-      <textarea value={objToString} onChange={emptyFunction} />,
-      container
-    );
-    expect(node.value).toEqual('foo');
-  });
+  var container = document.createElement('div');
+  var stub = <textarea>giraffe</textarea>;
+  var node = renderTextarea(stub, container);
 
-  it('should take updates to `defaultValue` for uncontrolled textarea', function() {
-    var container = document.createElement('div');
+  expect(console.error.calls.count()).toBe(1);
+  expect(node.value).toBe('giraffe');
 
-    var node = ReactDOM.render(<textarea defaultValue="0" />, container);
+  // Changing children should do nothing, it functions like `defaultValue`.
+  stub = ReactDOM.render(<textarea>gorilla</textarea>, container);
+  expect(node.value).toEqual('giraffe');
+});
 
-    expect(node.value).toBe('0');
+it('should keep value when switching to uncontrolled element if not changed', function() {
+  var container = document.createElement('div');
 
-    ReactDOM.render(<textarea defaultValue="1" />, container);
+  var node = renderTextarea(<textarea value="kitten" onChange={emptyFunction} />, container);
 
-    expect(node.value).toBe('0');
-  });
+  expect(node.value).toBe('kitten');
 
-  it('should take updates to children in lieu of `defaultValue` for uncontrolled textarea', function() {
-    var container = document.createElement('div');
+  ReactDOM.render(<textarea defaultValue="gorilla"></textarea>, container);
 
-    var node = ReactDOM.render(<textarea defaultValue="0" />, container);
+  expect(node.value).toEqual('kitten');
+});
 
-    expect(node.value).toBe('0');
+it('should keep value when switching to uncontrolled element if changed', function() {
+  var container = document.createElement('div');
 
-    spyOn(console, 'error'); // deprecation warning for `children` content
+  var node = renderTextarea(<textarea value="kitten" onChange={emptyFunction} />, container);
 
-    ReactDOM.render(<textarea>1</textarea>, container);
+  expect(node.value).toBe('kitten');
 
-    expect(node.value).toBe('0');
-  });
+  ReactDOM.render(<textarea value="puppies" onChange={emptyFunction}></textarea>, container);
 
-  it('should not incur unnecessary DOM mutations', function() {
-    var container = document.createElement('div');
-    ReactDOM.render(<textarea value="a" onChange={emptyFunction} />, container);
+  expect(node.value).toBe('puppies');
 
-    var node = container.firstChild;
-    var nodeValue = 'a';
-    var nodeValueSetter = jest.genMockFn();
-    Object.defineProperty(node, 'value', {
-      get: function() {
-        return nodeValue;
-      },
-      set: nodeValueSetter.mockImplementation(function(newValue) {
-        nodeValue = newValue;
-      }),
-    });
+  ReactDOM.render(<textarea defaultValue="gorilla"></textarea>, container);
 
-    ReactDOM.render(<textarea value="a" onChange={emptyFunction} />, container);
-    expect(nodeValueSetter.mock.calls.length).toBe(0);
+  expect(node.value).toEqual('puppies');
+});
 
-    ReactDOM.render(<textarea value="b" onChange={emptyFunction} />, container);
-    expect(nodeValueSetter.mock.calls.length).toBe(1);
-  });
+it('should allow numbers as children', function() {
+  spyOn(console, 'error');
+  var node = renderTextarea(<textarea>{17}</textarea>);
+  expect(console.error.calls.count()).toBe(1);
+  expect(node.value).toBe('17');
+});
 
-  it('should properly control a value of number `0`', function() {
-    var stub = <textarea value={0} onChange={emptyFunction} />;
-    var node = renderTextarea(stub);
+it('should allow booleans as children', function() {
+  spyOn(console, 'error');
+  var node = renderTextarea(<textarea>{false}</textarea>);
+  expect(console.error.calls.count()).toBe(1);
+  expect(node.value).toBe('false');
+});
 
-    node.value = 'giraffe';
-    ReactTestUtils.Simulate.change(node);
-    expect(node.value).toBe('0');
-  });
+it('should allow objects as children', function() {
+  spyOn(console, 'error');
+  var obj = {
+    toString: function() {
+      return 'sharkswithlasers';
+    },
+  };
+  var node = renderTextarea(<textarea>{obj}</textarea>);
+  expect(console.error.calls.count()).toBe(1);
+  expect(node.value).toBe('sharkswithlasers');
+});
 
-  it('should treat children like `defaultValue`', function() {
-    spyOn(console, 'error');
+it('should throw with multiple or invalid children', function() {
+  spyOn(console, 'error');
 
-    var container = document.createElement('div');
-    var stub = <textarea>giraffe</textarea>;
-    var node = renderTextarea(stub, container);
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(node.value).toBe('giraffe');
-
-    // Changing children should do nothing, it functions like `defaultValue`.
-    stub = ReactDOM.render(<textarea>gorilla</textarea>, container);
-    expect(node.value).toEqual('giraffe');
-  });
-
-  it('should keep value when switching to uncontrolled element if not changed', function() {
-    var container = document.createElement('div');
-
-    var node = renderTextarea(<textarea value="kitten" onChange={emptyFunction} />, container);
-
-    expect(node.value).toBe('kitten');
-
-    ReactDOM.render(<textarea defaultValue="gorilla"></textarea>, container);
-
-    expect(node.value).toEqual('kitten');
-  });
-
-  it('should keep value when switching to uncontrolled element if changed', function() {
-    var container = document.createElement('div');
-
-    var node = renderTextarea(<textarea value="kitten" onChange={emptyFunction} />, container);
-
-    expect(node.value).toBe('kitten');
-
-    ReactDOM.render(<textarea value="puppies" onChange={emptyFunction}></textarea>, container);
-
-    expect(node.value).toBe('puppies');
-
-    ReactDOM.render(<textarea defaultValue="gorilla"></textarea>, container);
-
-    expect(node.value).toEqual('puppies');
-  });
-
-  it('should allow numbers as children', function() {
-    spyOn(console, 'error');
-    var node = renderTextarea(<textarea>{17}</textarea>);
-    expect(console.error.calls.count()).toBe(1);
-    expect(node.value).toBe('17');
-  });
-
-  it('should allow booleans as children', function() {
-    spyOn(console, 'error');
-    var node = renderTextarea(<textarea>{false}</textarea>);
-    expect(console.error.calls.count()).toBe(1);
-    expect(node.value).toBe('false');
-  });
-
-  it('should allow objects as children', function() {
-    spyOn(console, 'error');
-    var obj = {
-      toString: function() {
-        return 'sharkswithlasers';
-      },
-    };
-    var node = renderTextarea(<textarea>{obj}</textarea>);
-    expect(console.error.calls.count()).toBe(1);
-    expect(node.value).toBe('sharkswithlasers');
-  });
-
-  it('should throw with multiple or invalid children', function() {
-    spyOn(console, 'error');
-
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(
-        <textarea>{'hello'}{'there'}</textarea>
-      );
-    }).toThrow();
-
-    expect(console.error.calls.count()).toBe(1);
-
-    var node;
-    expect(function() {
-      node = renderTextarea(<textarea><strong /></textarea>);
-    }).not.toThrow();
-
-    expect(node.value).toBe('[object Object]');
-
-    expect(console.error.calls.count()).toBe(2);
-  });
-
-  it('should support ReactLink', function() {
-    var link = new ReactLink('yolo', jest.fn());
-    var instance = <textarea valueLink={link} />;
-
-    spyOn(console, 'error');
-    instance = renderTextarea(instance);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      '`valueLink` prop on `textarea` is deprecated; set `value` and `onChange` instead.'
-    );
-
-
-    expect(instance.value).toBe('yolo');
-    expect(link.value).toBe('yolo');
-    expect(link.requestChange.mock.calls.length).toBe(0);
-
-    instance.value = 'test';
-    ReactTestUtils.Simulate.change(instance);
-
-    expect(link.requestChange.mock.calls.length).toBe(1);
-    expect(link.requestChange.mock.calls[0][0]).toEqual('test');
-  });
-
-  it('should unmount', function() {
-    var container = document.createElement('div');
-    renderTextarea(<textarea />, container);
-    ReactDOM.unmountComponentAtNode(container);
-  });
-
-  it('should warn if value is null', function() {
-    spyOn(console, 'error');
-
-    ReactTestUtils.renderIntoDocument(<textarea value={null} />);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      '`value` prop on `textarea` should not be null. ' +
-      'Consider using the empty string to clear the component or `undefined` ' +
-      'for uncontrolled components.'
-    );
-
-    ReactTestUtils.renderIntoDocument(<textarea value={null} />);
-    expect(console.error.calls.count()).toBe(1);
-  });
-
-  it('should warn if value and defaultValue are specified', function() {
-    spyOn(console, 'error');
+  expect(function() {
     ReactTestUtils.renderIntoDocument(
-      <textarea value="foo" defaultValue="bar" readOnly={true} />
+      <textarea>{'hello'}{'there'}</textarea>
     );
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Textarea elements must be either controlled or uncontrolled ' +
-      '(specify either the value prop, or the defaultValue prop, but not ' +
-      'both). Decide between using a controlled or uncontrolled textarea ' +
-      'and remove one of these props. More info: ' +
-      'https://fb.me/react-controlled-components'
-    );
+  }).toThrow();
 
-    ReactTestUtils.renderIntoDocument(
-      <textarea value="foo" defaultValue="bar" readOnly={true} />
-    );
-    expect(console.error.calls.count()).toBe(1);
-  });
+  expect(console.error.calls.count()).toBe(1);
 
+  var node;
+  expect(function() {
+    node = renderTextarea(<textarea><strong /></textarea>);
+  }).not.toThrow();
+
+  expect(node.value).toBe('[object Object]');
+
+  expect(console.error.calls.count()).toBe(2);
+});
+
+it('should support ReactLink', function() {
+  var link = new ReactLink('yolo', jest.fn());
+  var instance = <textarea valueLink={link} />;
+
+  spyOn(console, 'error');
+  instance = renderTextarea(instance);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    '`valueLink` prop on `textarea` is deprecated; set `value` and `onChange` instead.'
+  );
+
+
+  expect(instance.value).toBe('yolo');
+  expect(link.value).toBe('yolo');
+  expect(link.requestChange.mock.calls.length).toBe(0);
+
+  instance.value = 'test';
+  ReactTestUtils.Simulate.change(instance);
+
+  expect(link.requestChange.mock.calls.length).toBe(1);
+  expect(link.requestChange.mock.calls[0][0]).toEqual('test');
+});
+
+it('should unmount', function() {
+  var container = document.createElement('div');
+  renderTextarea(<textarea />, container);
+  ReactDOM.unmountComponentAtNode(container);
+});
+
+it('should warn if value is null', function() {
+  spyOn(console, 'error');
+
+  ReactTestUtils.renderIntoDocument(<textarea value={null} />);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    '`value` prop on `textarea` should not be null. ' +
+    'Consider using the empty string to clear the component or `undefined` ' +
+    'for uncontrolled components.'
+  );
+
+  ReactTestUtils.renderIntoDocument(<textarea value={null} />);
+  expect(console.error.calls.count()).toBe(1);
+});
+
+it('should warn if value and defaultValue are specified', function() {
+  spyOn(console, 'error');
+  ReactTestUtils.renderIntoDocument(
+    <textarea value="foo" defaultValue="bar" readOnly={true} />
+  );
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'Textarea elements must be either controlled or uncontrolled ' +
+    '(specify either the value prop, or the defaultValue prop, but not ' +
+    'both). Decide between using a controlled or uncontrolled textarea ' +
+    'and remove one of these props. More info: ' +
+    'https://fb.me/react-controlled-components'
+  );
+
+  ReactTestUtils.renderIntoDocument(
+    <textarea value="foo" defaultValue="bar" readOnly={true} />
+  );
+  expect(console.error.calls.count()).toBe(1);
 });

--- a/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
@@ -22,554 +22,552 @@ var ReactServerRendering;
 var ID_ATTRIBUTE_NAME;
 var ROOT_ATTRIBUTE_NAME;
 
-describe('ReactServerRendering', function() {
-  beforeEach(function() {
-    jest.resetModuleRegistry();
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactMarkupChecksum = require('ReactMarkupChecksum');
-    ReactTestUtils = require('ReactTestUtils');
-    ReactReconcileTransaction = require('ReactReconcileTransaction');
+beforeEach(function() {
+  jest.resetModuleRegistry();
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactMarkupChecksum = require('ReactMarkupChecksum');
+  ReactTestUtils = require('ReactTestUtils');
+  ReactReconcileTransaction = require('ReactReconcileTransaction');
 
-    ExecutionEnvironment = require('ExecutionEnvironment');
-    ExecutionEnvironment.canUseDOM = false;
-    ReactServerRendering = require('ReactServerRendering');
+  ExecutionEnvironment = require('ExecutionEnvironment');
+  ExecutionEnvironment.canUseDOM = false;
+  ReactServerRendering = require('ReactServerRendering');
 
-    var DOMProperty = require('DOMProperty');
-    ID_ATTRIBUTE_NAME = DOMProperty.ID_ATTRIBUTE_NAME;
-    ROOT_ATTRIBUTE_NAME = DOMProperty.ROOT_ATTRIBUTE_NAME;
+  var DOMProperty = require('DOMProperty');
+  ID_ATTRIBUTE_NAME = DOMProperty.ID_ATTRIBUTE_NAME;
+  ROOT_ATTRIBUTE_NAME = DOMProperty.ROOT_ATTRIBUTE_NAME;
+});
+
+describe('renderToString', function() {
+  it('should generate simple markup', function() {
+    var response = ReactServerRendering.renderToString(
+      <span>hello world</span>
+    );
+    expect(response).toMatch(new RegExp(
+      '<span ' + ROOT_ATTRIBUTE_NAME + '="" ' +
+        ID_ATTRIBUTE_NAME + '="[^"]+" ' +
+        ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="[^"]+">hello world</span>'
+    ));
   });
 
-  describe('renderToString', function() {
-    it('should generate simple markup', function() {
+  it('should generate simple markup for self-closing tags', function() {
+    var response = ReactServerRendering.renderToString(
+      <img />
+    );
+    expect(response).toMatch(new RegExp(
+      '<img ' + ROOT_ATTRIBUTE_NAME + '="" ' +
+        ID_ATTRIBUTE_NAME + '="[^"]+" ' +
+        ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="[^"]+"/>'
+    ));
+  });
+
+  it('should generate simple markup for attribute with `>` symbol', function() {
+    var response = ReactServerRendering.renderToString(
+      <img data-attr=">" />
+    );
+    expect(response).toMatch(new RegExp(
+      '<img data-attr="&gt;" ' + ROOT_ATTRIBUTE_NAME + '="" ' +
+        ID_ATTRIBUTE_NAME + '="[^"]+" ' +
+        ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="[^"]+"/>'
+    ));
+  });
+
+  it('should generate comment markup for component returns null', function() {
+    class NullComponent extends React.Component {
+      render() {
+        return null;
+      }
+    }
+
+    var response = ReactServerRendering.renderToString(<NullComponent />);
+    expect(response).toBe('<!-- react-empty: 1 -->');
+  });
+
+  it('should not register event listeners', function() {
+    var EventPluginHub = require('EventPluginHub');
+    var cb = jest.fn();
+
+    ReactServerRendering.renderToString(
+      <span onClick={cb}>hello world</span>
+    );
+    expect(EventPluginHub.__getListenerBank()).toEqual({});
+  });
+
+  it('should render composite components', function() {
+    class Parent extends React.Component {
+      render() {
+        return <div><Child name="child" /></div>;
+      }
+    }
+
+    class Child extends React.Component {
+      render() {
+        return <span>My name is {this.props.name}</span>;
+      }
+    }
+
+    var response = ReactServerRendering.renderToString(
+      <Parent />
+    );
+    expect(response).toMatch(new RegExp(
+      '<div ' + ROOT_ATTRIBUTE_NAME + '="" ' +
+        ID_ATTRIBUTE_NAME + '="[^"]+" ' +
+        ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="[^"]+">' +
+        '<span ' + ID_ATTRIBUTE_NAME + '="[^"]+">' +
+          '<!-- react-text: [0-9]+ -->My name is <!-- /react-text -->' +
+          '<!-- react-text: [0-9]+ -->child<!-- /react-text -->' +
+        '</span>' +
+      '</div>'
+    ));
+  });
+
+  it('should only execute certain lifecycle methods', function() {
+    function runTest() {
+      var lifecycle = [];
+
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          lifecycle.push('getInitialState');
+          this.state = {name: 'TestComponent'};
+        }
+
+        componentWillMount() {
+          lifecycle.push('componentWillMount');
+        }
+
+        componentDidMount() {
+          lifecycle.push('componentDidMount');
+        }
+
+        render() {
+          lifecycle.push('render');
+          return <span>Component name: {this.state.name}</span>;
+        }
+
+        componentWillUpdate() {
+          lifecycle.push('componentWillUpdate');
+        }
+
+        componentDidUpdate() {
+          lifecycle.push('componentDidUpdate');
+        }
+
+        shouldComponentUpdate() {
+          lifecycle.push('shouldComponentUpdate');
+        }
+
+        componentWillReceiveProps() {
+          lifecycle.push('componentWillReceiveProps');
+        }
+
+        componentWillUnmount() {
+          lifecycle.push('componentWillUnmount');
+        }
+      }
+
       var response = ReactServerRendering.renderToString(
-        <span>hello world</span>
+        <TestComponent />
       );
+
       expect(response).toMatch(new RegExp(
         '<span ' + ROOT_ATTRIBUTE_NAME + '="" ' +
           ID_ATTRIBUTE_NAME + '="[^"]+" ' +
-          ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="[^"]+">hello world</span>'
-      ));
-    });
-
-    it('should generate simple markup for self-closing tags', function() {
-      var response = ReactServerRendering.renderToString(
-        <img />
-      );
-      expect(response).toMatch(new RegExp(
-        '<img ' + ROOT_ATTRIBUTE_NAME + '="" ' +
-          ID_ATTRIBUTE_NAME + '="[^"]+" ' +
-          ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="[^"]+"/>'
-      ));
-    });
-
-    it('should generate simple markup for attribute with `>` symbol', function() {
-      var response = ReactServerRendering.renderToString(
-        <img data-attr=">" />
-      );
-      expect(response).toMatch(new RegExp(
-        '<img data-attr="&gt;" ' + ROOT_ATTRIBUTE_NAME + '="" ' +
-          ID_ATTRIBUTE_NAME + '="[^"]+" ' +
-          ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="[^"]+"/>'
-      ));
-    });
-
-    it('should generate comment markup for component returns null', function() {
-      class NullComponent extends React.Component {
-        render() {
-          return null;
-        }
-      }
-
-      var response = ReactServerRendering.renderToString(<NullComponent />);
-      expect(response).toBe('<!-- react-empty: 1 -->');
-    });
-
-    it('should not register event listeners', function() {
-      var EventPluginHub = require('EventPluginHub');
-      var cb = jest.fn();
-
-      ReactServerRendering.renderToString(
-        <span onClick={cb}>hello world</span>
-      );
-      expect(EventPluginHub.__getListenerBank()).toEqual({});
-    });
-
-    it('should render composite components', function() {
-      class Parent extends React.Component {
-        render() {
-          return <div><Child name="child" /></div>;
-        }
-      }
-
-      class Child extends React.Component {
-        render() {
-          return <span>My name is {this.props.name}</span>;
-        }
-      }
-
-      var response = ReactServerRendering.renderToString(
-        <Parent />
-      );
-      expect(response).toMatch(new RegExp(
-        '<div ' + ROOT_ATTRIBUTE_NAME + '="" ' +
-          ID_ATTRIBUTE_NAME + '="[^"]+" ' +
           ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="[^"]+">' +
-          '<span ' + ID_ATTRIBUTE_NAME + '="[^"]+">' +
-            '<!-- react-text: [0-9]+ -->My name is <!-- /react-text -->' +
-            '<!-- react-text: [0-9]+ -->child<!-- /react-text -->' +
-          '</span>' +
-        '</div>'
+          '<!-- react-text: [0-9]+ -->Component name: <!-- /react-text -->' +
+          '<!-- react-text: [0-9]+ -->TestComponent<!-- /react-text -->' +
+        '</span>'
       ));
-    });
-
-    it('should only execute certain lifecycle methods', function() {
-      function runTest() {
-        var lifecycle = [];
-
-        class TestComponent extends React.Component {
-          constructor(props) {
-            super(props);
-            lifecycle.push('getInitialState');
-            this.state = {name: 'TestComponent'};
-          }
-
-          componentWillMount() {
-            lifecycle.push('componentWillMount');
-          }
-
-          componentDidMount() {
-            lifecycle.push('componentDidMount');
-          }
-
-          render() {
-            lifecycle.push('render');
-            return <span>Component name: {this.state.name}</span>;
-          }
-
-          componentWillUpdate() {
-            lifecycle.push('componentWillUpdate');
-          }
-
-          componentDidUpdate() {
-            lifecycle.push('componentDidUpdate');
-          }
-
-          shouldComponentUpdate() {
-            lifecycle.push('shouldComponentUpdate');
-          }
-
-          componentWillReceiveProps() {
-            lifecycle.push('componentWillReceiveProps');
-          }
-
-          componentWillUnmount() {
-            lifecycle.push('componentWillUnmount');
-          }
-        }
-
-        var response = ReactServerRendering.renderToString(
-          <TestComponent />
-        );
-
-        expect(response).toMatch(new RegExp(
-          '<span ' + ROOT_ATTRIBUTE_NAME + '="" ' +
-            ID_ATTRIBUTE_NAME + '="[^"]+" ' +
-            ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="[^"]+">' +
-            '<!-- react-text: [0-9]+ -->Component name: <!-- /react-text -->' +
-            '<!-- react-text: [0-9]+ -->TestComponent<!-- /react-text -->' +
-          '</span>'
-        ));
-        expect(lifecycle).toEqual(
-          ['getInitialState', 'componentWillMount', 'render']
-        );
-      }
-
-      runTest();
-
-      // This should work the same regardless of whether you can use DOM or not.
-      ExecutionEnvironment.canUseDOM = true;
-      runTest();
-    });
-
-    it('should have the correct mounting behavior', function() {
-      // This test is testing client-side behavior.
-      ExecutionEnvironment.canUseDOM = true;
-
-      var mountCount = 0;
-      var numClicks = 0;
-
-      class TestComponent extends React.Component {
-        componentDidMount() {
-          mountCount++;
-        }
-
-        click = () => {
-          numClicks++;
-        };
-
-        render() {
-          return (
-            <span ref="span" onClick={this.click}>Name: {this.props.name}</span>
-          );
-        }
-      }
-
-      var element = document.createElement('div');
-      ReactDOM.render(<TestComponent />, element);
-
-      var lastMarkup = element.innerHTML;
-
-      // Exercise the update path. Markup should not change,
-      // but some lifecycle methods should be run again.
-      ReactDOM.render(<TestComponent name="x" />, element);
-      expect(mountCount).toEqual(1);
-
-      // Unmount and remount. We should get another mount event and
-      // we should get different markup, as the IDs are unique each time.
-      ReactDOM.unmountComponentAtNode(element);
-      expect(element.innerHTML).toEqual('');
-      ReactDOM.render(<TestComponent name="x" />, element);
-      expect(mountCount).toEqual(2);
-      expect(element.innerHTML).not.toEqual(lastMarkup);
-
-      // Now kill the node and render it on top of server-rendered markup, as if
-      // we used server rendering. We should mount again, but the markup should
-      // be unchanged. We will append a sentinel at the end of innerHTML to be
-      // sure that innerHTML was not changed.
-      ReactDOM.unmountComponentAtNode(element);
-      expect(element.innerHTML).toEqual('');
-
-      ExecutionEnvironment.canUseDOM = false;
-      lastMarkup = ReactServerRendering.renderToString(
-        <TestComponent name="x" />
+      expect(lifecycle).toEqual(
+        ['getInitialState', 'componentWillMount', 'render']
       );
-      ExecutionEnvironment.canUseDOM = true;
-      element.innerHTML = lastMarkup;
+    }
 
-      var instance = ReactDOM.render(<TestComponent name="x" />, element);
-      expect(mountCount).toEqual(3);
-      expect(element.innerHTML).toBe(lastMarkup);
+    runTest();
 
-      // Ensure the events system works after mount into server markup
-      expect(numClicks).toEqual(0);
-      ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(instance.refs.span));
-      expect(numClicks).toEqual(1);
-
-      ReactDOM.unmountComponentAtNode(element);
-      expect(element.innerHTML).toEqual('');
-
-      // Now simulate a situation where the app is not idempotent. React should
-      // warn but do the right thing.
-      element.innerHTML = lastMarkup;
-      spyOn(console, 'error');
-      instance = ReactDOM.render(<TestComponent name="y" />, element);
-      expect(mountCount).toEqual(4);
-      expect(console.error.calls.count()).toBe(1);
-      expect(element.innerHTML.length > 0).toBe(true);
-      expect(element.innerHTML).not.toEqual(lastMarkup);
-
-      // Ensure the events system works after markup mismatch.
-      expect(numClicks).toEqual(1);
-      ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(instance.refs.span));
-      expect(numClicks).toEqual(2);
-    });
-
-    it('should throw with silly args', function() {
-      expect(
-        ReactServerRendering.renderToString.bind(
-          ReactServerRendering,
-          'not a component'
-        )
-      ).toThrowError(
-        'renderToString(): You must pass a valid ReactElement.'
-      );
-    });
+    // This should work the same regardless of whether you can use DOM or not.
+    ExecutionEnvironment.canUseDOM = true;
+    runTest();
   });
 
-  describe('renderToStaticMarkup', function() {
-    it('should not put checksum and React ID on components', function() {
-      class NestedComponent extends React.Component {
-        render() {
-          return <div>inner text</div>;
-        }
+  it('should have the correct mounting behavior', function() {
+    // This test is testing client-side behavior.
+    ExecutionEnvironment.canUseDOM = true;
+
+    var mountCount = 0;
+    var numClicks = 0;
+
+    class TestComponent extends React.Component {
+      componentDidMount() {
+        mountCount++;
       }
 
-      class TestComponent extends React.Component {
-        render() {
-          return <span><NestedComponent /></span>;
-        }
-      }
-
-      var response = ReactServerRendering.renderToStaticMarkup(
-        <TestComponent />
-      );
-
-      expect(response).toBe('<span><div>inner text</div></span>');
-    });
-
-    it('should not put checksum and React ID on text components', function() {
-      class TestComponent extends React.Component {
-        render() {
-          return <span>{'hello'} {'world'}</span>;
-        }
-      }
-
-      var response = ReactServerRendering.renderToStaticMarkup(
-        <TestComponent />
-      );
-
-      expect(response).toBe('<span>hello world</span>');
-    });
-
-    it('should not register event listeners', function() {
-      var EventPluginHub = require('EventPluginHub');
-      var cb = jest.fn();
-
-      ReactServerRendering.renderToString(
-        <span onClick={cb}>hello world</span>
-      );
-      expect(EventPluginHub.__getListenerBank()).toEqual({});
-    });
-
-    it('should only execute certain lifecycle methods', function() {
-      function runTest() {
-        var lifecycle = [];
-
-        class TestComponent extends React.Component {
-          constructor(props) {
-            super(props);
-            lifecycle.push('getInitialState');
-            this.state = {name: 'TestComponent'};
-          }
-
-          componentWillMount() {
-            lifecycle.push('componentWillMount');
-          }
-
-          componentDidMount() {
-            lifecycle.push('componentDidMount');
-          }
-
-          render() {
-            lifecycle.push('render');
-            return <span>Component name: {this.state.name}</span>;
-          }
-
-          componentWillUpdate() {
-            lifecycle.push('componentWillUpdate');
-          }
-
-          componentDidUpdate() {
-            lifecycle.push('componentDidUpdate');
-          }
-
-          shouldComponentUpdate() {
-            lifecycle.push('shouldComponentUpdate');
-          }
-
-          componentWillReceiveProps() {
-            lifecycle.push('componentWillReceiveProps');
-          }
-
-          componentWillUnmount() {
-            lifecycle.push('componentWillUnmount');
-          }
-        }
-
-        var response = ReactServerRendering.renderToStaticMarkup(
-          <TestComponent />
-        );
-
-        expect(response).toBe('<span>Component name: TestComponent</span>');
-        expect(lifecycle).toEqual(
-          ['getInitialState', 'componentWillMount', 'render']
-        );
-      }
-
-      runTest();
-
-      // This should work the same regardless of whether you can use DOM or not.
-      ExecutionEnvironment.canUseDOM = true;
-      runTest();
-    });
-
-    it('should throw with silly args', function() {
-      expect(
-        ReactServerRendering.renderToStaticMarkup.bind(
-          ReactServerRendering,
-          'not a component'
-        )
-      ).toThrowError(
-        'renderToStaticMarkup(): You must pass a valid ReactElement.'
-      );
-    });
-
-    it('allows setState in componentWillMount without using DOM', function() {
-      class Component extends React.Component {
-        componentWillMount() {
-          this.setState({text: 'hello, world'});
-        }
-
-        render() {
-          return <div>{this.state.text}</div>;
-        }
-      }
-
-      ReactReconcileTransaction.prototype.perform = function() {
-        // We shouldn't ever be calling this on the server
-        throw new Error('Browser reconcile transaction should not be used');
+      click = () => {
+        numClicks++;
       };
-      var markup = ReactServerRendering.renderToString(
-        <Component />
-      );
-      expect(markup.indexOf('hello, world') >= 0).toBe(true);
-    });
 
-    it('renders components with different batching strategies', function() {
-      class StaticComponent extends React.Component {
-        render() {
-          const staticContent = ReactServerRendering.renderToStaticMarkup(
-            <div>
-              <img src="foo-bar.jpg" />
-            </div>
-          );
-          return <div dangerouslySetInnerHTML={{__html: staticContent}} />;
-        }
+      render() {
+        return (
+          <span ref="span" onClick={this.click}>Name: {this.props.name}</span>
+        );
       }
+    }
 
-      class Component extends React.Component {
+    var element = document.createElement('div');
+    ReactDOM.render(<TestComponent />, element);
+
+    var lastMarkup = element.innerHTML;
+
+    // Exercise the update path. Markup should not change,
+    // but some lifecycle methods should be run again.
+    ReactDOM.render(<TestComponent name="x" />, element);
+    expect(mountCount).toEqual(1);
+
+    // Unmount and remount. We should get another mount event and
+    // we should get different markup, as the IDs are unique each time.
+    ReactDOM.unmountComponentAtNode(element);
+    expect(element.innerHTML).toEqual('');
+    ReactDOM.render(<TestComponent name="x" />, element);
+    expect(mountCount).toEqual(2);
+    expect(element.innerHTML).not.toEqual(lastMarkup);
+
+    // Now kill the node and render it on top of server-rendered markup, as if
+    // we used server rendering. We should mount again, but the markup should
+    // be unchanged. We will append a sentinel at the end of innerHTML to be
+    // sure that innerHTML was not changed.
+    ReactDOM.unmountComponentAtNode(element);
+    expect(element.innerHTML).toEqual('');
+
+    ExecutionEnvironment.canUseDOM = false;
+    lastMarkup = ReactServerRendering.renderToString(
+      <TestComponent name="x" />
+    );
+    ExecutionEnvironment.canUseDOM = true;
+    element.innerHTML = lastMarkup;
+
+    var instance = ReactDOM.render(<TestComponent name="x" />, element);
+    expect(mountCount).toEqual(3);
+    expect(element.innerHTML).toBe(lastMarkup);
+
+    // Ensure the events system works after mount into server markup
+    expect(numClicks).toEqual(0);
+    ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(instance.refs.span));
+    expect(numClicks).toEqual(1);
+
+    ReactDOM.unmountComponentAtNode(element);
+    expect(element.innerHTML).toEqual('');
+
+    // Now simulate a situation where the app is not idempotent. React should
+    // warn but do the right thing.
+    element.innerHTML = lastMarkup;
+    spyOn(console, 'error');
+    instance = ReactDOM.render(<TestComponent name="y" />, element);
+    expect(mountCount).toEqual(4);
+    expect(console.error.calls.count()).toBe(1);
+    expect(element.innerHTML.length > 0).toBe(true);
+    expect(element.innerHTML).not.toEqual(lastMarkup);
+
+    // Ensure the events system works after markup mismatch.
+    expect(numClicks).toEqual(1);
+    ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(instance.refs.span));
+    expect(numClicks).toEqual(2);
+  });
+
+  it('should throw with silly args', function() {
+    expect(
+      ReactServerRendering.renderToString.bind(
+        ReactServerRendering,
+        'not a component'
+      )
+    ).toThrowError(
+      'renderToString(): You must pass a valid ReactElement.'
+    );
+  });
+});
+
+describe('renderToStaticMarkup', function() {
+  it('should not put checksum and React ID on components', function() {
+    class NestedComponent extends React.Component {
+      render() {
+        return <div>inner text</div>;
+      }
+    }
+
+    class TestComponent extends React.Component {
+      render() {
+        return <span><NestedComponent /></span>;
+      }
+    }
+
+    var response = ReactServerRendering.renderToStaticMarkup(
+      <TestComponent />
+    );
+
+    expect(response).toBe('<span><div>inner text</div></span>');
+  });
+
+  it('should not put checksum and React ID on text components', function() {
+    class TestComponent extends React.Component {
+      render() {
+        return <span>{'hello'} {'world'}</span>;
+      }
+    }
+
+    var response = ReactServerRendering.renderToStaticMarkup(
+      <TestComponent />
+    );
+
+    expect(response).toBe('<span>hello world</span>');
+  });
+
+  it('should not register event listeners', function() {
+    var EventPluginHub = require('EventPluginHub');
+    var cb = jest.fn();
+
+    ReactServerRendering.renderToString(
+      <span onClick={cb}>hello world</span>
+    );
+    expect(EventPluginHub.__getListenerBank()).toEqual({});
+  });
+
+  it('should only execute certain lifecycle methods', function() {
+    function runTest() {
+      var lifecycle = [];
+
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          lifecycle.push('getInitialState');
+          this.state = {name: 'TestComponent'};
+        }
+
         componentWillMount() {
-          this.setState({text: 'hello, world'});
+          lifecycle.push('componentWillMount');
+        }
+
+        componentDidMount() {
+          lifecycle.push('componentDidMount');
         }
 
         render() {
-          return <div>{this.state.text}</div>;
+          lifecycle.push('render');
+          return <span>Component name: {this.state.name}</span>;
+        }
+
+        componentWillUpdate() {
+          lifecycle.push('componentWillUpdate');
+        }
+
+        componentDidUpdate() {
+          lifecycle.push('componentDidUpdate');
+        }
+
+        shouldComponentUpdate() {
+          lifecycle.push('shouldComponentUpdate');
+        }
+
+        componentWillReceiveProps() {
+          lifecycle.push('componentWillReceiveProps');
+        }
+
+        componentWillUnmount() {
+          lifecycle.push('componentWillUnmount');
         }
       }
 
-      expect(
-        ReactServerRendering.renderToString.bind(
-          ReactServerRendering,
+      var response = ReactServerRendering.renderToStaticMarkup(
+        <TestComponent />
+      );
+
+      expect(response).toBe('<span>Component name: TestComponent</span>');
+      expect(lifecycle).toEqual(
+        ['getInitialState', 'componentWillMount', 'render']
+      );
+    }
+
+    runTest();
+
+    // This should work the same regardless of whether you can use DOM or not.
+    ExecutionEnvironment.canUseDOM = true;
+    runTest();
+  });
+
+  it('should throw with silly args', function() {
+    expect(
+      ReactServerRendering.renderToStaticMarkup.bind(
+        ReactServerRendering,
+        'not a component'
+      )
+    ).toThrowError(
+      'renderToStaticMarkup(): You must pass a valid ReactElement.'
+    );
+  });
+
+  it('allows setState in componentWillMount without using DOM', function() {
+    class Component extends React.Component {
+      componentWillMount() {
+        this.setState({text: 'hello, world'});
+      }
+
+      render() {
+        return <div>{this.state.text}</div>;
+      }
+    }
+
+    ReactReconcileTransaction.prototype.perform = function() {
+      // We shouldn't ever be calling this on the server
+      throw new Error('Browser reconcile transaction should not be used');
+    };
+    var markup = ReactServerRendering.renderToString(
+      <Component />
+    );
+    expect(markup.indexOf('hello, world') >= 0).toBe(true);
+  });
+
+  it('renders components with different batching strategies', function() {
+    class StaticComponent extends React.Component {
+      render() {
+        const staticContent = ReactServerRendering.renderToStaticMarkup(
           <div>
-            <StaticComponent />
-            <Component />
+            <img src="foo-bar.jpg" />
           </div>
-        )
-      ).not.toThrow();
-    });
-  });
-
-  it('warns with a no-op when an async setState is triggered', function() {
-    class Foo extends React.Component {
-      componentWillMount() {
-        this.setState({text: 'hello'});
-        setTimeout(() => {
-          this.setState({text: 'error'});
-        });
-      }
-      render() {
-        return <div onClick={() => {}}>{this.state.text}</div>;
+        );
+        return <div dangerouslySetInnerHTML={{__html: staticContent}} />;
       }
     }
 
-    spyOn(console, 'error');
-    ReactServerRendering.renderToString(<Foo />);
-    jest.runOnlyPendingTimers();
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.mostRecent().args[0]).toBe(
-      'Warning: setState(...): Can only update a mounting component.' +
-      ' This usually means you called setState() outside componentWillMount() on the server.' +
-      ' This is a no-op. Please check the code for the Foo component.'
-    );
-    var markup = ReactServerRendering.renderToStaticMarkup(<Foo />);
-    expect(markup).toBe('<div>hello</div>');
-  });
-
-  it('warns with a no-op when an async replaceState is triggered', function() {
-    var Bar = React.createClass({
-      componentWillMount: function() {
-        this.replaceState({text: 'hello'});
-        setTimeout(() => {
-          this.replaceState({text: 'error'});
-        });
-      },
-      render: function() {
-        return <div onClick={() => {}}>{this.state.text}</div>;
-      },
-    });
-
-    spyOn(console, 'error');
-    ReactServerRendering.renderToString(<Bar />);
-    jest.runOnlyPendingTimers();
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.mostRecent().args[0]).toBe(
-      'Warning: replaceState(...): Can only update a mounting component. ' +
-      'This usually means you called replaceState() outside componentWillMount() on the server. ' +
-      'This is a no-op. Please check the code for the Bar component.'
-    );
-    var markup = ReactServerRendering.renderToStaticMarkup(<Bar />);
-    expect(markup).toBe('<div>hello</div>');
-  });
-
-  it('warns with a no-op when an async forceUpdate is triggered', function() {
-    class Baz extends React.Component {
+    class Component extends React.Component {
       componentWillMount() {
+        this.setState({text: 'hello, world'});
+      }
+
+      render() {
+        return <div>{this.state.text}</div>;
+      }
+    }
+
+    expect(
+      ReactServerRendering.renderToString.bind(
+        ReactServerRendering,
+        <div>
+          <StaticComponent />
+          <Component />
+        </div>
+      )
+    ).not.toThrow();
+  });
+});
+
+it('warns with a no-op when an async setState is triggered', function() {
+  class Foo extends React.Component {
+    componentWillMount() {
+      this.setState({text: 'hello'});
+      setTimeout(() => {
+        this.setState({text: 'error'});
+      });
+    }
+    render() {
+      return <div onClick={() => {}}>{this.state.text}</div>;
+    }
+  }
+
+  spyOn(console, 'error');
+  ReactServerRendering.renderToString(<Foo />);
+  jest.runOnlyPendingTimers();
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.mostRecent().args[0]).toBe(
+    'Warning: setState(...): Can only update a mounting component.' +
+    ' This usually means you called setState() outside componentWillMount() on the server.' +
+    ' This is a no-op. Please check the code for the Foo component.'
+  );
+  var markup = ReactServerRendering.renderToStaticMarkup(<Foo />);
+  expect(markup).toBe('<div>hello</div>');
+});
+
+it('warns with a no-op when an async replaceState is triggered', function() {
+  var Bar = React.createClass({
+    componentWillMount: function() {
+      this.replaceState({text: 'hello'});
+      setTimeout(() => {
+        this.replaceState({text: 'error'});
+      });
+    },
+    render: function() {
+      return <div onClick={() => {}}>{this.state.text}</div>;
+    },
+  });
+
+  spyOn(console, 'error');
+  ReactServerRendering.renderToString(<Bar />);
+  jest.runOnlyPendingTimers();
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.mostRecent().args[0]).toBe(
+    'Warning: replaceState(...): Can only update a mounting component. ' +
+    'This usually means you called replaceState() outside componentWillMount() on the server. ' +
+    'This is a no-op. Please check the code for the Bar component.'
+  );
+  var markup = ReactServerRendering.renderToStaticMarkup(<Bar />);
+  expect(markup).toBe('<div>hello</div>');
+});
+
+it('warns with a no-op when an async forceUpdate is triggered', function() {
+  class Baz extends React.Component {
+    componentWillMount() {
+      this.forceUpdate();
+      setTimeout(() => {
         this.forceUpdate();
-        setTimeout(() => {
-          this.forceUpdate();
-        });
-      }
-
-      render() {
-        return <div onClick={() => {}}></div>;
-      }
+      });
     }
 
-    spyOn(console, 'error');
-    ReactServerRendering.renderToString(<Baz />);
-    jest.runOnlyPendingTimers();
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.mostRecent().args[0]).toBe(
-      'Warning: forceUpdate(...): Can only update a mounting component. ' +
-      'This usually means you called forceUpdate() outside componentWillMount() on the server. ' +
-      'This is a no-op. Please check the code for the Baz component.'
-    );
-    var markup = ReactServerRendering.renderToStaticMarkup(<Baz />);
-    expect(markup).toBe('<div></div>');
-  });
-
-  it('warns when children are mutated before render', function() {
-    function normalizeCodeLocInfo(str) {
-      return str.replace(/\(at .+?:\d+\)/g, '(at **)');
+    render() {
+      return <div onClick={() => {}}></div>;
     }
+  }
 
-    spyOn(console, 'error');
-    var children = [<span key={0} />, <span key={1} />, <span key={2} />];
-    var element = <div>{children}</div>;
-    children[1] = <p key={1} />; // Mutation is illegal
-    ReactServerRendering.renderToString(element);
-    expect(console.error.calls.count()).toBe(1);
-    expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-      'Warning: Component\'s children should not be mutated.\n    in div (at **)'
-    );
-  });
+  spyOn(console, 'error');
+  ReactServerRendering.renderToString(<Baz />);
+  jest.runOnlyPendingTimers();
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.mostRecent().args[0]).toBe(
+    'Warning: forceUpdate(...): Can only update a mounting component. ' +
+    'This usually means you called forceUpdate() outside componentWillMount() on the server. ' +
+    'This is a no-op. Please check the code for the Baz component.'
+  );
+  var markup = ReactServerRendering.renderToStaticMarkup(<Baz />);
+  expect(markup).toBe('<div></div>');
+});
 
-  it('should warn when children are mutated', function() {
-    function normalizeCodeLocInfo(str) {
-      return str.replace(/\(at .+?:\d+\)/g, '(at **)');
-    }
+it('warns when children are mutated before render', function() {
+  function normalizeCodeLocInfo(str) {
+    return str.replace(/\(at .+?:\d+\)/g, '(at **)');
+  }
 
-    spyOn(console, 'error');
-    var children = [<span key={0} />, <span key={1} />, <span key={2} />];
-    function Wrapper(props) {
-      props.children[1] = <p key={1} />; // Mutation is illegal
-      return <div>{props.children}</div>;
-    }
-    ReactServerRendering.renderToString(<Wrapper>{children}</Wrapper>);
-    expect(console.error.calls.count()).toBe(1);
-    expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-      'Warning: Component\'s children should not be mutated.\n    in Wrapper (at **)'
-    );
-  });
+  spyOn(console, 'error');
+  var children = [<span key={0} />, <span key={1} />, <span key={2} />];
+  var element = <div>{children}</div>;
+  children[1] = <p key={1} />; // Mutation is illegal
+  ReactServerRendering.renderToString(element);
+  expect(console.error.calls.count()).toBe(1);
+  expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+    'Warning: Component\'s children should not be mutated.\n    in div (at **)'
+  );
+});
+
+it('should warn when children are mutated', function() {
+  function normalizeCodeLocInfo(str) {
+    return str.replace(/\(at .+?:\d+\)/g, '(at **)');
+  }
+
+  spyOn(console, 'error');
+  var children = [<span key={0} />, <span key={1} />, <span key={2} />];
+  function Wrapper(props) {
+    props.children[1] = <p key={1} />; // Mutation is illegal
+    return <div>{props.children}</div>;
+  }
+  ReactServerRendering.renderToString(<Wrapper>{children}</Wrapper>);
+  expect(console.error.calls.count()).toBe(1);
+  expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+    'Warning: Component\'s children should not be mutated.\n    in Wrapper (at **)'
+  );
 });

--- a/src/renderers/dom/shared/__tests__/CSSProperty-test.js
+++ b/src/renderers/dom/shared/__tests__/CSSProperty-test.js
@@ -11,21 +11,18 @@
 
 'use strict';
 
-describe('CSSProperty', function() {
-  var CSSProperty;
+var CSSProperty;
 
-  beforeEach(function() {
-    jest.resetModuleRegistry();
-    CSSProperty = require('CSSProperty');
-  });
+beforeEach(function() {
+  jest.resetModuleRegistry();
+  CSSProperty = require('CSSProperty');
+});
 
-  it('should generate browser prefixes for its `isUnitlessNumber`', function() {
-    expect(CSSProperty.isUnitlessNumber.lineClamp).toBeTruthy();
-    expect(CSSProperty.isUnitlessNumber.WebkitLineClamp).toBeTruthy();
-    expect(CSSProperty.isUnitlessNumber.msFlexGrow).toBeTruthy();
-    expect(CSSProperty.isUnitlessNumber.MozFlexGrow).toBeTruthy();
-    expect(CSSProperty.isUnitlessNumber.msGridRow).toBeTruthy();
-    expect(CSSProperty.isUnitlessNumber.msGridColumn).toBeTruthy();
-  });
-
+it('should generate browser prefixes for its `isUnitlessNumber`', function() {
+  expect(CSSProperty.isUnitlessNumber.lineClamp).toBeTruthy();
+  expect(CSSProperty.isUnitlessNumber.WebkitLineClamp).toBeTruthy();
+  expect(CSSProperty.isUnitlessNumber.msFlexGrow).toBeTruthy();
+  expect(CSSProperty.isUnitlessNumber.MozFlexGrow).toBeTruthy();
+  expect(CSSProperty.isUnitlessNumber.msGridRow).toBeTruthy();
+  expect(CSSProperty.isUnitlessNumber.msGridColumn).toBeTruthy();
 });

--- a/src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
@@ -15,219 +15,217 @@ var React = require('React');
 var ReactDOM = require('ReactDOM');
 var ReactDOMServer = require('ReactDOMServer');
 
-describe('CSSPropertyOperations', function() {
-  var CSSPropertyOperations;
+var CSSPropertyOperations;
 
-  beforeEach(function() {
-    jest.resetModuleRegistry();
-    CSSPropertyOperations = require('CSSPropertyOperations');
+beforeEach(function() {
+  jest.resetModuleRegistry();
+  CSSPropertyOperations = require('CSSPropertyOperations');
+});
+
+it('should create markup for simple styles', function() {
+  expect(CSSPropertyOperations.createMarkupForStyles({
+    backgroundColor: '#3b5998',
+    display: 'none',
+  })).toBe('background-color:#3b5998;display:none;');
+});
+
+it('should ignore undefined styles', function() {
+  expect(CSSPropertyOperations.createMarkupForStyles({
+    backgroundColor: undefined,
+    display: 'none',
+  })).toBe('display:none;');
+});
+
+it('should ignore null styles', function() {
+  expect(CSSPropertyOperations.createMarkupForStyles({
+    backgroundColor: null,
+    display: 'none',
+  })).toBe('display:none;');
+});
+
+it('should return null for no styles', function() {
+  expect(CSSPropertyOperations.createMarkupForStyles({
+    backgroundColor: null,
+    display: null,
+  })).toBe(null);
+});
+
+it('should automatically append `px` to relevant styles', function() {
+  expect(CSSPropertyOperations.createMarkupForStyles({
+    left: 0,
+    margin: 16,
+    opacity: 0.5,
+    padding: '4px',
+  })).toBe('left:0;margin:16px;opacity:0.5;padding:4px;');
+});
+
+it('should trim values', function() {
+  expect(CSSPropertyOperations.createMarkupForStyles({
+    left: '16 ',
+    opacity: 0.5,
+    right: ' 4 ',
+  })).toBe('left:16;opacity:0.5;right:4;');
+});
+
+it('should not append `px` to styles that might need a number', function() {
+  var CSSProperty = require('CSSProperty');
+  var unitlessProperties = Object.keys(CSSProperty.isUnitlessNumber);
+  unitlessProperties.forEach(function(property) {
+    var styles = {};
+    styles[property] = 1;
+    expect(CSSPropertyOperations.createMarkupForStyles(styles))
+      .toMatch(/:1;$/);
   });
+});
 
-  it('should create markup for simple styles', function() {
-    expect(CSSPropertyOperations.createMarkupForStyles({
-      backgroundColor: '#3b5998',
-      display: 'none',
-    })).toBe('background-color:#3b5998;display:none;');
-  });
+it('should create vendor-prefixed markup correctly', function() {
+  expect(CSSPropertyOperations.createMarkupForStyles({
+    msTransition: 'none',
+    MozTransition: 'none',
+  })).toBe('-ms-transition:none;-moz-transition:none;');
+});
 
-  it('should ignore undefined styles', function() {
-    expect(CSSPropertyOperations.createMarkupForStyles({
-      backgroundColor: undefined,
-      display: 'none',
-    })).toBe('display:none;');
-  });
+it('should set style attribute when styles exist', function() {
+  var styles = {
+    backgroundColor: '#000',
+    display: 'none',
+  };
+  var div = <div style={styles} />;
+  var root = document.createElement('div');
+  div = ReactDOM.render(div, root);
+  expect(/style=".*"/.test(root.innerHTML)).toBe(true);
+});
 
-  it('should ignore null styles', function() {
-    expect(CSSPropertyOperations.createMarkupForStyles({
-      backgroundColor: null,
-      display: 'none',
-    })).toBe('display:none;');
-  });
+it('should not set style attribute when no styles exist', function() {
+  var styles = {
+    backgroundColor: null,
+    display: null,
+  };
+  var div = <div style={styles} />;
+  var html = ReactDOMServer.renderToString(div);
+  expect(/style=/.test(html)).toBe(false);
+});
 
-  it('should return null for no styles', function() {
-    expect(CSSPropertyOperations.createMarkupForStyles({
-      backgroundColor: null,
-      display: null,
-    })).toBe(null);
-  });
+it('should warn when using hyphenated style names', function() {
+  class Comp extends React.Component {
+    static displayName = 'Comp';
 
-  it('should automatically append `px` to relevant styles', function() {
-    expect(CSSPropertyOperations.createMarkupForStyles({
-      left: 0,
-      margin: 16,
-      opacity: 0.5,
-      padding: '4px',
-    })).toBe('left:0;margin:16px;opacity:0.5;padding:4px;');
-  });
-
-  it('should trim values', function() {
-    expect(CSSPropertyOperations.createMarkupForStyles({
-      left: '16 ',
-      opacity: 0.5,
-      right: ' 4 ',
-    })).toBe('left:16;opacity:0.5;right:4;');
-  });
-
-  it('should not append `px` to styles that might need a number', function() {
-    var CSSProperty = require('CSSProperty');
-    var unitlessProperties = Object.keys(CSSProperty.isUnitlessNumber);
-    unitlessProperties.forEach(function(property) {
-      var styles = {};
-      styles[property] = 1;
-      expect(CSSPropertyOperations.createMarkupForStyles(styles))
-        .toMatch(/:1;$/);
-    });
-  });
-
-  it('should create vendor-prefixed markup correctly', function() {
-    expect(CSSPropertyOperations.createMarkupForStyles({
-      msTransition: 'none',
-      MozTransition: 'none',
-    })).toBe('-ms-transition:none;-moz-transition:none;');
-  });
-
-  it('should set style attribute when styles exist', function() {
-    var styles = {
-      backgroundColor: '#000',
-      display: 'none',
-    };
-    var div = <div style={styles} />;
-    var root = document.createElement('div');
-    div = ReactDOM.render(div, root);
-    expect(/style=".*"/.test(root.innerHTML)).toBe(true);
-  });
-
-  it('should not set style attribute when no styles exist', function() {
-    var styles = {
-      backgroundColor: null,
-      display: null,
-    };
-    var div = <div style={styles} />;
-    var html = ReactDOMServer.renderToString(div);
-    expect(/style=/.test(html)).toBe(false);
-  });
-
-  it('should warn when using hyphenated style names', function() {
-    class Comp extends React.Component {
-      static displayName = 'Comp';
-
-      render() {
-        return <div style={{ 'background-color': 'crimson' }}/>;
-      }
+    render() {
+      return <div style={{ 'background-color': 'crimson' }}/>;
     }
+  }
 
-    spyOn(console, 'error');
-    var root = document.createElement('div');
-    ReactDOM.render(<Comp />, root);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toEqual(
-      'Warning: Unsupported style property background-color. Did you mean backgroundColor? ' +
-      'Check the render method of `Comp`.'
-    );
-  });
+  spyOn(console, 'error');
+  var root = document.createElement('div');
+  ReactDOM.render(<Comp />, root);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toEqual(
+    'Warning: Unsupported style property background-color. Did you mean backgroundColor? ' +
+    'Check the render method of `Comp`.'
+  );
+});
 
-  it('should warn when updating hyphenated style names', function() {
-    class Comp extends React.Component {
-      static displayName = 'Comp';
+it('should warn when updating hyphenated style names', function() {
+  class Comp extends React.Component {
+    static displayName = 'Comp';
 
-      render() {
-        return <div style={this.props.style} />;
-      }
+    render() {
+      return <div style={this.props.style} />;
     }
+  }
 
-    spyOn(console, 'error');
-    var styles = {
-      '-ms-transform': 'translate3d(0, 0, 0)',
-      '-webkit-transform': 'translate3d(0, 0, 0)',
-    };
-    var root = document.createElement('div');
-    ReactDOM.render(<Comp />, root);
-    ReactDOM.render(<Comp style={styles} />, root);
+  spyOn(console, 'error');
+  var styles = {
+    '-ms-transform': 'translate3d(0, 0, 0)',
+    '-webkit-transform': 'translate3d(0, 0, 0)',
+  };
+  var root = document.createElement('div');
+  ReactDOM.render(<Comp />, root);
+  ReactDOM.render(<Comp style={styles} />, root);
 
-    expect(console.error.calls.count()).toBe(2);
-    expect(console.error.calls.argsFor(0)[0]).toEqual(
-      'Warning: Unsupported style property -ms-transform. Did you mean msTransform? ' +
-      'Check the render method of `Comp`.'
-    );
-    expect(console.error.calls.argsFor(1)[0]).toEqual(
-      'Warning: Unsupported style property -webkit-transform. Did you mean WebkitTransform? ' +
-      'Check the render method of `Comp`.'
-    );
-  });
+  expect(console.error.calls.count()).toBe(2);
+  expect(console.error.calls.argsFor(0)[0]).toEqual(
+    'Warning: Unsupported style property -ms-transform. Did you mean msTransform? ' +
+    'Check the render method of `Comp`.'
+  );
+  expect(console.error.calls.argsFor(1)[0]).toEqual(
+    'Warning: Unsupported style property -webkit-transform. Did you mean WebkitTransform? ' +
+    'Check the render method of `Comp`.'
+  );
+});
 
-  it('warns when miscapitalizing vendored style names', function() {
-    class Comp extends React.Component {
-      static displayName = 'Comp';
+it('warns when miscapitalizing vendored style names', function() {
+  class Comp extends React.Component {
+    static displayName = 'Comp';
 
-      render() {
-        return (<div style={{
-          msTransform: 'translate3d(0, 0, 0)',
-          oTransform: 'translate3d(0, 0, 0)',
-          webkitTransform: 'translate3d(0, 0, 0)',
-        }} />);
-      }
+    render() {
+      return (<div style={{
+        msTransform: 'translate3d(0, 0, 0)',
+        oTransform: 'translate3d(0, 0, 0)',
+        webkitTransform: 'translate3d(0, 0, 0)',
+      }} />);
     }
+  }
 
-    spyOn(console, 'error');
-    var root = document.createElement('div');
-    ReactDOM.render(<Comp />, root);
-    // msTransform is correct already and shouldn't warn
-    expect(console.error.calls.count()).toBe(2);
-    expect(console.error.calls.argsFor(0)[0]).toEqual(
-      'Warning: Unsupported vendor-prefixed style property oTransform. ' +
-      'Did you mean OTransform? Check the render method of `Comp`.'
-    );
-    expect(console.error.calls.argsFor(1)[0]).toEqual(
-      'Warning: Unsupported vendor-prefixed style property webkitTransform. ' +
-      'Did you mean WebkitTransform? Check the render method of `Comp`.'
-    );
-  });
+  spyOn(console, 'error');
+  var root = document.createElement('div');
+  ReactDOM.render(<Comp />, root);
+  // msTransform is correct already and shouldn't warn
+  expect(console.error.calls.count()).toBe(2);
+  expect(console.error.calls.argsFor(0)[0]).toEqual(
+    'Warning: Unsupported vendor-prefixed style property oTransform. ' +
+    'Did you mean OTransform? Check the render method of `Comp`.'
+  );
+  expect(console.error.calls.argsFor(1)[0]).toEqual(
+    'Warning: Unsupported vendor-prefixed style property webkitTransform. ' +
+    'Did you mean WebkitTransform? Check the render method of `Comp`.'
+  );
+});
 
-  it('should warn about style having a trailing semicolon', function() {
-    class Comp extends React.Component {
-      static displayName = 'Comp';
+it('should warn about style having a trailing semicolon', function() {
+  class Comp extends React.Component {
+    static displayName = 'Comp';
 
-      render() {
-        return (<div style={{
-          fontFamily: 'Helvetica, arial',
-          backgroundImage: 'url(foo;bar)',
-          backgroundColor: 'blue;',
-          color: 'red;   ',
-        }} />);
-      }
+    render() {
+      return (<div style={{
+        fontFamily: 'Helvetica, arial',
+        backgroundImage: 'url(foo;bar)',
+        backgroundColor: 'blue;',
+        color: 'red;   ',
+      }} />);
     }
+  }
 
-    spyOn(console, 'error');
-    var root = document.createElement('div');
-    ReactDOM.render(<Comp />, root);
-    expect(console.error.calls.count()).toBe(2);
-    expect(console.error.calls.argsFor(0)[0]).toEqual(
-      'Warning: Style property values shouldn\'t contain a semicolon. ' +
-      'Check the render method of `Comp`. Try "backgroundColor: blue" instead.',
-    );
-    expect(console.error.calls.argsFor(1)[0]).toEqual(
-      'Warning: Style property values shouldn\'t contain a semicolon. ' +
-      'Check the render method of `Comp`. Try "color: red" instead.',
-    );
-  });
+  spyOn(console, 'error');
+  var root = document.createElement('div');
+  ReactDOM.render(<Comp />, root);
+  expect(console.error.calls.count()).toBe(2);
+  expect(console.error.calls.argsFor(0)[0]).toEqual(
+    'Warning: Style property values shouldn\'t contain a semicolon. ' +
+    'Check the render method of `Comp`. Try "backgroundColor: blue" instead.',
+  );
+  expect(console.error.calls.argsFor(1)[0]).toEqual(
+    'Warning: Style property values shouldn\'t contain a semicolon. ' +
+    'Check the render method of `Comp`. Try "color: red" instead.',
+  );
+});
 
-  it('should warn about style containing a NaN value', function() {
-    class Comp extends React.Component {
-      static displayName = 'Comp';
+it('should warn about style containing a NaN value', function() {
+  class Comp extends React.Component {
+    static displayName = 'Comp';
 
-      render() {
-        return <div style={{ fontSize: NaN }}/>;
-      }
+    render() {
+      return <div style={{ fontSize: NaN }}/>;
     }
+  }
 
-    spyOn(console, 'error');
-    var root = document.createElement('div');
-    ReactDOM.render(<Comp />, root);
+  spyOn(console, 'error');
+  var root = document.createElement('div');
+  ReactDOM.render(<Comp />, root);
 
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toEqual(
-      'Warning: `NaN` is an invalid value for the `fontSize` css style property. ' +
-      'Check the render method of `Comp`.'
-    );
-  });
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toEqual(
+    'Warning: `NaN` is an invalid value for the `fontSize` css style property. ' +
+    'Check the render method of `Comp`.'
+  );
 });

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -11,447 +11,445 @@
 
 'use strict';
 
-describe('DOMPropertyOperations', function() {
-  var DOMPropertyOperations;
-  var DOMProperty;
-  var ReactDOMComponentTree;
+var DOMPropertyOperations;
+var DOMProperty;
+var ReactDOMComponentTree;
+
+beforeEach(function() {
+  jest.resetModuleRegistry();
+  var ReactDefaultInjection = require('ReactDefaultInjection');
+  ReactDefaultInjection.inject();
+
+  DOMPropertyOperations = require('DOMPropertyOperations');
+  DOMProperty = require('DOMProperty');
+  ReactDOMComponentTree = require('ReactDOMComponentTree');
+});
+
+describe('createMarkupForProperty', function() {
+
+  it('should create markup for simple properties', function() {
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'name',
+      'simple'
+    )).toBe('name="simple"');
+
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'name',
+      false
+    )).toBe('name="false"');
+
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'name',
+      null
+    )).toBe('');
+  });
+
+  it('should work with the id attribute', function() {
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'id',
+      'simple'
+    )).toBe('id="simple"');
+  });
+
+  it('should create markup for boolean properties', function() {
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'checked',
+      'simple'
+    )).toBe('checked=""');
+
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'checked',
+      true
+    )).toBe('checked=""');
+
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'checked',
+      false
+    )).toBe('');
+
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'scoped',
+      true
+    )).toBe('scoped=""');
+  });
+
+  it('should create markup for booleanish properties', function() {
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'download',
+      'simple'
+    )).toBe('download="simple"');
+
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'download',
+      true
+    )).toBe('download=""');
+
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'download',
+      'true'
+    )).toBe('download="true"');
+
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'download',
+      false
+    )).toBe('');
+
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'download',
+      'false'
+    )).toBe('download="false"');
+
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'download',
+      undefined
+    )).toBe('');
+
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'download',
+      null
+    )).toBe('');
+
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'download',
+      0
+    )).toBe('download="0"');
+  });
+
+  it('should create markup for custom attributes', function() {
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'aria-label',
+      'simple'
+    )).toBe('aria-label="simple"');
+
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'aria-label',
+      false
+    )).toBe('aria-label="false"');
+
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'aria-label',
+      null
+    )).toBe('');
+  });
+
+  it('should create markup for numeric properties', function() {
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'start',
+      5
+    )).toBe('start="5"');
+
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'start',
+      0
+    )).toBe('start="0"');
+
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'size',
+      0
+    )).toBe('');
+
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'size',
+      1
+    )).toBe('size="1"');
+  });
+
+});
+
+describe('createMarkupForProperty', function() {
+
+  it('should allow custom properties on web components', function() {
+    expect(DOMPropertyOperations.createMarkupForCustomAttribute(
+      'awesomeness',
+      5
+    )).toBe('awesomeness="5"');
+
+    expect(DOMPropertyOperations.createMarkupForCustomAttribute(
+      'dev',
+      'jim'
+    )).toBe('dev="jim"');
+  });
+});
+
+describe('setValueForProperty', function() {
+  var stubNode;
+  var stubInstance;
 
   beforeEach(function() {
-    jest.resetModuleRegistry();
-    var ReactDefaultInjection = require('ReactDefaultInjection');
-    ReactDefaultInjection.inject();
-
-    DOMPropertyOperations = require('DOMPropertyOperations');
-    DOMProperty = require('DOMProperty');
-    ReactDOMComponentTree = require('ReactDOMComponentTree');
+    stubNode = document.createElement('div');
+    stubInstance = {_debugID: 1};
+    ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
   });
 
-  describe('createMarkupForProperty', function() {
-
-    it('should create markup for simple properties', function() {
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'name',
-        'simple'
-      )).toBe('name="simple"');
-
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'name',
-        false
-      )).toBe('name="false"');
-
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'name',
-        null
-      )).toBe('');
-    });
-
-    it('should work with the id attribute', function() {
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'id',
-        'simple'
-      )).toBe('id="simple"');
-    });
-
-    it('should create markup for boolean properties', function() {
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'checked',
-        'simple'
-      )).toBe('checked=""');
-
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'checked',
-        true
-      )).toBe('checked=""');
-
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'checked',
-        false
-      )).toBe('');
-
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'scoped',
-        true
-      )).toBe('scoped=""');
-    });
-
-    it('should create markup for booleanish properties', function() {
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'download',
-        'simple'
-      )).toBe('download="simple"');
-
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'download',
-        true
-      )).toBe('download=""');
-
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'download',
-        'true'
-      )).toBe('download="true"');
-
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'download',
-        false
-      )).toBe('');
-
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'download',
-        'false'
-      )).toBe('download="false"');
-
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'download',
-        undefined
-      )).toBe('');
-
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'download',
-        null
-      )).toBe('');
-
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'download',
-        0
-      )).toBe('download="0"');
-    });
-
-    it('should create markup for custom attributes', function() {
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'aria-label',
-        'simple'
-      )).toBe('aria-label="simple"');
-
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'aria-label',
-        false
-      )).toBe('aria-label="false"');
-
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'aria-label',
-        null
-      )).toBe('');
-    });
-
-    it('should create markup for numeric properties', function() {
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'start',
-        5
-      )).toBe('start="5"');
-
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'start',
-        0
-      )).toBe('start="0"');
-
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'size',
-        0
-      )).toBe('');
-
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'size',
-        1
-      )).toBe('size="1"');
-    });
-
+  it('should set values as properties by default', function() {
+    DOMPropertyOperations.setValueForProperty(stubNode, 'title', 'Tip!');
+    expect(stubNode.title).toBe('Tip!');
   });
 
-  describe('createMarkupForProperty', function() {
-
-    it('should allow custom properties on web components', function() {
-      expect(DOMPropertyOperations.createMarkupForCustomAttribute(
-        'awesomeness',
-        5
-      )).toBe('awesomeness="5"');
-
-      expect(DOMPropertyOperations.createMarkupForCustomAttribute(
-        'dev',
-        'jim'
-      )).toBe('dev="jim"');
-    });
+  it('should set values as attributes if necessary', function() {
+    DOMPropertyOperations.setValueForProperty(stubNode, 'role', '#');
+    expect(stubNode.getAttribute('role')).toBe('#');
+    expect(stubNode.role).toBeUndefined();
   });
 
-  describe('setValueForProperty', function() {
-    var stubNode;
-    var stubInstance;
-
-    beforeEach(function() {
-      stubNode = document.createElement('div');
-      stubInstance = {_debugID: 1};
-      ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
-    });
-
-    it('should set values as properties by default', function() {
-      DOMPropertyOperations.setValueForProperty(stubNode, 'title', 'Tip!');
-      expect(stubNode.title).toBe('Tip!');
-    });
-
-    it('should set values as attributes if necessary', function() {
-      DOMPropertyOperations.setValueForProperty(stubNode, 'role', '#');
-      expect(stubNode.getAttribute('role')).toBe('#');
-      expect(stubNode.role).toBeUndefined();
-    });
-
-    it('should set values as namespace attributes if necessary', function() {
-      spyOn(stubNode, 'setAttributeNS');
-      DOMPropertyOperations.setValueForProperty(
-        stubNode,
-        'xlinkHref',
-        'about:blank'
-      );
-      expect(stubNode.setAttributeNS.calls.count()).toBe(1);
-      expect(stubNode.setAttributeNS.calls.argsFor(0))
-        .toEqual(['http://www.w3.org/1999/xlink', 'xlink:href', 'about:blank']);
-    });
-
-    it('should set values as boolean properties', function() {
-      DOMPropertyOperations.setValueForProperty(stubNode, 'disabled', 'disabled');
-      expect(stubNode.getAttribute('disabled')).toBe('');
-      DOMPropertyOperations.setValueForProperty(stubNode, 'disabled', true);
-      expect(stubNode.getAttribute('disabled')).toBe('');
-      DOMPropertyOperations.setValueForProperty(stubNode, 'disabled', false);
-      expect(stubNode.getAttribute('disabled')).toBe(null);
-    });
-
-    it('should convert attribute values to string first', function() {
-      // Browsers default to this behavior, but some test environments do not.
-      // This ensures that we have consistent behavior.
-      var obj = {
-        toString: function() {
-          return '<html>';
-        },
-      };
-      DOMPropertyOperations.setValueForProperty(stubNode, 'role', obj);
-      expect(stubNode.getAttribute('role')).toBe('<html>');
-    });
-
-    it('should not remove empty attributes for special properties', function() {
-      stubNode = document.createElement('input');
-      ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
-
-      DOMPropertyOperations.setValueForProperty(stubNode, 'value', '');
-      // JSDOM does not behave correctly for attributes/properties
-      //expect(stubNode.getAttribute('value')).toBe('');
-      expect(stubNode.value).toBe('');
-    });
-
-    it('should remove for falsey boolean properties', function() {
-      DOMPropertyOperations.setValueForProperty(
-        stubNode,
-        'allowFullScreen',
-        false
-      );
-      expect(stubNode.hasAttribute('allowFullScreen')).toBe(false);
-    });
-
-    it('should remove when setting custom attr to null', function() {
-      DOMPropertyOperations.setValueForProperty(
-        stubNode,
-        'data-foo',
-        'bar'
-      );
-      expect(stubNode.hasAttribute('data-foo')).toBe(true);
-      DOMPropertyOperations.setValueForProperty(
-        stubNode,
-        'data-foo',
-        null
-      );
-      expect(stubNode.hasAttribute('data-foo')).toBe(false);
-    });
-
-    it('should use mutation method where applicable', function() {
-      var foobarSetter = jest.fn();
-      // inject foobar DOM property
-      DOMProperty.injection.injectDOMPropertyConfig({
-        Properties: {foobar: null},
-        DOMMutationMethods: {
-          foobar: foobarSetter,
-        },
-      });
-
-      DOMPropertyOperations.setValueForProperty(
-        stubNode,
-        'foobar',
-        'cows say moo'
-      );
-
-      expect(foobarSetter.mock.calls.length).toBe(1);
-      expect(foobarSetter.mock.calls[0][0]).toBe(stubNode);
-      expect(foobarSetter.mock.calls[0][1]).toBe('cows say moo');
-    });
-
-    it('should set className to empty string instead of null', function() {
-      DOMPropertyOperations.setValueForProperty(
-        stubNode,
-        'className',
-        'selected'
-      );
-      expect(stubNode.className).toBe('selected');
-
-      DOMPropertyOperations.setValueForProperty(
-        stubNode,
-        'className',
-        null
-      );
-      // className should be '', not 'null' or null (which becomes 'null' in
-      // some browsers)
-      expect(stubNode.className).toBe('');
-      expect(stubNode.getAttribute('class')).toBe(null);
-    });
-
-    it('should remove property properly for boolean properties', function() {
-      DOMPropertyOperations.setValueForProperty(
-        stubNode,
-        'hidden',
-        true
-      );
-      expect(stubNode.hasAttribute('hidden')).toBe(true);
-
-      DOMPropertyOperations.setValueForProperty(
-        stubNode,
-        'hidden',
-        false
-      );
-      expect(stubNode.hasAttribute('hidden')).toBe(false);
-    });
-
-    it('should remove property properly even with different name', function() {
-      // Suppose 'foobar' is a property that corresponds to the underlying
-      // 'className' property:
-      DOMProperty.injection.injectDOMPropertyConfig({
-        Properties: {foobar: DOMProperty.injection.MUST_USE_PROPERTY},
-        DOMPropertyNames: {
-          foobar: 'className',
-        },
-        DOMAttributeNames: {
-          foobar: 'class',
-        },
-      });
-
-      DOMPropertyOperations.setValueForProperty(
-        stubNode,
-        'foobar',
-        'selected'
-      );
-      expect(stubNode.className).toBe('selected');
-
-      DOMPropertyOperations.setValueForProperty(
-        stubNode,
-        'foobar',
-        null
-      );
-      // className should be '', not 'null' or null (which becomes 'null' in
-      // some browsers)
-      expect(stubNode.className).toBe('');
-    });
-
+  it('should set values as namespace attributes if necessary', function() {
+    spyOn(stubNode, 'setAttributeNS');
+    DOMPropertyOperations.setValueForProperty(
+      stubNode,
+      'xlinkHref',
+      'about:blank'
+    );
+    expect(stubNode.setAttributeNS.calls.count()).toBe(1);
+    expect(stubNode.setAttributeNS.calls.argsFor(0))
+      .toEqual(['http://www.w3.org/1999/xlink', 'xlink:href', 'about:blank']);
   });
 
-  describe('deleteValueForProperty', function() {
-    var stubNode;
-    var stubInstance;
-
-    beforeEach(function() {
-      stubNode = document.createElement('div');
-      stubInstance = {_debugID: 1};
-      ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
-    });
-
-    it('should remove attributes for normal properties', function() {
-      DOMPropertyOperations.setValueForProperty(stubNode, 'title', 'foo');
-      expect(stubNode.getAttribute('title')).toBe('foo');
-      expect(stubNode.title).toBe('foo');
-
-      DOMPropertyOperations.deleteValueForProperty(stubNode, 'title');
-      expect(stubNode.getAttribute('title')).toBe(null);
-      // JSDOM does not behave correctly for attributes/properties
-      //expect(stubNode.title).toBe('');
-    });
-
-    it('should not remove attributes for special properties', function() {
-      stubNode = document.createElement('input');
-      ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
-
-      stubNode.setAttribute('value', 'foo');
-
-      DOMPropertyOperations.deleteValueForProperty(stubNode, 'value');
-      // JSDOM does not behave correctly for attributes/properties
-      //expect(stubNode.getAttribute('value')).toBe('foo');
-      expect(stubNode.value).toBe('');
-    });
-
-    it('should not leave all options selected when deleting multiple', function() {
-      stubNode = document.createElement('select');
-      ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
-
-      stubNode.multiple = true;
-      stubNode.appendChild(document.createElement('option'));
-      stubNode.appendChild(document.createElement('option'));
-      stubNode.options[0].selected = true;
-      stubNode.options[1].selected = true;
-
-      DOMPropertyOperations.deleteValueForProperty(stubNode, 'multiple');
-      expect(stubNode.getAttribute('multiple')).toBe(null);
-      expect(stubNode.multiple).toBe(false);
-
-      expect(
-        stubNode.options[0].selected &&
-        stubNode.options[1].selected
-      ).toBe(false);
-    });
+  it('should set values as boolean properties', function() {
+    DOMPropertyOperations.setValueForProperty(stubNode, 'disabled', 'disabled');
+    expect(stubNode.getAttribute('disabled')).toBe('');
+    DOMPropertyOperations.setValueForProperty(stubNode, 'disabled', true);
+    expect(stubNode.getAttribute('disabled')).toBe('');
+    DOMPropertyOperations.setValueForProperty(stubNode, 'disabled', false);
+    expect(stubNode.getAttribute('disabled')).toBe(null);
   });
 
-  describe('injectDOMPropertyConfig', function() {
-    it('should support custom attributes', function() {
-      // foobar does not exist yet
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'foobar',
-        'simple'
-      )).toBe(null);
+  it('should convert attribute values to string first', function() {
+    // Browsers default to this behavior, but some test environments do not.
+    // This ensures that we have consistent behavior.
+    var obj = {
+      toString: function() {
+        return '<html>';
+      },
+    };
+    DOMPropertyOperations.setValueForProperty(stubNode, 'role', obj);
+    expect(stubNode.getAttribute('role')).toBe('<html>');
+  });
 
-      // foo-* does not exist yet
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'foo-xyz',
-        'simple'
-      )).toBe(null);
+  it('should not remove empty attributes for special properties', function() {
+    stubNode = document.createElement('input');
+    ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
 
-      // inject foobar DOM property
-      DOMProperty.injection.injectDOMPropertyConfig({
-        isCustomAttribute: function(name) {
-          return name.indexOf('foo-') === 0;
-        },
-        Properties: {foobar: null},
-      });
+    DOMPropertyOperations.setValueForProperty(stubNode, 'value', '');
+    // JSDOM does not behave correctly for attributes/properties
+    //expect(stubNode.getAttribute('value')).toBe('');
+    expect(stubNode.value).toBe('');
+  });
 
-      // Ensure old attributes still work
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'name',
-        'simple'
-      )).toBe('name="simple"');
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'data-name',
-        'simple'
-      )).toBe('data-name="simple"');
+  it('should remove for falsey boolean properties', function() {
+    DOMPropertyOperations.setValueForProperty(
+      stubNode,
+      'allowFullScreen',
+      false
+    );
+    expect(stubNode.hasAttribute('allowFullScreen')).toBe(false);
+  });
 
-      // foobar should work
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'foobar',
-        'simple'
-      )).toBe('foobar="simple"');
+  it('should remove when setting custom attr to null', function() {
+    DOMPropertyOperations.setValueForProperty(
+      stubNode,
+      'data-foo',
+      'bar'
+    );
+    expect(stubNode.hasAttribute('data-foo')).toBe(true);
+    DOMPropertyOperations.setValueForProperty(
+      stubNode,
+      'data-foo',
+      null
+    );
+    expect(stubNode.hasAttribute('data-foo')).toBe(false);
+  });
 
-      // foo-* should work
-      expect(DOMPropertyOperations.createMarkupForProperty(
-        'foo-xyz',
-        'simple'
-      )).toBe('foo-xyz="simple"');
-
-      // It should complain about double injections.
-      expect(function() {
-        DOMProperty.injection.injectDOMPropertyConfig(
-          {Properties: {foobar: null}}
-        );
-      }).toThrow();
+  it('should use mutation method where applicable', function() {
+    var foobarSetter = jest.fn();
+    // inject foobar DOM property
+    DOMProperty.injection.injectDOMPropertyConfig({
+      Properties: {foobar: null},
+      DOMMutationMethods: {
+        foobar: foobarSetter,
+      },
     });
+
+    DOMPropertyOperations.setValueForProperty(
+      stubNode,
+      'foobar',
+      'cows say moo'
+    );
+
+    expect(foobarSetter.mock.calls.length).toBe(1);
+    expect(foobarSetter.mock.calls[0][0]).toBe(stubNode);
+    expect(foobarSetter.mock.calls[0][1]).toBe('cows say moo');
+  });
+
+  it('should set className to empty string instead of null', function() {
+    DOMPropertyOperations.setValueForProperty(
+      stubNode,
+      'className',
+      'selected'
+    );
+    expect(stubNode.className).toBe('selected');
+
+    DOMPropertyOperations.setValueForProperty(
+      stubNode,
+      'className',
+      null
+    );
+    // className should be '', not 'null' or null (which becomes 'null' in
+    // some browsers)
+    expect(stubNode.className).toBe('');
+    expect(stubNode.getAttribute('class')).toBe(null);
+  });
+
+  it('should remove property properly for boolean properties', function() {
+    DOMPropertyOperations.setValueForProperty(
+      stubNode,
+      'hidden',
+      true
+    );
+    expect(stubNode.hasAttribute('hidden')).toBe(true);
+
+    DOMPropertyOperations.setValueForProperty(
+      stubNode,
+      'hidden',
+      false
+    );
+    expect(stubNode.hasAttribute('hidden')).toBe(false);
+  });
+
+  it('should remove property properly even with different name', function() {
+    // Suppose 'foobar' is a property that corresponds to the underlying
+    // 'className' property:
+    DOMProperty.injection.injectDOMPropertyConfig({
+      Properties: {foobar: DOMProperty.injection.MUST_USE_PROPERTY},
+      DOMPropertyNames: {
+        foobar: 'className',
+      },
+      DOMAttributeNames: {
+        foobar: 'class',
+      },
+    });
+
+    DOMPropertyOperations.setValueForProperty(
+      stubNode,
+      'foobar',
+      'selected'
+    );
+    expect(stubNode.className).toBe('selected');
+
+    DOMPropertyOperations.setValueForProperty(
+      stubNode,
+      'foobar',
+      null
+    );
+    // className should be '', not 'null' or null (which becomes 'null' in
+    // some browsers)
+    expect(stubNode.className).toBe('');
+  });
+
+});
+
+describe('deleteValueForProperty', function() {
+  var stubNode;
+  var stubInstance;
+
+  beforeEach(function() {
+    stubNode = document.createElement('div');
+    stubInstance = {_debugID: 1};
+    ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
+  });
+
+  it('should remove attributes for normal properties', function() {
+    DOMPropertyOperations.setValueForProperty(stubNode, 'title', 'foo');
+    expect(stubNode.getAttribute('title')).toBe('foo');
+    expect(stubNode.title).toBe('foo');
+
+    DOMPropertyOperations.deleteValueForProperty(stubNode, 'title');
+    expect(stubNode.getAttribute('title')).toBe(null);
+    // JSDOM does not behave correctly for attributes/properties
+    //expect(stubNode.title).toBe('');
+  });
+
+  it('should not remove attributes for special properties', function() {
+    stubNode = document.createElement('input');
+    ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
+
+    stubNode.setAttribute('value', 'foo');
+
+    DOMPropertyOperations.deleteValueForProperty(stubNode, 'value');
+    // JSDOM does not behave correctly for attributes/properties
+    //expect(stubNode.getAttribute('value')).toBe('foo');
+    expect(stubNode.value).toBe('');
+  });
+
+  it('should not leave all options selected when deleting multiple', function() {
+    stubNode = document.createElement('select');
+    ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
+
+    stubNode.multiple = true;
+    stubNode.appendChild(document.createElement('option'));
+    stubNode.appendChild(document.createElement('option'));
+    stubNode.options[0].selected = true;
+    stubNode.options[1].selected = true;
+
+    DOMPropertyOperations.deleteValueForProperty(stubNode, 'multiple');
+    expect(stubNode.getAttribute('multiple')).toBe(null);
+    expect(stubNode.multiple).toBe(false);
+
+    expect(
+      stubNode.options[0].selected &&
+      stubNode.options[1].selected
+    ).toBe(false);
+  });
+});
+
+describe('injectDOMPropertyConfig', function() {
+  it('should support custom attributes', function() {
+    // foobar does not exist yet
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'foobar',
+      'simple'
+    )).toBe(null);
+
+    // foo-* does not exist yet
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'foo-xyz',
+      'simple'
+    )).toBe(null);
+
+    // inject foobar DOM property
+    DOMProperty.injection.injectDOMPropertyConfig({
+      isCustomAttribute: function(name) {
+        return name.indexOf('foo-') === 0;
+      },
+      Properties: {foobar: null},
+    });
+
+    // Ensure old attributes still work
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'name',
+      'simple'
+    )).toBe('name="simple"');
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'data-name',
+      'simple'
+    )).toBe('data-name="simple"');
+
+    // foobar should work
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'foobar',
+      'simple'
+    )).toBe('foobar="simple"');
+
+    // foo-* should work
+    expect(DOMPropertyOperations.createMarkupForProperty(
+      'foo-xyz',
+      'simple'
+    )).toBe('foo-xyz="simple"');
+
+    // It should complain about double injections.
+    expect(function() {
+      DOMProperty.injection.injectDOMPropertyConfig(
+        {Properties: {foobar: null}}
+      );
+    }).toThrow();
   });
 });

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -12,1488 +12,1486 @@
 'use strict';
 
 
-describe('ReactDOMComponent', function() {
-  var React;
-  var ReactDOM;
-  var ReactDOMFeatureFlags;
-  var ReactDOMServer;
-  var inputValueTracking;
+var React;
+var ReactDOM;
+var ReactDOMFeatureFlags;
+var ReactDOMServer;
+var inputValueTracking;
 
-  function normalizeCodeLocInfo(str) {
-    return str.replace(/\(at .+?:\d+\)/g, '(at **)');
-  }
+function normalizeCodeLocInfo(str) {
+  return str.replace(/\(at .+?:\d+\)/g, '(at **)');
+}
+
+beforeEach(function() {
+  jest.resetModuleRegistry();
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
+  ReactDOMServer = require('ReactDOMServer');
+  inputValueTracking = require('inputValueTracking');
+});
+
+describe('updateDOM', function() {
+  var ReactTestUtils;
 
   beforeEach(function() {
-    jest.resetModuleRegistry();
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
-    ReactDOMServer = require('ReactDOMServer');
-    inputValueTracking = require('inputValueTracking');
+    ReactTestUtils = require('ReactTestUtils');
   });
 
-  describe('updateDOM', function() {
-    var ReactTestUtils;
+  it('should handle className', function() {
+    var container = document.createElement('div');
+    ReactDOM.render(<div style={{}} />, container);
 
-    beforeEach(function() {
-      ReactTestUtils = require('ReactTestUtils');
-    });
+    ReactDOM.render(<div className={'foo'} />, container);
+    expect(container.firstChild.className).toEqual('foo');
+    ReactDOM.render(<div className={'bar'} />, container);
+    expect(container.firstChild.className).toEqual('bar');
+    ReactDOM.render(<div className={null} />, container);
+    expect(container.firstChild.className).toEqual('');
+  });
 
-    it('should handle className', function() {
-      var container = document.createElement('div');
-      ReactDOM.render(<div style={{}} />, container);
+  it('should gracefully handle various style value types', function() {
+    var container = document.createElement('div');
+    ReactDOM.render(<div style={{}} />, container);
+    var stubStyle = container.firstChild.style;
 
-      ReactDOM.render(<div className={'foo'} />, container);
-      expect(container.firstChild.className).toEqual('foo');
-      ReactDOM.render(<div className={'bar'} />, container);
-      expect(container.firstChild.className).toEqual('bar');
-      ReactDOM.render(<div className={null} />, container);
-      expect(container.firstChild.className).toEqual('');
-    });
+    // set initial style
+    var setup = {display: 'block', left: '1px', top: 2, fontFamily: 'Arial'};
+    ReactDOM.render(<div style={setup} />, container);
+    expect(stubStyle.display).toEqual('block');
+    expect(stubStyle.left).toEqual('1px');
+    expect(stubStyle.fontFamily).toEqual('Arial');
 
-    it('should gracefully handle various style value types', function() {
-      var container = document.createElement('div');
-      ReactDOM.render(<div style={{}} />, container);
-      var stubStyle = container.firstChild.style;
+    // reset the style to their default state
+    var reset = {display: '', left: null, top: false, fontFamily: true};
+    ReactDOM.render(<div style={reset} />, container);
+    expect(stubStyle.display).toEqual('');
+    expect(stubStyle.left).toEqual('');
+    expect(stubStyle.top).toEqual('');
+    expect(stubStyle.fontFamily).toEqual('');
+  });
 
-      // set initial style
-      var setup = {display: 'block', left: '1px', top: 2, fontFamily: 'Arial'};
-      ReactDOM.render(<div style={setup} />, container);
-      expect(stubStyle.display).toEqual('block');
-      expect(stubStyle.left).toEqual('1px');
-      expect(stubStyle.fontFamily).toEqual('Arial');
+  // TODO: (poshannessy) deprecate this pattern.
+  it('should update styles when mutating style object', function() {
+    // not actually used. Just to suppress the style mutation warning
+    spyOn(console, 'error');
 
-      // reset the style to their default state
-      var reset = {display: '', left: null, top: false, fontFamily: true};
-      ReactDOM.render(<div style={reset} />, container);
-      expect(stubStyle.display).toEqual('');
-      expect(stubStyle.left).toEqual('');
-      expect(stubStyle.top).toEqual('');
-      expect(stubStyle.fontFamily).toEqual('');
-    });
+    var styles = {display: 'none', fontFamily: 'Arial', lineHeight: 1.2};
+    var container = document.createElement('div');
+    ReactDOM.render(<div style={styles} />, container);
 
-    // TODO: (poshannessy) deprecate this pattern.
-    it('should update styles when mutating style object', function() {
-      // not actually used. Just to suppress the style mutation warning
-      spyOn(console, 'error');
+    var stubStyle = container.firstChild.style;
+    stubStyle.display = styles.display;
+    stubStyle.fontFamily = styles.fontFamily;
 
-      var styles = {display: 'none', fontFamily: 'Arial', lineHeight: 1.2};
-      var container = document.createElement('div');
-      ReactDOM.render(<div style={styles} />, container);
+    styles.display = 'block';
 
-      var stubStyle = container.firstChild.style;
-      stubStyle.display = styles.display;
-      stubStyle.fontFamily = styles.fontFamily;
+    ReactDOM.render(<div style={styles} />, container);
+    expect(stubStyle.display).toEqual('block');
+    expect(stubStyle.fontFamily).toEqual('Arial');
+    expect(stubStyle.lineHeight).toEqual('1.2');
 
-      styles.display = 'block';
+    styles.fontFamily = 'Helvetica';
 
-      ReactDOM.render(<div style={styles} />, container);
-      expect(stubStyle.display).toEqual('block');
-      expect(stubStyle.fontFamily).toEqual('Arial');
-      expect(stubStyle.lineHeight).toEqual('1.2');
+    ReactDOM.render(<div style={styles} />, container);
+    expect(stubStyle.display).toEqual('block');
+    expect(stubStyle.fontFamily).toEqual('Helvetica');
+    expect(stubStyle.lineHeight).toEqual('1.2');
 
-      styles.fontFamily = 'Helvetica';
+    styles.lineHeight = 0.5;
 
-      ReactDOM.render(<div style={styles} />, container);
-      expect(stubStyle.display).toEqual('block');
-      expect(stubStyle.fontFamily).toEqual('Helvetica');
-      expect(stubStyle.lineHeight).toEqual('1.2');
+    ReactDOM.render(<div style={styles} />, container);
+    expect(stubStyle.display).toEqual('block');
+    expect(stubStyle.fontFamily).toEqual('Helvetica');
+    expect(stubStyle.lineHeight).toEqual('0.5');
 
-      styles.lineHeight = 0.5;
+    ReactDOM.render(<div style={undefined} />, container);
+    expect(stubStyle.display).toBe('');
+    expect(stubStyle.fontFamily).toBe('');
+    expect(stubStyle.lineHeight).toBe('');
+  });
 
-      ReactDOM.render(<div style={styles} />, container);
-      expect(stubStyle.display).toEqual('block');
-      expect(stubStyle.fontFamily).toEqual('Helvetica');
-      expect(stubStyle.lineHeight).toEqual('0.5');
+  it('should warn when mutating style', function() {
+    spyOn(console, 'error');
 
-      ReactDOM.render(<div style={undefined} />, container);
-      expect(stubStyle.display).toBe('');
-      expect(stubStyle.fontFamily).toBe('');
-      expect(stubStyle.lineHeight).toBe('');
-    });
+    var style = {border: '1px solid black'};
 
-    it('should warn when mutating style', function() {
-      spyOn(console, 'error');
+    class App extends React.Component {
+      state = {style: style};
 
-      var style = {border: '1px solid black'};
-
-      class App extends React.Component {
-        state = {style: style};
-
-        render() {
-          return <div style={this.state.style}>asd</div>;
-        }
+      render() {
+        return <div style={this.state.style}>asd</div>;
       }
+    }
 
-      var stub = ReactTestUtils.renderIntoDocument(<App />);
-      style.position = 'absolute';
-      stub.setState({style: style});
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toEqual(
-        'Warning: `div` was passed a style object that has previously been ' +
-        'mutated. Mutating `style` is deprecated. Consider cloning it ' +
-        'beforehand. Check the `render` of `App`. Previous style: ' +
-        '{border: "1px solid black"}. Mutated style: ' +
-        '{border: "1px solid black", position: "absolute"}.'
-      );
+    var stub = ReactTestUtils.renderIntoDocument(<App />);
+    style.position = 'absolute';
+    stub.setState({style: style});
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toEqual(
+      'Warning: `div` was passed a style object that has previously been ' +
+      'mutated. Mutating `style` is deprecated. Consider cloning it ' +
+      'beforehand. Check the `render` of `App`. Previous style: ' +
+      '{border: "1px solid black"}. Mutated style: ' +
+      '{border: "1px solid black", position: "absolute"}.'
+    );
 
-      style = {background: 'red'};
-      stub = ReactTestUtils.renderIntoDocument(<App />);
-      style.background = 'green';
-      stub.setState({style: {background: 'green'}});
-      // already warned once for the same component and owner
-      expect(console.error.calls.count()).toBe(1);
+    style = {background: 'red'};
+    stub = ReactTestUtils.renderIntoDocument(<App />);
+    style.background = 'green';
+    stub.setState({style: {background: 'green'}});
+    // already warned once for the same component and owner
+    expect(console.error.calls.count()).toBe(1);
 
-      style = {background: 'red'};
-      var div = document.createElement('div');
-      ReactDOM.render(<span style={style}></span>, div);
-      style.background = 'blue';
-      ReactDOM.render(<span style={style}></span>, div);
-      expect(console.error.calls.count()).toBe(2);
-    });
+    style = {background: 'red'};
+    var div = document.createElement('div');
+    ReactDOM.render(<span style={style}></span>, div);
+    style.background = 'blue';
+    ReactDOM.render(<span style={style}></span>, div);
+    expect(console.error.calls.count()).toBe(2);
+  });
 
-    it('should warn for unknown prop', function() {
-      spyOn(console, 'error');
-      var container = document.createElement('div');
-      ReactDOM.render(<div foo="bar" />, container);
-      expect(console.error.calls.count(0)).toBe(1);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Unknown prop `foo` on <div> tag. Remove this prop from the element. ' +
-        'For details, see https://fb.me/react-unknown-prop\n    in div (at **)'
-      );
-    });
+  it('should warn for unknown prop', function() {
+    spyOn(console, 'error');
+    var container = document.createElement('div');
+    ReactDOM.render(<div foo="bar" />, container);
+    expect(console.error.calls.count(0)).toBe(1);
+    expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+      'Warning: Unknown prop `foo` on <div> tag. Remove this prop from the element. ' +
+      'For details, see https://fb.me/react-unknown-prop\n    in div (at **)'
+    );
+  });
 
-    it('should group multiple unknown prop warnings together', function() {
-      spyOn(console, 'error');
-      var container = document.createElement('div');
-      ReactDOM.render(<div foo="bar" baz="qux" />, container);
-      expect(console.error.calls.count(0)).toBe(1);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Unknown props `foo`, `baz` on <div> tag. Remove these props from the element. ' +
-        'For details, see https://fb.me/react-unknown-prop\n    in div (at **)'
-      );
-    });
+  it('should group multiple unknown prop warnings together', function() {
+    spyOn(console, 'error');
+    var container = document.createElement('div');
+    ReactDOM.render(<div foo="bar" baz="qux" />, container);
+    expect(console.error.calls.count(0)).toBe(1);
+    expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+      'Warning: Unknown props `foo`, `baz` on <div> tag. Remove these props from the element. ' +
+      'For details, see https://fb.me/react-unknown-prop\n    in div (at **)'
+    );
+  });
 
-    it('should warn for onDblClick prop', function() {
-      spyOn(console, 'error');
-      var container = document.createElement('div');
-      ReactDOM.render(<div onDblClick={() => {}} />, container);
-      expect(console.error.calls.count(0)).toBe(1);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Unknown event handler property onDblClick. Did you mean `onDoubleClick`?\n    in div (at **)'
-      );
-    });
+  it('should warn for onDblClick prop', function() {
+    spyOn(console, 'error');
+    var container = document.createElement('div');
+    ReactDOM.render(<div onDblClick={() => {}} />, container);
+    expect(console.error.calls.count(0)).toBe(1);
+    expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+      'Warning: Unknown event handler property onDblClick. Did you mean `onDoubleClick`?\n    in div (at **)'
+    );
+  });
 
-    it('should not warn for "0" as a unitless style value', function() {
-      spyOn(console, 'error');
+  it('should not warn for "0" as a unitless style value', function() {
+    spyOn(console, 'error');
 
-      class Component extends React.Component {
-        render() {
-          return <div style={{margin: '0'}} />;
-        }
+    class Component extends React.Component {
+      render() {
+        return <div style={{margin: '0'}} />;
       }
+    }
 
-      ReactTestUtils.renderIntoDocument(<Component />);
-      expect(console.error.calls.count()).toBe(0);
-    });
+    ReactTestUtils.renderIntoDocument(<Component />);
+    expect(console.error.calls.count()).toBe(0);
+  });
 
-    it('should warn nicely about NaN in style', function() {
-      spyOn(console, 'error');
+  it('should warn nicely about NaN in style', function() {
+    spyOn(console, 'error');
 
-      var style = {fontSize: NaN};
-      var div = document.createElement('div');
-      ReactDOM.render(<span style={style}></span>, div);
-      ReactDOM.render(<span style={style}></span>, div);
+    var style = {fontSize: NaN};
+    var div = document.createElement('div');
+    ReactDOM.render(<span style={style}></span>, div);
+    ReactDOM.render(<span style={style}></span>, div);
 
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toEqual(
-        'Warning: `NaN` is an invalid value for the `fontSize` css style property.',
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toEqual(
+      'Warning: `NaN` is an invalid value for the `fontSize` css style property.',
+    );
+  });
+
+  it('should update styles if initially null', function() {
+    var styles = null;
+    var container = document.createElement('div');
+    ReactDOM.render(<div style={styles} />, container);
+
+    var stubStyle = container.firstChild.style;
+
+    styles = {display: 'block'};
+
+    ReactDOM.render(<div style={styles} />, container);
+    expect(stubStyle.display).toEqual('block');
+  });
+
+  it('should update styles if updated to null multiple times', function() {
+    var styles = null;
+    var container = document.createElement('div');
+    ReactDOM.render(<div style={styles} />, container);
+
+    styles = {display: 'block'};
+    var stubStyle = container.firstChild.style;
+
+    ReactDOM.render(<div style={styles} />, container);
+    expect(stubStyle.display).toEqual('block');
+
+    ReactDOM.render(<div style={null} />, container);
+    expect(stubStyle.display).toEqual('');
+
+    ReactDOM.render(<div style={styles} />, container);
+    expect(stubStyle.display).toEqual('block');
+
+    ReactDOM.render(<div style={null} />, container);
+    expect(stubStyle.display).toEqual('');
+  });
+
+  it('should skip reserved props on web components', function() {
+    var container = document.createElement('div');
+
+    ReactDOM.render(
+      <my-component
+        children={['foo']}
+        suppressContentEditableWarning={true}
+      />,
+      container
+    );
+    expect(container.firstChild.hasAttribute('children')).toBe(false);
+    expect(
+      container.firstChild.hasAttribute('suppressContentEditableWarning')
+    ).toBe(false);
+
+    ReactDOM.render(
+      <my-component
+        children={['bar']}
+        suppressContentEditableWarning={false}
+      />,
+      container
+    );
+    expect(container.firstChild.hasAttribute('children')).toBe(false);
+    expect(
+      container.firstChild.hasAttribute('suppressContentEditableWarning')
+    ).toBe(false);
+  });
+
+  it('should skip dangerouslySetInnerHTML on web components', function() {
+    var container = document.createElement('div');
+
+    ReactDOM.render(
+      <my-component dangerouslySetInnerHTML={{__html: 'hi'}} />,
+      container
+    );
+    expect(
+      container.firstChild.hasAttribute('dangerouslySetInnerHTML')
+    ).toBe(false);
+
+    ReactDOM.render(
+      <my-component dangerouslySetInnerHTML={{__html: 'bye'}} />,
+      container
+    );
+    expect(
+      container.firstChild.hasAttribute('dangerouslySetInnerHTML')
+    ).toBe(false);
+  });
+
+  it('should remove attributes', function() {
+    var container = document.createElement('div');
+    ReactDOM.render(<img height="17" />, container);
+
+    expect(container.firstChild.hasAttribute('height')).toBe(true);
+    ReactDOM.render(<img />, container);
+    expect(container.firstChild.hasAttribute('height')).toBe(false);
+  });
+
+  it('should remove properties', function() {
+    var container = document.createElement('div');
+    ReactDOM.render(<div className="monkey" />, container);
+
+    expect(container.firstChild.className).toEqual('monkey');
+    ReactDOM.render(<div />, container);
+    expect(container.firstChild.className).toEqual('');
+  });
+
+  it('should properly update custom attributes on custom elements', function() {
+    var container = document.createElement('div');
+    ReactDOM.render(<some-custom-element foo="bar"/>, container);
+    ReactDOM.render(<some-custom-element bar="buzz"/>, container);
+    var node = container.firstChild;
+    expect(node.hasAttribute('foo')).toBe(false);
+    expect(node.getAttribute('bar')).toBe('buzz');
+  });
+
+  it('should clear a single style prop when changing `style`', function() {
+    var styles = {display: 'none', color: 'red'};
+    var container = document.createElement('div');
+    ReactDOM.render(<div style={styles} />, container);
+
+    var stubStyle = container.firstChild.style;
+
+    styles = {color: 'green'};
+    ReactDOM.render(<div style={styles} />, container);
+    expect(stubStyle.display).toEqual('');
+    expect(stubStyle.color).toEqual('green');
+  });
+
+  it('should reject attribute key injection attack on markup', function() {
+    spyOn(console, 'error');
+    for (var i = 0; i < 3; i++) {
+      var container = document.createElement('div');
+      var element = React.createElement(
+        'x-foo-component',
+        {'blah" onclick="beevil" noise="hi': 'selected'},
+        null
       );
-    });
+      ReactDOM.render(element, container);
+    }
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toEqual(
+      'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`'
+    );
+  });
 
-    it('should update styles if initially null', function() {
-      var styles = null;
+  it('should reject attribute key injection attack on update', function() {
+    spyOn(console, 'error');
+    for (var i = 0; i < 3; i++) {
       var container = document.createElement('div');
-      ReactDOM.render(<div style={styles} />, container);
-
-      var stubStyle = container.firstChild.style;
-
-      styles = {display: 'block'};
-
-      ReactDOM.render(<div style={styles} />, container);
-      expect(stubStyle.display).toEqual('block');
-    });
-
-    it('should update styles if updated to null multiple times', function() {
-      var styles = null;
-      var container = document.createElement('div');
-      ReactDOM.render(<div style={styles} />, container);
-
-      styles = {display: 'block'};
-      var stubStyle = container.firstChild.style;
-
-      ReactDOM.render(<div style={styles} />, container);
-      expect(stubStyle.display).toEqual('block');
-
-      ReactDOM.render(<div style={null} />, container);
-      expect(stubStyle.display).toEqual('');
-
-      ReactDOM.render(<div style={styles} />, container);
-      expect(stubStyle.display).toEqual('block');
-
-      ReactDOM.render(<div style={null} />, container);
-      expect(stubStyle.display).toEqual('');
-    });
-
-    it('should skip reserved props on web components', function() {
-      var container = document.createElement('div');
-
-      ReactDOM.render(
-        <my-component
-          children={['foo']}
-          suppressContentEditableWarning={true}
-        />,
-        container
-      );
-      expect(container.firstChild.hasAttribute('children')).toBe(false);
-      expect(
-        container.firstChild.hasAttribute('suppressContentEditableWarning')
-      ).toBe(false);
-
-      ReactDOM.render(
-        <my-component
-          children={['bar']}
-          suppressContentEditableWarning={false}
-        />,
-        container
-      );
-      expect(container.firstChild.hasAttribute('children')).toBe(false);
-      expect(
-        container.firstChild.hasAttribute('suppressContentEditableWarning')
-      ).toBe(false);
-    });
-
-    it('should skip dangerouslySetInnerHTML on web components', function() {
-      var container = document.createElement('div');
-
-      ReactDOM.render(
-        <my-component dangerouslySetInnerHTML={{__html: 'hi'}} />,
-        container
-      );
-      expect(
-        container.firstChild.hasAttribute('dangerouslySetInnerHTML')
-      ).toBe(false);
-
-      ReactDOM.render(
-        <my-component dangerouslySetInnerHTML={{__html: 'bye'}} />,
-        container
-      );
-      expect(
-        container.firstChild.hasAttribute('dangerouslySetInnerHTML')
-      ).toBe(false);
-    });
-
-    it('should remove attributes', function() {
-      var container = document.createElement('div');
-      ReactDOM.render(<img height="17" />, container);
-
-      expect(container.firstChild.hasAttribute('height')).toBe(true);
-      ReactDOM.render(<img />, container);
-      expect(container.firstChild.hasAttribute('height')).toBe(false);
-    });
-
-    it('should remove properties', function() {
-      var container = document.createElement('div');
-      ReactDOM.render(<div className="monkey" />, container);
-
-      expect(container.firstChild.className).toEqual('monkey');
-      ReactDOM.render(<div />, container);
-      expect(container.firstChild.className).toEqual('');
-    });
-
-    it('should properly update custom attributes on custom elements', function() {
-      var container = document.createElement('div');
-      ReactDOM.render(<some-custom-element foo="bar"/>, container);
-      ReactDOM.render(<some-custom-element bar="buzz"/>, container);
-      var node = container.firstChild;
-      expect(node.hasAttribute('foo')).toBe(false);
-      expect(node.getAttribute('bar')).toBe('buzz');
-    });
-
-    it('should clear a single style prop when changing `style`', function() {
-      var styles = {display: 'none', color: 'red'};
-      var container = document.createElement('div');
-      ReactDOM.render(<div style={styles} />, container);
-
-      var stubStyle = container.firstChild.style;
-
-      styles = {color: 'green'};
-      ReactDOM.render(<div style={styles} />, container);
-      expect(stubStyle.display).toEqual('');
-      expect(stubStyle.color).toEqual('green');
-    });
-
-    it('should reject attribute key injection attack on markup', function() {
-      spyOn(console, 'error');
-      for (var i = 0; i < 3; i++) {
-        var container = document.createElement('div');
-        var element = React.createElement(
-          'x-foo-component',
-          {'blah" onclick="beevil" noise="hi': 'selected'},
-          null
-        );
-        ReactDOM.render(element, container);
-      }
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toEqual(
-        'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`'
-      );
-    });
-
-    it('should reject attribute key injection attack on update', function() {
-      spyOn(console, 'error');
-      for (var i = 0; i < 3; i++) {
-        var container = document.createElement('div');
-        var beforeUpdate = React.createElement('x-foo-component', {}, null);
-        ReactDOM.render(beforeUpdate, container);
-
-        var afterUpdate = React.createElement(
-          'x-foo-component',
-          {'blah" onclick="beevil" noise="hi': 'selected'},
-          null
-        );
-        ReactDOM.render(afterUpdate, container);
-      }
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toEqual(
-        'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`'
-      );
-    });
-
-    it('should update arbitrary attributes for tags containing dashes', function() {
-      var container = document.createElement('div');
-
       var beforeUpdate = React.createElement('x-foo-component', {}, null);
       ReactDOM.render(beforeUpdate, container);
 
-      var afterUpdate = <x-foo-component myattr="myval" />;
+      var afterUpdate = React.createElement(
+        'x-foo-component',
+        {'blah" onclick="beevil" noise="hi': 'selected'},
+        null
+      );
       ReactDOM.render(afterUpdate, container);
-
-      expect(container.childNodes[0].getAttribute('myattr')).toBe('myval');
-    });
-
-    it('should clear all the styles when removing `style`', function() {
-      var styles = {display: 'none', color: 'red'};
-      var container = document.createElement('div');
-      ReactDOM.render(<div style={styles} />, container);
-
-      var stubStyle = container.firstChild.style;
-
-      ReactDOM.render(<div />, container);
-      expect(stubStyle.display).toEqual('');
-      expect(stubStyle.color).toEqual('');
-    });
-
-    it('should update styles when `style` changes from null to object', function() {
-      var container = document.createElement('div');
-      var styles = {color: 'red'};
-      ReactDOM.render(<div style={styles} />, container);
-      ReactDOM.render(<div />, container);
-      ReactDOM.render(<div style={styles} />, container);
-
-      var stubStyle = container.firstChild.style;
-      expect(stubStyle.color).toEqual('red');
-    });
-
-    it('should empty element when removing innerHTML', function() {
-      var container = document.createElement('div');
-      ReactDOM.render(<div dangerouslySetInnerHTML={{__html: ':)'}} />, container);
-
-      expect(container.firstChild.innerHTML).toEqual(':)');
-      ReactDOM.render(<div />, container);
-      expect(container.firstChild.innerHTML).toEqual('');
-    });
-
-    it('should transition from string content to innerHTML', function() {
-      var container = document.createElement('div');
-      ReactDOM.render(<div>hello</div>, container);
-
-      expect(container.firstChild.innerHTML).toEqual('hello');
-      ReactDOM.render(
-        <div dangerouslySetInnerHTML={{__html: 'goodbye'}} />,
-        container
-      );
-      expect(container.firstChild.innerHTML).toEqual('goodbye');
-    });
-
-    it('should transition from innerHTML to string content', function() {
-      var container = document.createElement('div');
-      ReactDOM.render(
-        <div dangerouslySetInnerHTML={{__html: 'bonjour'}} />,
-        container
-      );
-
-      expect(container.firstChild.innerHTML).toEqual('bonjour');
-      ReactDOM.render(<div>adieu</div>, container);
-      expect(container.firstChild.innerHTML).toEqual('adieu');
-    });
-
-    it('should transition from innerHTML to children in nested el', function() {
-      var container = document.createElement('div');
-      ReactDOM.render(
-        <div><div dangerouslySetInnerHTML={{__html: 'bonjour'}} /></div>,
-        container
-      );
-
-      expect(container.textContent).toEqual('bonjour');
-      ReactDOM.render(<div><div><span>adieu</span></div></div>, container);
-      expect(container.textContent).toEqual('adieu');
-    });
-
-    it('should transition from children to innerHTML in nested el', function() {
-      var container = document.createElement('div');
-      ReactDOM.render(<div><div><span>adieu</span></div></div>, container);
-
-      expect(container.textContent).toEqual('adieu');
-      ReactDOM.render(
-        <div><div dangerouslySetInnerHTML={{__html: 'bonjour'}} /></div>,
-        container
-      );
-      expect(container.textContent).toEqual('bonjour');
-    });
-
-    it('should not incur unnecessary DOM mutations for attributes', function() {
-      var container = document.createElement('div');
-      ReactDOM.render(<div id="" />, container);
-
-      var node = container.firstChild;
-      var nodeSetAttribute = node.setAttribute;
-      node.setAttribute = jest.fn();
-      node.setAttribute.mockImpl(nodeSetAttribute);
-
-      var nodeRemoveAttribute = node.removeAttribute;
-      node.removeAttribute = jest.fn();
-      node.removeAttribute.mockImpl(nodeRemoveAttribute);
-
-      ReactDOM.render(<div id="" />, container);
-      expect(node.setAttribute.mock.calls.length).toBe(0);
-      expect(node.removeAttribute.mock.calls.length).toBe(0);
-
-      ReactDOM.render(<div id="foo" />, container);
-      expect(node.setAttribute.mock.calls.length).toBe(1);
-      expect(node.removeAttribute.mock.calls.length).toBe(0);
-
-      ReactDOM.render(<div id="foo" />, container);
-      expect(node.setAttribute.mock.calls.length).toBe(1);
-      expect(node.removeAttribute.mock.calls.length).toBe(0);
-
-      ReactDOM.render(<div />, container);
-      expect(node.setAttribute.mock.calls.length).toBe(1);
-      expect(node.removeAttribute.mock.calls.length).toBe(1);
-
-      ReactDOM.render(<div id="" />, container);
-      expect(node.setAttribute.mock.calls.length).toBe(2);
-      expect(node.removeAttribute.mock.calls.length).toBe(1);
-
-      ReactDOM.render(<div />, container);
-      expect(node.setAttribute.mock.calls.length).toBe(2);
-      expect(node.removeAttribute.mock.calls.length).toBe(2);
-    });
-
-    it('should not incur unnecessary DOM mutations for string properties', function() {
-      var container = document.createElement('div');
-      ReactDOM.render(<div value="" />, container);
-
-      var node = container.firstChild;
-
-      var nodeValueSetter = jest.genMockFn();
-
-      var oldSetAttribute = node.setAttribute.bind(node);
-      node.setAttribute = function(key, value) {
-        oldSetAttribute(key, value);
-        nodeValueSetter(key, value);
-      };
-
-      ReactDOM.render(<div value="foo" />, container);
-      expect(nodeValueSetter.mock.calls.length).toBe(1);
-
-      ReactDOM.render(<div value="foo" />, container);
-      expect(nodeValueSetter.mock.calls.length).toBe(1);
-
-      ReactDOM.render(<div />, container);
-      expect(nodeValueSetter.mock.calls.length).toBe(1);
-
-      ReactDOM.render(<div value={null} />, container);
-      expect(nodeValueSetter.mock.calls.length).toBe(1);
-
-      ReactDOM.render(<div value="" />, container);
-      expect(nodeValueSetter.mock.calls.length).toBe(2);
-
-      ReactDOM.render(<div />, container);
-      expect(nodeValueSetter.mock.calls.length).toBe(2);
-    });
-
-    it('should not incur unnecessary DOM mutations for boolean properties', function() {
-      var container = document.createElement('div');
-      ReactDOM.render(<div checked={true} />, container);
-
-      var node = container.firstChild;
-      var nodeValue = true;
-      var nodeValueSetter = jest.fn();
-      Object.defineProperty(node, 'checked', {
-        get: function() {
-          return nodeValue;
-        },
-        set: nodeValueSetter.mockImplementation(function(newValue) {
-          nodeValue = newValue;
-        }),
-      });
-
-      ReactDOM.render(<div checked={true} />, container);
-      expect(nodeValueSetter.mock.calls.length).toBe(0);
-
-      ReactDOM.render(<div />, container);
-      expect(nodeValueSetter.mock.calls.length).toBe(1);
-
-      ReactDOM.render(<div checked={false} />, container);
-      expect(nodeValueSetter.mock.calls.length).toBe(2);
-
-      ReactDOM.render(<div checked={true} />, container);
-      expect(nodeValueSetter.mock.calls.length).toBe(3);
-    });
-
-    it('should ignore attribute whitelist for elements with the "is: attribute', function() {
-      var container = document.createElement('div');
-      ReactDOM.render(<button is="test" cowabunga="chevynova"/>, container);
-      expect(container.firstChild.hasAttribute('cowabunga')).toBe(true);
-    });
-
-    it('should not update when switching between null/undefined', function() {
-      var container = document.createElement('div');
-      var node = ReactDOM.render(<div />, container);
-
-      var setter = jest.fn();
-      node.setAttribute = setter;
-
-      ReactDOM.render(<div dir={null} />, container);
-      ReactDOM.render(<div dir={undefined} />, container);
-      ReactDOM.render(<div />, container);
-      expect(setter.mock.calls.length).toBe(0);
-      ReactDOM.render(<div dir="ltr" />, container);
-      expect(setter.mock.calls.length).toBe(1);
-    });
-
-    it('handles multiple child updates without interference', function() {
-      // This test might look like it's just testing ReactMultiChild but the
-      // last bug in this was actually in DOMChildrenOperations so this test
-      // needs to be in some DOM-specific test file.
-      var container = document.createElement('div');
-
-      // ABCD
-      ReactDOM.render(
-        <div>
-          <div key="one">
-            <div key="A">A</div><div key="B">B</div>
-          </div>
-          <div key="two">
-            <div key="C">C</div><div key="D">D</div>
-          </div>
-        </div>,
-        container
-      );
-      // BADC
-      ReactDOM.render(
-        <div>
-          <div key="one">
-            <div key="B">B</div><div key="A">A</div>
-          </div>
-          <div key="two">
-            <div key="D">D</div><div key="C">C</div>
-          </div>
-        </div>,
-        container
-      );
-
-      expect(container.textContent).toBe('BADC');
-    });
-  });
-
-  describe('createOpenTagMarkup', function() {
-    var genMarkup;
-
-    function quoteRegexp(str) {
-      return (str + '').replace(/([.?*+\^$\[\]\\(){}|-])/g, '\\$1');
     }
-
-    beforeEach(function() {
-      var ReactDefaultInjection = require('ReactDefaultInjection');
-      ReactDefaultInjection.inject();
-
-      var ReactDOMComponent = require('ReactDOMComponent');
-      var ReactReconcileTransaction = require('ReactReconcileTransaction');
-
-      var NodeStub = function(initialProps) {
-        this._currentElement = {props: initialProps};
-        this._rootNodeID = 1;
-      };
-      Object.assign(NodeStub.prototype, ReactDOMComponent.Mixin);
-
-      genMarkup = function(props) {
-        var transaction = new ReactReconcileTransaction();
-        return (new NodeStub(props))._createOpenTagMarkupAndPutListeners(
-          transaction,
-          props
-        );
-      };
-
-      jasmine.addMatchers({
-        toHaveAttribute() {
-          return {
-            compare(actual, expected) {
-              var [attr, value] = expected;
-              var re = '(?:^|\\s)' + attr + '=[\\\'"]';
-              if (typeof value !== 'undefined') {
-                re += quoteRegexp(value) + '[\\\'"]';
-              }
-              return {
-                pass: (new RegExp(re)).test(actual),
-              };
-            },
-          };
-        },
-      });
-    });
-
-    it('should generate the correct markup with className', function() {
-      expect(genMarkup({className: 'a'})).toHaveAttribute(['class', 'a']);
-      expect(genMarkup({className: 'a b'})).toHaveAttribute(['class', 'a b']);
-      expect(genMarkup({className: ''})).toHaveAttribute(['class', '']);
-    });
-
-    it('should escape style names and values', function() {
-      expect(genMarkup({
-        style: {'b&ckground': '<3'},
-      })).toHaveAttribute(['style', 'b&amp;ckground:&lt;3;']);
-    });
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toEqual(
+      'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`'
+    );
   });
 
-  describe('createContentMarkup', function() {
-    var genMarkup;
+  it('should update arbitrary attributes for tags containing dashes', function() {
+    var container = document.createElement('div');
 
-    function quoteRegexp(str) {
-      return (str + '').replace(/([.?*+\^$\[\]\\(){}|-])/g, '\\$1');
-    }
+    var beforeUpdate = React.createElement('x-foo-component', {}, null);
+    ReactDOM.render(beforeUpdate, container);
 
-    beforeEach(function() {
-      var ReactDOMComponent = require('ReactDOMComponent');
-      var ReactReconcileTransaction = require('ReactReconcileTransaction');
+    var afterUpdate = <x-foo-component myattr="myval" />;
+    ReactDOM.render(afterUpdate, container);
 
-      var NodeStub = function(initialProps) {
-        this._currentElement = {props: initialProps};
-        this._rootNodeID = 1;
-      };
-      Object.assign(NodeStub.prototype, ReactDOMComponent.Mixin);
-
-      genMarkup = function(props) {
-        var transaction = new ReactReconcileTransaction();
-        return (new NodeStub(props))._createContentMarkup(
-          transaction,
-          props,
-          {}
-        );
-      };
-
-      jasmine.addMatchers({
-        toHaveInnerhtml() {
-          return {
-            compare(actual, expected) {
-              var re = '^' + quoteRegexp(expected) + '$';
-              return {
-                pass: (new RegExp(re)).test(actual),
-              };
-            },
-          };
-        },
-      });
-    });
-
-    it('should handle dangerouslySetInnerHTML', function() {
-      var innerHTML = {__html: 'testContent'};
-      expect(
-        genMarkup({dangerouslySetInnerHTML: innerHTML})
-      ).toHaveInnerhtml('testContent');
-    });
+    expect(container.childNodes[0].getAttribute('myattr')).toBe('myval');
   });
 
-  describe('mountComponent', function() {
-    var mountComponent;
+  it('should clear all the styles when removing `style`', function() {
+    var styles = {display: 'none', color: 'red'};
+    var container = document.createElement('div');
+    ReactDOM.render(<div style={styles} />, container);
 
-    beforeEach(function() {
-      mountComponent = function(props) {
-        var container = document.createElement('div');
-        ReactDOM.render(<div {...props} />, container);
-      };
-    });
+    var stubStyle = container.firstChild.style;
 
-    it('should work error event on <source> element', function() {
-      spyOn(console, 'error');
-      var container = document.createElement('div');
-      ReactDOM.render(
-        <video>
-          <source src="http://example.org/video" type="video/mp4" onError={(e) => console.error('onError called')} />
-        </video>,
-        container
-      );
-
-      var errorEvent = document.createEvent('Event');
-      errorEvent.initEvent('error', false, false);
-      container.getElementsByTagName('source')[0].dispatchEvent(errorEvent);
-
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        'onError called'
-      );
-    });
-
-    it('should not duplicate uppercased selfclosing tags', function() {
-      class Container extends React.Component {
-        render() {
-          return React.createElement('BR', null);
-        }
-      }
-
-      var returnedValue = ReactDOMServer.renderToString(<Container/>);
-      expect(returnedValue).not.toContain('</BR>');
-    });
-
-    it('should warn against children for void elements', function() {
-      var container = document.createElement('div');
-
-      expect(function() {
-        ReactDOM.render(<input>children</input>, container);
-      }).toThrowError(
-        'input is a void element tag and must neither have `children` nor ' +
-        'use `dangerouslySetInnerHTML`.'
-      );
-    });
-
-    it('should warn against dangerouslySetInnerHTML for void elements', function() {
-      var container = document.createElement('div');
-
-      expect(function() {
-        ReactDOM.render(
-          <input dangerouslySetInnerHTML={{__html: 'content'}} />,
-          container
-        );
-      }).toThrowError(
-        'input is a void element tag and must neither have `children` nor use ' +
-        '`dangerouslySetInnerHTML`.'
-      );
-    });
-
-    it('should treat menuitem as a void element but still create the closing tag', function() {
-      var container = document.createElement('div');
-
-      var returnedValue = ReactDOMServer.renderToString(<menu><menuitem /></menu>);
-
-      expect(returnedValue).toContain('</menuitem>');
-
-      expect(function() {
-        ReactDOM.render(<menu><menuitem>children</menuitem></menu>, container);
-      }).toThrowError(
-        'menuitem is a void element tag and must neither have `children` nor use ' +
-        '`dangerouslySetInnerHTML`.'
-      );
-
-    });
-
-    it('should validate against multiple children props', function() {
-      expect(function() {
-        mountComponent({children: '', dangerouslySetInnerHTML: ''});
-      }).toThrowError(
-        'Can only set one of `children` or `props.dangerouslySetInnerHTML`.'
-      );
-    });
-
-    it('should validate against use of innerHTML', function() {
-
-      spyOn(console, 'error');
-      mountComponent({innerHTML: '<span>Hi Jim!</span>'});
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        'Directly setting property `innerHTML` is not permitted. '
-      );
-    });
-
-    it('should validate use of dangerouslySetInnerHTML', function() {
-      expect(function() {
-        mountComponent({dangerouslySetInnerHTML: '<span>Hi Jim!</span>'});
-      }).toThrowError(
-        '`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. ' +
-        'Please visit https://fb.me/react-invariant-dangerously-set-inner-html for more information.'
-      );
-    });
-
-    it('should validate use of dangerouslySetInnerHTML', function() {
-      expect(function() {
-        mountComponent({dangerouslySetInnerHTML: {foo: 'bar'} });
-      }).toThrowError(
-        '`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. ' +
-        'Please visit https://fb.me/react-invariant-dangerously-set-inner-html for more information.'
-      );
-    });
-
-    it('should allow {__html: null}', function() {
-      expect(function() {
-        mountComponent({dangerouslySetInnerHTML: {__html: null} });
-      }).not.toThrow();
-    });
-
-    it('should warn about contentEditable and children', function() {
-      spyOn(console, 'error');
-      mountComponent({contentEditable: true, children: ''});
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain('contentEditable');
-    });
-
-    it('should respect suppressContentEditableWarning', function() {
-      spyOn(console, 'error');
-      mountComponent({contentEditable: true, children: '', suppressContentEditableWarning: true});
-      expect(console.error.calls.count()).toBe(0);
-    });
-
-    it('should validate against invalid styles', function() {
-      expect(function() {
-        mountComponent({style: 'display: none'});
-      }).toThrowError(
-        'The `style` prop expects a mapping from style properties to values, ' +
-        'not a string. For example, style={{marginRight: spacing + \'em\'}} ' +
-        'when using JSX.'
-      );
-    });
-
-    it('should track input values', function() {
-      var container = document.createElement('div');
-      var inst = ReactDOM.render(<input type="text" defaultValue="foo"/>, container);
-
-      var tracker = inputValueTracking._getTrackerFromNode(inst);
-
-      expect(tracker.getValue()).toEqual('foo');
-    });
-
-    it('should track textarea values', function() {
-      var container = document.createElement('div');
-      var inst = ReactDOM.render(<textarea defaultValue="foo"/>, container);
-
-      var tracker = inputValueTracking._getTrackerFromNode(inst);
-
-      expect(tracker.getValue()).toEqual('foo');
-    });
-
-    it('should execute custom event plugin listening behavior', function() {
-      var SimpleEventPlugin = require('SimpleEventPlugin');
-
-      SimpleEventPlugin.didPutListener = jest.fn();
-      SimpleEventPlugin.willDeleteListener = jest.fn();
-
-      var container = document.createElement('div');
-      ReactDOM.render(
-        <div onClick={() => true} />,
-        container
-      );
-
-      expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(1);
-
-      ReactDOM.unmountComponentAtNode(container);
-
-      expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(1);
-    });
-
-    it('should handle null and missing properly with event hooks', function() {
-      var SimpleEventPlugin = require('SimpleEventPlugin');
-
-      SimpleEventPlugin.didPutListener = jest.fn();
-      SimpleEventPlugin.willDeleteListener = jest.fn();
-      var container = document.createElement('div');
-
-      ReactDOM.render(<div onClick={false} />, container);
-      expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(0);
-      expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(0);
-
-      ReactDOM.render(<div onClick={null} />, container);
-      expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(0);
-      expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(0);
-
-      ReactDOM.render(<div onClick={() => 'apple'} />, container);
-      expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(1);
-      expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(0);
-
-      ReactDOM.render(<div onClick={() => 'banana'} />, container);
-      expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(2);
-      expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(0);
-
-      ReactDOM.render(<div onClick={null} />, container);
-      expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(2);
-      expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(1);
-
-      ReactDOM.render(<div />, container);
-      expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(2);
-      expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(1);
-
-      ReactDOM.unmountComponentAtNode(container);
-      expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(2);
-      expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(1);
-    });
-
-    it('should warn for children on void elements', function() {
-      class X extends React.Component {
-        render() {
-          return <input>moo</input>;
-        }
-      }
-
-      var container = document.createElement('div');
-      expect(function() {
-        ReactDOM.render(<X />, container);
-      }).toThrowError(
-        'input is a void element tag and must neither have `children` ' +
-        'nor use `dangerouslySetInnerHTML`. Check the render method of X.'
-      );
-    });
-
-    it('should support custom elements which extend native elements', function() {
-      if (ReactDOMFeatureFlags.useCreateElement) {
-        var container = document.createElement('div');
-        spyOn(document, 'createElement').and.callThrough();
-        ReactDOM.render(<div is="custom-div" />, container);
-        expect(document.createElement).toHaveBeenCalledWith('div', 'custom-div');
-      } else {
-        expect(ReactDOMServer.renderToString(<div is="custom-div" />)).toContain('is="custom-div"');
-      }
-    });
+    ReactDOM.render(<div />, container);
+    expect(stubStyle.display).toEqual('');
+    expect(stubStyle.color).toEqual('');
   });
 
-  describe('updateComponent', function() {
-    var container;
+  it('should update styles when `style` changes from null to object', function() {
+    var container = document.createElement('div');
+    var styles = {color: 'red'};
+    ReactDOM.render(<div style={styles} />, container);
+    ReactDOM.render(<div />, container);
+    ReactDOM.render(<div style={styles} />, container);
 
-    beforeEach(function() {
-      container = document.createElement('div');
-    });
-
-    it('should warn against children for void elements', function() {
-      ReactDOM.render(<input />, container);
-
-      expect(function() {
-        ReactDOM.render(<input>children</input>, container);
-      }).toThrowError(
-        'input is a void element tag and must neither have `children` nor use ' +
-        '`dangerouslySetInnerHTML`.'
-      );
-    });
-
-    it('should warn against dangerouslySetInnerHTML for void elements', function() {
-      ReactDOM.render(<input />, container);
-
-      expect(function() {
-        ReactDOM.render(
-          <input dangerouslySetInnerHTML={{__html: 'content'}} />,
-          container
-        );
-      }).toThrowError(
-        'input is a void element tag and must neither have `children` nor use ' +
-        '`dangerouslySetInnerHTML`.'
-      );
-    });
-
-    it('should validate against multiple children props', function() {
-      ReactDOM.render(<div></div>, container);
-
-      expect(function() {
-        ReactDOM.render(
-          <div children="" dangerouslySetInnerHTML={{__html: ''}}></div>,
-          container
-        );
-      }).toThrowError(
-        'Can only set one of `children` or `props.dangerouslySetInnerHTML`.'
-      );
-    });
-
-    it('should warn about contentEditable and children', function() {
-      spyOn(console, 'error');
-      ReactDOM.render(
-        <div contentEditable={true}><div /></div>,
-        container
-      );
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain('contentEditable');
-    });
-
-    it('should validate against invalid styles', function() {
-      ReactDOM.render(<div></div>, container);
-
-      expect(function() {
-        ReactDOM.render(<div style={1}></div>, container);
-      }).toThrowError(
-        'The `style` prop expects a mapping from style properties to values, ' +
-        'not a string. For example, style={{marginRight: spacing + \'em\'}} ' +
-        'when using JSX.'
-      );
-    });
-
-    it('should report component containing invalid styles', function() {
-      class Animal extends React.Component {
-        render() {
-          return <div style={1}></div>;
-        }
-      }
-
-      expect(function() {
-        ReactDOM.render(<Animal/>, container);
-      }).toThrowError(
-        'The `style` prop expects a mapping from style properties to values, ' +
-        'not a string. For example, style={{marginRight: spacing + \'em\'}} ' +
-        'when using JSX. This DOM node was rendered by `Animal`.'
-      );
-    });
-
-    it('should properly escape text content and attributes values', function() {
-      expect(
-        ReactDOMServer.renderToStaticMarkup(
-          React.DOM.div({
-            title: '\'"<>&',
-            style: {
-              textAlign: '\'"<>&',
-            },
-          }, '\'"<>&')
-        )
-      ).toBe(
-        '<div title="&#x27;&quot;&lt;&gt;&amp;" style="text-align:&#x27;&quot;&lt;&gt;&amp;;">' +
-          '&#x27;&quot;&lt;&gt;&amp;' +
-        '</div>'
-      );
-    });
+    var stubStyle = container.firstChild.style;
+    expect(stubStyle.color).toEqual('red');
   });
 
-  describe('unmountComponent', function() {
-    it('should clean up listeners', function() {
-      var EventPluginHub = require('EventPluginHub');
-      var ReactDOMComponentTree = require('ReactDOMComponentTree');
+  it('should empty element when removing innerHTML', function() {
+    var container = document.createElement('div');
+    ReactDOM.render(<div dangerouslySetInnerHTML={{__html: ':)'}} />, container);
 
-      var container = document.createElement('div');
-      document.body.appendChild(container);
-
-      var callback = function() {};
-      var instance = <div onClick={callback} />;
-      instance = ReactDOM.render(instance, container);
-
-      var rootNode = ReactDOM.findDOMNode(instance);
-      var inst = ReactDOMComponentTree.getInstanceFromNode(rootNode);
-      expect(
-        EventPluginHub.getListener(inst, 'onClick')
-      ).toBe(callback);
-      expect(rootNode).toBe(ReactDOM.findDOMNode(instance));
-
-      ReactDOM.unmountComponentAtNode(container);
-
-      expect(
-        EventPluginHub.getListener(inst, 'onClick')
-      ).toBe(undefined);
-    });
-
-    it('should clean up input value tracking', function() {
-      var container = document.createElement('div');
-      var node = ReactDOM.render(<input type="text" defaultValue="foo"/>, container);
-      var tracker = inputValueTracking._getTrackerFromNode(node);
-
-      spyOn(tracker, 'stopTracking');
-
-      ReactDOM.unmountComponentAtNode(container);
-
-      expect(tracker.stopTracking.calls.count()).toBe(1);
-    });
-
-    it('should clean up input textarea tracking', function() {
-      var container = document.createElement('div');
-      var node = ReactDOM.render(<textarea defaultValue="foo"/>, container);
-      var tracker = inputValueTracking._getTrackerFromNode(node);
-
-      spyOn(tracker, 'stopTracking');
-
-      ReactDOM.unmountComponentAtNode(container);
-
-      expect(tracker.stopTracking.calls.count()).toBe(1);
-    });
-
-    it('unmounts children before unsetting DOM node info', function() {
-      class Inner extends React.Component {
-        render() {
-          return <span />;
-        }
-
-        componentWillUnmount() {
-          // Should not throw
-          expect(ReactDOM.findDOMNode(this).nodeName).toBe('SPAN');
-        }
-      }
-
-      var container = document.createElement('div');
-      ReactDOM.render(<div><Inner /></div>, container);
-      ReactDOM.unmountComponentAtNode(container);
-    });
+    expect(container.firstChild.innerHTML).toEqual(':)');
+    ReactDOM.render(<div />, container);
+    expect(container.firstChild.innerHTML).toEqual('');
   });
 
-  describe('onScroll warning', function() {
-    it('should warn about the `onScroll` issue when unsupported (IE8)', () => {
-      // Mock this here so we can mimic IE8 support. We require isEventSupported
-      // before React so it's pre-mocked before React would require it.
-      jest.resetModuleRegistry()
-        .mock('isEventSupported');
-      var isEventSupported = require('isEventSupported');
-      isEventSupported.mockReturnValueOnce(false);
+  it('should transition from string content to innerHTML', function() {
+    var container = document.createElement('div');
+    ReactDOM.render(<div>hello</div>, container);
 
-      var ReactTestUtils = require('ReactTestUtils');
-
-      spyOn(console, 'error');
-      ReactTestUtils.renderIntoDocument(<div onScroll={function() {}} />);
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: This browser doesn\'t support the `onScroll` event'
-      );
-    });
-
-    it('should not warn when server-side rendering `onScroll`', function() {
-      spyOn(console, 'error');
-      ReactDOMServer.renderToString(<div onScroll={() => {}}/>);
-      expect(console.error).not.toHaveBeenCalled();
-    });
+    expect(container.firstChild.innerHTML).toEqual('hello');
+    ReactDOM.render(
+      <div dangerouslySetInnerHTML={{__html: 'goodbye'}} />,
+      container
+    );
+    expect(container.firstChild.innerHTML).toEqual('goodbye');
   });
 
-  describe('tag sanitization', function() {
-    it('should throw when an invalid tag name is used', () => {
-      var ReactTestUtils = require('ReactTestUtils');
-      var hackzor = React.createElement('script tag');
-      expect(
-        () => ReactTestUtils.renderIntoDocument(hackzor)
-      ).toThrowError(
-        'Invalid tag: script tag'
-      );
-    });
+  it('should transition from innerHTML to string content', function() {
+    var container = document.createElement('div');
+    ReactDOM.render(
+      <div dangerouslySetInnerHTML={{__html: 'bonjour'}} />,
+      container
+    );
 
-    it('should throw when an attack vector is used', () => {
-      var ReactTestUtils = require('ReactTestUtils');
-      var hackzor = React.createElement('div><img /><div');
-      expect(
-        () => ReactTestUtils.renderIntoDocument(hackzor)
-      ).toThrowError(
-        'Invalid tag: div><img /><div'
-      );
-    });
+    expect(container.firstChild.innerHTML).toEqual('bonjour');
+    ReactDOM.render(<div>adieu</div>, container);
+    expect(container.firstChild.innerHTML).toEqual('adieu');
   });
 
-  describe('nesting validation', function() {
-    var ReactTestUtils;
+  it('should transition from innerHTML to children in nested el', function() {
+    var container = document.createElement('div');
+    ReactDOM.render(
+      <div><div dangerouslySetInnerHTML={{__html: 'bonjour'}} /></div>,
+      container
+    );
 
-    beforeEach(function() {
-      ReactTestUtils = require('ReactTestUtils');
+    expect(container.textContent).toEqual('bonjour');
+    ReactDOM.render(<div><div><span>adieu</span></div></div>, container);
+    expect(container.textContent).toEqual('adieu');
+  });
+
+  it('should transition from children to innerHTML in nested el', function() {
+    var container = document.createElement('div');
+    ReactDOM.render(<div><div><span>adieu</span></div></div>, container);
+
+    expect(container.textContent).toEqual('adieu');
+    ReactDOM.render(
+      <div><div dangerouslySetInnerHTML={{__html: 'bonjour'}} /></div>,
+      container
+    );
+    expect(container.textContent).toEqual('bonjour');
+  });
+
+  it('should not incur unnecessary DOM mutations for attributes', function() {
+    var container = document.createElement('div');
+    ReactDOM.render(<div id="" />, container);
+
+    var node = container.firstChild;
+    var nodeSetAttribute = node.setAttribute;
+    node.setAttribute = jest.fn();
+    node.setAttribute.mockImpl(nodeSetAttribute);
+
+    var nodeRemoveAttribute = node.removeAttribute;
+    node.removeAttribute = jest.fn();
+    node.removeAttribute.mockImpl(nodeRemoveAttribute);
+
+    ReactDOM.render(<div id="" />, container);
+    expect(node.setAttribute.mock.calls.length).toBe(0);
+    expect(node.removeAttribute.mock.calls.length).toBe(0);
+
+    ReactDOM.render(<div id="foo" />, container);
+    expect(node.setAttribute.mock.calls.length).toBe(1);
+    expect(node.removeAttribute.mock.calls.length).toBe(0);
+
+    ReactDOM.render(<div id="foo" />, container);
+    expect(node.setAttribute.mock.calls.length).toBe(1);
+    expect(node.removeAttribute.mock.calls.length).toBe(0);
+
+    ReactDOM.render(<div />, container);
+    expect(node.setAttribute.mock.calls.length).toBe(1);
+    expect(node.removeAttribute.mock.calls.length).toBe(1);
+
+    ReactDOM.render(<div id="" />, container);
+    expect(node.setAttribute.mock.calls.length).toBe(2);
+    expect(node.removeAttribute.mock.calls.length).toBe(1);
+
+    ReactDOM.render(<div />, container);
+    expect(node.setAttribute.mock.calls.length).toBe(2);
+    expect(node.removeAttribute.mock.calls.length).toBe(2);
+  });
+
+  it('should not incur unnecessary DOM mutations for string properties', function() {
+    var container = document.createElement('div');
+    ReactDOM.render(<div value="" />, container);
+
+    var node = container.firstChild;
+
+    var nodeValueSetter = jest.genMockFn();
+
+    var oldSetAttribute = node.setAttribute.bind(node);
+    node.setAttribute = function(key, value) {
+      oldSetAttribute(key, value);
+      nodeValueSetter(key, value);
+    };
+
+    ReactDOM.render(<div value="foo" />, container);
+    expect(nodeValueSetter.mock.calls.length).toBe(1);
+
+    ReactDOM.render(<div value="foo" />, container);
+    expect(nodeValueSetter.mock.calls.length).toBe(1);
+
+    ReactDOM.render(<div />, container);
+    expect(nodeValueSetter.mock.calls.length).toBe(1);
+
+    ReactDOM.render(<div value={null} />, container);
+    expect(nodeValueSetter.mock.calls.length).toBe(1);
+
+    ReactDOM.render(<div value="" />, container);
+    expect(nodeValueSetter.mock.calls.length).toBe(2);
+
+    ReactDOM.render(<div />, container);
+    expect(nodeValueSetter.mock.calls.length).toBe(2);
+  });
+
+  it('should not incur unnecessary DOM mutations for boolean properties', function() {
+    var container = document.createElement('div');
+    ReactDOM.render(<div checked={true} />, container);
+
+    var node = container.firstChild;
+    var nodeValue = true;
+    var nodeValueSetter = jest.fn();
+    Object.defineProperty(node, 'checked', {
+      get: function() {
+        return nodeValue;
+      },
+      set: nodeValueSetter.mockImplementation(function(newValue) {
+        nodeValue = newValue;
+      }),
     });
 
-    it('warns on invalid nesting', () => {
-      spyOn(console, 'error');
-      ReactTestUtils.renderIntoDocument(<div><tr /><tr /></div>);
+    ReactDOM.render(<div checked={true} />, container);
+    expect(nodeValueSetter.mock.calls.length).toBe(0);
 
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: validateDOMNesting(...): <tr> cannot appear as a child of ' +
-        '<div>. See div > tr.'
-      );
-    });
+    ReactDOM.render(<div />, container);
+    expect(nodeValueSetter.mock.calls.length).toBe(1);
 
-    it('warns on invalid nesting at root', () => {
-      spyOn(console, 'error');
-      var p = document.createElement('p');
-      ReactDOM.render(<span><p /></span>, p);
+    ReactDOM.render(<div checked={false} />, container);
+    expect(nodeValueSetter.mock.calls.length).toBe(2);
 
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: validateDOMNesting(...): <p> cannot appear as a descendant ' +
-        'of <p>. See p > ... > p.'
-      );
-    });
+    ReactDOM.render(<div checked={true} />, container);
+    expect(nodeValueSetter.mock.calls.length).toBe(3);
+  });
 
-    it('warns nicely for table rows', () => {
-      spyOn(console, 'error');
+  it('should ignore attribute whitelist for elements with the "is: attribute', function() {
+    var container = document.createElement('div');
+    ReactDOM.render(<button is="test" cowabunga="chevynova"/>, container);
+    expect(container.firstChild.hasAttribute('cowabunga')).toBe(true);
+  });
 
-      class Row extends React.Component {
-        render() {
-          return <tr>x</tr>;
-        }
-      }
+  it('should not update when switching between null/undefined', function() {
+    var container = document.createElement('div');
+    var node = ReactDOM.render(<div />, container);
 
-      class Foo extends React.Component {
-        render() {
-          return <table><Row /> </table>;
-        }
-      }
+    var setter = jest.fn();
+    node.setAttribute = setter;
 
-      ReactTestUtils.renderIntoDocument(<Foo />);
+    ReactDOM.render(<div dir={null} />, container);
+    ReactDOM.render(<div dir={undefined} />, container);
+    ReactDOM.render(<div />, container);
+    expect(setter.mock.calls.length).toBe(0);
+    ReactDOM.render(<div dir="ltr" />, container);
+    expect(setter.mock.calls.length).toBe(1);
+  });
 
-      expect(console.error.calls.count()).toBe(3);
-      expect(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: validateDOMNesting(...): <tr> cannot appear as a child of ' +
-        '<table>. See Foo > table > Row > tr. Add a <tbody> to your code to ' +
-        'match the DOM tree generated by the browser.'
-      );
-      expect(console.error.calls.argsFor(1)[0]).toBe(
-        'Warning: validateDOMNesting(...): Text nodes cannot appear as a ' +
-        'child of <tr>. See Row > tr > #text.'
-      );
-      expect(console.error.calls.argsFor(2)[0]).toBe(
-        'Warning: validateDOMNesting(...): Whitespace text nodes cannot ' +
-        'appear as a child of <table>. Make sure you don\'t have any extra ' +
-        'whitespace between tags on each line of your source code. See Foo > ' +
-        'table > #text.'
-      );
-    });
+  it('handles multiple child updates without interference', function() {
+    // This test might look like it's just testing ReactMultiChild but the
+    // last bug in this was actually in DOMChildrenOperations so this test
+    // needs to be in some DOM-specific test file.
+    var container = document.createElement('div');
 
-    it('gives useful context in warnings', () => {
-      spyOn(console, 'error');
-      var Row = React.createClass({
-        render: () => <tr />,
-      });
-      var FancyRow = React.createClass({
-        render: () => <Row />,
-      });
-
-      class Table extends React.Component {
-        render() {
-          return <table>{this.props.children}</table>;
-        }
-      }
-
-      class FancyTable extends React.Component {
-        render() {
-          return <Table>{this.props.children}</Table>;
-        }
-      }
-
-      var Viz1 = React.createClass({
-        render: () => <table><FancyRow /></table>,
-      });
-      var App1 = React.createClass({
-        render: () => <Viz1 />,
-      });
-      ReactTestUtils.renderIntoDocument(<App1 />);
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        'See Viz1 > table > FancyRow > Row > tr.'
-      );
-
-      var Viz2 = React.createClass({
-        render: () => <FancyTable><FancyRow /></FancyTable>,
-      });
-      var App2 = React.createClass({
-        render: () => <Viz2 />,
-      });
-      ReactTestUtils.renderIntoDocument(<App2 />);
-      expect(console.error.calls.count()).toBe(2);
-      expect(console.error.calls.argsFor(1)[0]).toContain(
-        'See Viz2 > FancyTable > Table > table > FancyRow > Row > tr.'
-      );
-
-      ReactTestUtils.renderIntoDocument(<FancyTable><FancyRow /></FancyTable>);
-      expect(console.error.calls.count()).toBe(3);
-      expect(console.error.calls.argsFor(2)[0]).toContain(
-        'See FancyTable > Table > table > FancyRow > Row > tr.'
-      );
-
-      ReactTestUtils.renderIntoDocument(<table><FancyRow /></table>);
-      expect(console.error.calls.count()).toBe(4);
-      expect(console.error.calls.argsFor(3)[0]).toContain(
-        'See table > FancyRow > Row > tr.'
-      );
-
-      ReactTestUtils.renderIntoDocument(<FancyTable><tr /></FancyTable>);
-      expect(console.error.calls.count()).toBe(5);
-      expect(console.error.calls.argsFor(4)[0]).toContain(
-        'See FancyTable > Table > table > tr.'
-      );
-
-      class Link extends React.Component {
-        render() {
-          return <a>{this.props.children}</a>;
-        }
-      }
-
-      ReactTestUtils.renderIntoDocument(<Link><div><Link /></div></Link>);
-      expect(console.error.calls.count()).toBe(6);
-      expect(console.error.calls.argsFor(5)[0]).toContain(
-        'See Link > a > ... > Link > a.'
-      );
-    });
-
-    it('should warn about incorrect casing on properties (ssr)', function() {
-      spyOn(console, 'error');
-      ReactDOMServer.renderToString(React.createElement('input', {type: 'text', tabindex: '1'}));
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain('tabIndex');
-    });
-
-    it('should warn about incorrect casing on event handlers (ssr)', function() {
-      spyOn(console, 'error');
-      ReactDOMServer.renderToString(React.createElement('input', {type: 'text', onclick: '1'}));
-      ReactDOMServer.renderToString(React.createElement('input', {type: 'text', onKeydown: '1'}));
-      expect(console.error.calls.count()).toBe(2);
-      expect(console.error.calls.argsFor(0)[0]).toContain('onClick');
-      expect(console.error.calls.argsFor(1)[0]).toContain('onKeyDown');
-    });
-
-    it('should warn about incorrect casing on properties', function() {
-      spyOn(console, 'error');
-      ReactTestUtils.renderIntoDocument(React.createElement('input', {type: 'text', tabindex: '1'}));
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain('tabIndex');
-    });
-
-    it('should warn about incorrect casing on event handlers', function() {
-      spyOn(console, 'error');
-      ReactTestUtils.renderIntoDocument(React.createElement('input', {type: 'text', onclick: '1'}));
-      ReactTestUtils.renderIntoDocument(React.createElement('input', {type: 'text', onKeydown: '1'}));
-      expect(console.error.calls.count()).toBe(2);
-      expect(console.error.calls.argsFor(0)[0]).toContain('onClick');
-      expect(console.error.calls.argsFor(1)[0]).toContain('onKeyDown');
-    });
-
-    it('should warn about class', function() {
-      spyOn(console, 'error');
-      ReactDOMServer.renderToString(React.createElement('div', {class: 'muffins'}));
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain('className');
-    });
-
-    it('should warn about props that are no longer supported', function() {
-      spyOn(console, 'error');
-      ReactTestUtils.renderIntoDocument(<div />);
-      expect(console.error.calls.count()).toBe(0);
-
-      ReactTestUtils.renderIntoDocument(<div onFocusIn={() => {}} />);
-      expect(console.error.calls.count()).toBe(1);
-
-      ReactTestUtils.renderIntoDocument(<div onFocusOut={() => {}} />);
-      expect(console.error.calls.count()).toBe(2);
-    });
-
-    it('gives source code refs for unknown prop warning', function() {
-      spyOn(console, 'error');
-      ReactDOMServer.renderToString(<div class="paladin"/>);
-      ReactDOMServer.renderToString(<input type="text" onclick="1"/>);
-      expect(console.error.calls.count()).toBe(2);
-      expect(
-        normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])
-      ).toBe(
-        'Warning: Unknown DOM property class. Did you mean className?\n    in div (at **)'
-      );
-      expect(
-        normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])
-      ).toBe(
-        'Warning: Unknown event handler property onclick. Did you mean ' +
-        '`onClick`?\n    in input (at **)'
-      );
-    });
-
-    it('gives source code refs for unknown prop warning for update render', function() {
-      spyOn(console, 'error');
-      var container = document.createElement('div');
-
-      ReactDOMServer.renderToString(<div className="paladin" />, container);
-      expect(console.error.calls.count()).toBe(0);
-
-      ReactDOMServer.renderToString(<div class="paladin" />, container);
-      expect(console.error.calls.count()).toBe(1);
-      expect(
-        normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])
-      ).toBe(
-        'Warning: Unknown DOM property class. Did you mean className?\n    in div (at **)'
-      );
-
-    });
-
-    it('gives source code refs for unknown prop warning for exact elements ', function() {
-      spyOn(console, 'error');
-
-      ReactDOMServer.renderToString(
-        <div className="foo1">
-        <div class="foo2"/>
-        <div onClick="foo3"/>
-        <div onclick="foo4"/>
-        <div className="foo5"/>
-        <div className="foo6"/>
+    // ABCD
+    ReactDOM.render(
+      <div>
+        <div key="one">
+          <div key="A">A</div><div key="B">B</div>
         </div>
+        <div key="two">
+          <div key="C">C</div><div key="D">D</div>
+        </div>
+      </div>,
+      container
+    );
+    // BADC
+    ReactDOM.render(
+      <div>
+        <div key="one">
+          <div key="B">B</div><div key="A">A</div>
+        </div>
+        <div key="two">
+          <div key="D">D</div><div key="C">C</div>
+        </div>
+      </div>,
+      container
+    );
+
+    expect(container.textContent).toBe('BADC');
+  });
+});
+
+describe('createOpenTagMarkup', function() {
+  var genMarkup;
+
+  function quoteRegexp(str) {
+    return (str + '').replace(/([.?*+\^$\[\]\\(){}|-])/g, '\\$1');
+  }
+
+  beforeEach(function() {
+    var ReactDefaultInjection = require('ReactDefaultInjection');
+    ReactDefaultInjection.inject();
+
+    var ReactDOMComponent = require('ReactDOMComponent');
+    var ReactReconcileTransaction = require('ReactReconcileTransaction');
+
+    var NodeStub = function(initialProps) {
+      this._currentElement = {props: initialProps};
+      this._rootNodeID = 1;
+    };
+    Object.assign(NodeStub.prototype, ReactDOMComponent.Mixin);
+
+    genMarkup = function(props) {
+      var transaction = new ReactReconcileTransaction();
+      return (new NodeStub(props))._createOpenTagMarkupAndPutListeners(
+        transaction,
+        props
       );
+    };
 
-      expect(console.error.calls.count()).toBe(2);
-
-      expect(console.error.calls.argsFor(0)[0]).toContain('className');
-      var matches = console.error.calls.argsFor(0)[0].match(/.*\(.*:(\d+)\).*/);
-      var previousLine = matches[1];
-
-      expect(console.error.calls.argsFor(1)[0]).toContain('onClick');
-      matches = console.error.calls.argsFor(1)[0].match(/.*\(.*:(\d+)\).*/);
-      var currentLine = matches[1];
-
-      //verify line number has a proper relative difference,
-      //since hard coding the line number would make test too brittle
-      expect(parseInt(previousLine, 10) + 2).toBe(parseInt(currentLine, 10));
+    jasmine.addMatchers({
+      toHaveAttribute() {
+        return {
+          compare(actual, expected) {
+            var [attr, value] = expected;
+            var re = '(?:^|\\s)' + attr + '=[\\\'"]';
+            if (typeof value !== 'undefined') {
+              re += quoteRegexp(value) + '[\\\'"]';
+            }
+            return {
+              pass: (new RegExp(re)).test(actual),
+            };
+          },
+        };
+      },
     });
+  });
 
-    it('gives source code refs for unknown prop warning for exact elements in composition ', function() {
-      spyOn(console, 'error');
+  it('should generate the correct markup with className', function() {
+    expect(genMarkup({className: 'a'})).toHaveAttribute(['class', 'a']);
+    expect(genMarkup({className: 'a b'})).toHaveAttribute(['class', 'a b']);
+    expect(genMarkup({className: ''})).toHaveAttribute(['class', '']);
+  });
+
+  it('should escape style names and values', function() {
+    expect(genMarkup({
+      style: {'b&ckground': '<3'},
+    })).toHaveAttribute(['style', 'b&amp;ckground:&lt;3;']);
+  });
+});
+
+describe('createContentMarkup', function() {
+  var genMarkup;
+
+  function quoteRegexp(str) {
+    return (str + '').replace(/([.?*+\^$\[\]\\(){}|-])/g, '\\$1');
+  }
+
+  beforeEach(function() {
+    var ReactDOMComponent = require('ReactDOMComponent');
+    var ReactReconcileTransaction = require('ReactReconcileTransaction');
+
+    var NodeStub = function(initialProps) {
+      this._currentElement = {props: initialProps};
+      this._rootNodeID = 1;
+    };
+    Object.assign(NodeStub.prototype, ReactDOMComponent.Mixin);
+
+    genMarkup = function(props) {
+      var transaction = new ReactReconcileTransaction();
+      return (new NodeStub(props))._createContentMarkup(
+        transaction,
+        props,
+        {}
+      );
+    };
+
+    jasmine.addMatchers({
+      toHaveInnerhtml() {
+        return {
+          compare(actual, expected) {
+            var re = '^' + quoteRegexp(expected) + '$';
+            return {
+              pass: (new RegExp(re)).test(actual),
+            };
+          },
+        };
+      },
+    });
+  });
+
+  it('should handle dangerouslySetInnerHTML', function() {
+    var innerHTML = {__html: 'testContent'};
+    expect(
+      genMarkup({dangerouslySetInnerHTML: innerHTML})
+    ).toHaveInnerhtml('testContent');
+  });
+});
+
+describe('mountComponent', function() {
+  var mountComponent;
+
+  beforeEach(function() {
+    mountComponent = function(props) {
       var container = document.createElement('div');
+      ReactDOM.render(<div {...props} />, container);
+    };
+  });
 
-      class Parent extends React.Component {
-        render() {
-          return <div><Child1 /><Child2 /><Child3 /><Child4 /></div>;
-        }
+  it('should work error event on <source> element', function() {
+    spyOn(console, 'error');
+    var container = document.createElement('div');
+    ReactDOM.render(
+      <video>
+        <source src="http://example.org/video" type="video/mp4" onError={(e) => console.error('onError called')} />
+      </video>,
+      container
+    );
+
+    var errorEvent = document.createEvent('Event');
+    errorEvent.initEvent('error', false, false);
+    container.getElementsByTagName('source')[0].dispatchEvent(errorEvent);
+
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toContain(
+      'onError called'
+    );
+  });
+
+  it('should not duplicate uppercased selfclosing tags', function() {
+    class Container extends React.Component {
+      render() {
+        return React.createElement('BR', null);
+      }
+    }
+
+    var returnedValue = ReactDOMServer.renderToString(<Container/>);
+    expect(returnedValue).not.toContain('</BR>');
+  });
+
+  it('should warn against children for void elements', function() {
+    var container = document.createElement('div');
+
+    expect(function() {
+      ReactDOM.render(<input>children</input>, container);
+    }).toThrowError(
+      'input is a void element tag and must neither have `children` nor ' +
+      'use `dangerouslySetInnerHTML`.'
+    );
+  });
+
+  it('should warn against dangerouslySetInnerHTML for void elements', function() {
+    var container = document.createElement('div');
+
+    expect(function() {
+      ReactDOM.render(
+        <input dangerouslySetInnerHTML={{__html: 'content'}} />,
+        container
+      );
+    }).toThrowError(
+      'input is a void element tag and must neither have `children` nor use ' +
+      '`dangerouslySetInnerHTML`.'
+    );
+  });
+
+  it('should treat menuitem as a void element but still create the closing tag', function() {
+    var container = document.createElement('div');
+
+    var returnedValue = ReactDOMServer.renderToString(<menu><menuitem /></menu>);
+
+    expect(returnedValue).toContain('</menuitem>');
+
+    expect(function() {
+      ReactDOM.render(<menu><menuitem>children</menuitem></menu>, container);
+    }).toThrowError(
+      'menuitem is a void element tag and must neither have `children` nor use ' +
+      '`dangerouslySetInnerHTML`.'
+    );
+
+  });
+
+  it('should validate against multiple children props', function() {
+    expect(function() {
+      mountComponent({children: '', dangerouslySetInnerHTML: ''});
+    }).toThrowError(
+      'Can only set one of `children` or `props.dangerouslySetInnerHTML`.'
+    );
+  });
+
+  it('should validate against use of innerHTML', function() {
+
+    spyOn(console, 'error');
+    mountComponent({innerHTML: '<span>Hi Jim!</span>'});
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toContain(
+      'Directly setting property `innerHTML` is not permitted. '
+    );
+  });
+
+  it('should validate use of dangerouslySetInnerHTML', function() {
+    expect(function() {
+      mountComponent({dangerouslySetInnerHTML: '<span>Hi Jim!</span>'});
+    }).toThrowError(
+      '`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. ' +
+      'Please visit https://fb.me/react-invariant-dangerously-set-inner-html for more information.'
+    );
+  });
+
+  it('should validate use of dangerouslySetInnerHTML', function() {
+    expect(function() {
+      mountComponent({dangerouslySetInnerHTML: {foo: 'bar'} });
+    }).toThrowError(
+      '`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. ' +
+      'Please visit https://fb.me/react-invariant-dangerously-set-inner-html for more information.'
+    );
+  });
+
+  it('should allow {__html: null}', function() {
+    expect(function() {
+      mountComponent({dangerouslySetInnerHTML: {__html: null} });
+    }).not.toThrow();
+  });
+
+  it('should warn about contentEditable and children', function() {
+    spyOn(console, 'error');
+    mountComponent({contentEditable: true, children: ''});
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toContain('contentEditable');
+  });
+
+  it('should respect suppressContentEditableWarning', function() {
+    spyOn(console, 'error');
+    mountComponent({contentEditable: true, children: '', suppressContentEditableWarning: true});
+    expect(console.error.calls.count()).toBe(0);
+  });
+
+  it('should validate against invalid styles', function() {
+    expect(function() {
+      mountComponent({style: 'display: none'});
+    }).toThrowError(
+      'The `style` prop expects a mapping from style properties to values, ' +
+      'not a string. For example, style={{marginRight: spacing + \'em\'}} ' +
+      'when using JSX.'
+    );
+  });
+
+  it('should track input values', function() {
+    var container = document.createElement('div');
+    var inst = ReactDOM.render(<input type="text" defaultValue="foo"/>, container);
+
+    var tracker = inputValueTracking._getTrackerFromNode(inst);
+
+    expect(tracker.getValue()).toEqual('foo');
+  });
+
+  it('should track textarea values', function() {
+    var container = document.createElement('div');
+    var inst = ReactDOM.render(<textarea defaultValue="foo"/>, container);
+
+    var tracker = inputValueTracking._getTrackerFromNode(inst);
+
+    expect(tracker.getValue()).toEqual('foo');
+  });
+
+  it('should execute custom event plugin listening behavior', function() {
+    var SimpleEventPlugin = require('SimpleEventPlugin');
+
+    SimpleEventPlugin.didPutListener = jest.fn();
+    SimpleEventPlugin.willDeleteListener = jest.fn();
+
+    var container = document.createElement('div');
+    ReactDOM.render(
+      <div onClick={() => true} />,
+      container
+    );
+
+    expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(1);
+
+    ReactDOM.unmountComponentAtNode(container);
+
+    expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(1);
+  });
+
+  it('should handle null and missing properly with event hooks', function() {
+    var SimpleEventPlugin = require('SimpleEventPlugin');
+
+    SimpleEventPlugin.didPutListener = jest.fn();
+    SimpleEventPlugin.willDeleteListener = jest.fn();
+    var container = document.createElement('div');
+
+    ReactDOM.render(<div onClick={false} />, container);
+    expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(0);
+    expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(0);
+
+    ReactDOM.render(<div onClick={null} />, container);
+    expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(0);
+    expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(0);
+
+    ReactDOM.render(<div onClick={() => 'apple'} />, container);
+    expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(1);
+    expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(0);
+
+    ReactDOM.render(<div onClick={() => 'banana'} />, container);
+    expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(2);
+    expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(0);
+
+    ReactDOM.render(<div onClick={null} />, container);
+    expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(2);
+    expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(1);
+
+    ReactDOM.render(<div />, container);
+    expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(2);
+    expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(1);
+
+    ReactDOM.unmountComponentAtNode(container);
+    expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(2);
+    expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(1);
+  });
+
+  it('should warn for children on void elements', function() {
+    class X extends React.Component {
+      render() {
+        return <input>moo</input>;
+      }
+    }
+
+    var container = document.createElement('div');
+    expect(function() {
+      ReactDOM.render(<X />, container);
+    }).toThrowError(
+      'input is a void element tag and must neither have `children` ' +
+      'nor use `dangerouslySetInnerHTML`. Check the render method of X.'
+    );
+  });
+
+  it('should support custom elements which extend native elements', function() {
+    if (ReactDOMFeatureFlags.useCreateElement) {
+      var container = document.createElement('div');
+      spyOn(document, 'createElement').and.callThrough();
+      ReactDOM.render(<div is="custom-div" />, container);
+      expect(document.createElement).toHaveBeenCalledWith('div', 'custom-div');
+    } else {
+      expect(ReactDOMServer.renderToString(<div is="custom-div" />)).toContain('is="custom-div"');
+    }
+  });
+});
+
+describe('updateComponent', function() {
+  var container;
+
+  beforeEach(function() {
+    container = document.createElement('div');
+  });
+
+  it('should warn against children for void elements', function() {
+    ReactDOM.render(<input />, container);
+
+    expect(function() {
+      ReactDOM.render(<input>children</input>, container);
+    }).toThrowError(
+      'input is a void element tag and must neither have `children` nor use ' +
+      '`dangerouslySetInnerHTML`.'
+    );
+  });
+
+  it('should warn against dangerouslySetInnerHTML for void elements', function() {
+    ReactDOM.render(<input />, container);
+
+    expect(function() {
+      ReactDOM.render(
+        <input dangerouslySetInnerHTML={{__html: 'content'}} />,
+        container
+      );
+    }).toThrowError(
+      'input is a void element tag and must neither have `children` nor use ' +
+      '`dangerouslySetInnerHTML`.'
+    );
+  });
+
+  it('should validate against multiple children props', function() {
+    ReactDOM.render(<div></div>, container);
+
+    expect(function() {
+      ReactDOM.render(
+        <div children="" dangerouslySetInnerHTML={{__html: ''}}></div>,
+        container
+      );
+    }).toThrowError(
+      'Can only set one of `children` or `props.dangerouslySetInnerHTML`.'
+    );
+  });
+
+  it('should warn about contentEditable and children', function() {
+    spyOn(console, 'error');
+    ReactDOM.render(
+      <div contentEditable={true}><div /></div>,
+      container
+    );
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toContain('contentEditable');
+  });
+
+  it('should validate against invalid styles', function() {
+    ReactDOM.render(<div></div>, container);
+
+    expect(function() {
+      ReactDOM.render(<div style={1}></div>, container);
+    }).toThrowError(
+      'The `style` prop expects a mapping from style properties to values, ' +
+      'not a string. For example, style={{marginRight: spacing + \'em\'}} ' +
+      'when using JSX.'
+    );
+  });
+
+  it('should report component containing invalid styles', function() {
+    class Animal extends React.Component {
+      render() {
+        return <div style={1}></div>;
+      }
+    }
+
+    expect(function() {
+      ReactDOM.render(<Animal/>, container);
+    }).toThrowError(
+      'The `style` prop expects a mapping from style properties to values, ' +
+      'not a string. For example, style={{marginRight: spacing + \'em\'}} ' +
+      'when using JSX. This DOM node was rendered by `Animal`.'
+    );
+  });
+
+  it('should properly escape text content and attributes values', function() {
+    expect(
+      ReactDOMServer.renderToStaticMarkup(
+        React.DOM.div({
+          title: '\'"<>&',
+          style: {
+            textAlign: '\'"<>&',
+          },
+        }, '\'"<>&')
+      )
+    ).toBe(
+      '<div title="&#x27;&quot;&lt;&gt;&amp;" style="text-align:&#x27;&quot;&lt;&gt;&amp;;">' +
+        '&#x27;&quot;&lt;&gt;&amp;' +
+      '</div>'
+    );
+  });
+});
+
+describe('unmountComponent', function() {
+  it('should clean up listeners', function() {
+    var EventPluginHub = require('EventPluginHub');
+    var ReactDOMComponentTree = require('ReactDOMComponentTree');
+
+    var container = document.createElement('div');
+    document.body.appendChild(container);
+
+    var callback = function() {};
+    var instance = <div onClick={callback} />;
+    instance = ReactDOM.render(instance, container);
+
+    var rootNode = ReactDOM.findDOMNode(instance);
+    var inst = ReactDOMComponentTree.getInstanceFromNode(rootNode);
+    expect(
+      EventPluginHub.getListener(inst, 'onClick')
+    ).toBe(callback);
+    expect(rootNode).toBe(ReactDOM.findDOMNode(instance));
+
+    ReactDOM.unmountComponentAtNode(container);
+
+    expect(
+      EventPluginHub.getListener(inst, 'onClick')
+    ).toBe(undefined);
+  });
+
+  it('should clean up input value tracking', function() {
+    var container = document.createElement('div');
+    var node = ReactDOM.render(<input type="text" defaultValue="foo"/>, container);
+    var tracker = inputValueTracking._getTrackerFromNode(node);
+
+    spyOn(tracker, 'stopTracking');
+
+    ReactDOM.unmountComponentAtNode(container);
+
+    expect(tracker.stopTracking.calls.count()).toBe(1);
+  });
+
+  it('should clean up input textarea tracking', function() {
+    var container = document.createElement('div');
+    var node = ReactDOM.render(<textarea defaultValue="foo"/>, container);
+    var tracker = inputValueTracking._getTrackerFromNode(node);
+
+    spyOn(tracker, 'stopTracking');
+
+    ReactDOM.unmountComponentAtNode(container);
+
+    expect(tracker.stopTracking.calls.count()).toBe(1);
+  });
+
+  it('unmounts children before unsetting DOM node info', function() {
+    class Inner extends React.Component {
+      render() {
+        return <span />;
       }
 
-      class Child1 extends React.Component {
-        render() {
-          return <div class="paladin">Child1</div>;
-        }
+      componentWillUnmount() {
+        // Should not throw
+        expect(ReactDOM.findDOMNode(this).nodeName).toBe('SPAN');
       }
+    }
 
-      class Child2 extends React.Component {
-        render() {
-          return <div>Child2</div>;
-        }
+    var container = document.createElement('div');
+    ReactDOM.render(<div><Inner /></div>, container);
+    ReactDOM.unmountComponentAtNode(container);
+  });
+});
+
+describe('onScroll warning', function() {
+  it('should warn about the `onScroll` issue when unsupported (IE8)', () => {
+    // Mock this here so we can mimic IE8 support. We require isEventSupported
+    // before React so it's pre-mocked before React would require it.
+    jest.resetModuleRegistry()
+      .mock('isEventSupported');
+    var isEventSupported = require('isEventSupported');
+    isEventSupported.mockReturnValueOnce(false);
+
+    var ReactTestUtils = require('ReactTestUtils');
+
+    spyOn(console, 'error');
+    ReactTestUtils.renderIntoDocument(<div onScroll={function() {}} />);
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toBe(
+      'Warning: This browser doesn\'t support the `onScroll` event'
+    );
+  });
+
+  it('should not warn when server-side rendering `onScroll`', function() {
+    spyOn(console, 'error');
+    ReactDOMServer.renderToString(<div onScroll={() => {}}/>);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+});
+
+describe('tag sanitization', function() {
+  it('should throw when an invalid tag name is used', () => {
+    var ReactTestUtils = require('ReactTestUtils');
+    var hackzor = React.createElement('script tag');
+    expect(
+      () => ReactTestUtils.renderIntoDocument(hackzor)
+    ).toThrowError(
+      'Invalid tag: script tag'
+    );
+  });
+
+  it('should throw when an attack vector is used', () => {
+    var ReactTestUtils = require('ReactTestUtils');
+    var hackzor = React.createElement('div><img /><div');
+    expect(
+      () => ReactTestUtils.renderIntoDocument(hackzor)
+    ).toThrowError(
+      'Invalid tag: div><img /><div'
+    );
+  });
+});
+
+describe('nesting validation', function() {
+  var ReactTestUtils;
+
+  beforeEach(function() {
+    ReactTestUtils = require('ReactTestUtils');
+  });
+
+  it('warns on invalid nesting', () => {
+    spyOn(console, 'error');
+    ReactTestUtils.renderIntoDocument(<div><tr /><tr /></div>);
+
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toBe(
+      'Warning: validateDOMNesting(...): <tr> cannot appear as a child of ' +
+      '<div>. See div > tr.'
+    );
+  });
+
+  it('warns on invalid nesting at root', () => {
+    spyOn(console, 'error');
+    var p = document.createElement('p');
+    ReactDOM.render(<span><p /></span>, p);
+
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toBe(
+      'Warning: validateDOMNesting(...): <p> cannot appear as a descendant ' +
+      'of <p>. See p > ... > p.'
+    );
+  });
+
+  it('warns nicely for table rows', () => {
+    spyOn(console, 'error');
+
+    class Row extends React.Component {
+      render() {
+        return <tr>x</tr>;
       }
+    }
 
-      class Child3 extends React.Component {
-        render() {
-          return <div onclick="1">Child3</div>;
-        }
+    class Foo extends React.Component {
+      render() {
+        return <table><Row /> </table>;
       }
+    }
 
-      class Child4 extends React.Component {
-        render() {
-          return <div>Child4</div>;
-        }
-      }
+    ReactTestUtils.renderIntoDocument(<Foo />);
 
-      ReactDOMServer.renderToString(<Parent />, container);
+    expect(console.error.calls.count()).toBe(3);
+    expect(console.error.calls.argsFor(0)[0]).toBe(
+      'Warning: validateDOMNesting(...): <tr> cannot appear as a child of ' +
+      '<table>. See Foo > table > Row > tr. Add a <tbody> to your code to ' +
+      'match the DOM tree generated by the browser.'
+    );
+    expect(console.error.calls.argsFor(1)[0]).toBe(
+      'Warning: validateDOMNesting(...): Text nodes cannot appear as a ' +
+      'child of <tr>. See Row > tr > #text.'
+    );
+    expect(console.error.calls.argsFor(2)[0]).toBe(
+      'Warning: validateDOMNesting(...): Whitespace text nodes cannot ' +
+      'appear as a child of <table>. Make sure you don\'t have any extra ' +
+      'whitespace between tags on each line of your source code. See Foo > ' +
+      'table > #text.'
+    );
+  });
 
-      expect(console.error.calls.count()).toBe(2);
-
-      expect(console.error.calls.argsFor(0)[0]).toContain('className');
-      var matches = console.error.calls.argsFor(0)[0].match(/.*\(.*:(\d+)\).*/);
-      var previousLine = matches[1];
-
-      expect(console.error.calls.argsFor(1)[0]).toContain('onClick');
-      matches = console.error.calls.argsFor(1)[0].match(/.*\(.*:(\d+)\).*/);
-      var currentLine = matches[1];
-
-      //verify line number has a proper relative difference,
-      //since hard coding the line number would make test too brittle
-      expect(parseInt(previousLine, 10) + 12).toBe(parseInt(currentLine, 10));
+  it('gives useful context in warnings', () => {
+    spyOn(console, 'error');
+    var Row = React.createClass({
+      render: () => <tr />,
     });
+    var FancyRow = React.createClass({
+      render: () => <Row />,
+    });
+
+    class Table extends React.Component {
+      render() {
+        return <table>{this.props.children}</table>;
+      }
+    }
+
+    class FancyTable extends React.Component {
+      render() {
+        return <Table>{this.props.children}</Table>;
+      }
+    }
+
+    var Viz1 = React.createClass({
+      render: () => <table><FancyRow /></table>,
+    });
+    var App1 = React.createClass({
+      render: () => <Viz1 />,
+    });
+    ReactTestUtils.renderIntoDocument(<App1 />);
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toContain(
+      'See Viz1 > table > FancyRow > Row > tr.'
+    );
+
+    var Viz2 = React.createClass({
+      render: () => <FancyTable><FancyRow /></FancyTable>,
+    });
+    var App2 = React.createClass({
+      render: () => <Viz2 />,
+    });
+    ReactTestUtils.renderIntoDocument(<App2 />);
+    expect(console.error.calls.count()).toBe(2);
+    expect(console.error.calls.argsFor(1)[0]).toContain(
+      'See Viz2 > FancyTable > Table > table > FancyRow > Row > tr.'
+    );
+
+    ReactTestUtils.renderIntoDocument(<FancyTable><FancyRow /></FancyTable>);
+    expect(console.error.calls.count()).toBe(3);
+    expect(console.error.calls.argsFor(2)[0]).toContain(
+      'See FancyTable > Table > table > FancyRow > Row > tr.'
+    );
+
+    ReactTestUtils.renderIntoDocument(<table><FancyRow /></table>);
+    expect(console.error.calls.count()).toBe(4);
+    expect(console.error.calls.argsFor(3)[0]).toContain(
+      'See table > FancyRow > Row > tr.'
+    );
+
+    ReactTestUtils.renderIntoDocument(<FancyTable><tr /></FancyTable>);
+    expect(console.error.calls.count()).toBe(5);
+    expect(console.error.calls.argsFor(4)[0]).toContain(
+      'See FancyTable > Table > table > tr.'
+    );
+
+    class Link extends React.Component {
+      render() {
+        return <a>{this.props.children}</a>;
+      }
+    }
+
+    ReactTestUtils.renderIntoDocument(<Link><div><Link /></div></Link>);
+    expect(console.error.calls.count()).toBe(6);
+    expect(console.error.calls.argsFor(5)[0]).toContain(
+      'See Link > a > ... > Link > a.'
+    );
+  });
+
+  it('should warn about incorrect casing on properties (ssr)', function() {
+    spyOn(console, 'error');
+    ReactDOMServer.renderToString(React.createElement('input', {type: 'text', tabindex: '1'}));
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toContain('tabIndex');
+  });
+
+  it('should warn about incorrect casing on event handlers (ssr)', function() {
+    spyOn(console, 'error');
+    ReactDOMServer.renderToString(React.createElement('input', {type: 'text', onclick: '1'}));
+    ReactDOMServer.renderToString(React.createElement('input', {type: 'text', onKeydown: '1'}));
+    expect(console.error.calls.count()).toBe(2);
+    expect(console.error.calls.argsFor(0)[0]).toContain('onClick');
+    expect(console.error.calls.argsFor(1)[0]).toContain('onKeyDown');
+  });
+
+  it('should warn about incorrect casing on properties', function() {
+    spyOn(console, 'error');
+    ReactTestUtils.renderIntoDocument(React.createElement('input', {type: 'text', tabindex: '1'}));
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toContain('tabIndex');
+  });
+
+  it('should warn about incorrect casing on event handlers', function() {
+    spyOn(console, 'error');
+    ReactTestUtils.renderIntoDocument(React.createElement('input', {type: 'text', onclick: '1'}));
+    ReactTestUtils.renderIntoDocument(React.createElement('input', {type: 'text', onKeydown: '1'}));
+    expect(console.error.calls.count()).toBe(2);
+    expect(console.error.calls.argsFor(0)[0]).toContain('onClick');
+    expect(console.error.calls.argsFor(1)[0]).toContain('onKeyDown');
+  });
+
+  it('should warn about class', function() {
+    spyOn(console, 'error');
+    ReactDOMServer.renderToString(React.createElement('div', {class: 'muffins'}));
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toContain('className');
+  });
+
+  it('should warn about props that are no longer supported', function() {
+    spyOn(console, 'error');
+    ReactTestUtils.renderIntoDocument(<div />);
+    expect(console.error.calls.count()).toBe(0);
+
+    ReactTestUtils.renderIntoDocument(<div onFocusIn={() => {}} />);
+    expect(console.error.calls.count()).toBe(1);
+
+    ReactTestUtils.renderIntoDocument(<div onFocusOut={() => {}} />);
+    expect(console.error.calls.count()).toBe(2);
+  });
+
+  it('gives source code refs for unknown prop warning', function() {
+    spyOn(console, 'error');
+    ReactDOMServer.renderToString(<div class="paladin"/>);
+    ReactDOMServer.renderToString(<input type="text" onclick="1"/>);
+    expect(console.error.calls.count()).toBe(2);
+    expect(
+      normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])
+    ).toBe(
+      'Warning: Unknown DOM property class. Did you mean className?\n    in div (at **)'
+    );
+    expect(
+      normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])
+    ).toBe(
+      'Warning: Unknown event handler property onclick. Did you mean ' +
+      '`onClick`?\n    in input (at **)'
+    );
+  });
+
+  it('gives source code refs for unknown prop warning for update render', function() {
+    spyOn(console, 'error');
+    var container = document.createElement('div');
+
+    ReactDOMServer.renderToString(<div className="paladin" />, container);
+    expect(console.error.calls.count()).toBe(0);
+
+    ReactDOMServer.renderToString(<div class="paladin" />, container);
+    expect(console.error.calls.count()).toBe(1);
+    expect(
+      normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])
+    ).toBe(
+      'Warning: Unknown DOM property class. Did you mean className?\n    in div (at **)'
+    );
+
+  });
+
+  it('gives source code refs for unknown prop warning for exact elements ', function() {
+    spyOn(console, 'error');
+
+    ReactDOMServer.renderToString(
+      <div className="foo1">
+      <div class="foo2"/>
+      <div onClick="foo3"/>
+      <div onclick="foo4"/>
+      <div className="foo5"/>
+      <div className="foo6"/>
+      </div>
+    );
+
+    expect(console.error.calls.count()).toBe(2);
+
+    expect(console.error.calls.argsFor(0)[0]).toContain('className');
+    var matches = console.error.calls.argsFor(0)[0].match(/.*\(.*:(\d+)\).*/);
+    var previousLine = matches[1];
+
+    expect(console.error.calls.argsFor(1)[0]).toContain('onClick');
+    matches = console.error.calls.argsFor(1)[0].match(/.*\(.*:(\d+)\).*/);
+    var currentLine = matches[1];
+
+    //verify line number has a proper relative difference,
+    //since hard coding the line number would make test too brittle
+    expect(parseInt(previousLine, 10) + 2).toBe(parseInt(currentLine, 10));
+  });
+
+  it('gives source code refs for unknown prop warning for exact elements in composition ', function() {
+    spyOn(console, 'error');
+    var container = document.createElement('div');
+
+    class Parent extends React.Component {
+      render() {
+        return <div><Child1 /><Child2 /><Child3 /><Child4 /></div>;
+      }
+    }
+
+    class Child1 extends React.Component {
+      render() {
+        return <div class="paladin">Child1</div>;
+      }
+    }
+
+    class Child2 extends React.Component {
+      render() {
+        return <div>Child2</div>;
+      }
+    }
+
+    class Child3 extends React.Component {
+      render() {
+        return <div onclick="1">Child3</div>;
+      }
+    }
+
+    class Child4 extends React.Component {
+      render() {
+        return <div>Child4</div>;
+      }
+    }
+
+    ReactDOMServer.renderToString(<Parent />, container);
+
+    expect(console.error.calls.count()).toBe(2);
+
+    expect(console.error.calls.argsFor(0)[0]).toContain('className');
+    var matches = console.error.calls.argsFor(0)[0].match(/.*\(.*:(\d+)\).*/);
+    var previousLine = matches[1];
+
+    expect(console.error.calls.argsFor(1)[0]).toContain('onClick');
+    matches = console.error.calls.argsFor(1)[0].match(/.*\(.*:(\d+)\).*/);
+    var currentLine = matches[1];
+
+    //verify line number has a proper relative difference,
+    //since hard coding the line number would make test too brittle
+    expect(parseInt(previousLine, 10) + 12).toBe(parseInt(currentLine, 10));
   });
 });

--- a/src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
@@ -15,94 +15,92 @@ var React;
 var ReactDOM;
 var ReactDOMServer;
 
-describe('ReactDOMTextComponent', function() {
-  beforeEach(function() {
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactDOMServer = require('ReactDOMServer');
-  });
+beforeEach(function() {
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactDOMServer = require('ReactDOMServer');
+});
 
-  it('updates a mounted text component in place', function() {
-    var el = document.createElement('div');
-    var inst = ReactDOM.render(<div><span />{'foo'}{'bar'}</div>, el);
+it('updates a mounted text component in place', function() {
+  var el = document.createElement('div');
+  var inst = ReactDOM.render(<div><span />{'foo'}{'bar'}</div>, el);
 
-    var foo = ReactDOM.findDOMNode(inst).childNodes[2];
-    var bar = ReactDOM.findDOMNode(inst).childNodes[5];
-    expect(foo.data).toBe('foo');
-    expect(bar.data).toBe('bar');
+  var foo = ReactDOM.findDOMNode(inst).childNodes[2];
+  var bar = ReactDOM.findDOMNode(inst).childNodes[5];
+  expect(foo.data).toBe('foo');
+  expect(bar.data).toBe('bar');
 
-    inst = ReactDOM.render(<div><span />{'baz'}{'qux'}</div>, el);
-    // After the update, the text nodes should have stayed in place (as opposed
-    // to getting unmounted and remounted)
-    expect(ReactDOM.findDOMNode(inst).childNodes[2]).toBe(foo);
-    expect(ReactDOM.findDOMNode(inst).childNodes[5]).toBe(bar);
-    expect(foo.data).toBe('baz');
-    expect(bar.data).toBe('qux');
-  });
+  inst = ReactDOM.render(<div><span />{'baz'}{'qux'}</div>, el);
+  // After the update, the text nodes should have stayed in place (as opposed
+  // to getting unmounted and remounted)
+  expect(ReactDOM.findDOMNode(inst).childNodes[2]).toBe(foo);
+  expect(ReactDOM.findDOMNode(inst).childNodes[5]).toBe(bar);
+  expect(foo.data).toBe('baz');
+  expect(bar.data).toBe('qux');
+});
 
-  it('can be toggled in and out of the markup', function() {
-    var el = document.createElement('div');
-    var inst = ReactDOM.render(<div>{'foo'}<div />{'bar'}</div>, el);
+it('can be toggled in and out of the markup', function() {
+  var el = document.createElement('div');
+  var inst = ReactDOM.render(<div>{'foo'}<div />{'bar'}</div>, el);
 
-    var container = ReactDOM.findDOMNode(inst);
-    var childDiv = container.childNodes[3];
-    var childNodes;
+  var container = ReactDOM.findDOMNode(inst);
+  var childDiv = container.childNodes[3];
+  var childNodes;
 
-    inst = ReactDOM.render(<div>{null}<div />{null}</div>, el);
-    container = ReactDOM.findDOMNode(inst);
-    childNodes = container.childNodes;
-    expect(childNodes.length).toBe(1);
-    expect(childNodes[0]).toBe(childDiv);
+  inst = ReactDOM.render(<div>{null}<div />{null}</div>, el);
+  container = ReactDOM.findDOMNode(inst);
+  childNodes = container.childNodes;
+  expect(childNodes.length).toBe(1);
+  expect(childNodes[0]).toBe(childDiv);
 
-    inst = ReactDOM.render(<div>{'foo'}<div />{'bar'}</div>, el);
-    container = ReactDOM.findDOMNode(inst);
-    childNodes = container.childNodes;
-    expect(childNodes.length).toBe(7);
-    expect(childNodes[1].data).toBe('foo');
-    expect(childNodes[3]).toBe(childDiv);
-    expect(childNodes[5].data).toBe('bar');
-  });
+  inst = ReactDOM.render(<div>{'foo'}<div />{'bar'}</div>, el);
+  container = ReactDOM.findDOMNode(inst);
+  childNodes = container.childNodes;
+  expect(childNodes.length).toBe(7);
+  expect(childNodes[1].data).toBe('foo');
+  expect(childNodes[3]).toBe(childDiv);
+  expect(childNodes[5].data).toBe('bar');
+});
 
-  it('can reconcile text merged by Node.normalize()', function() {
-    var el = document.createElement('div');
-    var inst = ReactDOM.render(<div>{'foo'}{'bar'}{'baz'}</div>, el);
+it('can reconcile text merged by Node.normalize()', function() {
+  var el = document.createElement('div');
+  var inst = ReactDOM.render(<div>{'foo'}{'bar'}{'baz'}</div>, el);
 
-    var container = ReactDOM.findDOMNode(inst);
-    container.normalize();
+  var container = ReactDOM.findDOMNode(inst);
+  container.normalize();
 
-    inst = ReactDOM.render(<div>{'bar'}{'baz'}{'qux'}</div>, el);
-    container = ReactDOM.findDOMNode(inst);
-    expect(container.textContent).toBe('barbazqux');
-  });
+  inst = ReactDOM.render(<div>{'bar'}{'baz'}{'qux'}</div>, el);
+  container = ReactDOM.findDOMNode(inst);
+  expect(container.textContent).toBe('barbazqux');
+});
 
-  it('can reconcile text from pre-rendered markup', function() {
-    var el = document.createElement('div');
-    var reactEl = <div>{'foo'}{'bar'}{'baz'}</div>;
-    el.innerHTML = ReactDOMServer.renderToString(reactEl);
+it('can reconcile text from pre-rendered markup', function() {
+  var el = document.createElement('div');
+  var reactEl = <div>{'foo'}{'bar'}{'baz'}</div>;
+  el.innerHTML = ReactDOMServer.renderToString(reactEl);
 
-    ReactDOM.render(reactEl, el);
-    expect(el.textContent).toBe('foobarbaz');
+  ReactDOM.render(reactEl, el);
+  expect(el.textContent).toBe('foobarbaz');
 
-    reactEl = <div>{''}{''}{''}</div>;
-    el.innerHTML = ReactDOMServer.renderToString(reactEl);
+  reactEl = <div>{''}{''}{''}</div>;
+  el.innerHTML = ReactDOMServer.renderToString(reactEl);
 
-    ReactDOM.render(reactEl, el);
-    expect(el.textContent).toBe('');
-  });
+  ReactDOM.render(reactEl, el);
+  expect(el.textContent).toBe('');
+});
 
-  it('can reconcile text arbitrarily split into multiple nodes', function() {
-    var el = document.createElement('div');
-    var inst = ReactDOM.render(<div><span />{'foobarbaz'}</div>, el);
+it('can reconcile text arbitrarily split into multiple nodes', function() {
+  var el = document.createElement('div');
+  var inst = ReactDOM.render(<div><span />{'foobarbaz'}</div>, el);
 
-    var container = ReactDOM.findDOMNode(inst);
-    var childNodes = container.childNodes;
-    var textNode = childNodes[2];
-    textNode.textContent = 'foo';
-    container.insertBefore(document.createTextNode('bar'), childNodes[3]);
-    container.insertBefore(document.createTextNode('baz'), childNodes[3]);
+  var container = ReactDOM.findDOMNode(inst);
+  var childNodes = container.childNodes;
+  var textNode = childNodes[2];
+  textNode.textContent = 'foo';
+  container.insertBefore(document.createTextNode('bar'), childNodes[3]);
+  container.insertBefore(document.createTextNode('baz'), childNodes[3]);
 
-    inst = ReactDOM.render(<div><span />{'barbazqux'}</div>, el);
-    container = ReactDOM.findDOMNode(inst);
-    expect(container.textContent).toBe('barbazqux');
-  });
+  inst = ReactDOM.render(<div><span />{'barbazqux'}</div>, el);
+  container = ReactDOM.findDOMNode(inst);
+  expect(container.textContent).toBe('barbazqux');
 });

--- a/src/renderers/dom/shared/__tests__/escapeTextContentForBrowser-test.js
+++ b/src/renderers/dom/shared/__tests__/escapeTextContentForBrowser-test.js
@@ -11,38 +11,34 @@
 
 'use strict';
 
-describe('escapeTextContentForBrowser', function() {
+var escapeTextContentForBrowser = require('escapeTextContentForBrowser');
 
-  var escapeTextContentForBrowser = require('escapeTextContentForBrowser');
+it('should escape boolean to string', function() {
+  expect(escapeTextContentForBrowser(true)).toBe('true');
+  expect(escapeTextContentForBrowser(false)).toBe('false');
+});
 
-  it('should escape boolean to string', function() {
-    expect(escapeTextContentForBrowser(true)).toBe('true');
-    expect(escapeTextContentForBrowser(false)).toBe('false');
+it('should escape object to string', function() {
+  var escaped = escapeTextContentForBrowser({
+    toString: function() {
+      return 'ponys';
+    },
   });
 
-  it('should escape object to string', function() {
-    var escaped = escapeTextContentForBrowser({
-      toString: function() {
-        return 'ponys';
-      },
-    });
+  expect(escaped).toBe('ponys');
+});
 
-    expect(escaped).toBe('ponys');
-  });
+it('should escape number to string', function() {
+  expect(escapeTextContentForBrowser(42)).toBe('42');
+});
 
-  it('should escape number to string', function() {
-    expect(escapeTextContentForBrowser(42)).toBe('42');
-  });
+it('should escape string', function() {
+  var escaped = escapeTextContentForBrowser('<script type=\'\' src=""></script>');
+  expect(escaped).not.toContain('<');
+  expect(escaped).not.toContain('>');
+  expect(escaped).not.toContain('\'');
+  expect(escaped).not.toContain('\"');
 
-  it('should escape string', function() {
-    var escaped = escapeTextContentForBrowser('<script type=\'\' src=""></script>');
-    expect(escaped).not.toContain('<');
-    expect(escaped).not.toContain('>');
-    expect(escaped).not.toContain('\'');
-    expect(escaped).not.toContain('\"');
-
-    escaped = escapeTextContentForBrowser('&');
-    expect(escaped).toBe('&amp;');
-  });
-
+  escaped = escapeTextContentForBrowser('&');
+  expect(escaped).toBe('&amp;');
 });

--- a/src/renderers/dom/shared/__tests__/quoteAttributeValueForBrowser-test.js
+++ b/src/renderers/dom/shared/__tests__/quoteAttributeValueForBrowser-test.js
@@ -11,38 +11,34 @@
 
 'use strict';
 
-describe('quoteAttributeValueForBrowser', function() {
+var quoteAttributeValueForBrowser = require('quoteAttributeValueForBrowser');
 
-  var quoteAttributeValueForBrowser = require('quoteAttributeValueForBrowser');
+it('should escape boolean to string', function() {
+  expect(quoteAttributeValueForBrowser(true)).toBe('"true"');
+  expect(quoteAttributeValueForBrowser(false)).toBe('"false"');
+});
 
-  it('should escape boolean to string', function() {
-    expect(quoteAttributeValueForBrowser(true)).toBe('"true"');
-    expect(quoteAttributeValueForBrowser(false)).toBe('"false"');
+it('should escape object to string', function() {
+  var escaped = quoteAttributeValueForBrowser({
+    toString: function() {
+      return 'ponys';
+    },
   });
 
-  it('should escape object to string', function() {
-    var escaped = quoteAttributeValueForBrowser({
-      toString: function() {
-        return 'ponys';
-      },
-    });
+  expect(escaped).toBe('"ponys"');
+});
 
-    expect(escaped).toBe('"ponys"');
-  });
+it('should escape number to string', function() {
+  expect(quoteAttributeValueForBrowser(42)).toBe('"42"');
+});
 
-  it('should escape number to string', function() {
-    expect(quoteAttributeValueForBrowser(42)).toBe('"42"');
-  });
+it('should escape string', function() {
+  var escaped = quoteAttributeValueForBrowser('<script type=\'\' src=""></script>');
+  expect(escaped).not.toContain('<');
+  expect(escaped).not.toContain('>');
+  expect(escaped).not.toContain('\'');
+  expect(escaped.substr(1, -1)).not.toContain('\"');
 
-  it('should escape string', function() {
-    var escaped = quoteAttributeValueForBrowser('<script type=\'\' src=""></script>');
-    expect(escaped).not.toContain('<');
-    expect(escaped).not.toContain('>');
-    expect(escaped).not.toContain('\'');
-    expect(escaped.substr(1, -1)).not.toContain('\"');
-
-    escaped = quoteAttributeValueForBrowser('&');
-    expect(escaped).toBe('"&amp;"');
-  });
-
+  escaped = quoteAttributeValueForBrowser('&');
+  expect(escaped).toBe('"&amp;"');
 });

--- a/src/renderers/native/__tests__/ReactNativeAttributePayload-test.js
+++ b/src/renderers/native/__tests__/ReactNativeAttributePayload-test.js
@@ -14,228 +14,224 @@ var ReactNativePropRegistry = require('ReactNativePropRegistry');
 
 var diff = ReactNativeAttributePayload.diff;
 
-describe('ReactNativeAttributePayload', function() {
+it('should work with simple example', () => {
+  expect(diff(
+    {a: 1, c: 3},
+    {b: 2, c: 3},
+    {a: true, b: true}
+  )).toEqual({a: null, b: 2});
+});
 
-  it('should work with simple example', () => {
-    expect(diff(
-      {a: 1, c: 3},
-      {b: 2, c: 3},
-      {a: true, b: true}
-    )).toEqual({a: null, b: 2});
+it('should skip fields that are equal', () => {
+  expect(diff(
+    {a: 1, b: 'two', c: true, d: false, e: undefined, f: 0},
+    {a: 1, b: 'two', c: true, d: false, e: undefined, f: 0},
+    {a: true, b: true, c: true, d: true, e: true, f: true}
+  )).toEqual(null);
+});
+
+it('should remove fields', () => {
+  expect(diff(
+    {a: 1},
+    {},
+    {a: true}
+  )).toEqual({a: null});
+});
+
+it('should remove fields that are set to undefined', () => {
+  expect(diff(
+    {a: 1},
+    {a: undefined},
+    {a: true}
+  )).toEqual({a: null});
+});
+
+it('should ignore invalid fields', () => {
+  expect(diff(
+    {a: 1},
+    {b: 2},
+    {}
+  )).toEqual(null);
+});
+
+it('should use the diff attribute', () => {
+  var diffA = jest.fn((a, b) => true);
+  var diffB = jest.fn((a, b) => false);
+  expect(diff(
+    {a: [1], b: [3]},
+    {a: [2], b: [4]},
+    {a: {diff: diffA}, b: {diff: diffB}}
+  )).toEqual({a: [2]});
+  expect(diffA).toBeCalledWith([1], [2]);
+  expect(diffB).toBeCalledWith([3], [4]);
+});
+
+it('should not use the diff attribute on addition/removal', () => {
+  var diffA = jest.fn();
+  var diffB = jest.fn();
+  expect(diff(
+    {a: [1]},
+    {b: [2]},
+    {a: {diff: diffA}, b: {diff: diffB}}
+  )).toEqual({a: null, b: [2]});
+  expect(diffA).not.toBeCalled();
+  expect(diffB).not.toBeCalled();
+});
+
+it('should do deep diffs of Objects by default', () => {
+  expect(diff(
+    {a: [1], b: {k: [3, 4]}, c: {k: [4, 4]} },
+    {a: [2], b: {k: [3, 4]}, c: {k: [4, 5]} },
+    {a: true, b: true, c: true}
+  )).toEqual({a: [2], c: {k: [4, 5]}});
+});
+
+it('should work with undefined styles', () => {
+  expect(diff(
+    { style: { a: '#ffffff', b: 1 } },
+    { style: undefined },
+    { style: { b: true } }
+  )).toEqual({ b: null });
+  expect(diff(
+    { style: undefined },
+    { style: { a: '#ffffff', b: 1 } },
+    { style: { b: true } }
+  )).toEqual({ b: 1 });
+  expect(diff(
+    { style: undefined },
+    { style: undefined },
+    { style: { b: true } }
+  )).toEqual(null);
+});
+
+it('should work with empty styles', () => {
+  expect(diff(
+    {a: 1, c: 3},
+    {},
+    {a: true, b: true}
+  )).toEqual({a: null});
+  expect(diff(
+    {},
+    {a: 1, c: 3},
+    {a: true, b: true}
+  )).toEqual({a: 1});
+  expect(diff(
+    {},
+    {},
+    {a: true, b: true}
+  )).toEqual(null);
+});
+
+it('should flatten nested styles and predefined styles', () => {
+  var validStyleAttribute = { someStyle: { foo: true, bar: true } };
+
+  expect(diff(
+    {},
+    { someStyle: [{ foo: 1 }, { bar: 2 }]},
+    validStyleAttribute
+  )).toEqual({ foo: 1, bar: 2 });
+
+  expect(diff(
+    { someStyle: [{ foo: 1 }, { bar: 2 }]},
+    {},
+    validStyleAttribute
+  )).toEqual({ foo: null, bar: null });
+
+  var barStyle = ReactNativePropRegistry.register({
+    bar: 3,
   });
 
-  it('should skip fields that are equal', () => {
-    expect(diff(
-      {a: 1, b: 'two', c: true, d: false, e: undefined, f: 0},
-      {a: 1, b: 'two', c: true, d: false, e: undefined, f: 0},
-      {a: true, b: true, c: true, d: true, e: true, f: true}
-    )).toEqual(null);
-  });
+  expect(diff(
+    {},
+    { someStyle: [[{ foo: 1 }, { foo: 2 }], barStyle]},
+    validStyleAttribute
+  )).toEqual({ foo: 2, bar: 3 });
+});
 
-  it('should remove fields', () => {
-    expect(diff(
-      {a: 1},
-      {},
-      {a: true}
-    )).toEqual({a: null});
-  });
+it('should reset a value to a previous if it is removed', () => {
+  var validStyleAttribute = { someStyle: { foo: true, bar: true } };
 
-  it('should remove fields that are set to undefined', () => {
-    expect(diff(
-      {a: 1},
-      {a: undefined},
-      {a: true}
-    )).toEqual({a: null});
-  });
+  expect(diff(
+    { someStyle: [{ foo: 1 }, { foo: 3 }]},
+    { someStyle: [{ foo: 1 }, { bar: 2 }]},
+    validStyleAttribute
+  )).toEqual({ foo: 1, bar: 2 });
+});
 
-  it('should ignore invalid fields', () => {
-    expect(diff(
-      {a: 1},
-      {b: 2},
-      {}
-    )).toEqual(null);
-  });
+it('should not clear removed props if they are still in another slot', () => {
+  var validStyleAttribute = { someStyle: { foo: true, bar: true } };
 
-  it('should use the diff attribute', () => {
-    var diffA = jest.fn((a, b) => true);
-    var diffB = jest.fn((a, b) => false);
-    expect(diff(
-      {a: [1], b: [3]},
-      {a: [2], b: [4]},
-      {a: {diff: diffA}, b: {diff: diffB}}
-    )).toEqual({a: [2]});
-    expect(diffA).toBeCalledWith([1], [2]);
-    expect(diffB).toBeCalledWith([3], [4]);
-  });
+  expect(diff(
+    { someStyle: [{}, { foo: 3, bar: 2 }]},
+    { someStyle: [{ foo: 3 }, { bar: 2 }]},
+    validStyleAttribute
+  )).toEqual({ foo: 3 }); // this should ideally be null. heuristic tradeoff.
 
-  it('should not use the diff attribute on addition/removal', () => {
-    var diffA = jest.fn();
-    var diffB = jest.fn();
-    expect(diff(
-      {a: [1]},
-      {b: [2]},
-      {a: {diff: diffA}, b: {diff: diffB}}
-    )).toEqual({a: null, b: [2]});
-    expect(diffA).not.toBeCalled();
-    expect(diffB).not.toBeCalled();
-  });
+  expect(diff(
+    { someStyle: [{}, { foo: 3, bar: 2 }]},
+    { someStyle: [{ foo: 1, bar: 1 }, { bar: 2 }]},
+    validStyleAttribute
+  )).toEqual({ bar: 2, foo: 1 });
+});
 
-  it('should do deep diffs of Objects by default', () => {
-    expect(diff(
-      {a: [1], b: {k: [3, 4]}, c: {k: [4, 4]} },
-      {a: [2], b: {k: [3, 4]}, c: {k: [4, 5]} },
-      {a: true, b: true, c: true}
-    )).toEqual({a: [2], c: {k: [4, 5]}});
-  });
+it('should clear a prop if a later style is explicit null/undefined', () => {
+  var validStyleAttribute = { someStyle: { foo: true, bar: true } };
+  expect(diff(
+    { someStyle: [{}, { foo: 3, bar: 2 }]},
+    { someStyle: [{ foo: 1 }, { bar: 2, foo: null }]},
+    validStyleAttribute
+  )).toEqual({ foo: null });
 
-  it('should work with undefined styles', () => {
-    expect(diff(
-      { style: { a: '#ffffff', b: 1 } },
-      { style: undefined },
-      { style: { b: true } }
-    )).toEqual({ b: null });
-    expect(diff(
-      { style: undefined },
-      { style: { a: '#ffffff', b: 1 } },
-      { style: { b: true } }
-    )).toEqual({ b: 1 });
-    expect(diff(
-      { style: undefined },
-      { style: undefined },
-      { style: { b: true } }
-    )).toEqual(null);
-  });
+  expect(diff(
+    { someStyle: [{ foo: 3 }, { foo: null, bar: 2 }]},
+    { someStyle: [{ foo: null }, { bar: 2 }]},
+    validStyleAttribute
+  )).toEqual({ foo: null });
 
-  it('should work with empty styles', () => {
-    expect(diff(
-      {a: 1, c: 3},
-      {},
-      {a: true, b: true}
-    )).toEqual({a: null});
-    expect(diff(
-      {},
-      {a: 1, c: 3},
-      {a: true, b: true}
-    )).toEqual({a: 1});
-    expect(diff(
-      {},
-      {},
-      {a: true, b: true}
-    )).toEqual(null);
-  });
+  expect(diff(
+    { someStyle: [{ foo: 1 }, { foo: null }]},
+    { someStyle: [{ foo: 2 }, { foo: null }]},
+    validStyleAttribute
+  )).toEqual({ foo: null }); // this should ideally be null. heuristic.
 
-  it('should flatten nested styles and predefined styles', () => {
-    var validStyleAttribute = { someStyle: { foo: true, bar: true } };
+  // Test the same case with object equality because an early bailout doesn't
+  // work in this case.
+  var fooObj = { foo: 3 };
+  expect(diff(
+    { someStyle: [{ foo: 1 }, fooObj]},
+    { someStyle: [{ foo: 2 }, fooObj]},
+    validStyleAttribute
+  )).toEqual({ foo: 3 }); // this should ideally be null. heuristic.
 
-    expect(diff(
-      {},
-      { someStyle: [{ foo: 1 }, { bar: 2 }]},
-      validStyleAttribute
-    )).toEqual({ foo: 1, bar: 2 });
+  expect(diff(
+    { someStyle: [{ foo: 1 }, { foo: 3 }]},
+    { someStyle: [{ foo: 2 }, { foo: undefined }]},
+    validStyleAttribute
+  )).toEqual({ foo: null }); // this should ideally be null. heuristic.
+});
 
-    expect(diff(
-      { someStyle: [{ foo: 1 }, { bar: 2 }]},
-      {},
-      validStyleAttribute
-    )).toEqual({ foo: null, bar: null });
-
-    var barStyle = ReactNativePropRegistry.register({
-      bar: 3,
-    });
-
-    expect(diff(
-      {},
-      { someStyle: [[{ foo: 1 }, { foo: 2 }], barStyle]},
-      validStyleAttribute
-    )).toEqual({ foo: 2, bar: 3 });
-  });
-
-  it('should reset a value to a previous if it is removed', () => {
-    var validStyleAttribute = { someStyle: { foo: true, bar: true } };
-
-    expect(diff(
-      { someStyle: [{ foo: 1 }, { foo: 3 }]},
-      { someStyle: [{ foo: 1 }, { bar: 2 }]},
-      validStyleAttribute
-    )).toEqual({ foo: 1, bar: 2 });
-  });
-
-  it('should not clear removed props if they are still in another slot', () => {
-    var validStyleAttribute = { someStyle: { foo: true, bar: true } };
-
-    expect(diff(
-      { someStyle: [{}, { foo: 3, bar: 2 }]},
-      { someStyle: [{ foo: 3 }, { bar: 2 }]},
-      validStyleAttribute
-    )).toEqual({ foo: 3 }); // this should ideally be null. heuristic tradeoff.
-
-    expect(diff(
-      { someStyle: [{}, { foo: 3, bar: 2 }]},
-      { someStyle: [{ foo: 1, bar: 1 }, { bar: 2 }]},
-      validStyleAttribute
-    )).toEqual({ bar: 2, foo: 1 });
-  });
-
-  it('should clear a prop if a later style is explicit null/undefined', () => {
-    var validStyleAttribute = { someStyle: { foo: true, bar: true } };
-    expect(diff(
-      { someStyle: [{}, { foo: 3, bar: 2 }]},
-      { someStyle: [{ foo: 1 }, { bar: 2, foo: null }]},
-      validStyleAttribute
-    )).toEqual({ foo: null });
-
-    expect(diff(
-      { someStyle: [{ foo: 3 }, { foo: null, bar: 2 }]},
-      { someStyle: [{ foo: null }, { bar: 2 }]},
-      validStyleAttribute
-    )).toEqual({ foo: null });
-
-    expect(diff(
-      { someStyle: [{ foo: 1 }, { foo: null }]},
-      { someStyle: [{ foo: 2 }, { foo: null }]},
-      validStyleAttribute
-    )).toEqual({ foo: null }); // this should ideally be null. heuristic.
-
-    // Test the same case with object equality because an early bailout doesn't
-    // work in this case.
-    var fooObj = { foo: 3 };
-    expect(diff(
-      { someStyle: [{ foo: 1 }, fooObj]},
-      { someStyle: [{ foo: 2 }, fooObj]},
-      validStyleAttribute
-    )).toEqual({ foo: 3 }); // this should ideally be null. heuristic.
-
-    expect(diff(
-      { someStyle: [{ foo: 1 }, { foo: 3 }]},
-      { someStyle: [{ foo: 2 }, { foo: undefined }]},
-      validStyleAttribute
-    )).toEqual({ foo: null }); // this should ideally be null. heuristic.
-  });
-
-  // Function properties are just markers to native that events should be sent.
-  it('should convert functions to booleans', () => {
-    // Note that if the property changes from one function to another, we don't
-    // need to send an update.
-    expect(diff(
-      {
-        a: function() {
-          return 1;
-        },
-        b: function() {
-          return 2;
-        },
-        c: 3,
+// Function properties are just markers to native that events should be sent.
+it('should convert functions to booleans', () => {
+  // Note that if the property changes from one function to another, we don't
+  // need to send an update.
+  expect(diff(
+    {
+      a: function() {
+        return 1;
       },
-      {
-        b: function() {
-          return 9;
-        },
-        c: function() {
-          return 3;
-        },
+      b: function() {
+        return 2;
       },
-      {a: true, b: true, c: true}
-    )).toEqual({a: null, c: true});
-  });
-
+      c: 3,
+    },
+    {
+      b: function() {
+        return 9;
+      },
+      c: function() {
+        return 3;
+      },
+    },
+    {a: true, b: true, c: true}
+  )).toEqual({a: null, c: true});
 });

--- a/src/renderers/native/__tests__/ReactNativeMount-test.js
+++ b/src/renderers/native/__tests__/ReactNativeMount-test.js
@@ -16,46 +16,43 @@ var ReactNative;
 var createReactNativeComponentClass;
 var UIManager;
 
-describe('ReactNative', function() {
-  beforeEach(function() {
-    React = require('React');
-    ReactNative = require('ReactNative');
-    UIManager = require('UIManager');
-    createReactNativeComponentClass = require('createReactNativeComponentClass');
+beforeEach(function() {
+  React = require('React');
+  ReactNative = require('ReactNative');
+  UIManager = require('UIManager');
+  createReactNativeComponentClass = require('createReactNativeComponentClass');
+});
+
+it('should be able to create and render a native component', function() {
+  var View = createReactNativeComponentClass({
+    validAttributes: { foo: true },
+    uiViewClassName: 'View',
   });
 
-  it('should be able to create and render a native component', function() {
-    var View = createReactNativeComponentClass({
-      validAttributes: { foo: true },
-      uiViewClassName: 'View',
-    });
+  ReactNative.render(<View foo="test" />, 1);
+  expect(UIManager.createView).toBeCalled();
+  expect(UIManager.setChildren).toBeCalled();
+  expect(UIManager.manageChildren).not.toBeCalled();
+  expect(UIManager.updateView).not.toBeCalled();
+});
 
-    ReactNative.render(<View foo="test" />, 1);
-    expect(UIManager.createView).toBeCalled();
-    expect(UIManager.setChildren).toBeCalled();
-    expect(UIManager.manageChildren).not.toBeCalled();
-    expect(UIManager.updateView).not.toBeCalled();
+it('should be able to create and update a native component', function() {
+  var View = createReactNativeComponentClass({
+    validAttributes: { foo: true },
+    uiViewClassName: 'View',
   });
 
-  it('should be able to create and update a native component', function() {
-    var View = createReactNativeComponentClass({
-      validAttributes: { foo: true },
-      uiViewClassName: 'View',
-    });
+  ReactNative.render(<View foo="foo" />, 11);
 
-    ReactNative.render(<View foo="foo" />, 11);
+  expect(UIManager.createView.mock.calls.length).toBe(2);
+  expect(UIManager.setChildren.mock.calls.length).toBe(2);
+  expect(UIManager.manageChildren).not.toBeCalled();
+  expect(UIManager.updateView).not.toBeCalled();
 
-    expect(UIManager.createView.mock.calls.length).toBe(2);
-    expect(UIManager.setChildren.mock.calls.length).toBe(2);
-    expect(UIManager.manageChildren).not.toBeCalled();
-    expect(UIManager.updateView).not.toBeCalled();
+  ReactNative.render(<View foo="bar" />, 11);
 
-    ReactNative.render(<View foo="bar" />, 11);
-
-    expect(UIManager.createView.mock.calls.length).toBe(2);
-    expect(UIManager.setChildren.mock.calls.length).toBe(2);
-    expect(UIManager.manageChildren).not.toBeCalled();
-    expect(UIManager.updateView).toBeCalledWith(3, 'View', { foo: 'bar' });
-  });
-
+  expect(UIManager.createView.mock.calls.length).toBe(2);
+  expect(UIManager.setChildren.mock.calls.length).toBe(2);
+  expect(UIManager.manageChildren).not.toBeCalled();
+  expect(UIManager.updateView).toBeCalledWith(3, 'View', { foo: 'bar' });
 });

--- a/src/renderers/shared/__tests__/ReactDebugTool-test.js
+++ b/src/renderers/shared/__tests__/ReactDebugTool-test.js
@@ -11,75 +11,73 @@
 
 'use strict';
 
-describe('ReactDebugTool', function() {
-  var ReactDebugTool;
+var ReactDebugTool;
 
-  beforeEach(function() {
-    jest.resetModuleRegistry();
-    ReactDebugTool = require('ReactDebugTool');
+beforeEach(function() {
+  jest.resetModuleRegistry();
+  ReactDebugTool = require('ReactDebugTool');
+});
+
+it('should add and remove hooks', () => {
+  var handler1 = jasmine.createSpy('spy');
+  var handler2 = jasmine.createSpy('spy');
+  var hook1 = {onTestEvent: handler1};
+  var hook2 = {onTestEvent: handler2};
+
+  ReactDebugTool.addHook(hook1);
+  ReactDebugTool.onTestEvent();
+  expect(handler1.calls.count()).toBe(1);
+  expect(handler2.calls.count()).toBe(0);
+
+  ReactDebugTool.onTestEvent();
+  expect(handler1.calls.count()).toBe(2);
+  expect(handler2.calls.count()).toBe(0);
+
+  ReactDebugTool.addHook(hook2);
+  ReactDebugTool.onTestEvent();
+  expect(handler1.calls.count()).toBe(3);
+  expect(handler2.calls.count()).toBe(1);
+
+  ReactDebugTool.onTestEvent();
+  expect(handler1.calls.count()).toBe(4);
+  expect(handler2.calls.count()).toBe(2);
+
+  ReactDebugTool.removeHook(hook1);
+  ReactDebugTool.onTestEvent();
+  expect(handler1.calls.count()).toBe(4);
+  expect(handler2.calls.count()).toBe(3);
+
+  ReactDebugTool.removeHook(hook2);
+  ReactDebugTool.onTestEvent();
+  expect(handler1.calls.count()).toBe(4);
+  expect(handler2.calls.count()).toBe(3);
+});
+
+it('warns once when an error is thrown in hook', () => {
+  spyOn(console, 'error');
+  ReactDebugTool.addHook({
+    onTestEvent() {
+      throw new Error('Hi.');
+    },
   });
 
-  it('should add and remove hooks', () => {
-    var handler1 = jasmine.createSpy('spy');
-    var handler2 = jasmine.createSpy('spy');
-    var hook1 = {onTestEvent: handler1};
-    var hook2 = {onTestEvent: handler2};
+  ReactDebugTool.onTestEvent();
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'Exception thrown by hook while handling ' +
+    'onTestEvent: Error: Hi.'
+  );
 
-    ReactDebugTool.addHook(hook1);
-    ReactDebugTool.onTestEvent();
-    expect(handler1.calls.count()).toBe(1);
-    expect(handler2.calls.count()).toBe(0);
+  ReactDebugTool.onTestEvent();
+  expect(console.error.calls.count()).toBe(1);
+});
 
-    ReactDebugTool.onTestEvent();
-    expect(handler1.calls.count()).toBe(2);
-    expect(handler2.calls.count()).toBe(0);
+it('returns isProfiling state', () => {
+  expect(ReactDebugTool.isProfiling()).toBe(false);
 
-    ReactDebugTool.addHook(hook2);
-    ReactDebugTool.onTestEvent();
-    expect(handler1.calls.count()).toBe(3);
-    expect(handler2.calls.count()).toBe(1);
+  ReactDebugTool.beginProfiling();
+  expect(ReactDebugTool.isProfiling()).toBe(true);
 
-    ReactDebugTool.onTestEvent();
-    expect(handler1.calls.count()).toBe(4);
-    expect(handler2.calls.count()).toBe(2);
-
-    ReactDebugTool.removeHook(hook1);
-    ReactDebugTool.onTestEvent();
-    expect(handler1.calls.count()).toBe(4);
-    expect(handler2.calls.count()).toBe(3);
-
-    ReactDebugTool.removeHook(hook2);
-    ReactDebugTool.onTestEvent();
-    expect(handler1.calls.count()).toBe(4);
-    expect(handler2.calls.count()).toBe(3);
-  });
-
-  it('warns once when an error is thrown in hook', () => {
-    spyOn(console, 'error');
-    ReactDebugTool.addHook({
-      onTestEvent() {
-        throw new Error('Hi.');
-      },
-    });
-
-    ReactDebugTool.onTestEvent();
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Exception thrown by hook while handling ' +
-      'onTestEvent: Error: Hi.'
-    );
-
-    ReactDebugTool.onTestEvent();
-    expect(console.error.calls.count()).toBe(1);
-  });
-
-  it('returns isProfiling state', () => {
-    expect(ReactDebugTool.isProfiling()).toBe(false);
-
-    ReactDebugTool.beginProfiling();
-    expect(ReactDebugTool.isProfiling()).toBe(true);
-
-    ReactDebugTool.endProfiling();
-    expect(ReactDebugTool.isProfiling()).toBe(false);
-  });
+  ReactDebugTool.endProfiling();
+  expect(ReactDebugTool.isProfiling()).toBe(false);
 });

--- a/src/renderers/shared/__tests__/ReactPerf-test.js
+++ b/src/renderers/shared/__tests__/ReactPerf-test.js
@@ -11,713 +11,711 @@
 
 'use strict';
 
-describe('ReactPerf', function() {
-  var React;
-  var ReactDOM;
-  var ReactPerf;
-  var ReactTestUtils;
-  var emptyFunction;
+var React;
+var ReactDOM;
+var ReactPerf;
+var ReactTestUtils;
+var emptyFunction;
 
-  var App;
-  var Box;
-  var Div;
-  var LifeCycle;
+var App;
+var Box;
+var Div;
+var LifeCycle;
 
-  beforeEach(function() {
-    var now = 0;
-    jest.setMock('fbjs/lib/performanceNow', function() {
-      return now++;
-    });
-
-    if (typeof console.table !== 'function') {
-      console.table = () => {};
-      console.table.isFake = true;
-    }
-
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactPerf = require('ReactPerf');
-    ReactTestUtils = require('ReactTestUtils');
-    emptyFunction = require('emptyFunction');
-
-    App = class extends React.Component {
-      render() {
-        return <div><Box /><Box flip={this.props.flipSecond} /></div>;
-      }
-    };
-
-    Box = class extends React.Component {
-      render() {
-        return <div key={!!this.props.flip}><input /></div>;
-      }
-    };
-
-    // ReactPerf only measures composites, so we put everything in one.
-    Div = class extends React.Component {
-      render() {
-        return <div {...this.props} />;
-      }
-    };
-
-    LifeCycle = React.createClass({
-      shouldComponentUpdate: emptyFunction.thatReturnsTrue,
-      componentWillMount: emptyFunction,
-      componentDidMount: emptyFunction,
-      componentWillReceiveProps: emptyFunction,
-      componentWillUpdate: emptyFunction,
-      componentDidUpdate: emptyFunction,
-      componentWillUnmount: emptyFunction,
-      render: emptyFunction.thatReturnsNull,
-    });
+beforeEach(function() {
+  var now = 0;
+  jest.setMock('fbjs/lib/performanceNow', function() {
+    return now++;
   });
 
-  afterEach(function() {
-    if (console.table.isFake) {
-      delete console.table;
-    }
-  });
-
-  function measure(fn) {
-    ReactPerf.start();
-    fn();
-    ReactPerf.stop();
-
-    // Make sure none of the methods crash.
-    ReactPerf.getWasted();
-    ReactPerf.getInclusive();
-    ReactPerf.getExclusive();
-    ReactPerf.getOperations();
-
-    return ReactPerf.getLastMeasurements();
+  if (typeof console.table !== 'function') {
+    console.table = () => {};
+    console.table.isFake = true;
   }
 
-  it('should count no-op update as waste', function() {
-    var container = document.createElement('div');
-    ReactDOM.render(<App />, container);
-    var measurements = measure(() => {
-      ReactDOM.render(<App />, container);
-    });
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactPerf = require('ReactPerf');
+  ReactTestUtils = require('ReactTestUtils');
+  emptyFunction = require('emptyFunction');
 
-    var summary = ReactPerf.getWasted(measurements);
-    expect(summary).toEqual([{
-      key: 'App',
-      instanceCount: 1,
-      inclusiveRenderDuration: 3,
-      renderCount: 1,
-    }, {
-      key: 'App > Box',
-      instanceCount: 2,
-      inclusiveRenderDuration: 2,
-      renderCount: 2,
-    }]);
+  App = class extends React.Component {
+    render() {
+      return <div><Box /><Box flip={this.props.flipSecond} /></div>;
+    }
+  };
+
+  Box = class extends React.Component {
+    render() {
+      return <div key={!!this.props.flip}><input /></div>;
+    }
+  };
+
+  // ReactPerf only measures composites, so we put everything in one.
+  Div = class extends React.Component {
+    render() {
+      return <div {...this.props} />;
+    }
+  };
+
+  LifeCycle = React.createClass({
+    shouldComponentUpdate: emptyFunction.thatReturnsTrue,
+    componentWillMount: emptyFunction,
+    componentDidMount: emptyFunction,
+    componentWillReceiveProps: emptyFunction,
+    componentWillUpdate: emptyFunction,
+    componentDidUpdate: emptyFunction,
+    componentWillUnmount: emptyFunction,
+    render: emptyFunction.thatReturnsNull,
   });
+});
 
-  it('should count no-op update in child as waste', function() {
-    var container = document.createElement('div');
-    ReactDOM.render(<App />, container);
-
-    // Here, we add a Box -- two of the <Box /> updates are wasted time (but the
-    // addition of the third is not)
-    var measurements = measure(() => {
-      ReactDOM.render(<App flipSecond={true} />, container);
-    });
-
-    var summary = ReactPerf.getWasted(measurements);
-    expect(summary).toEqual([{
-      key: 'App > Box',
-      instanceCount: 1,
-      inclusiveRenderDuration: 1,
-      renderCount: 1,
-    }]);
-  });
-
-  function expectNoWaste(fn) {
-    var measurements = measure(fn);
-    var summary = ReactPerf.getWasted(measurements);
-    expect(summary).toEqual([]);
+afterEach(function() {
+  if (console.table.isFake) {
+    delete console.table;
   }
+});
 
-  it('should not count initial render as waste', function() {
-    expectNoWaste(() => {
-      ReactTestUtils.renderIntoDocument(<App />);
-    });
+function measure(fn) {
+  ReactPerf.start();
+  fn();
+  ReactPerf.stop();
+
+  // Make sure none of the methods crash.
+  ReactPerf.getWasted();
+  ReactPerf.getInclusive();
+  ReactPerf.getExclusive();
+  ReactPerf.getOperations();
+
+  return ReactPerf.getLastMeasurements();
+}
+
+it('should count no-op update as waste', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(<App />, container);
+  var measurements = measure(() => {
+    ReactDOM.render(<App />, container);
   });
 
-  it('should not count unmount as waste', function() {
-    var container = document.createElement('div');
-    ReactDOM.render(<Div>hello</Div>, container);
-    expectNoWaste(() => {
-      ReactDOM.unmountComponentAtNode(container);
-    });
+  var summary = ReactPerf.getWasted(measurements);
+  expect(summary).toEqual([{
+    key: 'App',
+    instanceCount: 1,
+    inclusiveRenderDuration: 3,
+    renderCount: 1,
+  }, {
+    key: 'App > Box',
+    instanceCount: 2,
+    inclusiveRenderDuration: 2,
+    renderCount: 2,
+  }]);
+});
+
+it('should count no-op update in child as waste', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(<App />, container);
+
+  // Here, we add a Box -- two of the <Box /> updates are wasted time (but the
+  // addition of the third is not)
+  var measurements = measure(() => {
+    ReactDOM.render(<App flipSecond={true} />, container);
   });
 
-  it('should not count content update as waste', function() {
-    var container = document.createElement('div');
-    ReactDOM.render(<Div>hello</Div>, container);
-    expectNoWaste(() => {
-      ReactDOM.render(<Div>hello world</Div>, container);
-    });
-  });
+  var summary = ReactPerf.getWasted(measurements);
+  expect(summary).toEqual([{
+    key: 'App > Box',
+    instanceCount: 1,
+    inclusiveRenderDuration: 1,
+    renderCount: 1,
+  }]);
+});
 
-  it('should not count child addition as waste', function() {
-    var container = document.createElement('div');
-    ReactDOM.render(<Div><span /></Div>, container);
-    expectNoWaste(() => {
-      ReactDOM.render(<Div><span /><span /></Div>, container);
-    });
-  });
+function expectNoWaste(fn) {
+  var measurements = measure(fn);
+  var summary = ReactPerf.getWasted(measurements);
+  expect(summary).toEqual([]);
+}
 
-  it('should not count child removal as waste', function() {
-    var container = document.createElement('div');
+it('should not count initial render as waste', function() {
+  expectNoWaste(() => {
+    ReactTestUtils.renderIntoDocument(<App />);
+  });
+});
+
+it('should not count unmount as waste', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(<Div>hello</Div>, container);
+  expectNoWaste(() => {
+    ReactDOM.unmountComponentAtNode(container);
+  });
+});
+
+it('should not count content update as waste', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(<Div>hello</Div>, container);
+  expectNoWaste(() => {
+    ReactDOM.render(<Div>hello world</Div>, container);
+  });
+});
+
+it('should not count child addition as waste', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(<Div><span /></Div>, container);
+  expectNoWaste(() => {
     ReactDOM.render(<Div><span /><span /></Div>, container);
-    expectNoWaste(() => {
-      ReactDOM.render(<Div><span /></Div>, container);
-    });
   });
+});
 
-  it('should not count property update as waste', function() {
-    var container = document.createElement('div');
-    ReactDOM.render(<Div className="yellow">hey</Div>, container);
-    expectNoWaste(() => {
-      ReactDOM.render(<Div className="blue">hey</Div>, container);
-    });
+it('should not count child removal as waste', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(<Div><span /><span /></Div>, container);
+  expectNoWaste(() => {
+    ReactDOM.render(<Div><span /></Div>, container);
   });
+});
 
-  it('should not count style update as waste', function() {
-    var container = document.createElement('div');
-    ReactDOM.render(<Div style={{color: 'yellow'}}>hey</Div>, container);
-    expectNoWaste(() => {
-      ReactDOM.render(<Div style={{color: 'blue'}}>hey</Div>, container);
-    });
+it('should not count property update as waste', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(<Div className="yellow">hey</Div>, container);
+  expectNoWaste(() => {
+    ReactDOM.render(<Div className="blue">hey</Div>, container);
   });
+});
 
-  it('should not count property removal as waste', function() {
-    var container = document.createElement('div');
-    ReactDOM.render(<Div className="yellow">hey</Div>, container);
-    expectNoWaste(() => {
-      ReactDOM.render(<Div>hey</Div>, container);
-    });
+it('should not count style update as waste', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(<Div style={{color: 'yellow'}}>hey</Div>, container);
+  expectNoWaste(() => {
+    ReactDOM.render(<Div style={{color: 'blue'}}>hey</Div>, container);
   });
+});
 
-  it('should not count raw HTML update as waste', function() {
-    var container = document.createElement('div');
+it('should not count property removal as waste', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(<Div className="yellow">hey</Div>, container);
+  expectNoWaste(() => {
+    ReactDOM.render(<Div>hey</Div>, container);
+  });
+});
+
+it('should not count raw HTML update as waste', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(
+    <Div dangerouslySetInnerHTML={{__html: 'me'}} />,
+    container
+  );
+  expectNoWaste(() => {
     ReactDOM.render(
-      <Div dangerouslySetInnerHTML={{__html: 'me'}} />,
+      <Div dangerouslySetInnerHTML={{__html: 'you'}} />,
       container
     );
-    expectNoWaste(() => {
-      ReactDOM.render(
-        <Div dangerouslySetInnerHTML={{__html: 'you'}} />,
-        container
-      );
-    });
   });
+});
 
-  it('should not count child reordering as waste', function() {
-    var container = document.createElement('div');
-    ReactDOM.render(<Div><div key="A" /><div key="B" /></Div>, container);
-    expectNoWaste(() => {
-      ReactDOM.render(<Div><div key="B" /><div key="A" /></Div>, container);
-    });
+it('should not count child reordering as waste', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(<Div><div key="A" /><div key="B" /></Div>, container);
+  expectNoWaste(() => {
+    ReactDOM.render(<Div><div key="B" /><div key="A" /></Div>, container);
   });
+});
 
-  it('should not count text update as waste', function() {
-    var container = document.createElement('div');
-    ReactDOM.render(<Div>{'hello'}{'world'}</Div>, container);
-    expectNoWaste(() => {
-      ReactDOM.render(<Div>{'hello'}{'friend'}</Div>, container);
-    });
+it('should not count text update as waste', function() {
+  var container = document.createElement('div');
+  ReactDOM.render(<Div>{'hello'}{'world'}</Div>, container);
+  expectNoWaste(() => {
+    ReactDOM.render(<Div>{'hello'}{'friend'}</Div>, container);
   });
+});
 
-  it('should not count replacing null with a host as waste', function() {
-    var element = null;
-    function Foo() {
-      return element;
-    }
-    var container = document.createElement('div');
+it('should not count replacing null with a host as waste', function() {
+  var element = null;
+  function Foo() {
+    return element;
+  }
+  var container = document.createElement('div');
+  ReactDOM.render(<Foo />, container);
+  expectNoWaste(() => {
+    element = <div />;
     ReactDOM.render(<Foo />, container);
-    expectNoWaste(() => {
-      element = <div />;
-      ReactDOM.render(<Foo />, container);
-    });
   });
+});
 
-  it('should not count replacing a host with null as waste', function() {
-    var element = <div />;
-    function Foo() {
-      return element;
-    }
-    var container = document.createElement('div');
+it('should not count replacing a host with null as waste', function() {
+  var element = <div />;
+  function Foo() {
+    return element;
+  }
+  var container = document.createElement('div');
+  ReactDOM.render(<Foo />, container);
+  expectNoWaste(() => {
+    element = null;
     ReactDOM.render(<Foo />, container);
-    expectNoWaste(() => {
-      element = null;
-      ReactDOM.render(<Foo />, container);
-    });
   });
+});
 
-  it('should include stats for components unmounted during measurement', function() {
-    var container = document.createElement('div');
-    var measurements = measure(() => {
-      ReactDOM.render(<Div><Div key="a" /></Div>, container);
-      ReactDOM.render(<Div><Div key="b" /></Div>, container);
-    });
-    expect(ReactPerf.getExclusive(measurements)).toEqual([{
-      key: 'Div',
-      instanceCount: 3,
-      counts: { ctor: 3, render: 4 },
-      durations: { ctor: 3, render: 4 },
-      totalDuration: 7,
-    }]);
+it('should include stats for components unmounted during measurement', function() {
+  var container = document.createElement('div');
+  var measurements = measure(() => {
+    ReactDOM.render(<Div><Div key="a" /></Div>, container);
+    ReactDOM.render(<Div><Div key="b" /></Div>, container);
   });
+  expect(ReactPerf.getExclusive(measurements)).toEqual([{
+    key: 'Div',
+    instanceCount: 3,
+    counts: { ctor: 3, render: 4 },
+    durations: { ctor: 3, render: 4 },
+    totalDuration: 7,
+  }]);
+});
 
-  it('should include lifecycle methods in measurements', function() {
-    var container = document.createElement('div');
-    var measurements = measure(() => {
-      var instance = ReactDOM.render(<LifeCycle />, container);
-      ReactDOM.render(<LifeCycle />, container);
-      instance.setState({});
-      ReactDOM.unmountComponentAtNode(container);
-    });
-    expect(ReactPerf.getExclusive(measurements)).toEqual([{
-      key: 'LifeCycle',
-      instanceCount: 1,
-      totalDuration: 14,
-      counts: {
-        ctor: 1,
-        shouldComponentUpdate: 2,
-        componentWillMount: 1,
-        componentDidMount: 1,
-        componentWillReceiveProps: 1,
-        componentWillUpdate: 2,
-        componentDidUpdate: 2,
-        componentWillUnmount: 1,
-        render: 3,
-      },
-      durations: {
-        ctor: 1,
-        shouldComponentUpdate: 2,
-        componentWillMount: 1,
-        componentDidMount: 1,
-        componentWillReceiveProps: 1,
-        componentWillUpdate: 2,
-        componentDidUpdate: 2,
-        componentWillUnmount: 1,
-        render: 3,
-      },
-    }]);
+it('should include lifecycle methods in measurements', function() {
+  var container = document.createElement('div');
+  var measurements = measure(() => {
+    var instance = ReactDOM.render(<LifeCycle />, container);
+    ReactDOM.render(<LifeCycle />, container);
+    instance.setState({});
+    ReactDOM.unmountComponentAtNode(container);
   });
+  expect(ReactPerf.getExclusive(measurements)).toEqual([{
+    key: 'LifeCycle',
+    instanceCount: 1,
+    totalDuration: 14,
+    counts: {
+      ctor: 1,
+      shouldComponentUpdate: 2,
+      componentWillMount: 1,
+      componentDidMount: 1,
+      componentWillReceiveProps: 1,
+      componentWillUpdate: 2,
+      componentDidUpdate: 2,
+      componentWillUnmount: 1,
+      render: 3,
+    },
+    durations: {
+      ctor: 1,
+      shouldComponentUpdate: 2,
+      componentWillMount: 1,
+      componentDidMount: 1,
+      componentWillReceiveProps: 1,
+      componentWillUpdate: 2,
+      componentDidUpdate: 2,
+      componentWillUnmount: 1,
+      render: 3,
+    },
+  }]);
+});
 
-  it('should include render time of functional components', function() {
-    function Foo() {
+it('should include render time of functional components', function() {
+  function Foo() {
+    return null;
+  }
+
+  var container = document.createElement('div');
+  var measurements = measure(() => {
+    ReactDOM.render(<Foo />, container);
+  });
+  expect(ReactPerf.getExclusive(measurements)).toEqual([{
+    key: 'Foo',
+    instanceCount: 1,
+    totalDuration: 1,
+    counts: {
+      render: 1,
+    },
+    durations: {
+      render: 1,
+    },
+  }]);
+});
+
+it('should not count time in a portal towards lifecycle method', function() {
+  function Foo() {
+    return null;
+  }
+
+  var portalContainer = document.createElement('div');
+  class Portal extends React.Component {
+    componentDidMount() {
+      ReactDOM.render(<Foo />, portalContainer);
+    }
+    render() {
       return null;
     }
+  }
 
-    var container = document.createElement('div');
-    var measurements = measure(() => {
-      ReactDOM.render(<Foo />, container);
-    });
-    expect(ReactPerf.getExclusive(measurements)).toEqual([{
-      key: 'Foo',
-      instanceCount: 1,
-      totalDuration: 1,
-      counts: {
-        render: 1,
-      },
-      durations: {
-        render: 1,
-      },
-    }]);
+  var container = document.createElement('div');
+  var measurements = measure(() => {
+    ReactDOM.render(<Portal />, container);
   });
 
-  it('should not count time in a portal towards lifecycle method', function() {
-    function Foo() {
-      return null;
+  expect(ReactPerf.getExclusive(measurements)).toEqual([{
+    key: 'Portal',
+    instanceCount: 1,
+    totalDuration: 6,
+    counts: {
+      ctor: 1,
+      componentDidMount: 1,
+      render: 1,
+    },
+    durations: {
+      ctor: 1,
+      // We want to exclude nested imperative ReactDOM.render() from lifecycle hook's own time.
+      // Otherwise it would artificially float to the top even though its exclusive time is small.
+      // This is how we get 4 as a number with the performanceNow() mock:
+      // - we capture the time we enter componentDidMount (n = 0)
+      // - we capture the time when we enter a nested flush (n = 1)
+      // - in the nested flush, we call it twice: before and after <Foo /> rendering. (n = 3)
+      // - we capture the time when we exit a nested flush (n = 4)
+      // - we capture the time we exit componentDidMount (n = 5)
+      // Time spent in componentDidMount = (5 - 0 - (4 - 3)) = 4.
+      componentDidMount: 4,
+      render: 1,
+    },
+  }, {
+    key: 'Foo',
+    instanceCount: 1,
+    totalDuration: 1,
+    counts: {
+      render: 1,
+    },
+    durations: {
+      render: 1,
+    },
+  }]);
+});
+
+it('warns once when using getMeasurementsSummaryMap', function() {
+  var measurements = measure(() => {});
+  spyOn(console, 'error');
+  ReactPerf.getMeasurementsSummaryMap(measurements);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    '`ReactPerf.getMeasurementsSummaryMap(...)` is deprecated. Use ' +
+    '`ReactPerf.getWasted(...)` instead.'
+  );
+
+  ReactPerf.getMeasurementsSummaryMap(measurements);
+  expect(console.error.calls.count()).toBe(1);
+});
+
+it('warns once when using printDOM', function() {
+  var measurements = measure(() => {});
+  spyOn(console, 'error');
+  ReactPerf.printDOM(measurements);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    '`ReactPerf.printDOM(...)` is deprecated. Use ' +
+    '`ReactPerf.printOperations(...)` instead.'
+  );
+
+  ReactPerf.printDOM(measurements);
+  expect(console.error.calls.count()).toBe(1);
+});
+
+it('returns isRunning state', () => {
+  expect(ReactPerf.isRunning()).toBe(false);
+
+  ReactPerf.start();
+  expect(ReactPerf.isRunning()).toBe(true);
+
+  ReactPerf.stop();
+  expect(ReactPerf.isRunning()).toBe(false);
+});
+
+it('start has no effect when already running', () => {
+  expect(ReactPerf.isRunning()).toBe(false);
+
+  ReactPerf.start();
+  expect(ReactPerf.isRunning()).toBe(true);
+
+  ReactPerf.start();
+  expect(ReactPerf.isRunning()).toBe(true);
+
+  ReactPerf.stop();
+  expect(ReactPerf.isRunning()).toBe(false);
+});
+
+it('stop has no effect when already stopped', () => {
+  expect(ReactPerf.isRunning()).toBe(false);
+
+  ReactPerf.stop();
+  expect(ReactPerf.isRunning()).toBe(false);
+
+  ReactPerf.stop();
+  expect(ReactPerf.isRunning()).toBe(false);
+});
+
+it('should print console error only once', () => {
+  __DEV__ = false;
+
+  spyOn(console, 'error');
+
+  expect(ReactPerf.getLastMeasurements()).toEqual([]);
+  expect(ReactPerf.getExclusive()).toEqual([]);
+  expect(ReactPerf.getInclusive()).toEqual([]);
+  expect(ReactPerf.getWasted()).toEqual([]);
+  expect(ReactPerf.getOperations()).toEqual([]);
+  expect(ReactPerf.printExclusive()).toEqual(undefined);
+  expect(ReactPerf.printInclusive()).toEqual(undefined);
+  expect(ReactPerf.printWasted()).toEqual(undefined);
+  expect(ReactPerf.printOperations()).toEqual(undefined);
+  expect(ReactPerf.start()).toBe(undefined);
+  expect(ReactPerf.stop()).toBe(undefined);
+  expect(ReactPerf.isRunning()).toBe(false);
+
+  expect(console.error.calls.count()).toBe(1);
+
+  __DEV__ = true;
+});
+
+it('should work when measurement starts during reconciliation', () => {
+  // https://github.com/facebook/react/issues/6949#issuecomment-230371009
+  class Measurer extends React.Component {
+    componentWillMount() {
+      ReactPerf.start();
     }
 
-    var portalContainer = document.createElement('div');
-    class Portal extends React.Component {
-      componentDidMount() {
-        ReactDOM.render(<Foo />, portalContainer);
-      }
-      render() {
-        return null;
-      }
+    componentDidMount() {
+      ReactPerf.stop();
     }
 
-    var container = document.createElement('div');
-    var measurements = measure(() => {
-      ReactDOM.render(<Portal />, container);
-    });
+    componentWillUpdate() {
+      ReactPerf.start();
+    }
 
-    expect(ReactPerf.getExclusive(measurements)).toEqual([{
-      key: 'Portal',
-      instanceCount: 1,
-      totalDuration: 6,
-      counts: {
-        ctor: 1,
-        componentDidMount: 1,
-        render: 1,
-      },
-      durations: {
-        ctor: 1,
-        // We want to exclude nested imperative ReactDOM.render() from lifecycle hook's own time.
-        // Otherwise it would artificially float to the top even though its exclusive time is small.
-        // This is how we get 4 as a number with the performanceNow() mock:
-        // - we capture the time we enter componentDidMount (n = 0)
-        // - we capture the time when we enter a nested flush (n = 1)
-        // - in the nested flush, we call it twice: before and after <Foo /> rendering. (n = 3)
-        // - we capture the time when we exit a nested flush (n = 4)
-        // - we capture the time we exit componentDidMount (n = 5)
-        // Time spent in componentDidMount = (5 - 0 - (4 - 3)) = 4.
-        componentDidMount: 4,
-        render: 1,
-      },
-    }, {
-      key: 'Foo',
-      instanceCount: 1,
-      totalDuration: 1,
-      counts: {
-        render: 1,
-      },
-      durations: {
-        render: 1,
-      },
-    }]);
-  });
+    componentDidUpdate() {
+      ReactPerf.stop();
+    }
 
-  it('warns once when using getMeasurementsSummaryMap', function() {
-    var measurements = measure(() => {});
-    spyOn(console, 'error');
-    ReactPerf.getMeasurementsSummaryMap(measurements);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      '`ReactPerf.getMeasurementsSummaryMap(...)` is deprecated. Use ' +
-      '`ReactPerf.getWasted(...)` instead.'
+    render() {
+      // Force reconciliation despite constant element
+      return React.cloneElement(this.props.children);
+    }
+  }
+
+  var container = document.createElement('div');
+  ReactDOM.render(<Measurer><App /></Measurer>, container);
+  expect(ReactPerf.getWasted()).toEqual([]);
+
+  ReactDOM.render(<Measurer><App /></Measurer>, container);
+  expect(ReactPerf.getWasted()).toEqual([{
+    key: 'Measurer',
+    instanceCount: 1,
+    inclusiveRenderDuration: 4,
+    renderCount: 1,
+  }, {
+    key: 'App',
+    instanceCount: 1,
+    inclusiveRenderDuration: 3,
+    renderCount: 1,
+  }, {
+    key: 'App > Box',
+    instanceCount: 2,
+    inclusiveRenderDuration: 2,
+    renderCount: 2,
+  }]);
+});
+
+it('should not print errant warnings if render() throws', () => {
+  var container = document.createElement('div');
+  var thrownErr = new Error('Muhaha!');
+
+  class Evil extends React.Component {
+    render() {
+      throw thrownErr;
+    }
+  }
+
+  ReactPerf.start();
+  try {
+    ReactDOM.render(
+      <div>
+        <LifeCycle />
+        <Evil />
+      </div>,
+      container
     );
+  } catch (err) {
+    if (err !== thrownErr) {
+      throw err;
+    }
+  }
+  ReactPerf.stop();
+});
 
-    ReactPerf.getMeasurementsSummaryMap(measurements);
-    expect(console.error.calls.count()).toBe(1);
-  });
+it('should not print errant warnings if componentWillMount() throws', () => {
+  var container = document.createElement('div');
+  var thrownErr = new Error('Muhaha!');
 
-  it('warns once when using printDOM', function() {
-    var measurements = measure(() => {});
-    spyOn(console, 'error');
-    ReactPerf.printDOM(measurements);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      '`ReactPerf.printDOM(...)` is deprecated. Use ' +
-      '`ReactPerf.printOperations(...)` instead.'
+  class Evil extends React.Component {
+    componentWillMount() {
+      throw thrownErr;
+    }
+    render() {
+      return <div />;
+    }
+  }
+
+  ReactPerf.start();
+  try {
+    ReactDOM.render(
+      <div>
+        <LifeCycle />
+        <Evil />
+      </div>,
+      container
     );
-
-    ReactPerf.printDOM(measurements);
-    expect(console.error.calls.count()).toBe(1);
-  });
-
-  it('returns isRunning state', () => {
-    expect(ReactPerf.isRunning()).toBe(false);
-
-    ReactPerf.start();
-    expect(ReactPerf.isRunning()).toBe(true);
-
-    ReactPerf.stop();
-    expect(ReactPerf.isRunning()).toBe(false);
-  });
-
-  it('start has no effect when already running', () => {
-    expect(ReactPerf.isRunning()).toBe(false);
-
-    ReactPerf.start();
-    expect(ReactPerf.isRunning()).toBe(true);
-
-    ReactPerf.start();
-    expect(ReactPerf.isRunning()).toBe(true);
-
-    ReactPerf.stop();
-    expect(ReactPerf.isRunning()).toBe(false);
-  });
-
-  it('stop has no effect when already stopped', () => {
-    expect(ReactPerf.isRunning()).toBe(false);
-
-    ReactPerf.stop();
-    expect(ReactPerf.isRunning()).toBe(false);
-
-    ReactPerf.stop();
-    expect(ReactPerf.isRunning()).toBe(false);
-  });
-
-  it('should print console error only once', () => {
-    __DEV__ = false;
-
-    spyOn(console, 'error');
-
-    expect(ReactPerf.getLastMeasurements()).toEqual([]);
-    expect(ReactPerf.getExclusive()).toEqual([]);
-    expect(ReactPerf.getInclusive()).toEqual([]);
-    expect(ReactPerf.getWasted()).toEqual([]);
-    expect(ReactPerf.getOperations()).toEqual([]);
-    expect(ReactPerf.printExclusive()).toEqual(undefined);
-    expect(ReactPerf.printInclusive()).toEqual(undefined);
-    expect(ReactPerf.printWasted()).toEqual(undefined);
-    expect(ReactPerf.printOperations()).toEqual(undefined);
-    expect(ReactPerf.start()).toBe(undefined);
-    expect(ReactPerf.stop()).toBe(undefined);
-    expect(ReactPerf.isRunning()).toBe(false);
-
-    expect(console.error.calls.count()).toBe(1);
-
-    __DEV__ = true;
-  });
-
-  it('should work when measurement starts during reconciliation', () => {
-    // https://github.com/facebook/react/issues/6949#issuecomment-230371009
-    class Measurer extends React.Component {
-      componentWillMount() {
-        ReactPerf.start();
-      }
-
-      componentDidMount() {
-        ReactPerf.stop();
-      }
-
-      componentWillUpdate() {
-        ReactPerf.start();
-      }
-
-      componentDidUpdate() {
-        ReactPerf.stop();
-      }
-
-      render() {
-        // Force reconciliation despite constant element
-        return React.cloneElement(this.props.children);
-      }
+  } catch (err) {
+    if (err !== thrownErr) {
+      throw err;
     }
+  }
+  ReactPerf.stop();
+});
 
-    var container = document.createElement('div');
-    ReactDOM.render(<Measurer><App /></Measurer>, container);
-    expect(ReactPerf.getWasted()).toEqual([]);
+it('should not print errant warnings if componentDidMount() throws', () => {
+  var container = document.createElement('div');
+  var thrownErr = new Error('Muhaha!');
 
-    ReactDOM.render(<Measurer><App /></Measurer>, container);
-    expect(ReactPerf.getWasted()).toEqual([{
-      key: 'Measurer',
-      instanceCount: 1,
-      inclusiveRenderDuration: 4,
-      renderCount: 1,
-    }, {
-      key: 'App',
-      instanceCount: 1,
-      inclusiveRenderDuration: 3,
-      renderCount: 1,
-    }, {
-      key: 'App > Box',
-      instanceCount: 2,
-      inclusiveRenderDuration: 2,
-      renderCount: 2,
-    }]);
-  });
-
-  it('should not print errant warnings if render() throws', () => {
-    var container = document.createElement('div');
-    var thrownErr = new Error('Muhaha!');
-
-    class Evil extends React.Component {
-      render() {
-        throw thrownErr;
-      }
+  class Evil extends React.Component {
+    componentDidMount() {
+      throw thrownErr;
     }
-
-    ReactPerf.start();
-    try {
-      ReactDOM.render(
-        <div>
-          <LifeCycle />
-          <Evil />
-        </div>,
-        container
-      );
-    } catch (err) {
-      if (err !== thrownErr) {
-        throw err;
-      }
+    render() {
+      return <div />;
     }
-    ReactPerf.stop();
-  });
+  }
 
-  it('should not print errant warnings if componentWillMount() throws', () => {
-    var container = document.createElement('div');
-    var thrownErr = new Error('Muhaha!');
-
-    class Evil extends React.Component {
-      componentWillMount() {
-        throw thrownErr;
-      }
-      render() {
-        return <div />;
-      }
+  ReactPerf.start();
+  try {
+    ReactDOM.render(
+      <div>
+        <LifeCycle />
+        <Evil />
+      </div>,
+      container
+    );
+  } catch (err) {
+    if (err !== thrownErr) {
+      throw err;
     }
+  }
+  ReactPerf.stop();
+});
 
-    ReactPerf.start();
-    try {
-      ReactDOM.render(
-        <div>
-          <LifeCycle />
-          <Evil />
-        </div>,
-        container
-      );
-    } catch (err) {
-      if (err !== thrownErr) {
-        throw err;
-      }
+it('should not print errant warnings if portal throws in render()', () => {
+  var container = document.createElement('div');
+  var thrownErr = new Error('Muhaha!');
+
+  class Evil extends React.Component {
+    render() {
+      throw thrownErr;
     }
-    ReactPerf.stop();
-  });
-
-  it('should not print errant warnings if componentDidMount() throws', () => {
-    var container = document.createElement('div');
-    var thrownErr = new Error('Muhaha!');
-
-    class Evil extends React.Component {
-      componentDidMount() {
-        throw thrownErr;
-      }
-      render() {
-        return <div />;
-      }
+  }
+  class EvilPortal extends React.Component {
+    componentWillMount() {
+      var portalContainer = document.createElement('div');
+      ReactDOM.render(<Evil />, portalContainer);
     }
-
-    ReactPerf.start();
-    try {
-      ReactDOM.render(
-        <div>
-          <LifeCycle />
-          <Evil />
-        </div>,
-        container
-      );
-    } catch (err) {
-      if (err !== thrownErr) {
-        throw err;
-      }
+    render() {
+      return <div />;
     }
-    ReactPerf.stop();
-  });
+  }
 
-  it('should not print errant warnings if portal throws in render()', () => {
-    var container = document.createElement('div');
-    var thrownErr = new Error('Muhaha!');
+  ReactPerf.start();
+  try {
+    ReactDOM.render(
+      <div>
+        <LifeCycle />
+        <EvilPortal />
+      </div>,
+      container
+    );
+  } catch (err) {
+    if (err !== thrownErr) {
+      throw err;
+    }
+  }
+  ReactDOM.unmountComponentAtNode(container);
+  ReactPerf.stop();
+});
 
-    class Evil extends React.Component {
-      render() {
-        throw thrownErr;
-      }
-    }
-    class EvilPortal extends React.Component {
-      componentWillMount() {
-        var portalContainer = document.createElement('div');
-        ReactDOM.render(<Evil />, portalContainer);
-      }
-      render() {
-        return <div />;
-      }
-    }
+it('should not print errant warnings if portal throws in componentWillMount()', () => {
+  var container = document.createElement('div');
+  var thrownErr = new Error('Muhaha!');
 
-    ReactPerf.start();
-    try {
-      ReactDOM.render(
-        <div>
-          <LifeCycle />
-          <EvilPortal />
-        </div>,
-        container
-      );
-    } catch (err) {
-      if (err !== thrownErr) {
-        throw err;
-      }
+  class Evil extends React.Component {
+    componentWillMount() {
+      throw thrownErr;
     }
-    ReactDOM.unmountComponentAtNode(container);
-    ReactPerf.stop();
-  });
+    render() {
+      return <div />;
+    }
+  }
+  class EvilPortal extends React.Component {
+    componentWillMount() {
+      var portalContainer = document.createElement('div');
+      ReactDOM.render(<Evil />, portalContainer);
+    }
+    render() {
+      return <div />;
+    }
+  }
 
-  it('should not print errant warnings if portal throws in componentWillMount()', () => {
-    var container = document.createElement('div');
-    var thrownErr = new Error('Muhaha!');
+  ReactPerf.start();
+  try {
+    ReactDOM.render(
+      <div>
+        <LifeCycle />
+        <EvilPortal />
+      </div>,
+      container
+    );
+  } catch (err) {
+    if (err !== thrownErr) {
+      throw err;
+    }
+  }
+  ReactDOM.unmountComponentAtNode(container);
+  ReactPerf.stop();
+});
 
-    class Evil extends React.Component {
-      componentWillMount() {
-        throw thrownErr;
-      }
-      render() {
-        return <div />;
-      }
-    }
-    class EvilPortal extends React.Component {
-      componentWillMount() {
-        var portalContainer = document.createElement('div');
-        ReactDOM.render(<Evil />, portalContainer);
-      }
-      render() {
-        return <div />;
-      }
-    }
+it('should not print errant warnings if portal throws in componentDidMount()', () => {
+  var container = document.createElement('div');
+  var thrownErr = new Error('Muhaha!');
 
-    ReactPerf.start();
-    try {
-      ReactDOM.render(
-        <div>
-          <LifeCycle />
-          <EvilPortal />
-        </div>,
-        container
-      );
-    } catch (err) {
-      if (err !== thrownErr) {
-        throw err;
-      }
+  class Evil extends React.Component {
+    componentDidMount() {
+      throw thrownErr;
     }
-    ReactDOM.unmountComponentAtNode(container);
-    ReactPerf.stop();
-  });
+    render() {
+      return <div />;
+    }
+  }
+  class EvilPortal extends React.Component {
+    componentWillMount() {
+      var portalContainer = document.createElement('div');
+      ReactDOM.render(<Evil />, portalContainer);
+    }
+    render() {
+      return <div />;
+    }
+  }
 
-  it('should not print errant warnings if portal throws in componentDidMount()', () => {
-    var container = document.createElement('div');
-    var thrownErr = new Error('Muhaha!');
-
-    class Evil extends React.Component {
-      componentDidMount() {
-        throw thrownErr;
-      }
-      render() {
-        return <div />;
-      }
+  ReactPerf.start();
+  try {
+    ReactDOM.render(
+      <div>
+        <LifeCycle />
+        <EvilPortal />
+      </div>,
+      container
+    );
+  } catch (err) {
+    if (err !== thrownErr) {
+      throw err;
     }
-    class EvilPortal extends React.Component {
-      componentWillMount() {
-        var portalContainer = document.createElement('div');
-        ReactDOM.render(<Evil />, portalContainer);
-      }
-      render() {
-        return <div />;
-      }
-    }
-
-    ReactPerf.start();
-    try {
-      ReactDOM.render(
-        <div>
-          <LifeCycle />
-          <EvilPortal />
-        </div>,
-        container
-      );
-    } catch (err) {
-      if (err !== thrownErr) {
-        throw err;
-      }
-    }
-    ReactDOM.unmountComponentAtNode(container);
-    ReactPerf.stop();
-  });
+  }
+  ReactDOM.unmountComponentAtNode(container);
+  ReactPerf.stop();
 });

--- a/src/renderers/shared/fiber/__tests__/ReactCoroutine-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactCoroutine-test.js
@@ -15,75 +15,72 @@ var React;
 var ReactNoop;
 var ReactCoroutine;
 
-describe('ReactCoroutine', function() {
-  beforeEach(function() {
-    React = require('React');
-    ReactNoop = require('ReactNoop');
-    ReactCoroutine = require('ReactCoroutine');
-  });
+beforeEach(function() {
+  React = require('React');
+  ReactNoop = require('ReactNoop');
+  ReactCoroutine = require('ReactCoroutine');
+});
 
-  it('should render a coroutine', function() {
+it('should render a coroutine', function() {
 
-    var ops = [];
+  var ops = [];
 
 
-    function Continuation({ isSame }) {
-      ops.push(['Continuation', isSame]);
-      return <span>{isSame ? 'foo==bar' : 'foo!=bar'}</span>;
-    }
+  function Continuation({ isSame }) {
+    ops.push(['Continuation', isSame]);
+    return <span>{isSame ? 'foo==bar' : 'foo!=bar'}</span>;
+  }
 
-    // An alternative API could mark Continuation as something that needs
-    // yielding. E.g. Continuation.yieldType = 123;
-    function Child({ bar }) {
-      ops.push(['Child', bar]);
-      return ReactCoroutine.createYield({
-        bar: bar,
-      }, Continuation, null);
-    }
+  // An alternative API could mark Continuation as something that needs
+  // yielding. E.g. Continuation.yieldType = 123;
+  function Child({ bar }) {
+    ops.push(['Child', bar]);
+    return ReactCoroutine.createYield({
+      bar: bar,
+    }, Continuation, null);
+  }
 
-    function Indirection() {
-      ops.push('Indirection');
-      return [<Child bar={true} />, <Child bar={false} />];
-    }
+  function Indirection() {
+    ops.push('Indirection');
+    return [<Child bar={true} />, <Child bar={false} />];
+  }
 
-    function HandleYields(props, yields) {
-      ops.push('HandleYields');
-      return yields.map(y =>
-        <y.continuation isSame={props.foo === y.props.bar} />
-      );
-    }
+  function HandleYields(props, yields) {
+    ops.push('HandleYields');
+    return yields.map(y =>
+      <y.continuation isSame={props.foo === y.props.bar} />
+    );
+  }
 
-    // An alternative API could mark Parent as something that needs
-    // yielding. E.g. Parent.handler = HandleYields;
-    function Parent(props) {
-      ops.push('Parent');
-      return ReactCoroutine.createCoroutine(
-        props.children,
-        HandleYields,
-        props
-      );
-    }
+  // An alternative API could mark Parent as something that needs
+  // yielding. E.g. Parent.handler = HandleYields;
+  function Parent(props) {
+    ops.push('Parent');
+    return ReactCoroutine.createCoroutine(
+      props.children,
+      HandleYields,
+      props
+    );
+  }
 
-    function App() {
-      return <div><Parent foo={true}><Indirection /></Parent></div>;
-    }
+  function App() {
+    return <div><Parent foo={true}><Indirection /></Parent></div>;
+  }
 
-    ReactNoop.render(<App />);
-    ReactNoop.flush();
+  ReactNoop.render(<App />);
+  ReactNoop.flush();
 
-    expect(ops).toEqual([
-      'Parent',
-      'Indirection',
-      ['Child', true],
-      // Yield
-      ['Child', false],
-      // Yield
-      'HandleYields',
-      // Continue yields
-      ['Continuation', true],
-      ['Continuation', false],
-    ]);
-
-  });
+  expect(ops).toEqual([
+    'Parent',
+    'Indirection',
+    ['Child', true],
+    // Yield
+    ['Child', false],
+    // Yield
+    'HandleYields',
+    // Continue yields
+    ['Continuation', true],
+    ['Continuation', false],
+  ]);
 
 });

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -14,546 +14,544 @@
 var React;
 var ReactNoop;
 
-describe('ReactIncremental', function() {
-  beforeEach(function() {
-    React = require('React');
-    ReactNoop = require('ReactNoop');
-  });
+beforeEach(function() {
+  React = require('React');
+  ReactNoop = require('ReactNoop');
+});
 
-  it('should render a simple component', function() {
+it('should render a simple component', function() {
 
-    function Bar() {
-      return <div>Hello World</div>;
+  function Bar() {
+    return <div>Hello World</div>;
+  }
+
+  function Foo() {
+    return <Bar isBar={true} />;
+  }
+
+  ReactNoop.render(<Foo />);
+  ReactNoop.flush();
+
+});
+
+it('should render a simple component, in steps if needed', function() {
+
+  var barCalled = false;
+  function Bar() {
+    barCalled = true;
+    return <span><div>Hello World</div></span>;
+  }
+
+  var fooCalled = false;
+  function Foo() {
+    fooCalled = true;
+    return [
+      <Bar isBar={true} />,
+      <Bar isBar={true} />,
+    ];
+  }
+
+  ReactNoop.render(<Foo />);
+  expect(fooCalled).toBe(false);
+  expect(barCalled).toBe(false);
+  // Do one step of work.
+  ReactNoop.flushLowPri(7);
+  expect(fooCalled).toBe(true);
+  expect(barCalled).toBe(false);
+  // Do the rest of the work.
+  ReactNoop.flushLowPri(50);
+  expect(fooCalled).toBe(true);
+  expect(barCalled).toBe(true);
+});
+
+it('updates a previous render', function() {
+
+  var ops = [];
+
+  function Header() {
+    ops.push('Header');
+    return <h1>Hi</h1>;
+  }
+
+  function Content(props) {
+    ops.push('Content');
+    return <div>{props.children}</div>;
+  }
+
+  function Footer() {
+    ops.push('Footer');
+    return <footer>Bye</footer>;
+  }
+
+  var header = <Header />;
+  var footer = <Footer />;
+
+  function Foo(props) {
+    ops.push('Foo');
+    return (
+      <div>
+        {header}
+        <Content>{props.text}</Content>
+        {footer}
+      </div>
+    );
+  }
+
+  ReactNoop.render(<Foo text="foo" />);
+  ReactNoop.flush();
+
+  expect(ops).toEqual(['Foo', 'Header', 'Content', 'Footer']);
+
+  ops = [];
+
+  ReactNoop.render(<Foo text="bar" />);
+  ReactNoop.flush();
+
+  // TODO: Test bail out of host components. This is currently unobservable.
+
+  // Since this is an update, it should bail out and reuse the work from
+  // Header and Content.
+  expect(ops).toEqual(['Foo', 'Content']);
+
+});
+
+it('can cancel partially rendered work and restart', function() {
+
+  var ops = [];
+
+  function Bar(props) {
+    ops.push('Bar');
+    return <div>{props.children}</div>;
+  }
+
+  function Foo(props) {
+    ops.push('Foo');
+    return (
+      <div>
+        <Bar>{props.text}</Bar>
+        <Bar>{props.text}</Bar>
+      </div>
+    );
+  }
+
+  // Init
+  ReactNoop.render(<Foo text="foo" />);
+  ReactNoop.flush();
+
+  ops = [];
+
+  ReactNoop.render(<Foo text="bar" />);
+  // Flush part of the work
+  ReactNoop.flushLowPri(20);
+
+  expect(ops).toEqual(['Foo', 'Bar']);
+
+  ops = [];
+
+  // This will abort the previous work and restart
+  ReactNoop.render(<Foo text="baz" />);
+
+  // Flush part of the new work
+  ReactNoop.flushLowPri(20);
+
+  expect(ops).toEqual(['Foo', 'Bar']);
+
+  // Flush the rest of the work which now includes the low priority
+  ReactNoop.flush(20);
+
+  expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
+
+});
+
+it('can deprioritize unfinished work and resume it later', function() {
+
+  var ops = [];
+
+  function Bar(props) {
+    ops.push('Bar');
+    return <div>{props.children}</div>;
+  }
+
+  function Middle(props) {
+    ops.push('Middle');
+    return <span>{props.children}</span>;
+  }
+
+  function Foo(props) {
+    ops.push('Foo');
+    return (
+      <div>
+        <Bar>{props.text}</Bar>
+        <section hidden={true}>
+          <Middle>{props.text}</Middle>
+        </section>
+        <Bar>{props.text}</Bar>
+        <footer hidden={true}>
+          <Middle>Footer</Middle>
+        </footer>
+      </div>
+    );
+  }
+
+  // Init
+  ReactNoop.render(<Foo text="foo" />);
+  ReactNoop.flush();
+
+  expect(ops).toEqual(['Foo', 'Bar', 'Bar', 'Middle', 'Middle']);
+
+  ops = [];
+
+  // Render part of the work. This should be enough to flush everything except
+  // the middle which has lower priority.
+  ReactNoop.render(<Foo text="bar" />);
+  ReactNoop.flushLowPri(40);
+
+  expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
+
+  ops = [];
+
+  // Flush only the remaining work
+  ReactNoop.flush();
+
+  expect(ops).toEqual(['Middle', 'Middle']);
+
+});
+
+it('can resume work in a subtree even when a parent bails out', function() {
+
+  var ops = [];
+
+  function Bar(props) {
+    ops.push('Bar');
+    return <div>{props.children}</div>;
+  }
+
+  function Tester() {
+    // This component is just here to ensure that the bail out is
+    // in fact in effect in the expected place for this test.
+    ops.push('Tester');
+    return <div />;
+  }
+
+  function Middle(props) {
+    ops.push('Middle');
+    return <span>{props.children}</span>;
+  }
+
+  var middleContent = (
+    <aaa>
+      <Tester />
+      <bbb hidden={true}>
+        <ccc>
+          <Middle>Hi</Middle>
+        </ccc>
+      </bbb>
+    </aaa>
+  );
+
+  function Foo(props) {
+    ops.push('Foo');
+    return (
+      <div>
+        <Bar>{props.text}</Bar>
+        {middleContent}
+        <Bar>{props.text}</Bar>
+      </div>
+    );
+  }
+
+  // Init
+  ReactNoop.render(<Foo text="foo" />);
+  ReactNoop.flushLowPri(52);
+
+  expect(ops).toEqual(['Foo', 'Bar', 'Tester', 'Bar']);
+
+  ops = [];
+
+  // We're now rendering an update that will bail out on updating middle.
+  ReactNoop.render(<Foo text="bar" />);
+  ReactNoop.flushLowPri(45);
+
+  expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
+
+  ops = [];
+
+  // Flush the rest to make sure that the bailout didn't block this work.
+  ReactNoop.flush();
+  expect(ops).toEqual(['Middle']);
+});
+
+it('can resume work in a bailed subtree within one pass', function() {
+  var ops = [];
+
+  function Bar(props) {
+    ops.push('Bar');
+    return <div>{props.children}</div>;
+  }
+
+  class Tester extends React.Component {
+    shouldComponentUpdate() {
+      return false;
     }
-
-    function Foo() {
-      return <Bar isBar={true} />;
-    }
-
-    ReactNoop.render(<Foo />);
-    ReactNoop.flush();
-
-  });
-
-  it('should render a simple component, in steps if needed', function() {
-
-    var barCalled = false;
-    function Bar() {
-      barCalled = true;
-      return <span><div>Hello World</div></span>;
-    }
-
-    var fooCalled = false;
-    function Foo() {
-      fooCalled = true;
-      return [
-        <Bar isBar={true} />,
-        <Bar isBar={true} />,
-      ];
-    }
-
-    ReactNoop.render(<Foo />);
-    expect(fooCalled).toBe(false);
-    expect(barCalled).toBe(false);
-    // Do one step of work.
-    ReactNoop.flushLowPri(7);
-    expect(fooCalled).toBe(true);
-    expect(barCalled).toBe(false);
-    // Do the rest of the work.
-    ReactNoop.flushLowPri(50);
-    expect(fooCalled).toBe(true);
-    expect(barCalled).toBe(true);
-  });
-
-  it('updates a previous render', function() {
-
-    var ops = [];
-
-    function Header() {
-      ops.push('Header');
-      return <h1>Hi</h1>;
-    }
-
-    function Content(props) {
-      ops.push('Content');
-      return <div>{props.children}</div>;
-    }
-
-    function Footer() {
-      ops.push('Footer');
-      return <footer>Bye</footer>;
-    }
-
-    var header = <Header />;
-    var footer = <Footer />;
-
-    function Foo(props) {
-      ops.push('Foo');
-      return (
-        <div>
-          {header}
-          <Content>{props.text}</Content>
-          {footer}
-        </div>
-      );
-    }
-
-    ReactNoop.render(<Foo text="foo" />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual(['Foo', 'Header', 'Content', 'Footer']);
-
-    ops = [];
-
-    ReactNoop.render(<Foo text="bar" />);
-    ReactNoop.flush();
-
-    // TODO: Test bail out of host components. This is currently unobservable.
-
-    // Since this is an update, it should bail out and reuse the work from
-    // Header and Content.
-    expect(ops).toEqual(['Foo', 'Content']);
-
-  });
-
-  it('can cancel partially rendered work and restart', function() {
-
-    var ops = [];
-
-    function Bar(props) {
-      ops.push('Bar');
-      return <div>{props.children}</div>;
-    }
-
-    function Foo(props) {
-      ops.push('Foo');
-      return (
-        <div>
-          <Bar>{props.text}</Bar>
-          <Bar>{props.text}</Bar>
-        </div>
-      );
-    }
-
-    // Init
-    ReactNoop.render(<Foo text="foo" />);
-    ReactNoop.flush();
-
-    ops = [];
-
-    ReactNoop.render(<Foo text="bar" />);
-    // Flush part of the work
-    ReactNoop.flushLowPri(20);
-
-    expect(ops).toEqual(['Foo', 'Bar']);
-
-    ops = [];
-
-    // This will abort the previous work and restart
-    ReactNoop.render(<Foo text="baz" />);
-
-    // Flush part of the new work
-    ReactNoop.flushLowPri(20);
-
-    expect(ops).toEqual(['Foo', 'Bar']);
-
-    // Flush the rest of the work which now includes the low priority
-    ReactNoop.flush(20);
-
-    expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
-
-  });
-
-  it('can deprioritize unfinished work and resume it later', function() {
-
-    var ops = [];
-
-    function Bar(props) {
-      ops.push('Bar');
-      return <div>{props.children}</div>;
-    }
-
-    function Middle(props) {
-      ops.push('Middle');
-      return <span>{props.children}</span>;
-    }
-
-    function Foo(props) {
-      ops.push('Foo');
-      return (
-        <div>
-          <Bar>{props.text}</Bar>
-          <section hidden={true}>
-            <Middle>{props.text}</Middle>
-          </section>
-          <Bar>{props.text}</Bar>
-          <footer hidden={true}>
-            <Middle>Footer</Middle>
-          </footer>
-        </div>
-      );
-    }
-
-    // Init
-    ReactNoop.render(<Foo text="foo" />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual(['Foo', 'Bar', 'Bar', 'Middle', 'Middle']);
-
-    ops = [];
-
-    // Render part of the work. This should be enough to flush everything except
-    // the middle which has lower priority.
-    ReactNoop.render(<Foo text="bar" />);
-    ReactNoop.flushLowPri(40);
-
-    expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
-
-    ops = [];
-
-    // Flush only the remaining work
-    ReactNoop.flush();
-
-    expect(ops).toEqual(['Middle', 'Middle']);
-
-  });
-
-  it('can resume work in a subtree even when a parent bails out', function() {
-
-    var ops = [];
-
-    function Bar(props) {
-      ops.push('Bar');
-      return <div>{props.children}</div>;
-    }
-
-    function Tester() {
+    render() {
       // This component is just here to ensure that the bail out is
       // in fact in effect in the expected place for this test.
       ops.push('Tester');
       return <div />;
     }
+  }
 
-    function Middle(props) {
-      ops.push('Middle');
-      return <span>{props.children}</span>;
+  function Middle(props) {
+    ops.push('Middle');
+    return <span>{props.children}</span>;
+  }
+
+  // Should content not just bail out on current, not workInProgress?
+
+  class Content extends React.Component {
+    shouldComponentUpdate() {
+      return false;
     }
-
-    var middleContent = (
-      <aaa>
-        <Tester />
+    render() {
+      return [
+        <Tester unused={this.props.unused} />,
         <bbb hidden={true}>
           <ccc>
             <Middle>Hi</Middle>
           </ccc>
-        </bbb>
-      </aaa>
-    );
-
-    function Foo(props) {
-      ops.push('Foo');
-      return (
-        <div>
-          <Bar>{props.text}</Bar>
-          {middleContent}
-          <Bar>{props.text}</Bar>
-        </div>
-      );
+        </bbb>,
+      ];
     }
+  }
 
-    // Init
-    ReactNoop.render(<Foo text="foo" />);
-    ReactNoop.flushLowPri(52);
-
-    expect(ops).toEqual(['Foo', 'Bar', 'Tester', 'Bar']);
-
-    ops = [];
-
-    // We're now rendering an update that will bail out on updating middle.
-    ReactNoop.render(<Foo text="bar" />);
-    ReactNoop.flushLowPri(45);
-
-    expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
-
-    ops = [];
-
-    // Flush the rest to make sure that the bailout didn't block this work.
-    ReactNoop.flush();
-    expect(ops).toEqual(['Middle']);
-  });
-
-  it('can resume work in a bailed subtree within one pass', function() {
-    var ops = [];
-
-    function Bar(props) {
-      ops.push('Bar');
-      return <div>{props.children}</div>;
-    }
-
-    class Tester extends React.Component {
-      shouldComponentUpdate() {
-        return false;
-      }
-      render() {
-        // This component is just here to ensure that the bail out is
-        // in fact in effect in the expected place for this test.
-        ops.push('Tester');
-        return <div />;
-      }
-    }
-
-    function Middle(props) {
-      ops.push('Middle');
-      return <span>{props.children}</span>;
-    }
-
-    // Should content not just bail out on current, not workInProgress?
-
-    class Content extends React.Component {
-      shouldComponentUpdate() {
-        return false;
-      }
-      render() {
-        return [
-          <Tester unused={this.props.unused} />,
-          <bbb hidden={true}>
-            <ccc>
-              <Middle>Hi</Middle>
-            </ccc>
-          </bbb>,
-        ];
-      }
-    }
-
-    function Foo(props) {
-      ops.push('Foo');
-      return (
-        <div hidden={props.text === 'bar'}>
-          <Bar>{props.text}</Bar>
-          <Content unused={props.text} />
-          <Bar>{props.text}</Bar>
-        </div>
-      );
-    }
-
-    // Init
-    ReactNoop.render(<Foo text="foo" />);
-    ReactNoop.flushLowPri(52);
-
-    expect(ops).toEqual(['Foo', 'Bar', 'Tester', 'Bar']);
-
-    ops = [];
-
-    // Make a quick update which will create a low pri tree on top of the
-    // already low pri tree.
-    ReactNoop.render(<Foo text="bar" />);
-    ReactNoop.flushLowPri(15);
-
-    expect(ops).toEqual(['Foo']);
-
-    ops = [];
-
-    // At this point, middle will bail out but it has not yet fully rendered.
-    // Since that is the same priority as its parent tree. This should render
-    // as a single batch. Therefore, it is correct that Middle should be in the
-    // middle. If it occurs after the two "Bar" components then it was flushed
-    // after them which is not correct.
-    ReactNoop.flush();
-    expect(ops).toEqual(['Bar', 'Middle', 'Bar']);
-  });
-
-  it('can reuse work done after being preempted', function() {
-
-    var ops = [];
-
-    function Bar(props) {
-      ops.push('Bar');
-      return <div>{props.children}</div>;
-    }
-
-    function Middle(props) {
-      ops.push('Middle');
-      return <span>{props.children}</span>;
-    }
-
-    var middleContent = (
-      <div>
-        <Middle>Hello</Middle>
-        <Bar>-</Bar>
-        <Middle>World</Middle>
+  function Foo(props) {
+    ops.push('Foo');
+    return (
+      <div hidden={props.text === 'bar'}>
+        <Bar>{props.text}</Bar>
+        <Content unused={props.text} />
+        <Bar>{props.text}</Bar>
       </div>
     );
+  }
 
-    var step0 = (
+  // Init
+  ReactNoop.render(<Foo text="foo" />);
+  ReactNoop.flushLowPri(52);
+
+  expect(ops).toEqual(['Foo', 'Bar', 'Tester', 'Bar']);
+
+  ops = [];
+
+  // Make a quick update which will create a low pri tree on top of the
+  // already low pri tree.
+  ReactNoop.render(<Foo text="bar" />);
+  ReactNoop.flushLowPri(15);
+
+  expect(ops).toEqual(['Foo']);
+
+  ops = [];
+
+  // At this point, middle will bail out but it has not yet fully rendered.
+  // Since that is the same priority as its parent tree. This should render
+  // as a single batch. Therefore, it is correct that Middle should be in the
+  // middle. If it occurs after the two "Bar" components then it was flushed
+  // after them which is not correct.
+  ReactNoop.flush();
+  expect(ops).toEqual(['Bar', 'Middle', 'Bar']);
+});
+
+it('can reuse work done after being preempted', function() {
+
+  var ops = [];
+
+  function Bar(props) {
+    ops.push('Bar');
+    return <div>{props.children}</div>;
+  }
+
+  function Middle(props) {
+    ops.push('Middle');
+    return <span>{props.children}</span>;
+  }
+
+  var middleContent = (
+    <div>
+      <Middle>Hello</Middle>
+      <Bar>-</Bar>
+      <Middle>World</Middle>
+    </div>
+  );
+
+  var step0 = (
+    <div>
+      <Middle>Hi</Middle>
+      <Bar>{'Foo'}</Bar>
+      <Middle>There</Middle>
+    </div>
+  );
+
+  function Foo(props) {
+    ops.push('Foo');
+    return (
       <div>
-        <Middle>Hi</Middle>
-        <Bar>{'Foo'}</Bar>
-        <Middle>There</Middle>
+        <Bar>{props.text2}</Bar>
+        <div hidden={true}>
+          {
+            props.step === 0 ?
+              step0
+              : middleContent
+          }
+        </div>
       </div>
     );
+  }
 
-    function Foo(props) {
-      ops.push('Foo');
+  // Init
+  ReactNoop.render(<Foo text="foo" text2="foo" step={0} />);
+  ReactNoop.flushLowPri(55);
+
+  // We only finish the higher priority work. So the low pri content
+  // has not yet finished mounting.
+  expect(ops).toEqual(['Foo', 'Bar', 'Middle', 'Bar']);
+
+  ops = [];
+
+  // Interupt the rendering with a quick update. This should not touch the
+  // middle content.
+  ReactNoop.render(<Foo text="foo" text2="bar" step={0} />);
+  ReactNoop.flush();
+
+  // We've now rendered the entire tree but we didn't have to redo the work
+  // done by the first Middle and Bar already.
+  expect(ops).toEqual(['Foo', 'Bar', 'Middle']);
+
+  ops = [];
+
+  // Make a quick update which will schedule low priority work to
+  // update the middle content.
+  ReactNoop.render(<Foo text="bar" text2="bar" step={1} />);
+  ReactNoop.flushLowPri(30);
+
+  expect(ops).toEqual(['Foo', 'Bar']);
+
+  ops = [];
+
+  // The middle content is now pending rendering...
+  ReactNoop.flushLowPri(30);
+  expect(ops).toEqual(['Middle', 'Bar']);
+
+  ops = [];
+
+  // but we'll interupt it to render some higher priority work.
+  // The middle content will bailout so it remains untouched.
+  ReactNoop.render(<Foo text="foo" text2="bar" step={1} />);
+  ReactNoop.flushLowPri(30);
+
+  expect(ops).toEqual(['Foo', 'Bar']);
+
+  ops = [];
+
+  // Since we did nothing to the middle subtree during the interuption,
+  // we should be able to reuse the reconciliation work that we already did
+  // without restarting.
+  ReactNoop.flush();
+  expect(ops).toEqual(['Middle']);
+
+});
+
+it('can reuse work if shouldComponentUpdate is false, after being preempted', function() {
+
+  var ops = [];
+
+  function Bar(props) {
+    ops.push('Bar');
+    return <div>{props.children}</div>;
+  }
+
+  class Middle extends React.Component {
+    shouldComponentUpdate(nextProps) {
+      return this.props.children !== nextProps.children;
+    }
+    render() {
+      ops.push('Middle');
+      return <span>{this.props.children}</span>;
+    }
+  }
+
+  class Content extends React.Component {
+    shouldComponentUpdate(nextProps) {
+      return this.props.step !== nextProps.step;
+    }
+    render() {
+      ops.push('Content');
       return (
         <div>
-          <Bar>{props.text2}</Bar>
-          <div hidden={true}>
-            {
-              props.step === 0 ?
-                step0
-                : middleContent
-            }
-          </div>
+          <Middle>{this.props.step === 0 ? 'Hi' : 'Hello'}</Middle>
+          <Bar>{this.props.step === 0 ? this.props.text : '-'}</Bar>
+          <Middle>{this.props.step === 0 ? 'There' : 'World'}</Middle>
         </div>
       );
     }
+  }
 
-    // Init
-    ReactNoop.render(<Foo text="foo" text2="foo" step={0} />);
-    ReactNoop.flushLowPri(55);
-
-    // We only finish the higher priority work. So the low pri content
-    // has not yet finished mounting.
-    expect(ops).toEqual(['Foo', 'Bar', 'Middle', 'Bar']);
-
-    ops = [];
-
-    // Interupt the rendering with a quick update. This should not touch the
-    // middle content.
-    ReactNoop.render(<Foo text="foo" text2="bar" step={0} />);
-    ReactNoop.flush();
-
-    // We've now rendered the entire tree but we didn't have to redo the work
-    // done by the first Middle and Bar already.
-    expect(ops).toEqual(['Foo', 'Bar', 'Middle']);
-
-    ops = [];
-
-    // Make a quick update which will schedule low priority work to
-    // update the middle content.
-    ReactNoop.render(<Foo text="bar" text2="bar" step={1} />);
-    ReactNoop.flushLowPri(30);
-
-    expect(ops).toEqual(['Foo', 'Bar']);
-
-    ops = [];
-
-    // The middle content is now pending rendering...
-    ReactNoop.flushLowPri(30);
-    expect(ops).toEqual(['Middle', 'Bar']);
-
-    ops = [];
-
-    // but we'll interupt it to render some higher priority work.
-    // The middle content will bailout so it remains untouched.
-    ReactNoop.render(<Foo text="foo" text2="bar" step={1} />);
-    ReactNoop.flushLowPri(30);
-
-    expect(ops).toEqual(['Foo', 'Bar']);
-
-    ops = [];
-
-    // Since we did nothing to the middle subtree during the interuption,
-    // we should be able to reuse the reconciliation work that we already did
-    // without restarting.
-    ReactNoop.flush();
-    expect(ops).toEqual(['Middle']);
-
-  });
-
-  it('can reuse work if shouldComponentUpdate is false, after being preempted', function() {
-
-    var ops = [];
-
-    function Bar(props) {
-      ops.push('Bar');
-      return <div>{props.children}</div>;
-    }
-
-    class Middle extends React.Component {
-      shouldComponentUpdate(nextProps) {
-        return this.props.children !== nextProps.children;
-      }
-      render() {
-        ops.push('Middle');
-        return <span>{this.props.children}</span>;
-      }
-    }
-
-    class Content extends React.Component {
-      shouldComponentUpdate(nextProps) {
-        return this.props.step !== nextProps.step;
-      }
-      render() {
-        ops.push('Content');
-        return (
-          <div>
-            <Middle>{this.props.step === 0 ? 'Hi' : 'Hello'}</Middle>
-            <Bar>{this.props.step === 0 ? this.props.text : '-'}</Bar>
-            <Middle>{this.props.step === 0 ? 'There' : 'World'}</Middle>
-          </div>
-        );
-      }
-    }
-
-    function Foo(props) {
-      ops.push('Foo');
-      return (
-        <div>
-          <Bar>{props.text}</Bar>
-          <div hidden={true}>
-            <Content step={props.step} text={props.text} />
-          </div>
+  function Foo(props) {
+    ops.push('Foo');
+    return (
+      <div>
+        <Bar>{props.text}</Bar>
+        <div hidden={true}>
+          <Content step={props.step} text={props.text} />
         </div>
-      );
-    }
+      </div>
+    );
+  }
 
-    // Init
-    ReactNoop.render(<Foo text="foo" step={0} />);
-    ReactNoop.flush();
+  // Init
+  ReactNoop.render(<Foo text="foo" step={0} />);
+  ReactNoop.flush();
 
-    expect(ops).toEqual(['Foo', 'Bar', 'Content', 'Middle', 'Bar', 'Middle']);
+  expect(ops).toEqual(['Foo', 'Bar', 'Content', 'Middle', 'Bar', 'Middle']);
 
-    ops = [];
+  ops = [];
 
-    // Make a quick update which will schedule low priority work to
-    // update the middle content.
-    ReactNoop.render(<Foo text="bar" step={1} />);
-    ReactNoop.flushLowPri(30);
+  // Make a quick update which will schedule low priority work to
+  // update the middle content.
+  ReactNoop.render(<Foo text="bar" step={1} />);
+  ReactNoop.flushLowPri(30);
 
-    expect(ops).toEqual(['Foo', 'Bar']);
+  expect(ops).toEqual(['Foo', 'Bar']);
 
-    ops = [];
+  ops = [];
 
-    // The middle content is now pending rendering...
-    ReactNoop.flushLowPri(30);
-    expect(ops).toEqual(['Content', 'Middle', 'Bar']); // One more Middle left.
+  // The middle content is now pending rendering...
+  ReactNoop.flushLowPri(30);
+  expect(ops).toEqual(['Content', 'Middle', 'Bar']); // One more Middle left.
 
-    ops = [];
+  ops = [];
 
-    // but we'll interupt it to render some higher priority work.
-    // The middle content will bailout so it remains untouched.
-    ReactNoop.render(<Foo text="foo" step={1} />);
-    ReactNoop.flushLowPri(30);
+  // but we'll interupt it to render some higher priority work.
+  // The middle content will bailout so it remains untouched.
+  ReactNoop.render(<Foo text="foo" step={1} />);
+  ReactNoop.flushLowPri(30);
 
-    expect(ops).toEqual(['Foo', 'Bar']);
+  expect(ops).toEqual(['Foo', 'Bar']);
 
-    ops = [];
+  ops = [];
 
-    // Since we did nothing to the middle subtree during the interuption,
-    // we should be able to reuse the reconciliation work that we already did
-    // without restarting.
-    ReactNoop.flush();
-    // TODO: Content never fully completed its render so can't completely bail
-    // out on the entire subtree. However, we could do a shallow bail out and
-    // not rerender Content, but keep going down the incomplete tree.
-    // Normally shouldComponentUpdate->false is not enough to determine that we
-    // can safely reuse the old props, but I think in this case it would be ok,
-    // since it is a resume of already started work.
-    // Because of the above we can also not reuse the work of Bar because the
-    // rerender of Content will generate a new element which will mean we don't
-    // auto-bail out from Bar.
-    expect(ops).toEqual(['Content', 'Bar', 'Middle']);
+  // Since we did nothing to the middle subtree during the interuption,
+  // we should be able to reuse the reconciliation work that we already did
+  // without restarting.
+  ReactNoop.flush();
+  // TODO: Content never fully completed its render so can't completely bail
+  // out on the entire subtree. However, we could do a shallow bail out and
+  // not rerender Content, but keep going down the incomplete tree.
+  // Normally shouldComponentUpdate->false is not enough to determine that we
+  // can safely reuse the old props, but I think in this case it would be ok,
+  // since it is a resume of already started work.
+  // Because of the above we can also not reuse the work of Bar because the
+  // rerender of Content will generate a new element which will mean we don't
+  // auto-bail out from Bar.
+  expect(ops).toEqual(['Content', 'Bar', 'Middle']);
 
-  });
 });

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -14,264 +14,261 @@
 var React;
 var ReactNoop;
 
-describe('ReactIncrementalSideEffects', function() {
-  beforeEach(function() {
-    React = require('React');
-    ReactNoop = require('ReactNoop');
-  });
+beforeEach(function() {
+  React = require('React');
+  ReactNoop = require('ReactNoop');
+});
 
-  function div(...children) {
-    return { type: 'div', children, prop: undefined };
+function div(...children) {
+  return { type: 'div', children, prop: undefined };
+}
+
+function span(prop) {
+  return { type: 'span', children: [], prop };
+}
+
+it('can update child nodes of a host instance', function() {
+
+  function Bar(props) {
+    return <span>{props.text}</span>;
   }
 
-  function span(prop) {
-    return { type: 'span', children: [], prop };
-  }
-
-  it('can update child nodes of a host instance', function() {
-
-    function Bar(props) {
-      return <span>{props.text}</span>;
-    }
-
-    function Foo(props) {
-      return (
-        <div>
-          <Bar text={props.text} />
-          {props.text === 'World' ? <Bar text={props.text} /> : null}
-        </div>
-      );
-    }
-
-    ReactNoop.render(<Foo text="Hello" />);
-    ReactNoop.flush();
-    expect(ReactNoop.root.children).toEqual([
-      div(span()),
-    ]);
-
-    ReactNoop.render(<Foo text="World" />);
-    ReactNoop.flush();
-    expect(ReactNoop.root.children).toEqual([
-      div(span(), span()),
-    ]);
-
-  });
-
-  it('does not update child nodes if a flush is aborted', function() {
-
-    function Bar(props) {
-      return <span prop={props.text} />;
-    }
-
-    function Foo(props) {
-      return (
-        <div>
-          <div>
-            <Bar text={props.text} />
-            {props.text === 'Hello' ? <Bar text={props.text} /> : null}
-          </div>
-          <Bar text="Yo" />
-        </div>
-      );
-    }
-
-    ReactNoop.render(<Foo text="Hello" />);
-    ReactNoop.flush();
-    expect(ReactNoop.root.children).toEqual([
-      div(div(span('Hello'), span('Hello')), span('Yo')),
-    ]);
-
-    ReactNoop.render(<Foo text="World" />);
-    ReactNoop.flushLowPri(35);
-    expect(ReactNoop.root.children).toEqual([
-      div(div(span('Hello'), span('Hello')), span('Yo')),
-    ]);
-
-  });
-
-  it('preserves a previously rendered node when deprioritized', function() {
-
-    function Middle(props) {
-      return <span prop={props.children} />;
-    }
-
-    function Foo(props) {
-      return (
-        <div>
-          <div hidden={true}>
-            <Middle>{props.text}</Middle>
-          </div>
-        </div>
-      );
-    }
-
-    ReactNoop.render(<Foo text="foo" />);
-    ReactNoop.flush();
-
-    expect(ReactNoop.root.children).toEqual([
-      div(div(span('foo'))),
-    ]);
-
-    ReactNoop.render(<Foo text="bar" />);
-    ReactNoop.flushLowPri(20);
-
-    expect(ReactNoop.root.children).toEqual([
-      div(div(span('foo'))),
-    ]);
-
-    ReactNoop.flush();
-
-    expect(ReactNoop.root.children).toEqual([
-      div(div(span('bar'))),
-    ]);
-
-  });
-
-  it('can reuse side-effects after being preempted', function() {
-
-    function Bar(props) {
-      return <span prop={props.children} />;
-    }
-
-    var middleContent = (
+  function Foo(props) {
+    return (
       <div>
-        <Bar>Hello</Bar>
-        <Bar>World</Bar>
+        <Bar text={props.text} />
+        {props.text === 'World' ? <Bar text={props.text} /> : null}
       </div>
     );
+  }
 
-    function Foo(props) {
-      return (
-        <div hidden={true}>
-          {
-            props.step === 0 ?
-              <div>
-                <Bar>Hi</Bar>
-                <Bar>{props.text}</Bar>
-              </div>
-              : middleContent
-          }
-        </div>
-      );
-    }
+  ReactNoop.render(<Foo text="Hello" />);
+  ReactNoop.flush();
+  expect(ReactNoop.root.children).toEqual([
+    div(span()),
+  ]);
 
-    // Init
-    ReactNoop.render(<Foo text="foo" step={0} />);
-    ReactNoop.flush();
-
-    expect(ReactNoop.root.children).toEqual([
-      div(div(span('Hi'), span('foo'))),
-    ]);
-
-    // Make a quick update which will schedule low priority work to
-    // update the middle content.
-    ReactNoop.render(<Foo text="bar" step={1} />);
-    ReactNoop.flushLowPri(30);
-
-    // The tree remains unchanged.
-    expect(ReactNoop.root.children).toEqual([
-      div(div(span('Hi'), span('foo'))),
-    ]);
-
-    // The first Bar has already completed its update but we'll interupt it to
-    // render some higher priority work. The middle content will bailout so
-    // it remains untouched which means that it should reuse it next time.
-    ReactNoop.render(<Foo text="foo" step={1} />);
-    ReactNoop.flush(30);
-
-    // Since we did nothing to the middle subtree during the interuption,
-    // we should be able to reuse the reconciliation work that we already did
-    // without restarting. The side-effects should still be replayed.
-
-    expect(ReactNoop.root.children).toEqual([
-      div(div(span('Hello'), span('World'))),
-    ]);
-  });
-
-  it('can reuse side-effects after being preempted, if shouldComponentUpdate is false', function() {
-
-    class Bar extends React.Component {
-      shouldComponentUpdate(nextProps) {
-        return this.props.children !== nextProps.children;
-      }
-      render() {
-        return <span prop={this.props.children} />;
-      }
-    }
-
-    class Content extends React.Component {
-      shouldComponentUpdate(nextProps) {
-        return this.props.step !== nextProps.step;
-      }
-      render() {
-        return (
-          <div>
-            <Bar>{this.props.step === 0 ? 'Hi' : 'Hello'}</Bar>
-            <Bar>{this.props.step === 0 ? this.props.text : 'World'}</Bar>
-          </div>
-        );
-      }
-    }
-
-    function Foo(props) {
-      return (
-        <div hidden={true}>
-          <Content step={props.step} text={props.text} />
-        </div>
-      );
-    }
-
-    // Init
-    ReactNoop.render(<Foo text="foo" step={0} />);
-    ReactNoop.flush();
-
-    expect(ReactNoop.root.children).toEqual([
-      div(div(span('Hi'), span('foo'))),
-    ]);
-
-    // Make a quick update which will schedule low priority work to
-    // update the middle content.
-    ReactNoop.render(<Foo text="bar" step={1} />);
-    ReactNoop.flushLowPri(35);
-
-    // The tree remains unchanged.
-    expect(ReactNoop.root.children).toEqual([
-      div(div(span('Hi'), span('foo'))),
-    ]);
-
-    // The first Bar has already completed its update but we'll interupt it to
-    // render some higher priority work. The middle content will bailout so
-    // it remains untouched which means that it should reuse it next time.
-    ReactNoop.render(<Foo text="foo" step={1} />);
-    ReactNoop.flush(30);
-
-    // Since we did nothing to the middle subtree during the interuption,
-    // we should be able to reuse the reconciliation work that we already did
-    // without restarting. The side-effects should still be replayed.
-
-    expect(ReactNoop.root.children).toEqual([
-      div(div(span('Hello'), span('World'))),
-    ]);
-  });
-
-  it('updates a child even though the old props is empty', function() {
-    function Foo(props) {
-      return (
-        <div hidden={true}>
-          <span prop={1} />
-        </div>
-      );
-    }
-
-    ReactNoop.render(<Foo />);
-    ReactNoop.flush();
-    expect(ReactNoop.root.children).toEqual([
-      div(span(1)),
-    ]);
-  });
-
-  // TODO: Test that side-effects are not cut off when a work in progress node
-  // moves to "current" without flushing due to having lower priority. Does this
-  // even happen? Maybe a child doesn't get processed because it is lower prio?
+  ReactNoop.render(<Foo text="World" />);
+  ReactNoop.flush();
+  expect(ReactNoop.root.children).toEqual([
+    div(span(), span()),
+  ]);
 
 });
+
+it('does not update child nodes if a flush is aborted', function() {
+
+  function Bar(props) {
+    return <span prop={props.text} />;
+  }
+
+  function Foo(props) {
+    return (
+      <div>
+        <div>
+          <Bar text={props.text} />
+          {props.text === 'Hello' ? <Bar text={props.text} /> : null}
+        </div>
+        <Bar text="Yo" />
+      </div>
+    );
+  }
+
+  ReactNoop.render(<Foo text="Hello" />);
+  ReactNoop.flush();
+  expect(ReactNoop.root.children).toEqual([
+    div(div(span('Hello'), span('Hello')), span('Yo')),
+  ]);
+
+  ReactNoop.render(<Foo text="World" />);
+  ReactNoop.flushLowPri(35);
+  expect(ReactNoop.root.children).toEqual([
+    div(div(span('Hello'), span('Hello')), span('Yo')),
+  ]);
+
+});
+
+it('preserves a previously rendered node when deprioritized', function() {
+
+  function Middle(props) {
+    return <span prop={props.children} />;
+  }
+
+  function Foo(props) {
+    return (
+      <div>
+        <div hidden={true}>
+          <Middle>{props.text}</Middle>
+        </div>
+      </div>
+    );
+  }
+
+  ReactNoop.render(<Foo text="foo" />);
+  ReactNoop.flush();
+
+  expect(ReactNoop.root.children).toEqual([
+    div(div(span('foo'))),
+  ]);
+
+  ReactNoop.render(<Foo text="bar" />);
+  ReactNoop.flushLowPri(20);
+
+  expect(ReactNoop.root.children).toEqual([
+    div(div(span('foo'))),
+  ]);
+
+  ReactNoop.flush();
+
+  expect(ReactNoop.root.children).toEqual([
+    div(div(span('bar'))),
+  ]);
+
+});
+
+it('can reuse side-effects after being preempted', function() {
+
+  function Bar(props) {
+    return <span prop={props.children} />;
+  }
+
+  var middleContent = (
+    <div>
+      <Bar>Hello</Bar>
+      <Bar>World</Bar>
+    </div>
+  );
+
+  function Foo(props) {
+    return (
+      <div hidden={true}>
+        {
+          props.step === 0 ?
+            <div>
+              <Bar>Hi</Bar>
+              <Bar>{props.text}</Bar>
+            </div>
+            : middleContent
+        }
+      </div>
+    );
+  }
+
+  // Init
+  ReactNoop.render(<Foo text="foo" step={0} />);
+  ReactNoop.flush();
+
+  expect(ReactNoop.root.children).toEqual([
+    div(div(span('Hi'), span('foo'))),
+  ]);
+
+  // Make a quick update which will schedule low priority work to
+  // update the middle content.
+  ReactNoop.render(<Foo text="bar" step={1} />);
+  ReactNoop.flushLowPri(30);
+
+  // The tree remains unchanged.
+  expect(ReactNoop.root.children).toEqual([
+    div(div(span('Hi'), span('foo'))),
+  ]);
+
+  // The first Bar has already completed its update but we'll interupt it to
+  // render some higher priority work. The middle content will bailout so
+  // it remains untouched which means that it should reuse it next time.
+  ReactNoop.render(<Foo text="foo" step={1} />);
+  ReactNoop.flush(30);
+
+  // Since we did nothing to the middle subtree during the interuption,
+  // we should be able to reuse the reconciliation work that we already did
+  // without restarting. The side-effects should still be replayed.
+
+  expect(ReactNoop.root.children).toEqual([
+    div(div(span('Hello'), span('World'))),
+  ]);
+});
+
+it('can reuse side-effects after being preempted, if shouldComponentUpdate is false', function() {
+
+  class Bar extends React.Component {
+    shouldComponentUpdate(nextProps) {
+      return this.props.children !== nextProps.children;
+    }
+    render() {
+      return <span prop={this.props.children} />;
+    }
+  }
+
+  class Content extends React.Component {
+    shouldComponentUpdate(nextProps) {
+      return this.props.step !== nextProps.step;
+    }
+    render() {
+      return (
+        <div>
+          <Bar>{this.props.step === 0 ? 'Hi' : 'Hello'}</Bar>
+          <Bar>{this.props.step === 0 ? this.props.text : 'World'}</Bar>
+        </div>
+      );
+    }
+  }
+
+  function Foo(props) {
+    return (
+      <div hidden={true}>
+        <Content step={props.step} text={props.text} />
+      </div>
+    );
+  }
+
+  // Init
+  ReactNoop.render(<Foo text="foo" step={0} />);
+  ReactNoop.flush();
+
+  expect(ReactNoop.root.children).toEqual([
+    div(div(span('Hi'), span('foo'))),
+  ]);
+
+  // Make a quick update which will schedule low priority work to
+  // update the middle content.
+  ReactNoop.render(<Foo text="bar" step={1} />);
+  ReactNoop.flushLowPri(35);
+
+  // The tree remains unchanged.
+  expect(ReactNoop.root.children).toEqual([
+    div(div(span('Hi'), span('foo'))),
+  ]);
+
+  // The first Bar has already completed its update but we'll interupt it to
+  // render some higher priority work. The middle content will bailout so
+  // it remains untouched which means that it should reuse it next time.
+  ReactNoop.render(<Foo text="foo" step={1} />);
+  ReactNoop.flush(30);
+
+  // Since we did nothing to the middle subtree during the interuption,
+  // we should be able to reuse the reconciliation work that we already did
+  // without restarting. The side-effects should still be replayed.
+
+  expect(ReactNoop.root.children).toEqual([
+    div(div(span('Hello'), span('World'))),
+  ]);
+});
+
+it('updates a child even though the old props is empty', function() {
+  function Foo(props) {
+    return (
+      <div hidden={true}>
+        <span prop={1} />
+      </div>
+    );
+  }
+
+  ReactNoop.render(<Foo />);
+  ReactNoop.flush();
+  expect(ReactNoop.root.children).toEqual([
+    div(span(1)),
+  ]);
+});
+
+// TODO: Test that side-effects are not cut off when a work in progress node
+// moves to "current" without flushing due to having lower priority. Does this
+// even happen? Maybe a child doesn't get processed because it is lower prio?

--- a/src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.js
+++ b/src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.js
@@ -11,15 +11,1878 @@
 
 'use strict';
 
-describe('ReactComponentTreeHook', () => {
-  var React;
-  var ReactDOM;
-  var ReactDOMServer;
-  var ReactInstanceMap;
-  var ReactComponentTreeHook;
-  var ReactComponentTreeTestUtils;
+var React;
+var ReactDOM;
+var ReactDOMServer;
+var ReactInstanceMap;
+var ReactComponentTreeHook;
+var ReactComponentTreeTestUtils;
+
+beforeEach(() => {
+  jest.resetModuleRegistry();
+
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactDOMServer = require('ReactDOMServer');
+  ReactInstanceMap = require('ReactInstanceMap');
+  ReactComponentTreeHook = require('ReactComponentTreeHook');
+  ReactComponentTreeTestUtils = require('ReactComponentTreeTestUtils');
+});
+
+function assertTreeMatches(pairs) {
+  if (!Array.isArray(pairs[0])) {
+    pairs = [pairs];
+  }
+
+  var node = document.createElement('div');
+  var currentElement;
+  var rootInstance;
+
+  class Wrapper extends React.Component {
+    render() {
+      rootInstance = ReactInstanceMap.get(this);
+      return currentElement;
+    }
+  }
+
+  function expectWrapperTreeToEqual(expectedTree, andStayMounted) {
+    ReactComponentTreeTestUtils.expectTree(rootInstance._debugID, {
+      displayName: 'Wrapper',
+      children: expectedTree ? [expectedTree] : [],
+    });
+    var rootDisplayNames = ReactComponentTreeTestUtils.getRootDisplayNames();
+    var registeredDisplayNames = ReactComponentTreeTestUtils.getRegisteredDisplayNames();
+    if (!expectedTree) {
+      expect(rootDisplayNames).toEqual([]);
+      expect(registeredDisplayNames).toEqual([]);
+    } else if (andStayMounted) {
+      expect(rootDisplayNames).toContain('Wrapper');
+      expect(registeredDisplayNames).toContain('Wrapper');
+    }
+  }
+
+  // Mount once, render updates, then unmount.
+  // Ensure the tree is correct on every step.
+  pairs.forEach(([element, expectedTree]) => {
+    currentElement = element;
+
+    // Mount a new tree or update the existing tree.
+    ReactDOM.render(<Wrapper />, node);
+    expectWrapperTreeToEqual(expectedTree, true);
+
+    // Purging should have no effect
+    // on the tree we expect to see.
+    ReactComponentTreeHook.purgeUnmountedComponents();
+    expectWrapperTreeToEqual(expectedTree, true);
+  });
+
+  // Unmounting the root node should purge
+  // the whole subtree automatically.
+  ReactDOM.unmountComponentAtNode(node);
+  expectWrapperTreeToEqual(null);
+
+  // Server render every pair.
+  // Ensure the tree is correct on every step.
+  pairs.forEach(([element, expectedTree]) => {
+    currentElement = element;
+
+    // Rendering to string should not produce any entries
+    // because ReactDebugTool purges it when the flush ends.
+    ReactDOMServer.renderToString(<Wrapper />);
+    expectWrapperTreeToEqual(null);
+
+    // To test it, we tell the hook to ignore next purge
+    // so the cleanup request by ReactDebugTool is ignored.
+    // This lets us make assertions on the actual tree.
+    ReactComponentTreeHook._preventPurging = true;
+    ReactDOMServer.renderToString(<Wrapper />);
+    ReactComponentTreeHook._preventPurging = false;
+    expectWrapperTreeToEqual(expectedTree);
+
+    // Purge manually since we skipped the automatic purge.
+    ReactComponentTreeHook.purgeUnmountedComponents();
+    expectWrapperTreeToEqual(null);
+  });
+}
+
+describe('mount', () => {
+  it('uses displayName or Unknown for classic components', () => {
+    class Foo extends React.Component {
+      render() {
+        return null;
+      }
+    }
+
+    Foo.displayName = 'Bar';
+
+    class Baz extends React.Component {
+      render() {
+        return null;
+      }
+    }
+
+    class Qux extends React.Component {
+      render() {
+        return null;
+      }
+    }
+
+    delete Qux.displayName;
+
+    var element = <div><Foo /><Baz /><Qux /></div>;
+    var tree = {
+      displayName: 'div',
+      children: [{
+        displayName: 'Bar',
+        children: [],
+      }, {
+        displayName: 'Baz',
+        children: [],
+      }, {
+        displayName: 'Unknown',
+        children: [],
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('uses displayName, name, or ReactComponent for modern components', () => {
+    class Foo extends React.Component {
+      render() {
+        return null;
+      }
+    }
+    Foo.displayName = 'Bar';
+    class Baz extends React.Component {
+      render() {
+        return null;
+      }
+    }
+    class Qux extends React.Component {
+      render() {
+        return null;
+      }
+    }
+    delete Qux.name;
+
+    var element = <div><Foo /><Baz /><Qux /></div>;
+    var tree = {
+      displayName: 'div',
+      element,
+      children: [{
+        displayName: 'Bar',
+        children: [],
+      }, {
+        displayName: 'Baz',
+        children: [],
+      }, {
+        // Note: Ideally fallback name should be consistent (e.g. "Unknown")
+        displayName: 'ReactComponent',
+        children: [],
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('uses displayName, name, or Object for factory components', () => {
+    function Foo() {
+      return {
+        render() {
+          return null;
+        },
+      };
+    }
+    Foo.displayName = 'Bar';
+    function Baz() {
+      return {
+        render() {
+          return null;
+        },
+      };
+    }
+    function Qux() {
+      return {
+        render() {
+          return null;
+        },
+      };
+    }
+    delete Qux.name;
+
+    var element = <div><Foo /><Baz /><Qux /></div>;
+    var tree = {
+      displayName: 'div',
+      element,
+      children: [{
+        displayName: 'Bar',
+        children: [],
+      }, {
+        displayName: 'Baz',
+        children: [],
+      }, {
+        displayName: 'Unknown',
+        children: [],
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('uses displayName, name, or StatelessComponent for functional components', () => {
+    function Foo() {
+      return null;
+    }
+    Foo.displayName = 'Bar';
+    function Baz() {
+      return null;
+    }
+    function Qux() {
+      return null;
+    }
+    delete Qux.name;
+
+    var element = <div><Foo /><Baz /><Qux /></div>;
+    var tree = {
+      displayName: 'div',
+      element,
+      children: [{
+        displayName: 'Bar',
+        children: [],
+      }, {
+        displayName: 'Baz',
+        children: [],
+      }, {
+        displayName: 'Unknown',
+        children: [],
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('reports a host tree correctly', () => {
+    var element = (
+      <div>
+        <p>
+          <span>
+            Hi!
+          </span>
+          Wow.
+        </p>
+        <hr />
+      </div>
+    );
+    var tree = {
+      displayName: 'div',
+      children: [{
+        displayName: 'p',
+        children: [{
+          displayName: 'span',
+          children: [{
+            displayName: '#text',
+            text: 'Hi!',
+          }],
+        }, {
+          displayName: '#text',
+          text: 'Wow.',
+        }],
+      }, {
+        displayName: 'hr',
+        element: <hr />,
+        children: [],
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('reports a simple tree with composites correctly', () => {
+    class Foo extends React.Component {
+      render() {
+        return <div />;
+      }
+    }
+
+    var element = <Foo />;
+    var tree = {
+      displayName: 'Foo',
+      element,
+      children: [{
+        displayName: 'div',
+        element: <div />,
+        children: [],
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('reports a tree with composites correctly', () => {
+    class Qux extends React.Component {
+      render() {
+        return null;
+      }
+    }
+
+    function Foo() {
+      return {
+        render() {
+          return <Qux />;
+        },
+      };
+    }
+    function Bar({children}) {
+      return <h1>{children}</h1>;
+    }
+    class Baz extends React.Component {
+      render() {
+        return (
+          <div>
+            <Foo />
+            <Bar>
+              <span>Hi,</span>
+              Mom
+            </Bar>
+            <a href="#">Click me.</a>
+          </div>
+        );
+      }
+    }
+
+    var element = <Baz />;
+    var tree = {
+      displayName: 'Baz',
+      element,
+      children: [{
+        displayName: 'div',
+        children: [{
+          displayName: 'Foo',
+          element: <Foo />,
+          children: [{
+            displayName: 'Qux',
+            element: <Qux />,
+            children: [],
+          }],
+        }, {
+          displayName: 'Bar',
+          children: [{
+            displayName: 'h1',
+            children: [{
+              displayName: 'span',
+              children: [{
+                displayName: '#text',
+                element: 'Hi,',
+                text: 'Hi,',
+              }],
+            }, {
+              displayName: '#text',
+              text: 'Mom',
+              element: 'Mom',
+            }],
+          }],
+        }, {
+          displayName: 'a',
+          children: [{
+            displayName: '#text',
+            text: 'Click me.',
+            element: 'Click me.',
+          }],
+        }],
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('ignores null children', () => {
+    class Foo extends React.Component {
+      render() {
+        return null;
+      }
+    }
+    var element = <Foo />;
+    var tree = {
+      displayName: 'Foo',
+      children: [],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('ignores false children', () => {
+    class Foo extends React.Component {
+      render() {
+        return false;
+      }
+    }
+    var element = <Foo />;
+    var tree = {
+      displayName: 'Foo',
+      children: [],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('reports text nodes as children', () => {
+    var element = <div>{'1'}{2}</div>;
+    var tree = {
+      displayName: 'div',
+      element,
+      children: [{
+        displayName: '#text',
+        text: '1',
+      }, {
+        displayName: '#text',
+        text: '2',
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('reports a single text node as a child', () => {
+    var element = <div>{'1'}</div>;
+    var tree = {
+      displayName: 'div',
+      element,
+      children: [{
+        displayName: '#text',
+        text: '1',
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('reports a single number node as a child', () => {
+    var element = <div>{42}</div>;
+    var tree = {
+      displayName: 'div',
+      element,
+      children: [{
+        displayName: '#text',
+        text: '42',
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('reports a zero as a child', () => {
+    var element = <div>{0}</div>;
+    var tree = {
+      displayName: 'div',
+      element,
+      children: [{
+        displayName: '#text',
+        text: '0',
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('skips empty nodes for multiple children', () => {
+    function Foo() {
+      return <div />;
+    }
+    var element = (
+      <div>
+        {'hi'}
+        {false}
+        {42}
+        {null}
+        <Foo />
+      </div>
+    );
+    var tree = {
+      displayName: 'div',
+      element,
+      children: [{
+        displayName: '#text',
+        text: 'hi',
+        element: 'hi',
+      }, {
+        displayName: '#text',
+        text: '42',
+        element: 42,
+      }, {
+        displayName: 'Foo',
+        element: <Foo />,
+        children: [{
+          displayName: 'div',
+          element: <div />,
+          children: [],
+        }],
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('reports html content as no children', () => {
+    var element = <div dangerouslySetInnerHTML={{__html: 'Bye.'}} />;
+    var tree = {
+      displayName: 'div',
+      children: [],
+    };
+    assertTreeMatches([element, tree]);
+  });
+});
+
+describe('update', () => {
+  describe('host component', () => {
+    it('updates text of a single text child', () => {
+      var elementBefore = <div>Hi.</div>;
+      var treeBefore = {
+        displayName: 'div',
+        children: [{
+          displayName: '#text',
+          text: 'Hi.',
+        }],
+      };
+
+      var elementAfter = <div>Bye.</div>;
+      var treeAfter = {
+        displayName: 'div',
+        children: [{
+          displayName: '#text',
+          text: 'Bye.',
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from no children to a single text child', () => {
+      var elementBefore = <div />;
+      var treeBefore = {
+        displayName: 'div',
+        children: [],
+      };
+
+      var elementAfter = <div>Hi.</div>;
+      var treeAfter = {
+        displayName: 'div',
+        children: [{
+          displayName: '#text',
+          text: 'Hi.',
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a single text child to no children', () => {
+      var elementBefore = <div>Hi.</div>;
+      var treeBefore = {
+        displayName: 'div',
+        children: [{
+          displayName: '#text',
+          text: 'Hi.',
+        }],
+      };
+
+      var elementAfter = <div />;
+      var treeAfter = {
+        displayName: 'div',
+        children: [],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from html content to a single text child', () => {
+      var elementBefore = <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />;
+      var treeBefore = {
+        displayName: 'div',
+        children: [],
+      };
+
+      var elementAfter = <div>Hi.</div>;
+      var treeAfter = {
+        displayName: 'div',
+        children: [{
+          displayName: '#text',
+          text: 'Hi.',
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a single text child to html content', () => {
+      var elementBefore = <div>Hi.</div>;
+      var treeBefore = {
+        displayName: 'div',
+        children: [{
+          displayName: '#text',
+          text: 'Hi.',
+        }],
+      };
+
+      var elementAfter = <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />;
+      var treeAfter = {
+        displayName: 'div',
+        children: [],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from no children to multiple text children', () => {
+      var elementBefore = <div />;
+      var treeBefore = {
+        displayName: 'div',
+        children: [],
+      };
+
+      var elementAfter = <div>{'Hi.'}{'Bye.'}</div>;
+      var treeAfter = {
+        displayName: 'div',
+        children: [{
+          displayName: '#text',
+          text: 'Hi.',
+        }, {
+          displayName: '#text',
+          text: 'Bye.',
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from multiple text children to no children', () => {
+      var elementBefore = <div>{'Hi.'}{'Bye.'}</div>;
+      var treeBefore = {
+        displayName: 'div',
+        children: [{
+          displayName: '#text',
+          text: 'Hi.',
+        }, {
+          displayName: '#text',
+          text: 'Bye.',
+        }],
+      };
+
+      var elementAfter = <div />;
+      var treeAfter = {
+        displayName: 'div',
+        children: [],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from html content to multiple text children', () => {
+      var elementBefore = <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />;
+      var treeBefore = {
+        displayName: 'div',
+        children: [],
+      };
+
+      var elementAfter = <div>{'Hi.'}{'Bye.'}</div>;
+      var treeAfter = {
+        displayName: 'div',
+        children: [{
+          displayName: '#text',
+          text: 'Hi.',
+        }, {
+          displayName: '#text',
+          text: 'Bye.',
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from multiple text children to html content', () => {
+      var elementBefore = <div>{'Hi.'}{'Bye.'}</div>;
+      var treeBefore = {
+        displayName: 'div',
+        children: [{
+          displayName: '#text',
+          text: 'Hi.',
+        }, {
+          displayName: '#text',
+          text: 'Bye.',
+        }],
+      };
+
+      var elementAfter = <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />;
+      var treeAfter = {
+        displayName: 'div',
+        children: [],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from html content to no children', () => {
+      var elementBefore = <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />;
+      var treeBefore = {
+        displayName: 'div',
+        children: [],
+      };
+
+      var elementAfter = <div />;
+      var treeAfter = {
+        displayName: 'div',
+        children: [],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from no children to html content', () => {
+      var elementBefore = <div />;
+      var treeBefore = {
+        displayName: 'div',
+        children: [],
+      };
+
+      var elementAfter = <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />;
+      var treeAfter = {
+        displayName: 'div',
+        children: [],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from one text child to multiple text children', () => {
+      var elementBefore = <div>Hi.</div>;
+      var treeBefore = {
+        displayName: 'div',
+        children: [{
+          displayName: '#text',
+          text: 'Hi.',
+        }],
+      };
+
+      var elementAfter = <div>{'Hi.'}{'Bye.'}</div>;
+      var treeAfter = {
+        displayName: 'div',
+        children: [{
+          displayName: '#text',
+          text: 'Hi.',
+        }, {
+          displayName: '#text',
+          text: 'Bye.',
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from multiple text children to one text child', () => {
+      var elementBefore = <div>{'Hi.'}{'Bye.'}</div>;
+      var treeBefore = {
+        displayName: 'div',
+        children: [{
+          displayName: '#text',
+          text: 'Hi.',
+        }, {
+          displayName: '#text',
+          text: 'Bye.',
+        }],
+      };
+
+      var elementAfter = <div>Hi.</div>;
+      var treeAfter = {
+        displayName: 'div',
+        children: [{
+          displayName: '#text',
+          text: 'Hi.',
+        }],
+      };
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates text nodes when reordering', () => {
+      var elementBefore = <div>{'Hi.'}{'Bye.'}</div>;
+      var treeBefore = {
+        displayName: 'div',
+        children: [{
+          displayName: '#text',
+          text: 'Hi.',
+        }, {
+          displayName: '#text',
+          text: 'Bye.',
+        }],
+      };
+
+      var elementAfter = <div>{'Bye.'}{'Hi.'}</div>;
+      var treeAfter = {
+        displayName: 'div',
+        children: [{
+          displayName: '#text',
+          text: 'Bye.',
+        }, {
+          displayName: '#text',
+          text: 'Hi.',
+        }],
+      };
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates host nodes when reordering with keys', () => {
+      var elementBefore = (
+        <div>
+          <div key="a">Hi.</div>
+          <div key="b">Bye.</div>
+        </div>
+      );
+      var treeBefore = {
+        displayName: 'div',
+        children: [{
+          displayName: 'div',
+          children: [{
+            displayName: '#text',
+            text: 'Hi.',
+          }],
+        }, {
+          displayName: 'div',
+          children: [{
+            displayName: '#text',
+            text: 'Bye.',
+          }],
+        }],
+      };
+
+      var elementAfter = (
+        <div>
+          <div key="b">Bye.</div>
+          <div key="a">Hi.</div>
+        </div>
+      );
+      var treeAfter = {
+        displayName: 'div',
+        children: [{
+          displayName: 'div',
+          children: [{
+            displayName: '#text',
+            text: 'Bye.',
+          }],
+        }, {
+          displayName: 'div',
+          children: [{
+            displayName: '#text',
+            text: 'Hi.',
+          }],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates host nodes when reordering without keys', () => {
+      var elementBefore = (
+        <div>
+          <div>Hi.</div>
+          <div>Bye.</div>
+        </div>
+      );
+      var treeBefore = {
+        displayName: 'div',
+        children: [{
+          displayName: 'div',
+          children: [{
+            displayName: '#text',
+            text: 'Hi.',
+          }],
+        }, {
+          displayName: 'div',
+          children: [{
+            displayName: '#text',
+            text: 'Bye.',
+          }],
+        }],
+      };
+
+      var elementAfter = (
+        <div>
+          <div>Bye.</div>
+          <div>Hi.</div>
+        </div>
+      );
+      var treeAfter = {
+        displayName: 'div',
+        children: [{
+          displayName: 'div',
+          children: [{
+            displayName: '#text',
+            text: 'Bye.',
+          }],
+        }, {
+          displayName: 'div',
+          children: [{
+            displayName: '#text',
+            text: 'Hi.',
+          }],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates a single composite child of a different type', () => {
+      function Foo() {
+        return null;
+      }
+
+      function Bar() {
+        return null;
+      }
+
+      var elementBefore = <div><Foo /></div>;
+      var treeBefore = {
+        displayName: 'div',
+        children: [{
+          displayName: 'Foo',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <div><Bar /></div>;
+      var treeAfter = {
+        displayName: 'div',
+        children: [{
+          displayName: 'Bar',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates a single composite child of the same type', () => {
+      function Foo({ children }) {
+        return children;
+      }
+
+      var elementBefore = <div><Foo><div /></Foo></div>;
+      var treeBefore = {
+        displayName: 'div',
+        children: [{
+          displayName: 'Foo',
+          children: [{
+            displayName: 'div',
+            children: [],
+          }],
+        }],
+      };
+
+      var elementAfter = <div><Foo><span /></Foo></div>;
+      var treeAfter = {
+        displayName: 'div',
+        children: [{
+          displayName: 'Foo',
+          children: [{
+            displayName: 'span',
+            children: [],
+          }],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from no children to a single composite child', () => {
+      function Foo() {
+        return null;
+      }
+
+      var elementBefore = <div />;
+      var treeBefore = {
+        displayName: 'div',
+        children: [],
+      };
+
+      var elementAfter = <div><Foo /></div>;
+      var treeAfter = {
+        displayName: 'div',
+        children: [{
+          displayName: 'Foo',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a single composite child to no children', () => {
+      function Foo() {
+        return null;
+      }
+
+      var elementBefore = <div><Foo /></div>;
+      var treeBefore = {
+        displayName: 'div',
+        children: [{
+          displayName: 'Foo',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <div />;
+      var treeAfter = {
+        displayName: 'div',
+        children: [],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates mixed children', () => {
+      function Foo() {
+        return <div />;
+      }
+      var element1 = (
+        <div>
+          {'hi'}
+          {false}
+          {42}
+          {null}
+          <Foo />
+        </div>
+      );
+      var tree1 = {
+        displayName: 'div',
+        children: [{
+          displayName: '#text',
+          text: 'hi',
+        }, {
+          displayName: '#text',
+          text: '42',
+        }, {
+          displayName: 'Foo',
+          children: [{
+            displayName: 'div',
+            children: [],
+          }],
+        }],
+      };
+
+      var element2 = (
+        <div>
+          <Foo />
+          {false}
+          {'hi'}
+          {null}
+        </div>
+      );
+      var tree2 = {
+        displayName: 'div',
+        children: [{
+          displayName: 'Foo',
+          children: [{
+            displayName: 'div',
+            children: [],
+          }],
+        }, {
+          displayName: '#text',
+          text: 'hi',
+        }],
+      };
+
+      var element3 = (
+        <div>
+          <Foo />
+        </div>
+      );
+      var tree3 = {
+        displayName: 'div',
+        children: [{
+          displayName: 'Foo',
+          children: [{
+            displayName: 'div',
+            children: [],
+          }],
+        }],
+      };
+
+      assertTreeMatches([
+        [element1, tree1],
+        [element2, tree2],
+        [element3, tree3],
+      ]);
+    });
+  });
+
+  describe('functional component', () => {
+    it('updates with a host child', () => {
+      function Foo({ children }) {
+        return children;
+      }
+
+      var elementBefore = <Foo><div /></Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'div',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Foo><span /></Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'span',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from null to a host child', () => {
+      function Foo({ children }) {
+        return children;
+      }
+
+      var elementBefore = <Foo>{null}</Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [],
+      };
+
+      var elementAfter = <Foo><div /></Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'div',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a host child to null', () => {
+      function Foo({ children }) {
+        return children;
+      }
+
+      var elementBefore = <Foo><div /></Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'div',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Foo>{null}</Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a host child to a composite child', () => {
+      function Bar() {
+        return null;
+      }
+
+      function Foo({ children }) {
+        return children;
+      }
+
+      var elementBefore = <Foo><div /></Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'div',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Foo><Bar /></Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'Bar',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a composite child to a host child', () => {
+      function Bar() {
+        return null;
+      }
+
+      function Foo({ children }) {
+        return children;
+      }
+
+      var elementBefore = <Foo><Bar /></Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'Bar',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Foo><div /></Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'div',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from null to a composite child', () => {
+      function Bar() {
+        return null;
+      }
+
+      function Foo({ children }) {
+        return children;
+      }
+
+      var elementBefore = <Foo>{null}</Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [],
+      };
+
+      var elementAfter = <Foo><Bar /></Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'Bar',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a composite child to null', () => {
+      function Bar() {
+        return null;
+      }
+
+      function Foo({ children }) {
+        return children;
+      }
+
+      var elementBefore = <Foo><Bar /></Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'Bar',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Foo>{null}</Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+  });
+
+  describe('class component', () => {
+    it('updates with a host child', () => {
+      class Foo extends React.Component {
+        render() {
+          return this.props.children;
+        }
+      }
+
+      var elementBefore = <Foo><div /></Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'div',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Foo><span /></Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'span',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from null to a host child', () => {
+      class Foo extends React.Component {
+        render() {
+          return this.props.children;
+        }
+      }
+
+      var elementBefore = <Foo>{null}</Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [],
+      };
+
+      var elementAfter = <Foo><div /></Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'div',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a host child to null', () => {
+      class Foo extends React.Component {
+        render() {
+          return this.props.children;
+        }
+      }
+
+      var elementBefore = <Foo><div /></Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'div',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Foo>{null}</Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a host child to a composite child', () => {
+      class Bar extends React.Component {
+        render() {
+          return null;
+        }
+      }
+
+      class Foo extends React.Component {
+        render() {
+          return this.props.children;
+        }
+      }
+
+      var elementBefore = <Foo><div /></Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'div',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Foo><Bar /></Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'Bar',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a composite child to a host child', () => {
+      class Bar extends React.Component {
+        render() {
+          return null;
+        }
+      }
+
+      class Foo extends React.Component {
+        render() {
+          return this.props.children;
+        }
+      }
+
+      var elementBefore = <Foo><Bar /></Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'Bar',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Foo><div /></Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'div',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from null to a composite child', () => {
+      class Bar extends React.Component {
+        render() {
+          return null;
+        }
+      }
+
+      class Foo extends React.Component {
+        render() {
+          return this.props.children;
+        }
+      }
+
+      var elementBefore = <Foo>{null}</Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [],
+      };
+
+      var elementAfter = <Foo><Bar /></Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'Bar',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a composite child to null', () => {
+      class Bar extends React.Component {
+        render() {
+          return null;
+        }
+      }
+
+      class Foo extends React.Component {
+        render() {
+          return this.props.children;
+        }
+      }
+
+      var elementBefore = <Foo><Bar /></Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'Bar',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Foo>{null}</Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+  });
+});
+
+it('tracks owner correctly', () => {
+  class Foo extends React.Component {
+    render() {
+      return <Bar><h1>Hi.</h1></Bar>;
+    }
+  }
+  function Bar({children}) {
+    return <div>{children} Mom</div>;
+  }
+
+  // Note that owner is not calculated for text nodes
+  // because they are not created from real elements.
+  var element = <article><Foo /></article>;
+  var tree = {
+    displayName: 'article',
+    children: [{
+      displayName: 'Foo',
+      children: [{
+        displayName: 'Bar',
+        ownerDisplayName: 'Foo',
+        children: [{
+          displayName: 'div',
+          ownerDisplayName: 'Bar',
+          children: [{
+            displayName: 'h1',
+            ownerDisplayName: 'Foo',
+            children: [{
+              displayName: '#text',
+              text: 'Hi.',
+            }],
+          }, {
+            displayName: '#text',
+            text: ' Mom',
+          }],
+        }],
+      }],
+    }],
+  };
+  assertTreeMatches([element, tree]);
+});
+
+it('purges unmounted components automatically', () => {
+  var node = document.createElement('div');
+  var renderBar = true;
+  var fooInstance;
+  var barInstance;
+
+  class Foo extends React.Component {
+    render() {
+      fooInstance = ReactInstanceMap.get(this);
+      return renderBar ? <Bar /> : null;
+    }
+  }
+
+  class Bar extends React.Component {
+    render() {
+      barInstance = ReactInstanceMap.get(this);
+      return null;
+    }
+  }
+
+  ReactDOM.render(<Foo />, node);
+  ReactComponentTreeTestUtils.expectTree(barInstance._debugID, {
+    displayName: 'Bar',
+    parentDisplayName: 'Foo',
+    parentID: fooInstance._debugID,
+    children: [],
+  }, 'Foo');
+
+  renderBar = false;
+  ReactDOM.render(<Foo />, node);
+  ReactDOM.render(<Foo />, node);
+  ReactComponentTreeTestUtils.expectTree(barInstance._debugID, {
+    displayName: 'Unknown',
+    children: [],
+    parentID: null,
+  }, 'Foo');
+
+  ReactDOM.unmountComponentAtNode(node);
+  ReactComponentTreeTestUtils.expectTree(barInstance._debugID, {
+    displayName: 'Unknown',
+    children: [],
+    parentID: null,
+  }, 'Foo');
+});
+
+it('reports update counts', () => {
+  var node = document.createElement('div');
+
+  ReactDOM.render(<div className="a" />, node);
+  var divID = ReactComponentTreeHook.getRootIDs()[0];
+  expect(ReactComponentTreeHook.getUpdateCount(divID)).toEqual(0);
+
+  ReactDOM.render(<span className="a" />, node);
+  var spanID = ReactComponentTreeHook.getRootIDs()[0];
+  expect(ReactComponentTreeHook.getUpdateCount(divID)).toEqual(0);
+  expect(ReactComponentTreeHook.getUpdateCount(spanID)).toEqual(0);
+
+  ReactDOM.render(<span className="b" />, node);
+  expect(ReactComponentTreeHook.getUpdateCount(divID)).toEqual(0);
+  expect(ReactComponentTreeHook.getUpdateCount(spanID)).toEqual(1);
+
+  ReactDOM.render(<span className="c" />, node);
+  expect(ReactComponentTreeHook.getUpdateCount(divID)).toEqual(0);
+  expect(ReactComponentTreeHook.getUpdateCount(spanID)).toEqual(2);
+
+  ReactDOM.unmountComponentAtNode(node);
+  expect(ReactComponentTreeHook.getUpdateCount(divID)).toEqual(0);
+  expect(ReactComponentTreeHook.getUpdateCount(spanID)).toEqual(0);
+});
+
+it('does not report top-level wrapper as a root', () => {
+  var node = document.createElement('div');
+
+  ReactDOM.render(<div className="a" />, node);
+  expect(ReactComponentTreeTestUtils.getRootDisplayNames()).toEqual(['div']);
+
+  ReactDOM.render(<div className="b" />, node);
+  expect(ReactComponentTreeTestUtils.getRootDisplayNames()).toEqual(['div']);
+
+  ReactDOM.unmountComponentAtNode(node);
+  expect(ReactComponentTreeTestUtils.getRootDisplayNames()).toEqual([]);
+  expect(ReactComponentTreeTestUtils.getRegisteredDisplayNames()).toEqual([]);
+});
+
+it('registers inlined text nodes', () => {
+  var node = document.createElement('div');
+
+  ReactDOM.render(<div>hi</div>, node);
+  expect(ReactComponentTreeTestUtils.getRegisteredDisplayNames()).toEqual(['div', '#text']);
+
+  ReactDOM.unmountComponentAtNode(node);
+  expect(ReactComponentTreeTestUtils.getRegisteredDisplayNames()).toEqual([]);
+});
+
+describe('stack addenda', () => {
+  it('gets created', () => {
+    function getAddendum(element) {
+      var addendum = ReactComponentTreeHook.getCurrentStackAddendum(element);
+      return addendum.replace(/\(at .+?:\d+\)/g, '(at **)');
+    }
+
+    var Anon = React.createClass({displayName: null, render: () => null});
+    var Orange = React.createClass({render: () => null});
+
+    expect(getAddendum()).toBe(
+      ''
+    );
+    expect(getAddendum(<div />)).toBe(
+      '\n    in div (at **)'
+    );
+    expect(getAddendum(<Anon />)).toBe(
+      '\n    in Unknown (at **)'
+    );
+    expect(getAddendum(<Orange />)).toBe(
+      '\n    in Orange (at **)'
+    );
+    expect(getAddendum(React.createElement(Orange))).toBe(
+      '\n    in Orange'
+    );
+
+    var renders = 0;
+    var rOwnedByQ;
+
+    function Q() {
+      return (rOwnedByQ = React.createElement(R));
+    }
+    function R() {
+      return <div><S /></div>;
+    }
+    class S extends React.Component {
+      componentDidMount() {
+        // Check that the parent path is still fetched when only S itself is on
+        // the stack.
+        this.forceUpdate();
+      }
+      render() {
+        expect(getAddendum()).toBe(
+          '\n    in S (at **)' +
+          '\n    in div (at **)' +
+          '\n    in R (created by Q)' +
+          '\n    in Q (at **)'
+        );
+        expect(getAddendum(<span />)).toBe(
+          '\n    in span (at **)' +
+          '\n    in S (at **)' +
+          '\n    in div (at **)' +
+          '\n    in R (created by Q)' +
+          '\n    in Q (at **)'
+        );
+        expect(getAddendum(React.createElement('span'))).toBe(
+          '\n    in span (created by S)' +
+          '\n    in S (at **)' +
+          '\n    in div (at **)' +
+          '\n    in R (created by Q)' +
+          '\n    in Q (at **)'
+        );
+        renders++;
+        return null;
+      }
+    }
+    ReactDOM.render(<Q />, document.createElement('div'));
+    expect(renders).toBe(2);
+
+    // Make sure owner is fetched for the top element too.
+    expect(getAddendum(rOwnedByQ)).toBe(
+      '\n    in R (created by Q)'
+    );
+  });
+
+  it('can be retrieved by ID', () => {
+    function getAddendum(id) {
+      var addendum = ReactComponentTreeHook.getStackAddendumByID(id);
+      return addendum.replace(/\(at .+?:\d+\)/g, '(at **)');
+    }
+
+    class Q extends React.Component {
+      render() {
+        return null;
+      }
+    }
+
+    var q = ReactDOM.render(<Q />, document.createElement('div'));
+    expect(getAddendum(ReactInstanceMap.get(q)._debugID)).toBe(
+      '\n    in Q (at **)'
+    );
+
+    spyOn(console, 'error');
+    getAddendum(-17);
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toBe(
+      'Warning: ReactComponentTreeHook: Missing React element for ' +
+      'debugID -17 when building stack'
+    );
+  });
+
+  it('is created during mounting', () => {
+    // https://github.com/facebook/react/issues/7187
+    var el = document.createElement('div');
+    var portalEl = document.createElement('div');
+    class Foo extends React.Component {
+      componentWillMount() {
+        ReactDOM.render(<div />, portalEl);
+      }
+      render() {
+        return <div><div /></div>;
+      }
+    }
+    ReactDOM.render(<Foo />, el);
+  });
+
+  it('is created when calling renderToString during render', () => {
+    // https://github.com/facebook/react/issues/7190
+    var el = document.createElement('div');
+    class Foo extends React.Component {
+      render() {
+        return (
+          <div>
+            <div>
+              {ReactDOMServer.renderToString(<div />)}
+            </div>
+          </div>
+        );
+      }
+    }
+    ReactDOM.render(<Foo />, el);
+  });
+});
+
+describe('in environment without Map, Set and Array.from', () => {
+  var realMap;
+  var realSet;
+  var realArrayFrom;
 
   beforeEach(() => {
+    realMap = global.Map;
+    realSet = global.Set;
+    realArrayFrom = Array.from;
+
+    global.Map = undefined;
+    global.Set = undefined;
+    Array.from = undefined;
+
     jest.resetModuleRegistry();
 
     React = require('React');
@@ -30,1950 +1893,85 @@ describe('ReactComponentTreeHook', () => {
     ReactComponentTreeTestUtils = require('ReactComponentTreeTestUtils');
   });
 
-  function assertTreeMatches(pairs) {
-    if (!Array.isArray(pairs[0])) {
-      pairs = [pairs];
-    }
+  afterEach(() => {
+    global.Map = realMap;
+    global.Set = realSet;
+    Array.from = realArrayFrom;
+  });
 
-    var node = document.createElement('div');
-    var currentElement;
-    var rootInstance;
-
-    class Wrapper extends React.Component {
+  it('works', () => {
+    class Qux extends React.Component {
       render() {
-        rootInstance = ReactInstanceMap.get(this);
-        return currentElement;
+        return null;
       }
     }
 
-    function expectWrapperTreeToEqual(expectedTree, andStayMounted) {
-      ReactComponentTreeTestUtils.expectTree(rootInstance._debugID, {
-        displayName: 'Wrapper',
-        children: expectedTree ? [expectedTree] : [],
-      });
-      var rootDisplayNames = ReactComponentTreeTestUtils.getRootDisplayNames();
-      var registeredDisplayNames = ReactComponentTreeTestUtils.getRegisteredDisplayNames();
-      if (!expectedTree) {
-        expect(rootDisplayNames).toEqual([]);
-        expect(registeredDisplayNames).toEqual([]);
-      } else if (andStayMounted) {
-        expect(rootDisplayNames).toContain('Wrapper');
-        expect(registeredDisplayNames).toContain('Wrapper');
+    function Foo() {
+      return {
+        render() {
+          return <Qux />;
+        },
+      };
+    }
+    function Bar({children}) {
+      return <h1>{children}</h1>;
+    }
+    class Baz extends React.Component {
+      render() {
+        return (
+          <div>
+            <Foo />
+            <Bar>
+              <span>Hi,</span>
+              Mom
+            </Bar>
+            <a href="#">Click me.</a>
+          </div>
+        );
       }
     }
 
-    // Mount once, render updates, then unmount.
-    // Ensure the tree is correct on every step.
-    pairs.forEach(([element, expectedTree]) => {
-      currentElement = element;
-
-      // Mount a new tree or update the existing tree.
-      ReactDOM.render(<Wrapper />, node);
-      expectWrapperTreeToEqual(expectedTree, true);
-
-      // Purging should have no effect
-      // on the tree we expect to see.
-      ReactComponentTreeHook.purgeUnmountedComponents();
-      expectWrapperTreeToEqual(expectedTree, true);
-    });
-
-    // Unmounting the root node should purge
-    // the whole subtree automatically.
-    ReactDOM.unmountComponentAtNode(node);
-    expectWrapperTreeToEqual(null);
-
-    // Server render every pair.
-    // Ensure the tree is correct on every step.
-    pairs.forEach(([element, expectedTree]) => {
-      currentElement = element;
-
-      // Rendering to string should not produce any entries
-      // because ReactDebugTool purges it when the flush ends.
-      ReactDOMServer.renderToString(<Wrapper />);
-      expectWrapperTreeToEqual(null);
-
-      // To test it, we tell the hook to ignore next purge
-      // so the cleanup request by ReactDebugTool is ignored.
-      // This lets us make assertions on the actual tree.
-      ReactComponentTreeHook._preventPurging = true;
-      ReactDOMServer.renderToString(<Wrapper />);
-      ReactComponentTreeHook._preventPurging = false;
-      expectWrapperTreeToEqual(expectedTree);
-
-      // Purge manually since we skipped the automatic purge.
-      ReactComponentTreeHook.purgeUnmountedComponents();
-      expectWrapperTreeToEqual(null);
-    });
-  }
-
-  describe('mount', () => {
-    it('uses displayName or Unknown for classic components', () => {
-      class Foo extends React.Component {
-        render() {
-          return null;
-        }
-      }
-
-      Foo.displayName = 'Bar';
-
-      class Baz extends React.Component {
-        render() {
-          return null;
-        }
-      }
-
-      class Qux extends React.Component {
-        render() {
-          return null;
-        }
-      }
-
-      delete Qux.displayName;
-
-      var element = <div><Foo /><Baz /><Qux /></div>;
-      var tree = {
+    var element = <Baz />;
+    var tree = {
+      displayName: 'Baz',
+      element,
+      children: [{
         displayName: 'div',
         children: [{
-          displayName: 'Bar',
-          children: [],
-        }, {
-          displayName: 'Baz',
-          children: [],
-        }, {
-          displayName: 'Unknown',
-          children: [],
-        }],
-      };
-      assertTreeMatches([element, tree]);
-    });
-
-    it('uses displayName, name, or ReactComponent for modern components', () => {
-      class Foo extends React.Component {
-        render() {
-          return null;
-        }
-      }
-      Foo.displayName = 'Bar';
-      class Baz extends React.Component {
-        render() {
-          return null;
-        }
-      }
-      class Qux extends React.Component {
-        render() {
-          return null;
-        }
-      }
-      delete Qux.name;
-
-      var element = <div><Foo /><Baz /><Qux /></div>;
-      var tree = {
-        displayName: 'div',
-        element,
-        children: [{
-          displayName: 'Bar',
-          children: [],
-        }, {
-          displayName: 'Baz',
-          children: [],
-        }, {
-          // Note: Ideally fallback name should be consistent (e.g. "Unknown")
-          displayName: 'ReactComponent',
-          children: [],
-        }],
-      };
-      assertTreeMatches([element, tree]);
-    });
-
-    it('uses displayName, name, or Object for factory components', () => {
-      function Foo() {
-        return {
-          render() {
-            return null;
-          },
-        };
-      }
-      Foo.displayName = 'Bar';
-      function Baz() {
-        return {
-          render() {
-            return null;
-          },
-        };
-      }
-      function Qux() {
-        return {
-          render() {
-            return null;
-          },
-        };
-      }
-      delete Qux.name;
-
-      var element = <div><Foo /><Baz /><Qux /></div>;
-      var tree = {
-        displayName: 'div',
-        element,
-        children: [{
-          displayName: 'Bar',
-          children: [],
-        }, {
-          displayName: 'Baz',
-          children: [],
-        }, {
-          displayName: 'Unknown',
-          children: [],
-        }],
-      };
-      assertTreeMatches([element, tree]);
-    });
-
-    it('uses displayName, name, or StatelessComponent for functional components', () => {
-      function Foo() {
-        return null;
-      }
-      Foo.displayName = 'Bar';
-      function Baz() {
-        return null;
-      }
-      function Qux() {
-        return null;
-      }
-      delete Qux.name;
-
-      var element = <div><Foo /><Baz /><Qux /></div>;
-      var tree = {
-        displayName: 'div',
-        element,
-        children: [{
-          displayName: 'Bar',
-          children: [],
-        }, {
-          displayName: 'Baz',
-          children: [],
-        }, {
-          displayName: 'Unknown',
-          children: [],
-        }],
-      };
-      assertTreeMatches([element, tree]);
-    });
-
-    it('reports a host tree correctly', () => {
-      var element = (
-        <div>
-          <p>
-            <span>
-              Hi!
-            </span>
-            Wow.
-          </p>
-          <hr />
-        </div>
-      );
-      var tree = {
-        displayName: 'div',
-        children: [{
-          displayName: 'p',
-          children: [{
-            displayName: 'span',
-            children: [{
-              displayName: '#text',
-              text: 'Hi!',
-            }],
-          }, {
-            displayName: '#text',
-            text: 'Wow.',
-          }],
-        }, {
-          displayName: 'hr',
-          element: <hr />,
-          children: [],
-        }],
-      };
-      assertTreeMatches([element, tree]);
-    });
-
-    it('reports a simple tree with composites correctly', () => {
-      class Foo extends React.Component {
-        render() {
-          return <div />;
-        }
-      }
-
-      var element = <Foo />;
-      var tree = {
-        displayName: 'Foo',
-        element,
-        children: [{
-          displayName: 'div',
-          element: <div />,
-          children: [],
-        }],
-      };
-      assertTreeMatches([element, tree]);
-    });
-
-    it('reports a tree with composites correctly', () => {
-      class Qux extends React.Component {
-        render() {
-          return null;
-        }
-      }
-
-      function Foo() {
-        return {
-          render() {
-            return <Qux />;
-          },
-        };
-      }
-      function Bar({children}) {
-        return <h1>{children}</h1>;
-      }
-      class Baz extends React.Component {
-        render() {
-          return (
-            <div>
-              <Foo />
-              <Bar>
-                <span>Hi,</span>
-                Mom
-              </Bar>
-              <a href="#">Click me.</a>
-            </div>
-          );
-        }
-      }
-
-      var element = <Baz />;
-      var tree = {
-        displayName: 'Baz',
-        element,
-        children: [{
-          displayName: 'div',
-          children: [{
-            displayName: 'Foo',
-            element: <Foo />,
-            children: [{
-              displayName: 'Qux',
-              element: <Qux />,
-              children: [],
-            }],
-          }, {
-            displayName: 'Bar',
-            children: [{
-              displayName: 'h1',
-              children: [{
-                displayName: 'span',
-                children: [{
-                  displayName: '#text',
-                  element: 'Hi,',
-                  text: 'Hi,',
-                }],
-              }, {
-                displayName: '#text',
-                text: 'Mom',
-                element: 'Mom',
-              }],
-            }],
-          }, {
-            displayName: 'a',
-            children: [{
-              displayName: '#text',
-              text: 'Click me.',
-              element: 'Click me.',
-            }],
-          }],
-        }],
-      };
-      assertTreeMatches([element, tree]);
-    });
-
-    it('ignores null children', () => {
-      class Foo extends React.Component {
-        render() {
-          return null;
-        }
-      }
-      var element = <Foo />;
-      var tree = {
-        displayName: 'Foo',
-        children: [],
-      };
-      assertTreeMatches([element, tree]);
-    });
-
-    it('ignores false children', () => {
-      class Foo extends React.Component {
-        render() {
-          return false;
-        }
-      }
-      var element = <Foo />;
-      var tree = {
-        displayName: 'Foo',
-        children: [],
-      };
-      assertTreeMatches([element, tree]);
-    });
-
-    it('reports text nodes as children', () => {
-      var element = <div>{'1'}{2}</div>;
-      var tree = {
-        displayName: 'div',
-        element,
-        children: [{
-          displayName: '#text',
-          text: '1',
-        }, {
-          displayName: '#text',
-          text: '2',
-        }],
-      };
-      assertTreeMatches([element, tree]);
-    });
-
-    it('reports a single text node as a child', () => {
-      var element = <div>{'1'}</div>;
-      var tree = {
-        displayName: 'div',
-        element,
-        children: [{
-          displayName: '#text',
-          text: '1',
-        }],
-      };
-      assertTreeMatches([element, tree]);
-    });
-
-    it('reports a single number node as a child', () => {
-      var element = <div>{42}</div>;
-      var tree = {
-        displayName: 'div',
-        element,
-        children: [{
-          displayName: '#text',
-          text: '42',
-        }],
-      };
-      assertTreeMatches([element, tree]);
-    });
-
-    it('reports a zero as a child', () => {
-      var element = <div>{0}</div>;
-      var tree = {
-        displayName: 'div',
-        element,
-        children: [{
-          displayName: '#text',
-          text: '0',
-        }],
-      };
-      assertTreeMatches([element, tree]);
-    });
-
-    it('skips empty nodes for multiple children', () => {
-      function Foo() {
-        return <div />;
-      }
-      var element = (
-        <div>
-          {'hi'}
-          {false}
-          {42}
-          {null}
-          <Foo />
-        </div>
-      );
-      var tree = {
-        displayName: 'div',
-        element,
-        children: [{
-          displayName: '#text',
-          text: 'hi',
-          element: 'hi',
-        }, {
-          displayName: '#text',
-          text: '42',
-          element: 42,
-        }, {
           displayName: 'Foo',
           element: <Foo />,
           children: [{
-            displayName: 'div',
-            element: <div />,
+            displayName: 'Qux',
+            element: <Qux />,
             children: [],
           }],
-        }],
-      };
-      assertTreeMatches([element, tree]);
-    });
-
-    it('reports html content as no children', () => {
-      var element = <div dangerouslySetInnerHTML={{__html: 'Bye.'}} />;
-      var tree = {
-        displayName: 'div',
-        children: [],
-      };
-      assertTreeMatches([element, tree]);
-    });
-  });
-
-  describe('update', () => {
-    describe('host component', () => {
-      it('updates text of a single text child', () => {
-        var elementBefore = <div>Hi.</div>;
-        var treeBefore = {
-          displayName: 'div',
+        }, {
+          displayName: 'Bar',
           children: [{
-            displayName: '#text',
-            text: 'Hi.',
-          }],
-        };
-
-        var elementAfter = <div>Bye.</div>;
-        var treeAfter = {
-          displayName: 'div',
-          children: [{
-            displayName: '#text',
-            text: 'Bye.',
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from no children to a single text child', () => {
-        var elementBefore = <div />;
-        var treeBefore = {
-          displayName: 'div',
-          children: [],
-        };
-
-        var elementAfter = <div>Hi.</div>;
-        var treeAfter = {
-          displayName: 'div',
-          children: [{
-            displayName: '#text',
-            text: 'Hi.',
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a single text child to no children', () => {
-        var elementBefore = <div>Hi.</div>;
-        var treeBefore = {
-          displayName: 'div',
-          children: [{
-            displayName: '#text',
-            text: 'Hi.',
-          }],
-        };
-
-        var elementAfter = <div />;
-        var treeAfter = {
-          displayName: 'div',
-          children: [],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from html content to a single text child', () => {
-        var elementBefore = <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />;
-        var treeBefore = {
-          displayName: 'div',
-          children: [],
-        };
-
-        var elementAfter = <div>Hi.</div>;
-        var treeAfter = {
-          displayName: 'div',
-          children: [{
-            displayName: '#text',
-            text: 'Hi.',
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a single text child to html content', () => {
-        var elementBefore = <div>Hi.</div>;
-        var treeBefore = {
-          displayName: 'div',
-          children: [{
-            displayName: '#text',
-            text: 'Hi.',
-          }],
-        };
-
-        var elementAfter = <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />;
-        var treeAfter = {
-          displayName: 'div',
-          children: [],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from no children to multiple text children', () => {
-        var elementBefore = <div />;
-        var treeBefore = {
-          displayName: 'div',
-          children: [],
-        };
-
-        var elementAfter = <div>{'Hi.'}{'Bye.'}</div>;
-        var treeAfter = {
-          displayName: 'div',
-          children: [{
-            displayName: '#text',
-            text: 'Hi.',
-          }, {
-            displayName: '#text',
-            text: 'Bye.',
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from multiple text children to no children', () => {
-        var elementBefore = <div>{'Hi.'}{'Bye.'}</div>;
-        var treeBefore = {
-          displayName: 'div',
-          children: [{
-            displayName: '#text',
-            text: 'Hi.',
-          }, {
-            displayName: '#text',
-            text: 'Bye.',
-          }],
-        };
-
-        var elementAfter = <div />;
-        var treeAfter = {
-          displayName: 'div',
-          children: [],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from html content to multiple text children', () => {
-        var elementBefore = <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />;
-        var treeBefore = {
-          displayName: 'div',
-          children: [],
-        };
-
-        var elementAfter = <div>{'Hi.'}{'Bye.'}</div>;
-        var treeAfter = {
-          displayName: 'div',
-          children: [{
-            displayName: '#text',
-            text: 'Hi.',
-          }, {
-            displayName: '#text',
-            text: 'Bye.',
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from multiple text children to html content', () => {
-        var elementBefore = <div>{'Hi.'}{'Bye.'}</div>;
-        var treeBefore = {
-          displayName: 'div',
-          children: [{
-            displayName: '#text',
-            text: 'Hi.',
-          }, {
-            displayName: '#text',
-            text: 'Bye.',
-          }],
-        };
-
-        var elementAfter = <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />;
-        var treeAfter = {
-          displayName: 'div',
-          children: [],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from html content to no children', () => {
-        var elementBefore = <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />;
-        var treeBefore = {
-          displayName: 'div',
-          children: [],
-        };
-
-        var elementAfter = <div />;
-        var treeAfter = {
-          displayName: 'div',
-          children: [],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from no children to html content', () => {
-        var elementBefore = <div />;
-        var treeBefore = {
-          displayName: 'div',
-          children: [],
-        };
-
-        var elementAfter = <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />;
-        var treeAfter = {
-          displayName: 'div',
-          children: [],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from one text child to multiple text children', () => {
-        var elementBefore = <div>Hi.</div>;
-        var treeBefore = {
-          displayName: 'div',
-          children: [{
-            displayName: '#text',
-            text: 'Hi.',
-          }],
-        };
-
-        var elementAfter = <div>{'Hi.'}{'Bye.'}</div>;
-        var treeAfter = {
-          displayName: 'div',
-          children: [{
-            displayName: '#text',
-            text: 'Hi.',
-          }, {
-            displayName: '#text',
-            text: 'Bye.',
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from multiple text children to one text child', () => {
-        var elementBefore = <div>{'Hi.'}{'Bye.'}</div>;
-        var treeBefore = {
-          displayName: 'div',
-          children: [{
-            displayName: '#text',
-            text: 'Hi.',
-          }, {
-            displayName: '#text',
-            text: 'Bye.',
-          }],
-        };
-
-        var elementAfter = <div>Hi.</div>;
-        var treeAfter = {
-          displayName: 'div',
-          children: [{
-            displayName: '#text',
-            text: 'Hi.',
-          }],
-        };
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates text nodes when reordering', () => {
-        var elementBefore = <div>{'Hi.'}{'Bye.'}</div>;
-        var treeBefore = {
-          displayName: 'div',
-          children: [{
-            displayName: '#text',
-            text: 'Hi.',
-          }, {
-            displayName: '#text',
-            text: 'Bye.',
-          }],
-        };
-
-        var elementAfter = <div>{'Bye.'}{'Hi.'}</div>;
-        var treeAfter = {
-          displayName: 'div',
-          children: [{
-            displayName: '#text',
-            text: 'Bye.',
-          }, {
-            displayName: '#text',
-            text: 'Hi.',
-          }],
-        };
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates host nodes when reordering with keys', () => {
-        var elementBefore = (
-          <div>
-            <div key="a">Hi.</div>
-            <div key="b">Bye.</div>
-          </div>
-        );
-        var treeBefore = {
-          displayName: 'div',
-          children: [{
-            displayName: 'div',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }],
-          }, {
-            displayName: 'div',
-            children: [{
-              displayName: '#text',
-              text: 'Bye.',
-            }],
-          }],
-        };
-
-        var elementAfter = (
-          <div>
-            <div key="b">Bye.</div>
-            <div key="a">Hi.</div>
-          </div>
-        );
-        var treeAfter = {
-          displayName: 'div',
-          children: [{
-            displayName: 'div',
-            children: [{
-              displayName: '#text',
-              text: 'Bye.',
-            }],
-          }, {
-            displayName: 'div',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates host nodes when reordering without keys', () => {
-        var elementBefore = (
-          <div>
-            <div>Hi.</div>
-            <div>Bye.</div>
-          </div>
-        );
-        var treeBefore = {
-          displayName: 'div',
-          children: [{
-            displayName: 'div',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }],
-          }, {
-            displayName: 'div',
-            children: [{
-              displayName: '#text',
-              text: 'Bye.',
-            }],
-          }],
-        };
-
-        var elementAfter = (
-          <div>
-            <div>Bye.</div>
-            <div>Hi.</div>
-          </div>
-        );
-        var treeAfter = {
-          displayName: 'div',
-          children: [{
-            displayName: 'div',
-            children: [{
-              displayName: '#text',
-              text: 'Bye.',
-            }],
-          }, {
-            displayName: 'div',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates a single composite child of a different type', () => {
-        function Foo() {
-          return null;
-        }
-
-        function Bar() {
-          return null;
-        }
-
-        var elementBefore = <div><Foo /></div>;
-        var treeBefore = {
-          displayName: 'div',
-          children: [{
-            displayName: 'Foo',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <div><Bar /></div>;
-        var treeAfter = {
-          displayName: 'div',
-          children: [{
-            displayName: 'Bar',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates a single composite child of the same type', () => {
-        function Foo({ children }) {
-          return children;
-        }
-
-        var elementBefore = <div><Foo><div /></Foo></div>;
-        var treeBefore = {
-          displayName: 'div',
-          children: [{
-            displayName: 'Foo',
-            children: [{
-              displayName: 'div',
-              children: [],
-            }],
-          }],
-        };
-
-        var elementAfter = <div><Foo><span /></Foo></div>;
-        var treeAfter = {
-          displayName: 'div',
-          children: [{
-            displayName: 'Foo',
+            displayName: 'h1',
             children: [{
               displayName: 'span',
-              children: [],
-            }],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from no children to a single composite child', () => {
-        function Foo() {
-          return null;
-        }
-
-        var elementBefore = <div />;
-        var treeBefore = {
-          displayName: 'div',
-          children: [],
-        };
-
-        var elementAfter = <div><Foo /></div>;
-        var treeAfter = {
-          displayName: 'div',
-          children: [{
-            displayName: 'Foo',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a single composite child to no children', () => {
-        function Foo() {
-          return null;
-        }
-
-        var elementBefore = <div><Foo /></div>;
-        var treeBefore = {
-          displayName: 'div',
-          children: [{
-            displayName: 'Foo',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <div />;
-        var treeAfter = {
-          displayName: 'div',
-          children: [],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates mixed children', () => {
-        function Foo() {
-          return <div />;
-        }
-        var element1 = (
-          <div>
-            {'hi'}
-            {false}
-            {42}
-            {null}
-            <Foo />
-          </div>
-        );
-        var tree1 = {
-          displayName: 'div',
-          children: [{
-            displayName: '#text',
-            text: 'hi',
-          }, {
-            displayName: '#text',
-            text: '42',
-          }, {
-            displayName: 'Foo',
-            children: [{
-              displayName: 'div',
-              children: [],
-            }],
-          }],
-        };
-
-        var element2 = (
-          <div>
-            <Foo />
-            {false}
-            {'hi'}
-            {null}
-          </div>
-        );
-        var tree2 = {
-          displayName: 'div',
-          children: [{
-            displayName: 'Foo',
-            children: [{
-              displayName: 'div',
-              children: [],
-            }],
-          }, {
-            displayName: '#text',
-            text: 'hi',
-          }],
-        };
-
-        var element3 = (
-          <div>
-            <Foo />
-          </div>
-        );
-        var tree3 = {
-          displayName: 'div',
-          children: [{
-            displayName: 'Foo',
-            children: [{
-              displayName: 'div',
-              children: [],
-            }],
-          }],
-        };
-
-        assertTreeMatches([
-          [element1, tree1],
-          [element2, tree2],
-          [element3, tree3],
-        ]);
-      });
-    });
-
-    describe('functional component', () => {
-      it('updates with a host child', () => {
-        function Foo({ children }) {
-          return children;
-        }
-
-        var elementBefore = <Foo><div /></Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'div',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Foo><span /></Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'span',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from null to a host child', () => {
-        function Foo({ children }) {
-          return children;
-        }
-
-        var elementBefore = <Foo>{null}</Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [],
-        };
-
-        var elementAfter = <Foo><div /></Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'div',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a host child to null', () => {
-        function Foo({ children }) {
-          return children;
-        }
-
-        var elementBefore = <Foo><div /></Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'div',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Foo>{null}</Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a host child to a composite child', () => {
-        function Bar() {
-          return null;
-        }
-
-        function Foo({ children }) {
-          return children;
-        }
-
-        var elementBefore = <Foo><div /></Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'div',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Foo><Bar /></Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'Bar',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a composite child to a host child', () => {
-        function Bar() {
-          return null;
-        }
-
-        function Foo({ children }) {
-          return children;
-        }
-
-        var elementBefore = <Foo><Bar /></Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'Bar',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Foo><div /></Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'div',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from null to a composite child', () => {
-        function Bar() {
-          return null;
-        }
-
-        function Foo({ children }) {
-          return children;
-        }
-
-        var elementBefore = <Foo>{null}</Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [],
-        };
-
-        var elementAfter = <Foo><Bar /></Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'Bar',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a composite child to null', () => {
-        function Bar() {
-          return null;
-        }
-
-        function Foo({ children }) {
-          return children;
-        }
-
-        var elementBefore = <Foo><Bar /></Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'Bar',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Foo>{null}</Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-    });
-
-    describe('class component', () => {
-      it('updates with a host child', () => {
-        class Foo extends React.Component {
-          render() {
-            return this.props.children;
-          }
-        }
-
-        var elementBefore = <Foo><div /></Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'div',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Foo><span /></Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'span',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from null to a host child', () => {
-        class Foo extends React.Component {
-          render() {
-            return this.props.children;
-          }
-        }
-
-        var elementBefore = <Foo>{null}</Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [],
-        };
-
-        var elementAfter = <Foo><div /></Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'div',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a host child to null', () => {
-        class Foo extends React.Component {
-          render() {
-            return this.props.children;
-          }
-        }
-
-        var elementBefore = <Foo><div /></Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'div',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Foo>{null}</Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a host child to a composite child', () => {
-        class Bar extends React.Component {
-          render() {
-            return null;
-          }
-        }
-
-        class Foo extends React.Component {
-          render() {
-            return this.props.children;
-          }
-        }
-
-        var elementBefore = <Foo><div /></Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'div',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Foo><Bar /></Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'Bar',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a composite child to a host child', () => {
-        class Bar extends React.Component {
-          render() {
-            return null;
-          }
-        }
-
-        class Foo extends React.Component {
-          render() {
-            return this.props.children;
-          }
-        }
-
-        var elementBefore = <Foo><Bar /></Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'Bar',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Foo><div /></Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'div',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from null to a composite child', () => {
-        class Bar extends React.Component {
-          render() {
-            return null;
-          }
-        }
-
-        class Foo extends React.Component {
-          render() {
-            return this.props.children;
-          }
-        }
-
-        var elementBefore = <Foo>{null}</Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [],
-        };
-
-        var elementAfter = <Foo><Bar /></Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'Bar',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a composite child to null', () => {
-        class Bar extends React.Component {
-          render() {
-            return null;
-          }
-        }
-
-        class Foo extends React.Component {
-          render() {
-            return this.props.children;
-          }
-        }
-
-        var elementBefore = <Foo><Bar /></Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'Bar',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Foo>{null}</Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-    });
-  });
-
-  it('tracks owner correctly', () => {
-    class Foo extends React.Component {
-      render() {
-        return <Bar><h1>Hi.</h1></Bar>;
-      }
-    }
-    function Bar({children}) {
-      return <div>{children} Mom</div>;
-    }
-
-    // Note that owner is not calculated for text nodes
-    // because they are not created from real elements.
-    var element = <article><Foo /></article>;
-    var tree = {
-      displayName: 'article',
-      children: [{
-        displayName: 'Foo',
-        children: [{
-          displayName: 'Bar',
-          ownerDisplayName: 'Foo',
-          children: [{
-            displayName: 'div',
-            ownerDisplayName: 'Bar',
-            children: [{
-              displayName: 'h1',
-              ownerDisplayName: 'Foo',
               children: [{
                 displayName: '#text',
-                text: 'Hi.',
+                element: 'Hi,',
+                text: 'Hi,',
               }],
             }, {
               displayName: '#text',
-              text: ' Mom',
+              text: 'Mom',
+              element: 'Mom',
             }],
+          }],
+        }, {
+          displayName: 'a',
+          children: [{
+            displayName: '#text',
+            text: 'Click me.',
+            element: 'Click me.',
           }],
         }],
       }],
     };
     assertTreeMatches([element, tree]);
-  });
-
-  it('purges unmounted components automatically', () => {
-    var node = document.createElement('div');
-    var renderBar = true;
-    var fooInstance;
-    var barInstance;
-
-    class Foo extends React.Component {
-      render() {
-        fooInstance = ReactInstanceMap.get(this);
-        return renderBar ? <Bar /> : null;
-      }
-    }
-
-    class Bar extends React.Component {
-      render() {
-        barInstance = ReactInstanceMap.get(this);
-        return null;
-      }
-    }
-
-    ReactDOM.render(<Foo />, node);
-    ReactComponentTreeTestUtils.expectTree(barInstance._debugID, {
-      displayName: 'Bar',
-      parentDisplayName: 'Foo',
-      parentID: fooInstance._debugID,
-      children: [],
-    }, 'Foo');
-
-    renderBar = false;
-    ReactDOM.render(<Foo />, node);
-    ReactDOM.render(<Foo />, node);
-    ReactComponentTreeTestUtils.expectTree(barInstance._debugID, {
-      displayName: 'Unknown',
-      children: [],
-      parentID: null,
-    }, 'Foo');
-
-    ReactDOM.unmountComponentAtNode(node);
-    ReactComponentTreeTestUtils.expectTree(barInstance._debugID, {
-      displayName: 'Unknown',
-      children: [],
-      parentID: null,
-    }, 'Foo');
-  });
-
-  it('reports update counts', () => {
-    var node = document.createElement('div');
-
-    ReactDOM.render(<div className="a" />, node);
-    var divID = ReactComponentTreeHook.getRootIDs()[0];
-    expect(ReactComponentTreeHook.getUpdateCount(divID)).toEqual(0);
-
-    ReactDOM.render(<span className="a" />, node);
-    var spanID = ReactComponentTreeHook.getRootIDs()[0];
-    expect(ReactComponentTreeHook.getUpdateCount(divID)).toEqual(0);
-    expect(ReactComponentTreeHook.getUpdateCount(spanID)).toEqual(0);
-
-    ReactDOM.render(<span className="b" />, node);
-    expect(ReactComponentTreeHook.getUpdateCount(divID)).toEqual(0);
-    expect(ReactComponentTreeHook.getUpdateCount(spanID)).toEqual(1);
-
-    ReactDOM.render(<span className="c" />, node);
-    expect(ReactComponentTreeHook.getUpdateCount(divID)).toEqual(0);
-    expect(ReactComponentTreeHook.getUpdateCount(spanID)).toEqual(2);
-
-    ReactDOM.unmountComponentAtNode(node);
-    expect(ReactComponentTreeHook.getUpdateCount(divID)).toEqual(0);
-    expect(ReactComponentTreeHook.getUpdateCount(spanID)).toEqual(0);
-  });
-
-  it('does not report top-level wrapper as a root', () => {
-    var node = document.createElement('div');
-
-    ReactDOM.render(<div className="a" />, node);
-    expect(ReactComponentTreeTestUtils.getRootDisplayNames()).toEqual(['div']);
-
-    ReactDOM.render(<div className="b" />, node);
-    expect(ReactComponentTreeTestUtils.getRootDisplayNames()).toEqual(['div']);
-
-    ReactDOM.unmountComponentAtNode(node);
-    expect(ReactComponentTreeTestUtils.getRootDisplayNames()).toEqual([]);
-    expect(ReactComponentTreeTestUtils.getRegisteredDisplayNames()).toEqual([]);
-  });
-
-  it('registers inlined text nodes', () => {
-    var node = document.createElement('div');
-
-    ReactDOM.render(<div>hi</div>, node);
-    expect(ReactComponentTreeTestUtils.getRegisteredDisplayNames()).toEqual(['div', '#text']);
-
-    ReactDOM.unmountComponentAtNode(node);
-    expect(ReactComponentTreeTestUtils.getRegisteredDisplayNames()).toEqual([]);
-  });
-
-  describe('stack addenda', () => {
-    it('gets created', () => {
-      function getAddendum(element) {
-        var addendum = ReactComponentTreeHook.getCurrentStackAddendum(element);
-        return addendum.replace(/\(at .+?:\d+\)/g, '(at **)');
-      }
-
-      var Anon = React.createClass({displayName: null, render: () => null});
-      var Orange = React.createClass({render: () => null});
-
-      expect(getAddendum()).toBe(
-        ''
-      );
-      expect(getAddendum(<div />)).toBe(
-        '\n    in div (at **)'
-      );
-      expect(getAddendum(<Anon />)).toBe(
-        '\n    in Unknown (at **)'
-      );
-      expect(getAddendum(<Orange />)).toBe(
-        '\n    in Orange (at **)'
-      );
-      expect(getAddendum(React.createElement(Orange))).toBe(
-        '\n    in Orange'
-      );
-
-      var renders = 0;
-      var rOwnedByQ;
-
-      function Q() {
-        return (rOwnedByQ = React.createElement(R));
-      }
-      function R() {
-        return <div><S /></div>;
-      }
-      class S extends React.Component {
-        componentDidMount() {
-          // Check that the parent path is still fetched when only S itself is on
-          // the stack.
-          this.forceUpdate();
-        }
-        render() {
-          expect(getAddendum()).toBe(
-            '\n    in S (at **)' +
-            '\n    in div (at **)' +
-            '\n    in R (created by Q)' +
-            '\n    in Q (at **)'
-          );
-          expect(getAddendum(<span />)).toBe(
-            '\n    in span (at **)' +
-            '\n    in S (at **)' +
-            '\n    in div (at **)' +
-            '\n    in R (created by Q)' +
-            '\n    in Q (at **)'
-          );
-          expect(getAddendum(React.createElement('span'))).toBe(
-            '\n    in span (created by S)' +
-            '\n    in S (at **)' +
-            '\n    in div (at **)' +
-            '\n    in R (created by Q)' +
-            '\n    in Q (at **)'
-          );
-          renders++;
-          return null;
-        }
-      }
-      ReactDOM.render(<Q />, document.createElement('div'));
-      expect(renders).toBe(2);
-
-      // Make sure owner is fetched for the top element too.
-      expect(getAddendum(rOwnedByQ)).toBe(
-        '\n    in R (created by Q)'
-      );
-    });
-
-    it('can be retrieved by ID', () => {
-      function getAddendum(id) {
-        var addendum = ReactComponentTreeHook.getStackAddendumByID(id);
-        return addendum.replace(/\(at .+?:\d+\)/g, '(at **)');
-      }
-
-      class Q extends React.Component {
-        render() {
-          return null;
-        }
-      }
-
-      var q = ReactDOM.render(<Q />, document.createElement('div'));
-      expect(getAddendum(ReactInstanceMap.get(q)._debugID)).toBe(
-        '\n    in Q (at **)'
-      );
-
-      spyOn(console, 'error');
-      getAddendum(-17);
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: ReactComponentTreeHook: Missing React element for ' +
-        'debugID -17 when building stack'
-      );
-    });
-
-    it('is created during mounting', () => {
-      // https://github.com/facebook/react/issues/7187
-      var el = document.createElement('div');
-      var portalEl = document.createElement('div');
-      class Foo extends React.Component {
-        componentWillMount() {
-          ReactDOM.render(<div />, portalEl);
-        }
-        render() {
-          return <div><div /></div>;
-        }
-      }
-      ReactDOM.render(<Foo />, el);
-    });
-
-    it('is created when calling renderToString during render', () => {
-      // https://github.com/facebook/react/issues/7190
-      var el = document.createElement('div');
-      class Foo extends React.Component {
-        render() {
-          return (
-            <div>
-              <div>
-                {ReactDOMServer.renderToString(<div />)}
-              </div>
-            </div>
-          );
-        }
-      }
-      ReactDOM.render(<Foo />, el);
-    });
-  });
-
-  describe('in environment without Map, Set and Array.from', () => {
-    var realMap;
-    var realSet;
-    var realArrayFrom;
-
-    beforeEach(() => {
-      realMap = global.Map;
-      realSet = global.Set;
-      realArrayFrom = Array.from;
-
-      global.Map = undefined;
-      global.Set = undefined;
-      Array.from = undefined;
-
-      jest.resetModuleRegistry();
-
-      React = require('React');
-      ReactDOM = require('ReactDOM');
-      ReactDOMServer = require('ReactDOMServer');
-      ReactInstanceMap = require('ReactInstanceMap');
-      ReactComponentTreeHook = require('ReactComponentTreeHook');
-      ReactComponentTreeTestUtils = require('ReactComponentTreeTestUtils');
-    });
-
-    afterEach(() => {
-      global.Map = realMap;
-      global.Set = realSet;
-      Array.from = realArrayFrom;
-    });
-
-    it('works', () => {
-      class Qux extends React.Component {
-        render() {
-          return null;
-        }
-      }
-
-      function Foo() {
-        return {
-          render() {
-            return <Qux />;
-          },
-        };
-      }
-      function Bar({children}) {
-        return <h1>{children}</h1>;
-      }
-      class Baz extends React.Component {
-        render() {
-          return (
-            <div>
-              <Foo />
-              <Bar>
-                <span>Hi,</span>
-                Mom
-              </Bar>
-              <a href="#">Click me.</a>
-            </div>
-          );
-        }
-      }
-
-      var element = <Baz />;
-      var tree = {
-        displayName: 'Baz',
-        element,
-        children: [{
-          displayName: 'div',
-          children: [{
-            displayName: 'Foo',
-            element: <Foo />,
-            children: [{
-              displayName: 'Qux',
-              element: <Qux />,
-              children: [],
-            }],
-          }, {
-            displayName: 'Bar',
-            children: [{
-              displayName: 'h1',
-              children: [{
-                displayName: 'span',
-                children: [{
-                  displayName: '#text',
-                  element: 'Hi,',
-                  text: 'Hi,',
-                }],
-              }, {
-                displayName: '#text',
-                text: 'Mom',
-                element: 'Mom',
-              }],
-            }],
-          }, {
-            displayName: 'a',
-            children: [{
-              displayName: '#text',
-              text: 'Click me.',
-              element: 'Click me.',
-            }],
-          }],
-        }],
-      };
-      assertTreeMatches([element, tree]);
-    });
   });
 });

--- a/src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.native.js
+++ b/src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.native.js
@@ -11,291 +11,380 @@
 
 'use strict';
 
-describe('ReactComponentTreeHook', () => {
-  var React;
-  var ReactNative;
-  var ReactInstanceMap;
-  var ReactComponentTreeHook;
-  var ReactComponentTreeTestUtils;
-  var createReactNativeComponentClass;
-  var View;
-  var Image;
-  var Text;
+var React;
+var ReactNative;
+var ReactInstanceMap;
+var ReactComponentTreeHook;
+var ReactComponentTreeTestUtils;
+var createReactNativeComponentClass;
+var View;
+var Image;
+var Text;
 
-  beforeEach(() => {
-    jest.resetModuleRegistry();
+beforeEach(() => {
+  jest.resetModuleRegistry();
 
-    React = require('React');
-    ReactNative = require('ReactNative');
-    ReactInstanceMap = require('ReactInstanceMap');
-    ReactComponentTreeHook = require('ReactComponentTreeHook');
-    ReactComponentTreeTestUtils = require('ReactComponentTreeTestUtils');
-    View = require('View');
-    createReactNativeComponentClass = require('createReactNativeComponentClass');
-    Image = createReactNativeComponentClass({
-      validAttributes: {},
-      uiViewClassName: 'Image',
-    });
-    var RCText = createReactNativeComponentClass({
-      validAttributes: {},
-      uiViewClassName: 'RCText',
-    });
-    Text = class extends React.Component {
-      static childContextTypes = {
-        isInAParentText: React.PropTypes.bool,
-      };
-
-      getChildContext() {
-        return {isInAParentText: true};
-      }
-
-      render() {
-        return <RCText {...this.props} />;
-      }
-    };
+  React = require('React');
+  ReactNative = require('ReactNative');
+  ReactInstanceMap = require('ReactInstanceMap');
+  ReactComponentTreeHook = require('ReactComponentTreeHook');
+  ReactComponentTreeTestUtils = require('ReactComponentTreeTestUtils');
+  View = require('View');
+  createReactNativeComponentClass = require('createReactNativeComponentClass');
+  Image = createReactNativeComponentClass({
+    validAttributes: {},
+    uiViewClassName: 'Image',
   });
+  var RCText = createReactNativeComponentClass({
+    validAttributes: {},
+    uiViewClassName: 'RCText',
+  });
+  Text = class extends React.Component {
+    static childContextTypes = {
+      isInAParentText: React.PropTypes.bool,
+    };
 
-  function assertTreeMatches(pairs, options) {
-    if (!Array.isArray(pairs[0])) {
-      pairs = [pairs];
+    getChildContext() {
+      return {isInAParentText: true};
     }
 
-    var currentElement;
-    var rootInstance;
-
-    class Wrapper extends React.Component {
-      render() {
-        rootInstance = ReactInstanceMap.get(this);
-        return currentElement;
-      }
+    render() {
+      return <RCText {...this.props} />;
     }
+  };
+});
 
-    function expectWrapperTreeToEqual(expectedTree, andStayMounted) {
-      ReactComponentTreeTestUtils.expectTree(rootInstance._debugID, {
-        displayName: 'Wrapper',
-        children: expectedTree ? [expectedTree] : [],
-      });
-      var rootDisplayNames = ReactComponentTreeTestUtils.getRootDisplayNames();
-      var registeredDisplayNames = ReactComponentTreeTestUtils.getRegisteredDisplayNames();
-      if (!expectedTree) {
-        expect(rootDisplayNames).toEqual([]);
-        expect(registeredDisplayNames).toEqual([]);
-      } else if (andStayMounted) {
-        expect(rootDisplayNames).toContain('Wrapper');
-        expect(registeredDisplayNames).toContain('Wrapper');
-      }
-    }
-
-    // Mount once, render updates, then unmount.
-    // Ensure the tree is correct on every step.
-    pairs.forEach(([element, expectedTree]) => {
-      currentElement = element;
-
-      // Mount a new tree or update the existing tree.
-      ReactNative.render(<Wrapper />, 1);
-      expectWrapperTreeToEqual(expectedTree, true);
-
-      // Purging should have no effect
-      // on the tree we expect to see.
-      ReactComponentTreeHook.purgeUnmountedComponents();
-      expectWrapperTreeToEqual(expectedTree, true);
-    });
-
-    // Unmounting the root node should purge
-    // the whole subtree automatically.
-    ReactNative.unmountComponentAtNode(1);
-    expectWrapperTreeToEqual(null);
-
-    // Mount and unmount for every pair.
-    // Ensure the tree is correct on every step.
-    pairs.forEach(([element, expectedTree]) => {
-      currentElement = element;
-
-      // Mount a new tree.
-      ReactNative.render(<Wrapper />, 1);
-      expectWrapperTreeToEqual(expectedTree);
-
-      // Unmounting should clean it up.
-      ReactNative.unmountComponentAtNode(1);
-      expectWrapperTreeToEqual(null);
-    });
+function assertTreeMatches(pairs, options) {
+  if (!Array.isArray(pairs[0])) {
+    pairs = [pairs];
   }
 
-  describe('mount', () => {
-    it('uses displayName or Unknown for classic components', () => {
-      class Foo extends React.Component {
-        render() {
-          return null;
-        }
-      }
+  var currentElement;
+  var rootInstance;
 
-      Foo.displayName = 'Bar';
+  class Wrapper extends React.Component {
+    render() {
+      rootInstance = ReactInstanceMap.get(this);
+      return currentElement;
+    }
+  }
 
-      class Baz extends React.Component {
-        render() {
-          return null;
-        }
-      }
-
-      class Qux extends React.Component {
-        render() {
-          return null;
-        }
-      }
-
-      delete Qux.displayName;
-
-      var element = <View><Foo /><Baz /><Qux /></View>;
-      var tree = {
-        displayName: 'View',
-        element,
-        children: [{
-          displayName: 'Bar',
-          children: [],
-        }, {
-          displayName: 'Baz',
-          children: [],
-        }, {
-          displayName: 'Unknown',
-          children: [],
-        }],
-      };
-      assertTreeMatches([element, tree]);
+  function expectWrapperTreeToEqual(expectedTree, andStayMounted) {
+    ReactComponentTreeTestUtils.expectTree(rootInstance._debugID, {
+      displayName: 'Wrapper',
+      children: expectedTree ? [expectedTree] : [],
     });
+    var rootDisplayNames = ReactComponentTreeTestUtils.getRootDisplayNames();
+    var registeredDisplayNames = ReactComponentTreeTestUtils.getRegisteredDisplayNames();
+    if (!expectedTree) {
+      expect(rootDisplayNames).toEqual([]);
+      expect(registeredDisplayNames).toEqual([]);
+    } else if (andStayMounted) {
+      expect(rootDisplayNames).toContain('Wrapper');
+      expect(registeredDisplayNames).toContain('Wrapper');
+    }
+  }
 
-    it('uses displayName, name, or ReactComponent for modern components', () => {
-      class Foo extends React.Component {
-        render() {
-          return null;
-        }
-      }
-      Foo.displayName = 'Bar';
-      class Baz extends React.Component {
-        render() {
-          return null;
-        }
-      }
-      class Qux extends React.Component {
-        render() {
-          return null;
-        }
-      }
-      delete Qux.name;
+  // Mount once, render updates, then unmount.
+  // Ensure the tree is correct on every step.
+  pairs.forEach(([element, expectedTree]) => {
+    currentElement = element;
 
-      var element = <View><Foo /><Baz /><Qux /></View>;
-      var tree = {
-        displayName: 'View',
-        children: [{
-          displayName: 'Bar',
-          children: [],
-        }, {
-          displayName: 'Baz',
-          children: [],
-        }, {
-          // Note: Ideally fallback name should be consistent (e.g. "Unknown")
-          displayName: 'ReactComponent',
-          children: [],
-        }],
-      };
-      assertTreeMatches([element, tree]);
-    });
+    // Mount a new tree or update the existing tree.
+    ReactNative.render(<Wrapper />, 1);
+    expectWrapperTreeToEqual(expectedTree, true);
 
-    it('uses displayName, name, or Object for factory components', () => {
-      function Foo() {
-        return {
-          render() {
-            return null;
-          },
-        };
-      }
-      Foo.displayName = 'Bar';
-      function Baz() {
-        return {
-          render() {
-            return null;
-          },
-        };
-      }
-      function Qux() {
-        return {
-          render() {
-            return null;
-          },
-        };
-      }
-      delete Qux.name;
+    // Purging should have no effect
+    // on the tree we expect to see.
+    ReactComponentTreeHook.purgeUnmountedComponents();
+    expectWrapperTreeToEqual(expectedTree, true);
+  });
 
-      var element = <View><Foo /><Baz /><Qux /></View>;
-      var tree = {
-        displayName: 'View',
-        children: [{
-          displayName: 'Bar',
-          children: [],
-        }, {
-          displayName: 'Baz',
-          children: [],
-        }, {
-          displayName: 'Unknown',
-          children: [],
-        }],
-      };
-      assertTreeMatches([element, tree]);
-    });
+  // Unmounting the root node should purge
+  // the whole subtree automatically.
+  ReactNative.unmountComponentAtNode(1);
+  expectWrapperTreeToEqual(null);
 
-    it('uses displayName, name, or StatelessComponent for functional components', () => {
-      function Foo() {
+  // Mount and unmount for every pair.
+  // Ensure the tree is correct on every step.
+  pairs.forEach(([element, expectedTree]) => {
+    currentElement = element;
+
+    // Mount a new tree.
+    ReactNative.render(<Wrapper />, 1);
+    expectWrapperTreeToEqual(expectedTree);
+
+    // Unmounting should clean it up.
+    ReactNative.unmountComponentAtNode(1);
+    expectWrapperTreeToEqual(null);
+  });
+}
+
+describe('mount', () => {
+  it('uses displayName or Unknown for classic components', () => {
+    class Foo extends React.Component {
+      render() {
         return null;
       }
-      Foo.displayName = 'Bar';
-      function Baz() {
-        return null;
-      }
-      function Qux() {
-        return null;
-      }
-      delete Qux.name;
+    }
 
-      var element = <View><Foo /><Baz /><Qux /></View>;
-      var tree = {
-        displayName: 'View',
-        children: [{
-          displayName: 'Bar',
-          children: [],
-        }, {
-          displayName: 'Baz',
-          children: [],
-        }, {
-          displayName: 'Unknown',
-          children: [],
-        }],
+    Foo.displayName = 'Bar';
+
+    class Baz extends React.Component {
+      render() {
+        return null;
+      }
+    }
+
+    class Qux extends React.Component {
+      render() {
+        return null;
+      }
+    }
+
+    delete Qux.displayName;
+
+    var element = <View><Foo /><Baz /><Qux /></View>;
+    var tree = {
+      displayName: 'View',
+      element,
+      children: [{
+        displayName: 'Bar',
+        children: [],
+      }, {
+        displayName: 'Baz',
+        children: [],
+      }, {
+        displayName: 'Unknown',
+        children: [],
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('uses displayName, name, or ReactComponent for modern components', () => {
+    class Foo extends React.Component {
+      render() {
+        return null;
+      }
+    }
+    Foo.displayName = 'Bar';
+    class Baz extends React.Component {
+      render() {
+        return null;
+      }
+    }
+    class Qux extends React.Component {
+      render() {
+        return null;
+      }
+    }
+    delete Qux.name;
+
+    var element = <View><Foo /><Baz /><Qux /></View>;
+    var tree = {
+      displayName: 'View',
+      children: [{
+        displayName: 'Bar',
+        children: [],
+      }, {
+        displayName: 'Baz',
+        children: [],
+      }, {
+        // Note: Ideally fallback name should be consistent (e.g. "Unknown")
+        displayName: 'ReactComponent',
+        children: [],
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('uses displayName, name, or Object for factory components', () => {
+    function Foo() {
+      return {
+        render() {
+          return null;
+        },
       };
-      assertTreeMatches([element, tree]);
-    });
+    }
+    Foo.displayName = 'Bar';
+    function Baz() {
+      return {
+        render() {
+          return null;
+        },
+      };
+    }
+    function Qux() {
+      return {
+        render() {
+          return null;
+        },
+      };
+    }
+    delete Qux.name;
 
-    it('reports a host tree correctly', () => {
-      var element = (
+    var element = <View><Foo /><Baz /><Qux /></View>;
+    var tree = {
+      displayName: 'View',
+      children: [{
+        displayName: 'Bar',
+        children: [],
+      }, {
+        displayName: 'Baz',
+        children: [],
+      }, {
+        displayName: 'Unknown',
+        children: [],
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('uses displayName, name, or StatelessComponent for functional components', () => {
+    function Foo() {
+      return null;
+    }
+    Foo.displayName = 'Bar';
+    function Baz() {
+      return null;
+    }
+    function Qux() {
+      return null;
+    }
+    delete Qux.name;
+
+    var element = <View><Foo /><Baz /><Qux /></View>;
+    var tree = {
+      displayName: 'View',
+      children: [{
+        displayName: 'Bar',
+        children: [],
+      }, {
+        displayName: 'Baz',
+        children: [],
+      }, {
+        displayName: 'Unknown',
+        children: [],
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('reports a host tree correctly', () => {
+    var element = (
+      <View>
         <View>
-          <View>
-            <Text>
-              Hi!
-            </Text>
-          </View>
-          <Image />
+          <Text>
+            Hi!
+          </Text>
         </View>
-      );
-      var tree = {
+        <Image />
+      </View>
+    );
+    var tree = {
+      displayName: 'View',
+      element,
+      children: [{
         displayName: 'View',
-        element,
         children: [{
-          displayName: 'View',
+          displayName: 'Text',
           children: [{
-            displayName: 'Text',
+            displayName: 'RCText',
             children: [{
-              displayName: 'RCText',
+              displayName: '#text',
+              element: 'Hi!',
+              text: 'Hi!',
+            }],
+          }],
+        }],
+      }, {
+        displayName: 'Image',
+        element: <Image />,
+        children: [],
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('reports a simple tree with composites correctly', () => {
+    class Foo extends React.Component {
+      render() {
+        return <Image />;
+      }
+    }
+
+    var element = <Foo />;
+    var tree = {
+      displayName: 'Foo',
+      element,
+      children: [{
+        displayName: 'Image',
+        element: <Image />,
+        children: [],
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('reports a tree with composites correctly', () => {
+    class Qux extends React.Component {
+      render() {
+        return null;
+      }
+    }
+
+    function Foo() {
+      return {
+        render() {
+          return <Qux />;
+        },
+      };
+    }
+    function Bar({children}) {
+      return <View>{children}</View>;
+    }
+    class Baz extends React.Component {
+      render() {
+        return (
+          <View>
+            <Foo />
+            <Bar>
+              <Text>Hi,</Text>
+            </Bar>
+            <Image />
+          </View>
+        );
+      }
+    }
+
+    var element = <Baz />;
+    var tree = {
+      displayName: 'Baz',
+      element,
+      children: [{
+        displayName: 'View',
+        children: [{
+          displayName: 'Foo',
+          element: <Foo />,
+          children: [{
+            displayName: 'Qux',
+            element: <Qux />,
+            children: [],
+          }],
+        }, {
+          displayName: 'Bar',
+          children: [{
+            displayName: 'View',
+            children: [{
+              displayName: 'Text',
               children: [{
-                displayName: '#text',
-                element: 'Hi!',
-                text: 'Hi!',
+                displayName: 'RCText',
+                children: [{
+                  displayName: '#text',
+                  element: 'Hi,',
+                  text: 'Hi,',
+                }],
               }],
             }],
           }],
@@ -304,1395 +393,1304 @@ describe('ReactComponentTreeHook', () => {
           element: <Image />,
           children: [],
         }],
-      };
-      assertTreeMatches([element, tree]);
-    });
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
 
-    it('reports a simple tree with composites correctly', () => {
-      class Foo extends React.Component {
-        render() {
-          return <Image />;
-        }
+  it('ignores null children', () => {
+    class Foo extends React.Component {
+      render() {
+        return null;
       }
+    }
+    var element = <Foo />;
+    var tree = {
+      displayName: 'Foo',
+      children: [],
+    };
+    assertTreeMatches([element, tree]);
+  });
 
-      var element = <Foo />;
-      var tree = {
+  it('ignores false children', () => {
+    class Foo extends React.Component {
+      render() {
+        return false;
+      }
+    }
+    var element = <Foo />;
+    var tree = {
+      displayName: 'Foo',
+      children: [],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('reports text nodes as children', () => {
+    var element = <Text>{'1'}{2}</Text>;
+    var tree = {
+      displayName: 'Text',
+      children: [{
+        displayName: 'RCText',
+        children: [{
+          displayName: '#text',
+          text: '1',
+        }, {
+          displayName: '#text',
+          text: '2',
+        }],
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('reports a single text node as a child', () => {
+    var element = <Text>{'1'}</Text>;
+    var tree = {
+      displayName: 'Text',
+      children: [{
+        displayName: 'RCText',
+        children: [{
+          displayName: '#text',
+          text: '1',
+        }],
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('reports a single number node as a child', () => {
+    var element = <Text>{42}</Text>;
+    var tree = {
+      displayName: 'Text',
+      children: [{
+        displayName: 'RCText',
+        children: [{
+          displayName: '#text',
+          text: '42',
+        }],
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('reports a zero as a child', () => {
+    var element = <Text>{0}</Text>;
+    var tree = {
+      displayName: 'Text',
+      children: [{
+        displayName: 'RCText',
+        children: [{
+          displayName: '#text',
+          text: '0',
+        }],
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+
+  it('skips empty nodes for multiple children', () => {
+    function Foo() {
+      return <Image />;
+    }
+    var element = (
+      <View>
+        {false}
+        <Foo />
+        {null}
+        <Foo />
+      </View>
+    );
+    var tree = {
+      displayName: 'View',
+      element,
+      children: [{
         displayName: 'Foo',
-        element,
+        element: <Foo />,
         children: [{
           displayName: 'Image',
           element: <Image />,
           children: [],
         }],
+      }, {
+        displayName: 'Foo',
+        element: <Foo />,
+        children: [{
+          displayName: 'Image',
+          element: <Image />,
+          children: [],
+        }],
+      }],
+    };
+    assertTreeMatches([element, tree]);
+  });
+});
+
+describe('update', () => {
+  describe('host component', () => {
+    it('updates text of a single text child', () => {
+      var elementBefore = <Text>Hi.</Text>;
+      var treeBefore = {
+        displayName: 'Text',
+        children: [{
+          displayName: 'RCText',
+          children: [{
+            displayName: '#text',
+            text: 'Hi.',
+          }],
+        }],
       };
-      assertTreeMatches([element, tree]);
+
+      var elementAfter = <Text>Bye.</Text>;
+      var treeAfter = {
+        displayName: 'Text',
+        children: [{
+          displayName: 'RCText',
+          children: [{
+            displayName: '#text',
+            text: 'Bye.',
+          }],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
     });
 
-    it('reports a tree with composites correctly', () => {
-      class Qux extends React.Component {
-        render() {
-          return null;
-        }
-      }
-
-      function Foo() {
-        return {
-          render() {
-            return <Qux />;
-          },
-        };
-      }
-      function Bar({children}) {
-        return <View>{children}</View>;
-      }
-      class Baz extends React.Component {
-        render() {
-          return (
-            <View>
-              <Foo />
-              <Bar>
-                <Text>Hi,</Text>
-              </Bar>
-              <Image />
-            </View>
-          );
-        }
-      }
-
-      var element = <Baz />;
-      var tree = {
-        displayName: 'Baz',
-        element,
+    it('updates from no children to a single text child', () => {
+      var elementBefore = <Text />;
+      var treeBefore = {
+        displayName: 'Text',
         children: [{
-          displayName: 'View',
+          displayName: 'RCText',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Text>Hi.</Text>;
+      var treeAfter = {
+        displayName: 'Text',
+        children: [{
+          displayName: 'RCText',
           children: [{
-            displayName: 'Foo',
-            element: <Foo />,
-            children: [{
-              displayName: 'Qux',
-              element: <Qux />,
-              children: [],
-            }],
+            displayName: '#text',
+            text: 'Hi.',
+          }],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a single text child to no children', () => {
+      var elementBefore = <Text>Hi.</Text>;
+      var treeBefore = {
+        displayName: 'Text',
+        children: [{
+          displayName: 'RCText',
+          children: [{
+            displayName: '#text',
+            text: 'Hi.',
+          }],
+        }],
+      };
+
+      var elementAfter = <Text />;
+      var treeAfter = {
+        displayName: 'Text',
+        children: [{
+          displayName: 'RCText',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from no children to multiple text children', () => {
+      var elementBefore = <Text />;
+      var treeBefore = {
+        displayName: 'Text',
+        children: [{
+          displayName: 'RCText',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Text>{'Hi.'}{'Bye.'}</Text>;
+      var treeAfter = {
+        displayName: 'Text',
+        children: [{
+          displayName: 'RCText',
+          children: [{
+            displayName: '#text',
+            text: 'Hi.',
           }, {
-            displayName: 'Bar',
-            children: [{
-              displayName: 'View',
-              children: [{
-                displayName: 'Text',
-                children: [{
-                  displayName: 'RCText',
-                  children: [{
-                    displayName: '#text',
-                    element: 'Hi,',
-                    text: 'Hi,',
-                  }],
-                }],
-              }],
-            }],
+            displayName: '#text',
+            text: 'Bye.',
+          }],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from multiple text children to no children', () => {
+      var elementBefore = <Text>{'Hi.'}{'Bye.'}</Text>;
+      var treeBefore = {
+        displayName: 'Text',
+        children: [{
+          displayName: 'RCText',
+          children: [{
+            displayName: '#text',
+            text: 'Hi.',
           }, {
-            displayName: 'Image',
-            element: <Image />,
+            displayName: '#text',
+            text: 'Bye.',
+          }],
+        }],
+      };
+
+      var elementAfter = <Text />;
+      var treeAfter = {
+        displayName: 'Text',
+        children: [{
+          displayName: 'RCText',
+          children: [],
+        }],
+      };
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from one text child to multiple text children', () => {
+      var elementBefore = <Text>Hi.</Text>;
+      var treeBefore = {
+        displayName: 'Text',
+        children: [{
+          displayName: 'RCText',
+          children: [{
+            displayName: '#text',
+            text: 'Hi.',
+          }],
+        }],
+      };
+
+      var elementAfter = <Text>{'Hi.'}{'Bye.'}</Text>;
+      var treeAfter = {
+        displayName: 'Text',
+        children: [{
+          displayName: 'RCText',
+          children: [{
+            displayName: '#text',
+            text: 'Hi.',
+          }, {
+            displayName: '#text',
+            text: 'Bye.',
+          }],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from multiple text children to one text child', () => {
+      var elementBefore = <Text>{'Hi.'}{'Bye.'}</Text>;
+      var treeBefore = {
+        displayName: 'Text',
+        children: [{
+          displayName: 'RCText',
+          children: [{
+            displayName: '#text',
+            text: 'Hi.',
+          }, {
+            displayName: '#text',
+            text: 'Bye.',
+          }],
+        }],
+      };
+
+      var elementAfter = <Text>Hi.</Text>;
+      var treeAfter = {
+        displayName: 'Text',
+        children: [{
+          displayName: 'RCText',
+          children: [{
+            displayName: '#text',
+            text: 'Hi.',
+          }],
+        }],
+      };
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates text nodes when reordering', () => {
+      var elementBefore = <Text>{'Hi.'}{'Bye.'}</Text>;
+      var treeBefore = {
+        displayName: 'Text',
+        children: [{
+          displayName: 'RCText',
+          children: [{
+            displayName: '#text',
+            text: 'Hi.',
+          }, {
+            displayName: '#text',
+            text: 'Bye.',
+          }],
+        }],
+      };
+
+      var elementAfter = <Text>{'Bye.'}{'Hi.'}</Text>;
+      var treeAfter = {
+        displayName: 'Text',
+        children: [{
+          displayName: 'RCText',
+          children: [{
+            displayName: '#text',
+            text: 'Bye.',
+          }, {
+            displayName: '#text',
+            text: 'Hi.',
+          }],
+        }],
+      };
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates host nodes when reordering with keys', () => {
+      var elementBefore = (
+        <View>
+          <Text key="a">Hi.</Text>
+          <Text key="b">Bye.</Text>
+        </View>
+      );
+      var treeBefore = {
+        displayName: 'View',
+        children: [{
+          displayName: 'Text',
+          children: [{
+            displayName: 'RCText',
+            children: [{
+              displayName: '#text',
+              text: 'Hi.',
+            }],
+          }],
+        }, {
+          displayName: 'Text',
+          children: [{
+            displayName: 'RCText',
+            children: [{
+              displayName: '#text',
+              text: 'Bye.',
+            }],
+          }],
+        }],
+      };
+
+      var elementAfter = (
+        <View>
+          <Text key="b">Bye.</Text>
+          <Text key="a">Hi.</Text>
+        </View>
+      );
+      var treeAfter = {
+        displayName: 'View',
+        children: [{
+          displayName: 'Text',
+          children: [{
+            displayName: 'RCText',
+            children: [{
+              displayName: '#text',
+              text: 'Bye.',
+            }],
+          }],
+        }, {
+          displayName: 'Text',
+          children: [{
+            displayName: 'RCText',
+            children: [{
+              displayName: '#text',
+              text: 'Hi.',
+            }],
+          }],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates host nodes when reordering with keys', () => {
+      var elementBefore = (
+        <View>
+          <Text>Hi.</Text>
+          <Text>Bye.</Text>
+        </View>
+      );
+      var treeBefore = {
+        displayName: 'View',
+        children: [{
+          displayName: 'Text',
+          children: [{
+            displayName: 'RCText',
+            children: [{
+              displayName: '#text',
+              text: 'Hi.',
+            }],
+          }],
+        }, {
+          displayName: 'Text',
+          children: [{
+            displayName: 'RCText',
+            children: [{
+              displayName: '#text',
+              text: 'Bye.',
+            }],
+          }],
+        }],
+      };
+
+      var elementAfter = (
+        <View>
+          <Text>Bye.</Text>
+          <Text>Hi.</Text>
+        </View>
+      );
+      var treeAfter = {
+        displayName: 'View',
+        children: [{
+          displayName: 'Text',
+          children: [{
+            displayName: 'RCText',
+            children: [{
+              displayName: '#text',
+              text: 'Bye.',
+            }],
+          }],
+        }, {
+          displayName: 'Text',
+          children: [{
+            displayName: 'RCText',
+            children: [{
+              displayName: '#text',
+              text: 'Hi.',
+            }],
+          }],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates a single composite child of a different type', () => {
+      function Foo() {
+        return null;
+      }
+
+      function Bar() {
+        return null;
+      }
+
+      var elementBefore = <View><Foo /></View>;
+      var treeBefore = {
+        displayName: 'View',
+        children: [{
+          displayName: 'Foo',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <View><Bar /></View>;
+      var treeAfter = {
+        displayName: 'View',
+        children: [{
+          displayName: 'Bar',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates a single composite child of the same type', () => {
+      function Foo({ children }) {
+        return children;
+      }
+
+      var elementBefore = <View><Foo><View /></Foo></View>;
+      var treeBefore = {
+        displayName: 'View',
+        children: [{
+          displayName: 'Foo',
+          children: [{
+            displayName: 'View',
             children: [],
           }],
         }],
       };
-      assertTreeMatches([element, tree]);
-    });
 
-    it('ignores null children', () => {
-      class Foo extends React.Component {
-        render() {
-          return null;
-        }
-      }
-      var element = <Foo />;
-      var tree = {
-        displayName: 'Foo',
-        children: [],
-      };
-      assertTreeMatches([element, tree]);
-    });
-
-    it('ignores false children', () => {
-      class Foo extends React.Component {
-        render() {
-          return false;
-        }
-      }
-      var element = <Foo />;
-      var tree = {
-        displayName: 'Foo',
-        children: [],
-      };
-      assertTreeMatches([element, tree]);
-    });
-
-    it('reports text nodes as children', () => {
-      var element = <Text>{'1'}{2}</Text>;
-      var tree = {
-        displayName: 'Text',
+      var elementAfter = <View><Foo><Image /></Foo></View>;
+      var treeAfter = {
+        displayName: 'View',
         children: [{
-          displayName: 'RCText',
+          displayName: 'Foo',
           children: [{
-            displayName: '#text',
-            text: '1',
-          }, {
-            displayName: '#text',
-            text: '2',
+            displayName: 'Image',
+            children: [],
           }],
         }],
       };
-      assertTreeMatches([element, tree]);
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
     });
 
-    it('reports a single text node as a child', () => {
-      var element = <Text>{'1'}</Text>;
-      var tree = {
-        displayName: 'Text',
-        children: [{
-          displayName: 'RCText',
-          children: [{
-            displayName: '#text',
-            text: '1',
-          }],
-        }],
-      };
-      assertTreeMatches([element, tree]);
-    });
-
-    it('reports a single number node as a child', () => {
-      var element = <Text>{42}</Text>;
-      var tree = {
-        displayName: 'Text',
-        children: [{
-          displayName: 'RCText',
-          children: [{
-            displayName: '#text',
-            text: '42',
-          }],
-        }],
-      };
-      assertTreeMatches([element, tree]);
-    });
-
-    it('reports a zero as a child', () => {
-      var element = <Text>{0}</Text>;
-      var tree = {
-        displayName: 'Text',
-        children: [{
-          displayName: 'RCText',
-          children: [{
-            displayName: '#text',
-            text: '0',
-          }],
-        }],
-      };
-      assertTreeMatches([element, tree]);
-    });
-
-    it('skips empty nodes for multiple children', () => {
+    it('updates from no children to a single composite child', () => {
       function Foo() {
-        return <Image />;
+        return null;
       }
-      var element = (
+
+      var elementBefore = <View />;
+      var treeBefore = {
+        displayName: 'View',
+        children: [],
+      };
+
+      var elementAfter = <View><Foo /></View>;
+      var treeAfter = {
+        displayName: 'View',
+        children: [{
+          displayName: 'Foo',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a single composite child to no children', () => {
+      function Foo() {
+        return null;
+      }
+
+      var elementBefore = <View><Foo /></View>;
+      var treeBefore = {
+        displayName: 'View',
+        children: [{
+          displayName: 'Foo',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <View />;
+      var treeAfter = {
+        displayName: 'View',
+        children: [],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates mixed children', () => {
+      function Foo() {
+        return <View />;
+      }
+      var element1 = (
         <View>
+          <Text>hi</Text>
           {false}
-          <Foo />
+          <Text>{42}</Text>
           {null}
           <Foo />
         </View>
       );
-      var tree = {
+      var tree1 = {
         displayName: 'View',
-        element,
         children: [{
-          displayName: 'Foo',
-          element: <Foo />,
+          displayName: 'Text',
           children: [{
-            displayName: 'Image',
-            element: <Image />,
-            children: [],
+            displayName: 'RCText',
+            children: [{
+              displayName: '#text',
+              text: 'hi',
+            }],
+          }],
+        }, {
+          displayName: 'Text',
+          children: [{
+            displayName: 'RCText',
+            children: [{
+              displayName: '#text',
+              text: '42',
+            }],
           }],
         }, {
           displayName: 'Foo',
-          element: <Foo />,
           children: [{
-            displayName: 'Image',
-            element: <Image />,
+            displayName: 'View',
             children: [],
           }],
         }],
       };
-      assertTreeMatches([element, tree]);
+
+      var element2 = (
+        <View>
+          <Foo />
+          {false}
+          <Text>hi</Text>
+          {null}
+        </View>
+      );
+      var tree2 = {
+        displayName: 'View',
+        children: [{
+          displayName: 'Foo',
+          children: [{
+            displayName: 'View',
+            children: [],
+          }],
+        }, {
+          displayName: 'Text',
+          children: [{
+            displayName: 'RCText',
+            children: [{
+              displayName: '#text',
+              text: 'hi',
+            }],
+          }],
+        }],
+      };
+
+      var element3 = (
+        <View>
+          <Foo />
+        </View>
+      );
+      var tree3 = {
+        displayName: 'View',
+        children: [{
+          displayName: 'Foo',
+          children: [{
+            displayName: 'View',
+            children: [],
+          }],
+        }],
+      };
+
+      assertTreeMatches([
+        [element1, tree1],
+        [element2, tree2],
+        [element3, tree3],
+      ]);
     });
   });
 
-  describe('update', () => {
-    describe('host component', () => {
-      it('updates text of a single text child', () => {
-        var elementBefore = <Text>Hi.</Text>;
-        var treeBefore = {
-          displayName: 'Text',
-          children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }],
-          }],
-        };
-
-        var elementAfter = <Text>Bye.</Text>;
-        var treeAfter = {
-          displayName: 'Text',
-          children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Bye.',
-            }],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from no children to a single text child', () => {
-        var elementBefore = <Text />;
-        var treeBefore = {
-          displayName: 'Text',
-          children: [{
-            displayName: 'RCText',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Text>Hi.</Text>;
-        var treeAfter = {
-          displayName: 'Text',
-          children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a single text child to no children', () => {
-        var elementBefore = <Text>Hi.</Text>;
-        var treeBefore = {
-          displayName: 'Text',
-          children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }],
-          }],
-        };
-
-        var elementAfter = <Text />;
-        var treeAfter = {
-          displayName: 'Text',
-          children: [{
-            displayName: 'RCText',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from no children to multiple text children', () => {
-        var elementBefore = <Text />;
-        var treeBefore = {
-          displayName: 'Text',
-          children: [{
-            displayName: 'RCText',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Text>{'Hi.'}{'Bye.'}</Text>;
-        var treeAfter = {
-          displayName: 'Text',
-          children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }, {
-              displayName: '#text',
-              text: 'Bye.',
-            }],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from multiple text children to no children', () => {
-        var elementBefore = <Text>{'Hi.'}{'Bye.'}</Text>;
-        var treeBefore = {
-          displayName: 'Text',
-          children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }, {
-              displayName: '#text',
-              text: 'Bye.',
-            }],
-          }],
-        };
-
-        var elementAfter = <Text />;
-        var treeAfter = {
-          displayName: 'Text',
-          children: [{
-            displayName: 'RCText',
-            children: [],
-          }],
-        };
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from one text child to multiple text children', () => {
-        var elementBefore = <Text>Hi.</Text>;
-        var treeBefore = {
-          displayName: 'Text',
-          children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }],
-          }],
-        };
-
-        var elementAfter = <Text>{'Hi.'}{'Bye.'}</Text>;
-        var treeAfter = {
-          displayName: 'Text',
-          children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }, {
-              displayName: '#text',
-              text: 'Bye.',
-            }],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from multiple text children to one text child', () => {
-        var elementBefore = <Text>{'Hi.'}{'Bye.'}</Text>;
-        var treeBefore = {
-          displayName: 'Text',
-          children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }, {
-              displayName: '#text',
-              text: 'Bye.',
-            }],
-          }],
-        };
-
-        var elementAfter = <Text>Hi.</Text>;
-        var treeAfter = {
-          displayName: 'Text',
-          children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }],
-          }],
-        };
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates text nodes when reordering', () => {
-        var elementBefore = <Text>{'Hi.'}{'Bye.'}</Text>;
-        var treeBefore = {
-          displayName: 'Text',
-          children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Hi.',
-            }, {
-              displayName: '#text',
-              text: 'Bye.',
-            }],
-          }],
-        };
-
-        var elementAfter = <Text>{'Bye.'}{'Hi.'}</Text>;
-        var treeAfter = {
-          displayName: 'Text',
-          children: [{
-            displayName: 'RCText',
-            children: [{
-              displayName: '#text',
-              text: 'Bye.',
-            }, {
-              displayName: '#text',
-              text: 'Hi.',
-            }],
-          }],
-        };
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates host nodes when reordering with keys', () => {
-        var elementBefore = (
-          <View>
-            <Text key="a">Hi.</Text>
-            <Text key="b">Bye.</Text>
-          </View>
-        );
-        var treeBefore = {
-          displayName: 'View',
-          children: [{
-            displayName: 'Text',
-            children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: 'Hi.',
-              }],
-            }],
-          }, {
-            displayName: 'Text',
-            children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: 'Bye.',
-              }],
-            }],
-          }],
-        };
-
-        var elementAfter = (
-          <View>
-            <Text key="b">Bye.</Text>
-            <Text key="a">Hi.</Text>
-          </View>
-        );
-        var treeAfter = {
-          displayName: 'View',
-          children: [{
-            displayName: 'Text',
-            children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: 'Bye.',
-              }],
-            }],
-          }, {
-            displayName: 'Text',
-            children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: 'Hi.',
-              }],
-            }],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates host nodes when reordering with keys', () => {
-        var elementBefore = (
-          <View>
-            <Text>Hi.</Text>
-            <Text>Bye.</Text>
-          </View>
-        );
-        var treeBefore = {
-          displayName: 'View',
-          children: [{
-            displayName: 'Text',
-            children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: 'Hi.',
-              }],
-            }],
-          }, {
-            displayName: 'Text',
-            children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: 'Bye.',
-              }],
-            }],
-          }],
-        };
-
-        var elementAfter = (
-          <View>
-            <Text>Bye.</Text>
-            <Text>Hi.</Text>
-          </View>
-        );
-        var treeAfter = {
-          displayName: 'View',
-          children: [{
-            displayName: 'Text',
-            children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: 'Bye.',
-              }],
-            }],
-          }, {
-            displayName: 'Text',
-            children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: 'Hi.',
-              }],
-            }],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates a single composite child of a different type', () => {
-        function Foo() {
-          return null;
-        }
-
-        function Bar() {
-          return null;
-        }
-
-        var elementBefore = <View><Foo /></View>;
-        var treeBefore = {
-          displayName: 'View',
-          children: [{
-            displayName: 'Foo',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <View><Bar /></View>;
-        var treeAfter = {
-          displayName: 'View',
-          children: [{
-            displayName: 'Bar',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates a single composite child of the same type', () => {
-        function Foo({ children }) {
-          return children;
-        }
-
-        var elementBefore = <View><Foo><View /></Foo></View>;
-        var treeBefore = {
-          displayName: 'View',
-          children: [{
-            displayName: 'Foo',
-            children: [{
-              displayName: 'View',
-              children: [],
-            }],
-          }],
-        };
-
-        var elementAfter = <View><Foo><Image /></Foo></View>;
-        var treeAfter = {
-          displayName: 'View',
-          children: [{
-            displayName: 'Foo',
-            children: [{
-              displayName: 'Image',
-              children: [],
-            }],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from no children to a single composite child', () => {
-        function Foo() {
-          return null;
-        }
-
-        var elementBefore = <View />;
-        var treeBefore = {
-          displayName: 'View',
-          children: [],
-        };
-
-        var elementAfter = <View><Foo /></View>;
-        var treeAfter = {
-          displayName: 'View',
-          children: [{
-            displayName: 'Foo',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a single composite child to no children', () => {
-        function Foo() {
-          return null;
-        }
-
-        var elementBefore = <View><Foo /></View>;
-        var treeBefore = {
-          displayName: 'View',
-          children: [{
-            displayName: 'Foo',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <View />;
-        var treeAfter = {
-          displayName: 'View',
-          children: [],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates mixed children', () => {
-        function Foo() {
-          return <View />;
-        }
-        var element1 = (
-          <View>
-            <Text>hi</Text>
-            {false}
-            <Text>{42}</Text>
-            {null}
-            <Foo />
-          </View>
-        );
-        var tree1 = {
-          displayName: 'View',
-          children: [{
-            displayName: 'Text',
-            children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: 'hi',
-              }],
-            }],
-          }, {
-            displayName: 'Text',
-            children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: '42',
-              }],
-            }],
-          }, {
-            displayName: 'Foo',
-            children: [{
-              displayName: 'View',
-              children: [],
-            }],
-          }],
-        };
-
-        var element2 = (
-          <View>
-            <Foo />
-            {false}
-            <Text>hi</Text>
-            {null}
-          </View>
-        );
-        var tree2 = {
-          displayName: 'View',
-          children: [{
-            displayName: 'Foo',
-            children: [{
-              displayName: 'View',
-              children: [],
-            }],
-          }, {
-            displayName: 'Text',
-            children: [{
-              displayName: 'RCText',
-              children: [{
-                displayName: '#text',
-                text: 'hi',
-              }],
-            }],
-          }],
-        };
-
-        var element3 = (
-          <View>
-            <Foo />
-          </View>
-        );
-        var tree3 = {
-          displayName: 'View',
-          children: [{
-            displayName: 'Foo',
-            children: [{
-              displayName: 'View',
-              children: [],
-            }],
-          }],
-        };
-
-        assertTreeMatches([
-          [element1, tree1],
-          [element2, tree2],
-          [element3, tree3],
-        ]);
-      });
-    });
-
-    describe('functional component', () => {
-      it('updates with a host child', () => {
-        function Foo({ children }) {
-          return children;
-        }
-
-        var elementBefore = <Foo><View /></Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'View',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Foo><Image /></Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'Image',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from null to a host child', () => {
-        function Foo({ children }) {
-          return children;
-        }
-
-        var elementBefore = <Foo>{null}</Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [],
-        };
-
-        var elementAfter = <Foo><View /></Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'View',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a host child to null', () => {
-        function Foo({ children }) {
-          return children;
-        }
-
-        var elementBefore = <Foo><View /></Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'View',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Foo>{null}</Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a host child to a composite child', () => {
-        function Bar() {
-          return null;
-        }
-
-        function Foo({ children }) {
-          return children;
-        }
-
-        var elementBefore = <Foo><View /></Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'View',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Foo><Bar /></Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'Bar',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a composite child to a host child', () => {
-        function Bar() {
-          return null;
-        }
-
-        function Foo({ children }) {
-          return children;
-        }
-
-        var elementBefore = <Foo><Bar /></Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'Bar',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Foo><View /></Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'View',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from null to a composite child', () => {
-        function Bar() {
-          return null;
-        }
-
-        function Foo({ children }) {
-          return children;
-        }
-
-        var elementBefore = <Foo>{null}</Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [],
-        };
-
-        var elementAfter = <Foo><Bar /></Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'Bar',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a composite child to null', () => {
-        function Bar() {
-          return null;
-        }
-
-        function Foo({ children }) {
-          return children;
-        }
-
-        var elementBefore = <Foo><Bar /></Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'Bar',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Foo>{null}</Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-    });
-
-    describe('class component', () => {
-      it('updates with a host child', () => {
-        class Foo extends React.Component {
-          render() {
-            return this.props.children;
-          }
-        }
-
-        var elementBefore = <Foo><View /></Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'View',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Foo><Image /></Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'Image',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from null to a host child', () => {
-        class Foo extends React.Component {
-          render() {
-            return this.props.children;
-          }
-        }
-
-        var elementBefore = <Foo>{null}</Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [],
-        };
-
-        var elementAfter = <Foo><View /></Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'View',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a host child to null', () => {
-        class Foo extends React.Component {
-          render() {
-            return this.props.children;
-          }
-        }
-
-        var elementBefore = <Foo><View /></Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'View',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Foo>{null}</Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a host child to a composite child', () => {
-        class Bar extends React.Component {
-          render() {
-            return null;
-          }
-        }
-
-        class Foo extends React.Component {
-          render() {
-            return this.props.children;
-          }
-        }
-
-        var elementBefore = <Foo><View /></Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'View',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Foo><Bar /></Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'Bar',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a composite child to a host child', () => {
-        class Bar extends React.Component {
-          render() {
-            return null;
-          }
-        }
-
-        class Foo extends React.Component {
-          render() {
-            return this.props.children;
-          }
-        }
-
-        var elementBefore = <Foo><Bar /></Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'Bar',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Foo><View /></Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'View',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from null to a composite child', () => {
-        class Bar extends React.Component {
-          render() {
-            return null;
-          }
-        }
-
-        class Foo extends React.Component {
-          render() {
-            return this.props.children;
-          }
-        }
-
-        var elementBefore = <Foo>{null}</Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [],
-        };
-
-        var elementAfter = <Foo><Bar /></Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'Bar',
-            children: [],
-          }],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-
-      it('updates from a composite child to null', () => {
-        class Bar extends React.Component {
-          render() {
-            return null;
-          }
-        }
-
-        class Foo extends React.Component {
-          render() {
-            return this.props.children;
-          }
-        }
-
-        var elementBefore = <Foo><Bar /></Foo>;
-        var treeBefore = {
-          displayName: 'Foo',
-          children: [{
-            displayName: 'Bar',
-            children: [],
-          }],
-        };
-
-        var elementAfter = <Foo>{null}</Foo>;
-        var treeAfter = {
-          displayName: 'Foo',
-          children: [],
-        };
-
-        assertTreeMatches([
-          [elementBefore, treeBefore],
-          [elementAfter, treeAfter],
-        ]);
-      });
-    });
-  });
-
-  it('tracks owner correctly', () => {
-    class Foo extends React.Component {
-      render() {
-        return <Bar><Text>Hi.</Text></Bar>;
+  describe('functional component', () => {
+    it('updates with a host child', () => {
+      function Foo({ children }) {
+        return children;
       }
-    }
-    function Bar({children}) {
-      return <View>{children}<Text>Mom</Text></View>;
-    }
 
-    // Note that owner is not calculated for text nodes
-    // because they are not created from real elements.
-    var element = <View><Foo /></View>;
-    var tree = {
-      displayName: 'View',
-      children: [{
+      var elementBefore = <Foo><View /></Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'View',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Foo><Image /></Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'Image',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from null to a host child', () => {
+      function Foo({ children }) {
+        return children;
+      }
+
+      var elementBefore = <Foo>{null}</Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [],
+      };
+
+      var elementAfter = <Foo><View /></Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'View',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a host child to null', () => {
+      function Foo({ children }) {
+        return children;
+      }
+
+      var elementBefore = <Foo><View /></Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'View',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Foo>{null}</Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a host child to a composite child', () => {
+      function Bar() {
+        return null;
+      }
+
+      function Foo({ children }) {
+        return children;
+      }
+
+      var elementBefore = <Foo><View /></Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'View',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Foo><Bar /></Foo>;
+      var treeAfter = {
         displayName: 'Foo',
         children: [{
           displayName: 'Bar',
-          ownerDisplayName: 'Foo',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a composite child to a host child', () => {
+      function Bar() {
+        return null;
+      }
+
+      function Foo({ children }) {
+        return children;
+      }
+
+      var elementBefore = <Foo><Bar /></Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'Bar',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Foo><View /></Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'View',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from null to a composite child', () => {
+      function Bar() {
+        return null;
+      }
+
+      function Foo({ children }) {
+        return children;
+      }
+
+      var elementBefore = <Foo>{null}</Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [],
+      };
+
+      var elementAfter = <Foo><Bar /></Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'Bar',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a composite child to null', () => {
+      function Bar() {
+        return null;
+      }
+
+      function Foo({ children }) {
+        return children;
+      }
+
+      var elementBefore = <Foo><Bar /></Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'Bar',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Foo>{null}</Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+  });
+
+  describe('class component', () => {
+    it('updates with a host child', () => {
+      class Foo extends React.Component {
+        render() {
+          return this.props.children;
+        }
+      }
+
+      var elementBefore = <Foo><View /></Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'View',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Foo><Image /></Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'Image',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from null to a host child', () => {
+      class Foo extends React.Component {
+        render() {
+          return this.props.children;
+        }
+      }
+
+      var elementBefore = <Foo>{null}</Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [],
+      };
+
+      var elementAfter = <Foo><View /></Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'View',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a host child to null', () => {
+      class Foo extends React.Component {
+        render() {
+          return this.props.children;
+        }
+      }
+
+      var elementBefore = <Foo><View /></Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'View',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Foo>{null}</Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a host child to a composite child', () => {
+      class Bar extends React.Component {
+        render() {
+          return null;
+        }
+      }
+
+      class Foo extends React.Component {
+        render() {
+          return this.props.children;
+        }
+      }
+
+      var elementBefore = <Foo><View /></Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'View',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Foo><Bar /></Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'Bar',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a composite child to a host child', () => {
+      class Bar extends React.Component {
+        render() {
+          return null;
+        }
+      }
+
+      class Foo extends React.Component {
+        render() {
+          return this.props.children;
+        }
+      }
+
+      var elementBefore = <Foo><Bar /></Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'Bar',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Foo><View /></Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'View',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from null to a composite child', () => {
+      class Bar extends React.Component {
+        render() {
+          return null;
+        }
+      }
+
+      class Foo extends React.Component {
+        render() {
+          return this.props.children;
+        }
+      }
+
+      var elementBefore = <Foo>{null}</Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [],
+      };
+
+      var elementAfter = <Foo><Bar /></Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'Bar',
+          children: [],
+        }],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+
+    it('updates from a composite child to null', () => {
+      class Bar extends React.Component {
+        render() {
+          return null;
+        }
+      }
+
+      class Foo extends React.Component {
+        render() {
+          return this.props.children;
+        }
+      }
+
+      var elementBefore = <Foo><Bar /></Foo>;
+      var treeBefore = {
+        displayName: 'Foo',
+        children: [{
+          displayName: 'Bar',
+          children: [],
+        }],
+      };
+
+      var elementAfter = <Foo>{null}</Foo>;
+      var treeAfter = {
+        displayName: 'Foo',
+        children: [],
+      };
+
+      assertTreeMatches([
+        [elementBefore, treeBefore],
+        [elementAfter, treeAfter],
+      ]);
+    });
+  });
+});
+
+it('tracks owner correctly', () => {
+  class Foo extends React.Component {
+    render() {
+      return <Bar><Text>Hi.</Text></Bar>;
+    }
+  }
+  function Bar({children}) {
+    return <View>{children}<Text>Mom</Text></View>;
+  }
+
+  // Note that owner is not calculated for text nodes
+  // because they are not created from real elements.
+  var element = <View><Foo /></View>;
+  var tree = {
+    displayName: 'View',
+    children: [{
+      displayName: 'Foo',
+      children: [{
+        displayName: 'Bar',
+        ownerDisplayName: 'Foo',
+        children: [{
+          displayName: 'View',
+          ownerDisplayName: 'Bar',
           children: [{
-            displayName: 'View',
+            displayName: 'Text',
+            ownerDisplayName: 'Foo',
+            children: [{
+              displayName: 'RCText',
+              ownerDisplayName: 'Text',
+              children: [{
+                displayName: '#text',
+                text: 'Hi.',
+              }],
+            }],
+          }, {
+            displayName: 'Text',
             ownerDisplayName: 'Bar',
             children: [{
-              displayName: 'Text',
-              ownerDisplayName: 'Foo',
+              displayName: 'RCText',
+              ownerDisplayName: 'Text',
               children: [{
-                displayName: 'RCText',
-                ownerDisplayName: 'Text',
-                children: [{
-                  displayName: '#text',
-                  text: 'Hi.',
-                }],
-              }],
-            }, {
-              displayName: 'Text',
-              ownerDisplayName: 'Bar',
-              children: [{
-                displayName: 'RCText',
-                ownerDisplayName: 'Text',
-                children: [{
-                  displayName: '#text',
-                  text: 'Mom',
-                }],
+                displayName: '#text',
+                text: 'Mom',
               }],
             }],
           }],
         }],
       }],
-    };
-    assertTreeMatches([element, tree], {includeOwnerDisplayName: true});
-  });
+    }],
+  };
+  assertTreeMatches([element, tree], {includeOwnerDisplayName: true});
+});
 
-  it('purges unmounted components automatically', () => {
-    var renderBar = true;
-    var fooInstance;
-    var barInstance;
+it('purges unmounted components automatically', () => {
+  var renderBar = true;
+  var fooInstance;
+  var barInstance;
 
-    class Foo extends React.Component {
-      render() {
-        fooInstance = ReactInstanceMap.get(this);
-        return renderBar ? <Bar /> : null;
-      }
+  class Foo extends React.Component {
+    render() {
+      fooInstance = ReactInstanceMap.get(this);
+      return renderBar ? <Bar /> : null;
     }
+  }
 
-    class Bar extends React.Component {
-      render() {
-        barInstance = ReactInstanceMap.get(this);
-        return null;
-      }
+  class Bar extends React.Component {
+    render() {
+      barInstance = ReactInstanceMap.get(this);
+      return null;
     }
+  }
 
-    ReactNative.render(<Foo />, 1);
-    ReactComponentTreeTestUtils.expectTree(barInstance._debugID, {
-      displayName: 'Bar',
-      parentDisplayName: 'Foo',
-      parentID: fooInstance._debugID,
-      children: [],
-    }, 'Foo');
+  ReactNative.render(<Foo />, 1);
+  ReactComponentTreeTestUtils.expectTree(barInstance._debugID, {
+    displayName: 'Bar',
+    parentDisplayName: 'Foo',
+    parentID: fooInstance._debugID,
+    children: [],
+  }, 'Foo');
 
-    renderBar = false;
-    ReactNative.render(<Foo />, 1);
-    ReactComponentTreeTestUtils.expectTree(barInstance._debugID, {
-      displayName: 'Unknown',
-      children: [],
-      parentID: null,
-    }, 'Foo');
+  renderBar = false;
+  ReactNative.render(<Foo />, 1);
+  ReactComponentTreeTestUtils.expectTree(barInstance._debugID, {
+    displayName: 'Unknown',
+    children: [],
+    parentID: null,
+  }, 'Foo');
 
-    ReactNative.unmountComponentAtNode(1);
-    ReactComponentTreeTestUtils.expectTree(barInstance._debugID, {
-      displayName: 'Unknown',
-      children: [],
-      parentID: null,
-    }, 'Foo');
-  });
+  ReactNative.unmountComponentAtNode(1);
+  ReactComponentTreeTestUtils.expectTree(barInstance._debugID, {
+    displayName: 'Unknown',
+    children: [],
+    parentID: null,
+  }, 'Foo');
+});
 
-  it('reports update counts', () => {
-    ReactNative.render(<View />, 1);
-    var viewID = ReactComponentTreeHook.getRootIDs()[0];
-    expect(ReactComponentTreeHook.getUpdateCount(viewID)).toEqual(0);
+it('reports update counts', () => {
+  ReactNative.render(<View />, 1);
+  var viewID = ReactComponentTreeHook.getRootIDs()[0];
+  expect(ReactComponentTreeHook.getUpdateCount(viewID)).toEqual(0);
 
-    ReactNative.render(<Image />, 1);
-    var imageID = ReactComponentTreeHook.getRootIDs()[0];
-    expect(ReactComponentTreeHook.getUpdateCount(viewID)).toEqual(0);
-    expect(ReactComponentTreeHook.getUpdateCount(imageID)).toEqual(0);
+  ReactNative.render(<Image />, 1);
+  var imageID = ReactComponentTreeHook.getRootIDs()[0];
+  expect(ReactComponentTreeHook.getUpdateCount(viewID)).toEqual(0);
+  expect(ReactComponentTreeHook.getUpdateCount(imageID)).toEqual(0);
 
-    ReactNative.render(<Image />, 1);
-    expect(ReactComponentTreeHook.getUpdateCount(viewID)).toEqual(0);
-    expect(ReactComponentTreeHook.getUpdateCount(imageID)).toEqual(1);
+  ReactNative.render(<Image />, 1);
+  expect(ReactComponentTreeHook.getUpdateCount(viewID)).toEqual(0);
+  expect(ReactComponentTreeHook.getUpdateCount(imageID)).toEqual(1);
 
-    ReactNative.render(<Image />, 1);
-    expect(ReactComponentTreeHook.getUpdateCount(viewID)).toEqual(0);
-    expect(ReactComponentTreeHook.getUpdateCount(imageID)).toEqual(2);
+  ReactNative.render(<Image />, 1);
+  expect(ReactComponentTreeHook.getUpdateCount(viewID)).toEqual(0);
+  expect(ReactComponentTreeHook.getUpdateCount(imageID)).toEqual(2);
 
-    ReactNative.unmountComponentAtNode(1);
-    expect(ReactComponentTreeHook.getUpdateCount(viewID)).toEqual(0);
-    expect(ReactComponentTreeHook.getUpdateCount(imageID)).toEqual(0);
-  });
+  ReactNative.unmountComponentAtNode(1);
+  expect(ReactComponentTreeHook.getUpdateCount(viewID)).toEqual(0);
+  expect(ReactComponentTreeHook.getUpdateCount(imageID)).toEqual(0);
+});
 
-  it('does not report top-level wrapper as a root', () => {
-    ReactNative.render(<View><Image /></View>, 1);
-    expect(ReactComponentTreeTestUtils.getRootDisplayNames()).toEqual(['View']);
+it('does not report top-level wrapper as a root', () => {
+  ReactNative.render(<View><Image /></View>, 1);
+  expect(ReactComponentTreeTestUtils.getRootDisplayNames()).toEqual(['View']);
 
-    ReactNative.render(<View><Text /></View>, 1);
-    expect(ReactComponentTreeTestUtils.getRootDisplayNames()).toEqual(['View']);
+  ReactNative.render(<View><Text /></View>, 1);
+  expect(ReactComponentTreeTestUtils.getRootDisplayNames()).toEqual(['View']);
 
-    ReactNative.unmountComponentAtNode(1);
-    expect(ReactComponentTreeTestUtils.getRootDisplayNames()).toEqual([]);
-    expect(ReactComponentTreeTestUtils.getRegisteredDisplayNames()).toEqual([]);
-  });
+  ReactNative.unmountComponentAtNode(1);
+  expect(ReactComponentTreeTestUtils.getRootDisplayNames()).toEqual([]);
+  expect(ReactComponentTreeTestUtils.getRegisteredDisplayNames()).toEqual([]);
 });

--- a/src/renderers/shared/hooks/__tests__/ReactHostOperationHistoryHook-test.js
+++ b/src/renderers/shared/hooks/__tests__/ReactHostOperationHistoryHook-test.js
@@ -11,130 +11,221 @@
 
 'use strict';
 
-describe('ReactHostOperationHistoryHook', () => {
-  var React;
-  var ReactPerf;
-  var ReactDOM;
-  var ReactDOMComponentTree;
-  var ReactDOMFeatureFlags;
-  var ReactHostOperationHistoryHook;
+var React;
+var ReactPerf;
+var ReactDOM;
+var ReactDOMComponentTree;
+var ReactDOMFeatureFlags;
+var ReactHostOperationHistoryHook;
 
-  beforeEach(() => {
-    jest.resetModuleRegistry();
+beforeEach(() => {
+  jest.resetModuleRegistry();
 
-    React = require('React');
-    ReactPerf = require('ReactPerf');
-    ReactDOM = require('ReactDOM');
-    ReactDOMComponentTree = require('ReactDOMComponentTree');
-    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
-    ReactHostOperationHistoryHook = require('ReactHostOperationHistoryHook');
+  React = require('React');
+  ReactPerf = require('ReactPerf');
+  ReactDOM = require('ReactDOM');
+  ReactDOMComponentTree = require('ReactDOMComponentTree');
+  ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
+  ReactHostOperationHistoryHook = require('ReactHostOperationHistoryHook');
 
-    ReactPerf.start();
+  ReactPerf.start();
+});
+
+afterEach(() => {
+  ReactPerf.stop();
+});
+
+function assertHistoryMatches(expectedHistory) {
+  var actualHistory = ReactHostOperationHistoryHook.getHistory();
+  expect(actualHistory).toEqual(expectedHistory);
+}
+
+describe('mount', () => {
+  it('gets recorded for host roots', () => {
+    var node = document.createElement('div');
+    ReactHostOperationHistoryHook._preventClearing = true;
+    ReactDOM.render(<div><p>Hi.</p></div>, node);
+
+    var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
+    assertHistoryMatches([{
+      instanceID: inst._debugID,
+      type: 'mount',
+      payload: ReactDOMFeatureFlags.useCreateElement ?
+        'DIV' :
+        '<div data-reactroot="" data-reactid="1"><p data-reactid="2">Hi.</p></div>',
+    }]);
   });
 
-  afterEach(() => {
-    ReactPerf.stop();
+  it('gets recorded for composite roots', () => {
+    function Foo() {
+      return <div><p>Hi.</p></div>;
+    }
+    var node = document.createElement('div');
+
+    ReactHostOperationHistoryHook._preventClearing = true;
+    ReactDOM.render(<Foo />, node);
+
+    var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
+    assertHistoryMatches([{
+      instanceID: inst._debugID,
+      type: 'mount',
+      payload: ReactDOMFeatureFlags.useCreateElement ?
+        'DIV' :
+        '<div data-reactroot="" data-reactid="1">' +
+        '<p data-reactid="2">Hi.</p></div>',
+    }]);
   });
 
-  function assertHistoryMatches(expectedHistory) {
-    var actualHistory = ReactHostOperationHistoryHook.getHistory();
-    expect(actualHistory).toEqual(expectedHistory);
-  }
+  it('gets ignored for composite roots that return null', () => {
+    function Foo() {
+      return null;
+    }
+    var node = document.createElement('div');
 
-  describe('mount', () => {
-    it('gets recorded for host roots', () => {
-      var node = document.createElement('div');
-      ReactHostOperationHistoryHook._preventClearing = true;
-      ReactDOM.render(<div><p>Hi.</p></div>, node);
+    ReactHostOperationHistoryHook._preventClearing = true;
+    ReactDOM.render(<Foo />, node);
 
-      var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
+    // Empty DOM components should be invisible to hooks.
+    assertHistoryMatches([]);
+  });
+
+  it('gets recorded when a native is mounted deeply instead of null', () => {
+    var element;
+    function Foo() {
+      return element;
+    }
+
+    ReactHostOperationHistoryHook._preventClearing = true;
+
+    var node = document.createElement('div');
+    element = null;
+    ReactDOM.render(<Foo />, node);
+
+    element = <span />;
+    ReactDOM.render(<Foo />, node);
+    var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
+
+    // Since empty components should be invisible to hooks,
+    // we record a "mount" event rather than a "replace with".
+    assertHistoryMatches([{
+      instanceID: inst._debugID,
+      type: 'mount',
+      payload: 'SPAN',
+    }]);
+  });
+});
+
+describe('update styles', () => {
+  it('gets recorded during mount', () => {
+    var node = document.createElement('div');
+
+    ReactHostOperationHistoryHook._preventClearing = true;
+    ReactDOM.render(<div style={{
+      color: 'red',
+      backgroundColor: 'yellow',
+    }} />, node);
+
+    var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
+    if (ReactDOMFeatureFlags.useCreateElement) {
+      assertHistoryMatches([{
+        instanceID: inst._debugID,
+        type: 'update styles',
+        payload: {
+          color: 'red',
+          backgroundColor: 'yellow',
+        },
+      }, {
+        instanceID: inst._debugID,
+        type: 'mount',
+        payload: 'DIV',
+      }]);
+    } else {
       assertHistoryMatches([{
         instanceID: inst._debugID,
         type: 'mount',
-        payload: ReactDOMFeatureFlags.useCreateElement ?
-          'DIV' :
-          '<div data-reactroot="" data-reactid="1"><p data-reactid="2">Hi.</p></div>',
+        payload: '<div style="color:red;background-color:yellow;" ' +
+        'data-reactroot="" data-reactid="1"></div>',
       }]);
-    });
-
-    it('gets recorded for composite roots', () => {
-      function Foo() {
-        return <div><p>Hi.</p></div>;
-      }
-      var node = document.createElement('div');
-
-      ReactHostOperationHistoryHook._preventClearing = true;
-      ReactDOM.render(<Foo />, node);
-
-      var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
-      assertHistoryMatches([{
-        instanceID: inst._debugID,
-        type: 'mount',
-        payload: ReactDOMFeatureFlags.useCreateElement ?
-          'DIV' :
-          '<div data-reactroot="" data-reactid="1">' +
-          '<p data-reactid="2">Hi.</p></div>',
-      }]);
-    });
-
-    it('gets ignored for composite roots that return null', () => {
-      function Foo() {
-        return null;
-      }
-      var node = document.createElement('div');
-
-      ReactHostOperationHistoryHook._preventClearing = true;
-      ReactDOM.render(<Foo />, node);
-
-      // Empty DOM components should be invisible to hooks.
-      assertHistoryMatches([]);
-    });
-
-    it('gets recorded when a native is mounted deeply instead of null', () => {
-      var element;
-      function Foo() {
-        return element;
-      }
-
-      ReactHostOperationHistoryHook._preventClearing = true;
-
-      var node = document.createElement('div');
-      element = null;
-      ReactDOM.render(<Foo />, node);
-
-      element = <span />;
-      ReactDOM.render(<Foo />, node);
-      var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
-
-      // Since empty components should be invisible to hooks,
-      // we record a "mount" event rather than a "replace with".
-      assertHistoryMatches([{
-        instanceID: inst._debugID,
-        type: 'mount',
-        payload: 'SPAN',
-      }]);
-    });
+    }
   });
 
-  describe('update styles', () => {
+  it('gets recorded during an update', () => {
+    var node = document.createElement('div');
+    ReactDOM.render(<div />, node);
+    var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
+
+    ReactHostOperationHistoryHook._preventClearing = true;
+    ReactDOM.render(<div style={{ color: 'red' }} />, node);
+    ReactDOM.render(<div style={{
+      color: 'blue',
+      backgroundColor: 'yellow',
+    }} />, node);
+    ReactDOM.render(<div style={{ backgroundColor: 'green' }} />, node);
+    ReactDOM.render(<div />, node);
+
+    assertHistoryMatches([{
+      instanceID: inst._debugID,
+      type: 'update styles',
+      payload: { color: 'red' },
+    }, {
+      instanceID: inst._debugID,
+      type: 'update styles',
+      payload: { color: 'blue', backgroundColor: 'yellow' },
+    }, {
+      instanceID: inst._debugID,
+      type: 'update styles',
+      payload: { color: '', backgroundColor: 'green' },
+    }, {
+      instanceID: inst._debugID,
+      type: 'update styles',
+      payload: { backgroundColor: '' },
+    }]);
+  });
+
+  it('gets ignored if the styles are shallowly equal', () => {
+    var node = document.createElement('div');
+    ReactDOM.render(<div />, node);
+    var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
+
+    ReactHostOperationHistoryHook._preventClearing = true;
+    ReactDOM.render(<div style={{
+      color: 'red',
+      backgroundColor: 'yellow',
+    }} />, node);
+    ReactDOM.render(<div style={{
+      color: 'red',
+      backgroundColor: 'yellow',
+    }} />, node);
+
+    assertHistoryMatches([{
+      instanceID: inst._debugID,
+      type: 'update styles',
+      payload: {
+        color: 'red',
+        backgroundColor: 'yellow',
+      },
+    }]);
+  });
+});
+
+describe('update attribute', () => {
+  describe('simple attribute', () => {
     it('gets recorded during mount', () => {
       var node = document.createElement('div');
 
       ReactHostOperationHistoryHook._preventClearing = true;
-      ReactDOM.render(<div style={{
-        color: 'red',
-        backgroundColor: 'yellow',
-      }} />, node);
+      ReactDOM.render(<div className="rad" tabIndex={42} />, node);
 
       var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
       if (ReactDOMFeatureFlags.useCreateElement) {
         assertHistoryMatches([{
           instanceID: inst._debugID,
-          type: 'update styles',
-          payload: {
-            color: 'red',
-            backgroundColor: 'yellow',
-          },
+          type: 'update attribute',
+          payload: { className: 'rad' },
+        }, {
+          instanceID: inst._debugID,
+          type: 'update attribute',
+          payload: { tabIndex: 42 },
         }, {
           instanceID: inst._debugID,
           type: 'mount',
@@ -144,8 +235,8 @@ describe('ReactHostOperationHistoryHook', () => {
         assertHistoryMatches([{
           instanceID: inst._debugID,
           type: 'mount',
-          payload: '<div style="color:red;background-color:yellow;" ' +
-          'data-reactroot="" data-reactid="1"></div>',
+          payload: '<div class="rad" tabindex="42" data-reactroot="" ' +
+          'data-reactid="1"></div>',
         }]);
       }
     });
@@ -156,190 +247,65 @@ describe('ReactHostOperationHistoryHook', () => {
       var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
       ReactHostOperationHistoryHook._preventClearing = true;
-      ReactDOM.render(<div style={{ color: 'red' }} />, node);
-      ReactDOM.render(<div style={{
-        color: 'blue',
-        backgroundColor: 'yellow',
-      }} />, node);
-      ReactDOM.render(<div style={{ backgroundColor: 'green' }} />, node);
-      ReactDOM.render(<div />, node);
+      ReactDOM.render(<div className="rad" />, node);
+      ReactDOM.render(<div className="mad" tabIndex={42} />, node);
+      ReactDOM.render(<div tabIndex={43} />, node);
 
       assertHistoryMatches([{
         instanceID: inst._debugID,
-        type: 'update styles',
-        payload: { color: 'red' },
+        type: 'update attribute',
+        payload: { className: 'rad' },
       }, {
         instanceID: inst._debugID,
-        type: 'update styles',
-        payload: { color: 'blue', backgroundColor: 'yellow' },
+        type: 'update attribute',
+        payload: { className: 'mad' },
       }, {
         instanceID: inst._debugID,
-        type: 'update styles',
-        payload: { color: '', backgroundColor: 'green' },
+        type: 'update attribute',
+        payload: { tabIndex: 42 },
       }, {
         instanceID: inst._debugID,
-        type: 'update styles',
-        payload: { backgroundColor: '' },
+        type: 'remove attribute',
+        payload: 'className',
+      }, {
+        instanceID: inst._debugID,
+        type: 'update attribute',
+        payload: { tabIndex: 43 },
       }]);
     });
+  });
 
-    it('gets ignored if the styles are shallowly equal', () => {
+  describe('attribute that gets removed with certain values', () => {
+    it('gets recorded as a removal during an update', () => {
       var node = document.createElement('div');
       ReactDOM.render(<div />, node);
       var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
       ReactHostOperationHistoryHook._preventClearing = true;
-      ReactDOM.render(<div style={{
-        color: 'red',
-        backgroundColor: 'yellow',
-      }} />, node);
-      ReactDOM.render(<div style={{
-        color: 'red',
-        backgroundColor: 'yellow',
-      }} />, node);
+      ReactDOM.render(<div disabled={true} />, node);
+      ReactDOM.render(<div disabled={false} />, node);
 
       assertHistoryMatches([{
         instanceID: inst._debugID,
-        type: 'update styles',
-        payload: {
-          color: 'red',
-          backgroundColor: 'yellow',
-        },
+        type: 'update attribute',
+        payload: { disabled: true },
+      }, {
+        instanceID: inst._debugID,
+        type: 'remove attribute',
+        payload: 'disabled',
       }]);
     });
   });
 
-  describe('update attribute', () => {
-    describe('simple attribute', () => {
-      it('gets recorded during mount', () => {
-        var node = document.createElement('div');
+  describe('custom attribute', () => {
+    it('gets recorded during mount', () => {
+      var node = document.createElement('div');
 
-        ReactHostOperationHistoryHook._preventClearing = true;
-        ReactDOM.render(<div className="rad" tabIndex={42} />, node);
+      ReactHostOperationHistoryHook._preventClearing = true;
+      ReactDOM.render(<div data-x="rad" data-y={42} />, node);
 
-        var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
-        if (ReactDOMFeatureFlags.useCreateElement) {
-          assertHistoryMatches([{
-            instanceID: inst._debugID,
-            type: 'update attribute',
-            payload: { className: 'rad' },
-          }, {
-            instanceID: inst._debugID,
-            type: 'update attribute',
-            payload: { tabIndex: 42 },
-          }, {
-            instanceID: inst._debugID,
-            type: 'mount',
-            payload: 'DIV',
-          }]);
-        } else {
-          assertHistoryMatches([{
-            instanceID: inst._debugID,
-            type: 'mount',
-            payload: '<div class="rad" tabindex="42" data-reactroot="" ' +
-            'data-reactid="1"></div>',
-          }]);
-        }
-      });
-
-      it('gets recorded during an update', () => {
-        var node = document.createElement('div');
-        ReactDOM.render(<div />, node);
-        var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
-
-        ReactHostOperationHistoryHook._preventClearing = true;
-        ReactDOM.render(<div className="rad" />, node);
-        ReactDOM.render(<div className="mad" tabIndex={42} />, node);
-        ReactDOM.render(<div tabIndex={43} />, node);
-
-        assertHistoryMatches([{
-          instanceID: inst._debugID,
-          type: 'update attribute',
-          payload: { className: 'rad' },
-        }, {
-          instanceID: inst._debugID,
-          type: 'update attribute',
-          payload: { className: 'mad' },
-        }, {
-          instanceID: inst._debugID,
-          type: 'update attribute',
-          payload: { tabIndex: 42 },
-        }, {
-          instanceID: inst._debugID,
-          type: 'remove attribute',
-          payload: 'className',
-        }, {
-          instanceID: inst._debugID,
-          type: 'update attribute',
-          payload: { tabIndex: 43 },
-        }]);
-      });
-    });
-
-    describe('attribute that gets removed with certain values', () => {
-      it('gets recorded as a removal during an update', () => {
-        var node = document.createElement('div');
-        ReactDOM.render(<div />, node);
-        var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
-
-        ReactHostOperationHistoryHook._preventClearing = true;
-        ReactDOM.render(<div disabled={true} />, node);
-        ReactDOM.render(<div disabled={false} />, node);
-
-        assertHistoryMatches([{
-          instanceID: inst._debugID,
-          type: 'update attribute',
-          payload: { disabled: true },
-        }, {
-          instanceID: inst._debugID,
-          type: 'remove attribute',
-          payload: 'disabled',
-        }]);
-      });
-    });
-
-    describe('custom attribute', () => {
-      it('gets recorded during mount', () => {
-        var node = document.createElement('div');
-
-        ReactHostOperationHistoryHook._preventClearing = true;
-        ReactDOM.render(<div data-x="rad" data-y={42} />, node);
-
-        var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
-        if (ReactDOMFeatureFlags.useCreateElement) {
-          assertHistoryMatches([{
-            instanceID: inst._debugID,
-            type: 'update attribute',
-            payload: { 'data-x': 'rad' },
-          }, {
-            instanceID: inst._debugID,
-            type: 'update attribute',
-            payload: { 'data-y': 42 },
-          }, {
-            instanceID: inst._debugID,
-            type: 'mount',
-            payload: 'DIV',
-          }]);
-        } else {
-          assertHistoryMatches([{
-            instanceID: inst._debugID,
-            type: 'mount',
-            payload: '<div data-x="rad" data-y="42" data-reactroot="" ' +
-            'data-reactid="1"></div>',
-          }]);
-        }
-      });
-
-      it('gets recorded during an update', () => {
-        var node = document.createElement('div');
-        ReactDOM.render(<div />, node);
-        var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
-
-        ReactHostOperationHistoryHook._preventClearing = true;
-        ReactDOM.render(<div data-x="rad" />, node);
-        ReactDOM.render(<div data-x="mad" data-y={42} />, node);
-        ReactDOM.render(<div data-y={43} />, node);
-
+      var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
+      if (ReactDOMFeatureFlags.useCreateElement) {
         assertHistoryMatches([{
           instanceID: inst._debugID,
           type: 'update attribute',
@@ -347,65 +313,65 @@ describe('ReactHostOperationHistoryHook', () => {
         }, {
           instanceID: inst._debugID,
           type: 'update attribute',
-          payload: { 'data-x': 'mad' },
-        }, {
-          instanceID: inst._debugID,
-          type: 'update attribute',
           payload: { 'data-y': 42 },
         }, {
           instanceID: inst._debugID,
-          type: 'remove attribute',
-          payload: 'data-x',
-        }, {
-          instanceID: inst._debugID,
-          type: 'update attribute',
-          payload: { 'data-y': 43 },
+          type: 'mount',
+          payload: 'DIV',
         }]);
-      });
+      } else {
+        assertHistoryMatches([{
+          instanceID: inst._debugID,
+          type: 'mount',
+          payload: '<div data-x="rad" data-y="42" data-reactroot="" ' +
+          'data-reactid="1"></div>',
+        }]);
+      }
     });
 
-    describe('attribute on a web component', () => {
-      it('gets recorded during mount', () => {
-        var node = document.createElement('div');
+    it('gets recorded during an update', () => {
+      var node = document.createElement('div');
+      ReactDOM.render(<div />, node);
+      var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
-        ReactHostOperationHistoryHook._preventClearing = true;
-        ReactDOM.render(<my-component className="rad" tabIndex={42} />, node);
+      ReactHostOperationHistoryHook._preventClearing = true;
+      ReactDOM.render(<div data-x="rad" />, node);
+      ReactDOM.render(<div data-x="mad" data-y={42} />, node);
+      ReactDOM.render(<div data-y={43} />, node);
 
-        var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
-        if (ReactDOMFeatureFlags.useCreateElement) {
-          assertHistoryMatches([{
-            instanceID: inst._debugID,
-            type: 'update attribute',
-            payload: { className: 'rad' },
-          }, {
-            instanceID: inst._debugID,
-            type: 'update attribute',
-            payload: { tabIndex: 42 },
-          }, {
-            instanceID: inst._debugID,
-            type: 'mount',
-            payload: 'MY-COMPONENT',
-          }]);
-        } else {
-          assertHistoryMatches([{
-            instanceID: inst._debugID,
-            type: 'mount',
-            payload: '<my-component className="rad" tabIndex="42" ' +
-            'data-reactroot="" data-reactid="1"></my-component>',
-          }]);
-        }
-      });
+      assertHistoryMatches([{
+        instanceID: inst._debugID,
+        type: 'update attribute',
+        payload: { 'data-x': 'rad' },
+      }, {
+        instanceID: inst._debugID,
+        type: 'update attribute',
+        payload: { 'data-x': 'mad' },
+      }, {
+        instanceID: inst._debugID,
+        type: 'update attribute',
+        payload: { 'data-y': 42 },
+      }, {
+        instanceID: inst._debugID,
+        type: 'remove attribute',
+        payload: 'data-x',
+      }, {
+        instanceID: inst._debugID,
+        type: 'update attribute',
+        payload: { 'data-y': 43 },
+      }]);
+    });
+  });
 
-      it('gets recorded during an update', () => {
-        var node = document.createElement('div');
-        ReactDOM.render(<my-component />, node);
-        var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
+  describe('attribute on a web component', () => {
+    it('gets recorded during mount', () => {
+      var node = document.createElement('div');
 
-        ReactHostOperationHistoryHook._preventClearing = true;
-        ReactDOM.render(<my-component className="rad" />, node);
-        ReactDOM.render(<my-component className="mad" tabIndex={42} />, node);
-        ReactDOM.render(<my-component tabIndex={43} />, node);
+      ReactHostOperationHistoryHook._preventClearing = true;
+      ReactDOM.render(<my-component className="rad" tabIndex={42} />, node);
 
+      var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
+      if (ReactDOMFeatureFlags.useCreateElement) {
         assertHistoryMatches([{
           instanceID: inst._debugID,
           type: 'update attribute',
@@ -413,225 +379,85 @@ describe('ReactHostOperationHistoryHook', () => {
         }, {
           instanceID: inst._debugID,
           type: 'update attribute',
-          payload: { className: 'mad' },
-        }, {
-          instanceID: inst._debugID,
-          type: 'update attribute',
           payload: { tabIndex: 42 },
         }, {
           instanceID: inst._debugID,
-          type: 'remove attribute',
-          payload: 'className',
-        }, {
-          instanceID: inst._debugID,
-          type: 'update attribute',
-          payload: { tabIndex: 43 },
+          type: 'mount',
+          payload: 'MY-COMPONENT',
         }]);
-      });
-    });
-  });
-
-  describe('replace text', () => {
-    describe('text content', () => {
-      it('gets recorded during an update from text content', () => {
-        var node = document.createElement('div');
-        ReactDOM.render(<div>Hi.</div>, node);
-        var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
-
-        ReactHostOperationHistoryHook._preventClearing = true;
-        ReactDOM.render(<div>Bye.</div>, node);
-
+      } else {
         assertHistoryMatches([{
           instanceID: inst._debugID,
-          type: 'replace text',
-          payload: 'Bye.',
+          type: 'mount',
+          payload: '<my-component className="rad" tabIndex="42" ' +
+          'data-reactroot="" data-reactid="1"></my-component>',
         }]);
-      });
-
-      it('gets recorded during an update from html', () => {
-        var node = document.createElement('div');
-        ReactDOM.render(<div dangerouslySetInnerHTML={{__html: 'Hi.'}} />, node);
-        var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
-
-        ReactHostOperationHistoryHook._preventClearing = true;
-        ReactDOM.render(<div>Bye.</div>, node);
-
-        assertHistoryMatches([{
-          instanceID: inst._debugID,
-          type: 'replace text',
-          payload: 'Bye.',
-        }]);
-      });
-
-      it('gets recorded during an update from children', () => {
-        var node = document.createElement('div');
-        ReactDOM.render(<div><span /><p /></div>, node);
-        var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
-
-        ReactHostOperationHistoryHook._preventClearing = true;
-        ReactDOM.render(<div>Bye.</div>, node);
-
-        assertHistoryMatches([{
-          instanceID: inst._debugID,
-          type: 'remove child',
-          payload: {fromIndex: 0},
-        }, {
-          instanceID: inst._debugID,
-          type: 'remove child',
-          payload: {fromIndex: 1},
-        }, {
-          instanceID: inst._debugID,
-          type: 'replace text',
-          payload: 'Bye.',
-        }]);
-      });
-
-      it('gets ignored if new text is equal', () => {
-        var node = document.createElement('div');
-        ReactDOM.render(<div>Hi.</div>, node);
-
-        ReactHostOperationHistoryHook._preventClearing = true;
-        ReactDOM.render(<div>Hi.</div>, node);
-
-        assertHistoryMatches([]);
-      });
-    });
-
-    describe('text node', () => {
-      it('gets recorded during an update', () => {
-        var node = document.createElement('div');
-        ReactDOM.render(<div>{'Hi.'}{42}</div>, node);
-        var inst1 = ReactDOMComponentTree.getInstanceFromNode(node.firstChild.childNodes[0]);
-        var inst2 = ReactDOMComponentTree.getInstanceFromNode(node.firstChild.childNodes[3]);
-
-        ReactHostOperationHistoryHook._preventClearing = true;
-        ReactDOM.render(<div>{'Bye.'}{43}</div>, node);
-
-        assertHistoryMatches([{
-          instanceID: inst1._debugID,
-          type: 'replace text',
-          payload: 'Bye.',
-        }, {
-          instanceID: inst2._debugID,
-          type: 'replace text',
-          payload: '43',
-        }]);
-      });
-
-      it('gets ignored if new text is equal', () => {
-        var node = document.createElement('div');
-        ReactDOM.render(<div>{'Hi.'}{42}</div>, node);
-
-        ReactHostOperationHistoryHook._preventClearing = true;
-        ReactDOM.render(<div>{'Hi.'}{42}</div>, node);
-
-        assertHistoryMatches([]);
-      });
-    });
-  });
-
-  describe('replace with', () => {
-    it('gets recorded when composite renders to a different type', () => {
-      var element;
-      function Foo() {
-        return element;
       }
+    });
 
+    it('gets recorded during an update', () => {
       var node = document.createElement('div');
-      element = <div />;
-      ReactDOM.render(<Foo />, node);
+      ReactDOM.render(<my-component />, node);
       var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
-      element = <span />;
-
       ReactHostOperationHistoryHook._preventClearing = true;
-      ReactDOM.render(<Foo />, node);
+      ReactDOM.render(<my-component className="rad" />, node);
+      ReactDOM.render(<my-component className="mad" tabIndex={42} />, node);
+      ReactDOM.render(<my-component tabIndex={43} />, node);
 
       assertHistoryMatches([{
         instanceID: inst._debugID,
-        type: 'replace with',
-        payload: 'SPAN',
-      }]);
-    });
-
-    it('gets recorded when composite renders to null after a native', () => {
-      var element;
-      function Foo() {
-        return element;
-      }
-
-      var node = document.createElement('div');
-      element = <span />;
-      ReactDOM.render(<Foo />, node);
-
-      var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
-      element = null;
-
-      ReactHostOperationHistoryHook._preventClearing = true;
-      ReactDOM.render(<Foo />, node);
-
-      assertHistoryMatches([{
+        type: 'update attribute',
+        payload: { className: 'rad' },
+      }, {
         instanceID: inst._debugID,
-        type: 'replace with',
-        payload: '#comment',
+        type: 'update attribute',
+        payload: { className: 'mad' },
+      }, {
+        instanceID: inst._debugID,
+        type: 'update attribute',
+        payload: { tabIndex: 42 },
+      }, {
+        instanceID: inst._debugID,
+        type: 'remove attribute',
+        payload: 'className',
+      }, {
+        instanceID: inst._debugID,
+        type: 'update attribute',
+        payload: { tabIndex: 43 },
       }]);
-    });
-
-    it('gets ignored if the type has not changed', () => {
-      var element;
-      function Foo() {
-        return element;
-      }
-
-      var node = document.createElement('div');
-      element = <div />;
-      ReactDOM.render(<Foo />, node);
-
-      element = <div />;
-
-      ReactHostOperationHistoryHook._preventClearing = true;
-      ReactDOM.render(<Foo />, node);
-
-      assertHistoryMatches([]);
     });
   });
+});
 
-  describe('replace children', () => {
+describe('replace text', () => {
+  describe('text content', () => {
     it('gets recorded during an update from text content', () => {
       var node = document.createElement('div');
       ReactDOM.render(<div>Hi.</div>, node);
       var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
       ReactHostOperationHistoryHook._preventClearing = true;
-      ReactDOM.render(
-        <div dangerouslySetInnerHTML={{__html: 'Bye.'}} />,
-        node
-      );
+      ReactDOM.render(<div>Bye.</div>, node);
 
       assertHistoryMatches([{
         instanceID: inst._debugID,
-        type: 'replace children',
+        type: 'replace text',
         payload: 'Bye.',
       }]);
     });
 
     it('gets recorded during an update from html', () => {
       var node = document.createElement('div');
-      ReactDOM.render(
-        <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />,
-        node
-      );
+      ReactDOM.render(<div dangerouslySetInnerHTML={{__html: 'Hi.'}} />, node);
       var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
       ReactHostOperationHistoryHook._preventClearing = true;
-      ReactDOM.render(
-        <div dangerouslySetInnerHTML={{__html: 'Bye.'}} />,
-        node
-      );
+      ReactDOM.render(<div>Bye.</div>, node);
 
       assertHistoryMatches([{
         instanceID: inst._debugID,
-        type: 'replace children',
+        type: 'replace text',
         payload: 'Bye.',
       }]);
     });
@@ -642,10 +468,7 @@ describe('ReactHostOperationHistoryHook', () => {
       var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
       ReactHostOperationHistoryHook._preventClearing = true;
-      ReactDOM.render(
-        <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />,
-        node
-      );
+      ReactDOM.render(<div>Bye.</div>, node);
 
       assertHistoryMatches([{
         instanceID: inst._debugID,
@@ -657,76 +480,251 @@ describe('ReactHostOperationHistoryHook', () => {
         payload: {fromIndex: 1},
       }, {
         instanceID: inst._debugID,
-        type: 'replace children',
-        payload: 'Hi.',
+        type: 'replace text',
+        payload: 'Bye.',
       }]);
     });
 
-    it('gets ignored if new html is equal', () => {
+    it('gets ignored if new text is equal', () => {
       var node = document.createElement('div');
-      ReactDOM.render(
-        <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />,
-        node
-      );
+      ReactDOM.render(<div>Hi.</div>, node);
 
       ReactHostOperationHistoryHook._preventClearing = true;
-      ReactDOM.render(
-        <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />,
-        node
-      );
+      ReactDOM.render(<div>Hi.</div>, node);
 
       assertHistoryMatches([]);
     });
   });
 
-  describe('insert child', () => {
-    it('gets reported when a child is inserted', () => {
+  describe('text node', () => {
+    it('gets recorded during an update', () => {
       var node = document.createElement('div');
-      ReactDOM.render(<div><span /></div>, node);
-      var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
+      ReactDOM.render(<div>{'Hi.'}{42}</div>, node);
+      var inst1 = ReactDOMComponentTree.getInstanceFromNode(node.firstChild.childNodes[0]);
+      var inst2 = ReactDOMComponentTree.getInstanceFromNode(node.firstChild.childNodes[3]);
 
       ReactHostOperationHistoryHook._preventClearing = true;
-      ReactDOM.render(<div><span /><p /></div>, node);
+      ReactDOM.render(<div>{'Bye.'}{43}</div>, node);
 
       assertHistoryMatches([{
-        instanceID: inst._debugID,
-        type: 'insert child',
-        payload: {toIndex: 1, content: 'P'},
+        instanceID: inst1._debugID,
+        type: 'replace text',
+        payload: 'Bye.',
+      }, {
+        instanceID: inst2._debugID,
+        type: 'replace text',
+        payload: '43',
       }]);
+    });
+
+    it('gets ignored if new text is equal', () => {
+      var node = document.createElement('div');
+      ReactDOM.render(<div>{'Hi.'}{42}</div>, node);
+
+      ReactHostOperationHistoryHook._preventClearing = true;
+      ReactDOM.render(<div>{'Hi.'}{42}</div>, node);
+
+      assertHistoryMatches([]);
     });
   });
+});
 
-  describe('move child', () => {
-    it('gets reported when a child is inserted', () => {
-      var node = document.createElement('div');
-      ReactDOM.render(<div><span key="a" /><p key="b" /></div>, node);
-      var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
+describe('replace with', () => {
+  it('gets recorded when composite renders to a different type', () => {
+    var element;
+    function Foo() {
+      return element;
+    }
 
-      ReactHostOperationHistoryHook._preventClearing = true;
-      ReactDOM.render(<div><p key="b" /><span key="a" /></div>, node);
+    var node = document.createElement('div');
+    element = <div />;
+    ReactDOM.render(<Foo />, node);
+    var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
 
-      assertHistoryMatches([{
-        instanceID: inst._debugID,
-        type: 'move child',
-        payload: {fromIndex: 0, toIndex: 1},
-      }]);
-    });
+    element = <span />;
+
+    ReactHostOperationHistoryHook._preventClearing = true;
+    ReactDOM.render(<Foo />, node);
+
+    assertHistoryMatches([{
+      instanceID: inst._debugID,
+      type: 'replace with',
+      payload: 'SPAN',
+    }]);
   });
 
-  describe('remove child', () => {
-    it('gets reported when a child is removed', () => {
-      var node = document.createElement('div');
-      ReactDOM.render(<div><span key="a" /><p key="b" /></div>, node);
-      var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
+  it('gets recorded when composite renders to null after a native', () => {
+    var element;
+    function Foo() {
+      return element;
+    }
 
-      ReactHostOperationHistoryHook._preventClearing = true;
-      ReactDOM.render(<div><span key="a" /></div>, node);
+    var node = document.createElement('div');
+    element = <span />;
+    ReactDOM.render(<Foo />, node);
 
-      assertHistoryMatches([{
-        instanceID: inst._debugID,
-        type: 'remove child',
-        payload: {fromIndex: 1},
-      }]);
-    });
+    var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
+    element = null;
+
+    ReactHostOperationHistoryHook._preventClearing = true;
+    ReactDOM.render(<Foo />, node);
+
+    assertHistoryMatches([{
+      instanceID: inst._debugID,
+      type: 'replace with',
+      payload: '#comment',
+    }]);
+  });
+
+  it('gets ignored if the type has not changed', () => {
+    var element;
+    function Foo() {
+      return element;
+    }
+
+    var node = document.createElement('div');
+    element = <div />;
+    ReactDOM.render(<Foo />, node);
+
+    element = <div />;
+
+    ReactHostOperationHistoryHook._preventClearing = true;
+    ReactDOM.render(<Foo />, node);
+
+    assertHistoryMatches([]);
+  });
+});
+
+describe('replace children', () => {
+  it('gets recorded during an update from text content', () => {
+    var node = document.createElement('div');
+    ReactDOM.render(<div>Hi.</div>, node);
+    var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
+
+    ReactHostOperationHistoryHook._preventClearing = true;
+    ReactDOM.render(
+      <div dangerouslySetInnerHTML={{__html: 'Bye.'}} />,
+      node
+    );
+
+    assertHistoryMatches([{
+      instanceID: inst._debugID,
+      type: 'replace children',
+      payload: 'Bye.',
+    }]);
+  });
+
+  it('gets recorded during an update from html', () => {
+    var node = document.createElement('div');
+    ReactDOM.render(
+      <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />,
+      node
+    );
+    var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
+
+    ReactHostOperationHistoryHook._preventClearing = true;
+    ReactDOM.render(
+      <div dangerouslySetInnerHTML={{__html: 'Bye.'}} />,
+      node
+    );
+
+    assertHistoryMatches([{
+      instanceID: inst._debugID,
+      type: 'replace children',
+      payload: 'Bye.',
+    }]);
+  });
+
+  it('gets recorded during an update from children', () => {
+    var node = document.createElement('div');
+    ReactDOM.render(<div><span /><p /></div>, node);
+    var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
+
+    ReactHostOperationHistoryHook._preventClearing = true;
+    ReactDOM.render(
+      <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />,
+      node
+    );
+
+    assertHistoryMatches([{
+      instanceID: inst._debugID,
+      type: 'remove child',
+      payload: {fromIndex: 0},
+    }, {
+      instanceID: inst._debugID,
+      type: 'remove child',
+      payload: {fromIndex: 1},
+    }, {
+      instanceID: inst._debugID,
+      type: 'replace children',
+      payload: 'Hi.',
+    }]);
+  });
+
+  it('gets ignored if new html is equal', () => {
+    var node = document.createElement('div');
+    ReactDOM.render(
+      <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />,
+      node
+    );
+
+    ReactHostOperationHistoryHook._preventClearing = true;
+    ReactDOM.render(
+      <div dangerouslySetInnerHTML={{__html: 'Hi.'}} />,
+      node
+    );
+
+    assertHistoryMatches([]);
+  });
+});
+
+describe('insert child', () => {
+  it('gets reported when a child is inserted', () => {
+    var node = document.createElement('div');
+    ReactDOM.render(<div><span /></div>, node);
+    var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
+
+    ReactHostOperationHistoryHook._preventClearing = true;
+    ReactDOM.render(<div><span /><p /></div>, node);
+
+    assertHistoryMatches([{
+      instanceID: inst._debugID,
+      type: 'insert child',
+      payload: {toIndex: 1, content: 'P'},
+    }]);
+  });
+});
+
+describe('move child', () => {
+  it('gets reported when a child is inserted', () => {
+    var node = document.createElement('div');
+    ReactDOM.render(<div><span key="a" /><p key="b" /></div>, node);
+    var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
+
+    ReactHostOperationHistoryHook._preventClearing = true;
+    ReactDOM.render(<div><p key="b" /><span key="a" /></div>, node);
+
+    assertHistoryMatches([{
+      instanceID: inst._debugID,
+      type: 'move child',
+      payload: {fromIndex: 0, toIndex: 1},
+    }]);
+  });
+});
+
+describe('remove child', () => {
+  it('gets reported when a child is removed', () => {
+    var node = document.createElement('div');
+    ReactDOM.render(<div><span key="a" /><p key="b" /></div>, node);
+    var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
+
+    ReactHostOperationHistoryHook._preventClearing = true;
+    ReactDOM.render(<div><span key="a" /></div>, node);
+
+    assertHistoryMatches([{
+      instanceID: inst._debugID,
+      type: 'remove child',
+      payload: {fromIndex: 1},
+    }]);
   });
 });

--- a/src/renderers/shared/stack/event/__tests__/EventPluginHub-test.js
+++ b/src/renderers/shared/stack/event/__tests__/EventPluginHub-test.js
@@ -13,22 +13,20 @@
 
 jest.mock('isEventSupported');
 
-describe('EventPluginHub', function() {
-  var EventPluginHub;
-  var isEventSupported;
+var EventPluginHub;
+var isEventSupported;
 
-  beforeEach(function() {
-    jest.resetModuleRegistry();
-    EventPluginHub = require('EventPluginHub');
-    isEventSupported = require('isEventSupported');
-    isEventSupported.mockReturnValueOnce(false);
-  });
+beforeEach(function() {
+  jest.resetModuleRegistry();
+  EventPluginHub = require('EventPluginHub');
+  isEventSupported = require('isEventSupported');
+  isEventSupported.mockReturnValueOnce(false);
+});
 
-  it('should prevent non-function listeners', function() {
-    expect(function() {
-      EventPluginHub.putListener(1, 'onClick', 'not a function');
-    }).toThrowError(
-      'Expected onClick listener to be a function, instead got type string'
-    );
-  });
+it('should prevent non-function listeners', function() {
+  expect(function() {
+    EventPluginHub.putListener(1, 'onClick', 'not a function');
+  }).toThrowError(
+    'Expected onClick listener to be a function, instead got type string'
+  );
 });

--- a/src/renderers/shared/stack/event/__tests__/EventPluginRegistry-test.js
+++ b/src/renderers/shared/stack/event/__tests__/EventPluginRegistry-test.js
@@ -12,253 +12,250 @@
 'use strict';
 
 
-describe('EventPluginRegistry', function() {
-  var EventPluginRegistry;
-  var createPlugin;
+var EventPluginRegistry;
+var createPlugin;
 
-  beforeEach(function() {
-    EventPluginRegistry = require('EventPluginRegistry');
-    EventPluginRegistry._resetEventPlugins();
+beforeEach(function() {
+  EventPluginRegistry = require('EventPluginRegistry');
+  EventPluginRegistry._resetEventPlugins();
 
-    createPlugin = function(properties) {
-      return Object.assign({extractEvents: function() {}}, properties);
-    };
+  createPlugin = function(properties) {
+    return Object.assign({extractEvents: function() {}}, properties);
+  };
+});
+
+it('should be able to inject ordering before plugins', function() {
+  var OnePlugin = createPlugin();
+  var TwoPlugin = createPlugin();
+  var ThreePlugin = createPlugin();
+
+  EventPluginRegistry.injectEventPluginOrder(['one', 'two', 'three']);
+  EventPluginRegistry.injectEventPluginsByName({
+    one: OnePlugin,
+    two: TwoPlugin,
+  });
+  EventPluginRegistry.injectEventPluginsByName({
+    three: ThreePlugin,
   });
 
-  it('should be able to inject ordering before plugins', function() {
-    var OnePlugin = createPlugin();
-    var TwoPlugin = createPlugin();
-    var ThreePlugin = createPlugin();
+  expect(EventPluginRegistry.plugins.length).toBe(3);
+  expect(EventPluginRegistry.plugins[0]).toBe(OnePlugin);
+  expect(EventPluginRegistry.plugins[1]).toBe(TwoPlugin);
+  expect(EventPluginRegistry.plugins[2]).toBe(ThreePlugin);
+});
 
-    EventPluginRegistry.injectEventPluginOrder(['one', 'two', 'three']);
+it('should be able to inject plugins before and after ordering', function() {
+  var OnePlugin = createPlugin();
+  var TwoPlugin = createPlugin();
+  var ThreePlugin = createPlugin();
+
+  EventPluginRegistry.injectEventPluginsByName({
+    one: OnePlugin,
+    two: TwoPlugin,
+  });
+  EventPluginRegistry.injectEventPluginOrder(['one', 'two', 'three']);
+  EventPluginRegistry.injectEventPluginsByName({
+    three: ThreePlugin,
+  });
+
+  expect(EventPluginRegistry.plugins.length).toBe(3);
+  expect(EventPluginRegistry.plugins[0]).toBe(OnePlugin);
+  expect(EventPluginRegistry.plugins[1]).toBe(TwoPlugin);
+  expect(EventPluginRegistry.plugins[2]).toBe(ThreePlugin);
+});
+
+it('should be able to inject repeated plugins and out-of-order', function() {
+  var OnePlugin = createPlugin();
+  var TwoPlugin = createPlugin();
+  var ThreePlugin = createPlugin();
+
+  EventPluginRegistry.injectEventPluginsByName({
+    one: OnePlugin,
+    three: ThreePlugin,
+  });
+  EventPluginRegistry.injectEventPluginOrder(['one', 'two', 'three']);
+  EventPluginRegistry.injectEventPluginsByName({
+    two: TwoPlugin,
+    three: ThreePlugin,
+  });
+
+  expect(EventPluginRegistry.plugins.length).toBe(3);
+  expect(EventPluginRegistry.plugins[0]).toBe(OnePlugin);
+  expect(EventPluginRegistry.plugins[1]).toBe(TwoPlugin);
+  expect(EventPluginRegistry.plugins[2]).toBe(ThreePlugin);
+});
+
+it('should throw if plugin does not implement `extractEvents`', function() {
+  var BadPlugin = {};
+
+  EventPluginRegistry.injectEventPluginOrder(['bad']);
+
+  expect(function() {
+    EventPluginRegistry.injectEventPluginsByName({
+      bad: BadPlugin,
+    });
+  }).toThrowError(
+    'EventPluginRegistry: Event plugins must implement an `extractEvents` ' +
+    'method, but `bad` does not.'
+  );
+});
+
+it('should throw if plugin does not exist in ordering', function() {
+  var OnePlugin = createPlugin();
+  var RandomPlugin = createPlugin();
+
+  EventPluginRegistry.injectEventPluginOrder(['one']);
+
+  expect(function() {
     EventPluginRegistry.injectEventPluginsByName({
       one: OnePlugin,
-      two: TwoPlugin,
+      random: RandomPlugin,
     });
-    EventPluginRegistry.injectEventPluginsByName({
-      three: ThreePlugin,
-    });
+  }).toThrowError(
+    'EventPluginRegistry: Cannot inject event plugins that do not exist ' +
+    'in the plugin ordering, `random`.'
+  );
+});
 
-    expect(EventPluginRegistry.plugins.length).toBe(3);
-    expect(EventPluginRegistry.plugins[0]).toBe(OnePlugin);
-    expect(EventPluginRegistry.plugins[1]).toBe(TwoPlugin);
-    expect(EventPluginRegistry.plugins[2]).toBe(ThreePlugin);
-  });
+it('should throw if ordering is injected more than once', function() {
+  var pluginOrdering = [];
 
-  it('should be able to inject plugins before and after ordering', function() {
-    var OnePlugin = createPlugin();
-    var TwoPlugin = createPlugin();
-    var ThreePlugin = createPlugin();
+  EventPluginRegistry.injectEventPluginOrder(pluginOrdering);
 
-    EventPluginRegistry.injectEventPluginsByName({
-      one: OnePlugin,
-      two: TwoPlugin,
-    });
-    EventPluginRegistry.injectEventPluginOrder(['one', 'two', 'three']);
-    EventPluginRegistry.injectEventPluginsByName({
-      three: ThreePlugin,
-    });
-
-    expect(EventPluginRegistry.plugins.length).toBe(3);
-    expect(EventPluginRegistry.plugins[0]).toBe(OnePlugin);
-    expect(EventPluginRegistry.plugins[1]).toBe(TwoPlugin);
-    expect(EventPluginRegistry.plugins[2]).toBe(ThreePlugin);
-  });
-
-  it('should be able to inject repeated plugins and out-of-order', function() {
-    var OnePlugin = createPlugin();
-    var TwoPlugin = createPlugin();
-    var ThreePlugin = createPlugin();
-
-    EventPluginRegistry.injectEventPluginsByName({
-      one: OnePlugin,
-      three: ThreePlugin,
-    });
-    EventPluginRegistry.injectEventPluginOrder(['one', 'two', 'three']);
-    EventPluginRegistry.injectEventPluginsByName({
-      two: TwoPlugin,
-      three: ThreePlugin,
-    });
-
-    expect(EventPluginRegistry.plugins.length).toBe(3);
-    expect(EventPluginRegistry.plugins[0]).toBe(OnePlugin);
-    expect(EventPluginRegistry.plugins[1]).toBe(TwoPlugin);
-    expect(EventPluginRegistry.plugins[2]).toBe(ThreePlugin);
-  });
-
-  it('should throw if plugin does not implement `extractEvents`', function() {
-    var BadPlugin = {};
-
-    EventPluginRegistry.injectEventPluginOrder(['bad']);
-
-    expect(function() {
-      EventPluginRegistry.injectEventPluginsByName({
-        bad: BadPlugin,
-      });
-    }).toThrowError(
-      'EventPluginRegistry: Event plugins must implement an `extractEvents` ' +
-      'method, but `bad` does not.'
-    );
-  });
-
-  it('should throw if plugin does not exist in ordering', function() {
-    var OnePlugin = createPlugin();
-    var RandomPlugin = createPlugin();
-
-    EventPluginRegistry.injectEventPluginOrder(['one']);
-
-    expect(function() {
-      EventPluginRegistry.injectEventPluginsByName({
-        one: OnePlugin,
-        random: RandomPlugin,
-      });
-    }).toThrowError(
-      'EventPluginRegistry: Cannot inject event plugins that do not exist ' +
-      'in the plugin ordering, `random`.'
-    );
-  });
-
-  it('should throw if ordering is injected more than once', function() {
-    var pluginOrdering = [];
-
+  expect(function() {
     EventPluginRegistry.injectEventPluginOrder(pluginOrdering);
+  }).toThrowError(
+    'EventPluginRegistry: Cannot inject event plugin ordering more than ' +
+    'once. You are likely trying to load more than one copy of React.'
+  );
+});
 
-    expect(function() {
-      EventPluginRegistry.injectEventPluginOrder(pluginOrdering);
-    }).toThrowError(
-      'EventPluginRegistry: Cannot inject event plugin ordering more than ' +
-      'once. You are likely trying to load more than one copy of React.'
-    );
+it('should throw if different plugins injected using same name', function() {
+  var OnePlugin = createPlugin();
+  var TwoPlugin = createPlugin();
+
+  EventPluginRegistry.injectEventPluginsByName({same: OnePlugin});
+
+  expect(function() {
+    EventPluginRegistry.injectEventPluginsByName({same: TwoPlugin});
+  }).toThrowError(
+    'EventPluginRegistry: Cannot inject two different event plugins using ' +
+    'the same name, `same`.'
+  );
+});
+
+it('should publish registration names of injected plugins', function() {
+  var OnePlugin = createPlugin({
+    eventTypes: {
+      click: {registrationName: 'onClick'},
+      focus: {registrationName: 'onFocus'},
+    },
   });
-
-  it('should throw if different plugins injected using same name', function() {
-    var OnePlugin = createPlugin();
-    var TwoPlugin = createPlugin();
-
-    EventPluginRegistry.injectEventPluginsByName({same: OnePlugin});
-
-    expect(function() {
-      EventPluginRegistry.injectEventPluginsByName({same: TwoPlugin});
-    }).toThrowError(
-      'EventPluginRegistry: Cannot inject two different event plugins using ' +
-      'the same name, `same`.'
-    );
-  });
-
-  it('should publish registration names of injected plugins', function() {
-    var OnePlugin = createPlugin({
-      eventTypes: {
-        click: {registrationName: 'onClick'},
-        focus: {registrationName: 'onFocus'},
-      },
-    });
-    var TwoPlugin = createPlugin({
-      eventTypes: {
-        magic: {
-          phasedRegistrationNames: {
-            bubbled: 'onMagicBubble',
-            captured: 'onMagicCapture',
-          },
+  var TwoPlugin = createPlugin({
+    eventTypes: {
+      magic: {
+        phasedRegistrationNames: {
+          bubbled: 'onMagicBubble',
+          captured: 'onMagicCapture',
         },
       },
-    });
+    },
+  });
 
-    EventPluginRegistry.injectEventPluginsByName({one: OnePlugin});
+  EventPluginRegistry.injectEventPluginsByName({one: OnePlugin});
+  EventPluginRegistry.injectEventPluginOrder(['one', 'two']);
+
+  expect(Object.keys(EventPluginRegistry.registrationNameModules).length).toBe(2);
+  expect(EventPluginRegistry.registrationNameModules.onClick).toBe(OnePlugin);
+  expect(EventPluginRegistry.registrationNameModules.onFocus).toBe(OnePlugin);
+
+  EventPluginRegistry.injectEventPluginsByName({two: TwoPlugin});
+
+  expect(Object.keys(EventPluginRegistry.registrationNameModules).length).toBe(4);
+  expect(EventPluginRegistry.registrationNameModules.onMagicBubble).toBe(TwoPlugin);
+  expect(
+    EventPluginRegistry.registrationNameModules.onMagicCapture
+  ).toBe(TwoPlugin);
+});
+
+it('should throw if multiple registration names collide', function() {
+  var OnePlugin = createPlugin({
+    eventTypes: {
+      photoCapture: {registrationName: 'onPhotoCapture'},
+    },
+  });
+  var TwoPlugin = createPlugin({
+    eventTypes: {
+      photo: {
+        phasedRegistrationNames: {
+          bubbled: 'onPhotoBubble',
+          captured: 'onPhotoCapture',
+        },
+      },
+    },
+  });
+
+  EventPluginRegistry.injectEventPluginsByName({
+    one: OnePlugin,
+    two: TwoPlugin,
+  });
+
+  expect(function() {
     EventPluginRegistry.injectEventPluginOrder(['one', 'two']);
+  }).toThrowError(
+    'EventPluginHub: More than one plugin attempted to publish the same ' +
+    'registration name, `onPhotoCapture`.'
+  );
+});
 
-    expect(Object.keys(EventPluginRegistry.registrationNameModules).length).toBe(2);
-    expect(EventPluginRegistry.registrationNameModules.onClick).toBe(OnePlugin);
-    expect(EventPluginRegistry.registrationNameModules.onFocus).toBe(OnePlugin);
-
-    EventPluginRegistry.injectEventPluginsByName({two: TwoPlugin});
-
-    expect(Object.keys(EventPluginRegistry.registrationNameModules).length).toBe(4);
-    expect(EventPluginRegistry.registrationNameModules.onMagicBubble).toBe(TwoPlugin);
-    expect(
-      EventPluginRegistry.registrationNameModules.onMagicCapture
-    ).toBe(TwoPlugin);
+it('should throw if an invalid event is published', function() {
+  var OnePlugin = createPlugin({
+    eventTypes: {
+      badEvent: {/* missing configuration */},
+    },
   });
 
-  it('should throw if multiple registration names collide', function() {
-    var OnePlugin = createPlugin({
-      eventTypes: {
-        photoCapture: {registrationName: 'onPhotoCapture'},
-      },
-    });
-    var TwoPlugin = createPlugin({
-      eventTypes: {
-        photo: {
-          phasedRegistrationNames: {
-            bubbled: 'onPhotoBubble',
-            captured: 'onPhotoCapture',
-          },
-        },
-      },
-    });
+  EventPluginRegistry.injectEventPluginsByName({one: OnePlugin});
 
-    EventPluginRegistry.injectEventPluginsByName({
-      one: OnePlugin,
-      two: TwoPlugin,
-    });
-
-    expect(function() {
-      EventPluginRegistry.injectEventPluginOrder(['one', 'two']);
-    }).toThrowError(
-      'EventPluginHub: More than one plugin attempted to publish the same ' +
-      'registration name, `onPhotoCapture`.'
-    );
-  });
-
-  it('should throw if an invalid event is published', function() {
-    var OnePlugin = createPlugin({
-      eventTypes: {
-        badEvent: {/* missing configuration */},
-      },
-    });
-
-    EventPluginRegistry.injectEventPluginsByName({one: OnePlugin});
-
-    expect(function() {
-      EventPluginRegistry.injectEventPluginOrder(['one']);
-    }).toThrowError(
-      'EventPluginRegistry: Failed to publish event `badEvent` for plugin ' +
-      '`one`.'
-    );
-  });
-
-  it('should be able to get the plugin from synthetic events', function() {
-    var clickDispatchConfig = {
-      registrationName: 'onClick',
-    };
-    var magicDispatchConfig = {
-      phasedRegistrationNames: {
-        bubbled: 'onMagicBubble',
-        captured: 'onMagicCapture',
-      },
-    };
-
-    var OnePlugin = createPlugin({
-      eventTypes: {
-        click: clickDispatchConfig,
-        magic: magicDispatchConfig,
-      },
-    });
-
-    var clickEvent = {dispatchConfig: clickDispatchConfig};
-    var magicEvent = {dispatchConfig: magicDispatchConfig};
-
-    expect(EventPluginRegistry.getPluginModuleForEvent(clickEvent)).toBe(null);
-    expect(EventPluginRegistry.getPluginModuleForEvent(magicEvent)).toBe(null);
-
-    EventPluginRegistry.injectEventPluginsByName({one: OnePlugin});
+  expect(function() {
     EventPluginRegistry.injectEventPluginOrder(['one']);
+  }).toThrowError(
+    'EventPluginRegistry: Failed to publish event `badEvent` for plugin ' +
+    '`one`.'
+  );
+});
 
-    expect(
-      EventPluginRegistry.getPluginModuleForEvent(clickEvent)
-    ).toBe(OnePlugin);
-    expect(
-      EventPluginRegistry.getPluginModuleForEvent(magicEvent)
-    ).toBe(OnePlugin);
+it('should be able to get the plugin from synthetic events', function() {
+  var clickDispatchConfig = {
+    registrationName: 'onClick',
+  };
+  var magicDispatchConfig = {
+    phasedRegistrationNames: {
+      bubbled: 'onMagicBubble',
+      captured: 'onMagicCapture',
+    },
+  };
+
+  var OnePlugin = createPlugin({
+    eventTypes: {
+      click: clickDispatchConfig,
+      magic: magicDispatchConfig,
+    },
   });
 
+  var clickEvent = {dispatchConfig: clickDispatchConfig};
+  var magicEvent = {dispatchConfig: magicDispatchConfig};
+
+  expect(EventPluginRegistry.getPluginModuleForEvent(clickEvent)).toBe(null);
+  expect(EventPluginRegistry.getPluginModuleForEvent(magicEvent)).toBe(null);
+
+  EventPluginRegistry.injectEventPluginsByName({one: OnePlugin});
+  EventPluginRegistry.injectEventPluginOrder(['one']);
+
+  expect(
+    EventPluginRegistry.getPluginModuleForEvent(clickEvent)
+  ).toBe(OnePlugin);
+  expect(
+    EventPluginRegistry.getPluginModuleForEvent(magicEvent)
+  ).toBe(OnePlugin);
 });

--- a/src/renderers/shared/stack/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
+++ b/src/renderers/shared/stack/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
@@ -327,676 +327,674 @@ var siblings = {
   childTwo: CHILD_ID2,
 };
 
-describe('ResponderEventPlugin', function() {
-  beforeEach(function() {
-    jest.resetModuleRegistry();
+beforeEach(function() {
+  jest.resetModuleRegistry();
 
-    EventPluginHub = require('EventPluginHub');
-    EventPluginUtils = require('EventPluginUtils');
-    ReactInstanceHandles = require('ReactInstanceHandles');
-    ResponderEventPlugin = require('ResponderEventPlugin');
+  EventPluginHub = require('EventPluginHub');
+  EventPluginUtils = require('EventPluginUtils');
+  ReactInstanceHandles = require('ReactInstanceHandles');
+  ResponderEventPlugin = require('ResponderEventPlugin');
 
-    EventPluginUtils.injection.injectComponentTree({
-      getInstanceFromNode: function(id) {
-        return idToInstance[id];
-      },
-      getNodeFromInstance: function(inst) {
-        return inst._rootNodeID;
-      },
-    });
+  EventPluginUtils.injection.injectComponentTree({
+    getInstanceFromNode: function(id) {
+      return idToInstance[id];
+    },
+    getNodeFromInstance: function(inst) {
+      return inst._rootNodeID;
+    },
+  });
 
-    EventPluginUtils.injection.injectTreeTraversal({
-      isAncestor: function(a, b) {
-        return ReactInstanceHandles.isAncestorIDOf(
-          a._rootNodeID,
-          b._rootNodeID
-        );
-      },
-      getLowestCommonAncestor: function(a, b) {
-        if (!a || !b) {
-          return null;
+  EventPluginUtils.injection.injectTreeTraversal({
+    isAncestor: function(a, b) {
+      return ReactInstanceHandles.isAncestorIDOf(
+        a._rootNodeID,
+        b._rootNodeID
+      );
+    },
+    getLowestCommonAncestor: function(a, b) {
+      if (!a || !b) {
+        return null;
+      }
+      var commonID = ReactInstanceHandles.getFirstCommonAncestorID(
+        a._rootNodeID,
+        b._rootNodeID
+      );
+      return idToInstance[commonID] || null;
+    },
+    getParentInstance: function(inst) {
+      var id = inst._rootNodeID;
+      var parentID = id.substr(0, id.lastIndexOf('.'));
+      return idToInstance[parentID] || null;
+    },
+    traverseTwoPhase: function(target, fn, arg) {
+      ReactInstanceHandles.traverseTwoPhase(
+        target._rootNodeID,
+        function(id, upwards) {
+          fn(idToInstance[id], upwards, arg);
         }
-        var commonID = ReactInstanceHandles.getFirstCommonAncestorID(
-          a._rootNodeID,
-          b._rootNodeID
-        );
-        return idToInstance[commonID] || null;
-      },
-      getParentInstance: function(inst) {
-        var id = inst._rootNodeID;
-        var parentID = id.substr(0, id.lastIndexOf('.'));
-        return idToInstance[parentID] || null;
-      },
-      traverseTwoPhase: function(target, fn, arg) {
-        ReactInstanceHandles.traverseTwoPhase(
-          target._rootNodeID,
-          function(id, upwards) {
-            fn(idToInstance[id], upwards, arg);
-          }
-        );
-      },
-    });
+      );
+    },
   });
+});
 
-  it('should do nothing when no one wants to respond', function() {
-    var config = oneEventLoopTestConfig(three);
-    config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
-    config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
-    config.startShouldSetResponder.bubbled.child = {order: 3, returnVal: false};
-    config.startShouldSetResponder.bubbled.parent = {order: 4, returnVal: false};
-    config.startShouldSetResponder.bubbled.grandParent = {order: 5, returnVal: false};
-    run(config, three, startConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(null);
+it('should do nothing when no one wants to respond', function() {
+  var config = oneEventLoopTestConfig(three);
+  config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
+  config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
+  config.startShouldSetResponder.bubbled.child = {order: 3, returnVal: false};
+  config.startShouldSetResponder.bubbled.parent = {order: 4, returnVal: false};
+  config.startShouldSetResponder.bubbled.grandParent = {order: 5, returnVal: false};
+  run(config, three, startConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(null);
 
-    // Now no handlers should be called on `touchEnd`.
-    config = oneEventLoopTestConfig(three);
-    run(config, three, endConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(null);
+  // Now no handlers should be called on `touchEnd`.
+  config = oneEventLoopTestConfig(three);
+  run(config, three, endConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(null);
+});
+
+
+/**
+ * Simple Start Granting
+ * --------------------
+ */
+
+
+it('should grant responder grandParent while capturing', () => {
+  var config = oneEventLoopTestConfig(three);
+  config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: true};
+  config.responderGrant.grandParent = {order: 1};
+  config.responderStart.grandParent = {order: 2};
+  run(config, three, startConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.grandParent);
+
+  config = oneEventLoopTestConfig(three);
+  config.responderEnd.grandParent = {order: 0};
+  config.responderRelease.grandParent = {order: 1};
+  run(config, three, endConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(null);
+});
+
+it('should grant responder parent while capturing', () => {
+  var config = oneEventLoopTestConfig(three);
+  config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.startShouldSetResponder.captured.parent = {order: 1, returnVal: true};
+  config.responderGrant.parent = {order: 2};
+  config.responderStart.parent = {order: 3};
+  run(config, three, startConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.parent);
+
+  config = oneEventLoopTestConfig(three);
+  config.responderEnd.parent = {order: 0};
+  config.responderRelease.parent = {order: 1};
+  run(config, three, endConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(null);
+});
+
+it('should grant responder child while capturing', () => {
+  var config = oneEventLoopTestConfig(three);
+  config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
+  config.startShouldSetResponder.captured.child = {order: 2, returnVal: true};
+  config.responderGrant.child = {order: 3};
+  config.responderStart.child = {order: 4};
+  run(config, three, startConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
+
+  config = oneEventLoopTestConfig(three);
+  config.responderEnd.child = {order: 0};
+  config.responderRelease.child = {order: 1};
+  run(config, three, endConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(null);
+});
+
+it('should grant responder child while bubbling', () => {
+  var config = oneEventLoopTestConfig(three);
+  config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
+  config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
+  config.startShouldSetResponder.bubbled.child = {order: 3, returnVal: true};
+  config.responderGrant.child = {order: 4};
+  config.responderStart.child = {order: 5};
+  run(config, three, startConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
+
+  config = oneEventLoopTestConfig(three);
+  config.responderEnd.child = {order: 0};
+  config.responderRelease.child = {order: 1};
+  run(config, three, endConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(null);
+});
+
+it('should grant responder parent while bubbling', () => {
+  var config = oneEventLoopTestConfig(three);
+  config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
+  config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
+  config.startShouldSetResponder.bubbled.child = {order: 3, returnVal: false};
+  config.startShouldSetResponder.bubbled.parent = {order: 4, returnVal: true};
+  config.responderGrant.parent = {order: 5};
+  config.responderStart.parent = {order: 6};
+  run(config, three, startConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.parent);
+
+  config = oneEventLoopTestConfig(three);
+  config.responderEnd.parent = {order: 0};
+  config.responderRelease.parent = {order: 1};
+  run(config, three, endConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(null);
+});
+
+it('should grant responder grandParent while bubbling', () => {
+  var config = oneEventLoopTestConfig(three);
+  config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
+  config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
+  config.startShouldSetResponder.bubbled.child = {order: 3, returnVal: false};
+  config.startShouldSetResponder.bubbled.parent = {order: 4, returnVal: false};
+  config.startShouldSetResponder.bubbled.grandParent = {order: 5, returnVal: true};
+  config.responderGrant.grandParent = {order: 6};
+  config.responderStart.grandParent = {order: 7};
+  run(config, three, startConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.grandParent);
+
+  config = oneEventLoopTestConfig(three);
+  config.responderEnd.grandParent = {order: 0};
+  config.responderRelease.grandParent = {order: 1};
+  run(config, three, endConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(null);
+});
+
+
+
+/**
+ * Simple Move Granting
+ * --------------------
+ */
+
+it('should grant responder grandParent while capturing move', () => {
+  var config = oneEventLoopTestConfig(three);
+
+  config.startShouldSetResponder.captured.grandParent = {order: 0};
+  config.startShouldSetResponder.captured.parent = {order: 1};
+  config.startShouldSetResponder.captured.child = {order: 2};
+  config.startShouldSetResponder.bubbled.child = {order: 3};
+  config.startShouldSetResponder.bubbled.parent = {order: 4};
+  config.startShouldSetResponder.bubbled.grandParent = {order: 5};
+  run(config, three, startConfig(three.child, [three.child], [0]));
+
+  config = oneEventLoopTestConfig(three);
+  config.moveShouldSetResponder.captured.grandParent = {order: 0, returnVal: true};
+  config.responderGrant.grandParent = {order: 1};
+  config.responderMove.grandParent = {order: 2};
+  run(config, three, moveConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.grandParent);
+
+  config = oneEventLoopTestConfig(three);
+  config.responderEnd.grandParent = {order: 0};
+  config.responderRelease.grandParent = {order: 1};
+  run(config, three, endConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(null);
+});
+
+it('should grant responder parent while capturing move', () => {
+  var config = oneEventLoopTestConfig(three);
+
+  config.startShouldSetResponder.captured.grandParent = {order: 0};
+  config.startShouldSetResponder.captured.parent = {order: 1};
+  config.startShouldSetResponder.captured.child = {order: 2};
+  config.startShouldSetResponder.bubbled.child = {order: 3};
+  config.startShouldSetResponder.bubbled.parent = {order: 4};
+  config.startShouldSetResponder.bubbled.grandParent = {order: 5};
+  run(config, three, startConfig(three.child, [three.child], [0]));
+
+  config = oneEventLoopTestConfig(three);
+  config.moveShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.moveShouldSetResponder.captured.parent = {order: 1, returnVal: true};
+  config.responderGrant.parent = {order: 2};
+  config.responderMove.parent = {order: 3};
+  run(config, three, moveConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.parent);
+
+  config = oneEventLoopTestConfig(three);
+  config.responderEnd.parent = {order: 0};
+  config.responderRelease.parent = {order: 1};
+  run(config, three, endConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(null);
+});
+
+it('should grant responder child while capturing move', () => {
+  var config = oneEventLoopTestConfig(three);
+
+  config.startShouldSetResponder.captured.grandParent = {order: 0};
+  config.startShouldSetResponder.captured.parent = {order: 1};
+  config.startShouldSetResponder.captured.child = {order: 2};
+  config.startShouldSetResponder.bubbled.child = {order: 3};
+  config.startShouldSetResponder.bubbled.parent = {order: 4};
+  config.startShouldSetResponder.bubbled.grandParent = {order: 5};
+  run(config, three, startConfig(three.child, [three.child], [0]));
+
+  config = oneEventLoopTestConfig(three);
+  config.moveShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.moveShouldSetResponder.captured.parent = {order: 1, returnVal: false};
+  config.moveShouldSetResponder.captured.child = {order: 2, returnVal: true};
+  config.responderGrant.child = {order: 3};
+  config.responderMove.child = {order: 4};
+  run(config, three, moveConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
+
+  config = oneEventLoopTestConfig(three);
+  config.responderEnd.child = {order: 0};
+  config.responderRelease.child = {order: 1};
+  run(config, three, endConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(null);
+});
+
+it('should grant responder child while bubbling move', () => {
+  var config = oneEventLoopTestConfig(three);
+
+  config.startShouldSetResponder.captured.grandParent = {order: 0};
+  config.startShouldSetResponder.captured.parent = {order: 1};
+  config.startShouldSetResponder.captured.child = {order: 2};
+  config.startShouldSetResponder.bubbled.child = {order: 3};
+  config.startShouldSetResponder.bubbled.parent = {order: 4};
+  config.startShouldSetResponder.bubbled.grandParent = {order: 5};
+  run(config, three, startConfig(three.child, [three.child], [0]));
+
+  config = oneEventLoopTestConfig(three);
+  config.moveShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.moveShouldSetResponder.captured.parent = {order: 1, returnVal: false};
+  config.moveShouldSetResponder.captured.child = {order: 2, returnVal: false};
+  config.moveShouldSetResponder.bubbled.child = {order: 3, returnVal: true};
+  config.responderGrant.child = {order: 4};
+  config.responderMove.child = {order: 5};
+  run(config, three, moveConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
+
+  config = oneEventLoopTestConfig(three);
+  config.responderEnd.child = {order: 0};
+  config.responderRelease.child = {order: 1};
+  run(config, three, endConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(null);
+});
+
+it('should grant responder parent while bubbling move', () => {
+  var config = oneEventLoopTestConfig(three);
+
+  config.startShouldSetResponder.captured.grandParent = {order: 0};
+  config.startShouldSetResponder.captured.parent = {order: 1};
+  config.startShouldSetResponder.captured.child = {order: 2};
+  config.startShouldSetResponder.bubbled.child = {order: 3};
+  config.startShouldSetResponder.bubbled.parent = {order: 4};
+  config.startShouldSetResponder.bubbled.grandParent = {order: 5};
+  run(config, three, startConfig(three.child, [three.child], [0]));
+
+  config = oneEventLoopTestConfig(three);
+  config.moveShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.moveShouldSetResponder.captured.parent = {order: 1, returnVal: false};
+  config.moveShouldSetResponder.captured.child = {order: 2, returnVal: false};
+  config.moveShouldSetResponder.bubbled.child = {order: 3, returnVal: false};
+  config.moveShouldSetResponder.bubbled.parent = {order: 4, returnVal: true};
+  config.responderGrant.parent = {order: 5};
+  config.responderMove.parent = {order: 6};
+  run(config, three, moveConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.parent);
+
+  config = oneEventLoopTestConfig(three);
+  config.responderEnd.parent = {order: 0};
+  config.responderRelease.parent = {order: 1};
+  run(config, three, endConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(null);
+});
+
+it('should grant responder grandParent while bubbling move', () => {
+  var config = oneEventLoopTestConfig(three);
+
+  config.startShouldSetResponder.captured.grandParent = {order: 0};
+  config.startShouldSetResponder.captured.parent = {order: 1};
+  config.startShouldSetResponder.captured.child = {order: 2};
+  config.startShouldSetResponder.bubbled.child = {order: 3};
+  config.startShouldSetResponder.bubbled.parent = {order: 4};
+  config.startShouldSetResponder.bubbled.grandParent = {order: 5};
+  run(config, three, startConfig(three.child, [three.child], [0]));
+
+  config = oneEventLoopTestConfig(three);
+  config.moveShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.moveShouldSetResponder.captured.parent = {order: 1, returnVal: false};
+  config.moveShouldSetResponder.captured.child = {order: 2, returnVal: false};
+  config.moveShouldSetResponder.bubbled.child = {order: 3, returnVal: false};
+  config.moveShouldSetResponder.bubbled.parent = {order: 4, returnVal: false};
+  config.moveShouldSetResponder.bubbled.grandParent = {order: 5, returnVal: true};
+  config.responderGrant.grandParent = {order: 6};
+  config.responderMove.grandParent = {order: 7};
+  run(config, three, moveConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.grandParent);
+
+  config = oneEventLoopTestConfig(three);
+  config.responderEnd.grandParent = {order: 0};
+  config.responderRelease.grandParent = {order: 1};
+  run(config, three, endConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(null);
+});
+
+
+/**
+ * Common ancestor tests
+ * ---------------------
+ */
+
+it('should bubble negotiation to first common ancestor of responder', () => {
+  var config = oneEventLoopTestConfig(three);
+  config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.startShouldSetResponder.captured.parent = {order: 1, returnVal: true};
+  config.responderGrant.parent = {order: 2};
+  config.responderStart.parent = {order: 3};
+  run(config, three, startConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.parent);
+
+  // While `parent` is still responder, we create new handlers that verify
+  // the ordering of propagation, restarting the count at `0`.
+  config = oneEventLoopTestConfig(three);
+  config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+
+  config.startShouldSetResponder.bubbled.grandParent = {order: 1, returnVal: false};
+  config.responderStart.parent = {order: 2};
+  run(config, three, startConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.parent);
+
+  config = oneEventLoopTestConfig(three);
+  config.responderEnd.parent = {order: 0};
+  config.responderRelease.parent = {order: 1};
+  run(config, three, endConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(null);
+});
+
+it('should bubble negotiation to first common ancestor of responder then transfer', () => {
+  var config = oneEventLoopTestConfig(three);
+  config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.startShouldSetResponder.captured.parent = {order: 1, returnVal: true};
+  config.responderGrant.parent = {order: 2};
+  config.responderStart.parent = {order: 3};
+  run(config, three, startConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.parent);
+
+  config = oneEventLoopTestConfig(three);
+
+  // Parent is responder, and responder is transferred by a second touch start
+  config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: true};
+  config.responderGrant.grandParent = {order: 1};
+  config.responderTerminationRequest.parent = {order: 2, returnVal: true};
+  config.responderTerminate.parent = {order: 3};
+  config.responderStart.grandParent = {order: 4};
+  run(config, three, startConfig(three.child, [three.child, three.child], [1]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.grandParent);
+
+  config = oneEventLoopTestConfig(three);
+  config.responderEnd.grandParent = {order: 0};
+                                    // one remains\ /one ended \
+  run(config, three, endConfig(three.child, [three.child, three.child], [1]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.grandParent);
+
+  config = oneEventLoopTestConfig(three);
+  config.responderEnd.grandParent = {order: 0};
+  config.responderRelease.grandParent = {order: 1};
+  run(config, three, endConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(null);
+});
+
+/**
+ * If nothing is responder, then the negotiation should propagate directly to
+ * the deepest target in the second touch.
+ */
+it('should negotiate with deepest target on second touch if nothing is responder', () => {
+  // Initially nothing wants to become the responder
+  var config = oneEventLoopTestConfig(three);
+  config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
+  config.startShouldSetResponder.bubbled.parent = {order: 2, returnVal: false};
+  config.startShouldSetResponder.bubbled.grandParent = {order: 3, returnVal: false};
+
+  run(config, three, startConfig(three.parent, [three.parent], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(null);
+
+  config = oneEventLoopTestConfig(three);
+
+  // Now child wants to become responder. Negotiation should bubble as deep
+  // as the target is because we don't find first common ancestor (with
+  // current responder) because there is no current responder.
+  // (Even if this is the second active touch).
+  config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
+  config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
+  config.startShouldSetResponder.bubbled.child = {order: 3, returnVal: true};
+  config.responderGrant.child = {order: 4};
+  config.responderStart.child = {order: 5};
+  //                                     /  Two active touches  \  /one of them new\
+  run(config, three, startConfig(three.child, [three.parent, three.child], [1]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
+
+
+  // Now we remove the original first touch, keeping the second touch that
+  // started within the current responder (child). Nothing changes because
+  // there's still touches that started inside of the current responder.
+  config = oneEventLoopTestConfig(three);
+  config.responderEnd.child = {order: 0};
+  //                                      / one ended\  /one remains \
+  run(config, three, endConfig(three.child, [three.parent, three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
+
+  // Okay, now let's add back that first touch (nothing should change) and
+  // then we'll try peeling back the touches in the opposite order to make
+  // sure that first removing the second touch instantly causes responder to
+  // be released.
+  config = oneEventLoopTestConfig(three);
+  config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
+  config.startShouldSetResponder.bubbled.parent = {order: 2, returnVal: false};
+  config.startShouldSetResponder.bubbled.grandParent = {order: 3, returnVal: false};
+  // Interesting: child still gets moves even though touch target is parent!
+  // Current responder gets a `responderStart` for any touch while responder.
+  config.responderStart.child = {order: 4};
+  //                                           /  Two active touches  \  /one of them new\
+  run(config, three, startConfig(three.parent, [three.child, three.parent], [1]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
+
+
+  // Now, move that new touch that had no effect, and did not start within
+  // the current responder.
+  config = oneEventLoopTestConfig(three);
+  config.moveShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.moveShouldSetResponder.captured.parent = {order: 1, returnVal: false};
+  config.moveShouldSetResponder.bubbled.parent = {order: 2, returnVal: false};
+  config.moveShouldSetResponder.bubbled.grandParent = {order: 3, returnVal: false};
+  // Interesting: child still gets moves even though touch target is parent!
+  // Current responder gets a `responderMove` for any touch while responder.
+  config.responderMove.child = {order: 4};
+  //                                     /  Two active touches  \  /one of them moved\
+  run(config, three, moveConfig(three.parent, [three.child, three.parent], [1]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
+
+
+  config = oneEventLoopTestConfig(three);
+  config.responderEnd.child = {order: 0};
+  config.responderRelease.child = {order: 1};
+  //                                        /child end \ /parent remain\
+  run(config, three, endConfig(three.child, [three.child, three.parent], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(null);
+});
+
+
+/**
+ * If nothing is responder, then the negotiation should propagate directly to
+ * the deepest target in the second touch.
+ */
+it('should negotiate until first common ancestor when there are siblings', () => {
+  // Initially nothing wants to become the responder
+  var config = oneEventLoopTestConfig(siblings);
+  config.startShouldSetResponder.captured.parent = {order: 0, returnVal: false};
+  config.startShouldSetResponder.captured.childOne = {order: 1, returnVal: false};
+  config.startShouldSetResponder.bubbled.childOne = {order: 2, returnVal: true};
+  config.responderGrant.childOne = {order: 3};
+  config.responderStart.childOne = {order: 4};
+
+  run(config, siblings, startConfig(siblings.childOne, [siblings.childOne], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(siblings.childOne);
+
+  // If the touch target is the sibling item, the negotiation should only
+  // propagate to first common ancestor of current responder and sibling (so
+  // the parent).
+  config = oneEventLoopTestConfig(siblings);
+  config.startShouldSetResponder.captured.parent = {order: 0, returnVal: false};
+  config.startShouldSetResponder.bubbled.parent = {order: 1, returnVal: false};
+  config.responderStart.childOne = {order: 2};
+
+  var touchConfig =
+    startConfig(siblings.childTwo, [siblings.childOne, siblings.childTwo], [1]);
+  run(config, siblings, touchConfig);
+  expect(ResponderEventPlugin._getResponderID()).toBe(siblings.childOne);
+
+
+  // move childOne
+  config = oneEventLoopTestConfig(siblings);
+  config.moveShouldSetResponder.captured.parent = {order: 0, returnVal: false};
+  config.moveShouldSetResponder.bubbled.parent = {order: 1, returnVal: false};
+  config.responderMove.childOne = {order: 2};
+  run(config, siblings, moveConfig(siblings.childOne, [siblings.childOne, siblings.childTwo], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(siblings.childOne);
+
+  // move childTwo: Only negotiates to `parent`.
+  config = oneEventLoopTestConfig(siblings);
+  config.moveShouldSetResponder.captured.parent = {order: 0, returnVal: false};
+  config.moveShouldSetResponder.bubbled.parent = {order: 1, returnVal: false};
+  config.responderMove.childOne = {order: 2};
+  run(config, siblings, moveConfig(siblings.childTwo, [siblings.childOne, siblings.childTwo], [1]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(siblings.childOne);
+
+});
+
+
+it('should notify of being rejected. responderStart/Move happens on current responder', () => {
+  // Initially nothing wants to become the responder
+  var config = oneEventLoopTestConfig(three);
+  config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
+  config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
+  config.startShouldSetResponder.bubbled.child = {order: 3, returnVal: true};
+  config.responderGrant.child = {order: 4};
+  config.responderStart.child = {order: 5};
+
+  run(config, three, startConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
+
+  // Suppose parent wants to become responder on move, and is rejected
+  config = oneEventLoopTestConfig(three);
+  config.moveShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.moveShouldSetResponder.captured.parent = {order: 1, returnVal: false};
+  config.moveShouldSetResponder.bubbled.parent = {order: 2, returnVal: true};
+  config.responderGrant.parent = {order: 3};
+  config.responderTerminationRequest.child = {order: 4, returnVal: false};
+  config.responderReject.parent = {order: 5};
+  // The start/move should occur on the original responder if new one is rejected
+  config.responderMove.child = {order: 6};
+
+  var touchConfig =
+    moveConfig(three.child, [three.child], [0]);
+  run(config, three, touchConfig);
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
+
+  config = oneEventLoopTestConfig(three);
+  config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
+  config.startShouldSetResponder.bubbled.parent = {order: 2, returnVal: true};
+  config.responderGrant.parent = {order: 3};
+  config.responderTerminationRequest.child = {order: 4, returnVal: false};
+  config.responderReject.parent = {order: 5};
+  // The start/move should occur on the original responder if new one is rejected
+  config.responderStart.child = {order: 6};
+
+  touchConfig =
+    startConfig(three.child, [three.child, three.child], [1]);
+  run(config, three, touchConfig);
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
+
+});
+
+
+it('should negotiate scroll', () => {
+  // Initially nothing wants to become the responder
+  var config = oneEventLoopTestConfig(three);
+  config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
+  config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
+  config.startShouldSetResponder.bubbled.child = {order: 3, returnVal: true};
+  config.responderGrant.child = {order: 4};
+  config.responderStart.child = {order: 5};
+
+  run(config, three, startConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
+
+  // If the touch target is the sibling item, the negotiation should only
+  // propagate to first common ancestor of current responder and sibling (so
+  // the parent).
+  config = oneEventLoopTestConfig(three);
+  config.scrollShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.scrollShouldSetResponder.captured.parent = {order: 1, returnVal: false};
+  config.scrollShouldSetResponder.bubbled.parent = {order: 2, returnVal: true};
+  config.responderGrant.parent = {order: 3};
+  config.responderTerminationRequest.child = {order: 4, returnVal: false};
+  config.responderReject.parent = {order: 5};
+
+  run(config, three, {
+    topLevelType: 'topScroll',
+    targetInst: idToInstance[three.parent],
+    nativeEvent: {},
   });
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
 
 
-  /**
-   * Simple Start Granting
-   * --------------------
-   */
+  // Now lets let the scroll take control this time.
+  config = oneEventLoopTestConfig(three);
+  config.scrollShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.scrollShouldSetResponder.captured.parent = {order: 1, returnVal: false};
+  config.scrollShouldSetResponder.bubbled.parent = {order: 2, returnVal: true};
+  config.responderGrant.parent = {order: 3};
+  config.responderTerminationRequest.child = {order: 4, returnVal: true};
+  config.responderTerminate.child = {order: 5};
 
-
-  it('should grant responder grandParent while capturing', () => {
-    var config = oneEventLoopTestConfig(three);
-    config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: true};
-    config.responderGrant.grandParent = {order: 1};
-    config.responderStart.grandParent = {order: 2};
-    run(config, three, startConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.grandParent);
-
-    config = oneEventLoopTestConfig(three);
-    config.responderEnd.grandParent = {order: 0};
-    config.responderRelease.grandParent = {order: 1};
-    run(config, three, endConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(null);
+  run(config, three, {
+    topLevelType: 'topScroll',
+    targetInst: idToInstance[three.parent],
+    nativeEvent: {},
   });
-
-  it('should grant responder parent while capturing', () => {
-    var config = oneEventLoopTestConfig(three);
-    config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.startShouldSetResponder.captured.parent = {order: 1, returnVal: true};
-    config.responderGrant.parent = {order: 2};
-    config.responderStart.parent = {order: 3};
-    run(config, three, startConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.parent);
-
-    config = oneEventLoopTestConfig(three);
-    config.responderEnd.parent = {order: 0};
-    config.responderRelease.parent = {order: 1};
-    run(config, three, endConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(null);
-  });
-
-  it('should grant responder child while capturing', () => {
-    var config = oneEventLoopTestConfig(three);
-    config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
-    config.startShouldSetResponder.captured.child = {order: 2, returnVal: true};
-    config.responderGrant.child = {order: 3};
-    config.responderStart.child = {order: 4};
-    run(config, three, startConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
-
-    config = oneEventLoopTestConfig(three);
-    config.responderEnd.child = {order: 0};
-    config.responderRelease.child = {order: 1};
-    run(config, three, endConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(null);
-  });
-
-  it('should grant responder child while bubbling', () => {
-    var config = oneEventLoopTestConfig(three);
-    config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
-    config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
-    config.startShouldSetResponder.bubbled.child = {order: 3, returnVal: true};
-    config.responderGrant.child = {order: 4};
-    config.responderStart.child = {order: 5};
-    run(config, three, startConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
-
-    config = oneEventLoopTestConfig(three);
-    config.responderEnd.child = {order: 0};
-    config.responderRelease.child = {order: 1};
-    run(config, three, endConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(null);
-  });
-
-  it('should grant responder parent while bubbling', () => {
-    var config = oneEventLoopTestConfig(three);
-    config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
-    config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
-    config.startShouldSetResponder.bubbled.child = {order: 3, returnVal: false};
-    config.startShouldSetResponder.bubbled.parent = {order: 4, returnVal: true};
-    config.responderGrant.parent = {order: 5};
-    config.responderStart.parent = {order: 6};
-    run(config, three, startConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.parent);
-
-    config = oneEventLoopTestConfig(three);
-    config.responderEnd.parent = {order: 0};
-    config.responderRelease.parent = {order: 1};
-    run(config, three, endConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(null);
-  });
-
-  it('should grant responder grandParent while bubbling', () => {
-    var config = oneEventLoopTestConfig(three);
-    config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
-    config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
-    config.startShouldSetResponder.bubbled.child = {order: 3, returnVal: false};
-    config.startShouldSetResponder.bubbled.parent = {order: 4, returnVal: false};
-    config.startShouldSetResponder.bubbled.grandParent = {order: 5, returnVal: true};
-    config.responderGrant.grandParent = {order: 6};
-    config.responderStart.grandParent = {order: 7};
-    run(config, three, startConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.grandParent);
-
-    config = oneEventLoopTestConfig(three);
-    config.responderEnd.grandParent = {order: 0};
-    config.responderRelease.grandParent = {order: 1};
-    run(config, three, endConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(null);
-  });
-
-
-
-  /**
-   * Simple Move Granting
-   * --------------------
-   */
-
-  it('should grant responder grandParent while capturing move', () => {
-    var config = oneEventLoopTestConfig(three);
-
-    config.startShouldSetResponder.captured.grandParent = {order: 0};
-    config.startShouldSetResponder.captured.parent = {order: 1};
-    config.startShouldSetResponder.captured.child = {order: 2};
-    config.startShouldSetResponder.bubbled.child = {order: 3};
-    config.startShouldSetResponder.bubbled.parent = {order: 4};
-    config.startShouldSetResponder.bubbled.grandParent = {order: 5};
-    run(config, three, startConfig(three.child, [three.child], [0]));
-
-    config = oneEventLoopTestConfig(three);
-    config.moveShouldSetResponder.captured.grandParent = {order: 0, returnVal: true};
-    config.responderGrant.grandParent = {order: 1};
-    config.responderMove.grandParent = {order: 2};
-    run(config, three, moveConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.grandParent);
-
-    config = oneEventLoopTestConfig(three);
-    config.responderEnd.grandParent = {order: 0};
-    config.responderRelease.grandParent = {order: 1};
-    run(config, three, endConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(null);
-  });
-
-  it('should grant responder parent while capturing move', () => {
-    var config = oneEventLoopTestConfig(three);
-
-    config.startShouldSetResponder.captured.grandParent = {order: 0};
-    config.startShouldSetResponder.captured.parent = {order: 1};
-    config.startShouldSetResponder.captured.child = {order: 2};
-    config.startShouldSetResponder.bubbled.child = {order: 3};
-    config.startShouldSetResponder.bubbled.parent = {order: 4};
-    config.startShouldSetResponder.bubbled.grandParent = {order: 5};
-    run(config, three, startConfig(three.child, [three.child], [0]));
-
-    config = oneEventLoopTestConfig(three);
-    config.moveShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.moveShouldSetResponder.captured.parent = {order: 1, returnVal: true};
-    config.responderGrant.parent = {order: 2};
-    config.responderMove.parent = {order: 3};
-    run(config, three, moveConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.parent);
-
-    config = oneEventLoopTestConfig(three);
-    config.responderEnd.parent = {order: 0};
-    config.responderRelease.parent = {order: 1};
-    run(config, three, endConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(null);
-  });
-
-  it('should grant responder child while capturing move', () => {
-    var config = oneEventLoopTestConfig(three);
-
-    config.startShouldSetResponder.captured.grandParent = {order: 0};
-    config.startShouldSetResponder.captured.parent = {order: 1};
-    config.startShouldSetResponder.captured.child = {order: 2};
-    config.startShouldSetResponder.bubbled.child = {order: 3};
-    config.startShouldSetResponder.bubbled.parent = {order: 4};
-    config.startShouldSetResponder.bubbled.grandParent = {order: 5};
-    run(config, three, startConfig(three.child, [three.child], [0]));
-
-    config = oneEventLoopTestConfig(three);
-    config.moveShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.moveShouldSetResponder.captured.parent = {order: 1, returnVal: false};
-    config.moveShouldSetResponder.captured.child = {order: 2, returnVal: true};
-    config.responderGrant.child = {order: 3};
-    config.responderMove.child = {order: 4};
-    run(config, three, moveConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
-
-    config = oneEventLoopTestConfig(three);
-    config.responderEnd.child = {order: 0};
-    config.responderRelease.child = {order: 1};
-    run(config, three, endConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(null);
-  });
-
-  it('should grant responder child while bubbling move', () => {
-    var config = oneEventLoopTestConfig(three);
-
-    config.startShouldSetResponder.captured.grandParent = {order: 0};
-    config.startShouldSetResponder.captured.parent = {order: 1};
-    config.startShouldSetResponder.captured.child = {order: 2};
-    config.startShouldSetResponder.bubbled.child = {order: 3};
-    config.startShouldSetResponder.bubbled.parent = {order: 4};
-    config.startShouldSetResponder.bubbled.grandParent = {order: 5};
-    run(config, three, startConfig(three.child, [three.child], [0]));
-
-    config = oneEventLoopTestConfig(three);
-    config.moveShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.moveShouldSetResponder.captured.parent = {order: 1, returnVal: false};
-    config.moveShouldSetResponder.captured.child = {order: 2, returnVal: false};
-    config.moveShouldSetResponder.bubbled.child = {order: 3, returnVal: true};
-    config.responderGrant.child = {order: 4};
-    config.responderMove.child = {order: 5};
-    run(config, three, moveConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
-
-    config = oneEventLoopTestConfig(three);
-    config.responderEnd.child = {order: 0};
-    config.responderRelease.child = {order: 1};
-    run(config, three, endConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(null);
-  });
-
-  it('should grant responder parent while bubbling move', () => {
-    var config = oneEventLoopTestConfig(three);
-
-    config.startShouldSetResponder.captured.grandParent = {order: 0};
-    config.startShouldSetResponder.captured.parent = {order: 1};
-    config.startShouldSetResponder.captured.child = {order: 2};
-    config.startShouldSetResponder.bubbled.child = {order: 3};
-    config.startShouldSetResponder.bubbled.parent = {order: 4};
-    config.startShouldSetResponder.bubbled.grandParent = {order: 5};
-    run(config, three, startConfig(three.child, [three.child], [0]));
-
-    config = oneEventLoopTestConfig(three);
-    config.moveShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.moveShouldSetResponder.captured.parent = {order: 1, returnVal: false};
-    config.moveShouldSetResponder.captured.child = {order: 2, returnVal: false};
-    config.moveShouldSetResponder.bubbled.child = {order: 3, returnVal: false};
-    config.moveShouldSetResponder.bubbled.parent = {order: 4, returnVal: true};
-    config.responderGrant.parent = {order: 5};
-    config.responderMove.parent = {order: 6};
-    run(config, three, moveConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.parent);
-
-    config = oneEventLoopTestConfig(three);
-    config.responderEnd.parent = {order: 0};
-    config.responderRelease.parent = {order: 1};
-    run(config, three, endConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(null);
-  });
-
-  it('should grant responder grandParent while bubbling move', () => {
-    var config = oneEventLoopTestConfig(three);
-
-    config.startShouldSetResponder.captured.grandParent = {order: 0};
-    config.startShouldSetResponder.captured.parent = {order: 1};
-    config.startShouldSetResponder.captured.child = {order: 2};
-    config.startShouldSetResponder.bubbled.child = {order: 3};
-    config.startShouldSetResponder.bubbled.parent = {order: 4};
-    config.startShouldSetResponder.bubbled.grandParent = {order: 5};
-    run(config, three, startConfig(three.child, [three.child], [0]));
-
-    config = oneEventLoopTestConfig(three);
-    config.moveShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.moveShouldSetResponder.captured.parent = {order: 1, returnVal: false};
-    config.moveShouldSetResponder.captured.child = {order: 2, returnVal: false};
-    config.moveShouldSetResponder.bubbled.child = {order: 3, returnVal: false};
-    config.moveShouldSetResponder.bubbled.parent = {order: 4, returnVal: false};
-    config.moveShouldSetResponder.bubbled.grandParent = {order: 5, returnVal: true};
-    config.responderGrant.grandParent = {order: 6};
-    config.responderMove.grandParent = {order: 7};
-    run(config, three, moveConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.grandParent);
-
-    config = oneEventLoopTestConfig(three);
-    config.responderEnd.grandParent = {order: 0};
-    config.responderRelease.grandParent = {order: 1};
-    run(config, three, endConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(null);
-  });
-
-
-  /**
-   * Common ancestor tests
-   * ---------------------
-   */
-
-  it('should bubble negotiation to first common ancestor of responder', () => {
-    var config = oneEventLoopTestConfig(three);
-    config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.startShouldSetResponder.captured.parent = {order: 1, returnVal: true};
-    config.responderGrant.parent = {order: 2};
-    config.responderStart.parent = {order: 3};
-    run(config, three, startConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.parent);
-
-    // While `parent` is still responder, we create new handlers that verify
-    // the ordering of propagation, restarting the count at `0`.
-    config = oneEventLoopTestConfig(three);
-    config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-
-    config.startShouldSetResponder.bubbled.grandParent = {order: 1, returnVal: false};
-    config.responderStart.parent = {order: 2};
-    run(config, three, startConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.parent);
-
-    config = oneEventLoopTestConfig(three);
-    config.responderEnd.parent = {order: 0};
-    config.responderRelease.parent = {order: 1};
-    run(config, three, endConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(null);
-  });
-
-  it('should bubble negotiation to first common ancestor of responder then transfer', () => {
-    var config = oneEventLoopTestConfig(three);
-    config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.startShouldSetResponder.captured.parent = {order: 1, returnVal: true};
-    config.responderGrant.parent = {order: 2};
-    config.responderStart.parent = {order: 3};
-    run(config, three, startConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.parent);
-
-    config = oneEventLoopTestConfig(three);
-
-    // Parent is responder, and responder is transferred by a second touch start
-    config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: true};
-    config.responderGrant.grandParent = {order: 1};
-    config.responderTerminationRequest.parent = {order: 2, returnVal: true};
-    config.responderTerminate.parent = {order: 3};
-    config.responderStart.grandParent = {order: 4};
-    run(config, three, startConfig(three.child, [three.child, three.child], [1]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.grandParent);
-
-    config = oneEventLoopTestConfig(three);
-    config.responderEnd.grandParent = {order: 0};
-                                      // one remains\ /one ended \
-    run(config, three, endConfig(three.child, [three.child, three.child], [1]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.grandParent);
-
-    config = oneEventLoopTestConfig(three);
-    config.responderEnd.grandParent = {order: 0};
-    config.responderRelease.grandParent = {order: 1};
-    run(config, three, endConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(null);
-  });
-
-  /**
-   * If nothing is responder, then the negotiation should propagate directly to
-   * the deepest target in the second touch.
-   */
-  it('should negotiate with deepest target on second touch if nothing is responder', () => {
-    // Initially nothing wants to become the responder
-    var config = oneEventLoopTestConfig(three);
-    config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
-    config.startShouldSetResponder.bubbled.parent = {order: 2, returnVal: false};
-    config.startShouldSetResponder.bubbled.grandParent = {order: 3, returnVal: false};
-
-    run(config, three, startConfig(three.parent, [three.parent], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(null);
-
-    config = oneEventLoopTestConfig(three);
-
-    // Now child wants to become responder. Negotiation should bubble as deep
-    // as the target is because we don't find first common ancestor (with
-    // current responder) because there is no current responder.
-    // (Even if this is the second active touch).
-    config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
-    config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
-    config.startShouldSetResponder.bubbled.child = {order: 3, returnVal: true};
-    config.responderGrant.child = {order: 4};
-    config.responderStart.child = {order: 5};
-    //                                     /  Two active touches  \  /one of them new\
-    run(config, three, startConfig(three.child, [three.parent, three.child], [1]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
-
-
-    // Now we remove the original first touch, keeping the second touch that
-    // started within the current responder (child). Nothing changes because
-    // there's still touches that started inside of the current responder.
-    config = oneEventLoopTestConfig(three);
-    config.responderEnd.child = {order: 0};
-    //                                      / one ended\  /one remains \
-    run(config, three, endConfig(three.child, [three.parent, three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
-
-    // Okay, now let's add back that first touch (nothing should change) and
-    // then we'll try peeling back the touches in the opposite order to make
-    // sure that first removing the second touch instantly causes responder to
-    // be released.
-    config = oneEventLoopTestConfig(three);
-    config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
-    config.startShouldSetResponder.bubbled.parent = {order: 2, returnVal: false};
-    config.startShouldSetResponder.bubbled.grandParent = {order: 3, returnVal: false};
-    // Interesting: child still gets moves even though touch target is parent!
-    // Current responder gets a `responderStart` for any touch while responder.
-    config.responderStart.child = {order: 4};
-    //                                           /  Two active touches  \  /one of them new\
-    run(config, three, startConfig(three.parent, [three.child, three.parent], [1]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
-
-
-    // Now, move that new touch that had no effect, and did not start within
-    // the current responder.
-    config = oneEventLoopTestConfig(three);
-    config.moveShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.moveShouldSetResponder.captured.parent = {order: 1, returnVal: false};
-    config.moveShouldSetResponder.bubbled.parent = {order: 2, returnVal: false};
-    config.moveShouldSetResponder.bubbled.grandParent = {order: 3, returnVal: false};
-    // Interesting: child still gets moves even though touch target is parent!
-    // Current responder gets a `responderMove` for any touch while responder.
-    config.responderMove.child = {order: 4};
-    //                                     /  Two active touches  \  /one of them moved\
-    run(config, three, moveConfig(three.parent, [three.child, three.parent], [1]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
-
-
-    config = oneEventLoopTestConfig(three);
-    config.responderEnd.child = {order: 0};
-    config.responderRelease.child = {order: 1};
-    //                                        /child end \ /parent remain\
-    run(config, three, endConfig(three.child, [three.child, three.parent], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(null);
-  });
-
-
-  /**
-   * If nothing is responder, then the negotiation should propagate directly to
-   * the deepest target in the second touch.
-   */
-  it('should negotiate until first common ancestor when there are siblings', () => {
-    // Initially nothing wants to become the responder
-    var config = oneEventLoopTestConfig(siblings);
-    config.startShouldSetResponder.captured.parent = {order: 0, returnVal: false};
-    config.startShouldSetResponder.captured.childOne = {order: 1, returnVal: false};
-    config.startShouldSetResponder.bubbled.childOne = {order: 2, returnVal: true};
-    config.responderGrant.childOne = {order: 3};
-    config.responderStart.childOne = {order: 4};
-
-    run(config, siblings, startConfig(siblings.childOne, [siblings.childOne], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(siblings.childOne);
-
-    // If the touch target is the sibling item, the negotiation should only
-    // propagate to first common ancestor of current responder and sibling (so
-    // the parent).
-    config = oneEventLoopTestConfig(siblings);
-    config.startShouldSetResponder.captured.parent = {order: 0, returnVal: false};
-    config.startShouldSetResponder.bubbled.parent = {order: 1, returnVal: false};
-    config.responderStart.childOne = {order: 2};
-
-    var touchConfig =
-      startConfig(siblings.childTwo, [siblings.childOne, siblings.childTwo], [1]);
-    run(config, siblings, touchConfig);
-    expect(ResponderEventPlugin._getResponderID()).toBe(siblings.childOne);
-
-
-    // move childOne
-    config = oneEventLoopTestConfig(siblings);
-    config.moveShouldSetResponder.captured.parent = {order: 0, returnVal: false};
-    config.moveShouldSetResponder.bubbled.parent = {order: 1, returnVal: false};
-    config.responderMove.childOne = {order: 2};
-    run(config, siblings, moveConfig(siblings.childOne, [siblings.childOne, siblings.childTwo], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(siblings.childOne);
-
-    // move childTwo: Only negotiates to `parent`.
-    config = oneEventLoopTestConfig(siblings);
-    config.moveShouldSetResponder.captured.parent = {order: 0, returnVal: false};
-    config.moveShouldSetResponder.bubbled.parent = {order: 1, returnVal: false};
-    config.responderMove.childOne = {order: 2};
-    run(config, siblings, moveConfig(siblings.childTwo, [siblings.childOne, siblings.childTwo], [1]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(siblings.childOne);
-
-  });
-
-
-  it('should notify of being rejected. responderStart/Move happens on current responder', () => {
-    // Initially nothing wants to become the responder
-    var config = oneEventLoopTestConfig(three);
-    config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
-    config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
-    config.startShouldSetResponder.bubbled.child = {order: 3, returnVal: true};
-    config.responderGrant.child = {order: 4};
-    config.responderStart.child = {order: 5};
-
-    run(config, three, startConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
-
-    // Suppose parent wants to become responder on move, and is rejected
-    config = oneEventLoopTestConfig(three);
-    config.moveShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.moveShouldSetResponder.captured.parent = {order: 1, returnVal: false};
-    config.moveShouldSetResponder.bubbled.parent = {order: 2, returnVal: true};
-    config.responderGrant.parent = {order: 3};
-    config.responderTerminationRequest.child = {order: 4, returnVal: false};
-    config.responderReject.parent = {order: 5};
-    // The start/move should occur on the original responder if new one is rejected
-    config.responderMove.child = {order: 6};
-
-    var touchConfig =
-      moveConfig(three.child, [three.child], [0]);
-    run(config, three, touchConfig);
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
-
-    config = oneEventLoopTestConfig(three);
-    config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
-    config.startShouldSetResponder.bubbled.parent = {order: 2, returnVal: true};
-    config.responderGrant.parent = {order: 3};
-    config.responderTerminationRequest.child = {order: 4, returnVal: false};
-    config.responderReject.parent = {order: 5};
-    // The start/move should occur on the original responder if new one is rejected
-    config.responderStart.child = {order: 6};
-
-    touchConfig =
-      startConfig(three.child, [three.child, three.child], [1]);
-    run(config, three, touchConfig);
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
-
-  });
-
-
-  it('should negotiate scroll', () => {
-    // Initially nothing wants to become the responder
-    var config = oneEventLoopTestConfig(three);
-    config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
-    config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
-    config.startShouldSetResponder.bubbled.child = {order: 3, returnVal: true};
-    config.responderGrant.child = {order: 4};
-    config.responderStart.child = {order: 5};
-
-    run(config, three, startConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
-
-    // If the touch target is the sibling item, the negotiation should only
-    // propagate to first common ancestor of current responder and sibling (so
-    // the parent).
-    config = oneEventLoopTestConfig(three);
-    config.scrollShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.scrollShouldSetResponder.captured.parent = {order: 1, returnVal: false};
-    config.scrollShouldSetResponder.bubbled.parent = {order: 2, returnVal: true};
-    config.responderGrant.parent = {order: 3};
-    config.responderTerminationRequest.child = {order: 4, returnVal: false};
-    config.responderReject.parent = {order: 5};
-
-    run(config, three, {
-      topLevelType: 'topScroll',
-      targetInst: idToInstance[three.parent],
-      nativeEvent: {},
-    });
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
-
-
-    // Now lets let the scroll take control this time.
-    config = oneEventLoopTestConfig(three);
-    config.scrollShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.scrollShouldSetResponder.captured.parent = {order: 1, returnVal: false};
-    config.scrollShouldSetResponder.bubbled.parent = {order: 2, returnVal: true};
-    config.responderGrant.parent = {order: 3};
-    config.responderTerminationRequest.child = {order: 4, returnVal: true};
-    config.responderTerminate.child = {order: 5};
-
-    run(config, three, {
-      topLevelType: 'topScroll',
-      targetInst: idToInstance[three.parent],
-      nativeEvent: {},
-    });
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.parent);
-
-
-  });
-
-  it('should cancel correctly', () => {
-    // Initially our child becomes responder
-    var config = oneEventLoopTestConfig(three);
-    config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
-    config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
-    config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
-    config.startShouldSetResponder.bubbled.child = {order: 3, returnVal: true};
-    config.responderGrant.child = {order: 4};
-    config.responderStart.child = {order: 5};
-
-    run(config, three, startConfig(three.child, [three.child], [0]));
-    expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
-
-    config = oneEventLoopTestConfig(three);
-    config.responderEnd.child = {order: 0};
-    config.responderTerminate.child = {order: 1};
-
-    var nativeEvent = _touchConfig(
-      'topTouchCancel',
-      three.child,
-      [three.child],
-      [0]
-    );
-    run(config, three, nativeEvent);
-    expect(ResponderEventPlugin._getResponderID()).toBe(null);
-  });
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.parent);
+
+
+});
+
+it('should cancel correctly', () => {
+  // Initially our child becomes responder
+  var config = oneEventLoopTestConfig(three);
+  config.startShouldSetResponder.captured.grandParent = {order: 0, returnVal: false};
+  config.startShouldSetResponder.captured.parent = {order: 1, returnVal: false};
+  config.startShouldSetResponder.captured.child = {order: 2, returnVal: false};
+  config.startShouldSetResponder.bubbled.child = {order: 3, returnVal: true};
+  config.responderGrant.child = {order: 4};
+  config.responderStart.child = {order: 5};
+
+  run(config, three, startConfig(three.child, [three.child], [0]));
+  expect(ResponderEventPlugin._getResponderID()).toBe(three.child);
+
+  config = oneEventLoopTestConfig(three);
+  config.responderEnd.child = {order: 0};
+  config.responderTerminate.child = {order: 1};
+
+  var nativeEvent = _touchConfig(
+    'topTouchCancel',
+    three.child,
+    [three.child],
+    [0]
+  );
+  run(config, three, nativeEvent);
+  expect(ResponderEventPlugin._getResponderID()).toBe(null);
 });

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactComponent-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactComponent-test.js
@@ -19,313 +19,310 @@ function normalizeCodeLocInfo(str) {
   return str.replace(/\(at .+?:\d+\)/g, '(at **)');
 }
 
-describe('ReactComponent', function() {
-  beforeEach(function() {
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactTestUtils = require('ReactTestUtils');
-  });
+beforeEach(function() {
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactTestUtils = require('ReactTestUtils');
+});
 
-  it('should throw on invalid render targets', function() {
-    var container = document.createElement('div');
-    // jQuery objects are basically arrays; people often pass them in by mistake
-    expect(function() {
-      ReactDOM.render(<div></div>, [container]);
-    }).toThrowError(
-      '_registerComponent(...): Target container is not a DOM element.'
-    );
+it('should throw on invalid render targets', function() {
+  var container = document.createElement('div');
+  // jQuery objects are basically arrays; people often pass them in by mistake
+  expect(function() {
+    ReactDOM.render(<div></div>, [container]);
+  }).toThrowError(
+    '_registerComponent(...): Target container is not a DOM element.'
+  );
 
-    expect(function() {
-      ReactDOM.render(<div></div>, null);
-    }).toThrowError(
-      '_registerComponent(...): Target container is not a DOM element.'
-    );
-  });
+  expect(function() {
+    ReactDOM.render(<div></div>, null);
+  }).toThrowError(
+    '_registerComponent(...): Target container is not a DOM element.'
+  );
+});
 
-  it('should throw when supplying a ref outside of render method', function() {
-    var instance = <div ref="badDiv" />;
-    expect(function() {
-      instance = ReactTestUtils.renderIntoDocument(instance);
-    }).toThrow();
-  });
-
-  it('should warn when children are mutated before render', function() {
-    spyOn(console, 'error');
-    var children = [<span key={0} />, <span key={1} />, <span key={2} />];
-    var element = <div>{children}</div>;
-    children[1] = <p key={1} />; // Mutation is illegal
-    ReactTestUtils.renderIntoDocument(element);
-    expect(console.error.calls.count()).toBe(1);
-    expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-      'Warning: Component\'s children should not be mutated.\n    in div (at **)'
-    );
-  });
-
-  it('should warn when children are mutated', function() {
-    spyOn(console, 'error');
-    var children = [<span key={0} />, <span key={1} />, <span key={2} />];
-    function Wrapper(props) {
-      props.children[1] = <p key={1} />; // Mutation is illegal
-      return <div>{props.children}</div>;
-    }
-    ReactTestUtils.renderIntoDocument(<Wrapper>{children}</Wrapper>);
-    expect(console.error.calls.count()).toBe(1);
-    expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-      'Warning: Component\'s children should not be mutated.\n    in Wrapper (at **)'
-    );
-  });
-
-  it('should support refs on owned components', function() {
-    var innerObj = {};
-    var outerObj = {};
-
-    class Wrapper extends React.Component {
-      getObject = () => {
-        return this.props.object;
-      };
-
-      render() {
-        return <div>{this.props.children}</div>;
-      }
-    }
-
-    class Component extends React.Component {
-      render() {
-        var inner = <Wrapper object={innerObj} ref="inner" />;
-        var outer = <Wrapper object={outerObj} ref="outer">{inner}</Wrapper>;
-        return outer;
-      }
-
-      componentDidMount() {
-        expect(this.refs.inner.getObject()).toEqual(innerObj);
-        expect(this.refs.outer.getObject()).toEqual(outerObj);
-      }
-    }
-
-    var instance = <Component />;
+it('should throw when supplying a ref outside of render method', function() {
+  var instance = <div ref="badDiv" />;
+  expect(function() {
     instance = ReactTestUtils.renderIntoDocument(instance);
-  });
+  }).toThrow();
+});
 
-  it('should not have refs on unmounted components', function() {
-    class Parent extends React.Component {
-      render() {
-        return <Child><div ref="test" /></Child>;
-      }
+it('should warn when children are mutated before render', function() {
+  spyOn(console, 'error');
+  var children = [<span key={0} />, <span key={1} />, <span key={2} />];
+  var element = <div>{children}</div>;
+  children[1] = <p key={1} />; // Mutation is illegal
+  ReactTestUtils.renderIntoDocument(element);
+  expect(console.error.calls.count()).toBe(1);
+  expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+    'Warning: Component\'s children should not be mutated.\n    in div (at **)'
+  );
+});
 
-      componentDidMount() {
-        expect(this.refs && this.refs.test).toEqual(undefined);
-      }
+it('should warn when children are mutated', function() {
+  spyOn(console, 'error');
+  var children = [<span key={0} />, <span key={1} />, <span key={2} />];
+  function Wrapper(props) {
+    props.children[1] = <p key={1} />; // Mutation is illegal
+    return <div>{props.children}</div>;
+  }
+  ReactTestUtils.renderIntoDocument(<Wrapper>{children}</Wrapper>);
+  expect(console.error.calls.count()).toBe(1);
+  expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+    'Warning: Component\'s children should not be mutated.\n    in Wrapper (at **)'
+  );
+});
+
+it('should support refs on owned components', function() {
+  var innerObj = {};
+  var outerObj = {};
+
+  class Wrapper extends React.Component {
+    getObject = () => {
+      return this.props.object;
+    };
+
+    render() {
+      return <div>{this.props.children}</div>;
+    }
+  }
+
+  class Component extends React.Component {
+    render() {
+      var inner = <Wrapper object={innerObj} ref="inner" />;
+      var outer = <Wrapper object={outerObj} ref="outer">{inner}</Wrapper>;
+      return outer;
     }
 
-    class Child extends React.Component {
-      render() {
-        return <div />;
-      }
+    componentDidMount() {
+      expect(this.refs.inner.getObject()).toEqual(innerObj);
+      expect(this.refs.outer.getObject()).toEqual(outerObj);
+    }
+  }
+
+  var instance = <Component />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+});
+
+it('should not have refs on unmounted components', function() {
+  class Parent extends React.Component {
+    render() {
+      return <Child><div ref="test" /></Child>;
     }
 
-    var instance = <Parent child={<span />} />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-  });
+    componentDidMount() {
+      expect(this.refs && this.refs.test).toEqual(undefined);
+    }
+  }
 
-  it('should support new-style refs', function() {
-    var innerObj = {};
-    var outerObj = {};
+  class Child extends React.Component {
+    render() {
+      return <div />;
+    }
+  }
 
-    class Wrapper extends React.Component {
-      getObject = () => {
-        return this.props.object;
-      };
+  var instance = <Parent child={<span />} />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+});
 
-      render() {
-        return <div>{this.props.children}</div>;
-      }
+it('should support new-style refs', function() {
+  var innerObj = {};
+  var outerObj = {};
+
+  class Wrapper extends React.Component {
+    getObject = () => {
+      return this.props.object;
+    };
+
+    render() {
+      return <div>{this.props.children}</div>;
+    }
+  }
+
+  var mounted = false;
+
+  class Component extends React.Component {
+    render() {
+      var inner = <Wrapper object={innerObj} ref={(c) => this.innerRef = c} />;
+      var outer = (
+        <Wrapper object={outerObj} ref={(c) => this.outerRef = c}>
+          {inner}
+        </Wrapper>
+      );
+      return outer;
     }
 
-    var mounted = false;
+    componentDidMount() {
+      expect(this.innerRef.getObject()).toEqual(innerObj);
+      expect(this.outerRef.getObject()).toEqual(outerObj);
+      mounted = true;
+    }
+  }
 
-    class Component extends React.Component {
-      render() {
-        var inner = <Wrapper object={innerObj} ref={(c) => this.innerRef = c} />;
-        var outer = (
-          <Wrapper object={outerObj} ref={(c) => this.outerRef = c}>
-            {inner}
-          </Wrapper>
-        );
-        return outer;
-      }
+  var instance = <Component />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  expect(mounted).toBe(true);
+});
 
-      componentDidMount() {
-        expect(this.innerRef.getObject()).toEqual(innerObj);
-        expect(this.outerRef.getObject()).toEqual(outerObj);
-        mounted = true;
-      }
+it('should support new-style refs with mixed-up owners', function() {
+  class Wrapper extends React.Component {
+    getTitle = () => {
+      return this.props.title;
+    };
+
+    render() {
+      return this.props.getContent();
+    }
+  }
+
+  var mounted = false;
+
+  class Component extends React.Component {
+    getInner = () => {
+      // (With old-style refs, it's impossible to get a ref to this div
+      // because Wrapper is the current owner when this function is called.)
+      return <div title="inner" ref={(c) => this.innerRef = c} />;
+    };
+
+    render() {
+      return (
+        <Wrapper
+          title="wrapper"
+          ref={(c) => this.wrapperRef = c}
+          getContent={this.getInner}
+          />
+      );
     }
 
-    var instance = <Component />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-    expect(mounted).toBe(true);
-  });
+    componentDidMount() {
+      // Check .props.title to make sure we got the right elements back
+      expect(this.wrapperRef.getTitle()).toBe('wrapper');
+      expect(ReactDOM.findDOMNode(this.innerRef).title).toBe('inner');
+      mounted = true;
+    }
+  }
 
-  it('should support new-style refs with mixed-up owners', function() {
-    class Wrapper extends React.Component {
-      getTitle = () => {
-        return this.props.title;
-      };
+  var instance = <Component />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  expect(mounted).toBe(true);
+});
 
-      render() {
-        return this.props.getContent();
-      }
+it('should call refs at the correct time', function() {
+  var log = [];
+
+  class Inner extends React.Component {
+    render() {
+      log.push(`inner ${this.props.id} render`);
+      return <div />;
     }
 
-    var mounted = false;
-
-    class Component extends React.Component {
-      getInner = () => {
-        // (With old-style refs, it's impossible to get a ref to this div
-        // because Wrapper is the current owner when this function is called.)
-        return <div title="inner" ref={(c) => this.innerRef = c} />;
-      };
-
-      render() {
-        return (
-          <Wrapper
-            title="wrapper"
-            ref={(c) => this.wrapperRef = c}
-            getContent={this.getInner}
-            />
-        );
-      }
-
-      componentDidMount() {
-        // Check .props.title to make sure we got the right elements back
-        expect(this.wrapperRef.getTitle()).toBe('wrapper');
-        expect(ReactDOM.findDOMNode(this.innerRef).title).toBe('inner');
-        mounted = true;
-      }
+    componentDidMount() {
+      log.push(`inner ${this.props.id} componentDidMount`);
     }
 
-    var instance = <Component />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-    expect(mounted).toBe(true);
-  });
-
-  it('should call refs at the correct time', function() {
-    var log = [];
-
-    class Inner extends React.Component {
-      render() {
-        log.push(`inner ${this.props.id} render`);
-        return <div />;
-      }
-
-      componentDidMount() {
-        log.push(`inner ${this.props.id} componentDidMount`);
-      }
-
-      componentDidUpdate() {
-        log.push(`inner ${this.props.id} componentDidUpdate`);
-      }
-
-      componentWillUnmount() {
-        log.push(`inner ${this.props.id} componentWillUnmount`);
-      }
+    componentDidUpdate() {
+      log.push(`inner ${this.props.id} componentDidUpdate`);
     }
 
-    class Outer extends React.Component {
-      render() {
-        return (
-          <div>
-            <Inner id={1} ref={(c) => {
-              log.push(`ref 1 got ${c ? `instance ${c.props.id}` : 'null'}`);
-            }}/>
-            <Inner id={2} ref={(c) => {
-              log.push(`ref 2 got ${c ? `instance ${c.props.id}` : 'null'}`);
-            }}/>
-          </div>
-        );
-      }
+    componentWillUnmount() {
+      log.push(`inner ${this.props.id} componentWillUnmount`);
+    }
+  }
 
-      componentDidMount() {
-        log.push('outer componentDidMount');
-      }
-
-      componentDidUpdate() {
-        log.push('outer componentDidUpdate');
-      }
-
-      componentWillUnmount() {
-        log.push('outer componentWillUnmount');
-      }
+  class Outer extends React.Component {
+    render() {
+      return (
+        <div>
+          <Inner id={1} ref={(c) => {
+            log.push(`ref 1 got ${c ? `instance ${c.props.id}` : 'null'}`);
+          }}/>
+          <Inner id={2} ref={(c) => {
+            log.push(`ref 2 got ${c ? `instance ${c.props.id}` : 'null'}`);
+          }}/>
+        </div>
+      );
     }
 
-    // mount, update, unmount
-    var el = document.createElement('div');
-    log.push('start mount');
-    ReactDOM.render(<Outer />, el);
-    log.push('start update');
-    ReactDOM.render(<Outer />, el);
-    log.push('start unmount');
-    ReactDOM.unmountComponentAtNode(el);
+    componentDidMount() {
+      log.push('outer componentDidMount');
+    }
 
-    /* eslint-disable indent */
-    expect(log).toEqual([
-      'start mount',
-        'inner 1 render',
-        'inner 2 render',
-        'inner 1 componentDidMount',
-        'ref 1 got instance 1',
-        'inner 2 componentDidMount',
-        'ref 2 got instance 2',
-        'outer componentDidMount',
-      'start update',
-        // Previous (equivalent) refs get cleared
-        'ref 1 got null',
-        'inner 1 render',
-        'ref 2 got null',
-        'inner 2 render',
-        'inner 1 componentDidUpdate',
-        'ref 1 got instance 1',
-        'inner 2 componentDidUpdate',
-        'ref 2 got instance 2',
-        'outer componentDidUpdate',
-      'start unmount',
-        'outer componentWillUnmount',
-        'ref 1 got null',
-        'inner 1 componentWillUnmount',
-        'ref 2 got null',
-        'inner 2 componentWillUnmount',
-    ]);
-    /* eslint-enable indent */
-  });
+    componentDidUpdate() {
+      log.push('outer componentDidUpdate');
+    }
 
-  it('fires the callback after a component is rendered', function() {
-    var callback = jest.fn();
-    var container = document.createElement('div');
-    ReactDOM.render(<div />, container, callback);
-    expect(callback.mock.calls.length).toBe(1);
-    ReactDOM.render(<div className="foo" />, container, callback);
-    expect(callback.mock.calls.length).toBe(2);
-    ReactDOM.render(<span />, container, callback);
-    expect(callback.mock.calls.length).toBe(3);
-  });
+    componentWillUnmount() {
+      log.push('outer componentWillUnmount');
+    }
+  }
 
-  it('throws usefully when rendering badly-typed elements', function() {
-    spyOn(console, 'error');
+  // mount, update, unmount
+  var el = document.createElement('div');
+  log.push('start mount');
+  ReactDOM.render(<Outer />, el);
+  log.push('start update');
+  ReactDOM.render(<Outer />, el);
+  log.push('start unmount');
+  ReactDOM.unmountComponentAtNode(el);
 
-    var X = undefined;
-    expect(() => ReactTestUtils.renderIntoDocument(<X />)).toThrowError(
-      'Element type is invalid: expected a string (for built-in components) ' +
-      'or a class/function (for composite components) but got: undefined.'
-    );
+  /* eslint-disable indent */
+  expect(log).toEqual([
+    'start mount',
+      'inner 1 render',
+      'inner 2 render',
+      'inner 1 componentDidMount',
+      'ref 1 got instance 1',
+      'inner 2 componentDidMount',
+      'ref 2 got instance 2',
+      'outer componentDidMount',
+    'start update',
+      // Previous (equivalent) refs get cleared
+      'ref 1 got null',
+      'inner 1 render',
+      'ref 2 got null',
+      'inner 2 render',
+      'inner 1 componentDidUpdate',
+      'ref 1 got instance 1',
+      'inner 2 componentDidUpdate',
+      'ref 2 got instance 2',
+      'outer componentDidUpdate',
+    'start unmount',
+      'outer componentWillUnmount',
+      'ref 1 got null',
+      'inner 1 componentWillUnmount',
+      'ref 2 got null',
+      'inner 2 componentWillUnmount',
+  ]);
+  /* eslint-enable indent */
+});
 
-    var Y = null;
-    expect(() => ReactTestUtils.renderIntoDocument(<Y />)).toThrowError(
-      'Element type is invalid: expected a string (for built-in components) ' +
-      'or a class/function (for composite components) but got: null.'
-    );
+it('fires the callback after a component is rendered', function() {
+  var callback = jest.fn();
+  var container = document.createElement('div');
+  ReactDOM.render(<div />, container, callback);
+  expect(callback.mock.calls.length).toBe(1);
+  ReactDOM.render(<div className="foo" />, container, callback);
+  expect(callback.mock.calls.length).toBe(2);
+  ReactDOM.render(<span />, container, callback);
+  expect(callback.mock.calls.length).toBe(3);
+});
 
-    // One warning for each element creation
-    expect(console.error.calls.count()).toBe(2);
-  });
+it('throws usefully when rendering badly-typed elements', function() {
+  spyOn(console, 'error');
 
+  var X = undefined;
+  expect(() => ReactTestUtils.renderIntoDocument(<X />)).toThrowError(
+    'Element type is invalid: expected a string (for built-in components) ' +
+    'or a class/function (for composite components) but got: undefined.'
+  );
+
+  var Y = null;
+  expect(() => ReactTestUtils.renderIntoDocument(<Y />)).toThrowError(
+    'Element type is invalid: expected a string (for built-in components) ' +
+    'or a class/function (for composite components) but got: null.'
+  );
+
+  // One warning for each element creation
+  expect(console.error.calls.count()).toBe(2);
 });

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactComponentLifeCycle-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactComponentLifeCycle-test.js
@@ -86,513 +86,504 @@ function getLifeCycleState(instance): ComponentLifeCycle {
          'UNMOUNTED';
 }
 
+beforeEach(function() {
+  jest.resetModuleRegistry();
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactTestUtils = require('ReactTestUtils');
+  ReactInstanceMap = require('ReactInstanceMap');
+});
+
+it('should not reuse an instance when it has been unmounted', function() {
+  var container = document.createElement('div');
+
+  class StatefulComponent extends React.Component {
+    state = {};
+
+    render() {
+      return (
+        <div></div>
+      );
+    }
+  }
+
+  var element = <StatefulComponent />;
+  var firstInstance = ReactDOM.render(element, container);
+  ReactDOM.unmountComponentAtNode(container);
+  var secondInstance = ReactDOM.render(element, container);
+  expect(firstInstance).not.toBe(secondInstance);
+});
+
 /**
- * TODO: We should make any setState calls fail in
- * `getInitialState` and `componentWillMount`. They will usually fail
- * anyways because `this._renderedComponent` is empty, however, if a component
- * is *reused*, then that won't be the case and things will appear to work in
- * some cases. Better to just block all updates in initialization.
+ * If a state update triggers rerendering that in turn fires an onDOMReady,
+ * that second onDOMReady should not fail.
  */
-describe('ReactComponentLifeCycle', function() {
-  beforeEach(function() {
-    jest.resetModuleRegistry();
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactTestUtils = require('ReactTestUtils');
-    ReactInstanceMap = require('ReactInstanceMap');
-  });
+it('it should fire onDOMReady when already in onDOMReady', function() {
+  var _testJournal = [];
 
-  it('should not reuse an instance when it has been unmounted', function() {
-    var container = document.createElement('div');
-
-    class StatefulComponent extends React.Component {
-      state = {};
-
-      render() {
-        return (
-          <div></div>
-        );
-      }
+  class Child extends React.Component {
+    componentDidMount() {
+      _testJournal.push('Child:onDOMReady');
     }
 
-    var element = <StatefulComponent />;
-    var firstInstance = ReactDOM.render(element, container);
-    ReactDOM.unmountComponentAtNode(container);
-    var secondInstance = ReactDOM.render(element, container);
-    expect(firstInstance).not.toBe(secondInstance);
-  });
+    render() {
+      return <div></div>;
+    }
+  }
 
-  /**
-   * If a state update triggers rerendering that in turn fires an onDOMReady,
-   * that second onDOMReady should not fail.
-   */
-  it('it should fire onDOMReady when already in onDOMReady', function() {
-    var _testJournal = [];
-
-    class Child extends React.Component {
-      componentDidMount() {
-        _testJournal.push('Child:onDOMReady');
-      }
-
-      render() {
-        return <div></div>;
-      }
+  class SwitcherParent extends React.Component {
+    constructor(props) {
+      super(props);
+      _testJournal.push('SwitcherParent:getInitialState');
+      this.state = {showHasOnDOMReadyComponent: false};
     }
 
-    class SwitcherParent extends React.Component {
-      constructor(props) {
-        super(props);
-        _testJournal.push('SwitcherParent:getInitialState');
-        this.state = {showHasOnDOMReadyComponent: false};
-      }
-
-      componentDidMount() {
-        _testJournal.push('SwitcherParent:onDOMReady');
-        this.switchIt();
-      }
-
-      switchIt = () => {
-        this.setState({showHasOnDOMReadyComponent: true});
-      };
-
-      render() {
-        return (
-          <div>{
-            this.state.showHasOnDOMReadyComponent ?
-            <Child /> :
-            <div> </div>
-          }</div>
-        );
-      }
+    componentDidMount() {
+      _testJournal.push('SwitcherParent:onDOMReady');
+      this.switchIt();
     }
 
-    var instance = <SwitcherParent />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-    expect(_testJournal).toEqual([
-      'SwitcherParent:getInitialState',
-      'SwitcherParent:onDOMReady',
-      'Child:onDOMReady',
-    ]);
-  });
-
-  // You could assign state here, but not access members of it, unless you
-  // had provided a getInitialState method.
-  it('throws when accessing state in componentWillMount', function() {
-    class StatefulComponent extends React.Component {
-      componentWillMount() {
-        void this.state.yada;
-      }
-
-      render() {
-        return (
-          <div></div>
-        );
-      }
-    }
-
-    var instance = <StatefulComponent />;
-    expect(function() {
-      instance = ReactTestUtils.renderIntoDocument(instance);
-    }).toThrow();
-  });
-
-  it('should allow update state inside of componentWillMount', function() {
-    class StatefulComponent extends React.Component {
-      componentWillMount() {
-        this.setState({stateField: 'something'});
-      }
-
-      render() {
-        return (
-          <div></div>
-        );
-      }
-    }
-
-    var instance = <StatefulComponent />;
-    expect(function() {
-      instance = ReactTestUtils.renderIntoDocument(instance);
-    }).not.toThrow();
-  });
-
-  it('should not allow update state inside of getInitialState', function() {
-    spyOn(console, 'error');
-
-    class StatefulComponent extends React.Component {
-      constructor(props, context) {
-        super(props, context);
-        this.setState({stateField: 'something'});
-
-        this.state = {stateField: 'somethingelse'};
-      }
-
-      render() {
-        return (
-          <div></div>
-        );
-      }
-    }
-
-    ReactTestUtils.renderIntoDocument(<StatefulComponent />);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: setState(...): Can only update a mounted or ' +
-      'mounting component. This usually means you called setState() on an ' +
-      'unmounted component. This is a no-op. Please check the code for the ' +
-      'StatefulComponent component.'
-    );
-  });
-
-  it('should correctly determine if a component is mounted', function() {
-    spyOn(console, 'error');
-    var Component = React.createClass({
-      componentWillMount: function() {
-        expect(this.isMounted()).toBeFalsy();
-      },
-      componentDidMount: function() {
-        expect(this.isMounted()).toBeTruthy();
-      },
-      render: function() {
-        expect(this.isMounted()).toBeFalsy();
-        return <div/>;
-      },
-    });
-
-    var element = <Component />;
-
-    var instance = ReactTestUtils.renderIntoDocument(element);
-    expect(instance.isMounted()).toBeTruthy();
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Component is accessing isMounted inside its render()'
-    );
-  });
-
-  it('should correctly determine if a null component is mounted', function() {
-    spyOn(console, 'error');
-    var Component = React.createClass({
-      componentWillMount: function() {
-        expect(this.isMounted()).toBeFalsy();
-      },
-      componentDidMount: function() {
-        expect(this.isMounted()).toBeTruthy();
-      },
-      render: function() {
-        expect(this.isMounted()).toBeFalsy();
-        return null;
-      },
-    });
-
-    var element = <Component />;
-
-    var instance = ReactTestUtils.renderIntoDocument(element);
-    expect(instance.isMounted()).toBeTruthy();
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Component is accessing isMounted inside its render()'
-    );
-  });
-
-  it('isMounted should return false when unmounted', function() {
-    var Component = React.createClass({
-      render: function() {
-        return <div/>;
-      },
-    });
-
-    var container = document.createElement('div');
-    var instance = ReactDOM.render(<Component />, container);
-
-    expect(instance.isMounted()).toBe(true);
-
-    ReactDOM.unmountComponentAtNode(container);
-
-    expect(instance.isMounted()).toBe(false);
-  });
-
-  it('warns if findDOMNode is used inside render', function() {
-    spyOn(console, 'error');
-    var Component = React.createClass({
-      getInitialState: function() {
-        return {isMounted: false};
-      },
-      componentDidMount: function() {
-        this.setState({isMounted: true});
-      },
-      render: function() {
-        if (this.state.isMounted) {
-          expect(ReactDOM.findDOMNode(this).tagName).toBe('DIV');
-        }
-        return <div/>;
-      },
-    });
-
-    ReactTestUtils.renderIntoDocument(<Component />);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Component is accessing findDOMNode inside its render()'
-    );
-  });
-
-  it('should carry through each of the phases of setup', function() {
-    class LifeCycleComponent extends React.Component {
-      constructor(props, context) {
-        super(props, context);
-        this._testJournal = {};
-        var initState = {
-          hasWillMountCompleted: false,
-          hasDidMountCompleted: false,
-          hasRenderCompleted: false,
-          hasWillUnmountCompleted: false,
-        };
-        this._testJournal.returnedFromGetInitialState = clone(initState);
-        this._testJournal.lifeCycleAtStartOfGetInitialState =
-          getLifeCycleState(this);
-        this.state = initState;
-      }
-
-      componentWillMount() {
-        this._testJournal.stateAtStartOfWillMount = clone(this.state);
-        this._testJournal.lifeCycleAtStartOfWillMount =
-          getLifeCycleState(this);
-        this.state.hasWillMountCompleted = true;
-      }
-
-      componentDidMount() {
-        this._testJournal.stateAtStartOfDidMount = clone(this.state);
-        this._testJournal.lifeCycleAtStartOfDidMount =
-          getLifeCycleState(this);
-        this.setState({hasDidMountCompleted: true});
-      }
-
-      render() {
-        var isInitialRender = !this.state.hasRenderCompleted;
-        if (isInitialRender) {
-          this._testJournal.stateInInitialRender = clone(this.state);
-          this._testJournal.lifeCycleInInitialRender = getLifeCycleState(this);
-        } else {
-          this._testJournal.stateInLaterRender = clone(this.state);
-          this._testJournal.lifeCycleInLaterRender = getLifeCycleState(this);
-        }
-        // you would *NEVER* do anything like this in real code!
-        this.state.hasRenderCompleted = true;
-        return (
-          <div ref="theDiv">
-            I am the inner DIV
-          </div>
-        );
-      }
-
-      componentWillUnmount() {
-        this._testJournal.stateAtStartOfWillUnmount = clone(this.state);
-        this._testJournal.lifeCycleAtStartOfWillUnmount =
-          getLifeCycleState(this);
-        this.state.hasWillUnmountCompleted = true;
-      }
-    }
-
-    // A component that is merely "constructed" (as in "constructor") but not
-    // yet initialized, or rendered.
-    //
-    var container = document.createElement('div');
-    var instance = ReactDOM.render(<LifeCycleComponent />, container);
-
-    // getInitialState
-    expect(instance._testJournal.returnedFromGetInitialState).toEqual(
-      GET_INIT_STATE_RETURN_VAL
-    );
-    expect(instance._testJournal.lifeCycleAtStartOfGetInitialState)
-      .toBe('UNMOUNTED');
-
-    // componentWillMount
-    expect(instance._testJournal.stateAtStartOfWillMount).toEqual(
-      instance._testJournal.returnedFromGetInitialState
-    );
-    expect(instance._testJournal.lifeCycleAtStartOfWillMount)
-      .toBe('MOUNTED');
-
-    // componentDidMount
-    expect(instance._testJournal.stateAtStartOfDidMount)
-      .toEqual(DID_MOUNT_STATE);
-    expect(instance._testJournal.lifeCycleAtStartOfDidMount).toBe(
-      'MOUNTED'
-    );
-
-    // render
-    expect(instance._testJournal.stateInInitialRender)
-      .toEqual(INIT_RENDER_STATE);
-    expect(instance._testJournal.lifeCycleInInitialRender).toBe(
-      'MOUNTED'
-    );
-
-    expect(getLifeCycleState(instance)).toBe('MOUNTED');
-
-    // Now *update the component*
-    instance.forceUpdate();
-
-    // render 2nd time
-    expect(instance._testJournal.stateInLaterRender)
-      .toEqual(NEXT_RENDER_STATE);
-    expect(instance._testJournal.lifeCycleInLaterRender).toBe(
-      'MOUNTED'
-    );
-
-    expect(getLifeCycleState(instance)).toBe('MOUNTED');
-
-    ReactDOM.unmountComponentAtNode(container);
-
-    expect(instance._testJournal.stateAtStartOfWillUnmount)
-      .toEqual(WILL_UNMOUNT_STATE);
-    // componentWillUnmount called right before unmount.
-    expect(instance._testJournal.lifeCycleAtStartOfWillUnmount).toBe(
-      'MOUNTED'
-    );
-
-    // But the current lifecycle of the component is unmounted.
-    expect(getLifeCycleState(instance)).toBe('UNMOUNTED');
-    expect(instance.state).toEqual(POST_WILL_UNMOUNT_STATE);
-  });
-
-  it('should not throw when updating an auxiliary component', function() {
-    class Tooltip extends React.Component {
-      render() {
-        return <div>{this.props.children}</div>;
-      }
-
-      componentDidMount() {
-        this.container = document.createElement('div');
-        this.updateTooltip();
-      }
-
-      componentDidUpdate() {
-        this.updateTooltip();
-      }
-
-      updateTooltip = () => {
-        // Even though this.props.tooltip has an owner, updating it shouldn't
-        // throw here because it's mounted as a root component
-        ReactDOM.render(this.props.tooltip, this.container);
-      };
-    }
-
-    class Component extends React.Component {
-      render() {
-        return (
-          <Tooltip
-              ref="tooltip"
-              tooltip={<div>{this.props.tooltipText}</div>}>
-            {this.props.text}
-          </Tooltip>
-        );
-      }
-    }
-
-    var container = document.createElement('div');
-    ReactDOM.render(
-      <Component text="uno" tooltipText="one" />,
-      container
-    );
-
-    // Since `instance` is a root component, we can set its props. This also
-    // makes Tooltip rerender the tooltip component, which shouldn't throw.
-    ReactDOM.render(
-      <Component text="dos" tooltipText="two" />,
-      container
-    );
-  });
-
-  it('should allow state updates in componentDidMount', function() {
-    /**
-     * calls setState in an componentDidMount.
-     */
-    class SetStateInComponentDidMount extends React.Component {
-      state = {
-        stateField: this.props.valueToUseInitially,
-      };
-
-      componentDidMount() {
-        this.setState({stateField: this.props.valueToUseInOnDOMReady});
-      }
-
-      render() {
-        return (<div></div>);
-      }
-    }
-
-    var instance =
-      <SetStateInComponentDidMount
-        valueToUseInitially="hello"
-        valueToUseInOnDOMReady="goodbye"
-      />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-    expect(instance.state.stateField).toBe('goodbye');
-  });
-
-  it('should call nested lifecycle methods in the right order', function() {
-    var log;
-    var logger = function(msg) {
-      return function() {
-        // return true for shouldComponentUpdate
-        log.push(msg);
-        return true;
-      };
+    switchIt = () => {
+      this.setState({showHasOnDOMReadyComponent: true});
     };
-    var Outer = React.createClass({
-      render: function() {
-        return <div><Inner x={this.props.x} /></div>;
-      },
-      componentWillMount: logger('outer componentWillMount'),
-      componentDidMount: logger('outer componentDidMount'),
-      componentWillReceiveProps: logger('outer componentWillReceiveProps'),
-      shouldComponentUpdate: logger('outer shouldComponentUpdate'),
-      componentWillUpdate: logger('outer componentWillUpdate'),
-      componentDidUpdate: logger('outer componentDidUpdate'),
-      componentWillUnmount: logger('outer componentWillUnmount'),
-    });
-    var Inner = React.createClass({
-      render: function() {
-        return <span>{this.props.x}</span>;
-      },
-      componentWillMount: logger('inner componentWillMount'),
-      componentDidMount: logger('inner componentDidMount'),
-      componentWillReceiveProps: logger('inner componentWillReceiveProps'),
-      shouldComponentUpdate: logger('inner shouldComponentUpdate'),
-      componentWillUpdate: logger('inner componentWillUpdate'),
-      componentDidUpdate: logger('inner componentDidUpdate'),
-      componentWillUnmount: logger('inner componentWillUnmount'),
-    });
 
+    render() {
+      return (
+        <div>{
+          this.state.showHasOnDOMReadyComponent ?
+          <Child /> :
+          <div> </div>
+        }</div>
+      );
+    }
+  }
 
-    var container = document.createElement('div');
-    log = [];
-    ReactDOM.render(<Outer x={17} />, container);
-    expect(log).toEqual([
-      'outer componentWillMount',
-      'inner componentWillMount',
-      'inner componentDidMount',
-      'outer componentDidMount',
-    ]);
+  var instance = <SwitcherParent />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  expect(_testJournal).toEqual([
+    'SwitcherParent:getInitialState',
+    'SwitcherParent:onDOMReady',
+    'Child:onDOMReady',
+  ]);
+});
 
-    log = [];
-    ReactDOM.render(<Outer x={42} />, container);
-    expect(log).toEqual([
-      'outer componentWillReceiveProps',
-      'outer shouldComponentUpdate',
-      'outer componentWillUpdate',
-      'inner componentWillReceiveProps',
-      'inner shouldComponentUpdate',
-      'inner componentWillUpdate',
-      'inner componentDidUpdate',
-      'outer componentDidUpdate',
-    ]);
+// You could assign state here, but not access members of it, unless you
+// had provided a getInitialState method.
+it('throws when accessing state in componentWillMount', function() {
+  class StatefulComponent extends React.Component {
+    componentWillMount() {
+      void this.state.yada;
+    }
 
-    log = [];
-    ReactDOM.unmountComponentAtNode(container);
-    expect(log).toEqual([
-      'outer componentWillUnmount',
-      'inner componentWillUnmount',
-    ]);
+    render() {
+      return (
+        <div></div>
+      );
+    }
+  }
+
+  var instance = <StatefulComponent />;
+  expect(function() {
+    instance = ReactTestUtils.renderIntoDocument(instance);
+  }).toThrow();
+});
+
+it('should allow update state inside of componentWillMount', function() {
+  class StatefulComponent extends React.Component {
+    componentWillMount() {
+      this.setState({stateField: 'something'});
+    }
+
+    render() {
+      return (
+        <div></div>
+      );
+    }
+  }
+
+  var instance = <StatefulComponent />;
+  expect(function() {
+    instance = ReactTestUtils.renderIntoDocument(instance);
+  }).not.toThrow();
+});
+
+it('should not allow update state inside of getInitialState', function() {
+  spyOn(console, 'error');
+
+  class StatefulComponent extends React.Component {
+    constructor(props, context) {
+      super(props, context);
+      this.setState({stateField: 'something'});
+
+      this.state = {stateField: 'somethingelse'};
+    }
+
+    render() {
+      return (
+        <div></div>
+      );
+    }
+  }
+
+  ReactTestUtils.renderIntoDocument(<StatefulComponent />);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: setState(...): Can only update a mounted or ' +
+    'mounting component. This usually means you called setState() on an ' +
+    'unmounted component. This is a no-op. Please check the code for the ' +
+    'StatefulComponent component.'
+  );
+});
+
+it('should correctly determine if a component is mounted', function() {
+  spyOn(console, 'error');
+  var Component = React.createClass({
+    componentWillMount: function() {
+      expect(this.isMounted()).toBeFalsy();
+    },
+    componentDidMount: function() {
+      expect(this.isMounted()).toBeTruthy();
+    },
+    render: function() {
+      expect(this.isMounted()).toBeFalsy();
+      return <div/>;
+    },
   });
+
+  var element = <Component />;
+
+  var instance = ReactTestUtils.renderIntoDocument(element);
+  expect(instance.isMounted()).toBeTruthy();
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'Component is accessing isMounted inside its render()'
+  );
+});
+
+it('should correctly determine if a null component is mounted', function() {
+  spyOn(console, 'error');
+  var Component = React.createClass({
+    componentWillMount: function() {
+      expect(this.isMounted()).toBeFalsy();
+    },
+    componentDidMount: function() {
+      expect(this.isMounted()).toBeTruthy();
+    },
+    render: function() {
+      expect(this.isMounted()).toBeFalsy();
+      return null;
+    },
+  });
+
+  var element = <Component />;
+
+  var instance = ReactTestUtils.renderIntoDocument(element);
+  expect(instance.isMounted()).toBeTruthy();
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'Component is accessing isMounted inside its render()'
+  );
+});
+
+it('isMounted should return false when unmounted', function() {
+  var Component = React.createClass({
+    render: function() {
+      return <div/>;
+    },
+  });
+
+  var container = document.createElement('div');
+  var instance = ReactDOM.render(<Component />, container);
+
+  expect(instance.isMounted()).toBe(true);
+
+  ReactDOM.unmountComponentAtNode(container);
+
+  expect(instance.isMounted()).toBe(false);
+});
+
+it('warns if findDOMNode is used inside render', function() {
+  spyOn(console, 'error');
+  var Component = React.createClass({
+    getInitialState: function() {
+      return {isMounted: false};
+    },
+    componentDidMount: function() {
+      this.setState({isMounted: true});
+    },
+    render: function() {
+      if (this.state.isMounted) {
+        expect(ReactDOM.findDOMNode(this).tagName).toBe('DIV');
+      }
+      return <div/>;
+    },
+  });
+
+  ReactTestUtils.renderIntoDocument(<Component />);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'Component is accessing findDOMNode inside its render()'
+  );
+});
+
+it('should carry through each of the phases of setup', function() {
+  class LifeCycleComponent extends React.Component {
+    constructor(props, context) {
+      super(props, context);
+      this._testJournal = {};
+      var initState = {
+        hasWillMountCompleted: false,
+        hasDidMountCompleted: false,
+        hasRenderCompleted: false,
+        hasWillUnmountCompleted: false,
+      };
+      this._testJournal.returnedFromGetInitialState = clone(initState);
+      this._testJournal.lifeCycleAtStartOfGetInitialState =
+        getLifeCycleState(this);
+      this.state = initState;
+    }
+
+    componentWillMount() {
+      this._testJournal.stateAtStartOfWillMount = clone(this.state);
+      this._testJournal.lifeCycleAtStartOfWillMount =
+        getLifeCycleState(this);
+      this.state.hasWillMountCompleted = true;
+    }
+
+    componentDidMount() {
+      this._testJournal.stateAtStartOfDidMount = clone(this.state);
+      this._testJournal.lifeCycleAtStartOfDidMount =
+        getLifeCycleState(this);
+      this.setState({hasDidMountCompleted: true});
+    }
+
+    render() {
+      var isInitialRender = !this.state.hasRenderCompleted;
+      if (isInitialRender) {
+        this._testJournal.stateInInitialRender = clone(this.state);
+        this._testJournal.lifeCycleInInitialRender = getLifeCycleState(this);
+      } else {
+        this._testJournal.stateInLaterRender = clone(this.state);
+        this._testJournal.lifeCycleInLaterRender = getLifeCycleState(this);
+      }
+      // you would *NEVER* do anything like this in real code!
+      this.state.hasRenderCompleted = true;
+      return (
+        <div ref="theDiv">
+          I am the inner DIV
+        </div>
+      );
+    }
+
+    componentWillUnmount() {
+      this._testJournal.stateAtStartOfWillUnmount = clone(this.state);
+      this._testJournal.lifeCycleAtStartOfWillUnmount =
+        getLifeCycleState(this);
+      this.state.hasWillUnmountCompleted = true;
+    }
+  }
+
+  // A component that is merely "constructed" (as in "constructor") but not
+  // yet initialized, or rendered.
+  //
+  var container = document.createElement('div');
+  var instance = ReactDOM.render(<LifeCycleComponent />, container);
+
+  // getInitialState
+  expect(instance._testJournal.returnedFromGetInitialState).toEqual(
+    GET_INIT_STATE_RETURN_VAL
+  );
+  expect(instance._testJournal.lifeCycleAtStartOfGetInitialState)
+    .toBe('UNMOUNTED');
+
+  // componentWillMount
+  expect(instance._testJournal.stateAtStartOfWillMount).toEqual(
+    instance._testJournal.returnedFromGetInitialState
+  );
+  expect(instance._testJournal.lifeCycleAtStartOfWillMount)
+    .toBe('MOUNTED');
+
+  // componentDidMount
+  expect(instance._testJournal.stateAtStartOfDidMount)
+    .toEqual(DID_MOUNT_STATE);
+  expect(instance._testJournal.lifeCycleAtStartOfDidMount).toBe(
+    'MOUNTED'
+  );
+
+  // render
+  expect(instance._testJournal.stateInInitialRender)
+    .toEqual(INIT_RENDER_STATE);
+  expect(instance._testJournal.lifeCycleInInitialRender).toBe(
+    'MOUNTED'
+  );
+
+  expect(getLifeCycleState(instance)).toBe('MOUNTED');
+
+  // Now *update the component*
+  instance.forceUpdate();
+
+  // render 2nd time
+  expect(instance._testJournal.stateInLaterRender)
+    .toEqual(NEXT_RENDER_STATE);
+  expect(instance._testJournal.lifeCycleInLaterRender).toBe(
+    'MOUNTED'
+  );
+
+  expect(getLifeCycleState(instance)).toBe('MOUNTED');
+
+  ReactDOM.unmountComponentAtNode(container);
+
+  expect(instance._testJournal.stateAtStartOfWillUnmount)
+    .toEqual(WILL_UNMOUNT_STATE);
+  // componentWillUnmount called right before unmount.
+  expect(instance._testJournal.lifeCycleAtStartOfWillUnmount).toBe(
+    'MOUNTED'
+  );
+
+  // But the current lifecycle of the component is unmounted.
+  expect(getLifeCycleState(instance)).toBe('UNMOUNTED');
+  expect(instance.state).toEqual(POST_WILL_UNMOUNT_STATE);
+});
+
+it('should not throw when updating an auxiliary component', function() {
+  class Tooltip extends React.Component {
+    render() {
+      return <div>{this.props.children}</div>;
+    }
+
+    componentDidMount() {
+      this.container = document.createElement('div');
+      this.updateTooltip();
+    }
+
+    componentDidUpdate() {
+      this.updateTooltip();
+    }
+
+    updateTooltip = () => {
+      // Even though this.props.tooltip has an owner, updating it shouldn't
+      // throw here because it's mounted as a root component
+      ReactDOM.render(this.props.tooltip, this.container);
+    };
+  }
+
+  class Component extends React.Component {
+    render() {
+      return (
+        <Tooltip
+            ref="tooltip"
+            tooltip={<div>{this.props.tooltipText}</div>}>
+          {this.props.text}
+        </Tooltip>
+      );
+    }
+  }
+
+  var container = document.createElement('div');
+  ReactDOM.render(
+    <Component text="uno" tooltipText="one" />,
+    container
+  );
+
+  // Since `instance` is a root component, we can set its props. This also
+  // makes Tooltip rerender the tooltip component, which shouldn't throw.
+  ReactDOM.render(
+    <Component text="dos" tooltipText="two" />,
+    container
+  );
+});
+
+it('should allow state updates in componentDidMount', function() {
+  /**
+   * calls setState in an componentDidMount.
+   */
+  class SetStateInComponentDidMount extends React.Component {
+    state = {
+      stateField: this.props.valueToUseInitially,
+    };
+
+    componentDidMount() {
+      this.setState({stateField: this.props.valueToUseInOnDOMReady});
+    }
+
+    render() {
+      return (<div></div>);
+    }
+  }
+
+  var instance =
+    <SetStateInComponentDidMount
+      valueToUseInitially="hello"
+      valueToUseInOnDOMReady="goodbye"
+    />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  expect(instance.state.stateField).toBe('goodbye');
+});
+
+it('should call nested lifecycle methods in the right order', function() {
+  var log;
+  var logger = function(msg) {
+    return function() {
+      // return true for shouldComponentUpdate
+      log.push(msg);
+      return true;
+    };
+  };
+  var Outer = React.createClass({
+    render: function() {
+      return <div><Inner x={this.props.x} /></div>;
+    },
+    componentWillMount: logger('outer componentWillMount'),
+    componentDidMount: logger('outer componentDidMount'),
+    componentWillReceiveProps: logger('outer componentWillReceiveProps'),
+    shouldComponentUpdate: logger('outer shouldComponentUpdate'),
+    componentWillUpdate: logger('outer componentWillUpdate'),
+    componentDidUpdate: logger('outer componentDidUpdate'),
+    componentWillUnmount: logger('outer componentWillUnmount'),
+  });
+  var Inner = React.createClass({
+    render: function() {
+      return <span>{this.props.x}</span>;
+    },
+    componentWillMount: logger('inner componentWillMount'),
+    componentDidMount: logger('inner componentDidMount'),
+    componentWillReceiveProps: logger('inner componentWillReceiveProps'),
+    shouldComponentUpdate: logger('inner shouldComponentUpdate'),
+    componentWillUpdate: logger('inner componentWillUpdate'),
+    componentDidUpdate: logger('inner componentDidUpdate'),
+    componentWillUnmount: logger('inner componentWillUnmount'),
+  });
+
+
+  var container = document.createElement('div');
+  log = [];
+  ReactDOM.render(<Outer x={17} />, container);
+  expect(log).toEqual([
+    'outer componentWillMount',
+    'inner componentWillMount',
+    'inner componentDidMount',
+    'outer componentDidMount',
+  ]);
+
+  log = [];
+  ReactDOM.render(<Outer x={42} />, container);
+  expect(log).toEqual([
+    'outer componentWillReceiveProps',
+    'outer shouldComponentUpdate',
+    'outer componentWillUpdate',
+    'inner componentWillReceiveProps',
+    'inner shouldComponentUpdate',
+    'inner componentWillUpdate',
+    'inner componentDidUpdate',
+    'outer componentDidUpdate',
+  ]);
+
+  log = [];
+  ReactDOM.unmountComponentAtNode(container);
+  expect(log).toEqual([
+    'outer componentWillUnmount',
+    'inner componentWillUnmount',
+  ]);
 });

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -23,1320 +23,1316 @@ var ReactUpdates;
 
 var reactComponentExpect;
 
-describe('ReactCompositeComponent', function() {
+beforeEach(function() {
+  jest.resetModuleRegistry();
+  reactComponentExpect = require('reactComponentExpect');
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactCurrentOwner = require('ReactCurrentOwner');
+  ReactPropTypes = require('ReactPropTypes');
+  ReactTestUtils = require('ReactTestUtils');
+  ReactServerRendering = require('ReactServerRendering');
+  ReactUpdates = require('ReactUpdates');
 
-  beforeEach(function() {
-    jest.resetModuleRegistry();
-    reactComponentExpect = require('reactComponentExpect');
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactCurrentOwner = require('ReactCurrentOwner');
-    ReactPropTypes = require('ReactPropTypes');
-    ReactTestUtils = require('ReactTestUtils');
-    ReactServerRendering = require('ReactServerRendering');
-    ReactUpdates = require('ReactUpdates');
+  MorphingComponent = class extends React.Component {
+    state = {activated: false};
 
-    MorphingComponent = class extends React.Component {
-      state = {activated: false};
-
-      _toggleActivatedState = () => {
-        this.setState({activated: !this.state.activated});
-      };
-
-      render() {
-        var toggleActivatedState = this._toggleActivatedState;
-        return !this.state.activated ?
-          <a ref="x" onClick={toggleActivatedState} /> :
-          <b ref="x" onClick={toggleActivatedState} />;
-      }
+    _toggleActivatedState = () => {
+      this.setState({activated: !this.state.activated});
     };
 
-    /**
-     * We'll use this to ensure that an old version is not cached when it is
-     * reallocated again.
-     */
-    ChildUpdates = class extends React.Component {
-      getAnchor = () => {
-        return this.refs.anch;
-      };
+    render() {
+      var toggleActivatedState = this._toggleActivatedState;
+      return !this.state.activated ?
+        <a ref="x" onClick={toggleActivatedState} /> :
+        <b ref="x" onClick={toggleActivatedState} />;
+    }
+  };
 
-      render() {
-        var className = this.props.anchorClassOn ? 'anchorClass' : '';
-        return this.props.renderAnchor ?
-          <a ref="anch" className={className}></a> :
-          <b></b>;
-      }
+  /**
+   * We'll use this to ensure that an old version is not cached when it is
+   * reallocated again.
+   */
+  ChildUpdates = class extends React.Component {
+    getAnchor = () => {
+      return this.refs.anch;
     };
+
+    render() {
+      var className = this.props.anchorClassOn ? 'anchorClass' : '';
+      return this.props.renderAnchor ?
+        <a ref="anch" className={className}></a> :
+        <b></b>;
+    }
+  };
+});
+
+it('should support module pattern components', function() {
+  function Child({test}) {
+    return {
+      render() {
+        return <div>{test}</div>;
+      },
+    };
+  }
+
+  var el = document.createElement('div');
+  ReactDOM.render(<Child test="test" />, el);
+
+  expect(el.textContent).toBe('test');
+});
+
+it('should support rendering to different child types over time', function() {
+  var instance = <MorphingComponent />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+
+  reactComponentExpect(instance)
+    .expectRenderedChild()
+    .toBeDOMComponentWithTag('a');
+
+  instance._toggleActivatedState();
+  reactComponentExpect(instance)
+    .expectRenderedChild()
+    .toBeDOMComponentWithTag('b');
+
+  instance._toggleActivatedState();
+  reactComponentExpect(instance)
+    .expectRenderedChild()
+    .toBeDOMComponentWithTag('a');
+});
+
+it('should not thrash a server rendered layout with client side one', () => {
+  class Child extends React.Component {
+    render() {
+      return null;
+    }
+  }
+
+  class Parent extends React.Component {
+    render() {
+      return <div><Child /></div>;
+    }
+  }
+
+  var markup = ReactServerRendering.renderToString(<Parent />);
+  var container = document.createElement('div');
+  container.innerHTML = markup;
+
+  ReactDOM.render(<Parent />, container);
+});
+
+it('should react to state changes from callbacks', function() {
+  var instance = <MorphingComponent />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+
+  var renderedChild = reactComponentExpect(instance)
+    .expectRenderedChild()
+    .instance();
+
+  ReactTestUtils.Simulate.click(renderedChild);
+  reactComponentExpect(instance)
+    .expectRenderedChild()
+    .toBeDOMComponentWithTag('b');
+});
+
+it('should rewire refs when rendering to different child types', function() {
+  var instance = <MorphingComponent />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+
+  expect(ReactDOM.findDOMNode(instance.refs.x).tagName).toBe('A');
+  instance._toggleActivatedState();
+  expect(ReactDOM.findDOMNode(instance.refs.x).tagName).toBe('B');
+  instance._toggleActivatedState();
+  expect(ReactDOM.findDOMNode(instance.refs.x).tagName).toBe('A');
+});
+
+it('should not cache old DOM nodes when switching constructors', function() {
+  var container = document.createElement('div');
+  var instance = ReactDOM.render(
+    <ChildUpdates renderAnchor={true} anchorClassOn={false}/>,
+    container
+  );
+  ReactDOM.render(  // Warm any cache
+    <ChildUpdates renderAnchor={true} anchorClassOn={true}/>,
+    container
+  );
+  ReactDOM.render(  // Clear out the anchor
+    <ChildUpdates renderAnchor={false} anchorClassOn={true}/>,
+    container
+  );
+  ReactDOM.render(  // rerender
+    <ChildUpdates renderAnchor={true} anchorClassOn={false}/>,
+    container
+  );
+  expect(instance.getAnchor().className).toBe('');
+});
+
+it('should auto bind methods and values correctly', function() {
+  spyOn(console, 'error');
+
+  var ComponentClass = React.createClass({
+    getInitialState: function() {
+      return {valueToReturn: 'hi'};
+    },
+    methodToBeExplicitlyBound: function() {
+      return this;
+    },
+    methodAutoBound: function() {
+      return this;
+    },
+    render: function() {
+      return <div></div>;
+    },
   });
+  var instance = <ComponentClass />;
 
-  it('should support module pattern components', function() {
-    function Child({test}) {
+  // Next, prove that once mounted, the scope is bound correctly to the actual
+  // component.
+  var mountedInstance = ReactTestUtils.renderIntoDocument(instance);
+
+  expect(function() {
+    mountedInstance.methodToBeExplicitlyBound.bind(instance)();
+  }).not.toThrow();
+  expect(function() {
+    mountedInstance.methodAutoBound();
+  }).not.toThrow();
+
+  expect(console.error.calls.count()).toBe(1);
+  var explicitlyBound = mountedInstance.methodToBeExplicitlyBound.bind(
+    mountedInstance
+  );
+  expect(console.error.calls.count()).toBe(2);
+  var autoBound = mountedInstance.methodAutoBound;
+
+  var context = {};
+  expect(explicitlyBound.call(context)).toBe(mountedInstance);
+  expect(autoBound.call(context)).toBe(mountedInstance);
+
+  expect(explicitlyBound.call(mountedInstance)).toBe(mountedInstance);
+  expect(autoBound.call(mountedInstance)).toBe(mountedInstance);
+
+});
+
+it('should not pass this to getDefaultProps', function() {
+  var Component = React.createClass({
+    getDefaultProps: function() {
+      expect(this.render).not.toBeDefined();
+      return {};
+    },
+    render: function() {
+      return <div />;
+    },
+  });
+  ReactTestUtils.renderIntoDocument(<Component />);
+});
+
+it('should use default values for undefined props', function() {
+  class Component extends React.Component {
+    static defaultProps = {prop: 'testKey'};
+
+    render() {
+      return <span />;
+    }
+  }
+
+  var instance1 = <Component />;
+  instance1 = ReactTestUtils.renderIntoDocument(instance1);
+  reactComponentExpect(instance1).scalarPropsEqual({prop: 'testKey'});
+
+  var instance2 = <Component prop={undefined} />;
+  instance2 = ReactTestUtils.renderIntoDocument(instance2);
+  reactComponentExpect(instance2).scalarPropsEqual({prop: 'testKey'});
+
+  var instance3 = <Component prop={null} />;
+  instance3 = ReactTestUtils.renderIntoDocument(instance3);
+  reactComponentExpect(instance3).scalarPropsEqual({prop: null});
+});
+
+it('should not mutate passed-in props object', function() {
+  class Component extends React.Component {
+    static defaultProps = {prop: 'testKey'};
+
+    render() {
+      return <span />;
+    }
+  }
+
+  var inputProps = {};
+  var instance1 = <Component {...inputProps} />;
+  instance1 = ReactTestUtils.renderIntoDocument(instance1);
+  expect(instance1.props.prop).toBe('testKey');
+
+  // We don't mutate the input, just in case the caller wants to do something
+  // with it after using it to instantiate a component
+  expect(inputProps.prop).not.toBeDefined();
+});
+
+it('should warn about `forceUpdate` on unmounted components', function() {
+  spyOn(console, 'error');
+
+  var container = document.createElement('div');
+  document.body.appendChild(container);
+
+  class Component extends React.Component {
+    render() {
+      return <div />;
+    }
+  }
+
+  var instance = <Component />;
+  expect(instance.forceUpdate).not.toBeDefined();
+
+  instance = ReactDOM.render(instance, container);
+  instance.forceUpdate();
+
+  expect(console.error.calls.count()).toBe(0);
+
+  ReactDOM.unmountComponentAtNode(container);
+
+  instance.forceUpdate();
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: forceUpdate(...): Can only update a mounted or ' +
+    'mounting component. This usually means you called forceUpdate() on an ' +
+    'unmounted component. This is a no-op. Please check the code for the ' +
+    'Component component.'
+  );
+});
+
+it('should warn about `setState` on unmounted components', function() {
+  spyOn(console, 'error');
+
+  var container = document.createElement('div');
+  document.body.appendChild(container);
+
+  var renders = 0;
+
+  class Component extends React.Component {
+    state = {value: 0};
+
+    render() {
+      renders++;
+      return <div />;
+    }
+  }
+
+  var instance = <Component />;
+  expect(instance.setState).not.toBeDefined();
+
+  instance = ReactDOM.render(instance, container);
+
+  expect(renders).toBe(1);
+
+  instance.setState({value: 1});
+
+  expect(console.error.calls.count()).toBe(0);
+
+  expect(renders).toBe(2);
+
+  ReactDOM.unmountComponentAtNode(container);
+  instance.setState({value: 2});
+
+  expect(renders).toBe(2);
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: setState(...): Can only update a mounted or ' +
+    'mounting component. This usually means you called setState() on an ' +
+    'unmounted component. This is a no-op. Please check the code for the ' +
+    'Component component.'
+  );
+});
+
+it('should silently allow `setState`, not call cb on unmounting components', function() {
+  var cbCalled = false;
+  var container = document.createElement('div');
+  document.body.appendChild(container);
+
+  class Component extends React.Component {
+    state = {value: 0};
+
+    componentWillUnmount() {
+      expect(() => {
+        this.setState({value: 2}, function() {
+          cbCalled = true;
+        });
+      }).not.toThrow();
+    }
+
+    render() {
+      return <div />;
+    }
+  }
+
+  var instance = ReactDOM.render(<Component />, container);
+  instance.setState({value: 1});
+
+  ReactDOM.unmountComponentAtNode(container);
+  expect(cbCalled).toBe(false);
+});
+
+
+it('should warn about `setState` in render', function() {
+  spyOn(console, 'error');
+
+  var container = document.createElement('div');
+
+  var renderedState = -1;
+  var renderPasses = 0;
+
+  class Component extends React.Component {
+    state = {value: 0};
+
+    render() {
+      renderPasses++;
+      renderedState = this.state.value;
+      if (this.state.value === 0) {
+        this.setState({ value: 1 });
+      }
+      return <div />;
+    }
+  }
+
+  expect(console.error.calls.count()).toBe(0);
+
+  var instance = ReactDOM.render(<Component />, container);
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: setState(...): Cannot update during an existing state ' +
+    'transition (such as within `render` or another component\'s ' +
+    'constructor). Render methods should be a pure function of props and ' +
+    'state; constructor side-effects are an anti-pattern, but can be moved ' +
+    'to `componentWillMount`.'
+  );
+
+  // The setState call is queued and then executed as a second pass. This
+  // behavior is undefined though so we're free to change it to suit the
+  // implementation details.
+  expect(renderPasses).toBe(2);
+  expect(renderedState).toBe(1);
+  expect(instance.state.value).toBe(1);
+
+  // Forcing a rerender anywhere will cause the update to happen.
+  var instance2 = ReactDOM.render(<Component prop={123} />, container);
+  expect(instance).toBe(instance2);
+  expect(renderedState).toBe(1);
+  expect(instance2.state.value).toBe(1);
+});
+
+it('should warn about `setState` in getChildContext', function() {
+  spyOn(console, 'error');
+
+  var container = document.createElement('div');
+
+  var renderPasses = 0;
+
+  class Component extends React.Component {
+    state = {value: 0};
+
+    getChildContext() {
+      if (this.state.value === 0) {
+        this.setState({ value: 1 });
+      }
+    }
+
+    render() {
+      renderPasses++;
+      return <div />;
+    }
+  }
+
+  expect(console.error.calls.count()).toBe(0);
+  var instance = ReactDOM.render(<Component />, container);
+  expect(renderPasses).toBe(2);
+  expect(instance.state.value).toBe(1);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: setState(...): Cannot call setState() inside getChildContext()'
+  );
+});
+
+it('should cleanup even if render() fatals', function() {
+  class BadComponent extends React.Component {
+    render() {
+      throw new Error();
+    }
+  }
+
+  var instance = <BadComponent />;
+
+  expect(ReactCurrentOwner.current).toBe(null);
+
+  expect(function() {
+    instance = ReactTestUtils.renderIntoDocument(instance);
+  }).toThrow();
+
+  expect(ReactCurrentOwner.current).toBe(null);
+});
+
+it('should call componentWillUnmount before unmounting', function() {
+  var container = document.createElement('div');
+  var innerUnmounted = false;
+
+  class Component extends React.Component {
+    render() {
+      return (
+        <div>
+          <Inner />
+          Text
+        </div>
+      );
+    }
+  }
+
+  class Inner extends React.Component {
+    componentWillUnmount() {
+      innerUnmounted = true;
+    }
+
+    render() {
+      return <div />;
+    }
+  }
+
+  ReactDOM.render(<Component />, container);
+  ReactDOM.unmountComponentAtNode(container);
+  expect(innerUnmounted).toBe(true);
+});
+
+it('should warn when shouldComponentUpdate() returns undefined', function() {
+  spyOn(console, 'error');
+
+  class Component extends React.Component {
+    state = {bogus: false};
+
+    shouldComponentUpdate() {
+      return undefined;
+    }
+
+    render() {
+      return <div />;
+    }
+  }
+
+  var instance = ReactTestUtils.renderIntoDocument(<Component />);
+  instance.setState({bogus: true});
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: Component.shouldComponentUpdate(): Returned undefined instead of a ' +
+    'boolean value. Make sure to return true or false.'
+  );
+});
+
+it('should warn when componentDidUnmount method is defined', function() {
+  spyOn(console, 'error');
+
+  class Component extends React.Component {
+    componentDidUnmount = () => {
+    };
+
+    render() {
+      return <div />;
+    }
+  }
+
+  ReactTestUtils.renderIntoDocument(<Component />);
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: Component has a method called ' +
+    'componentDidUnmount(). But there is no such lifecycle method. ' +
+    'Did you mean componentWillUnmount()?'
+  );
+});
+
+it('should pass context to children when not owner', function() {
+  class Parent extends React.Component {
+    render() {
+      return <Child><Grandchild /></Child>;
+    }
+  }
+
+  class Child extends React.Component {
+    static childContextTypes = {
+      foo: ReactPropTypes.string,
+    };
+
+    getChildContext() {
       return {
-        render() {
-          return <div>{test}</div>;
-        },
+        foo: 'bar',
       };
     }
 
-    var el = document.createElement('div');
-    ReactDOM.render(<Child test="test" />, el);
+    render() {
+      return React.Children.only(this.props.children);
+    }
+  }
 
-    expect(el.textContent).toBe('test');
+  class Grandchild extends React.Component {
+    static contextTypes = {
+      foo: ReactPropTypes.string,
+    };
+
+    render() {
+      return <div>{this.context.foo}</div>;
+    }
+  }
+
+  var component = ReactTestUtils.renderIntoDocument(<Parent />);
+  expect(ReactDOM.findDOMNode(component).innerHTML).toBe('bar');
+});
+
+it('should skip update when rerendering element in container', function() {
+  class Parent extends React.Component {
+    render() {
+      return <div>{this.props.children}</div>;
+    }
+  }
+
+  var childRenders = 0;
+
+  class Child extends React.Component {
+    render() {
+      childRenders++;
+      return <div />;
+    }
+  }
+
+  var container = document.createElement('div');
+  var child = <Child />;
+
+  ReactDOM.render(<Parent>{child}</Parent>, container);
+  ReactDOM.render(<Parent>{child}</Parent>, container);
+  expect(childRenders).toBe(1);
+});
+
+it('should pass context when re-rendered for static child', function() {
+  var parentInstance = null;
+  var childInstance = null;
+
+  class Parent extends React.Component {
+    static childContextTypes = {
+      foo: ReactPropTypes.string,
+      flag: ReactPropTypes.bool,
+    };
+
+    state = {
+      flag: false,
+    };
+
+    getChildContext() {
+      return {
+        foo: 'bar',
+        flag: this.state.flag,
+      };
+    }
+
+    render() {
+      return React.Children.only(this.props.children);
+    }
+  }
+
+  class Middle extends React.Component {
+    render() {
+      return this.props.children;
+    }
+  }
+
+  class Child extends React.Component {
+    static contextTypes = {
+      foo: ReactPropTypes.string,
+      flag: ReactPropTypes.bool,
+    };
+
+    render() {
+      childInstance = this;
+      return <span>Child</span>;
+    }
+  }
+
+  parentInstance = ReactTestUtils.renderIntoDocument(
+    <Parent><Middle><Child /></Middle></Parent>
+  );
+
+  expect(parentInstance.state.flag).toBe(false);
+  reactComponentExpect(childInstance).scalarContextEqual({foo: 'bar', flag: false});
+
+  parentInstance.setState({flag: true});
+  expect(parentInstance.state.flag).toBe(true);
+
+  reactComponentExpect(childInstance).scalarContextEqual({foo: 'bar', flag: true});
+});
+
+it('should pass context when re-rendered for static child within a composite component', function() {
+  class Parent extends React.Component {
+    static childContextTypes = {
+      flag: ReactPropTypes.bool,
+    };
+
+    state = {
+      flag: true,
+    };
+
+    getChildContext() {
+      return {
+        flag: this.state.flag,
+      };
+    }
+
+    render() {
+      return <div>{this.props.children}</div>;
+    }
+  }
+
+  class Child extends React.Component {
+    static contextTypes = {
+      flag: ReactPropTypes.bool,
+    };
+
+    render() {
+      return <div />;
+    }
+  }
+
+  class Wrapper extends React.Component {
+    render() {
+      return (
+        <Parent ref="parent">
+          <Child ref="child" />
+        </Parent>
+      );
+    }
+  }
+
+
+  var wrapper = ReactTestUtils.renderIntoDocument(
+    <Wrapper />
+  );
+
+  expect(wrapper.refs.parent.state.flag).toEqual(true);
+  reactComponentExpect(wrapper.refs.child).scalarContextEqual({flag: true});
+
+  // We update <Parent /> while <Child /> is still a static prop relative to this update
+  wrapper.refs.parent.setState({flag: false});
+
+  expect(wrapper.refs.parent.state.flag).toEqual(false);
+  reactComponentExpect(wrapper.refs.child).scalarContextEqual({flag: false});
+});
+
+it('should pass context transitively', function() {
+  var childInstance = null;
+  var grandchildInstance = null;
+
+  class Parent extends React.Component {
+    static childContextTypes = {
+      foo: ReactPropTypes.string,
+      depth: ReactPropTypes.number,
+    };
+
+    getChildContext() {
+      return {
+        foo: 'bar',
+        depth: 0,
+      };
+    }
+
+    render() {
+      return <Child />;
+    }
+  }
+
+  class Child extends React.Component {
+    static contextTypes = {
+      foo: ReactPropTypes.string,
+      depth: ReactPropTypes.number,
+    };
+
+    static childContextTypes = {
+      depth: ReactPropTypes.number,
+    };
+
+    getChildContext() {
+      return {
+        depth: this.context.depth + 1,
+      };
+    }
+
+    render() {
+      childInstance = this;
+      return <Grandchild />;
+    }
+  }
+
+  class Grandchild extends React.Component {
+    static contextTypes = {
+      foo: ReactPropTypes.string,
+      depth: ReactPropTypes.number,
+    };
+
+    render() {
+      grandchildInstance = this;
+      return <div />;
+    }
+  }
+
+  ReactTestUtils.renderIntoDocument(<Parent />);
+  reactComponentExpect(childInstance).scalarContextEqual({foo: 'bar', depth: 0});
+  reactComponentExpect(grandchildInstance).scalarContextEqual({foo: 'bar', depth: 1});
+});
+
+it('should pass context when re-rendered', function() {
+  var parentInstance = null;
+  var childInstance = null;
+
+  class Parent extends React.Component {
+    static childContextTypes = {
+      foo: ReactPropTypes.string,
+      depth: ReactPropTypes.number,
+    };
+
+    state = {
+      flag: false,
+    };
+
+    getChildContext() {
+      return {
+        foo: 'bar',
+        depth: 0,
+      };
+    }
+
+    render() {
+      var output = <Child />;
+      if (!this.state.flag) {
+        output = <span>Child</span>;
+      }
+      return output;
+    }
+  }
+
+  class Child extends React.Component {
+    static contextTypes = {
+      foo: ReactPropTypes.string,
+      depth: ReactPropTypes.number,
+    };
+
+    render() {
+      childInstance = this;
+      return <span>Child</span>;
+    }
+  }
+
+  parentInstance = ReactTestUtils.renderIntoDocument(<Parent />);
+  expect(childInstance).toBeNull();
+
+  expect(parentInstance.state.flag).toBe(false);
+  ReactUpdates.batchedUpdates(function() {
+    parentInstance.setState({flag: true});
   });
+  expect(parentInstance.state.flag).toBe(true);
 
-  it('should support rendering to different child types over time', function() {
-    var instance = <MorphingComponent />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
+  reactComponentExpect(childInstance).scalarContextEqual({foo: 'bar', depth: 0});
+});
 
-    reactComponentExpect(instance)
-      .expectRenderedChild()
-      .toBeDOMComponentWithTag('a');
+it('unmasked context propagates through updates', function() {
+  class Leaf extends React.Component {
+    static contextTypes = {
+      foo: ReactPropTypes.string.isRequired,
+    };
 
-    instance._toggleActivatedState();
-    reactComponentExpect(instance)
-      .expectRenderedChild()
-      .toBeDOMComponentWithTag('b');
+    componentWillReceiveProps(nextProps, nextContext) {
+      expect('foo' in nextContext).toBe(true);
+    }
 
-    instance._toggleActivatedState();
-    reactComponentExpect(instance)
-      .expectRenderedChild()
-      .toBeDOMComponentWithTag('a');
-  });
+    componentDidUpdate(prevProps, prevState, prevContext) {
+      expect('foo' in prevContext).toBe(true);
+    }
 
-  it('should not thrash a server rendered layout with client side one', () => {
-    class Child extends React.Component {
-      render() {
-        return null;
+    shouldComponentUpdate(nextProps, nextState, nextContext) {
+      expect('foo' in nextContext).toBe(true);
+      return true;
+    }
+
+    render() {
+      return <span>{this.context.foo}</span>;
+    }
+  }
+
+  class Intermediary extends React.Component {
+    componentWillReceiveProps(nextProps, nextContext) {
+      expect('foo' in nextContext).toBe(false);
+    }
+
+    componentDidUpdate(prevProps, prevState, prevContext) {
+      expect('foo' in prevContext).toBe(false);
+    }
+
+    shouldComponentUpdate(nextProps, nextState, nextContext) {
+      expect('foo' in nextContext).toBe(false);
+      return true;
+    }
+
+    render() {
+      return <Leaf />;
+    }
+  }
+
+  class Parent extends React.Component {
+    static childContextTypes = {
+      foo: ReactPropTypes.string,
+    };
+
+    getChildContext() {
+      return {
+        foo: this.props.cntxt,
+      };
+    }
+
+    render() {
+      return <Intermediary />;
+    }
+  }
+
+  var div = document.createElement('div');
+  ReactDOM.render(<Parent cntxt="noise" />, div);
+  expect(div.children[0].innerHTML).toBe('noise');
+  div.children[0].innerHTML = 'aliens';
+  div.children[0].id = 'aliens';
+  expect(div.children[0].innerHTML).toBe('aliens');
+  expect(div.children[0].id).toBe('aliens');
+  ReactDOM.render(<Parent cntxt="bar" />, div);
+  expect(div.children[0].innerHTML).toBe('bar');
+  expect(div.children[0].id).toBe('aliens');
+});
+
+it('should trigger componentWillReceiveProps for context changes', function() {
+  var contextChanges = 0;
+  var propChanges = 0;
+
+  class GrandChild extends React.Component {
+    static contextTypes = {
+      foo: ReactPropTypes.string.isRequired,
+    };
+
+    componentWillReceiveProps(nextProps, nextContext) {
+      expect('foo' in nextContext).toBe(true);
+
+      if (nextProps !== this.props) {
+        propChanges++;
+      }
+
+      if (nextContext !== this.context) {
+        contextChanges++;
       }
     }
 
-    class Parent extends React.Component {
-      render() {
-        return <div><Child /></div>;
+    render() {
+      return <span className="grand-child">{this.props.children}</span>;
+    }
+  }
+
+  class ChildWithContext extends React.Component {
+    static contextTypes = {
+      foo: ReactPropTypes.string.isRequired,
+    };
+
+    componentWillReceiveProps(nextProps, nextContext) {
+      expect('foo' in nextContext).toBe(true);
+
+      if (nextProps !== this.props) {
+        propChanges++;
+      }
+
+      if (nextContext !== this.context) {
+        contextChanges++;
       }
     }
 
-    var markup = ReactServerRendering.renderToString(<Parent />);
-    var container = document.createElement('div');
-    container.innerHTML = markup;
+    render() {
+      return <div className="child-with">{this.props.children}</div>;
+    }
+  }
 
-    ReactDOM.render(<Parent />, container);
-  });
+  class ChildWithoutContext extends React.Component {
+    componentWillReceiveProps(nextProps, nextContext) {
+      expect('foo' in nextContext).toBe(false);
 
-  it('should react to state changes from callbacks', function() {
-    var instance = <MorphingComponent />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
+      if (nextProps !== this.props) {
+        propChanges++;
+      }
 
-    var renderedChild = reactComponentExpect(instance)
-      .expectRenderedChild()
-      .instance();
-
-    ReactTestUtils.Simulate.click(renderedChild);
-    reactComponentExpect(instance)
-      .expectRenderedChild()
-      .toBeDOMComponentWithTag('b');
-  });
-
-  it('should rewire refs when rendering to different child types', function() {
-    var instance = <MorphingComponent />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-
-    expect(ReactDOM.findDOMNode(instance.refs.x).tagName).toBe('A');
-    instance._toggleActivatedState();
-    expect(ReactDOM.findDOMNode(instance.refs.x).tagName).toBe('B');
-    instance._toggleActivatedState();
-    expect(ReactDOM.findDOMNode(instance.refs.x).tagName).toBe('A');
-  });
-
-  it('should not cache old DOM nodes when switching constructors', function() {
-    var container = document.createElement('div');
-    var instance = ReactDOM.render(
-      <ChildUpdates renderAnchor={true} anchorClassOn={false}/>,
-      container
-    );
-    ReactDOM.render(  // Warm any cache
-      <ChildUpdates renderAnchor={true} anchorClassOn={true}/>,
-      container
-    );
-    ReactDOM.render(  // Clear out the anchor
-      <ChildUpdates renderAnchor={false} anchorClassOn={true}/>,
-      container
-    );
-    ReactDOM.render(  // rerender
-      <ChildUpdates renderAnchor={true} anchorClassOn={false}/>,
-      container
-    );
-    expect(instance.getAnchor().className).toBe('');
-  });
-
-  it('should auto bind methods and values correctly', function() {
-    spyOn(console, 'error');
-
-    var ComponentClass = React.createClass({
-      getInitialState: function() {
-        return {valueToReturn: 'hi'};
-      },
-      methodToBeExplicitlyBound: function() {
-        return this;
-      },
-      methodAutoBound: function() {
-        return this;
-      },
-      render: function() {
-        return <div></div>;
-      },
-    });
-    var instance = <ComponentClass />;
-
-    // Next, prove that once mounted, the scope is bound correctly to the actual
-    // component.
-    var mountedInstance = ReactTestUtils.renderIntoDocument(instance);
-
-    expect(function() {
-      mountedInstance.methodToBeExplicitlyBound.bind(instance)();
-    }).not.toThrow();
-    expect(function() {
-      mountedInstance.methodAutoBound();
-    }).not.toThrow();
-
-    expect(console.error.calls.count()).toBe(1);
-    var explicitlyBound = mountedInstance.methodToBeExplicitlyBound.bind(
-      mountedInstance
-    );
-    expect(console.error.calls.count()).toBe(2);
-    var autoBound = mountedInstance.methodAutoBound;
-
-    var context = {};
-    expect(explicitlyBound.call(context)).toBe(mountedInstance);
-    expect(autoBound.call(context)).toBe(mountedInstance);
-
-    expect(explicitlyBound.call(mountedInstance)).toBe(mountedInstance);
-    expect(autoBound.call(mountedInstance)).toBe(mountedInstance);
-
-  });
-
-  it('should not pass this to getDefaultProps', function() {
-    var Component = React.createClass({
-      getDefaultProps: function() {
-        expect(this.render).not.toBeDefined();
-        return {};
-      },
-      render: function() {
-        return <div />;
-      },
-    });
-    ReactTestUtils.renderIntoDocument(<Component />);
-  });
-
-  it('should use default values for undefined props', function() {
-    class Component extends React.Component {
-      static defaultProps = {prop: 'testKey'};
-
-      render() {
-        return <span />;
+      if (nextContext !== this.context) {
+        contextChanges++;
       }
     }
 
-    var instance1 = <Component />;
-    instance1 = ReactTestUtils.renderIntoDocument(instance1);
-    reactComponentExpect(instance1).scalarPropsEqual({prop: 'testKey'});
+    render() {
+      return <div className="child-without">{this.props.children}</div>;
+    }
+  }
 
-    var instance2 = <Component prop={undefined} />;
-    instance2 = ReactTestUtils.renderIntoDocument(instance2);
-    reactComponentExpect(instance2).scalarPropsEqual({prop: 'testKey'});
+  class Parent extends React.Component {
+    static childContextTypes = {
+      foo: ReactPropTypes.string,
+    };
 
-    var instance3 = <Component prop={null} />;
-    instance3 = ReactTestUtils.renderIntoDocument(instance3);
-    reactComponentExpect(instance3).scalarPropsEqual({prop: null});
-  });
+    state = {
+      foo: 'abc',
+    };
 
-  it('should not mutate passed-in props object', function() {
-    class Component extends React.Component {
-      static defaultProps = {prop: 'testKey'};
-
-      render() {
-        return <span />;
-      }
+    getChildContext() {
+      return {
+        foo: this.state.foo,
+      };
     }
 
-    var inputProps = {};
-    var instance1 = <Component {...inputProps} />;
-    instance1 = ReactTestUtils.renderIntoDocument(instance1);
-    expect(instance1.props.prop).toBe('testKey');
+    onClick = () => {
+      this.setState({
+        foo: 'def',
+      });
+    };
 
-    // We don't mutate the input, just in case the caller wants to do something
-    // with it after using it to instantiate a component
-    expect(inputProps.prop).not.toBeDefined();
-  });
+    render() {
+      return <div className="parent" onClick={this.onClick}>{this.props.children}</div>;
+    }
+  }
 
-  it('should warn about `forceUpdate` on unmounted components', function() {
-    spyOn(console, 'error');
+  var div = document.createElement('div');
 
-    var container = document.createElement('div');
-    document.body.appendChild(container);
+  ReactDOM.render(
+    <Parent>
+      <ChildWithoutContext>
+        A1
+        <GrandChild>A2</GrandChild>
+      </ChildWithoutContext>
 
-    class Component extends React.Component {
-      render() {
-        return <div />;
-      }
+      <ChildWithContext>
+        B1
+        <GrandChild>B2</GrandChild>
+      </ChildWithContext>
+    </Parent>,
+    div
+  );
+
+  ReactTestUtils.Simulate.click(div.childNodes[0]);
+
+  expect(propChanges).toBe(0);
+  expect(contextChanges).toBe(3); // ChildWithContext, GrandChild x 2
+});
+
+it('should disallow nested render calls', function() {
+  spyOn(console, 'error');
+
+  class Inner extends React.Component {
+    render() {
+      return <div />;
+    }
+  }
+
+  class Outer extends React.Component {
+    render() {
+      ReactTestUtils.renderIntoDocument(<Inner />);
+      return <div />;
+    }
+  }
+
+  ReactTestUtils.renderIntoDocument(<Outer />);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: _renderNewRootComponent(): Render methods should ' +
+    'be a pure function of props and state; triggering nested component ' +
+    'updates from render is not allowed. If necessary, trigger nested ' +
+    'updates in componentDidUpdate. Check the render method of Outer.'
+  );
+});
+
+it('only renders once if updated in componentWillReceiveProps', function() {
+  var renders = 0;
+
+  class Component extends React.Component {
+    state = {updated: false};
+
+    componentWillReceiveProps(props) {
+      expect(props.update).toBe(1);
+      this.setState({updated: true});
     }
 
-    var instance = <Component />;
-    expect(instance.forceUpdate).not.toBeDefined();
+    render() {
+      renders++;
+      return <div />;
+    }
+  }
 
-    instance = ReactDOM.render(instance, container);
-    instance.forceUpdate();
+  var container = document.createElement('div');
+  var instance = ReactDOM.render(<Component update={0} />, container);
+  expect(renders).toBe(1);
+  expect(instance.state.updated).toBe(false);
+  ReactDOM.render(<Component update={1} />, container);
+  expect(renders).toBe(2);
+  expect(instance.state.updated).toBe(true);
+});
 
-    expect(console.error.calls.count()).toBe(0);
-
-    ReactDOM.unmountComponentAtNode(container);
-
-    instance.forceUpdate();
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: forceUpdate(...): Can only update a mounted or ' +
-      'mounting component. This usually means you called forceUpdate() on an ' +
-      'unmounted component. This is a no-op. Please check the code for the ' +
-      'Component component.'
-    );
-  });
-
-  it('should warn about `setState` on unmounted components', function() {
-    spyOn(console, 'error');
-
-    var container = document.createElement('div');
-    document.body.appendChild(container);
-
-    var renders = 0;
-
-    class Component extends React.Component {
-      state = {value: 0};
-
-      render() {
-        renders++;
-        return <div />;
-      }
+it('should update refs if shouldComponentUpdate gives false', function() {
+  class Static extends React.Component {
+    shouldComponentUpdate() {
+      return false;
     }
 
-    var instance = <Component />;
-    expect(instance.setState).not.toBeDefined();
-
-    instance = ReactDOM.render(instance, container);
-
-    expect(renders).toBe(1);
-
-    instance.setState({value: 1});
-
-    expect(console.error.calls.count()).toBe(0);
-
-    expect(renders).toBe(2);
-
-    ReactDOM.unmountComponentAtNode(container);
-    instance.setState({value: 2});
-
-    expect(renders).toBe(2);
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: setState(...): Can only update a mounted or ' +
-      'mounting component. This usually means you called setState() on an ' +
-      'unmounted component. This is a no-op. Please check the code for the ' +
-      'Component component.'
-    );
-  });
-
-  it('should silently allow `setState`, not call cb on unmounting components', function() {
-    var cbCalled = false;
-    var container = document.createElement('div');
-    document.body.appendChild(container);
-
-    class Component extends React.Component {
-      state = {value: 0};
-
-      componentWillUnmount() {
-        expect(() => {
-          this.setState({value: 2}, function() {
-            cbCalled = true;
-          });
-        }).not.toThrow();
-      }
-
-      render() {
-        return <div />;
-      }
+    render() {
+      return <div>{this.props.children}</div>;
     }
+  }
 
-    var instance = ReactDOM.render(<Component />, container);
-    instance.setState({value: 1});
-
-    ReactDOM.unmountComponentAtNode(container);
-    expect(cbCalled).toBe(false);
-  });
-
-
-  it('should warn about `setState` in render', function() {
-    spyOn(console, 'error');
-
-    var container = document.createElement('div');
-
-    var renderedState = -1;
-    var renderPasses = 0;
-
-    class Component extends React.Component {
-      state = {value: 0};
-
-      render() {
-        renderPasses++;
-        renderedState = this.state.value;
-        if (this.state.value === 0) {
-          this.setState({ value: 1 });
-        }
-        return <div />;
-      }
-    }
-
-    expect(console.error.calls.count()).toBe(0);
-
-    var instance = ReactDOM.render(<Component />, container);
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: setState(...): Cannot update during an existing state ' +
-      'transition (such as within `render` or another component\'s ' +
-      'constructor). Render methods should be a pure function of props and ' +
-      'state; constructor side-effects are an anti-pattern, but can be moved ' +
-      'to `componentWillMount`.'
-    );
-
-    // The setState call is queued and then executed as a second pass. This
-    // behavior is undefined though so we're free to change it to suit the
-    // implementation details.
-    expect(renderPasses).toBe(2);
-    expect(renderedState).toBe(1);
-    expect(instance.state.value).toBe(1);
-
-    // Forcing a rerender anywhere will cause the update to happen.
-    var instance2 = ReactDOM.render(<Component prop={123} />, container);
-    expect(instance).toBe(instance2);
-    expect(renderedState).toBe(1);
-    expect(instance2.state.value).toBe(1);
-  });
-
-  it('should warn about `setState` in getChildContext', function() {
-    spyOn(console, 'error');
-
-    var container = document.createElement('div');
-
-    var renderPasses = 0;
-
-    class Component extends React.Component {
-      state = {value: 0};
-
-      getChildContext() {
-        if (this.state.value === 0) {
-          this.setState({ value: 1 });
-        }
-      }
-
-      render() {
-        renderPasses++;
-        return <div />;
-      }
-    }
-
-    expect(console.error.calls.count()).toBe(0);
-    var instance = ReactDOM.render(<Component />, container);
-    expect(renderPasses).toBe(2);
-    expect(instance.state.value).toBe(1);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: setState(...): Cannot call setState() inside getChildContext()'
-    );
-  });
-
-  it('should cleanup even if render() fatals', function() {
-    class BadComponent extends React.Component {
-      render() {
-        throw new Error();
-      }
-    }
-
-    var instance = <BadComponent />;
-
-    expect(ReactCurrentOwner.current).toBe(null);
-
-    expect(function() {
-      instance = ReactTestUtils.renderIntoDocument(instance);
-    }).toThrow();
-
-    expect(ReactCurrentOwner.current).toBe(null);
-  });
-
-  it('should call componentWillUnmount before unmounting', function() {
-    var container = document.createElement('div');
-    var innerUnmounted = false;
-
-    class Component extends React.Component {
-      render() {
+  class Component extends React.Component {
+    render() {
+      if (this.props.flipped) {
         return (
           <div>
-            <Inner />
-            Text
+            <Static ref="static0" key="B">B (ignored)</Static>
+            <Static ref="static1" key="A">A (ignored)</Static>
+          </div>
+        );
+      } else {
+        return (
+          <div>
+            <Static ref="static0" key="A">A</Static>
+            <Static ref="static1" key="B">B</Static>
           </div>
         );
       }
     }
+  }
 
-    class Inner extends React.Component {
-      componentWillUnmount() {
-        innerUnmounted = true;
-      }
+  var container = document.createElement('div');
+  var comp = ReactDOM.render(<Component flipped={false} />, container);
+  expect(ReactDOM.findDOMNode(comp.refs.static0).textContent).toBe('A');
+  expect(ReactDOM.findDOMNode(comp.refs.static1).textContent).toBe('B');
 
-      render() {
-        return <div />;
-      }
+  // When flipping the order, the refs should update even though the actual
+  // contents do not
+  ReactDOM.render(<Component flipped={true} />, container);
+  expect(ReactDOM.findDOMNode(comp.refs.static0).textContent).toBe('B');
+  expect(ReactDOM.findDOMNode(comp.refs.static1).textContent).toBe('A');
+});
+
+it('should allow access to findDOMNode in componentWillUnmount', function() {
+  var a = null;
+  var b = null;
+
+  class Component extends React.Component {
+    componentDidMount() {
+      a = ReactDOM.findDOMNode(this);
+      expect(a).not.toBe(null);
     }
 
-    ReactDOM.render(<Component />, container);
-    ReactDOM.unmountComponentAtNode(container);
-    expect(innerUnmounted).toBe(true);
-  });
-
-  it('should warn when shouldComponentUpdate() returns undefined', function() {
-    spyOn(console, 'error');
-
-    class Component extends React.Component {
-      state = {bogus: false};
-
-      shouldComponentUpdate() {
-        return undefined;
-      }
-
-      render() {
-        return <div />;
-      }
+    componentWillUnmount() {
+      b = ReactDOM.findDOMNode(this);
+      expect(b).not.toBe(null);
     }
 
-    var instance = ReactTestUtils.renderIntoDocument(<Component />);
-    instance.setState({bogus: true});
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: Component.shouldComponentUpdate(): Returned undefined instead of a ' +
-      'boolean value. Make sure to return true or false.'
-    );
-  });
-
-  it('should warn when componentDidUnmount method is defined', function() {
-    spyOn(console, 'error');
-
-    class Component extends React.Component {
-      componentDidUnmount = () => {
-      };
-
-      render() {
-        return <div />;
-      }
+    render() {
+      return <div />;
     }
-
-    ReactTestUtils.renderIntoDocument(<Component />);
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: Component has a method called ' +
-      'componentDidUnmount(). But there is no such lifecycle method. ' +
-      'Did you mean componentWillUnmount()?'
-    );
-  });
-
-  it('should pass context to children when not owner', function() {
-    class Parent extends React.Component {
-      render() {
-        return <Child><Grandchild /></Child>;
-      }
-    }
-
-    class Child extends React.Component {
-      static childContextTypes = {
-        foo: ReactPropTypes.string,
-      };
-
-      getChildContext() {
-        return {
-          foo: 'bar',
-        };
-      }
-
-      render() {
-        return React.Children.only(this.props.children);
-      }
-    }
-
-    class Grandchild extends React.Component {
-      static contextTypes = {
-        foo: ReactPropTypes.string,
-      };
-
-      render() {
-        return <div>{this.context.foo}</div>;
-      }
-    }
-
-    var component = ReactTestUtils.renderIntoDocument(<Parent />);
-    expect(ReactDOM.findDOMNode(component).innerHTML).toBe('bar');
-  });
-
-  it('should skip update when rerendering element in container', function() {
-    class Parent extends React.Component {
-      render() {
-        return <div>{this.props.children}</div>;
-      }
-    }
-
-    var childRenders = 0;
-
-    class Child extends React.Component {
-      render() {
-        childRenders++;
-        return <div />;
-      }
-    }
-
-    var container = document.createElement('div');
-    var child = <Child />;
-
-    ReactDOM.render(<Parent>{child}</Parent>, container);
-    ReactDOM.render(<Parent>{child}</Parent>, container);
-    expect(childRenders).toBe(1);
-  });
-
-  it('should pass context when re-rendered for static child', function() {
-    var parentInstance = null;
-    var childInstance = null;
-
-    class Parent extends React.Component {
-      static childContextTypes = {
-        foo: ReactPropTypes.string,
-        flag: ReactPropTypes.bool,
-      };
-
-      state = {
-        flag: false,
-      };
-
-      getChildContext() {
-        return {
-          foo: 'bar',
-          flag: this.state.flag,
-        };
-      }
-
-      render() {
-        return React.Children.only(this.props.children);
-      }
-    }
-
-    class Middle extends React.Component {
-      render() {
-        return this.props.children;
-      }
-    }
-
-    class Child extends React.Component {
-      static contextTypes = {
-        foo: ReactPropTypes.string,
-        flag: ReactPropTypes.bool,
-      };
-
-      render() {
-        childInstance = this;
-        return <span>Child</span>;
-      }
-    }
-
-    parentInstance = ReactTestUtils.renderIntoDocument(
-      <Parent><Middle><Child /></Middle></Parent>
-    );
-
-    expect(parentInstance.state.flag).toBe(false);
-    reactComponentExpect(childInstance).scalarContextEqual({foo: 'bar', flag: false});
-
-    parentInstance.setState({flag: true});
-    expect(parentInstance.state.flag).toBe(true);
-
-    reactComponentExpect(childInstance).scalarContextEqual({foo: 'bar', flag: true});
-  });
-
-  it('should pass context when re-rendered for static child within a composite component', function() {
-    class Parent extends React.Component {
-      static childContextTypes = {
-        flag: ReactPropTypes.bool,
-      };
-
-      state = {
-        flag: true,
-      };
-
-      getChildContext() {
-        return {
-          flag: this.state.flag,
-        };
-      }
-
-      render() {
-        return <div>{this.props.children}</div>;
-      }
-    }
-
-    class Child extends React.Component {
-      static contextTypes = {
-        flag: ReactPropTypes.bool,
-      };
-
-      render() {
-        return <div />;
-      }
-    }
-
-    class Wrapper extends React.Component {
-      render() {
-        return (
-          <Parent ref="parent">
-            <Child ref="child" />
-          </Parent>
-        );
-      }
-    }
-
-
-    var wrapper = ReactTestUtils.renderIntoDocument(
-      <Wrapper />
-    );
-
-    expect(wrapper.refs.parent.state.flag).toEqual(true);
-    reactComponentExpect(wrapper.refs.child).scalarContextEqual({flag: true});
-
-    // We update <Parent /> while <Child /> is still a static prop relative to this update
-    wrapper.refs.parent.setState({flag: false});
-
-    expect(wrapper.refs.parent.state.flag).toEqual(false);
-    reactComponentExpect(wrapper.refs.child).scalarContextEqual({flag: false});
-  });
-
-  it('should pass context transitively', function() {
-    var childInstance = null;
-    var grandchildInstance = null;
-
-    class Parent extends React.Component {
-      static childContextTypes = {
-        foo: ReactPropTypes.string,
-        depth: ReactPropTypes.number,
-      };
-
-      getChildContext() {
-        return {
-          foo: 'bar',
-          depth: 0,
-        };
-      }
-
-      render() {
-        return <Child />;
-      }
-    }
-
-    class Child extends React.Component {
-      static contextTypes = {
-        foo: ReactPropTypes.string,
-        depth: ReactPropTypes.number,
-      };
-
-      static childContextTypes = {
-        depth: ReactPropTypes.number,
-      };
-
-      getChildContext() {
-        return {
-          depth: this.context.depth + 1,
-        };
-      }
-
-      render() {
-        childInstance = this;
-        return <Grandchild />;
-      }
-    }
-
-    class Grandchild extends React.Component {
-      static contextTypes = {
-        foo: ReactPropTypes.string,
-        depth: ReactPropTypes.number,
-      };
-
-      render() {
-        grandchildInstance = this;
-        return <div />;
-      }
-    }
-
-    ReactTestUtils.renderIntoDocument(<Parent />);
-    reactComponentExpect(childInstance).scalarContextEqual({foo: 'bar', depth: 0});
-    reactComponentExpect(grandchildInstance).scalarContextEqual({foo: 'bar', depth: 1});
-  });
-
-  it('should pass context when re-rendered', function() {
-    var parentInstance = null;
-    var childInstance = null;
-
-    class Parent extends React.Component {
-      static childContextTypes = {
-        foo: ReactPropTypes.string,
-        depth: ReactPropTypes.number,
-      };
-
-      state = {
-        flag: false,
-      };
-
-      getChildContext() {
-        return {
-          foo: 'bar',
-          depth: 0,
-        };
-      }
-
-      render() {
-        var output = <Child />;
-        if (!this.state.flag) {
-          output = <span>Child</span>;
-        }
-        return output;
-      }
-    }
-
-    class Child extends React.Component {
-      static contextTypes = {
-        foo: ReactPropTypes.string,
-        depth: ReactPropTypes.number,
-      };
-
-      render() {
-        childInstance = this;
-        return <span>Child</span>;
-      }
-    }
-
-    parentInstance = ReactTestUtils.renderIntoDocument(<Parent />);
-    expect(childInstance).toBeNull();
-
-    expect(parentInstance.state.flag).toBe(false);
-    ReactUpdates.batchedUpdates(function() {
-      parentInstance.setState({flag: true});
-    });
-    expect(parentInstance.state.flag).toBe(true);
-
-    reactComponentExpect(childInstance).scalarContextEqual({foo: 'bar', depth: 0});
-  });
-
-  it('unmasked context propagates through updates', function() {
-    class Leaf extends React.Component {
-      static contextTypes = {
-        foo: ReactPropTypes.string.isRequired,
-      };
-
-      componentWillReceiveProps(nextProps, nextContext) {
-        expect('foo' in nextContext).toBe(true);
-      }
-
-      componentDidUpdate(prevProps, prevState, prevContext) {
-        expect('foo' in prevContext).toBe(true);
-      }
-
-      shouldComponentUpdate(nextProps, nextState, nextContext) {
-        expect('foo' in nextContext).toBe(true);
-        return true;
-      }
-
-      render() {
-        return <span>{this.context.foo}</span>;
-      }
-    }
-
-    class Intermediary extends React.Component {
-      componentWillReceiveProps(nextProps, nextContext) {
-        expect('foo' in nextContext).toBe(false);
-      }
-
-      componentDidUpdate(prevProps, prevState, prevContext) {
-        expect('foo' in prevContext).toBe(false);
-      }
-
-      shouldComponentUpdate(nextProps, nextState, nextContext) {
-        expect('foo' in nextContext).toBe(false);
-        return true;
-      }
-
-      render() {
-        return <Leaf />;
-      }
-    }
-
-    class Parent extends React.Component {
-      static childContextTypes = {
-        foo: ReactPropTypes.string,
-      };
-
-      getChildContext() {
-        return {
-          foo: this.props.cntxt,
-        };
-      }
-
-      render() {
-        return <Intermediary />;
-      }
-    }
-
-    var div = document.createElement('div');
-    ReactDOM.render(<Parent cntxt="noise" />, div);
-    expect(div.children[0].innerHTML).toBe('noise');
-    div.children[0].innerHTML = 'aliens';
-    div.children[0].id = 'aliens';
-    expect(div.children[0].innerHTML).toBe('aliens');
-    expect(div.children[0].id).toBe('aliens');
-    ReactDOM.render(<Parent cntxt="bar" />, div);
-    expect(div.children[0].innerHTML).toBe('bar');
-    expect(div.children[0].id).toBe('aliens');
-  });
-
-  it('should trigger componentWillReceiveProps for context changes', function() {
-    var contextChanges = 0;
-    var propChanges = 0;
-
-    class GrandChild extends React.Component {
-      static contextTypes = {
-        foo: ReactPropTypes.string.isRequired,
-      };
-
-      componentWillReceiveProps(nextProps, nextContext) {
-        expect('foo' in nextContext).toBe(true);
-
-        if (nextProps !== this.props) {
-          propChanges++;
-        }
-
-        if (nextContext !== this.context) {
-          contextChanges++;
-        }
-      }
-
-      render() {
-        return <span className="grand-child">{this.props.children}</span>;
-      }
-    }
-
-    class ChildWithContext extends React.Component {
-      static contextTypes = {
-        foo: ReactPropTypes.string.isRequired,
-      };
-
-      componentWillReceiveProps(nextProps, nextContext) {
-        expect('foo' in nextContext).toBe(true);
-
-        if (nextProps !== this.props) {
-          propChanges++;
-        }
-
-        if (nextContext !== this.context) {
-          contextChanges++;
-        }
-      }
-
-      render() {
-        return <div className="child-with">{this.props.children}</div>;
-      }
-    }
-
-    class ChildWithoutContext extends React.Component {
-      componentWillReceiveProps(nextProps, nextContext) {
-        expect('foo' in nextContext).toBe(false);
-
-        if (nextProps !== this.props) {
-          propChanges++;
-        }
-
-        if (nextContext !== this.context) {
-          contextChanges++;
-        }
-      }
-
-      render() {
-        return <div className="child-without">{this.props.children}</div>;
-      }
-    }
-
-    class Parent extends React.Component {
-      static childContextTypes = {
-        foo: ReactPropTypes.string,
-      };
-
-      state = {
-        foo: 'abc',
-      };
-
-      getChildContext() {
-        return {
-          foo: this.state.foo,
-        };
-      }
-
-      onClick = () => {
-        this.setState({
-          foo: 'def',
-        });
-      };
-
-      render() {
-        return <div className="parent" onClick={this.onClick}>{this.props.children}</div>;
-      }
-    }
-
-    var div = document.createElement('div');
-
-    ReactDOM.render(
-      <Parent>
-        <ChildWithoutContext>
-          A1
-          <GrandChild>A2</GrandChild>
-        </ChildWithoutContext>
-
-        <ChildWithContext>
-          B1
-          <GrandChild>B2</GrandChild>
-        </ChildWithContext>
-      </Parent>,
-      div
-    );
-
-    ReactTestUtils.Simulate.click(div.childNodes[0]);
-
-    expect(propChanges).toBe(0);
-    expect(contextChanges).toBe(3); // ChildWithContext, GrandChild x 2
-  });
-
-  it('should disallow nested render calls', function() {
-    spyOn(console, 'error');
-
-    class Inner extends React.Component {
-      render() {
-        return <div />;
-      }
-    }
-
-    class Outer extends React.Component {
-      render() {
-        ReactTestUtils.renderIntoDocument(<Inner />);
-        return <div />;
-      }
-    }
-
-    ReactTestUtils.renderIntoDocument(<Outer />);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: _renderNewRootComponent(): Render methods should ' +
-      'be a pure function of props and state; triggering nested component ' +
-      'updates from render is not allowed. If necessary, trigger nested ' +
-      'updates in componentDidUpdate. Check the render method of Outer.'
-    );
-  });
-
-  it('only renders once if updated in componentWillReceiveProps', function() {
-    var renders = 0;
-
-    class Component extends React.Component {
-      state = {updated: false};
-
-      componentWillReceiveProps(props) {
-        expect(props.update).toBe(1);
-        this.setState({updated: true});
-      }
-
-      render() {
-        renders++;
-        return <div />;
-      }
-    }
-
-    var container = document.createElement('div');
-    var instance = ReactDOM.render(<Component update={0} />, container);
-    expect(renders).toBe(1);
-    expect(instance.state.updated).toBe(false);
-    ReactDOM.render(<Component update={1} />, container);
-    expect(renders).toBe(2);
-    expect(instance.state.updated).toBe(true);
-  });
-
-  it('should update refs if shouldComponentUpdate gives false', function() {
-    class Static extends React.Component {
-      shouldComponentUpdate() {
-        return false;
-      }
-
-      render() {
-        return <div>{this.props.children}</div>;
-      }
-    }
-
-    class Component extends React.Component {
-      render() {
-        if (this.props.flipped) {
-          return (
-            <div>
-              <Static ref="static0" key="B">B (ignored)</Static>
-              <Static ref="static1" key="A">A (ignored)</Static>
-            </div>
-          );
-        } else {
-          return (
-            <div>
-              <Static ref="static0" key="A">A</Static>
-              <Static ref="static1" key="B">B</Static>
-            </div>
-          );
-        }
-      }
-    }
-
-    var container = document.createElement('div');
-    var comp = ReactDOM.render(<Component flipped={false} />, container);
-    expect(ReactDOM.findDOMNode(comp.refs.static0).textContent).toBe('A');
-    expect(ReactDOM.findDOMNode(comp.refs.static1).textContent).toBe('B');
-
-    // When flipping the order, the refs should update even though the actual
-    // contents do not
-    ReactDOM.render(<Component flipped={true} />, container);
-    expect(ReactDOM.findDOMNode(comp.refs.static0).textContent).toBe('B');
-    expect(ReactDOM.findDOMNode(comp.refs.static1).textContent).toBe('A');
-  });
-
-  it('should allow access to findDOMNode in componentWillUnmount', function() {
-    var a = null;
-    var b = null;
-
-    class Component extends React.Component {
-      componentDidMount() {
-        a = ReactDOM.findDOMNode(this);
-        expect(a).not.toBe(null);
-      }
-
-      componentWillUnmount() {
-        b = ReactDOM.findDOMNode(this);
-        expect(b).not.toBe(null);
-      }
-
-      render() {
-        return <div />;
-      }
-    }
-
-    var container = document.createElement('div');
-    expect(a).toBe(container.firstChild);
-    ReactDOM.render(<Component />, container);
-    ReactDOM.unmountComponentAtNode(container);
-    expect(a).toBe(b);
-  });
-
-  it('context should be passed down from the parent', function() {
-    class Parent extends React.Component {
-      static childContextTypes = {
-        foo: ReactPropTypes.string,
-      };
-
-      getChildContext() {
-        return {
-          foo: 'bar',
-        };
-      }
-
-      render() {
-        return <div>{this.props.children}</div>;
-      }
-    }
-
-    class Component extends React.Component {
-      static contextTypes = {
-        foo: ReactPropTypes.string.isRequired,
-      };
-
-      render() {
-        return <div />;
-      }
-    }
-
-    var div = document.createElement('div');
-    ReactDOM.render(<Parent><Component /></Parent>, div);
-  });
-
-  it('should replace state', function() {
-    var Moo = React.createClass({
-      getInitialState: function() {
-        return {x: 1};
-      },
-      render: function() {
-        return <div />;
-      },
-    });
-
-    var moo = ReactTestUtils.renderIntoDocument(<Moo />);
-    moo.replaceState({y: 2});
-    expect('x' in moo.state).toBe(false);
-    expect(moo.state.y).toBe(2);
-  });
-
-  it('should support objects with prototypes as state', function() {
-    var NotActuallyImmutable = function(str) {
-      this.str = str;
-    };
-    NotActuallyImmutable.prototype.amIImmutable = function() {
-      return true;
-    };
-    var Moo = React.createClass({
-      getInitialState: function() {
-        return new NotActuallyImmutable('first');
-      },
-      render: function() {
-        return <div />;
-      },
-    });
-
-    var moo = ReactTestUtils.renderIntoDocument(<Moo />);
-    expect(moo.state.str).toBe('first');
-    expect(moo.state.amIImmutable()).toBe(true);
-
-    var secondState = new NotActuallyImmutable('second');
-    moo.replaceState(secondState);
-    expect(moo.state.str).toBe('second');
-    expect(moo.state.amIImmutable()).toBe(true);
-    expect(moo.state).toBe(secondState);
-
-    moo.setState({str: 'third'});
-    expect(moo.state.str).toBe('third');
-    // Here we lose the prototype.
-    expect(moo.state.amIImmutable).toBe(undefined);
-
-    // When more than one state update is enqueued, we have the same behavior
-    var fifthState = new NotActuallyImmutable('fifth');
-    ReactUpdates.batchedUpdates(function() {
-      moo.setState({str: 'fourth'});
-      moo.replaceState(fifthState);
-    });
-    expect(moo.state).toBe(fifthState);
-
-    // When more than one state update is enqueued, we have the same behavior
-    var sixthState = new NotActuallyImmutable('sixth');
-    ReactUpdates.batchedUpdates(function() {
-      moo.replaceState(sixthState);
-      moo.setState({str: 'seventh'});
-    });
-    expect(moo.state.str).toBe('seventh');
-    expect(moo.state.amIImmutable).toBe(undefined);
-  });
-
-  it('should not warn about unmounting during unmounting', function() {
-    var container = document.createElement('div');
-    var layer = document.createElement('div');
-
-    class Component extends React.Component {
-      componentWillMount() {
-        ReactDOM.render(<div />, layer);
-      }
-
-      componentWillUnmount() {
-        ReactDOM.unmountComponentAtNode(layer);
-      }
-
-      render() {
-        return <div />;
-      }
-    }
-
-    class Outer extends React.Component {
-      render() {
-        return <div>{this.props.children}</div>;
-      }
-    }
-
-    ReactDOM.render(<Outer><Component /></Outer>, container);
-    ReactDOM.render(<Outer />, container);
-  });
-
-  it('should warn when mutated props are passed', function() {
-    spyOn(console, 'error');
-
-    var container = document.createElement('div');
-
-    class Foo extends React.Component {
-      constructor(props) {
-        var _props = { idx: props.idx + '!' };
-        super(_props);
-      }
-
-      render() {
-        return <span />;
-      }
-    }
-
-    expect(console.error.calls.count()).toBe(0);
-
-    ReactDOM.render(<Foo idx="qwe" />, container);
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Foo(...): When calling super() in `Foo`, make sure to pass ' +
-      'up the same props that your component\'s constructor was passed.'
-    );
-
-  });
-
-  it('should only call componentWillUnmount once', function() {
-    var app;
-    var count = 0;
-
-    class App extends React.Component {
-      render() {
-        if (this.props.stage === 1) {
-          return <UnunmountableComponent />;
-        } else {
-          return null;
-        }
-      }
-    }
-
-    class UnunmountableComponent extends React.Component {
-      componentWillUnmount() {
-        app.setState({});
-        count++;
-        throw Error('always fails');
-      }
-
-      render() {
-        return <div>Hello {this.props.name}</div>;
-      }
-    }
-
-    var container = document.createElement('div');
-
-    var setRef = (ref) => {
-      if (ref) {
-        app = ref;
-      }
+  }
+
+  var container = document.createElement('div');
+  expect(a).toBe(container.firstChild);
+  ReactDOM.render(<Component />, container);
+  ReactDOM.unmountComponentAtNode(container);
+  expect(a).toBe(b);
+});
+
+it('context should be passed down from the parent', function() {
+  class Parent extends React.Component {
+    static childContextTypes = {
+      foo: ReactPropTypes.string,
     };
 
-    expect(function() {
-      ReactDOM.render(<App ref={setRef} stage={1} />, container);
-      ReactDOM.render(<App ref={setRef} stage={2} />, container);
-    }).toThrow();
-    expect(count).toBe(1);
+    getChildContext() {
+      return {
+        foo: 'bar',
+      };
+    }
+
+    render() {
+      return <div>{this.props.children}</div>;
+    }
+  }
+
+  class Component extends React.Component {
+    static contextTypes = {
+      foo: ReactPropTypes.string.isRequired,
+    };
+
+    render() {
+      return <div />;
+    }
+  }
+
+  var div = document.createElement('div');
+  ReactDOM.render(<Parent><Component /></Parent>, div);
+});
+
+it('should replace state', function() {
+  var Moo = React.createClass({
+    getInitialState: function() {
+      return {x: 1};
+    },
+    render: function() {
+      return <div />;
+    },
   });
 
+  var moo = ReactTestUtils.renderIntoDocument(<Moo />);
+  moo.replaceState({y: 2});
+  expect('x' in moo.state).toBe(false);
+  expect(moo.state.y).toBe(2);
+});
+
+it('should support objects with prototypes as state', function() {
+  var NotActuallyImmutable = function(str) {
+    this.str = str;
+  };
+  NotActuallyImmutable.prototype.amIImmutable = function() {
+    return true;
+  };
+  var Moo = React.createClass({
+    getInitialState: function() {
+      return new NotActuallyImmutable('first');
+    },
+    render: function() {
+      return <div />;
+    },
+  });
+
+  var moo = ReactTestUtils.renderIntoDocument(<Moo />);
+  expect(moo.state.str).toBe('first');
+  expect(moo.state.amIImmutable()).toBe(true);
+
+  var secondState = new NotActuallyImmutable('second');
+  moo.replaceState(secondState);
+  expect(moo.state.str).toBe('second');
+  expect(moo.state.amIImmutable()).toBe(true);
+  expect(moo.state).toBe(secondState);
+
+  moo.setState({str: 'third'});
+  expect(moo.state.str).toBe('third');
+  // Here we lose the prototype.
+  expect(moo.state.amIImmutable).toBe(undefined);
+
+  // When more than one state update is enqueued, we have the same behavior
+  var fifthState = new NotActuallyImmutable('fifth');
+  ReactUpdates.batchedUpdates(function() {
+    moo.setState({str: 'fourth'});
+    moo.replaceState(fifthState);
+  });
+  expect(moo.state).toBe(fifthState);
+
+  // When more than one state update is enqueued, we have the same behavior
+  var sixthState = new NotActuallyImmutable('sixth');
+  ReactUpdates.batchedUpdates(function() {
+    moo.replaceState(sixthState);
+    moo.setState({str: 'seventh'});
+  });
+  expect(moo.state.str).toBe('seventh');
+  expect(moo.state.amIImmutable).toBe(undefined);
+});
+
+it('should not warn about unmounting during unmounting', function() {
+  var container = document.createElement('div');
+  var layer = document.createElement('div');
+
+  class Component extends React.Component {
+    componentWillMount() {
+      ReactDOM.render(<div />, layer);
+    }
+
+    componentWillUnmount() {
+      ReactDOM.unmountComponentAtNode(layer);
+    }
+
+    render() {
+      return <div />;
+    }
+  }
+
+  class Outer extends React.Component {
+    render() {
+      return <div>{this.props.children}</div>;
+    }
+  }
+
+  ReactDOM.render(<Outer><Component /></Outer>, container);
+  ReactDOM.render(<Outer />, container);
+});
+
+it('should warn when mutated props are passed', function() {
+  spyOn(console, 'error');
+
+  var container = document.createElement('div');
+
+  class Foo extends React.Component {
+    constructor(props) {
+      var _props = { idx: props.idx + '!' };
+      super(_props);
+    }
+
+    render() {
+      return <span />;
+    }
+  }
+
+  expect(console.error.calls.count()).toBe(0);
+
+  ReactDOM.render(<Foo idx="qwe" />, container);
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'Foo(...): When calling super() in `Foo`, make sure to pass ' +
+    'up the same props that your component\'s constructor was passed.'
+  );
+
+});
+
+it('should only call componentWillUnmount once', function() {
+  var app;
+  var count = 0;
+
+  class App extends React.Component {
+    render() {
+      if (this.props.stage === 1) {
+        return <UnunmountableComponent />;
+      } else {
+        return null;
+      }
+    }
+  }
+
+  class UnunmountableComponent extends React.Component {
+    componentWillUnmount() {
+      app.setState({});
+      count++;
+      throw Error('always fails');
+    }
+
+    render() {
+      return <div>Hello {this.props.name}</div>;
+    }
+  }
+
+  var container = document.createElement('div');
+
+  var setRef = (ref) => {
+    if (ref) {
+      app = ref;
+    }
+  };
+
+  expect(function() {
+    ReactDOM.render(<App ref={setRef} stage={1} />, container);
+    ReactDOM.render(<App ref={setRef} stage={2} />, container);
+  }).toThrow();
+  expect(count).toBe(1);
 });

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponentDOMMinimalism-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponentDOMMinimalism-test.js
@@ -22,86 +22,77 @@ var MyCompositeComponent;
 
 var expectSingleChildlessDiv;
 
-/**
- * Integration test, testing the combination of JSX with our unit of
- * abstraction, `ReactCompositeComponent` does not ever add superfluous DOM
- * nodes.
- */
-describe('ReactCompositeComponentDOMMinimalism', function() {
+beforeEach(function() {
+  reactComponentExpect = require('reactComponentExpect');
+  React = require('React');
+  ReactTestUtils = require('ReactTestUtils');
 
-  beforeEach(function() {
-    reactComponentExpect = require('reactComponentExpect');
-    React = require('React');
-    ReactTestUtils = require('ReactTestUtils');
+  LowerLevelComposite = class extends React.Component {
+    render() {
+      return (
+        <div>
+          {this.props.children}
+        </div>
+      );
+    }
+  };
 
-    LowerLevelComposite = class extends React.Component {
-      render() {
-        return (
-          <div>
-            {this.props.children}
-          </div>
-        );
-      }
-    };
+  MyCompositeComponent = class extends React.Component {
+    render() {
+      return (
+        <LowerLevelComposite>
+          {this.props.children}
+        </LowerLevelComposite>
+      );
+    }
+  };
 
-    MyCompositeComponent = class extends React.Component {
-      render() {
-        return (
-          <LowerLevelComposite>
-            {this.props.children}
-          </LowerLevelComposite>
-        );
-      }
-    };
-
-    expectSingleChildlessDiv = function(instance) {
-      reactComponentExpect(instance)
-        .expectRenderedChild()
-        .toBeCompositeComponentWithType(LowerLevelComposite)
-          .expectRenderedChild()
-          .toBeDOMComponentWithTag('div')
-          .toBeDOMComponentWithNoChildren();
-    };
-  });
-
-  it('should not render extra nodes for non-interpolated text', function() {
-    var instance = (
-      <MyCompositeComponent>
-        A string child
-      </MyCompositeComponent>
-    );
-    instance = ReactTestUtils.renderIntoDocument(instance);
-    expectSingleChildlessDiv(instance);
-  });
-
-  it('should not render extra nodes for non-interpolated text', function() {
-    var instance = (
-      <MyCompositeComponent>
-        {'Interpolated String Child'}
-      </MyCompositeComponent>
-    );
-    instance = ReactTestUtils.renderIntoDocument(instance);
-    expectSingleChildlessDiv(instance);
-  });
-
-  it('should not render extra nodes for non-interpolated text', function() {
-    var instance = (
-      <MyCompositeComponent>
-        <ul>
-          This text causes no children in ul, just innerHTML
-        </ul>
-      </MyCompositeComponent>
-    );
-    instance = ReactTestUtils.renderIntoDocument(instance);
+  expectSingleChildlessDiv = function(instance) {
     reactComponentExpect(instance)
       .expectRenderedChild()
       .toBeCompositeComponentWithType(LowerLevelComposite)
         .expectRenderedChild()
         .toBeDOMComponentWithTag('div')
-        .toBeDOMComponentWithChildCount(1)
-        .expectRenderedChildAt(0)
-          .toBeDOMComponentWithTag('ul')
-          .toBeDOMComponentWithNoChildren();
-  });
+        .toBeDOMComponentWithNoChildren();
+  };
+});
 
+it('should not render extra nodes for non-interpolated text', function() {
+  var instance = (
+    <MyCompositeComponent>
+      A string child
+    </MyCompositeComponent>
+  );
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  expectSingleChildlessDiv(instance);
+});
+
+it('should not render extra nodes for non-interpolated text', function() {
+  var instance = (
+    <MyCompositeComponent>
+      {'Interpolated String Child'}
+    </MyCompositeComponent>
+  );
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  expectSingleChildlessDiv(instance);
+});
+
+it('should not render extra nodes for non-interpolated text', function() {
+  var instance = (
+    <MyCompositeComponent>
+      <ul>
+        This text causes no children in ul, just innerHTML
+      </ul>
+    </MyCompositeComponent>
+  );
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  reactComponentExpect(instance)
+    .expectRenderedChild()
+    .toBeCompositeComponentWithType(LowerLevelComposite)
+      .expectRenderedChild()
+      .toBeDOMComponentWithTag('div')
+      .toBeDOMComponentWithChildCount(1)
+      .expectRenderedChildAt(0)
+        .toBeDOMComponentWithTag('ul')
+        .toBeDOMComponentWithNoChildren();
 });

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponentNestedState-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponentNestedState-test.js
@@ -15,104 +15,101 @@ var React;
 var ReactDOM;
 var ReactTestUtils;
 
-describe('ReactCompositeComponentNestedState-state', function() {
+beforeEach(function() {
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactTestUtils = require('ReactTestUtils');
+});
 
-  beforeEach(function() {
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactTestUtils = require('ReactTestUtils');
-  });
+it('should provide up to date values for props', function() {
+  class ParentComponent extends React.Component {
+    state = {color: 'blue'};
 
-  it('should provide up to date values for props', function() {
-    class ParentComponent extends React.Component {
-      state = {color: 'blue'};
+    handleColor = (color) => {
+      this.props.logger('parent-handleColor', this.state.color);
+      this.setState({color: color}, function() {
+        this.props.logger('parent-after-setState', this.state.color);
+      });
+    };
 
-      handleColor = (color) => {
-        this.props.logger('parent-handleColor', this.state.color);
-        this.setState({color: color}, function() {
-          this.props.logger('parent-after-setState', this.state.color);
-        });
-      };
+    render() {
+      this.props.logger('parent-render', this.state.color);
+      return (
+        <ChildComponent
+          logger={this.props.logger}
+          color={this.state.color}
+          onSelectColor={this.handleColor}
+        />
+      );
+    }
+  }
 
-      render() {
-        this.props.logger('parent-render', this.state.color);
-        return (
-          <ChildComponent
-            logger={this.props.logger}
-            color={this.state.color}
-            onSelectColor={this.handleColor}
-          />
-        );
-      }
+  class ChildComponent extends React.Component {
+    constructor(props) {
+      super(props);
+      props.logger('getInitialState', props.color);
+      this.state = {hue: 'dark ' + props.color};
     }
 
-    class ChildComponent extends React.Component {
-      constructor(props) {
-        super(props);
-        props.logger('getInitialState', props.color);
-        this.state = {hue: 'dark ' + props.color};
-      }
+    handleHue = (shade, color) => {
+      this.props.logger('handleHue', this.state.hue, this.props.color);
+      this.props.onSelectColor(color);
+      this.setState(function(state, props) {
+        this.props.logger('setState-this', this.state.hue, this.props.color);
+        this.props.logger('setState-args', state.hue, props.color);
+        return {hue: shade + ' ' + props.color};
+      }, function() {
+        this.props.logger('after-setState', this.state.hue, this.props.color);
+      });
+    };
 
-      handleHue = (shade, color) => {
-        this.props.logger('handleHue', this.state.hue, this.props.color);
-        this.props.onSelectColor(color);
-        this.setState(function(state, props) {
-          this.props.logger('setState-this', this.state.hue, this.props.color);
-          this.props.logger('setState-args', state.hue, props.color);
-          return {hue: shade + ' ' + props.color};
-        }, function() {
-          this.props.logger('after-setState', this.state.hue, this.props.color);
-        });
-      };
-
-      render() {
-        this.props.logger('render', this.state.hue, this.props.color);
-        return (
-          <div>
-            <button onClick={this.handleHue.bind(this, 'dark', 'blue')}>
-              Dark Blue
-            </button>
-            <button onClick={this.handleHue.bind(this, 'light', 'blue')}>
-              Light Blue
-            </button>
-            <button onClick={this.handleHue.bind(this, 'dark', 'green')}>
-              Dark Green
-            </button>
-            <button onClick={this.handleHue.bind(this, 'light', 'green')}>
-              Light Green
-            </button>
-          </div>
-        );
-      }
+    render() {
+      this.props.logger('render', this.state.hue, this.props.color);
+      return (
+        <div>
+          <button onClick={this.handleHue.bind(this, 'dark', 'blue')}>
+            Dark Blue
+          </button>
+          <button onClick={this.handleHue.bind(this, 'light', 'blue')}>
+            Light Blue
+          </button>
+          <button onClick={this.handleHue.bind(this, 'dark', 'green')}>
+            Dark Green
+          </button>
+          <button onClick={this.handleHue.bind(this, 'light', 'green')}>
+            Light Green
+          </button>
+        </div>
+      );
     }
+  }
 
-    var container = document.createElement('div');
-    document.body.appendChild(container);
+  var container = document.createElement('div');
+  document.body.appendChild(container);
 
-    var logger = jest.fn();
+  var logger = jest.fn();
 
-    void ReactDOM.render(
-      <ParentComponent logger={logger} />,
-      container
-    );
+  void ReactDOM.render(
+    <ParentComponent logger={logger} />,
+    container
+  );
 
-    // click "light green"
-    ReactTestUtils.Simulate.click(
-      container.childNodes[0].childNodes[3]
-    );
+  // click "light green"
+  ReactTestUtils.Simulate.click(
+    container.childNodes[0].childNodes[3]
+  );
 
-    expect(logger.mock.calls).toEqual([
-      ['parent-render', 'blue'],
-      ['getInitialState', 'blue'],
-      ['render', 'dark blue', 'blue'],
-      ['handleHue', 'dark blue', 'blue'],
-      ['parent-handleColor', 'blue'],
-      ['parent-render', 'green'],
-      ['setState-this', 'dark blue', 'blue'],
-      ['setState-args', 'dark blue', 'green'],
-      ['render', 'light green', 'green'],
-      ['parent-after-setState', 'green'],
-      ['after-setState', 'light green', 'green'],
-    ]);
-  });
+  expect(logger.mock.calls).toEqual([
+    ['parent-render', 'blue'],
+    ['getInitialState', 'blue'],
+    ['render', 'dark blue', 'blue'],
+    ['handleHue', 'dark blue', 'blue'],
+    ['parent-handleColor', 'blue'],
+    ['parent-render', 'green'],
+    ['setState-this', 'dark blue', 'blue'],
+    ['setState-args', 'dark blue', 'green'],
+    ['render', 'light green', 'green'],
+    ['parent-after-setState', 'green'],
+    ['after-setState', 'light green', 'green'],
+  ]);
 });

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponentState-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponentState-test.js
@@ -16,233 +16,230 @@ var ReactDOM;
 
 var TestComponent;
 
-describe('ReactCompositeComponent-state', function() {
+beforeEach(function() {
+  React = require('React');
 
-  beforeEach(function() {
-    React = require('React');
+  ReactDOM = require('ReactDOM');
 
-    ReactDOM = require('ReactDOM');
+  TestComponent = React.createClass({
+    peekAtState: function(from, state) {
+      state = state || this.state;
+      this.props.stateListener(from, state && state.color);
+    },
 
-    TestComponent = React.createClass({
-      peekAtState: function(from, state) {
-        state = state || this.state;
-        this.props.stateListener(from, state && state.color);
-      },
+    peekAtCallback: function(from) {
+      return () => this.peekAtState(from);
+    },
 
-      peekAtCallback: function(from) {
-        return () => this.peekAtState(from);
-      },
+    setFavoriteColor: function(nextColor) {
+      this.setState(
+        {color: nextColor},
+        this.peekAtCallback('setFavoriteColor')
+      );
+    },
 
-      setFavoriteColor: function(nextColor) {
-        this.setState(
-          {color: nextColor},
-          this.peekAtCallback('setFavoriteColor')
-        );
-      },
+    getInitialState: function() {
+      this.peekAtState('getInitialState');
+      return {color: 'red'};
+    },
 
-      getInitialState: function() {
-        this.peekAtState('getInitialState');
-        return {color: 'red'};
-      },
+    render: function() {
+      this.peekAtState('render');
+      return <div>{this.state.color}</div>;
+    },
 
-      render: function() {
-        this.peekAtState('render');
-        return <div>{this.state.color}</div>;
-      },
+    componentWillMount: function() {
+      this.peekAtState('componentWillMount-start');
+      this.setState(function(state) {
+        this.peekAtState('before-setState-sunrise', state);
+      });
+      this.setState(
+        {color: 'sunrise'},
+        this.peekAtCallback('setState-sunrise')
+      );
+      this.setState(function(state) {
+        this.peekAtState('after-setState-sunrise', state);
+      });
+      this.peekAtState('componentWillMount-after-sunrise');
+      this.setState(
+        {color: 'orange'},
+        this.peekAtCallback('setState-orange')
+      );
+      this.setState(function(state) {
+        this.peekAtState('after-setState-orange', state);
+      });
+      this.peekAtState('componentWillMount-end');
+    },
 
-      componentWillMount: function() {
-        this.peekAtState('componentWillMount-start');
+    componentDidMount: function() {
+      this.peekAtState('componentDidMount-start');
+      this.setState(
+        {color: 'yellow'},
+        this.peekAtCallback('setState-yellow')
+      );
+      this.peekAtState('componentDidMount-end');
+    },
+
+    componentWillReceiveProps: function(newProps) {
+      this.peekAtState('componentWillReceiveProps-start');
+      if (newProps.nextColor) {
         this.setState(function(state) {
-          this.peekAtState('before-setState-sunrise', state);
+          this.peekAtState('before-setState-receiveProps', state);
+          return {color: newProps.nextColor};
         });
+        this.replaceState({color: undefined});
         this.setState(
-          {color: 'sunrise'},
-          this.peekAtCallback('setState-sunrise')
-        );
-        this.setState(function(state) {
-          this.peekAtState('after-setState-sunrise', state);
-        });
-        this.peekAtState('componentWillMount-after-sunrise');
-        this.setState(
-          {color: 'orange'},
-          this.peekAtCallback('setState-orange')
-        );
-        this.setState(function(state) {
-          this.peekAtState('after-setState-orange', state);
-        });
-        this.peekAtState('componentWillMount-end');
-      },
-
-      componentDidMount: function() {
-        this.peekAtState('componentDidMount-start');
-        this.setState(
-          {color: 'yellow'},
-          this.peekAtCallback('setState-yellow')
-        );
-        this.peekAtState('componentDidMount-end');
-      },
-
-      componentWillReceiveProps: function(newProps) {
-        this.peekAtState('componentWillReceiveProps-start');
-        if (newProps.nextColor) {
-          this.setState(function(state) {
-            this.peekAtState('before-setState-receiveProps', state);
+          function(state) {
+            this.peekAtState('before-setState-again-receiveProps', state);
             return {color: newProps.nextColor};
-          });
-          this.replaceState({color: undefined});
-          this.setState(
-            function(state) {
-              this.peekAtState('before-setState-again-receiveProps', state);
-              return {color: newProps.nextColor};
-            },
-            this.peekAtCallback('setState-receiveProps')
-          );
-          this.setState(function(state) {
-            this.peekAtState('after-setState-receiveProps', state);
-          });
-        }
-        this.peekAtState('componentWillReceiveProps-end');
-      },
-
-      shouldComponentUpdate: function(nextProps, nextState) {
-        this.peekAtState('shouldComponentUpdate-currentState');
-        this.peekAtState('shouldComponentUpdate-nextState', nextState);
-        return true;
-      },
-
-      componentWillUpdate: function(nextProps, nextState) {
-        this.peekAtState('componentWillUpdate-currentState');
-        this.peekAtState('componentWillUpdate-nextState', nextState);
-      },
-
-      componentDidUpdate: function(prevProps, prevState) {
-        this.peekAtState('componentDidUpdate-currentState');
-        this.peekAtState('componentDidUpdate-prevState', prevState);
-      },
-
-      componentWillUnmount: function() {
-        this.peekAtState('componentWillUnmount');
-      },
-    });
-  });
-
-  it('should support setting state', function() {
-    var container = document.createElement('div');
-    document.body.appendChild(container);
-
-    var stateListener = jest.fn();
-    var instance = ReactDOM.render(
-      <TestComponent stateListener={stateListener} />,
-      container,
-      function peekAtInitialCallback() {
-        this.peekAtState('initial-callback');
+          },
+          this.peekAtCallback('setState-receiveProps')
+        );
+        this.setState(function(state) {
+          this.peekAtState('after-setState-receiveProps', state);
+        });
       }
-    );
-    ReactDOM.render(
-      <TestComponent stateListener={stateListener} nextColor="green" />,
-      container,
-      instance.peekAtCallback('setProps')
-    );
-    instance.setFavoriteColor('blue');
-    instance.forceUpdate(instance.peekAtCallback('forceUpdate'));
+      this.peekAtState('componentWillReceiveProps-end');
+    },
 
+    shouldComponentUpdate: function(nextProps, nextState) {
+      this.peekAtState('shouldComponentUpdate-currentState');
+      this.peekAtState('shouldComponentUpdate-nextState', nextState);
+      return true;
+    },
+
+    componentWillUpdate: function(nextProps, nextState) {
+      this.peekAtState('componentWillUpdate-currentState');
+      this.peekAtState('componentWillUpdate-nextState', nextState);
+    },
+
+    componentDidUpdate: function(prevProps, prevState) {
+      this.peekAtState('componentDidUpdate-currentState');
+      this.peekAtState('componentDidUpdate-prevState', prevState);
+    },
+
+    componentWillUnmount: function() {
+      this.peekAtState('componentWillUnmount');
+    },
+  });
+});
+
+it('should support setting state', function() {
+  var container = document.createElement('div');
+  document.body.appendChild(container);
+
+  var stateListener = jest.fn();
+  var instance = ReactDOM.render(
+    <TestComponent stateListener={stateListener} />,
+    container,
+    function peekAtInitialCallback() {
+      this.peekAtState('initial-callback');
+    }
+  );
+  ReactDOM.render(
+    <TestComponent stateListener={stateListener} nextColor="green" />,
+    container,
+    instance.peekAtCallback('setProps')
+  );
+  instance.setFavoriteColor('blue');
+  instance.forceUpdate(instance.peekAtCallback('forceUpdate'));
+
+  ReactDOM.unmountComponentAtNode(container);
+
+  expect(stateListener.mock.calls.join('\n')).toEqual([
+    // there is no state when getInitialState() is called
+    ['getInitialState', null],
+    ['componentWillMount-start', 'red'],
+    // setState()'s only enqueue pending states.
+    ['componentWillMount-after-sunrise', 'red'],
+    ['componentWillMount-end', 'red'],
+    // pending state queue is processed
+    ['before-setState-sunrise', 'red'],
+    ['after-setState-sunrise', 'sunrise'],
+    ['after-setState-orange', 'orange'],
+    // pending state has been applied
+    ['render', 'orange'],
+    ['componentDidMount-start', 'orange'],
+    // setState-sunrise and setState-orange should be called here,
+    // after the bug in #1740
+    // componentDidMount() called setState({color:'yellow'}), which is async.
+    // The update doesn't happen until the next flush.
+    ['componentDidMount-end', 'orange'],
+    ['shouldComponentUpdate-currentState', 'orange'],
+    ['shouldComponentUpdate-nextState', 'yellow'],
+    ['componentWillUpdate-currentState', 'orange'],
+    ['componentWillUpdate-nextState', 'yellow'],
+    ['render', 'yellow'],
+    ['componentDidUpdate-currentState', 'yellow'],
+    ['componentDidUpdate-prevState', 'orange'],
+    ['setState-sunrise', 'yellow'],
+    ['setState-orange', 'yellow'],
+    ['setState-yellow', 'yellow'],
+    ['initial-callback', 'yellow'],
+    ['componentWillReceiveProps-start', 'yellow'],
+    // setState({color:'green'}) only enqueues a pending state.
+    ['componentWillReceiveProps-end', 'yellow'],
+    // pending state queue is processed
+    // before-setState-receiveProps never called, due to replaceState.
+    ['before-setState-again-receiveProps', undefined],
+    ['after-setState-receiveProps', 'green'],
+    ['shouldComponentUpdate-currentState', 'yellow'],
+    ['shouldComponentUpdate-nextState', 'green'],
+    ['componentWillUpdate-currentState', 'yellow'],
+    ['componentWillUpdate-nextState', 'green'],
+    ['render', 'green'],
+    ['componentDidUpdate-currentState', 'green'],
+    ['componentDidUpdate-prevState', 'yellow'],
+    ['setState-receiveProps', 'green'],
+    ['setProps', 'green'],
+    // setFavoriteColor('blue')
+    ['shouldComponentUpdate-currentState', 'green'],
+    ['shouldComponentUpdate-nextState', 'blue'],
+    ['componentWillUpdate-currentState', 'green'],
+    ['componentWillUpdate-nextState', 'blue'],
+    ['render', 'blue'],
+    ['componentDidUpdate-currentState', 'blue'],
+    ['componentDidUpdate-prevState', 'green'],
+    ['setFavoriteColor', 'blue'],
+    // forceUpdate()
+    ['componentWillUpdate-currentState', 'blue'],
+    ['componentWillUpdate-nextState', 'blue'],
+    ['render', 'blue'],
+    ['componentDidUpdate-currentState', 'blue'],
+    ['componentDidUpdate-prevState', 'blue'],
+    ['forceUpdate', 'blue'],
+    // unmountComponent()
+    // state is available within `componentWillUnmount()`
+    ['componentWillUnmount', 'blue'],
+  ].join('\n'));
+});
+
+it('should batch unmounts', function() {
+  var outer;
+
+  class Inner extends React.Component {
+    render() {
+      return <div />;
+    }
+
+    componentWillUnmount() {
+      // This should get silently ignored (maybe with a warning), but it
+      // shouldn't break React.
+      outer.setState({showInner: false});
+    }
+  }
+
+  class Outer extends React.Component {
+    state = {showInner: true};
+
+    render() {
+      return <div>{this.state.showInner && <Inner />}</div>;
+    }
+  }
+
+  var container = document.createElement('div');
+  outer = ReactDOM.render(<Outer />, container);
+  expect(() => {
     ReactDOM.unmountComponentAtNode(container);
-
-    expect(stateListener.mock.calls.join('\n')).toEqual([
-      // there is no state when getInitialState() is called
-      ['getInitialState', null],
-      ['componentWillMount-start', 'red'],
-      // setState()'s only enqueue pending states.
-      ['componentWillMount-after-sunrise', 'red'],
-      ['componentWillMount-end', 'red'],
-      // pending state queue is processed
-      ['before-setState-sunrise', 'red'],
-      ['after-setState-sunrise', 'sunrise'],
-      ['after-setState-orange', 'orange'],
-      // pending state has been applied
-      ['render', 'orange'],
-      ['componentDidMount-start', 'orange'],
-      // setState-sunrise and setState-orange should be called here,
-      // after the bug in #1740
-      // componentDidMount() called setState({color:'yellow'}), which is async.
-      // The update doesn't happen until the next flush.
-      ['componentDidMount-end', 'orange'],
-      ['shouldComponentUpdate-currentState', 'orange'],
-      ['shouldComponentUpdate-nextState', 'yellow'],
-      ['componentWillUpdate-currentState', 'orange'],
-      ['componentWillUpdate-nextState', 'yellow'],
-      ['render', 'yellow'],
-      ['componentDidUpdate-currentState', 'yellow'],
-      ['componentDidUpdate-prevState', 'orange'],
-      ['setState-sunrise', 'yellow'],
-      ['setState-orange', 'yellow'],
-      ['setState-yellow', 'yellow'],
-      ['initial-callback', 'yellow'],
-      ['componentWillReceiveProps-start', 'yellow'],
-      // setState({color:'green'}) only enqueues a pending state.
-      ['componentWillReceiveProps-end', 'yellow'],
-      // pending state queue is processed
-      // before-setState-receiveProps never called, due to replaceState.
-      ['before-setState-again-receiveProps', undefined],
-      ['after-setState-receiveProps', 'green'],
-      ['shouldComponentUpdate-currentState', 'yellow'],
-      ['shouldComponentUpdate-nextState', 'green'],
-      ['componentWillUpdate-currentState', 'yellow'],
-      ['componentWillUpdate-nextState', 'green'],
-      ['render', 'green'],
-      ['componentDidUpdate-currentState', 'green'],
-      ['componentDidUpdate-prevState', 'yellow'],
-      ['setState-receiveProps', 'green'],
-      ['setProps', 'green'],
-      // setFavoriteColor('blue')
-      ['shouldComponentUpdate-currentState', 'green'],
-      ['shouldComponentUpdate-nextState', 'blue'],
-      ['componentWillUpdate-currentState', 'green'],
-      ['componentWillUpdate-nextState', 'blue'],
-      ['render', 'blue'],
-      ['componentDidUpdate-currentState', 'blue'],
-      ['componentDidUpdate-prevState', 'green'],
-      ['setFavoriteColor', 'blue'],
-      // forceUpdate()
-      ['componentWillUpdate-currentState', 'blue'],
-      ['componentWillUpdate-nextState', 'blue'],
-      ['render', 'blue'],
-      ['componentDidUpdate-currentState', 'blue'],
-      ['componentDidUpdate-prevState', 'blue'],
-      ['forceUpdate', 'blue'],
-      // unmountComponent()
-      // state is available within `componentWillUnmount()`
-      ['componentWillUnmount', 'blue'],
-    ].join('\n'));
-  });
-
-  it('should batch unmounts', function() {
-    var outer;
-
-    class Inner extends React.Component {
-      render() {
-        return <div />;
-      }
-
-      componentWillUnmount() {
-        // This should get silently ignored (maybe with a warning), but it
-        // shouldn't break React.
-        outer.setState({showInner: false});
-      }
-    }
-
-    class Outer extends React.Component {
-      state = {showInner: true};
-
-      render() {
-        return <div>{this.state.showInner && <Inner />}</div>;
-      }
-    }
-
-    var container = document.createElement('div');
-    outer = ReactDOM.render(<Outer />, container);
-    expect(() => {
-      ReactDOM.unmountComponentAtNode(container);
-    }).not.toThrow();
-  });
+  }).not.toThrow();
 });

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactEmptyComponent-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactEmptyComponent-test.js
@@ -20,301 +20,299 @@ var reactComponentExpect;
 
 var log;
 
-describe('ReactEmptyComponent', function() {
-  beforeEach(function() {
-    jest.resetModuleRegistry();
+beforeEach(function() {
+  jest.resetModuleRegistry();
 
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactTestUtils = require('ReactTestUtils');
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactTestUtils = require('ReactTestUtils');
 
-    reactComponentExpect = require('reactComponentExpect');
+  reactComponentExpect = require('reactComponentExpect');
 
-    log = jasmine.createSpy();
+  log = jasmine.createSpy();
 
-    TogglingComponent = class extends React.Component {
-      state = {component: this.props.firstComponent};
+  TogglingComponent = class extends React.Component {
+    state = {component: this.props.firstComponent};
 
-      componentDidMount() {
-        log(ReactDOM.findDOMNode(this));
-        this.setState({component: this.props.secondComponent});
-      }
-
-      componentDidUpdate() {
-        log(ReactDOM.findDOMNode(this));
-      }
-
-      render() {
-        var Component = this.state.component;
-        return Component ? <Component /> : null;
-      }
-    };
-  });
-
-  it('should render null and false as a noscript tag under the hood', () => {
-    class Component1 extends React.Component {
-      render() {
-        return null;
-      }
+    componentDidMount() {
+      log(ReactDOM.findDOMNode(this));
+      this.setState({component: this.props.secondComponent});
     }
 
-    class Component2 extends React.Component {
-      render() {
-        return false;
-      }
+    componentDidUpdate() {
+      log(ReactDOM.findDOMNode(this));
     }
 
-    var instance1 = ReactTestUtils.renderIntoDocument(<Component1 />);
-    var instance2 = ReactTestUtils.renderIntoDocument(<Component2 />);
-    reactComponentExpect(instance1)
-      .expectRenderedChild()
-      .toBeEmptyComponent();
-    reactComponentExpect(instance2)
-      .expectRenderedChild()
-      .toBeEmptyComponent();
-  });
-
-  it('should still throw when rendering to undefined', () => {
-    class Component extends React.Component {
-      render() {}
+    render() {
+      var Component = this.state.component;
+      return Component ? <Component /> : null;
     }
+  };
+});
 
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(<Component />);
-    }).toThrowError(
-      'Component.render(): A valid React element (or null) must be returned. You may ' +
-      'have returned undefined, an array or some other invalid object.'
-    );
-  });
+it('should render null and false as a noscript tag under the hood', () => {
+  class Component1 extends React.Component {
+    render() {
+      return null;
+    }
+  }
 
-  it('should be able to switch between rendering null and a normal tag', () => {
+  class Component2 extends React.Component {
+    render() {
+      return false;
+    }
+  }
+
+  var instance1 = ReactTestUtils.renderIntoDocument(<Component1 />);
+  var instance2 = ReactTestUtils.renderIntoDocument(<Component2 />);
+  reactComponentExpect(instance1)
+    .expectRenderedChild()
+    .toBeEmptyComponent();
+  reactComponentExpect(instance2)
+    .expectRenderedChild()
+    .toBeEmptyComponent();
+});
+
+it('should still throw when rendering to undefined', () => {
+  class Component extends React.Component {
+    render() {}
+  }
+
+  expect(function() {
+    ReactTestUtils.renderIntoDocument(<Component />);
+  }).toThrowError(
+    'Component.render(): A valid React element (or null) must be returned. You may ' +
+    'have returned undefined, an array or some other invalid object.'
+  );
+});
+
+it('should be able to switch between rendering null and a normal tag', () => {
+  var instance1 =
+    <TogglingComponent
+      firstComponent={null}
+      secondComponent={'div'}
+    />;
+  var instance2 =
+    <TogglingComponent
+      firstComponent={'div'}
+      secondComponent={null}
+    />;
+
+  ReactTestUtils.renderIntoDocument(instance1);
+  ReactTestUtils.renderIntoDocument(instance2);
+
+  expect(log.calls.count()).toBe(4);
+  expect(log.calls.argsFor(0)[0]).toBe(null);
+  expect(log.calls.argsFor(1)[0].tagName).toBe('DIV');
+  expect(log.calls.argsFor(2)[0].tagName).toBe('DIV');
+  expect(log.calls.argsFor(3)[0]).toBe(null);
+});
+
+it('should be able to switch in a list of children', () => {
+  var instance1 =
+    <TogglingComponent
+      firstComponent={null}
+      secondComponent={'div'}
+    />;
+
+  ReactTestUtils.renderIntoDocument(
+    <div>
+      {instance1}
+      {instance1}
+      {instance1}
+    </div>
+  );
+
+  expect(log.calls.count()).toBe(6);
+  expect(log.calls.argsFor(0)[0]).toBe(null);
+  expect(log.calls.argsFor(1)[0]).toBe(null);
+  expect(log.calls.argsFor(2)[0]).toBe(null);
+  expect(log.calls.argsFor(3)[0].tagName).toBe('DIV');
+  expect(log.calls.argsFor(4)[0].tagName).toBe('DIV');
+  expect(log.calls.argsFor(5)[0].tagName).toBe('DIV');
+});
+
+it('should distinguish between a script placeholder and an actual script tag',
+  () => {
     var instance1 =
       <TogglingComponent
         firstComponent={null}
-        secondComponent={'div'}
+        secondComponent={'script'}
       />;
     var instance2 =
       <TogglingComponent
-        firstComponent={'div'}
+        firstComponent={'script'}
         secondComponent={null}
       />;
 
-    ReactTestUtils.renderIntoDocument(instance1);
-    ReactTestUtils.renderIntoDocument(instance2);
+    expect(function() {
+      ReactTestUtils.renderIntoDocument(instance1);
+    }).not.toThrow();
+    expect(function() {
+      ReactTestUtils.renderIntoDocument(instance2);
+    }).not.toThrow();
 
     expect(log.calls.count()).toBe(4);
     expect(log.calls.argsFor(0)[0]).toBe(null);
-    expect(log.calls.argsFor(1)[0].tagName).toBe('DIV');
-    expect(log.calls.argsFor(2)[0].tagName).toBe('DIV');
+    expect(log.calls.argsFor(1)[0].tagName).toBe('SCRIPT');
+    expect(log.calls.argsFor(2)[0].tagName).toBe('SCRIPT');
     expect(log.calls.argsFor(3)[0]).toBe(null);
-  });
+  }
+);
 
-  it('should be able to switch in a list of children', () => {
-    var instance1 =
-      <TogglingComponent
-        firstComponent={null}
-        secondComponent={'div'}
-      />;
-
-    ReactTestUtils.renderIntoDocument(
-      <div>
-        {instance1}
-        {instance1}
-        {instance1}
-      </div>
-    );
-
-    expect(log.calls.count()).toBe(6);
-    expect(log.calls.argsFor(0)[0]).toBe(null);
-    expect(log.calls.argsFor(1)[0]).toBe(null);
-    expect(log.calls.argsFor(2)[0]).toBe(null);
-    expect(log.calls.argsFor(3)[0].tagName).toBe('DIV');
-    expect(log.calls.argsFor(4)[0].tagName).toBe('DIV');
-    expect(log.calls.argsFor(5)[0].tagName).toBe('DIV');
-  });
-
-  it('should distinguish between a script placeholder and an actual script tag',
-    () => {
-      var instance1 =
-        <TogglingComponent
-          firstComponent={null}
-          secondComponent={'script'}
-        />;
-      var instance2 =
-        <TogglingComponent
-          firstComponent={'script'}
-          secondComponent={null}
-        />;
-
-      expect(function() {
-        ReactTestUtils.renderIntoDocument(instance1);
-      }).not.toThrow();
-      expect(function() {
-        ReactTestUtils.renderIntoDocument(instance2);
-      }).not.toThrow();
-
-      expect(log.calls.count()).toBe(4);
-      expect(log.calls.argsFor(0)[0]).toBe(null);
-      expect(log.calls.argsFor(1)[0].tagName).toBe('SCRIPT');
-      expect(log.calls.argsFor(2)[0].tagName).toBe('SCRIPT');
-      expect(log.calls.argsFor(3)[0]).toBe(null);
-    }
-  );
-
-  it('should have findDOMNode return null when multiple layers of composite ' +
-    'components render to the same null placeholder',
-    () => {
-      class GrandChild extends React.Component {
-        render() {
-          return null;
-        }
-      }
-
-      class Child extends React.Component {
-        render() {
-          return <GrandChild />;
-        }
-      }
-
-      var instance1 =
-        <TogglingComponent
-          firstComponent={'div'}
-          secondComponent={Child}
-        />;
-      var instance2 =
-        <TogglingComponent
-          firstComponent={Child}
-          secondComponent={'div'}
-        />;
-
-      expect(function() {
-        ReactTestUtils.renderIntoDocument(instance1);
-      }).not.toThrow();
-      expect(function() {
-        ReactTestUtils.renderIntoDocument(instance2);
-      }).not.toThrow();
-
-      expect(log.calls.count()).toBe(4);
-      expect(log.calls.argsFor(0)[0].tagName).toBe('DIV');
-      expect(log.calls.argsFor(1)[0]).toBe(null);
-      expect(log.calls.argsFor(2)[0]).toBe(null);
-      expect(log.calls.argsFor(3)[0].tagName).toBe('DIV');
-    }
-  );
-
-  it('works when switching components', function() {
-    var assertions = 0;
-
-    class Inner extends React.Component {
-      render() {
-        return <span />;
-      }
-
-      componentDidMount() {
-        // Make sure the DOM node resolves properly even if we're replacing a
-        // `null` component
-        expect(ReactDOM.findDOMNode(this)).not.toBe(null);
-        assertions++;
-      }
-
-      componentWillUnmount() {
-        // Even though we're getting replaced by `null`, we haven't been
-        // replaced yet!
-        expect(ReactDOM.findDOMNode(this)).not.toBe(null);
-        assertions++;
-      }
-    }
-
-    class Wrapper extends React.Component {
-      render() {
-        return this.props.showInner ? <Inner /> : null;
-      }
-    }
-
-    var el = document.createElement('div');
-    var component;
-
-    // Render the <Inner /> component...
-    component = ReactDOM.render(<Wrapper showInner={true} />, el);
-    expect(ReactDOM.findDOMNode(component)).not.toBe(null);
-
-    // Switch to null...
-    component = ReactDOM.render(<Wrapper showInner={false} />, el);
-    expect(ReactDOM.findDOMNode(component)).toBe(null);
-
-    // ...then switch back.
-    component = ReactDOM.render(<Wrapper showInner={true} />, el);
-    expect(ReactDOM.findDOMNode(component)).not.toBe(null);
-
-    expect(assertions).toBe(3);
-  });
-
-  it('throws when rendering null at the top level', function() {
-    // TODO: This should actually work since `null` is a valid ReactNode
-    var div = document.createElement('div');
-    expect(function() {
-      ReactDOM.render(null, div);
-    }).toThrowError(
-      'ReactDOM.render(): Invalid component element.'
-    );
-  });
-
-  it('does not break when updating during mount', function() {
-    class Child extends React.Component {
-      componentDidMount() {
-        if (this.props.onMount) {
-          this.props.onMount();
-        }
-      }
-
-      render() {
-        if (!this.props.visible) {
-          return null;
-        }
-
-        return <div>hello world</div>;
-      }
-    }
-
-    class Parent extends React.Component {
-      update = () => {
-        this.forceUpdate();
-      };
-
-      render() {
-        return (
-          <div>
-            <Child key="1" visible={false} />
-            <Child key="0" visible={true} onMount={this.update} />
-            <Child key="2" visible={false} />
-          </div>
-        );
-      }
-    }
-
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(<Parent />);
-    }).not.toThrow();
-  });
-
-  it('preserves the dom node during updates', function() {
-    class Empty extends React.Component {
+it('should have findDOMNode return null when multiple layers of composite ' +
+  'components render to the same null placeholder',
+  () => {
+    class GrandChild extends React.Component {
       render() {
         return null;
       }
     }
 
-    var container = document.createElement('div');
+    class Child extends React.Component {
+      render() {
+        return <GrandChild />;
+      }
+    }
 
-    ReactDOM.render(<Empty />, container);
-    var noscript1 = container.firstChild;
-    expect(noscript1.nodeName).toBe('#comment');
+    var instance1 =
+      <TogglingComponent
+        firstComponent={'div'}
+        secondComponent={Child}
+      />;
+    var instance2 =
+      <TogglingComponent
+        firstComponent={Child}
+        secondComponent={'div'}
+      />;
 
-    // This update shouldn't create a DOM node
-    ReactDOM.render(<Empty />, container);
-    var noscript2 = container.firstChild;
-    expect(noscript2.nodeName).toBe('#comment');
+    expect(function() {
+      ReactTestUtils.renderIntoDocument(instance1);
+    }).not.toThrow();
+    expect(function() {
+      ReactTestUtils.renderIntoDocument(instance2);
+    }).not.toThrow();
 
-    expect(noscript1).toBe(noscript2);
-  });
+    expect(log.calls.count()).toBe(4);
+    expect(log.calls.argsFor(0)[0].tagName).toBe('DIV');
+    expect(log.calls.argsFor(1)[0]).toBe(null);
+    expect(log.calls.argsFor(2)[0]).toBe(null);
+    expect(log.calls.argsFor(3)[0].tagName).toBe('DIV');
+  }
+);
+
+it('works when switching components', function() {
+  var assertions = 0;
+
+  class Inner extends React.Component {
+    render() {
+      return <span />;
+    }
+
+    componentDidMount() {
+      // Make sure the DOM node resolves properly even if we're replacing a
+      // `null` component
+      expect(ReactDOM.findDOMNode(this)).not.toBe(null);
+      assertions++;
+    }
+
+    componentWillUnmount() {
+      // Even though we're getting replaced by `null`, we haven't been
+      // replaced yet!
+      expect(ReactDOM.findDOMNode(this)).not.toBe(null);
+      assertions++;
+    }
+  }
+
+  class Wrapper extends React.Component {
+    render() {
+      return this.props.showInner ? <Inner /> : null;
+    }
+  }
+
+  var el = document.createElement('div');
+  var component;
+
+  // Render the <Inner /> component...
+  component = ReactDOM.render(<Wrapper showInner={true} />, el);
+  expect(ReactDOM.findDOMNode(component)).not.toBe(null);
+
+  // Switch to null...
+  component = ReactDOM.render(<Wrapper showInner={false} />, el);
+  expect(ReactDOM.findDOMNode(component)).toBe(null);
+
+  // ...then switch back.
+  component = ReactDOM.render(<Wrapper showInner={true} />, el);
+  expect(ReactDOM.findDOMNode(component)).not.toBe(null);
+
+  expect(assertions).toBe(3);
+});
+
+it('throws when rendering null at the top level', function() {
+  // TODO: This should actually work since `null` is a valid ReactNode
+  var div = document.createElement('div');
+  expect(function() {
+    ReactDOM.render(null, div);
+  }).toThrowError(
+    'ReactDOM.render(): Invalid component element.'
+  );
+});
+
+it('does not break when updating during mount', function() {
+  class Child extends React.Component {
+    componentDidMount() {
+      if (this.props.onMount) {
+        this.props.onMount();
+      }
+    }
+
+    render() {
+      if (!this.props.visible) {
+        return null;
+      }
+
+      return <div>hello world</div>;
+    }
+  }
+
+  class Parent extends React.Component {
+    update = () => {
+      this.forceUpdate();
+    };
+
+    render() {
+      return (
+        <div>
+          <Child key="1" visible={false} />
+          <Child key="0" visible={true} onMount={this.update} />
+          <Child key="2" visible={false} />
+        </div>
+      );
+    }
+  }
+
+  expect(function() {
+    ReactTestUtils.renderIntoDocument(<Parent />);
+  }).not.toThrow();
+});
+
+it('preserves the dom node during updates', function() {
+  class Empty extends React.Component {
+    render() {
+      return null;
+    }
+  }
+
+  var container = document.createElement('div');
+
+  ReactDOM.render(<Empty />, container);
+  var noscript1 = container.firstChild;
+  expect(noscript1.nodeName).toBe('#comment');
+
+  // This update shouldn't create a DOM node
+  ReactDOM.render(<Empty />, container);
+  var noscript2 = container.firstChild;
+  expect(noscript2.nodeName).toBe('#comment');
+
+  expect(noscript1).toBe(noscript2);
 });

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactErrorBoundaries-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactErrorBoundaries-test.js
@@ -14,292 +14,289 @@
 var React;
 var ReactDOM;
 
-describe('ReactErrorBoundaries', function() {
+beforeEach(function() {
+  ReactDOM = require('ReactDOM');
+  React = require('React');
+});
 
-  beforeEach(function() {
-    ReactDOM = require('ReactDOM');
-    React = require('React');
-  });
+it('does not register event handlers for unmounted children', function() {
+  class Angry extends React.Component {
+    render() {
+      throw new Error('Please, do not render me.');
+    }
+  }
 
-  it('does not register event handlers for unmounted children', function() {
-    class Angry extends React.Component {
-      render() {
-        throw new Error('Please, do not render me.');
+  class Boundary extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {error: false};
+    }
+    render() {
+      if (!this.state.error) {
+        return (
+          <div><button onClick={this.onClick}>ClickMe</button><Angry /></div>
+        );
+      } else {
+        return <div>Happy Birthday!</div>;
       }
     }
+    onClick() {
+      /* do nothing */
+    }
+    unstable_handleError() {
+      this.setState({error: true});
+    }
+  }
 
-    class Boundary extends React.Component {
-      constructor(props) {
-        super(props);
-        this.state = {error: false};
-      }
-      render() {
-        if (!this.state.error) {
-          return (
-            <div><button onClick={this.onClick}>ClickMe</button><Angry /></div>
-          );
-        } else {
-          return <div>Happy Birthday!</div>;
-        }
-      }
-      onClick() {
-        /* do nothing */
-      }
-      unstable_handleError() {
-        this.setState({error: true});
+  var EventPluginHub = require('EventPluginHub');
+  var container = document.createElement('div');
+  EventPluginHub.putListener = jest.fn();
+  ReactDOM.render(<Boundary />, container);
+  expect(EventPluginHub.putListener).not.toBeCalled();
+});
+
+it('renders an error state', function() {
+  var log = [];
+  class Angry extends React.Component {
+    render() {
+      log.push('Angry render');
+      throw new Error('Please, do not render me.');
+    }
+    componentDidMount() {
+      log.push('Angry componentDidMount');
+    }
+    componentWillUnmount() {
+      log.push('Angry componentWillUnmount');
+    }
+  }
+
+  class Boundary extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {error: false};
+    }
+    render() {
+      log.push('Boundary render');
+      if (!this.state.error) {
+        return (
+          <div><button onClick={this.onClick}>ClickMe</button><Angry /></div>
+        );
+      } else {
+        return <div>Happy Birthday!</div>;
       }
     }
+    componentDidMount() {
+      log.push('Boundary componentDidMount');
+    }
+    componentWillUnmount() {
+      log.push('Boundary componentWillUnmount');
+    }
+    onClick() {
+      /* do nothing */
+    }
+    unstable_handleError() {
+      this.setState({error: true});
+    }
+  }
 
-    var EventPluginHub = require('EventPluginHub');
-    var container = document.createElement('div');
-    EventPluginHub.putListener = jest.fn();
-    ReactDOM.render(<Boundary />, container);
-    expect(EventPluginHub.putListener).not.toBeCalled();
-  });
+  var container = document.createElement('div');
+  ReactDOM.render(<Boundary />, container);
+  expect(container.firstChild.innerHTML).toBe('Happy Birthday!');
+  expect(log).toEqual([
+    'Boundary render',
+    'Angry render',
+    'Boundary render',
+    'Boundary componentDidMount',
+  ]);
+});
 
-  it('renders an error state', function() {
-    var log = [];
-    class Angry extends React.Component {
-      render() {
-        log.push('Angry render');
-        throw new Error('Please, do not render me.');
-      }
-      componentDidMount() {
-        log.push('Angry componentDidMount');
-      }
-      componentWillUnmount() {
-        log.push('Angry componentWillUnmount');
-      }
+it('will catch exceptions in componentWillUnmount', function() {
+  class ErrorBoundary extends React.Component {
+    constructor() {
+      super();
+      this.state = {error: false};
     }
 
-    class Boundary extends React.Component {
-      constructor(props) {
-        super(props);
-        this.state = {error: false};
+    render() {
+      if (!this.state.error) {
+        return <div>{this.props.children}</div>;
       }
-      render() {
-        log.push('Boundary render');
-        if (!this.state.error) {
-          return (
-            <div><button onClick={this.onClick}>ClickMe</button><Angry /></div>
-          );
-        } else {
-          return <div>Happy Birthday!</div>;
-        }
-      }
-      componentDidMount() {
-        log.push('Boundary componentDidMount');
-      }
-      componentWillUnmount() {
-        log.push('Boundary componentWillUnmount');
-      }
-      onClick() {
-        /* do nothing */
-      }
-      unstable_handleError() {
-        this.setState({error: true});
-      }
+      return <div>Error has been caught</div>;
     }
 
-    var container = document.createElement('div');
-    ReactDOM.render(<Boundary />, container);
-    expect(container.firstChild.innerHTML).toBe('Happy Birthday!');
-    expect(log).toEqual([
-      'Boundary render',
-      'Angry render',
-      'Boundary render',
-      'Boundary componentDidMount',
-    ]);
-  });
-
-  it('will catch exceptions in componentWillUnmount', function() {
-    class ErrorBoundary extends React.Component {
-      constructor() {
-        super();
-        this.state = {error: false};
-      }
-
-      render() {
-        if (!this.state.error) {
-          return <div>{this.props.children}</div>;
-        }
-        return <div>Error has been caught</div>;
-      }
-
-      unstable_handleError() {
-        this.setState({error: true});
-      }
+    unstable_handleError() {
+      this.setState({error: true});
     }
+  }
 
-    class BrokenRender extends React.Component {
-      render() {
-        throw new Error('Always broken.');
-      }
-    }
-
-    class BrokenUnmount extends React.Component {
-      render() {
-        return <div />;
-      }
-      componentWillUnmount() {
-        throw new Error('Always broken.');
-      }
-    }
-
-    var container = document.createElement('div');
-    ReactDOM.render(
-      <ErrorBoundary>
-        <BrokenUnmount />
-        <BrokenRender />
-        <BrokenUnmount />
-      </ErrorBoundary>,
-      container
-    );
-    ReactDOM.unmountComponentAtNode(container);
-  });
-
-  it('expect uneventful render to succeed', function() {
-    var log = [];
-    class Boundary extends React.Component {
-      constructor(props) {
-        super(props);
-        this.state = {error: false};
-      }
-      render() {
-        log.push('Boundary render');
-        return <div><button onClick={this.onClick}>ClickMe</button></div>;
-      }
-      onClick() {
-        /* do nothing */
-      }
-      componentDidMount() {
-        log.push('Boundary componentDidMount');
-      }
-      componentWillUnmount() {
-        log.push('Boundary componentWillUnmount');
-      }
-      unstable_handleError() {
-        this.setState({error: true});
-      }
-    }
-
-    var container = document.createElement('div');
-    ReactDOM.render(<Boundary />, container);
-    expect(log).toEqual([
-      'Boundary render',
-      'Boundary componentDidMount',
-    ]);
-  });
-
-  it('correctly handles composite siblings', function() {
-    class ErrorBoundary extends React.Component {
-      constructor() {
-        super();
-        this.state = {error: false};
-      }
-
-      render() {
-        if (!this.state.error) {
-          return <div>{this.props.children}</div>;
-        }
-        return <div>Error has been caught</div>;
-      }
-
-      unstable_handleError() {
-        this.setState({error: true});
-      }
-    }
-
-    function Broken() {
+  class BrokenRender extends React.Component {
+    render() {
       throw new Error('Always broken.');
     }
+  }
 
-    function Composite() {
+  class BrokenUnmount extends React.Component {
+    render() {
       return <div />;
     }
+    componentWillUnmount() {
+      throw new Error('Always broken.');
+    }
+  }
 
-    var container = document.createElement('div');
-    ReactDOM.render(
-      <ErrorBoundary><Broken /><Composite /></ErrorBoundary>,
-      container
-    );
-    ReactDOM.unmountComponentAtNode(container);
-  });
+  var container = document.createElement('div');
+  ReactDOM.render(
+    <ErrorBoundary>
+      <BrokenUnmount />
+      <BrokenRender />
+      <BrokenUnmount />
+    </ErrorBoundary>,
+    container
+  );
+  ReactDOM.unmountComponentAtNode(container);
+});
 
-  it('catches errors from children', function() {
-    var log = [];
+it('expect uneventful render to succeed', function() {
+  var log = [];
+  class Boundary extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {error: false};
+    }
+    render() {
+      log.push('Boundary render');
+      return <div><button onClick={this.onClick}>ClickMe</button></div>;
+    }
+    onClick() {
+      /* do nothing */
+    }
+    componentDidMount() {
+      log.push('Boundary componentDidMount');
+    }
+    componentWillUnmount() {
+      log.push('Boundary componentWillUnmount');
+    }
+    unstable_handleError() {
+      this.setState({error: true});
+    }
+  }
 
-    class Box extends React.Component {
-      constructor(props) {
-        super(props);
-        this.state = {errorMessage: null};
-      }
-      render() {
-        if (this.state.errorMessage != null) {
-          log.push('Box renderError');
-          return <div>Error: {this.state.errorMessage}</div>;
-        }
-        log.push('Box render');
-        var ref = function(x) {
-          log.push('Inquisitive ref ' + x);
-        };
-        return (
-          <div>
-            <Inquisitive ref={ref} />
-            <Angry />
-          </div>
-        );
-      }
-      unstable_handleError(e) {
-        this.setState({errorMessage: e.message});
-      }
-      componentDidMount() {
-        log.push('Box componentDidMount');
-      }
-      componentWillUnmount() {
-        log.push('Box componentWillUnmount');
-      }
+  var container = document.createElement('div');
+  ReactDOM.render(<Boundary />, container);
+  expect(log).toEqual([
+    'Boundary render',
+    'Boundary componentDidMount',
+  ]);
+});
+
+it('correctly handles composite siblings', function() {
+  class ErrorBoundary extends React.Component {
+    constructor() {
+      super();
+      this.state = {error: false};
     }
 
-    class Inquisitive extends React.Component {
-      render() {
-        log.push('Inquisitive render');
-        return <div>What is love?</div>;
+    render() {
+      if (!this.state.error) {
+        return <div>{this.props.children}</div>;
       }
-      componentDidMount() {
-        log.push('Inquisitive componentDidMount');
-      }
-      componentWillUnmount() {
-        log.push('Inquisitive componentWillUnmount');
-      }
+      return <div>Error has been caught</div>;
     }
 
-    class Angry extends React.Component {
-      render() {
-        log.push('Angry render');
-        throw new Error('Please, do not render me.');
-      }
-      componentDidMount() {
-        log.push('Angry componentDidMount');
-      }
-      componentWillUnmount() {
-        log.push('Angry componentWillUnmount');
-      }
+    unstable_handleError() {
+      this.setState({error: true});
     }
+  }
 
-    var container = document.createElement('div');
-    ReactDOM.render(<Box />, container);
-    expect(container.textContent).toBe('Error: Please, do not render me.');
-    ReactDOM.unmountComponentAtNode(container);
-    expect(log).toEqual([
-      'Box render',
-      'Inquisitive render',
-      'Angry render',
-      'Inquisitive ref null',
-      'Inquisitive componentWillUnmount',
-      'Box renderError',
-      'Box componentDidMount',
-      'Box componentWillUnmount',
-    ]);
-  });
+  function Broken() {
+    throw new Error('Always broken.');
+  }
+
+  function Composite() {
+    return <div />;
+  }
+
+  var container = document.createElement('div');
+  ReactDOM.render(
+    <ErrorBoundary><Broken /><Composite /></ErrorBoundary>,
+    container
+  );
+  ReactDOM.unmountComponentAtNode(container);
+});
+
+it('catches errors from children', function() {
+  var log = [];
+
+  class Box extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {errorMessage: null};
+    }
+    render() {
+      if (this.state.errorMessage != null) {
+        log.push('Box renderError');
+        return <div>Error: {this.state.errorMessage}</div>;
+      }
+      log.push('Box render');
+      var ref = function(x) {
+        log.push('Inquisitive ref ' + x);
+      };
+      return (
+        <div>
+          <Inquisitive ref={ref} />
+          <Angry />
+        </div>
+      );
+    }
+    unstable_handleError(e) {
+      this.setState({errorMessage: e.message});
+    }
+    componentDidMount() {
+      log.push('Box componentDidMount');
+    }
+    componentWillUnmount() {
+      log.push('Box componentWillUnmount');
+    }
+  }
+
+  class Inquisitive extends React.Component {
+    render() {
+      log.push('Inquisitive render');
+      return <div>What is love?</div>;
+    }
+    componentDidMount() {
+      log.push('Inquisitive componentDidMount');
+    }
+    componentWillUnmount() {
+      log.push('Inquisitive componentWillUnmount');
+    }
+  }
+
+  class Angry extends React.Component {
+    render() {
+      log.push('Angry render');
+      throw new Error('Please, do not render me.');
+    }
+    componentDidMount() {
+      log.push('Angry componentDidMount');
+    }
+    componentWillUnmount() {
+      log.push('Angry componentWillUnmount');
+    }
+  }
+
+  var container = document.createElement('div');
+  ReactDOM.render(<Box />, container);
+  expect(container.textContent).toBe('Error: Please, do not render me.');
+  ReactDOM.unmountComponentAtNode(container);
+  expect(log).toEqual([
+    'Box render',
+    'Inquisitive render',
+    'Angry render',
+    'Inquisitive ref null',
+    'Inquisitive componentWillUnmount',
+    'Box renderError',
+    'Box componentDidMount',
+    'Box componentWillUnmount',
+  ]);
 });

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactIdentity-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactIdentity-test.js
@@ -16,258 +16,253 @@ var ReactDOM;
 var ReactFragment;
 var ReactTestUtils;
 
-describe('ReactIdentity', function() {
+beforeEach(function() {
+  jest.resetModuleRegistry();
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactFragment = require('ReactFragment');
+  ReactTestUtils = require('ReactTestUtils');
+});
 
-  beforeEach(function() {
-    jest.resetModuleRegistry();
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactFragment = require('ReactFragment');
-    ReactTestUtils = require('ReactTestUtils');
-  });
+function frag(obj) {
+  return ReactFragment.create(obj);
+}
 
-  function frag(obj) {
-    return ReactFragment.create(obj);
+it('should allow key property to express identity', function() {
+  var node;
+  var Component = (props) =>
+    <div ref={(c) => node = c}>
+      <div key={props.swap ? 'banana' : 'apple'} />
+      <div key={props.swap ? 'apple' : 'banana'} />
+    </div>;
+
+  var container = document.createElement('div');
+  ReactDOM.render(<Component />, container);
+  var origChildren = Array.from(node.childNodes);
+  ReactDOM.render(<Component swap={true} />, container);
+  var newChildren = Array.from(node.childNodes);
+  expect(origChildren[0]).toBe(newChildren[1]);
+  expect(origChildren[1]).toBe(newChildren[0]);
+});
+
+it('should use composite identity', function() {
+  class Wrapper extends React.Component {
+    render() {
+      return <a>{this.props.children}</a>;
+    }
   }
 
-  it('should allow key property to express identity', function() {
-    var node;
-    var Component = (props) =>
-      <div ref={(c) => node = c}>
-        <div key={props.swap ? 'banana' : 'apple'} />
-        <div key={props.swap ? 'apple' : 'banana'} />
-      </div>;
+  var container = document.createElement('div');
+  var node1;
+  var node2;
+  ReactDOM.render(
+    <Wrapper key="wrap1"><span ref={(c) => node1 = c} /></Wrapper>,
+    container
+  );
+  ReactDOM.render(
+    <Wrapper key="wrap2"><span ref={(c) => node2 = c} /></Wrapper>,
+    container
+  );
 
-    var container = document.createElement('div');
-    ReactDOM.render(<Component />, container);
-    var origChildren = Array.from(node.childNodes);
-    ReactDOM.render(<Component swap={true} />, container);
-    var newChildren = Array.from(node.childNodes);
-    expect(origChildren[0]).toBe(newChildren[1]);
-    expect(origChildren[1]).toBe(newChildren[0]);
-  });
+  expect(node1).not.toBe(node2);
+});
 
-  it('should use composite identity', function() {
-    class Wrapper extends React.Component {
-      render() {
-        return <a>{this.props.children}</a>;
-      }
+function renderAComponentWithKeyIntoContainer(key, container) {
+  class Wrapper extends React.Component {
+    render() {
+      var s1 = <span ref="span1" key={key} />;
+      var s2 = <span ref="span2" />;
+
+      var map = {};
+      map[key] = s2;
+      return <div>{[s1, frag(map)]}</div>;
     }
-
-    var container = document.createElement('div');
-    var node1;
-    var node2;
-    ReactDOM.render(
-      <Wrapper key="wrap1"><span ref={(c) => node1 = c} /></Wrapper>,
-      container
-    );
-    ReactDOM.render(
-      <Wrapper key="wrap2"><span ref={(c) => node2 = c} /></Wrapper>,
-      container
-    );
-
-    expect(node1).not.toBe(node2);
-  });
-
-  function renderAComponentWithKeyIntoContainer(key, container) {
-    class Wrapper extends React.Component {
-      render() {
-        var s1 = <span ref="span1" key={key} />;
-        var s2 = <span ref="span2" />;
-
-        var map = {};
-        map[key] = s2;
-        return <div>{[s1, frag(map)]}</div>;
-      }
-    }
-
-    var instance = ReactDOM.render(<Wrapper />, container);
-    var span1 = instance.refs.span1;
-    var span2 = instance.refs.span2;
-
-    expect(ReactDOM.findDOMNode(span1)).not.toBe(null);
-    expect(ReactDOM.findDOMNode(span2)).not.toBe(null);
   }
 
-  it('should allow any character as a key, in a detached parent', function() {
-    var detachedContainer = document.createElement('div');
-    renderAComponentWithKeyIntoContainer(
-      "<'WEIRD/&\\key'>",
-      detachedContainer
-    );
-  });
+  var instance = ReactDOM.render(<Wrapper />, container);
+  var span1 = instance.refs.span1;
+  var span2 = instance.refs.span2;
 
-  it('should allow any character as a key, in an attached parent', function() {
-    // This test exists to protect against implementation details that
-    // incorrectly query escaped IDs using DOM tools like getElementById.
-    var attachedContainer = document.createElement('div');
-    document.body.appendChild(attachedContainer);
+  expect(ReactDOM.findDOMNode(span1)).not.toBe(null);
+  expect(ReactDOM.findDOMNode(span2)).not.toBe(null);
+}
 
-    renderAComponentWithKeyIntoContainer(
-      "<'WEIRD/&\\key'>",
-      attachedContainer
-    );
+it('should allow any character as a key, in a detached parent', function() {
+  var detachedContainer = document.createElement('div');
+  renderAComponentWithKeyIntoContainer(
+    "<'WEIRD/&\\key'>",
+    detachedContainer
+  );
+});
 
-    document.body.removeChild(attachedContainer);
-  });
+it('should allow any character as a key, in an attached parent', function() {
+  // This test exists to protect against implementation details that
+  // incorrectly query escaped IDs using DOM tools like getElementById.
+  var attachedContainer = document.createElement('div');
+  document.body.appendChild(attachedContainer);
 
-  it('should not allow scripts in keys to execute', function() {
-    var h4x0rKey =
-      '"><script>window[\'YOUVEBEENH4X0RED\']=true;</script><div id="';
+  renderAComponentWithKeyIntoContainer(
+    "<'WEIRD/&\\key'>",
+    attachedContainer
+  );
 
-    var attachedContainer = document.createElement('div');
-    document.body.appendChild(attachedContainer);
+  document.body.removeChild(attachedContainer);
+});
 
-    renderAComponentWithKeyIntoContainer(h4x0rKey, attachedContainer);
+it('should not allow scripts in keys to execute', function() {
+  var h4x0rKey =
+    '"><script>window[\'YOUVEBEENH4X0RED\']=true;</script><div id="';
 
-    document.body.removeChild(attachedContainer);
+  var attachedContainer = document.createElement('div');
+  document.body.appendChild(attachedContainer);
 
-    // If we get this far, make sure we haven't executed the code
-    expect(window.YOUVEBEENH4X0RED).toBe(undefined);
-  });
+  renderAComponentWithKeyIntoContainer(h4x0rKey, attachedContainer);
 
-  it('should let restructured components retain their uniqueness', function() {
-    var instance0 = <span />;
-    var instance1 = <span />;
-    var instance2 = <span />;
+  document.body.removeChild(attachedContainer);
 
-    class TestComponent extends React.Component {
-      render() {
-        return (
-          <div>
-            {instance2}
-            {this.props.children[0]}
-            {this.props.children[1]}
-          </div>
-        );
-      }
+  // If we get this far, make sure we haven't executed the code
+  expect(window.YOUVEBEENH4X0RED).toBe(undefined);
+});
+
+it('should let restructured components retain their uniqueness', function() {
+  var instance0 = <span />;
+  var instance1 = <span />;
+  var instance2 = <span />;
+
+  class TestComponent extends React.Component {
+    render() {
+      return (
+        <div>
+          {instance2}
+          {this.props.children[0]}
+          {this.props.children[1]}
+        </div>
+      );
     }
+  }
 
-    class TestContainer extends React.Component {
-      render() {
-        return <TestComponent>{instance0}{instance1}</TestComponent>;
-      }
+  class TestContainer extends React.Component {
+    render() {
+      return <TestComponent>{instance0}{instance1}</TestComponent>;
     }
+  }
 
-    expect(function() {
+  expect(function() {
 
-      ReactTestUtils.renderIntoDocument(<TestContainer />);
+    ReactTestUtils.renderIntoDocument(<TestContainer />);
 
-    }).not.toThrow();
-  });
+  }).not.toThrow();
+});
 
-  it('should let nested restructures retain their uniqueness', function() {
-    var instance0 = <span />;
-    var instance1 = <span />;
-    var instance2 = <span />;
+it('should let nested restructures retain their uniqueness', function() {
+  var instance0 = <span />;
+  var instance1 = <span />;
+  var instance2 = <span />;
 
-    class TestComponent extends React.Component {
-      render() {
-        return (
-          <div>
-            {instance2}
-            {this.props.children[0]}
-            {this.props.children[1]}
-          </div>
-        );
-      }
+  class TestComponent extends React.Component {
+    render() {
+      return (
+        <div>
+          {instance2}
+          {this.props.children[0]}
+          {this.props.children[1]}
+        </div>
+      );
     }
+  }
 
-    class TestContainer extends React.Component {
-      render() {
-        return (
-          <div>
-            <TestComponent>{instance0}{instance1}</TestComponent>
-          </div>
-        );
-      }
+  class TestContainer extends React.Component {
+    render() {
+      return (
+        <div>
+          <TestComponent>{instance0}{instance1}</TestComponent>
+        </div>
+      );
     }
+  }
 
-    expect(function() {
+  expect(function() {
 
-      ReactTestUtils.renderIntoDocument(<TestContainer />);
+    ReactTestUtils.renderIntoDocument(<TestContainer />);
 
-    }).not.toThrow();
-  });
+  }).not.toThrow();
+});
 
-  it('should let text nodes retain their uniqueness', function() {
-    class TestComponent extends React.Component {
-      render() {
-        return <div>{this.props.children}<span /></div>;
-      }
+it('should let text nodes retain their uniqueness', function() {
+  class TestComponent extends React.Component {
+    render() {
+      return <div>{this.props.children}<span /></div>;
     }
+  }
 
-    class TestContainer extends React.Component {
-      render() {
-        return (
-          <TestComponent>
-            <div />
-            {'second'}
-          </TestComponent>
-        );
-      }
+  class TestContainer extends React.Component {
+    render() {
+      return (
+        <TestComponent>
+          <div />
+          {'second'}
+        </TestComponent>
+      );
     }
+  }
 
-    expect(function() {
+  expect(function() {
 
-      ReactTestUtils.renderIntoDocument(<TestContainer />);
+    ReactTestUtils.renderIntoDocument(<TestContainer />);
 
-    }).not.toThrow();
-  });
+  }).not.toThrow();
+});
 
-  it('should retain key during updates in composite components', function() {
-    class TestComponent extends React.Component {
-      render() {
-        return <div>{this.props.children}</div>;
-      }
+it('should retain key during updates in composite components', function() {
+  class TestComponent extends React.Component {
+    render() {
+      return <div>{this.props.children}</div>;
     }
+  }
 
-    class TestContainer extends React.Component {
-      state = {swapped: false};
+  class TestContainer extends React.Component {
+    state = {swapped: false};
 
-      swap = () => {
-        this.setState({swapped: true});
-      };
+    swap = () => {
+      this.setState({swapped: true});
+    };
 
-      render() {
-        return (
-          <TestComponent>
-            {this.state.swapped ? this.props.second : this.props.first}
-            {this.state.swapped ? this.props.first : this.props.second}
-          </TestComponent>
-        );
-      }
+    render() {
+      return (
+        <TestComponent>
+          {this.state.swapped ? this.props.second : this.props.first}
+          {this.state.swapped ? this.props.first : this.props.second}
+        </TestComponent>
+      );
     }
+  }
 
-    var instance0 = <span key="A" />;
-    var instance1 = <span key="B" />;
+  var instance0 = <span key="A" />;
+  var instance1 = <span key="B" />;
 
-    var wrapped = <TestContainer first={instance0} second={instance1} />;
+  var wrapped = <TestContainer first={instance0} second={instance1} />;
 
-    wrapped = ReactDOM.render(wrapped, document.createElement('div'));
-    var div = ReactDOM.findDOMNode(wrapped);
+  wrapped = ReactDOM.render(wrapped, document.createElement('div'));
+  var div = ReactDOM.findDOMNode(wrapped);
 
-    var beforeA = div.childNodes[0];
-    var beforeB = div.childNodes[1];
-    wrapped.swap();
-    var afterA = div.childNodes[1];
-    var afterB = div.childNodes[0];
+  var beforeA = div.childNodes[0];
+  var beforeB = div.childNodes[1];
+  wrapped.swap();
+  var afterA = div.childNodes[1];
+  var afterB = div.childNodes[0];
 
-    expect(beforeA).toBe(afterA);
-    expect(beforeB).toBe(afterB);
-  });
+  expect(beforeA).toBe(afterA);
+  expect(beforeB).toBe(afterB);
+});
 
-  it('should not allow implicit and explicit keys to collide', function() {
-    var component =
-      <div>
-        <span />
-        <span key="0" />
-      </div>;
+it('should not allow implicit and explicit keys to collide', function() {
+  var component =
+    <div>
+      <span />
+      <span key="0" />
+    </div>;
 
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(component);
-    }).not.toThrow();
-  });
-
-
+  expect(function() {
+    ReactTestUtils.renderIntoDocument(component);
+  }).not.toThrow();
 });

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactMockedComponent-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactMockedComponent-test.js
@@ -17,84 +17,80 @@ var ReactTestUtils;
 var AutoMockedComponent;
 var MockedComponent;
 
-describe('ReactMockedComponent', function() {
+beforeEach(function() {
+  React = require('React');
+  ReactTestUtils = require('ReactTestUtils');
 
-  beforeEach(function() {
-    React = require('React');
-    ReactTestUtils = require('ReactTestUtils');
+  AutoMockedComponent = jest.genMockFromModule('ReactMockedComponentTestComponent');
+  MockedComponent = jest.genMockFromModule('ReactMockedComponentTestComponent');
 
-    AutoMockedComponent = jest.genMockFromModule('ReactMockedComponentTestComponent');
-    MockedComponent = jest.genMockFromModule('ReactMockedComponentTestComponent');
+  ReactTestUtils.mockComponent(MockedComponent);
+});
 
-    ReactTestUtils.mockComponent(MockedComponent);
-  });
+it('should allow an implicitly mocked component to be rendered without warnings', () => {
+  spyOn(console, 'error');
+  ReactTestUtils.renderIntoDocument(<AutoMockedComponent />);
+  expect(console.error.calls.count()).toBe(0);
+});
 
-  it('should allow an implicitly mocked component to be rendered without warnings', () => {
-    spyOn(console, 'error');
-    ReactTestUtils.renderIntoDocument(<AutoMockedComponent />);
-    expect(console.error.calls.count()).toBe(0);
-  });
+it('should allow an implicitly mocked component to be updated', () => {
+  class Wrapper extends React.Component {
+    state = {foo: 1};
 
-  it('should allow an implicitly mocked component to be updated', () => {
-    class Wrapper extends React.Component {
-      state = {foo: 1};
+    update = () => {
+      this.setState({foo: 2});
+    };
 
-      update = () => {
-        this.setState({foo: 2});
-      };
-
-      render() {
-        return <div><AutoMockedComponent prop={this.state.foo} /></div>;
-      }
+    render() {
+      return <div><AutoMockedComponent prop={this.state.foo} /></div>;
     }
+  }
 
-    var instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
+  var instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
 
-    var found = ReactTestUtils.findRenderedComponentWithType(
-      instance,
-      AutoMockedComponent
-    );
-    expect(typeof found).toBe('object');
+  var found = ReactTestUtils.findRenderedComponentWithType(
+    instance,
+    AutoMockedComponent
+  );
+  expect(typeof found).toBe('object');
 
-    instance.update();
-  });
+  instance.update();
+});
 
-  it('has custom methods on the implicitly mocked component', () => {
-    var instance = ReactTestUtils.renderIntoDocument(<AutoMockedComponent />);
-    expect(typeof instance.hasCustomMethod).toBe('function');
-  });
+it('has custom methods on the implicitly mocked component', () => {
+  var instance = ReactTestUtils.renderIntoDocument(<AutoMockedComponent />);
+  expect(typeof instance.hasCustomMethod).toBe('function');
+});
 
-  it('should allow an explicitly mocked component to be rendered', () => {
-    ReactTestUtils.renderIntoDocument(<MockedComponent />);
-  });
+it('should allow an explicitly mocked component to be rendered', () => {
+  ReactTestUtils.renderIntoDocument(<MockedComponent />);
+});
 
-  it('should allow an explicitly mocked component to be updated', () => {
-    class Wrapper extends React.Component {
-      state = {foo: 1};
+it('should allow an explicitly mocked component to be updated', () => {
+  class Wrapper extends React.Component {
+    state = {foo: 1};
 
-      update = () => {
-        this.setState({foo: 2});
-      };
+    update = () => {
+      this.setState({foo: 2});
+    };
 
-      render() {
-        return <div><MockedComponent prop={this.state.foo} /></div>;
-      }
+    render() {
+      return <div><MockedComponent prop={this.state.foo} /></div>;
     }
+  }
 
-    var instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
+  var instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
 
-    var found = ReactTestUtils.findRenderedComponentWithType(
-      instance,
-      MockedComponent
-    );
-    expect(typeof found).toBe('object');
+  var found = ReactTestUtils.findRenderedComponentWithType(
+    instance,
+    MockedComponent
+  );
+  expect(typeof found).toBe('object');
 
-    instance.update();
-  });
+  instance.update();
+});
 
-  it('has custom methods on the explicitly mocked component', () => {
-    var instance = ReactTestUtils.renderIntoDocument(<MockedComponent />);
-    expect(typeof instance.hasCustomMethod).toBe('function');
-  });
-
+it('has custom methods on the explicitly mocked component', () => {
+  var instance = ReactTestUtils.renderIntoDocument(<MockedComponent />);
+  expect(typeof instance.hasCustomMethod).toBe('function');
 });

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactMultiChild-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactMultiChild-test.js
@@ -11,191 +11,189 @@
 
 'use strict';
 
-describe('ReactMultiChild', function() {
-  function normalizeCodeLocInfo(str) {
-    return str.replace(/\(at .+?:\d+\)/g, '(at **)');
-  }
+function normalizeCodeLocInfo(str) {
+  return str.replace(/\(at .+?:\d+\)/g, '(at **)');
+}
 
-  var React;
-  var ReactDOM;
+var React;
+var ReactDOM;
 
-  beforeEach(function() {
-    jest.resetModuleRegistry();
-    React = require('React');
-    ReactDOM = require('ReactDOM');
+beforeEach(function() {
+  jest.resetModuleRegistry();
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+});
+
+describe('reconciliation', function() {
+  it('should update children when possible', function() {
+    var container = document.createElement('div');
+
+    var mockMount = jest.fn();
+    var mockUpdate = jest.fn();
+    var mockUnmount = jest.fn();
+
+    var MockComponent = React.createClass({
+      componentDidMount: mockMount,
+      componentDidUpdate: mockUpdate,
+      componentWillUnmount: mockUnmount,
+      render: function() {
+        return <span />;
+      },
+    });
+
+    expect(mockMount.mock.calls.length).toBe(0);
+    expect(mockUpdate.mock.calls.length).toBe(0);
+    expect(mockUnmount.mock.calls.length).toBe(0);
+
+    ReactDOM.render(<div><MockComponent /></div>, container);
+
+    expect(mockMount.mock.calls.length).toBe(1);
+    expect(mockUpdate.mock.calls.length).toBe(0);
+    expect(mockUnmount.mock.calls.length).toBe(0);
+
+    ReactDOM.render(<div><MockComponent /></div>, container);
+
+    expect(mockMount.mock.calls.length).toBe(1);
+    expect(mockUpdate.mock.calls.length).toBe(1);
+    expect(mockUnmount.mock.calls.length).toBe(0);
   });
 
-  describe('reconciliation', function() {
-    it('should update children when possible', function() {
-      var container = document.createElement('div');
+  it('should replace children with different constructors', function() {
+    var container = document.createElement('div');
 
-      var mockMount = jest.fn();
-      var mockUpdate = jest.fn();
-      var mockUnmount = jest.fn();
+    var mockMount = jest.fn();
+    var mockUnmount = jest.fn();
 
-      var MockComponent = React.createClass({
-        componentDidMount: mockMount,
-        componentDidUpdate: mockUpdate,
-        componentWillUnmount: mockUnmount,
-        render: function() {
-          return <span />;
-        },
-      });
-
-      expect(mockMount.mock.calls.length).toBe(0);
-      expect(mockUpdate.mock.calls.length).toBe(0);
-      expect(mockUnmount.mock.calls.length).toBe(0);
-
-      ReactDOM.render(<div><MockComponent /></div>, container);
-
-      expect(mockMount.mock.calls.length).toBe(1);
-      expect(mockUpdate.mock.calls.length).toBe(0);
-      expect(mockUnmount.mock.calls.length).toBe(0);
-
-      ReactDOM.render(<div><MockComponent /></div>, container);
-
-      expect(mockMount.mock.calls.length).toBe(1);
-      expect(mockUpdate.mock.calls.length).toBe(1);
-      expect(mockUnmount.mock.calls.length).toBe(0);
+    var MockComponent = React.createClass({
+      componentDidMount: mockMount,
+      componentWillUnmount: mockUnmount,
+      render: function() {
+        return <span />;
+      },
     });
 
-    it('should replace children with different constructors', function() {
-      var container = document.createElement('div');
+    expect(mockMount.mock.calls.length).toBe(0);
+    expect(mockUnmount.mock.calls.length).toBe(0);
 
-      var mockMount = jest.fn();
-      var mockUnmount = jest.fn();
+    ReactDOM.render(<div><MockComponent /></div>, container);
 
-      var MockComponent = React.createClass({
-        componentDidMount: mockMount,
-        componentWillUnmount: mockUnmount,
-        render: function() {
-          return <span />;
-        },
-      });
+    expect(mockMount.mock.calls.length).toBe(1);
+    expect(mockUnmount.mock.calls.length).toBe(0);
 
-      expect(mockMount.mock.calls.length).toBe(0);
-      expect(mockUnmount.mock.calls.length).toBe(0);
+    ReactDOM.render(<div><span /></div>, container);
 
-      ReactDOM.render(<div><MockComponent /></div>, container);
+    expect(mockMount.mock.calls.length).toBe(1);
+    expect(mockUnmount.mock.calls.length).toBe(1);
+  });
 
-      expect(mockMount.mock.calls.length).toBe(1);
-      expect(mockUnmount.mock.calls.length).toBe(0);
+  it('should NOT replace children with different owners', function() {
+    var container = document.createElement('div');
 
-      ReactDOM.render(<div><span /></div>, container);
+    var mockMount = jest.fn();
+    var mockUnmount = jest.fn();
 
-      expect(mockMount.mock.calls.length).toBe(1);
-      expect(mockUnmount.mock.calls.length).toBe(1);
+    var MockComponent = React.createClass({
+      componentDidMount: mockMount,
+      componentWillUnmount: mockUnmount,
+      render: function() {
+        return <span />;
+      },
     });
 
-    it('should NOT replace children with different owners', function() {
-      var container = document.createElement('div');
-
-      var mockMount = jest.fn();
-      var mockUnmount = jest.fn();
-
-      var MockComponent = React.createClass({
-        componentDidMount: mockMount,
-        componentWillUnmount: mockUnmount,
-        render: function() {
-          return <span />;
-        },
-      });
-
-      class WrapperComponent extends React.Component {
-        render() {
-          return this.props.children || <MockComponent />;
-        }
+    class WrapperComponent extends React.Component {
+      render() {
+        return this.props.children || <MockComponent />;
       }
+    }
 
-      expect(mockMount.mock.calls.length).toBe(0);
-      expect(mockUnmount.mock.calls.length).toBe(0);
+    expect(mockMount.mock.calls.length).toBe(0);
+    expect(mockUnmount.mock.calls.length).toBe(0);
 
-      ReactDOM.render(<WrapperComponent />, container);
+    ReactDOM.render(<WrapperComponent />, container);
 
-      expect(mockMount.mock.calls.length).toBe(1);
-      expect(mockUnmount.mock.calls.length).toBe(0);
+    expect(mockMount.mock.calls.length).toBe(1);
+    expect(mockUnmount.mock.calls.length).toBe(0);
 
-      ReactDOM.render(
-        <WrapperComponent><MockComponent /></WrapperComponent>,
-        container
-      );
+    ReactDOM.render(
+      <WrapperComponent><MockComponent /></WrapperComponent>,
+      container
+    );
 
-      expect(mockMount.mock.calls.length).toBe(1);
-      expect(mockUnmount.mock.calls.length).toBe(0);
+    expect(mockMount.mock.calls.length).toBe(1);
+    expect(mockUnmount.mock.calls.length).toBe(0);
+  });
+
+  it('should replace children with different keys', function() {
+    var container = document.createElement('div');
+
+    var mockMount = jest.fn();
+    var mockUnmount = jest.fn();
+
+    var MockComponent = React.createClass({
+      componentDidMount: mockMount,
+      componentWillUnmount: mockUnmount,
+      render: function() {
+        return <span />;
+      },
     });
 
-    it('should replace children with different keys', function() {
-      var container = document.createElement('div');
+    expect(mockMount.mock.calls.length).toBe(0);
+    expect(mockUnmount.mock.calls.length).toBe(0);
 
-      var mockMount = jest.fn();
-      var mockUnmount = jest.fn();
+    ReactDOM.render(<div><MockComponent key="A" /></div>, container);
 
-      var MockComponent = React.createClass({
-        componentDidMount: mockMount,
-        componentWillUnmount: mockUnmount,
-        render: function() {
-          return <span />;
-        },
-      });
+    expect(mockMount.mock.calls.length).toBe(1);
+    expect(mockUnmount.mock.calls.length).toBe(0);
 
-      expect(mockMount.mock.calls.length).toBe(0);
-      expect(mockUnmount.mock.calls.length).toBe(0);
+    ReactDOM.render(<div><MockComponent key="B" /></div>, container);
 
-      ReactDOM.render(<div><MockComponent key="A" /></div>, container);
+    expect(mockMount.mock.calls.length).toBe(2);
+    expect(mockUnmount.mock.calls.length).toBe(1);
+  });
 
-      expect(mockMount.mock.calls.length).toBe(1);
-      expect(mockUnmount.mock.calls.length).toBe(0);
+  it('should warn for duplicated keys with component stack info', function() {
+    spyOn(console, 'error');
 
-      ReactDOM.render(<div><MockComponent key="B" /></div>, container);
+    var container = document.createElement('div');
 
-      expect(mockMount.mock.calls.length).toBe(2);
-      expect(mockUnmount.mock.calls.length).toBe(1);
-    });
-
-    it('should warn for duplicated keys with component stack info', function() {
-      spyOn(console, 'error');
-
-      var container = document.createElement('div');
-
-      class WrapperComponent extends React.Component {
-        render() {
-          return <div>{this.props.children}</div>;
-        }
+    class WrapperComponent extends React.Component {
+      render() {
+        return <div>{this.props.children}</div>;
       }
+    }
 
-      class Parent extends React.Component {
-        render() {
-          return (
-            <div>
-              <WrapperComponent>
-                {this.props.children}
-              </WrapperComponent>
-            </div>
-          );
-        }
+    class Parent extends React.Component {
+      render() {
+        return (
+          <div>
+            <WrapperComponent>
+              {this.props.children}
+            </WrapperComponent>
+          </div>
+        );
       }
+    }
 
-      ReactDOM.render(
-        <Parent>{[<div key="1"/>]}</Parent>,
-        container
-      );
+    ReactDOM.render(
+      <Parent>{[<div key="1"/>]}</Parent>,
+      container
+    );
 
-      ReactDOM.render(
-        <Parent>{[<div key="1"/>, <div key="1"/>]}</Parent>,
-        container
-      );
+    ReactDOM.render(
+      <Parent>{[<div key="1"/>, <div key="1"/>]}</Parent>,
+      container
+    );
 
-      expect(console.error.calls.count()).toBe(1);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: flattenChildren(...): ' +
-        'Encountered two children with the same key, `1`. ' +
-        'Child keys must be unique; when two children share a key, ' +
-        'only the first child will be used.\n' +
-        '    in div (at **)\n' +
-        '    in WrapperComponent (at **)\n' +
-        '    in div (at **)\n' +
-        '    in Parent (at **)'
-      );
-    });
+    expect(console.error.calls.count()).toBe(1);
+    expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+      'Warning: flattenChildren(...): ' +
+      'Encountered two children with the same key, `1`. ' +
+      'Child keys must be unique; when two children share a key, ' +
+      'only the first child will be used.\n' +
+      '    in div (at **)\n' +
+      '    in WrapperComponent (at **)\n' +
+      '    in div (at **)\n' +
+      '    in Parent (at **)'
+    );
   });
 });

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactMultiChildReconcile-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactMultiChildReconcile-test.js
@@ -275,550 +275,548 @@ function testPropsSequence(sequence) {
   }
 }
 
-describe('ReactMultiChildReconcile', function() {
-  beforeEach(function() {
-    jest.resetModuleRegistry();
-  });
+beforeEach(function() {
+  jest.resetModuleRegistry();
+});
 
-  it('should reset internal state if removed then readded', function() {
-    // Test basics.
-    var props = {
+it('should reset internal state if removed then readded', function() {
+  // Test basics.
+  var props = {
+    usernameToStatus: {
+      jcw: 'jcwStatus',
+    },
+  };
+
+  var container = document.createElement('div');
+  var parentInstance = ReactDOM.render(
+    <FriendsStatusDisplay {...props} />,
+    container
+  );
+  var statusDisplays = parentInstance.getStatusDisplays();
+  var startingInternalState = statusDisplays.jcw.getInternalState();
+
+  // Now remove the child.
+  ReactDOM.render(
+    <FriendsStatusDisplay />,
+    container
+  );
+  statusDisplays = parentInstance.getStatusDisplays();
+  expect(statusDisplays.jcw).toBeFalsy();
+
+  // Now reset the props that cause there to be a child
+  ReactDOM.render(
+    <FriendsStatusDisplay {...props} />,
+    container
+  );
+  statusDisplays = parentInstance.getStatusDisplays();
+  expect(statusDisplays.jcw).toBeTruthy();
+  expect(statusDisplays.jcw.getInternalState())
+      .not.toBe(startingInternalState);
+});
+
+it('should create unique identity', function() {
+  // Test basics.
+  var usernameToStatus = {
+    jcw: 'jcwStatus',
+    awalke: 'awalkeStatus',
+    bob: 'bobStatus',
+  };
+
+  testPropsSequence([{usernameToStatus: usernameToStatus}]);
+});
+
+it('should preserve order if children order has not changed', function() {
+  var PROPS_SEQUENCE = [
+    {
       usernameToStatus: {
         jcw: 'jcwStatus',
+        jordanjcw: 'jordanjcwStatus',
       },
-    };
-
-    var container = document.createElement('div');
-    var parentInstance = ReactDOM.render(
-      <FriendsStatusDisplay {...props} />,
-      container
-    );
-    var statusDisplays = parentInstance.getStatusDisplays();
-    var startingInternalState = statusDisplays.jcw.getInternalState();
-
-    // Now remove the child.
-    ReactDOM.render(
-      <FriendsStatusDisplay />,
-      container
-    );
-    statusDisplays = parentInstance.getStatusDisplays();
-    expect(statusDisplays.jcw).toBeFalsy();
-
-    // Now reset the props that cause there to be a child
-    ReactDOM.render(
-      <FriendsStatusDisplay {...props} />,
-      container
-    );
-    statusDisplays = parentInstance.getStatusDisplays();
-    expect(statusDisplays.jcw).toBeTruthy();
-    expect(statusDisplays.jcw.getInternalState())
-        .not.toBe(startingInternalState);
-  });
-
-  it('should create unique identity', function() {
-    // Test basics.
-    var usernameToStatus = {
-      jcw: 'jcwStatus',
-      awalke: 'awalkeStatus',
-      bob: 'bobStatus',
-    };
-
-    testPropsSequence([{usernameToStatus: usernameToStatus}]);
-  });
-
-  it('should preserve order if children order has not changed', function() {
-    var PROPS_SEQUENCE = [
-      {
-        usernameToStatus: {
-          jcw: 'jcwStatus',
-          jordanjcw: 'jordanjcwStatus',
-        },
+    },
+    {
+      usernameToStatus: {
+        jcw: 'jcwstatus2',
+        jordanjcw: 'jordanjcwstatus2',
       },
-      {
-        usernameToStatus: {
-          jcw: 'jcwstatus2',
-          jordanjcw: 'jordanjcwstatus2',
-        },
-      },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
+});
 
-  it('should transition from zero to one children correctly', function() {
-    var PROPS_SEQUENCE = [
-      {usernameToStatus: {} },
-      {
-        usernameToStatus: {
-          first: 'firstStatus',
-        },
+it('should transition from zero to one children correctly', function() {
+  var PROPS_SEQUENCE = [
+    {usernameToStatus: {} },
+    {
+      usernameToStatus: {
+        first: 'firstStatus',
       },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
+});
 
-  it('should transition from one to zero children correctly', function() {
-    var PROPS_SEQUENCE = [
-      {
-        usernameToStatus: {
-          first: 'firstStatus',
-        },
+it('should transition from one to zero children correctly', function() {
+  var PROPS_SEQUENCE = [
+    {
+      usernameToStatus: {
+        first: 'firstStatus',
       },
-      {usernameToStatus: {} },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+    {usernameToStatus: {} },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
+});
 
-  it('should transition from one child to null children', function() {
-    testPropsSequence([
-      {
-        usernameToStatus: {
-          first: 'firstStatus',
-        },
+it('should transition from one child to null children', function() {
+  testPropsSequence([
+    {
+      usernameToStatus: {
+        first: 'firstStatus',
       },
-      {},
-    ]);
-  });
+    },
+    {},
+  ]);
+});
 
-  it('should transition from null children to one child', function() {
-    testPropsSequence([
-      {},
-      {
-        usernameToStatus: {
-          first: 'firstStatus',
-        },
+it('should transition from null children to one child', function() {
+  testPropsSequence([
+    {},
+    {
+      usernameToStatus: {
+        first: 'firstStatus',
       },
-    ]);
-  });
+    },
+  ]);
+});
 
-  it('should transition from zero children to null children', function() {
-    testPropsSequence([
-      {
-        usernameToStatus: {},
-      },
-      {},
-    ]);
-  });
+it('should transition from zero children to null children', function() {
+  testPropsSequence([
+    {
+      usernameToStatus: {},
+    },
+    {},
+  ]);
+});
 
-  it('should transition from null children to zero children', function() {
-    testPropsSequence([
-      {},
-      {
-        usernameToStatus: {},
-      },
-    ]);
-  });
+it('should transition from null children to zero children', function() {
+  testPropsSequence([
+    {},
+    {
+      usernameToStatus: {},
+    },
+  ]);
+});
 
 
 
-  /**
-   * `FriendsStatusDisplay` renders nulls as empty children (it's a convention
-   * of `FriendsStatusDisplay`, nothing related to React or these test cases.
-   */
-  it('should remove nulled out children at the beginning', function() {
-    var PROPS_SEQUENCE = [
-      {
-        usernameToStatus: {
-          jcw: 'jcwStatus',
-          jordanjcw: 'jordanjcwStatus',
-        },
+/**
+ * `FriendsStatusDisplay` renders nulls as empty children (it's a convention
+ * of `FriendsStatusDisplay`, nothing related to React or these test cases.
+ */
+it('should remove nulled out children at the beginning', function() {
+  var PROPS_SEQUENCE = [
+    {
+      usernameToStatus: {
+        jcw: 'jcwStatus',
+        jordanjcw: 'jordanjcwStatus',
       },
-      {
-        usernameToStatus: {
-          jcw: null,
-          jordanjcw: 'jordanjcwstatus2',
-        },
+    },
+    {
+      usernameToStatus: {
+        jcw: null,
+        jordanjcw: 'jordanjcwstatus2',
       },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
+});
 
-  it('should remove nulled out children at the end', function() {
-    var PROPS_SEQUENCE = [
-      {
-        usernameToStatus: {
-          jcw: 'jcwStatus',
-          jordanjcw: 'jordanjcwStatus',
-        },
+it('should remove nulled out children at the end', function() {
+  var PROPS_SEQUENCE = [
+    {
+      usernameToStatus: {
+        jcw: 'jcwStatus',
+        jordanjcw: 'jordanjcwStatus',
       },
-      {
-        usernameToStatus: {
-          jcw: 'jcwstatus2',
-          jordanjcw: null,
-        },
+    },
+    {
+      usernameToStatus: {
+        jcw: 'jcwstatus2',
+        jordanjcw: null,
       },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
+});
 
-  it('should reverse the order of two children', function() {
-    var PROPS_SEQUENCE = [
-      {
-        usernameToStatus: {
-          userOne: 'userOneStatus',
-          userTwo: 'userTwoStatus',
-        },
+it('should reverse the order of two children', function() {
+  var PROPS_SEQUENCE = [
+    {
+      usernameToStatus: {
+        userOne: 'userOneStatus',
+        userTwo: 'userTwoStatus',
       },
-      {
-        usernameToStatus: {
-          userTwo: 'userTwoStatus',
-          userOne: 'userOneStatus',
-        },
+    },
+    {
+      usernameToStatus: {
+        userTwo: 'userTwoStatus',
+        userOne: 'userOneStatus',
       },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
+});
 
-  it('should reverse the order of more than two children', function() {
-    var PROPS_SEQUENCE = [
-      {
-        usernameToStatus: {
-          userOne: 'userOneStatus',
-          userTwo: 'userTwoStatus',
-          userThree: 'userThreeStatus',
-        },
+it('should reverse the order of more than two children', function() {
+  var PROPS_SEQUENCE = [
+    {
+      usernameToStatus: {
+        userOne: 'userOneStatus',
+        userTwo: 'userTwoStatus',
+        userThree: 'userThreeStatus',
       },
-      {
-        usernameToStatus: {
-          userThree: 'userThreeStatus',
-          userTwo: 'userTwoStatus',
-          userOne: 'userOneStatus',
-        },
+    },
+    {
+      usernameToStatus: {
+        userThree: 'userThreeStatus',
+        userTwo: 'userTwoStatus',
+        userOne: 'userOneStatus',
       },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
+});
 
-  it('should cycle order correctly', function() {
-    var PROPS_SEQUENCE = [
-      {
-        usernameToStatus: {
-          userOne: 'userOneStatus',
-          userTwo: 'userTwoStatus',
-          userThree: 'userThreeStatus',
-          userFour: 'userFourStatus',
-        },
+it('should cycle order correctly', function() {
+  var PROPS_SEQUENCE = [
+    {
+      usernameToStatus: {
+        userOne: 'userOneStatus',
+        userTwo: 'userTwoStatus',
+        userThree: 'userThreeStatus',
+        userFour: 'userFourStatus',
       },
-      {
-        usernameToStatus: {
-          userTwo: 'userTwoStatus',
-          userThree: 'userThreeStatus',
-          userFour: 'userFourStatus',
-          userOne: 'userOneStatus',
-        },
+    },
+    {
+      usernameToStatus: {
+        userTwo: 'userTwoStatus',
+        userThree: 'userThreeStatus',
+        userFour: 'userFourStatus',
+        userOne: 'userOneStatus',
       },
-      {
-        usernameToStatus: {
-          userThree: 'userThreeStatus',
-          userFour: 'userFourStatus',
-          userOne: 'userOneStatus',
-          userTwo: 'userTwoStatus',
-        },
+    },
+    {
+      usernameToStatus: {
+        userThree: 'userThreeStatus',
+        userFour: 'userFourStatus',
+        userOne: 'userOneStatus',
+        userTwo: 'userTwoStatus',
       },
-      {
-        usernameToStatus: {
-          userFour: 'userFourStatus',
-          userOne: 'userOneStatus',
-          userTwo: 'userTwoStatus',
-          userThree: 'userThreeStatus',
-        },
+    },
+    {
+      usernameToStatus: {
+        userFour: 'userFourStatus',
+        userOne: 'userOneStatus',
+        userTwo: 'userTwoStatus',
+        userThree: 'userThreeStatus',
       },
-      {
-        usernameToStatus: {               // Full circle!
-          userOne: 'userOneStatus',
-          userTwo: 'userTwoStatus',
-          userThree: 'userThreeStatus',
-          userFour: 'userFourStatus',
-        },
+    },
+    {
+      usernameToStatus: {               // Full circle!
+        userOne: 'userOneStatus',
+        userTwo: 'userTwoStatus',
+        userThree: 'userThreeStatus',
+        userFour: 'userFourStatus',
       },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
+});
 
-  it('should cycle order correctly in the other direction', function() {
-    var PROPS_SEQUENCE = [
-      {
-        usernameToStatus: {
-          userOne: 'userOneStatus',
-          userTwo: 'userTwoStatus',
-          userThree: 'userThreeStatus',
-          userFour: 'userFourStatus',
-        },
+it('should cycle order correctly in the other direction', function() {
+  var PROPS_SEQUENCE = [
+    {
+      usernameToStatus: {
+        userOne: 'userOneStatus',
+        userTwo: 'userTwoStatus',
+        userThree: 'userThreeStatus',
+        userFour: 'userFourStatus',
       },
-      {
-        usernameToStatus: {
-          userFour: 'userFourStatus',
-          userOne: 'userOneStatus',
-          userTwo: 'userTwoStatus',
-          userThree: 'userThreeStatus',
-        },
+    },
+    {
+      usernameToStatus: {
+        userFour: 'userFourStatus',
+        userOne: 'userOneStatus',
+        userTwo: 'userTwoStatus',
+        userThree: 'userThreeStatus',
       },
-      {
-        usernameToStatus: {
-          userThree: 'userThreeStatus',
-          userFour: 'userFourStatus',
-          userOne: 'userOneStatus',
-          userTwo: 'userTwoStatus',
-        },
+    },
+    {
+      usernameToStatus: {
+        userThree: 'userThreeStatus',
+        userFour: 'userFourStatus',
+        userOne: 'userOneStatus',
+        userTwo: 'userTwoStatus',
       },
-      {
-        usernameToStatus: {
-          userTwo: 'userTwoStatus',
-          userThree: 'userThreeStatus',
-          userFour: 'userFourStatus',
-          userOne: 'userOneStatus',
-        },
+    },
+    {
+      usernameToStatus: {
+        userTwo: 'userTwoStatus',
+        userThree: 'userThreeStatus',
+        userFour: 'userFourStatus',
+        userOne: 'userOneStatus',
       },
-      {
-        usernameToStatus: {               // Full circle!
-          userOne: 'userOneStatus',
-          userTwo: 'userTwoStatus',
-          userThree: 'userThreeStatus',
-          userFour: 'userFourStatus',
-        },
+    },
+    {
+      usernameToStatus: {               // Full circle!
+        userOne: 'userOneStatus',
+        userTwo: 'userTwoStatus',
+        userThree: 'userThreeStatus',
+        userFour: 'userFourStatus',
       },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
+});
 
 
-  it('should remove nulled out children and ignore new null children', function() {
-    var PROPS_SEQUENCE = [
-      {
-        usernameToStatus: {
-          jcw: 'jcwStatus',
-          jordanjcw: 'jordanjcwStatus',
-        },
+it('should remove nulled out children and ignore new null children', function() {
+  var PROPS_SEQUENCE = [
+    {
+      usernameToStatus: {
+        jcw: 'jcwStatus',
+        jordanjcw: 'jordanjcwStatus',
       },
-      {
-        usernameToStatus: {
-          jordanjcw: 'jordanjcwstatus2',
-          jcw: null,
-          another: null,
-        },
+    },
+    {
+      usernameToStatus: {
+        jordanjcw: 'jordanjcwstatus2',
+        jcw: null,
+        another: null,
       },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
+});
 
-  it('should remove nulled out children and reorder remaining', function() {
-    var PROPS_SEQUENCE = [
-      {
-        usernameToStatus: {
-          jcw: 'jcwStatus',
-          jordanjcw: 'jordanjcwStatus',
-          john: 'johnStatus',  // john will go away
-          joe: 'joeStatus',
-        },
+it('should remove nulled out children and reorder remaining', function() {
+  var PROPS_SEQUENCE = [
+    {
+      usernameToStatus: {
+        jcw: 'jcwStatus',
+        jordanjcw: 'jordanjcwStatus',
+        john: 'johnStatus',  // john will go away
+        joe: 'joeStatus',
       },
-      {
-        usernameToStatus: {
-          jordanjcw: 'jordanjcwStatus',
-          joe: 'joeStatus',
-          jcw: 'jcwStatus',
-        },
+    },
+    {
+      usernameToStatus: {
+        jordanjcw: 'jordanjcwStatus',
+        joe: 'joeStatus',
+        jcw: 'jcwStatus',
       },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
+});
 
-  it('should append children to the end', function() {
-    var PROPS_SEQUENCE = [
-      {
-        usernameToStatus: {
-          jcw: 'jcwStatus',
-          jordanjcw: 'jordanjcwStatus',
-        },
+it('should append children to the end', function() {
+  var PROPS_SEQUENCE = [
+    {
+      usernameToStatus: {
+        jcw: 'jcwStatus',
+        jordanjcw: 'jordanjcwStatus',
       },
-      {
-        usernameToStatus: {
-          jcw: 'jcwStatus',
-          jordanjcw: 'jordanjcwStatus',
-          jordanjcwnew: 'jordanjcwnewStatus',
-        },
+    },
+    {
+      usernameToStatus: {
+        jcw: 'jcwStatus',
+        jordanjcw: 'jordanjcwStatus',
+        jordanjcwnew: 'jordanjcwnewStatus',
       },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
+});
 
-  it('should append multiple children to the end', function() {
-    var PROPS_SEQUENCE = [
-      {
-        usernameToStatus: {
-          jcw: 'jcwStatus',
-          jordanjcw: 'jordanjcwStatus',
-        },
+it('should append multiple children to the end', function() {
+  var PROPS_SEQUENCE = [
+    {
+      usernameToStatus: {
+        jcw: 'jcwStatus',
+        jordanjcw: 'jordanjcwStatus',
       },
-      {
-        usernameToStatus: {
-          jcw: 'jcwStatus',
-          jordanjcw: 'jordanjcwStatus',
-          jordanjcwnew: 'jordanjcwnewStatus',
-          jordanjcwnew2: 'jordanjcwnewStatus2',
-        },
+    },
+    {
+      usernameToStatus: {
+        jcw: 'jcwStatus',
+        jordanjcw: 'jordanjcwStatus',
+        jordanjcwnew: 'jordanjcwnewStatus',
+        jordanjcwnew2: 'jordanjcwnewStatus2',
       },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
+});
 
-  it('should prepend children to the beginning', function() {
-    var PROPS_SEQUENCE = [
-      {
-        usernameToStatus: {
-          jcw: 'jcwStatus',
-          jordanjcw: 'jordanjcwStatus',
-        },
+it('should prepend children to the beginning', function() {
+  var PROPS_SEQUENCE = [
+    {
+      usernameToStatus: {
+        jcw: 'jcwStatus',
+        jordanjcw: 'jordanjcwStatus',
       },
-      {
-        usernameToStatus: {
-          newUsername: 'newUsernameStatus',
-          jcw: 'jcwStatus',
-          jordanjcw: 'jordanjcwStatus',
-        },
+    },
+    {
+      usernameToStatus: {
+        newUsername: 'newUsernameStatus',
+        jcw: 'jcwStatus',
+        jordanjcw: 'jordanjcwStatus',
       },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
+});
 
-  it('should prepend multiple children to the beginning', function() {
-    var PROPS_SEQUENCE = [
-      {
-        usernameToStatus: {
-          jcw: 'jcwStatus',
-          jordanjcw: 'jordanjcwStatus',
-        },
+it('should prepend multiple children to the beginning', function() {
+  var PROPS_SEQUENCE = [
+    {
+      usernameToStatus: {
+        jcw: 'jcwStatus',
+        jordanjcw: 'jordanjcwStatus',
       },
-      {
-        usernameToStatus: {
-          newNewUsername: 'newNewUsernameStatus',
-          newUsername: 'newUsernameStatus',
-          jcw: 'jcwStatus',
-          jordanjcw: 'jordanjcwStatus',
-        },
+    },
+    {
+      usernameToStatus: {
+        newNewUsername: 'newNewUsernameStatus',
+        newUsername: 'newUsernameStatus',
+        jcw: 'jcwStatus',
+        jordanjcw: 'jordanjcwStatus',
       },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
+});
 
-  it('should not prepend an empty child to the beginning', function() {
-    var PROPS_SEQUENCE = [
-      {
-        usernameToStatus: {
-          jcw: 'jcwStatus',
-          jordanjcw: 'jordanjcwStatus',
-        },
+it('should not prepend an empty child to the beginning', function() {
+  var PROPS_SEQUENCE = [
+    {
+      usernameToStatus: {
+        jcw: 'jcwStatus',
+        jordanjcw: 'jordanjcwStatus',
       },
-      {
-        usernameToStatus: {
-          emptyUsername: null,
-          jcw: 'jcwStatus',
-          jordanjcw: 'jordanjcwStatus',
-        },
+    },
+    {
+      usernameToStatus: {
+        emptyUsername: null,
+        jcw: 'jcwStatus',
+        jordanjcw: 'jordanjcwStatus',
       },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
+});
 
-  it('should not append an empty child to the end', function() {
-    var PROPS_SEQUENCE = [
-      {
-        usernameToStatus: {
-          jcw: 'jcwStatus',
-          jordanjcw: 'jordanjcwStatus',
-        },
+it('should not append an empty child to the end', function() {
+  var PROPS_SEQUENCE = [
+    {
+      usernameToStatus: {
+        jcw: 'jcwStatus',
+        jordanjcw: 'jordanjcwStatus',
       },
-      {
-        usernameToStatus: {
-          jcw: 'jcwStatus',
-          jordanjcw: 'jordanjcwStatus',
-          emptyUsername: null,
-        },
+    },
+    {
+      usernameToStatus: {
+        jcw: 'jcwStatus',
+        jordanjcw: 'jordanjcwStatus',
+        emptyUsername: null,
       },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
+});
 
-  it('should not insert empty children in the middle', function() {
-    var PROPS_SEQUENCE = [
-      {
-        usernameToStatus: {
-          jcw: 'jcwStatus',
-          jordanjcw: 'jordanjcwStatus',
-        },
+it('should not insert empty children in the middle', function() {
+  var PROPS_SEQUENCE = [
+    {
+      usernameToStatus: {
+        jcw: 'jcwStatus',
+        jordanjcw: 'jordanjcwStatus',
       },
-      {
-        usernameToStatus: {
-          jcw: 'jcwstatus2',
-          skipOverMe: null,
-          skipOverMeToo: null,
-          definitelySkipOverMe: null,
-          jordanjcw: 'jordanjcwstatus2',
-        },
+    },
+    {
+      usernameToStatus: {
+        jcw: 'jcwstatus2',
+        skipOverMe: null,
+        skipOverMeToo: null,
+        definitelySkipOverMe: null,
+        jordanjcw: 'jordanjcwstatus2',
       },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
+});
 
-  it('should insert one new child in the middle', function() {
-    var PROPS_SEQUENCE = [
-      {
-        usernameToStatus: {
-          jcw: 'jcwStatus',
-          jordanjcw: 'jordanjcwStatus',
-        },
+it('should insert one new child in the middle', function() {
+  var PROPS_SEQUENCE = [
+    {
+      usernameToStatus: {
+        jcw: 'jcwStatus',
+        jordanjcw: 'jordanjcwStatus',
       },
-      {
-        usernameToStatus: {
-          jcw: 'jcwstatus2',
-          insertThis: 'insertThisStatus',
-          jordanjcw: 'jordanjcwstatus2',
-        },
+    },
+    {
+      usernameToStatus: {
+        jcw: 'jcwstatus2',
+        insertThis: 'insertThisStatus',
+        jordanjcw: 'jordanjcwstatus2',
       },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
+});
 
-  it('should insert multiple new truthy children in the middle', function() {
-    var PROPS_SEQUENCE = [
-      {
-        usernameToStatus: {
-          jcw: 'jcwStatus',
-          jordanjcw: 'jordanjcwStatus',
-        },
+it('should insert multiple new truthy children in the middle', function() {
+  var PROPS_SEQUENCE = [
+    {
+      usernameToStatus: {
+        jcw: 'jcwStatus',
+        jordanjcw: 'jordanjcwStatus',
       },
-      {
-        usernameToStatus: {
-          jcw: 'jcwstatus2',
-          insertThis: 'insertThisStatus',
-          insertThisToo: 'insertThisTooStatus',
-          definitelyInsertThisToo: 'definitelyInsertThisTooStatus',
-          jordanjcw: 'jordanjcwstatus2',
-        },
+    },
+    {
+      usernameToStatus: {
+        jcw: 'jcwstatus2',
+        insertThis: 'insertThisStatus',
+        insertThisToo: 'insertThisTooStatus',
+        definitelyInsertThisToo: 'definitelyInsertThisTooStatus',
+        jordanjcw: 'jordanjcwstatus2',
       },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
+});
 
-  it('should insert non-empty children in middle where nulls were', function() {
-    var PROPS_SEQUENCE = [
-      {
-        usernameToStatus: {
-          jcw: 'jcwStatus',
-          insertThis: null,
-          insertThisToo: null,
-          definitelyInsertThisToo: null,
-          jordanjcw: 'jordanjcwStatus',
-        },
+it('should insert non-empty children in middle where nulls were', function() {
+  var PROPS_SEQUENCE = [
+    {
+      usernameToStatus: {
+        jcw: 'jcwStatus',
+        insertThis: null,
+        insertThisToo: null,
+        definitelyInsertThisToo: null,
+        jordanjcw: 'jordanjcwStatus',
       },
-      {
-        usernameToStatus: {
-          jcw: 'jcwstatus2',
-          insertThis: 'insertThisStatus',
-          insertThisToo: 'insertThisTooStatus',
-          definitelyInsertThisToo: 'definitelyInsertThisTooStatus',
-          jordanjcw: 'jordanjcwstatus2',
-        },
+    },
+    {
+      usernameToStatus: {
+        jcw: 'jcwstatus2',
+        insertThis: 'insertThisStatus',
+        insertThisToo: 'insertThisTooStatus',
+        definitelyInsertThisToo: 'definitelyInsertThisTooStatus',
+        jordanjcw: 'jordanjcwstatus2',
       },
-    ];
-    testPropsSequence(PROPS_SEQUENCE);
-  });
+    },
+  ];
+  testPropsSequence(PROPS_SEQUENCE);
 });

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactMultiChildText-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactMultiChildText-test.js
@@ -89,161 +89,154 @@ var expectChildren = function(d, children) {
 };
 
 
-/**
- * ReactMultiChild DOM integration test. In ReactDOM components, we make sure
- * that single children that are strings are treated as "content" which is much
- * faster to render and update.
- */
-describe('ReactMultiChildText', function() {
-  it('should correctly handle all possible children for render and update', function() {
-    spyOn(console, 'error');
-    testAllPermutations([
-      // basic values
-      undefined, [],
-      null, [],
-      false, [],
-      true, [],
-      0, '0',
-      1.2, '1.2',
-      '', '',
-      'foo', 'foo',
+it('should correctly handle all possible children for render and update', function() {
+  spyOn(console, 'error');
+  testAllPermutations([
+    // basic values
+    undefined, [],
+    null, [],
+    false, [],
+    true, [],
+    0, '0',
+    1.2, '1.2',
+    '', '',
+    'foo', 'foo',
 
-      [], [],
-      [undefined], [],
-      [null], [],
-      [false], [],
-      [true], [],
-      [0], ['0'],
-      [1.2], ['1.2'],
-      [''], [''],
-      ['foo'], ['foo'],
-      [<div />], [<div />],
+    [], [],
+    [undefined], [],
+    [null], [],
+    [false], [],
+    [true], [],
+    [0], ['0'],
+    [1.2], ['1.2'],
+    [''], [''],
+    ['foo'], ['foo'],
+    [<div />], [<div />],
 
-      // two adjacent values
-      [true, 0], ['0'],
-      [0, 0], ['0', '0'],
-      [1.2, 0], ['1.2', '0'],
-      [0, ''], ['0', ''],
-      ['foo', 0], ['foo', '0'],
-      [0, <div />], ['0', <div />],
+    // two adjacent values
+    [true, 0], ['0'],
+    [0, 0], ['0', '0'],
+    [1.2, 0], ['1.2', '0'],
+    [0, ''], ['0', ''],
+    ['foo', 0], ['foo', '0'],
+    [0, <div />], ['0', <div />],
 
-      [true, 1.2], ['1.2'],
-      [1.2, 0], ['1.2', '0'],
-      [1.2, 1.2], ['1.2', '1.2'],
-      [1.2, ''], ['1.2', ''],
-      ['foo', 1.2], ['foo', '1.2'],
-      [1.2, <div />], ['1.2', <div />],
+    [true, 1.2], ['1.2'],
+    [1.2, 0], ['1.2', '0'],
+    [1.2, 1.2], ['1.2', '1.2'],
+    [1.2, ''], ['1.2', ''],
+    ['foo', 1.2], ['foo', '1.2'],
+    [1.2, <div />], ['1.2', <div />],
 
-      [true, ''], [''],
-      ['', 0], ['', '0'],
-      [1.2, ''], ['1.2', ''],
-      ['', ''], ['', ''],
-      ['foo', ''], ['foo', ''],
-      ['', <div />], ['', <div />],
+    [true, ''], [''],
+    ['', 0], ['', '0'],
+    [1.2, ''], ['1.2', ''],
+    ['', ''], ['', ''],
+    ['foo', ''], ['foo', ''],
+    ['', <div />], ['', <div />],
 
-      [true, 'foo'], ['foo'],
-      ['foo', 0], ['foo', '0'],
-      [1.2, 'foo'], ['1.2', 'foo'],
-      ['foo', ''], ['foo', ''],
-      ['foo', 'foo'], ['foo', 'foo'],
-      ['foo', <div />], ['foo', <div />],
+    [true, 'foo'], ['foo'],
+    ['foo', 0], ['foo', '0'],
+    [1.2, 'foo'], ['1.2', 'foo'],
+    ['foo', ''], ['foo', ''],
+    ['foo', 'foo'], ['foo', 'foo'],
+    ['foo', <div />], ['foo', <div />],
 
-      // values separated by an element
-      [true, <div />, true], [<div />],
-      [1.2, <div />, 1.2], ['1.2', <div />, '1.2'],
-      ['', <div />, ''], ['', <div />, ''],
-      ['foo', <div />, 'foo'], ['foo', <div />, 'foo'],
+    // values separated by an element
+    [true, <div />, true], [<div />],
+    [1.2, <div />, 1.2], ['1.2', <div />, '1.2'],
+    ['', <div />, ''], ['', <div />, ''],
+    ['foo', <div />, 'foo'], ['foo', <div />, 'foo'],
 
-      [true, 1.2, <div />, '', 'foo'], ['1.2', <div />, '', 'foo'],
-      [1.2, '', <div />, 'foo', true], ['1.2', '', <div />, 'foo'],
-      ['', 'foo', <div />, true, 1.2], ['', 'foo', <div />, '1.2'],
+    [true, 1.2, <div />, '', 'foo'], ['1.2', <div />, '', 'foo'],
+    [1.2, '', <div />, 'foo', true], ['1.2', '', <div />, 'foo'],
+    ['', 'foo', <div />, true, 1.2], ['', 'foo', <div />, '1.2'],
 
-      [true, 1.2, '', <div />, 'foo', true, 1.2], ['1.2', '', <div />, 'foo', '1.2'],
-      ['', 'foo', true, <div />, 1.2, '', 'foo'], ['', 'foo', <div />, '1.2', '', 'foo'],
+    [true, 1.2, '', <div />, 'foo', true, 1.2], ['1.2', '', <div />, 'foo', '1.2'],
+    ['', 'foo', true, <div />, 1.2, '', 'foo'], ['', 'foo', <div />, '1.2', '', 'foo'],
 
-      // values inside arrays
-      [[true], [true]], [],
-      [[1.2], [1.2]], ['1.2', '1.2'],
-      [[''], ['']], ['', ''],
-      [['foo'], ['foo']], ['foo', 'foo'],
-      [[<div />], [<div />]], [<div />, <div />],
+    // values inside arrays
+    [[true], [true]], [],
+    [[1.2], [1.2]], ['1.2', '1.2'],
+    [[''], ['']], ['', ''],
+    [['foo'], ['foo']], ['foo', 'foo'],
+    [[<div />], [<div />]], [<div />, <div />],
 
-      [[true, 1.2, <div />], '', 'foo'], ['1.2', <div />, '', 'foo'],
-      [1.2, '', [<div />, 'foo', true]], ['1.2', '', <div />, 'foo'],
-      ['', ['foo', <div />, true], 1.2], ['', 'foo', <div />, '1.2'],
+    [[true, 1.2, <div />], '', 'foo'], ['1.2', <div />, '', 'foo'],
+    [1.2, '', [<div />, 'foo', true]], ['1.2', '', <div />, 'foo'],
+    ['', ['foo', <div />, true], 1.2], ['', 'foo', <div />, '1.2'],
 
-      [true, [1.2, '', <div />, 'foo'], true, 1.2], ['1.2', '', <div />, 'foo', '1.2'],
-      ['', 'foo', [true, <div />, 1.2, ''], 'foo'], ['', 'foo', <div />, '1.2', '', 'foo'],
+    [true, [1.2, '', <div />, 'foo'], true, 1.2], ['1.2', '', <div />, 'foo', '1.2'],
+    ['', 'foo', [true, <div />, 1.2, ''], 'foo'], ['', 'foo', <div />, '1.2', '', 'foo'],
 
-      // values inside elements
-      [<div>{true}{1.2}{<div />}</div>, '', 'foo'], [<div />, '', 'foo'],
-      [1.2, '', <div>{<div />}{'foo'}{true}</div>], ['1.2', '', <div />],
-      ['', <div>{'foo'}{<div />}{true}</div>, 1.2], ['', <div />, '1.2'],
+    // values inside elements
+    [<div>{true}{1.2}{<div />}</div>, '', 'foo'], [<div />, '', 'foo'],
+    [1.2, '', <div>{<div />}{'foo'}{true}</div>], ['1.2', '', <div />],
+    ['', <div>{'foo'}{<div />}{true}</div>, 1.2], ['', <div />, '1.2'],
 
-      [true, <div>{1.2}{''}{<div />}{'foo'}</div>, true, 1.2], [<div />, '1.2'],
-      ['', 'foo', <div>{true}{<div />}{1.2}{''}</div>, 'foo'], ['', 'foo', <div />, 'foo'],
-    ]);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Warning: Each child in an array or iterator should have a unique "key" prop.'
+    [true, <div>{1.2}{''}{<div />}{'foo'}</div>, true, 1.2], [<div />, '1.2'],
+    ['', 'foo', <div>{true}{<div />}{1.2}{''}</div>, 'foo'], ['', 'foo', <div />, 'foo'],
+  ]);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'Warning: Each child in an array or iterator should have a unique "key" prop.'
+  );
+});
+
+it('should throw if rendering both HTML and children', function() {
+  expect(function() {
+    ReactTestUtils.renderIntoDocument(
+      <div dangerouslySetInnerHTML={{__html: 'abcdef'}}>ghjkl</div>
     );
-  });
+  }).toThrow();
+});
 
-  it('should throw if rendering both HTML and children', function() {
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(
-        <div dangerouslySetInnerHTML={{__html: 'abcdef'}}>ghjkl</div>
-      );
-    }).toThrow();
-  });
+it('should render between nested components and inline children', function() {
+  ReactTestUtils.renderIntoDocument(<div><h1><span /><span /></h1></div>);
 
-  it('should render between nested components and inline children', function() {
-    ReactTestUtils.renderIntoDocument(<div><h1><span /><span /></h1></div>);
+  expect(function() {
+    ReactTestUtils.renderIntoDocument(<div><h1>A</h1></div>);
+  }).not.toThrow();
 
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(<div><h1>A</h1></div>);
-    }).not.toThrow();
+  expect(function() {
+    ReactTestUtils.renderIntoDocument(<div><h1>{['A']}</h1></div>);
+  }).not.toThrow();
 
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(<div><h1>{['A']}</h1></div>);
-    }).not.toThrow();
+  expect(function() {
+    ReactTestUtils.renderIntoDocument(<div><h1>{['A', 'B']}</h1></div>);
+  }).not.toThrow();
+});
 
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(<div><h1>{['A', 'B']}</h1></div>);
-    }).not.toThrow();
-  });
+it('should reorder keyed text nodes', function() {
+  spyOn(console, 'error');
 
-  it('should reorder keyed text nodes', function() {
-    spyOn(console, 'error');
+  var container = document.createElement('div');
+  ReactDOM.render(
+    <div>{new Map([['a', 'alpha'], ['b', 'beta']])}</div>,
+    container
+  );
 
-    var container = document.createElement('div');
-    ReactDOM.render(
-      <div>{new Map([['a', 'alpha'], ['b', 'beta']])}</div>,
-      container
-    );
+  var childNodes = container.firstChild.childNodes;
+  var alpha1 = childNodes[0];
+  var alpha2 = childNodes[1];
+  var alpha3 = childNodes[2];
+  var beta1 = childNodes[3];
+  var beta2 = childNodes[4];
+  var beta3 = childNodes[5];
 
-    var childNodes = container.firstChild.childNodes;
-    var alpha1 = childNodes[0];
-    var alpha2 = childNodes[1];
-    var alpha3 = childNodes[2];
-    var beta1 = childNodes[3];
-    var beta2 = childNodes[4];
-    var beta3 = childNodes[5];
+  ReactDOM.render(
+    <div>{new Map([['b', 'beta'], ['a', 'alpha']])}</div>,
+    container
+  );
 
-    ReactDOM.render(
-      <div>{new Map([['b', 'beta'], ['a', 'alpha']])}</div>,
-      container
-    );
+  childNodes = container.firstChild.childNodes;
+  expect(childNodes[0]).toBe(beta1);
+  expect(childNodes[1]).toBe(beta2);
+  expect(childNodes[2]).toBe(beta3);
+  expect(childNodes[3]).toBe(alpha1);
+  expect(childNodes[4]).toBe(alpha2);
+  expect(childNodes[5]).toBe(alpha3);
 
-    childNodes = container.firstChild.childNodes;
-    expect(childNodes[0]).toBe(beta1);
-    expect(childNodes[1]).toBe(beta2);
-    expect(childNodes[2]).toBe(beta3);
-    expect(childNodes[3]).toBe(alpha1);
-    expect(childNodes[4]).toBe(alpha2);
-    expect(childNodes[5]).toBe(alpha3);
-
-    // Using Maps as children gives a single warning
-    expect(console.error.calls.count()).toBe(1);
-  });
+  // Using Maps as children gives a single warning
+  expect(console.error.calls.count()).toBe(1);
 });

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactStateSetters-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactStateSetters-test.js
@@ -18,135 +18,133 @@ var ReactTestUtils = require('ReactTestUtils');
 var TestComponent;
 var TestComponentWithMixin;
 
-describe('ReactStateSetters', function() {
-  beforeEach(function() {
-    jest.resetModuleRegistry();
+beforeEach(function() {
+  jest.resetModuleRegistry();
 
-    TestComponent = class extends React.Component {
-      state = {foo: 'foo'};
+  TestComponent = class extends React.Component {
+    state = {foo: 'foo'};
 
-      render() {
-        return <div />;
-      }
-    };
+    render() {
+      return <div />;
+    }
+  };
 
-    TestComponentWithMixin = React.createClass({
-      mixins: [ReactStateSetters.Mixin],
+  TestComponentWithMixin = React.createClass({
+    mixins: [ReactStateSetters.Mixin],
 
-      getInitialState: function() {
-        return {foo: 'foo'};
-      },
+    getInitialState: function() {
+      return {foo: 'foo'};
+    },
 
-      render: function() {
-        return <div />;
-      },
-    });
+    render: function() {
+      return <div />;
+    },
   });
+});
 
-  it('createStateSetter should update state', function() {
-    var instance = <TestComponent />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-    expect(instance.state).toEqual({foo: 'foo'});
+it('createStateSetter should update state', function() {
+  var instance = <TestComponent />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  expect(instance.state).toEqual({foo: 'foo'});
 
-    var setter = ReactStateSetters.createStateSetter(
-      instance,
-      function(a, b, c) {
-        return {
-          foo: a + b + c,
-          bar: a * b * c,
-        };
-      }
-    );
-    expect(instance.state).toEqual({foo: 'foo'});
+  var setter = ReactStateSetters.createStateSetter(
+    instance,
+    function(a, b, c) {
+      return {
+        foo: a + b + c,
+        bar: a * b * c,
+      };
+    }
+  );
+  expect(instance.state).toEqual({foo: 'foo'});
 
-    setter(1, 2, 3);
-    expect(instance.state).toEqual({foo: 6, bar: 6});
+  setter(1, 2, 3);
+  expect(instance.state).toEqual({foo: 6, bar: 6});
 
-    setter(10, 11, 12);
-    expect(instance.state).toEqual({foo: 33, bar: 1320});
-  });
+  setter(10, 11, 12);
+  expect(instance.state).toEqual({foo: 33, bar: 1320});
+});
 
-  it('createStateKeySetter should update state', function() {
-    var instance = <TestComponent />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-    expect(instance.state).toEqual({foo: 'foo'});
+it('createStateKeySetter should update state', function() {
+  var instance = <TestComponent />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  expect(instance.state).toEqual({foo: 'foo'});
 
-    var setter = ReactStateSetters.createStateKeySetter(instance, 'foo');
+  var setter = ReactStateSetters.createStateKeySetter(instance, 'foo');
 
-    expect(instance.state).toEqual({foo: 'foo'});
+  expect(instance.state).toEqual({foo: 'foo'});
 
-    setter('bar');
-    expect(instance.state).toEqual({foo: 'bar'});
+  setter('bar');
+  expect(instance.state).toEqual({foo: 'bar'});
 
-    setter('baz');
-    expect(instance.state).toEqual({foo: 'baz'});
-  });
+  setter('baz');
+  expect(instance.state).toEqual({foo: 'baz'});
+});
 
-  it('createStateKeySetter is memoized', function() {
-    var instance = <TestComponent />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-    expect(instance.state).toEqual({foo: 'foo'});
+it('createStateKeySetter is memoized', function() {
+  var instance = <TestComponent />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  expect(instance.state).toEqual({foo: 'foo'});
 
-    var foo1 = ReactStateSetters.createStateKeySetter(instance, 'foo');
-    var bar1 = ReactStateSetters.createStateKeySetter(instance, 'bar');
+  var foo1 = ReactStateSetters.createStateKeySetter(instance, 'foo');
+  var bar1 = ReactStateSetters.createStateKeySetter(instance, 'bar');
 
-    var foo2 = ReactStateSetters.createStateKeySetter(instance, 'foo');
-    var bar2 = ReactStateSetters.createStateKeySetter(instance, 'bar');
+  var foo2 = ReactStateSetters.createStateKeySetter(instance, 'foo');
+  var bar2 = ReactStateSetters.createStateKeySetter(instance, 'bar');
 
-    expect(foo2).toBe(foo1);
-    expect(bar2).toBe(bar1);
-  });
+  expect(foo2).toBe(foo1);
+  expect(bar2).toBe(bar1);
+});
 
-  it('createStateSetter should update state from mixin', function() {
-    var instance = <TestComponentWithMixin />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-    expect(instance.state).toEqual({foo: 'foo'});
+it('createStateSetter should update state from mixin', function() {
+  var instance = <TestComponentWithMixin />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  expect(instance.state).toEqual({foo: 'foo'});
 
-    var setter = instance.createStateSetter(
-      function(a, b, c) {
-        return {
-          foo: a + b + c,
-          bar: a * b * c,
-        };
-      }
-    );
-    expect(instance.state).toEqual({foo: 'foo'});
+  var setter = instance.createStateSetter(
+    function(a, b, c) {
+      return {
+        foo: a + b + c,
+        bar: a * b * c,
+      };
+    }
+  );
+  expect(instance.state).toEqual({foo: 'foo'});
 
-    setter(1, 2, 3);
-    expect(instance.state).toEqual({foo: 6, bar: 6});
+  setter(1, 2, 3);
+  expect(instance.state).toEqual({foo: 6, bar: 6});
 
-    setter(10, 11, 12);
-    expect(instance.state).toEqual({foo: 33, bar: 1320});
-  });
+  setter(10, 11, 12);
+  expect(instance.state).toEqual({foo: 33, bar: 1320});
+});
 
-  it('createStateKeySetter should update state with mixin', function() {
-    var instance = <TestComponentWithMixin />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-    expect(instance.state).toEqual({foo: 'foo'});
+it('createStateKeySetter should update state with mixin', function() {
+  var instance = <TestComponentWithMixin />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  expect(instance.state).toEqual({foo: 'foo'});
 
-    var setter = instance.createStateKeySetter('foo');
+  var setter = instance.createStateKeySetter('foo');
 
-    expect(instance.state).toEqual({foo: 'foo'});
+  expect(instance.state).toEqual({foo: 'foo'});
 
-    setter('bar');
-    expect(instance.state).toEqual({foo: 'bar'});
+  setter('bar');
+  expect(instance.state).toEqual({foo: 'bar'});
 
-    setter('baz');
-    expect(instance.state).toEqual({foo: 'baz'});
-  });
+  setter('baz');
+  expect(instance.state).toEqual({foo: 'baz'});
+});
 
-  it('createStateKeySetter is memoized with mixin', function() {
-    var instance = <TestComponentWithMixin />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-    expect(instance.state).toEqual({foo: 'foo'});
+it('createStateKeySetter is memoized with mixin', function() {
+  var instance = <TestComponentWithMixin />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+  expect(instance.state).toEqual({foo: 'foo'});
 
-    var foo1 = instance.createStateKeySetter('foo');
-    var bar1 = instance.createStateKeySetter('bar');
+  var foo1 = instance.createStateKeySetter('foo');
+  var bar1 = instance.createStateKeySetter('bar');
 
-    var foo2 = instance.createStateKeySetter('foo');
-    var bar2 = instance.createStateKeySetter('bar');
+  var foo2 = instance.createStateKeySetter('foo');
+  var bar2 = instance.createStateKeySetter('bar');
 
-    expect(foo2).toBe(foo1);
-    expect(bar2).toBe(bar1);
-  });
+  expect(foo2).toBe(foo1);
+  expect(bar2).toBe(bar1);
 });

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactStatelessComponent-test.js
@@ -19,256 +19,253 @@ function StatelessComponent(props) {
   return <div>{props.name}</div>;
 }
 
-describe('ReactStatelessComponent', function() {
+beforeEach(function() {
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactTestUtils = require('ReactTestUtils');
+});
 
-  beforeEach(function() {
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactTestUtils = require('ReactTestUtils');
-  });
+it('should render stateless component', function() {
+  var el = document.createElement('div');
+  ReactDOM.render(<StatelessComponent name="A" />, el);
 
-  it('should render stateless component', function() {
-    var el = document.createElement('div');
-    ReactDOM.render(<StatelessComponent name="A" />, el);
+  expect(el.textContent).toBe('A');
+});
 
-    expect(el.textContent).toBe('A');
-  });
+it('should update stateless component', function() {
+  class Parent extends React.Component {
+    render() {
+      return <StatelessComponent {...this.props} />;
+    }
+  }
 
-  it('should update stateless component', function() {
-    class Parent extends React.Component {
-      render() {
-        return <StatelessComponent {...this.props} />;
-      }
+  var el = document.createElement('div');
+  ReactDOM.render(<Parent name="A" />, el);
+  expect(el.textContent).toBe('A');
+
+  ReactDOM.render(<Parent name="B" />, el);
+  expect(el.textContent).toBe('B');
+});
+
+it('should unmount stateless component', function() {
+  var container = document.createElement('div');
+
+  ReactDOM.render(<StatelessComponent name="A" />, container);
+  expect(container.textContent).toBe('A');
+
+  ReactDOM.unmountComponentAtNode(container);
+  expect(container.textContent).toBe('');
+});
+
+it('should pass context thru stateless component', function() {
+  class Child extends React.Component {
+    static contextTypes = {
+      test: React.PropTypes.string.isRequired,
+    };
+
+    render() {
+      return <div>{this.context.test}</div>;
+    }
+  }
+
+  function Parent() {
+    return <Child />;
+  }
+
+  class GrandParent extends React.Component {
+    static childContextTypes = {
+      test: React.PropTypes.string.isRequired,
+    };
+
+    getChildContext() {
+      return {test: this.props.test};
     }
 
-    var el = document.createElement('div');
-    ReactDOM.render(<Parent name="A" />, el);
-    expect(el.textContent).toBe('A');
+    render() {
+      return <Parent />;
+    }
+  }
 
-    ReactDOM.render(<Parent name="B" />, el);
-    expect(el.textContent).toBe('B');
-  });
+  var el = document.createElement('div');
+  ReactDOM.render(<GrandParent test="test" />, el);
 
-  it('should unmount stateless component', function() {
-    var container = document.createElement('div');
+  expect(el.textContent).toBe('test');
 
-    ReactDOM.render(<StatelessComponent name="A" />, container);
-    expect(container.textContent).toBe('A');
+  ReactDOM.render(<GrandParent test="mest" />, el);
 
-    ReactDOM.unmountComponentAtNode(container);
-    expect(container.textContent).toBe('');
-  });
+  expect(el.textContent).toBe('mest');
+});
 
-  it('should pass context thru stateless component', function() {
-    class Child extends React.Component {
-      static contextTypes = {
-        test: React.PropTypes.string.isRequired,
-      };
+it('should warn for childContextTypes on a functional component', () => {
+  spyOn(console, 'error');
+  function StatelessComponentWithChildContext(props) {
+    return <div>{props.name}</div>;
+  }
 
-      render() {
-        return <div>{this.context.test}</div>;
-      }
+  StatelessComponentWithChildContext.childContextTypes = {
+    foo: React.PropTypes.string,
+  };
+
+  var container = document.createElement('div');
+
+  ReactDOM.render(<StatelessComponentWithChildContext name="A" />, container);
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'StatelessComponentWithChildContext(...): childContextTypes cannot ' +
+    'be defined on a functional component.'
+  );
+});
+
+it('should warn when stateless component returns array', function() {
+  spyOn(console, 'error');
+  function NotAComponent() {
+    return [<div />, <div />];
+  }
+  expect(function() {
+    ReactTestUtils.renderIntoDocument(<div><NotAComponent /></div>);
+  }).toThrow();
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'NotAComponent(...): A valid React element (or null) must be returned. ' +
+    'You may have returned undefined, an array or some other invalid object.'
+  );
+});
+
+it('should throw on string refs in pure functions', function() {
+  function Child() {
+    return <div ref="me" />;
+  }
+
+  expect(function() {
+    ReactTestUtils.renderIntoDocument(<Child test="test" />);
+  }).toThrowError(
+    'Stateless function components cannot have refs.'
+  );
+});
+
+it('should warn when given a ref', function() {
+  spyOn(console, 'error');
+
+  class Parent extends React.Component {
+    static displayName = 'Parent';
+
+    render() {
+      return <StatelessComponent name="A" ref="stateless"/>;
+    }
+  }
+
+  ReactTestUtils.renderIntoDocument(<Parent/>);
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'Stateless function components cannot be given refs ' +
+    '(See ref "stateless" in StatelessComponent created by Parent). ' +
+    'Attempts to access this ref will fail.'
+  );
+});
+
+it('should provide a null ref', function() {
+  function Child() {
+    return <div />;
+  }
+
+  var comp = ReactTestUtils.renderIntoDocument(<Child />);
+  expect(comp).toBe(null);
+});
+
+it('should use correct name in key warning', function() {
+  function Child() {
+    return <div>{[<span />]}</div>;
+  }
+
+  spyOn(console, 'error');
+  ReactTestUtils.renderIntoDocument(<Child />);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain('a unique "key" prop');
+  expect(console.error.calls.argsFor(0)[0]).toContain('Child');
+});
+
+it('should support default props and prop types', function() {
+  function Child(props) {
+    return <div>{props.test}</div>;
+  }
+  Child.defaultProps = {test: 2};
+  Child.propTypes = {test: React.PropTypes.string};
+
+  spyOn(console, 'error');
+  ReactTestUtils.renderIntoDocument(<Child />);
+  expect(console.error.calls.count()).toBe(1);
+  expect(
+    console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
+  ).toBe(
+    'Warning: Failed prop type: Invalid prop `test` of type `number` ' +
+    'supplied to `Child`, expected `string`.\n' +
+    '    in Child (at **)'
+  );
+});
+
+it('should receive context', function() {
+  class Parent extends React.Component {
+    static childContextTypes = {
+      lang: React.PropTypes.string,
+    };
+
+    getChildContext() {
+      return {lang: 'en'};
     }
 
-    function Parent() {
+    render() {
       return <Child />;
     }
+  }
 
-    class GrandParent extends React.Component {
-      static childContextTypes = {
-        test: React.PropTypes.string.isRequired,
-      };
+  function Child(props, context) {
+    return <div>{context.lang}</div>;
+  }
+  Child.contextTypes = {lang: React.PropTypes.string};
 
-      getChildContext() {
-        return {test: this.props.test};
-      }
+  var el = document.createElement('div');
+  ReactDOM.render(<Parent />, el);
+  expect(el.textContent).toBe('en');
+});
 
-      render() {
-        return <Parent />;
-      }
-    }
+it('should work with arrow functions', function() {
+  var Child = function() {
+    return <div />;
+  };
+  // Will create a new bound function without a prototype, much like a native
+  // arrow function.
+  Child = Child.bind(this);
 
-    var el = document.createElement('div');
-    ReactDOM.render(<GrandParent test="test" />, el);
+  expect(() => ReactTestUtils.renderIntoDocument(<Child />)).not.toThrow();
+});
 
-    expect(el.textContent).toBe('test');
+it('should allow simple functions to return null', function() {
+  var Child = function() {
+    return null;
+  };
+  expect(() => ReactTestUtils.renderIntoDocument(<Child />)).not.toThrow();
+});
 
-    ReactDOM.render(<GrandParent test="mest" />, el);
+it('should allow simple functions to return false', function() {
+  function Child() {
+    return false;
+  }
+  expect(() => ReactTestUtils.renderIntoDocument(<Child />)).not.toThrow();
+});
 
-    expect(el.textContent).toBe('mest');
-  });
-
-  it('should warn for childContextTypes on a functional component', () => {
-    spyOn(console, 'error');
-    function StatelessComponentWithChildContext(props) {
-      return <div>{props.name}</div>;
-    }
-
-    StatelessComponentWithChildContext.childContextTypes = {
-      foo: React.PropTypes.string,
-    };
-
-    var container = document.createElement('div');
-
-    ReactDOM.render(<StatelessComponentWithChildContext name="A" />, container);
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'StatelessComponentWithChildContext(...): childContextTypes cannot ' +
-      'be defined on a functional component.'
-    );
-  });
-
-  it('should warn when stateless component returns array', function() {
-    spyOn(console, 'error');
-    function NotAComponent() {
-      return [<div />, <div />];
-    }
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(<div><NotAComponent /></div>);
-    }).toThrow();
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'NotAComponent(...): A valid React element (or null) must be returned. ' +
-      'You may have returned undefined, an array or some other invalid object.'
-    );
-  });
-
-  it('should throw on string refs in pure functions', function() {
-    function Child() {
-      return <div ref="me" />;
-    }
-
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(<Child test="test" />);
-    }).toThrowError(
-      'Stateless function components cannot have refs.'
-    );
-  });
-
-  it('should warn when given a ref', function() {
-    spyOn(console, 'error');
-
-    class Parent extends React.Component {
-      static displayName = 'Parent';
-
-      render() {
-        return <StatelessComponent name="A" ref="stateless"/>;
-      }
-    }
-
-    ReactTestUtils.renderIntoDocument(<Parent/>);
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Stateless function components cannot be given refs ' +
-      '(See ref "stateless" in StatelessComponent created by Parent). ' +
-      'Attempts to access this ref will fail.'
-    );
-  });
-
-  it('should provide a null ref', function() {
-    function Child() {
-      return <div />;
-    }
-
-    var comp = ReactTestUtils.renderIntoDocument(<Child />);
-    expect(comp).toBe(null);
-  });
-
-  it('should use correct name in key warning', function() {
-    function Child() {
-      return <div>{[<span />]}</div>;
-    }
-
-    spyOn(console, 'error');
-    ReactTestUtils.renderIntoDocument(<Child />);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain('a unique "key" prop');
-    expect(console.error.calls.argsFor(0)[0]).toContain('Child');
-  });
-
-  it('should support default props and prop types', function() {
-    function Child(props) {
-      return <div>{props.test}</div>;
-    }
-    Child.defaultProps = {test: 2};
-    Child.propTypes = {test: React.PropTypes.string};
-
-    spyOn(console, 'error');
-    ReactTestUtils.renderIntoDocument(<Child />);
-    expect(console.error.calls.count()).toBe(1);
-    expect(
-      console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
-    ).toBe(
-      'Warning: Failed prop type: Invalid prop `test` of type `number` ' +
-      'supplied to `Child`, expected `string`.\n' +
-      '    in Child (at **)'
-    );
-  });
-
-  it('should receive context', function() {
-    class Parent extends React.Component {
-      static childContextTypes = {
-        lang: React.PropTypes.string,
-      };
-
-      getChildContext() {
-        return {lang: 'en'};
-      }
-
-      render() {
-        return <Child />;
-      }
-    }
-
-    function Child(props, context) {
-      return <div>{context.lang}</div>;
-    }
-    Child.contextTypes = {lang: React.PropTypes.string};
-
-    var el = document.createElement('div');
-    ReactDOM.render(<Parent />, el);
-    expect(el.textContent).toBe('en');
-  });
-
-  it('should work with arrow functions', function() {
-    var Child = function() {
-      return <div />;
-    };
-    // Will create a new bound function without a prototype, much like a native
-    // arrow function.
-    Child = Child.bind(this);
-
-    expect(() => ReactTestUtils.renderIntoDocument(<Child />)).not.toThrow();
-  });
-
-  it('should allow simple functions to return null', function() {
-    var Child = function() {
-      return null;
-    };
-    expect(() => ReactTestUtils.renderIntoDocument(<Child />)).not.toThrow();
-  });
-
-  it('should allow simple functions to return false', function() {
-    function Child() {
-      return false;
-    }
-    expect(() => ReactTestUtils.renderIntoDocument(<Child />)).not.toThrow();
-  });
-
-  it('should warn when using non-React functions in JSX', function() {
-    spyOn(console, 'error');
-    function NotAComponent() {
-      return [<div />, <div />];
-    }
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(<div><NotAComponent /></div>);
-    }).toThrow();  // has no method 'render'
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'NotAComponent(...): A valid React element (or null) must be returned. You may ' +
-      'have returned undefined, an array or some other invalid object.'
-    );
-  });
+it('should warn when using non-React functions in JSX', function() {
+  spyOn(console, 'error');
+  function NotAComponent() {
+    return [<div />, <div />];
+  }
+  expect(function() {
+    ReactTestUtils.renderIntoDocument(<div><NotAComponent /></div>);
+  }).toThrow();  // has no method 'render'
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'NotAComponent(...): A valid React element (or null) must be returned. You may ' +
+    'have returned undefined, an array or some other invalid object.'
+  );
 });

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactUpdates-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactUpdates-test.js
@@ -16,1141 +16,1139 @@ var ReactDOM;
 var ReactTestUtils;
 var ReactUpdates;
 
-describe('ReactUpdates', function() {
-  beforeEach(function() {
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactTestUtils = require('ReactTestUtils');
-    ReactUpdates = require('ReactUpdates');
-  });
+beforeEach(function() {
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactTestUtils = require('ReactTestUtils');
+  ReactUpdates = require('ReactUpdates');
+});
 
-  it('should batch state when updating state twice', function() {
-    var updateCount = 0;
+it('should batch state when updating state twice', function() {
+  var updateCount = 0;
 
-    class Component extends React.Component {
-      state = {x: 0};
+  class Component extends React.Component {
+    state = {x: 0};
 
-      componentDidUpdate() {
-        updateCount++;
-      }
-
-      render() {
-        return <div>{this.state.x}</div>;
-      }
+    componentDidUpdate() {
+      updateCount++;
     }
 
-    var instance = ReactTestUtils.renderIntoDocument(<Component />);
+    render() {
+      return <div>{this.state.x}</div>;
+    }
+  }
+
+  var instance = ReactTestUtils.renderIntoDocument(<Component />);
+  expect(instance.state.x).toBe(0);
+
+  ReactUpdates.batchedUpdates(function() {
+    instance.setState({x: 1});
+    instance.setState({x: 2});
     expect(instance.state.x).toBe(0);
-
-    ReactUpdates.batchedUpdates(function() {
-      instance.setState({x: 1});
-      instance.setState({x: 2});
-      expect(instance.state.x).toBe(0);
-      expect(updateCount).toBe(0);
-    });
-
-    expect(instance.state.x).toBe(2);
-    expect(updateCount).toBe(1);
+    expect(updateCount).toBe(0);
   });
 
-  it('should batch state when updating two different state keys', function() {
-    var updateCount = 0;
+  expect(instance.state.x).toBe(2);
+  expect(updateCount).toBe(1);
+});
 
-    class Component extends React.Component {
-      state = {x: 0, y: 0};
+it('should batch state when updating two different state keys', function() {
+  var updateCount = 0;
 
-      componentDidUpdate() {
-        updateCount++;
-      }
+  class Component extends React.Component {
+    state = {x: 0, y: 0};
 
-      render() {
-        return <div>({this.state.x}, {this.state.y})</div>;
-      }
+    componentDidUpdate() {
+      updateCount++;
     }
 
-    var instance = ReactTestUtils.renderIntoDocument(<Component />);
+    render() {
+      return <div>({this.state.x}, {this.state.y})</div>;
+    }
+  }
+
+  var instance = ReactTestUtils.renderIntoDocument(<Component />);
+  expect(instance.state.x).toBe(0);
+  expect(instance.state.y).toBe(0);
+
+  ReactUpdates.batchedUpdates(function() {
+    instance.setState({x: 1});
+    instance.setState({y: 2});
     expect(instance.state.x).toBe(0);
     expect(instance.state.y).toBe(0);
-
-    ReactUpdates.batchedUpdates(function() {
-      instance.setState({x: 1});
-      instance.setState({y: 2});
-      expect(instance.state.x).toBe(0);
-      expect(instance.state.y).toBe(0);
-      expect(updateCount).toBe(0);
-    });
-
-    expect(instance.state.x).toBe(1);
-    expect(instance.state.y).toBe(2);
-    expect(updateCount).toBe(1);
+    expect(updateCount).toBe(0);
   });
 
-  it('should batch state and props together', function() {
-    var updateCount = 0;
+  expect(instance.state.x).toBe(1);
+  expect(instance.state.y).toBe(2);
+  expect(updateCount).toBe(1);
+});
 
-    class Component extends React.Component {
-      state = {y: 0};
+it('should batch state and props together', function() {
+  var updateCount = 0;
 
-      componentDidUpdate() {
-        updateCount++;
-      }
+  class Component extends React.Component {
+    state = {y: 0};
 
-      render() {
-        return <div>({this.props.x}, {this.state.y})</div>;
-      }
+    componentDidUpdate() {
+      updateCount++;
     }
 
-    var container = document.createElement('div');
-    var instance = ReactDOM.render(<Component x={0} />, container);
+    render() {
+      return <div>({this.props.x}, {this.state.y})</div>;
+    }
+  }
+
+  var container = document.createElement('div');
+  var instance = ReactDOM.render(<Component x={0} />, container);
+  expect(instance.props.x).toBe(0);
+  expect(instance.state.y).toBe(0);
+
+  ReactUpdates.batchedUpdates(function() {
+    ReactDOM.render(<Component x={1} />, container);
+    instance.setState({y: 2});
     expect(instance.props.x).toBe(0);
     expect(instance.state.y).toBe(0);
-
-    ReactUpdates.batchedUpdates(function() {
-      ReactDOM.render(<Component x={1} />, container);
-      instance.setState({y: 2});
-      expect(instance.props.x).toBe(0);
-      expect(instance.state.y).toBe(0);
-      expect(updateCount).toBe(0);
-    });
-
-    expect(instance.props.x).toBe(1);
-    expect(instance.state.y).toBe(2);
-    expect(updateCount).toBe(1);
+    expect(updateCount).toBe(0);
   });
 
-  it('should batch parent/child state updates together', function() {
-    var parentUpdateCount = 0;
+  expect(instance.props.x).toBe(1);
+  expect(instance.state.y).toBe(2);
+  expect(updateCount).toBe(1);
+});
 
-    class Parent extends React.Component {
-      state = {x: 0};
+it('should batch parent/child state updates together', function() {
+  var parentUpdateCount = 0;
 
-      componentDidUpdate() {
-        parentUpdateCount++;
-      }
+  class Parent extends React.Component {
+    state = {x: 0};
 
-      render() {
-        return <div><Child ref="child" x={this.state.x} /></div>;
-      }
+    componentDidUpdate() {
+      parentUpdateCount++;
     }
 
-    var childUpdateCount = 0;
+    render() {
+      return <div><Child ref="child" x={this.state.x} /></div>;
+    }
+  }
 
-    class Child extends React.Component {
-      state = {y: 0};
+  var childUpdateCount = 0;
 
-      componentDidUpdate() {
-        childUpdateCount++;
-      }
+  class Child extends React.Component {
+    state = {y: 0};
 
-      render() {
-        return <div>{this.props.x + this.state.y}</div>;
-      }
+    componentDidUpdate() {
+      childUpdateCount++;
     }
 
-    var instance = ReactTestUtils.renderIntoDocument(<Parent />);
-    var child = instance.refs.child;
+    render() {
+      return <div>{this.props.x + this.state.y}</div>;
+    }
+  }
+
+  var instance = ReactTestUtils.renderIntoDocument(<Parent />);
+  var child = instance.refs.child;
+  expect(instance.state.x).toBe(0);
+  expect(child.state.y).toBe(0);
+
+  ReactUpdates.batchedUpdates(function() {
+    instance.setState({x: 1});
+    child.setState({y: 2});
     expect(instance.state.x).toBe(0);
     expect(child.state.y).toBe(0);
-
-    ReactUpdates.batchedUpdates(function() {
-      instance.setState({x: 1});
-      child.setState({y: 2});
-      expect(instance.state.x).toBe(0);
-      expect(child.state.y).toBe(0);
-      expect(parentUpdateCount).toBe(0);
-      expect(childUpdateCount).toBe(0);
-    });
-
-    expect(instance.state.x).toBe(1);
-    expect(child.state.y).toBe(2);
-    expect(parentUpdateCount).toBe(1);
-    expect(childUpdateCount).toBe(1);
+    expect(parentUpdateCount).toBe(0);
+    expect(childUpdateCount).toBe(0);
   });
 
-  it('should batch child/parent state updates together', function() {
-    var parentUpdateCount = 0;
+  expect(instance.state.x).toBe(1);
+  expect(child.state.y).toBe(2);
+  expect(parentUpdateCount).toBe(1);
+  expect(childUpdateCount).toBe(1);
+});
 
-    class Parent extends React.Component {
-      state = {x: 0};
+it('should batch child/parent state updates together', function() {
+  var parentUpdateCount = 0;
 
-      componentDidUpdate() {
-        parentUpdateCount++;
-      }
+  class Parent extends React.Component {
+    state = {x: 0};
 
-      render() {
-        return <div><Child ref="child" x={this.state.x} /></div>;
-      }
+    componentDidUpdate() {
+      parentUpdateCount++;
     }
 
-    var childUpdateCount = 0;
+    render() {
+      return <div><Child ref="child" x={this.state.x} /></div>;
+    }
+  }
 
-    class Child extends React.Component {
-      state = {y: 0};
+  var childUpdateCount = 0;
 
-      componentDidUpdate() {
-        childUpdateCount++;
-      }
+  class Child extends React.Component {
+    state = {y: 0};
 
-      render() {
-        return <div>{this.props.x + this.state.y}</div>;
-      }
+    componentDidUpdate() {
+      childUpdateCount++;
     }
 
-    var instance = ReactTestUtils.renderIntoDocument(<Parent />);
-    var child = instance.refs.child;
+    render() {
+      return <div>{this.props.x + this.state.y}</div>;
+    }
+  }
+
+  var instance = ReactTestUtils.renderIntoDocument(<Parent />);
+  var child = instance.refs.child;
+  expect(instance.state.x).toBe(0);
+  expect(child.state.y).toBe(0);
+
+  ReactUpdates.batchedUpdates(function() {
+    child.setState({y: 2});
+    instance.setState({x: 1});
     expect(instance.state.x).toBe(0);
     expect(child.state.y).toBe(0);
-
-    ReactUpdates.batchedUpdates(function() {
-      child.setState({y: 2});
-      instance.setState({x: 1});
-      expect(instance.state.x).toBe(0);
-      expect(child.state.y).toBe(0);
-      expect(parentUpdateCount).toBe(0);
-      expect(childUpdateCount).toBe(0);
-    });
-
-    expect(instance.state.x).toBe(1);
-    expect(child.state.y).toBe(2);
-    expect(parentUpdateCount).toBe(1);
-
-    // Batching reduces the number of updates here to 1.
-    expect(childUpdateCount).toBe(1);
+    expect(parentUpdateCount).toBe(0);
+    expect(childUpdateCount).toBe(0);
   });
 
-  it('should support chained state updates', function() {
-    var updateCount = 0;
+  expect(instance.state.x).toBe(1);
+  expect(child.state.y).toBe(2);
+  expect(parentUpdateCount).toBe(1);
 
-    class Component extends React.Component {
-      state = {x: 0};
+  // Batching reduces the number of updates here to 1.
+  expect(childUpdateCount).toBe(1);
+});
 
-      componentDidUpdate() {
-        updateCount++;
-      }
+it('should support chained state updates', function() {
+  var updateCount = 0;
 
-      render() {
-        return <div>{this.state.x}</div>;
-      }
+  class Component extends React.Component {
+    state = {x: 0};
+
+    componentDidUpdate() {
+      updateCount++;
     }
 
-    var instance = ReactTestUtils.renderIntoDocument(<Component />);
-    expect(instance.state.x).toBe(0);
-
-    var innerCallbackRun = false;
-    ReactUpdates.batchedUpdates(function() {
-      instance.setState({x: 1}, function() {
-        instance.setState({x: 2}, function() {
-          expect(this).toBe(instance);
-          innerCallbackRun = true;
-          expect(instance.state.x).toBe(2);
-          expect(updateCount).toBe(2);
-        });
-        expect(instance.state.x).toBe(1);
-        expect(updateCount).toBe(1);
-      });
-      expect(instance.state.x).toBe(0);
-      expect(updateCount).toBe(0);
-    });
-
-    expect(innerCallbackRun).toBeTruthy();
-    expect(instance.state.x).toBe(2);
-    expect(updateCount).toBe(2);
-  });
-
-  it('should batch forceUpdate together', function() {
-    var shouldUpdateCount = 0;
-    var updateCount = 0;
-
-    class Component extends React.Component {
-      state = {x: 0};
-
-      shouldComponentUpdate() {
-        shouldUpdateCount++;
-      }
-
-      componentDidUpdate() {
-        updateCount++;
-      }
-
-      render() {
-        return <div>{this.state.x}</div>;
-      }
+    render() {
+      return <div>{this.state.x}</div>;
     }
+  }
 
-    var instance = ReactTestUtils.renderIntoDocument(<Component />);
-    expect(instance.state.x).toBe(0);
+  var instance = ReactTestUtils.renderIntoDocument(<Component />);
+  expect(instance.state.x).toBe(0);
 
-    var callbacksRun = 0;
-    ReactUpdates.batchedUpdates(function() {
-      instance.setState({x: 1}, function() {
-        callbacksRun++;
-      });
-      instance.forceUpdate(function() {
-        callbacksRun++;
-      });
-      expect(instance.state.x).toBe(0);
-      expect(updateCount).toBe(0);
-    });
-
-    expect(callbacksRun).toBe(2);
-    // shouldComponentUpdate shouldn't be called since we're forcing
-    expect(shouldUpdateCount).toBe(0);
-    expect(instance.state.x).toBe(1);
-    expect(updateCount).toBe(1);
-  });
-
-  it('should update children even if parent blocks updates', function() {
-    var parentRenderCount = 0;
-    var childRenderCount = 0;
-
-    class Parent extends React.Component {
-      shouldComponentUpdate() {
-        return false;
-      }
-
-      render() {
-        parentRenderCount++;
-        return <Child ref="child" />;
-      }
-    }
-
-    class Child extends React.Component {
-      render() {
-        childRenderCount++;
-        return <div />;
-      }
-    }
-
-    expect(parentRenderCount).toBe(0);
-    expect(childRenderCount).toBe(0);
-
-    var instance = <Parent />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-
-    expect(parentRenderCount).toBe(1);
-    expect(childRenderCount).toBe(1);
-
-    ReactUpdates.batchedUpdates(function() {
-      instance.setState({x: 1});
-    });
-
-    expect(parentRenderCount).toBe(1);
-    expect(childRenderCount).toBe(1);
-
-    ReactUpdates.batchedUpdates(function() {
-      instance.refs.child.setState({x: 1});
-    });
-
-    expect(parentRenderCount).toBe(1);
-    expect(childRenderCount).toBe(2);
-  });
-
-  it('should not reconcile children passed via props', function() {
-    var numMiddleRenders = 0;
-    var numBottomRenders = 0;
-
-    class Top extends React.Component {
-      render() {
-        return <Middle><Bottom /></Middle>;
-      }
-    }
-
-    class Middle extends React.Component {
-      componentDidMount() {
-        this.forceUpdate();
-      }
-
-      render() {
-        numMiddleRenders++;
-        return React.Children.only(this.props.children);
-      }
-    }
-
-    class Bottom extends React.Component {
-      render() {
-        numBottomRenders++;
-        return null;
-      }
-    }
-
-    ReactTestUtils.renderIntoDocument(<Top />);
-    expect(numMiddleRenders).toBe(2);
-    expect(numBottomRenders).toBe(1);
-  });
-
-  it('should flow updates correctly', function() {
-    var willUpdates = [];
-    var didUpdates = [];
-
-    var UpdateLoggingMixin = {
-      componentWillUpdate: function() {
-        willUpdates.push(this.constructor.displayName);
-      },
-      componentDidUpdate: function() {
-        didUpdates.push(this.constructor.displayName);
-      },
-    };
-
-    var Box = React.createClass({
-      mixins: [UpdateLoggingMixin],
-
-      render: function() {
-        return <div ref="boxDiv">{this.props.children}</div>;
-      },
-    });
-
-    var Child = React.createClass({
-      mixins: [UpdateLoggingMixin],
-
-      render: function() {
-        return <span ref="span">child</span>;
-      },
-    });
-
-    var Switcher = React.createClass({
-      mixins: [UpdateLoggingMixin],
-
-      getInitialState: function() {
-        return {tabKey: 'hello'};
-      },
-
-      render: function() {
-        var child = this.props.children;
-
-        return (
-          <Box ref="box">
-            <div
-              ref="switcherDiv"
-              style={{
-                display: this.state.tabKey === child.key ? '' : 'none',
-              }}>
-              {child}
-            </div>
-          </Box>
-        );
-      },
-    });
-
-    var App = React.createClass({
-      mixins: [UpdateLoggingMixin],
-
-      render: function() {
-        return (
-          <Switcher ref="switcher">
-            <Child key="hello" ref="child" />
-          </Switcher>
-        );
-      },
-    });
-
-    var root = <App />;
-    root = ReactTestUtils.renderIntoDocument(root);
-
-    function expectUpdates(desiredWillUpdates, desiredDidUpdates) {
-      var i;
-      for (i = 0; i < desiredWillUpdates; i++) {
-        expect(willUpdates).toContain(desiredWillUpdates[i]);
-      }
-      for (i = 0; i < desiredDidUpdates; i++) {
-        expect(didUpdates).toContain(desiredDidUpdates[i]);
-      }
-      willUpdates = [];
-      didUpdates = [];
-    }
-
-    function triggerUpdate(c) {
-      c.setState({x: 1});
-    }
-
-    function testUpdates(components, desiredWillUpdates, desiredDidUpdates) {
-      var i;
-
-      ReactUpdates.batchedUpdates(function() {
-        for (i = 0; i < components.length; i++) {
-          triggerUpdate(components[i]);
-        }
-      });
-
-      expectUpdates(desiredWillUpdates, desiredDidUpdates);
-
-      // Try them in reverse order
-
-      ReactUpdates.batchedUpdates(function() {
-        for (i = components.length - 1; i >= 0; i--) {
-          triggerUpdate(components[i]);
-        }
-      });
-
-      expectUpdates(desiredWillUpdates, desiredDidUpdates);
-    }
-    testUpdates(
-      [root.refs.switcher.refs.box, root.refs.switcher],
-      // Owner-child relationships have inverse will and did
-      ['Switcher', 'Box'],
-      ['Box', 'Switcher']
-    );
-
-    testUpdates(
-      [root.refs.child, root.refs.switcher.refs.box],
-      // Not owner-child so reconcile independently
-      ['Box', 'Child'],
-      ['Box', 'Child']
-    );
-
-    testUpdates(
-      [root.refs.child, root.refs.switcher],
-      // Switcher owns Box and Child, Box does not own Child
-      ['Switcher', 'Box', 'Child'],
-      ['Box', 'Switcher', 'Child']
-    );
-  });
-
-  it('should share reconcile transaction across different roots', function() {
-    var ReconcileTransaction = ReactUpdates.ReactReconcileTransaction;
-    spyOn(ReconcileTransaction, 'getPooled').and.callThrough();
-
-    class Component extends React.Component {
-      render() {
-        return <div>{this.props.text}</div>;
-      }
-    }
-
-    var containerA = document.createElement('div');
-    var containerB = document.createElement('div');
-
-    // Initial renders aren't batched together yet...
-    ReactUpdates.batchedUpdates(function() {
-      ReactDOM.render(<Component text="A1" />, containerA);
-      ReactDOM.render(<Component text="B1" />, containerB);
-    });
-    expect(ReconcileTransaction.getPooled.calls.count()).toBe(2);
-
-    // ...but updates are! Here only one more transaction is used, which means
-    // we only have to initialize and close the wrappers once.
-    ReactUpdates.batchedUpdates(function() {
-      ReactDOM.render(<Component text="A2" />, containerA);
-      ReactDOM.render(<Component text="B2" />, containerB);
-    });
-    expect(ReconcileTransaction.getPooled.calls.count()).toBe(3);
-  });
-
-  it('should queue mount-ready handlers across different roots', function() {
-    // We'll define two components A and B, then update both of them. When A's
-    // componentDidUpdate handlers is called, B's DOM should already have been
-    // updated.
-
-    var a;
-    var b;
-
-    var aUpdated = false;
-
-    class A extends React.Component {
-      state = {x: 0};
-
-      componentDidUpdate() {
-        expect(ReactDOM.findDOMNode(b).textContent).toBe('B1');
-        aUpdated = true;
-      }
-
-      render() {
-        return <div>A{this.state.x}</div>;
-      }
-    }
-
-    class B extends React.Component {
-      state = {x: 0};
-
-      render() {
-        return <div>B{this.state.x}</div>;
-      }
-    }
-
-    a = ReactTestUtils.renderIntoDocument(<A />);
-    b = ReactTestUtils.renderIntoDocument(<B />);
-
-    ReactUpdates.batchedUpdates(function() {
-      a.setState({x: 1});
-      b.setState({x: 1});
-    });
-
-    expect(aUpdated).toBe(true);
-  });
-
-  it('should flush updates in the correct order', function() {
-    var updates = [];
-
-    class Outer extends React.Component {
-      state = {x: 0};
-
-      render() {
-        updates.push('Outer-render-' + this.state.x);
-        return <div><Inner x={this.state.x} ref="inner" /></div>;
-      }
-
-      componentDidUpdate() {
-        var x = this.state.x;
-        updates.push('Outer-didUpdate-' + x);
-        updates.push('Inner-setState-' + x);
-        this.refs.inner.setState({x: x}, function() {
-          updates.push('Inner-callback-' + x);
-        });
-      }
-    }
-
-    class Inner extends React.Component {
-      state = {x: 0};
-
-      render() {
-        updates.push('Inner-render-' + this.props.x + '-' + this.state.x);
-        return <div />;
-      }
-
-      componentDidUpdate() {
-        updates.push('Inner-didUpdate-' + this.props.x + '-' + this.state.x);
-      }
-    }
-
-    var instance = ReactTestUtils.renderIntoDocument(<Outer />);
-
-    updates.push('Outer-setState-1');
+  var innerCallbackRun = false;
+  ReactUpdates.batchedUpdates(function() {
     instance.setState({x: 1}, function() {
-      updates.push('Outer-callback-1');
-      updates.push('Outer-setState-2');
       instance.setState({x: 2}, function() {
-        updates.push('Outer-callback-2');
+        expect(this).toBe(instance);
+        innerCallbackRun = true;
+        expect(instance.state.x).toBe(2);
+        expect(updateCount).toBe(2);
       });
+      expect(instance.state.x).toBe(1);
+      expect(updateCount).toBe(1);
     });
-
-    /* eslint-disable indent */
-    expect(updates).toEqual([
-      'Outer-render-0',
-        'Inner-render-0-0',
-
-      'Outer-setState-1',
-        'Outer-render-1',
-          'Inner-render-1-0',
-          'Inner-didUpdate-1-0',
-        'Outer-didUpdate-1',
-          'Inner-setState-1',
-            'Inner-render-1-1',
-            'Inner-didUpdate-1-1',
-          'Inner-callback-1',
-      'Outer-callback-1',
-
-      'Outer-setState-2',
-        'Outer-render-2',
-          'Inner-render-2-1',
-          'Inner-didUpdate-2-1',
-        'Outer-didUpdate-2',
-          'Inner-setState-2',
-            'Inner-render-2-2',
-            'Inner-didUpdate-2-2',
-          'Inner-callback-2',
-      'Outer-callback-2',
-    ]);
-    /* eslint-enable indent */
+    expect(instance.state.x).toBe(0);
+    expect(updateCount).toBe(0);
   });
 
-  it('should flush updates in the correct order across roots', function() {
-    var instances = [];
-    var updates = [];
+  expect(innerCallbackRun).toBeTruthy();
+  expect(instance.state.x).toBe(2);
+  expect(updateCount).toBe(2);
+});
 
-    class MockComponent extends React.Component {
-      render() {
-        updates.push(this.props.depth);
-        return <div />;
-      }
+it('should batch forceUpdate together', function() {
+  var shouldUpdateCount = 0;
+  var updateCount = 0;
 
-      componentDidMount() {
-        instances.push(this);
-        if (this.props.depth < this.props.count) {
-          ReactDOM.render(
-            <MockComponent
-              depth={this.props.depth + 1}
-              count={this.props.count}
-            />,
-            ReactDOM.findDOMNode(this)
-          );
-        }
-      }
+  class Component extends React.Component {
+    state = {x: 0};
+
+    shouldComponentUpdate() {
+      shouldUpdateCount++;
     }
 
-    ReactTestUtils.renderIntoDocument(<MockComponent depth={0} count={2} />);
+    componentDidUpdate() {
+      updateCount++;
+    }
 
-    expect(updates).toEqual([0, 1, 2]);
+    render() {
+      return <div>{this.state.x}</div>;
+    }
+  }
+
+  var instance = ReactTestUtils.renderIntoDocument(<Component />);
+  expect(instance.state.x).toBe(0);
+
+  var callbacksRun = 0;
+  ReactUpdates.batchedUpdates(function() {
+    instance.setState({x: 1}, function() {
+      callbacksRun++;
+    });
+    instance.forceUpdate(function() {
+      callbacksRun++;
+    });
+    expect(instance.state.x).toBe(0);
+    expect(updateCount).toBe(0);
+  });
+
+  expect(callbacksRun).toBe(2);
+  // shouldComponentUpdate shouldn't be called since we're forcing
+  expect(shouldUpdateCount).toBe(0);
+  expect(instance.state.x).toBe(1);
+  expect(updateCount).toBe(1);
+});
+
+it('should update children even if parent blocks updates', function() {
+  var parentRenderCount = 0;
+  var childRenderCount = 0;
+
+  class Parent extends React.Component {
+    shouldComponentUpdate() {
+      return false;
+    }
+
+    render() {
+      parentRenderCount++;
+      return <Child ref="child" />;
+    }
+  }
+
+  class Child extends React.Component {
+    render() {
+      childRenderCount++;
+      return <div />;
+    }
+  }
+
+  expect(parentRenderCount).toBe(0);
+  expect(childRenderCount).toBe(0);
+
+  var instance = <Parent />;
+  instance = ReactTestUtils.renderIntoDocument(instance);
+
+  expect(parentRenderCount).toBe(1);
+  expect(childRenderCount).toBe(1);
+
+  ReactUpdates.batchedUpdates(function() {
+    instance.setState({x: 1});
+  });
+
+  expect(parentRenderCount).toBe(1);
+  expect(childRenderCount).toBe(1);
+
+  ReactUpdates.batchedUpdates(function() {
+    instance.refs.child.setState({x: 1});
+  });
+
+  expect(parentRenderCount).toBe(1);
+  expect(childRenderCount).toBe(2);
+});
+
+it('should not reconcile children passed via props', function() {
+  var numMiddleRenders = 0;
+  var numBottomRenders = 0;
+
+  class Top extends React.Component {
+    render() {
+      return <Middle><Bottom /></Middle>;
+    }
+  }
+
+  class Middle extends React.Component {
+    componentDidMount() {
+      this.forceUpdate();
+    }
+
+    render() {
+      numMiddleRenders++;
+      return React.Children.only(this.props.children);
+    }
+  }
+
+  class Bottom extends React.Component {
+    render() {
+      numBottomRenders++;
+      return null;
+    }
+  }
+
+  ReactTestUtils.renderIntoDocument(<Top />);
+  expect(numMiddleRenders).toBe(2);
+  expect(numBottomRenders).toBe(1);
+});
+
+it('should flow updates correctly', function() {
+  var willUpdates = [];
+  var didUpdates = [];
+
+  var UpdateLoggingMixin = {
+    componentWillUpdate: function() {
+      willUpdates.push(this.constructor.displayName);
+    },
+    componentDidUpdate: function() {
+      didUpdates.push(this.constructor.displayName);
+    },
+  };
+
+  var Box = React.createClass({
+    mixins: [UpdateLoggingMixin],
+
+    render: function() {
+      return <div ref="boxDiv">{this.props.children}</div>;
+    },
+  });
+
+  var Child = React.createClass({
+    mixins: [UpdateLoggingMixin],
+
+    render: function() {
+      return <span ref="span">child</span>;
+    },
+  });
+
+  var Switcher = React.createClass({
+    mixins: [UpdateLoggingMixin],
+
+    getInitialState: function() {
+      return {tabKey: 'hello'};
+    },
+
+    render: function() {
+      var child = this.props.children;
+
+      return (
+        <Box ref="box">
+          <div
+            ref="switcherDiv"
+            style={{
+              display: this.state.tabKey === child.key ? '' : 'none',
+            }}>
+            {child}
+          </div>
+        </Box>
+      );
+    },
+  });
+
+  var App = React.createClass({
+    mixins: [UpdateLoggingMixin],
+
+    render: function() {
+      return (
+        <Switcher ref="switcher">
+          <Child key="hello" ref="child" />
+        </Switcher>
+      );
+    },
+  });
+
+  var root = <App />;
+  root = ReactTestUtils.renderIntoDocument(root);
+
+  function expectUpdates(desiredWillUpdates, desiredDidUpdates) {
+    var i;
+    for (i = 0; i < desiredWillUpdates; i++) {
+      expect(willUpdates).toContain(desiredWillUpdates[i]);
+    }
+    for (i = 0; i < desiredDidUpdates; i++) {
+      expect(didUpdates).toContain(desiredDidUpdates[i]);
+    }
+    willUpdates = [];
+    didUpdates = [];
+  }
+
+  function triggerUpdate(c) {
+    c.setState({x: 1});
+  }
+
+  function testUpdates(components, desiredWillUpdates, desiredDidUpdates) {
+    var i;
 
     ReactUpdates.batchedUpdates(function() {
-      // Simulate update on each component from top to bottom.
-      instances.forEach(function(instance) {
-        instance.forceUpdate();
-      });
+      for (i = 0; i < components.length; i++) {
+        triggerUpdate(components[i]);
+      }
     });
 
-    expect(updates).toEqual([0, 1, 2, 0, 1, 2]);
-  });
+    expectUpdates(desiredWillUpdates, desiredDidUpdates);
 
-  it('should queue nested updates', function() {
-    // See https://github.com/facebook/react/issues/1147
+    // Try them in reverse order
 
-    class X extends React.Component {
-      state = {s: 0};
-
-      render() {
-        if (this.state.s === 0) {
-          return (
-            <div>
-              <span>0</span>
-            </div>
-          );
-        } else {
-          return <div>1</div>;
-        }
+    ReactUpdates.batchedUpdates(function() {
+      for (i = components.length - 1; i >= 0; i--) {
+        triggerUpdate(components[i]);
       }
+    });
 
-      go = () => {
-        this.setState({s: 1});
-        this.setState({s: 0});
-        this.setState({s: 1});
-      };
+    expectUpdates(desiredWillUpdates, desiredDidUpdates);
+  }
+  testUpdates(
+    [root.refs.switcher.refs.box, root.refs.switcher],
+    // Owner-child relationships have inverse will and did
+    ['Switcher', 'Box'],
+    ['Box', 'Switcher']
+  );
+
+  testUpdates(
+    [root.refs.child, root.refs.switcher.refs.box],
+    // Not owner-child so reconcile independently
+    ['Box', 'Child'],
+    ['Box', 'Child']
+  );
+
+  testUpdates(
+    [root.refs.child, root.refs.switcher],
+    // Switcher owns Box and Child, Box does not own Child
+    ['Switcher', 'Box', 'Child'],
+    ['Box', 'Switcher', 'Child']
+  );
+});
+
+it('should share reconcile transaction across different roots', function() {
+  var ReconcileTransaction = ReactUpdates.ReactReconcileTransaction;
+  spyOn(ReconcileTransaction, 'getPooled').and.callThrough();
+
+  class Component extends React.Component {
+    render() {
+      return <div>{this.props.text}</div>;
+    }
+  }
+
+  var containerA = document.createElement('div');
+  var containerB = document.createElement('div');
+
+  // Initial renders aren't batched together yet...
+  ReactUpdates.batchedUpdates(function() {
+    ReactDOM.render(<Component text="A1" />, containerA);
+    ReactDOM.render(<Component text="B1" />, containerB);
+  });
+  expect(ReconcileTransaction.getPooled.calls.count()).toBe(2);
+
+  // ...but updates are! Here only one more transaction is used, which means
+  // we only have to initialize and close the wrappers once.
+  ReactUpdates.batchedUpdates(function() {
+    ReactDOM.render(<Component text="A2" />, containerA);
+    ReactDOM.render(<Component text="B2" />, containerB);
+  });
+  expect(ReconcileTransaction.getPooled.calls.count()).toBe(3);
+});
+
+it('should queue mount-ready handlers across different roots', function() {
+  // We'll define two components A and B, then update both of them. When A's
+  // componentDidUpdate handlers is called, B's DOM should already have been
+  // updated.
+
+  var a;
+  var b;
+
+  var aUpdated = false;
+
+  class A extends React.Component {
+    state = {x: 0};
+
+    componentDidUpdate() {
+      expect(ReactDOM.findDOMNode(b).textContent).toBe('B1');
+      aUpdated = true;
     }
 
-    class Y extends React.Component {
-      render() {
+    render() {
+      return <div>A{this.state.x}</div>;
+    }
+  }
+
+  class B extends React.Component {
+    state = {x: 0};
+
+    render() {
+      return <div>B{this.state.x}</div>;
+    }
+  }
+
+  a = ReactTestUtils.renderIntoDocument(<A />);
+  b = ReactTestUtils.renderIntoDocument(<B />);
+
+  ReactUpdates.batchedUpdates(function() {
+    a.setState({x: 1});
+    b.setState({x: 1});
+  });
+
+  expect(aUpdated).toBe(true);
+});
+
+it('should flush updates in the correct order', function() {
+  var updates = [];
+
+  class Outer extends React.Component {
+    state = {x: 0};
+
+    render() {
+      updates.push('Outer-render-' + this.state.x);
+      return <div><Inner x={this.state.x} ref="inner" /></div>;
+    }
+
+    componentDidUpdate() {
+      var x = this.state.x;
+      updates.push('Outer-didUpdate-' + x);
+      updates.push('Inner-setState-' + x);
+      this.refs.inner.setState({x: x}, function() {
+        updates.push('Inner-callback-' + x);
+      });
+    }
+  }
+
+  class Inner extends React.Component {
+    state = {x: 0};
+
+    render() {
+      updates.push('Inner-render-' + this.props.x + '-' + this.state.x);
+      return <div />;
+    }
+
+    componentDidUpdate() {
+      updates.push('Inner-didUpdate-' + this.props.x + '-' + this.state.x);
+    }
+  }
+
+  var instance = ReactTestUtils.renderIntoDocument(<Outer />);
+
+  updates.push('Outer-setState-1');
+  instance.setState({x: 1}, function() {
+    updates.push('Outer-callback-1');
+    updates.push('Outer-setState-2');
+    instance.setState({x: 2}, function() {
+      updates.push('Outer-callback-2');
+    });
+  });
+
+  /* eslint-disable indent */
+  expect(updates).toEqual([
+    'Outer-render-0',
+      'Inner-render-0-0',
+
+    'Outer-setState-1',
+      'Outer-render-1',
+        'Inner-render-1-0',
+        'Inner-didUpdate-1-0',
+      'Outer-didUpdate-1',
+        'Inner-setState-1',
+          'Inner-render-1-1',
+          'Inner-didUpdate-1-1',
+        'Inner-callback-1',
+    'Outer-callback-1',
+
+    'Outer-setState-2',
+      'Outer-render-2',
+        'Inner-render-2-1',
+        'Inner-didUpdate-2-1',
+      'Outer-didUpdate-2',
+        'Inner-setState-2',
+          'Inner-render-2-2',
+          'Inner-didUpdate-2-2',
+        'Inner-callback-2',
+    'Outer-callback-2',
+  ]);
+  /* eslint-enable indent */
+});
+
+it('should flush updates in the correct order across roots', function() {
+  var instances = [];
+  var updates = [];
+
+  class MockComponent extends React.Component {
+    render() {
+      updates.push(this.props.depth);
+      return <div />;
+    }
+
+    componentDidMount() {
+      instances.push(this);
+      if (this.props.depth < this.props.count) {
+        ReactDOM.render(
+          <MockComponent
+            depth={this.props.depth + 1}
+            count={this.props.count}
+          />,
+          ReactDOM.findDOMNode(this)
+        );
+      }
+    }
+  }
+
+  ReactTestUtils.renderIntoDocument(<MockComponent depth={0} count={2} />);
+
+  expect(updates).toEqual([0, 1, 2]);
+
+  ReactUpdates.batchedUpdates(function() {
+    // Simulate update on each component from top to bottom.
+    instances.forEach(function(instance) {
+      instance.forceUpdate();
+    });
+  });
+
+  expect(updates).toEqual([0, 1, 2, 0, 1, 2]);
+});
+
+it('should queue nested updates', function() {
+  // See https://github.com/facebook/react/issues/1147
+
+  class X extends React.Component {
+    state = {s: 0};
+
+    render() {
+      if (this.state.s === 0) {
         return (
           <div>
-            <Z />
+            <span>0</span>
           </div>
         );
+      } else {
+        return <div>1</div>;
       }
     }
 
-    class Z extends React.Component {
-      render() {
-        return <div />;
-      }
+    go = () => {
+      this.setState({s: 1});
+      this.setState({s: 0});
+      this.setState({s: 1});
+    };
+  }
 
-      componentWillUpdate() {
-        x.go();
-      }
-    }
-
-    var x;
-    var y;
-
-    x = ReactTestUtils.renderIntoDocument(<X />);
-    y = ReactTestUtils.renderIntoDocument(<Y />);
-    expect(ReactDOM.findDOMNode(x).textContent).toBe('0');
-
-    y.forceUpdate();
-    expect(ReactDOM.findDOMNode(x).textContent).toBe('1');
-  });
-
-  it('should queue updates from during mount', function() {
-    // See https://github.com/facebook/react/issues/1353
-    var a;
-
-    class A extends React.Component {
-      state = {x: 0};
-
-      componentWillMount() {
-        a = this;
-      }
-
-      render() {
-        return <div>A{this.state.x}</div>;
-      }
-    }
-
-    class B extends React.Component {
-      componentWillMount() {
-        a.setState({x: 1});
-      }
-
-      render() {
-        return <div />;
-      }
-    }
-
-    ReactUpdates.batchedUpdates(function() {
-      ReactTestUtils.renderIntoDocument(
+  class Y extends React.Component {
+    render() {
+      return (
         <div>
-          <A />
-          <B />
+          <Z />
         </div>
       );
-    });
+    }
+  }
 
-    expect(a.state.x).toBe(1);
-    expect(ReactDOM.findDOMNode(a).textContent).toBe('A1');
+  class Z extends React.Component {
+    render() {
+      return <div />;
+    }
+
+    componentWillUpdate() {
+      x.go();
+    }
+  }
+
+  var x;
+  var y;
+
+  x = ReactTestUtils.renderIntoDocument(<X />);
+  y = ReactTestUtils.renderIntoDocument(<Y />);
+  expect(ReactDOM.findDOMNode(x).textContent).toBe('0');
+
+  y.forceUpdate();
+  expect(ReactDOM.findDOMNode(x).textContent).toBe('1');
+});
+
+it('should queue updates from during mount', function() {
+  // See https://github.com/facebook/react/issues/1353
+  var a;
+
+  class A extends React.Component {
+    state = {x: 0};
+
+    componentWillMount() {
+      a = this;
+    }
+
+    render() {
+      return <div>A{this.state.x}</div>;
+    }
+  }
+
+  class B extends React.Component {
+    componentWillMount() {
+      a.setState({x: 1});
+    }
+
+    render() {
+      return <div />;
+    }
+  }
+
+  ReactUpdates.batchedUpdates(function() {
+    ReactTestUtils.renderIntoDocument(
+      <div>
+        <A />
+        <B />
+      </div>
+    );
   });
 
-  it('calls componentWillReceiveProps setState callback properly', function() {
-    var callbackCount = 0;
+  expect(a.state.x).toBe(1);
+  expect(ReactDOM.findDOMNode(a).textContent).toBe('A1');
+});
 
-    class A extends React.Component {
-      state = {x: this.props.x};
+it('calls componentWillReceiveProps setState callback properly', function() {
+  var callbackCount = 0;
 
-      componentWillReceiveProps(nextProps) {
-        var newX = nextProps.x;
-        this.setState({x: newX}, function() {
-          // State should have updated by the time this callback gets called
-          expect(this.state.x).toBe(newX);
+  class A extends React.Component {
+    state = {x: this.props.x};
+
+    componentWillReceiveProps(nextProps) {
+      var newX = nextProps.x;
+      this.setState({x: newX}, function() {
+        // State should have updated by the time this callback gets called
+        expect(this.state.x).toBe(newX);
+        callbackCount++;
+      });
+    }
+
+    render() {
+      return <div>{this.state.x}</div>;
+    }
+  }
+
+  var container = document.createElement('div');
+  ReactDOM.render(<A x={1} />, container);
+  ReactDOM.render(<A x={2} />, container);
+  expect(callbackCount).toBe(1);
+});
+
+it('calls asap callbacks properly', function() {
+  var callbackCount = 0;
+
+  class A extends React.Component {
+    render() {
+      return <div />;
+    }
+
+    componentDidUpdate() {
+      ReactUpdates.asap(function() {
+        expect(this).toBe(component);
+        callbackCount++;
+        ReactUpdates.asap(function() {
           callbackCount++;
         });
-      }
+        expect(callbackCount).toBe(1);
+      }, component);
+      expect(callbackCount).toBe(0);
+    }
+  }
 
-      render() {
-        return <div>{this.state.x}</div>;
-      }
+  var component = ReactTestUtils.renderIntoDocument(<A />);
+  component.forceUpdate();
+  expect(callbackCount).toBe(2);
+});
+
+it('calls asap callbacks with queued updates', function() {
+  var log = [];
+
+  class A extends React.Component {
+    state = {updates: 0};
+
+    render() {
+      log.push('render-' + this.state.updates);
+      return <div />;
     }
 
-    var container = document.createElement('div');
-    ReactDOM.render(<A x={1} />, container);
-    ReactDOM.render(<A x={2} />, container);
-    expect(callbackCount).toBe(1);
-  });
-
-  it('calls asap callbacks properly', function() {
-    var callbackCount = 0;
-
-    class A extends React.Component {
-      render() {
-        return <div />;
-      }
-
-      componentDidUpdate() {
+    componentDidUpdate() {
+      if (this.state.updates === 1) {
         ReactUpdates.asap(function() {
-          expect(this).toBe(component);
-          callbackCount++;
-          ReactUpdates.asap(function() {
-            callbackCount++;
-          });
-          expect(callbackCount).toBe(1);
-        }, component);
-        expect(callbackCount).toBe(0);
-      }
-    }
-
-    var component = ReactTestUtils.renderIntoDocument(<A />);
-    component.forceUpdate();
-    expect(callbackCount).toBe(2);
-  });
-
-  it('calls asap callbacks with queued updates', function() {
-    var log = [];
-
-    class A extends React.Component {
-      state = {updates: 0};
-
-      render() {
-        log.push('render-' + this.state.updates);
-        return <div />;
-      }
-
-      componentDidUpdate() {
-        if (this.state.updates === 1) {
-          ReactUpdates.asap(function() {
-            this.setState({updates: 2}, function() {
-              ReactUpdates.asap(function() {
-                log.push('asap-1.2');
-              });
-              log.push('setState-cb');
+          this.setState({updates: 2}, function() {
+            ReactUpdates.asap(function() {
+              log.push('asap-1.2');
             });
-            log.push('asap-1.1');
-          }, this);
-        } else if (this.state.updates === 2) {
-          ReactUpdates.asap(function() {
-            log.push('asap-2');
+            log.push('setState-cb');
           });
-        }
-        log.push('didUpdate-' + this.state.updates);
+          log.push('asap-1.1');
+        }, this);
+      } else if (this.state.updates === 2) {
+        ReactUpdates.asap(function() {
+          log.push('asap-2');
+        });
       }
+      log.push('didUpdate-' + this.state.updates);
+    }
+  }
+
+  var component = ReactTestUtils.renderIntoDocument(<A />);
+  component.setState({updates: 1});
+  expect(log).toEqual([
+    'render-0',
+    // We do the first update...
+    'render-1',
+    'didUpdate-1',
+    // ...which calls asap and enqueues a second update...
+    'asap-1.1',
+    // ...which runs and enqueues the asap-2 log in its didUpdate...
+    'render-2',
+    'didUpdate-2',
+    // ...and runs the setState callback, which enqueues the log for
+    // asap-1.2.
+    'setState-cb',
+    'asap-2',
+    'asap-1.2',
+  ]);
+});
+
+it('does not call render after a component as been deleted', function() {
+  var renderCount = 0;
+  var componentB = null;
+
+  class B extends React.Component {
+    state = {updates: 0};
+
+    componentDidMount() {
+      componentB = this;
     }
 
-    var component = ReactTestUtils.renderIntoDocument(<A />);
-    component.setState({updates: 1});
-    expect(log).toEqual([
-      'render-0',
-      // We do the first update...
-      'render-1',
-      'didUpdate-1',
-      // ...which calls asap and enqueues a second update...
-      'asap-1.1',
-      // ...which runs and enqueues the asap-2 log in its didUpdate...
-      'render-2',
-      'didUpdate-2',
-      // ...and runs the setState callback, which enqueues the log for
-      // asap-1.2.
-      'setState-cb',
-      'asap-2',
-      'asap-1.2',
-    ]);
+    render() {
+      renderCount++;
+      return <div />;
+    }
+  }
+
+  class A extends React.Component {
+    state = {showB: true};
+
+    render() {
+      return this.state.showB ? <B /> : <div />;
+    }
+  }
+
+  var component = ReactTestUtils.renderIntoDocument(<A />);
+
+  ReactUpdates.batchedUpdates(function() {
+    // B will have scheduled an update but the batching should ensure that its
+    // update never fires.
+    componentB.setState({updates: 1});
+    component.setState({showB: false});
   });
 
-  it('does not call render after a component as been deleted', function() {
-    var renderCount = 0;
-    var componentB = null;
+  expect(renderCount).toBe(1);
+});
 
-    class B extends React.Component {
-      state = {updates: 0};
+it('marks top-level updates', function() {
+  var ReactFeatureFlags = require('ReactFeatureFlags');
 
-      componentDidMount() {
-        componentB = this;
-      }
-
-      render() {
-        renderCount++;
-        return <div />;
-      }
+  class Foo extends React.Component {
+    render() {
+      return <Bar />;
     }
+  }
 
-    class A extends React.Component {
-      state = {showB: true};
-
-      render() {
-        return this.state.showB ? <B /> : <div />;
-      }
+  class Bar extends React.Component {
+    render() {
+      return <div />;
     }
+  }
 
-    var component = ReactTestUtils.renderIntoDocument(<A />);
+  var container = document.createElement('div');
+  ReactDOM.render(<Foo />, container);
 
-    ReactUpdates.batchedUpdates(function() {
-      // B will have scheduled an update but the batching should ensure that its
-      // update never fires.
-      componentB.setState({updates: 1});
-      component.setState({showB: false});
-    });
+  try {
+    ReactFeatureFlags.logTopLevelRenders = true;
+    spyOn(console, 'time');
+    spyOn(console, 'timeEnd');
 
-    expect(renderCount).toBe(1);
-  });
-
-  it('marks top-level updates', function() {
-    var ReactFeatureFlags = require('ReactFeatureFlags');
-
-    class Foo extends React.Component {
-      render() {
-        return <Bar />;
-      }
-    }
-
-    class Bar extends React.Component {
-      render() {
-        return <div />;
-      }
-    }
-
-    var container = document.createElement('div');
     ReactDOM.render(<Foo />, container);
 
-    try {
-      ReactFeatureFlags.logTopLevelRenders = true;
-      spyOn(console, 'time');
-      spyOn(console, 'timeEnd');
+    expect(console.time.calls.count()).toBe(1);
+    expect(console.time.calls.argsFor(0)[0]).toBe('React update: Foo');
+    expect(console.timeEnd.calls.count()).toBe(1);
+    expect(console.timeEnd.calls.argsFor(0)[0]).toBe('React update: Foo');
+  } finally {
+    ReactFeatureFlags.logTopLevelRenders = false;
+  }
+});
 
-      ReactDOM.render(<Foo />, container);
+it('throws in setState if the update callback is not a function', function() {
+  function Foo() {
+    this.a = 1;
+    this.b = 2;
+  }
 
-      expect(console.time.calls.count()).toBe(1);
-      expect(console.time.calls.argsFor(0)[0]).toBe('React update: Foo');
-      expect(console.timeEnd.calls.count()).toBe(1);
-      expect(console.timeEnd.calls.argsFor(0)[0]).toBe('React update: Foo');
-    } finally {
-      ReactFeatureFlags.logTopLevelRenders = false;
+  class A extends React.Component {
+    state = {};
+
+    render() {
+      return <div />;
     }
+  }
+
+  var component = ReactTestUtils.renderIntoDocument(<A />);
+
+  expect(() => component.setState({}, 'no')).toThrowError(
+    'setState(...): Expected the last optional `callback` argument ' +
+    'to be a function. Instead received: string.'
+  );
+  expect(() => component.setState({}, {})).toThrowError(
+    'setState(...): Expected the last optional `callback` argument ' +
+    'to be a function. Instead received: Object.'
+  );
+  expect(() => component.setState({}, new Foo())).toThrowError(
+    'setState(...): Expected the last optional `callback` argument ' +
+    'to be a function. Instead received: Foo (keys: a, b).'
+  );
+});
+
+it('throws in replaceState if the update callback is not a function', function() {
+  function Foo() {
+    this.a = 1;
+    this.b = 2;
+  }
+  var A = React.createClass({
+    getInitialState: function() {
+      return {};
+    },
+    render: function() {
+      return <div />;
+    },
   });
+  var component = ReactTestUtils.renderIntoDocument(<A />);
 
-  it('throws in setState if the update callback is not a function', function() {
-    function Foo() {
-      this.a = 1;
-      this.b = 2;
+  expect(() => component.replaceState({}, 'no')).toThrowError(
+    'replaceState(...): Expected the last optional `callback` argument ' +
+    'to be a function. Instead received: string.'
+  );
+  expect(() => component.replaceState({}, {})).toThrowError(
+    'replaceState(...): Expected the last optional `callback` argument ' +
+    'to be a function. Instead received: Object.'
+  );
+  expect(() => component.replaceState({}, new Foo())).toThrowError(
+    'replaceState(...): Expected the last optional `callback` argument ' +
+    'to be a function. Instead received: Foo (keys: a, b).'
+  );
+});
+
+it('throws in forceUpdate if the update callback is not a function', function() {
+  function Foo() {
+    this.a = 1;
+    this.b = 2;
+  }
+
+  class A extends React.Component {
+    state = {};
+
+    render() {
+      return <div />;
     }
+  }
 
-    class A extends React.Component {
-      state = {};
+  var component = ReactTestUtils.renderIntoDocument(<A />);
 
-      render() {
-        return <div />;
+  expect(() => component.forceUpdate('no')).toThrowError(
+    'forceUpdate(...): Expected the last optional `callback` argument ' +
+    'to be a function. Instead received: string.'
+  );
+  expect(() => component.forceUpdate({})).toThrowError(
+    'forceUpdate(...): Expected the last optional `callback` argument ' +
+    'to be a function. Instead received: Object.'
+  );
+  expect(() => component.forceUpdate(new Foo())).toThrowError(
+    'forceUpdate(...): Expected the last optional `callback` argument ' +
+    'to be a function. Instead received: Foo (keys: a, b).'
+  );
+});
+
+it('does not update one component twice in a batch (#2410)', function() {
+  class Parent extends React.Component {
+    getChild = () => {
+      return this.refs.child;
+    };
+
+    render() {
+      return <Child ref="child" />;
+    }
+  }
+
+  var renderCount = 0;
+  var postRenderCount = 0;
+  var once = false;
+
+  class Child extends React.Component {
+    state = {updated: false};
+
+    componentWillUpdate() {
+      if (!once) {
+        once = true;
+        this.setState({updated: true});
       }
     }
 
-    var component = ReactTestUtils.renderIntoDocument(<A />);
+    componentDidMount() {
+      expect(renderCount).toBe(postRenderCount + 1);
+      postRenderCount++;
+    }
 
-    expect(() => component.setState({}, 'no')).toThrowError(
-      'setState(...): Expected the last optional `callback` argument ' +
-      'to be a function. Instead received: string.'
-    );
-    expect(() => component.setState({}, {})).toThrowError(
-      'setState(...): Expected the last optional `callback` argument ' +
-      'to be a function. Instead received: Object.'
-    );
-    expect(() => component.setState({}, new Foo())).toThrowError(
-      'setState(...): Expected the last optional `callback` argument ' +
-      'to be a function. Instead received: Foo (keys: a, b).'
-    );
+    componentDidUpdate() {
+      expect(renderCount).toBe(postRenderCount + 1);
+      postRenderCount++;
+    }
+
+    render() {
+      expect(renderCount).toBe(postRenderCount);
+      renderCount++;
+      return <div />;
+    }
+  }
+
+  var parent = ReactTestUtils.renderIntoDocument(<Parent />);
+  var child = parent.getChild();
+  ReactDOM.unstable_batchedUpdates(function() {
+    parent.forceUpdate();
+    child.forceUpdate();
   });
+});
 
-  it('throws in replaceState if the update callback is not a function', function() {
-    function Foo() {
-      this.a = 1;
-      this.b = 2;
+it('does not update one component twice in a batch (#6371)', function() {
+  var callbacks = [];
+  function emitChange() {
+    callbacks.forEach(c => c());
+  }
+
+  class App extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = { showChild: true };
     }
-    var A = React.createClass({
-      getInitialState: function() {
-        return {};
-      },
-      render: function() {
-        return <div />;
-      },
-    });
-    var component = ReactTestUtils.renderIntoDocument(<A />);
+    componentDidMount() {
+      this.setState({ showChild: false });
+    }
+    render() {
+      return (
+        <div>
+          <ForceUpdatesOnChange />
+          {this.state.showChild && <EmitsChangeOnUnmount />}
+        </div>
+      );
+    }
+  }
 
-    expect(() => component.replaceState({}, 'no')).toThrowError(
-      'replaceState(...): Expected the last optional `callback` argument ' +
-      'to be a function. Instead received: string.'
-    );
-    expect(() => component.replaceState({}, {})).toThrowError(
-      'replaceState(...): Expected the last optional `callback` argument ' +
-      'to be a function. Instead received: Object.'
-    );
-    expect(() => component.replaceState({}, new Foo())).toThrowError(
-      'replaceState(...): Expected the last optional `callback` argument ' +
-      'to be a function. Instead received: Foo (keys: a, b).'
-    );
+  class EmitsChangeOnUnmount extends React.Component {
+    componentWillUnmount() {
+      emitChange();
+    }
+    render() {
+      return null;
+    }
+  }
+
+  class ForceUpdatesOnChange extends React.Component {
+    componentDidMount() {
+      this.onChange = () => this.forceUpdate();
+      this.onChange();
+      callbacks.push(this.onChange);
+    }
+    componentWillUnmount() {
+      callbacks = callbacks.filter((c) => c !== this.onChange);
+    }
+    render() {
+      return <div key={Math.random()} onClick={function() {}} />;
+    }
+  }
+
+  ReactDOM.render(<App />, document.createElement('div'));
+});
+
+it('unstable_batchedUpdates should return value from a callback', function() {
+  var result = ReactDOM.unstable_batchedUpdates(function() {
+    return 42;
   });
-
-  it('throws in forceUpdate if the update callback is not a function', function() {
-    function Foo() {
-      this.a = 1;
-      this.b = 2;
-    }
-
-    class A extends React.Component {
-      state = {};
-
-      render() {
-        return <div />;
-      }
-    }
-
-    var component = ReactTestUtils.renderIntoDocument(<A />);
-
-    expect(() => component.forceUpdate('no')).toThrowError(
-      'forceUpdate(...): Expected the last optional `callback` argument ' +
-      'to be a function. Instead received: string.'
-    );
-    expect(() => component.forceUpdate({})).toThrowError(
-      'forceUpdate(...): Expected the last optional `callback` argument ' +
-      'to be a function. Instead received: Object.'
-    );
-    expect(() => component.forceUpdate(new Foo())).toThrowError(
-      'forceUpdate(...): Expected the last optional `callback` argument ' +
-      'to be a function. Instead received: Foo (keys: a, b).'
-    );
-  });
-
-  it('does not update one component twice in a batch (#2410)', function() {
-    class Parent extends React.Component {
-      getChild = () => {
-        return this.refs.child;
-      };
-
-      render() {
-        return <Child ref="child" />;
-      }
-    }
-
-    var renderCount = 0;
-    var postRenderCount = 0;
-    var once = false;
-
-    class Child extends React.Component {
-      state = {updated: false};
-
-      componentWillUpdate() {
-        if (!once) {
-          once = true;
-          this.setState({updated: true});
-        }
-      }
-
-      componentDidMount() {
-        expect(renderCount).toBe(postRenderCount + 1);
-        postRenderCount++;
-      }
-
-      componentDidUpdate() {
-        expect(renderCount).toBe(postRenderCount + 1);
-        postRenderCount++;
-      }
-
-      render() {
-        expect(renderCount).toBe(postRenderCount);
-        renderCount++;
-        return <div />;
-      }
-    }
-
-    var parent = ReactTestUtils.renderIntoDocument(<Parent />);
-    var child = parent.getChild();
-    ReactDOM.unstable_batchedUpdates(function() {
-      parent.forceUpdate();
-      child.forceUpdate();
-    });
-  });
-
-  it('does not update one component twice in a batch (#6371)', function() {
-    var callbacks = [];
-    function emitChange() {
-      callbacks.forEach(c => c());
-    }
-
-    class App extends React.Component {
-      constructor(props) {
-        super(props);
-        this.state = { showChild: true };
-      }
-      componentDidMount() {
-        this.setState({ showChild: false });
-      }
-      render() {
-        return (
-          <div>
-            <ForceUpdatesOnChange />
-            {this.state.showChild && <EmitsChangeOnUnmount />}
-          </div>
-        );
-      }
-    }
-
-    class EmitsChangeOnUnmount extends React.Component {
-      componentWillUnmount() {
-        emitChange();
-      }
-      render() {
-        return null;
-      }
-    }
-
-    class ForceUpdatesOnChange extends React.Component {
-      componentDidMount() {
-        this.onChange = () => this.forceUpdate();
-        this.onChange();
-        callbacks.push(this.onChange);
-      }
-      componentWillUnmount() {
-        callbacks = callbacks.filter((c) => c !== this.onChange);
-      }
-      render() {
-        return <div key={Math.random()} onClick={function() {}} />;
-      }
-    }
-
-    ReactDOM.render(<App />, document.createElement('div'));
-  });
-
-  it('unstable_batchedUpdates should return value from a callback', function() {
-    var result = ReactDOM.unstable_batchedUpdates(function() {
-      return 42;
-    });
-    expect(result).toEqual(42);
-  });
+  expect(result).toEqual(42);
 });

--- a/src/renderers/shared/stack/reconciler/__tests__/refs-destruction-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/refs-destruction-test.js
@@ -17,94 +17,92 @@ var ReactTestUtils;
 
 var TestComponent;
 
-describe('refs-destruction', function() {
-  beforeEach(function() {
-    jest.resetModuleRegistry();
+beforeEach(function() {
+  jest.resetModuleRegistry();
 
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactTestUtils = require('ReactTestUtils');
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactTestUtils = require('ReactTestUtils');
 
-    TestComponent = class extends React.Component {
-      render() {
-        return (
-          <div>
-            {this.props.destroy ? null :
-              <div ref="theInnerDiv">
-                Lets try to destroy this.
-              </div>
-            }
-          </div>
-        );
-      }
-    };
-  });
+  TestComponent = class extends React.Component {
+    render() {
+      return (
+        <div>
+          {this.props.destroy ? null :
+            <div ref="theInnerDiv">
+              Lets try to destroy this.
+            </div>
+          }
+        </div>
+      );
+    }
+  };
+});
 
-  it('should remove refs when destroying the parent', function() {
-    var container = document.createElement('div');
-    var testInstance = ReactDOM.render(<TestComponent />, container);
-    expect(ReactTestUtils.isDOMComponent(testInstance.refs.theInnerDiv))
-      .toBe(true);
-    expect(Object.keys(testInstance.refs || {}).length).toEqual(1);
-    ReactDOM.unmountComponentAtNode(container);
-    expect(Object.keys(testInstance.refs || {}).length).toEqual(0);
-  });
+it('should remove refs when destroying the parent', function() {
+  var container = document.createElement('div');
+  var testInstance = ReactDOM.render(<TestComponent />, container);
+  expect(ReactTestUtils.isDOMComponent(testInstance.refs.theInnerDiv))
+    .toBe(true);
+  expect(Object.keys(testInstance.refs || {}).length).toEqual(1);
+  ReactDOM.unmountComponentAtNode(container);
+  expect(Object.keys(testInstance.refs || {}).length).toEqual(0);
+});
 
-  it('should remove refs when destroying the child', function() {
-    var container = document.createElement('div');
-    var testInstance = ReactDOM.render(<TestComponent />, container);
-    expect(ReactTestUtils.isDOMComponent(testInstance.refs.theInnerDiv))
-      .toBe(true);
-    expect(Object.keys(testInstance.refs || {}).length).toEqual(1);
-    ReactDOM.render(<TestComponent destroy={true} />, container);
-    expect(Object.keys(testInstance.refs || {}).length).toEqual(0);
-  });
+it('should remove refs when destroying the child', function() {
+  var container = document.createElement('div');
+  var testInstance = ReactDOM.render(<TestComponent />, container);
+  expect(ReactTestUtils.isDOMComponent(testInstance.refs.theInnerDiv))
+    .toBe(true);
+  expect(Object.keys(testInstance.refs || {}).length).toEqual(1);
+  ReactDOM.render(<TestComponent destroy={true} />, container);
+  expect(Object.keys(testInstance.refs || {}).length).toEqual(0);
+});
 
-  it('should not error when destroying child with ref asynchronously', function() {
-    class Modal extends React.Component {
-      componentDidMount() {
-        this.div = document.createElement('div');
-        document.body.appendChild(this.div);
-        this.componentDidUpdate();
-      }
-
-      componentDidUpdate() {
-        ReactDOM.render(<div>{this.props.children}</div>, this.div);
-      }
-
-      componentWillUnmount() {
-        var self = this;
-        // some async animation
-        setTimeout(function() {
-          expect(function() {
-            ReactDOM.unmountComponentAtNode(self.div);
-          }).not.toThrow();
-          document.body.removeChild(self.div);
-        }, 0);
-      }
-
-      render() {
-        return null;
-      }
+it('should not error when destroying child with ref asynchronously', function() {
+  class Modal extends React.Component {
+    componentDidMount() {
+      this.div = document.createElement('div');
+      document.body.appendChild(this.div);
+      this.componentDidUpdate();
     }
 
-    class AppModal extends React.Component {
-      render() {
-        return (<Modal>
-          <a ref="ref"/>
-        </Modal>);
-      }
+    componentDidUpdate() {
+      ReactDOM.render(<div>{this.props.children}</div>, this.div);
     }
 
-    class App extends React.Component {
-      render() {
-        return this.props.hidden ? null : <AppModal onClose={this.close}/>;
-      }
+    componentWillUnmount() {
+      var self = this;
+      // some async animation
+      setTimeout(function() {
+        expect(function() {
+          ReactDOM.unmountComponentAtNode(self.div);
+        }).not.toThrow();
+        document.body.removeChild(self.div);
+      }, 0);
     }
 
-    var container = document.createElement('div');
-    ReactDOM.render(<App />, container);
-    ReactDOM.render(<App hidden={true}/>, container);
-    jest.runAllTimers();
-  });
+    render() {
+      return null;
+    }
+  }
+
+  class AppModal extends React.Component {
+    render() {
+      return (<Modal>
+        <a ref="ref"/>
+      </Modal>);
+    }
+  }
+
+  class App extends React.Component {
+    render() {
+      return this.props.hidden ? null : <AppModal onClose={this.close}/>;
+    }
+  }
+
+  var container = document.createElement('div');
+  ReactDOM.render(<App />, container);
+  ReactDOM.render(<App hidden={true}/>, container);
+  jest.runAllTimers();
 });

--- a/src/renderers/shared/utils/__tests__/Transaction-test.js
+++ b/src/renderers/shared/utils/__tests__/Transaction-test.js
@@ -15,295 +15,293 @@
 var Transaction;
 
 var INIT_ERRORED = 'initErrored';     // Just a dummy value to check for.
-describe('Transaction', function() {
-  beforeEach(function() {
-    jest.resetModuleRegistry();
-    Transaction = require('Transaction');
-  });
+beforeEach(function() {
+  jest.resetModuleRegistry();
+  Transaction = require('Transaction');
+});
+
+/**
+ * We should not invoke closers for inits that failed. We should pass init
+ * return values to closers when those inits are successful. We should not
+ * invoke the actual method when any of the initializers fail.
+ */
+it('should invoke closers with/only-with init returns', function() {
+  var throwInInit = function() {
+    throw new Error('close[0] should receive Transaction.OBSERVED_ERROR');
+  };
+
+  var performSideEffect;
+  var dontPerformThis = function() {
+    performSideEffect = 'This should never be set to this';
+  };
 
   /**
-   * We should not invoke closers for inits that failed. We should pass init
-   * return values to closers when those inits are successful. We should not
-   * invoke the actual method when any of the initializers fail.
+   * New test Transaction subclass.
    */
-  it('should invoke closers with/only-with init returns', function() {
-    var throwInInit = function() {
-      throw new Error('close[0] should receive Transaction.OBSERVED_ERROR');
-    };
-
-    var performSideEffect;
-    var dontPerformThis = function() {
-      performSideEffect = 'This should never be set to this';
-    };
-
-    /**
-     * New test Transaction subclass.
-     */
-    var TestTransaction = function() {
-      this.reinitializeTransaction();
-      this.firstCloseParam = INIT_ERRORED;   // WON'T be set to something else
-      this.secondCloseParam = INIT_ERRORED;  // WILL be set to something else
-      this.lastCloseParam = INIT_ERRORED;    // WON'T be set to something else
-    };
-    Object.assign(TestTransaction.prototype, Transaction);
-    TestTransaction.prototype.getTransactionWrappers = function() {
-      return [
-        {
-          initialize: throwInInit,
-          close: function(initResult) {
-            this.firstCloseParam = initResult;
-          },
+  var TestTransaction = function() {
+    this.reinitializeTransaction();
+    this.firstCloseParam = INIT_ERRORED;   // WON'T be set to something else
+    this.secondCloseParam = INIT_ERRORED;  // WILL be set to something else
+    this.lastCloseParam = INIT_ERRORED;    // WON'T be set to something else
+  };
+  Object.assign(TestTransaction.prototype, Transaction);
+  TestTransaction.prototype.getTransactionWrappers = function() {
+    return [
+      {
+        initialize: throwInInit,
+        close: function(initResult) {
+          this.firstCloseParam = initResult;
         },
-        {
-          initialize: function() {
-            return 'asdf';
-          },
-          close: function(initResult) {
-            this.secondCloseParam = initResult;
-          },
+      },
+      {
+        initialize: function() {
+          return 'asdf';
         },
-        {
-          initialize: throwInInit,
-          close: function(initResult) {
-            this.lastCloseParam = initResult;
-          },
+        close: function(initResult) {
+          this.secondCloseParam = initResult;
         },
-      ];
-    };
-
-    var transaction = new TestTransaction();
-
-    expect(function() {
-      transaction.perform(dontPerformThis);
-    }).toThrow();
-
-    expect(performSideEffect).toBe(undefined);
-    expect(transaction.firstCloseParam).toBe(INIT_ERRORED);
-    expect(transaction.secondCloseParam).toBe('asdf');
-    expect(transaction.lastCloseParam).toBe(INIT_ERRORED);
-    expect(transaction.isInTransaction()).toBe(false);
-  });
-
-  it('should invoke closers and wrapped method when inits success', function() {
-
-    var performSideEffect;
-    /**
-     * New test Transaction subclass.
-     */
-    var TestTransaction = function() {
-      this.reinitializeTransaction();
-      this.firstCloseParam = INIT_ERRORED;   // WILL be set to something else
-      this.secondCloseParam = INIT_ERRORED;  // WILL be set to something else
-      this.lastCloseParam = INIT_ERRORED;    // WILL be set to something else
-    };
-    Object.assign(TestTransaction.prototype, Transaction);
-    TestTransaction.prototype.getTransactionWrappers = function() {
-      return [
-        {
-          initialize: function() {
-            return 'firstResult';
-          },
-          close: function(initResult) {
-            this.firstCloseParam = initResult;
-          },
+      },
+      {
+        initialize: throwInInit,
+        close: function(initResult) {
+          this.lastCloseParam = initResult;
         },
-        {
-          initialize: function() {
-            return 'secondResult';
-          },
-          close: function(initResult) {
-            this.secondCloseParam = initResult;
-          },
-        },
-        {
-          initialize: function() {
-            return 'thirdResult';
-          },
-          close: function(initResult) {
-            this.lastCloseParam = initResult;
-          },
-        },
-      ];
-    };
+      },
+    ];
+  };
 
-    var transaction = new TestTransaction();
+  var transaction = new TestTransaction();
 
-    transaction.perform(function() {
-      performSideEffect = 'SIDE_EFFECT';
-    });
+  expect(function() {
+    transaction.perform(dontPerformThis);
+  }).toThrow();
 
-    expect(performSideEffect).toBe('SIDE_EFFECT');
-    expect(transaction.firstCloseParam).toBe('firstResult');
-    expect(transaction.secondCloseParam).toBe('secondResult');
-    expect(transaction.lastCloseParam).toBe('thirdResult');
-    expect(transaction.isInTransaction()).toBe(false);
-  });
+  expect(performSideEffect).toBe(undefined);
+  expect(transaction.firstCloseParam).toBe(INIT_ERRORED);
+  expect(transaction.secondCloseParam).toBe('asdf');
+  expect(transaction.lastCloseParam).toBe(INIT_ERRORED);
+  expect(transaction.isInTransaction()).toBe(false);
+});
 
+it('should invoke closers and wrapped method when inits success', function() {
+
+  var performSideEffect;
   /**
-   * When the operation throws, the transaction should throw, but all of the
-   * error-free closers should execute gracefully without issue. If a closer
-   * throws an error, the transaction should prefer to throw the error
-   * encountered earlier in the operation.
+   * New test Transaction subclass.
    */
-  it('should throw when wrapped operation throws', function() {
-
-    var performSideEffect;
-    /**
-     * New test Transaction subclass.
-     */
-    var TestTransaction = function() {
-      this.reinitializeTransaction();
-      this.firstCloseParam = INIT_ERRORED;   // WILL be set to something else
-      this.secondCloseParam = INIT_ERRORED;  // WILL be set to something else
-      this.lastCloseParam = INIT_ERRORED;    // WILL be set to something else
-    };
-    Object.assign(TestTransaction.prototype, Transaction);
-    // Now, none of the close/inits throw, but the operation we wrap will throw.
-    TestTransaction.prototype.getTransactionWrappers = function() {
-      return [
-        {
-          initialize: function() {
-            return 'firstResult';
-          },
-          close: function(initResult) {
-            this.firstCloseParam = initResult;
-          },
+  var TestTransaction = function() {
+    this.reinitializeTransaction();
+    this.firstCloseParam = INIT_ERRORED;   // WILL be set to something else
+    this.secondCloseParam = INIT_ERRORED;  // WILL be set to something else
+    this.lastCloseParam = INIT_ERRORED;    // WILL be set to something else
+  };
+  Object.assign(TestTransaction.prototype, Transaction);
+  TestTransaction.prototype.getTransactionWrappers = function() {
+    return [
+      {
+        initialize: function() {
+          return 'firstResult';
         },
-        {
-          initialize: function() {
-            return 'secondResult';
-          },
-          close: function(initResult) {
-            this.secondCloseParam = initResult;
-          },
+        close: function(initResult) {
+          this.firstCloseParam = initResult;
         },
-        {
-          initialize: function() {
-            return 'thirdResult';
-          },
-          close: function(initResult) {
-            this.lastCloseParam = initResult;
-          },
+      },
+      {
+        initialize: function() {
+          return 'secondResult';
         },
-        {
-          initialize: function() {
-            return 'fourthResult';
-          },
-          close: function(initResult) {
-            throw new Error('The transaction should throw a TypeError.');
-          },
+        close: function(initResult) {
+          this.secondCloseParam = initResult;
         },
-      ];
-    };
+      },
+      {
+        initialize: function() {
+          return 'thirdResult';
+        },
+        close: function(initResult) {
+          this.lastCloseParam = initResult;
+        },
+      },
+    ];
+  };
 
-    var transaction = new TestTransaction();
+  var transaction = new TestTransaction();
 
-    expect(function() {
-      var isTypeError = false;
-      try {
-        transaction.perform(function() {
-          throw new TypeError('Thrown in main wrapped operation');
-        });
-      } catch (err) {
-        isTypeError = (err instanceof TypeError);
-      }
-      return isTypeError;
-    }()).toBe(true);
-
-    expect(performSideEffect).toBe(undefined);
-    expect(transaction.firstCloseParam).toBe('firstResult');
-    expect(transaction.secondCloseParam).toBe('secondResult');
-    expect(transaction.lastCloseParam).toBe('thirdResult');
-    expect(transaction.isInTransaction()).toBe(false);
+  transaction.perform(function() {
+    performSideEffect = 'SIDE_EFFECT';
   });
 
-  it('should throw errors in transaction close', function() {
-    var TestTransaction = function() {
-      this.reinitializeTransaction();
-    };
-    Object.assign(TestTransaction.prototype, Transaction);
-    var exceptionMsg = 'This exception should throw.';
-    TestTransaction.prototype.getTransactionWrappers = function() {
-      return [
-        {
-          close: function(initResult) {
-            throw new Error(exceptionMsg);
-          },
-        },
-      ];
-    };
+  expect(performSideEffect).toBe('SIDE_EFFECT');
+  expect(transaction.firstCloseParam).toBe('firstResult');
+  expect(transaction.secondCloseParam).toBe('secondResult');
+  expect(transaction.lastCloseParam).toBe('thirdResult');
+  expect(transaction.isInTransaction()).toBe(false);
+});
 
-    var transaction = new TestTransaction();
-    expect(function() {
-      transaction.perform(function() {});
-    }).toThrowError(exceptionMsg);
-    expect(transaction.isInTransaction()).toBe(false);
+/**
+ * When the operation throws, the transaction should throw, but all of the
+ * error-free closers should execute gracefully without issue. If a closer
+ * throws an error, the transaction should prefer to throw the error
+ * encountered earlier in the operation.
+ */
+it('should throw when wrapped operation throws', function() {
+
+  var performSideEffect;
+  /**
+   * New test Transaction subclass.
+   */
+  var TestTransaction = function() {
+    this.reinitializeTransaction();
+    this.firstCloseParam = INIT_ERRORED;   // WILL be set to something else
+    this.secondCloseParam = INIT_ERRORED;  // WILL be set to something else
+    this.lastCloseParam = INIT_ERRORED;    // WILL be set to something else
+  };
+  Object.assign(TestTransaction.prototype, Transaction);
+  // Now, none of the close/inits throw, but the operation we wrap will throw.
+  TestTransaction.prototype.getTransactionWrappers = function() {
+    return [
+      {
+        initialize: function() {
+          return 'firstResult';
+        },
+        close: function(initResult) {
+          this.firstCloseParam = initResult;
+        },
+      },
+      {
+        initialize: function() {
+          return 'secondResult';
+        },
+        close: function(initResult) {
+          this.secondCloseParam = initResult;
+        },
+      },
+      {
+        initialize: function() {
+          return 'thirdResult';
+        },
+        close: function(initResult) {
+          this.lastCloseParam = initResult;
+        },
+      },
+      {
+        initialize: function() {
+          return 'fourthResult';
+        },
+        close: function(initResult) {
+          throw new Error('The transaction should throw a TypeError.');
+        },
+      },
+    ];
+  };
+
+  var transaction = new TestTransaction();
+
+  expect(function() {
+    var isTypeError = false;
+    try {
+      transaction.perform(function() {
+        throw new TypeError('Thrown in main wrapped operation');
+      });
+    } catch (err) {
+      isTypeError = (err instanceof TypeError);
+    }
+    return isTypeError;
+  }()).toBe(true);
+
+  expect(performSideEffect).toBe(undefined);
+  expect(transaction.firstCloseParam).toBe('firstResult');
+  expect(transaction.secondCloseParam).toBe('secondResult');
+  expect(transaction.lastCloseParam).toBe('thirdResult');
+  expect(transaction.isInTransaction()).toBe(false);
+});
+
+it('should throw errors in transaction close', function() {
+  var TestTransaction = function() {
+    this.reinitializeTransaction();
+  };
+  Object.assign(TestTransaction.prototype, Transaction);
+  var exceptionMsg = 'This exception should throw.';
+  TestTransaction.prototype.getTransactionWrappers = function() {
+    return [
+      {
+        close: function(initResult) {
+          throw new Error(exceptionMsg);
+        },
+      },
+    ];
+  };
+
+  var transaction = new TestTransaction();
+  expect(function() {
+    transaction.perform(function() {});
+  }).toThrowError(exceptionMsg);
+  expect(transaction.isInTransaction()).toBe(false);
+});
+
+it('should allow nesting of transactions', function() {
+  var performSideEffect;
+  var nestedPerformSideEffect;
+  /**
+   * New test Transaction subclass.
+   */
+  var TestTransaction = function() {
+    this.reinitializeTransaction();
+    this.firstCloseParam = INIT_ERRORED; // WILL be set to something else
+  };
+  Object.assign(TestTransaction.prototype, Transaction);
+  TestTransaction.prototype.getTransactionWrappers = function() {
+    return [
+      {
+        initialize: function() {
+          return 'firstResult';
+        },
+        close: function(initResult) {
+          this.firstCloseParam = initResult;
+        },
+      },
+      {
+        initialize: function() {
+          this.nestedTransaction = new NestedTransaction();
+        },
+        close: function() {
+          // Test performing a transaction in another transaction's close()
+          this.nestedTransaction.perform(function() {
+            nestedPerformSideEffect = 'NESTED_SIDE_EFFECT';
+          });
+        },
+      },
+    ];
+  };
+
+  var NestedTransaction = function() {
+    this.reinitializeTransaction();
+  };
+  Object.assign(NestedTransaction.prototype, Transaction);
+  NestedTransaction.prototype.getTransactionWrappers = function() {
+    return [
+      {
+        initialize: function() {
+          this.hasInitializedNested = true;
+        },
+        close: function() {
+          this.hasClosedNested = true;
+        },
+      },
+    ];
+  };
+
+  var transaction = new TestTransaction();
+
+  transaction.perform(function() {
+    performSideEffect = 'SIDE_EFFECT';
   });
 
-  it('should allow nesting of transactions', function() {
-    var performSideEffect;
-    var nestedPerformSideEffect;
-    /**
-     * New test Transaction subclass.
-     */
-    var TestTransaction = function() {
-      this.reinitializeTransaction();
-      this.firstCloseParam = INIT_ERRORED; // WILL be set to something else
-    };
-    Object.assign(TestTransaction.prototype, Transaction);
-    TestTransaction.prototype.getTransactionWrappers = function() {
-      return [
-        {
-          initialize: function() {
-            return 'firstResult';
-          },
-          close: function(initResult) {
-            this.firstCloseParam = initResult;
-          },
-        },
-        {
-          initialize: function() {
-            this.nestedTransaction = new NestedTransaction();
-          },
-          close: function() {
-            // Test performing a transaction in another transaction's close()
-            this.nestedTransaction.perform(function() {
-              nestedPerformSideEffect = 'NESTED_SIDE_EFFECT';
-            });
-          },
-        },
-      ];
-    };
-
-    var NestedTransaction = function() {
-      this.reinitializeTransaction();
-    };
-    Object.assign(NestedTransaction.prototype, Transaction);
-    NestedTransaction.prototype.getTransactionWrappers = function() {
-      return [
-        {
-          initialize: function() {
-            this.hasInitializedNested = true;
-          },
-          close: function() {
-            this.hasClosedNested = true;
-          },
-        },
-      ];
-    };
-
-    var transaction = new TestTransaction();
-
-    transaction.perform(function() {
-      performSideEffect = 'SIDE_EFFECT';
-    });
-
-    expect(performSideEffect).toBe('SIDE_EFFECT');
-    expect(nestedPerformSideEffect).toBe('NESTED_SIDE_EFFECT');
-    expect(transaction.firstCloseParam).toBe('firstResult');
-    expect(transaction.isInTransaction()).toBe(false);
-    expect(transaction.nestedTransaction.hasClosedNested).toBe(true);
-    expect(transaction.nestedTransaction.hasInitializedNested).toBe(true);
-    expect(transaction.nestedTransaction.isInTransaction()).toBe(false);
-  });
+  expect(performSideEffect).toBe('SIDE_EFFECT');
+  expect(nestedPerformSideEffect).toBe('NESTED_SIDE_EFFECT');
+  expect(transaction.firstCloseParam).toBe('firstResult');
+  expect(transaction.isInTransaction()).toBe(false);
+  expect(transaction.nestedTransaction.hasClosedNested).toBe(true);
+  expect(transaction.nestedTransaction.hasInitializedNested).toBe(true);
+  expect(transaction.nestedTransaction.isInTransaction()).toBe(false);
 });

--- a/src/renderers/shared/utils/__tests__/accumulateInto-test.js
+++ b/src/renderers/shared/utils/__tests__/accumulateInto-test.js
@@ -13,40 +13,37 @@
 
 var accumulateInto;
 
-describe('accumulateInto', function() {
+beforeEach(function() {
+  accumulateInto = require('accumulateInto');
+});
 
-  beforeEach(function() {
-    accumulateInto = require('accumulateInto');
-  });
+it('throws if the second item is null', function() {
+  expect(function() {
+    accumulateInto([], null);
+  }).toThrowError(
+    'accumulateInto(...): Accumulated items must not be null or undefined.'
+  );
+});
 
-  it('throws if the second item is null', function() {
-    expect(function() {
-      accumulateInto([], null);
-    }).toThrowError(
-      'accumulateInto(...): Accumulated items must not be null or undefined.'
-    );
-  });
+it('returns the second item if first is null', function() {
+  var a = [];
+  expect(accumulateInto(null, a)).toBe(a);
+});
 
-  it('returns the second item if first is null', function() {
-    var a = [];
-    expect(accumulateInto(null, a)).toBe(a);
-  });
+it('merges the second into the first if first item is an array', function() {
+  var a = [1, 2];
+  var b = [3, 4];
+  accumulateInto(a, b);
+  expect(a).toEqual([1, 2, 3, 4]);
+  expect(b).toEqual([3, 4]);
+  var c = [1];
+  accumulateInto(c, 2);
+  expect(c).toEqual([1, 2]);
+});
 
-  it('merges the second into the first if first item is an array', function() {
-    var a = [1, 2];
-    var b = [3, 4];
-    accumulateInto(a, b);
-    expect(a).toEqual([1, 2, 3, 4]);
-    expect(b).toEqual([3, 4]);
-    var c = [1];
-    accumulateInto(c, 2);
-    expect(c).toEqual([1, 2]);
-  });
-
-  it('returns a new array if first or both items are scalar', function() {
-    var a = [2];
-    expect(accumulateInto(1, a)).toEqual([1, 2]);
-    expect(a).toEqual([2]);
-    expect(accumulateInto(1, 2)).toEqual([1, 2]);
-  });
+it('returns a new array if first or both items are scalar', function() {
+  var a = [2];
+  expect(accumulateInto(1, a)).toEqual([1, 2]);
+  expect(a).toEqual([2]);
+  expect(accumulateInto(1, 2)).toEqual([1, 2]);
 });

--- a/src/renderers/shared/utils/__tests__/adler32-test.js
+++ b/src/renderers/shared/utils/__tests__/adler32-test.js
@@ -13,29 +13,27 @@
 
 var adler32 = require('adler32');
 
-describe('adler32', function() {
-  it('generates differing checksums', function() {
-    expect(adler32('foo')).not.toBe(adler32('bar'));
-  });
+it('generates differing checksums', function() {
+  expect(adler32('foo')).not.toBe(adler32('bar'));
+});
 
-  it('generates consistent checksums', function() {
-    expect(adler32('linux')).toBe(adler32('linux'));
-  });
+it('generates consistent checksums', function() {
+  expect(adler32('linux')).toBe(adler32('linux'));
+});
 
-  it('is case sensitive', function() {
-    expect(adler32('a')).not.toBe(adler32('A'));
-  });
+it('is case sensitive', function() {
+  expect(adler32('a')).not.toBe(adler32('A'));
+});
 
-  it('doesn\'t barf on large inputs', function() {
-    var str = '';
-    for (var i = 0; i < 100000; i++) {
-      str += 'This will be repeated to be very large indeed. ';
-    }
-    expect(adler32(str)).toBe(692898118);
-  });
+it('doesn\'t barf on large inputs', function() {
+  var str = '';
+  for (var i = 0; i < 100000; i++) {
+    str += 'This will be repeated to be very large indeed. ';
+  }
+  expect(adler32(str)).toBe(692898118);
+});
 
-  it('doesn\'t barf on international inputs', function() {
-    var str = 'Linux 是一個真棒操作系統!';
-    expect(adler32(str)).toBe(-1183804097);
-  });
+it('doesn\'t barf on international inputs', function() {
+  var str = 'Linux 是一個真棒操作系統!';
+  expect(adler32(str)).toBe(-1183804097);
 });

--- a/src/renderers/testing/__tests__/ReactTestRenderer-test.js
+++ b/src/renderers/testing/__tests__/ReactTestRenderer-test.js
@@ -14,254 +14,250 @@
 var React = require('React');
 var ReactTestRenderer = require('ReactTestRenderer');
 
-describe('ReactTestRenderer', function() {
+it('renders a simple component', function() {
+  function Link() {
+    return <a role="link" />;
+  }
+  var renderer = ReactTestRenderer.create(<Link />);
+  expect(renderer.toJSON()).toEqual({
+    type: 'a',
+    props: { role: 'link' },
+    children: null,
+  });
+});
 
-  it('renders a simple component', function() {
-    function Link() {
-      return <a role="link" />;
+it('renders a top-level empty component', function() {
+  function Empty() {
+    return null;
+  }
+  var renderer = ReactTestRenderer.create(<Empty />);
+  expect(renderer.toJSON()).toEqual(null);
+});
+
+it('exposes a type flag', function() {
+  function Link() {
+    return <a role="link" />;
+  }
+  var renderer = ReactTestRenderer.create(<Link />);
+  var object = renderer.toJSON();
+  expect(object.$$typeof).toBe(Symbol.for('react.test.json'));
+
+  // $$typeof should not be enumerable.
+  for (var key in object) {
+    if (Object.prototype.hasOwnProperty.call(object, key)) {
+      expect(key).not.toBe('$$typeof');
     }
-    var renderer = ReactTestRenderer.create(<Link />);
-    expect(renderer.toJSON()).toEqual({
-      type: 'a',
-      props: { role: 'link' },
-      children: null,
-    });
+  }
+});
+
+it('renders some basics with an update', function() {
+  var renders = 0;
+
+  class Component extends React.Component {
+    state = {x: 3};
+
+    render() {
+      renders++;
+      return (
+        <div className="purple">
+          {this.state.x}
+          <Child />
+          <Null />
+        </div>
+      );
+    }
+
+    componentDidMount() {
+      this.setState({x: 7});
+    }
+  }
+
+  var Child = () => (renders++, <moo />);
+  var Null = () => (renders++, null);
+
+  var renderer = ReactTestRenderer.create(<Component />);
+  expect(renderer.toJSON()).toEqual({
+    type: 'div',
+    props: { className: 'purple' },
+    children: [
+      7,
+      { type: 'moo', props: {}, children: null },
+    ],
+  });
+  expect(renders).toBe(6);
+});
+
+it('exposes the instance', function() {
+  class Mouse extends React.Component {
+    constructor() {
+      super();
+      this.state = {mouse: 'mouse'};
+    }
+    handleMoose() {
+      this.setState({mouse: 'moose'});
+    }
+    render() {
+      return <div>{this.state.mouse}</div>;
+    }
+  }
+  var renderer = ReactTestRenderer.create(<Mouse />);
+
+  expect(renderer.toJSON()).toEqual({
+    type: 'div',
+    props: {},
+    children: ['mouse'],
   });
 
-  it('renders a top-level empty component', function() {
-    function Empty() {
-      return null;
-    }
-    var renderer = ReactTestRenderer.create(<Empty />);
-    expect(renderer.toJSON()).toEqual(null);
+  var mouse = renderer.getInstance();
+  mouse.handleMoose();
+  expect(renderer.toJSON()).toEqual({
+    type: 'div',
+    props: {},
+    children: ['moose'],
+  });
+});
+
+it('updates types', function() {
+  var renderer = ReactTestRenderer.create(<div>mouse</div>);
+  expect(renderer.toJSON()).toEqual({
+    type: 'div',
+    props: {},
+    children: ['mouse'],
   });
 
-  it('exposes a type flag', function() {
-    function Link() {
-      return <a role="link" />;
-    }
-    var renderer = ReactTestRenderer.create(<Link />);
-    var object = renderer.toJSON();
-    expect(object.$$typeof).toBe(Symbol.for('react.test.json'));
+  renderer.update(<span>mice</span>);
+  expect(renderer.toJSON()).toEqual({
+    type: 'span',
+    props: {},
+    children: ['mice'],
+  });
+});
 
-    // $$typeof should not be enumerable.
-    for (var key in object) {
-      if (Object.prototype.hasOwnProperty.call(object, key)) {
-        expect(key).not.toBe('$$typeof');
-      }
-    }
+it('updates children', function() {
+  var renderer = ReactTestRenderer.create(
+    <div>
+      <span key="a">A</span>
+      <span key="b">B</span>
+      <span key="c">C</span>
+    </div>
+  );
+  expect(renderer.toJSON()).toEqual({
+    type: 'div',
+    props: {},
+    children: [
+      {type: 'span', props: {}, children: ['A']},
+      {type: 'span', props: {}, children: ['B']},
+      {type: 'span', props: {}, children: ['C']},
+    ],
   });
 
-  it('renders some basics with an update', function() {
-    var renders = 0;
+  renderer.update(
+    <div>
+      <span key="d">D</span>
+      <span key="c">C</span>
+      <span key="b">B</span>
+    </div>
+  );
+  expect(renderer.toJSON()).toEqual({
+    type: 'div',
+    props: {},
+    children: [
+      {type: 'span', props: {}, children: ['D']},
+      {type: 'span', props: {}, children: ['C']},
+      {type: 'span', props: {}, children: ['B']},
+    ],
+  });
+});
 
-    class Component extends React.Component {
-      state = {x: 3};
+it('does the full lifecycle', function() {
+  var log = [];
+  class Log extends React.Component {
+    render() {
+      log.push('render ' + this.props.name);
+      return <div />;
+    }
+    componentDidMount() {
+      log.push('mount ' + this.props.name);
+    }
+    componentWillUnmount() {
+      log.push('unmount ' + this.props.name);
+    }
+  }
 
-      render() {
-        renders++;
+  var renderer = ReactTestRenderer.create(<Log key="foo" name="Foo" />);
+  renderer.update(<Log key="bar" name="Bar" />);
+  renderer.unmount();
+
+  expect(log).toEqual([
+    'render Foo',
+    'mount Foo',
+    'unmount Foo',
+    'render Bar',
+    'mount Bar',
+    'unmount Bar',
+  ]);
+});
+
+it('gives a ref to native components', function() {
+  var log = [];
+  ReactTestRenderer.create(<div ref={(r) => log.push(r)} />);
+  expect(log).toEqual([null]);
+});
+
+it('supports error boundaries', function() {
+  var log = [];
+  class Angry extends React.Component {
+    render() {
+      log.push('Angry render');
+      throw new Error('Please, do not render me.');
+    }
+    componentDidMount() {
+      log.push('Angry componentDidMount');
+    }
+    componentWillUnmount() {
+      log.push('Angry componentWillUnmount');
+    }
+  }
+
+  class Boundary extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {error: false};
+    }
+    render() {
+      log.push('Boundary render');
+      if (!this.state.error) {
         return (
-          <div className="purple">
-            {this.state.x}
-            <Child />
-            <Null />
-          </div>
+          <div><button onClick={this.onClick}>ClickMe</button><Angry /></div>
         );
-      }
-
-      componentDidMount() {
-        this.setState({x: 7});
+      } else {
+        return <div>Happy Birthday!</div>;
       }
     }
-
-    var Child = () => (renders++, <moo />);
-    var Null = () => (renders++, null);
-
-    var renderer = ReactTestRenderer.create(<Component />);
-    expect(renderer.toJSON()).toEqual({
-      type: 'div',
-      props: { className: 'purple' },
-      children: [
-        7,
-        { type: 'moo', props: {}, children: null },
-      ],
-    });
-    expect(renders).toBe(6);
-  });
-
-  it('exposes the instance', function() {
-    class Mouse extends React.Component {
-      constructor() {
-        super();
-        this.state = {mouse: 'mouse'};
-      }
-      handleMoose() {
-        this.setState({mouse: 'moose'});
-      }
-      render() {
-        return <div>{this.state.mouse}</div>;
-      }
+    componentDidMount() {
+      log.push('Boundary componentDidMount');
     }
-    var renderer = ReactTestRenderer.create(<Mouse />);
-
-    expect(renderer.toJSON()).toEqual({
-      type: 'div',
-      props: {},
-      children: ['mouse'],
-    });
-
-    var mouse = renderer.getInstance();
-    mouse.handleMoose();
-    expect(renderer.toJSON()).toEqual({
-      type: 'div',
-      props: {},
-      children: ['moose'],
-    });
-  });
-
-  it('updates types', function() {
-    var renderer = ReactTestRenderer.create(<div>mouse</div>);
-    expect(renderer.toJSON()).toEqual({
-      type: 'div',
-      props: {},
-      children: ['mouse'],
-    });
-
-    renderer.update(<span>mice</span>);
-    expect(renderer.toJSON()).toEqual({
-      type: 'span',
-      props: {},
-      children: ['mice'],
-    });
-  });
-
-  it('updates children', function() {
-    var renderer = ReactTestRenderer.create(
-      <div>
-        <span key="a">A</span>
-        <span key="b">B</span>
-        <span key="c">C</span>
-      </div>
-    );
-    expect(renderer.toJSON()).toEqual({
-      type: 'div',
-      props: {},
-      children: [
-        {type: 'span', props: {}, children: ['A']},
-        {type: 'span', props: {}, children: ['B']},
-        {type: 'span', props: {}, children: ['C']},
-      ],
-    });
-
-    renderer.update(
-      <div>
-        <span key="d">D</span>
-        <span key="c">C</span>
-        <span key="b">B</span>
-      </div>
-    );
-    expect(renderer.toJSON()).toEqual({
-      type: 'div',
-      props: {},
-      children: [
-        {type: 'span', props: {}, children: ['D']},
-        {type: 'span', props: {}, children: ['C']},
-        {type: 'span', props: {}, children: ['B']},
-      ],
-    });
-  });
-
-  it('does the full lifecycle', function() {
-    var log = [];
-    class Log extends React.Component {
-      render() {
-        log.push('render ' + this.props.name);
-        return <div />;
-      }
-      componentDidMount() {
-        log.push('mount ' + this.props.name);
-      }
-      componentWillUnmount() {
-        log.push('unmount ' + this.props.name);
-      }
+    componentWillUnmount() {
+      log.push('Boundary componentWillUnmount');
     }
-
-    var renderer = ReactTestRenderer.create(<Log key="foo" name="Foo" />);
-    renderer.update(<Log key="bar" name="Bar" />);
-    renderer.unmount();
-
-    expect(log).toEqual([
-      'render Foo',
-      'mount Foo',
-      'unmount Foo',
-      'render Bar',
-      'mount Bar',
-      'unmount Bar',
-    ]);
-  });
-
-  it('gives a ref to native components', function() {
-    var log = [];
-    ReactTestRenderer.create(<div ref={(r) => log.push(r)} />);
-    expect(log).toEqual([null]);
-  });
-
-  it('supports error boundaries', function() {
-    var log = [];
-    class Angry extends React.Component {
-      render() {
-        log.push('Angry render');
-        throw new Error('Please, do not render me.');
-      }
-      componentDidMount() {
-        log.push('Angry componentDidMount');
-      }
-      componentWillUnmount() {
-        log.push('Angry componentWillUnmount');
-      }
+    onClick() {
+      /* do nothing */
     }
-
-    class Boundary extends React.Component {
-      constructor(props) {
-        super(props);
-        this.state = {error: false};
-      }
-      render() {
-        log.push('Boundary render');
-        if (!this.state.error) {
-          return (
-            <div><button onClick={this.onClick}>ClickMe</button><Angry /></div>
-          );
-        } else {
-          return <div>Happy Birthday!</div>;
-        }
-      }
-      componentDidMount() {
-        log.push('Boundary componentDidMount');
-      }
-      componentWillUnmount() {
-        log.push('Boundary componentWillUnmount');
-      }
-      onClick() {
-        /* do nothing */
-      }
-      unstable_handleError() {
-        this.setState({error: true});
-      }
+    unstable_handleError() {
+      this.setState({error: true});
     }
+  }
 
-    var renderer = ReactTestRenderer.create(<Boundary />);
-    expect(renderer.toJSON()).toEqual({
-      type: 'div',
-      props: {},
-      children: ['Happy Birthday!'],
-    });
-    expect(log).toEqual([
-      'Boundary render',
-      'Angry render',
-      'Boundary render',
-      'Boundary componentDidMount',
-    ]);
+  var renderer = ReactTestRenderer.create(<Boundary />);
+  expect(renderer.toJSON()).toEqual({
+    type: 'div',
+    props: {},
+    children: ['Happy Birthday!'],
   });
-
+  expect(log).toEqual([
+    'Boundary render',
+    'Angry render',
+    'Boundary render',
+    'Boundary componentDidMount',
+  ]);
 });

--- a/src/shared/utils/__tests__/KeyEscapeUtils-test.js
+++ b/src/shared/utils/__tests__/KeyEscapeUtils-test.js
@@ -13,26 +13,24 @@
 
 var KeyEscapeUtils;
 
-describe('KeyEscapeUtils', () => {
-  beforeEach(() => {
-    jest.resetModuleRegistry();
+beforeEach(() => {
+  jest.resetModuleRegistry();
 
-    KeyEscapeUtils = require('KeyEscapeUtils');
+  KeyEscapeUtils = require('KeyEscapeUtils');
+});
+
+describe('escape', () => {
+  it('should properly escape and wrap user defined keys', () => {
+    expect(KeyEscapeUtils.escape('1')).toBe('$1');
+    expect(KeyEscapeUtils.escape('1=::=2')).toBe('$1=0=2=2=02');
   });
+});
 
-  describe('escape', () => {
-    it('should properly escape and wrap user defined keys', () => {
-      expect(KeyEscapeUtils.escape('1')).toBe('$1');
-      expect(KeyEscapeUtils.escape('1=::=2')).toBe('$1=0=2=2=02');
-    });
-  });
-
-  describe('unescape', () => {
-    it('should properly unescape and unwrap user defined keys', () => {
-      expect(KeyEscapeUtils.unescape('.1')).toBe('1');
-      expect(KeyEscapeUtils.unescape('$1')).toBe('1');
-      expect(KeyEscapeUtils.unescape('.$1')).toBe('1');
-      expect(KeyEscapeUtils.unescape('$1=0=2=2=02')).toBe('1=::=2');
-    });
+describe('unescape', () => {
+  it('should properly unescape and unwrap user defined keys', () => {
+    expect(KeyEscapeUtils.unescape('.1')).toBe('1');
+    expect(KeyEscapeUtils.unescape('$1')).toBe('1');
+    expect(KeyEscapeUtils.unescape('.$1')).toBe('1');
+    expect(KeyEscapeUtils.unescape('$1=0=2=2=02')).toBe('1=::=2');
   });
 });

--- a/src/shared/utils/__tests__/PooledClass-test.js
+++ b/src/shared/utils/__tests__/PooledClass-test.js
@@ -14,114 +14,112 @@
 var PooledClass;
 var PoolableClass;
 
-describe('Pooled class', function() {
-  beforeEach(function() {
-    PooledClass = require('PooledClass');
-    PoolableClass = function() {};
-    PoolableClass.prototype.destructor = function() {};
-    PooledClass.addPoolingTo(PoolableClass);
-  });
+beforeEach(function() {
+  PooledClass = require('PooledClass');
+  PoolableClass = function() {};
+  PoolableClass.prototype.destructor = function() {};
+  PooledClass.addPoolingTo(PoolableClass);
+});
 
-  it('should initialize a pool correctly', function() {
-    expect(PoolableClass.instancePool).toBeDefined();
-  });
+it('should initialize a pool correctly', function() {
+  expect(PoolableClass.instancePool).toBeDefined();
+});
 
-  it('should return a new instance when the pool is empty', function() {
-    var instance = PoolableClass.getPooled();
-    expect(instance instanceof PoolableClass).toBe(true);
-  });
+it('should return a new instance when the pool is empty', function() {
+  var instance = PoolableClass.getPooled();
+  expect(instance instanceof PoolableClass).toBe(true);
+});
 
-  it('should return the instance back into the pool when it gets released',
-    function() {
-      var instance = PoolableClass.getPooled();
-      PoolableClass.release(instance);
-      expect(PoolableClass.instancePool.length).toBe(1);
-      expect(PoolableClass.instancePool[0]).toBe(instance);
-    }
-  );
-
-  it('should return an old instance if available in the pool', function() {
+it('should return the instance back into the pool when it gets released',
+  function() {
     var instance = PoolableClass.getPooled();
     PoolableClass.release(instance);
-    var instance2 = PoolableClass.getPooled();
-    expect(instance).toBe(instance2);
-  });
+    expect(PoolableClass.instancePool.length).toBe(1);
+    expect(PoolableClass.instancePool[0]).toBe(instance);
+  }
+);
 
-  it('should call the destructor when instance gets released', function() {
-    var log = [];
-    var PoolableClassWithDestructor = function() {};
-    PoolableClassWithDestructor.prototype.destructor = function() {
-      log.push('released');
-    };
-    PooledClass.addPoolingTo(PoolableClassWithDestructor);
-    var instance = PoolableClassWithDestructor.getPooled();
-    PoolableClassWithDestructor.release(instance);
-    expect(log).toEqual(['released']);
-  });
+it('should return an old instance if available in the pool', function() {
+  var instance = PoolableClass.getPooled();
+  PoolableClass.release(instance);
+  var instance2 = PoolableClass.getPooled();
+  expect(instance).toBe(instance2);
+});
 
-  it('should accept poolers with different arguments', function() {
-    var log = [];
-    var PoolableClassWithMultiArguments = function(a, b) {
-      log.push(a, b);
-    };
-    PoolableClassWithMultiArguments.prototype.destructor = function() {};
-    PooledClass.addPoolingTo(
-      PoolableClassWithMultiArguments,
-      PooledClass.twoArgumentPooler
-    );
-    PoolableClassWithMultiArguments.getPooled('a', 'b', 'c');
-    expect(log).toEqual(['a', 'b']);
-  });
+it('should call the destructor when instance gets released', function() {
+  var log = [];
+  var PoolableClassWithDestructor = function() {};
+  PoolableClassWithDestructor.prototype.destructor = function() {
+    log.push('released');
+  };
+  PooledClass.addPoolingTo(PoolableClassWithDestructor);
+  var instance = PoolableClassWithDestructor.getPooled();
+  PoolableClassWithDestructor.release(instance);
+  expect(log).toEqual(['released']);
+});
 
-  it('should call a new constructor with arguments', function() {
-    var log = [];
-    var PoolableClassWithOneArgument = function(a) {
-      log.push(a);
-    };
-    PoolableClassWithOneArgument.prototype.destructor = function() {};
-    PooledClass.addPoolingTo(
-      PoolableClassWithOneArgument
-    );
-    PoolableClassWithOneArgument.getPooled('new');
-    expect(log).toEqual(['new']);
-  });
-
-  it('should call an old constructor with arguments', function() {
-    var log = [];
-    var PoolableClassWithOneArgument = function(a) {
-      log.push(a);
-    };
-    PoolableClassWithOneArgument.prototype.destructor = function() {};
-    PooledClass.addPoolingTo(
-      PoolableClassWithOneArgument
-    );
-    var instance = PoolableClassWithOneArgument.getPooled('new');
-    PoolableClassWithOneArgument.release(instance);
-    PoolableClassWithOneArgument.getPooled('old');
-    expect(log).toEqual(['new', 'old']);
-  });
-
-  it('should throw when the class releases an instance of a different type',
-    function() {
-      var RandomClass = function() {};
-      RandomClass.prototype.destructor = function() {};
-      PooledClass.addPoolingTo(RandomClass);
-      var randomInstance = RandomClass.getPooled();
-      PoolableClass.getPooled();
-      expect(function() {
-        PoolableClass.release(randomInstance);
-      }).toThrowError(
-        'Trying to release an instance into a pool of a different type.'
-      );
-    }
+it('should accept poolers with different arguments', function() {
+  var log = [];
+  var PoolableClassWithMultiArguments = function(a, b) {
+    log.push(a, b);
+  };
+  PoolableClassWithMultiArguments.prototype.destructor = function() {};
+  PooledClass.addPoolingTo(
+    PoolableClassWithMultiArguments,
+    PooledClass.twoArgumentPooler
   );
+  PoolableClassWithMultiArguments.getPooled('a', 'b', 'c');
+  expect(log).toEqual(['a', 'b']);
+});
 
-  it('should throw if no destructor is defined', function() {
-    var ImmortalClass = function() {};
-    PooledClass.addPoolingTo(ImmortalClass);
-    var inst = ImmortalClass.getPooled();
+it('should call a new constructor with arguments', function() {
+  var log = [];
+  var PoolableClassWithOneArgument = function(a) {
+    log.push(a);
+  };
+  PoolableClassWithOneArgument.prototype.destructor = function() {};
+  PooledClass.addPoolingTo(
+    PoolableClassWithOneArgument
+  );
+  PoolableClassWithOneArgument.getPooled('new');
+  expect(log).toEqual(['new']);
+});
+
+it('should call an old constructor with arguments', function() {
+  var log = [];
+  var PoolableClassWithOneArgument = function(a) {
+    log.push(a);
+  };
+  PoolableClassWithOneArgument.prototype.destructor = function() {};
+  PooledClass.addPoolingTo(
+    PoolableClassWithOneArgument
+  );
+  var instance = PoolableClassWithOneArgument.getPooled('new');
+  PoolableClassWithOneArgument.release(instance);
+  PoolableClassWithOneArgument.getPooled('old');
+  expect(log).toEqual(['new', 'old']);
+});
+
+it('should throw when the class releases an instance of a different type',
+  function() {
+    var RandomClass = function() {};
+    RandomClass.prototype.destructor = function() {};
+    PooledClass.addPoolingTo(RandomClass);
+    var randomInstance = RandomClass.getPooled();
+    PoolableClass.getPooled();
     expect(function() {
-      ImmortalClass.release(inst);
-    }).toThrow();
-  });
+      PoolableClass.release(randomInstance);
+    }).toThrowError(
+      'Trying to release an instance into a pool of a different type.'
+    );
+  }
+);
+
+it('should throw if no destructor is defined', function() {
+  var ImmortalClass = function() {};
+  PooledClass.addPoolingTo(ImmortalClass);
+  var inst = ImmortalClass.getPooled();
+  expect(function() {
+    ImmortalClass.release(inst);
+  }).toThrow();
 });

--- a/src/shared/utils/__tests__/reactProdInvariant-test.js
+++ b/src/shared/utils/__tests__/reactProdInvariant-test.js
@@ -12,38 +12,36 @@
 
 var reactProdInvariant;
 
-describe('reactProdInvariant', function() {
-  beforeEach(function() {
-    jest.resetModuleRegistry();
-    reactProdInvariant = require('reactProdInvariant');
-  });
+beforeEach(function() {
+  jest.resetModuleRegistry();
+  reactProdInvariant = require('reactProdInvariant');
+});
 
-  it('should throw with the correct number of `%s`s in the URL', function() {
-    expect(function() {
-      reactProdInvariant(124, 'foo', 'bar');
-    }).toThrowError(
-      'Minified React error #124; visit ' +
-      'http://facebook.github.io/react/docs/error-decoder.html?invariant=124&args[]=foo&args[]=bar' +
-      ' for the full message or use the non-minified dev environment' +
-      ' for full errors and additional helpful warnings.'
-    );
+it('should throw with the correct number of `%s`s in the URL', function() {
+  expect(function() {
+    reactProdInvariant(124, 'foo', 'bar');
+  }).toThrowError(
+    'Minified React error #124; visit ' +
+    'http://facebook.github.io/react/docs/error-decoder.html?invariant=124&args[]=foo&args[]=bar' +
+    ' for the full message or use the non-minified dev environment' +
+    ' for full errors and additional helpful warnings.'
+  );
 
-    expect(function() {
-      reactProdInvariant(20);
-    }).toThrowError(
-      'Minified React error #20; visit ' +
-      'http://facebook.github.io/react/docs/error-decoder.html?invariant=20' +
-      ' for the full message or use the non-minified dev environment' +
-      ' for full errors and additional helpful warnings.'
-    );
+  expect(function() {
+    reactProdInvariant(20);
+  }).toThrowError(
+    'Minified React error #20; visit ' +
+    'http://facebook.github.io/react/docs/error-decoder.html?invariant=20' +
+    ' for the full message or use the non-minified dev environment' +
+    ' for full errors and additional helpful warnings.'
+  );
 
-    expect(function() {
-      reactProdInvariant(77, '<div>', '&?bar');
-    }).toThrowError(
-      'Minified React error #77; visit ' +
-      'http://facebook.github.io/react/docs/error-decoder.html?invariant=77&args[]=%3Cdiv%3E&args[]=%26%3Fbar' +
-      ' for the full message or use the non-minified dev environment' +
-      ' for full errors and additional helpful warnings.'
-    );
-  });
+  expect(function() {
+    reactProdInvariant(77, '<div>', '&?bar');
+  }).toThrowError(
+    'Minified React error #77; visit ' +
+    'http://facebook.github.io/react/docs/error-decoder.html?invariant=77&args[]=%3Cdiv%3E&args[]=%26%3Fbar' +
+    ' for the full message or use the non-minified dev environment' +
+    ' for full errors and additional helpful warnings.'
+  );
 });

--- a/src/shared/utils/__tests__/traverseAllChildren-test.js
+++ b/src/shared/utils/__tests__/traverseAllChildren-test.js
@@ -11,487 +11,448 @@
 
 'use strict';
 
-describe('traverseAllChildren', function() {
-  var traverseAllChildren;
-  var React;
-  var ReactFragment;
-  var ReactTestUtils;
+var traverseAllChildren;
+var React;
+var ReactFragment;
+var ReactTestUtils;
 
-  beforeEach(function() {
-    jest.resetModuleRegistry();
-    traverseAllChildren = require('traverseAllChildren');
-    React = require('React');
-    ReactFragment = require('ReactFragment');
-    ReactTestUtils = require('ReactTestUtils');
-  });
+beforeEach(function() {
+  jest.resetModuleRegistry();
+  traverseAllChildren = require('traverseAllChildren');
+  React = require('React');
+  ReactFragment = require('ReactFragment');
+  ReactTestUtils = require('ReactTestUtils');
+});
 
-  function frag(obj) {
-    return ReactFragment.create(obj);
-  }
+function frag(obj) {
+  return ReactFragment.create(obj);
+}
 
-  it('should support identity for simple', function() {
-    var traverseContext = [];
-    var traverseFn =
-      jasmine.createSpy().and.callFake(function(context, kid, key, index) {
-        context.push(true);
-      });
+it('should support identity for simple', function() {
+  var traverseContext = [];
+  var traverseFn =
+    jasmine.createSpy().and.callFake(function(context, kid, key, index) {
+      context.push(true);
+    });
 
-    var simpleKid = <span key="simple" />;
+  var simpleKid = <span key="simple" />;
 
-    // Jasmine doesn't provide a way to test that the fn was invoked with scope.
-    var instance = <div>{simpleKid}</div>;
-    traverseAllChildren(instance.props.children, traverseFn, traverseContext);
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      simpleKid,
-      '.$simple'
-    );
-    expect(traverseContext.length).toEqual(1);
-  });
+  // Jasmine doesn't provide a way to test that the fn was invoked with scope.
+  var instance = <div>{simpleKid}</div>;
+  traverseAllChildren(instance.props.children, traverseFn, traverseContext);
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    simpleKid,
+    '.$simple'
+  );
+  expect(traverseContext.length).toEqual(1);
+});
 
-  it('should treat single arrayless child as being in array', function() {
-    var traverseContext = [];
-    var traverseFn =
-      jasmine.createSpy().and.callFake(function(context, kid, key, index) {
-        context.push(true);
-      });
+it('should treat single arrayless child as being in array', function() {
+  var traverseContext = [];
+  var traverseFn =
+    jasmine.createSpy().and.callFake(function(context, kid, key, index) {
+      context.push(true);
+    });
 
-    var simpleKid = <span />;
-    var instance = <div>{simpleKid}</div>;
-    traverseAllChildren(instance.props.children, traverseFn, traverseContext);
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      simpleKid,
-      '.0'
-    );
-    expect(traverseContext.length).toEqual(1);
-  });
+  var simpleKid = <span />;
+  var instance = <div>{simpleKid}</div>;
+  traverseAllChildren(instance.props.children, traverseFn, traverseContext);
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    simpleKid,
+    '.0'
+  );
+  expect(traverseContext.length).toEqual(1);
+});
 
-  it('should treat single child in array as expected', function() {
-    spyOn(console, 'error');
-    var traverseContext = [];
-    var traverseFn =
-      jasmine.createSpy().and.callFake(function(context, kid, key, index) {
-        context.push(true);
-      });
+it('should treat single child in array as expected', function() {
+  spyOn(console, 'error');
+  var traverseContext = [];
+  var traverseFn =
+    jasmine.createSpy().and.callFake(function(context, kid, key, index) {
+      context.push(true);
+    });
 
-    var simpleKid = <span />;
-    var instance = <div>{[simpleKid]}</div>;
-    traverseAllChildren(instance.props.children, traverseFn, traverseContext);
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      simpleKid,
-      '.0'
-    );
-    expect(traverseContext.length).toEqual(1);
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Warning: Each child in an array or iterator should have a unique "key" prop.'
-    );
-  });
+  var simpleKid = <span />;
+  var instance = <div>{[simpleKid]}</div>;
+  traverseAllChildren(instance.props.children, traverseFn, traverseContext);
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    simpleKid,
+    '.0'
+  );
+  expect(traverseContext.length).toEqual(1);
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'Warning: Each child in an array or iterator should have a unique "key" prop.'
+  );
+});
 
-  it('should be called for each child', function() {
-    var zero = <div key="keyZero" />;
-    var one = null;
-    var two = <div key="keyTwo" />;
-    var three = null;
-    var four = <div key="keyFour" />;
+it('should be called for each child', function() {
+  var zero = <div key="keyZero" />;
+  var one = null;
+  var two = <div key="keyTwo" />;
+  var three = null;
+  var four = <div key="keyFour" />;
 
-    var traverseContext = [];
-    var traverseFn =
-      jasmine.createSpy().and.callFake(function(context, kid, key, index) {
-        context.push(true);
-      });
+  var traverseContext = [];
+  var traverseFn =
+    jasmine.createSpy().and.callFake(function(context, kid, key, index) {
+      context.push(true);
+    });
 
+  var instance = (
+    <div>
+      {zero}
+      {one}
+      {two}
+      {three}
+      {four}
+    </div>
+  );
+
+  traverseAllChildren(instance.props.children, traverseFn, traverseContext);
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    zero,
+    '.$keyZero'
+  );
+  expect(traverseFn).toHaveBeenCalledWith(traverseContext, one, '.1');
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    two,
+    '.$keyTwo'
+  );
+  expect(traverseFn).toHaveBeenCalledWith(traverseContext, three, '.3');
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    four,
+    '.$keyFour'
+  );
+});
+
+it('should traverse children of different kinds', function() {
+  var div = <div key="divNode" />;
+  var span = <span key="spanNode" />;
+  var a = <a key="aNode" />;
+
+  var traverseContext = [];
+  var traverseFn =
+    jasmine.createSpy().and.callFake(function(context, kid, key, index) {
+      context.push(true);
+    });
+
+  var instance = (
+    <div>
+      {div}
+      {[frag({span})]}
+      {frag({a: a})}
+      {'string'}
+      {1234}
+      {true}
+      {false}
+      {null}
+      {undefined}
+    </div>
+  );
+
+  traverseAllChildren(instance.props.children, traverseFn, traverseContext);
+
+  expect(traverseFn.calls.count()).toBe(9);
+  expect(traverseContext.length).toEqual(9);
+
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext, div, '.$divNode'
+  );
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext, <span key="span/.$spanNode" />, '.1:0:$span/.$spanNode'
+  );
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext, <a key="a/.$aNode" />, '.2:$a/.$aNode'
+  );
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext, 'string', '.3'
+  );
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext, 1234, '.4'
+  );
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext, null, '.5'
+  );
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext, null, '.6'
+  );
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext, null, '.7'
+  );
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext, null, '.8'
+  );
+});
+
+it('should be called for each child in nested structure', function() {
+  var zero = <div key="keyZero" />;
+  var one = null;
+  var two = <div key="keyTwo" />;
+  var three = null;
+  var four = <div key="keyFour" />;
+  var five = <div key="keyFiveInner" />;
+  // five is placed into a JS object with a key that is joined to the
+  // component key attribute.
+  // Precedence is as follows:
+  // 1. If grouped in an Object, the object key combined with `key` prop
+  // 2. If grouped in an Array, the `key` prop, falling back to array index
+
+
+  var traverseContext = [];
+  var traverseFn =
+    jasmine.createSpy().and.callFake(function(context, kid, key, index) {
+      context.push(true);
+    });
+
+  var instance = (
+    <div>{
+      [
+        frag({
+          firstHalfKey: [zero, one, two],
+          secondHalfKey: [three, four],
+          keyFive: five,
+        }),
+      ]
+    }</div>
+  );
+
+  traverseAllChildren(instance.props.children, traverseFn, traverseContext);
+  expect(traverseFn.calls.count()).toBe(4);
+  expect(traverseContext.length).toEqual(4);
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    <div key="firstHalfKey/.$keyZero" />,
+    '.0:$firstHalfKey/.$keyZero'
+  );
+
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    <div key="firstHalfKey/.$keyTwo" />,
+    '.0:$firstHalfKey/.$keyTwo'
+  );
+
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    <div key="secondHalfKey/.$keyFour" />,
+    '.0:$secondHalfKey/.$keyFour'
+  );
+
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    <div key="keyFive/.$keyFiveInner" />,
+    '.0:$keyFive/.$keyFiveInner'
+  );
+});
+
+it('should retain key across two mappings', function() {
+  var zeroForceKey = <div key="keyZero" />;
+  var oneForceKey = <div key="keyOne" />;
+  var traverseContext = [];
+  var traverseFn =
+    jasmine.createSpy().and.callFake(function(context, kid, key, index) {
+      context.push(true);
+    });
+
+  var forcedKeys = (
+    <div>
+      {zeroForceKey}
+      {oneForceKey}
+    </div>
+  );
+
+  traverseAllChildren(forcedKeys.props.children, traverseFn, traverseContext);
+  expect(traverseContext.length).toEqual(2);
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    zeroForceKey,
+    '.$keyZero'
+  );
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    oneForceKey,
+    '.$keyOne'
+  );
+});
+
+it('should be called for each child in an iterable without keys', function() {
+  spyOn(console, 'error');
+  var threeDivIterable = {
+    '@@iterator': function() {
+      var i = 0;
+      return {
+        next: function() {
+          if (i++ < 3) {
+            return {value: <div />, done: false};
+          } else {
+            return {value: undefined, done: true};
+          }
+        },
+      };
+    },
+  };
+
+  var traverseContext = [];
+  var traverseFn =
+    jasmine.createSpy().and.callFake(function(context, kid, key, index) {
+      context.push(kid);
+    });
+
+  var instance = (
+    <div>
+      {threeDivIterable}
+    </div>
+  );
+
+  traverseAllChildren(instance.props.children, traverseFn, traverseContext);
+  expect(traverseFn.calls.count()).toBe(3);
+
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    traverseContext[0],
+    '.0'
+  );
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    traverseContext[1],
+    '.1'
+  );
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    traverseContext[2],
+    '.2'
+  );
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'Warning: Each child in an array or iterator should have a unique "key" prop.'
+  );
+});
+
+it('should be called for each child in an iterable with keys', function() {
+  var threeDivIterable = {
+    '@@iterator': function() {
+      var i = 0;
+      return {
+        next: function() {
+          if (i++ < 3) {
+            return {value: <div key={'#' + i} />, done: false};
+          } else {
+            return {value: undefined, done: true};
+          }
+        },
+      };
+    },
+  };
+
+  var traverseContext = [];
+  var traverseFn =
+    jasmine.createSpy().and.callFake(function(context, kid, key, index) {
+      context.push(kid);
+    });
+
+  var instance = (
+    <div>
+      {threeDivIterable}
+    </div>
+  );
+
+  traverseAllChildren(instance.props.children, traverseFn, traverseContext);
+  expect(traverseFn.calls.count()).toBe(3);
+
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    traverseContext[0],
+    '.$#1'
+  );
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    traverseContext[1],
+    '.$#2'
+  );
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    traverseContext[2],
+    '.$#3'
+  );
+});
+
+it('should use keys from entry iterables', function() {
+  spyOn(console, 'error');
+
+  var threeDivEntryIterable = {
+    '@@iterator': function() {
+      var i = 0;
+      return {
+        next: function() {
+          if (i++ < 3) {
+            return {value: ['#' + i, <div />], done: false};
+          } else {
+            return {value: undefined, done: true};
+          }
+        },
+      };
+    },
+  };
+  threeDivEntryIterable.entries = threeDivEntryIterable['@@iterator'];
+
+  var traverseContext = [];
+  var traverseFn =
+    jasmine.createSpy().and.callFake(function(context, kid, key, index) {
+      context.push(kid);
+    });
+
+  var instance = (
+    <div>
+      {threeDivEntryIterable}
+    </div>
+  );
+
+  traverseAllChildren(instance.props.children, traverseFn, traverseContext);
+  expect(traverseFn.calls.count()).toBe(3);
+
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    traverseContext[0],
+    '.$#1:0'
+  );
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    traverseContext[1],
+    '.$#2:0'
+  );
+  expect(traverseFn).toHaveBeenCalledWith(
+    traverseContext,
+    traverseContext[2],
+    '.$#3:0'
+  );
+
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toContain(
+    'Warning: Using Maps as children is not yet fully supported. It is an ' +
+    'experimental feature that might be removed. Convert it to a sequence ' +
+    '/ iterable of keyed ReactElements instead.'
+  );
+});
+
+it('should not enumerate enumerable numbers (#4776)', function() {
+  /*eslint-disable no-extend-native */
+  Number.prototype['@@iterator'] = function() {
+    throw new Error('number iterator called');
+  };
+  /*eslint-enable no-extend-native */
+
+  try {
     var instance = (
       <div>
-        {zero}
-        {one}
-        {two}
-        {three}
-        {four}
-      </div>
-    );
-
-    traverseAllChildren(instance.props.children, traverseFn, traverseContext);
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      zero,
-      '.$keyZero'
-    );
-    expect(traverseFn).toHaveBeenCalledWith(traverseContext, one, '.1');
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      two,
-      '.$keyTwo'
-    );
-    expect(traverseFn).toHaveBeenCalledWith(traverseContext, three, '.3');
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      four,
-      '.$keyFour'
-    );
-  });
-
-  it('should traverse children of different kinds', function() {
-    var div = <div key="divNode" />;
-    var span = <span key="spanNode" />;
-    var a = <a key="aNode" />;
-
-    var traverseContext = [];
-    var traverseFn =
-      jasmine.createSpy().and.callFake(function(context, kid, key, index) {
-        context.push(true);
-      });
-
-    var instance = (
-      <div>
-        {div}
-        {[frag({span})]}
-        {frag({a: a})}
-        {'string'}
-        {1234}
-        {true}
-        {false}
-        {null}
-        {undefined}
-      </div>
-    );
-
-    traverseAllChildren(instance.props.children, traverseFn, traverseContext);
-
-    expect(traverseFn.calls.count()).toBe(9);
-    expect(traverseContext.length).toEqual(9);
-
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext, div, '.$divNode'
-    );
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext, <span key="span/.$spanNode" />, '.1:0:$span/.$spanNode'
-    );
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext, <a key="a/.$aNode" />, '.2:$a/.$aNode'
-    );
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext, 'string', '.3'
-    );
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext, 1234, '.4'
-    );
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext, null, '.5'
-    );
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext, null, '.6'
-    );
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext, null, '.7'
-    );
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext, null, '.8'
-    );
-  });
-
-  it('should be called for each child in nested structure', function() {
-    var zero = <div key="keyZero" />;
-    var one = null;
-    var two = <div key="keyTwo" />;
-    var three = null;
-    var four = <div key="keyFour" />;
-    var five = <div key="keyFiveInner" />;
-    // five is placed into a JS object with a key that is joined to the
-    // component key attribute.
-    // Precedence is as follows:
-    // 1. If grouped in an Object, the object key combined with `key` prop
-    // 2. If grouped in an Array, the `key` prop, falling back to array index
-
-
-    var traverseContext = [];
-    var traverseFn =
-      jasmine.createSpy().and.callFake(function(context, kid, key, index) {
-        context.push(true);
-      });
-
-    var instance = (
-      <div>{
-        [
-          frag({
-            firstHalfKey: [zero, one, two],
-            secondHalfKey: [three, four],
-            keyFive: five,
-          }),
-        ]
-      }</div>
-    );
-
-    traverseAllChildren(instance.props.children, traverseFn, traverseContext);
-    expect(traverseFn.calls.count()).toBe(4);
-    expect(traverseContext.length).toEqual(4);
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      <div key="firstHalfKey/.$keyZero" />,
-      '.0:$firstHalfKey/.$keyZero'
-    );
-
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      <div key="firstHalfKey/.$keyTwo" />,
-      '.0:$firstHalfKey/.$keyTwo'
-    );
-
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      <div key="secondHalfKey/.$keyFour" />,
-      '.0:$secondHalfKey/.$keyFour'
-    );
-
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      <div key="keyFive/.$keyFiveInner" />,
-      '.0:$keyFive/.$keyFiveInner'
-    );
-  });
-
-  it('should retain key across two mappings', function() {
-    var zeroForceKey = <div key="keyZero" />;
-    var oneForceKey = <div key="keyOne" />;
-    var traverseContext = [];
-    var traverseFn =
-      jasmine.createSpy().and.callFake(function(context, kid, key, index) {
-        context.push(true);
-      });
-
-    var forcedKeys = (
-      <div>
-        {zeroForceKey}
-        {oneForceKey}
-      </div>
-    );
-
-    traverseAllChildren(forcedKeys.props.children, traverseFn, traverseContext);
-    expect(traverseContext.length).toEqual(2);
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      zeroForceKey,
-      '.$keyZero'
-    );
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      oneForceKey,
-      '.$keyOne'
-    );
-  });
-
-  it('should be called for each child in an iterable without keys', function() {
-    spyOn(console, 'error');
-    var threeDivIterable = {
-      '@@iterator': function() {
-        var i = 0;
-        return {
-          next: function() {
-            if (i++ < 3) {
-              return {value: <div />, done: false};
-            } else {
-              return {value: undefined, done: true};
-            }
-          },
-        };
-      },
-    };
-
-    var traverseContext = [];
-    var traverseFn =
-      jasmine.createSpy().and.callFake(function(context, kid, key, index) {
-        context.push(kid);
-      });
-
-    var instance = (
-      <div>
-        {threeDivIterable}
-      </div>
-    );
-
-    traverseAllChildren(instance.props.children, traverseFn, traverseContext);
-    expect(traverseFn.calls.count()).toBe(3);
-
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      traverseContext[0],
-      '.0'
-    );
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      traverseContext[1],
-      '.1'
-    );
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      traverseContext[2],
-      '.2'
-    );
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Warning: Each child in an array or iterator should have a unique "key" prop.'
-    );
-  });
-
-  it('should be called for each child in an iterable with keys', function() {
-    var threeDivIterable = {
-      '@@iterator': function() {
-        var i = 0;
-        return {
-          next: function() {
-            if (i++ < 3) {
-              return {value: <div key={'#' + i} />, done: false};
-            } else {
-              return {value: undefined, done: true};
-            }
-          },
-        };
-      },
-    };
-
-    var traverseContext = [];
-    var traverseFn =
-      jasmine.createSpy().and.callFake(function(context, kid, key, index) {
-        context.push(kid);
-      });
-
-    var instance = (
-      <div>
-        {threeDivIterable}
-      </div>
-    );
-
-    traverseAllChildren(instance.props.children, traverseFn, traverseContext);
-    expect(traverseFn.calls.count()).toBe(3);
-
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      traverseContext[0],
-      '.$#1'
-    );
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      traverseContext[1],
-      '.$#2'
-    );
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      traverseContext[2],
-      '.$#3'
-    );
-  });
-
-  it('should use keys from entry iterables', function() {
-    spyOn(console, 'error');
-
-    var threeDivEntryIterable = {
-      '@@iterator': function() {
-        var i = 0;
-        return {
-          next: function() {
-            if (i++ < 3) {
-              return {value: ['#' + i, <div />], done: false};
-            } else {
-              return {value: undefined, done: true};
-            }
-          },
-        };
-      },
-    };
-    threeDivEntryIterable.entries = threeDivEntryIterable['@@iterator'];
-
-    var traverseContext = [];
-    var traverseFn =
-      jasmine.createSpy().and.callFake(function(context, kid, key, index) {
-        context.push(kid);
-      });
-
-    var instance = (
-      <div>
-        {threeDivEntryIterable}
-      </div>
-    );
-
-    traverseAllChildren(instance.props.children, traverseFn, traverseContext);
-    expect(traverseFn.calls.count()).toBe(3);
-
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      traverseContext[0],
-      '.$#1:0'
-    );
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      traverseContext[1],
-      '.$#2:0'
-    );
-    expect(traverseFn).toHaveBeenCalledWith(
-      traverseContext,
-      traverseContext[2],
-      '.$#3:0'
-    );
-
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'Warning: Using Maps as children is not yet fully supported. It is an ' +
-      'experimental feature that might be removed. Convert it to a sequence ' +
-      '/ iterable of keyed ReactElements instead.'
-    );
-  });
-
-  it('should not enumerate enumerable numbers (#4776)', function() {
-    /*eslint-disable no-extend-native */
-    Number.prototype['@@iterator'] = function() {
-      throw new Error('number iterator called');
-    };
-    /*eslint-enable no-extend-native */
-
-    try {
-      var instance = (
-        <div>
-          {5}
-          {12}
-          {13}
-        </div>
-      );
-
-      var traverseFn = jasmine.createSpy();
-
-      traverseAllChildren(instance.props.children, traverseFn, null);
-      expect(traverseFn.calls.count()).toBe(3);
-
-      expect(traverseFn).toHaveBeenCalledWith(
-        null,
-        5,
-        '.0'
-      );
-      expect(traverseFn).toHaveBeenCalledWith(
-        null,
-        12,
-        '.1'
-      );
-      expect(traverseFn).toHaveBeenCalledWith(
-        null,
-        13,
-        '.2'
-      );
-    } finally {
-      delete Number.prototype['@@iterator'];
-    }
-  });
-
-  it('should allow extension of native prototypes', function() {
-    /*eslint-disable no-extend-native */
-    String.prototype.key = 'react';
-    Number.prototype.key = 'rocks';
-    /*eslint-enable no-extend-native */
-
-    var instance = (
-      <div>
-        {'a'}
+        {5}
+        {12}
         {13}
       </div>
     );
@@ -499,64 +460,101 @@ describe('traverseAllChildren', function() {
     var traverseFn = jasmine.createSpy();
 
     traverseAllChildren(instance.props.children, traverseFn, null);
-    expect(traverseFn.calls.count()).toBe(2);
+    expect(traverseFn.calls.count()).toBe(3);
 
     expect(traverseFn).toHaveBeenCalledWith(
       null,
-      'a',
+      5,
       '.0'
     );
     expect(traverseFn).toHaveBeenCalledWith(
       null,
-      13,
+      12,
       '.1'
     );
-
-    delete String.prototype.key;
-    delete Number.prototype.key;
-  });
-
-  it('should throw on object', function() {
-    expect(function() {
-      traverseAllChildren({a: 1, b: 2}, function() {}, null);
-    }).toThrowError(
-      'Objects are not valid as a React child (found: object with keys ' +
-      '{a, b}). If you meant to render a collection of children, use an ' +
-      'array instead or wrap the object using createFragment(object) from ' +
-      'the React add-ons.'
+    expect(traverseFn).toHaveBeenCalledWith(
+      null,
+      13,
+      '.2'
     );
-  });
+  } finally {
+    delete Number.prototype['@@iterator'];
+  }
+});
 
-  it('should throw on regex', function() {
-    // Really, we care about dates (#4840) but those have nondeterministic
-    // serialization (timezones) so let's test a regex instead:
-    expect(function() {
-      traverseAllChildren(/abc/, function() {}, null);
-    }).toThrowError(
-      'Objects are not valid as a React child (found: /abc/). If you meant ' +
-      'to render a collection of children, use an array instead or wrap the ' +
-      'object using createFragment(object) from the React add-ons.'
-    );
-  });
+it('should allow extension of native prototypes', function() {
+  /*eslint-disable no-extend-native */
+  String.prototype.key = 'react';
+  Number.prototype.key = 'rocks';
+  /*eslint-enable no-extend-native */
 
-  it('should warn for using maps as children with owner info', function() {
-    spyOn(console, 'error');
+  var instance = (
+    <div>
+      {'a'}
+      {13}
+    </div>
+  );
 
-    class Parent extends React.Component {
-      render() {
-        return (
-          <div>{new Map([['foo', 0], ['bar', 1]])}</div>
-        );
-      }
+  var traverseFn = jasmine.createSpy();
+
+  traverseAllChildren(instance.props.children, traverseFn, null);
+  expect(traverseFn.calls.count()).toBe(2);
+
+  expect(traverseFn).toHaveBeenCalledWith(
+    null,
+    'a',
+    '.0'
+  );
+  expect(traverseFn).toHaveBeenCalledWith(
+    null,
+    13,
+    '.1'
+  );
+
+  delete String.prototype.key;
+  delete Number.prototype.key;
+});
+
+it('should throw on object', function() {
+  expect(function() {
+    traverseAllChildren({a: 1, b: 2}, function() {}, null);
+  }).toThrowError(
+    'Objects are not valid as a React child (found: object with keys ' +
+    '{a, b}). If you meant to render a collection of children, use an ' +
+    'array instead or wrap the object using createFragment(object) from ' +
+    'the React add-ons.'
+  );
+});
+
+it('should throw on regex', function() {
+  // Really, we care about dates (#4840) but those have nondeterministic
+  // serialization (timezones) so let's test a regex instead:
+  expect(function() {
+    traverseAllChildren(/abc/, function() {}, null);
+  }).toThrowError(
+    'Objects are not valid as a React child (found: /abc/). If you meant ' +
+    'to render a collection of children, use an array instead or wrap the ' +
+    'object using createFragment(object) from the React add-ons.'
+  );
+});
+
+it('should warn for using maps as children with owner info', function() {
+  spyOn(console, 'error');
+
+  class Parent extends React.Component {
+    render() {
+      return (
+        <div>{new Map([['foo', 0], ['bar', 1]])}</div>
+      );
     }
+  }
 
-    ReactTestUtils.renderIntoDocument(<Parent />);
+  ReactTestUtils.renderIntoDocument(<Parent />);
 
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toBe(
-      'Warning: Using Maps as children is not yet fully supported. It is an ' +
-      'experimental feature that might be removed. Convert it to a sequence ' +
-      '/ iterable of keyed ReactElements instead. Check the render method of `Parent`.'
-    );
-  });
+  expect(console.error.calls.count()).toBe(1);
+  expect(console.error.calls.argsFor(0)[0]).toBe(
+    'Warning: Using Maps as children is not yet fully supported. It is an ' +
+    'experimental feature that might be removed. Convert it to a sequence ' +
+    '/ iterable of keyed ReactElements instead. Check the render method of `Parent`.'
+  );
 });

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -16,18 +16,139 @@ var ReactDOM;
 var ReactDOMServer;
 var ReactTestUtils;
 
-describe('ReactTestUtils', function() {
+beforeEach(function() {
+  React = require('React');
+  ReactDOM = require('ReactDOM');
+  ReactDOMServer = require('ReactDOMServer');
+  ReactTestUtils = require('ReactTestUtils');
+});
 
-  beforeEach(function() {
-    React = require('React');
-    ReactDOM = require('ReactDOM');
-    ReactDOMServer = require('ReactDOMServer');
-    ReactTestUtils = require('ReactTestUtils');
+it('should have shallow rendering', function() {
+  class SomeComponent extends React.Component {
+    render() {
+      return (
+        <div>
+          <span className="child1" />
+          <span className="child2" />
+        </div>
+      );
+    }
+  }
+
+  var shallowRenderer = ReactTestUtils.createRenderer();
+  var result = shallowRenderer.render(<SomeComponent />);
+
+  expect(result.type).toBe('div');
+  expect(result.props.children).toEqual([
+    <span className="child1" />,
+    <span className="child2" />,
+  ]);
+});
+
+it('should shallow render a functional component', function() {
+  function SomeComponent() {
+    return (
+      <div>
+        <span className="child1" />
+        <span className="child2" />
+      </div>
+    );
+  }
+
+  var shallowRenderer = ReactTestUtils.createRenderer();
+  var result = shallowRenderer.render(<SomeComponent />);
+
+  expect(result.type).toBe('div');
+  expect(result.props.children).toEqual([
+    <span className="child1" />,
+    <span className="child2" />,
+  ]);
+});
+
+it('should throw for invalid elements', function() {
+  class SomeComponent extends React.Component {
+    render() {
+      return <div />;
+    }
+  }
+
+  var shallowRenderer = ReactTestUtils.createRenderer();
+  expect(() => shallowRenderer.render(SomeComponent)).toThrowError(
+    'ReactShallowRenderer render(): Invalid component element. Instead of ' +
+    'passing a component class, make sure to instantiate it by passing it ' +
+    'to React.createElement.'
+  );
+  expect(() => shallowRenderer.render(<div />)).toThrowError(
+    'ReactShallowRenderer render(): Shallow rendering works only with ' +
+    'custom components, not primitives (div). Instead of calling ' +
+    '`.render(el)` and inspecting the rendered output, look at `el.props` ' +
+    'directly instead.'
+  );
+});
+
+it('should have shallow unmounting', function() {
+  var componentWillUnmount = jest.fn();
+
+  var SomeComponent = React.createClass({
+    render: function() {
+      return <div />;
+    },
+    componentWillUnmount,
   });
 
-  it('should have shallow rendering', function() {
-    class SomeComponent extends React.Component {
-      render() {
+  var shallowRenderer = ReactTestUtils.createRenderer();
+  shallowRenderer.render(<SomeComponent />);
+  shallowRenderer.unmount();
+
+  expect(componentWillUnmount).toBeCalled();
+});
+
+it('can shallow render to null', function() {
+  class SomeComponent extends React.Component {
+    render() {
+      return null;
+    }
+  }
+
+  var shallowRenderer = ReactTestUtils.createRenderer();
+  var result = shallowRenderer.render(<SomeComponent />);
+
+  expect(result).toBe(null);
+});
+
+it('can shallow render with a ref', function() {
+  class SomeComponent extends React.Component {
+    render() {
+      return <div ref="hello" />;
+    }
+  }
+
+  var shallowRenderer = ReactTestUtils.createRenderer();
+  // Shouldn't crash.
+  shallowRenderer.render(<SomeComponent />);
+});
+
+it('lets you update shallowly rendered components', function() {
+  class SomeComponent extends React.Component {
+    state = {clicked: false};
+
+    onClick = () => {
+      this.setState({clicked: true});
+    };
+
+    render() {
+      var className = this.state.clicked ? 'was-clicked' : '';
+
+      if (this.props.aNew === 'prop') {
+        return (
+          <a
+            href="#"
+            onClick={this.onClick}
+            className={className}>
+            Test link
+          </a>
+        );
+      } else {
         return (
           <div>
             <span className="child1" />
@@ -36,555 +157,430 @@ describe('ReactTestUtils', function() {
         );
       }
     }
+  }
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    var result = shallowRenderer.render(<SomeComponent />);
+  var shallowRenderer = ReactTestUtils.createRenderer();
+  var result = shallowRenderer.render(<SomeComponent />);
+  expect(result.type).toBe('div');
+  expect(result.props.children).toEqual([
+    <span className="child1" />,
+    <span className="child2" />,
+  ]);
 
-    expect(result.type).toBe('div');
-    expect(result.props.children).toEqual([
-      <span className="child1" />,
-      <span className="child2" />,
-    ]);
+  var updatedResult = shallowRenderer.render(<SomeComponent aNew="prop" />);
+  expect(updatedResult.type).toBe('a');
+
+  var mockEvent = {};
+  updatedResult.props.onClick(mockEvent);
+
+  var updatedResultCausedByClick = shallowRenderer.getRenderOutput();
+  expect(updatedResultCausedByClick.type).toBe('a');
+  expect(updatedResultCausedByClick.props.className).toBe('was-clicked');
+});
+
+it('can access the mounted component instance', function() {
+  class SimpleComponent extends React.Component {
+    someMethod = () => {
+      return this.props.n;
+    };
+
+    render() {
+      return <div>{this.props.n}</div>;
+    }
+  }
+
+  var shallowRenderer = ReactTestUtils.createRenderer();
+  shallowRenderer.render(<SimpleComponent n={5} />);
+  expect(shallowRenderer.getMountedInstance().someMethod()).toEqual(5);
+});
+
+it('can shallowly render components with contextTypes', function() {
+  class SimpleComponent extends React.Component {
+    static contextTypes = {
+      name: React.PropTypes.string,
+    };
+
+    render() {
+      return <div />;
+    }
+  }
+
+  var shallowRenderer = ReactTestUtils.createRenderer();
+  var result = shallowRenderer.render(<SimpleComponent />);
+  expect(result).toEqual(<div />);
+});
+
+it('can shallowly render components with ref as function', function() {
+  class SimpleComponent extends React.Component {
+    state = {clicked: false};
+
+    handleUserClick = () => {
+      this.setState({ clicked: true });
+    };
+
+    render() {
+      return (
+        <div
+          ref={() => {}}
+          onClick={this.handleUserClick}
+          className={this.state.clicked ? 'clicked' : ''}
+        />
+      );
+    }
+  }
+
+  var shallowRenderer = ReactTestUtils.createRenderer();
+  shallowRenderer.render(<SimpleComponent />);
+  var result = shallowRenderer.getRenderOutput();
+  expect(result.type).toEqual('div');
+  expect(result.props.className).toEqual('');
+  result.props.onClick();
+
+  result = shallowRenderer.getRenderOutput();
+  expect(result.type).toEqual('div');
+  expect(result.props.className).toEqual('clicked');
+});
+
+it('can setState in componentWillMount when shallow rendering', function() {
+  class SimpleComponent extends React.Component {
+    componentWillMount() {
+      this.setState({groovy: 'doovy'});
+    }
+
+    render() {
+      return <div>{this.state.groovy}</div>;
+    }
+  }
+
+  var shallowRenderer = ReactTestUtils.createRenderer();
+  var result = shallowRenderer.render(<SimpleComponent />);
+  expect(result).toEqual(<div>doovy</div>);
+});
+
+it('can pass context when shallowly rendering', function() {
+  class SimpleComponent extends React.Component {
+    static contextTypes = {
+      name: React.PropTypes.string,
+    };
+
+    render() {
+      return <div>{this.context.name}</div>;
+    }
+  }
+
+  var shallowRenderer = ReactTestUtils.createRenderer();
+  var result = shallowRenderer.render(<SimpleComponent />, {
+    name: 'foo',
+  });
+  expect(result).toEqual(<div>foo</div>);
+});
+
+it('can fail context when shallowly rendering', function() {
+  spyOn(console, 'error');
+
+  class SimpleComponent extends React.Component {
+    static contextTypes = {
+      name: React.PropTypes.string.isRequired,
+    };
+
+    render() {
+      return <div>{this.context.name}</div>;
+    }
+  }
+
+  var shallowRenderer = ReactTestUtils.createRenderer();
+  shallowRenderer.render(<SimpleComponent />);
+  expect(console.error.calls.count()).toBe(1);
+  expect(
+    console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
+  ).toBe(
+    'Warning: Failed context type: The context `name` is marked as ' +
+    'required in `SimpleComponent`, but its value is `undefined`.\n' +
+    '    in SimpleComponent (at **)'
+  );
+});
+
+it('can scryRenderedDOMComponentsWithClass with TextComponent', function() {
+  class Wrapper extends React.Component {
+    render() {
+      return <div>Hello <span>Jim</span></div>;
+    }
+  }
+
+  var renderedComponent = ReactTestUtils.renderIntoDocument(<Wrapper />);
+  var scryResults = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+    renderedComponent,
+    'NonExistentClass'
+  );
+  expect(scryResults.length).toBe(0);
+});
+
+it('can scryRenderedDOMComponentsWithClass with className contains \\n', function() {
+  class Wrapper extends React.Component {
+    render() {
+      return <div>Hello <span className={'x\ny'}>Jim</span></div>;
+    }
+  }
+
+  var renderedComponent = ReactTestUtils.renderIntoDocument(<Wrapper />);
+  var scryResults = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+    renderedComponent,
+    'x'
+  );
+  expect(scryResults.length).toBe(1);
+});
+
+it('can scryRenderedDOMComponentsWithClass with multiple classes', function() {
+  class Wrapper extends React.Component {
+    render() {
+      return <div>Hello <span className={'x y z'}>Jim</span></div>;
+    }
+  }
+
+  var renderedComponent = ReactTestUtils.renderIntoDocument(<Wrapper />);
+  var scryResults1 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+    renderedComponent,
+    'x y'
+  );
+  expect(scryResults1.length).toBe(1);
+
+  var scryResults2 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+    renderedComponent,
+    'x z'
+  );
+  expect(scryResults2.length).toBe(1);
+
+  var scryResults3 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+    renderedComponent,
+    ['x', 'y']
+  );
+  expect(scryResults3.length).toBe(1);
+
+  expect(scryResults1[0]).toBe(scryResults2[0]);
+  expect(scryResults1[0]).toBe(scryResults3[0]);
+
+  var scryResults4 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+    renderedComponent,
+    ['x', 'a']
+  );
+  expect(scryResults4.length).toBe(0);
+
+  var scryResults5 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
+    renderedComponent,
+    ['x a']
+  );
+  expect(scryResults5.length).toBe(0);
+});
+
+it('traverses children in the correct order', function() {
+  class Wrapper extends React.Component {
+    render() {
+      return <div>{this.props.children}</div>;
+    }
+  }
+
+  var container = document.createElement('div');
+  ReactDOM.render(
+    <Wrapper>
+      {null}
+      <div>purple</div>
+    </Wrapper>,
+    container
+  );
+  var tree = ReactDOM.render(
+    <Wrapper>
+      <div>orange</div>
+      <div>purple</div>
+    </Wrapper>,
+    container
+  );
+
+  var log = [];
+  ReactTestUtils.findAllInRenderedTree(tree, function(child) {
+    if (ReactTestUtils.isDOMComponent(child)) {
+      log.push(ReactDOM.findDOMNode(child).textContent);
+    }
   });
 
-  it('should shallow render a functional component', function() {
-    function SomeComponent() {
+  // Should be document order, not mount order (which would be purple, orange)
+  expect(log).toEqual(['orangepurple', 'orange', 'purple']);
+});
+
+it('should support injected wrapper components as DOM components', function() {
+  var getTestDocument = require('getTestDocument');
+
+  var injectedDOMComponents = [
+    'button',
+    'form',
+    'iframe',
+    'img',
+    'input',
+    'option',
+    'select',
+    'textarea',
+  ];
+
+  injectedDOMComponents.forEach(function(type) {
+    var testComponent = ReactTestUtils.renderIntoDocument(
+      React.createElement(type)
+    );
+    expect(testComponent.tagName).toBe(type.toUpperCase());
+    expect(ReactTestUtils.isDOMComponent(testComponent)).toBe(true);
+  });
+
+  // Full-page components (html, head, body) can't be rendered into a div
+  // directly...
+  class Root extends React.Component {
+    render() {
+      return (
+        <html ref="html">
+          <head ref="head">
+            <title>hello</title>
+          </head>
+          <body ref="body">
+            hello, world
+          </body>
+        </html>
+      );
+    }
+  }
+
+  var markup = ReactDOMServer.renderToString(<Root />);
+  var testDocument = getTestDocument(markup);
+  var component = ReactDOM.render(<Root />, testDocument);
+
+  expect(component.refs.html.tagName).toBe('HTML');
+  expect(component.refs.head.tagName).toBe('HEAD');
+  expect(component.refs.body.tagName).toBe('BODY');
+  expect(ReactTestUtils.isDOMComponent(component.refs.html)).toBe(true);
+  expect(ReactTestUtils.isDOMComponent(component.refs.head)).toBe(true);
+  expect(ReactTestUtils.isDOMComponent(component.refs.body)).toBe(true);
+});
+
+it('should change the value of an input field', function() {
+  var obj = {
+    handler: function(e) {
+      e.persist();
+    },
+  };
+  spyOn(obj, 'handler').and.callThrough();
+  var container = document.createElement('div');
+  var instance = ReactDOM.render(<input type="text" onChange={obj.handler} />, container);
+
+  var node = ReactDOM.findDOMNode(instance);
+  node.value = 'giraffe';
+  ReactTestUtils.Simulate.change(node);
+
+  expect(obj.handler).toHaveBeenCalledWith(jasmine.objectContaining({target: node}));
+});
+
+it('should change the value of an input field in a component', function() {
+  class SomeComponent extends React.Component {
+    render() {
       return (
         <div>
-          <span className="child1" />
-          <span className="child2" />
+          <input type="text" ref="input" onChange={this.props.handleChange} />
         </div>
       );
     }
+  }
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    var result = shallowRenderer.render(<SomeComponent />);
+  var obj = {
+    handler: function(e) {
+      e.persist();
+    },
+  };
+  spyOn(obj, 'handler').and.callThrough();
+  var container = document.createElement('div');
+  var instance = ReactDOM.render(<SomeComponent handleChange={obj.handler} />, container);
 
-    expect(result.type).toBe('div');
-    expect(result.props.children).toEqual([
-      <span className="child1" />,
-      <span className="child2" />,
-    ]);
-  });
+  var node = ReactDOM.findDOMNode(instance.refs.input);
+  node.value = 'zebra';
+  ReactTestUtils.Simulate.change(node);
 
-  it('should throw for invalid elements', function() {
-    class SomeComponent extends React.Component {
-      render() {
-        return <div />;
-      }
-    }
+  expect(obj.handler).toHaveBeenCalledWith(jasmine.objectContaining({target: node}));
+});
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    expect(() => shallowRenderer.render(SomeComponent)).toThrowError(
-      'ReactShallowRenderer render(): Invalid component element. Instead of ' +
-      'passing a component class, make sure to instantiate it by passing it ' +
-      'to React.createElement.'
-    );
-    expect(() => shallowRenderer.render(<div />)).toThrowError(
-      'ReactShallowRenderer render(): Shallow rendering works only with ' +
-      'custom components, not primitives (div). Instead of calling ' +
-      '`.render(el)` and inspecting the rendered output, look at `el.props` ' +
-      'directly instead.'
-    );
-  });
-
-  it('should have shallow unmounting', function() {
-    var componentWillUnmount = jest.fn();
-
-    var SomeComponent = React.createClass({
-      render: function() {
-        return <div />;
-      },
-      componentWillUnmount,
-    });
-
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    shallowRenderer.render(<SomeComponent />);
-    shallowRenderer.unmount();
-
-    expect(componentWillUnmount).toBeCalled();
-  });
-
-  it('can shallow render to null', function() {
-    class SomeComponent extends React.Component {
-      render() {
-        return null;
-      }
-    }
-
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    var result = shallowRenderer.render(<SomeComponent />);
-
-    expect(result).toBe(null);
-  });
-
-  it('can shallow render with a ref', function() {
-    class SomeComponent extends React.Component {
-      render() {
-        return <div ref="hello" />;
-      }
-    }
-
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    // Shouldn't crash.
-    shallowRenderer.render(<SomeComponent />);
-  });
-
-  it('lets you update shallowly rendered components', function() {
-    class SomeComponent extends React.Component {
-      state = {clicked: false};
-
-      onClick = () => {
-        this.setState({clicked: true});
-      };
-
-      render() {
-        var className = this.state.clicked ? 'was-clicked' : '';
-
-        if (this.props.aNew === 'prop') {
-          return (
-            <a
-              href="#"
-              onClick={this.onClick}
-              className={className}>
-              Test link
-            </a>
-          );
-        } else {
-          return (
-            <div>
-              <span className="child1" />
-              <span className="child2" />
-            </div>
-          );
-        }
-      }
-    }
-
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    var result = shallowRenderer.render(<SomeComponent />);
-    expect(result.type).toBe('div');
-    expect(result.props.children).toEqual([
-      <span className="child1" />,
-      <span className="child2" />,
-    ]);
-
-    var updatedResult = shallowRenderer.render(<SomeComponent aNew="prop" />);
-    expect(updatedResult.type).toBe('a');
-
-    var mockEvent = {};
-    updatedResult.props.onClick(mockEvent);
-
-    var updatedResultCausedByClick = shallowRenderer.getRenderOutput();
-    expect(updatedResultCausedByClick.type).toBe('a');
-    expect(updatedResultCausedByClick.props.className).toBe('was-clicked');
-  });
-
-  it('can access the mounted component instance', function() {
-    class SimpleComponent extends React.Component {
-      someMethod = () => {
-        return this.props.n;
-      };
-
-      render() {
-        return <div>{this.props.n}</div>;
-      }
-    }
-
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    shallowRenderer.render(<SimpleComponent n={5} />);
-    expect(shallowRenderer.getMountedInstance().someMethod()).toEqual(5);
-  });
-
-  it('can shallowly render components with contextTypes', function() {
-    class SimpleComponent extends React.Component {
-      static contextTypes = {
-        name: React.PropTypes.string,
-      };
-
-      render() {
-        return <div />;
-      }
-    }
-
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    var result = shallowRenderer.render(<SimpleComponent />);
-    expect(result).toEqual(<div />);
-  });
-
-  it('can shallowly render components with ref as function', function() {
-    class SimpleComponent extends React.Component {
-      state = {clicked: false};
-
-      handleUserClick = () => {
-        this.setState({ clicked: true });
-      };
-
-      render() {
-        return (
-          <div
-            ref={() => {}}
-            onClick={this.handleUserClick}
-            className={this.state.clicked ? 'clicked' : ''}
-          />
-        );
-      }
-    }
-
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    shallowRenderer.render(<SimpleComponent />);
-    var result = shallowRenderer.getRenderOutput();
-    expect(result.type).toEqual('div');
-    expect(result.props.className).toEqual('');
-    result.props.onClick();
-
-    result = shallowRenderer.getRenderOutput();
-    expect(result.type).toEqual('div');
-    expect(result.props.className).toEqual('clicked');
-  });
-
-  it('can setState in componentWillMount when shallow rendering', function() {
-    class SimpleComponent extends React.Component {
-      componentWillMount() {
-        this.setState({groovy: 'doovy'});
-      }
-
-      render() {
-        return <div>{this.state.groovy}</div>;
-      }
-    }
-
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    var result = shallowRenderer.render(<SimpleComponent />);
-    expect(result).toEqual(<div>doovy</div>);
-  });
-
-  it('can pass context when shallowly rendering', function() {
-    class SimpleComponent extends React.Component {
-      static contextTypes = {
-        name: React.PropTypes.string,
-      };
-
-      render() {
-        return <div>{this.context.name}</div>;
-      }
-    }
-
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    var result = shallowRenderer.render(<SimpleComponent />, {
-      name: 'foo',
-    });
-    expect(result).toEqual(<div>foo</div>);
-  });
-
-  it('can fail context when shallowly rendering', function() {
-    spyOn(console, 'error');
-
-    class SimpleComponent extends React.Component {
-      static contextTypes = {
-        name: React.PropTypes.string.isRequired,
-      };
-
-      render() {
-        return <div>{this.context.name}</div>;
-      }
-    }
-
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    shallowRenderer.render(<SimpleComponent />);
-    expect(console.error.calls.count()).toBe(1);
-    expect(
-      console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
-    ).toBe(
-      'Warning: Failed context type: The context `name` is marked as ' +
-      'required in `SimpleComponent`, but its value is `undefined`.\n' +
-      '    in SimpleComponent (at **)'
-    );
-  });
-
-  it('can scryRenderedDOMComponentsWithClass with TextComponent', function() {
-    class Wrapper extends React.Component {
-      render() {
-        return <div>Hello <span>Jim</span></div>;
-      }
-    }
-
-    var renderedComponent = ReactTestUtils.renderIntoDocument(<Wrapper />);
-    var scryResults = ReactTestUtils.scryRenderedDOMComponentsWithClass(
-      renderedComponent,
-      'NonExistentClass'
-    );
-    expect(scryResults.length).toBe(0);
-  });
-
-  it('can scryRenderedDOMComponentsWithClass with className contains \\n', function() {
-    class Wrapper extends React.Component {
-      render() {
-        return <div>Hello <span className={'x\ny'}>Jim</span></div>;
-      }
-    }
-
-    var renderedComponent = ReactTestUtils.renderIntoDocument(<Wrapper />);
-    var scryResults = ReactTestUtils.scryRenderedDOMComponentsWithClass(
-      renderedComponent,
-      'x'
-    );
-    expect(scryResults.length).toBe(1);
-  });
-
-  it('can scryRenderedDOMComponentsWithClass with multiple classes', function() {
-    class Wrapper extends React.Component {
-      render() {
-        return <div>Hello <span className={'x y z'}>Jim</span></div>;
-      }
-    }
-
-    var renderedComponent = ReactTestUtils.renderIntoDocument(<Wrapper />);
-    var scryResults1 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
-      renderedComponent,
-      'x y'
-    );
-    expect(scryResults1.length).toBe(1);
-
-    var scryResults2 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
-      renderedComponent,
-      'x z'
-    );
-    expect(scryResults2.length).toBe(1);
-
-    var scryResults3 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
-      renderedComponent,
-      ['x', 'y']
-    );
-    expect(scryResults3.length).toBe(1);
-
-    expect(scryResults1[0]).toBe(scryResults2[0]);
-    expect(scryResults1[0]).toBe(scryResults3[0]);
-
-    var scryResults4 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
-      renderedComponent,
-      ['x', 'a']
-    );
-    expect(scryResults4.length).toBe(0);
-
-    var scryResults5 = ReactTestUtils.scryRenderedDOMComponentsWithClass(
-      renderedComponent,
-      ['x a']
-    );
-    expect(scryResults5.length).toBe(0);
-  });
-
-  it('traverses children in the correct order', function() {
-    class Wrapper extends React.Component {
-      render() {
-        return <div>{this.props.children}</div>;
-      }
-    }
-
-    var container = document.createElement('div');
-    ReactDOM.render(
-      <Wrapper>
-        {null}
-        <div>purple</div>
-      </Wrapper>,
-      container
-    );
-    var tree = ReactDOM.render(
-      <Wrapper>
-        <div>orange</div>
-        <div>purple</div>
-      </Wrapper>,
-      container
-    );
-
-    var log = [];
-    ReactTestUtils.findAllInRenderedTree(tree, function(child) {
-      if (ReactTestUtils.isDOMComponent(child)) {
-        log.push(ReactDOM.findDOMNode(child).textContent);
-      }
-    });
-
-    // Should be document order, not mount order (which would be purple, orange)
-    expect(log).toEqual(['orangepurple', 'orange', 'purple']);
-  });
-
-  it('should support injected wrapper components as DOM components', function() {
-    var getTestDocument = require('getTestDocument');
-
-    var injectedDOMComponents = [
-      'button',
-      'form',
-      'iframe',
-      'img',
-      'input',
-      'option',
-      'select',
-      'textarea',
-    ];
-
-    injectedDOMComponents.forEach(function(type) {
-      var testComponent = ReactTestUtils.renderIntoDocument(
-        React.createElement(type)
+it('should throw when attempting to use ReactTestUtils.Simulate with shallow rendering', function() {
+  class SomeComponent extends React.Component {
+    render() {
+      return (
+        <div onClick={this.props.handleClick}>
+          hello, world.
+        </div>
       );
-      expect(testComponent.tagName).toBe(type.toUpperCase());
-      expect(ReactTestUtils.isDOMComponent(testComponent)).toBe(true);
+    }
+  }
+
+  var handler = jasmine.createSpy('spy');
+  var shallowRenderer = ReactTestUtils.createRenderer();
+  var result = shallowRenderer.render(<SomeComponent handleClick={handler} />);
+
+  expect(() => ReactTestUtils.Simulate.click(result)).toThrowError(
+    'TestUtils.Simulate expects a component instance and not a ReactElement.' +
+    'TestUtils.Simulate will not work if you are using shallow rendering.'
+  );
+  expect(handler).not.toHaveBeenCalled();
+});
+
+it('should not warn when simulating events with extra properties', function() {
+  spyOn(console, 'error');
+
+  var CLIENT_X = 100;
+
+  class Component extends React.Component {
+    handleClick = (e) => {
+      expect(e.clientX).toBe(CLIENT_X);
+    };
+
+    render() {
+      return <div onClick={this.handleClick} />;
+    }
+  }
+
+  var element = document.createElement('div');
+  var instance = ReactDOM.render(<Component />, element);
+  ReactTestUtils.Simulate.click(
+    ReactDOM.findDOMNode(instance),
+    {clientX: CLIENT_X}
+  );
+  expect(console.error.calls.count()).toBe(0);
+});
+
+it('can scry with stateless components involved', function() {
+  var Stateless = () => <div><hr /></div>;
+
+  class SomeComponent extends React.Component {
+    render() {
+      return (
+        <div>
+          <Stateless />
+          <hr />
+        </div>
+      );
+    }
+  }
+
+  var inst = ReactTestUtils.renderIntoDocument(<SomeComponent />);
+  var hrs = ReactTestUtils.scryRenderedDOMComponentsWithTag(inst, 'hr');
+  expect(hrs.length).toBe(2);
+});
+
+describe('Simulate', () => {
+  it('should set the type of the event', () => {
+    let event;
+    const stub = jest.genMockFn().mockImpl((e) => {
+      e.persist();
+      event = e;
     });
 
-    // Full-page components (html, head, body) can't be rendered into a div
-    // directly...
-    class Root extends React.Component {
-      render() {
-        return (
-          <html ref="html">
-            <head ref="head">
-              <title>hello</title>
-            </head>
-            <body ref="body">
-              hello, world
-            </body>
-          </html>
-        );
-      }
-    }
+    const container = document.createElement('div');
+    const instance = ReactDOM.render(<div onKeyDown={stub} />, container);
+    const node = ReactDOM.findDOMNode(instance);
 
-    var markup = ReactDOMServer.renderToString(<Root />);
-    var testDocument = getTestDocument(markup);
-    var component = ReactDOM.render(<Root />, testDocument);
+    ReactTestUtils.Simulate.keyDown(node);
 
-    expect(component.refs.html.tagName).toBe('HTML');
-    expect(component.refs.head.tagName).toBe('HEAD');
-    expect(component.refs.body.tagName).toBe('BODY');
-    expect(ReactTestUtils.isDOMComponent(component.refs.html)).toBe(true);
-    expect(ReactTestUtils.isDOMComponent(component.refs.head)).toBe(true);
-    expect(ReactTestUtils.isDOMComponent(component.refs.body)).toBe(true);
+    expect(event.type).toBe('keydown');
+    expect(event.nativeEvent.type).toBe('keydown');
   });
-
-  it('should change the value of an input field', function() {
-    var obj = {
-      handler: function(e) {
-        e.persist();
-      },
-    };
-    spyOn(obj, 'handler').and.callThrough();
-    var container = document.createElement('div');
-    var instance = ReactDOM.render(<input type="text" onChange={obj.handler} />, container);
-
-    var node = ReactDOM.findDOMNode(instance);
-    node.value = 'giraffe';
-    ReactTestUtils.Simulate.change(node);
-
-    expect(obj.handler).toHaveBeenCalledWith(jasmine.objectContaining({target: node}));
-  });
-
-  it('should change the value of an input field in a component', function() {
-    class SomeComponent extends React.Component {
-      render() {
-        return (
-          <div>
-            <input type="text" ref="input" onChange={this.props.handleChange} />
-          </div>
-        );
-      }
-    }
-
-    var obj = {
-      handler: function(e) {
-        e.persist();
-      },
-    };
-    spyOn(obj, 'handler').and.callThrough();
-    var container = document.createElement('div');
-    var instance = ReactDOM.render(<SomeComponent handleChange={obj.handler} />, container);
-
-    var node = ReactDOM.findDOMNode(instance.refs.input);
-    node.value = 'zebra';
-    ReactTestUtils.Simulate.change(node);
-
-    expect(obj.handler).toHaveBeenCalledWith(jasmine.objectContaining({target: node}));
-  });
-
-  it('should throw when attempting to use ReactTestUtils.Simulate with shallow rendering', function() {
-    class SomeComponent extends React.Component {
-      render() {
-        return (
-          <div onClick={this.props.handleClick}>
-            hello, world.
-          </div>
-        );
-      }
-    }
-
-    var handler = jasmine.createSpy('spy');
-    var shallowRenderer = ReactTestUtils.createRenderer();
-    var result = shallowRenderer.render(<SomeComponent handleClick={handler} />);
-
-    expect(() => ReactTestUtils.Simulate.click(result)).toThrowError(
-      'TestUtils.Simulate expects a component instance and not a ReactElement.' +
-      'TestUtils.Simulate will not work if you are using shallow rendering.'
-    );
-    expect(handler).not.toHaveBeenCalled();
-  });
-
-  it('should not warn when simulating events with extra properties', function() {
-    spyOn(console, 'error');
-
-    var CLIENT_X = 100;
-
-    class Component extends React.Component {
-      handleClick = (e) => {
-        expect(e.clientX).toBe(CLIENT_X);
-      };
-
-      render() {
-        return <div onClick={this.handleClick} />;
-      }
-    }
-
-    var element = document.createElement('div');
-    var instance = ReactDOM.render(<Component />, element);
-    ReactTestUtils.Simulate.click(
-      ReactDOM.findDOMNode(instance),
-      {clientX: CLIENT_X}
-    );
-    expect(console.error.calls.count()).toBe(0);
-  });
-
-  it('can scry with stateless components involved', function() {
-    var Stateless = () => <div><hr /></div>;
-
-    class SomeComponent extends React.Component {
-      render() {
-        return (
-          <div>
-            <Stateless />
-            <hr />
-          </div>
-        );
-      }
-    }
-
-    var inst = ReactTestUtils.renderIntoDocument(<SomeComponent />);
-    var hrs = ReactTestUtils.scryRenderedDOMComponentsWithTag(inst, 'hr');
-    expect(hrs.length).toBe(2);
-  });
-
-  describe('Simulate', () => {
-    it('should set the type of the event', () => {
-      let event;
-      const stub = jest.genMockFn().mockImpl((e) => {
-        e.persist();
-        event = e;
-      });
-
-      const container = document.createElement('div');
-      const instance = ReactDOM.render(<div onKeyDown={stub} />, container);
-      const node = ReactDOM.findDOMNode(instance);
-
-      ReactTestUtils.Simulate.keyDown(node);
-
-      expect(event.type).toBe('keydown');
-      expect(event.nativeEvent.type).toBe('keydown');
-    });
-  });
-
 });

--- a/src/test/__tests__/reactComponentExpect-test.js
+++ b/src/test/__tests__/reactComponentExpect-test.js
@@ -15,31 +15,28 @@ var React;
 var ReactTestUtils;
 var reactComponentExpect;
 
-describe('reactComponentExpect', function() {
+beforeEach(function() {
+  React = require('React');
+  ReactTestUtils = require('ReactTestUtils');
+  reactComponentExpect = require('reactComponentExpect');
+});
 
-  beforeEach(function() {
-    React = require('React');
-    ReactTestUtils = require('ReactTestUtils');
-    reactComponentExpect = require('reactComponentExpect');
-  });
-
-  it('should detect text components', function() {
-    class SomeComponent extends React.Component {
-      render() {
-        return (
-          <div>
-            <div>This is a div</div>
-            {'This is text'}
-          </div>
-        );
-      }
+it('should detect text components', function() {
+  class SomeComponent extends React.Component {
+    render() {
+      return (
+        <div>
+          <div>This is a div</div>
+          {'This is text'}
+        </div>
+      );
     }
+  }
 
-    var component = ReactTestUtils.renderIntoDocument(<SomeComponent />);
+  var component = ReactTestUtils.renderIntoDocument(<SomeComponent />);
 
-    reactComponentExpect(component)
-      .expectRenderedChild()
-      .expectRenderedChildAt(1)
-      .toBeTextComponentWithValue('This is text');
-  });
+  reactComponentExpect(component)
+    .expectRenderedChild()
+    .expectRenderedChildAt(1)
+    .toBeTextComponentWithValue('This is text');
 });


### PR DESCRIPTION
Most of our test files only have one describe block with the name being the name of the file. This isn't useful and is only noise in the test files. It turns out that jest doesn't require it and removed it from the tutorials

I ran the following codemod https://github.com/cpojer/js-codemod/pull/54

```js
find `find . -name __tests__` | grep -v '__tests__$' | xargs ../js-codemod/node_modules/.bin/jscodeshift -t ../js-codemod/transforms/jest-remove-describe.js
```

And had to manually one two file where backtick were not properly re-printed by recast.