### PR TITLE
[docs] Add note about refs on stateless components

### DIFF
--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -13,7 +13,7 @@ permalink: docs/refs-and-the-dom.html
 
 In the typical React dataflow, [props](/react/docs/components-and-props.html) are the only way that parent components interact with their children. To modify a child, you re-render it with new props. However, there are a few cases where you need to imperatively modify a child outside of the typical dataflow. The child to be modified could be an instance of a React component, or it could be a DOM element. For both of these cases, React provides an escape hatch.
 
-## Refs to DOM Elements
+### Refs to DOM Elements
 
 React supports a special attribute that you can attach to any component. The `ref` attribute takes a callback function, and the callback will be executed immediately after the component is mounted or unmounted.
 
@@ -54,9 +54,7 @@ React will call the `ref` callback with the DOM element when the component mount
 
 Using the `ref` callback just to set a property on the class is a common pattern for accessing DOM elements. The preferred way is to set the property in the `ref` callback like in the above example. There is even a shorter way to write it: `ref={input => this.textInput = input}`. 
 
-If you worked with React before, you might be familiar with an older API where the `ref` attribute is a string, like `"textInput"`, and the DOM node is accessed as `this.refs.textInput`. We advise against it because string refs have [some issues](https://github.com/facebook/react/pull/8333#issuecomment-271648615), are considered legacy, and **are likely to be removed in one of the future releases**. If you're currently using `this.refs.textInput` to access refs, we recommend the callback pattern instead.
-
-## Refs to Custom Components
+### Refs to Custom Components
 
 When the `ref` attribute is used on a custom component, the `ref` callback receives the mounted instance of the component as its argument. For example, if we wanted to wrap the `CustomTextInput` above to simulate it being clicked immediately after mounting:
 
@@ -119,6 +117,10 @@ function CustomTextInput(props) {
   );  
 }
 ```
+
+### Legacy API: String Refs
+
+If you worked with React before, you might be familiar with an older API where the `ref` attribute is a string, like `"textInput"`, and the DOM node is accessed as `this.refs.textInput`. We advise against it because string refs have [some issues](https://github.com/facebook/react/pull/8333#issuecomment-271648615), are considered legacy, and **are likely to be removed in one of the future releases**. If you're currently using `this.refs.textInput` to access refs, we recommend the callback pattern instead.
 
 ### Don't Overuse Refs
 

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -13,7 +13,7 @@ permalink: docs/refs-and-the-dom.html
 
 In the typical React dataflow, [props](/react/docs/components-and-props.html) are the only way that parent components interact with their children. To modify a child, you re-render it with new props. However, there are a few cases where you need to imperatively modify a child outside of the typical dataflow. The child to be modified could be an instance of a React component, or it could be a DOM element. For both of these cases, React provides an escape hatch.
 
-## The ref Callback Attribute
+## Refs to DOM Elements
 
 React supports a special attribute that you can attach to any component. The `ref` attribute takes a callback function, and the callback will be executed immediately after the component is mounted or unmounted.
 
@@ -56,6 +56,8 @@ Using the `ref` callback just to set a property on the class is a common pattern
 
 If you worked with React before, you might be familiar with an older API where the `ref` attribute is a string, like `"textInput"`, and the DOM node is accessed as `this.refs.textInput`. We advise against it because string refs have [some issues](https://github.com/facebook/react/pull/8333#issuecomment-271648615), are considered legacy, and **are likely to be removed in one of the future releases**. If you're currently using `this.refs.textInput` to access refs, we recommend the callback pattern instead.
 
+## Refs to Custom Components
+
 When the `ref` attribute is used on a custom component, the `ref` callback receives the mounted instance of the component as its argument. For example, if we wanted to wrap the `CustomTextInput` above to simulate it being clicked immediately after mounting:
 
 ```javascript{3,9}
@@ -73,24 +75,26 @@ class AutoFocusTextInput extends React.Component {
 }
 ```
 
-**You may not use the `ref` attribute on functional components** because they don't have instances. This won't work:
+Note that in the above example, `CustomTextInput` must be a class.  
+**You may not use the `ref` attribute on functional components** because they don't have instances:
 
-```
+```{1,7,10}
 function MyFunctionalComponent() {
-  return <div>hello</div>
+  return <input />;
 }
 
-// This will not work!
-class ParentComponent extends React.Component {
+class Parent extends React.Component {
   render() {
-    return <StatelessComponent ref={node => this.helloNode = node} />
+    // This will *not* work!
+    return (
+      <MyFunctionalComponent
+        ref={(input) => { this.textInput = input; }} />
+    );
   }
 }
 ```
 
