### PR TITLE
removing version specific cdn link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ The fastest way to get started is to serve JavaScript from a CDN. We're using [u
 
 ```html
 <!-- The core React library -->
-<script src="https://unpkg.com/react@15.3.2/dist/react.js"></script>
+<script src="https://unpkg.com/react/dist/react.js"></script>
 <!-- The ReactDOM Library -->
-<script src="https://unpkg.com/react-dom@15.3.2/dist/react-dom.js"></script>
+<script src="https://unpkg.com/react-dom/dist/react-dom.js"></script>
 ```
 
 We've also built a [starter kit](https://facebook.github.io/react/downloads/react-15.3.2.zip) which might be useful if this is your first time using React. It includes a webpage with an example of using React with live code.


### PR DESCRIPTION
In accordance to https://unpkg.com/ , if version is removed , it will default to the latest version.
```
You may also use a tag or version range instead of a fixed version number, or omit the version/tag entirely to use the latest tag.
```