### PR TITLE
Add onBailout hook to React DevTools

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -53,6 +53,7 @@ var {NoWork, OffscreenPriority} = require('ReactPriorityLevel');
 var {Placement, ContentReset, Err, Ref} = require('ReactTypeOfSideEffect');
 var ReactFiberClassComponent = require('ReactFiberClassComponent');
 var {ReactCurrentOwner} = require('ReactGlobalSharedState');
+var {onBailout} = require('ReactFiberDevToolsHook');
 var invariant = require('fbjs/lib/invariant');
 
 if (__DEV__) {
@@ -740,6 +741,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   ): Fiber | null {
     if (__DEV__) {
       cancelWorkTimer(workInProgress);
+    }
+
+    if (typeof onBailout === 'function') {
+      onBailout(workInProgress);
     }
 
     const priorityLevel = workInProgress.pendingWorkPriority;

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -53,7 +53,7 @@ var {NoWork, OffscreenPriority} = require('ReactPriorityLevel');
 var {Placement, ContentReset, Err, Ref} = require('ReactTypeOfSideEffect');
 var ReactFiberClassComponent = require('ReactFiberClassComponent');
 var {ReactCurrentOwner} = require('ReactGlobalSharedState');
-var {onBailout} = require('ReactFiberDevToolsHook');
+var {onRender} = require('ReactFiberDevToolsHook');
 var invariant = require('fbjs/lib/invariant');
 
 if (__DEV__) {
@@ -250,6 +250,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     } else {
       nextChildren = fn(nextProps, context);
     }
+    if (typeof onRender === 'function') {
+      onRender(workInProgress);
+    }
+
     reconcileChildren(current, workInProgress, nextChildren);
     memoizeProps(workInProgress, nextProps);
     return workInProgress.child;
@@ -316,6 +320,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     } else {
       nextChildren = instance.render();
     }
+    if (typeof onRender === 'function') {
+      onRender(workInProgress);
+    }
+
     reconcileChildren(current, workInProgress, nextChildren);
     // Memoize props and state using the values we just used to render.
     // TODO: Restructure so we never read values from the instance.
