### PR TITLE
Replace 2 occurrences of string in type ReactTestRendererJSON

### DIFF
--- a/src/renderers/testing/ReactTestRendererFiber.js
+++ b/src/renderers/testing/ReactTestRendererFiber.js
@@ -18,14 +18,15 @@ var ReactGenericBatching = require('ReactGenericBatching');
 var emptyObject = require('emptyObject');
 
 import type { TestRendererOptions } from 'ReactTestMount';
+import type { ReactText } from 'ReactTypes';
 
 type ReactTestRendererJSON = {|
   type : string,
-  props : {[propName: string] : string },
+  props : {[propName: string] : any },
   children : null | Array<ReactTestRendererNode>,
   $$typeof ?: Symbol, // Optional because we add it with defineProperty().
 |};
-type ReactTestRendererNode = ReactTestRendererJSON | string;
+type ReactTestRendererNode = ReactTestRendererJSON | ReactText;
 
 type Container = {|
   children : Array<Instance | TextInstance>,

--- a/src/renderers/testing/ReactTestRendererFiber.js
+++ b/src/renderers/testing/ReactTestRendererFiber.js
@@ -18,7 +18,6 @@ var ReactGenericBatching = require('ReactGenericBatching');
 var emptyObject = require('emptyObject');
 
 import type { TestRendererOptions } from 'ReactTestMount';
-import type { ReactText } from 'ReactTypes';
 
 type ReactTestRendererJSON = {|
   type : string,
@@ -26,7 +25,7 @@ type ReactTestRendererJSON = {|
   children : null | Array<ReactTestRendererNode>,
   $$typeof ?: Symbol, // Optional because we add it with defineProperty().
 |};
-type ReactTestRendererNode = ReactTestRendererJSON | ReactText;
+type ReactTestRendererNode = ReactTestRendererJSON | string;
 
 type Container = {|
   children : Array<Instance | TextInstance>,

--- a/src/renderers/testing/stack/ReactTestRendererStack.js
+++ b/src/renderers/testing/stack/ReactTestRendererStack.js
@@ -27,11 +27,12 @@ var invariant = require('invariant');
 
 import type { ReactElement } from 'ReactElementType';
 import type { ReactInstance } from 'ReactInstanceType';
+import type { ReactText } from 'ReactTypes';
 
 type ReactTestRendererJSON = {
   type: string,
-  props: { [propName: string]: string },
-  children: null | Array<string | ReactTestRendererJSON>,
+  props: { [propName: string]: any },
+  children: null | Array<ReactText | ReactTestRendererJSON>,
   $$typeof?: any
 }
 


### PR DESCRIPTION
While studying implementation details of react-test-renderer, type `ReactTestRendererJSON` contradicted instead of confirmed what I had observed in Jest.

To verify misleading Flow errors, I temporarily pasted an object as if from `renderer.create(<th colSpan={2}>{13}</th>).toJSON()` into ReactTestRendererFiber.js and ReactTestRendererStack.js:

```js
const th: ReactTestRendererJSON = {
  type: 'th',
  props: { colSpan: 2 },
  children: [13],
};
```

Currently the type is neither exported nor has an opportunity to report incorrect errors, but it could confuse people who read it as the specification of the object format from the test renderer.

* Is `any` too lax as the type for values of `props`?
* For the definition of `ReactText` see https://github.com/facebook/react/blob/master/src/renderers/shared/fiber/isomorphic/ReactTypes.js#L24
