### PR TITLE
Removed unnecessary RN fiber "topsecret-" prefix

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1710,6 +1710,10 @@ src/renderers/native/__tests__/ReactNativeMount-test.js
 * returns the correct instance and calls it in the callback
 * renders and reorders children
 
+src/renderers/native/__tests__/createReactNativeComponentClass-test.js
+* should register viewConfigs
+* should not allow viewConfigs with duplicate uiViewClassNames to be registered
+
 src/renderers/shared/__tests__/ReactDOMFrameScheduling-test.js
 * throws when requestAnimationFrame is not polyfilled in the browser
 * can import findDOMNode in Node environment

--- a/src/renderers/native/ReactNativeFiberInspector.js
+++ b/src/renderers/native/ReactNativeFiberInspector.js
@@ -76,12 +76,9 @@ if (__DEV__) {
     return null;
   };
 
-  var stripTopSecret = str =>
-    typeof str === 'string' && str.replace('topsecret-', '');
-
   var createHierarchy = function(fiberHierarchy) {
     return fiberHierarchy.map(fiber => ({
-      name: stripTopSecret(getComponentName(fiber)),
+      name: getComponentName(fiber),
       getInspectorData: findNodeHandle => ({
         measure: callback =>
           UIManager.measure(getHostNode(fiber, findNodeHandle), callback),

--- a/src/renderers/native/ReactNativeViewConfigRegistry.js
+++ b/src/renderers/native/ReactNativeViewConfigRegistry.js
@@ -22,8 +22,6 @@ export type ReactNativeBaseComponentViewConfig = {
 
 const viewConfigs = new Map();
 
-const prefix = 'topsecret-';
-
 const ReactNativeViewConfigRegistry = {
   register(viewConfig: ReactNativeBaseComponentViewConfig) {
     const name = viewConfig.uiViewClassName;
@@ -32,13 +30,12 @@ const ReactNativeViewConfigRegistry = {
       'Tried to register two views with the same name %s',
       name,
     );
-    const secretName = prefix + name;
-    viewConfigs.set(secretName, viewConfig);
-    return secretName;
+    viewConfigs.set(name, viewConfig);
+    return name;
   },
-  get(secretName: string) {
-    const config = viewConfigs.get(secretName);
-    invariant(config, 'View config not found for name %s', secretName);
+  get(name: string) {
+    const config = viewConfigs.get(name);
+    invariant(config, 'View config not found for name %s', name);
     return config;
   },
 };

--- a/src/renderers/native/__tests__/createReactNativeComponentClass-test.js
+++ b/src/renderers/native/__tests__/createReactNativeComponentClass-test.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let createReactNativeComponentClass;
+let React;
+let ReactNative;
+let ReactNativeFeatureFlags = require('ReactNativeFeatureFlags');
+
+describe('createReactNativeComponentClass', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    createReactNativeComponentClass = require('createReactNativeComponentClass');
+    React = require('React');
+    ReactNative = require('ReactNative');
+  });
+
+  it('should register viewConfigs', () => {
+    const textViewConfig = {
+      validAttributes: {},
+      uiViewClassName: 'Text',
+    };
+    const viewViewConfig = {
+      validAttributes: {},
+      uiViewClassName: 'View',
+    };
+
+    const Text = createReactNativeComponentClass(textViewConfig);
+    const View = createReactNativeComponentClass(viewViewConfig);
+
+    expect(Text).not.toBe(View);
+
+    ReactNative.render(<Text />, 1);
+    ReactNative.render(<View />, 1);
+  });
+
+  if (ReactNativeFeatureFlags.useFiber) {
+    it('should not allow viewConfigs with duplicate uiViewClassNames to be registered', () => {
+      const textViewConfig = {
+        validAttributes: {},
+        uiViewClassName: 'Text',
+      };
+      const altTextViewConfig = {
+        validAttributes: {},
+        uiViewClassName: 'Text', // Same
+      };
+
+      createReactNativeComponentClass(textViewConfig);
+
+      expect(() => {
+        createReactNativeComponentClass(altTextViewConfig);
+      }).toThrow('Tried to register two views with the same name Text');
+    });
+  }
+});


### PR DESCRIPTION
Removed temporary sanitizing function in `ReactNativeFiberInspector` that hid this prefix from the devtools.

Also added a test to ensure that duplicate view-names can't be registered with `createReactNativeComponentClass`.