### PR TITLE
Disable tests of recovering from node.normalize()

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -3,9 +3,3 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * should not blow away user-entered text on successful reconnect to a controlled checkbox
 * should not blow away user-selected value on successful reconnect to an uncontrolled select
 * should not blow away user-selected value on successful reconnect to an controlled select
-
-src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
-* can reconcile text merged by Node.normalize() alongside other elements
-* can reconcile text merged by Node.normalize()
-* can reconcile text arbitrarily split into multiple nodes
-* can reconcile text arbitrarily split into multiple nodes on some substitutions only


### PR DESCRIPTION
According to #9836 we're intentionally choosing to not support this until we have better proof of this being a big need. E.g. to protect against extensions. In a way that it's not better to push extensions to be fixed.

I went with the `xit` model since jest doesn't yet have a way to intentionally fail. We already have precedent for other `xit` in our tests.