### PR TITLE
Add missing testcases for warning messages.

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -464,6 +464,7 @@ src/renderers/__tests__/ReactCompositeComponent-test.js
 * should warn when shouldComponentUpdate() returns undefined
 * should warn when componentDidUnmount method is defined
 * should warn when defaultProps was defined as an instance property
+* should warn when propTypes was defined as an instance property
 * should pass context to children when not owner
 * should skip update when rerendering element in container
 * should pass context when re-rendered for static child

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -465,6 +465,7 @@ src/renderers/__tests__/ReactCompositeComponent-test.js
 * should warn when componentDidUnmount method is defined
 * should warn when defaultProps was defined as an instance property
 * should warn when propTypes was defined as an instance property
+* should warn when getInitialState was defined on Component, a plain JavaScript class
 * should pass context to children when not owner
 * should skip update when rerendering element in container
 * should pass context when re-rendered for static child

--- a/src/renderers/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/__tests__/ReactCompositeComponent-test.js
@@ -532,6 +532,31 @@ describe('ReactCompositeComponent', () => {
     );
   });
 
+  it('should warn when getInitialState was defined on Component, a plain JavaScript class', () => {
+    spyOn(console, 'error');
+
+    class Component extends React.Component {
+      getInitialState() {
+        return {
+          name: 'Aryan',
+        };
+      }
+
+      render() {
+        return <div />;
+      }
+    }
+
+    ReactTestUtils.renderIntoDocument(<Component />);
+
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toBe(
+      'Warning: getInitialState was defined on Component, a plain JavaScript class.' +
+        ' This is only supported for classes created using React.createClass.' +
+        ' Did you mean to define a state property instead?',
+    );
+  });
+
   it('should pass context to children when not owner', () => {
     class Parent extends React.Component {
       render() {

--- a/src/renderers/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/__tests__/ReactCompositeComponent-test.js
@@ -509,6 +509,29 @@ describe('ReactCompositeComponent', () => {
     );
   });
 
+  it('should warn when propTypes was defined as an instance property', () => {
+    spyOn(console, 'error');
+
+    class Component extends React.Component {
+      constructor(props) {
+        super(props);
+        this.propTypes = {name: ReactPropTypes.string};
+      }
+
+      render() {
+        return <div />;
+      }
+    }
+
+    ReactTestUtils.renderIntoDocument(<Component />);
+
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toBe(
+      'Warning: propTypes was defined as an instance property ' +
+        'on Component. Use a static property to define propTypes instead.',
+    );
+  });
+
   it('should pass context to children when not owner', () => {
     class Parent extends React.Component {
       render() {

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -814,9 +814,10 @@ describe('ReactDOMComponent', () => {
         spyOn(console, 'error');
 
         let realToString;
+        let object = Object;
         try {
-          realToString = Object.prototype.toString;
-          Object.prototype.toString = function() {
+          realToString = object.prototype.toString;
+          object.prototype.toString = function() {
             // Emulate browser behavior which is missing in jsdom
             if (this instanceof window.HTMLUnknownElement) {
               return '[object HTMLUnknownElement]';
@@ -825,7 +826,7 @@ describe('ReactDOMComponent', () => {
           };
           ReactTestUtils.renderIntoDocument(<mycustomcomponent />);
         } finally {
-          Object.prototype.toString = realToString;
+          object.prototype.toString = realToString;
         }
 
         expectDev(console.error.calls.count()).toBe(1);


### PR DESCRIPTION
- `Object prototype is read only, properties should not be added  no-extend-native` solved warning.
- Added missing testcase for propTypes defined on instance property.
- Added missing testcase for getInitialState defined on plain JavaScript class.

