### PR TITLE
[docs] Fix initial state example for React.createClass

### DIFF
--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -324,7 +324,7 @@ With `React.createClass()`, you have to provide a separate `getInitialState` met
 ```javascript
 var Counter = React.createClass({
   getInitialState: function() {
-    return {count: props.initialCount};
+    return {count: this.props.initialCount};
   },
   // ...
 });


### PR DESCRIPTION
In the example there was a typo with setting initial state using `getInitialState` method