### PR TITLE
Update addons-test-utils.md

### DIFF
--- a/docs/docs/addons-test-utils.md
+++ b/docs/docs/addons-test-utils.md
@@ -9,8 +9,8 @@ category: Reference
 **Importing**
 
 ```javascript
-import ReactTestUtils from 'react-dom/test-utils'; // ES6
-var ReactTestUtils = require('react-dom/test-utils'); // ES5 with npm
+import ReactTestUtils from 'react-dom/lib/ReactTestUtils'; // ES6
+var ReactTestUtils = require('react-dom/lib/ReactTestUtils'); // ES5 with npm
 ```
 
 ## Overview


### PR DESCRIPTION
```
import ReactTestUtils from 'react-dom/test-utils'
```

won't work for me, while:

```
import ReactTestUtils from 'react-dom/lib/ReactTestUtils'
```

does work.

Tested both in a create-react-app (v0.9.5) and creating a new project and installing `react-dom@15.5.3`.