### PR TITLE
Remove EventPluginRegistry.getPluginModuleForEvent

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1656,7 +1656,6 @@ src/renderers/shared/shared/event/__tests__/EventPluginRegistry-test.js
 * should publish registration names of injected plugins
 * should throw if multiple registration names collide
 * should throw if an invalid event is published
-* should be able to get the plugin from synthetic events
 
 src/renderers/shared/shared/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
 * should do nothing when no one wants to respond

--- a/src/renderers/shared/shared/event/EventPluginRegistry.js
+++ b/src/renderers/shared/shared/event/EventPluginRegistry.js
@@ -14,7 +14,6 @@
 
 import type {
   DispatchConfig,
-  ReactSyntheticEvent,
 } from 'ReactSyntheticEventType';
 
 import type {
@@ -255,41 +254,6 @@ var EventPluginRegistry = {
     if (isOrderingDirty) {
       recomputePluginOrdering();
     }
-  },
-
-  /**
-   * Looks up the plugin for the supplied event.
-   *
-   * @param {object} event A synthetic event.
-   * @return {?object} The plugin that created the supplied event.
-   * @internal
-   */
-  getPluginModuleForEvent: function(
-    event: ReactSyntheticEvent,
-  ): null | PluginModule<AnyNativeEvent> {
-    var dispatchConfig = event.dispatchConfig;
-    if (dispatchConfig.registrationName) {
-      return EventPluginRegistry.registrationNameModules[
-        dispatchConfig.registrationName
-      ] || null;
-    }
-    if (dispatchConfig.phasedRegistrationNames !== undefined) {
-      // pulling phasedRegistrationNames out of dispatchConfig helps Flow see
-      // that it is not undefined.
-      var {phasedRegistrationNames} = dispatchConfig;
-      for (var phase in phasedRegistrationNames) {
-        if (!phasedRegistrationNames.hasOwnProperty(phase)) {
-          continue;
-        }
-        var pluginModule = EventPluginRegistry.registrationNameModules[
-          phasedRegistrationNames[phase]
-        ];
-        if (pluginModule) {
-          return pluginModule;
-        }
-      }
-    }
-    return null;
   },
 
   /**

--- a/src/renderers/shared/shared/event/__tests__/EventPluginRegistry-test.js
+++ b/src/renderers/shared/shared/event/__tests__/EventPluginRegistry-test.js
@@ -225,40 +225,4 @@ describe('EventPluginRegistry', () => {
       '`one`.'
     );
   });
-
-  it('should be able to get the plugin from synthetic events', () => {
-    var clickDispatchConfig = {
-      registrationName: 'onClick',
-    };
-    var magicDispatchConfig = {
-      phasedRegistrationNames: {
-        bubbled: 'onMagicBubble',
-        captured: 'onMagicCapture',
-      },
-    };
-
-    var OnePlugin = createPlugin({
-      eventTypes: {
-        click: clickDispatchConfig,
-        magic: magicDispatchConfig,
-      },
-    });
-
-    var clickEvent = {dispatchConfig: clickDispatchConfig};
-    var magicEvent = {dispatchConfig: magicDispatchConfig};
-
-    expect(EventPluginRegistry.getPluginModuleForEvent(clickEvent)).toBe(null);
-    expect(EventPluginRegistry.getPluginModuleForEvent(magicEvent)).toBe(null);
-
-    EventPluginRegistry.injectEventPluginsByName({one: OnePlugin});
-    EventPluginRegistry.injectEventPluginOrder(['one']);
-
-    expect(
-      EventPluginRegistry.getPluginModuleForEvent(clickEvent)
-    ).toBe(OnePlugin);
-    expect(
-      EventPluginRegistry.getPluginModuleForEvent(magicEvent)
-    ).toBe(OnePlugin);
-  });
-
 });


### PR DESCRIPTION
At no point in the event system do we use `getPluginModuleForEvent` to get the corresponding event plugin for a synthetic event, so I believe this can be removed 🎈 