### PR TITLE
Fix whitespace in headers

### DIFF
--- a/src/addons/shallowCompare.js
+++ b/src/addons/shallowCompare.js
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
-* @providesModule shallowCompare
-*/
+ * @providesModule shallowCompare
+ */
 
 'use strict';
 

--- a/src/renderers/dom/client/renderSubtreeIntoContainer.js
+++ b/src/renderers/dom/client/renderSubtreeIntoContainer.js
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
-* @providesModule renderSubtreeIntoContainer
-*/
+ * @providesModule renderSubtreeIntoContainer
+ */
 
 'use strict';
 

--- a/src/renderers/shared/stack/reconciler/ReactInstanceType.js
+++ b/src/renderers/shared/stack/reconciler/ReactInstanceType.js
@@ -1,4 +1,4 @@
- /**
+/**
  * Copyright 2016-present, Facebook, Inc.
  * All rights reserved.
  *
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @flow
  * @providesModule ReactInstanceType
+ * @flow
  */
 
 'use strict';


### PR DESCRIPTION
The script that strips providesModule is very sensitive.

Test plan:

Searched for providesModule in build. No more.

reactComponentExpect used to have problems too but doesn't seem to anymore. Don't know why.