### PR TITLE
Use setProperty when setting style properties

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -816,6 +816,7 @@ src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
 * warns when miscapitalizing vendored style names
 * should warn about style having a trailing semicolon
 * should warn about style containing a NaN value
+* should not warn when setting CSS variables
 
 src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
 * should create markup for simple properties

--- a/src/renderers/dom/shared/CSSPropertyOperations.js
+++ b/src/renderers/dom/shared/CSSPropertyOperations.js
@@ -134,6 +134,10 @@ if (__DEV__) {
    * @param {ReactDOMComponent} component
    */
   var warnValidStyle = function(name, value, component) {
+    // Don't warn for CSS variables
+    if (name.indexOf('--') === 0) {
+      return;
+    }
     var owner;
     if (component) {
       owner = component._currentElement._owner;
@@ -213,8 +217,9 @@ var CSSPropertyOperations = {
       if (styleName === 'float') {
         styleName = 'cssFloat';
       }
+      var hyphenatedStyleName = processStyleName(styleName);
       if (styleValue) {
-        style[styleName] = styleValue;
+        style.setProperty(hyphenatedStyleName, styleValue);
       } else {
         var expansion = hasShorthandPropertyBug &&
           CSSProperty.shorthandPropertyExpansions[styleName];
@@ -225,7 +230,7 @@ var CSSPropertyOperations = {
             style[individualStyleName] = '';
           }
         } else {
-          style[styleName] = '';
+          style.setProperty(hyphenatedStyleName, '');
         }
       }
     }

--- a/src/renderers/dom/shared/CSSPropertyOperations.js
+++ b/src/renderers/dom/shared/CSSPropertyOperations.js
@@ -217,9 +217,10 @@ var CSSPropertyOperations = {
       if (styleName === 'float') {
         styleName = 'cssFloat';
       }
-      var hyphenatedStyleName = processStyleName(styleName);
-      if (styleValue) {
-        style.setProperty(hyphenatedStyleName, styleValue);
+      if (styleName.indexOf('--') === 0) {
+        style.setProperty(styleName, styleValue);
+      } else if (styleValue) {
+        style[styleName] = styleValue;
       } else {
         var expansion = hasShorthandPropertyBug &&
           CSSProperty.shorthandPropertyExpansions[styleName];
@@ -230,7 +231,7 @@ var CSSPropertyOperations = {
             style[individualStyleName] = '';
           }
         } else {
-          style.setProperty(hyphenatedStyleName, '');
+          style[styleName] = '';
         }
       }
     }

--- a/src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
@@ -253,4 +253,18 @@ describe('CSSPropertyOperations', () => {
         '\n\nCheck the render method of `Comp`.',
     );
   });
+
+  it('should not warn when setting CSS variables', () => {
+    class Comp extends React.Component {
+      render() {
+        return <div style={{ '--foo-primary': 'red', backgroundColor: 'red' }} />;
+      }
+    }
+
+    spyOn(console, 'error');
+    var root = document.createElement('div');
+    ReactDOM.render(<Comp />, root);
+
+    expectDev(console.error.calls.count()).toBe(0);
+  });
 });

--- a/src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
@@ -257,7 +257,7 @@ describe('CSSPropertyOperations', () => {
   it('should not warn when setting CSS variables', () => {
     class Comp extends React.Component {
       render() {
-        return <div style={{ '--foo-primary': 'red', backgroundColor: 'red' }} />;
+        return <div style={{'--foo-primary': 'red', backgroundColor: 'red'}} />;
       }
     }
 


### PR DESCRIPTION
Work in progress. Resolves https://github.com/facebook/react/issues/6411

Using `setProperty` does incur the cost of parsing the style name as `setProperty` requires the hyphenated property name (`background-color` not `backgroundColor`). I'm also not sure if we want to special case IE given the performance benefits mentioned https://github.com/facebook/react/issues/6411#issuecomment-290579386

cc @trueadm @sebmarkbage @spicyj 