### PR TITLE
Only expose FiberRoot at the top level instead of a Fiber

### DIFF
--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -362,7 +362,7 @@ var ReactNoop = {
     log('HOST INSTANCES:');
     logContainer(rootContainer, 0);
     log('FIBERS:');
-    logFiber((root.stateNode : any).current, 0);
+    logFiber(root.current, 0);
 
     console.log(...bufferedLog);
   },


### PR DESCRIPTION
It is strange to get a handle on the Fiber since it is one of possibly two root Fibers. The correct way to get the current Fiber is through the root.current.

I exposed the Fiber originally because I thought we might use it for Portals but we went with a different approach. I don't think we don't need this API to be shared by Portals.
