### PR TITLE
        Added double newline delimiters to the following functions/files:

### DIFF
--- a/src/addons/__tests__/ReactFragment-test.js
+++ b/src/addons/__tests__/ReactFragment-test.js
@@ -55,7 +55,7 @@ describe('ReactFragment', () => {
       'Objects are not valid as a React child (found: object with keys ' +
       '{a, b, c}). If you meant to render a collection of children, use an ' +
       'array instead or wrap the object using createFragment(object) from ' +
-      'the React add-ons. Check the render method of `Foo`.'
+      'the React add-ons.\n\nCheck the render method of `Foo`.'
     );
   });
 

--- a/src/isomorphic/classic/class/ReactClass.js
+++ b/src/isomorphic/classic/class/ReactClass.js
@@ -677,7 +677,7 @@ function bindAutoBindMethod(component, method) {
         warning(
           false,
           'bind(): React component methods may only be bound to the ' +
-          'component instance. See %s',
+          'component instance.\n\nSee %s',
           componentName
         );
       } else if (!args.length) {
@@ -685,7 +685,7 @@ function bindAutoBindMethod(component, method) {
           false,
           'bind(): You are binding a component method to the component. ' +
           'React does this for you automatically in a high-performance ' +
-          'way, so you can safely remove this call. See %s',
+          'way, so you can safely remove this call.\n\nSee %s',
           componentName
         );
         return boundMethod;

--- a/src/isomorphic/classic/class/__tests__/ReactBind-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactBind-test.js
@@ -127,7 +127,7 @@ describe('autobinding', () => {
     expectDev(console.error.calls.argsFor(0)[0]).toBe(
       'Warning: bind(): You are binding a component method to the component. ' +
       'React does this for you automatically in a high-performance ' +
-      'way, so you can safely remove this call. See TestBindComponent'
+      'way, so you can safely remove this call.\n\nSee TestBindComponent'
     );
   });
 

--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -33,7 +33,7 @@ function getDeclarationErrorAddendum() {
   if (ReactCurrentOwner.current) {
     var name = getComponentName(ReactCurrentOwner.current);
     if (name) {
-      return ' Check the render method of `' + name + '`.';
+      return '\n\nCheck the render method of `' + name + '`.';
     }
   }
   return '';
@@ -48,7 +48,7 @@ function getSourceInfoErrorAddendum(elementProps) {
     var source = elementProps.__source;
     var fileName = source.fileName.replace(/^.*[\\\/]/, '');
     var lineNumber = source.lineNumber;
-    return ' Check your code at ' + fileName + ':' + lineNumber + '.';
+    return '\n\nCheck your code at ' + fileName + ':' + lineNumber + '.';
   }
   return '';
 }
@@ -67,7 +67,7 @@ function getCurrentComponentErrorInfo(parentType) {
     var parentName = typeof parentType === 'string' ?
       parentType : parentType.displayName || parentType.name;
     if (parentName) {
-      info = ` Check the top-level render call using <${parentName}>.`;
+      info = `\n\nCheck the top-level render call using <${parentName}>.`;
     }
   }
   return info;

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -76,8 +76,8 @@ describe('ReactElementValidator', () => {
 
     expectDev(console.error.calls.count()).toBe(1);
     expectDev(console.error.calls.argsFor(0)[0]).toContain(
-      'Each child in an array or iterator should have a unique "key" prop. ' +
-      'Check the render method of `InnerClass`. ' +
+      'Each child in an array or iterator should have a unique "key" prop.' +
+      '\n\nCheck the render method of `InnerClass`. ' +
       'It was passed a child from ComponentWrapper. '
     );
   });
@@ -118,7 +118,7 @@ describe('ReactElementValidator', () => {
     expectDev(console.error.calls.count()).toBe(1);
     expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
       'Warning: Each child in an array or iterator should have a unique ' +
-      '"key" prop. Check the top-level render call using <div>. See ' +
+      '"key" prop.\n\nCheck the top-level render call using <div>. See ' +
       'https://fb.me/react-warning-keys for more information.\n' +
       '    in div (at **)'
     );
@@ -150,7 +150,7 @@ describe('ReactElementValidator', () => {
     expectDev(console.error.calls.count()).toBe(1);
     expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
       'Warning: Each child in an array or iterator should have a unique ' +
-      '"key" prop. Check the render method of `Component`. See ' +
+      '"key" prop.\n\nCheck the render method of `Component`. See ' +
       'https://fb.me/react-warning-keys for more information.\n' +
       '    in div (at **)\n' +
       '    in Component (at **)\n' +
@@ -342,14 +342,14 @@ describe('ReactElementValidator', () => {
       ReactTestUtils.renderIntoDocument(React.createElement(ParentComp));
     }).toThrowError(
       'Element type is invalid: expected a string (for built-in components) ' +
-      'or a class/function (for composite components) but got: null. Check ' +
+      'or a class/function (for composite components) but got: null.\n\nCheck ' +
       'the render method of `ParentComp`.'
     );
     expectDev(console.error.calls.count()).toBe(1);
     expectDev(console.error.calls.argsFor(0)[0]).toBe(
       'Warning: React.createElement: type is invalid -- expected a string ' +
       '(for built-in components) or a class/function (for composite ' +
-      'components) but got: null. Check the render method of `ParentComp`.' +
+      'components) but got: null.\n\nCheck the render method of `ParentComp`.' +
       '\n    in ParentComp'
     );
   });
@@ -551,7 +551,7 @@ describe('ReactElementValidator', () => {
       'Warning: React.createElement: type is invalid -- expected a string ' +
       '(for built-in components) or a class/function (for composite ' +
       'components) but got: undefined. You likely forgot to export your ' +
-      'component from the file it\'s defined in. Check your code at **.'
+      'component from the file it\'s defined in.\n\nCheck your code at **.'
     );
   });
 

--- a/src/isomorphic/modern/class/ReactNoopUpdateQueue.js
+++ b/src/isomorphic/modern/class/ReactNoopUpdateQueue.js
@@ -20,7 +20,7 @@ function warnNoop(publicInstance, callerName) {
       false,
       '%s(...): Can only update a mounted or mounting component. ' +
       'This usually means you called %s() on an unmounted component. ' +
-      'This is a no-op. Please check the code for the %s component.',
+      'This is a no-op.\n\nPlease check the code for the %s component.',
       callerName,
       callerName,
       constructor && (constructor.displayName || constructor.name) || 'ReactClass'

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -82,8 +82,8 @@ describe('ReactJSXElementValidator', () => {
 
     expectDev(console.error.calls.count()).toBe(1);
     expectDev(console.error.calls.argsFor(0)[0]).toContain(
-      'Each child in an array or iterator should have a unique "key" prop. ' +
-      'Check the render method of `InnerComponent`. ' +
+      'Each child in an array or iterator should have a unique "key" prop.' +
+      '\n\nCheck the render method of `InnerComponent`. ' +
       'It was passed a child from ComponentWrapper. '
     );
   });
@@ -260,26 +260,26 @@ describe('ReactJSXElementValidator', () => {
       'Warning: React.createElement: type is invalid -- expected a string ' +
       '(for built-in components) or a class/function (for composite ' +
       'components) but got: undefined. You likely forgot to export your ' +
-      'component from the file it\'s defined in. ' +
-      'Check your code at **.'
+      'component from the file it\'s defined in.' +
+      '\n\nCheck your code at **.'
     );
     expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
       'Warning: React.createElement: type is invalid -- expected a string ' +
       '(for built-in components) or a class/function (for composite ' +
-      'components) but got: null. ' +
-      'Check your code at **.'
+      'components) but got: null.' +
+      '\n\nCheck your code at **.'
     );
     expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(2)[0])).toBe(
       'Warning: React.createElement: type is invalid -- expected a string ' +
       '(for built-in components) or a class/function (for composite ' +
-      'components) but got: boolean. ' +
-      'Check your code at **.'
+      'components) but got: boolean.' +
+      '\n\nCheck your code at **.'
     );
     expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(3)[0])).toBe(
       'Warning: React.createElement: type is invalid -- expected a string ' +
       '(for built-in components) or a class/function (for composite ' +
-      'components) but got: number. ' +
-      'Check your code at **.'
+      'components) but got: number.' +
+      '\n\nCheck your code at **.'
     );
     void <Div />;
     expectDev(console.error.calls.count()).toBe(4);

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -68,7 +68,7 @@ function getDeclarationErrorAddendum() {
   var ownerName = getCurrentFiberOwnerName();
   if (ownerName) {
     // TODO: also report the stack.
-    return ' This DOM node was rendered by `' + ownerName + '`.';
+    return '\n\nThis DOM node was rendered by `' + ownerName + '`.';
   }
   return '';
 }

