### PR TITLE
Fix production propTypes test so it works with error code system

### DIFF
--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -142,5 +142,6 @@
   "140": "Expected hook events to fire for the child before its parent includes it in onSetChildren().",
   "141": "Expected onSetChildren() to fire for a container child before its parent includes it in onSetChildren().",
   "142": "Expected onBeforeMountComponent() parent and onSetChildren() to be consistent (%s has parents %s and %s).",
-  "143": "React.Children.only expected to receive a single React element child."
+  "143": "React.Children.only expected to receive a single React element child.",
+  "144": "React.PropTypes type checking code is stripped in production."
 }

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypesProduction-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypesProduction-test.js
@@ -49,7 +49,7 @@ describe('ReactPropTypesProduction', function() {
         'prop'
       );
     }).toThrowError(
-      'React.PropTypes type checking code is stripped in production.'
+      'Minified React error #144'
     );
   }
 


### PR DESCRIPTION
Test expects the unminified error message. Without this fix the test will break after the next release.