### PR TITLE
PR for issue #9801

### DIFF
--- a/docs/_posts/2015-12-16-ismounted-antipattern.md
+++ b/docs/_posts/2015-12-16-ismounted-antipattern.md
@@ -62,7 +62,7 @@ const managedPromise = managePromise(
 managedPromise
   .promise
   .then((val) => {
-    // call to component.setState goes here, so it can be prevented by 
+    // call to component.setState goes here, so it can be prevented by cancelThen()
     console.log('resolved with', val)
   })
   .catch((reason) => console.log('cancelThen', reason.cancelThen));

--- a/docs/_posts/2015-12-16-ismounted-antipattern.md
+++ b/docs/_posts/2015-12-16-ismounted-antipattern.md
@@ -3,8 +3,6 @@ title: "isMounted is an Antipattern"
 author: jimfb
 ---
 
-_Update: isMounted has been deprecated and has no equivalent in the ES6 version of React components. However, there is still a need to ensure that calls to setState do not happen after the component has been unmounted._  
-
 As we move closer to officially deprecating isMounted, it's worth understanding why the function is an antipattern, and how to write code without the isMounted function.
 
 The primary use case for `isMounted()` is to avoid calling `setState()` after a component has unmounted, because calling `setState()` after a component has unmounted will emit a warning. The “setState warning” exists to help you catch bugs, because calling `setState()` on an unmounted component is an indication that your app/component has somehow failed to clean up properly. Specifically, calling `setState()` in an unmounted component means that your app is still holding a reference to the component after the component has been unmounted - which often indicates a memory leak!
@@ -41,7 +39,7 @@ class MyComponent extends React.Component {
 }
 ```
 
-If you use ES6 promises, you may need to wrap your promise in order to manage what happens once it has resolved with the intent of preventing the subsequent 'then' from executing.  
+If you use ES6 promises, you will need to manage your promise in order to prevent the `then` stage of the Promise chain from executing. 
 
 ```js
 const managedPromise = managePromise(

--- a/docs/_posts/2015-12-16-ismounted-antipattern.md
+++ b/docs/_posts/2015-12-16-ismounted-antipattern.md
@@ -3,6 +3,8 @@ title: "isMounted is an Antipattern"
 author: jimfb
 ---
 
+_Update: isMounted has been deprecated and has no equivalent in the ES6 version of React components. However, there is still a need to ensure that calls to setState do not happen after the component has been unmounted._  
+
 As we move closer to officially deprecating isMounted, it's worth understanding why the function is an antipattern, and how to write code without the isMounted function.
 
 The primary use case for `isMounted()` is to avoid calling `setState()` after a component has unmounted, because calling `setState()` after a component has unmounted will emit a warning. The “setState warning” exists to help you catch bugs, because calling `setState()` on an unmounted component is an indication that your app/component has somehow failed to clean up properly. Specifically, calling `setState()` in an unmounted component means that your app is still holding a reference to the component after the component has been unmounted - which often indicates a memory leak!
@@ -39,42 +41,61 @@ class MyComponent extends React.Component {
 }
 ```
 
-If you use ES6 promises, you may need to wrap your promise in order to make it cancelable.
+If you use ES6 promises, you may need to wrap your promise in order to manage what happens once it has resolved with the intent of preventing the subsequent 'then' from executing.  
 
 ```js
-const cancelablePromise = makeCancelable(
-  new Promise(r => component.setState({...}}))
+const managedPromise = managePromise(
+  /* In actual practice, this is where we would pass our Promise-returning async call: 
+     The code below simply simulates such call */
+  new Promise((resolve, reject) => {
+    // callback invoked upon success of some async call
+    const successCallback = (val) => {
+      console.log('async call was successful')
+      resolve(val)
+    }
+    // simulating async call
+    setTimeout(successCallback, 1000, 'success')
+
+    // In actual practice, we'd also have a failureCallback that reject()'s the promise with
+    // some error value
+  })
 );
 
-cancelablePromise
+managedPromise
   .promise
-  .then(() => console.log('resolved'))
-  .catch((reason) => console.log('isCanceled', reason.isCanceled));
+  .then((val) => {
+    // call to component.setState goes here, so it can be prevented by 
+    console.log('resolved with', val)
+  })
+  .catch((reason) => console.log('cancelThen', reason.cancelThen));
 
-cancelablePromise.cancel(); // Cancel the promise
+managedPromise.cancelThen(); // Cancel the 'then' on managed promise
 ```
 
-Where `makeCancelable` was originally [defined by @istarkov](https://github.com/facebook/react/issues/5465#issuecomment-157888325) as:
+Where `managePromise` was originally [defined by @istarkov](https://github.com/facebook/react/issues/5465#issuecomment-157888325) and [modified by @idibidiart](https://github.com/facebook/react/issues/9801) as:
 
 ```js
-const makeCancelable = (promise) => {
-  let hasCanceled_ = false;
+const managePromise = (originalPromise) => {
+  let cancelThen = false;
 
   const wrappedPromise = new Promise((resolve, reject) => {
-    promise.then(
-      val => hasCanceled_ ? reject({isCanceled: true}) : resolve(val),
-      error => hasCanceled_ ? reject({isCanceled: true}) : reject(error)
+    originalPromise.then(
+      val => cancelThen ? reject({cancelThen: true}) : resolve(val),
+      error => cancelThen ? reject({cancelThen: true}) : reject(error)
     );
   });
 
   return {
     promise: wrappedPromise,
-    cancel() {
-      hasCanceled_ = true;
+    cancelThen() {
+      cancelThen = true;
     },
   };
 };
 ```
-As an added bonus for getting your code cleaned up early, getting rid of `isMounted()` makes it one step easier for you to upgrade to ES6 classes, where using `isMounted()` is already prohibited.  Happy coding!
+As an added bonus for getting your code cleaned up early, getting rid of `isMounted()` makes it one step easier for you to upgrade to ES6 classes, where using `isMounted()` is not supported.  Happy coding!
 
 * _Update 2017-05-12: altered `#makeCancelable` implementation so rejected promises won't go uncaught._
+* _Update 2017-05-30: eliminated confusion with respect to ES Promise spec by changing `#makeCancelable` to `#managePromise` since 'Cancellable' means something else in ES spec Promise discussions. Also, changed `#cancel()` to `#cancelThen()` and moved `component.setState` to the `then` stage so that it can be prevented from being invoked after component has been unmounted.
+
+

--- a/docs/_posts/2015-12-16-ismounted-antipattern.md
+++ b/docs/_posts/2015-12-16-ismounted-antipattern.md
@@ -39,7 +39,7 @@ class MyComponent extends React.Component {
 }
 ```
 
-If you use ES6 promises, you will need to manage your promise in order to prevent the `then` stage of the Promise chain from executing. 
+If you use ES6 promises, you will need to wrap your promise and use the wrapped promise in order to control whether or not the `then` callback gets executed.
 
 ```js
 const managedPromise = managePromise(


### PR DESCRIPTION
This PR mostly affects the code content of a post on the official React blog. It does not touch any React code.

https://github.com/facebook/react/issues/9801

Here is the updated code from that blog post running on Babel:

https://babeljs.io/repl/#?babili=false&evaluate=true&lineWrap=false&presets=es2015%2Creact%2Cstage-2&targets=&browsers=&builtIns=false&debug=false&code=const%20managePromise%20%3D%20(originalPromise)%20%3D%3E%20%7B%0A%20%20let%20cancelThen%20%3D%20false%3B%0A%0A%20%20const%20wrappedPromise%20%3D%20new%20Promise((resolve%2C%20reject)%20%3D%3E%20%7B%0A%20%20%20%20originalPromise.then(%0A%20%20%20%20%20%20val%20%3D%3E%20cancelThen%20%3F%20reject(%7BcancelThen%3A%20true%7D)%20%3A%20resolve(val)%2C%0A%20%20%20%20%20%20error%20%3D%3E%20cancelThen%20%3F%20reject(%7BcancelThen%3A%20true%7D)%20%3A%20reject(error)%0A%20%20%20%20)%3B%0A%20%20%7D)%3B%0A%0A%20%20return%20%7B%0A%20%20%20%20promise%3A%20wrappedPromise%2C%0A%20%20%20%20cancelThen()%20%7B%0A%20%20%20%20%20%20cancelThen%20%3D%20true%3B%0A%20%20%20%20%7D%2C%0A%20%20%7D%3B%0A%7D%3B%0A%0Aconst%20managedPromise%20%3D%20managePromise(%0A%20%20%0A%20%20%2F*%20In%20actual%20practice%2C%20this%20is%20where%20we%20would%20have%20our%20Promise-returning%20async%20call%3A%20%0A%20%20%20%20%20The%20code%20below%20simply%20simulates%20such%20call%20*%2F%0A%20%20new%20Promise((resolve%2C%20reject)%20%3D%3E%20%7B%0A%20%20%20%20%2F%2F%20callback%20invoked%20upon%20success%20of%20some%20async%20call%0A%20%20%20%20const%20successCallback%20%3D%20(val)%20%3D%3E%20%7B%0A%20%20%20%20%20%20console.log('async%20call%20was%20successful')%0A%20%20%20%20%20%20resolve(val)%0A%20%20%20%20%7D%0A%20%20%20%20%2F%2F%20simulating%20async%20call%0A%20%20%20%20setTimeout(successCallback%2C%201000%2C%20'success')%0A%0A%20%20%20%20%2F%2F%20In%20actual%20practice%2C%20we'd%20also%20have%20a%20failureCallback%20that%20reject()'s%20the%20promise%20with%0A%20%20%20%20%2F%2F%20some%20error%20value%0A%20%20%7D)%0A)%3B%0A%0AmanagedPromise%0A%20%20.promise%0A%20%20.then((val)%20%3D%3E%20%7B%0A%20%20%20%20%2F%2F%20call%20to%20component.setState%20goes%20here%2C%20so%20it%20can%20be%20prevented%20by%20%0A%20%20%20%20console.log('resolved%20with'%2C%20val)%0A%20%20%7D)%0A%20%20.catch((reason)%20%3D%3E%20console.log('cancelThen'%2C%20reason.cancelThen))%3B%0A%0AmanagedPromise.cancelThen()%3B%20%2F%2F%20Cancel%20the%20'then'%20on%20managed%20promise