### PR TITLE
[Fiber] Add ReactDOMFiber.unstable_createPortal()

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -488,6 +488,10 @@ src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
 * finds the first child when a component returns a fragment
 * finds the first child even when fragment is nested
 * finds the first child even when first child renders null
+* should render portal children
+* should pass portal context when rendering subtree elsewhere
+* should update portal context if it changes due to setState
+* should update portal context if it changes due to re-render
 
 src/renderers/dom/shared/__tests__/CSSProperty-test.js
 * should generate browser prefixes for its `isUnitlessNumber`

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -24,7 +24,6 @@ var ReactDOMInjection = require('ReactDOMInjection');
 var ReactFiberReconciler = require('ReactFiberReconciler');
 var ReactInstanceMap = require('ReactInstanceMap');
 var ReactPortal = require('ReactPortal');
-var ReactTypeOfWork = require('ReactTypeOfWork');
 
 var findDOMNode = require('findDOMNode');
 var invariant = require('invariant');
@@ -35,9 +34,6 @@ ReactControlledComponent.injection.injectFiberControlledHostComponent(
   ReactDOMFiberComponent
 );
 
-var {
-  Portal,
-} = ReactTypeOfWork;
 var {
   createElement,
   setInitialProperties,
@@ -72,11 +68,7 @@ function recursivelyAppendChildren(parent : Element, child : HostChildren<Instan
     /* As a result of the refinement issue this type isn't known. */
     let node : any = child;
     do {
-      // TODO: this is an implementation detail leaking into the renderer.
-      // Once we move output traversal to complete phase, we won't need this.
-      if (node.tag !== Portal) {
-        recursivelyAppendChildren(parent, node.output);
-      }
+      recursivelyAppendChildren(parent, node.output);
     } while (node = node.sibling);
   }
 }

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
@@ -186,4 +186,225 @@ describe('ReactDOMFiber', () => {
       expect(firstNode.tagName).toBe('DIV');
     });
   }
