### PR TITLE
[New Docs] Fix image size for tutorial page

### DIFF
--- a/docs/css/react.scss
+++ b/docs/css/react.scss
@@ -69,7 +69,6 @@ html {
 .container {
   padding-top: $navHeight;
   width: 100%;
-  overflow: hidden;
 }
 
 .wrap {

--- a/docs/css/react.scss
+++ b/docs/css/react.scss
@@ -69,6 +69,7 @@ html {
 .container {
   padding-top: $navHeight;
   width: 100%;
+  overflow: hidden;
 }
 
 .wrap {

--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -124,7 +124,7 @@ If you click on any square, an X should show up in it.
 
 The React Devtools extension for [Chrome](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/react-devtools/) lets you inspect a React component tree in your browser devtools.
 
-![React Devtools](/react/img/tutorial/devtools.png)
+<img src="/react/img/tutorial/devtools.png" alt="React Devtools" style="max-width: 100%">
 
 It lets you inspect the props and state of any of the components in your tree.
 


### PR DESCRIPTION
For example, in a tutorial page we have an extra space and a horizontal scroll, because of images in a content. We have no any content outside the container so I think we can just set overflow hidden for it.

<img width="399" alt="screen shot 2016-10-14 at 8 38 20 pm" src="https://cloud.githubusercontent.com/assets/147321/19396990/87429082-924e-11e6-97bd-40306b0ac0d1.png">
