### PR TITLE
Always pass error code to CI

### DIFF
--- a/scripts/tasks/eslint.js
+++ b/scripts/tasks/eslint.js
@@ -20,8 +20,8 @@ spawn(path.join('node_modules', '.bin', 'eslint' + extension), ['.'], {
 }).on('close', function(code) {
   if (code !== 0) {
     console.error('Lint failed');
-    process.exit(code);
   }
 
   console.log('Lint passed');
+  process.exit(code);
 });

--- a/scripts/tasks/flow.js
+++ b/scripts/tasks/flow.js
@@ -20,7 +20,7 @@ spawn(path.join('node_modules', '.bin', 'flow' + extension), ['check', '.'], {
 }).on('close', function(code) {
   if (code !== 0) {
     console.log('Flow failed');
-    process.exit(code);
   }
   console.log('Flow passed');
+  process.exit(code);
 });

--- a/scripts/tasks/jest.js
+++ b/scripts/tasks/jest.js
@@ -27,5 +27,5 @@ jest.on('close', code => {
   } else {
     console.log('Jest passed!');
   }
-  process.exit(0);
+  process.exit(code);
 });


### PR DESCRIPTION
During Rollup PR, we forgot to pass the error code from the Jest task.
As a result, master currently has a failing test.

The failing test was introduced in #9608.

This PR makes sure we always pass the code down.
It is expected to break CI.

In a followup PR we will look at the root cause.