### PR TITLE
Add basic bundle+type filters to Rollup build script

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -46,6 +46,11 @@ const mangleRegex = new RegExp(
   'g'
 );
 
+const filters = {
+  bundle: process.env.npm_config_bundle,
+  bundleType: process.env.npm_config_bundleType,
+};
+
 function getBanner(bundleType, hasteName, filename) {
   switch (bundleType) {
     case FB_DEV:
@@ -305,7 +310,8 @@ function getPlugins(
 }
 
 function createBundle(bundle, bundleType) {
-  const shouldSkipBundleType = bundle.bundleTypes.indexOf(bundleType) === -1;
+  const shouldSkipBundleType = bundle.bundleTypes.indexOf(bundleType) === -1 ||
+    (filters.bundleType && !bundleType.includes(filters.bundleType));
   if (shouldSkipBundleType) {
     return Promise.resolve();
   }
@@ -393,7 +399,12 @@ rimraf('build', () => {
     Packaging.createFacebookWWWBuild,
     Packaging.createReactNativeBuild,
   ];
-  for (const bundle of Bundles.bundles) {
+
+  const bundles = filters.bundle
+    ? Bundles.bundles.filter(bundle => bundle.name.includes(filters.bundle))
+    : Bundles.bundles;
+
+  for (const bundle of bundles) {
     tasks.push(
       () => createBundle(bundle, UMD_DEV),
       () => createBundle(bundle, UMD_PROD),
@@ -412,8 +423,13 @@ rimraf('build', () => {
     .then(() => {
       // output the results
       console.log(Stats.printResults());
+
       // save the results for next run
-      Stats.saveResults();
+      // don't save results if we've only ran part of the build
+      if (!filters.bundle && !filters.bundleType) {
+        Stats.saveResults();
+      }
+
       if (argv.extractErrors) {
         console.warn(
           '\nWarning: this build was created with --extractErrors enabled.\n' +


### PR DESCRIPTION
While working on the new react-dom/test-utils and react-test-renderer/shallow bundles, I frequently found myself wanting to run the build command on only a subset of the bundles. (I just wanted to test some bundle config changes without rebuilding the entire suite.)

This PR adds some basic filters that I think might be useful for others when iterating on the builds. When filters are used- results/size will still be displayed but the `results.json` file will not be updated. (This will prevent someone from accidentally deleting some of the stats locally.)

```bash
# Build everything
npm run build

# Build all react-dom bundles+types (react-dom, react-dom/server, etc)
npm run build --bundle=react-dom

# Build all FB_PROD bundle-types
npm run build --bundleType=FB_PROD

# Build all FB bundle-types (prod and dev)
npm run build --bundleType=FB

# Build FB_PROD version of react-dom/server only
npm run build --bundle=react-dom/server --bundleType=FB_PROD
```