### PR TITLE
Fix ReactDOMFiberSelect to set the initial values

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -88,23 +88,6 @@ src/renderers/dom/shared/eventPlugins/__tests__/SimpleEventPlugin-test.js
 src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
 * should control a value in reentrant events
 
-src/renderers/dom/shared/wrappers/__tests__/ReactDOMOption-test.js
-* should allow ignoring `value` on option
-
-src/renderers/dom/shared/wrappers/__tests__/ReactDOMSelect-test.js
-* should allow setting `defaultValue`
-* should not control when using `defaultValue`
-* should allow setting `defaultValue` with multiple
-* should allow setting `value`
-* should allow setting `value` with multiple
-* should not select other options automatically
-* should allow setting `value` with `objectToString`
-* should allow switching to multiple
-* should allow switching from multiple
-* should remember value when switching to uncontrolled
-* should not control defaultValue if readding options
-* should select grandchild options nested inside an optgroup
-
 src/renderers/dom/stack/client/__tests__/ReactDOM-test.js
 * throws in render() if the mount callback is not a function
 * throws in render() if the update callback is not a function

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -831,18 +831,31 @@ src/renderers/dom/shared/wrappers/__tests__/ReactDOMOption-test.js
 * should ignore null/undefined/false children without warning
 * should be able to use dangerouslySetInnerHTML on option
 * should set attribute for empty value
+* should allow ignoring `value` on option
 
 src/renderers/dom/shared/wrappers/__tests__/ReactDOMSelect-test.js
+* should allow setting `defaultValue`
 * should not throw with `defaultValue` and without children
+* should not control when using `defaultValue`
+* should allow setting `defaultValue` with multiple
+* should allow setting `value`
 * should not throw with `value` and without children
+* should allow setting `value` with multiple
+* should not select other options automatically
 * should reset child options selected when they are changed and `value` is set
+* should allow setting `value` with `objectToString`
+* should allow switching to multiple
+* should allow switching from multiple
+* should remember value when switching to uncontrolled
 * should remember updated value when switching to uncontrolled
 * should support server-side rendering
 * should support server-side rendering with defaultValue
 * should support server-side rendering with multiple
+* should not control defaultValue if readding options
 * should refresh state on change
 * should warn if value and defaultValue props are specified
 * should be able to safely remove select onChange
+* should select grandchild options nested inside an optgroup
 
 src/renderers/dom/shared/wrappers/__tests__/ReactDOMTextarea-test.js
 * should allow setting `defaultValue`

--- a/src/renderers/dom/fiber/wrappers/ReactDOMFiberSelect.js
+++ b/src/renderers/dom/fiber/wrappers/ReactDOMFiberSelect.js
@@ -153,6 +153,13 @@ var ReactDOMSelect = {
       );
       didWarnValueDefaultValue = true;
     }
+
+    node.multiple = Boolean(props.multiple);
+    if (value != null) {
+      updateOptions(node, Boolean(props.multiple), value);
+    } else if (props.defaultValue != null) {
+      updateOptions(node, Boolean(props.multiple), props.defaultValue);
+    }
   },
 
   postUpdateWrapper: function(element : Element, props : Object) {


### PR DESCRIPTION
I forgot that the normal properties route doesn't do this. We also have to make sure that the order is 1) insert children (options), 2) set multiple 3) update the options.