### PR TITLE
Drop runtime validation and lower case coercion of tag names

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -664,6 +664,8 @@ src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * should properly escape text content and attributes values
 * unmounts children before unsetting DOM node info
 * should warn about the `onScroll` issue when unsupported (IE8)
+* should throw when an invalid tag name is used server-side
+* should throw when an attack vector is used server-side
 * should throw when an invalid tag name is used
 * should throw when an attack vector is used
 * should warn about props that are no longer supported

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -640,6 +640,7 @@ src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * should handle dangerouslySetInnerHTML
 * should work error event on <source> element
 * should not duplicate uppercased selfclosing tags
+* should warn on upper case HTML tags, not SVG nor custom tags
 * should warn against children for void elements
 * should warn against dangerouslySetInnerHTML for void elements
 * should emit a warning once for an unnamed custom component using shady DOM

--- a/src/renderers/art/ReactARTFiber.js
+++ b/src/renderers/art/ReactARTFiber.js
@@ -408,7 +408,7 @@ const ARTRenderer = ReactFiberReconciler({
     // Noop
   },
 
-  commitUpdate(instance, oldProps, newProps) {
+  commitUpdate(instance, type, oldProps, newProps) {
     instance._applyProps(instance, newProps, oldProps);
   },
 
@@ -467,7 +467,7 @@ const ARTRenderer = ReactFiberReconciler({
     // Noop
   },
 
-  prepareUpdate(domElement, oldProps, newProps) {
+  prepareUpdate(domElement, type, oldProps, newProps) {
     return true;
   },
 

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -97,20 +97,16 @@ var DOMRenderer = ReactFiberReconciler({
 
   finalizeInitialChildren(
     domElement : Instance,
+    type : string,
     props : Props,
     rootContainerInstance : Container,
   ) : void {
-    // TODO: we normalize here because DOM renderer expects tag to be lowercase.
-    // We can change DOM renderer to compare special case against upper case,
-    // and use tagName (which is upper case for HTML DOM elements). Or we could
-    // let the renderer "normalize" the fiber type so we don't have to read
-    // the type from DOM. However we need to remember SVG is case-sensitive.
-    var tag = domElement.tagName.toLowerCase();
-    setInitialProperties(domElement, tag, props, rootContainerInstance);
+    setInitialProperties(domElement, type, props, rootContainerInstance);
   },
 
   prepareUpdate(
     domElement : Instance,
+    type : string,
     oldProps : Props,
     newProps : Props
   ) : boolean {
@@ -119,21 +115,16 @@ var DOMRenderer = ReactFiberReconciler({
 
   commitUpdate(
     domElement : Instance,
+    type : string,
     oldProps : Props,
     newProps : Props,
     rootContainerInstance : Container,
     internalInstanceHandle : Object,
   ) : void {
-    // TODO: we normalize here because DOM renderer expects tag to be lowercase.
-    // We can change DOM renderer to compare special case against upper case,
-    // and use tagName (which is upper case for HTML DOM elements). Or we could
-    // let the renderer "normalize" the fiber type so we don't have to read
-    // the type from DOM. However we need to remember SVG is case-sensitive.
-    var tag = domElement.tagName.toLowerCase();
     // Update the internal instance handle so that we know which props are
     // the current ones.
     precacheFiberNode(internalInstanceHandle, domElement);
-    updateProperties(domElement, tag, oldProps, newProps, rootContainerInstance);
+    updateProperties(domElement, type, oldProps, newProps, rootContainerInstance);
   },
 
   shouldSetTextContent(props : Props) : boolean {

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -489,8 +489,6 @@ var ReactDOMFiberComponent = {
     parentNamespace : string | null
   ) : Element {
     validateDangerousTag(type);
-    // TODO:
-    // const tag = type.toLowerCase(); Do we need to apply lower case only on non-custom elements?
 
     // We create tags in the namespace of their parent container, except HTML
     // tags get no namespace.
@@ -498,8 +496,17 @@ var ReactDOMFiberComponent = {
     var domElement : Element;
     var namespaceURI = parentNamespace || getIntrinsicNamespace(type);
     if (namespaceURI == null) {
-      const tag = type.toLowerCase();
-      if (tag === 'script') {
+      if (__DEV__) {
+        warning(
+          type === type.toLowerCase() ||
+          isCustomComponent(type, props),
+          '<%s /> is using uppercase HTML. Always use lowercase HTML tags ' +
+          'in React.',
+          type
+        );
+      }
+
+      if (type === 'script') {
         // Create the script via .innerHTML so its "parser-inserted" flag is
         // set to true and it does not execute
         var div = ownerDocument.createElement('div');

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -279,21 +279,6 @@ var voidElementTags = {
   ...omittedCloseTags,
 };
 
-// We accept any tag to be rendered but since this gets injected into arbitrary
-// HTML, we want to make sure that it's a safe tag.
-// http://www.w3.org/TR/REC-xml/#NT-Name
-
-var VALID_TAG_REGEX = /^[a-zA-Z][a-zA-Z:_\.\-\d]*$/; // Simplified subset
-var validatedTagCache = {};
-var hasOwnProperty = {}.hasOwnProperty;
-
-function validateDangerousTag(tag) {
-  if (!hasOwnProperty.call(validatedTagCache, tag)) {
-    invariant(VALID_TAG_REGEX.test(tag), 'Invalid tag: %s', tag);
-    validatedTagCache[tag] = true;
-  }
-}
-
 function isCustomComponent(tagName, props) {
   return tagName.indexOf('-') >= 0 || props.is != null;
 }
@@ -488,8 +473,6 @@ var ReactDOMFiberComponent = {
     rootContainerElement : Element,
     parentNamespace : string | null
   ) : Element {
-    validateDangerousTag(type);
-
     // We create tags in the namespace of their parent container, except HTML
     // tags get no namespace.
     var ownerDocument = rootContainerElement.ownerDocument;

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -1207,22 +1207,36 @@ describe('ReactDOMComponent', () => {
   });
 
   describe('tag sanitization', () => {
+    it('should throw when an invalid tag name is used server-side', () => {
+      var hackzor = React.createElement('script tag');
+      expect(
+        () => ReactDOMServer.renderToString(hackzor)
+      ).toThrowError(
+        'Invalid tag: script tag'
+      );
+    });
+
+    it('should throw when an attack vector is used server-side', () => {
+      var hackzor = React.createElement('div><img /><div');
+      expect(
+        () => ReactDOMServer.renderToString(hackzor)
+      ).toThrowError(
+        'Invalid tag: div><img /><div'
+      );
+    });
+
     it('should throw when an invalid tag name is used', () => {
       var hackzor = React.createElement('script tag');
       expect(
         () => ReactTestUtils.renderIntoDocument(hackzor)
-      ).toThrowError(
-        'Invalid tag: script tag'
-      );
+      ).toThrow();
     });
 
     it('should throw when an attack vector is used', () => {
       var hackzor = React.createElement('div><img /><div');
       expect(
         () => ReactTestUtils.renderIntoDocument(hackzor)
-      ).toThrowError(
-        'Invalid tag: div><img /><div'
-      );
+      ).toThrow();
     });
   });
 

--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -413,7 +413,6 @@ var globalIdCounter = 1;
  */
 function ReactDOMComponent(element) {
   var tag = element.type;
-  validateDangerousTag(tag);
   this._currentElement = element;
   this._tag = tag.toLowerCase();
   this._namespaceURI = null;
@@ -605,6 +604,7 @@ ReactDOMComponent.Mixin = {
       this._createInitialChildren(transaction, props, context, lazyTree);
       mountImage = lazyTree;
     } else {
+      validateDangerousTag(this._tag);
       var tagOpen = this._createOpenTagMarkupAndPutListeners(transaction, props);
       var tagContent = this._createContentMarkup(transaction, props, context);
       if (!tagContent && omittedCloseTags[this._tag]) {

--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -524,6 +524,15 @@ ReactDOMComponent.Mixin = {
       namespaceURI = DOMNamespaces.html;
     }
     if (namespaceURI === DOMNamespaces.html) {
+      if (__DEV__) {
+        warning(
+          isCustomComponent(this._tag, props) ||
+          this._tag === this._currentElement.type,
+          '<%s /> is using uppercase HTML. Always use lowercase HTML tags ' +
+          'in React.',
+          this._currentElement.type
+        );
+      }
       if (this._tag === 'svg') {
         namespaceURI = DOMNamespaces.svg;
       } else if (this._tag === 'math') {

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -60,15 +60,15 @@ var NoopRenderer = ReactFiberReconciler({
     parentInstance.children.push(child);
   },
 
-  finalizeInitialChildren(domElement : Instance, props : Props) : void {
+  finalizeInitialChildren(domElement : Instance, type : string, props : Props) : void {
     // Noop
   },
 
-  prepareUpdate(instance : Instance, oldProps : Props, newProps : Props) : boolean {
+  prepareUpdate(instance : Instance, type : string, oldProps : Props, newProps : Props) : boolean {
     return true;
   },
 
-  commitUpdate(instance : Instance, oldProps : Props, newProps : Props) : void {
+  commitUpdate(instance : Instance, type : string, oldProps : Props, newProps : Props) : void {
     instance.prop = newProps.prop;
   },
 

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -373,7 +373,8 @@ module.exports = function<T, P, I, TI, C, CX>(
           const newProps = finishedWork.memoizedProps;
           const oldProps = current.memoizedProps;
           const rootContainerInstance = getRootHostContainer();
-          commitUpdate(instance, oldProps, newProps, rootContainerInstance, finishedWork);
+          const type = finishedWork.type;
+          commitUpdate(instance, type, oldProps, newProps, rootContainerInstance, finishedWork);
         }
         detachRefIfNeeded(current, finishedWork);
         return;

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -215,6 +215,7 @@ module.exports = function<T, P, I, TI, C, CX>(
       }
       case HostComponent:
         popHostContext(workInProgress);
+        const type = workInProgress.type;
         let newProps = workInProgress.pendingProps;
         if (current && workInProgress.stateNode != null) {
           // If we have an alternate, that means this is an update and we need to
@@ -228,7 +229,7 @@ module.exports = function<T, P, I, TI, C, CX>(
             newProps = workInProgress.memoizedProps || oldProps;
           }
           const instance : I = workInProgress.stateNode;
-          if (prepareUpdate(instance, oldProps, newProps)) {
+          if (prepareUpdate(instance, type, oldProps, newProps)) {
             // This returns true if there was something to update.
             markUpdate(workInProgress);
           }
@@ -249,14 +250,14 @@ module.exports = function<T, P, I, TI, C, CX>(
           // or completeWork depending on we want to add then top->down or
           // bottom->up. Top->down is faster in IE11.
           const instance = createInstance(
-            workInProgress.type,
+            type,
             newProps,
             rootContainerInstance,
             currentHostContext,
             workInProgress
           );
           appendAllChildren(instance, workInProgress);
-          finalizeInitialChildren(instance, newProps, rootContainerInstance);
+          finalizeInitialChildren(instance, type, newProps, rootContainerInstance);
 
           workInProgress.stateNode = instance;
           if (workInProgress.ref) {

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -46,10 +46,10 @@ export type HostConfig<T, P, I, TI, C, CX> = {
 
   createInstance(type : T, props : P, rootContainerInstance : C, hostContext : CX | null, internalInstanceHandle : OpaqueNode) : I,
   appendInitialChild(parentInstance : I, child : I | TI) : void,
-  finalizeInitialChildren(parentInstance : I, props : P, rootContainerInstance : C) : void,
+  finalizeInitialChildren(parentInstance : I, type : T, props : P, rootContainerInstance : C) : void,
 
-  prepareUpdate(instance : I, oldProps : P, newProps : P) : boolean,
-  commitUpdate(instance : I, oldProps : P, newProps : P, rootContainerInstance : C, internalInstanceHandle : OpaqueNode) : void,
+  prepareUpdate(instance : I, type : T, oldProps : P, newProps : P) : boolean,
+  commitUpdate(instance : I, type : T, oldProps : P, newProps : P, rootContainerInstance : C, internalInstanceHandle : OpaqueNode) : void,
 
   shouldSetTextContent(props : P) : boolean,
   resetTextContent(instance : I) : void,


### PR DESCRIPTION
In #2756 we ended up using toLowerCase to allow case insensitive HTML tags. However, this requires extra processing every time we access the tag or at least we need to process it for mount and store it in an extra field which wastes memory.

So instead, we can just enforce case sensitivity for HTML since this might matter for the XML namespaces like SVG anyway.

We introduced runtime validation of tag names because we used to generate HTML that was supposed to be inserted into a HTML string which could've been an XSS attack.

However, these days we use `document.createElement(tagName)` in most cases. That already does its internal validation in the browser which throws. We're now double validating it. Stack still has a path where innerHTML is used and with this change we still apply validation there. However in Fiber we can remove it completely since we only use `document.createElement(tagName)` and never generate HTML.