### PR TITLE
[Fiber] [Do not merge: failing] Add failing tests for coroutines

### DIFF
--- a/src/renderers/shared/fiber/__tests__/ReactCoroutine-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactCoroutine-test.js
@@ -23,12 +23,21 @@ describe('ReactCoroutine', () => {
     ReactCoroutine = require('ReactCoroutine');
   });
 
+  function div(...children) {
+    children = children.map(c => typeof c === 'string' ? { text: c } : c);
+    return { type: 'div', children, prop: undefined };
+  }
+
+  function span(prop) {
+    return { type: 'span', children: [], prop };
+  }
+
   it('should render a coroutine', () => {
     var ops = [];
 
     function Continuation({ isSame }) {
       ops.push(['Continuation', isSame]);
-      return <span>{isSame ? 'foo==bar' : 'foo!=bar'}</span>;
+      return <span prop={isSame ? 'foo==bar' : 'foo!=bar'} />;
     }
 
     // An alternative API could mark Continuation as something that needs
@@ -81,6 +90,64 @@ describe('ReactCoroutine', () => {
       // Continue yields
       ['Continuation', true],
       ['Continuation', false],
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([
+      div(
+        span('foo==bar'),
+        span('foo!=bar'),
+      ),
+    ]);
+  });
+
+  it('should update a coroutine', () => {
+    function Continuation({ isSame }) {
+      return <span prop={isSame ? 'foo==bar' : 'foo!=bar'} />;
+    }
+
+    function Child({ bar }) {
+      return ReactCoroutine.createYield({
+        bar: bar,
+      }, Continuation, null);
+    }
+
+    function Indirection() {
+      return [<Child bar={true} />, <Child bar={false} />];
+    }
+
+    function HandleYields(props, yields) {
+      return yields.map(y =>
+        <y.continuation isSame={props.foo === y.props.bar} />
+      );
+    }
+
+    function Parent(props) {
+      return ReactCoroutine.createCoroutine(
+        props.children,
+        HandleYields,
+        props
+      );
+    }
+
+    function App(props) {
+      return <div><Parent foo={props.foo}><Indirection /></Parent></div>;
+    }
+
+    ReactNoop.render(<App foo={true} />);
+    ReactNoop.flush();
+    expect(ReactNoop.getChildren()).toEqual([
+      div(
+        span('foo==bar'),
+        span('foo!=bar'),
+      ),
+    ]);
+
+    ReactNoop.render(<App foo={false} />);
+    ReactNoop.flush();
+    expect(ReactNoop.getChildren()).toEqual([
+      div(
+        span('foo!=bar'),
+        span('foo==bar'),
+      ),
     ]);
   });
 


### PR DESCRIPTION
There are a few different issues:

* Updates result in unnecessary duplicate placements because it can't find the current fiber for continuations.
* When run together, coroutine update and unmounting tests appear to lock down in an infinite loop. They don't freeze in isolation.

I don't have a solution for this but just leaving it for future fixes.
