### PR TITLE
Fiber: Fix reconciling after null

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -568,9 +568,6 @@ src/renderers/shared/stack/reconciler/__tests__/ReactEmptyComponent-test.js
 src/renderers/shared/stack/reconciler/__tests__/ReactMultiChild-test.js
 * should warn for duplicated keys with component stack info
 
-src/renderers/shared/stack/reconciler/__tests__/ReactMultiChildReconcile-test.js
-* should insert non-empty children in middle where nulls were
-
 src/renderers/shared/stack/reconciler/__tests__/ReactMultiChildText-test.js
 * should correctly handle all possible children for render and update
 * should throw if rendering both HTML and children

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1113,6 +1113,7 @@ src/renderers/shared/stack/reconciler/__tests__/ReactMultiChildReconcile-test.js
 * should not insert empty children in the middle
 * should insert one new child in the middle
 * should insert multiple new truthy children in the middle
+* should insert non-empty children in middle where nulls were
 
 src/renderers/shared/stack/reconciler/__tests__/ReactMultiChildText-test.js
 * should render between nested components and inline children

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -529,6 +529,9 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         // unfortunate because it triggers the slow path all the time. We need
         // a better way to communicate whether this was a miss or null,
         // boolean, undefined, etc.
+        if (!oldFiber) {
+          oldFiber = nextOldFiber;
+        }
         break;
       }
       if (shouldTrackSideEffects) {


### PR DESCRIPTION
Before, this code was bailing out after encoutering a null child because it thought it was out of old children. Seen when reconciling [null, <span />, <Image />] with [null, <span />, <Image />] in XUISelector.