### PR TITLE
"Don't Mutate the Original Component" example and description mismatch

### DIFF
--- a/docs/docs/higher-order-components.md
+++ b/docs/docs/higher-order-components.md
@@ -188,7 +188,7 @@ function logProps(InputComponent) {
 const EnhancedComponent = logProps(InputComponent);
 ```
 
-There are a few problems with this. One is that the input component cannot be reused separately from the enhanced component. More crucially, if you apply another HOC to `EnhancedComponent` that *also* mutates `shouldComponentUpdate`, the first HOC's functionality will be overridden! This HOC also won't work with function components, which do not have lifecycle methods.
+There are a few problems with this. One is that the input component cannot be reused separately from the enhanced component. More crucially, if you apply another HOC to `EnhancedComponent` that *also* mutates `componentWillReceiveProps`, the first HOC's functionality will be overridden! This HOC also won't work with function components, which do not have lifecycle methods.
 
 Mutating HOCs are a leaky abstraction—the consumer must know how they are implemented in order to avoid conflicts with other HOCs.
 


### PR DESCRIPTION
Description states that _"if you apply another HOC to `EnhancedComponent` that *also* mutates `shouldComponentUpdate`"_.

Example changes componentWillReceiveProps() method on the component not shouldComponentUpdate().

