### PR TITLE
Add createComponentMock option to test renderer

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1791,6 +1791,8 @@ src/renderers/testing/__tests__/ReactTestRenderer-test.js
 * toTree() renders complicated trees of composites and hosts
 * can update text nodes when rendered as root
 * can render and update root fragments
+* allows createComponentMock option to be passed in, simulating shallow
+* createComponentMock can mock out specific components
 
 src/shared/utils/__tests__/KeyEscapeUtils-test.js
 * should properly escape and wrap user defined keys

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -61,6 +61,7 @@ export type Fiber = {
   _debugSource?: Source | null,
   _debugOwner?: Fiber | ReactInstance | null, // Stack compatible
   _debugIsCurrentlyTiming?: boolean,
+  _unmockedType?: any,
 
   // These first fields are conceptually members of an Instance. This used to
   // be split into a separate type and intersected with the other Fiber fields,
@@ -222,6 +223,7 @@ var createFiber = function(tag: TypeOfWork, key: null | string): Fiber {
     fiber._debugSource = null;
     fiber._debugOwner = null;
     fiber._debugIsCurrentlyTiming = false;
+    fiber._unmockedType = null;
     if (typeof Object.preventExtensions === 'function') {
       Object.preventExtensions(fiber);
     }

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -102,6 +102,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     memoizeState,
   );
 
+  if (__DEV__) {
+    var hasMockingBehavior = typeof config.mockComponent === 'function';
+    var mockComponent = config.mockComponent || (() => {});
+  }
+
   function markChildAsProgressed(current, workInProgress, priorityLevel) {
     // We now have clones. Let's store them as the currently progressed work.
     workInProgress.progressedChild = workInProgress.child;
@@ -792,6 +797,18 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       // If we have progressed work on this priority level already, we can
       // proceed this that as the child.
       workInProgress.child = workInProgress.progressedChild;
+    }
+
+    if (__DEV__) {
+      if (hasMockingBehavior) {
+        switch (workInProgress.tag) {
+          case IndeterminateComponent:
+          case FunctionalComponent:
+          case ClassComponent:
+            mockComponent(workInProgress, hostContext.getRootHostContainer());
+            break;
+        }
+      }
     }
 
     switch (workInProgress.tag) {

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -115,6 +115,8 @@ export type HostConfig<T, P, I, TI, PI, C, CX, PL> = {
   resetAfterCommit(): void,
 
   useSyncScheduling?: boolean,
+
+  mockComponent?: Function,
 };
 
 export type Reconciler<C, I, TI> = {


### PR DESCRIPTION
This PR is a followup to #8931, and adds a `createComponentMock` option to the test renderer when using fiber. The function is expected to return the correct type (mocked or not) for the provided fiber. This gets called on functional components and class components, but not hosts.

I've added corresponding tests that show how one could use this property to emulate shallow rendering, as well as what I believe is an even more practical usage, simple mocking of components that have implementations difficult to test.

The implementation of this uses an additional optional `mockComponent` function that is added to the `HostConfig` when creating the reconciler.  This required that we pass the host config into a couple of additional places in the fiber codebase.

There are still some outstanding questions:

1. Do we want to allow `createComponentMock` to return `null` in the case of not mocking, or keep it as is where it just returns `type`?
2. Is `mockComponent` the right name to use?
3. `createComponentMock` gets called with a `Fiber`. Do we instead want to only pass it `type` and `tag`, or some transformation of `tag`? Right now user land code will have to know if the mock should be a functional component or a class component.  Alternatively, we could have two methods, one for functional component mocking, and another for class component mocking.

cc @gaearon @sebmarkbage @aweary @iamdustan 
