### PR TITLE
Add package builds for new server renderer and enable tests

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -46,34 +46,23 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a div with text with client render on top of good server markup
 * renders a div with text with flanking whitespace with client render on top of good server markup
 * renders a div with an empty text child with client render on top of good server markup
-* renders a div with multiple empty text children with server string render
 * renders a div with multiple empty text children with client render on top of good server markup
-* renders a div with multiple whitespace children with server string render
 * renders a div with multiple whitespace children with client render on top of good server markup
-* renders a div with text sibling to a node with server string render
 * renders a div with text sibling to a node with client render on top of good server markup
 * renders a non-standard element with text with client render on top of good server markup
 * renders a custom element with text with client render on top of good server markup
-* renders a leading blank child with a text sibling with server string render
 * renders a leading blank child with a text sibling with client render on top of good server markup
-* renders a trailing blank child with a text sibling with server string render
 * renders a trailing blank child with a text sibling with client render on top of good server markup
-* renders an element with two text children with server string render
 * renders an element with two text children with client render on top of good server markup
 * renders a number as single child with client render on top of good server markup
 * renders zero as single child with client render on top of good server markup
-* renders an element with number and text children with server string render
 * renders an element with number and text children with client render on top of good server markup
 * renders null single child as blank with client render on top of good server markup
 * renders false single child as blank with client render on top of good server markup
 * renders undefined single child as blank with client render on top of good server markup
-* renders a null component children as empty with server string render
 * renders a null component children as empty with client render on top of good server markup
-* renders null children as blank with server string render
 * renders null children as blank with client render on top of good server markup
-* renders false children as blank with server string render
 * renders false children as blank with client render on top of good server markup
-* renders null and false children together as blank with server string render
 * renders null and false children together as blank with client render on top of good server markup
 * renders only null and false children as blank with client render on top of good server markup
 * renders an svg element with client render on top of good server markup
@@ -92,12 +81,9 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders multi-child hierarchies of components with client render on top of good server markup
 * renders a div with a child with client render on top of good server markup
 * renders a div with multiple children with client render on top of good server markup
-* renders a div with multiple children separated by whitespace with server string render
 * renders a div with multiple children separated by whitespace with client render on top of good server markup
-* renders a div with a single child surrounded by whitespace with server string render
 * renders a div with a single child surrounded by whitespace with client render on top of good server markup
 * renders >,<, and & as single child with client render on top of good server markup
-* renders >,<, and & as multiple children with server string render
 * renders >,<, and & as multiple children with client render on top of good server markup
 * renders an input with a value and an onChange with client render on top of good server markup
 * renders an input with a value and readOnly with client render on top of good server markup

--- a/scripts/fiber/tests-passing-except-dev.txt
+++ b/scripts/fiber/tests-passing-except-dev.txt
@@ -1,7 +1,4 @@
 src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
-* should warn about incorrect casing on properties (ssr)
-* should warn about incorrect casing on event handlers (ssr)
-* should warn about class (ssr)
 * should suggest property name if available (ssr)
 
 src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -38,10 +35,8 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders no children attribute with client render on top of bad server markup
 * renders no key attribute with client render on top of bad server markup
 * renders no dangerouslySetInnerHTML attribute with client render on top of bad server markup
-* renders no unknown attributes with server string render
 * renders no unknown attributes with client render on top of bad server markup
 * renders unknown data- attributes with client render on top of bad server markup
-* renders no unknown attributes for non-standard elements with server string render
 * renders no unknown attributes for non-standard elements with client render on top of bad server markup
 * renders unknown attributes for custom elements with client render on top of bad server markup
 * renders unknown attributes for custom elements using is with client render on top of bad server markup

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -929,9 +929,12 @@ src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * warns on invalid nesting at root
 * warns nicely for table rows
 * gives useful context in warnings
+* should warn about incorrect casing on properties (ssr)
+* should warn about incorrect casing on event handlers (ssr)
 * should warn about incorrect casing on properties
 * should warn about incorrect casing on event handlers
 * should warn about class
+* should warn about class (ssr)
 * should warn about props that are no longer supported
 * should warn about props that are no longer supported (ssr)
 * gives source code refs for unknown prop warning
