### PR TITLE
One-click benchmark runner script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ docs/downloads
 docs/vendor/bundle
 examples/shared/*.js
 examples/**/bundle.js
+scripts/bench/arena
 test/the-files-to-test.generated.js
 *.log*
 chrome-user-data

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "object-assign": "^4.1.0",
     "platform": "^1.1.0",
     "run-sequence": "^1.1.4",
+    "shelljs": "^0.7.4",
     "through2": "^2.0.0",
     "tmp": "~0.0.28",
     "typescript": "~1.8.10",

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -2,6 +2,13 @@ Work-in-progress benchmarks.
 
 ## Running the suite
 
+### One-click benchmark runner
+```
+./scripts/bench/benchmark-runner [--dev]
+```
+It takes bundles from your local `build` folder and compares them with React's latest master build (from http://react.zpao.com/builds/master/latest/). Notice that it doesn't build React by default; you can run `npm run build` manually before invoking the benchmark runner (like `npm run build && ./scripts/bench/benchmark-runner`).
+
+### Run the suite manually
 You'll need two folders to compare, each of them containing `react.min.js` and `react-dom-server.min.js`. You can run `npm run build` at the repo root to get a `build` folder with these files.
 
 For example, if you want to compare a stable verion against master, you can create folders called `build-stable` and `build-master` and use the benchmark scripts like this:

--- a/scripts/bench/benchmark-runner
+++ b/scripts/bench/benchmark-runner
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+'use strict';
+
+const shell = require('shelljs');
+const path = require('path');
+
+const benchRoot = __dirname;
+const projectRoot = path.resolve(benchRoot, '../..');
+const arenaRoot = path.resolve(benchRoot, 'arena');
+
+const __DEV__ = process.argv[2] === '--dev';
+
+const files = __DEV__ ?
+  ['react.js', 'react-dom-server.js'] :
+  ['react.min.js', 'react-dom-server.min.js'];
+
+function cleanUp() {
+  shell.rm('-rf', arenaRoot);
+  shell.mkdir(arenaRoot);
+}
+
+cleanUp();
+
+shell.mkdir(path.join(arenaRoot, 'build-latest-master'));
+files.forEach((name) => {
+  shell.exec(
+    `wget http://react.zpao.com/builds/master/latest/${name}`,
+    {cwd: path.join(arenaRoot, 'build-latest-master')}
+  );
+});
+
+shell.mkdir(path.join(arenaRoot, 'build-test'));
+shell.cp(
+  files.map((name) => path.join(projectRoot, 'build', name)),
+  path.join(arenaRoot, 'build-test')
+);
+
+shell.exec([
+  `DEV=${__DEV__} ./measure.py arena/build-latest-master arena/master.txt arena/build-test arena/test.txt && `,
+  './analyze.py arena/master.txt arena/test.txt',
+].join(''), {cwd: benchRoot});
+
+cleanUp();

--- a/scripts/bench/measure.py
+++ b/scripts/bench/measure.py
@@ -71,10 +71,13 @@ def _run_js_in_node(js, env):
 
 
 def _measure_ssr_ms(engine, react_path, bench_name, bench_path, measure_warm):
+    react_core_path = "%s/%s" % (react_path, "react.js" if os.environ["DEV"] == "true" else "react.min.js")
+    react_dom_path = "%s/%s" % (react_path, "react-dom-server.js" if os.environ["DEV"] == "true" else "react-dom-server.min.js")
+
     return engine(
         """
-            var reactCode = readFile(ENV.react_path + '/react.min.js');
-            var reactDOMServerCode = readFile(ENV.react_path + '/react-dom-server.min.js');
+            var reactCode = readFile(ENV.react_core_path);
+            var reactDOMServerCode = readFile(ENV.react_dom_path);
             var START = now();
             globalEval(reactCode);
             globalEval(reactDOMServerCode);
@@ -112,7 +115,8 @@ def _measure_ssr_ms(engine, react_path, bench_name, bench_path, measure_warm):
             'bench_name': bench_name,
             'bench_path': bench_path,
             'measure_warm': measure_warm,
-            'react_path': react_path,
+            'react_core_path': react_core_path,
+            'react_dom_path': react_dom_path,
         },
     )
 
@@ -172,4 +176,3 @@ def _main():
 
 if __name__ == '__main__':
     sys.exit(_main())
-


### PR DESCRIPTION
It's a bit verbose to run our [benchmark script](https://github.com/facebook/react/blob/master/scripts/bench/README.md) now and I'm thinking about ways to make it easier (open to better ideas).

> ```
> ./scripts/bench/benchmark-runner [--dev]
> ```
> 
> It takes bundles from your local `build` folder and compares them with React's latest master build (from http://react.zpao.com/builds/master/latest/). Notice that it doesn't build React by default; you can run `npm run build` manually before invoking the benchmark runner (like `npm run build && ./scripts/bench/benchmark-runner`).

cc @spicyj @gaearon @zpao 
