### PR TITLE
Added missing @flow annotation to ReactNativeFeatureFlags file

### DIFF
--- a/src/renderers/native/ReactNativeFeatureFlags.js
+++ b/src/renderers/native/ReactNativeFeatureFlags.js
@@ -7,6 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule ReactNativeFeatureFlags
+ * @flow
  */
 
 'use strict';


### PR DESCRIPTION
Noticed this discrepancy while doing the ReactNative <> React sync. Guess it had gotten added in fbsource and not synced upstream.