### PR TITLE
Docs - Pass strip_html instead of remove in meta tags

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,7 +1,7 @@
 {% if page.excerpt %}
 {% assign type = 'article' %}
 {% assign sectionTitle = 'React Blog' %}
-{% assign description = page.excerpt | remove: '<p>' | remove: '</p>' %}
+{% assign description = page.excerpt | strip_html %}
 {% else %}
 {% assign type = 'website' %}
 {% assign sectionTitle = 'React' %}


### PR DESCRIPTION
This PR proposes a change to the default layout of `docs` which removes HTML tags from `description`.
Note from https://jekyllrb.com/docs/posts/#post-excerpts
> Also, as with any output generated by Liquid tags, you can pass the | strip_html filter to remove any html tags in the output. This is particularly helpful if you wish to output a post excerpt as a meta="description" tag within the post head, or anywhere else having html tags along with the content is not desirable.

Rebuilding old `gh-pages` is needed. E.g. https://facebook.github.io/react/blog/2014/07/30/flux-actions-and-the-dispatcher.html