### PR TITLE
[Fiber] Support SVG

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -235,7 +235,11 @@ var DOMRenderer = ReactFiberReconciler({
     portalStateIndex--;
   },
 
-  // TODO: unwind host context on errors and consider portals.
+  resetHostContext() : void {
+    currentNamespaceURI = null;
+    foreignObjectDepth = 0;
+    portalStateIndex = -1;
+  },
 
   prepareForCommit() : void {
     eventsEnabled = ReactBrowserEventEmitter.isEnabled();

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -15,7 +15,6 @@
 'use strict';
 
 var CSSPropertyOperations = require('CSSPropertyOperations');
-var DOMNamespaces = require('DOMNamespaces');
 var DOMProperty = require('DOMProperty');
 var DOMPropertyOperations = require('DOMPropertyOperations');
 var EventPluginRegistry = require('EventPluginRegistry');
@@ -453,43 +452,19 @@ function updateDOMProperties(
 
 var ReactDOMFiberComponent = {
 
-  // TODO: Use this to keep track of changes to the host context and use this
-  // to determine whether we switch to svg and back.
-  // TODO: Does this need to check the current namespace? In case these tags
-  // happen to be valid in some other namespace.
-  isNewHostContainer(tag : string) {
-    return tag === 'svg' || tag === 'foreignobject';
-  },
-
   createElement(
     tag : string,
     props : Object,
+    namespaceURI : string | null,
     rootContainerElement : Element
   ) : Element {
     validateDangerousTag(tag);
     // TODO:
     // tag.toLowerCase(); Do we need to apply lower case only on non-custom elements?
 
-    // We create tags in the namespace of their parent container, except HTML
-    // tags get no namespace.
-    var namespaceURI = rootContainerElement.namespaceURI;
-    if (namespaceURI == null ||
-        namespaceURI === DOMNamespaces.svg &&
-        rootContainerElement.tagName === 'foreignObject') {
-      namespaceURI = DOMNamespaces.html;
-    }
-    if (namespaceURI === DOMNamespaces.html) {
-      if (tag === 'svg') {
-        namespaceURI = DOMNamespaces.svg;
-      } else if (tag === 'math') {
-        namespaceURI = DOMNamespaces.mathml;
-      }
-      // TODO: Make this a new root container element.
-    }
-
     var ownerDocument = rootContainerElement.ownerDocument;
     var domElement : Element;
-    if (namespaceURI === DOMNamespaces.html) {
+    if (namespaceURI == null) {
       if (tag === 'script') {
         // Create the script via .innerHTML so its "parser-inserted" flag is
         // set to true and it does not execute

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
@@ -333,6 +333,42 @@ describe('ReactDOMFiber', () => {
       expect(container.innerHTML).toBe('');
     });
 
+    it('should not apply SVG mode across portals', () => {
+      var portalContainer = document.createElement('div');
+
+      ReactDOM.render(
+        <svg>
+          <image xlinkHref="http://i.imgur.com/w7GCRPb.png" />
+          {ReactDOM.unstable_createPortal(
+            <div>portal</div>,
+            portalContainer
+          )}
+          <image xlinkHref="http://i.imgur.com/w7GCRPb.png" />
+        </svg>,
+        container
+      );
+
+      const div = portalContainer.childNodes[0];
+      const image1 = container.firstChild.childNodes[0];
+      const image2 = container.firstChild.childNodes[1];
+      expect(div.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
+      expect(div.tagName).toBe('DIV');
+      expect(image1.namespaceURI).toBe('http://www.w3.org/2000/svg');
+      expect(image1.tagName).toBe('image');
+      expect(
+        image1.getAttributeNS('http://www.w3.org/1999/xlink', 'href')
+      ).toBe('http://i.imgur.com/w7GCRPb.png');
+      expect(image2.namespaceURI).toBe('http://www.w3.org/2000/svg');
+      expect(image2.tagName).toBe('image');
+      expect(
+        image2.getAttributeNS('http://www.w3.org/1999/xlink', 'href')
+      ).toBe('http://i.imgur.com/w7GCRPb.png');
+
+      ReactDOM.unmountComponentAtNode(container);
+      expect(portalContainer.innerHTML).toBe('');
+      expect(container.innerHTML).toBe('');
+    });
+
     it('should pass portal context when rendering subtree elsewhere', () => {
       var portalContainer = document.createElement('div');
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMSVG-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMSVG-test.js
@@ -12,12 +12,14 @@
 'use strict';
 
 var React;
+var ReactDOM;
 var ReactDOMServer;
 
 describe('ReactDOMSVG', () => {
 
   beforeEach(() => {
     React = require('React');
+    ReactDOM = require('ReactDOM');
     ReactDOMServer = require('ReactDOMServer');
   });
 
@@ -28,6 +30,102 @@ describe('ReactDOMSVG', () => {
       </svg>
     );
     expect(markup).toContain('xlink:href="http://i.imgur.com/w7GCRPb.png"');
+  });
+
+  it('creates elements with SVG namespace inside SVG tag during mount', () => {
+    var node = document.createElement('div');
+    var div, foreignDiv, foreignObject, g, image, image2, p, svg;
+    ReactDOM.render(
+      <div>
+        <svg ref={el => svg = el}>
+          <g ref={el => g = el} strokeWidth="5">
+            <image ref={el => image = el} xlinkHref="http://i.imgur.com/w7GCRPb.png" />
+            <foreignObject ref={el => foreignObject = el}>
+              <div ref={el => foreignDiv = el} />
+            </foreignObject>
+          </g>
+        </svg>
+        <p ref={el => p = el}>
+          <svg>
+            <image ref={el => image2 = el} xlinkHref="http://i.imgur.com/w7GCRPb.png" />
+          </svg>
+        </p>
+        <div ref={el => div = el} />
+      </div>,
+      node
+    );
+    // SVG tagName is case sensitive.
+    expect(svg.namespaceURI).toBe('http://www.w3.org/2000/svg');
+    expect(svg.tagName).toBe('svg');
+    expect(g.namespaceURI).toBe('http://www.w3.org/2000/svg');
+    expect(g.tagName).toBe('g');
+    expect(g.getAttribute('stroke-width')).toBe('5');
+    expect(image.namespaceURI).toBe('http://www.w3.org/2000/svg');
+    expect(image.tagName).toBe('image');
+    expect(
+      image.getAttributeNS('http://www.w3.org/1999/xlink', 'href')
+    ).toBe('http://i.imgur.com/w7GCRPb.png');
+    expect(foreignObject.namespaceURI).toBe('http://www.w3.org/2000/svg');
+    expect(foreignObject.tagName).toBe('foreignObject');
+    expect(image2.namespaceURI).toBe('http://www.w3.org/2000/svg');
+    expect(image2.tagName).toBe('image');
+    expect(
+      image2.getAttributeNS('http://www.w3.org/1999/xlink', 'href')
+    ).toBe('http://i.imgur.com/w7GCRPb.png');
+    // DOM tagName is capitalized by browsers.
+    expect(p.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
+    expect(p.tagName).toBe('P');
+    expect(div.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
+    expect(div.tagName).toBe('DIV');
+    expect(foreignDiv.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
+    expect(foreignDiv.tagName).toBe('DIV');
+  });
+
+  it('creates elements with SVG namespace inside SVG tag during update', () => {
+    var inst, foreignObject, foreignDiv, g, image, svg;
+
+    class App extends React.Component {
+      state = {step: 0};
+      render() {
+        inst = this;
+        const {step} = this.state;
+        if (step === 0) {
+          return null;
+        }
+        return (
+          <g ref={el => g = el} strokeWidth="5">
+            <image ref={el => image = el} xlinkHref="http://i.imgur.com/w7GCRPb.png" />
+            <foreignObject ref={el => foreignObject = el}>
+              <div ref={el => foreignDiv = el} />
+            </foreignObject>
+          </g>
+        );
+      }
+    }
+
+    var node = document.createElement('div');
+    ReactDOM.render(
+      <svg ref={el => svg = el}>
+        <App />
+      </svg>,
+      node
+    );
+    inst.setState({step: 1});
+
+    expect(svg.namespaceURI).toBe('http://www.w3.org/2000/svg');
+    expect(svg.tagName).toBe('svg');
+    expect(g.namespaceURI).toBe('http://www.w3.org/2000/svg');
+    expect(g.tagName).toBe('g');
+    expect(g.getAttribute('stroke-width')).toBe('5');
+    expect(image.namespaceURI).toBe('http://www.w3.org/2000/svg');
+    expect(image.tagName).toBe('image');
+    expect(
+      image.getAttributeNS('http://www.w3.org/1999/xlink', 'href')
+    ).toBe('http://i.imgur.com/w7GCRPb.png');
+    expect(foreignObject.namespaceURI).toBe('http://www.w3.org/2000/svg');
+    expect(foreignObject.tagName).toBe('foreignObject');
+    expect(foreignDiv.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
+    expect(foreignDiv.tagName).toBe('DIV');
   });
 
 });

--- a/src/renderers/dom/shared/__tests__/ReactDOMSVG-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMSVG-test.js
@@ -34,55 +34,65 @@ describe('ReactDOMSVG', () => {
 
   it('creates elements with SVG namespace inside SVG tag during mount', () => {
     var node = document.createElement('div');
-    var div, foreignDiv, foreignObject, g, image, image2, p, svg;
+    var div, div2, div3, foreignObject, foreignObject2, g, image, image2, image3, p, svg, svg2, svg3, svg4;
     ReactDOM.render(
       <div>
         <svg ref={el => svg = el}>
           <g ref={el => g = el} strokeWidth="5">
-            <image ref={el => image = el} xlinkHref="http://i.imgur.com/w7GCRPb.png" />
-            <foreignObject ref={el => foreignObject = el}>
-              <div ref={el => foreignDiv = el} />
+            <svg ref={el => svg2 = el}>
+              <foreignObject ref={el => foreignObject = el}>
+                <svg ref={el => svg3 = el}>
+                  <svg ref={el => svg4 = el} />
+                  <image ref={el => image = el} xlinkHref="http://i.imgur.com/w7GCRPb.png" />
+                </svg>
+                <div ref={el => div = el} />
+              </foreignObject>
+            </svg>
+            <image ref={el => image2 = el} xlinkHref="http://i.imgur.com/w7GCRPb.png" />
+            <foreignObject ref={el => foreignObject2 = el}>
+              <div ref={el => div2 = el} />
             </foreignObject>
           </g>
         </svg>
         <p ref={el => p = el}>
           <svg>
-            <image ref={el => image2 = el} xlinkHref="http://i.imgur.com/w7GCRPb.png" />
+            <image ref={el => image3 = el} xlinkHref="http://i.imgur.com/w7GCRPb.png" />
           </svg>
         </p>
-        <div ref={el => div = el} />
+        <div ref={el => div3 = el} />
       </div>,
       node
     );
-    // SVG tagName is case sensitive.
-    expect(svg.namespaceURI).toBe('http://www.w3.org/2000/svg');
-    expect(svg.tagName).toBe('svg');
+    [svg, svg2, svg3, svg4].forEach(el => {
+      expect(el.namespaceURI).toBe('http://www.w3.org/2000/svg');
+      // SVG tagName is case sensitive.
+      expect(el.tagName).toBe('svg');
+    });
     expect(g.namespaceURI).toBe('http://www.w3.org/2000/svg');
     expect(g.tagName).toBe('g');
     expect(g.getAttribute('stroke-width')).toBe('5');
-    expect(image.namespaceURI).toBe('http://www.w3.org/2000/svg');
-    expect(image.tagName).toBe('image');
-    expect(
-      image.getAttributeNS('http://www.w3.org/1999/xlink', 'href')
-    ).toBe('http://i.imgur.com/w7GCRPb.png');
-    expect(foreignObject.namespaceURI).toBe('http://www.w3.org/2000/svg');
-    expect(foreignObject.tagName).toBe('foreignObject');
-    expect(image2.namespaceURI).toBe('http://www.w3.org/2000/svg');
-    expect(image2.tagName).toBe('image');
-    expect(
-      image2.getAttributeNS('http://www.w3.org/1999/xlink', 'href')
-    ).toBe('http://i.imgur.com/w7GCRPb.png');
-    // DOM tagName is capitalized by browsers.
     expect(p.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
+    // DOM tagName is capitalized by browsers.
     expect(p.tagName).toBe('P');
-    expect(div.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
-    expect(div.tagName).toBe('DIV');
-    expect(foreignDiv.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
-    expect(foreignDiv.tagName).toBe('DIV');
+    [image, image2, image3].forEach(el => {
+      expect(el.namespaceURI).toBe('http://www.w3.org/2000/svg');
+      expect(el.tagName).toBe('image');
+      expect(
+        el.getAttributeNS('http://www.w3.org/1999/xlink', 'href')
+      ).toBe('http://i.imgur.com/w7GCRPb.png');
+    });
+    [foreignObject, foreignObject2].forEach(el => {
+      expect(el.namespaceURI).toBe('http://www.w3.org/2000/svg');
+      expect(el.tagName).toBe('foreignObject');
+    });
+    [div, div2, div3].forEach(el => {
+      expect(el.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
+      expect(el.tagName).toBe('DIV');
+    });
   });
 
   it('creates elements with SVG namespace inside SVG tag during update', () => {
-    var inst, foreignObject, foreignDiv, g, image, svg;
+    var inst, div, div2, foreignObject, foreignObject2, g, image, image2, svg, svg2, svg3, svg4;
 
     class App extends React.Component {
       state = {step: 0};
@@ -94,9 +104,18 @@ describe('ReactDOMSVG', () => {
         }
         return (
           <g ref={el => g = el} strokeWidth="5">
-            <image ref={el => image = el} xlinkHref="http://i.imgur.com/w7GCRPb.png" />
-            <foreignObject ref={el => foreignObject = el}>
-              <div ref={el => foreignDiv = el} />
+            <svg ref={el => svg2 = el}>
+              <foreignObject ref={el => foreignObject = el}>
+                <svg ref={el => svg3 = el}>
+                  <svg ref={el => svg4 = el} />
+                  <image ref={el => image = el} xlinkHref="http://i.imgur.com/w7GCRPb.png" />
+                </svg>
+                <div ref={el => div = el} />
+              </foreignObject>
+            </svg>
+            <image ref={el => image2 = el} xlinkHref="http://i.imgur.com/w7GCRPb.png" />
+            <foreignObject ref={el => foreignObject2 = el}>
+              <div ref={el => div2 = el} />
             </foreignObject>
           </g>
         );
@@ -112,20 +131,30 @@ describe('ReactDOMSVG', () => {
     );
     inst.setState({step: 1});
 
-    expect(svg.namespaceURI).toBe('http://www.w3.org/2000/svg');
-    expect(svg.tagName).toBe('svg');
+    [svg, svg2, svg3, svg4].forEach(el => {
+      expect(el.namespaceURI).toBe('http://www.w3.org/2000/svg');
+      // SVG tagName is case sensitive.
+      expect(el.tagName).toBe('svg');
+    });
     expect(g.namespaceURI).toBe('http://www.w3.org/2000/svg');
     expect(g.tagName).toBe('g');
     expect(g.getAttribute('stroke-width')).toBe('5');
-    expect(image.namespaceURI).toBe('http://www.w3.org/2000/svg');
-    expect(image.tagName).toBe('image');
-    expect(
-      image.getAttributeNS('http://www.w3.org/1999/xlink', 'href')
-    ).toBe('http://i.imgur.com/w7GCRPb.png');
-    expect(foreignObject.namespaceURI).toBe('http://www.w3.org/2000/svg');
-    expect(foreignObject.tagName).toBe('foreignObject');
-    expect(foreignDiv.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
-    expect(foreignDiv.tagName).toBe('DIV');
+    [image, image2].forEach(el => {
+      expect(el.namespaceURI).toBe('http://www.w3.org/2000/svg');
+      expect(el.tagName).toBe('image');
+      expect(
+        el.getAttributeNS('http://www.w3.org/1999/xlink', 'href')
+      ).toBe('http://i.imgur.com/w7GCRPb.png');
+    });
+    [foreignObject, foreignObject2].forEach(el => {
+      expect(el.namespaceURI).toBe('http://www.w3.org/2000/svg');
+      expect(el.tagName).toBe('foreignObject');
+    });
+    [div, div2].forEach(el => {
+      expect(el.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
+      // DOM tagName is capitalized by browsers.
+      expect(el.tagName).toBe('DIV');
+    });
   });
 
 });

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -152,6 +152,9 @@ var NoopRenderer = ReactFiberReconciler({
   popHostContext() : void {
   },
 
+  resetHostContext() : void {
+  },
+
   pushHostPortal() : void {
   },
 

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -146,6 +146,12 @@ var NoopRenderer = ReactFiberReconciler({
   resetAfterCommit() : void {
   },
 
+  pushHostContext() : void {
+  },
+
+  popHostContext() : void {
+  },
+
 });
 
 var rootContainers = new Map();

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -152,6 +152,12 @@ var NoopRenderer = ReactFiberReconciler({
   popHostContext() : void {
   },
 
+  pushHostPortal() : void {
+  },
+
+  popHostPortal() : void {
+  },
+
 });
 
 var rootContainers = new Map();

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -74,6 +74,7 @@ module.exports = function<T, P, I, TI, C>(
   const {
     pushHostContext,
     pushHostPortal,
+    resetHostContext,
   } = config;
 
   function markChildAsProgressed(current, workInProgress, priorityLevel) {
@@ -428,6 +429,7 @@ module.exports = function<T, P, I, TI, C>(
     if (!workInProgress.return) {
       // Don't start new work with context on the stack.
       resetContext();
+      resetHostContext();
     }
 
     if (workInProgress.pendingWorkPriority === NoWork ||

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -73,6 +73,7 @@ module.exports = function<T, P, I, TI, C>(
 
   const {
     pushHostContext,
+    pushHostPortal,
   } = config;
 
   function markChildAsProgressed(current, workInProgress, priorityLevel) {
@@ -319,6 +320,8 @@ module.exports = function<T, P, I, TI, C>(
   }
 
   function updatePortalComponent(current, workInProgress) {
+    pushHostPortal();
+
     const priorityLevel = workInProgress.pendingWorkPriority;
     const nextChildren = workInProgress.pendingProps;
     if (!current) {
@@ -409,6 +412,8 @@ module.exports = function<T, P, I, TI, C>(
       pushHostContext(workInProgress.type);
     } else if (isContextProvider(workInProgress)) {
       pushContextProvider(workInProgress, false);
+    } else if (workInProgress.tag === HostPortal) {
+      pushHostPortal();
     }
     return workInProgress.child;
   }
@@ -493,7 +498,6 @@ module.exports = function<T, P, I, TI, C>(
         return null;
       case HostPortal:
         updatePortalComponent(current, workInProgress);
-        // TODO: is this right?
         return workInProgress.child;
       case Fragment:
         updateFragment(current, workInProgress);

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -71,6 +71,10 @@ module.exports = function<T, P, I, TI, C>(
     updateClassInstance,
   } = ReactFiberClassComponent(scheduleUpdate);
 
+  const {
+    pushHostContext,
+  } = config;
+
   function markChildAsProgressed(current, workInProgress, priorityLevel) {
     // We now have clones. Let's store them as the currently progressed work.
     workInProgress.progressedChild = workInProgress.child;
@@ -268,6 +272,7 @@ module.exports = function<T, P, I, TI, C>(
       // Abort and don't process children yet.
       return null;
     } else {
+      pushHostContext(workInProgress.type);
       reconcileChildren(current, workInProgress, nextChildren);
       return workInProgress.child;
     }
@@ -355,8 +360,9 @@ module.exports = function<T, P, I, TI, C>(
 
   function bailoutOnAlreadyFinishedWork(current, workInProgress : Fiber) : ?Fiber {
     const priorityLevel = workInProgress.pendingWorkPriority;
+    const isHostComponent = workInProgress.tag === HostComponent;
 
-    if (workInProgress.tag === HostComponent &&
+    if (isHostComponent &&
         workInProgress.memoizedProps.hidden &&
         workInProgress.pendingWorkPriority !== OffscreenPriority) {
       // This subtree still has work, but it should be deprioritized so we need
@@ -399,7 +405,9 @@ module.exports = function<T, P, I, TI, C>(
     cloneChildFibers(current, workInProgress);
     markChildAsProgressed(current, workInProgress, priorityLevel);
     // Put context on the stack because we will work on children
-    if (isContextProvider(workInProgress)) {
+    if (isHostComponent) {
+      pushHostContext(workInProgress.type);
+    } else if (isContextProvider(workInProgress)) {
       pushContextProvider(workInProgress, false);
     }
     return workInProgress.child;

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -52,6 +52,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
     createTextInstance,
     prepareUpdate,
     popHostContext,
+    popHostPortal,
   } = config;
 
   function markUpdate(workInProgress : Fiber) {
@@ -295,6 +296,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
         workInProgress.memoizedProps = workInProgress.pendingProps;
         return null;
       case HostPortal:
+        popHostPortal();
         // TODO: Only mark this as an update if we have any pending callbacks.
         markUpdate(workInProgress);
         workInProgress.memoizedProps = workInProgress.pendingProps;

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -45,11 +45,14 @@ var {
 
 module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
 
-  const createInstance = config.createInstance;
-  const appendInitialChild = config.appendInitialChild;
-  const finalizeInitialChildren = config.finalizeInitialChildren;
-  const createTextInstance = config.createTextInstance;
-  const prepareUpdate = config.prepareUpdate;
+  const {
+    createInstance,
+    appendInitialChild,
+    finalizeInitialChildren,
+    createTextInstance,
+    prepareUpdate,
+    popHostContext,
+  } = config;
 
   function markUpdate(workInProgress : Fiber) {
     // Tag the fiber with an update effect. This turns a Placement into
@@ -202,6 +205,7 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
         return null;
       }
       case HostComponent:
+        popHostContext(workInProgress.type);
         let newProps = workInProgress.pendingProps;
         if (current && workInProgress.stateNode != null) {
           // If we have an alternate, that means this is an update and we need to

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -65,6 +65,9 @@ export type HostConfig<T, P, I, TI, C> = {
   prepareForCommit() : void,
   resetAfterCommit() : void,
 
+  pushHostContext(type : T) : void,
+  popHostContext(type : T) : void,
+
   useSyncScheduling ?: boolean,
 };
 

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -67,6 +67,7 @@ export type HostConfig<T, P, I, TI, C> = {
 
   pushHostContext(type : T) : void,
   popHostContext(type : T) : void,
+  resetHostContext() : void,
 
   pushHostPortal() : void,
   popHostPortal() : void,

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -68,6 +68,9 @@ export type HostConfig<T, P, I, TI, C> = {
   pushHostContext(type : T) : void,
   popHostContext(type : T) : void,
 
+  pushHostPortal() : void,
+  popHostPortal() : void,
+
   useSyncScheduling ?: boolean,
 };
 

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -46,7 +46,9 @@ var {
 } = require('ReactTypeOfSideEffect');
 
 var {
+  HostComponent,
   HostRoot,
+  HostPortal,
   ClassComponent,
 } = require('ReactTypeOfWork');
 
@@ -73,6 +75,9 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
 
   const prepareForCommit = config.prepareForCommit;
   const resetAfterCommit = config.resetAfterCommit;
+
+  const popHostContext = config.popHostContext;
+  const popHostPortal = config.popHostPortal;
 
   // The priority level to use when scheduling an update.
   let priorityContext : PriorityLevel = useSyncScheduling ?
@@ -583,6 +588,10 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
           // props, the nodes higher up in the tree will rerender unnecessarily.
           if (failedWork) {
             unwindContext(failedWork, boundary);
+            // TODO: disabling this doesn't fail any tests because we don't
+            // do any more host work and immediately restart from the root:
+            unwindHostContext(failedWork, boundary);
+            // This seems like a bug in error boundaries.
           }
           nextUnitOfWork = completeUnitOfWork(boundary);
 
@@ -696,6 +705,21 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) {
         return;
       default:
         throw new Error('Invalid type of work.');
+    }
+  }
+
+  function unwindHostContext(from : Fiber, to: Fiber) {
+    let node = from;
+    while (node && (node !== to) && (node.alternate !== to)) {
+      switch (node.tag) {
+        case HostComponent:
+          popHostContext(node.type);
+          break;
+        case HostPortal:
+          popHostPortal();
+          break;
+      }
+      node = node.return;
     }
   }
 


### PR DESCRIPTION
Replaces #8417.

Instead of keeping a stack, we're notifying the renderer when the work begins and ends.
This lets DOM renderer avoid the stack because namespace logic is not complex.

This is not done yet (missing portals and unwinding on error handling) but I want to get early feedback on the approach.