### PR TITLE
[Fiber] Adds DEV condition around getDeclarationErrorAddendum

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -68,10 +68,12 @@ var {
 var DOC_FRAGMENT_TYPE = 11;
 
 function getDeclarationErrorAddendum() {
-  var ownerName = getCurrentFiberOwnerName();
-  if (ownerName) {
-    // TODO: also report the stack.
-    return '\n\nThis DOM node was rendered by `' + ownerName + '`.';
+  if (__DEV__) {
+    var ownerName = getCurrentFiberOwnerName();
+    if (ownerName) {
+      // TODO: also report the stack.
+      return '\n\nThis DOM node was rendered by `' + ownerName + '`.';
+    }
   }
   return '';
 }


### PR DESCRIPTION
Currently, `getDeclarationErrorAddendum()` makes reference to `getCurrentFiberOwnerName()` in its contents. This causes the `ReactDebugCurrentFiber` module to be imported when it's only a DEV module.
