### PR TITLE
Flow type event plugins

### DIFF
--- a/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
@@ -7,6 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule SimpleEventPlugin
+ * @flow
  */
 
 'use strict';
@@ -30,6 +31,14 @@ var emptyFunction = require('emptyFunction');
 var getEventCharCode = require('getEventCharCode');
 var invariant = require('invariant');
 
+import type {TopLevelTypes} from 'EventConstants';
+import type {
+  DispatchConfig,
+  ReactSyntheticEvent,
+} from 'ReactSyntheticEventType';
+import type {ReactInstance} from 'ReactInstanceType';
+import type {PluginModule} from 'PluginModuleType';
+
 /**
  * Turns
  * ['abort', ...]
@@ -48,8 +57,8 @@ var invariant = require('invariant');
  *   'topAbort': { sameConfig }
  * };
  */
-var eventTypes = {};
-var topLevelEventsToDispatchConfig = {};
+var eventTypes: {[key: string]: DispatchConfig} = {};
+var topLevelEventsToDispatchConfig: {[key: TopLevelTypes]: DispatchConfig} = {};
 [
   'abort',
   'animationEnd',
@@ -131,22 +140,22 @@ var topLevelEventsToDispatchConfig = {};
 
 var onClickListeners = {};
 
-function getDictionaryKey(inst) {
+function getDictionaryKey(inst: ReactInstance): string {
   // Prevents V8 performance issue:
   // https://github.com/facebook/react/pull/7232
   return '.' + inst._rootNodeID;
 }
 
-var SimpleEventPlugin = {
+var SimpleEventPlugin: PluginModule<MouseEvent> = {
 
   eventTypes: eventTypes,
 
   extractEvents: function(
-    topLevelType,
-    targetInst,
-    nativeEvent,
-    nativeEventTarget
-  ) {
+    topLevelType: TopLevelTypes,
+    targetInst: ReactInstance,
+    nativeEvent: MouseEvent,
+    nativeEventTarget: EventTarget,
+  ): null | ReactSyntheticEvent {
     var dispatchConfig = topLevelEventsToDispatchConfig[topLevelType];
     if (!dispatchConfig) {
       return null;
@@ -268,7 +277,11 @@ var SimpleEventPlugin = {
     return event;
   },
 
-  didPutListener: function(inst, registrationName, listener) {
+  didPutListener: function(
+    inst: ReactInstance,
+    registrationName: string,
+    listener: () => void,
+  ): void {
     // Mobile Safari does not fire properly bubble click events on
     // non-interactive elements, which means delegated click listeners do not
     // fire. The workaround for this bug involves attaching an empty click
@@ -286,7 +299,10 @@ var SimpleEventPlugin = {
     }
   },
 
-  willDeleteListener: function(inst, registrationName) {
+  willDeleteListener: function(
+    inst: ReactInstance,
+    registrationName: string,
+  ): void {
     if (registrationName === 'onClick') {
       var key = getDictionaryKey(inst);
       onClickListeners[key].remove();

--- a/src/renderers/shared/stack/event/EventPluginRegistry.js
+++ b/src/renderers/shared/stack/event/EventPluginRegistry.js
@@ -17,13 +17,13 @@ import type {
   ReactSyntheticEvent,
 } from 'ReactSyntheticEventType';
 
-type PluginName = string;
+import type {
+  AnyNativeEvent,
+  PluginName,
+  PluginModule,
+} from 'PluginModuleType';
 
-type PluginModule = {
-  eventTypes: any,
-};
-
-type NamesToPlugins = {[key: PluginName]: PluginModule};
+type NamesToPlugins = {[key: PluginName]: PluginModule<AnyNativeEvent>};
 
 type EventPluginOrder = null | Array<PluginName>;
 
@@ -94,7 +94,7 @@ function recomputePluginOrdering(): void {
  */
 function publishEventForPlugin(
   dispatchConfig: DispatchConfig,
-  pluginModule: PluginModule,
+  pluginModule: PluginModule<AnyNativeEvent>,
   eventName: string,
 ): boolean {
   invariant(
@@ -139,7 +139,7 @@ function publishEventForPlugin(
  */
 function publishRegistrationName(
   registrationName: string,
-  pluginModule: PluginModule,
+  pluginModule: PluginModule<AnyNativeEvent>,
   eventName: string,
 ): void {
   invariant(
@@ -267,22 +267,27 @@ var EventPluginRegistry = {
    */
   getPluginModuleForEvent: function(
     event: ReactSyntheticEvent,
-  ): null | PluginModule {
+  ): null | PluginModule<AnyNativeEvent> {
     var dispatchConfig = event.dispatchConfig;
     if (dispatchConfig.registrationName) {
       return EventPluginRegistry.registrationNameModules[
         dispatchConfig.registrationName
       ] || null;
     }
-    for (var phase in dispatchConfig.phasedRegistrationNames) {
-      if (!dispatchConfig.phasedRegistrationNames.hasOwnProperty(phase)) {
-        continue;
-      }
-      var pluginModule = EventPluginRegistry.registrationNameModules[
-        dispatchConfig.phasedRegistrationNames[phase]
-      ];
-      if (pluginModule) {
-        return pluginModule;
+    if (dispatchConfig.phasedRegistrationNames !== undefined) {
+      // pulling phasedRegistrationNames out of dispatchConfig helps Flow see
+      // that it is not undefined.
+      var {phasedRegistrationNames} = dispatchConfig;
+      for (var phase in phasedRegistrationNames) {
+        if (!phasedRegistrationNames.hasOwnProperty(phase)) {
+          continue;
+        }
+        var pluginModule = EventPluginRegistry.registrationNameModules[
+          phasedRegistrationNames[phase]
+        ];
+        if (pluginModule) {
+          return pluginModule;
+        }
       }
     }
     return null;

--- a/src/renderers/shared/stack/event/EventPluginRegistry.js
+++ b/src/renderers/shared/stack/event/EventPluginRegistry.js
@@ -15,7 +15,7 @@
 import type {
   DispatchConfig,
   ReactSyntheticEvent,
-} from 'ReactSyntheticEvent';
+} from 'ReactSyntheticEventType';
 
 type PluginName = string;
 

--- a/src/renderers/shared/stack/event/PluginModuleType.js
+++ b/src/renderers/shared/stack/event/PluginModuleType.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule PluginModuleType
+ * @flow
+ */
+
+'use strict';
+
+import type {ReactInstance} from 'ReactInstanceType';
+import type {
+  DispatchConfig,
+  ReactSyntheticEvent,
+} from 'ReactSyntheticEventType';
+
+type EventTypes = {[key: string]: DispatchConfig};
+
+export type AnyNativeEvent =
+  Event |
+  KeyboardEvent |
+  MouseEvent |
+  Touch;
+
+export type PluginName = string;
+
+export type PluginModule<NativeEvent> = {
+  eventTypes: EventTypes,
+  extractEvents: (
+    topLevelType: string,
+    targetInst: ReactInstance,
+    nativeTarget: NativeEvent,
+    nativeEventTarget: EventTarget,
+  ) => null | ReactSyntheticEvent,
+  didPutListener?: (
+    inst: ReactInstance,
+    registrationName: string,
+    listener: () => void,
+  ) => void,
+  willDeleteListener?: (
+    inst: ReactInstance,
+    registrationName: string,
+  ) => void,
+  tapMoveThreshold?: number,
+};

--- a/src/renderers/shared/stack/event/ReactSyntheticEventType.js
+++ b/src/renderers/shared/stack/event/ReactSyntheticEventType.js
@@ -14,8 +14,23 @@
 
 'use strict';
 
-export type DispatchConfig = any;
+import type {ReactInstance} from 'ReactInstanceType';
 
-export class ReactSyntheticEvent extends SyntheticEvent {
+export type DispatchConfig = {
+  dependencies: Array<string>,
+  phasedRegistrationNames?: {
+    bubbled: string,
+    captured: string,
+  },
+  registrationName?: string,
+};
+
+export type ReactSyntheticEvent = {
   dispatchConfig: DispatchConfig;
-}
+  getPooled: (
+    dispatchConfig: DispatchConfig,
+    targetInst: ReactInstance,
+    nativeTarget: Event,
+    nativeEventTarget: EventTarget,
+  ) => ReactSyntheticEvent;
+} & SyntheticEvent;

--- a/src/renderers/shared/stack/event/ReactSyntheticEventType.js
+++ b/src/renderers/shared/stack/event/ReactSyntheticEventType.js
@@ -8,7 +8,7 @@
  *
  * Flow type for SyntheticEvent class that includes private properties
  *
- * @providesModule ReactSyntheticEvent
+ * @providesModule ReactSyntheticEventType
  * @flow
  */
 

--- a/src/renderers/shared/stack/reconciler/ReactInstanceType.js
+++ b/src/renderers/shared/stack/reconciler/ReactInstanceType.js
@@ -28,6 +28,7 @@ export type ReactInstance = {
   detachRef: (ref: string) => void,
   getName: () => string,
   getPublicInstance: any,
+  _rootNodeID: number,
 
   // instantiateReactComponent
   _mountIndex: number,


### PR DESCRIPTION
## Type SimpleEventPlugin and TapEventPlugin

- Fills in the 'any' holes that were left in DispatchConfig type and the
  type annotations in EventPluginRegistry.
- Adds polymorphic PluginModule type and related types
- Uses hack to support indexable properties on 'Touch' type in
  TapEventPlugin

The issue in TapEventPlugin is that the code is accessing one of four
possible properties on the 'Touch' type native event using the bracket
accessor. Classes in Flow don't support using the bracket accessor,
unless you use a declaration and the syntax `[key: Type]: Type`.[1] The
downside of using that here is that we create a global type, which we
may not need in other files.

[1]: https://github.com/facebook/flow/issues/1323

Other options:
- Use looser typing or a '@FixMe' comment and open an issue with Flow to
  support indexing on regular classes.
- Rewrite TapEventPlugin to not use the bracket accessor on 'Touch'. I
  thought the current implementation was elegant and didn't want to
  change it. But we could do something like this:
```
 if (nativeEvent.pageX || nativeEvent.pageY) {
   return axis.page === 'pageX' ? nativeEvent.pageX : nativeEvent.pageY;
 } else {
   var clientAxis = axis.client === 'clientX' ? nativeEvent.clientX : nativeEvent.clientY;
   return nativeEvent[axis.client] + ViewportMetrics[axis.envScroll];
 }
```
