### PR TITLE
Insert blockquote on prop value explanation.

### DIFF
--- a/docs/docs/lifting-state-up.md
+++ b/docs/docs/lifting-state-up.md
@@ -196,7 +196,7 @@ Now, when the `TemperatureInput` wants to update its temperature, it calls `this
     this.props.onTemperatureChange(e.target.value);
 ```
 
-Note that there is no special meaning to either `temperature` or `onTemperatureChange` prop names in custom components. We could have called them anything else, like name them `value` and `onChange` which is a common convention.
+> Note that there is no special meaning to either `temperature` or `onTemperatureChange` prop names in custom components. We could have called them anything else, like name them `value` and `onChange` which is a common convention.
 
 The `onTemperatureChange` prop will be provided together with the `temperature` prop by the parent `Calculator` component. It will handle the change by modifying its own local state, thus re-rendering both inputs with the new values. We will look at the new `Calculator` implementation very soon.
 


### PR DESCRIPTION
While reading the page, the "chain of thought" is broken by stating that the `tempertature` and `onTemperatureChange` don't have any special meaning. Making this a blockquote makes that note look more like a comment and keep the "chain of thought" intact.
