### PR TITLE
Fix Symbol to String conversion in ReactPropTypes.oneOf

### DIFF
--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -326,9 +326,11 @@ function createEnumTypeChecker(expectedValues) {
       }
     }
 
+    // eslint-disable-next-line react-internal/no-primitive-constructors
+    var propValueString = String(propValue);
     var valuesString = JSON.stringify(expectedValues);
     return new PropTypeError(
-      `Invalid ${location} \`${propFullName}\` of value \`${propValue}\` ` +
+      `Invalid ${location} \`${propFullName}\` of value \`${propValueString}\` ` +
         `supplied to \`${componentName}\`, expected one of ${valuesString}.`,
     );
   }

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -318,6 +318,15 @@ function createEnumTypeChecker(expectedValues) {
     return emptyFunction.thatReturnsNull;
   }
 
+  function replaceSymbol(key, value) {
+    var valueType = getPropType(value);
+    if (valueType === 'symbol') {
+      return value.toString();
+    } else {
+      return value;
+    }
+  }
+
   function validate(props, propName, componentName, location, propFullName) {
     var propValue = props[propName];
     for (var i = 0; i < expectedValues.length; i++) {
@@ -328,7 +337,7 @@ function createEnumTypeChecker(expectedValues) {
 
     // eslint-disable-next-line react-internal/no-primitive-constructors
     var propValueString = String(propValue);
-    var valuesString = JSON.stringify(expectedValues);
+    var valuesString = JSON.stringify(expectedValues, replaceSymbol);
     return new PropTypeError(
       `Invalid ${location} \`${propFullName}\` of value \`${propValueString}\` ` +
         `supplied to \`${componentName}\`, expected one of ${valuesString}.`,

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -872,12 +872,19 @@ describe('ReactPropTypes', () => {
         'Invalid prop `testProp` of value `false` supplied to ' +
           '`testComponent`, expected one of [0,"false"].',
       );
+      typeCheckFail(
+        PropTypes.oneOf(['red', 'blue']),
+        Symbol('red'),
+        'Invalid prop `testProp` of value `Symbol(red)` supplied to ' +
+          '`testComponent`, expected one of ["red","blue"].',
+      );
     });
 
     it('should not warn for valid values', () => {
       typeCheckPass(PropTypes.oneOf(['red', 'blue']), 'red');
       typeCheckPass(PropTypes.oneOf(['red', 'blue']), 'blue');
       typeCheckPass(PropTypes.oneOf(['red', 'blue', NaN]), NaN);
+      typeCheckPass(PropTypes.oneOf([0, Symbol.for('red')]), Symbol.for('red'));
     });
 
     it('should be implicitly optional and not warn without values', () => {

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -878,6 +878,12 @@ describe('ReactPropTypes', () => {
         'Invalid prop `testProp` of value `Symbol(red)` supplied to ' +
           '`testComponent`, expected one of ["red","blue"].',
       );
+      typeCheckFail(
+        PropTypes.oneOf([0, Symbol.for('blue')]),
+        Symbol.for('red'),
+        'Invalid prop `testProp` of value `Symbol(red)` supplied to ' +
+          '`testComponent`, expected one of [0,"Symbol(blue)"].',
+      );
     });
 
     it('should not warn for valid values', () => {


### PR DESCRIPTION
This PR addresses issues when using symbols in `PropTypes.oneOf` (#9181).

1.  The safe way to convert a `Symbol` into a `String` is to use `String(sym)` or `sym.toString()`. Using template string interpolation (ES6) or concatenation (ES5/Babel) throws a `TypeError`.

2. The current warning does not include symbols (because `JSON.stringify` strips them). A _replacer_ is added to handle them. This is done in the second commit (so it can be easily reverted).