### PR TITLE
Update docs to deprecate React<CSS>TransitionGroup

### DIFF
--- a/docs/_data/nav_docs.yml
+++ b/docs/_data/nav_docs.yml
@@ -72,8 +72,8 @@
           title: Performance Tools
         - id: test-utils
           title: Test Utilities
-        - id: animation
-          title: Animation
+        - id: shallow-renderer
+          title: Shallow Renderer
         - id: create-fragment
           title: Keyed Fragments
         - id: update

--- a/docs/docs/addons-animation.md
+++ b/docs/docs/addons-animation.md
@@ -4,13 +4,14 @@ title: Animation Add-Ons
 permalink: docs/animation.html
 layout: docs
 category: Add-Ons
-prev: addons.html
-next: create-fragment.html
 redirect_from:
   - "docs/animation-ja-JP.html"
   - "docs/animation-ko-KR.html"
   - "docs/animation-zh-CN.html"
 ---
+
+>Note:
+> `ReactTransitionGroup` and `ReactCSSTransitionGroup` are both deprecated as of React v15.5.0. The recommendation is to use `TransitionGroup` and `CSSTransitionGroup` from ['react-transition-group'](https://github.com/reactjs/react-transition-group) instead.
 
 The [`ReactTransitionGroup`](#low-level-api-reacttransitiongroup) add-on component is a low-level API for animation, and [`ReactCSSTransitionGroup`](#high-level-api-reactcsstransitiongroup) is an add-on component for easily implementing basic CSS animations and transitions.
 

--- a/docs/docs/addons-create-fragment.md
+++ b/docs/docs/addons-create-fragment.md
@@ -4,8 +4,8 @@ title: Keyed Fragments
 permalink: docs/create-fragment.html
 layout: docs
 category: Add-Ons
-prev: animation.html
-next: perf.html
+prev: shallow-renderer.html
+next: update.html
 ---
 
 **Importing**

--- a/docs/docs/addons.md
+++ b/docs/docs/addons.md
@@ -6,7 +6,6 @@ permalink: docs/addons.html
 
 The React add-ons are a collection of useful utility modules for building React apps. **These should be considered experimental** and tend to change more often than the core.
 
-- [`TransitionGroup` and `CSSTransitionGroup`](animation.html), for dealing with animations and transitions that are usually not simple to implement, such as before a component's removal.
 - [`createFragment`](create-fragment.html), to create a set of externally-keyed children.
 
 The add-ons below are in the development (unminified) version of React only:
@@ -24,7 +23,8 @@ The add-ons below are considered legacy and their use is discouraged.
 
 ### Deprecated Add-ons
 
-[`LinkedStateMixin`](two-way-binding-helpers.html) has been deprecated.
+- [`LinkedStateMixin`](two-way-binding-helpers.html) has been deprecated.
+- [`TransitionGroup` and `CSSTransitionGroup`](animation.html) have been deprecated.
 
 ## Using React with Add-ons
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -17,7 +17,6 @@ var React = require('react');
 // Addons are in separate packages:
 var createFragment = require('react-addons-create-fragment');
 var immutabilityHelpers = require('react-addons-update');
-var CSSTransitionGroup = require('react-addons-css-transition-group');
 ```
 
 For a complete list of addons visit the [addons documentation page](https://facebook.github.io/react/docs/addons.html).


### PR DESCRIPTION
Another piece of updating the docs for the 15.5 release.

 - removes link to the docs about `ReactCSSTransitionGroup` and
   `ReactTransitionGroup` from the main navigation
 - updates 'prev' and 'next' pointers to skip this page
 - adds deprecation warning to the top of the page
 - remove references to these modules from the packages README
 - updates 'add-ons' main page to list this as a deprecated add-on