### PR TITLE
Fix UMD bundles, making safe to use as required modules

### DIFF
--- a/grunt/config/browserify.js
+++ b/grunt/config/browserify.js
@@ -76,37 +76,36 @@ function simpleBannerify(src) {
 // back to the global, just like it would previously.
 function wrapperify(src) {
   return `
-;(function() {
-  var React;
-
+;(function(f) {
   // CommonJS
   if (typeof exports === "object" && typeof module !== "undefined") {
-    React = require('react');
+    f(require('react'));
 
-  // TODO: AMD/RequireJS
+  // RequireJS
   } else if (typeof define === "function" && define.amd) {
-    throw('How does RequireJS work again?');
+    require(['react'], f);
 
   // <script>
   } else {
     var g;
     if (typeof window !== "undefined") {
-      React = window.React;
+      g = window;
     } else if (typeof global !== "undefined") {
-      React = global.React;
+      g = global;
     } else if (typeof self !== "undefined") {
-      React = self.React;
+      g = self;
     } else {
       // works providing we're not in "use strict";
       // needed for Java 8 Nashorn
       // see https://github.com/facebook/react/issues/3037
-      React = this.React;
+      g = this;
     }
+    f(g.React)
   }
-
+})(function(React) {
   ${src}
-})()
-`
+});
+`;
 }
 
 // Our basic config which we'll add to to make our other builds
@@ -202,7 +201,7 @@ var domMin = {
   // No need to derequire because the minifier will mangle
   // the "require" calls.
 
-  after: [minify, bannerify],
+  after: [wrapperify, minify, bannerify],
 };
 
 var domServer = {
@@ -216,7 +215,7 @@ var domServer = {
   transforms: [shimSharedModules],
   globalTransforms: [envifyDev],
   plugins: [collapser],
-  after: [derequire, simpleBannerify],
+  after: [derequire, wrapperify, simpleBannerify],
 };
 
 var domServerMin = {
@@ -234,7 +233,7 @@ var domServerMin = {
   // No need to derequire because the minifier will mangle
   // the "require" calls.
 
-  after: [minify, bannerify],
+  after: [wrapperify, minify, bannerify],
 };
 
 var domFiber = {
@@ -248,7 +247,7 @@ var domFiber = {
   transforms: [shimSharedModules],
   globalTransforms: [envifyDev],
   plugins: [collapser],
-  after: [derequire, simpleBannerify],
+  after: [derequire, wrapperify, simpleBannerify],
 };
 
 var domFiberMin = {
@@ -266,7 +265,7 @@ var domFiberMin = {
   // No need to derequire because the minifier will mangle
   // the "require" calls.
 
-  after: [minify, bannerify],
+  after: [wrapperify, minify, bannerify],
 };
 
 module.exports = {


### PR DESCRIPTION
I think this fixes the problem. There's a giant comment in there explaining why and how.

I want to stress that this is a short-term solution. It works and the reasoning is sound but I'm not happy that we need this. It's probably time to start using webpack to bundle but that would have taken me much longer to go do.

Byte-wise this should be fine. We're just adding the code that you can see in there. Since we do this after the bundle process is done, that `require('react')` isn't analyzed.

## Todo:
- [x] Look for any other expected globals in shims
- [x] Use this in other bundles
- [x] Look into the RequireJS situation. I honestly don't care much about that but we should probably make it work. It would require rejiggering the wrapper (since we couldn't execute the UMDed module immediately)

cc @facebook/react-core 

Fixes #7482 

## Test Plan:
- Made a hello world app with webpack and aliased `react` and `react-dom`.
- Ran the same hello world using the dist files directly (so React & ReactDOM were globals).