### PR TITLE
Fix TransitionGroup error on quick toggle of components

### DIFF
--- a/src/addons/transitions/ReactTransitionGroup.js
+++ b/src/addons/transitions/ReactTransitionGroup.js
@@ -114,6 +114,9 @@ class ReactTransitionGroup extends React.Component {
 
   _handleDoneAppearing = (key) => {
     var component = this.refs[key];
+    if (!component) {
+      return;
+    }
     if (component.componentDidAppear) {
       component.componentDidAppear();
     }
@@ -146,6 +149,9 @@ class ReactTransitionGroup extends React.Component {
 
   _handleDoneEntering = (key) => {
     var component = this.refs[key];
+    if (!component) {
+      return;
+    }
     if (component.componentDidEnter) {
       component.componentDidEnter();
     }
@@ -178,7 +184,9 @@ class ReactTransitionGroup extends React.Component {
 
   _handleDoneLeaving = (key) => {
     var component = this.refs[key];
-
+    if (!component) {
+      return;
+    }
     if (component.componentDidLeave) {
       component.componentDidLeave();
     }


### PR DESCRIPTION
I had this pull request to address this issue: https://github.com/facebook/react/issues/8966