### PR TITLE
jest@15.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "gulp-load-plugins": "^1.2.4",
     "gulp-util": "^3.0.7",
     "gzip-js": "~0.3.2",
-    "jest": "^15.0.2",
+    "jest": "^15.1.1",
     "loose-envify": "^1.1.0",
     "merge-stream": "^1.0.0",
     "object-assign": "^4.1.0",
@@ -113,7 +113,6 @@
     ],
     "collectCoverageFrom": [
       "src/**/*.js",
-      "!src/**/__tests__/*.js",
       "!src/shared/vendor/third_party/*.js",
       "!src/test/*.js"
     ],


### PR DESCRIPTION
we exclude test files from the coverage report by default now