### PR TITLE
Fiber logs timing for HostRoot if logTopLevelRenders enabled

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -61,8 +61,5 @@ src/renderers/shared/shared/__tests__/ReactEmptyComponent-test.js
 src/renderers/shared/shared/__tests__/ReactMultiChildText-test.js
 * should reorder keyed text nodes
 
-src/renderers/shared/shared/__tests__/ReactUpdates-test.js
-* marks top-level updates
-
 src/renderers/shared/shared/__tests__/refs-test.js
 * Should increase refs with an increase in divs

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1598,6 +1598,7 @@ src/renderers/shared/shared/__tests__/ReactUpdates-test.js
 * should queue updates from during mount
 * calls componentWillReceiveProps setState callback properly
 * does not call render after a component as been deleted
+* marks top-level updates
 * throws in setState if the update callback is not a function
 * throws in replaceState if the update callback is not a function
 * throws in forceUpdate if the update callback is not a function

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -40,6 +40,7 @@ var ReactFiberCompleteWork = require('ReactFiberCompleteWork');
 var ReactFiberCommitWork = require('ReactFiberCommitWork');
 var ReactFiberHostContext = require('ReactFiberHostContext');
 var ReactCurrentOwner = require('ReactCurrentOwner');
+var ReactFeatureFlags = require('ReactFeatureFlags');
 var getComponentName = require('getComponentName');
 
 var { cloneFiber } = require('ReactFiber');
@@ -628,6 +629,18 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       nextUnitOfWork = findNextUnitOfWork();
     }
 
+    let hostRootTimeMarker;
+    if (
+      ReactFeatureFlags.logTopLevelRenders &&
+      nextUnitOfWork &&
+      nextUnitOfWork.tag === HostRoot &&
+      nextUnitOfWork.child
+    ) {
+      const componentName = getComponentName(nextUnitOfWork.child) || '';
+      hostRootTimeMarker = 'React update: ' + componentName;
+      console.time(hostRootTimeMarker);
+    }
+
     // If there's a deadline, and we're not performing Task work, perform work
     // using this loop that checks the deadline on every iteration.
     if (deadline && priorityLevel > TaskPriority) {
@@ -671,6 +684,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
           clearErrors();
         }
       }
+    }
+
+    if (hostRootTimeMarker) {
+      console.timeEnd(hostRootTimeMarker);
     }
 
     return deadlineHasExpired;


### PR DESCRIPTION
Adds calls to `console.time` and `console.timeEnd` before beginning work on the top-level (`HostRoot`) component if `ReactFeatureFlags.logTopLevelRenders` is enabled.

Couple of concerns / open questions about this approach:
* Is this equivalent (enough) to the timing information stack logs?
* Are we concerned about timing in the case of bailouts caused by higher-priority updates? What about work that gets broken up across frames?

**Update**: This implementation potentially logs a single time entry for multiple roots, since `workLoop` calls `findNextUnitOfWork` which searches across roots. That's probably _not_ what we want. Maybe we could only enable this logging when `useSyncScheduling` is enabled?