### PR TITLE
Upgraded Flow dev dependency for 'implements' support

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -36,4 +36,4 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 
 [version]
-^0.37.0
+^0.41.0

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-react-internal": "file:./eslint-rules",
     "fbjs": "^0.8.9",
     "fbjs-scripts": "^0.6.0",
-    "flow-bin": "^0.37.0",
+    "flow-bin": "^0.41.0",
     "glob": "^6.0.1",
     "glob-stream": "^6.1.0",
     "grunt": "^0.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2232,9 +2232,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.37.0:
-  version "0.37.4"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.37.4.tgz#3d8da2ef746e80e730d166e09040f4198969b76b"
+flow-bin@^0.41.0:
+  version "0.41.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.41.0.tgz#8badac9a19da45004997e599bd316518db489b2e"
 
 flow-parser@0.40.0:
   version "0.40.0"


### PR DESCRIPTION
Flow added support for the `implements` keyword in [version 38](https://github.com/facebook/flow/blob/master/Changelog.md#v0380). I rely on this for the `ReactNativeFiber` upgrade I've been working on.

This change doesn't affect any other dev dependencies.