### PR TITLE
Add test for unmount/remount in a single batch

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -118,6 +118,7 @@ src/renderers/shared/shared/__tests__/ReactUpdates-test.js
 * throws in setState if the update callback is not a function
 * throws in replaceState if the update callback is not a function
 * throws in forceUpdate if the update callback is not a function
+* unmounts and remounts a root in the same batch
 
 src/renderers/shared/shared/__tests__/refs-test.js
 * Should increase refs with an increase in divs

--- a/src/renderers/shared/shared/__tests__/ReactUpdates-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactUpdates-test.js
@@ -1081,4 +1081,14 @@ describe('ReactUpdates', () => {
     });
     expect(result).toEqual(42);
   });
+
+  it('unmounts and remounts a root in the same batch', () => {
+    var container = document.createElement('div');
+    ReactDOM.render(<span>a</span>, container);
+    ReactDOM.unstable_batchedUpdates(function() {
+      ReactDOM.unmountComponentAtNode(container);
+      ReactDOM.render(<span>b</span>, container);
+    });
+    expect(container.textContent).toBe('b');
+  });
 });


### PR DESCRIPTION
Fails in Fiber. Could be fixed by clearing the container at commit time rather than in ReactDOMFiber.render synchronously.