### PR TITLE
Added memoization test for interrupted low-priority renders

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1174,6 +1174,7 @@ src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
 * maintains the correct context when providers bail out due to low priority
 * maintains the correct context when unwinding due to an error in render
 * should not recreate masked context unless inputs have changed
+* should reuse memoized work if pointers are updated before calling lifecycles
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
 * catches render error in a boundary during full deferred mounting


### PR DESCRIPTION
Added a test to verify that a high-priority update can reuse the children from an aborted low-priority update if `shouldComponentUpdate` returns false.

(Note that this PR is now different from the original. The original description is preserved below so that the subsequent discussion on this PR makes sense.)

#### Previous Description (no longer valid)

`this.props` and `this.context` are not reset when a render is interrupted mid-way and overridden by a subsequent, higher-priority update. The result is that a subsequent calls to `shouldComponentUpdate` will yield unexpected results<sup>1</sup> when comparing `this.props` and `this.context` to the provided `nexProps` and `nexContext`.

This PR captures the behavior in a (failing) unit test. Posting for discussion purposes.

* <sup>1</sup> It is unclear if this is intentional behavior. I don't _think_ it causes any problems but it was not what I expected initially.