### PR TITLE
Remove IE8-specific shorthand style property logic

### DIFF
--- a/src/renderers/dom/shared/CSSProperty.js
+++ b/src/renderers/dom/shared/CSSProperty.js
@@ -77,71 +77,8 @@ Object.keys(isUnitlessNumber).forEach(function(prop) {
   });
 });
 
-/**
- * Most style properties can be unset by doing .style[prop] = '' but IE8
- * doesn't like doing that with shorthand properties so for the properties that
- * IE8 breaks on, which are listed here, we instead unset each of the
- * individual properties. See http://bugs.jquery.com/ticket/12385.
- * The 4-value 'clock' properties like margin, padding, border-width seem to
- * behave without any problems. Curiously, list-style works too without any
- * special prodding.
- */
-var shorthandPropertyExpansions = {
-  background: {
-    backgroundAttachment: true,
-    backgroundColor: true,
-    backgroundImage: true,
-    backgroundPositionX: true,
-    backgroundPositionY: true,
-    backgroundRepeat: true,
-  },
-  backgroundPosition: {
-    backgroundPositionX: true,
-    backgroundPositionY: true,
-  },
-  border: {
-    borderWidth: true,
-    borderStyle: true,
-    borderColor: true,
-  },
-  borderBottom: {
-    borderBottomWidth: true,
-    borderBottomStyle: true,
-    borderBottomColor: true,
-  },
-  borderLeft: {
-    borderLeftWidth: true,
-    borderLeftStyle: true,
-    borderLeftColor: true,
-  },
-  borderRight: {
-    borderRightWidth: true,
-    borderRightStyle: true,
-    borderRightColor: true,
-  },
-  borderTop: {
-    borderTopWidth: true,
-    borderTopStyle: true,
-    borderTopColor: true,
-  },
-  font: {
-    fontStyle: true,
-    fontVariant: true,
-    fontWeight: true,
-    fontSize: true,
-    lineHeight: true,
-    fontFamily: true,
-  },
-  outline: {
-    outlineWidth: true,
-    outlineStyle: true,
-    outlineColor: true,
-  },
-};
-
 var CSSProperty = {
   isUnitlessNumber: isUnitlessNumber,
-  shorthandPropertyExpansions: shorthandPropertyExpansions,
 };
 
 module.exports = CSSProperty;

--- a/src/renderers/dom/shared/CSSPropertyOperations.js
+++ b/src/renderers/dom/shared/CSSPropertyOperations.js
@@ -11,7 +11,6 @@
 
 'use strict';
 
-var CSSProperty = require('CSSProperty');
 var ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
 
 var camelizeStyleName = require('fbjs/lib/camelizeStyleName');
@@ -29,16 +28,8 @@ var processStyleName = memoizeStringOnly(function(styleName) {
   return hyphenateStyleName(styleName);
 });
 
-var hasShorthandPropertyBug = false;
 var styleFloatAccessor = 'cssFloat';
 if (ExecutionEnvironment.canUseDOM) {
-  var tempStyle = document.createElement('div').style;
-  try {
-    // IE8 throws "Invalid argument." if resetting shorthand style properties.
-    tempStyle.font = '';
-  } catch (e) {
-    hasShorthandPropertyBug = true;
-  }
   // IE8 only supports accessing cssFloat (standard) as styleFloat
   if (document.documentElement.style.cssFloat === undefined) {
     styleFloatAccessor = 'styleFloat';
@@ -218,21 +209,7 @@ var CSSPropertyOperations = {
       if (styleName === 'float' || styleName === 'cssFloat') {
         styleName = styleFloatAccessor;
       }
-      if (styleValue) {
-        style[styleName] = styleValue;
-      } else {
-        var expansion = hasShorthandPropertyBug &&
-          CSSProperty.shorthandPropertyExpansions[styleName];
-        if (expansion) {
-          // Shorthand property that IE8 won't like unsetting, so unset each
-          // component to placate it
-          for (var individualStyleName in expansion) {
-            style[individualStyleName] = '';
-          }
-        } else {
-          style[styleName] = '';
-        }
-      }
+      style[styleName] = styleValue || '';
     }
   },
 };


### PR DESCRIPTION
This logic was only here for IE8. Setting `.stype[prop]` for shorthand properties works fine in all other tested browsers.

## Testing strategy

Used the following snippet to verify shorthand property behavior

```html
 <span id="span" style="background-color: blue; font-size: 20px; font-family: monospace; border-width: 5px; border-style: solid; border-color: red; outline-width: 10px; outline-color: green;">Click Me</span>
  <script>
    var span = document.getElementById('span');
    span.onclick = function() {
      span.style.font = '';
      span.style.background = '';
      span.style.outline = '';
      span.style.border = '';
    }
  </script>
```

## Tested Browsers

Verified all listed browsers behaved as expected (unset the shorthand style property)

* IE9
* Firefox 3 (OS X Snow Leopard)
* Safari (iOS 6)
* Safari 4 (OS X Snow Leopard)
* Android Browser (Android 4.1, S3)
* Chrome (Android 4.4, Note 4)
* Windows Phone 8.1
* Opera 12.12


**edit** I updated the test to be more robust and noticed that `font` does not work in Android Browser for Android 4.1 or iOS 4. We may still need this if we support those browsers, though we should be able to remove a number of the properties.
