### PR TITLE
Add npm v4.0.0 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "devEngines": {
     "node": "4.x || 5.x || 6.x",
-    "npm": "2.x || 3.x"
+    "npm": "2.x || 3.x || 4.x"
   },
   "commonerConfig": {
     "version": 7


### PR DESCRIPTION
Just tested recently released [npm v4.0.0](https://github.com/npm/npm/releases/tag/v4.0.0) and all scripts in `package.json` scripts sections worked as expected (there are still some errors when runninig `npm run build` but this should be fixed by #7999 and it is exactly the same as when using npm v3)