### PR TITLE
Wrap all non-UMD DEV bundles into a condition

### DIFF
--- a/scripts/rollup/header.js
+++ b/scripts/rollup/header.js
@@ -1,7 +1,5 @@
 const Bundles = require('./bundles');
 
-const FB_DEV = Bundles.bundleTypes.FB_DEV;
-
 function getProvidesHeader(hasteFinalName) {
   return `/**
  * Copyright 2013-present, Facebook, Inc.

--- a/scripts/rollup/header.js
+++ b/scripts/rollup/header.js
@@ -1,4 +1,4 @@
-const Bundles = require('./bundles');
+'use strict';
 
 function getProvidesHeader(hasteFinalName) {
   return `/**

--- a/scripts/rollup/header.js
+++ b/scripts/rollup/header.js
@@ -2,7 +2,7 @@ const Bundles = require('./bundles');
 
 const FB_DEV = Bundles.bundleTypes.FB_DEV;
 
-function getProvidesHeader(hasteFinalName, bundleType, fbDevCode) {
+function getProvidesHeader(hasteFinalName) {
   return `/**
  * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
@@ -13,7 +13,7 @@ function getProvidesHeader(hasteFinalName, bundleType, fbDevCode) {
  *
  * @noflow
  * @providesModule ${hasteFinalName}
- */${bundleType === FB_DEV ? fbDevCode : ''}
+ */
 `;
 }
 

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -1,27 +1,27 @@
 {
   "bundleSizes": {
     "react.development.js (UMD_DEV)": {
-      "size": 71599,
-      "gzip": 18503
+      "size": 71605,
+      "gzip": 18506
     },
     "react.production.min.js (UMD_PROD)": {
       "size": 7585,
       "gzip": 2999
     },
     "react.development.js (NODE_DEV)": {
-      "size": 61813,
-      "gzip": 16088
+      "size": 61884,
+      "gzip": 16131
     },
     "react.production.min.js (NODE_PROD)": {
       "size": 6483,
       "gzip": 2581
     },
     "React-dev.js (FB_DEV)": {
-      "size": 61047,
-      "gzip": 15811
+      "size": 61056,
+      "gzip": 15809
     },
     "React-prod.js (FB_PROD)": {
-      "size": 29022,
+      "size": 29031,
       "gzip": 7690
     },
     "react-dom.development.js (UMD_DEV)": {


### PR DESCRIPTION
This should help with weak dead code elimination systems that can't DCE `require`s.
I have not tested this yet, would appreciate help.