### PR TITLE
[Fiber] Don't schedule class fibers without relevant lifecycles for commit

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -227,17 +227,6 @@ module.exports = function(
     }
   }
 
-  function markUpdateIfAlreadyInProgress(current: Fiber | null, workInProgress : Fiber) {
-    // If an update was already in progress, we should schedule an Update
-    // effect even though we're bailing out, so that cWU/cDU are called.
-    if (current !== null && typeof instance.componentDidUpdate === 'function') {
-      if (workInProgress.memoizedProps !== current.memoizedProps ||
-          workInProgress.memoizedState !== current.memoizedState) {
-        workInProgress.effectTag |= Update;
-      }
-    }
-  }
-
   function resetInputPointers(workInProgress : Fiber, instance : any) {
     instance.props = workInProgress.memoizedProps;
     instance.state = workInProgress.memoizedState;
@@ -446,7 +435,14 @@ module.exports = function(
         oldState === newState &&
         !hasContextChanged() &&
         !(updateQueue !== null && updateQueue.hasForceUpdate)) {
-      markUpdateIfAlreadyInProgress(current, workInProgress);
+      // If an update was already in progress, we should schedule an Update
+      // effect even though we're bailing out, so that cWU/cDU are called.
+      if (typeof instance.componentDidUpdate === 'function') {
+        if (oldProps !== current.memoizedProps ||
+            oldState !== current.memoizedState) {
+          workInProgress.effectTag |= Update;
+        }
+      }
       return false;
     }
 
@@ -467,7 +463,14 @@ module.exports = function(
         workInProgress.effectTag |= Update;
       }
     } else {
-      markUpdateIfAlreadyInProgress(current, workInProgress);
+      // If an update was already in progress, we should schedule an Update
+      // effect even though we're bailing out, so that cWU/cDU are called.
+      if (typeof instance.componentDidUpdate === 'function') {
+        if (oldProps !== current.memoizedProps ||
+            oldState !== current.memoizedState) {
+          workInProgress.effectTag |= Update;
+        }
+      }
 
       // If shouldComponentUpdate returned false, we should still update the
       // memoized props/state to indicate that this work can be reused.

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -231,17 +231,10 @@ module.exports = function(
   function markUpdateIfNecessary(workInProgress) {
     const current = workInProgress.alternate;
     const instance = workInProgress.stateNode;
-    let shouldMarkUpdate = false;
-    if (current) {
-      if (typeof instance.componentDidUpdate === 'function') {
-        shouldMarkUpdate = true;
-      }
-    } else {
-      if (typeof instance.componentDidMount === 'function') {
-        shouldMarkUpdate = true;
-      }
+    if (!current && typeof instance.componentDidMount !== 'function') {
+      return;
     }
-    if (!shouldMarkUpdate) {
+    if (current && typeof instance.componentDidUpdate !== 'function') {
       return;
     }
     workInProgress.effectTag |= Update;

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -231,12 +231,18 @@ module.exports = function(
   function markUpdateIfNecessary(workInProgress) {
     const current = workInProgress.alternate;
     const instance = workInProgress.stateNode;
-    if (!current && typeof instance.componentDidMount !== 'function') {
-      return;
+    if (current !== null) {
+      if (typeof instance.componentDidUpdate !== 'function') {
+        // Update without a lifecycle
+        return;
+      }
+    } else {
+      if (typeof instance.componentDidMount !== 'function') {
+        // Mount without a lifecycle
+        return;
+      }
     }
-    if (current && typeof instance.componentDidUpdate !== 'function') {
-      return;
-    }
+    // We use the Update tag both for didMount and didUpdate lifecycles.
     workInProgress.effectTag |= Update;
   }
 

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -233,16 +233,10 @@ module.exports = function(
     const instance = workInProgress.stateNode;
     let shouldMarkUpdate = false;
     if (current) {
-      // During an update, we might either need to detach a ref
-      // or to call the componentDidUpdate() hook in the commit phase.
-      const currentRef = current.ref;
-      if (currentRef !== null && currentRef !== workInProgress.ref) {
-        shouldMarkUpdate = true;
-      } else if (typeof instance.componentDidUpdate === 'function') {
+      if (typeof instance.componentDidUpdate === 'function') {
         shouldMarkUpdate = true;
       }
     } else {
-      // During mounting, we only need to call the componentDidMount hook.
       if (typeof instance.componentDidMount === 'function') {
         shouldMarkUpdate = true;
       }

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -87,16 +87,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
-  // Only called during update. It's ok to throw.
-  function detachRefIfNeeded(current : Fiber | null, finishedWork : Fiber) {
-    if (current) {
-      const currentRef = current.ref;
-      if (currentRef !== null && currentRef !== finishedWork.ref) {
-        currentRef(null);
-      }
-    }
-  }
-
   function getHostParent(fiber : Fiber) : I | C {
     let parent = fiber.return;
     while (parent !== null) {
@@ -381,7 +371,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   function commitWork(current : Fiber | null, finishedWork : Fiber) : void {
     switch (finishedWork.tag) {
       case ClassComponent: {
-        detachRefIfNeeded(current, finishedWork);
         return;
       }
       case HostComponent: {
@@ -398,7 +387,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
             commitUpdate(instance, updatePayload, type, oldProps, newProps, finishedWork);
           }
         }
-        detachRefIfNeeded(current, finishedWork);
         return;
       }
       case HostText: {
@@ -435,15 +423,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         const instance = finishedWork.stateNode;
         if (finishedWork.effectTag & Update) {
           if (current === null) {
-            if (typeof instance.componentDidMount === 'function') {
-              instance.componentDidMount();
-            }
+            instance.componentDidMount();
           } else {
-            if (typeof instance.componentDidUpdate === 'function') {
-              const prevProps = current.memoizedProps;
-              const prevState = current.memoizedState;
-              instance.componentDidUpdate(prevProps, prevState);
-            }
+            const prevProps = current.memoizedProps;
+            const prevState = current.memoizedState;
+            instance.componentDidUpdate(prevProps, prevState);
           }
         }
         if ((finishedWork.effectTag & Callback) && finishedWork.updateQueue !== null) {
@@ -495,14 +479,18 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
-  function commitRef(finishedWork : Fiber) {
-    if (finishedWork.tag !== ClassComponent && finishedWork.tag !== HostComponent) {
-      return;
-    }
+  function commitAttachRef(finishedWork : Fiber) {
     const ref = finishedWork.ref;
     if (ref !== null) {
       const instance = getPublicInstance(finishedWork.stateNode);
       ref(instance);
+    }
+  }
+
+  function commitDetachRef(current) {
+    const currentRef = current.ref;
+    if (currentRef !== null) {
+      currentRef(null);
     }
   }
 
@@ -511,7 +499,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     commitDeletion,
     commitWork,
     commitLifeCycles,
-    commitRef,
+    commitAttachRef,
+    commitDetachRef,
   };
 
 };

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -487,7 +487,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
-  function commitDetachRef(current) {
+  function commitDetachRef(current : Fiber) {
     const currentRef = current.ref;
     if (currentRef !== null) {
       currentRef(null);

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -85,6 +85,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     workInProgress.effectTag |= Update;
   }
 
+  function markRef(workInProgress : Fiber) {
+    workInProgress.effectTag |= Ref;
+  }
+
   function appendAllYields(yields : Array<mixed>, workInProgress : Fiber) {
     let node = workInProgress.stateNode;
     if (node) {
@@ -231,8 +235,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           workInProgress.updateQueue = (updatePayload : any);
           // If the update payload indicates that there is a change or if there
           // is a new ref we mark this as an update.
-          if (updatePayload || current.ref !== workInProgress.ref) {
+          if (updatePayload) {
             markUpdate(workInProgress);
+          }
+          if (current.ref !== workInProgress.ref) {
+            markRef(workInProgress);
           }
         } else {
           if (!newProps) {
@@ -270,7 +277,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           workInProgress.stateNode = instance;
           if (workInProgress.ref !== null) {
             // If there is a ref on a host node we need to schedule a callback
-            workInProgress.effectTag |= Ref;
+            markRef(workInProgress);
           }
         }
         return null;


### PR DESCRIPTION
While working on #9071, I noticed that we're scheduling `Update` effect for all classes, regardless of whether they have something to do in the commit phase:

<img width="591" alt="screen shot 2017-03-03 at 7 46 52 pm" src="https://cloud.githubusercontent.com/assets/810438/23566537/31084ada-004a-11e7-9b62-9163be86c4f2.png">

(The `JSONArrow` class doesn't have lifecycle methods.)

To fix this, I am checking whether there's work to do before marking a fiber with the `Update` tag. This mirrors the logic in the commit phase.

To verify, I ran the same code with the new bundle, and now only class fibers with corresponding lifecycles are scheduled in the effect list:

<img width="352" alt="screen shot 2017-03-03 at 7 45 09 pm" src="https://cloud.githubusercontent.com/assets/810438/23566593/875046ea-004a-11e7-9973-3e201b2a0aff.png">

This is a perf optimization and is unobservable from tests.