### PR TITLE
[Stack] Fix error boundary when mounting a component into a already mounted tree

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1440,6 +1440,7 @@ src/renderers/shared/shared/__tests__/ReactEmptyComponent-test.js
 * preserves the dom node during updates
 
 src/renderers/shared/shared/__tests__/ReactErrorBoundaries-test.js
+* catches update errors
 * does not swallow exceptions on mounting without boundaries
 * does not swallow exceptions on updating without boundaries
 * does not swallow exceptions on unmounting without boundaries

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1440,7 +1440,7 @@ src/renderers/shared/shared/__tests__/ReactEmptyComponent-test.js
 * preserves the dom node during updates
 
 src/renderers/shared/shared/__tests__/ReactErrorBoundaries-test.js
-* catches update errors
+* catches error in mounting component in a already mounted tree
 * does not swallow exceptions on mounting without boundaries
 * does not swallow exceptions on updating without boundaries
 * does not swallow exceptions on unmounting without boundaries

--- a/src/renderers/shared/shared/__tests__/ReactErrorBoundaries-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactErrorBoundaries-test.js
@@ -535,7 +535,7 @@ describe('ReactErrorBoundaries', () => {
     };
   });
 
-  it('catches update errors', () => {
+  it('catches error in mounting component in a already mounted tree', () => {
     ErrorBoundary = class extends React.Component {
       state = {
         error: null,

--- a/src/renderers/shared/shared/__tests__/ReactErrorBoundaries-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactErrorBoundaries-test.js
@@ -542,7 +542,7 @@ describe('ReactErrorBoundaries', () => {
       };
       unstable_handleError(error) {
         log.push('ErrorBoundary unstable_handleError');
-        this.setState({ error: error });
+        this.setState({ error: error });
       }
       render() {
         if (this.state.error) {
@@ -552,14 +552,14 @@ describe('ReactErrorBoundaries', () => {
         log.push('ErrorBoundary render children');
         return this.props.children;
       }
-    }
+    };
 
-    class Child extends React.Component {
+    BrokenRender = class extends React.Component {
       render() {
-        log.push('Child render');
+        log.push('Broken render');
         throw new Error('Child error');
       }
-    }
+    };
 
     var container = document.createElement('div');
     ReactDOM.render(<ErrorBoundary><h1>Child</h1></ErrorBoundary>, container);
@@ -567,10 +567,10 @@ describe('ReactErrorBoundaries', () => {
       'ErrorBoundary render children',
     ]);
     log = [];
-    expect(() => ReactDOM.render(<ErrorBoundary><Child /></ErrorBoundary>, container)).not.toThrow();
+    expect(() => ReactDOM.render(<ErrorBoundary><BrokenRender /></ErrorBoundary>, container)).not.toThrow();    
     expect(log).toEqual([
       'ErrorBoundary render children',
-      'Child render',
+      'Broken render',
       'ErrorBoundary unstable_handleError',
       'ErrorBoundary render error',
     ]);

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -1144,6 +1144,14 @@ var ReactCompositeComponent = {
         debugID
       );
 
+      /*
+       The reason we don't assign the child to _renderedComponent until now is because 
+       if inst.render() throws an error when calling mountComponent
+       we have already assigned the _renderedComponent to the failing instance
+       which in the next run (cleanup) will try to find the DOM node of the failing instance 
+       but since it failed to mount we won't find any and the application will crash.
+       Putting the assignment here will simply make sure that we don't endup in that state.
+      */
       this._renderedComponent = child;
 
       if (ReactFeatureFlags.prepareNewChildrenBeforeUnmountInStack) {

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -1119,7 +1119,7 @@ var ReactCompositeComponent = {
       );
     } else {
       var oldHostNode = ReactReconciler.getHostNode(prevComponentInstance);
-      
+
       if (!ReactFeatureFlags.prepareNewChildrenBeforeUnmountInStack) {
         ReactReconciler.unmountComponent(
           prevComponentInstance,

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -1119,7 +1119,7 @@ var ReactCompositeComponent = {
       );
     } else {
       var oldHostNode = ReactReconciler.getHostNode(prevComponentInstance);
-
+      
       if (!ReactFeatureFlags.prepareNewChildrenBeforeUnmountInStack) {
         ReactReconciler.unmountComponent(
           prevComponentInstance,
@@ -1134,7 +1134,7 @@ var ReactCompositeComponent = {
         nextRenderedElement,
         nodeType !== ReactNodeTypes.EMPTY /* shouldHaveDebugID */
       );
-      this._renderedComponent = child;
+      
 
       var nextMarkup = ReactReconciler.mountComponent(
         child,
@@ -1144,6 +1144,8 @@ var ReactCompositeComponent = {
         this._processChildContext(context),
         debugID
       );
+
+      this._renderedComponent = child;
 
       if (ReactFeatureFlags.prepareNewChildrenBeforeUnmountInStack) {
         ReactReconciler.unmountComponent(
@@ -1165,6 +1167,7 @@ var ReactCompositeComponent = {
         nextMarkup,
         prevComponentInstance
       );
+      
     }
   },
 

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -1134,7 +1134,6 @@ var ReactCompositeComponent = {
         nextRenderedElement,
         nodeType !== ReactNodeTypes.EMPTY /* shouldHaveDebugID */
       );
-      
 
       var nextMarkup = ReactReconciler.mountComponent(
         child,
@@ -1167,7 +1166,6 @@ var ReactCompositeComponent = {
         nextMarkup,
         prevComponentInstance
       );
-      
     }
   },
 


### PR DESCRIPTION
Opening a failing test PR for error boundary in Stack. If there is an easy fix I will be happy to fix it otherwise I guess I can wait for Fiber which this seems to be working in
cc @gaearon 
**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure the test suite passes (`npm test`).
5. Make sure your code lints (`npm run lint`).
6. Run the [Flow](https://flowtype.org/) typechecks (`npm run flow`).
7. If you added or removed any tests, run `./scripts/fiber/record-tests` before submitting the pull request, and commit the resulting changes.
8. If you haven't already, complete the [CLA](https://code.facebook.com/cla).
