### PR TITLE
Delete fiveArgumentPooler

### DIFF
--- a/src/shared/utils/PooledClass.js
+++ b/src/shared/utils/PooledClass.js
@@ -65,17 +65,6 @@ var fourArgumentPooler = function(a1, a2, a3, a4) {
   }
 };
 
-var fiveArgumentPooler = function(a1, a2, a3, a4, a5) {
-  var Klass = this;
-  if (Klass.instancePool.length) {
-    var instance = Klass.instancePool.pop();
-    Klass.call(instance, a1, a2, a3, a4, a5);
-    return instance;
-  } else {
-    return new Klass(a1, a2, a3, a4, a5);
-  }
-};
-
 var standardReleaser = function(instance) {
   var Klass = this;
   invariant(
@@ -127,7 +116,6 @@ var PooledClass = {
   twoArgumentPooler: (twoArgumentPooler: Pooler),
   threeArgumentPooler: (threeArgumentPooler: Pooler),
   fourArgumentPooler: (fourArgumentPooler: Pooler),
-  fiveArgumentPooler: (fiveArgumentPooler: Pooler),
 };
 
 module.exports = PooledClass;


### PR DESCRIPTION
Fixes #8596 I found no referenced use of [fiveArgumentPooler](https://github.com/facebook/react/blob/32f5b034ed229d048f76ae74e18d270edc801dbf/src/shared/utils/PooledClass.js#L68). Deleted the function, and ran all tests without issue. Current search of fiveArgumentPooler [Here](https://github.com/facebook/react/search?utf8=%E2%9C%93&q=fiveArgumentPooler).

CLA signed.