### PR TITLE
Rename react-dom to ReactDOM in Facebook www

### DIFF
--- a/scripts/rollup/modules.js
+++ b/scripts/rollup/modules.js
@@ -165,6 +165,7 @@ function getExternalModules(externals, bundleType, isRenderer) {
       externalModules.push('ReactCurrentOwner');
       if (isRenderer) {
         externalModules.push('React');
+        externalModules.push('ReactDOM');
       }
       break;
   }
@@ -211,6 +212,7 @@ function replaceFbjsModuleAliases(bundleType) {
       // we will either allow both variants or migrate to lowercase.
       return {
         "'react'": "'React'",
+        "'react-dom'": "'ReactDOM'",
       };
     default:
       return {};


### PR DESCRIPTION
Test plan:

1. `yarn build -- test --type=FB`
2. Confirm `ReactTestUtils-dev.js` requires `ReactDOM` instead of `react-dom`