### PR TITLE
[Fiber] Add types for ReactFiber and ReactChildFiber

### DIFF
--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -71,7 +71,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
   function deleteChild(
     returnFiber : Fiber,
     childToDelete : Fiber
-  ) {
+  ) : void {
     if (!shouldTrackSideEffects) {
       // Noop.
       return;
@@ -102,7 +102,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
   function deleteRemainingChildren(
     returnFiber : Fiber,
     currentFirstChild : ?Fiber
-  ) {
+  ) : null {
     if (!shouldTrackSideEffects) {
       // Noop.
       return null;
@@ -139,7 +139,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     return existingChildren;
   }
 
-  function useFiber(fiber : Fiber, priority : PriorityLevel) {
+  function useFiber(fiber : Fiber, priority : PriorityLevel) : Fiber {
     // We currently set sibling to null and index to 0 here because it is easy
     // to forget to do before returning it. E.g. for the single child case.
     if (shouldClone) {
@@ -159,7 +159,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     }
   }
 
-  function placeChild(newFiber : Fiber, lastPlacedIndex : number, newIndex : number) {
+  function placeChild(newFiber : Fiber, lastPlacedIndex : number, newIndex : number) : number {
     newFiber.index = newIndex;
     if (!shouldTrackSideEffects) {
       // Noop.
@@ -183,7 +183,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     }
   }
 
-  function placeSingleChild(newFiber : Fiber) {
+  function placeSingleChild(newFiber : Fiber) : Fiber {
     // This is simpler for the single child case. We only need to do a
     // placement for inserting new children.
     if (shouldTrackSideEffects && !newFiber.alternate) {
@@ -217,7 +217,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     current : ?Fiber,
     element : ReactElement<any>,
     priority : PriorityLevel
-  ) {
+  ) : Fiber {
     if (current == null || current.type !== element.type) {
       // Insert
       const created = createFiberFromElement(element, priority);
@@ -239,7 +239,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     current : ?Fiber,
     coroutine : ReactCoroutine,
     priority : PriorityLevel
-  ) {
+  ) : Fiber {
     // TODO: Should this also compare handler to determine whether to reuse?
     if (current == null || current.tag !== CoroutineComponent) {
       // Insert
@@ -260,7 +260,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     current : ?Fiber,
     yieldNode : ReactYield,
     priority : PriorityLevel
-  ) {
+  ) : Fiber {
     // TODO: Should this also compare continuation to determine whether to reuse?
     if (current == null || current.tag !== YieldComponent) {
       // Insert
@@ -286,7 +286,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     current : ?Fiber,
     fragment : Iterable<*>,
     priority : PriorityLevel
-  ) {
+  ) : Fiber {
     if (current == null || current.tag !== Fragment) {
       // Insert
       const created = createFiberFromFragment(fragment, priority);
@@ -461,7 +461,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     returnFiber : Fiber,
     currentFirstChild : ?Fiber,
     newChildren : Array<*>,
-    priority : PriorityLevel) {
+    priority : PriorityLevel) : ?Fiber {
 
     // This algorithm can't optimize by searching from boths ends since we
     // don't have backpointers on fibers. I'm trying to see how far we can get
@@ -600,7 +600,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     returnFiber : Fiber,
     currentFirstChild : ?Fiber,
     newChildren : Iterator<*>,
-    priority : PriorityLevel) {
+    priority : PriorityLevel) : null {
     // TODO: Copy everything from reconcileChildrenArray but use the iterator
     // instead.
     return null;
@@ -611,7 +611,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     currentFirstChild : ?Fiber,
     textContent : string,
     priority : PriorityLevel
-  ) {
+  ) : Fiber {
     // There's no need to check for keys on text nodes since we don't have a
     // way to define them.
     if (currentFirstChild && currentFirstChild.tag === HostText) {
@@ -636,7 +636,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     currentFirstChild : ?Fiber,
     element : ReactElement<any>,
     priority : PriorityLevel
-  ) {
+  ) : Fiber {
     const key = element.key;
     let child = currentFirstChild;
     while (child) {
@@ -671,7 +671,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     currentFirstChild : ?Fiber,
     coroutine : ReactCoroutine,
     priority : PriorityLevel
-  ) {
+  ) : Fiber {
     const key = coroutine.key;
     let child = currentFirstChild;
     while (child) {
@@ -704,7 +704,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     currentFirstChild : ?Fiber,
     yieldNode : ReactYield,
     priority : PriorityLevel
-  ) {
+  ) : Fiber {
     const key = yieldNode.key;
     let child = currentFirstChild;
     while (child) {
@@ -820,7 +820,7 @@ exports.reconcileChildFibersInPlace = ChildReconciler(false, true);
 
 exports.mountChildFibersInPlace = ChildReconciler(false, false);
 
-exports.cloneChildFibers = function(current : ?Fiber, workInProgress : Fiber) {
+exports.cloneChildFibers = function(current : ?Fiber, workInProgress : Fiber) : void {
   if (!workInProgress.child) {
     return;
   }

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -259,12 +259,12 @@ exports.cloneFiber = function(fiber : Fiber, priorityLevel : PriorityLevel) : Fi
   return alt;
 };
 
-exports.createHostContainerFiber = function() {
+exports.createHostContainerFiber = function() : Fiber {
   const fiber = createFiber(HostContainer, null);
   return fiber;
 };
 
-exports.createFiberFromElement = function(element : ReactElement<*>, priorityLevel : PriorityLevel) {
+exports.createFiberFromElement = function(element : ReactElement<*>, priorityLevel : PriorityLevel) : Fiber {
 // $FlowFixMe: ReactElement.key is currently defined as ?string but should be defined as null | string in Flow.
   const fiber = createFiberFromElementType(element.type, element.key);
   fiber.pendingProps = element.props;
@@ -272,7 +272,7 @@ exports.createFiberFromElement = function(element : ReactElement<*>, priorityLev
   return fiber;
 };
 
-exports.createFiberFromFragment = function(elements : ReactFragment, priorityLevel : PriorityLevel) {
+exports.createFiberFromFragment = function(elements : ReactFragment, priorityLevel : PriorityLevel) : Fiber {
   // TODO: Consider supporting keyed fragments. Technically, we accidentally
   // support that in the existing React.
   const fiber = createFiber(Fragment, null);
@@ -281,14 +281,14 @@ exports.createFiberFromFragment = function(elements : ReactFragment, priorityLev
   return fiber;
 };
 
-exports.createFiberFromText = function(content : string, priorityLevel : PriorityLevel) {
+exports.createFiberFromText = function(content : string, priorityLevel : PriorityLevel) : Fiber {
   const fiber = createFiber(HostText, null);
   fiber.pendingProps = content;
   fiber.pendingWorkPriority = priorityLevel;
   return fiber;
 };
 
-function createFiberFromElementType(type : mixed, key : null | string) {
+function createFiberFromElementType(type : mixed, key : null | string) : Fiber {
   let fiber;
   if (typeof type === 'function') {
     fiber = shouldConstruct(type) ?
@@ -314,7 +314,7 @@ function createFiberFromElementType(type : mixed, key : null | string) {
 
 exports.createFiberFromElementType = createFiberFromElementType;
 
-exports.createFiberFromCoroutine = function(coroutine : ReactCoroutine, priorityLevel : PriorityLevel) {
+exports.createFiberFromCoroutine = function(coroutine : ReactCoroutine, priorityLevel : PriorityLevel) : Fiber {
   const fiber = createFiber(CoroutineComponent, coroutine.key);
   fiber.type = coroutine.handler;
   fiber.pendingProps = coroutine;
@@ -322,7 +322,7 @@ exports.createFiberFromCoroutine = function(coroutine : ReactCoroutine, priority
   return fiber;
 };
 
-exports.createFiberFromYield = function(yieldNode : ReactYield, priorityLevel : PriorityLevel) {
+exports.createFiberFromYield = function(yieldNode : ReactYield, priorityLevel : PriorityLevel) : Fiber {
   const fiber = createFiber(YieldComponent, yieldNode.key);
   fiber.pendingProps = {};
   return fiber;


### PR DESCRIPTION
It might be unnecessary because Flow can infer their return types.
But I think the type annotations for ReactFiber in this is valuable because it's module boundaries.