### PR TITLE
Fix docs on ReactElement

### DIFF
--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -97,7 +97,7 @@ function defineRefPropWarningGetter(props, displayName) {
 /**
  * Factory method to create a new React element. This no longer adheres to
  * the class pattern, so do not use new to call it. Also, no instanceof check
- * will work. Instead test $$typeof field against Symbol.for('react.element') to check
+ * will work. Instead test $$typeof field against REACT_ELEMENT_TYPE to check
  * if something is a React Element.
  *
  * @param {*} type


### PR DESCRIPTION
We should test $$typeof field against REACT_ELEMENT_TYPE to check if something is a React Element.
