### PR TITLE
Correct usage of formatName() function in docs

### DIFF
--- a/docs/docs/introducing-jsx.md
+++ b/docs/docs/introducing-jsx.md
@@ -59,7 +59,7 @@ This means that you can use JSX inside of `if` statements and `for` loops, assig
 ```js{3,5}
 function getGreeting(user) {
   if (user) {
-    return <h1>Hello, {formatName(user.name)}!</h1>;
+    return <h1>Hello, {formatName(user)}!</h1>;
   } else {
     return <h1>Hello, Stranger.</h1>;
   }


### PR DESCRIPTION
The code section above these changes defines a `formatName()` function that expects a parameter `user`. The code section containing these changes incorrectly called `formatName(user.name)`. For those following along with CodePen, this section should correctly call `formatName(user)`.