### PR TITLE
Docs: handle async state in "Uncontrolled Checkbox"

### DIFF
--- a/docs/docs/forms.md
+++ b/docs/docs/forms.md
@@ -471,15 +471,17 @@ class Form extends React.Component {
 
   handleChange(event) {
     const value = event.target.value;
-    // Copy the object so we don't mutate the old state.
-    // (This requires an Object.assign polyfill):
-    const checked = Object.assign({}, this.state.checked)
-    if (!checked[value]) {
-      checked[value] = true;
-    } else {
-      checked[value] = false;
-    };
-    this.setState({checked});
+    this.setState((prevState) => {
+      // Copy the object so we don't mutate the old state.
+      // (This requires an Object.assign polyfill):
+      const checked = Object.assign({}, prevState.checked)
+      if (!checked[value]) {
+        checked[value] = true;
+      } else {
+        checked[value] = false;
+      };
+      return {checked};
+    });
   }
 
   handleSubmit(event) {


### PR DESCRIPTION
The Uncontrolled Checkbox example treats `this.state` as synchronous in its `handleChange()` method, but earlier in the tutorial (https://facebook.github.io/react/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous) we are told to assume `this.setState` may be async and we should not reference `this.state` directly while updating it.

This proposed change updates the example to pass a callback rather than an object to `this.setState` in `handleChange()` and copy over the checkbox value using the `prevState` argument in the callback.

Very minor change, I'm just reading through the React docs for my first time and have been very impressed with how airtight they are so far. This is the only inconsistency I've noticed, thought I might as well toss up a patch.