### PR TITLE
[New Docs] Fix text size adjust for <pre> element in webkit browsers

### DIFF
--- a/docs/css/react.scss
+++ b/docs/css/react.scss
@@ -7,8 +7,9 @@
 
 @mixin code-typography {
   font-family: 'source-code-pro', Menlo, Consolas, 'Courier New', monospace;
-  font-size: 13px;
   line-height: 1.5;
+  font-size: 13px;
+  -webkit-text-size-adjust: none;
 }
 
 $skinnyContentWidth: 650px;


### PR DESCRIPTION
iOS Safari tries to adjust a font size of `<pre>` element if a length of a string is long, so the difference between font sizes looks strange:

<img width="372" alt="screen shot 2016-10-14 at 4 09 10 pm" src="https://cloud.githubusercontent.com/assets/147321/19388613/33577656-9229-11e6-91ef-f854d0a0950d.png">

After this fix:

<img width="373" alt="screen shot 2016-10-14 at 4 07 21 pm" src="https://cloud.githubusercontent.com/assets/147321/19388620/3ded6eae-9229-11e6-9f57-8aa55e192686.png">

