### PR TITLE
include the version number in the header

### DIFF
--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -16,7 +16,7 @@
       </ul>
       <ul class="nav-site nav-site-external">
         <li><a href="https://github.com/facebook/react">GitHub</a></li>
-        <li><a href="https://facebook.github.io/react-native/">React Native</a></li>
+        <li><a href="https://github.com/facebook/react/releases">v{{site.react_version}}</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
This just changes the React docs' header to have a link to release notes in the upper right corner, instead of a link to React Native.

Rationale:
1/ Checking Google Analytics, that link is currently worthless as a driver of traffic to React Native. So we're not missing out on much there.
2/ It is handy to be able to check the current version and to see notes about it. You often want to go check those when you're looking at some doc, so put it in the header. (We do that for the React Native docs and have heard positive feedback.)