### PR TITLE
Revert "Fix createNodeMock doc to avoid Invariant Violation"

### DIFF
--- a/docs/_posts/2016-11-16-react-v15.4.0.md
+++ b/docs/_posts/2016-11-16-react-v15.4.0.md
@@ -75,7 +75,6 @@ import renderer from 'react-test-renderer';
 function createNodeMock(element) {
   if (element.type === 'input') {
     return {
-      nodeType: 1,
       focus() {},
     };
   }


### PR DESCRIPTION
Reverts facebook/react#8989, for the reason explained in it.
It was unnecessary.