### PR TITLE
[Fiber] Don't deprioritize hidden trees when we're in sync mode

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -847,6 +847,7 @@ src/renderers/__tests__/ReactUpdates-test.js
 * handles reentrant mounting in synchronous mode
 * mounts and unmounts are sync even in a batch
 * does not re-render if state update is null
+* synchronously renders hidden subtrees
 
 src/renderers/__tests__/refs-destruction-test.js
 * should remove refs when destroying the parent

--- a/src/renderers/__tests__/ReactUpdates-test.js
+++ b/src/renderers/__tests__/ReactUpdates-test.js
@@ -1223,4 +1223,39 @@ describe('ReactUpdates', () => {
     instance.setState(() => null);
     expect(ops).toEqual([]);
   });
+
+  // Will change once we switch to async by default
+  it('synchronously renders hidden subtrees', () => {
+    let container = document.createElement('div');
+    let ops = [];
+
+    function Baz() {
+      ops.push('Baz');
+      return null;
+    }
+
+    function Bar() {
+      ops.push('Bar');
+      return null;
+    }
+
+    function Foo() {
+      ops.push('Foo');
+      return (
+        <div>
+          <div hidden={true}><Bar /></div>
+          <Baz />
+        </div>
+      );
+    }
+
+    // Mount
+    ReactDOM.render(<Foo />, container);
+    expect(ops).toEqual(['Foo', 'Bar', 'Baz']);
+    ops = [];
+
+    // Update
+    ReactDOM.render(<Foo />, container);
+    expect(ops).toEqual(['Foo', 'Bar', 'Baz']);
+  });
 });

--- a/src/renderers/__tests__/ReactUpdates-test.js
+++ b/src/renderers/__tests__/ReactUpdates-test.js
@@ -1194,15 +1194,16 @@ describe('ReactUpdates', () => {
     expect(mounts).toBe(1);
   });
 
