### PR TITLE
Improve warning for `React.createClass`

### DIFF
--- a/src/isomorphic/React.js
+++ b/src/isomorphic/React.js
@@ -112,8 +112,7 @@ if (__DEV__) {
           didWarnPropTypesDeprecated,
           'Accessing PropTypes via the main React package is deprecated,' +
             ' and will be removed in  React v16.0.' +
-            ' Use the prop-types package from npm instead.' +
-            ' Version 15.5.10 provides a drop-in replacement.' +
+            ' Use the latest available 15.* prop-types package from npm instead.' +
             ' For info on usage, compatibility, migration and more, see ' +
             'https://fb.me/prop-types-docs',
         );
@@ -129,7 +128,7 @@ if (__DEV__) {
           'Accessing createClass via the main React package is deprecated,' +
             ' and will be removed in React v16.0.' +
             " Use a plain JavaScript class instead. If you're not yet " +
-            'ready to migrade, create-react-class v15.5.3 is available ' +
+            'ready to migrade, create-react-class v15.* is available ' +
             'on npm as a temporary, drop-in replacement. ' +
             'For more info see https://fb.me/react-create-class',
         );

--- a/src/isomorphic/React.js
+++ b/src/isomorphic/React.js
@@ -112,7 +112,7 @@ if (__DEV__) {
           didWarnPropTypesDeprecated,
           'Accessing PropTypes via the main React package is deprecated,' +
             ' and will be removed in  React v16.0.' +
-            ' Use the latest available 15.* prop-types package from npm instead.' +
+            ' Use the latest available v15.* prop-types package from npm instead.' +
             ' For info on usage, compatibility, migration and more, see ' +
             'https://fb.me/prop-types-docs',
         );
@@ -128,7 +128,7 @@ if (__DEV__) {
           'Accessing createClass via the main React package is deprecated,' +
             ' and will be removed in React v16.0.' +
             " Use a plain JavaScript class instead. If you're not yet " +
-            'ready to migrade, create-react-class v15.* is available ' +
+            'ready to migrate, create-react-class v15.* is available ' +
             'on npm as a temporary, drop-in replacement. ' +
             'For more info see https://fb.me/react-create-class',
         );

--- a/src/isomorphic/React.js
+++ b/src/isomorphic/React.js
@@ -126,10 +126,12 @@ if (__DEV__) {
       get: function() {
         lowPriorityWarning(
           warnedForCreateClass,
-          'React.createClass is no longer supported. Use a plain JavaScript ' +
-            "class instead. If you're not yet ready to migrate, " +
-            'create-react-class is available on npm as a temporary, ' +
-            'drop-in replacement.',
+          'Accessing createClass via the main React package is deprecated,' +
+            ' and will be removed in React v16.0.' +
+            " Use a plain JavaScript class instead. If you're not yet " +
+            'ready to migrade, create-react-class v15.5.3 is available ' +
+            'on npm as a temporary, drop-in replacement. ' +
+            'For more info see https://fb.me/react-create-class',
         );
         warnedForCreateClass = true;
         return createReactClass;

--- a/src/isomorphic/__tests__/React-test.js
+++ b/src/isomorphic/__tests__/React-test.js
@@ -46,10 +46,10 @@ describe('React', () => {
     expect(console.warn.calls.count()).toBe(1);
     expect(console.warn.calls.argsFor(0)[0]).toContain(
       'Warning: Accessing createClass via the main React package is ' +
-        'deprecated, and will be removed in React v16.0. Use a plain ' +
-        "JavaScript class instead. If you're not yet ready to migrade," +
-        ' create-react-class v15.5.3 is available on npm as a ' +
-        'temporary, drop-in replacement. ' +
+        'deprecated, and will be removed in React v16.0. ' +
+        'Use a plain JavaScript class instead. ' +
+        "If you're not yet ready to migrade, create-react-class " +
+        'v15.* is available on npm as a temporary, drop-in replacement. ' +
         'For more info see https://fb.me/react-create-class',
     );
   });
@@ -63,8 +63,7 @@ describe('React', () => {
     expect(console.warn.calls.argsFor(0)[0]).toContain(
       'Warning: Accessing PropTypes via the main React package is ' +
         'deprecated, and will be removed in  React v16.0. ' +
-        'Use the prop-types package from npm instead. ' +
-        'Version 15.5.10 provides a drop-in replacement. ' +
+        'Use the latest available 15.* prop-types package from npm instead. ' +
         'For info on usage, compatibility, migration and more, ' +
         'see https://fb.me/prop-types-docs',
     );

--- a/src/isomorphic/__tests__/React-test.js
+++ b/src/isomorphic/__tests__/React-test.js
@@ -45,10 +45,12 @@ describe('React', () => {
     expect(createClass).not.toBe(undefined);
     expect(console.warn.calls.count()).toBe(1);
     expect(console.warn.calls.argsFor(0)[0]).toContain(
-      'React.createClass is no longer supported. Use a plain ' +
-        "JavaScript class instead. If you're not yet ready to migrate, " +
-        'create-react-class is available on npm as a temporary, ' +
-        'drop-in replacement.',
+      'Warning: Accessing createClass via the main React package is ' +
+        'deprecated, and will be removed in React v16.0. Use a plain ' +
+        "JavaScript class instead. If you're not yet ready to migrade," +
+        ' create-react-class v15.5.3 is available on npm as a ' +
+        'temporary, drop-in replacement. ' +
+        'For more info see https://fb.me/react-create-class',
     );
   });
 

--- a/src/isomorphic/__tests__/React-test.js
+++ b/src/isomorphic/__tests__/React-test.js
@@ -47,9 +47,9 @@ describe('React', () => {
     expect(console.warn.calls.argsFor(0)[0]).toContain(
       'Warning: Accessing createClass via the main React package is ' +
         'deprecated, and will be removed in React v16.0. ' +
-        'Use a plain JavaScript class instead. ' +
-        "If you're not yet ready to migrade, create-react-class " +
-        'v15.* is available on npm as a temporary, drop-in replacement. ' +
+        "Use a plain JavaScript class instead. If you're not yet ready " +
+        'to migrate, create-react-class v15.* is available on npm as ' +
+        'a temporary, drop-in replacement. ' +
         'For more info see https://fb.me/react-create-class',
     );
   });
@@ -63,9 +63,9 @@ describe('React', () => {
     expect(console.warn.calls.argsFor(0)[0]).toContain(
       'Warning: Accessing PropTypes via the main React package is ' +
         'deprecated, and will be removed in  React v16.0. ' +
-        'Use the latest available 15.* prop-types package from npm instead. ' +
-        'For info on usage, compatibility, migration and more, ' +
-        'see https://fb.me/prop-types-docs',
+        'Use the latest available v15.* prop-types package from ' +
+        'npm instead. For info on usage, compatibility, migration ' +
+        'and more, see https://fb.me/prop-types-docs',
     );
   });
 });


### PR DESCRIPTION
This might be the last PR to land for 15.6RC! 💫

**what is the change?:**
- Explain that this will be removed in v16.0 specifically
- Mention the version number for the drop-in replacement module.
- Link to docs in the blog post about how to migrate

**why make this change?:**
We want to make our deprecation warnings more clear and helpful.

**test plan:**
Visual inspection and `yarn test`

**issue:**
https://github.com/facebook/react/issues/9398