### PR TITLE
[Fiber] Compute the Host Diff During Reconciliation

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -9,9 +9,6 @@ src/isomorphic/classic/__tests__/ReactContextValidator-test.js
 src/renderers/dom/__tests__/ReactDOMProduction-test.js
 * should throw with an error code in production
 
-src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
-* should not update event handlers until commit
-
 src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * should clean up input value tracking
 * should clean up input textarea tracking
@@ -39,6 +36,9 @@ src/renderers/dom/shared/__tests__/ReactRenderDocument-test.js
 * should give helpful errors on state desync
 * should throw on full document render w/ no markup
 * supports findDOMNode on full-page components
+
+src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
+* should control a value in reentrant events
 
 src/renderers/shared/__tests__/ReactPerf-test.js
 * should count no-op update as waste

--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -9,6 +9,9 @@ src/isomorphic/classic/__tests__/ReactContextValidator-test.js
 src/renderers/dom/__tests__/ReactDOMProduction-test.js
 * should throw with an error code in production
 
+src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+* should not update event handlers until commit
+
 src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * should clean up input value tracking
 * should clean up input textarea tracking

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -546,6 +546,7 @@ src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
 * findDOMNode should find dom element after expanding a fragment
 * should bubble events from the portal to the parent
 * should not onMouseLeave when staying in the portal
+* should not update event handlers until commit
 * should not crash encountering low-priority tree
 * throws if non-element passed to top-level render
 * throws if something other than false, null, or an element is returned from render
@@ -959,7 +960,6 @@ src/renderers/dom/shared/wrappers/__tests__/ReactDOMIframe-test.js
 
 src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
 * should properly control a value even if no event listener exists
-* should control a value in reentrant events
 * should control values in reentrant events with different targets
 * should display `defaultValue` of number 0
 * only assigns defaultValue if it changes

--- a/src/renderers/art/ReactARTFiber.js
+++ b/src/renderers/art/ReactARTFiber.js
@@ -42,6 +42,8 @@ const TYPES = {
   TEXT: 'Text',
 };
 
