### PR TITLE
Add failing test demonstrating progressed work bug

### DIFF
--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -493,6 +493,49 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Foo constructor: foo', 'Foo', 'Bar']);
   });
 
+  it('can reuse a partially rendered, not-yet-mounted tree', () => {
+    let ops = [];
+
+    function Bar(props) {
+      ops.push('Bar ' + props.id);
+      return null;
+    }
+
+    class Foo extends React.Component {
+      componentWillMount() {
+        ops.push('Foo will mount');
+      }
+      render() {
+        ops.push('Foo');
+        return [
+          <Bar key="1" id="1" />,
+          <Bar key="2" id="2" />,
+          <Bar key="3" id="3" />,
+        ];
+      }
+    }
+
+    const element = <Foo />;
+    ReactNoop.render(element);
+    ReactNoop.flushDeferredPri(25);
+    expect(ops).toEqual([
+      'Foo will mount',
+      'Foo',
+      'Bar 1',
+      'Bar 2',
+      // Bar 3 did not render
+    ]);
+
+    ops = [];
+
+    // Render again. This will start back at the root.
+    ReactNoop.render(element);
+    ReactNoop.flush();
+    expect(ops).toEqual([
+      'Bar 3',
+    ]);
+  });
+
   it('can reuse work done after being preempted', () => {
     var ops = [];
 


### PR DESCRIPTION
In `cloneFiber`, we always copy the `memoizedProps` from current. That means we lose the memoization of the progressed work.

This bug manifests itself in several ways. The simplest example is that if we resume mounting a partially rendered tree, we can't reuse any of the progressed work, because the current `memoizedProps` is null.

I believe the reason we didn't discover this flaw earlier is because we don't implement memoization correctly, and the cloned current props end up being used to memoize the `progressedChild`. Which happens to work in many cases, even though it's incorrect.

In addition to fixing the bugs, we may want to consider adding a `progressedProps` (and `progressedState`) field to the Fiber type.