### PR TITLE
Add warnning about overwriting React component's instance property `updater`

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -353,6 +353,9 @@ src/isomorphic/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
 * supports this.context passed via getChildContext
 * supports classic refs
 * supports drilling through to the DOM using findDOMNode
+* should warn when mutating the updater in the constructor
+* should warn when mutating the updater somewhere else
+* should not warn when mutating the updater with a valid update
 
 src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
 * preserves the name of the class for use in error messages
@@ -376,11 +379,16 @@ src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
 * supports this.context passed via getChildContext
 * supports classic refs
 * supports drilling through to the DOM using findDOMNode
+* should warn when mutating the updater in the constructor
+* should warn when mutating the updater somewhere else
+* should not warn when mutating the updater with a valid update
 
 src/isomorphic/modern/class/__tests__/ReactPureComponent-test.js
 * should render
 * can override shouldComponentUpdate
 * extends React.Component
+* should warn when mutating the updater in the constructor
+* should warn when mutating the updater somewhere else
 
 src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
 * preserves the name of the class for use in error messages
@@ -404,6 +412,9 @@ src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
 * supports this.context passed via getChildContext
 * supports classic refs
 * supports drilling through to the DOM using findDOMNode
+* should warn when mutating the updater in the constructor
+* should warn when mutating the updater somewhere else
+* should not warn when mutating the updater with a valid update
 
 src/isomorphic/modern/element/__tests__/ReactJSXElement-test.js
 * returns a complete element according to spec

--- a/src/isomorphic/modern/class/ReactBaseClasses.js
+++ b/src/isomorphic/modern/class/ReactBaseClasses.js
@@ -21,7 +21,26 @@ var warning = require('fbjs/lib/warning');
 /**
  * Base class helpers for the updating state of a component.
  */
