### PR TITLE
Move takeSnapshot from UIManager to ReactNative renderer(s)

### DIFF
--- a/flow/react-native-host-hooks.js
+++ b/flow/react-native-host-hooks.js
@@ -58,6 +58,15 @@ declare module 'UIManager' {
     viewName : string,
     props : ?Object,
   ) : void;
+  declare function __takeSnapshot(
+    view ?: 'window' | Element<any> | number,
+    options ?: {
+       width ?: number,
+       height ?: number,
+       format ?: 'png' | 'jpeg',
+       quality ?: number,
+    },
+  ) : Promise<any>;
 }
 declare module 'View' {
   declare var exports : typeof ReactComponent;

--- a/src/__mocks__/UIManager.js
+++ b/src/__mocks__/UIManager.js
@@ -20,6 +20,7 @@ var RCTUIManager = {
   updateView: jest.fn(),
   removeSubviewsFromContainerWithID: jest.fn(),
   replaceExistingNonRootView: jest.fn(),
+  __takeSnapshot: jest.fn(),
   customBubblingEventTypes: {
     topBlur: {
       phasedRegistrationNames: {

--- a/src/renderers/native/ReactNativeFiber.js
+++ b/src/renderers/native/ReactNativeFiber.js
@@ -27,6 +27,7 @@ const deepFreezeAndThrowOnMutationInDev = require('deepFreezeAndThrowOnMutationI
 const emptyObject = require('fbjs/lib/emptyObject');
 const findNodeHandle = require('findNodeHandle');
 const invariant = require('fbjs/lib/invariant');
+const takeSnapshot = require('takeSnapshot');
 
 const {injectInternals} = require('ReactFiberDevToolsHook');
 
@@ -401,6 +402,8 @@ const ReactNative = {
 
     return NativeRenderer.getPublicRootInstance(root);
   },
+
+  takeSnapshot,
 
   unmountComponentAtNode(containerTag: number) {
     const root = roots.get(containerTag);

--- a/src/renderers/native/ReactNativeStack.js
+++ b/src/renderers/native/ReactNativeStack.js
@@ -18,6 +18,7 @@ var ReactNativeStackInjection = require('ReactNativeStackInjection');
 var ReactUpdates = require('ReactUpdates');
 
 var findNodeHandle = require('findNodeHandle');
+var takeSnapshot = require('takeSnapshot');
 
 ReactNativeInjection.inject();
 ReactNativeStackInjection.inject();
@@ -45,6 +46,9 @@ var ReactNative = {
   },
 
   render: render,
+
+  takeSnapshot,
+
   unmountComponentAtNode: ReactNativeMount.unmountComponentAtNode,
 
   /* eslint-disable camelcase */

--- a/src/renderers/native/takeSnapshot.js
+++ b/src/renderers/native/takeSnapshot.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule takeSnapshot
+ * @flow
+ */
+'use strict';
+
+var ReactNative = require('ReactNative');
+var UIManager = require('UIManager');
+
+import type {Element} from 'React';
+
+/**
+ * Capture an image of the screen, window or an individual view. The image
+ * will be stored in a temporary file that will only exist for as long as the
+ * app is running.
+ *
+ * The `view` argument can be the literal string `window` if you want to
+ * capture the entire window, or it can be a reference to a specific
+ * React Native component.
+ *
+ * The `options` argument may include:
+ * - width/height (number) - the width and height of the image to capture.
+ * - format (string) - either 'png' or 'jpeg'. Defaults to 'png'.
+ * - quality (number) - the quality when using jpeg. 0.0 - 1.0 (default).
+ *
+ * Returns a Promise.
+ * @platform ios
+ */
+function takeSnapshot(
+  view ?: 'window' | Element<any> | number,
+  options ?: {
+     width ?: number,
+     height ?: number,
+     format ?: 'png' | 'jpeg',
+     quality ?: number,
+  },
+) : Promise<any> {
+  if (
+    typeof view !== 'number' &&
+    view !== 'window'
+  ) {
+    view = ReactNative.findNodeHandle(view) || 'window';
+  }
+
+  // Call the hidden '__takeSnapshot' method; the main one throws an error to
+  // prevent accidental backwards-incompatible usage.
+  return UIManager.__takeSnapshot(view, options);
+}
+
+module.exports = takeSnapshot;

--- a/src/renderers/native/takeSnapshot.js
+++ b/src/renderers/native/takeSnapshot.js
@@ -34,18 +34,15 @@ import type {Element} from 'React';
  * @platform ios
  */
 function takeSnapshot(
-  view ?: 'window' | Element<any> | number,
-  options ?: {
-     width ?: number,
-     height ?: number,
-     format ?: 'png' | 'jpeg',
-     quality ?: number,
+  view?: 'window' | Element<any> | number,
+  options?: {
+    width?: number,
+    height?: number,
+    format?: 'png' | 'jpeg',
+    quality?: number,
   },
-) : Promise<any> {
-  if (
-    typeof view !== 'number' &&
-    view !== 'window'
-  ) {
+): Promise<any> {
+  if (typeof view !== 'number' && view !== 'window') {
     view = ReactNative.findNodeHandle(view) || 'window';
   }
 


### PR DESCRIPTION
(_This is an upstream sync from a change committed to fbsource._)

This prevents a potential cycle between `UIManager` <> `ReactNative` and unblocks flat bundling for ReactNative.