### PR TITLE
Expose batchedUpdates on shallow renderer

### DIFF
--- a/src/renderers/testing/ReactShallowRenderer.js
+++ b/src/renderers/testing/ReactShallowRenderer.js
@@ -129,6 +129,11 @@ class ReactShallowRenderer {
       ReactReconciler.unmountComponent(this._instance, false);
     }
   }
+  unstable_batchedUpdates(callback, bookkeeping) {
+    // This is used by Enzyme for fake-simulating events in shallow mode.
+    injectDefaults();
+    return ReactUpdates.batchedUpdates(callback, bookkeeping);
+  }
   _render(element, transaction, context) {
     if (this._instance) {
       ReactReconciler.receiveComponent(


### PR DESCRIPTION
I think this should help resolve issues with migration to `react-test-renderer/shallow` in https://github.com/airbnb/enzyme/pull/876. Turns out Enzyme relied on `ReactDOM.unstable_batchedUpdates` which stopped working with shallow renderer. This is fixable if we expose an equivalent on shallow renderer itself.