### PR TITLE
Updated PropTypes test to work with newer prop-types version

### DIFF
--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -22,6 +22,7 @@ var MyComponent;
 function resetWarningCache() {
   jest.resetModules();
   checkPropTypes = require('prop-types/checkPropTypes');
+  PropTypes = require('ReactPropTypes');
 }
 
 function getPropTypeWarningMessage(propTypes, object, componentName) {
@@ -99,6 +100,7 @@ function expectWarningInDevelopment(declaration, value) {
   var props = {testProp: value};
   var propName = 'testProp' + Math.random().toString();
   var componentName = 'testComponent' + Math.random().toString();
+  resetWarningCache();
   for (var i = 0; i < 3; i++) {
     declaration(props, propName, componentName, 'prop');
   }
@@ -111,7 +113,6 @@ function expectWarningInDevelopment(declaration, value) {
 
 describe('ReactPropTypes', () => {
   beforeEach(() => {
-    PropTypes = require('ReactPropTypes');
     React = require('react');
     ReactDOM = require('react-dom');
     resetWarningCache();


### PR DESCRIPTION
The prop-types lib got an anti-spamming change in 15.5.8 ([e1d51dd](https://github.com/reactjs/prop-types/commit/e1d51dd0efbd0eee5e4a8d24759f2a4d518721d3)) that broke some of our tests. This PR resolves that by resetting the prop-types import between tests.