### PR TITLE
[Fiber] Relax test about rendering top-level null

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -74,7 +74,6 @@ src/renderers/shared/shared/__tests__/ReactCompositeComponent-test.js
 
 src/renderers/shared/shared/__tests__/ReactEmptyComponent-test.js
 * should still throw when rendering to undefined
-* throws when rendering null at the top level
 
 src/renderers/shared/shared/__tests__/ReactMultiChildText-test.js
 * should reorder keyed text nodes

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1403,6 +1403,7 @@ src/renderers/shared/shared/__tests__/ReactEmptyComponent-test.js
 * should distinguish between a script placeholder and an actual script tag
 * should have findDOMNode return null when multiple layers of composite components render to the same null placeholder
 * works when switching components
+* can render null at the top level
 * does not break when updating during mount
 * preserves the dom node during updates
 

--- a/src/renderers/shared/shared/__tests__/ReactEmptyComponent-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactEmptyComponent-test.js
@@ -246,14 +246,20 @@ describe('ReactEmptyComponent', () => {
     expect(assertions).toBe(3);
   });
 
-  it('throws when rendering null at the top level', () => {
-    // TODO: This should actually work since `null` is a valid ReactNode
+  it('can render null at the top level', () => {
     var div = document.createElement('div');
-    expect(function() {
+
+    if (ReactDOMFeatureFlags.useFiber) {
       ReactDOM.render(null, div);
-    }).toThrowError(
-      'ReactDOM.render(): Invalid component element.'
-    );
+      expect(div.innerHTML).toBe('');
+    } else {
+      // Stack does not implement this.
+      expect(function() {
+        ReactDOM.render(null, div);
+      }).toThrowError(
+        'ReactDOM.render(): Invalid component element.'
+      );
+    }
   });
 
   it('does not break when updating during mount', () => {


### PR DESCRIPTION
It asserts error but this is no longer supposed to be an error in Fiber.