### PR TITLE
Deep Object Merge

### DIFF
--- a/src/test/ReactTestUtils.js
+++ b/src/test/ReactTestUtils.js
@@ -461,7 +461,20 @@ function makeSimulator(eventType) {
     // Since we aren't using pooling, always persist the event. This will make
     // sure it's marked and won't warn when setting additional properties.
     event.persist();
-    Object.assign(event, eventData);
+    function mergeDeep(target, source) {
+      if (isObject(target) && isObject(source)) {
+        for (const key in source) {
+          if (isObject(source[key])) {
+            if (!target[key]) Object.assign(target, { [key]: {} });
+            mergeDeep(target[key], source[key]);
+          } else {
+            Object.assign(target, { [key]: source[key] });
+          }
+        }
+      }
+      return target;
+    }
+    mergeDeep(event, eventData);
 
     if (dispatchConfig.phasedRegistrationNames) {
       EventPropagators.accumulateTwoPhaseDispatches(event);


### PR DESCRIPTION
Infinite loops! Straight from SO! http://stackoverflow.com/posts/34749873/revisions

But seriously I need to change some things in the overriding 'mock' object for the `mousemove` event. 
That's fine and dandy, but if I want to override something in a deeper object like `target`, it gets replaced entirely, not merged.
Is something like this change possible, perhaps only for one level deep?