### PR TITLE
Move ReactElementType to shared

### DIFF
--- a/src/shared/ReactElementType.js
+++ b/src/shared/ReactElementType.js
@@ -12,8 +12,6 @@
 
 'use strict';
 
-import type { ReactInstance } from 'ReactInstanceType';
-
 export type Source = {
   fileName: string,
   lineNumber: number,
@@ -25,7 +23,7 @@ export type ReactElement = {
   key: any,
   ref: any,
   props: any,
-  _owner: ReactInstance,
+  _owner: any, // ReactInstance or ReactFiber
 
   // __DEV__
   _store: {


### PR DESCRIPTION
This is currently used by both isomorphic and the renderer. I think that
we can probably split these up. The isomorphic type should actually be
different. It has to do with that the caller needs to know exactly which
type of element it is but this is never needed in the renderer which only
needs to know that the type is internally consistent.

The owner type is renderer dependent so it can literally be anything.
