### PR TITLE
RFC: Remove build time extractErrors message when error codes can't be found

### DIFF
--- a/scripts/error-codes/__tests__/dev-expression-with-codes-test.js
+++ b/scripts/error-codes/__tests__/dev-expression-with-codes-test.js
@@ -115,28 +115,4 @@ ${expectedInvariantTransformResult}`
         `_prodInvariant('18', 'Foo', 'Bar') : void 0;`
     );
   });
-
-  it('should warn in non-test envs if the error message cannot be found', () => {
-    spyOn(console, 'warn');
-    transform("invariant(condition, 'a %s b', 'c');");
-
-    expect(console.warn.calls.count()).toBe(1);
-    expect(console.warn.calls.argsFor(0)[0]).toBe(
-      'Error message "a %s b" ' +
-        'cannot be found. The current React version ' +
-        'and the error map are probably out of sync. ' +
-        'Please run `yarn build -- --extractErrors` to build React with the error map in sync.'
-    );
-  });
-
-  it('should not warn in test env if the error message cannot be found', () => {
-    process.env.NODE_ENV = 'test';
-
-    spyOn(console, 'warn');
-    transform("invariant(condition, 'a %s b', 'c');");
-
-    expect(console.warn.calls.count()).toBe(0);
-
-    process.env.NODE_ENV = '';
-  });
 });

--- a/scripts/error-codes/dev-expression-with-codes.js
+++ b/scripts/error-codes/dev-expression-with-codes.js
@@ -117,16 +117,6 @@ module.exports = function(babel) {
             if (prodErrorId === undefined) {
               // The error cannot be found in the map.
               node[SEEN_SYMBOL] = true;
-              if (process.env.NODE_ENV !== 'test') {
-                console.warn(
-                  'Error message "' +
-                    errorMsgLiteral +
-                    '" cannot be found. The current React version ' +
-                    'and the error map are probably out of sync. ' +
-                    'Please run `yarn build -- --extractErrors` to ' +
-                    'build React with the error map in sync.'
-                );
-              }
               return;
             }
 

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -28,8 +28,6 @@ scripts/error-codes/__tests__/dev-expression-with-codes-test.js
 * should only add `reactProdInvariant` once
 * should support invariant calls with args
 * should support invariant calls with a concatenated template string and args
-* should warn in non-test envs if the error message cannot be found
-* should not warn in test env if the error message cannot be found
 
 scripts/error-codes/__tests__/invertObject-test.js
 * should return an empty object for an empty input


### PR DESCRIPTION
Per https://github.com/facebook/react/pull/9548#issuecomment-297949223 -- just removing these errors since they're noisy. The extract errors process is documented as part of releases, and we don't extract errors between releases.