### PR TITLE
Warn about Infinity in style value

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -777,6 +777,7 @@ src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
 * should warn about style having a trailing semicolon
 * should warn about style containing a NaN value
 * should not warn when setting CSS variables
+* should warn about style containing a Infinity value
 
 src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
 * should create markup for simple properties

--- a/src/renderers/dom/shared/CSSPropertyOperations.js
+++ b/src/renderers/dom/shared/CSSPropertyOperations.js
@@ -172,7 +172,6 @@ if (__DEV__) {
         warnStyleValueIsInfinity(name, value, owner);
       }
     }
-
   };
 }
 

--- a/src/renderers/dom/shared/CSSPropertyOperations.js
+++ b/src/renderers/dom/shared/CSSPropertyOperations.js
@@ -50,6 +50,7 @@ if (__DEV__) {
   var warnedStyleNames = {};
   var warnedStyleValues = {};
   var warnedForNaNValue = false;
+  var warnedForInfinityValue = false;
 
   var warnHyphenatedStyleName = function(name, owner) {
     if (warnedStyleNames.hasOwnProperty(name) && warnedStyleNames[name]) {
@@ -111,6 +112,20 @@ if (__DEV__) {
     );
   };
 
+  var warnStyleValueIsInfinity = function(name, value, owner) {
+    if (warnedForInfinityValue) {
+      return;
+    }
+
+    warnedForInfinityValue = true;
+    warning(
+      false,
+      '`Infinity` is an invalid value for the `%s` css style property.%s',
+      name,
+      checkRenderMessage(owner),
+    );
+  };
+
   var checkRenderMessage = function(owner) {
     var ownerName;
     if (owner != null) {
@@ -150,9 +165,14 @@ if (__DEV__) {
       warnStyleValueWithSemicolon(name, value, owner);
     }
 
-    if (typeof value === 'number' && isNaN(value)) {
-      warnStyleValueIsNaN(name, value, owner);
+    if (typeof value === 'number') {
+      if (isNaN(value)) {
+        warnStyleValueIsNaN(name, value, owner);
+      } else if (!isFinite(value)) {
+        warnStyleValueIsInfinity(name, value, owner);
+      }
     }
+
   };
 }
 

--- a/src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
@@ -267,4 +267,24 @@ describe('CSSPropertyOperations', () => {
 
     expectDev(console.error.calls.count()).toBe(0);
   });
+
+  it('should warn about style containing a Infinity value', () => {
+    class Comp extends React.Component {
+      static displayName = 'Comp';
+
+      render() {
+        return <div style={{fontSize: 1 / 0}} />;
+      }
+    }
+
+    spyOn(console, 'error');
+    var root = document.createElement('div');
+    ReactDOM.render(<Comp />, root);
+
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toEqual(
+      'Warning: `Infinity` is an invalid value for the `fontSize` css style property.' +
+      '\n\nCheck the render method of `Comp`.',
+    );
+  });
 });

--- a/src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
@@ -284,7 +284,7 @@ describe('CSSPropertyOperations', () => {
     expectDev(console.error.calls.count()).toBe(1);
     expectDev(console.error.calls.argsFor(0)[0]).toEqual(
       'Warning: `Infinity` is an invalid value for the `fontSize` css style property.' +
-      '\n\nCheck the render method of `Comp`.',
+        '\n\nCheck the render method of `Comp`.',
     );
   });
 });


### PR DESCRIPTION
Currently React warns about `NaN` values in style. 
This PR adds warnings about `Infinity`:
```jsx
<h1 style={{ fontSize: 1 / 0 }}></h1>
```
Warning:
```
Warning: `Infinity` is an invalid value for the `fontSize` css style property.