### PR TITLE
Add DEV mode warning

### DIFF
--- a/src/isomorphic/React.js
+++ b/src/isomorphic/React.js
@@ -28,6 +28,13 @@ var createFactory = ReactElement.createFactory;
 var cloneElement = ReactElement.cloneElement;
 
 if (__DEV__) {
+  console.log(
+    'React loaded in DEV mode. ' +
+    'See https://fb.me/react-dev-mode for more details'
+  )
+}
+
+if (__DEV__) {
   var ReactElementValidator = require('ReactElementValidator');
   createElement = ReactElementValidator.createElement;
   createFactory = ReactElementValidator.createFactory;


### PR DESCRIPTION
Just a quick patch to get the discussion started. 

The warning reads:

```
React loaded in DEV mode. See https://fb.me/react-dev-mode for more details
```

- I'm not sure this is the best place to add this. Other warnings are present in the file, and it's inside  `isomorphic`, so I made the decision based on that
- I decided not to use the built-in `warning` utility because I don't need any conditions. Thoughts?
  - Are we supporting environments where `console.log` should be checked for?
- Jest will output these warnings during tests. I've seen in other parts of the codebase there are checks for it that look like this. I decided not to include it because it's pretty verbose, but please let me know if I should change it
  ```js
  if (
    typeof process !== 'undefined' &&
    process.env &&
    process.env.NODE_ENV === 'test'
  ) {
    // …
  }
  ```
- My suggestion is to create a page / redirection from `https://fb.me/react-dev-mode` to a place where some notes are collected around:
  - How to get rid of the warning
  - What the differences are between dev mode and prod mode
  - Tips for benchmark authors and perhaps an example of what's considered a useful benchmark
    - Perhaps useful links to articles like [this one](https://medium.com/@localvoid/how-to-win-in-web-framework-benchmarks-8bc31af76ce7#.defwxx2re)