### PR TITLE
[Fiber] Initial implementation of context

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -19,8 +19,7 @@ src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
 * should transition from false to one
 
 src/isomorphic/classic/__tests__/ReactContextValidator-test.js
-* should filter out context not in contextTypes
-* should filter context properly in callbacks
+* should pass previous context to lifecycles
 
 src/isomorphic/classic/class/__tests__/ReactBind-test.js
 * Holds reference to instance
@@ -31,23 +30,8 @@ src/isomorphic/classic/class/__tests__/ReactBindOptout-test.js
 * works with mixins that have not opted out of autobinding
 * works with mixins that have opted out of autobinding
 
-src/isomorphic/classic/class/__tests__/ReactClass-test.js
-* renders based on context getInitialState
-
 src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
 * includes the owner name when passing null, undefined, boolean, or number
-
-src/isomorphic/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
-* renders based on context in the constructor
-* supports this.context passed via getChildContext
-
-src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
-* renders based on context in the constructor
-* supports this.context passed via getChildContext
-
-src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
-* renders based on context in the constructor
-* supports this.context passed via getChildContext
 
 src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
 * should give context for PropType errors in nested components.
@@ -441,11 +425,8 @@ src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponent-test.js
 * should warn about `setState` on unmounted components
 * should warn about `setState` in render
 * should warn about `setState` in getChildContext
-* should pass context to children when not owner
 * should pass context when re-rendered for static child
 * should pass context when re-rendered for static child within a composite component
-* should pass context transitively
-* should pass context when re-rendered
 * unmasked context propagates through updates
 * should trigger componentWillReceiveProps for context changes
 * should update refs if shouldComponentUpdate gives false
@@ -467,10 +448,8 @@ src/renderers/shared/stack/reconciler/__tests__/ReactMultiChildText-test.js
 * should throw if rendering both HTML and children
 
 src/renderers/shared/stack/reconciler/__tests__/ReactStatelessComponent-test.js
-* should pass context thru stateless component
 * should warn when stateless component returns array
 * should throw on string refs in pure functions
-* should receive context
 * should warn when using non-React functions in JSX
 
 src/renderers/shared/stack/reconciler/__tests__/ReactUpdates-test.js

--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -425,8 +425,6 @@ src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponent-test.js
 * should warn about `setState` on unmounted components
 * should warn about `setState` in render
 * should warn about `setState` in getChildContext
-* unmasked context propagates through updates
-* should trigger componentWillReceiveProps for context changes
 * should update refs if shouldComponentUpdate gives false
 * should support objects with prototypes as state
 

--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -425,8 +425,6 @@ src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponent-test.js
 * should warn about `setState` on unmounted components
 * should warn about `setState` in render
 * should warn about `setState` in getChildContext
-* should pass context when re-rendered for static child
-* should pass context when re-rendered for static child within a composite component
 * unmasked context propagates through updates
 * should trigger componentWillReceiveProps for context changes
 * should update refs if shouldComponentUpdate gives false

--- a/scripts/fiber/tests-passing-except-dev.txt
+++ b/scripts/fiber/tests-passing-except-dev.txt
@@ -12,9 +12,6 @@ src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
 * warns for keys with component stack info
 * should give context for PropType errors in nested components.
 
-src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
-* should warn on invalid context types
-
 src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
 * should warn when using hyphenated style names
 * should warn when updating hyphenated style names

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1041,6 +1041,8 @@ src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponent-test.js
 * should pass context when re-rendered for static child within a composite component
 * should pass context transitively
 * should pass context when re-rendered
+* unmasked context propagates through updates
+* should trigger componentWillReceiveProps for context changes
 * only renders once if updated in componentWillReceiveProps
 * should allow access to findDOMNode in componentWillUnmount
 * context should be passed down from the parent

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -819,6 +819,8 @@ src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
 * can nest batchedUpdates
 * can handle if setState callback throws
 * merges and masks context
+* does not leak own context into context provider
+* provides context when reusing work
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
 * catches render error in a boundary during mounting

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -128,6 +128,10 @@ src/isomorphic/children/__tests__/sliceChildren-test.js
 * should allow static children to be sliced
 * should slice nested children
 
+src/isomorphic/classic/__tests__/ReactContextValidator-test.js
+* should filter out context not in contextTypes
+* should pass next context to lifecycles
+
 src/isomorphic/classic/class/__tests__/ReactBind-test.js
 * warns if you try to bind to this
 * does not warn if you pass an auto-bound method to setState
