### PR TITLE
Move small utility modules out of ReactDOM(Fiber)?Component

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -26,10 +26,12 @@ var {getCurrentFiberOwnerName} = require('ReactDebugCurrentFiber');
 var {DOCUMENT_FRAGMENT_NODE} = require('HTMLNodeType');
 
 var emptyFunction = require('fbjs/lib/emptyFunction');
+var inputValueTracking = require('inputValueTracking');
 var invariant = require('fbjs/lib/invariant');
+var isCustomComponent = require('isCustomComponent');
 var setInnerHTML = require('setInnerHTML');
 var setTextContent = require('setTextContent');
-var inputValueTracking = require('inputValueTracking');
+var voidElementTags = require('voidElementTags');
 var warning = require('fbjs/lib/warning');
 
 if (__DEV__) {
@@ -235,40 +237,6 @@ function trapBubbledEventsLocal(node: Element, tag: string) {
       ReactBrowserEventEmitter.trapBubbledEvent('topToggle', 'toggle', node);
       break;
   }
-}
-
-// For HTML, certain tags should omit their close tag. We keep a whitelist for
-// those special-case tags.
-
-var omittedCloseTags = {
-  area: true,
-  base: true,
-  br: true,
-  col: true,
-  embed: true,
-  hr: true,
-  img: true,
-  input: true,
-  keygen: true,
-  link: true,
-  meta: true,
-  param: true,
-  source: true,
-  track: true,
-  wbr: true,
-  // NOTE: menuitem's close tag should be omitted, but that causes problems.
-};
-
-// For HTML, certain tags cannot have children. This has the same purpose as
-// `omittedCloseTags` except that `menuitem` should still have its closing tag.
-
-var voidElementTags = {
-  menuitem: true,
-  ...omittedCloseTags,
-};
-
-function isCustomComponent(tagName, props) {
-  return tagName.indexOf('-') >= 0 || props.is != null;
 }
 
 function setInitialDOMProperties(

--- a/src/renderers/dom/shared/utils/isCustomComponent.js
+++ b/src/renderers/dom/shared/utils/isCustomComponent.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule isCustomComponent
+ */
+
+'use strict';
+
+function isCustomComponent(tagName, props) {
+  return tagName.indexOf('-') >= 0 || props.is != null;
+}
+
+module.exports = isCustomComponent;

--- a/src/renderers/dom/shared/utils/omittedCloseTags.js
+++ b/src/renderers/dom/shared/utils/omittedCloseTags.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule omittedCloseTags
+ */
+
+'use strict';
+
+// For HTML, certain tags should omit their close tag. We keep a whitelist for
+// those special-case tags.
+
+var omittedCloseTags = {
+  area: true,
+  base: true,
+  br: true,
+  col: true,
+  embed: true,
+  hr: true,
+  img: true,
+  input: true,
+  keygen: true,
+  link: true,
+  meta: true,
+  param: true,
+  source: true,
+  track: true,
+  wbr: true,
+  // NOTE: menuitem's close tag should be omitted, but that causes problems.
+};
+
+module.exports = omittedCloseTags;

--- a/src/renderers/dom/shared/utils/voidElementTags.js
+++ b/src/renderers/dom/shared/utils/voidElementTags.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule voidElementTags
+ */
+
+'use strict';
+
+var omittedCloseTags = require('omittedCloseTags');
+
+// For HTML, certain tags cannot have children. This has the same purpose as
+// `omittedCloseTags` except that `menuitem` should still have its closing tag.
+
+var voidElementTags = {
+  menuitem: true,
+  ...omittedCloseTags,
+};
+
+module.exports = voidElementTags;

--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -30,13 +30,16 @@ var ReactMultiChild = require('ReactMultiChild');
 var ReactServerRenderingTransaction = require('ReactServerRenderingTransaction');
 var {DOCUMENT_FRAGMENT_NODE} = require('HTMLNodeType');
 
+var didWarnShadyDOM = false;
 var emptyFunction = require('fbjs/lib/emptyFunction');
 var escapeTextContentForBrowser = require('escapeTextContentForBrowser');
-var invariant = require('fbjs/lib/invariant');
 var inputValueTracking = require('inputValueTracking');
+var invariant = require('fbjs/lib/invariant');
+var isCustomComponent = require('isCustomComponent');
+var omittedCloseTags = require('omittedCloseTags');
 var validateDOMNesting = require('validateDOMNesting');
+var voidElementTags = require('voidElementTags');
 var warning = require('fbjs/lib/warning');
-var didWarnShadyDOM = false;
 
 var Flags = ReactDOMComponentFlags;
 var getNode = ReactDOMComponentTree.getNodeFromInstance;
@@ -312,43 +315,11 @@ function postUpdateSelectWrapper() {
   ReactDOMSelect.postUpdateWrapper(this);
 }
 
-// For HTML, certain tags should omit their close tag. We keep a whitelist for
-// those special-case tags.
-
-var omittedCloseTags = {
-  area: true,
-  base: true,
-  br: true,
-  col: true,
-  embed: true,
-  hr: true,
-  img: true,
-  input: true,
-  keygen: true,
-  link: true,
-  meta: true,
-  param: true,
-  source: true,
-  track: true,
-  wbr: true,
-  // NOTE: menuitem's close tag should be omitted, but that causes problems.
-};
-
 var newlineEatingTags = {
   listing: true,
   pre: true,
   textarea: true,
 };
-
-// For HTML, certain tags cannot have children. This has the same purpose as
-// `omittedCloseTags` except that `menuitem` should still have its closing tag.
-
-var voidElementTags = Object.assign(
-  {
-    menuitem: true,
-  },
-  omittedCloseTags,
-);
 
 // We accept any tag to be rendered but since this gets injected into arbitrary
 // HTML, we want to make sure that it's a safe tag.
@@ -362,10 +333,6 @@ function validateDangerousTag(tag) {
     invariant(VALID_TAG_REGEX.test(tag), 'Invalid tag: %s', tag);
     validatedTagCache[tag] = true;
   }
-}
-
-function isCustomComponent(tagName, props) {
-  return tagName.indexOf('-') >= 0 || props.is != null;
 }
 
 var globalIdCounter = 1;

--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -30,7 +30,6 @@ var ReactMultiChild = require('ReactMultiChild');
 var ReactServerRenderingTransaction = require('ReactServerRenderingTransaction');
 var {DOCUMENT_FRAGMENT_NODE} = require('HTMLNodeType');
 
-var didWarnShadyDOM = false;
 var emptyFunction = require('fbjs/lib/emptyFunction');
 var escapeTextContentForBrowser = require('escapeTextContentForBrowser');
 var inputValueTracking = require('inputValueTracking');
@@ -40,6 +39,8 @@ var omittedCloseTags = require('omittedCloseTags');
 var validateDOMNesting = require('validateDOMNesting');
 var voidElementTags = require('voidElementTags');
 var warning = require('fbjs/lib/warning');
+
+var didWarnShadyDOM = false;
 
 var Flags = ReactDOMComponentFlags;
 var getNode = ReactDOMComponentTree.getNodeFromInstance;


### PR DESCRIPTION
These are all going to be needed in the server renderer, so I'm moving them out now so I can use them from in there.