### PR TITLE
Add unit test to onlyChild to ensure onlyChild returns child element

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -142,7 +142,6 @@ src/isomorphic/children/__tests__/onlyChild-test.js
 * should fail when passed nully values
 * should fail when key/value objects
 * should not fail when passed interpolated single child
-* should not throw when passed non-interpolated single child
 * should return the only child
 
 src/isomorphic/children/__tests__/sliceChildren-test.js

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -142,6 +142,7 @@ src/isomorphic/children/__tests__/onlyChild-test.js
 * should fail when passed nully values
 * should fail when key/value objects
 * should not fail when passed interpolated single child
+* should not throw when passed non-interpolated single child
 * should return the only child
 
 src/isomorphic/children/__tests__/sliceChildren-test.js

--- a/src/isomorphic/children/__tests__/onlyChild-test.js
+++ b/src/isomorphic/children/__tests__/onlyChild-test.js
@@ -83,17 +83,6 @@ describe('onlyChild', () => {
     }).not.toThrow();
   });
 
-
-  it('should not throw when passed non-interpolated single child', () => {
-    expect(function() {
-      var instance =
-        <WrapComponent>
-          <span />
-        </WrapComponent>;
-      onlyChild(instance.props.children);
-    }).not.toThrow();
-  });
-
   it('should return the only child', () => {
     var instance =
       <WrapComponent>

--- a/src/isomorphic/children/__tests__/onlyChild-test.js
+++ b/src/isomorphic/children/__tests__/onlyChild-test.js
@@ -84,7 +84,7 @@ describe('onlyChild', () => {
   });
 
 
-  it('should return the only child', () => {
+  it('should not throw when passed non-interpolated single child', () => {
     expect(function() {
       var instance =
         <WrapComponent>
@@ -92,6 +92,14 @@ describe('onlyChild', () => {
         </WrapComponent>;
       onlyChild(instance.props.children);
     }).not.toThrow();
+  });
+
+  it('should return the only child', () => {
+    var instance =
+      <WrapComponent>
+        <span />
+      </WrapComponent>;
+    expect(onlyChild(instance.props.children)).toEqual(<span />);
   });
 
 });


### PR DESCRIPTION
It looks like the last test in onlyChild-test.js was not actually testing what it should have been.

Instead of testing the return value of onlyChild, it was simply testing that an error was not being thrown.