### PR TITLE
Remove scroll capture support warning

### DIFF
--- a/scripts/fiber/tests-passing-except-dev.txt
+++ b/scripts/fiber/tests-passing-except-dev.txt
@@ -1,5 +1,4 @@
 src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
-* should not warn when server-side rendering `onScroll`
 * should warn about incorrect casing on properties (ssr)
 * should warn about incorrect casing on event handlers (ssr)
 * should warn about class (ssr)

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -951,7 +951,6 @@ src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * should report component containing invalid styles
 * should properly escape text content and attributes values
 * unmounts children before unsetting DOM node info
-* should warn about the `onScroll` issue when unsupported (IE8)
 * should throw when an invalid tag name is used server-side
 * should throw when an attack vector is used server-side
 * should throw when an invalid tag name is used

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -28,7 +28,6 @@ var {getCurrentFiberOwnerName} = require('ReactDebugCurrentFiber');
 
 var emptyFunction = require('fbjs/lib/emptyFunction');
 var invariant = require('fbjs/lib/invariant');
-var isEventSupported = require('isEventSupported');
 var setInnerHTML = require('setInnerHTML');
 var setTextContent = require('setTextContent');
 var inputValueTracking = require('inputValueTracking');
@@ -145,14 +144,6 @@ if (__DEV__) {
 }
 
 function ensureListeningTo(rootContainerElement, registrationName) {
-  if (__DEV__) {
-    // IE8 has no API for event capturing and the `onScroll` event doesn't
-    // bubble.
-    warning(
-      registrationName !== 'onScroll' || isEventSupported('scroll', true),
-      "This browser doesn't support the `onScroll` event",
-    );
-  }
   var isDocumentFragment = rootContainerElement.nodeType === DOC_FRAGMENT_TYPE;
   var doc = isDocumentFragment
     ? rootContainerElement

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -1233,30 +1233,6 @@ describe('ReactDOMComponent', () => {
     });
   });
 
-  describe('onScroll warning', () => {
-    it('should warn about the `onScroll` issue when unsupported (IE8)', () => {
-      // Mock this here so we can mimic IE8 support. We require isEventSupported
-      // before React so it's pre-mocked before React would require it.
-      jest.resetModules().mock('isEventSupported');
-      var isEventSupported = require('isEventSupported');
-      isEventSupported.mockReturnValueOnce(false);
-      ReactTestUtils = require('ReactTestUtils');
-
-      spyOn(console, 'error');
-      ReactTestUtils.renderIntoDocument(<div onScroll={function() {}} />);
-      expectDev(console.error.calls.count()).toBe(1);
-      expectDev(console.error.calls.argsFor(0)[0]).toBe(
-        "Warning: This browser doesn't support the `onScroll` event",
-      );
-    });
-
-    it('should not warn when server-side rendering `onScroll`', () => {
-      spyOn(console, 'error');
-      ReactDOMServer.renderToString(<div onScroll={() => {}} />);
-      expectDev(console.error).not.toHaveBeenCalled();
-    });
-  });
-
   describe('tag sanitization', () => {
     it('should throw when an invalid tag name is used server-side', () => {
       var hackzor = React.createElement('script tag');

--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -34,7 +34,6 @@ var ReactServerRenderingTransaction = require('ReactServerRenderingTransaction')
 var emptyFunction = require('fbjs/lib/emptyFunction');
 var escapeTextContentForBrowser = require('escapeTextContentForBrowser');
 var invariant = require('fbjs/lib/invariant');
-var isEventSupported = require('isEventSupported');
 var inputValueTracking = require('inputValueTracking');
 var validateDOMNesting = require('validateDOMNesting');
 var warning = require('fbjs/lib/warning');
@@ -137,14 +136,6 @@ function assertValidProps(component, props) {
 function ensureListeningTo(inst, registrationName, transaction) {
   if (transaction instanceof ReactServerRenderingTransaction) {
     return;
-  }
-  if (__DEV__) {
-    // IE8 has no API for event capturing and the `onScroll` event doesn't
-    // bubble.
-    warning(
-      registrationName !== 'onScroll' || isEventSupported('scroll', true),
-      "This browser doesn't support the `onScroll` event",
-    );
   }
   var containerInfo = inst._hostContainerInfo;
   var isDocumentFragment = containerInfo._node &&


### PR DESCRIPTION
I removed the scroll capture feature check for IE8, however I missed
the associated warning.

I think it eliminates a dev-only fiber test failure too!