### PR TITLE
Updates to use JSFiddle referenced in submit Git Issue Template

### DIFF
--- a/docs/contributing/how-to-contribute.md
+++ b/docs/contributing/how-to-contribute.md
@@ -39,7 +39,7 @@ We are using [GitHub Issues](https://github.com/facebook/react/issues) for our p
 
 #### Reporting New Issues
 
-The best way to get your bug fixed is to provide a reduced test case. This [JSFiddle template](https://jsfiddle.net/reactjs/69z2wepo/) is a great starting point.
+The best way to get your bug fixed is to provide a reduced test case. This [JSFiddle template](https://jsfiddle.net/84v837e9/) is a great starting point.
 
 #### Security Bugs
 


### PR DESCRIPTION
@aweary [recently updated the JSFiddle used in the submit Git issue template #9289](https://github.com/facebook/react/pull/9289).
This change updates the JSFiddle in the Reporting New Issues section of how-to-contribute.md to use the new JSFiddle found in the [submit Git issue template](https://github.com/facebook/react/issues/new).