### PR TITLE
[Fiber] Miscellaneous fixes to get more tests passing

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -555,6 +555,8 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
       });
     }
 
+    ReactCurrentOwner.current = null;
+
     // Surface the first error uncaught by the boundaries to the user.
     if (firstUncaughtError) {
       // We need to make sure any future root can get scheduled despite these errors.

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactComponent-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactComponent-test.js
@@ -13,12 +13,14 @@
 
 var React;
 var ReactDOM;
+var ReactDOMFeatureFlags;
 var ReactTestUtils;
 
 describe('ReactComponent', () => {
   beforeEach(() => {
     React = require('React');
     ReactDOM = require('ReactDOM');
+    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
     ReactTestUtils = require('ReactTestUtils');
   });
 
@@ -195,7 +197,7 @@ describe('ReactComponent', () => {
       getInner = () => {
         // (With old-style refs, it's impossible to get a ref to this div
         // because Wrapper is the current owner when this function is called.)
-        return <div title="inner" ref={(c) => this.innerRef = c} />;
+        return <div className="inner" ref={(c) => this.innerRef = c} />;
       };
 
       render() {
@@ -211,7 +213,7 @@ describe('ReactComponent', () => {
       componentDidMount() {
         // Check .props.title to make sure we got the right elements back
         expect(this.wrapperRef.getTitle()).toBe('wrapper');
-        expect(ReactDOM.findDOMNode(this.innerRef).title).toBe('inner');
+        expect(ReactDOM.findDOMNode(this.innerRef).className).toBe('inner');
         mounted = true;
       }
     }
@@ -291,10 +293,19 @@ describe('ReactComponent', () => {
         'outer componentDidMount',
       'start update',
         // Previous (equivalent) refs get cleared
-        'ref 1 got null',
-        'inner 1 render',
-        'ref 2 got null',
-        'inner 2 render',
+        ...(ReactDOMFeatureFlags.useFiber ? [
+          // Fiber renders first, resets refs later
+          'inner 1 render',
+          'inner 2 render',
+          'ref 1 got null',
+          'ref 2 got null',
+        ] : [
+          // Stack resets refs before rendering
+          'ref 1 got null',
+          'inner 1 render',
+          'ref 2 got null',
+          'inner 2 render',
+        ]),
         'inner 1 componentDidUpdate',
         'ref 1 got instance 1',
         'inner 2 componentDidUpdate',

--- a/src/renderers/shared/stack/reconciler/__tests__/refs-destruction-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/refs-destruction-test.js
@@ -45,9 +45,17 @@ describe('refs-destruction', () => {
     var testInstance = ReactDOM.render(<TestComponent />, container);
     expect(ReactTestUtils.isDOMComponent(testInstance.refs.theInnerDiv))
       .toBe(true);
-    expect(Object.keys(testInstance.refs || {}).length).toEqual(1);
+    expect(
+      Object.keys(testInstance.refs || {})
+        .filter(key => testInstance.refs[key])
+        .length
+    ).toEqual(1);
     ReactDOM.unmountComponentAtNode(container);
-    expect(Object.keys(testInstance.refs || {}).length).toEqual(0);
+    expect(
+      Object.keys(testInstance.refs || {})
+        .filter(key => testInstance.refs[key])
+        .length
+    ).toEqual(0);
   });
 
   it('should remove refs when destroying the child', () => {
@@ -55,9 +63,17 @@ describe('refs-destruction', () => {
     var testInstance = ReactDOM.render(<TestComponent />, container);
     expect(ReactTestUtils.isDOMComponent(testInstance.refs.theInnerDiv))
       .toBe(true);
-    expect(Object.keys(testInstance.refs || {}).length).toEqual(1);
+    expect(
+      Object.keys(testInstance.refs || {})
+        .filter(key => testInstance.refs[key])
+        .length
+    ).toEqual(1);
     ReactDOM.render(<TestComponent destroy={true} />, container);
-    expect(Object.keys(testInstance.refs || {}).length).toEqual(0);
+    expect(
+      Object.keys(testInstance.refs || {})
+        .filter(key => testInstance.refs[key])
+        .length
+    ).toEqual(0);
   });
 
   it('should not error when destroying child with ref asynchronously', () => {


### PR DESCRIPTION
1. Reset current owner in error handling as previously discussed
2. Relax a test that insists on `this.refs` being deleted rather than cleared out
3. Relax a test that insists on `refs` being cleared before render

I'm actually not sure if (3) is correct so I want to talk about this new behavior. If we don't clear refs before rendering, people can potentially rely on (stale) refs in render. In fact I've seen this pattern quite a bit in our layer code even with the old reconciler. Can/should we completely clear refs before calling render?