### PR TITLE
'npm init' needed before installing react via npm.

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -52,13 +52,14 @@ We recommend using [Yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/)
 To install React with Yarn, run:
 
 ```bash
+yarn init
 yarn add react react-dom
 ```
 
 To install React with npm, run:
-(Note: You may need to run ```npm init``` from your project's root directory before you run the command below so that package.json is created if not already present)
 
 ```bash
+npm init
 npm install --save react react-dom
 ```
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -56,6 +56,7 @@ yarn add react react-dom
 ```
 
 To install React with npm, run:
+(Note: You may need to run ```npm init``` from your project's root directory before you run the command below so that package.json is created if not already present)
 
 ```bash
 npm install --save react react-dom


### PR DESCRIPTION
I was trying to install react in my django project directory and was getting warnings about package.json not being present. Started this SO post (http://stackoverflow.com/questions/41340909/npm-cant-find-package-json-when-installing-react/41340975#41340975) to figure it out. I think it'll be useful to others too if we add it in the documentation itself.

*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure the test suite passes (`npm test`).
5. Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.
6. If you haven't already, complete the [CLA](https://code.facebook.com/cla).
