### PR TITLE
Log all Fiber errors w/ component stack

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1194,6 +1194,9 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
 * does not interrupt unmounting if detaching a ref throws
 * handles error thrown by host config while working on failed root
 * handles error thrown by top-level callback
+* should log errors that occur during the begin phase
+* should log errors that occur during the commit phase
+* should ignore errors thrown in log method to prevent cycle
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalReflection-test.js
 * handles isMounted even when the initial render is deferred

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1196,8 +1196,8 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
 * handles error thrown by top-level callback
 * should log errors that occur during the begin phase
 * should log errors that occur during the commit phase
-* should relay info about error boundary and retry attempts if applicable
 * should ignore errors thrown in log method to prevent cycle
+* should relay info about error boundary and retry attempts if applicable
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalReflection-test.js
 * handles isMounted even when the initial render is deferred

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1196,6 +1196,7 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
 * handles error thrown by top-level callback
 * should log errors that occur during the begin phase
 * should log errors that occur during the commit phase
+* should relay info about error boundary and retry attempts if applicable
 * should ignore errors thrown in log method to prevent cycle
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalReflection-test.js

--- a/scripts/jest/test-framework-setup.js
+++ b/scripts/jest/test-framework-setup.js
@@ -10,6 +10,10 @@ jest.mock('ReactDOMFeatureFlags', () => {
   });
 });
 
+// Error logging varies between Fiber and Stack;
+// Rather than fork dozens of tests, mock the error-logging file by default.
+jest.mock('ReactFiberErrorLogger');
+
 var env = jasmine.getEnv();
 
 var callCount = 0;

--- a/src/renderers/shared/fiber/ReactFiberErrorLogger.js
+++ b/src/renderers/shared/fiber/ReactFiberErrorLogger.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactFiberErrorLogger
+ * @flow
+ */
+
+'use strict';
+
+import type { CapturedError } from 'ReactFiberScheduler';
+
+function logCapturedError(capturedError : CapturedError) : void {
+  if (__DEV__) {
+    // console.log rather than console.error to avoid breaking tests
+    // (Jest complains about unexpected console.error calls.)
+    console.log(capturedError.error);
+    console.log(`Error location: ${capturedError.componentStack}`);
+  }
+}
+
+exports.logCapturedError = logCapturedError;

