### PR TITLE
do not need the judgement

### DIFF
--- a/src/renderers/shared/stack/reconciler/Transaction.js
+++ b/src/renderers/shared/stack/reconciler/Transaction.js
@@ -87,11 +87,7 @@ var TransactionImpl = {
    */
   reinitializeTransaction: function(): void {
     this.transactionWrappers = this.getTransactionWrappers();
-    if (this.wrapperInitData) {
-      this.wrapperInitData.length = 0;
-    } else {
-      this.wrapperInitData = [];
-    }
+    this.wrapperInitData = [];
     this._isInTransaction = false;
   },
 


### PR DESCRIPTION
Acturally we just need give `wrapperInitData` an empty array