### PR TITLE
Fix bug where null props is passed to constructor when resuming mount

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -260,7 +260,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     if (current === null) {
       if (!workInProgress.stateNode) {
         // In the initial pass we might need to construct the instance.
-        constructClassInstance(workInProgress);
+        constructClassInstance(workInProgress, workInProgress.pendingProps);
         mountClassInstance(workInProgress, priorityLevel);
         shouldUpdate = true;
       } else {

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -294,7 +294,6 @@ module.exports = function(
       : emptyObject;
     const instance = new ctor(props, context);
     adoptClassInstance(workInProgress, instance);
-    checkClassInstance(workInProgress);
 
     // Cache unmasked context so we can avoid recreating masked context unless necessary.
     // ReactFiberContext usually updates this cache but can't for newly-created instances.
@@ -310,6 +309,10 @@ module.exports = function(
     workInProgress: Fiber,
     priorityLevel: PriorityLevel,
   ): void {
+    if (__DEV__) {
+      checkClassInstance(workInProgress);
+    }
+
     const instance = workInProgress.stateNode;
     const state = instance.state || null;
 

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -285,9 +285,8 @@ module.exports = function(
     ReactInstanceMap.set(instance, workInProgress);
   }
 
-  function constructClassInstance(workInProgress: Fiber): any {
+  function constructClassInstance(workInProgress: Fiber, props: any): any {
     const ctor = workInProgress.type;
-    const props = workInProgress.pendingProps;
     const unmaskedContext = getUnmaskedContext(workInProgress);
     const needsContext = isContextConsumer(workInProgress);
     const context = needsContext
@@ -411,7 +410,7 @@ module.exports = function(
 
     // If we didn't bail out we need to construct a new instance. We don't
     // want to reuse one that failed to fully mount.
-    const newInstance = constructClassInstance(workInProgress);
+    const newInstance = constructClassInstance(workInProgress, newProps);
     newInstance.props = newProps;
     newInstance.state = newState = newInstance.state || null;
     newInstance.context = newContext;


### PR DESCRIPTION
Another example of where the pending/progressed/memoized props model would benefit from a refactor.

TODO: unit test