### PR TITLE
Fix spacing in documentation

### DIFF
--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -145,7 +145,7 @@ function CustomTextInput(props) {
 
 Your first inclination may be to use refs to "make things happen" in your app. If this is the case, take a moment and think more critically about where state should be owned in the component hierarchy. Often, it becomes clear that the proper place to "own" that state is at a higher level in the hierarchy. See the [Lifting State Up](/react/docs/lifting-state-up.html) guide for examples of this.
 
-### Legacy API: String Refs
+### Legacy API: String Refs
 
 If you worked with React before, you might be familiar with an older API where the `ref` attribute is a string, like `"textInput"`, and the DOM node is accessed as `this.refs.textInput`. We advise against it because string refs have [some issues](https://github.com/facebook/react/pull/8333#issuecomment-271648615), are considered legacy, and **are likely to be removed in one of the future releases**. If you're currently using `this.refs.textInput` to access refs, we recommend the callback pattern instead.
 


### PR DESCRIPTION
Replace non-breaking space by space in refs and the dom.

Fixes:
![image](https://cloud.githubusercontent.com/assets/132/23370341/a2076bd2-fd14-11e6-8c92-bbf55d10fd30.png)
