### PR TITLE
Add a couple missing SVG tags to DOM Elements docs

### DIFF
--- a/docs/docs/reference-dom-elements.md
+++ b/docs/docs/reference-dom-elements.md
@@ -168,7 +168,7 @@ underlineThickness unicode unicodeBidi unicodeRange unitsPerEm vAlphabetic
 vHanging vIdeographic vMathematical values vectorEffect version vertAdvY
 vertOriginX vertOriginY viewBox viewTarget visibility widths wordSpacing
 writingMode x x1 x2 xChannelSelector xHeight xlinkActuate xlinkArcrole
-xlinkHref xlinkRole xlinkShow xlinkTitle xlinkType xmlBase xmlLang xmlSpace
-y y1 y2 yChannelSelector z zoomAndPan
+xlinkHref xlinkRole xlinkShow xlinkTitle xlinkType xmlns xmlnsXlink xmlBase
+xmlLang xmlSpace y y1 y2 yChannelSelector z zoomAndPan
 
 ```


### PR DESCRIPTION
My first contribution to React!

While upgrading a React project, I found some suspect SVG that needed updating, so I dug in after checking the docs. I knew that support for some SVG properties had been added (namely `xmlns` and `xmlnsXlink`), but I noticed them missing from the reference's attribute list. This pull request updates `reference-dom-elements.md` by adding said properties.