### PR TITLE
Reference process as global's property, so webpack users dont get who…

### DIFF
--- a/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
+++ b/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
@@ -23,8 +23,8 @@ var warning = require('fbjs/lib/warning');
 var ReactComponentTreeHook;
 
 if (
-  typeof process !== 'undefined' &&
-  process.env &&
+  typeof global.process !== 'undefined' &&
+  global.process.env &&
   process.env.NODE_ENV === 'test'
 ) {
   // Temporary hack.

--- a/src/renderers/shared/stack/reconciler/flattenStackChildren.js
+++ b/src/renderers/shared/stack/reconciler/flattenStackChildren.js
@@ -19,8 +19,8 @@ var warning = require('fbjs/lib/warning');
 var ReactComponentTreeHook;
 
 if (
-  typeof process !== 'undefined' &&
-  process.env &&
+  typeof global.process !== 'undefined' &&
+  global.process.env &&
   process.env.NODE_ENV === 'test'
 ) {
   // Temporary hack.


### PR DESCRIPTION
I know [we've agreed](https://github.com/facebook/react/pull/9518#discussion_r113145331) that this should wait for React 16, but I've found a way (credits to @benjamn) to improve those checks so they produce smaller polyfill when bundled by webpack (only `global` - which is few lines of code, and not whole `process`).

If you agree on the change this commit should be cherry-picked into the `v15` line. Can also be merged into the master as precaution for now if somebody's using already `next`. 

I've confirmed that bundles are ok, tests are passing and this is in fact 'fixing' the whole auto-polyfill situation for webpack's users. If you decide its not a time for such fix, just close the PR :)

cc @gaearon 