### PR TITLE
Update comment to refer to correct method name

### DIFF
--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -347,7 +347,7 @@ class SayHello extends React.Component {
   }
 
   render() {
-    // Because we `this.tick` is bound, we can use it as an event handler.
+    // Because `this.handleClick` is bound, we can use it as an event handler.
     return (
       <button onClick={this.handleClick}>
         Say hello


### PR DESCRIPTION
Fixes a small typo / copy-paste error in Reusable Components docs.
