### PR TITLE
Fixed stray text appearing on top of the navbar in docs, at small screen sizes

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,7 +1,7 @@
 {% if page.excerpt %}
 {% assign type = 'article' %}
 {% assign sectionTitle = 'React Blog' %}
-{% assign description = page.excerpt | remove: '<p>' | remove: '</p>' %}
+{% assign description = page.excerpt | strip_html %}
 {% else %}
 {% assign type = 'website' %}
 {% assign sectionTitle = 'React' %}


### PR DESCRIPTION
Fixes #8676 

- Stray text is now removed from the top of the navbar in small screen sizes.
