### PR TITLE
findNodeHandle -> ReactNative.findNodeHandle

### DIFF
--- a/src/renderers/native/NativeMethodsMixin.js
+++ b/src/renderers/native/NativeMethodsMixin.js
@@ -11,11 +11,11 @@
  */
 'use strict';
 
+var ReactNative = require('ReactNative');
 var ReactNativeAttributePayload = require('ReactNativeAttributePayload');
 var TextInputState = require('TextInputState');
 var UIManager = require('UIManager');
 
-var findNodeHandle = require('findNodeHandle');
 var invariant = require('invariant');
 
 type MeasureOnSuccessCallback = (
@@ -85,7 +85,7 @@ var NativeMethodsMixin = {
    */
   measure: function(callback: MeasureOnSuccessCallback) {
     UIManager.measure(
-      findNodeHandle(this),
+      ReactNative.findNodeHandle(this),
       mountSafeCallback(this, callback)
     );
   },
@@ -107,7 +107,7 @@ var NativeMethodsMixin = {
    */
   measureInWindow: function(callback: MeasureInWindowOnSuccessCallback) {
     UIManager.measureInWindow(
-      findNodeHandle(this),
+      ReactNative.findNodeHandle(this),
       mountSafeCallback(this, callback)
     );
   },
@@ -118,7 +118,7 @@ var NativeMethodsMixin = {
    * are relative to the origin x, y of the ancestor view.
    *
    * As always, to obtain a native node handle for a component, you can use
-   * `React.findNodeHandle(component)`.
+   * `ReactNative.findNodeHandle(component)`.
    */
   measureLayout: function(
     relativeToNativeNode: number,
@@ -126,7 +126,7 @@ var NativeMethodsMixin = {
     onFail: () => void /* currently unused */
   ) {
     UIManager.measureLayout(
-      findNodeHandle(this),
+      ReactNative.findNodeHandle(this),
       relativeToNativeNode,
       mountSafeCallback(this, onFail),
       mountSafeCallback(this, onSuccess)
@@ -150,7 +150,7 @@ var NativeMethodsMixin = {
     );
 
     UIManager.updateView(
-      (findNodeHandle(this) : any),
+      (ReactNative.findNodeHandle(this) : any),
       this.viewConfig.uiViewClassName,
       updatePayload
     );
@@ -161,14 +161,14 @@ var NativeMethodsMixin = {
    * will depend on the platform and type of view.
    */
   focus: function() {
-    TextInputState.focusTextInput(findNodeHandle(this));
+    TextInputState.focusTextInput(ReactNative.findNodeHandle(this));
   },
 
   /**
    * Removes focus from an input or view. This is the opposite of `focus()`.
    */
   blur: function() {
-    TextInputState.blurTextInput(findNodeHandle(this));
+    TextInputState.blurTextInput(ReactNative.findNodeHandle(this));
   },
 };
 


### PR DESCRIPTION
Submitted this internally already.

Needed because people import this file directly and they might not have the renderer inject the findNodeHandle handler yet.
