### PR TITLE
Remove commented out code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const OFF = 0;
-// const WARNING = 1;
 const ERROR = 2;
 
 module.exports = {


### PR DESCRIPTION
There is no clear benefit of keeping that info there.. if warnings will be added later to the rules it's very straightforward on what have to happen.