### PR TITLE
Don't set value prop for uncontrolled component

### DIFF
--- a/docs/docs/forms.md
+++ b/docs/docs/forms.md
@@ -115,7 +115,7 @@ class Form extends React.Component {
       <div>
         <input type="text"
           placeholder="Hello!"
-          value={this.state.value}
+          // value={this.state.value} value prop should not be set here!
           onChange={this.handleChange} />
         <button onClick={this.handleSubmit}>Submit</button>
       </div>


### PR DESCRIPTION
I'm a newbie, but as far as I understand you don't set `value` property for uncontrolled components. In code example for uncontrolled components the `value` prop is set.