### PR TITLE
Improve low priority warning

### DIFF
--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -1,8 +1,8 @@
 {
   "bundleSizes": {
     "react.development.js (UMD_DEV)": {
-      "size": 125119,
-      "gzip": 31339
+      "size": 125800,
+      "gzip": 31378
     },
     "react.production.min.js (UMD_PROD)": {
       "size": 15753,
@@ -33,24 +33,24 @@
       "gzip": 29313
     },
     "react.development.js (NODE_DEV)": {
-      "size": 71914,
-      "gzip": 18276
+      "size": 72595,
+      "gzip": 18499
     },
     "react.production.min.js (NODE_PROD)": {
       "size": 9195,
       "gzip": 3614
     },
     "React-dev.js (FB_DEV)": {
-      "size": 73423,
-      "gzip": 18751
+      "size": 74104,
+      "gzip": 18972
     },
     "React-prod.js (FB_PROD)": {
       "size": 36836,
       "gzip": 9248
     },
     "ReactDOMStack-dev.js (FB_DEV)": {
-      "size": 496986,
-      "gzip": 118763
+      "size": 497667,
+      "gzip": 118999
     },
     "ReactDOMStack-prod.js (FB_PROD)": {
       "size": 353129,

--- a/src/shared/utils/lowPriorityWarning.js
+++ b/src/shared/utils/lowPriorityWarning.js
@@ -28,7 +28,7 @@
 var lowPriorityWarning = function() {};
 
 if (__DEV__) {
-  const printWarning = function (format, ...args) {
+  const printWarning = function(format, ...args) {
     var argIndex = 0;
     var message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
     if (typeof console !== 'undefined') {

--- a/src/shared/utils/lowPriorityWarning.js
+++ b/src/shared/utils/lowPriorityWarning.js
@@ -19,7 +19,6 @@
  * and do nothing when 'console' is not supported.
  * This really simplifies the code.
  * ---
- *
  * Similar to invariant but only logs a warning if the condition is not met.
  * This can be used to log issues in development environments in critical
  * paths. Removing the logging code for production environments will keep the
@@ -29,11 +28,29 @@
 var lowPriorityWarning = function() {};
 
 if (__DEV__) {
-  lowPriorityWarning = function(condition, format, ...args) {
+  const printWarning = function (format, ...args) {
     var argIndex = 0;
     var message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
-    if (!condition && typeof console !== 'undefined') {
+    if (typeof console !== 'undefined') {
       console.warn(message);
+    }
+    try {
+      // --- Welcome to debugging React ---
+      // This error was thrown as a convenience so that you can use this stack
+      // to find the callsite that caused this warning to fire.
+      throw new Error(message);
+    } catch (x) {}
+  };
+
+  lowPriorityWarning = function(condition, format, ...args) {
+    if (format === undefined) {
+      throw new Error(
+        '`warning(condition, format, ...args)` requires a warning ' +
+          'message argument',
+      );
+    }
+    if (!condition) {
+      printWarning(format, ...args);
     }
   };
 }


### PR DESCRIPTION
Thanks to @spicyj for suggesting this in code review of https://github.com/facebook/react/pull/9650

**what is the change?:**
This change makes 'lowPriorityWarning' an exact copy of 'warning.js' from
https://github.com/facebook/fbjs/blob/e66ba20ad5be433eb54423f2b097d829324d9de6/packages/fbjs/src/__forks__/warning.js
where before we had skipped some checks from that module.

- Adds an error which we catch, in order to let people find the error and resulting stack trace when using devtools with 'pause on caught errors' checked.
- Adds check that 'format' argument is passed

**why make this change?:**
- To maintain a closer fork to 'warning.js'
- To allow easier debugging using 'pause on caught errors'
- To validate inputs to 'lowPriorityWarning'

**test plan:**
`yarn test`

**issue:**
https://github.com/facebook/react/issues/9398