### PR TITLE
pre format only compile time errors

### DIFF
--- a/docs/_js/live_editor.js
+++ b/docs/_js/live_editor.js
@@ -219,9 +219,9 @@ var ReactPlayground = React.createClass({
         eval(compiledCode);
       }
     } catch (err) {
+      // Babel errors are preformatted, runtime errors are not.
       const errorMessage = err._babel ?
-        <pre style={{overflowX: 'auto'}} className="playgroundError">{err.toString()}</pre>
-        :
+        <pre style={{overflowX: 'auto'}} className="playgroundError">{err.toString()}</pre> :
         <div className="playgroundError">{err.toString()}</div>;
       this.setTimeout(function() {
         ReactDOM.render(

--- a/docs/_js/live_editor.js
+++ b/docs/_js/live_editor.js
@@ -219,9 +219,13 @@ var ReactPlayground = React.createClass({
         eval(compiledCode);
       }
     } catch (err) {
+      const errorMessage = err._babel ?
+        <pre style={{overflowX: 'auto'}} className="playgroundError">{err.toString()}</pre>
+        :
+        <div className="playgroundError">{err.toString()}</div>;
       this.setTimeout(function() {
         ReactDOM.render(
-          <pre style={{overflowX: 'auto'}} className="playgroundError">{err.toString()}</pre>,
+          errorMessage,
           mountNode
         );
       }, 500);


### PR DESCRIPTION
This fixes the behavior changed by #9497 for #9479. 

Now it renders only the compile time error messages in `<pre>`  and runtime messages as before in a div which wraps text.

Compile error:
![compile_error](https://cloud.githubusercontent.com/assets/450559/25466720/e818bff4-2b27-11e7-9cd7-1826270031b6.png)

Runtime error:
![runtime](https://cloud.githubusercontent.com/assets/450559/25466724/ee60d5b8-2b27-11e7-8c00-569951fff373.png)



