### PR TITLE
Note that getInitialState is not used in ES6 classes in docs

### DIFF
--- a/docs/docs/ref-03-component-specs.it-IT.md
+++ b/docs/docs/ref-03-component-specs.it-IT.md
@@ -39,7 +39,7 @@ Invocato una volta prima che il componente venga montato. Il valore di ritorno s
 
 > Nota:
 >
-> Questo metodo non è disponibile il componenti `class` ES6 che estendono `React.Component`. Potrebbe essere eliminato del tutto in una versione futura di React.
+> Questo metodo non è disponibile il componenti `class` ES6 che estendono `React.Component`. Potrebbe essere eliminato del tutto in una versione futura di React. Per maggiori informazioni, leggi la nostra documentazione sulle [classi ES6](/react/docs/reusable-components.html#es6-classes).
 
 
 ### getDefaultProps

--- a/docs/docs/ref-03-component-specs.it-IT.md
+++ b/docs/docs/ref-03-component-specs.it-IT.md
@@ -39,7 +39,7 @@ Invocato una volta prima che il componente venga montato. Il valore di ritorno s
 
 > Nota:
 >
-> Questo metodo non è disponibile il componenti `class` ES6 che estendono `React.Component`. Potrebbe essere eliminato del tutto in una versione futura di React. Per maggiori informazioni, leggi la nostra documentazione sulle [classi ES6](/react/docs/reusable-components.html#es6-classes).
+> Questo metodo non è disponibile il componenti `class` ES6 che estendono `React.Component`. Per maggiori informazioni, leggi la nostra documentazione sulle [classi ES6](/react/docs/reusable-components.html#es6-classes).
 
 
 ### getDefaultProps

--- a/docs/docs/ref-03-component-specs.it-IT.md
+++ b/docs/docs/ref-03-component-specs.it-IT.md
@@ -37,6 +37,10 @@ object getInitialState()
 
 Invocato una volta prima che il componente venga montato. Il valore di ritorno sarà usato come il valore iniziale di `this.state`.
 
+> Nota:
+>
+> Questo metodo non è disponibile il componenti `class` ES6 che estendono `React.Component`. Potrebbe essere eliminato del tutto in una versione futura di React.
+
 
 ### getDefaultProps
 

--- a/docs/docs/ref-03-component-specs.ko-KR.md
+++ b/docs/docs/ref-03-component-specs.ko-KR.md
@@ -39,7 +39,7 @@ object getInitialState()
 
 > 주의:
 >
-> 이 메소드는 `React.Component`를 확장한 ES6 `class` 컴포넌트에서는 사용할 수 없습니다. React의 미래 버전에서 이는 완전히 사라지게 될 것입니다.
+> 이 메소드는 `React.Component`를 확장한 ES6 `class` 컴포넌트에서는 사용할 수 없습니다. React의 미래 버전에서 이는 완전히 사라지게 될 것입니다. 관한 더 자세한 정보는 [ES6 클래스](/react/docs/reusable-components-ko-KR.html#es6-클래스)를 읽어보세요.
 
 
 ### getDefaultProps

--- a/docs/docs/ref-03-component-specs.ko-KR.md
+++ b/docs/docs/ref-03-component-specs.ko-KR.md
@@ -39,7 +39,7 @@ object getInitialState()
 
 > 주의:
 >
-> 이 메소드는 `React.Component`를 확장한 ES6 `class` 컴포넌트에서는 사용할 수 없습니다. React의 미래 버전에서 이는 완전히 사라지게 될 것입니다. 관한 더 자세한 정보는 [ES6 클래스](/react/docs/reusable-components-ko-KR.html#es6-클래스)를 읽어보세요.
+> 이 메소드는 `React.Component`를 확장한 ES6 `class` 컴포넌트에서는 사용할 수 없습니다. 관한 더 자세한 정보는 [ES6 클래스](/react/docs/reusable-components-ko-KR.html#es6-클래스)를 읽어보세요.
 
 
 ### getDefaultProps

--- a/docs/docs/ref-03-component-specs.ko-KR.md
+++ b/docs/docs/ref-03-component-specs.ko-KR.md
@@ -37,6 +37,10 @@ object getInitialState()
 
 컴포넌트가 마운트되기 전에 한번 호출됩니다. 리턴값은 `this.state`의 초기값으로 사용됩니다.
 
+> 주의:
+>
+> 이 메소드는 `React.Component`를 확장한 ES6 `class` 컴포넌트에서는 사용할 수 없습니다. React의 미래 버전에서 이는 완전히 사라지게 될 것입니다.
+
 
 ### getDefaultProps
 

--- a/docs/docs/ref-03-component-specs.md
+++ b/docs/docs/ref-03-component-specs.md
@@ -39,7 +39,7 @@ Invoked once before the component is mounted. The return value will be used as t
 
 > Note:
 >
-> This method is not available on ES6 `class` components that extend `React.Component`. It may be removed entirely in a future version of React. For more information, please read our documentation about [ES6 classes](/react/docs/reusable-components.html#es6-classes).
+> This method is not available on ES6 `class` components that extend `React.Component`. For more information, please read our documentation about [ES6 classes](/react/docs/reusable-components.html#es6-classes).
 
 
 ### getDefaultProps

--- a/docs/docs/ref-03-component-specs.md
+++ b/docs/docs/ref-03-component-specs.md
@@ -37,6 +37,10 @@ object getInitialState()
 
 Invoked once before the component is mounted. The return value will be used as the initial value of `this.state`.
 
+> Note:
+>
+> This method is not available on ES6 `class` components that extend `React.Component`. It may be removed entirely in a future version of React.
+
 
 ### getDefaultProps
 

--- a/docs/docs/ref-03-component-specs.md
+++ b/docs/docs/ref-03-component-specs.md
@@ -39,7 +39,7 @@ Invoked once before the component is mounted. The return value will be used as t
 
 > Note:
 >
-> This method is not available on ES6 `class` components that extend `React.Component`. It may be removed entirely in a future version of React.
+> This method is not available on ES6 `class` components that extend `React.Component`. It may be removed entirely in a future version of React. For more information, please read our documentation about [ES6 classes](/react/docs/reusable-components.html#es6-classes).
 
 
 ### getDefaultProps

--- a/docs/docs/ref-03-component-specs.zh-CN.md
+++ b/docs/docs/ref-03-component-specs.zh-CN.md
@@ -39,7 +39,7 @@ object getInitialState()
 
 > 注意:
 >
-> 这个方法在从 `React.Component` 扩展的 ES6 `class` 组件里不可用。它也许会在未来的 React 版本中被完全移除。更多的信息,请阅读我们关于[ES6 classes](/react/docs/reusable-components.html#es6-classes)的文档.
+> 这个方法在从 `React.Component` 扩展的 ES6 `class` 组件里不可用。 更多的信息,请阅读我们关于[ES6 classes](/react/docs/reusable-components.html#es6-classes)的文档.
 
 
 ### getDefaultProps

--- a/docs/docs/ref-03-component-specs.zh-CN.md
+++ b/docs/docs/ref-03-component-specs.zh-CN.md
@@ -12,7 +12,7 @@ next: tags-and-attributes-zh-CN.html
 
 > 注意:
 >
-> 同样可以使用单纯的 JavaScript 类作为组件类. 这些类可以实现大多数相同的方法,虽然有一些不同.更多关于不同的信息,请阅读我们关于[ES6 classes](/react/docs/reusable-components.html#es6-classes)的文档.
+> 同样可以使用单纯的 JavaScript 类作为组件类. 这些类可以实现大多数相同的方法,虽然有一些不同. 更多的信息,请阅读我们关于[ES6 classes](/react/docs/reusable-components.html#es6-classes)的文档.
 
 ### render
 

--- a/docs/docs/ref-03-component-specs.zh-CN.md
+++ b/docs/docs/ref-03-component-specs.zh-CN.md
@@ -11,7 +11,7 @@ next: tags-and-attributes-zh-CN.html
 当调用 `React.createClass()` 创建一个组件类时,你应该提供一个包含有 `render` 方法以及可选的其他生命周期方法的 规范(Specifications)对象.
 
 > 注意:
-> 
+>
 > 同样可以使用单纯的 JavaScript 类作为组件类. 这些类可以实现大多数相同的方法,虽然有一些不同.更多关于不同的信息,请阅读我们关于[ES6 classes](/react/docs/reusable-components.html#es6-classes)的文档.
 
 ### render
@@ -21,21 +21,25 @@ ReactElement render()
 ```
 
  `render()` 是必须的
- 
+
  当被调用时,它应该检查 `this.props` 和 `this.state` 并返回单个子元素.这个子元素即可以是一个 对原生DOM的虚拟表达(比如 `<div />` 或 `React.DOM.div()`)也可以是其他你自定义的复合组件.
- 
+
  你也可以返回 `null` 或 `false` 来指示你不想要任何东西被渲染.幕后,React 渲染一个 `<noscript>` tag 来与我们当前的diffing算法协同工作.当返回 `null` 或 `false` ,`ReactDOM.findDOMNode(this)` 会返回 `null`.
- 
+
  `render()` 函数应该是纯净的,意味着它不改变组件的状态,它在每次调用时返回相同的结果,并且它不读和写 DOM 或者其他方式与浏览器互动(例如,使用 `setTimeout`).如果你需要与浏览器互动,在 `componentDidMount()` 里执行你的工作,或者其他生命周期方法里.保持 `render()` 纯净使服务器渲染更实用并且让组件更容易被思考.
- 
- 
+
+
  ### getInitialState
- 
+
  ```javascript
 object getInitialState()
 ```
 
 当组件被挂载时调用一次.返回值会被用作为 `this.state` 的初始值.
+
+> 注意:
+>
+> 这个方法在从 `React.Component` 扩展的 ES6 `class` 组件里不可用。它也许会在未来的 React 版本中被完全移除。
 
 
 ### getDefaultProps

--- a/docs/docs/ref-03-component-specs.zh-CN.md
+++ b/docs/docs/ref-03-component-specs.zh-CN.md
@@ -12,7 +12,7 @@ next: tags-and-attributes-zh-CN.html
 
 > 注意:
 >
-> 同样可以使用单纯的 JavaScript 类作为组件类. 这些类可以实现大多数相同的方法,虽然有一些不同. 更多的信息,请阅读我们关于[ES6 classes](/react/docs/reusable-components.html#es6-classes)的文档.
+> 同样可以使用单纯的 JavaScript 类作为组件类. 这些类可以实现大多数相同的方法,虽然有一些不同.更多关于不同的信息,请阅读我们关于[ES6 classes](/react/docs/reusable-components.html#es6-classes)的文档.
 
 ### render
 
@@ -39,7 +39,7 @@ object getInitialState()
 
 > 注意:
 >
-> 这个方法在从 `React.Component` 扩展的 ES6 `class` 组件里不可用。它也许会在未来的 React 版本中被完全移除。
+> 这个方法在从 `React.Component` 扩展的 ES6 `class` 组件里不可用。它也许会在未来的 React 版本中被完全移除。更多的信息,请阅读我们关于[ES6 classes](/react/docs/reusable-components.html#es6-classes)的文档.
 
 
 ### getDefaultProps


### PR DESCRIPTION
per https://github.com/facebook/react/issues/7746 Adding Note that getInitialState is not used in es6 classes

