### PR TITLE
[Fiber] Scheduler improvements

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1149,6 +1149,7 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
 * preserves a previously rendered node when deprioritized
 * can reuse side-effects after being preempted
 * can reuse side-effects after being preempted, if shouldComponentUpdate is false
+* can update a completed tree before it has a chance to commit
 * updates a child even though the old props is empty
 * can defer side-effects and resume them later on
 * can defer side-effects and reuse them later - complex

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1107,6 +1107,7 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
 * catches reconciler errors in a boundary during update
 * recovers from uncaught reconciler errors
 * unmounts components with uncaught errors
+* does not interrupt unmounting if detaching a ref throws
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalReflection-test.js
 * handles isMounted even when the initial render is deferred

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1138,6 +1138,8 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
 * handles interleaved deferred and animation work
 * schedules sync updates when inside componentDidMount/Update
 * can opt-in to deferred/animation scheduling inside componentDidMount/Update
+* performs Task work even after time runs out
+* does not perform animation work after time runs out
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
 * can update child nodes of a host instance

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -54,6 +54,7 @@ var {
 var {
   Placement,
   ContentReset,
+  Err,
 } = require('ReactTypeOfSideEffect');
 var ReactCurrentOwner = require('ReactCurrentOwner');
 var ReactFiberClassComponent = require('ReactFiberClassComponent');
@@ -502,6 +503,9 @@ module.exports = function<T, P, I, TI, C>(
         workInProgress.tag !== HostRoot) {
       throw new Error('Invalid type of work');
     }
+
+    // Add an error effect so we can handle the error during the commit phase
+    workInProgress.effectTag |= Err;
 
     if (workInProgress.pendingWorkPriority === NoWork ||
         workInProgress.pendingWorkPriority > priorityLevel) {

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -35,7 +35,7 @@ var {
 
 module.exports = function<T, P, I, TI, C>(
   config : HostConfig<T, P, I, TI, C>,
-  captureError : (failedFiber : Fiber, error: Error) => Fiber | null
+  captureError : (failedFiber : Fiber, error: Error) => ?Fiber
 ) {
 
   const commitUpdate = config.commitUpdate;

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -143,6 +143,9 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) :
       root.pendingContext = getContextForSubtree(parentComponent);
       // TODO: Use pending work/state instead of props.
       root.current.pendingProps = element;
+      if (root.current.alternate) {
+        root.current.alternate.pendingProps = element;
+      }
 
       scheduleWork(root);
 
@@ -156,6 +159,9 @@ module.exports = function<T, P, I, TI, C>(config : HostConfig<T, P, I, TI, C>) :
       const root : FiberRoot = (container.stateNode : any);
       // TODO: Use pending work/state instead of props.
       root.current.pendingProps = [];
+      if (root.current.alternate) {
+        root.current.alternate.pendingProps = [];
+      }
 
       scheduleWork(root);
 

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -66,25 +66,19 @@ exports.addCallbackToQueue = function(queue : UpdateQueue, callback: Function) :
   return queue;
 };
 
-exports.callCallbacks = function(queue : UpdateQueue, context : any) : Error | null {
+exports.callCallbacks = function(queue : UpdateQueue, context : any) {
   let node : ?UpdateQueueNode = queue;
-  let firstError = null;
   while (node) {
     const callback = node.callback;
     if (callback) {
-      try {
-        if (typeof context !== 'undefined') {
-          callback.call(context);
-        } else {
-          callback();
-        }
-      } catch (error) {
-        firstError = firstError || error;
+      if (typeof context !== 'undefined') {
+        callback.call(context);
+      } else {
+        callback();
       }
     }
     node = node.next;
   }
-  return firstError;
 };
 
 function getStateFromNode(node, instance, state, props) {

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -625,16 +625,7 @@ describe('ReactIncremental', () => {
     // we should be able to reuse the reconciliation work that we already did
     // without restarting.
     ReactNoop.flush();
-    // TODO: Content never fully completed its render so can't completely bail
-    // out on the entire subtree. However, we could do a shallow bail out and
-    // not rerender Content, but keep going down the incomplete tree.
-    // Normally shouldComponentUpdate->false is not enough to determine that we
-    // can safely reuse the old props, but I think in this case it would be ok,
-    // since it is a resume of already started work.
-    // Because of the above we can not reuse the work of Bar because the
-    // rerender of Content will generate a new element which will mean we don't
-    // auto-bail out from Bar.
-    expect(ops).toEqual(['Bar', 'Middle']);
+    expect(ops).toEqual(['Middle']);
 
   });
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -410,7 +410,7 @@ describe('ReactIncremental', () => {
     // Make a quick update which will create a low pri tree on top of the
     // already low pri tree.
     ReactNoop.render(<Foo text="bar" />);
-    ReactNoop.flushDeferredPri(15 + 5);
+    ReactNoop.flushDeferredPri(15);
 
     expect(ops).toEqual(['Foo']);
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -410,7 +410,7 @@ describe('ReactIncremental', () => {
     // Make a quick update which will create a low pri tree on top of the
     // already low pri tree.
     ReactNoop.render(<Foo text="bar" />);
-    ReactNoop.flushDeferredPri(15);
+    ReactNoop.flushDeferredPri(15 + 5);
 
     expect(ops).toEqual(['Foo']);
 
@@ -491,7 +491,7 @@ describe('ReactIncremental', () => {
 
     // Init
     ReactNoop.render(<Foo text="foo" text2="foo" step={0} />);
-    ReactNoop.flushDeferredPri(55 + 25 + 5);
+    ReactNoop.flushDeferredPri(55 + 25 + 5 + 5);
 
     // We only finish the higher priority work. So the low pri content
     // has not yet finished mounting.
@@ -520,7 +520,7 @@ describe('ReactIncremental', () => {
     ops = [];
 
     // The middle content is now pending rendering...
-    ReactNoop.flushDeferredPri(30);
+    ReactNoop.flushDeferredPri(30 + 5);
     expect(ops).toEqual(['Middle', 'Bar']);
 
     ops = [];
@@ -600,7 +600,7 @@ describe('ReactIncremental', () => {
     // Make a quick update which will schedule low priority work to
     // update the middle content.
     ReactNoop.render(<Foo text="bar" step={1} />);
-    ReactNoop.flushDeferredPri(30);
+    ReactNoop.flushDeferredPri(30 + 5);
 
     expect(ops).toEqual(['Foo', 'Bar']);
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -1497,11 +1497,10 @@ describe('ReactIncremental', () => {
       ReactNoop.flush();
     }).toThrow('callback error');
 
-    // Should call all callbacks, even though the second one throws
+    // The third callback isn't called because the second one throws
     expect(ops).toEqual([
       'first callback',
       'second callback',
-      'third callback',
     ]);
     expect(instance.state.n).toEqual(3);
   });

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -1465,6 +1465,7 @@ describe('ReactIncremental', () => {
     ]);
     expect(instance.state.n).toEqual(4);
   });
+
   it('can handle if setState callback throws', () => {
     var ops = [];
     var instance;

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
@@ -88,7 +88,7 @@ describe('ReactIncrementalErrorHandling', () => {
     expect(ReactNoop.getChildren()).toEqual([]);
 
     ops.length = 0;
-    ReactNoop.flushDeferredPri(30 + 5 + 5 + 5 + 5);
+    ReactNoop.flushDeferredPri(25 + 10);
     expect(ops).toEqual([
       'BrokenRender',
       'ErrorBoundary unstable_handleError',
@@ -132,10 +132,6 @@ describe('ReactIncrementalErrorHandling', () => {
     expect(ops).toEqual([
       'ErrorBoundary render success',
       'BrokenRender',
-    ]);
-    ops = [];
-    ReactNoop.flushDeferredPri(25 + 5 + 5 + 5);
-    expect(ops).toEqual([
       'ErrorBoundary unstable_handleError',
       'ErrorBoundary render error',
     ]);

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
@@ -88,7 +88,7 @@ describe('ReactIncrementalErrorHandling', () => {
     expect(ReactNoop.getChildren()).toEqual([]);
 
     ops.length = 0;
-    ReactNoop.flushDeferredPri(30 + 5 + 5 + 5);
+    ReactNoop.flushDeferredPri(30 + 5 + 5 + 5 + 5);
     expect(ops).toEqual([
       'BrokenRender',
       'ErrorBoundary unstable_handleError',
@@ -134,7 +134,7 @@ describe('ReactIncrementalErrorHandling', () => {
       'BrokenRender',
     ]);
     ops = [];
-    ReactNoop.flushDeferredPri(25 + 5 + 5);
+    ReactNoop.flushDeferredPri(25 + 5 + 5 + 5);
     expect(ops).toEqual([
       'ErrorBoundary unstable_handleError',
       'ErrorBoundary render error',

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
@@ -88,7 +88,7 @@ describe('ReactIncrementalErrorHandling', () => {
     expect(ReactNoop.getChildren()).toEqual([]);
 
     ops.length = 0;
-    ReactNoop.flushDeferredPri(30);
+    ReactNoop.flushDeferredPri(30 + 5 + 5 + 5);
     expect(ops).toEqual([
       'BrokenRender',
       'ErrorBoundary unstable_handleError',
@@ -134,7 +134,7 @@ describe('ReactIncrementalErrorHandling', () => {
       'BrokenRender',
     ]);
     ops = [];
-    ReactNoop.flushDeferredPri(25);
+    ReactNoop.flushDeferredPri(25 + 5 + 5);
     expect(ops).toEqual([
       'ErrorBoundary unstable_handleError',
       'ErrorBoundary render error',

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
@@ -93,7 +93,7 @@ describe('ReactIncrementalErrorHandling', () => {
     expect(ReactNoop.getChildren()).toEqual([]);
 
     ops.length = 0;
-    ReactNoop.flushDeferredPri(25 + 10);
+    ReactNoop.flushDeferredPri(30);
     expect(ops).toEqual([
       'BrokenRender',
       'ErrorBoundary unstable_handleError',

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
@@ -419,11 +419,11 @@ describe('ReactIncrementalScheduling', () => {
     });
     // We're flushing deferred work
     // Still, roots with animation work are handled first
-    ReactNoop.flushDeferredPri(15 + 5);
+    ReactNoop.flushDeferredPri(15);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
-    ReactNoop.flushDeferredPri(15 + 5);
+    ReactNoop.flushDeferredPri(15);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
@@ -434,7 +434,7 @@ describe('ReactIncrementalScheduling', () => {
       ReactNoop.renderToRootWithID(<span prop="b:3" />, 'b');
     });
     // Animation is still handled first
-    ReactNoop.flushDeferredPri(15 + 5);
+    ReactNoop.flushDeferredPri(15);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:3')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
@@ -144,7 +144,7 @@ describe('ReactIncrementalScheduling', () => {
     ReactNoop.flushDeferredPri(10);
     expect(ReactNoop.getChildren()).toEqual([]);
 
-    ReactNoop.flushDeferredPri(10);
+    ReactNoop.flushDeferredPri(10 + 5);
     expect(ReactNoop.getChildren()).toEqual([span('2')]);
   });
 
@@ -159,17 +159,17 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
 
-    ReactNoop.flushDeferredPri(15);
+    ReactNoop.flushDeferredPri(15 + 5);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
 
-    ReactNoop.flushDeferredPri(15);
+    ReactNoop.flushDeferredPri(15 + 5);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
 
-    ReactNoop.flushDeferredPri(15);
+    ReactNoop.flushDeferredPri(15 + 5);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
@@ -329,19 +329,19 @@ describe('ReactIncrementalScheduling', () => {
   it('splits deferred work on multiple roots', () => {
     // Schedule one root
     ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
-    ReactNoop.flushDeferredPri(15);
+    ReactNoop.flushDeferredPri(15 + 5);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
 
     // Schedule two roots
     ReactNoop.renderToRootWithID(<span prop="a:2" />, 'a');
     ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
     // First scheduled one gets processed first
-    ReactNoop.flushDeferredPri(15);
+    ReactNoop.flushDeferredPri(15 + 5);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual(null);
     // Then the second one gets processed
-    ReactNoop.flushDeferredPri(15);
+    ReactNoop.flushDeferredPri(15 + 5);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual(null);
@@ -351,15 +351,15 @@ describe('ReactIncrementalScheduling', () => {
     ReactNoop.renderToRootWithID(<span prop="b:3" />, 'b');
     ReactNoop.renderToRootWithID(<span prop="c:3" />, 'c');
     // They get processed in the order they were scheduled
-    ReactNoop.flushDeferredPri(15);
+    ReactNoop.flushDeferredPri(15 + 5);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:3')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
-    ReactNoop.flushDeferredPri(15);
+    ReactNoop.flushDeferredPri(15 + 5);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:3')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:3')]);
     expect(ReactNoop.getChildren('c')).toEqual([]);
-    ReactNoop.flushDeferredPri(15);
+    ReactNoop.flushDeferredPri(15 + 5);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:3')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:3')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:3')]);
@@ -368,7 +368,7 @@ describe('ReactIncrementalScheduling', () => {
     ReactNoop.renderToRootWithID(<span prop="a:4" />, 'a');
     ReactNoop.renderToRootWithID(<span prop="a:5" />, 'a');
     ReactNoop.renderToRootWithID(<span prop="a:6" />, 'a');
-    ReactNoop.flushDeferredPri(15);
+    ReactNoop.flushDeferredPri(15 + 5);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:6')]);
   });
 
@@ -385,18 +385,18 @@ describe('ReactIncrementalScheduling', () => {
     ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
     ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
     // Ensure it starts in the order it was scheduled
-    ReactNoop.flushDeferredPri(15);
+    ReactNoop.flushDeferredPri(15 + 5);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
     // Schedule last bit of work, it will get processed the last
     ReactNoop.renderToRootWithID(<span prop="a:2" />, 'a');
     // Keep performing work in the order it was scheduled
-    ReactNoop.flushDeferredPri(15);
+    ReactNoop.flushDeferredPri(15 + 5);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
-    ReactNoop.flushDeferredPri(15);
+    ReactNoop.flushDeferredPri(15 + 5);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
@@ -419,11 +419,11 @@ describe('ReactIncrementalScheduling', () => {
     });
     // We're flushing deferred work
     // Still, roots with animation work are handled first
-    ReactNoop.flushDeferredPri(15);
+    ReactNoop.flushDeferredPri(15 + 5);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
-    ReactNoop.flushDeferredPri(15);
+    ReactNoop.flushDeferredPri(15 + 5);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
@@ -434,17 +434,17 @@ describe('ReactIncrementalScheduling', () => {
       ReactNoop.renderToRootWithID(<span prop="b:3" />, 'b');
     });
     // Animation is still handled first
-    ReactNoop.flushDeferredPri(15);
+    ReactNoop.flushDeferredPri(15 + 5);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:3')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
 
     // Finally we handle deferred root in the order it was scheduled
-    ReactNoop.flushDeferredPri(15);
+    ReactNoop.flushDeferredPri(15 + 5);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:3')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
-    ReactNoop.flushDeferredPri(15);
+    ReactNoop.flushDeferredPri(15 + 5);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:3')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:3')]);
@@ -483,7 +483,7 @@ describe('ReactIncrementalScheduling', () => {
 
     ReactNoop.render(<Foo />);
 
-    ReactNoop.flushDeferredPri(20);
+    ReactNoop.flushDeferredPri(20 + 5);
     expect(ops).toEqual([
       'render: 0',
       'componentDidMount (before setState): 0',
@@ -496,7 +496,7 @@ describe('ReactIncrementalScheduling', () => {
 
     ops = [];
     instance.setState({ tick: 2 });
-    ReactNoop.flushDeferredPri(20);
+    ReactNoop.flushDeferredPri(20 + 5);
 
     expect(ops).toEqual([
       'render: 2',
@@ -545,7 +545,7 @@ describe('ReactIncrementalScheduling', () => {
 
     ReactNoop.render(<Foo />);
 
-    ReactNoop.flushDeferredPri(20);
+    ReactNoop.flushDeferredPri(20 + 5);
     expect(ops).toEqual([
       'render: 0',
       'componentDidMount (before setState): 0',
@@ -566,7 +566,7 @@ describe('ReactIncrementalScheduling', () => {
 
     ops = [];
     instance.setState({ tick: 2 });
-    ReactNoop.flushDeferredPri(20);
+    ReactNoop.flushDeferredPri(20 + 5);
 
     expect(ops).toEqual([
       'render: 2',

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
@@ -483,7 +483,7 @@ describe('ReactIncrementalScheduling', () => {
 
     ReactNoop.render(<Foo />);
 
-    ReactNoop.flushDeferredPri(20 + 5 + 5);
+    ReactNoop.flushDeferredPri(5 + 20 + 20);
     expect(ops).toEqual([
       'render: 0',
       'componentDidMount (before setState): 0',
@@ -496,7 +496,7 @@ describe('ReactIncrementalScheduling', () => {
 
     ops = [];
     instance.setState({ tick: 2 });
-    ReactNoop.flushDeferredPri(20 + 5 + 5);
+    ReactNoop.flushDeferredPri(5 + 20 + 20);
 
     expect(ops).toEqual([
       'render: 2',

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
@@ -341,7 +341,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([]);
     expect(ReactNoop.getChildren('c')).toEqual(null);
     // Then the second one gets processed
-    ReactNoop.flushDeferredPri(15 + 5);
+    ReactNoop.flushDeferredPri(15 + 5 + 5);
     expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual(null);
@@ -483,7 +483,7 @@ describe('ReactIncrementalScheduling', () => {
 
     ReactNoop.render(<Foo />);
 
-    ReactNoop.flushDeferredPri(20 + 5);
+    ReactNoop.flushDeferredPri(20 + 5 + 5);
     expect(ops).toEqual([
       'render: 0',
       'componentDidMount (before setState): 0',
@@ -496,7 +496,7 @@ describe('ReactIncrementalScheduling', () => {
 
     ops = [];
     instance.setState({ tick: 2 });
-    ReactNoop.flushDeferredPri(20 + 5);
+    ReactNoop.flushDeferredPri(20 + 5 + 5);
 
     expect(ops).toEqual([
       'render: 2',

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -491,7 +491,7 @@ describe('ReactIncrementalSideEffects', () => {
     // To confirm, perform one more unit of work. The tree should now be flushed.
     // (ReactNoop decrements the time remaining by 5 *before* returning it from
     // the deadline, so to perform n units of work, you need to give it 5n + 5.
-    // TODO: This is confusing. Decerement it after.)
+    // TODO: This is confusing. Decrement it after.)
     ReactNoop.flushDeferredPri(10);
     expect(ReactNoop.getChildren()).toEqual([span(1)]);
 

--- a/src/renderers/shared/shared/__tests__/ReactErrorBoundaries-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactErrorBoundaries-test.js
@@ -808,8 +808,8 @@ describe('ReactErrorBoundaries', () => {
       ...(ReactDOMFeatureFlags.useFiber ? [
         // In Fiber, noop error boundaries render null
         'RethrowErrorBoundary componentDidMount',
-        'ErrorBoundary componentDidMount',
         'RethrowErrorBoundary unstable_handleError [!]',
+        'ErrorBoundary componentDidMount',
         // The error got rethrown here.
         // This time, the error propagates to the higher boundary
         'RethrowErrorBoundary componentWillUnmount',
@@ -904,9 +904,9 @@ describe('ReactErrorBoundaries', () => {
       ...(ReactDOMFeatureFlags.useFiber ? [
         // Finish mounting with null children
         'BrokenRenderErrorBoundary componentDidMount',
-        'ErrorBoundary componentDidMount',
         // Attempt to handle the error
         'BrokenRenderErrorBoundary unstable_handleError',
+        'ErrorBoundary componentDidMount',
         'BrokenRenderErrorBoundary render error [!]',
         // Boundary fails with new error, propagate to next boundary
         'BrokenRenderErrorBoundary componentWillUnmount',
@@ -2044,15 +2044,15 @@ describe('ReactErrorBoundaries', () => {
         'OuterErrorBoundary componentDidUpdate',
         // After the commit phase, attempt to recover from any errors that
         // were captured
+        'BrokenComponentDidUpdate componentWillUnmount',
+        'BrokenComponentDidUpdate componentWillUnmount',
         'InnerUnmountBoundary unstable_handleError',
+        'InnerUpdateBoundary unstable_handleError',
         'InnerUnmountBoundary componentWillUpdate',
         'InnerUnmountBoundary render error',
-        'BrokenComponentDidUpdate componentWillUnmount',
-        'BrokenComponentDidUpdate componentWillUnmount',
-        'InnerUnmountBoundary componentDidUpdate',
-        'InnerUpdateBoundary unstable_handleError',
         'InnerUpdateBoundary componentWillUpdate',
         'InnerUpdateBoundary render error',
+        'InnerUnmountBoundary componentDidUpdate',
         'InnerUpdateBoundary componentDidUpdate',
       ]);
 


### PR DESCRIPTION
- [x] Split the commit phase from `performUnitOfWork` so that we can complete a tree without having to commit it within the same frame.
- [x] Consolidate the work loop functions.
- [x] Consolidate try-catch-finally blocks. Aim for three: one for the work loop, and one for each pass of the commit phase.
- [x] Avoid checking for failed work every time so that we don't pay a penalty in the normal case. When we know there are errors somewhere in the tree, use a forked version of the work loop that performs the check and is slightly slower. In the normal case, use the faster version without the check.
- [x] Error recovery work should not be incremental. Give it Task priority. (Why?)
- [x] Fix bug from https://github.com/facebook/react/pull/8485