### PR TITLE
Introduce facts-tracker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,13 @@ script:
       ./node_modules/.bin/grunt jest:normal
       git checkout -- src/renderers/dom/shared/ReactDOMFeatureFlags.js
       ./node_modules/.bin/gulp react:extract-errors
+
+      ALL_FILES=`find src -name '*.js' | grep -v umd/ | grep -v __tests__ | grep -v __mocks__`
+      COUNT_ALL_FILES=`echo $ALL_FILES | wc -l`
+      COUNT_WITH_FLOW=`grep '@flow' $ALL_FILES | perl -pe 's/:.+//' | wc -l`
+
+      node scripts/facts-tracker/index.js \
+        "flow-files" "$COUNT_WITH_FLOW/$COUNT_ALL_FILES"
     else
       ./node_modules/.bin/grunt $TEST_TYPE
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,13 +79,16 @@ script:
       ./node_modules/.bin/grunt jest:normal
       git checkout -- src/renderers/dom/shared/ReactDOMFeatureFlags.js
       ./node_modules/.bin/gulp react:extract-errors
+    elif [ "$TEST_TYPE" = flow ]; then
+      set -e
+      ./node_modules/.bin/grunt flow
 
       ALL_FILES=`find src -name '*.js' | grep -v umd/ | grep -v __tests__ | grep -v __mocks__`
       COUNT_ALL_FILES=`echo $ALL_FILES | wc -l`
       COUNT_WITH_FLOW=`grep '@flow' $ALL_FILES | perl -pe 's/:.+//' | wc -l`
-
       node scripts/facts-tracker/index.js \
         "flow-files" "$COUNT_WITH_FLOW/$COUNT_ALL_FILES"
+
     else
       ./node_modules/.bin/grunt $TEST_TYPE
     fi

