### PR TITLE
Shares debugID information across modules

### DIFF
--- a/src/renderers/shared/stack/reconciler/instantiateReactComponent.js
+++ b/src/renderers/shared/stack/reconciler/instantiateReactComponent.js
@@ -15,6 +15,7 @@ var ReactCompositeComponent = require('ReactCompositeComponent');
 var ReactEmptyComponent = require('ReactEmptyComponent');
 var ReactHostComponent = require('ReactHostComponent');
 
+var getNextDebugID = require('getNextDebugID');
 var invariant = require('invariant');
 var warning = require('warning');
 
@@ -55,8 +56,6 @@ function isInternalComponentType(type) {
     typeof type.prototype.receiveComponent === 'function'
   );
 }
-
-var nextDebugID = 1;
 
 /**
  * Given a ReactNode, create an instance that will actually be mounted.
@@ -125,7 +124,7 @@ function instantiateReactComponent(node, shouldHaveDebugID) {
   instance._mountImage = null;
 
   if (__DEV__) {
-    instance._debugID = shouldHaveDebugID ? nextDebugID++ : 0;
+    instance._debugID = shouldHaveDebugID ? getNextDebugID() : 0;
   }
 
   // Internal instances should fully constructed at this point, so they should

--- a/src/shared/utils/getNextDebugID.js
+++ b/src/shared/utils/getNextDebugID.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule getNextDebugID
+ * @flow
+ */
+
+'use strict';
+
+var nextDebugID = 1;
+
+function getNextDebugID(): number {
+  return nextDebugID++;
+}
+
+module.exports = getNextDebugID;

--- a/src/test/ReactShallowRenderer.js
+++ b/src/test/ReactShallowRenderer.js
@@ -20,9 +20,8 @@ var ReactReconciler = require('ReactReconciler');
 var ReactUpdates = require('ReactUpdates');
 
 var emptyObject = require('emptyObject');
+var getNextDebugID = require('getNextDebugID');
 var invariant = require('invariant');
-
-var nextDebugID = 1;
 
 class NoopInternalComponent {
   constructor(element) {
@@ -30,7 +29,7 @@ class NoopInternalComponent {
     this._currentElement = element;
 
     if (__DEV__) {
-      this._debugID = nextDebugID++;
+      this._debugID = getNextDebugID();
     }
   }
   mountComponent() {}
@@ -50,7 +49,7 @@ class NoopInternalComponent {
 var ShallowComponentWrapper = function(element) {
   // TODO: Consolidate with instantiateReactComponent
   if (__DEV__) {
-    this._debugID = nextDebugID++;
+    this._debugID = getNextDebugID();
   }
 
   this.construct(element);


### PR DESCRIPTION
Prior to this, React was using a nextDebugID variable that was locally
scoped to both `instantiateReactComponent` and `ReactShallowRenderer`.
This caused problems when the debugIDs would collide, the `itemMap` in
`ReactComponentTreeHook` would be overwritten and tests would fail
with the message "Expected onBeforeMountComponent() parent and
onSetChildren() to be consistent".

This change shares the debugID with both modules thus preventing any
collisions in the future.

Fixes #7927

Ideally this would be in the next (hotfix?) release of React 15.x as this is preventing us (Airbnb) from upgrading at the moment.