### PR TITLE
Added onChange/requestChange support to LinkedInput

### DIFF
--- a/packages/react-linked-input/LinkedInput.js
+++ b/packages/react-linked-input/LinkedInput.js
@@ -17,6 +17,7 @@ class LinkedInput extends React.Component {
     var newProps = Object.assign({}, this.props);
     newProps.value = LinkedValueUtils.getValue(this.props);
     newProps.checked = LinkedValueUtils.getChecked(this.props);
+    newProps.onChange = LinkedValueUtils.executeOnChange.bind(this, this.props);
     delete newProps.valueLink;
     delete newProps.checkedLink;
     return React.createElement('input', newProps);


### PR DESCRIPTION
For `LinkedInput` to be actually useful as a replacement for `valueLink`/`checkedLink` on regular `input` elements, it needs to trigger `requestChange` of the `ReactLink` object. This can be achieved by this one-line change.

I wanted to add a corresponding test, but for tests to work for me locally, I had to revert parts of #7168, which I assume is going in a wrong direction.

A couple of additional notes on the tests:
- Currently, they're not captured by `grunt test` as both the folder name is wrong and the `packages` folder is not in `testPathDirs` of `package.json`
- When fixing the previous issue, and getting jest to find this package's tests, they fail on require statements. I had an idea on how to fix this, but it looked to me as if it would break npm packaging of `react-linked-input` and since I couldn't find instructions on how to build that package, I gave up on fixing the tests.
