### PR TITLE
Add Videos link to React Europe 2017

### DIFF
--- a/docs/community/conferences.md
+++ b/docs/community/conferences.md
@@ -123,4 +123,4 @@ April 21st in Amsterdam, The Netherlands
 ### ReactEurope 2017
 May 18th & 19th in Paris, France
 
-[Website](http://www.react-europe.org/) - [Schedule](http://www.react-europe.org/#schedule)
+[Website](http://www.react-europe.org/) - [Schedule](http://www.react-europe.org/#schedule) - [Videos](https://www.youtube.com/channel/UCorlLn2oZfgOJ-FUcF2eZ1A/playlists)


### PR DESCRIPTION
Videos have now started appearing on React Europe's YouTube channel, added the link in the docs.