-If you need to a ref to a component, it must be a class.
-
-You can, however, use the `ref` attribute inside the functional component:
+You can, however, use the `ref` attribute **inside** the functional component:
 
 ```javascript{2,3,6,13}
 function CustomTextInput(props) {

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -106,3 +106,23 @@ Your first inclination may be to use refs to "make things happen" in your app. I
 ### Caveats
 
 If the `ref` callback is defined as an inline function, it will get called twice during updates, first with `null` and then again with the DOM element. This is because a new instance of the function is created with each render, so React needs to clear the old ref and set up the new one. You can avoid this by defining the `ref` callback as a bound method on the class, but note that it shouldn't matter in most cases.
+
+Also, setting `ref` attribute on a custom component which is implemented as a stateless function won't work as intened. For example, given this code:
+
+```
+function StatelessComponent() {
+  return <div>hello</div>
+}
+
+class ParentComponent extends React.Component {
+  render() {
+    return (
+      <StatelessComponent
+        ref={node => this.helloNode = node}
+      />
+    );
+  }
+}
+```
+
+`this.helloNode` will be set to `null`. This is a deliberate decision, detailed discussion can be found in [this issue on GitHub](https://github.com/facebook/react/issues/4936). While it would be possible (currently) to make `ref` on stateless components work the same as with component classes, in the future versions of React it would be hard or even impossible to implement. Citing Sebastian Markbåge: "it is easier to go from restrictive -> loose than the other way around".

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -76,7 +76,7 @@ class AutoFocusTextInput extends React.Component {
 Note that in the above example, `CustomTextInput` must be a class.  
 **You may not use the `ref` attribute on functional components** because they don't have instances:
 
-```{1,7,10}
+```javascript{1,7,10}
 function MyFunctionalComponent() {
   return <input />;
 }

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -73,7 +73,23 @@ class AutoFocusTextInput extends React.Component {
 }
 ```
 
