### PR TITLE
Update Flow version to v0.34.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -35,4 +35,4 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 
 [version]
-^0.33.0
+^0.34.0

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint-plugin-react-internal": "file:eslint-rules",
     "fbjs": "^0.8.5",
     "fbjs-scripts": "^0.6.0",
-    "flow-bin": "^0.33.0",
+    "flow-bin": "^0.34.0",
     "glob": "^6.0.1",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",

--- a/src/renderers/native/ReactNativeAttributePayload.js
+++ b/src/renderers/native/ReactNativeAttributePayload.js
@@ -37,6 +37,8 @@ type CustomAttributeConfiguration =
 
 type AttributeConfiguration =
   { [key: string]: (
+    // This can be fixed with `+`, unfortunately babylon 6.8.0 can't parse that.
+    // $FlowFixMe: dictionary types are invariant by default from Flow v0.34.0
     CustomAttributeConfiguration | AttributeConfiguration /*| boolean*/
   ) };
 

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -291,7 +291,7 @@ exports.createFiberFromText = function(content : string, priorityLevel : Priorit
   return fiber;
 };
 
-function createFiberFromElementType(type : mixed, key : null | string) : Fiber {
+function createFiberFromElementType(type : any, key : null | string) : Fiber {
   let fiber;
   if (typeof type === 'function') {
     fiber = shouldConstruct(type) ?


### PR DESCRIPTION
This PR is to update Flowtype version to `v0.34.0` and fix some errors.

In Flowtype `v0.34.0`, dictionary types are treated as `invariant`.

* https://github.com/facebook/flow/releases/tag/v0.34.0

In the following case, it has to explicit covariance with `+`.

* ReactNativeAttributePayload.js

```js
type AttributeConfiguration =
  { [key: string]: (
    CustomAttributeConfiguration | AttributeConfiguration /*| boolean*/
  ) };
```

But I avoid the error by using `$FlowFixMe` comment because it's needed some works like this.

1. The covariant syntax(`+`) causes a parse error in ESLint.
2. To fix it, we have to update `babylon` for parse covariant syntax with `+`.
3. `2.` causes other ESLint errors, which are `no-undef` for type parameters.
4. To fix them, We have to use `eslint-plugin-flowtype`.
5. To install `eslint-plugin-flowtype`, We have to update ESLint to `>=2.0.0` because of `peerDependencies`.
7. `5.` causes other ESLint errors, We have to fix them. 

Can I work on this?
If so, I'll work on this as other PRs. 