### PR TITLE
Remove addons path deleted in #9209

### DIFF
--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -57,7 +57,6 @@ const bundles = [
     name: 'react',
     paths: [
       'src/isomorphic/**/*.js',
-      'src/addons/**/*.js',
 
       'src/ReactVersion.js',
       'src/shared/**/*.js',


### PR DESCRIPTION
Remove already deleted addons path in `scripts/rollup/bundles.js`