### PR TITLE
Warn for keys in fragments - second approach

### DIFF
--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -1,17 +1,17 @@
 {
-  "branch": "master",
+  "branch": "warnForKeysInFragmentsRefactor",
   "bundleSizes": {
     "react.development.js (UMD_DEV)": {
-      "size": 121454,
-      "gzip": 30515
+      "size": 122649,
+      "gzip": 30785
     },
     "react.production.min.js (UMD_PROD)": {
       "size": 15685,
       "gzip": 5765
     },
     "react-dom.development.js (UMD_DEV)": {
-      "size": 583190,
-      "gzip": 134534
+      "size": 585217,
+      "gzip": 135179
     },
     "react-dom.production.min.js (UMD_PROD)": {
       "size": 120740,
@@ -26,24 +26,24 @@
       "gzip": 33273
     },
     "react-art.development.js (UMD_DEV)": {
-      "size": 342608,
-      "gzip": 76782
+      "size": 344635,
+      "gzip": 77415
     },
     "react-art.production.min.js (UMD_PROD)": {
       "size": 95013,
       "gzip": 28991
     },
     "react.development.js (NODE_DEV)": {
-      "size": 70266,
-      "gzip": 17594
+      "size": 71459,
+      "gzip": 17851
     },
     "react.production.min.js (NODE_PROD)": {
       "size": 9226,
       "gzip": 3628
     },
     "React-dev.js (FB_DEV)": {
-      "size": 72123,
-      "gzip": 18231
+      "size": 73317,
+      "gzip": 18490
     },
     "React-prod.js (FB_PROD)": {
       "size": 36643,
@@ -58,16 +58,16 @@
       "gzip": 84675
     },
     "react-dom.development.js (NODE_DEV)": {
-      "size": 542188,
-      "gzip": 125158
+      "size": 544213,
+      "gzip": 125804
     },
     "react-dom.production.min.js (NODE_PROD)": {
       "size": 116925,
       "gzip": 36732
     },
     "ReactDOMFiber-dev.js (FB_DEV)": {
-      "size": 797235,
-      "gzip": 184122
+      "size": 799262,
+      "gzip": 184749
     },
     "ReactDOMFiber-prod.js (FB_PROD)": {
       "size": 407613,
@@ -98,16 +98,16 @@
       "gzip": 22993
     },
     "react-art.development.js (NODE_DEV)": {
-      "size": 265052,
-      "gzip": 56927
+      "size": 267077,
+      "gzip": 57558
     },
     "react-art.production.min.js (NODE_PROD)": {
       "size": 56628,
       "gzip": 17152
     },
     "ReactARTFiber-dev.js (FB_DEV)": {
-      "size": 264230,
-      "gzip": 56736
+      "size": 266255,
+      "gzip": 57354
     },
     "ReactARTFiber-prod.js (FB_PROD)": {
       "size": 205336,
@@ -122,20 +122,20 @@
       "gzip": 84001
     },
     "ReactTestRendererFiber-dev.js (FB_DEV)": {
-      "size": 262139,
-      "gzip": 55704
+      "size": 264164,
+      "gzip": 56321
     },
     "ReactTestRendererStack-dev.js (FB_DEV)": {
       "size": 151521,
       "gzip": 34765
     },
     "react-noop-renderer.development.js (NODE_DEV)": {
-      "size": 254136,
-      "gzip": 53682
+      "size": 256161,
+      "gzip": 54312
     },
     "react-test-renderer.development.js (NODE_DEV)": {
-      "size": 262970,
-      "gzip": 55891
+      "size": 264995,
+      "gzip": 56524
     }
   }
 }

--- a/src/isomorphic/children/__tests__/ReactChildren-test.js
+++ b/src/isomorphic/children/__tests__/ReactChildren-test.js
@@ -878,7 +878,7 @@ describe('ReactChildren', () => {
         expectDev(console.error.calls.count()).toBe(1);
         expectDev(console.error.calls.argsFor(0)[0]).toContain(
           'Warning: ' +
-          'Each child in an array or iterator should have a unique "key" prop.'
+            'Each child in an array or iterator should have a unique "key" prop.',
         );
       });
 
