### PR TITLE
Fixed batching reentrant controlled events

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -250,6 +250,7 @@ src/renderers/dom/shared/wrappers/__tests__/ReactDOMIframe-test.js
 
 src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
 * should properly control a value even if no event listener exists
+* should control a value in reentrant events
 * should display `defaultValue` of number 0
 * should display "true" for `defaultValue` of `true`
 * should display "false" for `defaultValue` of `false`

--- a/src/renderers/dom/shared/ReactEventListener.js
+++ b/src/renderers/dom/shared/ReactEventListener.js
@@ -14,7 +14,6 @@
 var EventListener = require('EventListener');
 var ExecutionEnvironment = require('ExecutionEnvironment');
 var PooledClass = require('PooledClass');
-var ReactControlledComponent = require('ReactControlledComponent');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var ReactGenericBatching = require('ReactGenericBatching');
 
@@ -172,14 +171,11 @@ var ReactEventListener = {
     try {
       // Event queue being processed in the same cycle allows
       // `preventDefault`.
-      ReactGenericBatching.batchedUpdates(handleTopLevelImpl, bookKeeping);
-      if (bookKeeping.targetInst) {
-        // Here we wait until all updates have propagated, which is important
-        // when using controlled components within layers:
-        // https://github.com/facebook/react/issues/1698
-        // Then we restore state of any controlled component.
-        ReactControlledComponent.restoreStateIfNeeded(bookKeeping.targetInst);
-      }
+      ReactGenericBatching.batchedUpdatesWithControlledTarget(
+        handleTopLevelImpl,
+        bookKeeping,
+        bookKeeping.targetInst
+      );
     } finally {
       TopLevelCallbackBookKeeping.release(bookKeeping);
     }

--- a/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
@@ -101,10 +101,11 @@ function manualDispatchChangeEvent(nativeEvent) {
   // components don't work properly in conjunction with event bubbling because
   // the component is rerendered and the value reverted before all the event
   // handlers can run. See https://github.com/facebook/react/issues/708.
-  ReactGenericBatching.batchedUpdates(runEventInBatch, event);
-  if (activeElementInst) {
-    ReactControlledComponent.restoreStateIfNeeded(activeElementInst);
-  }
+  ReactGenericBatching.batchedUpdatesWithControlledTarget(
+    runEventInBatch,
+    event,
+    activeElementInst
+  );
 }
 
 function runEventInBatch(event) {


### PR DESCRIPTION
If a controlled target fires within another controlled event, we should not restore it until we've fully completed the event. Otherwise, if someone reads from it afterwards, they'll get the restored value.

Not super happy with this particular solution.