### PR TITLE
Exlude disabled elements from propagation

### DIFF
--- a/src/renderers/dom/client/ReactDOMTreeTraversal.js
+++ b/src/renderers/dom/client/ReactDOMTreeTraversal.js
@@ -80,13 +80,18 @@ function getParentInstance(inst) {
 }
 
 /**
- * Simulates the traversal of a two-phase, capture/bubble event dispatch.
+ * Simulates the traversal of a two-phase, capture/bubble event dispatch
+ * with skipping disabled instances.
  */
 function traverseTwoPhase(inst, fn, arg) {
   var path = [];
   while (inst) {
     path.push(inst);
-    inst = inst._hostParent;
+    var parent = getParentInstance(inst);
+    while (parent && parent._currentElement && parent._currentElement.props.disabled) {
+      parent = getParentInstance(parent);
+    }
+    inst = parent;
   }
   var i;
   for (i = path.length; i-- > 0;) {

--- a/src/renderers/dom/client/__tests__/ReactDOMTreeTraversal-test.js
+++ b/src/renderers/dom/client/__tests__/ReactDOMTreeTraversal-test.js
@@ -40,6 +40,10 @@ class ParentComponent extends React.Component {
           <ChildComponent ref="P_P1_C1" />
           <ChildComponent ref="P_P1_C2" />
         </div>
+        <div disabled={true} ref="P_P2" >
+          <ChildComponent ref="P_P2_C1" />
+          <ChildComponent ref="P_P2_C2" />
+        </div>
         <div ref="P_OneOff" />
       </div>
     );
@@ -90,6 +94,22 @@ describe('ReactDOMTreeTraversal', () => {
         {node: parent.refs.P_P1_C1.refs.DIV_1, isUp: true, arg: ARG},
         {node: parent.refs.P_P1_C1.refs.DIV, isUp: true, arg: ARG},
         {node: parent.refs.P_P1, isUp: true, arg: ARG},
+        {node: parent.refs.P, isUp: true, arg: ARG},
+      ];
+      ReactDOMTreeTraversal.traverseTwoPhase(target, argAggregator, ARG);
+      expect(aggregatedArgs).toEqual(expectedAggregation);
+    });
+
+    it('should traverse two phase across component boundary exlude disabled ones', () => {
+      var parent = renderParentIntoDocument();
+      var target = getInst(parent.refs.P_P2_C1.refs.DIV_1);
+      var expectedAggregation = [
+        {node: parent.refs.P, isUp: false, arg: ARG},
+        {node: parent.refs.P_P2_C1.refs.DIV, isUp: false, arg: ARG},
+        {node: parent.refs.P_P2_C1.refs.DIV_1, isUp: false, arg: ARG},
+
+        {node: parent.refs.P_P2_C1.refs.DIV_1, isUp: true, arg: ARG},
+        {node: parent.refs.P_P2_C1.refs.DIV, isUp: true, arg: ARG},
         {node: parent.refs.P, isUp: true, arg: ARG},
       ];
       ReactDOMTreeTraversal.traverseTwoPhase(target, argAggregator, ARG);


### PR DESCRIPTION
This is should be the fix for #7711 
Basically, I've realised that when it simulates capturing and bubbling inside `ReactDOMTreeTraversal` - it ignores that element could be disabled, apart from browser - https://jsfiddle.net/dzj1z9p9/.
