### PR TITLE
Minor mobile layout fix

### DIFF
--- a/docs/css/react.scss
+++ b/docs/css/react.scss
@@ -366,8 +366,9 @@ h1, h2, h3, h4, h5, h6 {
 
   @include bp-medium {
     width: 100%;
+    padding-bottom: 40px;
   }
-
+   
   ul {
     list-style: none;
     margin: 0;
@@ -1058,6 +1059,12 @@ div[data-twttr-id] iframe {
 
   * {
     max-width: 100%;
+  }
+}
+
+#twitter-widget-0 {
+  @include bp-large {
+    display: none !important; // Need !important because they inline displau on the iframe.
   }
 }
 

--- a/docs/css/react.scss
+++ b/docs/css/react.scss
@@ -1064,7 +1064,7 @@ div[data-twttr-id] iframe {
 
 #twitter-widget-0 {
   @include bp-large {
-    display: none !important; // Need !important because they inline displau on the iframe.
+    display: none !important; // Need !important because they inline display on the iframe.
   }
 }
 


### PR DESCRIPTION
Removes the Twitter embedded timeline from the Community page when viewed in mobile. In mobile, this embedded timeline made it hard to scroll past and reach the Community Resources TOC.

This also adds padding underneath the mobile navigation in order to gain some separation before the footer.