### PR TITLE
Add component stack to invalid element type warning

### DIFF
--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -39,6 +39,20 @@ function getDeclarationErrorAddendum() {
   return '';
 }
 
+function getSourceInfoErrorAddendum(elementProps) {
+  if (
+    elementProps !== null &&
+    elementProps !== undefined &&
+    elementProps.__source !== undefined
+  ) {
+    var source = elementProps.__source;
+    var fileName = source.fileName.replace(/^.*[\\\/]/, '');
+    var lineNumber = source.lineNumber;
+    return ' Check your code (at ' + fileName + ':' + lineNumber + ').';
+  }
+  return '';
+}
+
 /**
  * Warn if there's no key explicitly set on dynamic arrays of children or
  * object keys are not valid. This allows us to keep track of children between
@@ -206,7 +220,14 @@ var ReactElementValidator = {
             ' You likely forgot to export your component from the file ' +
             'it\'s defined in.';
         }
-        info += getDeclarationErrorAddendum();
+
+        var sourceInfo = getSourceInfoErrorAddendum(props);
+        if (sourceInfo) {
+          info += sourceInfo;
+        } else {
+          info += getDeclarationErrorAddendum();
+        }
+
         warning(
           false,
           'React.createElement: type is invalid -- expected a string (for ' +

--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -228,6 +228,8 @@ var ReactElementValidator = {
           info += getDeclarationErrorAddendum();
         }
 
+        info += ReactComponentTreeHook.getCurrentStackAddendum();
+
         warning(
           false,
           'React.createElement: type is invalid -- expected a string (for ' +

--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -48,7 +48,7 @@ function getSourceInfoErrorAddendum(elementProps) {
     var source = elementProps.__source;
     var fileName = source.fileName.replace(/^.*[\\\/]/, '');
     var lineNumber = source.lineNumber;
-    return ' Check your code (at ' + fileName + ':' + lineNumber + ').';
+    return ' Check your code at ' + fileName + ':' + lineNumber + '.';
   }
   return '';
 }

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -20,7 +20,7 @@ var ReactTestUtils;
 
 describe('ReactElementValidator', () => {
   function normalizeCodeLocInfo(str) {
-    return str && str.replace(/\(at .+?:\d+\)/g, '(at **)');
+    return str && str.replace(/at .+?:\d+/g, 'at **');
   }
 
   var ComponentClass;
@@ -551,7 +551,7 @@ describe('ReactElementValidator', () => {
       'Warning: React.createElement: type is invalid -- expected a string ' +
       '(for built-in components) or a class/function (for composite ' +
       'components) but got: undefined. You likely forgot to export your ' +
-      'component from the file it\'s defined in. Check your code (at **).'
+      'component from the file it\'s defined in. Check your code at **.'
     );
   });
 

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -349,7 +349,8 @@ describe('ReactElementValidator', () => {
     expectDev(console.error.calls.argsFor(0)[0]).toBe(
       'Warning: React.createElement: type is invalid -- expected a string ' +
       '(for built-in components) or a class/function (for composite ' +
-      'components) but got: null. Check the render method of `ParentComp`.'
+      'components) but got: null. Check the render method of `ParentComp`.' +
+      '\n    in ParentComp'
     );
   });
 

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -546,11 +546,11 @@ describe('ReactElementValidator', () => {
     var Foo = undefined;
     void <Foo>{[<div />]}</Foo>;
     expectDev(console.error.calls.count()).toBe(1);
-    expectDev(console.error.calls.argsFor(0)[0]).toBe(
+    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
       'Warning: React.createElement: type is invalid -- expected a string ' +
       '(for built-in components) or a class/function (for composite ' +
       'components) but got: undefined. You likely forgot to export your ' +
-      'component from the file it\'s defined in.'
+      'component from the file it\'s defined in. Check your code (at **).'
     );
   });
 

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -256,26 +256,38 @@ describe('ReactJSXElementValidator', () => {
     void <True />;
     void <Num />;
     expectDev(console.error.calls.count()).toBe(4);
-    expectDev(console.error.calls.argsFor(0)[0]).toBe(
+    expectDev(
+      console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
+    ).toBe(
       'Warning: React.createElement: type is invalid -- expected a string ' +
       '(for built-in components) or a class/function (for composite ' +
       'components) but got: undefined. You likely forgot to export your ' +
-      'component from the file it\'s defined in.'
+      'component from the file it\'s defined in. ' +
+      'Check your code (at **).'
     );
-    expectDev(console.error.calls.argsFor(1)[0]).toBe(
+    expectDev(
+      console.error.calls.argsFor(1)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
+    ).toBe(
       'Warning: React.createElement: type is invalid -- expected a string ' +
       '(for built-in components) or a class/function (for composite ' +
-      'components) but got: null.'
+      'components) but got: null. ' +
+      'Check your code (at **).'
     );
-    expectDev(console.error.calls.argsFor(2)[0]).toBe(
+    expectDev(
+      console.error.calls.argsFor(2)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
+    ).toBe(
       'Warning: React.createElement: type is invalid -- expected a string ' +
       '(for built-in components) or a class/function (for composite ' +
-      'components) but got: boolean.'
+      'components) but got: boolean. ' +
+      'Check your code (at **).'
     );
-    expectDev(console.error.calls.argsFor(3)[0]).toBe(
+    expectDev(
+      console.error.calls.argsFor(3)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
+    ).toBe(
       'Warning: React.createElement: type is invalid -- expected a string ' +
       '(for built-in components) or a class/function (for composite ' +
-      'components) but got: number.'
+      'components) but got: number. ' +
+      'Check your code (at **).'
     );
     void <Div />;
     expectDev(console.error.calls.count()).toBe(4);

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -19,6 +19,10 @@ var ReactDOM;
 var ReactTestUtils;
 
 describe('ReactJSXElementValidator', () => {
+  function normalizeCodeLocInfo(str) {
+    return str && str.replace(/\(at .+?:\d+\)/g, '(at **)');
+  }
+
   var Component;
   var RequiredPropComponent;
 
@@ -194,9 +198,7 @@ describe('ReactJSXElementValidator', () => {
       }
     }
     ReactTestUtils.renderIntoDocument(<ParentComp />);
-    expect(
-      console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
-    ).toBe(
+    expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
       'Warning: Failed prop type: ' +
       'Invalid prop `color` of type `number` supplied to `MyComp`, ' +
       'expected `string`.\n' +
@@ -232,9 +234,7 @@ describe('ReactJSXElementValidator', () => {
     expect(console.error.calls.count()).toBe(1);
     // The warning should have the full stack with line numbers.
     // If it doesn't, it means we're using information from the old element.
-    expect(
-      console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
-    ).toBe(
+    expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
       'Warning: Failed prop type: ' +
       'Invalid prop `color` of type `number` supplied to `MyComp`, ' +
       'expected `string`.\n' +
@@ -256,34 +256,26 @@ describe('ReactJSXElementValidator', () => {
     void <True />;
     void <Num />;
     expectDev(console.error.calls.count()).toBe(4);
-    expectDev(
-      console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
-    ).toBe(
+    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
       'Warning: React.createElement: type is invalid -- expected a string ' +
       '(for built-in components) or a class/function (for composite ' +
       'components) but got: undefined. You likely forgot to export your ' +
       'component from the file it\'s defined in. ' +
       'Check your code (at **).'
     );
-    expectDev(
-      console.error.calls.argsFor(1)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
-    ).toBe(
+    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
       'Warning: React.createElement: type is invalid -- expected a string ' +
       '(for built-in components) or a class/function (for composite ' +
       'components) but got: null. ' +
       'Check your code (at **).'
     );
-    expectDev(
-      console.error.calls.argsFor(2)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
-    ).toBe(
+    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(2)[0])).toBe(
       'Warning: React.createElement: type is invalid -- expected a string ' +
       '(for built-in components) or a class/function (for composite ' +
       'components) but got: boolean. ' +
       'Check your code (at **).'
     );
-    expectDev(
-      console.error.calls.argsFor(3)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
-    ).toBe(
+    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(3)[0])).toBe(
       'Warning: React.createElement: type is invalid -- expected a string ' +
       '(for built-in components) or a class/function (for composite ' +
       'components) but got: number. ' +
@@ -301,9 +293,7 @@ describe('ReactJSXElementValidator', () => {
     ReactTestUtils.renderIntoDocument(<RequiredPropComponent />);
 
     expectDev(console.error.calls.count()).toBe(1);
-    expect(
-      console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
-    ).toBe(
+    expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
       'Warning: Failed prop type: The prop `prop` is marked as required in ' +
       '`RequiredPropComponent`, but its value is `null`.\n' +
       '    in RequiredPropComponent (at **)'
@@ -316,9 +306,7 @@ describe('ReactJSXElementValidator', () => {
     ReactTestUtils.renderIntoDocument(<RequiredPropComponent prop={null} />);
 
     expectDev(console.error.calls.count()).toBe(1);
-    expect(
-      console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
-    ).toBe(
+    expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
       'Warning: Failed prop type: The prop `prop` is marked as required in ' +
       '`RequiredPropComponent`, but its value is `null`.\n' +
       '    in RequiredPropComponent (at **)'
@@ -332,18 +320,14 @@ describe('ReactJSXElementValidator', () => {
     ReactTestUtils.renderIntoDocument(<RequiredPropComponent prop={42} />);
 
     expectDev(console.error.calls.count()).toBe(2);
-    expect(
-      console.error.calls.argsFor(0)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
-    ).toBe(
+    expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
       'Warning: Failed prop type: ' +
       'The prop `prop` is marked as required in `RequiredPropComponent`, but ' +
       'its value is `undefined`.\n' +
       '    in RequiredPropComponent (at **)'
     );
 
-    expect(
-      console.error.calls.argsFor(1)[0].replace(/\(at .+?:\d+\)/g, '(at **)')
-    ).toBe(
+    expect(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
       'Warning: Failed prop type: ' +
       'Invalid prop `prop` of type `number` supplied to ' +
       '`RequiredPropComponent`, expected `string`.\n' +

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -20,7 +20,7 @@ var ReactTestUtils;
 
 describe('ReactJSXElementValidator', () => {
   function normalizeCodeLocInfo(str) {
-    return str && str.replace(/\(at .+?:\d+\)/g, '(at **)');
+    return str && str.replace(/at .+?:\d+/g, 'at **');
   }
 
   var Component;
@@ -261,25 +261,25 @@ describe('ReactJSXElementValidator', () => {
       '(for built-in components) or a class/function (for composite ' +
       'components) but got: undefined. You likely forgot to export your ' +
       'component from the file it\'s defined in. ' +
-      'Check your code (at **).'
+      'Check your code at **.'
     );
     expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
       'Warning: React.createElement: type is invalid -- expected a string ' +
       '(for built-in components) or a class/function (for composite ' +
       'components) but got: null. ' +
-      'Check your code (at **).'
+      'Check your code at **.'
     );
     expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(2)[0])).toBe(
       'Warning: React.createElement: type is invalid -- expected a string ' +
       '(for built-in components) or a class/function (for composite ' +
       'components) but got: boolean. ' +
-      'Check your code (at **).'
+      'Check your code at **.'
     );
     expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(3)[0])).toBe(
       'Warning: React.createElement: type is invalid -- expected a string ' +
       '(for built-in components) or a class/function (for composite ' +
       'components) but got: number. ' +
-      'Check your code (at **).'
+      'Check your code at **.'
     );
     void <Div />;
     expectDev(console.error.calls.count()).toBe(4);


### PR DESCRIPTION
To resolve #7856 and #7859 seems no longer active

Add stack addendum to  Invalid element type warning

- It will get stack from constructed element if the element has `_source` (file and line number), the stack will be look like `In Unknown (at file.js:12)`.
- In case jsx babel transform isn't being used, we won't have location info (in `element._source`). we will use parent's generated stack instead.

**Sample Code**
```js
let Foo = {};
class Button extends React.Component {
  render() {
    return (
      <div>
        <Foo /> // Foo is invalid element
      </div>
    );
  }
}

class DangerButton extends React.Component {
  render() {
    return <Button />;
  }
}

var ExampleApplication = React.createClass({
  render: function() {
    return (
      <div>
        <DangerButton />
      </div>
    )
  }
});

ReactDOM.render(
  <ExampleApplication />,
  document.getElementById('container')
);
```

**Output (with babel transform)**
```
react.js:3683 Warning: React.createElement: type should not be null, undefined, boolean, or number. It should be a string (for DOM elements) or a ReactClass (for composite components). Check the render method of `Button`.
    in Unknown (at example.js:7)
    in Button (at example.js:15)
    in DangerButton (at example.js:23)
    in div (at example.js:22)
    in ExampleApplication (at example.js:30)
```

**Output (without _source from babel)**
```
react.js:3683 Warning: React.createElement: type should not be null, undefined, boolean, or number. It should be a string (for DOM elements) or a ReactClass (for composite components). Check the render method of `Button`.
    in Button (created by DangerButton)
    in DangerButton (created by ExampleApplication)
    in div (created by ExampleApplication)
    in ExampleApplication
```

We drop the first line which is `in Unknown (created by Button)` since it's not very useful.