### PR TITLE
Hello 15.6 Release Candidate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-build",
   "private": true,
-  "version": "15.5.4",
+  "version": "15.6.0-rc.1",
   "devDependencies": {
     "aliasify": "^2.0.0",
     "art": "^0.10.1",

--- a/packages/react-addons/package.json
+++ b/packages/react-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-addons-template",
-  "version": "15.5.4",
+  "version": "15.6.0-rc.1",
   "main": "index.js",
   "repository": "facebook/react",
   "keywords": [
@@ -13,7 +13,7 @@
     "object-assign": "^4.1.0"
   },
   "peerDependencies": {
-    "react": "^15.5.4"
+    "react": "^15.6.0-rc.1"
   },
   "files": [
     "LICENSE",

--- a/packages/react-dom-factories/package.json
+++ b/packages/react-dom-factories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dom-factories",
-  "version": "1.0-alpha",
+  "version": "15.6.0-rc",
   "description": "React package for DOM factory methods.",
   "main": "index.js",
   "repository": "facebook/react",
@@ -13,7 +13,7 @@
   },
   "homepage": "https://facebook.github.io/react/",
   "peerDependencies": {
-    "react": "^15.5.4"
+    "react": "^15.6.0-rc.1"
   },
   "files": [
     "LICENSE",

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dom",
-  "version": "15.5.4",
+  "version": "15.6.0-rc.1",
   "description": "React package for working with the DOM.",
   "main": "index.js",
   "repository": "facebook/react",
@@ -19,7 +19,7 @@
     "prop-types": "~15.5.7"
   },
   "peerDependencies": {
-    "react": "^15.5.4"
+    "react": "^15.6.0-rc.1"
   },
   "files": [
     "LICENSE",

--- a/packages/react-native-renderer/package.json
+++ b/packages/react-native-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-renderer",
-  "version": "15.5.4",
+  "version": "15.6.0-rc.1",
   "description": "React package for use inside react-native.",
   "main": "index.js",
   "repository": "facebook/react",
@@ -18,7 +18,7 @@
     "object-assign": "^4.1.0"
   },
   "peerDependencies": {
-    "react": "^15.5.4"
+    "react": "^15.6.0-rc.1"
   },
   "files": [
     "LICENSE",

--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-test-renderer",
-  "version": "15.5.4",
+  "version": "15.6.0-rc.1",
   "description": "React package for snapshot testing.",
   "main": "index.js",
   "repository": "facebook/react",
@@ -19,7 +19,7 @@
     "object-assign": "^4.1.0"
   },
   "peerDependencies": {
-    "react": "^15.5.4"
+    "react": "^15.6.0-rc.1"
   },
   "files": [
     "LICENSE",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react",
   "description": "React is a JavaScript library for building user interfaces.",
-  "version": "15.5.4",
+  "version": "15.6.0-rc.1",
   "keywords": [
     "react"
   ],

--- a/src/ReactVersion.js
+++ b/src/ReactVersion.js
@@ -11,4 +11,4 @@
 
 'use strict';
 
-module.exports = '15.5.4';
+module.exports = '15.6.0-rc.1';


### PR DESCRIPTION
**what is the change?:**
We update the versions of all associated React packages when bumping the
version of React.

**why make this change?:**
We want to publish a RC to give folks time to try out the latest version
before it's final.

Why bump the version of every other associated package?

It makes the dependency between them more clear.

There will be cases where we make a fix in React-DOM and it requires
changes in React core. In that case, it will be more clear to people
when we update the versions of both and they remain in sync.

**test plan:**
Visual inspection

**issue:**
https://github.com/facebook/react/issues/9398