### PR TITLE
[Fiber] Add DEV-only internal API for reporting unhandled errors

### DIFF
--- a/examples/fiber/debugger/src/App.js
+++ b/examples/fiber/debugger/src/App.js
@@ -110,6 +110,7 @@ class App extends Component {
           ]
         }));
       },
+      onUncaughtError() {},
     };
     window.React = React;
     window.ReactNoop = ReactNoop;

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -65,6 +65,7 @@ var {
 if (__DEV__) {
   var ReactFiberInstrumentation = require('ReactFiberInstrumentation');
   var ReactDebugCurrentFiber = require('ReactDebugCurrentFiber');
+  var ReactComponentTreeHook = require('ReactComponentTreeHook');
 }
 
 var timeHeuristicForUnitOfWork = 1;
@@ -137,6 +138,10 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
   let firstUncaughtError : Error | null = null;
   let fatalError : Error | null = null;
 
+  if (__DEV__) {
+    var errorStacks : Map<Error, string> = new Map();
+  }
+
   let isCommitting : boolean = false;
   let isUnmounting : boolean = false;
 
@@ -206,6 +211,10 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
       // a single point which happens right before any new work and
       // unfortunately this is it.
       resetContextStack();
+
+      if (__DEV__) {
+        errorStacks.clear();
+      }
 
       return cloneFiber(
         highestPriorityRoot.current,
@@ -781,11 +790,23 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
       let e = fatalError;
       fatalError = null;
       firstUncaughtError = null;
+      if (__DEV__) {
+        if (ReactFiberInstrumentation.debugTool) {
+          const stackInfo = errorStacks.get(e);
+          ReactFiberInstrumentation.debugTool.onUncaughtError(e, stackInfo);
+        }
+      }
       throw e;
     }
     if (firstUncaughtError) {
       let e = firstUncaughtError;
       firstUncaughtError = null;
+      if (__DEV__) {
+        if (ReactFiberInstrumentation.debugTool) {
+          const stackInfo = errorStacks.get(e);
+          ReactFiberInstrumentation.debugTool.onUncaughtError(e, stackInfo);
+        }
+      }
       throw e;
     }
   }
@@ -799,6 +820,16 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
     }
     // It is no longer valid because this unit of work failed.
     nextUnitOfWork = null;
+
+    if (__DEV__) {
+      let stackInfo = ReactComponentTreeHook
+        .getStackAddendumByWorkInProgressFiber(failedWork);
+      errorStacks.set(
+        error,
+        // Trim leading newline
+        stackInfo.substring(1)
+      );
+    }
 
     // Search for the nearest error boundary.
     let boundary : ?Fiber = null;

--- a/src/renderers/shared/fiber/__tests__/ReactFiberInstrumentation-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactFiberInstrumentation-test.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var React;
+var ReactFiberInstrumentation;
+var ReactNoop;
+
+describe('ReactFiberInstrumentation', () => {
+  function normalizeCodeLocInfo(str) {
+    return str && str.replace(/\(at .+?:\d+\)/g, '(at **)');
+  }
+
+  beforeEach(() => {
+    jest.resetModuleRegistry();
+    React = require('React');
+    ReactFiberInstrumentation = require('ReactFiberInstrumentation');
+    ReactNoop = require('ReactNoop');
+  });
+
+  afterEach(() => {
+    ReactFiberInstrumentation.debugTool = null;
+  });
+
+  it('should report unhandled errors', () => {
+    const calls = [];
+    ReactFiberInstrumentation.debugTool = {
+      onMountContainer() {},
+      onUpdateContainer() {},
+      onWillBeginWork() {},
+      onDidBeginWork() {},
+      onWillCompleteWork() {},
+      onDidCompleteWork() {},
+      onUncaughtError(err, stack) {
+        calls.push([err, stack]);
+      },
+    };
+
+    function Bar() {
+      throw new Error('Hello');
+    }
+
+    function Foo() {
+      return (
+        <h1>
+          <Bar isBar={true} />
+        </h1>
+      );
+    }
+
+    ReactNoop.render(<Foo />);
+    expect(() => {
+      ReactNoop.flush();
+    }).toThrowError('Hello');
+    expect(calls.length).toBe(1);
+    let [err, stack] = calls[0];
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe('Hello');
+    expect(normalizeCodeLocInfo(stack)).toBe(
+      '    in Bar (at **)\n' +
+      '    in h1 (at **)\n' +
+      '    in Foo (at **)'
+    );
+
+    // Make sure recorded errors get cleared.
+    calls.length = 0;
+    ReactNoop.render(<h1>No errors</h1>);
+    ReactNoop.flush();
+    expect(calls.length).toBe(0);
+
+    // Make sure it works when no stack is available.
+    calls.length = 0;
+    ReactNoop.render(React.createElement(Bar));
+    expect(() => {
+      ReactNoop.flush();
+    }).toThrowError('Hello');
+    expect(calls.length).toBe(1);
+    ([err, stack] = calls[0]);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe('Hello');
+    expect(normalizeCodeLocInfo(stack)).toBe(
+      '    in Bar'
+    );
+  });
+});


### PR DESCRIPTION
I'm using my existing debug tool handler here since it already exists and makes it easy to add some additional logging for debugging without touching Fiber sources. I can extract it separately if you prefer.

`onUncaughtError` gets an error object and the component stack info (if it exists). You can override the handler by setting `require('ReactFiberInstrumentation').debugTool`.

**This is not a public API and should not be used externally.**