### PR TITLE
Clean up ReactTestRenderer

### DIFF
--- a/src/renderers/testing/ReactTestEmptyComponent.js
+++ b/src/renderers/testing/ReactTestEmptyComponent.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactTestEmptyComponent
+ * @flow
+ */
+
+'use strict';
+
+class ReactTestEmptyComponent {
+  constructor() {
+    this._currentElement = null;
+  }
+  receiveComponent(): void {}
+  toJSON(): void {}
+  mountComponent(): void {}
+  getHostNode(): void {}
+  unmountComponent(): void {}
+}
+
+module.exports = ReactTestEmptyComponent;

--- a/src/renderers/testing/ReactTestRenderer.js
+++ b/src/renderers/testing/ReactTestRenderer.js
@@ -7,6 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule ReactTestRenderer
+ * @flow
  */
 
 'use strict';
@@ -21,6 +22,14 @@ var ReactTestReconcileTransaction = require('ReactTestReconcileTransaction');
 var ReactUpdates = require('ReactUpdates');
 var ReactTestTextComponent = require('ReactTestTextComponent');
 var ReactTestEmptyComponent = require('ReactTestEmptyComponent');
+
+import type { ReactElement } from 'ReactElementType';
+
+type ReactTestRendererJSON = {
+  type: string,
+  props: { [propName: string]: string },
+  children: Array<string | ReactTestRendererJSON>,
+}
 
 /**
  * Drill down (through composites and empty components) until we get a native or
@@ -38,38 +47,38 @@ function getRenderedHostOrTextFromComponent(component) {
 }
 
 class ReactTestComponent {
-  constructor(element) {
+  constructor(element: ReactElement) {
     this._currentElement = element;
     this._renderedChildren = null;
     this._topLevelWrapper = null;
   }
 
   mountComponent(
-    transaction,
-    nativeParent,
-    nativeContainerInfo,
-    context,
+    transaction: ReactTestReconcileTransaction,
+    nativeParent: null | ReactTestComponent,
+    nativeContainerInfo: ?null,
+    context: Object,
   ) {
     var element = this._currentElement;
     this.mountChildren(element.props.children, transaction, context);
   }
 
   receiveComponent(
-    nextElement,
-    transaction,
-    context,
+    nextElement: ReactElement,
+    transaction: ReactTestReconcileTransaction,
+    context: Object,
   ) {
     this._currentElement = nextElement;
     this.updateChildren(nextElement.props.children, transaction, context);
   }
 
-  getPublicInstance(transaction) {
+  getPublicInstance(transaction: ReactTestReconcileTransaction): Object {
     var element = this._currentElement;
     var options = transaction.getTestOptions();
     return options.createNodeMock(element);
   }
 
-  toJSON() {
+  toJSON(): ReactTestRendererJSON {
     var {children, ...props} = this._currentElement.props;
     var childrenJSON = [];
     for (var key in this._renderedChildren) {
@@ -91,8 +100,8 @@ class ReactTestComponent {
     return object;
   }
 
-  getHostNode() {}
-  unmountComponent() {}
+  getHostNode(): void {}
+  unmountComponent(): void {}
 }
 
 Object.assign(ReactTestComponent.prototype, ReactMultiChild);

--- a/src/renderers/testing/ReactTestRenderer.js
+++ b/src/renderers/testing/ReactTestRenderer.js
@@ -19,6 +19,7 @@ var ReactHostComponent = require('ReactHostComponent');
 var ReactTestMount = require('ReactTestMount');
 var ReactTestReconcileTransaction = require('ReactTestReconcileTransaction');
 var ReactUpdates = require('ReactUpdates');
+var ReactTestTextComponent = require('ReactTestTextComponent');
 
 /**
  * Drill down (through composites and empty components) until we get a native or
@@ -95,21 +96,6 @@ ReactTestComponent.prototype.toJSON = function() {
   return object;
 };
 Object.assign(ReactTestComponent.prototype, ReactMultiChild);
-
-// =============================================================================
-
-var ReactTestTextComponent = function(element) {
-  this._currentElement = element;
-};
-ReactTestTextComponent.prototype.mountComponent = function() {};
-ReactTestTextComponent.prototype.receiveComponent = function(nextElement) {
-  this._currentElement = nextElement;
-};
-ReactTestTextComponent.prototype.getHostNode = function() {};
-ReactTestTextComponent.prototype.unmountComponent = function() {};
-ReactTestTextComponent.prototype.toJSON = function() {
-  return this._currentElement;
-};
 
 // =============================================================================
 

--- a/src/renderers/testing/ReactTestRenderer.js
+++ b/src/renderers/testing/ReactTestRenderer.js
@@ -20,6 +20,7 @@ var ReactTestMount = require('ReactTestMount');
 var ReactTestReconcileTransaction = require('ReactTestReconcileTransaction');
 var ReactUpdates = require('ReactUpdates');
 var ReactTestTextComponent = require('ReactTestTextComponent');
+var ReactTestEmptyComponent = require('ReactTestEmptyComponent');
 
 /**
  * Drill down (through composites and empty components) until we get a native or
@@ -36,77 +37,65 @@ function getRenderedHostOrTextFromComponent(component) {
   return component;
 }
 
-
-// =============================================================================
-
-var ReactTestComponent = function(element) {
-  this._currentElement = element;
-  this._renderedChildren = null;
-  this._topLevelWrapper = null;
-};
-
-ReactTestComponent.prototype.mountComponent = function(
-  transaction,
-  nativeParent,
-  nativeContainerInfo,
-  context
-) {
-  var element = this._currentElement;
-  this.mountChildren(element.props.children, transaction, context);
-};
-
-ReactTestComponent.prototype.receiveComponent = function(
-  nextElement,
-  transaction,
-  context
-) {
-  this._currentElement = nextElement;
-  this.updateChildren(nextElement.props.children, transaction, context);
-};
-
-ReactTestComponent.prototype.getHostNode = function() {};
-
-ReactTestComponent.prototype.getPublicInstance = function(transaction) {
-  var element = this._currentElement;
-  var options = transaction.getTestOptions();
-  return options.createNodeMock(element);
-};
-
-ReactTestComponent.prototype.unmountComponent = function() {};
-
-ReactTestComponent.prototype.toJSON = function() {
-  var {children, ...props} = this._currentElement.props;
-  var childrenJSON = [];
-  for (var key in this._renderedChildren) {
-    var inst = this._renderedChildren[key];
-    inst = getRenderedHostOrTextFromComponent(inst);
-    var json = inst.toJSON();
-    if (json !== undefined) {
-      childrenJSON.push(json);
-    }
+class ReactTestComponent {
+  constructor(element) {
+    this._currentElement = element;
+    this._renderedChildren = null;
+    this._topLevelWrapper = null;
   }
-  var object = {
-    type: this._currentElement.type,
-    props: props,
-    children: childrenJSON.length ? childrenJSON : null,
-  };
-  Object.defineProperty(object, '$$typeof', {
-    value: Symbol.for('react.test.json'),
-  });
-  return object;
-};
+
+  mountComponent(
+    transaction,
+    nativeParent,
+    nativeContainerInfo,
+    context,
+  ) {
+    var element = this._currentElement;
+    this.mountChildren(element.props.children, transaction, context);
+  }
+
+  receiveComponent(
+    nextElement,
+    transaction,
+    context,
+  ) {
+    this._currentElement = nextElement;
+    this.updateChildren(nextElement.props.children, transaction, context);
+  }
+
+  getPublicInstance(transaction) {
+    var element = this._currentElement;
+    var options = transaction.getTestOptions();
+    return options.createNodeMock(element);
+  }
+
+  toJSON() {
+    var {children, ...props} = this._currentElement.props;
+    var childrenJSON = [];
+    for (var key in this._renderedChildren) {
+      var inst = this._renderedChildren[key];
+      inst = getRenderedHostOrTextFromComponent(inst);
+      var json = inst.toJSON();
+      if (json !== undefined) {
+        childrenJSON.push(json);
+      }
+    }
+    var object = {
+      type: this._currentElement.type,
+      props: props,
+      children: childrenJSON.length ? childrenJSON : null,
+    };
+    Object.defineProperty(object, '$$typeof', {
+      value: Symbol.for('react.test.json'),
+    });
+    return object;
+  }
+
+  getHostNode() {}
+  unmountComponent() {}
+}
+
 Object.assign(ReactTestComponent.prototype, ReactMultiChild);
-
-// =============================================================================
-
-var ReactTestEmptyComponent = function(element) {
-  this._currentElement = null;
-};
-ReactTestEmptyComponent.prototype.mountComponent = function() {};
-ReactTestEmptyComponent.prototype.receiveComponent = function() {};
-ReactTestEmptyComponent.prototype.getHostNode = function() {};
-ReactTestEmptyComponent.prototype.unmountComponent = function() {};
-ReactTestEmptyComponent.prototype.toJSON = function() {};
 
 // =============================================================================
 

--- a/src/renderers/testing/ReactTestTextComponent.js
+++ b/src/renderers/testing/ReactTestTextComponent.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactTestTextComponent
+ * @flow
+ */
+
+'use strict';
+
+import type { ReactText } from 'ReactTypes';
+
+class ReactTestTextComponent {
+  constructor(element: ReactText) {
+    this._currentElement = element;
+  }
+
+  receiveComponent(nextElement: ReactText) {
+    this._currentElement = nextElement;
+  }
+
+  toJSON(): ReactText {
+    return this._currentElement;
+  }
+
+  mountComponent(): void {}
+  getHostNode(): void {}
+  unmountComponent(): void {}
+}
+
+module.exports = ReactTestTextComponent;


### PR DESCRIPTION
This breaks out `ReactTestTextComponent` and `ReactTestEmptyComponent` into their own files so the main ReactTestRenderer.js file is a little cleaner.

I also implemented `ReactTestRenderer` with an ES6 class + flow types.

cc @gaearon @spicyj 