@@ -149,6 +153,7 @@ src/isomorphic/classic/class/__tests__/ReactClass-test.js
 * should throw if a reserved property is in statics
 * should support statics
 * should work with object getInitialState() return values
+* renders based on context getInitialState
 * should throw with non-object getInitialState() return values
 * should work with a null getInitialState() return value
 * should throw when using legacy factories
@@ -354,6 +359,7 @@ src/isomorphic/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
 * renders a simple stateless component with prop
 * renders based on state using initial values in this.props
 * renders based on state using props in the constructor
+* renders based on context in the constructor
 * renders only once when setting state in componentWillMount
 * should throw with non-object in the initial state property
 * should render with null in the initial state property
@@ -365,6 +371,7 @@ src/isomorphic/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
 * should warn when misspelling shouldComponentUpdate
 * should warn when misspelling componentWillReceiveProps
 * should throw AND warn when trying to access classic APIs
+* supports this.context passed via getChildContext
 * supports classic refs
 * supports drilling through to the DOM using findDOMNode
 
@@ -374,6 +381,7 @@ src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
 * renders a simple stateless component with prop
 * renders based on state using initial values in this.props
 * renders based on state using props in the constructor
+* renders based on context in the constructor
 * renders only once when setting state in componentWillMount
 * should throw with non-object in the initial state property
 * should render with null in the initial state property
@@ -385,6 +393,7 @@ src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
 * should warn when misspelling shouldComponentUpdate
 * should warn when misspelling componentWillReceiveProps
 * should throw AND warn when trying to access classic APIs
+* supports this.context passed via getChildContext
 * supports classic refs
 * supports drilling through to the DOM using findDOMNode
 
@@ -399,6 +408,7 @@ src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
 * renders a simple stateless component with prop
 * renders based on state using initial values in this.props
 * renders based on state using props in the constructor
+* renders based on context in the constructor
 * renders only once when setting state in componentWillMount
 * should throw with non-object in the initial state property
 * should render with null in the initial state property
@@ -410,6 +420,7 @@ src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
 * should warn when misspelling shouldComponentUpdate
 * should warn when misspelling componentWillReceiveProps
 * should throw AND warn when trying to access classic APIs
+* supports this.context passed via getChildContext
 * supports classic refs
 * supports drilling through to the DOM using findDOMNode
 
@@ -446,6 +457,7 @@ src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
 * should not check the default for explicit null
 * should check declared prop types
 * should warn on invalid prop types
+* should warn on invalid context types
 * should warn if getDefaultProps is specificed on the class
 
 src/renderers/dom/__tests__/ReactDOMProduction-test.js
@@ -806,6 +818,7 @@ src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
 * performs batched updates at the end of the batch
 * can nest batchedUpdates
 * can handle if setState callback throws
+* merges and masks context
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
 * catches render error in a boundary during mounting
@@ -1018,7 +1031,10 @@ src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponent-test.js
 * should call componentWillUnmount before unmounting
 * should warn when shouldComponentUpdate() returns undefined
 * should warn when componentDidUnmount method is defined
+* should pass context to children when not owner
 * should skip update when rerendering element in container
+* should pass context transitively
+* should pass context when re-rendered
 * only renders once if updated in componentWillReceiveProps
 * should allow access to findDOMNode in componentWillUnmount
 * context should be passed down from the parent
@@ -1147,9 +1163,11 @@ src/renderers/shared/stack/reconciler/__tests__/ReactStatelessComponent-test.js
 * should render stateless component
 * should update stateless component
 * should unmount stateless component
+* should pass context thru stateless component
 * should provide a null ref
 * should use correct name in key warning
 * should support default props and prop types
+* should receive context
 * should work with arrow functions
 * should allow simple functions to return null
 * should allow simple functions to return false

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1035,6 +1035,8 @@ src/renderers/shared/stack/reconciler/__tests__/ReactCompositeComponent-test.js
 * should warn when componentDidUnmount method is defined
 * should pass context to children when not owner
 * should skip update when rerendering element in container
+* should pass context when re-rendered for static child
+* should pass context when re-rendered for static child within a composite component
 * should pass context transitively
 * should pass context when re-rendered
 * only renders once if updated in componentWillReceiveProps

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -821,6 +821,8 @@ src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
 * merges and masks context
 * does not leak own context into context provider
 * provides context when reusing work
