### PR TITLE
Update typechecking-with-proptypes.md

### DIFF
--- a/docs/docs/typechecking-with-proptypes.md
+++ b/docs/docs/typechecking-with-proptypes.md
@@ -125,7 +125,7 @@ class MyComponent extends React.Component {
 }
 
 MyComponent.propTypes = {
-  children: React.PropTypes.element.isRequired
+  children: React.PropTypes.node.isRequired
 };
 ```
 


### PR DESCRIPTION
Shouldn't children's PropType be a `node`? [Here's](https://github.com/yannickcr/eslint-plugin-react/issues/7) a good conversation on it in the eslint-plugin-react repo.