### PR TITLE
[v15.5] Deprecate ReactTransitionGroup and ReactCSSTransitionGroup

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -82,6 +82,7 @@ src/addons/__tests__/update-test.js
 * should perform safe hasOwnProperty check
 
 src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
+* warns once when using ReactTransitionGroup
 * should warn if timeouts aren't specified
 * should not warn if timeouts is zero
 * should clean-up silently after the timeout elapses
@@ -104,6 +105,7 @@ src/addons/transitions/__tests__/ReactTransitionChildMapping-test.js
 * should support mergeChildMappings with undefined input
 
 src/addons/transitions/__tests__/ReactTransitionGroup-test.js
+* warns once when using ReactTransitionGroup
 * should handle willEnter correctly
 * should handle enter/leave/enter/leave correctly
 * should handle enter/leave/enter correctly

--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -15,6 +15,9 @@ var React = require('React');
 var ReactTransitionChildMapping = require('ReactTransitionChildMapping');
 
 var emptyFunction = require('emptyFunction');
+var warning = require('warning');
+
+var didWarnTransitionGroup = false;
 
 /**
  * A basis for animations. When children are declaratively added or removed,
@@ -40,6 +43,15 @@ class ReactTransitionGroup extends React.Component {
   };
 
   componentWillMount() {
+    if (__DEV__) {
+      if (!didWarnTransitionGroup) {
+        warning(
+          false,
+          'ReactTransitionGroup and ReactCSSTransitionGroup are deprecated; use `react-transition-group` instead.'
+        );
+        didWarnTransitionGroup = true;
+      }
+    }
     this.currentlyTransitioningKeys = {};
     this.keysToEnter = [];
     this.keysToLeave = [];

--- a/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactCSSTransitionGroup-test.js
@@ -32,6 +32,35 @@ describe('ReactCSSTransitionGroup', () => {
     spyOn(console, 'error');
   });
 
+  it('warns once when using ReactTransitionGroup', () => {
+    ReactDOM.render(
+      <ReactCSSTransitionGroup
+        transitionName="yolo"
+        transitionEnter={false}
+        transitionLeaveTimeout={200}
+      >
+        <span key="two" />
+      </ReactCSSTransitionGroup>,
+      container
+    );
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+       'ReactTransitionGroup and ReactCSSTransitionGroup are deprecated; use `react-transition-group` instead.'
+    );
+
+    ReactDOM.render(
+      <ReactCSSTransitionGroup
+        transitionName="yolo"
+        transitionEnter={false}
+        transitionLeaveTimeout={200}
+      >
+        <span key="two" />
+      </ReactCSSTransitionGroup>,
+      container
+    );
+    expectDev(console.error.calls.count()).toBe(1);
+  });
+
   it('should warn if timeouts aren\'t specified', () => {
     ReactDOM.render(
       <ReactCSSTransitionGroup
@@ -44,8 +73,8 @@ describe('ReactCSSTransitionGroup', () => {
       container
     );
 
-    // Warning about the missing transitionLeaveTimeout prop
-    expectDev(console.error.calls.count()).toBe(1);
+    // Warning about deprecation and the missing transitionLeaveTimeout prop
+    expectDev(console.error.calls.count()).toBe(2);
   });
 
   it('should not warn if timeouts is zero', () => {
@@ -61,7 +90,8 @@ describe('ReactCSSTransitionGroup', () => {
       container
     );
 
-    expectDev(console.error.calls.count()).toBe(0);
+    // Warning about deprecation
+    expectDev(console.error.calls.count()).toBe(1);
   });
 
   it('should clean-up silently after the timeout elapses', () => {
@@ -102,8 +132,8 @@ describe('ReactCSSTransitionGroup', () => {
       }
     }
 
-    // No warnings
-    expectDev(console.error.calls.count()).toBe(0);
+    // Warning about deprecation
+    expectDev(console.error.calls.count()).toBe(1);
 
     // The leaving child has been removed
     expect(ReactDOM.findDOMNode(a).childNodes.length).toBe(1);

--- a/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
+++ b/src/addons/transitions/__tests__/ReactTransitionGroup-test.js
@@ -28,6 +28,18 @@ describe('ReactTransitionGroup', () => {
     container = document.createElement('div');
   });
 
+  it('warns once when using ReactTransitionGroup', () => {
+    spyOn(console, 'error');
+
+    ReactDOM.render(<ReactTransitionGroup />, container);
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+       'ReactTransitionGroup and ReactCSSTransitionGroup are deprecated; use `react-transition-group` instead.'
+    );
+
+    ReactDOM.render(<ReactTransitionGroup />, container);
+    expectDev(console.error.calls.count()).toBe(1);
+  });
 
   it('should handle willEnter correctly', () => {
     var log = [];


### PR DESCRIPTION
This PR is for adding deprecation warnings for ReactTransitionGroup and ReactCSSTransitionGroup, which is listed in #8854.