### PR TITLE
Tiny grammar fix in forms.md

### DIFF
--- a/docs/docs/forms.md
+++ b/docs/docs/forms.md
@@ -160,7 +160,7 @@ Like all DOM events, the `onChange` prop is supported on all native components a
 
 > Note:
 >
-> For `<input>` and `<textarea>`, `onChange` should generally used instead of — the DOM's built-in [`oninput`](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/oninput) event handler.
+> For `<input>` and `<textarea>`, `onChange` should generally be used instead of — the DOM's built-in [`oninput`](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/oninput) event handler.
 
 ## Advanced Topics
 


### PR DESCRIPTION
*Before* submitting a pull request, please make sure the following is done...

- [x] This branch branched of the `master` branch.
- Only documentation changes.
- [x] CLA signed.

---

> For `<input>` and `<textarea>`, `onChange` should generally used instead of — the DOM's built-in [`oninput`](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/oninput) event handler.

Since `onChange` is the prop that the user should use, the sentence should use a passive voice.

I’m still not sure why we need an “—” in _<q>instead of — the DOM's built-in `oninput` event handler.</q>_ Or should the sentence be rewritten, e.g., in active voice (you should generally use `onChange` instead of the DOM's built-in `oninput` event handler.)?