### PR TITLE
Show more meanignful stack trace for ReactNative errors

### DIFF
--- a/flow/react-native-host-hooks.js
+++ b/flow/react-native-host-hooks.js
@@ -26,6 +26,12 @@ declare module 'TextInputState' {
   declare function blurTextInput(object : any) : void;
   declare function focusTextInput(object : any) : void;
 }
+declare module 'ExceptionsManager' {
+  declare function handleException(
+    error: Error,
+    isFatal: boolean,
+  ) : void;
+}
 declare module 'UIManager' {
   declare var customBubblingEventTypes : Object;
   declare var customDirectEventTypes : Object;

--- a/src/__mocks__/ExceptionsManager.js
+++ b/src/__mocks__/ExceptionsManager.js
@@ -10,5 +10,5 @@
 'use strict';
 
 module.exports = {
-  handleException: jest.fn()
+  handleException: jest.fn(),
 };

--- a/src/__mocks__/ExceptionsManager.js
+++ b/src/__mocks__/ExceptionsManager.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+module.exports = {
+  handleException: jest.fn()
+};

--- a/src/renderers/native/ReactNativeFiber.js
+++ b/src/renderers/native/ReactNativeFiber.js
@@ -378,7 +378,6 @@ findNodeHandle.injection.injectFindNode((fiber: Fiber) =>
   NativeRenderer.findHostInstance(fiber));
 findNodeHandle.injection.injectFindRootNodeID(instance => instance);
 
-
 // Intercept lifecycle errors and ensure they are shown with the correct stack
 // trace within the native redbox component.
 ReactFiberErrorLogger.injection.injectDialog(

--- a/src/renderers/native/ReactNativeFiber.js
+++ b/src/renderers/native/ReactNativeFiber.js
@@ -12,10 +12,12 @@
 
 'use strict';
 
+const ReactFiberErrorLogger = require('ReactFiberErrorLogger');
 const ReactFiberReconciler = require('ReactFiberReconciler');
 const ReactGenericBatching = require('ReactGenericBatching');
 const ReactNativeAttributePayload = require('ReactNativeAttributePayload');
 const ReactNativeComponentTree = require('ReactNativeComponentTree');
+const ReactNativeFiberErrorDialog = require('ReactNativeFiberErrorDialog');
 const ReactNativeFiberHostComponent = require('ReactNativeFiberHostComponent');
 const ReactNativeInjection = require('ReactNativeInjection');
 const ReactNativeTagHandles = require('ReactNativeTagHandles');
@@ -375,6 +377,13 @@ const roots = new Map();
 findNodeHandle.injection.injectFindNode((fiber: Fiber) =>
   NativeRenderer.findHostInstance(fiber));
 findNodeHandle.injection.injectFindRootNodeID(instance => instance);
+
+
+// Intercept lifecycle errors and ensure they are shown with the correct stack
+// trace within the native redbox component.
+ReactFiberErrorLogger.injection.injectDialog(
+  ReactNativeFiberErrorDialog.showDialog,
+);
 
 const ReactNative = {
   // External users of findNodeHandle() expect the host tag number return type.

--- a/src/renderers/native/ReactNativeFiberErrorDialog.js
+++ b/src/renderers/native/ReactNativeFiberErrorDialog.js
@@ -21,18 +21,16 @@ import type {CapturedError} from 'ReactFiberScheduler';
  * trace within the native redbox component.
  */
 function ReactNativeFiberErrorDialog(capturedError: CapturedError): boolean {
-  const { componentStack, error } = capturedError;
-  const { message, name } = error;
+  const {componentStack, error} = capturedError;
+  const {message, name} = error;
 
-  const errorSummary = message
-    ? `${name}: ${message}`
-    : name;
+  const errorSummary = message ? `${name}: ${message}` : name;
 
   // Trimmed down version of the text we normally log to console.error via
   // ReactFiberErrorLogger. The reduced message is easier to read on a smaller
   // mobile screen.
   const newError = new error.constructor(
-    `${errorSummary}\n\nThis error is located at:${componentStack}`
+    `${errorSummary}\n\nThis error is located at:${componentStack}`,
   );
   newError.stack = error.stack;
 

--- a/src/renderers/native/ReactNativeFiberErrorDialog.js
+++ b/src/renderers/native/ReactNativeFiberErrorDialog.js
@@ -22,17 +22,28 @@ import type {CapturedError} from 'ReactFiberScheduler';
  */
 function ReactNativeFiberErrorDialog(capturedError: CapturedError): boolean {
   const {componentStack, error} = capturedError;
-  const {message, name} = error;
 
-  const errorSummary = message ? `${name}: ${message}` : name;
+  let errorMessage: string;
+  let errorStack: string;
+  let errorType: Class<Error>;
 
-  // Trimmed down version of the text we normally log to console.error via
-  // ReactFiberErrorLogger. The reduced message is easier to read on a smaller
-  // mobile screen.
-  const newError = new error.constructor(
-    `${errorSummary}\n\nThis error is located at:${componentStack}`,
-  );
-  newError.stack = error.stack;
+  // Typically Errors are thrown but eg strings or null can be thrown as well.
+  if (error && typeof error === 'object') {
+    const {message, name} = error;
+
+    const summary = message ? `${name}: ${message}` : name;
+
+    errorMessage = `${summary}\n\nThis error is located at:${componentStack}`;
+    errorStack = error.stack;
+    errorType = error.constructor;
+  } else {
+    errorMessage = `Unspecified error at:${componentStack}`;
+    errorStack = '';
+    errorType = Error;
+  }
+
+  const newError = new errorType(errorMessage);
+  newError.stack = errorStack;
 
   ExceptionsManager.handleException(newError, false);
 

--- a/src/renderers/native/ReactNativeFiberErrorDialog.js
+++ b/src/renderers/native/ReactNativeFiberErrorDialog.js
@@ -20,7 +20,7 @@ import type {CapturedError} from 'ReactFiberScheduler';
  * Intercept lifecycle errors and ensure they are shown with the correct stack
  * trace within the native redbox component.
  */
-function ReactNativeFiberErrorDialog(capturedError: CapturedError): ?boolean {
+function ReactNativeFiberErrorDialog(capturedError: CapturedError): boolean {
   const { componentStack, error } = capturedError;
   const { message, name } = error;
 
@@ -38,11 +38,11 @@ function ReactNativeFiberErrorDialog(capturedError: CapturedError): ?boolean {
 
   ExceptionsManager.handleException(newError, false);
 
-  // Return true here to prevent ReactFiberErrorLogger default behavior of
+  // Return false here to prevent ReactFiberErrorLogger default behavior of
   // logging error details to console.error. Calls to console.error are
   // automatically routed to the native redbox controller, which we've already
   // done above by calling ExceptionsManager.
-  return true;
+  return false;
 }
 
 module.exports.showDialog = ReactNativeFiberErrorDialog;

--- a/src/renderers/native/ReactNativeFiberErrorDialog.js
+++ b/src/renderers/native/ReactNativeFiberErrorDialog.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactNativeFiberErrorDialog
+ * @flow
+ */
+
+'use strict';
+
+const ExceptionsManager = require('ExceptionsManager');
+
+import type {CapturedError} from 'ReactFiberScheduler';
+
+/**
+ * Intercept lifecycle errors and ensure they are shown with the correct stack
+ * trace within the native redbox component.
+ */
+function ReactNativeFiberErrorDialog(capturedError: CapturedError): ?boolean {
+  const { componentStack, error } = capturedError;
+  const { message, name } = error;
+
+  const errorSummary = message
+    ? `${name}: ${message}`
+    : name;
+
+  // Trimmed down version of the text we normally log to console.error via
+  // ReactFiberErrorLogger. The reduced message is easier to read on a smaller
+  // mobile screen.
+  const newError = new error.constructor(
+    `${errorSummary}\n\nThis error is located at:${componentStack}`
+  );
+  newError.stack = error.stack;
+
+  ExceptionsManager.handleException(newError, false);
+
+  // Return true here to prevent ReactFiberErrorLogger default behavior of
+  // logging error details to console.error. Calls to console.error are
+  // automatically routed to the native redbox controller, which we've already
+  // done above by calling ExceptionsManager.
+  return true;
+}
+
+module.exports.showDialog = ReactNativeFiberErrorDialog;

--- a/src/renderers/shared/fiber/ReactFiberErrorLogger.js
+++ b/src/renderers/shared/fiber/ReactFiberErrorLogger.js
@@ -12,7 +12,6 @@
 
 'use strict';
 
-const emptyFunction = require('fbjs/lib/emptyFunction');
 const invariant = require('fbjs/lib/invariant');
 
 import type {CapturedError} from 'ReactFiberScheduler';

--- a/src/renderers/shared/fiber/ReactFiberErrorLogger.js
+++ b/src/renderers/shared/fiber/ReactFiberErrorLogger.js
@@ -20,6 +20,14 @@ import type {CapturedError} from 'ReactFiberScheduler';
 let showDialog = emptyFunction;
 
 function logCapturedError(capturedError: CapturedError): void {
+  const logError = showDialog(capturedError);
+
+  // Allow injected showDialog() to prevent default console.error logging.
+  // This enables renderers like ReactNative to better manage redbox behavior.
+  if (logError === true) {
+    return;
+  }
+
   if (__DEV__) {
     const {
       componentName,
@@ -85,12 +93,10 @@ function logCapturedError(capturedError: CapturedError): void {
       `React caught an error thrown by one of your components.\n\n${error.stack}`,
     );
   }
-
-  showDialog(capturedError);
 }
 
 exports.injection = {
-  injectDialog(fn: (e: CapturedError) => void) {
+  injectDialog(fn: (e: CapturedError) => ?boolean) {
     invariant(
       showDialog === emptyFunction,
       'The custom dialog was already injected.',

--- a/src/renderers/shared/fiber/ReactFiberErrorLogger.js
+++ b/src/renderers/shared/fiber/ReactFiberErrorLogger.js
@@ -17,14 +17,16 @@ const invariant = require('fbjs/lib/invariant');
 
 import type {CapturedError} from 'ReactFiberScheduler';
 
-let showDialog = emptyFunction;
+const defaultShowDialog = () => true;
+
+let showDialog = defaultShowDialog;
 
 function logCapturedError(capturedError: CapturedError): void {
   const logError = showDialog(capturedError);
 
   // Allow injected showDialog() to prevent default console.error logging.
   // This enables renderers like ReactNative to better manage redbox behavior.
-  if (logError === true) {
+  if (logError === false) {
     return;
   }
 
@@ -96,9 +98,13 @@ function logCapturedError(capturedError: CapturedError): void {
 }
 
 exports.injection = {
-  injectDialog(fn: (e: CapturedError) => ?boolean) {
+  /**
+   * Display custom dialog for lifecycle errors.
+   * Return false to prevent default behavior of logging to console.error.
+   */
+  injectDialog(fn: (e: CapturedError) => boolean) {
     invariant(
-      showDialog === emptyFunction,
+      showDialog === defaultShowDialog,
       'The custom dialog was already injected.',
     );
     invariant(


### PR DESCRIPTION
(_This is an upstream sync from a change committed to fbsource._)

Clicking on the stack should jump to where the error actually occurred rather than to where it's logged in a redbox component.

### Before
![image](https://cloud.githubusercontent.com/assets/29597/24514898/b7c5de44-152a-11e7-8e39-48cb2ae067ef.png)

### After
![image](https://cloud.githubusercontent.com/assets/29597/24514903/babd9eb6-152a-11e7-998f-ed2a78b97069.png)
