### PR TITLE
[Docs] Add link to catalog of components

### DIFF
--- a/docs/_data/nav_community.yml
+++ b/docs/_data/nav_community.yml
@@ -12,3 +12,6 @@
     - id: examples
       title: Examples
       href: https://github.com/facebook/react/wiki/Examples
+    - id: catalog-of-components
+      title: Catalog of Components
+      href: http://devarchy.com/react-components

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -23,6 +23,7 @@
       <a href="/react/community/videos.html">Videos</a>
       <a href="https://github.com/facebook/react/wiki/Examples" target="_blank">Examples</a>
       <a href="https://github.com/facebook/react/wiki/Complementary-Tools" target="_blank">Complementary Tools</a>
+      <a href="http://devarchy.com/react-components" target="_blank">Catalog of Components</a>
     </div>
     <div>
       <h5>More</h5>


### PR DESCRIPTION
The catalog: http://devarchy.com/react-components.

Not sure if you guys are up for linking to such unofficial list, if not just close this PR.

I think this is important for the ecosystem because it allows new components to get sustainable exposure to users.

Thanks for React btw, it has improved my Front-end life so much.