### PR TITLE
Use proper render method in static markup event listener test

### DIFF
--- a/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/server/__tests__/ReactServerRendering-test.js
@@ -326,7 +326,7 @@ describe('ReactServerRendering', function() {
       var EventPluginHub = require('EventPluginHub');
       var cb = jest.fn();
 
-      ReactServerRendering.renderToString(
+      ReactServerRendering.renderToStaticMarkup(
         <span onClick={cb}>hello world</span>
       );
       expect(EventPluginHub.__getListenerBank()).toEqual({});


### PR DESCRIPTION
The `renderToStaticMarkup` test that checks for event listeners was using the wrong render method.