### PR TITLE
Remove broken GCC annotation from create-react-class

### DIFF
--- a/addons/create-react-class/factory.js
+++ b/addons/create-react-class/factory.js
@@ -160,7 +160,6 @@ function factory(ReactComponent, isValidElement, ReactNoopUpdateQueue) {
      *   }
      *
      * @return {ReactComponent}
-     * @nosideeffects
      * @required
      */
     render: 'DEFINE_ONCE',


### PR DESCRIPTION
Fixes last issue in https://github.com/facebook/react/issues/7551.
Same as https://github.com/facebook/react/pull/9928 but submitted against the right branch.