### PR TITLE
Make React 0.14 compatible with prop-types

### DIFF
--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -195,7 +195,14 @@ function checkPropTypes(componentName, propTypes, props, location) {
           ReactPropTypeLocationNames[location],
           propName
         );
-        error = propTypes[propName](props, propName, componentName, location);
+        error = propTypes[propName](
+          props,
+          propName,
+          componentName,
+          location,
+          null,
+          'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED'
+        );
       } catch (ex) {
         error = ex;
       }

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -159,7 +159,8 @@ function createArrayOfTypeChecker(typeChecker) {
         i,
         componentName,
         location,
-        `${propFullName}[${i}]`
+        `${propFullName}[${i}]`,
+        'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED'
       );
       if (error instanceof Error) {
         return error;
@@ -246,7 +247,8 @@ function createObjectOfTypeChecker(typeChecker) {
           key,
           componentName,
           location,
-          `${propFullName}.${key}`
+          `${propFullName}.${key}`,
+          'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED'
         );
         if (error instanceof Error) {
           return error;
@@ -271,7 +273,14 @@ function createUnionTypeChecker(arrayOfTypeCheckers) {
     for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
       var checker = arrayOfTypeCheckers[i];
       if (
-        checker(props, propName, componentName, location, propFullName) == null
+        checker(
+          props,
+          propName,
+          componentName,
+          location,
+          propFullName,
+          'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED'
+        ) == null
       ) {
         return null;
       }
@@ -321,7 +330,8 @@ function createShapeTypeChecker(shapeTypes) {
         key,
         componentName,
         location,
-        `${propFullName}.${key}`
+        `${propFullName}.${key}`,
+        'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED'
       );
       if (error) {
         return error;

--- a/src/renderers/dom/client/wrappers/LinkedValueUtils.js
+++ b/src/renderers/dom/client/wrappers/LinkedValueUtils.js
@@ -110,7 +110,9 @@ var LinkedValueUtils = {
           props,
           propName,
           tagName,
-          ReactPropTypeLocations.prop
+          ReactPropTypeLocations.prop,
+          null,
+          'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED'
         );
       }
       if (error instanceof Error && !(error.message in loggedTypeFailures)) {

--- a/src/renderers/shared/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/reconciler/ReactCompositeComponent.js
@@ -471,7 +471,14 @@ var ReactCompositeComponentMixin = {
             ReactPropTypeLocationNames[location],
             propName
           );
-          error = propTypes[propName](props, propName, componentName, location);
+          error = propTypes[propName](
+            props,
+            propName,
+            componentName,
+            location,
+            null,
+            'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED'
+          );
         } catch (ex) {
           error = ex;
         }


### PR DESCRIPTION
Never thought I'd go back to 0.14 but here we are: https://github.com/reactjs/react-redux/issues/669.

It's reasonable for standalone `prop-types` package to support both 0.14 and 15 to ease the migration effort for library authors. So let's release React 0.14.9 that “understands” standalone `prop-types` by passing the secret.

(Also I hope this doesn't get me fired?)