### PR TITLE
Inline case statement in DOM Fiber Component

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -81,34 +81,6 @@ function ensureListeningTo(rootContainerElement, registrationName) {
   listenTo(registrationName, doc);
 }
 
-// There are so many media events, it makes sense to just
-// maintain a list rather than create a `trapBubbledEvent` for each
-var mediaEvents = {
-  topAbort: 'abort',
-  topCanPlay: 'canplay',
-  topCanPlayThrough: 'canplaythrough',
-  topDurationChange: 'durationchange',
-  topEmptied: 'emptied',
-  topEncrypted: 'encrypted',
-  topEnded: 'ended',
-  topError: 'error',
-  topLoadedData: 'loadeddata',
-  topLoadedMetadata: 'loadedmetadata',
-  topLoadStart: 'loadstart',
-  topPause: 'pause',
-  topPlay: 'play',
-  topPlaying: 'playing',
-  topProgress: 'progress',
-  topRateChange: 'ratechange',
-  topSeeked: 'seeked',
-  topSeeking: 'seeking',
-  topStalled: 'stalled',
-  topSuspend: 'suspend',
-  topTimeUpdate: 'timeupdate',
-  topVolumeChange: 'volumechange',
-  topWaiting: 'waiting',
-};
-
 function trapClickOnNonInteractiveElement(node: HTMLElement) {
   // Mobile Safari does not fire properly bubble click events on
   // non-interactive elements, which means delegated click listeners do not
@@ -353,7 +325,11 @@ var ReactDOMFiberComponent = {
       case 'source':
       case 'video':
       case 'details':
-        ReactBrowserEventEmitter.trapBubbledEvent('topToggle', 'toggle', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topToggle',
+          'toggle',
+          domElement,
+        );
         props = rawProps;
         break;
       case 'input':
@@ -377,7 +353,11 @@ var ReactDOMFiberComponent = {
       case 'textarea':
         ReactDOMFiberTextarea.initWrapperState(domElement, rawProps);
         props = ReactDOMFiberTextarea.getHostProps(domElement, rawProps);
-        ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topInvalid',
+          'invalid',
+          domElement,
+        );
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
@@ -688,7 +668,11 @@ var ReactDOMFiberComponent = {
       case 'source':
       case 'video':
       case 'details':
-        ReactBrowserEventEmitter.trapBubbledEvent('topToggle', 'toggle', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topToggle',
+          'toggle',
+          domElement,
+        );
         break;
       case 'input':
         ReactDOMFiberInput.initWrapperState(domElement, rawProps);
@@ -707,7 +691,11 @@ var ReactDOMFiberComponent = {
         break;
       case 'textarea':
         ReactDOMFiberTextarea.initWrapperState(domElement, rawProps);
-        ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topInvalid',
+          'invalid',
+          domElement,
+        );
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -129,45 +129,43 @@ function trapBubbledEventsLocal(node: Element, tag: string) {
   // TODO: Make sure that we check isMounted before firing any of these events.
   // TODO: Inline these below since we're calling this from an equivalent
   // switch statement.
-  switch (tag) {
-    case 'iframe':
-    case 'object':
-      ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', node);
-      break;
-    case 'video':
-    case 'audio':
-      // Create listener for each media event
-      for (var event in mediaEvents) {
-        if (mediaEvents.hasOwnProperty(event)) {
-          ReactBrowserEventEmitter.trapBubbledEvent(
-            event,
-            mediaEvents[event],
-            node,
-          );
-        }
+  case 'iframe':
+  case 'object':
+    ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', node);
+    break;
+  case 'video':
+  case 'audio':
+    // Create listener for each media event
+    for (var event in mediaEvents) {
+      if (mediaEvents.hasOwnProperty(event)) {
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          event,
+          mediaEvents[event],
+          node,
+        );
       }
-      break;
-    case 'source':
-      ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', node);
-      break;
-    case 'img':
-    case 'image':
-      ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', node);
-      ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', node);
-      break;
-    case 'form':
-      ReactBrowserEventEmitter.trapBubbledEvent('topReset', 'reset', node);
-      ReactBrowserEventEmitter.trapBubbledEvent('topSubmit', 'submit', node);
-      break;
-    case 'input':
-    case 'select':
-    case 'textarea':
-      ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', node);
-      break;
-    case 'details':
-      ReactBrowserEventEmitter.trapBubbledEvent('topToggle', 'toggle', node);
-      break;
-  }
+    }
+    break;
+  case 'source':
+    ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', node);
+    break;
+  case 'img':
+  case 'image':
+    ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', node);
+    ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', node);
+    break;
+  case 'form':
+    ReactBrowserEventEmitter.trapBubbledEvent('topReset', 'reset', node);
+    ReactBrowserEventEmitter.trapBubbledEvent('topSubmit', 'submit', node);
+    break;
+  case 'input':
+  case 'select':
+  case 'textarea':
+    ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', node);
+    break;
+  case 'details':
+    ReactBrowserEventEmitter.trapBubbledEvent('topToggle', 'toggle', node);
+    break;
 }
 
 function setInitialDOMProperties(

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -71,6 +71,16 @@ if (__DEV__) {
   };
 }
 
+function ensureListeningTo(rootContainerElement, registrationName) {
+  var isDocumentOrFragment =
+    rootContainerElement.nodeType === DOCUMENT_NODE ||
+    rootContainerElement.nodeType === DOCUMENT_FRAGMENT_NODE;
+  var doc = isDocumentOrFragment
+    ? rootContainerElement
+    : rootContainerElement.ownerDocument;
+  listenTo(registrationName, doc);
+}
+
 // There are so many media events, it makes sense to just
 // maintain a list rather than create a `trapBubbledEvent` for each
 var mediaEvents = {
@@ -98,16 +108,6 @@ var mediaEvents = {
   topVolumeChange: 'volumechange',
   topWaiting: 'waiting',
 };
-
-function ensureListeningTo(rootContainerElement, registrationName) {
-  var isDocumentOrFragment =
-    rootContainerElement.nodeType === DOCUMENT_NODE ||
-    rootContainerElement.nodeType === DOCUMENT_FRAGMENT_NODE;
-  var doc = isDocumentOrFragment
-    ? rootContainerElement
-    : rootContainerElement.ownerDocument;
-  listenTo(registrationName, doc);
-}
 
 function trapClickOnNonInteractiveElement(node: HTMLElement) {
   // Mobile Safari does not fire properly bubble click events on

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -71,6 +71,34 @@ if (__DEV__) {
   };
 }
 
+// There are so many media events, it makes sense to just
+// maintain a list rather than create a `trapBubbledEvent` for each
+var mediaEvents = {
+  topAbort: 'abort',
+  topCanPlay: 'canplay',
+  topCanPlayThrough: 'canplaythrough',
+  topDurationChange: 'durationchange',
+  topEmptied: 'emptied',
+  topEncrypted: 'encrypted',
+  topEnded: 'ended',
+  topError: 'error',
+  topLoadedData: 'loadeddata',
+  topLoadedMetadata: 'loadedmetadata',
+  topLoadStart: 'loadstart',
+  topPause: 'pause',
+  topPlay: 'play',
+  topPlaying: 'playing',
+  topProgress: 'progress',
+  topRateChange: 'ratechange',
+  topSeeked: 'seeked',
+  topSeeking: 'seeking',
+  topStalled: 'stalled',
+  topSuspend: 'suspend',
+  topTimeUpdate: 'timeupdate',
+  topVolumeChange: 'volumechange',
+  topWaiting: 'waiting',
+};
+
 function ensureListeningTo(rootContainerElement, registrationName) {
   var isDocumentOrFragment =
     rootContainerElement.nodeType === DOCUMENT_NODE ||
@@ -316,13 +344,29 @@ var ReactDOMFiberComponent = {
     var props: Object;
     switch (tag) {
       case 'audio':
+        // Create listener for each media event
+        for (var event in mediaEvents) {
+          if (mediaEvents.hasOwnProperty(event)) {
+            ReactBrowserEventEmitter.trapBubbledEvent(
+              event,
+              mediaEvents[event],
+              domElement,
+            );
+          }
+        }
+        break;
       case 'form':
       case 'iframe':
       case 'img':
       case 'image':
+        ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', domElement);
+        break;
       case 'link':
       case 'object':
       case 'source':
+        ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', domElement);
+        break;
       case 'video':
       case 'details':
         ReactBrowserEventEmitter.trapBubbledEvent(
@@ -335,6 +379,7 @@ var ReactDOMFiberComponent = {
       case 'input':
         ReactDOMFiberInput.initWrapperState(domElement, rawProps);
         props = ReactDOMFiberInput.getHostProps(domElement, rawProps);
+        ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', domElement);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
@@ -346,6 +391,7 @@ var ReactDOMFiberComponent = {
       case 'select':
         ReactDOMFiberSelect.initWrapperState(domElement, rawProps);
         props = ReactDOMFiberSelect.getHostProps(domElement, rawProps);
+        ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', domElement);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
@@ -658,14 +704,29 @@ var ReactDOMFiberComponent = {
 
     // TODO: Make sure that we check isMounted before firing any of the below events.
     switch (tag) {
-      case 'audio':
+        case 'audio':
+        // Create listener for each media event
+        for (var event in mediaEvents) {
+          if (mediaEvents.hasOwnProperty(event)) {
+            ReactBrowserEventEmitter.trapBubbledEvent(
+              event,
+              mediaEvents[event],
+              domElement,
+            );
+          }
+        }
+        break;
       case 'form':
       case 'iframe':
       case 'img':
       case 'image':
+        ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', domElement);
+        break;
       case 'link':
       case 'object':
       case 'source':
+        ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', domElement);
       case 'video':
       case 'details':
         ReactBrowserEventEmitter.trapBubbledEvent(
@@ -676,6 +737,7 @@ var ReactDOMFiberComponent = {
         break;
       case 'input':
         ReactDOMFiberInput.initWrapperState(domElement, rawProps);
+        ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', domElement);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
@@ -685,6 +747,7 @@ var ReactDOMFiberComponent = {
         break;
       case 'select':
         ReactDOMFiberSelect.initWrapperState(domElement, rawProps);
+        ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', domElement);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -127,8 +127,6 @@ function trapBubbledEventsLocal(node: Element, tag: string) {
   // the state of the tree to be corrupted, `node` here can be null.
 
   // TODO: Make sure that we check isMounted before firing any of these events.
-  // TODO: Inline these below since we're calling this from an equivalent
-  // switch statement.
   case 'iframe':
   case 'object':
     ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', node);

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -122,50 +122,6 @@ function trapClickOnNonInteractiveElement(node: HTMLElement) {
   node.onclick = emptyFunction;
 }
 
-function trapBubbledEventsLocal(node: Element, tag: string) {
-  // If a component renders to null or if another component fatals and causes
-  // the state of the tree to be corrupted, `node` here can be null.
-
-  // TODO: Make sure that we check isMounted before firing any of these events.
-  case 'iframe':
-  case 'object':
-    ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', node);
-    break;
-  case 'video':
-  case 'audio':
-    // Create listener for each media event
-    for (var event in mediaEvents) {
-      if (mediaEvents.hasOwnProperty(event)) {
-        ReactBrowserEventEmitter.trapBubbledEvent(
-          event,
-          mediaEvents[event],
-          node,
-        );
-      }
-    }
-    break;
-  case 'source':
-    ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', node);
-    break;
-  case 'img':
-  case 'image':
-    ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', node);
-    ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', node);
-    break;
-  case 'form':
-    ReactBrowserEventEmitter.trapBubbledEvent('topReset', 'reset', node);
-    ReactBrowserEventEmitter.trapBubbledEvent('topSubmit', 'submit', node);
-    break;
-  case 'input':
-  case 'select':
-  case 'textarea':
-    ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', node);
-    break;
-  case 'details':
-    ReactBrowserEventEmitter.trapBubbledEvent('topToggle', 'toggle', node);
-    break;
-}
-
 function setInitialDOMProperties(
   domElement: Element,
   rootContainerElement: Element | Document,
@@ -384,6 +340,7 @@ var ReactDOMFiberComponent = {
       }
     }
 
+    // TODO: Make sure that we check isMounted before firing any of the below events.
     var props: Object;
     switch (tag) {
       case 'audio':
@@ -396,13 +353,12 @@ var ReactDOMFiberComponent = {
       case 'source':
       case 'video':
       case 'details':
-        trapBubbledEventsLocal(domElement, tag);
+        ReactBrowserEventEmitter.trapBubbledEvent('topToggle', 'toggle', domElement);
         props = rawProps;
         break;
       case 'input':
         ReactDOMFiberInput.initWrapperState(domElement, rawProps);
         props = ReactDOMFiberInput.getHostProps(domElement, rawProps);
-        trapBubbledEventsLocal(domElement, tag);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
@@ -414,7 +370,6 @@ var ReactDOMFiberComponent = {
       case 'select':
         ReactDOMFiberSelect.initWrapperState(domElement, rawProps);
         props = ReactDOMFiberSelect.getHostProps(domElement, rawProps);
-        trapBubbledEventsLocal(domElement, tag);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
@@ -422,7 +377,7 @@ var ReactDOMFiberComponent = {
       case 'textarea':
         ReactDOMFiberTextarea.initWrapperState(domElement, rawProps);
         props = ReactDOMFiberTextarea.getHostProps(domElement, rawProps);
-        trapBubbledEventsLocal(domElement, tag);
+        ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', domElement);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
@@ -721,6 +676,7 @@ var ReactDOMFiberComponent = {
       }
     }
 
+    // TODO: Make sure that we check isMounted before firing any of the below events.
     switch (tag) {
       case 'audio':
       case 'form':
@@ -732,11 +688,10 @@ var ReactDOMFiberComponent = {
       case 'source':
       case 'video':
       case 'details':
-        trapBubbledEventsLocal(domElement, tag);
+        ReactBrowserEventEmitter.trapBubbledEvent('topToggle', 'toggle', domElement);
         break;
       case 'input':
         ReactDOMFiberInput.initWrapperState(domElement, rawProps);
-        trapBubbledEventsLocal(domElement, tag);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
@@ -746,14 +701,13 @@ var ReactDOMFiberComponent = {
         break;
       case 'select':
         ReactDOMFiberSelect.initWrapperState(domElement, rawProps);
-        trapBubbledEventsLocal(domElement, tag);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
         break;
       case 'textarea':
         ReactDOMFiberTextarea.initWrapperState(domElement, rawProps);
-        trapBubbledEventsLocal(domElement, tag);
+        ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', domElement);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');


### PR DESCRIPTION
In looking through the TODO's, I found this one concerning inlining trapping bubbled events, since the function is being called in an equivalent case statement

The function was a no-op for input and select so those changes are just removals. I wasn't exactly sure what to do with the comments. For the `isMounted` one, I duplicated it where the function was being called and for the one about null nodes I dropped it since it seemed specific to bubbling events
