### PR TITLE
[Fiber] Replace `throw new Error` with invariant module

### DIFF
--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -806,15 +806,13 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       // First, validate keys.
       // We'll get a different iterator later for the main pass.
       const newChildren = iteratorFn.call(newChildrenIterable);
-      invariant(
-        newChildren != null,
-        'An iterable object provided no iterator.'
-      );
-      let knownKeys = null;
-      let step = newChildren.next();
-      for (; !step.done; step = newChildren.next()) {
-        const child = step.value;
-        knownKeys = warnOnDuplicateKey(child, knownKeys);
+      if (newChildren) {
+        let knownKeys = null;
+        let step = newChildren.next();
+        for (; !step.done; step = newChildren.next()) {
+          const child = step.value;
+          knownKeys = warnOnDuplicateKey(child, knownKeys);
+        }
       }
     }
 

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -72,6 +72,9 @@ const {
   Deletion,
 } = ReactTypeOfSideEffect;
 
+const internalErrorMessage =
+  'This error is likely caused by a bug in React. Please file an issue.';
+
 function coerceRef(current: ?Fiber, element: ReactElement) {
   let mixedRef = element.ref;
   if (mixedRef != null && typeof mixedRef !== 'function') {
@@ -88,7 +91,11 @@ function coerceRef(current: ?Fiber, element: ReactElement) {
           inst = (owner : any).getPublicInstance();
         }
       }
-      invariant(inst, 'Missing owner for string ref %s', mixedRef);
+      invariant(
+        inst, 'Missing owner for string ref %s. (%s)',
+        mixedRef,
+        internalErrorMessage
+      );
       const stringRef = String(mixedRef);
       // Check if previous string ref matches new string ref
       if (current && current.ref && current.ref._stringRef === stringRef) {
@@ -799,7 +806,8 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     const iteratorFn = getIteratorFn(newChildrenIterable);
     invariant(
       typeof iteratorFn === 'function',
-      'An object is not an iterable.'
+      'An object is not an iterable. (%s)',
+      internalErrorMessage
     );
 
     if (__DEV__) {
@@ -819,7 +827,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     const newChildren = iteratorFn.call(newChildrenIterable);
     invariant(
       newChildren != null,
-      'An iterable object provided no iterator.'
+      'An iterable object provided no iterator.',
     );
 
     let resultingFirstChild : ?Fiber = null;

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -797,17 +797,19 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     // but using the iterator instead.
 
     const iteratorFn = getIteratorFn(newChildrenIterable);
-    if (typeof iteratorFn !== 'function') {
-      throw new Error('An object is not an iterable.');
-    }
+    invariant(
+      typeof iteratorFn === 'function',
+      'An object is not an iterable.'
+    );
 
     if (__DEV__) {
       // First, validate keys.
       // We'll get a different iterator later for the main pass.
       const newChildren = iteratorFn.call(newChildrenIterable);
-      if (newChildren == null) {
-        throw new Error('An iterable object provided no iterator.');
-      }
+      invariant(
+        newChildren != null,
+        'An iterable object provided no iterator.'
+      );
       let knownKeys = null;
       let step = newChildren.next();
       for (; !step.done; step = newChildren.next()) {
@@ -817,9 +819,10 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     }
 
     const newChildren = iteratorFn.call(newChildrenIterable);
-    if (newChildren == null) {
-      throw new Error('An iterable object provided no iterator.');
-    }
+    invariant(
+      newChildren != null,
+      'An iterable object provided no iterator.'
+    );
 
     let resultingFirstChild : ?Fiber = null;
     let previousNewFiber : ?Fiber = null;

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -62,10 +62,11 @@ var {
 } = require('ReactTypeOfSideEffect');
 var ReactCurrentOwner = require('ReactCurrentOwner');
 var ReactFiberClassComponent = require('ReactFiberClassComponent');
-var warning = require('warning');
+var invariant = require('invariant');
 
 if (__DEV__) {
   var ReactDebugCurrentFiber = require('ReactDebugCurrentFiber');
+  var warning = require('warning');
 
   var warnedAboutStatelessRefs = {};
 }
@@ -341,9 +342,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       // we don't do the bailout and we have to reuse existing props instead.
       if (nextProps === null) {
         nextProps = memoizedProps;
-        if (!nextProps) {
-          throw new Error('We should always have pending or current props.');
-        }
+        invariant(
+          nextProps !== null,
+          'We should always have pending or current props.'
+        );
       }
     } else if (nextProps === null || memoizedProps === nextProps) {
       if (memoizedProps.hidden &&
@@ -442,9 +444,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   }
 
   function mountIndeterminateComponent(current, workInProgress, priorityLevel) {
-    if (current) {
-      throw new Error('An indeterminate component should never have mounted.');
-    }
+    invariant(
+      current === null,
+      'An indeterminate component should never have mounted'
+    );
     var fn = workInProgress.type;
     var props = workInProgress.pendingProps;
     var unmaskedContext = getUnmaskedContext(workInProgress);
@@ -511,9 +514,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       // we don't do the bailout and we have to reuse existing props instead.
       if (nextCoroutine === null) {
         nextCoroutine = current && current.memoizedProps;
-        if (!nextCoroutine) {
-          throw new Error('We should always have pending or current props.');
-        }
+        invariant(
+          nextCoroutine != null,
+          'We should always have pending or current props.'
+        );
       }
     } else if (nextCoroutine === null || workInProgress.memoizedProps === nextCoroutine) {
       nextCoroutine = workInProgress.memoizedProps;
@@ -575,9 +579,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       // we don't do the bailout and we have to reuse existing props instead.
       if (nextChildren === null) {
         nextChildren = current && current.memoizedProps;
-        if (!nextChildren) {
-          throw new Error('We should always have pending or current props.');
-        }
+        invariant(
+          nextChildren != null,
+          'We should always have pending or current props.'
+        );
       }
     } else if (nextChildren === null || workInProgress.memoizedProps === nextChildren) {
       return bailoutOnAlreadyFinishedWork(current, workInProgress);
@@ -727,15 +732,16 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       case Fragment:
         return updateFragment(current, workInProgress);
       default:
-        throw new Error('Unknown unit of work tag');
+        invariant(false, 'Unknown unit of work tag');
     }
   }
 
   function beginFailedWork(current : ?Fiber, workInProgress : Fiber, priorityLevel : PriorityLevel) {
-    if (workInProgress.tag !== ClassComponent &&
-        workInProgress.tag !== HostRoot) {
-      throw new Error('Invalid type of work');
-    }
+    invariant(
+      workInProgress.tag === ClassComponent ||
+      workInProgress.tag === HostRoot,
+      'Invalid type of work'
+    );
 
     // Add an error effect so we can handle the error during the commit phase
     workInProgress.effectTag |= Err;

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -71,6 +71,9 @@ if (__DEV__) {
   var warnedAboutStatelessRefs = {};
 }
 
+const internalErrorMessage =
+  'This error is likely caused by a bug in React. Please file an issue.';
+
 module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   config : HostConfig<T, P, I, TI, PI, C, CX, PL>,
   hostContext : HostContext<C, CX>,
@@ -344,7 +347,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         nextProps = memoizedProps;
         invariant(
           nextProps !== null,
-          'We should always have pending or current props.'
+          'We should always have pending or current props. (%s)',
+          internalErrorMessage
         );
       }
     } else if (nextProps === null || memoizedProps === nextProps) {
@@ -446,7 +450,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   function mountIndeterminateComponent(current, workInProgress, priorityLevel) {
     invariant(
       current === null,
-      'An indeterminate component should never have mounted'
+      'An indeterminate component should never have mounted. (%s)',
+      internalErrorMessage
     );
     var fn = workInProgress.type;
     var props = workInProgress.pendingProps;
@@ -516,7 +521,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         nextCoroutine = current && current.memoizedProps;
         invariant(
           nextCoroutine != null,
-          'We should always have pending or current props.'
+          'We should always have pending or current props. (%s)',
+          internalErrorMessage
         );
       }
     } else if (nextCoroutine === null || workInProgress.memoizedProps === nextCoroutine) {
@@ -581,7 +587,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         nextChildren = current && current.memoizedProps;
         invariant(
           nextChildren != null,
-          'We should always have pending or current props.'
+          'We should always have pending or current props. (%s)',
+          internalErrorMessage
         );
       }
     } else if (nextChildren === null || workInProgress.memoizedProps === nextChildren) {
@@ -732,7 +739,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       case Fragment:
         return updateFragment(current, workInProgress);
       default:
-        invariant(false, 'Unknown unit of work tag');
+        invariant(
+          false,
+          'Unknown unit of work tag. (%s)',
+          internalErrorMessage
+        );
     }
   }
 
