### PR TITLE
Respect state set in componentWillMount() on resuming

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -152,7 +152,7 @@ module.exports = function(scheduleUpdate : (fiber: Fiber, priorityLevel : Priori
       // process them now.
       const newUpdateQueue = workInProgress.updateQueue;
       if (newUpdateQueue) {
-        instance.state = mergeUpdateQueue(newUpdateQueue, newState, newProps);
+        newInstance.state = mergeUpdateQueue(newUpdateQueue, newState, newProps);
       }
     }
     return true;


### PR DESCRIPTION
When resuming creating new instance after resuming work, we should set the `state` on the newly created instance rather than the old one.