### PR TITLE
Don't bundle ReactComponentTreeHook in production

### DIFF
--- a/src/umd/ReactUMDEntry.js
+++ b/src/umd/ReactUMDEntry.js
@@ -17,8 +17,17 @@ var React = require('React');
 var ReactUMDEntry = Object.assign({
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
     ReactCurrentOwner: require('ReactCurrentOwner'),
-    ReactComponentTreeHook: require('ReactComponentTreeHook'),
   },
 }, React);
+
+if (__DEV__) {
+  Object.assign(
+    ReactUMDEntry.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
+    {
+      // ReactComponentTreeHook should not be included in production.
+      ReactComponentTreeHook: require('ReactComponentTreeHook'),
+    }
+  );
+}
 
 module.exports = ReactUMDEntry;

--- a/src/umd/ReactWithAddonsUMDEntry.js
+++ b/src/umd/ReactWithAddonsUMDEntry.js
@@ -17,8 +17,17 @@ var ReactWithAddons = require('ReactWithAddons');
 var ReactWithAddonsUMDEntry = Object.assign({
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
     ReactCurrentOwner: require('ReactCurrentOwner'),
-    ReactComponentTreeHook: require('ReactComponentTreeHook'),
   },
 }, ReactWithAddons);
+
+if (__DEV__) {
+  Object.assign(
+    ReactWithAddonsUMDEntry.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
+    {
+      // ReactComponentTreeHook should not be included in production.
+      ReactComponentTreeHook: require('ReactComponentTreeHook'),
+    }
+  );
+}
 
 module.exports = ReactWithAddonsUMDEntry;


### PR DESCRIPTION
Fixes #7492.
This was a build size regression introduced in #7164.

This should go in `15.4.0` if we ship in #7164 in it so I’ll tag as patch just in case.
Feel free to remove the tag if not necessary.

```
   raw     gz Compared to master @ 7b247f3609ad25d79ae267b4b5c919a35da45cb4    
     =      = build/react-dom-fiber.js                                         
     =      = build/react-dom-fiber.min.js                                     
     =      = build/react-dom-server.js                                        
     =      = build/react-dom-server.min.js                                    
     =      = build/react-dom.js                                               
     =      = build/react-dom.min.js                                           
  +202    +34 build/react-with-addons.js                                       
 -3967  -1278 build/react-with-addons.min.js                                   
  +192    +44 build/react.js                                                   
 -3979  -1240 build/react.min.js 
```