### PR TITLE
[Fiber] Don't call componentDidUpdate if shouldComponentUpdate returns false

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -129,7 +129,14 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
         // Transfer update queue to callbackList field so callbacks can be
         // called during commit phase.
         workInProgress.callbackList = workInProgress.updateQueue;
-        markUpdate(workInProgress);
+        if (current) {
+          if (current.memoizedProps !== workInProgress.memoizedProps ||
+              current.memoizedState !== workInProgress.memoizedState) {
+            markUpdate(workInProgress);
+          }
+        } else {
+          markUpdate(workInProgress);
+        }
         return null;
       case HostContainer:
         transferOutput(workInProgress.child, workInProgress);


### PR DESCRIPTION
Builds on #8015

This fix relies on the props and state objects being different to know if we can avoid a componentDidUpdate. This is not a great solution because we actually want to use the new props/state object even if sCU returns false. That's the current semantics and it can actually be important because new parent rerenders that are able to reuse props objects are more likely to have the new props object so we won't be able to quickly bail out next time. For example:

```js
class Foo extends React.Component {
  state = { tick: 0 };
  componentDidMount() {
    setInterval(() => this.setState({ tick: this.state.tick + 1 }));
  }
  render() {
     return this.props.children;
  }
}
```

I don't have a better idea atm though.