### PR TITLE
HostRoot no longer pops context provider during complete phase

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -202,7 +202,6 @@ module.exports = function<T, P, I, TI, C, CX>(
         return null;
       case HostRoot: {
         workInProgress.memoizedProps = workInProgress.pendingProps;
-        popContextProvider();
         const fiberRoot = (workInProgress.stateNode : FiberRoot);
         if (fiberRoot.pendingContext) {
           fiberRoot.context = fiberRoot.pendingContext;

--- a/src/renderers/shared/fiber/ReactFiberContext.js
+++ b/src/renderers/shared/fiber/ReactFiberContext.js
@@ -77,6 +77,7 @@ function isContextProvider(fiber : Fiber) : boolean {
 exports.isContextProvider = isContextProvider;
 
 function popContextProvider() : void {
+  invariant(index > -1, 'Unexpected context pop');
   contextStack[index] = emptyObject;
   didPerformWorkStack[index] = false;
   index--;


### PR DESCRIPTION
In the begin work phase, we call `pushContextProvider` for `ClassComponent`s. In the complete work phase, we call `popContextProvider` for both `ClassComponent`s and `HostRoot`s. The result is that we end up popping more times than we should.

This PR removes the `popContextProvider` call for `HostRoot` and adds an invariant warning to `popContextProvider` as well.

Note that no new tests fail with the new invariant warning once the superfluous `popContextProvider` call is removed. (Several fail with it in place.)

Note also that in the begin work phase we call `pushHostContainer` for `HostRoot`s and `HostPortal`s but we only call `popHostContainer` for `HostPortal`s during the complete work phase. It seems like we should align these calls as well but I don't have enough context to tackle that yet.