### PR TITLE
Add support all lifecycle methods to ShallowRender

### DIFF
--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -118,6 +118,46 @@ describe('ReactTestUtils', () => {
     expect(result).toBe(null);
   });
 
+  it('should run all lifecycle methods', function() {
+    var componentWillMount = jasmine.createSpy('componentWillMount');
+    var componentDidMount = jasmine.createSpy('componentDidMount');
+    var componentWillReceiveProps = jasmine.createSpy('componentWillReceiveProps');
+    var shouldComponentUpdate = jasmine.createSpy('shouldComponentUpdate');
+    var componentWillUpdate = jasmine.createSpy('componentWillUpdate');
+    var componentDidUpdate = jasmine.createSpy('componentDidUpdate');
+    var componentWillUnmount = jasmine.createSpy('componentWillUnmount');
+
+    var SomeComponent = React.createClass({
+      render: function() {
+        return <SomeComponent onChange={() => this.setState({a: 1})} />;
+      },
+      componentWillMount,
+      componentDidMount,
+      componentWillReceiveProps,
+      shouldComponentUpdate() {
+        shouldComponentUpdate();
+        return true;
+      },
+      componentWillUpdate,
+      componentDidUpdate,
+      componentWillUnmount,
+    });
+
+    var shallowRenderer = ReactTestUtils.createRenderer();
+    shallowRenderer.render(<SomeComponent />);
+    shallowRenderer.getRenderOutput().props.onChange();
+    shallowRenderer.render(<SomeComponent />);
+    shallowRenderer.unmount();
+
+    expect(componentWillMount).toBeCalled();
+    expect(componentDidMount).toBeCalled();
+    expect(componentWillReceiveProps).toBeCalled();
+    expect(shouldComponentUpdate).toBeCalled();
+    expect(componentWillUpdate).toBeCalled();
+    expect(componentDidUpdate).toBeCalled();
+    expect(componentWillUnmount).toBeCalled();
+  });
+
   it('can shallow render with a ref', () => {
     class SomeComponent extends React.Component {
       render() {


### PR DESCRIPTION
This PR has a **breaking change**.

Supporting all lifecycle methods in ShallowRender merged at #4993, but reverted at #5394.
The reason why the PR is reverted is that it didn't support string `refs`.

This PR is fixed it.

Currently, ShallowRender is replacing `_renderValidatedComponent` with `_renderValidatedComponentWithoutOwnerOrContext`, which it seems to be a little hacky.

```
-    _renderValidatedComponent:     
-      ReactCompositeComponent      
-        ._renderValidatedComponentWithoutOwnerOrContext,
```

I think it's better to assign `null` to `_onwer` filed.
