### PR TITLE
[Fiber] Add tests for recovery from errors thrown in the reconciler

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1087,6 +1087,9 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
 * can schedule updates after uncaught error during umounting
 * continues work on other roots despite caught errors
 * continues work on other roots despite uncaught errors
+* catches reconciler errors in a boundary during mounting
+* catches reconciler errors in a boundary during update
+* recovers from uncaught reconciler errors
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalReflection-test.js
 * handles isMounted even when the initial render is deferred


### PR DESCRIPTION
Test that errors in the reconciler can be caught by error boundaries, and that we can still schedule updates if they are uncaught.

I want to get this in because #8304 is regressing on them.