### PR TITLE
Add "Handling Multiple Inputs" to Forms doc

### DIFF
--- a/docs/docs/forms.md
+++ b/docs/docs/forms.md
@@ -186,7 +186,7 @@ Overall, this makes it so that `<input type="text">`, `<textarea>`, and `<select
 
 When you need to handle multiple controlled `input` elements, you can add a `name` attribute to each element and let a handler function choose what to do based on the value of `event.target.name`. For example:
 
-```javascript{14-15,18,32,39}
+```javascript{15,18,27,34}
 class Reservation extends React.Component {
   constructor(props) {
     super(props);
@@ -199,18 +199,13 @@ class Reservation extends React.Component {
   }
 
   handleInputChange(event) {
-    const pendingState = {};
-    switch (event.target.name) {
-      case 'isGoing':
-        pendingState[event.target.name] = event.target.checked;
-        break;
-      case 'numberOfGuests':
-        pendingState[event.target.name] = event.target.value;
-        break;
-      default:
-        return;
-    }
-    this.setState(pendingState);
+    const target = event.target;
+    const value = target.type === 'checkbox' ? target.checked : target.value;
+    const name = target.name;
+
+    this.setState({
+      [name]: value
+    });
   }
 
   render() {

--- a/docs/docs/forms.md
+++ b/docs/docs/forms.md
@@ -182,6 +182,59 @@ class FlavorForm extends React.Component {
 
 Overall, this makes it so that `<input type="text">`, `<textarea>`, and `<select>` all work very similarly - they all accept a `value` attribute that you can use to implement a controlled component.
 
+## Handling Multiple Inputs
+
+When you need to handle multiple controlled `input` elements, you can add a `name` attribute to each element and let a handler function choose what to do based on the value of `event.target.name`. For example:
+
+```javascript{14-15,18,32,38}
+class RSVP extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isGoing: false,
+      numberOfGuests: 0
+    };
+
+    this.handleInputChange = this.handleInputChange.bind(this);
+  }
+
+  handleInputChange(event) {
+    const pendingState = {};
+    switch (event.target.name) {
+      case 'isGoing':
+        pendingState[event.target.name] = event.target.checked;
+        break;
+      case 'numberOfGuests':
+        pendingState[event.target.name] = event.target.value;
+        break;
+      default:
+        // the code should never reach here
+        return;
+    }
+    this.setState(pendingState);
+  }
+
+  render() {
+    return (
+      <div>
+        <input
+          name="isGoing"
+          type="checkbox"
+          checked={this.state.isGoing}
+          onChange={this.handleInputChange}
+        />
+        <input
+          name="numberOfGuests"
+          type="number"
+          value={this.state.numberOfGuests}
+          onChange={this.handleInputChange}
+        />
+      </div>
+    );
+  }
+}
+```
+
 ## Alternatives to Controlled Components
 
 It can sometimes be tedious to use controlled components, because you need to write an event handler for every way your data can change and pipe all of the input state through a React component. This can become particularly annoying when you are converting a preexisting codebase to React, or integrating a React application with a non-React library. In these situations, you might want to check out [uncontrolled components](/react/docs/uncontrolled-components.html), an alternative technique for implementing input forms.

--- a/docs/docs/forms.md
+++ b/docs/docs/forms.md
@@ -186,8 +186,8 @@ Overall, this makes it so that `<input type="text">`, `<textarea>`, and `<select
 
 When you need to handle multiple controlled `input` elements, you can add a `name` attribute to each element and let a handler function choose what to do based on the value of `event.target.name`. For example:
 
-```javascript{14-15,18,32,38}
-class RSVP extends React.Component {
+```javascript{14-15,18,32,39}
+class Reservation extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -208,7 +208,6 @@ class RSVP extends React.Component {
         pendingState[event.target.name] = event.target.value;
         break;
       default:
-        // the code should never reach here
         return;
     }
     this.setState(pendingState);
@@ -217,12 +216,14 @@ class RSVP extends React.Component {
   render() {
     return (
       <div>
+        Is going:
         <input
           name="isGoing"
           type="checkbox"
           checked={this.state.isGoing}
           onChange={this.handleInputChange}
         />
+        Number of guests:
         <input
           name="numberOfGuests"
           type="number"
@@ -234,6 +235,8 @@ class RSVP extends React.Component {
   }
 }
 ```
+
+[Try it on CodePen.](https://codepen.io/keyanzhang/pen/pRENvx?editors=0010)
 
 ## Alternatives to Controlled Components
 


### PR DESCRIPTION
It was brought up on this [blog post](http://pixeljets.com/blog/why-we-chose-vuejs-over-react) (search for "Working with forms and Redux in React") and on [Hacker News](https://news.ycombinator.com/item?id=13152368). 

To be fair, this is a pretty common pattern of handling multiple inputs and it's not intuitive for someone to realize the `name` attribute can be used to achieve this. I think it's worth it to add it to the Forms section.