@@ -740,7 +751,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     invariant(
       workInProgress.tag === ClassComponent ||
       workInProgress.tag === HostRoot,
-      'Invalid type of work'
+      'Invalid type of work. (%s)',
+      internalErrorMessage
     );
 
     // Add an error effect so we can handle the error during the commit phase

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -40,6 +40,9 @@ var invariant = require('invariant');
 
 const isArray = Array.isArray;
 
+const internalErrorMessage =
+  'This error is likely caused by a bug in React. Please file an issue.';
+
 module.exports = function(
   scheduleUpdate : (fiber : Fiber, priorityLevel : PriorityLevel) => void,
   getPriorityContext : () => PriorityLevel,
@@ -259,7 +262,8 @@ module.exports = function(
     let props = workInProgress.pendingProps;
     invariant(
       props,
-      'There must be pending props for an initial mount.'
+      'There must be pending props for an initial mount. (%s)',
+      internalErrorMessage
     );
 
     const unmaskedContext = getUnmaskedContext(workInProgress);
@@ -301,7 +305,8 @@ module.exports = function(
       newProps = workInProgress.memoizedProps;
       invariant(
         newProps != null,
-        'There should always be pending or memoized props.'
+        'There should always be pending or memoized props. (%s)',
+        internalErrorMessage
       );
     }
     const newUnmaskedContext = getUnmaskedContext(workInProgress);
@@ -367,7 +372,8 @@ module.exports = function(
       newProps = oldProps;
       invariant(
         newProps != null,
-        'There should always be pending or memoized props.'
+        'There should always be pending or memoized props. (%s)',
+        internalErrorMessage
       );
     }
     const oldContext = instance.context;

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -257,9 +257,10 @@ module.exports = function(
     const state = instance.state || null;
 
     let props = workInProgress.pendingProps;
-    if (!props) {
-      throw new Error('There must be pending props for an initial mount.');
-    }
+    invariant(
+      props,
+      'There must be pending props for an initial mount.'
+    );
 
     const unmaskedContext = getUnmaskedContext(workInProgress);
 
@@ -298,9 +299,10 @@ module.exports = function(
       // If there isn't any new props, then we'll reuse the memoized props.
       // This could be from already completed work.
       newProps = workInProgress.memoizedProps;
-      if (!newProps) {
-        throw new Error('There should always be pending or memoized props.');
-      }
+      invariant(
+        newProps != null,
+        'There should always be pending or memoized props.'
+      );
     }
     const newUnmaskedContext = getUnmaskedContext(workInProgress);
     const newContext = getMaskedContext(workInProgress, newUnmaskedContext);
@@ -363,9 +365,10 @@ module.exports = function(
       // If there aren't any new props, then we'll reuse the memoized props.
       // This could be from already completed work.
       newProps = oldProps;
-      if (!newProps) {
-        throw new Error('There should always be pending or memoized props.');
-      }
+      invariant(
+        newProps != null,
+        'There should always be pending or memoized props.'
+      );
     }
     const oldContext = instance.context;
     const newUnmaskedContext = getUnmaskedContext(workInProgress);

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -34,6 +34,8 @@ var {
   ContentReset,
 } = require('ReactTypeOfSideEffect');
 
+var invariant = require('invariant');
+
 module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   config : HostConfig<T, P, I, TI, PI, C, CX, PL>,
   captureError : (failedFiber : Fiber, error: Error) => ?Fiber
@@ -94,7 +96,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       }
       parent = parent.return;
     }
-    throw new Error('Expected to find a host parent.');
+    invariant(
+      false,
+      'Expected to find a host parent.'
+    );
   }
 
   function getHostParentFiber(fiber : Fiber) : Fiber {
@@ -105,7 +110,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       }
       parent = parent.return;
     }
