### PR TITLE
Add browserify transform

### DIFF
--- a/addons/create-react-class/package.json
+++ b/addons/create-react-class/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://facebook.github.io/react/",
   "dependencies": {
     "fbjs": "^0.8.9",
+    "loose-envify": "^1.3.1",
     "object-assign": "^4.1.1"
   },
   "scripts": {
@@ -32,5 +33,10 @@
     "react": "^15.5.0",
     "react-addons-test-utils": "^15.5.0",
     "react-dom": "^15.5.0"
+  },
+  "browserify": {
+    "transform": [
+      "loose-envify"
+    ]
   }
 }

--- a/addons/create-react-class/yarn.lock
+++ b/addons/create-react-class/yarn.lock
@@ -1300,9 +1300,9 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  resolved "https://artifacts.netflix.com/api/npm/npm-netflix/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
 

--- a/addons/react-addons-create-fragment/package.json
+++ b/addons/react-addons-create-fragment/package.json
@@ -10,6 +10,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "fbjs": "^0.8.4",
+    "loose-envify": "^1.3.1",
     "object-assign": "^4.1.0"
   },
   "files": [
@@ -27,5 +28,10 @@
     "jest": "^19.0.2",
     "react": "^15.4.2",
     "react-dom": "^15.4.2"
+  },
+  "browserify": {
+    "transform": [
+      "loose-envify"
+    ]
   }
 }

--- a/addons/react-addons-create-fragment/yarn.lock
+++ b/addons/react-addons-create-fragment/yarn.lock
@@ -1300,9 +1300,9 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  resolved "https://artifacts.netflix.com/api/npm/npm-netflix/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
 


### PR DESCRIPTION
Related to https://github.com/facebook/react/issues/9641

This tells browserify to remove `process.env.NODE_ENV` conditionals during bundling for `create-react-class` and `react-addons-create-fragment`.