+const UPDATE_SIGNAL = {};
+
 /** Helper Methods */
 
 function addEventListeners(instance, type, listener) {
@@ -418,7 +420,7 @@ const ARTRenderer = ReactFiberReconciler({
     // Noop
   },
 
-  commitUpdate(instance, type, oldProps, newProps) {
+  commitUpdate(instance, updatePayload, type, oldProps, newProps) {
     instance._applyProps(instance, newProps, oldProps);
   },
 
@@ -482,7 +484,7 @@ const ARTRenderer = ReactFiberReconciler({
   },
 
   prepareUpdate(domElement, type, oldProps, newProps) {
-    return true;
+    return UPDATE_SIGNAL;
   },
 
   removeChild(parentInstance, child) {

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -38,7 +38,10 @@ var {
   diffProperties,
   updateProperties,
 } = ReactDOMFiberComponent;
-var { precacheFiberNode } = ReactDOMComponentTree;
+var {
+  precacheFiberNode,
+  updateFiberEventHandlers,
+} = ReactDOMComponentTree;
 
 if (__DEV__) {
   var validateDOMNesting = require('validateDOMNesting');
@@ -185,6 +188,7 @@ var DOMRenderer = ReactFiberReconciler({
     }
     const domElement : Instance = createElement(type, props, rootContainerInstance, parentNamespace);
     precacheFiberNode(internalInstanceHandle, domElement);
+    updateFiberEventHandlers(domElement, props);
     return domElement;
   },
 
@@ -240,9 +244,9 @@ var DOMRenderer = ReactFiberReconciler({
     newProps : Props,
     internalInstanceHandle : Object,
   ) : void {
-    // Update the internal instance handle so that we know which props are
-    // the current ones.
-    precacheFiberNode(internalInstanceHandle, domElement);
+    // Update the props handle so that we know which props are the ones with
+    // with current event handlers.
+    updateFiberEventHandlers(domElement, newProps);
     // Apply the diff to the DOM node.
     updateProperties(domElement, updatePayload, type, oldProps, newProps);
   },

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -206,8 +206,9 @@ var DOMRenderer = ReactFiberReconciler({
     type : string,
     oldProps : Props,
     newProps : Props,
+    rootContainerInstance : Container,
     hostContext : HostContext,
-  ) : boolean {
+  ) : null | Object {
     if (__DEV__) {
       const hostContextDev = ((hostContext : any) : HostContextDev);
       if (typeof newProps.children !== typeof oldProps.children && (
@@ -218,7 +219,7 @@ var DOMRenderer = ReactFiberReconciler({
         validateDOMNesting(null, String(newProps.children), null, ownAncestorInfo);
       }
     }
-    return true;
+    return {};
   },
 
   commitMount(
@@ -233,14 +234,16 @@ var DOMRenderer = ReactFiberReconciler({
 
   commitUpdate(
     domElement : Instance,
+    updatePayload : Object,
     type : string,
     oldProps : Props,
     newProps : Props,
-    rootContainerInstance : Container,
     internalInstanceHandle : Object,
   ) : void {
     // Update the internal instance handle so that we know which props are
     // the current ones.
+    // TODO: Fix this hack.
+    var rootContainerInstance = (domElement : any);
     precacheFiberNode(internalInstanceHandle, domElement);
     updateProperties(domElement, type, oldProps, newProps, rootContainerInstance);
   },

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -35,6 +35,7 @@ var {
   createElement,
   getChildNamespace,
   setInitialProperties,
+  diffProperties,
   updateProperties,
 } = ReactDOMFiberComponent;
 var { precacheFiberNode } = ReactDOMComponentTree;
@@ -208,7 +209,7 @@ var DOMRenderer = ReactFiberReconciler({
     newProps : Props,
     rootContainerInstance : Container,
     hostContext : HostContext,
-  ) : null | Object {
+  ) : null | Array<mixed> {
     if (__DEV__) {
       const hostContextDev = ((hostContext : any) : HostContextDev);
       if (typeof newProps.children !== typeof oldProps.children && (
@@ -219,7 +220,7 @@ var DOMRenderer = ReactFiberReconciler({
         validateDOMNesting(null, String(newProps.children), null, ownAncestorInfo);
       }
     }
-    return {};
+    return diffProperties(domElement, type, oldProps, newProps, rootContainerInstance);
   },
 
   commitMount(
@@ -234,7 +235,7 @@ var DOMRenderer = ReactFiberReconciler({
 
   commitUpdate(
     domElement : Instance,
-    updatePayload : Object,
+    updatePayload : Array<mixed>,
     type : string,
     oldProps : Props,
     newProps : Props,
@@ -242,10 +243,9 @@ var DOMRenderer = ReactFiberReconciler({
   ) : void {
     // Update the internal instance handle so that we know which props are
     // the current ones.
-    // TODO: Fix this hack.
-    var rootContainerInstance = (domElement : any);
     precacheFiberNode(internalInstanceHandle, domElement);
-    updateProperties(domElement, type, oldProps, newProps, rootContainerInstance);
+    // Apply the diff to the DOM node.
+    updateProperties(domElement, updatePayload, type, oldProps, newProps);
   },
 
   shouldSetTextContent(props : Props) : boolean {

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -227,7 +227,6 @@ var DOMRenderer = ReactFiberReconciler({
     domElement : Instance,
     type : string,
     newProps : Props,
-    rootContainerInstance : Container,
     internalInstanceHandle : Object,
   ) : void {
     ((domElement : any) : HTMLButtonElement | HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement).focus();

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -746,10 +746,14 @@ var ReactDOMFiberComponent = {
           // We eagerly listen to this even though we haven't committed yet.
           ensureListeningTo(rootContainerElement, propKey);
         }
-        if (!updatePayload && lastProp !== nextProp) {
+        if (!updatePayload /*&& lastProp !== nextProp*/) {
           // This is a special case. If any listener updates we need to ensure
           // that the "current" fiber pointer gets updated so we need a commit
           // to update this element.
+          // TODO: It turns out that we always need to update if there are
+          // listeners. In fact, even this is not enough because not updating
+          // the "current" pointer will make it so that work in progress
+          // listeners can fire before they're mounted.
           updatePayload = [];
         }
       } else {

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -658,9 +658,7 @@ var ReactDOMFiberComponent = {
         }
       } else if (propKey === DANGEROUSLY_SET_INNER_HTML ||
                  propKey === CHILDREN) {
-        // TODO: Clear innerHTML. This is currently broken in Fiber because we are
-        // too late to clear everything at this point because new children have
-        // already been inserted.
+        // Noop. This is handled by the clear text mechanism.
       } else if (propKey === SUPPRESS_CONTENT_EDITABLE_WARNING) {
         // Noop
       } else if (registrationNameModules.hasOwnProperty(propKey)) {

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -301,69 +301,15 @@ function isCustomComponent(tagName, props) {
   return tagName.indexOf('-') >= 0 || props.is != null;
 }
 
-/**
- * Reconciles the properties by detecting differences in property values and
- * updating the DOM as necessary. This function is probably the single most
- * critical path for performance optimization.
- *
- * TODO: Benchmark whether checking for changed values in memory actually
- *       improves performance (especially statically positioned elements).
- * TODO: Benchmark the effects of putting this at the top since 99% of props
- *       do not change for a given reconciliation.
- * TODO: Benchmark areas that can be improved with caching.
- */
-function updateDOMProperties(
+function setInitialDOMProperties(
   domElement : Element,
   rootContainerElement : Element,
-  lastProps : null | Object,
   nextProps : Object,
-  wasCustomComponentTag : boolean,
   isCustomComponentTag : boolean,
 ) : void {
-  var propKey;
-  var styleName;
-  var styleUpdates;
-  for (propKey in lastProps) {
-    if (nextProps.hasOwnProperty(propKey) ||
-       !lastProps.hasOwnProperty(propKey) ||
-       lastProps[propKey] == null) {
-      continue;
-    }
-    if (propKey === STYLE) {
-      var lastStyle = lastProps[propKey];
-      for (styleName in lastStyle) {
-        if (lastStyle.hasOwnProperty(styleName)) {
-          styleUpdates = styleUpdates || {};
-          styleUpdates[styleName] = '';
-        }
-      }
-    } else if (propKey === DANGEROUSLY_SET_INNER_HTML ||
-               propKey === CHILDREN) {
-      // TODO: Clear innerHTML. This is currently broken in Fiber because we are
-      // too late to clear everything at this point because new children have
-      // already been inserted.
-    } else if (propKey === SUPPRESS_CONTENT_EDITABLE_WARNING) {
-      // Noop
-    } else if (registrationNameModules.hasOwnProperty(propKey)) {
-      // Do nothing for deleted listeners.
-    } else if (wasCustomComponentTag) {
-      DOMPropertyOperations.deleteValueForAttribute(
-        domElement,
-        propKey
-      );
-    } else if (
-        DOMProperty.properties[propKey] ||
-        DOMProperty.isCustomAttribute(propKey)) {
-      DOMPropertyOperations.deleteValueForProperty(domElement, propKey);
-    }
-  }
-  for (propKey in nextProps) {
+  for (var propKey in nextProps) {
     var nextProp = nextProps[propKey];
-    var lastProp =
-      lastProps != null ? lastProps[propKey] : undefined;
-    if (!nextProps.hasOwnProperty(propKey) ||
-        nextProp === lastProp ||
-        nextProp == null && lastProp == null) {
+    if (!nextProps.hasOwnProperty(propKey)) {
       continue;
     }
     if (propKey === STYLE) {
@@ -374,38 +320,16 @@ function updateDOMProperties(
           Object.freeze(nextProp);
         }
       }
-      if (lastProp) {
-        // Unset styles on `lastProp` but not on `nextProp`.
-        for (styleName in lastProp) {
-          if (lastProp.hasOwnProperty(styleName) &&
-              (!nextProp || !nextProp.hasOwnProperty(styleName))) {
-            styleUpdates = styleUpdates || {};
-            styleUpdates[styleName] = '';
-          }
-        }
-        // Update styles that changed since `lastProp`.
-        for (styleName in nextProp) {
-          if (nextProp.hasOwnProperty(styleName) &&
-              lastProp[styleName] !== nextProp[styleName]) {
-            styleUpdates = styleUpdates || {};
-            styleUpdates[styleName] = nextProp[styleName];
-          }
-        }
-      } else {
-        // Relies on `updateStylesByID` not mutating `styleUpdates`.
-        styleUpdates = nextProp;
-      }
+      // Relies on `updateStylesByID` not mutating `styleUpdates`.
+      // TODO: call ReactInstrumentation.debugTool.onHostOperation in DEV.
+      CSSPropertyOperations.setValueForStyles(
+        domElement,
+        nextProp,
+      );
     } else if (propKey === DANGEROUSLY_SET_INNER_HTML) {
       var nextHtml = nextProp ? nextProp[HTML] : undefined;
-      var lastHtml = lastProp ? lastProp[HTML] : undefined;
-      // Intentional use of != to avoid catching zero/false.
       if (nextHtml != null) {
-        if (lastHtml !== nextHtml) {
-          setInnerHTML(domElement, '' + nextHtml);
-        }
-      } else {
-        // TODO: It might be too late to clear this if we have children
-        // inserted already.
+        setInnerHTML(domElement, nextHtml);
       }
     } else if (propKey === CHILDREN) {
       if (typeof nextProp === 'string') {
@@ -433,17 +357,55 @@ function updateDOMProperties(
       // brings us in line with the same behavior we have on initial render.
       if (nextProp != null) {
         DOMPropertyOperations.setValueForProperty(domElement, propKey, nextProp);
+      }
+    }
+  }
+}
+
+function updateDOMProperties(
+  domElement : Element,
+  updatePayload : Array<any>,
+  wasCustomComponentTag : boolean,
+  isCustomComponentTag : boolean,
+) : void {
+  for (var i = 0; i < updatePayload.length; i+=2) {
+    var propKey = updatePayload[i];
+    var propValue = updatePayload[i + 1];
+    if (propKey === STYLE) {
+      // TODO: call ReactInstrumentation.debugTool.onHostOperation in DEV.
+      CSSPropertyOperations.setValueForStyles(
+        domElement,
+        propValue,
+      );
+    } else if (propKey === DANGEROUSLY_SET_INNER_HTML) {
+      setInnerHTML(domElement, propValue);
+    } else if (propKey === CHILDREN) {
+      setTextContent(domElement, propValue);
+    } else if (isCustomComponentTag) {
+      if (propValue != null) {
+        DOMPropertyOperations.setValueForAttribute(
+          domElement,
+          propKey,
+          propValue
+        );
+      } else {
+        DOMPropertyOperations.deleteValueForAttribute(
+          domElement,
+          propKey
+        );
+      }
+    } else if (
+        DOMProperty.properties[propKey] ||
+        DOMProperty.isCustomAttribute(propKey)) {
+      // If we're updating to null or undefined, we should remove the property
+      // from the DOM node instead of inadvertently setting to a string. This
+      // brings us in line with the same behavior we have on initial render.
+      if (propValue != null) {
+        DOMPropertyOperations.setValueForProperty(domElement, propKey, propValue);
       } else {
         DOMPropertyOperations.deleteValueForProperty(domElement, propKey);
       }
     }
-  }
-  if (styleUpdates) {
-    // TODO: call ReactInstrumentation.debugTool.onHostOperation in DEV.
-    CSSPropertyOperations.setValueForStyles(
-      domElement,
-      styleUpdates,
-    );
   }
 }
 
@@ -592,12 +554,10 @@ var ReactDOMFiberComponent = {
 
     assertValidProps(tag, props);
 
-    updateDOMProperties(
+    setInitialDOMProperties(
       domElement,
       rootContainerElement,
-      null,
       props,
-      false,
       isCustomComponentTag
     );
 
@@ -626,13 +586,14 @@ var ReactDOMFiberComponent = {
     }
   },
 
-  updateProperties(
+  // Calculate the diff between the two objects.
+  diffProperties(
     domElement : Element,
     tag : string,
     lastRawProps : Object,
     nextRawProps : Object,
     rootContainerElement : Element,
-  ) : void {
+  ) : null | Array<mixed> {
     if (__DEV__) {
       validatePropertiesInDevelopment(tag, nextRawProps);
     }
@@ -668,17 +629,161 @@ var ReactDOMFiberComponent = {
     }
 
     assertValidProps(tag, nextProps);
-    var wasCustomComponentTag = isCustomComponent(tag, lastProps);
-    var isCustomComponentTag = isCustomComponent(tag, nextProps);
+
+    var propKey;
+    var styleName;
+    var styleUpdates = null;
+    var updatePayload : null | Array<any> = null;
+    for (propKey in lastProps) {
+      if (nextProps.hasOwnProperty(propKey) ||
+         !lastProps.hasOwnProperty(propKey) ||
+         lastProps[propKey] == null) {
+        continue;
+      }
+      if (propKey === STYLE) {
+        var lastStyle = lastProps[propKey];
+        for (styleName in lastStyle) {
+          if (lastStyle.hasOwnProperty(styleName)) {
+            if (!styleUpdates) {
+              styleUpdates = {};
+            }
+            styleUpdates[styleName] = '';
+          }
+        }
+      } else if (propKey === DANGEROUSLY_SET_INNER_HTML ||
+                 propKey === CHILDREN) {
+        // TODO: Clear innerHTML. This is currently broken in Fiber because we are
+        // too late to clear everything at this point because new children have
+        // already been inserted.
+      } else if (propKey === SUPPRESS_CONTENT_EDITABLE_WARNING) {
+        // Noop
+      } else if (registrationNameModules.hasOwnProperty(propKey)) {
+        // This is a special case. If any listener updates we need to ensure
+        // that the "current" fiber pointer gets updated so we need a commit
+        // to update this element.
+        if (!updatePayload) {
+          updatePayload = [];
+        }
+      } else {
+        // For all other deleted properties we add it to the queue. We use
+        // the whitelist in the commit phase instead.
+        (updatePayload = updatePayload || []).push(propKey, null);
+      }
+    }
+    for (propKey in nextProps) {
+      var nextProp = nextProps[propKey];
+      var lastProp =
+        lastProps != null ? lastProps[propKey] : undefined;
+      if (!nextProps.hasOwnProperty(propKey) ||
+          nextProp === lastProp ||
+          nextProp == null && lastProp == null) {
+        continue;
+      }
+      if (propKey === STYLE) {
+        if (__DEV__) {
+          if (nextProp) {
+            // Freeze the next style object so that we can assume it won't be
+            // mutated. We have already warned for this in the past.
+            Object.freeze(nextProp);
+          }
+        }
+        if (lastProp) {
+          // Unset styles on `lastProp` but not on `nextProp`.
+          for (styleName in lastProp) {
+            if (lastProp.hasOwnProperty(styleName) &&
+                (!nextProp || !nextProp.hasOwnProperty(styleName))) {
+              if (!styleUpdates) {
+                styleUpdates = {};
+              }
+              styleUpdates[styleName] = '';
+            }
+          }
+          // Update styles that changed since `lastProp`.
+          for (styleName in nextProp) {
+            if (nextProp.hasOwnProperty(styleName) &&
+                lastProp[styleName] !== nextProp[styleName]) {
+              if (!styleUpdates) {
+                styleUpdates = {};
+              }
+              styleUpdates[styleName] = nextProp[styleName];
+            }
+          }
+        } else {
+          // Relies on `updateStylesByID` not mutating `styleUpdates`.
+          if (!styleUpdates) {
+            if (!updatePayload) {
+              updatePayload = [];
+            }
+            updatePayload.push(propKey, styleUpdates);
+          }
+          styleUpdates = nextProp;
+        }
+      } else if (propKey === DANGEROUSLY_SET_INNER_HTML) {
+        var nextHtml = nextProp ? nextProp[HTML] : undefined;
+        var lastHtml = lastProp ? lastProp[HTML] : undefined;
+        if (nextHtml) {
+          if (lastHtml) {
+            if (lastHtml !== nextHtml) {
+              (updatePayload = updatePayload || []).push(propKey, '' + nextHtml);
+            }
+          } else {
+            (updatePayload = updatePayload || []).push(propKey, '' + nextHtml);
+          }
+        } else {
+          // TODO: It might be too late to clear this if we have children
+          // inserted already.
+        }
+      } else if (propKey === CHILDREN) {
+        if (lastProp !== nextProp && (
+            typeof nextProp === 'string' || typeof nextProp === 'number'
+            )) {
+          (updatePayload = updatePayload || []).push(propKey, '' + nextProp);
+        }
+      } else if (propKey === SUPPRESS_CONTENT_EDITABLE_WARNING) {
+        // Noop
+      } else if (registrationNameModules.hasOwnProperty(propKey)) {
+        if (nextProp) {
+          // We eagerly listen to this even though we haven't committed yet.
+          ensureListeningTo(rootContainerElement, propKey);
+        }
+        if (!updatePayload && lastProp !== nextProp) {
+          // This is a special case. If any listener updates we need to ensure
+          // that the "current" fiber pointer gets updated so we need a commit
+          // to update this element.
+          updatePayload = [];
+        }
+      } else {
+        // For any other property we always add it to the queue and then we
+        // filter it out using the whitelist during the commit.
+        (updatePayload = updatePayload || []).push(propKey, nextProp);
+      }
+    }
+    if (styleUpdates) {
+      (updatePayload = updatePayload || []).push(STYLE, styleUpdates);
+    }
+    return updatePayload;
+  },
+
+  // Apply the diff.
+  updateProperties(
+    domElement : Element,
+    updatePayload : Array<any>,
+    tag : string,
+    lastRawProps : Object,
+    nextRawProps : Object
+  ) : void {
+    var wasCustomComponentTag = isCustomComponent(tag, lastRawProps);
+    var isCustomComponentTag = isCustomComponent(tag, nextRawProps);
+    // Apply the diff.
     updateDOMProperties(
       domElement,
-      rootContainerElement,
-      lastProps,
-      nextProps,
+      updatePayload,
       wasCustomComponentTag,
       isCustomComponentTag
     );
 
+    // TODO: Ensure that an update gets scheduled if any of the special props
+    // changed.
     switch (tag) {
       case 'input':
         // Update the wrapper around inputs *after* updating props. This has to

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -368,6 +368,7 @@ function updateDOMProperties(
   wasCustomComponentTag : boolean,
   isCustomComponentTag : boolean,
 ) : void {
+  // TODO: Handle wasCustomComponentTag
   for (var i = 0; i < updatePayload.length; i+=2) {
     var propKey = updatePayload[i];
     var propValue = updatePayload[i + 1];

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -746,14 +746,10 @@ var ReactDOMFiberComponent = {
           // We eagerly listen to this even though we haven't committed yet.
           ensureListeningTo(rootContainerElement, propKey);
         }
-        if (!updatePayload /*&& lastProp !== nextProp*/) {
+        if (!updatePayload && lastProp !== nextProp) {
           // This is a special case. If any listener updates we need to ensure
-          // that the "current" fiber pointer gets updated so we need a commit
+          // that the "current" props pointer gets updated so we need a commit
           // to update this element.
-          // TODO: It turns out that we always need to update if there are
-          // listeners. In fact, even this is not enough because not updating
-          // the "current" pointer will make it so that work in progress
-          // listeners can fire before they're mounted.
           updatePayload = [];
         }
       } else {

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -599,24 +599,30 @@ var ReactDOMFiberComponent = {
       validatePropertiesInDevelopment(tag, nextRawProps);
     }
 
+    var updatePayload : null | Array<any> = null;
+
     var lastProps : Object;
     var nextProps : Object;
     switch (tag) {
       case 'input':
         lastProps = ReactDOMFiberInput.getHostProps(domElement, lastRawProps);
         nextProps = ReactDOMFiberInput.getHostProps(domElement, nextRawProps);
+        updatePayload = [];
         break;
       case 'option':
         lastProps = ReactDOMFiberOption.getHostProps(domElement, lastRawProps);
         nextProps = ReactDOMFiberOption.getHostProps(domElement, nextRawProps);
+        updatePayload = [];
         break;
       case 'select':
         lastProps = ReactDOMFiberSelect.getHostProps(domElement, lastRawProps);
         nextProps = ReactDOMFiberSelect.getHostProps(domElement, nextRawProps);
+        updatePayload = [];
         break;
       case 'textarea':
         lastProps = ReactDOMFiberTextarea.getHostProps(domElement, lastRawProps);
         nextProps = ReactDOMFiberTextarea.getHostProps(domElement, nextRawProps);
+        updatePayload = [];
         break;
       default:
         lastProps = lastRawProps;
@@ -634,7 +640,6 @@ var ReactDOMFiberComponent = {
     var propKey;
     var styleName;
     var styleUpdates = null;
-    var updatePayload : null | Array<any> = null;
     for (propKey in lastProps) {
       if (nextProps.hasOwnProperty(propKey) ||
          !lastProps.hasOwnProperty(propKey) ||

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -727,12 +727,8 @@ var ReactDOMFiberComponent = {
       } else if (propKey === DANGEROUSLY_SET_INNER_HTML) {
         var nextHtml = nextProp ? nextProp[HTML] : undefined;
         var lastHtml = lastProp ? lastProp[HTML] : undefined;
-        if (nextHtml) {
-          if (lastHtml) {
-            if (lastHtml !== nextHtml) {
-              (updatePayload = updatePayload || []).push(propKey, '' + nextHtml);
-            }
-          } else {
+        if (nextHtml != null) {
+          if (lastHtml !== nextHtml) {
             (updatePayload = updatePayload || []).push(propKey, '' + nextHtml);
           }
         } else {

--- a/src/renderers/dom/shared/ReactDOMComponentTree.js
+++ b/src/renderers/dom/shared/ReactDOMComponentTree.js
@@ -20,8 +20,11 @@ var invariant = require('invariant');
 var ATTR_NAME = DOMProperty.ID_ATTRIBUTE_NAME;
 var Flags = ReactDOMComponentFlags;
 
-var internalInstanceKey =
-  '__reactInternalInstance$' + Math.random().toString(36).slice(2);
+var randomKey = Math.random().toString(36).slice(2);
+
+var internalInstanceKey = '__reactInternalInstance$' + randomKey;
+
+var internalEventHandlersKey = '__reactEventHandlers$' + randomKey;
 
 /**
  * Check if a given node should be cached.
@@ -218,6 +221,14 @@ function getNodeFromInstance(inst) {
   return inst._hostNode;
 }
 
+function getFiberEventHandlersFromNode(node) {
+  return node[internalEventHandlersKey] || null;
+}
+
+function updateFiberEventHandlers(node, props) {
+  node[internalEventHandlersKey] = props;
+}
+
 var ReactDOMComponentTree = {
   getClosestInstanceFromNode: getClosestInstanceFromNode,
   getInstanceFromNode: getInstanceFromNode,
@@ -226,6 +237,8 @@ var ReactDOMComponentTree = {
   precacheNode: precacheNode,
   uncacheNode: uncacheNode,
   precacheFiberNode: precacheFiberNode,
+  getFiberEventHandlersFromNode,
+  updateFiberEventHandlers,
 };
 
 module.exports = ReactDOMComponentTree;

--- a/src/renderers/native/ReactNativeComponentTree.js
+++ b/src/renderers/native/ReactNativeComponentTree.js
@@ -14,6 +14,7 @@
 var invariant = require('invariant');
 
 var instanceCache = {};
+var instanceProps = {};
 
 /**
  * Drill down (through composites and empty components) until we get a host or
@@ -65,6 +66,14 @@ function getTagFromInstance(inst) {
   return tag;
 }
 
+function getFiberEventHandlersFromTag(tag) {
+  return instanceProps[tag] || null;
+}
+
+function updateFiberEventHandlers(tag, props) {
+  instanceProps[tag] = props;
+}
+
 var ReactNativeComponentTree = {
   getClosestInstanceFromNode: getInstanceFromTag,
   getInstanceFromNode: getInstanceFromTag,
@@ -73,6 +82,8 @@ var ReactNativeComponentTree = {
   precacheNode,
   uncacheFiberNode,
   uncacheNode,
+  getFiberEventHandlersFromNode: getFiberEventHandlersFromTag,
+  updateFiberEventHandlers,
 };
 
 module.exports = ReactNativeComponentTree;

--- a/src/renderers/native/ReactNativeFiber.js
+++ b/src/renderers/native/ReactNativeFiber.js
@@ -114,7 +114,6 @@ const NativeRenderer = ReactFiberReconciler({
     instance : Instance,
     type : string,
     newProps : Props,
-    rootContainerInstance : Object,
     internalInstanceHandle : Object
   ) : void {
     // Noop

--- a/src/renderers/native/ReactNativeFiber.js
+++ b/src/renderers/native/ReactNativeFiber.js
@@ -33,7 +33,11 @@ const emptyObject = require('emptyObject');
 const findNodeHandle = require('findNodeHandle');
 const invariant = require('invariant');
 
-const { precacheFiberNode, uncacheFiberNode } = ReactNativeComponentTree;
+const {
+  precacheFiberNode,
+  uncacheFiberNode,
+  updateFiberEventHandlers,
+} = ReactNativeComponentTree;
 
 ReactNativeInjection.inject();
 
@@ -129,7 +133,7 @@ const NativeRenderer = ReactFiberReconciler({
   ) : void {
     const viewConfig = instance.viewConfig;
 
-    precacheFiberNode(internalInstanceHandle, instance._nativeTag);
+    updateFiberEventHandlers(instance._nativeTag, newProps);
 
     const updatePayload = ReactNativeAttributePayload.diff(
       oldProps,
@@ -177,6 +181,7 @@ const NativeRenderer = ReactFiberReconciler({
     const component = new NativeHostComponent(tag, viewConfig);
 
     precacheFiberNode(internalInstanceHandle, tag);
+    updateFiberEventHandlers(tag, props);
 
     return component;
   },

--- a/src/renderers/native/ReactNativeFiber.js
+++ b/src/renderers/native/ReactNativeFiber.js
@@ -122,10 +122,10 @@ const NativeRenderer = ReactFiberReconciler({
 
   commitUpdate(
     instance : Instance,
+    updatePayloadTODO : Object,
     type : string,
     oldProps : Props,
     newProps : Props,
-    rootContainerInstance : Object,
     internalInstanceHandle : Object
   ) : void {
     const viewConfig = instance.viewConfig;
@@ -149,7 +149,7 @@ const NativeRenderer = ReactFiberReconciler({
     type : string,
     props : Props,
     rootContainerInstance : Container,
-    hostContext : Object,
+    hostContext : {||},
     internalInstanceHandle : Object
   ) : Instance {
     const tag = ReactNativeTagHandles.allocateTag();
@@ -185,7 +185,7 @@ const NativeRenderer = ReactFiberReconciler({
   createTextInstance(
     text : string,
     rootContainerInstance : Container,
-    hostContext : Object,
+    hostContext : {||},
     internalInstanceHandle : Object,
   ) : TextInstance {
     const tag = ReactNativeTagHandles.allocateTag();
@@ -224,11 +224,11 @@ const NativeRenderer = ReactFiberReconciler({
     return false;
   },
 
-  getRootHostContext() {
+  getRootHostContext() : {||} {
     return emptyObject;
   },
 
-  getChildHostContext() {
+  getChildHostContext() : {||} {
     return emptyObject;
   },
 
@@ -290,9 +290,11 @@ const NativeRenderer = ReactFiberReconciler({
     instance : Instance,
     type : string,
     oldProps : Props,
-    newProps : Props
-  ) : boolean {
-    return true;
+    newProps : Props,
+    rootContainerInstance : Container,
+    hostContext : {||}
+  ) : null | Object {
+    return emptyObject;
   },
 
   removeChild(

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -29,6 +29,8 @@ var {
 } = require('ReactPriorityLevel');
 var emptyObject = require('emptyObject');
 
+const UPDATE_SIGNAL = {};
+
 var scheduledAnimationCallback = null;
 var scheduledDeferredCallback = null;
 
@@ -78,15 +80,15 @@ var NoopRenderer = ReactFiberReconciler({
     return false;
   },
 
-  prepareUpdate(instance : Instance, type : string, oldProps : Props, newProps : Props) : boolean {
-    return true;
+  prepareUpdate(instance : Instance, type : string, oldProps : Props, newProps : Props) : null | {} {
+    return UPDATE_SIGNAL;
   },
 
   commitMount(instance : Instance, type : string, newProps : Props) : void {
     // Noop
   },
 
-  commitUpdate(instance : Instance, type : string, oldProps : Props, newProps : Props) : void {
+  commitUpdate(instance : Instance, updatePayload : Object, type : string, oldProps : Props, newProps : Props) : void {
     instance.prop = newProps.prop;
   },
 

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -70,8 +70,8 @@ if (__DEV__) {
   var warnedAboutStatelessRefs = {};
 }
 
-module.exports = function<T, P, I, TI, PI, C, CX>(
-  config : HostConfig<T, P, I, TI, PI, C, CX>,
+module.exports = function<T, P, I, TI, PI, C, CX, PL>(
+  config : HostConfig<T, P, I, TI, PI, C, CX, PL>,
   hostContext : HostContext<C, CX>,
   scheduleUpdate : (fiber : Fiber, priorityLevel : PriorityLevel) => void,
   getPriorityContext : () => PriorityLevel,

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -13,7 +13,6 @@
 'use strict';
 
 import type { Fiber } from 'ReactFiber';
-import type { HostContext } from 'ReactFiberHostContext';
 import type { HostConfig } from 'ReactFiberReconciler';
 
 var ReactTypeOfWork = require('ReactTypeOfWork');
@@ -34,8 +33,8 @@ var {
   ContentReset,
 } = require('ReactTypeOfSideEffect');
 
-module.exports = function<T, P, I, TI, PI, C, CX>(
-  config : HostConfig<T, P, I, TI, PI, C, CX>,
+module.exports = function<T, P, I, TI, PI, C, CX, PL>(
+  config : HostConfig<T, P, I, TI, PI, C, CX, PL>,
   hostContext : HostContext<C, CX>,
   captureError : (failedFiber : Fiber, error: Error) => ?Fiber
 ) {
@@ -50,10 +49,6 @@ module.exports = function<T, P, I, TI, PI, C, CX>(
     removeChild,
     getPublicInstance,
   } = config;
-
-  const {
-    getRootHostContainer,
-  } = hostContext;
 
   // Capture errors so they don't interrupt unmounting.
   function safelyCallComponentWillUnmount(current, instance) {
@@ -367,9 +362,13 @@ module.exports = function<T, P, I, TI, PI, C, CX>(
           // Commit the work prepared earlier.
           const newProps = finishedWork.memoizedProps;
           const oldProps = current.memoizedProps;
-          const rootContainerInstance = getRootHostContainer();
           const type = finishedWork.type;
-          commitUpdate(instance, type, oldProps, newProps, rootContainerInstance, finishedWork);
+          // TODO: Type the updateQueue to be specific to host components.
+          const updatePayload : null | PL = (finishedWork.updateQueue : any);
+          finishedWork.updateQueue = null;
+          if (updatePayload) {
+            commitUpdate(instance, updatePayload, type, oldProps, newProps, finishedWork);
+          }
         }
         detachRefIfNeeded(current, finishedWork);
         return;

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -35,7 +35,6 @@ var {
 
 module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   config : HostConfig<T, P, I, TI, PI, C, CX, PL>,
-  hostContext : HostContext<C, CX>,
   captureError : (failedFiber : Fiber, error: Error) => ?Fiber
 ) {
 
@@ -437,8 +436,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         ) {
           const type = finishedWork.type;
           const props = finishedWork.memoizedProps;
-          const rootContainerInstance = getRootHostContainer();
-          commitMount(instance, type, props, rootContainerInstance, finishedWork);
+          commitMount(instance, type, props, finishedWork);
         }
 
         return;

--- a/src/renderers/shared/fiber/ReactFiberHostContext.js
+++ b/src/renderers/shared/fiber/ReactFiberHostContext.js
@@ -34,8 +34,8 @@ export type HostContext<C, CX> = {
   resetHostContainer() : void,
 };
 
-module.exports = function<T, P, I, TI, PI, C, CX>(
-  config : HostConfig<T, P, I, TI, PI, C, CX>
+module.exports = function<T, P, I, TI, PI, C, CX, PL>(
+  config : HostConfig<T, P, I, TI, PI, C, CX, PL>
 ) : HostContext<C, CX> {
   const {
     getChildHostContext,

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -43,7 +43,7 @@ export type Deadline = {
 
 type OpaqueNode = Fiber;
 
-export type HostConfig<T, P, I, TI, PI, C, CX> = {
+export type HostConfig<T, P, I, TI, PI, C, CX, PL> = {
 
   getRootHostContext(rootContainerInstance : C) : CX,
   getChildHostContext(parentHostContext : CX, type : T) : CX,
@@ -53,8 +53,8 @@ export type HostConfig<T, P, I, TI, PI, C, CX> = {
   appendInitialChild(parentInstance : I, child : I | TI) : void,
   finalizeInitialChildren(parentInstance : I, type : T, props : P, rootContainerInstance : C) : boolean,
 
-  prepareUpdate(instance : I, type : T, oldProps : P, newProps : P, hostContext : CX) : boolean,
-  commitUpdate(instance : I, type : T, oldProps : P, newProps : P, rootContainerInstance : C, internalInstanceHandle : OpaqueNode) : void,
+  prepareUpdate(instance : I, type : T, oldProps : P, newProps : P, rootContainerInstance : C, hostContext : CX) : null | PL,
+  commitUpdate(instance : I, updatePayload : PL, type : T, oldProps : P, newProps : P, internalInstanceHandle : OpaqueNode) : void,
   commitMount(instance : I, type : T, newProps : P, rootContainerInstance : C, internalInstanceHandle : OpaqueNode) : void,
 
   shouldSetTextContent(props : P) : boolean,
@@ -102,7 +102,7 @@ getContextForSubtree._injectFiber(function(fiber : Fiber) {
     parentContext;
 });
 
-module.exports = function<T, P, I, TI, PI, C, CX>(config : HostConfig<T, P, I, TI, PI, C, CX>) : Reconciler<C, I, TI> {
+module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, I, TI, PI, C, CX, PL>) : Reconciler<C, I, TI> {
 
   var {
     scheduleUpdate,

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -55,7 +55,7 @@ export type HostConfig<T, P, I, TI, PI, C, CX, PL> = {
 
   prepareUpdate(instance : I, type : T, oldProps : P, newProps : P, rootContainerInstance : C, hostContext : CX) : null | PL,
   commitUpdate(instance : I, updatePayload : PL, type : T, oldProps : P, newProps : P, internalInstanceHandle : OpaqueNode) : void,
-  commitMount(instance : I, type : T, newProps : P, rootContainerInstance : C, internalInstanceHandle : OpaqueNode) : void,
+  commitMount(instance : I, type : T, newProps : P, internalInstanceHandle : OpaqueNode) : void,
 
   shouldSetTextContent(props : P) : boolean,
   resetTextContent(instance : I) : void,

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -88,7 +88,7 @@ if (__DEV__) {
 
 var timeHeuristicForUnitOfWork = 1;
 
-module.exports = function<T, P, I, TI, PI, C, CX>(config : HostConfig<T, P, I, TI, PI, C, CX>) {
+module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, I, TI, PI, C, CX, PL>) {
   const hostContext = ReactFiberHostContext(config);
   const { popHostContainer, popHostContext, resetHostContainer } = hostContext;
   const { beginWork, beginFailedWork } = ReactFiberBeginWork(
@@ -104,7 +104,7 @@ module.exports = function<T, P, I, TI, PI, C, CX>(config : HostConfig<T, P, I, T
     commitWork,
     commitLifeCycles,
     commitRef,
-  } = ReactFiberCommitWork(config, hostContext, captureError);
+  } = ReactFiberCommitWork(config, captureError);
   const {
     scheduleAnimationCallback: hostScheduleAnimationCallback,
     scheduleDeferredCallback: hostScheduleDeferredCallback,

--- a/src/renderers/shared/shared/ReactTreeTraversal.js
+++ b/src/renderers/shared/shared/ReactTreeTraversal.js
@@ -12,7 +12,6 @@
 'use strict';
 
 var { HostComponent } = require('ReactTypeOfWork');
-var { getNodeFromInstance, getInstanceFromNode } = require('EventPluginUtils');
 
 function getParent(inst) {
   if (inst._hostParent !== undefined) {
@@ -27,13 +26,8 @@ function getParent(inst) {
       // host node but that wouldn't work for React Native and doesn't let us
       // do the portal feature.
     } while (inst && inst.tag !== HostComponent);
-    // Going through the Host Node will guarantee that we get the "current"
-    // Fiber, instead of the alternate because that pointer is updated when
-    // props update.
-    // TODO: This is a bit hacky and possibly slow. We should ideally have
-    // something in the reconciler that allow us to do this safely.
     if (inst) {
-      return getInstanceFromNode(getNodeFromInstance(inst));
+      return inst;
     }
   }
   return null;

--- a/src/renderers/shared/shared/event/EventPluginHub.js
+++ b/src/renderers/shared/shared/event/EventPluginHub.js
@@ -127,6 +127,10 @@ var EventPluginHub = {
     // live here; needs to be moved to a better place soon
     if (typeof inst.tag === 'number') {
       const props = inst.memoizedProps;
+      if (!props) {
+        // Work in progress.
+        return null;
+      }
       listener = props[registrationName];
       if (shouldPreventMouseEvent(registrationName, inst.type, props)) {
         return null;

--- a/src/renderers/shared/shared/event/EventPluginHub.js
+++ b/src/renderers/shared/shared/event/EventPluginHub.js
@@ -126,7 +126,9 @@ var EventPluginHub = {
     // TODO: shouldPreventMouseEvent is DOM-specific and definitely should not
     // live here; needs to be moved to a better place soon
     if (typeof inst.tag === 'number') {
-      const props = inst.memoizedProps;
+      const props = EventPluginUtils.getFiberEventHandlersFromNode(
+        inst.stateNode
+      );
       if (!props) {
         // Work in progress.
         return null;

--- a/src/renderers/shared/shared/event/EventPluginUtils.js
+++ b/src/renderers/shared/shared/event/EventPluginUtils.js
@@ -219,6 +219,9 @@ var EventPluginUtils = {
   executeDispatchesInOrderStopAtTrue: executeDispatchesInOrderStopAtTrue,
   hasDispatches: hasDispatches,
 
+  getFiberEventHandlersFromNode: function(node) {
+    return ComponentTree.getFiberEventHandlersFromNode(node);
+  },
   getInstanceFromNode: function(node) {
     return ComponentTree.getInstanceFromNode(node);
   },

--- a/src/renderers/testing/ReactTestRendererFiber.js
+++ b/src/renderers/testing/ReactTestRendererFiber.js
@@ -47,6 +47,8 @@ type TextInstance = {|
   tag : 'TEXT',
 |};
 
+const UPDATE_SIGNAL = {};
+
 var TestRenderer = ReactFiberReconciler({
   getRootHostContext() {
     return emptyObject;
@@ -102,17 +104,18 @@ var TestRenderer = ReactFiberReconciler({
     type : string,
     oldProps : Props,
     newProps : Props,
+    rootContainerInstance : Container,
     hostContext : Object,
-  ) : boolean {
-    return true;
+  ) : null | {} {
+    return UPDATE_SIGNAL;
   },
 
   commitUpdate(
     instance : Instance,
+    updatePayload : {},
     type : string,
     oldProps : Props,
     newProps : Props,
-    rootContainerInstance : Container,
     internalInstanceHandle : Object,
   ) : void {
     instance.type = type;
@@ -123,7 +126,6 @@ var TestRenderer = ReactFiberReconciler({
     instance : Instance,
     type : string,
     newProps : Props,
-    rootContainerInstance : Object,
     internalInstanceHandle : Object
   ) : void {
     // noop


### PR DESCRIPTION
This uses prepareUpdate to compute the diff to apply. If there is no work to do, we don't schedule any updates at all for the commit phase.

Unfortunately wrapper components have custom logic that gets applied in the commit phase so for now we need to always schedule an update for those.

The payload has an array of only the prop key and values that need to update.

This makes the commit phase in the Sierpinski Triangle demo go from 2.5-3ms to <1.5ms. The overall time probably increases but at least now we won't risk dropping frames as we're updating low-pri content.

A neat side-effect of this is that we no longer depend on any "contextual information" like host context or root instance in the commit phase.

TODO 1: ~~This doesn't correctly apply the diff when the `is` property switches from custom component mode to built-in component mode. I'll just need to deal with that when deleting values.~~ Errr... This is not true. We can't switch between modes. I just added some unused code at some point because I thought we could.

~~TODO 2: A more fundamental problem is that we always need to update the pointer to the "current" fiber atm because of how the lazy event listener thing works. I could probably change it to store the props object instead of going through the fiber.~~

~~TODO 3: Flow infinite loops. (Updating to 0.37.1 doesn't help. https://github.com/facebook/react/pull/8608)~~ Fixed using workaround.