### PR TITLE
Remove local trapBubbledEvents

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -122,54 +122,6 @@ function trapClickOnNonInteractiveElement(node: HTMLElement) {
   node.onclick = emptyFunction;
 }
 
-function trapBubbledEventsLocal(node: Element, tag: string) {
-  // If a component renders to null or if another component fatals and causes
-  // the state of the tree to be corrupted, `node` here can be null.
-
-  // TODO: Make sure that we check isMounted before firing any of these events.
-  // TODO: Inline these below since we're calling this from an equivalent
-  // switch statement.
-  switch (tag) {
-    case 'iframe':
-    case 'object':
-      ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', node);
-      break;
-    case 'video':
-    case 'audio':
-      // Create listener for each media event
-      for (var event in mediaEvents) {
-        if (mediaEvents.hasOwnProperty(event)) {
-          ReactBrowserEventEmitter.trapBubbledEvent(
-            event,
-            mediaEvents[event],
-            node,
-          );
-        }
-      }
-      break;
-    case 'source':
-      ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', node);
-      break;
-    case 'img':
-    case 'image':
-      ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', node);
-      ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', node);
-      break;
-    case 'form':
-      ReactBrowserEventEmitter.trapBubbledEvent('topReset', 'reset', node);
-      ReactBrowserEventEmitter.trapBubbledEvent('topSubmit', 'submit', node);
-      break;
-    case 'input':
-    case 'select':
-    case 'textarea':
-      ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', node);
-      break;
-    case 'details':
-      ReactBrowserEventEmitter.trapBubbledEvent('topToggle', 'toggle', node);
-      break;
-  }
-}
-
 function setInitialDOMProperties(
   domElement: Element,
   rootContainerElement: Element | Document,
@@ -388,25 +340,51 @@ var ReactDOMFiberComponent = {
       }
     }
 
