### PR TITLE
Point users to the npm page instead of the github project for prop-types

### DIFF
--- a/docs/docs/typechecking-with-proptypes.md
+++ b/docs/docs/typechecking-with-proptypes.md
@@ -7,7 +7,7 @@ redirect_from:
 ---
 
 > Note:
-> `React.PropTypes` is deprecated as of React v15.5. Please use [the `prop-types` library instead](https://github.com/aackerman/PropTypes).
+> `React.PropTypes` is deprecated as of React v15.5. Please use [the `prop-types` library instead](https://www.npmjs.com/package/prop-types).
 
 As your app grows, you can catch a lot of bugs with typechecking. For some applications, you can use JavaScript extensions like [Flow](https://flowtype.org/) or [TypeScript](https://www.typescriptlang.org/) to typecheck your whole application. But even if you don't use those, React has some built-in typechecking abilities. To run typechecking on the props for a component, you can assign the special `propTypes` property:
 


### PR DESCRIPTION
It seems incorrect to point users to my fork of PropTypes since the npm releases are now based off source code in the react repo. I've updated the readme for my project to reflect this fact, but I saw that the documentation was still pointing to my repo and I think it would be better to point users directly to the npm page if not the source in the react repo itself.