@@ -1034,9 +1037,11 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders no key attribute with clean client render
 * renders no dangerouslySetInnerHTML attribute with server string render
 * renders no dangerouslySetInnerHTML attribute with clean client render
+* renders no unknown attributes with server string render
 * renders no unknown attributes with clean client render
 * renders unknown data- attributes with server string render
 * renders unknown data- attributes with clean client render
+* renders no unknown attributes for non-standard elements with server string render
 * renders no unknown attributes for non-standard elements with clean client render
 * renders unknown attributes for custom elements with server string render
 * renders unknown attributes for custom elements with clean client render
@@ -1050,20 +1055,27 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a div with text with flanking whitespace with clean client render
 * renders a div with an empty text child with server string render
 * renders a div with an empty text child with clean client render
+* renders a div with multiple empty text children with server string render
 * renders a div with multiple empty text children with clean client render
+* renders a div with multiple whitespace children with server string render
 * renders a div with multiple whitespace children with clean client render
+* renders a div with text sibling to a node with server string render
 * renders a div with text sibling to a node with clean client render
 * renders a non-standard element with text with server string render
 * renders a non-standard element with text with clean client render
 * renders a custom element with text with server string render
 * renders a custom element with text with clean client render
+* renders a leading blank child with a text sibling with server string render
 * renders a leading blank child with a text sibling with clean client render
+* renders a trailing blank child with a text sibling with server string render
 * renders a trailing blank child with a text sibling with clean client render
+* renders an element with two text children with server string render
 * renders an element with two text children with clean client render
 * renders a number as single child with server string render
 * renders a number as single child with clean client render
 * renders zero as single child with server string render
 * renders zero as single child with clean client render
+* renders an element with number and text children with server string render
 * renders an element with number and text children with clean client render
 * renders null single child as blank with server string render
 * renders null single child as blank with clean client render
@@ -1071,9 +1083,13 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders false single child as blank with clean client render
 * renders undefined single child as blank with server string render
 * renders undefined single child as blank with clean client render
+* renders a null component children as empty with server string render
 * renders a null component children as empty with clean client render
+* renders null children as blank with server string render
 * renders null children as blank with clean client render
+* renders false children as blank with server string render
 * renders false children as blank with clean client render
+* renders null and false children together as blank with server string render
 * renders null and false children together as blank with clean client render
 * renders only null and false children as blank with server string render
 * renders only null and false children as blank with clean client render
@@ -1109,10 +1125,13 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a div with a child with clean client render
 * renders a div with multiple children with server string render
 * renders a div with multiple children with clean client render
+* renders a div with multiple children separated by whitespace with server string render
 * renders a div with multiple children separated by whitespace with clean client render
+* renders a div with a single child surrounded by whitespace with server string render
 * renders a div with a single child surrounded by whitespace with clean client render
 * renders >,<, and & as single child with server string render
 * renders >,<, and & as single child with clean client render
+* renders >,<, and & as multiple children with server string render
 * renders >,<, and & as multiple children with clean client render
 * throws when rendering a string component with server string render
 * throws when rendering an undefined component with server string render

--- a/scripts/jest/test-framework-setup.js
+++ b/scripts/jest/test-framework-setup.js
@@ -3,6 +3,7 @@
 // We want to globally mock this but jest doesn't let us do that by default
 // for a file that already exists. So we have to explicitly mock it.
 jest.mock('ReactDOM');