--- a/src/renderers/shared/fiber/ReactFiberErrorLogger.js
+++ b/src/renderers/shared/fiber/ReactFiberErrorLogger.js
@@ -30,15 +30,15 @@ function logCapturedError(capturedError : CapturedError) : void {
       : 'React caught an error thrown by one of your components.';
 
     let errorBoundaryMessage;
-    if (errorBoundaryFound) {
-      // errorBoundaryFound check is sufficient; errorBoundaryName check is to satisfy Flow.
+    // errorBoundaryFound check is sufficient; errorBoundaryName check is to satisfy Flow.
+    if (errorBoundaryFound && errorBoundaryName) {
       if (willRetry) {
         errorBoundaryMessage =
           `React will try to recreate this component tree from scratch ` +
-          `using the error boundary you provided, ${errorBoundaryName || ''}.`;
+          `using the error boundary you provided, ${errorBoundaryName}.`;
       } else {
         errorBoundaryMessage =
-          `This error was initially handled by the error boundary ${errorBoundaryName || ''}. ` +
+          `This error was initially handled by the error boundary ${errorBoundaryName}. ` +
           `Recreating the tree from scratch failed so React will unmount the tree.`;
       }
     } else {

--- a/src/renderers/shared/fiber/ReactFiberErrorLogger.js
+++ b/src/renderers/shared/fiber/ReactFiberErrorLogger.js
@@ -8,7 +8,7 @@
  *
  * @providesModule ReactFiberErrorLogger
  * @flow
- */3
+ */
 
 'use strict';
 
@@ -16,13 +16,49 @@ import type { CapturedError } from 'ReactFiberScheduler';
 
 function logCapturedError(capturedError : CapturedError) : void {
   if (__DEV__) {
-    const { componentName, componentStack, error } = capturedError;
-    // TODO Link to unstable_handleError() documentation once it exists.
+    const {
+      componentName,
+      componentStack,
+      error,
+      errorBoundaryName,
+      errorBoundaryFound,
+      willRetry,
+    } = capturedError;
+
+    const componentNameMessage = componentName
+      ? `React caught an error thrown by ${componentName}.`
+      : 'React caught an error thrown by one of your components.';
+
+    let errorBoundaryMessage;
+    if (errorBoundaryFound) {
+      // errorBoundaryFound check is sufficient; errorBoundaryName check is to satisfy Flow.
+      if (willRetry) {
+        errorBoundaryMessage =
+          `This error will be handled by the error boundary ${errorBoundaryName || ''}. ` +
+          `React will try to recreate this component tree from scratch.`;
+      } else {
+        errorBoundaryMessage =
+          `This error was initially handled by the error boundary ${errorBoundaryName || ''}. ` +
+          `Recreating the tree from scratch failed so React will unmount the tree.`;
+      }
+    } else {
+      // TODO Link to unstable_handleError() documentation once it exists.
+      errorBoundaryMessage =
+        'Consider adding an error boundary to your tree to customize error handling behavior.';
+    }
+
     console.error(
-      `React caught an error thrown by ${componentName}. ` +
-      `Consider using an error boundary to capture this and other errors.\n\n` +
-      `${error}\n\n` +
+      `${componentNameMessage} You should fix this error in your code.\n\n` +
+      `${errorBoundaryMessage}\n\n` +
+      `${error.stack}\n\n` +
       `The error was thrown in the following location: ${componentStack}`
+    );
+  }
+
+  if (!__DEV__) {
+    const { error } = capturedError;
+    console.error(
+      `React caught an error thrown by one of your components.\n\n${error.stack}`
     );
   }
 }

--- a/src/renderers/shared/fiber/ReactFiberErrorLogger.js
+++ b/src/renderers/shared/fiber/ReactFiberErrorLogger.js
@@ -8,7 +8,7 @@
  *
  * @providesModule ReactFiberErrorLogger
  * @flow
- */
+ */3
 
 'use strict';
 
@@ -16,11 +16,16 @@ import type { CapturedError } from 'ReactFiberScheduler';
 
 function logCapturedError(capturedError : CapturedError) : void {
   if (__DEV__) {
-    // console.log rather than console.error to avoid breaking tests
-    // (Jest complains about unexpected console.error calls.)
-    console.log(capturedError.error);
-    console.log(`Error location: ${capturedError.componentStack}`);
+    const { componentName, componentStack, error } = capturedError;
+    // TODO Link to unstable_handleError() documentation once it exists.
+    console.error(
+      `React caught an error thrown by ${componentName}. ` +
+      `Consider using an error boundary to capture this and other errors.\n\n` +
+      `${error}\n\n` +
+      `The error was thrown in the following location: ${componentStack}`
+    );
   }
 }
 
 exports.logCapturedError = logCapturedError;
+

--- a/src/renderers/shared/fiber/ReactFiberErrorLogger.js
+++ b/src/renderers/shared/fiber/ReactFiberErrorLogger.js
@@ -34,8 +34,8 @@ function logCapturedError(capturedError : CapturedError) : void {
       // errorBoundaryFound check is sufficient; errorBoundaryName check is to satisfy Flow.
       if (willRetry) {
         errorBoundaryMessage =
-          `This error will be handled by the error boundary ${errorBoundaryName || ''}. ` +
-          `React will try to recreate this component tree from scratch.`;
+          `React will try to recreate this component tree from scratch ` +
+          `using the error boundary you provided, ${errorBoundaryName || ''}.`;
       } else {
         errorBoundaryMessage =
           `This error was initially handled by the error boundary ${errorBoundaryName || ''}. ` +
@@ -48,8 +48,7 @@ function logCapturedError(capturedError : CapturedError) : void {
     }
 
     console.error(
-      `${componentNameMessage} You should fix this error in your code.\n\n` +
-      `${errorBoundaryMessage}\n\n` +
+      `${componentNameMessage} You should fix this error in your code. ${errorBoundaryMessage}\n\n` +
       `${error.stack}\n\n` +
       `The error was thrown in the following location: ${componentStack}`
     );

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -18,6 +18,7 @@ import type { HostConfig, Deadline } from 'ReactFiberReconciler';
 import type { PriorityLevel } from 'ReactPriorityLevel';
 
 export type CapturedError = {
+  componentName: string,
   componentStack: string,
   error: Error,
 };
@@ -36,6 +37,7 @@ var ReactFiberCompleteWork = require('ReactFiberCompleteWork');
 var ReactFiberCommitWork = require('ReactFiberCommitWork');
 var ReactFiberHostContext = require('ReactFiberHostContext');
 var ReactCurrentOwner = require('ReactCurrentOwner');
+var getComponentName = require('getComponentName');
 
 var { cloneFiber } = require('ReactFiber');
 
@@ -890,6 +892,7 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
       // The risk is that the return path from this Fiber may not be accurate.
       // That risk is acceptable given the benefit of providing users more context.
       const componentStack = getStackAddendumByWorkInProgressFiber(failedWork);
+      const componentName = getComponentName(failedWork) || 'Unknown';
 
       // Add to the collection of captured errors. This is stored as a global
       // map of errors and their component stack location keyed by the boundaries
@@ -899,6 +902,7 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
         capturedErrors = new Map();
       }
       capturedErrors.set(boundary, {
+        componentName,
         componentStack,
         error,
       });
@@ -969,6 +973,7 @@ module.exports = function<T, P, I, TI, C, CX>(config : HostConfig<T, P, I, TI, C
       } catch (e) {
         // Prevent cycle if logCapturedError() throws.
         // A cycle may still occur if logCapturedError renders a component that throws.
+        console.error(e);
       }
     }
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
@@ -973,6 +973,7 @@ describe('ReactIncrementalErrorHandling', () => {
 
       expect(logCapturedErrorCalls.length).toBe(1);
       expect(logCapturedErrorCalls[0].error.message).toBe('componentWillMount error');
+      expect(logCapturedErrorCalls[0].componentName).toBe('ErrorThrowingComponent');
       expect(normalizeCodeLocInfo(logCapturedErrorCalls[0].componentStack)).toContain(
         '    in ErrorThrowingComponent (at **)\n' +
         '    in span (at **)\n' +
@@ -997,6 +998,7 @@ describe('ReactIncrementalErrorHandling', () => {
 
       expect(logCapturedErrorCalls.length).toBe(1);
       expect(logCapturedErrorCalls[0].error.message).toBe('componentDidMount error');
+      expect(logCapturedErrorCalls[0].componentName).toBe('ErrorThrowingComponent');
       expect(normalizeCodeLocInfo(logCapturedErrorCalls[0].componentStack)).toContain(
         '    in ErrorThrowingComponent (at **)\n' +
         '    in span (at **)\n' +
@@ -1005,6 +1007,8 @@ describe('ReactIncrementalErrorHandling', () => {
     });
 
     it('should ignore errors thrown in log method to prevent cycle', () => {
+      spyOn(console, 'error');
+
       class ErrorThrowingComponent extends React.Component {
         render() {
           throw Error('render error');
@@ -1024,6 +1028,10 @@ describe('ReactIncrementalErrorHandling', () => {
       } catch (error) {}
 
       expect(logCapturedErrorCalls.length).toBe(1);
+
+      // The error thrown in logCapturedError should also be logged
+      expect(console.error.calls.count()).toBe(1);
+      expect(console.error.calls.argsFor(0)[0].message).toContain('logCapturedError error');
     });
   });
 });

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
@@ -11,7 +11,6 @@
 
 'use strict';
 
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 var React;
 var ReactNoop;
 
@@ -938,95 +937,93 @@ describe('ReactIncrementalErrorHandling', () => {
     expect(() => ReactNoop.flush()).toThrow('Error!');
   });
 
-  if (ReactDOMFeatureFlags.useFiber) {
-    describe('ReactFiberErrorLogger', () => {
-      function normalizeCodeLocInfo(str) {
-        return str && str.replace(/\(at .+?:\d+\)/g, '(at **)');
+  describe('ReactFiberErrorLogger', () => {
+    function normalizeCodeLocInfo(str) {
+      return str && str.replace(/\(at .+?:\d+\)/g, '(at **)');
+    }
+
+    let logCapturedErrorCalls;
+    let ReactFiberErrorLogger;
+
+    beforeEach(() => {
+      logCapturedErrorCalls = [];
+
+      ReactFiberErrorLogger = require('ReactFiberErrorLogger');
+      ReactFiberErrorLogger.logCapturedError.mockImplementation(
+        (capturedError) => {
+          logCapturedErrorCalls.push(capturedError);
+        }
+      );
+    });
+
+    it('should log errors that occur during the begin phase', () => {
+      class ErrorThrowingComponent extends React.Component {
+        componentWillMount() {
+          throw Error('componentWillMount error');
+        }
+        render() {
+          return <div/>;
+        }
       }
 
-      let logCapturedErrorCalls;
-      let ReactFiberErrorLogger;
+      try {
+        ReactNoop.render(<div><span><ErrorThrowingComponent/></span></div>);
+        ReactNoop.flushDeferredPri();
+      } catch (error) {}
 
-      beforeEach(() => {
-        logCapturedErrorCalls = [];
-
-        ReactFiberErrorLogger = require('ReactFiberErrorLogger');
-        ReactFiberErrorLogger.logCapturedError.mockImplementation(
-          (capturedError) => {
-            logCapturedErrorCalls.push(capturedError);
-          }
-        );
-      });
-
-      it('should log errors that occur during the begin phase', () => {
-        class ErrorThrowingComponent extends React.Component {
-          componentWillMount() {
-            throw Error('componentWillMount error');
-          }
-          render() {
-            return <div/>;
-          }
-        }
-
-        try {
-          ReactNoop.render(<div><span><ErrorThrowingComponent/></span></div>);
-          ReactNoop.flushDeferredPri();
-        } catch (error) {}
-
-        expect(logCapturedErrorCalls.length).toBe(1);
-        expect(logCapturedErrorCalls[0].error.message).toBe('componentWillMount error');
-        expect(normalizeCodeLocInfo(logCapturedErrorCalls[0].componentStack)).toContain(
-          '    in ErrorThrowingComponent (at **)\n' +
-          '    in span (at **)\n' +
-          '    in div (at **)'
-        );
-      });
-
-      it('should log errors that occur during the commit phase', () => {
-        class ErrorThrowingComponent extends React.Component {
-          componentDidMount() {
-            throw Error('componentDidMount error');
-          }
-          render() {
-            return <div/>;
-          }
-        }
-
-        try {
-          ReactNoop.render(<div><span><ErrorThrowingComponent/></span></div>);
-          ReactNoop.flushDeferredPri();
-        } catch (error) {}
-
-        expect(logCapturedErrorCalls.length).toBe(1);
-        expect(logCapturedErrorCalls[0].error.message).toBe('componentDidMount error');
-        expect(normalizeCodeLocInfo(logCapturedErrorCalls[0].componentStack)).toContain(
-          '    in ErrorThrowingComponent (at **)\n' +
-          '    in span (at **)\n' +
-          '    in div (at **)'
-        );
-      });
-
-      it('should ignore errors thrown in log method to prevent cycle', () => {
-        class ErrorThrowingComponent extends React.Component {
-          render() {
-            throw Error('render error');
-          }
-        }
-
-        ReactFiberErrorLogger.logCapturedError.mockImplementation(
-          (capturedError) => {
-            logCapturedErrorCalls.push(capturedError);
-            throw Error('logCapturedError error');
-          }
-        );
-
-        try {
-          ReactNoop.render(<div><span><ErrorThrowingComponent/></span></div>);
-          ReactNoop.flushDeferredPri();
-        } catch (error) {}
-
-        expect(logCapturedErrorCalls.length).toBe(1);
-      });
+      expect(logCapturedErrorCalls.length).toBe(1);
+      expect(logCapturedErrorCalls[0].error.message).toBe('componentWillMount error');
+      expect(normalizeCodeLocInfo(logCapturedErrorCalls[0].componentStack)).toContain(
+        '    in ErrorThrowingComponent (at **)\n' +
+        '    in span (at **)\n' +
+        '    in div (at **)'
+      );
     });
-  }
+
+    it('should log errors that occur during the commit phase', () => {
+      class ErrorThrowingComponent extends React.Component {
+        componentDidMount() {
+          throw Error('componentDidMount error');
+        }
+        render() {
+          return <div/>;
+        }
+      }
+
+      try {
+        ReactNoop.render(<div><span><ErrorThrowingComponent/></span></div>);
+        ReactNoop.flushDeferredPri();
+      } catch (error) {}
+
+      expect(logCapturedErrorCalls.length).toBe(1);
+      expect(logCapturedErrorCalls[0].error.message).toBe('componentDidMount error');
+      expect(normalizeCodeLocInfo(logCapturedErrorCalls[0].componentStack)).toContain(
+        '    in ErrorThrowingComponent (at **)\n' +
+        '    in span (at **)\n' +
+        '    in div (at **)'
+      );
+    });
+
+    it('should ignore errors thrown in log method to prevent cycle', () => {
+      class ErrorThrowingComponent extends React.Component {
+        render() {
+          throw Error('render error');
+        }
+      }
+
+      ReactFiberErrorLogger.logCapturedError.mockImplementation(
+        (capturedError) => {
+          logCapturedErrorCalls.push(capturedError);
+          throw Error('logCapturedError error');
+        }
+      );
+
+      try {
+        ReactNoop.render(<div><span><ErrorThrowingComponent/></span></div>);
+        ReactNoop.flushDeferredPri();
+      } catch (error) {}
+
+      expect(logCapturedErrorCalls.length).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
A new module has been added (`ReactFiberErrorLogger`). This logs error information (call stack and component stack) to the console to make errors easier to debug. It also prompts users to use error boundaries if they are not already using them.

In the future, perhaps this will be injectable, enabling users to provide their own handler for custom processing/logging. For the time being, this should help with issues like [this](https://github.com/facebook/react/issues/2461#issuecomment-270552765) / #2461.