### PR TITLE
Fix reactComponentExpect.toBeDOMComponentWithChildCount(0) regression

### DIFF
--- a/src/test/reactComponentExpect.js
+++ b/src/test/reactComponentExpect.js
@@ -157,8 +157,8 @@ Object.assign(reactComponentExpectInternal.prototype, {
       if (count > 0) {
         expect(renderedChildren).toBeTruthy();
         expect(Object.keys(renderedChildren).length).toBe(count);
-      } else {
-        expect(renderedChildren).toBeFalsy();
+      } else if (renderedChildren) {
+        expect(Object.keys(renderedChildren).length).toBe(0);
       }
     }
     return this;


### PR DESCRIPTION
This should fix https://github.com/facebook/react/commit/3e2680411efa3b478afc1f26057f417c7aae7915#commitcomment-19788988.