### PR TITLE
Don't prevent extensions on Fiber if using bad Map polyfill

### DIFF
--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -49,6 +49,18 @@ var invariant = require('fbjs/lib/invariant');
 
 if (__DEV__) {
   var getComponentName = require('getComponentName');
+
+  var hasBadMapPolyfill = false;
+  try {
+    const nonExtensibleObject = Object.preventExtensions({});
+    /* eslint-disable no-new */
+    new Map([[nonExtensibleObject, null]]);
+    new Set([nonExtensibleObject]);
+    /* eslint-enable no-new */
+  } catch (e) {
+    // TODO: Consider warning about bad polyfills
+    hasBadMapPolyfill = true;
+  }
 }
 
 // A Fiber is work on a Component that needs to be done or was done. There can
@@ -234,7 +246,7 @@ var createFiber = function(
     fiber._debugSource = null;
     fiber._debugOwner = null;
     fiber._debugIsCurrentlyTiming = false;
-    if (typeof Object.preventExtensions === 'function') {
+    if (!hasBadMapPolyfill && typeof Object.preventExtensions === 'function') {
       Object.preventExtensions(fiber);
     }
   }


### PR DESCRIPTION
Many Map polyfills work by adding an extra field to the key type. In the future, we'll likely print a warning.