### PR TITLE
add dependencies to react-test-renderer and react-addons

### DIFF
--- a/packages/react-addons/package.json
+++ b/packages/react-addons/package.json
@@ -8,7 +8,10 @@
     "react-addon"
   ],
   "license": "BSD-3-Clause",
-  "dependencies": {},
+  "dependencies": {
+    "fbjs": "^0.8.4",
+    "object-assign": "^4.1.0"
+  },
   "peerDependencies": {
     "react": "^16.0.0-alpha"
   },

--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/facebook/react/issues"
   },
   "homepage": "https://facebook.github.io/react/",
+  "dependencies": {
+    "fbjs": "^0.8.4",
+    "object-assign": "^4.1.0"
+  },
   "peerDependencies": {
     "react": "^16.0.0-alpha"
   },


### PR DESCRIPTION
**What** and **Why**:

* When using npm version 2, `object-assign` and `fbjs` were not installed
* This PR adds `object-assign` and `fbjs` as explicit dependencies to both `react-test-renderer` and `react-addons`