### PR TITLE
[Fiber] Add tests for scheduling inside callbacks

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -819,6 +819,18 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
 * splits deferred work on multiple roots
 * works on deferred roots in the order they were scheduled
 * handles interleaved deferred and animation work
+* performs animation work in animation callback
+* schedules deferred work in animation callback
+* schedules deferred work and performs animation work in animation callback
+* performs animation work and schedules deferred work in animation callback
+* performs deferred work in deferred callback if it has time
+* schedules deferred work in deferred callback if it runs out of time
+* performs animated work in deferred callback if it has time
+* performs animated work and deferred work in deferred callback if it has time
+* performs deferred and animated work work in deferred callback if it has time
+* FIXME: schedules animated work as if it was deferred in deferred callback if it runs out of time
+* schedules animated work and deferred work in deferred callback if it runs out of time
+* schedules deferred work and animated work in deferred callback if it runs out of time
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
 * can update child nodes of a host instance

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -172,14 +172,6 @@ var ReactNoop = {
     }
   },
 
-  hasScheduledDeferredCallback() {
-    return Boolean(scheduledDeferredCallback);
-  },
-
-  hasScheduledAnimationCallback() {
-    return Boolean(scheduledAnimationCallback);
-  },
-
   // Shortcut for testing a single root
   render(element : ReactElement<any>, callback: ?Function) {
     ReactNoop.renderToRootWithID(element, DEFAULT_ROOT_ID, callback);

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
@@ -29,13 +29,9 @@ describe('ReactIncrementalScheduling', () => {
     ReactNoop.performAnimationWork(() => {
       ReactNoop.render(<span prop="1" />);
     });
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     ReactNoop.flushAnimationPri();
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren()).toEqual([span('1')]);
   });
 
@@ -45,15 +41,11 @@ describe('ReactIncrementalScheduling', () => {
       ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
       ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
     });
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren('a')).toEqual([]);
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
 
     ReactNoop.flushAnimationPri();
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
@@ -66,13 +58,9 @@ describe('ReactIncrementalScheduling', () => {
     ReactNoop.performAnimationWork(() => {
       ReactNoop.render(<span prop="2" />);
     });
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     ReactNoop.flushAnimationPri();
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren()).toEqual([span('2')]);
   });
 
