### PR TITLE
[Fiber] Handle Bailed Out HostText update and MultiChildText test

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -249,9 +249,20 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
       case HostText:
         let newText = workInProgress.pendingProps;
         if (current && workInProgress.stateNode != null) {
-          // If we have an alternate, that means this is an update and we need to
-          // schedule a side-effect to do the updates.
-          markUpdate(workInProgress);
+          const oldText = current.memoizedProps;
+          if (newText === null) {
+            // If this was a bail out we need to fall back to memoized text.
+            // This works the same way as HostComponent.
+            newText = workInProgress.memoizedProps;
+            if (newText === null) {
+              newText = oldText;
+            }
+          }
+          // If we have an alternate, that means this is an update and we need
+          // to schedule a side-effect to do the updates.
+          if (oldText !== newText) {
+            markUpdate(workInProgress);
+          }
         } else {
           if (typeof newText !== 'string') {
             if (workInProgress.stateNode === null) {

--- a/src/renderers/shared/shared/__tests__/ReactMultiChildText-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactMultiChildText-test.js
@@ -13,6 +13,7 @@
 
 var React = require('React');
 var ReactDOM = require('ReactDOM');
+var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 var ReactTestUtils = require('ReactTestUtils');
 
 // Helpers
@@ -57,28 +58,35 @@ var expectChildren = function(container, children) {
       var child = children[i];
 
       if (typeof child === 'string') {
-        openingCommentNode = outerNode.childNodes[mountIndex];
-
-        expect(openingCommentNode.nodeType).toBe(8);
-        expect(openingCommentNode.nodeValue).toMatch(/ react-text: [0-9]+ /);
-
-        if (child === '') {
-          textNode = null;
-          closingCommentNode = openingCommentNode.nextSibling;
-          mountIndex += 2;
-        } else {
-          textNode = openingCommentNode.nextSibling;
-          closingCommentNode = textNode.nextSibling;
-          mountIndex += 3;
-        }
-
-        if (textNode) {
+        if (ReactDOMFeatureFlags.useFiber) {
+          textNode = outerNode.childNodes[mountIndex];
           expect(textNode.nodeType).toBe(3);
           expect(textNode.data).toBe('' + child);
-        }
+          mountIndex++;
+        } else {
+          openingCommentNode = outerNode.childNodes[mountIndex];
 
-        expect(closingCommentNode.nodeType).toBe(8);
-        expect(closingCommentNode.nodeValue).toBe(' /react-text ');
+          expect(openingCommentNode.nodeType).toBe(8);
+          expect(openingCommentNode.nodeValue).toMatch(/ react-text: [0-9]+ /);
+
+          if (child === '') {
+            textNode = null;
+            closingCommentNode = openingCommentNode.nextSibling;
+            mountIndex += 2;
+          } else {
+            textNode = openingCommentNode.nextSibling;
+            closingCommentNode = textNode.nextSibling;
+            mountIndex += 3;
+          }
+
+          if (textNode) {
+            expect(textNode.nodeType).toBe(3);
+            expect(textNode.data).toBe('' + child);
+          }
+
+          expect(closingCommentNode.nodeType).toBe(8);
+          expect(closingCommentNode.nodeValue).toBe(' /react-text ');
+        }
       } else {
         var elementDOMNode = outerNode.childNodes[mountIndex];
         expect(elementDOMNode.tagName).toBe('DIV');


### PR DESCRIPTION
This handles the case where a host text bails out. In that case we need to reuse its previous memoizedProps. We should also only schedule an actual update if it did actually change its text content.

I updated the unit test to ignore comment nodes if we're using Fiber.

When combined with #8331 the test actually passes.