### PR TITLE
Update docs for test utils add ons change

### DIFF
--- a/docs/_data/nav_docs.yml
+++ b/docs/_data/nav_docs.yml
@@ -72,6 +72,8 @@
           title: Performance Tools
         - id: test-utils
           title: Test Utilities
+        - id: shallow-renderer
+          title: Shallow Renderer
         - id: animation
           title: Animation
         - id: create-fragment

--- a/docs/docs/addons-animation.md
+++ b/docs/docs/addons-animation.md
@@ -4,7 +4,7 @@ title: Animation Add-Ons
 permalink: docs/animation.html
 layout: docs
 category: Add-Ons
-prev: addons.html
+prev: shallow-renderer.html
 next: create-fragment.html
 redirect_from:
   - "docs/animation-ja-JP.html"

--- a/docs/docs/addons-create-fragment.md
+++ b/docs/docs/addons-create-fragment.md
@@ -5,7 +5,7 @@ permalink: docs/create-fragment.html
 layout: docs
 category: Add-Ons
 prev: animation.html
-next: perf.html
+next: update.html
 ---
 
 **Importing**

--- a/docs/docs/addons-perf.md
+++ b/docs/docs/addons-perf.md
@@ -4,7 +4,7 @@ title: Performance Tools
 permalink: docs/perf.html
 layout: docs
 category: Add-Ons
-prev: create-fragment.html
+prev: two-way-binding-helpers.html
 next: test-utils.html
 ---
 

--- a/docs/docs/addons-pure-render-mixin.md
+++ b/docs/docs/addons-pure-render-mixin.md
@@ -4,6 +4,8 @@ title: PureRenderMixin
 permalink: docs/pure-render-mixin.html
 layout: docs
 category: Add-Ons
+prev: update.html
+next: shallow-compare.html
 ---
 
 > Note:

--- a/docs/docs/addons-shallow-compare.md
+++ b/docs/docs/addons-shallow-compare.md
@@ -4,6 +4,8 @@ title: Shallow Compare
 permalink: docs/shallow-compare.html
 layout: docs
 category: Reference
+prev: pure-render-mixin.html
+next: two-way-binding-helpers.html
 ---
 
 > Note:

--- a/docs/docs/addons-shallow-renderer.md
+++ b/docs/docs/addons-shallow-renderer.md
@@ -44,9 +44,9 @@ Then you can assert:
 
 ```javascript
 const ReactShallowRenderer = require('react-test-renderer/shallow');
-const renderer = new ReactShallowRenderer();
-renderer.render(<MyComponent />);
-const result = renderer.getRenderOutput();
+const shallowRenderer = new ReactShallowRenderer();
+shallowRenderer.render(<MyComponent />);
+const result = shallowRenderer.getRenderOutput();
 
 expect(result.type).toBe('div');
 expect(result.props.children).toEqual([

--- a/docs/docs/addons-shallow-renderer.md
+++ b/docs/docs/addons-shallow-renderer.md
@@ -1,0 +1,62 @@
+---
+id: shallow-renderer
+title: Shallow Renderer
+permalink: docs/shallow-renderer.html
+layout: docs
+category: Reference
+prev: test-utils.html
+next: animation.html
+---
+
+**Importing**
+
+```javascript
+import shallowRenderer from 'react-test-renderer/shallow'; // ES6
+var shallowRenderer = require('react-test-renderer/shallow'); // ES5 with npm
+```
+### Shallow Rendering
+
+Shallow rendering lets you render a component "one level deep" and assert facts about what its render method returns, without worrying about the behavior of child components, which are not instantiated or rendered. This does not require a DOM.
+
+ - [`createRenderer()`](#createrenderer)
+ - [`shallowRenderer.render()`](#shallowrenderer.render)
+ - [`shallowRenderer.getRenderOutput()`](#shallowrenderer.getrenderoutput)
+
+You can think of the shallowRenderer as a "place" to render the component you're testing, and from which you can extract the component's output.
+
+[`shallowRenderer.render()`](#shallowrenderer.render) is similar to [`ReactDOM.render()`](/react/docs/react-dom.html#render) but it doesn't require DOM and only renders a single level deep. This means you can test components isolated from how their children are implemented.
+
+After `shallowRenderer.render()` has been called, you can use [`shallowRenderer.getRenderOutput()`](#shallowrenderer.getrenderoutput) to get the shallowly rendered output.
+
+You can then begin to assert facts about the output. For example, if you have the following component:
+
+```javascript
+function MyComponent() {
+  return (
+    <div>
+      <span className="heading">Title</span>
+      <Subcomponent foo="bar" />
+    </div>
+  );
+}
+```
+
+Then you can assert:
+
+```javascript
+const renderer = ReactTestUtils.createRenderer();
+renderer.render(<MyComponent />);
+const result = renderer.getRenderOutput();
+
+expect(result.type).toBe('div');
+expect(result.props.children).toEqual([
+  <span className="heading">Title</span>,
+  <Subcomponent foo="bar" />
+]);
+```
+
+Shallow testing currently has some limitations, namely not supporting refs.
+
+We also recommend checking out Enzyme's [Shallow Rendering API](http://airbnb.io/enzyme/docs/api/shallow.html). It provides a nicer higher-level API over the same functionality.
+
+* * *

--- a/docs/docs/addons-shallow-renderer.md
+++ b/docs/docs/addons-shallow-renderer.md
@@ -18,7 +18,6 @@ var shallowRenderer = require('react-test-renderer/shallow'); // ES5 with npm
 
 Shallow rendering lets you render a component "one level deep" and assert facts about what its render method returns, without worrying about the behavior of child components, which are not instantiated or rendered. This does not require a DOM.
 
- - [`createRenderer()`](#createrenderer)
  - [`shallowRenderer.render()`](#shallowrenderer.render)
  - [`shallowRenderer.getRenderOutput()`](#shallowrenderer.getrenderoutput)
 
@@ -44,7 +43,8 @@ function MyComponent() {
 Then you can assert:
 
 ```javascript
