### PR TITLE
Adjust code to handle more availability of function.name

### DIFF
--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -24,6 +24,12 @@ import type { ReactPropTypeLocations } from 'ReactPropTypeLocations';
 
 var MIXINS_KEY = 'mixins';
 
+// Helper function to allow the creation of anonymous functions which do not
+// have .name set to the name of the variable being assigned to.
+function identity(fn) {
+  return fn;
+}
+
 /**
  * Policies that describe methods in `ReactClassInterface`.
  */
@@ -762,7 +768,10 @@ var ReactClass = {
    * @public
    */
   createClass: function(spec) {
-    var Constructor = function(props, context, updater) {
+    // To keep our warnings more understandable, we'll use a little hack here to
+    // ensure that Constructor.name !== 'Constructor'. This makes sure we don't
+    // unnecessarily identify a class without displayName as 'Constructor'.
+    var Constructor = identity(function(props, context, updater) {
       // This constructor gets overridden by mocks. The argument is used
       // by mocks to assert on what gets mounted.
 
@@ -806,7 +815,7 @@ var ReactClass = {
       );
 
       this.state = initialState;
-    };
+    });
     Constructor.prototype = new ReactClassComponent();
     Constructor.prototype.constructor = Constructor;
     Constructor.prototype.__reactAutoBindPairs = [];


### PR DESCRIPTION
As @vjeux noted in https://www.facebook.com/groups/2003630259862046/permalink/2102903916601346/, using node v6.5 fails some tests. This is due to the status quo where `function.name` isn't well supported. @keyanzhang point to https://github.com/facebook/react/blob/ed8a753346661ca8ecff04385f6cf4abe87167c1/src/isomorphic/classic/class/ReactClass.js#L765 which is the function name we're picking up.

I changed a couple places in our code which were falling back to `function.name` to actually attempt to differentiate between cases where that's useful. It's not useful for the `React.createClass` cases since that will always be `Constructor`. Instead I check if we have a `displayName` property instead of just using truthiness which seems to be good enough to differentiate.

Tangential - we should probably consolidate so we don't duplicate this code. Originally it was pretty simple but we've had to add more checks and it's gotten longer. It's slightly different in these 2 places but close enough (and we can just use the same thing in both places).

**Test Plan:** Run tests in both node v6.5 & 4.x. Pass consistently.