### PR TITLE
Reapply Check for event listener in props instead of bank

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -423,6 +423,7 @@ src/renderers/shared/shared/__tests__/ReactTreeTraversal-test.js
 
 src/renderers/shared/shared/event/__tests__/EventPluginHub-test.js
 * should prevent non-function listeners, at dispatch
+* should not prevent null listeners, at dispatch
 
 src/renderers/shared/stack/reconciler/__tests__/ReactComponent-test.js
 * should throw on invalid render targets

--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -119,8 +119,6 @@ src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * should validate against invalid styles
 * should track input values
 * should track textarea values
-* should execute custom event plugin listening behavior
-* should handle null and missing properly with event hooks
 * should warn for children on void elements
 * should support custom elements which extend native elements
 * should warn against children for void elements
@@ -128,7 +126,6 @@ src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * should validate against multiple children props
 * should validate against invalid styles
 * should report component containing invalid styles
-* should clean up listeners
 * should clean up input value tracking
 * should clean up input textarea tracking
 * should throw when an invalid tag name is used
@@ -305,13 +302,11 @@ src/renderers/dom/stack/server/__tests__/ReactServerRendering-test.js
 * should generate simple markup for self-closing tags
 * should generate simple markup for attribute with `>` symbol
 * should generate comment markup for component returns null
-* should not register event listeners
 * should render composite components
 * should only execute certain lifecycle methods
 * should have the correct mounting behavior
 * should not put checksum and React ID on components
 * should not put checksum and React ID on text components
-* should not register event listeners
 * should only execute certain lifecycle methods
 * allows setState in componentWillMount without using DOM
 * renders components with different batching strategies
@@ -425,6 +420,9 @@ src/renderers/shared/shared/__tests__/ReactTreeTraversal-test.js
 * should enter from the window to the shallowest
 * should leave to the window
 * should leave to the window from the shallowest
+
+src/renderers/shared/shared/event/__tests__/EventPluginHub-test.js
+* should prevent non-function listeners, at dispatch
 
 src/renderers/shared/stack/reconciler/__tests__/ReactComponent-test.js
 * should throw on invalid render targets

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -945,9 +945,6 @@ src/renderers/shared/shared/__tests__/ReactTreeTraversal-test.js
 * should not traverse if enter/leave the same node
 * should determine the first common ancestor correctly
 
-src/renderers/shared/shared/event/__tests__/EventPluginHub-test.js
-* should prevent non-function listeners
-
 src/renderers/shared/shared/event/__tests__/EventPluginRegistry-test.js
 * should be able to inject ordering before plugins
 * should be able to inject plugins before and after ordering
@@ -1053,7 +1050,6 @@ src/renderers/shared/stack/reconciler/__tests__/ReactErrorBoundaries-test.js
 * propagates errors on retry on mounting
 * propagates errors inside boundary during componentWillMount
 * propagates errors inside boundary while rendering error state
-* does not register event handlers for unmounted children
 * does not call componentWillUnmount when aborting initial mount
 * resets refs if mounting aborts
 * successfully mounts if no error occurs

--- a/src/renderers/dom/shared/ReactBrowserEventEmitter.js
+++ b/src/renderers/dom/shared/ReactBrowserEventEmitter.js
@@ -163,16 +163,6 @@ function getListeningForDocument(mountAt) {
   return alreadyListeningTo[mountAt[topListenersIDKey]];
 }
 