+    // TODO: Make sure that we check isMounted before firing any of these events.
     var props: Object;
     switch (tag) {
-      case 'audio':
-      case 'form':
       case 'iframe':
+      case 'object':
+        ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', domElement);
+        props = rawProps;
+        break;
+      case 'video':
+      case 'audio':
+        // Create listener for each media event
+        for (var event in mediaEvents) {
+          if (mediaEvents.hasOwnProperty(event)) {
+            ReactBrowserEventEmitter.trapBubbledEvent(
+              event,
+              mediaEvents[event],
+              domElement,
+            );
+          }
+        }
+        props = rawProps;
+        break;
+      case 'source':
+        ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', domElement);
+        props = rawProps;
+        break;
       case 'img':
       case 'image':
-      case 'link':
-      case 'object':
-      case 'source':
-      case 'video':
+        ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', domElement);
+        props = rawProps;
+        break;
+      case 'form':
+        ReactBrowserEventEmitter.trapBubbledEvent('topReset', 'reset', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent('topSubmit', 'submit', domElement);
+        props = rawProps;
+        break;
       case 'details':
-        trapBubbledEventsLocal(domElement, tag);
+        ReactBrowserEventEmitter.trapBubbledEvent('topToggle', 'toggle', domElement);
         props = rawProps;
         break;
       case 'input':
         ReactDOMFiberInput.initWrapperState(domElement, rawProps);
         props = ReactDOMFiberInput.getHostProps(domElement, rawProps);
-        trapBubbledEventsLocal(domElement, tag);
+        ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', domElement);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
@@ -418,7 +396,7 @@ var ReactDOMFiberComponent = {
       case 'select':
         ReactDOMFiberSelect.initWrapperState(domElement, rawProps);
         props = ReactDOMFiberSelect.getHostProps(domElement, rawProps);
-        trapBubbledEventsLocal(domElement, tag);
+        ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', domElement);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
@@ -426,7 +404,7 @@ var ReactDOMFiberComponent = {
       case 'textarea':
         ReactDOMFiberTextarea.initWrapperState(domElement, rawProps);
         props = ReactDOMFiberTextarea.getHostProps(domElement, rawProps);
-        trapBubbledEventsLocal(domElement, tag);
+        ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', domElement);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
@@ -725,22 +703,49 @@ var ReactDOMFiberComponent = {
       }
     }
 
+    // TODO: Make sure that we check isMounted before firing any of these events.
     switch (tag) {
-      case 'audio':
-      case 'form':
       case 'iframe':
+      case 'object':
+        ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', domElement);
+        props = rawProps;
+        break;
+      case 'video':
+      case 'audio':
+        // Create listener for each media event
+        for (var event in mediaEvents) {
+          if (mediaEvents.hasOwnProperty(event)) {
+            ReactBrowserEventEmitter.trapBubbledEvent(
+              event,
+              mediaEvents[event],
+              domElement,
+            );
+          }
+        }
+        props = rawProps;
+        break;
+      case 'source':
+        ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', domElement);
+        props = rawProps;
+        break;
       case 'img':
       case 'image':
-      case 'link':
-      case 'object':
-      case 'source':
-      case 'video':
+        ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', domElement);
+        props = rawProps;
+        break;
+      case 'form':
+        ReactBrowserEventEmitter.trapBubbledEvent('topReset', 'reset', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent('topSubmit', 'submit', domElement);
+        props = rawProps;
+        break;
       case 'details':
-        trapBubbledEventsLocal(domElement, tag);
+        ReactBrowserEventEmitter.trapBubbledEvent('topToggle', 'toggle', domElement);
+        props = rawProps;
         break;
       case 'input':
         ReactDOMFiberInput.initWrapperState(domElement, rawProps);
-        trapBubbledEventsLocal(domElement, tag);
+        ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', domElement);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
@@ -750,14 +755,14 @@ var ReactDOMFiberComponent = {
         break;
       case 'select':
         ReactDOMFiberSelect.initWrapperState(domElement, rawProps);
-        trapBubbledEventsLocal(domElement, tag);
+        ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', domElement);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
         break;
       case 'textarea':
         ReactDOMFiberTextarea.initWrapperState(domElement, rawProps);
-        trapBubbledEventsLocal(domElement, tag);
+        ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', domElement);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -752,7 +752,6 @@ var ReactDOMFiberComponent = {
           'load',
           domElement,
         );
-        props = rawProps;
         break;
       case 'video':
       case 'audio':
@@ -766,7 +765,6 @@ var ReactDOMFiberComponent = {
             );
           }
         }
-        props = rawProps;
         break;
       case 'source':
         ReactBrowserEventEmitter.trapBubbledEvent(
@@ -774,7 +772,6 @@ var ReactDOMFiberComponent = {
           'error',
           domElement,
         );
-        props = rawProps;
         break;
       case 'img':
       case 'image':
@@ -788,7 +785,6 @@ var ReactDOMFiberComponent = {
           'load',
           domElement,
         );
-        props = rawProps;
         break;
       case 'form':
         ReactBrowserEventEmitter.trapBubbledEvent(
@@ -801,7 +797,6 @@ var ReactDOMFiberComponent = {
           'submit',
           domElement,
         );
-        props = rawProps;
         break;
       case 'details':
         ReactBrowserEventEmitter.trapBubbledEvent(
@@ -809,7 +804,6 @@ var ReactDOMFiberComponent = {
           'toggle',
           domElement,
         );
-        props = rawProps;
         break;
       case 'input':
         ReactDOMFiberInput.initWrapperState(domElement, rawProps);

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -345,7 +345,11 @@ var ReactDOMFiberComponent = {
     switch (tag) {
       case 'iframe':
       case 'object':
-        ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topLoad',
+          'load',
+          domElement,
+        );
         props = rawProps;
         break;
       case 'video':
@@ -363,28 +367,56 @@ var ReactDOMFiberComponent = {
         props = rawProps;
         break;
       case 'source':
-        ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topError',
+          'error',
+          domElement,
+        );
         props = rawProps;
         break;
       case 'img':
       case 'image':
-        ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', domElement);
-        ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topError',
+          'error',
+          domElement,
+        );
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topLoad',
+          'load',
+          domElement,
+        );
         props = rawProps;
         break;
       case 'form':
-        ReactBrowserEventEmitter.trapBubbledEvent('topReset', 'reset', domElement);
-        ReactBrowserEventEmitter.trapBubbledEvent('topSubmit', 'submit', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topReset',
+          'reset',
+          domElement,
+        );
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topSubmit',
+          'submit',
+          domElement,
+        );
         props = rawProps;
         break;
       case 'details':
-        ReactBrowserEventEmitter.trapBubbledEvent('topToggle', 'toggle', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topToggle',
+          'toggle',
+          domElement,
+        );
         props = rawProps;
         break;
       case 'input':
         ReactDOMFiberInput.initWrapperState(domElement, rawProps);
         props = ReactDOMFiberInput.getHostProps(domElement, rawProps);
-        ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topInvalid',
+          'invalid',
+          domElement,
+        );
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
@@ -396,7 +428,11 @@ var ReactDOMFiberComponent = {
       case 'select':
         ReactDOMFiberSelect.initWrapperState(domElement, rawProps);
         props = ReactDOMFiberSelect.getHostProps(domElement, rawProps);
-        ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topInvalid',
+          'invalid',
+          domElement,
+        );
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
@@ -404,7 +440,11 @@ var ReactDOMFiberComponent = {
       case 'textarea':
         ReactDOMFiberTextarea.initWrapperState(domElement, rawProps);
         props = ReactDOMFiberTextarea.getHostProps(domElement, rawProps);
-        ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topInvalid',
+          'invalid',
+          domElement,
+        );
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
@@ -707,7 +747,11 @@ var ReactDOMFiberComponent = {
     switch (tag) {
       case 'iframe':
       case 'object':
-        ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topLoad',
+          'load',
+          domElement,
+        );
         props = rawProps;
         break;
       case 'video':
@@ -725,27 +769,55 @@ var ReactDOMFiberComponent = {
         props = rawProps;
         break;
       case 'source':
-        ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topError',
+          'error',
+          domElement,
+        );
         props = rawProps;
         break;
       case 'img':
       case 'image':
-        ReactBrowserEventEmitter.trapBubbledEvent('topError', 'error', domElement);
-        ReactBrowserEventEmitter.trapBubbledEvent('topLoad', 'load', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topError',
+          'error',
+          domElement,
+        );
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topLoad',
+          'load',
+          domElement,
+        );
         props = rawProps;
         break;
       case 'form':
-        ReactBrowserEventEmitter.trapBubbledEvent('topReset', 'reset', domElement);
-        ReactBrowserEventEmitter.trapBubbledEvent('topSubmit', 'submit', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topReset',
+          'reset',
+          domElement,
+        );
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topSubmit',
+          'submit',
+          domElement,
+        );
         props = rawProps;
         break;
       case 'details':
-        ReactBrowserEventEmitter.trapBubbledEvent('topToggle', 'toggle', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topToggle',
+          'toggle',
+          domElement,
+        );
         props = rawProps;
         break;
       case 'input':
         ReactDOMFiberInput.initWrapperState(domElement, rawProps);
-        ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topInvalid',
+          'invalid',
+          domElement,
+        );
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
@@ -755,14 +827,22 @@ var ReactDOMFiberComponent = {
         break;
       case 'select':
         ReactDOMFiberSelect.initWrapperState(domElement, rawProps);
-        ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topInvalid',
+          'invalid',
+          domElement,
+        );
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
         break;
       case 'textarea':
         ReactDOMFiberTextarea.initWrapperState(domElement, rawProps);
-        ReactBrowserEventEmitter.trapBubbledEvent('topInvalid', 'invalid', domElement);
+        ReactBrowserEventEmitter.trapBubbledEvent(
+          'topInvalid',
+          'invalid',
+          domElement,
+        );
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');


### PR DESCRIPTION
In looking through the TODO's, I found this one concerning inlining trapping bubbled events, since the function is being called in an equivalent case statement

I wasn't exactly sure what to do with the comments. For the isMounted one, I duplicated it where the function was being called and for the one about null nodes I dropped it completely
