### PR TITLE
[Fiber] Add more tests and fix an issue with incremental error handling

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -803,6 +803,9 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
 * propagates an error from a noop error boundary during animation mounting
 * propagates an error from a noop error boundary during synchronous mounting
 * propagates an error from a noop error boundary during batched mounting
+* applies batched updates regardless despite errors in scheduling
+* applies nested batched updates despite errors in scheduling
+* applies sync updates regardless despite errors in scheduling
 * can schedule updates after uncaught error in render on mount
 * can schedule updates after uncaught error in render on update
 * can schedule updates after uncaught error during umounting

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -793,8 +793,16 @@ src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
 * can nest batchedUpdates
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
-* catches render error in a boundary during mounting
-* propagates an error from a noop error boundary
+* catches render error in a boundary during full deferred mounting
+* catches render error in a boundary during partial deferred mounting
+* catches render error in a boundary during animation mounting
+* catches render error in a boundary during synchronous mounting
+* catches render error in a boundary during batched mounting
+* propagates an error from a noop error boundary during full deferred mounting
+* propagates an error from a noop error boundary during partial deferred mounting
+* propagates an error from a noop error boundary during animation mounting
+* propagates an error from a noop error boundary during synchronous mounting
+* propagates an error from a noop error boundary during batched mounting
 * can schedule updates after uncaught error in render on mount
 * can schedule updates after uncaught error in render on update
 * can schedule updates after uncaught error during umounting

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -39,6 +39,7 @@ var {
 var {
   NoWork,
   OffscreenPriority,
+  TaskPriority,
 } = require('ReactPriorityLevel');
 var {
   Placement,
@@ -365,9 +366,12 @@ module.exports = function<T, P, I, TI, C>(
     workInProgress.firstEffect = null;
     workInProgress.lastEffect = null;
 
-    if (workInProgress.progressedPriority === priorityLevel) {
+    if (workInProgress.progressedPriority === priorityLevel ||
+        priorityLevel === TaskPriority) {
       // If we have progressed work on this priority level already, we can
       // proceed this that as the child.
+      // We also can reuse the child if we're doing Task work. This avoids
+      // having the error boundaries doing the failed work twice before mount.
       workInProgress.child = workInProgress.progressedChild;
     }
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
@@ -424,6 +424,50 @@ describe('ReactIncrementalErrorHandling', () => {
     expect(ReactNoop.getChildren()).toEqual([]);
   });
 
+  it('applies batched updates regardless despite errors in scheduling', () => {
+    ReactNoop.render(<span prop="a:1" />);
+    expect(() => {
+      ReactNoop.batchedUpdates(() => {
+        ReactNoop.render(<span prop="a:2" />);
+        ReactNoop.render(<span prop="a:3" />);
+        throw new Error('Hello');
+      });
+    }).toThrow('Hello');
+    ReactNoop.flush();
+    expect(ReactNoop.getChildren()).toEqual([span('a:3')]);
+  });
+
+  it('applies nested batched updates despite errors in scheduling', () => {
+    ReactNoop.render(<span prop="a:1" />);
+    expect(() => {
+      ReactNoop.batchedUpdates(() => {
+        ReactNoop.render(<span prop="a:2" />);
+        ReactNoop.render(<span prop="a:3" />);
+        ReactNoop.batchedUpdates(() => {
+          ReactNoop.render(<span prop="a:4" />);
+          ReactNoop.render(<span prop="a:5" />);
+          throw new Error('Hello');
+        });
+      });
+    }).toThrow('Hello');
+    ReactNoop.flush();
+    expect(ReactNoop.getChildren()).toEqual([span('a:5')]);
+  });
+
+  it('applies sync updates regardless despite errors in scheduling', () => {
+    ReactNoop.render(<span prop="a:1" />);
+    expect(() => {
+      ReactNoop.syncUpdates(() => {
+        ReactNoop.batchedUpdates(() => {
+          ReactNoop.render(<span prop="a:2" />);
+          ReactNoop.render(<span prop="a:3" />);
+          throw new Error('Hello');
+        });
+      });
+    }).toThrow('Hello');
+    expect(ReactNoop.getChildren()).toEqual([span('a:3')]);
+  });
+
   it('can schedule updates after uncaught error in render on mount', () => {
     var ops = [];
 


### PR DESCRIPTION
See individual commits.

### Add more tests for incremental error handling

Added more tests that test how error boundaries behave inside different priorities.
These new tests are currently failing:

```
  ✕ catches render error in a boundary during partial deferred mounting
  ✕ catches render error in a boundary during animation mounting
  ✕ propagates an error from a noop error boundary during full deferred mounting
  ✕ propagates an error from a noop error boundary during partial deferred mounting
  ✕ propagates an error from a noop error boundary during animation mounting
```

The observed behavior is that `unstable_handleError()` unexpectedly gets called twice:

```diff
      "ErrorBoundary render success",
      "BrokenRender",
      "ErrorBoundary unstable_handleError",
  +   "ErrorBoundary render success",
  +   "BrokenRender",
  +   "ErrorBoundary unstable_handleError",
      "ErrorBoundary render error"
```

This is not a big deal but if people call error reporting services in `unstable_handleError`, they'll get each error twice on mounting.

### 	Always reuse progressChild when starting Task work

The above problem happens because `Task` is a higher priority work than animated or deferred, and so it throws away the already progressed child. This is why we render the failed path twice before continuing with the success path.

As a fix, I changed it to always reuse the progressed child when we're working with `Task` priority. **I’m not sure this is the right fix.** Maybe we should only do this for error handling work. I couldn’t figure out how to come up with a counter-example to this so I’d appreciate special attention there.

### 	Verify batched updates get scheduled despite errors

This just adds a few tests I planned to do earlier so that we don’t accidentally regress on them.