### PR TITLE
Do not extract mouse events for children of disabled parents

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -69,21 +69,9 @@ src/renderers/dom/shared/__tests__/ReactEventIndependence-test.js
 
 src/renderers/dom/shared/__tests__/ReactEventListener-test.js
 * should batch between handlers from different roots
-* should not fire duplicate events for a React DOM tree
 
 src/renderers/dom/shared/eventPlugins/__tests__/ChangeEventPlugin-test.js
 * should not fire change when setting checked programmatically
-
-src/renderers/dom/shared/eventPlugins/__tests__/SimpleEventPlugin-test.js
-* A non-interactive tags clicks bubble when disabled
-* should not forward clicks when it starts out disabled
-* should not forward clicks when it becomes disabled
-* should not forward clicks when it starts out disabled
-* should not forward clicks when it becomes disabled
-* should not forward clicks when it starts out disabled
-* should not forward clicks when it becomes disabled
-* should not forward clicks when it starts out disabled
-* should not forward clicks when it becomes disabled
 
 src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
 * should control a value in reentrant events

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -624,6 +624,7 @@ src/renderers/dom/shared/__tests__/ReactEventListener-test.js
 * should propagate events one level down
 * should propagate events two levels down
 * should not get confused by disappearing elements
+* should not fire duplicate events for a React DOM tree
 
 src/renderers/dom/shared/__tests__/escapeTextContentForBrowser-test.js
 * should escape boolean to string
@@ -689,17 +690,32 @@ src/renderers/dom/shared/eventPlugins/__tests__/SelectEventPlugin-test.js
 
 src/renderers/dom/shared/eventPlugins/__tests__/SimpleEventPlugin-test.js
 * A non-interactive tags click when disabled
+* A non-interactive tags clicks bubble when disabled
+* clicking a child of a disabled element does not register a click
+* triggers click events for children of disabled elements
+* triggers parent captured click events when target is a child of a disabled elements
+* does not trigger captured click events when target is a disabled element
+* triggers captured click events for children of disabled elements
+* buttons inside of disabled fieldsets do not click
 * should forward clicks when it starts out not disabled
+* should not forward clicks when it starts out disabled
 * should forward clicks when it becomes not disabled
+* should not forward clicks when it becomes disabled
 * should work correctly if the listener is changed
 * should forward clicks when it starts out not disabled
+* should not forward clicks when it starts out disabled
 * should forward clicks when it becomes not disabled
+* should not forward clicks when it becomes disabled
 * should work correctly if the listener is changed
 * should forward clicks when it starts out not disabled
+* should not forward clicks when it starts out disabled
 * should forward clicks when it becomes not disabled
+* should not forward clicks when it becomes disabled
 * should work correctly if the listener is changed
 * should forward clicks when it starts out not disabled
+* should not forward clicks when it starts out disabled
 * should forward clicks when it becomes not disabled
+* should not forward clicks when it becomes disabled
 * should work correctly if the listener is changed
 * does not add a local click to interactive elements
 * adds a local click listener to non-interactive elements

--- a/src/renderers/dom/shared/ReactEventListener.js
+++ b/src/renderers/dom/shared/ReactEventListener.js
@@ -16,7 +16,6 @@ var ExecutionEnvironment = require('ExecutionEnvironment');
 var PooledClass = require('PooledClass');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var ReactGenericBatching = require('ReactGenericBatching');
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 var ReactTreeTraversal = require('ReactTreeTraversal');
 var getEventTarget = require('getEventTarget');
 var getUnboundedScrollPosition = require('getUnboundedScrollPosition');
@@ -33,9 +32,9 @@ function findParent(inst) {
   // traversal, but caching is difficult to do correctly without using a
   // mutation observer to listen for all DOM changes.
   do {
-    root = inst
-    inst = ReactTreeTraversal.getParentInstance(inst)
-  } while(inst)
+    root = inst;
+    inst = ReactTreeTraversal.getParentInstance(inst);
+  } while (inst);
 
   var rootNode = ReactDOMComponentTree.getNodeFromInstance(root);
   var container = rootNode.parentNode;

--- a/src/renderers/dom/shared/ReactEventListener.js
+++ b/src/renderers/dom/shared/ReactEventListener.js
@@ -16,7 +16,8 @@ var ExecutionEnvironment = require('ExecutionEnvironment');
 var PooledClass = require('PooledClass');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var ReactGenericBatching = require('ReactGenericBatching');
