### PR TITLE
Add 'unreleased' incremental change log for v15.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@
 ## 15.5.4 (April 11, 2017)
 
 ### React Addons
-* **Critical Bugfix:** Update the version of `prop-types` to fix critical bug.  ([@gaearon](https://github.com/gaearon) in [#545c87f](https://github.com/facebook/react/commit/545c87fdc348f82eb0c3830bef715ed180785390))
+* **Critical Bugfix:** Update the version of `prop-types` to fix critical bug.  ([@gaearon](https://github.com/gaearon) in [545c87f](https://github.com/facebook/react/commit/545c87fdc348f82eb0c3830bef715ed180785390))
 
 ### React Test Renderer
-* Fix compatibility with Enzyme by exposing `batchedUpdates` on shallow renderer. ([@gaearon](https://github.com/gaearon) in [#9382](https://github.com/facebook/react/commit/69933e25c37cf5453a9ef132177241203ee8d2fd))
+* Fix compatibility with Enzyme by exposing `batchedUpdates` on shallow renderer. ([@gaearon](https://github.com/gaearon) in [9382](https://github.com/facebook/react/commit/69933e25c37cf5453a9ef132177241203ee8d2fd))
 
 
 ## 15.5.3 (April 7, 2017)
@@ -40,7 +40,7 @@
 **Note: this release has a critical issue and was deprecated. Please update to 15.5.4 or higher.**
 
 ### React
-* Fix erroneous PropTypes access warning. ([@acdlite](https://github.com/acdlite) in ([#ec97ebb](https://github.com/facebook/react/commit/ec97ebbe7f15b58ae2f1323df39d06f119873344))
+* Fix erroneous PropTypes access warning. ([@acdlite](https://github.com/acdlite) in ([ec97ebb](https://github.com/facebook/react/commit/ec97ebbe7f15b58ae2f1323df39d06f119873344))
 
 ## 15.5.0 (April 7, 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### React
 
-* Fix bug where performance entries were being cleared.  ([@chrisui](https://github.com/chrisui) in [9451](https://github.com/facebook/react/pull/9451))
-* Stop adding 'px' to numbers passed for CSS Grid attributes.  ([@ericsakmar](https://github.com/ericsakmar) in [9185](https://github.com/facebook/react/pull/9185))
-* Deprecate `React.createMixin`. ([@aweary](https://github.com/aweary) in [#8853](https://github.com/facebook/react/pull/8853))
+* Fix bug where performance entries were being cleared.  ([@chrisui](https://github.com/chrisui) in [#9451](https://github.com/facebook/react/pull/9451))
+* Stop adding 'px' to numbers passed for unitless CSS Grid attributes.  ([@ericsakmar](https://github.com/ericsakmar) in [#9185](https://github.com/facebook/react/pull/9185))
+* Deprecate `React.createMixin` helper, which was never used. ([@aweary](https://github.com/aweary) in [#8853](https://github.com/facebook/react/pull/8853))
 
 </details>
 
@@ -40,15 +40,15 @@
 **Note: this release has a critical issue and was deprecated. Please update to 15.5.4 or higher.**
 
 ### React
-* Fix erroneous PropTypes access warning. ([@acdlite](https://github.com/acdlite) in ([ec97ebb](https://github.com/facebook/react/commit/ec97ebbe7f15b58ae2f1323df39d06f119873344))
+* Fix erroneous PropTypes access warning. ([@acdlite](https://github.com/acdlite) in ([#ec97ebb](https://github.com/facebook/react/commit/ec97ebbe7f15b58ae2f1323df39d06f119873344))
 
 ## 15.5.0 (April 7, 2017)
 
 **Note: this release has a critical issue and was deprecated. Please update to 15.5.4 or higher.**
 
 ### React
-* Added a deprecation warning for `React.createClass`. Points users to create-react-class instead. ([@acdlite](https://github.com/acdlite) in [d9a4fa4](https://github.com/facebook/react/commit/d9a4fa4f51c6da895e1655f32255cf72c0fe620e))
-* Added a deprecation warning for `React.PropTypes`. Points users to prop-types instead. ([@acdlite](https://github.com/acdlite) in [043845c](https://github.com/facebook/react/commit/043845ce75ea0812286bbbd9d34994bb7e01eb28))
+* Added a deprecation warning for `React.createClass`. Points users to create-react-class instead. ([@acdlite](https://github.com/acdlite) in [#d9a4fa4](https://github.com/facebook/react/commit/d9a4fa4f51c6da895e1655f32255cf72c0fe620e))
+* Added a deprecation warning for `React.PropTypes`. Points users to prop-types instead. ([@acdlite](https://github.com/acdlite) in [#043845c](https://github.com/facebook/react/commit/043845ce75ea0812286bbbd9d34994bb7e01eb28))
 * Fixed an issue when using `ReactDOM` together with `ReactDOMServer`. ([@wacii](https://github.com/wacii) in [#9005](https://github.com/facebook/react/pull/9005))
 * Fixed issue with Closure Compiler. ([@anmonteiro](https://github.com/anmonteiro) in [#8895](https://github.com/facebook/react/pull/8895))
 * Another fix for Closure Compiler. ([@Shastel](https://github.com/Shastel) in [#8882](https://github.com/facebook/react/pull/8882))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 15.6.0 [Unreleased]
+<details>
+ <summary>Changed we plan to include in the 15.6.0 release.</summary>
+
+### React
+
+* Fix bug where performance entries were being cleared.  ([@chrisui](https://github.com/chrisui) in [9451](https://github.com/facebook/react/pull/9451))
+* Stop adding 'px' to numbers passed for CSS Grid attributes.  ([@ericsakmar](https://github.com/ericsakmar) in [9185](https://github.com/facebook/react/pull/9185))
+* Deprecate `React.createMixin`. ([@aweary](https://github.com/aweary) in [#8853](https://github.com/facebook/react/pull/8853))
+
+</details>
+
 ## 15.5.4 (April 11, 2017)
 
 ### React Addons


### PR DESCRIPTION
**what is the change?:**
Adding a section to the change log where we start accumulating
annotations for React v15.6.0.

**why make this change?:**
- Saves us the trouble of writing the change log entry all at once when
  we do the release.
- Adds transparency about what is in the upcoming release, for those who
  aren't following https://github.com/facebook/react/issues/9398

**test plan:**
Visual inspection

**issue:**
https://github.com/facebook/react/issues/9398