### PR TITLE
Update cloneElement() description

### DIFF
--- a/docs/docs/reference-react.md
+++ b/docs/docs/reference-react.md
@@ -155,12 +155,12 @@ Code written with [JSX](/react/docs/introducing-jsx.html) will be converted to u
 ```
 React.cloneElement(
   element,
-  [props],
+  {props},
   [...children]
 )
 ```
 
-Clone and return a new React element using `element` as the starting point. The resulting element will have the original element's props with the new props merged in shallowly. New children will replace existing children. `key` and `ref` from the original element will be preserved.
+Clone and return a new React element using `element` as the starting point. The resulting element will have the original element's props with the new props merged in shallowly. New children will replace existing children. `key` and `ref` from the original element will be preserved. New props should be passed on a name-value pair fashion: `{propsName: value}`.
 
 `React.cloneElement()` is almost equivalent to:
 


### PR DESCRIPTION
Hi guys,

To have success using `cloneElement()`  I have to pass new props in a name-value pair fashion, rather than using [props]:  

`React.cloneElement(
  element,
  {propA: valueA, propB: valueB},
  [...children]
)
`

So, If it's the correct way I think we can be more explicit on that instruction.  Let me know if any change is needed.

