### PR TITLE
[Fiber] Prevent extensions to fiber in DEV

### DIFF
--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -223,7 +223,11 @@ var createFiber = function(tag : TypeOfWork, key : null | string) : Fiber {
     fiber._debugID = debugCounter++;
     fiber._debugSource = null;
     fiber._debugOwner = null;
+    if (typeof Object.preventExtensions === 'function') {
+      Object.preventExtensions(fiber);
+    }
   }
+
 
   return fiber;
 };


### PR DESCRIPTION
Helps us avoid accidentally adding fields to the fiber class.

See https://github.com/facebook/react/pull/8949#discussion_r102717019