-
+var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
+var ReactTreeTraversal = require('ReactTreeTraversal');
 var getEventTarget = require('getEventTarget');
 var getUnboundedScrollPosition = require('getUnboundedScrollPosition');
 
@@ -26,13 +27,17 @@ var getUnboundedScrollPosition = require('getUnboundedScrollPosition');
  * other). If React trees are not nested, returns null.
  */
 function findParent(inst) {
+  var root;
+
   // TODO: It may be a good idea to cache this to prevent unnecessary DOM
   // traversal, but caching is difficult to do correctly without using a
   // mutation observer to listen for all DOM changes.
-  while (inst._hostParent) {
-    inst = inst._hostParent;
-  }
-  var rootNode = ReactDOMComponentTree.getNodeFromInstance(inst);
+  do {
+    root = inst
+    inst = ReactTreeTraversal.getParentInstance(inst)
+  } while(inst)
+
+  var rootNode = ReactDOMComponentTree.getNodeFromInstance(root);
   var container = rootNode.parentNode;
   return ReactDOMComponentTree.getClosestInstanceFromNode(container);
 }

--- a/src/renderers/dom/shared/eventPlugins/SimpleEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/SimpleEventPlugin.js
@@ -140,17 +140,15 @@ var topLevelEventsToDispatchConfig: {[key: TopLevelTypes]: DispatchConfig} = {};
 
 function isInteractive(tag) {
   return (
-    tag === 'button' || tag === 'input' ||
-    tag === 'select' || tag === 'textarea'
+    tag === 'BUTTON' || tag === 'INPUT' ||
+    tag === 'SELECT' || tag === 'TEXTAREA'
   );
 }
 
