### PR TITLE
PropTypes type checking: Add additional check to UnionType checker

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -352,6 +352,7 @@ src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
 * should be implicitly optional and not warn without values
 * should warn for missing required values
 * should warn but not error for invalid argument
+* should warn when no checker functions are provided
 * should warn if none of the types are valid
 * should not warn if one of the types are valid
 * should be implicitly optional and not warn without values

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -347,6 +347,13 @@ function createUnionTypeChecker(arrayOfTypeCheckers) {
     return emptyFunction.thatReturnsNull;
   }
 
+  for (var k = 0; k < arrayOfTypeCheckers.length; k++) {
+    if (typeof arrayOfTypeCheckers[k] !== 'function') {
+      warning(false, 'Invalid argument supplied to oneOfType, expected an array containing check functions.');
+      return emptyFunction.thatReturnsNull;
+    }
+  }
+
   function validate(props, propName, componentName, location, propFullName) {
     for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
       var checker = arrayOfTypeCheckers[i];

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -675,6 +675,16 @@ describe('ReactPropTypes', () => {
       typeCheckPass(PropTypes.oneOf(PropTypes.string, PropTypes.number), []);
     });
 
+    it('should warn when no checker functions are provided', () => {
+      spyOn(console, 'error');
+
+      PropTypes.oneOfType([undefined])
+
+      expectDev(console.error).toHaveBeenCalled();
+      expectDev(console.error.calls.argsFor(0)[0])
+        .toContain('Invalid argument supplied to oneOfType, expected an array containing check functions.');
+    });
+
     it('should warn if none of the types are valid', () => {
       typeCheckFail(
         PropTypes.oneOfType([PropTypes.string, PropTypes.number]),


### PR DESCRIPTION
PropTypes type checking: Add additional check to UnionType checker to ensure only functions are used as argument of oneOfType.

This is especially handy to catch typos during PropType definition like for example:
```javascript
Greeting.propTypes = {
  name: React.PropTypes.oneOfType([React.PropTypes.sting, React.PropTypes.func])
};
```

The pull request will print a warning 
`Invalid argument supplied to oneOfType, expected an array containing check functions.`
