### PR TITLE
[Fiber] Throw on plain object children

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -1,8 +1,3 @@
-src/addons/__tests__/ReactFragment-test.js
-* should throw if a plain object is used as a child
-* should throw if a plain object even if it is in an owner
-* should throw if a plain object looks like an old element
-
 src/isomorphic/classic/__tests__/ReactContextValidator-test.js
 * should pass previous context to lifecycles
 

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -41,7 +41,6 @@ src/addons/__tests__/ReactComponentWithPureRenderMixin-test.js
 src/addons/__tests__/ReactFragment-test.js
 * should throw if a plain object is used as a child
 * should throw if a plain object even if it is in an owner
-* should throw if a plain object looks like an old element
 * warns for numeric keys on objects as children
 * should warn if passing null to createFragment
 * should warn if passing an array to createFragment

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -39,6 +39,9 @@ src/addons/__tests__/ReactComponentWithPureRenderMixin-test.js
 * does not do a deep comparison
 
 src/addons/__tests__/ReactFragment-test.js
+* should throw if a plain object is used as a child
+* should throw if a plain object even if it is in an owner
+* should throw if a plain object looks like an old element
 * warns for numeric keys on objects as children
 * should warn if passing null to createFragment
 * should warn if passing an array to createFragment

--- a/src/addons/__tests__/ReactFragment-test.js
+++ b/src/addons/__tests__/ReactFragment-test.js
@@ -59,17 +59,6 @@ describe('ReactFragment', () => {
     );
   });
 
-  it('should throw if a plain object looks like an old element', () => {
-    var oldEl = {_isReactElement: true, type: 'span', props: {}};
-    var container = document.createElement('div');
-    expect(() => ReactDOM.render(<div>{oldEl}</div>, container)).toThrowError(
-      'Objects are not valid as a React child (found: object with keys ' +
-      '{_isReactElement, type, props}). It looks like you\'re using an ' +
-      'element created by a different version of React. Make sure to use ' +
-      'only one copy of React.'
-    );
-  });
-
   it('warns for numeric keys on objects as children', () => {
     spyOn(console, 'error');
 

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -508,6 +508,14 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
             return null;
           }
         }
