### PR TITLE
[Fiber] Inject DevTools integration for React Native

### DIFF
--- a/src/renderers/native/ReactNativeFiber.js
+++ b/src/renderers/native/ReactNativeFiber.js
@@ -33,6 +33,7 @@ const emptyObject = require('emptyObject');
 const findNodeHandle = require('findNodeHandle');
 const invariant = require('invariant');
 
+const { injectInternals } = require('ReactFiberDevToolsHook');
 const {
   precacheFiberNode,
   uncacheFiberNode,
@@ -415,5 +416,12 @@ const ReactNative = {
   unstable_batchedUpdates: ReactGenericBatching.batchedUpdates,
 
 };
+
+if (typeof injectInternals === 'function') {
+  injectInternals({
+    findFiberByHostInstance: ReactNativeComponentTree.getClosestInstanceFromNode,
+    findHostInstanceByFiber: NativeRenderer.findHostInstance,
+  });
+}
 
 module.exports = ReactNative;


### PR DESCRIPTION
Adds React DevTools support (based on #8818) to RN Fiber. There's more work necessary on React DevTools side to make this happen, but this should be the extent of changes in this repo for now.