### PR TITLE
Refer to object by name instead of function call context

### DIFF
--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -138,7 +138,7 @@ var DOMPropertyOperations = {
       if (mutationMethod) {
         mutationMethod(node, value);
       } else if (shouldIgnoreValue(propertyInfo, value)) {
-        this.deleteValueForProperty(node, name);
+        DOMPropertyOperations.deleteValueForProperty(node, name);
         return;
       } else if (propertyInfo.mustUseProperty) {
         // Contrary to `setAttribute`, object properties are properly


### PR DESCRIPTION
fixes #8887 
