### PR TITLE
Remove ensureScrollValueMonitoring

### DIFF
--- a/src/renderers/dom/shared/ReactDOMEventListener.js
+++ b/src/renderers/dom/shared/ReactDOMEventListener.js
@@ -19,7 +19,6 @@ var ReactGenericBatching = require('ReactGenericBatching');
 var ReactTypeOfWork = require('ReactTypeOfWork');
 
 var getEventTarget = require('getEventTarget');
-var getUnboundedScrollPosition = require('fbjs/lib/getUnboundedScrollPosition');
 
 var {HostRoot} = ReactTypeOfWork;
 
@@ -102,11 +101,6 @@ function handleTopLevelImpl(bookKeeping) {
   }
 }
 
-function scrollValueMonitor(cb) {
-  var scrollPosition = getUnboundedScrollPosition(window);
-  cb(scrollPosition);
-}
-
 var ReactDOMEventListener = {
   _enabled: true,
   _handleTopLevel: null,
@@ -163,11 +157,6 @@ var ReactDOMEventListener = {
       handlerBaseName,
       ReactDOMEventListener.dispatchEvent.bind(null, topLevelType),
     );
-  },
-
-  monitorScrollValue: function(refresh) {
-    var callback = scrollValueMonitor.bind(null, refresh);
-    EventListener.listen(window, 'scroll', callback);
   },
 
   dispatchEvent: function(topLevelType, nativeEvent) {


### PR DESCRIPTION
Working through #9333 I discovered that I never actually removed the rest of `ViewportMetrics` in https://github.com/facebook/react/pull/9290. We no longer need `ReactDOMEventListener.monitorScrollValue`, or its trail of stuff.

😨 🙏 😨 🙏 