### PR TITLE
Disable 'comma-dangle' eslint rule for './addons'

### DIFF
--- a/addons/.eslintrc
+++ b/addons/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "comma-dangle": 0
+  }
+}


### PR DESCRIPTION
**what is the change?:**
Added an `eslintrc` which disables the 'comma-dangle' rule just for
addons.

**why make this change?:**
To get CI passing again on the 15* branches.

We don't have dangling commas in the addons because it breaks GCC under
certain conditions. This doesn't affect React because we use Babel with
React, but it's not worth setting up Babel for the addons at this time.

**test plan:**
`yarn lint`

**issue:**
None - hopefully will fix this before it's a problem
