### PR TITLE
Update tutorial to match class component docs

### DIFF
--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -216,7 +216,7 @@ class Square extends React.Component {
 }
 ```
 
-In [JavaScript classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes), you need to explicitly call `super();` when defining the constructor of a subclass. When creating a class component in React, you should always call the base constructor with `props`.
+In [JavaScript classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes), you need to explicitly call `super();` when defining the constructor of a subclass. When extending a class component in React, always call the base constructor with `props`.
 
 Now change the Square `render` method to display the value from the current state, and to toggle it on click:
 

--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -199,8 +199,8 @@ First, add a constructor to the class to initialize the state:
 
 ```javascript{2-7}
 class Square extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       value: null,
     };
@@ -216,7 +216,7 @@ class Square extends React.Component {
 }
 ```
 
-In [JavaScript classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes), you need to explicitly call `super();` when defining the constructor of a subclass.
+In [JavaScript classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes), you need to explicitly call `super();` when defining the constructor of a subclass. When creating a class component in React, you should always call the base constructor with `props`.
 
 Now change the Square `render` method to display the value from the current state, and to toggle it on click:
 
@@ -227,8 +227,8 @@ Now the `<button>` tag looks like this:
 
 ```javascript{10-12}
 class Square extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       value: null,
     };
@@ -281,8 +281,8 @@ Pulling state upwards like this is common when refactoring React components, so 
 
 ```javascript{2-7}
 class Board extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       squares: Array(9).fill(null),
     };
@@ -398,8 +398,8 @@ Try clicking a square – you should get an error because we haven't defined `ha
 
 ```javascript{9-13}
 class Board extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       squares: Array(9).fill(null),
     };
@@ -527,8 +527,8 @@ Let's default the first move to be by 'X'. Modify our starting state in our Boar
 
 ```javascript{6}
 class Board extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       squares: Array(9).fill(null),
       xIsNext: true,
@@ -563,8 +563,8 @@ After these changes you should have this Board component:
 
 ```javascript{6,11-16,29}
 class Board extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       squares: Array(9).fill(null),
       xIsNext: true,
@@ -714,8 +714,8 @@ First, set up the initial state for Game by adding a constructor to it:
 
 ```javascript{2-10}
 class Game extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       history: [{
         squares: Array(9).fill(null),
@@ -1005,8 +1005,8 @@ First, add `stepNumber: 0` to the initial state in Game's `constructor`:
 
 ```js{8}
 class Game extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       history: [{
         squares: Array(9).fill(null),


### PR DESCRIPTION
[According to the docs](https://facebook.github.io/react/docs/state-and-lifecycle.html#adding-local-state-to-a-class), class components should always call the base constructor with props. Update the tutorial to reflect this.