### PR TITLE
[Fiber] Use ReactDOM.unstable_batchedUpdates in Fiber tests

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -567,20 +567,9 @@ src/renderers/shared/stack/reconciler/__tests__/ReactStatelessComponent-test.js
 * should warn when using non-React functions in JSX
 
 src/renderers/shared/stack/reconciler/__tests__/ReactUpdates-test.js
-* should batch state when updating state twice
-* should batch state when updating two different state keys
-* should batch state and props together
-* should batch parent/child state updates together
-* should batch child/parent state updates together
-* should support chained state updates
-* should batch forceUpdate together
-* should update children even if parent blocks updates
-* should flow updates correctly
 * should share reconcile transaction across different roots
 * should queue mount-ready handlers across different roots
-* should flush updates in the correct order across roots
 * should queue updates from during mount
-* does not call render after a component as been deleted
 * marks top-level updates
 * throws in setState if the update callback is not a function
 * throws in replaceState if the update callback is not a function

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1155,10 +1155,21 @@ src/renderers/shared/stack/reconciler/__tests__/ReactStatelessComponent-test.js
 * should allow simple functions to return false
 
 src/renderers/shared/stack/reconciler/__tests__/ReactUpdates-test.js
+* should batch state when updating state twice
+* should batch state when updating two different state keys
+* should batch state and props together
+* should batch parent/child state updates together
+* should batch child/parent state updates together
+* should support chained state updates
+* should batch forceUpdate together
+* should update children even if parent blocks updates
 * should not reconcile children passed via props
+* should flow updates correctly
 * should flush updates in the correct order
+* should flush updates in the correct order across roots
 * should queue nested updates
 * calls componentWillReceiveProps setState callback properly
