### PR TITLE
Rewrite some tests relying on internal APIs

### DIFF
--- a/src/isomorphic/classic/__tests__/ReactContextValidator-test.js
+++ b/src/isomorphic/classic/__tests__/ReactContextValidator-test.js
@@ -21,8 +21,6 @@ var React;
 var ReactDOM;
 var ReactTestUtils;
 
-var reactComponentExpect;
-
 describe('ReactContextValidator', () => {
   function normalizeCodeLocInfo(str) {
     return str.replace(/\(at .+?:\d+\)/g, '(at **)');
@@ -34,7 +32,6 @@ describe('ReactContextValidator', () => {
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactTestUtils = require('ReactTestUtils');
-    reactComponentExpect = require('reactComponentExpect');
   });
 
   // TODO: This behavior creates a runtime dependency on propTypes. We should
@@ -65,12 +62,12 @@ describe('ReactContextValidator', () => {
       },
 
       render: function() {
-        return <Component />;
+        return <Component ref="child" />;
       },
     });
 
     var instance = ReactTestUtils.renderIntoDocument(<ComponentInFooBarContext />);
-    reactComponentExpect(instance).expectRenderedChild().scalarContextEqual({foo: 'abc'});
+    expect(instance.refs.child.context).toEqual({foo: 'abc'});
   });
 
   it('should filter context properly in callbacks', () => {

--- a/src/isomorphic/classic/class/__tests__/ReactBind-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactBind-test.js
@@ -13,7 +13,6 @@
 
 var React = require('React');
 var ReactTestUtils = require('ReactTestUtils');
-var reactComponentExpect = require('reactComponentExpect');
 
 // TODO: Test render and all stock methods.
 describe('autobinding', () => {
@@ -42,6 +41,7 @@ describe('autobinding', () => {
       render: function() {
         return (
           <div
+            ref="child"
             onMouseOver={this.onMouseEnter}
             onMouseOut={this.onMouseLeave}
             onClick={this.onClick}
@@ -50,48 +50,42 @@ describe('autobinding', () => {
       },
     });
 
-    var instance1 = <TestBindComponent />;
-    var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
-    var rendered1 = reactComponentExpect(mountedInstance1)
-      .expectRenderedChild()
-      .instance();
+    var instance1 = ReactTestUtils.renderIntoDocument(<TestBindComponent />);
+    var rendered1 = instance1.refs.child;
 
-    var instance2 = <TestBindComponent />;
-    var mountedInstance2 = ReactTestUtils.renderIntoDocument(instance2);
-    var rendered2 = reactComponentExpect(mountedInstance2)
-      .expectRenderedChild()
-      .instance();
+    var instance2 = ReactTestUtils.renderIntoDocument(<TestBindComponent />);
+    var rendered2 = instance2.refs.child;
 
     expect(function() {
       var badIdea = instance1.badIdeas.badBind;
       badIdea();
     }).toThrow();
 
-    expect(mountedInstance1.onClick).not.toBe(mountedInstance2.onClick);
+    expect(instance1.onClick).not.toBe(instance2.onClick);
 
     ReactTestUtils.Simulate.click(rendered1);
     expect(mouseDidClick.mock.instances.length).toBe(1);
-    expect(mouseDidClick.mock.instances[0]).toBe(mountedInstance1);
+    expect(mouseDidClick.mock.instances[0]).toBe(instance1);
 
     ReactTestUtils.Simulate.click(rendered2);
     expect(mouseDidClick.mock.instances.length).toBe(2);
-    expect(mouseDidClick.mock.instances[1]).toBe(mountedInstance2);
+    expect(mouseDidClick.mock.instances[1]).toBe(instance2);
 
     ReactTestUtils.Simulate.mouseOver(rendered1);
     expect(mouseDidEnter.mock.instances.length).toBe(1);
-    expect(mouseDidEnter.mock.instances[0]).toBe(mountedInstance1);
+    expect(mouseDidEnter.mock.instances[0]).toBe(instance1);
 
     ReactTestUtils.Simulate.mouseOver(rendered2);
     expect(mouseDidEnter.mock.instances.length).toBe(2);
-    expect(mouseDidEnter.mock.instances[1]).toBe(mountedInstance2);
+    expect(mouseDidEnter.mock.instances[1]).toBe(instance2);
 
     ReactTestUtils.Simulate.mouseOut(rendered1);
     expect(mouseDidLeave.mock.instances.length).toBe(1);
-    expect(mouseDidLeave.mock.instances[0]).toBe(mountedInstance1);
+    expect(mouseDidLeave.mock.instances[0]).toBe(instance1);
 
     ReactTestUtils.Simulate.mouseOut(rendered2);
     expect(mouseDidLeave.mock.instances.length).toBe(2);
-    expect(mouseDidLeave.mock.instances[1]).toBe(mountedInstance2);
+    expect(mouseDidLeave.mock.instances[1]).toBe(instance2);
   });
 
   it('works with mixins', () => {
@@ -105,19 +99,16 @@ describe('autobinding', () => {
       mixins: [TestMixin],
 
       render: function() {
-        return <div onClick={this.onClick} />;
+        return <div ref="child" onClick={this.onClick} />;
       },
     });
 
-    var instance1 = <TestBindComponent />;
-    var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
-    var rendered1 = reactComponentExpect(mountedInstance1)
-      .expectRenderedChild()
-      .instance();
+    var instance1 = ReactTestUtils.renderIntoDocument(<TestBindComponent />);
+    var rendered1 = instance1.refs.child;
 
     ReactTestUtils.Simulate.click(rendered1);
     expect(mouseDidClick.mock.instances.length).toBe(1);
-    expect(mouseDidClick.mock.instances[0]).toBe(mountedInstance1);
+    expect(mouseDidClick.mock.instances[0]).toBe(instance1);
   });
 
   it('warns if you try to bind to this', () => {

--- a/src/isomorphic/classic/class/__tests__/ReactBindOptout-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactBindOptout-test.js
@@ -13,7 +13,6 @@
 
 var React = require('React');
 var ReactTestUtils = require('ReactTestUtils');
-var reactComponentExpect = require('reactComponentExpect');
 
 // TODO: Test render and all stock methods.
 describe('autobind optout', () => {
@@ -36,6 +35,7 @@ describe('autobind optout', () => {
       render: function() {
         return (
           <div
+            ref="child"
             onMouseOver={this.onMouseEnter.bind(this)}
             onMouseOut={this.onMouseLeave.bind(this)}
             onClick={this.onClick.bind(this)}
@@ -44,41 +44,35 @@ describe('autobind optout', () => {
       },
     });
 
-    var instance1 = <TestBindComponent />;
-    var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
-    var rendered1 = reactComponentExpect(mountedInstance1)
-      .expectRenderedChild()
-      .instance();
+    var instance1 = ReactTestUtils.renderIntoDocument(<TestBindComponent />);
+    var rendered1 = instance1.refs.child;
 
-    var instance2 = <TestBindComponent />;
-    var mountedInstance2 = ReactTestUtils.renderIntoDocument(instance2);
-    var rendered2 = reactComponentExpect(mountedInstance2)
-      .expectRenderedChild()
-      .instance();
+    var instance2 = ReactTestUtils.renderIntoDocument(<TestBindComponent />);
+    var rendered2 = instance2.refs.child;
 
     ReactTestUtils.Simulate.click(rendered1);
     expect(mouseDidClick.mock.instances.length).toBe(1);
-    expect(mouseDidClick.mock.instances[0]).toBe(mountedInstance1);
+    expect(mouseDidClick.mock.instances[0]).toBe(instance1);
 
     ReactTestUtils.Simulate.click(rendered2);
     expect(mouseDidClick.mock.instances.length).toBe(2);
-    expect(mouseDidClick.mock.instances[1]).toBe(mountedInstance2);
+    expect(mouseDidClick.mock.instances[1]).toBe(instance2);
 
     ReactTestUtils.Simulate.mouseOver(rendered1);
     expect(mouseDidEnter.mock.instances.length).toBe(1);
-    expect(mouseDidEnter.mock.instances[0]).toBe(mountedInstance1);
+    expect(mouseDidEnter.mock.instances[0]).toBe(instance1);
 
     ReactTestUtils.Simulate.mouseOver(rendered2);
     expect(mouseDidEnter.mock.instances.length).toBe(2);
-    expect(mouseDidEnter.mock.instances[1]).toBe(mountedInstance2);
+    expect(mouseDidEnter.mock.instances[1]).toBe(instance2);
 
     ReactTestUtils.Simulate.mouseOut(rendered1);
     expect(mouseDidLeave.mock.instances.length).toBe(1);
-    expect(mouseDidLeave.mock.instances[0]).toBe(mountedInstance1);
+    expect(mouseDidLeave.mock.instances[0]).toBe(instance1);
 
     ReactTestUtils.Simulate.mouseOut(rendered2);
     expect(mouseDidLeave.mock.instances.length).toBe(2);
-    expect(mouseDidLeave.mock.instances[1]).toBe(mountedInstance2);
+    expect(mouseDidLeave.mock.instances[1]).toBe(instance2);
   });
 
   it('should not hold reference to instance', () => {
@@ -103,30 +97,25 @@ describe('autobind optout', () => {
       render: function() {
         return (
           <div
+            ref="child"
             onClick={this.onClick}
           />
         );
       },
     });
 
-    var instance1 = <TestBindComponent />;
-    var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
-    var rendered1 = reactComponentExpect(mountedInstance1)
-      .expectRenderedChild()
-      .instance();
+    var instance1 = ReactTestUtils.renderIntoDocument(<TestBindComponent />);
+    var rendered1 = instance1.refs.child;
 
-    var instance2 = <TestBindComponent />;
-    var mountedInstance2 = ReactTestUtils.renderIntoDocument(instance2);
-    var rendered2 = reactComponentExpect(mountedInstance2)
-      .expectRenderedChild()
-      .instance();
+    var instance2 = ReactTestUtils.renderIntoDocument(<TestBindComponent />);
+    var rendered2 = instance2.refs.child;
 
     expect(function() {
       var badIdea = instance1.badIdeas.badBind;
       badIdea();
     }).toThrow();
 
-    expect(mountedInstance1.onClick).toBe(mountedInstance2.onClick);
+    expect(instance1.onClick).toBe(instance2.onClick);
 
     expect(function() {
       ReactTestUtils.Simulate.click(rendered1);
@@ -148,19 +137,16 @@ describe('autobind optout', () => {
       mixins: [TestMixin],
 
       render: function() {
-        return <div onClick={this.onClick} />;
+        return <div ref="child" onClick={this.onClick} />;
       },
     });
 
-    var instance1 = <TestBindComponent />;
-    var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
-    var rendered1 = reactComponentExpect(mountedInstance1)
-      .expectRenderedChild()
-      .instance();
+    var instance1 = ReactTestUtils.renderIntoDocument(<TestBindComponent />);
+    var rendered1 = instance1.refs.child;
 
     ReactTestUtils.Simulate.click(rendered1);
     expect(mouseDidClick.mock.instances.length).toBe(1);
-    expect(mouseDidClick.mock.instances[0]).toBe(mountedInstance1);
+    expect(mouseDidClick.mock.instances[0]).toBe(instance1);
   });
 
   it('works with mixins that have opted out of autobinding', () => {
@@ -175,19 +161,16 @@ describe('autobind optout', () => {
       mixins: [TestMixin],
 
       render: function() {
-        return <div onClick={this.onClick.bind(this)} />;
+        return <div ref="child" onClick={this.onClick.bind(this)} />;
       },
     });
 
-    var instance1 = <TestBindComponent />;
-    var mountedInstance1 = ReactTestUtils.renderIntoDocument(instance1);
-    var rendered1 = reactComponentExpect(mountedInstance1)
-      .expectRenderedChild()
-      .instance();
+    var instance1 = ReactTestUtils.renderIntoDocument(<TestBindComponent />);
+    var rendered1 = instance1.refs.child;
 
     ReactTestUtils.Simulate.click(rendered1);
     expect(mouseDidClick.mock.instances.length).toBe(1);
-    expect(mouseDidClick.mock.instances[0]).toBe(mountedInstance1);
+    expect(mouseDidClick.mock.instances[0]).toBe(instance1);
   });
 
   it('does not warn if you try to bind to this', () => {

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -21,13 +21,10 @@ var ReactServerRendering;
 var ReactTestUtils;
 var ReactUpdates;
 
-var reactComponentExpect;
-
 describe('ReactCompositeComponent', () => {
 
   beforeEach(() => {
     jest.resetModuleRegistry();
-    reactComponentExpect = require('reactComponentExpect');
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactCurrentOwner = require('ReactCurrentOwner');
@@ -85,22 +82,17 @@ describe('ReactCompositeComponent', () => {
   });
 
   it('should support rendering to different child types over time', () => {
-    var instance = <MorphingComponent />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
-
-    reactComponentExpect(instance)
-      .expectRenderedChild()
-      .toBeComponentOfType('a');
+    var instance = ReactTestUtils.renderIntoDocument(<MorphingComponent />);
+    var el = ReactDOM.findDOMNode(instance);
+    expect(el.tagName).toBe('A');
 
     instance._toggleActivatedState();
-    reactComponentExpect(instance)
-      .expectRenderedChild()
-      .toBeComponentOfType('b');
+    el = ReactDOM.findDOMNode(instance);
+    expect(el.tagName).toBe('B');
 
     instance._toggleActivatedState();
-    reactComponentExpect(instance)
-      .expectRenderedChild()
-      .toBeComponentOfType('a');
+    el = ReactDOM.findDOMNode(instance);
+    expect(el.tagName).toBe('A');
   });
 
   it('should not thrash a server rendered layout with client side one', () => {
@@ -124,22 +116,17 @@ describe('ReactCompositeComponent', () => {
   });
 
   it('should react to state changes from callbacks', () => {
-    var instance = <MorphingComponent />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
+    var instance = ReactTestUtils.renderIntoDocument(<MorphingComponent />);
+    var el = ReactDOM.findDOMNode(instance);
+    expect(el.tagName).toBe('A');
 
-    var renderedChild = reactComponentExpect(instance)
-      .expectRenderedChild()
-      .instance();
-
-    ReactTestUtils.Simulate.click(renderedChild);
-    reactComponentExpect(instance)
-      .expectRenderedChild()
-      .toBeComponentOfType('b');
+    ReactTestUtils.Simulate.click(el);
+    el = ReactDOM.findDOMNode(instance);
+    expect(el.tagName).toBe('B');
   });
 
   it('should rewire refs when rendering to different child types', () => {
-    var instance = <MorphingComponent />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
+    var instance = ReactTestUtils.renderIntoDocument(<MorphingComponent />);
 
     expect(ReactDOM.findDOMNode(instance.refs.x).tagName).toBe('A');
     instance._toggleActivatedState();
@@ -237,17 +224,14 @@ describe('ReactCompositeComponent', () => {
       }
     }
 
-    var instance1 = <Component />;
-    instance1 = ReactTestUtils.renderIntoDocument(instance1);
-    reactComponentExpect(instance1).scalarPropsEqual({prop: 'testKey'});
+    var instance1 = ReactTestUtils.renderIntoDocument(<Component />);
+    expect(instance1.props).toEqual({prop: 'testKey'});
 
-    var instance2 = <Component prop={undefined} />;
-    instance2 = ReactTestUtils.renderIntoDocument(instance2);
-    reactComponentExpect(instance2).scalarPropsEqual({prop: 'testKey'});
+    var instance2 = ReactTestUtils.renderIntoDocument(<Component prop={undefined} />);
+    expect(instance2.props).toEqual({prop: 'testKey'});
 
-    var instance3 = <Component prop={null} />;
-    instance3 = ReactTestUtils.renderIntoDocument(instance3);
-    reactComponentExpect(instance3).scalarPropsEqual({prop: null});
+    var instance3 = ReactTestUtils.renderIntoDocument(<Component prop={null} />);
+    expect(instance3.props).toEqual({prop: null});
   });
 
   it('should not mutate passed-in props object', () => {
@@ -659,12 +643,11 @@ describe('ReactCompositeComponent', () => {
     );
 
     expect(parentInstance.state.flag).toBe(false);
-    reactComponentExpect(childInstance).scalarContextEqual({foo: 'bar', flag: false});
+    expect(childInstance.context).toEqual({foo: 'bar', flag: false});
 
     parentInstance.setState({flag: true});
     expect(parentInstance.state.flag).toBe(true);
-
-    reactComponentExpect(childInstance).scalarContextEqual({foo: 'bar', flag: true});
+    expect(childInstance.context).toEqual({foo: 'bar', flag: true});
   });
 
   it('should pass context when re-rendered for static child within a composite component', () => {
@@ -714,13 +697,13 @@ describe('ReactCompositeComponent', () => {
     );
 
     expect(wrapper.refs.parent.state.flag).toEqual(true);
-    reactComponentExpect(wrapper.refs.child).scalarContextEqual({flag: true});
+    expect(wrapper.refs.child.context).toEqual({flag: true});
 
     // We update <Parent /> while <Child /> is still a static prop relative to this update
     wrapper.refs.parent.setState({flag: false});
 
     expect(wrapper.refs.parent.state.flag).toEqual(false);
-    reactComponentExpect(wrapper.refs.child).scalarContextEqual({flag: false});
+    expect(wrapper.refs.child.context).toEqual({flag: false});
   });
 
   it('should pass context transitively', () => {
@@ -780,8 +763,8 @@ describe('ReactCompositeComponent', () => {
     }
 
     ReactTestUtils.renderIntoDocument(<Parent />);
-    reactComponentExpect(childInstance).scalarContextEqual({foo: 'bar', depth: 0});
-    reactComponentExpect(grandchildInstance).scalarContextEqual({foo: 'bar', depth: 1});
+    expect(childInstance.context).toEqual({foo: 'bar', depth: 0});
+    expect(grandchildInstance.context).toEqual({foo: 'bar', depth: 1});
   });
 
   it('should pass context when re-rendered', () => {
@@ -835,7 +818,7 @@ describe('ReactCompositeComponent', () => {
     });
     expect(parentInstance.state.flag).toBe(true);
 
-    reactComponentExpect(childInstance).scalarContextEqual({foo: 'bar', depth: 0});
+    expect(childInstance.context).toEqual({foo: 'bar', depth: 0});
   });
 
   it('unmasked context propagates through updates', () => {

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponentDOMMinimalism-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponentDOMMinimalism-test.js
@@ -13,8 +13,8 @@
 
 // Requires
 var React;
+var ReactDOM;
 var ReactTestUtils;
-var reactComponentExpect;
 
 // Test components
 var LowerLevelComposite;
@@ -30,8 +30,8 @@ var expectSingleChildlessDiv;
 describe('ReactCompositeComponentDOMMinimalism', () => {
 
   beforeEach(() => {
-    reactComponentExpect = require('reactComponentExpect');
     React = require('React');
+    ReactDOM = require('ReactDOM');
     ReactTestUtils = require('ReactTestUtils');
 
     LowerLevelComposite = class extends React.Component {
@@ -55,12 +55,9 @@ describe('ReactCompositeComponentDOMMinimalism', () => {
     };
 
     expectSingleChildlessDiv = function(instance) {
-      reactComponentExpect(instance)
-        .expectRenderedChild()
-        .toBeCompositeComponentWithType(LowerLevelComposite)
-          .expectRenderedChild()
-          .toBeComponentOfType('div')
-          .toBeDOMComponentWithNoChildren();
+      var el = ReactDOM.findDOMNode(instance);
+      expect(el.tagName).toBe('DIV');
+      expect(el.children.length).toBe(0);
     };
   });
 
@@ -93,15 +90,11 @@ describe('ReactCompositeComponentDOMMinimalism', () => {
       </MyCompositeComponent>
     );
     instance = ReactTestUtils.renderIntoDocument(instance);
-    reactComponentExpect(instance)
-      .expectRenderedChild()
-      .toBeCompositeComponentWithType(LowerLevelComposite)
-        .expectRenderedChild()
-        .toBeComponentOfType('div')
-        .toBeDOMComponentWithChildCount(1)
-        .expectRenderedChildAt(0)
-          .toBeComponentOfType('ul')
-          .toBeDOMComponentWithNoChildren();
+    var el = ReactDOM.findDOMNode(instance);
+    expect(el.tagName).toBe('DIV');
+    expect(el.children.length).toBe(1);
+    expect(el.children[0].tagName).toBe('UL');
+    expect(el.children[0].children.length).toBe(0);
   });
 
 });

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactEmptyComponent-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactEmptyComponent-test.js
@@ -16,8 +16,6 @@ var ReactDOM;
 var ReactTestUtils;
 var TogglingComponent;
 
-var reactComponentExpect;
-
 var log;
 
 describe('ReactEmptyComponent', () => {
@@ -27,8 +25,6 @@ describe('ReactEmptyComponent', () => {
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactTestUtils = require('ReactTestUtils');
-
-    reactComponentExpect = require('reactComponentExpect');
 
     log = jasmine.createSpy();
 
@@ -51,7 +47,7 @@ describe('ReactEmptyComponent', () => {
     };
   });
 
-  it('should render null and false as a noscript tag under the hood', () => {
+  it('should not produce child DOM nodes for null and false', () => {
     class Component1 extends React.Component {
       render() {
         return null;
@@ -64,14 +60,13 @@ describe('ReactEmptyComponent', () => {
       }
     }
 
-    var instance1 = ReactTestUtils.renderIntoDocument(<Component1 />);
-    var instance2 = ReactTestUtils.renderIntoDocument(<Component2 />);
-    reactComponentExpect(instance1)
-      .expectRenderedChild()
-      .toBeEmptyComponent();
-    reactComponentExpect(instance2)
-      .expectRenderedChild()
-      .toBeEmptyComponent();
+    var container1 = document.createElement('div');
+    ReactDOM.render(<Component1 />, container1);
+    expect(container1.children.length).toBe(0);
+
+    var container2 = document.createElement('div');
+    ReactDOM.render(<Component2 />, container2);
+    expect(container2.children.length).toBe(0);
   });
 
   it('should still throw when rendering to undefined', () => {

--- a/src/renderers/shared/stack/reconciler/__tests__/refs-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/refs-test.js
@@ -14,9 +14,6 @@
 var React = require('React');
 var ReactTestUtils = require('ReactTestUtils');
 
-var reactComponentExpect = require('reactComponentExpect');
-
-
 /**
  * Counts clicks and has a renders an item for each click. Each item rendered
  * has a ref of the form "clickLogN".
@@ -92,17 +89,13 @@ class TestRefsComponent extends React.Component {
 var renderTestRefsComponent = function() {
   var testRefsComponent =
       ReactTestUtils.renderIntoDocument(<TestRefsComponent />);
-
-  reactComponentExpect(testRefsComponent)
-      .toBeCompositeComponentWithType(TestRefsComponent);
+  expect(testRefsComponent instanceof TestRefsComponent).toBe(true);
 
   var generalContainer = testRefsComponent.refs.myContainer;
-  var counter = testRefsComponent.refs.myCounter;
+  expect(generalContainer instanceof GeneralContainerComponent).toBe(true);
 
-  reactComponentExpect(generalContainer)
-      .toBeCompositeComponentWithType(GeneralContainerComponent);
-  reactComponentExpect(counter)
-      .toBeCompositeComponentWithType(ClickCounter);
+  var counter = testRefsComponent.refs.myCounter;
+  expect(counter instanceof ClickCounter).toBe(true);
 
   return testRefsComponent;
 };


### PR DESCRIPTION
This deletes our use of `reactComponentExpect` (which has never been a public API).
Pretty sure it was added at some point to save the time but here we are.

I haven't checked the use of this internally yet but if we do use it, we should either change those callsites or at least put it in the contrib folder and mark as deprecated.

This bumps from 960 to 967 tests on Fiber, but more importantly, it surfaces real errors instead of artificial ones.