### PR TITLE
Rename ReactEventListener to ReactDOMEventListener

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -946,6 +946,14 @@ src/renderers/dom/shared/__tests__/ReactDOMComponentTree-test.js
 * finds nodes for instances
 * finds instances for nodes
 
+src/renderers/dom/shared/__tests__/ReactDOMEventListener-test.js
+* should dispatch events from outside React tree
+* should propagate events one level down
+* should propagate events two levels down
+* should not get confused by disappearing elements
+* should batch between handlers from different roots
+* should not fire duplicate events for a React DOM tree
+
 src/renderers/dom/shared/__tests__/ReactDOMInvalidARIAHook-test.js
 * should allow valid aria-* props
 * should warn for one invalid aria-* prop
@@ -1229,14 +1237,6 @@ src/renderers/dom/shared/__tests__/ReactEventIndependence-test.js
 * does not crash with other react inside
 * does not crash with other react outside
 * does not when event fired on unmounted tree
-
-src/renderers/dom/shared/__tests__/ReactEventListener-test.js
-* should dispatch events from outside React tree
-* should propagate events one level down
-* should propagate events two levels down
-* should not get confused by disappearing elements
-* should batch between handlers from different roots
-* should not fire duplicate events for a React DOM tree
 
 src/renderers/dom/shared/__tests__/ReactMount-test.js
 * throws when given a non-node

--- a/src/renderers/dom/shared/ReactBrowserEventEmitter.js
+++ b/src/renderers/dom/shared/ReactBrowserEventEmitter.js
@@ -22,8 +22,9 @@ var {topLevelTypes} = require('BrowserEventConstants');
  *
  *  - Top-level delegation is used to trap most native browser events. This
  *    may only occur in the main thread and is the responsibility of
- *    ReactEventListener, which is injected and can therefore support pluggable
- *    event sources. This is the only work that occurs in the main thread.
+ *    ReactDOMEventListener, which is injected and can therefore support
+ *    pluggable event sources. This is the only work that occurs in the main
+ *    thread.
  *
  *  - We normalize and de-duplicate events to account for browser quirks. This
  *    may be done in the worker thread.
