### PR TITLE
Docs: Remove part about context being experimental

### DIFF
--- a/docs/docs/context.md
+++ b/docs/docs/context.md
@@ -13,8 +13,6 @@ You can do this directly in React with the powerful "context" API.
 
 The vast majority of applications do not need to use context.
 
-If you want your application to be stable, don't use context. It is an experimental API and it is likely to break in future releases of React.
-
 If you aren't familiar with state management libraries like [Redux](https://github.com/reactjs/redux) or [MobX](https://github.com/mobxjs/mobx), don't use context. For many practical applications, these libraries and their React bindings are a good choice for managing state that is relevant to many components. It is far more likely that Redux is the right solution to your problem than that context is the right solution.
 
 If you aren't an experienced React developer, don't use context. There is usually a better way to implement functionality just using props and state.


### PR DESCRIPTION
Removed from docs part about context being experimental feature.
It's there for few years now and I don't remember it being broken or planned to be removed/modified.

In addition, few high profile libraries use context, it would be bummer if context went away:
* react-redux
* react-router

What's current roadmap regarding context? Will it be removed in fiber? 