### PR TITLE
Move some tests from failing to passing except dev

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -1,8 +1,3 @@
-src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
-* gives source code refs for unknown prop warning (ssr)
-* gives source code refs for unknown prop warning for exact elements (ssr)
-* gives source code refs for unknown prop warning for exact elements in composition (ssr)
-
 src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a blank div with client render on top of good server markup
 * renders a div with inline styles with client render on top of good server markup

--- a/scripts/fiber/tests-passing-except-dev.txt
+++ b/scripts/fiber/tests-passing-except-dev.txt
@@ -1,4 +1,7 @@
 src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+* gives source code refs for unknown prop warning (ssr)
+* gives source code refs for unknown prop warning for exact elements (ssr)
+* gives source code refs for unknown prop warning for exact elements in composition (ssr)
 * should suggest property name if available (ssr)
 
 src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -1592,10 +1592,10 @@ describe('ReactDOMComponent', () => {
       ReactTestUtils.renderIntoDocument(<div class="paladin" />);
       ReactTestUtils.renderIntoDocument(<input type="text" onclick="1" />);
       expectDev(console.error.calls.count()).toBe(2);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+      expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
         'Warning: Unknown DOM property class. Did you mean className?\n    in div (at **)',
       );
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
+      expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
         'Warning: Unknown event handler property onclick. Did you mean ' +
           '`onClick`?\n    in input (at **)',
       );
@@ -1606,10 +1606,10 @@ describe('ReactDOMComponent', () => {
       ReactDOMServer.renderToString(<div class="paladin" />);
       ReactDOMServer.renderToString(<input type="text" onclick="1" />);
       expectDev(console.error.calls.count()).toBe(2);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+      expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
         'Warning: Unknown DOM property class. Did you mean className?\n    in div (at **)',
       );
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
+      expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
         'Warning: Unknown event handler property onclick. Did you mean ' +
           '`onClick`?\n    in input (at **)',
       );
@@ -1624,7 +1624,7 @@ describe('ReactDOMComponent', () => {
 
       ReactTestUtils.renderIntoDocument(<div class="paladin" />, container);
       expectDev(console.error.calls.count()).toBe(1);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+      expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
         'Warning: Unknown DOM property class. Did you mean className?\n    in div (at **)',
       );
     });
@@ -1674,15 +1674,16 @@ describe('ReactDOMComponent', () => {
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain('className');
       var matches = console.error.calls.argsFor(0)[0].match(/.*\(.*:(\d+)\).*/);
-      var previousLine = matches[1];
+      var previousLine = (matches || [])[1];
 
       expectDev(console.error.calls.argsFor(1)[0]).toContain('onClick');
-      matches = console.error.calls.argsFor(1)[0].match(/.*\(.*:(\d+)\).*/);
-      var currentLine = matches[1];
+      matches = console.error.calls.argsFor(1)[0].match(/.*\(.*:(\d+)\).*/) || {
+      };
+      var currentLine = (matches || [])[1];
 
       //verify line number has a proper relative difference,
       //since hard coding the line number would make test too brittle
-      expect(parseInt(previousLine, 10) + 2).toBe(parseInt(currentLine, 10));
+      expectDev(parseInt(previousLine, 10) + 2).toBe(parseInt(currentLine, 10));
     });
 
     it('gives source code refs for unknown prop warning for exact elements in composition', () => {
@@ -1725,11 +1726,11 @@ describe('ReactDOMComponent', () => {
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain('className');
       var matches = console.error.calls.argsFor(0)[0].match(/.*\(.*:(\d+)\).*/);
-      var previousLine = matches[1];
+      var previousLine = (matches || [])[1];
 
       expectDev(console.error.calls.argsFor(1)[0]).toContain('onClick');
       matches = console.error.calls.argsFor(1)[0].match(/.*\(.*:(\d+)\).*/);
-      var currentLine = matches[1];
+      var currentLine = (matches || [])[1];
 
       //verify line number has a proper relative difference,
       //since hard coding the line number would make test too brittle
@@ -1776,15 +1777,17 @@ describe('ReactDOMComponent', () => {
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain('className');
       var matches = console.error.calls.argsFor(0)[0].match(/.*\(.*:(\d+)\).*/);
-      var previousLine = matches[1];
+      var previousLine = (matches || [])[1];
 
       expectDev(console.error.calls.argsFor(1)[0]).toContain('onClick');
       matches = console.error.calls.argsFor(1)[0].match(/.*\(.*:(\d+)\).*/);
-      var currentLine = matches[1];
+      var currentLine = (matches || [])[1];
 
       //verify line number has a proper relative difference,
       //since hard coding the line number would make test too brittle
-      expect(parseInt(previousLine, 10) + 12).toBe(parseInt(currentLine, 10));
+      expectDev(parseInt(previousLine, 10) + 12).toBe(
+        parseInt(currentLine, 10),
+      );
     });
 
     it('should suggest property name if available', () => {


### PR DESCRIPTION
These throw because we're asserting on the warnings. Make this not throw so that they instead only fail to assert the warnings.

We don't warn for this in the new server renderer atm.
