### PR TITLE
Proper font-family for docs search box (#7706)

### DIFF
--- a/docs/_css/_typography.scss
+++ b/docs/_css/_typography.scss
@@ -112,8 +112,6 @@ li {
   line-height: 20px;
 }
 
-
-
 a {
   color: $linkColor;
   text-decoration: none;
@@ -130,4 +128,8 @@ a {
 }
 .center {
   text-align: center;
+}
+
+input {
+  font-family: inherit;
 }


### PR DESCRIPTION
This is a straight-forward change to font-family of search input on docs, unifying it with the rest of the page

Before:
<img width="244" alt="screen shot 2016-09-13 at 00 27 48" src="https://cloud.githubusercontent.com/assets/5106466/18455232/11519d64-7949-11e6-9012-3e20fc142b17.png">
After:
<img width="248" alt="screen shot 2016-09-13 at 00 27 38" src="https://cloud.githubusercontent.com/assets/5106466/18455231/1150ac92-7949-11e6-9b62-6c2557f4b8a5.png">

