### PR TITLE
Delete logTopLevelRenders flag and console timing

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -9,6 +9,3 @@ src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
 * can reconcile text merged by Node.normalize()
 * can reconcile text arbitrarily split into multiple nodes
 * can reconcile text arbitrarily split into multiple nodes on some substitutions only
-
-src/renderers/dom/shared/__tests__/ReactMount-test.js
-* marks top-level mounts

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -583,7 +583,6 @@ src/renderers/__tests__/ReactUpdates-test.js
 * should queue updates from during mount
 * calls componentWillReceiveProps setState callback properly
 * does not call render after a component as been deleted
-* marks top-level updates
 * throws in setState if the update callback is not a function
 * throws in forceUpdate if the update callback is not a function
 * does not update one component twice in a batch (#2410)

--- a/src/renderers/__tests__/ReactUpdates-test.js
+++ b/src/renderers/__tests__/ReactUpdates-test.js
@@ -825,40 +825,6 @@ describe('ReactUpdates', () => {
     expect(renderCount).toBe(1);
   });
 
-  it('marks top-level updates', () => {
-    var ReactFeatureFlags = require('ReactFeatureFlags');
-
-    class Foo extends React.Component {
-      render() {
-        return <Bar />;
-      }
-    }
-
-    class Bar extends React.Component {
-      render() {
-        return <div />;
-      }
-    }
-
-    var container = document.createElement('div');
-    ReactDOM.render(<Foo />, container);
-
-    try {
-      ReactFeatureFlags.logTopLevelRenders = true;
-      spyOn(console, 'time');
-      spyOn(console, 'timeEnd');
-
-      ReactDOM.render(<Foo />, container);
-
-      expect(console.time.calls.count()).toBe(1);
-      expect(console.time.calls.argsFor(0)[0]).toBe('React update: Foo');
-      expect(console.timeEnd.calls.count()).toBe(1);
-      expect(console.timeEnd.calls.argsFor(0)[0]).toBe('React update: Foo');
-    } finally {
-      ReactFeatureFlags.logTopLevelRenders = false;
-    }
-  });
-
   it('throws in setState if the update callback is not a function', () => {
     spyOn(console, 'error');
 

--- a/src/renderers/dom/shared/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactMount-test.js
@@ -310,35 +310,4 @@ describe('ReactMount', () => {
 
     expect(calls).toBe(5);
   });
-
-  it('marks top-level mounts', () => {
-    var ReactFeatureFlags = require('ReactFeatureFlags');
-
-    class Foo extends React.Component {
-      render() {
-        return <Bar />;
-      }
-    }
-
-    class Bar extends React.Component {
-      render() {
-        return <div />;
-      }
-    }
-
-    try {
-      ReactFeatureFlags.logTopLevelRenders = true;
-      spyOn(console, 'time');
-      spyOn(console, 'timeEnd');
-
-      ReactTestUtils.renderIntoDocument(<Foo />);
-
-      expect(console.time.calls.count()).toBe(1);
-      expect(console.time.calls.argsFor(0)[0]).toBe('React mount: Foo');
-      expect(console.timeEnd.calls.count()).toBe(1);
-      expect(console.timeEnd.calls.argsFor(0)[0]).toBe('React mount: Foo');
-    } finally {
-      ReactFeatureFlags.logTopLevelRenders = false;
-    }
-  });
 });

--- a/src/renderers/dom/stack/client/ReactMount.js
+++ b/src/renderers/dom/stack/client/ReactMount.js
@@ -17,7 +17,6 @@ var React = require('react');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var ReactDOMContainerInfo = require('ReactDOMContainerInfo');
 var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
-var ReactFeatureFlags = require('ReactFeatureFlags');
 var ReactInstanceMap = require('ReactInstanceMap');
 var ReactInstrumentation = require('ReactInstrumentation');
 var ReactMarkupChecksum = require('ReactMarkupChecksum');
@@ -99,16 +98,6 @@ function mountComponentIntoNode(
   shouldReuseMarkup,
   context,
 ) {
-  var markerName;
-  if (ReactFeatureFlags.logTopLevelRenders) {
-    var wrappedElement = wrapperInstance._currentElement.props.child;
-    var type = wrappedElement.type;
-    markerName =
-      'React mount: ' +
-      (typeof type === 'string' ? type : type.displayName || type.name);
-    console.time(markerName);
-  }
-
   var markup = ReactReconciler.mountComponent(
     wrapperInstance,
     transaction,
@@ -117,10 +106,6 @@ function mountComponentIntoNode(
     context,
     0 /* parentDebugID */,
   );
-
-  if (markerName) {
-    console.timeEnd(markerName);
-  }
 
   wrapperInstance._renderedComponent._topLevelWrapper = wrapperInstance;
   ReactMount._mountImageIntoNode(

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -45,7 +45,6 @@ var ReactFiberCompleteWork = require('ReactFiberCompleteWork');
 var ReactFiberCommitWork = require('ReactFiberCommitWork');
 var ReactFiberHostContext = require('ReactFiberHostContext');
 var ReactFiberHydrationContext = require('ReactFiberHydrationContext');
-var ReactFeatureFlags = require('ReactFeatureFlags');
 var {ReactCurrentOwner} = require('ReactGlobalSharedState');
 var getComponentName = require('getComponentName');
 
@@ -793,18 +792,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       nextUnitOfWork = findNextUnitOfWork();
     }
 
-    let hostRootTimeMarker;
-    if (
-      ReactFeatureFlags.logTopLevelRenders &&
-      nextUnitOfWork !== null &&
-      nextUnitOfWork.tag === HostRoot &&
-      nextUnitOfWork.child !== null
-    ) {
-      const componentName = getComponentName(nextUnitOfWork.child) || '';
-      hostRootTimeMarker = 'React update: ' + componentName;
-      console.time(hostRootTimeMarker);
-    }
-
     // If there's a deadline, and we're not performing Task work, perform work
     // using this loop that checks the deadline on every iteration.
     if (deadline !== null && priorityLevel > TaskPriority) {
@@ -850,10 +837,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           clearErrors();
         }
       }
-    }
-
-    if (hostRootTimeMarker) {
-      console.timeEnd(hostRootTimeMarker);
     }
   }
 

