### PR TITLE
Allow returning null as host context

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1457,6 +1457,9 @@ src/renderers/shared/fiber/__tests__/ReactCoroutine-test.js
 * should unmount a composite in a coroutine
 * should handle deep updates in coroutine
 
+src/renderers/shared/fiber/__tests__/ReactFiberHostContext-test.js
+* works with null host context
+
 src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
 * should render a simple component
 * should render a simple component, in steps if needed

--- a/src/renderers/shared/fiber/__tests__/ReactFiberHostContext-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactFiberHostContext-test.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var React;
+var ReactFiberReconciler;
+
+describe('ReactFiberHostContext', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    React = require('React');
+    ReactFiberReconciler = require('ReactFiberReconciler');
+  });
+
+  it('works with null host context', () => {
+    var creates = 0;
+    var Renderer = ReactFiberReconciler({
+      prepareForCommit: function() {},
+      resetAfterCommit: function() {},
+      getRootHostContext: function() {
+        return null;
+      },
+      getChildHostContext: function() {
+        return null;
+      },
+      shouldSetTextContent: function() {
+        return false;
+      },
+      createInstance: function() {
+        creates++;
+      },
+      finalizeInitialChildren: function() {
+        return null;
+      },
+      appendInitialChild: function() {
+        return null;
+      },
+      appendChild: function() {
+        return null;
+      },
+      useSyncScheduling: true,
+    });
+
+    const container = Renderer.createContainer(/* root: */ null);
+    Renderer.updateContainer(
+      <a><b /></a>,
+      container,
+      /* parentComponent: */ null,
+      /* callback: */ null,
+    );
+    expect(creates).toBe(2);
+  });
+});


### PR DESCRIPTION
If your renderer doesn't use host context, you might prefer to return null. This used to give an error:

> Invariant Violation: Expected host context to exist. This error is likely caused by a bug in React. Please file an issue.

I use a sentinel value instead now.

The code in ReactFiberHostContext is a little complicated now. We could probably also just remove the invariants.