### PR TITLE
docs/docs/reference-react-component: Document throwing errors

### DIFF
--- a/docs/docs/reference-react-component.md
+++ b/docs/docs/reference-react-component.md
@@ -37,6 +37,8 @@ If you don't use ES6 yet, you may use the [`React.createClass`](/react/docs/reac
 
 Each component has several "lifecycle methods" that you can override to run code at particular times in the process. Methods prefixed with **`will`** are called right before something happens, and methods prefixed with **`did`** are called right after something happens.
 
+Throwing errors from lifecycle methods is not currently supported and may lead to cryptic error messages.
+
 #### Mounting
 
 These methods are called when an instance of a component is being created and inserted into the DOM:


### PR DESCRIPTION
So folks know not to intentionally throw errors from these methods, and understand that if/when that happens anyway the resulting error may not be very helpful.

It [sounds][1] [like][2] React will do a better job of providing helpful errors in the next release.  I haven't been able to track down the commit/branch where that is happening, so I can't provide more specific advice on how to catch errors in components (although there [will be a way to do that][2]).

Spun off from #9037.

[1]: https://github.com/facebook/react/issues/6895#issuecomment-281405036
[2]: https://github.com/facebook/react/issues/9037#issuecomment-281558149