### PR TITLE
Remove extraneous `value` in controlled form elements docs

### DIFF
--- a/docs/docs/forms.md
+++ b/docs/docs/forms.md
@@ -115,7 +115,6 @@ class Form extends React.Component {
       <div>
         <input type="text"
           placeholder="Hello!"
-          value={this.state.value}
           onChange={this.handleChange} />
         <button onClick={this.handleSubmit}>Submit</button>
       </div>


### PR DESCRIPTION
The uncontrolled input should not have `value` attribute – this is the main difference and it’s confusing to see it in this example. Codepen is correct (does not have the `value` attr`).