### PR TITLE
Fix erroneous DOM updates when setting textarea value

### DIFF
--- a/src/renderers/dom/stack/client/wrappers/ReactDOMTextarea.js
+++ b/src/renderers/dom/stack/client/wrappers/ReactDOMTextarea.js
@@ -137,9 +137,6 @@ var ReactDOMTextarea = {
       if (newValue !== node.value) {
         node.value = newValue;
       }
-      if (props.defaultValue == null) {
-        node.defaultValue = newValue;
-      }
     }
     if (props.defaultValue != null) {
       node.defaultValue = props.defaultValue;


### PR DESCRIPTION
Currently upon setting state from a parent component and thus triggering a re-render of a `textarea`, the `textarea` always erroneously updates the DOM by removing and subsequently adding the `value` field in two separate updates, even if you don't change the `value` or `defaultValue` props handed to it.

It turned out `updateWrapper` was trying to simultaneously set both `value` and `defaultValue` to whatever your new `value` was, even if `defaultValue` was `undefined`. Removing the second part fixed this flashing behaviour by removing the unnecessary DOM updates.