### PR TITLE
Jest preprocessor better aware of error-codes/codes.json WRT caching

### DIFF
--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -23,6 +23,7 @@ var pathToModuleMap = require.resolve('fbjs/module-map');
 var pathToBabelPluginDevWithCode = require.resolve('../error-codes/dev-expression-with-codes');
 var pathToBabelPluginModules = require.resolve('fbjs-scripts/babel-6/rewrite-modules');
 var pathToBabelrc = path.join(__dirname, '..', '..', '.babelrc');
+var pathToErrorCodes = require.resolve('../error-codes/codes.json');
 
 // TODO: make sure this stays in sync with gulpfile
 var babelOptions = {
@@ -71,5 +72,6 @@ module.exports = {
     pathToModuleMap,
     pathToBabelPluginDevWithCode,
     pathToBabelPluginModules,
+    pathToErrorCodes,
   ]),
 };


### PR DESCRIPTION
I recently [broke the `jest:coverage` Grunt task](https://circleci.com/gh/facebook/react/411?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) in my [`bvaughn:shared-context-stack` branch](https://github.com/facebook/react/pull/8611) because I added new invariants/warning messages and regenerated the error codes JSON file. I was confused because master appeared to be broken as well. It turns out that this was due to a caching issue in our preprocessor. This PR makes that caching strategy aware of the error codes JSON file.