### PR TITLE
[Fiber] Support to render number as children

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -51,7 +51,7 @@ var DOMRenderer = ReactFiberReconciler({
   createInstance(type : string, props : Props, children : HostChildren<Instance>) : Instance {
     const domElement = document.createElement(type);
     recursivelyAppendChildren(domElement, children);
-    if (typeof props.children === 'string') {
+    if (typeof props.children === 'string' || typeof props.children === 'number') {
       domElement.textContent = props.children;
     }
     return domElement;
@@ -69,7 +69,7 @@ var DOMRenderer = ReactFiberReconciler({
   commitUpdate(domElement : Instance, oldProps : Props, newProps : Props, children : HostChildren<Instance>) : void {
     domElement.innerHTML = '';
     recursivelyAppendChildren(domElement, children);
-    if (typeof newProps.children === 'string') {
+    if (typeof newProps.children === 'string' || typeof newProps.children === 'number') {
       domElement.textContent = newProps.children;
     }
   },

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var React = require('React');
+var ReactDOMFiber = require('ReactDOMFiber');
+
+describe('ReactDOMFiber', () => {
+  var containerEl;
+
+  beforeEach(() => {
+    // to supress a warning that ReactDOMFiber is an experimental renderer.
+    spyOn(console, 'error');
+    containerEl = document.createElement('div');
+  });
+
+  it('should be able to render string as children', () => {
+    var Foo = ({child}) => <div>{child}</div>;
+    ReactDOMFiber.render(
+      <Foo child="test" />,
+      containerEl
+    );
+    expect(containerEl.textContent).toBe('test');
+  });
+
+  it('should be able to render number as children', () => {
+    var Foo = ({child}) => <div>{child}</div>;
+    ReactDOMFiber.render(
+      <Foo child={1} />,
+      containerEl
+    );
+    expect(containerEl.textContent).toBe('1');
+  });
+});


### PR DESCRIPTION
I'm trying to understand what ReactFiber is.

Currently, `ReactDOMFiber` can't render `number` as children.
I know ReactFiber is working in progress but I'd like to contribute to it.

I think it would be nice if this PR makes sense and is merged.