### PR TITLE
[docs] Link to mixins considered harmful

### DIFF
--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -156,6 +156,8 @@ ReactDOM.render(
 
 ## Mixins
 
+Read about why [mixins are considered harmful](https://facebook.github.io/react/blog/2016/07/13/mixins-considered-harmful.html) at Facebook.
+
 Components are the best way to reuse code in React, but sometimes very different components may share some common functionality. These are sometimes called [cross-cutting concerns](https://en.wikipedia.org/wiki/Cross-cutting_concern). React provides `mixins` to solve this problem.
 
 One common use case is a component wanting to update itself on a time interval. It's easy to use `setInterval()`, but it's important to cancel your interval when you don't need it anymore to save memory. React provides [lifecycle methods](/react/docs/working-with-the-browser.html#component-lifecycle) that let you know when a component is about to be created or destroyed. Let's create a simple mixin that uses these methods to provide an easy `setInterval()` function that will automatically get cleaned up when your component is destroyed.


### PR DESCRIPTION
Extend the knowledge about mixins contained in [reusable components](https://facebook.github.io/react/docs/reusable-components.html) to include [mixins considered harmful](https://facebook.github.io/react/blog/2016/07/13/mixins-considered-harmful.html).
