### PR TITLE
Fix illogical code in tutorial.md

### DIFF
--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -414,7 +414,7 @@ const moves = history.map((step, move) => {
     'Move #' + move :
     'Game start';
   return (
-    <li key={move}>
+    <li>
       <a href="#" onClick={() => this.jumpTo(move)}>{desc}</a>
     </li>
   );


### PR DESCRIPTION
The tutorial wants to throw a `warning` and explains about `key` of React's list, but it throws nothing since there is sensible key.

`key={move}` should be removed, and added after explaining about key.