### PR TITLE
Remove PR check from GH Pages build hook for stable branch

### DIFF
--- a/scripts/circleci/build_gh_pages.sh
+++ b/scripts/circleci/build_gh_pages.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ -z $CI_PULL_REQUEST ] && [ "$CIRCLE_BRANCH" = "$REACT_WEBSITE_BRANCH" ]; then
+if [ "$CIRCLE_BRANCH" = "$REACT_WEBSITE_BRANCH" ]; then
 
   GH_PAGES_DIR=`pwd`/../react-gh-pages
 


### PR DESCRIPTION
Circle seems to detect wrong PR numbers on commits in `15-stable`:

<img width="267" alt="screen shot 2017-03-09 at 11 41 12 pm" src="https://cloud.githubusercontent.com/assets/810438/23775714/ee335880-0521-11e7-9d41-6982e3ee0d14.png">

https://github.com/facebook/react/pull/8988 doesn’t exist for some reason.

Anyway, this seems to prevent the build of the docs: https://circleci.com/gh/facebook/react/1804

<img width="370" alt="screen shot 2017-03-09 at 11 37 27 pm" src="https://cloud.githubusercontent.com/assets/810438/23775740/0ebbb962-0522-11e7-948a-9d01da478ad4.png">

Do we need this check?