### PR TITLE
Ignore events on text nodes in stack

### DIFF
--- a/src/renderers/shared/shared/event/EventPluginHub.js
+++ b/src/renderers/shared/shared/event/EventPluginHub.js
@@ -138,6 +138,10 @@ var EventPluginHub = {
         return null;
       }
     } else {
+      if (typeof inst._currentElement === 'string') {
+        // Text node, let it bubble through.
+        return null;
+      }
       const props = inst._currentElement.props;
       listener = props[registrationName];
       if (shouldPreventMouseEvent(registrationName, inst._currentElement.type, props)) {


### PR DESCRIPTION
In React Native events can fire on text nodes (on Android at least).

In that case, the current element will be a string and not props. These can not have event handlers on them so we need to bail out so that we don't throw later on.
