### PR TITLE
[Fiber] Change a test to be relevant in Fiber

### DIFF
--- a/src/renderers/dom/__tests__/ReactDOMProduction-test.js
+++ b/src/renderers/dom/__tests__/ReactDOMProduction-test.js
@@ -178,7 +178,7 @@ describe('ReactDOMProduction', () => {
     expect(function() {
       class Component extends React.Component {
         render() {
-          return ['this is wrong'];
+          return undefined;
         }
       }
 


### PR DESCRIPTION
Fiber supports fragments so we will use undefined instead.
This test is then valid both in Stack and in Fiber.

The test still passes in Stack and still fails in Fiber, but at least it fails for a good reason now.