### PR TITLE
ref-04-tags-and-attributes.md. `data-*` and `aria-*` attrs not camel-…

### DIFF
--- a/docs/docs/ref-04-tags-and-attributes.md
+++ b/docs/docs/ref-04-tags-and-attributes.md
@@ -47,7 +47,7 @@ React supports all `data-*` and `aria-*` attributes as well as every attribute i
 
 > Note:
 >
-> All attributes are camel-cased and the attributes `class` and `for` are `className` and `htmlFor`, respectively, to match the DOM API specification.
+> All attributes are camel-cased and the attributes `class` and `for` are `className` and `htmlFor`, respectively, to match the DOM API specification. `data-*` and `aria-*` attributes should not be camel-cased.
 
 For a list of events, see [Supported Events](/react/docs/events.html).
 


### PR DESCRIPTION
IMO it's not clear form the docs how I should pass `aria-labelledby`. 

> React supports all data-* and aria-* attributes as well as every attribute in the following lists.
> Note: 

This note about camel-case makes it look like it's also about the `data-*` and `aria-*` attributes while it's not. [Users might think](http://stackoverflow.com/questions/38490143/react-bootstrap-add-aria-label-to-safeanchor/39967317#comment67273285_39967317) they should use it like `ariaLabelledBy` or `aria-labelledBy` while they shouldn't. I think this addition makes this more clear. 