### PR TITLE
Improve component type check in getComponentKey.

### DIFF
--- a/src/isomorphic/children/traverseAllChildren.js
+++ b/src/isomorphic/children/traverseAllChildren.js
@@ -45,7 +45,9 @@ var didWarnAboutMaps = false;
 function getComponentKey(component, index) {
   // Do some typechecking here since we call this blindly. We want to ensure
   // that we don't block potential future ES APIs.
-  if (typeof component === 'object' && component !== null && component.key != null) {
+  if (
+    typeof component === 'object' && component !== null && component.key != null
+  ) {
     // Explicit key
     return KeyEscapeUtils.escape(component.key);
   }

--- a/src/isomorphic/children/traverseAllChildren.js
+++ b/src/isomorphic/children/traverseAllChildren.js
@@ -45,7 +45,7 @@ var didWarnAboutMaps = false;
 function getComponentKey(component, index) {
   // Do some typechecking here since we call this blindly. We want to ensure
   // that we don't block potential future ES APIs.
-  if (component && typeof component === 'object' && component.key != null) {
+  if (typeof component === 'object' && component !== null && component.key != null) {
     // Explicit key
     return KeyEscapeUtils.escape(component.key);
   }


### PR DESCRIPTION
The sequence
```
component && typeof component === 'object'
```
checks whether component is any JavaScript object except document.all.
Since document.all cannot occur here, this can be replaced with the
usual
```
typeof component === 'object' && component !== null
```
sequence, which yields true for all JavaScript objects and is well
optimized by all JavaScript engines.