### PR TITLE
Fix record-tests script

### DIFF
--- a/scripts/fiber/record-tests
+++ b/scripts/fiber/record-tests
@@ -80,7 +80,7 @@ function wrapRunner(originalPath) {
 
 function runJest(maxWorkers) {
   return readConfig(argv, root)
-    .then((config) => {
+    .then(({ config }) => {
       config = Object.assign({}, config, {
         testRunner: wrapRunnerFile(config.testRunner),
       });


### PR DESCRIPTION
I was unable to run the record-test script. Did some digging and turns out the result of readConfig changed slightly in Jest 0.19, which we recently updated to. This fixes the script.

I'm not entirely sure why this didn't break CI...

To test, make sure you run yarn so you're on the latest version of jest.
