### PR TITLE
Added semicolons to addons imports examples.

### DIFF
--- a/docs/docs/addons-animation.md
+++ b/docs/docs/addons-animation.md
@@ -21,8 +21,8 @@ The [`ReactTransitionGroup`](#low-level-api-reacttransitiongroup) add-on compone
 **Importing**
 
 ```javascript
-import ReactCSSTransitionGroup from 'react-addons-css-transition-group' // ES6
-var ReactCSSTransitionGroup = require('react-addons-css-transition-group') // ES5 with npm
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group'; // ES6
+var ReactCSSTransitionGroup = require('react-addons-css-transition-group'); // ES5 with npm
 var ReactCSSTransitionGroup = React.addons.CSSTransitionGroup; // ES5 with react-with-addons.js
 ```
 

--- a/docs/docs/addons-create-fragment.md
+++ b/docs/docs/addons-create-fragment.md
@@ -11,8 +11,8 @@ next: perf.html
 **Importing**
 
 ```javascript
-import createFragment from 'react-addons-create-fragment' // ES6
-var createFragment = require('react-addons-create-fragment') // ES5 with npm
+import createFragment from 'react-addons-create-fragment'; // ES6
+var createFragment = require('react-addons-create-fragment'); // ES5 with npm
 var createFragment = React.addons.createFragment; // ES5 with react-with-addons.js
 ```
 
@@ -42,8 +42,8 @@ To solve this problem, you can use the `createFragment` add-on to give keys to t
 
 Instead of creating arrays, we write:
 
-```js
-import createFragment from 'react-addons-create-fragment'
+```javascript
+import createFragment from 'react-addons-create-fragment';
 
 function Swapper(props) {
   let children;

--- a/docs/docs/addons-perf.md
+++ b/docs/docs/addons-perf.md
@@ -11,8 +11,8 @@ next: test-utils.html
 **Importing**
 
 ```javascript
-import Perf from 'react-addons-perf' // ES6
-var Perf = require('react-addons-perf') // ES5 with npm
+import Perf from 'react-addons-perf'; // ES6
+var Perf = require('react-addons-perf'); // ES5 with npm
 var Perf = React.addons.Perf; // ES5 with react-with-addons.js
 ```
 

--- a/docs/docs/addons-pure-render-mixin.md
+++ b/docs/docs/addons-pure-render-mixin.md
@@ -12,8 +12,8 @@ category: Add-Ons
 **Importing**
 
 ```javascript
-import PureRenderMixin from 'react-addons-pure-render-mixin' // ES6
-var PureRenderMixin = require('react-addons-pure-render-mixin') // ES5 with npm
+import PureRenderMixin from 'react-addons-pure-render-mixin'; // ES6
+var PureRenderMixin = require('react-addons-pure-render-mixin'); // ES5 with npm
 var PureRenderMixin = React.addons.PureRenderMixin; // ES5 with react-with-addons.js
 ```
 

--- a/docs/docs/addons-shallow-compare.md
+++ b/docs/docs/addons-shallow-compare.md
@@ -12,8 +12,8 @@ category: Reference
 **Importing**
 
 ```javascript
-import shallowCompare from 'react-addons-shallow-compare' // ES6
-var shallowCompare = require('react-addons-shallow-compare') // ES5 with npm
+import shallowCompare from 'react-addons-shallow-compare'; // ES6
+var shallowCompare = require('react-addons-shallow-compare'); // ES5 with npm
 var shallowCompare = React.addons.shallowCompare; // ES5 with react-with-addons.js
 ```
 

--- a/docs/docs/addons-test-utils.md
+++ b/docs/docs/addons-test-utils.md
@@ -10,8 +10,8 @@ prev: perf.html
 **Importing**
 
 ```javascript
-import ReactTestUtils from 'react-addons-test-utils' // ES6
-var ReactTestUtils = require('react-addons-test-utils') // ES5 with npm
+import ReactTestUtils from 'react-addons-test-utils'; // ES6
+var ReactTestUtils = require('react-addons-test-utils'); // ES5 with npm
 var ReactTestUtils = React.addons.TestUtils; // ES5 with react-with-addons.js
 ```
 

--- a/docs/docs/addons-two-way-binding-helpers.md
+++ b/docs/docs/addons-two-way-binding-helpers.md
@@ -14,8 +14,8 @@ next: update.html
 **Importing**
 
 ```javascript
-import LinkedStateMixin from 'react-addons-linked-state-mixin' // ES6
-var LinkedStateMixin = require('react-addons-linked-state-mixin') // ES5 with npm
+import LinkedStateMixin from 'react-addons-linked-state-mixin'; // ES6
+var LinkedStateMixin = require('react-addons-linked-state-mixin'); // ES5 with npm
 var LinkedStateMixin = React.addons.LinkedStateMixin; // ES5 with react-with-addons.js
 ```
 


### PR DESCRIPTION
I'm not sure if this was intentional, but I'm fairly sure that the semicolons should be there.
