### PR TITLE
15.5 bump proptypes version

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "merge-stream": "^1.0.0",
     "object-assign": "^4.1.1",
     "platform": "^1.1.0",
-    "prop-types": "15.5.0-alpha.0",
+    "prop-types": "15.5.7",
     "run-sequence": "^1.1.4",
     "through2": "^2.0.0",
     "tmp": "~0.0.28",


### PR DESCRIPTION
To fix a breaking change which was not supposed to be included yet, we
reverted the change in prop-types v15.5.7 and are now pulling that into
React.

Related to fixing https://github.com/reactjs/prop-types/issues/17