### PR TITLE
Only attempt to clear measures if we created the measure

### DIFF
--- a/src/renderers/shared/ReactDebugTool.js
+++ b/src/renderers/shared/ReactDebugTool.js
@@ -305,7 +305,9 @@ if (__DEV__) {
     }
 
     performance.clearMarks(markName);
-    performance.clearMeasures(measurementName);
+    if (measurementName) {
+      performance.clearMeasures(measurementName);
+    }
   };
 
   ReactDebugTool = {


### PR DESCRIPTION
This fixes an issue where if we decided not to create a measurement we would clear ALL measurements from the performance entry buffer due to passing `undefined` as the entry name.

The original bug here means any `performance` entries the user might have in their application will be inadvertently nuked.

For reference see the [performance.clearMeasures spec](https://www.w3.org/TR/user-timing/#dom-performance-clearmeasures).

### Todo

- [ ] Test/s incoming (would love some help in finding where to add such a test!)
