### PR TITLE
[gulp] Change 'react:modules' to copy 'react/lib' into 'react-native/lib'

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -202,7 +202,8 @@ gulp.task('react:modules', function() {
       .src(paths.react.src)
       .pipe(babel(babelOptsReact))
       .pipe(flatten())
-      .pipe(gulp.dest(paths.react.lib)),
+      .pipe(gulp.dest(paths.react.lib))
+      .pipe(gulp.dest(paths.reactNative.lib)),
 
     gulp
       .src(paths.reactDOM.src)


### PR DESCRIPTION
Unless I'm missing something, files like `ReactElement.js` were not being copied into `react-native/lib`.

Is there another (recommended) way of using a `react` fork with `react-native`?