### PR TITLE
[v16] Remove React.__spread

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -111,7 +111,6 @@ src/addons/transitions/__tests__/ReactTransitionGroup-test.js
 * should warn for duplicated keys
 
 src/isomorphic/__tests__/React-test.js
-* should log a deprecation warning once when using React.__spread
 * should log a deprecation warning once when using React.createMixin
 
 src/isomorphic/children/__tests__/ReactChildren-test.js

--- a/src/isomorphic/React.js
+++ b/src/isomorphic/React.js
@@ -33,25 +33,12 @@ if (__DEV__) {
   cloneElement = ReactElementValidator.cloneElement;
 }
 
-var __spread = Object.assign;
 var createMixin = function(mixin) {
   return mixin;
 };
 
 if (__DEV__) {
-  var warnedForSpread = false;
   var warnedForCreateMixin = false;
-  __spread = function() {
-    warning(
-      warnedForSpread,
-      'React.__spread is deprecated and should not be used. Use ' +
-      'Object.assign directly or another helper function with similar ' +
-      'semantics. You may be seeing this warning due to your compiler. ' +
-      'See https://fb.me/react-spread-deprecation for more details.'
-    );
-    warnedForSpread = true;
-    return Object.assign.apply(null, arguments);
-  };
 
   createMixin = function(mixin) {
     warning(
@@ -97,8 +84,6 @@ var React = {
 
   version: ReactVersion,
 
-  // Deprecated hook for JSX spread, don't use this for anything.
-  __spread: __spread,
 };
 
 module.exports = React;

--- a/src/isomorphic/__tests__/React-test.js
+++ b/src/isomorphic/__tests__/React-test.js
@@ -19,16 +19,6 @@ describe('React', () => {
     React = require('React');
   });
 
-  it('should log a deprecation warning once when using React.__spread', () => {
-    spyOn(console, 'error');
-    React.__spread({});
-    React.__spread({});
-    expectDev(console.error.calls.count()).toBe(1);
-    expectDev(console.error.calls.argsFor(0)[0]).toContain(
-      'React.__spread is deprecated and should not be used'
-    );
-  });
-
   it('should log a deprecation warning once when using React.createMixin', () => {
     spyOn(console, 'error');
     React.createMixin();


### PR DESCRIPTION
This PR is for removing `React.__spread`, which is listed in #8854.