### PR TITLE
Improve perf of getting capitalized event

### DIFF
--- a/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/SimpleEventPlugin.js
@@ -126,7 +126,7 @@ var topLevelEventsToDispatchConfig: {[key: TopLevelTypes]: DispatchConfig} = {};
   'waiting',
   'wheel',
 ].forEach(event => {
-  var capitalizedEvent = event[0].toUpperCase() + event.slice(1);
+  var capitalizedEvent = String.fromCharCode(event.charCodeAt(0) & 223) + event.slice(1);
   var onEvent = 'on' + capitalizedEvent;
   var topEvent = 'top' + capitalizedEvent;
 


### PR DESCRIPTION
`Bitwise operations` are faster than`toUpperCase`.

I applied that to the `forEach` loop where we're getting event types.
We know every event name, so it's safe to use bitwise operations here.

I know that we won't get a lot of perf from that little change, but some ms are good too.

[Benchmark](https://jsbin.com/betoyi/edit?js,console) using benchmark.js

Result on my MBP:

1 item:

|   Technique   | Ops/sec |
| ------------- | ------------- |
| toUpperCase  | 19,145,910 |
| **bitwise**  | **83,779,805**  |
| bitwise array  | 87,807,680  |
| bitwise array cached  | 87,726,636  |

`forEach` on all items:

|   Technique   | Ops/sec |
| ------------- | ------------- |
| toUpperCase  | 60,439 |
| **bitwise**  | **73,086**  |
| bitwise array  | 62,633  |
| bitwise array cached  | 68,193  |