### PR TITLE
Removed unnecessary if

### DIFF
--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -204,40 +204,35 @@ var ReactElementValidator = {
     // We warn in this case but don't throw. We expect the element creation to
     // succeed and there will likely be errors in render.
     if (!validType) {
+      var info = '';
       if (
-        typeof type !== 'function' &&
-        typeof type !== 'string'
+        type === undefined ||
+        typeof type === 'object' &&
+        type !== null &&
+        Object.keys(type).length === 0
       ) {
-        var info = '';
-        if (
-          type === undefined ||
-          typeof type === 'object' &&
-          type !== null &&
-          Object.keys(type).length === 0
-        ) {
-          info +=
-            ' You likely forgot to export your component from the file ' +
-            'it\'s defined in.';
-        }
-
-        var sourceInfo = getSourceInfoErrorAddendum(props);
-        if (sourceInfo) {
-          info += sourceInfo;
-        } else {
-          info += getDeclarationErrorAddendum();
-        }
-
-        info += ReactComponentTreeHook.getCurrentStackAddendum();
-
-        warning(
-          false,
-          'React.createElement: type is invalid -- expected a string (for ' +
-          'built-in components) or a class/function (for composite ' +
-          'components) but got: %s.%s',
-          type == null ? type : typeof type,
-          info,
-        );
+        info +=
+          ' You likely forgot to export your component from the file ' +
+          'it\'s defined in.';
       }
+
+      var sourceInfo = getSourceInfoErrorAddendum(props);
+      if (sourceInfo) {
+        info += sourceInfo;
+      } else {
+        info += getDeclarationErrorAddendum();
+      }
+
+      info += ReactComponentTreeHook.getCurrentStackAddendum();
+
+      warning(
+        false,
+        'React.createElement: type is invalid -- expected a string (for ' +
+        'built-in components) or a class/function (for composite ' +
+        'components) but got: %s.%s',
+        type == null ? type : typeof type,
+        info,
+      );
     }
 
     var element = ReactElement.createElement.apply(this, arguments);


### PR DESCRIPTION
Found this little thing while stepping through an example.

validType already checks whether type is a string or a function

```
var validType =
      typeof type === 'string' ||
      typeof type === 'function';
```

 so the inner if was unnecessary.

```
if (
  typeof type !== 'function' &&
  typeof type !== 'string'
)  {
```