### PR TITLE
Add controlList to DOM property whitelist

### DIFF
--- a/docs/docs/reference-dom-elements.md
+++ b/docs/docs/reference-dom-elements.md
@@ -104,8 +104,8 @@ React supports all `data-*` and `aria-*` attributes as well as these attributes:
 accept acceptCharset accessKey action allowFullScreen allowTransparency alt
 async autoComplete autoFocus autoPlay capture cellPadding cellSpacing challenge
 charSet checked cite classID className colSpan cols content contentEditable
-contextMenu controls coords crossOrigin data dateTime default defer dir
-disabled download draggable encType form formAction formEncType formMethod
+contextMenu controls controlsList coords crossOrigin data dateTime default defer
+dir disabled download draggable encType form formAction formEncType formMethod
 formNoValidate formTarget frameBorder headers height hidden high href hrefLang
 htmlFor httpEquiv icon id inputMode integrity is keyParams keyType kind label
 lang list loop low manifest marginHeight marginWidth max maxLength media

--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -58,6 +58,7 @@ var HTMLDOMPropertyConfig = {
     contentEditable: 0,
     contextMenu: 0,
     controls: HAS_BOOLEAN_VALUE,
+    controlsList: 0,
     coords: 0,
     crossOrigin: 0,
     data: 0, // For `<object />` acts as `src`.


### PR DESCRIPTION
Addresses #9594. Long term, we can ignore this sort of stuff, but the attribute white list change hasn't landed (will it for 15.x?).

**Testing:**

I've hoisted this build of React on surge.sh and setup a fiddle:
https://jsfiddle.net/84v837e9/88/

The video tag should correctly receive the controlList attribute.

**More info:**

- https://github.com/WICG/controls-list/blob/gh-pages/explainer.md
- https://developers.google.com/web/updates/2017/03/chrome-58-media-updates#controlslist