### PR TITLE
Shallow clone Fiber component initial state to prevent modification

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -1,6 +1,3 @@
-src/addons/__tests__/ReactComponentWithPureRenderMixin-test.js
-* does not do a deep comparison
-
 src/addons/__tests__/ReactFragment-test.js
 * should throw if a plain object is used as a child
 * should throw if a plain object even if it is in an owner

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -36,6 +36,7 @@ scripts/error-codes/__tests__/invertObject-test.js
 
 src/addons/__tests__/ReactComponentWithPureRenderMixin-test.js
 * provides a default shouldComponentUpdate implementation
+* does not do a deep comparison
 
 src/addons/__tests__/ReactFragment-test.js
 * warns for numeric keys on objects as children

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -228,7 +228,9 @@ module.exports = function(scheduleUpdate : (fiber: Fiber) => void) {
     }
 
     instance.props = props;
-    instance.state = state;
+    // Shallow clone the initial state object to prevent accidental
+    // modification
+    instance.state = state ? Object.assign({}, state) : state;
     instance.context = getMaskedContext(workInProgress);
 
     if (typeof instance.componentWillMount === 'function') {


### PR DESCRIPTION
Fixes the ReactComponentWithPureRenderMixin test by shallow cloning the component's initial state. Prior to this commit, the test was modifying a property on the state object passed into `setState`. This had the side-effect of also modifying the component's state, since the object was shared.

The alternative here was to update the test; I wasn't sure of the overhead of a shallow clone was forgivable. But at the very least, this diagnosis the issue and proposes a fix.