@@ -741,10 +749,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   ): Fiber | null {
     if (__DEV__) {
       cancelWorkTimer(workInProgress);
-    }
-
-    if (typeof onBailout === 'function') {
-      onBailout(workInProgress);
     }
 
     const priorityLevel = workInProgress.pendingWorkPriority;

--- a/src/renderers/shared/fiber/ReactFiberDevToolsHook.js
+++ b/src/renderers/shared/fiber/ReactFiberDevToolsHook.js
@@ -12,6 +12,7 @@
 
 'use strict';
 
+var emptyFunction = require('fbjs/lib/emptyFunction');
 var warning = require('fbjs/lib/warning');
 
 import type {Fiber} from 'ReactFiber';
@@ -19,8 +20,22 @@ import type {FiberRoot} from 'ReactFiberRoot';
 
 declare var __REACT_DEVTOOLS_GLOBAL_HOOK__: Object | void;
 
+let didCatchErrors = false;
+function tryCall(fn, rendererID, arg) {
+  try {
+    fn(rendererID, arg);
+  } catch (err) {
+    // Catch all errors from DevTools because throwing might be unsafe
+    if (__DEV__) {
+      warning(!didCatchErrors, 'React DevTools encountered an error: %s', err);
+      didCatchErrors = true;
+    }
+  }
+}
+
 let rendererID = null;
 let injectInternals = null;
+let onBailout = null;
 let onCommitRoot = null;
 let onCommitUnmount = null;
 if (
@@ -29,6 +44,7 @@ if (
 ) {
   let {
     inject,
+    onFiberBailout = emptyFunction, // Does not exist in DevTools 2.1.x and earlier
     onCommitFiberRoot,
     onCommitFiberUnmount,
   } = __REACT_DEVTOOLS_GLOBAL_HOOK__;
@@ -38,35 +54,29 @@ if (
     rendererID = inject(internals);
   };
 
+  onBailout = function(root: Fiber) {
+    if (rendererID == null) {
+      return;
+    }
+    tryCall(onFiberBailout, rendererID, root);
+  };
+
   onCommitRoot = function(root: FiberRoot) {
     if (rendererID == null) {
       return;
     }
-    try {
-      onCommitFiberRoot(rendererID, root);
-    } catch (err) {
-      // Catch all errors because it is unsafe to throw in the commit phase.
-      if (__DEV__) {
-        warning(false, 'React DevTools encountered an error: %s', err);
-      }
-    }
+    tryCall(onCommitFiberRoot, rendererID, root);
   };
 
   onCommitUnmount = function(fiber: Fiber) {
     if (rendererID == null) {
       return;
     }
-    try {
-      onCommitFiberUnmount(rendererID, fiber);
-    } catch (err) {
-      // Catch all errors because it is unsafe to throw in the commit phase.
-      if (__DEV__) {
-        warning(false, 'React DevTools encountered an error: %s', err);
-      }
-    }
+    tryCall(onCommitFiberUnmount, rendererID, fiber);
   };
 }
 
 exports.injectInternals = injectInternals;
+exports.onBailout = onBailout;
 exports.onCommitRoot = onCommitRoot;
 exports.onCommitUnmount = onCommitUnmount;

--- a/src/renderers/shared/fiber/ReactFiberDevToolsHook.js
+++ b/src/renderers/shared/fiber/ReactFiberDevToolsHook.js
@@ -35,7 +35,7 @@ function tryCall(fn, rendererID, arg) {
 
 let rendererID = null;
 let injectInternals = null;
-let onBailout = null;
+let onRender = null;
 let onCommitRoot = null;
 let onCommitUnmount = null;
 if (
@@ -44,7 +44,7 @@ if (
 ) {
   let {
     inject,
-    onFiberBailout = emptyFunction, // Does not exist in DevTools 2.1.x and earlier
+    onRenderFiber = emptyFunction, // Does not exist in DevTools 2.1.x and earlier
     onCommitFiberRoot,
     onCommitFiberUnmount,
   } = __REACT_DEVTOOLS_GLOBAL_HOOK__;
@@ -54,11 +54,11 @@ if (
     rendererID = inject(internals);
   };
 
-  onBailout = function(root: Fiber) {
+  onRender = function(root: Fiber) {
     if (rendererID == null) {
       return;
     }
-    tryCall(onFiberBailout, rendererID, root);
+    tryCall(onRenderFiber, rendererID, root);
   };
 
   onCommitRoot = function(root: FiberRoot) {
@@ -77,6 +77,6 @@ if (
 }
 
 exports.injectInternals = injectInternals;
-exports.onBailout = onBailout;
+exports.onRender = onRender;
 exports.onCommitRoot = onCommitRoot;
 exports.onCommitUnmount = onCommitUnmount;


### PR DESCRIPTION
I need to know if a Fiber bailed or not.

I currently have a [comparison like this](https://github.com/facebook/react-devtools/blob/94206873bcfc2f131edcaf264a84706b9dc9d2a2/backend/attachRendererFiber.js#L40-L59) but it’s not exhaustive and doesn’t catch `shouldComponentUpdate` bailouts. This is especially bad because Fiber DevTools actually traverse the whole tree on every commit, so we need to be more aggressive about bailouts there than with Stack.

I talked to @acdlite and we couldn't find any reliable way to deduce it from the structure (which would change anyway). Feel like an explicit hook is more appropriate.

Having this information should both help me avoid unnecessary traversal and updates in DevTools, and fix https://github.com/facebook/react-devtools/issues/337 once and for all (which unfortunately makes the “trace update” feature pretty much useless).

Example before (note how even bailed out AddTodo and other TodoItems are highlighted):

![](https://d2ppvlu71ri8gs.cloudfront.net/items/1z3W2R0E1n2Q0X3B3h3r/Screen%20Recording%202017-06-07%20at%2005.26%20PM.gif?v=bea5092f)

Example after (note how TodoList and one TodoItem are highlighted, others are skipped):

![](https://d2ppvlu71ri8gs.cloudfront.net/items/3W3I312q273v2a461l0r/Screen%20Recording%202017-06-07%20at%2005.22%20PM.gif?v=aac71c5e)

Internally, @emilsjolander is very interested in this for his project, and I'm sure we can find many people interested in www as well who gave up on this tool before (since it wasn't accurate).