--- a/src/renderers/dom/fiber/wrappers/ReactDOMFiberSelect.js
+++ b/src/renderers/dom/fiber/wrappers/ReactDOMFiberSelect.js
@@ -28,7 +28,7 @@ var didWarnValueDefaultValue = false;
 function getDeclarationErrorAddendum() {
   var ownerName = getCurrentFiberOwnerName();
   if (ownerName) {
-    return ' Check the render method of `' + ownerName + '`.';
+    return '\n\nCheck the render method of `' + ownerName + '`.';
   }
   return '';
 }

--- a/src/renderers/dom/shared/CSSPropertyOperations.js
+++ b/src/renderers/dom/shared/CSSPropertyOperations.js
@@ -128,7 +128,7 @@ if (__DEV__) {
       // TODO: also report the stack.
     }
     if (ownerName) {
-      return ' Check the render method of `' + ownerName + '`.';
+      return '\n\nCheck the render method of `' + ownerName + '`.';
     }
     return '';
   };

--- a/src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
@@ -121,8 +121,8 @@ describe('CSSPropertyOperations', () => {
     ReactDOM.render(<Comp />, root);
     expectDev(console.error.calls.count()).toBe(1);
     expectDev(console.error.calls.argsFor(0)[0]).toEqual(
-      'Warning: Unsupported style property background-color. Did you mean backgroundColor? ' +
-      'Check the render method of `Comp`.'
+      'Warning: Unsupported style property background-color. Did you mean backgroundColor?' +
+      '\n\nCheck the render method of `Comp`.'
     );
   });
 