-function shouldPreventMouseEvent(inst) {
-  if (inst) {
-    var disabled = inst._currentElement && inst._currentElement.props.disabled;
-
-    if (disabled) {
-      return isInteractive(inst._tag);
+function shouldPreventMouseEvent(node) {
+  if (node) {
+    if (node.disabled) {
+      return isInteractive(node.tagName)
     }
   }
 
@@ -233,7 +231,7 @@ var SimpleEventPlugin: PluginModule<MouseEvent> = {
       case 'topMouseMove':
       case 'topMouseUp':
         // Disabled elements should not respond to mouse events
-        if (shouldPreventMouseEvent(targetInst)) {
+        if (shouldPreventMouseEvent(nativeEventTarget)) {
           return null;
         }
         /* falls through */
@@ -290,6 +288,7 @@ var SimpleEventPlugin: PluginModule<MouseEvent> = {
       nativeEventTarget
     );
     EventPropagators.accumulateTwoPhaseDispatches(event);
+
     return event;
   },
 

--- a/src/renderers/dom/shared/eventPlugins/SimpleEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/SimpleEventPlugin.js
@@ -266,7 +266,6 @@ var SimpleEventPlugin: PluginModule<MouseEvent> = {
       nativeEventTarget
     );
     EventPropagators.accumulateTwoPhaseDispatches(event);
-
     return event;
   },
 

--- a/src/renderers/dom/shared/eventPlugins/SimpleEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/SimpleEventPlugin.js
@@ -138,23 +138,6 @@ var topLevelEventsToDispatchConfig: {[key: TopLevelTypes]: DispatchConfig} = {};
   topLevelEventsToDispatchConfig[topEvent] = type;
 });
 
-function isInteractive(tag) {
-  return (
-    tag === 'BUTTON' || tag === 'INPUT' ||
-    tag === 'SELECT' || tag === 'TEXTAREA'
-  );
-}
-
-function shouldPreventMouseEvent(node) {
-  if (node) {
-    if (node.disabled) {
-      return isInteractive(node.tagName)
-    }
-  }
-
-  return false;
-}
-
 var SimpleEventPlugin: PluginModule<MouseEvent> = {
 
   eventTypes: eventTypes,
@@ -230,11 +213,6 @@ var SimpleEventPlugin: PluginModule<MouseEvent> = {
       case 'topMouseDown':
       case 'topMouseMove':
       case 'topMouseUp':
-        // Disabled elements should not respond to mouse events
-        if (shouldPreventMouseEvent(nativeEventTarget)) {
-          return null;
-        }
-        /* falls through */
       case 'topMouseOut':
       case 'topMouseOver':
       case 'topContextMenu':

--- a/src/renderers/dom/shared/eventPlugins/__tests__/SimpleEventPlugin-test.js
+++ b/src/renderers/dom/shared/eventPlugins/__tests__/SimpleEventPlugin-test.js
@@ -58,6 +58,78 @@ describe('SimpleEventPlugin', function() {
     expect(onClick.mock.calls.length).toBe(1);
   });
 
+  it('clicking a child of a disabled element does not register a click', function() {
+    var element = ReactTestUtils.renderIntoDocument(
+      <button onClick={onClick} disabled={true}><span /></button>
+    );
+    var child = ReactDOM.findDOMNode(element).querySelector('span');
+
+    onClick.mockClear();
+    ReactTestUtils.SimulateNative.click(child);
+    expect(onClick.mock.calls.length).toBe(0);
+  });
+
+  it('triggers click events for children of disabled elements', function() {
+    var element = ReactTestUtils.renderIntoDocument(
+      <button disabled={true}><span onClick={onClick} /></button>
+    );
+    var child = ReactDOM.findDOMNode(element).querySelector('span');
+
+    onClick.mockClear();
+    ReactTestUtils.SimulateNative.click(child);
+    expect(onClick.mock.calls.length).toBe(1);
+  });
+
+  it('triggers parent captured click events when target is a child of a disabled elements', function() {
+    var element = ReactTestUtils.renderIntoDocument(
+      <div onClickCapture={onClick}>
+        <button disabled={true}><span /></button>
+      </div>
+    );
+    var child = ReactDOM.findDOMNode(element).querySelector('span');
+
+    onClick.mockClear();
+    ReactTestUtils.SimulateNative.click(child);
+    expect(onClick.mock.calls.length).toBe(1);
+  });
+
+  it('does not trigger captured click events when target is a disabled element', function() {
+    var element = ReactTestUtils.renderIntoDocument(
+      <div onClickCapture={onClick}>
+        <button disabled={true}></button>
+      </div>
+    );
+    var button = ReactDOM.findDOMNode(element).querySelector('button');
+
+    onClick.mockClear();
+    ReactTestUtils.SimulateNative.click(button);
+    expect(onClick.mock.calls.length).toBe(0);
+  });
+
+  it('triggers captured click events for children of disabled elements', function() {
+    var element = ReactTestUtils.renderIntoDocument(
+      <button disabled={true}><span onClickCapture={onClick} /></button>
+    );
+    var child = ReactDOM.findDOMNode(element).querySelector('span');
+
+    onClick.mockClear();
+    ReactTestUtils.SimulateNative.click(child);
+    expect(onClick.mock.calls.length).toBe(1);
+  });
+
+  it('buttons inside of disabled fieldsets do not click', function() {
+    var element = ReactTestUtils.renderIntoDocument(
+      <fieldset disabled={true}>
+        <button onClick={onClick} />
+      </fieldset>
+    );
+    var child = ReactDOM.findDOMNode(element).querySelector('button');
+
+    onClick.mockClear();
+    ReactTestUtils.SimulateNative.click(child);
+    expect(onClick.mock.calls.length).toBe(0);
+  });
+
   ['button', 'input', 'select', 'textarea'].forEach(function(tagName) {
 
     describe(tagName, function() {

--- a/src/renderers/dom/shared/eventPlugins/__tests__/SimpleEventPlugin-test.js
+++ b/src/renderers/dom/shared/eventPlugins/__tests__/SimpleEventPlugin-test.js
@@ -96,7 +96,7 @@ describe('SimpleEventPlugin', function() {
   it('does not trigger captured click events when target is a disabled element', function() {
     var element = ReactTestUtils.renderIntoDocument(
       <div onClickCapture={onClick}>
-        <button disabled={true}></button>
+        <button disabled={true} />
       </div>
     );
     var button = ReactDOM.findDOMNode(element).querySelector('button');

--- a/src/renderers/shared/shared/ReactTreeTraversal.js
+++ b/src/renderers/shared/shared/ReactTreeTraversal.js
@@ -111,6 +111,12 @@ function shouldIgnoreElement(inst) {
 }
 
 function traverseTwoPhase(inst, fn, arg) {
+  // Do not traverse an tree that originates with a disabled
+  // element
+  if (shouldIgnoreElement(inst)) {
+    return
+  }
+
   var path = [];
   while (inst) {
     path.push(inst);
@@ -118,14 +124,14 @@ function traverseTwoPhase(inst, fn, arg) {
   }
 
   var i;
-  var disabledParent = false;
+  var disabled = false;
   // walking from parent to child
   for (i = path.length; i-- > 0;) {
-    // Check to see if we are within a disabled tree
-    disabledParent = disabledParent || shouldIgnoreElement(path[i])
-    // If we are within a disabled tree, and the current element
-    // is active, remove the item from the tree
-    if (disabledParent && isInteractive(path[i])) {
+    // Are we currently, our about to be, within a disabled tree
+    disabled = disabled || shouldIgnoreElement(path[i])
+    // If so, remove the current element from traversion if it
+    // is interactive
+    if (disabled && isInteractive(path[i])) {
       path.splice(i, 1);
     }
   }

--- a/src/renderers/shared/shared/ReactTreeTraversal.js
+++ b/src/renderers/shared/shared/ReactTreeTraversal.js
@@ -111,10 +111,9 @@ function shouldIgnoreElement(inst) {
 }
 
 function traverseTwoPhase(inst, fn, arg) {
-  // Do not traverse an tree that originates with a disabled
-  // element
+  // Do not traverse an tree that originates with a disabled element
   if (shouldIgnoreElement(inst)) {
-    return
+    return false;
   }
 
   var path = [];
@@ -128,7 +127,7 @@ function traverseTwoPhase(inst, fn, arg) {
   // walking from parent to child
   for (i = path.length; i-- > 0;) {
     // Are we currently, our about to be, within a disabled tree
-    disabled = disabled || shouldIgnoreElement(path[i])
+    disabled = disabled || shouldIgnoreElement(path[i]);
     // If so, remove the current element from traversion if it
     // is interactive
     if (disabled && isInteractive(path[i])) {

--- a/src/renderers/shared/shared/ReactTreeTraversal.js
+++ b/src/renderers/shared/shared/ReactTreeTraversal.js
@@ -105,7 +105,7 @@ function isInteractive(inst) {
 function shouldIgnoreElement(inst) {
   if (inst && isInteractive(inst)) {
     if (ReactDOMFeatureFlags.useFiber) {
-      return inst.stateNode.disabled
+      return inst.stateNode.disabled;
     } else if (inst._currentElement) {
       return inst._currentElement.props.disabled;
     }

--- a/src/renderers/shared/shared/ReactTreeTraversal.js
+++ b/src/renderers/shared/shared/ReactTreeTraversal.js
@@ -11,6 +11,7 @@
 
 'use strict';
 
+var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 var { HostComponent } = require('ReactTypeOfWork');
 
 function getParent(inst) {
@@ -92,7 +93,8 @@ function getParentInstance(inst) {
  */
 
 function isInteractive(inst) {
-  var tag = inst._tag;
+  var tag = ReactDOMFeatureFlags.useFiber ? inst.type : inst._tag;
+
   return (
     tag === 'button' || tag === 'input' ||
     tag === 'select' || tag === 'textarea' ||
@@ -101,9 +103,11 @@ function isInteractive(inst) {
 }
 
 function shouldIgnoreElement(inst) {
-  if (inst && inst._currentElement) {
-    if (inst._currentElement.props.disabled) {
-      return isInteractive(inst);
+  if (inst && isInteractive(inst)) {
+    if (ReactDOMFeatureFlags.useFiber) {
+      return inst.stateNode.disabled
+    } else if (inst._currentElement) {
+      return inst._currentElement.props.disabled;
     }
   }
 


### PR DESCRIPTION
Potential fix for https://github.com/facebook/react/issues/8308. React (my fault) only sifts out mouse events for disabled elements that are the direct target of dispatch. If an element is the child of a disabled parent, the event incorrectly dispatches because `SimpleEventPlugin` doesn't see a `disabled` prop. For example:

```javascript
<button onClick={...} disabled>
    <span />    <------ Click!
</button>
```

Incorrectly fires the onClick handler

Original test case (From that issue) here:
https://jsfiddle.net/rcataldo/69z2wepo/62589/