-You may not use the `ref` attribute on functional components because they don't have instances. You can, however, use the `ref` attribute inside the functional component:
+**You may not use the `ref` attribute on functional components** because they don't have instances. In the below code the ref will always be called with `null`:
+
+```
+function StatelessComponent() {
+  return <div>hello</div>
+}
+
+class ParentComponent extends React.Component {
+  render() {
+    return <StatelessComponent ref={node => this.helloNode = node} />
+  }
+}
+```
+
+If you need to a ref to a component, it must be a class (additional discussion can be found in [this issue on GitHub](https://github.com/facebook/react/issues/4936)).
+
+You can, however, use the `ref` attribute inside the functional component:
 
 ```javascript{2,3,6,13}
 function CustomTextInput(props) {
@@ -106,23 +122,3 @@ Your first inclination may be to use refs to "make things happen" in your app. I
 ### Caveats
 
 If the `ref` callback is defined as an inline function, it will get called twice during updates, first with `null` and then again with the DOM element. This is because a new instance of the function is created with each render, so React needs to clear the old ref and set up the new one. You can avoid this by defining the `ref` callback as a bound method on the class, but note that it shouldn't matter in most cases.
-
-Also, setting `ref` attribute on a custom component which is implemented as a stateless function won't work as intened. For example, given this code:
-
-```
-function StatelessComponent() {
-  return <div>hello</div>
-}
-
-class ParentComponent extends React.Component {
-  render() {
-    return (
-      <StatelessComponent
-        ref={node => this.helloNode = node}
-      />
-    );
-  }
-}
-```
-
-`this.helloNode` will be set to `null`. This is a deliberate decision, detailed discussion can be found in [this issue on GitHub](https://github.com/facebook/react/issues/4936). While it would be possible (currently) to make `ref` on stateless components work the same as with component classes, in the future versions of React it would be hard or even impossible to implement. Citing Sebastian Markbåge: "it is easier to go from restrictive -> loose than the other way around".

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -73,13 +73,14 @@ class AutoFocusTextInput extends React.Component {
 }
 ```
 
-**You may not use the `ref` attribute on functional components** because they don't have instances. In the below code the ref will always be called with `null`:
+**You may not use the `ref` attribute on functional components** because they don't have instances. This won't work:
 
 ```
-function StatelessComponent() {
+function MyFunctionalComponent() {
   return <div>hello</div>
 }
 
+// This will not work!
 class ParentComponent extends React.Component {
   render() {
     return <StatelessComponent ref={node => this.helloNode = node} />
@@ -87,7 +88,7 @@ class ParentComponent extends React.Component {
 }
 ```
 
-If you need to a ref to a component, it must be a class (additional discussion can be found in [this issue on GitHub](https://github.com/facebook/react/issues/4936)).
+If you need to a ref to a component, it must be a class.
 
 You can, however, use the `ref` attribute inside the functional component:
 

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -13,7 +13,19 @@ permalink: docs/refs-and-the-dom.html
 
 In the typical React dataflow, [props](/react/docs/components-and-props.html) are the only way that parent components interact with their children. To modify a child, you re-render it with new props. However, there are a few cases where you need to imperatively modify a child outside of the typical dataflow. The child to be modified could be an instance of a React component, or it could be a DOM element. For both of these cases, React provides an escape hatch.
 
-### Refs to DOM Elements
+### When to Use Refs
+
+There are a few good use cases for refs:
+
+* Managing focus, text selection, or media playback.
+* Triggering imperative animations.
+* Integrating with third-party DOM libraries.
+
+Avoid using refs for anything that can be done declaratively.
+
+For example, instead of exposing `open()` and `close()` methods on a `Dialog` component, pass an `isOpen` prop to it.
+
+### Adding a Ref to a DOM Element
 
 React supports a special attribute that you can attach to any component. The `ref` attribute takes a callback function, and the callback will be executed immediately after the component is mounted or unmounted.
 
@@ -54,9 +66,9 @@ React will call the `ref` callback with the DOM element when the component mount
 
 Using the `ref` callback just to set a property on the class is a common pattern for accessing DOM elements. The preferred way is to set the property in the `ref` callback like in the above example. There is even a shorter way to write it: `ref={input => this.textInput = input}`. 
 
-### Refs to Custom Components
+### Adding a Ref to a Class Component
 
-When the `ref` attribute is used on a custom component, the `ref` callback receives the mounted instance of the component as its argument. For example, if we wanted to wrap the `CustomTextInput` above to simulate it being clicked immediately after mounting:
+When the `ref` attribute is used on a custom component declared as a class, the `ref` callback receives the mounted instance of the component as its argument. For example, if we wanted to wrap the `CustomTextInput` above to simulate it being clicked immediately after mounting:
 
 ```javascript{3,9}
 class AutoFocusTextInput extends React.Component {
@@ -73,10 +85,19 @@ class AutoFocusTextInput extends React.Component {
 }
 ```
 
-Note that in the above example, `CustomTextInput` must be a class.  
+Note that this only works if `CustomTextInput` is declared as a class:
+
+```js{1}
+class CustomTextInput extends React.Component {
+  // ...
+}
+```
+
+### Refs and Functional Components
+
 **You may not use the `ref` attribute on functional components** because they don't have instances:
 
-```javascript{1,7,10}
+```javascript{1,7}
 function MyFunctionalComponent() {
   return <input />;
 }
@@ -92,7 +113,9 @@ class Parent extends React.Component {
 }
 ```
 
-You can, however, use the `ref` attribute **inside** the functional component:
+You should convert the component to a class if you need a ref to it, just like you do when you need lifecycle methods or state.
+
+You can, however, **use the `ref` attribute inside a functional component** as long as you refer to a DOM element or a class component:
 
 ```javascript{2,3,6,13}
 function CustomTextInput(props) {
@@ -118,13 +141,13 @@ function CustomTextInput(props) {
 }
 ```
 
-### Legacy API: String Refs
-
-If you worked with React before, you might be familiar with an older API where the `ref` attribute is a string, like `"textInput"`, and the DOM node is accessed as `this.refs.textInput`. We advise against it because string refs have [some issues](https://github.com/facebook/react/pull/8333#issuecomment-271648615), are considered legacy, and **are likely to be removed in one of the future releases**. If you're currently using `this.refs.textInput` to access refs, we recommend the callback pattern instead.
-
 ### Don't Overuse Refs
 
 Your first inclination may be to use refs to "make things happen" in your app. If this is the case, take a moment and think more critically about where state should be owned in the component hierarchy. Often, it becomes clear that the proper place to "own" that state is at a higher level in the hierarchy. See the [Lifting State Up](/react/docs/lifting-state-up.html) guide for examples of this.
+
+### Legacy API: String Refs
+
+If you worked with React before, you might be familiar with an older API where the `ref` attribute is a string, like `"textInput"`, and the DOM node is accessed as `this.refs.textInput`. We advise against it because string refs have [some issues](https://github.com/facebook/react/pull/8333#issuecomment-271648615), are considered legacy, and **are likely to be removed in one of the future releases**. If you're currently using `this.refs.textInput` to access refs, we recommend the callback pattern instead.
 
 ### Caveats
 


### PR DESCRIPTION
Today at work we were trying to debug some code that used stateless components. We found out, that it's not possible to use `refs` on the stateless components as described in the docs. We founded this issue: https://github.com/facebook/react/issues/4936
and given that it wasn't obvious behaviour, we decided to add this info to the Caveats section in the doc page about ref.

Please let me know what you think about this. Thanks!