-const renderer = ReactTestUtils.createRenderer();
+const ReactShallowRenderer = require('react-test-renderer/shallow');
+const renderer = new ReactShallowRenderer();
 renderer.render(<MyComponent />);
 const result = renderer.getRenderOutput();
 

--- a/docs/docs/addons-shallow-renderer.md
+++ b/docs/docs/addons-shallow-renderer.md
@@ -11,8 +11,8 @@ next: animation.html
 **Importing**
 
 ```javascript
-import shallowRenderer from 'react-test-renderer/shallow'; // ES6
-var shallowRenderer = require('react-test-renderer/shallow'); // ES5 with npm
+import ReactShallowRenderer from 'react-test-renderer/shallow'; // ES6
+var ReactShallowRenderer = require('react-test-renderer/shallow'); // ES5 with npm
 ```
 ### Shallow Rendering
 

--- a/docs/docs/addons-test-utils.md
+++ b/docs/docs/addons-test-utils.md
@@ -5,14 +5,14 @@ permalink: docs/test-utils.html
 layout: docs
 category: Reference
 prev: perf.html
+next: shallow-renderer
 ---
 
 **Importing**
 
 ```javascript
-import ReactTestUtils from 'react-addons-test-utils'; // ES6
-var ReactTestUtils = require('react-addons-test-utils'); // ES5 with npm
-var ReactTestUtils = React.addons.TestUtils; // ES5 with react-with-addons.js
+import ReactTestUtils from 'react-dom/test-utils'; // ES6
+var ReactTestUtils = require('react-dom/test-utils'); // ES5 with npm
 ```
 
 ## Overview
