### PR TITLE
[WIP] Set _hostNode in mountComponent / receiveComponent

### DIFF
--- a/src/renderers/testing/ReactTestRenderer.js
+++ b/src/renderers/testing/ReactTestRenderer.js
@@ -53,11 +53,13 @@ class ReactTestComponent {
   _currentElement: ReactElement;
   _renderedChildren: null | Object;
   _topLevelWrapper: null | ReactInstance;
+  _hostNode: null | Object;
 
   constructor(element: ReactElement) {
     this._currentElement = element;
     this._renderedChildren = null;
     this._topLevelWrapper = null;
+    this._hostNode = null;
   }
 
   mountComponent(
@@ -66,7 +68,10 @@ class ReactTestComponent {
     nativeContainerInfo: ?null,
     context: Object,
   ) {
+    var options = transaction.getTestOptions();
     var element = this._currentElement;
+    this._hostNode = options.createNodeMock(element);
+
     // $FlowFixMe https://github.com/facebook/flow/issues/1805
     this.mountChildren(element.props.children, transaction, context);
   }
@@ -76,7 +81,9 @@ class ReactTestComponent {
     transaction: ReactTestReconcileTransaction,
     context: Object,
   ) {
+    var options = transaction.getTestOptions();
     this._currentElement = nextElement;
+    this._hostNode = options.createNodeMock(nextElement);
     // $FlowFixMe https://github.com/facebook/flow/issues/1805
     this.updateChildren(nextElement.props.children, transaction, context);
   }

--- a/src/renderers/testing/__tests__/ReactTestRenderer-test.js
+++ b/src/renderers/testing/__tests__/ReactTestRenderer-test.js
@@ -12,6 +12,7 @@
 'use strict';
 
 var React = require('React');
+var findDOMNode = require('findDOMNode');
 var ReactTestRenderer = require('ReactTestRenderer');
 
 describe('ReactTestRenderer', () => {
@@ -362,6 +363,48 @@ describe('ReactTestRenderer', () => {
       'Boundary render',
       'Boundary componentDidMount',
     ]);
+  });
+
+  it('works with findDOMNode', () => {
+    let nodes = [];
+    function createNodeMock(element) {
+      return element.type;
+    }
+
+    class GrandChild extends React.Component {
+      render() {
+        return <h1>Grand child</h1>;
+      }
+    }
+
+    class Child extends React.Component {
+
+      componentDidMount() {
+        nodes.push(findDOMNode(this.ref));
+      }
+
+      render() {
+        return (
+          <ul>
+            <li>
+              <GrandChild ref={n => this.ref = n} />
+            </li>
+          </ul>
+        );
+      }
+    }
+
+    class Parent extends React.Component {
+      componentDidMount() {
+        nodes.push(findDOMNode(this.ref));
+      }
+
+      render() {
+        return <Child ref={n => this.ref = n}/>;
+      }
+    }
+    ReactTestRenderer.create(<Parent />, { createNodeMock });
+    expect(nodes).toEqual(['h1', 'ul']);
   });
 
 });


### PR DESCRIPTION
Adds support for `findDOMNode` with `ReactTestRenderer`, initially mentioned [here](https://github.com/facebook/react/issues/7770#issuecomment-255263096).

