### PR TITLE
Add freenode #reactjs link to support.md

### DIFF
--- a/docs/community/support.md
+++ b/docs/community/support.md
@@ -23,6 +23,10 @@ In the forum there's also a category for job posts and a category for discussion
 
 If you need an answer right away, check out the [Reactiflux Discord](https://discord.gg/0ZcbPKXt5bZjGY5n) community. There are usually a number of React experts there who can help out or point you to somewhere you might want to look.
 
+## Freenode IRC
+
+Many developers also hang out in [#reactjs on Freenode](irc://irc.freenode.net/reactjs).
+
 ## Facebook and Twitter
 
 For the latest news about React, [like us on Facebook](https://facebook.com/react) and [follow **@reactjs** on Twitter](https://twitter.com/reactjs). In addition, you can use the [#reactjs](https://twitter.com/hashtag/reactjs) hashtag to see what others are saying or add to the conversation.

--- a/docs/community/support.md
+++ b/docs/community/support.md
@@ -25,7 +25,7 @@ If you need an answer right away, check out the [Reactiflux Discord](https://dis
 
 ## Freenode IRC
 
-Many developers also hang out in [#reactjs on Freenode](irc://irc.freenode.net/reactjs).
+Many developers also hang out in [#reactjs on Freenode](http://irc.lc/freenode/reactjs).
 
 ## Facebook and Twitter
 


### PR DESCRIPTION
The irc: link scheme is not supported (whitelisted) by Github, so the link is transformed to plaintext. I'm not sure if there is a workaround for this.

Closes #8268.
@lacker 