### PR TITLE
Remove PropTypes dependency from ReactLink

### DIFF
--- a/src/addons/link/ReactLink.js
+++ b/src/addons/link/ReactLink.js
@@ -34,7 +34,6 @@
  * consumption of ReactLink easier; see LinkedValueUtils and LinkedStateMixin.
  */
 
-var PropTypes = require('prop-types');
 var React = require('React');
 
 /**
@@ -48,27 +47,5 @@ function ReactLink(value, requestChange) {
   this.value = value;
   this.requestChange = requestChange;
 }
-
-/**
- * Creates a PropType that enforces the ReactLink API and optionally checks the
- * type of the value being passed inside the link. Example:
- *
- * MyComponent.propTypes = {
- *   tabIndexLink: ReactLink.PropTypes.link(React.PropTypes.number)
- * }
- */
-function createLinkTypeChecker(linkType) {
-  var shapes = {
-    value: linkType === undefined
-      ? PropTypes.any.isRequired
-      : linkType.isRequired,
-    requestChange: PropTypes.func.isRequired,
-  };
-  return PropTypes.shape(shapes);
-}
-
-ReactLink.PropTypes = {
-  link: createLinkTypeChecker,
-};
 
 module.exports = ReactLink;


### PR DESCRIPTION
It doesn't seem to be used. It was probably used by internal FB consumers of ReactLink which has long been removed.
