### PR TITLE
Ensure first error is thrown if HostRoot catches two errors in commit phase

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1480,6 +1480,7 @@ src/renderers/shared/shared/__tests__/ReactErrorBoundaries-test.js
 * lets different boundaries catch their own first errors
 * discards a bad root if the root component fails
 * renders empty output if error boundary does not handle the error
+* passes first error when two errors happen in commit
 
 src/renderers/shared/shared/__tests__/ReactIdentity-test.js
 * should allow key property to express identity

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -861,39 +861,42 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
             errorBoundaryFound = true;
             errorBoundaryName = getComponentName(node);
 
-            if (isFailedBoundary(node)) {
-              // This boundary is already in a failed state. The error should
-              // propagate to the next boundary — except in the
-              // following cases:
-
-              // If we're currently unmounting, that means this error was
-              // thrown while unmounting a failed subtree. We should ignore
-              // the error.
-              if (isUnmounting) {
-                return null;
-              }
-
-              // If we're in the commit phase, we should check to see if
-              // this boundary already captured an error during this commit.
-              // This case exists because multiple errors can be thrown during
-              // a single commit without interruption.
-              if (commitPhaseBoundaries && (
-                commitPhaseBoundaries.has(node) ||
-                (node.alternate) && commitPhaseBoundaries.has(node.alternate)
-              )) {
-                // If so, we should ignore this error.
-                return null;
-              }
-            } else {
-              // Found an error boundary!
-              boundary = node;
-              willRetry = true;
-            }
+            // Found an error boundary!
+            boundary = node;
+            willRetry = true;
           }
         } else if (node.tag === HostRoot) {
           // Treat the root like a no-op error boundary.
           boundary = node;
         }
+
+        if (isFailedBoundary(node)) {
+          // This boundary is already in a failed state.
+
+          // If we're currently unmounting, that means this error was
+          // thrown while unmounting a failed subtree. We should ignore
+          // the error.
+          if (isUnmounting) {
+            return null;
+          }
+
+          // If we're in the commit phase, we should check to see if
+          // this boundary already captured an error during this commit.
+          // This case exists because multiple errors can be thrown during
+          // a single commit without interruption.
+          if (commitPhaseBoundaries && (
+            commitPhaseBoundaries.has(node) ||
+            (node.alternate) && commitPhaseBoundaries.has(node.alternate)
+          )) {
+            // If so, we should ignore this error.
+            return null;
+          }
+
+          // The error should propagate to the next boundary -— we keep looking.
+          boundary = null;
+          willRetry = false;
+        }
+
         node = node.return;
       }
     }

--- a/src/renderers/shared/shared/__tests__/ReactErrorBoundaries-test.js
+++ b/src/renderers/shared/shared/__tests__/ReactErrorBoundaries-test.js
@@ -2178,6 +2178,48 @@ describe('ReactErrorBoundaries', () => {
         'NoopErrorBoundary componentWillUnmount',
       ]);
     });
+
+    it('passes first error when two errors happen in commit', () => {
+      const errors = [];
+      let caughtError;
+      class Parent extends React.Component {
+        render() {
+          return <Child />;
+        }
+        componentDidMount() {
+          errors.push('parent sad');
+          throw new Error('parent sad');
+        }
+      }
+      class Child extends React.Component {
+        render() {
+          return <div />;
+        }
+        componentDidMount() {
+          errors.push('child sad');
+          throw new Error('child sad');
+        }
+      }
+
+      var container = document.createElement('div');
+      try {
+        // Here, we test the behavior where there is no error boundary and we
+        // delegate to the host root.
+        ReactDOM.render(<Parent />, container);
+      } catch (e) {
+        if (e.message !== 'parent sad' && e.message !== 'child sad') {
+          throw e;
+        }
+        caughtError = e;
+      }
+
+      expect(errors).toEqual([
+        'child sad',
+        'parent sad',
+      ]);
+      // Error should be the first thrown
+      expect(caughtError.message).toBe('child sad');
+    });
   }
 
 });


### PR DESCRIPTION
Previously, we were overwriting capturedErrors with the second error and throwing that one.