### PR TITLE
Resolve #8656 WebComponent 1.0 support.

### DIFF
--- a/docs/docs/web-components.md
+++ b/docs/docs/web-components.md
@@ -42,19 +42,17 @@ function BrickFlipbox() {
 ## Using React in your Web Components
 
 ```javascript
-const proto = Object.create(HTMLElement.prototype, {
-  attachedCallback: {
-    value: function() {
-      const mountPoint = document.createElement('span');
-      this.createShadowRoot().appendChild(mountPoint);
+class XSearch extends HTMLElement.prototype {
+  constructor() {
+    const mountPoint = document.createElement('span');
+    this.attachShadow({mode: 'open'}).appendChild(mountPoint);
 
-      const name = this.getAttribute('name');
-      const url = 'https://www.google.com/search?q=' + encodeURIComponent(name);
-      ReactDOM.render(<a href={url}>{name}</a>, mountPoint);
-    }
+    const name = this.getAttribute('name');
+    const url = 'https://www.google.com/search?q=' + encodeURIComponent(name);
+    ReactDOM.render(<a href={url}>{name}</a>, mountPoint);
   }
-});
-document.registerElement('x-search', {prototype: proto});
+}
+customElements.define('x-search', XSearch);
 ```
 
 You can also check out this [complete Web Components example on GitHub](https://github.com/facebook/react/tree/master/examples/webcomponents).

--- a/examples/webcomponents/index.html
+++ b/examples/webcomponents/index.html
@@ -28,7 +28,7 @@
       Learn more about React at
       <a href="http://facebook.github.io/react" target="_blank">facebook.github.io/react</a>.
     </p>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.7.21/webcomponents.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/custom-elements/1.0.0-alpha.3/custom-elements.min.js"></script>
     <script src="../../build/react.js"></script>
     <script src="../../build/react-dom.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.24/browser.min.js"></script>

--- a/examples/webcomponents/index.html
+++ b/examples/webcomponents/index.html
@@ -46,7 +46,7 @@
           var url = 'https://www.google.com/search?q=' + encodeURIComponent(name);
           ReactDOM.render(<a href={url}>{name}</a>, mountPoint);
         }
-      };
+      }
       customElements.define('x-search', XSearch);
 
       // Define React Component

--- a/examples/webcomponents/index.html
+++ b/examples/webcomponents/index.html
@@ -36,19 +36,18 @@
     <script type="text/babel">
 
       // Define WebComponent
-      var proto = Object.create(HTMLElement.prototype, {
-        attachedCallback: {
-          value: function() {
-            var mountPoint = document.createElement('span');
-            this.createShadowRoot().appendChild(mountPoint);
+      class XSearch extends HTMLElement {
+        constructor() {
+          super();
+          var mountPoint = document.createElement('span');
+          this.attachShadow({mode: 'open'}).appendChild(mountPoint);
 
-            var name = this.getAttribute('name');
-            var url = 'https://www.google.com/search?q=' + encodeURIComponent(name);
-            ReactDOM.render(<a href={url}>{name}</a>, mountPoint);
-          }
+          var name = this.getAttribute('name');
+          var url = 'https://www.google.com/search?q=' + encodeURIComponent(name);
+          ReactDOM.render(<a href={url}>{name}</a>, mountPoint);
         }
-      });
-      document.registerElement('x-search', {prototype: proto});
+      };
+      customElements.define('x-search', XSearch);
 
       // Define React Component
       class HelloMessage extends React.Component {


### PR DESCRIPTION
This is a straightforward update of the WebComponent example to match the final WebComponent 1.0 specification, which mandates ES6 Class syntax.

I'm unsure of any paths forward to maintaining support for old browsers while also supporting new ones, short of feature detection & having two separate codepaths. The situation in the aftermath of #8656 is un-ideal.

This PR depends on cdnjs adding the custom-element polyfill. Those changes are tracked in cdnjs/cdnjs#10108