### PR TITLE
fix yaml redirect syntax

### DIFF
--- a/docs/docs/components-and-props.md
+++ b/docs/docs/components-and-props.md
@@ -2,10 +2,11 @@
 id: components-and-props
 title: Components and Props
 permalink: docs/components-and-props.html
-redirect_from: "/docs/reusable-components.html"
-redirect_from: "/docs/transferring-props.html"
-redirect_from: "/tips/props-in-getInitialState-as-anti-pattern.html"
-redirect_from: "/tips/communicate-between-components.html"
+redirect_from:
+  - "/docs/reusable-components.html"
+  - "/docs/transferring-props.html"
+  - "/tips/props-in-getInitialState-as-anti-pattern.html"
+  - "/tips/communicate-between-components.html"
 prev: rendering-elements.html
 next: state-and-lifecycle.html
 ---

--- a/docs/docs/hello-world.md
+++ b/docs/docs/hello-world.md
@@ -4,8 +4,9 @@ title: Hello World
 permalink: docs/hello-world.html
 prev: installation.html
 next: introducing-jsx.html
-redirect_from: "docs/index.html"
-redirect_from: "docs/getting-started.html"
+redirect_from:
+  - "docs/index.html"
+  - "docs/getting-started.html"
 ---
 
 The easiest way to get started with React is to use [this Hello World example code on CodePen](http://codepen.io/gaearon/pen/ZpvBNJ?editors=0010). You don't need to install anything; you can just open it in another tab and follow along as we go through examples. If you'd rather use a local development environment, check out the [Installation](/docs/installation.html) page.

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -2,11 +2,12 @@
 id: installation
 title: Installation
 permalink: docs/installation.html
-redirect_from: "downloads.html"
-redirect_from: "docs/tooling-integration.html"
-redirect_from: "/docs/package-management.html"
-redirect_from: "/docs/language-tooling.html"
-redirect_from: "/docs/environments.html"
+redirect_from:
+  - "downloads.html"
+  - "docs/tooling-integration.html"
+  - "/docs/package-management.html"
+  - "/docs/language-tooling.html"
+  - "/docs/environments.html"
 next: hello-world.html
 ---
 

--- a/docs/docs/jsx-in-depth.md
+++ b/docs/docs/jsx-in-depth.md
@@ -2,12 +2,13 @@
 id: jsx-in-depth
 title: JSX In Depth
 permalink: docs/jsx-in-depth.html
-redirect_from: "/docs/jsx-spread.html"
-redirect_from: "/docs/jsx-gotchas.html"
-redirect_from: "/tips/if-else-in-JSX.html"
-redirect_from: "/tips/self-closing-tag.html"
-redirect_from: "/tips/maximum-number-of-jsx-root-nodes.html"
-redirect_from: "/tips/children-props-type.html"
+redirect_from:
+  - "/docs/jsx-spread.html"
+  - "/docs/jsx-gotchas.html"
+  - "/tips/if-else-in-JSX.html"
+  - "/tips/self-closing-tag.html"
+  - "/tips/maximum-number-of-jsx-root-nodes.html"
+  - "/tips/children-props-type.html"
 ---
 
 Fundamentally, JSX just provides syntactic sugar for the `React.createElement(component, props, ...children)` function. The JSX code:

--- a/docs/docs/reference-dom-elements.md
+++ b/docs/docs/reference-dom-elements.md
@@ -4,12 +4,13 @@ title: DOM Elements
 layout: docs
 category: Reference
 permalink: docs/dom-elements.html
-redirect_from: "/docs/tags-and-attributes.html"
-redirect_from: "/docs/dom-differences.html"
-redirect_from: "/docs/special-non-dom-attributes.html"
-redirect_from: "/tips/inline-styles.html"
-redirect_from: "/tips/style-props-value-px.html"
-redirect_from: "/tips/dangerously-set-inner-html.html"
+redirect_from:
+  - "/docs/tags-and-attributes.html"
+  - "/docs/dom-differences.html"
+  - "/docs/special-non-dom-attributes.html"
+  - "/tips/inline-styles.html"
+  - "/tips/style-props-value-px.html"
+  - "/tips/dangerously-set-inner-html.html"
 ---
 
 React implements a browser-independent DOM system for performance and cross-browser compatibility. We took the opportunity to clean up a few rough edges in browser DOM implementations.

--- a/docs/docs/reference-react-component.md
+++ b/docs/docs/reference-react-component.md
@@ -4,12 +4,13 @@ title: React.Component
 layout: docs
 category: Reference
 permalink: docs/react-component.html
-redirect_from: "/docs/component-api.html"
-redirect_from: "/docs/component-specs.html"
-redirect_from: "/tips/componentWillReceiveProps-not-triggered-after-mounting.html"
-redirect_from: "/tips/dom-event-listeners.html"
-redirect_from: "/tips/initial-ajax.html"
-redirect_from: "/tips/use-react-with-other-libraries.html"
+redirect_from:
+  - "/docs/component-api.html"
+  - "/docs/component-specs.html"
+  - "/tips/componentWillReceiveProps-not-triggered-after-mounting.html"
+  - "/tips/dom-event-listeners.html"
+  - "/tips/initial-ajax.html"
+  - "/tips/use-react-with-other-libraries.html"
 ---
 
 [Components](/react/docs/components-and-props.html) let you split the UI into independent, reusable pieces, and think about each piece in isolation. `React.Component` is provided by [`React`](/react/docs/react-api.html).

--- a/docs/docs/reference-react.md
+++ b/docs/docs/reference-react.md
@@ -4,10 +4,11 @@ title: React Top-Level API
 layout: docs
 category: Reference
 permalink: docs/react-api.html
-redirect_from: "/docs/reference.html"
-redirect_from: "/docs/clone-with-props.html"
-redirect_from: "/docs/top-level-api.html"
-redirect_from: "/docs/glossary.html"
+redirect_from:
+  - "/docs/reference.html"
+  - "/docs/clone-with-props.html"
+  - "/docs/top-level-api.html"
+  - "/docs/glossary.html"
 ---
 
 `React` is the entry point to the React library. If you use React as a script tag, these top-level APIs are available on the `React` global. If you use ES6 with npm, you can write `import React from 'react'`. If you use ES5 with npm, you can write `var React = require('react')`.

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -1,10 +1,11 @@
 ---
 id: refs-and-the-dom
 title: Refs and the DOM
-redirect_from: "/docs/working-with-the-browser.html"
-redirect_from: "/docs/more-about-refs.html"
-redirect_from: "/tips/expose-component-functions.html"
-redirect_from: "/tips/children-undefined.html"
+redirect_from:
+  - "/docs/working-with-the-browser.html"
+  - "/docs/more-about-refs.html"
+  - "/tips/expose-component-functions.html"
+  - "/tips/children-undefined.html"
 permalink: docs/refs-and-the-dom.html
 ---
 

--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -4,8 +4,9 @@ title: "Tutorial: Intro To React"
 layout: tutorial
 sectionid: tutorial
 permalink: /tutorial/tutorial.html
-redirect_from: "/docs/tutorial.html"
-redirect_from: "/docs/why-react.html"
+redirect_from:
+  - "/docs/tutorial.html"
+  - "/docs/why-react.html"
 ---
 
 ## What We're Building


### PR DESCRIPTION
I had the yaml syntax for redirect_from wrong, thus breaking all but the last redirect in these redirect lists.