### PR TITLE
Inject the previous batching strategy when rendering to string

### DIFF
--- a/src/renderers/dom/server/ReactServerRendering.js
+++ b/src/renderers/dom/server/ReactServerRendering.js
@@ -12,7 +12,6 @@
 
 var React = require('React');
 var ReactDOMContainerInfo = require('ReactDOMContainerInfo');
-var ReactDefaultBatchingStrategy = require('ReactDefaultBatchingStrategy');
 var ReactInstrumentation = require('ReactInstrumentation');
 var ReactMarkupChecksum = require('ReactMarkupChecksum');
 var ReactReconciler = require('ReactReconciler');
@@ -33,7 +32,9 @@ var pendingTransactions = 0;
  */
 function renderToStringImpl(element, makeStaticMarkup) {
   var transaction;
+  var previousBatchingStrategy;
   try {
+    previousBatchingStrategy = ReactUpdates.injection.getBatchingStrategy();
     ReactUpdates.injection.injectBatchingStrategy(ReactServerBatchingStrategy);
 
     transaction = ReactServerRenderingTransaction.getPooled(makeStaticMarkup);
@@ -67,7 +68,7 @@ function renderToStringImpl(element, makeStaticMarkup) {
     // currently share these stateful modules.
     if (!pendingTransactions) {
       ReactUpdates.injection.injectBatchingStrategy(
-        ReactDefaultBatchingStrategy
+        previousBatchingStrategy
       );
     }
   }

--- a/src/renderers/shared/stack/reconciler/ReactUpdates.js
+++ b/src/renderers/shared/stack/reconciler/ReactUpdates.js
@@ -272,6 +272,10 @@ var ReactUpdatesInjection = {
     );
     batchingStrategy = _batchingStrategy;
   },
+
+  getBatchingStrategy: function() {
+    return batchingStrategy;
+  },
 };
 
 var ReactUpdates = {


### PR DESCRIPTION
Before this change calling renderToStringImpl would inject ReactDefaultBatchingStrategy after completion, even if a custom batching strategy was injected before. This makes renderToStringImpl keep a reference to the batching strategy before it runs and reinjects it afterwards.