### PR TITLE
Update to Flow 0.47

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -38,4 +38,4 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 
 [version]
-^0.45.0
+^0.47.0

--- a/flow/react-native-host-hooks.js
+++ b/flow/react-native-host-hooks.js
@@ -20,7 +20,7 @@ declare module 'deepFreezeAndThrowOnMutationInDev' {
 declare module 'flattenStyle' { }
 declare module 'InitializeCore' { }
 declare module 'RCTEventEmitter' {
-  declare function register() : void;
+  declare function register(any) : void;
 }
 declare module 'TextInputState' {
   declare function blurTextInput(object : any) : void;
@@ -49,11 +49,19 @@ declare module 'UIManager' {
     addAtIndices : Array<number>,
     removeAtIndices : Array<number>
   ) : void;
-  declare function measure() : void;
-  declare function measureInWindow() : void;
-  declare function measureLayout() : void;
-  declare function removeRootView() : void;
-  declare function removeSubviewsFromContainerWithID() : void;
+  declare function measure(hostComponent: any, callback: Function) : void;
+  declare function measureInWindow(
+    nativeTag : ?number,
+    callback : Function
+  ) : void;
+  declare function measureLayout(
+    nativeTag : any,
+    nativeNode : number,
+    onFail : Function,
+    onSuccess : Function
+  ) : void;
+  declare function removeRootView(containerTag : number) : void;
+  declare function removeSubviewsFromContainerWithID(containerId : number) : void;
   declare function replaceExistingNonRootView() : void;
   declare function setChildren(
     containerTag : number,

--- a/flow/react-native-host-hooks.js
+++ b/flow/react-native-host-hooks.js
@@ -20,7 +20,7 @@ declare module 'deepFreezeAndThrowOnMutationInDev' {
 declare module 'flattenStyle' { }
 declare module 'InitializeCore' { }
 declare module 'RCTEventEmitter' {
-  declare function register(any) : void;
+  declare function register(mixed) : void;
 }
 declare module 'TextInputState' {
   declare function blurTextInput(object : any) : void;
@@ -49,13 +49,13 @@ declare module 'UIManager' {
     addAtIndices : Array<number>,
     removeAtIndices : Array<number>
   ) : void;
-  declare function measure(hostComponent: any, callback: Function) : void;
+  declare function measure(hostComponent: mixed, callback: Function) : void;
   declare function measureInWindow(
     nativeTag : ?number,
     callback : Function
   ) : void;
   declare function measureLayout(
-    nativeTag : any,
+    nativeTag : mixed,
     nativeNode : number,
     onFail : Function,
     onSuccess : Function

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "fbjs": "^0.8.9",
     "fbjs-scripts": "^0.6.0",
     "filesize": "^3.5.6",
-    "flow-bin": "^0.45.0",
+    "flow-bin": "^0.47.0",
     "git-branch": "^0.3.0",
     "glob": "^6.0.4",
     "glob-stream": "^6.1.0",

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -303,7 +303,7 @@ var ReactDOMFiberComponent = {
   },
 
   createElement(
-    type: string,
+    type: *,
     props: Object,
     rootContainerElement: Element | Document,
     parentNamespace: string,
@@ -341,6 +341,7 @@ var ReactDOMFiberComponent = {
         var firstChild = ((div.firstChild: any): HTMLScriptElement);
         domElement = div.removeChild(firstChild);
       } else if (props.is) {
+        // $FlowIssue `createElement` should be updated for Web Components
         domElement = ownerDocument.createElement(type, {is: props.is});
       } else {
         // Separate else branch instead of using `props.is || undefined` above because of a Firefox bug.

--- a/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
+++ b/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
@@ -201,7 +201,7 @@ var ReactDOMInput = {
         // Note: IE9 reports a number inputs as 'text', so check props instead.
       } else if (props.type === 'number') {
         // Simulate `input.valueAsNumber`. IE9 does not support it
-        var valueAsNumber = parseFloat(node.value, 10) || 0;
+        var valueAsNumber = parseFloat(node.value) || 0;
 
         // eslint-disable-next-line
         if (value != valueAsNumber) {

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -66,7 +66,7 @@ if (__DEV__) {
 module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   config: HostConfig<T, P, I, TI, PI, C, CX, PL>,
   hostContext: HostContext<C, CX>,
-  hydrationContext: HydrationContext<I, TI>,
+  hydrationContext: HydrationContext<I, TI, C>,
   scheduleUpdate: (fiber: Fiber, priorityLevel: PriorityLevel) => void,
   getPriorityContext: (fiber: Fiber, forceAsync: boolean) => PriorityLevel,
 ) {

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -340,9 +340,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           let textInstance;
           let wasHydrated = popHydrationState(workInProgress);
           if (wasHydrated) {
-            textInstance = hydrateHostTextInstance(
-              workInProgress,
-            );
+            textInstance = hydrateHostTextInstance(workInProgress);
           } else {
             textInstance = createTextInstance(
               newText,

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -280,7 +280,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           if (wasHydrated) {
             instance = hydrateHostInstance(
               workInProgress,
-              rootContainerInstance,
             );
           } else {
             instance = createInstance(
@@ -342,7 +341,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           if (wasHydrated) {
             textInstance = hydrateHostTextInstance(
               workInProgress,
-              rootContainerInstance,
             );
           } else {
             textInstance = createTextInstance(

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -47,7 +47,7 @@ var invariant = require('fbjs/lib/invariant');
 module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   config: HostConfig<T, P, I, TI, PI, C, CX, PL>,
   hostContext: HostContext<C, CX>,
-  hydrationContext: HydrationContext<I, TI>,
+  hydrationContext: HydrationContext<I, TI, C>,
 ) {
   const {
     createInstance,
@@ -280,6 +280,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           if (wasHydrated) {
             instance = hydrateHostInstance(
               workInProgress,
+              rootContainerInstance,
             );
           } else {
             instance = createInstance(

--- a/src/renderers/shared/fiber/ReactFiberHostContext.js
+++ b/src/renderers/shared/fiber/ReactFiberHostContext.js
@@ -89,7 +89,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   function pushHostContext(fiber: Fiber): void {
     const rootInstance = requiredContext(rootInstanceStackCursor.current);
     const context = requiredContext(contextStackCursor.current);
-    const nextContext = getChildHostContext(context, fiber.type, rootInstance);
+    const nextContext = getChildHostContext(context, fiber.type);
 
     // Don't push this Fiber's context unless it's unique.
     if (context === nextContext) {

--- a/src/renderers/shared/fiber/ReactFiberHostContext.js
+++ b/src/renderers/shared/fiber/ReactFiberHostContext.js
@@ -89,7 +89,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   function pushHostContext(fiber: Fiber): void {
     const rootInstance = requiredContext(rootInstanceStackCursor.current);
     const context = requiredContext(contextStackCursor.current);
-    const nextContext = getChildHostContext(context, fiber.type);
+    const nextContext = getChildHostContext(context, fiber.type, rootInstance);
 
     // Don't push this Fiber's context unless it's unique.
     if (context === nextContext) {

--- a/src/renderers/shared/fiber/ReactFiberHydrationContext.js
+++ b/src/renderers/shared/fiber/ReactFiberHydrationContext.js
@@ -22,18 +22,18 @@ const {Deletion, Placement} = require('ReactTypeOfSideEffect');
 
 const {createFiberFromHostInstanceForDeletion} = require('ReactFiber');
 
-export type HydrationContext<I, TI> = {
+export type HydrationContext<I, TI, C> = {
   enterHydrationState(fiber: Fiber): boolean,
   resetHydrationState(): void,
   tryToClaimNextHydratableInstance(fiber: Fiber): void,
-  hydrateHostInstance(fiber: Fiber): I,
+  hydrateHostInstance(fiber: Fiber, rootContainerInstance: C): I,
   hydrateHostTextInstance(fiber: Fiber): TI,
   popHydrationState(fiber: Fiber): boolean,
 };
 
 module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   config: HostConfig<T, P, I, TI, PI, C, CX, PL>,
-): HydrationContext<I, TI> {
+): HydrationContext<I, TI, C> {
   const {
     shouldSetTextContent,
     canHydrateInstance,
@@ -147,7 +147,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     nextHydratableInstance = getFirstHydratableChild(nextInstance);
   }
 
-  function hydrateHostInstance(fiber: Fiber, rootContainerInstance: any): I {
+  function hydrateHostInstance(fiber: Fiber, rootContainerInstance: C): I {
     const instance: I = fiber.stateNode;
     hydrateInstance(
       instance,

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -146,7 +146,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   config: HostConfig<T, P, I, TI, PI, C, CX, PL>,
 ) {
   const hostContext = ReactFiberHostContext(config);
-  const hydrationContext: HydrationContext<I, TI> = ReactFiberHydrationContext(
+  const hydrationContext: HydrationContext<I, TI, C> = ReactFiberHydrationContext(
     config,
   );
   const {popHostContainer, popHostContext, resetHostContainer} = hostContext;

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -146,9 +146,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   config: HostConfig<T, P, I, TI, PI, C, CX, PL>,
 ) {
   const hostContext = ReactFiberHostContext(config);
-  const hydrationContext: HydrationContext<I, TI, C> = ReactFiberHydrationContext(
-    config,
-  );
+  const hydrationContext: HydrationContext<
+    I,
+    TI,
+    C
+  > = ReactFiberHydrationContext(config);
   const {popHostContainer, popHostContext, resetHostContainer} = hostContext;
   const {beginWork, beginFailedWork} = ReactFiberBeginWork(
     config,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2287,9 +2287,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.45.0:
-  version "0.45.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.45.0.tgz#009dd0f577a3f665c74ca8be827ae8c2dd8fd6b5"
+flow-bin@^0.47.0:
+  version "0.47.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.47.0.tgz#a2a08ab3e0d1f1cb57d17e27b30b118b62fda367"
 
 flow-parser@0.43.0:
   version "0.43.0"


### PR DESCRIPTION
I was going to give rebasing https://github.com/facebook/react/pull/8545 a try and seeing what breaks, but first catching up to latest release of Flow. The big change here is that function call arity is now strictly enforces.

https://flow.org/blog/2017/05/07/Strict-Function-Call-Arity/

Specific call outs:

* Reverted flow’s understanding of `getPooled` and `release` variadic arguments with `...args: args`
* The Fiber implementation was passing arguments through that were not used in a few places.
* ReactNative had a few issues with incomplete stubbed function typedefs. Fleshed those out enough for flow to be okay.
* ReactDOMFiber had an issue with `{is: is}` as the second arg to `createElement`. ignored it with `$FlowIssue`
* ReactDOMFiber every single `createElement` call was erroring because the entry `string` type was erroring when flowing into the more constrained types such as `'span'` or `'th'|'td'`. Got around it by changing the `string` type to the existential `*` type.