-    throw new Error('Expected to find a host parent.');
+    invariant(
+      false,
+      'Expected to find a host parent.'
+    );
   }
 
   function isHostParent(fiber : Fiber) : boolean {
@@ -173,7 +181,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         parent = parentFiber.stateNode.containerInfo;
         break;
       default:
-        throw new Error('Invalid host parent fiber.');
+        invariant(
+          false,
+          'Invalid host parent fiber.'
+        );
     }
     if (parentFiber.effectTag & ContentReset) {
       // Reset the text content of the parent before doing any insertions
@@ -374,9 +385,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         return;
       }
       case HostText: {
-        if (finishedWork.stateNode == null || !current) {
-          throw new Error('This should only be done during updates.');
-        }
+        invariant(
+          finishedWork.stateNode !== null && current != null,
+          'This should only be done during updates.'
+        );
         const textInstance : TI = finishedWork.stateNode;
         const newText : string = finishedWork.memoizedProps;
         const oldText : string = current.memoizedProps;
@@ -389,8 +401,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       case HostPortal: {
         return;
       }
-      default:
-        throw new Error('This unit of work tag should not have side-effects.');
+      default: {
+        invariant(
+          false,
+          'This unit of work tag should not have side-effects.'
+        );
+      }
     }
   }
 
@@ -450,8 +466,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         // We have no life-cycles associated with portals.
         return;
       }
