### PR TITLE
Ensure ReactTransitionGroup.state.children is always object 

### DIFF
--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -37,7 +37,7 @@ class ReactTransitionGroup extends React.Component {
 
   state = {
     // TODO: can we get useful debug information to show at this point?
-    children: ReactTransitionChildMapping.getChildMapping(this.props.children),
+    children: ReactTransitionChildMapping.getChildMapping(this.props.children) || {},
   };
 
   componentWillMount() {


### PR DESCRIPTION
Since `ReactTransitionGroup` uses a` for .. in` loop on `this.state.children`, it seems best to make sure that it is always looping an object. Currently, it can end up looping a non-object falsey value, which can cause errors (e.g. in my case, another library was extending the String prototype with enumerable properties).

There were two failing tests and 7 lint warnings on my system before and after making this change.
