### PR TITLE
[Fiber] Preserve "Break on all/uncaught exceptions" behavior in DEV mode

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1667,18 +1667,20 @@ src/renderers/shared/stack/reconciler/__tests__/Transaction-test.js
 * should allow nesting of transactions
 
 src/renderers/shared/utils/__tests__/ReactErrorUtils-test.js
-* should call the callback the passed arguments
-* should call the callback with the provided context
-* should return a caught error
-* should return null if no error is thrown
-* should rethrow caught errors
-* should call the callback the passed arguments
-* should call the callback with the provided context
-* should return a caught error
-* should return null if no error is thrown
-* can nest with same debug name
-* does not return nested errors
-* should use invokeGuardedCallbackProd in production
+* it should rethrow errors caught by invokeGuardedCallbackAndCatchFirstError (development)
+* should call the callback the passed arguments (development)
+* should call the callback with the provided context (development)
+* should return a caught error (development)
+* should return null if no error is thrown (development)
+* can nest with same debug name (development)
+* does not return nested errors (development)
+* it should rethrow errors caught by invokeGuardedCallbackAndCatchFirstError (production)
+* should call the callback the passed arguments (production)
+* should call the callback with the provided context (production)
+* should return a caught error (production)
+* should return null if no error is thrown (production)
+* can nest with same debug name (production)
+* does not return nested errors (production)
 
 src/renderers/shared/utils/__tests__/accumulateInto-test.js
 * throws if the second item is null

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1676,6 +1676,8 @@ src/renderers/shared/utils/__tests__/ReactErrorUtils-test.js
 * should call the callback with the provided context
 * should return a caught error
 * should return null if no error is thrown
+* can nest with same debug name
+* does not return nested errors
 * should use invokeGuardedCallbackProd in production
 
 src/renderers/shared/utils/__tests__/accumulateInto-test.js

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1667,11 +1667,16 @@ src/renderers/shared/stack/reconciler/__tests__/Transaction-test.js
 * should allow nesting of transactions
 
 src/renderers/shared/utils/__tests__/ReactErrorUtils-test.js
-* should call the callback with only the passed argument
-* should catch errors
+* should call the callback the passed arguments
+* should call the callback with the provided context
+* should return a caught error
+* should return null if no error is thrown
 * should rethrow caught errors
-* should call the callback with only the passed argument
-* should use invokeGuardedCallbackWithCatch in production
+* should call the callback the passed arguments
+* should call the callback with the provided context
+* should return a caught error
+* should return null if no error is thrown
+* should use invokeGuardedCallbackProd in production
 
 src/renderers/shared/utils/__tests__/accumulateInto-test.js
 * throws if the second item is null

--- a/src/renderers/native/__tests__/ReactNativeEvents-test.js
+++ b/src/renderers/native/__tests__/ReactNativeEvents-test.js
@@ -13,7 +13,6 @@
 
 var RCTEventEmitter;
 var React;
-var ReactErrorUtils;
 var ReactNative;
 var ResponderEventPlugin;
 var UIManager;
