### PR TITLE
Update invalid prop type error strings to point to `prop-types`

### DIFF
--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -83,7 +83,7 @@
   "81": "mergeIntoWithNoDuplicateKeys(): Tried to merge two objects with the same key: `%s`. This conflict may be due to a mixin; in particular, this may be caused by two getInitialState() or getDefaultProps() methods returning objects with clashing keys.",
   "82": "%s.getInitialState(): must return an object or null",
   "83": "createClass(...): Class specification must implement a `render` method.",
-  "84": "%s: %s type `%s` is invalid; it must be a function, usually from React.PropTypes.",
+  "84": "%s: %s type `%s` is invalid; it must be a function, usually from the `prop-types` package.",
   "85": "setState(...): takes an object of state variables to update or a function which returns an object of state variables.",
   "86": "SimpleEventPlugin: Unhandled event type, `%s`.",
   "87": "Cannot provide a checkedLink and a valueLink. If you want to use checkedLink, you probably don't want to use valueLink and vice versa.",

--- a/src/isomorphic/classic/__tests__/createReactClassIntegration-test.js
+++ b/src/isomorphic/classic/__tests__/createReactClassIntegration-test.js
@@ -67,7 +67,7 @@ describe('create-react-class-integration', () => {
     expect(console.error.calls.count()).toBe(1);
     expect(console.error.calls.argsFor(0)[0]).toBe(
       'Warning: Component: prop type `prop` is invalid; ' +
-        'it must be a function, usually from React.PropTypes.',
+        'it must be a function, usually from the `prop-types` package.',
     );
   });
 
@@ -85,7 +85,7 @@ describe('create-react-class-integration', () => {
     expect(console.error.calls.count()).toBe(1);
     expect(console.error.calls.argsFor(0)[0]).toBe(
       'Warning: Component: context type `prop` is invalid; ' +
-        'it must be a function, usually from React.PropTypes.',
+        'it must be a function, usually from the `prop-types` package.',
     );
   });
 
@@ -103,7 +103,7 @@ describe('create-react-class-integration', () => {
     expect(console.error.calls.count()).toBe(1);
     expect(console.error.calls.argsFor(0)[0]).toBe(
       'Warning: Component: child context type `prop` is invalid; ' +
-        'it must be a function, usually from React.PropTypes.',
+        'it must be a function, usually from the `prop-types` package.',
     );
   });
 

--- a/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
+++ b/src/isomorphic/modern/element/__tests__/ReactJSXElementValidator-test.js
@@ -358,7 +358,7 @@ describe('ReactJSXElementValidator', () => {
     expectDev(console.error.calls.count()).toBe(1);
     expectDev(console.error.calls.argsFor(0)[0]).toContain(
       'NullPropTypeComponent: prop type `prop` is invalid; it must be a ' +
-        'function, usually from React.PropTypes.',
+        'function, usually from the `prop-types` package.',
     );
   });
 
@@ -376,7 +376,7 @@ describe('ReactJSXElementValidator', () => {
     expectDev(console.error.calls.count()).toBe(1);
     expectDev(console.error.calls.argsFor(0)[0]).toContain(
       'NullContextTypeComponent: context type `prop` is invalid; it must ' +
-        'be a function, usually from React.PropTypes.',
+        'be a function, usually from the `prop-types` package.',
     );
   });
 


### PR DESCRIPTION
There are a couple of outdated error code strings that point to `React.PropTypes` rather than the `prop-types` package.