### PR TITLE
Remove Animation priority

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "jest": "^19.0.1",
     "jest-config": "^19.0.1",
     "jest-jasmine2": "^19.0.1",
+    "jest-matchers": "^20.0.3",
     "jest-runtime": "^19.0.1",
     "loose-envify": "^1.1.0",
     "merge-stream": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "jest": "^19.0.1",
     "jest-config": "^19.0.1",
     "jest-jasmine2": "^19.0.1",
-    "jest-matchers": "^20.0.3",
+    "jest-matchers": "^19.0.1",
     "jest-runtime": "^19.0.1",
     "loose-envify": "^1.1.0",
     "merge-stream": "^1.0.0",

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1309,6 +1309,7 @@ src/renderers/dom/shared/__tests__/ReactMount-test.js
 * should warn if render removes React-rendered children
 * should warn if the unmounted node was rendered by another copy of React
 * passes the correct callback context
+* initial mount is sync inside batchedUpdates, but task work is deferred until the end of the batch
 
 src/renderers/dom/shared/__tests__/ReactMountDestruction-test.js
 * should destroy a react root upon request
@@ -1832,6 +1833,7 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalPerf-test.js
 * deduplicates lifecycle names during commit to reduce overhead
 * supports coroutines
 * supports portals
+* does not schedule an extra callback if setState is called during a synchronous commit phase
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalReflection-test.js
 * handles isMounted even when the initial render is deferred

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1791,12 +1791,10 @@ src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
 src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
 * catches render error in a boundary during full deferred mounting
 * catches render error in a boundary during partial deferred mounting
-* catches render error in a boundary during animation mounting
 * catches render error in a boundary during synchronous mounting
 * catches render error in a boundary during batched mounting
 * propagates an error from a noop error boundary during full deferred mounting
 * propagates an error from a noop error boundary during partial deferred mounting
-* propagates an error from a noop error boundary during animation mounting
 * propagates an error from a noop error boundary during synchronous mounting
 * propagates an error from a noop error boundary during batched mounting
 * applies batched updates regardless despite errors in scheduling
@@ -1842,18 +1840,16 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalReflection-test.js
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
 * schedules and flushes deferred work
-* schedules and flushes animation work
 * searches for work on other roots once the current root completes
