### PR TITLE
[Fiber] Some setState related issues

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -160,15 +160,24 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>, s
     // Account for the possibly of missing pending props by falling back to the
     // memoized props.
     var props = workInProgress.pendingProps;
-    if (!props && current) {
-      props = current.memoizedProps;
+    if (!props) {
+      // If there isn't any new props, then we'll reuse the memoized props.
+      // This could be from already completed work.
+      props = workInProgress.memoizedProps;
+      if (!props) {
+        throw new Error('There should always be pending or memoized props.');
+      }
     }
+
     // Compute the state using the memoized state and the update queue.
     var updateQueue = workInProgress.updateQueue;
-    var previousState = current ? current.memoizedState : null;
-    var state = updateQueue ?
-      mergeUpdateQueue(updateQueue, previousState, props) :
-      previousState;
+    var previousState = workInProgress.memoizedState;
+    var state;
+    if (updateQueue) {
+      state = mergeUpdateQueue(updateQueue, previousState, props);
+    } else {
+      state = previousState;
+    }
 
     var instance = workInProgress.stateNode;
     if (!instance) {

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -601,6 +601,113 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ops).toEqual(['Baz', 'Bar', 'Baz', 'Bar', 'Bar']);
   });
 
+  it('deprioritizes setStates that happens within a deprioritized tree', () => {
+    var ops = [];
+
+    var barInstances = [];
+
+    class Bar extends React.Component {
+      constructor() {
+        super();
+        this.state = { active: false };
+        barInstances.push(this);
+      }
+      activate() {
+        this.setState({ active: true });
+      }
+      render() {
+        ops.push('Bar');
+        return <span prop={this.state.active ? 'X' : this.props.idx} />;
+      }
+    }
+    function Foo(props) {
+      ops.push('Foo');
+      return (
+        <div>
+          <span prop={props.tick} />
+          <div hidden={true}>
+            <Bar idx={props.idx} />
+            <Bar idx={props.idx} />
+            <Bar idx={props.idx} />
+          </div>
+        </div>
+      );
+    }
+    ReactNoop.render(<Foo tick={0} idx={0} />);
+    ReactNoop.flush();
+    expect(ReactNoop.root.children).toEqual([
+      div(
+        span(0),
+        div(
+          span(0),
+          span(0),
+          span(0)
+        )
+      ),
+    ]);
+
+    expect(ops).toEqual(['Foo', 'Bar', 'Bar', 'Bar']);
+
+    ops = [];
+
+    ReactNoop.render(<Foo tick={1} idx={0} />);
+    ReactNoop.flushDeferredPri(70);
+    expect(ReactNoop.root.children).toEqual([
+      div(
+        // Updated.
+        span(1),
+        div(
+          // Still not updated.
+          span(0),
+          span(0),
+          span(0)
+        )
+      ),
+    ]);
+
+    expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
+    ops = [];
+
+    barInstances[0].activate();
+
+    // This should not be enough time to render the content of all the hidden
+    // items. Including the set state since that is deprioritized.
+    // TODO: The cycles it takes to do this could be lowered with further
+    // optimizations.
+    ReactNoop.flushDeferredPri(60);
+    expect(ReactNoop.root.children).toEqual([
+      div(
+        // Updated.
+        span(1),
+        div(
+          // Still not updated.
+          span(0),
+          span(0),
+          span(0)
+        )
+      ),
+    ]);
+
+    expect(ops).toEqual(['Bar']);
+    ops = [];
+
+    // However, once we render fully, we will have enough time to finish it all
+    // at once.
+    ReactNoop.flush();
+    expect(ReactNoop.root.children).toEqual([
+      div(
+        span(1),
+        div(
+          // Now we had enough time to finish the spans.
+          span('X'),
+          span(0),
+          span(0),
+        )
+      ),
+    ]);
+
+    expect(ops).toEqual(['Bar', 'Bar']);
+  });
   // TODO: Test that side-effects are not cut off when a work in progress node
   // moves to "current" without flushing due to having lower priority. Does this
   // even happen? Maybe a child doesn't get processed because it is lower prio?

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -650,7 +650,7 @@ describe('ReactIncrementalSideEffects', () => {
 
     ops = [];
 
-    ReactNoop.render(<Foo tick={1} idx={0} />);
+    ReactNoop.render(<Foo tick={1} idx={1} />);
     ReactNoop.flushDeferredPri(70);
     expect(ReactNoop.root.children).toEqual([
       div(
@@ -700,8 +700,8 @@ describe('ReactIncrementalSideEffects', () => {
         div(
           // Now we had enough time to finish the spans.
           span('X'),
-          span(0),
-          span(0),
+          span(1),
+          span(1),
         )
       ),
     ]);


### PR DESCRIPTION
Use the memoized props/state from the workInProgress

We don't want to use the "current" props/state because if we have started work, then pause and continue then we'll have the newer props/state on it already. If it is not a resume, it should be the same as current.

Deprioritize setState within a deprioritized tree

Currently we flag the path to a setState as a higher priority than "offscreen". When we reconcile down this tree we bail out if it is a hidden node. However, in the case that node is already completed we don't hit that bail out path. We end up doing the work immediately which ends up committing that part of the tree at a higher priority.

This ensures that we don't let a deprioritized subtree get reconciled at a higher priority.