### PR TITLE
Warn for callback refs on functional components (Stack + Fiber)

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -66,7 +66,6 @@ src/renderers/shared/shared/__tests__/ReactMultiChildText-test.js
 
 src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
 * should warn when stateless component returns array
-* should throw on string refs in pure functions
 * should warn when using non-React functions in JSX
 
 src/renderers/shared/shared/__tests__/ReactUpdates-test.js

--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -49,9 +49,6 @@ src/renderers/shared/__tests__/ReactPerf-test.js
 * should not count time in a portal towards lifecycle method
 * should work when measurement starts during reconciliation
 
-src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
-* invokes ref callbacks after insertion/update/unmount
-
 src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.js
 * can be retrieved by ID
 

--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -49,6 +49,9 @@ src/renderers/shared/__tests__/ReactPerf-test.js
 * should not count time in a portal towards lifecycle method
 * should work when measurement starts during reconciliation
 
+src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+* invokes ref callbacks after insertion/update/unmount
+
 src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.js
 * can be retrieved by ID
 

--- a/scripts/fiber/tests-passing-except-dev.txt
+++ b/scripts/fiber/tests-passing-except-dev.txt
@@ -116,4 +116,3 @@ src/renderers/shared/shared/__tests__/ReactMultiChild-test.js
 
 src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
 * should warn for childContextTypes on a functional component
-* should warn when given a ref

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1535,6 +1535,7 @@ src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
 * should update stateless component
 * should unmount stateless component
 * should pass context thru stateless component
+* should throw on string refs in pure functions
 * should warn when given a string ref
 * should warn when given a function ref
 * should provide a null ref

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1535,6 +1535,8 @@ src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
 * should update stateless component
 * should unmount stateless component
 * should pass context thru stateless component
