### PR TITLE
Add 'Test Utils' docs back to main navigation

### DIFF
--- a/docs/_data/nav_docs.yml
+++ b/docs/_data/nav_docs.yml
@@ -69,3 +69,5 @@
       title: SyntheticEvent
     - id: test-utils
       title: Test Utilities
+    - id: shallow-renderer
+      title: Shallow Renderer

--- a/docs/_data/nav_docs.yml
+++ b/docs/_data/nav_docs.yml
@@ -32,8 +32,6 @@
       title: JSX In Depth
     - id: typechecking-with-proptypes
       title: Typechecking With PropTypes
-    - id: test-utils
-      title: Test Utilities
     - id: refs-and-the-dom
       title: Refs and the DOM
     - id: uncontrolled-components
@@ -69,3 +67,5 @@
       title: DOM Elements
     - id: events
       title: SyntheticEvent
+    - id: test-utils
+      title: Test Utilities

--- a/docs/_data/nav_docs.yml
+++ b/docs/_data/nav_docs.yml
@@ -32,6 +32,8 @@
       title: JSX In Depth
     - id: typechecking-with-proptypes
       title: Typechecking With PropTypes
+    - id: test-utils
+      title: Test Utilities
     - id: refs-and-the-dom
       title: Refs and the DOM
     - id: uncontrolled-components

--- a/docs/docs/addons-shallow-renderer.md
+++ b/docs/docs/addons-shallow-renderer.md
@@ -14,7 +14,7 @@ var ReactShallowRenderer = require('react-test-renderer/shallow'); // ES5 with n
 ```
 ### Shallow Rendering
 
-Shallow rendering lets you render a component "one level deep" and assert facts about what its render method returns, without worrying about the behavior of child components, which are not instantiated or rendered. This does not require a DOM.
+When writing unit tests for React, shallow rendering can be helpful. Shallow rendering lets you render a component "one level deep" and assert facts about what its render method returns, without worrying about the behavior of child components, which are not instantiated or rendered. This does not require a DOM.
 
  - [`shallowRenderer.render()`](#shallowrenderer.render)
  - [`shallowRenderer.getRenderOutput()`](#shallowrenderer.getrenderoutput)
@@ -57,4 +57,3 @@ Shallow testing currently has some limitations, namely not supporting refs.
 
 We also recommend checking out Enzyme's [Shallow Rendering API](http://airbnb.io/enzyme/docs/api/shallow.html). It provides a nicer higher-level API over the same functionality.
 
-* * *

--- a/docs/docs/addons-test-utils.md
+++ b/docs/docs/addons-test-utils.md
@@ -2,8 +2,6 @@
 id: test-utils
 title: Test Utilities
 permalink: docs/test-utils.html
-layout: docs
-category: Reference
 ---
 
 **Importing**

--- a/docs/docs/addons-test-utils.md
+++ b/docs/docs/addons-test-utils.md
@@ -39,6 +39,11 @@ var ReactTestUtils = require('react-dom/test-utils'); // ES5 with npm
 
 ## Reference
 
+## Shallow Rendering
+
+> Note:
+> The shallow renderer has moved to `react-test-renderer/shallow`. [Please see the updated documentation.](/react/docs/shallow-renderer.html)
+
 ### `Simulate`
 
 ```javascript
@@ -250,7 +255,3 @@ Same as [`scryRenderedComponentsWithType()`](#scryrenderedcomponentswithtype) bu
 
 * * *
 
-## Shallow Rendering
-
-> Note:
-> The shallow renderer has moved to `react-test-renderer/shallow`. [Please see the updated documents.](/react/docs/shallow-renderer.html)

--- a/docs/docs/addons-test-utils.md
+++ b/docs/docs/addons-test-utils.md
@@ -2,6 +2,8 @@
 id: test-utils
 title: Test Utilities
 permalink: docs/test-utils.html
+layout: docs
+category: Reference
 ---
 
 **Importing**

--- a/docs/docs/addons-test-utils.md
+++ b/docs/docs/addons-test-utils.md
@@ -252,32 +252,5 @@ Same as [`scryRenderedComponentsWithType()`](#scryrenderedcomponentswithtype) bu
 
 ## Shallow Rendering
 
-### `createRenderer()`
-
-```javascript
-createRenderer()
-```
-
-Call this in your tests to create a [shallow renderer](#shallow-rendering).
-
-* * *
-
-### `shallowRenderer.render()`
-
-```javascript
-shallowRenderer.render(
-  element
-)
-```
-
-Similar to [`ReactDOM.render`](/react/docs/react-dom.html#render) but it doesn't require DOM and only renders a single level deep. See [Shallow Rendering](#shallow-rendering).
-
-* * *
-
-### `shallowRenderer.getRenderOutput()`
-
-```javascript
-shallowRenderer.getRenderOutput()
-```
-
-After [`shallowRenderer.render()`](#shallowrenderer.render) has been called, returns shallowly rendered output.
+> Note:
+> The shallow renderer has moved to `react-test-renderer/shallow`. [Please see the updated documents.](/react/docs/shallow-renderer.html)


### PR DESCRIPTION
**why make this change?:**
We accidentally removed this - still supporting the use of Test Utilities, so we should have them in the docs.

**test plan:**
Manually tested the website - will insert a screenshot.

**issue:**
https://github.com/facebook/react/issues/9651