### PR TITLE
[Fiber] Change work priority to represent the priority of the child

### DIFF
--- a/examples/fiber/index.html
+++ b/examples/fiber/index.html
@@ -90,7 +90,7 @@
           return r;
         }
         var newSize = s / 2;
-        var slowDown = false;
+        var slowDown = true;
         if (slowDown) {
           var e = performance.now() + 0.8;
           while (performance.now() < e) {

--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -49,9 +49,6 @@ src/renderers/shared/__tests__/ReactPerf-test.js
 * should not count time in a portal towards lifecycle method
 * should work when measurement starts during reconciliation
 
-src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
-* can defer side-effects and reuse them later - complex
-
 src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.js
 * can be retrieved by ID
 

--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -49,6 +49,9 @@ src/renderers/shared/__tests__/ReactPerf-test.js
 * should not count time in a portal towards lifecycle method
 * should work when measurement starts during reconciliation
 
+src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+* can defer side-effects and reuse them later - complex
+
 src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.js
 * can be retrieved by ID
 

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1245,6 +1245,7 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
 * updates a child even though the old props is empty
 * can defer side-effects and resume them later on
 * can defer side-effects and reuse them later - complex
+* does not drop priority from a progressed subtree
 * deprioritizes setStates that happens within a deprioritized tree
 * calls callback after update is flushed
 * calls setState callback even if component bails out

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1244,7 +1244,6 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
 * can update a completed tree before it has a chance to commit
 * updates a child even though the old props is empty
 * can defer side-effects and resume them later on
-* can defer side-effects and reuse them later - complex
 * deprioritizes setStates that happens within a deprioritized tree
 * calls callback after update is flushed
 * calls setState callback even if component bails out

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1246,6 +1246,7 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
 * can defer side-effects and resume them later on
 * can defer side-effects and reuse them later - complex
 * does not drop priority from a progressed subtree
+* does not complete already completed work
 * deprioritizes setStates that happens within a deprioritized tree
 * calls callback after update is flushed
 * calls setState callback even if component bails out

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1244,6 +1244,7 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
 * can update a completed tree before it has a chance to commit
 * updates a child even though the old props is empty
 * can defer side-effects and resume them later on
+* can defer side-effects and reuse them later - complex
 * deprioritizes setStates that happens within a deprioritized tree
 * calls callback after update is flushed
 * calls setState callback even if component bails out

--- a/src/renderers/art/ReactARTFiber.js
+++ b/src/renderers/art/ReactARTFiber.js
@@ -21,6 +21,7 @@ const invariant = require('fbjs/lib/invariant');
 const emptyObject = require('emptyObject');
 const React = require('React');
 const ReactFiberReconciler = require('ReactFiberReconciler');
+const ReactDOMFrameScheduling = require('ReactDOMFrameScheduling');
 
 const { Component } = React;
 
@@ -509,9 +510,9 @@ const ARTRenderer = ReactFiberReconciler({
     return emptyObject;
   },
 
-  scheduleAnimationCallback: window.requestAnimationFrame,
+  scheduleAnimationCallback: ReactDOMFrameScheduling.rAF,
 
-  scheduleDeferredCallback: window.requestIdleCallback,
+  scheduleDeferredCallback: ReactDOMFrameScheduling.rIC,
 
   shouldSetTextContent(props) {
     return (

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -20,6 +20,7 @@ var ReactControlledComponent = require('ReactControlledComponent');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 var ReactDOMFiberComponent = require('ReactDOMFiberComponent');
+var ReactDOMFrameScheduling = require('ReactDOMFrameScheduling');
 var ReactDOMInjection = require('ReactDOMInjection');
 var ReactGenericBatching = require('ReactGenericBatching');
 var ReactFiberReconciler = require('ReactFiberReconciler');
@@ -302,9 +303,9 @@ var DOMRenderer = ReactFiberReconciler({
     parentInstance.removeChild(child);
   },
 
-  scheduleAnimationCallback: window.requestAnimationFrame,
+  scheduleAnimationCallback: ReactDOMFrameScheduling.rAF,
 
-  scheduleDeferredCallback: window.requestIdleCallback,
+  scheduleDeferredCallback: ReactDOMFrameScheduling.rIC,
 
   useSyncScheduling: true,
 

--- a/src/renderers/dom/fiber/ReactDOMFrameScheduling.js
+++ b/src/renderers/dom/fiber/ReactDOMFrameScheduling.js
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactDOMFrameScheduling
+ * @flow
+ */
+
+'use strict';
+
+// This a built-in polyfill for requestIdleCallback. It works by scheduling
+// a requestAnimationFrame, store the time for the start of the frame, then
+// schedule a postMessage which gets scheduled after paint. Within the
+// postMessage handler do as much work as possible until time + frame rate.
+// By separating the idle call into a separate event tick we ensure that
+// layout, paint and other browser work is counted against the available time.
+// The frame rate is dynamically adjusted.
+
+import type { Deadline } from 'ReactFiberReconciler';
+
+var invariant = require('invariant');
+
+// TODO: There's no way to cancel these, because Fiber doesn't atm.
+let rAF : (callback : (time : number) => void) => number;
+let rIC : (callback : (deadline : Deadline) => void) => number;
+if (typeof requestAnimationFrame !== 'function') {
+  invariant(
+    false,
+    'React depends on requestAnimationFrame. Make sure that you load a ' +
+    'polyfill in older browsers.'
+  );
+} else if (typeof requestIdleCallback !== 'function') {
+  // Wrap requestAnimationFrame and polyfill requestIdleCallback.
+
+  var scheduledRAFCallback = null;
+  var scheduledRICCallback = null;
+
+  var isIdleScheduled = false;
+  var isAnimationFrameScheduled = false;
+
+  var frameDeadline = 0;
+  // We start out assuming that we run at 30fps but then the heuristic tracking
+  // will adjust this value to a faster fps if we get more frequent animation
+  // frames.
+  var previousFrameTime = 33;
+  var activeFrameTime = 33;
+
+  var frameDeadlineObject = {
+    timeRemaining: (
+      typeof performance === 'object' &&
+      typeof performance.now === 'function' ? function() {
+        // We assume that if we have a performance timer that the rAF callback
+        // gets a performance timer value. Not sure if this is always true.
+        return frameDeadline - performance.now();
+      } : function() {
+        // As a fallback we use Date.now.
+        return frameDeadline - Date.now();
+      }
+    ),
+  };
+
+  // We use the postMessage trick to defer idle work until after the repaint.
+  var messageKey =
+    '__reactIdleCallback$' + Math.random().toString(36).slice(2);
+  var idleTick = function(event) {
+    if (event.source !== window || event.data !== messageKey) {
+      return;
+    }
+    isIdleScheduled = false;
+    var callback = scheduledRICCallback;
+    scheduledRICCallback = null;
+    if (callback) {
+      callback(frameDeadlineObject);
+    }
+  };
+  // Assumes that we have addEventListener in this environment. Might need
+  // something better for old IE.
+  window.addEventListener('message', idleTick, false);
+
+  var animationTick = function(rafTime) {
+    isAnimationFrameScheduled = false;
+    var nextFrameTime = rafTime - frameDeadline + activeFrameTime;
+    if (nextFrameTime < activeFrameTime && previousFrameTime < activeFrameTime) {
+      if (nextFrameTime < 8) {
+        // Defensive coding. We don't support higher frame rates than 120hz.
+        // If we get lower than that, it is probably a bug.
+        nextFrameTime = 8;
+      }
+      // If one frame goes long, then the next one can be short to catch up.
+      // If two frames are short in a row, then that's an indication that we
+      // actually have a higher frame rate than what we're currently optimizing.
+      // We adjust our heuristic dynamically accordingly. For example, if we're
+      // running on 120hz display or 90hz VR display.
+      // Take the max of the two in case one of them was an anomaly due to
+      // missed frame deadlines.
+      activeFrameTime = nextFrameTime < previousFrameTime ?
+                        previousFrameTime : nextFrameTime;
+    } else {
+      previousFrameTime = nextFrameTime;
+    }
+    frameDeadline = rafTime + activeFrameTime;
+    if (!isIdleScheduled) {
+      isIdleScheduled = true;
+      window.postMessage(messageKey, '*');
+    }
+    var callback = scheduledRAFCallback;
+    scheduledRAFCallback = null;
+    if (callback) {
+      callback(rafTime);
+    }
+  };
+
+  rAF = function(callback : (time : number) => void) : number {
+    // This assumes that we only schedule one callback at a time because that's
+    // how Fiber uses it.
+    scheduledRAFCallback = callback;
+    if (!isAnimationFrameScheduled) {
+      // If rIC didn't already schedule one, we need to schedule a frame.
+      isAnimationFrameScheduled = true;
+      requestAnimationFrame(animationTick);
+    }
+    return 0;
+  };
+
+  rIC = function(callback : (deadline : Deadline) => void) : number {
+    // This assumes that we only schedule one callback at a time because that's
+    // how Fiber uses it.
+    scheduledRICCallback = callback;
+    if (!isAnimationFrameScheduled) {
+      // If rAF didn't already schedule one, we need to schedule a frame.
+      // TODO: If this rAF doesn't materialize because the browser throttles, we
+      // might want to still have setTimeout trigger rIC as a backup to ensure
+      // that we keep performing work.
+      isAnimationFrameScheduled = true;
+      requestAnimationFrame(animationTick);
+    }
+    return 0;
+  };
+} else {
+  rAF = requestAnimationFrame;
+  rIC = requestIdleCallback;
+}
+
+exports.rAF = rAF;
+exports.rIC = rIC;

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -1090,7 +1090,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
               returnFiber,
               currentFirstChild,
               newChild,
-              priority
             ));
 
           case REACT_PORTAL_TYPE:
@@ -1098,7 +1097,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
               returnFiber,
               currentFirstChild,
               newChild,
-              priority
             ));
         }
       }

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -192,19 +192,15 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     return existingChildren;
   }
 
