### PR TITLE
[Fiber] Child Reconciliation, Refs and Life-Cycles

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -15,6 +15,7 @@
 import type { HostChildren } from 'ReactFiberReconciler';
 
 var ReactFiberReconciler = require('ReactFiberReconciler');
+var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 
 var warning = require('warning');
 
@@ -98,8 +99,9 @@ var DOMRenderer = ReactFiberReconciler({
 var warned = false;
 
 function warnAboutUnstableUse() {
+  // Ignore this warning is the feature flag is turned on. E.g. for tests.
   warning(
-    warned,
+    warned || ReactDOMFeatureFlags.useFiber,
     'You are using React DOM Fiber which is an experimental renderer. ' +
     'It is likely to have bugs, breaking changes and is unsupported.'
   );

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -46,6 +46,7 @@ function recursivelyAppendChildren(parent : Element, child : HostChildren<Instan
 var DOMRenderer = ReactFiberReconciler({
 
   updateContainer(container : Container, children : HostChildren<Instance | TextInstance>) : void {
+    // TODO: Containers should update similarly to other parents.
     container.innerHTML = '';
     recursivelyAppendChildren(container, children);
   },
@@ -63,23 +64,16 @@ var DOMRenderer = ReactFiberReconciler({
   prepareUpdate(
     domElement : Instance,
     oldProps : Props,
-    newProps : Props,
-    children : HostChildren<Instance | TextInstance>
+    newProps : Props
   ) : boolean {
     return true;
   },
 
-  commitUpdate(domElement : Instance, oldProps : Props, newProps : Props, children : HostChildren<Instance | TextInstance>) : void {
-    domElement.innerHTML = '';
-    recursivelyAppendChildren(domElement, children);
+  commitUpdate(domElement : Instance, oldProps : Props, newProps : Props) : void {
     if (typeof newProps.children === 'string' ||
         typeof newProps.children === 'number') {
       domElement.textContent = newProps.children;
     }
-  },
-
-  deleteInstance(instance : Instance) : void {
-    // Noop
   },
 
   createTextInstance(text : string) : TextInstance {
@@ -88,6 +82,18 @@ var DOMRenderer = ReactFiberReconciler({
 
   commitTextUpdate(textInstance : TextInstance, oldText : string, newText : string) : void {
     textInstance.nodeValue = newText;
+  },
+
+  appendChild(parentInstance : Instance, child : Instance | TextInstance) : void {
+    parentInstance.appendChild(child);
+  },
+
+  insertBefore(parentInstance : Instance, child : Instance | TextInstance, beforeChild : Instance | TextInstance) : void {
+    parentInstance.insertBefore(child, beforeChild);
+  },
+
+  removeChild(parentInstance : Instance, child : Instance | TextInstance) : void {
+    parentInstance.removeChild(child);
   },
 
   scheduleAnimationCallback: window.requestAnimationFrame,

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -81,16 +81,12 @@ var NoopRenderer = ReactFiberReconciler({
     return inst;
   },
 
-  prepareUpdate(instance : Instance, oldProps : Props, newProps : Props, children : HostChildren<Instance | TextInstance>) : boolean {
+  prepareUpdate(instance : Instance, oldProps : Props, newProps : Props) : boolean {
     return true;
   },
 
-  commitUpdate(instance : Instance, oldProps : Props, newProps : Props, children : HostChildren<Instance | TextInstance>) : void {
-    instance.children = flattenChildren(children);
+  commitUpdate(instance : Instance, oldProps : Props, newProps : Props) : void {
     instance.prop = newProps.prop;
-  },
-
-  deleteInstance(instance : Instance) : void {
   },
 
   createTextInstance(text : string) : TextInstance {
@@ -102,6 +98,34 @@ var NoopRenderer = ReactFiberReconciler({
 
   commitTextUpdate(textInstance : TextInstance, oldText : string, newText : string) : void {
     textInstance.text = newText;
+  },
+
+  appendChild(parentInstance : Instance, child : Instance | TextInstance) : void {
+    const index = parentInstance.children.indexOf(child);
+    if (index !== -1) {
+      parentInstance.children.splice(index, 1);
+    }
+    parentInstance.children.push(child);
+  },
+
+  insertBefore(parentInstance : Instance, child : Instance | TextInstance, beforeChild : Instance | TextInstance) : void {
+    const index = parentInstance.children.indexOf(child);
+    if (index !== -1) {
+      parentInstance.children.splice(index, 1);
+    }
+    const beforeIndex = parentInstance.children.indexOf(beforeChild);
+    if (beforeIndex === -1) {
+      throw new Error('This child does not exist.');
+    }
+    parentInstance.children.splice(beforeIndex, 0, child);
+  },
+
+  removeChild(parentInstance : Instance, child : Instance | TextInstance) : void {
+    const index = parentInstance.children.indexOf(child);
+    if (index === -1) {
+      throw new Error('This child does not exist.');
+    }
+    parentInstance.children.splice(index, 1);
   },
 
   scheduleAnimationCallback(callback) {

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -221,11 +221,13 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     if (current == null || current.type !== element.type) {
       // Insert
       const created = createFiberFromElement(element, priority);
+      created.ref = element.ref;
       created.return = returnFiber;
       return created;
     } else {
       // Move based on index
       const existing = useFiber(current, priority);
+      existing.ref = element.ref;
       existing.pendingProps = element.props;
       existing.return = returnFiber;
       return existing;
@@ -317,6 +319,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       switch (newChild.$$typeof) {
         case REACT_ELEMENT_TYPE: {
           const created = createFiberFromElement(newChild, priority);
+          created.ref = newChild.ref;
           created.return = returnFiber;
           return created;
         }
@@ -643,6 +646,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         if (child.type === element.type) {
           deleteRemainingChildren(returnFiber, child.sibling);
           const existing = useFiber(child, priority);
+          existing.ref = element.ref;
           existing.pendingProps = element.props;
           existing.return = returnFiber;
           return existing;
@@ -657,6 +661,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     }
 
     const created = createFiberFromElement(element, priority);
+    created.ref = element.ref;
     created.return = returnFiber;
     return created;
   }

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -31,6 +31,7 @@ const {
   cloneFiber,
   createFiberFromElement,
   createFiberFromFragment,
+  createFiberFromText,
   createFiberFromCoroutine,
   createFiberFromYield,
 } = ReactFiber;
@@ -50,6 +51,13 @@ function ChildReconciler(shouldClone) {
     newChildren : any,
     priority : PriorityLevel
   ) : Fiber {
+    if (typeof newChildren === 'string') {
+      const textNode = createFiberFromText(newChildren, priority);
+      previousSibling.sibling = textNode;
+      textNode.return = returnFiber;
+      return textNode;
+    }
+
     if (typeof newChildren !== 'object' || newChildren === null) {
       return previousSibling;
     }
@@ -111,6 +119,12 @@ function ChildReconciler(shouldClone) {
   }
 
   function createFirstChild(returnFiber, existingChild, newChildren : any, priority) {
+    if (typeof newChildren === 'string') {
+      const textNode = createFiberFromText(newChildren, priority);
+      textNode.return = returnFiber;
+      return textNode;
+    }
+
     if (typeof newChildren !== 'object' || newChildren === null) {
       return null;
     }

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -148,10 +148,10 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       clone.sibling = null;
       return clone;
     } else {
-      if (fiber.pendingWorkPriority === NoWork ||
-          fiber.pendingWorkPriority > priority) {
-        fiber.pendingWorkPriority = priority;
-      }
+      // We override the pending priority even if it is higher, because if
+      // we're reconciling at a lower priority that means that this was
+      // down-prioritized.
+      fiber.pendingWorkPriority = priority;
       fiber.effectTag = NoWork;
       fiber.index = 0;
       fiber.sibling = null;

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -56,62 +56,60 @@ const {
   NoWork,
 } = ReactPriorityLevel;
 
-
-function deleteChild(
-  returnFiber : Fiber,
-  childToDelete : Fiber
-) {
-  if (!shouldTrackSideEffects) {
-    // Noop.
-    return;
-  }
-
-  // TODO: Add this child to the side-effect queue for deletion.
-}
-
-function deleteRemainingChildren(
-  returnFiber : Fiber,
-  currentFirstChild : ?Fiber
-) {
-  if (!shouldTrackSideEffects) {
-    // Noop.
-    return null;
-  }
-  // TODO: Add these children to the side-effect queue for deletion.
-  return null;
-}
-
-function mapAndDeleteRemainingChildren(
-  returnFiber : Fiber,
-  currentFirstChild : ?Fiber
-) : Map<string, Fiber> {
-  // Add the remaining children to a temporary map so that we can find them by
-  // keys quickly. At the same time, we'll flag them all for deletion. However,
-  // we will then undo the deletion as we restore children. Implicit (null) keys
-  // don't get added to this set.
-  const existingChildren : Map<string, Fiber> = new Map();
-  let existingChild = currentFirstChild;
-  while (existingChild) {
-    if (existingChild.key !== null) {
-      existingChildren.set(existingChild.key, existingChild);
-    }
-    // Add everything to the delete queue
-    // Actually... It is not possible to delete things from the queue since
-    // we don't have access to the previous link. Does that mean we need a
-    // second pass to add them? We should be able to keep track of the
-    // previous deletion as we're iterating through the list the next time.
-    // That way we know which item to patch when we delete a deletion.
-    existingChild = existingChild.sibling;
-  }
-  return existingChildren;
-}
-
-
 // This wrapper function exists because I expect to clone the code in each path
 // to be able to optimize each path individually by branching early. This needs
 // a compiler or we can do it manually. Helpers that don't need this branching
 // live outside of this function.
 function ChildReconciler(shouldClone, shouldTrackSideEffects) {
+
+  function deleteChild(
+    returnFiber : Fiber,
+    childToDelete : Fiber
+  ) {
+    if (!shouldTrackSideEffects) {
+      // Noop.
+      return;
+    }
+
+    // TODO: Add this child to the side-effect queue for deletion.
+  }
+
+  function deleteRemainingChildren(
+    returnFiber : Fiber,
+    currentFirstChild : ?Fiber
+  ) {
+    if (!shouldTrackSideEffects) {
+      // Noop.
+      return null;
+    }
+    // TODO: Add these children to the side-effect queue for deletion.
+    return null;
+  }
+
+  function mapAndDeleteRemainingChildren(
+    returnFiber : Fiber,
+    currentFirstChild : ?Fiber
+  ) : Map<string, Fiber> {
+    // Add the remaining children to a temporary map so that we can find them by
+    // keys quickly. At the same time, we'll flag them all for deletion. However,
+    // we will then undo the deletion as we restore children. Implicit (null) keys
+    // don't get added to this set.
+    const existingChildren : Map<string, Fiber> = new Map();
+    let existingChild = currentFirstChild;
+    while (existingChild) {
+      if (existingChild.key !== null) {
+        existingChildren.set(existingChild.key, existingChild);
+      }
+      // Add everything to the delete queue
+      // Actually... It is not possible to delete things from the queue since
+      // we don't have access to the previous link. Does that mean we need a
+      // second pass to add them? We should be able to keep track of the
+      // previous deletion as we're iterating through the list the next time.
+      // That way we know which item to patch when we delete a deletion.
+      existingChild = existingChild.sibling;
+    }
+    return existingChildren;
+  }
 
   function useFiber(fiber : Fiber, priority : PriorityLevel) {
     // We currently set sibling to null and index to 0 here because it is easy

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -58,7 +58,6 @@ const {
 } = ReactPriorityLevel;
 
 const {
-  NoEffect,
   Placement,
   Deletion,
 } = ReactTypeOfSideEffect;
@@ -581,10 +580,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       // to add them to the deletion list.
       existingChildren.forEach(child => deleteChild(returnFiber, child));
     }
-
-    // TODO: Add deletions and insert/moves to the side-effect list.
-    // TODO: Clear the deletion list when we don't reconcile in place. When
-    // progressedChild isn't reused.
 
     return resultingFirstChild;
   }

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -16,8 +16,6 @@ import type { ReactCoroutine, ReactYield } from 'ReactCoroutine';
 import type { Fiber } from 'ReactFiber';
 import type { PriorityLevel } from 'ReactPriorityLevel';
 
-import type { ReactNodeList } from 'ReactTypes';
-
 var REACT_ELEMENT_TYPE = require('ReactElementSymbol');
 var {
   REACT_COROUTINE_TYPE,
@@ -25,7 +23,11 @@ var {
 } = require('ReactCoroutine');
 
 var ReactFiber = require('ReactFiber');
+var ReactPriorityLevel = require('ReactPriorityLevel');
 var ReactReifiedYield = require('ReactReifiedYield');
+var ReactTypeOfWork = require('ReactTypeOfWork');
+
+var getIteratorFn = require('getIteratorFn');
 
 const {
   cloneFiber,
@@ -38,211 +40,683 @@ const {
 
 const {
   createReifiedYield,
+  createUpdatedReifiedYield,
 } = ReactReifiedYield;
 
 const isArray = Array.isArray;
 
-function ChildReconciler(shouldClone) {
+const {
+  HostText,
+  CoroutineComponent,
+  YieldComponent,
+  Fragment,
+} = ReactTypeOfWork;
 
-  function createSubsequentChild(
+const {
+  NoWork,
+} = ReactPriorityLevel;
+
+
+function deleteChild(
+  returnFiber : Fiber,
+  childToDelete : Fiber
+) {
+  // TODO: Add this child to the side-effect queue for deletion.
+}
+
+function deleteRemainingChildren(
+  returnFiber : Fiber,
+  currentFirstChild : ?Fiber
+) {
+  // TODO: Add these children to the side-effect queue for deletion.
+  return null;
+}
+
+function mapAndDeleteRemainingChildren(
+  returnFiber : Fiber,
+  currentFirstChild : ?Fiber
+) : Map<string, Fiber> {
+  // Add the remaining children to a temporary map so that we can find them by
+  // keys quickly. At the same time, we'll flag them all for deletion. However,
+  // we will then undo the deletion as we restore children. Implicit (null) keys
+  // don't get added to this set.
+  const existingChildren : Map<string, Fiber> = new Map();
+  // TODO: This also needs to store the "previous index of this node". That lets
+  // us determine whether something needs to be a placement. It might be best to
+  // just store this on the fiber itself since that lets us use the "implicit"
+  // index resolution mechanism without adding null values to the linked list.
+  let existingChild = currentFirstChild;
+  while (existingChild) {
+    if (existingChild.key !== null) {
+      existingChildren.set(existingChild.key, existingChild);
+    }
+    // Add everything to the delete queue
+    // Actually... It is not possible to delete things from the queue since
+    // we don't have access to the previous link. Does that mean we need a
+    // second pass to add them? We should be able to keep track of the
+    // previous deletion as we're iterating through the list the next time.
+    // That way we know which item to patch when we delete a deletion.
+    existingChild = existingChild.sibling;
+  }
+  return existingChildren;
+}
+
+
+// This wrapper function exists because I expect to clone the code in each path
+// to be able to optimize each path individually by branching early. This needs
+// a compiler or we can do it manually. Helpers that don't need this branching
+// live outside of this function.
+function ChildReconciler(shouldClone, shouldTrackSideEffects) {
+
+  function useFiber(fiber : Fiber, priority : PriorityLevel) {
+    // We currently set sibling to null here because it is easy to forget to do
+    // before returning it.
+    if (shouldClone) {
+      const clone = cloneFiber(fiber, priority);
+      clone.sibling = null;
+      return clone;
+    } else {
+      if (fiber.pendingWorkPriority === NoWork ||
+          fiber.pendingWorkPriority > priority) {
+        fiber.pendingWorkPriority = priority;
+      }
+      fiber.sibling = null;
+      return fiber;
+    }
+  }
+
+  function updateTextNode(
     returnFiber : Fiber,
-    existingChild : ?Fiber,
-    previousSibling : Fiber,
-    newChildren : any,
+    current : ?Fiber,
+    textContent : string,
     priority : PriorityLevel
-  ) : Fiber {
-    if (typeof newChildren === 'string') {
-      const textNode = createFiberFromText(newChildren, priority);
-      previousSibling.sibling = textNode;
-      textNode.return = returnFiber;
-      return textNode;
-    }
-
-    if (typeof newChildren !== 'object' || newChildren === null) {
-      return previousSibling;
-    }
-
-    switch (newChildren.$$typeof) {
-      case REACT_ELEMENT_TYPE: {
-        const element = (newChildren : ReactElement<any>);
-        if (existingChild &&
-            element.type === existingChild.type &&
-            element.key === existingChild.key) {
-          // TODO: This is not sufficient since previous siblings could be new.
-          // Will fix reconciliation properly later.
-          const clone = shouldClone ? cloneFiber(existingChild, priority) : existingChild;
-          if (!shouldClone) {
-            // TODO: This might be lowering the priority of nested unfinished work.
-            clone.pendingWorkPriority = priority;
-          }
-          clone.pendingProps = element.props;
-          clone.sibling = null;
-          clone.return = returnFiber;
-          previousSibling.sibling = clone;
-          return clone;
-        }
-        const child = createFiberFromElement(element, priority);
-        previousSibling.sibling = child;
-        child.return = returnFiber;
-        return child;
-      }
-
-      case REACT_COROUTINE_TYPE: {
-        const coroutine = (newChildren : ReactCoroutine);
-        const child = createFiberFromCoroutine(coroutine, priority);
-        previousSibling.sibling = child;
-        child.return = returnFiber;
-        return child;
-      }
-
-      case REACT_YIELD_TYPE: {
-        const yieldNode = (newChildren : ReactYield);
-        const reifiedYield = createReifiedYield(yieldNode);
-        const child = createFiberFromYield(yieldNode, priority);
-        child.output = reifiedYield;
-        previousSibling.sibling = child;
-        child.return = returnFiber;
-        return child;
-      }
-    }
-
-    if (isArray(newChildren)) {
-      // Nested arrays have a special fiber type.
-      const fragment = createFiberFromFragment(newChildren, priority);
-      previousSibling.sibling = fragment;
-      fragment.return = returnFiber;
-      return fragment;
+  ) {
+    if (current == null || current.tag !== HostText) {
+      // Insert
+      const created = createFiberFromText(textContent, priority);
+      created.return = returnFiber;
+      return created;
     } else {
-      // TODO: Throw for unknown children.
-      return previousSibling;
+      // Update
+      const existing = useFiber(current, priority);
+      existing.pendingProps = textContent;
+      existing.return = returnFiber;
+      return existing;
     }
   }
 
-  function createFirstChild(returnFiber, existingChild, newChildren : any, priority) {
-    if (typeof newChildren === 'string') {
-      const textNode = createFiberFromText(newChildren, priority);
-      textNode.return = returnFiber;
-      return textNode;
-    }
-
-    if (typeof newChildren !== 'object' || newChildren === null) {
-      return null;
-    }
-
-    switch (newChildren.$$typeof) {
-      case REACT_ELEMENT_TYPE: {
-        const element = (newChildren : ReactElement<any>);
-        if (existingChild &&
-            element.type === existingChild.type &&
-            element.key === existingChild.key) {
-          // Get the clone of the existing fiber.
-          const clone = shouldClone ? cloneFiber(existingChild, priority) : existingChild;
-          if (!shouldClone) {
-            // TODO: This might be lowering the priority of nested unfinished work.
-            clone.pendingWorkPriority = priority;
-          }
-          clone.pendingProps = element.props;
-          clone.sibling = null;
-          clone.return = returnFiber;
-          return clone;
-        }
-        const child = createFiberFromElement(element, priority);
-        child.return = returnFiber;
-        return child;
-      }
-
-      case REACT_COROUTINE_TYPE: {
-        const coroutine = (newChildren : ReactCoroutine);
-        const child = createFiberFromCoroutine(coroutine, priority);
-        child.return = returnFiber;
-        return child;
-      }
-
-      case REACT_YIELD_TYPE: {
-        // A yield results in a fragment fiber whose output is the continuation.
-        // TODO: When there is only a single child, we can optimize this to avoid
-        // the fragment.
-        const yieldNode = (newChildren : ReactYield);
-        const reifiedYield = createReifiedYield(yieldNode);
-        const child = createFiberFromYield(yieldNode, priority);
-        child.output = reifiedYield;
-        child.return = returnFiber;
-        return child;
-      }
-    }
-
-    if (isArray(newChildren)) {
-      // Nested arrays have a special fiber type.
-      const fragment = createFiberFromFragment(newChildren, priority);
-      fragment.return = returnFiber;
-      return fragment;
+  function updateElement(
+    returnFiber : Fiber,
+    current : ?Fiber,
+    element : ReactElement<any>,
+    priority : PriorityLevel
+  ) {
+    if (current == null || current.type !== element.type) {
+      // Insert
+      const created = createFiberFromElement(element, priority);
+      created.return = returnFiber;
+      return created;
     } else {
-      // TODO: Throw for unknown children.
-      return null;
+      // Move based on index, TODO: This needs to restore a deletion marking.
+      const existing = useFiber(current, priority);
+      existing.pendingProps = element.props;
+      existing.return = returnFiber;
+      return existing;
     }
   }
 
-  // TODO: This API won't work because we'll need to transfer the side-effects of
-  // unmounting children to the returnFiber.
+  function updateCoroutine(
+    returnFiber : Fiber,
+    current : ?Fiber,
+    coroutine : ReactCoroutine,
+    priority : PriorityLevel
+  ) {
+    // TODO: Should this also compare handler to determine whether to reuse?
+    if (current == null || current.tag !== CoroutineComponent) {
+      // Insert
+      const created = createFiberFromCoroutine(coroutine, priority);
+      created.return = returnFiber;
+      return created;
+    } else {
+      // Move based on index, TODO: This needs to restore a deletion marking.
+      const existing = useFiber(current, priority);
+      existing.pendingProps = coroutine;
+      existing.return = returnFiber;
+      return existing;
+    }
+  }
+
+  function updateYield(
+    returnFiber : Fiber,
+    current : ?Fiber,
+    yieldNode : ReactYield,
+    priority : PriorityLevel
+  ) {
+    // TODO: Should this also compare continuation to determine whether to reuse?
+    if (current == null || current.tag !== YieldComponent) {
+      // Insert
+      const reifiedYield = createReifiedYield(yieldNode);
+      const created = createFiberFromYield(yieldNode, priority);
+      created.output = reifiedYield;
+      created.return = returnFiber;
+      return created;
+    } else {
+      // Move based on index, TODO: This needs to restore a deletion marking.
+      const existing = useFiber(current, priority);
+      existing.output = createUpdatedReifiedYield(
+        current.output,
+        yieldNode
+      );
+      existing.return = returnFiber;
+      return existing;
+    }
+  }
+
+  function updateFragment(
+    returnFiber : Fiber,
+    current : ?Fiber,
+    fragment : Iterable<*>,
+    priority : PriorityLevel
+  ) {
+    if (current == null || current.tag !== Fragment) {
+      // Insert
+      const created = createFiberFromFragment(fragment, priority);
+      created.return = returnFiber;
+      return created;
+    } else {
+      // Update
+      const existing = useFiber(current, priority);
+      existing.pendingProps = fragment;
+      existing.return = returnFiber;
+      return existing;
+    }
+  }
+
+  function updateSlot(
+    returnFiber : Fiber,
+    oldFiber : Fiber,
+    newChild : any,
+    priority : PriorityLevel
+  ) : ?Fiber {
+    // Update the fiber if the keys match, otherwise return null.
+
+    if (typeof newChild === 'string' || typeof newChild === 'number') {
+      // Text nodes doesn't have keys. If the previous node is implicitly keyed
+      // we can continue to replace it without aborting even if it is not a text
+      // node.
+      if (oldFiber.key !== null) {
+        return null;
+      }
+      return updateTextNode(returnFiber, oldFiber, '' + newChild, priority);
+    }
+
+    if (typeof newChild === 'object' && newChild !== null) {
+      switch (newChild.$$typeof) {
+        case REACT_ELEMENT_TYPE: {
+          if (newChild.key === oldFiber.key) {
+            return updateElement(
+              returnFiber,
+              oldFiber,
+              newChild,
+              priority
+            );
+          } else {
+            return null;
+          }
+        }
+
+        case REACT_COROUTINE_TYPE: {
+          if (newChild.key === oldFiber.key) {
+            return updateCoroutine(
+              returnFiber,
+              oldFiber,
+              newChild,
+              priority
+            );
+          } else {
+            return null;
+          }
+        }
+
+        case REACT_YIELD_TYPE: {
+          if (newChild.key === oldFiber.key) {
+            return updateYield(
+              returnFiber,
+              oldFiber,
+              newChild,
+              priority
+            );
+          } else {
+            return null;
+          }
+        }
+      }
+
+      if (isArray(newChild) || getIteratorFn(newChild)) {
+        // Fragments doesn't have keys so if the previous key is implicit we can
+        // update it.
+        if (oldFiber.key !== null) {
+          return null;
+        }
+        return updateFragment(returnFiber, oldFiber, newChild, priority);
+      }
+    }
+
+    return null;
+  }
+
+  function updateFromMap(
+    existingChildren : Map<string, Fiber>,
+    returnFiber : Fiber,
+    oldFiber : ?Fiber,
+    newChild : any,
+    priority : PriorityLevel
+  ) : ?Fiber {
+
+    // TODO: If this child matches, we need to undo the deletion. However,
+    // we don't do that for the updateSlot case because nothing was deleted yet.
+
+    if (typeof newChild === 'string' || typeof newChild === 'number') {
+      // Text nodes doesn't have keys, so we neither have to check the old nor
+      // new node for the key. If both are text nodes, they match.
+      return updateTextNode(returnFiber, oldFiber, '' + newChild, priority);
+    }
+
+    if (typeof newChild === 'object' && newChild !== null) {
+      switch (newChild.$$typeof) {
+        case REACT_ELEMENT_TYPE: {
+          if (newChild.key === null) {
+            // For implicit keys, we'll use the existing fiber in this slot
+            // but only if it also is an implicit key.
+            return updateElement(
+              returnFiber,
+              oldFiber && oldFiber.key === null ? oldFiber : null,
+              newChild,
+              priority
+            );
+          } else {
+            // For explicit keys we look for an existing fiber in the map.
+            // TODO: We could test oldFiber.key first incase it happens to be
+            // the same key but it might not be worth it given the likelihood.
+            const matchedFiber = existingChildren.get(newChild.key);
+            return updateElement(
+              returnFiber,
+              matchedFiber ? matchedFiber : null,
+              newChild,
+              priority
+            );
+          }
+        }
+
+        case REACT_COROUTINE_TYPE: {
+          if (newChild.key === null) {
+            // For implicit keys, we'll use the existing fiber in this slot
+            // but only if it also is an implicit key.
+            return updateCoroutine(
+              returnFiber,
+              oldFiber && oldFiber.key === null ? oldFiber : null,
+              newChild,
+              priority
+            );
+          } else {
+            // For explicit keys we look for an existing fiber in the map.
+            // TODO: We could test oldFiber.key first incase it happens to be
+            // the same key but it might not be worth it given the likelihood.
+            const matchedFiber = existingChildren.get(newChild.key);
+            return updateCoroutine(
+              returnFiber,
+              matchedFiber ? matchedFiber : null,
+              newChild,
+              priority
+            );
+          }
+        }
+
+        case REACT_YIELD_TYPE: {
+          if (newChild.key === null) {
+            // For implicit keys, we'll use the existing fiber in this slot
+            // but only if it also is an implicit key.
+            return updateYield(
+              returnFiber,
+              oldFiber && oldFiber.key === null ? oldFiber : null,
+              newChild,
+              priority
+            );
+          } else {
+            // For explicit keys we look for an existing fiber in the map.
+            // TODO: We could test oldFiber.key first incase it happens to be
+            // the same key but it might not be worth it given the likelihood.
+            const matchedFiber = existingChildren.get(newChild.key);
+            return updateYield(
+              returnFiber,
+              matchedFiber ? matchedFiber : null,
+              newChild,
+              priority
+            );
+          }
+        }
+      }
+
+      if (isArray(newChild) || getIteratorFn(newChild)) {
+        // Fragments doesn't have keys so if the previous is a fragment, we
+        // update it.
+        return updateFragment(returnFiber, oldFiber, newChild, priority);
+      }
+    }
+
+    return null;
+  }
+
+  function reconcileChildrenArray(
+    returnFiber : Fiber,
+    currentFirstChild : ?Fiber,
+    newChildren : Array<*>,
+    priority : PriorityLevel) {
+
+    // This algorithm can't optimize by searching from boths ends since we
+    // don't have backpointers on fibers. I'm trying to see how far we can get
+    // with that model. If it ends up not being worth the tradeoffs, we can
+    // add it later.
+
+    // Even with a two ended optimization, we'd want to optimize for the case
+    // where there are few changes and brute force the comparison instead of
+    // going for the Map. It'd like to explore hitting that path first in
+    // forward-only mode and only go for the Map once we notice that we need
+    // lots of look ahead. This doesn't handle reversal as well as two ended
+    // search but that's unusual. Besides, for the two ended optimization to
+    // work on Iterables, we'd need to copy the whole set.
+
+    // In this first iteration, we'll just live with hitting the bad case
+    // (adding everything to a Map) in for every insert/move.
+
+    let resultingFirstChild : ?Fiber = null;
+    let previousNewFiber : ?Fiber = null;
+
+    let oldFiber = currentFirstChild;
+    let newIdx = 0;
+    for (; oldFiber && newIdx < newChildren.length; newIdx++) {
+      const nextOldFiber = oldFiber.sibling; // In-case we mutate this fiber.
+      const newFiber = updateSlot(returnFiber, oldFiber, newChildren[newIdx], priority);
+      if (!newFiber) {
+        break;
+      }
+      if (!previousNewFiber) {
+        // TODO: Move out of the loop. This only happens for the first run.
+        resultingFirstChild = newFiber;
+      } else {
+        // TODO: Defer siblings if we're not at the right index for this slot.
+        // I.e. if we had null values before, then we want to defer this
+        // for each null value. However, we also don't want to call updateSlot
+        // with the previous one.
+        previousNewFiber.sibling = newFiber;
+      }
+      previousNewFiber = newFiber;
+      oldFiber = nextOldFiber;
+    }
+
+    if (newIdx === newChildren.length) {
+      // We've reached the end of the new children. We can delete the rest.
+      deleteRemainingChildren(returnFiber, oldFiber);
+      return resultingFirstChild;
+    }
+
+    // Mark all children as deleted and add them to a key map for quick lookups.
+    const existingChildren = mapAndDeleteRemainingChildren(returnFiber, oldFiber);
+
+    // Keep scanning and use the map to restore deleted items as moves.
+    for (; newIdx < newChildren.length; newIdx++) {
+      // TODO: Since the mutation of existing fibers can happen at any order
+      // we might break the link before we're done with it. :(
+      const nextOldFiber = oldFiber ? oldFiber.sibling : null;
+      const newFiber = updateFromMap(
+        existingChildren,
+        returnFiber,
+        oldFiber,
+        newChildren[newIdx],
+        priority
+      );
+      if (newFiber) {
+        if (!previousNewFiber) {
+          resultingFirstChild = newFiber;
+        } else {
+          previousNewFiber.sibling = newFiber;
+        }
+        previousNewFiber = newFiber;
+      }
+      // We will keep traversing the oldFiber in order, in case the new child
+      // has a null key that we'll need to match in the same slot.
+      if (oldFiber) {
+        oldFiber = nextOldFiber;
+      }
+    }
+
+    // TODO: Add deletion side-effects to the returnFiber's side-effects.
+
+    return resultingFirstChild;
+  }
+
+  function reconcileChildrenIterator(
+    returnFiber : Fiber,
+    currentFirstChild : ?Fiber,
+    newChildren : Iterator<*>,
+    priority : PriorityLevel) {
+    // TODO: Copy everything from reconcileChildrenArray but use the iterator
+    // instead.
+    return null;
+  }
+
+  function reconcileSingleTextNode(
+    returnFiber : Fiber,
+    currentFirstChild : ?Fiber,
+    textContent : string,
+    priority : PriorityLevel
+  ) {
+    // There's no need to check for keys on text nodes since we don't have a
+    // way to define them.
+    if (currentFirstChild && currentFirstChild.tag === HostText) {
+      // We already have an existing node so let's just update it and delete
+      // the rest.
+      deleteRemainingChildren(returnFiber, currentFirstChild.sibling);
+      const existing = useFiber(currentFirstChild, priority);
+      existing.pendingProps = textContent;
+      existing.return = returnFiber;
+      return existing;
+    }
+    // The existing first child is not a text node so we need to create one
+    // and delete the existing ones.
+    deleteRemainingChildren(returnFiber, currentFirstChild);
+    const created = createFiberFromText(textContent, priority);
+    created.return = returnFiber;
+    return created;
+  }
+
+  function reconcileSingleElement(
+    returnFiber : Fiber,
+    currentFirstChild : ?Fiber,
+    element : ReactElement<any>,
+    priority : PriorityLevel
+  ) {
+    const key = element.key;
+    let child = currentFirstChild;
+    while (child) {
+      // TODO: If key === null and child.key === null, then this only applies to
+      // the first item in the list.
+      if (child.key === key) {
+        if (child.type === element.type) {
+          deleteRemainingChildren(returnFiber, child.sibling);
+          const existing = useFiber(child, priority);
+          existing.pendingProps = element.props;
+          existing.return = returnFiber;
+          return existing;
+        } else {
+          deleteRemainingChildren(returnFiber, child);
+          break;
+        }
+      } else {
+        deleteChild(returnFiber, child);
+      }
+      child = child.sibling;
+    }
+
+    const created = createFiberFromElement(element, priority);
+    created.return = returnFiber;
+    return created;
+  }
+
+  function reconcileSingleCoroutine(
+    returnFiber : Fiber,
+    currentFirstChild : ?Fiber,
+    coroutine : ReactCoroutine,
+    priority : PriorityLevel
+  ) {
+    const key = coroutine.key;
+    let child = currentFirstChild;
+    while (child) {
+      // TODO: If key === null and child.key === null, then this only applies to
+      // the first item in the list.
+      if (child.key === key) {
+        if (child.tag === CoroutineComponent) {
+          deleteRemainingChildren(returnFiber, child.sibling);
+          const existing = useFiber(child, priority);
+          existing.pendingProps = coroutine;
+          existing.return = returnFiber;
+          return existing;
+        } else {
+          deleteRemainingChildren(returnFiber, child);
+          break;
+        }
+      } else {
+        deleteChild(returnFiber, child);
+      }
+      child = child.sibling;
+    }
+
+    const created = createFiberFromCoroutine(coroutine, priority);
+    created.return = returnFiber;
+    return created;
+  }
+
+  function reconcileSingleYield(
+    returnFiber : Fiber,
+    currentFirstChild : ?Fiber,
+    yieldNode : ReactYield,
+    priority : PriorityLevel
+  ) {
+    const key = yieldNode.key;
+    let child = currentFirstChild;
+    while (child) {
+      // TODO: If key === null and child.key === null, then this only applies to
+      // the first item in the list.
+      if (child.key === key) {
+        if (child.tag === YieldComponent) {
+          deleteRemainingChildren(returnFiber, child.sibling);
+          const existing = useFiber(child, priority);
+          existing.output = createUpdatedReifiedYield(
+            child.output,
+            yieldNode
+          );
+          existing.return = returnFiber;
+          return existing;
+        } else {
+          deleteRemainingChildren(returnFiber, child);
+          break;
+        }
+      } else {
+        deleteChild(returnFiber, child);
+      }
+      child = child.sibling;
+    }
+
+    const reifiedYield = createReifiedYield(yieldNode);
+    const created = createFiberFromYield(yieldNode, priority);
+    created.output = reifiedYield;
+    created.return = returnFiber;
+    return created;
+  }
+
+  // TODO: This API will tag the children with the side-effect of the
+  // reconciliation itself. Deletes have to get added to the side-effect list
+  // of the return fiber right now. Other side-effects will be added as we
+  // pass through those children.
   function reconcileChildFibers(
     returnFiber : Fiber,
     currentFirstChild : ?Fiber,
-    newChild : ReactNodeList,
+    newChild : any,
     priority : PriorityLevel
   ) : ?Fiber {
     // This function is not recursive.
     // If the top level item is an array, we treat it as a set of children,
     // not as a fragment. Nested arrays on the other hand will be treated as
     // fragment nodes. Recursion happens at the normal flow.
-    if (isArray(newChild)) {
-      /* $FlowIssue(>=0.31.0) #12747709
-       *
-       * `Array.isArray` is matched syntactically for now until predicate
-       * support is complete.
-       */
-      var newChildren : Array<*> = newChild;
-      var first : ?Fiber = null;
-      var prev : ?Fiber = null;
-      var existing : ?Fiber = currentFirstChild;
-      for (var i = 0; i < newChildren.length; i++) {
-        var nextExisting = existing && existing.sibling;
-        if (prev == null) {
-          prev = createFirstChild(returnFiber, existing, newChildren[i], priority);
-          first = prev;
-        } else {
-          prev = createSubsequentChild(returnFiber, existing, prev, newChildren[i], priority);
-        }
-        if (prev && existing) {
-          // TODO: This is not correct because there could've been more
-          // than one sibling consumed but I don't want to return a tuple.
-          existing = nextExisting;
-        }
-      }
-      return first;
+
+    if (typeof newChild === 'string' || typeof newChild === 'number') {
+      return reconcileSingleTextNode(
+        returnFiber,
+        currentFirstChild,
+        '' + newChild,
+        priority
+      );
     }
-    return createFirstChild(returnFiber, currentFirstChild, newChild, priority);
+
+    if (typeof newChild === 'object' && newChild !== null) {
+      switch (newChild.$$typeof) {
+        case REACT_ELEMENT_TYPE:
+          return reconcileSingleElement(
+            returnFiber,
+            currentFirstChild,
+            newChild,
+            priority
+          );
+
+        case REACT_COROUTINE_TYPE:
+          return reconcileSingleCoroutine(
+            returnFiber,
+            currentFirstChild,
+            newChild,
+            priority
+          );
+
+        case REACT_YIELD_TYPE:
+          return reconcileSingleYield(
+            returnFiber,
+            currentFirstChild,
+            newChild,
+            priority
+          );
+      }
+
+      if (isArray(newChild)) {
+        return reconcileChildrenArray(
+          returnFiber,
+          currentFirstChild,
+          newChild,
+          priority
+        );
+      }
+
+      const iteratorFn = getIteratorFn(newChild);
+      if (iteratorFn) {
+        return reconcileChildrenIterator(
+          returnFiber,
+          currentFirstChild,
+          newChild,
+          priority
+        );
+      }
+    }
+
+    // Remaining cases are all treated as empty.
+    return deleteRemainingChildren(returnFiber, currentFirstChild);
   }
 
   return reconcileChildFibers;
 }
 
-exports.reconcileChildFibers = ChildReconciler(true);
+exports.reconcileChildFibers = ChildReconciler(true, true);
 
-exports.reconcileChildFibersInPlace = ChildReconciler(false);
+exports.reconcileChildFibersInPlace = ChildReconciler(false, true);
 
-
-function cloneSiblings(current : Fiber, workInProgress : Fiber, returnFiber : Fiber) {
-  workInProgress.return = returnFiber;
-  while (current.sibling) {
-    current = current.sibling;
-    workInProgress = workInProgress.sibling = cloneFiber(
-      current,
-      current.pendingWorkPriority
-    );
-    workInProgress.return = returnFiber;
-  }
-  workInProgress.sibling = null;
-}
+exports.mountChildFibersInPlace = ChildReconciler(false, false);
 
 exports.cloneChildFibers = function(current : ?Fiber, workInProgress : Fiber) {
   if (!workInProgress.child) {
@@ -252,7 +726,7 @@ exports.cloneChildFibers = function(current : ?Fiber, workInProgress : Fiber) {
     // We use workInProgress.child since that lets Flow know that it can't be
     // null since we validated that already. However, as the line above suggests
     // they're actually the same thing.
-    const currentChild = workInProgress.child;
+    let currentChild = workInProgress.child;
     // TODO: This used to reset the pending priority. Not sure if that is needed.
     // workInProgress.pendingWorkPriority = current.pendingWorkPriority;
     // TODO: The below priority used to be set to NoWork which would've
@@ -260,9 +734,19 @@ exports.cloneChildFibers = function(current : ?Fiber, workInProgress : Fiber) {
     // observable when the first sibling has lower priority work remaining
     // than the next sibling. At that point we should add tests that catches
     // this.
-    const newChild = cloneFiber(currentChild, currentChild.pendingWorkPriority);
+    let newChild = cloneFiber(currentChild, currentChild.pendingWorkPriority);
     workInProgress.child = newChild;
-    cloneSiblings(currentChild, newChild, workInProgress);
+
+    newChild.return = workInProgress;
+    while (currentChild.sibling) {
+      currentChild = currentChild.sibling;
+      newChild = newChild.sibling = cloneFiber(
+        currentChild,
+        currentChild.pendingWorkPriority
+      );
+      newChild.return = workInProgress;
+    }
+    newChild.sibling = null;
   }
 
   // If there is no alternate, then we don't need to clone the children.

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -30,6 +30,7 @@ var ReactReifiedYield = require('ReactReifiedYield');
 const {
   cloneFiber,
   createFiberFromElement,
+  createFiberFromFragment,
   createFiberFromCoroutine,
   createFiberFromYield,
 } = ReactFiber;
@@ -46,7 +47,7 @@ function ChildReconciler(shouldClone) {
     returnFiber : Fiber,
     existingChild : ?Fiber,
     previousSibling : Fiber,
-    newChildren,
+    newChildren : any,
     priority : PriorityLevel
   ) : Fiber {
     if (typeof newChildren !== 'object' || newChildren === null) {
@@ -98,35 +99,24 @@ function ChildReconciler(shouldClone) {
     }
 
     if (isArray(newChildren)) {
-      let prev : Fiber = previousSibling;
-      let existing : ?Fiber = existingChild;
-      for (var i = 0; i < newChildren.length; i++) {
-        var nextExisting = existing && existing.sibling;
-        prev = createSubsequentChild(returnFiber, existing, prev, newChildren[i], priority);
-        if (prev && existing) {
-          // TODO: This is not correct because there could've been more
-          // than one sibling consumed but I don't want to return a tuple.
-          existing = nextExisting;
-        }
-      }
-      return prev;
+      // Nested arrays have a special fiber type.
+      const fragment = createFiberFromFragment(newChildren, priority);
+      previousSibling.sibling = fragment;
+      fragment.return = returnFiber;
+      return fragment;
     } else {
       // TODO: Throw for unknown children.
       return previousSibling;
     }
   }
 
-  function createFirstChild(returnFiber, existingChild, newChildren, priority) {
+  function createFirstChild(returnFiber, existingChild, newChildren : any, priority) {
     if (typeof newChildren !== 'object' || newChildren === null) {
       return null;
     }
 
     switch (newChildren.$$typeof) {
       case REACT_ELEMENT_TYPE: {
-        /* $FlowFixMe(>=0.31.0): This is an unsafe cast. Consider adding a type
-         *                       annotation to the `newChildren` param of this
-         *                       function.
-         */
         const element = (newChildren : ReactElement<any>);
         if (existingChild &&
             element.type === existingChild.type &&
@@ -148,8 +138,6 @@ function ChildReconciler(shouldClone) {
       }
 
       case REACT_COROUTINE_TYPE: {
-        /* $FlowFixMe(>=0.31.0): No 'handler' property found in object type
-         */
         const coroutine = (newChildren : ReactCoroutine);
         const child = createFiberFromCoroutine(coroutine, priority);
         child.return = returnFiber;
@@ -160,9 +148,6 @@ function ChildReconciler(shouldClone) {
         // A yield results in a fragment fiber whose output is the continuation.
         // TODO: When there is only a single child, we can optimize this to avoid
         // the fragment.
-        /* $FlowFixMe(>=0.31.0): No 'continuation' property found in object
-         * type
-         */
         const yieldNode = (newChildren : ReactYield);
         const reifiedYield = createReifiedYield(yieldNode);
         const child = createFiberFromYield(yieldNode, priority);
@@ -173,14 +158,38 @@ function ChildReconciler(shouldClone) {
     }
 
     if (isArray(newChildren)) {
-      var first : ?Fiber = null;
-      var prev : ?Fiber = null;
-      var existing : ?Fiber = existingChild;
+      // Nested arrays have a special fiber type.
+      const fragment = createFiberFromFragment(newChildren, priority);
+      fragment.return = returnFiber;
+      return fragment;
+    } else {
+      // TODO: Throw for unknown children.
+      return null;
+    }
+  }
+
+  // TODO: This API won't work because we'll need to transfer the side-effects of
+  // unmounting children to the returnFiber.
+  function reconcileChildFibers(
+    returnFiber : Fiber,
+    currentFirstChild : ?Fiber,
+    newChild : ReactNodeList,
+    priority : PriorityLevel
+  ) : ?Fiber {
+    // This function is not recursive.
+    // If the top level item is an array, we treat it as a set of children,
+    // not as a fragment. Nested arrays on the other hand will be treated as
+    // fragment nodes. Recursion happens at the normal flow.
+    if (isArray(newChild)) {
       /* $FlowIssue(>=0.31.0) #12747709
        *
        * `Array.isArray` is matched syntactically for now until predicate
        * support is complete.
        */
+      var newChildren : Array<*> = newChild;
+      var first : ?Fiber = null;
+      var prev : ?Fiber = null;
+      var existing : ?Fiber = currentFirstChild;
       for (var i = 0; i < newChildren.length; i++) {
         var nextExisting = existing && existing.sibling;
         if (prev == null) {
@@ -196,21 +205,8 @@ function ChildReconciler(shouldClone) {
         }
       }
       return first;
-    } else {
-      // TODO: Throw for unknown children.
-      return null;
     }
-  }
-
-  // TODO: This API won't work because we'll need to transfer the side-effects of
-  // unmounting children to the returnFiber.
-  function reconcileChildFibers(
-    returnFiber : Fiber,
-    currentFirstChild : ?Fiber,
-    newChildren : ReactNodeList,
-    priority : PriorityLevel
-  ) : ?Fiber {
-    return createFirstChild(returnFiber, currentFirstChild, newChildren, priority);
+    return createFirstChild(returnFiber, currentFirstChild, newChild, priority);
   }
 
   return reconcileChildFibers;

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -183,6 +183,15 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     }
   }
 
+  function placeSingleChild(newFiber : Fiber) {
+    // This is simpler for the single child case. We only need to do a
+    // placement for inserting new children.
+    if (shouldTrackSideEffects && !newFiber.alternate) {
+      newFiber.effectTag = Placement;
+    }
+    return newFiber;
+  }
+
   function updateTextNode(
     returnFiber : Fiber,
     current : ?Fiber,
@@ -738,39 +747,39 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     // fragment nodes. Recursion happens at the normal flow.
 
     if (typeof newChild === 'string' || typeof newChild === 'number') {
-      return reconcileSingleTextNode(
+      return placeSingleChild(reconcileSingleTextNode(
         returnFiber,
         currentFirstChild,
         '' + newChild,
         priority
-      );
+      ));
     }
 
     if (typeof newChild === 'object' && newChild !== null) {
       switch (newChild.$$typeof) {
         case REACT_ELEMENT_TYPE:
-          return reconcileSingleElement(
+          return placeSingleChild(reconcileSingleElement(
             returnFiber,
             currentFirstChild,
             newChild,
             priority
-          );
+          ));
 
         case REACT_COROUTINE_TYPE:
-          return reconcileSingleCoroutine(
+          return placeSingleChild(reconcileSingleCoroutine(
             returnFiber,
             currentFirstChild,
             newChild,
             priority
-          );
+          ));
 
         case REACT_YIELD_TYPE:
-          return reconcileSingleYield(
+          return placeSingleChild(reconcileSingleYield(
             returnFiber,
             currentFirstChild,
             newChild,
             priority
-          );
+          ));
       }
 
       if (isArray(newChild)) {

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -71,6 +71,7 @@ export type Fiber = Instance & {
   // Singly Linked List Tree Structure.
   child: ?Fiber,
   sibling: ?Fiber,
+  index: number,
 
   // The ref last used to attach this node.
   // I'll avoid adding an owner field for prod and model that as functions.
@@ -156,6 +157,7 @@ var createFiber = function(tag : TypeOfWork, key : null | string) : Fiber {
 
     child: null,
     sibling: null,
+    index: 0,
 
     ref: null,
 
@@ -221,6 +223,7 @@ exports.cloneFiber = function(fiber : Fiber, priorityLevel : PriorityLevel) : Fi
   alt.stateNode = fiber.stateNode;
   alt.child = fiber.child;
   alt.sibling = fiber.sibling; // This should always be overridden. TODO: null
+  alt.index = fiber.index; // This should always be overridden.
   alt.ref = fiber.ref;
   // pendingProps is here for symmetry but is unnecessary in practice for now.
   // TODO: Pass in the new pendingProps as an argument maybe?

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -12,6 +12,7 @@
 
 'use strict';
 
+import type { ReactFragment } from 'ReactTypes';
 import type { ReactCoroutine, ReactYield } from 'ReactCoroutine';
 import type { TypeOfWork } from 'ReactTypeOfWork';
 import type { PriorityLevel } from 'ReactPriorityLevel';
@@ -25,6 +26,7 @@ var {
   HostComponent,
   CoroutineComponent,
   YieldComponent,
+  Fragment,
 } = ReactTypeOfWork;
 
 var {
@@ -245,6 +247,15 @@ exports.createFiberFromElement = function(element : ReactElement<*>, priorityLev
   return fiber;
 };
 
+exports.createFiberFromFragment = function(elements : ReactFragment, priorityLevel : PriorityLevel) {
+  // TODO: Consider supporting keyed fragments. Technically, we accidentally
+  // support that in the existing React.
+  const fiber = createFiber(Fragment, null);
+  fiber.pendingProps = elements;
+  fiber.pendingWorkPriority = priorityLevel;
+  return fiber;
+};
+
 function createFiberFromElementType(type : mixed, key : null | string) {
   let fiber;
   if (typeof type === 'function') {
@@ -279,3 +290,4 @@ exports.createFiberFromYield = function(yieldNode : ReactYield, priorityLevel : 
   fiber.pendingProps = {};
   return fiber;
 };
+

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -114,6 +114,13 @@ export type Fiber = Instance & {
   // or may not be the same as the "current" child.
   progressedChild: ?Fiber,
 
+  // When we reconcile children onto progressedChild it is possible that we have
+  // to delete some child fibers. We need to keep track of this side-effects so
+  // that if we continue later on, we have to include those effects. Deletions
+  // are added in the reverse order from sibling pointers.
+  progressedFirstDeletion: ?Fiber,
+  progressedLastDeletion: ?Fiber,
+
   // This is a pooled version of a Fiber. Every fiber that gets updated will
   // eventually have a pair. There are cases when we can clean up pairs to save
   // memory if we need to.
@@ -175,6 +182,8 @@ var createFiber = function(tag : TypeOfWork, key : null | string) : Fiber {
     pendingWorkPriority: NoWork,
     progressedPriority: NoWork,
     progressedChild: null,
+    progressedFirstDeletion: null,
+    progressedLastDeletion: null,
 
     alternate: null,
 

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -221,8 +221,9 @@ exports.cloneFiber = function(fiber : Fiber, priorityLevel : PriorityLevel) : Fi
   // extra memory if needed.
   let alt = fiber.alternate;
   if (alt) {
-    // Whenever we clone, we do so to get a new work in progress.
-    // This ensures that we've reset these in the new tree.
+    // If we clone, then we do so from the "current" state. The current state
+    // can't have any side-effects that are still valid so we reset just to be
+    // sure.
     alt.effectTag = NoEffect;
     alt.nextEffect = null;
     alt.firstEffect = null;

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -15,6 +15,7 @@
 import type { ReactFragment } from 'ReactTypes';
 import type { ReactCoroutine, ReactYield } from 'ReactCoroutine';
 import type { TypeOfWork } from 'ReactTypeOfWork';
+import type { TypeOfSideEffect } from 'ReactTypeOfSideEffect';
 import type { PriorityLevel } from 'ReactPriorityLevel';
 import type { UpdateQueue } from 'ReactFiberUpdateQueue';
 
@@ -33,6 +34,10 @@ var {
 var {
   NoWork,
 } = require('ReactPriorityLevel');
+
+var {
+  NoEffect,
+} = require('ReactTypeOfSideEffect');
 
 // An Instance is shared between all versions of a component. We can easily
 // break this out into a separate object to avoid copying so much to the
@@ -90,6 +95,9 @@ export type Fiber = Instance & {
   // Output is the return value of this fiber, or a linked list of return values
   // if this returns multiple values. Such as a fragment.
   output: any, // This type will be more specific once we overload the tag.
+
+  // Effect
+  effectTag: TypeOfSideEffect,
 
   // Singly linked list fast path to the next fiber with side-effects.
   nextEffect: ?Fiber,
@@ -175,6 +183,7 @@ var createFiber = function(tag : TypeOfWork, key : null | string) : Fiber {
     callbackList: null,
     output: null,
 
+    effectTag: NoEffect,
     nextEffect: null,
     firstEffect: null,
     lastEffect: null,
@@ -214,6 +223,7 @@ exports.cloneFiber = function(fiber : Fiber, priorityLevel : PriorityLevel) : Fi
   if (alt) {
     // Whenever we clone, we do so to get a new work in progress.
     // This ensures that we've reset these in the new tree.
+    alt.effectTag = NoEffect;
     alt.nextEffect = null;
     alt.firstEffect = null;
     alt.lastEffect = null;

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -24,6 +24,7 @@ var {
   ClassComponent,
   HostContainer,
   HostComponent,
+  HostText,
   CoroutineComponent,
   YieldComponent,
   Fragment,
@@ -252,6 +253,13 @@ exports.createFiberFromFragment = function(elements : ReactFragment, priorityLev
   // support that in the existing React.
   const fiber = createFiber(Fragment, null);
   fiber.pendingProps = elements;
+  fiber.pendingWorkPriority = priorityLevel;
+  return fiber;
+};
+
+exports.createFiberFromText = function(content : string, priorityLevel : PriorityLevel) {
+  const fiber = createFiber(HostText, null);
+  fiber.pendingProps = content;
   fiber.pendingWorkPriority = priorityLevel;
   return fiber;
 };

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -276,6 +276,11 @@ function createFiberFromElementType(type : mixed, key : null | string) {
     fiber.type = type;
   } else if (typeof type === 'object' && type !== null) {
     // Currently assumed to be a continuation and therefore is a fiber already.
+    // TODO: The yield system is currently broken for updates in some cases.
+    // The reified yield stores a fiber, but we don't know which fiber that is;
+    // the current or a workInProgress? When the continuation gets rendered here
+    // we don't know if we can reuse that fiber or if we need to clone it.
+    // There is probably a clever way to restructure this.
     fiber = type;
   } else {
     throw new Error('Unknown component type: ' + typeof type);

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -441,14 +441,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>, g
         reconcileChildren(current, workInProgress, workInProgress.pendingProps);
         // A yield component is just a placeholder, we can just run through the
         // next one immediately.
-        if (workInProgress.child) {
-          return beginWork(
-            workInProgress.child.alternate,
-            workInProgress.child,
-            priorityLevel
-          );
-        }
-        return null;
+        return workInProgress.child;
       case HostComponent:
         if (workInProgress.stateNode && config.beginUpdate) {
           config.beginUpdate(workInProgress.stateNode);
@@ -466,35 +459,14 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>, g
         updateCoroutineComponent(current, workInProgress);
         // This doesn't take arbitrary time so we could synchronously just begin
         // eagerly do the work of workInProgress.child as an optimization.
-        if (workInProgress.child) {
-          return beginWork(
-            workInProgress.child.alternate,
-            workInProgress.child,
-            priorityLevel
-          );
-        }
         return workInProgress.child;
       case YieldComponent:
         // A yield component is just a placeholder, we can just run through the
         // next one immediately.
-        if (workInProgress.sibling) {
-          return beginWork(
-            workInProgress.sibling.alternate,
-            workInProgress.sibling,
-            priorityLevel
-          );
-        }
         return null;
       case Fragment:
         updateFragment(current, workInProgress);
-        if (workInProgress.child) {
-          return beginWork(
-            workInProgress.child.alternate,
-            workInProgress.child,
-            priorityLevel
-          );
-        }
-        return null;
+        return workInProgress.child;
       default:
         throw new Error('Unknown unit of work tag');
     }

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -36,6 +36,7 @@ var {
   CoroutineComponent,
   CoroutineHandlerPhase,
   YieldComponent,
+  Fragment,
 } = ReactTypeOfWork;
 var {
   NoWork,
@@ -95,6 +96,11 @@ module.exports = function<T, P, I, C>(config : HostConfig<T, P, I, C>, getSchedu
       );
     }
     markChildAsProgressed(current, workInProgress, priorityLevel);
+  }
+
+  function updateFragment(current, workInProgress) {
+    var nextChildren = workInProgress.pendingProps;
+    reconcileChildren(current, workInProgress, nextChildren);
   }
 
   function updateFunctionalComponent(current, workInProgress) {
@@ -408,6 +414,16 @@ module.exports = function<T, P, I, C>(config : HostConfig<T, P, I, C>, getSchedu
           return beginWork(
             workInProgress.sibling.alternate,
             workInProgress.sibling,
+            priorityLevel
+          );
+        }
+        return null;
+      case Fragment:
+        updateFragment(current, workInProgress);
+        if (workInProgress.child) {
+          return beginWork(
+            workInProgress.child.alternate,
+            workInProgress.child,
             priorityLevel
           );
         }

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -402,17 +402,8 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>, g
   }
 
   function bailoutOnLowPriority(current, workInProgress) {
-    if (current) {
-      // TODO: If I have started work on this node, mark it as finished, then
-      // return do other work, come back and hit this node... we killed that
-      // work. It is now in an inconsistent state. We probably need to check
-      // progressedChild or something.
-      workInProgress.child = current.child;
-      workInProgress.memoizedProps = current.memoizedProps;
-      workInProgress.output = current.output;
-      workInProgress.firstEffect = null;
-      workInProgress.lastEffect = null;
-    }
+    // TODO: What if this is currently in progress?
+    // How can that happen? How is this not being cloned?
     return null;
   }
 

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -21,13 +21,15 @@ var {
   ClassComponent,
   HostContainer,
   HostComponent,
+  HostText,
 } = ReactTypeOfWork;
 var { callCallbacks } = require('ReactFiberUpdateQueue');
 
-module.exports = function<T, P, I, C>(config : HostConfig<T, P, I, C>) {
+module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
 
   const updateContainer = config.updateContainer;
   const commitUpdate = config.commitUpdate;
+  const commitTextUpdate = config.commitTextUpdate;
 
   function commitWork(current : ?Fiber, finishedWork : Fiber) : void {
     switch (finishedWork.tag) {
@@ -67,6 +69,18 @@ module.exports = function<T, P, I, C>(config : HostConfig<T, P, I, C>) {
         const instance : I = finishedWork.stateNode;
         commitUpdate(instance, oldProps, newProps, children);
         return;
+      }
+      case HostText: {
+        if (finishedWork.stateNode == null || !current) {
+          throw new Error('This should only be done during updates.');
+        }
+        // TODO: This never gets called yet because I don't have update support
+        // for text nodes. This only gets updated through a host component or
+        // container updating with this as one of its child nodes.
+        const textInstance : TI = finishedWork.stateNode;
+        const oldText : string = finishedWork.memoizedProps;
+        const newText : string = current.memoizedProps;
+        commitTextUpdate(textInstance, oldText, newText);
       }
       default:
         throw new Error('This unit of work tag should not have side-effects.');

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -25,11 +25,145 @@ var {
 } = ReactTypeOfWork;
 var { callCallbacks } = require('ReactFiberUpdateQueue');
 
+var {
+  Placement,
+  PlacementAndUpdate,
+} = require('ReactTypeOfSideEffect');
+
 module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
 
   const updateContainer = config.updateContainer;
   const commitUpdate = config.commitUpdate;
   const commitTextUpdate = config.commitTextUpdate;
+
+  const appendChild = config.appendChild;
+  const insertBefore = config.insertBefore;
+  const removeChild = config.removeChild;
+
+  function getHostParent(fiber : Fiber) : ?I {
+    let parent = fiber.return;
+    while (parent) {
+      switch (parent.tag) {
+        case HostComponent:
+          return parent.stateNode;
+        case HostContainer:
+          // TODO: Currently we use the updateContainer feature to update these,
+          // but we should be able to handle this case too.
+          return null;
+      }
+      parent = parent.return;
+    }
+    return null;
+  }
+
+  function getHostSibling(fiber : Fiber) : ?I {
+    // We're going to search forward into the tree until we find a sibling host
+    // node. Unfortunately, if multiple insertions are done in a row we have to
+    // search past them. This leads to exponential search for the next sibling.
+    // TODO: Find a more efficient way to do this.
+    let node : Fiber = fiber;
+    siblings: while (true) {
+      // If we didn't find anything, let's try the next sibling.
+      while (!node.sibling) {
+        if (!node.return || node.return.tag === HostComponent) {
+          // If we pop out of the root or hit the parent the fiber we are the
+          // last sibling.
+          return null;
+        }
+        node = node.return;
+      }
+      node = node.sibling;
+      while (node.tag !== HostComponent && node.tag !== HostText) {
+        // If it is not host node and, we might have a host node inside it.
+        // Try to search down until we find one.
+        // TODO: For coroutines, this will have to search the stateNode.
+        if (node.effectTag === Placement ||
+          node.effectTag === PlacementAndUpdate) {
+          // If we don't have a child, try the siblings instead.
+          continue siblings;
+        }
+        if (!node.child) {
+          continue siblings;
+        } else {
+          node = node.child;
+        }
+      }
+      // Check if this host node is stable or about to be placed.
+      if (node.effectTag !== Placement &&
+        node.effectTag !== PlacementAndUpdate) {
+        // Found it!
+        return node.stateNode;
+      }
+    }
+  }
+
+  function commitInsertion(finishedWork : Fiber) : void {
+    // Recursively insert all host nodes into the parent.
+    const parent = getHostParent(finishedWork);
+    if (!parent) {
+      return;
+    }
+    const before = getHostSibling(finishedWork);
+    // We only have the top Fiber that was inserted but we need recurse down its
+    // children to find all the terminal nodes.
+    let node : Fiber = finishedWork;
+    while (true) {
+      if (node.tag === HostComponent || node.tag === HostText) {
+        if (before) {
+          insertBefore(parent, node.stateNode, before);
+        } else {
+          appendChild(parent, node.stateNode);
+        }
+      } else if (node.child) {
+        // TODO: Coroutines need to visit the stateNode.
+        node = node.child;
+        continue;
+      }
+      if (node === finishedWork) {
+        return;
+      }
+      while (!node.sibling) {
+        if (!node.return || node.return === finishedWork) {
+          return;
+        }
+        node = node.return;
+      }
+      node = node.sibling;
+    }
+  }
+
+  function commitDeletion(current : Fiber) : void {
+    // Recursively delete all host nodes from the parent.
+    const parent = getHostParent(current);
+    if (!parent) {
+      return;
+    }
+    // We only have the top Fiber that was inserted but we need recurse down its
+    // children to find all the terminal nodes.
+    // TODO: Call componentWillUnmount on all classes as needed. Recurse down
+    // removed HostComponents but don't call removeChild on already removed
+    // children.
+    let node : Fiber = current;
+    while (true) {
+      if (node.tag === HostComponent || node.tag === HostText) {
+        removeChild(parent, node.stateNode);
+      } else if (node.child) {
+        // TODO: Coroutines need to visit the stateNode.
+        node = node.child;
+        continue;
+      }
+      if (node === current) {
+        return;
+      }
+      while (!node.sibling) {
+        if (!node.return || node.return === current) {
+          return;
+        }
+        node = node.return;
+      }
+      node = node.sibling;
+    }
+  }
 
   function commitWork(current : ?Fiber, finishedWork : Fiber) : void {
     switch (finishedWork.tag) {
@@ -62,12 +196,10 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
           throw new Error('This should only be done during updates.');
         }
         // Commit the work prepared earlier.
-        const child = finishedWork.child;
-        const children = (child && !child.sibling) ? (child.output : ?Fiber | I) : child;
         const newProps = finishedWork.memoizedProps;
         const oldProps = current.memoizedProps;
         const instance : I = finishedWork.stateNode;
-        commitUpdate(instance, oldProps, newProps, children);
+        commitUpdate(instance, oldProps, newProps);
         return;
       }
       case HostText: {
@@ -86,6 +218,8 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
   }
 
   return {
+    commitInsertion,
+    commitDeletion,
     commitWork,
   };
 

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -74,13 +74,11 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
         if (finishedWork.stateNode == null || !current) {
           throw new Error('This should only be done during updates.');
         }
-        // TODO: This never gets called yet because I don't have update support
-        // for text nodes. This only gets updated through a host component or
-        // container updating with this as one of its child nodes.
         const textInstance : TI = finishedWork.stateNode;
-        const oldText : string = finishedWork.memoizedProps;
-        const newText : string = current.memoizedProps;
+        const newText : string = finishedWork.memoizedProps;
+        const oldText : string = current.memoizedProps;
         commitTextUpdate(textInstance, oldText, newText);
+        return;
       }
       default:
         throw new Error('This unit of work tag should not have side-effects.');

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -142,8 +142,6 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
         return null;
       case HostComponent:
         let newProps = workInProgress.pendingProps;
-        const child = workInProgress.child;
-        const children = (child && !child.sibling) ? (child.output : ?Fiber | I) : child;
         if (current && workInProgress.stateNode != null) {
           // If we have an alternate, that means this is an update and we need to
           // schedule a side-effect to do the updates.
@@ -156,7 +154,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
             newProps = oldProps;
           }
           const instance : I = workInProgress.stateNode;
-          if (prepareUpdate(instance, oldProps, newProps, children)) {
+          if (prepareUpdate(instance, oldProps, newProps)) {
             // This returns true if there was something to update.
             markUpdate(workInProgress);
           }
@@ -171,6 +169,8 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
               return null;
             }
           }
+          const child = workInProgress.child;
+          const children = (child && !child.sibling) ? (child.output : ?Fiber | I) : child;
           const instance = createInstance(workInProgress.type, newProps, children);
           // TODO: This seems like unnecessary duplication.
           workInProgress.stateNode = instance;

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -28,6 +28,7 @@ var {
   CoroutineComponent,
   CoroutineHandlerPhase,
   YieldComponent,
+  Fragment,
 } = ReactTypeOfWork;
 
 module.exports = function<T, P, I, C>(config : HostConfig<T, P, I, C>) {
@@ -198,6 +199,9 @@ module.exports = function<T, P, I, C>(config : HostConfig<T, P, I, C>) {
         return null;
       case YieldComponent:
         // Does nothing.
+        return null;
+      case Fragment:
+        transferOutput(workInProgress.child, workInProgress);
         return null;
 
       // Error cases

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -151,7 +151,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
           // TODO: Split the update API as separate for the props vs. children.
           // Even better would be if children weren't special cased at all tho.
           if (!newProps) {
-            newProps = oldProps;
+            newProps = workInProgress.memoizedProps || oldProps;
           }
           const instance : I = workInProgress.stateNode;
           if (prepareUpdate(instance, oldProps, newProps)) {

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -175,6 +175,10 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
           // TODO: This seems like unnecessary duplication.
           workInProgress.stateNode = instance;
           workInProgress.output = instance;
+          if (workInProgress.ref) {
+            // If there is a ref on a host node we need to schedule a callback
+            markUpdate(workInProgress);
+          }
         }
         workInProgress.memoizedProps = newProps;
         return null;

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -28,18 +28,21 @@ type HostChildNode<I> = { tag: TypeOfWork, output: HostChildren<I>, sibling: any
 
 export type HostChildren<I> = null | void | I | HostChildNode<I>;
 
-export type HostConfig<T, P, I, C> = {
+export type HostConfig<T, P, I, TI, C> = {
 
   // TODO: We don't currently have a quick way to detect that children didn't
   // reorder so we host will always need to check the set. We should make a flag
   // or something so that it can bailout easily.
 
-  updateContainer(containerInfo : C, children : HostChildren<I>) : void;
+  updateContainer(containerInfo : C, children : HostChildren<I | TI>) : void;
 
-  createInstance(type : T, props : P, children : HostChildren<I>) : I,
-  prepareUpdate(instance : I, oldProps : P, newProps : P, children : HostChildren<I>) : boolean,
-  commitUpdate(instance : I, oldProps : P, newProps : P, children : HostChildren<I>) : void,
+  createInstance(type : T, props : P, children : HostChildren<I | TI>) : I,
+  prepareUpdate(instance : I, oldProps : P, newProps : P, children : HostChildren<I | TI>) : boolean,
+  commitUpdate(instance : I, oldProps : P, newProps : P, children : HostChildren<I | TI>) : void,
   deleteInstance(instance : I) : void,
+
+  createTextInstance(text : string) : TI,
+  commitTextUpdate(textInstance : TI, oldText : string, newText : string) : void,
 
   scheduleAnimationCallback(callback : () => void) : void,
   scheduleDeferredCallback(callback : (deadline : Deadline) => void) : void
@@ -58,7 +61,7 @@ export type Reconciler<C> = {
   getPublicRootInstance(container : OpaqueNode) : (C | null),
 };
 
-module.exports = function<T, P, I, C>(config : HostConfig<T, P, I, C>) : Reconciler<C> {
+module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) : Reconciler<C> {
 
   var { scheduleWork, performWithPriority } = ReactFiberScheduler(config);
 

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -34,15 +34,18 @@ export type HostConfig<T, P, I, TI, C> = {
   // reorder so we host will always need to check the set. We should make a flag
   // or something so that it can bailout easily.
 
-  updateContainer(containerInfo : C, children : HostChildren<I | TI>) : void;
+  updateContainer(containerInfo : C, children : HostChildren<I | TI>) : void,
 
   createInstance(type : T, props : P, children : HostChildren<I | TI>) : I,
-  prepareUpdate(instance : I, oldProps : P, newProps : P, children : HostChildren<I | TI>) : boolean,
-  commitUpdate(instance : I, oldProps : P, newProps : P, children : HostChildren<I | TI>) : void,
-  deleteInstance(instance : I) : void,
+  prepareUpdate(instance : I, oldProps : P, newProps : P) : boolean,
+  commitUpdate(instance : I, oldProps : P, newProps : P) : void,
 
   createTextInstance(text : string) : TI,
   commitTextUpdate(textInstance : TI, oldText : string, newText : string) : void,
+
+  appendChild(parentInstance : I, child : I | TI) : void,
+  insertBefore(parentInstance : I, child : I | TI, beforeChild : I | TI) : void,
+  removeChild(parentInstance : I, child : I | TI) : void,
 
   scheduleAnimationCallback(callback : () => void) : void,
   scheduleDeferredCallback(callback : (deadline : Deadline) => void) : void

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -36,7 +36,7 @@ export type Scheduler = {
   scheduleDeferredWork: (root : FiberRoot, priority : PriorityLevel) => void
 };
 
-module.exports = function<T, P, I, C>(config : HostConfig<T, P, I, C>) {
+module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
   // Use a closure to circumvent the circular dependency between the scheduler
   // and ReactFiberBeginWork. Don't know if there's a better way to do this.
   let scheduler;

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -116,6 +116,9 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
     let effectfulFiber = finishedWork.firstEffect;
     while (effectfulFiber) {
       switch (effectfulFiber.effectTag) {
+        // TODO: Should we commit host updates here? Otherwise update to parent
+        // host components are not visible in life-cycles. Such as when you read
+        // layout information.
         case Placement:
         case PlacementAndUpdate:
           commitInsertion(effectfulFiber);

--- a/src/renderers/shared/fiber/ReactReifiedYield.js
+++ b/src/renderers/shared/fiber/ReactReifiedYield.js
@@ -31,8 +31,15 @@ exports.createReifiedYield = function(yieldNode : ReactYield) : ReifiedYield {
 };
 
 exports.createUpdatedReifiedYield = function(previousYield : ReifiedYield, yieldNode : ReactYield) : ReifiedYield {
+  var fiber = previousYield.continuation;
+  if (fiber.type !== yieldNode.continuation) {
+    fiber = createFiberFromElementType(
+      yieldNode.continuation,
+      yieldNode.key
+    );
+  }
   return {
-    continuation: previousYield.continuation,
+    continuation: fiber,
     props: yieldNode.props,
   };
 };

--- a/src/renderers/shared/fiber/ReactTypeOfSideEffect.js
+++ b/src/renderers/shared/fiber/ReactTypeOfSideEffect.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactTypeOfSideEffect
+ * @flow
+ */
+
+'use strict';
+
+export type TypeOfSideEffect = 0 | 1 | 2 | 3 | 4;
+
+module.exports = {
+  NoEffect: 0,
+  Placement: 1,
+  Update: 2,
+  PlacementAndUpdate: 3,
+  Deletion: 4,
+};

--- a/src/renderers/shared/fiber/ReactTypeOfWork.js
+++ b/src/renderers/shared/fiber/ReactTypeOfWork.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-export type TypeOfWork = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+export type TypeOfWork = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 
 module.exports = {
   IndeterminateComponent: 0, // Before we know whether it is functional or class
@@ -20,8 +20,9 @@ module.exports = {
   ClassComponent: 2,
   HostContainer: 3, // Root of a host tree. Could be nested inside another node.
   HostComponent: 4,
-  CoroutineComponent: 5,
-  CoroutineHandlerPhase: 6,
-  YieldComponent: 7,
-  Fragment: 8,
+  HostText: 5,
+  CoroutineComponent: 6,
+  CoroutineHandlerPhase: 7,
+  YieldComponent: 8,
+  Fragment: 9,
 };

--- a/src/renderers/shared/fiber/ReactTypeOfWork.js
+++ b/src/renderers/shared/fiber/ReactTypeOfWork.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-export type TypeOfWork = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
+export type TypeOfWork = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 
 module.exports = {
   IndeterminateComponent: 0, // Before we know whether it is functional or class
@@ -23,4 +23,5 @@ module.exports = {
   CoroutineComponent: 5,
   CoroutineHandlerPhase: 6,
   YieldComponent: 7,
+  Fragment: 8,
 };

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -417,6 +417,24 @@ describe('ReactIncremental', () => {
     // after them which is not correct.
     ReactNoop.flush();
     expect(ops).toEqual(['Bar', 'Middle', 'Bar']);
+
+    ops = [];
+
+    // Let us try this again without fully finishing the first time. This will
+    // create a hanging subtree that is reconciling at the normal priority.
+    ReactNoop.render(<Foo text="foo" />);
+    ReactNoop.flushDeferredPri(40);
+
+    expect(ops).toEqual(['Foo', 'Bar']);
+
+    ops = [];
+
+    // This update will create a tree that aborts that work and down-prioritizes
+    // it. If the priority levels aren't down-prioritized correctly this may
+    // abort rendering of the down-prioritized content.
+    ReactNoop.render(<Foo text="bar" />);
+    ReactNoop.flush();
+    expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
   });
 
   it('can reuse work done after being preempted', () => {

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -56,7 +56,7 @@ describe('ReactIncremental', () => {
     expect(fooCalled).toBe(false);
     expect(barCalled).toBe(false);
     // Do one step of work.
-    ReactNoop.flushDeferredPri(7);
+    ReactNoop.flushDeferredPri(7 + 5);
     expect(fooCalled).toBe(true);
     expect(barCalled).toBe(false);
     // Do the rest of the work.
@@ -143,7 +143,7 @@ describe('ReactIncremental', () => {
 
     ReactNoop.render(<Foo text="bar" />);
     // Flush part of the work
-    ReactNoop.flushDeferredPri(20);
+    ReactNoop.flushDeferredPri(20 + 5);
 
     expect(ops).toEqual(['Foo', 'Bar']);
 
@@ -153,7 +153,7 @@ describe('ReactIncremental', () => {
     ReactNoop.render(<Foo text="baz" />);
 
     // Flush part of the new work
-    ReactNoop.flushDeferredPri(20);
+    ReactNoop.flushDeferredPri(20 + 5);
 
     expect(ops).toEqual(['Foo', 'Bar']);
 
@@ -328,7 +328,7 @@ describe('ReactIncremental', () => {
 
     // We're now rendering an update that will bail out on updating middle.
     ReactNoop.render(<Foo text="bar" />);
-    ReactNoop.flushDeferredPri(45);
+    ReactNoop.flushDeferredPri(45 + 5);
 
     expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
 
@@ -395,7 +395,7 @@ describe('ReactIncremental', () => {
 
     // Init
     ReactNoop.render(<Foo text="foo" />);
-    ReactNoop.flushDeferredPri(52);
+    ReactNoop.flushDeferredPri(52 + 5);
 
     expect(ops).toEqual(['Foo', 'Bar', 'Tester', 'Bar']);
 
@@ -467,7 +467,7 @@ describe('ReactIncremental', () => {
 
     // Init
     ReactNoop.render(<Foo text="foo" text2="foo" step={0} />);
-    ReactNoop.flushDeferredPri(55 + 25);
+    ReactNoop.flushDeferredPri(55 + 25 + 5);
 
     // We only finish the higher priority work. So the low pri content
     // has not yet finished mounting.
@@ -489,7 +489,7 @@ describe('ReactIncremental', () => {
     // Make a quick update which will schedule low priority work to
     // update the middle content.
     ReactNoop.render(<Foo text="bar" text2="bar" step={1} />);
-    ReactNoop.flushDeferredPri(30 + 25);
+    ReactNoop.flushDeferredPri(30 + 25 + 5);
 
     expect(ops).toEqual(['Foo', 'Bar']);
 
@@ -583,7 +583,7 @@ describe('ReactIncremental', () => {
     ops = [];
 
     // The middle content is now pending rendering...
-    ReactNoop.flushDeferredPri(30 + 25);
+    ReactNoop.flushDeferredPri(30 + 25 + 5);
     expect(ops).toEqual(['Content', 'Middle', 'Bar']); // One more Middle left.
 
     ops = [];

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -21,6 +21,7 @@ describe('ReactIncrementalSideEffects', () => {
   });
 
   function div(...children) {
+    children = children.map(c => typeof c === 'string' ? { text: c } : c);
     return { type: 'div', children, prop: undefined };
   }
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -557,7 +557,87 @@ describe('ReactIncrementalSideEffects', () => {
 
   });
 
-  // TODO: Test that unmounts and deletions happen in the expected way for
-  // aborted and resumed render life-cycles.
+  it('calls componentDidMount/Update after insertion/update', () => {
+
+    var ops = [];
+
+    class Bar extends React.Component {
+      componentDidMount() {
+        ops.push('mount:' + this.props.name);
+      }
+      componentDidUpdate() {
+        ops.push('update:' + this.props.name);
+      }
+      render() {
+        return <span />;
+      }
+    }
+
+    class Wrapper extends React.Component {
+      componentDidMount() {
+        ops.push('mount:wrapper-' + this.props.name);
+      }
+      componentDidUpdate() {
+        ops.push('update:wrapper-' + this.props.name);
+      }
+      render() {
+        return <Bar name={this.props.name} />;
+      }
+    }
+
+    function Foo(props) {
+      return (
+        <div>
+          <Bar key="a" name="A" />
+          <Wrapper key="b" name="B" />
+          <div key="cd">
+            <Bar name="C" />
+            <Wrapper name="D" />
+          </div>
+          {[
+            <Bar key="e" name="E" />,
+            <Bar key="f" name="F" />,
+          ]}
+          <div>
+            <Bar key="g" name="G" />
+          </div>
+        </div>
+      );
+    }
+
+    ReactNoop.render(<Foo />);
+    ReactNoop.flush();
+    expect(ops).toEqual([
+      'mount:A',
+      'mount:B',
+      'mount:wrapper-B',
+      'mount:C',
+      'mount:D',
+      'mount:wrapper-D',
+      'mount:E',
+      'mount:F',
+      'mount:G',
+    ]);
+
+    ops = [];
+
+    ReactNoop.render(<Foo />);
+    ReactNoop.flush();
+    expect(ops).toEqual([
+      'update:A',
+      'update:B',
+      'update:wrapper-B',
+      'update:C',
+      'update:D',
+      'update:wrapper-D',
+      'update:E',
+      'update:F',
+      'update:G',
+    ]);
+
+  });
+
+  // TODO: Test that mounts, updates, refs, unmounts and deletions happen in the
+  // expected way for aborted and resumed render life-cycles.
 
 });

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -680,14 +680,11 @@ describe('ReactIncrementalSideEffects', () => {
     ReactNoop.render(<Foo show={true} />);
     ReactNoop.flush();
     expect(ops).toEqual([
-      // TODO: All detach should happen first. Currently they're interleaved.
-      // detach
+      // detach all refs that switched handlers first.
       null,
-      // reattach
+      null,
+      // reattach as a separate phase
       classInstance,
-      // detach
-      null,
-      // reattach
       div(),
     ]);
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -57,6 +57,38 @@ describe('ReactIncrementalSideEffects', () => {
 
   });
 
+  it('can update child nodes of a fragment', function() {
+
+    function Bar(props) {
+      return <span>{props.text}</span>;
+    }
+
+    function Foo(props) {
+      return (
+        <div>
+          <Bar text={props.text} />
+          {props.text === 'World' ? [
+            <Bar key="a" text={props.text} />,
+            <div key="b" />,
+          ] : null}
+        </div>
+      );
+    }
+
+    ReactNoop.render(<Foo text="Hello" />);
+    ReactNoop.flush();
+    expect(ReactNoop.root.children).toEqual([
+      div(span()),
+    ]);
+
+    ReactNoop.render(<Foo text="World" />);
+    ReactNoop.flush();
+    expect(ReactNoop.root.children).toEqual([
+      div(span(), span(), div()),
+    ]);
+
+  });
+
   it('does not update child nodes if a flush is aborted', () => {
 
     function Bar(props) {

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -71,7 +71,11 @@ describe('ReactIncrementalSideEffects', () => {
           {props.text === 'World' ? [
             <Bar key="a" text={props.text} />,
             <div key="b" />,
+          ] : props.text === 'Hi' ? [
+            <div key="b" />,
+            <Bar key="a" text={props.text} />,
           ] : null}
+          <span prop="test" />
         </div>
       );
     }
@@ -79,13 +83,19 @@ describe('ReactIncrementalSideEffects', () => {
     ReactNoop.render(<Foo text="Hello" />);
     ReactNoop.flush();
     expect(ReactNoop.root.children).toEqual([
-      div(span()),
+      div(span(), span('test')),
     ]);
 
     ReactNoop.render(<Foo text="World" />);
     ReactNoop.flush();
     expect(ReactNoop.root.children).toEqual([
-      div(span(), span(), div()),
+      div(span(), span(), div(), span('test')),
+    ]);
+
+    ReactNoop.render(<Foo text="Hi" />);
+    ReactNoop.flush();
+    expect(ReactNoop.root.children).toEqual([
+      div(span(), div(), span(), span('test')),
     ]);
 
   });

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -380,7 +380,7 @@ describe('ReactIncrementalSideEffects', () => {
   it('can defer side-effects and resume them later on', function() {
     class Bar extends React.Component {
       shouldComponentUpdate(nextProps) {
-        return this.props.idx !== nextProps;
+        return this.props.idx !== nextProps.idx;
       }
       render() {
         return <span prop={this.props.idx} />;
@@ -437,10 +437,11 @@ describe('ReactIncrementalSideEffects', () => {
         )
       ),
     ]);
-    ReactNoop.flushDeferredPri(30);
+    ReactNoop.render(<Foo tick={3} idx={1} />);
+    ReactNoop.flush();
     expect(ReactNoop.root.children).toEqual([
       div(
-        span(2),
+        span(3),
         div(
           // New numbers.
           span(1),
@@ -456,6 +457,149 @@ describe('ReactIncrementalSideEffects', () => {
     expect(innerSpanA).toBe(innerSpanB);
   });
 
+  it('can defer side-effects and reuse them later - complex', function() {
+    var ops = [];
+
+    class Bar extends React.Component {
+      shouldComponentUpdate(nextProps) {
+        return this.props.idx !== nextProps.idx;
+      }
+      render() {
+        ops.push('Bar');
+        return <span prop={this.props.idx} />;
+      }
+    }
+    class Baz extends React.Component {
+      shouldComponentUpdate(nextProps) {
+        return this.props.idx !== nextProps.idx;
+      }
+      render() {
+        ops.push('Baz');
+        return [<Bar idx={this.props.idx} />, <Bar idx={this.props.idx} />];
+      }
+    }
+    function Foo(props) {
+      ops.push('Foo');
+      return (
+        <div>
+          <span prop={props.tick} />
+          <div hidden={true}>
+            <Baz idx={props.idx} />
+            <Baz idx={props.idx} />
+            <Baz idx={props.idx} />
+          </div>
+        </div>
+      );
+    }
+    ReactNoop.render(<Foo tick={0} idx={0} />);
+    ReactNoop.flushDeferredPri(65);
+    expect(ReactNoop.root.children).toEqual([
+      div(
+        span(0),
+        div(/*the spans are down-prioritized and not rendered yet*/)
+      ),
+    ]);
+
+    expect(ops).toEqual(['Foo', 'Baz', 'Bar']);
+    ops = [];
+
+    ReactNoop.render(<Foo tick={1} idx={0} />);
+    ReactNoop.flushDeferredPri(70);
+    expect(ReactNoop.root.children).toEqual([
+      div(
+        span(1),
+        div(/*still not rendered yet*/)
+      ),
+    ]);
+
+    expect(ops).toEqual(['Foo', 'Baz', 'Bar']);
+    ops = [];
+
+    ReactNoop.flush();
+    expect(ReactNoop.root.children).toEqual([
+      div(
+        span(1),
+        div(
+          // Now we had enough time to finish the spans.
+          span(0),
+          span(0),
+          span(0),
+          span(0),
+          span(0),
+          span(0)
+        )
+      ),
+    ]);
+
+    expect(ops).toEqual(['Bar', 'Baz', 'Bar', 'Bar', 'Baz', 'Bar', 'Bar']);
+    ops = [];
+
+    // Now we're going to update the index but we'll only let it finish half
+    // way through.
+    ReactNoop.render(<Foo tick={2} idx={1} />);
+    ReactNoop.flushDeferredPri(95);
+    expect(ReactNoop.root.children).toEqual([
+      div(
+        span(2),
+        div(
+          // Still same old numbers.
+          span(0),
+          span(0),
+          span(0),
+          span(0),
+          span(0),
+          span(0)
+        )
+      ),
+    ]);
+
+    // We let it finish half way through. That means we'll have one fully
+    // completed Baz, one half-way completed Baz and one fully incomplete Baz.
+    expect(ops).toEqual(['Foo', 'Baz', 'Bar', 'Bar', 'Baz', 'Bar']);
+    ops = [];
+
+    // We'll update again, without letting the new index update yet. Only half
+    // way through.
+    ReactNoop.render(<Foo tick={3} idx={1} />);
+    ReactNoop.flushDeferredPri(50);
+    expect(ReactNoop.root.children).toEqual([
+      div(
+        span(3),
+        div(
+          // Old numbers.
+          span(0),
+          span(0),
+          span(0),
+          span(0),
+          span(0),
+          span(0)
+        )
+      ),
+    ]);
+
+    expect(ops).toEqual(['Foo']);
+    ops = [];
+
+    // We should now be able to reuse some of the work we've already done
+    // and replay those side-effects.
+    ReactNoop.flush();
+    expect(ReactNoop.root.children).toEqual([
+      div(
+        span(3),
+        div(
+          // New numbers.
+          span(1),
+          span(1),
+          span(1),
+          span(1),
+          span(1),
+          span(1)
+        )
+      ),
+    ]);
+
+    expect(ops).toEqual(['Baz', 'Bar', 'Baz', 'Bar', 'Bar']);
+  });
 
   // TODO: Test that side-effects are not cut off when a work in progress node
   // moves to "current" without flushing due to having lower priority. Does this

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -89,6 +89,38 @@ describe('ReactIncrementalSideEffects', () => {
 
   });
 
+  it('can update child nodes rendering into text nodes', function() {
+
+    function Bar(props) {
+      return props.text;
+    }
+
+    function Foo(props) {
+      return (
+        <div>
+          <Bar text={props.text} />
+          {props.text === 'World' ? [
+            <Bar key="a" text={props.text} />,
+            '!',
+          ] : null}
+        </div>
+      );
+    }
+
+    ReactNoop.render(<Foo text="Hello" />);
+    ReactNoop.flush();
+    expect(ReactNoop.root.children).toEqual([
+      div('Hello'),
+    ]);
+
+    ReactNoop.render(<Foo text="World" />);
+    ReactNoop.flush();
+    expect(ReactNoop.root.children).toEqual([
+      div('World', 'World', '!'),
+    ]);
+
+  });
+
   it('does not update child nodes if a flush is aborted', () => {
 
     function Bar(props) {

--- a/src/renderers/shared/fiber/__tests__/ReactTopLevelFragment-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactTopLevelFragment-test.js
@@ -94,4 +94,73 @@ describe('ReactTopLevelFragment', function() {
 
   });
 
+  it('preserves state if an implicit key slot switches from/to null', function() {
+
+    var instance = null;
+
+    class Stateful extends React.Component {
+      render() {
+        instance = this;
+        return <div>World</div>;
+      }
+    }
+
+    function Fragment({ condition }) {
+      return condition ? [null, <Stateful />] :
+        [<div>Hello</div>, <Stateful />];
+    }
+    ReactNoop.render(<Fragment />);
+    ReactNoop.flush();
+
+    var instanceA = instance;
+
+    expect(instanceA).not.toBe(null);
+
+    ReactNoop.render(<Fragment condition={true} />);
+    ReactNoop.flush();
+
+    var instanceB = instance;
+
+    expect(instanceB).toBe(instanceA);
+
+    ReactNoop.render(<Fragment condition={false} />);
+    ReactNoop.flush();
+
+    var instanceC = instance;
+
+    expect(instanceC === instanceA).toBe(true);
+
+  });
+
+  it('should preserve state in a reorder', function() {
+
+    var instance = null;
+
+    class Stateful extends React.Component {
+      render() {
+        instance = this;
+        return <div>Hello</div>;
+      }
+    }
+
+    function Fragment({ condition }) {
+      return condition ? [[<div key="b">World</div>, <Stateful key="a" />]] :
+        [[<Stateful key="a" />, <div key="b">World</div>], <div />];
+    }
+    ReactNoop.render(<Fragment />);
+    ReactNoop.flush();
+
+    var instanceA = instance;
+
+    expect(instanceA).not.toBe(null);
+
+    ReactNoop.render(<Fragment condition={true} />);
+    ReactNoop.flush();
+
+    var instanceB = instance;
+
+    expect(instanceB).toBe(instanceA);
+
+  });
+
 });

--- a/src/renderers/shared/fiber/__tests__/ReactTopLevelFragment-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactTopLevelFragment-test.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var React;
+var ReactNoop;
+
+// This is a new feature in Fiber so I put it in its own test file. It could
+// probably move to one of the other test files once it is official.
+describe('ReactTopLevelFragment', function() {
+  beforeEach(function() {
+    React = require('React');
+    ReactNoop = require('ReactNoop');
+  });
+
+  it('should render a simple fragment at the top of a component', function() {
+
+    function Fragment() {
+      return [<div key="a">Hello</div>, <div key="b">World</div>];
+    }
+    ReactNoop.render(<Fragment />);
+    ReactNoop.flush();
+
+  });
+
+  it('should preserve state when switching from a single child', function() {
+
+    var instance = null;
+
+    class Stateful extends React.Component {
+      render() {
+        instance = this;
+        return <div>Hello</div>;
+      }
+    }
+
+    function Fragment({ condition }) {
+      return condition ? <Stateful key="a" /> :
+        [<Stateful key="a" />, <div key="b">World</div>];
+    }
+    ReactNoop.render(<Fragment />);
+    ReactNoop.flush();
+
+    var instanceA = instance;
+
+    expect(instanceA).not.toBe(null);
+
+    ReactNoop.render(<Fragment condition={true} />);
+    ReactNoop.flush();
+
+    var instanceB = instance;
+
+    expect(instanceB).toBe(instanceA);
+
+  });
+
+  it('should not preserve state when switching to a nested array', function() {
+
+    var instance = null;
+
+    class Stateful extends React.Component {
+      render() {
+        instance = this;
+        return <div>Hello</div>;
+      }
+    }
+
+    function Fragment({ condition }) {
+      return condition ? <Stateful key="a" /> :
+        [[<Stateful key="a" />, <div key="b">World</div>], <div />];
+    }
+    ReactNoop.render(<Fragment />);
+    ReactNoop.flush();
+
+    var instanceA = instance;
+
+    expect(instanceA).not.toBe(null);
+
+    ReactNoop.render(<Fragment condition={true} />);
+    ReactNoop.flush();
+
+    var instanceB = instance;
+
+    expect(instanceB).not.toBe(instanceA);
+
+  });
+
+});

--- a/src/renderers/shared/fiber/isomorphic/ReactCoroutine.js
+++ b/src/renderers/shared/fiber/isomorphic/ReactCoroutine.js
@@ -33,10 +33,7 @@ export type ReactCoroutine = {
   children: any,
   // This should be a more specific CoroutineHandler
   handler: (props: any, yields: Array<ReifiedYield>) => ReactNodeList,
-  /* $FlowFixMe(>=0.31.0): Which is it? mixed? Or Object? Must match
-   * `ReactYield` type.
-   */
-  props: mixed,
+  props: any,
 };
 export type ReactYield = {
   $$typeof: Symbol | number,

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactMultiChildText-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactMultiChildText-test.js
@@ -26,17 +26,17 @@ var testAllPermutations = function(testCases) {
       var expectedResultAfterUpdate = testCases[j + 1];
 
       var container = document.createElement('div');
-      var d = ReactDOM.render(<div>{renderWithChildren}</div>, container);
-      expectChildren(d, expectedResultAfterRender);
+      ReactDOM.render(<div>{renderWithChildren}</div>, container);
+      expectChildren(container, expectedResultAfterRender);
 
-      d = ReactDOM.render(<div>{updateWithChildren}</div>, container);
-      expectChildren(d, expectedResultAfterUpdate);
+      ReactDOM.render(<div>{updateWithChildren}</div>, container);
+      expectChildren(container, expectedResultAfterUpdate);
     }
   }
 };
 
-var expectChildren = function(d, children) {
-  var outerNode = ReactDOM.findDOMNode(d);
+var expectChildren = function(container, children) {
+  var outerNode = container.firstChild;
   var textNode;
   if (typeof children === 'string') {
     textNode = outerNode.firstChild;


### PR DESCRIPTION
I'll take a page out of @gaearon's playbook and list out my todo in an early PR as I'm implementing it:

- [x] Add the fragment fiber type.
- [x] Add the text fiber type.
- [x] Implement the proper child reconciliation algorithm. Split initial from updates since initial will not need to track side-effects (like move).
- [x] Track mount index in Fiber. This allows us to detect reorders by comparing to committed fields instead of wip. It also allows us to insert nulls in the list without additional fibers.
- [x] ~~Change side-effects to reverse order.~~
- [x] Add to the side-effects list for insert/move/delete. Tag them.
- [x] Change the host config API to deal with insert/move/delete before. Use the tag to avoid updating props if not needed.
- [x] Trigger life-cycle methods. componentDidMount, componentDidUpdate, componentWillUnmount
- [x] Detach and attach refs.