-* schedules an animation callback when there`s leftover animation work
 * schedules top-level updates in order of priority
 * schedules top-level updates with same priority in order of insertion
 * works on deferred roots in the order they were scheduled
 * schedules sync updates when inside componentDidMount/Update
-* can opt-in to deferred/animation scheduling inside componentDidMount/Update
+* can opt-in to async scheduling inside componentDidMount/Update
 * performs Task work even after time runs out
-* does not perform animation work after time runs out
 * can opt-out of batching using unbatchedUpdates
 * nested updates are always deferred, even inside unbatchedUpdates
+* updates do not schedule a new callback if already inside a callback
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
 * can update child nodes of a host instance

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -338,7 +338,7 @@ const bundles = [
       sourceMap: false,
     },
     entry: 'src/renderers/noop/ReactNoopEntry',
-    externals: ['prop-types/checkPropTypes'],
+    externals: ['prop-types/checkPropTypes', 'jest-matchers'],
     isRenderer: true,
     label: 'noop-fiber',
     manglePropertiesOnProd: false,

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -145,8 +145,8 @@
       "gzip": 2234
     },
     "react-noop-renderer.development.js (NODE_DEV)": {
-      "size": 269722,
-      "gzip": 56481
+      "size": 272256,
+      "gzip": 56994
     }
   }
 }

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -25,28 +25,28 @@
       "gzip": 7690
     },
     "react-dom.development.js (UMD_DEV)": {
-      "size": 609702,
-      "gzip": 139802
+      "size": 608162,
+      "gzip": 139430
     },
     "react-dom.production.min.js (UMD_PROD)": {
-      "size": 126123,
-      "gzip": 39666
+      "size": 125771,
+      "gzip": 39564
     },
     "react-dom.development.js (NODE_DEV)": {
-      "size": 568320,
-      "gzip": 130089
+      "size": 566845,
+      "gzip": 129774
     },
     "react-dom.production.min.js (NODE_PROD)": {
-      "size": 122488,
-      "gzip": 38393
+      "size": 122136,
+      "gzip": 38292
     },
     "ReactDOMFiber-dev.js (FB_DEV)": {
-      "size": 568338,
-      "gzip": 130385
+      "size": 566594,
+      "gzip": 129950
     },
     "ReactDOMFiber-prod.js (FB_PROD)": {
-      "size": 428140,
-      "gzip": 96977
+      "size": 426211,
+      "gzip": 96543
     },
     "react-dom-test-utils.development.js (NODE_DEV)": {
       "size": 52921,
@@ -65,28 +65,28 @@
       "gzip": 81957
     },
     "react-dom-server.development.js (UMD_DEV)": {
-      "size": 305758,
-      "gzip": 76967
+      "size": 306445,
+      "gzip": 77153
     },
     "react-dom-server.production.min.js (UMD_PROD)": {
-      "size": 65877,
-      "gzip": 22507
+      "size": 65952,
+      "gzip": 22521
     },
     "react-dom-server.development.js (NODE_DEV)": {
-      "size": 264541,
-      "gzip": 67428
+      "size": 265293,
+      "gzip": 67673
     },
     "react-dom-server.production.min.js (NODE_PROD)": {
-      "size": 62227,
-      "gzip": 21217
+      "size": 62302,
+      "gzip": 21232
     },
     "ReactDOMServerStream-dev.js (FB_DEV)": {
-      "size": 264063,
-      "gzip": 67393
+      "size": 264750,
+      "gzip": 67600
     },
     "ReactDOMServerStream-prod.js (FB_PROD)": {
-      "size": 197791,
-      "gzip": 51009
+      "size": 198041,
+      "gzip": 51047
     },
     "react-art.development.js (UMD_DEV)": {
       "size": 359725,

--- a/src/renderers/art/ReactARTFiberEntry.js
+++ b/src/renderers/art/ReactARTFiberEntry.js
@@ -509,8 +509,6 @@ const ARTRenderer = ReactFiberReconciler({
     return emptyObject;
   },
 
-  scheduleAnimationCallback: ReactDOMFrameScheduling.rAF,
-
   scheduleDeferredCallback: ReactDOMFrameScheduling.rIC,
 
   shouldSetTextContent(type, props) {

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -429,8 +429,6 @@ var DOMRenderer = ReactFiberReconciler({
     return textInstance.nodeValue !== text;
   },
 
-  scheduleAnimationCallback: ReactDOMFrameScheduling.rAF,
-
   scheduleDeferredCallback: ReactDOMFrameScheduling.rIC,
 
   useSyncScheduling: !ReactDOMFeatureFlags.fiberAsyncScheduling,

--- a/src/renderers/native/ReactNativeFiberRenderer.js
+++ b/src/renderers/native/ReactNativeFiberRenderer.js
@@ -360,8 +360,6 @@ const NativeRenderer = ReactFiberReconciler({
     return false;
   },
 
-  scheduleAnimationCallback: global.requestAnimationFrame,
-
   scheduleDeferredCallback: global.requestIdleCallback,
 
   shouldSetTextContent(type: string, props: Props): boolean {

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -25,15 +25,14 @@ import type {UpdateQueue} from 'ReactFiberUpdateQueue';
 var ReactFiberInstrumentation = require('ReactFiberInstrumentation');
 var ReactFiberReconciler = require('ReactFiberReconciler');
 var ReactInstanceMap = require('ReactInstanceMap');
-var {AnimationPriority} = require('ReactPriorityLevel');
+var {TaskPriority} = require('ReactPriorityLevel');
 var emptyObject = require('fbjs/lib/emptyObject');
 
 var expect = require('jest-matchers');
 
 const UPDATE_SIGNAL = {};
 
-var scheduledAnimationCallback = null;
-var scheduledDeferredCallback = null;
+var scheduledCallback = null;
 
 type Container = {rootID: string, children: Array<Instance | TextInstance>};
 type Props = {prop: any, hidden?: boolean};
@@ -185,24 +184,14 @@ var NoopRenderer = ReactFiberReconciler({
     parentInstance.children.splice(index, 1);
   },
 
-  scheduleAnimationCallback(callback) {
-    if (scheduledAnimationCallback) {
-      throw new Error(
-        'Scheduling an animation callback twice is excessive. ' +
-          'Instead, keep track of whether the callback has already been scheduled.',
-      );
-    }
-    scheduledAnimationCallback = callback;
-  },
-
   scheduleDeferredCallback(callback) {
-    if (scheduledDeferredCallback) {
+    if (scheduledCallback) {
       throw new Error(
-        'Scheduling deferred callback twice is excessive. ' +
-          'Instead, keep track of whether the callback has already been scheduled.',
+        'Scheduling a callback twice is excessive. Instead, keep track of ' +
+          'whether the callback has already been scheduled.',
       );
     }
-    scheduledDeferredCallback = callback;
+    scheduledCallback = callback;
   },
 
   prepareForCommit(): void {},
@@ -216,13 +205,11 @@ var DEFAULT_ROOT_ID = '<default>';
 
 let yieldedValues = null;
 
-function* flushUnitsOfWork(
-  n: number = Infinity,
-): Generator<Array<mixed>, void, void> {
+function* flushUnitsOfWork(n: number): Generator<Array<mixed>, void, void> {
   var didStop = false;
-  while (!didStop && scheduledDeferredCallback !== null) {
-    var cb = scheduledDeferredCallback;
-    scheduledDeferredCallback = null;
+  while (!didStop && scheduledCallback !== null) {
+    var cb = scheduledCallback;
+    scheduledCallback = null;
     yieldedValues = null;
     var unitsRemaining = n;
     cb({
@@ -301,16 +288,6 @@ var ReactNoop = {
     return inst ? NoopRenderer.findHostInstance(inst) : null;
   },
 
-  // TODO: Remove this method
-  flushAnimationPri() {
-    var cb = scheduledAnimationCallback;
-    if (cb === null) {
-      return;
-    }
-    scheduledAnimationCallback = null;
-    cb();
-  },
-
   flushDeferredPri(timeout: number = Infinity): Array<mixed> {
     // The legacy version of this function decremented the timeout before
     // returning the new time.
@@ -321,23 +298,17 @@ var ReactNoop = {
     for (const value of flushUnitsOfWork(n)) {
       values.push(...value);
     }
-    // Don't flush animation priority in this legacy function. Some tests may
-    // still rely on this behavior.
     return values;
   },
 
   flush(): Array<mixed> {
-    ReactNoop.flushAnimationPri();
-    return ReactNoop.flushDeferredPri();
+    return ReactNoop.flushUnitsOfWork(Infinity);
   },
 
-  *flushAndYield(
+  flushAndYield(
     unitsOfWork: number = Infinity,
   ): Generator<Array<mixed>, void, void> {
-    for (const value of flushUnitsOfWork(unitsOfWork)) {
-      yield value;
-    }
-    ReactNoop.flushAnimationPri();
+    return flushUnitsOfWork(unitsOfWork);
   },
 
   flushUnitsOfWork(n: number): Array<mixed> {
@@ -345,24 +316,19 @@ var ReactNoop = {
     for (const value of flushUnitsOfWork(n)) {
       values.push(...value);
     }
-    // TODO: We should always flush animation priority after flushing normal/low
-    // priority. Move this to flushUnitsOfWork generator once tests
-    // are converted.
-    ReactNoop.flushAnimationPri();
     return values;
   },
 
   flushThrough(expected: Array<mixed>): void {
     let actual = [];
     if (expected.length !== 0) {
-      for (const value of flushUnitsOfWork()) {
+      for (const value of flushUnitsOfWork(Infinity)) {
         actual.push(...value);
         if (actual.length >= expected.length) {
           break;
         }
       }
     }
-    ReactNoop.flushAnimationPri();
     expect(actual).toEqual(expected);
   },
 
@@ -374,15 +340,17 @@ var ReactNoop = {
     }
   },
 
-  hasScheduledDeferredCallback() {
-    return !!scheduledDeferredCallback;
+  hasScheduledCallback() {
+    return !!scheduledCallback;
   },
 
-  performAnimationWork(fn: Function) {
-    NoopRenderer.performWithPriority(AnimationPriority, fn);
+  taskUpdates(fn: Function) {
+    NoopRenderer.performWithPriority(TaskPriority, fn);
   },
 
   batchedUpdates: NoopRenderer.batchedUpdates,
+
+  deferredUpdates: NoopRenderer.deferredUpdates,
 
   unbatchedUpdates: NoopRenderer.unbatchedUpdates,
 

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -28,6 +28,8 @@ var ReactInstanceMap = require('ReactInstanceMap');
 var {AnimationPriority} = require('ReactPriorityLevel');
 var emptyObject = require('fbjs/lib/emptyObject');
 
+var expect = require('jest-matchers');
+
 const UPDATE_SIGNAL = {};
 
 var scheduledAnimationCallback = null;
@@ -212,22 +214,20 @@ var rootContainers = new Map();
 var roots = new Map();
 var DEFAULT_ROOT_ID = '<default>';
 
-let yieldBeforeNextUnitOfWork = false;
-let yieldValue = null;
+let yieldedValues = null;
 
-function* flushUnitsOfWork(n: number): Generator<mixed, void, void> {
+function* flushUnitsOfWork(
+  n: number = Infinity,
+): Generator<Array<mixed>, void, void> {
   var didStop = false;
   while (!didStop && scheduledDeferredCallback !== null) {
     var cb = scheduledDeferredCallback;
     scheduledDeferredCallback = null;
-    yieldBeforeNextUnitOfWork = false;
-    yieldValue = null;
+    yieldedValues = null;
     var unitsRemaining = n;
-    var didYield = false;
     cb({
       timeRemaining() {
-        if (yieldBeforeNextUnitOfWork) {
-          didYield = true;
+        if (yieldedValues !== null) {
           return 0;
         }
         if (unitsRemaining-- > 0) {
@@ -238,10 +238,10 @@ function* flushUnitsOfWork(n: number): Generator<mixed, void, void> {
       },
     });
 
-    if (didYield) {
-      const valueToYield = yieldValue;
-      yieldValue = null;
-      yield valueToYield;
+    if (yieldedValues !== null) {
+      const values = yieldedValues;
+      yieldedValues = null;
+      yield values;
     }
   }
 }
@@ -301,6 +301,7 @@ var ReactNoop = {
     return inst ? NoopRenderer.findHostInstance(inst) : null;
   },
 
+  // TODO: Remove this method
   flushAnimationPri() {
     var cb = scheduledAnimationCallback;
     if (cb === null) {
@@ -310,47 +311,71 @@ var ReactNoop = {
     cb();
   },
 
-  flushDeferredPri(timeout: number = Infinity) {
+  flushDeferredPri(timeout: number = Infinity): Array<mixed> {
     // The legacy version of this function decremented the timeout before
     // returning the new time.
     // TODO: Convert tests to use flushUnitsOfWork or flushAndYield instead.
     const n = timeout / 5 - 1;
-    const iterator = flushUnitsOfWork(n);
-    let value = iterator.next();
-    while (!value.done) {
-      value = iterator.next();
+
+    let values = [];
+    for (const value of flushUnitsOfWork(n)) {
+      values.push(...value);
     }
     // Don't flush animation priority in this legacy function. Some tests may
     // still rely on this behavior.
+    return values;
   },
 
-  flush() {
+  flush(): Array<mixed> {
     ReactNoop.flushAnimationPri();
-    ReactNoop.flushDeferredPri();
+    return ReactNoop.flushDeferredPri();
   },
 
-  *flushAndYield(unitsOfWork: number = Infinity): Generator<mixed, void, void> {
+  *flushAndYield(
+    unitsOfWork: number = Infinity,
+  ): Generator<Array<mixed>, void, void> {
     for (const value of flushUnitsOfWork(unitsOfWork)) {
       yield value;
     }
     ReactNoop.flushAnimationPri();
   },
 
-  flushUnitsOfWork(n: number) {
-    const iterator = flushUnitsOfWork(n);
-    let value = iterator.next();
-    while (!value.done) {
-      value = iterator.next();
+  flushUnitsOfWork(n: number): Array<mixed> {
+    let values = [];
+    for (const value of flushUnitsOfWork(n)) {
+      values.push(...value);
     }
     // TODO: We should always flush animation priority after flushing normal/low
     // priority. Move this to flushUnitsOfWork generator once tests
     // are converted.
     ReactNoop.flushAnimationPri();
+    return values;
+  },
+
+  flushThrough(expected: Array<mixed>): void {
+    let actual = [];
+    if (expected.length !== 0) {
+      for (const value of flushUnitsOfWork()) {
+        actual.push(...value);
+        if (actual.length >= expected.length) {
+          break;
+        }
+      }
+    }
+    ReactNoop.flushAnimationPri();
+    expect(actual).toEqual(expected);
   },
 
   yield(value: mixed) {
-    yieldBeforeNextUnitOfWork = true;
-    yieldValue = value;
+    if (yieldedValues === null) {
+      yieldedValues = [value];
+    } else {
+      yieldedValues.push(value);
+    }
+  },
+
+  hasScheduledDeferredCallback() {
+    return !!scheduledDeferredCallback;
   },
 
   performAnimationWork(fn: Function) {

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -107,7 +107,6 @@ export type HostConfig<T, P, I, TI, PI, C, CX, PL> = {
   insertBefore(parentInstance: I | C, child: I | TI, beforeChild: I | TI): void,
   removeChild(parentInstance: I | C, child: I | TI): void,
 
-  scheduleAnimationCallback(callback: () => void): number | void,
   scheduleDeferredCallback(
     callback: (deadline: Deadline) => void,
   ): number | void,

--- a/src/renderers/shared/fiber/ReactPriorityLevel.js
+++ b/src/renderers/shared/fiber/ReactPriorityLevel.js
@@ -12,14 +12,13 @@
 
 'use strict';
 
-export type PriorityLevel = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+export type PriorityLevel = 0 | 1 | 2 | 3 | 4 | 5;
 
 module.exports = {
   NoWork: 0, // No work is pending.
   SynchronousPriority: 1, // For controlled text inputs. Synchronous side-effects.
   TaskPriority: 2, // Completes at the end of the current tick.
-  AnimationPriority: 3, // Needs to complete before the next frame.
-  HighPriority: 4, // Interaction that needs to complete pretty soon to feel responsive.
-  LowPriority: 5, // Data fetching, or result from updating stores.
-  OffscreenPriority: 6, // Won't be visible but do the work in case it becomes visible.
+  HighPriority: 3, // Interaction that needs to complete pretty soon to feel responsive.
+  LowPriority: 4, // Data fetching, or result from updating stores.
+  OffscreenPriority: 5, // Won't be visible but do the work in case it becomes visible.
 };

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -320,29 +320,25 @@ describe('ReactIncremental', () => {
     }
 
     // Init
-    ReactNoop.performAnimationWork(() => {
+    ReactNoop.syncUpdates(() => {
       ReactNoop.render(<Foo text="foo" />);
     });
     ReactNoop.flush();
-
     expect(ops).toEqual(['Foo', 'Bar', 'Bar', 'Middle', 'Middle']);
 
     ops = [];
 
     // Render the high priority work (everying except the hidden trees).
-    ReactNoop.performAnimationWork(() => {
+    ReactNoop.syncUpdates(() => {
       ReactNoop.render(<Foo text="foo" />);
     });
-    ReactNoop.flushAnimationPri();
-
     expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
 
     ops = [];
 
     // The hidden content was deprioritized from high to low priority. A low
     // priority callback should have been scheduled. Flush it now.
-    ReactNoop.flushDeferredPri();
-
+    ReactNoop.flush();
     expect(ops).toEqual(['Middle', 'Middle']);
   });
 
@@ -769,10 +765,9 @@ describe('ReactIncremental', () => {
     // Interrupt the current low pri work with a high pri update elsewhere in
     // the tree.
     ops = [];
-    ReactNoop.performAnimationWork(() => {
+    ReactNoop.syncUpdates(() => {
       sibling.setState({});
     });
-    ReactNoop.flushAnimationPri();
     expect(ops).toEqual(['Sibling']);
 
     // Continue the low pri work. The work on Child and GrandChild was memoized

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
@@ -109,49 +109,6 @@ describe('ReactIncrementalErrorHandling', () => {
     expect(ReactNoop.getChildren()).toEqual([span('Caught an error: Hello.')]);
   });
 
-  it('catches render error in a boundary during animation mounting', () => {
-    var ops = [];
-    class ErrorBoundary extends React.Component {
-      state = {error: null};
-      unstable_handleError(error) {
-        ops.push('ErrorBoundary unstable_handleError');
-        this.setState({error});
-      }
-      render() {
-        if (this.state.error) {
-          ops.push('ErrorBoundary render error');
-          return (
-            <span prop={`Caught an error: ${this.state.error.message}.`} />
-          );
-        }
-        ops.push('ErrorBoundary render success');
-        return this.props.children;
-      }
-    }
-
-    function BrokenRender(props) {
-      ops.push('BrokenRender');
-      throw new Error('Hello');
-    }
-
-    ReactNoop.performAnimationWork(() => {
-      ReactNoop.render(
-        <ErrorBoundary>
-          <BrokenRender />
-        </ErrorBoundary>,
-      );
-    });
-
-    ReactNoop.flushAnimationPri();
-    expect(ops).toEqual([
-      'ErrorBoundary render success',
-      'BrokenRender',
-      'ErrorBoundary unstable_handleError',
-      'ErrorBoundary render error',
-    ]);
-    expect(ReactNoop.getChildren()).toEqual([span('Caught an error: Hello.')]);
-  });
-
   it('catches render error in a boundary during synchronous mounting', () => {
     var ops = [];
     class ErrorBoundary extends React.Component {
@@ -310,43 +267,6 @@ describe('ReactIncrementalErrorHandling', () => {
       ReactNoop.flush();
     }).toThrow('Hello');
     expect(ops).toEqual([
-      'BrokenRender',
-      'RethrowErrorBoundary unstable_handleError',
-    ]);
-    expect(ReactNoop.getChildren()).toEqual([]);
-  });
-
-  it('propagates an error from a noop error boundary during animation mounting', () => {
-    var ops = [];
-    class RethrowErrorBoundary extends React.Component {
-      unstable_handleError(error) {
-        ops.push('RethrowErrorBoundary unstable_handleError');
-        throw error;
-      }
-      render() {
-        ops.push('RethrowErrorBoundary render');
-        return this.props.children;
-      }
-    }
-
-    function BrokenRender() {
-      ops.push('BrokenRender');
-      throw new Error('Hello');
-    }
-
-    ReactNoop.performAnimationWork(() => {
-      ReactNoop.render(
-        <RethrowErrorBoundary>
-          <BrokenRender />
-        </RethrowErrorBoundary>,
-      );
-    });
-
-    expect(() => {
-      ReactNoop.flush();
-    }).toThrow('Hello');
-    expect(ops).toEqual([
-      'RethrowErrorBoundary render',
       'BrokenRender',
       'RethrowErrorBoundary unstable_handleError',
     ]);

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalPerf-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalPerf-test.js
@@ -281,7 +281,8 @@ describe('ReactDebugFiberPerf', () => {
   });
 
   it('measures deprioritized work', () => {
-    ReactNoop.performAnimationWork(() => {
+    addComment('Flush the parent');
+    ReactNoop.syncUpdates(() => {
       ReactNoop.render(
         <Parent>
           <div hidden={true}>
@@ -290,10 +291,8 @@ describe('ReactDebugFiberPerf', () => {
         </Parent>,
       );
     });
-    addComment('Flush the parent');
-    ReactNoop.flushAnimationPri();
     addComment('Flush the child');
-    ReactNoop.flushDeferredPri();
+    ReactNoop.flush();
     expect(getFlameChart()).toMatchSnapshot();
   });
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalPerf-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalPerf-test.js
@@ -487,4 +487,20 @@ describe('ReactDebugFiberPerf', () => {
     ReactNoop.flush();
     expect(getFlameChart()).toMatchSnapshot();
   });
+
+  it('does not schedule an extra callback if setState is called during a synchronous commit phase', () => {
+    class Component extends React.Component {
+      state = {step: 1};
+      componentDidMount() {
+        this.setState({step: 2});
+      }
+      render() {
+        return <span prop={this.state.step} />;
+      }
+    }
+    ReactNoop.syncUpdates(() => {
+      ReactNoop.render(<Component />);
+    });
+    expect(getFlameChart()).toMatchSnapshot();
+  });
 });

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
@@ -36,16 +36,6 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren()).toEqual([span('1')]);
   });
 
-  it('schedules and flushes animation work', () => {
-    ReactNoop.performAnimationWork(() => {
-      ReactNoop.render(<span prop="1" />);
-    });
-    expect(ReactNoop.getChildren()).toEqual([]);
-
-    ReactNoop.flushAnimationPri();
-    expect(ReactNoop.getChildren()).toEqual([span('1')]);
-  });
-
   it('searches for work on other roots once the current root completes', () => {
     ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
     ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
@@ -58,46 +48,23 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
   });
 
-  it('schedules an animation callback when there`\s leftover animation work', () => {
-    class Foo extends React.Component {
-      state = {step: 0};
-      componentDidMount() {
-        ReactNoop.performAnimationWork(() => {
-          this.setState({step: 2});
-        });
-        this.setState({step: 1});
-      }
-      render() {
-        return <span prop={this.state.step} />;
-      }
-    }
-
-    ReactNoop.render(<Foo />);
-    // Flush just enough work to mount the component, but not enough to flush
-    // the animation update.
-    ReactNoop.flushDeferredPri(25);
-    expect(ReactNoop.getChildren()).toEqual([span(1)]);
-
-    // There's more animation work. A callback should have been scheduled.
-    ReactNoop.flushAnimationPri();
-    expect(ReactNoop.getChildren()).toEqual([span(2)]);
-  });
-
   it('schedules top-level updates in order of priority', () => {
     // Initial render.
     ReactNoop.render(<span prop={1} />);
     ReactNoop.flush();
     expect(ReactNoop.getChildren()).toEqual([span(1)]);
 
-    ReactNoop.render(<span prop={5} />);
-    ReactNoop.performAnimationWork(() => {
-      ReactNoop.render(<span prop={2} />);
-      ReactNoop.render(<span prop={3} />);
-      ReactNoop.render(<span prop={4} />);
+    ReactNoop.batchedUpdates(() => {
+      ReactNoop.render(<span prop={5} />);
+      ReactNoop.syncUpdates(() => {
+        ReactNoop.render(<span prop={2} />);
+        ReactNoop.render(<span prop={3} />);
+        ReactNoop.render(<span prop={4} />);
+      });
     });
 
     // The low pri update should be flushed last, even though it was scheduled
-    // before the animation updates.
+    // before the sync updates.
     ReactNoop.flush();
     expect(ReactNoop.getChildren()).toEqual([span(5)]);
   });
@@ -207,78 +174,69 @@ describe('ReactIncrementalScheduling', () => {
     ]);
   });
 
