### PR TITLE
Add test for duplicate events with nested dispatch

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -759,6 +759,7 @@ src/renderers/dom/shared/__tests__/ReactDOM-test.js
 * throws in render() if the update callback is not a function
 * preserves focus
 * calls focus() on autoFocus elements after they have been mounted to the DOM
+* shouldn't fire duplicate event handler while handling other nested dispatch
 
 src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * should handle className


### PR DESCRIPTION

Still have tests to write, but they should be pretty straightforward after PR aproval.

Also had no idea where I should put `once` utility function, so its place in the PR for now is just a temporary.

This PR is just a proposal of a fix, the thing I've come with to tackle this problem, I'm open to change the code appropriately if somebody comes up with the better idea how to solve this.

cc @Aweary 