### PR TITLE
[Fiber] Demonstrate an error boundary bug

### DIFF
--- a/src/renderers/dom/shared/ReactDOMFeatureFlags.js
+++ b/src/renderers/dom/shared/ReactDOMFeatureFlags.js
@@ -13,7 +13,7 @@
 
 var ReactDOMFeatureFlags = {
   useCreateElement: true,
-  useFiber: false,
+  useFiber: true,
 };
 
 module.exports = ReactDOMFeatureFlags;

--- a/src/renderers/shared/shared/__tests__/ReactErrorBoundaries-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactErrorBoundaries-test.js
@@ -503,13 +503,14 @@ describe('ReactErrorBoundaries', () => {
         log.push('RethrowErrorBoundary componentWillUnmount');
       }
       unstable_handleError(error) {
-        if (!ReactDOMFeatureFlags.useFiber) {
+        if (ReactDOMFeatureFlags.useFiber) {
+          log.push('RethrowErrorBoundary unstable_handleError [!]');
+          // In Fiber, calling setState() (and failing) is treated as a rethrow.
+          this.setState({});
+        } else {
           log.push('RethrowErrorBoundary unstable_handleError [*]');
           // In Stack, not calling setState() is treated as a rethrow.
-          return;
         }
-        log.push('RethrowErrorBoundary unstable_handleError [!]');
-        throw error;
       }
     };
 


### PR DESCRIPTION
@acdlite This one is for you :-)

I changed the test for rethrowing behavior in Fiber from literal "rethrow" to calling `setState` and attempting to render broken children again. We should probably test both cases, but this one is currently failing with "Cannot commit same tree". Instead (I think?) it should propagate the error to the parent boundary (or fail).

There is also some sort of shared mutable state because when this test fails, it also brings down another test in the same file.

```
npm test -- --watch ReactErrorB
```