### PR TITLE
Remove useCreateElement flag

### DIFF
--- a/scripts/circleci/test_entry_point.sh
+++ b/scripts/circleci/test_entry_point.sh
@@ -12,10 +12,6 @@ if [ $((2 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
   COMMANDS_TO_RUN+=('./scripts/circleci/test_fiber.sh')
 fi
 
-if [ $((3 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
-  COMMANDS_TO_RUN+=('./scripts/circleci/test_html_generation.sh')
-fi
-
 # These seem out of order but extract-errors must be run after jest.
 if [ $((0 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
   COMMANDS_TO_RUN+=('node ./scripts/tasks/eslint')

--- a/scripts/circleci/test_entry_point.sh
+++ b/scripts/circleci/test_entry_point.sh
@@ -12,9 +12,12 @@ if [ $((2 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
   COMMANDS_TO_RUN+=('./scripts/circleci/test_fiber.sh')
 fi
 
+if [ $((3 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
+  COMMANDS_TO_RUN+=('node ./scripts/tasks/eslint')
+fi
+
 # These seem out of order but extract-errors must be run after jest.
 if [ $((0 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
-  COMMANDS_TO_RUN+=('node ./scripts/tasks/eslint')
   COMMANDS_TO_RUN+=('node ./scripts/prettier/index')
   COMMANDS_TO_RUN+=('node ./scripts/tasks/flow')
   COMMANDS_TO_RUN+=('node ./scripts/tasks/jest')

--- a/scripts/circleci/test_html_generation.sh
+++ b/scripts/circleci/test_html_generation.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e
-
-echo 'Testing in server-render (HTML generation) mode...'
-printf '\nmodule.exports.useCreateElement = false;\n' \
-  >> src/renderers/dom/shared/ReactDOMFeatureFlags.js
-node ./scripts/tasks/jest
-git checkout -- src/renderers/dom/shared/ReactDOMFeatureFlags.js

--- a/src/renderers/__tests__/ReactHostOperationHistoryHook-test.js
+++ b/src/renderers/__tests__/ReactHostOperationHistoryHook-test.js
@@ -55,9 +55,7 @@ describeStack('ReactHostOperationHistoryHook', () => {
         {
           instanceID: inst._debugID,
           type: 'mount',
-          payload: ReactDOMFeatureFlags.useCreateElement
-            ? 'DIV'
-            : '<div data-reactroot="" data-reactid="1"><p data-reactid="2">Hi.</p></div>',
+          payload: 'DIV',
         },
       ]);
     });
@@ -76,10 +74,7 @@ describeStack('ReactHostOperationHistoryHook', () => {
         {
           instanceID: inst._debugID,
           type: 'mount',
-          payload: ReactDOMFeatureFlags.useCreateElement
-            ? 'DIV'
-            : '<div data-reactroot="" data-reactid="1">' +
-                '<p data-reactid="2">Hi.</p></div>',
+          payload: 'DIV',
         },
       ]);
     });
@@ -141,32 +136,21 @@ describeStack('ReactHostOperationHistoryHook', () => {
       );
 
       var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
-      if (ReactDOMFeatureFlags.useCreateElement) {
-        assertHistoryMatches([
-          {
-            instanceID: inst._debugID,
-            type: 'update styles',
-            payload: {
-              color: 'red',
-              backgroundColor: 'yellow',
-            },
+      assertHistoryMatches([
+        {
+          instanceID: inst._debugID,
+          type: 'update styles',
+          payload: {
+            color: 'red',
+            backgroundColor: 'yellow',
           },
-          {
-            instanceID: inst._debugID,
-            type: 'mount',
-            payload: 'DIV',
-          },
-        ]);
-      } else {
-        assertHistoryMatches([
-          {
-            instanceID: inst._debugID,
-            type: 'mount',
-            payload: '<div style="color:red;background-color:yellow" ' +
-              'data-reactroot="" data-reactid="1"></div>',
-          },
-        ]);
-      }
+        },
+        {
+          instanceID: inst._debugID,
+          type: 'mount',
+          payload: 'DIV',
+        },
+      ]);
     });
 
     it('gets recorded during an update', () => {
@@ -259,34 +243,23 @@ describeStack('ReactHostOperationHistoryHook', () => {
         ReactDOM.render(<div className="rad" tabIndex={42} />, node);
 
         var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
-        if (ReactDOMFeatureFlags.useCreateElement) {
-          assertHistoryMatches([
-            {
-              instanceID: inst._debugID,
-              type: 'update attribute',
-              payload: {className: 'rad'},
-            },
-            {
-              instanceID: inst._debugID,
-              type: 'update attribute',
-              payload: {tabIndex: 42},
-            },
-            {
-              instanceID: inst._debugID,
-              type: 'mount',
-              payload: 'DIV',
-            },
-          ]);
-        } else {
-          assertHistoryMatches([
-            {
-              instanceID: inst._debugID,
-              type: 'mount',
-              payload: '<div class="rad" tabindex="42" data-reactroot="" ' +
-                'data-reactid="1"></div>',
-            },
-          ]);
-        }
+        assertHistoryMatches([
+          {
+            instanceID: inst._debugID,
+            type: 'update attribute',
+            payload: {className: 'rad'},
+          },
+          {
+            instanceID: inst._debugID,
+            type: 'update attribute',
+            payload: {tabIndex: 42},
+          },
+          {
+            instanceID: inst._debugID,
+            type: 'mount',
+            payload: 'DIV',
+          },
+        ]);
       });
 
       it('gets recorded during an update', () => {
@@ -362,34 +335,23 @@ describeStack('ReactHostOperationHistoryHook', () => {
         ReactDOM.render(<div data-x="rad" data-y={42} />, node);
 
         var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
-        if (ReactDOMFeatureFlags.useCreateElement) {
-          assertHistoryMatches([
-            {
-              instanceID: inst._debugID,
-              type: 'update attribute',
-              payload: {'data-x': 'rad'},
-            },
-            {
-              instanceID: inst._debugID,
-              type: 'update attribute',
-              payload: {'data-y': 42},
-            },
-            {
-              instanceID: inst._debugID,
-              type: 'mount',
-              payload: 'DIV',
-            },
-          ]);
-        } else {
-          assertHistoryMatches([
-            {
-              instanceID: inst._debugID,
-              type: 'mount',
-              payload: '<div data-x="rad" data-y="42" data-reactroot="" ' +
-                'data-reactid="1"></div>',
-            },
-          ]);
-        }
+        assertHistoryMatches([
+          {
+            instanceID: inst._debugID,
+            type: 'update attribute',
+            payload: {'data-x': 'rad'},
+          },
+          {
+            instanceID: inst._debugID,
+            type: 'update attribute',
+            payload: {'data-y': 42},
+          },
+          {
+            instanceID: inst._debugID,
+            type: 'mount',
+            payload: 'DIV',
+          },
+        ]);
       });
 
       it('gets recorded during an update', () => {
@@ -440,34 +402,23 @@ describeStack('ReactHostOperationHistoryHook', () => {
         ReactDOM.render(<my-component className="rad" tabIndex={42} />, node);
 
         var inst = ReactDOMComponentTree.getInstanceFromNode(node.firstChild);
-        if (ReactDOMFeatureFlags.useCreateElement) {
-          assertHistoryMatches([
-            {
-              instanceID: inst._debugID,
-              type: 'update attribute',
-              payload: {className: 'rad'},
-            },
-            {
-              instanceID: inst._debugID,
-              type: 'update attribute',
-              payload: {tabIndex: 42},
-            },
-            {
-              instanceID: inst._debugID,
-              type: 'mount',
-              payload: 'MY-COMPONENT',
-            },
-          ]);
-        } else {
-          assertHistoryMatches([
-            {
-              instanceID: inst._debugID,
-              type: 'mount',
-              payload: '<my-component className="rad" tabIndex="42" ' +
-                'data-reactroot="" data-reactid="1"></my-component>',
-            },
-          ]);
-        }
+        assertHistoryMatches([
+          {
+            instanceID: inst._debugID,
+            type: 'update attribute',
+            payload: {className: 'rad'},
+          },
+          {
+            instanceID: inst._debugID,
+            type: 'update attribute',
+            payload: {tabIndex: 42},
+          },
+          {
+            instanceID: inst._debugID,
+            type: 'mount',
+            payload: 'MY-COMPONENT',
+          },
+        ]);
       });
 
       it('gets recorded during an update', () => {

--- a/src/renderers/dom/shared/ReactDOMFeatureFlags.js
+++ b/src/renderers/dom/shared/ReactDOMFeatureFlags.js
@@ -13,7 +13,6 @@
 
 var ReactDOMFeatureFlags = {
   fiberAsyncScheduling: false,
-  useCreateElement: true,
   useFiber: true,
 };
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -810,30 +810,28 @@ describe('ReactDOMComponent', () => {
     });
 
     it('should warn if the tag is unrecognized', () => {
-      if (ReactDOMFeatureFlags.useCreateElement) {
-        spyOn(console, 'error');
+      spyOn(console, 'error');
 
-        let realToString;
-        try {
-          realToString = Object.prototype.toString;
-          let wrappedToString = function() {
-            // Emulate browser behavior which is missing in jsdom
-            if (this instanceof window.HTMLUnknownElement) {
-              return '[object HTMLUnknownElement]';
-            }
-            return realToString.apply(this, arguments);
-          };
-          Object.prototype.toString = wrappedToString; // eslint-disable-line no-extend-native
-          ReactTestUtils.renderIntoDocument(<mycustomcomponent />);
-        } finally {
-          Object.prototype.toString = realToString; // eslint-disable-line no-extend-native
-        }
-
-        expectDev(console.error.calls.count()).toBe(1);
-        expectDev(console.error.calls.argsFor(0)[0]).toContain(
-          'The tag <mycustomcomponent> is unrecognized in this browser',
-        );
+      let realToString;
+      try {
+        realToString = Object.prototype.toString;
+        let wrappedToString = function() {
+          // Emulate browser behavior which is missing in jsdom
+          if (this instanceof window.HTMLUnknownElement) {
+            return '[object HTMLUnknownElement]';
+          }
+          return realToString.apply(this, arguments);
+        };
+        Object.prototype.toString = wrappedToString; // eslint-disable-line no-extend-native
+        ReactTestUtils.renderIntoDocument(<mycustomcomponent />);
+      } finally {
+        Object.prototype.toString = realToString; // eslint-disable-line no-extend-native
       }
+
+      expectDev(console.error.calls.count()).toBe(1);
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        'The tag <mycustomcomponent> is unrecognized in this browser',
+      );
     });
 
     it('should warn against children for void elements', () => {
@@ -884,62 +882,58 @@ describe('ReactDOMComponent', () => {
     });
 
     it('should emit a warning once for a named custom component using shady DOM', () => {
-      if (ReactDOMFeatureFlags.useCreateElement) {
-        spyOn(console, 'error');
+      spyOn(console, 'error');
 
-        var defaultCreateElement = document.createElement.bind(document);
+      var defaultCreateElement = document.createElement.bind(document);
 
-        try {
-          document.createElement = element => {
-            var container = defaultCreateElement(element);
-            container.shadyRoot = {};
-            return container;
-          };
-          class ShadyComponent extends React.Component {
-            render() {
-              return <polymer-component />;
-            }
+      try {
+        document.createElement = element => {
+          var container = defaultCreateElement(element);
+          container.shadyRoot = {};
+          return container;
+        };
+        class ShadyComponent extends React.Component {
+          render() {
+            return <polymer-component />;
           }
-          var node = document.createElement('div');
-          ReactDOM.render(<ShadyComponent />, node);
-          expectDev(console.error.calls.count()).toBe(1);
-          expectDev(console.error.calls.argsFor(0)[0]).toContain(
-            'ShadyComponent is using shady DOM. Using shady DOM with React can ' +
-              'cause things to break subtly.',
-          );
-          mountComponent({is: 'custom-shady-div2'});
-          expectDev(console.error.calls.count()).toBe(1);
-        } finally {
-          document.createElement = defaultCreateElement;
         }
+        var node = document.createElement('div');
+        ReactDOM.render(<ShadyComponent />, node);
+        expectDev(console.error.calls.count()).toBe(1);
+        expectDev(console.error.calls.argsFor(0)[0]).toContain(
+          'ShadyComponent is using shady DOM. Using shady DOM with React can ' +
+            'cause things to break subtly.',
+        );
+        mountComponent({is: 'custom-shady-div2'});
+        expectDev(console.error.calls.count()).toBe(1);
+      } finally {
+        document.createElement = defaultCreateElement;
       }
     });
 
     it('should emit a warning once for an unnamed custom component using shady DOM', () => {
-      if (ReactDOMFeatureFlags.useCreateElement) {
-        spyOn(console, 'error');
+      spyOn(console, 'error');
 
-        var defaultCreateElement = document.createElement.bind(document);
+      var defaultCreateElement = document.createElement.bind(document);
 
-        try {
-          document.createElement = element => {
-            var container = defaultCreateElement(element);
-            container.shadyRoot = {};
-            return container;
-          };
+      try {
+        document.createElement = element => {
+          var container = defaultCreateElement(element);
+          container.shadyRoot = {};
+          return container;
+        };
 
-          mountComponent({is: 'custom-shady-div'});
-          expectDev(console.error.calls.count()).toBe(1);
-          expectDev(console.error.calls.argsFor(0)[0]).toContain(
-            'A component is using shady DOM. Using shady DOM with React can ' +
-              'cause things to break subtly.',
-          );
+        mountComponent({is: 'custom-shady-div'});
+        expectDev(console.error.calls.count()).toBe(1);
+        expectDev(console.error.calls.argsFor(0)[0]).toContain(
+          'A component is using shady DOM. Using shady DOM with React can ' +
+            'cause things to break subtly.',
+        );
 
-          mountComponent({is: 'custom-shady-div2'});
-          expectDev(console.error.calls.count()).toBe(1);
-        } finally {
-          document.createElement = defaultCreateElement;
-        }
+        mountComponent({is: 'custom-shady-div2'});
+        expectDev(console.error.calls.count()).toBe(1);
+      } finally {
+        document.createElement = defaultCreateElement;
       }
     });
 
@@ -1068,18 +1062,12 @@ describe('ReactDOMComponent', () => {
     });
 
     it('should support custom elements which extend native elements', () => {
-      if (ReactDOMFeatureFlags.useCreateElement) {
-        var container = document.createElement('div');
-        spyOn(document, 'createElement').and.callThrough();
-        ReactDOM.render(<div is="custom-div" />, container);
-        expect(document.createElement).toHaveBeenCalledWith('div', {
-          is: 'custom-div',
-        });
-      } else {
-        expect(
-          ReactDOMServer.renderToString(<div is="custom-div" />),
-        ).toContain('is="custom-div"');
-      }
+      var container = document.createElement('div');
+      spyOn(document, 'createElement').and.callThrough();
+      ReactDOM.render(<div is="custom-div" />, container);
+      expect(document.createElement).toHaveBeenCalledWith('div', {
+        is: 'custom-div',
+      });
     });
 
     it('should work load and error events on <image> element in SVG', () => {

--- a/src/renderers/dom/shared/__tests__/ReactDOMSVG-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMSVG-test.js
@@ -13,14 +13,12 @@
 
 var React;
 var ReactDOM;
-var ReactDOMFeatureFlags;
 var ReactDOMServer;
 
 describe('ReactDOMSVG', () => {
   beforeEach(() => {
     React = require('react');
     ReactDOM = require('react-dom');
-    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
     ReactDOMServer = require('react-dom/server');
   });
 
@@ -211,15 +209,6 @@ describe('ReactDOMSVG', () => {
   });
 
   it('can render HTML into a foreignObject in non-React SVG tree', () => {
-    if (!ReactDOMFeatureFlags.useCreateElement) {
-      // jsdom doesn't give HTML namespace to foreignObject.innerHTML children.
-      // This problem doesn't exist in the browsers.
-      // https://github.com/facebook/react/pull/8638#issuecomment-269349642
-      // We will skip this test in non-createElement mode considering
-      // that non-createElement mounting is effectively dead code now anyway.
-      return;
-    }
-
     var outerSVGRoot = document.createElementNS(
       'http://www.w3.org/2000/svg',
       'svg',

--- a/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
@@ -1132,9 +1132,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('sets type, step, min, max before value always', () => {
-    if (!ReactDOMFeatureFlags.useCreateElement) {
-      return;
-    }
     var log = [];
     var originalCreateElement = document.createElement;
     spyOn(document, 'createElement').and.callFake(function(type) {
@@ -1196,11 +1193,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('resets value of date/time input to fix bugs in iOS Safari', () => {
-    // https://github.com/facebook/react/issues/7233
-    if (!ReactDOMFeatureFlags.useCreateElement) {
-      return;
-    }
-
     function strify(x) {
       return JSON.stringify(x, null, 2);
     }

--- a/src/renderers/dom/stack/client/ReactMount.js
+++ b/src/renderers/dom/stack/client/ReactMount.js
@@ -16,7 +16,6 @@ var DOMProperty = require('DOMProperty');
 var React = require('react');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var ReactDOMContainerInfo = require('ReactDOMContainerInfo');
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 var ReactInstanceMap = require('ReactInstanceMap');
 var ReactInstrumentation = require('ReactInstrumentation');
 var ReactMarkupChecksum = require('ReactMarkupChecksum');
@@ -132,7 +131,7 @@ function batchedMountComponentIntoNode(
 ) {
   var transaction = ReactUpdates.ReactReconcileTransaction.getPooled(
     /* useCreateElement */
-    !shouldReuseMarkup && ReactDOMFeatureFlags.useCreateElement,
+    !shouldReuseMarkup,
   );
   transaction.perform(
     mountComponentIntoNode,


### PR DESCRIPTION
This removes the flag that used to force Stack into HTML generation mode even for client side.
It should make our CI runs a bit faster.

Note that we didn’t rely on this in the bundles for a long time.
The only real use of this flag was the HTML generation test that we run on CI.

However it no longer represents the way forward (server renderer was separated from Stack), and we have a new suite that covers HTML generation specifically that's independent of this flag.

I still keep the actual HTML generation codepath in the DOMStack, so that we can keep using the Stack bundle. It's just not covered by the normal Stack tests anymore (but it's still covered by new integration tests).