### PR TITLE
Track if SelectEventPlugin is attached on a per document basis

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -221,6 +221,7 @@ src/renderers/dom/shared/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
 * should set relatedTarget properly in iframe
 
 src/renderers/dom/shared/eventPlugins/__tests__/SelectEventPlugin-test.js
+* should skip extraction if no listeners are present
 * should extract if an `onSelect` listener is present
 
 src/renderers/dom/shared/eventPlugins/__tests__/SimpleEventPlugin-test.js

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -590,9 +590,6 @@ src/renderers/dom/shared/eventPlugins/__tests__/FallbackCompositionState-test.js
 * extracts when inserted within text
 * extracts when inserted at end of text
 
-src/renderers/dom/shared/eventPlugins/__tests__/SelectEventPlugin-test.js
-* should skip extraction if no listeners are present
-
 src/renderers/dom/shared/eventPlugins/__tests__/SimpleEventPlugin-test.js
 * does not add a local click to interactive elements
 * adds a local click listener to non-interactive elements
@@ -743,6 +740,7 @@ src/renderers/native/__tests__/ReactNativeEvents-test.js
 
 src/renderers/native/__tests__/ReactNativeMount-test.js
 * should be able to create and render a native component
+* should be able to create and update a native component
 * should be able to create and update a native component
 
 src/renderers/shared/__tests__/ReactDebugTool-test.js

--- a/src/renderers/dom/shared/ReactBrowserEventEmitter.js
+++ b/src/renderers/dom/shared/ReactBrowserEventEmitter.js
@@ -328,6 +328,22 @@ var ReactBrowserEventEmitter = Object.assign({}, ReactEventEmitterMixin, {
     }
   },
 
+  isListeningToAllDependencies: function(registrationName, mountAt) {
+    var isListening = getListeningForDocument(mountAt);
+    var dependencies =
+      EventPluginRegistry.registrationNameDependencies[registrationName];
+    for (var i = 0; i < dependencies.length; i++) {
+      var dependency = dependencies[i];
+      if (!(
+            isListening.hasOwnProperty(dependency) &&
+            isListening[dependency]
+          )) {
+        return false;
+      }
+    }
+    return true;
+  },
+
   trapBubbledEvent: function(topLevelType, handlerBaseName, handle) {
     return ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(
       topLevelType,

--- a/src/renderers/dom/shared/eventPlugins/__tests__/SelectEventPlugin-test.js
+++ b/src/renderers/dom/shared/eventPlugins/__tests__/SelectEventPlugin-test.js
@@ -46,6 +46,16 @@ describe('SelectEventPlugin', () => {
     var node = ReactDOM.findDOMNode(rendered);
     node.focus();
 
+    // It seems that .focus() isn't triggering this event in our test
+    // environment so we need to ensure it gets set for this test to be valid.
+    var fakeNativeEvent = new function() {};
+    fakeNativeEvent.target = node;
+    ReactTestUtils.simulateNativeEventOnNode(
+      'topFocus',
+      node,
+      fakeNativeEvent
+    );
+
     var mousedown = extract(node, 'topMouseDown');
     expect(mousedown).toBe(null);
 


### PR DESCRIPTION
This gets rid of the global flag on if something has listened to onSelect
and instead reads the isListening map if all the events are covered.
This is required if we want to attach events locally at roots.

Could be slower perf wise to handle events. An alternative solution would
be to attach a special flag on the listener map for the document so we
don't have to check the full dependency list.

However, my favorite solution would be to just eagerly attach all event
listeners (except maybe wheel). Then we don't have to do any of this stuff
on a per element basis.