### PR TITLE
Fixed lint error in master

### DIFF
--- a/src/renderers/shared/shared/__tests__/ReactCompositeComponentState-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactCompositeComponentState-test.js
@@ -298,12 +298,13 @@ describe('ReactCompositeComponent-state', () => {
     });
     // We expect the same thing to happen if we bail out in the middle.
     expect(ops).toEqual(
-      ReactDOMFeatureFlags.useFiber ?
-      [
+      ReactDOMFeatureFlags.useFiber
+      ? [
         // Fiber works as expected
         'child did update',
         'parent did update',
-      ] : [
+      ]
+      : [
         // Stack treats these as two separate updates and therefore the order
         // is inverse.
         'parent did update',


### PR DESCRIPTION
Fixes lint error introduced in commit 343fb958.

```
src/renderers/shared/shared/__tests__/ReactCompositeComponentState-test.js
  302:7  error  Expected indentation of 8 spaces but found 6   indent
  304:9  error  Expected indentation of 10 spaces but found 8  indent
  305:9  error  Expected indentation of 10 spaces but found 8  indent
  306:7  error  Expected indentation of 8 spaces but found 6   indent
```

Will auto-merge once CircleCI finishes.