### PR TITLE
[Fiber] Use `T | null` instead of `?T` types

### DIFF
--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -73,9 +73,9 @@ const {
   Deletion,
 } = ReactTypeOfSideEffect;
 
-function coerceRef(current: ?Fiber, element: ReactElement) {
+function coerceRef(current: Fiber | null, element: ReactElement) {
   let mixedRef = element.ref;
-  if (mixedRef != null && typeof mixedRef !== 'function') {
+  if (mixedRef !== null && typeof mixedRef !== 'function') {
     if (element._owner) {
       const owner : ?(Fiber | ReactInstance) = (element._owner : any);
       let inst;
@@ -97,7 +97,7 @@ function coerceRef(current: ?Fiber, element: ReactElement) {
       );
       const stringRef = String(mixedRef);
       // Check if previous string ref matches new string ref
-      if (current && current.ref && current.ref._stringRef === stringRef) {
+      if (current !== null && current.ref !== null && current.ref._stringRef === stringRef) {
         return current.ref;
       }
       const ref = function(value) {
@@ -161,14 +161,14 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       // When we're reconciling in place we have a work in progress copy. We
       // actually want the current copy. If there is no current copy, then we
       // don't need to track deletion side-effects.
-      if (!childToDelete.alternate) {
+      if (childToDelete.alternate === null) {
         return;
       }
       childToDelete = childToDelete.alternate;
     }
     // Deletions are added in reversed order so we add it to the front.
     const last = returnFiber.progressedLastDeletion;
-    if (last) {
+    if (last !== null) {
       last.nextEffect = childToDelete;
       returnFiber.progressedLastDeletion = childToDelete;
     } else {
@@ -182,7 +182,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
   function deleteRemainingChildren(
     returnFiber : Fiber,
-    currentFirstChild : ?Fiber
+    currentFirstChild : Fiber | null
   ) : null {
     if (!shouldTrackSideEffects) {
       // Noop.
@@ -192,7 +192,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     // TODO: For the shouldClone case, this could be micro-optimized a bit by
     // assuming that after the first child we've already added everything.
     let childToDelete = currentFirstChild;
-    while (childToDelete) {
+    while (childToDelete !== null) {
       deleteChild(returnFiber, childToDelete);
       childToDelete = childToDelete.sibling;
     }
@@ -209,7 +209,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     const existingChildren : Map<string | number, Fiber> = new Map();
 
     let existingChild = currentFirstChild;
-    while (existingChild) {
+    while (existingChild !== null) {
       if (existingChild.key !== null) {
         existingChildren.set(existingChild.key, existingChild);
       } else {
@@ -247,7 +247,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       return lastPlacedIndex;
     }
     const current = newFiber.alternate;
-    if (current) {
+    if (current !== null) {
       const oldIndex = current.index;
       if (oldIndex < lastPlacedIndex) {
         // This is a move.
@@ -267,7 +267,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
   function placeSingleChild(newFiber : Fiber) : Fiber {
     // This is simpler for the single child case. We only need to do a
     // placement for inserting new children.
-    if (shouldTrackSideEffects && !newFiber.alternate) {
+    if (shouldTrackSideEffects && newFiber.alternate === null) {
       newFiber.effectTag = Placement;
     }
     return newFiber;
@@ -275,11 +275,11 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
   function updateTextNode(
     returnFiber : Fiber,
-    current : ?Fiber,
+    current : Fiber | null,
     textContent : string,
     priority : PriorityLevel
   ) {
-    if (current == null || current.tag !== HostText) {
+    if (current === null || current.tag !== HostText) {
       // Insert
       const created = createFiberFromText(textContent, priority);
       created.return = returnFiber;
@@ -295,11 +295,11 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
   function updateElement(
     returnFiber : Fiber,
-    current : ?Fiber,
+    current : Fiber | null,
     element : ReactElement,
     priority : PriorityLevel
   ) : Fiber {
-    if (current == null || current.type !== element.type) {
+    if (current === null || current.type !== element.type) {
       // Insert
       const created = createFiberFromElement(element, priority);
       created.ref = coerceRef(current, element);
@@ -321,12 +321,12 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
   function updateCoroutine(
     returnFiber : Fiber,
-    current : ?Fiber,
+    current : Fiber | null,
     coroutine : ReactCoroutine,
     priority : PriorityLevel
   ) : Fiber {
     // TODO: Should this also compare handler to determine whether to reuse?
-    if (current == null || current.tag !== CoroutineComponent) {
+    if (current === null || current.tag !== CoroutineComponent) {
       // Insert
       const created = createFiberFromCoroutine(coroutine, priority);
       created.return = returnFiber;
@@ -342,11 +342,11 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
   function updateYield(
     returnFiber : Fiber,
-    current : ?Fiber,
+    current : Fiber | null,
     yieldNode : ReactYield,
     priority : PriorityLevel
   ) : Fiber {
-    if (current == null || current.tag !== YieldComponent) {
+    if (current === null || current.tag !== YieldComponent) {
       // Insert
       const created = createFiberFromYield(yieldNode, priority);
       created.type = yieldNode.value;
@@ -363,12 +363,12 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
   function updatePortal(
     returnFiber : Fiber,
-    current : ?Fiber,
+    current : Fiber | null,
     portal : ReactPortal,
     priority : PriorityLevel
   ) : Fiber {
     if (
-      current == null ||
+      current === null ||
       current.tag !== HostPortal ||
       current.stateNode.containerInfo !== portal.containerInfo ||
       current.stateNode.implementation !== portal.implementation
@@ -388,11 +388,11 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
   function updateFragment(
     returnFiber : Fiber,
-    current : ?Fiber,
+    current : Fiber | null,
     fragment : Iterable<*>,
     priority : PriorityLevel
   ) : Fiber {
-    if (current == null || current.tag !== Fragment) {
+    if (current === null || current.tag !== Fragment) {
       // Insert
       const created = createFiberFromFragment(fragment, priority);
       created.return = returnFiber;
@@ -410,7 +410,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     returnFiber : Fiber,
     newChild : any,
     priority : PriorityLevel
-  ) : ?Fiber {
+  ) : Fiber | null {
     if (typeof newChild === 'string' || typeof newChild === 'number') {
       // Text nodes doesn't have keys. If the previous node is implicitly keyed
       // we can continue to replace it without aborting even if it is not a text
@@ -463,13 +463,13 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
   function updateSlot(
     returnFiber : Fiber,
-    oldFiber : ?Fiber,
+    oldFiber : Fiber | null,
     newChild : any,
     priority : PriorityLevel
-  ) : ?Fiber {
+  ) : Fiber | null {
     // Update the fiber if the keys match, otherwise return null.
 
-    const key = oldFiber ? oldFiber.key : null;
+    const key = oldFiber !== null ? oldFiber.key : null;
 
     if (typeof newChild === 'string' || typeof newChild === 'number') {
       // Text nodes doesn't have keys. If the previous node is implicitly keyed
@@ -540,7 +540,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     newIdx : number,
     newChild : any,
     priority : PriorityLevel
-  ) : ?Fiber {
+  ) : Fiber | null {
 
     if (typeof newChild === 'string' || typeof newChild === 'number') {
       // Text nodes doesn't have keys, so we neither have to check the old nor
@@ -596,7 +596,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     knownKeys : Set<string> | null
   ) : Set<string> | null {
     if (__DEV__) {
-      if (typeof child !== 'object' || child == null) {
+      if (typeof child !== 'object' || child === null) {
         return knownKeys;
       }
       switch (child.$$typeof) {
@@ -607,7 +607,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
           if (typeof key !== 'string') {
             break;
           }
-          if (knownKeys == null) {
+          if (knownKeys === null) {
             knownKeys = new Set();
             knownKeys.add(key);
             break;
@@ -634,9 +634,9 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
   function reconcileChildrenArray(
     returnFiber : Fiber,
-    currentFirstChild : ?Fiber,
+    currentFirstChild : Fiber | null,
     newChildren : Array<*>,
-    priority : PriorityLevel) : ?Fiber {
+    priority : PriorityLevel) : Fiber | null {
 
     // This algorithm can't optimize by searching from boths ends since we
     // don't have backpointers on fibers. I'm trying to see how far we can get
@@ -666,21 +666,19 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       }
     }
 
-    let resultingFirstChild : ?Fiber = null;
-    let previousNewFiber : ?Fiber = null;
+    let resultingFirstChild : Fiber | null = null;
+    let previousNewFiber : Fiber | null = null;
 
     let oldFiber = currentFirstChild;
     let lastPlacedIndex = 0;
     let newIdx = 0;
     let nextOldFiber = null;
-    for (; oldFiber && newIdx < newChildren.length; newIdx++) {
-      if (oldFiber) {
-        if (oldFiber.index > newIdx) {
-          nextOldFiber = oldFiber;
-          oldFiber = null;
-        } else {
-          nextOldFiber = oldFiber.sibling;
-        }
+    for (; oldFiber !== null && newIdx < newChildren.length; newIdx++) {
+      if (oldFiber.index > newIdx) {
+        nextOldFiber = oldFiber;
+        oldFiber = null;
+      } else {
+        nextOldFiber = oldFiber.sibling;
       }
       const newFiber = updateSlot(
         returnFiber,
@@ -688,25 +686,25 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         newChildren[newIdx],
         priority
       );
-      if (!newFiber) {
+      if (newFiber === null) {
         // TODO: This breaks on empty slots like null children. That's
         // unfortunate because it triggers the slow path all the time. We need
         // a better way to communicate whether this was a miss or null,
         // boolean, undefined, etc.
-        if (!oldFiber) {
+        if (oldFiber === null) {
           oldFiber = nextOldFiber;
         }
         break;
       }
       if (shouldTrackSideEffects) {
-        if (oldFiber && !newFiber.alternate) {
+        if (oldFiber && newFiber.alternate === null) {
           // We matched the slot, but we didn't reuse the existing fiber, so we
           // need to delete the existing child.
           deleteChild(returnFiber, oldFiber);
         }
       }
       lastPlacedIndex = placeChild(newFiber, lastPlacedIndex, newIdx);
-      if (!previousNewFiber) {
+      if (previousNewFiber === null) {
         // TODO: Move out of the loop. This only happens for the first run.
         resultingFirstChild = newFiber;
       } else {
@@ -726,7 +724,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       return resultingFirstChild;
     }
 
-    if (!oldFiber) {
+    if (oldFiber === null) {
       // If we don't have any more existing children we can choose a fast path
       // since the rest will all be insertions.
       for (; newIdx < newChildren.length; newIdx++) {
@@ -739,7 +737,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
           continue;
         }
         lastPlacedIndex = placeChild(newFiber, lastPlacedIndex, newIdx);
-        if (!previousNewFiber) {
+        if (previousNewFiber === null) {
           // TODO: Move out of the loop. This only happens for the first run.
           resultingFirstChild = newFiber;
         } else {
@@ -764,7 +762,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       );
       if (newFiber) {
         if (shouldTrackSideEffects) {
-          if (newFiber.alternate) {
+          if (newFiber.alternate !== null) {
             // The new fiber is a work in progress, but if there exists a
             // current, that means that we reused the fiber. We need to delete
             // it from the child list so that we don't add it to the deletion
@@ -775,7 +773,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
           }
         }
         lastPlacedIndex = placeChild(newFiber, lastPlacedIndex, newIdx);
-        if (!previousNewFiber) {
+        if (previousNewFiber === null) {
           resultingFirstChild = newFiber;
         } else {
           previousNewFiber.sibling = newFiber;
@@ -795,9 +793,9 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
   function reconcileChildrenIterator(
     returnFiber : Fiber,
-    currentFirstChild : ?Fiber,
+    currentFirstChild : Fiber | null,
     newChildrenIterable : Iterable<*>,
-    priority : PriorityLevel) : ?Fiber {
+    priority : PriorityLevel) : Fiber | null {
 
     // This is the same implementation as reconcileChildrenArray(),
     // but using the iterator instead.
@@ -852,8 +850,8 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       'An iterable object provided no iterator.',
     );
 
-    let resultingFirstChild : ?Fiber = null;
-    let previousNewFiber : ?Fiber = null;
+    let resultingFirstChild : Fiber | null = null;
+    let previousNewFiber : Fiber | null = null;
 
     let oldFiber = currentFirstChild;
     let lastPlacedIndex = 0;
@@ -861,14 +859,12 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     let nextOldFiber = null;
 
     let step = newChildren.next();
-    for (; oldFiber && !step.done; newIdx++, step = newChildren.next()) {
-      if (oldFiber) {
-        if (oldFiber.index > newIdx) {
-          nextOldFiber = oldFiber;
-          oldFiber = null;
-        } else {
-          nextOldFiber = oldFiber.sibling;
-        }
+    for (; oldFiber !== null && !step.done; newIdx++, step = newChildren.next()) {
+      if (oldFiber.index > newIdx) {
+        nextOldFiber = oldFiber;
+        oldFiber = null;
+      } else {
+        nextOldFiber = oldFiber.sibling;
       }
       const newFiber = updateSlot(
         returnFiber,
@@ -876,7 +872,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         step.value,
         priority
       );
-      if (!newFiber) {
+      if (newFiber === null) {
         // TODO: This breaks on empty slots like null children. That's
         // unfortunate because it triggers the slow path all the time. We need
         // a better way to communicate whether this was a miss or null,
@@ -887,14 +883,14 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         break;
       }
       if (shouldTrackSideEffects) {
-        if (oldFiber && !newFiber.alternate) {
+        if (oldFiber && newFiber.alternate === null) {
           // We matched the slot, but we didn't reuse the existing fiber, so we
           // need to delete the existing child.
           deleteChild(returnFiber, oldFiber);
         }
       }
       lastPlacedIndex = placeChild(newFiber, lastPlacedIndex, newIdx);
-      if (!previousNewFiber) {
+      if (previousNewFiber === null) {
         // TODO: Move out of the loop. This only happens for the first run.
         resultingFirstChild = newFiber;
       } else {
@@ -914,7 +910,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       return resultingFirstChild;
     }
 
-    if (!oldFiber) {
+    if (oldFiber === null) {
       // If we don't have any more existing children we can choose a fast path
       // since the rest will all be insertions.
       for (; !step.done; newIdx++, step = newChildren.next()) {
@@ -923,11 +919,11 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
           step.value,
           priority
         );
-        if (!newFiber) {
+        if (newFiber === null) {
           continue;
         }
         lastPlacedIndex = placeChild(newFiber, lastPlacedIndex, newIdx);
-        if (!previousNewFiber) {
+        if (previousNewFiber === null) {
           // TODO: Move out of the loop. This only happens for the first run.
           resultingFirstChild = newFiber;
         } else {
@@ -950,9 +946,9 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         step.value,
         priority
       );
-      if (newFiber) {
+      if (newFiber !== null) {
         if (shouldTrackSideEffects) {
-          if (newFiber.alternate) {
+          if (newFiber.alternate !== null) {
             // The new fiber is a work in progress, but if there exists a
             // current, that means that we reused the fiber. We need to delete
             // it from the child list so that we don't add it to the deletion
@@ -963,7 +959,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
           }
         }
         lastPlacedIndex = placeChild(newFiber, lastPlacedIndex, newIdx);
-        if (!previousNewFiber) {
+        if (previousNewFiber === null) {
           resultingFirstChild = newFiber;
         } else {
           previousNewFiber.sibling = newFiber;
@@ -983,13 +979,13 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
   function reconcileSingleTextNode(
     returnFiber : Fiber,
-    currentFirstChild : ?Fiber,
+    currentFirstChild : Fiber | null,
     textContent : string,
     priority : PriorityLevel
   ) : Fiber {
     // There's no need to check for keys on text nodes since we don't have a
     // way to define them.
-    if (currentFirstChild && currentFirstChild.tag === HostText) {
+    if (currentFirstChild !== null && currentFirstChild.tag === HostText) {
       // We already have an existing node so let's just update it and delete
       // the rest.
       deleteRemainingChildren(returnFiber, currentFirstChild.sibling);
@@ -1008,13 +1004,13 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
   function reconcileSingleElement(
     returnFiber : Fiber,
-    currentFirstChild : ?Fiber,
+    currentFirstChild : Fiber | null,
     element : ReactElement,
     priority : PriorityLevel
   ) : Fiber {
     const key = element.key;
     let child = currentFirstChild;
-    while (child) {
+    while (child !== null) {
       // TODO: If key === null and child.key === null, then this only applies to
       // the first item in the list.
       if (child.key === key) {
@@ -1047,13 +1043,13 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
   function reconcileSingleCoroutine(
     returnFiber : Fiber,
-    currentFirstChild : ?Fiber,
+    currentFirstChild : Fiber | null,
     coroutine : ReactCoroutine,
     priority : PriorityLevel
   ) : Fiber {
     const key = coroutine.key;
     let child = currentFirstChild;
-    while (child) {
+    while (child !== null) {
       // TODO: If key === null and child.key === null, then this only applies to
       // the first item in the list.
       if (child.key === key) {
@@ -1080,13 +1076,13 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
   function reconcileSingleYield(
     returnFiber : Fiber,
-    currentFirstChild : ?Fiber,
+    currentFirstChild : Fiber | null,
     yieldNode : ReactYield,
     priority : PriorityLevel
   ) : Fiber {
     // There's no need to check for keys on yields since they're stateless.
     let child = currentFirstChild;
-    if (child) {
+    if (child !== null) {
       if (child.tag === YieldComponent) {
         deleteRemainingChildren(returnFiber, child.sibling);
         const existing = useFiber(child, priority);
@@ -1106,13 +1102,13 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
   function reconcileSinglePortal(
     returnFiber : Fiber,
-    currentFirstChild : ?Fiber,
+    currentFirstChild : Fiber | null,
     portal : ReactPortal,
     priority : PriorityLevel
   ) : Fiber {
     const key = portal.key;
     let child = currentFirstChild;
-    while (child) {
+    while (child !== null) {
       // TODO: If key === null and child.key === null, then this only applies to
       // the first item in the list.
       if (child.key === key) {
@@ -1146,10 +1142,10 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
   // children and the parent.
   function reconcileChildFibers(
     returnFiber : Fiber,
-    currentFirstChild : ?Fiber,
+    currentFirstChild : Fiber | null,
     newChild : any,
     priority : PriorityLevel
-  ) : ?Fiber {
+  ) : Fiber | null {
     // This function is not recursive.
     // If the top level item is an array, we treat it as a set of children,
     // not as a fragment. Nested arrays on the other hand will be treated as
@@ -1329,11 +1325,11 @@ exports.reconcileChildFibersInPlace = ChildReconciler(false, true);
 
 exports.mountChildFibersInPlace = ChildReconciler(false, false);
 
-exports.cloneChildFibers = function(current : ?Fiber, workInProgress : Fiber) : void {
+exports.cloneChildFibers = function(current : Fiber | null, workInProgress : Fiber) : void {
   if (!workInProgress.child) {
     return;
   }
-  if (current && workInProgress.child === current.child) {
+  if (current !== null && workInProgress.child === current.child) {
     // We use workInProgress.child since that lets Flow know that it can't be
     // null since we validated that already. However, as the line above suggests
     // they're actually the same thing.
@@ -1349,7 +1345,7 @@ exports.cloneChildFibers = function(current : ?Fiber, workInProgress : Fiber) : 
     workInProgress.child = newChild;
 
     newChild.return = workInProgress;
-    while (currentChild.sibling) {
+    while (currentChild.sibling !== null) {
       currentChild = currentChild.sibling;
       newChild = newChild.sibling = cloneFiber(
         currentChild,
@@ -1365,7 +1361,7 @@ exports.cloneChildFibers = function(current : ?Fiber, workInProgress : Fiber) : 
   // need to clone. We need to reset the return fiber though since we'll
   // traverse down into them.
   let child = workInProgress.child;
-  while (child) {
+  while (child !== null) {
     child.return = workInProgress;
     child = child.sibling;
   }

--- a/src/renderers/shared/fiber/ReactDebugCurrentFiber.js
+++ b/src/renderers/shared/fiber/ReactDebugCurrentFiber.js
@@ -22,7 +22,7 @@ if (__DEV__) {
 function getCurrentFiberOwnerName() : string | null {
   if (__DEV__) {
     const fiber = ReactDebugCurrentFiber.current;
-    if (fiber == null) {
+    if (fiber === null) {
       return null;
     }
     if (fiber._debugOwner != null) {
@@ -35,7 +35,7 @@ function getCurrentFiberOwnerName() : string | null {
 function getCurrentFiberStackAddendum() : string | null {
   if (__DEV__) {
     const fiber = ReactDebugCurrentFiber.current;
-    if (fiber == null) {
+    if (fiber === null) {
       return null;
     }
     // Safe because if current fiber exists, we are reconciling,

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -93,11 +93,11 @@ export type Fiber = {
   // This is effectively the parent, but there can be multiple parents (two)
   // so this is only the parent of the thing we're currently processing.
   // It is conceptually the same as the return address of a stack frame.
-  return: ?Fiber,
+  return: Fiber | null,
 
   // Singly Linked List Tree Structure.
-  child: ?Fiber,
-  sibling: ?Fiber,
+  child: Fiber | null,
+  sibling: Fiber | null,
   index: number,
 
   // The ref last used to attach this node.
@@ -119,13 +119,13 @@ export type Fiber = {
   effectTag: TypeOfSideEffect,
 
   // Singly linked list fast path to the next fiber with side-effects.
-  nextEffect: ?Fiber,
+  nextEffect: Fiber | null,
 
   // The first and last fiber with side-effect within this subtree. This allows
   // us to reuse a slice of the linked list when we reuse the work done within
   // this fiber.
-  firstEffect: ?Fiber,
-  lastEffect: ?Fiber,
+  firstEffect: Fiber | null,
+  lastEffect: Fiber | null,
 
   // This will be used to quickly determine if a subtree has no pending changes.
   pendingWorkPriority: PriorityLevel,
@@ -139,19 +139,19 @@ export type Fiber = {
   // priority, then we need to store the progressed work somewhere. This holds
   // the started child set until we need to get back to working on it. It may
   // or may not be the same as the "current" child.
-  progressedChild: ?Fiber,
+  progressedChild: Fiber | null,
 
   // When we reconcile children onto progressedChild it is possible that we have
   // to delete some child fibers. We need to keep track of this side-effects so
   // that if we continue later on, we have to include those effects. Deletions
   // are added in the reverse order from sibling pointers.
-  progressedFirstDeletion: ?Fiber,
-  progressedLastDeletion: ?Fiber,
+  progressedFirstDeletion: Fiber | null,
+  progressedLastDeletion: Fiber | null,
 
   // This is a pooled version of a Fiber. Every fiber that gets updated will
   // eventually have a pair. There are cases when we can clean up pairs to save
   // memory if we need to.
-  alternate: ?Fiber,
+  alternate: Fiber | null,
 
   // Conceptual aliases
   // workInProgress : Fiber ->  alternate The alternate used for reuse happens
@@ -249,7 +249,7 @@ exports.cloneFiber = function(fiber : Fiber, priorityLevel : PriorityLevel) : Fi
   // objects for things that are never updated. It also allow us to reclaim the
   // extra memory if needed.
   let alt = fiber.alternate;
-  if (alt) {
+  if (alt !== null) {
     // If we clone, then we do so from the "current" state. The current state
     // can't have any side-effects that are still valid so we reset just to be
     // sure.

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -71,7 +71,7 @@ module.exports = function(
   };
 
   function checkShouldComponentUpdate(workInProgress, oldProps, newProps, oldState, newState, newContext) {
-    if (oldProps === null || (workInProgress.updateQueue && workInProgress.updateQueue.hasForceUpdate)) {
+    if (oldProps === null || (workInProgress.updateQueue !== null && workInProgress.updateQueue.hasForceUpdate)) {
       // If the workInProgress already has an Update effect, return true
       return true;
     }
@@ -208,10 +208,10 @@ module.exports = function(
     workInProgress.effectTag |= Update;
   }
 
-  function markUpdateIfAlreadyInProgress(current: ?Fiber, workInProgress : Fiber) {
+  function markUpdateIfAlreadyInProgress(current: Fiber | null, workInProgress : Fiber) {
     // If an update was already in progress, we should schedule an Update
     // effect even though we're bailing out, so that cWU/cDU are called.
-    if (current) {
+    if (current !== null) {
       if (workInProgress.memoizedProps !== current.memoizedProps ||
           workInProgress.memoizedState !== current.memoizedState) {
         markUpdate(workInProgress);
@@ -274,7 +274,7 @@ module.exports = function(
       // If we had additional state updates during this life-cycle, let's
       // process them now.
       const updateQueue = workInProgress.updateQueue;
-      if (updateQueue) {
+      if (updateQueue !== null) {
         instance.state = beginUpdateQueue(
           workInProgress,
           updateQueue,
@@ -343,7 +343,7 @@ module.exports = function(
     // They may be from componentWillMount() or from error boundary's setState()
     // during initial mounting.
     const newUpdateQueue = workInProgress.updateQueue;
-    if (newUpdateQueue) {
+    if (newUpdateQueue !== null) {
       newInstance.state = beginUpdateQueue(
         workInProgress,
         newUpdateQueue,
@@ -392,7 +392,7 @@ module.exports = function(
     const oldState = workInProgress.memoizedState;
     // TODO: Previous state can be null.
     let newState;
-    if (updateQueue) {
+    if (updateQueue !== null) {
       newState = beginUpdateQueue(
         workInProgress,
         updateQueue,
@@ -408,7 +408,7 @@ module.exports = function(
     if (oldProps === newProps &&
         oldState === newState &&
         !hasContextChanged() &&
-        !(updateQueue && updateQueue.hasForceUpdate)) {
+        !(updateQueue !== null && updateQueue.hasForceUpdate)) {
       markUpdateIfAlreadyInProgress(current, workInProgress);
       return false;
     }

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -71,7 +71,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     // We now have clones. Let's store them as the currently progressed work.
     workInProgress.progressedChild = workInProgress.child;
     workInProgress.progressedPriority = priorityLevel;
-    if (current) {
+    if (current !== null) {
       // We also store it on the current. When the alternate swaps in we can
       // continue from this point.
       current.progressedChild = workInProgress.progressedChild;
@@ -90,7 +90,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     if (node) {
       node.return = workInProgress;
     }
-    while (node) {
+    while (node !== null) {
       if (node.tag === HostComponent || node.tag === HostText ||
           node.tag === HostPortal) {
         invariant(
@@ -99,13 +99,13 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         );
       } else if (node.tag === YieldComponent) {
         yields.push(node.type);
-      } else if (node.child) {
+      } else if (node.child !== null) {
         node.child.return = node;
         node = node.child;
         continue;
       }
-      while (!node.sibling) {
-        if (!node.return || node.return === workInProgress) {
+      while (node.sibling === null) {
+        if (node.return === null || node.return === workInProgress) {
           return;
         }
         node = node.return;
@@ -115,7 +115,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
-  function moveCoroutineToHandlerPhase(current : ?Fiber, workInProgress : Fiber) {
+  function moveCoroutineToHandlerPhase(current : Fiber | null, workInProgress : Fiber) {
     var coroutine = (workInProgress.memoizedProps : ?ReactCoroutine);
     invariant(
       coroutine,
@@ -140,7 +140,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     var props = coroutine.props;
     var nextChildren = fn(props, yields);
 
-    var currentFirstChild = current ? current.child : null;
+    var currentFirstChild = current !== null ? current.child : null;
     // Inherit the priority of the returnFiber.
     const priority = workInProgress.pendingWorkPriority;
     workInProgress.child = reconcileChildFibers(
@@ -157,22 +157,22 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     // We only have the top Fiber that was created but we need recurse down its
     // children to find all the terminal nodes.
     let node = workInProgress.child;
-    while (node) {
+    while (node !== null) {
       if (node.tag === HostComponent || node.tag === HostText) {
         appendInitialChild(parent, node.stateNode);
       } else if (node.tag === HostPortal) {
         // If we have a portal child, then we don't want to traverse
         // down its children. Instead, we'll get insertions from each child in
         // the portal directly.
-      } else if (node.child) {
+      } else if (node.child !== null) {
         node = node.child;
         continue;
       }
       if (node === workInProgress) {
         return;
       }
-      while (!node.sibling) {
-        if (!node.return || node.return === workInProgress) {
+      while (node.sibling === null) {
+        if (node.return === null || node.return === workInProgress) {
           return;
         }
         node = node.return;
@@ -181,7 +181,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
-  function completeWork(current : ?Fiber, workInProgress : Fiber) : ?Fiber {
+  function completeWork(current : Fiber | null, workInProgress : Fiber) : Fiber | null {
     if (__DEV__) {
       ReactDebugCurrentFiber.current = workInProgress;
     }
@@ -208,7 +208,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         const rootContainerInstance = getRootHostContainer();
         const type = workInProgress.type;
         const newProps = workInProgress.memoizedProps;
-        if (current && workInProgress.stateNode != null) {
+        if (current !== null && workInProgress.stateNode != null) {
           // If we have an alternate, that means this is an update and we need to
           // schedule a side-effect to do the updates.
           const oldProps = current.memoizedProps;
@@ -268,7 +268,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           }
 
           workInProgress.stateNode = instance;
-          if (workInProgress.ref) {
+          if (workInProgress.ref !== null) {
             // If there is a ref on a host node we need to schedule a callback
             workInProgress.effectTag |= Ref;
           }

--- a/src/renderers/shared/fiber/ReactFiberContext.js
+++ b/src/renderers/shared/fiber/ReactFiberContext.js
@@ -149,7 +149,7 @@ function processChildContext(fiber : Fiber, parentContext : Object, isReconcilin
   if (typeof instance.getChildContext !== 'function') {
     if (__DEV__) {
       const componentName = getComponentName(fiber);
-      
+
       if (!warnedAboutMissingGetChildContext[componentName]) {
         warnedAboutMissingGetChildContext[componentName] = true;
         warning(

--- a/src/renderers/shared/fiber/ReactFiberHostContext.js
+++ b/src/renderers/shared/fiber/ReactFiberHostContext.js
@@ -44,14 +44,14 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     getRootHostContext,
   } = config;
 
-  let contextStackCursor : StackCursor<?CX> = createCursor((null: ?CX));
-  let contextFiberStackCursor : StackCursor<?Fiber> = createCursor((null: ?Fiber));
-  let rootInstanceStackCursor : StackCursor<?C> = createCursor((null: ?C));
+  let contextStackCursor : StackCursor<CX | null> = createCursor((null: ?CX));
+  let contextFiberStackCursor : StackCursor<Fiber | null> = createCursor((null: Fiber | null));
+  let rootInstanceStackCursor : StackCursor<C | null> = createCursor((null: ?C));
 
   function getRootHostContainer() : C {
     const rootInstance = rootInstanceStackCursor.current;
     invariant(
-      rootInstance != null,
+      rootInstance !== null,
       'Expected root container to exist. This error is likely caused by a ' +
       'bug in React. Please file an issue.'
     );
@@ -95,7 +95,9 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       'a bug in React. Please file an issue.'
     );
 
-    const context = contextStackCursor.current || emptyObject;
+    const context = contextStackCursor.current !== null ?
+      contextStackCursor.current :
+      emptyObject;
     const nextContext = getChildHostContext(context, fiber.type, rootInstance);
 
     // Don't push this Fiber's context unless it's unique.

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -206,7 +206,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
     findHostInstance(fiber : Fiber) : I | TI | null {
       const hostFiber = findCurrentHostFiber(fiber);
-      if (!hostFiber) {
+      if (hostFiber === null) {
         return null;
       }
       return hostFiber.stateNode;

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -24,10 +24,10 @@ export type FiberRoot = {
   // Determines if this root has already been added to the schedule for work.
   isScheduled: boolean,
   // The work schedule is a linked list.
-  nextScheduledRoot: ?FiberRoot,
+  nextScheduledRoot: FiberRoot | null,
   // Top context object, used by renderSubtreeIntoContainer
-  context: ?Object,
-  pendingContext: ?Object,
+  context: Object | null,
+  pendingContext: Object | null,
 };
 
 exports.createFiberRoot = function(containerInfo : any) : FiberRoot {

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -22,7 +22,7 @@ export type CapturedError = {
   componentStack : string,
   error : Error,
   errorBoundaryFound : boolean,
-  errorBoundaryName : ?string,
+  errorBoundaryName : string | null,
   willRetry : boolean,
 };
 
@@ -134,17 +134,17 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
   let isBatchingUpdates : boolean = false;
 
   // The next work in progress fiber that we're currently working on.
-  let nextUnitOfWork : ?Fiber = null;
+  let nextUnitOfWork : Fiber | null = null;
   let nextPriorityLevel : PriorityLevel = NoWork;
 
   // The next fiber with an effect that we're currently committing.
-  let nextEffect : ?Fiber = null;
+  let nextEffect : Fiber | null = null;
 
-  let pendingCommit : ?Fiber = null;
+  let pendingCommit : Fiber | null = null;
 
   // Linked list of roots with scheduled work on them.
-  let nextScheduledRoot : ?FiberRoot = null;
-  let lastScheduledRoot : ?FiberRoot = null;
+  let nextScheduledRoot : FiberRoot | null = null;
+  let lastScheduledRoot : FiberRoot | null = null;
 
   // Keep track of which host environment callbacks are scheduled.
   let isAnimationCallbackScheduled : boolean = false;
@@ -193,7 +193,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
   // the work loop.
   function findNextUnitOfWork() {
     // Clear out roots with no more work on them, or if they have uncaught errors
-    while (nextScheduledRoot && nextScheduledRoot.current.pendingWorkPriority === NoWork) {
+    while (nextScheduledRoot !== null && nextScheduledRoot.current.pendingWorkPriority === NoWork) {
       // Unschedule this root.
       nextScheduledRoot.isScheduled = false;
       // Read the next pointer now.
@@ -215,7 +215,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
     let root = nextScheduledRoot;
     let highestPriorityRoot = null;
     let highestPriorityLevel = NoWork;
-    while (root) {
+    while (root !== null) {
       if (root.current.pendingWorkPriority !== NoWork && (
           highestPriorityLevel === NoWork ||
           highestPriorityLevel > root.current.pendingWorkPriority)) {
@@ -225,7 +225,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       // We didn't find anything to do in this root, so let's try the next one.
       root = root.nextScheduledRoot;
     }
-    if (highestPriorityRoot) {
+    if (highestPriorityRoot !== null) {
       nextPriorityLevel = highestPriorityLevel;
       priorityContext = nextPriorityLevel;
 
@@ -247,7 +247,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
   }
 
   function commitAllHostEffects() {
-    while (nextEffect) {
+    while (nextEffect !== null) {
       if (__DEV__) {
         ReactDebugCurrentFiber.current = nextEffect;
       }
@@ -306,7 +306,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
   }
 
   function commitAllLifeCycles() {
-    while (nextEffect) {
+    while (nextEffect !== null) {
       const current = nextEffect.alternate;
       // Use Task priority for lifecycle updates
       if (nextEffect.effectTag & (Update | Callback)) {
@@ -359,7 +359,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       // the root has an effect, we need to add it to the end of the list. The
       // resulting list is the set that would belong to the root's parent, if
       // it had one; that is, all the effects in the tree including the root.
-      if (finishedWork.lastEffect) {
+      if (finishedWork.lastEffect !== null) {
         finishedWork.lastEffect.nextEffect = finishedWork;
         firstEffect = finishedWork.firstEffect;
       } else {
@@ -376,18 +376,18 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
     // The first pass performs all the host insertions, updates, deletions and
     // ref unmounts.
     nextEffect = firstEffect;
-    while (nextEffect) {
+    while (nextEffect !== null) {
       try {
         commitAllHostEffects(finishedWork);
       } catch (error) {
         invariant(
-          nextEffect != null,
+          nextEffect !== null,
           'Should have next effect. This error is likely caused by a bug ' +
           'in React. Please file an issue.'
         );
         captureError(nextEffect, error);
         // Clean-up
-        if (nextEffect) {
+        if (nextEffect !== null) {
           nextEffect = nextEffect.nextEffect;
         }
       }
@@ -406,17 +406,17 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
     // and deletions in the entire tree have already been invoked.
     // This pass also triggers any renderer-specific initial effects.
     nextEffect = firstEffect;
-    while (nextEffect) {
+    while (nextEffect !== null) {
       try {
         commitAllLifeCycles(finishedWork, nextEffect);
       } catch (error) {
         invariant(
-          nextEffect != null,
+          nextEffect !== null,
           'Should have next effect. This error is likely caused by a bug ' +
           'in React. Please file an issue.'
         );
         captureError(nextEffect, error);
-        if (nextEffect) {
+        if (nextEffect !== null) {
           nextEffect = nextEffect.nextEffect;
         }
       }
@@ -446,7 +446,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
     // Check for pending update priority. This is usually null so it shouldn't
     // be a perf issue.
     const queue = workInProgress.updateQueue;
-    if (queue) {
+    if (queue !== null) {
       newPriority = getPendingPriority(queue);
     }
 
@@ -456,7 +456,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
     // Either it is the same as child, or it just bailed out because it choose
     // not to do the work.
     let child = workInProgress.progressedChild;
-    while (child) {
+    while (child !== null) {
       // Ensure that remaining work priority bubbles up.
       if (child.pendingWorkPriority !== NoWork &&
           (newPriority === NoWork ||
@@ -468,7 +468,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
     workInProgress.pendingWorkPriority = newPriority;
   }
 
-  function completeUnitOfWork(workInProgress : Fiber) : ?Fiber {
+  function completeUnitOfWork(workInProgress : Fiber) : Fiber | null {
     while (true) {
       // The current, flushed, state of this fiber is the alternate.
       // Ideally nothing should rely on this, but relying on it here
@@ -482,7 +482,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
 
       resetWorkPriority(workInProgress);
 
-      if (next) {
+      if (next !== null) {
         if (__DEV__ && ReactFiberInstrumentation.debugTool) {
           ReactFiberInstrumentation.debugTool.onCompleteWork(workInProgress);
         }
@@ -491,15 +491,15 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
         return next;
       }
 
-      if (returnFiber) {
+      if (returnFiber !== null) {
         // Append all the effects of the subtree and this fiber onto the effect
         // list of the parent. The completion order of the children affects the
         // side-effect order.
-        if (!returnFiber.firstEffect) {
+        if (returnFiber.firstEffect === null) {
           returnFiber.firstEffect = workInProgress.firstEffect;
         }
-        if (workInProgress.lastEffect) {
-          if (returnFiber.lastEffect) {
+        if (workInProgress.lastEffect !== null) {
+          if (returnFiber.lastEffect !== null) {
             returnFiber.lastEffect.nextEffect = workInProgress.firstEffect;
           }
           returnFiber.lastEffect = workInProgress.lastEffect;
@@ -512,7 +512,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
         // reusing children we'll schedule this effect onto itself since we're
         // at the end.
         if (workInProgress.effectTag !== NoEffect) {
-          if (returnFiber.lastEffect) {
+          if (returnFiber.lastEffect !== null) {
             returnFiber.lastEffect.nextEffect = workInProgress;
           } else {
             returnFiber.firstEffect = workInProgress;
@@ -525,10 +525,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
         ReactFiberInstrumentation.debugTool.onCompleteWork(workInProgress);
       }
 
-      if (siblingFiber) {
+      if (siblingFiber !== null) {
         // If there is more work to do in this returnFiber, do that next.
         return siblingFiber;
-      } else if (returnFiber) {
+      } else if (returnFiber !== null) {
         // If there's no more work in this returnFiber. Complete the returnFiber.
         workInProgress = returnFiber;
         continue;
@@ -548,7 +548,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
     }
   }
 
-  function performUnitOfWork(workInProgress : Fiber) : ?Fiber {
+  function performUnitOfWork(workInProgress : Fiber) : Fiber | null {
     // The current, flushed, state of this fiber is the alternate.
     // Ideally nothing should rely on this, but relying on it here
     // means that we don't need an additional field on the work in
@@ -561,7 +561,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       ReactFiberInstrumentation.debugTool.onBeginWork(workInProgress);
     }
 
-    if (!next) {
+    if (next === null) {
       // If this doesn't spawn new work, complete the current work.
       next = completeUnitOfWork(workInProgress);
     }
@@ -574,7 +574,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
     return next;
   }
 
-  function performFailedUnitOfWork(workInProgress : Fiber) : ?Fiber {
+  function performFailedUnitOfWork(workInProgress : Fiber) : Fiber | null {
 
     // The current, flushed, state of this fiber is the alternate.
     // Ideally nothing should rely on this, but relying on it here
@@ -588,7 +588,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       ReactFiberInstrumentation.debugTool.onBeginWork(workInProgress);
     }
 
-    if (!next) {
+    if (next === null) {
       // If this doesn't spawn new work, complete the current work.
       next = completeUnitOfWork(workInProgress);
     }
@@ -610,16 +610,16 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
 
   function performAnimationWork() {
     isAnimationCallbackScheduled = false;
-    performWork(AnimationPriority);
+    performWork(AnimationPriority, null);
   }
 
   function clearErrors() {
-    if (!nextUnitOfWork) {
+    if (nextUnitOfWork === null) {
       nextUnitOfWork = findNextUnitOfWork();
     }
     // Keep performing work until there are no more errors
-    while (capturedErrors && capturedErrors.size &&
-           nextUnitOfWork &&
+    while (capturedErrors !== null && capturedErrors.size &&
+           nextUnitOfWork !== null &&
            nextPriorityLevel !== NoWork &&
            nextPriorityLevel <= TaskPriority) {
       if (hasCapturedError(nextUnitOfWork)) {
@@ -628,7 +628,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       } else {
         nextUnitOfWork = performUnitOfWork(nextUnitOfWork);
       }
-      if (!nextUnitOfWork) {
+      if (nextUnitOfWork === null) {
         // If performUnitOfWork returns null, that means we just comitted
         // a root. Normally we'd need to clear any errors that were scheduled
         // during the commit phase. But we're already clearing errors, so
@@ -642,16 +642,16 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
     // Clear any errors.
     clearErrors();
 
-    if (!nextUnitOfWork) {
+    if (nextUnitOfWork === null) {
       nextUnitOfWork = findNextUnitOfWork();
     }
 
     let hostRootTimeMarker;
     if (
       ReactFeatureFlags.logTopLevelRenders &&
-      nextUnitOfWork &&
+      nextUnitOfWork !== null &&
       nextUnitOfWork.tag === HostRoot &&
-      nextUnitOfWork.child
+      nextUnitOfWork.child !== null
     ) {
       const componentName = getComponentName(nextUnitOfWork.child) || '';
       hostRootTimeMarker = 'React update: ' + componentName;
@@ -660,17 +660,17 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
 
     // If there's a deadline, and we're not performing Task work, perform work
     // using this loop that checks the deadline on every iteration.
-    if (deadline && priorityLevel > TaskPriority) {
+    if (deadline !== null && priorityLevel > TaskPriority) {
       // The deferred work loop will run until there's no time left in
       // the current frame.
-      while (nextUnitOfWork && !deadlineHasExpired) {
+      while (nextUnitOfWork !== null && !deadlineHasExpired) {
         if (deadline.timeRemaining() > timeHeuristicForUnitOfWork) {
           nextUnitOfWork = performUnitOfWork(nextUnitOfWork);
           // In a deferred work batch, iff nextUnitOfWork returns null, we just
           // completed a root and a pendingCommit exists. Logically, we could
           // omit either of the checks in the following condition, but we need
           // both to satisfy Flow.
-          if (!nextUnitOfWork && pendingCommit) {
+          if (nextUnitOfWork === null && pendingCommit !== null) {
             // If we have time, we should commit the work now.
             if (deadline.timeRemaining() > timeHeuristicForUnitOfWork) {
               commitAllWork(pendingCommit);
@@ -690,11 +690,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       // If there's no deadline, or if we're performing Task work, use this loop
       // that doesn't check how much time is remaining. It will keep running
       // until we run out of work at this priority level.
-      while (nextUnitOfWork &&
+      while (nextUnitOfWork !== null &&
              nextPriorityLevel !== NoWork &&
              nextPriorityLevel <= priorityLevel) {
         nextUnitOfWork = performUnitOfWork(nextUnitOfWork);
-        if (!nextUnitOfWork) {
+        if (nextUnitOfWork === null) {
           nextUnitOfWork = findNextUnitOfWork();
           // performUnitOfWork returned null, which means we just comitted a
           // root. Clear any errors that were scheduled during the commit phase.
@@ -725,14 +725,14 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
     // deferred batch.
     while (priorityLevel !== NoWork && !fatalError) {
       invariant(
-        deadline || (priorityLevel < HighPriority),
+        deadline !== null || (priorityLevel < HighPriority),
         'Cannot perform deferred work without a deadline. This error is ' +
         'likely caused by a bug in React. Please file an issue.'
       );
 
       // Before starting any work, check to see if there are any pending
       // commits from the previous frame.
-      if (pendingCommit && !deadlineHasExpired) {
+      if (pendingCommit !== null && !deadlineHasExpired) {
         commitAllWork(pendingCommit);
       }
 
@@ -746,7 +746,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       } catch (error) {
         // We caught an error during either the begin or complete phases.
         const failedWork = nextUnitOfWork;
-        if (failedWork) {
+        if (failedWork !== null) {
           // Reset the priority context to its value before reconcilation.
           priorityContext = priorityContextBeforeReconciliation;
 
@@ -754,7 +754,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
           // error boundary, the nearest host container acts as one. If
           // captureError returns null, the error was intentionally ignored.
           const maybeBoundary = captureError(failedWork, error);
-          if (maybeBoundary) {
+          if (maybeBoundary !== null) {
             const boundary = maybeBoundary;
 
             // Complete the boundary as if it rendered null. This will unmount
@@ -774,7 +774,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
           }
           // Continue performing work
           continue;
-        } else if (!fatalError) {
+        } else if (fatalError === null) {
           // There is no current unit of work. This is a worst-case scenario
           // and should only be possible if there's a bug in the renderer, e.g.
           // inside resetAfterCommit.
@@ -830,13 +830,13 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
     failedBoundaries = null;
 
     // It's safe to throw any unhandled errors.
-    if (errorToThrow) {
+    if (errorToThrow !== null) {
       throw errorToThrow;
     }
   }
 
   // Returns the boundary that captured the error, or null if the error is ignored
-  function captureError(failedWork : Fiber, error : Error) : ?Fiber {
+  function captureError(failedWork : Fiber, error : Error) : Fiber | null {
     // It is no longer valid because we exited the user code.
     ReactCurrentOwner.current = null;
     if (__DEV__) {
@@ -846,12 +846,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
     nextUnitOfWork = null;
 
     // Search for the nearest error boundary.
-    let boundary : ?Fiber = null;
+    let boundary : Fiber | null = null;
 
     // Passed to logCapturedError()
     let errorBoundaryFound : boolean = false;
     let willRetry : boolean = false;
-    let errorBoundaryName : ?string = null;
+    let errorBoundaryName : string | null = null;
 
     // Host containers are a special case. If the failed work itself is a host
     // container, then it acts as its own boundary. In all other cases, we
@@ -867,7 +867,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       }
     } else {
       let node = failedWork.return;
-      while (node && !boundary) {
+      while (node !== null && boundary === null) {
         if (node.tag === ClassComponent) {
           const instance = node.stateNode;
           if (typeof instance.unstable_handleError === 'function') {
@@ -897,9 +897,9 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
           // this boundary already captured an error during this commit.
           // This case exists because multiple errors can be thrown during
           // a single commit without interruption.
-          if (commitPhaseBoundaries && (
+          if (commitPhaseBoundaries !== null && (
             commitPhaseBoundaries.has(node) ||
-            (node.alternate) && commitPhaseBoundaries.has(node.alternate)
+            (node.alternate !== null && commitPhaseBoundaries.has(node.alternate))
           )) {
             // If so, we should ignore this error.
             return null;
@@ -914,10 +914,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       }
     }
 
-    if (boundary) {
+    if (boundary !== null) {
       // Add to the collection of failed boundaries. This lets us know that
       // subsequent errors in this subtree should propagate to the next boundary.
-      if (!failedBoundaries) {
+      if (failedBoundaries === null) {
         failedBoundaries = new Set();
       }
       failedBoundaries.add(boundary);
@@ -933,7 +933,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       // map of errors and their component stack location keyed by the boundaries
       // that capture them. We mostly use this Map as a Set; it's a Map only to
       // avoid adding a field to Fiber to store the error.
-      if (!capturedErrors) {
+      if (capturedErrors === null) {
         capturedErrors = new Map();
       }
       capturedErrors.set(boundary, {
@@ -948,7 +948,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       // If we're in the commit phase, defer scheduling an update on the
       // boundary until after the commit is complete
       if (isCommitting) {
-        if (!commitPhaseBoundaries) {
+        if (commitPhaseBoundaries === null) {
           commitPhaseBoundaries = new Set();
         }
         commitPhaseBoundaries.add(boundary);
@@ -957,7 +957,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
         scheduleErrorRecovery(boundary);
       }
       return boundary;
-    } else if (!firstUncaughtError) {
+    } else if (firstUncaughtError === null) {
       // If no boundary is found, we'll need to throw the error
       firstUncaughtError = error;
     }
@@ -968,8 +968,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
     // TODO: capturedErrors should store the boundary instance, to avoid needing
     // to check the alternate.
     return Boolean(
-      capturedErrors &&
-      (capturedErrors.has(fiber) || (fiber.alternate && capturedErrors.has(fiber.alternate)))
+      capturedErrors !== null &&
+      (capturedErrors.has(fiber) || (fiber.alternate !== null && capturedErrors.has(fiber.alternate)))
     );
   }
 
@@ -977,18 +977,18 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
     // TODO: failedBoundaries should store the boundary instance, to avoid
     // needing to check the alternate.
     return Boolean(
-      failedBoundaries &&
-      (failedBoundaries.has(fiber) || (fiber.alternate && failedBoundaries.has(fiber.alternate)))
+      failedBoundaries !== null &&
+      (failedBoundaries.has(fiber) || (fiber.alternate !== null && failedBoundaries.has(fiber.alternate)))
     );
   }
 
   function commitErrorHandling(effectfulFiber : Fiber) {
     let capturedError;
-    if (capturedErrors) {
+    if (capturedErrors !== null) {
       capturedError = capturedErrors.get(effectfulFiber);
       capturedErrors.delete(effectfulFiber);
-      if (!capturedError) {
-        if (effectfulFiber.alternate) {
+      if (capturedError == null) {
+        if (effectfulFiber.alternate !== null) {
           effectfulFiber = effectfulFiber.alternate;
           capturedError = capturedErrors.get(effectfulFiber);
           capturedErrors.delete(effectfulFiber);
@@ -1002,19 +1002,13 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       'bug in React. Please file an issue.'
     );
 
-    let error;
-
-    // Conditional required to satisfy Flow
-    if (capturedError) {
-      error = capturedError.error;
-
-      try {
-        logCapturedError(capturedError);
-      } catch (e) {
-        // Prevent cycle if logCapturedError() throws.
-        // A cycle may still occur if logCapturedError renders a component that throws.
-        console.error(e);
-      }
+    const error = capturedError.error;
+    try {
+      logCapturedError(capturedError);
+    } catch (e) {
+      // Prevent cycle if logCapturedError() throws.
+      // A cycle may still occur if logCapturedError renders a component that throws.
+      console.error(e);
     }
 
     switch (effectfulFiber.tag) {
@@ -1025,7 +1019,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
         instance.unstable_handleError(error);
         return;
       case HostRoot:
-        if (!firstUncaughtError) {
+        if (firstUncaughtError === null) {
           // If this is the host container, we treat it as a no-op error
           // boundary. We'll throw the first uncaught error once it's safe to
           // do so, at the end of the batch.
@@ -1043,7 +1037,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
 
   function unwindContexts(from : Fiber, to: Fiber) {
     let node = from;
-    while (node && (node !== to) && (node.alternate !== to)) {
+    while (node !== null && (node !== to) && (node.alternate !== to)) {
       switch (node.tag) {
         case ClassComponent:
           popContextProvider(node);
@@ -1091,7 +1085,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
 
     let node = fiber;
     let shouldContinue = true;
-    while (node && shouldContinue) {
+    while (node !== null && shouldContinue) {
       // Walk the parent path to the root and update each node's priority. Once
       // we reach a node whose priority matches (and whose alternate's priority
       // matches) we can exit safely knowing that the rest of the path is correct.
@@ -1102,7 +1096,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
         shouldContinue = true;
         node.pendingWorkPriority = priorityLevel;
       }
-      if (node.alternate) {
+      if (node.alternate !== null) {
         if (node.alternate.pendingWorkPriority === NoWork ||
             node.alternate.pendingWorkPriority > priorityLevel) {
           // Priority did not match. Update and keep going.
@@ -1110,7 +1104,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
           node.alternate.pendingWorkPriority = priorityLevel;
         }
       }
-      if (!node.return) {
+      if (node.return === null) {
         if (node.tag === HostRoot) {
           const root : FiberRoot = (node.stateNode : any);
           scheduleRoot(root, priorityLevel);
@@ -1118,7 +1112,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
           // schedule a callback to perform work later.
           switch (priorityLevel) {
             case SynchronousPriority:
-              performWork(SynchronousPriority);
+              performWork(SynchronousPriority, null);
               return;
             case TaskPriority:
               // TODO: If we're not already performing work, schedule a
@@ -1175,7 +1169,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
       // If we're not already inside a batch, we need to flush any task work
       // that was created by the user-provided function.
       if (!isPerformingWork && !isBatchingUpdates) {
-        performWork(TaskPriority);
+        performWork(TaskPriority, null);
       }
     }
   }


### PR DESCRIPTION
Flow maybe types accept both null and undefined. When the final parameter of a function accepts a maybe type, passing nothing (undefined) successfully typechecks, which can lead to bugs if the omission is accidental. Being forced to pass null is harder to screw up.

Explicit null checks are also faster.