### PR TITLE
Don't build gh-pages branch on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,4 @@
 ---
-general:
-  branches:
-    ignore:
-      - gh-pages
-
 machine:
   timezone: America/Los_Angeles
   node:

--- a/docs/circle.yml
+++ b/docs/circle.yml
@@ -1,0 +1,5 @@
+---
+general:
+  branches:
+    ignore:
+      - gh-pages


### PR DESCRIPTION
Turns out I was incorrect in my initial setup of Circle and if we want to tell Circle not to try to build the `gh-pages` branch we need to do it in that branch. So I just setup a new `circle.yml` here that will get built into that branch when docs get built. I did a quick test to confirm that the file does get built into the branch by running the `build_gh_pages.sh` script (minus the `push` part)

From [the docs](https://circleci.com/docs/1.0/configuration/#branches):
> `circle.yml` is per-branch configuration file, and the branch ignore list in one branch will only affect that branch and no other one.

