### PR TITLE
Refactor reactpurecomponent

### DIFF
--- a/src/isomorphic/modern/class/ReactPureComponent.js
+++ b/src/isomorphic/modern/class/ReactPureComponent.js
@@ -29,10 +29,11 @@ function ReactPureComponent(props, context, updater) {
   this.updater = updater || ReactNoopUpdateQueue;
 }
 
-function ComponentDummy() {}
-ComponentDummy.prototype = ReactComponent.prototype;
-ReactPureComponent.prototype = new ComponentDummy();
-ReactPureComponent.prototype.constructor = ReactPureComponent;
+// Set the ReactPureComponent.prototype to a new object that delegates to
+// ReactComponent.prototype
+ReactPureComponent.prototype = Object.create(ReactComponent.prototype);
+// Reassign constructor to the ReactPureComponent.prototype
+ReactPureComponent.constructor = ReactPureComponent;
 // Avoid an extra prototype jump for these methods.
 Object.assign(ReactPureComponent.prototype, ReactComponent.prototype);
 ReactPureComponent.prototype.isPureReactComponent = true;


### PR DESCRIPTION
I'm curious to hear thoughts on this PR.

Looks to me like the code in this PR is shorter (smaller byte-size) and slightly more expressive. My personal opinion is that ComponentDummy parasitic inheritance pattern used here adds an unnecessary layer of misdirection. That said, if it exists for a good reason I would love to hear it!

The only criticism I might have of this PR is that Object.create is not very expressive if you're unfamiliar with its functionality.