### PR TITLE
Add case typo catching for prop types

### DIFF
--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -433,6 +433,29 @@ describe('ReactElementValidator', () => {
     expect(console.error.calls.count()).toBe(2);
   });
 
+  it('should throw on mispelling a prop type', () => {
+    spyOn(console, 'error');
+
+    var Foo = React.createClass({
+      displayName: 'Foo',
+      propTypes: {
+        onAction: React.PropTypes.func,
+      },
+      render: function() {
+        return <span onClick={this.props.onAction}></span>;
+      },
+    });
+
+    ReactTestUtils.renderIntoDocument(
+      React.createElement(Foo, {onaction: () => console.log('action')})
+    );
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.argsFor(0)[0]).toBe(
+      'Warning: Foo: prop type `onaction` was not defined in PropTypes; ' +
+      'did you mean to use `onAction`?'
+    );
+  });
+
   it('should warn if a PropType creator is used as a PropType', () => {
     spyOn(console, 'error');
 

--- a/src/shared/types/checkReactTypeSpec.js
+++ b/src/shared/types/checkReactTypeSpec.js
@@ -66,7 +66,7 @@ function checkReactTypeSpec(
       // Check for potential improperly cased property name that was defined
       // in the element's propTypes
       let keys = Object.keys(values);
-      if (!keys.includes(typeSpecName)) {
+      if (keys.indexOf(typeSpecName) === -1) {
         let equiPos = keys.map(a => a.toLowerCase()).indexOf(typeSpecName.toLowerCase());
         warning(
           equiPos === -1,

--- a/src/shared/types/checkReactTypeSpec.js
+++ b/src/shared/types/checkReactTypeSpec.js
@@ -62,6 +62,21 @@ function checkReactTypeSpec(
       // Prop type validation may throw. In case they do, we don't want to
       // fail the render phase where it didn't fail before. So we log it.
       // After these have been cleaned up, we'll let them throw.
+
+      // Check for potential improperly cased property name that was defined
+      // in the element's propTypes
+      let keys = Object.keys(values);
+      if (!keys.includes(typeSpecName)) {
+        let equiPos = keys.map(a => a.toLowerCase()).indexOf(typeSpecName.toLowerCase());
+        warning(
+          equiPos === -1,
+          '%s: prop type `%s` was not defined in PropTypes; did you mean to use `%s`?',
+          componentName,
+          keys[equiPos],
+          typeSpecName
+        );
+      }
+
       try {
         // This is intentionally an invariant that gets caught. It's the same
         // behavior as without this statement except with a better message.


### PR DESCRIPTION
We currently don't warn for properties that don't exist in the propTypes set. I.e. we don't catch typos.

This is an attempt at fixing that (This issue is at #6153)
