### PR TITLE
Fix RN bug when event responder unmounts during touch sequence

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1453,6 +1453,7 @@ src/renderers/native/__tests__/ReactNativeAttributePayload-test.js
 
 src/renderers/native/__tests__/ReactNativeEvents-test.js
 * handles events
+* handles when a responder is unmounted while a touch sequence is in progress
 
 src/renderers/native/__tests__/ReactNativeMount-test.js
 * should be able to create and render a native component

--- a/src/__mocks__/UIManager.js
+++ b/src/__mocks__/UIManager.js
@@ -12,7 +12,9 @@
 // Mock of the Native Hooks
 
 var RCTUIManager = {
+  clearJSResponder: jest.fn(),
   createView: jest.fn(),
+  setJSResponder: jest.fn(),
   setChildren: jest.fn(),
   manageChildren: jest.fn(),
   updateView: jest.fn(),

--- a/src/renderers/native/ReactNativeComponentTree.js
+++ b/src/renderers/native/ReactNativeComponentTree.js
@@ -53,6 +53,7 @@ function uncacheNode(inst) {
 
 function uncacheFiberNode(tag) {
   delete instanceCache[tag];
+  delete instanceProps[tag];
 }
 
 function getInstanceFromTag(tag) {

--- a/src/renderers/shared/shared/event/EventPluginHub.js
+++ b/src/renderers/shared/shared/event/EventPluginHub.js
@@ -142,6 +142,10 @@ var EventPluginHub = {
         // Text node, let it bubble through.
         return null;
       }
+      if (!inst._rootNodeID) {
+        // If the instance is already unmounted, we have no listeners.
+        return null;
+      }
       const props = inst._currentElement.props;
       listener = props[registrationName];
       if (shouldPreventMouseEvent(registrationName, inst._currentElement.type, props)) {


### PR DESCRIPTION
This PR adds a test (initially failing) for this case along with a fix for stack and fiber. The stack fix was copied from a Diff submitted by @sebmarkbage. The fiber fix was to stop leaking properties for unmounted views.

Longer term we may want to explicitly invoke a release event listener for a responder just before unmounting it. This PR does not do that.