### PR TITLE
Fixed to use 'className'

### DIFF
--- a/src/shared/vendor/third_party/webcomponents.js
+++ b/src/shared/vendor/third_party/webcomponents.js
@@ -2444,7 +2444,7 @@ if (WebComponents.flags.shadow) {
         return unsafeUnwrap(this).className;
       },
       set className(v) {
-        this.setAttribute("class", v);
+        this.className = v;
       },
       get id() {
         return unsafeUnwrap(this).id;


### PR DESCRIPTION
In the case of IE, using className is better than using setAttribute.