### PR TITLE
adds indirect refs to docs

### DIFF
--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -175,7 +175,9 @@ In the above example, `this.inputElement` in `Parent` will be set to the DOM nod
 
 Note that the name of the `inputRef` prop in the above example has no special meaning, as it is a regular component prop. However, using the `ref` attribute on the `<input>` itself is important, as it tells React to attach a ref to its DOM node.
 
-One benefit of this pattern is that it works several components deep. For example, let's say `Parent` didn't need that DOM node, but a component that rendered `Parent` (let's call it `Grandparent`) needed access to it. Then we could let the `Grandparent` specify the `inputRef` prop to the `Parent`, and let `Parent` "forward" it to the `Child`, just like we can do with any other prop:
+Also note how this works even though `CustomTextInput` is a functional component. Unlike the special `ref` attribute which can only be specified for DOM elements and for class components, there are no restrictions on regular component props like `inputRef`.
+
+Another benefit of this pattern is that it works several components deep. For example, let's say `Parent` didn't need that DOM node, but a component that rendered `Parent` (let's call it `Grandparent`) needed access to it. Then we could let the `Grandparent` specify the `inputRef` prop to the `Parent`, and let `Parent` "forward" it to the `Child`, just like we can do with any other prop:
 
 ```javascript{4,12,22}
 function CustomTextInput(props) {
@@ -189,7 +191,7 @@ function CustomTextInput(props) {
 function Parent(props) {
   return (
     <div>
-      My input: <CustomTextInput ref={this.props.inputRef} />
+      My input: <CustomTextInput inputRef={this.props.inputRef} />
     </div>
   );
 }

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -141,6 +141,32 @@ function CustomTextInput(props) {
 }
 ```
 
+### Indirect refs
+
+With cooperation from the child component, you can attach refs to elements without making assumptions about the html structure of the child. This works on both class and function components.
+
+```javascript{4,13}
+function CustomTextInput(props) {
+  return (
+    <div>
+      <input ref={props.inputRef} />
+    </div>
+  );
+}
+
+class Parent extends React.Component {
+  render() {
+    return (
+      <CustomTextInput
+        inputRef={el => this.inputElement = el}
+      />
+    );
+  }
+}
+```
+
+In this case, `this.inputElement` will be the HTMLInputElement DOM node.
+
 ### Don't Overuse Refs
 
 Your first inclination may be to use refs to "make things happen" in your app. If this is the case, take a moment and think more critically about where state should be owned in the component hierarchy. Often, it becomes clear that the proper place to "own" that state is at a higher level in the hierarchy. See the [Lifting State Up](/react/docs/lifting-state-up.html) guide for examples of this.

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -195,7 +195,7 @@ function CustomTextInput(props) {
 function Parent(props) {
   return (
     <div>
-      My input: <CustomTextInput inputRef={this.props.inputRef} />
+      My input: <CustomTextInput inputRef={props.inputRef} />
     </div>
   );
 }

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -149,9 +149,9 @@ function CustomTextInput(props) {
 
 In rare cases, you might want to have access to a child's DOM node from a parent component. This is generally not recommended because it breaks component encapsulation, but it can occasionally be useful for triggering focus or measuring the size or position of a child DOM node.
 
-While you could [add a ref to to the child component](#adding-a-ref-to-a-class-component), this is not an ideal solution, as you'd only get a component instance rather than a DOM node. Additionally, this wouldn't work with functional components.
+While you could [add a ref to to the child component](#adding-a-ref-to-a-class-component), this is not an ideal solution, as you would only get a component instance rather than a DOM node. Additionally, this wouldn't work with functional components.
 
-Instead, one common pattern for this is to expose a special prop on the child. The child would take a prop with an arbitrary name (e.g. `inputRef`) and would attach it to the DOM node as a `ref` attribute. This way the parent is able to pass its own ref callback to the child's DOM node, as long as the child explicitly provides such a prop.
+Instead, in such cases we recommend to expose a special prop on the child. The child would take a function prop with an arbitrary name (e.g. `inputRef`) and would attach it to the DOM node as a `ref` attribute. This way the parent is able to pass its own ref callback to the child's DOM node.
 
 This works both for classes and for functional components.
 
@@ -175,13 +175,13 @@ class Parent extends React.Component {
 }
 ```
 
-In the above example, `this.inputElement` in `Parent` will be set to the DOM node corresponding to the `<input>` element in the `Child`. This works because the `Parent` passes its ref callback as an `inputRef` prop to the `Child`, and the `Child` passes it as a special `ref` attribute to the `<input>`.
+In the example above, `Parent` passes its ref callback as an `inputRef` prop to the `CustomTextInput`, and the `CustomTextInput` passes the same function as a special `ref` attribute to the `<input>`. As a result, `this.inputElement` in `Parent` will be set to the DOM node corresponding to the `<input>` element in the `CustomTextInput`.
 
 Note that the name of the `inputRef` prop in the above example has no special meaning, as it is a regular component prop. However, using the `ref` attribute on the `<input>` itself is important, as it tells React to attach a ref to its DOM node.
 
-Also note how this works even though `CustomTextInput` is a functional component. Unlike the special `ref` attribute which can only be specified for DOM elements and for class components, there are no restrictions on regular component props like `inputRef`.
+This works even though `CustomTextInput` is a functional component. Unlike the special `ref` attribute which can [only be specified for DOM elements and for class components](#refs-and-functional-components), there are no restrictions on regular component props like `inputRef`.
 
-Another benefit of this pattern is that it works several components deep. For example, let's say `Parent` didn't need that DOM node, but a component that rendered `Parent` (let's call it `Grandparent`) needed access to it. Then we could let the `Grandparent` specify the `inputRef` prop to the `Parent`, and let `Parent` "forward" it to the `Child`, just like we can do with any other prop:
+Another benefit of this pattern is that it works several components deep. For example, imagine `Parent` didn't need that DOM node, but a component that rendered `Parent` (let's call it `Grandparent`) needed access to it. Then we could let the `Grandparent` specify the `inputRef` prop to the `Parent`, and let `Parent` "forward" it to the `CustomTextInput`:
 
 ```javascript{4,12,22}
 function CustomTextInput(props) {
@@ -212,7 +212,7 @@ class Grandparent extends React.Component {
 }
 ```
 
-In the above example, `this.inputElement` in `Grandparent` will be set to the DOM node corresponding to the `<input>` element in the `Child`.
+The ref callback is specified by `Grandparent`, passed to `Parent` as a regular prop called `inputRef`, and the `Parent` passes it to the `CustomTextInput` as a prop too. Finally, the `CustomTextInput` reads the `inputRef` prop and attaches the passed function as a `ref` attribute to the `<input>`. As a result, `this.inputElement` in `Grandparent` will be set to the DOM node corresponding to the `<input>` element in the `CustomTextInput`.
 
 All things considered, we advise against exposing DOM nodes whenever possible, but this can be a useful escape hatch. Also keep in mind that following this approach requires that you to add a prop to the child component. If you have absolutely no control over the child component, your last option is to use [`findDOMNode()`](/react/docs/react-dom.html#finddomnode), but it is discouraged.
 

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -214,7 +214,7 @@ class Grandparent extends React.Component {
 
 Here, the ref callback is first specified by `Grandparent`. It is passed to the `Parent` as a regular prop called `inputRef`, and the `Parent` passes it to the `CustomTextInput` as a prop too. Finally, the `CustomTextInput` reads the `inputRef` prop and attaches the passed function as a `ref` attribute to the `<input>`. As a result, `this.inputElement` in `Grandparent` will be set to the DOM node corresponding to the `<input>` element in the `CustomTextInput`.
 
-All things considered, we advise against exposing DOM nodes whenever possible, but this can be a useful escape hatch. Also note that following this approach requires that you to add a prop to the child component. If you have absolutely no control over the child component, your last option is to use [`findDOMNode()`](/react/docs/react-dom.html#finddomnode), but it is discouraged.
+All things considered, we advise against exposing DOM nodes whenever possible, but this can be a useful escape hatch. Note that this approach requires you to add some code to the child component. If you have absolutely no control over the child component implementation, your last option is to use [`findDOMNode()`](/react/docs/react-dom.html#finddomnode), but it is discouraged.
 
 ### Legacy API: String Refs
 

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -212,7 +212,7 @@ class Grandparent extends React.Component {
 }
 ```
 
-The ref callback is specified by `Grandparent`, passed to `Parent` as a regular prop called `inputRef`, and the `Parent` passes it to the `CustomTextInput` as a prop too. Finally, the `CustomTextInput` reads the `inputRef` prop and attaches the passed function as a `ref` attribute to the `<input>`. As a result, `this.inputElement` in `Grandparent` will be set to the DOM node corresponding to the `<input>` element in the `CustomTextInput`.
+Here, the ref callback is first specified by `Grandparent`. It is passed to `Parent` as a regular prop called `inputRef`, and the `Parent` passes it to the `CustomTextInput` as a prop too. Finally, the `CustomTextInput` reads the `inputRef` prop and attaches the passed function as a `ref` attribute to the `<input>`. As a result, `this.inputElement` in `Grandparent` will be set to the DOM node corresponding to the `<input>` element in the `CustomTextInput`.
 
 All things considered, we advise against exposing DOM nodes whenever possible, but this can be a useful escape hatch. Also keep in mind that following this approach requires that you to add a prop to the child component. If you have absolutely no control over the child component, your last option is to use [`findDOMNode()`](/react/docs/react-dom.html#finddomnode), but it is discouraged.
 

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -145,7 +145,7 @@ function CustomTextInput(props) {
 
 In rare cases, you might want to have access to a child's DOM node from a parent component. This is generally not recommended because it breaks component encapsulation, but it can occasionally be useful for triggering focus or measuring the size or position of a child DOM node.
 
-Just using the `ref` attribute on the custom component wouldn't work for this, as you'd get a component instance (for a class component), and you can't put a `ref` on a functional component at all.
+Using the `ref` attribute on a custom component is not ideal for this, as you'd only get a component instance rather than a DOM node. Additionally, this wouldn't work with functional components at all because they have no instances.
 
 Instead, one common pattern for this is to expose a special prop on the child. The child would take a prop with an arbitrary name (e.g. `inputRef`) and would attach it to the DOM node as a `ref` attribute. This way the parent is able to pass its own ref callback to the child's DOM node, as long as the child explicitly provides such a prop.
 

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -151,7 +151,7 @@ In rare cases, you might want to have access to a child's DOM node from a parent
 
 While you could [add a ref to to the child component](#adding-a-ref-to-a-class-component), this is not an ideal solution, as you would only get a component instance rather than a DOM node. Additionally, this wouldn't work with functional components.
 
-Instead, in such cases we recommend to expose a special prop on the child. The child would take a function prop with an arbitrary name (e.g. `inputRef`) and would attach it to the DOM node as a `ref` attribute. This way the parent is able to pass its own ref callback to the child's DOM node.
+Instead, in such cases we recommend exposing a special prop on the child. The child would take a function prop with an arbitrary name (e.g. `inputRef`) and attach it to the DOM node as a `ref` attribute. This lets the parent pass its ref callback to the child's DOM node through the component in the middle.
 
 This works both for classes and for functional components.
 

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -145,7 +145,7 @@ function CustomTextInput(props) {
 
 In rare cases, you might want to have access to a child's DOM node from a parent component. This is generally not recommended because it breaks component encapsulation, but it can occasionally be useful for triggering focus or measuring the size or position of a child DOM node.
 
-Using the `ref` attribute on a custom component is not ideal for this, as you'd only get a component instance rather than a DOM node. Additionally, this wouldn't work with functional components at all because they have no instances.
+While you could [add a ref to to the child component](#adding-a-ref-to-a-class-component), this is not an ideal solution, as you'd only get a component instance rather than a DOM node. Additionally, this wouldn't work with functional components.
 
 Instead, one common pattern for this is to expose a special prop on the child. The child would take a prop with an arbitrary name (e.g. `inputRef`) and would attach it to the DOM node as a `ref` attribute. This way the parent is able to pass its own ref callback to the child's DOM node, as long as the child explicitly provides such a prop.
 

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -141,9 +141,13 @@ function CustomTextInput(props) {
 }
 ```
 
-### Indirect refs
+### Exposing DOM Refs to Parent Components
 
-With cooperation from the child component, you can attach refs to elements without making assumptions about the html structure of the child. This works on both class and function components.
+In rare cases, you might want to have access to a child's DOM node from a parent component. This is generally not recommended because it breaks component encapsulation, but it can occasionally be useful for triggering focus or measuring the size or position of a child DOM node.
+
+One common pattern for this is to expose a special prop on the child. The child would take a prop with an arbitrary name (e.g. `inputRef`) and would attach it to the DOM node as a `ref` attribute. This way the parent is able to pass its own ref callback to the child's DOM node, as long as the child explicitly provides such a prop.
+
+This works both for classes and for functional components.
 
 ```javascript{4,13}
 function CustomTextInput(props) {
@@ -165,7 +169,42 @@ class Parent extends React.Component {
 }
 ```
 
-In this case, `this.inputElement` will be the HTMLInputElement DOM node.
+In the above example, `this.inputElement` in `Parent` will be set to the DOM node corresponding to the `<input>` element in the `Child`.
+
+One benefit of this pattern is that it works several components deep. For example, let's say `Parent` didn't need that DOM node, but a component that rendered `Parent` (let's call it `Grandparent`) needed access to it. Then we could let the `Grandparent` specify the `inputRef` prop to the `Parent`, and let `Parent` "forward" it to the `Child`, just like we can do with any other prop:
+
+```javascript{4,12,22}
+function CustomTextInput(props) {
+  return (
+    <div>
+      <input ref={props.inputRef} />
+    </div>
+  );
+}
+
+function Parent(props) {
+  return (
+    <div>
+      My input: <CustomTextInput ref={this.props.inputRef} />
+    </div>
+  );
+}
+
+
+class Grandparent extends React.Component {
+  render() {
+    return (
+      <Parent
+        inputRef={el => this.inputElement = el}
+      />
+    );
+  }
+}
+```
+
+In the above example, `this.inputElement` in `Grandparent` will be set to the DOM node corresponding to the `<input>` element in the `Child`.
+
+Still, we advise against exposing DOM nodes whenever possible.
 
 ### Don't Overuse Refs
 

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -145,7 +145,9 @@ function CustomTextInput(props) {
 
 In rare cases, you might want to have access to a child's DOM node from a parent component. This is generally not recommended because it breaks component encapsulation, but it can occasionally be useful for triggering focus or measuring the size or position of a child DOM node.
 
-One common pattern for this is to expose a special prop on the child. The child would take a prop with an arbitrary name (e.g. `inputRef`) and would attach it to the DOM node as a `ref` attribute. This way the parent is able to pass its own ref callback to the child's DOM node, as long as the child explicitly provides such a prop.
+Just using the `ref` attribute on the custom component wouldn't work for this, as you'd get a component instance (for a class component), and you can't put a `ref` on a functional component at all.
+
+Instead, one common pattern for this is to expose a special prop on the child. The child would take a prop with an arbitrary name (e.g. `inputRef`) and would attach it to the DOM node as a `ref` attribute. This way the parent is able to pass its own ref callback to the child's DOM node, as long as the child explicitly provides such a prop.
 
 This works both for classes and for functional components.
 
@@ -169,7 +171,7 @@ class Parent extends React.Component {
 }
 ```
 
-In the above example, `this.inputElement` in `Parent` will be set to the DOM node corresponding to the `<input>` element in the `Child`.
+In the above example, `this.inputElement` in `Parent` will be set to the DOM node corresponding to the `<input>` element in the `Child`. Note that the name of the `inputRef` prop in the above example has no special meaning, as it is a regular component prop. However, using the `ref` attribute on the `<input>` itself is important, as it tells React to attach a ref to its DOM node.
 
 One benefit of this pattern is that it works several components deep. For example, let's say `Parent` didn't need that DOM node, but a component that rendered `Parent` (let's call it `Grandparent`) needed access to it. Then we could let the `Grandparent` specify the `inputRef` prop to the `Parent`, and let `Parent` "forward" it to the `Child`, just like we can do with any other prop:
 

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -212,7 +212,7 @@ class Grandparent extends React.Component {
 }
 ```
 
-Here, the ref callback is first specified by `Grandparent`. It is passed to `Parent` as a regular prop called `inputRef`, and the `Parent` passes it to the `CustomTextInput` as a prop too. Finally, the `CustomTextInput` reads the `inputRef` prop and attaches the passed function as a `ref` attribute to the `<input>`. As a result, `this.inputElement` in `Grandparent` will be set to the DOM node corresponding to the `<input>` element in the `CustomTextInput`.
+Here, the ref callback is first specified by `Grandparent`. It is passed to the `Parent` as a regular prop called `inputRef`, and the `Parent` passes it to the `CustomTextInput` as a prop too. Finally, the `CustomTextInput` reads the `inputRef` prop and attaches the passed function as a `ref` attribute to the `<input>`. As a result, `this.inputElement` in `Grandparent` will be set to the DOM node corresponding to the `<input>` element in the `CustomTextInput`.
 
 All things considered, we advise against exposing DOM nodes whenever possible, but this can be a useful escape hatch. Also keep in mind that following this approach requires that you to add a prop to the child component. If you have absolutely no control over the child component, your last option is to use [`findDOMNode()`](/react/docs/react-dom.html#finddomnode), but it is discouraged.
 

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -25,6 +25,10 @@ Avoid using refs for anything that can be done declaratively.
 
 For example, instead of exposing `open()` and `close()` methods on a `Dialog` component, pass an `isOpen` prop to it.
 
+### Don't Overuse Refs
+
+Your first inclination may be to use refs to "make things happen" in your app. If this is the case, take a moment and think more critically about where state should be owned in the component hierarchy. Often, it becomes clear that the proper place to "own" that state is at a higher level in the hierarchy. See the [Lifting State Up](/react/docs/lifting-state-up.html) guide for examples of this.
+
 ### Adding a Ref to a DOM Element
 
 React supports a special attribute that you can attach to any component. The `ref` attribute takes a callback function, and the callback will be executed immediately after the component is mounted or unmounted.
@@ -210,11 +214,7 @@ class Grandparent extends React.Component {
 
 In the above example, `this.inputElement` in `Grandparent` will be set to the DOM node corresponding to the `<input>` element in the `Child`.
 
-Still, we advise against exposing DOM nodes whenever possible.
-
-### Don't Overuse Refs
-
-Your first inclination may be to use refs to "make things happen" in your app. If this is the case, take a moment and think more critically about where state should be owned in the component hierarchy. Often, it becomes clear that the proper place to "own" that state is at a higher level in the hierarchy. See the [Lifting State Up](/react/docs/lifting-state-up.html) guide for examples of this.
+All things considered, we advise against exposing DOM nodes whenever possible, but this can be a useful escape hatch. Also keep in mind that following this approach requires that you to add a prop to the child component. If you have absolutely no control over the child component, your last option is to use [`findDOMNode()`](/react/docs/react-dom.html#finddomnode), but it is discouraged.
 
 ### Legacy API: String Refs
 

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -214,7 +214,7 @@ class Grandparent extends React.Component {
 
 Here, the ref callback is first specified by `Grandparent`. It is passed to the `Parent` as a regular prop called `inputRef`, and the `Parent` passes it to the `CustomTextInput` as a prop too. Finally, the `CustomTextInput` reads the `inputRef` prop and attaches the passed function as a `ref` attribute to the `<input>`. As a result, `this.inputElement` in `Grandparent` will be set to the DOM node corresponding to the `<input>` element in the `CustomTextInput`.
 
-All things considered, we advise against exposing DOM nodes whenever possible, but this can be a useful escape hatch. Also keep in mind that following this approach requires that you to add a prop to the child component. If you have absolutely no control over the child component, your last option is to use [`findDOMNode()`](/react/docs/react-dom.html#finddomnode), but it is discouraged.
+All things considered, we advise against exposing DOM nodes whenever possible, but this can be a useful escape hatch. Also note that following this approach requires that you to add a prop to the child component. If you have absolutely no control over the child component, your last option is to use [`findDOMNode()`](/react/docs/react-dom.html#finddomnode), but it is discouraged.
 
 ### Legacy API: String Refs
 

--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -171,7 +171,9 @@ class Parent extends React.Component {
 }
 ```
 
-In the above example, `this.inputElement` in `Parent` will be set to the DOM node corresponding to the `<input>` element in the `Child`. Note that the name of the `inputRef` prop in the above example has no special meaning, as it is a regular component prop. However, using the `ref` attribute on the `<input>` itself is important, as it tells React to attach a ref to its DOM node.
+In the above example, `this.inputElement` in `Parent` will be set to the DOM node corresponding to the `<input>` element in the `Child`. This works because the `Parent` passes its ref callback as an `inputRef` prop to the `Child`, and the `Child` passes it as a special `ref` attribute to the `<input>`.
+
+Note that the name of the `inputRef` prop in the above example has no special meaning, as it is a regular component prop. However, using the `ref` attribute on the `<input>` itself is important, as it tells React to attach a ref to its DOM node.
 
 One benefit of this pattern is that it works several components deep. For example, let's say `Parent` didn't need that DOM node, but a component that rendered `Parent` (let's call it `Grandparent`) needed access to it. Then we could let the `Grandparent` specify the `inputRef` prop to the `Parent`, and let `Parent` "forward" it to the `Child`, just like we can do with any other prop:
 


### PR DESCRIPTION
If I remember, I originally picked this trick up from @gaearon and it goes a long way towards not making assumptions about child components. I think it's worth a mention here.

---

![indirect refs docs page](https://cloud.githubusercontent.com/assets/936069/25420169/93ee028a-2a0b-11e7-91f2-b54d4fd7d6d8.png)
