### PR TITLE
NOT FOR MERGE: ./scripts/fiber/find-errors to make future Umbrella task easier

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "jest-config": "^17.0.2",
     "jest-jasmine2": "^17.0.2",
     "jest-runtime": "^17.0.2",
+    "jscodeshift": "^0.3.30",
     "loose-envify": "^1.1.0",
     "merge-stream": "^1.0.0",
     "object-assign": "^4.1.0",

--- a/scripts/fiber/find-errors
+++ b/scripts/fiber/find-errors
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const jscodeshift = require('jscodeshift');
+const Runner = require('jscodeshift/dist/Runner');
+const path = require('path');
+
+const options = {
+  path: [path.join(process.cwd(), 'src')],
+  dry: true,
+  cpus: 1,
+  transform: path.join(__dirname, 'jscodeshift-find-error.js'),
+};
+
+process.env.JSCODESHIFT_PRINT_LEVEL = (
+  process.argv.some(arg => /quiet/.test(arg)) ? 'quiet' :
+  process.argv.some(arg => /files-only/.test(arg)) ? 'files' :
+  ''
+);
+console.log('Detecting Errors to convert to invariant calls.');
+Runner.run(
+  options.transform,
+  options.path,
+  options
+).then((results) => {
+  console.log(
+    '%s throw statements to to convert to `invariant`',
+    results.stats.error
+  );
+});

--- a/scripts/fiber/jscodeshift-find-error.js
+++ b/scripts/fiber/jscodeshift-find-error.js
@@ -1,0 +1,39 @@
+'use strict';
+const printLevel = process.env.JSCODESHIFT_PRINT_LEVEL;
+
+module.exports = (fileInfo, api) => {
+  const jscodeshift = api.jscodeshift;
+  if (
+    /__tests__|vendor/.test(fileInfo.path)
+  ) {
+    return;
+  }
+  // slice off process.cwd() and leading /
+  const normalizedPath = fileInfo.path.replace(process.cwd(), '').slice(1);
+  let detected = 0;
+
+  jscodeshift(fileInfo.source)
+    .find(jscodeshift.ThrowStatement)
+    .forEach(path => {
+      api.stats('error');
+      detected++;
+      if (printLevel !== 'files') {
+        console.log(
+          '%s#%s:',
+          normalizedPath,
+          path.value.loc.start.line
+        );
+        if (printLevel !== 'quiet') {
+          console.log(
+            jscodeshift(path).toSource().split('\n').map(line => '  ' + line).join('\n')
+          );
+          console.log();
+        }
+      }
+    });
+
+  if (printLevel === 'files' && detected) {
+    console.log('%s has %s statement(s)', normalizedPath, detected);
+  }
+};
+


### PR DESCRIPTION
In #7925 there is a task to:

> Ensure we replace errors with invariant calls and they have sensible
> messages

While it is likely a bit premature to begin that work, this script will
make it easier to find and replace the exact call sites to manage.

At the time of writing there are 42 `ThrowStatement`s. It looks like there are a few outliers in `src/test`, but most of those are from `src/renderers/shared/fiber/*.js`

Usage:
``` sh
$ ./scripts/fiber/find-errors

...lots of output...

src/renderers/shared/fiber/ReactFiberScheduler.js#921:
  throw new Error('No error for given unit of work.');

src/renderers/shared/fiber/ReactFiberScheduler.js#940:
  throw new Error('Invalid type of work.');

src/renderers/shared/utils/ReactErrorUtils.js#55:
  throw error;

All done.
Results:
6 errors
0 unmodified
380 skipped
0 ok
Stats:
error: 42
Time elapsed: 4.031seconds
42 throw statements to to convert to `invariant`

```

``` sh
$ ./scripts/fiber/find-errors --quiet

...lots of output...

src/renderers/shared/fiber/ReactFiberScheduler.js#780:
src/renderers/shared/fiber/ReactFiberScheduler.js#785:
src/renderers/shared/fiber/ReactFiberScheduler.js#921:
src/renderers/shared/fiber/ReactFiberScheduler.js#940:
src/renderers/shared/utils/ReactErrorUtils.js#55:
All done.
Results:
6 errors
0 unmodified
380 skipped
0 ok
Stats:
error: 42
Time elapsed: 3.728seconds
42 throw statements to to convert to `invariant`
```