### PR TITLE
Fix externalization of 'lowPriorityWarning' in fb builds

### DIFF
--- a/scripts/rollup/modules.js
+++ b/scripts/rollup/modules.js
@@ -78,10 +78,11 @@ function createModuleMap(paths, extractErrors, bundleType) {
       moduleMap[moduleName] = resolve(file);
     });
   });
-  // if this is FB, we want to remove ReactCurrentOwner, so we can
-  // handle it with a different case
+  // if this is FB, we want to remove ReactCurrentOwner and lowPriorityWarning,
+  // so we can handle it with a different case
   if (bundleType === FB_DEV || bundleType === FB_PROD) {
     delete moduleMap.ReactCurrentOwner;
+    delete moduleMap.lowPriorityWarning;
   }
   return moduleMap;
 }
@@ -120,6 +121,7 @@ function ignoreFBModules() {
     // In FB bundles, we preserve an inline require to ReactCurrentOwner.
     // See the explanation in FB version of ReactCurrentOwner in www:
     'ReactCurrentOwner',
+    'lowPriorityWarning',
   ];
 }
 

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -41,16 +41,16 @@
       "gzip": 3614
     },
     "React-dev.js (FB_DEV)": {
-      "size": 74115,
-      "gzip": 18980
+      "size": 71806,
+      "gzip": 18233
     },
     "React-prod.js (FB_PROD)": {
-      "size": 36847,
-      "gzip": 9254
+      "size": 36172,
+      "gzip": 9226
     },
     "ReactDOMStack-dev.js (FB_DEV)": {
-      "size": 497678,
-      "gzip": 119007
+      "size": 495315,
+      "gzip": 118265
     },
     "ReactDOMStack-prod.js (FB_PROD)": {
       "size": 353140,


### PR DESCRIPTION
Thanks to @spicyj for pairing with me on this.

**what is the change?:**
 - Add two more special cases for 'lowPriorityWarning' in 'modules.js',
   treating it the same as 'ReactCurrentOwner'.

**why make this change?:**
Without this, the build was including 'lowPriorityWarning' seemingly both as an external module and as part of the bundle in fb builds.

**test plan:**
Ran `yarn build` and inspected the `React-dev` build. `lowPriorityWarning` did not get bundled in this time.

**issue:**
None yet - @gaearon flagged this for me directly.