### PR TITLE
[Fiber] [WIP] Errors shouldn't interfere with scheduling

### DIFF
--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -728,6 +728,11 @@ var ReactClassMixin = {
    * type signature and the only use case for this, is to avoid that.
    */
   replaceState: function(newState, callback) {
+    if (this.updater.isFiberUpdater) {
+      this.updater.enqueueReplaceState(this, newState, callback);
+      return;
+    }
+
     this.updater.enqueueReplaceState(this, newState);
     if (callback) {
       this.updater.enqueueCallback(this, callback, 'replaceState');

--- a/src/isomorphic/modern/class/ReactComponent.js
+++ b/src/isomorphic/modern/class/ReactComponent.js
@@ -65,6 +65,12 @@ ReactComponent.prototype.setState = function(partialState, callback) {
     'setState(...): takes an object of state variables to update or a ' +
     'function which returns an object of state variables.'
   );
+
+  if (this.updater.isFiberUpdater) {
+    this.updater.enqueueSetState(this, partialState, callback);
+    return;
+  }
+
   this.updater.enqueueSetState(this, partialState);
   if (callback) {
     this.updater.enqueueCallback(this, callback, 'setState');
@@ -86,6 +92,11 @@ ReactComponent.prototype.setState = function(partialState, callback) {
  * @protected
  */
 ReactComponent.prototype.forceUpdate = function(callback) {
+  if (this.updater.isFiberUpdater) {
+    this.updater.enqueueForceUpdate(this, callback);
+    return;
+  }
+
   this.updater.enqueueForceUpdate(this);
   if (callback) {
     this.updater.enqueueCallback(this, callback, 'forceUpdate');

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -165,6 +165,10 @@ var ReactDOM = {
     return DOMRenderer.findHostInstance(component);
   },
 
+  unstable_batchedUpdates(fn : Function) : void {
+    DOMRenderer.batchedUpdates(fn);
+  },
+
 };
 
 module.exports = ReactDOM;

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -165,8 +165,8 @@ var ReactDOM = {
     return DOMRenderer.findHostInstance(component);
   },
 
-  unstable_batchedUpdates(fn : Function) : void {
-    DOMRenderer.batchedUpdates(fn);
+  unstable_batchedUpdates<A>(fn : () => A) : A {
+    return DOMRenderer.batchedUpdates(fn);
   },
 
 };

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -112,6 +112,8 @@ var DOMRenderer = ReactFiberReconciler({
 
   scheduleDeferredCallback: window.requestIdleCallback,
 
+  useSyncScheduling: true,
+
 });
 
 var warned = false;

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -48,7 +48,7 @@ var ReactFiberClassComponent = require('ReactFiberClassComponent');
 
 module.exports = function<T, P, I, TI, C>(
   config : HostConfig<T, P, I, TI, C>,
-  scheduleUpdate : (fiber: Fiber, priorityLevel : PriorityLevel) => void
+  scheduleUpdate : (fiber: Fiber, priorityLevel : ?PriorityLevel) => void
 ) {
 
   const {

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -41,36 +41,35 @@ module.exports = function(scheduleUpdate : (fiber: Fiber, priorityLevel : ?Prior
   // Class component state updater
   const updater = {
     isMounted,
-    enqueueSetState(instance, partialState) {
+    enqueueSetState(instance, partialState, callback) {
       const fiber = ReactInstanceMap.get(instance);
       const updateQueue = fiber.updateQueue ?
         addToQueue(fiber.updateQueue, partialState) :
         createUpdateQueue(partialState);
+      if (callback) {
+        addCallbackToQueue(updateQueue, callback);
+      }
       scheduleUpdateQueue(fiber, updateQueue);
     },
-    enqueueReplaceState(instance, state) {
+    enqueueReplaceState(instance, state, callback) {
       const fiber = ReactInstanceMap.get(instance);
       const updateQueue = createUpdateQueue(state);
       updateQueue.isReplace = true;
+      if (callback) {
+        addCallbackToQueue(updateQueue, callback);
+      }
       scheduleUpdateQueue(fiber, updateQueue);
     },
-    enqueueForceUpdate(instance) {
+    enqueueForceUpdate(instance, callback) {
       const fiber = ReactInstanceMap.get(instance);
       const updateQueue = fiber.updateQueue || createUpdateQueue(null);
       updateQueue.isForced = true;
+      if (callback) {
+        addCallbackToQueue(updateQueue, callback);
+      }
       scheduleUpdateQueue(fiber, updateQueue);
     },
-    enqueueCallback(instance, callback) {
-      const fiber = ReactInstanceMap.get(instance);
-      let updateQueue = fiber.updateQueue ?
-        fiber.updateQueue :
-        createUpdateQueue(null);
-      addCallbackToQueue(updateQueue, callback);
-      fiber.updateQueue = updateQueue;
-      if (fiber.alternate) {
-        fiber.alternate.updateQueue = updateQueue;
-      }
-    },
+    isFiberUpdater: true,
   };
 
   function checkShouldComponentUpdate(workInProgress, oldProps, newProps, newState) {

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -16,7 +16,6 @@ import type { Fiber } from 'ReactFiber';
 import type { PriorityLevel } from 'ReactPriorityLevel';
 import type { UpdateQueue } from 'ReactFiberUpdateQueue';
 
-var { LowPriority } = require('ReactPriorityLevel');
 var {
   createUpdateQueue,
   addToQueue,
@@ -27,16 +26,16 @@ var { isMounted } = require('ReactFiberTreeReflection');
 var ReactInstanceMap = require('ReactInstanceMap');
 var shallowEqual = require('shallowEqual');
 
-module.exports = function(scheduleUpdate : (fiber: Fiber, priorityLevel : PriorityLevel) => void) {
+module.exports = function(scheduleUpdate : (fiber: Fiber, priorityLevel : ?PriorityLevel) => void) {
 
-  function scheduleUpdateQueue(fiber: Fiber, updateQueue: UpdateQueue, priorityLevel : PriorityLevel) {
+  function scheduleUpdateQueue(fiber: Fiber, updateQueue: UpdateQueue) {
     fiber.updateQueue = updateQueue;
     // Schedule update on the alternate as well, since we don't know which tree
     // is current.
     if (fiber.alternate) {
       fiber.alternate.updateQueue = updateQueue;
     }
-    scheduleUpdate(fiber, priorityLevel);
+    scheduleUpdate(fiber);
   }
 
   // Class component state updater
@@ -47,19 +46,19 @@ module.exports = function(scheduleUpdate : (fiber: Fiber, priorityLevel : Priori
       const updateQueue = fiber.updateQueue ?
         addToQueue(fiber.updateQueue, partialState) :
         createUpdateQueue(partialState);
-      scheduleUpdateQueue(fiber, updateQueue, LowPriority);
+      scheduleUpdateQueue(fiber, updateQueue);
     },
     enqueueReplaceState(instance, state) {
       const fiber = ReactInstanceMap.get(instance);
       const updateQueue = createUpdateQueue(state);
       updateQueue.isReplace = true;
-      scheduleUpdateQueue(fiber, updateQueue, LowPriority);
+      scheduleUpdateQueue(fiber, updateQueue);
     },
     enqueueForceUpdate(instance) {
       const fiber = ReactInstanceMap.get(instance);
       const updateQueue = fiber.updateQueue || createUpdateQueue(null);
       updateQueue.isForced = true;
-      scheduleUpdateQueue(fiber, updateQueue, LowPriority);
+      scheduleUpdateQueue(fiber, updateQueue);
     },
     enqueueCallback(instance, callback) {
       const fiber = ReactInstanceMap.get(instance);

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -130,7 +130,7 @@ module.exports = function(scheduleUpdate : (fiber: Fiber, priorityLevel : ?Prior
       // process them now.
       const updateQueue = workInProgress.updateQueue;
       if (updateQueue) {
-        instance.state = mergeUpdateQueue(updateQueue, state, props);
+        instance.state = mergeUpdateQueue(updateQueue, instance, state, props);
       }
     }
   }
@@ -174,7 +174,7 @@ module.exports = function(scheduleUpdate : (fiber: Fiber, priorityLevel : ?Prior
       // process them now.
       const newUpdateQueue = workInProgress.updateQueue;
       if (newUpdateQueue) {
-        newInstance.state = mergeUpdateQueue(newUpdateQueue, newState, newProps);
+        newInstance.state = mergeUpdateQueue(newUpdateQueue, newInstance, newState, newProps);
       }
     }
     return true;
@@ -211,7 +211,7 @@ module.exports = function(scheduleUpdate : (fiber: Fiber, priorityLevel : ?Prior
     // TODO: Previous state can be null.
     let newState;
     if (updateQueue) {
-      newState = mergeUpdateQueue(updateQueue, previousState, newProps);
+      newState = mergeUpdateQueue(updateQueue, instance, previousState, newProps);
     } else {
       newState = previousState;
     }

--- a/src/renderers/shared/fiber/ReactFiberErrorBoundary.js
+++ b/src/renderers/shared/fiber/ReactFiberErrorBoundary.js
@@ -13,14 +13,17 @@
 'use strict';
 
 import type { Fiber } from 'ReactFiber';
+import type { FiberRoot } from 'ReactFiberRoot';
 
 var {
   ClassComponent,
+  HostContainer,
 } = require('ReactTypeOfWork');
 
 export type TrappedError = {
   boundary: Fiber | null,
   error: any,
+  root: FiberRoot,
 };
 
 function findClosestErrorBoundary(fiber : Fiber): Fiber | null {
@@ -37,9 +40,24 @@ function findClosestErrorBoundary(fiber : Fiber): Fiber | null {
   return null;
 }
 
+function findRoot(fiber : Fiber) : FiberRoot {
+  while (fiber) {
+    if (!fiber.return) {
+      if (fiber.tag === HostContainer) {
+        return ((fiber.stateNode : any) : FiberRoot);
+      } else {
+        throw new Error('Invalid root');
+      }
+    }
+    fiber = fiber.return;
+  }
+  throw new Error('Could not find a root.');
+}
+
 function trapError(fiber : Fiber, error : any) : TrappedError {
   return {
     boundary: findClosestErrorBoundary(fiber),
+    root: findRoot(fiber),
     error,
   };
 }

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -68,6 +68,7 @@ export type Reconciler<C, I, TI> = {
   updateContainer(element : ReactElement<any>, container : OpaqueNode) : void,
   unmountContainer(container : OpaqueNode) : void,
   performWithPriority(priorityLevel : PriorityLevel, fn : Function) : void,
+  batchedUpdates(fn: Function) : void,
 
   // Used to extract the return value from the initial render. Legacy API.
   getPublicRootInstance(container : OpaqueNode) : (ReactComponent<any, any, any> | TI | I | null),
@@ -78,7 +79,11 @@ export type Reconciler<C, I, TI> = {
 
 module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) : Reconciler<C, I, TI> {
 
-  var { scheduleWork, performWithPriority } = ReactFiberScheduler(config);
+  var {
+    scheduleWork,
+    performWithPriority,
+    batchedUpdates,
+  } = ReactFiberScheduler(config);
 
   return {
 
@@ -141,6 +146,8 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) :
     },
 
     performWithPriority,
+
+    batchedUpdates,
 
     getPublicRootInstance(container : OpaqueNode) : (ReactComponent<any, any, any> | I | TI | null) {
       const root : FiberRoot = (container.stateNode : any);

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -56,8 +56,9 @@ export type HostConfig<T, P, I, TI, C> = {
   removeChild(parentInstance : I, child : I | TI) : void,
 
   scheduleAnimationCallback(callback : () => void) : void,
-  scheduleDeferredCallback(callback : (deadline : Deadline) => void) : void
+  scheduleDeferredCallback(callback : (deadline : Deadline) => void) : void,
 
+  useSyncScheduling ?: boolean,
 };
 
 type OpaqueNode = Fiber;

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -68,7 +68,10 @@ export type Reconciler<C, I, TI> = {
   updateContainer(element : ReactElement<any>, container : OpaqueNode) : void,
   unmountContainer(container : OpaqueNode) : void,
   performWithPriority(priorityLevel : PriorityLevel, fn : Function) : void,
-  batchedUpdates(fn: Function) : void,
+  /* eslint-disable no-undef */
+  // FIXME: ESLint complains about type parameter
+  batchedUpdates<A>(fn : () => A) : A,
+  /* eslint-enable no-undef */
 
   // Used to extract the return value from the initial render. Legacy API.
   getPublicRootInstance(container : OpaqueNode) : (ReactComponent<any, any, any> | TI | I | null),

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -28,7 +28,7 @@ if (__DEV__) {
 
 var { findCurrentHostFiber } = require('ReactFiberTreeReflection');
 
-type Deadline = {
+export type Deadline = {
   timeRemaining : () => number
 };
 

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -62,11 +62,14 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
 
   const scheduleAnimationCallback = config.scheduleAnimationCallback;
   const scheduleDeferredCallback = config.scheduleDeferredCallback;
+  const useSyncScheduling = config.useSyncScheduling;
 
   // The priority level to use when scheduling an update.
   let priorityContext : (PriorityLevel | null) = null;
   // The priority level to use if there is no priority context.
-  let defaultPriorityContext : PriorityLevel = LowPriority;
+  let defaultPriorityContext : PriorityLevel = useSyncScheduling ?
+    SynchronousPriority :
+    LowPriority;
 
   // The next work in progress fiber that we're currently working on.
   let nextUnitOfWork : ?Fiber = null;

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -417,17 +417,16 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
     // Always start from the root
     nextUnitOfWork = findNextUnitOfWork();
     while (nextUnitOfWork &&
-           nextPriorityLevel !== NoWork) {
+           nextPriorityLevel !== NoWork &&
+           nextPriorityLevel <= AnimationPriority) {
       nextUnitOfWork = performUnitOfWork(nextUnitOfWork, false);
       if (!nextUnitOfWork) {
         // Keep searching for animation work until there's no more left
         nextUnitOfWork = findNextUnitOfWork();
       }
-      // Stop if the next unit of work is low priority
-      if (nextPriorityLevel > AnimationPriority) {
-        scheduleDeferredCallback(performDeferredWork);
-        return;
-      }
+    }
+    if (nextUnitOfWork && nextPriorityLevel > AnimationPriority) {
+      scheduleDeferredCallback(performDeferredWork);
     }
   }
 

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -500,12 +500,10 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
   }
 
   function performSynchronousWork() {
-    if (useSyncScheduling) {
-      // Start batching updates
-      shouldBatchUpdates = true;
-    }
-    performAndHandleErrors(performSynchronousWorkUnsafe);
-    shouldBatchUpdates = false;
+    // All nested updates are batched
+    batchedUpdates(() => {
+      performAndHandleErrors(performSynchronousWorkUnsafe);
+    });
   }
 
   function scheduleSynchronousWork(root : FiberRoot) {
@@ -526,6 +524,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
       lastScheduledRoot = root;
 
       if (!shouldBatchUpdates) {
+        // Unless in batched mode, perform work immediately
         performSynchronousWork();
       }
     }
@@ -682,9 +681,20 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
     }
   }
 
+  function batchedUpdates(fn: Function) {
+    const prev = shouldBatchUpdates;
+    shouldBatchUpdates = true;
+    try {
+      fn();
+    } finally {
+      shouldBatchUpdates = prev;
+    }
+  }
+
   return {
     scheduleWork: scheduleWork,
     scheduleDeferredWork: scheduleDeferredWork,
     performWithPriority: performWithPriority,
+    batchedUpdates: batchedUpdates,
   };
 };

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -15,7 +15,7 @@
 import type { TrappedError } from 'ReactFiberErrorBoundary';
 import type { Fiber } from 'ReactFiber';
 import type { FiberRoot } from 'ReactFiberRoot';
-import type { HostConfig } from 'ReactFiberReconciler';
+import type { HostConfig, Deadline } from 'ReactFiberReconciler';
 import type { PriorityLevel } from 'ReactPriorityLevel';
 
 var ReactFiberBeginWork = require('ReactFiberBeginWork');
@@ -371,7 +371,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
   }
 
   function performDeferredWork(deadline) {
-    performAndHandleErrors(performDeferredWorkUnsafe, deadline);
+    performAndHandleErrors(LowPriority, deadline);
   }
 
   function scheduleDeferredWork(root : FiberRoot, priority : PriorityLevel) {
@@ -424,7 +424,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
   }
 
   function performAnimationWork() {
-    performAndHandleErrors(performAnimationWorkUnsafe);
+    performAndHandleErrors(AnimationPriority);
   }
 
   function scheduleAnimationWork(root: FiberRoot, priorityLevel : PriorityLevel) {
@@ -502,7 +502,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
     shouldBatchUpdates = true;
     // All nested updates are batched
     try {
-      performAndHandleErrors(performSynchronousWorkUnsafe);
+      performAndHandleErrors(SynchronousPriority);
     } finally {
       shouldBatchUpdates = prev;
     }
@@ -532,9 +532,22 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
     }
   }
 
-  function performAndHandleErrors<A>(fn: (a: A) => void, a: A) {
+  function performAndHandleErrors(priorityLevel : PriorityLevel, deadline : ?Deadline) {
+    // The exact priority level doesn't matter, so long as it's in range of the
+    // work (sync, animation, deferred) being performed.
     try {
-      fn(a);
+      if (priorityLevel === SynchronousPriority) {
+        performSynchronousWorkUnsafe();
+      }
+      if (priorityLevel > AnimationPriority) {
+        if (!deadline) {
+          throw new Error('No deadline');
+        } else {
+          performDeferredWorkUnsafe(deadline);
+        }
+        return;
+      }
+      performAnimationWorkUnsafe();
     } catch (error) {
       const failedUnitOfWork = nextUnitOfWork;
       // Reset because it points to the error boundary:

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -673,11 +673,11 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
     }
   }
 
-  function batchedUpdates(fn: Function) {
+  function batchedUpdates<A>(fn : () => A) : A {
     const prev = shouldBatchUpdates;
     shouldBatchUpdates = true;
     try {
-      fn();
+      return fn();
     } finally {
       shouldBatchUpdates = prev;
     }

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -65,9 +65,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
   const useSyncScheduling = config.useSyncScheduling;
 
   // The priority level to use when scheduling an update.
-  let priorityContext : (PriorityLevel | null) = null;
-  // The priority level to use if there is no priority context.
-  let defaultPriorityContext : PriorityLevel = useSyncScheduling ?
+  let priorityContext : PriorityLevel = useSyncScheduling ?
     SynchronousPriority :
     LowPriority;
 
@@ -583,9 +581,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
 
       // We will process an update caused by each error boundary synchronously.
       affectedBoundaries.forEach(boundary => {
-        const priority = priorityContext !== null ?
-          priorityContext :
-          defaultPriorityContext;
+        const priority = priorityContext;
         const root = scheduleErrorBoundaryWork(boundary, priority);
         // This should use findNextUnitOfWork() when synchronous scheduling is implemented.
         let fiber = cloneFiber(root.current, priority);
@@ -620,9 +616,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
 
   function scheduleWork(root : FiberRoot, priorityLevel : ?PriorityLevel) {
     if (priorityLevel == null) {
-      priorityLevel = priorityContext !== null ?
-        priorityContext :
-        defaultPriorityContext;
+      priorityLevel = priorityContext;
     }
 
     if (priorityLevel === SynchronousPriority) {
@@ -642,9 +636,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
   function scheduleUpdate(fiber: Fiber, priorityLevel : ?PriorityLevel): void {
     // Use priority context if no priority is provided
     if (priorityLevel == null) {
-      priorityLevel = priorityContext !== null ?
-        priorityContext :
-        defaultPriorityContext;
+      priorityLevel = priorityContext;
     }
 
     while (true) {

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -63,8 +63,10 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
   const scheduleAnimationCallback = config.scheduleAnimationCallback;
   const scheduleDeferredCallback = config.scheduleDeferredCallback;
 
-  // The default priority to use for updates.
-  let defaultPriority : PriorityLevel = LowPriority;
+  // The priority level to use when scheduling an update.
+  let priorityContext : (PriorityLevel | null) = null;
+  // The priority level to use if there is no priority context.
+  let defaultPriorityContext : PriorityLevel = LowPriority;
 
   // The next work in progress fiber that we're currently working on.
   let nextUnitOfWork : ?Fiber = null;
@@ -477,7 +479,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
     while (nextUnitOfWork &&
            nextPriorityLevel === SynchronousPriority) {
       nextUnitOfWork = performUnitOfWork(nextUnitOfWork, false);
-      // If there's no nextUnitForWork, we don't need to search for more
+      // If there's no nextUnitOfWork, we don't need to search for more
       // because it shouldn't be possible to schedule sync work without
       // immediately performing it
     }
@@ -583,23 +585,45 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
     }
   }
 
-  function scheduleWork(root : FiberRoot) {
-    if (defaultPriority === SynchronousPriority) {
+  function scheduleWork(root : FiberRoot, priorityLevel : ?PriorityLevel) {
+    if (priorityLevel == null) {
+      priorityLevel = priorityContext !== null ?
+        priorityContext :
+        defaultPriorityContext;
+    }
+
+    if (priorityLevel === SynchronousPriority) {
       root.current.pendingWorkPriority = SynchronousPriority;
       performSynchronousWork();
     }
 
-    if (defaultPriority === NoWork) {
+    if (priorityLevel === NoWork) {
       return;
     }
-    if (defaultPriority > AnimationPriority) {
-      scheduleDeferredWork(root, defaultPriority);
+    if (priorityLevel > AnimationPriority) {
+      scheduleDeferredWork(root, priorityLevel);
       return;
     }
-    scheduleAnimationWork(root, defaultPriority);
+    scheduleAnimationWork(root, priorityLevel);
   }
 
-  function scheduleUpdate(fiber: Fiber, priorityLevel : PriorityLevel): void {
+  function scheduleUpdate(fiber: Fiber, priorityLevel : ?PriorityLevel): void {
+    // Use priority context if no priority is provided
+    if (priorityLevel == null) {
+      priorityLevel = priorityContext !== null ?
+        priorityContext :
+        defaultPriorityContext;
+    }
+
+    // Don't bother bubbling the priority to the root if it is synchronous. Just
+    // perform it now.
+    if (priorityLevel === SynchronousPriority) {
+      fiber.pendingWorkPriority = SynchronousPriority;
+      nextUnitOfWork = fiber;
+      performSynchronousWork();
+      return;
+    }
+
     while (true) {
       if (fiber.pendingWorkPriority === NoWork ||
           fiber.pendingWorkPriority >= priorityLevel) {
@@ -614,7 +638,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
       if (!fiber.return) {
         if (fiber.tag === HostContainer) {
           const root : FiberRoot = (fiber.stateNode : any);
-          scheduleDeferredWork(root, priorityLevel);
+          scheduleWork(root, priorityLevel);
           return;
         } else {
           throw new Error('Invalid root');
@@ -625,12 +649,12 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
   }
 
   function performWithPriority(priorityLevel : PriorityLevel, fn : Function) {
-    const previousDefaultPriority = defaultPriority;
-    defaultPriority = priorityLevel;
+    const previousPriorityContext = priorityContext;
+    priorityContext = priorityLevel;
     try {
       fn();
     } finally {
-      defaultPriority = previousDefaultPriority;
+      priorityContext = previousPriorityContext;
     }
   }
 

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -365,20 +365,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
   }
 
   function performDeferredWork(deadline) {
-    try {
-      performDeferredWorkUnsafe(deadline);
-    } catch (error) {
-      const failedUnitOfWork = nextUnitOfWork;
-      // Reset because it points to the error boundary:
-      nextUnitOfWork = null;
-      if (!failedUnitOfWork) {
-        // We shouldn't end up here because nextUnitOfWork
-        // should always be set while work is being performed.
-        throw error;
-      }
-      const trappedError = trapError(failedUnitOfWork, error);
-      handleErrors([trappedError]);
-    }
+    performAndHandleErrors(performDeferredWorkUnsafe, deadline);
   }
 
   function scheduleDeferredWork(root : FiberRoot, priority : PriorityLevel) {
@@ -431,20 +418,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
   }
 
   function performAnimationWork() {
-    try {
-      performAnimationWorkUnsafe();
-    } catch (error) {
-      const failedUnitOfWork = nextUnitOfWork;
-      // Reset because it points to the error boundary:
-      nextUnitOfWork = null;
-      if (!failedUnitOfWork) {
-        // We shouldn't end up here because nextUnitOfWork
-        // should always be set while work is being performed.
-        throw error;
-      }
-      const trappedError = trapError(failedUnitOfWork, error);
-      handleErrors([trappedError]);
-    }
+    performAndHandleErrors(performAnimationWorkUnsafe);
   }
 
   function scheduleAnimationWork(root: FiberRoot, priorityLevel : PriorityLevel) {
@@ -495,6 +469,46 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
       throw new Error('Could not find root from the boundary.');
     }
     return root;
+  }
+
+  function performSynchronousWorkUnsafe() {
+    // Perform work now
+    nextUnitOfWork = findNextUnitOfWork();
+    while (nextUnitOfWork &&
+           nextPriorityLevel === SynchronousPriority) {
+      nextUnitOfWork = performUnitOfWork(nextUnitOfWork, false);
+      // If there's no nextUnitForWork, we don't need to search for more
+      // because it shouldn't be possible to schedule sync work without
+      // immediately performing it
+    }
+    if (nextUnitOfWork) {
+      if (nextPriorityLevel > AnimationPriority) {
+        scheduleDeferredCallback(performDeferredWork);
+        return;
+      }
+      scheduleAnimationCallback(performAnimationWork);
+    }
+  }
+
+  function performSynchronousWork() {
+    performAndHandleErrors(performSynchronousWorkUnsafe);
+  }
+
+  function performAndHandleErrors<A>(fn: (a: A) => void, a: A) {
+    try {
+      fn(a);
+    } catch (error) {
+      const failedUnitOfWork = nextUnitOfWork;
+      // Reset because it points to the error boundary:
+      nextUnitOfWork = null;
+      if (!failedUnitOfWork) {
+        // We shouldn't end up here because nextUnitOfWork
+        // should always be set while work is being performed.
+        throw error;
+      }
+      const trappedError = trapError(failedUnitOfWork, error);
+      handleErrors([trappedError]);
+    }
   }
 
   function handleErrors(initialTrappedErrors : Array<TrappedError>) : void {
@@ -571,7 +585,8 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
 
   function scheduleWork(root : FiberRoot) {
     if (defaultPriority === SynchronousPriority) {
-      throw new Error('Not implemented yet');
+      root.current.pendingWorkPriority = SynchronousPriority;
+      performSynchronousWork();
     }
 
     if (defaultPriority === NoWork) {

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -71,6 +71,9 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
     SynchronousPriority :
     LowPriority;
 
+  // Whether updates should be batched. Only applies when using sync scheduling.
+  let shouldBatchUpdates : boolean = false;
+
   // The next work in progress fiber that we're currently working on.
   let nextUnitOfWork : ?Fiber = null;
   let nextPriorityLevel : PriorityLevel = NoWork;
@@ -482,9 +485,10 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
     while (nextUnitOfWork &&
            nextPriorityLevel === SynchronousPriority) {
       nextUnitOfWork = performUnitOfWork(nextUnitOfWork, false);
-      // If there's no nextUnitOfWork, we don't need to search for more
-      // because it shouldn't be possible to schedule sync work without
-      // immediately performing it
+
+      if (!nextUnitOfWork && shouldBatchUpdates) {
+        nextUnitOfWork = findNextUnitOfWork();
+      }
     }
     if (nextUnitOfWork) {
       if (nextPriorityLevel > AnimationPriority) {
@@ -496,7 +500,35 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
   }
 
   function performSynchronousWork() {
+    if (useSyncScheduling) {
+      // Start batching updates
+      shouldBatchUpdates = true;
+    }
     performAndHandleErrors(performSynchronousWorkUnsafe);
+    shouldBatchUpdates = false;
+  }
+
+  function scheduleSynchronousWork(root : FiberRoot) {
+    root.current.pendingWorkPriority = SynchronousPriority;
+
+    if (root.isScheduled) {
+      // If we're already scheduled, we can bail out.
+      return;
+    }
+    root.isScheduled = true;
+    if (lastScheduledRoot) {
+      // Schedule ourselves to the end.
+      lastScheduledRoot.nextScheduledRoot = root;
+      lastScheduledRoot = root;
+    } else {
+      // We're the only work scheduled.
+      nextScheduledRoot = root;
+      lastScheduledRoot = root;
+
+      if (!shouldBatchUpdates) {
+        performSynchronousWork();
+      }
+    }
   }
 
   function performAndHandleErrors<A>(fn: (a: A) => void, a: A) {
@@ -552,10 +584,9 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
 
       // We will process an update caused by each error boundary synchronously.
       affectedBoundaries.forEach(boundary => {
-        // FIXME: We only specify LowPriority here so that setState() calls from the error
-        // boundaries are respected. Instead we should set default priority level or something
-        // like this. Reconsider this piece when synchronous scheduling is in place.
-        const priority = LowPriority;
+        const priority = priorityContext !== null ?
+          priorityContext :
+          defaultPriorityContext;
         const root = scheduleErrorBoundaryWork(boundary, priority);
         // This should use findNextUnitOfWork() when synchronous scheduling is implemented.
         let fiber = cloneFiber(root.current, priority);
@@ -596,8 +627,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
     }
 
     if (priorityLevel === SynchronousPriority) {
-      root.current.pendingWorkPriority = SynchronousPriority;
-      performSynchronousWork();
+      scheduleSynchronousWork(root);
     }
 
     if (priorityLevel === NoWork) {
@@ -616,15 +646,6 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
       priorityLevel = priorityContext !== null ?
         priorityContext :
         defaultPriorityContext;
-    }
-
-    // Don't bother bubbling the priority to the root if it is synchronous. Just
-    // perform it now.
-    if (priorityLevel === SynchronousPriority) {
-      fiber.pendingWorkPriority = SynchronousPriority;
-      nextUnitOfWork = fiber;
-      performSynchronousWork();
-      return;
     }
 
     while (true) {

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -73,14 +73,14 @@ exports.callCallbacks = function(queue : UpdateQueue, context : any) {
   }
 };
 
-exports.mergeUpdateQueue = function(queue : UpdateQueue, prevState : any, props : any) : any {
+exports.mergeUpdateQueue = function(queue : UpdateQueue, instance : any, prevState : any, props : any) : any {
   let node : ?UpdateQueueNode = queue;
   let state = queue.isReplace ? null : Object.assign({}, prevState);
   while (node) {
     let partialState;
     if (typeof node.partialState === 'function') {
       const updateFn = node.partialState;
-      partialState = updateFn(state, props);
+      partialState = updateFn.call(instance, state, props);
     } else {
       partialState = node.partialState;
     }

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling.js
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+describe('ReactIncrementalErrorBoundaries', () => {
+  var React;
+  var ReactNoop;
+  var ErrorBoundary;
+
+  beforeEach(() => {
+    React = require('React');
+    ReactNoop = require('ReactNoop');
+  });
+
+  it('can schedule updates after crashing in render on mount', () => {
+    var ops = [];
+
+    function BrokenRender() {
+      ops.push('BrokenRender');
+      throw new Error('Hello.');
+    }
+
+    function Foo() {
+      ops.push('Foo');
+      return null;
+    }
+
+    ReactNoop.render(<BrokenRender />);
+    expect(() => {
+      ReactNoop.flush();
+    }).toThrow('Hello.');
+    expect(ops).toEqual(['BrokenRender']);
+
+    ops = [];
+    ReactNoop.render(<Foo />);
+    ReactNoop.flush();
+    expect(ops).toEqual(['Foo']);
+  });
+
+  it('can schedule updates after crashing in render on update', () => {
+    var ops = [];
+
+    function BrokenRender(props) {
+      ops.push('BrokenRender');
+      if (props.throw) {
+        throw new Error('Hello.');
+      }
+    }
+
+    function Foo() {
+      ops.push('Foo');
+      return null;
+    }
+
+    ReactNoop.render(<BrokenRender throw={false} />);
+    ReactNoop.flush();
+    ops = [];
+
+    expect(() => {
+      ReactNoop.render(<BrokenRender throw={true} />);
+      ReactNoop.flush();
+    }).toThrow('Hello.');
+    expect(ops).toEqual(['BrokenRender']);
+
+    ops = [];
+    ReactNoop.render(<Foo />);
+    ReactNoop.flush();
+    expect(ops).toEqual(['Foo']);
+  });
+
+  it('can schedule updates after crashing during umounting', () => {
+    var ops = [];
+
+    class BrokenComponentWillUnmount extends React.Component {
+      render() {
+        return <div />;
+      }
+      componentWillUnmount() {
+        throw new Error('Hello.');
+      }
+    }
+
+    function Foo() {
+      ops.push('Foo');
+      return null;
+    }
+
+    ReactNoop.render(<BrokenComponentWillUnmount />);
+    ReactNoop.flush();
+
+    expect(() => {
+      ReactNoop.render(<div />);
+      ReactNoop.flush();
+    }).toThrow('Hello.');
+
+    ops = [];
+    ReactNoop.render(<Foo />);
+    ReactNoop.flush();
+    expect(ops).toEqual(['Foo']);
+  });
+
+});


### PR DESCRIPTION
Builds on #8127.
This is probably incomplete and there may be ways to simplify.
It removes the recursion from error handling and makes scheduling resilient to errors.