@@ -24,16 +23,10 @@ beforeEach(() => {
 
   RCTEventEmitter = require('RCTEventEmitter');
   React = require('React');
-  ReactErrorUtils = require('ReactErrorUtils');
   ReactNative = require('ReactNative');
   ResponderEventPlugin = require('ResponderEventPlugin');
   UIManager = require('UIManager');
   createReactNativeComponentClass = require('createReactNativeComponentClass');
-
-  // Ensure errors from event callbacks are properly surfaced (otherwise,
-  // jest/jsdom swallows them when we do the .dispatchEvent call)
-  ReactErrorUtils.invokeGuardedCallback =
-    ReactErrorUtils.invokeGuardedCallbackWithCatch;
 });
 
 it('handles events', () => {

--- a/src/renderers/shared/shared/event/EventPluginUtils.js
+++ b/src/renderers/shared/shared/event/EventPluginUtils.js
@@ -89,15 +89,7 @@ if (__DEV__) {
 function executeDispatch(event, simulated, listener, inst) {
   var type = event.type || 'unknown-event';
   event.currentTarget = EventPluginUtils.getNodeFromInstance(inst);
-  if (simulated) {
-    ReactErrorUtils.invokeGuardedCallbackWithCatch(
-      type,
-      listener,
-      event
-    );
-  } else {
-    ReactErrorUtils.invokeGuardedCallback(type, listener, event);
-  }
+  ReactErrorUtils.invokeGuardedCallbackAndCatchFirstError(type, listener, undefined, event);
   event.currentTarget = null;
 }
 

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -557,7 +557,7 @@ var ReactCompositeComponent = {
       if (safely) {
         if (!skipLifecycle) {
           var name = this.getName() + '.componentWillUnmount()';
-          ReactErrorUtils.invokeGuardedCallback(name, inst.componentWillUnmount.bind(inst));
+          ReactErrorUtils.invokeGuardedCallbackAndCatchFirstError(name, inst.componentWillUnmount, inst);
         }
       } else {
         if (__DEV__) {

--- a/src/renderers/shared/utils/ReactErrorUtils.js
+++ b/src/renderers/shared/utils/ReactErrorUtils.js
@@ -1,4 +1,4 @@
-/**
+  /**
  * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var caughtError = null;
+let caughtError = null;
 
 /**
  * Call a function while guarding against errors that happens within it.
@@ -23,29 +23,26 @@ var caughtError = null;
  * @param {*} context The context to use when calling the function
  * @param {...*} args Arguments for function
  */
-function invokeGuardedCallback<A, B, C, D, E, F, Context>(
-  name: string | null,
-  func: (A, B, C, D, E, F) => void,
-  context: Context,
-  a: A,
-  b: B,
-  c: C,
-  d: D,
-  e: E,
-  f: F,
-): Error | null {
-  const funcArgs = Array.prototype.slice.call(arguments, 3);
-  try {
-    func.apply(context, funcArgs);
-  } catch (error) {
-    return error;
-  }
-  return null;
-}
-
-var ReactErrorUtils = {
-  invokeGuardedCallback,
-  invokeGuardedCallbackProd: invokeGuardedCallback,
+const ReactErrorUtils = {
+  invokeGuardedCallback: function<A, B, C, D, E, F, Context>(
+    name: string | null,
+    func: (A, B, C, D, E, F) => void,
+    context: Context,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+  ): Error | null {
+    const funcArgs = Array.prototype.slice.call(arguments, 3);
+    try {
+      func.apply(context, funcArgs);
+    } catch (error) {
+      return error;
+    }
+    return null;
+  },
 
   /**
    * Same as invokeGuardedCallback, but instead of returning an error, it stores
@@ -79,7 +76,7 @@ var ReactErrorUtils = {
    */
   rethrowCaughtError: function() {
     if (caughtError) {
-      var error = caughtError;
+      const error = caughtError;
       caughtError = null;
       throw error;
     }

--- a/src/renderers/shared/utils/__tests__/ReactErrorUtils-test.js
+++ b/src/renderers/shared/utils/__tests__/ReactErrorUtils-test.js
@@ -89,6 +89,34 @@ describe('ReactErrorUtils', () => {
       expect(returnValue).toBe(null);
     });
 
+    it('can nest with same debug name', () => {
+      const err1 = new Error();
+      let err2;
+      const err3 = new Error();
+      const err4 = ReactErrorUtils.invokeGuardedCallback('foo', function() {
+        err2 = ReactErrorUtils.invokeGuardedCallback('foo', function() {
+          throw err1;
+        }, null);
+        throw err3;
+      }, null);
+
+      expect(err2).toBe(err1);
+      expect(err4).toBe(err3);
+    });
+
+    it('does not return nested errors', () => {
+      const err1 = new Error();
+      let err2;
+      const err3 = ReactErrorUtils.invokeGuardedCallback('foo', function() {
+        err2 = ReactErrorUtils.invokeGuardedCallback('foo', function() {
+          throw err1;
+        }, null);
+      }, null);
+
+      expect(err3).toBe(null); // Returns null because inner error was already captured
+      expect(err2).toBe(err1);
+    });
+
     it('should use invokeGuardedCallbackProd in production', () => {
       expect(ReactErrorUtils.invokeGuardedCallback).not.toEqual(
         ReactErrorUtils.invokeGuardedCallbackProd


### PR DESCRIPTION
- [x] Refactor `invokeGuardedCallback` so that it returns a thrown error. Need this for Fiber's error handling.
- [x] Use `invokeGuardedCallback` in place of Fiber's try/catch blocks.
- [x] Test behavior in browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- [x] Figure out how to deal with ErrorUtils shimming (see D4538250)