### PR TITLE
Reminder: strip quotes from attributes with JS code

### DIFF
--- a/docs/docs/introducing-jsx.md
+++ b/docs/docs/introducing-jsx.md
@@ -79,6 +79,8 @@ You may also use curly braces to embed a JavaScript expression in an attribute:
 const element = <img src={user.avatarUrl}></img>;
 ```
 
+You must remove quotes around curly braces when embedding a JavaScript expression in an attribute. Otherwise JSX will treat the attribute as a string literal, not as JavaScript code.  This is an important difference between JSX and HTML, XML, or other templating languages that require quotes around all attributes.
+
 ### Specifying Children with JSX
 
 If a tag is empty, you may close it immediately with `/>`, like XML:

--- a/docs/docs/introducing-jsx.md
+++ b/docs/docs/introducing-jsx.md
@@ -79,7 +79,7 @@ You may also use curly braces to embed a JavaScript expression in an attribute:
 const element = <img src={user.avatarUrl}></img>;
 ```
 
-You must remove quotes around curly braces when embedding a JavaScript expression in an attribute. Otherwise JSX will treat the attribute as a string literal, not as JavaScript code.  This is an important difference between JSX and HTML, XML, or other templating languages that require quotes around all attributes.
+Don't put quotes around curly braces when embedding a JavaScript expression in an attribute. Otherwise JSX will treat the attribute as a string literal rather than an expression. You should either use quotes (for string values) or curly braces (for expressions), but not both in the same attribute.
 
 ### Specifying Children with JSX
 


### PR DESCRIPTION
Web developers who are used to standards-compliant HTML and XML will, out of habit, put quotes around all attributes because the standards require them. Other templating systems like ASP.NET also require (or at least allow) quotes around attributes that contain code. This behavior will get users into trouble in JSX because a quoted attribute is always treated as a string literal, even if it contains curly-braced javascript code.  Let's add to the docs to help newbies evade this problem.

*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure the test suite passes (`npm test`).
5. Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.
6. If you haven't already, complete the [CLA](https://code.facebook.com/cla).
