### PR TITLE
Tweak Rollup setup

### DIFF
--- a/scripts/rollup/modules.js
+++ b/scripts/rollup/modules.js
@@ -256,28 +256,6 @@ function getReactCurrentOwnerModuleAlias(bundleType, isRenderer) {
 }
 
 // this works almost identically to the ReactCurrentOwner shim above
-const shimReactCheckPropTypes = resolve(
-  './scripts/rollup/shims/rollup/ReactCheckPropTypesRollupShim.js'
-);
-const realCheckPropTypes = resolve(
-  './src/isomorphic/classic/types/checkPropTypes.js'
-);
-
-function getReactCheckPropTypesModuleAlias(bundleType, isRenderer) {
-  if (isRenderer) {
-    return {
-      checkPropTypes: shimReactCheckPropTypes,
-      'react/lib/checkPropTypes': shimReactCheckPropTypes,
-    };
-  } else {
-    return {
-      checkPropTypes: realCheckPropTypes,
-      'react/lib/checkPropTypes': realCheckPropTypes,
-    };
-  }
-}
-
-// this works almost identically to the ReactCurrentOwner shim above
 const shimReactComponentTreeHook = resolve(
   './scripts/rollup/shims/rollup/ReactComponentTreeHookRollupShim.js'
 );
@@ -323,7 +301,6 @@ function replaceDevOnlyStubbedModules(bundleType) {
 function getAliases(paths, bundleType, isRenderer, extractErrors) {
   return Object.assign(
     getReactCurrentOwnerModuleAlias(bundleType, isRenderer),
-    getReactCheckPropTypesModuleAlias(bundleType, isRenderer),
     getReactComponentTreeHookModuleAlias(bundleType, isRenderer),
     createModuleMap(
       paths,
@@ -353,17 +330,7 @@ module.exports = {
   getExcludedHasteGlobs,
   getDefaultReplaceModules,
   getAliases,
-  createModuleMap,
-  getNodeModules,
-  replaceInternalModules,
-  getInternalModules,
-  getFbjsModuleAliases,
-  replaceFbjsModuleAliases,
   ignoreFBModules,
   ignoreReactNativeModules,
   getExternalModules,
-  getReactCurrentOwnerModuleAlias,
-  getReactCheckPropTypesModuleAlias,
-  getReactComponentTreeHookModuleAlias,
-  replaceDevOnlyStubbedModules,
 };

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -2,24 +2,24 @@
   "branch": "master",
   "bundleSizes": {
     "react.development.js (UMD_DEV)": {
-      "size": 116402,
-      "gzip": 29598
+      "size": 116208,
+      "gzip": 29564
     },
     "react.production.min.js (UMD_PROD)": {
       "size": 13719,
       "gzip": 5080
     },
     "react-dom.development.js (UMD_DEV)": {
-      "size": 564925,
-      "gzip": 130471
+      "size": 564771,
+      "gzip": 130439
     },
     "react-dom.production.min.js (UMD_PROD)": {
       "size": 120123,
       "gzip": 37844
     },
     "react-dom-server.development.js (UMD_DEV)": {
-      "size": 477377,
-      "gzip": 115561
+      "size": 477021,
+      "gzip": 115494
     },
     "react-dom-server.production.min.js (UMD_PROD)": {
       "size": 106349,
@@ -34,56 +34,56 @@
       "gzip": 28976
     },
     "react.development.js (NODE_DEV)": {
-      "size": 109416,
-      "gzip": 27554
+      "size": 109222,
+      "gzip": 27519
     },
     "react.production.min.js (NODE_PROD)": {
       "size": 12615,
       "gzip": 4659
     },
     "React-dev.js (FB_DEV)": {
-      "size": 110901,
-      "gzip": 28115
+      "size": 110705,
+      "gzip": 28075
     },
     "React-prod.js (FB_PROD)": {
       "size": 56205,
       "gzip": 14329
     },
     "ReactDOMStack-dev.js (FB_DEV)": {
-      "size": 523568,
-      "gzip": 124900
+      "size": 523202,
+      "gzip": 124830
     },
     "ReactDOMStack-prod.js (FB_PROD)": {
       "size": 351707,
       "gzip": 84367
     },
     "react-dom.development.js (NODE_DEV)": {
-      "size": 543299,
-      "gzip": 125435
+      "size": 543145,
+      "gzip": 125402
     },
     "react-dom.production.min.js (NODE_PROD)": {
       "size": 116802,
       "gzip": 36707
     },
     "ReactDOMFiber-dev.js (FB_DEV)": {
-      "size": 797779,
-      "gzip": 184190
+      "size": 797617,
+      "gzip": 184146
     },
     "ReactDOMFiber-prod.js (FB_PROD)": {
       "size": 407360,
       "gzip": 93460
     },
     "react-dom-server.development.js (NODE_DEV)": {
-      "size": 446778,
-      "gzip": 107862
+      "size": 446422,
+      "gzip": 107796
     },
     "react-dom-server.production.min.js (NODE_PROD)": {
       "size": 101204,
       "gzip": 31227
     },
     "ReactDOMServerStack-dev.js (FB_DEV)": {
-      "size": 445529,
-      "gzip": 107719
+      "size": 445173,
+      "gzip": 107652
     },
     "ReactDOMServerStack-prod.js (FB_PROD)": {
       "size": 332974,


### PR DESCRIPTION
* Removes unused exports in `modules.js`
* Removes a shim for `checkPropTypes` that’s no longer used
* Adds a way to build multiple bundles: `yarn build -- core,dom --type umd,node`