### PR TITLE
Updated Router import for example

### DIFF
--- a/docs/docs/context.md
+++ b/docs/docs/context.md
@@ -111,7 +111,7 @@ If `contextTypes` is not defined, then `context` will be an empty object.
 Context can also let you build an API where parents and children communicate. For example, one library that works this way is [React Router V4](https://reacttraining.com/react-router):
 
 ```javascript
-import { Router, Route, Link } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Link } from 'react-router-dom';
 
 const BasicExample = () => (
   <Router>


### PR DESCRIPTION
Just simple update on Docs. Updated import statement for react-router-dom in order to be a correct working example as in accordance with the https://reacttraining.com/react-router/web/guides/quick-start.