### PR TITLE
Make sure .createElement({}) warns

### DIFF
--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -183,8 +183,10 @@ function validatePropTypes(element) {
 var ReactElementValidator = {
 
   createElement: function(type, props, children) {
-    var validType = typeof type === 'string' || typeof type === 'function' ||
-                    (type !== null && typeof type === 'object');
+    var validType =
+      typeof type === 'string' ||
+      typeof type === 'function' ||
+      type !== null && typeof type === 'object' && typeof type.tag === 'number';
     // We warn in this case but don't throw. We expect the element creation to
     // succeed and there will likely be errors in render.
     if (!validType) {


### PR DESCRIPTION
This is common when forgetting to export anything from a file.