### PR TITLE
Should not re-render as the result of a null state update

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1578,6 +1578,7 @@ src/renderers/shared/shared/__tests__/ReactUpdates-test.js
 * unmounts and remounts a root in the same batch
 * handles reentrant mounting in synchronous mode
 * mounts and unmounts are sync even in a batch
+* does not re-render if state update is null
 
 src/renderers/shared/shared/__tests__/refs-destruction-test.js
 * should remove refs when destroying the parent

--- a/src/renderers/shared/shared/__tests__/ReactUpdates-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactUpdates-test.js
@@ -1165,25 +1165,22 @@ describe('ReactUpdates', () => {
     expect(called).toEqual(true);
   });
 
-  if (ReactDOMFeatureFlags.useFiber) {
-    // TODO: Should we add this feature to stack, too?
-    it('does not re-render if state update is null', () => {
-      let container = document.createElement('div');
+  it('does not re-render if state update is null', () => {
+    let container = document.createElement('div');
 
-      let instance;
-      let ops = [];
-      class Foo extends React.Component {
-        render() {
-          instance = this;
-          ops.push('render');
-          return <div />;
-        }
+    let instance;
+    let ops = [];
+    class Foo extends React.Component {
+      render() {
+        instance = this;
+        ops.push('render');
+        return <div />;
       }
-      ReactDOM.render(<Foo />, container);
+    }
+    ReactDOM.render(<Foo />, container);
 
-      ops = [];
-      instance.setState(() => null);
-      expect(ops).toEqual([]);
-    });
-  }
+    ops = [];
+    instance.setState(() => null);
+    expect(ops).toEqual([]);
+  });
 });

--- a/src/renderers/shared/shared/__tests__/ReactUpdates-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactUpdates-test.js
@@ -13,9 +13,9 @@
 
 var React;
 var ReactDOM;
-var ReactDOMFeatureFlags;
 var ReactTestUtils;
 var ReactUpdates;
+var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 
 describe('ReactUpdates', () => {
   beforeEach(() => {
@@ -1164,4 +1164,26 @@ describe('ReactUpdates', () => {
     ReactDOM.render(<Foo />, container1);
     expect(called).toEqual(true);
   });
+
+  if (ReactDOMFeatureFlags.useFiber) {
+    // TODO: Should we add this feature to stack, too?
+    it('does not re-render if state update is null', () => {
+      let container = document.createElement('div');
+
+      let instance;
+      let ops = [];
+      class Foo extends React.Component {
+        render() {
+          instance = this;
+          ops.push('render');
+          return <div />;
+        }
+      }
+      ReactDOM.render(<Foo />, container);
+
+      ops = [];
+      instance.setState(() => null);
+      expect(ops).toEqual([]);
+    });
+  }
 });


### PR DESCRIPTION
Fiber already happens to behave this way; this just adds a test.

~~TODO: Should we add this feature to Stack, too?~~ Done.

See this post for context: https://www.facebook.com/groups/2003630259862046/permalink/2190298087861928/