### PR TITLE
Tutorial: Absolute image links to work with github preview

### DIFF
--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -82,11 +82,11 @@ Just to get our feet wet, let's try passing some data from the Board component t
 
 Before:
 
-![React Devtools](/react/img/tutorial/tictac-empty.png)
+![React Devtools](https://facebook.github.io/react/img/tutorial/tictac-empty.png)
 
 After: You should see a number in each square in the rendered output.
 
-![React Devtools](/react/img/tutorial/tictac-numbers.png)
+![React Devtools](https://facebook.github.io/react/img/tutorial/tictac-numbers.png)
 
 ##An Interactive Component
 
@@ -130,7 +130,7 @@ If you click on any square, an X should show up in it.
 
 The React Devtools extension for [Chrome](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/react-devtools/) lets you inspect a React component tree in your browser devtools.
 
-<img src="/react/img/tutorial/devtools.png" alt="React Devtools" style="max-width: 100%">
+<img src="https://facebook.github.io/react/img/tutorial/devtools.png" alt="React Devtools" style="max-width: 100%">
 
 It lets you inspect the props and state of any of the components in your tree.
 


### PR DESCRIPTION
When visiting [tutorial.md](https://github.com/facebook/react/blob/master/docs/tutorial/tutorial.md) the images can't be displayed because relative links are used. The [Website](https://facebook.github.io/react/tutorial/tutorial.html) is working. 

I'd suggest using absolute links for images to work with both - website and github preview.

### Screenshot
![image](https://cloud.githubusercontent.com/assets/13085980/22160805/8fe15a02-df47-11e6-865b-a7f3b1ab36e1.png)
