### PR TITLE
[Fiber] Separate priority for updates

### DIFF
--- a/examples/fiber/index.html
+++ b/examples/fiber/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html style="width: 100%; height: 100%; overflow: hidden">
   <head>
     <meta charset="utf-8">
     <title>Fiber Example</title>
@@ -19,26 +19,156 @@
     </div>
     <script src="../../build/react.js"></script>
     <script src="../../build/react-dom-fiber.js"></script>
-    <script>
-      function ExampleApplication(props) {
-        var elapsed = Math.round(props.elapsed  / 100);
-        var seconds = elapsed / 10 + (elapsed % 10 ? '' : '.0' );
-        var message =
-          'React has been successfully running for ' + seconds + ' seconds.';
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.24/browser.min.js"></script>
+    <script type="text/babel">
+      var dotStyle = {
+        position: 'absolute',
+        background: '#61dafb',
+        font: 'normal 15px sans-serif',
+        textAlign: 'center',
+        cursor: 'pointer',
+      };
 
-        return React.DOM.p(null, message);
+      var containerStyle = {
+        position: 'absolute',
+        transformOrigin: '0 0',
+        left: '50%',
+        top: '50%',
+        width: '10px',
+        height: '10px',
+        background: '#eee',
+      };
+
+      var targetSize = 25;
+
+      class Dot extends React.Component {
+        constructor() {
+          super();
+          this.state = { hover: false };
+        }
+        enter() {
+          this.setState({
+            hover: true
+          });
+        }
+        leave() {
+          this.setState({
+            hover: false
+          });
+        }
+        render() {
+          var props = this.props;
+          var s = props.size * 1.3;
+          var style = {
+            ...dotStyle,
+            width: s + 'px',
+            height: s + 'px',
+            left: (props.x) + 'px',
+            top: (props.y) + 'px',
+            borderRadius: (s / 2) + 'px',
+            lineHeight: (s) + 'px',
+            background: this.state.hover ? '#ff0' : dotStyle.background
+          };
+          return (
+            <div style={style} onMouseEnter={() => this.enter()} onMouseLeave={() => this.leave()}>
+              {this.state.hover ? '*' + props.text + '*' : props.text}
+            </div>
+          );
+        }
       }
 
-      // Call React.createFactory instead of directly call ExampleApplication({...}) in React.render
-      var ExampleApplicationFactory = React.createFactory(ExampleApplication);
+      function SierpinskiTriangle({ x, y, s, children }) {
+        if (s <= targetSize) {
+          return (
+            <Dot
+              x={x - (targetSize / 2)}
+              y={y - (targetSize / 2)}
+              size={targetSize}
+              text={children}
+            />
+          );
+          return r;
+        }
+        var newSize = s / 2;
+        var slowDown = false;
+        if (slowDown) {
+          var e = performance.now() + 0.8;
+          while (performance.now() < e) {
+            // Artificially long execution time.
+          }
+        }
+
+        s /= 2;
+
+        return [
+          <SierpinskiTriangle x={x} y={y - (s / 2)} s={s}>
+            {children}
+          </SierpinskiTriangle>,
+          <SierpinskiTriangle x={x - s} y={y + (s / 2)} s={s}>
+            {children}
+          </SierpinskiTriangle>,
+          <SierpinskiTriangle x={x + s} y={y + (s / 2)} s={s}>
+            {children}
+          </SierpinskiTriangle>,
+        ];
+      }
+      SierpinskiTriangle.shouldComponentUpdate = function(oldProps, newProps) {
+        var o = oldProps;
+        var n = newProps;
+        const res = !(
+          o.x === n.x &&
+          o.y === n.y &&
+          o.s === n.s &&
+          o.children === n.children
+        );
+        // console.log('shouldComponentUpdate', res);
+        return res;
+      };
+
+      class ExampleApplication extends React.Component {
+        constructor() {
+          super();
+          this.state = { seconds: 0 };
+          this.tick = this.tick.bind(this);
+        }
+        componentDidMount() {
+          this.invervalID = setInterval(this.tick, 1000);
+        }
+        tick() {
+          ReactDOMFiber.unstable_deferredUpdates(() =>
+            this.setState(state => ({ seconds: (state.seconds % 10) + 1 }))
+          );
+        }
+        componentWillUnmount() {
+          clearInterval(this.intervalID);
+        }
+        render() {
+          const seconds = this.state.seconds;
+          const elapsed = this.props.elapsed;
+          const t = (elapsed / 1000) % 10;
+          const scale = 1 + (t > 5 ? 10 - t : t) / 10;
+          const transform = 'scaleX(' + (scale / 2.1) + ') scaleY(0.7) translateZ(0.1px)';
+          return (
+            <div style={{ ...containerStyle, transform }}>
+              <div>
+                <SierpinskiTriangle x={0} y={0} s={1000}>
+                  {this.state.seconds}
+                </SierpinskiTriangle>
+              </div>
+            </div>
+          );
+        }
+      }
 
       var start = new Date().getTime();
-      setInterval(function() {
+      function update() {
         ReactDOMFiber.render(
-          ExampleApplicationFactory({elapsed: new Date().getTime() - start}),
+          <ExampleApplication elapsed={new Date().getTime() - start} />,
           document.getElementById('container')
         );
-      }, 50);
+        requestAnimationFrame(update);
+      }
+      requestAnimationFrame(update);
     </script>
   </body>
 </html>

--- a/examples/fiber/index.html
+++ b/examples/fiber/index.html
@@ -115,14 +115,12 @@
       SierpinskiTriangle.shouldComponentUpdate = function(oldProps, newProps) {
         var o = oldProps;
         var n = newProps;
-        const res = !(
+        return !(
           o.x === n.x &&
           o.y === n.y &&
           o.s === n.s &&
           o.children === n.children
         );
-        // console.log('shouldComponentUpdate', res);
-        return res;
       };
 
       class ExampleApplication extends React.Component {

--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -71,12 +71,7 @@ src/renderers/shared/shared/__tests__/ReactComponentLifeCycle-test.js
 * should carry through each of the phases of setup
 
 src/renderers/shared/shared/__tests__/ReactCompositeComponent-test.js
-* should warn about `setState` in render
-* should warn about `setState` in getChildContext
 * should update refs if shouldComponentUpdate gives false
-
-src/renderers/shared/shared/__tests__/ReactCompositeComponentState-test.js
-* should update state when called from child cWRP
 
 src/renderers/shared/shared/__tests__/ReactEmptyComponent-test.js
 * should still throw when rendering to undefined

--- a/scripts/fiber/tests-passing-except-dev.txt
+++ b/scripts/fiber/tests-passing-except-dev.txt
@@ -114,6 +114,8 @@ src/renderers/shared/shared/__tests__/ReactComponentLifeCycle-test.js
 src/renderers/shared/shared/__tests__/ReactCompositeComponent-test.js
 * should warn about `forceUpdate` on unmounted components
 * should warn about `setState` on unmounted components
+* should warn about `setState` in render
+* should warn about `setState` in getChildContext
 * should disallow nested render calls
 
 src/renderers/shared/shared/__tests__/ReactMultiChild-test.js

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1230,6 +1230,14 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
 * invokes ref callbacks after insertion/update/unmount
 * supports string refs
 
+src/renderers/shared/fiber/__tests__/ReactIncrementalUpdates-test.js
+* applies updates in order of priority
+* applies updates with equal priority in insertion order
+* only drops updates with equal or lesser priority when replaceState is called
+* can abort an update, schedule additional updates, and resume
+* can abort an update, schedule a replaceState, and resume
+* does not call callbacks that are scheduled by another callback until a later commit
+
 src/renderers/shared/fiber/__tests__/ReactTopLevelFragment-test.js
 * should render a simple fragment at the top of a component
 * should preserve state when switching from a single child

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1382,6 +1382,7 @@ src/renderers/shared/shared/__tests__/ReactCompositeComponentState-test.js
 * should support setting state
 * should call componentDidUpdate of children first
 * should batch unmounts
+* should update state when called from child cWRP
 
 src/renderers/shared/shared/__tests__/ReactEmptyComponent-test.js
 * should not produce child DOM nodes for null and false

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1237,6 +1237,7 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalUpdates-test.js
 * can abort an update, schedule additional updates, and resume
 * can abort an update, schedule a replaceState, and resume
 * does not call callbacks that are scheduled by another callback until a later commit
+* enqueues setState inside an updater function as if the in-progress update is progressed (and warns)
 
 src/renderers/shared/fiber/__tests__/ReactTopLevelFragment-test.js
 * should render a simple fragment at the top of a component

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1237,6 +1237,7 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalUpdates-test.js
 * can abort an update, schedule additional updates, and resume
 * can abort an update, schedule a replaceState, and resume
 * does not call callbacks that are scheduled by another callback until a later commit
+* gives setState during reconciliation the same priority as whatever level is currently reconciling
 * enqueues setState inside an updater function as if the in-progress update is progressed (and warns)
 
 src/renderers/shared/fiber/__tests__/ReactTopLevelFragment-test.js

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -242,6 +242,8 @@ var ReactDOM = {
 
   unstable_batchedUpdates: ReactGenericBatching.batchedUpdates,
 
+  unstable_deferredUpdates: DOMRenderer.deferredUpdates,
+
 };
 
 module.exports = ReactDOM;

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -286,23 +286,18 @@ var ReactNoop = {
       log(
         '  '.repeat(depth + 1) + 'QUEUED UPDATES'
       );
-      let firstPendingUpdate;
-      if (updateQueue.lastProgressedUpdate) {
-        firstPendingUpdate = updateQueue.lastProgressedUpdate.next;
-      } else {
-        firstPendingUpdate = updateQueue.first;
-      }
-      if (!firstPendingUpdate) {
+      const firstUpdate = updateQueue.first;
+      if (!firstUpdate) {
         return;
       }
 
       log(
         '  '.repeat(depth + 1) + '~',
-        firstPendingUpdate && firstPendingUpdate.partialState,
-        firstPendingUpdate.callback ? 'with callback' : ''
+        firstUpdate && firstUpdate.partialState,
+        firstUpdate.callback ? 'with callback' : ''
       );
       var next;
-      while (next = firstPendingUpdate.next) {
+      while (next = firstUpdate.next) {
         log(
           '  '.repeat(depth + 1) + '~',
           next.partialState,

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -286,10 +286,16 @@ var ReactNoop = {
       log(
         '  '.repeat(depth + 1) + 'QUEUED UPDATES'
       );
-      const firstPendingUpdate = updateQueue.firstPendingUpdate;
+      let firstPendingUpdate;
+      if (updateQueue.lastProgressedUpdate) {
+        firstPendingUpdate = updateQueue.lastProgressedUpdate.next;
+      } else {
+        firstPendingUpdate = updateQueue.first;
+      }
       if (!firstPendingUpdate) {
         return;
       }
+
       log(
         '  '.repeat(depth + 1) + '~',
         firstPendingUpdate && firstPendingUpdate.partialState,

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -284,17 +284,19 @@ var ReactNoop = {
 
     function logUpdateQueue(updateQueue : UpdateQueue, depth) {
       log(
-        '  '.repeat(depth + 1) + 'QUEUED UPDATES',
-        updateQueue.isReplace ? 'is replace' : '',
-        updateQueue.isForced ? 'is forced' : ''
+        '  '.repeat(depth + 1) + 'QUEUED UPDATES'
       );
+      const firstPendingUpdate = updateQueue.firstPendingUpdate;
+      if (!firstPendingUpdate) {
+        return;
+      }
       log(
         '  '.repeat(depth + 1) + '~',
-        updateQueue.partialState,
-        updateQueue.callback ? 'with callback' : ''
+        firstPendingUpdate && firstPendingUpdate.partialState,
+        firstPendingUpdate.callback ? 'with callback' : ''
       );
       var next;
-      while (next = updateQueue.next) {
+      while (next = firstPendingUpdate.next) {
         log(
           '  '.repeat(depth + 1) + '~',
           next.partialState,

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -43,6 +43,10 @@ var {
   NoEffect,
 } = require('ReactTypeOfSideEffect');
 
+var {
+  cloneUpdateQueue,
+} = require('ReactFiberUpdateQueue');
+
 var invariant = require('invariant');
 
 // A Fiber is work on a Component that needs to be done or was done. There can
@@ -103,6 +107,8 @@ export type Fiber = {
 
   // A queue of state updates and callbacks.
   updateQueue: UpdateQueue | null,
+  // A list of callbacks that should be called during the next commit.
+  callbackList: UpdateQueue | null,
   // The state used to create the output
   memoizedState: any,
 
@@ -193,6 +199,7 @@ var createFiber = function(tag : TypeOfWork, key : null | string) : Fiber {
     pendingProps: null,
     memoizedProps: null,
     updateQueue: null,
+    callbackList: null,
     memoizedState: null,
 
     effectTag: NoEffect,
@@ -268,7 +275,7 @@ exports.cloneFiber = function(fiber : Fiber, priorityLevel : PriorityLevel) : Fi
   // pendingProps is here for symmetry but is unnecessary in practice for now.
   // TODO: Pass in the new pendingProps as an argument maybe?
   alt.pendingProps = fiber.pendingProps;
-  alt.updateQueue = fiber.updateQueue;
+  cloneUpdateQueue(alt, fiber);
   alt.pendingWorkPriority = priorityLevel;
 
   alt.memoizedProps = fiber.memoizedProps;

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -100,12 +100,11 @@ export type Fiber = {
   pendingProps: any, // This type will be more specific once we overload the tag.
   // TODO: I think that there is a way to merge pendingProps and memoizedProps.
   memoizedProps: any, // The props used to create the output.
-  // A queue of local state updates.
-  updateQueue: ?UpdateQueue,
-  // The state used to create the output. This is a full state object.
+
+  // A queue of state updates and callbacks.
+  updateQueue: UpdateQueue | null,
+  // The state used to create the output
   memoizedState: any,
-  // Linked list of callbacks to call after updates are committed.
-  callbackList: ?UpdateQueue,
 
   // Effect
   effectTag: TypeOfSideEffect,
@@ -195,7 +194,6 @@ var createFiber = function(tag : TypeOfWork, key : null | string) : Fiber {
     memoizedProps: null,
     updateQueue: null,
     memoizedState: null,
-    callbackList: null,
 
     effectTag: NoEffect,
     nextEffect: null,
@@ -271,7 +269,6 @@ exports.cloneFiber = function(fiber : Fiber, priorityLevel : PriorityLevel) : Fi
   // TODO: Pass in the new pendingProps as an argument maybe?
   alt.pendingProps = fiber.pendingProps;
   alt.updateQueue = fiber.updateQueue;
-  alt.callbackList = fiber.callbackList;
   alt.pendingWorkPriority = priorityLevel;
 
   alt.memoizedProps = fiber.memoizedProps;

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -71,8 +71,10 @@ if (__DEV__) {
 module.exports = function<T, P, I, TI, C, CX>(
   config : HostConfig<T, P, I, TI, C, CX>,
   hostContext : HostContext<C, CX>,
-  scheduleUpdateAtPriority : (fiber: Fiber, priorityLevel : PriorityLevel) => void,
-  getPriorityContext : () => PriorityLevel
+  scheduleSetState: (fiber : Fiber, partialState : any) => void,
+  scheduleReplaceState: (fiber : Fiber, state : any) => void,
+  scheduleForceUpdate: (fiber : Fiber) => void,
+  scheduleUpdateCallback: (fiber : Fiber, callback : Function) => void,
 ) {
 
   const { shouldSetTextContent } = config;
@@ -89,7 +91,12 @@ module.exports = function<T, P, I, TI, C, CX>(
     mountClassInstance,
     resumeMountClassInstance,
     updateClassInstance,
-  } = ReactFiberClassComponent(scheduleUpdateAtPriority, getPriorityContext);
+  } = ReactFiberClassComponent(
+    scheduleSetState,
+    scheduleReplaceState,
+    scheduleForceUpdate,
+    scheduleUpdateCallback
+  );
 
   function markChildAsProgressed(current, workInProgress, priorityLevel) {
     // We now have clones. Let's store them as the currently progressed work.

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -502,7 +502,7 @@ module.exports = function<T, P, I, TI, C, CX>(
       )                                     // )
     );
     if (!hasNewProps) {
-      const hasUpdate = updateQueue && hasPendingUpdate(updateQueue);
+      const hasUpdate = updateQueue && hasPendingUpdate(updateQueue, priorityLevel);
       if (!hasUpdate && !hasContextChanged()) {
         return bailoutOnAlreadyFinishedWork(current, workInProgress);
       }

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -493,8 +493,6 @@ module.exports = function<T, P, I, TI, C, CX>(
     const memoizedProps = workInProgress.memoizedProps;
     const updateQueue = workInProgress.updateQueue;
 
-
-
     // This is kept as a single expression to take advantage of short-circuiting.
     const hasNewProps = (
       pendingProps !== null && (            // hasPendingProps && (

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -27,7 +27,7 @@ var {
 } = require('ReactChildFiber');
 var {
   hasPendingUpdate,
-  mergeQueue,
+  beginUpdateQueue,
 } = require('ReactFiberUpdateQueue');
 var ReactTypeOfWork = require('ReactTypeOfWork');
 var {
@@ -57,7 +57,6 @@ var {
 } = require('ReactPriorityLevel');
 var {
   Update,
-  Callback,
   Placement,
   ContentReset,
   Err,
@@ -217,12 +216,6 @@ module.exports = function<T, P, I, TI, C, CX>(
     }
 
     // Schedule side-effects
-    const updateQueue = workInProgress.updateQueue;
-    if (updateQueue && updateQueue.hasCallback) {
-      // The update queue has a callback. Schedule a callback effect.
-      // Callbacks are scheduled regardless of whether we bail out below.
-      workInProgress.effectTag |= Callback;
-    }
     if (shouldUpdate) {
       workInProgress.effectTag |= Update;
     } else {
@@ -537,10 +530,7 @@ module.exports = function<T, P, I, TI, C, CX>(
         if (updateQueue) {
           // The last three arguments are unimportant because there should be
           // no update functions in a HostRoot's queue.
-          mergeQueue(updateQueue, null, null, null);
-          if (updateQueue.hasCallback) {
-            workInProgress.effectTag |= Callback;
-          }
+          beginUpdateQueue(workInProgress, updateQueue, null, null, null);
         }
 
         pushHostContainer(workInProgress.stateNode.containerInfo);

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -26,6 +26,8 @@ var {
   addCallback,
   beginUpdateQueue,
 } = require('ReactFiberUpdateQueue');
+var { hasContextChanged } = require('ReactFiberContext');
+var { ForceUpdate } = require('ReactTypeOfSideEffect');
 var { getComponentName, isMounted } = require('ReactFiberTreeReflection');
 var ReactInstanceMap = require('ReactInstanceMap');
 var shallowEqual = require('shallowEqual');
@@ -76,8 +78,7 @@ module.exports = function(scheduleUpdate : (fiber: Fiber) => void) {
   };
 
   function checkShouldComponentUpdate(workInProgress, oldProps, newProps, newState, newContext) {
-    const updateQueue = workInProgress.updateQueue;
-    if (oldProps === null || (updateQueue && updateQueue.hasForceUpdate)) {
+    if (oldProps === null || (workInProgress.effectTag & ForceUpdate)) {
       // If the workInProgress already has an Update effect, return true
       return true;
     }
@@ -339,8 +340,8 @@ module.exports = function(scheduleUpdate : (fiber: Fiber) => void) {
 
     if (oldProps === newProps &&
         oldState === newState &&
-        oldContext === newContext &&
-        updateQueue && !updateQueue.hasForceUpdate) {
+        !hasContextChanged() &&
+        !(workInProgress.effectTag & ForceUpdate)) {
       return false;
     }
 

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -24,7 +24,7 @@ var {
   addReplaceUpdate,
   addForceUpdate,
   addCallback,
-  mergeQueue,
+  beginUpdateQueue,
 } = require('ReactFiberUpdateQueue');
 var { getComponentName, isMounted } = require('ReactFiberTreeReflection');
 var ReactInstanceMap = require('ReactInstanceMap');
@@ -78,6 +78,7 @@ module.exports = function(scheduleUpdate : (fiber: Fiber) => void) {
   function checkShouldComponentUpdate(workInProgress, oldProps, newProps, newState, newContext) {
     const updateQueue = workInProgress.updateQueue;
     if (oldProps === null || (updateQueue && updateQueue.hasForceUpdate)) {
+      // If the workInProgress already has an Update effect, return true
       return true;
     }
 
@@ -244,7 +245,7 @@ module.exports = function(scheduleUpdate : (fiber: Fiber) => void) {
       // process them now.
       const updateQueue = workInProgress.updateQueue;
       if (updateQueue) {
-        instance.state = mergeQueue(updateQueue, instance, state, props);
+        instance.state = beginUpdateQueue(workInProgress, updateQueue, instance, state, props);
       }
     }
   }
@@ -293,7 +294,7 @@ module.exports = function(scheduleUpdate : (fiber: Fiber) => void) {
     // during initial mounting.
     const newUpdateQueue = workInProgress.updateQueue;
     if (newUpdateQueue) {
-      newInstance.state = mergeQueue(newUpdateQueue, newInstance, newState, newProps);
+      newInstance.state = beginUpdateQueue(workInProgress, newUpdateQueue, newInstance, newState, newProps);
     }
     return true;
   }
@@ -331,7 +332,7 @@ module.exports = function(scheduleUpdate : (fiber: Fiber) => void) {
     // TODO: Previous state can be null.
     let newState;
     if (updateQueue) {
-      newState = mergeQueue(updateQueue, instance, oldState, newProps);
+      newState = beginUpdateQueue(workInProgress, updateQueue, instance, oldState, newProps);
     } else {
       newState = oldState;
     }

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -22,7 +22,6 @@ var {
   beginUpdateQueue,
 } = require('ReactFiberUpdateQueue');
 var { hasContextChanged } = require('ReactFiberContext');
-var { ForceUpdate } = require('ReactTypeOfSideEffect');
 var { getComponentName, isMounted } = require('ReactFiberTreeReflection');
 var ReactInstanceMap = require('ReactInstanceMap');
 var shallowEqual = require('shallowEqual');
@@ -60,7 +59,7 @@ module.exports = function(
   };
 
   function checkShouldComponentUpdate(workInProgress, oldProps, newProps, newState, newContext) {
-    if (oldProps === null || (workInProgress.effectTag & ForceUpdate)) {
+    if (oldProps === null || (workInProgress.updateQueue && workInProgress.updateQueue.hasForceUpdate)) {
       // If the workInProgress already has an Update effect, return true
       return true;
     }
@@ -344,7 +343,7 @@ module.exports = function(
     if (oldProps === newProps &&
         oldState === newState &&
         !hasContextChanged() &&
-        !(workInProgress.effectTag & ForceUpdate)) {
+        !(updateQueue && updateQueue.hasForceUpdate)) {
       return false;
     }
 

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -19,7 +19,6 @@ var {
   getMaskedContext,
 } = require('ReactFiberContext');
 var {
-  ensureUpdateQueue,
   addUpdate,
   addReplaceUpdate,
   addForceUpdate,
@@ -46,30 +45,26 @@ module.exports = function(
     isMounted,
     enqueueSetState(instance, partialState) {
       const fiber = ReactInstanceMap.get(instance);
-      const queue = ensureUpdateQueue(fiber);
       const priorityLevel = getPriorityContext();
-      addUpdate(queue, partialState, priorityLevel);
+      addUpdate(fiber, partialState, priorityLevel);
       scheduleUpdateAtPriority(fiber, priorityLevel);
     },
     enqueueReplaceState(instance, state) {
       const fiber = ReactInstanceMap.get(instance);
-      const queue = ensureUpdateQueue(fiber);
       const priorityLevel = getPriorityContext();
-      addReplaceUpdate(queue, state, priorityLevel);
+      addReplaceUpdate(fiber, state, priorityLevel);
       scheduleUpdateAtPriority(fiber, priorityLevel);
     },
     enqueueForceUpdate(instance) {
       const fiber = ReactInstanceMap.get(instance);
-      const queue = ensureUpdateQueue(fiber);
       const priorityLevel = getPriorityContext();
-      addForceUpdate(queue, priorityLevel);
+      addForceUpdate(fiber, priorityLevel);
       scheduleUpdateAtPriority(fiber, priorityLevel);
     },
     enqueueCallback(instance, callback) {
       const fiber = ReactInstanceMap.get(instance);
-      const queue = ensureUpdateQueue(fiber);
       const priorityLevel = getPriorityContext();
-      addCallback(queue, callback, priorityLevel);
+      addCallback(fiber, callback, priorityLevel);
       scheduleUpdateAtPriority(fiber, priorityLevel);
     },
   };

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -19,10 +19,6 @@ var {
   getMaskedContext,
 } = require('ReactFiberContext');
 var {
-  addUpdate,
-  addReplaceUpdate,
-  addForceUpdate,
-  addCallback,
   beginUpdateQueue,
 } = require('ReactFiberUpdateQueue');
 var { hasContextChanged } = require('ReactFiberContext');
@@ -36,8 +32,10 @@ var invariant = require('invariant');
 const isArray = Array.isArray;
 
 module.exports = function(
-  scheduleUpdateAtPriority : (fiber: Fiber, priorityLevel : PriorityLevel) => void,
-  getPriorityContext : () => PriorityLevel,
+  scheduleSetState: (fiber : Fiber, partialState : any) => void,
+  scheduleReplaceState: (fiber : Fiber, state : any) => void,
+  scheduleForceUpdate: (fiber : Fiber) => void,
+  scheduleUpdateCallback: (fiber : Fiber, callback : Function) => void,
 ) {
 
   // Class component state updater
@@ -45,27 +43,19 @@ module.exports = function(
     isMounted,
     enqueueSetState(instance, partialState) {
       const fiber = ReactInstanceMap.get(instance);
-      const priorityLevel = getPriorityContext();
-      addUpdate(fiber, partialState, priorityLevel);
-      scheduleUpdateAtPriority(fiber, priorityLevel);
+      scheduleSetState(fiber, partialState);
     },
     enqueueReplaceState(instance, state) {
       const fiber = ReactInstanceMap.get(instance);
-      const priorityLevel = getPriorityContext();
-      addReplaceUpdate(fiber, state, priorityLevel);
-      scheduleUpdateAtPriority(fiber, priorityLevel);
+      scheduleReplaceState(fiber, state);
     },
     enqueueForceUpdate(instance) {
       const fiber = ReactInstanceMap.get(instance);
-      const priorityLevel = getPriorityContext();
-      addForceUpdate(fiber, priorityLevel);
-      scheduleUpdateAtPriority(fiber, priorityLevel);
+      scheduleForceUpdate(fiber);
     },
     enqueueCallback(instance, callback) {
       const fiber = ReactInstanceMap.get(instance);
-      const priorityLevel = getPriorityContext();
-      addCallback(fiber, callback, priorityLevel);
-      scheduleUpdateAtPriority(fiber, priorityLevel);
+      scheduleUpdateCallback(fiber, callback);
     },
   };
 

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -25,12 +25,11 @@ var {
   HostPortal,
   CoroutineComponent,
 } = ReactTypeOfWork;
-var { callCallbacks } = require('ReactFiberUpdateQueue');
+var { commitUpdateQueue } = require('ReactFiberUpdateQueue');
 
 var {
   Placement,
   Update,
-  Callback,
   ContentReset,
 } = require('ReactTypeOfSideEffect');
 
@@ -418,25 +417,16 @@ module.exports = function<T, P, I, TI, C, CX>(
           }
           attachRef(current, finishedWork, instance);
         }
-        // Clear updates from current fiber.
-        if (finishedWork.alternate) {
-          finishedWork.alternate.updateQueue = null;
-        }
-        if (finishedWork.effectTag & Callback) {
-          if (finishedWork.callbackList) {
-            const callbackList = finishedWork.callbackList;
-            finishedWork.callbackList = null;
-            callCallbacks(callbackList, instance);
-          }
+        if (finishedWork.updateQueue) {
+          commitUpdateQueue(finishedWork, finishedWork.updateQueue, instance);
         }
         return;
       }
       case HostRoot: {
-        const rootFiber = finishedWork.stateNode;
-        if (rootFiber.callbackList) {
-          const callbackList = rootFiber.callbackList;
-          rootFiber.callbackList = null;
-          callCallbacks(callbackList, rootFiber.current.child.stateNode);
+        const updateQueue = finishedWork.updateQueue;
+        if (updateQueue) {
+          const instance = finishedWork.child && finishedWork.child.stateNode;
+          commitUpdateQueue(finishedWork, updateQueue, instance);
         }
         return;
       }

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -25,7 +25,7 @@ var {
   HostPortal,
   CoroutineComponent,
 } = ReactTypeOfWork;
-var { commitUpdateQueue } = require('ReactFiberUpdateQueue');
+var { commitCallbacks } = require('ReactFiberUpdateQueue');
 
 var {
   Placement,
@@ -417,16 +417,17 @@ module.exports = function<T, P, I, TI, C, CX>(
           }
           attachRef(current, finishedWork, instance);
         }
-        if (finishedWork.updateQueue) {
-          commitUpdateQueue(finishedWork, finishedWork.updateQueue, instance);
+        const callbackList = finishedWork.callbackList;
+        if (callbackList) {
+          commitCallbacks(finishedWork, callbackList, instance);
         }
         return;
       }
       case HostRoot: {
-        const updateQueue = finishedWork.updateQueue;
-        if (updateQueue) {
+        const callbackList = finishedWork.callbackList;
+        if (callbackList) {
           const instance = finishedWork.child && finishedWork.child.stateNode;
-          commitUpdateQueue(finishedWork, updateQueue, instance);
+          commitCallbacks(finishedWork, callbackList, instance);
         }
         return;
       }

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -173,7 +173,7 @@ module.exports = function<T, P, I, TI, C, CX>(
       case FunctionalComponent:
         workInProgress.memoizedProps = workInProgress.pendingProps;
         return null;
-      case ClassComponent:
+      case ClassComponent: {
         // We are leaving this subtree, so pop context if any.
         if (isContextProvider(workInProgress)) {
           popContextProvider();
@@ -182,11 +182,12 @@ module.exports = function<T, P, I, TI, C, CX>(
         // merged it and assigned it to the instance. Transfer it from there.
         // Also need to transfer the props, because pendingProps will be null
         // in the case of an update.
-        const { state, props } = workInProgress.stateNode;
-        workInProgress.memoizedState = state;
-        workInProgress.memoizedProps = props;
+        const instance = workInProgress.stateNode;
+        workInProgress.memoizedState = instance.state;
+        workInProgress.memoizedProps = instance.props;
 
         return null;
+      }
       case HostRoot: {
         workInProgress.memoizedProps = workInProgress.pendingProps;
         const fiberRoot = (workInProgress.stateNode : FiberRoot);

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -41,7 +41,6 @@ var {
 } = ReactTypeOfWork;
 var {
   Update,
-  Callback,
 } = ReactTypeOfSideEffect;
 
 if (__DEV__) {
@@ -71,11 +70,6 @@ module.exports = function<T, P, I, TI, C, CX>(
     // Tag the fiber with an update effect. This turns a Placement into
     // an UpdateAndPlacement.
     workInProgress.effectTag |= Update;
-  }
-
-  function markCallback(workInProgress : Fiber) {
-    // Tag the fiber with a callback effect.
-    workInProgress.effectTag |= Callback;
   }
 
   function appendAllYields(yields : Array<ReifiedYield>, workInProgress : Fiber) {
@@ -187,26 +181,11 @@ module.exports = function<T, P, I, TI, C, CX>(
         // Don't use the state queue to compute the memoized state. We already
         // merged it and assigned it to the instance. Transfer it from there.
         // Also need to transfer the props, because pendingProps will be null
-        // in the case of an update
+        // in the case of an update.
         const { state, props } = workInProgress.stateNode;
-        const updateQueue = workInProgress.updateQueue;
         workInProgress.memoizedState = state;
         workInProgress.memoizedProps = props;
-        if (current) {
-          if (current.memoizedProps !== workInProgress.memoizedProps ||
-              current.memoizedState !== workInProgress.memoizedState ||
-              updateQueue && updateQueue.isForced) {
-            markUpdate(workInProgress);
-          }
-        } else {
-          markUpdate(workInProgress);
-        }
-        if (updateQueue && updateQueue.hasCallback) {
-          // Transfer update queue to callbackList field so callbacks can be
-          // called during commit phase.
-          workInProgress.callbackList = updateQueue;
-          markCallback(workInProgress);
-        }
+
         return null;
       case HostRoot: {
         workInProgress.memoizedProps = workInProgress.pendingProps;
@@ -215,9 +194,6 @@ module.exports = function<T, P, I, TI, C, CX>(
           fiberRoot.context = fiberRoot.pendingContext;
           fiberRoot.pendingContext = null;
         }
-        // TODO: Only mark this as an update if we have any pending callbacks
-        // on it.
-        markUpdate(workInProgress);
         return null;
       }
       case HostComponent:

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -24,7 +24,7 @@ var {
 var { createFiberRoot } = require('ReactFiberRoot');
 var ReactFiberScheduler = require('ReactFiberScheduler');
 
-var { createUpdateQueue, addCallback } = require('ReactFiberUpdateQueue');
+var { ensureUpdateQueue, addCallback } = require('ReactFiberUpdateQueue');
 
 if (__DEV__) {
   var ReactFiberInstrumentation = require('ReactFiberInstrumentation');
@@ -99,6 +99,7 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
 
   var {
     scheduleWork,
+    getPriorityContext,
     performWithPriority,
     batchedUpdates,
     syncUpdates,
@@ -114,13 +115,15 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
       // TODO: Use the updateQueue and scheduleUpdate, instead of pendingProps.
       // TODO: This should not override the pendingWorkPriority if there is
       // higher priority work in the subtree.
+
       current.pendingProps = element;
       if (current.alternate) {
         current.alternate.pendingProps = element;
       }
       if (callback) {
-        const queue = current.updateQueue || createUpdateQueue();
-        addCallback(queue, callback);
+        const queue = ensureUpdateQueue(current);
+        const priorityLevel = getPriorityContext();
+        addCallback(queue, callback, priorityLevel);
         current.updateQueue = queue;
         if (current.alternate) {
           current.alternate.updateQueue = queue;
@@ -154,8 +157,9 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
         current.alternate.pendingProps = element;
       }
       if (callback) {
-        const queue = current.updateQueue || createUpdateQueue();
-        addCallback(queue, callback);
+        const queue = ensureUpdateQueue(current);
+        const priorityLevel = getPriorityContext();
+        addCallback(queue, callback, priorityLevel);
         current.updateQueue = queue;
         if (current.alternate) {
           current.alternate.updateQueue = queue;

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -79,6 +79,7 @@ export type Reconciler<C, I, TI> = {
   // FIXME: ESLint complains about type parameter
   batchedUpdates<A>(fn : () => A) : A,
   syncUpdates<A>(fn : () => A) : A,
+  deferredUpdates<A>(fn : () => A) : A,
   /* eslint-enable no-undef */
 
   // Used to extract the return value from the initial render. Legacy API.
@@ -103,6 +104,7 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
     performWithPriority,
     batchedUpdates,
     syncUpdates,
+    deferredUpdates,
   } = ReactFiberScheduler(config);
 
   return {
@@ -194,6 +196,8 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
     batchedUpdates,
 
     syncUpdates,
+
+    deferredUpdates,
 
     getPublicRootInstance(container : OpaqueNode) : (ReactComponent<any, any, any> | I | TI | null) {
       const root : FiberRoot = (container.stateNode : any);

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -24,7 +24,7 @@ var {
 var { createFiberRoot } = require('ReactFiberRoot');
 var ReactFiberScheduler = require('ReactFiberScheduler');
 
-var { ensureUpdateQueue, addCallback } = require('ReactFiberUpdateQueue');
+var { addCallback } = require('ReactFiberUpdateQueue');
 
 if (__DEV__) {
   var ReactFiberInstrumentation = require('ReactFiberInstrumentation');
@@ -123,13 +123,8 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
         current.alternate.pendingProps = element;
       }
       if (callback) {
-        const queue = ensureUpdateQueue(current);
         const priorityLevel = getPriorityContext();
-        addCallback(queue, callback, priorityLevel);
-        current.updateQueue = queue;
-        if (current.alternate) {
-          current.alternate.updateQueue = queue;
-        }
+        addCallback(current, callback, priorityLevel);
       }
 
       scheduleWork(root);
@@ -159,13 +154,8 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
         current.alternate.pendingProps = element;
       }
       if (callback) {
-        const queue = ensureUpdateQueue(current);
         const priorityLevel = getPriorityContext();
-        addCallback(queue, callback, priorityLevel);
-        current.updateQueue = queue;
-        if (current.alternate) {
-          current.alternate.updateQueue = queue;
-        }
+        addCallback(current, callback, priorityLevel);
       }
 
       scheduleWork(root);

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -24,8 +24,6 @@ var {
 var { createFiberRoot } = require('ReactFiberRoot');
 var ReactFiberScheduler = require('ReactFiberScheduler');
 
-var { addCallback } = require('ReactFiberUpdateQueue');
-
 if (__DEV__) {
   var ReactFiberInstrumentation = require('ReactFiberInstrumentation');
 }
@@ -100,7 +98,7 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
 
   var {
     scheduleWork,
-    getPriorityContext,
+    scheduleUpdateCallback,
     performWithPriority,
     batchedUpdates,
     syncUpdates,
@@ -123,8 +121,7 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
         current.alternate.pendingProps = element;
       }
       if (callback) {
-        const priorityLevel = getPriorityContext();
-        addCallback(current, callback, priorityLevel);
+        scheduleUpdateCallback(current, callback);
       }
 
       scheduleWork(root);
@@ -154,8 +151,7 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
         current.alternate.pendingProps = element;
       }
       if (callback) {
-        const priorityLevel = getPriorityContext();
-        addCallback(current, callback, priorityLevel);
+        scheduleUpdateCallback(current, callback);
       }
 
       scheduleWork(root);

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -13,7 +13,6 @@
 'use strict';
 
 import type { Fiber } from 'ReactFiber';
-import type { UpdateQueue } from 'ReactFiberUpdateQueue';
 
 const { createHostRootFiber } = require('ReactFiber');
 
@@ -26,8 +25,6 @@ export type FiberRoot = {
   isScheduled: boolean,
   // The work schedule is a linked list.
   nextScheduledRoot: ?FiberRoot,
-  // Linked list of callbacks to call after updates are committed.
-  callbackList: ?UpdateQueue,
   // Top context object, used by renderSubtreeIntoContainer
   context: Object,
   pendingContext: ?Object,

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -392,7 +392,6 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
       // The work is now done. We don't need this anymore. This flags
       // to the system not to redo any work here.
       workInProgress.pendingProps = null;
-      workInProgress.updateQueue = null;
 
       const returnFiber = workInProgress.return;
       const siblingFiber = workInProgress.sibling;

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -680,17 +680,9 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
       }
 
       // Before starting any work, check to see if there are any pending
-      // commits from the previous frame. An exception is if we're flushing
-      // Task work in a deferred batch and the pending commit does not
-      // have Task priority.
-      if (pendingCommit) {
-        const isFlushingTaskWorkInDeferredBatch =
-          priorityLevel === TaskPriority &&
-          isPerformingDeferredWork &&
-          pendingCommit.pendingWorkPriority !== TaskPriority;
-        if (!isFlushingTaskWorkInDeferredBatch) {
-          commitAllWork(pendingCommit);
-        }
+      // commits from the previous frame.
+      if (pendingCommit && !deadlineHasExpired) {
+        commitAllWork(pendingCommit);
       }
 
       // Nothing in performWork should be allowed to throw. All unsafe

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -390,7 +390,8 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
   function resetWorkPriority(workInProgress : Fiber) {
     let newPriority = NoWork;
 
-    // Check for pending update priority
+    // Check for pending update priority. This is usually null so it shouldn't
+    // be a perf issue.
     const queue = workInProgress.updateQueue;
     if (queue) {
       newPriority = getPendingPriority(queue);

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -1076,11 +1076,22 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
     }
   }
 
+  function deferredUpdates<A>(fn : () => A) : A {
+    const previousPriorityContext = priorityContext;
+    priorityContext = LowPriority;
+    try {
+      return fn();
+    } finally {
+      priorityContext = previousPriorityContext;
+    }
+  }
+
   return {
     scheduleWork: scheduleWork,
     getPriorityContext: getPriorityContext,
     performWithPriority: performWithPriority,
     batchedUpdates: batchedUpdates,
     syncUpdates: syncUpdates,
+    deferredUpdates: deferredUpdates,
   };
 };

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -40,7 +40,6 @@ var {
   Placement,
   Update,
   PlacementAndUpdate,
-  ForceUpdate,
   Deletion,
   ContentReset,
   Callback,
@@ -224,7 +223,7 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
       // possible bitmap value, we remove the secondary effects from the
       // effect tag and switch on that value.
       let primaryEffectTag =
-        nextEffect.effectTag & ~(ForceUpdate | Callback | Err | ContentReset);
+        nextEffect.effectTag & ~(Callback | Err | ContentReset);
       switch (primaryEffectTag) {
         case Placement: {
           commitPlacement(nextEffect);

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -40,6 +40,7 @@ var {
   Placement,
   Update,
   PlacementAndUpdate,
+  ForceUpdate,
   Deletion,
   ContentReset,
   Callback,
@@ -199,7 +200,8 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
       // updates, and deletions. To avoid needing to add a case for every
       // possible bitmap value, we remove the secondary effects from the
       // effect tag and switch on that value.
-      let primaryEffectTag = nextEffect.effectTag & ~(Callback | Err | ContentReset);
+      let primaryEffectTag =
+        nextEffect.effectTag & ~(ForceUpdate | Callback | Err | ContentReset);
       switch (primaryEffectTag) {
         case Placement: {
           commitPlacement(nextEffect);

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -12,100 +12,252 @@
 
 'use strict';
 
-type UpdateQueueNode = {
-  partialState: any,
-  callback: ?Function,
+import type { Fiber } from 'ReactFiber';
+
+type PartialState<State, Props> =
+  $Subtype<State> |
+  (prevState: State, props: Props) => $Subtype<State>;
+
+type Callback = () => void;
+
+type Update = {
+  partialState: PartialState<any, any>,
+  callback: Callback | null,
   isReplace: boolean,
-  next: ?UpdateQueueNode,
-};
-
-export type UpdateQueue = UpdateQueueNode & {
   isForced: boolean,
-  hasUpdate: boolean,
+  next: Update | null,
+};
+
+export type UpdateQueue = {
+  // Points to the first (oldest) update.
+  first: Update | null,
+  // Points to the first pending update. A pending update is one that is not
+  // part of the progressed work. This could be null even in a non-empty queue,
+  // when none of the updates are empty.
+  firstPendingUpdate: Update | null,
+  // Points to the last (newest) update.
+  last: Update | null,
+
+  // Used to implement forceUpdate. Only true if there's a merged (non-pending)
+  // force update; pending force updates do not affect this.
+  hasForceUpdate: boolean,
+
+  // TODO: Remove this by scheduling the side-effect during the begin phase.
   hasCallback: boolean,
-  tail: UpdateQueueNode
 };
 
-exports.createUpdateQueue = function(partialState : mixed) : UpdateQueue {
-  const queue = {
-    partialState,
-    callback: null,
-    isReplace: false,
-    next: null,
-    isForced: false,
-    hasUpdate: partialState != null,
+exports.createUpdateQueue = function() : UpdateQueue {
+  return {
+    first: null,
+    firstPendingUpdate: null,
+    last: null,
+
+    hasForceUpdate: false,
     hasCallback: false,
-    tail: (null : any),
   };
-  queue.tail = queue;
-  return queue;
 };
 
-function addToQueue(queue : UpdateQueue, partialState : mixed) : UpdateQueue {
-  const node = {
-    partialState,
-    callback: null,
-    isReplace: false,
-    next: null,
-  };
-  queue.tail.next = node;
-  queue.tail = node;
-  queue.hasUpdate = queue.hasUpdate || (partialState != null);
-  return queue;
+function insertUpdateIntoQueue(queue : UpdateQueue, update : Update) : void {
+  // Add a pending update to the end of the queue.
+  // TODO: Once updates have priorities, they should be inserted in the
+  // correct order. Addtionally, replaceState should remove any pending updates
+  // that have lower priority from queue.
+  if (!queue.last) {
+    // The queue is empty.
+    queue.first = queue.last = queue.firstPendingUpdate = update;
+  } else {
+    // The queue is not empty. Append the update to the end.
+    queue.last.next = update;
+    queue.last = update;
+
+    if (!queue.firstPendingUpdate) {
+      // This is the first pending update. Update the pointer.
+      queue.firstPendingUpdate = update;
+    }
+  }
 }
 
-exports.addToQueue = addToQueue;
-
-exports.addCallbackToQueue = function(queue : UpdateQueue, callback: Function) : UpdateQueue {
-  if (queue.tail.callback) {
-    // If the tail already as a callback, add an empty node to queue
-    addToQueue(queue, null);
-  }
-  queue.tail.callback = callback;
-  queue.hasCallback = true;
-  return queue;
+exports.addUpdate = function(queue : UpdateQueue, partialState : PartialState<any, any> | null) : void {
+  const update = {
+    partialState,
+    callback: null,
+    isReplace: false,
+    isForced: false,
+    next: null,
+  };
+  insertUpdateIntoQueue(queue, update);
 };
 
-exports.callCallbacks = function(queue : UpdateQueue, context : any) {
-  let node : ?UpdateQueueNode = queue;
-  while (node) {
-    const callback = node.callback;
-    if (callback) {
-      if (typeof context !== 'undefined') {
-        callback.call(context);
-      } else {
-        callback();
+exports.addReplaceUpdate = function(queue : UpdateQueue, state : any | null) : void {
+  const replaceUpdate = {
+    partialState: state,
+    callback: null,
+    isReplace: true,
+    isForced: false,
+    next: null,
+  };
+
+
+  if (!queue.last) {
+    // The queue is empty.
+    queue.first = queue.last = queue.firstPendingUpdate = replaceUpdate;
+  } else {
+    // The queue is not empty.
+
+    // Drop all existing pending updates.
+    // TODO: Only drop updates with matching priority.
+    let lastMergedUpdate = null;
+    if (queue.firstPendingUpdate) {
+      let node = queue.first;
+      while (node && node.next !== queue.firstPendingUpdate) {
+        node = node.next;
+      }
+      lastMergedUpdate = node;
+    } else {
+      lastMergedUpdate = queue.last;
+    }
+
+    if (lastMergedUpdate) {
+      // Append the new update to the end of the list.
+      // $FlowFixMe: Union bug (I think? Getting "object literal - This type incompatible with null")
+      lastMergedUpdate.next = replaceUpdate;
+      queue.firstPendingUpdate = replaceUpdate;
+      queue.last = replaceUpdate;
+    } else {
+      // Drop everything
+      queue.first = queue.firstPendingUpdate = queue.last = replaceUpdate;
+    }
+  }
+
+};
+
+exports.addForceUpdate = function(queue : UpdateQueue) : void {
+  const update = {
+    partialState: null,
+    callback: null,
+    isReplace: false,
+    isForced: true,
+    next: null,
+  };
+  insertUpdateIntoQueue(queue, update);
+};
+
+
+exports.addCallback = function(queue : UpdateQueue, callback: Callback) : void {
+  if (queue.firstPendingUpdate && queue.last && !queue.last.callback) {
+    // If pending updates already exist, and the last pending update does not
+    // have a callback, we can add the new callback to that update.
+    // TODO: Add an additional check to ensure the priority matches.
+    queue.last.callback = callback;
+    return;
+  }
+
+  const update = {
+    partialState: null,
+    callback,
+    isReplace: false,
+    isForced: false,
+    next: null,
+  };
+  insertUpdateIntoQueue(queue, update);
+};
+
+exports.hasPendingUpdate = function(queue : UpdateQueue) : boolean {
+  // TODO: Check priority level
+  return queue.firstPendingUpdate !== null;
+};
+
+function getStateFromUpdate(update, instance, prevState, props) {
+  const partialState = update.partialState;
+  if (typeof partialState === 'function') {
+    const updateFn = partialState;
+    return updateFn.call(instance, prevState, props);
+  } else {
+    return partialState;
+  }
+}
+
+// TODO: Move callback effect scheduling here. Rename to beginUpdateQueue or similar.
+exports.mergeQueue = function(queue : UpdateQueue, instance : any, prevState : any, props : any) : any {
+  // This merges the entire update queue into a single object, not just the
+  // pending updates, because the previous state and props may have changed.
+  // TODO: Would memoization be worth it?
+
+  // Reset these flags. We'll update them while looping through the queue.
+  queue.hasForceUpdate = false;
+  queue.hasCallback = false;
+
+  let state = prevState;
+  let dontMutatePrevState = true;
+  let update : Update | null = queue.first;
+  let isEmpty = true;
+
+  // TODO: Stop merging once we reach an update whose priority doesn't match.
+  // Should this also apply to updates that were previous merged but bailed out?
+  while (update) {
+    let partialState;
+    if (update.isReplace) {
+      // A replace should drop all previous updates in the queue, so
+      // use the original `prevState`, not the accumulated `state`
+      state = getStateFromUpdate(update, instance, prevState, props);
+      dontMutatePrevState = true;
+      isEmpty = false;
+    } else {
+      partialState = getStateFromUpdate(update, instance, state, props);
+      if (partialState) {
+        if (dontMutatePrevState) {
+          state = Object.assign({}, state, partialState);
+        } else {
+          state = Object.assign(state, partialState);
+        }
+        dontMutatePrevState = false;
+        isEmpty = false;
       }
     }
-    node = node.next;
+    if (update.isForced) {
+      queue.hasForceUpdate = true;
+    }
+    if (update.callback) {
+      queue.hasCallback = true;
+    }
+    update = update.next;
   }
+
+  // The next pending update is the one that we exited on in the loop above.
+  // Until priorities are implemented, this is always null.
+  queue.firstPendingUpdate = update;
+
+  if (isEmpty) {
+    // None of the updates contained state. Return the original state object.
+    return prevState;
+  }
+
+  return state;
 };
 
-function getStateFromNode(node, instance, state, props) {
-  if (typeof node.partialState === 'function') {
-    const updateFn = node.partialState;
-    return updateFn.call(instance, state, props);
-  } else {
-    return node.partialState;
-  }
-}
-
-exports.mergeUpdateQueue = function(queue : UpdateQueue, instance : any, prevState : any, props : any) : any {
-  let node : ?UpdateQueueNode = queue;
-  if (queue.isReplace) {
-    // replaceState is always first in the queue.
-    prevState = getStateFromNode(queue, instance, prevState, props);
-    node = queue.next;
-    if (!node) {
-      // If there is no more work, we replace the raw object instead of cloning.
-      return prevState;
+exports.commitUpdateQueue = function(finishedWork : Fiber, queue : UpdateQueue, context : mixed) {
+  if (queue.hasCallback) {
+    // Call the callbacks on all the non-pending updates.
+    let update = queue.first;
+    while (update && update !== queue.firstPendingUpdate) {
+      const callback = update.callback;
+      if (typeof callback === 'function') {
+        callback.call(context);
+      }
+      update = update.next;
     }
   }
-  let state = Object.assign({}, prevState);
-  while (node) {
-    let partialState = getStateFromNode(node, instance, state, props);
-    Object.assign(state, partialState);
-    node = node.next;
+
+  // Drop all completed updates, leaving only the pending updates.
+  queue.first = queue.firstPendingUpdate;
+  if (!queue.first) {
+    // If the list is now empty, we can remove it from the finished work
+    finishedWork.updateQueue = null;
+    if (finishedWork.alternate) {
+      // Normally we don't mutate the current tree, but we do for updates.
+      // The queue on the work in progress is always the same as the queue
+      // on the current.
+      finishedWork.alternate.updateQueue = null;
+    }
   }
-  return state;
 };

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -69,10 +69,10 @@ function comparePriority(a : PriorityLevel, b : PriorityLevel) : number {
     return 0;
   }
   if (a === NoWork && b !== NoWork) {
-    return -Infinity;
+    return -255;
   }
   if (a !== NoWork && b === NoWork) {
-    return Infinity;
+    return 255;
   }
   return a - b;
 }
@@ -299,7 +299,7 @@ function addReplaceUpdate(
   for (let i = 0; queue && i < 2; i++) {
     let replaceAfter = null;
     let replaceBefore = queue.first;
-    let comparison = Infinity;
+    let comparison = 255;
     while (replaceBefore &&
            (comparison = comparePriority(replaceBefore.priorityLevel, priorityLevel)) <= 0) {
       if (comparison < 0) {

--- a/src/renderers/shared/fiber/ReactTypeOfSideEffect.js
+++ b/src/renderers/shared/fiber/ReactTypeOfSideEffect.js
@@ -12,15 +12,16 @@
 
 'use strict';
 
-export type TypeOfSideEffect = 0 | 1 | 2 | 3 | 4 | 8 | 16 | 32;
+export type TypeOfSideEffect = 0 | 1 | 2 | 3 | 4 | 8 | 16 | 32 | 64;
 
 module.exports = {
-  NoEffect: 0,                                // 0b000000
-  Placement: 1,                               // 0b000001
-  Update: 2,                                  // 0b000010
-  PlacementAndUpdate: 3,                      // 0b000011
-  Deletion: 4,                                // 0b000100
-  ContentReset: 8,                            // 0b001000
-  Callback: 16,                               // 0b010000
-  Err: 32,                                    // 0b100000
+  NoEffect: 0,                                // 0b0000000
+  Placement: 1,                               // 0b0000001
+  Update: 2,                                  // 0b0000010
+  PlacementAndUpdate: 3,                      // 0b0000011
+  ForceUpdate: 4,                             // 0b0000100
+  Deletion: 8,                                // 0b0001000
+  ContentReset: 16,                           // 0b0010000
+  Callback: 32,                               // 0b0100000
+  Err: 64,                                    // 0b1000000
 };

--- a/src/renderers/shared/fiber/ReactTypeOfSideEffect.js
+++ b/src/renderers/shared/fiber/ReactTypeOfSideEffect.js
@@ -12,16 +12,15 @@
 
 'use strict';
 
-export type TypeOfSideEffect = 0 | 1 | 2 | 3 | 4 | 8 | 16 | 32 | 64;
+export type TypeOfSideEffect = 0 | 1 | 2 | 3 | 4 | 8 | 16 | 32;
 
 module.exports = {
-  NoEffect: 0,                                // 0b0000000
-  Placement: 1,                               // 0b0000001
-  Update: 2,                                  // 0b0000010
-  PlacementAndUpdate: 3,                      // 0b0000011
-  ForceUpdate: 4,                             // 0b0000100
-  Deletion: 8,                                // 0b0001000
-  ContentReset: 16,                           // 0b0010000
-  Callback: 32,                               // 0b0100000
-  Err: 64,                                    // 0b1000000
+  NoEffect: 0,                                // 0b000000
+  Placement: 1,                               // 0b000001
+  Update: 2,                                  // 0b000010
+  PlacementAndUpdate: 3,                      // 0b000011
+  Deletion: 4,                                // 0b000100
+  ContentReset: 8,                            // 0b001000
+  Callback: 16,                               // 0b010000
+  Err: 32,                                    // 0b100000
 };

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalUpdates-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalUpdates-test.js
@@ -211,7 +211,7 @@ describe('ReactIncrementalUpdates', () => {
     // Because e is a replaceState, d gets dropped.
     ReactNoop.flush();
     expect(ReactNoop.getChildren()).toEqual([span('efg')]);
-    // Ensure that update d is not progressed before being replaced.
+    // Ensure that updater function d is never called.
     expect(progressedUpdates).toEqual(['e', 'f', 'g']);
   });
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalUpdates-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalUpdates-test.js
@@ -1,0 +1,248 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var React;
+var ReactNoop;
+
+describe('ReactIncrementalUpdates', () => {
+  beforeEach(() => {
+    jest.resetModuleRegistry();
+    React = require('React');
+    ReactNoop = require('ReactNoop');
+  });
+
+  function div(...children) {
+    children = children.map(c => typeof c === 'string' ? { text: c } : c);
+    return { type: 'div', children, prop: undefined };
+  }
+
+  function span(prop) {
+    return { type: 'span', children: [], prop };
+  }
+
+  it('applies updates in order of priority', () => {
+    let state;
+    class Foo extends React.Component {
+      state = {};
+      componentDidMount() {
+        ReactNoop.performAnimationWork(() => {
+          //  Has Animation priority
+          this.setState({ b: 'b' });
+          this.setState({ c: 'c' });
+        });
+        // Has Task priority
+        this.setState({ a: 'a' });
+      }
+      render() {
+        state = this.state;
+        return <div />;
+      }
+    }
+
+    ReactNoop.render(<Foo />);
+    ReactNoop.flush();
+    expect(Object.keys(state)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('applies updates with equal priority in insertion order', () => {
+    let state;
+    class Foo extends React.Component {
+      state = {};
+      componentDidMount() {
+        // All have Task priority
+        this.setState({ a: 'a' });
+        this.setState({ b: 'b' });
+        this.setState({ c: 'c' });
+      }
+      render() {
+        state = this.state;
+        return <div />;
+      }
+    }
+
+    ReactNoop.render(<Foo />);
+    ReactNoop.flush();
+    expect(Object.keys(state)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('only drops updates with equal or lesser priority when replaceState is called', () => {
+    let instance;
+    const Foo = React.createClass({
+      getInitialState() {
+        return {};
+      },
+      render() {
+        instance = this;
+        return (
+          <span prop={Object.keys(this.state).join('')} />
+        );
+      },
+    });
+
+    ReactNoop.render(<Foo />);
+    ReactNoop.flush();
+
+    instance.setState({ x: 'x' });
+    instance.setState({ y: 'y' });
+    ReactNoop.performAnimationWork(() => {
+      instance.setState({ a: 'a' });
+      instance.setState({ b: 'b' });
+    });
+    instance.replaceState({ c: 'c' });
+    instance.setState({ d: 'd' });
+
+    ReactNoop.flushAnimationPri();
+    // Even though a replaceState has been already scheduled, it hasn't been
+    // flushed yet because it has low priority.
+    expect(ReactNoop.getChildren()).toEqual([span('ab')]);
+
+    ReactNoop.flush();
+    // Now the rest of the updates are flushed.
+    expect(ReactNoop.getChildren()).toEqual([span('cd')]);
+  });
+
+  it('can abort an update, schedule additional updates, and resume', () => {
+    let instance;
+    class Foo extends React.Component {
+      state = {};
+      render() {
+        instance = this;
+        return (
+          <span prop={Object.keys(this.state).join('')} />
+        );
+      }
+    }
+
+    ReactNoop.render(<Foo />);
+    ReactNoop.flush();
+
+    let progressedUpdates = [];
+    function createUpdate(letter) {
+      return () => {
+        progressedUpdates.push(letter);
+        return {
+          [letter]: letter,
+        };
+      };
+    }
+
+    instance.setState(createUpdate('a'));
+    instance.setState(createUpdate('b'));
+    instance.setState(createUpdate('c'));
+
+    // Do just enough work to begin the update but not enough to flush it
+    ReactNoop.flushDeferredPri(20);
+    expect(ReactNoop.getChildren()).toEqual([span('')]);
+    expect(progressedUpdates).toEqual(['a', 'b', 'c']);
+
+    instance.setState(createUpdate('f'));
+    ReactNoop.performAnimationWork(() => {
+      instance.setState(createUpdate('d'));
+      instance.setState(createUpdate('e'));
+    });
+    instance.setState(createUpdate('g'));
+
+    // Updates a, b, and c were aborted, so they should be applied first even
+    // though they have low priority. Update f was scheduled after the render
+    // was aborted, so it should come after d and e, which have higher priority.
+    ReactNoop.flush();
+    expect(ReactNoop.getChildren()).toEqual([span('abcdefg')]);
+    expect(progressedUpdates).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+  });
+
+  it('can abort an update, schedule a replaceState, and resume', () => {
+    let instance;
+    const Foo = React.createClass({
+      getInitialState() {
+        return {};
+      },
+      render() {
+        instance = this;
+        return (
+          <span prop={Object.keys(this.state).join('')} />
+        );
+      },
+    });
+
+    ReactNoop.render(<Foo />);
+    ReactNoop.flush();
+
+    let progressedUpdates = [];
+    function createUpdate(letter) {
+      return () => {
+        progressedUpdates.push(letter);
+        return {
+          [letter]: letter,
+        };
+      };
+    }
+
+    instance.setState(createUpdate('a'));
+    instance.setState(createUpdate('b'));
+    instance.setState(createUpdate('c'));
+
+    // Do just enough work to begin the update but not enough to flush it
+    ReactNoop.flushDeferredPri(20);
+    expect(ReactNoop.getChildren()).toEqual([span('')]);
+    expect(progressedUpdates).toEqual(['a', 'b', 'c']);
+
+    progressedUpdates = [];
+
+    instance.setState(createUpdate('f'));
+    ReactNoop.performAnimationWork(() => {
+      instance.setState(createUpdate('d'));
+      instance.replaceState(createUpdate('e'));
+    });
+    instance.setState(createUpdate('g'));
+
+    // Updates a, b, and c were aborted, so they should be applied first even
+    // though they have low priority. Update f was scheduled after the render
+    // was aborted, so it should come after d and e, which have higher priority.
+    // Because e is a replaceState, d gets dropped.
+    ReactNoop.flush();
+    expect(ReactNoop.getChildren()).toEqual([span('efg')]);
+    // Ensure that update d is not progressed before being replaced.
+    expect(progressedUpdates).toEqual(['e', 'f', 'g']);
+  });
+
+  it('does not call callbacks that are scheduled by another callback until a later commit', () => {
+    let ops = [];
+    class Foo extends React.Component {
+      state = {};
+      componentDidMount() {
+        ops.push('did mount');
+        this.setState({ a: 'a' }, () => {
+          ops.push('callback a');
+          this.setState({ b: 'b' }, () => {
+            ops.push('callback b');
+          });
+        });
+      }
+      render() {
+        ops.push('render');
+        return <div />;
+      }
+    }
+
+    ReactNoop.render(<Foo />);
+    ReactNoop.flush();
+    expect(ops).toEqual([
+      'render',
+      'did mount',
+      'render',
+      'callback a',
+      'render',
+      'callback b',
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes a few issues with the way updates currently work.

Right now we reset the work-in-progress's update queue during the complete phase, which means updates that occur during `render` or in a child's begin phase (constructor, `cWM`, `cWRP`, `render`) are completely dropped. This isn't an ideal pattern but Stack supports it and it's fairly common. The lack of support in Fiber today is causing a nasty infinite loop bug for some components at Facebook.

To fix this, the update queue maintains a pointer to the first pending update. When an update is used during reconciliation, the pointer is set to null to indicate that the entire queue has been processed. If new updates come in before the component is committed, the pointer points to the first new update. Then in the commit phase, the processed updates are dropped, but the pending updates are kept in the queue.

Another problem is that we use the same priority field for both props and updates, and when we reset the priority field during the complete phase, we don't have a way to read the priority of the pending updates. In the first pass, I'll add a priority field to the update queue to solve this. What we really want, though, is for each individual update to have its own priority, so that when we render a component, we only process the updates that match the current priority level.

- [x] Don't clear pending updates from the queue.
- [x] Move scheduling of update/callback side-effects to the begin phase.
- [x] Add priority field to the update queue so that pending priority isn't dropped.

May do in a follow-up; not needed to fix the infinite loop bug, but necessary to get the Fiber triangle demo working:

- [x] Sort the queue by priority and only render updates that match the current priority.