### PR TITLE
Read "current" props from the node instead of the Fiber

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -37,9 +37,6 @@ src/renderers/dom/shared/__tests__/ReactRenderDocument-test.js
 * should throw on full document render w/ no markup
 * supports findDOMNode on full-page components
 
-src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
-* should control a value in reentrant events
-
 src/renderers/shared/__tests__/ReactPerf-test.js
 * should count no-op update as waste
 * should count no-op update in child as waste

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -960,6 +960,7 @@ src/renderers/dom/shared/wrappers/__tests__/ReactDOMIframe-test.js
 
 src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
 * should properly control a value even if no event listener exists
+* should control a value in reentrant events
 * should control values in reentrant events with different targets
 * should display `defaultValue` of number 0
 * only assigns defaultValue if it changes

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -40,7 +40,7 @@ var {
 } = ReactDOMFiberComponent;
 var {
   precacheFiberNode,
-  updateFiberEventHandlers,
+  updateFiberProps,
 } = ReactDOMComponentTree;
 
 if (__DEV__) {
@@ -188,7 +188,7 @@ var DOMRenderer = ReactFiberReconciler({
     }
     const domElement : Instance = createElement(type, props, rootContainerInstance, parentNamespace);
     precacheFiberNode(internalInstanceHandle, domElement);
-    updateFiberEventHandlers(domElement, props);
+    updateFiberProps(domElement, props);
     return domElement;
   },
 
@@ -246,7 +246,7 @@ var DOMRenderer = ReactFiberReconciler({
   ) : void {
     // Update the props handle so that we know which props are the ones with
     // with current event handlers.
-    updateFiberEventHandlers(domElement, newProps);
+    updateFiberProps(domElement, newProps);
     // Apply the diff to the DOM node.
     updateProperties(domElement, updatePayload, type, oldProps, newProps);
   },

--- a/src/renderers/dom/shared/ReactDOMComponentTree.js
+++ b/src/renderers/dom/shared/ReactDOMComponentTree.js
@@ -221,11 +221,11 @@ function getNodeFromInstance(inst) {
   return inst._hostNode;
 }
 
-function getFiberEventHandlersFromNode(node) {
+function getFiberCurrentPropsFromNode(node) {
   return node[internalEventHandlersKey] || null;
 }
 
-function updateFiberEventHandlers(node, props) {
+function updateFiberProps(node, props) {
   node[internalEventHandlersKey] = props;
 }
 
@@ -237,8 +237,8 @@ var ReactDOMComponentTree = {
   precacheNode: precacheNode,
   uncacheNode: uncacheNode,
   precacheFiberNode: precacheFiberNode,
-  getFiberEventHandlersFromNode,
-  updateFiberEventHandlers,
+  getFiberCurrentPropsFromNode,
+  updateFiberProps,
 };
 
 module.exports = ReactDOMComponentTree;

--- a/src/renderers/native/ReactNativeComponentTree.js
+++ b/src/renderers/native/ReactNativeComponentTree.js
@@ -70,7 +70,7 @@ function getFiberEventHandlersFromTag(tag) {
   return instanceProps[tag] || null;
 }
 
-function updateFiberEventHandlers(tag, props) {
+function updateFiberProps(tag, props) {
   instanceProps[tag] = props;
 }
 
@@ -82,8 +82,8 @@ var ReactNativeComponentTree = {
   precacheNode,
   uncacheFiberNode,
   uncacheNode,
-  getFiberEventHandlersFromNode: getFiberEventHandlersFromTag,
-  updateFiberEventHandlers,
+  getFiberCurrentPropsFromNode: getFiberEventHandlersFromTag,
+  updateFiberProps,
 };
 
 module.exports = ReactNativeComponentTree;

--- a/src/renderers/native/ReactNativeFiber.js
+++ b/src/renderers/native/ReactNativeFiber.js
@@ -36,7 +36,7 @@ const invariant = require('invariant');
 const {
   precacheFiberNode,
   uncacheFiberNode,
-  updateFiberEventHandlers,
+  updateFiberProps,
 } = ReactNativeComponentTree;
 
 ReactNativeInjection.inject();
@@ -133,7 +133,7 @@ const NativeRenderer = ReactFiberReconciler({
   ) : void {
     const viewConfig = instance.viewConfig;
 
-    updateFiberEventHandlers(instance._nativeTag, newProps);
+    updateFiberProps(instance._nativeTag, newProps);
 
     const updatePayload = ReactNativeAttributePayload.diff(
       oldProps,
@@ -181,7 +181,7 @@ const NativeRenderer = ReactFiberReconciler({
     const component = new NativeHostComponent(tag, viewConfig);
 
     precacheFiberNode(internalInstanceHandle, tag);
-    updateFiberEventHandlers(tag, props);
+    updateFiberProps(tag, props);
 
     return component;
   },

--- a/src/renderers/shared/shared/event/EventPluginHub.js
+++ b/src/renderers/shared/shared/event/EventPluginHub.js
@@ -126,7 +126,7 @@ var EventPluginHub = {
     // TODO: shouldPreventMouseEvent is DOM-specific and definitely should not
     // live here; needs to be moved to a better place soon
     if (typeof inst.tag === 'number') {
-      const props = EventPluginUtils.getFiberEventHandlersFromNode(
+      const props = EventPluginUtils.getFiberCurrentPropsFromNode(
         inst.stateNode
       );
       if (!props) {

--- a/src/renderers/shared/shared/event/EventPluginUtils.js
+++ b/src/renderers/shared/shared/event/EventPluginUtils.js
@@ -219,8 +219,8 @@ var EventPluginUtils = {
   executeDispatchesInOrderStopAtTrue: executeDispatchesInOrderStopAtTrue,
   hasDispatches: hasDispatches,
 
-  getFiberEventHandlersFromNode: function(node) {
-    return ComponentTree.getFiberEventHandlersFromNode(node);
+  getFiberCurrentPropsFromNode: function(node) {
+    return ComponentTree.getFiberCurrentPropsFromNode(node);
   },
   getInstanceFromNode: function(node) {
     return ComponentTree.getInstanceFromNode(node);

--- a/src/renderers/shared/shared/event/ReactControlledComponent.js
+++ b/src/renderers/shared/shared/event/ReactControlledComponent.js
@@ -45,10 +45,13 @@ function restoreStateOfTarget(target) {
       'Fiber needs to be injected to handle a fiber target for controlled ' +
       'events.'
     );
+    const props = EventPluginUtils.getFiberCurrentPropsFromNode(
+      internalInstance.stateNode
+    );
     fiberHostComponent.restoreControlledState(
       internalInstance.stateNode,
       internalInstance.type,
-      internalInstance.memoizedProps
+      props
     );
     return;
   }


### PR DESCRIPTION
This fixes controlled components after I broke them in. #8607

It's not just events that read the current props. Controlled components do as well. Since we're no longer updating the Fiber pointer during updates we have to instead read from the node props to get the current props.

Since this method is no longer just used for events I renamed it.