+
+  if (ReactDOMFeatureFlags.useFiber) {
+    it('should render portal children', () => {
+      var portalContainer1 = document.createElement('div');
+      var portalContainer2 = document.createElement('div');
+
+      var ops = [];
+      class Child extends React.Component {
+        componentDidMount() {
+          ops.push(`${this.props.name} componentDidMount`);
+        }
+        componentDidUpdate() {
+          ops.push(`${this.props.name} componentDidUpdate`);
+        }
+        componentWillUnmount() {
+          ops.push(`${this.props.name} componentWillUnmount`);
+        }
+        render() {
+          return <div>{this.props.name}</div>;
+        }
+      }
+
+      class Parent extends React.Component {
+        componentDidMount() {
+          ops.push(`Parent:${this.props.step} componentDidMount`);
+        }
+        componentDidUpdate() {
+          ops.push(`Parent:${this.props.step} componentDidUpdate`);
+        }
+        componentWillUnmount() {
+          ops.push(`Parent:${this.props.step} componentWillUnmount`);
+        }
+        render() {
+          const {step} = this.props;
+          return [
+            <Child name={`normal[0]:${step}`} />,
+            ReactDOM.unstable_createPortal(
+              <Child name={`portal1[0]:${step}`} />,
+              portalContainer1
+            ),
+            <Child name={`normal[1]:${step}`} />,
+            ReactDOM.unstable_createPortal(
+              [
+                <Child name={`portal2[0]:${step}`} />,
+                <Child name={`portal2[1]:${step}`} />,
+              ],
+              portalContainer2
+            ),
+          ];
+        }
+      }
+
+      ReactDOM.render(<Parent step="a" />, container);
+      expect(portalContainer1.innerHTML).toBe('<div>portal1[0]:a</div>');
+      expect(portalContainer2.innerHTML).toBe('<div>portal2[0]:a</div><div>portal2[1]:a</div>');
+      expect(container.innerHTML).toBe('<div>normal[0]:a</div><div>normal[1]:a</div>');
+      expect(ops).toEqual([
+        'normal[0]:a componentDidMount',
+        'portal1[0]:a componentDidMount',
+        'normal[1]:a componentDidMount',
+        'portal2[0]:a componentDidMount',
+        'portal2[1]:a componentDidMount',
+        'Parent:a componentDidMount',
+      ]);
+
+      ops.length = 0;
+      ReactDOM.render(<Parent step="b" />, container);
+      expect(portalContainer1.innerHTML).toBe('<div>portal1[0]:b</div>');
+      expect(portalContainer2.innerHTML).toBe('<div>portal2[0]:b</div><div>portal2[1]:b</div>');
+      expect(container.innerHTML).toBe('<div>normal[0]:b</div><div>normal[1]:b</div>');
+      expect(ops).toEqual([
+        'normal[0]:b componentDidUpdate',
+        'portal1[0]:b componentDidUpdate',
+        'normal[1]:b componentDidUpdate',
+        'portal2[0]:b componentDidUpdate',
+        'portal2[1]:b componentDidUpdate',
+        'Parent:b componentDidUpdate',
+      ]);
+
+      ops.length = 0;
+      ReactDOM.unmountComponentAtNode(container);
+      expect(portalContainer1.innerHTML).toBe('');
+      expect(portalContainer2.innerHTML).toBe('');
+      expect(container.innerHTML).toBe('');
+      expect(ops).toEqual([
+        'Parent:b componentWillUnmount',
+        'normal[0]:b componentWillUnmount',
+        'portal1[0]:b componentWillUnmount',
+        'normal[1]:b componentWillUnmount',
+        'portal2[0]:b componentWillUnmount',
+        'portal2[1]:b componentWillUnmount',
+      ]);
+    });
+
+    it('should pass portal context when rendering subtree elsewhere', () => {
+      var portalContainer = document.createElement('div');
+
+      class Component extends React.Component {
+        static contextTypes = {
+          foo: React.PropTypes.string.isRequired,
+        };
+
+        render() {
+          return <div>{this.context.foo}</div>;
+        }
+      }
+
+      class Parent extends React.Component {
+        static childContextTypes = {
+          foo: React.PropTypes.string.isRequired,
+        };
+
+        getChildContext() {
+          return {
+            foo: 'bar',
+          };
+        }
+
+        render() {
+          return ReactDOM.unstable_createPortal(
+            <Component />,
+            portalContainer
+          );
+        }
+      }
+
+      ReactDOM.render(<Parent />, container);
+      expect(container.innerHTML).toBe('');
+      expect(portalContainer.innerHTML).toBe('<div>bar</div>');
+    });
+
+    it('should update portal context if it changes due to setState', () => {
+      var portalContainer = document.createElement('div');
+
+      class Component extends React.Component {
+        static contextTypes = {
+          foo: React.PropTypes.string.isRequired,
+          getFoo: React.PropTypes.func.isRequired,
+        };
+
+        render() {
+          return <div>{this.context.foo + '-' + this.context.getFoo()}</div>;
+        }
+      }
+
+      class Parent extends React.Component {
+        static childContextTypes = {
+          foo: React.PropTypes.string.isRequired,
+          getFoo: React.PropTypes.func.isRequired,
+        };
+
+        state = {
+          bar: 'initial',
+        };
+
+        getChildContext() {
+          return {
+            foo: this.state.bar,
+            getFoo: () => this.state.bar,
+          };
+        }
+
+        render() {
+          return ReactDOM.unstable_createPortal(
+            <Component />,
+            portalContainer
+          );
+        }
+      }
+
+      var instance = ReactDOM.render(<Parent />, container);
+      expect(portalContainer.innerHTML).toBe('<div>initial-initial</div>');
+      expect(container.innerHTML).toBe('');
+      instance.setState({bar: 'changed'});
+      expect(portalContainer.innerHTML).toBe('<div>changed-changed</div>');
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('should update portal context if it changes due to re-render', () => {
+      var portalContainer = document.createElement('div');
+
+      class Component extends React.Component {
+        static contextTypes = {
+          foo: React.PropTypes.string.isRequired,
+          getFoo: React.PropTypes.func.isRequired,
+        };
+
+        render() {
+          return <div>{this.context.foo + '-' + this.context.getFoo()}</div>;
+        }
+      }
+
+      class Parent extends React.Component {
+        static childContextTypes = {
+          foo: React.PropTypes.string.isRequired,
+          getFoo: React.PropTypes.func.isRequired,
+        };
+
+        getChildContext() {
+          return {
+            foo: this.props.bar,
+            getFoo: () => this.props.bar,
+          };
+        }
+
+        render() {
+          return ReactDOM.unstable_createPortal(
+            <Component />,
+            portalContainer
+          );
+        }
+      }
+
+      ReactDOM.render(<Parent bar="initial" />, container);
+      expect(portalContainer.innerHTML).toBe('<div>initial-initial</div>');
+      expect(container.innerHTML).toBe('');
+      ReactDOM.render(<Parent bar="changed" />, container);
+      expect(portalContainer.innerHTML).toBe('<div>changed-changed</div>');
+      expect(container.innerHTML).toBe('');
+    });
+  }
 });

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -14,6 +14,7 @@
 
 import type { ReactFragment } from 'ReactTypes';
 import type { ReactCoroutine, ReactYield } from 'ReactCoroutine';
