### PR TITLE
Fix: Remove unneeded else branches from documentation examples

### DIFF
--- a/docs/docs/conditional-rendering.md
+++ b/docs/docs/conditional-rendering.md
@@ -30,9 +30,8 @@ function Greeting(props) {
   const isLoggedIn = props.isLoggedIn;
   if (isLoggedIn) {
     return <UserGreeting />;
-  } else {
-    return <GuestGreeting />;
   }
+  return <GuestGreeting />;
 }
 
 ReactDOM.render(

--- a/docs/docs/introducing-jsx.md
+++ b/docs/docs/introducing-jsx.md
@@ -59,7 +59,7 @@ This means that you can use JSX inside of `if` statements and `for` loops, assig
 ```js{3,5}
 function getGreeting(user) {
   if (user) {
-    return <h1>Hello, {formatName(user.name)}!</h1>;
+    return <h1>Hello, {formatName(user)}!</h1>;
   }
   return <h1>Hello, Stranger.</h1>;
 }

--- a/docs/docs/introducing-jsx.md
+++ b/docs/docs/introducing-jsx.md
@@ -60,9 +60,8 @@ This means that you can use JSX inside of `if` statements and `for` loops, assig
 function getGreeting(user) {
   if (user) {
     return <h1>Hello, {formatName(user.name)}!</h1>;
-  } else {
-    return <h1>Hello, Stranger.</h1>;
   }
+  return <h1>Hello, Stranger.</h1>;
 }
 ```
 

--- a/docs/docs/lifting-state-up.md
+++ b/docs/docs/lifting-state-up.md
@@ -16,9 +16,8 @@ We will start with a component called `BoilingVerdict`. It accepts the `celsius`
 function BoilingVerdict(props) {
   if (props.celsius >= 100) {
     return <p>The water would boil.</p>;
-  } else {
-    return <p>The water would not boil.</p>;
   }
+  return <p>The water would not boil.</p>;
 }
 ```
 


### PR DESCRIPTION
This PR

* [x] removes unneeded `else` branches from documentation examples

💁‍♂️ As we are returning in the `if` branches, there's no need for an `else` here.