### PR TITLE
Fix Flow errors in Event Plugins

### DIFF
--- a/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
@@ -37,7 +37,10 @@ import type {
   ReactSyntheticEvent,
 } from 'ReactSyntheticEventType';
 import type {ReactInstance} from 'ReactInstanceType';
-import type {PluginModule} from 'PluginModuleType';
+import type {
+  EventTypes,
+  PluginModule,
+} from 'PluginModuleType';
 
 /**
  * Turns
@@ -57,7 +60,7 @@ import type {PluginModule} from 'PluginModuleType';
  *   'topAbort': { sameConfig }
  * };
  */
-var eventTypes: {[key: string]: DispatchConfig} = {};
+var eventTypes: EventTypes = {};
 var topLevelEventsToDispatchConfig: {[key: TopLevelTypes]: DispatchConfig} = {};
 [
   'abort',

--- a/src/renderers/dom/client/eventPlugins/TapEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/TapEventPlugin.js
@@ -21,8 +21,10 @@ var ViewportMetrics = require('ViewportMetrics');
 var isStartish = EventPluginUtils.isStartish;
 var isEndish = EventPluginUtils.isEndish;
 
-import type {DispatchConfig} from 'ReactSyntheticEventType';
-import type {PluginModule} from 'PluginModuleType';
+import type {
+  EventTypes,
+  PluginModule,
+} from 'PluginModuleType';
 import type {ReactInstance} from 'ReactInstanceType';
 import type {TopLevelTypes} from 'EventConstants';
 
@@ -109,7 +111,7 @@ var dependencies = [
   'topMouseUp',
 ].concat(touchEvents);
 
-var eventTypes: DispatchConfig = {
+var eventTypes: EventTypes = {
   touchTap: {
     phasedRegistrationNames: {
       bubbled: 'onTouchTap',

--- a/src/renderers/dom/client/eventPlugins/__tests__/SimpleEventPlugin-test.js
+++ b/src/renderers/dom/client/eventPlugins/__tests__/SimpleEventPlugin-test.js
@@ -128,7 +128,7 @@ describe('SimpleEventPlugin', function() {
       onClick.mockClear();
     });
 
-    it ('does not add a local click to interactive elements', function() {
+    it('does not add a local click to interactive elements', function() {
       var container = document.createElement('div');
 
       ReactDOM.render(<button onClick={ onClick }></button>, container);
@@ -140,7 +140,7 @@ describe('SimpleEventPlugin', function() {
       expect(onClick.mock.calls.length).toBe(0);
     });
 
-    it ('adds a local click listener to non-interactive elements', function() {
+    it('adds a local click listener to non-interactive elements', function() {
       var container = document.createElement('div');
 
       ReactDOM.render(<div onClick={ onClick }></div>, container);

--- a/src/renderers/shared/stack/event/PluginModuleType.js
+++ b/src/renderers/shared/stack/event/PluginModuleType.js
@@ -18,7 +18,7 @@ import type {
   ReactSyntheticEvent,
 } from 'ReactSyntheticEventType';
 
-type EventTypes = {[key: string]: DispatchConfig};
+export type EventTypes = {[key: string]: DispatchConfig};
 
 export type AnyNativeEvent =
   Event |

--- a/src/renderers/shared/stack/reconciler/ReactInstanceType.js
+++ b/src/renderers/shared/stack/reconciler/ReactInstanceType.js
@@ -30,6 +30,9 @@ export type ReactInstance = {
   getPublicInstance: any,
   _rootNodeID: number,
 
+  // ReactDOMComponent
+  _tag: string,
+
   // instantiateReactComponent
   _mountIndex: number,
   _mountImage: any,


### PR DESCRIPTION
Due to a typo in PR#7667 where I put 'DispatchConfig' when the type was
'EventTypes', there were some flow errors being thrown.

Then PR#7642 fixed a bug in SimpleEventPlugin and added some untyped
methods, which threw more flow errors.

Last, while fixing this, I fixed two eslint errors in the
SimpleEventPlugin test.