### PR TITLE
eslint warning fixed for no-primitive-constructors-test

### DIFF
--- a/eslint-rules/__tests__/no-primitive-constructors-test.js
+++ b/eslint-rules/__tests__/no-primitive-constructors-test.js
@@ -34,7 +34,7 @@ ruleTester.run('eslint-rules/no-primitive-constructors', rule, {
       code: 'String(obj)',
       errors: [
         {
-          message: 'Do not use the String constructor. To cast a value to a string, concat it with the empty string (unless it\'s a symbol, which has different semantics): \'\' + value',
+          message: 'Do not use the String constructor. To cast a value to a string, concat it with the empty string (unless it\'s a symbol, which has different semantics): \'\' + value', // eslint-disable-line
         },
       ],
     },


### PR DESCRIPTION
Hey, I was seeing a small warning in `yarn lint`. With this PR I intend to fix that. I am just adding `// eslint-disable-line` to the necessary line.