### PR TITLE
Use prop-types instead of prop-types factory

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -212,11 +212,11 @@ src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
 * should not warn for valid values
 * should be implicitly optional and not warn without values
 * should warn for missing required values
-* should warn if called manually in development
+* should throw if called manually in development
 * should should accept any value
 * should be implicitly optional and not warn without values
 * should warn for missing required values
-* should warn if called manually in development
+* should throw if called manually in development
 * should fail for invalid argument
 * should support the arrayOf propTypes
 * should support arrayOf with complex types
@@ -226,19 +226,19 @@ src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
 * should not warn when passing an empty array
 * should be implicitly optional and not warn without values
 * should warn for missing required values
-* should warn if called manually in development
+* should throw if called manually in development
 * should support components
 * should not support multiple components or scalar values
 * should be able to define a single child as label
 * should warn when passing no label and isRequired is set
 * should be implicitly optional and not warn without values
 * should warn for missing required values
-* should warn if called manually in development
+* should throw if called manually in development
 * should warn for invalid instances
 * should not warn for valid values
 * should be implicitly optional and not warn without values
 * should warn for missing required values
-* should warn if called manually in development
+* should throw if called manually in development
 * should warn for invalid values
 * should not warn for valid values
 * should not warn for iterables
@@ -246,7 +246,7 @@ src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
 * should not warn for null/undefined if not required
 * should warn for missing required values
 * should accept empty array for required props
-* should warn if called manually in development
+* should throw if called manually in development
 * should fail for invalid argument
 * should support the objectOf propTypes
 * should support objectOf with complex types
@@ -256,19 +256,19 @@ src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
 * should not warn when passing an empty object
 * should be implicitly optional and not warn without values
 * should warn for missing required values
-* should warn if called manually in development
+* should throw if called manually in development
 * should warn but not error for invalid argument
 * should warn for invalid values
 * should not warn for valid values
 * should be implicitly optional and not warn without values
 * should warn for missing required values
-* should warn if called manually in development
+* should throw if called manually in development
 * should warn but not error for invalid argument
 * should warn if none of the types are valid
 * should not warn if one of the types are valid
 * should be implicitly optional and not warn without values
 * should warn for missing required values
-* should warn if called manually in development
+* should throw if called manually in development
 * should warn for non objects
 * should not warn for empty values
 * should not warn for an empty object
@@ -279,7 +279,7 @@ src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
 * should warn for invalid key types
 * should be implicitly optional and not warn without values
 * should warn for missing required values
-* should warn if called manually in development
+* should throw if called manually in development
 * should warn for non-symbol
 * should not warn for a polyfilled Symbol
 * should have been called with the right params

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -49,7 +49,6 @@ const bundles = [
       'create-react-class/factory',
       'prop-types',
       'prop-types/checkPropTypes',
-      'prop-types/factory',
     ],
     fbEntry: 'src/fb/ReactFBEntry.js',
     hasteName: 'React',

--- a/scripts/rollup/modules.js
+++ b/scripts/rollup/modules.js
@@ -57,7 +57,6 @@ const legacyModules = [
   'create-react-class/factory',
   'prop-types',
   'prop-types/checkPropTypes',
-  'prop-types/factory',
 ];
 
 // this function builds up a very niave Haste-like moduleMap

--- a/src/isomorphic/classic/types/ReactPropTypes.js
+++ b/src/isomorphic/classic/types/ReactPropTypes.js
@@ -11,7 +11,4 @@
 
 'use strict';
 
-var {isValidElement} = require('ReactElement');
-var factory = require('prop-types/factory');
-
-module.exports = factory(isValidElement);
+module.exports = require('prop-types');

--- a/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
+++ b/src/isomorphic/classic/types/__tests__/ReactPropTypes-test.js
@@ -96,17 +96,18 @@ function typeCheckPass(declaration, value) {
   expect(message).toBe(null);
 }
 
