### PR TITLE
Change `target` to `currentTarget` in documentation for React forms

### DIFF
--- a/docs/docs/forms.md
+++ b/docs/docs/forms.md
@@ -42,7 +42,7 @@ class NameForm extends React.Component {
   }
 
   handleChange(event) {
-    this.setState({value: event.target.value});
+    this.setState({value: event.currentTarget.value});
   }
 
   handleSubmit(event) {
@@ -72,7 +72,7 @@ With a controlled component, every state mutation will have an associated handle
 
 ```javascript{2}
 handleChange(event) {
-  this.setState({value: event.target.value.toUpperCase()});
+  this.setState({value: event.currentTarget.value.toUpperCase()});
 }
 ```
 
@@ -101,7 +101,7 @@ class EssayForm extends React.Component {
   }
 
   handleChange(event) {
-    this.setState({value: event.target.value});
+    this.setState({value: event.currentTarget.value});
   }
 
   handleSubmit(event) {


### PR DESCRIPTION
Because `currentTarget` is more appropriate
(https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget)
and it makes TypeScript typing works better
(https://github.com/DefinitelyTyped/DefinitelyTyped/pull/12239 and
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/11508#issuecomment-256045682)

**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure the test suite passes (`npm test`).
5. Make sure your code lints (`npm run lint`).
6. Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
7. Run the [Flow](https://flowtype.org/) typechecks (`npm run flow`).
8. If you added or removed any tests, run `./scripts/fiber/record-tests` before submitting the pull request, and commit the resulting changes.
9. If you haven't already, complete the CLA.
