### PR TITLE
Don't warn about class components using getInitialState if state is set

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -400,6 +400,7 @@ src/isomorphic/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
 * renders using forceUpdate even when there is no state
 * will call all the normal life cycle methods
 * warns when classic properties are defined on the instance, but does not invoke them.
+* does not warn about getInitialState() on class components if state is also defined.
 * should warn when misspelling shouldComponentUpdate
 * should warn when misspelling componentWillReceiveProps
 * should throw AND warn when trying to access classic APIs
@@ -422,6 +423,7 @@ src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
 * renders using forceUpdate even when there is no state
 * will call all the normal life cycle methods
 * warns when classic properties are defined on the instance, but does not invoke them.
+* does not warn about getInitialState() on class components if state is also defined.
 * should warn when misspelling shouldComponentUpdate
 * should warn when misspelling componentWillReceiveProps
 * should throw AND warn when trying to access classic APIs
@@ -449,6 +451,7 @@ src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
 * renders using forceUpdate even when there is no state
 * will call all the normal life cycle methods
 * warns when classic properties are defined on the instance, but does not invoke them.
+* does not warn about getInitialState() on class components if state is also defined.
 * should warn when misspelling shouldComponentUpdate
 * should warn when misspelling componentWillReceiveProps
 * should throw AND warn when trying to access classic APIs

--- a/src/isomorphic/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/src/isomorphic/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -319,6 +319,25 @@ describe 'ReactCoffeeScriptClass', ->
     )
     undefined
 
+  it 'does not warn about getInitialState() on class components
+      if state is also defined.', ->
+    spyOn console, 'error'
+    class Foo extends React.Component
+      constructor: (props) ->
+        super props
+        @state = bar: @props.initialValue
+
+      getInitialState: ->
+        {}
+
+      render: ->
+        span
+          className: 'foo'
+
+    test React.createElement(Foo), 'SPAN', 'foo'
+    expect(console.error.calls.count()).toBe 0
+    undefined
+
   it 'should warn when misspelling shouldComponentUpdate', ->
     spyOn console, 'error'
     class NamedComponent extends React.Component

--- a/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
+++ b/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
@@ -354,6 +354,21 @@ describe('ReactES6Class', () => {
     );
   });
 
+  it('does not warn about getInitialState() on class components if state is also defined.', () => {
+    spyOn(console, 'error');
+    class Foo extends React.Component {
+      state = this.getInitialState();
+      getInitialState() {
+        return {};
+      }
+      render() {
+        return <span className="foo" />;
+      }
+    }
+    test(<Foo />, 'SPAN', 'foo');
+    expect(console.error.calls.count()).toBe(0);
+  });
+
   it('should warn when misspelling shouldComponentUpdate', () => {
     spyOn(console, 'error');
 

--- a/src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
+++ b/src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
@@ -454,6 +454,24 @@ describe('ReactTypeScriptClass', function() {
     );
   });
 
+  it('does not warn about getInitialState() on class components ' +
+     'if state is also defined.', () => {
+    spyOn(console, 'error');
+
+    class Example extends React.Component {
+      state = {};
+      getInitialState() {
+        return {};
+      }
+      render() {
+        return React.createElement('span', {className: 'foo'});
+      }
+    }
+
+    test(React.createElement(Example), 'SPAN', 'foo');
+    expect((<any>console.error).calls.count()).toBe(0);
+  });
+
   it('should warn when misspelling shouldComponentUpdate', function() {
     spyOn(console, 'error');
 

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -104,7 +104,8 @@ module.exports = function(
       );
       const noGetInitialStateOnES6 = (
         !instance.getInitialState ||
-        instance.getInitialState.isReactClassApproved
+        instance.getInitialState.isReactClassApproved ||
+        instance.state
       );
       warning(
         noGetInitialStateOnES6,

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -271,7 +271,8 @@ var ReactCompositeComponent = {
       // catch them here, at initialization time, instead.
       warning(
         !inst.getInitialState ||
-        inst.getInitialState.isReactClassApproved,
+        inst.getInitialState.isReactClassApproved ||
+        inst.state,
         'getInitialState was defined on %s, a plain JavaScript class. ' +
         'This is only supported for classes created using React.createClass. ' +
         'Did you mean to define a state property instead?',


### PR DESCRIPTION
We warn about `getInitialState()` usage in class components in case users accidentally used it when they should have used `.state`. If they have also specified `.state` though then it seems unnecessary to blacklist this property name.

Context: https://twitter.com/soprano/status/810003963286163456