### PR TITLE
Revert normalized text node fix

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -189,6 +189,9 @@ src/renderers/dom/shared/__tests__/ReactDOMInvalidARIAHook-test.js
 
 src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
 * can reconcile text merged by Node.normalize() alongside other elements
+* can reconcile text merged by Node.normalize()
+* can reconcile text arbitrarily split into multiple nodes
+* can reconcile text arbitrarily split into multiple nodes on some substitutions only
 
 src/renderers/dom/shared/__tests__/ReactEventIndependence-test.js
 * does not crash with other react inside

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -539,10 +539,7 @@ src/renderers/dom/shared/__tests__/ReactDOMSVG-test.js
 src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
 * updates a mounted text component in place
 * can be toggled in and out of the markup
-* can reconcile text merged by Node.normalize()
 * can reconcile text from pre-rendered markup
-* can reconcile text arbitrarily split into multiple nodes
-* can reconcile text arbitrarily split into multiple nodes on some substitutions only
 
 src/renderers/dom/shared/__tests__/ReactEventListener-test.js
 * should dispatch events from outside React tree

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -13,11 +13,9 @@
 'use strict';
 
 import type { HostChildren } from 'ReactFiberReconciler';
-import type { Fiber } from 'ReactFiber';
 
 var ReactFiberReconciler = require('ReactFiberReconciler');
 var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
-var ReactTypeOfWork = require('ReactTypeOfWork');
 
 var warning = require('warning');
 
@@ -90,33 +88,8 @@ var DOMRenderer = ReactFiberReconciler({
     return document.createTextNode(text);
   },
 
-  commitTextUpdate(textInstance : TextInstance, oldText : string, newText : string, current: ?Fiber) : void {
-    let nodeValueLen = textInstance.nodeValue.length;
-    let nextSibling : ?Node = textInstance.nextSibling;
-    // The Node may have been split in this case we need to clean up some next sibling nodes
-    while (nextSibling && nodeValueLen < oldText.length) {
-      const currentSibling : Node = nextSibling;
-      nextSibling = currentSibling.nextSibling;
-      nodeValueLen += currentSibling.nodeValue.length;
-      const parentNode = currentSibling.parentElement;
-      if (parentNode) {
-        parentNode.removeChild(currentSibling);
-      }
-    }
+  commitTextUpdate(textInstance : TextInstance, oldText : string, newText : string) : void {
     textInstance.nodeValue = newText;
-    // After a Node#normalize() on a parent, we need to reattach to the tree
-    if (!textInstance.parentNode) {
-      // We may need to go back through different types of work (not necessarily an host node)
-      // That's why, we're going up the stack testing for an HostComponent type of work
-      let parentFiber: ?Fiber = current && current.return;
-      while (parentFiber) {
-        if (parentFiber.tag === ReactTypeOfWork.HostComponent) {
-          (parentFiber.stateNode: Instance).appendChild(textInstance);
-          break;
-        }
-        parentFiber = parentFiber.return;
-      }
-    }
   },
 
   appendChild(parentInstance : Instance, child : Instance | TextInstance) : void {

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -288,7 +288,7 @@ module.exports = function<T, P, I, TI, C>(
         const textInstance : TI = finishedWork.stateNode;
         const newText : string = finishedWork.memoizedProps;
         const oldText : string = current.memoizedProps;
-        commitTextUpdate(textInstance, oldText, newText, current);
+        commitTextUpdate(textInstance, oldText, newText);
         return;
       }
       default:

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -49,7 +49,7 @@ export type HostConfig<T, P, I, TI, C> = {
   commitUpdate(instance : I, oldProps : P, newProps : P) : void,
 
   createTextInstance(text : string) : TI,
-  commitTextUpdate(textInstance : TI, oldText : string, newText : string, parentInstance: ?Fiber) : void,
+  commitTextUpdate(textInstance : TI, oldText : string, newText : string) : void,
 
   appendChild(parentInstance : I, child : I | TI) : void,
   insertBefore(parentInstance : I, child : I | TI, beforeChild : I | TI) : void,


### PR DESCRIPTION
This reverts the implementation in 33325ad0097e0689fd415703a1a7c1665629be7e.

I didn't mean to merge the implementation since it is incorrect and incomplete. I meant to just merge the unit test.
