### PR TITLE
Bailout if the element and the context is unchanged properly

### DIFF
--- a/src/renderers/shared/stack/reconciler/ReactReconciler.js
+++ b/src/renderers/shared/stack/reconciler/ReactReconciler.js
@@ -13,6 +13,7 @@
 
 var ReactRef = require('ReactRef');
 var ReactInstrumentation = require('ReactInstrumentation');
+var shallowEqual = require('shallowEqual');
 
 var warning = require('warning');
 
@@ -127,7 +128,7 @@ var ReactReconciler = {
     var prevElement = internalInstance._currentElement;
 
     if (nextElement === prevElement &&
-        context === internalInstance._context
+        shallowEqual(context, internalInstance._context)
       ) {
       // Since elements are immutable after the owner is rendered,
       // we can do a cheap identity compare here to determine if this is a

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -610,6 +610,40 @@ describe('ReactCompositeComponent', () => {
     expect(childRenders).toBe(1);
   });
 
+  it('should skip update when rerendering element in container and the context is unchanged', () => {
+    var context = { foo: 'bar' };
+
+    class Parent extends React.Component {
+      static childContextTypes = {
+        foo: ReactPropTypes.string,
+      };
+
+      getChildContext() {
+        return context;
+      }
+
+      render() {
+        return <div>{this.props.children}</div>;
+      }
+    }
+
+    var childRenders = 0;
+
+    class Child extends React.Component {
+      render() {
+        childRenders++;
+        return <div />;
+      }
+    }
+
+    var container = document.createElement('div');
+    var child = <Child />;
+
+    ReactDOM.render(<Parent>{child}</Parent>, container);
+    ReactDOM.render(<Parent>{child}</Parent>, container);
+    expect(childRenders).toBe(1);
+  });
+
   it('should pass context when re-rendered for static child', () => {
     var parentInstance = null;
     var childInstance = null;


### PR DESCRIPTION
Currently, We use `===` to check if a context is changed [before bailing out](https://github.com/facebook/react/blob/master/src/renderers/shared/stack/reconciler/ReactReconciler.js#L130), but we [create a new context](https://github.com/facebook/react/blob/master/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js#L673) everytime a compnent is updated, regardless the origin context provided by the consumer is unchanged. 

As a result, `===` would always return `false` unless the context is `undefined`. That is, when there is a context, a component would never be bailed out. Specifically, If we use `react-redux`, `react-router`, `react-intl` or any other lib which provides a context, we would get no bailout optimization.

To fix this, I suggest we use `shallowEqual` instead of `===`. But I am not sure it would introduce a breaking change or not. I have made this change in this PR along with a test.
