### PR TITLE
RN Inspector guard against clicks outside of RN

### DIFF
--- a/src/renderers/native/ReactNativeFiberInspector.js
+++ b/src/renderers/native/ReactNativeFiberInspector.js
@@ -89,9 +89,19 @@ if (__DEV__) {
   };
 
   getInspectorDataForViewTag = function(viewTag: number): Object {
-    const fiber = findCurrentFiberUsingSlowPath(
-      getClosestInstanceFromNode(viewTag),
-    );
+    const closestInstance = getClosestInstanceFromNode(viewTag);
+
+    // Handle case where user clicks outside of ReactNative
+    if (!closestInstance) {
+      return {
+        hierarchy: [],
+        props: emptyObject,
+        selection: null,
+        source: null,
+      };
+    }
+
+    const fiber = findCurrentFiberUsingSlowPath(closestInstance);
     const fiberHierarchy = getOwnerHierarchy(fiber);
     const instance = lastNonHostInstance(fiberHierarchy);
     const hierarchy = createHierarchy(fiberHierarchy);

--- a/src/renderers/native/ReactNativeStackInspector.js
+++ b/src/renderers/native/ReactNativeStackInspector.js
@@ -67,6 +67,17 @@ if (__DEV__) {
     const component = ReactNativeComponentTree.getClosestInstanceFromNode(
       viewTag,
     );
+
+    // Handle case where user clicks outside of ReactNative
+    if (!component) {
+      return {
+        hierarchy: [],
+        props: emptyObject,
+        selection: null,
+        source: null,
+      };
+    }
+
     const componentHierarchy = getOwnerHierarchy(component);
     const instance = lastNotNativeInstance(componentHierarchy);
     const hierarchy = createHierarchy(componentHierarchy);


### PR DESCRIPTION
Clicking "outside" of a React Native app can cause the latest incarnation of the Inspector to choke. This diff adds guards for this case.