### PR TITLE
Hardened validateCallback to better handle null values

### DIFF
--- a/src/renderers/shared/utils/validateCallback.js
+++ b/src/renderers/shared/utils/validateCallback.js
@@ -28,13 +28,19 @@ function formatUnexpectedArgument(arg: any) {
 }
 
 function validateCallback(callback: ?Function, callerName: string) {
-  invariant(
-    !callback || typeof callback === 'function',
-    '%s(...): Expected the last optional `callback` argument to be a ' +
-    'function. Instead received: %s.',
-    callerName,
-    formatUnexpectedArgument(callback)
-  );
+  if (
+    callback !== null &&
+    callback !== undefined &&
+    typeof callback !== 'function'
+  ) {
+    invariant(
+      false,
+      '%s(...): Expected the last optional `callback` argument to be a ' +
+      'function. Instead received: %s.',
+      callerName,
+      formatUnexpectedArgument(callback)
+    );
+  }
 }
 
 module.exports = validateCallback;


### PR DESCRIPTION
Previously, calls to `validateCallback()` with a null callback value resulted in runtime errors if a certain transform was not applied prior to running. This commit wraps the invariant() with the condition check so as to avoid calling `formatUnexpectedArgument()` unless necessary. It also replaces the truthy/falsy callback check with an explicit check for improved performance.