### PR TITLE
shouldLeaveMarkup flag for unmountComponentAtNode

### DIFF
--- a/docs/docs/reference-react-dom.md
+++ b/docs/docs/reference-react-dom.md
@@ -59,10 +59,10 @@ If the optional callback is provided, it will be executed after the component is
 ### `unmountComponentAtNode()`
 
 ```javascript
-ReactDOM.unmountComponentAtNode(container)
+ReactDOM.unmountComponentAtNode(container, shouldLeaveMarkup)
 ```
 
-Remove a mounted React component from the DOM and clean up its event handlers and state. If no component was mounted in the container, calling this function does nothing. Returns `true` if a component was unmounted and `false` if there was no component to unmount.
+Remove a mounted React component from the DOM and clean up its event handlers and state. If no component was mounted in the container, calling this function does nothing. By default `unmountComponentAtNode` also removes rendered markup from container. But this behavior can be bypassed by setting `shouldLeaveMarkup` to `true`. *This can be useful if you want to free memory used by component but leave markup rendered by component in DOM*. Returns `true` if a component was unmounted and `false` if there was no component to unmount.
 
 * * *
 

--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -20,6 +20,9 @@ src/renderers/dom/shared/__tests__/ReactMount-test.js
 * tracks root instances
 * marks top-level mounts
 
+src/renderers/dom/shared/__tests__/ReactMountDestruction-test.js
+* should not destroy a react root upon request if shouldLeaveMarkup is set to true
+
 src/renderers/dom/shared/__tests__/ReactRenderDocument-test.js
 * should be able to adopt server markup
 * should not be able to unmount component from document node

--- a/src/renderers/dom/shared/__tests__/ReactMountDestruction-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactMountDestruction-test.js
@@ -47,10 +47,10 @@ describe('ReactMount', () => {
     var instance = <div className="reactDiv" />;
     ReactDOM.render(instance, containerDiv);
 
-    // Test that two react roots are rendered in isolation
+    // Test that react root is rendered
     expect(containerDiv.firstChild.className).toBe('reactDiv');
 
-    // Test that after unmounting, they are still in the document.
+    // Test that after unmounting, it is still in the document
     ReactDOM.unmountComponentAtNode(containerDiv, true);
     expect(containerDiv.firstChild.className).toBe('reactDiv');
   });

--- a/src/renderers/dom/shared/__tests__/ReactMountDestruction-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactMountDestruction-test.js
@@ -40,6 +40,21 @@ describe('ReactMount', () => {
     expect(secondRootDiv.firstChild).toBeNull();
   });
 
+  it('should not destroy a react root upon request if shouldLeaveMarkup is set to true', () => {
+    var containerDiv = document.createElement('div');
+    document.body.appendChild(containerDiv);
+
+    var instance = <div className="reactDiv" />;
+    ReactDOM.render(instance, containerDiv);
+
+    // Test that two react roots are rendered in isolation
+    expect(containerDiv.firstChild.className).toBe('reactDiv');
+
+    // Test that after unmounting, they are still in the document.
+    ReactDOM.unmountComponentAtNode(containerDiv, true);
+    expect(containerDiv.firstChild.className).toBe('reactDiv');
+  });
+
   it('should warn when unmounting a non-container root node', () => {
     var mainContainerDiv = document.createElement('div');
 

--- a/src/renderers/dom/stack/client/ReactMount.js
+++ b/src/renderers/dom/stack/client/ReactMount.js
@@ -167,11 +167,12 @@ function batchedMountComponentIntoNode(
  *
  * @param {ReactComponent} instance React component instance.
  * @param {DOMElement} container DOM element to unmount from.
+ * @param {boolean} shouldLeaveMarkup if we need to leave renderd markup at DOM
  * @final
  * @internal
  * @see {ReactMount.unmountComponentAtNode}
  */
-function unmountComponentFromNode(instance, container) {
+function unmountComponentFromNode(instance, container, shouldLeaveMarkup) {
   if (__DEV__) {
     ReactInstrumentation.debugTool.onBeginFlush();
   }
@@ -182,6 +183,10 @@ function unmountComponentFromNode(instance, container) {
   );
   if (__DEV__) {
     ReactInstrumentation.debugTool.onEndFlush();
+  }
+
+  if (shouldLeaveMarkup) {
+    return;
   }
 
   if (container.nodeType === DOC_NODE_TYPE) {
@@ -559,10 +564,11 @@ var ReactMount = {
    * See https://facebook.github.io/react/docs/react-dom.html#unmountcomponentatnode
    *
    * @param {DOMElement} container DOM element containing a React component.
+   * @param {?boolean} shouldLeaveMarkup if we need to leave renderd markup at DOM
    * @return {boolean} True if a component was found in and unmounted from
    *                   `container`
    */
-  unmountComponentAtNode: function(container) {
+  unmountComponentAtNode: function(container, shouldLeaveMarkup) {
     // Various parts of our code (such as ReactCompositeComponent's
     // _renderValidatedComponent) assume that calls to render aren't nested;
     // verify that that's the case. (Strictly speaking, unmounting won't cause a
@@ -621,7 +627,8 @@ var ReactMount = {
     ReactUpdates.batchedUpdates(
       unmountComponentFromNode,
       prevComponent,
-      container
+      container,
+      shouldLeaveMarkup
     );
     return true;
   },


### PR DESCRIPTION
This can help to resolve the issue when using React with [turbolinks](https://github.com/turbolinks/turbolinks) and libraries like [react-rails](https://github.com/reactjs/react-rails) or [react-on-rails](https://github.com/shakacode/react_on_rails). Turbolinks turns any conventional web application into pseudo-SPA.
> When you follow a link, Turbolinks automatically fetches the page, swaps in its <body>, and merges its <head>, all without incurring the cost of a full page load.

Both react-rails and react-on-rails uses [turbolinks events](https://github.com/turbolinks/turbolinks#full-list-of-events) to know when to mount and unmount React components on page.

They can use two events for unmounting:

First is `turbolinks:before-render`. It happens just before turbolinks swaps the page body. But using this event leads to warnings in console.
```
Warning: unmountComponentAtNode(): The node you're attempting to unmount was rendered by another copy of React.
```

Second is `turbolinks:before-visit`. It happens before turbolinks fetch next page body from server. But unmounting components at this point and removing rendered markup from DOM causes visual changes on page which is bad for UX. By adding `sholdLeaveMarkup` flag for `unmountComponentAtNode` we can free the memory used by component but leave markup in DOM while turbolinks loads new page.

I tested these changes on my fork, and they resolve the issue with "flickering" components on turbolinks navigation.