### PR TITLE
Update tests to not warn due to moved PropTypes and shallowRenderer

### DIFF
--- a/scripts/jest/ts-preprocessor.js
+++ b/scripts/jest/ts-preprocessor.js
@@ -28,7 +28,7 @@ function compile(content, contentFilename) {
       // the file path into backslashes on Windows.
       filename = path.normalize(filename);
       var reactRegex = new RegExp(
-        path.join('/', '(?:React|ReactDOM)(?:\.d)?\.ts$')
+        path.join('/', '(?:React|ReactDOM|PropTypes)(?:\.d)?\.ts$')
       );
 
       var jestRegex = /jest\.d\.ts/;

--- a/src/addons/__tests__/renderSubtreeIntoContainer-test.js
+++ b/src/addons/__tests__/renderSubtreeIntoContainer-test.js
@@ -11,6 +11,7 @@
 
 'use strict';
 
+var PropTypes = require('prop-types');
 var React = require('React');
 var ReactDOM = require('ReactDOM');
 var ReactTestUtils = require('ReactTestUtils');
@@ -22,7 +23,7 @@ describe('renderSubtreeIntoContainer', () => {
 
     class Component extends React.Component {
       static contextTypes = {
-        foo: React.PropTypes.string.isRequired,
+        foo: PropTypes.string.isRequired,
       };
 
       render() {
@@ -32,7 +33,7 @@ describe('renderSubtreeIntoContainer', () => {
 
     class Parent extends React.Component {
       static childContextTypes = {
-        foo: React.PropTypes.string.isRequired,
+        foo: PropTypes.string.isRequired,
       };
 
       getChildContext() {
@@ -63,7 +64,7 @@ describe('renderSubtreeIntoContainer', () => {
 
     class Component extends React.Component {
       static contextTypes = {
-        foo: React.PropTypes.string.isRequired,
+        foo: PropTypes.string.isRequired,
       };
 
       render() {
@@ -76,7 +77,7 @@ describe('renderSubtreeIntoContainer', () => {
     // eslint-disable-next-line no-unused-vars
     class Parent extends React.Component {
       static childContextTypes = {
-        foo: React.PropTypes.string.isRequired,
+        foo: PropTypes.string.isRequired,
       };
 
       getChildContext() {
@@ -104,8 +105,8 @@ describe('renderSubtreeIntoContainer', () => {
 
     class Component extends React.Component {
       static contextTypes = {
-        foo: React.PropTypes.string.isRequired,
-        getFoo: React.PropTypes.func.isRequired,
+        foo: PropTypes.string.isRequired,
+        getFoo: PropTypes.func.isRequired,
       };
 
       render() {
@@ -115,8 +116,8 @@ describe('renderSubtreeIntoContainer', () => {
 
     class Parent extends React.Component {
       static childContextTypes = {
-        foo: React.PropTypes.string.isRequired,
-        getFoo: React.PropTypes.func.isRequired,
+        foo: PropTypes.string.isRequired,
+        getFoo: PropTypes.func.isRequired,
       };
 
       state = {
@@ -156,8 +157,8 @@ describe('renderSubtreeIntoContainer', () => {
 
     class Component extends React.Component {
       static contextTypes = {
-        foo: React.PropTypes.string.isRequired,
-        getFoo: React.PropTypes.func.isRequired,
+        foo: PropTypes.string.isRequired,
+        getFoo: PropTypes.func.isRequired,
       };
 
       render() {
@@ -167,8 +168,8 @@ describe('renderSubtreeIntoContainer', () => {
 
     class Parent extends React.Component {
       static childContextTypes = {
-        foo: React.PropTypes.string.isRequired,
-        getFoo: React.PropTypes.func.isRequired,
+        foo: PropTypes.string.isRequired,
+        getFoo: PropTypes.func.isRequired,
       };
 
       getChildContext() {

--- a/src/isomorphic/classic/__tests__/ReactContextValidator-test.js
+++ b/src/isomorphic/classic/__tests__/ReactContextValidator-test.js
@@ -17,6 +17,7 @@
 
 'use strict';
 
+var PropTypes;
 var React;
 var ReactDOM;
 var ReactTestUtils;
@@ -34,6 +35,7 @@ describe('ReactContextValidator', () => {
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactTestUtils = require('ReactTestUtils');
+    PropTypes = require('prop-types');
     reactComponentExpect = require('reactComponentExpect');
   });
 
@@ -47,7 +49,7 @@ describe('ReactContextValidator', () => {
       }
     }
     Component.contextTypes = {
-      foo: React.PropTypes.string,
+      foo: PropTypes.string,
     };
 
     class ComponentInFooBarContext extends React.Component {
@@ -63,8 +65,8 @@ describe('ReactContextValidator', () => {
       }
     }
     ComponentInFooBarContext.childContextTypes = {
-      foo: React.PropTypes.string,
-      bar: React.PropTypes.number,
+      foo: PropTypes.string,
+      bar: PropTypes.number,
     };
 
     var instance = ReactTestUtils.renderIntoDocument(
@@ -94,8 +96,8 @@ describe('ReactContextValidator', () => {
       }
     }
     Parent.childContextTypes = {
-      foo: React.PropTypes.string.isRequired,
-      bar: React.PropTypes.string.isRequired,
+      foo: PropTypes.string.isRequired,
+      bar: PropTypes.string.isRequired,
     };
 
     class Component extends React.Component {
@@ -122,7 +124,7 @@ describe('ReactContextValidator', () => {
       }
     }
     Component.contextTypes = {
-      foo: React.PropTypes.string,
+      foo: PropTypes.string,
     };
 
     var container = document.createElement('div');
@@ -143,7 +145,7 @@ describe('ReactContextValidator', () => {
       }
     }
     Component.contextTypes = {
-      foo: React.PropTypes.string.isRequired,
+      foo: PropTypes.string.isRequired,
     };
 
     ReactTestUtils.renderIntoDocument(<Component />);
@@ -168,7 +170,7 @@ describe('ReactContextValidator', () => {
       }
     }
     ComponentInFooStringContext.childContextTypes = {
-      foo: React.PropTypes.string,
+      foo: PropTypes.string,
     };
 
     ReactTestUtils.renderIntoDocument(
@@ -190,7 +192,7 @@ describe('ReactContextValidator', () => {
       }
     }
     ComponentInFooNumberContext.childContextTypes = {
-      foo: React.PropTypes.number,
+      foo: PropTypes.number,
     };
 
     ReactTestUtils.renderIntoDocument(
@@ -220,8 +222,8 @@ describe('ReactContextValidator', () => {
       }
     }
     Component.childContextTypes = {
-      foo: React.PropTypes.string.isRequired,
-      bar: React.PropTypes.number,
+      foo: PropTypes.string.isRequired,
+      bar: PropTypes.number,
     };
 
     ReactTestUtils.renderIntoDocument(<Component testContext={{bar: 123}} />);

--- a/src/isomorphic/classic/class/__tests__/ReactClass-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactClass-test.js
@@ -14,12 +14,14 @@
 var React;
 var ReactDOM;
 var ReactTestUtils;
+var PropTypes;
 
 describe('ReactClass-spec', () => {
   beforeEach(() => {
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactTestUtils = require('ReactTestUtils');
+    PropTypes = require('prop-types');
   });
 
   it('should warn on first call to React.createClass', () => {
@@ -212,13 +214,13 @@ describe('ReactClass-spec', () => {
     React.createClass({
       mixins: [{}],
       propTypes: {
-        foo: React.PropTypes.string,
+        foo: PropTypes.string,
       },
       contextTypes: {
-        foo: React.PropTypes.string,
+        foo: PropTypes.string,
       },
       childContextTypes: {
-        foo: React.PropTypes.string,
+        foo: PropTypes.string,
       },
       render: function() {
         return <div />;
@@ -292,7 +294,7 @@ describe('ReactClass-spec', () => {
   it('renders based on context getInitialState', () => {
     var Foo = React.createClass({
       contextTypes: {
-        className: React.PropTypes.string,
+        className: PropTypes.string,
       },
       getInitialState() {
         return {className: this.context.className};
@@ -304,7 +306,7 @@ describe('ReactClass-spec', () => {
 
     var Outer = React.createClass({
       childContextTypes: {
-        className: React.PropTypes.string,
+        className: PropTypes.string,
       },
       getChildContext() {
         return {className: 'foo'};

--- a/src/isomorphic/classic/class/__tests__/ReactCreateClass-test.js
+++ b/src/isomorphic/classic/class/__tests__/ReactCreateClass-test.js
@@ -11,6 +11,7 @@
 
 'use strict';
 
+var PropTypes;
 var React;
 var ReactDOM;
 var ReactTestUtils;
@@ -18,6 +19,7 @@ var createReactClass;
 
 describe('ReactClass-spec', () => {
   beforeEach(() => {
+    PropTypes = require('prop-types');
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactTestUtils = require('ReactTestUtils');
@@ -199,13 +201,13 @@ describe('ReactClass-spec', () => {
     createReactClass({
       mixins: [{}],
       propTypes: {
-        foo: React.PropTypes.string,
+        foo: PropTypes.string,
       },
       contextTypes: {
-        foo: React.PropTypes.string,
+        foo: PropTypes.string,
       },
       childContextTypes: {
-        foo: React.PropTypes.string,
+        foo: PropTypes.string,
       },
       render: function() {
         return <div />;
@@ -279,7 +281,7 @@ describe('ReactClass-spec', () => {
   it('renders based on context getInitialState', () => {
     var Foo = createReactClass({
       contextTypes: {
-        className: React.PropTypes.string,
+        className: PropTypes.string,
       },
       getInitialState() {
         return {className: this.context.className};
@@ -291,7 +293,7 @@ describe('ReactClass-spec', () => {
 
     var Outer = createReactClass({
       childContextTypes: {
-        className: React.PropTypes.string,
+        className: PropTypes.string,
       },
       getChildContext() {
         return {className: 'foo'};

--- a/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementClone-test.js
@@ -11,6 +11,7 @@
 
 'use strict';
 
+var PropTypes;
 var React;
 var ReactDOM;
 var ReactTestUtils;
@@ -22,6 +23,7 @@ describe('ReactElementClone', () => {
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactTestUtils = require('ReactTestUtils');
+    PropTypes = require('prop-types');
 
     // NOTE: We're explicitly not using JSX here. This is intended to test
     // classic JS without JSX.
@@ -293,7 +295,7 @@ describe('ReactElementClone', () => {
       }
     }
     Component.propTypes = {
-      color: React.PropTypes.string.isRequired,
+      color: PropTypes.string.isRequired,
     };
     class Parent extends React.Component {
       render() {

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -14,6 +14,7 @@
 // NOTE: We're explicitly not using JSX in this file. This is intended to test
 // classic JS without JSX.
 
+var PropTypes;
 var React;
 var ReactDOM;
 var ReactTestUtils;
@@ -31,6 +32,7 @@ describe('ReactElementValidator', () => {
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactTestUtils = require('ReactTestUtils');
+    PropTypes = require('prop-types');
     ComponentClass = class extends React.Component {
       render() {
         return React.createElement('div');
@@ -250,7 +252,7 @@ describe('ReactElementValidator', () => {
       return React.createElement('div', null, 'My color is ' + props.color);
     }
     MyComp.propTypes = {
-      color: React.PropTypes.string,
+      color: PropTypes.string,
     };
     function ParentComp() {
       return React.createElement(MyComp, {color: 123});
@@ -339,7 +341,7 @@ describe('ReactElementValidator', () => {
         return React.createElement('span', null, this.props.prop);
       }
     }
-    Component.propTypes = {prop: React.PropTypes.string.isRequired};
+    Component.propTypes = {prop: PropTypes.string.isRequired};
     Component.defaultProps = {prop: null};
 
     ReactTestUtils.renderIntoDocument(React.createElement(Component));
@@ -360,7 +362,7 @@ describe('ReactElementValidator', () => {
         return React.createElement('span', null, this.props.prop);
       }
     }
-    Component.propTypes = {prop: React.PropTypes.string.isRequired};
+    Component.propTypes = {prop: PropTypes.string.isRequired};
     Component.defaultProps = {prop: 'text'};
 
     ReactTestUtils.renderIntoDocument(
@@ -384,7 +386,7 @@ describe('ReactElementValidator', () => {
       }
     }
     Component.propTypes = {
-      prop: React.PropTypes.string.isRequired,
+      prop: PropTypes.string.isRequired,
     };
 
     ReactTestUtils.renderIntoDocument(React.createElement(Component));
@@ -424,7 +426,7 @@ describe('ReactElementValidator', () => {
       }
     }
     Component.propTypes = {
-      myProp: React.PropTypes.shape,
+      myProp: PropTypes.shape,
     };
 
     ReactTestUtils.renderIntoDocument(

--- a/src/isomorphic/modern/class/PropTypes.d.ts
+++ b/src/isomorphic/modern/class/PropTypes.d.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/**
+ * TypeScript Definition File for React.
+ *
+ * Full type definitions are not yet officially supported. These are mostly
+ * just helpers for the unit test.
+ */
+
+declare module 'prop-types' {
+  export var string : any;
+}

--- a/src/isomorphic/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/src/isomorphic/modern/class/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -7,6 +7,7 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 ###
 
+PropTypes = null
 React = null
 ReactDOM = null
 
@@ -21,6 +22,7 @@ describe 'ReactCoffeeScriptClass', ->
   beforeEach ->
     React = require 'React'
     ReactDOM = require 'ReactDOM'
+    PropTypes = require 'prop-types'
     container = document.createElement 'div'
     attachedListener = null
     renderedName = null
@@ -102,8 +104,8 @@ describe 'ReactCoffeeScriptClass', ->
   it 'renders based on context in the constructor', ->
     class Foo extends React.Component
       @contextTypes:
-        tag: React.PropTypes.string
-        className: React.PropTypes.string
+        tag: PropTypes.string
+        className: PropTypes.string
 
       constructor: (props, context) ->
         super props, context
@@ -118,8 +120,8 @@ describe 'ReactCoffeeScriptClass', ->
 
     class Outer extends React.Component
       @childContextTypes:
-        tag: React.PropTypes.string
-        className: React.PropTypes.string
+        tag: PropTypes.string
+        className: PropTypes.string
 
       getChildContext: ->
         tag: 'span'
@@ -393,13 +395,13 @@ describe 'ReactCoffeeScriptClass', ->
   it 'supports this.context passed via getChildContext', ->
     class Bar extends React.Component
       @contextTypes:
-        bar: React.PropTypes.string
+        bar: PropTypes.string
       render: ->
         div className: @context.bar
 
     class Foo extends React.Component
       @childContextTypes:
-        bar: React.PropTypes.string
+        bar: PropTypes.string
       getChildContext: ->
         bar: 'bar-through-context'
       render: ->

--- a/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
+++ b/src/isomorphic/modern/class/__tests__/ReactES6Class-test.js
@@ -11,6 +11,7 @@
 
 'use strict';
 
+var PropTypes;
 var React;
 var ReactDOM;
 
@@ -27,6 +28,7 @@ describe('ReactES6Class', () => {
   beforeEach(() => {
     React = require('React');
     ReactDOM = require('ReactDOM');
+    PropTypes = require('prop-types');
     container = document.createElement('div');
     attachedListener = null;
     renderedName = null;
@@ -123,8 +125,8 @@ describe('ReactES6Class', () => {
       }
     }
     Foo.contextTypes = {
-      tag: React.PropTypes.string,
-      className: React.PropTypes.string,
+      tag: PropTypes.string,
+      className: PropTypes.string,
     };
 
     class Outer extends React.Component {
@@ -136,8 +138,8 @@ describe('ReactES6Class', () => {
       }
     }
     Outer.childContextTypes = {
-      tag: React.PropTypes.string,
-      className: React.PropTypes.string,
+      tag: PropTypes.string,
+      className: PropTypes.string,
     };
     test(<Outer />, 'SPAN', 'foo');
   });
@@ -425,7 +427,7 @@ describe('ReactES6Class', () => {
         return <div className={this.context.bar} />;
       }
     }
-    Bar.contextTypes = {bar: React.PropTypes.string};
+    Bar.contextTypes = {bar: PropTypes.string};
     class Foo extends React.Component {
       getChildContext() {
         return {bar: 'bar-through-context'};
@@ -434,7 +436,7 @@ describe('ReactES6Class', () => {
         return <Bar />;
       }
     }
-    Foo.childContextTypes = {bar: React.PropTypes.string};
+    Foo.childContextTypes = {bar: PropTypes.string};
     test(<Foo />, 'DIV', 'bar-through-context');
   });
 

--- a/src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
+++ b/src/isomorphic/modern/class/__tests__/ReactTypeScriptClass-test.ts
@@ -1,3 +1,4 @@
+/// <reference path="../PropTypes.d.ts" />
 /// <reference path="../React.d.ts" />
 /// <reference path="../ReactDOM.d.ts" />
 
@@ -12,6 +13,7 @@
 
 import React = require('React');
 import ReactDOM = require('ReactDOM');
+import PropTypes = require('prop-types');
 
 // Before Each
 
@@ -85,8 +87,8 @@ class StateBasedOnProps extends React.Component {
 // it renders based on context in the constructor
 class StateBasedOnContext extends React.Component {
   static contextTypes = {
-    tag: React.PropTypes.string,
-    className: React.PropTypes.string
+    tag: PropTypes.string,
+    className: PropTypes.string
   };
   state = {
     tag: this.context.tag,
@@ -100,8 +102,8 @@ class StateBasedOnContext extends React.Component {
 
 class ProvideChildContextTypes extends React.Component {
   static childContextTypes = {
-    tag: React.PropTypes.string,
-    className: React.PropTypes.string
+    tag: PropTypes.string,
+    className: PropTypes.string
   };
   getChildContext() {
     return { tag: 'span', className: 'foo' };
@@ -278,13 +280,13 @@ class MisspelledComponent2 extends React.Component {
 
 // it supports this.context passed via getChildContext
 class ReadContext extends React.Component {
-  static contextTypes = { bar: React.PropTypes.string };
+  static contextTypes = { bar: PropTypes.string };
   render() {
     return React.createElement('div', { className: this.context.bar });
   }
 }
 class ProvideContext extends React.Component {
-  static childContextTypes = { bar: React.PropTypes.string };
+  static childContextTypes = { bar: PropTypes.string };
   getChildContext() {
     return { bar: 'bar-through-context' };
   }

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -14,6 +14,7 @@
 // TODO: All these warnings should become static errors using Flow instead
 // of dynamic errors when using JSX with Flow.
 
+var PropTypes;
 var React;
 var ReactDOM;
 var ReactTestUtils;
@@ -32,6 +33,7 @@ describe('ReactJSXElementValidator', () => {
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactTestUtils = require('ReactTestUtils');
+    PropTypes = require('prop-types');
 
     Component = class extends React.Component {
       render() {
@@ -45,7 +47,7 @@ describe('ReactJSXElementValidator', () => {
       }
     };
     RequiredPropComponent.displayName = 'RequiredPropComponent';
-    RequiredPropComponent.propTypes = {prop: React.PropTypes.string.isRequired};
+    RequiredPropComponent.propTypes = {prop: PropTypes.string.isRequired};
   });
 
   it('warns for keys for arrays of elements in children position', () => {
@@ -191,7 +193,7 @@ describe('ReactJSXElementValidator', () => {
       }
     }
     MyComp.propTypes = {
-      color: React.PropTypes.string,
+      color: PropTypes.string,
     };
     class ParentComp extends React.Component {
       render() {
@@ -214,7 +216,7 @@ describe('ReactJSXElementValidator', () => {
       return null;
     }
     MyComp.propTypes = {
-      color: React.PropTypes.string,
+      color: PropTypes.string,
     };
     function MiddleComp(props) {
       return <MyComp color={props.color} />;

--- a/src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.native.js
+++ b/src/renderers/shared/hooks/__tests__/ReactComponentTreeHook-test.native.js
@@ -12,6 +12,7 @@
 'use strict';
 
 describe('ReactComponentTreeHook', () => {
+  var PropTypes;
   var React;
   var ReactNative;
   var ReactInstanceMap;
@@ -25,6 +26,7 @@ describe('ReactComponentTreeHook', () => {
   beforeEach(() => {
     jest.resetModuleRegistry();
 
+    PropTypes = require('prop-types');
     React = require('React');
     ReactNative = require('ReactNative');
     ReactInstanceMap = require('ReactInstanceMap');
@@ -42,7 +44,7 @@ describe('ReactComponentTreeHook', () => {
     });
     Text = class extends React.Component {
       static childContextTypes = {
-        isInAParentText: React.PropTypes.bool,
+        isInAParentText: PropTypes.bool,
       };
 
       getChildContext() {

--- a/src/renderers/shared/stack/reconciler/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/shared/stack/reconciler/__tests__/ReactStatelessComponent-test.js
@@ -11,6 +11,7 @@
 
 'use strict';
 
+var PropTypes;
 var React;
 var ReactDOM;
 var ReactTestUtils;
@@ -24,6 +25,7 @@ describe('ReactStatelessComponent', () => {
     React = require('React');
     ReactDOM = require('ReactDOM');
     ReactTestUtils = require('ReactTestUtils');
+    PropTypes = require('prop-types');
   });
 
   it('should render stateless component', () => {
@@ -61,7 +63,7 @@ describe('ReactStatelessComponent', () => {
   it('should pass context thru stateless component', () => {
     class Child extends React.Component {
       static contextTypes = {
-        test: React.PropTypes.string.isRequired,
+        test: PropTypes.string.isRequired,
       };
 
       render() {
@@ -75,7 +77,7 @@ describe('ReactStatelessComponent', () => {
 
     class GrandParent extends React.Component {
       static childContextTypes = {
-        test: React.PropTypes.string.isRequired,
+        test: PropTypes.string.isRequired,
       };
 
       getChildContext() {
@@ -104,7 +106,7 @@ describe('ReactStatelessComponent', () => {
     }
 
     StatelessComponentWithChildContext.childContextTypes = {
-      foo: React.PropTypes.string,
+      foo: PropTypes.string,
     };
 
     var container = document.createElement('div');
@@ -190,7 +192,7 @@ describe('ReactStatelessComponent', () => {
       return <div>{props.test}</div>;
     }
     Child.defaultProps = {test: 2};
-    Child.propTypes = {test: React.PropTypes.string};
+    Child.propTypes = {test: PropTypes.string};
 
     spyOn(console, 'error');
     ReactTestUtils.renderIntoDocument(<Child />);
@@ -207,7 +209,7 @@ describe('ReactStatelessComponent', () => {
   it('should receive context', () => {
     class Parent extends React.Component {
       static childContextTypes = {
-        lang: React.PropTypes.string,
+        lang: PropTypes.string,
       };
 
       getChildContext() {
@@ -222,7 +224,7 @@ describe('ReactStatelessComponent', () => {
     function Child(props, context) {
       return <div>{context.lang}</div>;
     }
-    Child.contextTypes = {lang: React.PropTypes.string};
+    Child.contextTypes = {lang: PropTypes.string};
 
     var el = document.createElement('div');
     ReactDOM.render(<Parent />, el);

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -525,7 +525,7 @@ describe('ReactTestUtils', () => {
     }
 
     var handler = jasmine.createSpy('spy');
-    var shallowRenderer = ReactTestUtils.createRenderer();
+    var shallowRenderer = new ReactShallowRenderer();
     var result = shallowRenderer.render(
       <SomeComponent handleClick={handler} />,
     );

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -15,6 +15,8 @@ var React;
 var ReactDOM;
 var ReactDOMServer;
 var ReactTestUtils;
+var ReactShallowRenderer;
+var PropTypes;
 
 describe('ReactTestUtils', () => {
   beforeEach(() => {
@@ -22,6 +24,8 @@ describe('ReactTestUtils', () => {
     ReactDOM = require('ReactDOM');
     ReactDOMServer = require('ReactDOMServer');
     ReactTestUtils = require('ReactTestUtils');
+    ReactShallowRenderer = require('ReactShallowRenderer');
+    PropTypes = require('prop-types');
   });
 
   it('should have shallow rendering', () => {
@@ -36,7 +40,7 @@ describe('ReactTestUtils', () => {
       }
     }
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
+    var shallowRenderer = new ReactShallowRenderer();
     var result = shallowRenderer.render(<SomeComponent />);
 
     expect(result.type).toBe('div');
@@ -56,7 +60,7 @@ describe('ReactTestUtils', () => {
       );
     }
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
+    var shallowRenderer = new ReactShallowRenderer();
     var result = shallowRenderer.render(<SomeComponent />);
 
     expect(result.type).toBe('div');
@@ -73,7 +77,7 @@ describe('ReactTestUtils', () => {
       }
     }
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
+    var shallowRenderer = new ReactShallowRenderer();
     expect(() => shallowRenderer.render(SomeComponent)).toThrowError(
       'ReactShallowRenderer render(): Invalid component element. Instead of ' +
         'passing a component class, make sure to instantiate it by passing it ' +
@@ -97,7 +101,7 @@ describe('ReactTestUtils', () => {
       }
     }
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
+    var shallowRenderer = new ReactShallowRenderer();
     shallowRenderer.render(<SomeComponent />);
     shallowRenderer.unmount();
 
@@ -111,7 +115,7 @@ describe('ReactTestUtils', () => {
       }
     }
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
+    var shallowRenderer = new ReactShallowRenderer();
     var result = shallowRenderer.render(<SomeComponent />);
 
     expect(result).toBe(null);
@@ -124,7 +128,7 @@ describe('ReactTestUtils', () => {
       }
     }
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
+    var shallowRenderer = new ReactShallowRenderer();
     // Shouldn't crash.
     shallowRenderer.render(<SomeComponent />);
   });
@@ -157,7 +161,7 @@ describe('ReactTestUtils', () => {
       }
     }
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
+    var shallowRenderer = new ReactShallowRenderer();
     var result = shallowRenderer.render(<SomeComponent />);
     expect(result.type).toBe('div');
     expect(result.props.children).toEqual([
@@ -187,7 +191,7 @@ describe('ReactTestUtils', () => {
       }
     }
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
+    var shallowRenderer = new ReactShallowRenderer();
     shallowRenderer.render(<SimpleComponent n={5} />);
     expect(shallowRenderer.getMountedInstance().someMethod()).toEqual(5);
   });
@@ -195,7 +199,7 @@ describe('ReactTestUtils', () => {
   it('can shallowly render components with contextTypes', () => {
     class SimpleComponent extends React.Component {
       static contextTypes = {
-        name: React.PropTypes.string,
+        name: PropTypes.string,
       };
 
       render() {
@@ -203,7 +207,7 @@ describe('ReactTestUtils', () => {
       }
     }
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
+    var shallowRenderer = new ReactShallowRenderer();
     var result = shallowRenderer.render(<SimpleComponent />);
     expect(result).toEqual(<div />);
   });
@@ -227,7 +231,7 @@ describe('ReactTestUtils', () => {
       }
     }
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
+    var shallowRenderer = new ReactShallowRenderer();
     shallowRenderer.render(<SimpleComponent />);
     var result = shallowRenderer.getRenderOutput();
     expect(result.type).toEqual('div');
@@ -250,7 +254,7 @@ describe('ReactTestUtils', () => {
       }
     }
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
+    var shallowRenderer = new ReactShallowRenderer();
     var result = shallowRenderer.render(<SimpleComponent />);
     expect(result).toEqual(<div>doovy</div>);
   });
@@ -258,7 +262,7 @@ describe('ReactTestUtils', () => {
   it('can pass context when shallowly rendering', () => {
     class SimpleComponent extends React.Component {
       static contextTypes = {
-        name: React.PropTypes.string,
+        name: PropTypes.string,
       };
 
       render() {
@@ -266,7 +270,7 @@ describe('ReactTestUtils', () => {
       }
     }
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
+    var shallowRenderer = new ReactShallowRenderer();
     var result = shallowRenderer.render(<SimpleComponent />, {
       name: 'foo',
     });
@@ -278,7 +282,7 @@ describe('ReactTestUtils', () => {
 
     class SimpleComponent extends React.Component {
       static contextTypes = {
-        name: React.PropTypes.string.isRequired,
+        name: PropTypes.string.isRequired,
       };
 
       render() {
@@ -286,7 +290,7 @@ describe('ReactTestUtils', () => {
       }
     }
 
-    var shallowRenderer = ReactTestUtils.createRenderer();
+    var shallowRenderer = new ReactShallowRenderer();
     shallowRenderer.render(<SimpleComponent />);
     expect(console.error.calls.count()).toBe(1);
     expect(
@@ -522,9 +526,8 @@ describe('ReactTestUtils', () => {
 
     var handler = jasmine.createSpy('spy');
     var shallowRenderer = ReactTestUtils.createRenderer();
-    var result = shallowRenderer.render(
-      <SomeComponent handleClick={handler} />,
-    );
+    var result = shallowRenderer
+      .render(<SomeComponent handleClick={handler} />);
 
     expect(() => ReactTestUtils.Simulate.click(result)).toThrowError(
       'TestUtils.Simulate expects a component instance and not a ReactElement.' +

--- a/src/test/__tests__/ReactTestUtils-test.js
+++ b/src/test/__tests__/ReactTestUtils-test.js
@@ -526,8 +526,9 @@ describe('ReactTestUtils', () => {
 
     var handler = jasmine.createSpy('spy');
     var shallowRenderer = ReactTestUtils.createRenderer();
-    var result = shallowRenderer
-      .render(<SomeComponent handleClick={handler} />);
+    var result = shallowRenderer.render(
+      <SomeComponent handleClick={handler} />,
+    );
 
     expect(() => ReactTestUtils.Simulate.click(result)).toThrowError(
       'TestUtils.Simulate expects a component instance and not a ReactElement.' +


### PR DESCRIPTION
This will unblock continued work on the 15.6-dev branch.

We added some warnings in v15.5 for calling `React.PropTypes` and
calling the shallow renderer from the wrong place. These warnings were
causing test failures, and now they are fixed.

Most of these were for the `React.PropTypes` change.