### PR TITLE
Boolean attributes no longer coerced to string

### DIFF
--- a/docs/docs/jsx-in-depth.md
+++ b/docs/docs/jsx-in-depth.md
@@ -218,9 +218,9 @@ When you pass a string literal, its value is HTML-unescaped. So these two JSX ex
 
 This behavior is usually not relevant. It's only mentioned here for completeness.
 
-### Props Default to "True"
+### Props Default to Empty String
 
-If you pass no value for a prop, it defaults to `true`. These two JSX expressions are equivalent:
+If you pass no value for a prop, it defaults to ''. These two JSX expressions are equivalent:
 
 ```js
 <MyTextBox autocomplete />

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -800,6 +800,7 @@ src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
 * should set values as namespace attributes if necessary
 * should set values as boolean properties
 * should convert attribute values to string first
+* should set values as boolean attributes
 * should not remove empty attributes for special properties
 * should remove for falsey boolean properties
 * should remove when setting custom attr to null

--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -170,6 +170,7 @@ var DOMPropertyOperations = {
       DOMPropertyOperations.setValueForAttribute(node, name, value);
       return;
     }
+
     if (__DEV__) {
       var payload = {};
       payload[name] = value;
@@ -187,9 +188,9 @@ var DOMPropertyOperations = {
     }
     if (value == null) {
       node.removeAttribute(name);
-    } else if (value === true || value === 'true') {
+    } else if (value === true) {
       node.setAttribute(name, '');
-    } else if (value === false || value === 'false') {
+    } else if (value === false) {
       node.removeAttribute(name);
     } else {
       node.setAttribute(name, '' + value);

--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -170,7 +170,6 @@ var DOMPropertyOperations = {
       DOMPropertyOperations.setValueForAttribute(node, name, value);
       return;
     }
-
     if (__DEV__) {
       var payload = {};
       payload[name] = value;
@@ -187,6 +186,10 @@ var DOMPropertyOperations = {
       return;
     }
     if (value == null) {
+      node.removeAttribute(name);
+    } else if (value === true || value === 'true') {
+      node.setAttribute(name, '');
+    } else if (value === false || value === 'false') {
       node.removeAttribute(name);
     } else {
       node.setAttribute(name, '' + value);

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -142,7 +142,7 @@ describe('DOMPropertyOperations', () => {
     });
   });
 
-  describe.only('setValueForProperty', () => {
+  describe('setValueForProperty', () => {
     var stubNode;
     var stubInstance;
 
@@ -203,7 +203,7 @@ describe('DOMPropertyOperations', () => {
       expect(stubNode.getAttribute('role')).toBe('<html>');
     });
 
-    it.only('should set values as boolean attributes', () => {
+    it('should set values as boolean attributes', () => {
       DOMPropertyOperations.setValueForProperty(stubNode, 'data-foo', true);
       expect(stubNode.getAttribute('data-foo')).toBe('');
       DOMPropertyOperations.setValueForProperty(stubNode, 'data-foo', false);

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -142,7 +142,7 @@ describe('DOMPropertyOperations', () => {
     });
   });
 
-  describe('setValueForProperty', () => {
+  describe.only('setValueForProperty', () => {
     var stubNode;
     var stubInstance;
 
@@ -201,6 +201,13 @@ describe('DOMPropertyOperations', () => {
       };
       DOMPropertyOperations.setValueForProperty(stubNode, 'role', obj);
       expect(stubNode.getAttribute('role')).toBe('<html>');
+    });
+
+    it.only('should set values as boolean attributes', () => {
+      DOMPropertyOperations.setValueForProperty(stubNode, 'data-foo', true);
+      expect(stubNode.getAttribute('data-foo')).toBe('');
+      DOMPropertyOperations.setValueForProperty(stubNode, 'data-foo', false);
+      expect(stubNode.getAttribute('data-foo')).toBe(null);
     });
 
     it('should not remove empty attributes for special properties', () => {


### PR DESCRIPTION
From #9230, this abides by the HTML5 spec mentioned in the issue.  This issue was left in an unsure state and I wanted to try my first contribution.