-      default:
-        throw new Error('This unit of work tag should not have side-effects.');
+      default: {
+        invariant(
+          false,
+          'This unit of work tag should not have side-effects.'
+        );
+      }
     }
   }
 

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -36,6 +36,9 @@ var {
 
 var invariant = require('invariant');
 
+const internalErrorMessage =
+  'This error is likely caused by a bug in React. Please file an issue.';
+
 module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   config : HostConfig<T, P, I, TI, PI, C, CX, PL>,
   captureError : (failedFiber : Fiber, error: Error) => ?Fiber
@@ -98,7 +101,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
     invariant(
       false,
-      'Expected to find a host parent.'
+      'Expected to find a host parent. (%s)',
+      internalErrorMessage
     );
   }
 
@@ -112,7 +116,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
     invariant(
       false,
-      'Expected to find a host parent.'
+      'Expected to find a host parent. (%s)',
+      internalErrorMessage
     );
   }
 
@@ -183,7 +188,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       default:
         invariant(
           false,
-          'Invalid host parent fiber.'
+          'Invalid host parent fiber. (%s)',
+          internalErrorMessage
         );
     }
     if (parentFiber.effectTag & ContentReset) {
@@ -387,7 +393,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       case HostText: {
         invariant(
           finishedWork.stateNode !== null && current != null,
-          'This should only be done during updates.'
+          'This should only be done during updates. (%s)',
+          internalErrorMessage
         );
         const textInstance : TI = finishedWork.stateNode;
         const newText : string = finishedWork.memoizedProps;
@@ -404,7 +411,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       default: {
         invariant(
           false,
-          'This unit of work tag should not have side-effects.'
+          'This unit of work tag should not have side-effects. (%s)',
+          internalErrorMessage
         );
       }
     }
@@ -469,7 +477,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       default: {
         invariant(
           false,
-          'This unit of work tag should not have side-effects.'
+          'This unit of work tag should not have side-effects. (%s)',
+          internalErrorMessage
         );
       }
     }

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -48,6 +48,9 @@ if (__DEV__) {
 
 var invariant = require('invariant');
 
+const internalErrorMessage =
+  'This error is likely caused by a bug in React. Please file an issue.';
+
 module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   config : HostConfig<T, P, I, TI, PI, C, CX, PL>,
   hostContext : HostContext<C, CX>,
@@ -119,7 +122,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     var coroutine = (workInProgress.memoizedProps : ?ReactCoroutine);
     invariant(
       coroutine,
-      'Should be resolved by now'
+      'Should be resolved by now. (%s)',
+      internalErrorMessage
     );
 
     // First step of the coroutine has completed. Now we need to do the second.
@@ -237,7 +241,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           if (!newProps) {
             invariant(
               workInProgress.stateNode !== null,
-              'We must have new props for new mounts'
+              'We must have new props for new mounts. (%s)',
+              internalErrorMessage
             );
             // This can happen when we abort work.
             return null;
@@ -286,7 +291,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           if (typeof newText !== 'string') {
             invariant(
               workInProgress.stateNode !== null,
-              'We must have new props for new mounts'
+              'We must have new props for new mounts. (%s)',
+              internalErrorMessage
             );
             // This can happen when we abort work.
             return null;
@@ -319,13 +325,15 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       case IndeterminateComponent:
         invariant(
           false,
-          'An indeterminate component should have become determinate before completing.'
+          'An indeterminate component should have become determinate before completing. (%s)',
+          internalErrorMessage
         );
         // eslint-disable-next-line no-fallthrough
       default:
         invariant(
           false,
-          'Unknown unit of work tag'
+          'Unknown unit of work tag. (%s)',
+          internalErrorMessage
         );
     }
   }

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -46,6 +46,8 @@ if (__DEV__) {
   var ReactDebugCurrentFiber = require('ReactDebugCurrentFiber');
 }
 
+var invariant = require('invariant');
+
 module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   config : HostConfig<T, P, I, TI, PI, C, CX, PL>,
   hostContext : HostContext<C, CX>,
@@ -91,7 +93,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     while (node) {
       if (node.tag === HostComponent || node.tag === HostText ||
           node.tag === HostPortal) {
-        throw new Error('A coroutine cannot have host component children.');
+        invariant(
+          false,
+          'A coroutine cannot have host component children.'
+        );
       } else if (node.tag === YieldComponent) {
         yields.push(node.type);
       } else if (node.child) {
@@ -112,9 +117,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
   function moveCoroutineToHandlerPhase(current : ?Fiber, workInProgress : Fiber) {
     var coroutine = (workInProgress.memoizedProps : ?ReactCoroutine);
-    if (!coroutine) {
-      throw new Error('Should be resolved by now');
-    }
+    invariant(
+      coroutine,
+      'Should be resolved by now'
+    );
 
     // First step of the coroutine has completed. Now we need to do the second.
     // TODO: It would be nice to have a multi stage coroutine represented by a
@@ -229,12 +235,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           }
         } else {
           if (!newProps) {
-            if (workInProgress.stateNode === null) {
-              throw new Error('We must have new props for new mounts.');
-            } else {
-              // This can happen when we abort work.
-              return null;
-            }
+            invariant(
+              workInProgress.stateNode !== null,
+              'We must have new props for new mounts'
+            );
+            // This can happen when we abort work.
+            return null;
           }
 
           const currentHostContext = getHostContext();
@@ -278,12 +284,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           }
         } else {
           if (typeof newText !== 'string') {
-            if (workInProgress.stateNode === null) {
-              throw new Error('We must have new props for new mounts.');
-            } else {
-              // This can happen when we abort work.
-              return null;
-            }
+            invariant(
+              workInProgress.stateNode !== null,
+              'We must have new props for new mounts'
+            );
+            // This can happen when we abort work.
+            return null;
           }
           const rootContainerInstance = getRootHostContainer();
           const currentHostContext = getHostContext();
@@ -311,9 +317,16 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
       // Error cases
       case IndeterminateComponent:
-        throw new Error('An indeterminate component should have become determinate before completing.');
+        invariant(
+          false,
+          'An indeterminate component should have become determinate before completing.'
+        );
+        // eslint-disable-next-line no-fallthrough
       default:
-        throw new Error('Unknown unit of work tag');
+        invariant(
+          false,
+          'Unknown unit of work tag'
+        );
     }
   }
 

