### PR TITLE
Add rootContainerInstance param to createTextInstance

### DIFF
--- a/src/renderers/art/ReactARTFiber.js
+++ b/src/renderers/art/ReactARTFiber.js
@@ -446,7 +446,7 @@ const ARTRenderer = ReactFiberReconciler({
     return instance;
   },
 
-  createTextInstance(text, internalInstanceHandle) {
+  createTextInstance(text, rootContainerInstance, internalInstanceHandle) {
     return text;
   },
 

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -152,7 +152,7 @@ var DOMRenderer = ReactFiberReconciler({
     domElement.textContent = '';
   },
 
-  createTextInstance(text : string, internalInstanceHandle : Object) : TextInstance {
+  createTextInstance(text : string, rootContainerInstance : Container, internalInstanceHandle : Object) : TextInstance {
     var textNode : TextInstance = document.createTextNode(text);
     precacheFiberNode(internalInstanceHandle, textNode);
     return textNode;

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -81,7 +81,7 @@ var NoopRenderer = ReactFiberReconciler({
 
   resetTextContent(instance : Instance) : void {},
 
-  createTextInstance(text : string) : TextInstance {
+  createTextInstance(text : string, rootContainerInstance : Container, internalInstanceHandle : Object) : TextInstance {
     var inst = { text : text, id: instanceCounter++ };
     // Hide from unit tests
     Object.defineProperty(inst, 'id', { value: inst.id, enumerable: false });

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -292,7 +292,8 @@ module.exports = function<T, P, I, TI, C, CX>(
               return null;
             }
           }
-          const textInstance = createTextInstance(newText, workInProgress);
+          const rootContainerInstance = getRootHostContainer();
+          const textInstance = createTextInstance(newText, rootContainerInstance, workInProgress);
           workInProgress.stateNode = textInstance;
         }
         workInProgress.memoizedProps = newText;

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -54,7 +54,7 @@ export type HostConfig<T, P, I, TI, C, CX> = {
   shouldSetTextContent(props : P) : boolean,
   resetTextContent(instance : I) : void,
 
-  createTextInstance(text : string, internalInstanceHandle : OpaqueNode) : TI,
+  createTextInstance(text : string, rootContainerInstance : C, internalInstanceHandle : OpaqueNode) : TI,
   commitTextUpdate(textInstance : TI, oldText : string, newText : string) : void,
 
   appendChild(parentInstance : I | C, child : I | TI) : void,


### PR DESCRIPTION
This mirrors a recent change (c87ffc0) in params passed to `createChild` and cleans up a root container hack currently required for the native fiber renderer to create text views.