### PR TITLE
Fix context handling for errors thrown in ClassComponent render

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1157,6 +1157,7 @@ src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
 * reads context when setState is below the provider
 * reads context when setState is above the provider
 * maintains the correct context index when context proviers are bailed out due to low priority
+* maintains the correct context index when unwinding due to an error ocurring during render
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
 * catches render error in a boundary during full deferred mounting

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -240,13 +240,17 @@ module.exports = function<T, P, I, TI, C, CX>(
     }
 
     // Rerender
-    const instance = workInProgress.stateNode;
-    ReactCurrentOwner.current = workInProgress;
-    const nextChildren = instance.render();
-    reconcileChildren(current, workInProgress, nextChildren);
-    // Put context on the stack because we will work on children
-    if (isContextProvider(workInProgress)) {
-      pushContextProvider(workInProgress, true);
+    try {
+      const instance = workInProgress.stateNode;
+      ReactCurrentOwner.current = workInProgress;
+      const nextChildren = instance.render();
+      reconcileChildren(current, workInProgress, nextChildren);
+    } finally {
+      // Put context on the stack because we will work on children.
+      // Push even if Error in render() because unwindContext() always pops.
+      if (isContextProvider(workInProgress)) {
+        pushContextProvider(workInProgress, true);
+      }
     }
     return workInProgress.child;
   }


### PR DESCRIPTION
Context providers are currently popped one too many times if an error is thrown by a context-provider's `render` method. In this case the begin phase is exited before context is _pushed_ but we still _pop_ it in.

This PR adds a test for this behavior (failing before) and fixes it by ensuring that we always push context before continuing (or unwinding). FWIW we plan to further clean-up and improve the handling of context-related code soon so this specific fix might be short-lived.

This PR relates to #8593.

#### Remaining work
- [ ] Replace the try/finally approach with one of the ones mentioned in [this comment](https://github.com/facebook/react/pull/8604#issuecomment-268672297).
- [ ] Verify the changes mentioned [this comment](https://github.com/facebook/react/pull/8604#issuecomment-268684971) are fixed by the final solution