### PR TITLE
[Fiber] Error boundaries should handle errors independently

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -131,6 +131,7 @@ var ReactDOM = {
   render(element : ReactElement<any>, container : DOMContainerElement, callback: ?Function) {
     warnAboutUnstableUse();
     let root;
+
     if (!container._reactRootContainer) {
       root = container._reactRootContainer = DOMRenderer.mountContainer(element, container, callback);
     } else {

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactErrorBoundaries-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactErrorBoundaries-test.js
@@ -36,9 +36,6 @@ describe('ReactErrorBoundaries', () => {
   var Normal;
 
   beforeEach(() => {
-    // TODO: Fiber isn't error resilient and one test can bring down them all.
-    jest.resetModuleRegistry();
-
     ReactDOM = require('ReactDOM');
     React = require('React');
 


### PR DESCRIPTION
Since error boundaries are "atomic" in Fiber, and errors in "did" lifecycles and "willUnmount" only surface after committing, we can end up in a situation where two independent boundaries should receive two independent errors from several components with broken lifecycle hooks.

This PR adds support for this and removes some unnecessary recursion.

It also "fixes" (I'm not sure it's a fix though) a problem: rethrowing errors makes some roots forever skip updates. You can search for "FIXME":

```js
      // We need to make sure any future root can get scheduled despite these errors.
      // Currently after throwing, nothing gets scheduled because these fields are set.
      // FIXME: this is likely a wrong fix! It's still better than ignoring updates though.
      nextScheduledRoot = null;
      lastScheduledRoot = null;
```

If I don't those fields, this test fails:

```js
    var container = document.createElement('div');
    expect(() => {
      ReactDOM.render(<BrokenRender />, container);
    }).toThrow('Hello');

    container = document.createElement('div');
    expect(() => {
      ReactDOM.render(<BrokenComponentWillMount />, container);
    }).toThrow('Hello');

    container = document.createElement('div');
    expect(() => {
      ReactDOM.render(<BrokenComponentDidMount />, container);
    }).toThrow('Hello');
```

It fails because second and third requests to `render` are completely ignored since scheduler thinks they're already scheduled. I don't understand the scheduler well enough to propose a better fix.