### PR TITLE
Fix AMD and Brunch issues

### DIFF
--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -1,0 +1,49 @@
+# Manual Testing Fixtures
+
+This folder exists for **React contributors** only.  
+If you use React you don't need to worry about it.
+
+These fixtures verify that the built React distributions are usable in different environments.  
+**They are not running automatically.** (At least not yet, feel free to contribute to automate them.)
+
+Run them when you make changes to how we package React, ReactDOM, and addons.
+
+## How to Run
+
+First, build React and the fixtures:
+
+```
+cd react
+npm run build
+
+cd fixtures
+node build-all.js
+```
+
+Then run a local server at the root of the repo, e.g.
+
+```
+npm i -g pushstate-server
+cd ..
+pushstate-server .
+```
+
+(Too complicated? Send a PR to simplify this :-).
+
+Then open the corresponding URLs, for example:
+
+```
+open http://localhost:9000/fixtures/globals.html
+open http://localhost:9000/fixtures/requirejs.html
+open http://localhost:9000/fixtures/systemjs.html
+open http://localhost:9000/fixtures/browserify/index.html
+open http://localhost:9000/fixtures/rjs/index.html
+open http://localhost:9000/fixtures/systemjs-builder/index.html
+open http://localhost:9000/fixtures/webpack/index.html
+open http://localhost:9000/fixtures/webpack-alias/index.html
+```
+
+You should see two things:
+
+* "Hello World" fading in with an animation.
+* No errors in the console.

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -37,6 +37,7 @@ open http://localhost:9000/fixtures/globals.html
 open http://localhost:9000/fixtures/requirejs.html
 open http://localhost:9000/fixtures/systemjs.html
 open http://localhost:9000/fixtures/browserify/index.html
+open http://localhost:9000/fixtures/brunch/index.html
 open http://localhost:9000/fixtures/rjs/index.html
 open http://localhost:9000/fixtures/systemjs-builder/index.html
 open http://localhost:9000/fixtures/webpack/index.html

--- a/fixtures/browserify/.gitignore
+++ b/fixtures/browserify/.gitignore
@@ -1,0 +1,1 @@
+output.js

--- a/fixtures/browserify/index.html
+++ b/fixtures/browserify/index.html
@@ -1,0 +1,16 @@
+<html>
+  <body>
+    <style>
+      .example-appear {
+        opacity: 0.01;
+      }
+
+      .example-appear.example-appear-active {
+        opacity: 1;
+        transition: opacity .5s ease-in;
+      }
+    </style>
+    <div id="container"></div>
+    <script src="output.js"></script>
+  </body>
+</html>

--- a/fixtures/browserify/input.js
+++ b/fixtures/browserify/input.js
@@ -1,0 +1,16 @@
+var React = require('react');
+var CSSTransitionGroup = require('react-addons-css-transition-group');
+var ReactDOM = require('react-dom');
+
+ReactDOM.render(
+  React.createElement(CSSTransitionGroup, {
+    transitionName: 'example',
+    transitionAppear: true,
+    transitionAppearTimeout: 500,
+    transitionEnterTimeout: 0,
+    transitionLeaveTimeout: 0,
+  }, React.createElement('h1', null,
+    'Hello World!'
+  )),
+  document.getElementById('container')
+);

--- a/fixtures/browserify/package.json
+++ b/fixtures/browserify/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "webpack-test",
+  "private": true,
+  "dependencies": {
+    "browserify": "^13.3.0"
+  },
+  "scripts": {
+    "build": "rm -f output.js && NODE_PATH=../../build/packages browserify ./input.js -o output.js"
+  }
+}

--- a/fixtures/brunch/.gitignore
+++ b/fixtures/brunch/.gitignore
@@ -1,0 +1,2 @@
+output.js
+output.js.map

--- a/fixtures/brunch/app/initialize.js
+++ b/fixtures/brunch/app/initialize.js
@@ -1,0 +1,16 @@
+var React = require('react');
+var CSSTransitionGroup = require('react-addons-css-transition-group');
+var ReactDOM = require('react-dom');
+
+ReactDOM.render(
+  React.createElement(CSSTransitionGroup, {
+    transitionName: 'example',
+    transitionAppear: true,
+    transitionAppearTimeout: 500,
+    transitionEnterTimeout: 0,
+    transitionLeaveTimeout: 0,
+  }, React.createElement('h1', null,
+    'Hello World!'
+  )),
+  document.getElementById('container')
+);

