### PR TITLE
[rfc] Support nested arrays of styles for inline styling prop

### DIFF
--- a/examples/inline-styles-in-jsx/index.html
+++ b/examples/inline-styles-in-jsx/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Inline Styles with JSX</title>
+    <link rel="stylesheet" href="../shared/css/base.css" />
+  </head>
+  <body>
+    <h1>Inline Styles with JSX</h1>
+    <div id="container">
+      <p>
+        To install React, follow the instructions on
+        <a href="https://github.com/facebook/react/">GitHub</a>.
+      </p>
+      <p>
+        If you can see this, React is <strong>not</strong> working right.
+        If you checked out the source from GitHub make sure to run <code>grunt</code>.
+      </p>
+    </div>
+    <h4>Example Details</h4>
+    <p>
+      This example includes inline styles.
+      It is written with JSX and transformed in the browser.
+    </p>
+    <p>
+      Learn more about React at
+      <a href="https://facebook.github.io/react" target="_blank">facebook.github.io/react</a>.
+    </p>
+    <script src="../../build/react.js"></script>
+    <script src="../../build/react-dom.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.24/browser.min.js"></script>
+    <script type="text/babel">
+      var ExampleApplication = React.createClass({
+        render: function() {
+          var elapsed = Math.round(this.props.elapsed  / 100);
+          var seconds = elapsed / 10 + (elapsed % 10 ? '' : '.0' );
+          var message1 =
+            'React has been successfully running for ' + seconds + ' seconds.';
+          var message2 = 'This message should be green and underlined.';
+          var styles = {
+            base: {textDecoration: 'underline'},
+            bold: {fontWeight: 'bold'},
+          };
+          var isBold = false;
+
+          return (
+            <div>
+              <p>
+                {message1}
+              </p>
+              <p style={[
+                styles.base,
+                isBold && styles.bold,
+                [{color: 'blue'}, {color: 'green'}],
+              ]}>
+                {message2}
+              </p>
+           </div>
+          );
+        }
+      });
+      var start = new Date().getTime();
+      setInterval(function() {
+        ReactDOM.render(
+          <ExampleApplication elapsed={new Date().getTime() - start} />,
+          document.getElementById('container')
+        );
+      }, 50);
+    </script>
+  </body>
+</html>

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -34,6 +34,7 @@ var ReactServerRenderingTransaction = require('ReactServerRenderingTransaction')
 
 var emptyFunction = require('emptyFunction');
 var escapeTextContentForBrowser = require('escapeTextContentForBrowser');
+var flattenStyleArray = require('flattenStyleArray');
 var invariant = require('invariant');
 var isEventSupported = require('isEventSupported');
 var shallowEqual = require('shallowEqual');
@@ -995,6 +996,9 @@ ReactDOMComponent.Mixin = {
       }
       if (propKey === STYLE) {
         if (nextProp) {
+          if (Array.isArray(nextProp)) {
+            nextProp = flattenStyleArray(nextProp);
+          }
           if (__DEV__) {
             checkAndWarnForMutatedStyle(
               this._previousStyleCopy,

--- a/src/renderers/dom/shared/__tests__/flattenStyleArray-test.js
+++ b/src/renderers/dom/shared/__tests__/flattenStyleArray-test.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var flattenStyleArray = require('flattenStyleArray');
+
+describe('flattenStyleArray', () => {
+  it('should flatten an array of objects', () => {
+    expect(flattenStyleArray([
+      {foo: 1},
+      {bar: 2},
+    ])).toEqual({foo: 1, bar: 2});
+  });
+
+  it('should flatten nested arrays of objects', () => {
+    expect(flattenStyleArray([
+      {foo: 1},
+      {bar: 2},
+      [{foo: 2, bar: 3}, {bar: 4}],
+    ])).toEqual({foo: 2, bar: 4});
+  });
+
+  it('should ignore null, false, or undefined values when flattening', () => {
+    expect(flattenStyleArray([
+      {foo: 1},
+      undefined,
+      false,
+      {bar: 2},
+      null,
+    ])).toEqual({foo: 1, bar: 2});
+  });
+
+  it('should handle deeply nested arrays', () => {
+    expect(flattenStyleArray([
+      {foo: 1},
+      {bar: 2},
+      [[[[[
+        {foo: 2},
+        [[[[[
+          {foo: 3},
+          [[[[[
+            {bar: 3},
+            [[[[[
+              {bar: 4},
+            ]]]]],
+          ]]]]],
+        ]]]]],
+      ]]]]],
+    ])).toEqual({foo: 3, bar: 4});
+  });
+});

--- a/src/renderers/dom/shared/flattenStyleArray.js
+++ b/src/renderers/dom/shared/flattenStyleArray.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule flattenStyleArray
+ * @flow
+ */
+
+'use strict';
+
+type NestedStylesArray = Array<Object | NestedStylesArray | null | false>;
+
+var result = {};
+
+function flattenStyleArray(nestedStylesArray: NestedStylesArray): Object {
+  nestedStylesArray.forEach((styleObjOrArray) => {
+    if (Array.isArray(styleObjOrArray)) {
+      flattenStyleArray(styleObjOrArray);
+    } else if (typeof styleObjOrArray === 'object' &&
+               styleObjOrArray !== null) {
+      // it is an object
+      // reassigning this value helps Flow remember that it is not null
+      var styleObj = styleObjOrArray;
+      Object.keys(styleObjOrArray).forEach(styleName => {
+        result[styleName] = styleObj[styleName];
+      });
+    }
+  });
+
+  return result;
+}
+
+module.exports = flattenStyleArray;


### PR DESCRIPTION
This is already a supported feature in ReactNative.[1] You can write;

```js
style={[
  styles.base,
  cond && styles.cond,
  [{color: blue}, {color: green}],
]}
```
[1]: https://facebook.github.io/react-native/docs/style.html

This diff makes the smallest possible tweak to add support for this
feature - if we get a nested array, then merge the nested arrays into
one object and handle it the same as before. Because the merging only
happens when the style prop is an array, there should be little or no
effect on performance when using the old syntax.

Even so, I would like to have more robust testing before landing this.
It would be easier to test and benchmark this change if we pulled the
diffing logic from the method `_updateDOMProperties` out into a separate
module.

Perhaps before adding this feature we could;
- pull out the logic for diffing the 'prevProps' and 'nextProps' into a
  separate module, used by '_updateDOMProperties'.
- test and benchmark that module

Then we could more easily add test cases for the new syntax that this
would support.

Or perhaps I'm over thinking it and this could be landed before doing
refactoring.

Test plan;
- existing unit tests, lints, flow all pass
(note: there are some flow errors on master, which I plan to fix in a
separate PR. None are introduced by this change though.)
- added unit test for 'flattenStyleArray' method
- added example in examples file