### PR TITLE
Make setState return a promise

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -367,6 +367,7 @@ src/isomorphic/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
 * should throw AND warn when trying to access classic APIs
 * supports classic refs
 * supports drilling through to the DOM using findDOMNode
+* supports Promise for setState method
 
 src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
 * preserves the name of the class for use in error messages
@@ -387,6 +388,7 @@ src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
 * should throw AND warn when trying to access classic APIs
 * supports classic refs
 * supports drilling through to the DOM using findDOMNode
+* supports Promise for setState method
 
 src/isomorphic/modern/class/__tests__/ReactPureComponent-test.js
 * should render
@@ -412,6 +414,7 @@ src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
 * should throw AND warn when trying to access classic APIs
 * supports classic refs
 * supports drilling through to the DOM using findDOMNode
+* supports Promise for setState method
 
 src/isomorphic/modern/element/__tests__/ReactJSXElement-test.js
 * returns a complete element according to spec

--- a/src/isomorphic/modern/class/ReactComponent.js
+++ b/src/isomorphic/modern/class/ReactComponent.js
@@ -54,6 +54,8 @@ ReactComponent.prototype.isReactComponent = {};
  * @param {object|function} partialState Next partial state or function to
  *        produce next partial state to be merged with current state.
  * @param {?function} callback Called after state is updated.
+ * @returns {Promise|undefined} If callback is not a function returns
+ *        the Promise that resolves after state is updated.
  * @final
  * @protected
  */
@@ -68,6 +70,12 @@ ReactComponent.prototype.setState = function(partialState, callback) {
   this.updater.enqueueSetState(this, partialState);
   if (callback) {
     this.updater.enqueueCallback(this, callback, 'setState');
+  } else {
+    return {
+      then: function(resolve) {
+        this.updater.enqueueCallback(this, resolve, 'setState');
+      }.bind(this),
+    };
   }
 };
 

--- a/src/isomorphic/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/src/isomorphic/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -405,3 +405,22 @@ describe 'ReactCoffeeScriptClass', ->
     node = ReactDOM.findDOMNode(instance)
     expect(node).toBe container.firstChild
     undefined
+
+  it 'supports Promise for setState method', ->
+    renderCount = 0
+    class Foo extends React.Component
+      constructor: (props) ->
+        @state = bar: props.initialValue
+
+      changeStateAndGetPromise: ->
+        @setState bar: 'bar'
+
+      render: ->
+        renderCount++;
+        div className: @state.bar
+
+    instance = test React.createElement(Foo, initialValue: 'foo'), 'DIV', 'foo'
+    instance.changeStateAndGetPromise()
+    .then ->
+      expect(renderCount).toBe(2);
+    undefined

--- a/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
+++ b/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
@@ -446,4 +446,26 @@ describe('ReactES6Class', () => {
     expect(node).toBe(container.firstChild);
   });
 
+  it('supports Promise for setState method', () => {
+    var renderCount = 0;
+    class Foo extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {bar: props.initialValue};
+      }
+      changeStateAndGetPromise() {
+        return this.setState({bar: 'bar'});
+      }
+      render() {
+        renderCount++;
+        return <div className={this.state.bar} />;
+      }
+    }
+    var instance = test(<Foo initialValue="foo" />, 'DIV', 'foo');
+    instance.changeStateAndGetPromise()
+    .then(function() {
+      expect(renderCount).toBe(2);
+    });
+  });
+
 });

--- a/src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
+++ b/src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
@@ -300,6 +300,22 @@ class ClassicRefs extends React.Component {
   }
 }
 
+// it supports Promise for setState method
+var setStatePromiseRenderCount = 0;
+class StatePromise extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {bar: props.initialValue};
+  }
+  changeStateAndGetPromise() {
+    return this.setState({bar: 'bar'});
+  }
+  render() {
+    setStatePromiseRenderCount++;
+    return React.createElement('div', { className: this.state.bar });
+  }
+}
+
 // Describe the actual test cases.
 
 describe('ReactTypeScriptClass', function() {
@@ -515,6 +531,18 @@ describe('ReactTypeScriptClass', function() {
     );
     var node = ReactDOM.findDOMNode(instance);
     expect(node).toBe(container.firstChild);
+  });
+
+	it('supports Promise for setState method', function() {
+    var instance = test(
+      React.createElement(StatePromise, {initialValue: 'foo'}),
+      'DIV',
+      'foo'
+    );
+    instance.changeStateAndGetPromise()
+    .then(function() {
+      expect(setStatePromiseRenderCount).toBe(2);
+    });
   });
 
 });


### PR DESCRIPTION
This PR related to #2642 that make setState() return a promise.
To make setState() back compatible setState() still accepts an optional second argument for callback and returns undefined. If the second argument isn't callback setState() returns Promise.
Usage:
```
# Use callback
this.setState({ bar: 'bar' }, function() {/* ... */});

# Use Promise
this.setState({ bar: 'bar' })
.then(function() {
  /* ... */
});

# Use await (es2016)
await this.setState({ bar: 'bar' });
/* ... */
```

I've been thinking about this to create a new method (for example `asyncState`) but I think it's good to have the single method for single responsibility.

The Promise is simple object returns `then` function that resolves after state is updated (doesn't use any libraries like Bluebird, Q, etc). This shouldn't be a performance issue.

I believe this to be the good feature for developers. Would be much appreciated if we could get this merged in.

Thanks! Let me know if you have any questions.