### PR TITLE
WIP - convert public React core properties to strings so uglify/gcc can mangle

### DIFF
--- a/src/isomorphic/React.js
+++ b/src/isomorphic/React.js
@@ -55,35 +55,35 @@ if (__DEV__) {
 var React = {
   // Modern
 
-  Children: {
-    map: ReactChildren.map,
-    forEach: ReactChildren.forEach,
-    count: ReactChildren.count,
-    toArray: ReactChildren.toArray,
-    only: onlyChild,
+  'Children': {
+    'map': ReactChildren.map,
+    'forEach': ReactChildren.forEach,
+    'count': ReactChildren.count,
+    'toArray': ReactChildren.toArray,
+    'only': onlyChild,
   },
 
-  Component: ReactBaseClasses.Component,
-  PureComponent: ReactBaseClasses.PureComponent,
+  'Component': ReactBaseClasses.Component,
+  'PureComponent': ReactBaseClasses.PureComponent,
 
-  createElement: createElement,
-  cloneElement: cloneElement,
-  isValidElement: ReactElement.isValidElement,
+  'createElement': createElement,
+  'cloneElement': cloneElement,
+  'isValidElement': ReactElement.isValidElement,
 
-  checkPropTypes: checkPropTypes,
+  'checkPropTypes': checkPropTypes,
 
   // Classic
 
-  PropTypes: ReactPropTypes,
-  createClass: ReactClass.createClass,
-  createFactory: createFactory,
-  createMixin: createMixin,
+  'PropTypes': ReactPropTypes,
+  'createClass': ReactClass.createClass,
+  'createFactory': createFactory,
+  'createMixin': createMixin,
 
   // This looks DOM specific but these are actually isomorphic helpers
   // since they are just generating DOM strings.
-  DOM: ReactDOMFactories,
+  'DOM': ReactDOMFactories,
 
-  version: ReactVersion,
+  'version': ReactVersion,
 };
 
 module.exports = React;

--- a/src/isomorphic/classic/element/ReactElement.js
+++ b/src/isomorphic/classic/element/ReactElement.js
@@ -117,16 +117,16 @@ function defineRefPropWarningGetter(props, displayName) {
 var ReactElement = function(type, key, ref, self, source, owner, props) {
   var element = {
     // This tag allow us to uniquely identify this as a React Element
-    $$typeof: REACT_ELEMENT_TYPE,
+    '$$typeof': REACT_ELEMENT_TYPE,
 
     // Built-in properties that belong on the element
-    type: type,
-    key: key,
-    ref: ref,
-    props: props,
+    'type': type,
+    'key': key,
+    'ref': ref,
+    'props': props,
 
     // Record the component responsible for creating this element.
-    _owner: owner,
+    '_owner': owner,
   };
 
   if (__DEV__) {

--- a/src/isomorphic/modern/class/ReactBaseClasses.js
+++ b/src/isomorphic/modern/class/ReactBaseClasses.js
@@ -22,12 +22,12 @@ var warning = require('fbjs/lib/warning');
  * Base class helpers for the updating state of a component.
  */
 function ReactComponent(props, context, updater) {
-  this.props = props;
-  this.context = context;
-  this.refs = emptyObject;
+  this['props'] = props;
+  this['context'] = context;
+  this['refs'] = emptyObject;
   // We initialize the default updater but the real one gets injected by the
   // renderer.
-  this.updater = updater || ReactNoopUpdateQueue;
+  this['updater'] = updater || ReactNoopUpdateQueue;
 }
 
 ReactComponent.prototype.isReactComponent = {};
@@ -65,7 +65,7 @@ ReactComponent.prototype.setState = function(partialState, callback) {
     'setState(...): takes an object of state variables to update or a ' +
       'function which returns an object of state variables.',
   );
-  this.updater.enqueueSetState(this, partialState, callback, 'setState');
+  this['updater'].enqueueSetState(this, partialState, callback, 'setState');
 };
 
 /**
@@ -83,7 +83,7 @@ ReactComponent.prototype.setState = function(partialState, callback) {
  * @protected
  */
 ReactComponent.prototype.forceUpdate = function(callback) {
-  this.updater.enqueueForceUpdate(this, callback, 'forceUpdate');
+  this['updater'].enqueueForceUpdate(this, callback, 'forceUpdate');
 };
 
 /**
@@ -131,12 +131,12 @@ if (__DEV__) {
  */
 function ReactPureComponent(props, context, updater) {
   // Duplicated from ReactComponent.
-  this.props = props;
-  this.context = context;
-  this.refs = emptyObject;
+  this['props'] = props;
+  this['context'] = context;
+  this['refs'] = emptyObject;
   // We initialize the default updater but the real one gets injected by the
   // renderer.
-  this.updater = updater || ReactNoopUpdateQueue;
+  this['updater'] = updater || ReactNoopUpdateQueue;
 }
 
 function ComponentDummy() {}

--- a/src/isomorphic/modern/class/ReactNoopUpdateQueue.js
+++ b/src/isomorphic/modern/class/ReactNoopUpdateQueue.js
@@ -15,7 +15,7 @@ var warning = require('fbjs/lib/warning');
 
 function warnNoop(publicInstance, callerName) {
   if (__DEV__) {
-    var constructor = publicInstance.constructor;
+    var constructor = publicInstance['constructor'];
     warning(
       false,
       '%s(...): Can only update a mounted or mounting component. ' +
@@ -23,7 +23,7 @@ function warnNoop(publicInstance, callerName) {
         'This is a no-op.\n\nPlease check the code for the %s component.',
       callerName,
       callerName,
-      (constructor && (constructor.displayName || constructor.name)) ||
+      (constructor && (constructor['displayName'] || constructor['name'])) ||
         'ReactClass',
     );
   }
@@ -40,7 +40,7 @@ var ReactNoopUpdateQueue = {
    * @protected
    * @final
    */
-  isMounted: function(publicInstance) {
+  'isMounted': function(publicInstance) {
     return false;
   },
 
@@ -59,7 +59,7 @@ var ReactNoopUpdateQueue = {
    * @param {?string} Name of the calling function in the public API.
    * @internal
    */
-  enqueueForceUpdate: function(publicInstance, callback, callerName) {
+  'enqueueForceUpdate': function(publicInstance, callback, callerName) {
     warnNoop(publicInstance, 'forceUpdate');
   },
 
@@ -76,7 +76,7 @@ var ReactNoopUpdateQueue = {
    * @param {?string} Name of the calling function in the public API.
    * @internal
    */
-  enqueueReplaceState: function(
+  'enqueueReplaceState': function(
     publicInstance,
     completeState,
     callback,
@@ -97,7 +97,7 @@ var ReactNoopUpdateQueue = {
    * @param {?string} Name of the calling function in the public API.
    * @internal
    */
-  enqueueSetState: function(
+  'enqueueSetState': function(
     publicInstance,
     partialState,
     callback,

--- a/src/shared/utils/PooledClass.js
+++ b/src/shared/utils/PooledClass.js
@@ -111,11 +111,11 @@ var addPoolingTo = function<T>(
 };
 
 var PooledClass = {
-  addPoolingTo: addPoolingTo,
-  oneArgumentPooler: (oneArgumentPooler: Pooler),
-  twoArgumentPooler: (twoArgumentPooler: Pooler),
-  threeArgumentPooler: (threeArgumentPooler: Pooler),
-  fourArgumentPooler: (fourArgumentPooler: Pooler),
+  'addPoolingTo': addPoolingTo,
+  'oneArgumentPooler': (oneArgumentPooler: Pooler),
+  'twoArgumentPooler': (twoArgumentPooler: Pooler),
+  'threeArgumentPooler': (threeArgumentPooler: Pooler),
+  'fourArgumentPooler': (fourArgumentPooler: Pooler),
 };
 
 module.exports = PooledClass;

--- a/src/shared/utils/ReactElementSymbol.js
+++ b/src/shared/utils/ReactElementSymbol.js
@@ -14,9 +14,9 @@
 
 // The Symbol used to tag the ReactElement type. If there is no native Symbol
 // nor polyfill, then a plain number is used for performance.
-var REACT_ELEMENT_TYPE = (typeof Symbol === 'function' &&
-  Symbol.for &&
-  Symbol.for('react.element')) ||
+const SymbolFor = Symbol.for;
+var REACT_ELEMENT_TYPE = (typeof Symbol === 'function'
+  && SymbolFor && SymbolFor('react.element')) ||
   0xeac7;
 
 module.exports = REACT_ELEMENT_TYPE;

--- a/src/umd/ReactUMDEntry.js
+++ b/src/umd/ReactUMDEntry.js
@@ -16,8 +16,8 @@ var React = require('React');
 // `version` will be added here by the React module.
 var ReactUMDEntry = Object.assign(
   {
-    __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
-      ReactCurrentOwner: require('react/lib/ReactCurrentOwner'),
+    '__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED': {
+      'ReactCurrentOwner': require('react/lib/ReactCurrentOwner'),
     },
   },
   React,


### PR DESCRIPTION
Ideally, we want to be able to leverage stronger minifcations/optimizations in our tooling so we can provide even smaller bundles. Tools such as Uglify and Google Closure Compiler can do this when set to mangle internal properties. However, this can break things when properties are expected to be consumed in the wild/public or by contract from another module. 

The simplest way to deal with this limitation is to manually specify that the property shouldn't be altered when it's a string literal. Whitelisting is also an option, however that has some limitations and can result in properties that aren't public not being mangled simply because of them being a common name.

This PR is a WIP.