### PR TITLE
Deprecate React.createMixin

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -108,6 +108,10 @@ src/addons/transitions/__tests__/ReactTransitionGroup-test.js
 * should handle entering/leaving several elements at once
 * should warn for duplicated keys
 
+src/isomorphic/__tests__/React-test.js
+* should log a deprecation warning once when using React.__spread
+* should log a deprecation warning once when using React.createMixin
+
 src/isomorphic/children/__tests__/ReactChildren-test.js
 * should support identity for simple
 * should treat single arrayless child as being in array

--- a/src/isomorphic/React.js
+++ b/src/isomorphic/React.js
@@ -35,20 +35,35 @@ if (__DEV__) {
 }
 
 var __spread = Object.assign;
+var createMixin = function(mixin) {
+  return mixin;
+};
 
 if (__DEV__) {
-  var warned = false;
+  var warnedForSpread = false;
+  var warnedForCreateMixin = false;
   __spread = function() {
     warning(
-      warned,
+      warnedForSpread,
       'React.__spread is deprecated and should not be used. Use ' +
       'Object.assign directly or another helper function with similar ' +
       'semantics. You may be seeing this warning due to your compiler. ' +
       'See https://fb.me/react-spread-deprecation for more details.'
     );
-    warned = true;
+    warnedForSpread = true;
     return Object.assign.apply(null, arguments);
   };
+
+  createMixin = function(mixin) {
+    warning(
+      warnedForCreateMixin,
+      'React.createMixin is deprecated and should not be used. You ' +
+      'can use your mixin directly instead.'
+    );
+    warnedForCreateMixin = true;
+    return mixin;
+  };
+
 }
 
 var React = {
@@ -75,10 +90,7 @@ var React = {
   PropTypes: ReactPropTypes,
   createClass: ReactClass.createClass,
   createFactory: createFactory,
-  createMixin: function(mixin) {
-    // Currently a noop. Will be used to validate and trace mixins.
-    return mixin;
-  },
+  createMixin: createMixin,
 
   // This looks DOM specific but these are actually isomorphic helpers
   // since they are just generating DOM strings.

--- a/src/isomorphic/React.js
+++ b/src/isomorphic/React.js
@@ -58,7 +58,7 @@ if (__DEV__) {
     warning(
       warnedForCreateMixin,
       'React.createMixin is deprecated and should not be used. You ' +
-      'can use your mixin directly instead.'
+      'can use this mixin directly instead.'
     );
     warnedForCreateMixin = true;
     return mixin;

--- a/src/isomorphic/__tests__/React-test.js
+++ b/src/isomorphic/__tests__/React-test.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+describe('React', () => {
+
+  var React;
+
+  beforeEach(() => {
+    React = require('React');
+  });
+
+  it('should log a deprecation warning once when using React.__spread', () => {
+    spyOn(console, 'error');
+    React.__spread({});
+    React.__spread({});
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      'React.__spread is deprecated and should not be used'
+    );
+  });
+
+  it('should log a deprecation warning once when using React.createMixin', () => {
+    spyOn(console, 'error');
+    React.createMixin();
+    React.createMixin();
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      'React.createMixin is deprecated and should not be used'
+    );
+  });
+
+});


### PR DESCRIPTION
One step towards #8852. This also adds tests for the deprecation warning, along with the `React.__spread` method. I didn't see a good place to stick these tests, so I just created a new `__tests__` folder in `src/isomorphic`.