### PR TITLE
Removing specific event polyfil code for ie9 in ChangeEventPlugin

### DIFF
--- a/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
@@ -11,17 +11,12 @@
 
 'use strict';
 
-var EventPluginHub = require('EventPluginHub');
 var EventPropagators = require('EventPropagators');
-var ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
 var ReactControlledComponent = require('ReactControlledComponent');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var ReactGenericBatching = require('ReactGenericBatching');
 var SyntheticEvent = require('SyntheticEvent');
 
 var inputValueTracking = require('inputValueTracking');
-var getEventTarget = require('getEventTarget');
-var isEventSupported = require('isEventSupported');
 var isTextInputElement = require('isTextInputElement');
 
 var eventTypes = {
@@ -56,11 +51,6 @@ function createAndAccumulateChangeEvent(inst, nativeEvent, target) {
   EventPropagators.accumulateTwoPhaseDispatches(event);
   return event;
 }
-/**
- * For IE shims
- */
-var activeElement = null;
-var activeElementInst = null;
 
 /**
  * SECTION: handle `change` event
@@ -69,32 +59,6 @@ function shouldUseChangeEvent(elem) {
   var nodeName = elem.nodeName && elem.nodeName.toLowerCase();
   return nodeName === 'select' ||
     (nodeName === 'input' && elem.type === 'file');
-}
-
-function manualDispatchChangeEvent(nativeEvent) {
-  var event = createAndAccumulateChangeEvent(
-    activeElementInst,
-    nativeEvent,
-    getEventTarget(nativeEvent),
-  );
-
-  // If change and propertychange bubbled, we'd just bind to it like all the
-  // other events and have it go through ReactBrowserEventEmitter. Since it
-  // doesn't, we manually listen for the events and so we have to enqueue and
-  // process the abstract event manually.
-  //
-  // Batching is necessary here in order to ensure that all event handlers run
-  // before the next rerender (including event handlers attached to ancestor
-  // elements instead of directly on the input). Without this, controlled
-  // components don't work properly in conjunction with event bubbling because
-  // the component is rerendered and the value reverted before all the event
-  // handlers can run. See https://github.com/facebook/react/issues/708.
-  ReactGenericBatching.batchedUpdates(runEventInBatch, event);
-}
-
-function runEventInBatch(event) {
-  EventPluginHub.enqueueEvents(event);
-  EventPluginHub.processEventQueue(false);
 }
 
 function getInstIfValueChanged(targetInst) {
@@ -106,94 +70,6 @@ function getInstIfValueChanged(targetInst) {
 function getTargetInstForChangeEvent(topLevelType, targetInst) {
   if (topLevelType === 'topChange') {
     return targetInst;
-  }
-}
-
-/**
- * SECTION: handle `input` event
- */
-var isInputEventSupported = false;
-if (ExecutionEnvironment.canUseDOM) {
-  // IE9 claims to support the input event but fails to trigger it when
-  // deleting text, so we ignore its input events.
-  isInputEventSupported = isEventSupported('input') &&
-    (!document.documentMode || document.documentMode > 9);
-}
-
-/**
- * (For IE <=9) Starts tracking propertychange events on the passed-in element
- * and override the value property so that we can distinguish user events from
- * value changes in JS.
- */
-function startWatchingForValueChange(target, targetInst) {
-  activeElement = target;
-  activeElementInst = targetInst;
-  activeElement.attachEvent('onpropertychange', handlePropertyChange);
-}
-
-/**
- * (For IE <=9) Removes the event listeners from the currently-tracked element,
- * if any exists.
- */
-function stopWatchingForValueChange() {
-  if (!activeElement) {
-    return;
-  }
-  activeElement.detachEvent('onpropertychange', handlePropertyChange);
-  activeElement = null;
-  activeElementInst = null;
-}
-
-/**
- * (For IE <=9) Handles a propertychange event, sending a `change` event if
- * the value of the active element has changed.
- */
-function handlePropertyChange(nativeEvent) {
-  if (nativeEvent.propertyName !== 'value') {
-    return;
-  }
-  if (getInstIfValueChanged(activeElementInst)) {
-    manualDispatchChangeEvent(nativeEvent);
-  }
-}
-
-function handleEventsForInputEventPolyfill(topLevelType, target, targetInst) {
-  if (topLevelType === 'topFocus') {
-    // In IE9, propertychange fires for most input events but is buggy and
-    // doesn't fire when text is deleted, but conveniently, selectionchange
-    // appears to fire in all of the remaining cases so we catch those and
-    // forward the event if the value has changed
-    // In either case, we don't want to call the event handler if the value
-    // is changed from JS so we redefine a setter for `.value` that updates
-    // our activeElementValue variable, allowing us to ignore those changes
-    //
-    // stopWatching() should be a noop here but we call it just in case we
-    // missed a blur event somehow.
-    stopWatchingForValueChange();
-    startWatchingForValueChange(target, targetInst);
-  } else if (topLevelType === 'topBlur') {
-    stopWatchingForValueChange();
-  }
-}
-
-// For IE8 and IE9.
-function getTargetInstForInputEventPolyfill(topLevelType, targetInst) {
-  if (
-    topLevelType === 'topSelectionChange' ||
-    topLevelType === 'topKeyUp' ||
-    topLevelType === 'topKeyDown'
-  ) {
-    // On the selectionchange event, the target is just document which isn't
-    // helpful for us so just check activeElement instead.
-    //
-    // 99% of the time, keydown and keyup aren't necessary. IE8 fails to fire
-    // propertychange on the first input event after setting `value` from a
-    // script and fires only keydown, keypress, keyup. Catching keyup usually
-    // gets it and catching keydown lets us fire an event for the first
-    // keystroke if user does a key repeat (it'll be a little delayed: right
-    // before the second keystroke). Other input methods (e.g., paste) seem to
-    // fire selectionchange normally.
-    return getInstIfValueChanged(activeElementInst);
   }
 }
 
@@ -255,8 +131,6 @@ function handleControlledInputBlur(inst, node) {
 var ChangeEventPlugin = {
   eventTypes: eventTypes,
 
-  _isInputEventSupported: isInputEventSupported,
-
   extractEvents: function(
     topLevelType,
     targetInst,
@@ -267,16 +141,11 @@ var ChangeEventPlugin = {
       ? ReactDOMComponentTree.getNodeFromInstance(targetInst)
       : window;
 
-    var getTargetInstFunc, handleEventFunc;
+    var getTargetInstFunc;
     if (shouldUseChangeEvent(targetNode)) {
       getTargetInstFunc = getTargetInstForChangeEvent;
     } else if (isTextInputElement(targetNode)) {
-      if (isInputEventSupported) {
-        getTargetInstFunc = getTargetInstForInputOrChangeEvent;
-      } else {
-        getTargetInstFunc = getTargetInstForInputEventPolyfill;
-        handleEventFunc = handleEventsForInputEventPolyfill;
-      }
+      getTargetInstFunc = getTargetInstForInputOrChangeEvent;
     } else if (shouldUseClickEvent(targetNode)) {
       getTargetInstFunc = getTargetInstForClickEvent;
     }
@@ -291,10 +160,6 @@ var ChangeEventPlugin = {
         );
         return event;
       }
-    }
-
-    if (handleEventFunc) {
-      handleEventFunc(topLevelType, targetNode, targetInst);
     }
 
     // When blurring, set the value attribute for number inputs

--- a/src/renderers/dom/shared/eventPlugins/__tests__/ChangeEventPlugin-test.js
+++ b/src/renderers/dom/shared/eventPlugins/__tests__/ChangeEventPlugin-test.js
@@ -14,7 +14,6 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 var ReactTestUtils = require('ReactTestUtils');
-var ChangeEventPlugin = require('ChangeEventPlugin');
 var inputValueTracking = require('inputValueTracking');
 
 function getTrackedValue(elem) {
@@ -179,10 +178,6 @@ describe('ChangeEventPlugin', () => {
     function cb(e) {
       called += 1;
       expect(e.type).toBe('change');
-    }
-
-    if (!ChangeEventPlugin._isInputEventSupported) {
-      return;
     }
 
     var input = ReactTestUtils.renderIntoDocument(


### PR DESCRIPTION
React does not support ie9, so the code specific for IE was removed

Size report - 

![size-change-2](https://cloud.githubusercontent.com/assets/2185721/24567703/7f455124-1667-11e7-93e0-34dd692cb002.jpeg)
