### PR TITLE
Improve wording for code conventions

### DIFF
--- a/docs/contributing/how-to-contribute.md
+++ b/docs/contributing/how-to-contribute.md
@@ -144,7 +144,7 @@ However, there are still some styles that the linter cannot pick up. If you are 
 * Prefer `'` over `"`
 * `'use strict';`
 * 120 character line length (**except documentation**)
-* Write "attractive" code
+* Write sustainable code
 * Do not use the optional parameters of `setTimeout` and `setInterval`
 
 ### Introductory Video

--- a/docs/contributing/how-to-contribute.md
+++ b/docs/contributing/how-to-contribute.md
@@ -144,7 +144,7 @@ However, there are still some styles that the linter cannot pick up. If you are 
 * Prefer `'` over `"`
 * `'use strict';`
 * 120 character line length (**except documentation**)
-* Write sustainable code
+* Write code that is explicit
 * Do not use the optional parameters of `setTimeout` and `setInterval`
 
 ### Introductory Video


### PR DESCRIPTION
_sustainable code_ can replace the current wording without the use of quotes, because it's probably the real intention of that phrase. 

The quotes sounds like a documentation smell. Other words can be used, but might bring the discussion (bikeshedding) if that item is really necessary in that list.

- `Write human-readable code`
- `Avoid writing unreadable code`
- `Write comprehensible code`

Any of them are subjective. Following the other items in that list is good enough already.
