### PR TITLE
Remove unused injectComponentClasses and tagToComponentClass

### DIFF
--- a/src/renderers/shared/stack/reconciler/ReactHostComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactHostComponent.js
@@ -43,12 +43,20 @@ var ReactHostComponentInjection = {
  * @return {function} The internal class constructor function.
  */
 function createInternalComponent(element) {
-  invariant(
-    genericComponentClass,
-    'There is no registered component for the tag %s',
-    element.type
-  );
-  return new genericComponentClass(element);
+  var internalComponent;
+
+  if (tagToComponentClass[element.type]) {
+    internalComponent = new tagToComponentClass[element.type](element);
+  } else {
+    invariant(
+      genericComponentClass,
+      'There is no registered component for the tag %s',
+      element.type
+    );
+    internalComponent = new genericComponentClass(element);
+  }
+
+  return internalComponent;
 }
 
 /**

--- a/src/renderers/shared/stack/reconciler/ReactHostComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactHostComponent.js
@@ -14,8 +14,6 @@
 var invariant = require('invariant');
 
 var genericComponentClass = null;
-// This registry keeps track of wrapper classes around host tags.
-var tagToComponentClass = {};
 var textComponentClass = null;
 
 var ReactHostComponentInjection = {
@@ -29,11 +27,6 @@ var ReactHostComponentInjection = {
   injectTextComponentClass: function(componentClass) {
     textComponentClass = componentClass;
   },
-  // This accepts a keyed object with classes as values. Each key represents a
-  // tag. That particular tag will use this class instead of the generic one.
-  injectComponentClasses: function(componentClasses) {
-    Object.assign(tagToComponentClass, componentClasses);
-  },
 };
 
 /**
@@ -43,20 +36,12 @@ var ReactHostComponentInjection = {
  * @return {function} The internal class constructor function.
  */
 function createInternalComponent(element) {
-  var internalComponent;
-
-  if (tagToComponentClass[element.type]) {
-    internalComponent = new tagToComponentClass[element.type](element);
-  } else {
-    invariant(
-      genericComponentClass,
-      'There is no registered component for the tag %s',
-      element.type
-    );
-    internalComponent = new genericComponentClass(element);
-  }
-
-  return internalComponent;
+  invariant(
+    genericComponentClass,
+    'There is no registered component for the tag %s',
+    element.type
+  );
+  return new genericComponentClass(element);
 }
 
 /**


### PR DESCRIPTION
tagToComponentClass attribute of [ReactHostComponent](https://github.com/facebook/react/blob/master/src/renderers/shared/stack/reconciler/ReactHostComponent.js#L18) is not being used when [creating an internal component](https://github.com/facebook/react/blob/master/src/renderers/shared/stack/reconciler/ReactHostComponent.js#L51), making useless to inject a Host Component class by the tag name.

The reconciler should check if there is a proper class implementation for a specific tag, and if not, return a generic component class instance.

