### PR TITLE
[Fiber] Include owner in invalid element type invariant

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -9,9 +9,6 @@ src/addons/__tests__/ReactFragment-test.js
 src/isomorphic/classic/__tests__/ReactContextValidator-test.js
 * should pass previous context to lifecycles
 
-src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
-* includes the owner name when passing null, undefined, boolean, or number
-
 src/renderers/dom/__tests__/ReactDOMProduction-test.js
 * should throw with an error code in production
 
@@ -62,9 +59,6 @@ src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.js
 
 src/renderers/shared/hooks/__tests__/ReactHostOperationHistoryHook-test.js
 * gets recorded during an update
-
-src/renderers/shared/shared/__tests__/ReactComponent-test.js
-* includes owner name in the error about badly-typed elements
 
 src/renderers/shared/shared/__tests__/ReactComponentLifeCycle-test.js
 * should carry through each of the phases of setup

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -287,6 +287,7 @@ src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
 * does not warn when the array contains a non-element
 * should give context for PropType errors in nested components.
 * gives a helpful error when passing invalid types
+* includes the owner name when passing null, undefined, boolean, or number
 * should check default prop values
 * should not check the default for explicit null
 * should check declared prop types
@@ -1334,6 +1335,7 @@ src/renderers/shared/shared/__tests__/ReactComponent-test.js
 * should call refs at the correct time
 * fires the callback after a component is rendered
 * throws usefully when rendering badly-typed elements
+* includes owner name in the error about badly-typed elements
 
 src/renderers/shared/shared/__tests__/ReactComponentLifeCycle-test.js
 * should not reuse an instance when it has been unmounted

--- a/src/renderers/shared/fiber/ReactDebugCurrentFiber.js
+++ b/src/renderers/shared/fiber/ReactDebugCurrentFiber.js
@@ -15,6 +15,12 @@
 import type { Fiber } from 'ReactFiber';
 
 if (__DEV__) {
+  var {
+    IndeterminateComponent,
+    FunctionalComponent,
+    ClassComponent,
+    HostComponent,
+  } = require('ReactTypeOfWork');
   var getComponentName = require('getComponentName');
   var { getStackAddendumByWorkInProgressFiber } = require('ReactComponentTreeHook');
 }
@@ -25,10 +31,19 @@ function getCurrentFiberOwnerName() : string | null {
     if (fiber == null) {
       return null;
     }
-    if (fiber._debugOwner == null) {
-      return null;
+    switch (fiber.tag) {
+      case IndeterminateComponent:
+      case FunctionalComponent:
+      case ClassComponent:
+        return getComponentName(fiber);
+      case HostComponent:
+        if (fiber._debugOwner != null) {
+          return getComponentName(fiber._debugOwner);
+        }
+        return null;
+      default:
+        return null;
     }
-    return getComponentName(fiber._debugOwner);
   }
   return null;
 }

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -49,6 +49,10 @@ var {
 
 var invariant = require('invariant');
 
+if (__DEV__) {
+  var { getCurrentFiberOwnerName } = require('ReactDebugCurrentFiber');
+}
+
 // A Fiber is work on a Component that needs to be done or was done. There can
 // be more than one per component.
 export type Fiber = {
@@ -359,8 +363,11 @@ function createFiberFromElementType(type : mixed, key : null | string) : Fiber {
           ' You likely forgot to export your component from the file ' +
           'it\'s defined in.';
       }
+      const ownerName = getCurrentFiberOwnerName();
+      if (ownerName) {
+        info += ' Check the render method of `' + ownerName + '`.';
+      }
     }
-    // TODO: Stack also includes owner name in the message.
     invariant(
       false,
       'Element type is invalid: expected a string (for built-in components) ' +

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
@@ -754,7 +754,7 @@ describe('ReactIncrementalErrorHandling', () => {
       'Element type is invalid: expected a string (for built-in components) or ' +
       'a class/function (for composite components) but got: undefined. ' +
       'You likely forgot to export your component from the file it\'s ' +
-      'defined in.'
+      'defined in. Check the render method of `BrokenRender`.'
     )]);
     expect(console.error.calls.count()).toBe(1);
   });
@@ -798,7 +798,7 @@ describe('ReactIncrementalErrorHandling', () => {
       'Element type is invalid: expected a string (for built-in components) or ' +
       'a class/function (for composite components) but got: undefined. ' +
       'You likely forgot to export your component from the file it\'s ' +
-      'defined in.'
+      'defined in. Check the render method of `BrokenRender`.'
     )]);
     expect(console.error.calls.count()).toBe(1);
   });


### PR DESCRIPTION
This adds owner to invalid type invariant for Fiber. It's already there in Stack.
Ideally we'd add component stack later here too, but I want parity for now.

I changed `ReactDebugCurrentFiber.getCurrentFiberOwnerName()` because it used to only work for host components since I first added it when working on DOM invariants/warnings. The problem is it didn't report the owner name when the owner is the current fiber itself. This is now fixed with an explicit switch on fiber tag.

@iamdustan Since you're looking at Fiber and warnings would you like to review this?