--- a/src/renderers/shared/fiber/ReactFiberHostContext.js
+++ b/src/renderers/shared/fiber/ReactFiberHostContext.js
@@ -36,6 +36,9 @@ export type HostContext<C, CX> = {
   resetHostContainer() : void,
 };
 
+const internalErrorMessage =
+  'This error is likely caused by a bug in React. Please file an issue.';
+
 module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   config : HostConfig<T, P, I, TI, PI, C, CX, PL>
 ) : HostContext<C, CX> {
@@ -52,7 +55,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     const rootInstance = rootInstanceStackCursor.current;
     invariant(
       rootInstance != null,
-      'Expected root container to exist.'
+      'Expected root container to exist. (%s)',
+      internalErrorMessage
     );
     return rootInstance;
   }
@@ -80,7 +84,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     const context = contextStackCursor.current;
     invariant(
       context != null,
-      'Expected host context to exist.'
+      'Expected host context to exist. (%s)',
+      internalErrorMessage
     );
     return context;
   }
@@ -89,7 +94,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     const rootInstance = rootInstanceStackCursor.current;
     invariant(
       rootInstance != null,
-      'Expected root host context to exist.'
+      'Expected root host context to exist. (%s)',
+      internalErrorMessage
     );
 
     const context = contextStackCursor.current || emptyObject;

