### PR TITLE
Add Bailout effectTag for React DevTools

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -50,7 +50,13 @@ var {
   Fragment,
 } = ReactTypeOfWork;
 var {NoWork, OffscreenPriority} = require('ReactPriorityLevel');
-var {Placement, ContentReset, Err, Ref} = require('ReactTypeOfSideEffect');
+var {
+  PerformedWork,
+  Placement,
+  ContentReset,
+  Err,
+  Ref,
+} = require('ReactTypeOfSideEffect');
 var ReactFiberClassComponent = require('ReactFiberClassComponent');
 var {ReactCurrentOwner} = require('ReactGlobalSharedState');
 var invariant = require('fbjs/lib/invariant');
@@ -249,6 +255,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     } else {
       nextChildren = fn(nextProps, context);
     }
+    // React DevTools reads this flag.
+    workInProgress.effectTag |= PerformedWork;
     reconcileChildren(current, workInProgress, nextChildren);
     memoizeProps(workInProgress, nextProps);
     return workInProgress.child;
@@ -315,6 +323,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     } else {
       nextChildren = instance.render();
     }
+    // React DevTools reads this flag.
+    workInProgress.effectTag |= PerformedWork;
     reconcileChildren(current, workInProgress, nextChildren);
     // Memoize props and state using the values we just used to render.
     // TODO: Restructure so we never read values from the instance.
@@ -548,6 +558,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     } else {
       value = fn(props, context);
     }
