### PR TITLE
Fix the proptypes deprecation warning url on the "Don't Call PropTypes Warning" doc page

### DIFF
--- a/docs/warnings/dont-call-proptypes.md
+++ b/docs/warnings/dont-call-proptypes.md
@@ -5,7 +5,7 @@ permalink: warnings/dont-call-proptypes.html
 ---
 
 > Note:
-> `React.PropTypes` is deprecated as of React v15.5. Please use [the `prop-types` library instead](https://github.com/aackerman/PropTypes).
+> `React.PropTypes` is deprecated as of React v15.5. Please use [the `prop-types` library instead](https://www.npmjs.com/package/prop-types).
 
 In a future major release of React, the code that implements PropType validation functions will be stripped in production. Once this happens, any code that calls these functions manually (that isn't stripped in production) will throw an error.
 

--- a/docs/warnings/dont-call-proptypes.md
+++ b/docs/warnings/dont-call-proptypes.md
@@ -5,7 +5,7 @@ permalink: warnings/dont-call-proptypes.html
 ---
 
 > Note:
-> `React.PropTypes` is deprecated as of React v15.5. Please use [the `prop-types` library instead](https://www.npmjs.com/package/prop-types).
+> `React.PropTypes` is deprecated as of React v15.5. Please use [the `prop-types` library instead](https://github.com/reactjs/prop-types).
 
 In a future major release of React, the code that implements PropType validation functions will be stripped in production. Once this happens, any code that calls these functions manually (that isn't stripped in production) will throw an error.
 


### PR DESCRIPTION
The [Don't Call PropTypes Warning doc page](https://facebook.github.io/react/warnings/dont-call-proptypes.html ) has a warning about the 15.5 deprecation pointing to an old proptypes repository.

This PR updates the link to the same link on the main [PropTypes doc page](https://facebook.github.io/react/docs/typechecking-with-proptypes.html).