### PR TITLE
Docs grammar: "in a very declarative way" -> "declaratively"

### DIFF
--- a/docs/docs/05-reusable-components.md
+++ b/docs/docs/05-reusable-components.md
@@ -135,7 +135,7 @@ MyComponent.propTypes = {
 
 ## Default Prop Values
 
-React lets you define default values for your `props` in a very declarative way:
+React lets you define default values for your `props` declaratively:
 
 ```javascript
 class Greeting extends React.Component {


### PR DESCRIPTION
It does not make sense to describe something as "very" declarative. There is no sensible notion of relative declarativity, so this is clearer by just saying "declaratively".