### PR TITLE
[Fiber] Queue top-level updates

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -90,7 +90,6 @@ src/renderers/shared/shared/__tests__/ReactUpdates-test.js
 * throws in setState if the update callback is not a function
 * throws in replaceState if the update callback is not a function
 * throws in forceUpdate if the update callback is not a function
-* unmounts and remounts a root in the same batch
 
 src/renderers/shared/shared/__tests__/refs-test.js
 * Should increase refs with an increase in divs

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1550,6 +1550,7 @@ src/renderers/shared/shared/__tests__/ReactUpdates-test.js
 * does not update one component twice in a batch (#2410)
 * does not update one component twice in a batch (#6371)
 * unstable_batchedUpdates should return value from a callback
+* unmounts and remounts a root in the same batch
 
 src/renderers/shared/shared/__tests__/refs-destruction-test.js
 * should remove refs when destroying the parent

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1181,27 +1181,13 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalReflection-test.js
 * finds no node before insertion and correct node before deletion
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
-* schedules and flushes animation work
-* schedules and flushes animation work for many roots
-* flushes all scheduled animation work
-* flushes all scheduled animation work for many roots
 * schedules and flushes deferred work
-* schedules and flushes deferred work for many roots
-* flushes scheduled deferred work fitting within deadline
-* flushes scheduled deferred work fitting within deadline for many roots
-* schedules more deferred work if it runs out of time
-* schedules more deferred work if it runs out of time with many roots
-* flushes late animation work in a deferred callback if it wins
-* flushes late animation work in a deferred callback if it wins with many roots
-* flushes late animation work in an animation callback if it wins
-* flushes late animation work in an animation callback if it wins with many roots
-* flushes all work in a deferred callback if it wins
-* flushes all work in a deferred callback if it wins with many roots
-* flushes root with late deferred work in an animation callback if it wins
-* flushes all roots with animation work in an animation callback if it wins
-* splits deferred work on multiple roots
+* schedules and flushes animation work
+* searches for work on other roots once the current root completes
+* schedules an animation callback when there`s leftover animation work
+* schedules top-level updates in order of priority
+* schedules top-level updates with same priority in order of insertion
 * works on deferred roots in the order they were scheduled
-* handles interleaved deferred and animation work
 * schedules sync updates when inside componentDidMount/Update
 * can opt-in to deferred/animation scheduling inside componentDidMount/Update
 * performs Task work even after time runs out

--- a/src/renderers/art/ReactARTFiber.js
+++ b/src/renderers/art/ReactARTFiber.js
@@ -356,7 +356,11 @@ class Surface extends Component {
   }
 
   componentWillUnmount() {
-    ARTRenderer.unmountContainer(this._mountNode);
+    ARTRenderer.updateContainer(
+      null,
+      this._mountNode,
+      this,
+    );
   }
 
   render() {

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -191,7 +191,7 @@ function warnAboutUnstableUse() {
   warned = true;
 }
 
-function renderSubtreeIntoContainer(parentComponent : ?ReactComponent<any, any, any>, element : ReactElement<any>, containerNode : DOMContainerElement | Document, callback: ?Function) {
+function renderSubtreeIntoContainer(parentComponent : ?ReactComponent<any, any, any>, children : ReactNodeList, containerNode : DOMContainerElement | Document, callback: ?Function) {
   let container : DOMContainerElement =
     containerNode.nodeType === DOCUMENT_NODE ? (containerNode : any).documentElement : (containerNode : any);
   let root;
@@ -200,9 +200,9 @@ function renderSubtreeIntoContainer(parentComponent : ?ReactComponent<any, any, 
     while (container.lastChild) {
       container.removeChild(container.lastChild);
     }
-    root = container._reactRootContainer = DOMRenderer.mountContainer(element, container, parentComponent, callback);
+    root = container._reactRootContainer = DOMRenderer.mountContainer(children, container, parentComponent, callback);
   } else {
-    DOMRenderer.updateContainer(element, root = container._reactRootContainer, parentComponent, callback);
+    DOMRenderer.updateContainer(children, root = container._reactRootContainer, parentComponent, callback);
   }
   return DOMRenderer.getPublicRootInstance(root);
 }
@@ -224,13 +224,9 @@ var ReactDOM = {
 
   unmountComponentAtNode(container : DOMContainerElement) {
     warnAboutUnstableUse();
-    const root = container._reactRootContainer;
-    if (root) {
-      // TODO: Is it safe to reset this now or should I wait since this
-      // unmount could be deferred?
+    return renderSubtreeIntoContainer(null, null, container, () => {
       container._reactRootContainer = null;
-      DOMRenderer.unmountContainer(root);
-    }
+    });
   },
 
   findDOMNode: findDOMNode,

--- a/src/renderers/native/ReactNativeFiber.js
+++ b/src/renderers/native/ReactNativeFiber.js
@@ -326,7 +326,7 @@ const NativeRenderer = ReactFiberReconciler({
     // But creates an additional child Fiber for raw text children.
     // No additional native views are created though.
     // It's not clear to me which is better so I'm deferring for now.
-    // More context @ github.com/facebook/react/pull/8560#discussion_r92111303 
+    // More context @ github.com/facebook/react/pull/8560#discussion_r92111303
     return false;
   },
 
@@ -372,8 +372,9 @@ const ReactNative = {
     const root = roots.get(containerTag);
     if (root) {
       // TODO: Is it safe to reset this now or should I wait since this unmount could be deferred?
-      roots.delete(containerTag);
-      NativeRenderer.unmountContainer(root);
+      NativeRenderer.updateContainer(null, root, null, () => {
+        roots.delete(containerTag);
+      });
     }
   },
 

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -188,10 +188,11 @@ var ReactNoop = {
 
   unmountRootWithID(rootID : string) {
     const root = roots.get(rootID);
-    roots.delete(rootID);
-    rootContainers.delete(rootID);
     if (root) {
-      NoopRenderer.unmountContainer(root);
+      NoopRenderer.updateContainer(null, root, null, () => {
+        roots.delete(rootID);
+        rootContainers.delete(rootID);
+      });
     }
   },
 

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -294,14 +294,16 @@ var ReactNoop = {
       log(
         '  '.repeat(depth + 1) + '~',
         firstUpdate && firstUpdate.partialState,
-        firstUpdate.callback ? 'with callback' : ''
+        firstUpdate.callback ? 'with callback' : '',
+        '[' + firstUpdate.priorityLevel + ']'
       );
       var next;
       while (next = firstUpdate.next) {
         log(
           '  '.repeat(depth + 1) + '~',
           next.partialState,
-          next.callback ? 'with callback' : ''
+          next.callback ? 'with callback' : '',
+          '[' + firstUpdate.priorityLevel + ']'
         );
       }
     }

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -533,12 +533,15 @@ module.exports = function<T, P, I, TI, C, CX>(
           pushTopLevelContextObject(root.context, false);
         }
 
-        if (updateQueue) {
-          beginUpdateQueue(workInProgress, updateQueue, null, null, null, priorityLevel);
-        }
+        pushHostContainer(root.containerInfo);
 
-        pushHostContainer(workInProgress.stateNode.containerInfo);
-        reconcileChildren(current, workInProgress, pendingProps);
+        if (updateQueue) {
+          const prevState = workInProgress.memoizedState;
+          const state = beginUpdateQueue(workInProgress, updateQueue, null, prevState, null, priorityLevel);
+          const element = state.element;
+          reconcileChildren(current, workInProgress, element);
+          workInProgress.memoizedState = state;
+        }
 
         // A yield component is just a placeholder, we can just run through the
         // next one immediately.

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -97,7 +97,7 @@ getContextForSubtree._injectFiber(function(fiber : Fiber) {
 module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C, CX>) : Reconciler<C, I, TI> {
 
   var {
-    scheduleWork,
+    scheduleSetState,
     scheduleUpdateCallback,
     performWithPriority,
     batchedUpdates,
@@ -112,19 +112,10 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
       const root = createFiberRoot(containerInfo, context);
       const current = root.current;
 
-      // TODO: Use the updateQueue and scheduleUpdate, instead of pendingProps.
-      // TODO: This should not override the pendingWorkPriority if there is
-      // higher priority work in the subtree.
-
-      current.pendingProps = element;
-      if (current.alternate) {
-        current.alternate.pendingProps = element;
-      }
+      scheduleSetState(current, { element });
       if (callback) {
         scheduleUpdateCallback(current, callback);
       }
-
-      scheduleWork(root);
 
       if (__DEV__ && ReactFiberInstrumentation.debugTool) {
         ReactFiberInstrumentation.debugTool.onMountContainer(root);
@@ -143,18 +134,10 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
 
       root.pendingContext = getContextForSubtree(parentComponent);
 
-      // TODO: Use the updateQueue and scheduleUpdate, instead of pendingProps.
-      // TODO: This should not override the pendingWorkPriority if there is
-      // higher priority work in the subtree.
-      current.pendingProps = element;
-      if (current.alternate) {
-        current.alternate.pendingProps = element;
-      }
+      scheduleSetState(current, { element });
       if (callback) {
         scheduleUpdateCallback(current, callback);
       }
-
-      scheduleWork(root);
 
       if (__DEV__ && ReactFiberInstrumentation.debugTool) {
         ReactFiberInstrumentation.debugTool.onUpdateContainer(root);
@@ -164,13 +147,9 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
     unmountContainer(container : OpaqueNode) : void {
       // TODO: If this is a nested container, this won't be the root.
       const root : FiberRoot = (container.stateNode : any);
-      // TODO: Use pending work/state instead of props.
-      root.current.pendingProps = [];
-      if (root.current.alternate) {
-        root.current.alternate.pendingProps = [];
-      }
+      const current = root.current;
 
-      scheduleWork(root);
+      scheduleSetState(current, { element: [] });
 
       if (__DEV__ && ReactFiberInstrumentation.debugTool) {
         ReactFiberInstrumentation.debugTool.onUnmountContainer(root);

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -15,6 +15,7 @@
 import type { Fiber } from 'ReactFiber';
 import type { FiberRoot } from 'ReactFiberRoot';
 import type { PriorityLevel } from 'ReactPriorityLevel';
+import type { ReactNodeList } from 'ReactTypes';
 
 var {
   findCurrentUnmaskedContext,
@@ -69,9 +70,8 @@ export type HostConfig<T, P, I, TI, C, CX> = {
 };
 
 export type Reconciler<C, I, TI> = {
-  mountContainer(element : ReactElement<any>, containerInfo : C, parentComponent : ?ReactComponent<any, any, any>) : OpaqueNode,
-  updateContainer(element : ReactElement<any>, container : OpaqueNode, parentComponent : ?ReactComponent<any, any, any>) : void,
-  unmountContainer(container : OpaqueNode) : void,
+  mountContainer(element : ReactNodeList, containerInfo : C, parentComponent : ?ReactComponent<any, any, any>) : OpaqueNode,
+  updateContainer(element : ReactNodeList, container : OpaqueNode, parentComponent : ?ReactComponent<any, any, any>) : void,
   performWithPriority(priorityLevel : PriorityLevel, fn : Function) : void,
   /* eslint-disable no-undef */
   // FIXME: ESLint complains about type parameter
@@ -97,7 +97,7 @@ getContextForSubtree._injectFiber(function(fiber : Fiber) {
 module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C, CX>) : Reconciler<C, I, TI> {
 
   var {
-    scheduleSetState,
+    scheduleTopLevelSetState,
     scheduleUpdateCallback,
     performWithPriority,
     batchedUpdates,
@@ -107,12 +107,12 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
 
   return {
 
-    mountContainer(element : ReactElement<any>, containerInfo : C, parentComponent : ?ReactComponent<any, any, any>, callback: ?Function) : OpaqueNode {
+    mountContainer(element : ReactNodeList, containerInfo : C, parentComponent : ?ReactComponent<any, any, any>, callback: ?Function) : OpaqueNode {
       const context = getContextForSubtree(parentComponent);
       const root = createFiberRoot(containerInfo, context);
       const current = root.current;
 
-      scheduleSetState(current, { element });
+      scheduleTopLevelSetState(current, { element });
       if (callback) {
         scheduleUpdateCallback(current, callback);
       }
@@ -127,32 +127,27 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
       return current;
     },
 
-    updateContainer(element : ReactElement<any>, container : OpaqueNode, parentComponent : ?ReactComponent<any, any, any>, callback: ?Function) : void {
+    updateContainer(element : ReactNodeList, container : OpaqueNode, parentComponent : ?ReactComponent<any, any, any>, callback: ?Function) : void {
       // TODO: If this is a nested container, this won't be the root.
       const root : FiberRoot = (container.stateNode : any);
       const current = root.current;
 
       root.pendingContext = getContextForSubtree(parentComponent);
 
-      scheduleSetState(current, { element });
+      scheduleTopLevelSetState(current, { element });
       if (callback) {
         scheduleUpdateCallback(current, callback);
       }
 
-      if (__DEV__ && ReactFiberInstrumentation.debugTool) {
-        ReactFiberInstrumentation.debugTool.onUpdateContainer(root);
-      }
-    },
-
-    unmountContainer(container : OpaqueNode) : void {
-      // TODO: If this is a nested container, this won't be the root.
-      const root : FiberRoot = (container.stateNode : any);
-      const current = root.current;
-
-      scheduleSetState(current, { element: [] });
-
-      if (__DEV__ && ReactFiberInstrumentation.debugTool) {
-        ReactFiberInstrumentation.debugTool.onUnmountContainer(root);
+      if (__DEV__) {
+        if (ReactFiberInstrumentation.debugTool) {
+          if (element === null) {
+            ReactFiberInstrumentation.debugTool.onUpdateContainer(root);
+          } else {
+            // This is an unmount
+            ReactFiberInstrumentation.debugTool.onUnmountContainer(root);
+          }
+        }
       }
     },
 

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -59,6 +59,7 @@ var {
   addReplaceUpdate,
   addForceUpdate,
   addCallback,
+  addTopLevelUpdate,
 } = require('ReactFiberUpdateQueue');
 
 var {
@@ -1058,6 +1059,12 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
     scheduleUpdateAtPriority(fiber, priorityContext);
   }
 
+  // TODO: This indirection will be removed as part of #8585
+  function scheduleTopLevelSetState(fiber : Fiber, partialState : any) {
+    addTopLevelUpdate(fiber, partialState, priorityContext);
+    scheduleUpdateAtPriority(fiber, priorityContext);
+  }
+
   function performWithPriority(priorityLevel : PriorityLevel, fn : Function) {
     const previousPriorityContext = priorityContext;
     priorityContext = priorityLevel;
@@ -1105,7 +1112,7 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
   }
 
   return {
-    scheduleSetState: scheduleSetState,
+    scheduleTopLevelSetState: scheduleTopLevelSetState,
     scheduleUpdateCallback: scheduleUpdateCallback,
     performWithPriority: performWithPriority,
     batchedUpdates: batchedUpdates,

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -944,28 +944,10 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
     }
   }
 
-  function scheduleWork(root : FiberRoot) {
-    let priorityLevel = priorityContext;
-
-    // If we're in a batch, switch to task priority
-    if (priorityLevel === SynchronousPriority && isPerformingWork) {
-      priorityLevel = TaskPriority;
-    }
-
-    scheduleWorkAtPriority(root, priorityLevel);
-  }
-
-  function scheduleWorkAtPriority(root : FiberRoot, priorityLevel : PriorityLevel) {
-    // Set the priority on the root, without deprioritizing
-    if (root.current.pendingWorkPriority === NoWork ||
-        priorityLevel <= root.current.pendingWorkPriority) {
-      root.current.pendingWorkPriority = priorityLevel;
-    }
-    if (root.current.alternate) {
-      if (root.current.alternate.pendingWorkPriority === NoWork ||
-          priorityLevel <= root.current.alternate.pendingWorkPriority) {
-        root.current.alternate.pendingWorkPriority = priorityLevel;
-      }
+  function scheduleRoot(root : FiberRoot) {
+    const priorityLevel = root.current.pendingWorkPriority;
+    if (priorityLevel === NoWork) {
+      return;
     }
 
     if (!root.isScheduled) {
@@ -986,30 +968,6 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
       // search from the root during the next tick, in case there is now higher
       // priority work somewhere earlier than before.
       nextUnitOfWork = null;
-    }
-
-    // Depending on the priority level, either perform work now or schedule
-    // a callback to perform work later.
-    switch (priorityLevel) {
-      case SynchronousPriority:
-        // Perform work immediately
-        performWork(SynchronousPriority);
-        return;
-      case TaskPriority:
-        // If we're already performing work, Task work will be flushed before
-        // exiting the current batch. So we can skip it here.
-        if (!isPerformingWork) {
-          performWork(TaskPriority);
-        }
-        return;
-      case AnimationPriority:
-        scheduleAnimationCallback(performAnimationWork);
-        return;
-      case HighPriority:
-      case LowPriority:
-      case OffscreenPriority:
-        scheduleDeferredCallback(performDeferredWork);
-        return;
     }
   }
 
@@ -1043,7 +1001,30 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
       if (!node.return) {
         if (node.tag === HostRoot) {
           const root : FiberRoot = (node.stateNode : any);
-          scheduleWorkAtPriority(root, priorityLevel);
+          scheduleRoot(root, priorityLevel);
+          // Depending on the priority level, either perform work now or
+          // schedule a callback to perform work later.
+          switch (priorityLevel) {
+            case SynchronousPriority:
+              // Perform work immediately
+              performWork(SynchronousPriority);
+              return;
+            case TaskPriority:
+              // If we're already performing work, Task work will be flushed before
+              // exiting the current batch. So we can skip it here.
+              if (!isPerformingWork) {
+                performWork(TaskPriority);
+              }
+              return;
+            case AnimationPriority:
+              scheduleAnimationCallback(performAnimationWork);
+              return;
+            case HighPriority:
+            case LowPriority:
+            case OffscreenPriority:
+              scheduleDeferredCallback(performDeferredWork);
+              return;
+          }
         } else {
           // TODO: Warn about setting state on an unmounted component.
           return;
@@ -1124,7 +1105,7 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
   }
 
   return {
-    scheduleWork: scheduleWork,
+    scheduleSetState: scheduleSetState,
     scheduleUpdateCallback: scheduleUpdateCallback,
     performWithPriority: performWithPriority,
     batchedUpdates: batchedUpdates,

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -267,7 +267,6 @@ describe('ReactIncremental', () => {
     ReactNoop.performAnimationWork(() => {
       ReactNoop.render(<Foo text="foo" />);
     });
-    ReactNoop.render(<Foo text="bar" />);
     ReactNoop.flushAnimationPri();
 
     expect(ops).toEqual(['Foo', 'Bar', 'Bar']);

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
@@ -654,6 +654,7 @@ describe('ReactIncrementalErrorHandling', () => {
     ReactNoop.unmountRootWithID('d');
     ReactNoop.unmountRootWithID('e');
     ReactNoop.unmountRootWithID('f');
+    ReactNoop.flush();
     expect(ReactNoop.getChildren('a')).toEqual(null);
     expect(ReactNoop.getChildren('b')).toEqual(null);
     expect(ReactNoop.getChildren('c')).toEqual(null);

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
@@ -25,6 +25,14 @@ describe('ReactIncrementalScheduling', () => {
     return { type: 'span', children: [], prop };
   }
 
+  it('schedules and flushes deferred work', () => {
+    ReactNoop.render(<span prop="1" />);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    ReactNoop.flushDeferredPri();
+    expect(ReactNoop.getChildren()).toEqual([span('1')]);
+  });
+
   it('schedules and flushes animation work', () => {
     ReactNoop.performAnimationWork(() => {
       ReactNoop.render(<span prop="1" />);
@@ -35,341 +43,75 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren()).toEqual([span('1')]);
   });
 
-  it('schedules and flushes animation work for many roots', () => {
-    ReactNoop.performAnimationWork(() => {
-      ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
-      ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
-      ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
-    });
-    expect(ReactNoop.getChildren('a')).toEqual([]);
-    expect(ReactNoop.getChildren('b')).toEqual([]);
-    expect(ReactNoop.getChildren('c')).toEqual([]);
+  it('searches for work on other roots once the current root completes', () => {
+    ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
+    ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
+    ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
 
-    ReactNoop.flushAnimationPri();
+    ReactNoop.flush();
+
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
   });
 
-  it('flushes all scheduled animation work', () => {
-    ReactNoop.performAnimationWork(() => {
-      ReactNoop.render(<span prop="1" />);
-    });
-    ReactNoop.performAnimationWork(() => {
-      ReactNoop.render(<span prop="2" />);
-    });
-    expect(ReactNoop.getChildren()).toEqual([]);
+  it('schedules an animation callback when there`\s leftover animation work', () => {
+    class Foo extends React.Component {
+      state = { step: 0 };
+      componentDidMount() {
+        ReactNoop.performAnimationWork(() => {
+          this.setState({ step: 2 });
+        });
+        this.setState({ step: 1 });
+      }
+      render() {
+        return <span prop={this.state.step} />;
+      }
+    }
 
+    ReactNoop.render(<Foo />);
+    // Flush just enough work to mount the component, but not enough to flush
+    // the animation update.
+    ReactNoop.flushDeferredPri(25);
+    expect(ReactNoop.getChildren()).toEqual([span(1)]);
+
+    // There's more animation work. A callback should have been scheduled.
     ReactNoop.flushAnimationPri();
-    expect(ReactNoop.getChildren()).toEqual([span('2')]);
+    expect(ReactNoop.getChildren()).toEqual([span(2)]);
   });
 
