### PR TITLE
Update the homepage with ES6

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ React is a JavaScript library for building user interfaces.
 We have several examples [on the website](https://facebook.github.io/react/). Here is the first one to get you started:
 
 ```js
-var HelloMessage = React.createClass({
-  render: function() {
+class HelloMessage extends React.Component {
+  render() {
     return <div>Hello {this.props.name}</div>;
   }
-});
+}
 
 ReactDOM.render(
   <HelloMessage name="John" />,

--- a/docs/Rakefile
+++ b/docs/Rakefile
@@ -6,8 +6,8 @@ require('open-uri')
 desc "download babel-browser"
 task :fetch_remotes do
   IO.copy_stream(
-    open('https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.34/browser.min.js'),
-    'js/babel-browser.min.js'
+    open('https://unpkg.com/babel-standalone@6.15.0/babel.min.js'),
+    'js/babel.min.js'
   )
 end
 

--- a/docs/_js/examples/hello.js
+++ b/docs/_js/examples/hello.js
@@ -1,12 +1,13 @@
+var name = Math.random() > 0.5 ? 'Jane' : 'John';
 var HELLO_COMPONENT = `
-var HelloMessage = React.createClass({
-  render: function() {
+class HelloMessage extends React.Component {
+  render() {
     return <div>Hello {this.props.name}</div>;
   }
-});
+}
 
-ReactDOM.render(<HelloMessage name="John" />, mountNode);
-`;
+ReactDOM.render(<HelloMessage name="${name}" />, mountNode);
+`.trim();
 
 ReactDOM.render(
   <ReactPlayground codeText={HELLO_COMPONENT} />,

--- a/docs/_js/examples/markdown.js
+++ b/docs/_js/examples/markdown.js
@@ -1,16 +1,21 @@
 var MARKDOWN_COMPONENT = `
-var MarkdownEditor = React.createClass({
-  getInitialState: function() {
-    return {value: 'Type some *markdown* here!'};
-  },
-  handleChange: function() {
+class MarkdownEditor extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleChange = this.handleChange.bind(this);
+    this.state = {value: 'Type some *markdown* here!'};
+  }
+
+  handleChange() {
     this.setState({value: this.refs.textarea.value});
-  },
-  rawMarkup: function() {
+  }
+
+  getRawMarkup() {
     var md = new Remarkable();
     return { __html: md.render(this.state.value) };
-  },
-  render: function() {
+  }
+
+  render() {
     return (
       <div className="MarkdownEditor">
         <h3>Input</h3>
@@ -21,15 +26,15 @@ var MarkdownEditor = React.createClass({
         <h3>Output</h3>
         <div
           className="content"
-          dangerouslySetInnerHTML={this.rawMarkup()}
+          dangerouslySetInnerHTML={this.getRawMarkup()}
         />
       </div>
     );
   }
-});
+}
 
 ReactDOM.render(<MarkdownEditor />, mountNode);
-`;
+`.trim();
 
 ReactDOM.render(
   <ReactPlayground codeText={MARKDOWN_COMPONENT} />,

--- a/docs/_js/examples/timer.js
+++ b/docs/_js/examples/timer.js
@@ -6,9 +6,9 @@ class Timer extends React.Component {
   }
 
   tick() {
-    this.setState({
-      secondsElapsed: this.state.secondsElapsed + 1
-    });
+    this.setState((prevState) => ({
+      secondsElapsed: prevState.secondsElapsed + 1
+    }));
   }
 
   componentDidMount() {

--- a/docs/_js/examples/timer.js
+++ b/docs/_js/examples/timer.js
@@ -1,26 +1,33 @@
 var TIMER_COMPONENT = `
-var Timer = React.createClass({
-  getInitialState: function() {
-    return {secondsElapsed: 0};
-  },
-  tick: function() {
-    this.setState({secondsElapsed: this.state.secondsElapsed + 1});
-  },
-  componentDidMount: function() {
-    this.interval = setInterval(this.tick, 1000);
-  },
-  componentWillUnmount: function() {
+class Timer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {secondsElapsed: 0};
+  }
+
+  tick() {
+    this.setState({
+      secondsElapsed: this.state.secondsElapsed + 1
+    });
+  }
+
+  componentDidMount() {
+    this.interval = setInterval(() => this.tick(), 1000);
+  }
+
+  componentWillUnmount() {
     clearInterval(this.interval);
-  },
-  render: function() {
+  }
+
+  render() {
     return (
       <div>Seconds Elapsed: {this.state.secondsElapsed}</div>
     );
   }
-});
+}
 
 ReactDOM.render(<Timer />, mountNode);
-`;
+`.trim();
 
 ReactDOM.render(
   <ReactPlayground codeText={TIMER_COMPONENT} />,

--- a/docs/_js/examples/todo.js
+++ b/docs/_js/examples/todo.js
@@ -30,10 +30,10 @@ class TodoApp extends React.Component {
       text: this.state.text,
       id: Date.now()
     };
-    this.setState({
-      items: [...this.state.items, newItem],
+    this.setState((prevState) => ({
+      items: prevState.items.concat(newItem),
       text: ''
-    });
+    }));
   }
 }
 

--- a/docs/_js/examples/todo.js
+++ b/docs/_js/examples/todo.js
@@ -1,41 +1,56 @@
 var TODO_COMPONENT = `
-var TodoList = React.createClass({
-  render: function() {
-    var createItem = function(item) {
-      return <li key={item.id}>{item.text}</li>;
-    };
-    return <ul>{this.props.items.map(createItem)}</ul>;
+class TodoApp extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleChange = this.handleChange.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.state = {items: [], text: ''};
   }
-});
-var TodoApp = React.createClass({
-  getInitialState: function() {
-    return {items: [], text: ''};
-  },
-  onChange: function(e) {
-    this.setState({text: e.target.value});
-  },
-  handleSubmit: function(e) {
-    e.preventDefault();
-    var nextItems = this.state.items.concat([{text: this.state.text, id: Date.now()}]);
-    var nextText = '';
-    this.setState({items: nextItems, text: nextText});
-  },
-  render: function() {
+
+  render() {
     return (
       <div>
         <h3>TODO</h3>
         <TodoList items={this.state.items} />
         <form onSubmit={this.handleSubmit}>
-          <input onChange={this.onChange} value={this.state.text} />
+          <input onChange={this.handleChange} value={this.state.text} />
           <button>{'Add #' + (this.state.items.length + 1)}</button>
         </form>
       </div>
     );
   }
-});
+
+  handleChange(e) {
+    this.setState({text: e.target.value});
+  }
+
+  handleSubmit(e) {
+    e.preventDefault();
+    var newItem = {
+      text: this.state.text,
+      id: Date.now()
+    };
+    this.setState({
+      items: [...this.state.items, newItem],
+      text: ''
+    });
+  }
+}
+
+class TodoList extends React.Component {
+  render() {
+    return (
+      <ul>
+        {this.props.items.map(item => (
+          <li key={item.id}>{item.text}</li>
+        ))}
+      </ul>
+    );
+  }
+}
 
 ReactDOM.render(<TodoApp />, mountNode);
-`;
+`.trim();
 
 ReactDOM.render(
   <ReactPlayground codeText={TODO_COMPONENT} />,

--- a/docs/_js/live_editor.js
+++ b/docs/_js/live_editor.js
@@ -90,8 +90,14 @@ var ReactPlayground = React.createClass({
 
   getDefaultProps: function() {
     return {
-      transformer: function(code) {
-        return babel.transform(code).code;
+      transformer: function(code, options) {
+        var presets = ['react'];
+        if (!options || !options.skipES2015Transform) {
+          presets.push('es2015');
+        }
+        return Babel.transform(code, {
+          presets
+        }).code;
       },
       editorTabTitle: 'Live JSX Editor',
       showCompiledJSTab: true,
@@ -115,15 +121,15 @@ var ReactPlayground = React.createClass({
     this.setState({mode: mode});
   },
 
-  compileCode: function() {
-    return this.props.transformer(this.state.code);
+  compileCode: function(options) {
+    return this.props.transformer(this.state.code, options);
   },
 
   render: function() {
     var isJS = this.state.mode === this.MODES.JS;
     var compiledCode = '';
     try {
-      compiledCode = this.compileCode();
+      compiledCode = this.compileCode({skipES2015Transform: true});
     } catch (err) {}
 
     var JSContent =
@@ -201,13 +207,15 @@ var ReactPlayground = React.createClass({
     } catch (e) { }
 
     try {
-      var compiledCode = this.compileCode();
+      var compiledCode;
       if (this.props.renderCode) {
+        compiledCode = this.compileCode({skipES2015Transform: true});
         ReactDOM.render(
           <CodeMirrorEditor codeText={compiledCode} readOnly={true} />,
           mountNode
         );
       } else {
+        compiledCode = this.compileCode({skipES2015Transform: false});
         eval(compiledCode);
       }
     } catch (err) {

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -36,7 +36,7 @@
   <script src="/react/js/jsx.js"></script>
   <script src="/react/js/react.js"></script>
   <script src="/react/js/react-dom.js"></script>
-  <script src="/react/js/babel-browser.min.js"></script>
+  <script src="/react/js/babel.min.js"></script>
   <script src="/react/js/live_editor.js"></script>
 </head>
 <body>


### PR DESCRIPTION
Sending this against master because it's independent and self-contained.

A few changes to unpack here:

* Updated it to use `babel-standalone` because it is much newer. This is already done in #7668 but since that didn't get merged yet I'm just doing it here, and we can clean up other places as part of #7864. There were no other places where this particular hosted file was used.

* Changed homepage examples to use ES6 classes.

* Changed code editor to only show JSX transform but eval code with JSX+ES2015. Verified the eval'd code has ES2015 by console.log()-ing it.

* Tweaked the examples for better readability.

* Changed the `render()` to be at the top of Todos example so that you see it immediately and it matches what you see on the screen.

* Updated main README too.

* Trimmed extra newline at the beginning from the examples.

Here's how it looks now:

<img width="955" alt="screen shot 2016-10-04 at 18 44 45" src="https://cloud.githubusercontent.com/assets/810438/19085941/165bb610-8a64-11e6-89b5-283c43ccb91c.png">

<img width="950" alt="screen shot 2016-10-04 at 18 44 53" src="https://cloud.githubusercontent.com/assets/810438/19085943/1a6620ba-8a64-11e6-9199-8e65fe2f51d8.png">

<img width="949" alt="screen shot 2016-10-04 at 18 46 31" src="https://cloud.githubusercontent.com/assets/810438/19085948/1e4f20f0-8a64-11e6-915f-470a27db89c8.png">

Compiled JS view:

<img width="639" alt="screen shot 2016-10-04 at 18 55 47" src="https://cloud.githubusercontent.com/assets/810438/19085972/352fe714-8a64-11e6-99ab-edb0ece30205.png">