--- a/src/renderers/shared/stack/reconciler/ReactUpdates.js
+++ b/src/renderers/shared/stack/reconciler/ReactUpdates.js
@@ -12,7 +12,6 @@
 'use strict';
 
 var PooledClass = require('PooledClass');
-var ReactFeatureFlags = require('ReactFeatureFlags');
 var ReactReconciler = require('ReactReconciler');
 var Transaction = require('Transaction');
 
@@ -131,26 +130,11 @@ function runBatchedUpdates(transaction) {
     // that performUpdateIfNecessary is a noop.
     var component = dirtyComponents[i];
 
-    var markerName;
-    if (ReactFeatureFlags.logTopLevelRenders) {
-      var namedComponent = component;
-      // Duck type TopLevelWrapper. This is probably always true.
-      if (component._currentElement.type.isReactTopLevelWrapper) {
-        namedComponent = component._renderedComponent;
-      }
-      markerName = 'React update: ' + namedComponent.getName();
-      console.time(markerName);
-    }
-
     ReactReconciler.performUpdateIfNecessary(
       component,
       transaction.reconcileTransaction,
       updateBatchNumber,
     );
-
-    if (markerName) {
-      console.timeEnd(markerName);
-    }
   }
 }
 

--- a/src/renderers/shared/utils/ReactFeatureFlags.js
+++ b/src/renderers/shared/utils/ReactFeatureFlags.js
@@ -13,10 +13,6 @@
 'use strict';
 
 var ReactFeatureFlags = {
-  // When true, call console.time() before and .timeEnd() after each top-level
-  // render (both initial renders and updates). Useful when looking at prod-mode
-  // timeline profiles in Chrome, for example.
-  logTopLevelRenders: false,
   prepareNewChildrenBeforeUnmountInStack: true,
   disableNewFiberFeatures: false,
   enableAsyncSubtreeAPI: false,


### PR DESCRIPTION
This was mostly used for timing of initial mounts. However, we haven't implemented that in Fiber and yet nobody has complained despite running without it. Further more the update tracks any update within the tree, not just updates to the props of the top level. This is much less useful due to the variation.

I could make this track initial mounts too but it's a bit awkward so I'd rather just delete it if possible. We can add the full profiler mode if we want more coverage.