### PR TITLE
Docs: Clarification of setState() behavior

### DIFF
--- a/docs/docs/reference-react-component.md
+++ b/docs/docs/reference-react-component.md
@@ -233,7 +233,7 @@ componentWillUnmount()
 setState(updater, [callback])
 ```
 
-`setState()` is an asynchronous method which enqueues changes to be made to the state during the next update cycle. This is the primary method you use to trigger UI updates in response to UI event handlers, server responses, etc...
+`setState()` is an asynchronous method which enqueues changes to be made to the state during the next update cycle. This is the primary method you use to trigger updates in response to event handlers, server responses, etc...
 
 `setState()` does not immediately mutate `this.state` but creates a pending state transition. Accessing `this.state` after calling this method can potentially return the previous state, rather than the state after enqueued updates have been applied. This is a common source of bugs in React applications.
 
@@ -247,7 +247,7 @@ The first argument is an updater function with the signature:
 (prevState, props) => nextState
 ```
 
-`prevState` is a reference to the previous state. It should not be directly mutated. Instead, changes should be represented by building a `nextState` based on the input from `prevState` and `props`. For instance, suppose we wanted to increment a value in state by `props.step`:
+`prevState` is a reference to the previous state. It should not be directly mutated. Instead, changes should be represented by building a new state object based on the input from `prevState` and `props`. For instance, suppose we wanted to increment a value in state by `props.step`:
 
 ```javascript
 this.setState((prevState, props) => {
@@ -263,18 +263,24 @@ You may optionally pass an object as the first argument to `setState()` instead 
 setState(stateChange, callback)
 ```
 
-This performs a shallow merge of `stateChange` into the new state. This form of `setState()` is also asynchronous, and multiple calls during the same cycle may be batched together, which will result in the equivalent of:
+This performs a shallow merge of `stateChange` into the new state, e.g., to adjust a shopping cart item quantity:
+
+```javascript
+this.setState({quantity: 2})
+```
+
+This form of `setState()` is also asynchronous, and multiple calls during the same cycle may be batched together. For example, if you attempt to increment an item quantity more than once in the same cycle, that will result in the equivalent of:
 
 ```javaScript
 Object.assign(
   previousState,
-  stateChange1,
-  stateChange2,
+  {quantity: state.quantity + 1},
+  {quantity: state.quantity + 1},
   ...
 )
 ```
 
-Subsequent calls may override values from previous calls. If the next state depends on the previous state, we recommend using the updater function form, instead.
+Subsequent calls will override values from previous calls in the same cycle, so the quantity will only be incremented once. If the next state depends on the previous state, we recommend using the updater function form, instead.
 
 For more detail, see the [State and Lifecycle guide](/react/docs/state-and-lifecycle.html).
 

--- a/docs/docs/reference-react-component.md
+++ b/docs/docs/reference-react-component.md
@@ -260,7 +260,7 @@ The second parameter to `setState()` is an optional callback function that will 
 You may optionally pass an object as the first argument to `setState()` instead of a function:
 
 ```javascript
-setState(stateChange, callback)
+setState(stateChange, [callback])
 ```
 
 This performs a shallow merge of `stateChange` into the new state, e.g., to adjust a shopping cart item quantity:

--- a/docs/docs/reference-react-component.md
+++ b/docs/docs/reference-react-component.md
@@ -251,9 +251,11 @@ The first argument is an `updater` function with the signature:
 
 ```javascript
 this.setState((prevState, props) => {
-  return {myInteger: prevState.myInteger + props.step};
+  return {counter: prevState.counter + props.step};
 });
 ```
+
+Both `prevState` and `props` received by the updater function are guaranteed to be up-to-date.
 
 The second parameter to `setState()` is an optional callback function that will be executed once `setState` is completed and the component is re-rendered. Generally we recommend using `componentDidUpdate()` for such logic instead.
 
@@ -280,7 +282,13 @@ Object.assign(
 )
 ```
 
-Subsequent calls will override values from previous calls in the same cycle, so the quantity will only be incremented once. If the next state depends on the previous state, we recommend using the updater function form, instead.
+Subsequent calls will override values from previous calls in the same cycle, so the quantity will only be incremented once. If the next state depends on the previous state, we recommend using the updater function form, instead:
+
+```js
+this.setState((prevState) => {
+  return {counter: prevState.quantity + 1};
+});
+```
 
 For more detail, see the [State and Lifecycle guide](/react/docs/state-and-lifecycle.html).
 

--- a/docs/docs/reference-react-component.md
+++ b/docs/docs/reference-react-component.md
@@ -233,15 +233,15 @@ componentWillUnmount()
 setState(updater, [callback])
 ```
 
-`setState()` is an asynchronous method which enqueues changes to be made to the state during the next update cycle. This is the primary method you use to trigger updates in response to event handlers, server responses, etc...
+`setState()` enqueues changes to the component state and tells React that this component and its children need to be re-rendered with the updated state. This is the primary method you use to update the user interface in response to event handlers and server responses.
 
-`setState()` does not immediately mutate `this.state` but creates a pending state transition. Accessing `this.state` after calling this method can potentially return the previous state, rather than the state after enqueued updates have been applied. This is a common source of bugs in React applications.
+Think of `setState()` as a *request* rather than an immediate command to update the component. For better perceived performance, React may delay it, and then update several components in a single pass. React does not guarantee that the state changes are applied immediately.
 
-There is no guarantee of synchronous operation of calls to `setState`.
+`setState()` does not always immediately update the component. It may batch or defer the update until later. This makes reading `this.state` right after calling `setState()` a potential pitfall. Instead, use `componentDidUpdate` or a `setState` callback (`setState(updater, callback)`), either of which are guaranteed to fire after the update has been applied. If you need to set the state based on the previous state, read about the `updater` argument below.
 
 `setState()` will always lead to a re-render unless `shouldComponentUpdate()` returns `false`. If mutable objects are being used and conditional rendering logic cannot be implemented in `shouldComponentUpdate()`, calling `setState()` only when the new state differs from the previous state will avoid unnecessary re-renders.
 
-The first argument is an updater function with the signature:
+The first argument is an `updater` function with the signature:
 
 ```javascript
 (prevState, props) => nextState


### PR DESCRIPTION
`setState()` is a frequent source of confusion for people new to React, and I believe part of that is due to minimization of the impact of the asynchronous behavior of `setState()` in the documentation. This revision is an attempt to clarify that behavior. For motivation and justification, see [setState Gate](https://medium.com/javascript-scene/setstate-gate-abc10a9b2d82).