### PR TITLE
Don't expose internal instance to React Native Inspector

### DIFF
--- a/src/renderers/native/ReactNativeFiberInspector.js
+++ b/src/renderers/native/ReactNativeFiberInspector.js
@@ -104,7 +104,6 @@ if (__DEV__) {
 
     return {
       hierarchy,
-      instance,
       props,
       selection,
       source,

--- a/src/renderers/native/ReactNativeStackInspector.js
+++ b/src/renderers/native/ReactNativeStackInspector.js
@@ -76,7 +76,6 @@ if (__DEV__) {
 
     return {
       hierarchy,
-      instance,
       props,
       selection,
       source,


### PR DESCRIPTION
This is the last leak of internal data structures to RN inspector.
I removed the only dependency on it in https://github.com/facebook/react-native/commit/86fad4b2f38001374a77abdf12cb9a1ae23e572c.