### PR TITLE
Fork ReactReconcileTransaction into ReactShallowReconcileTransaction

### DIFF
--- a/src/renderers/testing/ReactShallowReconcileTransaction.js
+++ b/src/renderers/testing/ReactShallowReconcileTransaction.js
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactShallowReconcileTransaction
+ */
+
+'use strict';
+
+var CallbackQueue = require('CallbackQueue');
+var PooledClass = require('PooledClass');
+var ReactInstrumentation = require('ReactInstrumentation');
+var Transaction = require('Transaction');
+var ReactUpdateQueue = require('ReactUpdateQueue');
+
+/**
+ * Provides a queue for collecting `componentDidMount` and
+ * `componentDidUpdate` callbacks during the transaction.
+ */
+var ON_DOM_READY_QUEUEING = {
+  /**
+   * Initializes the internal `onDOMReady` queue.
+   */
+  initialize: function() {
+    this.reactMountReady.reset();
+  },
+
+  /**
+   * After DOM is flushed, invoke all registered `onDOMReady` callbacks.
+   */
+  close: function() {
+    this.reactMountReady.notifyAll();
+  },
+};
+
+/**
+ * Executed within the scope of the `Transaction` instance. Consider these as
+ * being member methods, but with an implied ordering while being isolated from
+ * each other.
+ */
+var TRANSACTION_WRAPPERS = [
+  ON_DOM_READY_QUEUEING,
+];
+
+if (__DEV__) {
+  TRANSACTION_WRAPPERS.push({
+    initialize: ReactInstrumentation.debugTool.onBeginFlush,
+    close: ReactInstrumentation.debugTool.onEndFlush,
+  });
+}
+
+/**
+ * Currently:
+ * - The order that these are listed in the transaction is critical:
+ * - Suppresses events.
+ * - Restores selection range.
+ *
+ * Future:
+ * - Restore document/overflow scroll positions that were unintentionally
+ *   modified via DOM insertions above the top viewport boundary.
+ * - Implement/integrate with customized constraint based layout system and keep
+ *   track of which dimensions must be remeasured.
+ *
+ * @class ReactShallowReconcileTransaction
+ */
+function ReactShallowReconcileTransaction(useCreateElement: boolean) {
+  this.reinitializeTransaction();
+  // Only server-side rendering really needs this option (see
+  // `ReactServerRendering`), but server-side uses
+  // `ReactServerRenderingTransaction` instead. This option is here so that it's
+  // accessible and defaults to false when `ReactDOMComponent` and
+  // `ReactDOMTextComponent` checks it in `mountComponent`.`
+  this.renderToStaticMarkup = false;
+  this.reactMountReady = CallbackQueue.getPooled(null);
+  this.useCreateElement = useCreateElement;
+}
+
+var Mixin = {
+  /**
+   * @see Transaction
+   * @abstract
+   * @final
+   * @return {array<object>} List of operation wrap procedures.
+   *   TODO: convert to array<TransactionWrapper>
+   */
+  getTransactionWrappers: function() {
+    return TRANSACTION_WRAPPERS;
+  },
+
+  /**
+   * @return {object} The queue to collect `onDOMReady` callbacks with.
+   */
+  getReactMountReady: function() {
+    return this.reactMountReady;
+  },
+
+  /**
+   * @return {object} The queue to collect React async events.
+   */
+  getUpdateQueue: function() {
+    return ReactUpdateQueue;
+  },
+
+  /**
+   * Save current transaction state -- if the return value from this method is
+   * passed to `rollback`, the transaction will be reset to that state.
+   */
+  checkpoint: function() {
+    // reactMountReady is the our only stateful wrapper
+    return this.reactMountReady.checkpoint();
+  },
+
+  rollback: function(checkpoint) {
+    this.reactMountReady.rollback(checkpoint);
+  },
+
+  /**
+   * `PooledClass` looks for this, and will invoke this before allowing this
+   * instance to be reused.
+   */
+  destructor: function() {
+    CallbackQueue.release(this.reactMountReady);
+    this.reactMountReady = null;
+  },
+};
+
+
+Object.assign(ReactShallowReconcileTransaction.prototype, Transaction, Mixin);
+
+PooledClass.addPoolingTo(ReactShallowReconcileTransaction);
+
+module.exports = ReactShallowReconcileTransaction;

--- a/src/renderers/testing/ReactShallowRenderer.js
+++ b/src/renderers/testing/ReactShallowRenderer.js
@@ -15,7 +15,7 @@ var React = require('React');
 var ReactCompositeComponent = require('ReactCompositeComponent');
 var ReactDefaultBatchingStrategy = require('ReactDefaultBatchingStrategy');
 var ReactReconciler = require('ReactReconciler');
-var ReactReconcileTransaction = require('ReactReconcileTransaction');
+var ReactShallowReconcileTransaction = require('ReactShallowReconcileTransaction');
 var ReactUpdates = require('ReactUpdates');
 
 var emptyObject = require('emptyObject');
@@ -24,7 +24,7 @@ var invariant = require('invariant');
 
 function injectDefaults() {
   ReactUpdates.injection.injectReconcileTransaction(
-    ReactReconcileTransaction
+    ReactShallowReconcileTransaction
   );
   ReactUpdates.injection.injectBatchingStrategy(
     ReactDefaultBatchingStrategy


### PR DESCRIPTION
I think this might fix #9372. But I haven't tested.

`ReactReconcileTransaction` is DOM dep so it didn't get included into package. I forked it and removed DOM-specific code (calls to `ReactBrowserEventEmitter` and `ReactInputSelection`).