### PR TITLE
[Fiber] Normalize className passed to dom from fiber

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -104,7 +104,6 @@ src/renderers/dom/shared/__tests__/ReactBrowserEventEmitter-test.js
 * should bubble onTouchTap
 
 src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
-* should handle className
 * should gracefully handle various style value types
 * should update styles when mutating style object
 * should warn when mutating style

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -509,6 +509,7 @@ src/renderers/dom/shared/__tests__/ReactBrowserEventEmitter-test.js
 * should not crash ensureScrollValueMonitoring when createEvent returns null
 
 src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+* should handle className
 * should not warn for "0" as a unitless style value
 * should skip reserved props on web components
 * should skip dangerouslySetInnerHTML on web components

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -43,6 +43,10 @@ function recursivelyAppendChildren(parent : Element, child : HostChildren<Instan
   }
 }
 
+function normalizeClassName(className) : string {
+  return (className === null) ? '' : className;
+}
+
 var DOMRenderer = ReactFiberReconciler({
 
   updateContainer(container : Container, children : HostChildren<Instance | TextInstance>) : void {
@@ -55,7 +59,7 @@ var DOMRenderer = ReactFiberReconciler({
     const domElement = document.createElement(type);
     recursivelyAppendChildren(domElement, children);
     if (typeof props.className !== 'undefined') {
-      domElement.className = props.className;
+      domElement.className = normalizeClassName(props.className);
     }
     if (typeof props.children === 'string') {
       domElement.textContent = props.children;
@@ -75,7 +79,7 @@ var DOMRenderer = ReactFiberReconciler({
 
   commitUpdate(domElement : Instance, oldProps : Props, newProps : Props) : void {
     if (typeof newProps.className !== 'undefined') {
-      domElement.className = newProps.className;
+      domElement.className = normalizeClassName(newProps.className);
     }
     if (typeof newProps.children === 'string') {
       domElement.textContent = newProps.children;


### PR DESCRIPTION
> Nobody wants to see `class="null"`. :)

Apologies for this being so small, but I wanted to confirm that this is the approach that you guys wanted to take wrt to helpers - I was going to start working on reconciling styles, but that's a hairy beast and I don't want to make a mess of things without verifying that component-level reconciliation is intended to be inlined into this file.

Is the `DOMRenderer` supposed to get huge as more features are built, or should each chunk of logic live in another module?

Thanks for your time! 😄 