### PR TITLE
[Fiber] Implement findDOMNode and isMounted

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -146,6 +146,18 @@ var ReactDOM = {
     }
   },
 
+  findDOMNode(componentOrElement : Element | ?ReactComponent<any, any, any>) : null | Element | Text {
+    if (componentOrElement == null) {
+      return null;
+    }
+    // Unsound duck typing.
+    const component = (componentOrElement : any);
+    if (component.nodeType === 1) {
+      return component;
+    }
+    return DOMRenderer.findHostInstance(component);
+  },
+
 };
 
 module.exports = ReactDOM;

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
@@ -64,5 +64,106 @@ describe('ReactDOMFiber', () => {
 
       expect(container.textContent).toEqual('10');
     });
+
+    it('finds the DOM Text node of a string child', () => {
+      class Text extends React.Component {
+        render() {
+          return this.props.value;
+        }
+      }
+
+      let instance = null;
+      ReactDOM.render(
+        <Text value="foo" ref={ref => instance = ref} />,
+        container
+      );
+
+      const textNode = ReactDOM.findDOMNode(instance);
+      expect(textNode).toBe(container.firstChild);
+      expect(textNode.nodeType).toBe(3);
+      expect(textNode.nodeValue).toBe('foo');
+    });
+
+    it('finds the first child when a component returns a fragment', () => {
+      class Fragment extends React.Component {
+        render() {
+          return [
+            <div />,
+            <span />,
+          ];
+        }
+      }
+
+      let instance = null;
+      ReactDOM.render(
+        <Fragment ref={ref => instance = ref} />,
+        container
+      );
+
+      expect(container.childNodes.length).toBe(2);
+
+      const firstNode = ReactDOM.findDOMNode(instance);
+      expect(firstNode).toBe(container.firstChild);
+      expect(firstNode.tagName).toBe('DIV');
+    });
+
+    it('finds the first child even when fragment is nested', () => {
+      class Wrapper extends React.Component {
+        render() {
+          return this.props.children;
+        }
+      }
+
+      class Fragment extends React.Component {
+        render() {
+          return [
+            <Wrapper><div /></Wrapper>,
+            <span />,
+          ];
+        }
+      }
+
+      let instance = null;
+      ReactDOM.render(
+        <Fragment ref={ref => instance = ref} />,
+        container
+      );
+
+      expect(container.childNodes.length).toBe(2);
+
+      const firstNode = ReactDOM.findDOMNode(instance);
+      expect(firstNode).toBe(container.firstChild);
+      expect(firstNode.tagName).toBe('DIV');
+    });
+
+    it('finds the first child even when first child renders null', () => {
+      class NullComponent extends React.Component {
+        render() {
+          return null;
+        }
+      }
+
+      class Fragment extends React.Component {
+        render() {
+          return [
+            <NullComponent />,
+            <div />,
+            <span />,
+          ];
+        }
+      }
+
+      let instance = null;
+      ReactDOM.render(
+        <Fragment ref={ref => instance = ref} />,
+        container
+      );
+
+      expect(container.childNodes.length).toBe(2);
+
+      const firstNode = ReactDOM.findDOMNode(instance);
+      expect(firstNode).toBe(container.firstChild);
+      expect(firstNode.tagName).toBe('DIV');
+    });
   }
 });

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -154,6 +154,18 @@ var ReactNoop = {
     }
   },
 
