### PR TITLE
Schedule state and callback at the same time

### DIFF
--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -728,10 +728,7 @@ var ReactClassMixin = {
    * type signature and the only use case for this, is to avoid that.
    */
   replaceState: function(newState, callback) {
-    this.updater.enqueueReplaceState(this, newState);
-    if (callback) {
-      this.updater.enqueueCallback(this, callback, 'replaceState');
-    }
+    this.updater.enqueueReplaceState(this, newState, callback, 'replaceState');
   },
 
   /**

--- a/src/isomorphic/modern/class/ReactComponent.js
+++ b/src/isomorphic/modern/class/ReactComponent.js
@@ -65,10 +65,7 @@ ReactComponent.prototype.setState = function(partialState, callback) {
     'setState(...): takes an object of state variables to update or a ' +
     'function which returns an object of state variables.'
   );
-  this.updater.enqueueSetState(this, partialState);
-  if (callback) {
-    this.updater.enqueueCallback(this, callback, 'setState');
-  }
+  this.updater.enqueueSetState(this, partialState, callback, 'setState');
 };
 
 /**
@@ -86,10 +83,7 @@ ReactComponent.prototype.setState = function(partialState, callback) {
  * @protected
  */
 ReactComponent.prototype.forceUpdate = function(callback) {
-  this.updater.enqueueForceUpdate(this);
-  if (callback) {
-    this.updater.enqueueCallback(this, callback, 'forceUpdate');
-  }
+  this.updater.enqueueForceUpdate(this, callback, 'forceUpdate');
 };
 
 /**

--- a/src/isomorphic/modern/class/ReactNoopUpdateQueue.js
+++ b/src/isomorphic/modern/class/ReactNoopUpdateQueue.js
@@ -45,16 +45,6 @@ var ReactNoopUpdateQueue = {
   },
 
   /**
-   * Enqueue a callback that will be executed after all the pending updates
-   * have processed.
-   *
-   * @param {ReactClass} publicInstance The instance to use as `this` context.
-   * @param {?function} callback Called after state is updated.
-   * @internal
-   */
-  enqueueCallback: function(publicInstance, callback) { },
-
-  /**
    * Forces an update. This should only be invoked when it is known with
    * certainty that we are **not** in a DOM transaction.
    *
@@ -65,9 +55,11 @@ var ReactNoopUpdateQueue = {
    * `componentWillUpdate` and `componentDidUpdate`.
    *
    * @param {ReactClass} publicInstance The instance that should rerender.
+   * @param {?function} callback Called after component is updated.
+   * @param {?string} Name of the calling function in the public API.
    * @internal
    */
-  enqueueForceUpdate: function(publicInstance) {
+  enqueueForceUpdate: function(publicInstance, callback, callerName) {
     warnNoop(publicInstance, 'forceUpdate');
   },
 
@@ -80,9 +72,11 @@ var ReactNoopUpdateQueue = {
    *
    * @param {ReactClass} publicInstance The instance that should rerender.
    * @param {object} completeState Next state.
+   * @param {?function} callback Called after component is updated.
+   * @param {?string} Name of the calling function in the public API.
    * @internal
    */
-  enqueueReplaceState: function(publicInstance, completeState) {
+  enqueueReplaceState: function(publicInstance, completeState, callback, callerName) {
     warnNoop(publicInstance, 'replaceState');
   },
 
@@ -94,9 +88,11 @@ var ReactNoopUpdateQueue = {
    *
    * @param {ReactClass} publicInstance The instance that should rerender.
    * @param {object} partialState Next partial state to be merged with state.
+   * @param {?function} callback Called after component is updated.
+   * @param {?string} Name of the calling function in the public API.
    * @internal
    */
-  enqueueSetState: function(publicInstance, partialState) {
+  enqueueSetState: function(publicInstance, partialState, callback, callerName) {
     warnNoop(publicInstance, 'setState');
   },
 };

--- a/src/renderers/dom/stack/server/ReactServerUpdateQueue.js
+++ b/src/renderers/dom/stack/server/ReactServerUpdateQueue.js
@@ -59,20 +59,6 @@ class ReactServerUpdateQueue {
   }
 
   /**
-   * Enqueue a callback that will be executed after all the pending updates
-   * have processed.
-   *
-   * @param {ReactClass} publicInstance The instance to use as `this` context.
-   * @param {?function} callback Called after state is updated.
-   * @internal
-   */
-  enqueueCallback(publicInstance: ReactComponent<any, any, any>, callback?: Function, callerName?: string) {
-    if (this.transaction.isInTransaction()) {
-      ReactUpdateQueue.enqueueCallback(publicInstance, callback, callerName);
-    }
-  }
-
-  /**
    * Forces an update. This should only be invoked when it is known with
    * certainty that we are **not** in a DOM transaction.
    *
@@ -83,11 +69,13 @@ class ReactServerUpdateQueue {
    * `componentWillUpdate` and `componentDidUpdate`.
    *
    * @param {ReactClass} publicInstance The instance that should rerender.
+   * @param {?function} callback Called after component is updated.
+   * @param {?string} Name of the calling function in the public API.
    * @internal
    */
-  enqueueForceUpdate(publicInstance: ReactComponent<any, any, any>) {
+  enqueueForceUpdate(publicInstance: ReactComponent<any, any, any>, callback?: Function, callerName?: string) {
     if (this.transaction.isInTransaction()) {
-      ReactUpdateQueue.enqueueForceUpdate(publicInstance);
+      ReactUpdateQueue.enqueueForceUpdate(publicInstance, callback, callerName);
     } else {
       warnNoop(publicInstance, 'forceUpdate');
     }
@@ -102,11 +90,18 @@ class ReactServerUpdateQueue {
    *
    * @param {ReactClass} publicInstance The instance that should rerender.
    * @param {object|function} completeState Next state.
+   * @param {?function} callback Called after component is updated.
+   * @param {?string} Name of the calling function in the public API.
    * @internal
    */
-  enqueueReplaceState(publicInstance: ReactComponent<any, any, any>, completeState: Object|Function) {
+  enqueueReplaceState(
+    publicInstance: ReactComponent<any, any, any>,
+    completeState: Object|Function,
+    callback?: Function,
+    callerName?: string
+  ) {
     if (this.transaction.isInTransaction()) {
-      ReactUpdateQueue.enqueueReplaceState(publicInstance, completeState);
+      ReactUpdateQueue.enqueueReplaceState(publicInstance, completeState, callback, callerName);
     } else {
       warnNoop(publicInstance, 'replaceState');
     }
@@ -122,9 +117,14 @@ class ReactServerUpdateQueue {
    * @param {object|function} partialState Next partial state to be merged with state.
    * @internal
    */
-  enqueueSetState(publicInstance: ReactComponent<any, any, any>, partialState: Object|Function) {
+  enqueueSetState(
+    publicInstance: ReactComponent<any, any, any>,
+    partialState: Object|Function,
+    callback?: Function,
+    callerName?: string
+  ) {
     if (this.transaction.isInTransaction()) {
-      ReactUpdateQueue.enqueueSetState(publicInstance, partialState);
+      ReactUpdateQueue.enqueueSetState(publicInstance, partialState, callback, callerName);
     } else {
       warnNoop(publicInstance, 'setState');
     }

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -71,10 +71,8 @@ if (__DEV__) {
 module.exports = function<T, P, I, TI, C, CX>(
   config : HostConfig<T, P, I, TI, C, CX>,
   hostContext : HostContext<C, CX>,
-  scheduleSetState: (fiber : Fiber, partialState : any) => void,
-  scheduleReplaceState: (fiber : Fiber, state : any) => void,
-  scheduleForceUpdate: (fiber : Fiber) => void,
-  scheduleUpdateCallback: (fiber : Fiber, callback : Function) => void,
+  scheduleUpdate : (fiber : Fiber, priorityLevel : PriorityLevel) => void,
+  getPriorityContext : () => PriorityLevel,
 ) {
 
   const { shouldSetTextContent } = config;
@@ -91,12 +89,7 @@ module.exports = function<T, P, I, TI, C, CX>(
     mountClassInstance,
     resumeMountClassInstance,
     updateClassInstance,
-  } = ReactFiberClassComponent(
-    scheduleSetState,
-    scheduleReplaceState,
-    scheduleForceUpdate,
-    scheduleUpdateCallback
-  );
+  } = ReactFiberClassComponent(scheduleUpdate, getPriorityContext);
 
   function markChildAsProgressed(current, workInProgress, priorityLevel) {
     // We now have clones. Let's store them as the currently progressed work.

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -22,7 +22,6 @@ var {
   addUpdate,
   addReplaceUpdate,
   addForceUpdate,
-  addCallback,
   beginUpdateQueue,
 } = require('ReactFiberUpdateQueue');
 var { hasContextChanged } = require('ReactFiberContext');
@@ -58,12 +57,6 @@ module.exports = function(
       const fiber = ReactInstanceMap.get(instance);
       const priorityLevel = getPriorityContext();
       addForceUpdate(fiber, callback || null, priorityLevel);
-      scheduleUpdate(fiber, priorityLevel);
-    },
-    enqueueCallback(instance, callback) {
-      const fiber = ReactInstanceMap.get(instance);
-      const priorityLevel = getPriorityContext();
-      addCallback(fiber, callback || null, priorityLevel);
       scheduleUpdate(fiber, priorityLevel);
     },
   };

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -350,25 +350,6 @@ function addForceUpdate(
 }
 exports.addForceUpdate = addForceUpdate;
 
-
-function addCallback(
-  fiber : Fiber,
-  callback: Callback,
-  priorityLevel : PriorityLevel
-) : void {
-  const update : Update = {
-    priorityLevel,
-    partialState: null,
-    callback,
-    isReplace: false,
-    isForced: false,
-    isTopLevelUnmount: false,
-    next: null,
-  };
-  insertUpdate(fiber, update);
-}
-exports.addCallback = addCallback;
-
 function getPendingPriority(queue : UpdateQueue) : PriorityLevel {
   return queue.first ? queue.first.priorityLevel : NoWork;
 }

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -284,12 +284,13 @@ function insertUpdate(fiber : Fiber, update : Update, methodName : ?string) : Up
 function addUpdate(
   fiber : Fiber,
   partialState : PartialState<any, any> | null,
+  callback : Callback | null,
   priorityLevel : PriorityLevel
 ) : void {
   const update = {
     priorityLevel,
     partialState,
-    callback: null,
+    callback,
     isReplace: false,
     isForced: false,
     isTopLevelUnmount: false,
@@ -306,12 +307,13 @@ exports.addUpdate = addUpdate;
 function addReplaceUpdate(
   fiber : Fiber,
   state : any | null,
+  callback : Callback | null,
   priorityLevel : PriorityLevel
 ) : void {
   const update = {
     priorityLevel,
     partialState: state,
-    callback: null,
+    callback,
     isReplace: true,
     isForced: false,
     isTopLevelUnmount: false,
@@ -326,11 +328,15 @@ function addReplaceUpdate(
 }
 exports.addReplaceUpdate = addReplaceUpdate;
 
-function addForceUpdate(fiber : Fiber, priorityLevel : PriorityLevel) : void {
+function addForceUpdate(
+  fiber : Fiber,
+  callback : Callback | null,
+  priorityLevel : PriorityLevel
+) : void {
   const update = {
     priorityLevel,
     partialState: null,
-    callback: null,
+    callback,
     isReplace: false,
     isForced: true,
     isTopLevelUnmount: false,
@@ -345,7 +351,11 @@ function addForceUpdate(fiber : Fiber, priorityLevel : PriorityLevel) : void {
 exports.addForceUpdate = addForceUpdate;
 
 
-function addCallback(fiber : Fiber, callback: Callback, priorityLevel : PriorityLevel) : void {
+function addCallback(
+  fiber : Fiber,
+  callback: Callback,
+  priorityLevel : PriorityLevel
+) : void {
   const update : Update = {
     priorityLevel,
     partialState: null,
@@ -367,14 +377,18 @@ exports.getPendingPriority = getPendingPriority;
 function addTopLevelUpdate(
   fiber : Fiber,
   partialState : PartialState<any, any>,
+  callback : Callback | null,
   priorityLevel : PriorityLevel
 ) : void {
-  const isTopLevelUnmount = partialState === null;
+  const isTopLevelUnmount = Boolean(
+    partialState &&
+    partialState.element === null
+  );
 
   const update = {
     priorityLevel,
     partialState,
-    callback: null,
+    callback,
     isReplace: false,
     isForced: false,
     isTopLevelUnmount,

--- a/src/renderers/shared/shared/__tests__/ReactCompositeComponentState-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactCompositeComponentState-test.js
@@ -171,20 +171,8 @@ describe('ReactCompositeComponent-state', () => {
       ['componentDidMount-end', 'orange'],
       ['setState-sunrise', 'orange'],
       ['setState-orange', 'orange'],
-    ];
-
-    // In Fiber, the initial callback is not enqueued until after any work
-    // scheduled by lifecycles has flushed (same semantics as a regular setState
-    // callback outside of a batch). In Stack, the initial render is scheduled
-    // inside of batchedUpdates, so the callback gets flushed right after
-    // componentDidMount.
-    // TODO: We should fix this, in both Stack and Fiber, so that the behavior
-    // is consistent regardless of whether you're in a batch.
-    if (!ReactDOMFeatureFlags.useFiber) {
-      expected.push(['initial-callback', 'orange']);
-    }
-
-    expected.push(['shouldComponentUpdate-currentState', 'orange'],
+      ['initial-callback', 'orange'],
+      ['shouldComponentUpdate-currentState', 'orange'],
       ['shouldComponentUpdate-nextState', 'yellow'],
       ['componentWillUpdate-currentState', 'orange'],
       ['componentWillUpdate-nextState', 'yellow'],
@@ -192,18 +180,11 @@ describe('ReactCompositeComponent-state', () => {
       ['componentDidUpdate-currentState', 'yellow'],
       ['componentDidUpdate-prevState', 'orange'],
       ['setState-yellow', 'yellow'],
-    );
-
-    if (ReactDOMFeatureFlags.useFiber) {
-      expected.push(['initial-callback', 'yellow']);
-    }
-
-    expected.push(
       ['componentWillReceiveProps-start', 'yellow'],
       // setState({color:'green'}) only enqueues a pending state.
       ['componentWillReceiveProps-end', 'yellow'],
       // pending state queue is processed
-    );
+    ];
 
     if (ReactDOMFeatureFlags.useFiber) {
       // In Stack, this is never called because replaceState drops all updates

--- a/src/renderers/shared/shared/__tests__/ReactUpdates-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactUpdates-test.js
@@ -648,16 +648,18 @@ describe('ReactUpdates', () => {
           'Inner-render-1-0',
           'Inner-didUpdate-1-0',
         'Outer-didUpdate-1',
+           // Happens in a batch, so don't re-render yet
           'Inner-setState-1',
-            'Inner-render-1-1',
-            'Inner-didUpdate-1-1',
-            'Inner-callback-1',
         'Outer-callback-1',
 
-      'Outer-setState-2',
+        // Happens in a batch
+        'Outer-setState-2',
+
+        // Flush batched updates all at once
         'Outer-render-2',
           'Inner-render-2-1',
           'Inner-didUpdate-2-1',
+          'Inner-callback-1',
         'Outer-didUpdate-2',
           'Inner-setState-2',
         'Outer-callback-2',

--- a/src/renderers/shared/stack/reconciler/ReactUpdateQueue.js
+++ b/src/renderers/shared/stack/reconciler/ReactUpdateQueue.js
@@ -112,40 +112,6 @@ var ReactUpdateQueue = {
     }
   },
 
-  /**
-   * Enqueue a callback that will be executed after all the pending updates
-   * have processed.
-   *
-   * @param {ReactClass} publicInstance The instance to use as `this` context.
-   * @param {?function} callback Called after state is updated.
-   * @param {string} callerName Name of the calling function in the public API.
-   * @internal
-   */
-  enqueueCallback: function(publicInstance, callback, callerName) {
-    ReactUpdateQueue.validateCallback(callback, callerName);
-    var internalInstance = getInternalInstanceReadyForUpdate(publicInstance);
-
-    // Previously we would throw an error if we didn't have an internal
-    // instance. Since we want to make it a no-op instead, we mirror the same
-    // behavior we have in other enqueue* methods.
-    // We also need to ignore callbacks in componentWillMount. See
-    // enqueueUpdates.
-    if (!internalInstance) {
-      return null;
-    }
-
-    if (internalInstance._pendingCallbacks) {
-      internalInstance._pendingCallbacks.push(callback);
-    } else {
-      internalInstance._pendingCallbacks = [callback];
-    }
-    // TODO: The callback here is ignored when setState is called from
-    // componentWillMount. Either fix it or disallow doing so completely in
-    // favor of getInitialState. Alternatively, we can disallow
-    // componentWillMount during server-side rendering.
-    enqueueUpdate(internalInstance);
-  },
-
   enqueueCallbackInternal: function(internalInstance, callback) {
     if (internalInstance._pendingCallbacks) {
       internalInstance._pendingCallbacks.push(callback);

--- a/src/renderers/shared/stack/reconciler/ReactUpdateQueue.js
+++ b/src/renderers/shared/stack/reconciler/ReactUpdateQueue.js
@@ -166,9 +166,11 @@ var ReactUpdateQueue = {
    * `componentWillUpdate` and `componentDidUpdate`.
    *
    * @param {ReactClass} publicInstance The instance that should rerender.
+   * @param {?function} callback Called after component is updated.
+   * @param {?string} Name of the calling function in the public API.
    * @internal
    */
-  enqueueForceUpdate: function(publicInstance) {
+  enqueueForceUpdate: function(publicInstance, callback, callerName) {
     var internalInstance = getInternalInstanceReadyForUpdate(
       publicInstance,
       'forceUpdate'
@@ -176,6 +178,15 @@ var ReactUpdateQueue = {
 
     if (!internalInstance) {
       return;
+    }
+
+    if (callback) {
+      ReactUpdateQueue.validateCallback(callback, callerName);
+      if (internalInstance._pendingCallbacks) {
+        internalInstance._pendingCallbacks.push(callback);
+      } else {
+        internalInstance._pendingCallbacks = [callback];
+      }
     }
 
     internalInstance._pendingForceUpdate = true;
@@ -192,9 +203,11 @@ var ReactUpdateQueue = {
    *
    * @param {ReactClass} publicInstance The instance that should rerender.
    * @param {object} completeState Next state.
+   * @param {?function} callback Called after state is updated.
+   * @param {?string} Name of the calling function in the public API.
    * @internal
    */
-  enqueueReplaceState: function(publicInstance, completeState) {
+  enqueueReplaceState: function(publicInstance, completeState, callback, callerName) {
     var internalInstance = getInternalInstanceReadyForUpdate(
       publicInstance,
       'replaceState'
@@ -207,6 +220,15 @@ var ReactUpdateQueue = {
     internalInstance._pendingStateQueue = [completeState];
     internalInstance._pendingReplaceState = true;
 
+    if (callback) {
+      ReactUpdateQueue.validateCallback(callback, callerName);
+      if (internalInstance._pendingCallbacks) {
+        internalInstance._pendingCallbacks.push(callback);
+      } else {
+        internalInstance._pendingCallbacks = [callback];
+      }
+    }
+
     enqueueUpdate(internalInstance);
   },
 
@@ -218,9 +240,11 @@ var ReactUpdateQueue = {
    *
    * @param {ReactClass} publicInstance The instance that should rerender.
    * @param {object} partialState Next partial state to be merged with state.
+   * @param {?function} callback Called after state is updated.
+   * @param {?string} Name of the calling function in the public API.
    * @internal
    */
-  enqueueSetState: function(publicInstance, partialState) {
+  enqueueSetState: function(publicInstance, partialState, callback, callerName) {
     if (__DEV__) {
       ReactInstrumentation.debugTool.onSetState();
       warning(
@@ -243,6 +267,15 @@ var ReactUpdateQueue = {
       internalInstance._pendingStateQueue ||
       (internalInstance._pendingStateQueue = []);
     queue.push(partialState);
+
+    if (callback) {
+      ReactUpdateQueue.validateCallback(callback, callerName);
+      if (internalInstance._pendingCallbacks) {
+        internalInstance._pendingCallbacks.push(callback);
+      } else {
+        internalInstance._pendingCallbacks = [callback];
+      }
+    }
 
     enqueueUpdate(internalInstance);
   },


### PR DESCRIPTION
Fixes an issue (in both Stack and Fiber) where `enqueueSetState` causes a synchronous update that flushes before `enqueueCallback` is ever called. Now `enqueueSetState` et al accept an optional callback so that both are scheduled at the same time.