### PR TITLE
Restructure code to work around a Rollup bug

### DIFF
--- a/src/isomorphic/hooks/ReactComponentTreeHook.js
+++ b/src/isomorphic/hooks/ReactComponentTreeHook.js
@@ -62,30 +62,38 @@ var canUseCollections = (
   isNative(Set.prototype.keys)
 );
 
+var setItem;
+var getItem;
+var removeItem;
+var getItemIDs;
+var addRoot;
+var removeRoot;
+var getRootIDs;
+
 if (canUseCollections) {
   var itemMap = new Map();
   var rootIDSet = new Set();
 
-  var setItem = function(id, item) {
+  setItem = function(id, item) {
     itemMap.set(id, item);
   };
-  var getItem = function(id) {
+  getItem = function(id) {
     return itemMap.get(id);
   };
-  var removeItem = function(id) {
+  removeItem = function(id) {
     itemMap.delete(id);
   };
-  var getItemIDs = function() {
+  getItemIDs = function() {
     return Array.from(itemMap.keys());
   };
 
-  var addRoot = function(id) {
+  addRoot = function(id) {
     rootIDSet.add(id);
   };
-  var removeRoot = function(id) {
+  removeRoot = function(id) {
     rootIDSet.delete(id);
   };
-  var getRootIDs = function() {
+  getRootIDs = function() {
     return Array.from(rootIDSet.keys());
   };
 
@@ -102,31 +110,31 @@ if (canUseCollections) {
     return parseInt(key.substr(1), 10);
   };
 
-  var setItem = function(id, item) {
+  setItem = function(id, item) {
     var key = getKeyFromID(id);
     itemByKey[key] = item;
   };
-  var getItem = function(id) {
+  getItem = function(id) {
     var key = getKeyFromID(id);
     return itemByKey[key];
   };
-  var removeItem = function(id) {
+  removeItem = function(id) {
     var key = getKeyFromID(id);
     delete itemByKey[key];
   };
-  var getItemIDs = function() {
+  getItemIDs = function() {
     return Object.keys(itemByKey).map(getIDFromKey);
   };
 
-  var addRoot = function(id) {
+  addRoot = function(id) {
     var key = getKeyFromID(id);
     rootByKey[key] = true;
   };
-  var removeRoot = function(id) {
+  removeRoot = function(id) {
     var key = getKeyFromID(id);
     delete rootByKey[key];
   };
-  var getRootIDs = function() {
+  getRootIDs = function() {
     return Object.keys(rootByKey).map(getIDFromKey);
   };
 }


### PR DESCRIPTION
**This PR is directly again `15-stable` because it's fixed in #8309 but tricky to cherry-pick.**

This fixes #8318.

It's not technically our bug, but it is a regression for Rollup users and it's easy for us to avoid.
In fact we already fixed this in master via #8309 because of the linter update.