### PR TITLE
Added jest-cli to the package.json for the Fiber record-tests script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "gulp-util": "^3.0.7",
     "gzip-js": "~0.3.2",
     "jest": "^19.0.1",
-    "jest-cli": "^19.0.1",
     "jest-config": "^19.0.1",
     "jest-jasmine2": "^19.0.1",
     "jest-runtime": "^19.0.1",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "gulp-util": "^3.0.7",
     "gzip-js": "~0.3.2",
     "jest": "^19.0.1",
+    "jest-cli": "^19.0.1",
     "jest-config": "^19.0.1",
     "jest-jasmine2": "^19.0.1",
     "jest-runtime": "^19.0.1",

--- a/scripts/fiber/record-tests
+++ b/scripts/fiber/record-tests
@@ -8,9 +8,9 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const SearchSource = require('jest-cli').SearchSource;
-const TestRunner = require('jest-cli').TestRunner;
-const TestWatcher = require('jest-cli/build/TestWatcher');
+const SearchSource = require('jest').SearchSource;
+const TestRunner = require('jest').TestRunner;
+const TestWatcher = require('jest').TestWatcher;
 
 const createHasteContext = require('jest-runtime').createHasteContext;
 const readConfig = require('jest-config').readConfig;


### PR DESCRIPTION
The `./scripts/fiber/record-tests` script currently doesn't work out of the box, because it depends on `jest-cli`, which isn't in package.json. Right now you have to manually `npm install jest-cli` to get the script to run correctly.

This PR just adds `jest-cli` to the package.json so that `record-tests` will work after a usual `npm install`.

Cheers!