### PR TITLE
Fixes a bug that prevented classname from being set on web components

### DIFF
--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -972,10 +972,17 @@ ReactDOMComponent.Mixin = {
         }
       } else if (isCustomComponent(this._tag, lastProps)) {
         if (!RESERVED_PROPS.hasOwnProperty(propKey)) {
-          DOMPropertyOperations.deleteValueForAttribute(
-            getNode(this),
-            propKey
-          );
+          if (DOMProperty.properties.hasOwnProperty(propKey)) {
+            DOMPropertyOperations.deleteValueForProperty(
+              getNode(this),
+              propKey
+            );
+          } else {
+            DOMPropertyOperations.deleteValueForAttribute(
+              getNode(this),
+              propKey
+            );
+          }
         }
       } else if (
           DOMProperty.properties[propKey] ||
@@ -1036,11 +1043,19 @@ ReactDOMComponent.Mixin = {
         }
       } else if (isCustomComponent(this._tag, nextProps)) {
         if (!RESERVED_PROPS.hasOwnProperty(propKey)) {
-          DOMPropertyOperations.setValueForAttribute(
-            getNode(this),
-            propKey,
-            nextProp
-          );
+          if (DOMProperty.properties.hasOwnProperty(propKey)) {
+            DOMPropertyOperations.setValueForProperty(
+              getNode(this),
+              propKey,
+              nextProp
+            );
+          } else {
+            DOMPropertyOperations.setValueForAttribute(
+              getNode(this),
+              propKey,
+              nextProp
+            );
+          }
         }
       } else if (
           DOMProperty.properties[propKey] ||

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -320,6 +320,35 @@ describe('ReactDOMComponent', () => {
       expect(node.getAttribute('bar')).toBe('buzz');
     });
 
+    it('should set the classname on a custom element', () => {
+
+      var container = document.createElement('div');
+      ReactDOM.render(<some-custom-element className="foo"/>, container);
+      var node = container.firstChild;
+      expect(node.classList[0]).toBe('foo');
+
+    });
+
+    it('should update the classname on a custom element', () => {
+
+      var container = document.createElement('div');
+      ReactDOM.render(<some-custom-element className="foo"/>, container);
+      ReactDOM.render(<some-custom-element className="bar"/>, container);
+      var node = container.firstChild;
+      expect(node.classList[0]).toBe('bar');
+
+    });
+
+    it('should remove the classname on a custom element', () => {
+
+      var container = document.createElement('div');
+      ReactDOM.render(<some-custom-element className="foo"/>, container);
+      ReactDOM.render(<some-custom-element/>, container);
+      var node = container.firstChild;
+      expect(node.classList.length).toBe(0);
+
+    });
+
     it('should clear a single style prop when changing `style`', () => {
       var styles = {display: 'none', color: 'red'};
       var container = document.createElement('div');


### PR DESCRIPTION
During development on our platform we found out that we could not set the classname on a web component.

Here is a jsfiddle demonstrating the bug: https://jsfiddle.net/zehydcnq/

What causes this bug to occur is that `ReactDOM` sets properties on web components using `setValueForAttribute` but never `setValueForProperty`, which does some marshalling with the `className` property.

My change adds an extra check to see whether a property is part of the `DOMProperties` and if so to set the property as opposed to the attribute.

I've made sure to add add/update/remove tests.