### PR TITLE
Convert ReactCSSTransitionGroupChild to React.Component

### DIFF
--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -21,10 +21,10 @@ var onlyChild = require('onlyChild');
 
 var TICK = 17;
 
-var ReactCSSTransitionGroupChild = React.createClass({
-  displayName: 'ReactCSSTransitionGroupChild',
+class ReactCSSTransitionGroupChild extends React.Component {
+  static displayName = 'ReactCSSTransitionGroupChild';
 
-  propTypes: {
+  static propTypes = {
     name: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.shape({
@@ -51,9 +51,9 @@ var ReactCSSTransitionGroupChild = React.createClass({
     appearTimeout: React.PropTypes.number,
     enterTimeout: React.PropTypes.number,
     leaveTimeout: React.PropTypes.number,
-  },
+  };
 
-  transition: function(animationType, finishCallback, userSpecifiedDelay) {
+  transition = (animationType, finishCallback, userSpecifiedDelay) => {
     var node = ReactAddonsDOMDependencies.getReactDOM().findDOMNode(this);
 
     if (!node) {
@@ -100,9 +100,9 @@ var ReactCSSTransitionGroupChild = React.createClass({
       // DEPRECATED: this listener will be removed in a future version of react
       ReactTransitionEvents.addEndEventListener(node, endListener);
     }
-  },
+  };
 
-  queueClassAndNode: function(className, node) {
+  queueClassAndNode = (className, node) => {
     this.classNameAndNodeQueue.push({
       className: className,
       node: node,
@@ -111,24 +111,22 @@ var ReactCSSTransitionGroupChild = React.createClass({
     if (!this.timeout) {
       this.timeout = setTimeout(this.flushClassNameAndNodeQueue, TICK);
     }
-  },
+  };
 
-  flushClassNameAndNodeQueue: function() {
-    if (this.isMounted()) {
-      this.classNameAndNodeQueue.forEach(function(obj) {
-        CSSCore.addClass(obj.node, obj.className);
-      });
-    }
+  flushClassNameAndNodeQueue = () => {
+    this.classNameAndNodeQueue.forEach(function(obj) {
+      CSSCore.addClass(obj.node, obj.className);
+    });
     this.classNameAndNodeQueue.length = 0;
     this.timeout = null;
-  },
+  };
 
-  componentWillMount: function() {
+  componentWillMount() {
     this.classNameAndNodeQueue = [];
     this.transitionTimeouts = [];
-  },
+  }
 
-  componentWillUnmount: function() {
+  componentWillUnmount() {
     if (this.timeout) {
       clearTimeout(this.timeout);
     }
@@ -137,35 +135,35 @@ var ReactCSSTransitionGroupChild = React.createClass({
     });
 
     this.classNameAndNodeQueue.length = 0;
-  },
+  }
 
-  componentWillAppear: function(done) {
+  componentWillAppear = (done) => {
     if (this.props.appear) {
       this.transition('appear', done, this.props.appearTimeout);
     } else {
       done();
     }
-  },
+  };
 
-  componentWillEnter: function(done) {
+  componentWillEnter = (done) => {
     if (this.props.enter) {
       this.transition('enter', done, this.props.enterTimeout);
     } else {
       done();
     }
-  },
+  };
 
-  componentWillLeave: function(done) {
+  componentWillLeave = (done) => {
     if (this.props.leave) {
       this.transition('leave', done, this.props.leaveTimeout);
     } else {
       done();
     }
-  },
+  };
 
-  render: function() {
+  render() {
     return onlyChild(this.props.children);
-  },
-});
+  }
+}
 
 module.exports = ReactCSSTransitionGroupChild;


### PR DESCRIPTION
This PR is for to convert `ReactCSSTransitionGroupChild` from `React.createClass` to `React.Component` using `react-codemod/transforms/class`.

To do that, I remove `this.isMounted` from `flushClassNameAndNodeQueue`.
- https://github.com/facebook/react/blob/master/src/addons/transitions/ReactCSSTransitionGroupChild.js#L117

It seems to be unnecessary because `ReactCSSTransitionGroupChild` is calling `clearTimer` with the `timerId` returned from the `flushClassNameAndNodeQueue` in its `componentWillUnmount`.

When the `this.isMounted` returns `false`, the `componentWillUnmount` had already been called. 
- https://github.com/facebook/react/blob/master/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js#L534-L575
- https://github.com/facebook/react/blob/master/src/renderers/shared/stack/reconciler/ReactUpdateQueue.js#L104-L112

Therefore the `flushClassNameAndNodeQueue` has never been called when unmounting `ReactCSSTransitionGroupChild` whether the `this.isMounted` is in the `componentWillUnmount` or not.
