### PR TITLE
Pass props down from ReactCSSTransitionGroupChild to child

### DIFF
--- a/src/addons/transitions/ReactCSSTransitionGroupChild.js
+++ b/src/addons/transitions/ReactCSSTransitionGroupChild.js
@@ -51,6 +51,7 @@ var ReactCSSTransitionGroupChild = React.createClass({
     appearTimeout: React.PropTypes.number,
     enterTimeout: React.PropTypes.number,
     leaveTimeout: React.PropTypes.number,
+    children: React.PropTypes.node,
   },
 
   transition: function(animationType, finishCallback, userSpecifiedDelay) {
@@ -164,7 +165,10 @@ var ReactCSSTransitionGroupChild = React.createClass({
   },
 
   render: function() {
-    return onlyChild(this.props.children);
+    var props = Object.assign({}, this.props);
+    Object.keys(ReactCSSTransitionGroupChild.propTypes)
+      .forEach(key => delete props[key]);
+    return React.cloneElement(onlyChild(this.props.children), props);
   },
 });
 

--- a/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
@@ -327,4 +327,46 @@ describe('ReactCSSTransitionGroup', () => {
     // Testing that no exception is thrown here, as the timeout has been cleared.
     jest.runAllTimers();
   });
+
+  it('should work with custom component wrapper cloning children', () => {
+    const extraClassNameProp = 'wrapper-item';
+    class Wrapper extends React.Component {
+      render() {
+        return (
+          <div>
+            {
+              React.Children.map(this.props.children,
+                child => React.cloneElement(child, { className: extraClassNameProp }))
+            }
+          </div>
+        );
+      }
+    }
+
+    class Child extends React.Component {
+      render() {
+        return <div {...this.props} />;
+      }
+    }
+
+    class Component extends React.Component {
+      render() {
+        return (
+          <ReactCSSTransitionGroup
+            transitionName="yolo"
+            component={Wrapper}
+          >
+            <Child />
+          </ReactCSSTransitionGroup>
+        );
+      }
+    }
+
+    var a = ReactDOM.render(<Component/>, container);
+    var child = ReactDOM.findDOMNode(a).childNodes[0];
+    expect(CSSCore.hasClass(child, extraClassNameProp)).toBe(true);
+
+    // Testing that no exception is thrown here, as the timeout has been cleared.
+    jest.runAllTimers();
+  });
 });


### PR DESCRIPTION
Useful for component wrapper that clone children and modify props, new props should be passed down to child.