### PR TITLE
Switch UMD build to Fiber

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -139,16 +139,6 @@ module.exports = function(grunt) {
     'version-check',
     'browserify:domServerMin',
   ]);
-  grunt.registerTask('build:dom-fiber', [
-    'build-modules',
-    'version-check',
-    'browserify:domFiber',
-  ]);
-  grunt.registerTask('build:dom-fiber-min', [
-    'build-modules',
-    'version-check',
-    'browserify:domFiberMin',
-  ]);
   grunt.registerTask('build:npm-react', [
     'version-check',
     'build-modules',
@@ -176,8 +166,6 @@ module.exports = function(grunt) {
     'browserify:domMin',
     'browserify:domServer',
     'browserify:domServerMin',
-    'browserify:domFiber',
-    'browserify:domFiberMin',
     'npm-react:release',
     'npm-react:pack',
     'npm-react-dom:release',

--- a/grunt/config/browserify.js
+++ b/grunt/config/browserify.js
@@ -206,7 +206,7 @@ var addonsMin = {
 // The DOM Builds
 var dom = {
   entries: [
-    './build/node_modules/react-dom/lib/ReactDOMUMDEntry.js',
+    './build/node_modules/react-dom/lib/ReactDOMFiber.js',
   ],
   outfile: './build/react-dom.js',
   debug: false,
@@ -220,7 +220,7 @@ var dom = {
 
 var domMin = {
   entries: [
-    './build/node_modules/react-dom/lib/ReactDOMUMDEntry.js',
+    './build/node_modules/react-dom/lib/ReactDOMFiber.js',
   ],
   outfile: './build/react-dom.min.js',
   debug: false,

--- a/grunt/config/browserify.js
+++ b/grunt/config/browserify.js
@@ -268,38 +268,6 @@ var domServerMin = {
   after: [wrapperify, minify, bannerify],
 };
 
-var domFiber = {
-  entries: [
-    './build/node_modules/react-dom/lib/ReactDOMFiber.js',
-  ],
-  outfile: './build/react-dom-fiber.js',
-  debug: false,
-  standalone: 'ReactDOMFiber',
-  // Apply as global transform so that we also envify fbjs and any other deps
-  transforms: [shimSharedModules],
-  globalTransforms: [envifyDev],
-  plugins: [collapser],
-  after: [derequire, wrapperify, simpleBannerify],
-};
-
-var domFiberMin = {
-  entries: [
-    './build/node_modules/react-dom/lib/ReactDOMFiber.js',
-  ],
-  outfile: './build/react-dom-fiber.min.js',
-  debug: false,
-  standalone: 'ReactDOMFiber',
-  // Envify twice. The first ensures that when we uglifyify, we have the right
-  // conditions to exclude requires. The global transform runs on deps.
-  transforms: [shimSharedModules, envifyProd, uglifyify],
-  globalTransforms: [envifyProd],
-  plugins: [collapser],
-  // No need to derequire because the minifier will mangle
-  // the "require" calls.
-
-  after: [wrapperify, minify, bannerify],
-};
-
 module.exports = {
   basic: basic,
   min: min,
@@ -309,6 +277,4 @@ module.exports = {
   domMin: domMin,
   domServer: domServer,
   domServerMin: domServerMin,
-  domFiber: domFiber,
-  domFiberMin: domFiberMin,
 };

--- a/grunt/config/browserify.js
+++ b/grunt/config/browserify.js
@@ -206,7 +206,7 @@ var addonsMin = {
 // The DOM Builds
 var dom = {
   entries: [
-    './build/node_modules/react-dom/lib/ReactDOMFiber.js',
+    './build/node_modules/react-dom/lib/ReactDOMUMDEntry.js',
   ],
   outfile: './build/react-dom.js',
   debug: false,
@@ -220,7 +220,7 @@ var dom = {
 
 var domMin = {
   entries: [
-    './build/node_modules/react-dom/lib/ReactDOMFiber.js',
+    './build/node_modules/react-dom/lib/ReactDOMUMDEntry.js',
   ],
   outfile: './build/react-dom.min.js',
   debug: false,

--- a/src/umd/ReactDOMUMDEntry.js
+++ b/src/umd/ReactDOMUMDEntry.js
@@ -12,7 +12,7 @@
 'use strict';
 
 var React = require('React');
-var ReactDOM = require('ReactDOM');
+var ReactDOM = require('ReactDOMFiber');
 
 var ReactDOMUMDEntry = ReactDOM;
 


### PR DESCRIPTION
Follow-up to https://github.com/facebook/react/pull/9015.

This PR switches UMD builds (`react-dom.js` and `react-dom.min.js`) to use `ReactDOMFiber` as an entry-point and removes `-fiber` builds altogether.

The change breaks `examples/fiber` and I intend to fix it with separate PR.