### PR TITLE
Warning added if defaultProps were defined as an instance property

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -395,6 +395,7 @@ src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
 * should warn on invalid prop types
 * should warn on invalid context types
 * should warn if getDefaultProps is specificed on the class
+* should warn on invalid default props
 
 src/renderers/__tests__/EventPluginHub-test.js
 * should prevent non-function listeners, at dispatch

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -395,7 +395,6 @@ src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
 * should warn on invalid prop types
 * should warn on invalid context types
 * should warn if getDefaultProps is specificed on the class
-* should warn on invalid default props
 
 src/renderers/__tests__/EventPluginHub-test.js
 * should prevent non-function listeners, at dispatch
@@ -460,6 +459,7 @@ src/renderers/__tests__/ReactCompositeComponent-test.js
 * should call componentWillUnmount before unmounting
 * should warn when shouldComponentUpdate() returns undefined
 * should warn when componentDidUnmount method is defined
+* should warn when defaultProps was defined as an instance property
 * should pass context to children when not owner
 * should skip update when rerendering element in container
 * should pass context when re-rendered for static child

--- a/src/renderers/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/__tests__/ReactCompositeComponent-test.js
@@ -486,6 +486,29 @@ describe('ReactCompositeComponent', () => {
     );
   });
 
+  it('should warn when defaultProps was defined as an instance property', () => {
+    spyOn(console, 'error');
+
+    class Component extends React.Component {
+      constructor(props) {
+        super(props);
+        this.defaultProps = {name: 'Abhay'};
+      }
+
+      render() {
+        return <div />;
+      }
+    }
+
+    ReactTestUtils.renderIntoDocument(<Component />);
+
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toBe(
+      'Warning: defaultProps was defined as an instance property ' +
+        'on Component. Use a static property to define defaultProps instead.',
+    );
+  });
+
   it('should pass context to children when not owner', () => {
     class Parent extends React.Component {
       render() {

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -229,6 +229,13 @@ module.exports = function(
         name,
         name,
       );
+      const noInstanceDefaultProps = !instance.defaultProps;
+      warning(
+        noInstanceDefaultProps,
+        'defaultProps was defined as an instance property on %s. Use a static ' +
+          'property to define defaultProps instead.',
+        name,
+      );
     }
 
     const state = instance.state;

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -300,6 +300,12 @@ var ReactCompositeComponent = {
           'componentWillRecieveProps(). Did you mean componentWillReceiveProps()?',
         this.getName() || 'A component',
       );
+      warning(
+        !inst.defaultProps,
+        'defaultProps was defined as an instance property on %s. Use a static ' +
+          'property to define defaultProps instead.',
+        this.getName() || 'a component',
+      );
     }
 
     var initialState = inst.state;


### PR DESCRIPTION
- Added a warning if defaultProps were defined as an instance property
- Added related testcases for the changes done.
- Issue related to #9239 
