### PR TITLE
[Fiber] Throw on undefined component output

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -66,14 +66,10 @@ src/renderers/shared/shared/__tests__/ReactComponentLifeCycle-test.js
 src/renderers/shared/shared/__tests__/ReactCompositeComponent-test.js
 * should update refs if shouldComponentUpdate gives false
 
-src/renderers/shared/shared/__tests__/ReactEmptyComponent-test.js
-* should still throw when rendering to undefined
-
 src/renderers/shared/shared/__tests__/ReactMultiChildText-test.js
 * should reorder keyed text nodes
 
 src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
-* should throw when stateless component returns undefined
 * should throw on string refs in pure functions
 
 src/renderers/shared/shared/__tests__/ReactUpdates-test.js

--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -73,9 +73,8 @@ src/renderers/shared/shared/__tests__/ReactMultiChildText-test.js
 * should reorder keyed text nodes
 
 src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
-* should warn when stateless component returns array
+* should throw when stateless component returns undefined
 * should throw on string refs in pure functions
-* should warn when using non-React functions in JSX
 
 src/renderers/shared/shared/__tests__/ReactUpdates-test.js
 * marks top-level updates

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1400,6 +1400,7 @@ src/renderers/shared/shared/__tests__/ReactCompositeComponentState-test.js
 
 src/renderers/shared/shared/__tests__/ReactEmptyComponent-test.js
 * should not produce child DOM nodes for null and false
+* should still throw when rendering to undefined
 * should be able to switch between rendering null and a normal tag
 * should be able to switch in a list of children
 * should distinguish between a script placeholder and an actual script tag
@@ -1526,6 +1527,7 @@ src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
 * should update stateless component
 * should unmount stateless component
 * should pass context thru stateless component
