### PR TITLE
[Fiber] Remove callbackList field from Fiber

### DIFF
--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -277,7 +277,7 @@ exports.cloneFiber = function(fiber : Fiber, priorityLevel : PriorityLevel) : Fi
   // pendingProps is here for symmetry but is unnecessary in practice for now.
   // TODO: Pass in the new pendingProps as an argument maybe?
   alt.pendingProps = fiber.pendingProps;
-  cloneUpdateQueue(alt, fiber);
+  cloneUpdateQueue(fiber, alt);
   alt.pendingWorkPriority = priorityLevel;
 
   alt.memoizedProps = fiber.memoizedProps;

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -111,8 +111,7 @@ export type Fiber = {
 
   // A queue of state updates and callbacks.
   updateQueue: UpdateQueue | null,
-  // A list of callbacks that should be called during the next commit.
-  callbackList: UpdateQueue | null,
+
   // The state used to create the output
   memoizedState: any,
 
@@ -203,7 +202,6 @@ var createFiber = function(tag : TypeOfWork, key : null | string) : Fiber {
     pendingProps: null,
     memoizedProps: null,
     updateQueue: null,
-    callbackList: null,
     memoizedState: null,
 
     effectTag: NoEffect,

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -30,6 +30,7 @@ var { commitCallbacks } = require('ReactFiberUpdateQueue');
 var {
   Placement,
   Update,
+  Callback,
   ContentReset,
 } = require('ReactTypeOfSideEffect');
 
@@ -410,17 +411,16 @@ module.exports = function<T, P, I, TI, C, CX, CI>(
             }
           }
         }
-        const callbackList = finishedWork.callbackList;
-        if (callbackList) {
-          commitCallbacks(finishedWork, callbackList, instance);
+        if ((finishedWork.effectTag & Callback) && finishedWork.updateQueue) {
+          commitCallbacks(finishedWork, finishedWork.updateQueue, instance);
         }
         return;
       }
       case HostRoot: {
-        const callbackList = finishedWork.callbackList;
-        if (callbackList) {
+        const updateQueue = finishedWork.updateQueue;
+        if (updateQueue) {
           const instance = finishedWork.child && finishedWork.child.stateNode;
-          commitCallbacks(finishedWork, callbackList, instance);
+          commitCallbacks(finishedWork, updateQueue, instance);
         }
         return;
       }

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -39,7 +39,6 @@ exports.createFiberRoot = function(containerInfo : any) : FiberRoot {
     containerInfo: containerInfo,
     isScheduled: false,
     nextScheduledRoot: null,
-    callbackList: null,
     context: null,
     pendingContext: null,
   };

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -113,21 +113,25 @@ function ensureUpdateQueue(fiber : Fiber) : UpdateQueue {
 }
 
 // Clones an update queue from a source fiber onto its alternate.
-function cloneUpdateQueue(alt : Fiber, fiber : Fiber) : UpdateQueue | null {
-  const sourceQueue = fiber.updateQueue;
-  if (!sourceQueue) {
+function cloneUpdateQueue(current : Fiber, workInProgress : Fiber) : UpdateQueue | null {
+  const currentQueue = current.updateQueue;
+  if (!currentQueue) {
     // The source fiber does not have an update queue.
-    alt.updateQueue = null;
+    workInProgress.updateQueue = null;
     return null;
   }
   // If the alternate already has a queue, reuse the previous object.
-  const altQueue = alt.updateQueue || {};
-  altQueue.first = sourceQueue.first;
-  altQueue.last = sourceQueue.last;
-  altQueue.hasForceUpdate = sourceQueue.hasForceUpdate;
-  altQueue.callbackList = sourceQueue.callbackList;
-  altQueue.isProcessing = sourceQueue.isProcessing;
-  alt.updateQueue = altQueue;
+  const altQueue = workInProgress.updateQueue || {};
+  altQueue.first = currentQueue.first;
+  altQueue.last = currentQueue.last;
+
+  // These fields are invalid by the time we clone from current. Reset them.
+  altQueue.hasForceUpdate = false;
+  altQueue.callbackList = null;
+  altQueue.isProcessing = false;
+
+  workInProgress.updateQueue = altQueue;
+
   return altQueue;
 }
 exports.cloneUpdateQueue = cloneUpdateQueue;


### PR DESCRIPTION
Moves it to UpdateQueue instead so that we don't waste memory for components that don't have update queues.

Unobservable, so no tests.