### PR TITLE
[Fiber] Fix portal unmounting

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -489,7 +489,8 @@ src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
 * finds the first child when a component returns a fragment
 * finds the first child even when fragment is nested
 * finds the first child even when first child renders null
-* should render portal children
+* should render one portal
+* should render many portals
 * should render nested portals
 * should pass portal context when rendering subtree elsewhere
 * should update portal context if it changes due to setState

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
@@ -188,7 +188,27 @@ describe('ReactDOMFiber', () => {
   }
 
   if (ReactDOMFeatureFlags.useFiber) {
-    it('should render portal children', () => {
+    it('should render one portal', () => {
+      var portalContainer = document.createElement('div');
+
+      ReactDOM.render(
+        <div>
+          {ReactDOM.unstable_createPortal(
+            <div>portal</div>,
+            portalContainer
+          )}
+        </div>,
+        container
+      );
+      expect(portalContainer.innerHTML).toBe('<div>portal</div>');
+      expect(container.innerHTML).toBe('<div></div>');
+
+      ReactDOM.unmountComponentAtNode(container);
+      expect(portalContainer.innerHTML).toBe('');
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('should render many portals', () => {
       var portalContainer1 = document.createElement('div');
       var portalContainer2 = document.createElement('div');
 

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -283,6 +283,11 @@ module.exports = function<T, P, I, TI, C>(
         commitNestedUnmounts(current.stateNode);
         return;
       }
+      case Portal: {
+        // TODO: this is recursive.
+        commitDeletion(current);
+        return;
+      }
     }
   }
 


### PR DESCRIPTION
We used to terminate the search on host nodes, and then use the nested unmount algorithm.
However this means we didn't unmount portals inside the host nodes.

We will probably need to restructure this somehow but for now I just added a recursive call to unblock myself.