### PR TITLE
Fix the HTML for package management

### DIFF
--- a/docs/docs/09.2-package-management.md
+++ b/docs/docs/09.2-package-management.md
@@ -27,11 +27,11 @@ ReactDOM.render(
 ```
 
 Configure [babel](https://babeljs.io/) with a `.babelrc` file:
- 
+
  ```json
  { "presets": ["react"] }
  ```
- 
+
  > Note:
  >
  > If you are using ES2015, you will want to also use the `babel-preset-es2015` package.
@@ -67,19 +67,16 @@ new webpack.DefinePlugin({
 
 Update your HTML file as below:
 
-```html{8,12}
+```html{9}
 <!DOCTYPE html>
 <html>
   <head>
     <meta charset="UTF-8" />
     <title>Hello React!</title>
-    <script src="build/react.js"></script>
-    <script src="build/react-dom.js"></script>
-    <!-- No need for Babel! -->
   </head>
   <body>
     <div id="example"></div>
-    <script src="build/helloworld.js"></script>
+    <script src="bundle.js"></script>
   </body>
 </html>
 ```
@@ -120,4 +117,3 @@ bower install --save react
 ## Using master
 
 We have instructions for building from `master` [in our GitHub repository](https://github.com/facebook/react).
-


### PR DESCRIPTION
I don't think we nead `react.js` and `react-dom.js` in package management, and the bundled file is `bundle.js`.