### PR TITLE
Cleanup ReactErrorUtils

### DIFF
--- a/src/renderers/shared/utils/ReactErrorUtils.js
+++ b/src/renderers/shared/utils/ReactErrorUtils.js
@@ -19,8 +19,7 @@ var caughtError = null;
  *
  * @param {String} name of the guard to use for logging or debugging
  * @param {Function} func The function to invoke
- * @param {*} a First argument
- * @param {*} b Second argument
+ * @param {*} a Argument
  */
 function invokeGuardedCallback<A>(
   name: string,


### PR DESCRIPTION
Hi guys,

This one is for #7902 

As I see the fourth argument was already deleted here https://github.com/facebook/react/commit/395888435b44b18b339f7626df5c472335601a11
but the annotation was left. So I just removed the annotation of that argument.

Please let me know if this makes sense.

Thanks
