### PR TITLE
Fix createNodeMock doc to avoid Invariant Violation

### DIFF
--- a/docs/_posts/2016-11-16-react-v15.4.0.md
+++ b/docs/_posts/2016-11-16-react-v15.4.0.md
@@ -75,6 +75,7 @@ import renderer from 'react-test-renderer';
 function createNodeMock(element) {
   if (element.type === 'input') {
     return {
+      nodeType: 1,
       focus() {},
     };
   }


### PR DESCRIPTION
Hi, when I try to mock refs for snapshot testing (described here: https://facebook.github.io/react/blog/2016/11/16/react-v15.4.0.html), I get the error:

`Invariant Violation: Element appears to be neither ReactComponent nor DOMNode`

I made use of this line of code to make it work: https://github.com/facebook/react/blob/master/src/renderers/dom/shared/findDOMNode.js#L46

I'm using react@15.4.2, react-test-renderer@15.4.2, and jest@18.1.0