### PR TITLE
RFC ReactSlim/Modern build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -104,6 +104,14 @@ module.exports = function(grunt) {
     'version-check',
     'browserify:basic',
   ]);
+  grunt.registerTask('build:slim', [
+    'build-modules',
+    'browserify:slim',
+  ]);
+  grunt.registerTask('build:slim-min', [
+    'build-modules',
+    'browserify:slimMin',
+  ]);
   grunt.registerTask('build:addons', [
     'build-modules',
     'browserify:addons',
@@ -168,8 +176,10 @@ module.exports = function(grunt) {
     'version-check',
     'browserify:basic',
     'browserify:addons',
+    'browserify:slim',
     'browserify:min',
     'browserify:addonsMin',
+    'browserify:slimMin',
     'browserify:dom',
     'browserify:domMin',
     'browserify:domServer',

--- a/grunt/config/browserify.js
+++ b/grunt/config/browserify.js
@@ -122,6 +122,38 @@ var basic = {
   after: [derequire, simpleBannerify],
 };
 
+var slim = {
+  entries: [
+    './build/node_modules/react/lib/ReactSlimUMDEntry.js',
+  ],
+  outfile: './build/react-slim.js',
+  debug: false,
+  standalone: 'ReactSlim',
+  // Apply as global transform so that we also envify fbjs and any other deps
+  globalTransforms: [envifyDev],
+  plugins: [collapser],
+  after: [derequire, simpleBannerify],
+};
+
+var slimMin = {
+  entries: [
+    './build/node_modules/react/lib/ReactSlimUMDEntry.js',
+  ],
+  outfile: './build/react-slim.min.js',
+  debug: false,
+  standalone: 'ReactSlim',
+  // Envify twice. The first ensures that when we uglifyify, we have the right
+  // conditions to exclude requires. The global transform runs on deps.
+  transforms: [envifyProd, uglifyify],
+  globalTransforms: [envifyProd],
+  plugins: [collapser],
+  // No need to derequire because the minifier will mangle
+  // the "require" calls.
+
+  after: [minify, bannerify],
+};
+
+
 var min = {
   entries: [
     './build/node_modules/react/lib/ReactUMDEntry.js',
@@ -270,6 +302,8 @@ var domFiberMin = {
 
 module.exports = {
   basic: basic,
+  slim: slim,
+  slimMin: slimMin,
   min: min,
   addons: addons,
   addonsMin: addonsMin,

--- a/grunt/tasks/npm-react.js
+++ b/grunt/tasks/npm-react.js
@@ -11,6 +11,8 @@ var dist = dest + 'dist/';
 var distFiles = [
   'react.js',
   'react.min.js',
+  'react-slim.js',
+  'react-slim.min.js',
   'react-with-addons.js',
   'react-with-addons.min.js',
 ];

--- a/grunt/tasks/release.js
+++ b/grunt/tasks/release.js
@@ -7,6 +7,8 @@ var BOWER_GLOB = [BOWER_PATH + '*.{js}'];
 var BOWER_FILES = [
   'react.js',
   'react.min.js',
+  'react-slim.js',
+  'react-slim.min.js',
   'react-with-addons.js',
   'react-with-addons.min.js',
   'react-dom.js',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,6 +45,23 @@ var paths = {
     ],
     lib: 'build/node_modules/react/lib',
   },
+  reactSlim: {
+    src: [
+      'src/umd/ReactSlimUMDEntry.js',
+      'src/umd/shims/**/*.js',
+
+      'src/isomorphic/**/*.js',
+      'src/addons/**/*.js',
+
+      'src/ReactVersion.js',
+      'src/shared/**/*.js',
+      '!src/shared/vendor/**/*.js',
+      '!src/**/__benchmarks__/**/*.js',
+      '!src/**/__tests__/**/*.js',
+      '!src/**/__mocks__/**/*.js',
+    ],
+    lib: 'build/node_modules/react/lib',
+  },
   reactDOM: {
     src: [
       'src/umd/ReactDOMUMDEntry.js',
@@ -113,6 +130,7 @@ var moduleMapReact = Object.assign(
 var rendererSharedState = {
   // Alias
   React: 'react/lib/React',
+  ReactSlim: 'react/lib/ReactSlim',
   // Shared state
   ReactCurrentOwner: 'react/lib/ReactCurrentOwner',
   ReactComponentTreeHook: 'react/lib/ReactComponentTreeHook',
@@ -205,6 +223,12 @@ gulp.task('react:modules', function() {
       .pipe(gulp.dest(paths.react.lib)),
 
     gulp
+      .src(paths.reactSlim.src)
+      .pipe(babel(babelOptsReact))
+      .pipe(flatten())
+      .pipe(gulp.dest(paths.reactSlim.lib)),
+
+    gulp
       .src(paths.reactDOM.src)
       .pipe(babel(babelOptsReactDOM))
       .pipe(flatten())
@@ -227,6 +251,7 @@ gulp.task('react:modules', function() {
 gulp.task('react:extract-errors', function() {
   return merge(
     gulp.src(paths.react.src).pipe(extractErrors(errorCodeOpts)),
+    gulp.src(paths.reactSlim.src).pipe(extractErrors(errorCodeOpts)),
     gulp.src(paths.reactDOM.src).pipe(extractErrors(errorCodeOpts)),
     gulp.src(paths.reactNative.src).pipe(extractErrors(errorCodeOpts)),
     gulp.src(paths.reactTestRenderer.src).pipe(extractErrors(errorCodeOpts))

--- a/packages/react/react-slim.js
+++ b/packages/react/react-slim.js
@@ -1,0 +1,4 @@
+'use strict';
+
+module.exports = require('./lib/ReactSlim');
+

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -134,5 +134,8 @@
   "132": "Ended a touch event which was not counted in trackedTouchCount.",
   "133": "Touch object is missing identifier",
   "134": "Touch data should have been recorded on start",
-  "135": "Cannot find single active touch"
+  "135": "Cannot find single active touch",
+  "136": "%s is a void element tag and must neither have `children` nor use `dangerouslySetInnerHTML`.%s",
+  "137": "Attempted to update component `%s` that has already been unmounted (or failed to mount).",
+  "138": "Touch object is missing identifier."
 }

--- a/src/isomorphic/ReactSlim.js
+++ b/src/isomorphic/ReactSlim.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactSlim
+ */
+
+'use strict';
+
+var ReactChildren = require('ReactChildren');
+var ReactComponent = require('ReactComponent');
+var ReactPureComponent = require('ReactPureComponent');
+var ReactElement = require('ReactElement');
+var ReactPropTypes = require('ReactPropTypes');
+var ReactVersion = require('ReactVersion');
+
+var onlyChild = require('onlyChild');
+var warning = require('warning');
+
+var createElement = ReactElement.createElement;
+var createFactory = ReactElement.createFactory;
+var cloneElement = ReactElement.cloneElement;
+
+if (__DEV__) {
+  var ReactElementValidator = require('ReactElementValidator');
+  createElement = ReactElementValidator.createElement;
+  createFactory = ReactElementValidator.createFactory;
+  cloneElement = ReactElementValidator.cloneElement;
+}
+
+var __spread = Object.assign;
+
+if (__DEV__) {
+  var warned = false;
+  __spread = function() {
+    warning(
+      warned,
+      'React.__spread is deprecated and should not be used. Use ' +
+      'Object.assign directly or another helper function with similar ' +
+      'semantics. You may be seeing this warning due to your compiler. ' +
+      'See https://fb.me/react-spread-deprecation for more details.'
+    );
+    warned = true;
+    return Object.assign.apply(null, arguments);
+  };
+}
+
+var ReactSlim = {
+
+  // Modern
+
+  Children: {
+    map: ReactChildren.map,
+    forEach: ReactChildren.forEach,
+    count: ReactChildren.count,
+    toArray: ReactChildren.toArray,
+    only: onlyChild,
+  },
+
+  Component: ReactComponent,
+  PureComponent: ReactPureComponent,
+
+  createElement: createElement,
+  cloneElement: cloneElement,
+  isValidElement: ReactElement.isValidElement,
+
+  // Classic
+
+  PropTypes: ReactPropTypes,
+  createFactory: createFactory,
+  createMixin: function(mixin) {
+    // Currently a noop. Will be used to validate and trace mixins.
+    return mixin;
+  },
+
+  version: ReactVersion,
+
+  // Deprecated hook for JSX spread, don't use this for anything.
+  __spread: __spread,
+};
+
+module.exports = ReactSlim;
+

--- a/src/umd/ReactSlimUMDEntry.js
+++ b/src/umd/ReactSlimUMDEntry.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactSlimUMDEntry
+ */
+
+'use strict';
+
+var ReactSlim = require('ReactSlim');
+
+// `version` will be added here by the React module.
+var ReactSlimUMDEntry = Object.assign({
+  __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
+    ReactCurrentOwner: require('ReactCurrentOwner'),
+  },
+}, ReactSlim);
+
+if (__DEV__) {
+  Object.assign(
+    ReactSlimUMDEntry.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
+    {
+      // ReactComponentTreeHook should not be included in production.
+      ReactComponentTreeHook: require('ReactComponentTreeHook'),
+    }
+  );
+}
+
+module.exports = ReactSlimUMDEntry;

--- a/src/umd/shims/ReactSlimUMDShim.js
+++ b/src/umd/shims/ReactSlimUMDShim.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactSlimUMDShim
+ */
+
+/* globals ReactSlim */
+
+'use strict';
+
+module.exports = ReactSlim;


### PR DESCRIPTION
Calling it modern feels weird although modern and classic are the internal folder names.

There’s been some chatter about `createClass` and `PropTypes` being generally in maintenance mode as `class` and `Flow` are the future. I was playing around with the build system anyway (see #7850 and https://twitter.com/iamdustan/status/783701952483856384) so decided to try to create a build removing `createClass` and `DOMFactories`. Potentially `createFactory` and `createMixin` could be removed as well.

The build of react-slim.js vs react.js is displayed in the screenshot below:
<img width="511" alt="screen shot 2016-10-05 at 9 14 54 pm" src="https://cloud.githubusercontent.com/assets/227879/19137308/d084b2b2-8b40-11e6-9c0f-798cfef0c832.png">

**Diff**

```
react-slim vs react: -31,869
react-slim.min vs react.min: -5,755
```

Removing PropTypes may be problematic due to `context` still using it? This is part of an experiment I’m considering that would convert https://github.com/reactjs/react-codemod/blob/master/transforms/class.js to a `babel` transform to run over arbitrary components outside of direct control (aka `babel` over `node_modules`. Heresy, heresy!)
