### PR TITLE
Refactor progressed work model

### DIFF
--- a/fixtures/fiber-triangle/index.html
+++ b/fixtures/fiber-triangle/index.html
@@ -26,6 +26,7 @@
         font: 'normal 15px sans-serif',
         textAlign: 'center',
         cursor: 'pointer',
+        color: 'white',
       };
 
       var containerStyle = {
@@ -39,6 +40,10 @@
       };
 
       var targetSize = 25;
+
+      let dotCount = 0;
+
+      const colors = ['red', 'blue', 'green', 'orange', 'purple', 'black'];
 
       class Dot extends React.Component {
         constructor() {
@@ -66,11 +71,12 @@
             top: (props.y) + 'px',
             borderRadius: (s / 2) + 'px',
             lineHeight: (s) + 'px',
-            background: this.state.hover ? '#ff0' : dotStyle.background
+            background: this.state.hover ? '#ff0' : colors[props.text % colors.length],
+            color: this.state.hover ? 'black' : dotStyle.color,
           };
           return (
-            <div style={style} onMouseEnter={() => this.enter()} onMouseLeave={() => this.leave()}>
-              {this.state.hover ? '*' + props.text + '*' : props.text}
+            <div ref={div => this.div = div} style={style} onMouseEnter={() => this.enter()} onMouseLeave={() => this.leave()}>
+              {this.state.hover ? `*${props.text}*` : props.text}
             </div>
           );
         }

--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -3,3 +3,6 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * should not blow away user-entered text on successful reconnect to a controlled checkbox
 * should not blow away user-selected value on successful reconnect to an uncontrolled select
 * should not blow away user-selected value on successful reconnect to an controlled select
+
+src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
+* resumes work by comparing the priority at which the work-in-progress was created/updated

--- a/scripts/fiber/tests-passing-except-dev.txt
+++ b/scripts/fiber/tests-passing-except-dev.txt
@@ -86,12 +86,6 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a div with a single child surrounded by whitespace with client render on top of bad server markup
 * renders >,<, and & as single child with client render on top of bad server markup
 * renders >,<, and & as multiple children with client render on top of bad server markup
-* throws when rendering a string component with clean client render
-* throws when rendering a string component with client render on top of bad server markup
-* throws when rendering an undefined component with clean client render
-* throws when rendering an undefined component with client render on top of bad server markup
-* throws when rendering a number component with clean client render
-* throws when rendering a number component with client render on top of bad server markup
 * renders an input with a value and an onChange with client render on top of bad server markup
 * renders an input with a value and readOnly with client render on top of bad server markup
 * renders an input with a value and no onChange/readOnly with client render on top of bad server markup

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1875,6 +1875,9 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
 * invokes ref callbacks after insertion/update/unmount
 * supports string refs
 
+src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
+* works
+
 src/renderers/shared/fiber/__tests__/ReactIncrementalUpdates-test.js
 * applies updates in order of priority
 * applies updates with equal priority in insertion order

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1866,6 +1866,8 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
 * can defer side-effects and resume them later on
 * can defer side-effects and reuse them later - complex
 * deprioritizes setStates that happens within a deprioritized tree
+* does not drop priority from a progressed subtree
+* does not complete already completed work
 * calls callback after update is flushed
 * calls setState callback even if component bails out
 * calls componentWillUnmount after a deletion, even if nested

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1877,6 +1877,7 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
 * works
+* fuzz tester
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalUpdates-test.js
 * applies updates in order of priority

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1877,7 +1877,6 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
 * works
-* fuzz tester
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalUpdates-test.js
 * applies updates in order of priority

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1121,8 +1121,14 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders >,<, and & as multiple children with clean client render
 * renders >,<, and & as multiple children with client render on top of good server markup
 * throws when rendering a string component with server string render
+* throws when rendering a string component with clean client render
+* throws when rendering a string component with client render on top of bad server markup
 * throws when rendering an undefined component with server string render
+* throws when rendering an undefined component with clean client render
+* throws when rendering an undefined component with client render on top of bad server markup
 * throws when rendering a number component with server string render
+* throws when rendering a number component with clean client render
+* throws when rendering a number component with client render on top of bad server markup
 * throws when rendering null with server string render
 * throws when rendering null with clean client render
 * throws when rendering null with client render on top of bad server markup

