### PR TITLE
Tweaked captured error log slightly based on feedback

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberErrorLogger.js
+++ b/src/renderers/shared/fiber/ReactFiberErrorLogger.js
@@ -33,6 +33,9 @@ function logCapturedError(capturedError : CapturedError) : void {
       ? `React caught an error thrown by ${componentName}.`
       : 'React caught an error thrown by one of your components.';
 
+    const callStack = error.stack;
+    const trimmedCallStack = callStack.substring(callStack.indexOf('\n'));
+
     let errorBoundaryMessage;
     // errorBoundaryFound check is sufficient; errorBoundaryName check is to satisfy Flow.
     if (errorBoundaryFound && errorBoundaryName) {
@@ -54,8 +57,8 @@ function logCapturedError(capturedError : CapturedError) : void {
     console.error(
       `${componentNameMessage} You should fix this error in your code. ${errorBoundaryMessage}\n\n` +
       errorSummary +
-      `The error was thrown in the following location: ${componentStack}\n\n` +
-      error.stack
+      `The error is located at: ${componentStack}\n\n` +
+      `The error was thrown at: ${trimmedCallStack}`
     );
   }
 

--- a/src/renderers/shared/fiber/ReactFiberErrorLogger.js
+++ b/src/renderers/shared/fiber/ReactFiberErrorLogger.js
@@ -25,16 +25,32 @@ function logCapturedError(capturedError : CapturedError) : void {
       willRetry,
     } = capturedError;
 
-    const errorSummary = error.message
-      ? `Error: ${error.message}\n\n`
-      : '';
+    const {
+      message,
+      name,
+      stack,
+    } = error;
+
+    const errorSummary = message
+      ? `${name}: ${message}`
+      : name;
 
     const componentNameMessage = componentName
       ? `React caught an error thrown by ${componentName}.`
       : 'React caught an error thrown by one of your components.';
 
-    const callStack = error.stack;
-    const trimmedCallStack = callStack.substring(callStack.indexOf('\n'));
+    // Error stack varies by browser, eg:
+    // Chrome prepends the Error name and type.
+    // Firefox, Safari, and IE don't indent the stack lines.
+    // Format it in a consistent way for error logging.
+    let formattedCallStack = stack.slice(0, errorSummary.length) === errorSummary
+      ? stack.slice(errorSummary.length)
+      : stack;
+    formattedCallStack = formattedCallStack
+      .trim()
+      .split('\n')
+      .map((line) => `\n    ${line.trim()}`)
+      .join();
 
     let errorBoundaryMessage;
     // errorBoundaryFound check is sufficient; errorBoundaryName check is to satisfy Flow.
@@ -56,9 +72,9 @@ function logCapturedError(capturedError : CapturedError) : void {
 
     console.error(
       `${componentNameMessage} You should fix this error in your code. ${errorBoundaryMessage}\n\n` +
-      errorSummary +
+      `${errorSummary}\n\n` +
       `The error is located at: ${componentStack}\n\n` +
-      `The error was thrown at: ${trimmedCallStack}`
+      `The error was thrown at: ${formattedCallStack}`
     );
   }
 

--- a/src/renderers/shared/fiber/ReactFiberErrorLogger.js
+++ b/src/renderers/shared/fiber/ReactFiberErrorLogger.js
@@ -25,6 +25,10 @@ function logCapturedError(capturedError : CapturedError) : void {
       willRetry,
     } = capturedError;
 
+    const errorSummary = error.message
+      ? `Error: ${error.message}\n\n`
+      : '';
+
     const componentNameMessage = componentName
       ? `React caught an error thrown by ${componentName}.`
       : 'React caught an error thrown by one of your components.';
@@ -49,8 +53,9 @@ function logCapturedError(capturedError : CapturedError) : void {
 
     console.error(
       `${componentNameMessage} You should fix this error in your code. ${errorBoundaryMessage}\n\n` +
-      `${error.stack}\n\n` +
-      `The error was thrown in the following location: ${componentStack}`
+      errorSummary +
+      `The error was thrown in the following location: ${componentStack}\n\n` +
+      error.stack
     );
   }
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
@@ -980,7 +980,7 @@ describe('ReactIncrementalErrorHandling', () => {
       );
       expect(errorMessage).toContain('Error: componentWillMount error');
       expect(normalizeCodeLocInfo(errorMessage)).toContain(
-        'The error was thrown in the following location: \n' +
+        'The error is located at: \n' +
         '    in ErrorThrowingComponent (at **)\n' +
         '    in span (at **)\n' +
         '    in div (at **)'
@@ -1014,7 +1014,7 @@ describe('ReactIncrementalErrorHandling', () => {
       );
       expect(errorMessage).toContain('Error: componentDidMount error');
       expect(normalizeCodeLocInfo(errorMessage)).toContain(
-        'The error was thrown in the following location: \n' +
+        'The error is located at: \n' +
         '    in ErrorThrowingComponent (at **)\n' +
         '    in span (at **)\n' +
         '    in div (at **)'


### PR DESCRIPTION
## Before
![screen shot 2017-01-13 at 4 19 17 pm](https://cloud.githubusercontent.com/assets/29597/21950113/ab4aeb1e-d9ac-11e6-9691-2537c9912742.png)

## After
#### Chrome
<img width="796" alt="screen shot 2017-01-14 at 9 32 15 am" src="https://cloud.githubusercontent.com/assets/29597/21956780/f74f5df2-da3c-11e6-9de0-2bc050376a80.png">

#### Firefox
<img width="793" alt="screen shot 2017-01-14 at 9 31 58 am" src="https://cloud.githubusercontent.com/assets/29597/21956781/fb6f4d52-da3c-11e6-8606-07ede56c37d9.png">

#### Safari
<img width="736" alt="screen shot 2017-01-14 at 9 31 47 am" src="https://cloud.githubusercontent.com/assets/29597/21956778/f1b9051e-da3c-11e6-806c-94d0948c2b1e.png">

#### Internet Explorer
<img width="969" alt="screen shot 2017-01-14 at 9 40 18 am" src="https://cloud.githubusercontent.com/assets/29597/21956800/811310ec-da3d-11e6-96e4-182c9909db59.png">

#### Edge
![screen shot 2017-01-17 at 10 00 49 am](https://cloud.githubusercontent.com/assets/29597/22033067/dbd1c784-dc9b-11e6-8a08-bf7ca3f26b99.png)
