### PR TITLE
Remove duplication in DOM Fiber Component per TODO

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -127,8 +127,6 @@ function trapBubbledEventsLocal(node: Element, tag: string) {
   // the state of the tree to be corrupted, `node` here can be null.
 
   // TODO: Make sure that we check isMounted before firing any of these events.
-  // TODO: Inline these below since we're calling this from an equivalent
-  // switch statement.
   switch (tag) {
     case 'iframe':
     case 'object':
@@ -388,6 +386,7 @@ var ReactDOMFiberComponent = {
       }
     }
 
+    trapBubbledEventsLocal(domElement, tag);
     var props: Object;
     switch (tag) {
       case 'audio':
@@ -400,13 +399,11 @@ var ReactDOMFiberComponent = {
       case 'source':
       case 'video':
       case 'details':
-        trapBubbledEventsLocal(domElement, tag);
         props = rawProps;
         break;
       case 'input':
         ReactDOMFiberInput.initWrapperState(domElement, rawProps);
         props = ReactDOMFiberInput.getHostProps(domElement, rawProps);
-        trapBubbledEventsLocal(domElement, tag);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
@@ -418,7 +415,6 @@ var ReactDOMFiberComponent = {
       case 'select':
         ReactDOMFiberSelect.initWrapperState(domElement, rawProps);
         props = ReactDOMFiberSelect.getHostProps(domElement, rawProps);
-        trapBubbledEventsLocal(domElement, tag);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
@@ -426,7 +422,6 @@ var ReactDOMFiberComponent = {
       case 'textarea':
         ReactDOMFiberTextarea.initWrapperState(domElement, rawProps);
         props = ReactDOMFiberTextarea.getHostProps(domElement, rawProps);
-        trapBubbledEventsLocal(domElement, tag);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
@@ -725,6 +720,7 @@ var ReactDOMFiberComponent = {
       }
     }
 
+    trapBubbledEventsLocal(domElement, tag);
     switch (tag) {
       case 'audio':
       case 'form':
@@ -736,11 +732,9 @@ var ReactDOMFiberComponent = {
       case 'source':
       case 'video':
       case 'details':
-        trapBubbledEventsLocal(domElement, tag);
         break;
       case 'input':
         ReactDOMFiberInput.initWrapperState(domElement, rawProps);
-        trapBubbledEventsLocal(domElement, tag);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
@@ -750,14 +744,12 @@ var ReactDOMFiberComponent = {
         break;
       case 'select':
         ReactDOMFiberSelect.initWrapperState(domElement, rawProps);
-        trapBubbledEventsLocal(domElement, tag);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');
         break;
       case 'textarea':
         ReactDOMFiberTextarea.initWrapperState(domElement, rawProps);
-        trapBubbledEventsLocal(domElement, tag);
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
         ensureListeningTo(rootContainerElement, 'onChange');


### PR DESCRIPTION
This is likely a better approach to the issue I was trying to help with in #9924

This PR removes the duplicated calls to `trapBubbledEventsLocal` across a tag case statement
