### PR TITLE
FIX: Move CRA build info under it's tab page

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -90,7 +90,7 @@ npm start
 
 Create React App doesn't handle backend logic or databases; it just creates a frontend build pipeline, so you can use it with any backend you want. It uses build tools like Babel and webpack under the hood, but works with zero configuration.
 
-When you're ready to deploy to production, running `npm run build` will create an optimized build of your app in the `build` folder.
+When you're ready to deploy to production, running `npm run build` will create an optimized build of your app in the `build` folder. You can learn more about Create React App [from its README](https://github.com/facebookincubator/create-react-app#create-react-app-) and the [User Guide](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#table-of-contents).
 
 <block class="existingapp" />
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -90,6 +90,8 @@ npm start
 
 Create React App doesn't handle backend logic or databases; it just creates a frontend build pipeline, so you can use it with any backend you want. It uses build tools like Babel and webpack under the hood, but works with zero configuration.
 
+When you're ready to deploy to production, running `npm run build` will create an optimized build of your app in the `build` folder.
+
 <block class="existingapp" />
 
 ## Adding React to an Existing Application
@@ -161,10 +163,6 @@ To create an optimized production build with Brunch, just add the `-p` flag to t
 #### Browserify
 
 Run Browserify with `NODE_ENV` environment variable set to `production` and use [UglifyJS](https://github.com/mishoo/UglifyJS) as the last build step so that development-only code gets stripped out.
-
-#### Create React App
-
-If you use [Create React App](https://github.com/facebookincubator/create-react-app), `npm run build` will create an optimized build of your app in the `build` folder.
 
 #### Rollup
 


### PR DESCRIPTION
After splitting the steps for the installation options into tab pages the build info for Create React App remained under the 'Adding React to an Existing Application' tab page ([here](https://facebook.github.io/react/docs/installation.html#create-react-app)). This PR moves it under the appropriate tab page.