@@ -94,17 +95,17 @@ var ReactBrowserEventEmitter = Object.assign({}, ReactEventEmitterMixin, {
   /**
    * Injectable event backend
    */
-  ReactEventListener: null,
+  ReactDOMEventListener: null,
 
   injection: {
     /**
-     * @param {object} ReactEventListener
+     * @param {object} ReactDOMEventListener
      */
-    injectReactEventListener: function(ReactEventListener) {
-      ReactEventListener.setHandleTopLevel(
+    injectReactDOMEventListener: function(ReactDOMEventListener) {
+      ReactDOMEventListener.setHandleTopLevel(
         ReactBrowserEventEmitter.handleTopLevel,
       );
-      ReactBrowserEventEmitter.ReactEventListener = ReactEventListener;
+      ReactBrowserEventEmitter.ReactDOMEventListener = ReactDOMEventListener;
     },
   },
 
@@ -114,8 +115,8 @@ var ReactBrowserEventEmitter = Object.assign({}, ReactEventEmitterMixin, {
    * @param {boolean} enabled True if callbacks should be enabled.
    */
   setEnabled: function(enabled) {
-    if (ReactBrowserEventEmitter.ReactEventListener) {
-      ReactBrowserEventEmitter.ReactEventListener.setEnabled(enabled);
+    if (ReactBrowserEventEmitter.ReactDOMEventListener) {
+      ReactBrowserEventEmitter.ReactDOMEventListener.setEnabled(enabled);
     }
   },
 
@@ -123,8 +124,8 @@ var ReactBrowserEventEmitter = Object.assign({}, ReactEventEmitterMixin, {
    * @return {boolean} True if callbacks are enabled.
    */
   isEnabled: function() {
-    return !!(ReactBrowserEventEmitter.ReactEventListener &&
-      ReactBrowserEventEmitter.ReactEventListener.isEnabled());
+    return !!(ReactBrowserEventEmitter.ReactDOMEventListener &&
+      ReactBrowserEventEmitter.ReactDOMEventListener.isEnabled());
   },
 
   /**
@@ -161,13 +162,13 @@ var ReactBrowserEventEmitter = Object.assign({}, ReactEventEmitterMixin, {
       ) {
         if (dependency === 'topWheel') {
           if (isEventSupported('wheel')) {
-            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(
+            ReactBrowserEventEmitter.ReactDOMEventListener.trapBubbledEvent(
               'topWheel',
               'wheel',
               mountAt,
             );
           } else if (isEventSupported('mousewheel')) {
-            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(
+            ReactBrowserEventEmitter.ReactDOMEventListener.trapBubbledEvent(
               'topWheel',
               'mousewheel',
               mountAt,
@@ -175,25 +176,25 @@ var ReactBrowserEventEmitter = Object.assign({}, ReactEventEmitterMixin, {
           } else {
             // Firefox needs to capture a different mouse scroll event.
             // @see http://www.quirksmode.org/dom/events/tests/scroll.html
-            ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(
+            ReactBrowserEventEmitter.ReactDOMEventListener.trapBubbledEvent(
               'topWheel',
               'DOMMouseScroll',
               mountAt,
             );
           }
         } else if (dependency === 'topScroll') {
-          ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
+          ReactBrowserEventEmitter.ReactDOMEventListener.trapCapturedEvent(
             'topScroll',
             'scroll',
             mountAt,
           );
         } else if (dependency === 'topFocus' || dependency === 'topBlur') {
-          ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
+          ReactBrowserEventEmitter.ReactDOMEventListener.trapCapturedEvent(
             'topFocus',
             'focus',
             mountAt,
           );
-          ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
+          ReactBrowserEventEmitter.ReactDOMEventListener.trapCapturedEvent(
             'topBlur',
             'blur',
             mountAt,
@@ -204,7 +205,7 @@ var ReactBrowserEventEmitter = Object.assign({}, ReactEventEmitterMixin, {
           isListening.topFocus = true;
         } else if (dependency === 'topCancel') {
           if (isEventSupported('cancel', true)) {
-            ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
+            ReactBrowserEventEmitter.ReactDOMEventListener.trapCapturedEvent(
               'topCancel',
               'cancel',
               mountAt,
@@ -213,7 +214,7 @@ var ReactBrowserEventEmitter = Object.assign({}, ReactEventEmitterMixin, {
           isListening.topCancel = true;
         } else if (dependency === 'topClose') {
           if (isEventSupported('close', true)) {
-            ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
+            ReactBrowserEventEmitter.ReactDOMEventListener.trapCapturedEvent(
               'topClose',
               'close',
               mountAt,
@@ -221,7 +222,7 @@ var ReactBrowserEventEmitter = Object.assign({}, ReactEventEmitterMixin, {
           }
           isListening.topClose = true;
         } else if (topLevelTypes.hasOwnProperty(dependency)) {
-          ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(
+          ReactBrowserEventEmitter.ReactDOMEventListener.trapBubbledEvent(
             dependency,
             topLevelTypes[dependency],
             mountAt,
@@ -249,7 +250,7 @@ var ReactBrowserEventEmitter = Object.assign({}, ReactEventEmitterMixin, {
   },
 
   trapBubbledEvent: function(topLevelType, handlerBaseName, handle) {
-    return ReactBrowserEventEmitter.ReactEventListener.trapBubbledEvent(
+    return ReactBrowserEventEmitter.ReactDOMEventListener.trapBubbledEvent(
       topLevelType,
       handlerBaseName,
       handle,
@@ -257,7 +258,7 @@ var ReactBrowserEventEmitter = Object.assign({}, ReactEventEmitterMixin, {
   },
 
   trapCapturedEvent: function(topLevelType, handlerBaseName, handle) {
-    return ReactBrowserEventEmitter.ReactEventListener.trapCapturedEvent(
+    return ReactBrowserEventEmitter.ReactDOMEventListener.trapCapturedEvent(
       topLevelType,
       handlerBaseName,
       handle,

--- a/src/renderers/dom/shared/ReactDOMEventListener.js
+++ b/src/renderers/dom/shared/ReactDOMEventListener.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule ReactEventListener
+ * @providesModule ReactDOMEventListener
  */
 
 'use strict';
@@ -92,7 +92,7 @@ function handleTopLevelImpl(bookKeeping) {
 
   for (var i = 0; i < bookKeeping.ancestors.length; i++) {
     targetInst = bookKeeping.ancestors[i];
-    ReactEventListener._handleTopLevel(
+    ReactDOMEventListener._handleTopLevel(
       bookKeeping.topLevelType,
       targetInst,
       bookKeeping.nativeEvent,
@@ -106,20 +106,20 @@ function scrollValueMonitor(cb) {
   cb(scrollPosition);
 }
 
-var ReactEventListener = {
+var ReactDOMEventListener = {
   _enabled: true,
   _handleTopLevel: null,
 
   setHandleTopLevel: function(handleTopLevel) {
-    ReactEventListener._handleTopLevel = handleTopLevel;
+    ReactDOMEventListener._handleTopLevel = handleTopLevel;
   },
 
   setEnabled: function(enabled) {
-    ReactEventListener._enabled = !!enabled;
+    ReactDOMEventListener._enabled = !!enabled;
   },
 
   isEnabled: function() {
-    return ReactEventListener._enabled;
+    return ReactDOMEventListener._enabled;
   },
 
   /**
@@ -139,7 +139,7 @@ var ReactEventListener = {
     return EventListener.listen(
       element,
       handlerBaseName,
-      ReactEventListener.dispatchEvent.bind(null, topLevelType),
+      ReactDOMEventListener.dispatchEvent.bind(null, topLevelType),
     );
   },
 
@@ -160,7 +160,7 @@ var ReactEventListener = {
     return EventListener.capture(
       element,
       handlerBaseName,
-      ReactEventListener.dispatchEvent.bind(null, topLevelType),
+      ReactDOMEventListener.dispatchEvent.bind(null, topLevelType),
     );
   },
 
@@ -170,7 +170,7 @@ var ReactEventListener = {
   },
 
   dispatchEvent: function(topLevelType, nativeEvent) {
-    if (!ReactEventListener._enabled) {
+    if (!ReactDOMEventListener._enabled) {
       return;
     }
 
@@ -195,4 +195,4 @@ var ReactEventListener = {
   },
 };
 
-module.exports = ReactEventListener;
+module.exports = ReactDOMEventListener;

--- a/src/renderers/dom/shared/ReactDOMInjection.js
+++ b/src/renderers/dom/shared/ReactDOMInjection.js
@@ -22,7 +22,7 @@ var EventPluginUtils = require('EventPluginUtils');
 var HTMLDOMPropertyConfig = require('HTMLDOMPropertyConfig');
 var ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
-var ReactEventListener = require('ReactEventListener');
+var ReactDOMEventListener = require('ReactDOMEventListener');
 var SVGDOMPropertyConfig = require('SVGDOMPropertyConfig');
 var SelectEventPlugin = require('SelectEventPlugin');
 var SimpleEventPlugin = require('SimpleEventPlugin');
@@ -38,8 +38,8 @@ function inject() {
   }
   alreadyInjected = true;
 
-  ReactBrowserEventEmitter.injection.injectReactEventListener(
-    ReactEventListener,
+  ReactBrowserEventEmitter.injection.injectReactDOMEventListener(
+    ReactDOMEventListener,
   );
 
   /**

--- a/src/renderers/dom/shared/__tests__/ReactDOMEventListener-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMEventListener-test.js
@@ -13,11 +13,11 @@
 
 var EVENT_TARGET_PARAM = 1;
 
-describe('ReactEventListener', () => {
+describe('ReactDOMEventListener', () => {
   var React;
   var ReactDOM;
   var ReactDOMComponentTree;
-  var ReactEventListener;
+  var ReactDOMEventListener;
   var ReactTestUtils;
   var handleTopLevel;
 
@@ -26,18 +26,18 @@ describe('ReactEventListener', () => {
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMComponentTree = require('ReactDOMComponentTree');
-    ReactEventListener = require('ReactEventListener');
+    ReactDOMEventListener = require('ReactDOMEventListener');
     ReactTestUtils = require('ReactTestUtils');
 
     handleTopLevel = jest.fn();
-    ReactEventListener._handleTopLevel = handleTopLevel;
+    ReactDOMEventListener._handleTopLevel = handleTopLevel;
   });
 
   it('should dispatch events from outside React tree', () => {
     var otherNode = document.createElement('h1');
     var component = ReactDOM.render(<div />, document.createElement('div'));
     expect(handleTopLevel.mock.calls.length).toBe(0);
-    ReactEventListener.dispatchEvent('topMouseOut', {
+    ReactDOMEventListener.dispatchEvent('topMouseOut', {
       type: 'mouseout',
       fromElement: otherNode,
       target: otherNode,
@@ -60,7 +60,7 @@ describe('ReactEventListener', () => {
       parentControl = ReactDOM.render(parentControl, parentContainer);
       ReactDOM.findDOMNode(parentControl).appendChild(childContainer);
 
-      var callback = ReactEventListener.dispatchEvent.bind(null, 'test');
+      var callback = ReactDOMEventListener.dispatchEvent.bind(null, 'test');
       callback({
         target: ReactDOM.findDOMNode(childControl),
       });
@@ -91,7 +91,7 @@ describe('ReactEventListener', () => {
       ReactDOM.findDOMNode(parentControl).appendChild(childContainer);
       ReactDOM.findDOMNode(grandParentControl).appendChild(parentContainer);
 
-      var callback = ReactEventListener.dispatchEvent.bind(null, 'test');
+      var callback = ReactDOMEventListener.dispatchEvent.bind(null, 'test');
       callback({
         target: ReactDOM.findDOMNode(childControl),
       });
@@ -134,7 +134,7 @@ describe('ReactEventListener', () => {
         }
       });
 
-      var callback = ReactEventListener.dispatchEvent.bind(null, 'test');
+      var callback = ReactDOMEventListener.dispatchEvent.bind(null, 'test');
       callback({
         target: childNode,
       });
@@ -173,8 +173,8 @@ describe('ReactEventListener', () => {
         expect(childNode.textContent).toBe('Child');
       });
 
-      var callback = ReactEventListener.dispatchEvent.bind(
-        ReactEventListener,
+      var callback = ReactDOMEventListener.dispatchEvent.bind(
+        ReactDOMEventListener,
         'test',
       );
       callback({
@@ -201,7 +201,7 @@ describe('ReactEventListener', () => {
 
     var instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
 
-    var callback = ReactEventListener.dispatchEvent.bind(null, 'test');
+    var callback = ReactDOMEventListener.dispatchEvent.bind(null, 'test');
     callback({
       target: ReactDOM.findDOMNode(instance.getInner()),
     });

--- a/src/renderers/dom/test/ReactTestUtils.js
+++ b/src/renderers/dom/test/ReactTestUtils.js
@@ -395,7 +395,7 @@ var ReactTestUtils = {
    */
   simulateNativeEventOnNode: function(topLevelType, node, fakeNativeEvent) {
     fakeNativeEvent.target = node;
-    ReactBrowserEventEmitter.ReactEventListener.dispatchEvent(
+    ReactBrowserEventEmitter.ReactDOMEventListener.dispatchEvent(
       topLevelType,
       fakeNativeEvent,
     );


### PR DESCRIPTION
Closes #9639

`ReactEventListener` is a DOM-specific module although the name suggests
otherwise. This change renames the module to the more specific 
`ReactDOMEventListener`.