-function expectWarningInDevelopment(declaration, value) {
+function expectThrowInDevelopment(declaration, value) {
   var props = {testProp: value};
   var propName = 'testProp' + Math.random().toString();
   var componentName = 'testComponent' + Math.random().toString();
-  resetWarningCache();
-  for (var i = 0; i < 3; i++) {
+  var message;
+  try {
     declaration(props, propName, componentName, 'prop');
+  } catch (e) {
+    message = e.message;
   }
-  expect(console.error.calls.count()).toBe(1);
-  expect(console.error.calls.argsFor(0)[0]).toContain(
-    'You are manually calling a React.PropTypes validation ',
+  expect(message).toContain(
+    'Calling PropTypes validators directly is not supported',
   );
   console.error.calls.reset();
 }
@@ -228,50 +229,50 @@ describe('ReactPropTypes', () => {
       typeCheckFailRequiredValues(PropTypes.string.isRequired);
     });
 
-    it('should warn if called manually in development', () => {
+    it('should throw if called manually in development', () => {
       spyOn(console, 'error');
-      expectWarningInDevelopment(PropTypes.array, /please/);
-      expectWarningInDevelopment(PropTypes.array, []);
-      expectWarningInDevelopment(PropTypes.array.isRequired, /please/);
-      expectWarningInDevelopment(PropTypes.array.isRequired, []);
-      expectWarningInDevelopment(PropTypes.array.isRequired, null);
-      expectWarningInDevelopment(PropTypes.array.isRequired, undefined);
-      expectWarningInDevelopment(PropTypes.bool, []);
-      expectWarningInDevelopment(PropTypes.bool, true);
-      expectWarningInDevelopment(PropTypes.bool.isRequired, []);
-      expectWarningInDevelopment(PropTypes.bool.isRequired, true);
-      expectWarningInDevelopment(PropTypes.bool.isRequired, null);
-      expectWarningInDevelopment(PropTypes.bool.isRequired, undefined);
-      expectWarningInDevelopment(PropTypes.func, false);
-      expectWarningInDevelopment(PropTypes.func, function() {});
-      expectWarningInDevelopment(PropTypes.func.isRequired, false);
-      expectWarningInDevelopment(PropTypes.func.isRequired, function() {});
-      expectWarningInDevelopment(PropTypes.func.isRequired, null);
-      expectWarningInDevelopment(PropTypes.func.isRequired, undefined);
-      expectWarningInDevelopment(PropTypes.number, function() {});
-      expectWarningInDevelopment(PropTypes.number, 42);
-      expectWarningInDevelopment(PropTypes.number.isRequired, function() {});
-      expectWarningInDevelopment(PropTypes.number.isRequired, 42);
-      expectWarningInDevelopment(PropTypes.number.isRequired, null);
-      expectWarningInDevelopment(PropTypes.number.isRequired, undefined);
-      expectWarningInDevelopment(PropTypes.string, 0);
-      expectWarningInDevelopment(PropTypes.string, 'foo');
-      expectWarningInDevelopment(PropTypes.string.isRequired, 0);
-      expectWarningInDevelopment(PropTypes.string.isRequired, 'foo');
-      expectWarningInDevelopment(PropTypes.string.isRequired, null);
-      expectWarningInDevelopment(PropTypes.string.isRequired, undefined);
-      expectWarningInDevelopment(PropTypes.symbol, 0);
-      expectWarningInDevelopment(PropTypes.symbol, Symbol('Foo'));
-      expectWarningInDevelopment(PropTypes.symbol.isRequired, 0);
-      expectWarningInDevelopment(PropTypes.symbol.isRequired, Symbol('Foo'));
-      expectWarningInDevelopment(PropTypes.symbol.isRequired, null);
-      expectWarningInDevelopment(PropTypes.symbol.isRequired, undefined);
-      expectWarningInDevelopment(PropTypes.object, '');
-      expectWarningInDevelopment(PropTypes.object, {foo: 'bar'});
-      expectWarningInDevelopment(PropTypes.object.isRequired, '');
-      expectWarningInDevelopment(PropTypes.object.isRequired, {foo: 'bar'});
-      expectWarningInDevelopment(PropTypes.object.isRequired, null);
-      expectWarningInDevelopment(PropTypes.object.isRequired, undefined);
+      expectThrowInDevelopment(PropTypes.array, /please/);
+      expectThrowInDevelopment(PropTypes.array, []);
+      expectThrowInDevelopment(PropTypes.array.isRequired, /please/);
+      expectThrowInDevelopment(PropTypes.array.isRequired, []);
+      expectThrowInDevelopment(PropTypes.array.isRequired, null);
+      expectThrowInDevelopment(PropTypes.array.isRequired, undefined);
+      expectThrowInDevelopment(PropTypes.bool, []);
+      expectThrowInDevelopment(PropTypes.bool, true);
+      expectThrowInDevelopment(PropTypes.bool.isRequired, []);
+      expectThrowInDevelopment(PropTypes.bool.isRequired, true);
+      expectThrowInDevelopment(PropTypes.bool.isRequired, null);
+      expectThrowInDevelopment(PropTypes.bool.isRequired, undefined);
+      expectThrowInDevelopment(PropTypes.func, false);
+      expectThrowInDevelopment(PropTypes.func, function() {});
+      expectThrowInDevelopment(PropTypes.func.isRequired, false);
+      expectThrowInDevelopment(PropTypes.func.isRequired, function() {});
+      expectThrowInDevelopment(PropTypes.func.isRequired, null);
+      expectThrowInDevelopment(PropTypes.func.isRequired, undefined);
+      expectThrowInDevelopment(PropTypes.number, function() {});
+      expectThrowInDevelopment(PropTypes.number, 42);
+      expectThrowInDevelopment(PropTypes.number.isRequired, function() {});
+      expectThrowInDevelopment(PropTypes.number.isRequired, 42);
+      expectThrowInDevelopment(PropTypes.number.isRequired, null);
+      expectThrowInDevelopment(PropTypes.number.isRequired, undefined);
+      expectThrowInDevelopment(PropTypes.string, 0);
+      expectThrowInDevelopment(PropTypes.string, 'foo');
+      expectThrowInDevelopment(PropTypes.string.isRequired, 0);
+      expectThrowInDevelopment(PropTypes.string.isRequired, 'foo');
+      expectThrowInDevelopment(PropTypes.string.isRequired, null);
+      expectThrowInDevelopment(PropTypes.string.isRequired, undefined);
+      expectThrowInDevelopment(PropTypes.symbol, 0);
+      expectThrowInDevelopment(PropTypes.symbol, Symbol('Foo'));
+      expectThrowInDevelopment(PropTypes.symbol.isRequired, 0);
+      expectThrowInDevelopment(PropTypes.symbol.isRequired, Symbol('Foo'));
+      expectThrowInDevelopment(PropTypes.symbol.isRequired, null);
+      expectThrowInDevelopment(PropTypes.symbol.isRequired, undefined);
+      expectThrowInDevelopment(PropTypes.object, '');
+      expectThrowInDevelopment(PropTypes.object, {foo: 'bar'});
+      expectThrowInDevelopment(PropTypes.object.isRequired, '');
+      expectThrowInDevelopment(PropTypes.object.isRequired, {foo: 'bar'});
+      expectThrowInDevelopment(PropTypes.object.isRequired, null);
+      expectThrowInDevelopment(PropTypes.object.isRequired, undefined);
     });
   });
 
@@ -292,11 +293,11 @@ describe('ReactPropTypes', () => {
       typeCheckFailRequiredValues(PropTypes.any.isRequired);
     });
 
-    it('should warn if called manually in development', () => {
+    it('should throw if called manually in development', () => {
       spyOn(console, 'error');
-      expectWarningInDevelopment(PropTypes.any, null);
-      expectWarningInDevelopment(PropTypes.any.isRequired, null);
-      expectWarningInDevelopment(PropTypes.any.isRequired, undefined);
+      expectThrowInDevelopment(PropTypes.any, null);
+      expectThrowInDevelopment(PropTypes.any.isRequired, null);
+      expectThrowInDevelopment(PropTypes.any.isRequired, undefined);
     });
   });
 
@@ -388,25 +389,25 @@ describe('ReactPropTypes', () => {
       );
     });
 
-    it('should warn if called manually in development', () => {
+    it('should throw if called manually in development', () => {
       spyOn(console, 'error');
-      expectWarningInDevelopment(PropTypes.arrayOf({foo: PropTypes.string}), {
+      expectThrowInDevelopment(PropTypes.arrayOf({foo: PropTypes.string}), {
         foo: 'bar',
       });
-      expectWarningInDevelopment(PropTypes.arrayOf(PropTypes.number), [
+      expectThrowInDevelopment(PropTypes.arrayOf(PropTypes.number), [
         1,
         2,
         'b',
       ]);
-      expectWarningInDevelopment(PropTypes.arrayOf(PropTypes.number), {
+      expectThrowInDevelopment(PropTypes.arrayOf(PropTypes.number), {
         '0': 'maybe-array',
         length: 1,
       });
-      expectWarningInDevelopment(
+      expectThrowInDevelopment(
         PropTypes.arrayOf(PropTypes.number).isRequired,
         null,
       );
-      expectWarningInDevelopment(
+      expectThrowInDevelopment(
         PropTypes.arrayOf(PropTypes.number).isRequired,
         undefined,
       );
@@ -484,15 +485,15 @@ describe('ReactPropTypes', () => {
       typeCheckFailRequiredValues(PropTypes.element.isRequired);
     });
 
-    it('should warn if called manually in development', () => {
+    it('should throw if called manually in development', () => {
       spyOn(console, 'error');
-      expectWarningInDevelopment(PropTypes.element, [<div />, <div />]);
-      expectWarningInDevelopment(PropTypes.element, <div />);
-      expectWarningInDevelopment(PropTypes.element, 123);
-      expectWarningInDevelopment(PropTypes.element, 'foo');
-      expectWarningInDevelopment(PropTypes.element, false);
-      expectWarningInDevelopment(PropTypes.element.isRequired, null);
-      expectWarningInDevelopment(PropTypes.element.isRequired, undefined);
+      expectThrowInDevelopment(PropTypes.element, [<div />, <div />]);
+      expectThrowInDevelopment(PropTypes.element, <div />);
+      expectThrowInDevelopment(PropTypes.element, 123);
+      expectThrowInDevelopment(PropTypes.element, 'foo');
+      expectThrowInDevelopment(PropTypes.element, false);
+      expectThrowInDevelopment(PropTypes.element.isRequired, null);
+      expectThrowInDevelopment(PropTypes.element.isRequired, undefined);
     });
   });
 
@@ -583,12 +584,12 @@ describe('ReactPropTypes', () => {
       typeCheckFailRequiredValues(PropTypes.instanceOf(String).isRequired);
     });
 
-    it('should warn if called manually in development', () => {
+    it('should throw if called manually in development', () => {
       spyOn(console, 'error');
-      expectWarningInDevelopment(PropTypes.instanceOf(Date), {});
-      expectWarningInDevelopment(PropTypes.instanceOf(Date), new Date());
-      expectWarningInDevelopment(PropTypes.instanceOf(Date).isRequired, {});
-      expectWarningInDevelopment(
+      expectThrowInDevelopment(PropTypes.instanceOf(Date), {});
+      expectThrowInDevelopment(PropTypes.instanceOf(Date), new Date());
+      expectThrowInDevelopment(PropTypes.instanceOf(Date).isRequired, {});
+      expectThrowInDevelopment(
         PropTypes.instanceOf(Date).isRequired,
         new Date(),
       );
@@ -680,13 +681,13 @@ describe('ReactPropTypes', () => {
       typeCheckPass(PropTypes.node.isRequired, []);
     });
 
-    it('should warn if called manually in development', () => {
+    it('should throw if called manually in development', () => {
       spyOn(console, 'error');
-      expectWarningInDevelopment(PropTypes.node, 'node');
-      expectWarningInDevelopment(PropTypes.node, {});
-      expectWarningInDevelopment(PropTypes.node.isRequired, 'node');
-      expectWarningInDevelopment(PropTypes.node.isRequired, undefined);
-      expectWarningInDevelopment(PropTypes.node.isRequired, undefined);
+      expectThrowInDevelopment(PropTypes.node, 'node');
+      expectThrowInDevelopment(PropTypes.node, {});
+      expectThrowInDevelopment(PropTypes.node.isRequired, 'node');
+      expectThrowInDevelopment(PropTypes.node.isRequired, undefined);
+      expectThrowInDevelopment(PropTypes.node.isRequired, undefined);
     });
   });
 
@@ -795,22 +796,19 @@ describe('ReactPropTypes', () => {
       );
     });
 
-    it('should warn if called manually in development', () => {
+    it('should throw if called manually in development', () => {
       spyOn(console, 'error');
-      expectWarningInDevelopment(PropTypes.objectOf({foo: PropTypes.string}), {
+      expectThrowInDevelopment(PropTypes.objectOf({foo: PropTypes.string}), {
         foo: 'bar',
       });
-      expectWarningInDevelopment(PropTypes.objectOf(PropTypes.number), {
+      expectThrowInDevelopment(PropTypes.objectOf(PropTypes.number), {
         a: 1,
         b: 2,
         c: 'b',
       });
-      expectWarningInDevelopment(PropTypes.objectOf(PropTypes.number), [1, 2]);
-      expectWarningInDevelopment(PropTypes.objectOf(PropTypes.number), null);
-      expectWarningInDevelopment(
-        PropTypes.objectOf(PropTypes.number),
-        undefined,
-      );
+      expectThrowInDevelopment(PropTypes.objectOf(PropTypes.number), [1, 2]);
+      expectThrowInDevelopment(PropTypes.objectOf(PropTypes.number), null);
+      expectThrowInDevelopment(PropTypes.objectOf(PropTypes.number), undefined);
     });
   });
 
@@ -870,11 +868,11 @@ describe('ReactPropTypes', () => {
       typeCheckFailRequiredValues(PropTypes.oneOf(['red', 'blue']).isRequired);
     });
 
-    it('should warn if called manually in development', () => {
+    it('should throw if called manually in development', () => {
       spyOn(console, 'error');
-      expectWarningInDevelopment(PropTypes.oneOf(['red', 'blue']), true);
-      expectWarningInDevelopment(PropTypes.oneOf(['red', 'blue']), null);
-      expectWarningInDevelopment(PropTypes.oneOf(['red', 'blue']), undefined);
+      expectThrowInDevelopment(PropTypes.oneOf(['red', 'blue']), true);
+      expectThrowInDevelopment(PropTypes.oneOf(['red', 'blue']), null);
+      expectThrowInDevelopment(PropTypes.oneOf(['red', 'blue']), undefined);
     });
   });
 
@@ -941,17 +939,17 @@ describe('ReactPropTypes', () => {
       );
     });
 
-    it('should warn if called manually in development', () => {
+    it('should throw if called manually in development', () => {
       spyOn(console, 'error');
-      expectWarningInDevelopment(
+      expectThrowInDevelopment(
         PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         [],
       );
-      expectWarningInDevelopment(
+      expectThrowInDevelopment(
         PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         null,
       );
-      expectWarningInDevelopment(
+      expectThrowInDevelopment(
         PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         undefined,
       );
@@ -1039,21 +1037,21 @@ describe('ReactPropTypes', () => {
       );
     });
 
-    it('should warn if called manually in development', () => {
+    it('should throw if called manually in development', () => {
       spyOn(console, 'error');
-      expectWarningInDevelopment(PropTypes.shape({}), 'some string');
-      expectWarningInDevelopment(PropTypes.shape({foo: PropTypes.number}), {
+      expectThrowInDevelopment(PropTypes.shape({}), 'some string');
+      expectThrowInDevelopment(PropTypes.shape({foo: PropTypes.number}), {
         foo: 42,
       });
-      expectWarningInDevelopment(
+      expectThrowInDevelopment(
         PropTypes.shape({key: PropTypes.number}).isRequired,
         null,
       );
-      expectWarningInDevelopment(
+      expectThrowInDevelopment(
         PropTypes.shape({key: PropTypes.number}).isRequired,
         undefined,
       );
-      expectWarningInDevelopment(PropTypes.element, <div />);
+      expectThrowInDevelopment(PropTypes.element, <div />);
     });
   });
 


### PR DESCRIPTION
Latest versions of prop-types don't depend on React, so the factory is not necessary, and in fact bloats the build because it is intended for 15.5 and so doesn't strip out the checkers in prod.