+* reads context when setState is below the provider
+* reads context when setState is above the provider
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
 * catches render error in a boundary during mounting

--- a/src/isomorphic/classic/__tests__/ReactContextValidator-test.js
+++ b/src/isomorphic/classic/__tests__/ReactContextValidator-test.js
@@ -70,11 +70,10 @@ describe('ReactContextValidator', () => {
     expect(instance.refs.child.context).toEqual({foo: 'abc'});
   });
 
-  it('should filter context properly in callbacks', () => {
+  it('should pass next context to lifecycles', () => {
     var actualComponentWillReceiveProps;
     var actualShouldComponentUpdate;
     var actualComponentWillUpdate;
-    var actualComponentDidUpdate;
 
     var Parent = React.createClass({
       childContextTypes: {
@@ -113,6 +112,45 @@ describe('ReactContextValidator', () => {
         actualComponentWillUpdate = nextContext;
       },
 
+      render: function() {
+        return <div />;
+      },
+    });
+
+    var container = document.createElement('div');
+    ReactDOM.render(<Parent foo="abc" />, container);
+    ReactDOM.render(<Parent foo="def" />, container);
+    expect(actualComponentWillReceiveProps).toEqual({foo: 'def'});
+    expect(actualShouldComponentUpdate).toEqual({foo: 'def'});
+    expect(actualComponentWillUpdate).toEqual({foo: 'def'});
+  });
+
+  it('should pass previous context to lifecycles', () => {
+    var actualComponentDidUpdate;
+
+    var Parent = React.createClass({
+      childContextTypes: {
+        foo: React.PropTypes.string.isRequired,
+        bar: React.PropTypes.string.isRequired,
+      },
+
+      getChildContext: function() {
+        return {
+          foo: this.props.foo,
+          bar: 'bar',
+        };
+      },
+
+      render: function() {
+        return <Component />;
+      },
+    });
+
+    var Component = React.createClass({
+      contextTypes: {
+        foo: React.PropTypes.string,
+      },
+
       componentDidUpdate: function(prevProps, prevState, prevContext) {
         actualComponentDidUpdate = prevContext;
       },
@@ -125,9 +163,6 @@ describe('ReactContextValidator', () => {
     var container = document.createElement('div');
     ReactDOM.render(<Parent foo="abc" />, container);
     ReactDOM.render(<Parent foo="def" />, container);
-    expect(actualComponentWillReceiveProps).toEqual({foo: 'def'});
-    expect(actualShouldComponentUpdate).toEqual({foo: 'def'});
-    expect(actualComponentWillUpdate).toEqual({foo: 'def'});
     expect(actualComponentDidUpdate).toEqual({foo: 'abc'});
   });
 

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -27,8 +27,6 @@ var {
 var ReactTypeOfWork = require('ReactTypeOfWork');
 var {
   getMaskedContext,
-  pushContextProvider,
-  resetContext,
 } = require('ReactFiberContext');
 var {
   IndeterminateComponent,
@@ -189,14 +187,11 @@ module.exports = function<T, P, I, TI, C>(
     } else {
       shouldUpdate = updateClassInstance(current, workInProgress);
     }
-    const instance = workInProgress.stateNode;
-    if (typeof instance.getChildContext === 'function') {
-      pushContextProvider(workInProgress);
-    }
     if (!shouldUpdate) {
       return bailoutOnAlreadyFinishedWork(current, workInProgress);
     }
     // Rerender
+    const instance = workInProgress.stateNode;
     ReactCurrentOwner.current = workInProgress;
     const nextChildren = instance.render();
     reconcileChildren(current, workInProgress, nextChildren);
@@ -367,9 +362,6 @@ module.exports = function<T, P, I, TI, C>(
   }
 
   function beginWork(current : ?Fiber, workInProgress : Fiber, priorityLevel : PriorityLevel) : ?Fiber {
-    if (!workInProgress.return) {
-      resetContext();
-    }
     if (workInProgress.pendingWorkPriority === NoWork ||
         workInProgress.pendingWorkPriority > priorityLevel) {
       return bailoutOnLowPriority(current, workInProgress);

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -28,6 +28,7 @@ var ReactTypeOfWork = require('ReactTypeOfWork');
 var {
   getMaskedContext,
   isContextProvider,
+  hasContextChanged,
   pushContextProvider,
   resetContext,
 } = require('ReactFiberContext');
@@ -200,7 +201,7 @@ module.exports = function<T, P, I, TI, C>(
     reconcileChildren(current, workInProgress, nextChildren);
     // Put context on the stack because we will work on children
     if (isContextProvider(workInProgress)) {
-      pushContextProvider(workInProgress);
+      pushContextProvider(workInProgress, true);
     }
     return workInProgress.child;
   }
@@ -361,7 +362,7 @@ module.exports = function<T, P, I, TI, C>(
     markChildAsProgressed(current, workInProgress, priorityLevel);
     // Put context on the stack because we will work on children
     if (isContextProvider(workInProgress)) {
-      pushContextProvider(workInProgress);
+      pushContextProvider(workInProgress, false);
     }
     return workInProgress.child;
   }
@@ -398,7 +399,8 @@ module.exports = function<T, P, I, TI, C>(
       workInProgress.memoizedProps !== null &&
       workInProgress.pendingProps === workInProgress.memoizedProps
       )) &&
-      workInProgress.updateQueue === null) {
+      workInProgress.updateQueue === null &&
+      !hasContextChanged()) {
       return bailoutOnAlreadyFinishedWork(current, workInProgress);
     }
 

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -18,6 +18,10 @@ import type { HostConfig } from 'ReactFiberReconciler';
 import type { ReifiedYield } from 'ReactReifiedYield';
 
 var { reconcileChildFibers } = require('ReactChildFiber');
+var {
+  isContextProvider,
+  popContextProvider,
+} = require('ReactFiberContext');
 var ReactTypeOfWork = require('ReactTypeOfWork');
 var ReactTypeOfSideEffect = require('ReactTypeOfSideEffect');
 var {
@@ -125,6 +129,10 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
         return null;
       case ClassComponent:
         transferOutput(workInProgress.child, workInProgress);
+        // We are leaving this subtree, so pop context if any.
+        if (isContextProvider(workInProgress)) {
+          popContextProvider();
+        }
         // Don't use the state queue to compute the memoized state. We already
         // merged it and assigned it to the instance. Transfer it from there.
         // Also need to transfer the props, because pendingProps will be null

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -18,6 +18,7 @@ import type { HostConfig } from 'ReactFiberReconciler';
 import type { ReifiedYield } from 'ReactReifiedYield';
 
 var { reconcileChildFibers } = require('ReactChildFiber');
+var { popContextProvider } = require('ReactFiberContext');
 var ReactTypeOfWork = require('ReactTypeOfWork');
 var ReactTypeOfSideEffect = require('ReactTypeOfSideEffect');
 var {
@@ -120,10 +121,11 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
 
   function completeWork(current : ?Fiber, workInProgress : Fiber) : ?Fiber {
     switch (workInProgress.tag) {
-      case FunctionalComponent:
+      case FunctionalComponent: {
         transferOutput(workInProgress.child, workInProgress);
         return null;
-      case ClassComponent:
+      }
+      case ClassComponent: {
         transferOutput(workInProgress.child, workInProgress);
         // Don't use the state queue to compute the memoized state. We already
         // merged it and assigned it to the instance. Transfer it from there.
@@ -148,8 +150,13 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
           workInProgress.callbackList = updateQueue;
           markCallback(workInProgress);
         }
+        const instance = workInProgress.stateNode;
+        if (typeof instance.getChildContext === 'function') {
+          popContextProvider();
+        }
         return null;
-      case HostContainer:
+      }
+      case HostContainer: {
         transferOutput(workInProgress.child, workInProgress);
         // We don't know if a container has updated any children so we always
         // need to update it right now. We schedule this side-effect before
@@ -158,7 +165,8 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
         // are invoked.
         markUpdate(workInProgress);
         return null;
-      case HostComponent:
+      }
+      case HostComponent: {
         let newProps = workInProgress.pendingProps;
         if (current && workInProgress.stateNode != null) {
           // If we have an alternate, that means this is an update and we need to
@@ -200,7 +208,8 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
         }
         workInProgress.memoizedProps = newProps;
         return null;
-      case HostText:
+      }
+      case HostText: {
         let newText = workInProgress.pendingProps;
         if (current && workInProgress.stateNode != null) {
           // If we have an alternate, that means this is an update and we need to
@@ -222,25 +231,32 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
         }
         workInProgress.memoizedProps = newText;
         return null;
-      case CoroutineComponent:
+      }
+      case CoroutineComponent: {
         return moveCoroutineToHandlerPhase(current, workInProgress);
-      case CoroutineHandlerPhase:
+      }
+      case CoroutineHandlerPhase: {
         transferOutput(workInProgress.stateNode, workInProgress);
         // Reset the tag to now be a first phase coroutine.
         workInProgress.tag = CoroutineComponent;
         return null;
-      case YieldComponent:
+      }
+      case YieldComponent: {
         // Does nothing.
         return null;
-      case Fragment:
+      }
+      case Fragment: {
         transferOutput(workInProgress.child, workInProgress);
         return null;
+      }
 
       // Error cases
-      case IndeterminateComponent:
+      case IndeterminateComponent: {
         throw new Error('An indeterminate component should have become determinate before completing.');
-      default:
+      }
+      default: {
         throw new Error('Unknown unit of work tag');
+      }
     }
   }
 

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -18,7 +18,6 @@ import type { HostConfig } from 'ReactFiberReconciler';
 import type { ReifiedYield } from 'ReactReifiedYield';
 
 var { reconcileChildFibers } = require('ReactChildFiber');
-var { popContextProvider } = require('ReactFiberContext');
 var ReactTypeOfWork = require('ReactTypeOfWork');
 var ReactTypeOfSideEffect = require('ReactTypeOfSideEffect');
 var {
@@ -121,11 +120,10 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
 
   function completeWork(current : ?Fiber, workInProgress : Fiber) : ?Fiber {
     switch (workInProgress.tag) {
-      case FunctionalComponent: {
+      case FunctionalComponent:
         transferOutput(workInProgress.child, workInProgress);
         return null;
-      }
-      case ClassComponent: {
+      case ClassComponent:
         transferOutput(workInProgress.child, workInProgress);
         // Don't use the state queue to compute the memoized state. We already
         // merged it and assigned it to the instance. Transfer it from there.
@@ -150,13 +148,8 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
           workInProgress.callbackList = updateQueue;
           markCallback(workInProgress);
         }
-        const instance = workInProgress.stateNode;
-        if (typeof instance.getChildContext === 'function') {
-          popContextProvider();
-        }
         return null;
-      }
-      case HostContainer: {
+      case HostContainer:
         transferOutput(workInProgress.child, workInProgress);
         // We don't know if a container has updated any children so we always
         // need to update it right now. We schedule this side-effect before
@@ -165,8 +158,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
         // are invoked.
         markUpdate(workInProgress);
         return null;
-      }
-      case HostComponent: {
+      case HostComponent:
         let newProps = workInProgress.pendingProps;
         if (current && workInProgress.stateNode != null) {
           // If we have an alternate, that means this is an update and we need to
@@ -208,8 +200,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
         }
         workInProgress.memoizedProps = newProps;
         return null;
-      }
-      case HostText: {
+      case HostText:
         let newText = workInProgress.pendingProps;
         if (current && workInProgress.stateNode != null) {
           // If we have an alternate, that means this is an update and we need to
@@ -231,32 +222,25 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
         }
         workInProgress.memoizedProps = newText;
         return null;
-      }
-      case CoroutineComponent: {
+      case CoroutineComponent:
         return moveCoroutineToHandlerPhase(current, workInProgress);
-      }
-      case CoroutineHandlerPhase: {
+      case CoroutineHandlerPhase:
         transferOutput(workInProgress.stateNode, workInProgress);
         // Reset the tag to now be a first phase coroutine.
         workInProgress.tag = CoroutineComponent;
         return null;
-      }
-      case YieldComponent: {
+      case YieldComponent:
         // Does nothing.
         return null;
-      }
-      case Fragment: {
+      case Fragment:
         transferOutput(workInProgress.child, workInProgress);
         return null;
-      }
 
       // Error cases
-      case IndeterminateComponent: {
+      case IndeterminateComponent:
         throw new Error('An indeterminate component should have become determinate before completing.');
-      }
-      default: {
+      default:
         throw new Error('Unknown unit of work tag');
-      }
     }
   }
 

--- a/src/renderers/shared/fiber/ReactFiberContext.js
+++ b/src/renderers/shared/fiber/ReactFiberContext.js
@@ -19,6 +19,9 @@ var invariant = require('invariant');
 var {
   getComponentName,
 } = require('ReactFiberTreeReflection');
+var {
+  ClassComponent,
+} = require('ReactTypeOfWork');
 
 if (__DEV__) {
   var checkReactTypeSpec = require('checkReactTypeSpec');
@@ -56,12 +59,19 @@ exports.getMaskedContext = function(fiber : Fiber) {
   return context;
 };
 
-exports.popContextProvider = function() {
+exports.isContextProvider = function(fiber : Fiber) : boolean {
+  return (
+    fiber.tag === ClassComponent &&
+    typeof fiber.stateNode.getChildContext === 'function'
+  );
+};
+
+exports.popContextProvider = function() : void {
   stack[index] = emptyObject;
   index--;
 };
 
-exports.pushContextProvider = function(fiber : Fiber) {
+exports.pushContextProvider = function(fiber : Fiber) : void {
   const instance = fiber.stateNode;
   const childContextTypes = fiber.type.childContextTypes;
   const childContext = instance.getChildContext();
@@ -85,7 +95,7 @@ exports.pushContextProvider = function(fiber : Fiber) {
   stack[index] = mergedContext;
 };
 
-exports.resetContext = function() {
+exports.resetContext = function() : void {
   index = -1;
 };
 

--- a/src/renderers/shared/fiber/ReactFiberContext.js
+++ b/src/renderers/shared/fiber/ReactFiberContext.js
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactFiberContext
+ * @flow
+ */
+
+'use strict';
+
+import type { Fiber } from 'ReactFiber';
+
+var emptyObject = require('emptyObject');
+var invariant = require('invariant');
+var {
+  getComponentName,
+} = require('ReactFiberTreeReflection');
+
+if (__DEV__) {
+  var checkReactTypeSpec = require('checkReactTypeSpec');
+}
+
+let index = -1;
+const stack = [];
+
+function getUnmaskedContext() {
+  if (index === -1) {
+    return emptyObject;
+  }
+  return stack[index];
+}
+
+exports.getMaskedContext = function(fiber : Fiber) {
+  const type = fiber.type;
+  const contextTypes = type.contextTypes;
+  if (!contextTypes) {
+    return null;
+  }
+
+  const unmaskedContext = getUnmaskedContext();
+  const context = {};
+  for (let key in contextTypes) {
+    context[key] = unmaskedContext[key];
+  }
+
+  if (__DEV__) {
+    const name = getComponentName(fiber);
+    const debugID = 0; // TODO: pass a real ID
+    checkReactTypeSpec(contextTypes, context, 'context', name, null, debugID);
+  }
+
+  return context;
+};
+
+exports.popContextProvider = function() {
+  stack[index] = emptyObject;
+  index--;
+};
+
+exports.pushContextProvider = function(fiber : Fiber) {
+  const instance = fiber.stateNode;
+  const childContextTypes = fiber.type.childContextTypes;
+  const childContext = instance.getChildContext();
+
+  for (let contextKey in childContext) {
+    invariant(
+      contextKey in childContextTypes,
+      '%s.getChildContext(): key "%s" is not defined in childContextTypes.',
+      getComponentName(fiber),
+      contextKey
+    );
+  }
+  if (__DEV__) {
+    const name = getComponentName(fiber);
+    const debugID = 0; // TODO: pass a real ID
+    checkReactTypeSpec(childContextTypes, childContext, 'childContext', name, null, debugID);
+  }
+
+  const mergedContext = Object.assign({}, getUnmaskedContext(), childContext);
+  index++;
+  stack[index] = mergedContext;
+};
+
+exports.resetContext = function() {
+  index = -1;
+};
+

--- a/src/renderers/shared/fiber/ReactFiberContext.js
+++ b/src/renderers/shared/fiber/ReactFiberContext.js
@@ -42,7 +42,7 @@ exports.getMaskedContext = function(fiber : Fiber) {
   const type = fiber.type;
   const contextTypes = type.contextTypes;
   if (!contextTypes) {
-    return null;
+    return emptyObject;
   }
 
   const unmaskedContext = getUnmaskedContext();

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -25,13 +25,6 @@ var ReactCurrentOwner = require('ReactCurrentOwner');
 var { cloneFiber } = require('ReactFiber');
 
 var {
-  isContextProvider,
-  pushContextProvider,
-  popContextProvider,
-  resetContext,
-} = require('ReactFiberContext');
-
-var {
   NoWork,
   SynchronousPriority,
   TaskPriority,
@@ -274,11 +267,6 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
       const current = workInProgress.alternate;
       const next = completeWork(current, workInProgress);
 
-      // We are leaving this subtree, so pop context if any.
-      if (isContextProvider(workInProgress)) {
-        popContextProvider();
-      }
-
       resetWorkPriority(workInProgress);
 
       // The work is now done. We don't need this anymore. This flags
@@ -357,11 +345,6 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
   }
 
   function performUnitOfWork(workInProgress : Fiber) : ?Fiber {
-    if (!workInProgress.return) {
-      // Don't start new work with context on the stack.
-      resetContext();
-    }
-
     // The current, flushed, state of this fiber is the alternate.
     // Ideally nothing should rely on this, but relying on it here
     // means that we don't need an additional field on the work in
@@ -377,12 +360,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
       ReactFiberInstrumentation.debugTool.onDidBeginWork(workInProgress);
     }
 
-    if (next) {
-      // There is work deeper in the tree, so push the context if it exists.
-      if (isContextProvider(workInProgress)) {
-        pushContextProvider(workInProgress);
-      }
-    } else {
+    if (!next) {
       if (__DEV__ && ReactFiberInstrumentation.debugTool) {
         ReactFiberInstrumentation.debugTool.onWillCompleteWork(workInProgress);
       }

--- a/src/renderers/shared/fiber/ReactFiberTreeReflection.js
+++ b/src/renderers/shared/fiber/ReactFiberTreeReflection.js
@@ -114,3 +114,14 @@ exports.findCurrentHostFiber = function(component : ReactComponent<any, any, any
   }
   return null;
 };
+
+exports.getComponentName = function(fiber: Fiber): string {
+  const type = fiber.type;
+  const instance = fiber.stateNode;
+  const constructor = instance && instance.constructor;
+  return (
+    type.displayName || (constructor && constructor.displayName) ||
+    type.name || (constructor && constructor.name) ||
+    'A Component'
+  );
+};

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -1596,7 +1596,7 @@ describe('ReactIncremental', () => {
       }
     }
 
-    ops.length = [];
+    ops.length = 0;
     ReactNoop.render(
       <Intl locale="fr">
         <ShowLocale />
@@ -1612,7 +1612,7 @@ describe('ReactIncremental', () => {
       'ShowBoth {"locale":"fr"}',
     ]);
 
-    ops.length = [];
+    ops.length = 0;
     ReactNoop.render(
       <Intl locale="de">
         <ShowLocale />
@@ -1628,7 +1628,7 @@ describe('ReactIncremental', () => {
       'ShowBoth {"locale":"de"}',
     ]);
 
-    ops.length = [];
+    ops.length = 0;
     ReactNoop.render(
       <Intl locale="sv">
         <ShowLocale />
@@ -1642,7 +1642,7 @@ describe('ReactIncremental', () => {
       'Intl null',
     ]);
 
-    ops.length = [];
+    ops.length = 0;
     ReactNoop.render(
       <Intl locale="en">
         <ShowLocale />

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -1605,7 +1605,7 @@ describe('ReactIncremental', () => {
     );
     ReactNoop.flush();
     expect(ops).toEqual([
-      'Intl null',
+      'Intl {}',
       'ShowLocale {"locale":"fr"}',
       'ShowBoth {"locale":"fr"}',
     ]);
@@ -1621,7 +1621,7 @@ describe('ReactIncremental', () => {
     );
     ReactNoop.flush();
     expect(ops).toEqual([
-      'Intl null',
+      'Intl {}',
       'ShowLocale {"locale":"de"}',
       'ShowBoth {"locale":"de"}',
     ]);
@@ -1637,7 +1637,7 @@ describe('ReactIncremental', () => {
     );
     ReactNoop.flushDeferredPri(15);
     expect(ops).toEqual([
-      'Intl null',
+      'Intl {}',
     ]);
 
     ops.length = 0;
@@ -1652,14 +1652,14 @@ describe('ReactIncremental', () => {
     );
     ReactNoop.flush();
     expect(ops).toEqual([
-      'Intl null',
+      'Intl {}',
       'ShowLocale {"locale":"en"}',
-      'Router null',
-      'Indirection null',
+      'Router {}',
+      'Indirection {}',
       'ShowLocale {"locale":"en"}',
       'ShowRoute {"route":"/about"}',
-      'ShowNeither null',
-      'Intl null',
+      'ShowNeither {}',
+      'Intl {}',
       'ShowBoth {"locale":"ru","route":"/about"}',
       'ShowBoth {"locale":"en","route":"/about"}',
       'ShowBoth {"locale":"en"}',
@@ -1740,7 +1740,7 @@ describe('ReactIncremental', () => {
     );
     ReactNoop.flushDeferredPri(40);
     expect(ops).toEqual([
-      'Intl null',
+      'Intl {}',
       'ShowLocale {"locale":"fr"}',
       'ShowLocale {"locale":"fr"}',
     ]);
@@ -1749,7 +1749,7 @@ describe('ReactIncremental', () => {
     ReactNoop.flush();
     expect(ops).toEqual([
       'ShowLocale {"locale":"fr"}',
-      'Intl null',
+      'Intl {}',
       'ShowLocale {"locale":"ru"}',
     ]);
   });
@@ -1828,10 +1828,10 @@ describe('ReactIncremental', () => {
     );
     ReactNoop.flush();
     expect(ops).toEqual([
-      'Intl:read null',
+      'Intl:read {}',
       'Intl:provide {"locale":"fr"}',
-      'IndirectionFn null',
-      'IndirectionClass null',
+      'IndirectionFn {}',
+      'IndirectionClass {}',
       'ShowLocaleClass:read {"locale":"fr"}',
       'ShowLocaleFn:read {"locale":"fr"}',
     ]);
@@ -1920,10 +1920,10 @@ describe('ReactIncremental', () => {
     );
     ReactNoop.flush();
     expect(ops).toEqual([
-      'Intl:read null',
+      'Intl:read {}',
       'Intl:provide {"locale":"fr"}',
-      'IndirectionFn null',
-      'IndirectionClass null',
+      'IndirectionFn {}',
+      'IndirectionClass {}',
       'ShowLocaleClass:read {"locale":"fr"}',
       'ShowLocaleFn:read {"locale":"fr"}',
     ]);
@@ -1935,12 +1935,12 @@ describe('ReactIncremental', () => {
       // Intl is below setState() so it might have been
       // affected by it. Therefore we re-render and recompute
       // its child context.
-      'Intl:read null',
+      'Intl:read {}',
       'Intl:provide {"locale":"gr"}',
       // TODO: it's unfortunate that we can't reuse work on
       // these components even though they don't depend on context.
-      'IndirectionFn null',
-      'IndirectionClass null',
+      'IndirectionFn {}',
+      'IndirectionClass {}',
        // These components depend on context:
       'ShowLocaleClass:read {"locale":"gr"}',
       'ShowLocaleFn:read {"locale":"gr"}',

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -1822,8 +1822,8 @@ describe('ReactIncremental', () => {
     statefulInst.setState({x: 1});
     ReactNoop.flush();
     expect(ops).toEqual([
-      // TODO: we should be able to reuse the previous child context.
-      'Intl:provide {"locale":"fr"}',
+      // Intl was memoized so we did not need to
+      // either render it or recompute its context.
       'ShowLocaleClass:read {"locale":"fr"}',
       'ShowLocaleFn:read {"locale":"fr"}',
     ]);
@@ -1895,6 +1895,9 @@ describe('ReactIncremental', () => {
     statefulInst.setState({locale: 'gr'});
     ReactNoop.flush();
     expect(ops).toEqual([
+      // Intl is below setState() so it might have been
+      // affected by it. Therefore we re-render and recompute
+      // its child context.
       'Intl:read null',
       'Intl:provide {"locale":"gr"}',
       'ShowLocaleClass:read {"locale":"gr"}',


### PR DESCRIPTION
Known issues:

* Passing `nextContext` to `componentDidUpdate()` would require changing the approach and adding a field to Fiber. For now we decided to bail on supporting this use case (e.g. Facebook doesn't have a single component in thousands using this pattern). We'll probably make a breaking change in Stack as well for this in 16.
* Deep updates blocked by sCU still don't work: this is about feature parity.
* It might be broken with error boundaries. I will address this in later PRs.