@@ -146,12 +146,12 @@ describe('CSSPropertyOperations', () => {
 
     expectDev(console.error.calls.count()).toBe(2);
     expectDev(console.error.calls.argsFor(0)[0]).toEqual(
-      'Warning: Unsupported style property -ms-transform. Did you mean msTransform? ' +
-      'Check the render method of `Comp`.'
+      'Warning: Unsupported style property -ms-transform. Did you mean msTransform?' +
+      '\n\nCheck the render method of `Comp`.'
     );
     expectDev(console.error.calls.argsFor(1)[0]).toEqual(
-      'Warning: Unsupported style property -webkit-transform. Did you mean WebkitTransform? ' +
-      'Check the render method of `Comp`.'
+      'Warning: Unsupported style property -webkit-transform. Did you mean WebkitTransform?' +
+      '\n\nCheck the render method of `Comp`.'
     );
   });
 
@@ -175,11 +175,11 @@ describe('CSSPropertyOperations', () => {
     expectDev(console.error.calls.count()).toBe(2);
     expectDev(console.error.calls.argsFor(0)[0]).toEqual(
       'Warning: Unsupported vendor-prefixed style property oTransform. ' +
-      'Did you mean OTransform? Check the render method of `Comp`.'
+      'Did you mean OTransform?\n\nCheck the render method of `Comp`.'
     );
     expectDev(console.error.calls.argsFor(1)[0]).toEqual(
       'Warning: Unsupported vendor-prefixed style property webkitTransform. ' +
-      'Did you mean WebkitTransform? Check the render method of `Comp`.'
+      'Did you mean WebkitTransform?\n\nCheck the render method of `Comp`.'
     );
   });
 
