### PR TITLE
ReactElementValidator uses temporary ReactNative View propTypes getter

### DIFF
--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -181,8 +181,17 @@ function validatePropTypes(element) {
     return;
   }
   var name = componentClass.displayName || componentClass.name;
-  if (componentClass.propTypes) {
-    checkReactTypeSpec(componentClass.propTypes, element.props, 'prop', name);
+
+  // ReactNative `View.propTypes` have been deprecated in favor of `ViewPropTypes`.
+  // In their place a temporary getter has been added with a deprecated warning message.
+  // Avoid triggering that warning during validation using the temporary workaround, __propTypesSecretDontUseThesePlease.
+  // TODO (bvaughn) Revert this particular change any time after April 1 ReactNative RC is tagged.
+  var propTypes = typeof componentClass.__propTypesSecretDontUseThesePlease === 'object'
+    ? componentClass.__propTypesSecretDontUseThesePlease
+    : componentClass.propTypes;
+
+  if (propTypes) {
+    checkReactTypeSpec(propTypes, element.props, 'prop', name);
   }
   if (typeof componentClass.getDefaultProps === 'function') {
     warning(


### PR DESCRIPTION
react-native `View.propTypes` have been deprecated in favor of `ViewPropTypes`. In their place a temporary getter has been added with a deprecated warning message. We should avoid triggering that warning during validation by using the temporary workaround accessor added to `View` - `__propTypesSecretDontUseThesePlease`.

This change can be removed any time after April 1 react-native RC is tagged. The getter warning wrapper will be removed then.