### PR TITLE
Document difference between Children.map & Array.map

### DIFF
--- a/docs/docs/reference-react.md
+++ b/docs/docs/reference-react.md
@@ -208,7 +208,7 @@ Verifies the object is a React element. Returns `true` or `false`.
 React.Children.map(children, function[(thisArg)])
 ```
 
-Invokes a function on every immediate child contained within `children` with `this` set to `thisArg`. If `children` is a keyed fragment or array it will be traversed: the function will never be passed the container objects. If children is `null` or `undefined`, returns `null` or `undefined` rather than an array.
+Invokes a function on every immediate child contained within `children` with `this` set to `thisArg`. If `children` is a keyed fragment or array it will be traversed: the function will never be passed the container objects. If children is `null` or `undefined`, returns `null` or `undefined` rather than an array. The function must return valid `Children` object, to generate different types of objects use `React.Children.toArray(children).map` instead.
 
 #### `React.Children.forEach`
 


### PR DESCRIPTION
The two are not equivalent (which would be a users' expectation), for example:
```
> Children.map(this.props.children, child => ['foo', child]))
["foobar", Object]
> Children.toArray(children).map(child => ['foo', child])
[["foobar", Object]]
```

Information obtained from this comment:
https://github.com/facebook/react/issues/4410#issuecomment-122158658