+jest.mock('ReactDOMServer');
 jest.mock('ReactNative');
 jest.mock('ReactDOMFeatureFlags', () => {
   const flags = require.requireActual('ReactDOMFeatureFlags');

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -158,8 +158,7 @@ const bundles = [
   /******* React DOM Server *******/
   {
     babelOpts: babelOptsReact,
-    // TODO: deal with the Node version of react-dom-server package
-    bundleTypes: [UMD_DEV, UMD_PROD, NODE_DEV, NODE_PROD, FB_DEV, FB_PROD],
+    bundleTypes: [FB_DEV, FB_PROD],
     config: {
       destDir: 'build/',
       globals: {
@@ -169,27 +168,46 @@ const bundles = [
       sourceMap: false,
     },
     entry: 'src/renderers/dom/ReactDOMServer.js',
-    externals: [
-      'prop-types',
-      'prop-types/checkPropTypes',
-      'create-react-class/factory',
-    ],
+    externals: ['prop-types', 'prop-types/checkPropTypes'],
     fbEntry: 'src/renderers/dom/ReactDOMServer.js',
     hasteName: 'ReactDOMServerStack',
     isRenderer: true,
-    label: 'dom-server',
+    label: 'dom-server-stack',
     manglePropertiesOnProd: false,
-    name: 'react-dom/server',
+    name: 'react-dom-stack/server',
     paths: [
-      'src/isomorphic/**/*.js',
       'src/renderers/dom/**/*.js',
       'src/renderers/shared/**/*.js',
       'src/ReactVersion.js',
       'src/shared/**/*.js',
-      'src/addons/**/*.js',
     ],
   },
-  // TODO: there is no Fiber version of ReactDOMServer.
+  {
+    babelOpts: babelOptsReact,
+    bundleTypes: [UMD_DEV, UMD_PROD, NODE_DEV, NODE_PROD, FB_DEV, FB_PROD],
+    config: {
+      destDir: 'build/',
+      globals: {
+        react: 'React',
+      },
+      moduleName: 'ReactDOMServer',
+      sourceMap: false,
+    },
+    entry: 'src/renderers/dom/ReactDOMServerStream.js',
+    externals: ['prop-types', 'prop-types/checkPropTypes'],
+    fbEntry: 'src/renderers/dom/ReactDOMServerStream.js',
+    hasteName: 'ReactDOMServerStream',
+    isRenderer: true,
+    label: 'dom-server-stream',
+    manglePropertiesOnProd: false,
+    name: 'react-dom/server',
+    paths: [
+      'src/renderers/dom/**/*.js',
+      'src/renderers/shared/**/*.js',
+      'src/ReactVersion.js',
+      'src/shared/**/*.js',
+    ],
+  },
 
   /******* React ART *******/
   {

--- a/src/renderers/dom/ReactDOMServer.js
+++ b/src/renderers/dom/ReactDOMServer.js
@@ -25,4 +25,15 @@ var ReactDOMServer = {
   version: ReactVersion,
 };
 
+if (__DEV__) {
+  var ReactInstrumentation = require('ReactInstrumentation');
+  var ReactDOMUnknownPropertyHook = require('ReactDOMUnknownPropertyHook');
+  var ReactDOMNullInputValuePropHook = require('ReactDOMNullInputValuePropHook');
+  var ReactDOMInvalidARIAHook = require('ReactDOMInvalidARIAHook');
+
+  ReactInstrumentation.debugTool.addHook(ReactDOMUnknownPropertyHook);
+  ReactInstrumentation.debugTool.addHook(ReactDOMNullInputValuePropHook);
+  ReactInstrumentation.debugTool.addHook(ReactDOMInvalidARIAHook);
+}
+
 module.exports = ReactDOMServer;

--- a/src/renderers/dom/ReactDOMServerStream.js
+++ b/src/renderers/dom/ReactDOMServerStream.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule ReactServer
+ * @providesModule ReactDOMServerStream
  */
 
 'use strict';
@@ -19,10 +19,10 @@ var ReactVersion = require('ReactVersion');
 ReactDOMInjection.inject();
 ReactDOMStackInjection.inject();
 
-var ReactServer = {
+var ReactDOMServer = {
   renderToString: ReactServerRenderer.renderToString,
   renderToStaticMarkup: ReactServerRenderer.renderToStaticMarkup,
   version: ReactVersion,
 };
 
-module.exports = ReactServer;
+module.exports = ReactDOMServer;

--- a/src/renderers/dom/__mocks__/ReactDOMServer.js
+++ b/src/renderers/dom/__mocks__/ReactDOMServer.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
+
+var useFiber = ReactDOMFeatureFlags.useFiber;
+
+module.exports = useFiber
+  ? require('ReactDOMServerStream')
+  : require.requireActual('ReactDOMServer');

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -528,10 +528,16 @@ describe('ReactDOMServerIntegration', () => {
         if (ReactDOMFeatureFlags.useFiber) {
           // with Fiber, there are just three separate text node children,
           // each of which is blank.
-          expect(e.childNodes.length).toBe(3);
-          expectTextNode(e.childNodes[0], '');
-          expectTextNode(e.childNodes[1], '');
-          expectTextNode(e.childNodes[2], '');
+          if (render === serverRender) {
+            // For plain server markup result we expect six comment nodes.
+            expect(e.childNodes.length).toBe(6);
+            expect(e.textContent).toBe('');
+          } else {
+            expect(e.childNodes.length).toBe(3);
+            expectTextNode(e.childNodes[0], '');
+            expectTextNode(e.childNodes[1], '');
+            expectTextNode(e.childNodes[2], '');
+          }
         } else {
           // with Stack, there are six react-text comment nodes.
           expect(e.childNodes.length).toBe(6);
@@ -545,10 +551,17 @@ describe('ReactDOMServerIntegration', () => {
         const e = await render(<div>{' '}{' '}{' '}</div>);
         if (ReactDOMFeatureFlags.useFiber) {
           // with Fiber, there are just three text nodes.
-          expect(e.childNodes.length).toBe(3);
-          expectTextNode(e.childNodes[0], ' ');
-          expectTextNode(e.childNodes[1], ' ');
-          expectTextNode(e.childNodes[2], ' ');
+          if (render === serverRender) {
+            expect(e.childNodes.length).toBe(9);
+            expectTextNode(e.childNodes[1], ' ');
+            expectTextNode(e.childNodes[4], ' ');
+            expectTextNode(e.childNodes[7], ' ');
+          } else {
+            expect(e.childNodes.length).toBe(3);
+            expectTextNode(e.childNodes[0], ' ');
+            expectTextNode(e.childNodes[1], ' ');
+            expectTextNode(e.childNodes[2], ' ');
+          }
         } else {
           // with Stack, each of the text nodes is surrounded by react-text
           // comment nodes, making 9 nodes in total.
@@ -562,7 +575,7 @@ describe('ReactDOMServerIntegration', () => {
       itRenders('a div with text sibling to a node', async render => {
         const e = await render(<div>Text<span>More Text</span></div>);
         let spanNode;
-        if (ReactDOMFeatureFlags.useFiber) {
+        if (ReactDOMFeatureFlags.useFiber && render !== serverRender) {
           // with Fiber, there are only two children, the "Text" text node and
           // the span element.
           expect(e.childNodes.length).toBe(2);
@@ -573,7 +586,11 @@ describe('ReactDOMServerIntegration', () => {
           expect(e.childNodes.length).toBe(4);
           spanNode = e.childNodes[3];
         }
-        expectTextNode(e.childNodes[0], 'Text');
+        if (ReactDOMFeatureFlags.useFiber && render === serverRender) {
+          expectTextNode(e.childNodes[1], 'Text');
+        } else {
+          expectTextNode(e.childNodes[0], 'Text');
+        }
         expect(spanNode.tagName).toBe('SPAN');
         expect(spanNode.childNodes.length).toBe(1);
         expectNode(spanNode.firstChild, TEXT_NODE_TYPE, 'More Text');
@@ -597,9 +614,14 @@ describe('ReactDOMServerIntegration', () => {
         const e = await render(<div>{''}foo</div>);
         if (ReactDOMFeatureFlags.useFiber) {
           // with Fiber, there are just two text nodes.
-          expect(e.childNodes.length).toBe(2);
-          expectTextNode(e.childNodes[0], '');
-          expectTextNode(e.childNodes[1], 'foo');
+          if (render === serverRender) {
+            expect(e.childNodes.length).toBe(5);
+            expectTextNode(e.childNodes[3], 'foo');
+          } else {
+            expect(e.childNodes.length).toBe(2);
+            expectTextNode(e.childNodes[0], '');
+            expectTextNode(e.childNodes[1], 'foo');
+          }
         } else {
           // with Stack, there are five nodes: two react-text comment nodes
           // without any text between them, and the text node foo surrounded
@@ -614,9 +636,14 @@ describe('ReactDOMServerIntegration', () => {
         const e = await render(<div>foo{''}</div>);
         if (ReactDOMFeatureFlags.useFiber) {
           // with Fiber, there are just two text nodes.
-          expect(e.childNodes.length).toBe(2);
-          expectTextNode(e.childNodes[0], 'foo');
-          expectTextNode(e.childNodes[1], '');
+          if (render === serverRender) {
+            expect(e.childNodes.length).toBe(5);
+            expectTextNode(e.childNodes[1], 'foo');
+          } else {
+            expect(e.childNodes.length).toBe(2);
+            expectTextNode(e.childNodes[0], 'foo');
+            expectTextNode(e.childNodes[1], '');
+          }
         } else {
           // with Stack, there are five nodes: the text node foo surrounded
           // by react-text comment nodes, and two react-text comment nodes
@@ -631,9 +658,15 @@ describe('ReactDOMServerIntegration', () => {
         const e = await render(<div>{'foo'}{'bar'}</div>);
         if (ReactDOMFeatureFlags.useFiber) {
           // with Fiber, there are just two text nodes.
-          expect(e.childNodes.length).toBe(2);
-          expectTextNode(e.childNodes[0], 'foo');
-          expectTextNode(e.childNodes[1], 'bar');
+          if (render === serverRender) {
+            expect(e.childNodes.length).toBe(6);
+            expectTextNode(e.childNodes[1], 'foo');
+            expectTextNode(e.childNodes[4], 'bar');
+          } else {
+            expect(e.childNodes.length).toBe(2);
+            expectTextNode(e.childNodes[0], 'foo');
+            expectTextNode(e.childNodes[1], 'bar');
+          }
         } else {
           // with Stack, there are six nodes: two text nodes, each surrounded
           // by react-text comment nodes.
@@ -660,9 +693,15 @@ describe('ReactDOMServerIntegration', () => {
         const e = await render(<div>{'foo'}{40}</div>);
         if (ReactDOMFeatureFlags.useFiber) {
           // with Fiber, there are just two text nodes.
-          expect(e.childNodes.length).toBe(2);
-          expectTextNode(e.childNodes[0], 'foo');
-          expectTextNode(e.childNodes[1], '40');
+          if (render === serverRender) {
+            expect(e.childNodes.length).toBe(6);
+            expectTextNode(e.childNodes[1], 'foo');
+            expectTextNode(e.childNodes[4], '40');
+          } else {
+            expect(e.childNodes.length).toBe(2);
+            expectTextNode(e.childNodes[0], 'foo');
+            expectTextNode(e.childNodes[1], '40');
+          }
         } else {
           // with Stack, there are six nodes: two text nodes, each surrounded
           // by react-text comment nodes.
@@ -694,7 +733,12 @@ describe('ReactDOMServerIntegration', () => {
         const e = await render(<div><NullComponent /></div>);
         if (ReactDOMFeatureFlags.useFiber) {
           // with Fiber, an empty component results in no markup.
-          expect(e.childNodes.length).toBe(0);
+          if (render === serverRender) {
+            expect(e.childNodes.length).toBe(1);
+            expectEmptyNode(e.firstChild);
+          } else {
+            expect(e.childNodes.length).toBe(0);
+          }
         } else {
           // with Stack, an empty component results in one react-empty comment
           // node.
@@ -707,36 +751,54 @@ describe('ReactDOMServerIntegration', () => {
         const e = await render(<div>{null}foo</div>);
         if (ReactDOMFeatureFlags.useFiber) {
           // with Fiber, there is just one text node.
-          expect(e.childNodes.length).toBe(1);
+          if (render === serverRender) {
+            expect(e.childNodes.length).toBe(3);
+            expectTextNode(e.childNodes[1], 'foo');
+          } else {
+            expect(e.childNodes.length).toBe(1);
+            expectTextNode(e.childNodes[0], 'foo');
+          }
         } else {
           // with Stack, there's a text node surronded by react-text comment nodes.
           expect(e.childNodes.length).toBe(3);
+          expectTextNode(e.childNodes[0], 'foo');
         }
-        expectTextNode(e.childNodes[0], 'foo');
       });
 
       itRenders('false children as blank', async render => {
         const e = await render(<div>{false}foo</div>);
         if (ReactDOMFeatureFlags.useFiber) {
           // with Fiber, there is just one text node.
-          expect(e.childNodes.length).toBe(1);
+          if (render === serverRender) {
+            expect(e.childNodes.length).toBe(3);
+            expectTextNode(e.childNodes[1], 'foo');
+          } else {
+            expect(e.childNodes.length).toBe(1);
+            expectTextNode(e.childNodes[0], 'foo');
+          }
         } else {
           // with Stack, there's a text node surronded by react-text comment nodes.
           expect(e.childNodes.length).toBe(3);
+          expectTextNode(e.childNodes[0], 'foo');
         }
-        expectTextNode(e.childNodes[0], 'foo');
       });
 
       itRenders('null and false children together as blank', async render => {
         const e = await render(<div>{false}{null}foo{null}{false}</div>);
         if (ReactDOMFeatureFlags.useFiber) {
           // with Fiber, there is just one text node.
-          expect(e.childNodes.length).toBe(1);
+          if (render === serverRender) {
+            expect(e.childNodes.length).toBe(3);
+            expectTextNode(e.childNodes[1], 'foo');
+          } else {
+            expect(e.childNodes.length).toBe(1);
+            expectTextNode(e.childNodes[0], 'foo');
+          }
         } else {
           // with Stack, there's a text node surronded by react-text comment nodes.
           expect(e.childNodes.length).toBe(3);
+          expectTextNode(e.childNodes[0], 'foo');
         }
-        expectTextNode(e.childNodes[0], 'foo');
       });
 
       itRenders('only null and false children as blank', async render => {
@@ -930,10 +992,17 @@ describe('ReactDOMServerIntegration', () => {
           if (ReactDOMFeatureFlags.useFiber) {
             // with Fiber, there are three children: the child1 element, a
             // single space text node, and the child2 element.
-            expect(e.childNodes.length).toBe(3);
-            child1 = e.childNodes[0];
-            textNode = e.childNodes[1];
-            child2 = e.childNodes[2];
+            if (render === serverRender) {
+              expect(e.childNodes.length).toBe(5);
+              child1 = e.childNodes[0];
+              textNode = e.childNodes[2];
+              child2 = e.childNodes[4];
+            } else {
+              expect(e.childNodes.length).toBe(3);
+              child1 = e.childNodes[0];
+              textNode = e.childNodes[1];
+              child2 = e.childNodes[2];
+            }
           } else {
             // with Stack, there are five children: the child1 element, a single
             // space surrounded by react-text comments, and the child2 element.
@@ -959,10 +1028,17 @@ describe('ReactDOMServerIntegration', () => {
           if (ReactDOMFeatureFlags.useFiber) {
             // with Fiber, there are three children: a one-space text node, the
             // child element, and a two-space text node.
-            expect(e.childNodes.length).toBe(3);
-            textNode1 = e.childNodes[0];
-            child = e.childNodes[1];
-            textNode2 = e.childNodes[2];
+            if (render === serverRender) {
+              expect(e.childNodes.length).toBe(7);
+              textNode1 = e.childNodes[1];
+              child = e.childNodes[3];
+              textNode2 = e.childNodes[5];
+            } else {
+              expect(e.childNodes.length).toBe(3);
+              textNode1 = e.childNodes[0];
+              child = e.childNodes[1];
+              textNode2 = e.childNodes[2];
+            }
           } else {
             // with Stack, there are 7 children: a one-space text node surrounded
             // by react-text comments, the child element, and a two-space text node
@@ -994,9 +1070,15 @@ describe('ReactDOMServerIntegration', () => {
         );
         if (ReactDOMFeatureFlags.useFiber) {
           // with Fiber, there are just two text nodes.
-          expect(e.childNodes.length).toBe(2);
-          expectTextNode(e.childNodes[0], '<span>Text1&quot;</span>');
-          expectTextNode(e.childNodes[1], '<span>Text2&quot;</span>');
+          if (render === serverRender) {
+            expect(e.childNodes.length).toBe(6);
+            expectTextNode(e.childNodes[1], '<span>Text1&quot;</span>');
+            expectTextNode(e.childNodes[4], '<span>Text2&quot;</span>');
+          } else {
+            expect(e.childNodes.length).toBe(2);
+            expectTextNode(e.childNodes[0], '<span>Text1&quot;</span>');
+            expectTextNode(e.childNodes[1], '<span>Text2&quot;</span>');
+          }
         } else {
           // with Stack there are six nodes: two text nodes each surrounded by
           // two react-text comment nodes.

--- a/src/renderers/shared/server/ReactServerRenderer.js
+++ b/src/renderers/shared/server/ReactServerRenderer.js
@@ -14,9 +14,8 @@
 var CSSPropertyOperations = require('CSSPropertyOperations');
 var DOMPropertyOperations = require('DOMPropertyOperations');
 var {registrationNameModules} = require('EventPluginRegistry');
-var React = require('React');
+var React = require('react');
 var ReactControlledValuePropTypes = require('ReactControlledValuePropTypes');
-var ReactElement = require('ReactElement');
 var ReactMarkupChecksum = require('ReactMarkupChecksum');
 
 var assertValidProps = require('assertValidProps');
@@ -25,7 +24,7 @@ var emptyObject = require('fbjs/lib/emptyObject');
 var escapeTextContentForBrowser = require('escapeTextContentForBrowser');
 var invariant = require('fbjs/lib/invariant');
 var omittedCloseTags = require('omittedCloseTags');
-var traverseAllChildren = require('traverseAllChildren');
+var traverseStackChildren = require('traverseStackChildren');
 var warning = require('fbjs/lib/warning');
 
 if (__DEV__) {
@@ -235,10 +234,7 @@ function createOpenTagMarkup(
 function resolve(child, context) {
   // TODO: We'll need to support Arrays (and strings) after Fiber is rolled out
   invariant(!Array.isArray(child), 'Did not expect to receive an Array child');
-  while (
-    ReactElement.isValidElement(child) &&
-    typeof child.type === 'function'
-  ) {
+  while (React.isValidElement(child) && typeof child.type === 'function') {
     var Component = child.type;
     var publicContext = processContext(Component, context);
 
@@ -653,7 +649,7 @@ class ReactDOMServerRenderer {
       }
       out += innerMarkup;
     } else {
-      traverseAllChildren(props.children, function(ctx, child, name) {
+      traverseStackChildren(props.children, function(ctx, child, name) {
         if (child != null) {
           children.push(child);
         }
@@ -677,7 +673,7 @@ class ReactDOMServerRenderer {
  */
 function renderToString(element) {
   invariant(
-    ReactElement.isValidElement(element),
+    React.isValidElement(element),
     'renderToString(): You must pass a valid ReactElement.',
   );
   var renderer = new ReactDOMServerRenderer(element, false);
@@ -693,7 +689,7 @@ function renderToString(element) {
  */
 function renderToStaticMarkup(element) {
   invariant(
-    ReactElement.isValidElement(element),
+    React.isValidElement(element),
     'renderToStaticMarkup(): You must pass a valid ReactElement.',
   );
   var renderer = new ReactDOMServerRenderer(element, true);


### PR DESCRIPTION
Follow up to #9673

Rename ReactServer -> ReactDOMServerStream This file is going to be the replacement for ReactDOMServer.

I mock ReactDOMServer and user ReactDOMServerStream when we have the fiber flag enabled. I'm now also enabling this as the default for distributions builds (react-dom/server on npm and react-dom-server.production.min.js as umd bundle).

I'm using traverseStackChildren instead of traverseAllChildren because traverseAllChildren is now only in the isomorphic package and we don't want to build all of that that into the server package.

I also have to require lower case react for the builds to work.

I also pulled in two commits from #9580 which fixes ReactDOMServer in Fiber mode, which fixed tests we're no longer testing (the injection) and fixes some assertions in Fiber mode to ensure that we pass a proper amount of tests.

Test Plan: Tested the SSR fixture.