### PR TITLE
Declare type higher up in mountComponent() in ReactDOMComponent

### DIFF
--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -607,6 +607,7 @@ ReactDOMComponent.Mixin = {
     }
 
     var mountImage;
+    var type = this._currentElement.type;
     if (transaction.useCreateElement) {
       var ownerDocument = hostContainerInfo._ownerDocument;
       var el;
@@ -615,21 +616,20 @@ ReactDOMComponent.Mixin = {
           // Create the script via .innerHTML so its "parser-inserted" flag is
           // set to true and it does not execute
           var div = ownerDocument.createElement('div');
-          var type = this._currentElement.type;
           div.innerHTML = `<${type}></${type}>`;
           el = div.removeChild(div.firstChild);
         } else if (props.is) {
-          el = ownerDocument.createElement(this._currentElement.type, props.is);
+          el = ownerDocument.createElement(type, props.is);
         } else {
           // Separate else branch instead of using `props.is || undefined` above becuase of a Firefox bug.
           // See discussion in https://github.com/facebook/react/pull/6896
           // and discussion in https://bugzilla.mozilla.org/show_bug.cgi?id=1276240
-          el = ownerDocument.createElement(this._currentElement.type);
+          el = ownerDocument.createElement(type);
         }
       } else {
         el = ownerDocument.createElementNS(
           namespaceURI,
-          this._currentElement.type
+          type
         );
       }
       ReactDOMComponentTree.precacheNode(this, el);
@@ -647,8 +647,7 @@ ReactDOMComponent.Mixin = {
       if (!tagContent && omittedCloseTags[this._tag]) {
         mountImage = tagOpen + '/>';
       } else {
-        mountImage =
-          tagOpen + '>' + tagContent + '</' + this._currentElement.type + '>';
+        mountImage = tagOpen + '>' + tagContent + '</' + type + '>';
       }
     }
 


### PR DESCRIPTION
Description:

This PR has a very limited scope. I came across this while working through `ReactDOMComponent.js` for #7911 and found that `var type = this._currentElement.type;` was assigned in a very limited scope within `mountComponent()` on line 618, while `this._currentElement.type` was being in nearly every case explicitly around it.

Changes Proposed:

- Assign `var type = this._currentElement.type;` higher inside `mountComponent()` to be used everywhere else `this._currentElement.type` is being explicitly written.

If line 610 is too high up, I could see it being placed after line 612 within the `if (transaction.useCreateElement)` block, since the only case where `type` might go unused is on the block on line 647, within the `else` block for `if (transaction.useCreateElement)`. Let me know what you think.

cc: @gaearon 