### PR TITLE
use npm-run-script in PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,6 @@
 1. Fork the repo and create your branch from `master`.
 2. If you've added code that should be tested, add tests!
 3. If you've changed APIs, update the documentation.
-4. Ensure the test suite passes (`grunt test`).
-5. Make sure your code lints (`grunt lint`) - we've done our best to make sure these rules match our internal linting guidelines.
+4. Ensure the test suite passes (`npm test`).
+5. Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.
 6. If you haven't already, complete the [CLA](https://code.facebook.com/cla).


### PR DESCRIPTION
I think it's better to use npm-run-script than to use `grunt` command directly.
`How to Contribute` page is also using npm-run-script.

* https://facebook.github.io/react/contributing/how-to-contribute.html#development-workflow