### PR TITLE
switch links to open GH pages, not 404

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -81,7 +81,7 @@ id: home
 <hr class="home-divider" />
 <section class="home-bottom-section">
   <div class="buttons-unit">
-    <a href="docs/hello-world.html" class="button">Get Started</a>
-    <a href="tutorial/tutorial.html" class="button">Take the Tutorial</a>
+    <a href="https://facebook.github.io/react/docs/hello-world.html" class="button">Get Started</a>
+    <a href="https://facebook.github.io/react/tutorial/tutorial.html" class="button">Take the Tutorial</a>
   </div>
 </section>


### PR DESCRIPTION
switched the current urls:
https://github.com/facebook/react/blob/master/docs/docs/hello-world.html
https://github.com/facebook/react/blob/master/docs/tutorial/tutorial.html
To the GitHub pages route. Currently they render a 404 page. 
https://facebook.github.io/react/docs/hello-world.html
https://facebook.github.io/react/tutorial/tutorial.html

**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure the test suite passes (`npm test`).
5. Make sure your code lints (`npm run lint`).
6. Run the [Flow](https://flowtype.org/) typechecks (`npm run flow`).
7. If you added or removed any tests, run `./scripts/fiber/record-tests` before submitting the pull request, and commit the resulting changes.
8. If you haven't already, complete the [CLA](https://code.facebook.com/cla).
