### PR TITLE
Remove stray reference to React.PropTypes in ReactLink

### DIFF
--- a/src/addons/link/ReactLink.js
+++ b/src/addons/link/ReactLink.js
@@ -34,6 +34,7 @@
  * consumption of ReactLink easier; see LinkedValueUtils and LinkedStateMixin.
  */
 
+var PropTypes = require('prop-types');
 var React = require('React');
 
 /**
@@ -59,11 +60,11 @@ function ReactLink(value, requestChange) {
 function createLinkTypeChecker(linkType) {
   var shapes = {
     value: linkType === undefined
-      ? React.PropTypes.any.isRequired
+      ? PropTypes.any.isRequired
       : linkType.isRequired,
-    requestChange: React.PropTypes.func.isRequired,
+    requestChange: PropTypes.func.isRequired,
   };
-  return React.PropTypes.shape(shapes);
+  return PropTypes.shape(shapes);
 }
 
 ReactLink.PropTypes = {


### PR DESCRIPTION
**what is the change?:**
It looks like we missed updating this callsite in https://github.com/facebook/react/commit/12a96b94823d6b6de6b1ac13bd576864abd50175

**why make this change?:**
We are deprecating the `React.PropTypes` syntax and splitting that functionality into [a separate module](https://github.com/facebook/react/commit/12a96b94823d6b6de6b1ac13bd576864abd50175).
@acdlite please correct me if there is a reason we left this here.

**test plan:**
`yarn test`

**issue:**
fixes #9755 