### PR TITLE
Return empty static markup for null components

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1330,6 +1330,7 @@ src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
 * should throw with silly args
 * should not put checksum and React ID on components
 * should not put checksum and React ID on text components
+* should not use comments for empty nodes
 * should only execute certain lifecycle methods
 * should throw with silly args
 * allows setState in componentWillMount without using DOM

--- a/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
@@ -337,6 +337,18 @@ describe('ReactDOMServer', () => {
       expect(response).toBe('<span>hello world</span>');
     });
 
+    it('should not use comments for empty nodes', () => {
+      class TestComponent extends React.Component {
+        render() {
+          return null;
+        }
+      }
+
+      var response = ReactDOMServer.renderToStaticMarkup(<TestComponent />);
+
+      expect(response).toBe('');
+    });
+
     it('should only execute certain lifecycle methods', () => {
       function runTest() {
         var lifecycle = [];

--- a/src/renderers/shared/server/ReactServerRenderer.js
+++ b/src/renderers/shared/server/ReactServerRenderer.js
@@ -382,6 +382,12 @@ class ReactDOMServerRenderer {
     } else {
       ({child, context} = resolve(child, context));
       if (child === null || child === false) {
+        if (this.makeStaticMarkup) {
+          // Normally we'd insert a comment node, but since this is a situation
+          // where React won't take over (static pages), we can simply return
+          // nothing.
+          return '';
+        }
         return '<!-- react-empty: ' + this.idCounter++ + ' -->';
       } else {
         return this.renderDOM(child, context);


### PR DESCRIPTION
This matches Stack behavior. Added a test that passes in both.