### PR TITLE
Preserve scroll position when restoring focus

### DIFF
--- a/src/renderers/dom/shared/ReactInputSelection.js
+++ b/src/renderers/dom/shared/ReactInputSelection.js
@@ -66,7 +66,27 @@ var ReactInputSelection = {
           priorSelectionRange
         );
       }
+
+      // Focusing a node can change the scroll position, which is undesirable
+      const ancestors = [];
+      let ancestor = priorFocusedElem;
+      while ((ancestor = ancestor.parentNode)) {
+        if (ancestor.nodeType === 1) {
+          ancestors.push({
+            element: ancestor,
+            left: ancestor.scrollLeft,
+            top: ancestor.scrollTop,
+          });
+        }
+      }
+
       focusNode(priorFocusedElem);
+
+      for (let i = 0; i < ancestors.length; i++) {
+        const ancestor = ancestors[i];
+        ancestor.element.scrollLeft = ancestor.left;
+        ancestor.element.scrollTop = ancestor.top;
+      }
     }
   },
 


### PR DESCRIPTION
This misbehavior is particularly egregious because of our current strategy for updating a container in Fiber, but regardless -- if we restore focus to an offscreen node (ex: because it was reordered among its siblings) then we should not scroll the page to reveal it.

We could check the `overflow` computed style values before saving the scroll positions but that's unlikely to be any faster.