### PR TITLE
[Fiber] Move memoization to begin phase

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -1,6 +1,3 @@
-src/addons/__tests__/ReactComponentWithPureRenderMixin-test.js
-* does not do a deep comparison
-
 src/addons/__tests__/ReactFragment-test.js
 * should throw if a plain object is used as a child
 * should throw if a plain object even if it is in an owner

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1143,6 +1143,7 @@ src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
 * can resume work in a subtree even when a parent bails out
 * can resume work in a bailed subtree within one pass
 * can reuse work done after being preempted
+* can reuse work that began but did not complete, after being preempted
 * can reuse work if shouldComponentUpdate is false, after being preempted
 * memoizes work even if shouldComponentUpdate returns false
 * can update in the middle of a tree using setState

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -36,6 +36,7 @@ scripts/error-codes/__tests__/invertObject-test.js
 
 src/addons/__tests__/ReactComponentWithPureRenderMixin-test.js
 * provides a default shouldComponentUpdate implementation
+* does not do a deep comparison
 
 src/addons/__tests__/ReactFragment-test.js
 * warns for numeric keys on objects as children
@@ -1143,6 +1144,7 @@ src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
 * can resume work in a bailed subtree within one pass
 * can reuse work done after being preempted
 * can reuse work if shouldComponentUpdate is false, after being preempted
+* memoizes work even if shouldComponentUpdate returns false
 * can update in the middle of a tree using setState
 * can queue multiple state updates
 * can use updater form of setState

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1410,6 +1410,7 @@ src/renderers/shared/shared/__tests__/ReactCompositeComponentState-test.js
 * should call componentDidUpdate of children first
 * should batch unmounts
 * should update state when called from child cWRP
+* should merge state when sCU returns false
 
 src/renderers/shared/shared/__tests__/ReactEmptyComponent-test.js
 * should not produce child DOM nodes for null and false

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -266,7 +266,6 @@ module.exports = function<T, P, I, TI, PI, C, CX>(
           const textInstance = createTextInstance(newText, rootContainerInstance, currentHostContext, workInProgress);
           workInProgress.stateNode = textInstance;
         }
-        workInProgress.memoizedProps = newText;
         return null;
       case CoroutineComponent:
         return moveCoroutineToHandlerPhase(current, workInProgress);

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -442,10 +442,6 @@ module.exports = function<T, P, I, TI, PI, C, CX>(config : HostConfig<T, P, I, T
       const current = workInProgress.alternate;
       const next = completeWork(current, workInProgress);
 
-      // The work is now done. We don't need this anymore. This flags
-      // to the system not to redo any work here.
-      workInProgress.pendingProps = null;
-
       const returnFiber = workInProgress.return;
       const siblingFiber = workInProgress.sibling;
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -667,7 +667,7 @@ describe('ReactIncrementalSideEffects', () => {
       ),
     ]);
 
-    expect(ops).toEqual(['Foo', 'Baz', 'Bar']);
+    expect(ops).toEqual(['Foo']);
     ops = [];
 
     ReactNoop.flush();
@@ -861,7 +861,7 @@ describe('ReactIncrementalSideEffects', () => {
       ),
     ]);
 
-    expect(ops).toEqual(['Bar', 'Bar']);
+    expect(ops).toEqual(['Bar']);
   });
   // TODO: Test that side-effects are not cut off when a work in progress node
   // moves to "current" without flushing due to having lower priority. Does this

--- a/src/renderers/shared/shared/__tests__/ReactCompositeComponentState-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactCompositeComponentState-test.js
@@ -385,4 +385,32 @@ describe('ReactCompositeComponent-state', () => {
       'child render two',
     ]);
   });
+
+  it('should merge state when sCU returns false', function() {
+    const log = [];
+    class Test extends React.Component {
+      state = {a: 0};
+      render() {
+        return null;
+      }
+      shouldComponentUpdate(nextProps, nextState) {
+        log.push(
+          'scu from ' + Object.keys(this.state) +
+          ' to ' + Object.keys(nextState)
+        );
+        return false;
+      }
+    }
+
+    const container = document.createElement('div');
+    const test = ReactDOM.render(<Test />, container);
+    test.setState({b: 0});
+    expect(log.length).toBe(1);
+    test.setState({c: 0});
+    expect(log.length).toBe(2);
+    expect(log).toEqual([
+      'scu from a to a,b',
+      'scu from a,b to a,b,c',
+    ]);
+  });
 });


### PR DESCRIPTION
Because `memoizedProps` and `memoizedState` are read from the instance, the
instance's input pointers (`props`, `state`, `context`) should be updated even
when `shouldComponentUpdate` causes a bail-out.

## Update

The scope of this PR changed a bit. The main change is to move memoization to the begin phase, right after reconciliation.

Currently we update the memoized inputs (props, state) during the complete phase, as we go back up the tree. That means we can't reuse work until of its children have completed.

By moving memoization to the begin phase, we can do a shallow bailout, reusing a unit of work even if there's still work to do in its children.

Memoization now happens whenever a fiber's `child` property is updated; typically, right after reconciling. It's also updated when `shouldComponentUpdate` returns false, because that indicates that the given state and props are equal to the memoized state and props.