### PR TITLE
Revert "Check for event listener in props instead of bank (#8192)"

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -147,6 +147,8 @@ src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * should validate against invalid styles
 * should track input values
 * should track textarea values
+* should execute custom event plugin listening behavior
+* should handle null and missing properly with event hooks
 * should warn for children on void elements
 * should support custom elements which extend native elements
 * should warn against children for void elements
@@ -155,6 +157,7 @@ src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * should warn about contentEditable and children
 * should validate against invalid styles
 * should report component containing invalid styles
+* should clean up listeners
 * should clean up input value tracking
 * should clean up input textarea tracking
 * should warn about the `onScroll` issue when unsupported (IE8)
@@ -379,11 +382,13 @@ src/renderers/dom/stack/server/__tests__/ReactServerRendering-test.js
 * should generate simple markup for self-closing tags
 * should generate simple markup for attribute with `>` symbol
 * should generate comment markup for component returns null
+* should not register event listeners
 * should render composite components
 * should only execute certain lifecycle methods
 * should have the correct mounting behavior
 * should not put checksum and React ID on components
 * should not put checksum and React ID on text components
+* should not register event listeners
 * should only execute certain lifecycle methods
 * allows setState in componentWillMount without using DOM
 * renders components with different batching strategies
@@ -497,9 +502,6 @@ src/renderers/shared/shared/__tests__/ReactTreeTraversal-test.js
 * should enter from the window to the shallowest
 * should leave to the window
 * should leave to the window from the shallowest
-
-src/renderers/shared/shared/event/__tests__/EventPluginHub-test.js
-* should prevent non-function listeners, at dispatch
 
 src/renderers/shared/stack/reconciler/__tests__/ReactChildReconciler-test.js
 * warns for duplicated keys

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -955,6 +955,9 @@ src/renderers/shared/shared/__tests__/ReactTreeTraversal-test.js
 * should not traverse if enter/leave the same node
 * should determine the first common ancestor correctly
 
+src/renderers/shared/shared/event/__tests__/EventPluginHub-test.js
+* should prevent non-function listeners
+
 src/renderers/shared/shared/event/__tests__/EventPluginRegistry-test.js
 * should be able to inject ordering before plugins
 * should be able to inject plugins before and after ordering
@@ -1059,6 +1062,7 @@ src/renderers/shared/stack/reconciler/__tests__/ReactErrorBoundaries-test.js
 * propagates errors on retry on mounting
 * propagates errors inside boundary during componentWillMount
 * propagates errors inside boundary while rendering error state
+* does not register event handlers for unmounted children
 * does not call componentWillUnmount when aborting initial mount
 * resets refs if mounting aborts
 * successfully mounts if no error occurs

--- a/src/renderers/dom/shared/ReactBrowserEventEmitter.js
+++ b/src/renderers/dom/shared/ReactBrowserEventEmitter.js
@@ -163,6 +163,16 @@ function getListeningForDocument(mountAt) {
   return alreadyListeningTo[mountAt[topListenersIDKey]];
 }
 
