### PR TITLE
Don't set innerHTML if content is empty

### DIFF
--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -787,8 +787,9 @@ ReactDOMComponent.Mixin = {
     // Intentional use of != to avoid catching zero/false.
     var innerHTML = props.dangerouslySetInnerHTML;
     if (innerHTML != null) {
-      if (innerHTML.__html != null) {
-        DOMLazyTree.queueHTML(lazyTree, innerHTML.__html);
+      const innerHTMLContent = innerHTML.__html;
+      if (innerHTMLContent != null && innerHTMLContent !== '') {
+        DOMLazyTree.queueHTML(lazyTree, innerHTMLContent);
       }
     } else {
       var contentToUse =


### PR DESCRIPTION
From D4296244:

> Each [...] had a component with innerHTML = '', causing us to go into HTML parsing code in the browser. Doing this takes 0.03ms per parse call which was 10x slower than skipping it.