### PR TITLE
Wrap DEV modules in explicit __DEV__ condition

### DIFF
--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -18,266 +18,260 @@
 
 'use strict';
 
-var ReactCurrentOwner = require('ReactCurrentOwner');
-var ReactElement = require('ReactElement');
-
-var checkReactTypeSpec = require('checkReactTypeSpec');
-
-var canDefineProperty = require('canDefineProperty');
-var getComponentName = require('getComponentName');
-var getIteratorFn = require('getIteratorFn');
+var ReactElementValidator;
 
 if (__DEV__) {
-  var warning = require('fbjs/lib/warning');
-  var ReactDebugCurrentFrame = require('ReactDebugCurrentFrame');
-  var {
+  const ReactCurrentOwner = require('ReactCurrentOwner');
+  const ReactElement = require('ReactElement');
+  const checkReactTypeSpec = require('checkReactTypeSpec');
+  const canDefineProperty = require('canDefineProperty');
+  const getComponentName = require('getComponentName');
+  const getIteratorFn = require('getIteratorFn');
+  const warning = require('fbjs/lib/warning');
+  const ReactDebugCurrentFrame = require('ReactDebugCurrentFrame');
+  const {
     getCurrentStackAddendum,
   } = require('ReactComponentTreeHook');
-}
 
-function getDeclarationErrorAddendum() {
-  if (ReactCurrentOwner.current) {
-    var name = getComponentName(ReactCurrentOwner.current);
-    if (name) {
-      return '\n\nCheck the render method of `' + name + '`.';
-    }
-  }
-  return '';
-}
 
-function getSourceInfoErrorAddendum(elementProps) {
-  if (
-    elementProps !== null &&
-    elementProps !== undefined &&
-    elementProps.__source !== undefined
-  ) {
-    var source = elementProps.__source;
-    var fileName = source.fileName.replace(/^.*[\\\/]/, '');
-    var lineNumber = source.lineNumber;
-    return '\n\nCheck your code at ' + fileName + ':' + lineNumber + '.';
-  }
-  return '';
-}
-
-/**
- * Warn if there's no key explicitly set on dynamic arrays of children or
- * object keys are not valid. This allows us to keep track of children between
- * updates.
- */
-var ownerHasKeyUseWarning = {};
-
-function getCurrentComponentErrorInfo(parentType) {
-  var info = getDeclarationErrorAddendum();
-
-  if (!info) {
-    var parentName = typeof parentType === 'string'
-      ? parentType
-      : parentType.displayName || parentType.name;
-    if (parentName) {
-      info = `\n\nCheck the top-level render call using <${parentName}>.`;
-    }
-  }
-  return info;
-}
-
-/**
- * Warn if the element doesn't have an explicit key assigned to it.
- * This element is in an array. The array could grow and shrink or be
- * reordered. All children that haven't already been validated are required to
- * have a "key" property assigned to it. Error statuses are cached so a warning
- * will only be shown once.
- *
- * @internal
- * @param {ReactElement} element Element that requires a key.
- * @param {*} parentType element's parent's type.
- */
-function validateExplicitKey(element, parentType) {
-  if (!element._store || element._store.validated || element.key != null) {
-    return;
-  }
-  element._store.validated = true;
-
-  var memoizer = ownerHasKeyUseWarning.uniqueKey ||
-    (ownerHasKeyUseWarning.uniqueKey = {});
-
-  var currentComponentErrorInfo = getCurrentComponentErrorInfo(parentType);
-  if (memoizer[currentComponentErrorInfo]) {
-    return;
-  }
-  memoizer[currentComponentErrorInfo] = true;
-
-  // Usually the current owner is the offender, but if it accepts children as a
-  // property, it may be the creator of the child that's responsible for
-  // assigning it a key.
-  var childOwner = '';
-  if (
-    element && element._owner && element._owner !== ReactCurrentOwner.current
-  ) {
-    // Give the component that originally created this child.
-    childOwner = ` It was passed a child from ${getComponentName(element._owner)}.`;
-  }
-
-  warning(
-    false,
-    'Each child in an array or iterator should have a unique "key" prop.' +
-      '%s%s See https://fb.me/react-warning-keys for more information.%s',
-    currentComponentErrorInfo,
-    childOwner,
-    getCurrentStackAddendum(element),
-  );
-}
-
-/**
- * Ensure that every element either is passed in a static location, in an
- * array with an explicit keys property defined, or in an object literal
- * with valid key property.
- *
- * @internal
- * @param {ReactNode} node Statically passed child of any type.
- * @param {*} parentType node's parent's type.
- */
-function validateChildKeys(node, parentType) {
-  if (typeof node !== 'object') {
-    return;
-  }
-  if (Array.isArray(node)) {
-    for (var i = 0; i < node.length; i++) {
-      var child = node[i];
-      if (ReactElement.isValidElement(child)) {
-        validateExplicitKey(child, parentType);
+  const getDeclarationErrorAddendum = function () {
+    if (ReactCurrentOwner.current) {
+      var name = getComponentName(ReactCurrentOwner.current);
+      if (name) {
+        return '\n\nCheck the render method of `' + name + '`.';
       }
     }
-  } else if (ReactElement.isValidElement(node)) {
-    // This element was passed in a valid location.
-    if (node._store) {
-      node._store.validated = true;
+    return '';
+  };
+
+  const getSourceInfoErrorAddendum = function (elementProps) {
+    if (
+      elementProps !== null &&
+      elementProps !== undefined &&
+      elementProps.__source !== undefined
+    ) {
+      var source = elementProps.__source;
+      var fileName = source.fileName.replace(/^.*[\\\/]/, '');
+      var lineNumber = source.lineNumber;
+      return '\n\nCheck your code at ' + fileName + ':' + lineNumber + '.';
     }
-  } else if (node) {
-    var iteratorFn = getIteratorFn(node);
-    // Entry iterators provide implicit keys.
-    if (iteratorFn) {
-      if (iteratorFn !== node.entries) {
-        var iterator = iteratorFn.call(node);
-        var step;
-        while (!(step = iterator.next()).done) {
-          if (ReactElement.isValidElement(step.value)) {
-            validateExplicitKey(step.value, parentType);
+    return '';
+  };
+
+  /**
+   * Warn if there's no key explicitly set on dynamic arrays of children or
+   * object keys are not valid. This allows us to keep track of children between
+   * updates.
+   */
+  const ownerHasKeyUseWarning = {};
+
+  const getCurrentComponentErrorInfo = function (parentType) {
+    var info = getDeclarationErrorAddendum();
+
+    if (!info) {
+      var parentName = typeof parentType === 'string'
+        ? parentType
+        : parentType.displayName || parentType.name;
+      if (parentName) {
+        info = `\n\nCheck the top-level render call using <${parentName}>.`;
+      }
+    }
+    return info;
+  };
+
+  /**
+   * Warn if the element doesn't have an explicit key assigned to it.
+   * This element is in an array. The array could grow and shrink or be
+   * reordered. All children that haven't already been validated are required to
+   * have a "key" property assigned to it. Error statuses are cached so a warning
+   * will only be shown once.
+   *
+   * @internal
+   * @param {ReactElement} element Element that requires a key.
+   * @param {*} parentType element's parent's type.
+   */
+  const validateExplicitKey = function (element, parentType) {
+    if (!element._store || element._store.validated || element.key != null) {
+      return;
+    }
+    element._store.validated = true;
+
+    var memoizer = ownerHasKeyUseWarning.uniqueKey ||
+      (ownerHasKeyUseWarning.uniqueKey = {});
+
+    var currentComponentErrorInfo = getCurrentComponentErrorInfo(parentType);
+    if (memoizer[currentComponentErrorInfo]) {
+      return;
+    }
+    memoizer[currentComponentErrorInfo] = true;
+
+    // Usually the current owner is the offender, but if it accepts children as a
+    // property, it may be the creator of the child that's responsible for
+    // assigning it a key.
+    var childOwner = '';
+    if (
+      element && element._owner && element._owner !== ReactCurrentOwner.current
+    ) {
+      // Give the component that originally created this child.
+      childOwner = ` It was passed a child from ${getComponentName(element._owner)}.`;
+    }
+
+    warning(
+      false,
+      'Each child in an array or iterator should have a unique "key" prop.' +
+        '%s%s See https://fb.me/react-warning-keys for more information.%s',
+      currentComponentErrorInfo,
+      childOwner,
+      getCurrentStackAddendum(element),
+    );
+  };
+
+  /**
+   * Ensure that every element either is passed in a static location, in an
+   * array with an explicit keys property defined, or in an object literal
+   * with valid key property.
+   *
+   * @internal
+   * @param {ReactNode} node Statically passed child of any type.
+   * @param {*} parentType node's parent's type.
+   */
+  const validateChildKeys = function (node, parentType) {
+    if (typeof node !== 'object') {
+      return;
+    }
+    if (Array.isArray(node)) {
+      for (var i = 0; i < node.length; i++) {
+        var child = node[i];
+        if (ReactElement.isValidElement(child)) {
+          validateExplicitKey(child, parentType);
+        }
+      }
+    } else if (ReactElement.isValidElement(node)) {
+      // This element was passed in a valid location.
+      if (node._store) {
+        node._store.validated = true;
+      }
+    } else if (node) {
+      var iteratorFn = getIteratorFn(node);
+      // Entry iterators provide implicit keys.
+      if (iteratorFn) {
+        if (iteratorFn !== node.entries) {
+          var iterator = iteratorFn.call(node);
+          var step;
+          while (!(step = iterator.next()).done) {
+            if (ReactElement.isValidElement(step.value)) {
+              validateExplicitKey(step.value, parentType);
+            }
           }
         }
       }
     }
-  }
-}
+  };
 
-/**
- * Given an element, validate that its props follow the propTypes definition,
- * provided by the type.
- *
- * @param {ReactElement} element
- */
-function validatePropTypes(element) {
-  var componentClass = element.type;
-  if (typeof componentClass !== 'function') {
-    return;
-  }
-  var name = componentClass.displayName || componentClass.name;
+  /**
+   * Given an element, validate that its props follow the propTypes definition,
+   * provided by the type.
+   *
+   * @param {ReactElement} element
+   */
+  const validatePropTypes = function (element) {
+    var componentClass = element.type;
+    if (typeof componentClass !== 'function') {
+      return;
+    }
+    var name = componentClass.displayName || componentClass.name;
 
-  // ReactNative `View.propTypes` have been deprecated in favor of `ViewPropTypes`.
-  // In their place a temporary getter has been added with a deprecated warning message.
-  // Avoid triggering that warning during validation using the temporary workaround,
-  // __propTypesSecretDontUseThesePlease.
-  // TODO (bvaughn) Revert this particular change any time after April 1 ReactNative tag.
-  var propTypes = typeof componentClass.__propTypesSecretDontUseThesePlease ===
-    'object'
-    ? componentClass.__propTypesSecretDontUseThesePlease
-    : componentClass.propTypes;
+    // ReactNative `View.propTypes` have been deprecated in favor of `ViewPropTypes`.
+    // In their place a temporary getter has been added with a deprecated warning message.
+    // Avoid triggering that warning during validation using the temporary workaround,
+    // __propTypesSecretDontUseThesePlease.
+    // TODO (bvaughn) Revert this particular change any time after April 1 ReactNative tag.
+    var propTypes = typeof componentClass.__propTypesSecretDontUseThesePlease ===
+      'object'
+      ? componentClass.__propTypesSecretDontUseThesePlease
+      : componentClass.propTypes;
 
-  if (propTypes) {
-    checkReactTypeSpec(propTypes, element.props, 'prop', name);
-  }
-  if (typeof componentClass.getDefaultProps === 'function') {
-    warning(
-      componentClass.getDefaultProps.isReactClassApproved,
-      'getDefaultProps is only used on classic React.createClass ' +
-        'definitions. Use a static property named `defaultProps` instead.',
-    );
-  }
-}
-
-var ReactElementValidator = {
-  createElement: function(type, props, children) {
-    var validType = typeof type === 'string' || typeof type === 'function';
-    // We warn in this case but don't throw. We expect the element creation to
-    // succeed and there will likely be errors in render.
-    if (!validType) {
-      var info = '';
-      if (
-        type === undefined ||
-        (typeof type === 'object' &&
-          type !== null &&
-          Object.keys(type).length === 0)
-      ) {
-        info += ' You likely forgot to export your component from the file ' +
-          "it's defined in.";
-      }
-
-      var sourceInfo = getSourceInfoErrorAddendum(props);
-      if (sourceInfo) {
-        info += sourceInfo;
-      } else {
-        info += getDeclarationErrorAddendum();
-      }
-
-      info += getCurrentStackAddendum();
-
+    if (propTypes) {
+      checkReactTypeSpec(propTypes, element.props, 'prop', name);
+    }
+    if (typeof componentClass.getDefaultProps === 'function') {
       warning(
-        false,
-        'React.createElement: type is invalid -- expected a string (for ' +
-          'built-in components) or a class/function (for composite ' +
-          'components) but got: %s.%s',
-        type == null ? type : typeof type,
-        info,
+        componentClass.getDefaultProps.isReactClassApproved,
+        'getDefaultProps is only used on classic React.createClass ' +
+          'definitions. Use a static property named `defaultProps` instead.',
       );
     }
+  };
 
-    var element = ReactElement.createElement.apply(this, arguments);
+  ReactElementValidator = {
+    createElement: function(type, props, children) {
+      var validType = typeof type === 'string' || typeof type === 'function';
+      // We warn in this case but don't throw. We expect the element creation to
+      // succeed and there will likely be errors in render.
+      if (!validType) {
+        var info = '';
+        if (
+          type === undefined ||
+          (typeof type === 'object' &&
+            type !== null &&
+            Object.keys(type).length === 0)
+        ) {
+          info += ' You likely forgot to export your component from the file ' +
+            "it's defined in.";
+        }
 
-    // The result can be nullish if a mock or a custom function is used.
-    // TODO: Drop this when these are no longer allowed as the type argument.
-    if (element == null) {
-      return element;
-    }
+        var sourceInfo = getSourceInfoErrorAddendum(props);
+        if (sourceInfo) {
+          info += sourceInfo;
+        } else {
+          info += getDeclarationErrorAddendum();
+        }
 
-    if (__DEV__) {
-      ReactDebugCurrentFrame.element = element;
-    }
+        info += getCurrentStackAddendum();
 
-    // Skip key warning if the type isn't valid since our key validation logic
-    // doesn't expect a non-string/function type and can throw confusing errors.
-    // We don't want exception behavior to differ between dev and prod.
-    // (Rendering will throw with a helpful message and as soon as the type is
-    // fixed, the key warnings will appear.)
-    if (validType) {
-      for (var i = 2; i < arguments.length; i++) {
-        validateChildKeys(arguments[i], type);
+        warning(
+          false,
+          'React.createElement: type is invalid -- expected a string (for ' +
+            'built-in components) or a class/function (for composite ' +
+            'components) but got: %s.%s',
+          type == null ? type : typeof type,
+          info,
+        );
       }
-    }
 
-    validatePropTypes(element);
+      var element = ReactElement.createElement.apply(this, arguments);
 
-    if (__DEV__) {
+      // The result can be nullish if a mock or a custom function is used.
+      // TODO: Drop this when these are no longer allowed as the type argument.
+      if (element == null) {
+        return element;
+      }
+
+      ReactDebugCurrentFrame.element = element;
+
+      // Skip key warning if the type isn't valid since our key validation logic
+      // doesn't expect a non-string/function type and can throw confusing errors.
+      // We don't want exception behavior to differ between dev and prod.
+      // (Rendering will throw with a helpful message and as soon as the type is
+      // fixed, the key warnings will appear.)
+      if (validType) {
+        for (var i = 2; i < arguments.length; i++) {
+          validateChildKeys(arguments[i], type);
+        }
+      }
+
+      validatePropTypes(element);
+
       ReactDebugCurrentFrame.element = null;
-    }
 
-    return element;
-  },
+      return element;
+    },
 
-  createFactory: function(type) {
-    var validatedFactory = ReactElementValidator.createElement.bind(null, type);
-    // Legacy hook TODO: Warn if this is accessed
-    validatedFactory.type = type;
+    createFactory: function(type) {
+      var validatedFactory = ReactElementValidator.createElement.bind(null, type);
+      // Legacy hook TODO: Warn if this is accessed
+      validatedFactory.type = type;
 
-    if (__DEV__) {
       if (canDefineProperty) {
         Object.defineProperty(validatedFactory, 'type', {
           enumerable: false,
@@ -294,25 +288,21 @@ var ReactElementValidator = {
           },
         });
       }
-    }
 
-    return validatedFactory;
-  },
+      return validatedFactory;
+    },
 
-  cloneElement: function(element, props, children) {
-    var newElement = ReactElement.cloneElement.apply(this, arguments);
-    if (__DEV__) {
+    cloneElement: function(element, props, children) {
+      var newElement = ReactElement.cloneElement.apply(this, arguments);
       ReactDebugCurrentFrame.element = newElement;
-    }
-    for (var i = 2; i < arguments.length; i++) {
-      validateChildKeys(arguments[i], newElement.type);
-    }
-    validatePropTypes(newElement);
-    if (__DEV__) {
+      for (var i = 2; i < arguments.length; i++) {
+        validateChildKeys(arguments[i], newElement.type);
+      }
+      validatePropTypes(newElement);
       ReactDebugCurrentFrame.element = null;
-    }
-    return newElement;
-  },
-};
+      return newElement;
+    },
+  };
+}
 
 module.exports = ReactElementValidator;


### PR DESCRIPTION
There are some issues with DEV modules (such as `ReactElementValidator`') content not being stripped in prod due to how DCE works in some minification tools. This PR explicitly wraps the contents of each module in explcit `__DEV__` tags to ensure the code isn't shipped in production.