### PR TITLE
[Fiber] UpdateQueue follow-up improvements

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1236,6 +1236,7 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalUpdates-test.js
 * only drops updates with equal or lesser priority when replaceState is called
 * can abort an update, schedule additional updates, and resume
 * can abort an update, schedule a replaceState, and resume
+* passes accumulation of previous updates to replaceState updater function
 * does not call callbacks that are scheduled by another callback until a later commit
 * gives setState during reconciliation the same priority as whatever level is currently reconciling
 * enqueues setState inside an updater function as if the in-progress update is progressed (and warns)

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -25,6 +25,8 @@ const {
   TaskPriority,
 } = require('ReactPriorityLevel');
 
+const warning = require('warning');
+
 type PartialState<State, Props> =
   $Subtype<State> |
   (prevState: State, props: Props) => $Subtype<State>;
@@ -193,21 +195,26 @@ function insertUpdate(fiber : Fiber, update : Update, methodName : ?string) : vo
   const queue2 = fiber.alternate ? ensureUpdateQueue(fiber.alternate) : null;
 
   // Warn if an update is scheduled from inside an updater function.
-  if (__DEV__ && typeof methodName === 'string' && (queue1.isProcessing || (queue2 && queue2.isProcessing))) {
-    if (methodName === 'setState') {
-      console.error(
-        'setState was called from inside the updater function of another' +
-        'setState. A function passed as the first argument of setState ' +
-        'should not contain any side-effects. Return a partial state object ' +
-        'instead of calling setState again. Example: ' +
-        'this.setState(function(state) { return { count: state.count + 1 }; })'
-      );
-    } else {
-      console.error(
-        `${methodName} was called from inside the updater function of ` +
-        'setState. A function passed as the first argument of setState ' +
-        'should not contain any side-effects.'
-      );
+  if (__DEV__ && typeof methodName === 'string') {
+    if (queue1.isProcessing || (queue2 && queue2.isProcessing)) {
+      if (methodName === 'setState') {
+        warning(
+          false,
+          'setState was called from inside the updater function of another' +
+          'setState. A function passed as the first argument of setState ' +
+          'should not contain any side-effects. Return a partial state ' +
+          'object instead of calling setState again. Example: ' +
+          'this.setState(function(state) { return { count: state.count + 1 }; })'
+        );
+      } else {
+        warning(
+          false,
+          '%s was called from inside the updater function of setState. A ' +
+          'function passed as the first argument of setState ' +
+          'should not contain any side-effects.',
+          methodName
+        );
+      }
     }
   }
 

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -309,36 +309,6 @@ function addReplaceUpdate(
     next: null,
   };
 
-  // Drop all updates with equal priority
-  let queue = ensureUpdateQueue(fiber);
-  for (let i = 0; queue && i < 2; i++) {
-    let replaceAfter = null;
-    let replaceBefore = queue.first;
-    let comparison = 255;
-    while (replaceBefore &&
-           (comparison = comparePriority(replaceBefore.priorityLevel, priorityLevel)) <= 0) {
-      if (comparison < 0) {
-        replaceAfter = replaceBefore;
-      }
-      replaceBefore = replaceBefore.next;
-    }
-
-    if (replaceAfter) {
-      replaceAfter.next = replaceBefore;
-    } else {
-      queue.first = replaceBefore;
-    }
-
-    if (!replaceBefore) {
-      queue.last = replaceAfter;
-    }
-
-    if (fiber.alternate) {
-      queue = ensureUpdateQueue(fiber.alternate);
-    } else {
-      queue = null;
-    }
-  }
   if (__DEV__) {
     insertUpdate(fiber, update, 'replaceState');
   } else {
@@ -426,9 +396,7 @@ function beginUpdateQueue(
 
     let partialState;
     if (update.isReplace) {
-      // A replace should drop all previous updates in the queue, so
-      // use the original `prevState`, not the accumulated `state`
-      state = getStateFromUpdate(update, instance, prevState, props);
+      state = getStateFromUpdate(update, instance, state, props);
       dontMutatePrevState = true;
     } else {
       partialState = getStateFromUpdate(update, instance, state, props);

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalUpdates-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalUpdates-test.js
@@ -203,9 +203,7 @@ describe('ReactIncrementalUpdates', () => {
       render() {
         ops.push('render');
         instance = this;
-        return (
-          <span prop={Object.keys(this.state).join('')} />
-        );
+        return <span />;
       },
     });
 
@@ -244,9 +242,29 @@ describe('ReactIncrementalUpdates', () => {
     instance.setState(createUpdate('g'));
 
     ReactNoop.flush();
-    // Ensure that updater function d is never called.
-    expect(progressedUpdates).toEqual(['e', 'f', 'g']);
+    expect(progressedUpdates).toEqual(['d', 'e', 'f', 'g']);
     expect(instance.state).toEqual({ e: 'e', f: 'f', g: 'g' });
+  });
+
+  it('passes accumulation of previous updates to replaceState updater function', () => {
+    let instance;
+    const Foo = React.createClass({
+      getInitialState() {
+        return {};
+      },
+      render() {
+        instance = this;
+        return <span />;
+      },
+    });
+    ReactNoop.render(<Foo />);
+    ReactNoop.flush();
+
+    instance.setState({ a: 'a' });
+    instance.setState({ b: 'b' });
+    instance.replaceState(previousState => ({ previousState }));
+    ReactNoop.flush();
+    expect(instance.state).toEqual({ previousState: { a: 'a', b : 'b' } });
   });
 
   it('does not call callbacks that are scheduled by another callback until a later commit', () => {

--- a/src/renderers/shared/shared/__tests__/ReactCompositeComponentState-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactCompositeComponentState-test.js
@@ -193,7 +193,19 @@ describe('ReactCompositeComponent-state', () => {
       // setState({color:'green'}) only enqueues a pending state.
       ['componentWillReceiveProps-end', 'yellow'],
       // pending state queue is processed
-      // before-setState-receiveProps never called, due to replaceState.
+    );
+
+    if (ReactDOMFeatureFlags.useFiber) {
+      // In Stack, this is never called because replaceState drops all updates
+      // from the queue. In Fiber, we keep updates in the queue to support
+      // replaceState(prevState => newState).
+      // TODO: Fix Stack to match Fiber.
+      expected.push(
+        ['before-setState-receiveProps', 'yellow'],
+      );
+    }
+
+    expected.push(
       ['before-setState-again-receiveProps', undefined],
       ['after-setState-receiveProps', 'green'],
       ['shouldComponentUpdate-currentState', 'yellow'],


### PR DESCRIPTION
Follow-up to https://github.com/facebook/react/pull/8538.

- [x] Replace `console.error` with `warning` module.
- [x] Remove `ForceUpdate` effect and put the flag back on the queue.
- [x] Don't need to track `isEmpty`
- [x] Don't drop updates from the queue in `replaceState` and always pass the accumulated state.
- [x] Inline `insertUpdateIntoQueue`, maybe. Make the logic easier to follow when an incoming update is cloned versus when it is not.
- [x] Don't update `memoizedState` in begin phase. Later, we'll move all memoization from complete to begin.
- [x] Get rid of weird for-loops. Either explode or use a helper function so it can be inlined.
- [x] Clone update before transferring to `callbackList`

