### PR TITLE
Update ignores in flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,13 +1,13 @@
 [ignore]
 
-.*/examples/.*
-.*/build/.*
-.*/node_modules/y18n/.*
-.*/__mocks__/.*
-.*/__tests__/.*
+<PROJECT_ROOT>/examples/.*
+<PROJECT_ROOT>/build/.*
+<PROJECT_ROOT>/.*/node_modules/y18n/.*
+<PROJECT_ROOT>/.*/__mocks__/.*
+<PROJECT_ROOT>/.*/__tests__/.*
 
 # Ignore Docs
-.*/docs/.*
+<PROJECT_ROOT>/.*/docs/.*
 
 [include]
 


### PR DESCRIPTION
This ensures we ignore relative to our project root and won't be tripped up by issues where checkouts in other places result in Flow passing when it shouldn't (eg on Travis CI where the checkout path is `/home/travis/build/facebook/react`)