### PR TITLE
Use separate feature flag for ReactTestRenderer

### DIFF
--- a/scripts/jest/test-framework-setup.js
+++ b/scripts/jest/test-framework-setup.js
@@ -22,6 +22,12 @@ jest.mock('ReactNativeFeatureFlags', () => {
     useFiber: flags.useFiber || !!process.env.REACT_DOM_JEST_USE_FIBER,
   });
 });
+jest.mock('ReactTestRendererFeatureFlags', () => {
+  const flags = require.requireActual('ReactTestRendererFeatureFlags');
+  return Object.assign({}, flags, {
+    useFiber: flags.useFiber || !!process.env.REACT_DOM_JEST_USE_FIBER,
+  });
+});
 
 // Error logging varies between Fiber and Stack;
 // Rather than fork dozens of tests, mock the error-logging file by default.

--- a/src/renderers/testing/ReactTestRenderer.js
+++ b/src/renderers/testing/ReactTestRenderer.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-const ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
+const ReactTestRendererFeatureFlags = require('ReactTestRendererFeatureFlags');
 
-module.exports = ReactDOMFeatureFlags.useFiber
+module.exports = ReactTestRendererFeatureFlags.useFiber
   ? require('ReactTestRendererFiber')
   : require('ReactTestRendererStack');

--- a/src/renderers/testing/ReactTestRendererFeatureFlags.js
+++ b/src/renderers/testing/ReactTestRendererFeatureFlags.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactTestRendererFeatureFlags
+ */
+
+'use strict';
+
+var ReactTestRendererFeatureFlags = {
+  useFiber: false,
+};
+
+module.exports = ReactTestRendererFeatureFlags;


### PR DESCRIPTION
The ReactDOMFeatureFlags is not reachable from the npm package since it is in a separate build so we need a separate one.