--- a/fixtures/brunch/config.js
+++ b/fixtures/brunch/config.js
@@ -1,0 +1,10 @@
+exports.config = {
+  paths: {
+    public: '.',
+  },
+  files: {
+    javascripts: {
+      joinTo: 'output.js',
+    },
+  },
+};

--- a/fixtures/brunch/index.html
+++ b/fixtures/brunch/index.html
@@ -1,0 +1,17 @@
+<html>
+  <body>
+    <style>
+      .example-appear {
+        opacity: 0.01;
+      }
+
+      .example-appear.example-appear-active {
+        opacity: 1;
+        transition: opacity .5s ease-in;
+      }
+    </style>
+    <div id="container"></div>
+    <script src="output.js"></script>
+    <script>require('initialize');</script>
+  </body>
+</html>

--- a/fixtures/brunch/input.js
+++ b/fixtures/brunch/input.js
@@ -1,0 +1,16 @@
+var React = require('react');
+var CSSTransitionGroup = require('react-addons-css-transition-group');
+var ReactDOM = require('react-dom');
+
+ReactDOM.render(
+  React.createElement(CSSTransitionGroup, {
+    transitionName: 'example',
+    transitionAppear: true,
+    transitionAppearTimeout: 500,
+    transitionEnterTimeout: 0,
+    transitionLeaveTimeout: 0,
+  }, React.createElement('h1', null,
+    'Hello World!'
+  )),
+  document.getElementById('container')
+);

--- a/fixtures/brunch/package.json
+++ b/fixtures/brunch/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "brunch-test",
+  "devDependencies": {
+      "brunch": "^2.9.1",
+      "javascript-brunch": "^2.0.0"
+  },
+  "scripts": {
+    "build": "rm -rf public && ln -fs ../../../build/packages/react node_modules/react && ln -fs ../../../build/packages/react-dom node_modules/react-dom && ln -fs ../../../build/packages/react-addons-css-transition-group node_modules/react-addons-css-transition-group && brunch build"
+  }
+}

--- a/fixtures/build-all.js
+++ b/fixtures/build-all.js
@@ -1,0 +1,30 @@
+var fs = require('fs');
+var path = require('path');
+var { spawnSync } = require('child_process');
+
+var fixtureDirs = fs.readdirSync(__dirname).filter((file) => {
+  return fs.statSync(path.join(__dirname, file)).isDirectory();
+});
+
+var cmdArgs = [
+  {cmd: 'npm', args: ['install']},
+  {cmd: 'npm', args: ['run', 'build']},
+];
+
+for (const dir of fixtureDirs) {
+  for (const cmdArg of cmdArgs) {
+    const opts = {
+      cwd: path.join(__dirname, dir),
+      stdio: 'inherit',
+    };
+    let result = spawnSync(cmdArg.cmd, cmdArg.args, opts);
+    if (result.status !== 0) {
+      throw new Error('Failed to build fixtures.');
+    }
+  }
+}
+
+console.log('-------------------------');
+console.log('All fixtures were built!');
+console.log('Now make sure to open each HTML file in this directory and each index.html in subdirectories.');
+console.log('-------------------------');

--- a/fixtures/globals.html
+++ b/fixtures/globals.html
@@ -1,0 +1,32 @@
+<html>
+  <body>
+    <script src="../build/react-with-addons.js"></script>
+    <script src="../build/react-dom.js"></script>
+    <style>
+      .example-appear {
+        opacity: 0.01;
+      }
+
+      .example-appear.example-appear-active {
+        opacity: 1;
+        transition: opacity .5s ease-in;
+      }
+    </style>
+    <div id="container"></div>
+    <script>
+      var CSSTransitionGroup = React.addons.CSSTransitionGroup;
+      ReactDOM.render(
+        React.createElement(CSSTransitionGroup, {
+          transitionName: 'example',
+          transitionAppear: true,
+          transitionAppearTimeout: 500,
+          transitionEnterTimeout: 0,
+          transitionLeaveTimeout: 0,
+        }, React.createElement('h1', null,
+          'Hello World!'
+        )),
+        document.getElementById('container')
+      );
+    </script>
+  </body>
+</html>

