### PR TITLE
Update 2016-11-16-react-v15.4.0.md

### DIFF
--- a/docs/_posts/2016-11-16-react-v15.4.0.md
+++ b/docs/_posts/2016-11-16-react-v15.4.0.md
@@ -41,7 +41,7 @@ To use it:
 
 Note that the numbers are relative so components will render faster in production. Still, this should help you realize when unrelated UI gets updated by mistake, and how deep and how often your UI updates occur.
 
-Currently Chrome is the only browser supporting this feature, but we use the standard [User Timing API](https://developer.mozilla.org/en-US/docs/Web/API/User_Timing_API) so we expect more browsers to add support for it.
+Currently Chrome, Edge, and IE are the only browsers supporting this feature, but we use the standard [User Timing API](https://developer.mozilla.org/en-US/docs/Web/API/User_Timing_API) so we expect more browsers to add support for it.
 
 ### Mocking Refs for Snapshot Testing
 


### PR DESCRIPTION
Edge and IE11 both show user marks and measures in the Dev Tools, so it's technically not accurate to say that only Chrome has this feature.

Here's what this looks like in Edge:

![2016-11-17 15_39_03-react app - microsoft edge](https://cloud.githubusercontent.com/assets/283842/20412882/554f12d0-acde-11e6-8857-db1a481cf7b2.png)

BTW thank you for promoting `performance.mark()` and `performance.measure()`. :smiley: Surfacing this info into the Dev Tools makes webdevs much more likely to use these APIs, and they're incredibly useful for telemetry, performance analyses, etc. It's great to see React leading on this.