### PR TITLE
Add callback validation to fiber-based renderers

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -12,10 +12,6 @@ src/isomorphic/classic/__tests__/ReactContextValidator-test.js
 src/renderers/dom/__tests__/ReactDOMProduction-test.js
 * should throw with an error code in production
 
-src/renderers/dom/shared/__tests__/ReactDOM-test.js
-* throws in render() if the mount callback is not a function
-* throws in render() if the update callback is not a function
-
 src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * should clean up input value tracking
 * should clean up input textarea tracking

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -620,6 +620,8 @@ src/renderers/dom/shared/__tests__/ReactDOM-test.js
 * should overwrite props.children with children argument
 * should purge the DOM cache when removing nodes
 * allow React.DOM factories to be called without warnings
+* throws in render() if the mount callback is not a function
+* throws in render() if the update callback is not a function
 * preserves focus
 * calls focus() on autoFocus elements after they have been mounted to the DOM
 

--- a/src/renderers/dom/shared/__tests__/ReactDOM-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOM-test.js
@@ -133,15 +133,15 @@ describe('ReactDOM', () => {
 
     var myDiv = document.createElement('div');
     expect(() => ReactDOM.render(<A />, myDiv, 'no')).toThrowError(
-      'ReactDOM.render(...): Expected the last optional `callback` argument ' +
+      'render(...): Expected the last optional `callback` argument ' +
       'to be a function. Instead received: string.'
     );
     expect(() => ReactDOM.render(<A />, myDiv, {})).toThrowError(
-      'ReactDOM.render(...): Expected the last optional `callback` argument ' +
+      'render(...): Expected the last optional `callback` argument ' +
       'to be a function. Instead received: Object.'
     );
     expect(() => ReactDOM.render(<A />, myDiv, new Foo())).toThrowError(
-      'ReactDOM.render(...): Expected the last optional `callback` argument ' +
+      'render(...): Expected the last optional `callback` argument ' +
       'to be a function. Instead received: Foo (keys: a, b).'
     );
   });
@@ -164,15 +164,15 @@ describe('ReactDOM', () => {
     ReactDOM.render(<A />, myDiv);
 
     expect(() => ReactDOM.render(<A />, myDiv, 'no')).toThrowError(
-      'ReactDOM.render(...): Expected the last optional `callback` argument ' +
+      'render(...): Expected the last optional `callback` argument ' +
       'to be a function. Instead received: string.'
     );
     expect(() => ReactDOM.render(<A />, myDiv, {})).toThrowError(
-      'ReactDOM.render(...): Expected the last optional `callback` argument ' +
+      'render(...): Expected the last optional `callback` argument ' +
       'to be a function. Instead received: Object.'
     );
     expect(() => ReactDOM.render(<A />, myDiv, new Foo())).toThrowError(
-      'ReactDOM.render(...): Expected the last optional `callback` argument ' +
+      'render(...): Expected the last optional `callback` argument ' +
       'to be a function. Instead received: Foo (keys: a, b).'
     );
   });

--- a/src/renderers/dom/stack/client/ReactMount.js
+++ b/src/renderers/dom/stack/client/ReactMount.js
@@ -33,6 +33,7 @@ var invariant = require('invariant');
 var setInnerHTML = require('setInnerHTML');
 var shouldUpdateReactComponent = require('shouldUpdateReactComponent');
 var warning = require('warning');
+var validateCallback = require('validateCallback');
 
 var ATTR_NAME = DOMProperty.ID_ATTRIBUTE_NAME;
 var ROOT_ATTR_NAME = DOMProperty.ROOT_ATTRIBUTE_NAME;
