### PR TITLE
Add support for implicitly mocked components using ReactServerRenderer

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -481,6 +481,7 @@ src/renderers/__tests__/ReactIdentity-test.js
 
 src/renderers/__tests__/ReactMockedComponent-test.js
 * should allow an implicitly mocked component to be rendered without warnings
+* should allow an implicitly mocked component to be rendered without warnings (SSR)
 * should allow an implicitly mocked component to be updated
 * has custom methods on the implicitly mocked component
 * should allow an explicitly mocked component to be rendered

--- a/src/renderers/__tests__/ReactMockedComponent-test.js
+++ b/src/renderers/__tests__/ReactMockedComponent-test.js
@@ -40,7 +40,7 @@ describe('ReactMockedComponent', () => {
     expectDev(console.error.calls.count()).toBe(0);
   });
 
-  it('should allow an implicitly mocked component to be rendered without warnings (ReactDOMServer)', () => {
+  it('should allow an implicitly mocked component to be rendered without warnings (SSR)', () => {
     spyOn(console, 'error');
     ReactDOMServer.renderToString(<AutoMockedComponent />);
     expectDev(console.error.calls.count()).toBe(0);

--- a/src/renderers/__tests__/ReactMockedComponent-test.js
+++ b/src/renderers/__tests__/ReactMockedComponent-test.js
@@ -16,11 +16,13 @@ var ReactTestUtils;
 
 var AutoMockedComponent;
 var MockedComponent;
+var ReactDOMServer;
 
 describe('ReactMockedComponent', () => {
   beforeEach(() => {
     React = require('react');
     ReactTestUtils = require('ReactTestUtils');
+    ReactDOMServer = require('ReactDOMServer');
 
     AutoMockedComponent = jest.genMockFromModule(
       'ReactMockedComponentTestComponent',
@@ -35,6 +37,12 @@ describe('ReactMockedComponent', () => {
   it('should allow an implicitly mocked component to be rendered without warnings', () => {
     spyOn(console, 'error');
     ReactTestUtils.renderIntoDocument(<AutoMockedComponent />);
+    expectDev(console.error.calls.count()).toBe(0);
+  });
+
+  it('should allow an implicitly mocked component to be rendered without warnings (ReactDOMServer)', () => {
+    spyOn(console, 'error');
+    ReactDOMServer.renderToString(<AutoMockedComponent />);
     expectDev(console.error.calls.count()).toBe(0);
   });
 

--- a/src/renderers/shared/server/ReactServerRenderer.js
+++ b/src/renderers/shared/server/ReactServerRenderer.js
@@ -321,6 +321,14 @@ function resolve(child, context) {
     }
     child = inst.render();
 
+    if (__DEV__) {
+      if (child === undefined && inst.render._isMockFunction) {
+        // This is probably bad practice. Consider warning here and
+        // deprecating this convenience.
+        child = null;
+      }
+    }
+
     var childContext = inst.getChildContext && inst.getChildContext();
     if (childContext) {
       context = Object.assign({}, context, childContext);


### PR DESCRIPTION
Takes the current Stack support for implicitly mocked components (automocked) that return undefined.