### PR TITLE
Check displayName when comparing trees in test utils

### DIFF
--- a/src/isomorphic/hooks/ReactComponentTreeHook.js
+++ b/src/isomorphic/hooks/ReactComponentTreeHook.js
@@ -358,9 +358,6 @@ var ReactComponentTreeHook = {
 
   getDisplayName(id: DebugID): ?string {
     var element = ReactComponentTreeHook.getElement(id);
-    if (!element) {
-      return null;
-    }
     return getDisplayName(element);
   },
 

--- a/src/renderers/__tests__/ReactComponentTreeHook-test.js
+++ b/src/renderers/__tests__/ReactComponentTreeHook-test.js
@@ -183,7 +183,7 @@ describe('ReactComponentTreeHook', () => {
 
     function expectWrapperTreeToEqual(expectedTree, andStayMounted) {
       ReactComponentTreeTestUtils.expectTree(rootInstance._debugID, {
-        displayName: 'Wrapper',
+        displayName: expectedTree ? 'Wrapper' : '#empty',
         children: expectedTree ? [expectedTree] : [],
       });
       var rootDisplayNames = ReactComponentTreeTestUtils.getRootDisplayNames();
@@ -264,6 +264,7 @@ describe('ReactComponentTreeHook', () => {
       }
 
       delete Qux.displayName;
+      Object.defineProperty(Qux, 'name', {value: null});
 
       var element = <div><Foo /><Baz /><Qux /></div>;
       var tree = {
@@ -351,7 +352,7 @@ describe('ReactComponentTreeHook', () => {
           },
         };
       }
-      delete Qux.name;
+      Object.defineProperty(Qux, 'name', {value: null});
 
       var element = <div><Foo /><Baz /><Qux /></div>;
       var tree = {
@@ -386,7 +387,7 @@ describe('ReactComponentTreeHook', () => {
       function Qux() {
         return null;
       }
-      delete Qux.name;
+      Object.defineProperty(Qux, 'name', {value: null});
 
       var element = <div><Foo /><Baz /><Qux /></div>;
       var tree = {
@@ -2024,7 +2025,7 @@ describe('ReactComponentTreeHook', () => {
       ReactComponentTreeTestUtils.expectTree(
         barInstance._debugID,
         {
-          displayName: 'Unknown',
+          displayName: '#empty',
           children: [],
           parentID: null,
         },
@@ -2035,7 +2036,7 @@ describe('ReactComponentTreeHook', () => {
       ReactComponentTreeTestUtils.expectTree(
         barInstance._debugID,
         {
-          displayName: 'Unknown',
+          displayName: '#empty',
           children: [],
           parentID: null,
         },

--- a/src/renderers/__tests__/ReactComponentTreeHook-test.native.js
+++ b/src/renderers/__tests__/ReactComponentTreeHook-test.native.js
@@ -80,7 +80,7 @@ describeStack('ReactComponentTreeHook', () => {
 
     function expectWrapperTreeToEqual(expectedTree, andStayMounted) {
       ReactComponentTreeTestUtils.expectTree(rootInstance._debugID, {
-        displayName: 'Wrapper',
+        displayName: expectedTree ? 'Wrapper' : '#empty',
         children: expectedTree ? [expectedTree] : [],
       });
       var rootDisplayNames = ReactComponentTreeTestUtils.getRootDisplayNames();
@@ -152,6 +152,7 @@ describeStack('ReactComponentTreeHook', () => {
       }
 
       delete Qux.displayName;
+      Object.defineProperty(Qux, 'name', {value: null});
 
       var element = <View><Foo /><Baz /><Qux /></View>;
       var tree = {
@@ -239,7 +240,7 @@ describeStack('ReactComponentTreeHook', () => {
           },
         };
       }
-      delete Qux.name;
+      Object.defineProperty(Qux, 'name', {value: null});
 
       var element = <View><Foo /><Baz /><Qux /></View>;
       var tree = {
@@ -273,7 +274,7 @@ describeStack('ReactComponentTreeHook', () => {
       function Qux() {
         return null;
       }
-      delete Qux.name;
+      Object.defineProperty(Qux, 'name', {value: null});
 
       var element = <View><Foo /><Baz /><Qux /></View>;
       var tree = {
@@ -1935,7 +1936,7 @@ describeStack('ReactComponentTreeHook', () => {
     ReactComponentTreeTestUtils.expectTree(
       barInstance._debugID,
       {
-        displayName: 'Unknown',
+        displayName: '#empty',
         children: [],
         parentID: null,
       },
@@ -1946,7 +1947,7 @@ describeStack('ReactComponentTreeHook', () => {
     ReactComponentTreeTestUtils.expectTree(
       barInstance._debugID,
       {
-        displayName: 'Unknown',
+        displayName: '#empty',
         children: [],
         parentID: null,
       },

--- a/src/test/ReactComponentTreeTestUtils.js
+++ b/src/test/ReactComponentTreeTestUtils.js
@@ -60,6 +60,9 @@ function expectTree(rootID, expectedTree, parentPath) {
       'ownerDisplayName',
     );
   }
+  if (expectedTree.displayName !== undefined) {
+    expectEqual(displayName, expectedTree.displayName, 'displayName');
+  }
   if (expectedTree.parentID !== undefined) {
     expectEqual(parentID, expectedTree.parentID, 'parentID');
   }


### PR DESCRIPTION
The core reason of this change is that [src/test/ReactComponentTreeTestUtils.js][1] does not check `displayName` when comparing two component trees. It means that some tests are irrelevant. For example, I can change [this line][2] from `"Unknown"` to `"blablabla"` and test will pass.

When I added check of `displayName` and runned tests I found two other problems:

* **Problem 1**  
   In several tests we [clear component name][3] as:
   ```js
   delete Qux.name;
   ```
   But for derived class this does not work as expected. Instead `Qux.name` returns the name of parent class. Example:
   ```js
   class B {}
   class A extends B {}
   console.log(A.name) // "A"
   delete A.name
   console.log(A.name) // "B"
   ```
   To fix it I replaced `delete Qux.name` with:
   ```js
   Object.defineProperty(Qux, 'name', {value: null});
   ```

* **Problem 2**  
  Getting `displayName` of zero component is invalid. It is tested [here][4] but actually test does not check display name:
   ```js
    it('reports a zero as a child', () => {
      var element = <div>{0}</div>;
      var tree = {
        displayName: 'div',
        element,
        children: [
          {
            displayName: '#text', // can be changed to 'blablabla'!
            text: '0',
          },
        ],
      };
      assertTreeMatches([element, tree]);
    });
   ```
   This is because element is [treated as boolean][5] in `getDisplayName()`:
   ```js
    var element = ReactComponentTreeHook.getElement(id);
    if (!element) {  // breaks for element = 0
      return null;
    }
    return getDisplayName(element);
   ```
   It makes `getDisplayName()` a bit inconsistent:
   ```js 
   <div>{0}</div> // returns null
   <div>{1}</div> // returns '#empty'
   ```
   I fixed it by removing this check totally. I seems better to always return `string` from `getDisplayName()`.

[1]: https://github.com/facebook/react/blob/72196da82915bee400edb1599d4223926aa2a8a0/src/test/ReactComponentTreeTestUtils.js#L28

[2]: https://github.com/facebook/react/blob/72196da82915bee400edb1599d4223926aa2a8a0/src/renderers/__tests__/ReactComponentTreeHook-test.js#L281

[3]: https://github.com/facebook/react/blob/72196da82915bee400edb1599d4223926aa2a8a0/src/renderers/__tests__/ReactComponentTreeHook-test.js#L354

[4]: https://github.com/facebook/react/blob/72196da82915bee400edb1599d4223926aa2a8a0/src/renderers/__tests__/ReactComponentTreeHook-test.js#L648

[5]: https://github.com/facebook/react/blob/72196da82915bee400edb1599d4223926aa2a8a0/src/isomorphic/hooks/ReactComponentTreeHook.js#L361