### PR TITLE
Preserve license headers from dependencies in minified build

### DIFF
--- a/grunt/config/browserify.js
+++ b/grunt/config/browserify.js
@@ -34,7 +34,18 @@ var LICENSE_TEMPLATE =
   grunt.file.read('./grunt/data/header-template-extended.txt');
 
 function minify(src) {
-  return UglifyJS.minify(src, {fromString: true}).code;
+  return UglifyJS.minify(src, {
+    fromString: true,
+    output: {
+      comments(node, comment) {
+        // Preserve license headers in dependencies like object-assign.
+        if (comment.type === 'comment2') {
+          return /@license/i.test(comment.value);
+        }
+        return false;
+      },
+    },
+  }).code;
 }
 
 // TODO: move this out to another build step maybe.

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "jest-runtime": "^18.0.0",
     "loose-envify": "^1.1.0",
     "merge-stream": "^1.0.0",
-    "object-assign": "^4.1.0",
+    "object-assign": "^4.1.1",
     "platform": "^1.1.0",
     "run-sequence": "^1.1.4",
     "through2": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -859,17 +859,13 @@ babel@^5.4.7:
     slash "^1.0.0"
     source-map "^0.5.0"
 
-babylon@6.15.0:
+babylon@6.15.0, babylon@^6.11.0, babylon@^6.13.0:
   version "6.15.0"
   resolved "http://registry.yarnpkg.com/babylon/-/babylon-6.15.0.tgz#ba65cfa1a80e1759b0e89fb562e27dccae70348e"
 
 babylon@^5.8.38:
   version "5.8.38"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-5.8.38.tgz#ec9b120b11bf6ccd4173a18bf217e60b79859ffd"
-
-babylon@^6.11.0, babylon@^6.13.0:
-  version "6.14.1"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.14.1.tgz#956275fab72753ad9b3435d7afe58f8bf0a29815"
 
 balanced-match@^0.4.1:
   version "0.4.2"
@@ -3937,6 +3933,10 @@ object-assign@^3.0.0:
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
+
+object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
 object-keys@^1.0.6:
   version "1.0.11"


### PR DESCRIPTION
Fixes #8789.

Test plan: verify that after manually applying https://github.com/sindresorhus/object-assign/pull/45 to `object-assign`, we preserve that header in the minified builds.

<img width="531" alt="screen shot 2017-01-16 at 15 25 13" src="https://cloud.githubusercontent.com/assets/810438/21988846/98cf9952-dc00-11e6-888a-d0c3d227e2a1.png">

We can merge it anytime but it will only have effect after an update to `object-assign` is released with https://github.com/sindresorhus/object-assign/pull/45.