### PR TITLE
Revert "Add unknown property warning for use of `autofocus`"

### DIFF
--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -41,7 +41,7 @@ var HTMLDOMPropertyConfig = {
     async: HAS_BOOLEAN_VALUE,
     autoComplete: 0,
     // autoFocus is polyfilled/normalized by AutoFocusUtils
-    autoFocus: HAS_BOOLEAN_VALUE,
+    // autoFocus: HAS_BOOLEAN_VALUE,
     autoPlay: HAS_BOOLEAN_VALUE,
     capture: HAS_BOOLEAN_VALUE,
     cellPadding: 0,
@@ -205,7 +205,6 @@ var HTMLDOMPropertyConfig = {
   },
   DOMAttributeNames: {
     acceptCharset: 'accept-charset',
-    autoFocus: 'autofocus',
     className: 'class',
     htmlFor: 'for',
     httpEquiv: 'http-equiv',

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -1495,22 +1495,5 @@ describe('ReactDOMComponent', () => {
       //since hard coding the line number would make test too brittle
       expect(parseInt(previousLine, 10) + 12).toBe(parseInt(currentLine, 10));
     });
-
-    it('should suggest property name if available', () => {
-      spyOn(console, 'error');
-
-      ReactTestUtils.renderIntoDocument(React.createElement('label', {for: 'test'}));
-      ReactTestUtils.renderIntoDocument(React.createElement('input', {type: 'text', autofocus: true}));
-
-      expect(console.error.calls.count()).toBe(2);
-
-      expect(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: Unknown DOM property for. Did you mean htmlFor?\n    in label'
-      );
-
-      expect(console.error.calls.argsFor(1)[0]).toBe(
-        'Warning: Unknown DOM property autofocus. Did you mean autoFocus?\n    in input'
-      );
-    });
   });
 });


### PR DESCRIPTION
Reverts facebook/react#6461

See https://github.com/facebook/react/pull/6461#issuecomment-245727376 for the reasoning.