### PR TITLE
Add link to 'Typechecking with PropTypes' under 'Advanced Guides'

### DIFF
--- a/docs/_data/nav_docs.yml
+++ b/docs/_data/nav_docs.yml
@@ -30,6 +30,8 @@
   items:
     - id: jsx-in-depth
       title: JSX In Depth
+    - id: typechecking-with-proptypes
+      title: Typechecking With PropTypes
     - id: refs-and-the-dom
       title: Refs and the DOM
     - id: uncontrolled-components


### PR DESCRIPTION
This should have been retained in our docs, since PropTypes are only
moved and not deprecated.

Partially handles #9467, and I'll make a separate PR to
https://github.com/reactjs/prop-types to add more docs to the README
there.