### PR TITLE
Remove duplicated word in doc

### DIFF
--- a/docs/docs/state-and-lifecycle.md
+++ b/docs/docs/state-and-lifecycle.md
@@ -7,7 +7,7 @@ prev: components-and-props.html
 next: handling-events.html
 ---
 
-Consider the ticking clock example from the [one of the previous sections](/react/docs/rendering-elements.html#updating-the-rendered-element).
+Consider the ticking clock example from [one of the previous sections](/react/docs/rendering-elements.html#updating-the-rendered-element).
 
 So far we have only learned one way to update the UI.
 


### PR DESCRIPTION
Gets rid of an obsolete word in the documentation for "State and Lifecycle":

"Consider the ticking clock example from the one of the previous sections."
->
"Consider the ticking clock example from one of the previous sections."