--- a/scripts/facts-tracker/index.js
+++ b/scripts/facts-tracker/index.js
@@ -65,10 +65,8 @@ if (isInsideOfTravis) {
   }
 
   exec(
-    'echo "machine github.com ' +
-    'login ' + escape(process.env.GITHUB_USER) + ' ' +
-    'password ' + escape(process.env.GITHUB_TOKEN) +
-    '" > ~/.netrc'
+    'echo "machine github.com login $GITHUB_USER password $GITHUB_TOKEN"' +
+    '> ~/.netrc'
   );
   exec(
     'git config --global user.name ' +
@@ -113,9 +111,7 @@ function checkoutFactsFolder() {
   if (!fs.existsSync(factsFolder)) {
     var repoURL;
     if (isInsideOfTravis) {
-      repoURL =
-        'https://' + process.env.GITHUB_TOKEN +
-        '@github.com/' + repoSlug + '.git';
+      repoURL = 'https://$GITHUB_TOKEN@github.com/' + repoSlug + '.git';
     } else {
       repoURL = 'git@github.com:' + repoSlug + '.git';
     }

--- a/scripts/facts-tracker/index.js
+++ b/scripts/facts-tracker/index.js
@@ -109,18 +109,18 @@ var currentTimestamp = new Date().toISOString()
 function checkoutFactsFolder() {
   var factsFolder = '../' + repoSlug.split('/')[1] + '-facts';
   if (!fs.existsSync(factsFolder)) {
-    var repoURL;
+    var escapedRepoURL;
     if (isInsideOfTravis) {
-      repoURL = 'https://$GITHUB_TOKEN@github.com/' + repoSlug + '.git';
+      escapedRepoURL = 'https://$GITHUB_TOKEN@github.com/' + escape(repoSlug) + '.git';
     } else {
-      repoURL = 'git@github.com:' + repoSlug + '.git';
+      escapedRepoURL = escape('git@github.com:' + repoSlug + '.git');
     }
 
     exec(
       'git clone ' +
       '--branch facts ' +
       '--depth=5 ' +
-      escape(repoURL) + ' ' +
+      escapedRepoURL + ' ' +
       escape(factsFolder)
     );
   }

--- a/scripts/facts-tracker/index.js
+++ b/scripts/facts-tracker/index.js
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+var fs = require('fs');
+var execSync = require('child_process').execSync;
+
+function escape(value) {
+  return '\'' + value.replace(/'/g, "'\\''") + '\'';
+}
+
+function exec(command) {
+  console.log('>', command.replace(process.env.GITHUB_TOKEN, '************'));
+  return execSync(command).toString();
+}
+
+if (process.env.TRAVIS_REPO_SLUG) {
+  if (process.env.TRAVIS_BRANCH !== 'master') {
+    console.error('facts-tracker: Branch is not master, exiting...');
+    process.exit(1);
+  }
+
+  if (process.env.TRAVIS_PULL_REQUEST !== 'false') {
+    console.error('facts-tracker: This is a pull request, exiting...');
+    process.exit(1);
+  }
+
+  if (!process.env.GITHUB_USER ||
+      !process.env.GITHUB_TOKEN) {
+    console.error(
+      'In order to use facts-tracker, you need to configure a ' +
+      'few environment variables in order to be able to commit to the ' +
+      'repository. Follow those steps to get you setup:\n' +
+      '\n' +
+      'Go to https://github.com/settings/tokens/new\n' +
+      ' - Fill "Token description" with "facts-tracker for ' + process.env.TRAVIS_REPO_SLUG + '"\n' +
+      ' - Check "public_repo"\n' +
+      ' - Press "Generate Token"\n' +
+      '\n' +
+      'In a different tab, go to https://travis-ci.org/' + process.env.TRAVIS_REPO_SLUG + '/settings\n' +
+      ' - Make sure "Build only if .travis.yml is present" is ON\n' +
+      ' - Fill "Name" with "GITHUB_TOKEN" and "Value" with the token you just generated. Press "Add"\n' +
+      ' - Fill "Name" with "GITHUB_USER" and "Value" with the name of the account you generated the token with. Press "Add"\n' +
+      '\n' +
+      'Once this is done, commit anything to the repository to restart Travis and it should work :)'
+    );
+    process.exit(1);
+  }
+
+  exec(
+    'echo "machine github.com ' +
+    'login ' + escape(process.env.GITHUB_USER) + ' ' +
+    'password ' + escape(process.env.GITHUB_TOKEN) +
+    '" > ~/.netrc'
+  );
+  var remoteOriginChanged = true;
+  exec('git remote rename origin __old_origin');
+  exec(
+    'git remote add origin https://' + escape(process.env.GITHUB_TOKEN) +
+    '@github.com/' + escape(process.env.TRAVIS_REPO_SLUG)
+  );
+  exec(
+    'git config --global user.name ' +
+    escape(process.env.GITHUB_USER_NAME || 'facts-tracker')
+  );
+  exec(
+    'git config --global user.email ' +
+    escape(process.env.GITHUB_USER_EMAIL || 'facts-tracker@no-reply.github.com')
+  );
+}
+
+if (process.argv.length <= 2) {
+  console.error('Usage: facts-tracker <name1> <value1> <name2> <value2>...');
+  process.exit(1);
+}
+
+var currentBranch = exec('git rev-parse --abbrev-ref HEAD').trim();
+var currentCommitHash = exec('git rev-parse HEAD').trim();
+var currentTimestamp = new Date().toISOString()
+  .replace('T', ' ')
+  .replace(/\..+/, '');
+
+if (exec('git status --porcelain')) {
+  console.error('facts-tracker: `git status` is not clean, aborting.')
+  process.exit(1);
+}
+
+function checkoutFactsBranch() {
+  exec('git fetch');
+  try {
+    exec('git checkout facts');
+  } catch(e) {
+    exec('git checkout --orphan facts');
+    exec('rm `git ls-files`');
+    return;
+  }
+
+  try {
+    exec('git rebase origin/facts');
+  } catch(e) {
+    exec('git rebase --abort');
+    exec('git checkout origin/facts');
+    exec('git branch -D facts');
+    exec('git checkout facts');
+  }
+}
+checkoutFactsBranch();
+
+for (var i =  2; i < process.argv.length; i += 2) {
+  var name = process.argv[i].trim();
+  var value = process.argv[i + 1];
+  if (value.indexOf('\n') !== -1) {
+    console.error(
+      'facts-tracker: skipping', name,
+      'as the value contains new lines:', value
+    );
+    continue;
+  }
+
+  var filename = name + '.txt';
+  try {
+    var lastLine = exec('tail -n 1 ' + escape(filename));
+  } catch(e) {
+    // ignore error
+  }
+  var lastValue = lastLine && lastLine
+    .replace(/^[^\t]+\t[^\t]+\t/, '') // commit hash \t timestamp \t
+    .slice(0, -1); // trailing \n
+
+  if (value !== lastValue) {
+    fs.appendFileSync(
+      filename,
+      currentCommitHash + '\t' + currentTimestamp + '\t' + value + '\n'
+    );    
+  }
+
+  console.log(name, value);
+}
+
+if (exec('git status --porcelain')) {
+  exec('git add --all');
+  exec('git commit -m "Adding facts for ' + escape(currentCommitHash) + '"');
+} else {
+  console.log('facts-tracker: nothing to update');
+}
+
+exec('git push origin facts');
+exec('git checkout ' + escape(currentBranch));
+
+if (remoteOriginChanged) {
+  exec('git remote remove origin');
+  exec('git remote rename __old_origin origin');
+}


### PR DESCRIPTION
We want to be able to track various things like number of files that are flowified, number of tests passing with Fiber...

This introduces a tool that lets you do that. The API is very simple, you execute the script with a list of tuples [key value] and it's going to create a `facts` branch and put a txt file for each fact and values over time.

```
node scripts/facts-tracker/index.js \
  "flow-files" "$COUNT_WITH_FLOW/$COUNT_ALL_FILES"
```

Test Plan:
This is tricky to test because Travis only exposes the private variables (github token) when it processes a committed file and not on branches. The reason is that otherwise anyone could send a pull requests that does `echo $GITHUB_TOKEN` and steal your token.

Given this constraint, I did all the work using two of my repos:
- https://github.com/vjeux/facts-tracker
- https://github.com/vjeux/facts-tracker-test

and am sending this pull request that should work as is /fingers crossed/, but we won't be able to test it out until it is committed.

Note that once this lands, I'm going to kill those two repos.