### PR TITLE
Fix a bug with memoizedState affecting React DevTools

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -383,6 +383,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
             priorityLevel,
           );
           markChildAsProgressed(current, workInProgress, priorityLevel);
+          memoizeState(workInProgress, state);
           return workInProgress.child;
         }
       }

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -361,36 +361,37 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         return bailoutOnAlreadyFinishedWork(current, workInProgress);
       }
       const element = state.element;
-      if (current === null || current.child === null) {
+      if (
+        (current === null || current.child === null) &&
+        enterHydrationState(workInProgress)
+      ) {
         // If we don't have any current children this might be the first pass.
         // We always try to hydrate. If this isn't a hydration pass there won't
         // be any children to hydrate which is effectively the same thing as
         // not hydrating.
-        if (enterHydrationState(workInProgress)) {
-          // This is a bit of a hack. We track the host root as a placement to
-          // know that we're currently in a mounting state. That way isMounted
-          // works as expected. We must reset this before committing.
-          // TODO: Delete this when we delete isMounted and findDOMNode.
-          workInProgress.effectTag |= Placement;
 
-          // Ensure that children mount into this root without tracking
-          // side-effects. This ensures that we don't store Placement effects on
-          // nodes that will be hydrated.
-          workInProgress.child = mountChildFibersInPlace(
-            workInProgress,
-            workInProgress.child,
-            element,
-            priorityLevel,
-          );
-          markChildAsProgressed(current, workInProgress, priorityLevel);
-          memoizeState(workInProgress, state);
-          return workInProgress.child;
-        }
+        // This is a bit of a hack. We track the host root as a placement to
+        // know that we're currently in a mounting state. That way isMounted
+        // works as expected. We must reset this before committing.
+        // TODO: Delete this when we delete isMounted and findDOMNode.
+        workInProgress.effectTag |= Placement;
+
+        // Ensure that children mount into this root without tracking
+        // side-effects. This ensures that we don't store Placement effects on
+        // nodes that will be hydrated.
+        workInProgress.child = mountChildFibersInPlace(
+          workInProgress,
+          workInProgress.child,
+          element,
+          priorityLevel,
+        );
+        markChildAsProgressed(current, workInProgress, priorityLevel);
+      } else {
+        // Otherwise reset hydration state in case we aborted and resumed another
+        // root.
+        resetHydrationState();
+        reconcileChildren(current, workInProgress, element);
       }
-      // Otherwise reset hydration state in case we aborted and resumed another
-      // root.
-      resetHydrationState();
-      reconcileChildren(current, workInProgress, element);
       memoizeState(workInProgress, state);
       return workInProgress.child;
     }


### PR DESCRIPTION
#9580 accidentally added a branch that didn’t memoize state for the root.
DevTools relies on root's memoizedState to tell if we're mounting or unmounting.
This should fix it.

Test plan: verified this fixes an issue in another app I'm debugging with a version from master.