### PR TITLE
[Fiber] Add more tests for scheduling

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -795,9 +795,27 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalReflection-test.js
 * finds no node before insertion and correct node before deletion
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
-* schedules multiple roots
-* works on deferred roots in the order they were scheduled
-* works on roots with animation priority before deferred work
+* schedules and flushes hi-pri work
+* schedules and flushes hi-pri work for many roots
+* flushes all scheduled hi-pri work
+* flushes all scheduled hi-pri work for many roots
+* schedules and flushes lo-pri work
+* schedules and flushes lo-pri work for many roots
+* flushes scheduled lo-pri work fitting within deadline
+* flushes scheduled lo-pri work fitting within deadline for many roots
+* schedules more lo-pri work if it runs out of time
+* schedules more lo-pri work if it runs out of time with many roots
+* FIXME: flushes late hi-pri work in a lo-pri callback if it wins
+* FIXME: flushes late hi-pri work in a lo-pri callback if it wins with many roots
+* FIXME: ignores late hi-pri work in a hi-pri callback if it wins
+* FIXME: ignores late hi-pri work in a hi-pri callback if it wins with many roots
+* FIXME: ignores all work in a lo-pri callback if it wins
+* FIXME: ignores all work in a lo-pri callback if it wins with many roots
+* flushes root with late lo-pri work in a hi-pri callback if it wins
+* flushes all roots with hi-pri work in a hi-pri callback if it wins
+* splits lo-pri work on multiple roots
+* works on lo-pri roots in the order they were scheduled
+* handles interleaved lo-pri and hi-pri work
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
 * can update child nodes of a host instance

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -136,10 +136,22 @@ var NoopRenderer = ReactFiberReconciler({
   },
 
   scheduleAnimationCallback(callback) {
+    if (scheduledAnimationCallback) {
+      throw new Error(
+        'Scheduling an animation callback twice is excessive. ' +
+        'Instead, keep track of whether the callback has already been scheduled.'
+      );
+    }
     scheduledAnimationCallback = callback;
   },
 
   scheduleDeferredCallback(callback) {
+    if (scheduledDeferredCallback) {
+      throw new Error(
+        'Scheduling deferred callback twice is excessive. ' +
+        'Instead, keep track of whether the callback has already been scheduled.'
+      );
+    }
     scheduledDeferredCallback = callback;
   },
 
@@ -158,6 +170,14 @@ var ReactNoop = {
     } else {
       return null;
     }
+  },
+
+  hasScheduledDeferredCallback() {
+    return Boolean(scheduledDeferredCallback);
+  },
+
+  hasScheduledAnimationCallback() {
+    return Boolean(scheduledAnimationCallback);
   },
 
   // Shortcut for testing a single root

