### PR TITLE
Correctly render placeholder for textarea in IE11

### DIFF
--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -461,20 +461,6 @@ function isCustomComponent(tagName, props) {
   return tagName.indexOf('-') >= 0 || props.is != null;
 }
 
-function shouldSetNodeTextContent(lazyTree, props, text) {
-  // TODO: Validate that text is allowed as a child of this node
-  var node = lazyTree.node;
-  // Avoid setting textContent on textareas when the text is empty
-  // and there is a placeholder. In IE11 setting textContent will cause
-  // the placeholder to not show within the textarea until it has been
-  // focused and blurred again.
-  // https://github.com/facebook/react/issues/6731#issuecomment-254874553
-  if (node.type === 'textarea' && props.placeholder && text === '') {
-    return false;
-  }
-  return true;
-}
-
 var globalIdCounter = 1;
 
 /**
@@ -861,8 +847,13 @@ ReactDOMComponent.Mixin = {
       var contentToUse =
         CONTENT_TYPES[typeof props.children] ? props.children : null;
       var childrenToUse = contentToUse != null ? null : props.children;
+      // TODO: Validate that text is allowed as a child of this node
       if (contentToUse != null) {
-        if (shouldSetNodeTextContent(lazyTree, props, contentToUse)) {
+        // Avoid setting textContent when the text is empty. In IE11 setting
+        // textContent on a text area will cause the placeholder to not
+        // show within the textarea until it has been focused and blurred again.
+        // https://github.com/facebook/react/issues/6731#issuecomment-254874553
+        if (contentToUse !== '') {
           if (__DEV__) {
             setAndValidateContentChildDev.call(this, contentToUse);
           }

--- a/src/renderers/dom/stack/client/wrappers/ReactDOMTextarea.js
+++ b/src/renderers/dom/stack/client/wrappers/ReactDOMTextarea.js
@@ -159,9 +159,15 @@ var ReactDOMTextarea = {
     // This is in postMount because we need access to the DOM node, which is not
     // available until after the component has mounted.
     var node = ReactDOMComponentTree.getNodeFromInstance(inst);
+    var textContent = node.textContent;
 
-    // Warning: node.value may be the empty string at this point (IE11) if placeholder is set.
-    node.value = node.textContent; // Detach value from defaultValue
+    // Only set node.value if textContent is equal to the expected
+    // initial value. In IE10/IE11 there is a bug where the placeholder attribute
+    // will populate textContent as well.
+    // https://developer.microsoft.com/microsoft-edge/platform/issues/101525/
+    if (textContent === inst._wrapperState.initialValue) {
+      node.value = textContent;
+    }
   },
 };
 


### PR DESCRIPTION
Resolves https://github.com/facebook/react/issues/6731

In IE11, setting the `node.placeholder` will also set `node.textContent`, so when we ended up setting `textContent` to `""` via `DOMLazyTree.queueText` in in `_createInitialChildren` , it caused the placeholder to never show up.

https://github.com/facebook/react/commit/18d418aa05acd2f3f895014e1652914a4c8cc651 resolves this by checking if the `<textarea/>` has a `placeholder` and `text` is empty. If it is, it skips `queueText`.

We were also unconditionally setting `node.value = node.textContent`, which before https://github.com/facebook/react/commit/18d418aa05acd2f3f895014e1652914a4c8cc651 just meant we'd set it to an empty string, but now we're setting `node.value` equal to the placeholder in IE11.

https://github.com/facebook/react/commit/07998a5e5c634f3b25ad21fff6d0b7a34856360f resolves this by only setting `node.value` if `textContent` is our expected `initialValue`.
#### Test plan

Tested with [this component](https://gist.github.com/Aweary/7797aa519c2190c8c5b820200012de37), which contains uncontrolled/controlled `<textarea/>`s with and without `defaultValue`/`placeholder`

Tested in the following browsers: 
- IE10
- IE11
- Firefox 49
- Chrome 53
- Safari 9
- Safari 10
- iOS 9 (Safari)
- iOS 8 (Safari)

cc @spicyj @sebmarkbage