--- a/fixtures/requirejs.html
+++ b/fixtures/requirejs.html
@@ -1,0 +1,40 @@
+<html>
+  <body>
+    <script src="https://unpkg.com/requirejs@2.3.2/require.js"></script>
+    <style>
+      .example-appear {
+        opacity: 0.01;
+      }
+
+      .example-appear.example-appear-active {
+        opacity: 1;
+        transition: opacity .5s ease-in;
+      }
+    </style>
+    <div id="container"></div>
+    <script>
+      requirejs.config({
+        paths: {
+          react: '../build/react-with-addons',
+          'react-dom': '../build/react-dom'
+        }
+      });
+
+      require(['react', 'react-dom'], function(React, ReactDOM) {
+        var CSSTransitionGroup = React.addons.CSSTransitionGroup;
+        ReactDOM.render(
+          React.createElement(CSSTransitionGroup, {
+            transitionName: 'example',
+            transitionAppear: true,
+            transitionAppearTimeout: 500,
+            transitionEnterTimeout: 0,
+            transitionLeaveTimeout: 0,
+          }, React.createElement('h1', null,
+            'Hello World!'
+          )),
+          document.getElementById('container')
+        );
+      });
+    </script>
+  </body>
+</html>

--- a/fixtures/rjs/.gitignore
+++ b/fixtures/rjs/.gitignore
@@ -1,0 +1,1 @@
+output.js

--- a/fixtures/rjs/config.js
+++ b/fixtures/rjs/config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  baseUrl: '.',
+  name: 'input',
+  out: 'output.js',
+  optimize: 'none',
+  paths: {
+    react: '../../build/react-with-addons',
+    'react-dom': '../../build/react-dom',
+  },
+};

--- a/fixtures/rjs/index.html
+++ b/fixtures/rjs/index.html
@@ -1,0 +1,17 @@
+<html>
+  <body>
+    <style>
+      .example-appear {
+        opacity: 0.01;
+      }
+
+      .example-appear.example-appear-active {
+        opacity: 1;
+        transition: opacity .5s ease-in;
+      }
+    </style>
+    <div id="container"></div>
+    <script src="https://unpkg.com/requirejs@2.3.2/require.js"></script>
+    <script src="output.js"></script>
+  </body>
+</html>

--- a/fixtures/rjs/input.js
+++ b/fixtures/rjs/input.js
@@ -1,0 +1,15 @@
+require(['react', 'react-dom'], function(React, ReactDOM) {
+  var CSSTransitionGroup = React.addons.CSSTransitionGroup;
+  ReactDOM.render(
+    React.createElement(CSSTransitionGroup, {
+      transitionName: 'example',
+      transitionAppear: true,
+      transitionAppearTimeout: 500,
+      transitionEnterTimeout: 0,
+      transitionLeaveTimeout: 0,
+    }, React.createElement('h1', null,
+      'Hello World!'
+    )),
+    document.getElementById('container')
+  );
+});

--- a/fixtures/rjs/package.json
+++ b/fixtures/rjs/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "rjs-test",
+  "private": true,
+  "dependencies": {
+    "requirejs": "^2.3.2"
+  },
+  "scripts": {
+    "build": "rm -f output.js && r.js -o config.js"
+  }
+}

--- a/fixtures/systemjs-builder/.gitignore
+++ b/fixtures/systemjs-builder/.gitignore
@@ -1,0 +1,1 @@
+output.js

--- a/fixtures/systemjs-builder/build.js
+++ b/fixtures/systemjs-builder/build.js
@@ -1,0 +1,12 @@
+var Builder = require('systemjs-builder');
+
+var builder = new Builder('/', './config.js');
+builder
+  .buildStatic('./input.js', './output.js')
+  .then(function() {
+    console.log('Build complete');
+  })
+  .catch(function(err) {
+    console.log('Build error');
+    console.log(err);
+  });

--- a/fixtures/systemjs-builder/config.js
+++ b/fixtures/systemjs-builder/config.js
@@ -1,0 +1,6 @@
+System.config({
+  paths: {
+    react: '../../build/react-with-addons.js',
+    'react-dom': '../../build/react-dom.js',
+  },
+});

--- a/fixtures/systemjs-builder/index.html
+++ b/fixtures/systemjs-builder/index.html
@@ -1,0 +1,16 @@
+<html>
+  <body>
+    <style>
+      .example-appear {
+        opacity: 0.01;
+      }
+
+      .example-appear.example-appear-active {
+        opacity: 1;
+        transition: opacity .5s ease-in;
+      }
+    </style>
+    <div id="container"></div>
+    <script src="output.js"></script>
+  </body>
+</html>

