### PR TITLE
Delete .babelrc from addons

### DIFF
--- a/addons/react-addons-pure-render-mixin/.babelrc
+++ b/addons/react-addons-pure-render-mixin/.babelrc
@@ -1,3 +1,0 @@
-{
-  "plugins": ["transform-react-jsx-source"]
-}

--- a/addons/react-addons-shallow-compare/.babelrc
+++ b/addons/react-addons-shallow-compare/.babelrc
@@ -1,3 +1,0 @@
-{
-  "plugins": ["transform-react-jsx-source"]
-}

--- a/addons/react-linked-input/.babelrc
+++ b/addons/react-linked-input/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["es2015"],
-  "plugins": ["transform-react-jsx-source"]
-}


### PR DESCRIPTION
These are currently unused, and at best are confusing since we didn't actually compile them to ES5.