### PR TITLE
Add warning for shady-dom use with rendered react components in DEV

### DIFF
--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -632,12 +632,20 @@ ReactDOMComponent.Mixin = {
           this._currentElement.type
         );
       }
+      var isCustomComponentTag = isCustomComponent(this._tag, props);
+      if (__DEV__ && isCustomComponentTag) {
+        warning(
+          !el.shadyRoot,
+          'A component is using shady dom. Using shady dom with React can ' +
+          'cause things to break subtly.'
+        );
+      }
       ReactDOMComponentTree.precacheNode(this, el);
       this._flags |= Flags.hasCachedChildNodes;
       if (!this._hostParent) {
         DOMPropertyOperations.setAttributeForRoot(el);
       }
-      this._updateDOMProperties(null, props, transaction);
+      this._updateDOMProperties(null, props, transaction, isCustomComponentTag);
       var lazyTree = DOMLazyTree(el);
       this._createInitialChildren(transaction, props, context, lazyTree);
       mountImage = lazyTree;
@@ -902,7 +910,8 @@ ReactDOMComponent.Mixin = {
     }
 
     assertValidProps(this, nextProps);
-    this._updateDOMProperties(lastProps, nextProps, transaction);
+    var isCustomComponentTag = isCustomComponent(this._tag, nextProps);
+    this._updateDOMProperties(lastProps, nextProps, transaction, isCustomComponentTag);
     this._updateDOMChildren(
       lastProps,
       nextProps,
@@ -944,7 +953,12 @@ ReactDOMComponent.Mixin = {
    * @param {object} nextProps
    * @param {?DOMElement} node
    */
-  _updateDOMProperties: function(lastProps, nextProps, transaction) {
+  _updateDOMProperties: function(
+    lastProps,
+    nextProps,
+    transaction,
+    isCustomComponentTag
+  ) {
     var propKey;
     var styleName;
     var styleUpdates;
@@ -1034,7 +1048,7 @@ ReactDOMComponent.Mixin = {
         } else if (lastProp) {
           deleteListener(this, propKey);
         }
-      } else if (isCustomComponent(this._tag, nextProps)) {
+      } else if (isCustomComponentTag) {
         if (!RESERVED_PROPS.hasOwnProperty(propKey)) {
           DOMPropertyOperations.setValueForAttribute(
             getNode(this),

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -634,9 +634,9 @@ ReactDOMComponent.Mixin = {
         );
       }
       var isCustomComponentTag = isCustomComponent(this._tag, props);
-      if (__DEV__ && isCustomComponentTag && !didWarnShadyDom) {
+      if (__DEV__ && isCustomComponentTag && !didWarnShadyDom && el.shadyRoot) {
         warning(
-          !el.shadyRoot,
+          didWarnShadyDom,
           'A component is using shady dom. Using shady dom with React can ' +
           'cause things to break subtly.'
         );

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -636,7 +636,7 @@ ReactDOMComponent.Mixin = {
       var isCustomComponentTag = isCustomComponent(this._tag, props);
       if (__DEV__ && isCustomComponentTag && !didWarnShadyDom && el.shadyRoot) {
         warning(
-          didWarnShadyDom,
+          false,
           'A component is using shady dom. Using shady dom with React can ' +
           'cause things to break subtly.'
         );

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -40,6 +40,7 @@ var shallowEqual = require('shallowEqual');
 var inputValueTracking = require('inputValueTracking');
 var validateDOMNesting = require('validateDOMNesting');
 var warning = require('warning');
+var didWarnShadyDom = false;
 
 var Flags = ReactDOMComponentFlags;
 var deleteListener = EventPluginHub.deleteListener;
@@ -633,12 +634,13 @@ ReactDOMComponent.Mixin = {
         );
       }
       var isCustomComponentTag = isCustomComponent(this._tag, props);
-      if (__DEV__ && isCustomComponentTag) {
+      if (__DEV__ && isCustomComponentTag && !didWarnShadyDom) {
         warning(
           !el.shadyRoot,
           'A component is using shady dom. Using shady dom with React can ' +
           'cause things to break subtly.'
         );
+        didWarnShadyDom = true;
       }
       ReactDOMComponentTree.precacheNode(this, el);
       this._flags |= Flags.hasCachedChildNodes;

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -40,7 +40,7 @@ var shallowEqual = require('shallowEqual');
 var inputValueTracking = require('inputValueTracking');
 var validateDOMNesting = require('validateDOMNesting');
 var warning = require('warning');
-var didWarnShadyDom = false;
+var didWarnShadyDOM = false;
 
 var Flags = ReactDOMComponentFlags;
 var deleteListener = EventPluginHub.deleteListener;
@@ -634,13 +634,13 @@ ReactDOMComponent.Mixin = {
         );
       }
       var isCustomComponentTag = isCustomComponent(this._tag, props);
-      if (__DEV__ && isCustomComponentTag && !didWarnShadyDom && el.shadyRoot) {
+      if (__DEV__ && isCustomComponentTag && !didWarnShadyDOM && el.shadyRoot) {
         warning(
           false,
-          'A component is using shady dom. Using shady dom with React can ' +
+          'A component is using shady DOM. Using shady DOM with React can ' +
           'cause things to break subtly.'
         );
-        didWarnShadyDom = true;
+        didWarnShadyDOM = true;
       }
       ReactDOMComponentTree.precacheNode(this, el);
       this._flags |= Flags.hasCachedChildNodes;

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -636,7 +636,7 @@ ReactDOMComponent.Mixin = {
       var isCustomComponentTag = isCustomComponent(this._tag, props);
       if (__DEV__ && isCustomComponentTag && !didWarnShadyDOM && el.shadyRoot) {
         var owner = this._currentElement._owner;
-        var name = owner.getName() || 'A component';
+        var name = owner && owner.getName() || 'A component';
         warning(
           false,
           '%s is using shady DOM. Using shady DOM with React can ' +

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -635,10 +635,13 @@ ReactDOMComponent.Mixin = {
       }
       var isCustomComponentTag = isCustomComponent(this._tag, props);
       if (__DEV__ && isCustomComponentTag && !didWarnShadyDOM && el.shadyRoot) {
+        var owner = this._currentElement._owner;
+        var name = owner.getName() || 'A component';
         warning(
           false,
-          'A component is using shady DOM. Using shady DOM with React can ' +
-          'cause things to break subtly.'
+          '%s is using shady DOM. Using shady DOM with React can ' +
+          'cause things to break subtly.',
+          name
         );
         didWarnShadyDOM = true;
       }

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -791,6 +791,26 @@ describe('ReactDOMComponent', () => {
       );
     });
 
+    it('should emit warning when using shady dom with a custom component', () => {
+      spyOn(console, 'error');
+      var defaultCreateElement = document.createElement.bind(document);
+      try {
+        document.createElement = element => {
+          var container = defaultCreateElement(element);
+          container.shadyRoot = {};
+          return container;
+        };
+        mountComponent({is: 'custom-shady-div'});
+        expect(console.error.calls.count()).toBe(1);
+        expect(console.error.calls.argsFor(0)[0]).toContain(
+          'A component is using shady dom. Using shady dom with React can ' +
+          'cause things to break subtly.'
+        );
+      } finally {
+        document.createElement = defaultCreateElement;
+      }
+    });
+
     it('should treat menuitem as a void element but still create the closing tag', () => {
       var container = document.createElement('div');
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -792,24 +792,31 @@ describe('ReactDOMComponent', () => {
     });
 
     it('should emit warning when using shady dom with a custom component', () => {
-      spyOn(console, 'error');
-      var defaultCreateElement = document.createElement.bind(document);
-      try {
-        document.createElement = element => {
-          var container = defaultCreateElement(element);
-          container.shadyRoot = {};
-          return container;
-        };
-        mountComponent({is: 'custom-shady-div'});
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'A component is using shady dom. Using shady dom with React can ' +
-          'cause things to break subtly.'
-        );
-        mountComponent({is: 'custom-shady-div2'});
-        expect(console.error.calls.count()).toBe(1);
-      } finally {
-        document.createElement = defaultCreateElement;
+      if (ReactDOMFeatureFlags.useCreateElement) {
+        spyOn(console, 'error');
+
+        var defaultCreateElement = document.createElement.bind(document);
+
+        try {
+          document.createElement = element => {
+            var container = defaultCreateElement(element);
+            container.shadyRoot = {};
+            return container;
+          };
+
+          mountComponent({is: 'custom-shady-div'});
+          expect(console.error.calls.count()).toBe(1);
+          expect(console.error.calls.argsFor(0)[0]).toContain(
+            'A component is using shady dom. Using shady dom with React can ' +
+            'cause things to break subtly.'
+          );
+
+          mountComponent({is: 'custom-shady-div2'});
+          expect(console.error.calls.count()).toBe(1);
+
+        } finally {
+          document.createElement = defaultCreateElement;
+        }
       }
     });
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -805,11 +805,11 @@ describe('ReactDOMComponent', () => {
           };
           var ShadyComponent = React.createClass({
             render() {
-              return <div { ...this.props }></div>;
+              return <polymer-component />;
             }
           });
-          var container = document.createElement('div');
-          ReactDOM.render(<ShadyComponent is="custom-shady-div" />, container);
+          var node = document.createElement('div');
+          ReactDOM.render(<ShadyComponent />, node);
           expect(console.error.calls.count()).toBe(1);
           expect(console.error.calls.argsFor(0)[0]).toContain(
             'ShadyComponent is using shady DOM. Using shady DOM with React can ' +

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -806,7 +806,7 @@ describe('ReactDOMComponent', () => {
           var ShadyComponent = React.createClass({
             render() {
               return <polymer-component />;
-            }
+            },
           });
           var node = document.createElement('div');
           ReactDOM.render(<ShadyComponent />, node);

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -807,7 +807,7 @@ describe('ReactDOMComponent', () => {
           mountComponent({is: 'custom-shady-div'});
           expect(console.error.calls.count()).toBe(1);
           expect(console.error.calls.argsFor(0)[0]).toContain(
-            'A component is using shady dom. Using shady dom with React can ' +
+            'A component is using shady DOM. Using shady DOM with React can ' +
             'cause things to break subtly.'
           );
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -806,6 +806,8 @@ describe('ReactDOMComponent', () => {
           'A component is using shady dom. Using shady dom with React can ' +
           'cause things to break subtly.'
         );
+        mountComponent({is: 'custom-shady-div2'});
+        expect(console.error.calls.count()).toBe(1);
       } finally {
         document.createElement = defaultCreateElement;
       }


### PR DESCRIPTION
**Description:**
As described in #7325, there should be a warning emitted when somebody uses shady dom with React.

#7383 & #7537 attempted to solve this issue, however they have not been updated or corrected in months. This PR is informed by those discussions and combines those findings into this completed solution with tests.

**Changes Proposed:**
This PR fulfills all requirements set by @gaearon's comments: https://github.com/facebook/react/pull/7537#issuecomment-241505692 & https://github.com/facebook/react/pull/7537#issuecomment-241522862

- [x] Add `isCustomComponentTag` boolean to the _updateDOMProperties signature as its last argument to avoid calling `isCustomComponent(this._tag, props)` multiple times
- [x] Add call for `var isCustomComponentTag = isCustomComponent(this._tag, props)` to both `mountComponent()` and `updateComponent()` to be consumed by `_updateDOMProperties`

As per the requirements for this warning, it will only emit to console when:
- [x] shadyRoot exists on the DOM element
- [x] only do this in ReactDOMComponent.mountComponent in DEV
- [x] only perform the check if isCustomComponent(this._tag, props) is true
- [x] Emit only once even when mounting multiple components using a check for `didWarnShadyDom`

Also, tests have been added for this warning:
- [x] Sets a fake `document.createElement` to simulate the creation of the `shadyRoot` property and returns `document.createElement`'s original functionality after resolution, regardless of tests passing/failing.
- [x] Checks for the shady dom warning emitted when the above requirements are met.
- [x] Tests that the warning is emitted only **once** even when mounting multiple components to prevent spamming the console.

-----
cc: @gaearon 