### PR TITLE
Remove captured focus feature check

### DIFF
--- a/src/renderers/dom/shared/ReactBrowserEventEmitter.js
+++ b/src/renderers/dom/shared/ReactBrowserEventEmitter.js
@@ -276,31 +276,16 @@ var ReactBrowserEventEmitter = Object.assign({}, ReactEventEmitterMixin, {
             );
           }
         } else if (dependency === 'topFocus' || dependency === 'topBlur') {
-          if (isEventSupported('focus', true)) {
-            ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
-              'topFocus',
-              'focus',
-              mountAt,
-            );
-            ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
-              'topBlur',
-              'blur',
-              mountAt,
-            );
-          } else if (isEventSupported('focusin')) {
-            // IE has `focusin` and `focusout` events which bubble.
-            // @see http://www.quirksmode.org/blog/archives/2008/04/delegating_the.html
-            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(
-              'topFocus',
-              'focusin',
-              mountAt,
-            );
-            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(
-              'topBlur',
-              'focusout',
-              mountAt,
-            );
-          }
+          ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
+            'topFocus',
+            'focus',
+            mountAt,
+          );
+          ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
+            'topBlur',
+            'blur',
+            mountAt,
+          );
 
           // to make sure blur and focus event listeners are only attached once
           isListening.topBlur = true;


### PR DESCRIPTION
IE8 was the only browser that did not support captured focus. We no
longer have that constraint.

Simpler to my last PR.

### Testing Methodology

I extracted the feature check from React into a CodePen:
http://codepen.io/nhunzaker/pen/xqQdgj

From there, I ran the "debug" view in every single browser via BrowserStack.

### Results

YES
----
IE9
FF 3
Chrome 15
Opera 10.6
Yandex 14.12
Safari 4 - Windows
Safari 4 - Mac
Windows Phone 8.1
iOS 4.3.2
Android 4

NO
-----
IE8