### PR TITLE
Document that `value={undefined}` is not controlled component

### DIFF
--- a/docs/docs/forms.md
+++ b/docs/docs/forms.md
@@ -66,17 +66,17 @@ class NameForm extends React.Component {
 
 [Try it on CodePen.](https://codepen.io/gaearon/pen/VmmPgp?editors=0010)
 
-Since the `value` attribute is set on our form element, the displayed value will always be `this.state.value`, making the React state the source of truth. Since `handleChange` runs on every keystroke to update the React state, the displayed value will update as the user types.
+When the `value` attribute is set on our input element, the displayed value will always be `this.state.value`, making the React state the source of truth. Similarly to not setting the `value` attribute at all, setting it to `null` or `undefined` will make React assume the component is not controlled and may produce a warning. We should use an empty string to represent an empty value.
 
-With a controlled component, every state mutation will have an associated handler function. This makes it straightforward to modify or validate user input. For example, if we wanted to enforce that names are written with all uppercase letters, we could write `handleChange` as:
+With a controlled component, every state mutation must have an associated handler function. Unlike the HTML5 onchange event, the `onChange` attribute in React runs the handler function on every keystroke, so the display value will update as the user types. We have to use the `setState` function, because `this.state` can be directly assigned only in the component's constructor.
+
+This pattern makes it straightforward to modify or validate user input. For example, if we wanted to enforce all uppercase letters, we could write `handleChange` as:
 
 ```javascript{2}
 handleChange(event) {
   this.setState({value: event.target.value.toUpperCase()});
 }
 ```
-
-However, if `this.state.value` becomes `null` or `undefined` at any time (including the initial state), React will evaluate the component as uncontrolled and may produce a warning: `Input elements should not switch from uncontrolled to controlled (or vice versa)`.
 
 ## The textarea Tag
 

--- a/docs/docs/forms.md
+++ b/docs/docs/forms.md
@@ -76,6 +76,8 @@ handleChange(event) {
 }
 ```
 
+However, if `this.state.value` becomes `null` or `undefined` at any time (including the initial state), React will evaluate the component as uncontrolled and may produce a warning: `Input elements should not switch from uncontrolled to controlled (or vice versa)`.
+
 ## The textarea Tag
 
 In HTML, a `<textarea>` element defines its text by its children:


### PR DESCRIPTION
I got a warning which points to this page: `bundle.js:11949 Warning: X is changing an uncontrolled input of type undefined to be controlled. Input elements should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://fb.me/react-controlled-components` but it's not explained here that `value={undefined}` can be the cause