-  function useFiber(fiber : Fiber, priority : PriorityLevel) : Fiber {
+  function useFiber(fiber : Fiber) : Fiber {
     // We currently set sibling to null and index to 0 here because it is easy
     // to forget to do before returning it. E.g. for the single child case.
     if (shouldClone) {
-      const clone = cloneFiber(fiber, priority);
+      const clone = cloneFiber(fiber);
       clone.index = 0;
       clone.sibling = null;
       return clone;
     } else {
-      // We override the pending priority even if it is higher, because if
-      // we're reconciling at a lower priority that means that this was
-      // down-prioritized.
-      fiber.pendingWorkPriority = priority;
       fiber.effectTag = NoEffect;
       fiber.index = 0;
       fiber.sibling = null;
@@ -248,17 +244,16 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
   function updateTextNode(
     returnFiber : Fiber,
     current : ?Fiber,
-    textContent : string,
-    priority : PriorityLevel
+    textContent : string
   ) {
     if (current == null || current.tag !== HostText) {
       // Insert
-      const created = createFiberFromText(textContent, priority);
+      const created = createFiberFromText(textContent);
       created.return = returnFiber;
       return created;
     } else {
       // Update
-      const existing = useFiber(current, priority);
+      const existing = useFiber(current);
       existing.pendingProps = textContent;
       existing.return = returnFiber;
       return existing;
@@ -268,18 +263,17 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
   function updateElement(
     returnFiber : Fiber,
     current : ?Fiber,
-    element : ReactElement,
-    priority : PriorityLevel
+    element : ReactElement
   ) : Fiber {
     if (current == null || current.type !== element.type) {
       // Insert
-      const created = createFiberFromElement(element, priority);
+      const created = createFiberFromElement(element);
       created.ref = coerceRef(current, element);
       created.return = returnFiber;
       return created;
     } else {
       // Move based on index
-      const existing = useFiber(current, priority);
+      const existing = useFiber(current);
       existing.ref = coerceRef(current, element);
       existing.pendingProps = element.props;
       existing.return = returnFiber;
@@ -294,18 +288,17 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
   function updateCoroutine(
     returnFiber : Fiber,
     current : ?Fiber,
-    coroutine : ReactCoroutine,
-    priority : PriorityLevel
+    coroutine : ReactCoroutine
   ) : Fiber {
     // TODO: Should this also compare handler to determine whether to reuse?
     if (current == null || current.tag !== CoroutineComponent) {
       // Insert
-      const created = createFiberFromCoroutine(coroutine, priority);
+      const created = createFiberFromCoroutine(coroutine);
       created.return = returnFiber;
       return created;
     } else {
       // Move based on index
-      const existing = useFiber(current, priority);
+      const existing = useFiber(current);
       existing.pendingProps = coroutine;
       existing.return = returnFiber;
       return existing;
@@ -315,20 +308,19 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
   function updateYield(
     returnFiber : Fiber,
     current : ?Fiber,
-    yieldNode : ReactYield,
-    priority : PriorityLevel
+    yieldNode : ReactYield
   ) : Fiber {
     // TODO: Should this also compare continuation to determine whether to reuse?
     if (current == null || current.tag !== YieldComponent) {
       // Insert
       const reifiedYield = createReifiedYield(yieldNode);
-      const created = createFiberFromYield(yieldNode, priority);
+      const created = createFiberFromYield(yieldNode);
       created.type = reifiedYield;
       created.return = returnFiber;
       return created;
     } else {
       // Move based on index
-      const existing = useFiber(current, priority);
+      const existing = useFiber(current);
       existing.type = createUpdatedReifiedYield(
         current.type,
         yieldNode
@@ -341,8 +333,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
   function updatePortal(
     returnFiber : Fiber,
     current : ?Fiber,
-    portal : ReactPortal,
-    priority : PriorityLevel
+    portal : ReactPortal
   ) : Fiber {
     if (
       current == null ||
@@ -351,12 +342,12 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       current.stateNode.implementation !== portal.implementation
     ) {
       // Insert
-      const created = createFiberFromPortal(portal, priority);
+      const created = createFiberFromPortal(portal);
       created.return = returnFiber;
       return created;
     } else {
       // Update
-      const existing = useFiber(current, priority);
+      const existing = useFiber(current);
       existing.pendingProps = portal.children || [];
       existing.return = returnFiber;
       return existing;
@@ -366,17 +357,16 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
   function updateFragment(
     returnFiber : Fiber,
     current : ?Fiber,
-    fragment : Iterable<*>,
-    priority : PriorityLevel
+    fragment : Iterable<*>
   ) : Fiber {
     if (current == null || current.tag !== Fragment) {
       // Insert
-      const created = createFiberFromFragment(fragment, priority);
+      const created = createFiberFromFragment(fragment);
       created.return = returnFiber;
       return created;
     } else {
       // Update
-      const existing = useFiber(current, priority);
+      const existing = useFiber(current);
       existing.pendingProps = fragment;
       existing.return = returnFiber;
       return existing;
@@ -385,14 +375,13 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
   function createChild(
     returnFiber : Fiber,
-    newChild : any,
-    priority : PriorityLevel
+    newChild : any
   ) : ?Fiber {
     if (typeof newChild === 'string' || typeof newChild === 'number') {
       // Text nodes doesn't have keys. If the previous node is implicitly keyed
       // we can continue to replace it without aborting even if it is not a text
       // node.
-      const created = createFiberFromText('' + newChild, priority);
+      const created = createFiberFromText('' + newChild);
       created.return = returnFiber;
       return created;
     }
@@ -400,35 +389,35 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     if (typeof newChild === 'object' && newChild !== null) {
       switch (newChild.$$typeof) {
         case REACT_ELEMENT_TYPE: {
-          const created = createFiberFromElement(newChild, priority);
+          const created = createFiberFromElement(newChild);
           created.ref = coerceRef(null, newChild);
           created.return = returnFiber;
           return created;
         }
 
         case REACT_COROUTINE_TYPE: {
-          const created = createFiberFromCoroutine(newChild, priority);
+          const created = createFiberFromCoroutine(newChild);
           created.return = returnFiber;
           return created;
         }
 
         case REACT_YIELD_TYPE: {
           const reifiedYield = createReifiedYield(newChild);
-          const created = createFiberFromYield(newChild, priority);
+          const created = createFiberFromYield(newChild);
           created.type = reifiedYield;
           created.return = returnFiber;
           return created;
         }
 
         case REACT_PORTAL_TYPE: {
-          const created = createFiberFromPortal(newChild, priority);
+          const created = createFiberFromPortal(newChild);
           created.return = returnFiber;
           return created;
         }
       }
 
       if (isArray(newChild) || getIteratorFn(newChild)) {
-        const created = createFiberFromFragment(newChild, priority);
+        const created = createFiberFromFragment(newChild);
         created.return = returnFiber;
         return created;
       }
@@ -440,8 +429,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
   function updateSlot(
     returnFiber : Fiber,
     oldFiber : ?Fiber,
-    newChild : any,
-    priority : PriorityLevel
+    newChild : any
   ) : ?Fiber {
     // Update the fiber if the keys match, otherwise return null.
 
@@ -454,14 +442,14 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       if (key !== null) {
         return null;
       }
-      return updateTextNode(returnFiber, oldFiber, '' + newChild, priority);
+      return updateTextNode(returnFiber, oldFiber, '' + newChild);
     }
 
     if (typeof newChild === 'object' && newChild !== null) {
       switch (newChild.$$typeof) {
         case REACT_ELEMENT_TYPE: {
           if (newChild.key === key) {
-            return updateElement(returnFiber, oldFiber, newChild, priority);
+            return updateElement(returnFiber, oldFiber, newChild);
           } else {
             return null;
           }
@@ -469,7 +457,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
         case REACT_COROUTINE_TYPE: {
           if (newChild.key === key) {
-            return updateCoroutine(returnFiber, oldFiber, newChild, priority);
+            return updateCoroutine(returnFiber, oldFiber, newChild);
           } else {
             return null;
           }
@@ -477,7 +465,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
         case REACT_YIELD_TYPE: {
           if (newChild.key === key) {
-            return updateYield(returnFiber, oldFiber, newChild, priority);
+            return updateYield(returnFiber, oldFiber, newChild);
           } else {
             return null;
           }
@@ -490,7 +478,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         if (key !== null) {
           return null;
         }
-        return updateFragment(returnFiber, oldFiber, newChild, priority);
+        return updateFragment(returnFiber, oldFiber, newChild);
       }
     }
 
@@ -501,15 +489,14 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     existingChildren : Map<string | number, Fiber>,
     returnFiber : Fiber,
     newIdx : number,
-    newChild : any,
-    priority : PriorityLevel
+    newChild : any
   ) : ?Fiber {
 
     if (typeof newChild === 'string' || typeof newChild === 'number') {
       // Text nodes doesn't have keys, so we neither have to check the old nor
       // new node for the key. If both are text nodes, they match.
       const matchedFiber = existingChildren.get(newIdx) || null;
-      return updateTextNode(returnFiber, matchedFiber, '' + newChild, priority);
+      return updateTextNode(returnFiber, matchedFiber, '' + newChild);
     }
 
     if (typeof newChild === 'object' && newChild !== null) {
@@ -518,34 +505,34 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
           const matchedFiber = existingChildren.get(
             newChild.key === null ? newIdx : newChild.key
           ) || null;
-          return updateElement(returnFiber, matchedFiber, newChild, priority);
+          return updateElement(returnFiber, matchedFiber, newChild);
         }
 
         case REACT_COROUTINE_TYPE: {
           const matchedFiber = existingChildren.get(
             newChild.key === null ? newIdx : newChild.key
           ) || null;
-          return updateCoroutine(returnFiber, matchedFiber, newChild, priority);
+          return updateCoroutine(returnFiber, matchedFiber, newChild);
         }
 
         case REACT_YIELD_TYPE: {
           const matchedFiber = existingChildren.get(
             newChild.key === null ? newIdx : newChild.key
           ) || null;
-          return updateYield(returnFiber, matchedFiber, newChild, priority);
+          return updateYield(returnFiber, matchedFiber, newChild);
         }
 
         case REACT_PORTAL_TYPE: {
           const matchedFiber = existingChildren.get(
             newChild.key === null ? newIdx : newChild.key
           ) || null;
-          return updatePortal(returnFiber, matchedFiber, newChild, priority);
+          return updatePortal(returnFiber, matchedFiber, newChild);
         }
       }
 
       if (isArray(newChild) || getIteratorFn(newChild)) {
         const matchedFiber = existingChildren.get(newIdx) || null;
-        return updateFragment(returnFiber, matchedFiber, newChild, priority);
+        return updateFragment(returnFiber, matchedFiber, newChild);
       }
     }
 
@@ -597,8 +584,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
   function reconcileChildrenArray(
     returnFiber : Fiber,
     currentFirstChild : ?Fiber,
-    newChildren : Array<*>,
-    priority : PriorityLevel) : ?Fiber {
+    newChildren : Array<*>) : ?Fiber {
 
     // This algorithm can't optimize by searching from boths ends since we
     // don't have backpointers on fibers. I'm trying to see how far we can get
@@ -647,8 +633,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       const newFiber = updateSlot(
         returnFiber,
         oldFiber,
-        newChildren[newIdx],
-        priority
+        newChildren[newIdx]
       );
       if (!newFiber) {
         // TODO: This breaks on empty slots like null children. That's
@@ -694,8 +679,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       for (; newIdx < newChildren.length; newIdx++) {
         const newFiber = createChild(
           returnFiber,
-          newChildren[newIdx],
-          priority
+          newChildren[newIdx]
         );
         if (!newFiber) {
           continue;
@@ -721,8 +705,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         existingChildren,
         returnFiber,
         newIdx,
-        newChildren[newIdx],
-        priority
+        newChildren[newIdx]
       );
       if (newFiber) {
         if (shouldTrackSideEffects) {
@@ -758,8 +741,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
   function reconcileChildrenIterator(
     returnFiber : Fiber,
     currentFirstChild : ?Fiber,
-    newChildrenIterable : Iterable<*>,
-    priority : PriorityLevel) : ?Fiber {
+    newChildrenIterable : Iterable<*>) : ?Fiber {
 
     // This is the same implementation as reconcileChildrenArray(),
     // but using the iterator instead.
@@ -810,8 +792,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       const newFiber = updateSlot(
         returnFiber,
         oldFiber,
-        step.value,
-        priority
+        step.value
       );
       if (!newFiber) {
         // TODO: This breaks on empty slots like null children. That's
@@ -857,8 +838,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       for (; !step.done; newIdx++, step = newChildren.next()) {
         const newFiber = createChild(
           returnFiber,
-          step.value,
-          priority
+          step.value
         );
         if (!newFiber) {
           continue;
@@ -884,8 +864,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         existingChildren,
         returnFiber,
         newIdx,
-        step.value,
-        priority
+        step.value
       );
       if (newFiber) {
         if (shouldTrackSideEffects) {
@@ -921,8 +900,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
   function reconcileSingleTextNode(
     returnFiber : Fiber,
     currentFirstChild : ?Fiber,
-    textContent : string,
-    priority : PriorityLevel
+    textContent : string
   ) : Fiber {
     // There's no need to check for keys on text nodes since we don't have a
     // way to define them.
@@ -930,7 +908,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       // We already have an existing node so let's just update it and delete
       // the rest.
       deleteRemainingChildren(returnFiber, currentFirstChild.sibling);
-      const existing = useFiber(currentFirstChild, priority);
+      const existing = useFiber(currentFirstChild);
       existing.pendingProps = textContent;
       existing.return = returnFiber;
       return existing;
@@ -938,7 +916,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     // The existing first child is not a text node so we need to create one
     // and delete the existing ones.
     deleteRemainingChildren(returnFiber, currentFirstChild);
-    const created = createFiberFromText(textContent, priority);
+    const created = createFiberFromText(textContent);
     created.return = returnFiber;
     return created;
   }
@@ -946,8 +924,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
   function reconcileSingleElement(
     returnFiber : Fiber,
     currentFirstChild : ?Fiber,
-    element : ReactElement,
-    priority : PriorityLevel
+    element : ReactElement
   ) : Fiber {
     const key = element.key;
     let child = currentFirstChild;
@@ -957,7 +934,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       if (child.key === key) {
         if (child.type === element.type) {
           deleteRemainingChildren(returnFiber, child.sibling);
-          const existing = useFiber(child, priority);
+          const existing = useFiber(child);
           existing.ref = coerceRef(child, element);
           existing.pendingProps = element.props;
           existing.return = returnFiber;
@@ -976,7 +953,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       child = child.sibling;
     }
 
-    const created = createFiberFromElement(element, priority);
+    const created = createFiberFromElement(element);
     created.ref = coerceRef(currentFirstChild, element);
     created.return = returnFiber;
     return created;
@@ -985,8 +962,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
   function reconcileSingleCoroutine(
     returnFiber : Fiber,
     currentFirstChild : ?Fiber,
-    coroutine : ReactCoroutine,
-    priority : PriorityLevel
+    coroutine : ReactCoroutine
   ) : Fiber {
     const key = coroutine.key;
     let child = currentFirstChild;
@@ -996,7 +972,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       if (child.key === key) {
         if (child.tag === CoroutineComponent) {
           deleteRemainingChildren(returnFiber, child.sibling);
-          const existing = useFiber(child, priority);
+          const existing = useFiber(child);
           existing.pendingProps = coroutine;
           existing.return = returnFiber;
           return existing;
@@ -1010,7 +986,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       child = child.sibling;
     }
 
-    const created = createFiberFromCoroutine(coroutine, priority);
+    const created = createFiberFromCoroutine(coroutine);
     created.return = returnFiber;
     return created;
   }
@@ -1018,8 +994,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
   function reconcileSingleYield(
     returnFiber : Fiber,
     currentFirstChild : ?Fiber,
-    yieldNode : ReactYield,
-    priority : PriorityLevel
+    yieldNode : ReactYield
   ) : Fiber {
     const key = yieldNode.key;
     let child = currentFirstChild;
@@ -1029,7 +1004,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       if (child.key === key) {
         if (child.tag === YieldComponent) {
           deleteRemainingChildren(returnFiber, child.sibling);
-          const existing = useFiber(child, priority);
+          const existing = useFiber(child);
           existing.type = createUpdatedReifiedYield(
             child.type,
             yieldNode
@@ -1047,7 +1022,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     }
 
     const reifiedYield = createReifiedYield(yieldNode);
-    const created = createFiberFromYield(yieldNode, priority);
+    const created = createFiberFromYield(yieldNode);
     created.type = reifiedYield;
     created.return = returnFiber;
     return created;
@@ -1056,8 +1031,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
   function reconcileSinglePortal(
     returnFiber : Fiber,
     currentFirstChild : ?Fiber,
-    portal : ReactPortal,
-    priority : PriorityLevel
+    portal : ReactPortal
   ) : Fiber {
     const key = portal.key;
     let child = currentFirstChild;
@@ -1071,7 +1045,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
           child.stateNode.implementation === portal.implementation
         ) {
           deleteRemainingChildren(returnFiber, child.sibling);
-          const existing = useFiber(child, priority);
+          const existing = useFiber(child);
           existing.pendingProps = portal.children || [];
           existing.return = returnFiber;
           return existing;
@@ -1085,7 +1059,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       child = child.sibling;
     }
 
-    const created = createFiberFromPortal(portal, priority);
+    const created = createFiberFromPortal(portal);
     created.return = returnFiber;
     return created;
   }
@@ -1097,8 +1071,10 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     returnFiber : Fiber,
     currentFirstChild : ?Fiber,
     newChild : any,
-    priority : PriorityLevel
+    priorityLevel : PriorityLevel
   ) : ?Fiber {
+    returnFiber.pendingWorkPriority = priorityLevel;
+
     // This function is not recursive.
     // If the top level item is an array, we treat it as a set of children,
     // not as a fragment. Nested arrays on the other hand will be treated as
@@ -1170,8 +1146,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       return placeSingleChild(reconcileSingleTextNode(
         returnFiber,
         currentFirstChild,
-        '' + newChild,
-        priority
+        '' + newChild
       ));
     }
 
@@ -1181,32 +1156,28 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
           return placeSingleChild(reconcileSingleElement(
             returnFiber,
             currentFirstChild,
-            newChild,
-            priority
+            newChild
           ));
 
         case REACT_COROUTINE_TYPE:
           return placeSingleChild(reconcileSingleCoroutine(
             returnFiber,
             currentFirstChild,
-            newChild,
-            priority
+            newChild
           ));
 
         case REACT_YIELD_TYPE:
           return placeSingleChild(reconcileSingleYield(
             returnFiber,
             currentFirstChild,
-            newChild,
-            priority
+            newChild
           ));
 
         case REACT_PORTAL_TYPE:
           return placeSingleChild(reconcileSinglePortal(
             returnFiber,
             currentFirstChild,
-            newChild,
-            priority
+            newChild
           ));
       }
 
@@ -1214,8 +1185,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         return reconcileChildrenArray(
           returnFiber,
           currentFirstChild,
-          newChild,
-          priority
+          newChild
         );
       }
 
@@ -1223,8 +1193,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         return reconcileChildrenIterator(
           returnFiber,
           currentFirstChild,
-          newChild,
-          priority
+          newChild
         );
       }
     }
@@ -1276,6 +1245,10 @@ exports.cloneChildFibers = function(current : ?Fiber, workInProgress : Fiber) : 
   if (!workInProgress.child) {
     return;
   }
+
+  // cloneChildFibers is only called when bailing out on already finished work.
+  // So the pendingWorkPriority should remain at its existing value.
+
   if (current && workInProgress.child === current.child) {
     // We use workInProgress.child since that lets Flow know that it can't be
     // null since we validated that already. However, as the line above suggests
@@ -1288,16 +1261,13 @@ exports.cloneChildFibers = function(current : ?Fiber, workInProgress : Fiber) : 
     // observable when the first sibling has lower priority work remaining
     // than the next sibling. At that point we should add tests that catches
     // this.
-    let newChild = cloneFiber(currentChild, currentChild.pendingWorkPriority);
+    let newChild = cloneFiber(currentChild);
     workInProgress.child = newChild;
 
     newChild.return = workInProgress;
     while (currentChild.sibling) {
       currentChild = currentChild.sibling;
-      newChild = newChild.sibling = cloneFiber(
-        currentChild,
-        currentChild.pendingWorkPriority
-      );
+      newChild = newChild.sibling = cloneFiber(currentChild);
       newChild.return = workInProgress;
     }
     newChild.sibling = null;

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -128,6 +128,8 @@ export type Fiber = {
   lastEffect: ?Fiber,
 
   // This will be used to quickly determine if a subtree has no pending changes.
+  // It represents the priority of the child subtree, not including the
+  // fiber itself.
   pendingWorkPriority: PriorityLevel,
 
   // This value represents the priority level that was last used to process this
@@ -234,7 +236,7 @@ function shouldConstruct(Component) {
 
 // This is used to create an alternate fiber to do work on.
 // TODO: Rename to createWorkInProgressFiber or something like that.
-exports.cloneFiber = function(fiber : Fiber, priorityLevel : PriorityLevel) : Fiber {
+exports.cloneFiber = function(fiber : Fiber) : Fiber {
   // We clone to get a work in progress. That means that this fiber is the
   // current. To make it safe to reuse that fiber later on as work in progress
   // we need to reset its work in progress flag now. We don't have an
@@ -278,7 +280,7 @@ exports.cloneFiber = function(fiber : Fiber, priorityLevel : PriorityLevel) : Fi
   // TODO: Pass in the new pendingProps as an argument maybe?
   alt.pendingProps = fiber.pendingProps;
   cloneUpdateQueue(fiber, alt);
-  alt.pendingWorkPriority = priorityLevel;
+  alt.pendingWorkPriority = fiber.pendingWorkPriority;
 
   alt.memoizedProps = fiber.memoizedProps;
   alt.memoizedState = fiber.memoizedState;
@@ -297,15 +299,13 @@ exports.createHostRootFiber = function() : Fiber {
   return fiber;
 };
 
-exports.createFiberFromElement = function(element : ReactElement, priorityLevel : PriorityLevel) : Fiber {
+exports.createFiberFromElement = function(element : ReactElement) : Fiber {
   let owner = null;
   if (__DEV__) {
     owner = element._owner;
   }
-
   const fiber = createFiberFromElementType(element.type, element.key, owner);
   fiber.pendingProps = element.props;
-  fiber.pendingWorkPriority = priorityLevel;
 
   if (__DEV__) {
     fiber._debugSource = element._source;
@@ -315,19 +315,17 @@ exports.createFiberFromElement = function(element : ReactElement, priorityLevel 
   return fiber;
 };
 
-exports.createFiberFromFragment = function(elements : ReactFragment, priorityLevel : PriorityLevel) : Fiber {
+exports.createFiberFromFragment = function(elements : ReactFragment) : Fiber {
   // TODO: Consider supporting keyed fragments. Technically, we accidentally
   // support that in the existing React.
   const fiber = createFiber(Fragment, null);
   fiber.pendingProps = elements;
-  fiber.pendingWorkPriority = priorityLevel;
   return fiber;
 };
 
-exports.createFiberFromText = function(content : string, priorityLevel : PriorityLevel) : Fiber {
+exports.createFiberFromText = function(content : string) : Fiber {
   const fiber = createFiber(HostText, null);
   fiber.pendingProps = content;
-  fiber.pendingWorkPriority = priorityLevel;
   return fiber;
 };
 
@@ -384,24 +382,22 @@ function createFiberFromElementType(type : mixed, key : null | string, debugOwne
 
 exports.createFiberFromElementType = createFiberFromElementType;
 
-exports.createFiberFromCoroutine = function(coroutine : ReactCoroutine, priorityLevel : PriorityLevel) : Fiber {
+exports.createFiberFromCoroutine = function(coroutine : ReactCoroutine) : Fiber {
   const fiber = createFiber(CoroutineComponent, coroutine.key);
   fiber.type = coroutine.handler;
   fiber.pendingProps = coroutine;
-  fiber.pendingWorkPriority = priorityLevel;
   return fiber;
 };
 
-exports.createFiberFromYield = function(yieldNode : ReactYield, priorityLevel : PriorityLevel) : Fiber {
+exports.createFiberFromYield = function(yieldNode : ReactYield) : Fiber {
   const fiber = createFiber(YieldComponent, yieldNode.key);
   fiber.pendingProps = {};
   return fiber;
 };
 
-exports.createFiberFromPortal = function(portal : ReactPortal, priorityLevel : PriorityLevel) : Fiber {
+exports.createFiberFromPortal = function(portal : ReactPortal) : Fiber {
   const fiber = createFiber(HostPortal, portal.key);
   fiber.pendingProps = portal.children || [];
-  fiber.pendingWorkPriority = priorityLevel;
   fiber.stateNode = {
     containerInfo: portal.containerInfo,
     implementation: portal.implementation,

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -629,7 +629,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     if (workInProgress.progressedPriority === priorityLevel) {
       // If we have progressed work on this priority level already, we can
       // proceed with that as the child.
-      workInProgress.pendingWorkPriority = priorityLevel;
       workInProgress.child = workInProgress.progressedChild;
     }
 

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -573,18 +573,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     workInProgress : Fiber,
     priorityLevel : PriorityLevel
   ) : ?Fiber {
-    // TODO: We should be able to bail out early if the children have no more
-    // work to do and have already completed. However, we currently don't have
-    // a way of knowing if the child has completed.
-    // if (workInProgress.priorityOfChildren <= priorityLevel) {
-    //   // If there are side-effects in these children that have not yet been
-    //   // committed we need to ensure that they get properly transferred up.
-    //   if (current && current.child !== workInProgress.child) {
-    //     reuseChildrenEffects(workInProgress, child);
-    //   }
-    //   return null;
-    // }
-
     if (current && workInProgress.child === current.child) {
       // If we had any progressed work already, that is invalid at this point so
       // let's throw it out.

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -583,9 +583,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       }
       return null;
     } else {
-      // Keep the existing progressed priority
       cloneChildFibers(current, workInProgress);
-      markChildAsProgressed(current, workInProgress, workInProgress.progressedPriority);
+      markChildAsProgressed(current, workInProgress, priorityLevel);
       return workInProgress.child;
     }
   }

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -629,6 +629,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     if (workInProgress.progressedPriority === priorityLevel) {
       // If we have progressed work on this priority level already, we can
       // proceed with that as the child.
+      workInProgress.pendingWorkPriority = priorityLevel;
       workInProgress.child = workInProgress.progressedChild;
     }
 

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -67,8 +67,8 @@ export type HostConfig<T, P, I, TI, PI, C, CX, PL> = {
   insertBefore(parentInstance : I | C, child : I | TI, beforeChild : I | TI) : void,
   removeChild(parentInstance : I | C, child : I | TI) : void,
 
-  scheduleAnimationCallback(callback : () => void) : void,
-  scheduleDeferredCallback(callback : (deadline : Deadline) => void) : void,
+  scheduleAnimationCallback(callback : () => void) : number | void,
+  scheduleDeferredCallback(callback : (deadline : Deadline) => void) : number | void,
 
   prepareForCommit() : void,
   resetAfterCommit() : void,

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -562,7 +562,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
   }
 
   function performFailedUnitOfWork(workInProgress : Fiber) : ?Fiber {
-
     // The current, flushed, state of this fiber is the alternate.
     // Ideally nothing should rely on this, but relying on it here
     // means that we don't need an additional field on the work in
@@ -576,6 +575,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
     }
 
     if (!next) {
+      const child = workInProgress.child;
+      if (child) {
+        // If we bailed out, ensure that we don't drop the effects from
+        // the subtree.
+        reuseChildrenEffects(workInProgress, child);
+      }
       // If this doesn't spawn new work, complete the current work.
       next = completeUnitOfWork(workInProgress);
     }

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -75,7 +75,6 @@ var {
 
 var {
   getPendingPriority,
-  addTopLevelUpdate,
 } = require('ReactFiberUpdateQueue');
 
 var {
@@ -1120,10 +1119,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
   }
 
   function scheduleErrorRecovery(fiber : Fiber) {
-    if (fiber.tag === HostRoot) {
-      // This is a root, which does not have a parent, so we need to use the
-      // update queue.
-      addTopLevelUpdate(fiber, { element: null }, null, TaskPriority);
+    // Set the priority on the boundaries children, not the boundary itself.
+    // This is a workaround for the fact that host roots, which act as error
+    // boundaries for uncaught errors
+    fiber.pendingWorkPriority = TaskPriority;
+    if (fiber.alternate) {
+      fiber.alternate.pendingWorkPriority = TaskPriority;
     }
     scheduleUpdate(fiber, TaskPriority);
   }

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -333,7 +333,7 @@ describe('ReactIncremental', () => {
 
     // We're now rendering an update that will bail out on updating middle.
     ReactNoop.render(<Foo text="bar" />);
-    ReactNoop.flushDeferredPri(45 + 5);
+    ReactNoop.flushDeferredPri(45 + 10);
 
     expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
 
@@ -428,7 +428,7 @@ describe('ReactIncremental', () => {
     // Let us try this again without fully finishing the first time. This will
     // create a hanging subtree that is reconciling at the normal priority.
     ReactNoop.render(<Foo text="foo" />);
-    ReactNoop.flushDeferredPri(40);
+    ReactNoop.flushDeferredPri(35);
 
     expect(ops).toEqual(['Foo', 'Bar']);
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -2225,7 +2225,7 @@ describe('ReactIncremental', () => {
 
     function Root(props) {
       return (
-        <div hidden={true}>
+        <div hidden={props.hidden}>
           <Middle {...props} />
         </div>
       );
@@ -2233,7 +2233,7 @@ describe('ReactIncremental', () => {
 
     // Initial render of the entire tree.
     // Renders: Root, Middle, FirstChild, SecondChild
-    ReactNoop.render(<Root>A</Root>);
+    ReactNoop.render(<Root hidden={true}>A</Root>);
     ReactNoop.flush();
 
     expect(renderCounter).toBe(1);
@@ -2241,7 +2241,7 @@ describe('ReactIncremental', () => {
     // Schedule low priority work to update children.
     // Give it enough time to partially render.
     // Renders: Root, Middle, FirstChild
-    ReactNoop.render(<Root>B</Root>);
+    ReactNoop.render(<Root hidden={true}>B</Root>);
     ReactNoop.flushDeferredPri(20 + 30 + 5);
 
     // At this point our FirstChild component has rendered a second time,
@@ -2255,7 +2255,7 @@ describe('ReactIncremental', () => {
     // Next interrupt the partial render with higher priority work.
     // The in-progress child content will bailout.
     // Renders: Root, Middle, FirstChild, SecondChild
-    ReactNoop.render(<Root>B</Root>);
+    ReactNoop.render(<Root hidden={false}>B</Root>);
     ReactNoop.flush();
 
     // At this point the higher priority render has completed.

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -2225,7 +2225,7 @@ describe('ReactIncremental', () => {
 
     function Root(props) {
       return (
-        <div hidden={props.hidden}>
+        <div hidden={true}>
           <Middle {...props} />
         </div>
       );
@@ -2233,7 +2233,7 @@ describe('ReactIncremental', () => {
 
     // Initial render of the entire tree.
     // Renders: Root, Middle, FirstChild, SecondChild
-    ReactNoop.render(<Root hidden={true}>A</Root>);
+    ReactNoop.render(<Root>A</Root>);
     ReactNoop.flush();
 
     expect(renderCounter).toBe(1);
@@ -2241,7 +2241,7 @@ describe('ReactIncremental', () => {
     // Schedule low priority work to update children.
     // Give it enough time to partially render.
     // Renders: Root, Middle, FirstChild
-    ReactNoop.render(<Root hidden={true}>B</Root>);
+    ReactNoop.render(<Root>B</Root>);
     ReactNoop.flushDeferredPri(20 + 30 + 5);
 
     // At this point our FirstChild component has rendered a second time,
@@ -2255,7 +2255,7 @@ describe('ReactIncremental', () => {
     // Next interrupt the partial render with higher priority work.
     // The in-progress child content will bailout.
     // Renders: Root, Middle, FirstChild, SecondChild
-    ReactNoop.render(<Root hidden={false}>B</Root>);
+    ReactNoop.render(<Root>B</Root>);
     ReactNoop.flush();
 
     // At this point the higher priority render has completed.

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -835,8 +835,8 @@ describe('ReactIncrementalSideEffects', () => {
         // Updated.
         span(1),
         div(
+          span(1),
           // Still not updated.
-          span(0),
           span(0),
           span(0)
         )

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -1013,8 +1013,8 @@ describe('ReactIncrementalSideEffects', () => {
         // Updated.
         span(1),
         div(
-          span(1),
           // Still not updated.
+          span(0),
           span(0),
           span(0)
         )

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -844,6 +844,96 @@ describe('ReactIncrementalSideEffects', () => {
     ]);
   });
 
+  it('does not complete already completed work', () => {
+    let ops = [];
+    let lowPri;
+    let highPri;
+
+    function LowPriDidComplete() {
+      ops.push('LowPriDidComplete');
+      // Because this is terminal, beginning work on LowPriDidComplete implies
+      // that LowPri will be completed before the scheduler yields.
+      return null;
+    }
+
+    class LowPri extends React.Component {
+      state = { step: 0 };
+      render() {
+        ops.push('LowPri');
+        lowPri = this;
+        return [
+          <span prop={this.state.step} />,
+          <LowPriDidComplete />,
+        ];
+      }
+    }
+
+    function LowPriSibling() {
+      ops.push('LowPriSibling');
+      return null;
+    }
+
+    class HighPri extends React.Component {
+      state = { step: 0 };
+      render() {
+        ops.push('HighPri');
+        highPri = this;
+        return <span prop={this.state.step} />;
+      }
+    }
+
+    function App() {
+      ops.push('App');
+      return [
+        <div>
+          <LowPri />
+          <LowPriSibling />
+        </div>,
+        <div><HighPri /></div>,
+      ];
+    }
+
+    ReactNoop.render(<App />);
+    ReactNoop.flush();
+    expect(ReactNoop.getChildren()).toEqual([
+      div(span(0)),
+      div(span(0)),
+    ]);
+    ops = [];
+
+    lowPri.setState({ step: 1 });
+    // Do just enough work to begin LowPri
+    ReactNoop.flushDeferredPri(30);
+    expect(ops).toEqual(['LowPri']);
+    // Now we'll do one more tick of work to complete LowPri. Because LowPri
+    // has a sibling, the parent div of LowPri has not yet completed.
+    ReactNoop.flushDeferredPri(10);
+    expect(ops).toEqual(['LowPri', 'LowPriDidComplete']);
+    expect(ReactNoop.getChildren()).toEqual([
+      div(span(0)), // Complete, but not yet updated
+      div(span(0)),
+    ]);
+    ops = [];
+
+    // Interrupt with high pri update
+    ReactNoop.performAnimationWork(() => highPri.setState({ step: 1 }));
+    ReactNoop.flushAnimationPri();
+    expect(ops).toEqual(['HighPri']);
+    expect(ReactNoop.getChildren()).toEqual([
+      div(span(0)), // Completed, but not yet updated
+      div(span(1)),
+    ]);
+    ops = [];
+
+    // If this is not enough to commit the rest of the work, that means we're
+    // not bailing out on the already-completed LowPri tree.
+    ReactNoop.flushDeferredPri(45);
+    expect(ReactNoop.getChildren()).toEqual([
+      div(span(1)),
+      div(span(1)),
+    ]);
+  });
+
   it('deprioritizes setStates that happens within a deprioritized tree', () => {
     var ops = [];
 


### PR DESCRIPTION
- When the children are reconciled, set the work priority of the parent to the current priority level. Do not set the work priority of the children.
- In `findNextUnitOfWork`, we need to check both the update priority and the work priority of the root, since the work priority field no longer represents both.
- In `scheduleUpdate`, when bubbling the priority to the root, skip the fiber that is being updated on and start with the parent.
- Move `resetWorkPriority` from `commitAllWork` in the scheduler into `ReactFiberCompleteWork` so we can branch on the type of the component. This is needed for HostComponents, which may have leftover work priority if we bailed out on a hidden subtree.
- Because a fiber has no field that represents its own priority, we cannot bailout on low priority at the beginning of `beginWork`. Instead we have to perform that check while performing work on the parent, before its child is returned.