-/**
- * `ReactBrowserEventEmitter` is used to attach top-level event listeners. For
- * example:
- *
- *   EventPluginHub.putListener('myID', 'onClick', myFunction);
- *
- * This would allocate a "registration" of `('onClick', myFunction)` on 'myID'.
- *
- * @internal
- */
 var ReactBrowserEventEmitter = Object.assign({}, ReactEventEmitterMixin, {
 
   /**

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -972,61 +972,6 @@ describe('ReactDOMComponent', () => {
       expect(tracker.getValue()).toEqual('foo');
     });
 
-    it('should execute custom event plugin listening behavior', () => {
-      var SimpleEventPlugin = require('SimpleEventPlugin');
-
-      SimpleEventPlugin.didPutListener = jest.fn();
-      SimpleEventPlugin.willDeleteListener = jest.fn();
-
-      var container = document.createElement('div');
-      ReactDOM.render(
-        <div onClick={() => true} />,
-        container
-      );
-
-      expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(1);
-
-      ReactDOM.unmountComponentAtNode(container);
-
-      expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(1);
-    });
-
-    it('should handle null and missing properly with event hooks', () => {
-      var SimpleEventPlugin = require('SimpleEventPlugin');
-
-      SimpleEventPlugin.didPutListener = jest.fn();
-      SimpleEventPlugin.willDeleteListener = jest.fn();
-      var container = document.createElement('div');
-
-      ReactDOM.render(<div onClick={false} />, container);
-      expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(0);
-      expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(0);
-
-      ReactDOM.render(<div onClick={null} />, container);
-      expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(0);
-      expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(0);
-
-      ReactDOM.render(<div onClick={() => 'apple'} />, container);
-      expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(1);
-      expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(0);
-
-      ReactDOM.render(<div onClick={() => 'banana'} />, container);
-      expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(2);
-      expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(0);
-
-      ReactDOM.render(<div onClick={null} />, container);
-      expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(2);
-      expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(1);
-
-      ReactDOM.render(<div />, container);
-      expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(2);
-      expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(1);
-
-      ReactDOM.unmountComponentAtNode(container);
-      expect(SimpleEventPlugin.didPutListener.mock.calls.length).toBe(2);
-      expect(SimpleEventPlugin.willDeleteListener.mock.calls.length).toBe(1);
-    });
-
     it('should warn for children on void elements', () => {
       class X extends React.Component {
         render() {
@@ -1157,31 +1102,6 @@ describe('ReactDOMComponent', () => {
   });
 
   describe('unmountComponent', () => {
-    it('should clean up listeners', () => {
-      var EventPluginHub = require('EventPluginHub');
-      var ReactDOMComponentTree = require('ReactDOMComponentTree');
-
-      var container = document.createElement('div');
-      document.body.appendChild(container);
-
-      var callback = function() {};
-      var instance = <div onClick={callback} />;
-      instance = ReactDOM.render(instance, container);
-
-      var rootNode = ReactDOM.findDOMNode(instance);
-      var inst = ReactDOMComponentTree.getInstanceFromNode(rootNode);
-      expect(
-        EventPluginHub.getListener(inst, 'onClick')
-      ).toBe(callback);
-      expect(rootNode).toBe(ReactDOM.findDOMNode(instance));
-
-      ReactDOM.unmountComponentAtNode(container);
-
-      expect(
-        EventPluginHub.getListener(inst, 'onClick')
-      ).toBe(undefined);
-    });
-
     it('should clean up input value tracking', () => {
       var container = document.createElement('div');
       var node = ReactDOM.render(<input type="text" defaultValue="foo"/>, container);

--- a/src/renderers/dom/stack/server/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/stack/server/__tests__/ReactServerRendering-test.js
@@ -85,15 +85,7 @@ describe('ReactServerRendering', () => {
       expect(response).toBe('<!-- react-empty: 1 -->');
     });
 
-    it('should not register event listeners', () => {
-      var EventPluginHub = require('EventPluginHub');
-      var cb = jest.fn();
-
-      ReactServerRendering.renderToString(
-        <span onClick={cb}>hello world</span>
-      );
-      expect(EventPluginHub.__getListenerBank()).toEqual({});
-    });
+    // TODO: Test that listeners are not registered onto any document/container.
 
     it('should render composite components', () => {
       class Parent extends React.Component {
@@ -320,16 +312,6 @@ describe('ReactServerRendering', () => {
       );
 
       expect(response).toBe('<span>hello world</span>');
-    });
-
-    it('should not register event listeners', () => {
-      var EventPluginHub = require('EventPluginHub');
-      var cb = jest.fn();
-
-      ReactServerRendering.renderToStaticMarkup(
-        <span onClick={cb}>hello world</span>
-      );
-      expect(EventPluginHub.__getListenerBank()).toEqual({});
     });
 
     it('should only execute certain lifecycle methods', () => {

--- a/src/renderers/native/ReactNativeBaseComponent.js
+++ b/src/renderers/native/ReactNativeBaseComponent.js
@@ -14,17 +14,11 @@
 var NativeMethodsMixin = require('NativeMethodsMixin');
 var ReactNativeAttributePayload = require('ReactNativeAttributePayload');
 var ReactNativeComponentTree = require('ReactNativeComponentTree');
-var ReactNativeEventEmitter = require('ReactNativeEventEmitter');
 var ReactNativeTagHandles = require('ReactNativeTagHandles');
 var ReactMultiChild = require('ReactMultiChild');
 var UIManager = require('UIManager');
 
 var deepFreezeAndThrowOnMutationInDev = require('deepFreezeAndThrowOnMutationInDev');
-
-var registrationNames = ReactNativeEventEmitter.registrationNames;
-var putListener = ReactNativeEventEmitter.putListener;
-var deleteListener = ReactNativeEventEmitter.deleteListener;
-var deleteAllListeners = ReactNativeEventEmitter.deleteAllListeners;
 
 type ReactNativeBaseComponentViewConfig = {
   validAttributes: Object;
@@ -57,7 +51,6 @@ ReactNativeBaseComponent.Mixin = {
 
   unmountComponent: function(safely, skipLifecycle) {
     ReactNativeComponentTree.uncacheNode(this);
-    deleteAllListeners(this);
     this.unmountChildren(safely, skipLifecycle);
     this._rootNodeID = 0;
   },
@@ -123,42 +116,7 @@ ReactNativeBaseComponent.Mixin = {
       );
     }
 
-    this._reconcileListenersUponUpdate(
-      prevElement.props,
-      nextElement.props
-    );
     this.updateChildren(nextElement.props.children, transaction, context);
-  },
-
-  /**
-   * @param {object} initialProps Native component props.
-   */
-  _registerListenersUponCreation: function(initialProps) {
-    for (var key in initialProps) {
-      // NOTE: The check for `!props[key]`, is only possible because this method
-      // registers listeners the *first* time a component is created.
-      if (registrationNames[key] && initialProps[key]) {
-        var listener = initialProps[key];
-        putListener(this, key, listener);
-      }
-    }
-  },
-
-  /**
-   * Reconciles event listeners, adding or removing if necessary.
-   * @param {object} prevProps Native component props including events.
-   * @param {object} nextProps Next native component props including events.
-   */
-  _reconcileListenersUponUpdate: function(prevProps, nextProps) {
-    for (var key in nextProps) {
-      if (registrationNames[key] && (nextProps[key] !== prevProps[key])) {
-        if (nextProps[key]) {
-          putListener(this, key, nextProps[key]);
-        } else {
-          deleteListener(this, key);
-        }
-      }
-    }
   },
 
   /**
@@ -207,7 +165,6 @@ ReactNativeBaseComponent.Mixin = {
 
     ReactNativeComponentTree.precacheNode(this, tag);
 
-    this._registerListenersUponCreation(this._currentElement.props);
     this.initializeChildren(
       this._currentElement.props.children,
       tag,

--- a/src/renderers/native/ReactNativeEventEmitter.js
+++ b/src/renderers/native/ReactNativeEventEmitter.js
@@ -78,28 +78,13 @@ var removeTouchesAtIndices = function(
   return rippedOut;
 };
 
-/**
- * `ReactNativeEventEmitter` is used to attach top-level event listeners. For example:
- *
- *   ReactNativeEventEmitter.putListener('myID', 'onClick', myFunction);
- *
- * This would allocate a "registration" of `('onClick', myFunction)` on 'myID'.
- *
- * @internal
- */
 var ReactNativeEventEmitter = {
 
   ...ReactEventEmitterMixin,
 
   registrationNames: EventPluginRegistry.registrationNameModules,
 
-  putListener: EventPluginHub.putListener,
-
   getListener: EventPluginHub.getListener,
-
-  deleteListener: EventPluginHub.deleteListener,
-
-  deleteAllListeners: EventPluginHub.deleteAllListeners,
 
   /**
    * Internal version of `receiveEvent` in terms of normalized (non-tag)

--- a/src/renderers/shared/shared/event/EventPluginHub.js
+++ b/src/renderers/shared/shared/event/EventPluginHub.js
@@ -97,14 +97,12 @@ var EventPluginHub = {
    */
   getListener: function(inst, registrationName) {
     var listener = inst._currentElement.props[registrationName];
-    if (listener !== undefined) {
-      invariant(
-        typeof listener === 'function',
-        'Expected %s listener to be a function, instead got type %s',
-        registrationName,
-        typeof listener
-      );
-    }
+    invariant(
+      !listener || typeof listener === 'function',
+      'Expected %s listener to be a function, instead got type %s',
+      registrationName,
+      typeof listener
+    );
     return listener;
   },
 

--- a/src/renderers/shared/shared/event/EventPluginRegistry.js
+++ b/src/renderers/shared/shared/event/EventPluginRegistry.js
@@ -130,8 +130,7 @@ function publishEventForPlugin(
 }
 
 /**
- * Publishes a registration name that is used to identify dispatched events and
- * can be used with `EventPluginHub.putListener` to register listeners.
+ * Publishes a registration name that is used to identify dispatched events.
  *
  * @param {string} registrationName Registration name to add.
  * @param {object} PluginModule Plugin publishing the event.

--- a/src/renderers/shared/shared/event/PluginModuleType.js
+++ b/src/renderers/shared/shared/event/PluginModuleType.js
@@ -36,14 +36,5 @@ export type PluginModule<NativeEvent> = {
     nativeTarget: NativeEvent,
     nativeEventTarget: EventTarget,
   ) => null | ReactSyntheticEvent,
-  didPutListener?: (
-    inst: ReactInstance,
-    registrationName: string,
-    listener: () => void,
-  ) => void,
-  willDeleteListener?: (
-    inst: ReactInstance,
-    registrationName: string,
-  ) => void,
   tapMoveThreshold?: number,
 };

--- a/src/renderers/shared/shared/event/__tests__/EventPluginHub-test.js
+++ b/src/renderers/shared/shared/event/__tests__/EventPluginHub-test.js
@@ -14,19 +14,21 @@
 jest.mock('isEventSupported');
 
 describe('EventPluginHub', () => {
-  var EventPluginHub;
-  var isEventSupported;
+  var React;
+  var ReactTestUtils;
 
   beforeEach(() => {
     jest.resetModuleRegistry();
-    EventPluginHub = require('EventPluginHub');
-    isEventSupported = require('isEventSupported');
-    isEventSupported.mockReturnValueOnce(false);
+    React = require('React');
+    ReactTestUtils = require('ReactTestUtils');
   });
 
-  it('should prevent non-function listeners', () => {
+  it('should prevent non-function listeners, at dispatch', () => {
+    var node = ReactTestUtils.renderIntoDocument(
+      <div onClick="not a function" />
+    );
     expect(function() {
-      EventPluginHub.putListener(1, 'onClick', 'not a function');
+      ReactTestUtils.SimulateNative.click(node);
     }).toThrowError(
       'Expected onClick listener to be a function, instead got type string'
     );

--- a/src/renderers/shared/shared/event/__tests__/EventPluginHub-test.js
+++ b/src/renderers/shared/shared/event/__tests__/EventPluginHub-test.js
@@ -33,4 +33,14 @@ describe('EventPluginHub', () => {
       'Expected onClick listener to be a function, instead got type string'
     );
   });
+
+  it('should not prevent null listeners, at dispatch', () => {
+    var node = ReactTestUtils.renderIntoDocument(
+      <div onClick={null} />
+    );
+    expect(function() {
+      ReactTestUtils.SimulateNative.click(node);
+    }).not.toThrow();
+  });
+
 });

--- a/src/renderers/shared/shared/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
+++ b/src/renderers/shared/shared/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
@@ -233,7 +233,7 @@ var registerTestHandlers = function(eventTestConfig, readableIDToID) {
           }
           return config.returnVal;
         }.bind(null, readableID, nodeConfig);
-      EventPluginHub.putListener(getInstanceFromNode(id), registrationName, handler);
+      putListener(getInstanceFromNode(id), registrationName, handler);
     }
   };
   for (var eventName in eventTestConfig) {
@@ -257,9 +257,6 @@ var registerTestHandlers = function(eventTestConfig, readableIDToID) {
   }
   return runs;
 };
-
-
-
 
 var run = function(config, hierarchyConfig, nativeEventConfig) {
   var max = NA;
@@ -309,10 +306,30 @@ var PARENT_HOST_NODE = { };
 var CHILD_HOST_NODE = { };
 var CHILD_HOST_NODE2 = { };
 
-var GRANDPARENT_INST = { _hostParent: null, _rootNodeID: '1', _hostNode: GRANDPARENT_HOST_NODE };
-var PARENT_INST = { _hostParent: GRANDPARENT_INST, _rootNodeID: '2', _hostNode: PARENT_HOST_NODE };
-var CHILD_INST = { _hostParent: PARENT_INST, _rootNodeID: '3', _hostNode: CHILD_HOST_NODE };
-var CHILD_INST2 = { _hostParent: PARENT_INST, _rootNodeID: '4', _hostNode: CHILD_HOST_NODE2 };
+var GRANDPARENT_INST = {
+  _hostParent: null,
+  _rootNodeID: '1',
+  _hostNode: GRANDPARENT_HOST_NODE,
+  _currentElement: { props: {} },
+};
+var PARENT_INST = {
+  _hostParent: GRANDPARENT_INST,
+  _rootNodeID: '2',
+  _hostNode: PARENT_HOST_NODE,
+  _currentElement: { props: {} },
+};
+var CHILD_INST = {
+  _hostParent: PARENT_INST,
+  _rootNodeID: '3',
+  _hostNode: CHILD_HOST_NODE,
+  _currentElement: { props: {} },
+};
+var CHILD_INST2 = {
+  _hostParent: PARENT_INST,
+  _rootNodeID: '4',
+  _hostNode: CHILD_HOST_NODE2,
+  _currentElement: { props: {} },
+};
 
 GRANDPARENT_HOST_NODE._reactInstance = GRANDPARENT_INST;
 PARENT_HOST_NODE._reactInstance = PARENT_INST;
@@ -339,6 +356,14 @@ function getNodeFromInstance(inst) {
   return inst._hostNode;
 }
 
+function putListener(node, registrationName, handler) {
+  node._currentElement.props[registrationName] = handler;
+}
+
+function deleteAllListeners(node) {
+  node._currentElement.props = {};
+}
+
 describe('ResponderEventPlugin', () => {
 
   beforeEach(() => {
@@ -347,6 +372,11 @@ describe('ResponderEventPlugin', () => {
     EventPluginHub = require('EventPluginHub');
     EventPluginUtils = require('EventPluginUtils');
     ResponderEventPlugin = require('ResponderEventPlugin');
+
+    deleteAllListeners(GRANDPARENT_INST);
+    deleteAllListeners(PARENT_INST);
+    deleteAllListeners(CHILD_INST);
+    deleteAllListeners(CHILD_INST2);
 
     EventPluginUtils.injection.injectComponentTree({
       getInstanceFromNode,

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactErrorBoundaries-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactErrorBoundaries-test.js
@@ -879,26 +879,6 @@ describe('ReactErrorBoundaries', () => {
     ]);
   });
 
-  it('does not register event handlers for unmounted children', () => {
-    var EventPluginHub = require('EventPluginHub');
-    var container = document.createElement('div');
-    EventPluginHub.putListener = jest.fn();
-    ReactDOM.render(
-      <ErrorBoundary>
-        <button onClick={() => {}}>Click me</button>
-        <BrokenRender />
-      </ErrorBoundary>,
-      container
-    );
-    expect(EventPluginHub.putListener).not.toBeCalled();
-
-    log.length = 0;
-    ReactDOM.unmountComponentAtNode(container);
-    expect(log).toEqual([
-      'ErrorBoundary componentWillUnmount',
-    ]);
-  });
-
   it('does not call componentWillUnmount when aborting initial mount', () => {
     var container = document.createElement('div');
     ReactDOM.render(


### PR DESCRIPTION
Reapply #8192 which was temporarily reverted. I think we're ready to land it now.

This also includes a fix to not throw on falsy event listeners (like `null`).