### PR TITLE
Move 'lighthouse' and 'nodegit' to 'optionalDependencies'

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,13 +68,11 @@
     "jest-config": "^19.0.1",
     "jest-jasmine2": "^19.0.1",
     "jest-runtime": "^19.0.1",
-    "lighthouse": "^1.6.3",
     "loose-envify": "^1.1.0",
     "merge-stream": "^1.0.0",
     "mime": "^1.3.4",
     "minimist": "^1.2.0",
     "ncp": "^2.0.0",
-    "nodegit": "^0.18.0",
     "object-assign": "^4.1.1",
     "platform": "^1.1.0",
     "prettier": "^1.2.2",
@@ -96,6 +94,10 @@
     "uglify-js": "^2.5.0",
     "uglifyify": "^3.0.1",
     "yargs": "^6.3.0"
+  },
+  "optionalDependencies": {
+    "lighthouse": "^1.6.3",
+    "nodegit": "^0.18.0"
   },
   "devEngines": {
     "node": "4.x || 5.x || 6.x || 7.x",


### PR DESCRIPTION
**what is the change?:**
See title.

**why make this change?:**
Both these dependencies were causing issues when working on React internally at
FB.

'lighthouse' requires node >=6 and we don't want to folks working on React to
using that version of node.
https://github.com/GoogleChrome/lighthouse/blob/master/package.json#L11

'nodegit' for me throws an error related to libssh2 and it's annoying to make
this work in every OS. See https://github.com/nodegit/nodegit/issues/1266

**test plan:**
`npm/yarn install`
Runs with no errors on my CentOS machine and also on MacOSX laptop.

**issue:**
This is blocking work related to https://github.com/facebook/react/issues/9398