### PR TITLE
Support for assigning to this.state inside componentWillReceiveProps

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -607,6 +607,7 @@ src/renderers/__tests__/ReactCompositeComponentState-test.js
 * should batch unmounts
 * should update state when called from child cWRP
 * should merge state when sCU returns false
+* should treat assigning to this.state inside cWRP as a replaceState, with a warning
 
 src/renderers/__tests__/ReactEmptyComponent-test.js
 * should not produce child DOM nodes for null and false

--- a/src/renderers/__tests__/ReactCompositeComponentState-test.js
+++ b/src/renderers/__tests__/ReactCompositeComponentState-test.js
@@ -414,4 +414,30 @@ describe('ReactCompositeComponent-state', () => {
       'scu from a,b to a,b,c',
     ]);
   });
+
+  it('should treat assigning to this.state inside cWRP as a replaceState, with a warning', () => {
+    let ops = [];
+    class Test extends React.Component {
+      state = { step: 1, extra: true };
+      componentWillReceiveProps() {
+        this.setState({ step: 2 }, () => {
+          // Tests that earlier setState callbacks are not dropped
+          ops.push(`step: ${this.state.step}, extra: ${!!this.state.extra}`);
+        });
+        // Treat like replaceState
+        this.state = { step: 3 };
+      }
+      render() {
+        return null;
+      }
+    }
+
+    // Mount
+    const container = document.createElement('div');
+    ReactDOM.render(<Test />, container);
+    // Update
+    ReactDOM.render(<Test />, container);
+
+    expect(ops).toEqual(['step: 3, extra: false']);
+  });
 });

--- a/src/renderers/__tests__/ReactCompositeComponentState-test.js
+++ b/src/renderers/__tests__/ReactCompositeComponentState-test.js
@@ -424,12 +424,13 @@ describe('ReactCompositeComponent-state', () => {
       componentWillReceiveProps() {
         this.setState({ step: 2 }, () => {
           // Tests that earlier setState callbacks are not dropped
-          ops.push(`step: ${this.state.step}, extra: ${!!this.state.extra}`);
+          ops.push(`callback -- step: ${this.state.step}, extra: ${!!this.state.extra}`);
         });
         // Treat like replaceState
         this.state = { step: 3 };
       }
       render() {
+        ops.push(`render -- step: ${this.state.step}, extra: ${!!this.state.extra}`);
         return null;
       }
     }
@@ -440,7 +441,11 @@ describe('ReactCompositeComponent-state', () => {
     // Update
     ReactDOM.render(<Test />, container);
 
-    expect(ops).toEqual(['step: 3, extra: false']);
+    expect(ops).toEqual([
+      'render -- step: 1, extra: true',
+      'render -- step: 3, extra: false',
+      'callback -- step: 3, extra: false',
+    ]);
     expect(console.error.calls.count()).toEqual(1);
     expect(console.error.calls.argsFor(0)[0]).toEqual(
       'Warning: Test.componentWillReceiveProps(): Assigning directly to ' +

--- a/src/renderers/__tests__/ReactCompositeComponentState-test.js
+++ b/src/renderers/__tests__/ReactCompositeComponentState-test.js
@@ -416,6 +416,8 @@ describe('ReactCompositeComponent-state', () => {
   });
 
   it('should treat assigning to this.state inside cWRP as a replaceState, with a warning', () => {
+    spyOn(console, 'error');
+
     let ops = [];
     class Test extends React.Component {
       state = { step: 1, extra: true };
@@ -439,5 +441,11 @@ describe('ReactCompositeComponent-state', () => {
     ReactDOM.render(<Test />, container);
 
     expect(ops).toEqual(['step: 3, extra: false']);
+    expect(console.error.calls.count()).toEqual(1);
+    expect(console.error.calls.argsFor(0)[0]).toEqual(
+      'Warning: Test.componentWillReceiveProps(): Assigning directly to ' +
+      'this.state is deprecated (except inside a component\'s constructor). ' +
+      'Use setState instead.'
+    );
   });
 });

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -410,6 +410,15 @@ module.exports = function(
         instance.componentWillReceiveProps(newProps, newContext);
 
         if (instance.state !== workInProgress.memoizedState) {
+          if (__DEV__) {
+            warning(
+              false,
+              '%s.componentWillReceiveProps(): Assigning directly to ' +
+              'this.state is deprecated (except inside a component\'s ' +
+              'constructor). Use setState instead.',
+              getComponentName(workInProgress)
+            );
+          }
           updater.enqueueReplaceState(instance, instance.state, null);
         }
       }

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -408,6 +408,10 @@ module.exports = function(
     if (oldProps !== newProps || oldContext !== newContext) {
       if (typeof instance.componentWillReceiveProps === 'function') {
         instance.componentWillReceiveProps(newProps, newContext);
+
+        if (instance.state !== workInProgress.memoizedState) {
+          updater.enqueueReplaceState(instance, instance.state, null);
+        }
       }
     }
 

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -864,6 +864,15 @@ var ReactCompositeComponent = {
       if (beforeState !== afterState) {
         inst.state = beforeState;
         inst.updater.enqueueReplaceState(inst, afterState);
+        if (__DEV__) {
+          warning(
+            false,
+            '%s.componentWillReceiveProps(): Assigning directly to ' +
+            'this.state is deprecated (except inside a component\'s ' +
+            'constructor). Use setState instead.',
+            this.getName() || 'ReactCompositeComponent'
+          );
+        }
       }
     }
 

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -850,6 +850,7 @@ var ReactCompositeComponent = {
     // _pendingStateQueue which will ensure that any state updates gets
     // immediately reconciled instead of waiting for the next batch.
     if (willReceive && inst.componentWillReceiveProps) {
+      const beforeState = inst.state;
       if (__DEV__) {
         measureLifeCyclePerf(
           () => inst.componentWillReceiveProps(nextProps, nextContext),
@@ -858,6 +859,11 @@ var ReactCompositeComponent = {
         );
       } else {
         inst.componentWillReceiveProps(nextProps, nextContext);
+      }
+      const afterState = inst.state;
+      if (beforeState !== afterState) {
+        inst.state = beforeState;
+        inst.updater.enqueueReplaceState(inst, afterState);
       }
     }
 


### PR DESCRIPTION
We don't explicitly support this pattern, but it happens to work (kinda) in Stack. We'll give it `replaceState` semantics and print a warning so that people stop relying on this pattern. In the future we'll remove the `replaceState` behavior but keep the warning.