### PR TITLE
[#9712] fix <input type="number" /> value '.98' should not be equal to '0.98'.

### DIFF
--- a/fixtures/dom/src/components/fixtures/number-inputs/NumberInputDecimal.js
+++ b/fixtures/dom/src/components/fixtures/number-inputs/NumberInputDecimal.js
@@ -1,0 +1,33 @@
+const React = window.React;
+
+import Fixture from '../../Fixture';
+
+class NumberInputDecimal extends React.Component {
+  state = { value: '.98' };
+  changeValue = () => {
+    this.setState({
+      value: '0.98',
+    });
+  }
+  render() {
+    const {value} = this.state;
+    return (
+      <Fixture>
+        <div>{this.props.children}</div>
+
+        <div className="control-box">
+          <input
+            type="number"
+            value={value}
+            onChange={(e) => {
+             this.setState({value: e.target.value}); 
+            }}
+          />
+          <button onClick={this.changeValue}>change.98 to 0.98</button>
+        </div>
+      </Fixture>
+    );
+  }
+}
+
+export default NumberInputDecimal;

--- a/fixtures/dom/src/components/fixtures/number-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/number-inputs/index.js
@@ -160,7 +160,7 @@ function NumberInputs() {
         <NumberTestCase />
       </TestCase>
       <TestCase
-          title="decimal numbers"
+          title="Decimal numbers"
           description="eg: initial value is '.98', when format to '0.98', should change to '0.98' "
       >
         <TestCase.Steps>

--- a/fixtures/dom/src/components/fixtures/number-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/number-inputs/index.js
@@ -3,6 +3,7 @@ const React = window.React;
 import FixtureSet from '../../FixtureSet';
 import TestCase from '../../TestCase';
 import NumberTestCase from './NumberTestCase';
+import NumberInputDecimal from './NumberInputDecimal';
 
 function NumberInputs() {
   return (
@@ -157,6 +158,20 @@ function NumberInputs() {
           The field should read "-3".
         </TestCase.ExpectedResult>
         <NumberTestCase />
+      </TestCase>
+      <TestCase
+          title="decimal numbers"
+          description="eg: initial value is '.98', when format to '0.98', should change to '0.98' "
+      >
+        <TestCase.Steps>
+          <li>initial value is '.98'</li>
+          <li>setState to '0.98'</li>
+        </TestCase.Steps>
+
+        <TestCase.ExpectedResult>
+          the input value should be '0.98'.
+        </TestCase.ExpectedResult>
+        <NumberInputDecimal />
       </TestCase>
     </FixtureSet>
   );

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1477,6 +1477,7 @@ src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
 * does change the number 2 to "2.0" with no change handler
 * does change the string "2" to "2.0" with no change handler
 * changes the number 2 to "2.0" using a change handler
+* does change the string ".98" to "0.98" with no change handler
 * should display `defaultValue` of number 0
 * only assigns defaultValue if it changes
 * should display "true" for `defaultValue` of `true`

--- a/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
+++ b/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
@@ -203,9 +203,10 @@ var ReactDOMInput = {
         // Simulate `input.valueAsNumber`. IE9 does not support it
         var valueAsNumber = parseFloat(node.value, 10) || 0;
 
-        // eslint-disable-next-line
         if (
+          // eslint-disable-next-line
           value != valueAsNumber ||
+          // eslint-disable-next-line
           (value == valueAsNumber && node.value != value)
         ) {
           // Cast `value` to a string to ensure the value is set correctly. While

--- a/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
+++ b/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
@@ -204,7 +204,10 @@ var ReactDOMInput = {
         var valueAsNumber = parseFloat(node.value, 10) || 0;
 
         // eslint-disable-next-line
-        if (value != valueAsNumber) {
+        if (
+          value != valueAsNumber ||
+          (value == valueAsNumber && node.value != value)
+        ) {
           // Cast `value` to a string to ensure the value is set correctly. While
           // browsers typically do this as necessary, jsdom doesn't.
           node.value = '' + value;

--- a/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
@@ -233,6 +233,23 @@ describe('ReactDOMInput', () => {
     });
   });
 
+  it('does change the string ".98" to "0.98" with no change handler', () => {
+    class Stub extends React.Component {
+      state = {
+        value: '.98',
+      };
+      render() {
+        return <input type="number" value={this.state.value} />;
+      }
+    }
+
+    var stub = ReactTestUtils.renderIntoDocument(<Stub />);
+    var node = ReactDOM.findDOMNode(stub);
+    stub.setState({value: '0.98'});
+
+    expect(node.value).toEqual('0.98');
+  });
+
   it('should display `defaultValue` of number 0', () => {
     var stub = <input type="text" defaultValue={0} />;
     stub = ReactTestUtils.renderIntoDocument(stub);

--- a/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
@@ -195,9 +195,10 @@ var ReactDOMInput = {
         // Simulate `input.valueAsNumber`. IE9 does not support it
         var valueAsNumber = parseFloat(node.value, 10) || 0;
 
-        // eslint-disable-next-line
         if (
+          // eslint-disable-next-line
           value != valueAsNumber ||
+          // eslint-disable-next-line
           (value == valueAsNumber && node.value != value)
         ) {
           // Cast `value` to a string to ensure the value is set correctly. While

--- a/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
+++ b/src/renderers/dom/stack/client/wrappers/ReactDOMInput.js
@@ -196,7 +196,10 @@ var ReactDOMInput = {
         var valueAsNumber = parseFloat(node.value, 10) || 0;
 
         // eslint-disable-next-line
-        if (value != valueAsNumber) {
+        if (
+          value != valueAsNumber ||
+          (value == valueAsNumber && node.value != value)
+        ) {
           // Cast `value` to a string to ensure the value is set correctly. While
           // browsers typically do this as necessary, jsdom doesn't.
           node.value = '' + value;


### PR DESCRIPTION
fix bug #9712 

I found in 15.5.4 is NOT OK, but in 16.0.0-alpha.3 is ok.
In 16.0.0-alpha.3 the number type is not handled separately. 

[15.5.4 is NOT OK](https://github.com/facebook/react/blob/master/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js#L202)

[16.0.0-alpha.3 is OK](https://github.com/facebook/react/blob/v16.0.0-alpha.3/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js#L190)

the change is base on master. Maybe the pr is worth to accept.