### PR TITLE
Eslint rule failure cleanup

### DIFF
--- a/grunt/config/browserify.js
+++ b/grunt/config/browserify.js
@@ -96,8 +96,10 @@ function simpleBannerify(src) {
 // Does it work? Yes.
 // Should it go away ASAP? Yes.
 function wrapperify(src) {
+  /* eslint-disable max-len*/
   var toReplace =
     `function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.${this.data.standalone} = f()}}`;
+  /* eslint-enable max-len */
   if (src.indexOf(toReplace) === -1) {
     throw new Error('wrapperify failed to find code to replace');
   }

--- a/scripts/release-manager/cli.js
+++ b/scripts/release-manager/cli.js
@@ -98,7 +98,11 @@ const app = {
       PATH_TO_REPO = config.reactPath;
       return config;
     } catch (e) {
-      console.error('Attempt to load config file failed. Please run `init` command for initial setup or make sure ~/.react-release-manager.json is valid JSON. Using a default config which may not work properly.');
+      console.error(
+        'Attempt to load config file failed. Please run `init` command for initial setup or make sure ' +
+        '~/.react-release-manager.json is valid JSON. Using a default config which may not work ' +
+        'properly.'
+      );
       return DEFAULT_CONFIG;
     }
   },

--- a/scripts/release-manager/commands/docs-prs.js
+++ b/scripts/release-manager/commands/docs-prs.js
@@ -16,7 +16,8 @@ const DOCS_LABEL = 'Documentation: needs merge to stable';
 // track progress. on fail, pause and force user to handle manually, continue? prompt
 // git push
 // update labels on each PR
-//   ALT: dump link to https://github.com/facebook/react/issues?q=label%3A%22Documentation%3A+needs+merge+to+stable%22+is%3Aclosed
+//   ALT: dump link to
+//        https://github.com/facebook/react/issues?q=label%3A%22Documentation%3A+needs+merge+to+stable%22+is%3Aclosed
 //        and say manual step to remove label
 
 

--- a/scripts/release-manager/commands/stable-prs.js
+++ b/scripts/release-manager/commands/stable-prs.js
@@ -131,7 +131,10 @@ module.exports = function(vorpal, app) {
             .then((richPRs) => {
               return richPRs.filter((pr) => {
                 if (!pr.merged_at) {
-                  this.log(`${chalk.yellow.bold('WARNING')} ${pr.html_url} was not merged, should have the milestone unset.`);
+                  this.log(
+                    `${chalk.yellow.bold('WARNING')} ${pr.html_url} was not merged,` +
+                     ` should have the milestone unset.`
+                  );
                   return false;
                 }
                 return true;
@@ -168,7 +171,10 @@ module.exports = function(vorpal, app) {
                 resolve(results);
               })
               .catch((err) => {
-                this.log(`${chalk.red.bold('ERROR')} Something went wrong and your repo is probably in a bad state. Sorry.`);
+                this.log(
+                  `${chalk.red.bold('ERROR')} Something went wrong and your repo is` +
+                   ` probably in a bad state. Sorry.`
+                );
                 resolve({
                   successful: [],
                   skipped: [],

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -325,7 +325,12 @@ function warnAboutUnstableUse() {
   warned = true;
 }
 
-function renderSubtreeIntoContainer(parentComponent : ?ReactComponent<any, any, any>, children : ReactNodeList, containerNode : DOMContainerElement | Document, callback: ?Function) {
+function renderSubtreeIntoContainer(
+  parentComponent : ?ReactComponent<any, any, any>,
+  children : ReactNodeList,
+  containerNode : DOMContainerElement | Document,
+  callback: ?Function
+) {
   validateContainer(containerNode);
 
   let container : DOMContainerElement =
@@ -355,7 +360,12 @@ var ReactDOM = {
     return renderSubtreeIntoContainer(null, element, container, callback);
   },
 
-  unstable_renderSubtreeIntoContainer(parentComponent : ReactComponent<any, any, any>, element : ReactElement<any>, containerNode : DOMContainerElement | Document, callback: ?Function) {
+  unstable_renderSubtreeIntoContainer(
+    parentComponent : ReactComponent<any, any, any>,
+    element : ReactElement<any>,
+    containerNode : DOMContainerElement | Document,
+    callback: ?Function
+  ) {
     invariant(
       parentComponent != null && ReactInstanceMap.has(parentComponent),
       'parentComponent must be a valid React Component'

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -369,7 +369,7 @@ function updateDOMProperties(
   isCustomComponentTag : boolean,
 ) : void {
   // TODO: Handle wasCustomComponentTag
-  for (var i = 0; i < updatePayload.length; i+=2) {
+  for (var i = 0; i < updatePayload.length; i += 2) {
     var propKey = updatePayload[i];
     var propValue = updatePayload[i + 1];
     if (propKey === STYLE) {

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -331,7 +331,11 @@ exports.createFiberFromText = function(content : string, priorityLevel : Priorit
   return fiber;
 };
 
-function createFiberFromElementType(type : mixed, key : null | string, debugOwner : null | Fiber | ReactInstance) : Fiber {
+function createFiberFromElementType(
+  type : mixed,
+  key : null | string,
+  debugOwner : null | Fiber | ReactInstance
+) : Fiber {
   let fiber;
   if (typeof type === 'function') {
     fiber = shouldConstruct(type) ?

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -201,7 +201,15 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           // Even better would be if children weren't special cased at all tho.
           const instance : I = workInProgress.stateNode;
           const currentHostContext = getHostContext();
-          const updatePayload = prepareUpdate(instance, type, oldProps, newProps, rootContainerInstance, currentHostContext);
+          const updatePayload = prepareUpdate(
+            instance,
+            type,
+            oldProps,
+            newProps,
+            rootContainerInstance,
+            currentHostContext
+          );
+
           // TODO: Type this specific to this type of component.
           workInProgress.updateQueue = (updatePayload : any);
           // If the update payload indicates that there is a change or if there

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -49,18 +49,43 @@ export type HostConfig<T, P, I, TI, PI, C, CX, PL> = {
   getChildHostContext(parentHostContext : CX, type : T) : CX,
   getPublicInstance(instance : I | TI) : PI,
 
-  createInstance(type : T, props : P, rootContainerInstance : C, hostContext : CX, internalInstanceHandle : OpaqueNode) : I,
+  createInstance(
+    type : T,
+    props : P,
+    rootContainerInstance : C,
+    hostContext : CX,
+    internalInstanceHandle : OpaqueNode
+  ) : I,
   appendInitialChild(parentInstance : I, child : I | TI) : void,
   finalizeInitialChildren(parentInstance : I, type : T, props : P, rootContainerInstance : C) : boolean,
 
-  prepareUpdate(instance : I, type : T, oldProps : P, newProps : P, rootContainerInstance : C, hostContext : CX) : null | PL,
-  commitUpdate(instance : I, updatePayload : PL, type : T, oldProps : P, newProps : P, internalInstanceHandle : OpaqueNode) : void,
+  prepareUpdate(
+    instance : I,
+    type : T,
+    oldProps : P,
+    newProps : P,
+    rootContainerInstance : C,
+    hostContext : CX
+  ) : null | PL,
+  commitUpdate(
+    instance : I,
+    updatePayload : PL,
+    type : T,
+    oldProps : P,
+    newProps : P,
+    internalInstanceHandle : OpaqueNode
+  ) : void,
   commitMount(instance : I, type : T, newProps : P, internalInstanceHandle : OpaqueNode) : void,
 
   shouldSetTextContent(props : P) : boolean,
   resetTextContent(instance : I) : void,
 
-  createTextInstance(text : string, rootContainerInstance : C, hostContext : CX, internalInstanceHandle : OpaqueNode) : TI,
+  createTextInstance(
+    text : string,
+    rootContainerInstance : C,
+    hostContext : CX,
+    internalInstanceHandle : OpaqueNode
+  ) : TI,
   commitTextUpdate(textInstance : TI, oldText : string, newText : string) : void,
 
   appendChild(parentInstance : I | C, child : I | TI) : void,
@@ -78,15 +103,16 @@ export type HostConfig<T, P, I, TI, PI, C, CX, PL> = {
 
 export type Reconciler<C, I, TI> = {
   createContainer(containerInfo : C) : OpaqueNode,
-  updateContainer(element : ReactNodeList, container : OpaqueNode, parentComponent : ?ReactComponent<any, any, any>) : void,
+  updateContainer(
+    element : ReactNodeList,
+    container : OpaqueNode,
+    parentComponent : ?ReactComponent<any, any, any>
+  ) : void,
   performWithPriority(priorityLevel : PriorityLevel, fn : Function) : void,
-  /* eslint-disable no-undef */
-  // FIXME: ESLint complains about type parameter
   batchedUpdates<A>(fn : () => A) : A,
   unbatchedUpdates<A>(fn : () => A) : A,
   syncUpdates<A>(fn : () => A) : A,
   deferredUpdates<A>(fn : () => A) : A,
-  /* eslint-enable no-undef */
 
   // Used to extract the return value from the initial render. Legacy API.
   getPublicRootInstance(container : OpaqueNode) : (ReactComponent<any, any, any> | TI | I | null),
@@ -102,8 +128,9 @@ getContextForSubtree._injectFiber(function(fiber : Fiber) {
     parentContext;
 });
 
-module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, I, TI, PI, C, CX, PL>) : Reconciler<C, I, TI> {
-
+module.exports = function<T, P, I, TI, PI, C, CX, PL>(
+  config : HostConfig<T, P, I, TI, PI, C, CX, PL>
+) : Reconciler<C, I, TI> {
   var {
     scheduleUpdate,
     getPriorityContext,
@@ -133,7 +160,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       return current;
     },
 
-    updateContainer(element : ReactNodeList, container : OpaqueNode, parentComponent : ?ReactComponent<any, any, any>, callback: ?Function) : void {
+    updateContainer(
+      element : ReactNodeList,
+      container : OpaqueNode,
+      parentComponent : ?ReactComponent<any, any, any>,
+      callback: ?Function
+    ) : void {
       // TODO: If this is a nested container, this won't be the root.
       const root : FiberRoot = (container.stateNode : any);
       const current = root.current;

--- a/src/renderers/shared/shared/__tests__/ReactCompositeComponentState-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactCompositeComponentState-test.js
@@ -301,12 +301,13 @@ describe('ReactCompositeComponent-state', () => {
     });
     // We expect the same thing to happen if we bail out in the middle.
     expect(ops).toEqual(
-      ReactDOMFeatureFlags.useFiber ?
-        [
+      ReactDOMFeatureFlags.useFiber
+        ? [
           // Fiber works as expected
           'child did update',
           'parent did update',
-        ] : [
+        ]
+        : [
           // Stack treats these as two separate updates and therefore the order
           // is inverse.
           'parent did update',

--- a/src/renderers/shared/shared/__tests__/ReactMultiChild-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactMultiChild-test.js
@@ -368,16 +368,16 @@ describe('ReactMultiChild', () => {
       'twoA componentDidMount',
 
       ...(
-        ReactDOMFeatureFlags.useFiber ?
-          [
+        ReactDOMFeatureFlags.useFiber
+          ? [
             'oneB componentWillMount',
             'oneB render',
             'twoB componentWillMount',
             'twoB render',
             'oneA componentWillUnmount',
             'twoA componentWillUnmount',
-          ] :
-          [
+          ]
+          : [
             'oneB componentWillMount',
             'oneB render',
             'oneA componentWillUnmount',


### PR DESCRIPTION
I noticed there were a lot of warnings and a few failures pertaining to slight formatting issues. I thought I'd clear them up as it twinged my OCD :D 

Most warnings were line length problems, I ignored lines that were lengthy because of string values or if they were the definition of a function. For any function calls I just put each parameter on a new line.

Also got rid of a FIXME related to eslint that didn't appear to be a problem anymore.

Might want to consider modifying the eslint rules to ignore string literals and comments to avoid more of these?
