### PR TITLE
Remove string ref from function component example

### DIFF
--- a/docs/docs/web-components.md
+++ b/docs/docs/web-components.md
@@ -31,7 +31,7 @@ One common confusion is that Web Components use "class" instead of "className".
 ```javascript
 function BrickFlipbox() {
   return (
-    <brick-flipbox class="demo" ref="foo">
+    <brick-flipbox class="demo">
       <div>front</div>
       <div>back</div>
     </brick-flipbox>


### PR DESCRIPTION
Refs can't be attached to stateless functional components.