### PR TITLE
Add process.cwd to the test process shim

### DIFF
--- a/src/isomorphic/classic/types/__tests__/ReactPropTypesProduction-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypesProduction-test.js
@@ -12,8 +12,6 @@
 'use strict';
 
 describe('ReactPropTypesProduction', function() {
-  var oldProcess;
-
   var PropTypes;
   var React;
   var ReactPropTypeLocations;
@@ -21,11 +19,7 @@ describe('ReactPropTypesProduction', function() {
 
   beforeEach(function() {
     __DEV__ = false;
-    oldProcess = process;
-    global.process = {
-      cwd: process.cwd,
-      env: Object.assign({}, process.env, {NODE_ENV: 'production'}),
-    };
+    process.env['NODE_ENV'] = 'production';
 
     jest.resetModules();
     PropTypes = require('ReactPropTypes');
@@ -36,7 +30,7 @@ describe('ReactPropTypesProduction', function() {
 
   afterEach(function() {
     __DEV__ = true;
-    global.process = oldProcess;
+    process.env['NODE_ENV'] = 'test';
   });
 
   function expectThrowsInProduction(declaration, value) {

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypesProduction-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypesProduction-test.js
@@ -19,6 +19,7 @@ describe('ReactPropTypesProduction', function() {
 
   beforeEach(function() {
     __DEV__ = false;
+    // eslint-disable-next-line dot-notation
     process.env['NODE_ENV'] = 'production';
 
     jest.resetModules();
@@ -30,6 +31,7 @@ describe('ReactPropTypesProduction', function() {
 
   afterEach(function() {
     __DEV__ = true;
+    // eslint-disable-next-line dot-notation
     process.env['NODE_ENV'] = 'test';
   });
 

--- a/src/renderers/dom/__tests__/ReactDOMProduction-test.js
+++ b/src/renderers/dom/__tests__/ReactDOMProduction-test.js
@@ -11,8 +11,6 @@
 'use strict';
 
 describe('ReactDOMProduction', () => {
-  var oldProcess;
-
   var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 
   var React;
@@ -20,11 +18,7 @@ describe('ReactDOMProduction', () => {
 
   beforeEach(() => {
     __DEV__ = false;
-    oldProcess = process;
-    global.process = {
-      cwd: process.cwd,
-      env: Object.assign({}, process.env, {NODE_ENV: 'production'}),
-    };
+    process.env['NODE_ENV'] = 'production';
 
     jest.resetModules();
     React = require('React');
@@ -33,7 +27,7 @@ describe('ReactDOMProduction', () => {
 
   afterEach(() => {
     __DEV__ = true;
-    global.process = oldProcess;
+    process.env['NODE_ENV'] = 'test';
   });
 
   it('should use prod fbjs', () => {

--- a/src/renderers/dom/__tests__/ReactDOMProduction-test.js
+++ b/src/renderers/dom/__tests__/ReactDOMProduction-test.js
@@ -22,6 +22,7 @@ describe('ReactDOMProduction', () => {
     __DEV__ = false;
     oldProcess = process;
     global.process = {
+      cwd: process.cwd,
       env: Object.assign({}, process.env, {NODE_ENV: 'production'}),
     };
 

--- a/src/renderers/dom/__tests__/ReactDOMProduction-test.js
+++ b/src/renderers/dom/__tests__/ReactDOMProduction-test.js
@@ -18,6 +18,7 @@ describe('ReactDOMProduction', () => {
 
   beforeEach(() => {
     __DEV__ = false;
+    // eslint-disable-next-line dot-notation
     process.env['NODE_ENV'] = 'production';
 
     jest.resetModules();
@@ -27,6 +28,7 @@ describe('ReactDOMProduction', () => {
 
   afterEach(() => {
     __DEV__ = true;
+    // eslint-disable-next-line dot-notation
     process.env['NODE_ENV'] = 'test';
   });
 


### PR DESCRIPTION
This makes sure Jest fails with a good error message.
This is not reflected in tests right now because the same test fails in Fiber with a different message.

**Only relevant for Fiber mode.**

Before:

```
npm test -- ReactDOMProduction
```

<img width="895" alt="screen shot 2017-01-30 at 21 49 49" src="https://cloud.githubusercontent.com/assets/810438/22443222/136f027a-e736-11e6-8e51-cc15a96d674f.png">

After:

<img width="955" alt="screen shot 2017-01-30 at 21 50 02" src="https://cloud.githubusercontent.com/assets/810438/22443228/18ec9320-e736-11e6-92a4-a6c1df9e175a.png">
