### PR TITLE
Optional queue transitions

### DIFF
--- a/docs/docs/addons-animation.md
+++ b/docs/docs/addons-animation.md
@@ -218,6 +218,29 @@ You can disable animating `enter` or `leave` animations if you want. For example
 >
 > When using `ReactCSSTransitionGroup`, there's no way for your components to be notified when a transition has ended or to perform any more complex logic around animation. If you want more fine-grained control, you can use the lower-level `ReactTransitionGroup` API which provides the hooks you need to do custom transitions.
 
+### Animation Queue
+
+Animations are queued by default. This is, if a component is removed before `enter` or `appear` animations end, `leave` animation will be queued, and will be fired when the first animation is finished.
+
+You can disable this behaviour by setting the `transitionQueue` property to false:
+```javascript{10}
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+
+function TransitionNoQueue(props) {
+  return (
+    <div>
+      <ReactCSSTransitionGroup
+        transitionName="noqueue"
+        transitionQueue={false}
+        transitionEnterTimeout={300}
+        transitionLeaveTimeout={300}>
+        <div>Instant leave animation</div>
+      </ReactCSSTransitionGroup>
+    </div>
+  );
+}
+```
+
 * * *
 
 ## Low-level API: ReactTransitionGroup

--- a/src/addons/transitions/ReactCSSTransitionGroup.js
+++ b/src/addons/transitions/ReactCSSTransitionGroup.js
@@ -55,6 +55,7 @@ class ReactCSSTransitionGroup extends React.Component {
     transitionAppear: React.PropTypes.bool,
     transitionEnter: React.PropTypes.bool,
     transitionLeave: React.PropTypes.bool,
+    transitionQueue: React.PropTypes.bool,
     transitionAppearTimeout: createTransitionTimeoutPropValidator('Appear'),
     transitionEnterTimeout: createTransitionTimeoutPropValidator('Enter'),
     transitionLeaveTimeout: createTransitionTimeoutPropValidator('Leave'),
@@ -64,6 +65,7 @@ class ReactCSSTransitionGroup extends React.Component {
     transitionAppear: false,
     transitionEnter: true,
     transitionLeave: true,
+    transitionQueue: true
   };
 
   _wrapChild = (child) => {
@@ -77,6 +79,7 @@ class ReactCSSTransitionGroup extends React.Component {
         appear: this.props.transitionAppear,
         enter: this.props.transitionEnter,
         leave: this.props.transitionLeave,
+        queue: this.props.transitionQueue,
         appearTimeout: this.props.transitionAppearTimeout,
         enterTimeout: this.props.transitionEnterTimeout,
         leaveTimeout: this.props.transitionLeaveTimeout,

--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -41,7 +41,6 @@ class ReactTransitionGroup extends React.Component {
   };
 
   componentWillMount() {
-    this.currentlyTransitioningKeys = {};
     this.keysToEnter = [];
     this.keysToLeave = [];
   }
@@ -80,16 +79,14 @@ class ReactTransitionGroup extends React.Component {
 
     for (key in nextChildMapping) {
       var hasPrev = prevChildMapping && prevChildMapping.hasOwnProperty(key);
-      if (nextChildMapping[key] && !hasPrev &&
-          !this.currentlyTransitioningKeys[key]) {
+      if (nextChildMapping[key] && !hasPrev) {
         this.keysToEnter.push(key);
       }
     }
 
     for (key in prevChildMapping) {
       var hasNext = nextChildMapping && nextChildMapping.hasOwnProperty(key);
-      if (prevChildMapping[key] && !hasNext &&
-          !this.currentlyTransitioningKeys[key]) {
+      if (prevChildMapping[key] && !hasNext) {
         this.keysToLeave.push(key);
       }
     }
@@ -100,16 +97,22 @@ class ReactTransitionGroup extends React.Component {
   componentDidUpdate() {
     var keysToEnter = this.keysToEnter;
     this.keysToEnter = [];
-    keysToEnter.forEach(this.performEnter);
+    keysToEnter.forEach((key) => {
+      if (this.refs[key].canTransition()) {
+        this.performEnter(key);
+      }
+    });
 
     var keysToLeave = this.keysToLeave;
     this.keysToLeave = [];
-    keysToLeave.forEach(this.performLeave);
+    keysToLeave.forEach((key) => {
+      if (this.refs[key].canTransition()) {
+        this.performLeave(key);
+      }
+    });
   }
 
   performAppear = (key) => {
-    this.currentlyTransitioningKeys[key] = true;
-
     var component = this.refs[key];
 
     if (component.componentWillAppear) {
@@ -126,8 +129,6 @@ class ReactTransitionGroup extends React.Component {
     if (component.componentDidAppear) {
       component.componentDidAppear();
     }
-
-    delete this.currentlyTransitioningKeys[key];
 
     var currentChildMapping;
     if (__DEV__) {
@@ -148,8 +149,6 @@ class ReactTransitionGroup extends React.Component {
   };
 
   performEnter = (key) => {
-    this.currentlyTransitioningKeys[key] = true;
-
     var component = this.refs[key];
 
     if (component.componentWillEnter) {
@@ -166,8 +165,6 @@ class ReactTransitionGroup extends React.Component {
     if (component.componentDidEnter) {
       component.componentDidEnter();
     }
-
-    delete this.currentlyTransitioningKeys[key];
 
     var currentChildMapping;
     if (__DEV__) {
@@ -188,8 +185,6 @@ class ReactTransitionGroup extends React.Component {
   };
 
   performLeave = (key) => {
-    this.currentlyTransitioningKeys[key] = true;
-
     var component = this.refs[key];
     if (component.componentWillLeave) {
       component.componentWillLeave(this._handleDoneLeaving.bind(this, key));
@@ -207,8 +202,6 @@ class ReactTransitionGroup extends React.Component {
     if (component.componentDidLeave) {
       component.componentDidLeave();
     }
-
-    delete this.currentlyTransitioningKeys[key];
 
     var currentChildMapping;
     if (__DEV__) {


### PR DESCRIPTION
Right now ReactCSSTransitionGroup forces ending one transition to start the next one. This is not the behaviour everyone wants, so I added a `transitionQueue` property which is `true` by default, and if set to `false` will disable transitions queues, so will force ending the current transition and inmediatelly start the next one.

I added this because I wanted `transitionLeave` to start as soon an element is removed, instead of waiting for `transitionEnter` to finish.