### PR TITLE
Add getName() to RN base component

### DIFF
--- a/src/renderers/native/ReactNativeBaseComponent.js
+++ b/src/renderers/native/ReactNativeBaseComponent.js
@@ -119,6 +119,10 @@ ReactNativeBaseComponent.Mixin = {
     this.updateChildren(nextElement.props.children, transaction, context);
   },
 
+  getName() {
+    return this.constructor.displayName || this.constructor.name || 'Unknown';
+  },
+
   /**
    * Currently this still uses IDs for reconciliation so this can return null.
    *


### PR DESCRIPTION
This is needed by RN Inspector to get component name for Stack components via inspector