### PR TITLE
[Fiber] Remove unnecessary second getComponentName()

### DIFF
--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -40,7 +40,7 @@ var ReactCurrentOwner = require('react/lib/ReactCurrentOwner');
 
 if (__DEV__) {
   var { getCurrentFiberStackAddendum } = require('ReactDebugCurrentFiber');
-  var { getComponentName } = require('ReactFiberTreeReflection');
+  var getComponentName = require('getComponentName');
   var warning = require('fbjs/lib/warning');
   var didWarnAboutMaps = false;
 }

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -31,9 +31,10 @@ var {
   beginUpdateQueue,
 } = require('ReactFiberUpdateQueue');
 var { hasContextChanged } = require('ReactFiberContext');
-var { getComponentName, isMounted } = require('ReactFiberTreeReflection');
+var { isMounted } = require('ReactFiberTreeReflection');
 var ReactInstanceMap = require('ReactInstanceMap');
 var emptyObject = require('fbjs/lib/emptyObject');
+var getComponentName = require('getComponentName');
 var shallowEqual = require('fbjs/lib/shallowEqual');
 var invariant = require('fbjs/lib/invariant');
 
@@ -119,7 +120,7 @@ module.exports = function(
           shouldUpdate !== undefined,
           '%s.shouldComponentUpdate(): Returned undefined instead of a ' +
           'boolean value. Make sure to return true or false.',
-          getComponentName(workInProgress)
+          getComponentName(workInProgress) || 'Unknown'
         );
       }
 

--- a/src/renderers/shared/fiber/ReactFiberContext.js
+++ b/src/renderers/shared/fiber/ReactFiberContext.js
@@ -16,10 +16,10 @@ import type { Fiber } from 'ReactFiber';
 import type { StackCursor } from 'ReactFiberStack';
 
 var emptyObject = require('fbjs/lib/emptyObject');
+var getComponentName = require('getComponentName');
 var invariant = require('fbjs/lib/invariant');
 var warning = require('fbjs/lib/warning');
 var {
-  getComponentName,
   isFiberMounted,
 } = require('ReactFiberTreeReflection');
 var {
@@ -96,7 +96,7 @@ exports.getMaskedContext = function(workInProgress : Fiber, unmaskedContext : Ob
   }
 
   if (__DEV__) {
-    const name = getComponentName(workInProgress);
+    const name = getComponentName(workInProgress) || 'Unknown';
     ReactDebugCurrentFrame.current = workInProgress;
     checkReactTypeSpec(contextTypes, context, 'context', name);
     ReactDebugCurrentFrame.current = null;
@@ -156,7 +156,7 @@ function processChildContext(fiber : Fiber, parentContext : Object, isReconcilin
   // It has only been added in Fiber to match the (unintentional) behavior in Stack.
   if (typeof instance.getChildContext !== 'function') {
     if (__DEV__) {
-      const componentName = getComponentName(fiber);
+      const componentName = getComponentName(fiber) || 'Unknown';
 
       if (!warnedAboutMissingGetChildContext[componentName]) {
         warnedAboutMissingGetChildContext[componentName] = true;
@@ -187,12 +187,12 @@ function processChildContext(fiber : Fiber, parentContext : Object, isReconcilin
     invariant(
       contextKey in childContextTypes,
       '%s.getChildContext(): key "%s" is not defined in childContextTypes.',
-      getComponentName(fiber),
+      getComponentName(fiber) || 'Unknown',
       contextKey
     );
   }
   if (__DEV__) {
-    const name = getComponentName(fiber);
+    const name = getComponentName(fiber) || 'Unknown';
     // We can only provide accurate element stacks if we pass work-in-progress tree
     // during the begin or complete phase. However currently this function is also
     // called from unstable_renderSubtree legacy implementation. In this case it unsafe to

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -148,9 +148,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
   function scheduleTopLevelUpdate(current : Fiber, element : ReactNodeList, callback : ?Function) {
     if (__DEV__) {
-      if (ReactDebugCurrentFiber.current !== null) {
+      if (
+        ReactDebugCurrentFiber.phase === 'render' &&
+        ReactDebugCurrentFiber.current !== null
+      ) {
         warning(
-          ReactDebugCurrentFiber.phase !== 'render',
+          false,
           'Render methods should be a pure function of props and state; ' +
           'triggering nested component updates from render is not allowed. ' +
           'If necessary, trigger nested updates in componentDidUpdate.\n\n' +

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -33,7 +33,7 @@ if (__DEV__) {
   var warning = require('fbjs/lib/warning');
   var ReactFiberInstrumentation = require('ReactFiberInstrumentation');
   var ReactDebugCurrentFiber = require('ReactDebugCurrentFiber');
-  var { getComponentName } = require('ReactFiberTreeReflection');
+  var getComponentName = require('getComponentName');
 }
 
 var { findCurrentHostFiber } = require('ReactFiberTreeReflection');
@@ -155,7 +155,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           'triggering nested component updates from render is not allowed. ' +
           'If necessary, trigger nested updates in componentDidUpdate.\n\n' +
           'Check the render method of %s.',
-          getComponentName(ReactDebugCurrentFiber.current)
+          getComponentName(ReactDebugCurrentFiber.current) || 'Unknown'
         );
       }
     }

--- a/src/renderers/shared/fiber/ReactFiberTreeReflection.js
+++ b/src/renderers/shared/fiber/ReactFiberTreeReflection.js
@@ -17,6 +17,7 @@ import type { Fiber } from 'ReactFiber';
 var ReactInstanceMap = require('ReactInstanceMap');
 var ReactCurrentOwner = require('react/lib/ReactCurrentOwner');
 
+var getComponentName = require('getComponentName');
 var invariant = require('fbjs/lib/invariant');
 
 if (__DEV__) {
@@ -84,7 +85,7 @@ exports.isMounted = function(component : ReactComponent<any, any, any>) : boolea
         'never access something that requires stale data from the previous ' +
         'render, such as refs. Move this logic to componentDidMount and ' +
         'componentDidUpdate instead.',
-        getComponentName(ownerFiber)
+        getComponentName(ownerFiber) || 'A component'
       );
       instance._warnedAboutRefsInRender = true;
     }
@@ -266,15 +267,3 @@ exports.findCurrentHostFiber = function(parent : Fiber) : Fiber | null {
   // eslint-disable-next-line no-unreachable
   return null;
 };
-
-function getComponentName(fiber: Fiber): string {
-  const type = fiber.type;
-  const instance = fiber.stateNode;
-  const constructor = instance && instance.constructor;
-  return (
-    type.displayName || (constructor && constructor.displayName) ||
-    type.name || (constructor && constructor.name) ||
-    'A Component'
-  );
-}
-exports.getComponentName = getComponentName;


### PR DESCRIPTION
We already have one. The other one is also less fragile and doesn't throw on `null` type.
I don’t really have a test for this specifically but I don’t think we’ll be breaking that again.

Additionally, simplified the check since it’s unnecessary to call `getComponentName` for every update.