### PR TITLE
Pass add'l component name and stack info to error boundary handler

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -27,6 +27,11 @@ export type CapturedError = {
   willRetry : boolean,
 };
 
+export type HandleErrorInfo = {
+  componentName : ?string,
+  componentStack : string,
+};
+
 var {
   popContextProvider,
 } = require('ReactFiberContext');
@@ -1077,9 +1082,15 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
     switch (effectfulFiber.tag) {
       case ClassComponent:
         const instance = effectfulFiber.stateNode;
+
+        const info : HandleErrorInfo = {
+          componentName: capturedError.componentName,
+          componentStack: capturedError.componentStack,
+        };
+
         // Allow the boundary to handle the error, usually by scheduling
         // an update to itself
-        instance.unstable_handleError(error);
+        instance.unstable_handleError(error, info);
         return;
       case HostRoot:
         if (firstUncaughtError === null) {

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -28,7 +28,6 @@ export type CapturedError = {
 };
 
 export type HandleErrorInfo = {
-  componentName : ?string,
   componentStack : string,
 };
 
@@ -1084,7 +1083,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(config : HostConfig<T, P, 
         const instance = effectfulFiber.stateNode;
 
         const info : HandleErrorInfo = {
-          componentName: capturedError.componentName,
           componentStack: capturedError.componentStack,
         };
 


### PR DESCRIPTION
This information is probably more useful for custom redbox components than the call stack info we are already passing. Open to suggestions about the approach though. It is a little clunky compared to ReactFiberErrorLogger (but at least it's backwards compatible).