### PR TITLE
Improved stack/fiber type-check to avoid false negative match

### DIFF
--- a/src/renderers/native/ReactNativeComponentTree.js
+++ b/src/renderers/native/ReactNativeComponentTree.js
@@ -61,7 +61,9 @@ function getInstanceFromTag(tag) {
 
 function getTagFromInstance(inst) {
   // TODO (bvaughn) Clean up once Stack is deprecated
-  var tag = inst._rootNodeID || inst.stateNode._nativeTag;
+  var tag = typeof inst.tag !== 'number'
+    ? inst._rootNodeID
+    : inst.stateNode._nativeTag;
   invariant(tag, 'All native instances should have a tag.');
   return tag;
 }

--- a/src/renderers/native/ReactNativeGlobalResponderHandler.js
+++ b/src/renderers/native/ReactNativeGlobalResponderHandler.js
@@ -16,10 +16,10 @@ var ReactNativeGlobalResponderHandler = {
   onChange: function(from, to, blockNativeResponder) {
     if (to !== null) {
       // TODO (bvaughn) Clean up once Stack is deprecated
-      UIManager.setJSResponder(
-        to._rootNodeID || to.stateNode._nativeTag,
-        blockNativeResponder
-      );
+      var tag = typeof to.tag !== 'number'
+        ? to._rootNodeID
+        : to.stateNode._nativeTag;
+      UIManager.setJSResponder(tag, blockNativeResponder);
     } else {
       UIManager.clearJSResponder();
     }


### PR DESCRIPTION
A bug was discovered in ReactNative where `getNodeFromInstance` was called for a stack instance with a `_rootNodeID` of 0. The way our code was previously written caused us to treat this as a fiber instance and caused a runtime error. This PR hardens that check to avoid the bad match. It does not address the underlying cause of the issue. (It is expected that after this change has been made, the issue will still result in an error- this time it will be an invariant statement though.)