### PR TITLE
Improve docs for select multiple

### DIFF
--- a/docs/docs/forms.md
+++ b/docs/docs/forms.md
@@ -184,7 +184,11 @@ Overall, this makes it so that `<input type="text">`, `<textarea>`, and `<select
 
 > Note
 >
-> You can pass an array into the `value` attribute, allowing you to select multiple options in a `select` tag: `<select multiple={true} value={['B', 'C']}>`.
+> You can pass an array into the `value` attribute, allowing you to select multiple options in a `select` tag:
+>
+>```js
+><select multiple={true} value={['B', 'C']}>
+>```
 
 ## Handling Multiple Inputs
 

--- a/docs/docs/forms.md
+++ b/docs/docs/forms.md
@@ -182,6 +182,10 @@ class FlavorForm extends React.Component {
 
 Overall, this makes it so that `<input type="text">`, `<textarea>`, and `<select>` all work very similarly - they all accept a `value` attribute that you can use to implement a controlled component.
 
+> Note
+>
+> You can pass an array into the `value` attribute, allowing you to select multiple options in a `select` tag: `<select multiple={true} value={['B', 'C']}>`.
+
 ## Handling Multiple Inputs
 
 When you need to handle multiple controlled `input` elements, you can add a `name` attribute to each element and let the handler function choose what to do based on the value of `event.target.name`.


### PR DESCRIPTION
This PR addresses issue #1700 

Currently it only re-adds the original note.

However, I'd like to discuss adding a new section, maybe called "Selecting Multiple Values", with a full example similar to the current `<select>` flavor example. This example would instead involve selecting multiple values by appending or removing values from the array in the `value` property of the `<select>` tag when the user clicks an `<option>` tag. Would this be preferable to the single block-quote style note from the old docs?