### PR TITLE
Correct a method param in Implementation Notes

### DIFF
--- a/docs/contributing/implementation-notes.md
+++ b/docs/contributing/implementation-notes.md
@@ -576,7 +576,7 @@ class CompositeComponent {
       // Component class
       // Call the lifecycle if necessary
       if (publicInstance.componentWillUpdate) {
-        publicInstance.componentWillUpdate(prevProps);
+        publicInstance.componentWillUpdate(nextProps);
       }
       // Update the props
       publicInstance.props = nextProps;


### PR DESCRIPTION
This is a tiny fix on Implementation Notes.

According to [React.Component in the reference](https://facebook.github.io/react/docs/react-component.html#componentwillupdate), `componentWillUpdate(nextProps, nextState)` is the correct signature. Because the guide hasn't referred to `state` at the point, `componentWillUpdate(nextProps)` would be correct here.