### PR TITLE
Corrected a stubbed modules problem for RN fiber bundle

### DIFF
--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -317,7 +317,7 @@ const bundles = [
     ],
     useFiber: false,
     modulesToStub: [
-      "'createReactNativeFiberComponentClass'",
+      "'createReactNativeComponentClassFiber'",
       "'ReactNativeFiberRenderer'",
       "'findNumericNodeHandleFiber'",
       "'ReactNativeFiber'",
@@ -359,7 +359,7 @@ const bundles = [
     ],
     useFiber: true,
     modulesToStub: [
-      "'createReactNativeComponentClass'",
+      "'createReactNativeComponentClassStack'",
       "'findNumericNodeHandleStack'",
       "'ReactNativeStack'",
     ],

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -165,20 +165,20 @@
       "gzip": 83320
     },
     "ReactNativeStack-dev.js (RN_DEV)": {
-      "size": 182999,
-      "gzip": 35650
+      "size": 182305,
+      "gzip": 35469
     },
     "ReactNativeStack-prod.js (RN_PROD)": {
-      "size": 134766,
-      "gzip": 25923
+      "size": 134072,
+      "gzip": 25710
     },
     "ReactNativeFiber-dev.js (RN_DEV)": {
-      "size": 271047,
-      "gzip": 49114
+      "size": 278278,
+      "gzip": 50225
     },
     "ReactNativeFiber-prod.js (RN_PROD)": {
-      "size": 208977,
-      "gzip": 36295
+      "size": 216205,
+      "gzip": 37384
     }
   }
 }

--- a/src/renderers/native/createReactNativeComponentClass.js
+++ b/src/renderers/native/createReactNativeComponentClass.js
@@ -12,51 +12,15 @@
 
 'use strict';
 
-const ReactNativeBaseComponent = require('ReactNativeBaseComponent');
 const ReactNativeFeatureFlags = require('ReactNativeFeatureFlags');
-const ReactNativeViewConfigRegistry = require('ReactNativeViewConfigRegistry');
 
 // See also ReactNativeBaseComponent
-type ReactNativeBaseComponentViewConfig = {
+export type ReactNativeBaseComponentViewConfig = {
   validAttributes: Object,
   uiViewClassName: string,
   propTypes?: Object,
 };
 
-/**
- * @param {string} config iOS View configuration.
- * @private
- */
-const createReactNativeFiberComponentClass = function(
-  viewConfig: ReactNativeBaseComponentViewConfig,
-): string {
-  return ReactNativeViewConfigRegistry.register(viewConfig);
-};
-
-/**
- * @param {string} config iOS View configuration.
- * @private
- */
-const createReactNativeComponentClass = function(
-  viewConfig: ReactNativeBaseComponentViewConfig,
-): ReactClass<any> {
-  const Constructor = function(element) {
-    this._currentElement = element;
-    this._topLevelWrapper = null;
-    this._hostParent = null;
-    this._hostContainerInfo = null;
-    this._rootNodeID = 0;
-    this._renderedChildren = null;
-  };
-  Constructor.displayName = viewConfig.uiViewClassName;
-  Constructor.viewConfig = viewConfig;
-  Constructor.propTypes = viewConfig.propTypes;
-  Constructor.prototype = new ReactNativeBaseComponent(viewConfig);
-  Constructor.prototype.constructor = Constructor;
-
-  return ((Constructor: any): ReactClass<any>);
-};
-
 module.exports = ReactNativeFeatureFlags.useFiber
-  ? createReactNativeFiberComponentClass
-  : createReactNativeComponentClass;
+  ? require('createReactNativeComponentClassFiber')
+  : require('createReactNativeComponentClassStack');

--- a/src/renderers/native/createReactNativeComponentClassFiber.js
+++ b/src/renderers/native/createReactNativeComponentClassFiber.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule createReactNativeComponentClassFiber
+ * @flow
+ */
+
+'use strict';
+
+const ReactNativeViewConfigRegistry = require('ReactNativeViewConfigRegistry');
+
+import type {
+  ReactNativeBaseComponentViewConfig,
+} from './createReactNativeComponentClass';
+
+/**
+ * @param {string} config iOS View configuration.
+ * @private
+ */
+const createReactNativeComponentClassFiber = function(
+  viewConfig: ReactNativeBaseComponentViewConfig,
+): string {
+  return ReactNativeViewConfigRegistry.register(viewConfig);
+};
+
+module.exports = createReactNativeComponentClassFiber;

--- a/src/renderers/native/createReactNativeComponentClassStack.js
+++ b/src/renderers/native/createReactNativeComponentClassStack.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule createReactNativeComponentClassStack
+ * @flow
+ */
+
+'use strict';
+
+const ReactNativeBaseComponent = require('ReactNativeBaseComponent');
+
+import type {
+  ReactNativeBaseComponentViewConfig,
+} from './createReactNativeComponentClass';
+
+/**
+ * @param {string} config iOS View configuration.
+ * @private
+ */
+const createReactNativeComponentClassStack = function(
+  viewConfig: ReactNativeBaseComponentViewConfig,
+): ReactClass<any> {
+  const Constructor = function(element) {
+    this._currentElement = element;
+    this._topLevelWrapper = null;
+    this._hostParent = null;
+    this._hostContainerInfo = null;
+    this._rootNodeID = 0;
+    this._renderedChildren = null;
+  };
+  Constructor.displayName = viewConfig.uiViewClassName;
+  Constructor.viewConfig = viewConfig;
+  Constructor.propTypes = viewConfig.propTypes;
+  Constructor.prototype = new ReactNativeBaseComponent(viewConfig);
+  Constructor.prototype.constructor = Constructor;
+
+  return ((Constructor: any): ReactClass<any>);
+};
+
+module.exports = createReactNativeComponentClassStack;


### PR DESCRIPTION
I made a mistake when stubbing out the `createReactNativeComponentClass` module for fiber. Corrected it by splitting files and updating the blacklist.