--- a/src/renderers/shared/fiber/ReactFiberHostContext.js
+++ b/src/renderers/shared/fiber/ReactFiberHostContext.js
@@ -24,6 +24,8 @@ const {
   push,
 } = require('ReactFiberStack');
 
+const invariant = require('invariant');
+
 export type HostContext<C, CX> = {
   getHostContext() : CX,
   getRootHostContainer() : C,
@@ -48,9 +50,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
   function getRootHostContainer() : C {
     const rootInstance = rootInstanceStackCursor.current;
-    if (rootInstance == null) {
-      throw new Error('Expected root container to exist.');
-    }
+    invariant(
+      rootInstance != null,
+      'Expected root container to exist.'
+    );
     return rootInstance;
   }
 
@@ -75,17 +78,19 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
   function getHostContext() : CX {
     const context = contextStackCursor.current;
-    if (context == null) {
-      throw new Error('Expected host context to exist.');
-    }
+    invariant(
+      context != null,
+      'Expected host context to exist.'
+    );
     return context;
   }
 
   function pushHostContext(fiber : Fiber) : void {
     const rootInstance = rootInstanceStackCursor.current;
-    if (rootInstance == null) {
-      throw new Error('Expected root host context to exist.');
-    }
+    invariant(
+      rootInstance != null,
+      'Expected root host context to exist.'
+    );
 
     const context = contextStackCursor.current || emptyObject;
     const nextContext = getChildHostContext(context, fiber.type, rootInstance);

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -83,6 +83,8 @@ var {
   resetContext,
 } = require('ReactFiberContext');
 
+var invariant = require('invariant');
+
 if (__DEV__) {
   var ReactFiberInstrumentation = require('ReactFiberInstrumentation');
   var ReactDebugCurrentFiber = require('ReactDebugCurrentFiber');
@@ -340,12 +342,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
 
     pendingCommit = null;
     const root : FiberRoot = (finishedWork.stateNode : any);
-    if (root.current === finishedWork) {
-      throw new Error(
-        'Cannot commit the same tree as before. This is probably a bug ' +
-        'related to the return field.'
-      );
-    }
+    invariant(
+      root.current !== finishedWork,
+      'Cannot commit the same tree as before. This is probably a bug ' +
+      'related to the return field.'
+    );
 
     // Updates that occur during the commit phase should have Task priority
     const previousPriorityContext = priorityContext;
@@ -378,9 +379,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       try {
         commitAllHostEffects(finishedWork);
       } catch (error) {
-        if (!nextEffect) {
-          throw new Error('Should have nextEffect.');
-        }
+        invariant(
+          nextEffect != null,
+          'Should have next effect.'
+        );
         captureError(nextEffect, error);
         // Clean-up
         if (nextEffect) {
@@ -406,9 +408,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       try {
         commitAllLifeCycles(finishedWork, nextEffect);
       } catch (error) {
-        if (!nextEffect) {
-          throw new Error('Should have nextEffect.');
-        }
+        invariant(
+          nextEffect != null,
+          'Should have next effect.'
+        );
         captureError(nextEffect, error);
         if (nextEffect) {
           nextEffect = nextEffect.nextEffect;
@@ -705,9 +708,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
   }
 
   function performWork(priorityLevel : PriorityLevel, deadline : Deadline | null) {
-    if (isPerformingWork) {
-      throw new Error('performWork was called recursively.');
-    }
+    invariant(
+      !isPerformingWork,
+      'performWork was called recursively.'
+    );
     isPerformingWork = true;
     const isPerformingDeferredWork = Boolean(deadline);
     let deadlineHasExpired = false;
@@ -716,11 +720,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
     // catching an error. It also lets us flush Task work at the end of a
     // deferred batch.
     while (priorityLevel !== NoWork && !fatalError) {
-      if (priorityLevel >= HighPriority && !deadline) {
-        throw new Error(
-          'Cannot perform deferred work without a deadline.'
-        );
-      }
+      invariant(
+        deadline || (priorityLevel < HighPriority),
+        'Cannot perform deferred work without a deadline.'
+      );
 
       // Before starting any work, check to see if there are any pending
       // commits from the previous frame.
@@ -988,9 +991,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       }
     }
 
-    if (!capturedError) {
-      throw new Error('No error for given unit of work.');
-    }
+    invariant(
+      capturedError != null,
+      'No error for given unit of work.'
+    );
 
     let error;
 
@@ -1023,7 +1027,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
         }
         return;
       default:
-        throw new Error('Invalid type of work.');
+        invariant(
+          false,
+          'Invalid type of work.'
+        );
     }
   }
 

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -92,6 +92,9 @@ if (__DEV__) {
 
 var timeHeuristicForUnitOfWork = 1;
 
+const internalErrorMessage =
+  'This error is likely caused by a bug in React. Please file an issue.';
+
 module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, I, TI, PI, C, CX, PL>) {
   const hostContext = ReactFiberHostContext(config);
   const { popHostContainer, popHostContext, resetHostContainer } = hostContext;
@@ -345,7 +348,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
     invariant(
       root.current !== finishedWork,
       'Cannot commit the same tree as before. This is probably a bug ' +
-      'related to the return field.'
+      'related to the return field. (%s)',
+      internalErrorMessage
     );
 
     // Updates that occur during the commit phase should have Task priority
@@ -381,7 +385,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       } catch (error) {
         invariant(
           nextEffect != null,
-          'Should have next effect.'
+          'Should have next effect. (%s)',
+          internalErrorMessage
         );
         captureError(nextEffect, error);
         // Clean-up
@@ -410,7 +415,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       } catch (error) {
         invariant(
           nextEffect != null,
-          'Should have next effect.'
+          'Should have next effect. (%s)',
+          internalErrorMessage
         );
         captureError(nextEffect, error);
         if (nextEffect) {
@@ -710,7 +716,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
   function performWork(priorityLevel : PriorityLevel, deadline : Deadline | null) {
     invariant(
       !isPerformingWork,
-      'performWork was called recursively.'
+      'performWork was called recursively. (%s)',
+      internalErrorMessage
     );
     isPerformingWork = true;
     const isPerformingDeferredWork = Boolean(deadline);
@@ -722,7 +729,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
     while (priorityLevel !== NoWork && !fatalError) {
       invariant(
         deadline || (priorityLevel < HighPriority),
-        'Cannot perform deferred work without a deadline.'
+        'Cannot perform deferred work without a deadline. (%s)',
+        internalErrorMessage
       );
 
       // Before starting any work, check to see if there are any pending
@@ -993,7 +1001,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
 
     invariant(
       capturedError != null,
-      'No error for given unit of work.'
+      'No error for given unit of work. (%s)',
+      internalErrorMessage
     );
 
     let error;
@@ -1029,7 +1038,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       default:
         invariant(
           false,
-          'Invalid type of work.'
+          'Invalid type of work. (%s)',
+          internalErrorMessage
         );
     }
   }


### PR DESCRIPTION
The umbrella task says they should have "sensible messages." Does this include internal invariants (ones that only throw if there's a bug in React)?