### PR TITLE
Remove npm shrinkwrap file from list of files to version

### DIFF
--- a/scripts/release-manager/commands/version.js
+++ b/scripts/release-manager/commands/version.js
@@ -95,10 +95,6 @@ module.exports = function(vorpal, app) {
             fields: ['version'],
           },
           {
-            file: 'npm-shrinkwrap.json',
-            fields: ['version'],
-          },
-          {
             file: 'packages/react/package.json',
             fields: ['version'],
           },


### PR DESCRIPTION
Correct me if I'm wrong, but I don't think we need this anymore.