+
+const validUpdater = Object.keys(ReactNoopUpdateQueue);
+
 function ReactComponent(props, context, updater) {
+  let _updater;
+
+  if (__DEV__) {
+    Object.defineProperty(this, 'updater', {
+      get: () => _updater,
+      set(value) {
+        warning(
+          value && validUpdater.every(key => value.hasOwnProperty(key)),
+          // eslint-disable-next-line max-len
+          'The updater property is an internal React method. Mutating it is not supported and it may be changed or removed in a future release.',
+        );
+        _updater = value;
+      },
+    });
+  }
+
   this.props = props;
   this.context = context;
   this.refs = emptyObject;
@@ -106,16 +125,18 @@ if (__DEV__) {
   };
 
   const validUpdater = Object.keys(ReactNoopUpdateQueue);
-
-  Object.defineProperty(ReactComponent.prototype, 'updater', {
-    set(value) {
-      warning(
-        validUpdater.every(key => value.hasOwnProperty(key)),
-        // eslint-disable-next-line max-len
-        'The updater property is an internal React method. Mutating it is not supported and it may be changed or removed in a future release.',
-      );
-    },
-  });
+  // let updater;
+  // Object.defineProperty(ReactComponent.prototype, 'updater', {
+  //   get: () => updater,
+  //   set(value) {
+  //     warning(
+  //       value && validUpdater.every(key => value.hasOwnProperty(key)),
+  //       // eslint-disable-next-line max-len
+  //       'The updater property is an internal React method. Mutating it is not supported and it may be changed or removed in a future release.',
+  //     );
+  //     updater = value;
+  //   },
+  // });
 
   var defineDeprecationWarning = function(methodName, info) {
     if (canDefineProperty) {
@@ -143,6 +164,22 @@ if (__DEV__) {
  * Base class helpers for the updating state of a component.
  */
 function ReactPureComponent(props, context, updater) {
+  let _updater;
+
+  if (__DEV__) {
+    Object.defineProperty(this, 'updater', {
+      get: () => _updater,
+      set(value) {
+        warning(
+          value && validUpdater.every(key => value.hasOwnProperty(key)),
+          // eslint-disable-next-line max-len
+          'The updater property is an internal React method. Mutating it is not supported and it may be changed or removed in a future release.',
+        );
+        _updater = value;
+      },
+    });
+  }
+
   // Duplicated from ReactComponent.
   this.props = props;
   this.context = context;

--- a/src/isomorphic/modern/class/ReactBaseClasses.js
+++ b/src/isomorphic/modern/class/ReactBaseClasses.js
@@ -104,6 +104,19 @@ if (__DEV__) {
         'https://github.com/facebook/react/issues/3236).',
     ],
   };
+
+  const validUpdater = Object.keys(ReactNoopUpdateQueue);
+
+  Object.defineProperty(ReactComponent.prototype, 'updater', {
+    set(value) {
+      warning(
+        validUpdater.every(key => value.hasOwnProperty(key)),
+        // eslint-disable-next-line max-len
+        'The updater property is an internal React method. Mutating it is not supported and it may be changed or removed in a future release.',
+      );
+    },
+  });
+
   var defineDeprecationWarning = function(methodName, info) {
     if (canDefineProperty) {
       Object.defineProperty(ReactComponent.prototype, methodName, {

--- a/src/isomorphic/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/src/isomorphic/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -7,6 +7,8 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 ###
 
+ReactNoopUpdateQueue = require 'ReactNoopUpdateQueue'
+
 React = null
 ReactDOM = null
 
@@ -423,4 +425,50 @@ describe 'ReactCoffeeScriptClass', ->
     instance = test Inner(name: 'foo'), 'DIV', 'foo'
     node = ReactDOM.findDOMNode(instance)
     expect(node).toBe container.firstChild
+    undefined
+
+  it 'should warn when mutating the updater in the constructor', ->
+    spyOn console, 'error'
+    class Component extends React.Component
+      constructor: (props) ->
+        super props
+        @updater = {}
+
+      render: ->
+        null
+    
+    ReactDOM.render(React.createElement(Component), container)
+
+    expect(console.error.calls.count()).toBe 1
+    expect(console.error.calls.mostRecent().args).toMatchSnapshot()
+    undefined
+
+  it 'should warn when mutating the updater somewhere else', ->
+    spyOn console, 'error'
+    class Component extends React.Component
+      componentDidMount: ->
+        @updater = {}
+
+      render: ->
+        null
+    
+    ReactDOM.render(React.createElement(Component), container)
+
+    expect(console.error.calls.count()).toBe 1
+    expect(console.error.calls.mostRecent().args).toMatchSnapshot()
+    undefined
+
+  it 'should not warn when mutating the updater with a valid update', ->
+    spyOn console, 'error'
+    class Component extends React.Component
+      constructor: (props) ->
+        super props
+        @updater = ReactNoopUpdateQueue
+
+      render: ->
+        null
+    
+    ReactDOM.render(React.createElement(Component), container)
+
+    expect(console.error.calls.count()).toBe(0);
     undefined

--- a/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
+++ b/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
@@ -455,7 +455,7 @@ describe('ReactES6Class', () => {
 
     class Component extends React.Component {
       constructor(props) {
-        super(props)
+        super(props);
         this.updater = {};
       }
 
@@ -463,7 +463,7 @@ describe('ReactES6Class', () => {
         return null;
       }
     }
-    
+
     ReactDOM.render(<Component />, document.createElement('div'));
 
     expect(console.error.calls.count()).toBe(1);
@@ -482,7 +482,7 @@ describe('ReactES6Class', () => {
         return null;
       }
     }
-    
+
     ReactDOM.render(<Component />, document.createElement('div'));
 
     expect(console.error.calls.count()).toBe(1);
@@ -494,7 +494,7 @@ describe('ReactES6Class', () => {
 
     class Component extends React.Component {
       constructor(props) {
-        super(props)
+        super(props);
         this.updater = ReactNoopUpdateQueue;
       }
 
@@ -502,7 +502,7 @@ describe('ReactES6Class', () => {
         return null;
       }
     }
-    
+
     ReactDOM.render(<Component />, document.createElement('div'));
 
     expect(console.error.calls.count()).toBe(0);

--- a/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
+++ b/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
@@ -11,6 +11,8 @@
 
 'use strict';
 
+var ReactNoopUpdateQueue = require('ReactNoopUpdateQueue');
+
 var React;
 var ReactDOM;
 
@@ -446,5 +448,63 @@ describe('ReactES6Class', () => {
     var instance = test(<Inner name="foo" />, 'DIV', 'foo');
     var node = ReactDOM.findDOMNode(instance);
     expect(node).toBe(container.firstChild);
+  });
+
+  it('should warn when mutating the updater in the constructor', () => {
+    spyOn(console, 'error');
+
+    class Component extends React.Component {
+      constructor(props) {
+        super(props)
+        this.updater = {};
+      }
+
+      render() {
+        return null;
+      }
+    }
+    
+    ReactDOM.render(<Component />, document.createElement('div'));
+
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.mostRecent().args).toMatchSnapshot();
+  });
+
+  it('should warn when mutating the updater somewhere else', () => {
+    spyOn(console, 'error');
+
+    class Component extends React.Component {
+      componentDidMount() {
+        this.updater = {};
+      }
+
+      render() {
+        return null;
+      }
+    }
+    
+    ReactDOM.render(<Component />, document.createElement('div'));
+
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.mostRecent().args).toMatchSnapshot();
+  });
+
+  it('should not warn when mutating the updater with a valid update', () => {
+    spyOn(console, 'error');
+
+    class Component extends React.Component {
+      constructor(props) {
+        super(props)
+        this.updater = ReactNoopUpdateQueue;
+      }
+
+      render() {
+        return null;
+      }
+    }
+    
+    ReactDOM.render(<Component />, document.createElement('div'));
+
+    expect(console.error.calls.count()).toBe(0);
   });
 });

--- a/src/isomorphic/modern/class/__tests__/ReactPureComponent-test.js
+++ b/src/isomorphic/modern/class/__tests__/ReactPureComponent-test.js
@@ -93,4 +93,42 @@ describe('ReactPureComponent', () => {
     ReactDOM.render(<Component />, document.createElement('div'));
     expect(renders).toBe(1);
   });
+
+  it('should warn when mutating the updater in the constructor', () => {
+    spyOn(console, 'error');
+
+    class Component extends React.PureComponent {
+      constructor(props) {
+        super(props)
+        this.updater = {};
+      }
+
+      render() {
+        return null;
+      }
+    }
+    
+    ReactDOM.render(<Component />, document.createElement('div'));
+
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.mostRecent().args).toMatchSnapshot();
+  });
+
+  it('should warn when mutating the updater somewhere else', () => {
+    spyOn(console, 'error');
+    class Component extends React.PureComponent {
+      componentDidMount() {
+        this.updater = {};
+      }
+
+      render() {
+        return null;
+      }
+    }
+    
+    ReactDOM.render(<Component />, document.createElement('div'));
+
+    expect(console.error.calls.count()).toBe(1);
+    expect(console.error.calls.mostRecent().args).toMatchSnapshot();
+  });
 });

--- a/src/isomorphic/modern/class/__tests__/ReactPureComponent-test.js
+++ b/src/isomorphic/modern/class/__tests__/ReactPureComponent-test.js
@@ -99,7 +99,7 @@ describe('ReactPureComponent', () => {
 
     class Component extends React.PureComponent {
       constructor(props) {
-        super(props)
+        super(props);
         this.updater = {};
       }
 
@@ -107,7 +107,7 @@ describe('ReactPureComponent', () => {
         return null;
       }
     }
-    
+
     ReactDOM.render(<Component />, document.createElement('div'));
 
     expect(console.error.calls.count()).toBe(1);
@@ -125,7 +125,7 @@ describe('ReactPureComponent', () => {
         return null;
       }
     }
-    
+
     ReactDOM.render(<Component />, document.createElement('div'));
 
     expect(console.error.calls.count()).toBe(1);

--- a/src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
+++ b/src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
@@ -9,10 +9,12 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
+
 import React = require('react');
 import ReactDOM = require('react-dom');
 
 // Before Each
+
 var container;
 var attachedListener = null;
 var renderedName = null;

--- a/src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
+++ b/src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
@@ -9,12 +9,10 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-
 import React = require('react');
 import ReactDOM = require('react-dom');
 
 // Before Each
-
 var container;
 var attachedListener = null;
 var renderedName = null;
@@ -535,4 +533,69 @@ describe('ReactTypeScriptClass', function() {
     expect(node).toBe(container.firstChild);
   });
 
+  it('should warn when mutating the updater in the constructor', function() {
+    spyOn(console, 'error');
+
+    class Component extends React.Component {
+      updater: Object
+      constructor(props) {
+        super(props)
+        this.updater = {};
+      }
+
+      render() {
+        return null;
+      }
+    }
+    
+    ReactDOM.render(React.createElement(Component), container);
+
+    expect((<any>console.error).calls.count()).toBe(1);
+    (<any>expect((<any>console.error).calls.mostRecent().args)).toMatchSnapshot();
+  });
+
+  it('should warn when mutating the updater somewhere else', function() {
+    spyOn(console, 'error');
+
+    class Component extends React.Component {
+      updater: Object
+      componentDidMount() {
+        this.updater = {};
+      }
+
+      render() {
+        return null;
+      }
+    }
+    
+    ReactDOM.render(React.createElement(Component), container);
+
+    expect((<any>console.error).calls.count()).toBe(1);
+    (<any>expect((<any>console.error).calls.mostRecent().args)).toMatchSnapshot();
+  });
+
+  it('should not warn when mutating the updater with a valid update', function() {
+    spyOn(console, 'error');
+
+    class Component extends React.Component {
+      updater: Object
+      constructor(props) {
+        super(props)
+        this.updater = {
+          isMounted() {},
+          enqueueForceUpdate() {},
+          enqueueReplaceState() {},
+          enqueueSetState() {},
+        };
+      }
+
+      render() {
+        return null;
+      }
+    }
+    
+    ReactDOM.render(React.createElement(Component), container);
+
+    expect((<any>console.error).calls.count()).toBe(0);
+  });
 });

--- a/src/isomorphic/modern/class/__tests__/__snapshots__/ReactCoffeeScriptClass-test.coffee.snap
+++ b/src/isomorphic/modern/class/__tests__/__snapshots__/ReactCoffeeScriptClass-test.coffee.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReactCoffeeScriptClass should warn when mutating the updater in the constructor 1`] = `
+Array [
+  "Warning: The updater property is an internal React method. Mutating it is not supported and it may be changed or removed in a future release.",
+]
+`;
+
+exports[`ReactCoffeeScriptClass should warn when mutating the updater somewhere else 1`] = `
+Array [
+  "Warning: The updater property is an internal React method. Mutating it is not supported and it may be changed or removed in a future release.",
+]
+`;

--- a/src/isomorphic/modern/class/__tests__/__snapshots__/ReactES6Class-test.js.snap
+++ b/src/isomorphic/modern/class/__tests__/__snapshots__/ReactES6Class-test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReactES6Class should warn when mutating the updater in the constructor 1`] = `
+Array [
+  "Warning: The updater property is an internal React method. Mutating it is not supported and it may be changed or removed in a future release.",
+]
+`;
+
+exports[`ReactES6Class should warn when mutating the updater somewhere else 1`] = `
+Array [
+  "Warning: The updater property is an internal React method. Mutating it is not supported and it may be changed or removed in a future release.",
+]
+`;

--- a/src/isomorphic/modern/class/__tests__/__snapshots__/ReactPureComponent-test.js.snap
+++ b/src/isomorphic/modern/class/__tests__/__snapshots__/ReactPureComponent-test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReactPureComponent should warn when mutating the updater in the constructor 1`] = `
+Array [
+  "Warning: The updater property is an internal React method. Mutating it is not supported and it may be changed or removed in a future release.",
+]
+`;
+
+exports[`ReactPureComponent should warn when mutating the updater somewhere else 1`] = `
+Array [
+  "Warning: The updater property is an internal React method. Mutating it is not supported and it may be changed or removed in a future release.",
+]
+`;

--- a/src/isomorphic/modern/class/__tests__/__snapshots__/ReactTypeScriptClass-test.ts.snap
+++ b/src/isomorphic/modern/class/__tests__/__snapshots__/ReactTypeScriptClass-test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReactTypeScriptClass should warn when mutating the updater in the constructor 1`] = `
+Array [
+  "Warning: The updater property is an internal React method. Mutating it is not supported and it may be changed or removed in a future release.",
+]
+`;
+
+exports[`ReactTypeScriptClass should warn when mutating the updater somewhere else 1`] = `
+Array [
+  "Warning: The updater property is an internal React method. Mutating it is not supported and it may be changed or removed in a future release.",
+]
+`;


### PR DESCRIPTION
This should fix #9164 , but I have the slight feeling that given my poor understanding of the project I might be tackling this in a really incorrect way 😊 so I have a couple of questions... Also please let me know if any of my assumptions are totally wrong!

* It seems that React is mutating the updater right? Which is guess this are "valid" mutations. Considering that my assumption is correct, what does a "valid updater" is? I currently check for it being either `ReactServerUpdateQueue` or a `ReactNoopUpdateQueue` but I'm not sure if this is correct.
* @acdlite https://github.com/facebook/react/pull/9188#discussion_r106303781 I'm having some trouble getting the component name.
* I'm getting an error when running `yarn build` which I guess it has to do with the bundle that gets created for browserify
```
Running "browserify:basic" (browserify) task
>> Error: Cannot find module './ReactServerUpdateQueue' from '/Users/rogelioguzman/dev/react/build/node_modules/react/lib'

Running "browserify:min" (browserify) task
>> Error: Cannot find module './ReactServerUpdateQueue' from '/Users/rogelioguzman/dev/react/build/node_modules/react/lib'
```