### PR TITLE
Moved the JSdoc for invokeGuardedCallback to correct position

### DIFF
--- a/src/renderers/shared/utils/ReactErrorUtils.js
+++ b/src/renderers/shared/utils/ReactErrorUtils.js
@@ -76,15 +76,6 @@ let rethrowCaughtError = function() {
   }
 };
 
-/**
- * Call a function while guarding against errors that happens within it.
- * Returns an error if it throws, otherwise null.
- *
- * @param {String} name of the guard to use for logging or debugging
- * @param {Function} func The function to invoke
- * @param {*} context The context to use when calling the function
- * @param {...*} args Arguments for function
- */
 const ReactErrorUtils = {
   injection: {
     injectErrorUtils(injectedErrorUtils: Object) {
@@ -96,6 +87,15 @@ const ReactErrorUtils = {
     },
   },
 
+  /**
+   * Call a function while guarding against errors that happens within it.
+   * Returns an error if it throws, otherwise null.
+   *
+   * @param {String} name of the guard to use for logging or debugging
+   * @param {Function} func The function to invoke
+   * @param {*} context The context to use when calling the function
+   * @param {...*} args Arguments for function
+   */
   invokeGuardedCallback: function<A, B, C, D, E, F, Context>(
     name: string | null,
     func: (a: A, b: B, c: C, d: D, e: E, f: F) => void,


### PR DESCRIPTION
### What ?
A JSDoc comment for invokeGuardedCallback was not at the correct place.
This pr fixes that.