--- a/src/renderers/__tests__/ReactComponent-test.js
+++ b/src/renderers/__tests__/ReactComponent-test.js
@@ -44,7 +44,12 @@ describe('ReactComponent', () => {
     var instance = <div ref="badDiv" />;
     expect(function() {
       instance = ReactTestUtils.renderIntoDocument(instance);
-    }).toThrow();
+    }).toThrow(
+      'Only a ReactOwner can have refs. You might be adding a ref to a ' +
+        "component that was not created inside a component's `render` " +
+        'method, or you have multiple copies of React loaded (details: ' +
+        'https://fb.me/react-refs-must-have-owner).'
+    );
   });
 
   it('should warn when children are mutated during render', () => {

--- a/src/renderers/__tests__/ReactComponent-test.js
+++ b/src/renderers/__tests__/ReactComponent-test.js
@@ -48,7 +48,7 @@ describe('ReactComponent', () => {
       'Only a ReactOwner can have refs. You might be adding a ref to a ' +
         "component that was not created inside a component's `render` " +
         'method, or you have multiple copies of React loaded (details: ' +
-        'https://fb.me/react-refs-must-have-owner).'
+        'https://fb.me/react-refs-must-have-owner).',
     );
   });
 

--- a/src/renderers/dom/fiber/ReactDOMFiber.js
+++ b/src/renderers/dom/fiber/ReactDOMFiber.js
@@ -115,7 +115,9 @@ function getReactRootElementInContainer(container: any) {
 
 function shouldReuseContent(container) {
   const rootElement = getReactRootElementInContainer(container);
-  return !!(rootElement && rootElement.getAttribute(ID_ATTRIBUTE_NAME));
+  return !!(rootElement &&
+    rootElement.nodeType === ELEMENT_NODE &&
+    rootElement.getAttribute(ID_ATTRIBUTE_NAME));
 }
 
 function shouldAutoFocusHostComponent(type: string, props: Props): boolean {

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -377,8 +377,7 @@ var ReactNoop = {
       if (fiber.updateQueue) {
         logUpdateQueue(fiber.updateQueue, depth);
       }
-      const progressedWork = fiber.progressedWork;
-      const childInProgress = progressedWork !== null ? progressedWork.child : fiber.child;
+      const childInProgress = fiber.progressedWork.child;
       if (childInProgress && childInProgress !== fiber.child) {
         log(
           '  '.repeat(depth + 1) + 'IN PROGRESS: ' + fiber.progressedPriority,

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -377,7 +377,8 @@ var ReactNoop = {
       if (fiber.updateQueue) {
         logUpdateQueue(fiber.updateQueue, depth);
       }
-      const childInProgress = fiber.progressedChild;
+      const progressedWork = fiber.progressedWork;
+      const childInProgress = progressedWork !== null ? progressedWork.child : fiber.child;
       if (childInProgress && childInProgress !== fiber.child) {
         log(
           '  '.repeat(depth + 1) + 'IN PROGRESS: ' + fiber.progressedPriority,

--- a/src/renderers/noop/ReactNoop.js
+++ b/src/renderers/noop/ReactNoop.js
@@ -300,6 +300,28 @@ var ReactNoop = {
     ReactNoop.flushDeferredPri();
   },
 
+  flushUnitsOfWork(n: number) {
+    const cb = scheduledDeferredCallback;
+    if (cb !== null) {
+      scheduledDeferredCallback = null;
+      let unitsRemaining = n;
+      cb({
+        timeRemaining() {
+          if (unitsRemaining-- > 0) {
+            return 999;
+          }
+          return 0;
+        },
+      });
+    }
+
+    const animationCb = scheduledAnimationCallback;
+    if (animationCb !== null) {
+      scheduledAnimationCallback = null;
+      animationCb();
+    }
+  },
+
   performAnimationWork(fn: Function) {
     NoopRenderer.performWithPriority(AnimationPriority, fn);
   },

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -106,9 +106,9 @@ function coerceRef(current: Fiber | null, element: ReactElement) {
     invariant(
       owner != null,
       'Only a ReactOwner can have refs. You might be adding a ref to a ' +
-      "component that was not created inside a component's `render` " +
-      'method, or you have multiple copies of React loaded (details: ' +
-      'https://fb.me/react-refs-must-have-owner).',
+        "component that was not created inside a component's `render` " +
+        'method, or you have multiple copies of React loaded (details: ' +
+        'https://fb.me/react-refs-must-have-owner).',
     );
     let inst;
     if (owner) {
@@ -144,7 +144,7 @@ function coerceRef(current: Fiber | null, element: ReactElement) {
         // TODO: Comparison to emptyObject always fails. Don't know why.
         // inst.refs !== emptyObject ? inst.refs : (inst.refs = {});
         typeof Object.isExtensible === 'function' &&
-        Object.isExtensible(inst.refs)
+          Object.isExtensible(inst.refs)
           ? inst.refs
           : (inst.refs = {});
       if (value === null) {
@@ -252,7 +252,11 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     return existingChildren;
   }
 
-  function useFiber(fiber: Fiber, priority: PriorityLevel, pendingProps: mixed): Fiber {
+  function useFiber(
+    fiber: Fiber,
+    priority: PriorityLevel,
+    pendingProps: mixed,
+  ): Fiber {
     // We currently set sibling to null and index to 0 here because it is easy
     // to forget to do before returning it. E.g. for the single child case.
     if (shouldClone) {

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -28,6 +28,7 @@ var ReactTypeOfWork = require('ReactTypeOfWork');
 
 var getIteratorFn = require('getIteratorFn');
 var invariant = require('fbjs/lib/invariant');
+var emptyObject = require('fbjs/lib/emptyObject');
 var ReactFeatureFlags = require('ReactFeatureFlags');
 
 if (__DEV__) {
@@ -399,7 +400,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       return created;
     } else {
       // Move based on index
-      const existing = useFiber(current, priority, null);
+      const existing = useFiber(current, priority, emptyObject);
       existing.type = yieldNode.value;
       existing.return = returnFiber;
       return existing;
@@ -1159,7 +1160,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     if (child !== null) {
       if (child.tag === YieldComponent) {
         deleteRemainingChildren(returnFiber, child.sibling);
-        const existing = useFiber(child, priority, null);
+        const existing = useFiber(child, priority, emptyObject);
         existing.type = yieldNode.value;
         existing.return = returnFiber;
         return existing;

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -26,7 +26,6 @@ var ReactFiber = require('ReactFiber');
 var ReactTypeOfSideEffect = require('ReactTypeOfSideEffect');
 var ReactTypeOfWork = require('ReactTypeOfWork');
 
-var emptyObject = require('fbjs/lib/emptyObject');
 var getIteratorFn = require('getIteratorFn');
 var invariant = require('fbjs/lib/invariant');
 var ReactFeatureFlags = require('ReactFeatureFlags');
@@ -140,7 +139,13 @@ function coerceRef(current: Fiber | null, element: ReactElement) {
       return current.ref;
     }
     const ref = function(value) {
-      const refs = inst.refs === emptyObject ? (inst.refs = {}) : inst.refs;
+      const refs =
+        // TODO: Comparison to emptyObject always fails. Don't know why.
+        // inst.refs !== emptyObject ? inst.refs : (inst.refs = {});
+        typeof Object.isExtensible === 'function' &&
+        Object.isExtensible(inst.refs)
+          ? inst.refs
+          : (inst.refs = {});
       if (value === null) {
         delete refs[stringRef];
       } else {

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -16,7 +16,6 @@ import type {ReactElement} from 'ReactElementType';
 import type {ReactCoroutine, ReactPortal, ReactYield} from 'ReactTypes';
 import type {Fiber} from 'ReactFiber';
 import type {ReactInstance} from 'ReactInstanceType';
-import type {PriorityLevel} from 'ReactPriorityLevel';
 
 var REACT_ELEMENT_TYPE = require('ReactElementSymbol');
 var {REACT_COROUTINE_TYPE, REACT_YIELD_TYPE} = require('ReactCoroutine');
@@ -252,15 +251,11 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     return existingChildren;
   }
 
-  function useFiber(
-    fiber: Fiber,
-    priority: PriorityLevel,
-    pendingProps: mixed,
-  ): Fiber {
+  function useFiber(fiber: Fiber, pendingProps: mixed): Fiber {
     // We currently set sibling to null and index to 0 here because it is easy
     // to forget to do before returning it. E.g. for the single child case.
     if (shouldClone) {
-      const clone = createWorkInProgress(fiber, priority, pendingProps);
+      const clone = createWorkInProgress(fiber, pendingProps);
       clone.index = 0;
       clone.sibling = null;
       return clone;
@@ -314,20 +309,18 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     returnFiber: Fiber,
     current: Fiber | null,
     textContent: string,
-    priority: PriorityLevel,
   ) {
     if (current === null || current.tag !== HostText) {
       // Insert
       const created = createFiberFromText(
         textContent,
         returnFiber.internalContextTag,
-        priority,
       );
       created.return = returnFiber;
       return created;
     } else {
       // Update
-      const existing = useFiber(current, priority, textContent);
+      const existing = useFiber(current, textContent);
       existing.return = returnFiber;
       return existing;
     }
@@ -337,21 +330,19 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     returnFiber: Fiber,
     current: Fiber | null,
     element: ReactElement,
-    priority: PriorityLevel,
   ): Fiber {
     if (current === null || current.type !== element.type) {
       // Insert
       const created = createFiberFromElement(
         element,
         returnFiber.internalContextTag,
-        priority,
       );
       created.ref = coerceRef(current, element);
       created.return = returnFiber;
       return created;
     } else {
       // Move based on index
-      const existing = useFiber(current, priority, element.props);
+      const existing = useFiber(current, element.props);
       existing.ref = coerceRef(current, element);
       existing.return = returnFiber;
       if (__DEV__) {
@@ -366,7 +357,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     returnFiber: Fiber,
     current: Fiber | null,
     coroutine: ReactCoroutine,
-    priority: PriorityLevel,
   ): Fiber {
     // TODO: Should this also compare handler to determine whether to reuse?
     if (current === null || current.tag !== CoroutineComponent) {
@@ -374,13 +364,12 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       const created = createFiberFromCoroutine(
         coroutine,
         returnFiber.internalContextTag,
-        priority,
       );
       created.return = returnFiber;
       return created;
     } else {
       // Move based on index
-      const existing = useFiber(current, priority, coroutine);
+      const existing = useFiber(current, coroutine);
       existing.return = returnFiber;
       return existing;
     }
@@ -390,21 +379,19 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     returnFiber: Fiber,
     current: Fiber | null,
     yieldNode: ReactYield,
-    priority: PriorityLevel,
   ): Fiber {
     if (current === null || current.tag !== YieldComponent) {
       // Insert
       const created = createFiberFromYield(
         yieldNode,
         returnFiber.internalContextTag,
-        priority,
       );
       created.type = yieldNode.value;
       created.return = returnFiber;
       return created;
     } else {
       // Move based on index
-      const existing = useFiber(current, priority, emptyObject);
+      const existing = useFiber(current, emptyObject);
       existing.type = yieldNode.value;
       existing.return = returnFiber;
       return existing;
@@ -415,7 +402,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     returnFiber: Fiber,
     current: Fiber | null,
     portal: ReactPortal,
-    priority: PriorityLevel,
   ): Fiber {
     if (
       current === null ||
@@ -427,13 +413,12 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       const created = createFiberFromPortal(
         portal,
         returnFiber.internalContextTag,
-        priority,
       );
       created.return = returnFiber;
       return created;
     } else {
       // Update
-      const existing = useFiber(current, priority, portal.children || []);
+      const existing = useFiber(current, portal.children || []);
       existing.return = returnFiber;
       return existing;
     }
@@ -443,30 +428,24 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     returnFiber: Fiber,
     current: Fiber | null,
     fragment: Iterable<*>,
-    priority: PriorityLevel,
   ): Fiber {
     if (current === null || current.tag !== Fragment) {
       // Insert
       const created = createFiberFromFragment(
         fragment,
         returnFiber.internalContextTag,
-        priority,
       );
       created.return = returnFiber;
       return created;
     } else {
       // Update
-      const existing = useFiber(current, priority, fragment);
+      const existing = useFiber(current, fragment);
       existing.return = returnFiber;
       return existing;
     }
   }
 
-  function createChild(
-    returnFiber: Fiber,
-    newChild: any,
-    priority: PriorityLevel,
-  ): Fiber | null {
+  function createChild(returnFiber: Fiber, newChild: any): Fiber | null {
     if (typeof newChild === 'string' || typeof newChild === 'number') {
       // Text nodes doesn't have keys. If the previous node is implicitly keyed
       // we can continue to replace it without aborting even if it is not a text
@@ -474,7 +453,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       const created = createFiberFromText(
         '' + newChild,
         returnFiber.internalContextTag,
-        priority,
       );
       created.return = returnFiber;
       return created;
@@ -486,7 +464,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
           const created = createFiberFromElement(
             newChild,
             returnFiber.internalContextTag,
-            priority,
           );
           created.ref = coerceRef(null, newChild);
           created.return = returnFiber;
@@ -497,7 +474,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
           const created = createFiberFromCoroutine(
             newChild,
             returnFiber.internalContextTag,
-            priority,
           );
           created.return = returnFiber;
           return created;
@@ -507,7 +483,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
           const created = createFiberFromYield(
             newChild,
             returnFiber.internalContextTag,
-            priority,
           );
           created.type = newChild.value;
           created.return = returnFiber;
@@ -518,7 +493,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
           const created = createFiberFromPortal(
             newChild,
             returnFiber.internalContextTag,
-            priority,
           );
           created.return = returnFiber;
           return created;
@@ -529,7 +503,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         const created = createFiberFromFragment(
           newChild,
           returnFiber.internalContextTag,
-          priority,
         );
         created.return = returnFiber;
         return created;
@@ -545,7 +518,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     returnFiber: Fiber,
     oldFiber: Fiber | null,
     newChild: any,
-    priority: PriorityLevel,
   ): Fiber | null {
     // Update the fiber if the keys match, otherwise return null.
 
@@ -558,14 +530,14 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       if (key !== null) {
         return null;
       }
-      return updateTextNode(returnFiber, oldFiber, '' + newChild, priority);
+      return updateTextNode(returnFiber, oldFiber, '' + newChild);
     }
 
     if (typeof newChild === 'object' && newChild !== null) {
       switch (newChild.$$typeof) {
         case REACT_ELEMENT_TYPE: {
           if (newChild.key === key) {
-            return updateElement(returnFiber, oldFiber, newChild, priority);
+            return updateElement(returnFiber, oldFiber, newChild);
           } else {
             return null;
           }
@@ -573,7 +545,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
         case REACT_COROUTINE_TYPE: {
           if (newChild.key === key) {
-            return updateCoroutine(returnFiber, oldFiber, newChild, priority);
+            return updateCoroutine(returnFiber, oldFiber, newChild);
           } else {
             return null;
           }
@@ -584,7 +556,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
           // we can continue to replace it without aborting even if it is not a
           // yield.
           if (key === null) {
-            return updateYield(returnFiber, oldFiber, newChild, priority);
+            return updateYield(returnFiber, oldFiber, newChild);
           } else {
             return null;
           }
@@ -592,7 +564,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
         case REACT_PORTAL_TYPE: {
           if (newChild.key === key) {
-            return updatePortal(returnFiber, oldFiber, newChild, priority);
+            return updatePortal(returnFiber, oldFiber, newChild);
           } else {
             return null;
           }
@@ -605,7 +577,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         if (key !== null) {
           return null;
         }
-        return updateFragment(returnFiber, oldFiber, newChild, priority);
+        return updateFragment(returnFiber, oldFiber, newChild);
       }
 
       throwOnInvalidObjectType(returnFiber, newChild);
@@ -619,13 +591,12 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     returnFiber: Fiber,
     newIdx: number,
     newChild: any,
-    priority: PriorityLevel,
   ): Fiber | null {
     if (typeof newChild === 'string' || typeof newChild === 'number') {
       // Text nodes doesn't have keys, so we neither have to check the old nor
       // new node for the key. If both are text nodes, they match.
       const matchedFiber = existingChildren.get(newIdx) || null;
-      return updateTextNode(returnFiber, matchedFiber, '' + newChild, priority);
+      return updateTextNode(returnFiber, matchedFiber, '' + newChild);
     }
 
     if (typeof newChild === 'object' && newChild !== null) {
@@ -635,7 +606,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
             existingChildren.get(
               newChild.key === null ? newIdx : newChild.key,
             ) || null;
-          return updateElement(returnFiber, matchedFiber, newChild, priority);
+          return updateElement(returnFiber, matchedFiber, newChild);
         }
 
         case REACT_COROUTINE_TYPE: {
@@ -643,14 +614,14 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
             existingChildren.get(
               newChild.key === null ? newIdx : newChild.key,
             ) || null;
-          return updateCoroutine(returnFiber, matchedFiber, newChild, priority);
+          return updateCoroutine(returnFiber, matchedFiber, newChild);
         }
 
         case REACT_YIELD_TYPE: {
           // Yields doesn't have keys, so we neither have to check the old nor
           // new node for the key. If both are yields, they match.
           const matchedFiber = existingChildren.get(newIdx) || null;
-          return updateYield(returnFiber, matchedFiber, newChild, priority);
+          return updateYield(returnFiber, matchedFiber, newChild);
         }
 
         case REACT_PORTAL_TYPE: {
@@ -658,13 +629,13 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
             existingChildren.get(
               newChild.key === null ? newIdx : newChild.key,
             ) || null;
-          return updatePortal(returnFiber, matchedFiber, newChild, priority);
+          return updatePortal(returnFiber, matchedFiber, newChild);
         }
       }
 
       if (isArray(newChild) || getIteratorFn(newChild)) {
         const matchedFiber = existingChildren.get(newIdx) || null;
-        return updateFragment(returnFiber, matchedFiber, newChild, priority);
+        return updateFragment(returnFiber, matchedFiber, newChild);
       }
 
       throwOnInvalidObjectType(returnFiber, newChild);
@@ -722,7 +693,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     returnFiber: Fiber,
     currentFirstChild: Fiber | null,
     newChildren: Array<*>,
-    priority: PriorityLevel,
   ): Fiber | null {
     // This algorithm can't optimize by searching from boths ends since we
     // don't have backpointers on fibers. I'm trying to see how far we can get
@@ -766,12 +736,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       } else {
         nextOldFiber = oldFiber.sibling;
       }
-      const newFiber = updateSlot(
-        returnFiber,
-        oldFiber,
-        newChildren[newIdx],
-        priority,
-      );
+      const newFiber = updateSlot(returnFiber, oldFiber, newChildren[newIdx]);
       if (newFiber === null) {
         // TODO: This breaks on empty slots like null children. That's
         // unfortunate because it triggers the slow path all the time. We need
@@ -814,11 +779,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       // If we don't have any more existing children we can choose a fast path
       // since the rest will all be insertions.
       for (; newIdx < newChildren.length; newIdx++) {
-        const newFiber = createChild(
-          returnFiber,
-          newChildren[newIdx],
-          priority,
-        );
+        const newFiber = createChild(returnFiber, newChildren[newIdx]);
         if (!newFiber) {
           continue;
         }
@@ -844,7 +805,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         returnFiber,
         newIdx,
         newChildren[newIdx],
-        priority,
       );
       if (newFiber) {
         if (shouldTrackSideEffects) {
@@ -881,7 +841,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     returnFiber: Fiber,
     currentFirstChild: Fiber | null,
     newChildrenIterable: Iterable<*>,
-    priority: PriorityLevel,
   ): Fiber | null {
     // This is the same implementation as reconcileChildrenArray(),
     // but using the iterator instead.
@@ -945,7 +904,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       } else {
         nextOldFiber = oldFiber.sibling;
       }
-      const newFiber = updateSlot(returnFiber, oldFiber, step.value, priority);
+      const newFiber = updateSlot(returnFiber, oldFiber, step.value);
       if (newFiber === null) {
         // TODO: This breaks on empty slots like null children. That's
         // unfortunate because it triggers the slow path all the time. We need
@@ -988,7 +947,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       // If we don't have any more existing children we can choose a fast path
       // since the rest will all be insertions.
       for (; !step.done; newIdx++, (step = newChildren.next())) {
-        const newFiber = createChild(returnFiber, step.value, priority);
+        const newFiber = createChild(returnFiber, step.value);
         if (newFiber === null) {
           continue;
         }
@@ -1014,7 +973,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         returnFiber,
         newIdx,
         step.value,
-        priority,
       );
       if (newFiber !== null) {
         if (shouldTrackSideEffects) {
@@ -1051,7 +1009,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     returnFiber: Fiber,
     currentFirstChild: Fiber | null,
     textContent: string,
-    priority: PriorityLevel,
   ): Fiber {
     // There's no need to check for keys on text nodes since we don't have a
     // way to define them.
@@ -1059,7 +1016,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       // We already have an existing node so let's just update it and delete
       // the rest.
       deleteRemainingChildren(returnFiber, currentFirstChild.sibling);
-      const existing = useFiber(currentFirstChild, priority, textContent);
+      const existing = useFiber(currentFirstChild, textContent);
       existing.return = returnFiber;
       return existing;
     }
@@ -1069,7 +1026,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     const created = createFiberFromText(
       textContent,
       returnFiber.internalContextTag,
-      priority,
     );
     created.return = returnFiber;
     return created;
@@ -1079,7 +1035,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     returnFiber: Fiber,
     currentFirstChild: Fiber | null,
     element: ReactElement,
-    priority: PriorityLevel,
   ): Fiber {
     const key = element.key;
     let child = currentFirstChild;
@@ -1089,7 +1044,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       if (child.key === key) {
         if (child.type === element.type) {
           deleteRemainingChildren(returnFiber, child.sibling);
-          const existing = useFiber(child, priority, element.props);
+          const existing = useFiber(child, element.props);
           existing.ref = coerceRef(child, element);
           existing.return = returnFiber;
           if (__DEV__) {
@@ -1110,7 +1065,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     const created = createFiberFromElement(
       element,
       returnFiber.internalContextTag,
-      priority,
     );
     created.ref = coerceRef(currentFirstChild, element);
     created.return = returnFiber;
@@ -1121,7 +1075,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     returnFiber: Fiber,
     currentFirstChild: Fiber | null,
     coroutine: ReactCoroutine,
-    priority: PriorityLevel,
   ): Fiber {
     const key = coroutine.key;
     let child = currentFirstChild;
@@ -1131,7 +1084,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       if (child.key === key) {
         if (child.tag === CoroutineComponent) {
           deleteRemainingChildren(returnFiber, child.sibling);
-          const existing = useFiber(child, priority, coroutine);
+          const existing = useFiber(child, coroutine);
           existing.return = returnFiber;
           return existing;
         } else {
@@ -1147,7 +1100,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     const created = createFiberFromCoroutine(
       coroutine,
       returnFiber.internalContextTag,
-      priority,
     );
     created.return = returnFiber;
     return created;
@@ -1157,14 +1109,13 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     returnFiber: Fiber,
     currentFirstChild: Fiber | null,
     yieldNode: ReactYield,
-    priority: PriorityLevel,
   ): Fiber {
     // There's no need to check for keys on yields since they're stateless.
     let child = currentFirstChild;
     if (child !== null) {
       if (child.tag === YieldComponent) {
         deleteRemainingChildren(returnFiber, child.sibling);
-        const existing = useFiber(child, priority, emptyObject);
+        const existing = useFiber(child, emptyObject);
         existing.type = yieldNode.value;
         existing.return = returnFiber;
         return existing;
@@ -1176,7 +1127,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     const created = createFiberFromYield(
       yieldNode,
       returnFiber.internalContextTag,
-      priority,
     );
     created.type = yieldNode.value;
     created.return = returnFiber;
@@ -1187,7 +1137,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     returnFiber: Fiber,
     currentFirstChild: Fiber | null,
     portal: ReactPortal,
-    priority: PriorityLevel,
   ): Fiber {
     const key = portal.key;
     let child = currentFirstChild;
@@ -1201,7 +1150,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
           child.stateNode.implementation === portal.implementation
         ) {
           deleteRemainingChildren(returnFiber, child.sibling);
-          const existing = useFiber(child, priority, portal.children || []);
+          const existing = useFiber(child, portal.children || []);
           existing.return = returnFiber;
           return existing;
         } else {
@@ -1217,7 +1166,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     const created = createFiberFromPortal(
       portal,
       returnFiber.internalContextTag,
-      priority,
     );
     created.return = returnFiber;
     return created;
@@ -1230,7 +1178,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     returnFiber: Fiber,
     currentFirstChild: Fiber | null,
     newChild: any,
-    priority: PriorityLevel,
   ): Fiber | null {
     // This function is not recursive.
     // If the top level item is an array, we treat it as a set of children,
@@ -1253,34 +1200,19 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         switch (newChild.$$typeof) {
           case REACT_ELEMENT_TYPE:
             return placeSingleChild(
-              reconcileSingleElement(
-                returnFiber,
-                currentFirstChild,
-                newChild,
-                priority,
-              ),
+              reconcileSingleElement(returnFiber, currentFirstChild, newChild),
             );
 
           case REACT_PORTAL_TYPE:
             return placeSingleChild(
-              reconcileSinglePortal(
-                returnFiber,
-                currentFirstChild,
-                newChild,
-                priority,
-              ),
+              reconcileSinglePortal(returnFiber, currentFirstChild, newChild),
             );
         }
       } else {
         switch (newChild.$$typeof) {
           case REACT_ELEMENT_TYPE:
             return placeSingleChild(
-              reconcileSingleElement(
-                returnFiber,
-                currentFirstChild,
-                newChild,
-                priority,
-              ),
+              reconcileSingleElement(returnFiber, currentFirstChild, newChild),
             );
 
           case REACT_COROUTINE_TYPE:
@@ -1289,28 +1221,17 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
                 returnFiber,
                 currentFirstChild,
                 newChild,
-                priority,
               ),
             );
 
           case REACT_YIELD_TYPE:
             return placeSingleChild(
-              reconcileSingleYield(
-                returnFiber,
-                currentFirstChild,
-                newChild,
-                priority,
-              ),
+              reconcileSingleYield(returnFiber, currentFirstChild, newChild),
             );
 
           case REACT_PORTAL_TYPE:
             return placeSingleChild(
-              reconcileSinglePortal(
-                returnFiber,
-                currentFirstChild,
-                newChild,
-                priority,
-              ),
+              reconcileSinglePortal(returnFiber, currentFirstChild, newChild),
             );
         }
       }
@@ -1359,22 +1280,12 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
 
     if (typeof newChild === 'string' || typeof newChild === 'number') {
       return placeSingleChild(
-        reconcileSingleTextNode(
-          returnFiber,
-          currentFirstChild,
-          '' + newChild,
-          priority,
-        ),
+        reconcileSingleTextNode(returnFiber, currentFirstChild, '' + newChild),
       );
     }
 
     if (isArray(newChild)) {
-      return reconcileChildrenArray(
-        returnFiber,
-        currentFirstChild,
-        newChild,
-        priority,
-      );
+      return reconcileChildrenArray(returnFiber, currentFirstChild, newChild);
     }
 
     if (getIteratorFn(newChild)) {
@@ -1382,7 +1293,6 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         returnFiber,
         currentFirstChild,
         newChild,
-        priority,
       );
     }
 

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -241,15 +241,16 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     return existingChildren;
   }
 
-  function useFiber(fiber: Fiber, priority: PriorityLevel): Fiber {
+  function useFiber(fiber: Fiber, priority: PriorityLevel, pendingProps: mixed): Fiber {
     // We currently set sibling to null and index to 0 here because it is easy
     // to forget to do before returning it. E.g. for the single child case.
     if (shouldClone) {
-      const clone = createWorkInProgress(fiber, priority);
+      const clone = createWorkInProgress(fiber, priority, pendingProps);
       clone.index = 0;
       clone.sibling = null;
       return clone;
     } else {
+      fiber.pendingProps = pendingProps;
       fiber.effectTag = NoEffect;
       fiber.index = 0;
       fiber.sibling = null;
@@ -311,8 +312,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       return created;
     } else {
       // Update
-      const existing = useFiber(current, priority);
-      existing.pendingProps = textContent;
+      const existing = useFiber(current, priority, textContent);
       existing.return = returnFiber;
       return existing;
     }
@@ -336,9 +336,8 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       return created;
     } else {
       // Move based on index
-      const existing = useFiber(current, priority);
+      const existing = useFiber(current, priority, element.props);
       existing.ref = coerceRef(current, element);
-      existing.pendingProps = element.props;
       existing.return = returnFiber;
       if (__DEV__) {
         existing._debugSource = element._source;
@@ -366,8 +365,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       return created;
     } else {
       // Move based on index
-      const existing = useFiber(current, priority);
-      existing.pendingProps = coroutine;
+      const existing = useFiber(current, priority, coroutine);
       existing.return = returnFiber;
       return existing;
     }
@@ -391,7 +389,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       return created;
     } else {
       // Move based on index
-      const existing = useFiber(current, priority);
+      const existing = useFiber(current, priority, null);
       existing.type = yieldNode.value;
       existing.return = returnFiber;
       return existing;
@@ -420,8 +418,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       return created;
     } else {
       // Update
-      const existing = useFiber(current, priority);
-      existing.pendingProps = portal.children || [];
+      const existing = useFiber(current, priority, portal.children || []);
       existing.return = returnFiber;
       return existing;
     }
@@ -444,8 +441,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       return created;
     } else {
       // Update
-      const existing = useFiber(current, priority);
-      existing.pendingProps = fragment;
+      const existing = useFiber(current, priority, fragment);
       existing.return = returnFiber;
       return existing;
     }
@@ -1048,8 +1044,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       // We already have an existing node so let's just update it and delete
       // the rest.
       deleteRemainingChildren(returnFiber, currentFirstChild.sibling);
-      const existing = useFiber(currentFirstChild, priority);
-      existing.pendingProps = textContent;
+      const existing = useFiber(currentFirstChild, priority, textContent);
       existing.return = returnFiber;
       return existing;
     }
@@ -1079,9 +1074,8 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       if (child.key === key) {
         if (child.type === element.type) {
           deleteRemainingChildren(returnFiber, child.sibling);
-          const existing = useFiber(child, priority);
+          const existing = useFiber(child, priority, element.props);
           existing.ref = coerceRef(child, element);
-          existing.pendingProps = element.props;
           existing.return = returnFiber;
           if (__DEV__) {
             existing._debugSource = element._source;
@@ -1122,8 +1116,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       if (child.key === key) {
         if (child.tag === CoroutineComponent) {
           deleteRemainingChildren(returnFiber, child.sibling);
-          const existing = useFiber(child, priority);
-          existing.pendingProps = coroutine;
+          const existing = useFiber(child, priority, coroutine);
           existing.return = returnFiber;
           return existing;
         } else {
@@ -1156,7 +1149,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     if (child !== null) {
       if (child.tag === YieldComponent) {
         deleteRemainingChildren(returnFiber, child.sibling);
-        const existing = useFiber(child, priority);
+        const existing = useFiber(child, priority, null);
         existing.type = yieldNode.value;
         existing.return = returnFiber;
         return existing;
@@ -1193,8 +1186,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
           child.stateNode.implementation === portal.implementation
         ) {
           deleteRemainingChildren(returnFiber, child.sibling);
-          const existing = useFiber(child, priority);
-          existing.pendingProps = portal.children || [];
+          const existing = useFiber(child, priority, portal.children || []);
           existing.return = returnFiber;
           return existing;
         } else {

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -189,6 +189,8 @@ export type ProgressedWork = {
   memoizedProps: any,
   memoizedState: any,
   updateQueue: UpdateQueue | null,
+
+  pendingWorkPriority: PriorityLevel,
 };
 
 if (__DEV__) {
@@ -285,6 +287,7 @@ exports.createProgressedWorkFork = function(
   memoizedProps: any,
   memoizedState: any,
   updateQueue: UpdateQueue | null,
+  pendingWorkPriority: PriorityLevel,
 ): ProgressedWork {
   // ProgressedWork is a subset of Fiber. We use a separate Flow type to prevent
   // access of extra properties, but we use a whole Fiber for monomorphism.
@@ -300,6 +303,7 @@ exports.createProgressedWorkFork = function(
   progressedWork.memoizedProps = memoizedProps;
   progressedWork.memoizedState = memoizedState;
   progressedWork.updateQueue = updateQueue;
+  progressedWork.pendingWorkPriority = pendingWorkPriority;
   return progressedWork;
 };
 

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -532,7 +532,10 @@ type EffectList = {
   lastEffect: Fiber | null,
 };
 
-exports.transferEffectsToParent = function(returnFiber: EffectList, workInProgress: Fiber) {
+exports.transferEffectsToParent = function(
+  returnFiber: EffectList,
+  workInProgress: Fiber,
+) {
   // Append all the effects of the subtree and this fiber onto the effect
   // list of the parent. The completion order of the children affects the
   // side-effect order.
@@ -564,4 +567,4 @@ exports.transferEffectsToParent = function(returnFiber: EffectList, workInProgre
     }
     returnFiber.lastEffect = workInProgress;
   }
-}
+};

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -157,6 +157,7 @@ export type Fiber = {
   // progressed work or if it is better to continue from the current state.
   progressedPriority: PriorityLevel,
   progressedWork: ProgressedWork,
+  newestWork: Fiber,
 
   // This is a pooled version of a Fiber. Every fiber that gets updated will
   // eventually have a pair. There are cases when we can clean up pairs to save
@@ -247,11 +248,13 @@ var createFiber = function(
     // TODO: Express this circular reference properly
     progressedWork: (null: any),
     progressedPriority: NoWork,
+    newestWork: (null: any),
 
     alternate: null,
   };
 
   fiber.progressedWork = fiber;
+  fiber.newestWork = fiber;
 
   if (__DEV__) {
     fiber._debugID = debugCounter++;
@@ -304,6 +307,7 @@ exports.createWorkInProgress = function(
 
     workInProgress.progressedPriority = current.progressedPriority;
     workInProgress.progressedWork = current.progressedWork;
+    workInProgress.newestWork = current.newestWork;
 
     // Clone child from current.
     workInProgress.child = current.child;

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -339,6 +339,13 @@ exports.createWorkInProgress = function(
   return workInProgress;
 };
 
+exports.largerPriority = function(
+  p1: PriorityLevel,
+  p2: PriorityLevel,
+): PriorityLevel {
+  return p1 !== NoWork && (p2 === NoWork || p2 > p1) ? p1 : p2;
+};
+
 exports.createHostRootFiber = function(): Fiber {
   const fiber = createFiber(HostRoot, null, NoContext);
   return fiber;

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -297,7 +297,6 @@ exports.createProgressedWork = function(fiber: Fiber): ProgressedWork {
 // bails out.
 exports.createWorkInProgress = function(
   current: Fiber,
-  renderPriority: PriorityLevel,
   pendingProps: mixed,
 ): Fiber {
   // We use a double buffering pooling technique because we know that we'll only

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -278,17 +278,28 @@ function shouldConstruct(Component) {
   return !!(Component.prototype && Component.prototype.isReactComponent);
 }
 
-exports.createProgressedWork = function(fiber: Fiber): ProgressedWork {
-  let progressedWork = fiber._pooledProgressedWork;
-  if (progressedWork === null) {
-    progressedWork = {};
-  }
-  progressedWork.child = fiber.child;
-  progressedWork.firstDeletion = fiber.firstDeletion;
-  progressedWork.lastDeletion = fiber.lastDeletion;
-  progressedWork.memoizedProps = fiber.memoizedProps;
-  progressedWork.memoizedState = fiber.memoizedState;
-  progressedWork.updateQueue = fiber.updateQueue;
+exports.createProgressedWorkFork = function(
+  child: Fiber | null,
+  firstDeletion: Fiber | null,
+  lastDeletion: Fiber | null,
+  memoizedProps: any,
+  memoizedState: any,
+  updateQueue: UpdateQueue | null,
+): ProgressedWork {
+  // ProgressedWork is a subset of Fiber. We use a separate Flow type to prevent
+  // access of extra properties, but we use a whole Fiber for monomorphism.
+  const progressedWork = createFiber(
+    // The actual values here don't matter.
+    HostRoot,
+    null,
+    NoContext,
+  );
+  progressedWork.child = child;
+  progressedWork.firstDeletion = firstDeletion;
+  progressedWork.lastDeletion = lastDeletion;
+  progressedWork.memoizedProps = memoizedProps;
+  progressedWork.memoizedState = memoizedState;
+  progressedWork.updateQueue = updateQueue;
   return progressedWork;
 };
 

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -184,7 +184,6 @@ export type ProgressedWork = {
   memoizedProps: any,
   memoizedState: any,
   updateQueue: UpdateQueue | null,
-
 };
 
 if (__DEV__) {
@@ -209,7 +208,7 @@ var createFiber = function(
   key: null | string,
   internalContextTag: TypeOfInternalContext,
 ): Fiber {
-  var fiber : Fiber = {
+  var fiber: Fiber = {
     // Instance
 
     tag: tag,
@@ -246,7 +245,7 @@ var createFiber = function(
 
     pendingWorkPriority: NoWork,
     // TODO: Express this circular reference properly
-    progressedWork: (null : any),
+    progressedWork: (null: any),
     progressedPriority: NoWork,
 
     alternate: null,

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -284,11 +284,13 @@ exports.createProgressedWork = function(fiber: Fiber): ProgressedWork {
   };
 };
 
-// This is used to create an alternate fiber to do work on. It's called right
-// before reconcilation.
+// This is used to create an alternate fiber to do work on. It's called during
+// the parent's begin phase, either during reconciliation or after the parent
+// bails out.
 exports.createWorkInProgress = function(
   current: Fiber,
   renderPriority: PriorityLevel,
+  pendingProps: mixed,
 ): Fiber {
   // We use a double buffering pooling technique because we know that we'll only
   // ever need at most two versions of a tree. We pool the "other" unused node
@@ -329,6 +331,10 @@ exports.createWorkInProgress = function(
     current.alternate = workInProgress;
   }
 
+  // Only touch fields that are set by the parent, not fields that correspond to
+  // the child (memoizedProps, memoizedState, et al), which will be determined
+  // during its own begin phase.
+  workInProgress.pendingProps = pendingProps;
   workInProgress.pendingWorkPriority = current.pendingWorkPriority;
 
   // These are overriden during reconcilation.
@@ -336,9 +342,6 @@ exports.createWorkInProgress = function(
   workInProgress.sibling = current.sibling; // This should always be overridden. TODO: null
   workInProgress.index = current.index; // This should always be overridden.
   workInProgress.ref = current.ref;
-  // pendingProps is here for symmetry but is unnecessary in practice for now.
-  // TODO: Pass in the new pendingProps as an argument maybe?
-  workInProgress.pendingProps = current.pendingProps;
 
   return workInProgress;
 };

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -249,6 +249,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     workInProgress,
     renderPriority,
   ) {
+    // Push context providers early to prevent context stack mismatches. During
+    // mounting we don't know the child context yet as the instance doesn't
+    // exist. We will invalidate the child context right after rendering.
+    const hasChildContext = pushContextProvider(workInProgress);
+
     invariant(
       current === null,
       'An indeterminate component should never have mounted. This error is ' +
@@ -290,6 +295,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         nextProps,
         nextContext,
         initialState,
+        hasChildContext,
         renderPriority,
       );
     } else {
@@ -438,6 +444,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     workInProgress: Fiber,
     renderPriority: PriorityLevel,
   ): Fiber | null {
+    // Push context providers early to prevent context stack mismatches. During
+    // mounting we don't know the child context yet as the instance doesn't
+    // exist. We will invalidate the child context right after rendering.
+    const hasChildContext = pushContextProvider(workInProgress);
+
     const ctor = workInProgress.type;
 
     const memoizedProps = workInProgress.memoizedProps;
@@ -479,6 +490,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       nextProps,
       nextContext,
       previousState,
+      hasChildContext,
       renderPriority,
     );
   }
@@ -495,6 +507,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     nextContext: mixed,
     // The memoized state, or the initial state for new components
     previousState: mixed,
+    hasChildContext: boolean,
     renderPriority: PriorityLevel,
   ): Fiber | null {
     const ctor = workInProgress.type;
@@ -510,11 +523,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     // Is this the initial render? (Note: different from whether this is initial
     // mount, since a component may render multiple times before mounting.)
     const isInitialRender = workInProgress.memoizedProps === null;
-
-    // Push context providers early to prevent context stack mismatches. During
-    // mounting we don't know the child context yet as the instance doesn't
-    // exist. We will invalidate the child context right after rendering.
-    const hasChildContext = pushContextProvider(workInProgress);
 
     // Check if this is a new component or an update.
     if ((nextProps !== memoizedProps && !isInitialRender) || contextDidChange) {

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -643,6 +643,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       );
       if (__DEV__) {
         stopPhaseTimer();
+        warning(
+          shouldUpdate !== undefined,
+          '%s.shouldComponentUpdate(): Returned undefined instead of a ' +
+            'boolean value. Make sure to return true or false.',
+          getComponentName(workInProgress) || 'Unknown',
+        );
       }
     } else if (ctor.prototype && ctor.prototype.isPureReactComponent) {
       // This is a PureComponent. Do a shallow comparison of props and state.

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -94,7 +94,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
-  function beginHostRoot(current, workInProgress, renderPriority) {
+  function beginHostRoot(
+    current: Fiber | null,
+    workInProgress: Fiber,
+    nextProps: mixed,
+    renderPriority: PriorityLevel
+  ): Fiber | null {
     const root = (workInProgress.stateNode: FiberRoot);
     if (root.pendingContext) {
       pushTopLevelContextObject(
@@ -156,17 +161,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   function beginHostPortal(
     current: Fiber | null,
     workInProgress: Fiber,
+    nextChildren: mixed,
     renderPriority: PriorityLevel,
   ): Fiber | null {
     pushHostContainer(workInProgress, workInProgress.stateNode.containerInfo);
 
     const memoizedChildren = workInProgress.memoizedProps;
-    let nextChildren = workInProgress.pendingProps;
-    if (nextChildren === null) {
-      nextChildren = memoizedChildren;
-      invariant(nextChildren !== null, 'Must have pending or memoized props.');
-    }
-
     if (nextChildren === memoizedChildren && !hasContextChanged()) {
       return bailout(current, workInProgress, nextChildren, null, renderPriority);
     }
@@ -182,17 +182,17 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     );
   }
 
-  function beginHostComponent(current, workInProgress, renderPriority) {
+  function beginHostComponent(
+    current: Fiber | null,
+    workInProgress: Fiber,
+    nextProps: mixed,
+    renderPriority: PriorityLevel,
+  ): Fiber | null {
     pushHostContext(workInProgress);
 
     const type = workInProgress.type;
 
     const memoizedProps = workInProgress.memoizedProps;
-    let nextProps = workInProgress.pendingProps;
-    if (nextProps === null) {
-      nextProps = memoizedProps;
-      invariant(nextProps !== null, 'Must have pending or memoized props.');
-    }
 
     // Check if the ref has changed and schedule an effect. This should happen
     // even if we bailout.
@@ -252,13 +252,13 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     );
   }
 
-  function beginHostText(current, workInProgress, renderPriority) {
+  function beginHostText(
+    current: Fiber | null,
+    workInProgress: Fiber,
+    nextProps: mixed,
+    renderPriority: PriorityLevel,
+  ): Fiber | null {
     const memoizedProps = workInProgress.memoizedProps;
-    let nextProps = workInProgress.pendingProps;
-    if (nextProps === null) {
-      nextProps = memoizedProps;
-      invariant(nextProps !== null, 'Must have pending or memoized props.');
-    }
     if (nextProps === memoizedProps) {
       return bailout(current, workInProgress, nextProps, null, renderPriority);
     }
@@ -275,10 +275,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   }
 
   function beginIndeterminateComponent(
-    current,
-    workInProgress,
-    renderPriority,
-  ) {
+    current: Fiber | null,
+    workInProgress: Fiber,
+    nextProps: mixed,
+    renderPriority: PriorityLevel,
+  ): Fiber | null {
     invariant(
       current === null,
       'An indeterminate component should never have mounted. This error is ' +
@@ -286,11 +287,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     );
 
     const fn = workInProgress.type;
-    const nextProps = workInProgress.pendingProps;
     let unmaskedContext = getUnmaskedContext(workInProgress);
     let nextContext = getMaskedContext(workInProgress, unmaskedContext);
-
-    invariant(nextProps !== null, 'Must have pending props.');
 
     // This is either a functional component or a module-style class component.
     let value;
@@ -384,16 +382,15 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
-  function beginFunctionalComponent(current, workInProgress, renderPriority) {
+  function beginFunctionalComponent(
+    current: Fiber | null,
+    workInProgress: Fiber,
+    nextProps: mixed,
+    renderPriority: PriorityLevel,
+  ): Fiber | null {
     const fn = workInProgress.type;
 
     const memoizedProps = workInProgress.memoizedProps;
-    let nextProps = workInProgress.pendingProps;
-    if (nextProps === null) {
-      nextProps = memoizedProps;
-      invariant(nextProps !== null, 'Must have pending or memoized props.');
-    }
-
     if (
       (nextProps === memoizedProps && !hasContextChanged()) ||
       // TODO: Disable this before release, since it is not part of the public
@@ -476,6 +473,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   function beginClassComponent(
     current: Fiber | null,
     workInProgress: Fiber,
+    nextProps: mixed,
     renderPriority: PriorityLevel,
   ): Fiber | null {
     // Push context providers early to prevent context stack mismatches. During
@@ -485,12 +483,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
     const ctor = workInProgress.type;
 
-    const memoizedProps = workInProgress.memoizedProps;
-    let nextProps = workInProgress.pendingProps;
-    if (nextProps === null) {
-      nextProps = memoizedProps;
-      invariant(nextProps !== null, 'Must have pending or memoized props.');
-    }
     const unmaskedContext = getUnmaskedContext(workInProgress);
     const nextContext = getMaskedContext(workInProgress, unmaskedContext);
 
@@ -829,15 +821,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   function beginFragment(
     current: Fiber | null,
     workInProgress: Fiber,
+    nextProps: mixed,
     renderPriority: PriorityLevel,
   ): Fiber | null {
     const memoizedProps = workInProgress.memoizedProps;
-    let nextProps = workInProgress.pendingProps;
-    if (nextProps === null) {
-      nextProps = memoizedProps;
-      invariant(nextProps !== null, 'Must have pending or memoized props.');
-    }
-
     if (nextProps === memoizedProps && !hasContextChanged()) {
       // No changes to props or context. Bailout.
       return bailout(current, workInProgress, nextProps, null, renderPriority);
@@ -1273,7 +1260,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     return resetToCurrent(current, workInProgress, renderPriority);
   }
 
-
   function beginWork(
     current: Fiber | null,
     workInProgress: Fiber,
@@ -1290,31 +1276,40 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     workInProgress.firstEffect = null;
     workInProgress.lastEffect = null;
 
+    let nextProps = workInProgress.pendingProps;
+    if (nextProps === null) {
+      // If there are no pending props, re-use the memoized props.
+      nextProps = workInProgress.memoizedProps;
+      invariant(nextProps !== null, 'Must have pending or memoized props.');
+    }
+
     switch (workInProgress.tag) {
       case HostRoot:
-        return beginHostRoot(current, workInProgress, renderPriority);
+        return beginHostRoot(current, workInProgress, nextProps, renderPriority);
       case HostPortal:
-        return beginHostPortal(current, workInProgress, renderPriority);
+        return beginHostPortal(current, workInProgress, nextProps, renderPriority);
       case HostComponent:
-        return beginHostComponent(current, workInProgress, renderPriority);
+        return beginHostComponent(current, workInProgress, nextProps, renderPriority);
       case HostText:
-        return beginHostText(current, workInProgress, renderPriority);
+        return beginHostText(current, workInProgress, nextProps, renderPriority);
       case IndeterminateComponent:
         return beginIndeterminateComponent(
           current,
           workInProgress,
+          nextProps,
           renderPriority,
         );
       case FunctionalComponent:
         return beginFunctionalComponent(
           current,
           workInProgress,
+          nextProps,
           renderPriority,
         );
       case ClassComponent:
-        return beginClassComponent(current, workInProgress, renderPriority);
+        return beginClassComponent(current, workInProgress, nextProps, renderPriority);
       case Fragment:
-        return beginFragment(current, workInProgress, renderPriority);
+        return beginFragment(current, workInProgress, nextProps, renderPriority);
       default:
         invariant(
           false,

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -552,10 +552,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
     // Is this the initial render? (Note: different from whether this is initial
     // mount, since a component may render multiple times before mounting.)
-    const isInitialRender = workInProgress.memoizedProps === null;
+    const isInitialRender = memoizedProps === null;
 
     // Check if this is a new component or an update.
-    if ((nextProps !== memoizedProps && !isInitialRender) || contextDidChange) {
+    if (!isInitialRender && (nextProps !== memoizedProps || contextDidChange)) {
       // This component has been rendered before, and it has received new props
       // or context since the last render. Call componentWillReceiveProps, if
       // it exists. This should be called even if the component hasn't mounted

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -966,21 +966,21 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       return null;
     }
 
-    // The priority of the children matches the render priority. We'll
-    // continue working on it.
-
-    // Check to see if we have progressed work since the last commit.
+    // The children have pending work that matches the render priority. Continue
+    // on the work-in-progress children.
     if (current === null || workInProgress.child !== current.child) {
-      // We already have progressed work. We can reuse the children. But we
-      // need to reset the return fiber since we'll traverse down into them.
+      // The child is not the current child, which means they are a work-in-
+      // progress set. We can reuse them. But reset the child pointer before
+      // traversing into them so we can find our way back later.
       let child = workInProgress.child;
       while (child !== null) {
         child.return = workInProgress;
         child = child.sibling;
       }
     } else {
-      // There is no progressed work. We need to create a new work in progress
-      // for each child.
+      // The child is the current child. Switch to the work-in-progress set
+      // instead. If a child does not already have a work-in-progress copy,
+      // it will be created.
       let currentChild = workInProgress.child;
       let newChild = createWorkInProgress(
         currentChild,
@@ -1005,6 +1005,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       // priority progressed work, it will be thrown out.
       markWorkAsProgressed(current, workInProgress, renderPriority);
     }
+
     // Continue working on child
     return workInProgress.child;
   }

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -75,7 +75,7 @@ if (__DEV__) {
 function bailoutHiddenChildren(
   current: Fiber | null,
   workInProgress: Fiber,
-  nextProps: mixed | null,
+  nextProps: any | null,
   nextState: mixed | null,
   renderPriority: PriorityLevel,
 ): Fiber | null {
@@ -96,7 +96,7 @@ function reconcileHiddenChildren(
   current: Fiber | null,
   workInProgress: Fiber,
   nextChildren: any,
-  nextProps: mixed | null,
+  nextProps: any | null,
   nextState: mixed | null,
   renderPriority: PriorityLevel,
 ): Fiber | null {
@@ -157,7 +157,7 @@ function reconcileHiddenChildren(
 function bailout(
   current: Fiber | null,
   workInProgress: Fiber,
-  nextProps: mixed | null,
+  nextProps: any | null,
   nextState: mixed | null,
   renderPriority: PriorityLevel,
 ): Fiber | null {
@@ -280,7 +280,7 @@ function reconcile(
   current: Fiber | null,
   workInProgress: Fiber,
   nextChildren: any,
-  nextProps: mixed | null,
+  nextProps: any | null,
   nextState: mixed | null,
   renderPriority: PriorityLevel,
 ) {
@@ -305,7 +305,7 @@ function reconcileImpl(
   workInProgress: Fiber,
   child: Fiber | null, // Child to reconcile against
   nextChildren: any,
-  nextProps: mixed | null,
+  nextProps: any | null,
   nextState: mixed | null,
   renderPriority: PriorityLevel,
 ): Fiber | null {
@@ -545,7 +545,7 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
   function beginHostRoot(
     current: Fiber | null,
     workInProgress: Fiber,
-    nextProps: mixed,
+    nextProps: any,
     renderPriority: PriorityLevel
   ): Fiber | null {
     const root = (workInProgress.stateNode: FiberRoot);
@@ -633,7 +633,7 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
   function beginHostComponent(
     current: Fiber | null,
     workInProgress: Fiber,
-    nextProps: mixed,
+    nextProps: any,
     renderPriority: PriorityLevel,
   ): Fiber | null {
     pushHostContext(workInProgress);
@@ -703,7 +703,7 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
   function beginHostText(
     current: Fiber | null,
     workInProgress: Fiber,
-    nextProps: mixed,
+    nextProps: any,
     renderPriority: PriorityLevel,
   ): Fiber | null {
     const memoizedProps = workInProgress.memoizedProps;
@@ -725,7 +725,7 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
   function beginIndeterminateComponent(
     current: Fiber | null,
     workInProgress: Fiber,
-    nextProps: mixed,
+    nextProps: any,
     renderPriority: PriorityLevel,
   ): Fiber | null {
     invariant(
@@ -833,7 +833,7 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
   function beginFunctionalComponent(
     current: Fiber | null,
     workInProgress: Fiber,
-    nextProps: mixed,
+    nextProps: any,
     renderPriority: PriorityLevel,
   ): Fiber | null {
     const fn = workInProgress.type;
@@ -921,7 +921,7 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
   function beginClassComponent(
     current: Fiber | null,
     workInProgress: Fiber,
-    nextProps: mixed,
+    nextProps: any,
     renderPriority: PriorityLevel,
   ): Fiber | null {
     // Push context providers early to prevent context stack mismatches. During
@@ -977,7 +977,7 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
     current: Fiber | null,
     workInProgress: Fiber,
     instance: any,
-    nextProps: mixed,
+    nextProps: any,
     nextContext: mixed,
     // The memoized state, or the initial state for new components
     previousState: mixed,
@@ -1269,7 +1269,7 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
   function beginFragment(
     current: Fiber | null,
     workInProgress: Fiber,
-    nextProps: mixed,
+    nextProps: any,
     renderPriority: PriorityLevel,
   ): Fiber | null {
     const memoizedProps = workInProgress.memoizedProps;

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -216,6 +216,12 @@ function bailout(
       workInProgress,
     );
     if (workInProgress === progressedWork) {
+      invariant(
+        current === null ||
+          current.child === null ||
+          workInProgress.child !== current.child,
+        'Expected child to be a work-in-progress child',
+      );
       if (workInProgress.progressedPriority === renderPriority) {
         // We have progressed work that completed at this level. Because the
         // remaining priority (pendingWorkPriority) is less than the priority
@@ -246,6 +252,11 @@ function bailout(
         );
         resetToCurrent(current, workInProgress, renderPriority);
       }
+    } else {
+      invariant(
+        current !== null && current.child === workInProgress.child,
+        'Expected child to be the current child',
+      );
     }
 
     // Return null to skip the children and continue on the sibling. If

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -390,7 +390,6 @@ function resumeAlreadyProgressedWork(
   // We're resuming off a fork, so we need to update the progressed work
   // priority, too. The remaining work priority is equal to whatever priority
   // we interrupted.
-  workInProgress.pendingWorkPriority = workInProgress.progressedPriority;
 
   workInProgress.child = progressedWork.child;
   workInProgress.firstDeletion = progressedWork.firstDeletion;
@@ -398,6 +397,7 @@ function resumeAlreadyProgressedWork(
   workInProgress.memoizedProps = progressedWork.memoizedProps;
   workInProgress.memoizedState = progressedWork.memoizedState;
   workInProgress.updateQueue = progressedWork.updateQueue;
+  workInProgress.pendingWorkPriority = progressedWork.pendingWorkPriority;
 
   // "Un-fork" the progressed work object. We no longer need it.
   workInProgress.progressedWork = workInProgress;
@@ -440,6 +440,7 @@ function forkWorkInProgress(
   memoizedProps: any,
   memoizedState: any,
   updateQueue: UpdateQueue | null,
+  pendingWorkPriority: PriorityLevel,
 ) {
   const stashedWork = createProgressedWorkFork(
     child,
@@ -448,6 +449,7 @@ function forkWorkInProgress(
     memoizedProps,
     memoizedState,
     updateQueue,
+    pendingWorkPriority,
   );
   workInProgress.progressedWork = stashedWork;
   if (current !== null) {
@@ -470,11 +472,6 @@ function resetToCurrent(
     workInProgress.memoizedProps = current.memoizedProps;
     workInProgress.memoizedState = current.memoizedState;
     workInProgress.updateQueue = current.updateQueue;
-
-    // Copy the priority. Priority is cleared from the work-in-progress tree
-    // as we complete work on it. Since this is a reset, any cleared priority
-    // needs to be restored to its current value. This is easy to overlook but
-    // leads to confusing bugs if messed up.
     workInProgress.pendingWorkPriority = current.pendingWorkPriority;
 
     // The effect list can be left alone because we reset it at the start of
@@ -491,7 +488,6 @@ function resetToCurrent(
     workInProgress.memoizedProps = null;
     workInProgress.memoizedState = null;
     workInProgress.updateQueue = null;
-
     workInProgress.pendingWorkPriority = NoWork;
   }
 }
@@ -524,6 +520,7 @@ function resumeOrResetWork(
           workInProgress.memoizedProps,
           workInProgress.memoizedState,
           workInProgress.updateQueue,
+          workInProgress.pendingWorkPriority,
         );
       }
       // Reset the work-in-progress. This makes it a copy of the current fiber.

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -1272,6 +1272,16 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         'Please file an issue.',
     );
 
+    const memoizedProps = workInProgress.memoizedProps;
+    let nextProps = workInProgress.pendingProps;
+    if (nextProps === null) {
+      nextProps = memoizedProps;
+    }
+
+    // Clear any pending props or updates.
+    workInProgress.pendingProps = null;
+    workInProgress.updateQueue = null;
+
     // Clear the effect list, as it's no longer valid.
     workInProgress.firstEffect = null;
     workInProgress.lastEffect = null;
@@ -1285,7 +1295,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       current,
       workInProgress,
       nextChildren,
-      workInProgress.memoizedProps,
+      memoizedProps,
       workInProgress.memoizedState,
       renderPriority,
     );

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -444,8 +444,8 @@ function forkWorkInProgress(
 ) {
   const stashedWork = createProgressedWorkFork(
     child,
-    lastDeletion,
     firstDeletion,
+    lastDeletion,
     memoizedProps,
     memoizedState,
     updateQueue,
@@ -515,8 +515,8 @@ function resumeOrResetWork(
           current,
           workInProgress,
           workInProgress.child,
-          workInProgress.lastDeletion,
           workInProgress.firstDeletion,
+          workInProgress.lastDeletion,
           workInProgress.memoizedProps,
           workInProgress.memoizedState,
           workInProgress.updateQueue,

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -823,7 +823,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     // priority reconciliation first before we can get down here. However,
     // that is a bit tricky since workInProgress and current can have
     // different "hidden" settings.
-    workInProgress.progressedPriority = OffscreenPriority;
+    workInProgress.pendingWorkPriority = OffscreenPriority;
     return bailout(current, workInProgress, nextProps, null, renderPriority);
   }
 

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -1129,6 +1129,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
     // "Un-fork" the progressed work object. We no longer need it.
     workInProgress.progressedWork = workInProgress;
+    const current = workInProgress.alternate;
+    if (current !== null) {
+      current.progressedWork = workInProgress;
+    }
   }
 
   function resetToCurrent(current: Fiber | null, workInProgress: Fiber, renderPriority) {

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -982,7 +982,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       // There is no progressed work. We need to create a new work in progress
       // for each child.
       let currentChild = workInProgress.child;
-      let newChild = createWorkInProgress(currentChild, renderPriority);
+      let newChild = createWorkInProgress(
+        currentChild,
+        renderPriority,
+        null,
+      );
       workInProgress.child = newChild;
 
       newChild.return = workInProgress;
@@ -991,12 +995,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         newChild = newChild.sibling = createWorkInProgress(
           currentChild,
           renderPriority,
+          null,
         );
-        // Set the pending props to null, since this is a bailout and any
-        // existing pending props are now invalid.
-        // TODO: We should really pass the pending props as an argument so that
-        // we don't forget to set them.
-        newChild.pendingProps = null;
         newChild.return = workInProgress;
       }
       newChild.sibling = null;

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -704,14 +704,14 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           instance,
           cWU,
           // this.props, this.context, this.state
-          nextProps,
-          nextContext,
-          nextState,
+          memoizedProps,
+          memoizedContext,
+          memoizedState,
           // Arguments
           // (The asymmetry between the signatures for componentWillMount and
           // componentWillUpdate is confusing. Oh well, can't change it now.)
-          memoizedProps,
-          memoizedState,
+          nextProps,
+          nextState,
         );
         if (__DEV__) {
           stopPhaseTimer();

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -230,11 +230,6 @@ function bailout(
           child = child.sibling;
         }
       } else {
-        invariant(
-          workInProgress.progressedPriority === OffscreenPriority,
-          'Progressed priority should only be less than work priority in ' +
-            'case of an offscreen/hidden subtree.',
-        );
         // Reset child to current. If we have progressed work, this will stash
         // it for later.
         resetToCurrent(current, workInProgress, renderPriority);

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -264,17 +264,13 @@ function bailout(
     // instead. If a child does not already have a work-in-progress copy,
     // it will be created.
     let currentChild = workInProgress.child;
-    let newChild = createWorkInProgress(currentChild, renderPriority, null);
+    let newChild = createWorkInProgress(currentChild, null);
     workInProgress.child = newChild;
 
     newChild.return = workInProgress;
     while (currentChild.sibling !== null) {
       currentChild = currentChild.sibling;
-      newChild = newChild.sibling = createWorkInProgress(
-        currentChild,
-        renderPriority,
-        null,
-      );
+      newChild = newChild.sibling = createWorkInProgress(currentChild, null);
       newChild.return = workInProgress;
     }
     newChild.sibling = null;
@@ -328,12 +324,7 @@ function reconcileImpl(
   // We have new children. Update the child set.
   let newChild;
   if (forceMountInPlace) {
-    newChild = mountChildFibersInPlace(
-      workInProgress,
-      child,
-      nextChildren,
-      renderPriority,
-    );
+    newChild = mountChildFibersInPlace(workInProgress, child, nextChildren);
   } else if (current === null) {
     if (workInProgress.tag === HostPortal) {
       // Portals are special because we don't append the children during mount
@@ -345,19 +336,13 @@ function reconcileImpl(
         workInProgress,
         child,
         nextChildren,
-        renderPriority,
       );
     } else {
       // If this is a fresh new component that hasn't been rendered yet, we
       // won't update its child set by applying minimal side-effects. Instead,
       // we will add them all to the child before it gets rendered. That means
       // we can optimize this reconciliation pass by not tracking side-effects.
-      newChild = mountChildFibersInPlace(
-        workInProgress,
-        child,
-        nextChildren,
-        renderPriority,
-      );
+      newChild = mountChildFibersInPlace(workInProgress, child, nextChildren);
     }
   } else if (workInProgress.child === current.child) {
     // If the child is the same as the current child, it means that we haven't
@@ -365,22 +350,12 @@ function reconcileImpl(
     // algorithm to create a copy of all the current children.
     // Note: Compare to `workInProgress.child`, not `child`, because for
     // a phase one coroutine, `child` is actually the state node.
-    newChild = reconcileChildFibers(
-      workInProgress,
-      child,
-      nextChildren,
-      renderPriority,
-    );
+    newChild = reconcileChildFibers(workInProgress, child, nextChildren);
   } else {
     // If, on the other hand, it is already using a clone, that means we've
     // already begun some work on this tree and we can continue where we left
     // off by reconciling against the existing children.
-    newChild = reconcileChildFibersInPlace(
-      workInProgress,
-      child,
-      nextChildren,
-      renderPriority,
-    );
+    newChild = reconcileChildFibersInPlace(workInProgress, child, nextChildren);
   }
 
   // Memoize this work.

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -1412,7 +1412,6 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
       workInProgress.pendingProps = null;
     }
 
-
     let next = null;
     switch (workInProgress.tag) {
       case HostRoot:

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -536,7 +536,14 @@ function resumeOrResetWork(
     // we can resume on.
   ) {
     // We have progressed work at this priority. Reuse it.
-    return resumeAlreadyProgressedWork(workInProgress, progressedWork);
+    resumeAlreadyProgressedWork(workInProgress, progressedWork);
+    invariant(
+      current === null ||
+        current.child === null ||
+        workInProgress.child !== current.child,
+      'Expected child not to be the current child',
+    );
+    return;
   }
   return resetToCurrent(current, workInProgress, renderPriority);
 }

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -587,12 +587,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     let shouldUpdate;
     if (isInitialRender) {
       shouldUpdate = true;
-    } else if (nextProps === memoizedProps && nextState === memoizedState && !contextDidChange) {
-      // None of the inputs have changed. Bailout.
-      shouldUpdate = false;
     } else if (workInProgress.updateQueue !== null && workInProgress.updateQueue.hasForceUpdate) {
       // This is a forced update. Re-render regardless of shouldComponentUpdate.
       shouldUpdate = true;
+    } else if (nextProps === memoizedProps && nextState === memoizedState && !contextDidChange) {
+      // None of the inputs have changed. Bailout.
+      shouldUpdate = false;
     } else if (typeof instance.shouldComponentUpdate === 'function') {
       // There was a change in props, state, or context. But we may be able to
       // bailout anyway if shouldComponentUpdate -> false.

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -66,7 +66,7 @@ var shallowEqual = require('fbjs/lib/shallowEqual');
 if (__DEV__) {
   var ReactDebugCurrentFiber = require('ReactDebugCurrentFiber');
   var warning = require('fbjs/lib/warning');
-  var {startPhaseTimer, stopPhaseTimer} = require('ReactDebugFiberPerf');
+  var {startPhaseTimer, stopPhaseTimer, cancelWorkTimer} = require('ReactDebugFiberPerf');
   var getComponentName = require('getComponentName');
 
   var warnedAboutStatelessRefs = {};
@@ -161,6 +161,10 @@ function bailout(
   nextState: mixed | null,
   renderPriority: PriorityLevel,
 ): Fiber | null {
+  if (__DEV__) {
+    cancelWorkTimer(workInProgress);
+  }
+
   // A bailout implies that the memoized props and state are equal to the next
   // props and state, but we should update them anyway because they might not
   // be referentially equal (shouldComponentUpdate -> false)

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -20,7 +20,12 @@ import type {HydrationContext} from 'ReactFiberHydrationContext';
 import type {HostConfig} from 'ReactFiberReconciler';
 import type {PriorityLevel} from 'ReactPriorityLevel';
 
-var {createWorkInProgress, createProgressedWork, largerPriority, transferEffectsToParent} = require('ReactFiber');
+var {
+  createWorkInProgress,
+  createProgressedWork,
+  largerPriority,
+  transferEffectsToParent,
+} = require('ReactFiber');
 var {
   mountChildFibersInPlace,
   reconcileChildFibers,
@@ -55,7 +60,14 @@ var {
   callClassInstanceMethod,
 } = require('ReactFiberClassComponent');
 var {NoWork, OffscreenPriority} = require('ReactPriorityLevel');
-var {Placement, Update, ContentReset, Ref, Err, Callback} = require('ReactTypeOfSideEffect');
+var {
+  Placement,
+  Update,
+  ContentReset,
+  Ref,
+  Err,
+  Callback,
+} = require('ReactTypeOfSideEffect');
 var {AsyncUpdates} = require('ReactTypeOfInternalContext');
 var {ReactCurrentOwner} = require('ReactGlobalSharedState');
 var ReactFeatureFlags = require('ReactFeatureFlags');
@@ -66,7 +78,11 @@ var shallowEqual = require('fbjs/lib/shallowEqual');
 if (__DEV__) {
   var ReactDebugCurrentFiber = require('ReactDebugCurrentFiber');
   var warning = require('fbjs/lib/warning');
-  var {startPhaseTimer, stopPhaseTimer, cancelWorkTimer} = require('ReactDebugFiberPerf');
+  var {
+    startPhaseTimer,
+    stopPhaseTimer,
+    cancelWorkTimer,
+  } = require('ReactDebugFiberPerf');
   var getComponentName = require('getComponentName');
 
   var warnedAboutStatelessRefs = {};
@@ -248,11 +264,7 @@ function bailout(
     // instead. If a child does not already have a work-in-progress copy,
     // it will be created.
     let currentChild = workInProgress.child;
-    let newChild = createWorkInProgress(
-      currentChild,
-      renderPriority,
-      null,
-    );
+    let newChild = createWorkInProgress(currentChild, renderPriority, null);
     workInProgress.child = newChild;
 
     newChild.return = workInProgress;
@@ -285,7 +297,7 @@ function reconcile(
   nextState: mixed | null,
   renderPriority: PriorityLevel,
 ) {
-  const child = workInProgress.child = reconcileImpl(
+  const child = (workInProgress.child = reconcileImpl(
     current,
     workInProgress,
     workInProgress.child,
@@ -294,7 +306,7 @@ function reconcile(
     nextState,
     false,
     renderPriority,
-  );
+  ));
   return child;
 }
 exports.reconcile = reconcile;
@@ -443,7 +455,11 @@ function resumeAlreadyProgressedWork(
   }
 }
 
-function resetToCurrent(current: Fiber | null, workInProgress: Fiber, renderPriority) {
+function resetToCurrent(
+  current: Fiber | null,
+  workInProgress: Fiber,
+  renderPriority,
+) {
   let progressedWork = workInProgress.progressedWork;
 
   if (
@@ -560,7 +576,7 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
     current: Fiber | null,
     workInProgress: Fiber,
     nextProps: any,
-    renderPriority: PriorityLevel
+    renderPriority: PriorityLevel,
   ): Fiber | null {
     const root = (workInProgress.stateNode: FiberRoot);
     if (root.pendingContext) {
@@ -591,7 +607,10 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
         );
 
     // Schedule a callback effect if needed.
-    if (workInProgress.updateQueue !== null && workInProgress.updateQueue.callbackList !== null) {
+    if (
+      workInProgress.updateQueue !== null &&
+      workInProgress.updateQueue.callbackList !== null
+    ) {
       workInProgress.effectTag |= Callback;
     }
 
@@ -637,7 +656,7 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
     }
 
     // Reconcile the children.
-    const child = workInProgress.child = reconcileImpl(
+    const child = (workInProgress.child = reconcileImpl(
       current,
       workInProgress,
       workInProgress.child,
@@ -646,7 +665,7 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
       nextState,
       forceMountInPlace,
       renderPriority,
-    );
+    ));
     return child;
   }
 
@@ -660,7 +679,13 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
 
     const memoizedChildren = workInProgress.memoizedProps;
     if (nextChildren === memoizedChildren && !hasContextChanged()) {
-      return bailout(current, workInProgress, nextChildren, null, renderPriority);
+      return bailout(
+        current,
+        workInProgress,
+        nextChildren,
+        null,
+        renderPriority,
+      );
     }
 
     // Reconcile the children.
@@ -806,7 +831,7 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
     ) {
       // Proceed under the assumption that this is a class instance.
       workInProgress.tag = ClassComponent;
-      const instance = workInProgress.stateNode = value;
+      const instance = (workInProgress.stateNode = value);
       const initialState = instance.state;
       instance.updater = classUpdater;
       instance.context = nextContext;
@@ -991,7 +1016,7 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
     if (instance === null) {
       // This is a fresh component. Construct the public component instance.
       instance = workInProgress.stateNode = new ctor(nextProps, nextContext);
-      const initialState = previousState = instance.state;
+      const initialState = (previousState = instance.state);
       instance.updater = classUpdater;
       instance.context = nextContext;
       ReactInstanceMap.set(instance, workInProgress);
@@ -1113,10 +1138,17 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
     let shouldUpdate;
     if (isInitialRender) {
       shouldUpdate = true;
-    } else if (workInProgress.updateQueue !== null && workInProgress.updateQueue.hasForceUpdate) {
+    } else if (
+      workInProgress.updateQueue !== null &&
+      workInProgress.updateQueue.hasForceUpdate
+    ) {
       // This is a forced update. Re-render regardless of shouldComponentUpdate.
       shouldUpdate = true;
-    } else if (nextProps === memoizedProps && nextState === memoizedState && !contextDidChange) {
+    } else if (
+      nextProps === memoizedProps &&
+      nextState === memoizedState &&
+      !contextDidChange
+    ) {
       // None of the inputs have changed. Bailout.
       shouldUpdate = false;
     } else if (typeof instance.shouldComponentUpdate === 'function') {
@@ -1148,7 +1180,9 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
       }
     } else if (ctor.prototype && ctor.prototype.isPureReactComponent) {
       // This is a PureComponent. Do a shallow comparison of props and state.
-      shouldUpdate = !shallowEqual(memoizedProps, nextProps) || !shallowEqual(memoizedState, nextState);
+      shouldUpdate =
+        !shallowEqual(memoizedProps, nextProps) ||
+        !shallowEqual(memoizedState, nextState);
     } else {
       // The inputs changed and we can't bail out. Re-render.
       shouldUpdate = true;
@@ -1247,7 +1281,10 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
     checkForUpdatedRef(current, workInProgress);
 
     // Schedule a callback effect if needed.
-    if (workInProgress.updateQueue !== null && workInProgress.updateQueue.callbackList !== null) {
+    if (
+      workInProgress.updateQueue !== null &&
+      workInProgress.updateQueue.callbackList !== null
+    ) {
       workInProgress.effectTag |= Callback;
     }
 
@@ -1281,7 +1318,13 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
     // By now, all effects should have been scheduled. It's safe to bailout.
     if (!shouldUpdate) {
       // This is a bailout. Reuse the work without re-rendering.
-      return bailout(current, workInProgress, nextProps, nextState, renderPriority);
+      return bailout(
+        current,
+        workInProgress,
+        nextProps,
+        nextState,
+        renderPriority,
+      );
     }
 
     // No bailout. Call the render method to get the next set of children.
@@ -1351,7 +1394,7 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
   ): Fiber | null {
     // TODO: Bailout if coroutine hasn't changed. When bailing out, we might
     // need to return the stateNode instead of the child. To check it for work.
-    const child = workInProgress.stateNode = reconcileImpl(
+    const child = (workInProgress.stateNode = reconcileImpl(
       current,
       workInProgress,
       workInProgress.stateNode,
@@ -1360,7 +1403,7 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
       null,
       false,
       renderPriority,
-    );
+    ));
     return child;
   }
 
@@ -1392,13 +1435,33 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
 
     switch (workInProgress.tag) {
       case HostRoot:
-        return beginHostRoot(current, workInProgress, nextProps, renderPriority);
+        return beginHostRoot(
+          current,
+          workInProgress,
+          nextProps,
+          renderPriority,
+        );
       case HostPortal:
-        return beginHostPortal(current, workInProgress, nextProps, renderPriority);
+        return beginHostPortal(
+          current,
+          workInProgress,
+          nextProps,
+          renderPriority,
+        );
       case HostComponent:
-        return beginHostComponent(current, workInProgress, nextProps, renderPriority);
+        return beginHostComponent(
+          current,
+          workInProgress,
+          nextProps,
+          renderPriority,
+        );
       case HostText:
-        return beginHostText(current, workInProgress, nextProps, renderPriority);
+        return beginHostText(
+          current,
+          workInProgress,
+          nextProps,
+          renderPriority,
+        );
       case IndeterminateComponent:
         return beginIndeterminateComponent(
           current,
@@ -1414,15 +1477,30 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
           renderPriority,
         );
       case ClassComponent:
-        return beginClassComponent(current, workInProgress, nextProps, renderPriority);
+        return beginClassComponent(
+          current,
+          workInProgress,
+          nextProps,
+          renderPriority,
+        );
       case Fragment:
-        return beginFragment(current, workInProgress, nextProps, renderPriority);
+        return beginFragment(
+          current,
+          workInProgress,
+          nextProps,
+          renderPriority,
+        );
       case CoroutineHandlerPhase:
         // This is a restart. Reset the tag to the initial phase.
         workInProgress.tag = CoroutineComponent;
       // Intentionally fall through since this is now the same.
       case CoroutineComponent:
-        return beginCoroutineComponent(current, workInProgress, nextProps, renderPriority);
+        return beginCoroutineComponent(
+          current,
+          workInProgress,
+          nextProps,
+          renderPriority,
+        );
       case YieldComponent:
         // A yield component is just a placeholder, we can just run through the
         // next one immediately.

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -750,6 +750,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
 
     // Now call the render method to get the next set of children.
+    ReactCurrentOwner.current = workInProgress;
     if (__DEV__) {
       ReactDebugCurrentFiber.phase = 'render';
     }

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -1209,6 +1209,7 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
             // componentWillUpdate is confusing. Oh well, can't change it now.)
             nextProps,
             nextState,
+            nextContext,
           );
           if (__DEV__) {
             stopPhaseTimer();

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -387,6 +387,11 @@ function resumeAlreadyProgressedWork(
     return;
   }
 
+  // We're resuming off a fork, so we need to update the progressed work
+  // priority, too. The remaining work priority is equal to whatever priority
+  // we interrupted.
+  workInProgress.pendingWorkPriority = workInProgress.progressedPriority;
+
   workInProgress.child = progressedWork.child;
   workInProgress.firstDeletion = progressedWork.firstDeletion;
   workInProgress.lastDeletion = progressedWork.lastDeletion;
@@ -1412,6 +1417,7 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
 
     // Clear the effect list, as it's no longer valid.
     workInProgress.firstEffect = null;
+    workInProgress.nextEffect = null;
     workInProgress.lastEffect = null;
 
     let nextProps = workInProgress.pendingProps;

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -161,9 +161,6 @@ function bailout(
   nextState: mixed | null,
   renderPriority: PriorityLevel,
 ): Fiber | null {
-  // Reset the pending props. We don't need them anymore.
-  workInProgress.pendingProps = null;
-
   // A bailout implies that the memoized props and state are equal to the next
   // props and state, but we should update them anyway because they might not
   // be referentially equal (shouldComponentUpdate -> false)
@@ -309,9 +306,6 @@ function reconcileImpl(
   nextState: mixed | null,
   renderPriority: PriorityLevel,
 ): Fiber | null {
-  // Reset the pending props. We don't need them anymore.
-  workInProgress.pendingProps = null;
-
   // We have new children. Update the child set.
   let newChild;
   if (current === null) {
@@ -1309,6 +1303,7 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
     );
     return child;
   }
+
   function beginWork(
     current: Fiber | null,
     workInProgress: Fiber,
@@ -1330,6 +1325,9 @@ const BeginWork = function<T, P, I, TI, PI, C, CX, PL>(
       // If there are no pending props, re-use the memoized props.
       nextProps = workInProgress.memoizedProps;
       invariant(nextProps !== null, 'Must have pending or memoized props.');
+    } else {
+      // Reset the pending props, since we're about to process them.
+      workInProgress.pendingProps = null;
     }
 
     switch (workInProgress.tag) {

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -41,7 +41,11 @@ if (__DEV__) {
 }
 
 // Call immediately after constructing a class instance.
-function validateClassInstance(workInProgress: Fiber, initialProps: mixed, initialState: mixed) {
+function validateClassInstance(
+  workInProgress: Fiber,
+  initialProps: mixed,
+  initialState: mixed,
+) {
   const instance = workInProgress.stateNode;
   const ctor = workInProgress.type;
   if (__DEV__) {
@@ -145,7 +149,10 @@ function validateClassInstance(workInProgress: Fiber, initialProps: mixed, initi
       name,
     );
   }
-  if (initialState !== undefined && (typeof initialState !== 'object' || isArray(initialState))) {
+  if (
+    initialState !== undefined &&
+    (typeof initialState !== 'object' || isArray(initialState))
+  ) {
     invariant(
       false,
       '%s.state: must be set to an object or null',

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -15,35 +15,19 @@
 import type {Fiber} from 'ReactFiber';
 import type {PriorityLevel} from 'ReactPriorityLevel';
 
-var {Update} = require('ReactTypeOfSideEffect');
-
-var ReactFeatureFlags = require('ReactFeatureFlags');
-var {AsyncUpdates} = require('ReactTypeOfInternalContext');
-
-var {
-  cacheContext,
-  getMaskedContext,
-  getUnmaskedContext,
-  isContextConsumer,
-} = require('ReactFiberContext');
 var {
   addUpdate,
   addReplaceUpdate,
   addForceUpdate,
-  beginUpdateQueue,
 } = require('ReactFiberUpdateQueue');
-var {hasContextChanged} = require('ReactFiberContext');
 var {isMounted} = require('ReactFiberTreeReflection');
 var ReactInstanceMap = require('ReactInstanceMap');
-var emptyObject = require('fbjs/lib/emptyObject');
 var getComponentName = require('getComponentName');
-var shallowEqual = require('fbjs/lib/shallowEqual');
 var invariant = require('fbjs/lib/invariant');
 
 const isArray = Array.isArray;
 
 if (__DEV__) {
-  var {startPhaseTimer, stopPhaseTimer} = require('ReactDebugFiberPerf');
   var warning = require('fbjs/lib/warning');
   var warnOnInvalidCallback = function(callback: mixed, callerName: string) {
     warning(
@@ -56,16 +40,155 @@ if (__DEV__) {
   };
 }
 
-module.exports = function(
+// Call immediately after constructing a class instance.
+function validateClassInstance(workInProgress: Fiber, initialProps: mixed, initialState: mixed) {
+  const instance = workInProgress.stateNode;
+  const ctor = workInProgress.type;
+  if (__DEV__) {
+    const name = getComponentName(workInProgress);
+    const renderPresent = instance.render;
+    warning(
+      renderPresent,
+      '%s(...): No `render` method found on the returned component ' +
+        'instance: you may have forgotten to define `render`.',
+      name,
+    );
+    const noGetInitialStateOnES6 =
+      !instance.getInitialState ||
+      instance.getInitialState.isReactClassApproved ||
+      initialState;
+    warning(
+      noGetInitialStateOnES6,
+      'getInitialState was defined on %s, a plain JavaScript class. ' +
+        'This is only supported for classes created using React.createClass. ' +
+        'Did you mean to define a state property instead?',
+      name,
+    );
+    const noGetDefaultPropsOnES6 =
+      !instance.getDefaultProps ||
+      instance.getDefaultProps.isReactClassApproved;
+    warning(
+      noGetDefaultPropsOnES6,
+      'getDefaultProps was defined on %s, a plain JavaScript class. ' +
+        'This is only supported for classes created using React.createClass. ' +
+        'Use a static property to define defaultProps instead.',
+      name,
+    );
+    const noInstancePropTypes = !instance.propTypes;
+    warning(
+      noInstancePropTypes,
+      'propTypes was defined as an instance property on %s. Use a static ' +
+        'property to define propTypes instead.',
+      name,
+    );
+    const noInstanceContextTypes = !instance.contextTypes;
+    warning(
+      noInstanceContextTypes,
+      'contextTypes was defined as an instance property on %s. Use a static ' +
+        'property to define contextTypes instead.',
+      name,
+    );
+    const noComponentShouldUpdate =
+      typeof instance.componentShouldUpdate !== 'function';
+    warning(
+      noComponentShouldUpdate,
+      '%s has a method called ' +
+        'componentShouldUpdate(). Did you mean shouldComponentUpdate()? ' +
+        'The name is phrased as a question because the function is ' +
+        'expected to return a value.',
+      name,
+    );
+    if (
+      ctor.prototype &&
+      ctor.prototype.isPureReactComponent &&
+      typeof instance.shouldComponentUpdate !== 'undefined'
+    ) {
+      warning(
+        false,
+        '%s has a method called shouldComponentUpdate(). ' +
+          'shouldComponentUpdate should not be used when extending React.PureComponent. ' +
+          'Please extend React.Component if shouldComponentUpdate is used.',
+        getComponentName(workInProgress) || 'A pure component',
+      );
+    }
+    const noComponentDidUnmount =
+      typeof instance.componentDidUnmount !== 'function';
+    warning(
+      noComponentDidUnmount,
+      '%s has a method called ' +
+        'componentDidUnmount(). But there is no such lifecycle method. ' +
+        'Did you mean componentWillUnmount()?',
+      name,
+    );
+    const noComponentWillRecieveProps =
+      typeof instance.componentWillRecieveProps !== 'function';
+    warning(
+      noComponentWillRecieveProps,
+      '%s has a method called ' +
+        'componentWillRecieveProps(). Did you mean componentWillReceiveProps()?',
+      name,
+    );
+    const hasMutatedProps = instance.props !== initialProps;
+    warning(
+      instance.props === undefined || !hasMutatedProps,
+      '%s(...): When calling super() in `%s`, make sure to pass ' +
+        "up the same props that your component's constructor was passed.",
+      name,
+      name,
+    );
+    const noInstanceDefaultProps = !instance.defaultProps;
+    warning(
+      noInstanceDefaultProps,
+      'Setting defaultProps as an instance property on %s is not supported and will be ignored.' +
+        ' Instead, define defaultProps as a static property on %s.',
+      name,
+      name,
+    );
+  }
+  if (initialState !== undefined && (typeof initialState !== 'object' || isArray(initialState))) {
+    invariant(
+      false,
+      '%s.state: must be set to an object or null',
+      getComponentName(workInProgress),
+    );
+  }
+  if (typeof instance.getChildContext === 'function') {
+    invariant(
+      typeof workInProgress.type.childContextTypes === 'object',
+      '%s.getChildContext(): childContextTypes must be defined in order to ' +
+        'use getChildContext().',
+      getComponentName(workInProgress),
+    );
+  }
+}
+exports.validateClassInstance = validateClassInstance;
+
+type Callback = () => mixed;
+
+function callClassInstanceMethod<A, B, C, D>(
+  instance: any,
+  lifecycle: (a: A, b: B, c: C) => D,
+  instanceProps: mixed,
+  instanceContext: mixed,
+  instanceState: mixed,
+  a: A,
+  b: B,
+  c: C,
+): D | void {
+  instance.props = instanceProps;
+  instance.context = instanceContext;
+  instance.state = instanceState;
+  return lifecycle.call(instance, a, b, c);
+}
+exports.callClassInstanceMethod = callClassInstanceMethod;
+
+function ClassUpdater(
   scheduleUpdate: (fiber: Fiber, priorityLevel: PriorityLevel) => void,
   getPriorityContext: (fiber: Fiber, forceAsync: boolean) => PriorityLevel,
-  memoizeProps: (workInProgress: Fiber, props: any) => void,
-  memoizeState: (workInProgress: Fiber, state: any) => void,
 ) {
-  // Class component state updater
-  const updater = {
+  return {
     isMounted,
-    enqueueSetState(instance, partialState, callback) {
+    enqueueSetState(instance: any, partialState: mixed, callback: ?Callback) {
       const fiber = ReactInstanceMap.get(instance);
       const priorityLevel = getPriorityContext(fiber, false);
       callback = callback === undefined ? null : callback;
@@ -75,7 +198,7 @@ module.exports = function(
       addUpdate(fiber, partialState, callback, priorityLevel);
       scheduleUpdate(fiber, priorityLevel);
     },
-    enqueueReplaceState(instance, state, callback) {
+    enqueueReplaceState(instance: any, state: mixed, callback: ?Callback) {
       const fiber = ReactInstanceMap.get(instance);
       const priorityLevel = getPriorityContext(fiber, false);
       callback = callback === undefined ? null : callback;
@@ -85,7 +208,7 @@ module.exports = function(
       addReplaceUpdate(fiber, state, callback, priorityLevel);
       scheduleUpdate(fiber, priorityLevel);
     },
-    enqueueForceUpdate(instance, callback) {
+    enqueueForceUpdate(instance: any, callback: ?Callback) {
       const fiber = ReactInstanceMap.get(instance);
       const priorityLevel = getPriorityContext(fiber, false);
       callback = callback === undefined ? null : callback;
@@ -96,559 +219,5 @@ module.exports = function(
       scheduleUpdate(fiber, priorityLevel);
     },
   };
-
-  function checkShouldComponentUpdate(
-    workInProgress,
-    oldProps,
-    newProps,
-    oldState,
-    newState,
-    newContext,
-  ) {
-    if (
-      oldProps === null ||
-      (workInProgress.updateQueue !== null &&
-        workInProgress.updateQueue.hasForceUpdate)
-    ) {
-      // If the workInProgress already has an Update effect, return true
-      return true;
-    }
-
-    const instance = workInProgress.stateNode;
-    const type = workInProgress.type;
-    if (typeof instance.shouldComponentUpdate === 'function') {
-      if (__DEV__) {
-        startPhaseTimer(workInProgress, 'shouldComponentUpdate');
-      }
-      const shouldUpdate = instance.shouldComponentUpdate(
-        newProps,
-        newState,
-        newContext,
-      );
-      if (__DEV__) {
-        stopPhaseTimer();
-      }
-
-      if (__DEV__) {
-        warning(
-          shouldUpdate !== undefined,
-          '%s.shouldComponentUpdate(): Returned undefined instead of a ' +
-            'boolean value. Make sure to return true or false.',
-          getComponentName(workInProgress) || 'Unknown',
-        );
-      }
-
-      return shouldUpdate;
-    }
-
-    if (type.prototype && type.prototype.isPureReactComponent) {
-      return (
-        !shallowEqual(oldProps, newProps) || !shallowEqual(oldState, newState)
-      );
-    }
-
-    return true;
-  }
-
-  function checkClassInstance(workInProgress: Fiber) {
-    const instance = workInProgress.stateNode;
-    const type = workInProgress.type;
-    if (__DEV__) {
-      const name = getComponentName(workInProgress);
-      const renderPresent = instance.render;
-      warning(
-        renderPresent,
-        '%s(...): No `render` method found on the returned component ' +
-          'instance: you may have forgotten to define `render`.',
-        name,
-      );
-      const noGetInitialStateOnES6 =
-        !instance.getInitialState ||
-        instance.getInitialState.isReactClassApproved ||
-        instance.state;
-      warning(
-        noGetInitialStateOnES6,
-        'getInitialState was defined on %s, a plain JavaScript class. ' +
-          'This is only supported for classes created using React.createClass. ' +
-          'Did you mean to define a state property instead?',
-        name,
-      );
-      const noGetDefaultPropsOnES6 =
-        !instance.getDefaultProps ||
-        instance.getDefaultProps.isReactClassApproved;
-      warning(
-        noGetDefaultPropsOnES6,
-        'getDefaultProps was defined on %s, a plain JavaScript class. ' +
-          'This is only supported for classes created using React.createClass. ' +
-          'Use a static property to define defaultProps instead.',
-        name,
-      );
-      const noInstancePropTypes = !instance.propTypes;
-      warning(
-        noInstancePropTypes,
-        'propTypes was defined as an instance property on %s. Use a static ' +
-          'property to define propTypes instead.',
-        name,
-      );
-      const noInstanceContextTypes = !instance.contextTypes;
-      warning(
-        noInstanceContextTypes,
-        'contextTypes was defined as an instance property on %s. Use a static ' +
-          'property to define contextTypes instead.',
-        name,
-      );
-      const noComponentShouldUpdate =
-        typeof instance.componentShouldUpdate !== 'function';
-      warning(
-        noComponentShouldUpdate,
-        '%s has a method called ' +
-          'componentShouldUpdate(). Did you mean shouldComponentUpdate()? ' +
-          'The name is phrased as a question because the function is ' +
-          'expected to return a value.',
-        name,
-      );
-      if (
-        type.prototype &&
-        type.prototype.isPureReactComponent &&
-        typeof instance.shouldComponentUpdate !== 'undefined'
-      ) {
-        warning(
-          false,
-          '%s has a method called shouldComponentUpdate(). ' +
-            'shouldComponentUpdate should not be used when extending React.PureComponent. ' +
-            'Please extend React.Component if shouldComponentUpdate is used.',
-          getComponentName(workInProgress) || 'A pure component',
-        );
-      }
-      const noComponentDidUnmount =
-        typeof instance.componentDidUnmount !== 'function';
-      warning(
-        noComponentDidUnmount,
-        '%s has a method called ' +
-          'componentDidUnmount(). But there is no such lifecycle method. ' +
-          'Did you mean componentWillUnmount()?',
-        name,
-      );
-      const noComponentWillRecieveProps =
-        typeof instance.componentWillRecieveProps !== 'function';
-      warning(
-        noComponentWillRecieveProps,
-        '%s has a method called ' +
-          'componentWillRecieveProps(). Did you mean componentWillReceiveProps()?',
-        name,
-      );
-      const hasMutatedProps = instance.props !== workInProgress.pendingProps;
-      warning(
-        instance.props === undefined || !hasMutatedProps,
-        '%s(...): When calling super() in `%s`, make sure to pass ' +
-          "up the same props that your component's constructor was passed.",
-        name,
-        name,
-      );
-      const noInstanceDefaultProps = !instance.defaultProps;
-      warning(
-        noInstanceDefaultProps,
-        'Setting defaultProps as an instance property on %s is not supported and will be ignored.' +
-          ' Instead, define defaultProps as a static property on %s.',
-        name,
-        name,
-      );
-    }
-
-    const state = instance.state;
-    if (state && (typeof state !== 'object' || isArray(state))) {
-      invariant(
-        false,
-        '%s.state: must be set to an object or null',
-        getComponentName(workInProgress),
-      );
-    }
-    if (typeof instance.getChildContext === 'function') {
-      invariant(
-        typeof workInProgress.type.childContextTypes === 'object',
-        '%s.getChildContext(): childContextTypes must be defined in order to ' +
-          'use getChildContext().',
-        getComponentName(workInProgress),
-      );
-    }
-  }
-
-  function resetInputPointers(workInProgress: Fiber, instance: any) {
-    instance.props = workInProgress.memoizedProps;
-    instance.state = workInProgress.memoizedState;
-  }
-
-  function adoptClassInstance(workInProgress: Fiber, instance: any): void {
-    instance.updater = updater;
-    workInProgress.stateNode = instance;
-    // The instance needs access to the fiber so that it can schedule updates
-    ReactInstanceMap.set(instance, workInProgress);
-  }
-
-  function constructClassInstance(workInProgress: Fiber, props: any): any {
-    const ctor = workInProgress.type;
-    const unmaskedContext = getUnmaskedContext(workInProgress);
-    const needsContext = isContextConsumer(workInProgress);
-    const context = needsContext
-      ? getMaskedContext(workInProgress, unmaskedContext)
-      : emptyObject;
-    const instance = new ctor(props, context);
-    adoptClassInstance(workInProgress, instance);
-
-    // Cache unmasked context so we can avoid recreating masked context unless necessary.
-    // ReactFiberContext usually updates this cache but can't for newly-created instances.
-    if (needsContext) {
-      cacheContext(workInProgress, unmaskedContext, context);
-    }
-
-    return instance;
-  }
-
-  function callComponentWillMount(workInProgress, instance) {
-    if (__DEV__) {
-      startPhaseTimer(workInProgress, 'componentWillMount');
-    }
-    const oldState = instance.state;
-    instance.componentWillMount();
-    if (__DEV__) {
-      stopPhaseTimer();
-    }
-
-    if (oldState !== instance.state) {
-      if (__DEV__) {
-        warning(
-          false,
-          '%s.componentWillMount(): Assigning directly to this.state is ' +
-            "deprecated (except inside a component's " +
-            'constructor). Use setState instead.',
-          getComponentName(workInProgress),
-        );
-      }
-      updater.enqueueReplaceState(instance, instance.state, null);
-    }
-  }
-
-  function callComponentWillReceiveProps(
-    workInProgress,
-    instance,
-    newProps,
-    newContext,
-  ) {
-    if (__DEV__) {
-      startPhaseTimer(workInProgress, 'componentWillReceiveProps');
-    }
-    const oldState = instance.state;
-    instance.componentWillReceiveProps(newProps, newContext);
-    if (__DEV__) {
-      stopPhaseTimer();
-    }
-
-    if (instance.state !== oldState) {
-      if (__DEV__) {
-        warning(
-          false,
-          '%s.componentWillReceiveProps(): Assigning directly to ' +
-            "this.state is deprecated (except inside a component's " +
-            'constructor). Use setState instead.',
-          getComponentName(workInProgress),
-        );
-      }
-      updater.enqueueReplaceState(instance, instance.state, null);
-    }
-  }
-
-  // Invokes the mount life-cycles on a previously never rendered instance.
-  function mountClassInstance(
-    workInProgress: Fiber,
-    priorityLevel: PriorityLevel,
-  ): void {
-    if (__DEV__) {
-      checkClassInstance(workInProgress);
-    }
-
-    const instance = workInProgress.stateNode;
-    const state = instance.state || null;
-
-    let props = workInProgress.pendingProps;
-    invariant(
-      props,
-      'There must be pending props for an initial mount. This error is ' +
-        'likely caused by a bug in React. Please file an issue.',
-    );
-
-    const unmaskedContext = getUnmaskedContext(workInProgress);
-
-    instance.props = props;
-    instance.state = state;
-    instance.refs = emptyObject;
-    instance.context = getMaskedContext(workInProgress, unmaskedContext);
-
-    if (
-      ReactFeatureFlags.enableAsyncSubtreeAPI &&
-      workInProgress.type != null &&
-      workInProgress.type.unstable_asyncUpdates === true
-    ) {
-      workInProgress.internalContextTag |= AsyncUpdates;
-    }
-
-    if (typeof instance.componentWillMount === 'function') {
-      callComponentWillMount(workInProgress, instance);
-      // If we had additional state updates during this life-cycle, let's
-      // process them now.
-      const updateQueue = workInProgress.updateQueue;
-      if (updateQueue !== null) {
-        instance.state = beginUpdateQueue(
-          workInProgress,
-          updateQueue,
-          instance,
-          state,
-          props,
-          priorityLevel,
-        );
-      }
-    }
-    if (typeof instance.componentDidMount === 'function') {
-      workInProgress.effectTag |= Update;
-    }
-  }
-
-  // Called on a preexisting class instance. Returns false if a resumed render
-  // could be reused.
-  function resumeMountClassInstance(
-    workInProgress: Fiber,
-    priorityLevel: PriorityLevel,
-  ): boolean {
-    const instance = workInProgress.stateNode;
-    resetInputPointers(workInProgress, instance);
-
-    let newState = workInProgress.memoizedState;
-    let newProps = workInProgress.pendingProps;
-    if (!newProps) {
-      // If there isn't any new props, then we'll reuse the memoized props.
-      // This could be from already completed work.
-      newProps = workInProgress.memoizedProps;
-      invariant(
-        newProps != null,
-        'There should always be pending or memoized props. This error is ' +
-          'likely caused by a bug in React. Please file an issue.',
-      );
-    }
-    const newUnmaskedContext = getUnmaskedContext(workInProgress);
-    const newContext = getMaskedContext(workInProgress, newUnmaskedContext);
-
-    const oldContext = instance.context;
-    const oldProps = workInProgress.memoizedProps;
-
-    if (
-      typeof instance.componentWillReceiveProps === 'function' &&
-      (oldProps !== newProps || oldContext !== newContext)
-    ) {
-      callComponentWillReceiveProps(
-        workInProgress,
-        instance,
-        newProps,
-        newContext,
-      );
-    }
-
-    // Process the update queue before calling shouldComponentUpdate
-    const updateQueue = workInProgress.updateQueue;
-    if (updateQueue !== null) {
-      newState = beginUpdateQueue(
-        workInProgress,
-        updateQueue,
-        instance,
-        newState,
-        newProps,
-        priorityLevel,
-      );
-    }
-
-    // TODO: Should we deal with a setState that happened after the last
-    // componentWillMount and before this componentWillMount? Probably
-    // unsupported anyway.
-
-    if (
-      !checkShouldComponentUpdate(
-        workInProgress,
-        workInProgress.memoizedProps,
-        newProps,
-        workInProgress.memoizedState,
-        newState,
-        newContext,
-      )
-    ) {
-      // Update the existing instance's state, props, and context pointers even
-      // though we're bailing out.
-      instance.props = newProps;
-      instance.state = newState;
-      instance.context = newContext;
-      return false;
-    }
-
-    // Update the input pointers now so that they are correct when we call
-    // componentWillMount
-    instance.props = newProps;
-    instance.state = newState;
-    instance.context = newContext;
-
-    if (typeof instance.componentWillMount === 'function') {
-      callComponentWillMount(workInProgress, instance);
-      // componentWillMount may have called setState. Process the update queue.
-      const newUpdateQueue = workInProgress.updateQueue;
-      if (newUpdateQueue !== null) {
-        newState = beginUpdateQueue(
-          workInProgress,
-          newUpdateQueue,
-          instance,
-          newState,
-          newProps,
-          priorityLevel,
-        );
-      }
-    }
-
-    if (typeof instance.componentDidMount === 'function') {
-      workInProgress.effectTag |= Update;
-    }
-
-    instance.state = newState;
-
-    return true;
-  }
-
-  // Invokes the update life-cycles and returns false if it shouldn't rerender.
-  function updateClassInstance(
-    current: Fiber,
-    workInProgress: Fiber,
-    priorityLevel: PriorityLevel,
-  ): boolean {
-    const instance = workInProgress.stateNode;
-    resetInputPointers(workInProgress, instance);
-
-    const oldProps = workInProgress.memoizedProps;
-    let newProps = workInProgress.pendingProps;
-    if (!newProps) {
-      // If there aren't any new props, then we'll reuse the memoized props.
-      // This could be from already completed work.
-      newProps = oldProps;
-      invariant(
-        newProps != null,
-        'There should always be pending or memoized props. This error is ' +
-          'likely caused by a bug in React. Please file an issue.',
-      );
-    }
-    const oldContext = instance.context;
-    const newUnmaskedContext = getUnmaskedContext(workInProgress);
-    const newContext = getMaskedContext(workInProgress, newUnmaskedContext);
-
-    // Note: During these life-cycles, instance.props/instance.state are what
-    // ever the previously attempted to render - not the "current". However,
-    // during componentDidUpdate we pass the "current" props.
-
-    if (
-      typeof instance.componentWillReceiveProps === 'function' &&
-      (oldProps !== newProps || oldContext !== newContext)
-    ) {
-      callComponentWillReceiveProps(
-        workInProgress,
-        instance,
-        newProps,
-        newContext,
-      );
-    }
-
-    // Compute the next state using the memoized state and the update queue.
-    const updateQueue = workInProgress.updateQueue;
-    const oldState = workInProgress.memoizedState;
-    // TODO: Previous state can be null.
-    let newState;
-    if (updateQueue !== null) {
-      newState = beginUpdateQueue(
-        workInProgress,
-        updateQueue,
-        instance,
-        oldState,
-        newProps,
-        priorityLevel,
-      );
-    } else {
-      newState = oldState;
-    }
-
-    if (
-      oldProps === newProps &&
-      oldState === newState &&
-      !hasContextChanged() &&
-      !(updateQueue !== null && updateQueue.hasForceUpdate)
-    ) {
-      // If an update was already in progress, we should schedule an Update
-      // effect even though we're bailing out, so that cWU/cDU are called.
-      if (typeof instance.componentDidUpdate === 'function') {
-        if (
-          oldProps !== current.memoizedProps ||
-          oldState !== current.memoizedState
-        ) {
-          workInProgress.effectTag |= Update;
-        }
-      }
-      return false;
-    }
-
-    const shouldUpdate = checkShouldComponentUpdate(
-      workInProgress,
-      oldProps,
-      newProps,
-      oldState,
-      newState,
-      newContext,
-    );
-
-    if (shouldUpdate) {
-      if (typeof instance.componentWillUpdate === 'function') {
-        if (__DEV__) {
-          startPhaseTimer(workInProgress, 'componentWillUpdate');
-        }
-        instance.componentWillUpdate(newProps, newState, newContext);
-        if (__DEV__) {
-          stopPhaseTimer();
-        }
-      }
-      if (typeof instance.componentDidUpdate === 'function') {
-        workInProgress.effectTag |= Update;
-      }
-    } else {
-      // If an update was already in progress, we should schedule an Update
-      // effect even though we're bailing out, so that cWU/cDU are called.
-      if (typeof instance.componentDidUpdate === 'function') {
-        if (
-          oldProps !== current.memoizedProps ||
-          oldState !== current.memoizedState
-        ) {
-          workInProgress.effectTag |= Update;
-        }
-      }
-
-      // If shouldComponentUpdate returned false, we should still update the
-      // memoized props/state to indicate that this work can be reused.
-      memoizeProps(workInProgress, newProps);
-      memoizeState(workInProgress, newState);
-    }
-
-    // Update the existing instance's state, props, and context pointers even
-    // if shouldComponentUpdate returns false.
-    instance.props = newProps;
-    instance.state = newState;
-    instance.context = newContext;
-
-    return shouldUpdate;
-  }
-
-  return {
-    adoptClassInstance,
-    constructClassInstance,
-    mountClassInstance,
-    resumeMountClassInstance,
-    updateClassInstance,
-  };
-};
+}
+exports.ClassUpdater = ClassUpdater;

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -185,7 +185,8 @@ function callClassInstanceMethod<A, B, C, D>(
   instance.props = instanceProps;
   instance.context = instanceContext;
   instance.state = instanceState;
-  return lifecycle.call(instance, a, b, c);
+  const args = Array.prototype.slice.call(arguments, 5);
+  return lifecycle.apply(instance, args);
 }
 exports.callClassInstanceMethod = callClassInstanceMethod;
 

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -24,6 +24,7 @@ var {
   HostPortal,
   CoroutineComponent,
 } = ReactTypeOfWork;
+var {callClassInstanceMethod} = require('ReactFiberClassComponent');
 var {commitCallbacks} = require('ReactFiberUpdateQueue');
 var {onCommitUnmount} = require('ReactFiberDevToolsHook');
 var {invokeGuardedCallback} = require('ReactErrorUtils');
@@ -59,7 +60,14 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   if (__DEV__) {
     var callComponentWillUnmountWithTimerInDev = function(current, instance) {
       startPhaseTimer(current, 'componentWillUnmount');
-      instance.componentWillUnmount();
+      callClassInstanceMethod(
+        instance,
+        instance.componentWillUnmount,
+        current.memoizedProps,
+        // TODO: Is there a better way to get the memoized context?
+        instance.context,
+        current.memoizedState,
+      );
       stopPhaseTimer();
     };
   }
@@ -79,7 +87,14 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       }
     } else {
       try {
-        instance.componentWillUnmount();
+        callClassInstanceMethod(
+          instance,
+          instance.componentWillUnmount,
+          current.memoizedProps,
+          // TODO: Is there a better way to get the memoized context?
+          instance.context,
+          current.memoizedState,
+        );
       } catch (unmountError) {
         captureError(current, unmountError);
       }
@@ -450,17 +465,32 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
             if (__DEV__) {
               startPhaseTimer(finishedWork, 'componentDidMount');
             }
-            instance.componentDidMount();
+            callClassInstanceMethod(
+              instance,
+              instance.componentDidMount,
+              instance.props, // finishedWork.memoizedProps,
+              // TODO: Is there a better way to get the memoized context?
+              instance.context,
+              instance.state, // finishedWork.memoizedState,
+            );
             if (__DEV__) {
               stopPhaseTimer();
             }
           } else {
-            const prevProps = current.memoizedProps;
-            const prevState = current.memoizedState;
             if (__DEV__) {
               startPhaseTimer(finishedWork, 'componentDidUpdate');
             }
-            instance.componentDidUpdate(prevProps, prevState);
+            callClassInstanceMethod(
+              instance,
+              instance.componentDidUpdate,
+              finishedWork.memoizedProps,
+              // TODO: Is there a better way to get the memoized context?
+              instance.context,
+              finishedWork.memoizedState,
+              // Arguments
+              current.memoizedProps,
+              current.memoizedState,
+            );
             if (__DEV__) {
               stopPhaseTimer();
             }

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -58,7 +58,12 @@ function appendEffects(workInProgress, firstEffect, lastEffect) {
   }
 }
 
-function transferEffectsToParent(returnFiber: Fiber, workInProgress: Fiber) {
+type EffectList = {
+  firstEffect: Fiber | null,
+  lastEffect: Fiber | null,
+};
+
+function transferEffectsToParent(returnFiber: EffectList, workInProgress: Fiber) {
   // Append all the effects of the subtree and this fiber onto the effect
   // list of the parent. The completion order of the children affects the
   // side-effect order.
@@ -91,7 +96,6 @@ function transferEffectsToParent(returnFiber: Fiber, workInProgress: Fiber) {
     returnFiber.lastEffect = workInProgress;
   }
 }
-
 exports.transferEffectsToParent = transferEffectsToParent;
 
 exports.CompleteWork = function<T, P, I, TI, PI, C, CX, PL>(

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -327,7 +327,11 @@ exports.CompleteWork = function<T, P, I, TI, PI, C, CX, PL>(
         break;
       }
       case CoroutineComponent:
-        next = moveCoroutineToHandlerPhase(current, workInProgress, renderPriority);
+        next = moveCoroutineToHandlerPhase(
+          current,
+          workInProgress,
+          renderPriority,
+        );
         break;
       case CoroutineHandlerPhase:
         // Reset the tag to now be a first phase coroutine.
@@ -362,15 +366,15 @@ exports.CompleteWork = function<T, P, I, TI, PI, C, CX, PL>(
 
     // Work in this tree was just completed. There may be lower priority
     // remaining. Reset the work priority by bubbling it up from the children.
-    let remainingWorkPriority =
-      workInProgress.pendingWorkPriority !== renderPriority
-        // If the work priority is lower than the render priority, this must
+    let remainingWorkPriority = workInProgress.pendingWorkPriority !==
+      renderPriority
+      ? // If the work priority is lower than the render priority, this must
         // have been a bailout. Keep the existing priority so that we can come
         // back to it later.
-        ? workInProgress.pendingWorkPriority
-        // Otherwise, there's no more work on this fiber. There may be work
+        workInProgress.pendingWorkPriority
+      : // Otherwise, there's no more work on this fiber. There may be work
         // in the children, though, which we'll handle below.
-        : NoWork;
+        NoWork;
 
     const childrenAreDeprioritized =
       remainingWorkPriority === NoWork ||

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -422,33 +422,40 @@ exports.CompleteWork = function<T, P, I, TI, PI, C, CX, PL>(
         // in the children, though, which we'll handle below.
         : NoWork;
 
-    let child = workInProgress.child;
-    if (current === null || child !== current.child) {
-      // The children are a work-in-progress set. Bubble up both the work
-      // priority and the update priority.
-      while (child !== null) {
-        remainingWorkPriority = largerPriority(
-          remainingWorkPriority,
-          child.pendingWorkPriority,
-        );
-        remainingWorkPriority = largerPriority(
-          remainingWorkPriority,
-          getUpdatePriority(child),
-        );
-        child = child.sibling;
-      }
-    } else {
-      // The children are the current children. That means this was a bailout.
-      // Work priority should only be bubbled up from the work-in-progress
-      // tree, so don't bubble it up here. But update priority should be
-      // bubbled up regardless, in case there are low priority updates in
-      // the children.
-      while (child !== null) {
-        remainingWorkPriority = largerPriority(
-          remainingWorkPriority,
-          getUpdatePriority(child),
-        );
-        child = child.sibling;
+    const childrenAreDeprioritized =
+      remainingWorkPriority === NoWork ||
+      remainingWorkPriority < workInProgress.pendingWorkPriority;
+
+    // Bubble priority from the children, unless they were deprioritized.
+    if (childrenAreDeprioritized) {
+      let child = workInProgress.child;
+      if (current === null || child !== current.child) {
+        // The children are a work-in-progress set. Bubble up both the work
+        // priority and the update priority.
+        while (child !== null) {
+          remainingWorkPriority = largerPriority(
+            remainingWorkPriority,
+            child.pendingWorkPriority,
+          );
+          remainingWorkPriority = largerPriority(
+            remainingWorkPriority,
+            getUpdatePriority(child),
+          );
+          child = child.sibling;
+        }
+      } else {
+        // The children are the current children. That means this was a bailout.
+        // Work priority should only be bubbled up from the work-in-progress
+        // tree, so don't bubble it up here. But update priority should be
+        // bubbled up regardless, in case there are low priority updates in
+        // the children.
+        while (child !== null) {
+          remainingWorkPriority = largerPriority(
+            remainingWorkPriority,
+            getUpdatePriority(child),
+          );
+          child = child.sibling;
+        }
       }
     }
     workInProgress.pendingWorkPriority = remainingWorkPriority;

--- a/src/renderers/shared/fiber/ReactFiberHydrationContext.js
+++ b/src/renderers/shared/fiber/ReactFiberHydrationContext.js
@@ -90,21 +90,15 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     childToDelete.stateNode = instance;
     childToDelete.return = returnFiber;
     // Deletions are added in reversed order so we add it to the front.
-    const last = returnFiber.progressedLastDeletion;
+    const last = returnFiber.lastDeletion;
     if (last !== null) {
       last.nextEffect = childToDelete;
-      returnFiber.progressedLastDeletion = childToDelete;
+      returnFiber.lastDeletion = childToDelete;
     } else {
-      returnFiber.progressedFirstDeletion = returnFiber.progressedLastDeletion = childToDelete;
+      returnFiber.firstDeletion = returnFiber.lastDeletion = childToDelete;
     }
+    childToDelete.nextEffect = null;
     childToDelete.effectTag = Deletion;
-
-    if (returnFiber.lastEffect !== null) {
-      returnFiber.lastEffect.nextEffect = childToDelete;
-      returnFiber.lastEffect = childToDelete;
-    } else {
-      returnFiber.firstEffect = returnFiber.lastEffect = childToDelete;
-    }
   }
 
   function tryToClaimNextHydratableInstance(fiber: Fiber) {

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -13,8 +13,10 @@
 'use strict';
 
 import type {Fiber} from 'ReactFiber';
+import type {PriorityLevel} from 'ReactPriorityLevel';
 
 const {createHostRootFiber} = require('ReactFiber');
+const {NoWork} = require('ReactPriorityLevel');
 
 export type FiberRoot = {
   // Any additional information from the host associated with this root.
@@ -25,6 +27,7 @@ export type FiberRoot = {
   isScheduled: boolean,
   // The work schedule is a linked list.
   nextScheduledRoot: FiberRoot | null,
+  pendingWorkPriority: PriorityLevel,
   // The effect list, used during the commit phase.
   firstEffect: Fiber | null,
   lastEffect: Fiber | null,
@@ -42,6 +45,7 @@ exports.createFiberRoot = function(containerInfo: any): FiberRoot {
     containerInfo: containerInfo,
     isScheduled: false,
     nextScheduledRoot: null,
+    pendingWorkPriority: NoWork,
     firstEffect: null,
     lastEffect: null,
     context: null,

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -25,6 +25,9 @@ export type FiberRoot = {
   isScheduled: boolean,
   // The work schedule is a linked list.
   nextScheduledRoot: FiberRoot | null,
+  // The effect list, used during the commit phase.
+  firstEffect: Fiber | null,
+  lastEffect: Fiber | null,
   // Top context object, used by renderSubtreeIntoContainer
   context: Object | null,
   pendingContext: Object | null,
@@ -39,6 +42,8 @@ exports.createFiberRoot = function(containerInfo: any): FiberRoot {
     containerInfo: containerInfo,
     isScheduled: false,
     nextScheduledRoot: null,
+    firstEffect: null,
+    lastEffect: null,
     context: null,
     pendingContext: null,
   };

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -40,15 +40,15 @@ var {
 var {logCapturedError} = require('ReactFiberErrorLogger');
 var {invokeGuardedCallback} = require('ReactErrorUtils');
 
-var ReactFiberBeginWork = require('ReactFiberBeginWork');
-var {CompleteWork, transferEffectsToParent} = require('ReactFiberCompleteWork');
+var {BeginWork} = require('ReactFiberBeginWork');
+var {CompleteWork} = require('ReactFiberCompleteWork');
 var ReactFiberCommitWork = require('ReactFiberCommitWork');
 var ReactFiberHostContext = require('ReactFiberHostContext');
 var ReactFiberHydrationContext = require('ReactFiberHydrationContext');
 var {ReactCurrentOwner} = require('ReactGlobalSharedState');
 var getComponentName = require('getComponentName');
 
-var {createWorkInProgress, largerPriority} = require('ReactFiber');
+var {createWorkInProgress, largerPriority, transferEffectsToParent} = require('ReactFiber');
 var {onCommitRoot} = require('ReactFiberDevToolsHook');
 
 var {
@@ -153,14 +153,18 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     C
   > = ReactFiberHydrationContext(config);
   const {popHostContainer, popHostContext, resetHostContainer} = hostContext;
-  const {beginWork, beginFailedWork} = ReactFiberBeginWork(
+  const {beginWork, beginFailedWork} = BeginWork(
     config,
     hostContext,
     hydrationContext,
     scheduleUpdate,
     getPriorityContext,
   );
-  const {completeWork} = CompleteWork(config, hostContext, hydrationContext);
+  const {completeWork} = CompleteWork(
+    config,
+    hostContext,
+    hydrationContext,
+  );
   const {
     commitPlacement,
     commitDeletion,

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -321,11 +321,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       // unfortunately this is it.
       resetContextStack();
 
-      return createWorkInProgress(
-        highestPriorityRoot.current,
-        highestPriorityLevel,
-        emptyObject,
-      );
+      return createWorkInProgress(highestPriorityRoot.current, emptyObject);
     }
 
     nextPriorityLevel = NoWork;

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -68,7 +68,6 @@ var {
 var {AsyncUpdates} = require('ReactTypeOfInternalContext');
 
 var {
-  NoEffect,
   Placement,
   Update,
   PlacementAndUpdate,

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -48,7 +48,11 @@ var ReactFiberHydrationContext = require('ReactFiberHydrationContext');
 var {ReactCurrentOwner} = require('ReactGlobalSharedState');
 var getComponentName = require('getComponentName');
 
-var {createWorkInProgress, largerPriority, transferEffectsToParent} = require('ReactFiber');
+var {
+  createWorkInProgress,
+  largerPriority,
+  transferEffectsToParent,
+} = require('ReactFiber');
 var {onCommitRoot} = require('ReactFiberDevToolsHook');
 
 var {
@@ -160,11 +164,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     scheduleUpdate,
     getPriorityContext,
   );
-  const {completeWork} = CompleteWork(
-    config,
-    hostContext,
-    hydrationContext,
-  );
+  const {completeWork} = CompleteWork(config, hostContext, hydrationContext);
   const {
     commitPlacement,
     commitDeletion,

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -320,6 +320,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       return createWorkInProgress(
         highestPriorityRoot.current,
         highestPriorityLevel,
+        null,
       );
     }
 

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -284,11 +284,18 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     while (root !== null) {
       const workPriority = root.current.pendingWorkPriority;
       const updatePriority = getUpdatePriority(root.current);
-      if (workPriority !== NoWork && (highestPriorityLevel === NoWork || highestPriorityLevel > workPriority)) {
+      if (
+        workPriority !== NoWork &&
+        (highestPriorityLevel === NoWork || highestPriorityLevel > workPriority)
+      ) {
         highestPriorityLevel = workPriority;
         highestPriorityRoot = root;
       }
-      if (updatePriority !== NoWork && (highestPriorityLevel === NoWork || highestPriorityLevel > updatePriority)) {
+      if (
+        updatePriority !== NoWork &&
+        (highestPriorityLevel === NoWork ||
+          highestPriorityLevel > updatePriority)
+      ) {
         highestPriorityLevel = updatePriority;
         highestPriorityRoot = root;
       }

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -87,6 +87,7 @@ var {getUpdatePriority} = require('ReactFiberUpdateQueue');
 var {resetContext} = require('ReactFiberContext');
 
 var invariant = require('fbjs/lib/invariant');
+var emptyObject = require('fbjs/lib/emptyObject');
 
 if (__DEV__) {
   var warning = require('fbjs/lib/warning');
@@ -320,7 +321,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       return createWorkInProgress(
         highestPriorityRoot.current,
         highestPriorityLevel,
-        null,
+        emptyObject,
       );
     }
 

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -284,13 +284,12 @@ function insertUpdate(fiber: Fiber, update: Update): Update | null {
   // insertion positions because it mutates the list.
   insertUpdateIntoQueue(queue1, update, insertAfter1, insertBefore1);
 
-  if (insertBefore1 !== insertBefore2) {
-    // The insertion positions are different, so we need to clone the update and
-    // insert the clone into the alternate queue.
-    const update2 = cloneUpdate(update);
-    insertUpdateIntoQueue(queue2, update2, insertAfter2, insertBefore2);
-    return update2;
-  } else {
+  // See if the insertion positions are equal. Be careful to only compare
+  // non-null values.
+  if (
+    (insertBefore1 === insertBefore2 && insertBefore1 !== null) ||
+    (insertAfter1 === insertAfter2 && insertAfter1 !== null)
+  ) {
     // The insertion positions are the same, so when we inserted into the first
     // queue, it also inserted into the alternate. All we need to do is update
     // the alternate queue's `first` and `last` pointers, in case they
@@ -301,9 +300,14 @@ function insertUpdate(fiber: Fiber, update: Update): Update | null {
     if (insertBefore2 === null) {
       queue2.last = null;
     }
+    return null;
+  } else {
+    // The insertion positions are different, so we need to clone the update and
+    // insert the clone into the alternate queue.
+    const update2 = cloneUpdate(update);
+    insertUpdateIntoQueue(queue2, update2, insertAfter2, insertBefore2);
+    return update2;
   }
-
-  return null;
 }
 
 function addUpdate(

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -434,13 +434,14 @@ function beginUpdateQueue(
   if (current !== null && current.updateQueue === queue) {
     // We need to create a work-in-progress queue, by cloning the current queue.
     const currentQueue = queue;
-    queue.first = currentQueue.first;
-    queue.last = currentQueue.last;
-
-    // These fields are no longer valid because they were already committed.
-    // Reset them.
-    queue.callbackList = null;
-    queue.hasForceUpdate = false;
+    queue = workInProgress.updateQueue = {
+      first: currentQueue.first,
+      last: currentQueue.last,
+      // These fields are no longer valid because they were already committed.
+      // Reset them.
+      callbackList: null,
+      hasForceUpdate: false,
+    };
   }
 
   if (__DEV__) {

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -15,8 +15,6 @@
 import type {Fiber} from 'ReactFiber';
 import type {PriorityLevel} from 'ReactPriorityLevel';
 
-const {Callback: CallbackEffect} = require('ReactTypeOfSideEffect');
-
 const {
   NoWork,
   SynchronousPriority,
@@ -498,7 +496,6 @@ function beginUpdateQueue(
     ) {
       callbackList = callbackList !== null ? callbackList : [];
       callbackList.push(update.callback);
-      workInProgress.effectTag |= CallbackEffect;
     }
     update = update.next;
   }

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -27,7 +27,7 @@ describe('ReactIncremental', () => {
     ReactFeatureFlags.disableNewFiberFeatures = false;
   });
 
-  fit('should render a simple component', () => {
+  it('should render a simple component', () => {
     function Bar() {
       return <div>Hello World</div>;
     }
@@ -40,7 +40,7 @@ describe('ReactIncremental', () => {
     ReactNoop.flush();
   });
 
-  fit('should render a simple component, in steps if needed', () => {
+  it('should render a simple component, in steps if needed', () => {
     var renderCallbackCalled = false;
     var barCalled = false;
     function Bar() {
@@ -70,7 +70,7 @@ describe('ReactIncremental', () => {
     expect(renderCallbackCalled).toBe(true);
   });
 
-  fit('updates a previous render', () => {
+  it('updates a previous render', () => {
     var ops = [];
 
     function Header() {
@@ -137,7 +137,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  fit('can cancel partially rendered work and restart', () => {
+  it('can cancel partially rendered work and restart', () => {
     var ops = [];
 
     function Bar(props) {
@@ -238,7 +238,7 @@ describe('ReactIncremental', () => {
     expect(inst.state).toEqual({text: 'bar', text2: 'baz'});
   });
 
-  fit('can deprioritize unfinished work and resume it later', () => {
+  it('can deprioritize unfinished work and resume it later', () => {
     var ops = [];
 
     function Bar(props) {
@@ -346,7 +346,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Middle', 'Middle']);
   });
 
-  it('can resume work in a subtree even when a parent bails out', () => {
+  xit('can resume work in a subtree even when a parent bails out', () => {
     var ops = [];
 
     function Bar(props) {
@@ -409,7 +409,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Middle']);
   });
 
-  it('can resume work in a bailed subtree within one pass', () => {
+  xit('can resume work in a bailed subtree within one pass', () => {
     var ops = [];
 
     function Bar(props) {
@@ -507,7 +507,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
   });
 
-  it('can resume mounting a class component', () => {
+  xit('can resume mounting a class component', () => {
     let ops = [];
     let foo;
     class Parent extends React.Component {
@@ -548,7 +548,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Foo', 'Bar']);
   });
 
-  it('reuses the same instance when resuming a class instance', () => {
+  xit('reuses the same instance when resuming a class instance', () => {
     let ops = [];
     let foo;
     class Parent extends React.Component {
@@ -710,7 +710,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Middle']);
   });
 
-  it('can reuse work that began but did not complete, after being preempted', () => {
+  xit('can reuse work that began but did not complete, after being preempted', () => {
     let ops = [];
     let child;
     let sibling;
@@ -786,7 +786,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  it('can reuse work if shouldComponentUpdate is false, after being preempted', () => {
+  xit('can reuse work if shouldComponentUpdate is false, after being preempted', () => {
     var ops = [];
 
     function Bar(props) {
@@ -871,7 +871,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Middle']);
   });
 
-  it('memoizes work even if shouldComponentUpdate returns false', () => {
+  xit('memoizes work even if shouldComponentUpdate returns false', () => {
     let ops = [];
     class Foo extends React.Component {
       shouldComponentUpdate(nextProps) {
@@ -906,7 +906,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  it('can update in the middle of a tree using setState', () => {
+  xit('can update in the middle of a tree using setState', () => {
     let instance;
     class Bar extends React.Component {
       constructor() {
@@ -935,7 +935,7 @@ describe('ReactIncremental', () => {
     expect(instance.state).toEqual({a: 'a', b: 'b'});
   });
 
-  it('can queue multiple state updates', () => {
+  xit('can queue multiple state updates', () => {
     let instance;
     class Bar extends React.Component {
       constructor() {
@@ -966,7 +966,7 @@ describe('ReactIncremental', () => {
     expect(instance.state).toEqual({a: 'a', b: 'b', c: 'c', d: 'd'});
   });
 
-  it('can use updater form of setState', () => {
+  xit('can use updater form of setState', () => {
     let instance;
     class Bar extends React.Component {
       constructor() {
@@ -1003,7 +1003,7 @@ describe('ReactIncremental', () => {
     expect(instance.state.num).toEqual(6);
   });
 
-  it('can call setState inside update callback', () => {
+  xit('can call setState inside update callback', () => {
     let instance;
     class Bar extends React.Component {
       constructor() {
@@ -1041,7 +1041,7 @@ describe('ReactIncremental', () => {
     expect(instance.state.called).toEqual(true);
   });
 
-  it('can replaceState', () => {
+  xit('can replaceState', () => {
     let instance;
     class Bar extends React.Component {
       state = {a: 'a'};
@@ -1068,7 +1068,7 @@ describe('ReactIncremental', () => {
     expect(instance.state).toEqual({d: 'd'});
   });
 
-  it('can forceUpdate', () => {
+  xit('can forceUpdate', () => {
     const ops = [];
 
     function Baz() {
@@ -1108,7 +1108,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Foo', 'Bar', 'Baz', 'Bar', 'Baz']);
   });
 
-  it('can call sCU while resuming a partly mounted component', () => {
+  xit('can call sCU while resuming a partly mounted component', () => {
     var ops = [];
 
     var instances = new Set();
@@ -1157,7 +1157,7 @@ describe('ReactIncremental', () => {
     expect(instances.size).toBe(4);
   });
 
-  it('gets new props when setting state on a partly updated component', () => {
+  xit('gets new props when setting state on a partly updated component', () => {
     var ops = [];
     var instances = [];
 
@@ -1213,7 +1213,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Bar:A-1', 'Baz']);
   });
 
-  it('calls componentWillMount twice if the initial render is aborted', () => {
+  xit('calls componentWillMount twice if the initial render is aborted', () => {
     var ops = [];
 
     class LifeCycle extends React.Component {
@@ -1269,7 +1269,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  it('uses state set in componentWillMount even if initial render was aborted', () => {
+  xit('uses state set in componentWillMount even if initial render was aborted', () => {
     var ops = [];
 
     class LifeCycle extends React.Component {
@@ -1316,7 +1316,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  it('calls componentWill* twice if an update render is aborted', () => {
+  xit('calls componentWill* twice if an update render is aborted', () => {
     var ops = [];
 
     class LifeCycle extends React.Component {
@@ -1403,7 +1403,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  it('does not call componentWillReceiveProps for state-only updates', () => {
+  xit('does not call componentWillReceiveProps for state-only updates', () => {
     var ops = [];
 
     var instances = [];
@@ -1552,7 +1552,7 @@ describe('ReactIncremental', () => {
     // incomplete parents.
   });
 
-  it('skips will/DidUpdate when bailing unless an update was already in progress', () => {
+  xit('skips will/DidUpdate when bailing unless an update was already in progress', () => {
     var ops = [];
 
     class LifeCycle extends React.Component {
@@ -1648,7 +1648,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  it('performs batched updates at the end of the batch', () => {
+  xit('performs batched updates at the end of the batch', () => {
     var ops = [];
     var instance;
 
@@ -1684,7 +1684,7 @@ describe('ReactIncremental', () => {
     expect(instance.state.n).toEqual(2);
   });
 
-  it('can nest batchedUpdates', () => {
+  xit('can nest batchedUpdates', () => {
     var ops = [];
     var instance;
 
@@ -1728,7 +1728,7 @@ describe('ReactIncremental', () => {
     expect(instance.state.n).toEqual(4);
   });
 
-  it('can handle if setState callback throws', () => {
+  xit('can handle if setState callback throws', () => {
     var ops = [];
     var instance;
 
@@ -1764,7 +1764,7 @@ describe('ReactIncremental', () => {
     expect(instance.state.n).toEqual(3);
   });
 
-  it('merges and masks context', () => {
+  xit('merges and masks context', () => {
     var ops = [];
 
     class Intl extends React.Component {
@@ -1918,7 +1918,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  it('does not leak own context into context provider', () => {
+  xit('does not leak own context into context provider', () => {
     var ops = [];
     class Recurse extends React.Component {
       static contextTypes = {
@@ -1949,7 +1949,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  it('provides context when reusing work', () => {
+  xit('provides context when reusing work', () => {
     var ops = [];
 
     class Intl extends React.Component {
@@ -2006,7 +2006,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  it('reads context when setState is below the provider', () => {
+  xit('reads context when setState is below the provider', () => {
     var ops = [];
     var statefulInst;
 
@@ -2096,7 +2096,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual([]);
   });
 
-  it('reads context when setState is above the provider', () => {
+  xit('reads context when setState is above the provider', () => {
     var ops = [];
     var statefulInst;
 
@@ -2199,7 +2199,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  it('maintains the correct context when providers bail out due to low priority', () => {
+  xit('maintains the correct context when providers bail out due to low priority', () => {
     class Root extends React.Component {
       render() {
         return <Middle {...this.props} />;
@@ -2242,7 +2242,7 @@ describe('ReactIncremental', () => {
     ReactNoop.flush();
   });
 
-  it('maintains the correct context when unwinding due to an error in render', () => {
+  xit('maintains the correct context when unwinding due to an error in render', () => {
     class Root extends React.Component {
       unstable_handleError(error) {
         // If context is pushed/popped correctly,
@@ -2289,7 +2289,7 @@ describe('ReactIncremental', () => {
     ReactNoop.flush();
   });
 
-  it('should not recreate masked context unless inputs have changed', () => {
+  xit('should not recreate masked context unless inputs have changed', () => {
     const ops = [];
 
     let scuCounter = 0;
@@ -2335,7 +2335,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  it('should reuse memoized work if pointers are updated before calling lifecycles', () => {
+  xit('should reuse memoized work if pointers are updated before calling lifecycles', () => {
     let cduNextProps = [];
     let cduPrevProps = [];
     let scuNextProps = [];

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -1316,7 +1316,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  xit('calls componentWill* twice if an update render is aborted', () => {
+  it('calls componentWill* twice if an update render is aborted', () => {
     var ops = [];
 
     class LifeCycle extends React.Component {
@@ -1552,7 +1552,7 @@ describe('ReactIncremental', () => {
     // incomplete parents.
   });
 
-  xit('skips will/DidUpdate when bailing unless an update was already in progress', () => {
+  it('skips will/DidUpdate when bailing unless an update was already in progress', () => {
     var ops = [];
 
     class LifeCycle extends React.Component {

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -183,7 +183,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
   });
 
-  xit('should call callbacks even if updates are aborted', () => {
+  it('should call callbacks even if updates are aborted', () => {
     const ops = [];
     let inst;
 
@@ -346,7 +346,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Middle', 'Middle']);
   });
 
-  xit('can resume work in a subtree even when a parent bails out', () => {
+  it('can resume work in a subtree even when a parent bails out', () => {
     var ops = [];
 
     function Bar(props) {
@@ -871,7 +871,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Middle']);
   });
 
-  xit('memoizes work even if shouldComponentUpdate returns false', () => {
+  it('memoizes work even if shouldComponentUpdate returns false', () => {
     let ops = [];
     class Foo extends React.Component {
       shouldComponentUpdate(nextProps) {
@@ -1949,7 +1949,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  xit('provides context when reusing work', () => {
+  it('provides context when reusing work', () => {
     var ops = [];
 
     class Intl extends React.Component {
@@ -2006,7 +2006,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  xit('reads context when setState is below the provider', () => {
+  it('reads context when setState is below the provider', () => {
     var ops = [];
     var statefulInst;
 
@@ -2096,7 +2096,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual([]);
   });
 
-  xit('reads context when setState is above the provider', () => {
+  it('reads context when setState is above the provider', () => {
     var ops = [];
     var statefulInst;
 
@@ -2199,7 +2199,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  xit('maintains the correct context when providers bail out due to low priority', () => {
+  it('maintains the correct context when providers bail out due to low priority', () => {
     class Root extends React.Component {
       render() {
         return <Middle {...this.props} />;
@@ -2242,7 +2242,7 @@ describe('ReactIncremental', () => {
     ReactNoop.flush();
   });
 
-  xit('maintains the correct context when unwinding due to an error in render', () => {
+  it('maintains the correct context when unwinding due to an error in render', () => {
     class Root extends React.Component {
       unstable_handleError(error) {
         // If context is pushed/popped correctly,
@@ -2289,7 +2289,7 @@ describe('ReactIncremental', () => {
     ReactNoop.flush();
   });
 
-  xit('should not recreate masked context unless inputs have changed', () => {
+  it('should not recreate masked context unless inputs have changed', () => {
     const ops = [];
 
     let scuCounter = 0;
@@ -2335,7 +2335,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  xit('should reuse memoized work if pointers are updated before calling lifecycles', () => {
+  it('should reuse memoized work if pointers are updated before calling lifecycles', () => {
     let cduNextProps = [];
     let cduPrevProps = [];
     let scuNextProps = [];

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -1003,7 +1003,7 @@ describe('ReactIncremental', () => {
     expect(instance.state.num).toEqual(6);
   });
 
-  xit('can call setState inside update callback', () => {
+  it('can call setState inside update callback', () => {
     let instance;
     class Bar extends React.Component {
       constructor() {
@@ -1068,7 +1068,7 @@ describe('ReactIncremental', () => {
     expect(instance.state).toEqual({d: 'd'});
   });
 
-  xit('can forceUpdate', () => {
+  it('can forceUpdate', () => {
     const ops = [];
 
     function Baz() {

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -1648,7 +1648,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  xit('performs batched updates at the end of the batch', () => {
+  it('performs batched updates at the end of the batch', () => {
     var ops = [];
     var instance;
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -710,7 +710,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Middle']);
   });
 
-  xit('can reuse work that began but did not complete, after being preempted', () => {
+  it('can reuse work that began but did not complete, after being preempted', () => {
     let ops = [];
     let child;
     let sibling;

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -409,7 +409,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Middle']);
   });
 
-  xit('can resume work in a bailed subtree within one pass', () => {
+  it('can resume work in a bailed subtree within one pass', () => {
     var ops = [];
 
     function Bar(props) {
@@ -493,7 +493,7 @@ describe('ReactIncremental', () => {
     // Let us try this again without fully finishing the first time. This will
     // create a hanging subtree that is reconciling at the normal priority.
     ReactNoop.render(<Foo text="foo" />);
-    ReactNoop.flushDeferredPri(40);
+    ReactNoop.flushDeferredPri(35);
 
     expect(ops).toEqual(['Foo', 'Bar']);
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -507,7 +507,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
   });
 
-  xit('can resume mounting a class component', () => {
+  it('can resume mounting a class component', () => {
     let ops = [];
     let foo;
     class Parent extends React.Component {
@@ -548,7 +548,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Foo', 'Bar']);
   });
 
-  xit('reuses the same instance when resuming a class instance', () => {
+  it('reuses the same instance when resuming a class instance', () => {
     let ops = [];
     let foo;
     class Parent extends React.Component {

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -786,7 +786,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  xit('can reuse work if shouldComponentUpdate is false, after being preempted', () => {
+  it('can reuse work if shouldComponentUpdate is false, after being preempted', () => {
     var ops = [];
 
     function Bar(props) {
@@ -906,7 +906,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  xit('can update in the middle of a tree using setState', () => {
+  it('can update in the middle of a tree using setState', () => {
     let instance;
     class Bar extends React.Component {
       constructor() {
@@ -935,7 +935,7 @@ describe('ReactIncremental', () => {
     expect(instance.state).toEqual({a: 'a', b: 'b'});
   });
 
-  xit('can queue multiple state updates', () => {
+  it('can queue multiple state updates', () => {
     let instance;
     class Bar extends React.Component {
       constructor() {
@@ -966,7 +966,7 @@ describe('ReactIncremental', () => {
     expect(instance.state).toEqual({a: 'a', b: 'b', c: 'c', d: 'd'});
   });
 
-  xit('can use updater form of setState', () => {
+  it('can use updater form of setState', () => {
     let instance;
     class Bar extends React.Component {
       constructor() {
@@ -1041,7 +1041,7 @@ describe('ReactIncremental', () => {
     expect(instance.state.called).toEqual(true);
   });
 
-  xit('can replaceState', () => {
+  it('can replaceState', () => {
     let instance;
     class Bar extends React.Component {
       state = {a: 'a'};
@@ -1108,7 +1108,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Foo', 'Bar', 'Baz', 'Bar', 'Baz']);
   });
 
-  xit('can call sCU while resuming a partly mounted component', () => {
+  it('can call sCU while resuming a partly mounted component', () => {
     var ops = [];
 
     var instances = new Set();
@@ -1157,7 +1157,7 @@ describe('ReactIncremental', () => {
     expect(instances.size).toBe(4);
   });
 
-  xit('gets new props when setting state on a partly updated component', () => {
+  it('gets new props when setting state on a partly updated component', () => {
     var ops = [];
     var instances = [];
 
@@ -1213,7 +1213,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Bar:A-1', 'Baz']);
   });
 
-  xit('calls componentWillMount twice if the initial render is aborted', () => {
+  it('calls componentWillMount twice if the initial render is aborted', () => {
     var ops = [];
 
     class LifeCycle extends React.Component {
@@ -1269,7 +1269,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  xit('uses state set in componentWillMount even if initial render was aborted', () => {
+  it('uses state set in componentWillMount even if initial render was aborted', () => {
     var ops = [];
 
     class LifeCycle extends React.Component {
@@ -1403,7 +1403,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  xit('does not call componentWillReceiveProps for state-only updates', () => {
+  it('does not call componentWillReceiveProps for state-only updates', () => {
     var ops = [];
 
     var instances = [];
@@ -1684,7 +1684,7 @@ describe('ReactIncremental', () => {
     expect(instance.state.n).toEqual(2);
   });
 
-  xit('can nest batchedUpdates', () => {
+  it('can nest batchedUpdates', () => {
     var ops = [];
     var instance;
 
@@ -1728,7 +1728,7 @@ describe('ReactIncremental', () => {
     expect(instance.state.n).toEqual(4);
   });
 
-  xit('can handle if setState callback throws', () => {
+  it('can handle if setState callback throws', () => {
     var ops = [];
     var instance;
 
@@ -1764,7 +1764,7 @@ describe('ReactIncremental', () => {
     expect(instance.state.n).toEqual(3);
   });
 
-  xit('merges and masks context', () => {
+  it('merges and masks context', () => {
     var ops = [];
 
     class Intl extends React.Component {
@@ -1918,7 +1918,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  xit('does not leak own context into context provider', () => {
+  it('does not leak own context into context provider', () => {
     var ops = [];
     class Recurse extends React.Component {
       static contextTypes = {

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -27,7 +27,7 @@ describe('ReactIncremental', () => {
     ReactFeatureFlags.disableNewFiberFeatures = false;
   });
 
-  it('should render a simple component', () => {
+  fit('should render a simple component', () => {
     function Bar() {
       return <div>Hello World</div>;
     }
@@ -40,7 +40,7 @@ describe('ReactIncremental', () => {
     ReactNoop.flush();
   });
 
-  it('should render a simple component, in steps if needed', () => {
+  fit('should render a simple component, in steps if needed', () => {
     var renderCallbackCalled = false;
     var barCalled = false;
     function Bar() {
@@ -70,7 +70,7 @@ describe('ReactIncremental', () => {
     expect(renderCallbackCalled).toBe(true);
   });
 
-  it('updates a previous render', () => {
+  fit('updates a previous render', () => {
     var ops = [];
 
     function Header() {
@@ -137,7 +137,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  it('can cancel partially rendered work and restart', () => {
+  fit('can cancel partially rendered work and restart', () => {
     var ops = [];
 
     function Bar(props) {
@@ -183,7 +183,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
   });
 
-  it('should call callbacks even if updates are aborted', () => {
+  xit('should call callbacks even if updates are aborted', () => {
     const ops = [];
     let inst;
 
@@ -238,7 +238,7 @@ describe('ReactIncremental', () => {
     expect(inst.state).toEqual({text: 'bar', text2: 'baz'});
   });
 
-  it('can deprioritize unfinished work and resume it later', () => {
+  fit('can deprioritize unfinished work and resume it later', () => {
     var ops = [];
 
     function Bar(props) {

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -37,7 +37,7 @@ describe('ReactIncrementalSideEffects', () => {
     return {type: 'span', children: [], prop};
   }
 
-  fit('can update child nodes of a host instance', () => {
+  it('can update child nodes of a host instance', () => {
     function Bar(props) {
       return <span>{props.text}</span>;
     }
@@ -60,7 +60,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ReactNoop.getChildren()).toEqual([div(span(), span())]);
   });
 
-  fit('can update child nodes of a fragment', function() {
+  it('can update child nodes of a fragment', function() {
     function Bar(props) {
       return <span>{props.text}</span>;
     }
@@ -96,7 +96,7 @@ describe('ReactIncrementalSideEffects', () => {
     ]);
   });
 
-  fit('can update child nodes rendering into text nodes', function() {
+  it('can update child nodes rendering into text nodes', function() {
     function Bar(props) {
       return props.text;
     }
@@ -121,7 +121,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ReactNoop.getChildren()).toEqual([div('World', 'World', '!')]);
   });
 
-  fit('can deletes children either components, host or text', function() {
+  it('can deletes children either components, host or text', function() {
     function Bar(props) {
       return <span prop={props.children} />;
     }
@@ -197,7 +197,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ReactNoop.getChildren()).toEqual([div('Trail')]);
   });
 
-  xit('can delete a child that changes type - explicit keys', function() {
+  it('can delete a child that changes type - explicit keys', function() {
     let unmounted = false;
 
     class ClassComponent extends React.Component {
@@ -241,7 +241,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ReactNoop.getChildren()).toEqual([div('Trail')]);
   });
 
-  fit('does not update child nodes if a flush is aborted', () => {
+  it('does not update child nodes if a flush is aborted', () => {
     function Bar(props) {
       return <span prop={props.text} />;
     }
@@ -271,7 +271,7 @@ describe('ReactIncrementalSideEffects', () => {
     ]);
   });
 
-  fit('preserves a previously rendered node when deprioritized', () => {
+  it('preserves a previously rendered node when deprioritized', () => {
     function Middle(props) {
       return <span prop={props.children} />;
     }
@@ -301,7 +301,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ReactNoop.getChildren()).toEqual([div(div(span('bar')))]);
   });
 
-  fit('can reuse side-effects after being preempted', () => {
+  it('can reuse side-effects after being preempted', () => {
     function Bar(props) {
       return <span prop={props.children} />;
     }
@@ -359,7 +359,7 @@ describe('ReactIncrementalSideEffects', () => {
     ]);
   });
 
-  xit('can reuse side-effects after being preempted, if shouldComponentUpdate is false', () => {
+  it('can reuse side-effects after being preempted, if shouldComponentUpdate is false', () => {
     class Bar extends React.Component {
       shouldComponentUpdate(nextProps) {
         return this.props.children !== nextProps.children;
@@ -424,7 +424,7 @@ describe('ReactIncrementalSideEffects', () => {
     ]);
   });
 
-  fit('can update a completed tree before it has a chance to commit', () => {
+  it('can update a completed tree before it has a chance to commit', () => {
     function Foo(props) {
       return <span prop={props.step} />;
     }
@@ -456,7 +456,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ReactNoop.getChildren()).toEqual([span(3)]);
   });
 
-  fit('updates a child even though the old props is empty', () => {
+  it('updates a child even though the old props is empty', () => {
     function Foo(props) {
       return (
         <div hidden={true}>
@@ -470,7 +470,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ReactNoop.getChildren()).toEqual([div(span(1))]);
   });
 
-  xit('can defer side-effects and resume them later on', function() {
+  it('can defer side-effects and resume them later on', function() {
     class Bar extends React.Component {
       shouldComponentUpdate(nextProps) {
         return this.props.idx !== nextProps.idx;
@@ -547,7 +547,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(innerSpanA).toBe(innerSpanB);
   });
 
-  xit('can defer side-effects and reuse them later - complex', function() {
+  it('can defer side-effects and reuse them later - complex', function() {
     var ops = [];
 
     class Bar extends React.Component {
@@ -691,7 +691,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ops).toEqual(['Bar', 'Baz', 'Bar', 'Bar']);
   });
 
-  xit('deprioritizes setStates that happens within a deprioritized tree', () => {
+  it('deprioritizes setStates that happens within a deprioritized tree', () => {
     var ops = [];
 
     var barInstances = [];

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -795,7 +795,7 @@ describe('ReactIncrementalSideEffects', () => {
   // moves to "current" without flushing due to having lower priority. Does this
   // even happen? Maybe a child doesn't get processed because it is lower prio?
 
-  xit('calls callback after update is flushed', () => {
+  it('calls callback after update is flushed', () => {
     let instance;
     class Foo extends React.Component {
       constructor() {
@@ -820,7 +820,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(called).toBe(true);
   });
 
-  xit('calls setState callback even if component bails out', () => {
+  it('calls setState callback even if component bails out', () => {
     let instance;
     class Foo extends React.Component {
       constructor() {
@@ -849,7 +849,7 @@ describe('ReactIncrementalSideEffects', () => {
 
   // TODO: Test that callbacks are not lost if an update is preempted.
 
-  xit('calls componentWillUnmount after a deletion, even if nested', () => {
+  it('calls componentWillUnmount after a deletion, even if nested', () => {
     var ops = [];
 
     class Bar extends React.Component {
@@ -911,7 +911,7 @@ describe('ReactIncrementalSideEffects', () => {
     ]);
   });
 
-  xit('calls componentDidMount/Update after insertion/update', () => {
+  it('calls componentDidMount/Update after insertion/update', () => {
     var ops = [];
 
     class Bar extends React.Component {
@@ -986,7 +986,7 @@ describe('ReactIncrementalSideEffects', () => {
     ]);
   });
 
-  xit('invokes ref callbacks after insertion/update/unmount', () => {
+  it('invokes ref callbacks after insertion/update/unmount', () => {
     spyOn(console, 'error');
     var classInstance = null;
 
@@ -1058,7 +1058,7 @@ describe('ReactIncrementalSideEffects', () => {
   // TODO: Test that mounts, updates, refs, unmounts and deletions happen in the
   // expected way for aborted and resumed render life-cycles.
 
-  xit('supports string refs', () => {
+  it('supports string refs', () => {
     var fooInstance = null;
 
     class Bar extends React.Component {

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -37,7 +37,7 @@ describe('ReactIncrementalSideEffects', () => {
     return {type: 'span', children: [], prop};
   }
 
-  it('can update child nodes of a host instance', () => {
+  fit('can update child nodes of a host instance', () => {
     function Bar(props) {
       return <span>{props.text}</span>;
     }
@@ -60,7 +60,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ReactNoop.getChildren()).toEqual([div(span(), span())]);
   });
 
-  it('can update child nodes of a fragment', function() {
+  fit('can update child nodes of a fragment', function() {
     function Bar(props) {
       return <span>{props.text}</span>;
     }
@@ -96,7 +96,7 @@ describe('ReactIncrementalSideEffects', () => {
     ]);
   });
 
-  it('can update child nodes rendering into text nodes', function() {
+  fit('can update child nodes rendering into text nodes', function() {
     function Bar(props) {
       return props.text;
     }
@@ -121,7 +121,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ReactNoop.getChildren()).toEqual([div('World', 'World', '!')]);
   });
 
-  it('can deletes children either components, host or text', function() {
+  fit('can deletes children either components, host or text', function() {
     function Bar(props) {
       return <span prop={props.children} />;
     }
@@ -197,7 +197,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ReactNoop.getChildren()).toEqual([div('Trail')]);
   });
 
-  it('can delete a child that changes type - explicit keys', function() {
+  xit('can delete a child that changes type - explicit keys', function() {
     let unmounted = false;
 
     class ClassComponent extends React.Component {
@@ -241,7 +241,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ReactNoop.getChildren()).toEqual([div('Trail')]);
   });
 
-  it('does not update child nodes if a flush is aborted', () => {
+  fit('does not update child nodes if a flush is aborted', () => {
     function Bar(props) {
       return <span prop={props.text} />;
     }
@@ -271,7 +271,7 @@ describe('ReactIncrementalSideEffects', () => {
     ]);
   });
 
-  it('preserves a previously rendered node when deprioritized', () => {
+  fit('preserves a previously rendered node when deprioritized', () => {
     function Middle(props) {
       return <span prop={props.children} />;
     }
@@ -301,7 +301,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ReactNoop.getChildren()).toEqual([div(div(span('bar')))]);
   });
 
-  it('can reuse side-effects after being preempted', () => {
+  fit('can reuse side-effects after being preempted', () => {
     function Bar(props) {
       return <span prop={props.children} />;
     }
@@ -359,7 +359,7 @@ describe('ReactIncrementalSideEffects', () => {
     ]);
   });
 
-  it('can reuse side-effects after being preempted, if shouldComponentUpdate is false', () => {
+  xit('can reuse side-effects after being preempted, if shouldComponentUpdate is false', () => {
     class Bar extends React.Component {
       shouldComponentUpdate(nextProps) {
         return this.props.children !== nextProps.children;
@@ -424,7 +424,7 @@ describe('ReactIncrementalSideEffects', () => {
     ]);
   });
 
-  it('can update a completed tree before it has a chance to commit', () => {
+  fit('can update a completed tree before it has a chance to commit', () => {
     function Foo(props) {
       return <span prop={props.step} />;
     }
@@ -456,7 +456,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ReactNoop.getChildren()).toEqual([span(3)]);
   });
 
-  it('updates a child even though the old props is empty', () => {
+  fit('updates a child even though the old props is empty', () => {
     function Foo(props) {
       return (
         <div hidden={true}>
@@ -470,7 +470,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ReactNoop.getChildren()).toEqual([div(span(1))]);
   });
 
-  it('can defer side-effects and resume them later on', function() {
+  xit('can defer side-effects and resume them later on', function() {
     class Bar extends React.Component {
       shouldComponentUpdate(nextProps) {
         return this.props.idx !== nextProps.idx;
@@ -547,7 +547,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(innerSpanA).toBe(innerSpanB);
   });
 
-  it('can defer side-effects and reuse them later - complex', function() {
+  xit('can defer side-effects and reuse them later - complex', function() {
     var ops = [];
 
     class Bar extends React.Component {
@@ -691,7 +691,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ops).toEqual(['Bar', 'Baz', 'Bar', 'Bar']);
   });
 
-  it('deprioritizes setStates that happens within a deprioritized tree', () => {
+  xit('deprioritizes setStates that happens within a deprioritized tree', () => {
     var ops = [];
 
     var barInstances = [];
@@ -795,7 +795,7 @@ describe('ReactIncrementalSideEffects', () => {
   // moves to "current" without flushing due to having lower priority. Does this
   // even happen? Maybe a child doesn't get processed because it is lower prio?
 
-  it('calls callback after update is flushed', () => {
+  xit('calls callback after update is flushed', () => {
     let instance;
     class Foo extends React.Component {
       constructor() {
@@ -820,7 +820,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(called).toBe(true);
   });
 
-  it('calls setState callback even if component bails out', () => {
+  xit('calls setState callback even if component bails out', () => {
     let instance;
     class Foo extends React.Component {
       constructor() {
@@ -849,7 +849,7 @@ describe('ReactIncrementalSideEffects', () => {
 
   // TODO: Test that callbacks are not lost if an update is preempted.
 
-  it('calls componentWillUnmount after a deletion, even if nested', () => {
+  xit('calls componentWillUnmount after a deletion, even if nested', () => {
     var ops = [];
 
     class Bar extends React.Component {
@@ -911,7 +911,7 @@ describe('ReactIncrementalSideEffects', () => {
     ]);
   });
 
-  it('calls componentDidMount/Update after insertion/update', () => {
+  xit('calls componentDidMount/Update after insertion/update', () => {
     var ops = [];
 
     class Bar extends React.Component {
@@ -986,7 +986,7 @@ describe('ReactIncrementalSideEffects', () => {
     ]);
   });
 
-  it('invokes ref callbacks after insertion/update/unmount', () => {
+  xit('invokes ref callbacks after insertion/update/unmount', () => {
     spyOn(console, 'error');
     var classInstance = null;
 
@@ -1058,7 +1058,7 @@ describe('ReactIncrementalSideEffects', () => {
   // TODO: Test that mounts, updates, refs, unmounts and deletions happen in the
   // expected way for aborted and resumed render life-cycles.
 
-  it('supports string refs', () => {
+  xit('supports string refs', () => {
     var fooInstance = null;
 
     class Bar extends React.Component {

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
@@ -241,6 +241,24 @@ describe('ReactIncrementalTriangle', () => {
     simulate(step(1), toggle(0), flush(2), step(2), toggle(0));
   });
 
+  it('resumes work by comparing the priority at which the work-in-progress was created/updated', () => {
+    const {simulate} = TriangleSimulator();
+    simulate(
+      // Start a low priority update.
+      step(1),
+      // Flush part of the tree
+      flush(50),
+      // Interrupt with a high priority update to a leaf node. Part of the
+      // work from the low-pri update (step 1) overlaps with this high-pri
+      // update, but some of it is untouched.
+      toggle(17),
+      // Start a new low priority update that is the same as the current
+      // value. This should override all of the previous work. The final
+      // value of the children should be 0.
+      step(0),
+    );
+  });
+
   xit('fuzz tester', () => {
     // This test is not deterministic because the inputs are randomized. It runs
     // a limited number of tests on every run. If it fails, it will output the

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
@@ -1,0 +1,258 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var React;
+var ReactNoop;
+var ReactFeatureFlags;
+
+describe('ReactConcurrency', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    React = require('react');
+    ReactNoop = require('ReactNoop');
+
+    ReactFeatureFlags = require('ReactFeatureFlags');
+    ReactFeatureFlags.disableNewFiberFeatures = false;
+  });
+
+  function span(prop) {
+    return {type: 'span', children: [], prop};
+  }
+
+  it('works', () => {
+    let triangles = [];
+    let leafTriangles = [];
+    let didRenderTriangle = null;
+    class Triangle extends React.Component {
+      constructor(props) {
+        super();
+        this.index = triangles.length;
+        triangles.push(this);
+        if (props.depth === 0) {
+          this.leafIndex = leafTriangles.length;
+          leafTriangles.push(this);
+        }
+        this.state = {isActive: false};
+      }
+      activate() {
+        if (this.props.depth !== 0) {
+          throw new Error('Cannot activate non-leaf component');
+        }
+        this.setState({isActive: true});
+      }
+      deactivate() {
+        if (this.props.depth !== 0) {
+          throw new Error('Cannot deactivate non-leaf component');
+        }
+        this.setState({isActive: false});
+      }
+      shouldComponentUpdate(nextProps, nextState) {
+        return (
+          this.props.counter !== nextProps.counter ||
+          this.state.isActive !== nextState.isActive
+        );
+      }
+      render() {
+        didRenderTriangle = this;
+        const {counter, depth} = this.props;
+        if (depth === 0) {
+          if (this.state.isActive) {
+            return <span prop={'*' + counter + '*'} />;
+          }
+          return <span prop={counter} />;
+        }
+        return [
+          <Triangle key={1} counter={counter} depth={depth - 1} />,
+          <Triangle key={2} counter={counter} depth={depth - 1} />,
+          <Triangle key={3} counter={counter} depth={depth - 1} />,
+        ];
+      }
+    }
+
+    let app;
+    class App extends React.Component {
+      state = {counter: 0};
+      interrupt() {
+        // Triggers a restart from the top.
+        ReactNoop.performAnimationWork(() => {
+          this.setState({});
+        });
+      }
+      setCounter(counter) {
+        const currentCounter = this.state.counter;
+        this.setState({counter});
+        return currentCounter;
+      }
+      render() {
+        app = this;
+        return <Triangle counter={this.state.counter} depth={3} />;
+      }
+    }
+
+    const depth = 3;
+
+    global.debugLog = (...args) => {
+      if (!global.debug) {
+        return;
+      }
+      console.log(...args);
+    };
+
+    ReactNoop.render(<App depth={depth} />);
+    ReactNoop.flush();
+    didRenderTriangle = null;
+    // Check initial mount
+    treeIsConsistent(0);
+    const totalTriangles = triangles.length;
+
+    function treeIsConsistent(counter, ...activeIndices) {
+      const children = ReactNoop.getChildren();
+      for (let i = 0; i < children.length; i++) {
+        let child = children[i];
+        let num = child.prop;
+
+        if (activeIndices.indexOf(i) > -1) {
+          if (num !== `*${counter}*`) {
+            throw new Error(
+              `Triangle ${i} is inconsistent: ${num} instead of *${counter}*.`,
+            );
+          }
+        } else {
+          if (num !== counter) {
+            throw new Error(
+              `Triangle ${i} is inconsistent: ${num} instead of ${counter}.`,
+            );
+          }
+        }
+      }
+    }
+
+    function renderNextTriangle() {
+      let i = 0;
+      while (didRenderTriangle === null) {
+        if (i++ > 100) {
+          throw new Error('Inifinite loop');
+        }
+        ReactNoop.flushUnitsOfWork(1);
+      }
+      const triangle = didRenderTriangle;
+      didRenderTriangle = null;
+      return triangle;
+    }
+
+    function stepWithoutYielding(nextCounter) {
+      // Increment the counter.
+      const currentCounter = app.setCounter(nextCounter);
+
+      // Flush the work incrementally, resetting the unit of work pointer after
+      // each new triangle.
+      const renderedTriangles = new Set();
+      let i = 0;
+      while (renderedTriangles.size < totalTriangles) {
+        if (i++ > 100) {
+          throw new Error('Infinite loop');
+        }
+        // Flush the work incrementally, resetting the unit of work pointer after
+        // each new triangle.
+        app.interrupt();
+
+        // Flush until a new triangle is rendered
+        const renderedTriangle = renderNextTriangle();
+        treeIsConsistent(currentCounter);
+        renderedTriangles.add(renderedTriangle);
+      }
+
+      // Should only take two more units of work to commit the tree: one to
+      // complete the final span, and one to perform the commit. Otherwise,
+      // work isn't bailing out like it should.
+      ReactNoop.flushUnitsOfWork(2);
+      treeIsConsistent(nextCounter);
+    }
+
+    function stepAndToggle(
+      nextCounter,
+      targetIndex,
+      toggleOnAfter,
+      toggleOffAfter,
+    ) {
+      const currentCounter = app.setCounter(nextCounter);
+
+      const targetTriangle = leafTriangles[targetIndex];
+      if (targetTriangle == null) {
+        throw new Error('targetIndex should be the index of a leaf triangle');
+      }
+
+      let isActive = false;
+      const renderedTriangles = new Set();
+      let i = 0;
+      while (renderedTriangles.size < totalTriangles) {
+        if (i++ > 1000) {
+          throw new Error('Infinite loop');
+        }
+        app.interrupt();
+
+        var renderedTriangle = renderNextTriangle();
+        if (isActive) {
+          treeIsConsistent(currentCounter, targetIndex);
+        } else {
+          treeIsConsistent(currentCounter);
+        }
+        renderedTriangles.add(renderedTriangle);
+
+        switch (renderedTriangle.index) {
+          case toggleOnAfter:
+            ReactNoop.performAnimationWork(() => {
+              targetTriangle.activate();
+            });
+            ReactNoop.flushAnimationPri();
+            isActive = true;
+            treeIsConsistent(currentCounter, targetIndex);
+            break;
+          case toggleOffAfter:
+            global.debug = true;
+            ReactNoop.performAnimationWork(() => {
+              targetTriangle.deactivate();
+            });
+            ReactNoop.flushAnimationPri();
+            isActive = false;
+            treeIsConsistent(currentCounter);
+            global.debug = false;
+            break;
+          default:
+            break;
+        }
+      }
+
+      ReactNoop.flushUnitsOfWork(2);
+      if (isActive) {
+        treeIsConsistent(nextCounter, targetIndex);
+      } else {
+        treeIsConsistent(nextCounter);
+      }
+    }
+
+    // Render the whole tree, without toggling any nodes. After each triangle,
+    // the unit of work pointer is reset to the root, to simulate being
+    // interrupted by the container's animation.
+    stepWithoutYielding(1);
+
+    // Now let's simulate the hover effect. Same as last time, but when were
+    // partially done rendering, we'll schedule a hi-pri update to "activate"
+    // a target leaf node. Then we'll render a bit more, and scheduling another
+    // hi-pri update to "deactivate" that same node.
+    stepAndToggle(2, 5, 5, 10);
+    stepAndToggle(3, 22, 20, 22);
+    stepAndToggle(4, 13, 10, 30);
+    stepAndToggle(5, 7, 35, 38);
+  });
+});

--- a/src/renderers/shared/fiber/__tests__/__snapshots__/ReactIncrementalPerf-test.js.snap
+++ b/src/renderers/shared/fiber/__tests__/__snapshots__/ReactIncrementalPerf-test.js.snap
@@ -85,6 +85,8 @@ exports[`ReactDebugFiberPerf does not treat setState from cWM or cWRP as cascadi
   ⚛ (Committing Changes)
     ⚛ (Committing Host Effects: 2 Total)
     ⚛ (Calling Lifecycle Methods: 2 Total)
+
+⚛ (React Tree Reconciliation)
 "
 `;
 

--- a/src/renderers/shared/fiber/__tests__/__snapshots__/ReactIncrementalPerf-test.js.snap
+++ b/src/renderers/shared/fiber/__tests__/__snapshots__/ReactIncrementalPerf-test.js.snap
@@ -212,7 +212,7 @@ exports[`ReactDebugFiberPerf supports coroutines 1`] = `
       ⚛ Continuation [mount]
       ⚛ Continuation [mount]
   ⚛ (Committing Changes)
-    ⚛ (Committing Host Effects: 3 Total)
+    ⚛ (Committing Host Effects: 1 Total)
     ⚛ (Calling Lifecycle Methods: 0 Total)
 "
 `;


### PR DESCRIPTION
As the title suggests, this isn't ready for review yet, but I think the big pieces are in place.

This refactors the whole begin phase, particularly our model for progressed work. I tried to avoid doing a big refactor like this in the first pass, but eventually gave up — there are just too many inter-related things that had to change.

This also incorporates a change to make pendingWorkPriority exclude the priority of the fiber it belongs to, as in https://github.com/facebook/react/pull/8716. Again, I tried to keep this separate but it was too tied to everything else.

I wrote detailed comments inline as I refactored. I'll do an additional pass once it's closer to review.

If you're interested in taking a look, read through ReactFiberBeginWork.js. I think it's easier to follow conceptually. The basic algorithm is now:

- Do we have progressed work since the last commit?
  - If not, reset to current.
  - If we do, did it render at the current priority?
    - If not, stash the progressed work and reset to current. This "forks" the child set.
    - If it did, reuse the progressed work.
- Do we have pending props, state, or context?
  - If so, reconcile. This will update the progressed work.
  - If not, bailout. This will leave the progressed work alone.

TODO:
- [x] `pendingWorkPriority` should represent subtree, excluding fiber it belongs to
- [x] Rebase on top of https://github.com/facebook/react/pull/9580 once that lands.
- [x] Finish implementing types of work
  - [x] HostRoot
  - [x] HostComponent
    - [x] `hidden`
  - [x] HostText
  - [x] IndeterminateComponent
  - [x] FunctionalComponent
  - [x] Fragments
  - [x] Classes
  - [x] Portals
  - [x] Coroutines
- [x] Decide on heuristic for determining whether a work-in-progress fiber has been worked on since the previous commit, or if it's actually the "previous current." This can be tricky after a bailout because fibers that bail out aren't marked as progressed work.
- [x] Hydration
- [ ] Bikeshed on naming before landing:
  - [ ] Distinguish between the last work that was reconciled (currently called "progressed" work) and the most recent fiber that was worked on, including bailouts (currently called "newest" work).
  - [ ] "Resume" a work-in-progress versus "resetting" by cloning from current.
  - [ ] We use "bailout" to mean "don't reconcile," but can we be more specific? Sometimes you bailout and continue working on the child, and other times we do a "full" bailout, reuse the current child, and return null.
- [ ] Write additional unit tests (or possible rewrite some existing ones) using an explicit `yield` API to avoid brittleness. (Will probably do this in a later PR; tests aren't changing significantly and I don't think it's blocking.)
- [ ] Follow up with DevTools after this is merged https://github.com/facebook/react-devtools/pull/755