### PR TITLE
Updated prod error code test to be fiber-compat

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -9,9 +9,6 @@ src/addons/__tests__/ReactFragment-test.js
 src/isomorphic/classic/__tests__/ReactContextValidator-test.js
 * should pass previous context to lifecycles
 
-src/renderers/dom/__tests__/ReactDOMProduction-test.js
-* should throw with an error code in production
-
 src/renderers/dom/shared/__tests__/ReactDOM-test.js
 * throws in render() if the mount callback is not a function
 * throws in render() if the update callback is not a function

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -513,6 +513,7 @@ src/renderers/dom/__tests__/ReactDOMProduction-test.js
 * should use prod React
 * should handle a simple flow
 * should call lifecycle methods
+* should throw with an error code in production
 * should keep track of namespace across portals in production
 
 src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js

--- a/src/renderers/dom/__tests__/ReactDOMProduction-test.js
+++ b/src/renderers/dom/__tests__/ReactDOMProduction-test.js
@@ -180,17 +180,11 @@ describe('ReactDOMProduction', () => {
 
   it('should throw with an error code in production', () => {
     expect(function() {
-      class Component extends React.Component {
-        render() {
-          return undefined;
-        }
-      }
-
       var container = document.createElement('div');
-      ReactDOM.render(<Component />, container);
+      ReactDOM.render(<input><div/></input>, container);
     }).toThrowError(
-      'Minified React error #109; visit ' +
-      'http://facebook.github.io/react/docs/error-decoder.html?invariant=109&args[]=Component' +
+      'Minified React error #137; visit ' +
+      'http://facebook.github.io/react/docs/error-decoder.html?invariant=137&args[]=input&args[]=' +
       ' for the full message or use the non-minified dev environment' +
       ' for full errors and additional helpful warnings.'
     );


### PR DESCRIPTION
This test previously returned `undefined` from `render()` to cause an error. Fiber allows this though so the test was failing. I've updated the test instead to trigger a different error that both Stack and Fiber share in common.