### PR TITLE
Tutorial: Lifting State Up more legible

### DIFF
--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -187,6 +187,8 @@ Now we're passing down two props from Board to Square: `value` and `onClick`. Th
 
 ```javascript
 <button className="square" onClick={() => this.props.onClick()}>
+  {this.props.value}
+</button>
 ```
 
 This means that when the square is clicked, it calls the onClick function that was passed by the parent. The `onClick` doesn't have any special meaning here, but it's popular to name handler props starting with `on` and their implementations with `handle`. Try clicking a square – you should get an error because we haven't defined `handleClick` yet. Add it to the Board class:


### PR DESCRIPTION
## Improved Tutorial

I found it confusing when I got to the end of the **lifting up state** section and it says that **the squares Now you should be able to click in squares to fill them again** but they do not.

The key was to update the `<button ...>` tags content from `{this.state.value}` to `{this.props.value}`

Now everything works as expected. Hope others find this helpful!