### PR TITLE
Revert "Missing a space for error 125"

### DIFF
--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -124,7 +124,7 @@
   "122": "%s(...): Expected the last optional `callback` argument to be a function. Instead received: %s.",
   "123": "ReactUpdates: must inject a reconcile transaction class and batching strategy",
   "124": "Expected flush transaction's stored dirty-components length (%s) to match dirty-components array length (%s).",
-  "125": "ReactUpdates.asap: Can't enqueue an asap callback in a context where updates are not being batched.",
+  "125": "ReactUpdates.asap: Can't enqueue an asap callback in a context whereupdates are not being batched.",
   "126": "ReactUpdates: must provide a reconcile transaction class",
   "127": "ReactUpdates: must provide a batching strategy",
   "128": "ReactUpdates: must provide a batchedUpdates() function",


### PR DESCRIPTION
Reverts facebook/react#8981

We shouldn't modify this file by hand.
It is automatically created by a build task that we run on stable releases.

If the current code has a misspelling, we should fix it in the code (and we'll update the file during a release).
Otherwise, we should keep the misspelling in because the file will be regenerated anyway.