### PR TITLE
[Documentation] Details/Example for Indexes as keys

### DIFF
--- a/docs/docs/lists-and-keys.md
+++ b/docs/docs/lists-and-keys.md
@@ -130,7 +130,7 @@ const todoItems = todos.map((todo, index) =>
 );
 ```
 
-We don't recommend using indexes for keys if the items can reorder, as that would impact performance and may cause issues with the components state. If you choose not to assign a key to your list items then React will use indexes as keys. You may read an [in-depth explanation about why keys are necessary](/react/docs/reconciliation.html#recursing-on-children) if you're interested in more information.
+We don't recommend using indexes for keys if the items can reorder as that would impact performance, and may cause issues with the reordering of components and their respective states. If you choose not to assign a key to your list items then React will use indexes as keys. You may read an [in-depth explanation about why keys are necessary](/react/docs/reconciliation.html#recursing-on-children) if you're interested in more information.
 
 ### Extracting Components with Keys
 

--- a/docs/docs/lists-and-keys.md
+++ b/docs/docs/lists-and-keys.md
@@ -130,7 +130,7 @@ const todoItems = todos.map((todo, index) =>
 );
 ```
 
-We don't recommend using indexes for keys if the items can reorder, as that would be slow. You may read an [in-depth explanation about why keys are necessary](/react/docs/reconciliation.html#recursing-on-children) if you're interested.
+We don't recommend using indexes for keys if the items can reorder, as that would impact performance and may cause issues with the components state. If you choose not to assign a key to your list items then React will use indexes as keys. You may read an [in-depth explanation about why keys are necessary](/react/docs/reconciliation.html#recursing-on-children) if you're interested in more information.
 
 ### Extracting Components with Keys
 

--- a/docs/docs/reconciliation.md
+++ b/docs/docs/reconciliation.md
@@ -140,9 +140,9 @@ When that's not the case, you can add a new ID property to your model or hash so
 
 As a last resort, you can pass item's index in the array as a key. This can work well if the items are never reordered, but reorders will be slow as React will naively update components.
 
-There can also be issues with the state of a component in a list if indexes are used as keys. The state of the first item (or any deep state inside of it) will stay attached to the first item even if it has “moved” in the data source. This can be confusing with inputs retaining their values in the original places even when their parent components reorder.
+There can also be issues with the state of a component in a list if indexes are used as keys. The state of the first item in a list (or any deep state inside of it) will stay attached to the first item even if it has “moved” in the data source. This can be confusing with inputs retaining their values in the original places even when their parent components reorder or are prepended to.
 
-[Here](https://codepen.io/ajcumine/pen/BWGWOE?editors=0010) is an example of the issues that can be caused by using indexes as keys on  CodePen.
+[Here](http://codepen.io/ajcumine/pen/KmVWmQ?editors=0010) is an example of the issues that can be caused by using indexes as keys on CodePen, and [here](https://codepen.io/ajcumine/pen/ZKQeJM?editors=0010) is a updated version of the same example showing how not using indexes as keys will fix these sorting issues.
 
 ## Tradeoffs
 

--- a/docs/docs/reconciliation.md
+++ b/docs/docs/reconciliation.md
@@ -138,11 +138,11 @@ In practice, finding a key is usually not hard. The element you are going to dis
 
 When that's not the case, you can add a new ID property to your model or hash some parts of the content to generate a key. The key only has to be unique among its siblings, not globally unique.
 
-As a last resort, you can pass item's index in the array as a key. This can work well if the items are never reordered, but reorders will be slow as React will naively update components.
+As a last resort, you can pass item's index in the array as a key. This can work well if the items are never reordered. However, there will be a performance impact with reordering as React will naively update components.
 
-There can also be issues with the state of a component in a list if indexes are used as keys. The state of the first item in a list (or any deep state inside of it) will stay attached to the first item even if it has “moved” in the data source. This can be confusing with inputs retaining their values in the original places even when their parent components reorder or are prepended to.
+There can also be issues with the state of a component in a list if indexes are used as keys. The state of an item in a list (or any deep state inside of it) will stay attached to the original position of the item, even if the item has “moved” in the data source. This is particularly noticeable with inputs retaining their values in the original positions even when their parent components reorder or are prepended to.
 
-[Here](http://codepen.io/ajcumine/pen/KmVWmQ?editors=0010) is an example of the issues that can be caused by using indexes as keys on CodePen, and [here](https://codepen.io/ajcumine/pen/ZKQeJM?editors=0010) is a updated version of the same example showing how not using indexes as keys will fix these sorting issues.
+[Here](http://codepen.io/ajcumine/pen/KmVWmQ?editors=0010) is an example of the issues that can be caused by using indexes as keys on CodePen, and [here](https://codepen.io/ajcumine/pen/ZKQeJM?editors=0010) is a updated version of the same example showing how not using indexes as keys will fix these reordering, sorting, and prepending issues.
 
 ## Tradeoffs
 

--- a/docs/docs/reconciliation.md
+++ b/docs/docs/reconciliation.md
@@ -138,7 +138,11 @@ In practice, finding a key is usually not hard. The element you are going to dis
 
 When that's not the case, you can add a new ID property to your model or hash some parts of the content to generate a key. The key only has to be unique among its siblings, not globally unique.
 
-As a last resort, you can pass item's index in the array as a key. This can work well if the items are never reordered, but reorders will be slow.
+As a last resort, you can pass item's index in the array as a key. This can work well if the items are never reordered, but reorders will be slow as React will naively update components.
+
+There can also be issues with the state of a component in a list if indexes are used as keys. The state of the first item (or any deep state inside of it) will stay attached to the first item even if it has “moved” in the data source. This can be confusing with inputs retaining their values in the original places even when their parent components reorder.
+
+[Here](https://codepen.io/ajcumine/pen/BWGWOE?editors=0010) is an example of the issues that can be caused by using indexes as keys on  CodePen.
 
 ## Tradeoffs
 


### PR DESCRIPTION
This aims to add more information to the documentation and address #9260 

1. Added more details on the performance and state issues cause by using indexes as keys in lists.
2. Added information that React uses indexes as keys if none are given.
3. Added a link to an example on Codepen to show the issue cause by using indexes as keys in list on state. http://codepen.io/ajcumine/pen/KmVWmQ?editors=0010
4. Added a link to an example on Codepen to show how not using indexes as keys in a list fixes the previous example's issues with state and reordering. https://codepen.io/ajcumine/pen/ZKQeJM?editors=0010