@@ -87,15 +75,11 @@ describe('ReactIncrementalScheduling', () => {
       ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
       ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
     });
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren('a')).toEqual([]);
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
 
     ReactNoop.flushAnimationPri();
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
@@ -103,13 +87,9 @@ describe('ReactIncrementalScheduling', () => {
 
   it('schedules and flushes deferred work', () => {
     ReactNoop.render(<span prop="1" />);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     ReactNoop.flushDeferredPri();
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren()).toEqual([span('1')]);
   });
 
@@ -117,15 +97,11 @@ describe('ReactIncrementalScheduling', () => {
     ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
     ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
     ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.getChildren('a')).toEqual([]);
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
 
     ReactNoop.flushDeferredPri();
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
@@ -134,13 +110,9 @@ describe('ReactIncrementalScheduling', () => {
   it('flushes scheduled deferred work fitting within deadline', () => {
     ReactNoop.render(<span prop="1" />);
     ReactNoop.render(<span prop="2" />);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     ReactNoop.flushDeferredPri();
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren()).toEqual([span('2')]);
   });
 
@@ -151,15 +123,11 @@ describe('ReactIncrementalScheduling', () => {
     ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
     ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
     ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.getChildren('a')).toEqual([]);
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
 
     ReactNoop.flushDeferredPri();
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
@@ -168,23 +136,15 @@ describe('ReactIncrementalScheduling', () => {
   it('schedules more deferred work if it runs out of time', () => {
     ReactNoop.render(<span prop="1" />);
     ReactNoop.render(<span prop="2" />);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     ReactNoop.flushDeferredPri(5);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     ReactNoop.flushDeferredPri(10);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     ReactNoop.flushDeferredPri(10);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren()).toEqual([span('2')]);
   });
 
@@ -195,29 +155,21 @@ describe('ReactIncrementalScheduling', () => {
     ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
     ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
     ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.getChildren('a')).toEqual([]);
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
 
     ReactNoop.flushDeferredPri(15);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
 
     ReactNoop.flushDeferredPri(15);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
 
     ReactNoop.flushDeferredPri(15);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
@@ -233,8 +185,6 @@ describe('ReactIncrementalScheduling', () => {
 
     // FIXME: I would expect true here because we should have scheduled an animation callback:
     // expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     // We only scheduled deferred callback so that's what we get.
@@ -242,8 +192,6 @@ describe('ReactIncrementalScheduling', () => {
     ReactNoop.flushDeferredPri();
     // TODO: I would expect true here because we should have tried to schedule animation sooner:
     // expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren()).toEqual([span('2')]);
   });
 
@@ -259,8 +207,6 @@ describe('ReactIncrementalScheduling', () => {
 
     // FIXME: I would expect true here because we should have scheduled an animation callback:
     // expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.getChildren('a')).toEqual([]);
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
@@ -270,8 +216,6 @@ describe('ReactIncrementalScheduling', () => {
     ReactNoop.flushDeferredPri();
     // TODO: I would expect true here because we tried to schedule animation sooner, and so it would still be scheduled:
     // expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
@@ -289,24 +233,18 @@ describe('ReactIncrementalScheduling', () => {
 
     // FIXME: I would expect true here because we should have scheduled an animation callback:
     // expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     // Flushing animation should have flushed the animation.
     // FIXME: But it currently doesn't.
     // Technically we didn't schedule this callback. This test is valid because we should have scheduled it.
     ReactNoop.flushAnimationPri();
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     // TODO: I would expect [span('2')] here because it was scheduled as animation:
     // expect(ReactNoop.getChildren()).toEqual([span('2')]);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     // TODO: I wouldn't expect this flush to be necessary for animation work to kick in.
     ReactNoop.flushDeferredPri();
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren()).toEqual([span('2')]);
   });
 
@@ -324,8 +262,6 @@ describe('ReactIncrementalScheduling', () => {
 
     // FIXME: I would expect true here because we should have scheduled an animation callback:
     // expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.getChildren('a')).toEqual([]);
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
@@ -334,8 +270,6 @@ describe('ReactIncrementalScheduling', () => {
     // FIXME: But it currently doesn't.
     // Technically we didn't schedule this callback. This test is valid because we should have scheduled it.
     ReactNoop.flushAnimationPri();
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     // TODO: I would expect this here because they were scheduled as animation:
     // expect(ReactNoop.getChildren('a')).toEqual([]);
     // expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
@@ -346,8 +280,6 @@ describe('ReactIncrementalScheduling', () => {
 
     // TODO: I wouldn't expect this flush to be necessary for animation work to kick in.
     ReactNoop.flushDeferredPri();
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
@@ -362,10 +294,7 @@ describe('ReactIncrementalScheduling', () => {
     });
     // Schedule late deferred
     ReactNoop.render(<span prop="2" />);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
     // We could also make this true because we know we have a deferred update coming.
-    // expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     // Flushing deferred should have flushed both early animation and late deferred work that invalidated it.
@@ -373,16 +302,12 @@ describe('ReactIncrementalScheduling', () => {
     // FIXME: Instead, it currently doesn't do anything.
     // TODO: is this even a valid test? Technically we didn't schedule this callback.
     ReactNoop.flushDeferredPri();
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     // TODO: I would expect [span('2')] here because we should have flushed everything by now:
     // expect(ReactNoop.getChildren()).toEqual([span('2')]);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     // Flushing animation should have been a no-op
     ReactNoop.flushAnimationPri();
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren()).toEqual([span('2')]);
   });
 
@@ -397,10 +322,7 @@ describe('ReactIncrementalScheduling', () => {
     // Schedule late deferred
     ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
     ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
     // We could also make this true because we know we have a deferred update coming.
-    // expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren('a')).toEqual([]);
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
@@ -410,8 +332,6 @@ describe('ReactIncrementalScheduling', () => {
     // FIXME: Instead, it currently doesn't do anything.
     // TODO: is this even a valid test? Technically we didn't schedule this callback.
     ReactNoop.flushDeferredPri();
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     // TODO: I would expect this here because we should have flushed everything:
     // expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     // expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
@@ -422,10 +342,8 @@ describe('ReactIncrementalScheduling', () => {
 
     // Flushing animation should have been a no-op.
     ReactNoop.flushAnimationPri();
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
     // FIXME: this deferred work should have been handled earlier.
     // expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     // FIXME: this deferred work should have been handled earlier.
@@ -444,15 +362,11 @@ describe('ReactIncrementalScheduling', () => {
     });
     // Schedule late deferred
     ReactNoop.render(<span prop="2" />);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
     // We don't need a deferred callback because the root already has animation work
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     // Flushing animation work flushes everything on this root.
     ReactNoop.flushAnimationPri();
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren()).toEqual([span('2')]);
   });
 
@@ -465,27 +379,20 @@ describe('ReactIncrementalScheduling', () => {
     // Schedule late deferred
     ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
     ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
     // TODO: I would expect this to be true because we know we have a deferred update coming.
-    // expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren('a')).toEqual([]);
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
 
     // Flushing animation work flushes all roots with animation work.
     ReactNoop.flushAnimationPri();
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
     // Now we know we also need a deferred update. Should we have scheduled it earlier?
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
 
     // Flushing deferred work flushes the root with only deferred work.
     ReactNoop.flushDeferredPri();
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
@@ -632,15 +539,11 @@ describe('ReactIncrementalScheduling', () => {
     ReactNoop.performAnimationWork(() => {
       ReactNoop.renderToRootWithID(<Foo />, 'a');
     });
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
 
     // Flushing animation work should flush animation work scheduled inside it
     ReactNoop.flushAnimationPri();
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
   });
 
   it('schedules deferred work in animation callback', () => {
@@ -658,22 +561,16 @@ describe('ReactIncrementalScheduling', () => {
     ReactNoop.performAnimationWork(() => {
       ReactNoop.renderToRootWithID(<Foo />, 'a');
     });
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
 
     // Flushing animation work should not flush the deferred work
     ReactNoop.flushAnimationPri();
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([]);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
 
     // Flush the deferred work
     ReactNoop.flushDeferredPri();
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
   });
 
   it('schedules deferred work and performs animation work in animation callback', () => {
@@ -699,8 +596,6 @@ describe('ReactIncrementalScheduling', () => {
     ReactNoop.performAnimationWork(() => {
       ReactNoop.renderToRootWithID(<Foo />, 'a');
     });
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
 
     // Flushing animation work should flush animation work scheduled inside it
     ReactNoop.flushAnimationPri();
@@ -709,8 +604,6 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
     expect(ReactNoop.getChildren('d')).toEqual([]);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
 
     // Flush the deferred work
     ReactNoop.flushDeferredPri();
@@ -718,8 +611,6 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
     expect(ReactNoop.getChildren('d')).toEqual([span('d:1')]);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
   });
 
   it('performs animation work and schedules deferred work in animation callback', () => {
@@ -747,8 +638,6 @@ describe('ReactIncrementalScheduling', () => {
     ReactNoop.performAnimationWork(() => {
       ReactNoop.renderToRootWithID(<Foo />, 'a');
     });
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
 
     // Flushing animation work should flush animation work scheduled inside it
     ReactNoop.flushAnimationPri();
@@ -757,8 +646,6 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
     expect(ReactNoop.getChildren('d')).toEqual([span('d:1')]);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
 
     // Flush the deferred work
     ReactNoop.flushDeferredPri();
@@ -766,8 +653,6 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
     expect(ReactNoop.getChildren('d')).toEqual([span('d:1')]);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
   });
 
   it('performs deferred work in deferred callback if it has time', () => {
@@ -783,15 +668,11 @@ describe('ReactIncrementalScheduling', () => {
 
     // Schedule deferred work
     ReactNoop.renderToRootWithID(<Foo />, 'a');
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
 
     // Flushing deferred work should flush deferred work scheduled inside it
     ReactNoop.flushDeferredPri();
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
   });
 
   it('schedules deferred work in deferred callback if it runs out of time', () => {
@@ -809,23 +690,17 @@ describe('ReactIncrementalScheduling', () => {
 
     // Schedule deferred work
     ReactNoop.renderToRootWithID(<Foo />, 'a');
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
 
     // Flush just enough deferred work to schedule more deferred work
     ReactNoop.flushDeferredPri(20);
     expect(hasScheduled).toBe(true);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([]);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
 
     // Flush the rest of the deferred work
     ReactNoop.flushDeferredPri(15);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
   });
 
   it('performs animated work in deferred callback if it has time', () => {
@@ -843,15 +718,11 @@ describe('ReactIncrementalScheduling', () => {
 
     // Schedule deferred work
     ReactNoop.renderToRootWithID(<Foo />, 'a');
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
 
     // Flushing deferred work should flush animated work scheduled inside it
     ReactNoop.flushDeferredPri();
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
   });
 
   it('performs animated work and deferred work in deferred callback if it has time', () => {
@@ -873,8 +744,6 @@ describe('ReactIncrementalScheduling', () => {
 
     // Schedule deferred work
     ReactNoop.renderToRootWithID(<Foo />, 'a');
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
 
     // Flushing deferred work should flush both deferred and animated work scheduled inside it
     ReactNoop.flushDeferredPri();
@@ -882,8 +751,6 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
     expect(ReactNoop.getChildren('d')).toEqual([span('d:1')]);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
   });
 
   it('performs deferred and animated work work in deferred callback if it has time', () => {
@@ -907,8 +774,6 @@ describe('ReactIncrementalScheduling', () => {
 
     // Schedule deferred work
     ReactNoop.renderToRootWithID(<Foo />, 'a');
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
 
     // Flushing deferred work should flush both deferred and animated work scheduled inside it
     ReactNoop.flushDeferredPri();
@@ -916,8 +781,6 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
     expect(ReactNoop.getChildren('d')).toEqual([span('d:1')]);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
   });
 
   // This test documents the existing behavior. Desired behavior:
@@ -939,8 +802,6 @@ describe('ReactIncrementalScheduling', () => {
 
     // Schedule deferred work
     ReactNoop.renderToRootWithID(<Foo />, 'a');
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
 
     // Flush just enough deferred work to schedule animated work
     ReactNoop.flushDeferredPri(20);
@@ -950,8 +811,6 @@ describe('ReactIncrementalScheduling', () => {
     // FIXME: I would expect these to be flipped because animation work was scheduled.
     // expect(ReactNoop.hasScheduledAnimationCallback()).toBe(true);
     // expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
 
     // Flush the rest of work in an animated callback.
     // Technically we didn't schedule this callback. This test is valid because we should have scheduled it.
@@ -963,15 +822,11 @@ describe('ReactIncrementalScheduling', () => {
     // expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([]);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
 
     // FIXME: it should be unnecessary to flush the deferred work:
     ReactNoop.flushDeferredPri();
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
   });
 
   it('schedules animated work and deferred work in deferred callback if it runs out of time', () => {
@@ -995,8 +850,6 @@ describe('ReactIncrementalScheduling', () => {
 
     // Schedule deferred work
     ReactNoop.renderToRootWithID(<Foo />, 'a');
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
 
     // Flushing deferred work should schedule both deferred and animated work
     ReactNoop.flushDeferredPri(20);
@@ -1005,8 +858,6 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
     expect(ReactNoop.getChildren('d')).toEqual([]);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
 
     // Flush the rest of the work
     ReactNoop.flushDeferredPri();
@@ -1014,8 +865,6 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
     expect(ReactNoop.getChildren('d')).toEqual([span('d:1')]);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
   });
 
   it('schedules deferred work and animated work in deferred callback if it runs out of time', () => {
@@ -1041,8 +890,6 @@ describe('ReactIncrementalScheduling', () => {
 
     // Schedule deferred work
     ReactNoop.renderToRootWithID(<Foo />, 'a');
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
 
     // Flushing deferred work should schedule both deferred and animated work
     ReactNoop.flushDeferredPri(20);
@@ -1051,8 +898,6 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
     expect(ReactNoop.getChildren('d')).toEqual([]);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(true);
 
     // Flush the rest of the work
     ReactNoop.flushDeferredPri();
@@ -1060,7 +905,5 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
     expect(ReactNoop.getChildren('d')).toEqual([span('d:1')]);
-    expect(ReactNoop.hasScheduledAnimationCallback()).toBe(false);
-    expect(ReactNoop.hasScheduledDeferredCallback()).toBe(false);
   });
 });


### PR DESCRIPTION
Like #8183, this adds more tests for scheduling.

In this particular case I'm testing that updates scheduled inside callbacks either get handled right away (when possible) or schedule more callbacks.