### PR TITLE
[Fiber] Fix rendering SVG into non-React SVG tree

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -26,9 +26,6 @@ src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * gives source code refs for unknown prop warning for exact elements (ssr)
 * gives source code refs for unknown prop warning for exact elements in composition (ssr)
 
-src/renderers/dom/shared/__tests__/ReactDOMSVG-test.js
-* can render SVG into a non-React SVG tree
-
 src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
 * can reconcile text merged by Node.normalize() alongside other elements
 * can reconcile text merged by Node.normalize()

--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -26,6 +26,9 @@ src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * gives source code refs for unknown prop warning for exact elements (ssr)
 * gives source code refs for unknown prop warning for exact elements in composition (ssr)
 
+src/renderers/dom/shared/__tests__/ReactDOMSVG-test.js
+* can render SVG into a non-React SVG tree
+
 src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
 * can reconcile text merged by Node.normalize() alongside other elements
 * can reconcile text merged by Node.normalize()

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -727,6 +727,7 @@ src/renderers/dom/shared/__tests__/ReactDOMSVG-test.js
 * creates initial namespaced markup
 * creates elements with SVG namespace inside SVG tag during mount
 * creates elements with SVG namespace inside SVG tag during update
+* can render SVG into a non-React SVG tree
 * can render HTML into a foreignObject in non-React SVG tree
 
 src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -727,6 +727,7 @@ src/renderers/dom/shared/__tests__/ReactDOMSVG-test.js
 * creates initial namespaced markup
 * creates elements with SVG namespace inside SVG tag during mount
 * creates elements with SVG namespace inside SVG tag during update
+* can render HTML into a foreignObject in non-React SVG tree
 
 src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
 * updates a mounted text component in place

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -99,14 +99,16 @@ function validateContainer(container) {
 var DOMRenderer = ReactFiberReconciler({
 
   getRootHostContext(rootContainerInstance : Container) : HostContext {
-    const type = rootContainerInstance.tagName.toLowerCase();
+    const ownNamespace = rootContainerInstance.namespaceURI || null;
+    const type = rootContainerInstance.tagName;
+    const namespace = getChildNamespace(ownNamespace, type);
     if (__DEV__) {
-      const namespace = getChildNamespace(null, type);
       const isMountingIntoDocument = rootContainerInstance.ownerDocument.documentElement === rootContainerInstance;
-      const ancestorInfo = updatedAncestorInfo(null, isMountingIntoDocument ? '#document' : type, null);
+      const validatedTag = isMountingIntoDocument ? '#document' : type.toLowerCase();
+      const ancestorInfo = updatedAncestorInfo(null, validatedTag, null);
       return {namespace, ancestorInfo};
     }
-    return getChildNamespace(null, type);
+    return namespace;
   },
 
   getChildHostContext(

--- a/src/renderers/dom/shared/__tests__/ReactDOMSVG-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMSVG-test.js
@@ -157,4 +157,17 @@ describe('ReactDOMSVG', () => {
     });
   });
 
+  it('can render SVG into a non-React SVG tree', () => {
+    var outerSVGRoot = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    var container = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    outerSVGRoot.appendChild(container);
+    var image;
+    ReactDOM.render(
+      <image ref={el => image = el} />,
+      container
+    );
+    expect(image.namespaceURI).toBe('http://www.w3.org/2000/svg');
+    expect(image.tagName).toBe('image');
+  });
+
 });

--- a/src/renderers/dom/shared/__tests__/ReactDOMSVG-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMSVG-test.js
@@ -170,4 +170,17 @@ describe('ReactDOMSVG', () => {
     expect(image.tagName).toBe('image');
   });
 
+  it('can render HTML into a foreignObject in non-React SVG tree', () => {
+    var outerSVGRoot = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    var container = document.createElementNS('http://www.w3.org/2000/svg', 'foreignObject');
+    outerSVGRoot.appendChild(container);
+    var div;
+    ReactDOM.render(
+      <div ref={el => div = el} />,
+      container
+    );
+    expect(div.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
+    expect(div.tagName).toBe('DIV');
+  });
+
 });

--- a/src/renderers/dom/shared/__tests__/ReactDOMSVG-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMSVG-test.js
@@ -13,6 +13,7 @@
 
 var React;
 var ReactDOM;
+var ReactDOMFeatureFlags;
 var ReactDOMServer;
 
 describe('ReactDOMSVG', () => {
@@ -20,6 +21,7 @@ describe('ReactDOMSVG', () => {
   beforeEach(() => {
     React = require('React');
     ReactDOM = require('ReactDOM');
+    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
     ReactDOMServer = require('ReactDOMServer');
   });
 
@@ -171,6 +173,15 @@ describe('ReactDOMSVG', () => {
   });
 
   it('can render HTML into a foreignObject in non-React SVG tree', () => {
+    if (!ReactDOMFeatureFlags.useCreateElement) {
+      // jsdom doesn't give HTML namespace to foreignObject.innerHTML children.
+      // This problem doesn't exist in the browsers.
+      // https://github.com/facebook/react/pull/8638#issuecomment-269349642
+      // We will skip this test in non-createElement mode considering
+      // that non-createElement mounting is effectively dead code now anyway.
+      return;
+    }
+
     var outerSVGRoot = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     var container = document.createElementNS('http://www.w3.org/2000/svg', 'foreignObject');
     outerSVGRoot.appendChild(container);


### PR DESCRIPTION
We used to determine the root tree namespace by the tag name alone in Fiber.

However this was broken for cases when we render an SVG tree into another SVG tree outside React.

This PR introduces a few new tests and fixes this by reading namespace from the root container, and using it in conjunction with the tag to determine child namespace.

Addresses https://github.com/facebook/react/pull/8586/files/414f1ec324bbce828c84900d66d202b5d776b6aa#r93161706.