### PR TITLE
Remove plain object warning for createElement & cloneElement

### DIFF
--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -192,16 +192,6 @@ ReactElement.createElement = function(type, config, children) {
   var source = null;
 
   if (config != null) {
-    if (__DEV__) {
-      warning(
-        /* eslint-disable no-proto */
-        config.__proto__ == null || config.__proto__ === Object.prototype,
-        /* eslint-enable no-proto */
-        'React.createElement(...): Expected props argument to be a plain object. ' +
-        'Properties defined in its prototype chain will be ignored.'
-      );
-    }
-
     if (hasValidRef(config)) {
       ref = config.ref;
     }
@@ -327,16 +317,6 @@ ReactElement.cloneElement = function(element, config, children) {
   var owner = element._owner;
 
   if (config != null) {
-    if (__DEV__) {
-      warning(
-        /* eslint-disable no-proto */
-        config.__proto__ == null || config.__proto__ === Object.prototype,
-        /* eslint-enable no-proto */
-        'React.cloneElement(...): Expected props argument to be a plain object. ' +
-        'Properties defined in its prototype chain will be ignored.'
-      );
-    }
-
     if (hasValidRef(config)) {
       // Silently steal the ref from the parent.
       ref = config.ref;

--- a/src/isomorphic/classic/element/__tests__/ReactElement-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElement-test.js
@@ -188,18 +188,6 @@ describe('ReactElement', () => {
     expect(element.props.foo).toBe(1);
   });
 
-  it('warns if the config object inherits from any type other than Object', () => {
-    spyOn(console, 'error');
-    React.createElement('div', {foo: 1});
-    expect(console.error).not.toHaveBeenCalled();
-    React.createElement('div', Object.create({foo: 1}));
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'React.createElement(...): Expected props argument to be a plain object. ' +
-      'Properties defined in its prototype chain will be ignored.'
-    );
-  });
-
   it('extracts key and ref from the config', () => {
     var element = React.createFactory(ComponentClass)({
       key: '12',

--- a/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
@@ -75,18 +75,6 @@ describe('ReactElementClone', () => {
     expect(ReactDOM.findDOMNode(component).childNodes[0].className).toBe('xyz');
   });
 
-  it('should warn if the config object inherits from any type other than Object', () => {
-    spyOn(console, 'error');
-    React.cloneElement('div', {foo: 1});
-    expect(console.error).not.toHaveBeenCalled();
-    React.cloneElement('div', Object.create({foo: 1}));
-    expect(console.error.calls.count()).toBe(1);
-    expect(console.error.calls.argsFor(0)[0]).toContain(
-      'React.cloneElement(...): Expected props argument to be a plain object. ' +
-      'Properties defined in its prototype chain will be ignored.'
-    );
-  });
-
   it('does not fail if config has no prototype', () => {
     var config = Object.create(null, {foo: {value: 1, enumerable: true}});
     React.cloneElement(<div />, config);


### PR DESCRIPTION
Fixes #7718 by removing the warning altogether, as suggested by @spicyj.

This is basically an exact revert of 17683e (Pull Request #6134).