+* does not call render after a component as been deleted
 * does not update one component twice in a batch (#2410)
 * does not update one component twice in a batch (#6371)
 * unstable_batchedUpdates should return value from a callback

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponent-test.js
@@ -19,7 +19,6 @@ var ReactCurrentOwner;
 var ReactPropTypes;
 var ReactServerRendering;
 var ReactTestUtils;
-var ReactUpdates;
 
 describe('ReactCompositeComponent', () => {
 
@@ -31,7 +30,6 @@ describe('ReactCompositeComponent', () => {
     ReactPropTypes = require('ReactPropTypes');
     ReactTestUtils = require('ReactTestUtils');
     ReactServerRendering = require('ReactServerRendering');
-    ReactUpdates = require('ReactUpdates');
 
     MorphingComponent = class extends React.Component {
       state = {activated: false};
@@ -813,7 +811,7 @@ describe('ReactCompositeComponent', () => {
     expect(childInstance).toBeNull();
 
     expect(parentInstance.state.flag).toBe(false);
-    ReactUpdates.batchedUpdates(function() {
+    ReactDOM.unstable_batchedUpdates(function() {
       parentInstance.setState({flag: true});
     });
     expect(parentInstance.state.flag).toBe(true);
@@ -1209,7 +1207,7 @@ describe('ReactCompositeComponent', () => {
 
     // When more than one state update is enqueued, we have the same behavior
     var fifthState = new NotActuallyImmutable('fifth');
-    ReactUpdates.batchedUpdates(function() {
+    ReactDOM.unstable_batchedUpdates(function() {
       moo.setState({str: 'fourth'});
       moo.replaceState(fifthState);
     });
@@ -1217,7 +1215,7 @@ describe('ReactCompositeComponent', () => {
 
     // When more than one state update is enqueued, we have the same behavior
     var sixthState = new NotActuallyImmutable('sixth');
-    ReactUpdates.batchedUpdates(function() {
+    ReactDOM.unstable_batchedUpdates(function() {
       moo.replaceState(sixthState);
       moo.setState({str: 'seventh'});
     });

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactUpdates-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactUpdates-test.js
@@ -42,7 +42,7 @@ describe('ReactUpdates', () => {
     var instance = ReactTestUtils.renderIntoDocument(<Component />);
     expect(instance.state.x).toBe(0);
 
-    ReactUpdates.batchedUpdates(function() {
+    ReactDOM.unstable_batchedUpdates(function() {
       instance.setState({x: 1});
       instance.setState({x: 2});
       expect(instance.state.x).toBe(0);
@@ -72,7 +72,7 @@ describe('ReactUpdates', () => {
     expect(instance.state.x).toBe(0);
     expect(instance.state.y).toBe(0);
 
-    ReactUpdates.batchedUpdates(function() {
+    ReactDOM.unstable_batchedUpdates(function() {
       instance.setState({x: 1});
       instance.setState({y: 2});
       expect(instance.state.x).toBe(0);
@@ -105,7 +105,7 @@ describe('ReactUpdates', () => {
     expect(instance.props.x).toBe(0);
     expect(instance.state.y).toBe(0);
 
-    ReactUpdates.batchedUpdates(function() {
+    ReactDOM.unstable_batchedUpdates(function() {
       ReactDOM.render(<Component x={1} />, container);
       instance.setState({y: 2});
       expect(instance.props.x).toBe(0);
@@ -152,7 +152,7 @@ describe('ReactUpdates', () => {
     expect(instance.state.x).toBe(0);
     expect(child.state.y).toBe(0);
 
-    ReactUpdates.batchedUpdates(function() {
+    ReactDOM.unstable_batchedUpdates(function() {
       instance.setState({x: 1});
       child.setState({y: 2});
       expect(instance.state.x).toBe(0);
@@ -201,7 +201,7 @@ describe('ReactUpdates', () => {
     expect(instance.state.x).toBe(0);
     expect(child.state.y).toBe(0);
 
-    ReactUpdates.batchedUpdates(function() {
+    ReactDOM.unstable_batchedUpdates(function() {
       child.setState({y: 2});
       instance.setState({x: 1});
       expect(instance.state.x).toBe(0);
@@ -237,7 +237,7 @@ describe('ReactUpdates', () => {
     expect(instance.state.x).toBe(0);
 
     var innerCallbackRun = false;
-    ReactUpdates.batchedUpdates(function() {
+    ReactDOM.unstable_batchedUpdates(function() {
       instance.setState({x: 1}, function() {
         instance.setState({x: 2}, function() {
           expect(this).toBe(instance);
@@ -281,7 +281,7 @@ describe('ReactUpdates', () => {
     expect(instance.state.x).toBe(0);
 
     var callbacksRun = 0;
-    ReactUpdates.batchedUpdates(function() {
+    ReactDOM.unstable_batchedUpdates(function() {
       instance.setState({x: 1}, function() {
         callbacksRun++;
       });
@@ -330,14 +330,14 @@ describe('ReactUpdates', () => {
     expect(parentRenderCount).toBe(1);
     expect(childRenderCount).toBe(1);
 
-    ReactUpdates.batchedUpdates(function() {
+    ReactDOM.unstable_batchedUpdates(function() {
       instance.setState({x: 1});
     });
 
     expect(parentRenderCount).toBe(1);
     expect(childRenderCount).toBe(1);
 
-    ReactUpdates.batchedUpdates(function() {
+    ReactDOM.unstable_batchedUpdates(function() {
       instance.refs.child.setState({x: 1});
     });
 
@@ -465,7 +465,7 @@ describe('ReactUpdates', () => {
     function testUpdates(components, desiredWillUpdates, desiredDidUpdates) {
       var i;
 
-      ReactUpdates.batchedUpdates(function() {
+      ReactDOM.unstable_batchedUpdates(function() {
         for (i = 0; i < components.length; i++) {
           triggerUpdate(components[i]);
         }
@@ -475,7 +475,7 @@ describe('ReactUpdates', () => {
 
       // Try them in reverse order
 
-      ReactUpdates.batchedUpdates(function() {
+      ReactDOM.unstable_batchedUpdates(function() {
         for (i = components.length - 1; i >= 0; i--) {
           triggerUpdate(components[i]);
         }
@@ -519,7 +519,7 @@ describe('ReactUpdates', () => {
     var containerB = document.createElement('div');
 
     // Initial renders aren't batched together yet...
-    ReactUpdates.batchedUpdates(function() {
+    ReactDOM.unstable_batchedUpdates(function() {
       ReactDOM.render(<Component text="A1" />, containerA);
       ReactDOM.render(<Component text="B1" />, containerB);
     });
@@ -527,7 +527,7 @@ describe('ReactUpdates', () => {
 
     // ...but updates are! Here only one more transaction is used, which means
     // we only have to initialize and close the wrappers once.
-    ReactUpdates.batchedUpdates(function() {
+    ReactDOM.unstable_batchedUpdates(function() {
       ReactDOM.render(<Component text="A2" />, containerA);
       ReactDOM.render(<Component text="B2" />, containerB);
     });
@@ -568,7 +568,7 @@ describe('ReactUpdates', () => {
     a = ReactTestUtils.renderIntoDocument(<A />);
     b = ReactTestUtils.renderIntoDocument(<B />);
 
-    ReactUpdates.batchedUpdates(function() {
+    ReactDOM.unstable_batchedUpdates(function() {
       a.setState({x: 1});
       b.setState({x: 1});
     });
@@ -679,7 +679,7 @@ describe('ReactUpdates', () => {
 
     expect(updates).toEqual([0, 1, 2]);
 
-    ReactUpdates.batchedUpdates(function() {
+    ReactDOM.unstable_batchedUpdates(function() {
       // Simulate update on each component from top to bottom.
       instances.forEach(function(instance) {
         instance.forceUpdate();
@@ -771,7 +771,7 @@ describe('ReactUpdates', () => {
       }
     }
 
-    ReactUpdates.batchedUpdates(function() {
+    ReactDOM.unstable_batchedUpdates(function() {
       ReactTestUtils.renderIntoDocument(
         <div>
           <A />
@@ -837,7 +837,7 @@ describe('ReactUpdates', () => {
 
     var component = ReactTestUtils.renderIntoDocument(<A />);
 
-    ReactUpdates.batchedUpdates(function() {
+    ReactDOM.unstable_batchedUpdates(function() {
       // B will have scheduled an update but the batching should ensure that its
       // update never fires.
       componentB.setState({updates: 1});


### PR DESCRIPTION
This fixes some errors due to attempting to use Stack-only `ReactUpdates`.
It uncovers an interesting bug in Fiber related to batching:

```
● ReactUpdates › should queue updates from during mount

    Cannot commit the same tree as before. This is probably a bug related to the return field.
      
      at completeUnitOfWork (src/renderers/shared/fiber/ReactFiberScheduler.js:323:17)
      at performUnitOfWork (src/renderers/shared/fiber/ReactFiberScheduler.js:368:14)
      at performTaskWorkUnsafe (src/renderers/shared/fiber/ReactFiberScheduler.js:460:9)
      at performAndHandleErrors (src/renderers/shared/fiber/ReactFiberScheduler.js:492:15)
      at performTaskWork (src/renderers/shared/fiber/ReactFiberScheduler.js:475:5)
      at Object.batchedUpdates (src/renderers/shared/fiber/ReactFiberScheduler.js:789:9)
      at Object.ReactDOM.unstable_batchedUpdates (src/renderers/dom/fiber/ReactDOMFiber.js:169:24)
      at Object.<anonymous> (src/renderers/shared/stack/reconciler/__tests__/ReactUpdates-test.js:774:14)
```

The failing test is [here](https://github.com/gaearon/react-docs-test-new/blob/0af2d8be4556eddfc6628d5bde25d42ad5224a51/src/renderers/shared/stack/reconciler/__tests__/ReactUpdates-test.js#L748-L785). It was extracted from #1353, and originally added in #1363.

The interesting part about it is that it's a hard Fiber crash (definitely a bug), and that it only occurs when rendering is wrapped in `ReactDOM.unstable_batchedUpdates`. See #1363 for more information about this scenario.