### PR TITLE
Split out container methods in host config

### DIFF
--- a/src/renderers/art/ReactARTFiberEntry.js
+++ b/src/renderers/art/ReactARTFiberEntry.js
@@ -394,7 +394,13 @@ const ARTRenderer = ReactFiberReconciler({
     if (child.parentNode === parentInstance) {
       child.eject();
     }
+    child.inject(parentInstance);
+  },
 
+  appendChildToContainer(parentInstance, child) {
+    if (child.parentNode === parentInstance) {
+      child.eject();
+    }
     child.inject(parentInstance);
   },
 
@@ -471,7 +477,14 @@ const ARTRenderer = ReactFiberReconciler({
       child !== beforeChild,
       'ReactART: Can not insert node before itself',
     );
+    child.injectBefore(beforeChild);
+  },
 
+  insertInContainerBefore(parentInstance, child, beforeChild) {
+    invariant(
+      child !== beforeChild,
+      'ReactART: Can not insert node before itself',
+    );
     child.injectBefore(beforeChild);
   },
 
@@ -485,7 +498,11 @@ const ARTRenderer = ReactFiberReconciler({
 
   removeChild(parentInstance, child) {
     destroyEventListeners(child);
+    child.eject();
+  },
 
+  removeChildFromContainer(parentInstance, child) {
+    destroyEventListeners(child);
     child.eject();
   },
 

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -346,26 +346,42 @@ var DOMRenderer = ReactFiberReconciler({
     textInstance.nodeValue = newText;
   },
 
-  appendChild(
-    parentInstance: Instance | Container,
-    child: Instance | TextInstance,
-  ): void {
+  appendChild(parentInstance: Instance, child: Instance | TextInstance): void {
     parentInstance.appendChild(child);
   },
 
+  appendChildToContainer(
+    container: Container,
+    child: Instance | TextInstance,
+  ): void {
+    container.appendChild(child);
+  },
+
   insertBefore(
-    parentInstance: Instance | Container,
+    parentInstance: Instance,
     child: Instance | TextInstance,
     beforeChild: Instance | TextInstance,
   ): void {
     parentInstance.insertBefore(child, beforeChild);
   },
 
-  removeChild(
-    parentInstance: Instance | Container,
+  insertInContainerBefore(
+    container: Container,
+    child: Instance | TextInstance,
+    beforeChild: Instance | TextInstance,
+  ): void {
+    container.insertBefore(child, beforeChild);
+  },
+
+  removeChild(parentInstance: Instance, child: Instance | TextInstance): void {
+    parentInstance.removeChild(child);
+  },
+
+  removeChildFromContainer(
+    container: Container,
     child: Instance | TextInstance,
   ): void {
-    parentInstance.removeChild(child);
+    container.removeChild(child);
   },
 
   canHydrateInstance(

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -47,6 +47,44 @@ var instanceCounter = 0;
 
 var failInBeginPhase = false;
 
+function appendChild(
+  parentInstance: Instance | Container,
+  child: Instance | TextInstance,
+): void {
+  const index = parentInstance.children.indexOf(child);
+  if (index !== -1) {
+    parentInstance.children.splice(index, 1);
+  }
+  parentInstance.children.push(child);
+}
+
+function insertBefore(
+  parentInstance: Instance | Container,
+  child: Instance | TextInstance,
+  beforeChild: Instance | TextInstance,
+): void {
+  const index = parentInstance.children.indexOf(child);
+  if (index !== -1) {
+    parentInstance.children.splice(index, 1);
+  }
+  const beforeIndex = parentInstance.children.indexOf(beforeChild);
+  if (beforeIndex === -1) {
+    throw new Error('This child does not exist.');
+  }
+  parentInstance.children.splice(beforeIndex, 0, child);
+}
+
+function removeChild(
+  parentInstance: Instance | Container,
+  child: Instance | TextInstance,
+): void {
+  const index = parentInstance.children.indexOf(child);
+  if (index === -1) {
+    throw new Error('This child does not exist.');
+  }
+  parentInstance.children.splice(index, 1);
+}
+
 var NoopRenderer = ReactFiberReconciler({
   getRootHostContext() {
     if (failInBeginPhase) {
@@ -145,43 +183,12 @@ var NoopRenderer = ReactFiberReconciler({
     textInstance.text = newText;
   },
 
-  appendChild(
-    parentInstance: Instance | Container,
-    child: Instance | TextInstance,
-  ): void {
-    const index = parentInstance.children.indexOf(child);
-    if (index !== -1) {
-      parentInstance.children.splice(index, 1);
-    }
-    parentInstance.children.push(child);
-  },
-
-  insertBefore(
-    parentInstance: Instance | Container,
-    child: Instance | TextInstance,
-    beforeChild: Instance | TextInstance,
-  ): void {
-    const index = parentInstance.children.indexOf(child);
-    if (index !== -1) {
-      parentInstance.children.splice(index, 1);
-    }
-    const beforeIndex = parentInstance.children.indexOf(beforeChild);
-    if (beforeIndex === -1) {
-      throw new Error('This child does not exist.');
-    }
-    parentInstance.children.splice(beforeIndex, 0, child);
-  },
-
-  removeChild(
-    parentInstance: Instance | Container,
-    child: Instance | TextInstance,
-  ): void {
-    const index = parentInstance.children.indexOf(child);
-    if (index === -1) {
-      throw new Error('This child does not exist.');
-    }
-    parentInstance.children.splice(index, 1);
-  },
+  appendChild: appendChild,
+  appendChildToContainer: appendChild,
+  insertBefore: insertBefore,
+  insertInContainerBefore: insertBefore,
+  removeChild: removeChild,
+  removeChildFromContainer: removeChild,
 
   scheduleAnimationCallback(callback) {
     if (scheduledAnimationCallback) {

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -103,9 +103,16 @@ export type HostConfig<T, P, I, TI, PI, C, CX, PL> = {
   ): TI,
   commitTextUpdate(textInstance: TI, oldText: string, newText: string): void,
 
-  appendChild(parentInstance: I | C, child: I | TI): void,
-  insertBefore(parentInstance: I | C, child: I | TI, beforeChild: I | TI): void,
-  removeChild(parentInstance: I | C, child: I | TI): void,
+  appendChild(parentInstance: I, child: I | TI): void,
+  appendChildToContainer(container: C, child: I | TI): void,
+  insertBefore(parentInstance: I, child: I | TI, beforeChild: I | TI): void,
+  insertInContainerBefore(
+    container: C,
+    child: I | TI,
+    beforeChild: I | TI,
+  ): void,
+  removeChild(parentInstance: I, child: I | TI): void,
+  removeChildFromContainer(container: C, child: I | TI): void,
 
   scheduleAnimationCallback(callback: () => void): number | void,
   scheduleDeferredCallback(
@@ -119,7 +126,7 @@ export type HostConfig<T, P, I, TI, PI, C, CX, PL> = {
   canHydrateInstance?: (instance: I | TI, type: T, props: P) => boolean,
   canHydrateTextInstance?: (instance: I | TI) => boolean,
   getNextHydratableSibling?: (instance: I | TI) => null | I | TI,
-  getFirstHydratableChild?: (parentInstance: C | I) => null | I | TI,
+  getFirstHydratableChild?: (parentInstance: I | C) => null | I | TI,
   hydrateInstance?: (
     instance: I,
     type: T,

--- a/src/renderers/shared/fiber/__tests__/ReactFiberHostContext-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactFiberHostContext-test.js
@@ -45,7 +45,7 @@ describe('ReactFiberHostContext', () => {
       appendInitialChild: function() {
         return null;
       },
-      appendChild: function() {
+      appendChildToContainer: function() {
         return null;
       },
       useSyncScheduling: true,

--- a/src/renderers/testing/ReactTestRendererFiberEntry.js
+++ b/src/renderers/testing/ReactTestRendererFiberEntry.js
@@ -63,6 +63,38 @@ type TextInstance = {|
 
 const UPDATE_SIGNAL = {};
 
+function appendChild(
+  parentInstance: Instance | Container,
+  child: Instance | TextInstance,
+): void {
+  const index = parentInstance.children.indexOf(child);
+  if (index !== -1) {
+    parentInstance.children.splice(index, 1);
+  }
+  parentInstance.children.push(child);
+}
+
+function insertBefore(
+  parentInstance: Instance | Container,
+  child: Instance | TextInstance,
+  beforeChild: Instance | TextInstance,
+): void {
+  const index = parentInstance.children.indexOf(child);
+  if (index !== -1) {
+    parentInstance.children.splice(index, 1);
+  }
+  const beforeIndex = parentInstance.children.indexOf(beforeChild);
+  parentInstance.children.splice(beforeIndex, 0, child);
+}
+
+function removeChild(
+  parentInstance: Instance | Container,
+  child: Instance | TextInstance,
+): void {
+  const index = parentInstance.children.indexOf(child);
+  parentInstance.children.splice(index, 1);
+}
+
 var TestRenderer = ReactFiberReconciler({
   getRootHostContext() {
     return emptyObject;
@@ -180,37 +212,12 @@ var TestRenderer = ReactFiberReconciler({
     textInstance.text = newText;
   },
 
-  appendChild(
-    parentInstance: Instance | Container,
-    child: Instance | TextInstance,
-  ): void {
-    const index = parentInstance.children.indexOf(child);
-    if (index !== -1) {
-      parentInstance.children.splice(index, 1);
-    }
-    parentInstance.children.push(child);
-  },
-
-  insertBefore(
-    parentInstance: Instance | Container,
-    child: Instance | TextInstance,
-    beforeChild: Instance | TextInstance,
-  ): void {
-    const index = parentInstance.children.indexOf(child);
-    if (index !== -1) {
-      parentInstance.children.splice(index, 1);
-    }
-    const beforeIndex = parentInstance.children.indexOf(beforeChild);
-    parentInstance.children.splice(beforeIndex, 0, child);
-  },
-
-  removeChild(
-    parentInstance: Instance | Container,
-    child: Instance | TextInstance,
-  ): void {
-    const index = parentInstance.children.indexOf(child);
-    parentInstance.children.splice(index, 1);
-  },
+  appendChild: appendChild,
+  appendChildToContainer: appendChild,
+  insertBefore: insertBefore,
+  insertInContainerBefore: insertBefore,
+  removeChild: removeChild,
+  removeChildFromContainer: removeChild,
 
   scheduleAnimationCallback(fn: Function): void {
     setTimeout(fn);


### PR DESCRIPTION
This makes it so you don't need to pattern-match manually to build a renderer where the container and instance types are not the same. Prerequisite to #9835.