### PR TITLE
Remove MouseEvent.button polyfill

### DIFF
--- a/src/renderers/dom/shared/syntheticEvents/SyntheticMouseEvent.js
+++ b/src/renderers/dom/shared/syntheticEvents/SyntheticMouseEvent.js
@@ -31,20 +31,7 @@ var MouseEventInterface = {
   altKey: null,
   metaKey: null,
   getModifierState: getEventModifierState,
-  button: function(event) {
-    // Webkit, Firefox, IE9+
-    // which:  1 2 3
-    // button: 0 1 2 (standard)
-    var button = event.button;
-    if ('which' in event) {
-      return button;
-    }
-    // IE<9
-    // which:  undefined
-    // button: 0 0 0
-    // button: 1 4 2 (onmouseup)
-    return button === 2 ? 2 : button === 4 ? 1 : 0;
-  },
+  button: null,
   buttons: null,
   relatedTarget: function(event) {
     return event.relatedTarget ||


### PR DESCRIPTION
Same old song and dance. MouseEvent.button is supported in every browser React targets:
https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button

I did a manual check too, using:
http://codepen.io/nhunzaker/pen/peBbOe

YES:
----
IE9/11/Edge
Chrome 15
Opera 10.6
Safari 4 Windows/Mac
Firefox 4
Android 4
iOS 3

NO:
----
IE8

---

What a strange IE8 quirk.