### PR TITLE
[WIP] Improve build's handling of externals better

### DIFF
--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -9,20 +9,20 @@
       "gzip": 3089
     },
     "react-dom.development.js (UMD_DEV)": {
-      "size": 603820,
-      "gzip": 138900
+      "size": 603869,
+      "gzip": 138920
     },
     "react-dom.production.min.js (UMD_PROD)": {
       "size": 124927,
       "gzip": 39493
     },
     "react-dom-server.development.js (UMD_DEV)": {
-      "size": 532325,
-      "gzip": 128572
+      "size": 532467,
+      "gzip": 128608
     },
     "react-dom-server.production.min.js (UMD_PROD)": {
-      "size": 112876,
-      "gzip": 35439
+      "size": 112916,
+      "gzip": 35462
     },
     "react-art.development.js (UMD_DEV)": {
       "size": 358834,
@@ -57,36 +57,36 @@
       "gzip": 86700
     },
     "react-dom.development.js (NODE_DEV)": {
-      "size": 562438,
-      "gzip": 129053
+      "size": 562487,
+      "gzip": 129063
     },
     "react-dom.production.min.js (NODE_PROD)": {
-      "size": 121292,
-      "gzip": 38189
+      "size": 121250,
+      "gzip": 38174
     },
     "ReactDOMFiber-dev.js (FB_DEV)": {
-      "size": 563608,
-      "gzip": 129673
+      "size": 563657,
+      "gzip": 129682
     },
     "ReactDOMFiber-prod.js (FB_PROD)": {
-      "size": 423197,
-      "gzip": 96509
+      "size": 423152,
+      "gzip": 96502
     },
     "react-dom-server.development.js (NODE_DEV)": {
-      "size": 481924,
-      "gzip": 116242
+      "size": 482066,
+      "gzip": 116273
     },
     "react-dom-server.production.min.js (NODE_PROD)": {
-      "size": 107403,
-      "gzip": 33347
+      "size": 107401,
+      "gzip": 33355
     },
     "ReactDOMServerStack-dev.js (FB_DEV)": {
-      "size": 463581,
-      "gzip": 112069
+      "size": 463630,
+      "gzip": 112080
     },
     "ReactDOMServerStack-prod.js (FB_PROD)": {
-      "size": 340301,
-      "gzip": 82162
+      "size": 340256,
+      "gzip": 82153
     },
     "ReactARTStack-dev.js (FB_DEV)": {
       "size": 143177,
@@ -157,12 +157,12 @@
       "gzip": 2234
     },
     "ReactDOMServerStream-dev.js (FB_DEV)": {
-      "size": 480568,
-      "gzip": 116171
+      "size": 480710,
+      "gzip": 116205
     },
     "ReactDOMServerStream-prod.js (FB_PROD)": {
-      "size": 351458,
-      "gzip": 85017
+      "size": 351501,
+      "gzip": 85033
     },
     "ReactNativeStack-dev.js (RN_DEV)": {
       "size": 186098,

--- a/src/renderers/dom/shared/CSSPropertyOperations.js
+++ b/src/renderers/dom/shared/CSSPropertyOperations.js
@@ -14,7 +14,6 @@
 var CSSProperty = require('CSSProperty');
 var ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
 
-var camelizeStyleName = require('fbjs/lib/camelizeStyleName');
 var dangerousStyleValue = require('dangerousStyleValue');
 var getComponentName = require('getComponentName');
 var hyphenateStyleName = require('fbjs/lib/hyphenateStyleName');
@@ -41,6 +40,7 @@ if (ExecutionEnvironment.canUseDOM) {
 }
 
 if (__DEV__) {
+  var camelizeStyleName = require('fbjs/lib/camelizeStyleName');
   // 'msTransform' is correct, but the other prefixes should be capitalized
   var badVendoredStyleNamePattern = /^(?:webkit|moz|o)[A-Z]/;
 


### PR DESCRIPTION
This is a follow on from comments in this PR:

https://github.com/facebook/react/pull/9790

Currently, the build can be quite hard to reason with given un-used externals don't give errors. This PR adds an exclusion list and forces unused external modules to throw an error - prompting that something needs to change.

This is still a WIP as I'm not sure this is 100% the best route for this still.