### PR TITLE
[Fiber] Don't call sCU with null props

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -194,6 +194,7 @@ module.exports = function<T, P, I, TI, C, CX>(
     } else if (nextProps === null || memoizedProps === nextProps || (
         // TODO: Disable this before release, since it is not part of the public API
         // I use this for testing to compare the relative overhead of classes.
+        memoizedProps !== null &&
         typeof fn.shouldComponentUpdate === 'function' &&
         !fn.shouldComponentUpdate(memoizedProps, nextProps)
       )) {


### PR DESCRIPTION
I missed this case in 8613 and it broke the triangle demo.

We don't have a test because we'll probably just delete it. Maybe.