### PR TITLE
Add test case to insure object with tag number doesn't warn

### DIFF
--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -318,6 +318,8 @@ describe('ReactElementValidator', () => {
     );
     React.createElement('div');
     expect(console.error.calls.count()).toBe(4);
+    React.createElement({ tag: 1 });
+    expect(console.error.calls.count()).toBe(4);
   });
 
   it('includes the owner name when passing null, undefined, boolean, or number', () => {


### PR DESCRIPTION
But I'm not sure that checking just for the type of tag key is enough to validate type – https://github.com/facebook/react/blob/master/src/isomorphic/classic/element/ReactElementValidator.js#L189
