### PR TITLE
Disable ESLint's no-extend-native for two lines

### DIFF
--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -816,16 +816,17 @@ describe('ReactDOMComponent', () => {
         let realToString;
         try {
           realToString = Object.prototype.toString;
-          Object.prototype.toString = function() {
+          let wrappedToString = function() {
             // Emulate browser behavior which is missing in jsdom
             if (this instanceof window.HTMLUnknownElement) {
               return '[object HTMLUnknownElement]';
             }
             return realToString.apply(this, arguments);
           };
+          Object.prototype.toString = wrappedToString; // eslint-disable-line no-extend-native
           ReactTestUtils.renderIntoDocument(<mycustomcomponent />);
         } finally {
-          Object.prototype.toString = realToString;
+          Object.prototype.toString = realToString; // eslint-disable-line no-extend-native
         }
 
         expectDev(console.error.calls.count()).toBe(1);


### PR DESCRIPTION
This fixes the following two `no-extend-native` warnings by adding `eslint-disable-line` comments.

    src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
      819:11  warning  Object prototype is read only, properties should not be added  no-extend-native
      828:11  warning  Object prototype is read only, properties should not be added  no-extend-native

I also had to move the code around a bit so both ESLint and Prettier would be satisfied. Initially the code was like like this:

    Object.prototype.toString = function() { // eslint-disable-line no-extend-native
      ...
    }

But Prettier moved the comment on the following line, which cased the ESLint warning to appear again.

    Object.prototype.toString = function() {
      // eslint-disable-line no-extend-native
      ...
    }

Moving the comment before the assignment prevented Prettier from reformatting the code but did not disable the warning, so I refactored the code like this:

    let  wrappedToString = function() {
      ...
    }
    Object.prototype.toString = wrappedToString; // eslint-disable-line no-extend-native


 The PR that introduced the warnings is #9163.