### PR TITLE
Fix typo in tutorial.md

### DIFF
--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -204,7 +204,7 @@ Square no longer keeps its own state; it receives its value from its parent `Boa
 
 ## Why Immutability Is Important
 
-In the previous code example, I suggest using the `.slice()` operator to copy the `squares` array prior to making changges and to prevent mutating the existing array. Let's talk about what this means and why it an important concept to learn.
+In the previous code example, I suggest using the `.slice()` operator to copy the `squares` array prior to making changes and to prevent mutating the existing array. Let's talk about what this means and why it an important concept to learn.
 
 There are generally two ways for changing data. The first, and most common method in past, has been to *mutate* the data by directly changing the values of a variable. The second method is to replace the data with a new copy of the object that also includes desired changes.
 


### PR DESCRIPTION
In "Why Immutability Is Important" section,
`changges` -> `changes`