### PR TITLE
Move DOM related code to the injection

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -786,6 +786,10 @@ src/renderers/dom/shared/__tests__/CSSPropertyOperations-test.js
 * should not warn when setting CSS variables
 * should warn about style containing a Infinity value
 
+src/renderers/dom/shared/__tests__/DOMPreventedEvents-test.js
+* should recognize events to be prevented
+* should recognize events to be not prevented
+
 src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
 * should create markup for simple properties
 * should work with the id attribute

--- a/src/renderers/dom/shared/DOMPreventedEvents.js
+++ b/src/renderers/dom/shared/DOMPreventedEvents.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule DOMPreventedEvents
+ */
+
+'use strict';
+
+/**
+* @param {object} tag
+* @return {boolean}
+*/
+var isInteractive = function(tag) {
+  return (
+    tag === 'button' ||
+    tag === 'input' ||
+    tag === 'select' ||
+    tag === 'textarea'
+  );
+};
+
+/**
+* @param {string} listenerName Name of listener (e.g. `onClick`).
+* @param {object} tagName Tag name of the source instance.
+* @param {object} props Properties of the source instance.
+* @return {boolean} True if event should be prevented.
+*/
+var shouldBePrevented = function(listenerName, tagName, props) {
+  switch (listenerName) {
+    case 'onClick':
+    case 'onClickCapture':
+    case 'onDoubleClick':
+    case 'onDoubleClickCapture':
+    case 'onMouseDown':
+    case 'onMouseDownCapture':
+    case 'onMouseMove':
+    case 'onMouseMoveCapture':
+    case 'onMouseUp':
+    case 'onMouseUpCapture':
+      return !!(props.disabled && isInteractive(tagName));
+    default:
+      return false;
+  }
+};
+
+/*
+ */
+var DOMPreventedEvents = {
+  /**
+  * @param {string} listenerName Name of listener (e.g. `onClick`).
+  * @param {object} tagName Tag name of the source instance.
+  * @param {object} props Properties of the source instance.
+  * @return {boolean} True if event should be prevented.
+  */
+  shouldBePrevented: shouldBePrevented,
+};
+
+module.exports = DOMPreventedEvents;

--- a/src/renderers/dom/shared/ReactDOMInjection.js
+++ b/src/renderers/dom/shared/ReactDOMInjection.js
@@ -16,6 +16,7 @@ var BeforeInputEventPlugin = require('BeforeInputEventPlugin');
 var DOMProperty = require('DOMProperty');
 var ChangeEventPlugin = require('ChangeEventPlugin');
 var DOMEventPluginOrder = require('DOMEventPluginOrder');
+var DOMPreventedEvents = require('DOMPreventedEvents');
 var EnterLeaveEventPlugin = require('EnterLeaveEventPlugin');
 var EventPluginHub = require('EventPluginHub');
 var EventPluginUtils = require('EventPluginUtils');
@@ -47,6 +48,11 @@ function inject() {
    */
   EventPluginHub.injection.injectEventPluginOrder(DOMEventPluginOrder);
   EventPluginUtils.injection.injectComponentTree(ReactDOMComponentTree);
+
+  /**
+   * Events that are ignored.
+   */
+  EventPluginHub.injection.injectPreventedEvents(DOMPreventedEvents);
 
   /**
    * Some important event plugins included by default (without having to require

--- a/src/renderers/dom/shared/__tests__/DOMPreventedEvents-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPreventedEvents-test.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+describe('DOMPreventedEvents', () => {
+  var DOMPreventedEvents;
+
+  beforeEach(() => {
+    jest.resetModules();
+    DOMPreventedEvents = require('DOMPreventedEvents');
+  });
+
+  describe('shouldBePrevented', () => {
+    it('should recognize events to be prevented', () => {
+      expect(
+        DOMPreventedEvents.shouldBePrevented('onClick', 'input', {
+          disabled: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('should recognize events to be not prevented', () => {
+      expect(
+        DOMPreventedEvents.shouldBePrevented('onBlur', 'input', {
+          disabled: true,
+        }),
+      ).toBe(false);
+
+      expect(
+        DOMPreventedEvents.shouldBePrevented('onClick', 'div', {
+          disabled: true,
+        }),
+      ).toBe(false);
+
+      expect(DOMPreventedEvents.shouldBePrevented('onClick', 'input', {})).toBe(
+        false,
+      );
+    });
+  });
+});


### PR DESCRIPTION
This PR is about a todo comment in `EventPluginHub`
```
// TODO: shouldPreventMouseEvent is DOM-specific and definitely should not		
// live here; needs to be moved to a better place soon
```

This is a proposal to add `PreventedEvents` injection that takes some DOM dependent code out of EventPluginHub.