@@ -38,53 +38,6 @@ var ReactTestUtils = React.addons.TestUtils; // ES5 with react-with-addons.js
  - [`findRenderedDOMComponentWithTag()`](#findrendereddomcomponentwithtag)
  - [`scryRenderedComponentsWithType()`](#scryrenderedcomponentswithtype)
  - [`findRenderedComponentWithType()`](#findrenderedcomponentwithtype)
-
-### Shallow Rendering
-
-Shallow rendering lets you render a component "one level deep" and assert facts about what its render method returns, without worrying about the behavior of child components, which are not instantiated or rendered. This does not require a DOM.
-
- - [`createRenderer()`](#createrenderer)
- - [`shallowRenderer.render()`](#shallowrenderer.render)
- - [`shallowRenderer.getRenderOutput()`](#shallowrenderer.getrenderoutput)
-
-Call [`createRenderer()`](#createrenderer) in your tests to create a shallow renderer. You can think of this as a "place" to render the component you're testing, and from which you can extract the component's output.
-
-[`shallowRenderer.render()`](#shallowrenderer.render) is similar to [`ReactDOM.render()`](/react/docs/react-dom.html#render) but it doesn't require DOM and only renders a single level deep. This means you can test components isolated from how their children are implemented.
-
-After `shallowRenderer.render()` has been called, you can use [`shallowRenderer.getRenderOutput()`](#shallowrenderer.getrenderoutput) to get the shallowly rendered output.
-
-You can then begin to assert facts about the output. For example, if you have the following component:
-
-```javascript
-function MyComponent() {
-  return (
-    <div>
-      <span className="heading">Title</span>
-      <Subcomponent foo="bar" />
-    </div>
-  );
-}
-```
-
-Then you can assert:
-
-```javascript
-const renderer = ReactTestUtils.createRenderer();
-renderer.render(<MyComponent />);
-const result = renderer.getRenderOutput();
-
-expect(result.type).toBe('div');
-expect(result.props.children).toEqual([
-  <span className="heading">Title</span>,
-  <Subcomponent foo="bar" />
-]);
-```
-
-Shallow testing currently has some limitations, namely not supporting refs.
-
-We also recommend checking out Enzyme's [Shallow Rendering API](http://airbnb.io/enzyme/docs/api/shallow.html). It provides a nicer higher-level API over the same functionality.
-
-* * *
 
 ## Reference
 

--- a/docs/docs/addons-two-way-binding-helpers.md
+++ b/docs/docs/addons-two-way-binding-helpers.md
@@ -4,7 +4,7 @@ title: Two-way Binding Helpers
 permalink: docs/two-way-binding-helpers.html
 layout: docs
 category: Add-Ons
-prev: pure-render-mixin.html
+prev: shallow-compare.html
 next: perf.html
 ---
 

--- a/docs/docs/addons-two-way-binding-helpers.md
+++ b/docs/docs/addons-two-way-binding-helpers.md
@@ -5,7 +5,7 @@ permalink: docs/two-way-binding-helpers.html
 layout: docs
 category: Add-Ons
 prev: pure-render-mixin.html
-next: update.html
+next: perf.html
 ---
 
 > Note:

--- a/docs/docs/addons-update.md
+++ b/docs/docs/addons-update.md
@@ -4,6 +4,8 @@ title: Immutability Helpers
 permalink: docs/update.html
 layout: docs
 category: Add-Ons
+prev: create-fragment.html
+next: pure-render-mixin.html
 ---
 
 > Note:

--- a/docs/docs/addons.md
+++ b/docs/docs/addons.md
@@ -28,7 +28,7 @@ The add-ons below are considered legacy and their use is discouraged.
 
 ## Using React with Add-ons
 
-If using npm, you can install the add-ons individually from npm (e.g. `npm install react-addons-test-utils`) and import them:
+You can install the add-ons individually from npm (e.g. `npm install react-addons-create-fragment`) and import them:
 
 ```javascript
 import Perf from 'react-addons-perf'; // ES6


### PR DESCRIPTION
Wanted to get this up so I can get any corrections. Continuing to work on the rest of the document updates, which I can either push on separate branches as they are finished or on one branch/PR that gets updated as I go. I assume we will hold off merging until the actual 15.5 release happens.

---
 Updating all references and docs on the `React.addons.TestUtils` and the
shallow renderer to refer to the correct targets.

Instead of:
```
const React = require('react');

// ...
React.addons.Testutils
// or

const ReactTestUtils = require('react-addons-test-utils');
```
we now show:
```
const ReactTestUtils = require('react-dom/test-utils');
```

And for shallow renderer, instead of:
```
const shallowRenderer = TestUtils.createRenderer();
```

we now show:
```
const shallowRenderer = require('react-test-renderer/shallow');
```

---

Also did a commit to update the incorrect or missing 'prev' and 'next' attributes on the 'add-ons' doc pages.