### PR TITLE
[Fiber] Disable ReactDOMFiber warning for tests in Fiber mode

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -14,6 +14,7 @@
 
 import type { HostChildren } from 'ReactFiberReconciler';
 
+var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 var ReactFiberReconciler = require('ReactFiberReconciler');
 
 var warning = require('warning');
@@ -88,7 +89,7 @@ var warned = false;
 
 function warnAboutUnstableUse() {
   warning(
-    warned,
+    ReactDOMFeatureFlags.useFiber || warned,
     'You are using React DOM Fiber which is an experimental renderer. ' +
     'It is likely to have bugs, breaking changes and is unsupported.'
   );


### PR DESCRIPTION
Maybe I'm missing something, but unless I disable it, Jest complains about the warning (and we see the warning on the first `ReactDOM.render` call in Fiber mode).

Test plan:

1. I can get some tests in `ReactES6Class` to pass that I previously couldn't
2. If I open `examples/fiber` I can still see the warning just fine