### PR TITLE
Clarify that `react.addons.update` is deprecated.

### DIFF
--- a/docs/docs/10.7-update.md
+++ b/docs/docs/10.7-update.md
@@ -10,6 +10,12 @@ React lets you use whatever style of data management you want, including mutatio
 
 Dealing with immutable data in JavaScript is more difficult than in languages designed for it, like [Clojure](http://clojure.org/). However, we've provided a simple immutability helper, `update()`, that makes dealing with this type of data much easier, *without* fundamentally changing how your data is represented. You can also take a look at Facebook's [Immutable-js](https://facebook.github.io/immutable-js/docs/) and the [Advanced Performance](/react/docs/advanced-performance.html) section for more detail on Immutable-js.
 
+**This immutability helper is deprecated, for reasons discussed [here](https://github.com/facebook/react/issues/5780). To quote that issue:**
+
+> it's probably a better idea in most cases to either use [Immutable JS](https://github.com/facebook/immutable-js) (more powerful and complete), or the [stage-2 proposal](https://github.com/sebmarkbage/ecmascript-rest-spread) for object spread syntax (simpler, will eventually be built into JS):
+
+**You should use one of those options instead of this.**
+
 ## The main idea
 
 If you mutate data like this:


### PR DESCRIPTION
`update` is deprecated. When I read this page, it would have been more helpful if I'd been pointed to the spread syntax (I already knew about Immutable.js but I wanted something lighter-weight).

Obviously the changes I made here are kind of hacky and don't give a great experience to the reader. But I think that pointing people to these other options is valuable enough that it's worth adding a temporary note like this.