### PR TITLE
Convert CallbackQueue to a class

### DIFF
--- a/src/renderers/shared/stack/event/ReactSyntheticEvent.js
+++ b/src/renderers/shared/stack/event/ReactSyntheticEvent.js
@@ -18,4 +18,4 @@ export type DispatchConfig = any;
 
 export class ReactSyntheticEvent extends SyntheticEvent {
   dispatchConfig: DispatchConfig;
-};
+}

--- a/src/renderers/shared/utils/CallbackQueue.js
+++ b/src/renderers/shared/utils/CallbackQueue.js
@@ -27,12 +27,14 @@ var invariant = require('invariant');
  * @implements PooledClass
  * @internal
  */
-function CallbackQueue() {
-  this._callbacks = null;
-  this._contexts = null;
-}
+class CallbackQueue<T> {
+  _callbacks: ?Array<() => void>;
+  _contexts: ?Array<T>;
 
-Object.assign(CallbackQueue.prototype, {
+  constructor() {
+    this._callbacks = null;
+    this._contexts = null;
+  }
 
   /**
    * Enqueues a callback to be invoked when `notifyAll` is invoked.
@@ -41,12 +43,12 @@ Object.assign(CallbackQueue.prototype, {
    * @param {?object} context Context to call `callback` with.
    * @internal
    */
-  enqueue: function(callback, context) {
+  enqueue(callback: () => void, context: T) {
     this._callbacks = this._callbacks || [];
-    this._contexts = this._contexts || [];
     this._callbacks.push(callback);
+    this._contexts = this._contexts || [];
     this._contexts.push(context);
-  },
+  }
 
   /**
    * Invokes all enqueued callbacks and clears the queue. This is invoked after
@@ -54,10 +56,10 @@ Object.assign(CallbackQueue.prototype, {
    *
    * @internal
    */
-  notifyAll: function() {
+  notifyAll() {
     var callbacks = this._callbacks;
     var contexts = this._contexts;
-    if (callbacks) {
+    if (callbacks && contexts) {
       invariant(
         callbacks.length === contexts.length,
         'Mismatched list of contexts in callback queue'
@@ -70,36 +72,35 @@ Object.assign(CallbackQueue.prototype, {
       callbacks.length = 0;
       contexts.length = 0;
     }
-  },
+  }
 
-  checkpoint: function() {
+  checkpoint() {
     return this._callbacks ? this._callbacks.length : 0;
-  },
+  }
 
-  rollback: function(len) {
-    if (this._callbacks) {
+  rollback(len: number) {
+    if (this._callbacks && this._contexts) {
       this._callbacks.length = len;
       this._contexts.length = len;
     }
-  },
+  }
 
   /**
    * Resets the internal queue.
    *
    * @internal
    */
-  reset: function() {
+  reset() {
     this._callbacks = null;
     this._contexts = null;
-  },
+  }
 
   /**
    * `PooledClass` looks for this.
    */
-  destructor: function() {
+  destructor() {
     this.reset();
-  },
-
-});
+  }
+}
 
 module.exports = PooledClass.addPoolingTo(CallbackQueue);


### PR DESCRIPTION
It turns out that flow cannot type `this` with a function constructor + prototype overrides. Turning it to a class makes flow happy and has minimal impact on the output.

In open source, we already use the loose version of the class transform and internally we have one that's outputting even less code if you have `@preventMunge` in the header.

See discussion in https://www.facebook.com/groups/2003630259862046/permalink/2098480820376989/