### PR TITLE
Move Safari onClick hack into ReactDOMComponent

### DIFF
--- a/src/renderers/dom/shared/eventPlugins/SimpleEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/SimpleEventPlugin.js
@@ -12,9 +12,7 @@
 
 'use strict';
 
-var EventListener = require('EventListener');
 var EventPropagators = require('EventPropagators');
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var SyntheticAnimationEvent = require('SyntheticAnimationEvent');
 var SyntheticClipboardEvent = require('SyntheticClipboardEvent');
 var SyntheticEvent = require('SyntheticEvent');
@@ -27,7 +25,6 @@ var SyntheticTransitionEvent = require('SyntheticTransitionEvent');
 var SyntheticUIEvent = require('SyntheticUIEvent');
 var SyntheticWheelEvent = require('SyntheticWheelEvent');
 
-var emptyFunction = require('emptyFunction');
 var getEventCharCode = require('getEventCharCode');
 var invariant = require('invariant');
 
@@ -140,14 +137,6 @@ var topLevelEventsToDispatchConfig: {[key: TopLevelTypes]: DispatchConfig} = {};
   eventTypes[event] = type;
   topLevelEventsToDispatchConfig[topEvent] = type;
 });
-
-var onClickListeners = {};
-
-function getDictionaryKey(inst: ReactInstance): string {
-  // Prevents V8 performance issue:
-  // https://github.com/facebook/react/pull/7232
-  return '.' + inst._rootNodeID;
-}
 
 function isInteractive(tag) {
   return (
@@ -302,40 +291,6 @@ var SimpleEventPlugin: PluginModule<MouseEvent> = {
     );
     EventPropagators.accumulateTwoPhaseDispatches(event);
     return event;
-  },
-
-  didPutListener: function(
-    inst: ReactInstance,
-    registrationName: string,
-    listener: () => void,
-  ): void {
-    // Mobile Safari does not fire properly bubble click events on
-    // non-interactive elements, which means delegated click listeners do not
-    // fire. The workaround for this bug involves attaching an empty click
-    // listener on the target node.
-    // http://www.quirksmode.org/blog/archives/2010/09/click_event_del.html
-    if (registrationName === 'onClick' && !isInteractive(inst._tag)) {
-      var key = getDictionaryKey(inst);
-      var node = ReactDOMComponentTree.getNodeFromInstance(inst);
-      if (!onClickListeners[key]) {
-        onClickListeners[key] = EventListener.listen(
-          node,
-          'click',
-          emptyFunction
-        );
-      }
-    }
-  },
-
-  willDeleteListener: function(
-    inst: ReactInstance,
-    registrationName: string,
-  ): void {
-    if (registrationName === 'onClick' && !isInteractive(inst._tag)) {
-      var key = getDictionaryKey(inst);
-      onClickListeners[key].remove();
-      delete onClickListeners[key];
-    }
   },
 
 };


### PR DESCRIPTION
This is already where we trap non-bubbling events. We also already branch on the tag type so we know if it is interactive or not.

This will let us get rid of the didPutListener and willDeleteListener abstractions.

I use a simple onclick = emptyFunction to avoid the need for a bookkeeping map.

Is it critical to unsubscribe from this when the listener is removed?
