### PR TITLE
Prevent process polyfill to be included in builds because of process …

### DIFF
--- a/src/isomorphic/children/flattenChildren.js
+++ b/src/isomorphic/children/flattenChildren.js
@@ -15,21 +15,7 @@
 var KeyEscapeUtils = require('KeyEscapeUtils');
 var traverseAllChildren = require('traverseAllChildren');
 var warning = require('fbjs/lib/warning');
-
-var ReactComponentTreeHook;
-
-if (
-  typeof process !== 'undefined' &&
-  process.env &&
-  process.env.NODE_ENV === 'test'
-) {
-  // Temporary hack.
-  // Inline requires don't work well with Jest:
-  // https://github.com/facebook/react/issues/7240
-  // Remove the inline requires when we don't need them anymore:
-  // https://github.com/facebook/react/pull/7178
-  ReactComponentTreeHook = require('ReactComponentTreeHook');
-}
+var ReactComponentTreeHook = require('ReactComponentTreeHook');
 
 /**
  * @param {function} traverseContext Context passed through traversal.
@@ -48,9 +34,6 @@ function flattenSingleChildIntoContext(
     const result = traverseContext;
     const keyUnique = result[name] === undefined;
     if (__DEV__) {
-      if (!ReactComponentTreeHook) {
-        ReactComponentTreeHook = require('ReactComponentTreeHook');
-      }
       if (!keyUnique) {
         warning(
           false,


### PR DESCRIPTION
Related - https://github.com/reactjs/redux/issues/2244

By guarding `process` like this its polyfill is included by default when bundled with webpack. It should be highly desirable to avoid such side effect. 

I understand that this PR is not complete, but as your build setup is way more complex than what is used in most projects I would need some guidelines how this should be proceeded further. Maybe introducing `__TEST__` in similar manner how u introduce `__DEV__`?

Also this should land in `15.x` branch too and aint sure how this should be tackled here.

cc @gaearon 

Also maybe that could have been tackled on webpack's side as most of the people dont realise this is a problem and guarding against `process` seems like a right way to do things in the code. Dunno if we can safely predict what was the user intention though. cc @TheLarkInn @sokra