### PR TITLE
Add guide on integrating with non-react code

### DIFF
--- a/docs/_data/nav_docs.yml
+++ b/docs/_data/nav_docs.yml
@@ -50,6 +50,8 @@
       title: Web Components
     - id: higher-order-components
       title: Higher-Order Components
+    - id: integrating-with-other-libraries
+      title: Integrating with other libraries
 - title: Reference
   items:
     - id: react-api

--- a/docs/_data/nav_docs.yml
+++ b/docs/_data/nav_docs.yml
@@ -51,7 +51,7 @@
     - id: higher-order-components
       title: Higher-Order Components
     - id: integrating-with-other-libraries
-      title: Integrating with other libraries
+      title: Integrating with Other Libraries
 - title: Reference
   items:
     - id: react-api

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -283,10 +283,18 @@ function Input(props) {
 }
 
 const WrappedInput = connectToBackboneModel('Input');
-const model = new Backbone.Model({ text: 'Sam' }); 
-const handleChange = event => model.set('text', event.target.value);
 
-<WrappedInput model={model} handleChange={handleChange} />
+function Example() {
+  const model = new Backbone.Model({ text: 'Sam' });
+  const handleChange = event => model.set('text', event.target.value);
+
+  return <WrappedInput model={model} handleChange={handleChange} />;
+}
+
+ReactDOM.render(
+  <Example />,
+  document.getElementById('root')
+);
 ```
 
 [Try it on CodePen.](http://codepen.io/wacii/pen/RKyWKZ?editors=0010)

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -33,7 +33,7 @@ The component still has to be unmounted, which provides one final opportunity fo
 
 To demonstrate these concepts let's write a minimal wrapper for the plugin [Chosen](https://github.com/harvesthq/chosen), which augments `<select>` inputs.
 
-Chosen does not render the initial select, so it is up to React to do so. What it does do is hide actual select and create its own control, notifying the original of changes using jQuery. Because it is Chosen maintaining the state, it is easiest to implement the wrapper using an [uncontrolled component.](/react/docs/uncontrolled-components.html)
+Chosen does not render the initial select, so it is up to React to do so. Chosen hides the initial select and creates its own control, notifying the original of changes using jQuery. Because it is Chosen maintaining the state, it is easiest to implement the wrapper using an [uncontrolled component.](/react/docs/uncontrolled-components.html)
 
 ```js
 class Chosen extends React.Component {

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -165,7 +165,7 @@ const ComponentView = Backbone.View.extend({
 
 State is maintained in the view as `this.model` and passed to the component as props.
 
-In addition to normal cleanup, event listeners registered through React as well as component state should be removed by calling `ReactDOM.unmountComponentAtNode()`. This is something React normally calls for us, but because we are controlling the application with Backbone, we must do this manually to avoid leaking memory.
+In addition to normal cleanup, event listeners registered through React as well as component state should be removed by calling `ReactDOM.unmountComponentAtNode()`. When a component is removed from within a React tree, this is called for us automatically, but because we are removing the entire tree, we must call it ourselves.
 
 [Try it on CodePen.](http://codepen.io/wacii/pen/OWZJMQ?editors=0010)
 

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -37,7 +37,14 @@ Chosen does not render the initial select, so it is up to React to do so. Chosen
 
 ```js
 class Chosen extends React.Component {
-  handleUpdate = event => this.props.update(event.target.value);
+  constructor(props) {
+    super(props);
+    this.handleUpdate = this.handleUpdate.bind(this);
+  }
+
+  handleUpdate(event) {
+    this.props.update(event.target.value);
+  }
 
   componentDidMount() {
     this.$el.chosen();
@@ -113,7 +120,10 @@ In the following code, `ListComponent` renders a collection with `ItemComponent`
 
 ```js
 class ItemComponent extends React.Component {
-  rerender = () => this.forceUpdate();
+  constructor(props) {
+    super(props);
+    this.rerender = this.forceUpdate.bind(this);
+  }
 
   componentDidMount() {
     this.props.model.on("change", rerender);
@@ -129,7 +139,10 @@ class ItemComponent extends React.Component {
 }
 
 class ListComponent extends React.Component {
-  rerender = () => this.forceUpdate();
+  constructor(props) {
+    super(props);
+    this.rerender = this.forceUpdate.bind(this);
+  }
 
   componentDidMount() {
     this.props.collection.on("add", "remove", rerender);
@@ -162,11 +175,14 @@ This way, only the HOC needs to know about backbone model internals, and the com
 ```js
 function backboneModelAdapter(Component) {
   return class extends React.Component {
-    handleChange = model => this.setState(model.changedAttributes);
-
     constructor(props) {
       super(props);
       this.state = { ...props.model.attributes };
+      this.handleChange = this.handleChange.bind(this);
+    }
+
+    handleChange(model) {
+      this.setState(model.changedAttributes());
     }
 
     componentDidMount() {

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -59,10 +59,6 @@ function onChange(event) {
 
 ```js
 class Chosen extends React.Component {
-  constructor(props) {
-    super(props);
-  }
-
   componentDidMount() {
     this.$el = $(this.el);
     this.$el.chosen();
@@ -92,7 +88,7 @@ Change listeners need to be setup inside `componentDidMount()` and torn down in 
 
 When the component is unmounted, use the cleanup method provided by Chosen. This removes the custom select control and restores the original `<select>` as well as removing any event listeners the plugin registered.
 
-[Try it on CodePen.](http://codepen.io/wacii/pen/ygzxjG?editors=0010)
+[Try it on CodePen.](http://codepen.io/wacii/pen/ygzxjG?editors=0011)
 
 Integrating with libraries in this way is not recommended. Although it is often a useful short term solution before replacing completely with a React component.
 
@@ -108,19 +104,19 @@ So the following jQuery implementation...
 ```js
 const htmlString = '<button id="jquery-btn">jQuery</button>';
 $el.html(htmlString);
-$('jquery-btn').click(() => window.alert('jQuery button'));
+$('#jquery-btn').click(() => console.log('jQuery button'));
 ```
 
 ...could be rewritten using a React Component.
 ```js
-function Button() {
+function ButtonTemplate() {
   return <button id='react-btn'>React</button>;
 }
 ReactDOM.render(
-  <Button />,
+  <ButtonTemplate />,
   document.getElementById('react-container'),
   () => {
-    $('#react-btn').click(() => window.alert('React button'));
+    $('#react-btn').click(() => console.log('React button'));
   }
 );
 ```
@@ -132,12 +128,12 @@ function Button(props) {
   return <button onClick={props.handleClick}>React</button>;
 }
 ReactDOM.render(
-  <Button handleClick={() => window.alert('React button v2')} />,
-  document.getElementById('react-container')
+  <Button handleClick={() => console.log('React button v2')} />,
+  document.getElementById('react-v2-container')
 );
 ```
 
-[Try it on CodePen.](http://codepen.io/wacii/pen/RpvYdj?editors=1010)
+[Try it on CodePen.](http://codepen.io/wacii/pen/RpvYdj?editors=1011)
 
 ### Embedding React in a Backbone View
 
@@ -282,7 +278,7 @@ function Input(props) {
   return <input value={props.text} onChange={props.handleChange} />;
 }
 
-const WrappedInput = connectToBackboneModel('Input');
+const WrappedInput = connectToBackboneModel(Input);
 
 function Example() {
   const model = new Backbone.Model({ text: 'Sam' });

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -17,6 +17,7 @@ The easiest way to avoid conflicts is to prevent the React component from updati
 ```js
 class SomePlugin extends React.Component {
   componentDidMount() {
+    this.$el = $(el);
     this.$el.somePlugin();
   }
 
@@ -25,7 +26,7 @@ class SomePlugin extends React.Component {
   }
 
   render() {
-    return <div ref={el => this.$el = $(el)} />
+    return <div ref={el => this.el = el} />
   }
 }
 ```
@@ -49,6 +50,7 @@ class Chosen extends React.Component {
   }
 
   componentDidMount() {
+    this.$el = $(this.el);
     this.$el.chosen();
     this.$el.on('change', this.handleUpdate);
   }
@@ -64,7 +66,7 @@ class Chosen extends React.Component {
 
   render() {
     return (
-      <select ref={el => this.$el = $(el)}>
+      <select ref={el => this.el = el}>
         {this.props.children}
       </select>
     );

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -94,6 +94,8 @@ When the component is unmounted, use the cleanup method provided by Chosen. This
 
 [Try it on CodePen.](http://codepen.io/wacii/pen/ygzxjG?editors=0010)
 
+Integrating with libraries in this way is not recommended. Although it is often a useful short term solution before replacing completely with a React component.
+
 ## Integrating with Other View Libraries
 
 React can be easily embedded into other applications thanks to the flexibility of `ReactDOM.render()`. While often used once at startup to load a single React application into the DOM, `ReactDOM.render()` can be called multiple times, both to create multiple React applications and to update existing ones. This allows applications to be rewritten in React piece by piece.

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -4,6 +4,8 @@ title: Integrating with other libraries
 permalink: docs/integrating-with-other-libraries.html
 ---
 
+An entire web application does not need to be controlled by React. React can be embedded in other applications and other applications can be embedded in React. This guide will examine some of the more common use cases, focusing on integration with jQuery and Backbone.
+
 ## Integrating with DOM Manipulation Plugins
 
 React is unaware of changes made to the DOM outside of React. It determines updates based on its own internal representation, and if those updates are invalidated, React has no way to recover.

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -18,10 +18,6 @@ class SomePlugin extends React.Component {
     this.$el.somePlugin();
   }
 
-  componentWillUnmount() {
-    // cleanup
-  }
-
   render() {
     return <div ref={el => this.$el = $(el)} />
   }

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -236,7 +236,7 @@ Alternatively, whenever a model changes, you can extract its attributes as plain
 This way, only the HOC needs to know about Backbone model internals, and the components concerned with presenting data can focus on that.
 
 ```js
-function backboneModelAdapter(Component) {
+function connectToBackboneModel(Component) {
   return class extends React.Component {
     constructor(props) {
       super(props);

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -17,7 +17,7 @@ The easiest way to avoid conflicts is to prevent the React component from updati
 ```js
 class SomePlugin extends React.Component {
   componentDidMount() {
-    this.$el = $(el);
+    this.$el = $(this.el);
     this.$el.somePlugin();
   }
 

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -167,7 +167,7 @@ In the following code, `ListComponent` renders a collection with `ItemComponent`
 class ItemComponent extends React.Component {
   constructor(props) {
     super(props);
-    this.rerender = this.forceUpdate.bind(this);
+    this.rerender = () => this.forceUpdate();
   }
 
   componentDidMount() {
@@ -186,7 +186,7 @@ class ItemComponent extends React.Component {
 class ListComponent extends React.Component {
   constructor(props) {
     super(props);
-    this.rerender = this.forceUpdate.bind(this);
+    this.rerender = () => this.forceUpdate();
   }
 
   componentDidMount() {
@@ -201,7 +201,7 @@ class ListComponent extends React.Component {
     return (
       <ul>
         {this.props.collection.map(model => (
-          <ItemComponent model={model} />
+          <ItemComponent key={model.cid} model={model} />
         ))}
       </ul>
     )

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -82,7 +82,7 @@ class Chosen extends React.Component {
 
 ### Embedding React in a Backbone View
 
-Creating a backbone wrapper around a react component is easy thanks to the flexibility of `ReactDOM.render()`. While a typical application usually calls the `render` method just once, it may be called repeatedly to update props or to create multiple component trees.
+Creating a Backbone wrapper around a react component is easy thanks to the flexibility of `ReactDOM.render()`. While a typical application usually calls the `render` method just once, it may be called repeatedly to update props or to create multiple component trees.
 
 Each view will have an associated component, and when the view renders, `ReactDOM.render()` is used to render the component into the view's `el`.
 
@@ -112,7 +112,7 @@ In addition to normal cleanup, event listeners registered through React as well 
 
 ### Using Backbone Models in React components
 
-The simplest way to consume backbone models and collections from a React component is to listen to the various change events and manually force an update.
+The simplest way to consume Backbone models and collections from a React component is to listen to the various change events and manually force an update.
 
 Components responsible for rendering models would listen to `"change"` events, while components responsible for rendering collections would listen for `"add"` and `"remove` events. In both cases, call `this.forceUpdate()` to rerender the component with the new data.
 
@@ -168,9 +168,9 @@ class ListComponent extends React.Component {
 
 ### Extracting data from Backbone models
 
-Alternatively, whenever a model changes, you can extract its attributes as plain data. The following is [a higher-order component (HOC)](/react/docs/higher-order-components.html) that extracts all attributes of a backbone model into state, passing the data to the wrapped component.
+Alternatively, whenever a model changes, you can extract its attributes as plain data. The following is [a higher-order component (HOC)](/react/docs/higher-order-components.html) that extracts all attributes of a Backbone model into state, passing the data to the wrapped component.
 
-This way, only the HOC needs to know about backbone model internals, and the components concerned with presenting data can focus on that.
+This way, only the HOC needs to know about Backbone model internals, and the components concerned with presenting data can focus on that.
 
 ```js
 function backboneModelAdapter(Component) {

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -146,14 +146,14 @@ Backbone Views typically use HTML strings, or string producing template function
 Each view will have an associated component, and when the view renders, `ReactDOM.render()` is used to render the component into the view's `el`.
 
 ```js
-function Component(props) {
+function Paragraph(props) {
   return <p>{props.text}</p>;
 }
 
 const ComponentView = Backbone.View.extend({
   render() {
     const text = this.model.get('text');
-    ReactDOM.render(<Component text={text} />, this.el);
+    ReactDOM.render(<Paragraph text={text} />, this.el);
     return this;
   },
   remove() {

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -82,9 +82,13 @@ class Chosen extends React.Component {
 
 [Try it on CodePen.](http://codepen.io/wacii/pen/ygzxjG?editors=0010)
 
-## Replacing String Based Rendering with React
+## Integrating with Other View Libraries
 
-A common pattern in older web applications is to describe chunks of the DOM as a string and insert it into the DOM like so: `$el.html(htmlString)`. These points in a codebase are perfect for introducing React. Start by rewriting one of these strings as a React component and render with `ReactDOM.render()`.
+React can be easily embedded into other applications thanks to the flexibility of `ReactDOM.render()`. While often used once at startup to load a single React application into the DOM, `ReactDOM.render()` can be called multiple times, both to create multiple React applications and to update existing ones. This allows applications to be rewritten in React piece by piece.
+
+### Replacing String Based Rendering with React
+
+A common pattern in older web applications is to describe chunks of the DOM as a string and insert it into the DOM like so: `$el.html(htmlString)`. These points in a codebase are perfect for introducing React. Just rewrite the string based rendering as a React component.
 
 So the following jQuery implementation...
 ```js

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -128,8 +128,8 @@ ReactDOM.render(
 From here you could start moving more logic into the component and begin adopting more common React practices. For example, in components it is best not to rely on IDs because the same component can be rendered multiple times. Instead, we will use the [React event system]("/react/docs/handling-events.html"), and register the click handler directly on the React `<button>` element.
 
 ```js
-function Button({ handleClick }) {
-  return <button onClick={handleClick}>React</button>;
+function Button(props) {
+  return <button onClick={props.handleClick}>React</button>;
 }
 ReactDOM.render(
   <Button handleClick={() => window.alert('React button v2')} />,
@@ -146,8 +146,8 @@ Backbone Views typically use HTML strings, or string producing template function
 Each view will have an associated component, and when the view renders, `ReactDOM.render()` is used to render the component into the view's `el`.
 
 ```js
-function Component({ text }) {
-  return <p>{text}</p>;
+function Component(props) {
+  return <p>{props.text}</p>;
 }
 
 const ComponentView = Backbone.View.extend({
@@ -269,8 +269,8 @@ A copy is made of the model's attributes to form the initial state. Every time t
 To demonstrate its use, we will use a basic input wrapper. The component will render the `'text'` attribute of the provided model, calling an update function whenever the input is changed, presumably to update the model.
 
 ```js
-function Input({ text, handleChange }) {
-  return <input value={text} onChange={handleChange} />;
+function Input(props) {
+  return <input value={props.text} onChange={props.handleChange} />;
 }
 
 function BackboneModelAdapterDemo() {

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -30,7 +30,7 @@ class SomePlugin extends React.Component {
   }
 }
 ```
-A [ref](/react/docs/refs-and-the-dom.html) is used to pass the underlying DOM element to the plugin. The `<div>` element has no properties or children, so React has no reason to update it.
+A [ref](/react/docs/refs-and-the-dom.html) is used to pass the underlying DOM element to the plugin. The `<div>` element has no properties or children, so React has no reason to update it, leaving the plugin free to update the DOM without conflicts.
 
 The component still has to be unmounted, which provides one final opportunity for conflict. If the plugin does not provide a method for cleanup, you will probably have to provide your own, remembering to remove any event listeners the plugin registered to prevent memory leaks.
 

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -147,6 +147,10 @@ In addition to normal cleanup, event listeners registered through React as well 
 
 [Try it on CodePen.](http://codepen.io/wacii/pen/OWZJMQ?editors=0010)
 
+## Integrating with Model Layers
+
+React has little opinion on how data is stored or updated and so it can be easily integrated with the model layer from other frameworks. Models may be consumed as is or extracted using containers for better separation of concerns. Both approaches will be demonstrated using Backbone.
+
 ### Using Backbone Models in React components
 
 The simplest way to consume Backbone models and collections from a React component is to listen to the various change events and manually force an update.

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -39,21 +39,30 @@ To demonstrate these concepts let's write a minimal wrapper for the plugin [Chos
 
 Chosen does not render the initial select, so it is up to React to do so. Chosen hides the initial select and creates its own control, notifying the original of changes using jQuery. Because it is Chosen maintaining the state, it is easiest to implement the wrapper using an [uncontrolled component.](/react/docs/uncontrolled-components.html)
 
+The component might be used as follows:
+```js
+const options = ["a", "b", "c"].map(value => {
+  return <option>{value}</option>;
+});
+function onChange(event) {
+  console.log(event.target.value);
+}
+
+<Chosen onChange={onChange}>
+  {options}
+</Chosen>
+```
+
 ```js
 class Chosen extends React.Component {
   constructor(props) {
     super(props);
-    this.handleUpdate = this.handleUpdate.bind(this);
-  }
-
-  handleUpdate(event) {
-    this.props.update(event.target.value);
   }
 
   componentDidMount() {
     this.$el = $(this.el);
     this.$el.chosen();
-    this.$el.on('change', this.handleUpdate);
+    this.$el.on('change', this.props.onChange);
   }
 
   componentDidUpdate() {
@@ -61,7 +70,7 @@ class Chosen extends React.Component {
   }
 
   componentWillUnmount() {
-    this.$el.off('change', this.handleUpdate);
+    this.$el.off('change', this.props.onChange);
     this.$el.chosen('destroy');
   }
 

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -10,7 +10,7 @@ React is unaware of changes made to the DOM outside of React. It determines upda
 
 This does not mean it is impossible or even necessarily difficult to combine React with other ways of affecting the DOM, you just have to be mindful of what each are doing.
 
-The easiest way to avoid conflicts is to prevent the React component from updating. This can be done explicitly by returning false from [`componentWillUpdate()`](/react/docs/react-component.html#componentwillupdate), or by rendering elements that have no reason to change.
+The easiest way to avoid conflicts is to prevent the React component from updating. This can be done explicitly by returning false from [`shouldComponentUpdate()`](/react/docs/react-component.html#shouldcomponentupdate), or by rendering elements that have no reason to change.
 
 ```js
 class SomePlugin extends React.Component {

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -125,7 +125,7 @@ ReactDOM.render(
 );
 ```
 
-From here you could start moving more logic into the component and begin adopting more common React practices.
+From here you could start moving more logic into the component and begin adopting more common React practices. For example, in components it is best not to rely on IDs because the same component can be rendered multiple times. Instead, we will use the [React event system]("/react/docs/handling-events.html"), and register the click handler directly on the React `<button>` element.
 
 ```js
 function Button({ handleClick }) {

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -44,16 +44,16 @@ class Chosen extends React.Component {
 
   componentDidMount() {
     this.$el.chosen();
-    this.$el.on("change", this.handleUpdate);
+    this.$el.on('change', this.handleUpdate);
   }
 
   componentDidUpdate() {
-    this.$el.trigger("chosen:updated");
+    this.$el.trigger('chosen:updated');
   }
 
   componentWillUnmount() {
-    this.$el.off("change", this.handleUpdate);
-    this.$el.chosen("destroy");
+    this.$el.off('change', this.handleUpdate);
+    this.$el.chosen('destroy');
   }
 
   render() {
@@ -68,7 +68,7 @@ class Chosen extends React.Component {
 
 1. Change listeners need to be setup inside `componentDidMount()` and torn down in `componentWillUnmount` as the events are emitted by the plugin use jQuery, which is outside the React event system.
 
-2. Chosen needs to be notified of any changes to the original select or its children. This is done in `componentWillUpdate()` by triggering a `"chosen:updated"` event.
+2. Chosen needs to be notified of any changes to the original select or its children. This is done in `componentWillUpdate()` by triggering a `'chosen:updated'` event.
 
 3. When the component is unmounted, use the cleanup method provided by Chosen. This removes the custom select control and restores the actual `<select>` as well as removing any event listeners the plugin registered.
 
@@ -89,7 +89,7 @@ function Component({ text }) {
 
 const ComponentView = Backbone.View.extend({
   render() {
-    const text = this.model.get("text");
+    const text = this.model.get('text');
     ReactDOM.render(<Component text={text} />, this.el);
     return this;
   },
@@ -110,7 +110,7 @@ In addition to normal cleanup, event listeners registered through React as well 
 
 The simplest way to consume Backbone models and collections from a React component is to listen to the various change events and manually force an update.
 
-Components responsible for rendering models would listen to `"change"` events, while components responsible for rendering collections would listen for `"add"` and `"remove` events. In both cases, call `this.forceUpdate()` to rerender the component with the new data.
+Components responsible for rendering models would listen to `'change'` events, while components responsible for rendering collections would listen for `'add'` and `'remove` events. In both cases, call `this.forceUpdate()` to rerender the component with the new data.
 
 In the following code, `ListComponent` renders a collection with `ItemComponent` responsible for rendering the individual models.
 
@@ -122,15 +122,15 @@ class ItemComponent extends React.Component {
   }
 
   componentDidMount() {
-    this.props.model.on("change", rerender);
+    this.props.model.on('change', rerender);
   }
 
   componentWillUnmount() {
-    this.props.model.off("change", rerender);
+    this.props.model.off('change', rerender);
   }
 
   render() {
-    return <li>{this.props.model.get("text")}</li>;
+    return <li>{this.props.model.get('text')}</li>;
   }
 }
 
@@ -141,11 +141,11 @@ class ListComponent extends React.Component {
   }
 
   componentDidMount() {
-    this.props.collection.on("add", "remove", rerender);
+    this.props.collection.on('add', 'remove', rerender);
   }
 
   componentWillUnmount() {
-    this.props.collection.off("add", "remove", rerender);
+    this.props.collection.off('add', 'remove', rerender);
   }
 
   render() {
@@ -182,11 +182,11 @@ function backboneModelAdapter(Component) {
     }
 
     componentDidMount() {
-      this.props.model.on("change", this.handleChange);
+      this.props.model.on('change', this.handleChange);
     }
 
     componentWillUnmount() {
-      this.props.model.off("change", this.handleChange);
+      this.props.model.off('change', this.handleChange);
     }
 
     render() {
@@ -199,7 +199,7 @@ function backboneModelAdapter(Component) {
 
 A copy is made of the model's attributes to form the initial state. Every time there is a change event, just the changed attributes are updated.
 
-To demonstrate its use, we will use a basic input wrapper. The component will render the `"text"` attribute of the provided model, calling an update function whenever the input is changed, presumably to update the model.
+To demonstrate its use, we will use a basic input wrapper. The component will render the `'text'` attribute of the provided model, calling an update function whenever the input is changed, presumably to update the model.
 
 ```js
 function Input({ text, handleChange }) {
@@ -207,8 +207,8 @@ function Input({ text, handleChange }) {
 }
 
 function BackboneModelAdapterDemo() {
-  const model = new Backbone.Model({ text: "Sam" });
-  const handleChange = event => model.set("text", event.target.value);
+  const model = new Backbone.Model({ text: 'Sam' });
+  const handleChange = event => model.set('text', event.target.value);
   const WrappedInput = backboneModelAdapter(Input);
   return <WrappedInput model={model} handleChange={handleChange} />;
 }

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -171,13 +171,13 @@ In addition to normal cleanup, event listeners registered through React as well 
 
 ## Integrating with Model Layers
 
-React has little opinion on how data is stored or updated and so React components can easily incorporate the model layer from other frameworks. Models may be consumed as is or extracted using containers for better separation of concerns. Both approaches will be demonstrated using Backbone.
+While it is generally recommended to use unidirectional data flow such as React state, Flux, or Redux, React components can easily incorporate the model layer from other frameworks. Models may be consumed as is or extracted using containers for better separation of concerns. Both approaches will be demonstrated using Backbone.
 
 ### Using Backbone Models in React components
 
 The simplest way to consume Backbone models and collections from a React component is to listen to the various change events and manually force an update.
 
-Components responsible for rendering models would listen to `'change'` events, while components responsible for rendering collections would listen for `'add'` and `'remove` events. In both cases, call `this.forceUpdate()` to rerender the component with the new data.
+Components responsible for rendering models would listen to `'change'` events, while components responsible for rendering collections would listen for `'add'` and `'remove'` events. In both cases, call `this.forceUpdate()` to rerender the component with the new data.
 
 In the following code, `ListComponent` renders a collection with `ItemComponent` responsible for rendering the individual models.
 

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -41,7 +41,7 @@ Chosen is called on an existing `<select>` element, but it does little to mutate
 
 What does this mean for our wrapper? First, it is up to React to render the initial select. Because Chosen manages the state of the control, the wrapper should be implemented as an [uncontrolled component.](/react/docs/uncontrolled-components.html). We will be returning `false` from `shouldComponentUpdate()` to prevent React from updating.
 
-> Because Chosen does not update the initial `<select>` beyond hiding it, we could still use React to update the DOM. We choose not to as that would complicate the implementation. What happens when you remove an option the user has just selected? Do you clear the selection, or fall back on some default? How do you notify the user of this change? These questions are not relevant to the example.
+> Because Chosen does not update the initial `<select>` beyond hiding it, we could still use React to update the DOM. We choose not to as that would complicate the implementation. What happens when you remove an option the user has just selected? Do you clear the selection, or fall back on some default? How do you notify the user of this change? These questions are not relevant to the discussion.
 
 The wrapper might be used as follows:
 ```js

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -12,7 +12,9 @@ React is unaware of changes made to the DOM outside of React. It determines upda
 
 This does not mean it is impossible or even necessarily difficult to combine React with other ways of affecting the DOM, you just have to be mindful of what each are doing.
 
-The easiest way to avoid conflicts is to prevent the React component from updating. This can be done explicitly by returning false from [`shouldComponentUpdate()`](/react/docs/react-component.html#shouldcomponentupdate), or by rendering elements that have no reason to change.
+The easiest way to avoid conflicts is to prevent the React component from updating. This can be done explicitly by returning false from [`shouldComponentUpdate()`](/react/docs/react-component.html#shouldcomponentupdate), or by rendering elements that have no reason to change, like an empty `<div />`.
+
+To demonstrate this, let's sketch out a wrapper for a generic jQuery plugin. We will be using an empty element to prevent conflicts, so just return an empty `<div />` in render. Use a [ref](/react/docs/refs-and-the-dom.html) to get a reference to the underlying DOM element to pass to the plugin. The `<div />` element has no properties or children, so React has no reason to update it, leaving the plugin free to manage that part of the DOM.
 
 ```js
 class SomePlugin extends React.Component {
@@ -26,11 +28,10 @@ class SomePlugin extends React.Component {
   }
 
   render() {
-    return <div ref={el => this.el = el} />
+    return <div ref={el => this.el = el} />;
   }
 }
 ```
-A [ref](/react/docs/refs-and-the-dom.html) is used to pass the underlying DOM element to the plugin. The `<div>` element has no properties or children, so React has no reason to update it, leaving the plugin free to update the DOM without conflicts.
 
 The component still has to be unmounted, which provides one final opportunity for conflict. If the plugin does not provide a method for cleanup, you will probably have to provide your own, remembering to remove any event listeners the plugin registered to prevent memory leaks.
 

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -82,7 +82,7 @@ class Chosen extends React.Component {
 
 ## Replacing String Based Rendering with React
 
-A common pattern in jQuery driven applications is to describe chunks of the DOM as a string and insert it into the DOM like so: `$el.html(htmlString)`. These points in a codebase are perfect for introducing React. Start by rewriting one of these strings as a React component and insert it into the DOM using `ReactDOM.render()`.
+A common pattern in older web applications is to describe chunks of the DOM as a string and insert it into the DOM like so: `$el.html(htmlString)`. These points in a codebase are perfect for introducing React. Start by rewriting one of these strings as a React component and render with `ReactDOM.render()`.
 
 So the following jQuery implementation...
 ```js
@@ -151,7 +151,7 @@ In addition to normal cleanup, event listeners registered through React as well 
 
 ## Integrating with Model Layers
 
-React has little opinion on how data is stored or updated and so it can be easily integrated with the model layer from other frameworks. Models may be consumed as is or extracted using containers for better separation of concerns. Both approaches will be demonstrated using Backbone.
+React has little opinion on how data is stored or updated and so React components can easily incorporate the model layer from other frameworks. Models may be consumed as is or extracted using containers for better separation of concerns. Both approaches will be demonstrated using Backbone.
 
 ### Using Backbone Models in React components
 

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -10,7 +10,7 @@ React is unaware of changes made to the DOM outside of React. It determines upda
 
 This does not mean it is impossible or even necessarily difficult to combine React with other ways of affecting the DOM, you just have to be mindful of what each are doing.
 
-The easiest way to avoid conflicts is to prevent the React component from updating. This can be done explicitly by returning false from [`componentWillUpdate()`](https://facebook.github.io/react/docs/react-component.html#componentwillupdate), or by rendering elements that have no reason to change.
+The easiest way to avoid conflicts is to prevent the React component from updating. This can be done explicitly by returning false from [`componentWillUpdate()`](/react/docs/react-component.html#componentwillupdate), or by rendering elements that have no reason to change.
 
 ```js
 class SomePlugin extends React.Component {
@@ -27,13 +27,13 @@ class SomePlugin extends React.Component {
   }
 }
 ```
-A [ref](https://facebook.github.io/react/docs/refs-and-the-dom.html) is used to pass the underlying DOM element to the plugin. The `<div>` element has no properties or children, so React has no reason to update it.
+A [ref](/react/docs/refs-and-the-dom.html) is used to pass the underlying DOM element to the plugin. The `<div>` element has no properties or children, so React has no reason to update it.
 
 The component still has to be unmounted, which provides one final opportunity for conflict. If the plugin does not provide a method for cleanup, you will probably have to provide your own, remembering to remove any event listeners the plugin registered to prevent memory leaks.
 
 To demonstrate these concepts let's write a minimal wrapper for the plugin [Chosen](https://github.com/harvesthq/chosen), which augments `<select>` inputs.
 
-Chosen does not render the initial select, so it is up to React to do so. What it does do is hide actual select and create its own control, notifying the original of changes using jQuery. Because it is Chosen maintaining the state, it is easiest to implement the wrapper using an [uncontrolled component.](https://facebook.github.io/react/docs/uncontrolled-components.html)
+Chosen does not render the initial select, so it is up to React to do so. What it does do is hide actual select and create its own control, notifying the original of changes using jQuery. Because it is Chosen maintaining the state, it is easiest to implement the wrapper using an [uncontrolled component.](/react/docs/uncontrolled-components.html)
 
 ```js
 class Chosen extends React.Component {
@@ -155,7 +155,7 @@ class ListComponent extends React.Component {
 
 ### Extracting data from Backbone models
 
-Alternatively, whenever a model changes, you can extract its attributes as plain data. The following is [a higher-order component (HOC)](https://facebook.github.io/react/docs/higher-order-components.html) that extracts all attributes of a backbone model into state, passing the data to the wrapped component.
+Alternatively, whenever a model changes, you can extract its attributes as plain data. The following is [a higher-order component (HOC)](/react/docs/higher-order-components.html) that extracts all attributes of a backbone model into state, passing the data to the wrapped component.
 
 This way, only the HOC needs to know about backbone model internals, and the components concerned with presenting data can focus on that.
 

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -4,7 +4,7 @@ title: Integrating with other libraries
 permalink: docs/integrating-with-other-libraries.html
 ---
 
-An entire web application does not need to be controlled by React. React can be embedded in other applications and other applications can be embedded in React. This guide will examine some of the more common use cases, focusing on integration with jQuery and Backbone.
+React can be used in any web application. It can be embedded in other applications and, with a little care, other applications can be embedded in React. This guide will examine some of the more common use cases, focusing on integration with jQuery and Backbone.
 
 ## Integrating with DOM Manipulation Plugins
 

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -18,6 +18,10 @@ class SomePlugin extends React.Component {
     this.$el.somePlugin();
   }
 
+  componentWillUnmount() {
+    this.$el.somePlugin('destroy');
+  }
+
   render() {
     return <div ref={el => this.$el = $(el)} />
   }

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -171,11 +171,11 @@ class ItemComponent extends React.Component {
   }
 
   componentDidMount() {
-    this.props.model.on('change', rerender);
+    this.props.model.on('change', this.rerender);
   }
 
   componentWillUnmount() {
-    this.props.model.off('change', rerender);
+    this.props.model.off('change', this.rerender);
   }
 
   render() {
@@ -190,11 +190,11 @@ class ListComponent extends React.Component {
   }
 
   componentDidMount() {
-    this.props.collection.on('add', 'remove', rerender);
+    this.props.collection.on('add', 'remove', this.rerender);
   }
 
   componentWillUnmount() {
-    this.props.collection.off('add', 'remove', rerender);
+    this.props.collection.off('add', 'remove', this.rerender);
   }
 
   render() {

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -244,6 +244,10 @@ function connectToBackboneModel(Component) {
       this.handleChange = this.handleChange.bind(this);
     }
 
+    componentWillReceiveProps(nextProps) {
+      this.setState(Object.assign({}, nextProps.model.attributes));
+    }
+
     handleChange(model) {
       this.setState(model.changedAttributes());
     }

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -106,7 +106,7 @@ ReactDOM.render(
   <Button />,
   document.getElementById('react-container'),
   () => {
-    $('#react-btn').click(() => window.alert('React button'))
+    $('#react-btn').click(() => window.alert('React button'));
   }
 );
 ```

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -98,7 +98,7 @@ Integrating with libraries in this way is not recommended. Although it is often 
 
 ## Integrating with Other View Libraries
 
-React can be easily embedded into other applications thanks to the flexibility of `ReactDOM.render()`. While often used once at startup to load a single React application into the DOM, `ReactDOM.render()` can be called multiple times, both to create multiple React applications and to update existing ones. This allows applications to be rewritten in React piece by piece.
+React can be easily embedded into other applications thanks to the flexibility of `ReactDOM.render()`. While often used once at startup to load a single React application into the DOM, `ReactDOM.render()` can be called multiple times, both to create multiple React applications and to update existing ones. In fact, this is exactly how React is used at Facebook. This approach allows applications to be rewritten in React piece by piece.
 
 ### Replacing String Based Rendering with React
 

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -240,7 +240,7 @@ function connectToBackboneModel(Component) {
   return class extends React.Component {
     constructor(props) {
       super(props);
-      this.state = { ...props.model.attributes };
+      this.state = Object.assign({}, props.model.attributes);
       this.handleChange = this.handleChange.bind(this);
     }
 
@@ -257,7 +257,12 @@ function connectToBackboneModel(Component) {
     }
 
     render() {
-      const { model, ...otherProps } = this.props;
+      const otherProps = Object.keys(this.props)
+        .filter(key => key !== "model")
+        .reduce((obj, key) => {
+          obj[key] = this.props[key];
+          return obj;
+        }, {});
       return <Component {...otherProps} {...this.state} />;
     }
   }

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -41,7 +41,7 @@ Chosen is called on an existing `<select>` element, but it does little to mutate
 
 What does this mean for our wrapper? First, it is up to React to render the initial select. Because Chosen manages the state of the control, the wrapper should be implemented as an [uncontrolled component.](/react/docs/uncontrolled-components.html). We will be returning `false` from `shouldComponentUpdate()` to prevent React from updating.
 
-> Because Chosen does not update the initial `<select>` beyond hiding it, we could still use React to update the DOM. We choose not to here as that would complicate the implementation. What happens when you remove an option the user has just selected? Do you clear the selection, or fall back on some default? How do you notify the user of this change? These questions are not relevant to this example.
+> Because Chosen does not update the initial `<select>` beyond hiding it, we could still use React to update the DOM. We choose not to as that would complicate the implementation. What happens when you remove an option the user has just selected? Do you clear the selection, or fall back on some default? How do you notify the user of this change? These questions are not relevant to the example.
 
 The wrapper might be used as follows:
 ```js
@@ -88,9 +88,9 @@ class Chosen extends React.Component {
 }
 ```
 
-Change listeners need to be setup inside `componentDidMount()` and torn down in `componentWillUnmount` as the events are emitted by the plugin use jQuery, which is outside the React event system.
+Change listeners need to be setup inside `componentDidMount()` and torn down in `componentWillUnmount` as the events are emitted by the plugin using jQuery, which is outside the React event system.
 
-When the component is unmounted, use the cleanup method provided by Chosen. This removes the custom select control and restores the actual `<select>` as well as removing any event listeners the plugin registered.
+When the component is unmounted, use the cleanup method provided by Chosen. This removes the custom select control and restores the original `<select>` as well as removing any event listeners the plugin registered.
 
 [Try it on CodePen.](http://codepen.io/wacii/pen/ygzxjG?editors=0010)
 
@@ -125,7 +125,7 @@ ReactDOM.render(
 );
 ```
 
-From here you could start moving more logic into the component and begin adopting more common React practices. For example, in components it is best not to rely on IDs because the same component can be rendered multiple times. Instead, we will use the [React event system]("/react/docs/handling-events.html"), and register the click handler directly on the React `<button>` element.
+From here you could start moving more logic into the component and begin adopting more common React practices. For example, in components it is best not to rely on IDs because the same component can be rendered multiple times. Instead, we will use the [React event system]("/react/docs/handling-events.html") and register the click handler directly on the React `<button>` element.
 
 ```js
 function Button(props) {

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -1,0 +1,205 @@
+---
+id: integrating-with-other-libraries
+title: Integrating with other libraries
+permalink: docs/integrating-with-other-libraries.html
+---
+
+## Using jQuery plugins from React
+
+React is unaware of changes made to the DOM outside of React. It determines updates based on its own internal representation, and if those updates are invalidated, React has no way to recover.
+
+This does not mean it is impossible or even necessarily difficult to combine React with other ways of affecting the DOM, you just have to be mindful of what each are doing.
+
+The easiest way to avoid conflicts is to prevent the React component from updating. This can be done explicitly by returning false from [`componentWillUpdate()`](https://facebook.github.io/react/docs/react-component.html#componentwillupdate), or by rendering elements that have no reason to change.
+
+```js
+class SomePlugin extends React.Component {
+  componentDidMount() {
+    this.$el.somePlugin();
+  }
+
+  componentWillUnmount() {
+    // cleanup
+  }
+
+  render() {
+    return <div ref={el => this.$el = $(el)} />
+  }
+}
+```
+A [ref](https://facebook.github.io/react/docs/refs-and-the-dom.html) is used to pass the underlying DOM element to the plugin. The `<div>` element has no properties or children, so React has no reason to update it.
+
+The component still has to be unmounted, which provides one final opportunity for conflict. If the plugin does not provide a method for cleanup, you will probably have to provide your own, remembering to remove any event listeners the plugin registered to prevent memory leaks.
+
+To demonstrate these concepts let's write a minimal wrapper for the plugin [Chosen](https://github.com/harvesthq/chosen), which augments `<select>` inputs.
+
+Chosen does not render the initial select, so it is up to React to do so. What it does do is hide actual select and create its own control, notifying the original of changes using jQuery. Because it is Chosen maintaining the state, it is easiest to implement the wrapper using an [uncontrolled component.](https://facebook.github.io/react/docs/uncontrolled-components.html)
+
+```js
+class Chosen extends React.Component {
+  handleUpdate = event => this.props.update(event.target.value);
+
+  componentDidMount() {
+    this.$el.chosen();
+    this.$el.on("change", this.handleUpdate);
+  }
+
+  componentDidUpdate() {
+    this.$el.trigger("chosen:updated");
+  }
+
+  componentWillUnmount() {
+    this.$el.off("change", this.handleUpdate);
+    this.$el.chosen("destroy");
+  }
+
+  render() {
+    return (
+      <select ref={el => this.$el = $(el)}>
+        {this.props.children}
+      </select>
+    );
+  }
+}
+```
+
+1. Change listeners need to be setup inside `componentDidMount()` and torn down in `componentWillUnmount` as the events are emitted by the plugin use jQuery, which is outside the React event system.
+
+2. Chosen needs to be notified of any changes to the original select or its children. This is done in `componentWillUpdate()` by triggering a `"chosen:updated"` event.
+
+3. When the component is unmounted, use the cleanup method provided by Chosen. This removes the custom select control and restores the actual `<select>` as well as removing any event listeners the plugin registered.
+
+[Try it on CodePen.](http://codepen.io/wacii/pen/ygzxjG?editors=0010)
+
+## Backbone
+
+### Embedding React in a Backbone View
+
+Creating a backbone wrapper around a react component is easy thanks to the flexibility of `ReactDOM.render()`. While a typical application usually calls the `render` method just once, it may be called repeatedly to update props or to create multiple component trees.
+
+Each view will have an associated component, and when the view renders, `ReactDOM.render()` is used to render the component into the view's `el`.
+
+```js
+function Component({ text }) {
+  return <p>{text}</p>;
+}
+
+const ComponentView = Backbone.View.extend({
+  render() {
+    const text = this.model.get("text");
+    ReactDOM.render(<Component text={text} />, this.el);
+    return this;
+  },
+  remove() {
+    ReactDOM.unmountComponentAtNode(this.el);
+    Backbone.View.prototype.remove.call(this);
+  }
+});
+```
+
+State is maintained in the view as `this.model` and passed to the component as props.
+
+In addition to normal cleanup, event listeners registered through React as well as component state should be removed by calling `ReactDOM.unmountComponentAtNode()`. This is something React normally calls for us, but because we are controlling the application with Backbone, we must do this manually to avoid leaking memory.
+
+[Try it on CodePen.](http://codepen.io/wacii/pen/OWZJMQ?editors=0010)
+
+### Using Backbone Models in React components
+
+The simplest way to consume backbone models and collections from a React component is to listen to the various change events and manually force an update.
+
+Components responsible for rendering models would listen to `"change"` events, while components responsible for rendering collections would listen for `"add"` and `"remove` events. In both cases, call `this.forceUpdate()` to rerender the component with the new data.
+
+In the following code, `ListComponent` renders a collection with `ItemComponent` responsible for rendering the individual models.
+
+```js
+class ItemComponent extends React.Component {
+  rerender = () => this.forceUpdate();
+
+  componentDidMount() {
+    this.props.model.on("change", rerender);
+  }
+
+  componentWillUnmount() {
+    this.props.model.off("change", rerender);
+  }
+
+  render() {
+    return <li>{this.props.model.get("text")}</li>;
+  }
+}
+
+class ListComponent extends React.Component {
+  rerender = () => this.forceUpdate();
+
+  componentDidMount() {
+    this.props.collection.on("add", "remove", rerender);
+  }
+
+  componentWillUnmount() {
+    this.props.collection.off("add", "remove", rerender);
+  }
+
+  render() {
+    return (
+      <ul>
+        {this.props.collection.map(model => (
+          <ItemComponent model={model} />
+        ))}
+      </ul>
+    )
+  }
+}
+```
+
+[Try it on CodePen.](http://codepen.io/wacii/pen/oBdgoM?editors=0010)
+
+### Extracting data from Backbone models
+
+Alternatively, whenever a model changes, you can extract its attributes as plain data. The following is [a higher-order component (HOC)](https://facebook.github.io/react/docs/higher-order-components.html) that extracts all attributes of a backbone model into state, passing the data to the wrapped component.
+
+This way, only the HOC needs to know about backbone model internals, and the components concerned with presenting data can focus on that.
+
+```js
+function backboneModelAdapter(Component) {
+  return class extends React.Component {
+    handleChange = model => this.setState(model.changedAttributes);
+
+    constructor(props) {
+      super(props);
+      this.state = { ...props.model.attributes };
+    }
+
+    componentDidMount() {
+      this.props.model.on("change", this.handleChange);
+    }
+
+    componentWillUnmount() {
+      this.props.model.off("change", this.handleChange);
+    }
+
+    render() {
+      const { model, ...otherProps } = this.props;
+      return <Component {...otherProps} {...this.state} />;
+    }
+  }
+}
+```
+
+A copy is made of the model's attributes to form the initial state. Every time there is a change event, just the changed attributes are updated.
+
+To demonstrate its use, we will use a basic input wrapper. The component will render the `"text"` attribute of the provided model, calling an update function whenever the input is changed, presumably to update the model.
+
+```js
+function Input({ text, handleChange }) {
+  return <input value={text} onChange={handleChange} />;
+}
+
+function BackboneModelAdapterDemo() {
+  const model = new Backbone.Model({ text: "Sam" });
+  const handleChange = event => model.set("text", event.target.value);
+  const WrappedInput = backboneModelAdapter(Input);
+  return <WrappedInput model={model} handleChange={handleChange} />;
+}
+```
+
+[Try it on CodePen.](http://codepen.io/wacii/pen/RKyWKZ?editors=0010)

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -82,7 +82,7 @@ class Chosen extends React.Component {
 
 ### Embedding React in a Backbone View
 
-Creating a Backbone wrapper around a react component is easy thanks to the flexibility of `ReactDOM.render()`. While a typical application usually calls the `render` method just once, it may be called repeatedly to update props or to create multiple component trees.
+Creating a Backbone wrapper around a React component is easy thanks to the flexibility of `ReactDOM.render()`. While a typical application usually calls the `render` method just once, it may be called repeatedly to update props or to create multiple component trees.
 
 Each view will have an associated component, and when the view renders, `ReactDOM.render()` is used to render the component into the view's `el`.
 

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -4,7 +4,7 @@ title: Integrating with other libraries
 permalink: docs/integrating-with-other-libraries.html
 ---
 
-## Using jQuery plugins from React
+## Integrating with DOM Manipulation Plugins
 
 React is unaware of changes made to the DOM outside of React. It determines updates based on its own internal representation, and if those updates are invalidated, React has no way to recover.
 
@@ -78,11 +78,48 @@ class Chosen extends React.Component {
 
 [Try it on CodePen.](http://codepen.io/wacii/pen/ygzxjG?editors=0010)
 
-## Backbone
+## Replacing String Based Rendering with React
+
+A common pattern in jQuery driven applications is to describe chunks of the DOM as a string and insert it into the DOM like so: `$el.html(htmlString)`. These points in a codebase are perfect for introducing React. Start by rewriting one of these strings as a React component and insert it into the DOM using `ReactDOM.render()`.
+
+So the following jQuery implementation...
+```js
+const htmlString = '<button id="jquery-btn">jQuery</button>';
+$el.html(htmlString);
+$('jquery-btn').click(() => window.alert('jQuery button'));
+```
+
+...could be rewritten using a React Component.
+```js
+function Button() {
+  return <button id='react-btn'>React</button>;
+}
+ReactDOM.render(
+  <Button />,
+  document.getElementById('react-container'),
+  () => {
+    $('#react-btn').click(() => window.alert('React button'))
+  }
+);
+```
+
+From here you could start moving more logic into the component and begin adopting more common React practices.
+
+```js
+function Button({ handleClick }) {
+  return <button onClick={handleClick}>React</button>;
+}
+ReactDOM.render(
+  <Button handleClick={() => window.alert('React button v2')} />,
+  document.getElementById('react-container')
+);
+```
+
+[Try it on CodePen.](http://codepen.io/wacii/pen/RpvYdj?editors=1010)
 
 ### Embedding React in a Backbone View
 
-Creating a Backbone wrapper around a React component is easy thanks to the flexibility of `ReactDOM.render()`. While a typical application usually calls the `render` method just once, it may be called repeatedly to update props or to create multiple component trees.
+Backbone Views typically use HTML strings, or string producing template functions, to create the content for their associated DOM element. Like before, this process may be replaced with a React component.
 
 Each view will have an associated component, and when the view renders, `ReactDOM.render()` is used to render the component into the view's `el`.
 

--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -282,12 +282,11 @@ function Input(props) {
   return <input value={props.text} onChange={props.handleChange} />;
 }
 
-function BackboneModelAdapterDemo() {
-  const model = new Backbone.Model({ text: 'Sam' });
-  const handleChange = event => model.set('text', event.target.value);
-  const WrappedInput = backboneModelAdapter(Input);
-  return <WrappedInput model={model} handleChange={handleChange} />;
-}
+const WrappedInput = connectToBackboneModel('Input');
+const model = new Backbone.Model({ text: 'Sam' }); 
+const handleChange = event => model.set('text', event.target.value);
+
+<WrappedInput model={model} handleChange={handleChange} />
 ```
 
 [Try it on CodePen.](http://codepen.io/wacii/pen/RKyWKZ?editors=0010)


### PR DESCRIPTION
One of the guides requested in #8060.

Discusses how to integrate with jQuery plugins in the abstract then provides a concrete example with Chosen. Moves on to Backbone, specifically how to render React components from Backbone views and two ways to consume Backbone models and collections from React.

Using Backbone views that way is not something I have done before. So hopefully I got that right.