### PR TITLE
Add Flow reminder to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,8 @@
 1. Fork the repo and create your branch from `master`.
 2. If you've added code that should be tested, add tests!
 3. If you've changed APIs, update the documentation.
-4. Ensure the test suite passes (`npm test`).
-5. Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.
-6. If you haven't already, complete the [CLA](https://code.facebook.com/cla).
+4. Ensure that:
+  * The test suite passes (`npm test`)
+  * Your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.
+  * Your code passes Flow (`npm run flow`).
+5. If you haven't already, complete the [CLA](https://code.facebook.com/cla).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
-*Before* submitting a pull request, please make sure the following is done...
+**Before submitting a pull request,** please make sure the following is done:
 
-1. Fork the repo and create your branch from `master`.
+1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
 2. If you've added code that should be tested, add tests!
-3. If you've changed APIs, update the documentation.
-4. Ensure that:
-  * The test suite passes (`npm test`)
-  * Your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.
-  * Your code passes Flow (`npm run flow`).
-5. If you haven't already, complete the [CLA](https://code.facebook.com/cla).
+3. If you added or removed any tests, run `./scripts/fiber/record-tests` before submitting the pull request, and commit the resulting changes.
+4. If you've changed APIs, update the documentation.
+5. Ensure the test suite passes (`npm test`).
+6. Make sure your code lints (`npm run lint`).
+7. Run the [Flow](https://flowtype.org/) typechecks (`npm run flow`).
+8. If you haven't already, complete the [CLA](https://code.facebook.com/cla).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,9 +2,9 @@
 
 1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
 2. If you've added code that should be tested, add tests!
-3. If you added or removed any tests, run `./scripts/fiber/record-tests` before submitting the pull request, and commit the resulting changes.
-4. If you've changed APIs, update the documentation.
-5. Ensure the test suite passes (`npm test`).
-6. Make sure your code lints (`npm run lint`).
-7. Run the [Flow](https://flowtype.org/) typechecks (`npm run flow`).
+3. If you've changed APIs, update the documentation.
+4. Ensure the test suite passes (`npm test`).
+5. Make sure your code lints (`npm run lint`).
+6. Run the [Flow](https://flowtype.org/) typechecks (`npm run flow`).
+7. If you added or removed any tests, run `./scripts/fiber/record-tests` before submitting the pull request, and commit the resulting changes.
 8. If you haven't already, complete the [CLA](https://code.facebook.com/cla).

--- a/docs/contributing/how-to-contribute.md
+++ b/docs/contributing/how-to-contribute.md
@@ -78,11 +78,12 @@ The core team is monitoring for pull requests. We will review your pull request 
 
 1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
 2. If you've added code that should be tested, add tests!
-3. If you've changed APIs, update the documentation.
-4. Ensure the test suite passes (`npm test`).
-5. Make sure your code lints (`npm run lint`).
-6. Run the [Flow](https://flowtype.org/) typechecks (`npm run flow`).
-7. If you haven't already, complete the CLA.
+3. If you added or removed any tests, run ./scripts/fiber/record-tests before submitting the pull request, and commit the resulting changes.
+4. If you've changed APIs, update the documentation.
+5. Ensure the test suite passes (`npm test`).
+6. Make sure your code lints (`npm run lint`).
+7. Run the [Flow](https://flowtype.org/) typechecks (`npm run flow`).
+8. If you haven't already, complete the CLA.
 
 ### Contributor License Agreement (CLA)
 

--- a/docs/contributing/how-to-contribute.md
+++ b/docs/contributing/how-to-contribute.md
@@ -78,11 +78,11 @@ The core team is monitoring for pull requests. We will review your pull request 
 
 1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
 2. If you've added code that should be tested, add tests!
-3. If you added or removed any tests, run ./scripts/fiber/record-tests before submitting the pull request, and commit the resulting changes.
-4. If you've changed APIs, update the documentation.
-5. Ensure the test suite passes (`npm test`).
-6. Make sure your code lints (`npm run lint`).
-7. Run the [Flow](https://flowtype.org/) typechecks (`npm run flow`).
+3. If you've changed APIs, update the documentation.
+4. Ensure the test suite passes (`npm test`).
+5. Make sure your code lints (`npm run lint`).
+6. Run the [Flow](https://flowtype.org/) typechecks (`npm run flow`).
+7. If you added or removed any tests, run `./scripts/fiber/record-tests` before submitting the pull request, and commit the resulting changes.
 8. If you haven't already, complete the CLA.
 
 ### Contributor License Agreement (CLA)


### PR DESCRIPTION
Since CircleCI fails on Flow errors, I think it would be helpful to add a reminder to `npm run flow` before submitting a PR.

Formatting was inspired by the [Draft.js PR template](https://github.com/facebook/draft-js/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
