### PR TITLE
Fix an argument name of TestUtils.renderIntoDocument

### DIFF
--- a/docs/docs/addons-test-utils.md
+++ b/docs/docs/addons-test-utils.md
@@ -122,10 +122,10 @@ ReactTestUtils.Simulate.keyDown(node, {key: "Enter", keyCode: 13, which: 13});
 ### `renderIntoDocument()`
 
 ```javascript
-renderIntoDocument(instance)
+renderIntoDocument(element)
 ```
 
-Render a component into a detached DOM node in the document. **This function requires a DOM.**
+Render a React element into a detached DOM node in the document. **This function requires a DOM.**
 
 > Note:
 >

--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -77,14 +77,14 @@ function findAllInRenderedTreeInternal(inst, test) {
  * @lends ReactTestUtils
  */
 var ReactTestUtils = {
-  renderIntoDocument: function(instance) {
+  renderIntoDocument: function(element) {
     var div = document.createElement('div');
     // None of our tests actually require attaching the container to the
     // DOM, and doing so creates a mess that we rely on test isolation to
     // clean up, so we're going to stop honoring the name of this method
     // (and probably rename it eventually) if no problems arise.
     // document.documentElement.appendChild(div);
-    return ReactDOM.render(instance, div);
+    return ReactDOM.render(element, div);
   },
 
   isElement: function(element) {


### PR DESCRIPTION
`renderIntoDocument` receives a React element, not instance :)