### PR TITLE
Fix fiber/record-tests to work on windows (slash differences)

### DIFF
--- a/scripts/fiber/record-tests
+++ b/scripts/fiber/record-tests
@@ -106,12 +106,14 @@ function runJest(maxWorkers) {
 function formatResults(runResults, predicate) {
   const formatted = [];
   runResults.testResults.forEach((fileResult) => {
-    const file = path.relative(root, fileResult.testFilePath);
+    const filePath = path.relative(root, fileResult.testFilePath);
+    // on windows, we still want to output forward slashes
+    const unixFilePath = filePath.replace(/\\/g, '/');
     const tests = fileResult.testResults.filter(
       (test) => predicate(fileResult, test)
     );
     if (tests.length) {
-      const lines = [file].concat(tests.map((test) => '* ' + test.title));
+      const lines = [unixFilePath].concat(tests.map((test) => '* ' + test.title));
       formatted.push(lines.join('\n'));
     }
   });


### PR DESCRIPTION
Running record-tests on windows modifies the output due to slash incompatibility.

![image](https://cloud.githubusercontent.com/assets/345235/21958662/b8afadce-db07-11e6-9e95-bf51c48db63a.png)

This change ensures the output is consistent across platforms which is required since the results are committed back to the repo.

Alternatively we could use [slash](https://www.npmjs.com/package/slash) to do this.