### PR TITLE
Improve deprecation warnings by more info and links

### DIFF
--- a/src/isomorphic/React.js
+++ b/src/isomorphic/React.js
@@ -59,8 +59,9 @@ if (__DEV__) {
   createMixin = function(mixin) {
     lowPriorityWarning(
       warnedForCreateMixin,
-      'React.createMixin is deprecated and should not be used. You ' +
-        'can use this mixin directly instead.',
+      'In React 16.0, React.createMixin is deprecated and should not be used. ' +
+        'You can use this mixin directly instead.' +
+        ' See (https://fb.me/createmixin-was-never-implemented) for more info.',
     );
     warnedForCreateMixin = true;
     return mixin;
@@ -109,8 +110,11 @@ if (__DEV__) {
       get() {
         lowPriorityWarning(
           didWarnPropTypesDeprecated,
-          'Accessing PropTypes via the main React package is deprecated. Use ' +
-            'the prop-types package from npm instead.',
+          'In React v16.0+, accessing PropTypes via the main React package is deprecated. Use ' +
+            'the prop-types package from npm instead.' +
+            ' Version 15.5.10 provides a drop-in replacement.' +
+            ' For info on usage, compatibility, migration and more, see ' +
+            'https://fb.me/prop-types-docs',
         );
         didWarnPropTypesDeprecated = true;
         return ReactPropTypes;
@@ -129,8 +133,10 @@ if (__DEV__) {
         lowPriorityWarning(
           false,
           'Accessing factories like React.DOM.%s has been deprecated ' +
-            'and will be removed in the future. Use the ' +
-            'react-addons-dom-factories package instead.',
+            'and will be removed in v16.0+. Use the ' +
+            'react-addons-dom-factories package instead. ' +
+            ' Version 1.0 provides a drop-in replacement.' +
+            ' For more info, see https://fb.me/react-addons-dom-factories',
           factory,
         );
         warnedForFactories = true;

--- a/src/isomorphic/React.js
+++ b/src/isomorphic/React.js
@@ -59,9 +59,10 @@ if (__DEV__) {
   createMixin = function(mixin) {
     lowPriorityWarning(
       warnedForCreateMixin,
-      'In React 16.0, React.createMixin is deprecated and should not be used. ' +
-        'You can use this mixin directly instead.' +
-        ' See (https://fb.me/createmixin-was-never-implemented) for more info.',
+      'React.createMixin is deprecated and should not be used. ' +
+        'In React v16.0, it will be removed. ' +
+        'You can use this mixin directly instead. ' +
+        'See https://fb.me/createmixin-was-never-implemented for more info.',
     );
     warnedForCreateMixin = true;
     return mixin;
@@ -110,8 +111,9 @@ if (__DEV__) {
       get() {
         lowPriorityWarning(
           didWarnPropTypesDeprecated,
-          'In React v16.0+, accessing PropTypes via the main React package is deprecated. Use ' +
-            'the prop-types package from npm instead.' +
+          'Accessing PropTypes via the main React package is deprecated,' +
+            ' and will be removed in  React v16.0.' +
+            ' Use the prop-types package from npm instead.' +
             ' Version 15.5.10 provides a drop-in replacement.' +
             ' For info on usage, compatibility, migration and more, see ' +
             'https://fb.me/prop-types-docs',


### PR DESCRIPTION
Not sure who to tag for review, but this and adding the warnings for `React.createClass` should be the last two things blocking the 15.6RC. So anyone who wants to unblock by reviewing feel free~ 🚀

**what is the change?:**
Updates the warnings for -
 - `React.createMixin` (was never implemented!)
 - `React.PropTypes`
 - `React.DOM.*`

**I think we never added the warning for `React.createClass` to the 15.5 line**, unless I'm missing it, so
a follow-up PR will add that, with a link to docs etc.

Does *not* update the older warnings for -
 - Factory.type
 - 'isMounted' and 'replaceState'
 - ReactPerf

We could do a second pass if we want to improve those three warnings, but for now I don't think they are as hi-pri.

Still TODO:
 - Do an initial release of the [`react-addons-dom-factories`](https://github.com/facebook/react/tree/master/packages/react-dom-factories#react-addons-dom-factories) package on npm, making it 1.0.
 - Improve the docs for `react-addons-dom-factories` adding documentation and mention the [codemod](https://github.com/reactjs/react-codemod/blob/master/transforms/React-DOM-to-react-dom-factories.js)

**why make this change?:**
 - We want to make updating as easy as possible. Warning messages should increase clarity, and in the past they have caused confusion.

**test plan:**
`yarn test` and running these messages past some folks who use React.

**issue:**
https://github.com/facebook/react/issues/9398