### PR TITLE
Remove captured scroll feature check

### DIFF
--- a/src/renderers/dom/shared/ReactBrowserEventEmitter.js
+++ b/src/renderers/dom/shared/ReactBrowserEventEmitter.js
@@ -262,19 +262,11 @@ var ReactBrowserEventEmitter = Object.assign({}, ReactEventEmitterMixin, {
             );
           }
         } else if (dependency === 'topScroll') {
-          if (isEventSupported('scroll', true)) {
-            ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
-              'topScroll',
-              'scroll',
-              mountAt,
-            );
-          } else {
-            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(
-              'topScroll',
-              'scroll',
-              ReactBrowserEventEmitter.ReactEventListener.WINDOW_HANDLE,
-            );
-          }
+          ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
+            'topScroll',
+            'scroll',
+            mountAt,
+          );
         } else if (dependency === 'topFocus' || dependency === 'topBlur') {
           if (isEventSupported('focus', true)) {
             ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(

--- a/src/renderers/dom/shared/ReactEventListener.js
+++ b/src/renderers/dom/shared/ReactEventListener.js
@@ -12,7 +12,6 @@
 'use strict';
 
 var EventListener = require('fbjs/lib/EventListener');
-var ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
 var PooledClass = require('PooledClass');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var ReactGenericBatching = require('ReactGenericBatching');
@@ -110,8 +109,6 @@ function scrollValueMonitor(cb) {
 var ReactEventListener = {
   _enabled: true,
   _handleTopLevel: null,
-
-  WINDOW_HANDLE: ExecutionEnvironment.canUseDOM ? window : null,
 
   setHandleTopLevel: function(handleTopLevel) {
     ReactEventListener._handleTopLevel = handleTopLevel;


### PR DESCRIPTION
IE8 was the only browser that did not support captured scroll. We no
longer have that constraint.

### Testing Methodology

I extracted the feature check from React into a CodePen:
http://codepen.io/nhunzaker/pen/KWrmwz

From there, I ran the "debug" view in every single browser via BrowserStack.


### Results

YES
----
IE9
FF 3
Chrome 15
Opera 10.6
Yandex 14.12
Safari 4 - Windows
Safari 4 - Mac
Windows Phone 8.1
iOS 4.3.2
Android 4

NO
-----
IE8