+* should warn when given a string ref
+* should warn when given a function ref
 * should provide a null ref
 * should use correct name in key warning
 * should support default props and prop types

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -78,14 +78,16 @@ function coerceRef(current: ?Fiber, element: ReactElement) {
   let mixedRef = element.ref;
   if (mixedRef != null && typeof mixedRef !== 'function') {
     if (element._owner) {
-      const ownerFiber : ?(Fiber | ReactInstance) = (element._owner : any);
+      const owner : ?(Fiber | ReactInstance) = (element._owner : any);
       let inst;
-      if (ownerFiber) {
-        if ((ownerFiber : any).tag === ClassComponent) {
-          inst = (ownerFiber : any).stateNode;
+      if (owner) {
+        if (typeof owner.tag === 'number') {
+          const ownerFiber = ((owner : any) : Fiber);
+          invariant(ownerFiber.tag === ClassComponent, 'Stateless function components cannot have refs.');
+          inst = ownerFiber.stateNode;
         } else {
           // Stack
-          inst = (ownerFiber : any).getPublicInstance();
+          inst = (owner : any).getPublicInstance();
         }
       }
       invariant(inst, 'Missing owner for string ref %s', mixedRef);

--- a/src/renderers/shared/fiber/ReactDebugCurrentFiber.js
+++ b/src/renderers/shared/fiber/ReactDebugCurrentFiber.js
@@ -15,12 +15,6 @@
 import type { Fiber } from 'ReactFiber';
 
 if (__DEV__) {
-  var {
-    IndeterminateComponent,
-    FunctionalComponent,
-    ClassComponent,
-    HostComponent,
-  } = require('ReactTypeOfWork');
   var getComponentName = require('getComponentName');
   var { getStackAddendumByWorkInProgressFiber } = require('ReactComponentTreeHook');
 }
@@ -31,18 +25,8 @@ function getCurrentFiberOwnerName() : string | null {
     if (fiber == null) {
       return null;
     }
-    switch (fiber.tag) {
-      case IndeterminateComponent:
-      case FunctionalComponent:
-      case ClassComponent:
-        return getComponentName(fiber);
-      case HostComponent:
-        if (fiber._debugOwner != null) {
-          return getComponentName(fiber._debugOwner);
-        }
-        return null;
-      default:
-        return null;
+    if (fiber._debugOwner != null) {
+      return getComponentName(fiber._debugOwner);
     }
   }
   return null;

--- a/src/renderers/shared/fiber/ReactDebugCurrentFiber.js
+++ b/src/renderers/shared/fiber/ReactDebugCurrentFiber.js
@@ -34,7 +34,11 @@ function getCurrentFiberOwnerName() : string | null {
     switch (fiber.tag) {
       case IndeterminateComponent:
       case ClassComponent:
+        return getComponentName(fiber);
       case FunctionalComponent:
+        if (fiber._debugOwner != null) {
+          return getComponentName(fiber._debugOwner);
+        }
         return getComponentName(fiber);
       case HostComponent:
         if (fiber._debugOwner != null) {

--- a/src/renderers/shared/fiber/ReactDebugCurrentFiber.js
+++ b/src/renderers/shared/fiber/ReactDebugCurrentFiber.js
@@ -33,12 +33,8 @@ function getCurrentFiberOwnerName() : string | null {
     }
     switch (fiber.tag) {
       case IndeterminateComponent:
-      case ClassComponent:
-        return getComponentName(fiber);
       case FunctionalComponent:
-        if (fiber._debugOwner != null) {
-          return getComponentName(fiber._debugOwner);
-        }
+      case ClassComponent:
         return getComponentName(fiber);
       case HostComponent:
         if (fiber._debugOwner != null) {

--- a/src/renderers/shared/fiber/ReactDebugCurrentFiber.js
+++ b/src/renderers/shared/fiber/ReactDebugCurrentFiber.js
@@ -33,8 +33,8 @@ function getCurrentFiberOwnerName() : string | null {
     }
     switch (fiber.tag) {
       case IndeterminateComponent:
-      case FunctionalComponent:
       case ClassComponent:
+      case FunctionalComponent:
         return getComponentName(fiber);
       case HostComponent:
         if (fiber._debugOwner != null) {

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -50,7 +50,7 @@ var {
 var invariant = require('invariant');
 
 if (__DEV__) {
-  var { getCurrentFiberOwnerName } = require('ReactDebugCurrentFiber');
+  var getComponentName = require('getComponentName');
 }
 
 // A Fiber is work on a Component that needs to be done or was done. There can
@@ -300,7 +300,12 @@ exports.createHostRootFiber = function() : Fiber {
 };
 
 exports.createFiberFromElement = function(element : ReactElement, priorityLevel : PriorityLevel) : Fiber {
-  const fiber = createFiberFromElementType(element.type, element.key);
+  let owner = null;
+  if (__DEV__) {
+    owner = element._owner;
+  }
+
+  const fiber = createFiberFromElementType(element.type, element.key, owner);
   fiber.pendingProps = element.props;
   fiber.pendingWorkPriority = priorityLevel;
 
@@ -328,7 +333,7 @@ exports.createFiberFromText = function(content : string, priorityLevel : Priorit
   return fiber;
 };
 
-function createFiberFromElementType(type : mixed, key : null | string) : Fiber {
+function createFiberFromElementType(type : mixed, key : null | string, debugOwner : null | Fiber | ReactInstance) : Fiber {
   let fiber;
   if (typeof type === 'function') {
     fiber = shouldConstruct(type) ?
@@ -363,7 +368,7 @@ function createFiberFromElementType(type : mixed, key : null | string) : Fiber {
           ' You likely forgot to export your component from the file ' +
           'it\'s defined in.';
       }
-      const ownerName = getCurrentFiberOwnerName();
+      const ownerName = debugOwner ? getComponentName(debugOwner) : null;
       if (ownerName) {
         info += ' Check the render method of `' + ownerName + '`.';
       }

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -457,19 +457,21 @@ module.exports = function<T, P, I, TI, C, CX, CI>(
       // Proceed under the assumption that this is a functional component
       workInProgress.tag = FunctionalComponent;
       if (__DEV__) {
-        let info = '';
-        const ownerName = ReactDebugCurrentFiber.getCurrentFiberOwnerName();
-        if (ownerName) {
-          info += ' Check the render method of `' + ownerName + '`.';
-        }
+        if (workInProgress.ref != null) {
+          let info = '';
+          const ownerName = ReactDebugCurrentFiber.getCurrentFiberOwnerName();
+          if (ownerName) {
+            info += ' Check the render method of `' + ownerName + '`.';
+          }
 
-        warning(
-          !workInProgress.ref,
-          'Stateless function components cannot be given refs. ' +
-          'Attempts to access this ref will fail.%s%s',
-          info,
-          ReactDebugCurrentFiber.getCurrentFiberStackAddendum()
-        );
+          warning(
+            false,
+            'Stateless function components cannot be given refs. ' +
+            'Attempts to access this ref will fail.%s%s',
+            info,
+            ReactDebugCurrentFiber.getCurrentFiberStackAddendum()
+          );
+        }
       }
       reconcileChildren(current, workInProgress, value);
       return workInProgress.child;

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -457,14 +457,12 @@ module.exports = function<T, P, I, TI, C, CX, CI>(
       // Proceed under the assumption that this is a functional component
       workInProgress.tag = FunctionalComponent;
       if (__DEV__) {
-        if (workInProgress.ref && workInProgress.ref._stringRef) {
-          warning(
-            !workInProgress.ref,
-            'Stateless function components cannot be given refs. ' +
-            'Attempts to access this ref will fail.%s',
-            ReactDebugCurrentFiber.getCurrentFiberStackAddendum()
-          );
-        }
+        warning(
+          !workInProgress.ref,
+          'Stateless function components cannot be given refs. ' +
+          'Attempts to access this ref will fail.%s',
+          ReactDebugCurrentFiber.getCurrentFiberStackAddendum()
+        );
       }
       reconcileChildren(current, workInProgress, value);
       return workInProgress.child;

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -63,6 +63,7 @@ var {
 } = require('ReactTypeOfSideEffect');
 var ReactCurrentOwner = require('ReactCurrentOwner');
 var ReactFiberClassComponent = require('ReactFiberClassComponent');
+var warning = require('warning');
 
 if (__DEV__) {
   var ReactDebugCurrentFiber = require('ReactDebugCurrentFiber');
@@ -455,6 +456,16 @@ module.exports = function<T, P, I, TI, C, CX, CI>(
     } else {
       // Proceed under the assumption that this is a functional component
       workInProgress.tag = FunctionalComponent;
+      if (__DEV__) {
+        if (workInProgress.ref && workInProgress.ref._stringRef) {
+          warning(
+            !workInProgress.ref,
+            'Stateless function components cannot be given refs. ' +
+            'Attempts to access this ref will fail.%s',
+            ReactDebugCurrentFiber.getCurrentFiberStackAddendum()
+          );
+        }
+      }
       reconcileChildren(current, workInProgress, value);
       return workInProgress.child;
     }

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -457,10 +457,17 @@ module.exports = function<T, P, I, TI, C, CX, CI>(
       // Proceed under the assumption that this is a functional component
       workInProgress.tag = FunctionalComponent;
       if (__DEV__) {
+        let info = '';
+        const ownerName = ReactDebugCurrentFiber.getCurrentFiberOwnerName();
+        if (ownerName) {
+          info += ' Check the render method of `' + ownerName + '`.';
+        }
+
         warning(
           !workInProgress.ref,
           'Stateless function components cannot be given refs. ' +
-          'Attempts to access this ref will fail.%s',
+          'Attempts to access this ref will fail.%s%s',
+          info,
           ReactDebugCurrentFiber.getCurrentFiberStackAddendum()
         );
       }

--- a/src/renderers/shared/fiber/ReactReifiedYield.js
+++ b/src/renderers/shared/fiber/ReactReifiedYield.js
@@ -22,7 +22,8 @@ export type ReifiedYield = { continuation: Fiber, props: Object };
 exports.createReifiedYield = function(yieldNode : ReactYield) : ReifiedYield {
   var fiber = createFiberFromElementType(
     yieldNode.continuation,
-    yieldNode.key
+    yieldNode.key,
+    null // debugOwner
   );
   return {
     continuation: fiber,
@@ -35,7 +36,8 @@ exports.createUpdatedReifiedYield = function(previousYield : ReifiedYield, yield
   if (fiber.type !== yieldNode.continuation) {
     fiber = createFiberFromElementType(
       yieldNode.continuation,
-      yieldNode.key
+      yieldNode.key,
+      null // debugOwner
     );
   }
   return {

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
@@ -739,9 +739,8 @@ describe('ReactIncrementalErrorHandling', () => {
       }
     }
     const InvalidType = undefined;
-    const brokenElement = <InvalidType />;
     function BrokenRender(props) {
-      return brokenElement;
+      return <InvalidType />;
     }
 
     ReactNoop.render(
@@ -776,9 +775,8 @@ describe('ReactIncrementalErrorHandling', () => {
     }
 
     const InvalidType = undefined;
-    const brokenElement = <InvalidType />;
     function BrokenRender(props) {
-      return props.fail ? brokenElement : <span />;
+      return props.fail ? <InvalidType /> : <span />;
     }
 
     ReactNoop.render(

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -21,6 +21,10 @@ describe('ReactIncrementalSideEffects', () => {
     ReactNoop = require('ReactNoop');
   });
 
+  function normalizeCodeLocInfo(str) {
+    return str && str.replace(/\(at .+?:\d+\)/g, '(at **)');
+  }
+
   function div(...children) {
     children = children.map(c => typeof c === 'string' ? { text: c } : c);
     return { type: 'div', children, prop: undefined };
@@ -1129,6 +1133,14 @@ describe('ReactIncrementalSideEffects', () => {
       null,
     ]);
 
+    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+      'Warning: Stateless function components cannot be given refs. ' +
+      'Attempts to access this ref will fail. Check the render method ' +
+      'of `Foo`.\n' +
+      '    in FunctionalComponent (at **)\n' +
+      '    in div (at **)\n' +
+      '    in Foo (at **)'
+    );
   });
 
   // TODO: Test that mounts, updates, refs, unmounts and deletions happen in the

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -1069,7 +1069,7 @@ describe('ReactIncrementalSideEffects', () => {
   });
 
   it('invokes ref callbacks after insertion/update/unmount', () => {
-
+    spyOn(console, 'error');
     var classInstance = null;
 
     var ops = [];

--- a/src/renderers/shared/shared/__tests__/ReactComponent-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactComponent-test.js
@@ -352,16 +352,25 @@ describe('ReactComponent', () => {
   it('includes owner name in the error about badly-typed elements', () => {
     spyOn(console, 'error');
 
+    var X = undefined;
+
+    function Indirection(props) {
+      return <div>{props.children}</div>;
+    }
+
+    function Bar() {
+      return <Indirection><X /></Indirection>;
+    }
+
     function Foo() {
-      var X = undefined;
-      return <X />;
+      return <Bar />;
     }
 
     expect(() => ReactTestUtils.renderIntoDocument(<Foo />)).toThrowError(
       'Element type is invalid: expected a string (for built-in components) ' +
       'or a class/function (for composite components) but got: undefined. ' +
       'You likely forgot to export your component from the file it\'s ' +
-      'defined in. Check the render method of `Foo`.'
+      'defined in. Check the render method of `Bar`.'
     );
 
     // One warning for each element creation

--- a/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
@@ -14,16 +14,21 @@
 var React;
 var ReactDOM;
 var ReactTestUtils;
+var ReactDOMFeatureFlags;
 
 function StatelessComponent(props) {
   return <div>{props.name}</div>;
 }
 
 describe('ReactStatelessComponent', () => {
+  function normalizeCodeLocInfo(str) {
+    return str && str.replace(/\(at .+?:\d+\)/g, '(at **)');
+  }
 
   beforeEach(() => {
     React = require('React');
     ReactDOM = require('ReactDOM');
+    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
     ReactTestUtils = require('ReactTestUtils');
   });
 
@@ -153,17 +158,17 @@ describe('ReactStatelessComponent', () => {
       static displayName = 'Parent';
 
       render() {
-        return <StatelessComponent name="A" ref="stateless"/>;
+        return <div><StatelessComponent name="A" ref="stateless"/></div>;
       }
     }
 
     ReactTestUtils.renderIntoDocument(<Parent/>);
 
     expectDev(console.error.calls.count()).toBe(1);
-    expectDev(console.error.calls.argsFor(0)[0]).toContain(
-      'Stateless function components cannot be given refs ' +
-      '(See ref "stateless" in StatelessComponent created by Parent). ' +
-      'Attempts to access this ref will fail.'
+    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+      'Warning: Stateless function components cannot be given refs. ' +
+      'Attempts to access this ref will fail.\n' +
+      '    in Parent (at **)'
     );
   });
 

--- a/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
@@ -169,14 +169,17 @@ describe('ReactStatelessComponent', () => {
     if (ReactDOMFeatureFlags.useFiber) {
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
         'Warning: Stateless function components cannot be given refs. ' +
-        'Attempts to access this ref will fail.\n' +
+        'Attempts to access this ref will fail. Check the render method ' +
+        'of `Parent`.\n' +
         '    in StatelessComponent (at **)\n' +
+        '    in div (at **)\n' +
         '    in Parent (at **)'
       );
     } else {
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
         'Warning: Stateless function components cannot be given refs. ' +
-        'Attempts to access this ref will fail.\n' +
+        'Attempts to access this ref will fail. Check the render method ' +
+        'of `Parent`.\n' +
         '    in Parent (at **)'
       );
     }
@@ -203,14 +206,17 @@ describe('ReactStatelessComponent', () => {
     if (ReactDOMFeatureFlags.useFiber) {
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
         'Warning: Stateless function components cannot be given refs. ' +
-        'Attempts to access this ref will fail.\n' +
+        'Attempts to access this ref will fail. Check the render method ' +
+        'of `Parent`.\n' +
         '    in StatelessComponent (at **)\n' +
+        '    in div (at **)\n' +
         '    in Parent (at **)'
       );
     } else {
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
         'Warning: Stateless function components cannot be given refs. ' +
-        'Attempts to access this ref will fail.\n' +
+        'Attempts to access this ref will fail. Check the render method ' +
+        'of `Parent`.\n' +
         '    in Parent (at **)'
       );
     }

--- a/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
@@ -165,11 +165,21 @@ describe('ReactStatelessComponent', () => {
     ReactTestUtils.renderIntoDocument(<Parent/>);
 
     expectDev(console.error.calls.count()).toBe(1);
-    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-      'Warning: Stateless function components cannot be given refs. ' +
-      'Attempts to access this ref will fail.\n' +
-      '    in Parent (at **)'
-    );
+
+    if (ReactDOMFeatureFlags.useFiber) {
+      expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+        'Warning: Stateless function components cannot be given refs. ' +
+        'Attempts to access this ref will fail.\n' +
+        '    in StatelessComponent (at **)\n' +
+        '    in Parent (at **)'
+      );
+    } else {
+      expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+        'Warning: Stateless function components cannot be given refs. ' +
+        'Attempts to access this ref will fail.\n' +
+        '    in Parent (at **)'
+      );
+    }
   });
 
   it('should provide a null ref', () => {

--- a/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
@@ -152,11 +152,13 @@ describe('ReactStatelessComponent', () => {
   it('should warn when given a string ref', () => {
     spyOn(console, 'error');
 
-    class Parent extends React.Component {
-      static displayName = 'Parent';
+    function Indirection(props) {
+      return <div>{props.children}</div>;
+    }
 
+    class Parent extends React.Component {
       render() {
-        return <div><StatelessComponent name="A" ref="stateless"/></div>;
+        return <Indirection><StatelessComponent name="A" ref="stateless"/></Indirection>;
       }
     }
 
@@ -169,6 +171,7 @@ describe('ReactStatelessComponent', () => {
       'of `Parent`.\n' +
       '    in StatelessComponent (at **)\n' +
       '    in div (at **)\n' +
+      '    in Indirection (at **)\n' +
       '    in Parent (at **)'
     );
   });
@@ -179,11 +182,13 @@ describe('ReactStatelessComponent', () => {
       expect(arg).toBe(null);
     });
 
-    class Parent extends React.Component {
-      static displayName = 'Parent';
+    function Indirection(props) {
+      return <div>{props.children}</div>;
+    }
 
+    class Parent extends React.Component {
       render() {
-        return <div><StatelessComponent name="A" ref={ref} /></div>;
+        return <Indirection><StatelessComponent name="A" ref={ref} /></Indirection>;
       }
     }
 
@@ -196,6 +201,7 @@ describe('ReactStatelessComponent', () => {
       'of `Parent`.\n' +
       '    in StatelessComponent (at **)\n' +
       '    in div (at **)\n' +
+      '    in Indirection (at **)\n' +
       '    in Parent (at **)'
     );
   });

--- a/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
@@ -14,7 +14,6 @@
 var React;
 var ReactDOM;
 var ReactTestUtils;
-var ReactDOMFeatureFlags;
 
 function StatelessComponent(props) {
   return <div>{props.name}</div>;
@@ -28,7 +27,6 @@ describe('ReactStatelessComponent', () => {
   beforeEach(() => {
     React = require('React');
     ReactDOM = require('ReactDOM');
-    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
     ReactTestUtils = require('ReactTestUtils');
   });
 
@@ -165,24 +163,14 @@ describe('ReactStatelessComponent', () => {
     ReactTestUtils.renderIntoDocument(<Parent/>);
 
     expectDev(console.error.calls.count()).toBe(1);
-
-    if (ReactDOMFeatureFlags.useFiber) {
-      expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Stateless function components cannot be given refs. ' +
-        'Attempts to access this ref will fail. Check the render method ' +
-        'of `Parent`.\n' +
-        '    in StatelessComponent (at **)\n' +
-        '    in div (at **)\n' +
-        '    in Parent (at **)'
-      );
-    } else {
-      expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Stateless function components cannot be given refs. ' +
-        'Attempts to access this ref will fail. Check the render method ' +
-        'of `Parent`.\n' +
-        '    in Parent (at **)'
-      );
-    }
+    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+      'Warning: Stateless function components cannot be given refs. ' +
+      'Attempts to access this ref will fail. Check the render method ' +
+      'of `Parent`.\n' +
+      '    in StatelessComponent (at **)\n' +
+      '    in div (at **)\n' +
+      '    in Parent (at **)'
+    );
   });
 
   it('should warn when given a function ref', () => {
@@ -202,24 +190,14 @@ describe('ReactStatelessComponent', () => {
     ReactTestUtils.renderIntoDocument(<Parent/>);
 
     expectDev(console.error.calls.count()).toBe(1);
-
-    if (ReactDOMFeatureFlags.useFiber) {
-      expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Stateless function components cannot be given refs. ' +
-        'Attempts to access this ref will fail. Check the render method ' +
-        'of `Parent`.\n' +
-        '    in StatelessComponent (at **)\n' +
-        '    in div (at **)\n' +
-        '    in Parent (at **)'
-      );
-    } else {
-      expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Stateless function components cannot be given refs. ' +
-        'Attempts to access this ref will fail. Check the render method ' +
-        'of `Parent`.\n' +
-        '    in Parent (at **)'
-      );
-    }
+    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+      'Warning: Stateless function components cannot be given refs. ' +
+      'Attempts to access this ref will fail. Check the render method ' +
+      'of `Parent`.\n' +
+      '    in StatelessComponent (at **)\n' +
+      '    in div (at **)\n' +
+      '    in Parent (at **)'
+    );
   });
 
   it('should provide a null ref', () => {

--- a/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
@@ -151,7 +151,7 @@ describe('ReactStatelessComponent', () => {
     );
   });
 
-  it('should warn when given a ref', () => {
+  it('should warn when given a string ref', () => {
     spyOn(console, 'error');
 
     class Parent extends React.Component {
@@ -159,6 +159,40 @@ describe('ReactStatelessComponent', () => {
 
       render() {
         return <div><StatelessComponent name="A" ref="stateless"/></div>;
+      }
+    }
+
+    ReactTestUtils.renderIntoDocument(<Parent/>);
+
+    expectDev(console.error.calls.count()).toBe(1);
+
+    if (ReactDOMFeatureFlags.useFiber) {
+      expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+        'Warning: Stateless function components cannot be given refs. ' +
+        'Attempts to access this ref will fail.\n' +
+        '    in StatelessComponent (at **)\n' +
+        '    in Parent (at **)'
+      );
+    } else {
+      expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+        'Warning: Stateless function components cannot be given refs. ' +
+        'Attempts to access this ref will fail.\n' +
+        '    in Parent (at **)'
+      );
+    }
+  });
+
+  it('should warn when given a function ref', () => {
+    spyOn(console, 'error');
+    var ref = jasmine.createSpy().and.callFake((arg) => {
+      expect(arg).toBe(null);
+    });
+
+    class Parent extends React.Component {
+      static displayName = 'Parent';
+
+      render() {
+        return <div><StatelessComponent name="A" ref={ref} /></div>;
       }
     }
 

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -13,6 +13,7 @@
 
 var React = require('React');
 var ReactComponentEnvironment = require('ReactComponentEnvironment');
+var ReactComponentTreeHook = require('ReactComponentTreeHook');
 var ReactCurrentOwner = require('ReactCurrentOwner');
 var ReactErrorUtils = require('ReactErrorUtils');
 var ReactFeatureFlags = require('ReactFeatureFlags');
@@ -1257,12 +1258,9 @@ var ReactCompositeComponent = {
       warning(
         publicComponentInstance != null ||
         component._compositeType !== CompositeTypes.StatelessFunctional,
-        'Stateless function components cannot be given refs ' +
-        '(See ref "%s" in %s created by %s). ' +
-        'Attempts to access this ref will fail.',
-        ref,
-        componentName,
-        this.getName()
+        'Stateless function components cannot be given refs. ' +
+        'Attempts to access this ref will fail.%s',
+        ReactComponentTreeHook.getStackAddendumByID(this._debugID)
       );
     }
     var refs = inst.refs === emptyObject ? (inst.refs = {}) : inst.refs;

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -14,6 +14,7 @@
 var React = require('React');
 var ReactComponentEnvironment = require('ReactComponentEnvironment');
 var ReactComponentTreeHook = require('ReactComponentTreeHook');
+var ReactCompositeComponentTypes = require('ReactCompositeComponentTypes');
 var ReactCurrentOwner = require('ReactCurrentOwner');
 var ReactErrorUtils = require('ReactErrorUtils');
 var ReactFeatureFlags = require('ReactFeatureFlags');
@@ -33,12 +34,6 @@ var shouldUpdateReactComponent = require('shouldUpdateReactComponent');
 var warning = require('warning');
 
 import type { ReactPropTypeLocations } from 'ReactPropTypeLocations';
-
-var CompositeTypes = {
-  ImpureClass: 0,
-  PureClass: 1,
-  StatelessFunctional: 2,
-};
 
 function StatelessComponent(Component) {
 }
@@ -221,12 +216,12 @@ var ReactCompositeComponent = {
         Component.displayName || Component.name || 'Component'
       );
       inst = new StatelessComponent(Component);
-      this._compositeType = CompositeTypes.StatelessFunctional;
+      this._compositeType = ReactCompositeComponentTypes.StatelessFunctional;
     } else {
       if (isPureComponent(Component)) {
-        this._compositeType = CompositeTypes.PureClass;
+        this._compositeType = ReactCompositeComponentTypes.PureClass;
       } else {
-        this._compositeType = CompositeTypes.ImpureClass;
+        this._compositeType = ReactCompositeComponentTypes.ImpureClass;
       }
     }
 
@@ -882,7 +877,7 @@ var ReactCompositeComponent = {
           shouldUpdate = inst.shouldComponentUpdate(nextProps, nextState, nextContext);
         }
       } else {
-        if (this._compositeType === CompositeTypes.PureClass) {
+        if (this._compositeType === ReactCompositeComponentTypes.PureClass) {
           shouldUpdate =
             !shallowEqual(prevProps, nextProps) ||
             !shallowEqual(inst.state, nextState);
@@ -1216,7 +1211,7 @@ var ReactCompositeComponent = {
    */
   _renderValidatedComponent: function() {
     var renderedElement;
-    if (__DEV__ || this._compositeType !== CompositeTypes.StatelessFunctional) {
+    if (__DEV__ || this._compositeType !== ReactCompositeComponentTypes.StatelessFunctional) {
       ReactCurrentOwner.current = this;
       try {
         renderedElement =
@@ -1253,11 +1248,9 @@ var ReactCompositeComponent = {
     invariant(inst != null, 'Stateless function components cannot have refs.');
     var publicComponentInstance = component.getPublicInstance();
     if (__DEV__) {
-      var componentName = component && component.getName ?
-        component.getName() : 'a component';
       warning(
         publicComponentInstance != null ||
-        component._compositeType !== CompositeTypes.StatelessFunctional,
+        component._compositeType !== ReactCompositeComponentTypes.StatelessFunctional,
         'Stateless function components cannot be given refs. ' +
         'Attempts to access this ref will fail.%s',
         ReactComponentTreeHook.getStackAddendumByID(this._debugID)
@@ -1305,7 +1298,7 @@ var ReactCompositeComponent = {
    */
   getPublicInstance: function() {
     var inst = this._instance;
-    if (this._compositeType === CompositeTypes.StatelessFunctional) {
+    if (this._compositeType === ReactCompositeComponentTypes.StatelessFunctional) {
       return null;
     }
     return inst;

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -1248,11 +1248,18 @@ var ReactCompositeComponent = {
     invariant(inst != null, 'Stateless function components cannot have refs.');
     var publicComponentInstance = component.getPublicInstance();
     if (__DEV__) {
+      let info = '';
+      const ownerName = this.getName();
+      if (ownerName) {
+        info += ' Check the render method of `' + ownerName + '`.';
+      }
+
       warning(
         publicComponentInstance != null ||
         component._compositeType !== ReactCompositeComponentTypes.StatelessFunctional,
-        'Stateless function components cannot be given refs. ' +
-        'Attempts to access this ref will fail.%s',
+        'Stateless function components cannot be given refs. Attempts to ' +
+        'access this ref will fail.%s%s',
+        info,
         ReactComponentTreeHook.getStackAddendumByID(this._debugID)
       );
     }

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -13,7 +13,6 @@
 
 var React = require('React');
 var ReactComponentEnvironment = require('ReactComponentEnvironment');
-var ReactComponentTreeHook = require('ReactComponentTreeHook');
 var ReactCompositeComponentTypes = require('ReactCompositeComponentTypes');
 var ReactCurrentOwner = require('ReactCurrentOwner');
 var ReactErrorUtils = require('ReactErrorUtils');
@@ -1247,22 +1246,6 @@ var ReactCompositeComponent = {
     var inst = this.getPublicInstance();
     invariant(inst != null, 'Stateless function components cannot have refs.');
     var publicComponentInstance = component.getPublicInstance();
-    if (__DEV__) {
-      let info = '';
-      const ownerName = this.getName();
-      if (ownerName) {
-        info += ' Check the render method of `' + ownerName + '`.';
-      }
-
-      warning(
-        publicComponentInstance != null ||
-        component._compositeType !== ReactCompositeComponentTypes.StatelessFunctional,
-        'Stateless function components cannot be given refs. Attempts to ' +
-        'access this ref will fail.%s%s',
-        info,
-        ReactComponentTreeHook.getStackAddendumByID(this._debugID)
-      );
-    }
     var refs = inst.refs === emptyObject ? (inst.refs = {}) : inst.refs;
     refs[ref] = publicComponentInstance;
   },

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponentTypes.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponentTypes.js
@@ -10,11 +10,10 @@
  * @flow
  */
 
+export type CompositeComponentTypes = 0 | 1 | 2;
 
-var CompositeTypes = {
+module.exports = {
   ImpureClass: 0,
   PureClass: 1,
   StatelessFunctional: 2,
 };
-
-module.exports = CompositeTypes;

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponentTypes.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponentTypes.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactCompositeComponentTypes
+ * @flow
+ */
+
+
+var CompositeTypes = {
+  ImpureClass: 0,
+  PureClass: 1,
+  StatelessFunctional: 2,
+};
+
+module.exports = CompositeTypes;

--- a/src/renderers/shared/stack/reconciler/ReactInstanceType.js
+++ b/src/renderers/shared/stack/reconciler/ReactInstanceType.js
@@ -13,6 +13,7 @@
 'use strict';
 
 import type {ReactElement} from 'ReactElementType';
+import type {CompositeComponentTypes} from 'ReactCompositeComponentTypes';
 
 export type DebugID = number;
 
@@ -34,6 +35,7 @@ export type ReactInstance = {
   attachRef: (ref: string, component: ReactInstance) => void,
   detachRef: (ref: string) => void,
   _rootNodeID: number,
+  _compositeType: CompositeComponentTypes,
 
   // ReactDOMComponent
   _tag: string,

--- a/src/renderers/shared/stack/reconciler/ReactRef.js
+++ b/src/renderers/shared/stack/reconciler/ReactRef.js
@@ -19,8 +19,23 @@ import type { ReactElement } from 'ReactElementType';
 
 var ReactRef = {};
 
+if (__DEV__) {
+  var ReactCompositeComponentTypes = require('ReactCompositeComponentTypes');
+  var ReactComponentTreeHook = require('ReactComponentTreeHook');
+  var warning = require('warning');
+}
+
 function attachRef(ref, component, owner) {
   if (typeof ref === 'function') {
+    if (__DEV__) {
+      warning(
+        /* $FlowFixMe component._compositeType really exists I swear. */
+        component._compositeType !== ReactCompositeComponentTypes.StatelessFunctional,
+        'Stateless function components cannot be given refs. ' +
+        'Attempts to access this ref will fail.%s',
+        ReactComponentTreeHook.getStackAddendumByID((owner || component)._debugID)
+      );
+    }
     ref(component.getPublicInstance());
   } else {
     // Legacy ref

--- a/src/renderers/shared/stack/reconciler/ReactRef.js
+++ b/src/renderers/shared/stack/reconciler/ReactRef.js
@@ -43,7 +43,6 @@ function attachRef(ref, component, owner) {
     }
 
     warning(
-      /* $FlowFixMe component._compositeType really exists I swear. */
       component._compositeType !== ReactCompositeComponentTypes.StatelessFunctional,
       'Stateless function components cannot be given refs. ' +
       'Attempts to access this ref will fail.%s%s',

--- a/src/renderers/shared/stack/reconciler/ReactRef.js
+++ b/src/renderers/shared/stack/reconciler/ReactRef.js
@@ -28,11 +28,18 @@ if (__DEV__) {
 function attachRef(ref, component, owner) {
   if (typeof ref === 'function') {
     if (__DEV__) {
+      let info = '';
+      const ownerName = owner && owner.getName();
+      if (ownerName) {
+        info += ' Check the render method of `' + ownerName + '`.';
+      }
+
       warning(
         /* $FlowFixMe component._compositeType really exists I swear. */
         component._compositeType !== ReactCompositeComponentTypes.StatelessFunctional,
         'Stateless function components cannot be given refs. ' +
-        'Attempts to access this ref will fail.%s',
+        'Attempts to access this ref will fail.%s%s',
+        info,
         ReactComponentTreeHook.getStackAddendumByID((owner || component)._debugID)
       );
     }

--- a/src/renderers/shared/stack/reconciler/ReactRef.js
+++ b/src/renderers/shared/stack/reconciler/ReactRef.js
@@ -22,27 +22,37 @@ var ReactRef = {};
 if (__DEV__) {
   var ReactCompositeComponentTypes = require('ReactCompositeComponentTypes');
   var ReactComponentTreeHook = require('ReactComponentTreeHook');
+  var ReactDebugCurrentFiber = require('ReactDebugCurrentFiber');
   var warning = require('warning');
 }
 
 function attachRef(ref, component, owner) {
-  if (typeof ref === 'function') {
-    if (__DEV__) {
-      let info = '';
-      const ownerName = owner && owner.getName();
+  if (__DEV__) {
+    let info = '';
+    if (owner) {
+      let ownerName;
+      if (typeof owner.getName === 'function') {
+        ownerName = owner.getName();
+      } else {
+        // if we're working on stack inside of fiber
+        ownerName = ReactDebugCurrentFiber.getCurrentFiberOwnerName();
+      }
       if (ownerName) {
         info += ' Check the render method of `' + ownerName + '`.';
       }
-
-      warning(
-        /* $FlowFixMe component._compositeType really exists I swear. */
-        component._compositeType !== ReactCompositeComponentTypes.StatelessFunctional,
-        'Stateless function components cannot be given refs. ' +
-        'Attempts to access this ref will fail.%s%s',
-        info,
-        ReactComponentTreeHook.getStackAddendumByID((owner || component)._debugID)
-      );
     }
+
+    warning(
+      /* $FlowFixMe component._compositeType really exists I swear. */
+      component._compositeType !== ReactCompositeComponentTypes.StatelessFunctional,
+      'Stateless function components cannot be given refs. ' +
+      'Attempts to access this ref will fail.%s%s',
+      info,
+      ReactComponentTreeHook.getStackAddendumByID(component._debugID)
+    );
+  }
+
+  if (typeof ref === 'function') {
     ref(component.getPublicInstance());
   } else {
     // Legacy ref

--- a/src/renderers/shared/stack/reconciler/ReactRef.js
+++ b/src/renderers/shared/stack/reconciler/ReactRef.js
@@ -22,7 +22,6 @@ var ReactRef = {};
 if (__DEV__) {
   var ReactCompositeComponentTypes = require('ReactCompositeComponentTypes');
   var ReactComponentTreeHook = require('ReactComponentTreeHook');
-  var ReactDebugCurrentFiber = require('ReactDebugCurrentFiber');
   var warning = require('warning');
 }
 
@@ -33,9 +32,6 @@ function attachRef(ref, component, owner) {
       let ownerName;
       if (typeof owner.getName === 'function') {
         ownerName = owner.getName();
-      } else {
-        // if we're working on stack inside of fiber
-        ownerName = ReactDebugCurrentFiber.getCurrentFiberOwnerName();
       }
       if (ownerName) {
         info += ' Check the render method of `' + ownerName + '`.';

--- a/src/renderers/testing/__tests__/ReactTestRenderer-test.js
+++ b/src/renderers/testing/__tests__/ReactTestRenderer-test.js
@@ -234,9 +234,9 @@ describe('ReactTestRenderer', () => {
     ReactTestRenderer.create(<Baz />);
     ReactTestRenderer.create(<Foo />);
     expectDev(console.error.calls.count()).toBe(1);
-    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toContain(
-      'Stateless function components cannot be given refs. ' +
-      'Attempts to access this ref will fail.\n' +
+    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+      'Warning: Stateless function components cannot be given refs. Attempts ' +
+      'to access this ref will fail. Check the render method of `Foo`.\n' +
       '    in Foo (at **)'
     );
   });

--- a/src/renderers/testing/__tests__/ReactTestRenderer-test.js
+++ b/src/renderers/testing/__tests__/ReactTestRenderer-test.js
@@ -15,6 +15,9 @@ var React = require('React');
 var ReactTestRenderer = require('ReactTestRenderer');
 
 describe('ReactTestRenderer', () => {
+  function normalizeCodeLocInfo(str) {
+    return str && str.replace(/\(at .+?:\d+\)/g, '(at **)');
+  }
 
   it('renders a simple component', () => {
     function Link() {
@@ -231,10 +234,10 @@ describe('ReactTestRenderer', () => {
     ReactTestRenderer.create(<Baz />);
     ReactTestRenderer.create(<Foo />);
     expectDev(console.error.calls.count()).toBe(1);
-    expectDev(console.error.calls.argsFor(0)[0]).toContain(
-      'Stateless function components cannot be given refs ' +
-      '(See ref "foo" in Bar created by Foo). ' +
-      'Attempts to access this ref will fail.'
+    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toContain(
+      'Stateless function components cannot be given refs. ' +
+      'Attempts to access this ref will fail.\n' +
+      '    in Foo (at **)'
     );
   });
 

--- a/src/renderers/testing/__tests__/ReactTestRenderer-test.js
+++ b/src/renderers/testing/__tests__/ReactTestRenderer-test.js
@@ -237,6 +237,7 @@ describe('ReactTestRenderer', () => {
     expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
       'Warning: Stateless function components cannot be given refs. Attempts ' +
       'to access this ref will fail. Check the render method of `Foo`.\n' +
+      '    in Bar (at **)\n' +
       '    in Foo (at **)'
     );
   });


### PR DESCRIPTION
**For the changelog, this also implements #7267 in Stack.**
It implements it for Fiber too, in addition to other Stack-related Fiber warnings and invariants.

==========

While working on the fiber implementation of ReactTestRenderer I came across this warning which is not yet implemented for fiber.

Initial questions:

* Are there any areas of the fiber impl where errors and warnings are expected to live? This is the first instance added to BeginWork which I think may indicate this warning should exist elsewhere
* This doesn’t actually stop any ref from being attached. How should that be done?
* A related test seems to show refs throwing an error if used on a top-level SFC. Should that exist in the same area of the code or elsewhere?