### PR TITLE
Handle nested controlled events

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -254,6 +254,7 @@ src/renderers/dom/shared/wrappers/__tests__/ReactDOMIframe-test.js
 src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
 * should properly control a value even if no event listener exists
 * should control a value in reentrant events
+* should control values in reentrant events with different targets
 * should display `defaultValue` of number 0
 * should display "true" for `defaultValue` of `true`
 * should display "false" for `defaultValue` of `false`

--- a/src/renderers/dom/shared/ReactEventListener.js
+++ b/src/renderers/dom/shared/ReactEventListener.js
@@ -171,11 +171,7 @@ var ReactEventListener = {
     try {
       // Event queue being processed in the same cycle allows
       // `preventDefault`.
-      ReactGenericBatching.batchedUpdatesWithControlledTarget(
-        handleTopLevelImpl,
-        bookKeeping,
-        bookKeeping.targetInst
-      );
+      ReactGenericBatching.batchedUpdates(handleTopLevelImpl, bookKeeping);
     } finally {
       TopLevelCallbackBookKeeping.release(bookKeeping);
     }

--- a/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
@@ -52,7 +52,7 @@ function createAndAccumulateChangeEvent(inst, nativeEvent, target) {
   );
   event.type = 'change';
   // Flag this event loop as needing state restore.
-  ReactControlledComponent.enqueueStateRestore();
+  ReactControlledComponent.enqueueStateRestore(inst);
   EventPropagators.accumulateTwoPhaseDispatches(event);
   return event;
 }
@@ -101,11 +101,7 @@ function manualDispatchChangeEvent(nativeEvent) {
   // components don't work properly in conjunction with event bubbling because
   // the component is rerendered and the value reverted before all the event
   // handlers can run. See https://github.com/facebook/react/issues/708.
-  ReactGenericBatching.batchedUpdatesWithControlledTarget(
-    runEventInBatch,
-    event,
-    activeElementInst
-  );
+  ReactGenericBatching.batchedUpdates(runEventInBatch, event);
 }
 
 function runEventInBatch(event) {

--- a/src/renderers/shared/shared/event/ReactControlledComponent.js
+++ b/src/renderers/shared/shared/event/ReactControlledComponent.js
@@ -25,35 +25,57 @@ var ReactControlledComponentInjection = {
   },
 };
 
-var needsRestoreState = false;
+var restoreTarget = null;
+var restoreQueue = null;
+
+function restoreStateOfTarget(internalInstance) {
+  if (typeof internalInstance.tag === 'number') {
+    invariant(
+      fiberHostComponent &&
+      typeof fiberHostComponent.restoreControlledState === 'function',
+      'Fiber needs to be injected to handle a fiber target for controlled ' +
+      'events.'
+    );
+    fiberHostComponent.restoreControlledState(internalInstance);
+  }
+  invariant(
+    typeof internalInstance.restoreControlledState === 'function',
+    'The internal instance must be a React host component.'
+  );
+  // If it is not a Fiber, we can just use dynamic dispatch.
+  internalInstance.restoreControlledState();
+}
 
 var ReactControlledComponent = {
   injection: ReactControlledComponentInjection,
 
-  enqueueStateRestore() {
-    needsRestoreState = true;
+  enqueueStateRestore(target) {
+    if (restoreTarget) {
+      if (restoreQueue) {
+        restoreQueue.push(target);
+      } else {
+        restoreQueue = [target];
+      }
+    } else {
+      restoreTarget = target;
+    }
   },
 
-  restoreStateIfNeeded(internalInstance) {
-    if (!needsRestoreState) {
+  restoreStateIfNeeded() {
+    if (!restoreTarget) {
       return;
     }
-    needsRestoreState = false;
-    if (typeof internalInstance.tag === 'number') {
-      invariant(
-        fiberHostComponent &&
-        typeof fiberHostComponent.restoreControlledState === 'function',
-        'Fiber needs to be injected to handle a fiber target for controlled ' +
-        'events.'
-      );
-      fiberHostComponent.restoreControlledState(internalInstance);
+    var target = restoreTarget;
+    var queuedTargets = restoreQueue;
+    restoreTarget = null;
+    restoreQueue = null;
+
+    restoreStateOfTarget(target);
+    if (queuedTargets) {
+      for (var i = 0; i < queuedTargets.length; i++) {
+        restoreStateOfTarget(queuedTargets[i]);
+      }
     }
-    invariant(
-      typeof internalInstance.restoreControlledState === 'function',
-      'The internal instance must be a React host component.'
-    );
-    // If it is not a Fiber, we can just use dynamic dispatch.
-    internalInstance.restoreControlledState();
   },
 };
 

--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -22,7 +22,7 @@ var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
 var ReactInstanceMap = require('ReactInstanceMap');
 var ReactTypeOfWork = require('ReactTypeOfWork');
-var ReactUpdates = require('ReactUpdates');
+var ReactGenericBatching = require('ReactGenericBatching');
 var SyntheticEvent = require('SyntheticEvent');
 var ReactShallowRenderer = require('ReactShallowRenderer');
 
@@ -465,16 +465,14 @@ function makeSimulator(eventType) {
       EventPropagators.accumulateDirectDispatches(event);
     }
 
-    ReactUpdates.batchedUpdates(function() {
+    ReactGenericBatching.batchedUpdates(function() {
+      // Normally extractEvent enqueues a state restore, but we'll just always
+      // do that since we we're by-passing it here.
+      ReactControlledComponent.enqueueStateRestore(targetInst);
+
       EventPluginHub.enqueueEvents(event);
       EventPluginHub.processEventQueue(true);
     });
-    // Normally extractEvent enqueues a state restore, but we'll just always do
-    // that.
-    ReactControlledComponent.enqueueStateRestore();
-    if (targetInst) {
-      ReactControlledComponent.restoreStateIfNeeded(targetInst);
-    }
   };
 }
 


### PR DESCRIPTION
I came up with a contrived case of where nested controlled events could fire within the same batch - but on different targets.

I think we came to the conclusion that controlled values typically cannot use preventDefault so it is ok that they don't flush until after the event has finished. So therefore we accumulate a queue of all the nested targets within a batch and then restore state on all of them.

I'm still skeptical that this is the correct way to do controlled values. The reason we have to do them in a single event loop is because when you type, the sequence of values that get accepted or not can matter. I wonder if there is a scenario we can come up with where you can fire multiple
inner events in an event loop and end up with batching causing problems.