### PR TITLE
Adding new SSR tests for context, refs, and reviving markup.

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -102,6 +102,17 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders >,<, and & as single child with client render on top of good server markup
 * renders >,<, and & as multiple children with server string render
 * renders >,<, and & as multiple children with client render on top of good server markup
+* renders class child with context with client render on top of good server markup
+* renders stateless child with context with client render on top of good server markup
+* renders class child without context with client render on top of good server markup
+* renders stateless child without context with client render on top of good server markup
+* renders class child with wrong context with client render on top of good server markup
+* renders stateless child with wrong context with client render on top of good server markup
+* renders with context passed through to a grandchild with client render on top of good server markup
+* renders a child context overriding a parent context with client render on top of good server markup
+* renders a child context merged with a parent context with client render on top of good server markup
+* renders with a call to componentWillMount before getChildContext with client render on top of good server markup
+* should send the correct element to ref functions on client
 
 src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
 * can reconcile text merged by Node.normalize() alongside other elements

--- a/scripts/fiber/tests-passing-except-dev.txt
+++ b/scripts/fiber/tests-passing-except-dev.txt
@@ -95,6 +95,35 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * throws when rendering an undefined component with client render on top of bad server markup
 * throws when rendering a number component with clean client render
 * throws when rendering a number component with client render on top of bad server markup
+* renders class child with context with client render on top of bad server markup
+* renders stateless child with context with client render on top of bad server markup
+* renders class child without context with client render on top of bad server markup
+* renders stateless child without context with client render on top of bad server markup
+* renders class child with wrong context with client render on top of bad server markup
+* renders stateless child with wrong context with client render on top of bad server markup
+* renders with context passed through to a grandchild with client render on top of bad server markup
+* renders a child context overriding a parent context with client render on top of bad server markup
+* renders a child context merged with a parent context with client render on top of bad server markup
+* renders with a call to componentWillMount before getChildContext with client render on top of bad server markup
+* should error reconnecting different element types
+* should error reconnecting missing attributes
+* should error reconnecting added attributes
+* should error reconnecting different attribute values
+* should error reconnecting different text
+* should error reconnecting different numbers
+* should error reconnecting different number from text
+* should error reconnecting different text in two code blocks
+* should error reconnecting missing children
+* should error reconnecting added children
+* should error reconnecting more children
+* should error reconnecting fewer children
+* should error reconnecting reordered children
+* should error reconnecting a div with children separated by whitespace on the client
+* should error reconnecting a div with children separated by different whitespace on the server
+* should error reconnecting a div with children separated by different whitespace
+* can distinguish an empty component from a dom node
+* can distinguish an empty component from an empty text component
+* should error reconnecting a div with different dangerouslySetInnerHTML
 
 src/renderers/dom/shared/__tests__/ReactMount-test.js
 * should warn if mounting into dirty rendered markup

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1154,6 +1154,46 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * throws when rendering string with server string render
 * throws when rendering string with clean client render
 * throws when rendering string with client render on top of bad server markup
+* renders class child with context with server string render
+* renders class child with context with clean client render
+* renders stateless child with context with server string render
+* renders stateless child with context with clean client render
+* renders class child without context with server string render
+* renders class child without context with clean client render
+* renders stateless child without context with server string render
+* renders stateless child without context with clean client render
+* renders class child with wrong context with server string render
+* renders class child with wrong context with clean client render
+* renders stateless child with wrong context with server string render
+* renders stateless child with wrong context with clean client render
+* renders with context passed through to a grandchild with server string render
+* renders with context passed through to a grandchild with clean client render
+* renders a child context overriding a parent context with server string render
+* renders a child context overriding a parent context with clean client render
+* renders a child context merged with a parent context with server string render
+* renders a child context merged with a parent context with clean client render
+* renders with a call to componentWillMount before getChildContext with server string render
+* renders with a call to componentWillMount before getChildContext with clean client render
+* throws when rendering if getChildContext exists without childContextTypes with server string render
+* throws when rendering if getChildContext exists without childContextTypes with clean client render
+* throws when rendering if getChildContext exists without childContextTypes with client render on top of bad server markup
+* throws when rendering if getChildContext returns a value not in childContextTypes with server string render
+* throws when rendering if getChildContext returns a value not in childContextTypes with clean client render
+* throws when rendering if getChildContext returns a value not in childContextTypes with client render on top of bad server markup
+* should not run ref code on server
+* should run ref code on client
+* should have string refs on client when rendered over server markup
+* should reconnect ES6 Class to ES6 Class
+* should reconnect Pure Component to ES6 Class
+* should reconnect Bare Element to ES6 Class
+* should reconnect ES6 Class to Pure Component
+* should reconnect Pure Component to Pure Component
+* should reconnect Bare Element to Pure Component
+* should reconnect ES6 Class to Bare Element
+* should reconnect Pure Component to Bare Element
+* should reconnect Bare Element to Bare Element
+* should reconnect a div with a number and string version of number
+* should reconnect if component trees differ but resulting markup is the same
 
 src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
 * updates a mounted text component in place


### PR DESCRIPTION
This is a latest chapter in a series of PRs adding server-side rendering unit tests (following on #9055, #9089, #9106, and #9221).

This PR adds SSR tests for context, refs, and markup mismatch warnings when reviving. 

If we end up implementing the new SSR as a Fiber renderer, then the context tests are probably not needed, as I'm guessing that Fiber handles context by itself and is well tested. If we write SSR from scratch, though, those tests will be useful.

Also, while I found all these tests useful when I wrote my custom server renderer, I totally understand if you find them repetitive, especially the ones that repeat tests for both class components and stateless components. Just let me know what you think!