### PR TITLE
Fix error code transform to look for fbjs/lib/invariant

### DIFF
--- a/scripts/error-codes/__tests__/dev-expression-with-codes-test.js
+++ b/scripts/error-codes/__tests__/dev-expression-with-codes-test.js
@@ -55,19 +55,10 @@ if (process.env.NODE_ENV !== 'production') {
     );
   });
 
-  it("should add `reactProdInvariant` when it finds `require('fbjs/lib/invariant')`", () => {
-    compare(
-"var invariant = require('fbjs/lib/invariant');",
-
-`var _prodInvariant = require('reactProdInvariant');
-
-var invariant = require('fbjs/lib/invariant');`
-    );
-  });
-
-  it('should replace simple invariant calls', () => {
+  it('should add a require statement and replace simple invariant calls', () => {
     compare(
       "invariant(condition, 'Do not override existing functions.');",
+
       "var _prodInvariant = require('reactProdInvariant');\n\n" +
       "!condition ? " +
       "process.env.NODE_ENV !== 'production' ? " +

--- a/scripts/error-codes/__tests__/dev-expression-with-codes-test.js
+++ b/scripts/error-codes/__tests__/dev-expression-with-codes-test.js
@@ -55,13 +55,13 @@ if (process.env.NODE_ENV !== 'production') {
     );
   });
 
-  it("should add `reactProdInvariant` when it finds `require('invariant')`", () => {
+  it("should add `reactProdInvariant` when it finds `require('fbjs/lib/invariant')`", () => {
     compare(
-"var invariant = require('invariant');",
+"var invariant = require('fbjs/lib/invariant');",
 
 `var _prodInvariant = require('reactProdInvariant');
 
-var invariant = require('invariant');`
+var invariant = require('fbjs/lib/invariant');`
     );
   });
 
@@ -85,13 +85,13 @@ var invariant = require('invariant');`
     );
 
     compare(
-`var invariant = require('invariant');
+`var invariant = require('fbjs/lib/invariant');
 invariant(condition, 'Do not override existing functions.');
 invariant(condition, 'Do not override existing functions.');`,
 
 `var _prodInvariant = require('reactProdInvariant');
 
-var invariant = require('invariant');
+var invariant = require('fbjs/lib/invariant');
 ${expectedInvariantTransformResult}
 ${expectedInvariantTransformResult}`
     );

--- a/scripts/error-codes/dev-expression-with-codes.js
+++ b/scripts/error-codes/dev-expression-with-codes.js
@@ -79,7 +79,7 @@ module.exports = function(babel) {
           if (
             path.get('callee').isIdentifier({name: 'require'}) &&
             path.get('arguments')[0] &&
-            path.get('arguments')[0].isStringLiteral({value: 'invariant'})
+            path.get('arguments')[0].isStringLiteral({value: 'fbjs/lib/invariant'})
           ) {
             node[SEEN_SYMBOL] = true;
             getProdInvariantIdentifier(path, this);

--- a/scripts/error-codes/dev-expression-with-codes.js
+++ b/scripts/error-codes/dev-expression-with-codes.js
@@ -19,8 +19,8 @@ module.exports = function(babel) {
 
   var SEEN_SYMBOL = Symbol('dev-expression-with-codes.seen');
 
-  // Generate a hygienic identifier
-  function getProdInvariantIdentifier(path, localState) {
+  // Generate or get a hygienic variable name
+  function createOrGetProdInvariantIdentifier(path, localState) {
     if (!localState.prodInvariantIdentifier) {
       localState.prodInvariantIdentifier = path.scope.generateUidIdentifier('prodInvariant');
       path.scope.getProgramParent().push({
@@ -76,14 +76,7 @@ module.exports = function(babel) {
           // Insert `var PROD_INVARIANT = require('reactProdInvariant');`
           // before all `require('invariant')`s.
           // NOTE it doesn't support ES6 imports yet.
-          if (
-            path.get('callee').isIdentifier({name: 'require'}) &&
-            path.get('arguments')[0] &&
-            path.get('arguments')[0].isStringLiteral({value: 'fbjs/lib/invariant'})
-          ) {
-            node[SEEN_SYMBOL] = true;
-            getProdInvariantIdentifier(path, this);
-          } else if (path.get('callee').isIdentifier({name: 'invariant'})) {
+          if (path.get('callee').isIdentifier({name: 'invariant'})) {
             // Turns this code:
             //
             // invariant(condition, argument, 'foo', 'bar');
@@ -138,7 +131,7 @@ module.exports = function(babel) {
 
             devInvariant[SEEN_SYMBOL] = true;
 
-            var localInvariantId = getProdInvariantIdentifier(path, this);
+            var localInvariantId = createOrGetProdInvariantIdentifier(path, this);
             var prodInvariant = t.callExpression(localInvariantId, [
               t.stringLiteral(prodErrorId),
             ].concat(node.arguments.slice(2)));

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -23,7 +23,7 @@ eslint-rules/__tests__/warning-and-invariant-args-test.js
 scripts/error-codes/__tests__/dev-expression-with-codes-test.js
 * should replace __DEV__ in if
 * should replace warning calls
-* should add `reactProdInvariant` when it finds `require('invariant')`
+* should add `reactProdInvariant` when it finds `require('fbjs/lib/invariant')`
 * should replace simple invariant calls
 * should only add `reactProdInvariant` once
 * should support invariant calls with args

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -23,8 +23,7 @@ eslint-rules/__tests__/warning-and-invariant-args-test.js
 scripts/error-codes/__tests__/dev-expression-with-codes-test.js
 * should replace __DEV__ in if
 * should replace warning calls
-* should add `reactProdInvariant` when it finds `require('fbjs/lib/invariant')`
-* should replace simple invariant calls
+* should add a require statement and replace simple invariant calls
 * should only add `reactProdInvariant` once
 * should support invariant calls with args
 * should support invariant calls with a concatenated template string and args


### PR DESCRIPTION
Since we now refer to it as `fbjs/lib/invariant`, this code path became dead.

I can’t actually reproduce any issue on master so I’m not sure I understand why this was necessary in the first place. @keyanzhang Maybe you can explain?

I have checked that the code path is hit again now after this change.