### PR TITLE
[React Native] Ignore event listener extraction on numeric text components

### DIFF
--- a/src/renderers/shared/shared/event/EventPluginHub.js
+++ b/src/renderers/shared/shared/event/EventPluginHub.js
@@ -138,7 +138,10 @@ var EventPluginHub = {
         return null;
       }
     } else {
-      if (typeof inst._currentElement === 'string') {
+      const currentElement = inst._currentElement;
+      if (
+        typeof currentElement === 'string' || typeof currentElement === 'number'
+      ) {
         // Text node, let it bubble through.
         return null;
       }
@@ -146,14 +149,10 @@ var EventPluginHub = {
         // If the instance is already unmounted, we have no listeners.
         return null;
       }
-      const props = inst._currentElement.props;
+      const props = currentElement.props;
       listener = props[registrationName];
       if (
-        shouldPreventMouseEvent(
-          registrationName,
-          inst._currentElement.type,
-          props,
-        )
+        shouldPreventMouseEvent(registrationName, currentElement.type, props)
       ) {
         return null;
       }


### PR DESCRIPTION
In ReactDOM we don't dispatch events in the synthetic event system on to
text nodes. We back up one to the element before dispatching.

In React Native we don't do that. The iOS native side doesn't dispatch on
the text nodes but only the parent. The Android native side however does
dispatch on text nodes.

We already covered this for strings, but current element in Stack can be
a number if it is numeric text content.

Verified on Android playground with:

```js
<Text onPress={() => {}}>
{123}
</Text>
```