### PR TITLE
Throw early on missing owner

### DIFF
--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -13,6 +13,7 @@
 
 var ReactCurrentOwner = require('ReactCurrentOwner');
 
+var invariant = require('fbjs/lib/invariant');
 var warning = require('fbjs/lib/warning');
 var canDefineProperty = require('canDefineProperty');
 var hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -128,6 +129,20 @@ var ReactElement = function(type, key, ref, self, source, owner, props) {
     // Record the component responsible for creating this element.
     _owner: owner,
   };
+
+  if (typeof ref === 'string' && owner === null) {
+    invariant(
+      false,
+      'An element with a string ref does not have an owner. ' +
+        'There are two common reasons for this error:\n\n' +
+        '1. You may have two copies of React in your bundle. ' +
+        'This is not supported. If you use npm, run `npm ls react` ' +
+        'to find where the second bundle is coming from, and delete it.\n\n' +
+        '2. You might be creating a React element with a string ref ' +
+        'outside of the `render()` method of a class component. In this ' +
+        'case, use a callback ref instead of a string ref.',
+    );
+  }
 
   if (__DEV__) {
     // The validation flag is currently mutative. We put it on


### PR DESCRIPTION
I haven't really experimented much with it, but curious what you think.
The error we throw right now is a bit cryptic because it happens later during mounting.

I thought it would make sense to throw it as early as possible instead, so that can see the JS stack for the specific element that has a bad owner. This might even help find the offending library that shipped a duplicate copy of React.