### PR TITLE
Dont recreate maked context unless unmasked context changes

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1165,6 +1165,7 @@ src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
 * reads context when setState is above the provider
 * maintains the correct context when providers bail out due to low priority
 * maintains the correct context when unwinding due to an error in render
+* should not recreate masked context unless inputs have changed
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
 * catches render error in a boundary during full deferred mounting

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -31,6 +31,7 @@ var {
 var ReactTypeOfWork = require('ReactTypeOfWork');
 var {
   getMaskedContext,
+  getUnmaskedContext,
   hasContextChanged,
   pushContextProvider,
   pushTopLevelContextObject,
@@ -210,7 +211,8 @@ module.exports = function<T, P, I, TI, C, CX, CI>(
       return bailoutOnAlreadyFinishedWork(current, workInProgress);
     }
 
-    var context = getMaskedContext(workInProgress);
+    var unmaskedContext = getUnmaskedContext(workInProgress);
+    var context = getMaskedContext(workInProgress, unmaskedContext);
 
     var nextChildren;
 
@@ -427,7 +429,8 @@ module.exports = function<T, P, I, TI, C, CX, CI>(
     }
     var fn = workInProgress.type;
     var props = workInProgress.pendingProps;
-    var context = getMaskedContext(workInProgress);
+    var unmaskedContext = getUnmaskedContext(workInProgress);
+    var context = getMaskedContext(workInProgress, unmaskedContext);
 
     var value;
 


### PR DESCRIPTION
### The problem
Fiber memoizes the merged `context` object for context-providers but does not memoize the _masked_ `context` object. This caused `componentWillReceiveProps` to be called tpo frequently for `context` consumers which can result in infinite loops (eg if `componentWillReceiveProps()` calls `setState()`).

A minimal reproduction of one such infinite loop has been added as a test. It looks a little silly but it is greatly reduced from a bug I was investigating in a larger, real-world app.

### The proposed solution

Given the way `context` is currently implemented, I think the only solution to this issue is to store memoized copies of both the _unmasked_ and _masked_ `context` objects in order to avoid unnecessarily recreating the _masked_ `context`. ([Stack already does something like this](https://github.com/facebook/react/blob/f589274604838ebe479848c816c2f4e7f4c5f292/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js#L832-L838).)

### Concerns

The solution in this PR is kind of awkward due to the facts that:
1. We probably want to cache this memoized `context` on a class instance rather than the Fiber to avoid adding 2 additional fields to all Fibers (because most won't consume `context`). Prior art is `__reactInternalMemoizedMaskedChildContext`.
1. The class instance doesn't yet exist the first time the masked `context` is created so we have to initially set the cached object outside of `ReactFiberContext`.

This change is kind of flimsy, but so is `context` in general at the moment (see [this comment](https://github.com/facebook/react/pull/8631#issuecomment-270450606) for elaboration).

Let's talk about it. 😄 