### PR TITLE
[Fiber] Cover all findDOMNode error cases in fiber

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -157,10 +157,19 @@ var ReactDOM = {
     }
     // Unsound duck typing.
     const component = (componentOrElement : any);
-    if (component.nodeType === 1) {
+    if (component.nodeType === 1) { // Element
       return component;
     }
-    return DOMRenderer.findHostInstance(component);
+    if (component.updater) { // Component
+      const whileRendering = component._reactInternalInstance.progressedChild;
+      if (!component.updater.isMounted(component) && whileRendering) {
+        throw new Error('findDOMNode was called on an unmounted component.');
+      }
+      return DOMRenderer.findHostInstance(component);
+    }
+    throw new Error(
+      `Element appears to be neither ReactComponent nor DOMNode (keys: ${Object.keys(component).join(', ')})`
+    );
   },
 
 };


### PR DESCRIPTION
The "throw" cases for `findDOMNode` were not covered by Fiber properly.
- If a component being rendered is not mounted: throw
- If the object passed to findDOMNode is neither a component or an element: throw
