### PR TITLE
[Fiber]IndeterminateComponent type is unnecessary?

### DIFF
--- a/examples/fiber/debugger/src/describeFibers.js
+++ b/examples/fiber/debugger/src/describeFibers.js
@@ -11,24 +11,22 @@ function getFiberUniqueID(fiber) {
 function getFriendlyTag(tag) {
   switch (tag) {
     case 0:
-      return '[indeterminate]';
-    case 1:
       return '[fn]';
-    case 2:
+    case 1:
       return '[class]';
-    case 3:
+    case 2:
       return '[root]';
-    case 4:
+    case 3:
       return '[host]';
-    case 5:
+    case 4:
       return '[text]';
-    case 6:
+    case 5:
       return '[coroutine]';
-    case 7:
+    case 6:
       return '[handler]';
-    case 8:
+    case 7:
       return '[yield]';
-    case 9:
+    case 8:
       return '[frag]';
     default:
       throw new Error('Unknown tag.');

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -21,7 +21,7 @@ import type { UpdateQueue } from 'ReactFiberUpdateQueue';
 
 var ReactTypeOfWork = require('ReactTypeOfWork');
 var {
-  IndeterminateComponent,
+  FunctionalComponent,
   ClassComponent,
   HostContainer,
   HostComponent,
@@ -293,7 +293,7 @@ function createFiberFromElementType(type : mixed, key : null | string) : Fiber {
   if (typeof type === 'function') {
     fiber = shouldConstruct(type) ?
       createFiber(ClassComponent, key) :
-      createFiber(IndeterminateComponent, key);
+      createFiber(FunctionalComponent, key);
     fiber.type = type;
   } else if (typeof type === 'string') {
     fiber = createFiber(HostComponent, key);

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -25,7 +25,6 @@ var {
 } = require('ReactChildFiber');
 var ReactTypeOfWork = require('ReactTypeOfWork');
 var {
-  IndeterminateComponent,
   FunctionalComponent,
   ClassComponent,
   HostContainer,
@@ -231,27 +230,6 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>, s
     }
   }
 
-  function mountIndeterminateComponent(current, workInProgress) {
-    if (current) {
-      throw new Error('An indeterminate component should never have mounted.');
-    }
-    var fn = workInProgress.type;
-    var props = workInProgress.pendingProps;
-    var value = fn(props);
-    if (typeof value === 'object' && value && typeof value.render === 'function') {
-      // Proceed under the assumption that this is a class instance
-      workInProgress.tag = ClassComponent;
-      adoptClassInstance(workInProgress, value);
-      mountClassInstance(workInProgress);
-      value = value.render();
-    } else {
-      // Proceed under the assumption that this is a functional component
-      workInProgress.tag = FunctionalComponent;
-    }
-    reconcileChildren(current, workInProgress, value);
-    return workInProgress.child;
-  }
-
   function updateCoroutineComponent(current, workInProgress) {
     var coroutine = (workInProgress.pendingProps : ?ReactCoroutine);
     if (!coroutine) {
@@ -359,8 +337,6 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>, s
     }
 
     switch (workInProgress.tag) {
-      case IndeterminateComponent:
-        return mountIndeterminateComponent(current, workInProgress);
       case FunctionalComponent:
         return updateFunctionalComponent(current, workInProgress);
       case ClassComponent:

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -21,7 +21,6 @@ var { reconcileChildFibers } = require('ReactChildFiber');
 var ReactTypeOfWork = require('ReactTypeOfWork');
 var ReactTypeOfSideEffect = require('ReactTypeOfSideEffect');
 var {
-  IndeterminateComponent,
   FunctionalComponent,
   ClassComponent,
   HostContainer,
@@ -219,8 +218,6 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
         return null;
 
       // Error cases
-      case IndeterminateComponent:
-        throw new Error('An indeterminate component should have become determinate before completing.');
       default:
         throw new Error('Unknown unit of work tag');
     }

--- a/src/renderers/shared/fiber/ReactTypeOfWork.js
+++ b/src/renderers/shared/fiber/ReactTypeOfWork.js
@@ -12,17 +12,16 @@
 
 'use strict';
 
-export type TypeOfWork = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+export type TypeOfWork = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 
 module.exports = {
-  IndeterminateComponent: 0, // Before we know whether it is functional or class
-  FunctionalComponent: 1,
-  ClassComponent: 2,
-  HostContainer: 3, // Root of a host tree. Could be nested inside another node.
-  HostComponent: 4,
-  HostText: 5,
-  CoroutineComponent: 6,
-  CoroutineHandlerPhase: 7,
-  YieldComponent: 8,
-  Fragment: 9,
+  FunctionalComponent: 0,
+  ClassComponent: 1,
+  HostContainer: 2, // Root of a host tree. Could be nested inside another node.
+  HostComponent: 3,
+  HostText: 4,
+  CoroutineComponent: 5,
+  CoroutineHandlerPhase: 6,
+  YieldComponent: 7,
+  Fragment: 8,
 };


### PR DESCRIPTION
I guess this PR is missing something. but I'm not sure why `IndeterminateComponent` is necessary.

I think `IndeterminateComponent` will be `FunctionalComponent` or `ClassComponent` in the end.

```js
    if (typeof value === 'object' && value && typeof value.render === 'function') {
      // Proceed under the assumption that this is a class instance
      workInProgress.tag = ClassComponent;
      adoptClassInstance(workInProgress, value);
      mountClassInstance(workInProgress);
      value = value.render();
    } else {
      // Proceed under the assumption that this is a functional component
      workInProgress.tag = FunctionalComponent;
    }
```

* https://github.com/facebook/react/blob/master/src/renderers/shared/fiber/ReactFiberBeginWork.js#L241-L250

At the following, I think `fiber` can be `FunctionalComponent` when `shouldConstruct(type)` returns `false`, right?

```js
  if (typeof type === 'function') {
    fiber = shouldConstruct(type) ?
      createFiber(ClassComponent, key) :
      createFiber(IndeterminateComponent, key);
    fiber.type = type;
```

* https://github.com/facebook/react/blob/master/src/renderers/shared/fiber/ReactFiber.js#L293-L297

If that is true, `IndeterminateComponent` can be deletable.
Or do you have any plans to use `IndeterminateComponent` in features that have not implemented yet?