### PR TITLE
Passing props to custom elements as properties instead of attributes

### DIFF
--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -130,7 +130,7 @@ var DOMPropertyOperations = {
    * @param {string} name
    * @param {*} value
    */
-  setValueForProperty: function(node, name, value) {
+  setValueForProperty: function(node, name, value, isCustomElement) {
     var propertyInfo = DOMProperty.properties.hasOwnProperty(name) ?
         DOMProperty.properties[name] : null;
     if (propertyInfo) {
@@ -161,6 +161,8 @@ var DOMPropertyOperations = {
     } else if (DOMProperty.isCustomAttribute(name)) {
       DOMPropertyOperations.setValueForAttribute(node, name, value);
       return;
+    } else if (isCustomElement) {
+      node[name] = value;
     }
 
     if (__DEV__) {
@@ -218,7 +220,7 @@ var DOMPropertyOperations = {
    * @param {DOMElement} node
    * @param {string} name
    */
-  deleteValueForProperty: function(node, name) {
+  deleteValueForProperty: function(node, name, isCustomElement) {
     var propertyInfo = DOMProperty.properties.hasOwnProperty(name) ?
         DOMProperty.properties[name] : null;
     if (propertyInfo) {
@@ -237,6 +239,8 @@ var DOMPropertyOperations = {
       }
     } else if (DOMProperty.isCustomAttribute(name)) {
       node.removeAttribute(name);
+    } else if (isCustomElement) {
+      delete node[name];
     }
 
     if (__DEV__) {

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -249,8 +249,7 @@ describe('ReactDOMComponent', () => {
 
       expect(lightDOM[0].getAttribute('slot')).toBe('first');
       expect(lightDOM[1].getAttribute('slot')).toBe('second');
-
-    } );
+    });
 
     it('should skip reserved props on web components', () => {
       var container = document.createElement('div');
@@ -318,13 +317,33 @@ describe('ReactDOMComponent', () => {
       expect(container.firstChild.className).toEqual('');
     });
 
-    it('should properly update custom attributes on custom elements', () => {
+    it('should properly update custom properties on custom elements', () => {
       var container = document.createElement('div');
       ReactDOM.render(<some-custom-element foo="bar"/>, container);
       ReactDOM.render(<some-custom-element bar="buzz"/>, container);
       var node = container.firstChild;
+      expect(node.hasOwnProperty('foo')).toBe(false);
+      expect(node.bar).toBe('buzz');
+    });
+
+    it('should not set attributes for props passed to custom elements', () => {
+      var container = document.createElement('div');
+      ReactDOM.render(<some-custom-element foo="bar"/>, container);
+      var node = container.firstChild;
       expect(node.hasAttribute('foo')).toBe(false);
-      expect(node.getAttribute('bar')).toBe('buzz');
+    });
+
+    it('should pass complex data to custom elements as properties on the dom node', () => {
+      var container = document.createElement('div');
+      var anArray = ['1', 2, new Date(), {}, [], false];
+      var date = new Date();
+      ReactDOM.render(<some-custom-element foo={{bar: 'baz'}} anArray={anArray} aNumber={2} aDate={date}/>, container);
+      var node = container.firstChild;
+      expect(node.hasAttribute('foo')).toBe(false);
+      expect(node.foo).toEqual({bar: 'baz'});
+      expect(node.anArray).toEqual(anArray);
+      expect(node.aNumber).toEqual(2);
+      expect(node.aDate).toEqual(date);
     });
 
     it('should clear a single style prop when changing `style`', () => {
@@ -340,53 +359,16 @@ describe('ReactDOMComponent', () => {
       expect(stubStyle.color).toEqual('green');
     });
 
-    it('should reject attribute key injection attack on markup', () => {
-      spyOn(console, 'error');
-      for (var i = 0; i < 3; i++) {
-        var container = document.createElement('div');
-        var element = React.createElement(
-          'x-foo-component',
-          {'blah" onclick="beevil" noise="hi': 'selected'},
-          null
-        );
-        ReactDOM.render(element, container);
-      }
-      expectDev(console.error.calls.count()).toBe(1);
-      expectDev(console.error.calls.argsFor(0)[0]).toEqual(
-        'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`'
-      );
-    });
-
-    it('should reject attribute key injection attack on update', () => {
-      spyOn(console, 'error');
-      for (var i = 0; i < 3; i++) {
-        var container = document.createElement('div');
-        var beforeUpdate = React.createElement('x-foo-component', {}, null);
-        ReactDOM.render(beforeUpdate, container);
-
-        var afterUpdate = React.createElement(
-          'x-foo-component',
-          {'blah" onclick="beevil" noise="hi': 'selected'},
-          null
-        );
-        ReactDOM.render(afterUpdate, container);
-      }
-      expectDev(console.error.calls.count()).toBe(1);
-      expectDev(console.error.calls.argsFor(0)[0]).toEqual(
-        'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`'
-      );
-    });
-
-    it('should update arbitrary attributes for tags containing dashes', () => {
+    it('should update arbitrary properties for tags containing dashes', () => {
       var container = document.createElement('div');
 
       var beforeUpdate = React.createElement('x-foo-component', {}, null);
       ReactDOM.render(beforeUpdate, container);
 
-      var afterUpdate = <x-foo-component myattr="myval" />;
+      var afterUpdate = <x-foo-component myProperty="myval" />;
       ReactDOM.render(afterUpdate, container);
 
-      expect(container.childNodes[0].getAttribute('myattr')).toBe('myval');
+      expect(container.childNodes[0].myProperty).toBe('myval');
     });
 
     it('should clear all the styles when removing `style`', () => {
@@ -595,10 +577,10 @@ describe('ReactDOMComponent', () => {
       expect(nodeValueSetter.mock.calls.length).toBe(3);
     });
 
-    it('should ignore attribute whitelist for elements with the "is: attribute', () => {
+    it('should ignore property whitelist for elements with the "is" attribute', () => {
       var container = document.createElement('div');
       ReactDOM.render(<button is="test" cowabunga="chevynova"/>, container);
-      expect(container.firstChild.hasAttribute('cowabunga')).toBe(true);
+      expect(container.firstChild.hasOwnProperty('cowabunga')).toBe(true);
     });
 
     it('should not update when switching between null/undefined', () => {
@@ -1057,7 +1039,7 @@ describe('ReactDOMComponent', () => {
         var container = document.createElement('div');
         spyOn(document, 'createElement').and.callThrough();
         ReactDOM.render(<div is="custom-div" />, container);
-        expect(document.createElement).toHaveBeenCalledWith('div', 'custom-div');
+        expect(document.createElement).toHaveBeenCalledWith('div', {is: 'custom-div'});
       } else {
         expect(ReactDOMServer.renderToString(<div is="custom-div" />)).toContain('is="custom-div"');
       }

--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -566,7 +566,7 @@ ReactDOMComponent.Mixin = {
           div.innerHTML = `<${type}></${type}>`;
           el = div.removeChild(div.firstChild);
         } else if (props.is) {
-          el = ownerDocument.createElement(type, props.is);
+          el = ownerDocument.createElement(type, {is: props.is});
         } else {
           // Separate else branch instead of using `props.is || undefined` above becuase of a Firefox bug.
           // See discussion in https://github.com/facebook/react/pull/6896
@@ -953,10 +953,7 @@ ReactDOMComponent.Mixin = {
         // Do nothing for event names.
       } else if (isCustomComponent(this._tag, lastProps)) {
         if (!RESERVED_PROPS.hasOwnProperty(propKey)) {
-          DOMPropertyOperations.deleteValueForAttribute(
-            getNode(this),
-            propKey
-          );
+          DOMPropertyOperations.deleteValueForProperty(getNode(this), propKey, true);
         }
       } else if (
           DOMProperty.properties[propKey] ||
@@ -1005,10 +1002,11 @@ ReactDOMComponent.Mixin = {
         }
       } else if (isCustomComponentTag) {
         if (!RESERVED_PROPS.hasOwnProperty(propKey)) {
-          DOMPropertyOperations.setValueForAttribute(
+          DOMPropertyOperations.setValueForProperty(
             getNode(this),
             propKey,
-            nextProp
+            nextProp,
+            true
           );
         }
       } else if (


### PR DESCRIPTION
This pull request introduces a **breaking change** to how React handles custom elements / web components. The change is that React props are currently passed to custom elements via `setAttribute`, but now are passed as properties on the dom element itself.

See discussion in #7901, specifically [this comment](https://github.com/facebook/react/issues/7901#issuecomment-256755466) where @sebmarkbage indicated that this change would be part of the next major release of React. Since react@16.0.0-alpha was released yesterday and is on the master branch, I'm hoping that now is the right time for this breaking change to make it into the master branch. I'm not sure if anyone else was planning on implementing this or not.

Notes:
- This makes it a lot easier to pass non-string data down to custom elements (e.g., objects can be passed without getting stringified to `[Object object]`). Instead of `<custom-element ref={el => el.myProp = myProp} />`, you can just do `<custom-element myProp={myProp} />`.
- This does *not* solve the problem of how to interoperate with events fired by custom elements. If this pr is merged, I will follow it up with another one to tackle that problem, using the proposed solution in #7901 as a guide.
- I am not doing `Object.assign(element, props)` (like @sebmarkbage suggested) because that does not delete any props that are passed conditionally to the custom element. Also, `Object.assign(element, props)` bypasses the events recorded in ReactHostOperationHistory, which seems like another reason against doing so. Not sure if ReactHostOperationHistory is important or not for custom elements, though.
- I did not change the corresponding ReactDOMFiberComponent because I wasn't sure if I should do so.
- The linter was broken for me on the master branch before I made any changes, but my changes did not introduce any new warnings or errors as far as I can tell.