### PR TITLE
Small ReactPropTypes refactor

### DIFF
--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -213,7 +213,7 @@ function createPrimitiveTypeChecker(expectedType) {
 }
 
 function createAnyTypeChecker() {
-  return createChainableTypeChecker(emptyFunction.thatReturns(null));
+  return createChainableTypeChecker(emptyFunction.thatReturnsNull);
 }
 
 function createArrayOfTypeChecker(typeChecker) {


### PR DESCRIPTION
Despite it may look as a silly refactor, makes sense to use the same api that is being used below (on `createEnumTypeChecker` and `createUnionTypeChecker`) 😄 