### PR TITLE
Fix react-addons-create-fragment package export

### DIFF
--- a/addons/react-addons-create-fragment/index.js
+++ b/addons/react-addons-create-fragment/index.js
@@ -439,4 +439,4 @@ module.exports = function(React) {
   }
 
   return createReactFragment;
-}
+}(React);


### PR DESCRIPTION
Fix the react-addons-create-fragment package to properly exports the `createReactFragment` function as intended. This package is currently exporting a function that returns the `createReactFragment()`, which is incorrect. The package should be exporting the actual `createReactFragment()`. 

This fixes facebook/react#9381.