@@ -432,7 +433,7 @@ var ReactMount = {
   },
 
   _renderSubtreeIntoContainer: function(parentComponent, nextElement, container, callback) {
-    ReactUpdateQueue.validateCallback(callback, 'ReactDOM.render');
+    validateCallback(callback, 'ReactDOM.render');
     invariant(
       React.isValidElement(nextElement),
       'ReactDOM.render(): Invalid component element.%s',

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -33,31 +33,6 @@ var invariant = require('invariant');
 
 const isArray = Array.isArray;
 
-function formatUnexpectedArgument(arg) {
-  var type = typeof arg;
-  if (type !== 'object') {
-    return type;
-  }
-  var displayName = arg.constructor && arg.constructor.name || type;
-  var keys = Object.keys(arg);
-  if (keys.length > 0 && keys.length < 20) {
-    return `${displayName} (keys: ${keys.join(', ')})`;
-  }
-  return displayName;
-}
-
-function validateCallback(callback, callerName) {
-  if (typeof callback !== 'function') {
-    invariant(
-      false,
-      '%s(...): Expected the last optional `callback` argument to be a ' +
-      'function. Instead received: %s.',
-      callerName,
-      formatUnexpectedArgument(callback)
-    );
-  }
-}
-
 module.exports = function(
   scheduleUpdate : (fiber : Fiber, priorityLevel : PriorityLevel) => void,
   getPriorityContext : () => PriorityLevel,
@@ -67,27 +42,18 @@ module.exports = function(
   const updater = {
     isMounted,
     enqueueSetState(instance, partialState, callback) {
-      if (callback) {
-        validateCallback(callback, 'setState');
-      }
       const fiber = ReactInstanceMap.get(instance);
       const priorityLevel = getPriorityContext();
       addUpdate(fiber, partialState, callback || null, priorityLevel);
       scheduleUpdate(fiber, priorityLevel);
     },
     enqueueReplaceState(instance, state, callback) {
-      if (callback) {
-        validateCallback(callback, 'replaceState');
-      }
       const fiber = ReactInstanceMap.get(instance);
       const priorityLevel = getPriorityContext();
       addReplaceUpdate(fiber, state, callback || null, priorityLevel);
       scheduleUpdate(fiber, priorityLevel);
     },
     enqueueForceUpdate(instance, callback) {
-      if (callback) {
-        validateCallback(callback, 'forceUpdate');
-      }
       const fiber = ReactInstanceMap.get(instance);
       const priorityLevel = getPriorityContext();
       addForceUpdate(fiber, callback || null, priorityLevel);

--- a/src/renderers/shared/stack/reconciler/ReactUpdateQueue.js
+++ b/src/renderers/shared/stack/reconciler/ReactUpdateQueue.js
@@ -16,24 +16,11 @@ var ReactInstanceMap = require('ReactInstanceMap');
 var ReactInstrumentation = require('ReactInstrumentation');
 var ReactUpdates = require('ReactUpdates');
 
-var invariant = require('invariant');
 var warning = require('warning');
+var validateCallback = require('validateCallback');
 
 function enqueueUpdate(internalInstance) {
   ReactUpdates.enqueueUpdate(internalInstance);
-}
-
-function formatUnexpectedArgument(arg) {
-  var type = typeof arg;
-  if (type !== 'object') {
-    return type;
-  }
-  var displayName = arg.constructor && arg.constructor.name || type;
-  var keys = Object.keys(arg);
-  if (keys.length > 0 && keys.length < 20) {
-    return `${displayName} (keys: ${keys.join(', ')})`;
-  }
-  return displayName;
 }
 
 function getInternalInstanceReadyForUpdate(publicInstance, callerName) {
@@ -147,7 +134,7 @@ var ReactUpdateQueue = {
     }
 
     if (callback) {
-      ReactUpdateQueue.validateCallback(callback, callerName);
+      validateCallback(callback, callerName);
       if (internalInstance._pendingCallbacks) {
         internalInstance._pendingCallbacks.push(callback);
       } else {
@@ -187,7 +174,7 @@ var ReactUpdateQueue = {
     internalInstance._pendingReplaceState = true;
 
     if (callback) {
-      ReactUpdateQueue.validateCallback(callback, callerName);
+      validateCallback(callback, callerName);
       if (internalInstance._pendingCallbacks) {
         internalInstance._pendingCallbacks.push(callback);
       } else {
@@ -235,7 +222,7 @@ var ReactUpdateQueue = {
     queue.push(partialState);
 
     if (callback) {
-      ReactUpdateQueue.validateCallback(callback, callerName);
+      validateCallback(callback, callerName);
       if (internalInstance._pendingCallbacks) {
         internalInstance._pendingCallbacks.push(callback);
       } else {
@@ -251,16 +238,6 @@ var ReactUpdateQueue = {
     // TODO: introduce _pendingContext instead of setting it directly.
     internalInstance._context = nextContext;
     enqueueUpdate(internalInstance);
-  },
-
-  validateCallback: function(callback, callerName) {
-    invariant(
-      !callback || typeof callback === 'function',
-      '%s(...): Expected the last optional `callback` argument to be a ' +
-      'function. Instead received: %s.',
-      callerName,
-      formatUnexpectedArgument(callback)
-    );
   },
 
 };

--- a/src/renderers/shared/utils/validateCallback.js
+++ b/src/renderers/shared/utils/validateCallback.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule validateCallback
+ * @flow
+ */
+
+'use strict';
+
+const invariant = require('invariant');
+
+function formatUnexpectedArgument(arg: any) {
+  let type = typeof arg;
+  if (type !== 'object') {
+    return type;
+  }
+  let displayName = arg.constructor && arg.constructor.name || type;
+  let keys = Object.keys(arg);
+  if (keys.length > 0 && keys.length < 20) {
+    return `${displayName} (keys: ${keys.join(', ')})`;
+  }
+  return displayName;
+}
+
+function validateCallback(callback: ?Function, callerName: string) {
+  invariant(
+    !callback || typeof callback === 'function',
+    '%s(...): Expected the last optional `callback` argument to be a ' +
+    'function. Instead received: %s.',
+    callerName,
+    formatUnexpectedArgument(callback)
+  );
+}
+
+module.exports = validateCallback;


### PR DESCRIPTION
Moved `ReactFiberClassComponent` `validateCallback()` helper function into a standalone util used by both fiber and stack implementations. Validation now happens in `ReactFiberUpdateQueue` so that non-DOM renderers will also benefit from it.

This fixes 2 failing fiber tests.