+import type { ReactPortal } from 'ReactPortal';
 import type { TypeOfWork } from 'ReactTypeOfWork';
 import type { TypeOfSideEffect } from 'ReactTypeOfSideEffect';
 import type { PriorityLevel } from 'ReactPriorityLevel';
@@ -29,6 +30,7 @@ var {
   CoroutineComponent,
   YieldComponent,
   Fragment,
+  Portal,
 } = ReactTypeOfWork;
 
 var {
@@ -336,5 +338,16 @@ exports.createFiberFromCoroutine = function(coroutine : ReactCoroutine, priority
 exports.createFiberFromYield = function(yieldNode : ReactYield, priorityLevel : PriorityLevel) : Fiber {
   const fiber = createFiber(YieldComponent, yieldNode.key);
   fiber.pendingProps = {};
+  return fiber;
+};
+
+exports.createFiberFromPortal = function(portal : ReactPortal, priorityLevel : PriorityLevel) : Fiber {
+  const fiber = createFiber(Portal, portal.key);
+  fiber.pendingProps = portal.children;
+  fiber.pendingWorkPriority = priorityLevel;
+  fiber.stateNode = {
+    containerInfo: portal.containerInfo,
+    implementation: portal.implementation,
+  };
   return fiber;
 };

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -45,6 +45,7 @@ var {
   CoroutineHandlerPhase,
   YieldComponent,
   Fragment,
+  Portal,
 } = ReactTypeOfWork;
 var {
   NoWork,
@@ -298,6 +299,10 @@ module.exports = function<T, P, I, TI, C>(
     reconcileChildren(current, workInProgress, coroutine.children);
   }
 
+  function updatePortalComponent(current, workInProgress) {
+    reconcileChildren(current, workInProgress, workInProgress.pendingProps);
+  }
+
   /*
   function reuseChildrenEffects(returnFiber : Fiber, firstChild : Fiber) {
     let child = firstChild;
@@ -450,6 +455,10 @@ module.exports = function<T, P, I, TI, C>(
         // A yield component is just a placeholder, we can just run through the
         // next one immediately.
         return null;
+      case Portal:
+        updatePortalComponent(current, workInProgress);
+        // TODO: is this right?
+        return workInProgress.child;
       case Fragment:
         updateFragment(current, workInProgress);
         return workInProgress.child;

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -22,6 +22,7 @@ var {
   HostContainer,
   HostComponent,
   HostText,
+  Portal,
 } = ReactTypeOfWork;
 var { callCallbacks } = require('ReactFiberUpdateQueue');
 
@@ -253,6 +254,11 @@ module.exports = function<T, P, I, TI, C>(
         detachRef(current);
         return;
       }
+      case Portal: {
+        const containerInfo : C = current.stateNode.containerInfo;
+        updateContainer(containerInfo, null);
+        return;
+      }
     }
   }
 
@@ -289,6 +295,12 @@ module.exports = function<T, P, I, TI, C>(
         const newText : string = finishedWork.memoizedProps;
         const oldText : string = current.memoizedProps;
         commitTextUpdate(textInstance, oldText, newText);
+        return;
+      }
+      case Portal: {
+        const children = finishedWork.output;
+        const containerInfo : C = finishedWork.stateNode.containerInfo;
+        updateContainer(containerInfo, children);
         return;
       }
       default:
@@ -351,6 +363,10 @@ module.exports = function<T, P, I, TI, C>(
       }
       case HostText: {
         // We have no life-cycles associated with text.
+        return;
+      }
+      case Portal: {
+        // We have no life-cycles associated with portals.
         return;
       }
       default:

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -298,7 +298,7 @@ module.exports = function<T, P, I, TI, C>(
         return;
       }
       case Portal: {
-        const children = finishedWork.output;
+        const children = finishedWork.child;
         const containerInfo : C = finishedWork.stateNode.containerInfo;
         updateContainer(containerInfo, children);
         return;

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -64,11 +64,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
     // If we have a single result, we just pass that through as the output to
     // avoid unnecessary traversal. When we have multiple output, we just pass
     // the linked list of fibers that has the individual output values.
-    if (!child || child.tag === Portal) {
-      returnFiber.output = null;
-    } else {
-      returnFiber.output = child.sibling ? child : child.output;
-    }
+    returnFiber.output = (child && !child.sibling) ? child.output : child;
     returnFiber.memoizedProps = returnFiber.pendingProps;
   }
 
@@ -257,8 +253,9 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
         transferOutput(workInProgress.child, workInProgress);
         return null;
       case Portal:
-        transferOutput(workInProgress.child, workInProgress);
         markUpdate(workInProgress);
+        workInProgress.output = null;
+        workInProgress.memoizedProps = workInProgress.pendingProps;
         return null;
 
       // Error cases

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -36,6 +36,7 @@ var {
   CoroutineHandlerPhase,
   YieldComponent,
   Fragment,
+  Portal,
 } = ReactTypeOfWork;
 var {
   Update,
@@ -63,7 +64,11 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
     // If we have a single result, we just pass that through as the output to
     // avoid unnecessary traversal. When we have multiple output, we just pass
     // the linked list of fibers that has the individual output values.
-    returnFiber.output = (child && !child.sibling) ? child.output : child;
+    if (!child || child.tag === Portal) {
+      returnFiber.output = null;
+    } else {
+      returnFiber.output = child.sibling ? child : child.output;
+    }
     returnFiber.memoizedProps = returnFiber.pendingProps;
   }
 
@@ -250,6 +255,10 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
         return null;
       case Fragment:
         transferOutput(workInProgress.child, workInProgress);
+        return null;
+      case Portal:
+        transferOutput(workInProgress.child, workInProgress);
+        markUpdate(workInProgress);
         return null;
 
       // Error cases

--- a/src/renderers/shared/fiber/ReactTypeOfWork.js
+++ b/src/renderers/shared/fiber/ReactTypeOfWork.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-export type TypeOfWork = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+export type TypeOfWork = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
 
 module.exports = {
   IndeterminateComponent: 0, // Before we know whether it is functional or class
@@ -25,4 +25,5 @@ module.exports = {
   CoroutineHandlerPhase: 7,
   YieldComponent: 8,
   Fragment: 9,
+  Portal: 10, // A subtree. Could be an entry point to a different renderer.
 };

--- a/src/renderers/shared/fiber/isomorphic/ReactPortal.js
+++ b/src/renderers/shared/fiber/isomorphic/ReactPortal.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactPortal
+ * @flow
+ */
+
+'use strict';
+
+import type { ReactNodeList } from 'ReactTypes';
+
+// The Symbol used to tag the special React types. If there is no native Symbol
+// nor polyfill, then a plain number is used for performance.
+var REACT_PORTAL_TYPE =
+  (typeof Symbol === 'function' && Symbol.for && Symbol.for('react.portal')) ||
+  0xeaca;
+
+export type ReactPortal = {
+  $$typeof: Symbol | number,
+  key: null | string,
+  containerInfo: any,
+  children : ReactNodeList,
+  // TODO: figure out the API for cross-renderer implementation.
+  implementation: any,
+};
+
+exports.createPortal = function(
+  children : ReactNodeList,
+  containerInfo : any,
+  // TODO: figure out the API for cross-renderer implementation.
+  implementation: any,
+  key : ?string = null
+) : ReactPortal {
+  return {
+    // This tag allow us to uniquely identify this as a React Portal
+    $$typeof: REACT_PORTAL_TYPE,
+    key: key == null ? null : '' + key,
+    children,
+    containerInfo,
+    implementation,
+  };
+};
+
+/**
+ * Verifies the object is a portal object.
+ */
+exports.isPortal = function(object : mixed) : boolean {
+  return (
+    typeof object === 'object' &&
+    object !== null &&
+    object.$$typeof === REACT_PORTAL_TYPE
+  );
+};
+
+exports.REACT_PORTAL_TYPE = REACT_PORTAL_TYPE;

--- a/src/renderers/shared/fiber/isomorphic/ReactTypes.js
+++ b/src/renderers/shared/fiber/isomorphic/ReactTypes.js
@@ -14,7 +14,9 @@
 
 import type { ReactCoroutine, ReactYield } from 'ReactCoroutine';
 
-export type ReactNode = ReactElement<any> | ReactCoroutine | ReactYield | ReactText | ReactFragment;
+import type { ReactPortal } from 'ReactPortal';
+
+export type ReactNode = ReactElement<any> | ReactCoroutine | ReactYield | ReactText | ReactFragment | ReactPortal;
 
 export type ReactFragment = ReactEmpty | Iterable<ReactNode>;
 

--- a/src/renderers/shared/fiber/isomorphic/ReactTypes.js
+++ b/src/renderers/shared/fiber/isomorphic/ReactTypes.js
@@ -13,10 +13,9 @@
 'use strict';
 
 import type { ReactCoroutine, ReactYield } from 'ReactCoroutine';
-
 import type { ReactPortal } from 'ReactPortal';
 
-export type ReactNode = ReactElement<any> | ReactCoroutine | ReactYield | ReactText | ReactFragment | ReactPortal;
+export type ReactNode = ReactElement<any> | ReactCoroutine | ReactYield | ReactPortal | ReactText | ReactFragment;
 
 export type ReactFragment = ReactEmpty | Iterable<ReactNode>;
 


### PR DESCRIPTION
While #8368 added a version of `ReactDOM.unstable_renderSubtreeIntoContainer()` to Fiber, it is a bit hacky and, more importantly, incompatible with Fiber goals. Since it encourages performing portal work in lifecycles, it stretches the commit phase and prevents slicing that work, potentially negating Fiber benefits.

This PR adds a first version of a declarative API meant to replace `ReactDOM.unstable_renderSubtreeIntoContainer()`. The API is a declarative way to render subtrees into DOM node containers.

It looks like this:

```js
function WelcomePopup() {
  return <h2>Welcome</h2>;
}

function App() {
  return (
    <div>
      <h1>Hi</h1>
      {ReactDOM.unstable_createPortal(
        <WelcomePopup />,
        document.getElementById('popup-container')
      )}
    </div>
  )
}
```

Fiber treats it as a regular slice-able work and commits the subtrees according to depth, like normal components. Context updates "just work" because of this. I copied the subtree tests, modified them to use the new API, and added them to `ReactDOMFiber-test` since it's a Fiber-specific feature. I also added some more assertions around the lifecycle order and ensuring node removal.

There are a few missing pieces:

* Only DOM node is accepted as a container. I'm not sure if we should accept a `() => node` instead because node might not be ready yet. This also doesn't play with server rendering, but since the support is baked into reconciler we can add `ReactDOMServer.createPortal(element, stream)` someday (note: not an actual API, I’m just showing potential future directions as discussed with @sebmarkbage).

* The portal object has a reserved `implementation` field that is currently unused. It will be used for supporting cross-renderer portals (e.g. ART inside DOM). It will contain `{ beginWork, completeWork, commitWork }` or something similar of the nested renderer. The parent renderer will still be responsible for scheduling, but will forward work to a nested renderer when it's inside a portal.

* We will need to keep track of the roots on the stack so that we can fix `document.body` hack in `ReactDOMFiber`.

* We still use `updateContainer` which is hacky since it replaces all children. The plan is to eventually move the output traversal to the complete phase, and let the renderer provide `*ToContainer` overloads of `appendChild`, `insertBefore`, and friends.

This is merely a first step towards supporting portals in Fiber, and it is not complete, but I want to land it so that we have the basics (like we do with coroutines) and don't regress on them.

Next I will work on SVGs and try to reuse this primitive for them.