### PR TITLE
Fix typo in explaining HOC

### DIFF
--- a/docs/docs/higher-order-components.md
+++ b/docs/docs/higher-order-components.md
@@ -261,7 +261,7 @@ The most common signature for HOCs looks like this:
 
 ```js
 // React Redux's `connect`
-const ConnectedComment = connect(commentSelector, commentActions)(Comment);
+const ConnectedComment = connect(commentSelector, commentActions)(CommentList);
 ```
 
 *What?!* If you break it apart, it's easier to see what's going on.


### PR DESCRIPTION
The example explaining how redux's connect works doesn't use the same component name. Line 264 references (Comment) while 274 referenced (CommentList). Changed 264 to match 274.