--- a/src/renderers/shared/fiber/__tests__/ReactCoroutine-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactCoroutine-test.js
@@ -17,6 +17,7 @@ var ReactCoroutine;
 
 describe('ReactCoroutine', () => {
   beforeEach(() => {
+    jest.resetModuleRegistry();
     React = require('React');
     ReactNoop = require('ReactNoop');
     ReactCoroutine = require('ReactCoroutine');

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -16,6 +16,7 @@ var ReactNoop;
 
 describe('ReactIncremental', () => {
   beforeEach(() => {
+    jest.resetModuleRegistry();
     React = require('React');
     ReactNoop = require('ReactNoop');
   });

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalReflection-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalReflection-test.js
@@ -16,6 +16,7 @@ var ReactNoop;
 
 describe('ReactIncrementalReflection', () => {
   beforeEach(() => {
+    jest.resetModuleRegistry();
     React = require('React');
     ReactNoop = require('ReactNoop');
   });

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
@@ -25,7 +25,7 @@ describe('ReactIncrementalScheduling', () => {
     return { type: 'span', children: [], prop };
   }
 
-  it('schedules and flushes hi-pri work', () => {
+  it('schedules and flushes animation work', () => {
     ReactNoop.performAnimationWork(() => {
       ReactNoop.render(<span prop="1" />);
     });
@@ -39,7 +39,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren()).toEqual([span('1')]);
   });
 
-  it('schedules and flushes hi-pri work for many roots', () => {
+  it('schedules and flushes animation work for many roots', () => {
     ReactNoop.performAnimationWork(() => {
       ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
       ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
@@ -59,7 +59,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
   });
 
-  it('flushes all scheduled hi-pri work', () => {
+  it('flushes all scheduled animation work', () => {
     ReactNoop.performAnimationWork(() => {
       ReactNoop.render(<span prop="1" />);
     });
@@ -76,7 +76,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren()).toEqual([span('2')]);
   });
 
-  it('flushes all scheduled hi-pri work for many roots', () => {
+  it('flushes all scheduled animation work for many roots', () => {
     ReactNoop.performAnimationWork(() => {
       ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
       ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
@@ -101,7 +101,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
   });
 
-  it('schedules and flushes lo-pri work', () => {
+  it('schedules and flushes deferred work', () => {
     ReactNoop.render(<span prop="1" />);
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
     expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
@@ -113,7 +113,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren()).toEqual([span('1')]);
   });
 
-  it('schedules and flushes lo-pri work for many roots', () => {
+  it('schedules and flushes deferred work for many roots', () => {
     ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
     ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
     ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
@@ -131,7 +131,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
   });
 
-  it('flushes scheduled lo-pri work fitting within deadline', () => {
+  it('flushes scheduled deferred work fitting within deadline', () => {
     ReactNoop.render(<span prop="1" />);
     ReactNoop.render(<span prop="2" />);
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
@@ -144,7 +144,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren()).toEqual([span('2')]);
   });
 
-  it('flushes scheduled lo-pri work fitting within deadline for many roots', () => {
+  it('flushes scheduled deferred work fitting within deadline for many roots', () => {
     ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
     ReactNoop.renderToRootWithID(<span prop="a:2" />, 'a');
     ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
@@ -165,7 +165,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
   });
 
-  it('schedules more lo-pri work if it runs out of time', () => {
+  it('schedules more deferred work if it runs out of time', () => {
     ReactNoop.render(<span prop="1" />);
     ReactNoop.render(<span prop="2" />);
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
@@ -188,7 +188,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren()).toEqual([span('2')]);
   });
 
-  it('schedules more lo-pri work if it runs out of time with many roots', () => {
+  it('schedules more deferred work if it runs out of time with many roots', () => {
     ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
     ReactNoop.renderToRootWithID(<span prop="a:2" />, 'a');
     ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
@@ -223,41 +223,41 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
   });
 
-  it('FIXME: flushes late hi-pri work in a lo-pri callback if it wins', () => {
-    // Schedule early lo-pri
+  it('FIXME: flushes late animation work in a deferred callback if it wins', () => {
+    // Schedule early deferred
     ReactNoop.render(<span prop="1" />);
-    // Schedule late hi-pri
+    // Schedule late animation
     ReactNoop.performAnimationWork(() => {
       ReactNoop.render(<span prop="2" />);
     });
 
-    // FIXME: I would expect true here because we should have scheduled a hi-pri callback:
+    // FIXME: I would expect true here because we should have scheduled an animation callback:
     // expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
     expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.getChildren()).toEqual([]);
 
-    // We only scheduled lo-pri callback so that's what we get.
+    // We only scheduled deferred callback so that's what we get.
     // It will flush everything.
     ReactNoop.flushDeferredPri();
-    // TODO: I would expect true here because we should have tried to schedule hi-pri sooner:
+    // TODO: I would expect true here because we should have tried to schedule animation sooner:
     // expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
     expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren()).toEqual([span('2')]);
   });
 
-  it('FIXME: flushes late hi-pri work in a lo-pri callback if it wins with many roots', () => {
-    // Schedule early lo-pri
+  it('FIXME: flushes late animation work in a deferred callback if it wins with many roots', () => {
+    // Schedule early deferred
     ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
     ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
-    // Schedule late hi-pri
+    // Schedule late animation
     ReactNoop.performAnimationWork(() => {
       ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
       ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
     });
 
-    // FIXME: I would expect true here because we should have scheduled a hi-pri callback:
+    // FIXME: I would expect true here because we should have scheduled an animation callback:
     // expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
     expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
@@ -265,10 +265,10 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
 
-    // We only scheduled lo-pri callback so that's what we get.
+    // We only scheduled deferred callback so that's what we get.
     // It will flush everything.
     ReactNoop.flushDeferredPri();
-    // TODO: I would expect true here because we tried to schedule hi-pri sooner, and so it would still be scheduled:
+    // TODO: I would expect true here because we tried to schedule animation sooner, and so it would still be scheduled:
     // expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
     expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
@@ -278,32 +278,32 @@ describe('ReactIncrementalScheduling', () => {
   });
 
   // This test documents the existing behavior. Desired behavior:
-  // it('flushes late hi-pri work in a hi-pri callback if it wins', () => {
-  it('FIXME: ignores late hi-pri work in a hi-pri callback if it wins', () => {
-    // Schedule early lo-pri
+  // it('flushes late animation work in an animation callback if it wins', () => {
+  it('FIXME: ignores late animation work in an animation callback if it wins', () => {
+    // Schedule early deferred
     ReactNoop.render(<span prop="1" />);
-    // Schedule late hi-pri
+    // Schedule late animation
     ReactNoop.performAnimationWork(() => {
       ReactNoop.render(<span prop="2" />);
     });
 
-    // FIXME: I would expect true here because we should have scheduled a hi-pri callback:
+    // FIXME: I would expect true here because we should have scheduled an animation callback:
     // expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
     expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.getChildren()).toEqual([]);
 
-    // Flushing hi-pri should have flushed the hi-pri.
+    // Flushing animation should have flushed the animation.
     // FIXME: But it currently doesn't.
     // Technically we didn't schedule this callback. This test is valid because we should have scheduled it.
     ReactNoop.flushAnimationPri();
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
     expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
-    // TODO: I would expect [span('2')] here because it was scheduled as hi-pri:
+    // TODO: I would expect [span('2')] here because it was scheduled as animation:
     // expect(ReactNoop.getChildren()).toEqual([span('2')]);
     expect(ReactNoop.getChildren()).toEqual([]);
 
-    // TODO: I wouldn't expect this flush to be necessary for hi-pri work to kick in.
+    // TODO: I wouldn't expect this flush to be necessary for animation work to kick in.
     ReactNoop.flushDeferredPri();
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
     expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
@@ -311,18 +311,18 @@ describe('ReactIncrementalScheduling', () => {
   });
 
   // This test documents the existing behavior. Desired behavior:
-  // it('flushes late hi-pri work in a hi-pri callback if it wins with many roots', () => {
-  it('FIXME: ignores late hi-pri work in a hi-pri callback if it wins with many roots', () => {
-    // Schedule early lo-pri
+  // it('flushes late animation work in an animation callback if it wins with many roots', () => {
+  it('FIXME: ignores late animation work in an animation callback if it wins with many roots', () => {
+    // Schedule early deferred
     ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
     ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
-    // Schedule late hi-pri
+    // Schedule late animation
     ReactNoop.performAnimationWork(() => {
       ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
       ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
     });
 
-    // FIXME: I would expect true here because we should have scheduled a hi-pri callback:
+    // FIXME: I would expect true here because we should have scheduled an animation callback:
     // expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
     expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
@@ -330,13 +330,13 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
 
-    // Flushing hi-pri should have flushed the hi-pri.
+    // Flushing animation should have flushed the animation.
     // FIXME: But it currently doesn't.
     // Technically we didn't schedule this callback. This test is valid because we should have scheduled it.
     ReactNoop.flushAnimationPri();
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
     expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
-    // TODO: I would expect this here because they were scheduled as hi-pri:
+    // TODO: I would expect this here because they were scheduled as animation:
     // expect(ReactNoop.getChildren('a')).toEqual([]);
     // expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     // expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
@@ -344,7 +344,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
 
-    // TODO: I wouldn't expect this flush to be necessary for hi-pri work to kick in.
+    // TODO: I wouldn't expect this flush to be necessary for animation work to kick in.
     ReactNoop.flushDeferredPri();
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
     expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
@@ -354,22 +354,22 @@ describe('ReactIncrementalScheduling', () => {
   });
 
   // This test documents the existing behavior. Desired behavior:
-  // it('flushes all work in a lo-pri callback if it wins', () => {
-  it('FIXME: ignores all work in a lo-pri callback if it wins', () => {
-    // Schedule early hi-pri
+  // it('flushes all work in a deferred callback if it wins', () => {
+  it('FIXME: ignores all work in a deferred callback if it wins', () => {
+    // Schedule early animation
     ReactNoop.performAnimationWork(() => {
       ReactNoop.render(<span prop="1" />);
     });
-    // Schedule late lo-pri
+    // Schedule late deferred
     ReactNoop.render(<span prop="2" />);
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
-    // We could also make this true because we know we have a lo-pri update coming.
+    // We could also make this true because we know we have a deferred update coming.
     // expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren()).toEqual([]);
 
-    // Flushing lo-pri should have flushed both early hi-pri and late lo-pri work that invalidated it.
-    // This is not a common case, as hi-pri should generally be flushed before lo-pri work.
+    // Flushing deferred should have flushed both early animation and late deferred work that invalidated it.
+    // This is not a common case, as animation should generally be flushed before deferred work.
     // FIXME: Instead, it currently doesn't do anything.
     // TODO: is this even a valid test? Technically we didn't schedule this callback.
     ReactNoop.flushDeferredPri();
@@ -379,7 +379,7 @@ describe('ReactIncrementalScheduling', () => {
     // expect(ReactNoop.getChildren()).toEqual([span('2')]);
     expect(ReactNoop.getChildren()).toEqual([]);
 
-    // Flushing hi-pri should have been a no-op
+    // Flushing animation should have been a no-op
     ReactNoop.flushAnimationPri();
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
     expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
@@ -387,26 +387,26 @@ describe('ReactIncrementalScheduling', () => {
   });
 
   // This test documents the existing behavior. Desired behavior:
-  // it('flushes all work in a lo-pri callback if it wins with many roots', () => {
-  it('FIXME: ignores all work in a lo-pri callback if it wins with many roots', () => {
-    // Schedule early hi-pri
+  // it('flushes all work in a deferred callback if it wins with many roots', () => {
+  it('FIXME: ignores all work in a deferred callback if it wins with many roots', () => {
+    // Schedule early animation
     ReactNoop.performAnimationWork(() => {
       ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
       ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
     });
-    // Schedule late lo-pri
+    // Schedule late deferred
     ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
     ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
-    // We could also make this true because we know we have a lo-pri update coming.
+    // We could also make this true because we know we have a deferred update coming.
     // expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren('a')).toEqual([]);
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
 
-    // Flushing lo-pri should have flushed both early hi-pri and late lo-pri work that invalidated it.
-    // This is not a common case, as hi-pri should generally be flushed before lo-pri work.
+    // Flushing deferred should have flushed both early animation and late deferred work that invalidated it.
+    // This is not a common case, as animation should generally be flushed before deferred work.
     // FIXME: Instead, it currently doesn't do anything.
     // TODO: is this even a valid test? Technically we didn't schedule this callback.
     ReactNoop.flushDeferredPri();
@@ -420,15 +420,15 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
 
-    // Flushing hi-pri should have been a no-op.
+    // Flushing animation should have been a no-op.
     ReactNoop.flushAnimationPri();
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    // FIXME: this lo-pri work should have been handled earlier.
+    // FIXME: this deferred work should have been handled earlier.
     // expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
-    // FIXME: this lo-pri work should have been handled earlier.
+    // FIXME: this deferred work should have been handled earlier.
     // expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
 
@@ -437,52 +437,52 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
   });
 
-  it('flushes root with late lo-pri work in a hi-pri callback if it wins', () => {
-    // Schedule early hi-pri
+  it('flushes root with late deferred work in an animation callback if it wins', () => {
+    // Schedule early animation
     ReactNoop.performAnimationWork(() => {
       ReactNoop.render(<span prop="1" />);
     });
-    // Schedule late lo-pri
+    // Schedule late deferred
     ReactNoop.render(<span prop="2" />);
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
-    // We don't need a lo-pri callback because the root already has hi-pri work
+    // We don't need a deferred callback because the root already has animation work
     expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren()).toEqual([]);
 
-    // Flushing hi-pri work flushes everything on this root.
+    // Flushing animation work flushes everything on this root.
     ReactNoop.flushAnimationPri();
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
     expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren()).toEqual([span('2')]);
   });
 
-  it('flushes all roots with hi-pri work in a hi-pri callback if it wins', () => {
-    // Schedule early hi-pri
+  it('flushes all roots with animation work in an animation callback if it wins', () => {
+    // Schedule early animation
     ReactNoop.performAnimationWork(() => {
       ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
       ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
     });
-    // Schedule late lo-pri
+    // Schedule late deferred
     ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
     ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
-    // TODO: I would expect this to be true because we know we have a lo-pri update coming.
+    // TODO: I would expect this to be true because we know we have a deferred update coming.
     // expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren('a')).toEqual([]);
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
 
-    // Flushing hi-pri work flushes all roots with hi-pri work.
+    // Flushing animation work flushes all roots with animation work.
     ReactNoop.flushAnimationPri();
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    // Now we know we also need a lo-pri update. Should we have scheduled it earlier?
+    // Now we know we also need a deferred update. Should we have scheduled it earlier?
     expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
 
-    // Flushing lo-pri work flushes the root with only lo-pri work.
+    // Flushing deferred work flushes the root with only deferred work.
     ReactNoop.flushDeferredPri();
     expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
     expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
@@ -491,7 +491,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
   });
 
-  it('splits lo-pri work on multiple roots', () => {
+  it('splits deferred work on multiple roots', () => {
     // Schedule one root
     ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
     ReactNoop.flushDeferredPri(15);
@@ -537,7 +537,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('a')).toEqual([span('a:6')]);
   });
 
-  it('works on lo-pri roots in the order they were scheduled', () => {
+  it('works on deferred roots in the order they were scheduled', () => {
     ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
     ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
     ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
@@ -546,7 +546,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
 
-    // Schedule lo-pri work in the reverse order
+    // Schedule deferred work in the reverse order
     ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
     ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
     // Ensure it starts in the order it was scheduled
@@ -567,7 +567,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
   });
 
-  it('handles interleaved lo-pri and hi-pri work', () => {
+  it('handles interleaved deferred and animation work', () => {
     ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
     ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
     ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
@@ -576,14 +576,14 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
 
-    // Schedule both lo-pri and hi-pri work
+    // Schedule both deferred and animation work
     ReactNoop.renderToRootWithID(<span prop="a:2" />, 'a');
     ReactNoop.performAnimationWork(() => {
       ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
       ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
     });
-    // We're flushing lo-pri work
-    // Still, roots with hi-pri work are handled first
+    // We're flushing deferred work
+    // Still, roots with animation work are handled first
     ReactNoop.flushDeferredPri(15);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
@@ -593,18 +593,18 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
 
-    // More lo-pri and hi-pri work just got scheduled!
+    // More deferred and animation work just got scheduled!
     ReactNoop.renderToRootWithID(<span prop="c:3" />, 'c');
     ReactNoop.performAnimationWork(() => {
       ReactNoop.renderToRootWithID(<span prop="b:3" />, 'b');
     });
-    // Hi-pri is still handled first
+    // Animation is still handled first
     ReactNoop.flushDeferredPri(15);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:3')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
 
-    // Finally we handle lo-pri root in the order it was scheduled
+    // Finally we handle deferred root in the order it was scheduled
     ReactNoop.flushDeferredPri(15);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:3')]);

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
@@ -16,6 +16,7 @@ var ReactNoop;
 
 describe('ReactIncrementalScheduling', () => {
   beforeEach(() => {
+    jest.resetModuleRegistry();
     React = require('React');
     ReactNoop = require('ReactNoop');
   });
@@ -24,7 +25,473 @@ describe('ReactIncrementalScheduling', () => {
     return { type: 'span', children: [], prop };
   }
 
-  it('schedules multiple roots', () => {
+  it('schedules and flushes hi-pri work', () => {
+    ReactNoop.performAnimationWork(() => {
+      ReactNoop.render(<span prop="1" />);
+    });
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    ReactNoop.flushAnimationPri();
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren()).toEqual([span('1')]);
+  });
+
+  it('schedules and flushes hi-pri work for many roots', () => {
+    ReactNoop.performAnimationWork(() => {
+      ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
+      ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
+      ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
+    });
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren('a')).toEqual([]);
+    expect(ReactNoop.getChildren('b')).toEqual([]);
+    expect(ReactNoop.getChildren('c')).toEqual([]);
+
+    ReactNoop.flushAnimationPri();
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
+    expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
+    expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
+  });
+
+  it('flushes all scheduled hi-pri work', () => {
+    ReactNoop.performAnimationWork(() => {
+      ReactNoop.render(<span prop="1" />);
+    });
+    ReactNoop.performAnimationWork(() => {
+      ReactNoop.render(<span prop="2" />);
+    });
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    ReactNoop.flushAnimationPri();
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren()).toEqual([span('2')]);
+  });
+
+  it('flushes all scheduled hi-pri work for many roots', () => {
+    ReactNoop.performAnimationWork(() => {
+      ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
+      ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
+      ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
+    });
+    ReactNoop.performAnimationWork(() => {
+      ReactNoop.renderToRootWithID(<span prop="a:2" />, 'a');
+      ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
+      ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
+    });
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren('a')).toEqual([]);
+    expect(ReactNoop.getChildren('b')).toEqual([]);
+    expect(ReactNoop.getChildren('c')).toEqual([]);
+
+    ReactNoop.flushAnimationPri();
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
+    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
+    expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
+  });
+
+  it('schedules and flushes lo-pri work', () => {
+    ReactNoop.render(<span prop="1" />);
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    ReactNoop.flushDeferredPri();
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren()).toEqual([span('1')]);
+  });
+
+  it('schedules and flushes lo-pri work for many roots', () => {
+    ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
+    ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
+    ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    expect(ReactNoop.getChildren('a')).toEqual([]);
+    expect(ReactNoop.getChildren('b')).toEqual([]);
+    expect(ReactNoop.getChildren('c')).toEqual([]);
+
+    ReactNoop.flushDeferredPri();
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
+    expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
+    expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
+  });
+
+  it('flushes scheduled lo-pri work fitting within deadline', () => {
+    ReactNoop.render(<span prop="1" />);
+    ReactNoop.render(<span prop="2" />);
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    ReactNoop.flushDeferredPri();
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren()).toEqual([span('2')]);
+  });
+
+  it('flushes scheduled lo-pri work fitting within deadline for many roots', () => {
+    ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
+    ReactNoop.renderToRootWithID(<span prop="a:2" />, 'a');
+    ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
+    ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
+    ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
+    ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    expect(ReactNoop.getChildren('a')).toEqual([]);
+    expect(ReactNoop.getChildren('b')).toEqual([]);
+    expect(ReactNoop.getChildren('c')).toEqual([]);
+
+    ReactNoop.flushDeferredPri();
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
+    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
+    expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
+  });
+
+  it('schedules more lo-pri work if it runs out of time', () => {
+    ReactNoop.render(<span prop="1" />);
+    ReactNoop.render(<span prop="2" />);
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    ReactNoop.flushDeferredPri(5);
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    ReactNoop.flushDeferredPri(10);
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    ReactNoop.flushDeferredPri(10);
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren()).toEqual([span('2')]);
+  });
+
+  it('schedules more lo-pri work if it runs out of time with many roots', () => {
+    ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
+    ReactNoop.renderToRootWithID(<span prop="a:2" />, 'a');
+    ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
+    ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
+    ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
+    ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    expect(ReactNoop.getChildren('a')).toEqual([]);
+    expect(ReactNoop.getChildren('b')).toEqual([]);
+    expect(ReactNoop.getChildren('c')).toEqual([]);
+
+    ReactNoop.flushDeferredPri(15);
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
+    expect(ReactNoop.getChildren('b')).toEqual([]);
+    expect(ReactNoop.getChildren('c')).toEqual([]);
+
+    ReactNoop.flushDeferredPri(15);
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
+    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
+    expect(ReactNoop.getChildren('c')).toEqual([]);
+
+    ReactNoop.flushDeferredPri(15);
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
+    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
+    expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
+  });
+
+  it('FIXME: flushes late hi-pri work in a lo-pri callback if it wins', () => {
+    // Schedule early lo-pri
+    ReactNoop.render(<span prop="1" />);
+    // Schedule late hi-pri
+    ReactNoop.performAnimationWork(() => {
+      ReactNoop.render(<span prop="2" />);
+    });
+
+    // FIXME: I would expect true here because we should have scheduled a hi-pri callback:
+    // expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // We only scheduled lo-pri callback so that's what we get.
+    // It will flush everything.
+    ReactNoop.flushDeferredPri();
+    // TODO: I would expect true here because we should have tried to schedule hi-pri sooner:
+    // expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren()).toEqual([span('2')]);
+  });
+
+  it('FIXME: flushes late hi-pri work in a lo-pri callback if it wins with many roots', () => {
+    // Schedule early lo-pri
+    ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
+    ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
+    // Schedule late hi-pri
+    ReactNoop.performAnimationWork(() => {
+      ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
+      ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
+    });
+
+    // FIXME: I would expect true here because we should have scheduled a hi-pri callback:
+    // expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    expect(ReactNoop.getChildren('a')).toEqual([]);
+    expect(ReactNoop.getChildren('b')).toEqual([]);
+    expect(ReactNoop.getChildren('c')).toEqual([]);
+
+    // We only scheduled lo-pri callback so that's what we get.
+    // It will flush everything.
+    ReactNoop.flushDeferredPri();
+    // TODO: I would expect true here because we tried to schedule hi-pri sooner, and so it would still be scheduled:
+    // expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
+    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
+    expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
+  });
+
+  // This test documents the existing behavior. Desired behavior:
+  // it('flushes late hi-pri work in a hi-pri callback if it wins', () => {
+  it('FIXME: ignores late hi-pri work in a hi-pri callback if it wins', () => {
+    // Schedule early lo-pri
+    ReactNoop.render(<span prop="1" />);
+    // Schedule late hi-pri
+    ReactNoop.performAnimationWork(() => {
+      ReactNoop.render(<span prop="2" />);
+    });
+
+    // FIXME: I would expect true here because we should have scheduled a hi-pri callback:
+    // expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Flushing hi-pri should have flushed the hi-pri.
+    // FIXME: But it currently doesn't.
+    // Technically we didn't schedule this callback. This test is valid because we should have scheduled it.
+    ReactNoop.flushAnimationPri();
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    // TODO: I would expect [span('2')] here because it was scheduled as hi-pri:
+    // expect(ReactNoop.getChildren()).toEqual([span('2')]);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // TODO: I wouldn't expect this flush to be necessary for hi-pri work to kick in.
+    ReactNoop.flushDeferredPri();
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren()).toEqual([span('2')]);
+  });
+
+  // This test documents the existing behavior. Desired behavior:
+  // it('flushes late hi-pri work in a hi-pri callback if it wins with many roots', () => {
+  it('FIXME: ignores late hi-pri work in a hi-pri callback if it wins with many roots', () => {
+    // Schedule early lo-pri
+    ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
+    ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
+    // Schedule late hi-pri
+    ReactNoop.performAnimationWork(() => {
+      ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
+      ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
+    });
+
+    // FIXME: I would expect true here because we should have scheduled a hi-pri callback:
+    // expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    expect(ReactNoop.getChildren('a')).toEqual([]);
+    expect(ReactNoop.getChildren('b')).toEqual([]);
+    expect(ReactNoop.getChildren('c')).toEqual([]);
+
+    // Flushing hi-pri should have flushed the hi-pri.
+    // FIXME: But it currently doesn't.
+    // Technically we didn't schedule this callback. This test is valid because we should have scheduled it.
+    ReactNoop.flushAnimationPri();
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    // TODO: I would expect this here because they were scheduled as hi-pri:
+    // expect(ReactNoop.getChildren('a')).toEqual([]);
+    // expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
+    // expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
+    expect(ReactNoop.getChildren('a')).toEqual([]);
+    expect(ReactNoop.getChildren('b')).toEqual([]);
+    expect(ReactNoop.getChildren('c')).toEqual([]);
+
+    // TODO: I wouldn't expect this flush to be necessary for hi-pri work to kick in.
+    ReactNoop.flushDeferredPri();
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
+    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
+    expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
+  });
+
+  // This test documents the existing behavior. Desired behavior:
+  // it('flushes all work in a lo-pri callback if it wins', () => {
+  it('FIXME: ignores all work in a lo-pri callback if it wins', () => {
+    // Schedule early hi-pri
+    ReactNoop.performAnimationWork(() => {
+      ReactNoop.render(<span prop="1" />);
+    });
+    // Schedule late lo-pri
+    ReactNoop.render(<span prop="2" />);
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
+    // We could also make this true because we know we have a lo-pri update coming.
+    // expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Flushing lo-pri should have flushed both early hi-pri and late lo-pri work that invalidated it.
+    // This is not a common case, as hi-pri should generally be flushed before lo-pri work.
+    // FIXME: Instead, it currently doesn't do anything.
+    // TODO: is this even a valid test? Technically we didn't schedule this callback.
+    ReactNoop.flushDeferredPri();
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    // TODO: I would expect [span('2')] here because we should have flushed everything by now:
+    // expect(ReactNoop.getChildren()).toEqual([span('2')]);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Flushing hi-pri should have been a no-op
+    ReactNoop.flushAnimationPri();
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren()).toEqual([span('2')]);
+  });
+
+  // This test documents the existing behavior. Desired behavior:
+  // it('flushes all work in a lo-pri callback if it wins with many roots', () => {
+  it('FIXME: ignores all work in a lo-pri callback if it wins with many roots', () => {
+    // Schedule early hi-pri
+    ReactNoop.performAnimationWork(() => {
+      ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
+      ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
+    });
+    // Schedule late lo-pri
+    ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
+    ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
+    // We could also make this true because we know we have a lo-pri update coming.
+    // expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren('a')).toEqual([]);
+    expect(ReactNoop.getChildren('b')).toEqual([]);
+    expect(ReactNoop.getChildren('c')).toEqual([]);
+
+    // Flushing lo-pri should have flushed both early hi-pri and late lo-pri work that invalidated it.
+    // This is not a common case, as hi-pri should generally be flushed before lo-pri work.
+    // FIXME: Instead, it currently doesn't do anything.
+    // TODO: is this even a valid test? Technically we didn't schedule this callback.
+    ReactNoop.flushDeferredPri();
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    // TODO: I would expect this here because we should have flushed everything:
+    // expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
+    // expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
+    // expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
+    expect(ReactNoop.getChildren('a')).toEqual([]);
+    expect(ReactNoop.getChildren('b')).toEqual([]);
+    expect(ReactNoop.getChildren('c')).toEqual([]);
+
+    // Flushing hi-pri should have been a no-op.
+    ReactNoop.flushAnimationPri();
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    // FIXME: this lo-pri work should have been handled earlier.
+    // expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
+    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
+    // FIXME: this lo-pri work should have been handled earlier.
+    // expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
+    expect(ReactNoop.getChildren('c')).toEqual([]);
+
+    // FIXME: it should be unnecessary to flush one more time:
+    ReactNoop.flushDeferredPri();
+    expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
+  });
+
+  it('flushes root with late lo-pri work in a hi-pri callback if it wins', () => {
+    // Schedule early hi-pri
+    ReactNoop.performAnimationWork(() => {
+      ReactNoop.render(<span prop="1" />);
+    });
+    // Schedule late lo-pri
+    ReactNoop.render(<span prop="2" />);
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
+    // We don't need a lo-pri callback because the root already has hi-pri work
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Flushing hi-pri work flushes everything on this root.
+    ReactNoop.flushAnimationPri();
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren()).toEqual([span('2')]);
+  });
+
+  it('flushes all roots with hi-pri work in a hi-pri callback if it wins', () => {
+    // Schedule early hi-pri
+    ReactNoop.performAnimationWork(() => {
+      ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
+      ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
+    });
+    // Schedule late lo-pri
+    ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
+    ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
+    // TODO: I would expect this to be true because we know we have a lo-pri update coming.
+    // expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren('a')).toEqual([]);
+    expect(ReactNoop.getChildren('b')).toEqual([]);
+    expect(ReactNoop.getChildren('c')).toEqual([]);
+
+    // Flushing hi-pri work flushes all roots with hi-pri work.
+    ReactNoop.flushAnimationPri();
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    // Now we know we also need a lo-pri update. Should we have scheduled it earlier?
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
+    expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
+    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
+    expect(ReactNoop.getChildren('c')).toEqual([]);
+
+    // Flushing lo-pri work flushes the root with only lo-pri work.
+    ReactNoop.flushDeferredPri();
+    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
+    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
+    expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
+    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
+    expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
+  });
+
+  it('splits lo-pri work on multiple roots', () => {
     // Schedule one root
     ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
     ReactNoop.flushDeferredPri(15);
@@ -70,7 +537,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('a')).toEqual([span('a:6')]);
   });
 
-  it('works on deferred roots in the order they were scheduled', () => {
+  it('works on lo-pri roots in the order they were scheduled', () => {
     ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
     ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
     ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
@@ -79,7 +546,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
 
-    // Schedule deferred work in the reverse order
+    // Schedule lo-pri work in the reverse order
     ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
     ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
     // Ensure it starts in the order it was scheduled
@@ -100,7 +567,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
   });
 
-  it('works on roots with animation priority before deferred work', () => {
+  it('handles interleaved lo-pri and hi-pri work', () => {
     ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
     ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
     ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
@@ -109,14 +576,14 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
 
-    // Schedule both deferred and animation work
+    // Schedule both lo-pri and hi-pri work
     ReactNoop.renderToRootWithID(<span prop="a:2" />, 'a');
     ReactNoop.performAnimationWork(() => {
       ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
       ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
     });
-    // We're flushing deferred work
-    // Still, roots with animation work are handled first
+    // We're flushing lo-pri work
+    // Still, roots with hi-pri work are handled first
     ReactNoop.flushDeferredPri(15);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
@@ -126,18 +593,18 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
 
-    // More deferred and animation work just got scheduled!
+    // More lo-pri and hi-pri work just got scheduled!
     ReactNoop.renderToRootWithID(<span prop="c:3" />, 'c');
     ReactNoop.performAnimationWork(() => {
       ReactNoop.renderToRootWithID(<span prop="b:3" />, 'b');
     });
-    // Animation is still handled first
+    // Hi-pri is still handled first
     ReactNoop.flushDeferredPri(15);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:3')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
 
-    // Finally we handle deferred root in the order it was scheduled
+    // Finally we handle lo-pri root in the order it was scheduled
     ReactNoop.flushDeferredPri(15);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:3')]);

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -16,6 +16,7 @@ var ReactNoop;
 
 describe('ReactIncrementalSideEffects', () => {
   beforeEach(() => {
+    jest.resetModuleRegistry();
     React = require('React');
     ReactNoop = require('ReactNoop');
   });

--- a/src/renderers/shared/fiber/__tests__/ReactTopLevelFragment-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactTopLevelFragment-test.js
@@ -18,6 +18,7 @@ var ReactNoop;
 // probably move to one of the other test files once it is official.
 describe('ReactTopLevelFragment', function() {
   beforeEach(function() {
+    jest.resetModuleRegistry();
     React = require('React');
     ReactNoop = require('ReactNoop');
   });

--- a/src/renderers/shared/fiber/__tests__/ReactTopLevelText-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactTopLevelText-test.js
@@ -18,6 +18,7 @@ var ReactNoop;
 // probably move to one of the other test files once it is official.
 describe('ReactTopLevelText', () => {
   beforeEach(() => {
+    jest.resetModuleRegistry();
     React = require('React');
     ReactNoop = require('ReactNoop');
   });


### PR DESCRIPTION
I add more tests for scheduling to better understand what's going on and document some existing suboptimal behavior.

I also add reasonable assertions to tests and isolate them better so that global state in scheduler doesn't leak between tests.