### PR TITLE
Fix formatting for prop name note

### DIFF
--- a/docs/docs/lifting-state-up.md
+++ b/docs/docs/lifting-state-up.md
@@ -195,8 +195,9 @@ Now, when the `TemperatureInput` wants to update its temperature, it calls `this
     // Before: this.setState({temperature: e.target.value});
     this.props.onTemperatureChange(e.target.value);
 ```
-
-> Note that there is no special meaning to either `temperature` or `onTemperatureChange` prop names in custom components. We could have called them anything else, like name them `value` and `onChange` which is a common convention.
+>**Note:**
+>
+> There is no special meaning to either `temperature` or `onTemperatureChange` prop names in custom components. We could have called them anything else, like name them `value` and `onChange` which is a common convention.
 
 The `onTemperatureChange` prop will be provided together with the `temperature` prop by the parent `Calculator` component. It will handle the change by modifying its own local state, thus re-rendering both inputs with the new values. We will look at the new `Calculator` implementation very soon.
 


### PR DESCRIPTION
Fixes formatting in https://github.com/facebook/react/pull/9770. Sorry about that. I'm unable to build the docs locally due to some ruby/gem issues but I'm relatively confident this will fix it since this is the same format used by other notes/tips.

cc @gaearon 