### PR TITLE
Upstream fix for possible null pointer in EventPropagators

### DIFF
--- a/src/renderers/shared/shared/event/EventPropagators.js
+++ b/src/renderers/shared/shared/event/EventPropagators.js
@@ -93,7 +93,7 @@ function accumulateTwoPhaseDispatchesSingleSkipTarget(event) {
  * requiring that the `dispatchMarker` be the same as the dispatched ID.
  */
 function accumulateDispatches(inst, ignoredDirection, event) {
-  if (event && event.dispatchConfig.registrationName) {
+  if (inst && event && event.dispatchConfig.registrationName) {
     var registrationName = event.dispatchConfig.registrationName;
     var listener = getListener(inst, registrationName);
     if (listener) {


### PR DESCRIPTION
This fix was accidentally omitted from PR #9219 and caused a regression after the most recent sync.