--- a/fixtures/systemjs-builder/input.js
+++ b/fixtures/systemjs-builder/input.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+var CSSTransitionGroup = React.addons.CSSTransitionGroup;
+ReactDOM.render(
+  React.createElement(CSSTransitionGroup, {
+    transitionName: 'example',
+    transitionAppear: true,
+    transitionAppearTimeout: 500,
+    transitionEnterTimeout: 0,
+    transitionLeaveTimeout: 0,
+  }, React.createElement('h1', null,
+    'Hello World!'
+  )),
+  document.getElementById('container')
+);

--- a/fixtures/systemjs-builder/package.json
+++ b/fixtures/systemjs-builder/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "systemjs-builder-test",
+  "private": true,
+  "dependencies": {
+    "systemjs-builder": "^0.15.34"
+  },
+  "scripts": {
+    "build": "rm -f output.js && node build.js"
+  }
+}

--- a/fixtures/systemjs.html
+++ b/fixtures/systemjs.html
@@ -1,0 +1,46 @@
+<html>
+  <body>
+    <script src="https://unpkg.com/systemjs@0.19.41/dist/system.js"></script>
+    <style>
+      .example-appear {
+        opacity: 0.01;
+      }
+
+      .example-appear.example-appear-active {
+        opacity: 1;
+        transition: opacity .5s ease-in;
+      }
+    </style>
+    <div id="container"></div>
+    <script>
+      System.config({
+        paths: {
+          react: '../build/react-with-addons.js',
+          'react-dom': '../build/react-dom.js'
+        }
+      });
+
+      Promise.all([
+        System.import("react"),
+        System.import("react-dom")
+      ]).then(function (deps) {
+        var React = deps[0];
+        var ReactDOM = deps[1];
+
+        var CSSTransitionGroup = React.addons.CSSTransitionGroup;
+        ReactDOM.render(
+          React.createElement(CSSTransitionGroup, {
+            transitionName: 'example',
+            transitionAppear: true,
+            transitionAppearTimeout: 500,
+            transitionEnterTimeout: 0,
+            transitionLeaveTimeout: 0,
+          }, React.createElement('h1', null,
+            'Hello World!'
+          )),
+          document.getElementById('container')
+        );
+      });
+    </script>
+  </body>
+</html>

--- a/fixtures/webpack-alias/.gitignore
+++ b/fixtures/webpack-alias/.gitignore
@@ -1,0 +1,1 @@
+output.js

--- a/fixtures/webpack-alias/config.js
+++ b/fixtures/webpack-alias/config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  entry: './input',
+  output: {
+    filename: 'output.js',
+  },
+  resolve: {
+    root: '../../build/packages',
+    alias: {
+      'react': 'react/dist/react-with-addons',
+      'react-dom': 'react-dom/dist/react-dom',
+    },
+  },
+};

--- a/fixtures/webpack-alias/index.html
+++ b/fixtures/webpack-alias/index.html
@@ -1,0 +1,16 @@
+<html>
+  <body>
+    <style>
+      .example-appear {
+        opacity: 0.01;
+      }
+
+      .example-appear.example-appear-active {
+        opacity: 1;
+        transition: opacity .5s ease-in;
+      }
+    </style>
+    <div id="container"></div>
+    <script src="output.js"></script>
+  </body>
+</html>

--- a/fixtures/webpack-alias/input.js
+++ b/fixtures/webpack-alias/input.js
@@ -1,0 +1,16 @@
+var React = require('react');
+var ReactDOM = require('react-dom');
+
+var CSSTransitionGroup = React.addons.CSSTransitionGroup;
+ReactDOM.render(
+  React.createElement(CSSTransitionGroup, {
+    transitionName: 'example',
+    transitionAppear: true,
+    transitionAppearTimeout: 500,
+    transitionEnterTimeout: 0,
+    transitionLeaveTimeout: 0,
+  }, React.createElement('h1', null,
+    'Hello World!'
+  )),
+  document.getElementById('container')
+);

--- a/fixtures/webpack-alias/package.json
+++ b/fixtures/webpack-alias/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "webpack-test",
+  "private": true,
+  "dependencies": {
+    "webpack": "^1.14.0"
+  },
+  "scripts": {
+    "build": "rm -f output.js && webpack --config config.js"
+  }
+}

--- a/fixtures/webpack/.gitignore
+++ b/fixtures/webpack/.gitignore
@@ -1,0 +1,1 @@
+output.js

