### PR TITLE
Adds support for labels on building bundles

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -32,6 +32,7 @@ const RN_PROD = Bundles.bundleTypes.RN_PROD;
 
 const reactVersion = require('../../package.json').version;
 const inputBundleType = argv.type;
+const inputBundleName = argv._ && argv._[0];
 
 // used for when we property mangle with uglify/gcc
 const mangleRegex = new RegExp(
@@ -295,7 +296,8 @@ function getPlugins(
 function createBundle(bundle, bundleType) {
   if (
     (inputBundleType && bundleType.indexOf(inputBundleType) === -1) ||
-    bundle.bundleTypes.indexOf(bundleType) === -1
+    bundle.bundleTypes.indexOf(bundleType) === -1 ||
+    (inputBundleName && bundle.label.indexOf(inputBundleName) === -1)
   ) {
     // Skip this bundle because its config doesn't specify this target.
     return Promise.resolve();

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -49,6 +49,7 @@ const bundles = [
     fbEntry: 'src/fb/ReactFBEntry.js',
     hasteName: 'React',
     isRenderer: false,
+    label: 'core',
     manglePropertiesOnProd: false,
     name: 'react',
     paths: [
@@ -81,6 +82,7 @@ const bundles = [
     fbEntry: 'src/fb/ReactDOMFBEntry.js',
     hasteName: 'ReactDOMStack',
     isRenderer: true,
+    label: 'dom-stack',
     manglePropertiesOnProd: false,
     name: 'react-dom-stack',
     paths: [
@@ -110,6 +112,7 @@ const bundles = [
     fbEntry: 'src/fb/ReactDOMFiberFBEntry.js',
     hasteName: 'ReactDOMFiber',
     isRenderer: true,
+    label: 'dom-fiber',
     manglePropertiesOnProd: false,
     name: 'react-dom',
     paths: [
@@ -142,6 +145,7 @@ const bundles = [
     fbEntry: 'src/umd/ReactDOMServerUMDEntry.js',
     hasteName: 'ReactDOMServerStack',
     isRenderer: true,
+    label: 'dom-server',
     manglePropertiesOnProd: false,
     name: 'react-dom/server',
     paths: [
@@ -179,6 +183,7 @@ const bundles = [
     fbEntry: 'src/renderers/art/ReactARTStack.js',
     hasteName: 'ReactARTStack',
     isRenderer: true,
+    label: 'art-stack',
     manglePropertiesOnProd: false,
     name: 'react-art',
     paths: [
@@ -213,6 +218,7 @@ const bundles = [
     fbEntry: 'src/renderers/art/ReactARTFiber.js',
     hasteName: 'ReactARTFiber',
     isRenderer: true,
+    label: 'art-fiber',
     manglePropertiesOnProd: false,
     name: 'react-art',
     paths: [
@@ -252,6 +258,7 @@ const bundles = [
     ],
     hasteName: 'ReactNativeStack',
     isRenderer: true,
+    label: 'native-stack',
     manglePropertiesOnProd: false,
     name: 'react-native-renderer',
     paths: [
@@ -287,6 +294,7 @@ const bundles = [
     ],
     hasteName: 'ReactNativeFiber',
     isRenderer: true,
+    label: 'native-fiber',
     manglePropertiesOnProd: false,
     name: 'react-native-renderer',
     paths: [
@@ -312,6 +320,7 @@ const bundles = [
     fbEntry: 'src/renderers/testing/ReactTestRendererFiber',
     hasteName: 'ReactTestRendererFiber',
     isRenderer: true,
+    label: 'test-fiber',
     manglePropertiesOnProd: false,
     name: 'react-test-renderer',
     paths: [
@@ -337,6 +346,7 @@ const bundles = [
     fbEntry: 'src/renderers/testing/stack/ReactTestRendererStack',
     hasteName: 'ReactTestRendererStack',
     isRenderer: true,
+    label: 'test-stack',
     manglePropertiesOnProd: false,
     name: 'react-test-renderer-stack',
     paths: [
@@ -364,6 +374,7 @@ const bundles = [
     entry: 'src/renderers/noop/ReactNoop.js',
     externals: [],
     isRenderer: true,
+    label: 'noop',
     manglePropertiesOnProd: false,
     name: 'react-noop-renderer',
     paths: [

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -1,5 +1,5 @@
 {
-  "branch": "rollup",
+  "branch": "build_bundle_labels",
   "bundleSizes": {
     "react.development.js (UMD_DEV)": {
       "size": 116402,
@@ -66,12 +66,12 @@
       "gzip": 36727
     },
     "ReactDOMFiber-dev.js (FB_DEV)": {
-      "size": 798188,
-      "gzip": 184347
+      "size": 797877,
+      "gzip": 184219
     },
     "ReactDOMFiber-prod.js (FB_PROD)": {
-      "size": 407208,
-      "gzip": 93465
+      "size": 407360,
+      "gzip": 93460
     },
     "react-dom-server.development.js (NODE_DEV)": {
       "size": 447187,

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -1,5 +1,5 @@
 {
-  "branch": "build_bundle_labels",
+  "branch": "rollup",
   "bundleSizes": {
     "react.development.js (UMD_DEV)": {
       "size": 116402,
@@ -66,12 +66,12 @@
       "gzip": 36727
     },
     "ReactDOMFiber-dev.js (FB_DEV)": {
-      "size": 797877,
-      "gzip": 184219
+      "size": 798188,
+      "gzip": 184347
     },
     "ReactDOMFiber-prod.js (FB_PROD)": {
-      "size": 407360,
-      "gzip": 93460
+      "size": 407208,
+      "gzip": 93465
     },
     "react-dom-server.development.js (NODE_DEV)": {
       "size": 447187,


### PR DESCRIPTION
This allows us to run builds on specific bundles by their `label`, for example:

`npm run build fiber` or `npm run build fiber -- --type=UMD`