### PR TITLE
Explain arbitrariness of ref name in callback

### DIFF
--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -33,7 +33,7 @@ class CustomTextInput extends React.Component {
 
   render() {
     // Use the `ref` callback to store a reference to the text input DOM
-    // element in this.textInput.
+    // element in this.textInput. textInput is an arbitary name e.g. this.userNameField works too
     return (
       <div>
         <input

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -33,7 +33,7 @@ class CustomTextInput extends React.Component {
 
   render() {
     // Use the `ref` callback to store a reference to the text input DOM
-    // element in this.textInput. textInput is an arbitary name e.g. this.userNameField works too
+    // element in an instance field (for example, this.textInput).
     return (
       <div>
         <input


### PR DESCRIPTION
The sample code was confusing because it's not clear that "textInput" in this.textInput is an arbitrary name for the ref.