--- a/fixtures/webpack/config.js
+++ b/fixtures/webpack/config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  entry: './input',
+  output: {
+    filename: 'output.js',
+  },
+  resolve: {
+    root: '../../build/packages',
+  },
+};

--- a/fixtures/webpack/index.html
+++ b/fixtures/webpack/index.html
@@ -1,0 +1,16 @@
+<html>
+  <body>
+    <style>
+      .example-appear {
+        opacity: 0.01;
+      }
+
+      .example-appear.example-appear-active {
+        opacity: 1;
+        transition: opacity .5s ease-in;
+      }
+    </style>
+    <div id="container"></div>
+    <script src="output.js"></script>
+  </body>
+</html>

--- a/fixtures/webpack/input.js
+++ b/fixtures/webpack/input.js
@@ -1,0 +1,16 @@
+var React = require('react');
+var CSSTransitionGroup = require('react-addons-css-transition-group');
+var ReactDOM = require('react-dom');
+
+ReactDOM.render(
+  React.createElement(CSSTransitionGroup, {
+    transitionName: 'example',
+    transitionAppear: true,
+    transitionAppearTimeout: 500,
+    transitionEnterTimeout: 0,
+    transitionLeaveTimeout: 0,
+  }, React.createElement('h1', null,
+    'Hello World!'
+  )),
+  document.getElementById('container')
+);

--- a/fixtures/webpack/package.json
+++ b/fixtures/webpack/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "webpack-test",
+  "private": true,
+  "dependencies": {
+    "webpack": "^1.14.0"
+  },
+  "scripts": {
+    "build": "rm -f output.js && webpack --config config.js"
+  }
+}

--- a/scripts/fiber/tests-passing-except-dev.txt
+++ b/scripts/fiber/tests-passing-except-dev.txt
@@ -1,6 +1,3 @@
-src/addons/transitions/__tests__/ReactTransitionGroup-test.js
-* should warn for duplicated keys with component stack info
-
 src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * should not warn when server-side rendering `onScroll`
 * should warn about incorrect casing on properties (ssr)

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -105,6 +105,7 @@ src/addons/transitions/__tests__/ReactTransitionGroup-test.js
 * should handle enter/leave/enter/leave correctly
 * should handle enter/leave/enter correctly
 * should handle entering/leaving several elements at once
+* should warn for duplicated keys
 
 src/isomorphic/children/__tests__/ReactChildren-test.js
 * should support identity for simple

--- a/src/addons/ReactAddonsDOMDependencies.js
+++ b/src/addons/ReactAddonsDOMDependencies.js
@@ -18,14 +18,20 @@ exports.getReactDOM = function() {
 };
 
 if (__DEV__) {
-  var ReactPerf = require('ReactPerf');
-  var ReactTestUtils = require('ReactTestUtils');
+  var ReactPerf;
+  var ReactTestUtils;
 
   exports.getReactPerf = function() {
+    if (!ReactPerf) {
+      ReactPerf = require('ReactPerf');
+    }
     return ReactPerf;
   };
 
   exports.getReactTestUtils = function() {
+    if (!ReactTestUtils) {
+      ReactTestUtils = require('ReactTestUtils');
+    }
     return ReactTestUtils;
   };
 }

--- a/src/addons/ReactAddonsDOMDependencies.js
+++ b/src/addons/ReactAddonsDOMDependencies.js
@@ -12,14 +12,9 @@
 'use strict';
 
 var ReactDOM = require('ReactDOM');
