### PR TITLE
[v15.5] Deprecate react-addons-update

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -56,6 +56,7 @@ src/addons/__tests__/renderSubtreeIntoContainer-test.js
 * should get context through middle non-context-provider layer
 
 src/addons/__tests__/update-test.js
+* warns once when using react-addons-update
 * pushes
 * does not mutate the original object
 * only pushes an array

--- a/src/addons/__tests__/update-test.js
+++ b/src/addons/__tests__/update-test.js
@@ -15,6 +15,18 @@ var update = require('update');
 
 describe('update', () => {
 
+  it('warns once when using react-addons-update', () => {
+    spyOn(console, 'error');
+
+    update([1], {$push: [2]});
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      '`react-addons-update` is deprecated; use `immutability-helper` instead'
+    );
+    update([1], {$push: [2]});
+    expectDev(console.error.calls.count()).toBe(1);
+  });
+
   describe('$push', () => {
     it('pushes', () => {
       expect(update([1], {$push: [7]})).toEqual([1, 7]);

--- a/src/addons/update.js
+++ b/src/addons/update.js
@@ -14,7 +14,10 @@
 'use strict';
 
 var invariant = require('invariant');
+var warning = require('warning');
 var hasOwnProperty = {}.hasOwnProperty;
+
+var didWarnDeprecated = false;
 
 function shallowCopy(x) {
   if (Array.isArray(x)) {
@@ -70,6 +73,15 @@ function invariantArrayCase(value, spec, command) {
  * See https://facebook.github.io/react/docs/update.html for details.
  */
 function update(value, spec) {
+  if (__DEV__) {
+    if (!didWarnDeprecated) {
+      warning(
+        false,
+        '`react-addons-update` is deprecated; use `immutability-helper` instead'
+      );
+      didWarnDeprecated = true;
+    }
+  }
   invariant(
     typeof spec === 'object',
     'update(): You provided a key path to update() that did not contain one ' +


### PR DESCRIPTION
This PR is for adding deprecation warnings for `react-addons-update`, which is listed in #8854.