### PR TITLE
Add DEV mode note to installation doc (#8784)

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -47,6 +47,10 @@ While React [can be used](/react/docs/react-without-es6.html) without a build pi
 
 ### Installing React
 
+>**Note:**
+>
+>Once installed, we strongly recommend setting the [production mode flags](/react/docs/optimizing-performance.html) to ensure you're using the fast version of React in production.
+
 We recommend using [Yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/) for managing front-end dependencies. If you're new to package managers, the [Yarn documentation](https://yarnpkg.com/en/docs/getting-started) is a good place to get started.
 
 To install React with Yarn, run:

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -49,7 +49,7 @@ While React [can be used](/react/docs/react-without-es6.html) without a build pi
 
 >**Note:**
 >
->Once installed, we strongly recommend setting the [production mode flags](/react/docs/optimizing-performance.html) to ensure you're using the fast version of React in production.
+>Once installed, we strongly recommend setting up a [production build process](/react/docs/optimizing-performance.html) to ensure you're using the fast version of React in production.
 
 We recommend using [Yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/) for managing front-end dependencies. If you're new to package managers, the [Yarn documentation](https://yarnpkg.com/en/docs/getting-started) is a good place to get started.
 


### PR DESCRIPTION
@gaearon First pass at adding a note to the installation guide reminding folks to use production mode flags. I've initially placed this before the install steps as it's a pretty prominent place. Any feedback welcome.

![image](https://cloud.githubusercontent.com/assets/110953/23820994/2ab46cf4-05db-11e7-9b94-da68a6ec4ff9.png)
