### PR TITLE
Temporarily add stack target to react-test-renderer bundle 

### DIFF
--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -27,6 +27,7 @@
     "README.md",
     "index.js",
     "shallow.js",
+    "stack.js",
     "cjs/"
   ]
 }

--- a/packages/react-test-renderer/stack.js
+++ b/packages/react-test-renderer/stack.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  throw Error('test renderer is not available in production mode.');
+} else {
+  module.exports = require('./cjs/react-test-renderer-stack.development');
+}

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -361,7 +361,7 @@ const bundles = [
   },
   {
     babelOpts: babelOptsReact,
-    bundleTypes: [FB_DEV],
+    bundleTypes: [FB_DEV, NODE_DEV],
     config: {
       destDir: 'build/',
       moduleName: 'ReactTestRenderer',
@@ -374,7 +374,7 @@ const bundles = [
     isRenderer: true,
     label: 'test-stack',
     manglePropertiesOnProd: false,
-    name: 'react-test-renderer-stack',
+    name: 'react-test-renderer/stack',
     paths: [
       'src/renderers/native/**/*.js',
       'src/renderers/shared/**/*.js',

--- a/src/isomorphic/React.js
+++ b/src/isomorphic/React.js
@@ -100,7 +100,7 @@ if (__DEV__) {
     return mixin;
   };
 
-  // TODO (bvaughn) Remove both of these deprecation warnings before 16.0.0
+  // TODO (bvaughn) Remove all of these accessors before 16.0.0
   if (canDefineProperty) {
     Object.defineProperty(React, 'checkPropTypes', {
       get() {
@@ -113,7 +113,7 @@ if (__DEV__) {
             '(https://fb.me/migrating-from-react-proptypes)',
         );
         warnedForCheckPropTypes = true;
-        return ReactPropTypes;
+        return checkPropTypes;
       },
     });
 


### PR DESCRIPTION
This will enable a React-to-ReactNative sync that is currently blocked by a stack-compatible-only test renderer forked from PR #7516 that's used in fbsource. Once the changes proposed in #7516 have been made to test renderer this target can be removed from the bundle (and the forked renderer can be deleted as well).

This PR also fixes a typo in the temporary `checkPropTypes` accessor that that had been added to the `React` object previously.