-  it('flushes all scheduled animation work for many roots', () => {
+  it('schedules top-level updates in order of priority', () => {
+    // Initial render.
+    ReactNoop.render(<span prop={1} />);
+    ReactNoop.flush();
+    expect(ReactNoop.getChildren()).toEqual([span(1)]);
+
+    ReactNoop.render(<span prop={5} />);
     ReactNoop.performAnimationWork(() => {
-      ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
-      ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
-      ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
+      ReactNoop.render(<span prop={2} />);
+      ReactNoop.render(<span prop={3} />);
+      ReactNoop.render(<span prop={4} />);
     });
-    ReactNoop.performAnimationWork(() => {
-      ReactNoop.renderToRootWithID(<span prop="a:2" />, 'a');
-      ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
-      ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
-    });
-    expect(ReactNoop.getChildren('a')).toEqual([]);
-    expect(ReactNoop.getChildren('b')).toEqual([]);
-    expect(ReactNoop.getChildren('c')).toEqual([]);
 
-    ReactNoop.flushAnimationPri();
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
-    expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
+    // The low pri update should be flushed last, even though it was scheduled
+    // before the animation updates.
+    ReactNoop.flush();
+    expect(ReactNoop.getChildren()).toEqual([span(5)]);
   });
 
-  it('schedules and flushes deferred work', () => {
-    ReactNoop.render(<span prop="1" />);
-    expect(ReactNoop.getChildren()).toEqual([]);
+  it('schedules top-level updates with same priority in order of insertion', () => {
+    // Initial render.
+    ReactNoop.render(<span prop={1} />);
+    ReactNoop.flush();
+    expect(ReactNoop.getChildren()).toEqual([span(1)]);
 
-    ReactNoop.flushDeferredPri();
-    expect(ReactNoop.getChildren()).toEqual([span('1')]);
-  });
+    ReactNoop.render(<span prop={2} />);
+    ReactNoop.render(<span prop={3} />);
+    ReactNoop.render(<span prop={4} />);
+    ReactNoop.render(<span prop={5} />);
 
-  it('schedules and flushes deferred work for many roots', () => {
-    ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
-    ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
-    ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
-    expect(ReactNoop.getChildren('a')).toEqual([]);
-    expect(ReactNoop.getChildren('b')).toEqual([]);
-    expect(ReactNoop.getChildren('c')).toEqual([]);
-
-    ReactNoop.flushDeferredPri();
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
-    expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
-  });
-
-  it('flushes scheduled deferred work fitting within deadline', () => {
-    ReactNoop.render(<span prop="1" />);
-    ReactNoop.render(<span prop="2" />);
-    expect(ReactNoop.getChildren()).toEqual([]);
-
-    ReactNoop.flushDeferredPri();
-    expect(ReactNoop.getChildren()).toEqual([span('2')]);
-  });
-
-  it('flushes scheduled deferred work fitting within deadline for many roots', () => {
-    ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
-    ReactNoop.renderToRootWithID(<span prop="a:2" />, 'a');
-    ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
-    ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
-    ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
-    ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
-    expect(ReactNoop.getChildren('a')).toEqual([]);
-    expect(ReactNoop.getChildren('b')).toEqual([]);
-    expect(ReactNoop.getChildren('c')).toEqual([]);
-
-    ReactNoop.flushDeferredPri();
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
-    expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
-  });
-
-  it('schedules more deferred work if it runs out of time', () => {
-    ReactNoop.render(<span prop="1" />);
-    ReactNoop.render(<span prop="2" />);
-    expect(ReactNoop.getChildren()).toEqual([]);
-
-    ReactNoop.flushDeferredPri(5);
-    expect(ReactNoop.getChildren()).toEqual([]);
-
-    ReactNoop.flushDeferredPri(10);
-    expect(ReactNoop.getChildren()).toEqual([]);
-
-    ReactNoop.flushDeferredPri(10 + 5);
-    expect(ReactNoop.getChildren()).toEqual([span('2')]);
-  });
-
-  it('schedules more deferred work if it runs out of time with many roots', () => {
-    ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
-    ReactNoop.renderToRootWithID(<span prop="a:2" />, 'a');
-    ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
-    ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
-    ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
-    ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
-    expect(ReactNoop.getChildren('a')).toEqual([]);
-    expect(ReactNoop.getChildren('b')).toEqual([]);
-    expect(ReactNoop.getChildren('c')).toEqual([]);
-
-    ReactNoop.flushDeferredPri(15 + 5);
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
-    expect(ReactNoop.getChildren('b')).toEqual([]);
-    expect(ReactNoop.getChildren('c')).toEqual([]);
-
-    ReactNoop.flushDeferredPri(15 + 5);
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
-    expect(ReactNoop.getChildren('c')).toEqual([]);
-
-    ReactNoop.flushDeferredPri(15 + 5);
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
-    expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
-  });
-
-  it('flushes late animation work in a deferred callback if it wins', () => {
-    // Schedule early deferred
-    ReactNoop.render(<span prop="1" />);
-    // Schedule late animation
-    ReactNoop.performAnimationWork(() => {
-      ReactNoop.render(<span prop="2" />);
-    });
-    expect(ReactNoop.getChildren()).toEqual([]);
-
-    // We only scheduled deferred callback so that's what we get.
-    // It will flush everything.
-    ReactNoop.flushDeferredPri();
-    expect(ReactNoop.getChildren()).toEqual([span('2')]);
-  });
-
-  it('flushes late animation work in a deferred callback if it wins with many roots', () => {
-    // Schedule early deferred
-    ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
-    ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
-    // Schedule late animation
-    ReactNoop.performAnimationWork(() => {
-      ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
-      ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
-    });
-    expect(ReactNoop.getChildren('a')).toEqual([]);
-    expect(ReactNoop.getChildren('b')).toEqual([]);
-    expect(ReactNoop.getChildren('c')).toEqual([]);
-
-    // We only scheduled deferred callback so that's what we get.
-    // It will flush everything.
-    ReactNoop.flushDeferredPri();
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
-    expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
-  });
-
-  it('flushes late animation work in an animation callback if it wins', () => {
-    // Schedule early deferred
-    ReactNoop.render(<span prop="1" />);
-    // Schedule late animation
-    ReactNoop.performAnimationWork(() => {
-      ReactNoop.render(<span prop="2" />);
-    });
-    expect(ReactNoop.getChildren()).toEqual([]);
-
-    // Flushing animation should have flushed the animation.
-    ReactNoop.flushAnimationPri();
-    expect(ReactNoop.getChildren()).toEqual([span('2')]);
-  });
-
-  it('flushes late animation work in an animation callback if it wins with many roots', () => {
-    // Schedule early deferred
-    ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
-    ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
-    // Schedule late animation
-    ReactNoop.performAnimationWork(() => {
-      ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
-      ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
-    });
-    expect(ReactNoop.getChildren('a')).toEqual([]);
-    expect(ReactNoop.getChildren('b')).toEqual([]);
-    expect(ReactNoop.getChildren('c')).toEqual([]);
-
-    // Flushing animation should have flushed the animation.
-    ReactNoop.flushAnimationPri();
-    expect(ReactNoop.getChildren('a')).toEqual([]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
-    expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
-
-    ReactNoop.flushDeferredPri();
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
-    expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
-  });
-
-  it('flushes all work in a deferred callback if it wins', () => {
-    // Schedule early animation
-    ReactNoop.performAnimationWork(() => {
-      ReactNoop.render(<span prop="1" />);
-    });
-    // Schedule late deferred
-    ReactNoop.render(<span prop="2" />);
-    expect(ReactNoop.getChildren()).toEqual([]);
-
-    // Flushing deferred should have flushed both early animation and late deferred work that invalidated it.
-    // This is not a common case, as animation should generally be flushed before deferred work.
-    ReactNoop.flushDeferredPri();
-    expect(ReactNoop.getChildren()).toEqual([span('2')]);
-  });
-
-  it('flushes all work in a deferred callback if it wins with many roots', () => {
-    // Schedule early animation
-    ReactNoop.performAnimationWork(() => {
-      ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
-      ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
-    });
-    // Schedule late deferred
-    ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
-    ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
-    expect(ReactNoop.getChildren('a')).toEqual([]);
-    expect(ReactNoop.getChildren('b')).toEqual([]);
-    expect(ReactNoop.getChildren('c')).toEqual([]);
-
-    // Flushing deferred should have flushed both early animation and late deferred work that invalidated it.
-    // This is not a common case, as animation should generally be flushed before deferred work.
-    ReactNoop.flushDeferredPri();
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
-    expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
-  });
-
-  it('flushes root with late deferred work in an animation callback if it wins', () => {
-    // Schedule early animation
-    ReactNoop.performAnimationWork(() => {
-      ReactNoop.render(<span prop="1" />);
-    });
-    // Schedule late deferred
-    ReactNoop.render(<span prop="2" />);
-    expect(ReactNoop.getChildren()).toEqual([]);
-
-    // Flushing animation work flushes everything on this root.
-    ReactNoop.flushAnimationPri();
-    expect(ReactNoop.getChildren()).toEqual([span('2')]);
-  });
-
-  it('flushes all roots with animation work in an animation callback if it wins', () => {
-    // Schedule early animation
-    ReactNoop.performAnimationWork(() => {
-      ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
-      ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
-    });
-    // Schedule late deferred
-    ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
-    ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
-    expect(ReactNoop.getChildren('a')).toEqual([]);
-    expect(ReactNoop.getChildren('b')).toEqual([]);
-    expect(ReactNoop.getChildren('c')).toEqual([]);
-
-    // Flushing animation work flushes all roots with animation work.
-    ReactNoop.flushAnimationPri();
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
-    expect(ReactNoop.getChildren('c')).toEqual([]);
-
-    // Flushing deferred work flushes the root with only deferred work.
-    ReactNoop.flushDeferredPri();
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
-    expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
-  });
-
-  it('splits deferred work on multiple roots', () => {
-    // Schedule one root
-    ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
-    ReactNoop.flushDeferredPri(15 + 5);
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
-
-    // Schedule two roots
-    ReactNoop.renderToRootWithID(<span prop="a:2" />, 'a');
-    ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
-    // First scheduled one gets processed first
-    ReactNoop.flushDeferredPri(15 + 5);
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
-    expect(ReactNoop.getChildren('b')).toEqual([]);
-    expect(ReactNoop.getChildren('c')).toEqual(null);
-    // Then the second one gets processed
-    ReactNoop.flushDeferredPri(15 + 5);
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
-    expect(ReactNoop.getChildren('c')).toEqual(null);
-
-    // Schedule three roots
-    ReactNoop.renderToRootWithID(<span prop="a:3" />, 'a');
-    ReactNoop.renderToRootWithID(<span prop="b:3" />, 'b');
-    ReactNoop.renderToRootWithID(<span prop="c:3" />, 'c');
-    // They get processed in the order they were scheduled
-    ReactNoop.flushDeferredPri(15 + 5);
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:3')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
-    expect(ReactNoop.getChildren('c')).toEqual([]);
-    ReactNoop.flushDeferredPri(15 + 5);
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:3')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:3')]);
-    expect(ReactNoop.getChildren('c')).toEqual([]);
-    ReactNoop.flushDeferredPri(15 + 5);
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:3')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:3')]);
-    expect(ReactNoop.getChildren('c')).toEqual([span('c:3')]);
-
-    // Schedule one root many times
-    ReactNoop.renderToRootWithID(<span prop="a:4" />, 'a');
-    ReactNoop.renderToRootWithID(<span prop="a:5" />, 'a');
-    ReactNoop.renderToRootWithID(<span prop="a:6" />, 'a');
-    ReactNoop.flushDeferredPri(15 + 5);
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:6')]);
+    ReactNoop.flush();
+    expect(ReactNoop.getChildren()).toEqual([span(5)]);
   });
 
   it('works on deferred roots in the order they were scheduled', () => {
@@ -400,54 +142,6 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
     expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
-  });
-
-  it('handles interleaved deferred and animation work', () => {
-    ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
-    ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
-    ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
-    ReactNoop.flush();
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
-    expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
-
-    // Schedule both deferred and animation work
-    ReactNoop.renderToRootWithID(<span prop="a:2" />, 'a');
-    ReactNoop.performAnimationWork(() => {
-      ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
-      ReactNoop.renderToRootWithID(<span prop="c:2" />, 'c');
-    });
-    // We're flushing deferred work
-    // Still, roots with animation work are handled first
-    ReactNoop.flushDeferredPri(15);
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
-    expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
-    ReactNoop.flushDeferredPri(15);
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:2')]);
-    expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
-
-    // More deferred and animation work just got scheduled!
-    ReactNoop.renderToRootWithID(<span prop="c:3" />, 'c');
-    ReactNoop.performAnimationWork(() => {
-      ReactNoop.renderToRootWithID(<span prop="b:3" />, 'b');
-    });
-    // Animation is still handled first
-    ReactNoop.flushDeferredPri(15);
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:3')]);
-    expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
-
-    // Finally we handle deferred root in the order it was scheduled
-    ReactNoop.flushDeferredPri(15 + 5);
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:3')]);
-    expect(ReactNoop.getChildren('c')).toEqual([span('c:2')]);
-    ReactNoop.flushDeferredPri(15 + 5);
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:2')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:3')]);
-    expect(ReactNoop.getChildren('c')).toEqual([span('c:3')]);
   });
 
   it('schedules sync updates when inside componentDidMount/Update', () => {


### PR DESCRIPTION
Use an UpdateQueue for top-level updates (`ReactDOM.render`), rather than mutate the pending props directly, which effectively overrides the previous update.

This uncovered an inconsistency in Stack related to top-level callbacks. I'll fix that in a separate PR.

Based on and blocked by https://github.com/facebook/react/pull/8538.

@gaearon, I removed some of the tests in `ReactIncrementalScheduling-test.js` in favor of tests in both `ReactIncremental-test.js` and `ReactIncrementalUpdates-test.js` which (if I'm correct) cover the same things. If I've deleted a test for a case you feel is no longer covered, let me know and I'll write a new one. My goal was only to reduce noise in the test suite, not to stop testing specific cases.