### PR TITLE
Higher-Order Components docs withSubscription() example fix

### DIFF
--- a/docs/docs/higher-order-components.md
+++ b/docs/docs/higher-order-components.md
@@ -148,7 +148,7 @@ function withSubscription(WrappedComponent, selectData) {
 
     handleChange() {
       this.setState({
-        comments: selectData(DataSource, this.props)
+        data: selectData(DataSource, this.props)
       });
     }
 


### PR DESCRIPTION
withSubscription() implementation was probably copied from one of previous code examples. 

When setting component state in handleChange() it uses "comments" property and then passes data to child component as this.state.data.