### PR TITLE
Support for string and callback refs in shallow rendering

### DIFF
--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -464,7 +464,8 @@ var ReactCompositeComponent = {
     hostParent,
     hostContainerInfo,
     transaction,
-    context
+    context,
+    shallowRendering
   ) {
     var markup;
     var checkpoint = transaction.checkpoint();
@@ -487,7 +488,8 @@ var ReactCompositeComponent = {
       this._renderedComponent.unmountComponent(
         true, /* safely */
         // Don't call componentWillUnmount() because they never fully mounted:
-        true /* skipLifecyle */
+        true, /* skipLifecyle */
+        shallowRendering
       );
       transaction.rollback(checkpoint);
 
@@ -509,7 +511,8 @@ var ReactCompositeComponent = {
     hostParent,
     hostContainerInfo,
     transaction,
-    context
+    context,
+    shallowRendering
   ) {
     // If not a stateless component, we now render
     if (renderedElement === undefined) {
@@ -535,7 +538,8 @@ var ReactCompositeComponent = {
       hostParent,
       hostContainerInfo,
       this._processChildContext(context),
-      debugID
+      debugID,
+      shallowRendering
     );
 
     if (__DEV__) {
@@ -558,7 +562,7 @@ var ReactCompositeComponent = {
    * @final
    * @internal
    */
-  unmountComponent: function(safely, skipLifecycle) {
+  unmountComponent: function(safely, skipLifecycle, shallowRendering) {
     if (!this._renderedComponent) {
       return;
     }
@@ -590,7 +594,8 @@ var ReactCompositeComponent = {
       ReactReconciler.unmountComponent(
         this._renderedComponent,
         safely,
-        skipLifecycle
+        skipLifecycle,
+        shallowRendering
       );
       this._renderedNodeType = null;
       this._renderedComponent = null;
@@ -1068,7 +1073,8 @@ var ReactCompositeComponent = {
     transaction,
     context,
     nextRenderedElement,
-    safely
+    safely,
+    shallowRendering
   ) {
     var prevComponentInstance = this._renderedComponent;
     var prevRenderedElement = prevComponentInstance._currentElement;
@@ -1090,7 +1096,8 @@ var ReactCompositeComponent = {
       ReactReconciler.unmountComponent(
         prevComponentInstance,
         safely,
-        false /* skipLifecycle */
+        false, /* skipLifecycle */
+        shallowRendering
       );
 
       var nodeType = ReactNodeTypes.getType(nextRenderedElement);
@@ -1107,7 +1114,8 @@ var ReactCompositeComponent = {
         this._hostParent,
         this._hostContainerInfo,
         this._processChildContext(context),
-        debugID
+        debugID,
+        shallowRendering
       );
 
       if (__DEV__) {

--- a/src/renderers/shared/stack/reconciler/ReactReconciler.js
+++ b/src/renderers/shared/stack/reconciler/ReactReconciler.js
@@ -43,7 +43,8 @@ var ReactReconciler = {
     hostParent,
     hostContainerInfo,
     context,
-    parentDebugID // 0 in production and for roots
+    parentDebugID, // 0 in production and for roots
+    shallowRendering
   ) {
     if (__DEV__) {
       if (internalInstance._debugID !== 0) {
@@ -61,9 +62,11 @@ var ReactReconciler = {
       context,
       parentDebugID
     );
-    if (internalInstance._currentElement &&
-        internalInstance._currentElement.ref != null) {
-      transaction.getReactMountReady().enqueue(attachRefs, internalInstance);
+    if (!shallowRendering) {
+      if (internalInstance._currentElement &&
+          internalInstance._currentElement.ref != null) {
+        transaction.getReactMountReady().enqueue(attachRefs, internalInstance);
+      }
     }
     if (__DEV__) {
       if (internalInstance._debugID !== 0) {
@@ -89,7 +92,12 @@ var ReactReconciler = {
    * @final
    * @internal
    */
-  unmountComponent: function(internalInstance, safely, skipLifecycle) {
+  unmountComponent: function(
+    internalInstance,
+    safely,
+    skipLifecycle,
+    shallowRendering
+  ) {
     if (__DEV__) {
       if (internalInstance._debugID !== 0) {
         ReactInstrumentation.debugTool.onBeforeUnmountComponent(
@@ -97,7 +105,9 @@ var ReactReconciler = {
         );
       }
     }
-    ReactRef.detachRefs(internalInstance, internalInstance._currentElement);
+    if (!shallowRendering) {
+      ReactRef.detachRefs(internalInstance, internalInstance._currentElement);
+    }
     internalInstance.unmountComponent(safely, skipLifecycle);
     if (__DEV__) {
       if (internalInstance._debugID !== 0) {


### PR DESCRIPTION
Since testing is horrible without refs IMHO, I made this.

I chose to have elements instead of instances to avoid rendering recursively all nodes and to allow the same way to access it. I think navigating in shallow instances, if necessary (since it's shallow rendering...), could easily fit in testing library like `enzyme`.

I actually started trying to solve the need of refs in shallow rendering in `enzyme` (since it's a smaller learning curve for contributing than with `react`) but I couldn't find a way to include callback refs in the solution. With this, it'll be pretty simple :)

So here's what this PR allow:

For string refs:
```javascript
renderer.getMountedInstance().refs.myButton
```

For callback refs:
```javascript
const instance = renderer.getMountedInstance();
const myButton = instance.myButton
```