### PR TITLE
[Fiber] Fix to call deferred callbackQueue even if updates are aborted

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1673,6 +1673,7 @@ src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
 * should render a simple component, in steps if needed
 * updates a previous render
 * can cancel partially rendered work and restart
+* should call callbacks even if updates are aborted
 * can deprioritize unfinished work and resume it later
 * can deprioritize a tree from without dropping work
 * can resume work in a subtree even when a parent bails out

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -426,7 +426,7 @@ function beginUpdateQueue(
   // a new state object.
   let state = prevState;
   let dontMutatePrevState = true;
-  let callbackList = null;
+  let callbackList = queue.callbackList;
   let update = queue.first;
   while (
     update !== null &&


### PR DESCRIPTION
Currently, setState callback has never been called when the update is interrupted.
This PR is fixed it and added a test for reproducing it.