### PR TITLE
Remove duplicated 'getDeclarationErrorAddendum' method implementations in react-dom.js

### DIFF
--- a/docs/js/react-dom.js
+++ b/docs/js/react-dom.js
@@ -5514,19 +5514,6 @@ var RESERVED_PROPS = {
 // Node type for document fragments (Node.DOCUMENT_FRAGMENT_NODE).
 var DOC_FRAGMENT_TYPE = 11;
 
-function getDeclarationErrorAddendum(internalInstance) {
-  if (internalInstance) {
-    var owner = internalInstance._currentElement._owner || null;
-    if (owner) {
-      var name = owner.getName();
-      if (name) {
-        return ' This DOM node was rendered by `' + name + '`.';
-      }
-    }
-  }
-  return '';
-}
-
 function friendlyStringify(obj) {
   if (typeof obj === 'object') {
     if (Array.isArray(obj)) {
@@ -7358,16 +7345,6 @@ function updateOptionsIfPendingUpdateAndMounted() {
       updateOptions(this, Boolean(props.multiple), value);
     }
   }
-}
-
-function getDeclarationErrorAddendum(owner) {
-  if (owner) {
-    var name = owner.getName();
-    if (name) {
-      return ' Check the render method of `' + name + '`.';
-    }
-  }
-  return '';
 }
 
 var valuePropNames = ['value', 'defaultValue'];
@@ -15966,16 +15943,6 @@ var ReactCompositeComponentWrapper = function (element) {
 _assign(ReactCompositeComponentWrapper.prototype, ReactCompositeComponent, {
   _instantiateReactComponent: instantiateReactComponent
 });
-
-function getDeclarationErrorAddendum(owner) {
-  if (owner) {
-    var name = owner.getName();
-    if (name) {
-      return ' Check the render method of `' + name + '`.';
-    }
-  }
-  return '';
-}
 
 /**
  * Check if the type reference is a known internal type. I.e. not a user


### PR DESCRIPTION
There were a total of 4 function definitions for "getDeclarationErrorAddendum" in react-dom.js.  I didn't see any commits in the master codebase referencing this function, and the only 2 issues referencing it didn't indicate whether this duplication was a feature or a bug.

3 of the implementations did not check for 'internalInstance', and one did perform this check.  The implementations without this check appeared more elegant, so I deleted all implementations except one without this check.
