### PR TITLE
`bailoutOnLowPriority` pushes context to mirror complete phase context pop

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1148,6 +1148,7 @@ src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
 * provides context when reusing work
 * reads context when setState is below the provider
 * reads context when setState is above the provider
+* maintains the correct context index when context proviers are bailed out due to low priority
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
 * catches render error in a boundary during full deferred mounting

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -462,8 +462,17 @@ module.exports = function<T, P, I, TI, C, CX>(
   }
 
   function bailoutOnLowPriority(current, workInProgress) {
-    if (workInProgress.tag === HostPortal) {
-      pushHostContainer(workInProgress.stateNode.containerInfo);
+    // TODO: Handle HostComponent tags here as well and call pushHostContext()?
+    // See PR 8590 discussion for context
+    switch (workInProgress.tag) {
+      case ClassComponent:
+        if (isContextProvider(workInProgress)) {
+          pushContextProvider(workInProgress, false);
+        }
+        break;
+      case HostPortal:
+        pushHostContainer(workInProgress.stateNode.containerInfo);
+        break;
     }
     // TODO: What if this is currently in progress?
     // How can that happen? How is this not being cloned?


### PR DESCRIPTION
While testing the new `ReactNativeFiber` renderer on internal apps, I discovered that the Ads Manager app as well as the "_App - UIExplorer Browser_" component inside of Catalyst both threw the an "_Unexpected context pop_" error. I traced the root cause of this error to the fact that in the _complete_ phase we always pop context for context providers _but_ in the begin phase we don't always push. (Specially if we bailout on low priority we don't push.) This causes us to pop too many times in certain cases.

This PR corrects the behavior, making push/pop mirror each other, and adds a unit test that verifies the fix. Both Ads Manager and "_App - UIExplorer Browser_" function correctly once this fix is in place.

cc @acdlite to review since we spoke about this briefly and you have some context (heh) about the problem.
cc @gaearon as well since I think you implemented this stuff initially?