### PR TITLE
Use a closure to bind argument to callback in ReactErrorUtils

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1418,6 +1418,13 @@ src/renderers/shared/stack/reconciler/__tests__/refs-test.js
 * ref called correctly for stateless component when __DEV__ = true
 * coerces numbers to strings
 
+src/renderers/shared/utils/__tests__/ReactErrorUtils-test.js
+* should call the callback with only the passed argument
+* should catch errors
+* should rethrow caught errors
+* should call the callback with only the passed argument
+* should use invokeGuardedCallbackWithCatch in production
+
 src/renderers/shared/utils/__tests__/accumulateInto-test.js
 * throws if the second item is null
 * returns the second item if first is null

--- a/src/renderers/shared/utils/ReactErrorUtils.js
+++ b/src/renderers/shared/utils/ReactErrorUtils.js
@@ -72,7 +72,9 @@ if (__DEV__) {
       func: (a: A) => void,
       a: A,
     ): void {
-      var boundFunc = func.bind(null, a);
+      var boundFunc = function() {
+        func(a);
+      };
       var evtType = `react-${name}`;
       fakeNode.addEventListener(evtType, boundFunc, false);
       var evt = document.createEvent('Event');

--- a/src/renderers/shared/utils/__tests__/ReactErrorUtils-test.js
+++ b/src/renderers/shared/utils/__tests__/ReactErrorUtils-test.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var ReactErrorUtils;
+
+describe('ReactErrorUtils', () => {
+
+  beforeEach(() => {
+    ReactErrorUtils = require('ReactErrorUtils');
+  });
+
+  describe('invokeGuardedCallbackWithCatch', () => {
+    it('should call the callback with only the passed argument', () => {
+      var callback = jest.fn();
+      ReactErrorUtils.invokeGuardedCallbackWithCatch('foo', callback, 'arg');
+      expect(callback).toBeCalledWith('arg');
+    });
+
+    it('should catch errors', () => {
+      var callback = function() {
+        throw new Error('foo');
+      };
+      expect(
+        () => ReactErrorUtils.invokeGuardedCallbackWithCatch('foo', callback)
+      ).not.toThrow();
+    });
+  });
+
+  describe('rethrowCaughtError', () => {
+    it('should rethrow caught errors', () => {
+      var err = new Error('foo');
+      var callback = function() {
+        throw err;
+      };
+      ReactErrorUtils.invokeGuardedCallbackWithCatch('foo', callback);
+      expect(() => ReactErrorUtils.rethrowCaughtError()).toThrow(err);
+    });
+  });
+
+  describe('invokeGuardedCallback', () => {
+    it('should call the callback with only the passed argument', () => {
+      var callback = jest.fn();
+      ReactErrorUtils.invokeGuardedCallback('foo', callback, 'arg');
+      expect(callback).toBeCalledWith('arg');
+    });
+
+    it('should use invokeGuardedCallbackWithCatch in production', () => {
+      expect(ReactErrorUtils.invokeGuardedCallback).not.toEqual(
+        ReactErrorUtils.invokeGuardedCallbackWithCatch
+      );
+      __DEV__ = false;
+      var oldProcess = process;
+      global.process = {env: {NODE_ENV: 'production'}};
+      jest.resetModuleRegistry();
+      ReactErrorUtils = require('ReactErrorUtils');
+      expect(ReactErrorUtils.invokeGuardedCallback).toEqual(
+        ReactErrorUtils.invokeGuardedCallbackWithCatch
+      );
+      __DEV__ = true;
+      global.process = oldProcess;
+    });
+  });
+});


### PR DESCRIPTION
See discussion starting [here](https://github.com/facebook/react/issues/8354#issuecomment-261802649).

This prevents the fake event used here from being passed to the callback. This was causing issues where event handlers received an extra argument in dev only.

@gaearon I verified this fix resolves the issue by building and testing in the basic click counter example. I'm not sure where a unit test for this would go.