### PR TITLE
Fixes the eager react-dom replacement on the rollup plugin

### DIFF
--- a/scripts/rollup/modules.js
+++ b/scripts/rollup/modules.js
@@ -178,11 +178,9 @@ function getInternalModules() {
 function replaceInternalModules() {
   // we inline these modules in the bundles rather than leave them as external
   return {
-    'react-dom/lib/ReactPerf': resolve('./src/renderers/shared/ReactPerf.js'),
-    'react-dom/lib/ReactTestUtils': resolve('./src/test/ReactTestUtils.js'),
-    'react-dom/lib/ReactInstanceMap': resolve(
-      './src/renderers/shared/shared/ReactInstanceMap.js'
-    ),
+    "'react-dom/lib/ReactPerf'": `'${resolve('./src/renderers/shared/ReactPerf.js')}'`,
+    "'react-dom/lib/ReactTestUtils'": `'${resolve('./src/test/ReactTestUtils.js')}'`,
+    "'react-dom/lib/ReactInstanceMap'": `'${resolve('./src/renderers/shared/shared/ReactInstanceMap.js')}'`,
     "'react-dom'": `'${resolve('./src/renderers/dom/ReactDOM.js')}'`,
   };
 }

--- a/scripts/rollup/modules.js
+++ b/scripts/rollup/modules.js
@@ -183,7 +183,7 @@ function replaceInternalModules() {
     'react-dom/lib/ReactInstanceMap': resolve(
       './src/renderers/shared/shared/ReactInstanceMap.js'
     ),
-    'react-dom': resolve('./src/renderers/dom/ReactDOM.js'),
+    "'react-dom'": `'${resolve('./src/renderers/dom/ReactDOM.js')}'`,
   };
 }
 


### PR DESCRIPTION
The `react-dom` replacement in the Rollup plugin is far to eager, this makes it far less so.