### PR TITLE
Ensure that dangerous innerHTML is a string if set

### DIFF
--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -971,6 +971,13 @@ describe('ReactDOMComponent', () => {
         '`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. ' +
         'Please visit https://fb.me/react-invariant-dangerously-set-inner-html for more information.'
       );
+
+      expect(function() {
+        mountComponent({dangerouslySetInnerHTML: {__html: {foo: 'bar'} } });
+      }).toThrowError(
+        '`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. ' +
+        'Please visit https://fb.me/react-invariant-dangerously-set-inner-html for more information.'
+      );
     });
 
     it('should allow {__html: null}', () => {

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -946,7 +946,6 @@ describe('ReactDOMComponent', () => {
     });
 
     it('should validate against use of innerHTML', () => {
-
       spyOn(console, 'error');
       mountComponent({innerHTML: '<span>Hi Jim!</span>'});
       expectDev(console.error.calls.count()).toBe(1);
@@ -971,12 +970,14 @@ describe('ReactDOMComponent', () => {
         '`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. ' +
         'Please visit https://fb.me/react-invariant-dangerously-set-inner-html for more information.'
       );
+    });
 
-      expect(function() {
-        mountComponent({dangerouslySetInnerHTML: {__html: {foo: 'bar'} } });
-      }).toThrowError(
-        '`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. ' +
-        'Please visit https://fb.me/react-invariant-dangerously-set-inner-html for more information.'
+    it('should warn if dangerouslySetInnerHTML is not a string', () => {
+      spyOn(console, 'error');
+      mountComponent({dangerouslySetInnerHTML: {__html: {foo: 'bar'} } });
+      expect(console.error.calls.count(0)).toBe(1);
+      expect(console.error.calls.argsFor(0)[0]).toContain(
+        '`props.dangerouslySetInnerHTML` should be a string.'
       );
     });
 

--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -98,6 +98,14 @@ function assertValidProps(component, props) {
     );
     invariant(
       typeof props.dangerouslySetInnerHTML === 'object' &&
+      HTML in props.dangerouslySetInnerHTML &&
+      (!props.dangerouslySetInnerHTML[HTML] || typeof props.dangerouslySetInnerHTML[HTML] === 'string'),
+      '`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. ' +
+      'Please visit https://fb.me/react-invariant-dangerously-set-inner-html ' +
+      'for more information.'
+    );
+    invariant(
+      typeof props.dangerouslySetInnerHTML === 'object' &&
       HTML in props.dangerouslySetInnerHTML,
       '`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. ' +
       'Please visit https://fb.me/react-invariant-dangerously-set-inner-html ' +

--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -98,19 +98,17 @@ function assertValidProps(component, props) {
     );
     invariant(
       typeof props.dangerouslySetInnerHTML === 'object' &&
-      HTML in props.dangerouslySetInnerHTML &&
-      (!props.dangerouslySetInnerHTML[HTML] || typeof props.dangerouslySetInnerHTML[HTML] === 'string'),
-      '`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. ' +
-      'Please visit https://fb.me/react-invariant-dangerously-set-inner-html ' +
-      'for more information.'
-    );
-    invariant(
-      typeof props.dangerouslySetInnerHTML === 'object' &&
       HTML in props.dangerouslySetInnerHTML,
       '`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. ' +
       'Please visit https://fb.me/react-invariant-dangerously-set-inner-html ' +
       'for more information.'
     );
+    if (props.dangerouslySetInnerHTML[HTML]) {
+      warning(
+        props.dangerouslySetInnerHTML[HTML].toString !== Object.prototype.toString,
+        '`props.dangerouslySetInnerHTML` should be a string.'
+      );
+    }
   }
   if (__DEV__) {
     warning(


### PR DESCRIPTION
This should avoid issues like this one:

``` javascript
let contents = { en: "hello", de: "hallo", fr: "salut" };

<div dangerouslySetInnerHTML={{ __html: contents }} />
```

(This just happened to me when I wasn't paying attention, resulting in much confusion when only `[object Object]` was being rendered - it took me a while to realize that `contents` was invalid.)

I realize the code here isn't pretty, but I'm not sure what React's convention is for this (e.g. extracting `props.dangerouslySetInnerHTML` into a temporary variable) - so feel free to suggest improvements.
