### PR TITLE
Update reference-react-component.md

### DIFF
--- a/docs/docs/reference-react-component.md
+++ b/docs/docs/reference-react-component.md
@@ -325,7 +325,7 @@ class CustomButton extends React.Component {
 }
 
 CustomButton.propTypes = {
-  name: React.PropTypes.string
+  color: React.PropTypes.string
 };
 ```
 


### PR DESCRIPTION
line 320: For example, this code ensures that the `color` prop is a string