### PR TITLE
Updated tutorial.md

### DIFF
--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -402,7 +402,7 @@ handleClick(i) {
 }
 ```
 
-At this point, Board only needs `renderStep` and `render`; the state initialization and click handler should both live in Game.
+At this point, Board only needs `renderSquare` and `render`; the state initialization and click handler should both live in Game.
 
 ## Showing the Moves
 
@@ -414,7 +414,7 @@ const moves = history.map((step, move) => {
     'Move #' + move :
     'Game start';
   return (
-    <li key={move}>
+    <li>
       <a href="#" onClick={() => this.jumpTo(move)}>{desc}</a>
     </li>
   );


### PR DESCRIPTION
Fixed method name (renderStep -> renderSquare).
Removed key attribute in li element to present the warning described below the code fragment.