### PR TITLE
Provide non-standard stack with invalid type warnings

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -3,6 +3,8 @@
 <PROJECT_ROOT>/examples/.*
 <PROJECT_ROOT>/fixtures/.*
 <PROJECT_ROOT>/build/.*
+<PROJECT_ROOT>/node_modules/chrome-devtools-frontend/.*
+<PROJECT_ROOT>/.*/node_modules/chrome-devtools-frontend/.*
 <PROJECT_ROOT>/.*/node_modules/y18n/.*
 <PROJECT_ROOT>/.*/__mocks__/.*
 <PROJECT_ROOT>/.*/__tests__/.*

--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -223,6 +223,12 @@ var ReactElementValidator = {
 
         info += ReactComponentTreeHook.getCurrentStackAddendum();
 
+        var currentSource = props !== null &&
+          props !== undefined &&
+          props.__source !== undefined
+          ? props.__source
+          : null;
+        ReactComponentTreeHook.pushNonStandardWarningStack(true, currentSource);
         warning(
           false,
           'React.createElement: type is invalid -- expected a string (for ' +
@@ -231,6 +237,7 @@ var ReactElementValidator = {
           type == null ? type : typeof type,
           info,
         );
+        ReactComponentTreeHook.popNonStandardWarningStack();
       }
     }
 

