### PR TITLE
[Fiber]: Fix failing test "Should increase refs with an increase in divs"

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -63,6 +63,3 @@ src/renderers/shared/shared/__tests__/ReactMultiChildText-test.js
 
 src/renderers/shared/shared/__tests__/ReactUpdates-test.js
 * marks top-level updates
-
-src/renderers/shared/shared/__tests__/refs-test.js
-* Should increase refs with an increase in divs

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1612,6 +1612,7 @@ src/renderers/shared/shared/__tests__/refs-destruction-test.js
 * should not error when destroying child with ref asynchronously
 
 src/renderers/shared/shared/__tests__/refs-test.js
+* Should increase refs with an increase in divs
 * Allow refs to hop around children correctly
 * always has a value for this.refs
 * ref called correctly for stateless component when __DEV__ = false

--- a/src/renderers/shared/shared/__tests__/refs-test.js
+++ b/src/renderers/shared/shared/__tests__/refs-test.js
@@ -15,100 +15,6 @@ var React = require('React');
 var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 var ReactTestUtils = require('ReactTestUtils');
 
-/**
- * Counts clicks and has a renders an item for each click. Each item rendered
- * has a ref of the form "clickLogN".
- */
-class ClickCounter extends React.Component {
-  state = {count: this.props.initialCount};
-
-  triggerReset = () => {
-    this.setState({count: this.props.initialCount});
-  };
-
-  handleClick = () => {
-    this.setState({count: this.state.count + 1});
-  };
-
-  render() {
-    var children = [];
-    var i;
-    for (i = 0; i < this.state.count; i++) {
-      children.push(
-        <div
-          className="clickLogDiv"
-          key={'clickLog' + i}
-          ref={'clickLog' + i}
-        />
-      );
-    }
-    return (
-      <span className="clickIncrementer" onClick={this.handleClick}>
-        {children}
-      </span>
-    );
-  }
-}
-
-/**
- * Only purpose is to test that refs are tracked even when applied to a
- * component that is injected down several layers. Ref systems are difficult to
- * build in such a way that ownership is maintained in an airtight manner.
- */
-class GeneralContainerComponent extends React.Component {
-  render() {
-    return <div>{this.props.children}</div>;
-  }
-}
-
-/**
- * Notice how refs ownership is maintained even when injecting a component
- * into a different parent.
- */
-class TestRefsComponent extends React.Component {
-  doReset = () => {
-    this.refs.myCounter.triggerReset();
-  };
-
-  render() {
-    return (
-      <div>
-        <div ref="resetDiv" onClick={this.doReset}>
-          Reset Me By Clicking This.
-        </div>
-        <GeneralContainerComponent ref="myContainer">
-          <ClickCounter ref="myCounter" initialCount={1}/>
-        </GeneralContainerComponent>
-      </div>
-    );
-  }
-}
-
-/**
- * Render a TestRefsComponent and ensure that the main refs are wired up.
- */
-var renderTestRefsComponent = function() {
-  var testRefsComponent =
-      ReactTestUtils.renderIntoDocument(<TestRefsComponent />);
-  expect(testRefsComponent instanceof TestRefsComponent).toBe(true);
-
-  var generalContainer = testRefsComponent.refs.myContainer;
-  expect(generalContainer instanceof GeneralContainerComponent).toBe(true);
-
-  var counter = testRefsComponent.refs.myCounter;
-  expect(counter instanceof ClickCounter).toBe(true);
-
-  return testRefsComponent;
-};
-
-
-var expectClickLogsLengthToBe = function(instance, length) {
-  var clickLogs =
-    ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'clickLogDiv');
-  expect(clickLogs.length).toBe(length);
-  expect(Object.keys(instance.refs.myCounter.refs).length).toBe(length);
-};
-
 describe('reactiverefs', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -121,6 +27,100 @@ describe('reactiverefs', () => {
    * perspective of the injected ClickCounter component.
    */
   it('Should increase refs with an increase in divs', () => {
+
+    /**
+     * Counts clicks and has a renders an item for each click. Each item rendered
+     * has a ref of the form "clickLogN".
+     */
+    class ClickCounter extends React.Component {
+      state = {count: this.props.initialCount};
+
+      triggerReset = () => {
+        this.setState({count: this.props.initialCount});
+      };
+
+      handleClick = () => {
+        this.setState({count: this.state.count + 1});
+      };
+
+      render() {
+        var children = [];
+        var i;
+        for (i = 0; i < this.state.count; i++) {
+          children.push(
+            <div
+              className="clickLogDiv"
+              key={'clickLog' + i}
+              ref={'clickLog' + i}
+            />
+          );
+        }
+        return (
+          <span className="clickIncrementer" onClick={this.handleClick}>
+            {children}
+          </span>
+        );
+      }
+    }
+
+    /**
+     * Only purpose is to test that refs are tracked even when applied to a
+     * component that is injected down several layers. Ref systems are difficult to
+     * build in such a way that ownership is maintained in an airtight manner.
+     */
+    class GeneralContainerComponent extends React.Component {
+      render() {
+        return <div>{this.props.children}</div>;
+      }
+    }
+
+    /**
+     * Notice how refs ownership is maintained even when injecting a component
+     * into a different parent.
+     */
+    class TestRefsComponent extends React.Component {
+      doReset = () => {
+        this.refs.myCounter.triggerReset();
+      };
+
+      render() {
+        return (
+          <div>
+            <div ref="resetDiv" onClick={this.doReset}>
+              Reset Me By Clicking This.
+            </div>
+            <GeneralContainerComponent ref="myContainer">
+              <ClickCounter ref="myCounter" initialCount={1}/>
+            </GeneralContainerComponent>
+          </div>
+        );
+      }
+    }
+    /**
+     * Render a TestRefsComponent and ensure that the main refs are wired up.
+     */
+    var renderTestRefsComponent = function() {
+      var testRefsComponent =
+          ReactTestUtils.renderIntoDocument(<TestRefsComponent />);
+      expect(testRefsComponent instanceof TestRefsComponent).toBe(true);
+
+      var generalContainer = testRefsComponent.refs.myContainer;
+      expect(generalContainer instanceof GeneralContainerComponent).toBe(true);
+
+      var counter = testRefsComponent.refs.myCounter;
+      expect(counter instanceof ClickCounter).toBe(true);
+
+      return testRefsComponent;
+    };
+
+
+    var expectClickLogsLengthToBe = function(instance, length) {
+      var clickLogs =
+        ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'clickLogDiv');
+      expect(clickLogs.length).toBe(length);
+      expect(Object.keys(instance.refs.myCounter.refs).length).toBe(length);
+    };
+
     var testRefsComponent = renderTestRefsComponent();
     var clickIncrementer =
       ReactTestUtils.findRenderedDOMComponentWithClass(


### PR DESCRIPTION
These test components defined outside of the test (ClickCounter, GeneralContainerComponent, TestRefsComponent) are constructed with a `refs` property referring to the initial value of `require('emptyObject')`

The module cache is *reset before each test*.

During the test an [equality comparison is done](https://github.com/facebook/react/blob/master/src/renderers/shared/fiber/ReactChildFiber.js#L104)  between the components `refs` property (the *initial value* of `require('emptyObject')`) and the *current value* of `require('emptyObject')`. This comparison incorrectly fails because the values are now different due to resetting the module cache!

Moving these component definitions into the test itself fixes this issue.