@@ -202,12 +202,12 @@ describe('CSSPropertyOperations', () => {
     ReactDOM.render(<Comp />, root);
     expectDev(console.error.calls.count()).toBe(2);
     expectDev(console.error.calls.argsFor(0)[0]).toEqual(
-      'Warning: Style property values shouldn\'t contain a semicolon. ' +
-      'Check the render method of `Comp`. Try "backgroundColor: blue" instead.',
+      'Warning: Style property values shouldn\'t contain a semicolon.' +
+      '\n\nCheck the render method of `Comp`. Try "backgroundColor: blue" instead.',
     );
     expectDev(console.error.calls.argsFor(1)[0]).toEqual(
-      'Warning: Style property values shouldn\'t contain a semicolon. ' +
-      'Check the render method of `Comp`. Try "color: red" instead.',
+      'Warning: Style property values shouldn\'t contain a semicolon.' +
+      '\n\nCheck the render method of `Comp`. Try "color: red" instead.',
     );
   });
 
@@ -226,8 +226,8 @@ describe('CSSPropertyOperations', () => {
 
     expectDev(console.error.calls.count()).toBe(1);
     expectDev(console.error.calls.argsFor(0)[0]).toEqual(
-      'Warning: `NaN` is an invalid value for the `fontSize` css style property. ' +
-      'Check the render method of `Comp`.'
+      'Warning: `NaN` is an invalid value for the `fontSize` css style property.' +
+      '\n\nCheck the render method of `Comp`.'
     );
   });
 });

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -911,7 +911,7 @@ describe('ReactDOMComponent', () => {
           container
         );
       }).toThrowError(
-        'This DOM node was rendered by `Owner`.'
+        '\n\nThis DOM node was rendered by `Owner`.'
       );
     });
 
@@ -1088,7 +1088,7 @@ describe('ReactDOMComponent', () => {
         ReactDOM.render(<X />, container);
       }).toThrowError(
         'input is a void element tag and must neither have `children` ' +
-        'nor use `dangerouslySetInnerHTML`. This DOM node was rendered by `X`.'
+        'nor use `dangerouslySetInnerHTML`.\n\nThis DOM node was rendered by `X`.'
       );
     });
 
@@ -1183,7 +1183,7 @@ describe('ReactDOMComponent', () => {
       }).toThrowError(
         'The `style` prop expects a mapping from style properties to values, ' +
         'not a string. For example, style={{marginRight: spacing + \'em\'}} ' +
-        'when using JSX. This DOM node was rendered by `Animal`.'
+        'when using JSX.\n\nThis DOM node was rendered by `Animal`.'
       );
     });
 

