### PR TITLE
[Fiber] Set DOM attributes

### DIFF
--- a/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
+++ b/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
@@ -26,6 +26,10 @@ describe('ReactES6Class', () => {
   var renderedName = null;
 
   beforeEach(() => {
+    // TODO: Fiber doesn't currently handle errors well
+    // so one test failure brings the other tests down.
+    jest.resetModuleRegistry();
+
     React = require('React');
     ReactDOM = require('ReactDOM');
     container = document.createElement('div');

--- a/src/renderers/dom/__tests__/ReactDOMProduction-test.js
+++ b/src/renderers/dom/__tests__/ReactDOMProduction-test.js
@@ -65,7 +65,7 @@ describe('ReactDOMProduction', () => {
       container
     );
 
-    expect(container.firstChild).toBe(inst);
+    expect(container.firstChild === inst).toBe(true);
     expect(inst.className).toBe('blue');
     expect(inst.textContent).toBe('ABC');
 

--- a/src/renderers/dom/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/client/wrappers/ReactDOMInput.js
@@ -191,15 +191,22 @@ var ReactDOMInput = {
 
     // TODO: Shouldn't this be getChecked(props)?
     var checked = props.checked;
+    var node = ReactDOMComponentTree.getNodeFromInstance(inst);
+
+    var debugID = 0;
+    if (__DEV__) {
+      debugID = inst._debugID;
+    }
+
     if (checked != null) {
       DOMPropertyOperations.setValueForProperty(
-        ReactDOMComponentTree.getNodeFromInstance(inst),
+        node,
         'checked',
-        checked || false
+        checked || false,
+        debugID
       );
     }
 
-    var node = ReactDOMComponentTree.getNodeFromInstance(inst);
     var value = LinkedValueUtils.getValue(props);
     if (value != null) {
 

--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -12,7 +12,6 @@
 'use strict';
 
 var DOMProperty = require('DOMProperty');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var ReactInstrumentation = require('ReactInstrumentation');
 
 var quoteAttributeValueForBrowser = require('quoteAttributeValueForBrowser');
@@ -130,7 +129,7 @@ var DOMPropertyOperations = {
    * @param {string} name
    * @param {*} value
    */
-  setValueForProperty: function(node, name, value) {
+  setValueForProperty: function(node, name, value, debugID) {
     var propertyInfo = DOMProperty.properties.hasOwnProperty(name) ?
         DOMProperty.properties[name] : null;
     if (propertyInfo) {
@@ -138,7 +137,7 @@ var DOMPropertyOperations = {
       if (mutationMethod) {
         mutationMethod(node, value);
       } else if (shouldIgnoreValue(propertyInfo, value)) {
-        this.deleteValueForProperty(node, name);
+        this.deleteValueForProperty(node, name, debugID);
         return;
       } else if (propertyInfo.mustUseProperty) {
         // Contrary to `setAttribute`, object properties are properly
@@ -159,7 +158,7 @@ var DOMPropertyOperations = {
         }
       }
     } else if (DOMProperty.isCustomAttribute(name)) {
-      DOMPropertyOperations.setValueForAttribute(node, name, value);
+      DOMPropertyOperations.setValueForAttribute(node, name, value, debugID);
       return;
     }
 
@@ -167,14 +166,14 @@ var DOMPropertyOperations = {
       var payload = {};
       payload[name] = value;
       ReactInstrumentation.debugTool.onHostOperation({
-        instanceID: ReactDOMComponentTree.getInstanceFromNode(node)._debugID,
+        instanceID: debugID,
         type: 'update attribute',
         payload: payload,
       });
     }
   },
 
-  setValueForAttribute: function(node, name, value) {
+  setValueForAttribute: function(node, name, value, debugID) {
     if (!isAttributeNameSafe(name)) {
       return;
     }
@@ -188,7 +187,7 @@ var DOMPropertyOperations = {
       var payload = {};
       payload[name] = value;
       ReactInstrumentation.debugTool.onHostOperation({
-        instanceID: ReactDOMComponentTree.getInstanceFromNode(node)._debugID,
+        instanceID: debugID,
         type: 'update attribute',
         payload: payload,
       });
@@ -201,11 +200,11 @@ var DOMPropertyOperations = {
    * @param {DOMElement} node
    * @param {string} name
    */
-  deleteValueForAttribute: function(node, name) {
+  deleteValueForAttribute: function(node, name, debugID) {
     node.removeAttribute(name);
     if (__DEV__) {
       ReactInstrumentation.debugTool.onHostOperation({
-        instanceID: ReactDOMComponentTree.getInstanceFromNode(node)._debugID,
+        instanceID: debugID,
         type: 'remove attribute',
         payload: name,
       });
@@ -218,7 +217,7 @@ var DOMPropertyOperations = {
    * @param {DOMElement} node
    * @param {string} name
    */
-  deleteValueForProperty: function(node, name) {
+  deleteValueForProperty: function(node, name, debugID) {
     var propertyInfo = DOMProperty.properties.hasOwnProperty(name) ?
         DOMProperty.properties[name] : null;
     if (propertyInfo) {
@@ -241,7 +240,7 @@ var DOMPropertyOperations = {
 
     if (__DEV__) {
       ReactInstrumentation.debugTool.onHostOperation({
-        instanceID: ReactDOMComponentTree.getInstanceFromNode(node)._debugID,
+        instanceID: debugID,
         type: 'remove attribute',
         payload: name,
       });

--- a/src/renderers/dom/shared/ReactDOMComponent.js
+++ b/src/renderers/dom/shared/ReactDOMComponent.js
@@ -963,6 +963,10 @@ ReactDOMComponent.Mixin = {
     transaction,
     isCustomComponentTag
   ) {
+    var debugID = 0;
+    if (__DEV__) {
+      debugID = this._debugID;
+    }
     var propKey;
     var styleName;
     var styleUpdates;
@@ -992,13 +996,14 @@ ReactDOMComponent.Mixin = {
         if (!RESERVED_PROPS.hasOwnProperty(propKey)) {
           DOMPropertyOperations.deleteValueForAttribute(
             getNode(this),
-            propKey
+            propKey,
+            debugID
           );
         }
       } else if (
           DOMProperty.properties[propKey] ||
           DOMProperty.isCustomAttribute(propKey)) {
-        DOMPropertyOperations.deleteValueForProperty(getNode(this), propKey);
+        DOMPropertyOperations.deleteValueForProperty(getNode(this), propKey, debugID);
       }
     }
     for (propKey in nextProps) {
@@ -1057,7 +1062,8 @@ ReactDOMComponent.Mixin = {
           DOMPropertyOperations.setValueForAttribute(
             getNode(this),
             propKey,
-            nextProp
+            nextProp,
+            debugID
           );
         }
       } else if (
@@ -1068,9 +1074,9 @@ ReactDOMComponent.Mixin = {
         // from the DOM node instead of inadvertently setting to a string. This
         // brings us in line with the same behavior we have on initial render.
         if (nextProp != null) {
-          DOMPropertyOperations.setValueForProperty(node, propKey, nextProp);
+          DOMPropertyOperations.setValueForProperty(node, propKey, nextProp, debugID);
         } else {
-          DOMPropertyOperations.deleteValueForProperty(node, propKey);
+          DOMPropertyOperations.deleteValueForProperty(node, propKey, debugID);
         }
       }
     }

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -14,7 +14,8 @@
 describe('DOMPropertyOperations', () => {
   var DOMPropertyOperations;
   var DOMProperty;
-  var ReactDOMComponentTree;
+
+  var debugID = 42;
 
   beforeEach(() => {
     jest.resetModuleRegistry();
@@ -23,7 +24,6 @@ describe('DOMPropertyOperations', () => {
 
     DOMPropertyOperations = require('DOMPropertyOperations');
     DOMProperty = require('DOMProperty');
-    ReactDOMComponentTree = require('ReactDOMComponentTree');
   });
 
   describe('createMarkupForProperty', () => {
@@ -174,21 +174,18 @@ describe('DOMPropertyOperations', () => {
 
   describe('setValueForProperty', () => {
     var stubNode;
-    var stubInstance;
 
     beforeEach(() => {
       stubNode = document.createElement('div');
-      stubInstance = {_debugID: 1};
-      ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
     });
 
     it('should set values as properties by default', () => {
-      DOMPropertyOperations.setValueForProperty(stubNode, 'title', 'Tip!');
+      DOMPropertyOperations.setValueForProperty(stubNode, 'title', 'Tip!', debugID);
       expect(stubNode.title).toBe('Tip!');
     });
 
     it('should set values as attributes if necessary', () => {
-      DOMPropertyOperations.setValueForProperty(stubNode, 'role', '#');
+      DOMPropertyOperations.setValueForProperty(stubNode, 'role', '#', debugID);
       expect(stubNode.getAttribute('role')).toBe('#');
       expect(stubNode.role).toBeUndefined();
     });
@@ -198,7 +195,8 @@ describe('DOMPropertyOperations', () => {
       DOMPropertyOperations.setValueForProperty(
         stubNode,
         'xlinkHref',
-        'about:blank'
+        'about:blank',
+        debugID
       );
       expect(stubNode.setAttributeNS.calls.count()).toBe(1);
       expect(stubNode.setAttributeNS.calls.argsFor(0))
@@ -206,11 +204,11 @@ describe('DOMPropertyOperations', () => {
     });
 
     it('should set values as boolean properties', () => {
-      DOMPropertyOperations.setValueForProperty(stubNode, 'disabled', 'disabled');
+      DOMPropertyOperations.setValueForProperty(stubNode, 'disabled', 'disabled', debugID);
       expect(stubNode.getAttribute('disabled')).toBe('');
-      DOMPropertyOperations.setValueForProperty(stubNode, 'disabled', true);
+      DOMPropertyOperations.setValueForProperty(stubNode, 'disabled', true, debugID);
       expect(stubNode.getAttribute('disabled')).toBe('');
-      DOMPropertyOperations.setValueForProperty(stubNode, 'disabled', false);
+      DOMPropertyOperations.setValueForProperty(stubNode, 'disabled', false, debugID);
       expect(stubNode.getAttribute('disabled')).toBe(null);
     });
 
@@ -222,15 +220,14 @@ describe('DOMPropertyOperations', () => {
           return '<html>';
         },
       };
-      DOMPropertyOperations.setValueForProperty(stubNode, 'role', obj);
+      DOMPropertyOperations.setValueForProperty(stubNode, 'role', obj, debugID);
       expect(stubNode.getAttribute('role')).toBe('<html>');
     });
 
     it('should not remove empty attributes for special properties', () => {
       stubNode = document.createElement('input');
-      ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
 
-      DOMPropertyOperations.setValueForProperty(stubNode, 'value', '');
+      DOMPropertyOperations.setValueForProperty(stubNode, 'value', '', debugID);
       // JSDOM does not behave correctly for attributes/properties
       //expect(stubNode.getAttribute('value')).toBe('');
       expect(stubNode.value).toBe('');
@@ -240,7 +237,8 @@ describe('DOMPropertyOperations', () => {
       DOMPropertyOperations.setValueForProperty(
         stubNode,
         'allowFullScreen',
-        false
+        false,
+        debugID
       );
       expect(stubNode.hasAttribute('allowFullScreen')).toBe(false);
     });
@@ -249,13 +247,15 @@ describe('DOMPropertyOperations', () => {
       DOMPropertyOperations.setValueForProperty(
         stubNode,
         'data-foo',
-        'bar'
+        'bar',
+        debugID
       );
       expect(stubNode.hasAttribute('data-foo')).toBe(true);
       DOMPropertyOperations.setValueForProperty(
         stubNode,
         'data-foo',
-        null
+        null,
+        debugID
       );
       expect(stubNode.hasAttribute('data-foo')).toBe(false);
     });
@@ -273,7 +273,8 @@ describe('DOMPropertyOperations', () => {
       DOMPropertyOperations.setValueForProperty(
         stubNode,
         'foobar',
-        'cows say moo'
+        'cows say moo',
+        debugID
       );
 
       expect(foobarSetter.mock.calls.length).toBe(1);
@@ -285,14 +286,16 @@ describe('DOMPropertyOperations', () => {
       DOMPropertyOperations.setValueForProperty(
         stubNode,
         'className',
-        'selected'
+        'selected',
+        debugID
       );
       expect(stubNode.className).toBe('selected');
 
       DOMPropertyOperations.setValueForProperty(
         stubNode,
         'className',
-        null
+        null,
+        debugID
       );
       // className should be '', not 'null' or null (which becomes 'null' in
       // some browsers)
@@ -304,14 +307,16 @@ describe('DOMPropertyOperations', () => {
       DOMPropertyOperations.setValueForProperty(
         stubNode,
         'hidden',
-        true
+        true,
+        debugID
       );
       expect(stubNode.hasAttribute('hidden')).toBe(true);
 
       DOMPropertyOperations.setValueForProperty(
         stubNode,
         'hidden',
-        false
+        false,
+        debugID
       );
       expect(stubNode.hasAttribute('hidden')).toBe(false);
     });
@@ -332,14 +337,16 @@ describe('DOMPropertyOperations', () => {
       DOMPropertyOperations.setValueForProperty(
         stubNode,
         'foobar',
-        'selected'
+        'selected',
+        debugID
       );
       expect(stubNode.className).toBe('selected');
 
       DOMPropertyOperations.setValueForProperty(
         stubNode,
         'foobar',
-        null
+        null,
+        debugID
       );
       // className should be '', not 'null' or null (which becomes 'null' in
       // some browsers)
@@ -350,20 +357,17 @@ describe('DOMPropertyOperations', () => {
 
   describe('deleteValueForProperty', () => {
     var stubNode;
-    var stubInstance;
 
     beforeEach(() => {
       stubNode = document.createElement('div');
-      stubInstance = {_debugID: 1};
-      ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
     });
 
     it('should remove attributes for normal properties', () => {
-      DOMPropertyOperations.setValueForProperty(stubNode, 'title', 'foo');
+      DOMPropertyOperations.setValueForProperty(stubNode, 'title', 'foo', debugID);
       expect(stubNode.getAttribute('title')).toBe('foo');
       expect(stubNode.title).toBe('foo');
 
-      DOMPropertyOperations.deleteValueForProperty(stubNode, 'title');
+      DOMPropertyOperations.deleteValueForProperty(stubNode, 'title', debugID);
       expect(stubNode.getAttribute('title')).toBe(null);
       // JSDOM does not behave correctly for attributes/properties
       //expect(stubNode.title).toBe('');
@@ -371,11 +375,9 @@ describe('DOMPropertyOperations', () => {
 
     it('should not remove attributes for special properties', () => {
       stubNode = document.createElement('input');
-      ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
-
       stubNode.setAttribute('value', 'foo');
 
-      DOMPropertyOperations.deleteValueForProperty(stubNode, 'value');
+      DOMPropertyOperations.deleteValueForProperty(stubNode, 'value', debugID);
       // JSDOM does not behave correctly for attributes/properties
       //expect(stubNode.getAttribute('value')).toBe('foo');
       expect(stubNode.value).toBe('');
@@ -383,7 +385,6 @@ describe('DOMPropertyOperations', () => {
 
     it('should not leave all options selected when deleting multiple', () => {
       stubNode = document.createElement('select');
-      ReactDOMComponentTree.precacheNode(stubInstance, stubNode);
 
       stubNode.multiple = true;
       stubNode.appendChild(document.createElement('option'));
@@ -391,7 +392,7 @@ describe('DOMPropertyOperations', () => {
       stubNode.options[0].selected = true;
       stubNode.options[1].selected = true;
 
-      DOMPropertyOperations.deleteValueForProperty(stubNode, 'multiple');
+      DOMPropertyOperations.deleteValueForProperty(stubNode, 'multiple', debugID);
       expect(stubNode.getAttribute('multiple')).toBe(null);
       expect(stubNode.multiple).toBe(false);
 


### PR DESCRIPTION
This builds on top of #7941 and adds basic support for setting DOM attributes.
Commit for review: 5a5bb86d1a6f59be61c5f9c54d00e208a99053c5.

Test plan: `examples/fiber/index.html` now can put `className` on a `div`:

<img width="228" alt="screen shot 2016-10-17 at 19 24 18" src="https://cloud.githubusercontent.com/assets/810438/19450334/eabe262c-94a0-11e6-8c16-155bb98c2c44.png">

`examples/basic/index.html` still works both with regular and minified builds.

There were a couple of issues:

* I needed `DOMProperty` so I had to inject `ReactDefaultInjection` which brought a bunch of the non-Fiber renderer into the Fiber build. I don't see a simpler workaround right now because we want to keep tests that test `ReactDOMFiber` alongside non-Fibery `ReactDOMServer`. Those are tricky to fix if we let both `ReactDOMFiber` and `ReactDOMServer` inject their own stuff independently. Another plausible option is to completely fork the files but it seemed excessive.

* I had to decouple `DOMPropertyOperations` from `ReactDOMComponentTree` so I added an explicit `debugID` argument to all methods.

This PR does include not support for events, web components, or style attribute. I figured I wouldn't waste time on this unless we agreed the approach is correct.

Fiber before this PR:

```
Test Suites: 73 failed, 46 passed, 119 total
Tests:       712 failed, 3 skipped, 736 passed, 1451 total
```

Fiber after this PR:

```
Test Suites: 73 failed, 46 passed, 119 total
Tests:       690 failed, 3 skipped, 758 passed, 1451 total
```
