### PR TITLE
Declare __REACT_DEVTOOLS_GLOBAL_HOOK__ for Flow

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberDevToolsHook.js
+++ b/src/renderers/shared/fiber/ReactFiberDevToolsHook.js
@@ -12,6 +12,8 @@
 
 /* globals __REACT_DEVTOOLS_GLOBAL_HOOK__ */
 
+declare var __REACT_DEVTOOLS_GLOBAL_HOOK__ : Object | void;
+
 'use strict';
 
 import type { Fiber } from 'ReactFiber';


### PR DESCRIPTION
This doesn't seem to fail with latest Flow, but it fails internally, so I assume Flow master is more strict. This change makes Flow pass.