### PR TITLE
[Fiber] Make requestIdleCallback() and requestAnimationFrame() shims async

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -537,6 +537,7 @@ src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
 * findDOMNode should find dom element after expanding a fragment
 * should bubble events from the portal to the parent
 * should not onMouseLeave when staying in the portal
+* should not crash encountering low-priority tree
 
 src/renderers/dom/shared/__tests__/CSSProperty-test.js
 * should generate browser prefixes for its `isUnitlessNumber`

--- a/scripts/jest/environment.js
+++ b/scripts/jest/environment.js
@@ -1,11 +1,13 @@
 /* eslint-disable */
 global.__DEV__ = true;
 
-// For testing DOM Fiber, we synchronously invoke all the scheduling.
+// For testing DOM Fiber.
 global.requestAnimationFrame = function(callback) {
-  callback();
+  setTimeout(callback);
 };
 
 global.requestIdleCallback = function(callback) {
-  callback({ timeRemaining() { return Infinity; } });
+  setTimeout(() => {
+    callback({ timeRemaining() { return Infinity; } })
+  });
 };

--- a/scripts/jest/environment.js
+++ b/scripts/jest/environment.js
@@ -8,6 +8,6 @@ global.requestAnimationFrame = function(callback) {
 
 global.requestIdleCallback = function(callback) {
   setTimeout(() => {
-    callback({ timeRemaining() { return Infinity; } })
+    callback({ timeRemaining() { return Infinity; } });
   });
 };

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
@@ -995,7 +995,6 @@ describe('ReactDOMFiber', () => {
     });
 
     it('should not crash encountering low-priority tree', () => {
-      var container = document.createElement('div');
       ReactDOM.render(
         <div hidden={true}>
           <div />

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
@@ -993,5 +993,15 @@ describe('ReactDOMFiber', () => {
         'leave parent', // Only when we leave the portal does onMouseLeave fire.
       ]);
     });
+
+    it('should not crash encountering low-priority tree', () => {
+      var container = document.createElement('div');
+      ReactDOM.render(
+        <div hidden={true}>
+          <div />
+        </div>,
+        container
+      );
+    });
   }
 });


### PR DESCRIPTION
They no longer need to be sync in tests because we already made DOM renderer sync by default.
This fixes a crash when testing incrementalness in DOM renderer itself.