### PR TITLE
Fiber ReactDOM shouldn't throw on import in Node environment if it's unused

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1642,6 +1642,10 @@ src/renderers/native/__tests__/ReactNativeMount-test.js
 * returns the correct instance and calls it in the callback
 * renders and reorders children
 
+src/renderers/shared/__tests__/ReactDOMFrameScheduling-test.js
+* throws when requestAnimationFrame is not polyfilled in the browser.
+* can import findDOMNode in Node environment.
+
 src/renderers/shared/__tests__/ReactDebugTool-test.js
 * should add and remove hooks
 * warns once when an error is thrown in hook

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1643,8 +1643,8 @@ src/renderers/native/__tests__/ReactNativeMount-test.js
 * renders and reorders children
 
 src/renderers/shared/__tests__/ReactDOMFrameScheduling-test.js
-* throws when requestAnimationFrame is not polyfilled in the browser.
-* can import findDOMNode in Node environment.
+* throws when requestAnimationFrame is not polyfilled in the browser
+* can import findDOMNode in Node environment
 
 src/renderers/shared/__tests__/ReactDebugTool-test.js
 * should add and remove hooks

--- a/src/renderers/shared/__tests__/ReactDOMFrameScheduling-test.js
+++ b/src/renderers/shared/__tests__/ReactDOMFrameScheduling-test.js
@@ -15,30 +15,41 @@ const ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 const describeFiber = ReactDOMFeatureFlags.useFiber ? describe : xdescribe;
 
 describeFiber('ReactDOMFrameScheduling', () => {
-  it('throws when requestAnimationFrame is not polyfilled in the browser.', () => {
+  it('throws when requestAnimationFrame is not polyfilled in the browser', () => {
     const previousRAF = global.requestAnimationFrame;
-    global.requestAnimationFrame = undefined;
-    jest.resetModules();
-    expect(() => {
-      require('ReactDOM');
-    }).toThrow(
-      'React depends on requestAnimationFrame. Make sure that you load a ' +
-        'polyfill in older browsers.',
-    );
-    global.requestAnimationFrame = previousRAF;
+    try {
+      global.requestAnimationFrame = undefined;
+      jest.resetModules();
+      expect(() => {
+        require('ReactDOM');
+      }).toThrow(
+        'React depends on requestAnimationFrame. Make sure that you load a ' +
+          'polyfill in older browsers.',
+      );
+    } finally {
+      global.requestAnimationFrame = previousRAF;
+    }
   });
 
-  it('can import findDOMNode in Node environment.', () => {
+  // We're just testing importing, not using it.
+  // It is important because even isomorphic components may import it.
+  it('can import findDOMNode in Node environment', () => {
     const previousRAF = global.requestAnimationFrame;
     const previousRIC = global.requestIdleCallback;
-    global.requestAnimationFrame = undefined;
-    global.requestIdleCallback = undefined;
     const prevWindow = global.window;
-    delete global.window;
-    jest.resetModules();
-    require('ReactDOM');
-    global.requestAnimationFrame = previousRAF;
-    global.requestIdleCallback = previousRIC;
-    global.window = prevWindow;
+    try {
+      global.requestAnimationFrame = undefined;
+      global.requestIdleCallback = undefined;
+      // Simulate the Node environment:
+      delete global.window;
+      jest.resetModules();
+      expect(() => {
+        require('ReactDOM');
+      }).not.toThrow();
+    } finally {
+      global.requestAnimationFrame = previousRAF;
+      global.requestIdleCallback = previousRIC;
+      global.window = prevWindow;
+    }
   });
 });

--- a/src/renderers/shared/__tests__/ReactDOMFrameScheduling-test.js
+++ b/src/renderers/shared/__tests__/ReactDOMFrameScheduling-test.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+const ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
+const describeFiber = ReactDOMFeatureFlags.useFiber ? describe : xdescribe;
+
+describeFiber('ReactDOMFrameScheduling', () => {
+  it('throws when requestAnimationFrame is not polyfilled in the browser.', () => {
+    const previousRAF = global.requestAnimationFrame;
+    global.requestAnimationFrame = undefined;
+    jest.resetModules();
+    expect(() => {
+      require('ReactDOM');
+    }).toThrow(
+      'React depends on requestAnimationFrame. Make sure that you load a ' +
+        'polyfill in older browsers.',
+    );
+    global.requestAnimationFrame = previousRAF;
+  });
+
+  it('can import findDOMNode in Node environment.', () => {
+    const previousRAF = global.requestAnimationFrame;
+    const previousRIC = global.requestIdleCallback;
+    global.requestAnimationFrame = undefined;
+    global.requestIdleCallback = undefined;
+    const prevWindow = global.window;
+    delete global.window;
+    jest.resetModules();
+    require('ReactDOM');
+    global.requestAnimationFrame = previousRAF;
+    global.requestIdleCallback = previousRIC;
+    global.window = prevWindow;
+  });
+});


### PR DESCRIPTION
Patch for #9102 