### PR TITLE
Do not allocate an array if no before input events

### DIFF
--- a/src/renderers/dom/client/eventPlugins/BeforeInputEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/BeforeInputEventPlugin.js
@@ -457,20 +457,21 @@ var BeforeInputEventPlugin = {
     nativeEvent,
     nativeEventTarget
   ) {
-    return [
-      extractCompositionEvent(
-        topLevelType,
-        targetInst,
-        nativeEvent,
-        nativeEventTarget
-      ),
-      extractBeforeInputEvent(
-        topLevelType,
-        targetInst,
-        nativeEvent,
-        nativeEventTarget
-      ),
-    ];
+    var compose = extractCompositionEvent(
+      topLevelType,
+      targetInst,
+      nativeEvent,
+      nativeEventTarget
+    );
+
+    var before = extractBeforeInputEvent(
+      topLevelType,
+      targetInst,
+      nativeEvent,
+      nativeEventTarget
+    );
+
+    return compose && before ? [compose, before] : compose ? compose : before;
   },
 };
 


### PR DESCRIPTION
Mostly following up on https://github.com/facebook/react/pull/7642#issuecomment-244517229. 

`BeforeInputEventPlugin` returns `[null, null]` a lot - I think every time an event dispatches. I also think this leads to a bunch of null/empty checks later down the event pipeline that could be eliminated, though I didn't address them here (maybe they would get easier to identify as Flow types trickle down).

This also saves an array on every single event dispatch, which may or not be substantial, but the fix is straightforward, so I thought I'd give it a try.