### PR TITLE
Fix anchor link for displayName

### DIFF
--- a/docs/docs/reference-react-component.md
+++ b/docs/docs/reference-react-component.md
@@ -70,7 +70,7 @@ Each component also provides some other APIs:
 ### Class Properties
 
   - [`defaultProps`](#defaultprops)
-  - [`displayName`](#displayName)
+  - [`displayName`](#displayname)
   - [`propTypes`](#proptypes)
 
 ### Instance Properties


### PR DESCRIPTION
Fix the anchor link for Class Properties 'displayName' section.