### PR TITLE
Added explicit null return to completeUnitOfWork() to resolve Flow error

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -684,6 +684,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         return null;
       }
     }
+
+    // Without this explicit null return Flow complains of invalid return type
+    // TODO Remove the above while(true) loop
+    return null;
   }
 
   function performUnitOfWork(workInProgress: Fiber): Fiber | null {


### PR DESCRIPTION
`completeUnitOfWork` causes Flow errors because of this `while (true)` loop:
```js
function completeUnitOfWork(workInProgress: Fiber): Fiber | null {
  while (true) {
    // ...
  }
}
```

[Here](https://flow.org/try/#0GYVwdgxgLglg9mABMOcAUBKAXIgzlAJxjAHNEBvAKEUQHcALGAGwFNE1CQWMLqbECLKCAJIA5GIDcfAL6U5QA) is a smaller repro.

Maybe we should remove or reconsider this `while` loop but for now I've fixed the issue by adding an explicit `null` return outside of the loop. (It was blocking a merge in fbsource so I fixed it there and this is an upstream sync.)