+  findInstance(componentOrElement : Element | ?ReactComponent<any, any, any>) : null | Instance | TextInstance {
+    if (componentOrElement == null) {
+      return null;
+    }
+    // Unsound duck typing.
+    const component = (componentOrElement : any);
+    if (component.tag === TERMINAL_TAG || component.tag === TEXT_TAG) {
+      return component;
+    }
+    return NoopRenderer.findHostInstance(component);
+  },
+
   flushAnimationPri() {
     var cb = scheduledAnimationCallback;
     if (cb === null) {

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -23,6 +23,7 @@ var {
   addCallbackToQueue,
   mergeUpdateQueue,
 } = require('ReactFiberUpdateQueue');
+var { isMounted } = require('ReactFiberTreeReflection');
 var ReactInstanceMap = require('ReactInstanceMap');
 
 module.exports = function(scheduleUpdate : (fiber: Fiber, priorityLevel : PriorityLevel) => void) {
@@ -39,6 +40,7 @@ module.exports = function(scheduleUpdate : (fiber: Fiber, priorityLevel : Priori
 
   // Class component state updater
   const updater = {
+    isMounted,
     enqueueSetState(instance, partialState) {
       const fiber = ReactInstanceMap.get(instance);
       const updateQueue = fiber.updateQueue ?

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -119,12 +119,18 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
       switch (effectfulFiber.effectTag) {
         case Placement: {
           commitInsertion(effectfulFiber);
+          // Clear the effect tag so that we know that this is inserted, before
+          // any life-cycles like componentDidMount gets called.
+          effectfulFiber.effectTag = NoWork;
           break;
         }
         case PlacementAndUpdate: {
           commitInsertion(effectfulFiber);
           const current = effectfulFiber.alternate;
           commitWork(current, effectfulFiber);
+          // Clear the effect tag so that we know that this is inserted, before
+          // any life-cycles like componentDidMount gets called.
+          effectfulFiber.effectTag = Update;
           break;
         }
         case Update: {
@@ -158,7 +164,6 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
       effectfulFiber.nextEffect = null;
       // Ensure that we reset the effectTag here so that we can rely on effect
       // tags to reason about the current life-cycle.
-      effectfulFiber.effectTag = NoWork;
       effectfulFiber = next;
     }
 

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -156,6 +156,9 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
       // and lastEffect since they're on every node, not just the effectful
       // ones. So we have to clean everything as we reuse nodes anyway.
       effectfulFiber.nextEffect = null;
+      // Ensure that we reset the effectTag here so that we can rely on effect
+      // tags to reason about the current life-cycle.
+      effectfulFiber.effectTag = NoWork;
       effectfulFiber = next;
     }
 

--- a/src/renderers/shared/fiber/ReactFiberTreeReflection.js
+++ b/src/renderers/shared/fiber/ReactFiberTreeReflection.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactFiberTreeReflection
+ * @flow
+ */
+
+'use strict';
+
+import type { Fiber } from 'ReactFiber';
+
+var ReactInstanceMap = require('ReactInstanceMap');
+
+var {
+  ClassComponent,
+  HostContainer,
+  HostComponent,
+  HostText,
+} = require('ReactTypeOfWork');
+
+exports.findCurrentHostFiber = function(component : ReactComponent<any, any, any>) : Fiber | null {
+  var parent : ?Fiber = ReactInstanceMap.get(component);
+  if (!parent) {
+    return null;
+  }
+
+  // TODO: This search is incomplete because this could be one of two possible fibers.
+  let node : Fiber = parent;
+  while (true) {
+    if (node.tag === HostComponent || node.tag === HostText) {
+      return node;
+    } else if (node.child) {
+      // TODO: Coroutines need to visit the stateNode.
+      node = node.child;
+      continue;
+    }
+    if (node === parent) {
+      return null;
+    }
+    while (!node.sibling) {
+      if (!node.return || node.return === parent) {
+        return null;
+      }
+      node = node.return;
+    }
+    node = node.sibling;
+  }
+  return null;
+};

--- a/src/renderers/shared/fiber/ReactFiberTreeReflection.js
+++ b/src/renderers/shared/fiber/ReactFiberTreeReflection.js
@@ -23,6 +23,17 @@ var {
   HostText,
 } = require('ReactTypeOfWork');
 
+exports.isMounted = function(component : ReactComponent<any, any, any>) : boolean {
+  var parent : ?Fiber = ReactInstanceMap.get(component);
+  if (!parent) {
+    return false;
+  }
+  // TODO: This doesn't deal with the case where it has completed but not yet
+  // committed. It also doesn't deal with unmounts since they currently don't
+  // clean up the item in the ReactInstanceMap.
+  return true;
+};
+
 exports.findCurrentHostFiber = function(component : ReactComponent<any, any, any>) : Fiber | null {
   var parent : ?Fiber = ReactInstanceMap.get(component);
   if (!parent) {

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalReflection-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalReflection-test.js
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var React;
+var ReactNoop;
+
+describe('ReactIncrementalReflection', () => {
+  beforeEach(() => {
+    React = require('React');
+    ReactNoop = require('ReactNoop');
+  });
+
+  it('handles isMounted even when the initial render is deferred', () => {
+
+    let ops = [];
+
+    const instances = [];
+
+    const Component = React.createClass({
+      componentWillMount() {
+        instances.push(this);
+        ops.push('componentWillMount', this.isMounted());
+      },
+      componentDidMount() {
+        ops.push('componentDidMount', this.isMounted());
+      },
+      render() {
+        return <span />;
+      },
+    });
+
+    function Foo() {
+      return <Component />;
+    }
+
+    ReactNoop.render(<Foo />);
+
+    // Render part way through but don't yet commit the updates.
+    ReactNoop.flushDeferredPri(20);
+
+    expect(ops).toEqual([
+      'componentWillMount', false,
+    ]);
+
+    expect(instances[0].isMounted()).toBe(false);
+
+    ops = [];
+
+    // Render the rest and commit the updates.
+    ReactNoop.flush();
+
+    expect(ops).toEqual([
+      'componentDidMount', true,
+    ]);
+
+    expect(instances[0].isMounted()).toBe(true);
+
+  });
+
+  it('handles isMounted when an unmount is deferred', () => {
+
+    let ops = [];
+
+    const instances = [];
+
+    const Component = React.createClass({
+      componentWillMount() {
+        instances.push(this);
+      },
+      componentWillUnmount() {
+        ops.push('componentWillUnmount', this.isMounted());
+      },
+      render() {
+        ops.push('Component');
+        return <span />;
+      },
+    });
+
+    function Other() {
+      ops.push('Other');
+      return <span />;
+    }
+
+    function Foo(props) {
+      return props.mount ? <Component /> : <Other />;
+    }
+
+    ReactNoop.render(<Foo mount={true} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual(['Component']);
+    ops = [];
+
+    expect(instances[0].isMounted()).toBe(true);
+
+    ReactNoop.render(<Foo mount={false} />);
+    // Render part way through but don't yet commit the updates so it is not
+    // fully unmounted yet.
+    ReactNoop.flushDeferredPri(20);
+
+    expect(ops).toEqual(['Other']);
+    ops = [];
+
+    expect(instances[0].isMounted()).toBe(true);
+
+    // Finish flushing the unmount.
+    ReactNoop.flush();
+
+    expect(ops).toEqual([
+      'componentWillUnmount', true,
+    ]);
+
+    expect(instances[0].isMounted()).toBe(false);
+
+  });
+
+});


### PR DESCRIPTION
The strategy of finding the "current" through the back pointers turned out to be inefficient. You basically have to scan from the top to find them since the return pointer is active even when a child is in `progressedChild` instead of `child`.

isMounted is pretty easy though since we can just cut off the return pointer when a child gets deleted.

The key realization to fix findDOMNode is the realization that it doesn't matter which one is current if there is no pending insertion / previous deletion. So we can just check for those to determine if we're looking in the wrong tree.

I'm not too worried about this being understandable unless we have other use cases for "reflection" that are less deprecated.

Also note two new features: findDOMNode in fragment returns first child rather than error/null. Just like element.querySelector. findDOMNode when a component returns a string, finds the host text node. This is the first time you could get access to a text node instance. It's not super great since if the text node merges (due to normalization) then it could actually represent multiple text nodes, but maybe that's fine. Seems useful.