+* should throw when stateless component returns undefined
 * should provide a null ref
 * should use correct name in key warning
 * should support default props and prop types

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -956,6 +956,7 @@ describe('ReactIncremental', () => {
 
     function Trail() {
       ops.push('Trail');
+      return null;
     }
 
     function App(props) {

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
@@ -496,6 +496,7 @@ describe('ReactIncrementalErrorHandling', () => {
       if (props.throw) {
         throw new Error('Hello');
       }
+      return null;
     }
 
     function Foo() {

--- a/src/renderers/shared/shared/__tests__/ReactEmptyComponent-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactEmptyComponent-test.js
@@ -72,15 +72,21 @@ describe('ReactEmptyComponent', () => {
   });
 
   it('should still throw when rendering to undefined', () => {
-    class Component extends React.Component {
+    class MyComponent extends React.Component {
       render() {}
     }
 
     expect(function() {
-      ReactTestUtils.renderIntoDocument(<Component />);
+      ReactTestUtils.renderIntoDocument(<MyComponent />);
     }).toThrowError(
-      'Component.render(): A valid React element (or null) must be returned. You may ' +
-      'have returned undefined, an array or some other invalid object.'
+      ReactDOMFeatureFlags.useFiber ? (
+        'A valid React element, null, or an array must be returned. ' +
+        'You may have returned undefined or some other invalid object. ' +
+        'Check the render method of `MyComponent`.'
+      ) : (
+        'MyComponent.render(): A valid React element (or null) must be returned. You may ' +
+        'have returned undefined, an array or some other invalid object.'
+      )
     );
   });
 

--- a/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
@@ -15,6 +15,8 @@ var React;
 var ReactDOM;
 var ReactTestUtils;
 
+var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
+
 function StatelessComponent(props) {
   return <div>{props.name}</div>;
 }
@@ -119,17 +121,20 @@ describe('ReactStatelessComponent', () => {
     );
   });
 
-  it('should throw when stateless component returns array', () => {
-    function NotAComponent() {
-      return [<div />, <div />];
-    }
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(<div><NotAComponent /></div>);
-    }).toThrowError(
-      'NotAComponent(...): A valid React element (or null) must be returned. ' +
-      'You may have returned undefined, an array or some other invalid object.'
-    );
-  });
+  if (!ReactDOMFeatureFlags.useFiber) {
+    // Stack doesn't support fragments
+    it('should throw when stateless component returns array', () => {
+      function NotAComponent() {
+        return [<div />, <div />];
+      }
+      expect(function() {
+        ReactTestUtils.renderIntoDocument(<div><NotAComponent /></div>);
+      }).toThrowError(
+        'NotAComponent(...): A valid React element (or null) must be returned. ' +
+        'You may have returned undefined, an array or some other invalid object.'
+      );
+    });
+  }
 
   it('should throw when stateless component returns undefined', () => {
     function NotAComponent() {

--- a/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
@@ -119,30 +119,24 @@ describe('ReactStatelessComponent', () => {
     );
   });
 
-  it('should warn when stateless component returns array', () => {
-    spyOn(console, 'error');
+  it('should throw when stateless component returns array', () => {
     function NotAComponent() {
       return [<div />, <div />];
     }
     expect(function() {
       ReactTestUtils.renderIntoDocument(<div><NotAComponent /></div>);
-    }).toThrow();
-    expectDev(console.error.calls.count()).toBe(1);
-    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+    }).toThrowError(
       'NotAComponent(...): A valid React element (or null) must be returned. ' +
       'You may have returned undefined, an array or some other invalid object.'
     );
   });
 
-  it('should warn when stateless component returns undefined', () => {
-    spyOn(console, 'error');
+  it('should throw when stateless component returns undefined', () => {
     function NotAComponent() {
     }
     expect(function() {
       ReactTestUtils.renderIntoDocument(<div><NotAComponent /></div>);
-    }).toThrow();
-    expectDev(console.error.calls.count()).toBe(1);
-    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+    }).toThrowError(
       'NotAComponent(...): A valid React element (or null) must be returned. ' +
       'You may have returned undefined, an array or some other invalid object.'
     );

--- a/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
@@ -271,18 +271,4 @@ describe('ReactStatelessComponent', () => {
     expect(() => ReactTestUtils.renderIntoDocument(<Child />)).not.toThrow();
   });
 
-  it('should warn when using non-React functions in JSX', () => {
-    spyOn(console, 'error');
-    function NotAComponent() {
-      return [<div />, <div />];
-    }
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(<div><NotAComponent /></div>);
-    }).toThrow();  // has no method 'render'
-    expectDev(console.error.calls.count()).toBe(1);
-    expectDev(console.error.calls.argsFor(0)[0]).toContain(
-      'NotAComponent(...): A valid React element (or null) must be returned. You may ' +
-      'have returned undefined, an array or some other invalid object.'
-    );
-  });
 });

--- a/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
@@ -142,8 +142,14 @@ describe('ReactStatelessComponent', () => {
     expect(function() {
       ReactTestUtils.renderIntoDocument(<div><NotAComponent /></div>);
     }).toThrowError(
-      'NotAComponent(...): A valid React element (or null) must be returned. ' +
-      'You may have returned undefined, an array or some other invalid object.'
+      ReactDOMFeatureFlags.useFiber ? (
+        'A valid React element, null, or an array must be returned. ' +
+        'You may have returned undefined or some other invalid object. ' +
+        'Check the render method of `NotAComponent`.'
+      ) : (
+        'NotAComponent(...): A valid React element (or null) must be returned. You may ' +
+        'have returned undefined, an array or some other invalid object.'
+      )
     );
   });
 

--- a/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
@@ -134,6 +134,20 @@ describe('ReactStatelessComponent', () => {
     );
   });
 
+  it('should warn when stateless component returns undefined', () => {
+    spyOn(console, 'error');
+    function NotAComponent() {
+    }
+    expect(function() {
+      ReactTestUtils.renderIntoDocument(<div><NotAComponent /></div>);
+    }).toThrow();
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      'NotAComponent(...): A valid React element (or null) must be returned. ' +
+      'You may have returned undefined, an array or some other invalid object.'
+    );
+  });
+
   it('should throw on string refs in pure functions', () => {
     function Child() {
       return <div ref="me" />;

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -44,25 +44,8 @@ function StatelessComponent(Component) {
 StatelessComponent.prototype.render = function() {
   var Component = ReactInstanceMap.get(this)._currentElement.type;
   var element = Component(this.props, this.context, this.updater);
-  warnIfInvalidElement(Component, element);
   return element;
 };
-
-function warnIfInvalidElement(Component, element) {
-  if (__DEV__) {
-    warning(
-      element === null || element === false || React.isValidElement(element),
-      '%s(...): A valid React element (or null) must be returned. You may have ' +
-      'returned undefined, an array or some other invalid object.',
-      Component.displayName || Component.name || 'Component'
-    );
-    warning(
-      !Component.childContextTypes,
-      '%s(...): childContextTypes cannot be defined on a functional component.',
-      Component.displayName || Component.name || 'Component'
-    );
-  }
-}
 
 function shouldConstruct(Component) {
   return !!(Component.prototype && Component.prototype.isReactComponent);
@@ -210,7 +193,13 @@ var ReactCompositeComponent = {
     // Support functional components
     if (!doConstruct && (inst == null || inst.render == null)) {
       renderedElement = inst;
-      warnIfInvalidElement(Component, renderedElement);
+      if (__DEV__) {
+        warning(
+          !Component.childContextTypes,
+          '%s(...): childContextTypes cannot be defined on a functional component.',
+          Component.displayName || Component.name || 'Component'
+        );
+      }
       invariant(
         inst === null ||
         inst === false ||


### PR DESCRIPTION
This removes an (in my opinion) unnecessary duplicate warning from Stack so that I don't have to reimplement it in Fiber. Then it changes Fiber to throw on undefined component output.

See individual commits. Only the last commit affects Fiber, the rest are tweaking Stack and tests.