### PR TITLE
[Docs] Show the name 'React' first in the homepage's <title>

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -7,7 +7,11 @@
 {% assign sectionTitle = 'React' %}
 {% assign description = 'A JavaScript library for building user interfaces' %}
 {% endif %}
-{% assign title = page.title | append: ' - ' | append: sectionTitle %}
+{% if page.id == 'home' %}
+  {% assign title = sectionTitle | append: ' - ' | append: page.title %}
+{% else %}
+  {% assign title = page.title | append: ' - ' | append: sectionTitle %}
+{% endif %}
 <!DOCTYPE html>
 <!--[if IE]><![endif]-->
 <html>


### PR DESCRIPTION
I've increased the usability of the homepage's `<title>`, so that the name 'React' is still visible a shorter browser tab. This should also increase visibility when people are searching for 'React'.

Short and sweet. 👐