-  it('mounts and unmounts are sync even in a batch', done => {
+  it('mounts and unmounts are sync even in a batch', () => {
+    var ops = [];
     var container = document.createElement('div');
     ReactDOM.unstable_batchedUpdates(() => {
       ReactDOM.render(<div>Hello</div>, container);
-      expect(container.textContent).toEqual('Hello');
+      ops.push(container.textContent);
       ReactDOM.unmountComponentAtNode(container);
-      expect(container.textContent).toEqual('');
-      done();
+      ops.push(container.textContent);
     });
+    expect(ops).toEqual(['Hello', '']);
   });
 
   it('does not re-render if state update is null', () => {
@@ -1226,7 +1227,7 @@ describe('ReactUpdates', () => {
 
   // Will change once we switch to async by default
   it('synchronously renders hidden subtrees', () => {
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     let ops = [];
 
     function Baz() {

--- a/src/renderers/art/ReactARTFiber.js
+++ b/src/renderers/art/ReactARTFiber.js
@@ -503,7 +503,7 @@ const ARTRenderer = ReactFiberReconciler({
     // Noop
   },
 
-  areChildrenOffscreen(type, props) {
+  shouldDeprioritizeSubtree(type, props) {
     return false;
   },
 

--- a/src/renderers/art/ReactARTFiber.js
+++ b/src/renderers/art/ReactARTFiber.js
@@ -503,7 +503,7 @@ const ARTRenderer = ReactFiberReconciler({
     // Noop
   },
 
-  areChildrenOffscreen(props : Props) {
+  areChildrenOffscreen(type, props) {
     return false;
   },
 

--- a/src/renderers/art/ReactARTFiber.js
+++ b/src/renderers/art/ReactARTFiber.js
@@ -503,6 +503,10 @@ const ARTRenderer = ReactFiberReconciler({
     // Noop
   },
 
+  areChildrenOffscreen(props : Props) {
+    return false;
+  },
+
   getRootHostContext() {
     return emptyObject;
   },

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -285,7 +285,7 @@ var DOMRenderer = ReactFiberReconciler({
     domElement.textContent = '';
   },
 
-  areChildrenOffscreen(props : Props) : boolean {
+  areChildrenOffscreen(type : string, props : Props) : boolean {
     return Boolean(props.hidden);
   },
 

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -285,7 +285,7 @@ var DOMRenderer = ReactFiberReconciler({
     domElement.textContent = '';
   },
 
-  areChildrenOffscreen(type : string, props : Props) : boolean {
+  shouldDeprioritizeSubtree(type : string, props : Props) : boolean {
     return Boolean(props.hidden);
   },
 

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -69,6 +69,7 @@ type Container = Element;
 type Props = {
   autoFocus ?: boolean,
   children ?: mixed,
+  hidden ?: boolean,
 };
 type Instance = Element;
 type TextInstance = Text;
@@ -282,6 +283,10 @@ var DOMRenderer = ReactFiberReconciler({
 
   resetTextContent(domElement : Instance) : void {
     domElement.textContent = '';
+  },
+
+  areChildrenOffscreen(props : Props) : boolean {
+    return Boolean(props.hidden);
   },
 
   createTextInstance(

--- a/src/renderers/native/ReactNativeFiber.js
+++ b/src/renderers/native/ReactNativeFiber.js
@@ -343,7 +343,7 @@ const NativeRenderer = ReactFiberReconciler({
     // Noop
   },
 
-  areChildrenOffscreen(props : Props) : boolean {
+  areChildrenOffscreen(type : string, props : Props) : boolean {
     return false;
   },
 

--- a/src/renderers/native/ReactNativeFiber.js
+++ b/src/renderers/native/ReactNativeFiber.js
@@ -343,7 +343,7 @@ const NativeRenderer = ReactFiberReconciler({
     // Noop
   },
 
-  areChildrenOffscreen(type : string, props : Props) : boolean {
+  shouldDeprioritizeSubtree(type : string, props : Props) : boolean {
     return false;
   },
 

--- a/src/renderers/native/ReactNativeFiber.js
+++ b/src/renderers/native/ReactNativeFiber.js
@@ -343,6 +343,10 @@ const NativeRenderer = ReactFiberReconciler({
     // Noop
   },
 
+  areChildrenOffscreen(props : Props) : boolean {
+    return false;
+  },
+
   scheduleAnimationCallback: global.requestAnimationFrame,
 
   scheduleDeferredCallback: global.requestIdleCallback,

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -101,7 +101,7 @@ var NoopRenderer = ReactFiberReconciler({
 
   resetTextContent(instance : Instance) : void {},
 
-  areChildrenOffscreen(type : string, props : Props) : boolean {
+  shouldDeprioritizeSubtree(type : string, props : Props) : boolean {
     return Boolean(props.hidden);
   },
 

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -101,7 +101,7 @@ var NoopRenderer = ReactFiberReconciler({
 
   resetTextContent(instance : Instance) : void {},
 
-  areChildrenOffscreen(props : Props) : boolean {
+  areChildrenOffscreen(type : string, props : Props) : boolean {
     return Boolean(props.hidden);
   },
 

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -35,7 +35,7 @@ var scheduledAnimationCallback = null;
 var scheduledDeferredCallback = null;
 
 type Container = { rootID: string, children: Array<Instance | TextInstance> };
-type Props = { prop: any };
+type Props = { prop: any, hidden ?: boolean };
 type Instance = {| type: string, id: number, children: Array<Instance | TextInstance>, prop: any |};
 type TextInstance = {| text: string, id: number |};
 
@@ -100,6 +100,10 @@ var NoopRenderer = ReactFiberReconciler({
   },
 
   resetTextContent(instance : Instance) : void {},
+
+  areChildrenOffscreen(props : Props) : boolean {
+    return Boolean(props.hidden);
+  },
 
   createTextInstance(
     text : string,

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -358,7 +358,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       }
     } else if (nextProps === null || memoizedProps === nextProps) {
       if (!useSyncScheduling &&
-          areChildrenOffscreen(memoizedProps) &&
+          areChildrenOffscreen(workInProgress.type, memoizedProps) &&
           workInProgress.pendingWorkPriority !== OffscreenPriority) {
         // This subtree still has work, but it should be deprioritized so we need
         // to bail out and not do any work yet.
@@ -400,7 +400,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     markRef(current, workInProgress);
 
     if (!useSyncScheduling &&
-        areChildrenOffscreen(nextProps) &&
+        areChildrenOffscreen(workInProgress.type, nextProps) &&
         workInProgress.pendingWorkPriority !== OffscreenPriority) {
       // If this host component is hidden, we can bail out on the children.
       // We'll rerender the children later at the lower priority.

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -77,7 +77,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   getPriorityContext : () => PriorityLevel,
 ) {
 
-  const { shouldSetTextContent } = config;
+  const { shouldSetTextContent, useSyncScheduling } = config;
 
   const {
     pushHostContext,
@@ -357,7 +357,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         );
       }
     } else if (nextProps === null || memoizedProps === nextProps) {
-      if (memoizedProps.hidden &&
+      if (!useSyncScheduling &&
+          memoizedProps.hidden &&
           workInProgress.pendingWorkPriority !== OffscreenPriority) {
         // This subtree still has work, but it should be deprioritized so we need
         // to bail out and not do any work yet.
@@ -398,7 +399,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
     markRef(current, workInProgress);
 
-    if (nextProps.hidden &&
+    if (!useSyncScheduling &&
+        nextProps.hidden &&
         workInProgress.pendingWorkPriority !== OffscreenPriority) {
       // If this host component is hidden, we can bail out on the children.
       // We'll rerender the children later at the lower priority.

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -77,7 +77,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   getPriorityContext : () => PriorityLevel,
 ) {
 
-  const { shouldSetTextContent, useSyncScheduling } = config;
+  const { shouldSetTextContent, useSyncScheduling, areChildrenOffscreen } = config;
 
   const {
     pushHostContext,
@@ -358,7 +358,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       }
     } else if (nextProps === null || memoizedProps === nextProps) {
       if (!useSyncScheduling &&
-          memoizedProps.hidden &&
+          areChildrenOffscreen(memoizedProps) &&
           workInProgress.pendingWorkPriority !== OffscreenPriority) {
         // This subtree still has work, but it should be deprioritized so we need
         // to bail out and not do any work yet.
@@ -400,7 +400,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     markRef(current, workInProgress);
 
     if (!useSyncScheduling &&
-        nextProps.hidden &&
+        areChildrenOffscreen(nextProps) &&
         workInProgress.pendingWorkPriority !== OffscreenPriority) {
       // If this host component is hidden, we can bail out on the children.
       // We'll rerender the children later at the lower priority.

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -77,7 +77,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   getPriorityContext : () => PriorityLevel,
 ) {
 
-  const { shouldSetTextContent, useSyncScheduling, areChildrenOffscreen } = config;
+  const { shouldSetTextContent, useSyncScheduling, shouldDeprioritizeSubtree } = config;
 
   const {
     pushHostContext,
@@ -358,7 +358,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       }
     } else if (nextProps === null || memoizedProps === nextProps) {
       if (!useSyncScheduling &&
-          areChildrenOffscreen(workInProgress.type, memoizedProps) &&
+          shouldDeprioritizeSubtree(workInProgress.type, memoizedProps) &&
           workInProgress.pendingWorkPriority !== OffscreenPriority) {
         // This subtree still has work, but it should be deprioritized so we need
         // to bail out and not do any work yet.
@@ -400,7 +400,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     markRef(current, workInProgress);
 
     if (!useSyncScheduling &&
-        areChildrenOffscreen(workInProgress.type, nextProps) &&
+        shouldDeprioritizeSubtree(workInProgress.type, nextProps) &&
         workInProgress.pendingWorkPriority !== OffscreenPriority) {
       // If this host component is hidden, we can bail out on the children.
       // We'll rerender the children later at the lower priority.

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -83,6 +83,7 @@ export type HostConfig<T, P, I, TI, PI, C, CX, PL> = {
 
   shouldSetTextContent(props : P) : boolean,
   resetTextContent(instance : I) : void,
+  areChildrenOffscreen(props : P) : boolean,
 
   createTextInstance(
     text : string,

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -83,7 +83,7 @@ export type HostConfig<T, P, I, TI, PI, C, CX, PL> = {
 
   shouldSetTextContent(props : P) : boolean,
   resetTextContent(instance : I) : void,
-  areChildrenOffscreen(props : P) : boolean,
+  areChildrenOffscreen(type : T, props : P) : boolean,
 
   createTextInstance(
     text : string,

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -83,7 +83,7 @@ export type HostConfig<T, P, I, TI, PI, C, CX, PL> = {
 
   shouldSetTextContent(props : P) : boolean,
   resetTextContent(instance : I) : void,
-  areChildrenOffscreen(type : T, props : P) : boolean,
+  shouldDeprioritizeSubtree(type : T, props : P) : boolean,
 
   createTextInstance(
     text : string,

--- a/src/renderers/testing/ReactTestRendererFiber.js
+++ b/src/renderers/testing/ReactTestRendererFiber.js
@@ -150,7 +150,7 @@ var TestRenderer = ReactFiberReconciler({
     // noop
   },
 
-  areChildrenOffscreen(type: string, props : Props) : boolean {
+  shouldDeprioritizeSubtree(type: string, props : Props) : boolean {
     return false;
   },
 

--- a/src/renderers/testing/ReactTestRendererFiber.js
+++ b/src/renderers/testing/ReactTestRendererFiber.js
@@ -150,7 +150,7 @@ var TestRenderer = ReactFiberReconciler({
     // noop
   },
 
-  areChildrenOffscreen(props : Props) : boolean {
+  areChildrenOffscreen(type: string, props : Props) : boolean {
     return false;
   },
 

--- a/src/renderers/testing/ReactTestRendererFiber.js
+++ b/src/renderers/testing/ReactTestRendererFiber.js
@@ -150,6 +150,10 @@ var TestRenderer = ReactFiberReconciler({
     // noop
   },
 
+  areChildrenOffscreen(props : Props) : boolean {
+    return false;
+  },
+
   createTextInstance(
     text : string,
     rootContainerInstance : Container,


### PR DESCRIPTION
When `useSyncScheduling` is set to true (as it is in the DOM renderer), we shouldn't give OffscreenPriority to hidden subtrees. Everything should be sync/task.