+/**
+ * `ReactBrowserEventEmitter` is used to attach top-level event listeners. For
+ * example:
+ *
+ *   EventPluginHub.putListener('myID', 'onClick', myFunction);
+ *
+ * This would allocate a "registration" of `('onClick', myFunction)` on 'myID'.
+ *
+ * @internal
+ */
 var ReactBrowserEventEmitter = Object.assign({}, ReactEventEmitterMixin, {
 
   /**

--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -19,6 +19,7 @@ var DOMLazyTree = require('DOMLazyTree');
 var DOMNamespaces = require('DOMNamespaces');
 var DOMProperty = require('DOMProperty');
 var DOMPropertyOperations = require('DOMPropertyOperations');
+var EventPluginHub = require('EventPluginHub');
 var EventPluginRegistry = require('EventPluginRegistry');
 var ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
 var ReactDOMComponentFlags = require('ReactDOMComponentFlags');
@@ -42,6 +43,7 @@ var warning = require('warning');
 var didWarnShadyDOM = false;
 
 var Flags = ReactDOMComponentFlags;
+var deleteListener = EventPluginHub.deleteListener;
 var getNode = ReactDOMComponentTree.getNodeFromInstance;
 var listenTo = ReactBrowserEventEmitter.listenTo;
 var registrationNameModules = EventPluginRegistry.registrationNameModules;
@@ -203,6 +205,30 @@ function assertValidProps(component, props) {
   );
 }
 
+function enqueuePutListener(inst, registrationName, listener, transaction) {
+  if (transaction instanceof ReactServerRenderingTransaction) {
+    return;
+  }
+  if (__DEV__) {
+    // IE8 has no API for event capturing and the `onScroll` event doesn't
+    // bubble.
+    warning(
+      registrationName !== 'onScroll' || isEventSupported('scroll', true),
+      'This browser doesn\'t support the `onScroll` event'
+    );
+  }
+  var containerInfo = inst._hostContainerInfo;
+  var isDocumentFragment = containerInfo._node && containerInfo._node.nodeType === DOC_FRAGMENT_TYPE;
+  var doc = isDocumentFragment ? containerInfo._node : containerInfo._ownerDocument;
+  listenTo(registrationName, doc);
+  transaction.getReactMountReady().enqueue(putListener, {
+    inst: inst,
+    registrationName: registrationName,
+    listener: listener,
+  });
+}
+
+// TODO: This is coming from future #8192. Dedupe this and enqueuePutListener.
 function ensureListeningTo(inst, registrationName, transaction) {
   if (transaction instanceof ReactServerRenderingTransaction) {
     return;
@@ -219,6 +245,15 @@ function ensureListeningTo(inst, registrationName, transaction) {
   var isDocumentFragment = containerInfo._node && containerInfo._node.nodeType === DOC_FRAGMENT_TYPE;
   var doc = isDocumentFragment ? containerInfo._node : containerInfo._ownerDocument;
   listenTo(registrationName, doc);
+}
+
+function putListener() {
+  var listenerToPut = this;
+  EventPluginHub.putListener(
+    listenerToPut.inst,
+    listenerToPut.registrationName,
+    listenerToPut.listener
+  );
 }
 
 function inputPostMount() {
@@ -757,7 +792,7 @@ ReactDOMComponent.Mixin = {
       }
       if (registrationNameModules.hasOwnProperty(propKey)) {
         if (propValue) {
-          ensureListeningTo(this, propKey, transaction);
+          enqueuePutListener(this, propKey, propValue, transaction);
         }
       } else {
         if (propKey === STYLE) {
@@ -1012,7 +1047,12 @@ ReactDOMComponent.Mixin = {
         }
         this._previousStyleCopy = null;
       } else if (registrationNameModules.hasOwnProperty(propKey)) {
-        // Do nothing for event names.
+        if (lastProps[propKey]) {
+          // Only call deleteListener if there was a listener previously or
+          // else willDeleteListener gets called when there wasn't actually a
+          // listener (e.g., onClick={null})
+          deleteListener(this, propKey);
+        }
       } else if (isCustomComponent(this._tag, lastProps)) {
         if (!RESERVED_PROPS.hasOwnProperty(propKey)) {
           DOMPropertyOperations.deleteValueForAttribute(
@@ -1073,7 +1113,9 @@ ReactDOMComponent.Mixin = {
         }
       } else if (registrationNameModules.hasOwnProperty(propKey)) {
         if (nextProp) {
-          ensureListeningTo(this, propKey, transaction);
+          enqueuePutListener(this, propKey, nextProp, transaction);
+        } else if (lastProp) {
+          deleteListener(this, propKey);
         }
       } else if (isCustomComponentTag) {
         if (!RESERVED_PROPS.hasOwnProperty(propKey)) {
@@ -1222,6 +1264,7 @@ ReactDOMComponent.Mixin = {
 
     this.unmountChildren(safely, skipLifecycle);
     ReactDOMComponentTree.uncacheNode(this);
+    EventPluginHub.deleteAllListeners(this);
     this._rootNodeID = 0;
     this._domID = 0;
     this._wrapperState = null;

--- a/src/renderers/dom/stack/server/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/stack/server/__tests__/ReactServerRendering-test.js
@@ -85,7 +85,15 @@ describe('ReactServerRendering', () => {
       expect(response).toBe('<!-- react-empty: 1 -->');
     });
 
-    // TODO: Test that listeners are not registered onto any document/container.
+    it('should not register event listeners', () => {
+      var EventPluginHub = require('EventPluginHub');
+      var cb = jest.fn();
+
+      ReactServerRendering.renderToString(
+        <span onClick={cb}>hello world</span>
+      );
+      expect(EventPluginHub.__getListenerBank()).toEqual({});
+    });
 
     it('should render composite components', () => {
       class Parent extends React.Component {
@@ -312,6 +320,16 @@ describe('ReactServerRendering', () => {
       );
 
       expect(response).toBe('<span>hello world</span>');
+    });
+
+    it('should not register event listeners', () => {
+      var EventPluginHub = require('EventPluginHub');
+      var cb = jest.fn();
+
+      ReactServerRendering.renderToStaticMarkup(
+        <span onClick={cb}>hello world</span>
+      );
+      expect(EventPluginHub.__getListenerBank()).toEqual({});
     });
 
     it('should only execute certain lifecycle methods', () => {

--- a/src/renderers/native/ReactNativeEventEmitter.js
+++ b/src/renderers/native/ReactNativeEventEmitter.js
@@ -78,13 +78,28 @@ var removeTouchesAtIndices = function(
   return rippedOut;
 };
 
+/**
+ * `ReactNativeEventEmitter` is used to attach top-level event listeners. For example:
+ *
+ *   ReactNativeEventEmitter.putListener('myID', 'onClick', myFunction);
+ *
+ * This would allocate a "registration" of `('onClick', myFunction)` on 'myID'.
+ *
+ * @internal
+ */
 var ReactNativeEventEmitter = {
 
   ...ReactEventEmitterMixin,
 
   registrationNames: EventPluginRegistry.registrationNameModules,
 
+  putListener: EventPluginHub.putListener,
+
   getListener: EventPluginHub.getListener,
+
+  deleteListener: EventPluginHub.deleteListener,
+
+  deleteAllListeners: EventPluginHub.deleteAllListeners,
 
   /**
    * Internal version of `receiveEvent` in terms of normalized (non-tag)

--- a/src/renderers/shared/shared/event/EventPluginHub.js
+++ b/src/renderers/shared/shared/event/EventPluginHub.js
@@ -20,6 +20,11 @@ var forEachAccumulated = require('forEachAccumulated');
 var invariant = require('invariant');
 
 /**
+ * Internal store for event listeners
+ */
+var listenerBank = {};
+
+/**
  * Internal queue of events that have accumulated their dispatches and are
  * waiting to have their dispatches executed.
  */
@@ -46,6 +51,12 @@ var executeDispatchesAndReleaseSimulated = function(e) {
 };
 var executeDispatchesAndReleaseTopLevel = function(e) {
   return executeDispatchesAndRelease(e, false);
+};
+
+var getDictionaryKey = function(inst) {
+  // Prevents V8 performance issue:
+  // https://github.com/facebook/react/pull/7232
+  return '.' + inst._rootNodeID;
 };
 
 /**
@@ -91,21 +102,87 @@ var EventPluginHub = {
   },
 
   /**
+   * Stores `listener` at `listenerBank[registrationName][key]`. Is idempotent.
+   *
+   * @param {object} inst The instance, which is the source of events.
+   * @param {string} registrationName Name of listener (e.g. `onClick`).
+   * @param {function} listener The callback to store.
+   */
+  putListener: function(inst, registrationName, listener) {
+    invariant(
+      typeof listener === 'function',
+      'Expected %s listener to be a function, instead got type %s',
+      registrationName, typeof listener
+    );
+
+    var key = getDictionaryKey(inst);
+    var bankForRegistrationName =
+      listenerBank[registrationName] || (listenerBank[registrationName] = {});
+    bankForRegistrationName[key] = listener;
+
+    var PluginModule =
+      EventPluginRegistry.registrationNameModules[registrationName];
+    if (PluginModule && PluginModule.didPutListener) {
+      PluginModule.didPutListener(inst, registrationName, listener);
+    }
+  },
+
+  /**
    * @param {object} inst The instance, which is the source of events.
    * @param {string} registrationName Name of listener (e.g. `onClick`).
    * @return {?function} The stored callback.
    */
   getListener: function(inst, registrationName) {
-    var listener = inst._currentElement.props[registrationName];
-    if (listener !== undefined) {
-      invariant(
-        typeof listener === 'function',
-        'Expected %s listener to be a function, instead got type %s',
-        registrationName,
-        typeof listener
-      );
+    var bankForRegistrationName = listenerBank[registrationName];
+    var key = getDictionaryKey(inst);
+    return bankForRegistrationName && bankForRegistrationName[key];
+  },
+
+  /**
+   * Deletes a listener from the registration bank.
+   *
+   * @param {object} inst The instance, which is the source of events.
+   * @param {string} registrationName Name of listener (e.g. `onClick`).
+   */
+  deleteListener: function(inst, registrationName) {
+    var PluginModule =
+      EventPluginRegistry.registrationNameModules[registrationName];
+    if (PluginModule && PluginModule.willDeleteListener) {
+      PluginModule.willDeleteListener(inst, registrationName);
     }
-    return listener;
+
+    var bankForRegistrationName = listenerBank[registrationName];
+    // TODO: This should never be null -- when is it?
+    if (bankForRegistrationName) {
+      var key = getDictionaryKey(inst);
+      delete bankForRegistrationName[key];
+    }
+  },
+
+  /**
+   * Deletes all listeners for the DOM element with the supplied ID.
+   *
+   * @param {object} inst The instance, which is the source of events.
+   */
+  deleteAllListeners: function(inst) {
+    var key = getDictionaryKey(inst);
+    for (var registrationName in listenerBank) {
+      if (!listenerBank.hasOwnProperty(registrationName)) {
+        continue;
+      }
+
+      if (!listenerBank[registrationName][key]) {
+        continue;
+      }
+
+      var PluginModule =
+        EventPluginRegistry.registrationNameModules[registrationName];
+      if (PluginModule && PluginModule.willDeleteListener) {
+        PluginModule.willDeleteListener(inst, registrationName);
+      }
+
+      delete listenerBank[registrationName][key];
+    }
   },
 
   /**
@@ -181,6 +258,17 @@ var EventPluginHub = {
     );
     // This would be a good time to rethrow if any of the event handlers threw.
     ReactErrorUtils.rethrowCaughtError();
+  },
+
+  /**
+   * These are needed for tests only. Do not use!
+   */
+  __purge: function() {
+    listenerBank = {};
+  },
+
+  __getListenerBank: function() {
+    return listenerBank;
   },
 
 };

--- a/src/renderers/shared/shared/event/EventPluginRegistry.js
+++ b/src/renderers/shared/shared/event/EventPluginRegistry.js
@@ -130,7 +130,8 @@ function publishEventForPlugin(
 }
 
 /**
- * Publishes a registration name that is used to identify dispatched events.
+ * Publishes a registration name that is used to identify dispatched events and
+ * can be used with `EventPluginHub.putListener` to register listeners.
  *
  * @param {string} registrationName Registration name to add.
  * @param {object} PluginModule Plugin publishing the event.

--- a/src/renderers/shared/shared/event/PluginModuleType.js
+++ b/src/renderers/shared/shared/event/PluginModuleType.js
@@ -36,5 +36,14 @@ export type PluginModule<NativeEvent> = {
     nativeTarget: NativeEvent,
     nativeEventTarget: EventTarget,
   ) => null | ReactSyntheticEvent,
+  didPutListener?: (
+    inst: ReactInstance,
+    registrationName: string,
+    listener: () => void,
+  ) => void,
+  willDeleteListener?: (
+    inst: ReactInstance,
+    registrationName: string,
+  ) => void,
   tapMoveThreshold?: number,
 };

--- a/src/renderers/shared/shared/event/__tests__/EventPluginHub-test.js
+++ b/src/renderers/shared/shared/event/__tests__/EventPluginHub-test.js
@@ -14,21 +14,19 @@
 jest.mock('isEventSupported');
 
 describe('EventPluginHub', () => {
-  var React;
-  var ReactTestUtils;
+  var EventPluginHub;
+  var isEventSupported;
 
   beforeEach(() => {
     jest.resetModuleRegistry();
-    React = require('React');
-    ReactTestUtils = require('ReactTestUtils');
+    EventPluginHub = require('EventPluginHub');
+    isEventSupported = require('isEventSupported');
+    isEventSupported.mockReturnValueOnce(false);
   });
 
-  it('should prevent non-function listeners, at dispatch', () => {
-    var node = ReactTestUtils.renderIntoDocument(
-      <div onClick="not a function" />
-    );
+  it('should prevent non-function listeners', () => {
     expect(function() {
-      ReactTestUtils.SimulateNative.click(node);
+      EventPluginHub.putListener(1, 'onClick', 'not a function');
     }).toThrowError(
       'Expected onClick listener to be a function, instead got type string'
     );

--- a/src/renderers/shared/shared/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
+++ b/src/renderers/shared/shared/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
@@ -233,7 +233,7 @@ var registerTestHandlers = function(eventTestConfig, readableIDToID) {
           }
           return config.returnVal;
         }.bind(null, readableID, nodeConfig);
-      putListener(getInstanceFromNode(id), registrationName, handler);
+      EventPluginHub.putListener(getInstanceFromNode(id), registrationName, handler);
     }
   };
   for (var eventName in eventTestConfig) {
@@ -257,6 +257,9 @@ var registerTestHandlers = function(eventTestConfig, readableIDToID) {
   }
   return runs;
 };
+
+
+
 
 var run = function(config, hierarchyConfig, nativeEventConfig) {
   var max = NA;
@@ -306,30 +309,10 @@ var PARENT_HOST_NODE = { };
 var CHILD_HOST_NODE = { };
 var CHILD_HOST_NODE2 = { };
 
-var GRANDPARENT_INST = {
-  _hostParent: null,
-  _rootNodeID: '1',
-  _hostNode: GRANDPARENT_HOST_NODE,
-  _currentElement: { props: {} },
-};
-var PARENT_INST = {
-  _hostParent: GRANDPARENT_INST,
-  _rootNodeID: '2',
-  _hostNode: PARENT_HOST_NODE,
-  _currentElement: { props: {} },
-};
-var CHILD_INST = {
-  _hostParent: PARENT_INST,
-  _rootNodeID: '3',
-  _hostNode: CHILD_HOST_NODE,
-  _currentElement: { props: {} },
-};
-var CHILD_INST2 = {
-  _hostParent: PARENT_INST,
-  _rootNodeID: '4',
-  _hostNode: CHILD_HOST_NODE2,
-  _currentElement: { props: {} },
-};
+var GRANDPARENT_INST = { _hostParent: null, _rootNodeID: '1', _hostNode: GRANDPARENT_HOST_NODE };
+var PARENT_INST = { _hostParent: GRANDPARENT_INST, _rootNodeID: '2', _hostNode: PARENT_HOST_NODE };
+var CHILD_INST = { _hostParent: PARENT_INST, _rootNodeID: '3', _hostNode: CHILD_HOST_NODE };
+var CHILD_INST2 = { _hostParent: PARENT_INST, _rootNodeID: '4', _hostNode: CHILD_HOST_NODE2 };
 
 GRANDPARENT_HOST_NODE._reactInstance = GRANDPARENT_INST;
 PARENT_HOST_NODE._reactInstance = PARENT_INST;
@@ -356,14 +339,6 @@ function getNodeFromInstance(inst) {
   return inst._hostNode;
 }
 
-function putListener(node, registrationName, handler) {
-  node._currentElement.props[registrationName] = handler;
-}
-
-function deleteAllListeners(node) {
-  node._currentElement.props = {};
-}
-
 describe('ResponderEventPlugin', () => {
 
   beforeEach(() => {
@@ -372,11 +347,6 @@ describe('ResponderEventPlugin', () => {
     EventPluginHub = require('EventPluginHub');
     EventPluginUtils = require('EventPluginUtils');
     ResponderEventPlugin = require('ResponderEventPlugin');
-
-    deleteAllListeners(GRANDPARENT_INST);
-    deleteAllListeners(PARENT_INST);
-    deleteAllListeners(CHILD_INST);
-    deleteAllListeners(CHILD_INST2);
 
     EventPluginUtils.injection.injectComponentTree({
       getInstanceFromNode,

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactErrorBoundaries-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactErrorBoundaries-test.js
@@ -879,6 +879,26 @@ describe('ReactErrorBoundaries', () => {
     ]);
   });
 
+  it('does not register event handlers for unmounted children', () => {
+    var EventPluginHub = require('EventPluginHub');
+    var container = document.createElement('div');
+    EventPluginHub.putListener = jest.fn();
+    ReactDOM.render(
+      <ErrorBoundary>
+        <button onClick={() => {}}>Click me</button>
+        <BrokenRender />
+      </ErrorBoundary>,
+      container
+    );
+    expect(EventPluginHub.putListener).not.toBeCalled();
+
+    log.length = 0;
+    ReactDOM.unmountComponentAtNode(container);
+    expect(log).toEqual([
+      'ErrorBoundary componentWillUnmount',
+    ]);
+  });
+
   it('does not call componentWillUnmount when aborting initial mount', () => {
     var container = document.createElement('div');
     ReactDOM.render(


### PR DESCRIPTION
This reverts commit a878c3056d2df0cf4d7f3b5e2db6031d598ef23f.

The previous PRs that this builds on didn't successfully land fully. I found a bug. Since I want to measure this in isolation, I'll revert this for now until the existing code is fixed.