### PR TITLE
Type shouldUpdateReactComponent

### DIFF
--- a/src/renderers/native/ReactNative.js
+++ b/src/renderers/native/ReactNative.js
@@ -21,13 +21,15 @@ var ReactUpdates = require('ReactUpdates');
 
 var findNodeHandle = require('findNodeHandle');
 
+import type { ReactElement } from 'ReactElementType';
+
 ReactNativeDefaultInjection.inject();
 
 var render = function(
-  element: ReactElement<any>,
+  element: ReactElement | string | number | null | false,
   mountInto: number,
   callback?: ?(() => void)
-): ?ReactComponent<any, any, any> {
+): ReactElement | string | number | null | false {
   return ReactNativeMount.renderComponent(element, mountInto, callback);
 };
 

--- a/src/renderers/native/ReactNativeMount.js
+++ b/src/renderers/native/ReactNativeMount.js
@@ -24,6 +24,8 @@ var emptyObject = require('emptyObject');
 var instantiateReactComponent = require('instantiateReactComponent');
 var shouldUpdateReactComponent = require('shouldUpdateReactComponent');
 
+import type { ReactElement } from 'ReactElementType';
+
 /**
  * Temporary (?) hack so that we can store all top-level pending updates on
  * composites instead of having to worry about different types of components
@@ -99,10 +101,10 @@ var ReactNativeMount = {
    * @param {containerTag} containerView Handle to native view tag
    */
   renderComponent: function(
-    nextElement: ReactElement<*>,
+    nextElement: ReactElement | string | number | null | false,
     containerTag: number,
     callback?: ?(() => void)
-  ): ?ReactComponent<any, any, any> {
+  ): ReactElement | string | number | null | false {
     var nextWrappedElement = React.createElement(
       TopLevelWrapper,
       { child: nextElement }

--- a/src/renderers/shared/shared/shouldUpdateReactComponent.js
+++ b/src/renderers/shared/shared/shouldUpdateReactComponent.js
@@ -7,9 +7,12 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule shouldUpdateReactComponent
+ * @flow
  */
 
 'use strict';
+
+import type { ReactElement } from 'ReactElementType';
 
 /**
  * Given a `prevElement` and `nextElement`, determines if the existing
@@ -22,24 +25,29 @@
  * @return {boolean} True if the existing instance should be updated.
  * @protected
  */
-function shouldUpdateReactComponent(prevElement, nextElement) {
-  var prevEmpty = prevElement === null || prevElement === false;
-  var nextEmpty = nextElement === null || nextElement === false;
-  if (prevEmpty || nextEmpty) {
-    return prevEmpty === nextEmpty;
+function shouldUpdateReactComponent(
+  prevElement: ReactElement | string | number | null | false,
+  nextElement: ReactElement | string | number | null | false,
+): boolean {
+  if (prevElement === null || prevElement === false) {
+    return nextElement === null || nextElement === false;
   }
 
-  var prevType = typeof prevElement;
-  var nextType = typeof nextElement;
-  if (prevType === 'string' || prevType === 'number') {
-    return (nextType === 'string' || nextType === 'number');
-  } else {
-    return (
-      nextType === 'object' &&
-      prevElement.type === nextElement.type &&
-      prevElement.key === nextElement.key
-    );
+  if (nextElement === null || nextElement === false) {
+    // We already checked that "prevElement === null || prevElement === false"
+    // didn't pass so we can just return false and not recompute it
+    return false;
   }
+
+  if (typeof prevElement === 'string' || typeof prevElement === 'number') {
+    return typeof nextElement === 'string' || typeof nextElement === 'number';
+  }
+
+  return (
+    typeof nextElement === 'object' &&
+    prevElement.type === nextElement.type &&
+    prevElement.key === nextElement.key
+  );
 }
 
 module.exports = shouldUpdateReactComponent;


### PR DESCRIPTION
Flow doesn't like that we put null-check conditions into variables as it loses track of them. I rewrote the logic a bit and took extra care of minimizing the extra work. The only place where I couldn't make it better is for the `typeof prevElement` which is duplicated twice, but I'm guessing that's not so bad...

I had to update some ReactNative files as they use the baked in flow definition which clashes with the internal one. I'm not sure if this is fine?