### PR TITLE
[Fiber] Warn when trying to unmount a non-root React node

### DIFF
--- a/scripts/fiber/tests-passing-except-dev.txt
+++ b/scripts/fiber/tests-passing-except-dev.txt
@@ -160,7 +160,6 @@ src/renderers/dom/shared/__tests__/ReactMount-test.js
 
 src/renderers/dom/shared/__tests__/ReactMountDestruction-test.js
 * should warn when unmounting a non-container root node
-* should warn when unmounting a non-container, non-root node
 
 src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
 * should have the correct mounting behavior

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1252,6 +1252,7 @@ src/renderers/dom/shared/__tests__/ReactMount-test.js
 
 src/renderers/dom/shared/__tests__/ReactMountDestruction-test.js
 * should destroy a react root upon request
+* should warn when unmounting a non-container, non-root node
 
 src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
 * should generate simple markup

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -524,6 +524,19 @@ var ReactDOM = {
         });
       });
     }
+
+    if (__DEV__) {
+      const rootEl = getReactRootElementInContainer(container);
+      const hasNonRootReactChild = !!(rootEl &&
+        ReactDOMComponentTree.getInstanceFromNode(rootEl));
+      warning(
+        !hasNonRootReactChild,
+        "unmountComponentAtNode(): The node you're attempting to unmount " +
+          'was rendered by React and is not a top-level container. ' +
+          'Instead, have the parent component update its state and ' +
+          'rerender in order to remove this component.',
+      );
+    }
   },
 
   findDOMNode: findDOMNode,


### PR DESCRIPTION
Fixes `"should warn when unmounting a non-container, non-root node"` testcase in `ReactMountDestruction-test`. I haven't added the second [warning](https://github.com/facebook/react/blob/master/src/renderers/dom/shared/__tests__/ReactMountDestruction-test.js#L59-L62), because with Fiber there's no difference between container node and root node, fragments may go directly into container.

Btw, there's no warning when one tries to call `unmountComponentAtNode` on a non-react node, it's just a silent no-op. Is it intentional?