### PR TITLE
fix: typo in list-and-keys.md

### DIFF
--- a/docs/docs/lists-and-keys.md
+++ b/docs/docs/lists-and-keys.md
@@ -154,7 +154,7 @@ function ListItem(props) {
 function NumberList(props) {
   const numbers = props.numbers;
   const listItems = numbers.map((item) =>
-    // Right! The key should have been specified here:
+    // Correct! The key should have been specified here:
     <ListItem value={number} />
   );
   return (

--- a/docs/docs/lists-and-keys.md
+++ b/docs/docs/lists-and-keys.md
@@ -154,7 +154,7 @@ function ListItem(props) {
 function NumberList(props) {
   const numbers = props.numbers;
   const listItems = numbers.map((item) =>
-    // Wrong! The key should have been specified here:
+    // Right! The key should have been specified here:
     <ListItem value={number} />
   );
   return (


### PR DESCRIPTION
This changes a 'Wrong!' in the list-and-keys documentation to 'Right!' and it makes more sense.

Hope this helps 🌞 
