### PR TITLE
Remove react proptypes references

### DIFF
--- a/docs/_js/live_editor.js
+++ b/docs/_js/live_editor.js
@@ -10,8 +10,8 @@ var IS_MOBILE = (
 
 var CodeMirrorEditor = React.createClass({
   propTypes: {
-    lineNumbers: React.PropTypes.bool,
-    onChange: React.PropTypes.func,
+    lineNumbers: PropTypes.bool,
+    onChange: PropTypes.func,
   },
   getDefaultProps: function() {
     return {
@@ -80,12 +80,12 @@ var ReactPlayground = React.createClass({
   MODES: {JSX: 'JSX', JS: 'JS'}, //keyMirror({JSX: true, JS: true}),
 
   propTypes: {
-    codeText: React.PropTypes.string.isRequired,
-    transformer: React.PropTypes.func,
-    renderCode: React.PropTypes.bool,
-    showCompiledJSTab: React.PropTypes.bool,
-    showLineNumbers: React.PropTypes.bool,
-    editorTabTitle: React.PropTypes.string,
+    codeText: PropTypes.string.isRequired,
+    transformer: PropTypes.func,
+    renderCode: PropTypes.bool,
+    showCompiledJSTab: PropTypes.bool,
+    showLineNumbers: PropTypes.bool,
+    editorTabTitle: PropTypes.string,
   },
 
   getDefaultProps: function() {

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -48,6 +48,7 @@
   <script src="https://unpkg.com/codemirror@5.15.2/mode/javascript/javascript.js"></script>
   <script src="https://unpkg.com/codemirror@5.15.2/mode/xml/xml.js"></script>
   <script src="https://unpkg.com/codemirror@5.15.2/mode/jsx/jsx.js"></script>
+  <script src="https://unpkg.com/prop-types/prop-types.min.js"></script>
   <script src="https://unpkg.com/react/dist/react.min.js"></script>
   <script src="https://unpkg.com/react-dom/dist/react-dom.min.js"></script>
   <script src="https://unpkg.com/babel-standalone@6.15.0/babel.min.js"></script>

--- a/docs/warnings/dont-call-proptypes.md
+++ b/docs/warnings/dont-call-proptypes.md
@@ -15,7 +15,7 @@ The normal usage of PropTypes is still supported:
 
 ```javascript
 Button.propTypes = {
-  highlighted: React.PropTypes.bool
+  highlighted: PropTypes.bool
 };
 ```
 
@@ -26,9 +26,9 @@ Nothing changes here.
 Using PropTypes in any other way than annotating React components with them is no longer supported:
 
 ```javascript
-var apiShape = React.PropTypes.shape({
-  body: React.PropTypes.object,
-  statusCode: React.PropTypes.number.isRequired
+var apiShape = PropTypes.shape({
+  body: PropTypes.object,
+  statusCode: PropTypes.number.isRequired
 }).isRequired;
 
 // Not supported!
@@ -46,13 +46,13 @@ Inspect the stack trace produced by the warning. You will find the component def
 ```js
 Button.propTypes = {
   highlighted: ThirdPartyPropTypes.deprecated(
-    React.PropTypes.bool,
+    PropTypes.bool,
     'Use `active` prop instead'
   )
 }
 ```
 
-In this case, `ThirdPartyPropTypes.deprecated` is a wrapper calling `React.PropTypes.bool`. This pattern by itself is fine, but triggers a false positive because React thinks you are calling PropTypes directly. The next section explains how to fix this problem for a library implementing something like `ThirdPartyPropTypes`. If it's not a library you wrote, you can file an issue against it.
+In this case, `ThirdPartyPropTypes.deprecated` is a wrapper calling `PropTypes.bool`. This pattern by itself is fine, but triggers a false positive because React thinks you are calling PropTypes directly. The next section explains how to fix this problem for a library implementing something like `ThirdPartyPropTypes`. If it's not a library you wrote, you can file an issue against it.
 
 ### Fixing the false positive in third party PropTypes
 


### PR DESCRIPTION
Following on from #9757, the purpose of this PR is to remove the few remaining React.PropTypes references.
I have only found a few occurrences in the doc and the warnings messages in the tests so it is only of minor importance.

Commits related to the live editor and the "warning" page have been tested by running the documentation in local.

Commit related to the warning sentences in the tests is more problematic because it breaks the tests if the warning message in the [prop-types](https://github.com/facebook/prop-types) library is not updated as well.
If it is acceptable, another option would be to only test the beginning of the warning message.
I am unsure but I also guess that the _scripts/error-codes/codes.json_ file should be regenerated.
So maybe this last commit could be excluded from the PR, because given these constraints it may not be worth it.