--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -228,7 +228,11 @@ var ReactElementValidator = {
           props.__source !== undefined
           ? props.__source
           : null;
-        ReactComponentTreeHook.pushNonStandardWarningStack(true, currentSource);
+        ReactComponentTreeHook.pushNonStandardWarningStack(
+          true,
+          true,
+          currentSource,
+        );
         warning(
           false,
           'React.createElement: type is invalid -- expected a string (for ' +

--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -228,11 +228,7 @@ var ReactElementValidator = {
           props.__source !== undefined
           ? props.__source
           : null;
-        ReactComponentTreeHook.pushNonStandardWarningStack(
-          true,
-          true,
-          currentSource,
-        );
+        ReactComponentTreeHook.pushNonStandardWarningStack(true, currentSource);
         warning(
           false,
           'React.createElement: type is invalid -- expected a string (for ' +

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -526,7 +526,7 @@ describe('ReactElementValidator', () => {
     );
   });
 
-  it('provides stack via non-standard console.stack for invalid types', () => {
+  it('provides stack via non-standard console.reactStack for invalid types', () => {
     spyOn(console, 'error');
 
     function Foo() {
@@ -539,8 +539,8 @@ describe('ReactElementValidator', () => {
     }
 
     try {
-      console.stack = jest.fn();
-      console.stackEnd = jest.fn();
+      console.reactStack = jest.fn();
+      console.reactStackEnd = jest.fn();
 
       expect(() => {
         ReactTestUtils.renderIntoDocument(React.createElement(App));
@@ -551,10 +551,10 @@ describe('ReactElementValidator', () => {
           'defined in. Check the render method of `Foo`.',
       );
 
-      expect(console.stack.mock.calls.length).toBe(1);
-      expect(console.stackEnd.mock.calls.length).toBe(1);
+      expect(console.reactStack.mock.calls.length).toBe(1);
+      expect(console.reactStackEnd.mock.calls.length).toBe(1);
 
-      var stack = console.stack.mock.calls[0][0];
+      var stack = console.reactStack.mock.calls[0][0];
       expect(Array.isArray(stack)).toBe(true);
       expect(stack.map(frame => frame.name)).toEqual([
         'Foo', // <Bad> is inside Foo
@@ -572,8 +572,8 @@ describe('ReactElementValidator', () => {
         null,
       ]);
     } finally {
-      delete console.stack;
-      delete console.stackEnd;
+      delete console.reactStack;
+      delete console.reactStackEnd;
     }
   });
 });

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -556,7 +556,7 @@ describe('ReactElementValidator', () => {
 
       var stack = console.stack.mock.calls[0][0];
       expect(Array.isArray(stack)).toBe(true);
-      expect(stack.map(frame => frame.functionName)).toEqual([
+      expect(stack.map(frame => frame.name)).toEqual([
         'Foo', // <Bad> is inside Foo
         'App', // <Foo> is inside App
         'App', // <div> is inside App

--- a/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElementValidator-test.js
@@ -562,12 +562,6 @@ describe('ReactElementValidator', () => {
         'App', // <div> is inside App
         null, // <App> is outside a component
       ]);
-      expect(stack.map(frame => frame.isPertinent)).toEqual([
-        true, // <Bad> caused the error
-        true, // <Foo> caused <Bad> to render
-        false, // <div> is not pertinent
-        true, // <App> caused <Foo> to render
-      ]);
       expect(
         stack.map(frame => frame.fileName && frame.fileName.slice(-8)),
       ).toEqual([null, null, null, null]);

--- a/src/isomorphic/hooks/ReactComponentTreeHook.js
+++ b/src/isomorphic/hooks/ReactComponentTreeHook.js
@@ -407,7 +407,7 @@ var ReactComponentTreeHook = {
     isCreatingElement: boolean,
     currentSource: ?Source,
   ) {
-    if (typeof console.stack !== 'function') {
+    if (typeof console.reactStack !== 'function') {
       return;
     }
 
@@ -444,14 +444,14 @@ var ReactComponentTreeHook = {
       // Stop building the stack (it's just a nice to have).
     }
 
-    console.stack(stack);
+    console.reactStack(stack);
   },
 
   popNonStandardWarningStack() {
-    if (typeof console.stackEnd !== 'function') {
+    if (typeof console.reactStackEnd !== 'function') {
       return;
     }
-    console.stackEnd();
+    console.reactStackEnd();
   },
 };
 

--- a/src/isomorphic/hooks/ReactComponentTreeHook.js
+++ b/src/isomorphic/hooks/ReactComponentTreeHook.js
@@ -405,7 +405,6 @@ var ReactComponentTreeHook = {
 
   pushNonStandardWarningStack(
     isCreatingElement: boolean,
-    isOwnerChainPertinent: boolean,
     currentSource: ?Source,
   ) {
     if (typeof console.stack !== 'function') {
@@ -415,12 +414,10 @@ var ReactComponentTreeHook = {
     var stack = [];
     var currentOwner = ReactCurrentOwner.current;
     var id = currentOwner && currentOwner._debugID;
-    var nextIDInOwnerChain = id;
 
     try {
       if (isCreatingElement) {
         stack.push({
-          isPertinent: true,
           functionName: id ? ReactComponentTreeHook.getDisplayName(id) : null,
           fileName: currentSource ? currentSource.fileName : null,
           lineNumber: currentSource ? currentSource.lineNumber : null,
@@ -435,19 +432,11 @@ var ReactComponentTreeHook = {
           ? ReactComponentTreeHook.getDisplayName(ownerID)
           : null;
         var source = element && element._source;
-        // For some warnings, only the owner chain is pertinent
-        var isPertintent = isOwnerChainPertinent
-          ? nextIDInOwnerChain === id || !nextIDInOwnerChain
-          : true;
         stack.push({
-          isPertinent: isPertintent,
           functionName: ownerName,
           fileName: source ? source.fileName : null,
           lineNumber: source ? source.lineNumber : null,
         });
-        if (isOwnerChainPertinent && isPertintent) {
-          nextIDInOwnerChain = ownerID;
-        }
         id = parentID;
       }
     } catch (err) {

--- a/src/isomorphic/hooks/ReactComponentTreeHook.js
+++ b/src/isomorphic/hooks/ReactComponentTreeHook.js
@@ -418,7 +418,7 @@ var ReactComponentTreeHook = {
     try {
       if (isCreatingElement) {
         stack.push({
-          functionName: id ? ReactComponentTreeHook.getDisplayName(id) : null,
+          name: id ? ReactComponentTreeHook.getDisplayName(id) : null,
           fileName: currentSource ? currentSource.fileName : null,
           lineNumber: currentSource ? currentSource.lineNumber : null,
         });
@@ -433,7 +433,7 @@ var ReactComponentTreeHook = {
           : null;
         var source = element && element._source;
         stack.push({
-          functionName: ownerName,
+          name: ownerName,
           fileName: source ? source.fileName : null,
           lineNumber: source ? source.lineNumber : null,
         });

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -431,7 +431,7 @@ describe('ReactJSXElementValidator', () => {
 
       var stack = console.stack.mock.calls[0][0];
       expect(Array.isArray(stack)).toBe(true);
-      expect(stack.map(frame => frame.functionName)).toEqual([
+      expect(stack.map(frame => frame.name)).toEqual([
         'Foo', // <Bad> is inside Foo
         'App', // <Foo> is inside App
         'App', // <div> is inside App

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -400,4 +400,53 @@ describe('ReactJSXElementValidator', () => {
         ' Use a static property named `defaultProps` instead.',
     );
   });
+
+  it('provides stack via non-standard console.stack for invalid types', () => {
+    spyOn(console, 'error');
+
+    function Foo() {
+      var Bad = undefined;
+      return <Bad />;
+    }
+
+    function App() {
+      return <Foo />;
+    }
+
+    try {
+      console.stack = jest.fn();
+      console.stackEnd = jest.fn();
+
+      expect(() => {
+        ReactTestUtils.renderIntoDocument(<App />);
+      }).toThrow(
+        'Element type is invalid: expected a string (for built-in components) ' +
+          'or a class/function (for composite components) but got: undefined. ' +
+          "You likely forgot to export your component from the file it's " +
+          'defined in. Check the render method of `Foo`.',
+      );
+
+      expect(console.stack.mock.calls.length).toBe(1);
+      expect(console.stackEnd.mock.calls.length).toBe(1);
+
+      var stack = console.stack.mock.calls[0][0];
+      expect(Array.isArray(stack)).toBe(true);
+      expect(stack.map(frame => frame.functionName)).toEqual([
+        'Foo',
+        'App',
+        null,
+      ]);
+      expect(
+        stack.map(frame => frame.fileName && frame.fileName.slice(-8)),
+      ).toEqual(['-test.js', '-test.js', '-test.js']);
+      expect(stack.map(frame => typeof frame.lineNumber)).toEqual([
+        'number',
+        'number',
+        'number',
+      ]);
+    } finally {
+      delete console.stack;
+      delete console.stackEnd;
+    }
+  });
 });

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -410,7 +410,7 @@ describe('ReactJSXElementValidator', () => {
     }
 
     function App() {
-      return <Foo />;
+      return <div><Foo /></div>;
     }
 
     try {
@@ -432,14 +432,22 @@ describe('ReactJSXElementValidator', () => {
       var stack = console.stack.mock.calls[0][0];
       expect(Array.isArray(stack)).toBe(true);
       expect(stack.map(frame => frame.functionName)).toEqual([
-        'Foo',
-        'App',
-        null,
+        'Foo', // <Bad> is inside Foo
+        'App', // <Foo> is inside App
+        'App', // <div> is inside App
+        null, // <App> is outside a component
+      ]);
+      expect(stack.map(frame => frame.isPertinent)).toEqual([
+        true, // <Bad> caused the error
+        true, // <Foo> caused <Bad> to render
+        false, // <div> is unrelated
+        true, // <App> caused <Foo> to render
       ]);
       expect(
         stack.map(frame => frame.fileName && frame.fileName.slice(-8)),
-      ).toEqual(['-test.js', '-test.js', '-test.js']);
+      ).toEqual(['-test.js', '-test.js', '-test.js', '-test.js']);
       expect(stack.map(frame => typeof frame.lineNumber)).toEqual([
+        'number',
         'number',
         'number',
         'number',

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -437,12 +437,6 @@ describe('ReactJSXElementValidator', () => {
         'App', // <div> is inside App
         null, // <App> is outside a component
       ]);
-      expect(stack.map(frame => frame.isPertinent)).toEqual([
-        true, // <Bad> caused the error
-        true, // <Foo> caused <Bad> to render
-        false, // <div> is unrelated
-        true, // <App> caused <Foo> to render
-      ]);
       expect(
         stack.map(frame => frame.fileName && frame.fileName.slice(-8)),
       ).toEqual(['-test.js', '-test.js', '-test.js', '-test.js']);

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -401,7 +401,7 @@ describe('ReactJSXElementValidator', () => {
     );
   });
 
-  it('provides stack via non-standard console.stack for invalid types', () => {
+  it('provides stack via non-standard console.reactStack for invalid types', () => {
     spyOn(console, 'error');
 
     function Foo() {
@@ -414,8 +414,8 @@ describe('ReactJSXElementValidator', () => {
     }
 
     try {
-      console.stack = jest.fn();
-      console.stackEnd = jest.fn();
+      console.reactStack = jest.fn();
+      console.reactStackEnd = jest.fn();
 
       expect(() => {
         ReactTestUtils.renderIntoDocument(<App />);
@@ -426,10 +426,10 @@ describe('ReactJSXElementValidator', () => {
           'defined in. Check the render method of `Foo`.',
       );
 
-      expect(console.stack.mock.calls.length).toBe(1);
-      expect(console.stackEnd.mock.calls.length).toBe(1);
+      expect(console.reactStack.mock.calls.length).toBe(1);
+      expect(console.reactStackEnd.mock.calls.length).toBe(1);
 
-      var stack = console.stack.mock.calls[0][0];
+      var stack = console.reactStack.mock.calls[0][0];
       expect(Array.isArray(stack)).toBe(true);
       expect(stack.map(frame => frame.name)).toEqual([
         'Foo', // <Bad> is inside Foo
@@ -447,8 +447,8 @@ describe('ReactJSXElementValidator', () => {
         'number',
       ]);
     } finally {
-      delete console.stack;
-      delete console.stackEnd;
+      delete console.reactStack;
+      delete console.reactStackEnd;
     }
   });
 });


### PR DESCRIPTION
I need rich information with full filenames for Create React App so I can show component stack prominently and map it back to source snippets.

Ideally I want it for all warnings, but the "invalid type" is the most common and useful one, and I'd like to start with it. I'm sending this against 15.6 because I want to get it in soon, and start iterating on this idea. Maybe we'll drop it in 16, or maybe not. I want to play with it for a while. If it works well I’ll send another PR against master later to do this in a more generic way.

The stack object format is `Array<{fileName: string | null, lineNumber: number | null, functionName: string | null}>`. `console.stack()` and `console.stackEnd()` does not really exist, but we’ll define it in CRA environment, and possibly in RN in the future. If it works well we can look at proposing a standard since it can be useful for other use cases too.