### PR TITLE
Use charAt instead of string indexing

### DIFF
--- a/src/renderers/dom/shared/eventPlugins/SimpleEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/SimpleEventPlugin.js
@@ -123,7 +123,7 @@ var topLevelEventsToDispatchConfig: {[key: TopLevelTypes]: DispatchConfig} = {};
   'waiting',
   'wheel',
 ].forEach(event => {
-  var capitalizedEvent = event[0].toUpperCase() + event.slice(1);
+  var capitalizedEvent = event.charAt(0).toUpperCase() + event.slice(1);
   var onEvent = 'on' + capitalizedEvent;
   var topEvent = 'top' + capitalizedEvent;
 


### PR DESCRIPTION
Related: https://github.com/facebook/react/pull/2651

This replaces the `event[0]` character access with `charAt`.

We're currently trying to use `react` with `PrinceXML`, which does not have character access by index implemented, causing a failure to render.