+    // React DevTools reads this flag.
+    workInProgress.effectTag |= PerformedWork;
 
     if (
       typeof value === 'object' &&

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -15,7 +15,7 @@
 import type {Fiber} from 'ReactFiber';
 import type {PriorityLevel} from 'ReactPriorityLevel';
 
-var {Bailout, Update} = require('ReactTypeOfSideEffect');
+var {Update} = require('ReactTypeOfSideEffect');
 
 var ReactFeatureFlags = require('ReactFeatureFlags');
 var {AsyncUpdates} = require('ReactTypeOfInternalContext');
@@ -620,17 +620,13 @@ module.exports = function(
     } else {
       // If an update was already in progress, we should schedule an Update
       // effect even though we're bailing out, so that cWU/cDU are called.
-      if (
-        typeof instance.componentDidUpdate === 'function' &&
-        (oldProps !== current.memoizedProps ||
-          oldState !== current.memoizedState)
-      ) {
-        workInProgress.effectTag |= Update | Bailout;
-      } else {
-        // Also mark it as a bailout. If alone, it won't be part of the effect list,
-        // but React DevTools will be able to determine this Fiber hasn't updated,
-        // and avoid flashing the component in "Highlight Updates" tracing mode.
-        workInProgress.effectTag |= Bailout;
+      if (typeof instance.componentDidUpdate === 'function') {
+        if (
+          oldProps !== current.memoizedProps ||
+          oldState !== current.memoizedState
+        ) {
+          workInProgress.effectTag |= Update;
+        }
       }
 
       // If shouldComponentUpdate returned false, we should still update the

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -64,7 +64,7 @@ var {
 var {AsyncUpdates} = require('ReactTypeOfInternalContext');
 
 var {
-  Bailout,
+  PerformedWork,
   Placement,
   Update,
   PlacementAndUpdate,
@@ -336,7 +336,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       // possible bitmap value, we remove the secondary effects from the
       // effect tag and switch on that value.
       let primaryEffectTag =
-        effectTag & ~(Callback | Err | ContentReset | Ref | Bailout);
+        effectTag & ~(Callback | Err | ContentReset | Ref | PerformedWork);
       switch (primaryEffectTag) {
         case Placement: {
           commitPlacement(nextEffect);
@@ -446,7 +446,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     priorityContext = TaskPriority;
 
     let firstEffect;
-    if (finishedWork.effectTag > Bailout) {
+    if (finishedWork.effectTag > PerformedWork) {
       // A fiber's effect list consists only of its children, not itself. So if
       // the root has an effect, we need to add it to the end of the list. The
       // resulting list is the set that would belong to the root's parent, if
@@ -643,9 +643,9 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         // reusing children we'll schedule this effect onto itself since we're
         // at the end.
         const effectTag = workInProgress.effectTag;
-        // Skip both NoWork and Bailout tags when creating the effect list.
-        // Bailout effect is read by React DevTools but shouldn't be committed.
-        if (effectTag > Bailout) {
+        // Skip both NoWork and PerformedWork tags when creating the effect list.
+        // PerformedWork effect is read by React DevTools but shouldn't be committed.
+        if (effectTag > PerformedWork) {
           if (returnFiber.lastEffect !== null) {
             returnFiber.lastEffect.nextEffect = workInProgress;
           } else {

--- a/src/renderers/shared/fiber/ReactTypeOfSideEffect.js
+++ b/src/renderers/shared/fiber/ReactTypeOfSideEffect.js
@@ -15,13 +15,16 @@
 export type TypeOfSideEffect = number;
 
 module.exports = {
-  NoEffect: 0, //           0b0000000
-  Placement: 1, //          0b0000001
-  Update: 2, //             0b0000010
-  PlacementAndUpdate: 3, // 0b0000011
-  Deletion: 4, //           0b0000100
-  ContentReset: 8, //       0b0001000
-  Callback: 16, //          0b0010000
-  Err: 32, //               0b0100000
-  Ref: 64, //               0b1000000
+  // Don't change these two values:
+  NoEffect: 0, //           0b00000000
+  Bailout: 1, //            0b00000001
+  // You can change the rest (and add more).
+  Placement: 2, //          0b00000010
+  Update: 4, //             0b00000100
+  PlacementAndUpdate: 6, // 0b00000110
+  Deletion: 8, //           0b00001000
+  ContentReset: 16, //      0b00010000
+  Callback: 32, //          0b00100000
+  Err: 64, //               0b01000000
+  Ref: 128, //              0b10000000
 };

--- a/src/renderers/shared/fiber/ReactTypeOfSideEffect.js
+++ b/src/renderers/shared/fiber/ReactTypeOfSideEffect.js
@@ -17,7 +17,7 @@ export type TypeOfSideEffect = number;
 module.exports = {
   // Don't change these two values:
   NoEffect: 0, //           0b00000000
-  Bailout: 1, //            0b00000001
+  PerformedWork: 1, //      0b00000001
   // You can change the rest (and add more).
   Placement: 2, //          0b00000010
   Update: 4, //             0b00000100


### PR DESCRIPTION
I have not added tests since it's not observable via public API, but I verified it works with React DevTools as expected if I make the necessary changes there.

This lets us fix this feature: https://github.com/facebook/react-devtools/issues/337. It also makes DevTools faster because we can confidently skip bailed trees, which is important since DevTools now traverses the complete tree.

I added this both in development and production because it doesn’t seem expensive to me, and I would prefer this feature to behave consistently. Its current pitfalls are already bad enough that people don’t trust it. I’d rather not trade them for other pitfalls. We can completely disable this in the future if we add a PROFILE build, and PROD build becomes incompatible with DevTools because of advanced optimizations. But I’d rather not break it earlier.

Example before (note how even bailed out AddTodo and other TodoItems are highlighted):

![](https://d2ppvlu71ri8gs.cloudfront.net/items/1z3W2R0E1n2Q0X3B3h3r/Screen%20Recording%202017-06-07%20at%2005.26%20PM.gif?v=bea5092f)

Example after (note how TodoList and one TodoItem are highlighted, others are skipped):

![](https://d2ppvlu71ri8gs.cloudfront.net/items/3W3I312q273v2a461l0r/Screen%20Recording%202017-06-07%20at%2005.22%20PM.gif?v=aac71c5e)

