### PR TITLE
Fix unnecessary ReactDOM require

### DIFF
--- a/scripts/rollup/modules.js
+++ b/scripts/rollup/modules.js
@@ -164,7 +164,9 @@ function getExternalModules(externals, bundleType, isRenderer) {
       externalModules.push('ReactCurrentOwner');
       if (isRenderer) {
         externalModules.push('React');
-        externalModules.push('ReactDOM');
+        if (externalModules.includes('react-dom')) {
+          externalModules.push('ReactDOM');
+        }
       }
       break;
   }


### PR DESCRIPTION
Apparently, when you mark something as external in Rollup, a require statement is inserted even if the module isn't used. This is causing ReactDOM and several other modules to be inserted unnecessarily.

We need a better fix for this, but I'm pushing this quick fix for now since it's blocking sync to www.

@gaearon @trueadm Would you mind taking a look?