--- a/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
@@ -474,7 +474,7 @@ describe('ReactDOMServer', () => {
     expectDev(console.error.calls.mostRecent().args[0]).toBe(
       'Warning: setState(...): Can only update a mounting component.' +
       ' This usually means you called setState() outside componentWillMount() on the server.' +
-      ' This is a no-op. Please check the code for the Foo component.'
+      ' This is a no-op.\n\nPlease check the code for the Foo component.'
     );
     var markup = ReactDOMServer.renderToStaticMarkup(<Foo />);
     expect(markup).toBe('<div>hello</div>');
@@ -500,7 +500,7 @@ describe('ReactDOMServer', () => {
     expectDev(console.error.calls.mostRecent().args[0]).toBe(
       'Warning: replaceState(...): Can only update a mounting component. ' +
       'This usually means you called replaceState() outside componentWillMount() on the server. ' +
-      'This is a no-op. Please check the code for the Bar component.'
+      'This is a no-op.\n\nPlease check the code for the Bar component.'
     );
     var markup = ReactDOMServer.renderToStaticMarkup(<Bar />);
     expect(markup).toBe('<div>hello</div>');
@@ -527,7 +527,7 @@ describe('ReactDOMServer', () => {
     expectDev(console.error.calls.mostRecent().args[0]).toBe(
       'Warning: forceUpdate(...): Can only update a mounting component. ' +
       'This usually means you called forceUpdate() outside componentWillMount() on the server. ' +
-      'This is a no-op. Please check the code for the Baz component.'
+      'This is a no-op.\n\nPlease check the code for the Baz component.'
     );
     var markup = ReactDOMServer.renderToStaticMarkup(<Baz />);
     expect(markup).toBe('<div></div>');

--- a/src/renderers/dom/shared/__tests__/findDOMNode-test.js
+++ b/src/renderers/dom/shared/__tests__/findDOMNode-test.js
@@ -64,7 +64,7 @@ describe('findDOMNode', () => {
     expect(function() {
       ReactDOM.findDOMNode({foo: 'bar'});
     }).toThrowError(
-      'Element appears to be neither ReactComponent nor DOMNode (keys: foo)'
+      'Element appears to be neither ReactComponent nor DOMNode. Keys: foo'
     );
   });
 

--- a/src/renderers/dom/shared/findDOMNode.js
+++ b/src/renderers/dom/shared/findDOMNode.js
@@ -64,7 +64,7 @@ const findDOMNode = function(componentOrElement : Element | ?ReactComponent<any,
   } else {
     invariant(
       false,
-      'Element appears to be neither ReactComponent nor DOMNode (keys: %s)',
+      'Element appears to be neither ReactComponent nor DOMNode. Keys: %s',
       Object.keys(componentOrElement)
     );
   }

--- a/src/renderers/dom/shared/utils/ReactControlledValuePropTypes.js
+++ b/src/renderers/dom/shared/utils/ReactControlledValuePropTypes.js
@@ -61,7 +61,7 @@ var propTypes = {
 var loggedTypeFailures = {};
 function getDeclarationErrorAddendum(ownerName) {
   if (ownerName) {
-    return ' Check the render method of `' + ownerName + '`.';
+    return '\n\nCheck the render method of `' + ownerName + '`.';
   }
   return '';
 }

--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -66,7 +66,7 @@ function getDeclarationErrorAddendum(internalInstance) {
     if (owner) {
       var name = owner.getName();
       if (name) {
-        return ' This DOM node was rendered by `' + name + '`.';
+        return '\n\nThis DOM node was rendered by `' + name + '`.';
       }
     }
   }

--- a/src/renderers/dom/stack/client/ReactMount.js
+++ b/src/renderers/dom/stack/client/ReactMount.js
@@ -369,7 +369,7 @@ var ReactMount = {
       '_renderNewRootComponent(): Render methods should be a pure function ' +
       'of props and state; triggering nested component updates from ' +
       'render is not allowed. If necessary, trigger nested updates in ' +
-      'componentDidUpdate. Check the render method of %s.',
+      'componentDidUpdate.\n\nCheck the render method of %s.',
       ReactCurrentOwner.current && ReactCurrentOwner.current.getName() ||
         'ReactCompositeComponent'
     );
@@ -572,7 +572,7 @@ var ReactMount = {
       'unmountComponentAtNode(): Render methods should be a pure function ' +
       'of props and state; triggering nested component updates from render ' +
       'is not allowed. If necessary, trigger nested updates in ' +
-      'componentDidUpdate. Check the render method of %s.',
+      'componentDidUpdate.\n\nCheck the render method of %s.',
       ReactCurrentOwner.current && ReactCurrentOwner.current.getName() ||
         'ReactCompositeComponent'
     );

--- a/src/renderers/dom/stack/client/wrappers/ReactDOMSelect.js
+++ b/src/renderers/dom/stack/client/wrappers/ReactDOMSelect.js
@@ -22,7 +22,7 @@ function getDeclarationErrorAddendum(owner) {
   if (owner) {
     var name = owner.getName();
     if (name) {
-      return ' Check the render method of `' + name + '`.';
+      return '\n\nCheck the render method of `' + name + '`.';
     }
   }
   return '';

--- a/src/renderers/dom/stack/server/ReactServerUpdateQueue.js
+++ b/src/renderers/dom/stack/server/ReactServerUpdateQueue.js
@@ -25,7 +25,7 @@ function warnNoop(publicInstance: ReactComponent<any, any, any>, callerName: str
       false,
       '%s(...): Can only update a mounting component. ' +
       'This usually means you called %s() outside componentWillMount() on the server. ' +
-      'This is a no-op. Please check the code for the %s component.',
+      'This is a no-op.\n\nPlease check the code for the %s component.',
       callerName,
       callerName,
       constructor && (constructor.displayName || constructor.name) || 'ReactClass'

--- a/src/renderers/shared/ReactDebugTool.js
+++ b/src/renderers/shared/ReactDebugTool.js
@@ -174,8 +174,8 @@ if (__DEV__) {
     if (currentTimerType && !lifeCycleTimerHasWarned) {
       warning(
         false,
-        'There is an internal error in the React performance measurement code. ' +
-        'Did not expect %s timer to start while %s timer is still in ' +
+        'There is an internal error in the React performance measurement code.' +
+        '\n\nDid not expect %s timer to start while %s timer is still in ' +
         'progress for %s instance.',
         timerType,
         currentTimerType || 'no',

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -368,7 +368,7 @@ function createFiberFromElementType(type : mixed, key : null | string, debugOwne
       }
       const ownerName = debugOwner ? getComponentName(debugOwner) : null;
       if (ownerName) {
-        info += ' Check the render method of `' + ownerName + '`.';
+        info += '\n\nCheck the render method of `' + ownerName + '`.';
       }
     }
     invariant(

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -478,7 +478,7 @@ module.exports = function<T, P, I, TI, PI, C, CX>(
           let info = '';
           const ownerName = ReactDebugCurrentFiber.getCurrentFiberOwnerName();
           if (ownerName) {
-            info += ' Check the render method of `' + ownerName + '`.';
+            info += '\n\nCheck the render method of `' + ownerName + '`.';
           }
 
           let warningKey = ownerName || workInProgress._debugID || '';

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
@@ -754,7 +754,7 @@ describe('ReactIncrementalErrorHandling', () => {
       'Element type is invalid: expected a string (for built-in components) or ' +
       'a class/function (for composite components) but got: undefined. ' +
       'You likely forgot to export your component from the file it\'s ' +
-      'defined in. Check the render method of `BrokenRender`.'
+      'defined in.\n\nCheck the render method of `BrokenRender`.'
     )]);
     expect(console.error.calls.count()).toBe(1);
   });
@@ -797,7 +797,7 @@ describe('ReactIncrementalErrorHandling', () => {
       'Element type is invalid: expected a string (for built-in components) or ' +
       'a class/function (for composite components) but got: undefined. ' +
       'You likely forgot to export your component from the file it\'s ' +
-      'defined in. Check the render method of `BrokenRender`.'
+      'defined in.\n\nCheck the render method of `BrokenRender`.'
     )]);
     expect(console.error.calls.count()).toBe(1);
   });

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -1135,7 +1135,7 @@ describe('ReactIncrementalSideEffects', () => {
 
     expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
       'Warning: Stateless function components cannot be given refs. ' +
-      'Attempts to access this ref will fail. Check the render method ' +
+      'Attempts to access this ref will fail.\n\nCheck the render method ' +
       'of `Foo`.\n' +
       '    in FunctionalComponent (at **)\n' +
       '    in div (at **)\n' +

--- a/src/renderers/shared/shared/__tests__/ReactComponent-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactComponent-test.js
@@ -370,7 +370,7 @@ describe('ReactComponent', () => {
       'Element type is invalid: expected a string (for built-in components) ' +
       'or a class/function (for composite components) but got: undefined. ' +
       'You likely forgot to export your component from the file it\'s ' +
-      'defined in. Check the render method of `Bar`.'
+      'defined in.\n\nCheck the render method of `Bar`.'
     );
 
     // One warning for each element creation

--- a/src/renderers/shared/shared/__tests__/ReactComponentLifeCycle-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactComponentLifeCycle-test.js
@@ -237,7 +237,7 @@ describe('ReactComponentLifeCycle', () => {
     expectDev(console.error.calls.argsFor(0)[0]).toBe(
       'Warning: setState(...): Can only update a mounted or ' +
       'mounting component. This usually means you called setState() on an ' +
-      'unmounted component. This is a no-op. Please check the code for the ' +
+      'unmounted component. This is a no-op.\n\nPlease check the code for the ' +
       'StatefulComponent component.'
     );
   });

--- a/src/renderers/shared/shared/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactCompositeComponent-test.js
@@ -280,7 +280,7 @@ describe('ReactCompositeComponent', () => {
     expectDev(console.error.calls.argsFor(0)[0]).toBe(
       'Warning: forceUpdate(...): Can only update a mounted or ' +
       'mounting component. This usually means you called forceUpdate() on an ' +
-      'unmounted component. This is a no-op. Please check the code for the ' +
+      'unmounted component. This is a no-op.\n\nPlease check the code for the ' +
       'Component component.'
     );
   });
@@ -324,7 +324,7 @@ describe('ReactCompositeComponent', () => {
     expectDev(console.error.calls.argsFor(0)[0]).toBe(
       'Warning: setState(...): Can only update a mounted or ' +
       'mounting component. This usually means you called setState() on an ' +
-      'unmounted component. This is a no-op. Please check the code for the ' +
+      'unmounted component. This is a no-op.\n\nPlease check the code for the ' +
       'Component component.'
     );
   });
@@ -1033,7 +1033,7 @@ describe('ReactCompositeComponent', () => {
       'Warning: _renderNewRootComponent(): Render methods should ' +
       'be a pure function of props and state; triggering nested component ' +
       'updates from render is not allowed. If necessary, trigger nested ' +
-      'updates in componentDidUpdate. Check the render method of Outer.'
+      'updates in componentDidUpdate.\n\nCheck the render method of Outer.'
     );
   });
 

--- a/src/renderers/shared/shared/__tests__/ReactMultiChild-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactMultiChild-test.js
@@ -280,7 +280,7 @@ describe('ReactMultiChild', () => {
       expectDev(console.error.calls.argsFor(0)[0]).toBe(
         'Warning: Using Maps as children is not yet fully supported. It is an ' +
         'experimental feature that might be removed. Convert it to a sequence ' +
-        '/ iterable of keyed ReactElements instead. Check the render method of `Parent`.'
+        '/ iterable of keyed ReactElements instead.\n\nCheck the render method of `Parent`.'
       );
     });
   });

--- a/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactStatelessComponent-test.js
@@ -189,7 +189,7 @@ describe('ReactStatelessComponent', () => {
     expectDev(console.error.calls.count()).toBe(1);
     expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
       'Warning: Stateless function components cannot be given refs. ' +
-      'Attempts to access this ref will fail. Check the render method ' +
+      'Attempts to access this ref will fail.\n\nCheck the render method ' +
       'of `ParentUsingStringRef`.\n' +
       '    in StatelessComponent (at **)\n' +
       '    in div (at **)\n' +
@@ -224,7 +224,7 @@ describe('ReactStatelessComponent', () => {
     expectDev(console.error.calls.count()).toBe(1);
     expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
       'Warning: Stateless function components cannot be given refs. ' +
-      'Attempts to access this ref will fail. Check the render method ' +
+      'Attempts to access this ref will fail.\n\nCheck the render method ' +
       'of `ParentUsingFunctionRef`.\n' +
       '    in StatelessComponent (at **)\n' +
       '    in div (at **)\n' +

--- a/src/renderers/shared/stack/reconciler/ReactRef.js
+++ b/src/renderers/shared/stack/reconciler/ReactRef.js
@@ -37,7 +37,7 @@ function attachRef(ref, component, owner) {
           ownerName = owner.getName();
         }
         if (ownerName) {
-          info += ' Check the render method of `' + ownerName + '`.';
+          info += '\n\nCheck the render method of `' + ownerName + '`.';
         }
       }
 

--- a/src/renderers/shared/stack/reconciler/ReactUpdateQueue.js
+++ b/src/renderers/shared/stack/reconciler/ReactUpdateQueue.js
@@ -35,7 +35,7 @@ function getInternalInstanceReadyForUpdate(publicInstance, callerName) {
         !callerName,
         '%s(...): Can only update a mounted or mounting component. ' +
         'This usually means you called %s() on an unmounted component. ' +
-        'This is a no-op. Please check the code for the %s component.',
+        'This is a no-op.\n\nPlease check the code for the %s component.',
         callerName,
         callerName,
         ctor && (ctor.displayName || ctor.name) || 'ReactClass'

--- a/src/renderers/shared/stack/reconciler/instantiateReactComponent.js
+++ b/src/renderers/shared/stack/reconciler/instantiateReactComponent.js
@@ -35,7 +35,7 @@ function getDeclarationErrorAddendum(owner) {
   if (owner) {
     var name = owner.getName();
     if (name) {
-      return ' Check the render method of `' + name + '`.';
+      return '\n\nCheck the render method of `' + name + '`.';
     }
   }
   return '';

--- a/src/renderers/testing/__tests__/ReactTestRenderer-test.js
+++ b/src/renderers/testing/__tests__/ReactTestRenderer-test.js
@@ -262,7 +262,7 @@ describe('ReactTestRenderer', () => {
     expectDev(console.error.calls.count()).toBe(1);
     expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
       'Warning: Stateless function components cannot be given refs. Attempts ' +
-      'to access this ref will fail. Check the render method of `Foo`.\n' +
+      'to access this ref will fail.\n\nCheck the render method of `Foo`.\n' +
       '    in Bar (at **)\n' +
       '    in Foo (at **)'
     );

--- a/src/shared/utils/traverseAllChildren.js
+++ b/src/shared/utils/traverseAllChildren.js
@@ -129,7 +129,7 @@ function traverseAllChildrenImpl(
           if (ReactCurrentOwner.current) {
             var mapsAsChildrenOwnerName = ReactCurrentOwner.current.getName();
             if (mapsAsChildrenOwnerName) {
-              mapsAsChildrenAddendum = ' Check the render method of `' + mapsAsChildrenOwnerName + '`.';
+              mapsAsChildrenAddendum = '\n\nCheck the render method of `' + mapsAsChildrenOwnerName + '`.';
             }
           }
           warning(
@@ -175,7 +175,7 @@ function traverseAllChildrenImpl(
         if (ReactCurrentOwner.current) {
           var name = ReactCurrentOwner.current.getName();
           if (name) {
-            addendum += ' Check the render method of `' + name + '`.';
+            addendum += '\n\nCheck the render method of `' + name + '`.';
           }
         }
       }


### PR DESCRIPTION
Added double newline delimiters to the following functions/files:

            * 'beginLifeCycleTimer' function of ReactDebugTool.js
            * 'bindAutoBindMethod' function of ReactClass.js
            * 'warnNoop' function of ReactServerUpdateQueue.js
            * 'getInternalInstanceReadyForUpdate' function of ReactUpdateQueue.js
            * 'warnNoop' function of ReactNoopUpdateQueue.js
            * 'getDeclarationErrorAddendum' function of ReactDOMComponent.js
            * 'getSourceInfoErrorAddendum' function of ReactElementValidator.js
            * 'getDeclarationErrorAddendum' function of instantiateReactComponent.js and ReactElementValidator.js
            * 'traverseAllChildrenImpl' function of traverseAllChildren.js
            * 'attachRef' function of ReactRef.js
            * 'mountIndeterminateComponent' function of ReactFiberBeginWork.js
            * 'createFiberFromElementType' function of ReactFiber.js
            * 'getDeclarationErrorAddendum' function of ReactDOMSelect.js
            * 'unmountComponentAtNode' function of ReactMount.js
            * 'getDeclarationErrorAddendum' function of ReactControlledValuePropTypes.js
            * 'checkRenderMessage' function of CSSPropertyOperations.js
            * 'getDeclarationErrorAddendum' function of ReactDomFiberSelect.js
            * 'getCurrentComponentErrorInfo' function in 'ReactElementValidator'
            * 'getDeclarationErrorAddendum' function in ReactDOMFiberComponent.js

Fixes #8719  