### PR TITLE
ReactDOM DOMLazyTree: add fix for IE11 popup rendering issue

### DIFF
--- a/src/renderers/dom/stack/client/DOMLazyTree.js
+++ b/src/renderers/dom/stack/client/DOMLazyTree.js
@@ -72,7 +72,11 @@ var insertTreeBefore = createMicrosoftUnsafeLocalFunction(
         (tree.node.namespaceURI == null ||
          tree.node.namespaceURI === DOMNamespaces.html)) {
       insertTreeChildren(tree);
-      parentNode.insertBefore(tree.node, referenceNode);
+      if (referenceNode) {
+        parentNode.insertBefore(tree.node, referenceNode);
+      } else {
+        parentNode.appendChild(tree.node);
+      }
     } else {
       parentNode.insertBefore(tree.node, referenceNode);
       insertTreeChildren(tree);


### PR DESCRIPTION
When rendering to a popup in IE11, components with multiple children can break.
Other browsers don't have this problem (render subtrees all at once while IE's get added step by step) and the problem also doesn't happen when rendering a problematic component to the main browser window.

## Demo
+ [Run the broken demo (requires IE11)](https://paulkogel.github.io/react-rendering-bug-ie11-popup-demo/)
+ [Run the fixed demo](https://paulkogel.github.io/react-rendering-bug-ie11-popup-demo/fixed.html)
+ Repository: [https://github.com/paulkogel/react-rendering-bug-ie11-popup-demo/](https://github.com/paulkogel/react-rendering-bug-ie11-popup-demo/)

## TODO
- [ ] **wait for feedback whether the current workaround is a good way to fix the issue**
- [ ] add regression test

**Screenshot of broken behaviour**
![screenshot broken](https://raw.githubusercontent.com/paulkogel/react-rendering-bug-ie11-popup-demo/gh-pages/screenshot-broken.png)

**Screenshot of fixed behaviour**
![screenshot fixed](https://github.com/paulkogel/react-rendering-bug-ie11-popup-demo/raw/gh-pages/screenshot-fixed.png)

React and ReactDOM versions tested: 15.4.2 and current master.

## Example for Problematic Markup
```
var WillBreakInPopup = function() {
  return React.createElement(
    'div',
    null,
    'Hello Popup!', // 2 children cause trouble!
    ' ...and more!'
  );
};
```
## Original Error Message

```
SCRIPT87: Invalid argument.
File: react-dom.js, Line: 1598, Column: 5
```

```
var insertTreeBefore = createMicrosoftUnsafeLocalFunction(function (parentNode, tree, referenceNode) {
  // DocumentFragments aren't actually part of the DOM after insertion so
  // appending children won't update the DOM. We need to ensure the fragment
  // is properly populated first, breaking out of our lazy approach for just
  // this level. Also, some <object> plugins (like Flash Player) will read
  // <param> nodes immediately upon insertion into the DOM, so <object>
  // must also be populated prior to insertion into the DOM.
  if (tree.node.nodeType === DOCUMENT_FRAGMENT_NODE_TYPE || tree.node.nodeType === ELEMENT_NODE_TYPE && tree.node.nodeName.toLowerCase() === 'object' && (tree.node.namespaceURI == null || tree.node.namespaceURI === DOMNamespaces.html)) {
    insertTreeChildren(tree);
    parentNode.insertBefore(tree.node, referenceNode); // ERRONEOUS LINE
  } else {
    parentNode.insertBefore(tree.node, referenceNode);
    insertTreeChildren(tree);
  }
});
```

## Workaround / Fix (!?)

```diff
-    parentNode.insertBefore(tree.node, referenceNode); // ERRONEOUS LINE
+    if (referenceNode) {
+      parentNode.insertBefore(tree.node, referenceNode);
+    } else {
+      parentNode.appendChild(tree.node);
+    }
```

**Explanation:** when `referenceNode` is `null` it will insert `tree.node` at the end of `parentNode` and can be replaced with `appendChild`. For some reason `appendChild` doesn't crash rendering and fixes the issue.
I'm not really sure what causes `insertBefore` to crash when rendering to the popout. Replacing it with `appendChild` fixes things in our app and tests still pass.
