### PR TITLE
Fix total count in flow tracker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ script:
       ./node_modules/.bin/grunt flow
 
       ALL_FILES=`find src -name '*.js' | grep -v umd/ | grep -v __tests__ | grep -v __mocks__`
-      COUNT_ALL_FILES=`echo $ALL_FILES | wc -l`
+      COUNT_ALL_FILES=`echo "$ALL_FILES" | wc -l`
       COUNT_WITH_FLOW=`grep '@flow' $ALL_FILES | perl -pe 's/:.+//' | wc -l`
       node scripts/facts-tracker/index.js \
         "flow-files" "$COUNT_WITH_FLOW/$COUNT_ALL_FILES"


### PR DESCRIPTION
When you put the output of a bash command in a variable, it replaces the `\n` with a space. Using `ls` instead of `echo` fixes it

Test Plan:
Run

```
ALL_FILES=`find src -name '*.js' | grep -v umd/ | grep -v __tests__ | grep -v __mocks__`
COUNT_ALL_FILES=`ls $ALL_FILES | wc -l`
echo $COUNT_ALL_FILES
```

Make sure that it outputs 221