### PR TITLE
Add unknown property warning for use of `autofocus`

### DIFF
--- a/src/renderers/dom/shared/DOMProperty.js
+++ b/src/renderers/dom/shared/DOMProperty.js
@@ -193,9 +193,13 @@ var DOMProperty = {
   /**
    * Mapping from lowercase property names to the properly cased version, used
    * to warn in the case of missing properties. Available only in __DEV__.
+   *
+   * autofocus is predefined, because adding it to the property whitelist
+   * causes unintended side effects.
+   *
    * @type {Object}
    */
-  getPossibleStandardName: __DEV__ ? {} : null,
+  getPossibleStandardName: __DEV__ ? {autofocus: 'autoFocus'} : null,
 
   /**
    * All of the isCustomAttribute() functions that have been injected.

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -1495,5 +1495,22 @@ describe('ReactDOMComponent', () => {
       //since hard coding the line number would make test too brittle
       expect(parseInt(previousLine, 10) + 12).toBe(parseInt(currentLine, 10));
     });
+
+    it('should suggest property name if available', () => {
+      spyOn(console, 'error');
+
+      ReactTestUtils.renderIntoDocument(React.createElement('label', {for: 'test'}));
+      ReactTestUtils.renderIntoDocument(React.createElement('input', {type: 'text', autofocus: true}));
+
+      expect(console.error.calls.count()).toBe(2);
+
+      expect(console.error.calls.argsFor(0)[0]).toBe(
+        'Warning: Unknown DOM property for. Did you mean htmlFor?\n    in label'
+      );
+
+      expect(console.error.calls.argsFor(1)[0]).toBe(
+        'Warning: Unknown DOM property autofocus. Did you mean autoFocus?\n    in input'
+      );
+    });
   });
 });


### PR DESCRIPTION
Resolves #3248 
Resubmission of #6461

cc @Aweary @zpao 
