### PR TITLE
[Fiber][Not for commit] Proof-of-concept: Promise as element type

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1247,6 +1247,10 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalUpdates-test.js
 * gives setState during reconciliation the same priority as whatever level is currently reconciling
 * enqueues setState inside an updater function as if the in-progress update is progressed (and warns)
 
+src/renderers/shared/fiber/__tests__/ReactPromiseComponent-test.js
+* supports promise as element type
+* can update a promise component with new props
+
 src/renderers/shared/fiber/__tests__/ReactTopLevelFragment-test.js
 * should render a simple fragment at the top of a component
 * should preserve state when switching from a single child

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1250,6 +1250,8 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalUpdates-test.js
 src/renderers/shared/fiber/__tests__/ReactPromiseComponent-test.js
 * supports promise as element type
 * can update a promise component with new props
+* blocks work at the same or lower priority from committing until promise resolves
+* does not block higher-priority work from committing
 
 src/renderers/shared/fiber/__tests__/ReactTopLevelFragment-test.js
 * should render a simple fragment at the top of a component

--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -187,7 +187,8 @@ var ReactElementValidator = {
     var validType =
       typeof type === 'string' ||
       typeof type === 'function' ||
-      type !== null && typeof type === 'object' && typeof type.tag === 'number';
+      type !== null && typeof type === 'object' &&
+        (typeof type.tag === 'number' || typeof type.then === 'function');
     // We warn in this case but don't throw. We expect the element creation to
     // succeed and there will likely be errors in render.
     if (!validType) {

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -128,6 +128,8 @@ export type Fiber = {
   // This will be used to quickly determine if a subtree has no pending changes.
   pendingWorkPriority: PriorityLevel,
 
+  blockedChild: ?Fiber,
+
   // This value represents the priority level that was last used to process this
   // component. This indicates whether it is better to continue from the
   // progressed work or if it is better to continue from the current state.
@@ -208,6 +210,7 @@ var createFiber = function(tag : TypeOfWork, key : null | string) : Fiber {
     firstEffect: null,
     lastEffect: null,
 
+    blockedChild: null,
     pendingWorkPriority: NoWork,
     progressedPriority: NoWork,
     progressedChild: null,
@@ -270,6 +273,7 @@ exports.cloneFiber = function(fiber : Fiber, priorityLevel : PriorityLevel) : Fi
 
   alt.stateNode = fiber.stateNode;
   alt.child = fiber.child;
+  alt.blockedChild = fiber.blockedChild;
   alt.sibling = fiber.sibling; // This should always be overridden. TODO: null
   alt.index = fiber.index; // This should always be overridden.
   alt.ref = fiber.ref;

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -128,8 +128,6 @@ export type Fiber = {
   // This will be used to quickly determine if a subtree has no pending changes.
   pendingWorkPriority: PriorityLevel,
 
-  blockedChild: ?Fiber,
-
   // This value represents the priority level that was last used to process this
   // component. This indicates whether it is better to continue from the
   // progressed work or if it is better to continue from the current state.
@@ -210,7 +208,6 @@ var createFiber = function(tag : TypeOfWork, key : null | string) : Fiber {
     firstEffect: null,
     lastEffect: null,
 
-    blockedChild: null,
     pendingWorkPriority: NoWork,
     progressedPriority: NoWork,
     progressedChild: null,
@@ -273,7 +270,6 @@ exports.cloneFiber = function(fiber : Fiber, priorityLevel : PriorityLevel) : Fi
 
   alt.stateNode = fiber.stateNode;
   alt.child = fiber.child;
-  alt.blockedChild = fiber.blockedChild;
   alt.sibling = fiber.sibling; // This should always be overridden. TODO: null
   alt.index = fiber.index; // This should always be overridden.
   alt.ref = fiber.ref;

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -33,6 +33,7 @@ var {
   CoroutineComponent,
   YieldComponent,
   Fragment,
+  PromiseComponent,
 } = ReactTypeOfWork;
 
 var {
@@ -335,13 +336,18 @@ function createFiberFromElementType(type : mixed, key : null | string) : Fiber {
     fiber = createFiber(HostComponent, key);
     fiber.type = type;
   } else if (typeof type === 'object' && type !== null) {
-    // Currently assumed to be a continuation and therefore is a fiber already.
-    // TODO: The yield system is currently broken for updates in some cases.
-    // The reified yield stores a fiber, but we don't know which fiber that is;
-    // the current or a workInProgress? When the continuation gets rendered here
-    // we don't know if we can reuse that fiber or if we need to clone it.
-    // There is probably a clever way to restructure this.
-    fiber = ((type : any) : Fiber);
+    if (typeof type.then === 'function') {
+      fiber = createFiber(PromiseComponent, key);
+      fiber.type = type;
+    } else {
+      // Currently assumed to be a continuation and therefore is a fiber already.
+      // TODO: The yield system is currently broken for updates in some cases.
+      // The reified yield stores a fiber, but we don't know which fiber that is;
+      // the current or a workInProgress? When the continuation gets rendered here
+      // we don't know if we can reuse that fiber or if we need to clone it.
+      // There is probably a clever way to restructure this.
+      fiber = ((type : any) : Fiber);
+    }
   } else {
     invariant(
       false,

--- a/src/renderers/shared/fiber/ReactFiberBlocking.js
+++ b/src/renderers/shared/fiber/ReactFiberBlocking.js
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactFiberBlocking
+ * @flow
+ */
+
+'use strict';
+
+import type { Fiber } from 'ReactFiber';
+import type { PriorityLevel } from 'ReactPriorityLevel';
+
+type Blocker = Promise<any>;
+
+export type BlockInfo = {
+  blockers: Map<Blocker, PriorityLevel> | null,
+  blockingPriority: PriorityLevel,
+  blockedChild: ?Fiber
+};
+
+const { NoWork } = require('ReactPriorityLevel');
+
+function createBlockInfo() : BlockInfo {
+  return {
+    blockers: null,
+    blockingPriority: NoWork,
+    blockedChild: null,
+  };
+}
+exports.createBlockInfo = createBlockInfo;
+
+function isBlockingBoundary(fiber : Fiber) : boolean {
+  if (fiber.stateNode && fiber.stateNode.blockInfo) {
+    return true;
+  }
+  return false;
+}
+exports.isBlockingBoundary = isBlockingBoundary;
+
+function block(fiber : Fiber, blocker : Blocker, priorityLevel : PriorityLevel) : BlockInfo | null {
+  let node = fiber;
+  let boundary;
+  while (node && !boundary) {
+    if (isBlockingBoundary(node)) {
+      boundary = node;
+    }
+    node = node.return;
+  }
+  if (!boundary) {
+    return null;
+  }
+
+  const info : BlockInfo = boundary.stateNode.blockInfo;
+  if (!info.blockers) {
+    info.blockers = new Map();
+  }
+  info.blockers.set(blocker, priorityLevel);
+  if (priorityLevel !== NoWork &&
+      (info.blockingPriority === NoWork || priorityLevel < info.blockingPriority)) {
+    info.blockingPriority = priorityLevel;
+  }
+  return info;
+}
+exports.block = block;
+
+function unblock(info : BlockInfo, blocker : Blocker) {
+  const blockers = info.blockers;
+  if (!blockers) {
+    return;
+  }
+
+  const deletedPriority = blockers.get(blocker);
+  blockers.delete(blocker);
+  if (deletedPriority === info.blockingPriority) {
+    info.blockingPriority = NoWork;
+    blockers.forEach(priorityLevel => {
+      if (priorityLevel !== NoWork &&
+          (info.blockingPriority === NoWork || priorityLevel < info.blockingPriority)) {
+        info.blockingPriority = priorityLevel;
+      }
+    });
+  }
+  if (!blockers.size) {
+    info.blockers = null;
+  }
+}
+exports.unblock = unblock;
+
+function markTreeAsBlocked(root : Fiber) {
+  let node : Fiber = root;
+  while (true) {
+    node.blockedChild = node.child;
+    if (node.alternate) {
+      node.alternate.blockedChild = node.child;
+    }
+
+    if (node.child) {
+      // TODO: Coroutines need to visit the stateNode.
+      node.child.return = node;
+      node = node.child;
+      continue;
+    }
+    if (node === root) {
+      return;
+    }
+    while (!node.sibling) {
+      if (!node.return || node.return === root) {
+        return;
+      }
+      node = node.return;
+    }
+    node.sibling.return = node.return;
+    node = node.sibling;
+  }
+}
+exports.markTreeAsBlocked = markTreeAsBlocked;
+
+function markTreeAsUnblocked(root : Fiber) {
+  let node : Fiber = root;
+  while (true) {
+    node.blockedChild = null;
+    if (node.alternate) {
+      node.alternate.blockedChild = null;
+    }
+
+    if (node.child) {
+      // TODO: Coroutines need to visit the stateNode.
+      node.child.return = node;
+      node = node.child;
+      continue;
+    }
+    if (node === root) {
+      return;
+    }
+    while (!node.sibling) {
+      if (!node.return || node.return === root) {
+        return;
+      }
+      node = node.return;
+    }
+    node.sibling.return = node.return;
+    node = node.sibling;
+  }
+}
+exports.markTreeAsUnblocked = markTreeAsUnblocked;

--- a/src/renderers/shared/fiber/ReactFiberBlocking.js
+++ b/src/renderers/shared/fiber/ReactFiberBlocking.js
@@ -20,131 +20,82 @@ type Blocker = Promise<any>;
 export type BlockInfo = {
   blockers: Map<Blocker, PriorityLevel> | null,
   blockingPriority: PriorityLevel,
-  blockedChild: ?Fiber
+  wasBlocked: boolean,
 };
 
 const { NoWork } = require('ReactPriorityLevel');
 
-function createBlockInfo() : BlockInfo {
+module.exports = function() {
+  // Blocking context. Mutated when we begin work on a tree. Children read this
+  // to determine if they should reuse the progressed work.
+  let wasBlocked = false;
+
+  function setBlockingContext(val : boolean) {
+    wasBlocked = val;
+  }
+
+  function getBlockingContext() : boolean {
+    return wasBlocked;
+  }
+
+  function isBlockingBoundary(fiber : Fiber) : boolean {
+    if (fiber.stateNode && fiber.stateNode.blockInfo) {
+      return true;
+    }
+    return false;
+  }
+
+  function block(fiber : Fiber, blocker : Blocker, priorityLevel : PriorityLevel) : BlockInfo | null {
+    let node = fiber;
+    let boundary;
+    while (node && !boundary) {
+      if (isBlockingBoundary(node)) {
+        boundary = node;
+      }
+      node = node.return;
+    }
+    if (!boundary) {
+      return null;
+    }
+
+    const info : BlockInfo = boundary.stateNode.blockInfo;
+    if (!info.blockers) {
+      info.blockers = new Map();
+    }
+    info.blockers.set(blocker, priorityLevel);
+    if (priorityLevel !== NoWork &&
+        (info.blockingPriority === NoWork || priorityLevel < info.blockingPriority)) {
+      info.blockingPriority = priorityLevel;
+    }
+    return info;
+  }
+
+  function unblock(info : BlockInfo, blocker : Blocker) {
+    const blockers = info.blockers;
+    if (!blockers) {
+      return;
+    }
+
+    const deletedPriority = blockers.get(blocker);
+    blockers.delete(blocker);
+    if (deletedPriority === info.blockingPriority) {
+      info.blockingPriority = NoWork;
+      blockers.forEach(priorityLevel => {
+        if (priorityLevel !== NoWork &&
+            (info.blockingPriority === NoWork || priorityLevel < info.blockingPriority)) {
+          info.blockingPriority = priorityLevel;
+        }
+      });
+    }
+    if (!blockers.size) {
+      info.blockers = null;
+    }
+  }
+
   return {
-    blockers: null,
-    blockingPriority: NoWork,
-    blockedChild: null,
+    setBlockingContext,
+    getBlockingContext,
+    block,
+    unblock,
   };
-}
-exports.createBlockInfo = createBlockInfo;
-
-function isBlockingBoundary(fiber : Fiber) : boolean {
-  if (fiber.stateNode && fiber.stateNode.blockInfo) {
-    return true;
-  }
-  return false;
-}
-exports.isBlockingBoundary = isBlockingBoundary;
-
-function block(fiber : Fiber, blocker : Blocker, priorityLevel : PriorityLevel) : BlockInfo | null {
-  let node = fiber;
-  let boundary;
-  while (node && !boundary) {
-    if (isBlockingBoundary(node)) {
-      boundary = node;
-    }
-    node = node.return;
-  }
-  if (!boundary) {
-    return null;
-  }
-
-  const info : BlockInfo = boundary.stateNode.blockInfo;
-  if (!info.blockers) {
-    info.blockers = new Map();
-  }
-  info.blockers.set(blocker, priorityLevel);
-  if (priorityLevel !== NoWork &&
-      (info.blockingPriority === NoWork || priorityLevel < info.blockingPriority)) {
-    info.blockingPriority = priorityLevel;
-  }
-  return info;
-}
-exports.block = block;
-
-function unblock(info : BlockInfo, blocker : Blocker) {
-  const blockers = info.blockers;
-  if (!blockers) {
-    return;
-  }
-
-  const deletedPriority = blockers.get(blocker);
-  blockers.delete(blocker);
-  if (deletedPriority === info.blockingPriority) {
-    info.blockingPriority = NoWork;
-    blockers.forEach(priorityLevel => {
-      if (priorityLevel !== NoWork &&
-          (info.blockingPriority === NoWork || priorityLevel < info.blockingPriority)) {
-        info.blockingPriority = priorityLevel;
-      }
-    });
-  }
-  if (!blockers.size) {
-    info.blockers = null;
-  }
-}
-exports.unblock = unblock;
-
-function markTreeAsBlocked(root : Fiber) {
-  let node : Fiber = root;
-  while (true) {
-    node.blockedChild = node.child;
-    if (node.alternate) {
-      node.alternate.blockedChild = node.child;
-    }
-
-    if (node.child) {
-      // TODO: Coroutines need to visit the stateNode.
-      node.child.return = node;
-      node = node.child;
-      continue;
-    }
-    if (node === root) {
-      return;
-    }
-    while (!node.sibling) {
-      if (!node.return || node.return === root) {
-        return;
-      }
-      node = node.return;
-    }
-    node.sibling.return = node.return;
-    node = node.sibling;
-  }
-}
-exports.markTreeAsBlocked = markTreeAsBlocked;
-
-function markTreeAsUnblocked(root : Fiber) {
-  let node : Fiber = root;
-  while (true) {
-    node.blockedChild = null;
-    if (node.alternate) {
-      node.alternate.blockedChild = null;
-    }
-
-    if (node.child) {
-      // TODO: Coroutines need to visit the stateNode.
-      node.child.return = node;
-      node = node.child;
-      continue;
-    }
-    if (node === root) {
-      return;
-    }
-    while (!node.sibling) {
-      if (!node.return || node.return === root) {
-        return;
-      }
-      node = node.return;
-    }
-    node.sibling.return = node.return;
-    node = node.sibling;
-  }
-}
-exports.markTreeAsUnblocked = markTreeAsUnblocked;
+};

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -38,6 +38,7 @@ var {
   CoroutineHandlerPhase,
   YieldComponent,
   Fragment,
+  PromiseComponent,
 } = ReactTypeOfWork;
 var {
   Update,
@@ -303,6 +304,8 @@ module.exports = function<T, P, I, TI, C, CX>(
         markUpdate(workInProgress);
         workInProgress.memoizedProps = workInProgress.pendingProps;
         popHostContainer();
+        return null;
+      case PromiseComponent:
         return null;
 
       // Error cases

--- a/src/renderers/shared/fiber/ReactFiberPromiseComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberPromiseComponent.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactFiberPromiseComponent
+ * @flow
+ */
+
+'use strict';
+
+export type PromiseComponentInfo = {
+  isResolved: boolean,
+  childElementType: any,
+};

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -13,8 +13,10 @@
 'use strict';
 
 import type { Fiber } from 'ReactFiber';
+import type { BlockInfo } from 'ReactFiberBlocking';
 
 const { createHostRootFiber } = require('ReactFiber');
+const { createBlockInfo } = require('ReactFiberBlocking');
 
 export type FiberRoot = {
   // Any additional information from the host associated with this root.
@@ -28,6 +30,7 @@ export type FiberRoot = {
   // Top context object, used by renderSubtreeIntoContainer
   context: Object,
   pendingContext: ?Object,
+  blockInfo: BlockInfo,
 };
 
 exports.createFiberRoot = function(containerInfo : any, context : Object) : FiberRoot {
@@ -42,6 +45,7 @@ exports.createFiberRoot = function(containerInfo : any, context : Object) : Fibe
     callbackList: null,
     context: context,
     pendingContext: null,
+    blockInfo: createBlockInfo(),
   };
   uninitializedFiber.stateNode = root;
   return root;

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -16,7 +16,7 @@ import type { Fiber } from 'ReactFiber';
 import type { BlockInfo } from 'ReactFiberBlocking';
 
 const { createHostRootFiber } = require('ReactFiber');
-const { createBlockInfo } = require('ReactFiberBlocking');
+const { NoWork } = require('ReactPriorityLevel');
 
 export type FiberRoot = {
   // Any additional information from the host associated with this root.
@@ -45,7 +45,11 @@ exports.createFiberRoot = function(containerInfo : any, context : Object) : Fibe
     callbackList: null,
     context: context,
     pendingContext: null,
-    blockInfo: createBlockInfo(),
+    blockInfo: {
+      blockers: null,
+      blockingPriority: NoWork,
+      wasBlocked: false,
+    },
   };
   uninitializedFiber.stateNode = root;
   return root;

--- a/src/renderers/shared/fiber/__tests__/ReactPromiseComponent-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactPromiseComponent-test.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var React;
+var ReactNoop;
+
+describe('ReactPromiseComponent', () => {
+  beforeEach(() => {
+    jest.resetModuleRegistry();
+    React = require('React');
+    ReactNoop = require('ReactNoop');
+  });
+
+  function div(...children) {
+    children = children.map(c => typeof c === 'string' ? { text: c } : c);
+    return { type: 'div', children, prop: undefined };
+  }
+
+  function span(prop) {
+    return { type: 'span', children: [], prop };
+  }
+
+  it('supports promise as element type', () => {
+    const PromiseForDiv = Promise.resolve('div');
+    ReactNoop.render(<PromiseForDiv><span prop="Hi" /></PromiseForDiv>);
+    ReactNoop.flush();
+    // Promise has not resolved yet
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    return PromiseForDiv.then(() => {
+      ReactNoop.flush();
+      expect(ReactNoop.getChildren()).toEqual([
+        div(span('Hi')),
+      ]);
+    });
+  });
+
+  it('can update a promise component with new props', () => {
+    function Foo(props) {
+      return <span prop={props.step} />;
+    }
+    const PromiseForFoo = Promise.resolve(Foo);
+    ReactNoop.render(<PromiseForFoo step={1} />);
+    ReactNoop.flush();
+    // Promise has not resolved yet
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    return PromiseForFoo.then(() => {
+      ReactNoop.flush();
+      expect(ReactNoop.getChildren()).toEqual([span(1)]);
+
+      ReactNoop.render(<PromiseForFoo step={2} />);
+      ReactNoop.flush();
+      // Should not have bailed out because the promise already resolved.
+      expect(ReactNoop.getChildren()).toEqual([span(2)]);
+    });
+  });
+});

--- a/src/shared/ReactTypeOfWork.js
+++ b/src/shared/ReactTypeOfWork.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-export type TypeOfWork = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
+export type TypeOfWork = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
 
 module.exports = {
   IndeterminateComponent: 0, // Before we know whether it is functional or class
@@ -26,4 +26,5 @@ module.exports = {
   CoroutineHandlerPhase: 8,
   YieldComponent: 9,
   Fragment: 10,
+  PromiseComponent: 11,
 };


### PR DESCRIPTION
For fun, here's a proof-of-concept based on an idea by @sebmarkbage.

If a promise is passed to `React.createElement`, on initial mount, React waits for the promise to resolve to a React element type. Meanwhile, it bails out and continues rendering elsewhere. Once the promise resolves, React renders using the resolved element type. Subsequent renders are not deferred and behave just like a regular element.

Such a feature could be useful alongside dynamic [`import()`](https://github.com/tc39/proposal-dynamic-import) (currently stage 3):

```js
// Stage 3 import()
const MyComponent = import('MyComponent');
// MyComponent is a promise that resolves to a normal React class/function

function ParentComponent() {
  // Use it with JSX like you normally would. It will render once the promise resolves.
  return <MyComponent prop="whatever" />;
}
```

(Again, this is just an experiment and only implemented in Fiber. It may never see public release.)