### PR TITLE
[Fiber] Remove output field

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1031,6 +1031,7 @@ src/renderers/shared/__tests__/ReactPerf-test.js
 
 src/renderers/shared/fiber/__tests__/ReactCoroutine-test.js
 * should render a coroutine
+* should unmount a composite in a coroutine
 
 src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
 * should render a simple component

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -294,14 +294,14 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       // Insert
       const reifiedYield = createReifiedYield(yieldNode);
       const created = createFiberFromYield(yieldNode, priority);
-      created.output = reifiedYield;
+      created.type = reifiedYield;
       created.return = returnFiber;
       return created;
     } else {
       // Move based on index
       const existing = useFiber(current, priority);
-      existing.output = createUpdatedReifiedYield(
-        current.output,
+      existing.type = createUpdatedReifiedYield(
+        current.type,
         yieldNode
       );
       existing.return = returnFiber;
@@ -386,7 +386,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         case REACT_YIELD_TYPE: {
           const reifiedYield = createReifiedYield(newChild);
           const created = createFiberFromYield(newChild, priority);
-          created.output = reifiedYield;
+          created.type = reifiedYield;
           created.return = returnFiber;
           return created;
         }
@@ -790,8 +790,8 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         if (child.tag === YieldComponent) {
           deleteRemainingChildren(returnFiber, child.sibling);
           const existing = useFiber(child, priority);
-          existing.output = createUpdatedReifiedYield(
-            child.output,
+          existing.type = createUpdatedReifiedYield(
+            child.type,
             yieldNode
           );
           existing.return = returnFiber;
@@ -808,7 +808,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
     const reifiedYield = createReifiedYield(yieldNode);
     const created = createFiberFromYield(yieldNode, priority);
-    created.output = reifiedYield;
+    created.type = reifiedYield;
     created.return = returnFiber;
     return created;
   }

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -97,9 +97,6 @@ export type Fiber = {
   memoizedState: any,
   // Linked list of callbacks to call after updates are committed.
   callbackList: ?UpdateQueue,
-  // Output is the return value of this fiber, or a linked list of return values
-  // if this returns multiple values. Such as a fragment.
-  output: any, // This type will be more specific once we overload the tag.
 
   // Effect
   effectTag: TypeOfSideEffect,
@@ -190,7 +187,6 @@ var createFiber = function(tag : TypeOfWork, key : null | string) : Fiber {
     updateQueue: null,
     memoizedState: null,
     callbackList: null,
-    output: null,
 
     effectTag: NoEffect,
     nextEffect: null,
@@ -267,7 +263,6 @@ exports.cloneFiber = function(fiber : Fiber, priorityLevel : PriorityLevel) : Fi
 
   alt.memoizedProps = fiber.memoizedProps;
   alt.memoizedState = fiber.memoizedState;
-  alt.output = fiber.output;
 
   return alt;
 };

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -21,6 +21,7 @@ var {
   HostContainer,
   HostComponent,
   HostText,
+  CoroutineComponent,
   Portal,
 } = ReactTypeOfWork;
 var { callCallbacks } = require('ReactFiberUpdateQueue');
@@ -276,6 +277,10 @@ module.exports = function<T, P, I, TI, C>(
       }
       case HostComponent: {
         detachRef(current);
+        return;
+      }
+      case CoroutineComponent: {
+        commitNestedUnmounts(current.stateNode);
         return;
       }
     }

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -14,7 +14,6 @@
 
 import type { Fiber } from 'ReactFiber';
 import type { FiberRoot } from 'ReactFiberRoot';
-import type { TypeOfWork } from 'ReactTypeOfWork';
 import type { PriorityLevel } from 'ReactPriorityLevel';
 
 var {
@@ -38,10 +37,6 @@ var getContextForSubtree = require('getContextForSubtree');
 export type Deadline = {
   timeRemaining : () => number
 };
-
-type HostChildNode<I> = { tag: TypeOfWork, output: HostChildren<I>, sibling: any };
-
-export type HostChildren<I> = null | void | I | HostChildNode<I>;
 
 type OpaqueNode = Fiber;
 

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -286,6 +286,12 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
       workInProgress.pendingProps = null;
       workInProgress.updateQueue = null;
 
+      if (next) {
+        // If completing this work spawned new work, do that next. We'll come
+        // back here again.
+        return next;
+      }
+
       const returnFiber = workInProgress.return;
 
       if (returnFiber) {
@@ -318,10 +324,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
         }
       }
 
-      if (next) {
-        // If completing this work spawned new work, do that next.
-        return next;
-      } else if (workInProgress.sibling) {
+      if (workInProgress.sibling) {
         // If there is more work to do in this returnFiber, do that next.
         return workInProgress.sibling;
       } else if (returnFiber) {

--- a/src/renderers/shared/fiber/__tests__/ReactCoroutine-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactCoroutine-test.js
@@ -24,9 +24,7 @@ describe('ReactCoroutine', () => {
   });
 
   it('should render a coroutine', () => {
-
     var ops = [];
-
 
     function Continuation({ isSame }) {
       ops.push(['Continuation', isSame]);
@@ -84,7 +82,72 @@ describe('ReactCoroutine', () => {
       ['Continuation', true],
       ['Continuation', false],
     ]);
-
   });
 
+  it('should unmount a composite in a coroutine', () => {
+    var ops = [];
+
+    class Continuation extends React.Component {
+      render() {
+        ops.push('Continuation');
+        return <div />;
+      }
+      componentWillUnmount() {
+        ops.push('Unmount Continuation');
+      }
+    }
+
+    class Child extends React.Component {
+      render() {
+        ops.push('Child');
+        return ReactCoroutine.createYield({}, Continuation, null);
+      }
+      componentWillUnmount() {
+        ops.push('Unmount Child');
+      }
+    }
+
+    function HandleYields(props, yields) {
+      ops.push('HandleYields');
+      return yields.map(y => <y.continuation />);
+    }
+
+    class Parent extends React.Component {
+      render() {
+        ops.push('Parent');
+        return ReactCoroutine.createCoroutine(
+          this.props.children,
+          HandleYields,
+          this.props
+        );
+      }
+      componentWillUnmount() {
+        ops.push('Unmount Parent');
+      }
+    }
+
+    ReactNoop.render(<Parent><Child /></Parent>);
+    ReactNoop.flush();
+
+    expect(ops).toEqual([
+      'Parent',
+      'Child',
+      'HandleYields',
+      'Continuation',
+    ]);
+
+    ops = [];
+
+    ReactNoop.render(<div />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual([
+      'Unmount Parent',
+      // TODO: This should happen in the order Child, Continuation which it
+      // will once we swap stateNode and child positions of these.
+      'Unmount Continuation',
+      'Unmount Child',
+    ]);
+
+  });
 });


### PR DESCRIPTION
The idea was originally that each fiber has a return value. In practice most of what we're modeling here are void functions and we track side effects instead of return values.

We do use this for coroutines to short cut access to terminal yields. However, since this can be nested fragments we end up searching the tree anyway. We also have to manage this in transferOutput so it ends up being as expensive. Maybe we can save some traversal for updates when coroutine branches bail out but meh.

Swapped the `.child` and `.stateNode` on coroutines so that `.stateNode` is the first phase and `.child` is the completed phase. This is a bit more useful.

Unmount nodes from the first phase when the parent is unmounted.