### PR TITLE
Update typechecking-with-proptypes.md

### DIFF
--- a/docs/docs/typechecking-with-proptypes.md
+++ b/docs/docs/typechecking-with-proptypes.md
@@ -12,6 +12,8 @@ redirect_from:
 As your app grows, you can catch a lot of bugs with typechecking. For some applications, you can use JavaScript extensions like [Flow](https://flowtype.org/) or [TypeScript](https://www.typescriptlang.org/) to typecheck your whole application. But even if you don't use those, React has some built-in typechecking abilities. To run typechecking on the props for a component, you can assign the special `propTypes` property:
 
 ```javascript
+import {string} from 'prop-types';
+
 class Greeting extends React.Component {
   render() {
     return (
@@ -21,68 +23,70 @@ class Greeting extends React.Component {
 }
 
 Greeting.propTypes = {
-  name: React.PropTypes.string
+  name: string
 };
 ```
 
-`React.PropTypes` exports a range of validators that can be used to make sure the data you receive is valid. In this example, we're using `React.PropTypes.string`. When an invalid value is provided for a prop, a warning will be shown in the JavaScript console. For performance reasons, `propTypes` is only checked in development mode.
+`PropTypes` exports a range of validators that can be used to make sure the data you receive is valid. In this example, we're using `PropTypes.string`. When an invalid value is provided for a prop, a warning will be shown in the JavaScript console. For performance reasons, `propTypes` is only checked in development mode.
 
-### React.PropTypes
+### PropTypes
 
 Here is an example documenting the different validators provided:
 
 ```javascript
+import PropTypes from 'prop-types';
+
 MyComponent.propTypes = {
   // You can declare that a prop is a specific JS primitive. By default, these
   // are all optional.
-  optionalArray: React.PropTypes.array,
-  optionalBool: React.PropTypes.bool,
-  optionalFunc: React.PropTypes.func,
-  optionalNumber: React.PropTypes.number,
-  optionalObject: React.PropTypes.object,
-  optionalString: React.PropTypes.string,
-  optionalSymbol: React.PropTypes.symbol,
+  optionalArray: array,
+  optionalBool: PropTypes.bool,
+  optionalFunc: PropTypes.func,
+  optionalNumber: PropTypes.number,
+  optionalObject: PropTypes.object,
+  optionalString: PropTypes.string,
+  optionalSymbol: PropTypes.symbol,
 
   // Anything that can be rendered: numbers, strings, elements or an array
   // (or fragment) containing these types.
-  optionalNode: React.PropTypes.node,
+  optionalNode: PropTypes.node,
 
   // A React element.
-  optionalElement: React.PropTypes.element,
+  optionalElement: PropTypes.element,
 
   // You can also declare that a prop is an instance of a class. This uses
   // JS's instanceof operator.
-  optionalMessage: React.PropTypes.instanceOf(Message),
+  optionalMessage: PropTypes.instanceOf(Message),
 
   // You can ensure that your prop is limited to specific values by treating
   // it as an enum.
-  optionalEnum: React.PropTypes.oneOf(['News', 'Photos']),
+  optionalEnum: PropTypes.oneOf(['News', 'Photos']),
 
   // An object that could be one of many types
-  optionalUnion: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.number,
-    React.PropTypes.instanceOf(Message)
+  optionalUnion: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.instanceOf(Message)
   ]),
 
   // An array of a certain type
-  optionalArrayOf: React.PropTypes.arrayOf(React.PropTypes.number),
+  optionalArrayOf: PropTypes.arrayOf(PropTypes.number),
 
   // An object with property values of a certain type
-  optionalObjectOf: React.PropTypes.objectOf(React.PropTypes.number),
+  optionalObjectOf: PropTypes.objectOf(PropTypes.number),
 
   // An object taking on a particular shape
-  optionalObjectWithShape: React.PropTypes.shape({
-    color: React.PropTypes.string,
-    fontSize: React.PropTypes.number
+  optionalObjectWithShape: PropTypes.shape({
+    color: PropTypes.string,
+    fontSize: PropTypes.number
   }),
 
   // You can chain any of the above with `isRequired` to make sure a warning
   // is shown if the prop isn't provided.
-  requiredFunc: React.PropTypes.func.isRequired,
+  requiredFunc: PropTypes.func.isRequired,
 
   // A value of any data type
-  requiredAny: React.PropTypes.any.isRequired,
+  requiredAny: PropTypes.any.isRequired,
 
   // You can also specify a custom validator. It should return an Error
   // object if the validation fails. Don't `console.warn` or throw, as this
@@ -101,7 +105,7 @@ MyComponent.propTypes = {
   // will be called for each key in the array or object. The first two
   // arguments of the validator are the array or object itself, and the
   // current item's key.
-  customArrayProp: React.PropTypes.arrayOf(function(propValue, key, componentName, location, propFullName) {
+  customArrayProp: PropTypes.arrayOf(function(propValue, key, componentName, location, propFullName) {
     if (!/matchme/.test(propValue[key])) {
       return new Error(
         'Invalid prop `' + propFullName + '` supplied to' +
@@ -114,9 +118,11 @@ MyComponent.propTypes = {
 
 ### Requiring Single Child
 
-With `React.PropTypes.element` you can specify that only a single child can be passed to a component as children.
+With `PropTypes.element` you can specify that only a single child can be passed to a component as children.
 
 ```javascript
+import PropTypes from 'prop-types';
+
 class MyComponent extends React.Component {
   render() {
     // This must be exactly one element or it will warn.
@@ -130,7 +136,7 @@ class MyComponent extends React.Component {
 }
 
 MyComponent.propTypes = {
-  children: React.PropTypes.element.isRequired
+  children: PropTypes.element.isRequired
 };
 ```
 

--- a/docs/docs/typechecking-with-proptypes.md
+++ b/docs/docs/typechecking-with-proptypes.md
@@ -39,7 +39,7 @@ import PropTypes from 'prop-types';
 MyComponent.propTypes = {
   // You can declare that a prop is a specific JS primitive. By default, these
   // are all optional.
-  optionalArray: array,
+  optionalArray: PropTypes.array,
   optionalBool: PropTypes.bool,
   optionalFunc: PropTypes.func,
   optionalNumber: PropTypes.number,
@@ -121,7 +121,7 @@ MyComponent.propTypes = {
 With `PropTypes.element` you can specify that only a single child can be passed to a component as children.
 
 ```javascript
-import PropTypes from 'prop-types';
+import {element} from 'prop-types';
 
 class MyComponent extends React.Component {
   render() {
@@ -136,7 +136,7 @@ class MyComponent extends React.Component {
 }
 
 MyComponent.propTypes = {
-  children: PropTypes.element.isRequired
+  children: element.isRequired
 };
 ```
 

--- a/docs/docs/typechecking-with-proptypes.md
+++ b/docs/docs/typechecking-with-proptypes.md
@@ -12,7 +12,7 @@ redirect_from:
 As your app grows, you can catch a lot of bugs with typechecking. For some applications, you can use JavaScript extensions like [Flow](https://flowtype.org/) or [TypeScript](https://www.typescriptlang.org/) to typecheck your whole application. But even if you don't use those, React has some built-in typechecking abilities. To run typechecking on the props for a component, you can assign the special `propTypes` property:
 
 ```javascript
-import {string} from 'prop-types';
+import PropTypes from 'prop-types';
 
 class Greeting extends React.Component {
   render() {
@@ -23,7 +23,7 @@ class Greeting extends React.Component {
 }
 
 Greeting.propTypes = {
-  name: string
+  name: PropTypes.string
 };
 ```
 
@@ -121,7 +121,7 @@ MyComponent.propTypes = {
 With `PropTypes.element` you can specify that only a single child can be passed to a component as children.
 
 ```javascript
-import {element} from 'prop-types';
+import PropTypes from 'prop-types';
 
 class MyComponent extends React.Component {
   render() {
@@ -136,7 +136,7 @@ class MyComponent extends React.Component {
 }
 
 MyComponent.propTypes = {
-  children: element.isRequired
+  children: PropTypes.element.isRequired
 };
 ```
 


### PR DESCRIPTION
This updates the documentation for type-checking with PropTypes, removing the usage of `React.PropTypes` in favor of the NPM package.