### PR TITLE
Caution (in docs) against dispatching redux actions or triggering component updates by any other means in `componentWillUpdate`

### DIFF
--- a/docs/docs/reference-react-component.md
+++ b/docs/docs/reference-react-component.md
@@ -192,7 +192,7 @@ componentWillUpdate(nextProps, nextState)
 
 `componentWillUpdate()` is invoked immediately before rendering when new props or state are being received. Use this as an opportunity to perform preparation before an update occurs. This method is not called for the initial render.
 
-Note that you cannot call `this.setState()` here. If you need to update state in response to a prop change, use `componentWillReceiveProps()` instead.
+Note that you cannot call `this.setState()` here; nor should you do anything else (for example, dispatching redux actions) that would trigger an update to any React component before `componentWillUpdate` returns. If you need to update state in response to a prop change, use `componentWillReceiveProps()` instead.
 
 > Note
 >


### PR DESCRIPTION
I just experienced really confusing errors that were happening because of an old component I wrote that was dispatching Redux actions during its `componentWillUpdate`.  The docs only warn that we can't call `setState` during `componentWillUpdate`, but I assume that causing component updates by any other means is likewise a bad idea, so I want to warn other devs about it in the official docs.