### PR TITLE
Add @preventMunge directives to classes

### DIFF
--- a/src/renderers/testing/ReactTestEmptyComponent.js
+++ b/src/renderers/testing/ReactTestEmptyComponent.js
@@ -7,6 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule ReactTestEmptyComponent
+ * @preventMunge
  * @flow
  */
 
@@ -14,7 +15,7 @@
 
 class ReactTestEmptyComponent {
   _currentElement: null;
-  
+
   constructor() {
     this._currentElement = null;
   }

--- a/src/renderers/testing/ReactTestRenderer.js
+++ b/src/renderers/testing/ReactTestRenderer.js
@@ -7,6 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule ReactTestRenderer
+ * @preventMunge
  * @flow
  */
 

--- a/src/renderers/testing/ReactTestTextComponent.js
+++ b/src/renderers/testing/ReactTestTextComponent.js
@@ -7,6 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule ReactTestTextComponent
+ * @preventMunge
  * @flow
  */
 
@@ -16,7 +17,7 @@ import type { ReactText } from 'ReactTypes';
 
 class ReactTestTextComponent {
   _currentElement: ReactText;
-  
+
   constructor(element: ReactText) {
     this._currentElement = element;
   }

--- a/src/test/ReactShallowRenderer.js
+++ b/src/test/ReactShallowRenderer.js
@@ -7,6 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule ReactShallowRenderer
+ * @preventMunge
  */
 
 'use strict';


### PR DESCRIPTION
We refactored some code to use classes recently but our internal FB transform mangles their "private" method and property names, breaking the code. This directive fixes it.