### PR TITLE
Remove _resetEventPlugins, use jest.resetModuleRegistry

### DIFF
--- a/src/renderers/shared/shared/event/EventPluginRegistry.js
+++ b/src/renderers/shared/shared/event/EventPluginRegistry.js
@@ -257,43 +257,42 @@ var EventPluginRegistry = {
   },
 
   /**
+<<<<<<< HEAD
    * Exposed for unit testing.
-   * @private
+=======
+   * Looks up the plugin for the supplied event.
+   *
+   * @param {object} event A synthetic event.
+   * @return {?object} The plugin that created the supplied event.
+   * @internal
    */
-  _resetEventPlugins: function(): void {
-    eventPluginOrder = null;
-    for (var pluginName in namesToPlugins) {
-      if (namesToPlugins.hasOwnProperty(pluginName)) {
-        delete namesToPlugins[pluginName];
-      }
+  getPluginModuleForEvent: function(
+    event: ReactSyntheticEvent,
+  ): null | PluginModule<AnyNativeEvent> {
+    var dispatchConfig = event.dispatchConfig;
+    if (dispatchConfig.registrationName) {
+      return EventPluginRegistry.registrationNameModules[
+        dispatchConfig.registrationName
+      ] || null;
     }
-    EventPluginRegistry.plugins.length = 0;
-
-    var eventNameDispatchConfigs = EventPluginRegistry.eventNameDispatchConfigs;
-    for (var eventName in eventNameDispatchConfigs) {
-      if (eventNameDispatchConfigs.hasOwnProperty(eventName)) {
-        delete eventNameDispatchConfigs[eventName];
-      }
-    }
-
-    var registrationNameModules = EventPluginRegistry.registrationNameModules;
-    for (var registrationName in registrationNameModules) {
-      if (registrationNameModules.hasOwnProperty(registrationName)) {
-        delete registrationNameModules[registrationName];
-      }
-    }
-
-    if (__DEV__) {
-      var possibleRegistrationNames =
-        EventPluginRegistry.possibleRegistrationNames;
-      for (var lowerCasedName in possibleRegistrationNames) {
-        if (possibleRegistrationNames.hasOwnProperty(lowerCasedName)) {
-          delete possibleRegistrationNames[lowerCasedName];
+    if (dispatchConfig.phasedRegistrationNames !== undefined) {
+      // pulling phasedRegistrationNames out of dispatchConfig helps Flow see
+      // that it is not undefined.
+      var {phasedRegistrationNames} = dispatchConfig;
+      for (var phase in phasedRegistrationNames) {
+        if (!phasedRegistrationNames.hasOwnProperty(phase)) {
+          continue;
+        }
+        var pluginModule = EventPluginRegistry.registrationNameModules[
+          phasedRegistrationNames[phase]
+        ];
+        if (pluginModule) {
+          return pluginModule;
         }
       }
     }
+    return null;
   },
-
 };
 
 module.exports = EventPluginRegistry;

--- a/src/renderers/shared/shared/event/EventPluginRegistry.js
+++ b/src/renderers/shared/shared/event/EventPluginRegistry.js
@@ -255,44 +255,6 @@ var EventPluginRegistry = {
       recomputePluginOrdering();
     }
   },
-
-  /**
-<<<<<<< HEAD
-   * Exposed for unit testing.
-=======
-   * Looks up the plugin for the supplied event.
-   *
-   * @param {object} event A synthetic event.
-   * @return {?object} The plugin that created the supplied event.
-   * @internal
-   */
-  getPluginModuleForEvent: function(
-    event: ReactSyntheticEvent,
-  ): null | PluginModule<AnyNativeEvent> {
-    var dispatchConfig = event.dispatchConfig;
-    if (dispatchConfig.registrationName) {
-      return EventPluginRegistry.registrationNameModules[
-        dispatchConfig.registrationName
-      ] || null;
-    }
-    if (dispatchConfig.phasedRegistrationNames !== undefined) {
-      // pulling phasedRegistrationNames out of dispatchConfig helps Flow see
-      // that it is not undefined.
-      var {phasedRegistrationNames} = dispatchConfig;
-      for (var phase in phasedRegistrationNames) {
-        if (!phasedRegistrationNames.hasOwnProperty(phase)) {
-          continue;
-        }
-        var pluginModule = EventPluginRegistry.registrationNameModules[
-          phasedRegistrationNames[phase]
-        ];
-        if (pluginModule) {
-          return pluginModule;
-        }
-      }
-    }
-    return null;
-  },
 };
 
 module.exports = EventPluginRegistry;

--- a/src/renderers/shared/shared/event/__tests__/EventPluginRegistry-test.js
+++ b/src/renderers/shared/shared/event/__tests__/EventPluginRegistry-test.js
@@ -17,8 +17,8 @@ describe('EventPluginRegistry', () => {
   var createPlugin;
 
   beforeEach(() => {
+    jest.resetModuleRegistry();
     EventPluginRegistry = require('EventPluginRegistry');
-    EventPluginRegistry._resetEventPlugins();
 
     createPlugin = function(properties) {
       return Object.assign({extractEvents: function() {}}, properties);


### PR DESCRIPTION
This isn't called at runtime and is only used in [internal unit tests](https://github.com/facebook/react/blob/e3131c1d55d6695c2f0966379535f88b813f912b/src/renderers/shared/shared/event/__tests__/EventPluginRegistry-test.js#L21). Despite that, it's currently being included in production builds. This change ~~makes it so only exists DEV~~ removes it and uses `jest.resetModuleRegistry` in its place.

~~We might even want to go a step further and define it in our test suite instead since it serves no purpose in DEV either. If that's acceptable, I can update the PR with that approach which seems preferable.~~

```
   raw     gz Compared to last run
  +115    +28 build/react-dom-fiber.js
  -243    -50 build/react-dom-fiber.min.js
  +115    +29 build/react-dom-server.js
  -242    -45 build/react-dom-server.min.js
  +115    +29 build/react-dom.js
  -242    -53 build/react-dom.min.js
     =      = build/react-with-addons.js
     =      = build/react-with-addons.min.js
     =      = build/react.js
     =      = build/react.min.js
```