@@ -890,9 +890,7 @@ describe('ReactChildren', () => {
           }
         }
 
-        ReactTestUtils.renderIntoDocument(
-          <ComponentReturningArray />
-        );
+        ReactTestUtils.renderIntoDocument(<ComponentReturningArray />);
 
         expectDev(console.error.calls.count()).toBe(0);
       });

--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -24,6 +24,7 @@ var ReactElement = require('ReactElement');
 var canDefineProperty = require('canDefineProperty');
 var getComponentName = require('getComponentName');
 var getIteratorFn = require('getIteratorFn');
+var validateExplicitKey = require('validateExplicitKey');
 
 if (__DEV__) {
   var checkPropTypes = require('checkPropTypes');
@@ -58,13 +59,6 @@ function getSourceInfoErrorAddendum(elementProps) {
   return '';
 }
 
-/**
- * Warn if there's no key explicitly set on dynamic arrays of children or
- * object keys are not valid. This allows us to keep track of children between
- * updates.
- */
-var ownerHasKeyUseWarning = {};
-
 function getCurrentComponentErrorInfo(parentType) {
   var info = getDeclarationErrorAddendum();
 
@@ -80,30 +74,16 @@ function getCurrentComponentErrorInfo(parentType) {
 }
 
 /**
- * Warn if the element doesn't have an explicit key assigned to it.
- * This element is in an array. The array could grow and shrink or be
- * reordered. All children that haven't already been validated are required to
- * have a "key" property assigned to it. Error statuses are cached so a warning
- * will only be shown once.
+ * Composes the warning that is shown when an element doesn't have an explicit
+ * key assigned to it.
  *
  * @internal
- * @param {ReactElement} element Element that requires a key.
  * @param {*} parentType element's parent's type.
+ * @param {ReactElement} element Element that requires a key.
+ * @return string message that described explicit key error
  */
-function validateExplicitKey(element, parentType) {
-  if (!element._store || element._store.validated || element.key != null) {
-    return;
-  }
-  element._store.validated = true;
-
-  var memoizer = ownerHasKeyUseWarning.uniqueKey ||
-    (ownerHasKeyUseWarning.uniqueKey = {});
-
+function getExplicitKeyErrorMessage(parentType, element) {
   var currentComponentErrorInfo = getCurrentComponentErrorInfo(parentType);
-  if (memoizer[currentComponentErrorInfo]) {
-    return;
-  }
-  memoizer[currentComponentErrorInfo] = true;
 
   // Usually the current owner is the offender, but if it accepts children as a
   // property, it may be the creator of the child that's responsible for
@@ -116,14 +96,12 @@ function validateExplicitKey(element, parentType) {
     childOwner = ` It was passed a child from ${getComponentName(element._owner)}.`;
   }
 
-  warning(
-    false,
+  const message =
     'Each child in an array or iterator should have a unique "key" prop.' +
-      '%s%s See https://fb.me/react-warning-keys for more information.%s',
-    currentComponentErrorInfo,
-    childOwner,
-    getCurrentStackAddendum(element),
-  );
+    currentComponentErrorInfo +
+    childOwner + ' ' +
+    'See https://fb.me/react-warning-keys for more information.';
+  return message;
 }
 
 /**
@@ -143,7 +121,13 @@ function validateChildKeys(node, parentType) {
     for (var i = 0; i < node.length; i++) {
       var child = node[i];
       if (ReactElement.isValidElement(child)) {
-        validateExplicitKey(child, parentType);
+        const getMainExplicitKeyErrorMessage =
+          getExplicitKeyErrorMessage.bind(null, parentType);
+        validateExplicitKey(
+          child,
+          getMainExplicitKeyErrorMessage,
+          getCurrentStackAddendum,
+        );
       }
     }
   } else if (ReactElement.isValidElement(node)) {
@@ -160,7 +144,13 @@ function validateChildKeys(node, parentType) {
         var step;
         while (!(step = iterator.next()).done) {
           if (ReactElement.isValidElement(step.value)) {
-            validateExplicitKey(step.value, parentType);
+            const getMainExplicitKeyErrorMessage =
+              getExplicitKeyErrorMessage.bind(null, parentType);
+            validateExplicitKey(
+              step.value,
+              getMainExplicitKeyErrorMessage,
+              getCurrentStackAddendum,
+            );
           }
         }
       }

--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -96,10 +96,10 @@ function getExplicitKeyErrorMessage(parentType, element) {
     childOwner = ` It was passed a child from ${getComponentName(element._owner)}.`;
   }
 
-  const message =
-    'Each child in an array or iterator should have a unique "key" prop.' +
+  const message = 'Each child in an array or iterator should have a unique "key" prop.' +
     currentComponentErrorInfo +
-    childOwner + ' ' +
+    childOwner +
+    ' ' +
     'See https://fb.me/react-warning-keys for more information.';
   return message;
 }
@@ -121,8 +121,10 @@ function validateChildKeys(node, parentType) {
     for (var i = 0; i < node.length; i++) {
       var child = node[i];
       if (ReactElement.isValidElement(child)) {
-        const getMainExplicitKeyErrorMessage =
-          getExplicitKeyErrorMessage.bind(null, parentType);
+        const getMainExplicitKeyErrorMessage = getExplicitKeyErrorMessage.bind(
+          null,
+          parentType,
+        );
         validateExplicitKey(
           child,
           getMainExplicitKeyErrorMessage,
@@ -144,8 +146,10 @@ function validateChildKeys(node, parentType) {
         var step;
         while (!(step = iterator.next()).done) {
           if (ReactElement.isValidElement(step.value)) {
-            const getMainExplicitKeyErrorMessage =
-              getExplicitKeyErrorMessage.bind(null, parentType);
+            const getMainExplicitKeyErrorMessage = getExplicitKeyErrorMessage.bind(
+              null,
+              parentType,
+            );
             validateExplicitKey(
               step.value,
               getMainExplicitKeyErrorMessage,

--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -96,12 +96,11 @@ function getExplicitKeyErrorMessage(parentType, element) {
     childOwner = ` It was passed a child from ${getComponentName(element._owner)}.`;
   }
 
-  const message = 'Each child in an array or iterator should have a unique "key" prop.' +
-    currentComponentErrorInfo +
+  const message = currentComponentErrorInfo +
     childOwner +
     ' ' +
     'See https://fb.me/react-warning-keys for more information.';
-  return message;
+  return message + getCurrentStackAddendum(element);
 }
 
 /**
@@ -117,18 +116,19 @@ function validateChildKeys(node, parentType) {
   if (typeof node !== 'object') {
     return;
   }
+  var memoizedPortionOfErrorMessage = getCurrentComponentErrorInfo(parentType);
+  const getMainExplicitKeyErrorMessage = getExplicitKeyErrorMessage.bind(
+    null,
+    parentType,
+  );
   if (Array.isArray(node)) {
     for (var i = 0; i < node.length; i++) {
       var child = node[i];
       if (ReactElement.isValidElement(child)) {
-        const getMainExplicitKeyErrorMessage = getExplicitKeyErrorMessage.bind(
-          null,
-          parentType,
-        );
         validateExplicitKey(
           child,
           getMainExplicitKeyErrorMessage,
-          getCurrentStackAddendum,
+          memoizedPortionOfErrorMessage,
         );
       }
     }
@@ -146,14 +146,10 @@ function validateChildKeys(node, parentType) {
         var step;
         while (!(step = iterator.next()).done) {
           if (ReactElement.isValidElement(step.value)) {
-            const getMainExplicitKeyErrorMessage = getExplicitKeyErrorMessage.bind(
-              null,
-              parentType,
-            );
             validateExplicitKey(
               step.value,
               getMainExplicitKeyErrorMessage,
-              getCurrentStackAddendum,
+              memoizedPortionOfErrorMessage,
             );
           }
         }

--- a/src/renderers/__tests__/ReactMultiChildText-test.js
+++ b/src/renderers/__tests__/ReactMultiChildText-test.js
@@ -191,10 +191,20 @@ describe('ReactMultiChildText', () => {
       [true, <div>{1.2}{''}{<div />}{'foo'}</div>, true, 1.2], [<div />, '1.2'],
       ['', 'foo', <div>{true}{<div />}{1.2}{''}</div>, 'foo'], ['', 'foo', <div />, 'foo'],
     ]);
-    expectDev(console.error.calls.count()).toBe(1);
-    expectDev(console.error.calls.argsFor(0)[0]).toContain(
-      'Warning: Each child in an array or iterator should have a unique "key" prop.',
-    );
+    if (ReactDOMFeatureFlags.useFiber) {
+      expectDev(console.error.calls.count()).toBe(2);
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        'Warning: Each child in an array or iterator should have a unique "key" prop.',
+      );
+      expectDev(console.error.calls.argsFor(1)[0]).toContain(
+        'Warning: Each child in an array or iterator should have a unique "key" prop.',
+      );
+    } else {
+      expectDev(console.error.calls.count()).toBe(1);
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        'Warning: Each child in an array or iterator should have a unique "key" prop.',
+      );
+    }
   });
 
   it('should throw if rendering both HTML and children', () => {

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
@@ -118,7 +118,7 @@ describe('ReactDOMFiber', () => {
     it('finds the first child when a component returns a fragment', () => {
       class Fragment extends React.Component {
         render() {
-          return [<div />, <span />];
+          return [<div key="a" />, <span key="b" />];
         }
       }
 
@@ -141,7 +141,7 @@ describe('ReactDOMFiber', () => {
 
       class Fragment extends React.Component {
         render() {
-          return [<Wrapper><div /></Wrapper>, <span />];
+          return [<Wrapper key="a"><div /></Wrapper>, <span key="b" />];
         }
       }
 
@@ -164,7 +164,11 @@ describe('ReactDOMFiber', () => {
 
       class Fragment extends React.Component {
         render() {
-          return [<NullComponent />, <div />, <span />];
+          return [
+            <NullComponent key="a" />,
+            <div key="b" />,
+            <span key="c" />,
+          ];
         }
       }
 
@@ -263,16 +267,16 @@ describe('ReactDOMFiber', () => {
         render() {
           const {step} = this.props;
           return [
-            <Child name={`normal[0]:${step}`} />,
+            <Child key="a" name={`normal[0]:${step}`} />,
             ReactDOM.unstable_createPortal(
-              <Child name={`portal1[0]:${step}`} />,
+              <Child key="b" name={`portal1[0]:${step}`} />,
               portalContainer1,
             ),
-            <Child name={`normal[1]:${step}`} />,
+            <Child key="c" name={`normal[1]:${step}`} />,
             ReactDOM.unstable_createPortal(
               [
-                <Child name={`portal2[0]:${step}`} />,
-                <Child name={`portal2[1]:${step}`} />,
+                <Child key="d" name={`portal2[0]:${step}`} />,
+                <Child key="e" name={`portal2[1]:${step}`} />,
               ],
               portalContainer2,
             ),
@@ -337,23 +341,23 @@ describe('ReactDOMFiber', () => {
 
       ReactDOM.render(
         [
-          <div>normal[0]</div>,
+          <div key="a">normal[0]</div>,
           ReactDOM.unstable_createPortal(
             [
-              <div>portal1[0]</div>,
+              <div key="b">portal1[0]</div>,
               ReactDOM.unstable_createPortal(
-                <div>portal2[0]</div>,
+                <div key="c">portal2[0]</div>,
                 portalContainer2,
               ),
               ReactDOM.unstable_createPortal(
-                <div>portal3[0]</div>,
+                <div key="d">portal3[0]</div>,
                 portalContainer3,
               ),
-              <div>portal1[1]</div>,
+              <div key="e">portal1[1]</div>,
             ],
             portalContainer1,
           ),
-          <div>normal[1]</div>,
+          <div key="f">normal[1]</div>,
         ],
         container,
       );
@@ -943,7 +947,7 @@ describe('ReactDOMFiber', () => {
       }
 
       let inst;
-      ReactDOM.render([<Example ref={n => inst = n} />], container);
+      ReactDOM.render([<Example key="a" ref={n => inst = n} />], container);
       const node = container.firstChild;
       expect(node.tagName).toEqual('DIV');
 
@@ -981,7 +985,10 @@ describe('ReactDOMFiber', () => {
       // click handler during render to simulate a click during an aborted
       // render. I use this hack because at current time we don't have a way to
       // test aborted ReactDOM renders.
-      ReactDOM.render([<Example forceA={true} />, <Click />], container);
+      ReactDOM.render(
+        [<Example key="a" forceA={true} />, <Click key="b" />],
+        container,
+      );
 
       // Because the new click handler has not yet committed, we should still
       // invoke B.
@@ -1030,7 +1037,7 @@ describe('disableNewFiberFeatures', () => {
     expect(() => ReactDOM.render(false, container)).toThrow(message, container);
     expect(() => ReactDOM.render('Hi', container)).toThrow(message, container);
     expect(() => ReactDOM.render(999, container)).toThrow(message, container);
-    expect(() => ReactDOM.render([<div />], container)).toThrow(
+    expect(() => ReactDOM.render([<div key="a" />], container)).toThrow(
       message,
       container,
     );
@@ -1048,7 +1055,7 @@ describe('disableNewFiberFeatures', () => {
       /You may have returned undefined/,
     );
     expect(() =>
-      ReactDOM.render(<Render>[<div />]</Render>, container)).toThrow(
+      ReactDOM.render(<Render>[<div key="a" />]</Render>, container)).toThrow(
       /You may have returned undefined/,
     );
   });

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
@@ -164,11 +164,7 @@ describe('ReactDOMFiber', () => {
 
       class Fragment extends React.Component {
         render() {
-          return [
-            <NullComponent key="a" />,
-            <div key="b" />,
-            <span key="c" />,
-          ];
+          return [<NullComponent key="a" />, <div key="b" />, <span key="c" />];
         }
       }
 

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -606,8 +606,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         case REACT_COROUTINE_TYPE:
         case REACT_PORTAL_TYPE:
           const getMainExplicitKeyWarning = () => {
-            const message =
-              'Each child in an array or iterator should have a unique ' +
+            const message = 'Each child in an array or iterator should have a unique ' +
               '"key" prop.' +
               'See https://fb.me/react-warning-keys for more information.';
             return message;

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -41,6 +41,7 @@ var {ReactCurrentOwner} = require('ReactGlobalSharedState');
 if (__DEV__) {
   var {getCurrentFiberStackAddendum} = require('ReactDebugCurrentFiber');
   var getComponentName = require('getComponentName');
+  var validateExplicitKey = require('validateExplicitKey');
   var warning = require('fbjs/lib/warning');
   var didWarnAboutMaps = false;
 }
@@ -604,6 +605,19 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         case REACT_ELEMENT_TYPE:
         case REACT_COROUTINE_TYPE:
         case REACT_PORTAL_TYPE:
+          const getMainExplicitKeyWarning = () => {
+            const message =
+              'Each child in an array or iterator should have a unique ' +
+              '"key" prop.' +
+              'See https://fb.me/react-warning-keys for more information.';
+            return message;
+          };
+          validateExplicitKey(
+            child,
+            getMainExplicitKeyWarning,
+            getCurrentFiberStackAddendum,
+          );
+
           const key = child.key;
           if (typeof key !== 'string') {
             break;

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -605,16 +605,10 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         case REACT_ELEMENT_TYPE:
         case REACT_COROUTINE_TYPE:
         case REACT_PORTAL_TYPE:
-          const getMainExplicitKeyWarning = () => {
-            const message = 'Each child in an array or iterator should have a unique ' +
-              '"key" prop.' +
-              'See https://fb.me/react-warning-keys for more information.';
-            return message;
-          };
           validateExplicitKey(
             child,
-            getMainExplicitKeyWarning,
             getCurrentFiberStackAddendum,
+            getCurrentFiberStackAddendum(child),
           );
 
           const key = child.key;

--- a/src/renderers/shared/fiber/__tests__/ReactCoroutine-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactCoroutine-test.js
@@ -57,13 +57,13 @@ describe('ReactCoroutine', () => {
 
     function Indirection() {
       ops.push('Indirection');
-      return [<Child bar={true} />, <Child bar={false} />];
+      return [<Child key="a" bar={true} />, <Child key="b" bar={false} />];
     }
 
     function HandleYields(props, yields) {
       ops.push('HandleYields');
-      return yields.map(y => (
-        <y.continuation isSame={props.foo === y.props.bar} />
+      return yields.map((y, i) => (
+        <y.continuation key={i} isSame={props.foo === y.props.bar} />
       ));
     }
 
@@ -117,12 +117,12 @@ describe('ReactCoroutine', () => {
     }
 
     function Indirection() {
-      return [<Child bar={true} />, <Child bar={false} />];
+      return [<Child key="a" bar={true} />, <Child key="b" bar={false} />];
     }
 
     function HandleYields(props, yields) {
-      return yields.map(y => (
-        <y.continuation isSame={props.foo === y.props.bar} />
+      return yields.map((y, i) => (
+        <y.continuation key={i} isSame={props.foo === y.props.bar} />
       ));
     }
 
@@ -176,7 +176,9 @@ describe('ReactCoroutine', () => {
 
     function HandleYields(props, yields) {
       ops.push('HandleYields');
-      return yields.map(ContinuationComponent => <ContinuationComponent />);
+      return yields.map((ContinuationComponent, i) => (
+        <ContinuationComponent key={i} />
+      ));
     }
 
     class Parent extends React.Component {
@@ -223,8 +225,12 @@ describe('ReactCoroutine', () => {
 
     function App(props) {
       return ReactCoroutine.createCoroutine(
-        [<Counter id="a" />, <Counter id="b" />, <Counter id="c" />],
-        (p, yields) => yields.map(y => <span prop={y * 100} />),
+        [
+          <Counter key="a" id="a" />,
+          <Counter key="b" id="b" />,
+          <Counter key="c" id="c" />,
+        ],
+        (p, yields) => yields.map((y, i) => <span key={i} prop={y * 100} />),
         {},
       );
     }

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -51,7 +51,7 @@ describe('ReactIncremental', () => {
     var fooCalled = false;
     function Foo() {
       fooCalled = true;
-      return [<Bar isBar={true} />, <Bar isBar={true} />];
+      return [<Bar key="a" isBar={true} />, <Bar key="b" isBar={true} />];
     }
 
     ReactNoop.render(<Foo />, () => renderCallbackCalled = true);
@@ -384,8 +384,8 @@ describe('ReactIncremental', () => {
       }
       render() {
         return [
-          <Tester unused={this.props.unused} />,
-          <bbb hidden={true}>
+          <Tester key="a" unused={this.props.unused} />,
+          <bbb key="b" hidden={true}>
             <ccc>
               <Middle>Hi</Middle>
             </ccc>
@@ -583,8 +583,8 @@ describe('ReactIncremental', () => {
         // low priority. I think this would be fixed by changing
         // pendingWorkPriority and progressedPriority to be the priority of
         // the children only, not including the fiber itself.
-        <div><Child /></div>,
-        <Sibling />,
+        <div key="a"><Child /></div>,
+        <Sibling key="b" />,
       ];
     }
 
@@ -1413,7 +1413,7 @@ describe('ReactIncremental', () => {
     }
 
     function App(props) {
-      return [<LifeCycle x={props.x} />, <Sibling />];
+      return [<LifeCycle key="a" x={props.x} />, <Sibling key="b" />];
     }
 
     ReactNoop.render(<App x={0} />);
@@ -1662,13 +1662,13 @@ describe('ReactIncremental', () => {
       render() {
         ops.push('Indirection ' + JSON.stringify(this.context));
         return [
-          <ShowLocale />,
-          <ShowRoute />,
-          <ShowNeither />,
-          <Intl locale="ru">
+          <ShowLocale key="a" />,
+          <ShowRoute key="b" />,
+          <ShowNeither key="c" />,
+          <Intl key="d" locale="ru">
             <ShowBoth />
           </Intl>,
-          <ShowBoth />,
+          <ShowBoth key="e" />,
         ];
       }
     }

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalPerf-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalPerf-test.js
@@ -449,12 +449,12 @@ describe('ReactDebugFiberPerf', () => {
     }
 
     function Indirection() {
-      return [<CoChild bar={true} />, <CoChild bar={false} />];
+      return [<CoChild key="a" bar={true} />, <CoChild key="b" bar={false} />];
     }
 
     function HandleYields(props, yields) {
-      return yields.map(y => (
-        <y.continuation isSame={props.foo === y.props.bar} />
+      return yields.map((y, i) => (
+        <y.continuation key={i} isSame={props.foo === y.props.bar} />
       ));
     }
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalReflection-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalReflection-test.js
@@ -169,7 +169,7 @@ describe('ReactIncrementalReflection', () => {
     }
 
     function Foo(props) {
-      return [<Component step={props.step} />, <Sibling />];
+      return [<Component key="a" step={props.step} />, <Sibling key="b" />];
     }
 
     ReactNoop.render(<Foo step={0} />);

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -565,7 +565,10 @@ describe('ReactIncrementalSideEffects', () => {
       }
       render() {
         ops.push('Baz');
-        return [<Bar idx={this.props.idx} />, <Bar idx={this.props.idx} />];
+        return [
+          <Bar key="a" idx={this.props.idx} />,
+          <Bar key="b" idx={this.props.idx} />,
+        ];
       }
     }
     function Foo(props) {

--- a/src/renderers/shared/fiber/__tests__/ReactTopLevelFragment-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactTopLevelFragment-test.js
@@ -77,7 +77,7 @@ describe('ReactTopLevelFragment', function() {
     function Fragment({condition}) {
       return condition
         ? <Stateful key="a" />
-        : [[<Stateful key="a" />, <div key="b">World</div>], <div />];
+        : [[<Stateful key="a" />, <div key="b">World</div>], <div key="c" />];
     }
     ReactNoop.render(<Fragment />);
     ReactNoop.flush();
@@ -106,8 +106,8 @@ describe('ReactTopLevelFragment', function() {
 
     function Fragment({condition}) {
       return condition
-        ? [null, <Stateful />]
-        : [<div>Hello</div>, <Stateful />];
+        ? [null, <Stateful key="a" />]
+        : [<div key="b">Hello</div>, <Stateful key="a" />];
     }
     ReactNoop.render(<Fragment />);
     ReactNoop.flush();
@@ -144,7 +144,7 @@ describe('ReactTopLevelFragment', function() {
     function Fragment({condition}) {
       return condition
         ? [[<div key="b">World</div>, <Stateful key="a" />]]
-        : [[<Stateful key="a" />, <div key="b">World</div>], <div />];
+        : [[<Stateful key="a" />, <div key="b">World</div>], <div key="c" />];
     }
     ReactNoop.render(<Fragment />);
     ReactNoop.flush();

--- a/src/renderers/testing/__tests__/ReactTestRenderer-test.js
+++ b/src/renderers/testing/__tests__/ReactTestRenderer-test.js
@@ -676,8 +676,8 @@ describe('ReactTestRenderer', () => {
       var Component = props => props.children;
 
       var renderer = ReactTestRenderer.create([
-        <Component>Hi</Component>,
-        <Component>Bye</Component>,
+        <Component key="a">Hi</Component>,
+        <Component key="b">Bye</Component>,
       ]);
       expect(renderer.toJSON()).toEqual(['Hi', 'Bye']);
       renderer.update(<div />);
@@ -686,7 +686,7 @@ describe('ReactTestRenderer', () => {
         children: null,
         props: {},
       });
-      renderer.update([<div>goodbye</div>, 'world']);
+      renderer.update([<div key="a">goodbye</div>, 'world']);
       expect(renderer.toJSON()).toEqual([
         {
           type: 'div',

--- a/src/shared/utils/validateExplicitKey.js
+++ b/src/shared/utils/validateExplicitKey.js
@@ -71,10 +71,7 @@ function validateExplicitKey(
   }
   memoizer[mainErrorMessage] = true;
 
-  warning(
-    false,
-    mainErrorMessage + getComponentStackMessage(element),
-  );
+  warning(false, mainErrorMessage + getComponentStackMessage(element));
 }
 
 module.exports = validateExplicitKey;

--- a/src/shared/utils/validateExplicitKey.js
+++ b/src/shared/utils/validateExplicitKey.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule validateExplicitKey
+ * @flow
+ */
+
+/**
+ * ReactElementValidator provides a wrapper around a element factory
+ * which validates the props passed to the element. This is intended to be
+ * used only in DEV and could be replaced by a static type checker for languages
+ * that support it.
+ */
+
+'use strict';
+
+if (__DEV__) {
+  var warning = require('fbjs/lib/warning');
+}
+
+/**
+ * Gets part of the string which we use as error message for user.
+ * We pass the element as the first parameter.
+ */
+type ErrorMessageCallbackType = (element: ReactElement) => string;
+
+/**
+ * Warn if there's no key explicitly set on dynamic arrays of children or
+ * object keys are not valid. This allows us to keep track of children between
+ * updates.
+ */
+var ownerHasKeyUseWarning = {};
+
+/**
+ * Warn if the element doesn't have an explicit key assigned to it.
+ * This element is in an array. The array could grow and shrink or be
+ * reordered. All children that haven't already been validated are required to
+ * have a "key" property assigned to it. Error statuses are cached so a warning
+ * will only be shown once.
+ *
+ * We use a callback for generating the error status since the error status is
+ * composed using different info and dependencies in different places where
+ * 'validateExplicitKey' is called.
+ *
+ * @internal
+ * @param {ReactElement} element Element that requires a key.
+ * @param {ErrorMessageCallbackType} ErrorMessageCallbackType
+ */
+function validateExplicitKey(
+  element: ReactElement,
+  getMainErrorMessage: ErrorMessageCallbackType,
+  getComponentStackMessage: ErrorMessageCallbackType,
+) {
+  if (!element._store || element._store.validated || element.key != null) {
+    return;
+  }
+  element._store.validated = true;
+
+  var memoizer = ownerHasKeyUseWarning.uniqueKey ||
+    (ownerHasKeyUseWarning.uniqueKey = {});
+
+  const mainErrorMessage = getMainErrorMessage(element);
+
+  if (memoizer[mainErrorMessage]) {
+    return;
+  }
+  memoizer[mainErrorMessage] = true;
+
+  warning(
+    false,
+    mainErrorMessage + getComponentStackMessage(element),
+  );
+}
+
+module.exports = validateExplicitKey;

--- a/src/shared/utils/validateExplicitKey.js
+++ b/src/shared/utils/validateExplicitKey.js
@@ -53,8 +53,8 @@ var ownerHasKeyUseWarning = {};
  */
 function validateExplicitKey(
   element: ReactElement,
-  getMainErrorMessage: ErrorMessageCallbackType,
-  getComponentStackMessage: ErrorMessageCallbackType,
+  getErrorMessage: ErrorMessageCallbackType,
+  memoizedPortionOfErrorMessage: string,
 ) {
   if (!element._store || element._store.validated || element.key != null) {
     return;
@@ -64,14 +64,16 @@ function validateExplicitKey(
   var memoizer = ownerHasKeyUseWarning.uniqueKey ||
     (ownerHasKeyUseWarning.uniqueKey = {});
 
-  const mainErrorMessage = getMainErrorMessage(element);
-
-  if (memoizer[mainErrorMessage]) {
+  if (memoizer[memoizedPortionOfErrorMessage]) {
     return;
   }
-  memoizer[mainErrorMessage] = true;
+  memoizer[memoizedPortionOfErrorMessage] = true;
 
-  warning(false, mainErrorMessage + getComponentStackMessage(element));
+  warning(
+    false,
+    'Each child in an array or iterator should have a unique "key" prop.%s',
+    getErrorMessage(element),
+  );
 }
 
 module.exports = validateExplicitKey;


### PR DESCRIPTION
If you return an array with React components that don't have the 'key'
prop set, we now throw this warning:
```
react-dom.development.js:498 Warning: Each child in an array or iterator should have a unique "key" prop.

See https://fb.me/react-warning-keys for more information.
    in ArrayFragmentExample (created by FragmentsExample)
    in div (created by FragmentsExample)
    in FragmentsExample
```

This is an improvement on the approach originally taken in https://github.com/facebook/react/pull/9420
Changes;
 - Not adding a fixture this time
 - Using `getCurrentFiberStackAddendum` instead of trying to use old
   `getCurrentStackAddendum`
 - Leave `ReactCurrentOwner` and `ReactComponentTreeHook` in isomorphic

**Test Plan:**
 - Added test to `ReactChildren-test`
 - Manually tested via fixture that was not committed.