### PR TITLE
Add 'create-react-class' to react dependencies for build

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,6 +23,7 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
+    "create-react-class": "^15.5.2",
     "fbjs": "^0.8.9",
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.0",


### PR DESCRIPTION
**what is the change?:**
We needed this dependency in the package.json

**why make this change?:**
Even though `create-react-class` was added as a dependency to the
`package.json` in https://github.com/facebook/react/pull/9399/files we
didn't completely cherry-pick this change onto 15.6 from master in https://github.com/facebook/react/commit/b48b2594fae7af3228ff6a0727cf8828b33b419e

This fixes that omission.
Following this fix we will review PR 9399 and make sure nothing else was
missed.

**test plan:**
`yarn build` and inspect the `builds/packages/react/package.json`, see
that `create-react-class` is included.

**issue:**
https://github.com/facebook/react/issues/9830

**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure the test suite passes (`npm test`).
5. Make sure your code lints (`npm run lint`).
6. Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
7. Run the [Flow](https://flowtype.org/) typechecks (`npm run flow`).
8. If you added or removed any tests, run `./scripts/fiber/record-tests` before submitting the pull request, and commit the resulting changes.
9. If you haven't already, complete the CLA.
