### PR TITLE
Fix relative link in Hello World

### DIFF
--- a/docs/docs/hello-world.md
+++ b/docs/docs/hello-world.md
@@ -9,7 +9,7 @@ redirect_from:
   - "docs/getting-started.html"
 ---
 
-The easiest way to get started with React is to use [this Hello World example code on CodePen](http://codepen.io/gaearon/pen/ZpvBNJ?editors=0010). You don't need to install anything; you can just open it in another tab and follow along as we go through examples. If you'd rather use a local development environment, check out the [Installation](../docs/installation.html) page.
+The easiest way to get started with React is to use [this Hello World example code on CodePen](http://codepen.io/gaearon/pen/ZpvBNJ?editors=0010). You don't need to install anything; you can just open it in another tab and follow along as we go through examples. If you'd rather use a local development environment, check out the [Installation](installation.html) page.
 
 The smallest React example looks like this:
 

--- a/docs/docs/hello-world.md
+++ b/docs/docs/hello-world.md
@@ -9,7 +9,7 @@ redirect_from:
   - "docs/getting-started.html"
 ---
 
-The easiest way to get started with React is to use [this Hello World example code on CodePen](http://codepen.io/gaearon/pen/ZpvBNJ?editors=0010). You don't need to install anything; you can just open it in another tab and follow along as we go through examples. If you'd rather use a local development environment, check out the [Installation](/docs/installation.html) page.
+The easiest way to get started with React is to use [this Hello World example code on CodePen](http://codepen.io/gaearon/pen/ZpvBNJ?editors=0010). You don't need to install anything; you can just open it in another tab and follow along as we go through examples. If you'd rather use a local development environment, check out the [Installation](../docs/installation.html) page.
 
 The smallest React example looks like this:
 

--- a/docs/docs/hello-world.md
+++ b/docs/docs/hello-world.md
@@ -9,7 +9,7 @@ redirect_from:
   - "docs/getting-started.html"
 ---
 
-The easiest way to get started with React is to use [this Hello World example code on CodePen](http://codepen.io/gaearon/pen/ZpvBNJ?editors=0010). You don't need to install anything; you can just open it in another tab and follow along as we go through examples. If you'd rather use a local development environment, check out the [Installation](installation.html) page.
+The easiest way to get started with React is to use [this Hello World example code on CodePen](http://codepen.io/gaearon/pen/ZpvBNJ?editors=0010). You don't need to install anything; you can just open it in another tab and follow along as we go through examples. If you'd rather use a local development environment, check out the [Installation](/react/docs/installation.html) page.
 
 The smallest React example looks like this:
 


### PR DESCRIPTION
This links https://facebook.github.io/docs/installation.html which redirects to https://code.facebook.com/

cc @lacker @hramos 