### PR TITLE
Replace ES2015 with ES6.

### DIFF
--- a/docs/contributing/codebase-overview.md
+++ b/docs/contributing/codebase-overview.md
@@ -196,7 +196,7 @@ You can run `npm run flow` locally to check your code with Flow.
 
 ### Classes and Mixins
 
-React was originally written in ES5. We have since enabled ES2015 features with [Babel](http://babeljs.io/), including classes. However most of React code is still written in ES5.
+React was originally written in ES5. We have since enabled ES6 features with [Babel](http://babeljs.io/), including classes. However most of React code is still written in ES5.
 
 In particular, you might see the following pattern quite often:
 
@@ -224,7 +224,7 @@ module.exports = ReactDOMComponent;
 
 The `Mixin` in this code has no relation to React `mixins` feature. It is just a way of grouping a few methods under an object. Those methods may later get attached to some other class. We use this pattern in a few places although we try to avoid it in the new code.
 
-Equivalent code in ES2015 would like this:
+Equivalent code in ES6 would like this:
 
 ```js
 class ReactDOMComponent {
@@ -240,7 +240,7 @@ class ReactDOMComponent {
 module.exports = ReactDOMComponent;
 ```
 
-Sometimes we [convert old code to ES2015 classes](https://github.com/facebook/react/pull/7647/files). However this is not very important to us because there is an [ongoing effort](#fiber-reconciler) to replace the React reconciler implementation with a less object-oriented approach which wouldn't use classes at all.
+Sometimes we [convert old code to ES6 classes](https://github.com/facebook/react/pull/7647/files). However this is not very important to us because there is an [ongoing effort](#fiber-reconciler) to replace the React reconciler implementation with a less object-oriented approach which wouldn't use classes at all.
 
 ### Dynamic Injection
 

--- a/docs/docs-old/09.1-language-tooling.md
+++ b/docs/docs-old/09.1-language-tooling.md
@@ -6,11 +6,11 @@ prev: tooling-integration.html
 next: package-management.html
 ---
 
-## ES2015 with JSX
+## ES6 with JSX
 
 ### In-browser JSX Transform
 
-If you like using JSX, Babel 5 provided an in-browser ES2015 and JSX transformer for development called browser.js that can be included from [CDNJS](https://cdnjs.com/libraries/babel-core/5.8.34). Include a `<script type="text/babel">` tag to engage the JSX transformer.
+If you like using JSX, Babel 5 provided an in-browser ES6 and JSX transformer for development called browser.js that can be included from [CDNJS](https://cdnjs.com/libraries/babel-core/5.8.34). Include a `<script type="text/babel">` tag to engage the JSX transformer.
 
 > Note:
 >
@@ -24,7 +24,7 @@ This tool will translate files that use JSX syntax to plain JavaScript files tha
 
 Beginning with Babel 6, there are no transforms included by default. This means that options must be specified when running the `babel` command, or a `.babelrc` must specify options. Additional packages must also be installed which bundle together a number of transforms, called presets. The most common use when working with React will be to include the `es2015` and `react` presets. More information about the changes to Babel can be found in [their blog post announcing Babel 6](http://babeljs.io/blog/2015/10/29/6.0.0).
 
-Here is an example of what you will do if using ES2015 syntax and React:
+Here is an example of what you will do if using ES6 syntax and React:
 
 ```
 npm install babel-preset-es2015 babel-preset-react
@@ -73,5 +73,3 @@ TypeScript is a type-checker and transpiler that supports type-checking React an
 For more info, check out their guide on [getting started with React and Webpack](https://www.typescriptlang.org/docs/handbook/react-&-webpack.html), or learn more about [TypeScript's JSX support](https://www.typescriptlang.org/docs/handbook/jsx.html).
 
 To learn more about TypeScript in general, visit the [TypeScript homepage](https://www.typescriptlang.org/).
-
-

--- a/docs/docs-old/09.2-package-management.md
+++ b/docs/docs-old/09.2-package-management.md
@@ -34,7 +34,7 @@ Configure [babel](https://babeljs.io/) with a `.babelrc` file:
 
  > Note:
  >
- > If you are using ES2015, you will want to also use the `babel-preset-es2015` package.
+ > If you are using ES6, you will want to also use the `babel-preset-es2015` package.
 
 
 To install React DOM and build your bundle with browserify:
@@ -53,7 +53,7 @@ $ webpack main.js bundle.js --module-bind 'js=babel-loader'
 
 > Note:
 >
-> If you are using ES2015, you will want to also use the `babel-preset-es2015` package.
+> If you are using ES6, you will want to also use the `babel-preset-es2015` package.
 
 **Note:** by default, React will be in development mode, which is slower, and not advised for production. To use React in production mode, set the environment variable `NODE_ENV` to `production` (using envify or webpack's DefinePlugin). For example:
 


### PR DESCRIPTION
Use ES6 throughout the docs as the term has gained more traction than ES2015.