### PR TITLE
setState update arrow function syntax

### DIFF
--- a/docs/docs/reference-react-component.md
+++ b/docs/docs/reference-react-component.md
@@ -249,9 +249,9 @@ The first argument is an `updater` function with the signature:
 `prevState` is a reference to the previous state. It should not be directly mutated. Instead, changes should be represented by building a new state object based on the input from `prevState` and `props`. For instance, suppose we wanted to increment a value in state by `props.step`:
 
 ```javascript
-this.setState((prevState, props) => ({
-  counter: prevState.counter + props.step
-}));
+this.setState(function(prevState, props) {
+  return { counter: prevState.counter + props.step }
+});
 ```
 
 Both `prevState` and `props` received by the updater function are guaranteed to be up-to-date.
@@ -284,9 +284,9 @@ Object.assign(
 Subsequent calls will override values from previous calls in the same cycle, so the quantity will only be incremented once. If the next state depends on the previous state, we recommend using the updater function form, instead:
 
 ```js
-this.setState((prevState) => ({
-  counter: prevState.quantity + 1;
-}));
+this.setState(function(prevState) {
+  return { counter: prevState.quantity + 1 }
+});
 ```
 
 For more detail, see the [State and Lifecycle guide](/react/docs/state-and-lifecycle.html).

--- a/docs/docs/reference-react-component.md
+++ b/docs/docs/reference-react-component.md
@@ -249,9 +249,9 @@ The first argument is an `updater` function with the signature:
 `prevState` is a reference to the previous state. It should not be directly mutated. Instead, changes should be represented by building a new state object based on the input from `prevState` and `props`. For instance, suppose we wanted to increment a value in state by `props.step`:
 
 ```javascript
-this.setState((prevState, props) => {
-  return {counter: prevState.counter + props.step};
-});
+this.setState((prevState, props) => ({
+  counter: prevState.counter + props.step
+}));
 ```
 
 Both `prevState` and `props` received by the updater function are guaranteed to be up-to-date.
@@ -284,9 +284,9 @@ Object.assign(
 Subsequent calls will override values from previous calls in the same cycle, so the quantity will only be incremented once. If the next state depends on the previous state, we recommend using the updater function form, instead:
 
 ```js
-this.setState((prevState) => {
-  return {counter: prevState.quantity + 1};
-});
+this.setState((prevState) => ({
+  counter: prevState.quantity + 1;
+}));
 ```
 
 For more detail, see the [State and Lifecycle guide](/react/docs/state-and-lifecycle.html).


### PR DESCRIPTION
updating the docs to remove `return` while using `arrow` functions. Also helps to keep the snippets examples in sync with other docs https://github.com/facebook/react/blob/master/docs/docs/state-and-lifecycle.md#state-updates-may-be-asynchronous