-  it('can opt-in to deferred/animation scheduling inside componentDidMount/Update', () => {
-    var instance;
-    var ops = [];
-
+  it('can opt-in to async scheduling inside componentDidMount/Update', () => {
+    let instance;
     class Foo extends React.Component {
       state = {tick: 0};
 
       componentDidMount() {
-        ReactNoop.performAnimationWork(() => {
-          ops.push('componentDidMount (before setState): ' + this.state.tick);
+        ReactNoop.deferredUpdates(() => {
+          ReactNoop.yield(
+            'componentDidMount (before setState): ' + this.state.tick,
+          );
           this.setState({tick: 1});
-          ops.push('componentDidMount (after setState): ' + this.state.tick);
+          ReactNoop.yield(
+            'componentDidMount (after setState): ' + this.state.tick,
+          );
         });
       }
 
       componentDidUpdate() {
-        ReactNoop.performAnimationWork(() => {
-          ops.push('componentDidUpdate: ' + this.state.tick);
+        ReactNoop.deferredUpdates(() => {
+          ReactNoop.yield('componentDidUpdate: ' + this.state.tick);
           if (this.state.tick === 2) {
-            ops.push(
+            ReactNoop.yield(
               'componentDidUpdate (before setState): ' + this.state.tick,
             );
             this.setState({tick: 3});
-            ops.push('componentDidUpdate (after setState): ' + this.state.tick);
+            ReactNoop.yield(
+              'componentDidUpdate (after setState): ' + this.state.tick,
+            );
           }
         });
       }
 
       render() {
-        ops.push('render: ' + this.state.tick);
+        ReactNoop.yield('render: ' + this.state.tick);
         instance = this;
         return <span prop={this.state.tick} />;
       }
     }
 
-    ReactNoop.render(<Foo />);
+    ReactNoop.syncUpdates(() => {
+      ReactNoop.render(<Foo />);
+    });
+    // The cDM update should not have flushed yet because it has async priority.
+    expect(ReactNoop.getChildren()).toEqual([span(0)]);
 
-    ReactNoop.flushDeferredPri(20 + 5);
-    expect(ops).toEqual([
-      'render: 0',
-      'componentDidMount (before setState): 0',
-      'componentDidMount (after setState): 0',
-      // Following items shouldn't appear because they are the result of an
-      // update scheduled with animation priority
-      // 'render: 1',
-      // 'componentDidUpdate: 1',
-    ]);
+    // Now flush the cDM update.
+    expect(ReactNoop.flush()).toEqual(['render: 1', 'componentDidUpdate: 1']);
+    expect(ReactNoop.getChildren()).toEqual([span(1)]);
 
-    ops = [];
-
-    ReactNoop.flushAnimationPri();
-    expect(ops).toEqual(['render: 1', 'componentDidUpdate: 1']);
-
-    ops = [];
+    // Increment the tick to 2. This will trigger an update inside cDU. Flush
+    // the first update without flushing the second one.
     instance.setState({tick: 2});
-    ReactNoop.flushDeferredPri(20 + 5);
-
-    expect(ops).toEqual([
+    ReactNoop.flushThrough([
       'render: 2',
       'componentDidUpdate: 2',
       'componentDidUpdate (before setState): 2',
       'componentDidUpdate (after setState): 2',
-      // Following items shouldn't appear because they are the result of an
-      // update scheduled with animation priority
-      // 'render: 3',
-      // 'componentDidUpdate: 3',
     ]);
+    expect(ReactNoop.getChildren()).toEqual([span(2)]);
 
-    ops = [];
-
-    ReactNoop.flushAnimationPri();
-    expect(ops).toEqual(['render: 3', 'componentDidUpdate: 3']);
+    // Now flush the cDU update.
+    expect(ReactNoop.flush()).toEqual(['render: 3', 'componentDidUpdate: 3']);
+    expect(ReactNoop.getChildren()).toEqual([span(3)]);
   });
 
   it('performs Task work even after time runs out', () => {
@@ -307,37 +265,6 @@ describe('ReactIncrementalScheduling', () => {
     ReactNoop.flushDeferredPri(10);
     // The updates should all be flushed with Task priority
     expect(ReactNoop.getChildren()).toEqual([span(5)]);
-  });
-
-  it('does not perform animation work after time runs out', () => {
-    class Foo extends React.Component {
-      state = {step: 1};
-      componentDidMount() {
-        ReactNoop.performAnimationWork(() => {
-          this.setState({step: 2}, () => {
-            this.setState({step: 3}, () => {
-              this.setState({step: 4}, () => {
-                this.setState({step: 5});
-              });
-            });
-          });
-        });
-      }
-      render() {
-        return <span prop={this.state.step} />;
-      }
-    }
-    ReactNoop.render(<Foo />);
-    // This should be just enough to complete all the work, but not enough to
-    // commit it.
-    ReactNoop.flushDeferredPri(20);
-    expect(ReactNoop.getChildren()).toEqual([]);
-
-    // Do one more unit of work.
-    ReactNoop.flushDeferredPri(10);
-    // None of the updates should be flushed because they only have
-    // animation priority.
-    expect(ReactNoop.getChildren()).toEqual([span(1)]);
   });
 
   it('can opt-out of batching using unbatchedUpdates', () => {
@@ -404,6 +331,33 @@ describe('ReactIncrementalScheduling', () => {
       'componentDidUpdate: 1',
       'render: 2',
       'componentDidUpdate: 2',
+    ]);
+  });
+
+  it('updates do not schedule a new callback if already inside a callback', () => {
+    class Foo extends React.Component {
+      state = {foo: 'foo'};
+      componentWillReceiveProps() {
+        ReactNoop.yield(
+          'has callback before setState: ' + ReactNoop.hasScheduledCallback(),
+        );
+        this.setState({foo: 'baz'});
+        ReactNoop.yield(
+          'has callback after setState: ' + ReactNoop.hasScheduledCallback(),
+        );
+      }
+      render() {
+        return null;
+      }
+    }
+
+    ReactNoop.render(<Foo step={1} />);
+    ReactNoop.flush();
+
+    ReactNoop.render(<Foo step={2} />);
+    expect(ReactNoop.flush()).toEqual([
+      'has callback before setState: false',
+      'has callback after setState: false',
     ]);
   });
 });

--- a/src/renderers/shared/fiber/__tests__/__snapshots__/ReactIncrementalPerf-test.js.snap
+++ b/src/renderers/shared/fiber/__tests__/__snapshots__/ReactIncrementalPerf-test.js.snap
@@ -85,8 +85,6 @@ exports[`ReactDebugFiberPerf does not treat setState from cWM or cWRP as cascadi
   ⚛ (Committing Changes)
     ⚛ (Committing Host Effects: 2 Total)
     ⚛ (Calling Lifecycle Methods: 2 Total)
-
-⚛ (React Tree Reconciliation)
 "
 `;
 

--- a/src/renderers/shared/fiber/__tests__/__snapshots__/ReactIncrementalPerf-test.js.snap
+++ b/src/renderers/shared/fiber/__tests__/__snapshots__/ReactIncrementalPerf-test.js.snap
@@ -67,6 +67,20 @@ exports[`ReactDebugFiberPerf deduplicates lifecycle names during commit to reduc
 "
 `;
 
+exports[`ReactDebugFiberPerf does not schedule an extra callback if setState is called during a synchronous commit phase 1`] = `
+"⛔ (React Tree Reconciliation) Warning: There were cascading updates
+  ⚛ Component [mount]
+  ⛔ (Committing Changes) Warning: Lifecycle hook scheduled a cascading update
+    ⚛ (Committing Host Effects: 1 Total)
+    ⚛ (Calling Lifecycle Methods: 1 Total)
+      ⛔ Component.componentDidMount Warning: Scheduled a cascading update
+  ⚛ Component [update]
+  ⛔ (Committing Changes) Warning: Caused by a cascading update in earlier commit
+    ⚛ (Committing Host Effects: 1 Total)
+    ⚛ (Calling Lifecycle Methods: 1 Total)
+"
+`;
+
 exports[`ReactDebugFiberPerf does not treat setState from cWM or cWRP as cascading 1`] = `
 "// Should not print a warning
 ⚛ (React Tree Reconciliation)

--- a/src/renderers/testing/ReactTestRendererFiberEntry.js
+++ b/src/renderers/testing/ReactTestRendererFiberEntry.js
@@ -212,10 +212,6 @@ var TestRenderer = ReactFiberReconciler({
     parentInstance.children.splice(index, 1);
   },
 
-  scheduleAnimationCallback(fn: Function): void {
-    setTimeout(fn);
-  },
-
   scheduleDeferredCallback(fn: Function): void {
     setTimeout(fn, 0, {timeRemaining: Infinity});
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,7 +90,7 @@ ansi-escapes@^1.1.0, ansi-escapes@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
-ansi-regex@^2.0.0:
+ansi-regex@^2.0.0, ansi-regex@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
@@ -1745,7 +1745,7 @@ devtools-timeline-model@1.1.6:
     chrome-devtools-frontend "1.0.401423"
     resolve "1.1.7"
 
-diff@^3.0.0:
+diff@^3.0.0, diff@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
@@ -3199,6 +3199,15 @@ jest-diff@^19.0.0:
     jest-matcher-utils "^19.0.0"
     pretty-format "^19.0.0"
 
+jest-diff@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-20.0.3.tgz#81f288fd9e675f0fb23c75f1c2b19445fe586617"
+  dependencies:
+    chalk "^1.1.3"
+    diff "^3.2.0"
+    jest-matcher-utils "^20.0.3"
+    pretty-format "^20.0.3"
+
 jest-environment-jsdom@^19.0.2:
   version "19.0.2"
   resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-19.0.2.tgz#ceda859c4a4b94ab35e4de7dab54b926f293e4a3"
@@ -3245,6 +3254,13 @@ jest-matcher-utils@^19.0.0:
     chalk "^1.1.3"
     pretty-format "^19.0.0"
 
+jest-matcher-utils@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz#b3a6b8e37ca577803b0832a98b164f44b7815612"
+  dependencies:
+    chalk "^1.1.3"
+    pretty-format "^20.0.3"
+
 jest-matchers@^19.0.0:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/jest-matchers/-/jest-matchers-19.0.0.tgz#c74ecc6ebfec06f384767ba4d6fa4a42d6755754"
@@ -3254,12 +3270,29 @@ jest-matchers@^19.0.0:
     jest-message-util "^19.0.0"
     jest-regex-util "^19.0.0"
 
+jest-matchers@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-matchers/-/jest-matchers-20.0.3.tgz#ca69db1c32db5a6f707fa5e0401abb55700dfd60"
+  dependencies:
+    jest-diff "^20.0.3"
+    jest-matcher-utils "^20.0.3"
+    jest-message-util "^20.0.3"
+    jest-regex-util "^20.0.3"
+
 jest-message-util@^19.0.0:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-19.0.0.tgz#721796b89c0e4d761606f9ba8cb828a3b6246416"
   dependencies:
     chalk "^1.1.1"
     micromatch "^2.3.11"
+
+jest-message-util@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-20.0.3.tgz#6aec2844306fcb0e6e74d5796c1006d96fdd831c"
+  dependencies:
+    chalk "^1.1.3"
+    micromatch "^2.3.11"
+    slash "^1.0.0"
 
 jest-mock@^19.0.0:
   version "19.0.0"
@@ -3268,6 +3301,10 @@ jest-mock@^19.0.0:
 jest-regex-util@^19.0.0:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-19.0.0.tgz#b7754587112aede1456510bb1f6afe74ef598691"
+
+jest-regex-util@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-20.0.3.tgz#85bbab5d133e44625b19faf8c6aa5122d085d762"
 
 jest-resolve-dependencies@^19.0.0:
   version "19.0.0"
@@ -4317,6 +4354,13 @@ pretty-format@^19.0.0:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-19.0.0.tgz#56530d32acb98a3fa4851c4e2b9d37b420684c84"
   dependencies:
+    ansi-styles "^3.0.0"
+
+pretty-format@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-20.0.3.tgz#020e350a560a1fe1a98dc3beb6ccffb386de8b14"
+  dependencies:
+    ansi-regex "^2.1.1"
     ansi-styles "^3.0.0"
 
 private@^0.1.6, private@~0.1.5:

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,7 +90,7 @@ ansi-escapes@^1.1.0, ansi-escapes@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
-ansi-regex@^2.0.0, ansi-regex@^2.1.1:
+ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
@@ -1745,7 +1745,7 @@ devtools-timeline-model@1.1.6:
     chrome-devtools-frontend "1.0.401423"
     resolve "1.1.7"
 
-diff@^3.0.0, diff@^3.2.0:
+diff@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
@@ -3199,15 +3199,6 @@ jest-diff@^19.0.0:
     jest-matcher-utils "^19.0.0"
     pretty-format "^19.0.0"
 
-jest-diff@^20.0.3:
-  version "20.0.3"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-20.0.3.tgz#81f288fd9e675f0fb23c75f1c2b19445fe586617"
-  dependencies:
-    chalk "^1.1.3"
-    diff "^3.2.0"
-    jest-matcher-utils "^20.0.3"
-    pretty-format "^20.0.3"
-
 jest-environment-jsdom@^19.0.2:
   version "19.0.2"
   resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-19.0.2.tgz#ceda859c4a4b94ab35e4de7dab54b926f293e4a3"
@@ -3254,14 +3245,7 @@ jest-matcher-utils@^19.0.0:
     chalk "^1.1.3"
     pretty-format "^19.0.0"
 
-jest-matcher-utils@^20.0.3:
-  version "20.0.3"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz#b3a6b8e37ca577803b0832a98b164f44b7815612"
-  dependencies:
-    chalk "^1.1.3"
-    pretty-format "^20.0.3"
-
-jest-matchers@^19.0.0:
+jest-matchers@^19.0.0, jest-matchers@^19.0.1:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/jest-matchers/-/jest-matchers-19.0.0.tgz#c74ecc6ebfec06f384767ba4d6fa4a42d6755754"
   dependencies:
@@ -3270,29 +3254,12 @@ jest-matchers@^19.0.0:
     jest-message-util "^19.0.0"
     jest-regex-util "^19.0.0"
 
-jest-matchers@^20.0.3:
-  version "20.0.3"
-  resolved "https://registry.yarnpkg.com/jest-matchers/-/jest-matchers-20.0.3.tgz#ca69db1c32db5a6f707fa5e0401abb55700dfd60"
-  dependencies:
-    jest-diff "^20.0.3"
-    jest-matcher-utils "^20.0.3"
-    jest-message-util "^20.0.3"
-    jest-regex-util "^20.0.3"
-
 jest-message-util@^19.0.0:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-19.0.0.tgz#721796b89c0e4d761606f9ba8cb828a3b6246416"
   dependencies:
     chalk "^1.1.1"
     micromatch "^2.3.11"
-
-jest-message-util@^20.0.3:
-  version "20.0.3"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-20.0.3.tgz#6aec2844306fcb0e6e74d5796c1006d96fdd831c"
-  dependencies:
-    chalk "^1.1.3"
-    micromatch "^2.3.11"
-    slash "^1.0.0"
 
 jest-mock@^19.0.0:
   version "19.0.0"
@@ -3301,10 +3268,6 @@ jest-mock@^19.0.0:
 jest-regex-util@^19.0.0:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-19.0.0.tgz#b7754587112aede1456510bb1f6afe74ef598691"
-
-jest-regex-util@^20.0.3:
-  version "20.0.3"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-20.0.3.tgz#85bbab5d133e44625b19faf8c6aa5122d085d762"
 
 jest-resolve-dependencies@^19.0.0:
   version "19.0.0"
@@ -4354,13 +4317,6 @@ pretty-format@^19.0.0:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-19.0.0.tgz#56530d32acb98a3fa4851c4e2b9d37b420684c84"
   dependencies:
-    ansi-styles "^3.0.0"
-
-pretty-format@^20.0.3:
-  version "20.0.3"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-20.0.3.tgz#020e350a560a1fe1a98dc3beb6ccffb386de8b14"
-  dependencies:
-    ansi-regex "^2.1.1"
     ansi-styles "^3.0.0"
 
 private@^0.1.6, private@~0.1.5:


### PR DESCRIPTION
Follow up to this comment: https://github.com/facebook/react/pull/9952#discussion_r121815361

If we're already performing work, we shouldn't schedule an additional callback, e.g. if `setState` is called inside `componentWillReceiveProps`.

### Update

The scope of this PR increased from its original description. Now it removes Animation priority as a feature. There's no advantage to scheduling updates with animation priority versus scheduling sync work inside `requestAnimationCallback`. So we can remove all the animation-specific code. Now there's only one type of callback.