### PR TITLE
Build shallow renderer independently

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,6 +82,24 @@ var paths = {
     ],
     lib: 'build/node_modules/react-native/lib',
   },
+  reactShallowRenderer: {
+    src: [
+      // Shallow renderer reuses some DOM code
+      'src/renderers/dom/**/*.js',
+      'src/renderers/testing/**/*.js',
+      'src/renderers/shared/**/*.js',
+
+      'src/ReactVersion.js',
+      'src/shared/**/*.js',
+      '!src/shared/vendor/**/*.js',
+      '!src/**/__benchmarks__/**/*.js',
+      '!src/**/__tests__/**/*.js',
+      '!src/**/__mocks__/**/*.js',
+    ],
+    // We put it into a subfolder of test renderer but
+    // with a separate copy of the reconciler.
+    lib: 'build/node_modules/react-test-renderer/lib/shallow/',
+  },
   reactTestRenderer: {
     src: [
       'src/renderers/testing/**/*.js',
@@ -153,6 +171,12 @@ var moduleMapReactNative = Object.assign(
   moduleMapBase
 );
 
+var moduleMapReactShallowRenderer = Object.assign(
+  {},
+  rendererSharedState,
+  moduleMapBase
+);
+
 var moduleMapReactTestRenderer = Object.assign(
   {},
   rendererSharedState,
@@ -184,6 +208,13 @@ var babelOptsReactNative = {
   ],
 };
 
+var babelOptsReactShallowRenderer = {
+  plugins: [
+    devExpressionWithCodes, // this pass has to run before `rewrite-modules`
+    [babelPluginModules, {map: moduleMapReactShallowRenderer}],
+  ],
+};
+
 var babelOptsReactTestRenderer = {
   plugins: [
     devExpressionWithCodes, // this pass has to run before `rewrite-modules`
@@ -204,6 +235,7 @@ gulp.task('react:clean', function() {
     paths.react.lib,
     paths.reactDOM.lib,
     paths.reactNative.lib,
+    paths.reactShallowRenderer.lib,
     paths.reactTestRenderer.lib,
   ]);
 });
@@ -232,6 +264,13 @@ gulp.task('react:modules', function() {
       .pipe(gulp.dest(paths.reactNative.lib)),
 
     gulp
+      .src(paths.reactShallowRenderer.src)
+      .pipe(stripProvidesModule())
+      .pipe(babel(babelOptsReactShallowRenderer))
+      .pipe(flatten())
+      .pipe(gulp.dest(paths.reactShallowRenderer.lib)),
+
+    gulp
       .src(paths.reactTestRenderer.src)
       .pipe(stripProvidesModule())
       .pipe(babel(babelOptsReactTestRenderer))
@@ -245,6 +284,7 @@ gulp.task('react:extract-errors', function() {
     paths.react.src,
     paths.reactDOM.src,
     paths.reactNative.src,
+    paths.reactShallowRenderer.src,
     paths.reactTestRenderer.src
   )).pipe(extractErrors(errorCodeOpts));
 });

--- a/packages/react-test-renderer/shallow.js
+++ b/packages/react-test-renderer/shallow.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = require('./lib/ReactShallowRenderer');
+module.exports = require('./lib/shallow/ReactShallowRenderer');


### PR DESCRIPTION
Alternative strategy for https://github.com/facebook/react/issues/9372 which shouldn't suffer from injection issues. My concern here is I'm not sure what happens if components use `react-dom` (which isn't deduplicated anymore) but I guess any other solutions suffer from the same problem, and we don't really interact with `react-dom` in shallow tests anyway.