### PR TITLE
Add 'Unreleased' section to changelog; update 'contributing' docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## [Unreleased]
+<details>
+ <summary>Changes that have landed in master but are not yet released.</summary>
+  Nothing yet! TODO: backfill this section.
+</details>
 
 ## 15.5.0 (April 7, 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [Unreleased]
+
 ## 15.5.0 (April 7, 2017)
 
 ### React

--- a/docs/contributing/how-to-contribute.md
+++ b/docs/contributing/how-to-contribute.md
@@ -79,6 +79,7 @@ The core team is monitoring for pull requests. We will review your pull request 
 1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
 2. If you've added code that should be tested, add tests!
 3. If you've changed APIs, update the documentation.
+4. If you have made any significant change then please [add an update to the "Unreleased" section of the change log](https://github.com/facebook/react/blob/master/CHANGELOG.md#unreleased). You may skip this step if you made documentation or dependency updates.
 4. Ensure the test suite passes (`npm test`).
 5. Make sure your code lints (`npm run lint`).
 6. Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).

--- a/docs/contributing/how-to-contribute.md
+++ b/docs/contributing/how-to-contribute.md
@@ -80,12 +80,12 @@ The core team is monitoring for pull requests. We will review your pull request 
 2. If you've added code that should be tested, add tests!
 3. If you've changed APIs, update the documentation.
 4. If you have made any significant change then please [add an update to the "Unreleased" section of the change log](https://github.com/facebook/react/blob/master/CHANGELOG.md#unreleased). You may skip this step if you made documentation or dependency updates.
-4. Ensure the test suite passes (`npm test`).
-5. Make sure your code lints (`npm run lint`).
-6. Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
-7. Run the [Flow](https://flowtype.org/) typechecks (`npm run flow`).
-8. If you added or removed any tests, run `./scripts/fiber/record-tests` before submitting the pull request, and commit the resulting changes.
-9. If you haven't already, complete the CLA.
+5. Ensure the test suite passes (`npm test`).
+6. Make sure your code lints (`npm run lint`).
+7. Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
+8. Run the [Flow](https://flowtype.org/) typechecks (`npm run flow`).
+9. If you added or removed any tests, run `./scripts/fiber/record-tests` before submitting the pull request, and commit the resulting changes.
+10. If you haven't already, complete the CLA.
 
 ### Contributor License Agreement (CLA)
 


### PR DESCRIPTION
**what is the change?:**
- Add 'Unreleased' section to `CHANGELOG`
- Add step to 'contributing' about updating the `CHANGELOG`

**why make this change?:**

Whoever does the release of a new React version must manually read
through the recent git history and write the CHANGELOG update.

If we incrementally add to the CHANGELOG under the 'Unreleased' header,
as we make PRs, then to release a new version will just be updating
'Unreleased' to be the new version number and adding a blank section for
'Unreleased'.

See http://keepachangelog.com/en/0.3.0/ for more info about this idea.

**test plan:**
Visual verification of the change, and also I built the website locally
and inspected the change.
![screen shot 2017-04-26 at 7 57 07 am](https://cloud.githubusercontent.com/assets/1114467/25441082/1ef41410-2a56-11e7-82cb-9430630f9590.png)

**issue:**
https://github.com/facebook/react/issues/9527