### PR TITLE
modify manual PropType calls warning

### DIFF
--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -145,9 +145,10 @@ function createChainableTypeChecker(validate) {
             false,
             'You are manually calling a React.PropTypes validation ' +
             'function for the `%s` prop on `%s`. This is deprecated ' +
-            'and will not work in the next major version. You may be ' +
-            'seeing this warning due to a third-party PropTypes library. ' +
-            'See https://fb.me/react-warning-dont-call-proptypes for details.',
+            'and will not work in production with the next major version. ' +
+            'You may be seeing this warning due to a third-party PropTypes ' +
+            'library. See https://fb.me/react-warning-dont-call-proptypes ' +
+            'for details.',
             propFullName,
             componentName
           );


### PR DESCRIPTION
To indicate that code will not work in production with the next major release