+
+        case REACT_PORTAL_TYPE: {
+          if (newChild.key === key) {
+            return updatePortal(returnFiber, oldFiber, newChild, priority);
+          } else {
+            return null;
+          }
+        }
       }
 
       if (isArray(newChild) || getIteratorFn(newChild)) {

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -110,34 +110,36 @@ function coerceRef(current: ?Fiber, element: ReactElement) {
 }
 
 function throwOnInvalidObjectType(returnFiber : Fiber, newChild : Object) {
-  const childrenString = String(newChild);
-  let addendum = '';
-  if (__DEV__) {
-    addendum =
-      ' If you meant to render a collection of children, use an array ' +
-      'instead or wrap the object using createFragment(object) from the ' +
-      'React add-ons.';
-    if (newChild._isReactElement) {
+  if (returnFiber.type !== 'textarea') {
+    const childrenString = String(newChild);
+    let addendum = '';
+    if (__DEV__) {
       addendum =
-        ' It looks like you\'re using an element created by a different ' +
-        'version of React. Make sure to use only one copy of React.';
-    }
-    const owner = ReactCurrentOwner.owner || returnFiber._debugOwner;
-    if (owner && typeof owner.tag === 'number') {
-      const name = getComponentName((owner : any));
-      if (name) {
-        addendum += ' Check the render method of `' + name + '`.';
+        ' If you meant to render a collection of children, use an array ' +
+        'instead or wrap the object using createFragment(object) from the ' +
+        'React add-ons.';
+      if (newChild._isReactElement) {
+        addendum =
+          ' It looks like you\'re using an element created by a different ' +
+          'version of React. Make sure to use only one copy of React.';
+      }
+      const owner = ReactCurrentOwner.owner || returnFiber._debugOwner;
+      if (owner && typeof owner.tag === 'number') {
+        const name = getComponentName((owner : any));
+        if (name) {
+          addendum += ' Check the render method of `' + name + '`.';
+        }
       }
     }
+    invariant(
+      false,
+      'Objects are not valid as a React child (found: %s).%s',
+      childrenString === '[object Object]' ?
+        'object with keys {' + Object.keys(newChild).join(', ') + '}' :
+        childrenString,
+      addendum
+    );
   }
-  invariant(
-    false,
-    'Objects are not valid as a React child (found: %s).%s',
-    childrenString === '[object Object]' ?
-      'object with keys {' + Object.keys(newChild).join(', ') + '}' :
-      childrenString,
-    addendum
-  );
 }
 
 // This wrapper function exists because I expect to clone the code in each path

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -118,11 +118,6 @@ function throwOnInvalidObjectType(returnFiber : Fiber, newChild : Object) {
         ' If you meant to render a collection of children, use an array ' +
         'instead or wrap the object using createFragment(object) from the ' +
         'React add-ons.';
-      if (newChild._isReactElement) {
-        addendum =
-          ' It looks like you\'re using an element created by a different ' +
-          'version of React. Make sure to use only one copy of React.';
-      }
       const owner = ReactCurrentOwner.owner || returnFiber._debugOwner;
       if (owner && typeof owner.tag === 'number') {
         const name = getComponentName((owner : any));

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -109,7 +109,7 @@ function coerceRef(current: ?Fiber, element: ReactElement) {
   return mixedRef;
 }
 
-function throwOnInvalidObjectType(newChild : Object) {
+function throwOnInvalidObjectType(returnFiber : Fiber, newChild : Object) {
   const childrenString = String(newChild);
   let addendum = '';
   if (__DEV__) {
@@ -122,9 +122,9 @@ function throwOnInvalidObjectType(newChild : Object) {
         ' It looks like you\'re using an element created by a different ' +
         'version of React. Make sure to use only one copy of React.';
     }
-    if (ReactCurrentOwner.current) {
-      const owner : Fiber = (ReactCurrentOwner.current : any);
-      let name = getComponentName(owner);
+    const owner = ReactCurrentOwner.owner || returnFiber._debugOwner;
+    if (owner && typeof owner.tag === 'number') {
+      const name = getComponentName((owner : any));
       if (name) {
         addendum += ' Check the render method of `' + name + '`.';
       }
@@ -452,7 +452,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         return created;
       }
 
-      throwOnInvalidObjectType(newChild);
+      throwOnInvalidObjectType(returnFiber, newChild);
     }
 
     return null;
@@ -517,7 +517,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         return updateFragment(returnFiber, oldFiber, newChild, priority);
       }
 
-      throwOnInvalidObjectType(newChild);
+      throwOnInvalidObjectType(returnFiber, newChild);
     }
 
     return null;
@@ -574,7 +574,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         return updateFragment(returnFiber, matchedFiber, newChild, priority);
       }
 
-      throwOnInvalidObjectType(newChild);
+      throwOnInvalidObjectType(returnFiber, newChild);
     }
 
     return null;
@@ -1240,7 +1240,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     }
 
     if (isObject) {
-      throwOnInvalidObjectType(newChild);
+      throwOnInvalidObjectType(returnFiber, newChild);
     }
 
     if (!disableNewFiberFeatures && typeof newChild === 'undefined') {

--- a/src/shared/utils/traverseAllChildren.js
+++ b/src/shared/utils/traverseAllChildren.js
@@ -167,11 +167,6 @@ function traverseAllChildrenImpl(
           ' If you meant to render a collection of children, use an array ' +
           'instead or wrap the object using createFragment(object) from the ' +
           'React add-ons.';
-        if (children._isReactElement) {
-          addendum =
-            ' It looks like you\'re using an element created by a different ' +
-            'version of React. Make sure to use only one copy of React.';
-        }
         if (ReactCurrentOwner.current) {
           var name = ReactCurrentOwner.current.getName();
           if (name) {


### PR DESCRIPTION
Fixes a few mores tests.

Also uncovered an oversight in the reconciler related to portals; was missing a portal case in `updateSlot`.