### PR TITLE
Update print warning script for low priority warning

### DIFF
--- a/scripts/print-warnings/print-warnings.js
+++ b/scripts/print-warnings/print-warnings.js
@@ -46,7 +46,11 @@ function transform(file, enc, cb) {
     traverse(ast, {
       CallExpression: {
         exit: function(astPath) {
-          if (astPath.get('callee').isIdentifier({name: 'warning'})) {
+          const callee = astPath.get('callee');
+          if (
+            callee.isIdentifier({name: 'warning'}) ||
+            callee.isIdentifier({name: 'lowPriorityWarning'})
+          ) {
             const node = astPath.node;
 
             // warning messages can be concatenated (`+`) at runtime, so here's

--- a/src/shared/utils/lowPriorityWarning.js
+++ b/src/shared/utils/lowPriorityWarning.js
@@ -28,7 +28,7 @@
 var lowPriorityWarning = function() {};
 
 if (__DEV__) {
-  const printWarning = function (format, ...args) {
+  const printWarning = function(format, ...args) {
     var argIndex = 0;
     var message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
     if (typeof console !== 'undefined') {

--- a/src/shared/utils/lowPriorityWarning.js
+++ b/src/shared/utils/lowPriorityWarning.js
@@ -28,7 +28,7 @@
 var lowPriorityWarning = function() {};
 
 if (__DEV__) {
-  const printWarning = function(format, ...args) {
+  const printWarning = function (format, ...args) {
     var argIndex = 0;
     var message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
     if (typeof console !== 'undefined') {


### PR DESCRIPTION
NOTE: This PR was made on a branch that goes off of https://github.com/facebook/react/pull/9754 and I'll rebase it once that lands.

So when reviewing just look at the change in `scripts/print-warnings/print-warnings.js`.

     **what is the change?:**
    We print the logs from 'lowPriorityWarning' as well as 'warning' from the 'print-warnings' script.
    
    NOTE: This PR is branching off of https://github.com/facebook/react/pull/9754
    
    **why make this change?:**
    We want to use the same process of white/blacklisting warnings with 'lowPriorityWarning' that we do with 'warning'.
    
    **test plan:**
    This is not super easy to test unless we are doing a sync with FB afaik. I plan on running a sync in the next few days, or next week at latest, for the sake of not landing big things on a Friday. That will be the actual test of this.
    
    **issue:**
    https://github.com/facebook/react/issues/9398