### PR TITLE
Removed takeSnapshot util function from ReactNative rendererr…

### DIFF
--- a/src/renderers/native/ReactNativeFiber.js
+++ b/src/renderers/native/ReactNativeFiber.js
@@ -29,7 +29,6 @@ const deepFreezeAndThrowOnMutationInDev = require('deepFreezeAndThrowOnMutationI
 const emptyObject = require('fbjs/lib/emptyObject');
 const findNodeHandle = require('findNodeHandle');
 const invariant = require('fbjs/lib/invariant');
-const takeSnapshot = require('takeSnapshot');
 
 const {injectInternals} = require('ReactFiberDevToolsHook');
 
@@ -414,8 +413,6 @@ const ReactNative = {
 
     return NativeRenderer.getPublicRootInstance(root);
   },
-
-  takeSnapshot,
 
   unmountComponentAtNode(containerTag: number) {
     const root = roots.get(containerTag);

--- a/src/renderers/native/ReactNativeStack.js
+++ b/src/renderers/native/ReactNativeStack.js
@@ -18,7 +18,6 @@ var ReactNativeStackInjection = require('ReactNativeStackInjection');
 var ReactUpdates = require('ReactUpdates');
 
 var findNodeHandle = require('findNodeHandle');
-var takeSnapshot = require('takeSnapshot');
 
 ReactNativeInjection.inject();
 ReactNativeStackInjection.inject();
@@ -46,8 +45,6 @@ var ReactNative = {
   },
 
   render: render,
-
-  takeSnapshot,
 
   unmountComponentAtNode: ReactNativeMount.unmountComponentAtNode,
 


### PR DESCRIPTION
It was added to `react-native-implementation` in react-native commit [c7387fe](https://github.com/facebook/react-native/commit/c7387fe).

Relates to this comment and issue facebook/react-native/issues/13343

Upstream sync of react-native pull [#13347](https://github.com/facebook/react-native/pull/13347)