### PR TITLE
[Fiber] Push class context providers even if they crash

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1157,7 +1157,8 @@ src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
 * provides context when reusing work
 * reads context when setState is below the provider
 * reads context when setState is above the provider
-* maintains the correct context index when context proviers are bailed out due to low priority
+* maintains the correct context when providers bail out due to low priority
+* maintains the correct context when unwinding due to an error in render
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
 * catches render error in a boundary during full deferred mounting

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1413,6 +1413,8 @@ src/renderers/shared/shared/__tests__/ReactErrorBoundaries-test.js
 * renders an error state if child throws in render
 * renders an error state if child throws in constructor
 * renders an error state if child throws in componentWillMount
+* renders an error state if context provider throws in componentWillMount
+* renders an error state if module-style context provider throws in componentWillMount
 * mounts the error message if mounting fails
 * propagates errors on retry on mounting
 * propagates errors inside boundary during componentWillMount

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -31,7 +31,6 @@ var {
 var ReactTypeOfWork = require('ReactTypeOfWork');
 var {
   getMaskedContext,
-  isContextProvider,
   hasContextChanged,
   pushContextProvider,
   pushTopLevelContextObject,
@@ -219,10 +218,7 @@ module.exports = function<T, P, I, TI, C, CX>(
     // Push context providers early to prevent context stack mismatches.
     // During mounting we don't know the child context yet as the instance doesn't exist.
     // We will invalidate the child context in finishClassComponent() right after rendering.
-    const hasContext = isContextProvider(workInProgress);
-    if (hasContext) {
-      pushContextProvider(workInProgress);
-    }
+    const hasContext = pushContextProvider(workInProgress);
 
     let shouldUpdate;
     if (!current) {
@@ -431,11 +427,7 @@ module.exports = function<T, P, I, TI, C, CX>(
       // Push context providers early to prevent context stack mismatches.
       // During mounting we don't know the child context yet as the instance doesn't exist.
       // We will invalidate the child context in finishClassComponent() right after rendering.
-      const hasContext = isContextProvider(workInProgress);
-      if (hasContext) {
-        pushContextProvider(workInProgress);
-      }
-
+      const hasContext = pushContextProvider(workInProgress);
       adoptClassInstance(workInProgress, value);
       mountClassInstance(workInProgress, priorityLevel);
       return finishClassComponent(current, workInProgress, true, hasContext);
@@ -554,9 +546,7 @@ module.exports = function<T, P, I, TI, C, CX>(
     // See PR 8590 discussion for context
     switch (workInProgress.tag) {
       case ClassComponent:
-        if (isContextProvider(workInProgress)) {
-          pushContextProvider(workInProgress);
-        }
+        pushContextProvider(workInProgress);
         break;
       case HostPortal:
         pushHostContainer(workInProgress, workInProgress.stateNode.containerInfo);

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -21,7 +21,6 @@ import type { ReifiedYield } from 'ReactReifiedYield';
 
 var { reconcileChildFibers } = require('ReactChildFiber');
 var {
-  isContextProvider,
   popContextProvider,
 } = require('ReactFiberContext');
 var ReactTypeOfWork = require('ReactTypeOfWork');
@@ -175,9 +174,7 @@ module.exports = function<T, P, I, TI, C, CX>(
         return null;
       case ClassComponent: {
         // We are leaving this subtree, so pop context if any.
-        if (isContextProvider(workInProgress)) {
-          popContextProvider(workInProgress);
-        }
+        popContextProvider(workInProgress);
         // Don't use the state queue to compute the memoized state. We already
         // merged it and assigned it to the instance. Transfer it from there.
         // Also need to transfer the props, because pendingProps will be null

--- a/src/renderers/shared/fiber/ReactFiberContext.js
+++ b/src/renderers/shared/fiber/ReactFiberContext.js
@@ -145,9 +145,7 @@ exports.pushContextProvider = function(workInProgress : Fiber) : boolean {
 
 exports.invalidateContextProvider = function(workInProgress : Fiber) : void {
   const instance = workInProgress.stateNode;
-  if (instance == null) {
-    throw new Error('Expected to have an instance by this point.');
-  }
+  invariant(instance, 'Expected to have an instance by this point.');
   const parentContext = getPrevious(contextStackCursor);
   const mergedContext = processChildContext(workInProgress, parentContext, true);
   instance.__reactInternalMemoizedMergedChildContext = mergedContext;

--- a/src/renderers/shared/fiber/ReactFiberContext.js
+++ b/src/renderers/shared/fiber/ReactFiberContext.js
@@ -81,6 +81,9 @@ function isContextProvider(fiber : Fiber) : boolean {
 exports.isContextProvider = isContextProvider;
 
 function popContextProvider(fiber : Fiber) : void {
+  if (!isContextProvider(fiber)) {
+    return;
+  }
   pop(didPerformWorkStackCursor, fiber);
   pop(contextStackCursor, fiber);
 }
@@ -119,7 +122,11 @@ function processChildContext(fiber : Fiber, parentContext : ?Object, isReconcili
 }
 exports.processChildContext = processChildContext;
 
-exports.pushContextProvider = function(workInProgress : Fiber) : void {
+exports.pushContextProvider = function(workInProgress : Fiber) : boolean {
+  if (!isContextProvider(workInProgress)) {
+    return false;
+  }
+
   const instance = workInProgress.stateNode;
   // We push the context as early as possible to ensure stack integrity.
   // If the instance does not exist yet, we will push null at first,
@@ -130,6 +137,7 @@ exports.pushContextProvider = function(workInProgress : Fiber) : void {
   ) || null;
   push(contextStackCursor, memoizedMergedChildContext, workInProgress);
   push(didPerformWorkStackCursor, false, workInProgress);
+  return true;
 };
 
 exports.invalidateContextProvider = function(workInProgress : Fiber) : void {

--- a/src/renderers/shared/fiber/ReactFiberContext.js
+++ b/src/renderers/shared/fiber/ReactFiberContext.js
@@ -27,18 +27,34 @@ var {
 } = require('ReactTypeOfWork');
 const {
   createCursor,
-  getPrevious,
   pop,
   push,
-  replace,
 } = require('ReactFiberStack');
 
 if (__DEV__) {
   var checkReactTypeSpec = require('checkReactTypeSpec');
 }
 
-let contextStackCursor : StackCursor<?Object> = createCursor((null: ?Object));
+// A cursor to the current merged context object on the stack.
+let contextStackCursor : StackCursor<Object> = createCursor(emptyObject);
+// A cursor to a boolean indicating whether the context has changed.
 let didPerformWorkStackCursor : StackCursor<boolean> = createCursor(false);
+// Keep track of the previous context object that was on the stack.
+// We use this to get access to the parent context after we have already
+// pushed the next context provider, and now need to merge their contexts.
+let previousContext : Object = emptyObject;
+
+function getUnmaskedContext(workInProgress : Fiber) : Object {
+  const hasOwnContext = isContextProvider(workInProgress);
+  if (hasOwnContext) {
+    // If the fiber is a context provider itself, when we read its context
+    // we have already pushed its own child context on the stack. A context
+    // provider should not "see" its own child context. Therefore we read the
+    // previous (parent) context instead for a context provider.
+    return previousContext;
+  }
+  return contextStackCursor.current;
+}
 
 exports.getMaskedContext = function(workInProgress : Fiber) {
   const type = workInProgress.type;
@@ -47,20 +63,10 @@ exports.getMaskedContext = function(workInProgress : Fiber) {
     return emptyObject;
   }
 
-  const hasOwnContext = isContextProvider(workInProgress);
-  // If the fiber is a context provider itself, by the time we read its context
-  // we have already pushed its own child context on the stack. A context
-  // provider should not "see" its own child context. Therefore we read the
-  // previous (parent) context instead for context providers.
-  const unmaskedContext = hasOwnContext ?
-    getPrevious(contextStackCursor) :
-    contextStackCursor.current;
-
+  const unmaskedContext = getUnmaskedContext(workInProgress);
   const context = {};
-  if (unmaskedContext != null) {
-    for (let key in contextTypes) {
-      context[key] = unmaskedContext[key];
-    }
+  for (let key in contextTypes) {
+    context[key] = unmaskedContext[key];
   }
 
   if (__DEV__) {
@@ -87,6 +93,7 @@ function popContextProvider(fiber : Fiber) : void {
   if (!isContextProvider(fiber)) {
     return;
   }
+
   pop(didPerformWorkStackCursor, fiber);
   pop(contextStackCursor, fiber);
 }
@@ -99,7 +106,7 @@ exports.pushTopLevelContextObject = function(fiber : Fiber, context : Object, di
   push(didPerformWorkStackCursor, didChange, fiber);
 };
 
-function processChildContext(fiber : Fiber, parentContext : ?Object, isReconciling : boolean): Object {
+function processChildContext(fiber : Fiber, parentContext : Object, isReconciling : boolean): Object {
   const instance = fiber.stateNode;
   const childContextTypes = fiber.type.childContextTypes;
   const childContext = instance.getChildContext();
@@ -137,24 +144,36 @@ exports.pushContextProvider = function(workInProgress : Fiber) : boolean {
   const memoizedMergedChildContext = (
     instance &&
     instance.__reactInternalMemoizedMergedChildContext
-  ) || null;
+  ) || emptyObject;
+
+  // Remember the parent context so we can merge with it later.
+  previousContext = contextStackCursor.current;
   push(contextStackCursor, memoizedMergedChildContext, workInProgress);
   push(didPerformWorkStackCursor, false, workInProgress);
+
   return true;
 };
 
 exports.invalidateContextProvider = function(workInProgress : Fiber) : void {
   const instance = workInProgress.stateNode;
   invariant(instance, 'Expected to have an instance by this point.');
-  const parentContext = getPrevious(contextStackCursor);
-  const mergedContext = processChildContext(workInProgress, parentContext, true);
+
+  // Merge parent and own context.
+  const mergedContext = processChildContext(workInProgress, previousContext, true);
   instance.__reactInternalMemoizedMergedChildContext = mergedContext;
-  replace(contextStackCursor, mergedContext, workInProgress);
-  replace(didPerformWorkStackCursor, true, workInProgress);
+
+  // Replace the old (or empty) context with the new one.
+  // It is important to unwind the context in the reverse order.
+  pop(didPerformWorkStackCursor, workInProgress);
+  pop(contextStackCursor, workInProgress);
+  // Now push the new context and mark that it has changed.
+  push(contextStackCursor, mergedContext, workInProgress);
+  push(didPerformWorkStackCursor, true, workInProgress);
 };
 
 exports.resetContext = function() : void {
-  contextStackCursor.current = null;
+  previousContext = emptyObject;
+  contextStackCursor.current = emptyObject;
   didPerformWorkStackCursor.current = false;
 };
 

--- a/src/renderers/shared/fiber/ReactFiberContext.js
+++ b/src/renderers/shared/fiber/ReactFiberContext.js
@@ -48,7 +48,10 @@ exports.getMaskedContext = function(workInProgress : Fiber) {
   }
 
   const hasOwnContext = isContextProvider(workInProgress);
-  // If it is a context provider then use the previous context instead.
+  // If the fiber is a context provider itself, by the time we read its context
+  // we have already pushed its own child context on the stack. A context
+  // provider should not "see" its own child context. Therefore we read the
+  // previous (parent) context instead for context providers.
   const unmaskedContext = hasOwnContext ?
     getPrevious(contextStackCursor) :
     contextStackCursor.current;

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -18,7 +18,6 @@ import type { HostConfig, Deadline } from 'ReactFiberReconciler';
 import type { PriorityLevel } from 'ReactPriorityLevel';
 
 var {
-  isContextProvider,
   popContextProvider,
 } = require('ReactFiberContext');
 const { reset } = require('ReactFiberStack');
@@ -957,9 +956,7 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
     while (node && (node !== to) && (node.alternate !== to)) {
       switch (node.tag) {
         case ClassComponent:
-          if (isContextProvider(node)) {
-            popContextProvider(node);
-          }
+          popContextProvider(node);
           break;
         case HostComponent:
           popHostContext(node);

--- a/src/renderers/shared/fiber/ReactFiberStack.js
+++ b/src/renderers/shared/fiber/ReactFiberStack.js
@@ -34,6 +34,21 @@ exports.createCursor = function<T>(defaultValue : T) : StackCursor<T> {
   };
 };
 
+exports.getPrevious = function<T>(
+  cursor : StackCursor<T>,
+) : T | null {
+  if (index < 0) {
+    if (__DEV__) {
+      warning(false, 'Unexpected read of previous.');
+    }
+    return null;
+  }
+  if (index === 0) {
+    return null;
+  }
+  return valueStack[index - 1];
+};
+
 exports.isEmpty = function() : boolean {
   return index === -1;
 };
@@ -77,6 +92,27 @@ exports.push = function<T>(
 
   if (__DEV__) {
     fiberStack[index] = fiber;
+  }
+
+  cursor.current = value;
+};
+
+exports.replace = function<T>(
+  cursor : StackCursor<T>,
+  value : T,
+  fiber: Fiber,
+) : void {
+  if (index < 0) {
+    if (__DEV__) {
+      warning(false, 'Unexpected replace.');
+    }
+    return;
+  }
+
+  if (__DEV__) {
+    if (fiber !== fiberStack[index]) {
+      warning(false, 'Unexpected Fiber replaced.');
+    }
   }
 
   cursor.current = value;

--- a/src/renderers/shared/fiber/ReactFiberStack.js
+++ b/src/renderers/shared/fiber/ReactFiberStack.js
@@ -34,18 +34,6 @@ exports.createCursor = function<T>(defaultValue : T) : StackCursor<T> {
   };
 };
 
-exports.getPrevious = function<T>(
-  cursor : StackCursor<T>,
-) : T | null {
-  if (index < 0) {
-    if (__DEV__) {
-      warning(false, 'Unexpected read of previous.');
-    }
-    return null;
-  }
-  return valueStack[index];
-};
-
 exports.isEmpty = function() : boolean {
   return index === -1;
 };
@@ -89,27 +77,6 @@ exports.push = function<T>(
 
   if (__DEV__) {
     fiberStack[index] = fiber;
-  }
-
-  cursor.current = value;
-};
-
-exports.replace = function<T>(
-  cursor : StackCursor<T>,
-  value : T,
-  fiber: Fiber,
-) : void {
-  if (index < 0) {
-    if (__DEV__) {
-      warning(false, 'Unexpected replace.');
-    }
-    return;
-  }
-
-  if (__DEV__) {
-    if (fiber !== fiberStack[index]) {
-      warning(false, 'Unexpected Fiber replaced.');
-    }
   }
 
   cursor.current = value;

--- a/src/renderers/shared/fiber/ReactFiberStack.js
+++ b/src/renderers/shared/fiber/ReactFiberStack.js
@@ -43,10 +43,7 @@ exports.getPrevious = function<T>(
     }
     return null;
   }
-  if (index === 0) {
-    return null;
-  }
-  return valueStack[index - 1];
+  return valueStack[index];
 };
 
 exports.isEmpty = function() : boolean {

--- a/src/renderers/shared/shared/__tests__/ReactErrorBoundaries-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactErrorBoundaries-test.js
@@ -733,6 +733,58 @@ describe('ReactErrorBoundaries', () => {
     ]);
   });
 
+  it('renders an error state if context provider throws in componentWillMount', () => {
+    class BrokenComponentWillMountWithContext extends React.Component {
+      static childContextTypes = {foo: React.PropTypes.number};
+      getChildContext() {
+        return {foo: 42};
+      }
+      render() {
+        return <div>{this.props.children}</div>;
+      }
+      componentWillMount() {
+        throw new Error('Hello');
+      }
+    }
+
+    var container = document.createElement('div');
+    ReactDOM.render(
+      <ErrorBoundary>
+        <BrokenComponentWillMountWithContext />
+      </ErrorBoundary>,
+      container
+    );
+    expect(container.firstChild.textContent).toBe('Caught an error: Hello.');
+  });
+
+  it('renders an error state if module-style context provider throws in componentWillMount', () => {
+    function BrokenComponentWillMountWithContext() {
+      return {
+        getChildContext() {
+          return {foo: 42};
+        },
+        render() {
+          return <div>{this.props.children}</div>;
+        },
+        componentWillMount() {
+          throw new Error('Hello');
+        },
+      };
+    }
+    BrokenComponentWillMountWithContext.childContextTypes = {
+      foo: React.PropTypes.number,
+    };
+
+    var container = document.createElement('div');
+    ReactDOM.render(
+      <ErrorBoundary>
+        <BrokenComponentWillMountWithContext />
+      </ErrorBoundary>,
+      container
+    );
+    expect(container.firstChild.textContent).toBe('Caught an error: Hello.');
+  });
+
   it('mounts the error message if mounting fails', () => {
     function renderError(error) {
       return (


### PR DESCRIPTION
Previously we used to push them only after the instance was available. This caused issues in cases an error is thrown during `componentWillMount()`.

In that case we never got to pushing the provider in the begin phase, but in complete phase the provider check returned `true` since the instance existed by that point. As a result we got mismatching context pops.

We solve the issue by making the context check independent of whether the instance actually exists. Instead we're checking the type itself.

This lets us push class context early. However there's another problem: we might not know the context value. If the instance is not yet created, we can't call `getChildContext` on it.

To fix this, we are introducing a way to replace current value on the stack, and a way to read the previous value. This also helps remove some branching and split the memoized from invalidated code paths.

I also added a test from #8604 to verify this also solves the problem described in that PR.