### PR TITLE
[v15.5] Deprecate React.createFactory

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -219,6 +219,7 @@ src/isomorphic/classic/class/__tests__/ReactClassMixin-test.js
 * should work with a null getInitialState return value and a mixin
 
 src/isomorphic/classic/element/__tests__/ReactElement-test.js
+* should warn when `createFactory` is used
 * uses the fallback value when in an environment without Symbol
 * returns a complete element according to spec
 * should warn when `key` is being accessed on createClass element

--- a/src/isomorphic/classic/element/ReactDOMFactories.js
+++ b/src/isomorphic/classic/element/ReactDOMFactories.js
@@ -18,10 +18,10 @@ var ReactElement = require('ReactElement');
  *
  * @private
  */
-var createDOMFactory = ReactElement.createFactory;
+var createDOMFactory = type => ReactElement.createElement.bind(null, type);
 if (__DEV__) {
   var ReactElementValidator = require('ReactElementValidator');
-  createDOMFactory = ReactElementValidator.createFactory;
+  createDOMFactory = type => ReactElementValidator.createElement.bind(null, type);
 }
 
 /**

--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -29,6 +29,8 @@ var getComponentName = require('getComponentName');
 var getIteratorFn = require('getIteratorFn');
 var warning = require('warning');
 
+var didWarncreateFactory = false;
+
 function getDeclarationErrorAddendum() {
   if (ReactCurrentOwner.current) {
     var name = getComponentName(ReactCurrentOwner.current);
@@ -273,6 +275,15 @@ var ReactElementValidator = {
     validatedFactory.type = type;
 
     if (__DEV__) {
+      if (!didWarncreateFactory) {
+        warning(
+          false,
+          'React.createFactory is deprecated: ' +
+          'You can create own createFactory, which is a one-liner. ' +
+          '`var createFacotry = (type) => ReactElement.createElement.bind(null, type)`'
+        );
+        didWarncreateFactory = true;
+      }
       if (canDefineProperty) {
         Object.defineProperty(
           validatedFactory,

--- a/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
@@ -323,7 +323,7 @@ describe('ReactElementClone', () => {
   });
 
   it('should ignore undefined key and ref', () => {
-    var element = React.createFactory(ComponentClass)({
+    var element = React.createElement(ComponentClass, {
       key: '12',
       ref: '34',
       foo: '56',
@@ -343,7 +343,7 @@ describe('ReactElementClone', () => {
   });
 
   it('should extract null key and ref', () => {
-    var element = React.createFactory(ComponentClass)({
+    var element = React.createElement(ComponentClass, {
       key: '12',
       ref: '34',
       foo: '56',

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -40,7 +40,7 @@ describe('ReactElementValidator', () => {
 
   it('warns for keys for arrays of elements in rest args', () => {
     spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
+    var Component = React.createElement.bind(null, ComponentClass);
 
     Component(null, [Component(), Component()]);
 
@@ -52,7 +52,7 @@ describe('ReactElementValidator', () => {
 
   it('warns for keys for arrays of elements with owner info', () => {
     spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
+    var Component = React.createElement.bind(null, ComponentClass);
 
     var InnerClass = React.createClass({
       displayName: 'InnerClass',
@@ -61,7 +61,7 @@ describe('ReactElementValidator', () => {
       },
     });
 
-    var InnerComponent = React.createFactory(InnerClass);
+    var InnerComponent = React.createElement.bind(null, InnerClass);
 
     var ComponentWrapper = React.createClass({
       displayName: 'ComponentWrapper',
@@ -185,7 +185,7 @@ describe('ReactElementValidator', () => {
 
   it('warns for keys for iterables of elements in rest args', () => {
     spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
+    var Component = React.createElement.bind(null, ComponentClass);
 
     var iterable = {
       '@@iterator': function() {
@@ -209,7 +209,7 @@ describe('ReactElementValidator', () => {
 
   it('does not warns for arrays of elements with keys', () => {
     spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
+    var Component = React.createElement.bind(null, ComponentClass);
 
     Component(null, [Component({key: '#1'}), Component({key: '#2'})]);
 
@@ -218,7 +218,7 @@ describe('ReactElementValidator', () => {
 
   it('does not warns for iterable elements with keys', () => {
     spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
+    var Component = React.createElement.bind(null, ComponentClass);
 
     var iterable = {
       '@@iterator': function() {
@@ -242,7 +242,7 @@ describe('ReactElementValidator', () => {
 
   it('does not warn when the element is directly in rest args', () => {
     spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
+    var Component = React.createElement.bind(null, ComponentClass);
 
     Component(null, Component(), Component());
 
@@ -251,7 +251,7 @@ describe('ReactElementValidator', () => {
 
   it('does not warn when the array contains a non-element', () => {
     spyOn(console, 'error');
-    var Component = React.createFactory(ComponentClass);
+    var Component = React.createElement.bind(null, ComponentClass);
 
     Component(null, [{}, {}]);
 
@@ -479,14 +479,15 @@ describe('ReactElementValidator', () => {
     });
     var TestFactory = React.createFactory(TestComponent);
     expect(TestFactory.type).toBe(TestComponent);
-    expectDev(console.error.calls.count()).toBe(1);
-    expectDev(console.error.calls.argsFor(0)[0]).toBe(
+    // including a deprecated warning
+    expectDev(console.error.calls.count()).toBe(2);
+    expectDev(console.error.calls.argsFor(1)[0]).toBe(
       'Warning: Factory.type is deprecated. Access the class directly before ' +
       'passing it to createFactory.'
     );
     // Warn once, not again
     expect(TestFactory.type).toBe(TestComponent);
-    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.count()).toBe(2);
   });
 
   it('does not warn when using DOM node as children', () => {

--- a/src/isomorphic/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/src/isomorphic/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -24,15 +24,15 @@ describe 'ReactCoffeeScriptClass', ->
     container = document.createElement 'div'
     attachedListener = null
     renderedName = null
-    div = React.createFactory 'div'
-    span = React.createFactory 'span'
+    div = React.createElement.bind null, 'div'
+    span = React.createElement.bind null, 'span'
     class InnerComponent extends React.Component
       getName: -> this.props.name
       render: ->
         attachedListener = this.props.onClick
         renderedName = this.props.name
         return div className: this.props.name
-    Inner = React.createFactory InnerComponent
+    Inner = React.createElement.bind null, InnerComponent
 
   test = (element, expectedTag, expectedClassName) ->
     instance = ReactDOM.render(element, container)


### PR DESCRIPTION
This PR is for adding deprecation warnings for `React.createFactory`, which is listed in #8854.

In development environment, `React.createFactory` is `ReactElementValidator.createFactory` so I added a warning only in `ReactElementValidator`.
Should I add this in `ReactElement` too?