### PR TITLE
Fix npm package builds

### DIFF
--- a/grunt/tasks/npm-react-native.js
+++ b/grunt/tasks/npm-react-native.js
@@ -35,9 +35,12 @@ function packRelease() {
   var spawnCmd = {
     cmd: 'npm',
     args: ['pack', 'packages/react-native-renderer'],
+    opts: {
+      cwd: 'build/',
+    },
   };
   grunt.util.spawn(spawnCmd, function() {
-    var buildSrc = 'react-native-renderer-' + grunt.config.data.pkg.version + '.tgz';
+    var buildSrc = 'build/react-native-renderer-' + grunt.config.data.pkg.version + '.tgz';
     var buildDest = 'build/packages/react-native-renderer.tgz';
     fs.rename(buildSrc, buildDest, done);
   });

--- a/grunt/tasks/npm-react-test.js
+++ b/grunt/tasks/npm-react-test.js
@@ -35,9 +35,12 @@ function packRelease() {
   var spawnCmd = {
     cmd: 'npm',
     args: ['pack', 'packages/react-test-renderer'],
+    opts: {
+      cwd: 'build/',
+    },
   };
   grunt.util.spawn(spawnCmd, function() {
-    var buildSrc = 'react-test-renderer-' + grunt.config.data.pkg.version + '.tgz';
+    var buildSrc = 'build/react-test-renderer-' + grunt.config.data.pkg.version + '.tgz';
     var buildDest = 'build/packages/react-test-renderer.tgz';
     fs.rename(buildSrc, buildDest, done);
   });

--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -21,6 +21,7 @@
     "LICENSE",
     "PATENTS",
     "README.md",
-    "index.js"
+    "index.js",
+    "lib/"
   ]
 }


### PR DESCRIPTION
Fixes both parts of #7880 and then the same for `react-native-renderer`.

- ensures we packages `lib/` in `react-test-renderer`
- make sure we run `npm pack` on the compiled packages, not the original src.

cc @Aweary @spicyj 