### PR TITLE
Fix erroneous '}' in JSX examples

### DIFF
--- a/docs/docs/jsx-in-depth.md
+++ b/docs/docs/jsx-in-depth.md
@@ -70,7 +70,7 @@ var MyComponents = {
 }
 
 function BlueDatePicker() {
-  return <MyComponents.DatePicker color="blue"} />;
+  return <MyComponents.DatePicker color="blue" />;
 }
 ```
 

--- a/docs/docs/reconciliation.md
+++ b/docs/docs/reconciliation.md
@@ -117,14 +117,14 @@ In order to solve this issue, React supports a `key` attribute. When children ha
 
 ```xml
 <ul>
-  <li key="2015"}>Duke</li>
-  <li key="2016"}>Villanova</li>
+  <li key="2015">Duke</li>
+  <li key="2016">Villanova</li>
 </ul>
 
 <ul>
-  <li key="2014"}>Connecticut</li>
-  <li key="2015"}>Duke</li>
-  <li key="2016"}>Villanova</li>
+  <li key="2014">Connecticut</li>
+  <li key="2015">Duke</li>
+  <li key="2016">Villanova</li>
 </ul>
 ```
 


### PR DESCRIPTION
Removed erroneous `}` in JSX examples for:
- `docs/docs/jsx-in-depth.md`
- `docs/docs/reconciliation.md`