-var ReactInstanceMap = require('ReactInstanceMap');
 
 exports.getReactDOM = function() {
   return ReactDOM;
-};
-
-exports.getReactInstanceMap = function() {
-  return ReactInstanceMap;
 };
 
 if (__DEV__) {

--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -12,7 +12,6 @@
 'use strict';
 
 var React = require('React');
-var ReactAddonsDOMDependencies = require('ReactAddonsDOMDependencies');
 var ReactTransitionChildMapping = require('ReactTransitionChildMapping');
 
 var emptyFunction = require('emptyFunction');
@@ -56,17 +55,9 @@ class ReactTransitionGroup extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    var nextChildMapping;
-    if (__DEV__) {
-      nextChildMapping = ReactTransitionChildMapping.getChildMapping(
-        nextProps.children,
-        ReactAddonsDOMDependencies.getReactInstanceMap().get(this)._debugID
-      );
-    } else {
-      nextChildMapping = ReactTransitionChildMapping.getChildMapping(
-        nextProps.children
-      );
-    }
+    var nextChildMapping = ReactTransitionChildMapping.getChildMapping(
+      nextProps.children
+    );
     var prevChildMapping = this.state.children;
 
     this.setState({
@@ -129,17 +120,9 @@ class ReactTransitionGroup extends React.Component {
 
     delete this.currentlyTransitioningKeys[key];
 
-    var currentChildMapping;
-    if (__DEV__) {
-      currentChildMapping = ReactTransitionChildMapping.getChildMapping(
-        this.props.children,
-        ReactAddonsDOMDependencies.getReactInstanceMap().get(this)._debugID
-      );
-    } else {
-      currentChildMapping = ReactTransitionChildMapping.getChildMapping(
-        this.props.children
-      );
-    }
+    var currentChildMapping = ReactTransitionChildMapping.getChildMapping(
+      this.props.children
+    );
 
     if (!currentChildMapping || !currentChildMapping.hasOwnProperty(key)) {
       // This was removed before it had fully appeared. Remove it.
@@ -169,17 +152,9 @@ class ReactTransitionGroup extends React.Component {
 
     delete this.currentlyTransitioningKeys[key];
 
-    var currentChildMapping;
-    if (__DEV__) {
-      currentChildMapping = ReactTransitionChildMapping.getChildMapping(
-        this.props.children,
-        ReactAddonsDOMDependencies.getReactInstanceMap().get(this)._debugID
-      );
-    } else {
-      currentChildMapping = ReactTransitionChildMapping.getChildMapping(
-        this.props.children
-      );
-    }
+    var currentChildMapping = ReactTransitionChildMapping.getChildMapping(
+      this.props.children
+    );
 
     if (!currentChildMapping || !currentChildMapping.hasOwnProperty(key)) {
       // This was removed before it had fully entered. Remove it.
@@ -210,17 +185,9 @@ class ReactTransitionGroup extends React.Component {
 
     delete this.currentlyTransitioningKeys[key];
 
-    var currentChildMapping;
-    if (__DEV__) {
-      currentChildMapping = ReactTransitionChildMapping.getChildMapping(
-        this.props.children,
-        ReactAddonsDOMDependencies.getReactInstanceMap().get(this)._debugID
-      );
-    } else {
-      currentChildMapping = ReactTransitionChildMapping.getChildMapping(
-        this.props.children
-      );
-    }
+    var currentChildMapping = ReactTransitionChildMapping.getChildMapping(
+      this.props.children
+    );
 
     if (currentChildMapping && currentChildMapping.hasOwnProperty(key)) {
       // This entered again before it fully left. Add it again.

--- a/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
@@ -20,10 +20,6 @@ var ReactTransitionGroup;
 describe('ReactTransitionGroup', () => {
   var container;
 
-  function normalizeCodeLocInfo(str) {
-    return str && str.replace(/\(at .+?:\d+\)/g, '(at **)');
-  }
-
   beforeEach(() => {
     React = require('React');
     ReactDOM = require('ReactDOM');
@@ -296,7 +292,7 @@ describe('ReactTransitionGroup', () => {
     ]);
   });
 
-  it('should warn for duplicated keys with component stack info', () => {
+  it('should warn for duplicated keys', () => {
     spyOn(console, 'error');
 
     class Component extends React.Component {
@@ -315,13 +311,11 @@ describe('ReactTransitionGroup', () => {
       'Child keys must be unique; when two children share a key, ' +
       'only the first child will be used.'
     );
-    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
+    expectDev(console.error.calls.argsFor(1)[0]).toBe(
       'Warning: flattenChildren(...): ' +
       'Encountered two children with the same key, `1`. ' +
       'Child keys must be unique; when two children share a key, ' +
-      'only the first child will be used.\n' +
-      '    in ReactTransitionGroup (at **)\n' +
-      '    in Component (at **)'
+      'only the first child will be used.'
     );
   });
 });

--- a/src/umd/ReactDOMUMDEntry.js
+++ b/src/umd/ReactDOMUMDEntry.js
@@ -11,24 +11,24 @@
 
 'use strict';
 
+var React = require('React');
 var ReactDOM = require('ReactDOM');
 
-var ReactDOMUMDEntry = Object.assign({
-  __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
-    ReactInstanceMap: require('ReactInstanceMap'),
-  },
-}, ReactDOM);
+var ReactDOMUMDEntry = ReactDOM;
 
 if (__DEV__) {
-  Object.assign(
-    ReactDOMUMDEntry.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
-    {
-      // ReactPerf and ReactTestUtils currently only work with the DOM renderer
-      // so we expose them from here, but only in DEV mode.
-      ReactPerf: require('ReactPerf'),
-      ReactTestUtils: require('ReactTestUtils'),
-    }
-  );
+  ReactDOMUMDEntry.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = {
+    // ReactPerf and ReactTestUtils currently only work with the DOM renderer
+    // so we expose them from here, but only in DEV mode.
+    ReactPerf: require('ReactPerf'),
+    ReactTestUtils: require('ReactTestUtils'),
+  };
+}
+
+// Inject ReactDOM into React for the addons UMD build that depends on ReactDOM (TransitionGroup).
+// We can remove this after we deprecate and remove the addons UMD build.
+if (React.addons) {
+  React.__SECRET_INJECTED_REACT_DOM_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = ReactDOMUMDEntry;
 }
 
 module.exports = ReactDOMUMDEntry;

--- a/src/umd/ReactWithAddonsUMDEntry.js
+++ b/src/umd/ReactWithAddonsUMDEntry.js
@@ -15,6 +15,7 @@ var ReactWithAddons = require('ReactWithAddons');
 
 // `version` will be added here by the React module.
 var ReactWithAddonsUMDEntry = Object.assign({
+  __SECRET_INJECTED_REACT_DOM_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: null, // Will be injected by ReactDOM UMD build.
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
     ReactCurrentOwner: require('ReactCurrentOwner'),
   },

--- a/src/umd/shims/ReactAddonsDOMDependenciesUMDShim.js
+++ b/src/umd/shims/ReactAddonsDOMDependenciesUMDShim.js
@@ -9,24 +9,22 @@
  * @providesModule ReactAddonsDOMDependenciesUMDShim
  */
 
-/* globals ReactDOM */
-
 'use strict';
 
-exports.getReactDOM = function() {
-  return ReactDOM;
-};
+function getReactDOM() {
+  var ReactWithAddonsUMDEntry = require('ReactWithAddonsUMDEntry');
+  // This is injected by the ReactDOM UMD build:
+  return ReactWithAddonsUMDEntry.__SECRET_INJECTED_REACT_DOM_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+}
 
-exports.getReactInstanceMap = function() {
-  return ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactInstanceMap;
-};
+exports.getReactDOM = getReactDOM;
 
 if (__DEV__) {
   exports.getReactPerf = function() {
-    return ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactPerf;
+    return getReactDOM().__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactPerf;
   };
 
   exports.getReactTestUtils = function() {
-    return ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactTestUtils;
+    return getReactDOM().__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactTestUtils;
   };
 }

--- a/src/umd/shims/ReactAddonsDOMDependenciesUMDShim.js
+++ b/src/umd/shims/ReactAddonsDOMDependenciesUMDShim.js
@@ -11,10 +11,16 @@
 
 'use strict';
 
+var ReactDOM;
+
 function getReactDOM() {
-  var ReactWithAddonsUMDEntry = require('ReactWithAddonsUMDEntry');
-  // This is injected by the ReactDOM UMD build:
-  return ReactWithAddonsUMDEntry.__SECRET_INJECTED_REACT_DOM_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+  if (!ReactDOM) {
+    // This is safe to use because current module only exists in the addons build:
+    var ReactWithAddonsUMDEntry = require('ReactWithAddonsUMDEntry');
+    // This is injected by the ReactDOM UMD build:
+    ReactDOM = ReactWithAddonsUMDEntry.__SECRET_INJECTED_REACT_DOM_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+  }
+  return ReactDOM;
 }
 
 exports.getReactDOM = getReactDOM;


### PR DESCRIPTION
This fixes #8392 and adds manual build fixtures so we can more easily check regressions like this.

We used to read ReactDOM as a global inside ReactAddonsDOMDependenciesUMDShim.
This didn't work in AMD environments such as RequireJS and SystemJS.

Instead, I changed it so that ReactDOM gets injected into ReactWithAddons by ReactDOM itself.
This way we don't have to try to require it (which wouldn't work because AMD doesn't handle circular dependencies well).

This means you have to load ReactDOM first before using ReactDOM-dependent addons, but this was already the case before.

This commit makes all build fixtures pass.
Build size changes appear insignificant.