### PR TITLE
Switch to shipping Fiber in npm packages

### DIFF
--- a/packages/react-dom/fiber.js
+++ b/packages/react-dom/fiber.js
@@ -1,3 +1,0 @@
-'use strict';
-
-module.exports = require('./lib/ReactDOMFiber');

--- a/packages/react-dom/index.js
+++ b/packages/react-dom/index.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = require('./lib/ReactDOM');
+module.exports = require('./lib/ReactDOMFiber');

--- a/packages/react-test-renderer/fiber.js
+++ b/packages/react-test-renderer/fiber.js
@@ -1,3 +1,0 @@
-'use strict';
-
-module.exports = require('./lib/ReactTestRendererFiber');

--- a/packages/react-test-renderer/index.js
+++ b/packages/react-test-renderer/index.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = require('./lib/ReactTestRendererStack');
+module.exports = require('./lib/ReactTestRendererFiber');


### PR DESCRIPTION
I added missing `fiber.js` to `react-dom` and `react-test-renderer` package.json-s so this file doesn't get stripped when packages are published to npm.