### PR TITLE
Fiber: Fix reentrant mounting in synchronous mode

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1565,6 +1565,7 @@ src/renderers/shared/shared/__tests__/ReactUpdates-test.js
 * does not update one component twice in a batch (#6371)
 * unstable_batchedUpdates should return value from a callback
 * unmounts and remounts a root in the same batch
+* handles reentrant mounting in synchronous mode
 
 src/renderers/shared/shared/__tests__/refs-destruction-test.js
 * should remove refs when destroying the parent

--- a/src/renderers/art/ReactARTFiber.js
+++ b/src/renderers/art/ReactARTFiber.js
@@ -328,9 +328,10 @@ class Surface extends Component {
 
     this._surface = Mode.Surface(+width, +height, this._tagRef);
 
-    this._mountNode = ARTRenderer.mountContainer(
+    this._mountNode = ARTRenderer.createContainer(this._surface);
+    ARTRenderer.updateContainer(
       this.props.children,
-      this._surface,
+      this._mountNode,
       this,
     );
   }

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -289,16 +289,15 @@ function renderSubtreeIntoContainer(parentComponent : ?ReactComponent<any, any, 
 
   let container : DOMContainerElement =
     containerNode.nodeType === DOCUMENT_NODE ? (containerNode : any).documentElement : (containerNode : any);
-  let root;
-  if (!container._reactRootContainer) {
+  let root = container._reactRootContainer;
+  if (!root) {
     // First clear any existing content.
     while (container.lastChild) {
       container.removeChild(container.lastChild);
     }
-    root = container._reactRootContainer = DOMRenderer.mountContainer(children, container, parentComponent, callback);
-  } else {
-    DOMRenderer.updateContainer(children, root = container._reactRootContainer, parentComponent, callback);
+    root = container._reactRootContainer = DOMRenderer.createContainer(container);
   }
+  DOMRenderer.updateContainer(children, root, parentComponent, callback);
   return DOMRenderer.getPublicRootInstance(root);
 }
 

--- a/src/renderers/native/ReactNativeFiber.js
+++ b/src/renderers/native/ReactNativeFiber.js
@@ -361,12 +361,10 @@ const ReactNative = {
     if (!root) {
       // TODO (bvaughn): If we decide to keep the wrapper component,
       // We could create a wrapper for containerTag as well to reduce special casing.
-      root = NativeRenderer.mountContainer(element, containerTag, null, callback);
-
+      root = NativeRenderer.createContainer(containerTag);
       roots.set(containerTag, root);
-    } else {
-      NativeRenderer.updateContainer(element, root, null, callback);
     }
+    NativeRenderer.updateContainer(element, root, null, callback);
 
     return NativeRenderer.getPublicRootInstance(root);
   },

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -188,17 +188,14 @@ var ReactNoop = {
   },
 
   renderToRootWithID(element : ReactElement<any>, rootID : string, callback : ?Function) {
-    if (!roots.has(rootID)) {
+    let root = roots.get(rootID);
+    if (!root) {
       const container = { rootID: rootID, children: [] };
       rootContainers.set(rootID, container);
-      const root = NoopRenderer.mountContainer(element, container, null, callback);
+      root = NoopRenderer.createContainer(container);
       roots.set(rootID, root);
-    } else {
-      const root = roots.get(rootID);
-      if (root) {
-        NoopRenderer.updateContainer(element, root, null, callback);
-      }
     }
+    NoopRenderer.updateContainer(element, root, null, callback);
   },
 
   unmountRootWithID(rootID : string) {

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -274,7 +274,8 @@ module.exports = function<T, P, I, TI, C, CX>(
         root.pendingContext,
         root.pendingContext !== root.context
       );
-    } else {
+    } else if (root.context) {
+      // Should always be set
       pushTopLevelContextObject(
         workInProgress,
         root.context,

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -26,11 +26,11 @@ export type FiberRoot = {
   // The work schedule is a linked list.
   nextScheduledRoot: ?FiberRoot,
   // Top context object, used by renderSubtreeIntoContainer
-  context: Object,
+  context: ?Object,
   pendingContext: ?Object,
 };
 
-exports.createFiberRoot = function(containerInfo : any, context : Object) : FiberRoot {
+exports.createFiberRoot = function(containerInfo : any) : FiberRoot {
   // Cyclic construction. This cheats the type system right now because
   // stateNode is any.
   const uninitializedFiber = createHostRootFiber();
@@ -40,7 +40,7 @@ exports.createFiberRoot = function(containerInfo : any, context : Object) : Fibe
     isScheduled: false,
     nextScheduledRoot: null,
     callbackList: null,
-    context: context,
+    context: null,
     pendingContext: null,
   };
   uninitializedFiber.stateNode = root;


### PR DESCRIPTION
We have to set the container in a way that it can be retrieved before we run any user code that could start a new top-level renderer. This API feels about as good to me.