### PR TITLE
[Fiber] Initial error boundaries

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -175,7 +175,12 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>, s
       var ctor = workInProgress.type;
       workInProgress.stateNode = instance = new ctor(props);
       mount(workInProgress, instance);
-      state = instance.state || null;
+      updateQueue = workInProgress.updateQueue;
+      if (updateQueue) {
+        state = mergeUpdateQueue(updateQueue, instance.state, props);
+      } else {
+        state = null;
+      }
     } else if (typeof instance.shouldComponentUpdate === 'function' &&
                !(updateQueue && updateQueue.isForced)) {
       if (workInProgress.memoizedProps !== null) {

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -80,6 +80,10 @@ module.exports = function(scheduleUpdate : (fiber: Fiber, priorityLevel : Priori
     // The instance needs access to the fiber so that it can schedule updates
     ReactInstanceMap.set(instance, workInProgress);
     instance.updater = updater;
+
+    if (typeof instance.componentWillMount === 'function') {
+      instance.componentWillMount();
+    }
   }
 
   return {

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -40,6 +40,7 @@ var {
 
 var {
   HostContainer,
+  ClassComponent,
 } = require('ReactTypeOfWork');
 
 var timeHeuristicForUnitOfWork = 1;
@@ -285,7 +286,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
     }
   }
 
-  function performDeferredWork(deadline) {
+  function performDeferredWorkUnsafe(deadline) {
     if (!nextUnitOfWork) {
       nextUnitOfWork = findNextUnitOfWork();
     }
@@ -299,6 +300,23 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
       } else {
         scheduleDeferredCallback(performDeferredWork);
         return;
+      }
+    }
+  }
+
+  function performDeferredWork(deadline) {
+    try {
+      performDeferredWorkUnsafe(deadline);
+    } catch (error) {
+      const failedUnitOfWork = nextUnitOfWork;
+      // Reset because it points to the error boundary:
+      nextUnitOfWork = null;
+      if (failedUnitOfWork) {
+        handleError(failedUnitOfWork, error);
+      } else {
+        // We shouldn't end up here because nextUnitOfWork
+        // should always be set while work is being performed.
+        throw error;
       }
     }
   }
@@ -334,7 +352,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
     }
   }
 
-  function performAnimationWork() {
+  function performAnimationWorkUnsafe() {
     // Always start from the root
     nextUnitOfWork = findNextUnitOfWork();
     while (nextUnitOfWork &&
@@ -348,6 +366,23 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
       if (nextPriorityLevel > AnimationPriority) {
         scheduleDeferredCallback(performDeferredWork);
         return;
+      }
+    }
+  }
+
+  function performAnimationWork() {
+    try {
+      performAnimationWorkUnsafe();
+    } catch (error) {
+      const failedUnitOfWork = nextUnitOfWork;
+      // Reset because it points to the error boundary:
+      nextUnitOfWork = null;
+      if (failedUnitOfWork) {
+        handleError(failedUnitOfWork, error);
+      } else {
+        // We shouldn't end up here because nextUnitOfWork
+        // should always be set while work is being performed.
+        throw error;
       }
     }
   }
@@ -423,6 +458,60 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
       fn();
     } finally {
       defaultPriority = previousDefaultPriority;
+    }
+  }
+
+  function findClosestErrorBoundary(fiber : Fiber): ?Fiber {
+    let maybeErrorBoundary = fiber.return;
+    while (maybeErrorBoundary) {
+      if (maybeErrorBoundary.tag === ClassComponent) {
+        const instance = maybeErrorBoundary.stateNode;
+        if (typeof instance.unstable_handleError === 'function') {
+          return maybeErrorBoundary;
+        }
+      }
+      maybeErrorBoundary = maybeErrorBoundary.return;
+    }
+    return null;
+  }
+
+  function handleError(failedUnitOfWork : Fiber, error : any) {
+    const errorBoundary = findClosestErrorBoundary(failedUnitOfWork);
+    if (errorBoundary) {
+      handleErrorInBoundary(errorBoundary, error);
+      return;
+    }
+    // TODO: Do we need to reset nextUnitOfWork here?
+    throw error;
+  }
+
+  function handleErrorInBoundary(errorBoundary : Fiber, error : any) {
+    // The work below failed so we need to clear it out and try to render the error state.
+    // TODO: Do we need to clear all of these fields? How do we teardown an existing tree?
+    errorBoundary.child = null;
+    errorBoundary.effectTag = NoEffect;
+    errorBoundary.nextEffect = null;
+    errorBoundary.firstEffect = null;
+    errorBoundary.lastEffect = null;
+    errorBoundary.progressedPriority = NoWork;
+    errorBoundary.progressedChild = null;
+    errorBoundary.progressedFirstDeletion = null;
+    errorBoundary.progressedLastDeletion = null;
+
+    // Error boundary implementations would usually call setState() here:
+    const instance = errorBoundary.stateNode;
+    instance.unstable_handleError(error);
+
+    try {
+      // The error path should be processed synchronously.
+      // This lets us easily propagate errors to a parent boundary.
+      let unitOfWork = errorBoundary;
+      while (unitOfWork) {
+        unitOfWork = performUnitOfWork(unitOfWork);
+      }
+    } catch (nextError) {
+      // Propagate error to the next boundary or rethrow.
+      handleError(errorBoundary, nextError);
     }
   }
 


### PR DESCRIPTION
This builds on top of #7941 + new tests I added in #7949 (hence the master merge commit).
It adds basic support for error boundaries during mount to Fiber.

Commit for review: 833a7f89427ff27fb14dc31ebdbcf47c247ed5af.

Test plan: `npm test -- ErrorB`.

```
 › Ran all tests matching "ErrorB".
 › 13 tests failed, 14 tests passed (27 total in 1 test suite, run time 1.545s)
```

Most of those 13 failing tests are failing because of the lack of `componentWillUpdate` and `componentWillReceiveProps`.

A few thoughts:

* This my first "real" Fiber PR so I have no idea what I'm doing.
* Adding a flag to all fibers seems bad. I'm not sure where to keep that state though. I need to store somewhere that we're "retrying" and if we fail, we should propagate error up. We used to rely on stack for this.
* I added some code to handle `setState` in `componentWillMount`.
* The part where I put the error flag and try to clear all work in progress is funny. Is there a better way?
* Neat: errors in `setState()` are now caught and I didn't have to do anything special to make that works 😄 .