### PR TITLE
Update declaration of shouldComponentUpdate

### DIFF
--- a/docs/docs/reference-react-component.md
+++ b/docs/docs/reference-react-component.md
@@ -169,7 +169,7 @@ React doesn't call `componentWillReceiveProps` with initial props during [mounti
 ### `shouldComponentUpdate()`
 
 ```javascript
-shouldComponentUpdate(nextProps, nextState)
+shouldComponentUpdate(nextProps, nextState, nextContext)
 ```
 
 Use `shouldComponentUpdate()` to let React know if a component's output is not affected by the current change in state or props. The default behavior is to re-render on every state change, and in the vast majority of cases you should rely on the default behavior.


### PR DESCRIPTION
Am I right in assuming that `shouldComponentUpdate` receives `nextContext` as well?

According to https://github.com/facebook/react/blob/master/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js#L910-L914 it looks like that is the case.