### PR TITLE
Updated label in build-script

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -397,7 +397,7 @@ function createBundle(bundle, bundleType) {
   const format = getFormat(bundleType);
   const packageName = Packaging.getPackageName(bundle.name);
 
-  console.log(`${chalk.bgYellow.black(' STARTING ')} ${logKey}`);
+  console.log(`${chalk.bgYellow.black(' BUILDING ')} ${logKey}`);
   return rollup({
     entry: bundleType === FB_DEV || bundleType === FB_PROD
       ? bundle.fbEntry


### PR DESCRIPTION
This is a tiny nit-PR to pair with diff D5194769. Basically I think the string "_BUILDING_" makes for a more meaningful message in a react sync than "_STARTING_".

![screen shot 2017-06-06 at 2 20 49 pm](https://user-images.githubusercontent.com/29597/26853119-8f9a2a94-4ac5-11e7-828b-f551f63fcf42.png)