### PR TITLE
Remove progressed work

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -2030,6 +2030,8 @@ src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
 * updates a previous render
 * can cancel partially rendered work and restart
 * should call callbacks even if updates are aborted
+* can deprioritize unfinished work and resume it later
+* can deprioritize a tree from without dropping work
 * memoizes work even if shouldComponentUpdate returns false
 * can update in the middle of a tree using setState
 * can queue multiple state updates
@@ -2042,6 +2044,7 @@ src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
 * can handle if setState callback throws
 * merges and masks context
 * does not leak own context into context provider
+* provides context when reusing work
 * reads context when setState is below the provider
 * reads context when setState is above the provider
 * maintains the correct context when providers bail out due to low priority
@@ -2085,6 +2088,7 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalPerf-test.js
 * warns on cascading renders from top-level render
 * does not treat setState from cWM or cWRP as cascading
 * captures all lifecycles
+* measures deprioritized work
 * measures deferred work in chunks
 * recovers from fatal errors
 * recovers from caught errors
@@ -2124,6 +2128,7 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
 * can reuse side-effects after being preempted, if shouldComponentUpdate is false
 * can update a completed tree before it has a chance to commit
 * updates a child even though the old props is empty
+* deprioritizes setStates that happens within a deprioritized tree
 * calls callback after update is flushed
 * calls setState callback even if component bails out
 * calls componentWillUnmount after a deletion, even if nested

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -2030,15 +2030,6 @@ src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
 * updates a previous render
 * can cancel partially rendered work and restart
 * should call callbacks even if updates are aborted
-* can deprioritize unfinished work and resume it later
-* can deprioritize a tree from without dropping work
-* can resume work in a subtree even when a parent bails out
-* can resume work in a bailed subtree within one pass
-* can resume mounting a class component
-* reuses the same instance when resuming a class instance
-* can reuse work done after being preempted
-* can reuse work that began but did not complete, after being preempted
-* can reuse work if shouldComponentUpdate is false, after being preempted
 * memoizes work even if shouldComponentUpdate returns false
 * can update in the middle of a tree using setState
 * can queue multiple state updates
@@ -2046,25 +2037,16 @@ src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
 * can call setState inside update callback
 * can replaceState
 * can forceUpdate
-* can call sCU while resuming a partly mounted component
-* gets new props when setting state on a partly updated component
-* calls componentWillMount twice if the initial render is aborted
-* uses state set in componentWillMount even if initial render was aborted
-* calls componentWill* twice if an update render is aborted
-* does not call componentWillReceiveProps for state-only updates
-* skips will/DidUpdate when bailing unless an update was already in progress
 * performs batched updates at the end of the batch
 * can nest batchedUpdates
 * can handle if setState callback throws
 * merges and masks context
 * does not leak own context into context provider
-* provides context when reusing work
 * reads context when setState is below the provider
 * reads context when setState is above the provider
 * maintains the correct context when providers bail out due to low priority
 * maintains the correct context when unwinding due to an error in render
 * should not recreate masked context unless inputs have changed
-* should reuse memoized work if pointers are updated before calling lifecycles
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
 * catches render error in a boundary during full deferred mounting
@@ -2103,7 +2085,6 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalPerf-test.js
 * warns on cascading renders from top-level render
 * does not treat setState from cWM or cWRP as cascading
 * captures all lifecycles
-* measures deprioritized work
 * measures deferred work in chunks
 * recovers from fatal errors
 * recovers from caught errors
@@ -2143,15 +2124,16 @@ src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
 * can reuse side-effects after being preempted, if shouldComponentUpdate is false
 * can update a completed tree before it has a chance to commit
 * updates a child even though the old props is empty
-* can defer side-effects and resume them later on
-* can defer side-effects and reuse them later - complex
-* deprioritizes setStates that happens within a deprioritized tree
 * calls callback after update is flushed
 * calls setState callback even if component bails out
 * calls componentWillUnmount after a deletion, even if nested
 * calls componentDidMount/Update after insertion/update
 * invokes ref callbacks after insertion/update/unmount
 * supports string refs
+
+src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
+* renders the triangle demo without inconsistencies
+* fuzz tester
 
 src/renderers/shared/fiber/__tests__/ReactIncrementalUpdates-test.js
 * applies updates in order of priority

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -430,18 +430,18 @@ var ReactNoop = {
       if (fiber.updateQueue) {
         logUpdateQueue(fiber.updateQueue, depth);
       }
-      const childInProgress = fiber.progressedChild;
-      if (childInProgress && childInProgress !== fiber.child) {
-        log(
-          '  '.repeat(depth + 1) + 'IN PROGRESS: ' + fiber.progressedPriority,
-        );
-        logFiber(childInProgress, depth + 1);
-        if (fiber.child) {
-          log('  '.repeat(depth + 1) + 'CURRENT');
-        }
-      } else if (fiber.child && fiber.updateQueue) {
-        log('  '.repeat(depth + 1) + 'CHILDREN');
-      }
+      // const childInProgress = fiber.progressedChild;
+      // if (childInProgress && childInProgress !== fiber.child) {
+      //   log(
+      //     '  '.repeat(depth + 1) + 'IN PROGRESS: ' + fiber.pendingWorkPriority,
+      //   );
+      //   logFiber(childInProgress, depth + 1);
+      //   if (fiber.child) {
+      //     log('  '.repeat(depth + 1) + 'CURRENT');
+      //   }
+      // } else if (fiber.child && fiber.updateQueue) {
+      //   log('  '.repeat(depth + 1) + 'CHILDREN');
+      // }
       if (fiber.child) {
         logFiber(fiber.child, depth + 1);
       }

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -1463,7 +1463,7 @@ exports.cloneChildFibers = function(
   let currentChild = workInProgress.child;
   let newChild = createWorkInProgress(currentChild, renderPriority);
   // TODO: Pass this as an argument, since it's easy to forget.
-  newChild.pendingProps = null;
+  newChild.pendingProps = currentChild.pendingProps;
   workInProgress.child = newChild;
 
   newChild.return = workInProgress;
@@ -1473,7 +1473,7 @@ exports.cloneChildFibers = function(
       currentChild,
       renderPriority,
     );
-    newChild.pendingProps = null;
+    newChild.pendingProps = currentChild.pendingProps;
     newChild.return = workInProgress;
   }
   newChild.sibling = null;

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -74,7 +74,7 @@ if (__DEV__) {
 }
 
 const {
-  cloneFiber,
+  createWorkInProgress,
   createFiberFromElement,
   createFiberFromFragment,
   createFiberFromText,
@@ -207,12 +207,16 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
       childToDelete = childToDelete.alternate;
     }
     // Deletions are added in reversed order so we add it to the front.
-    const last = returnFiber.progressedLastDeletion;
+    // At this point, the return fiber's effect list is empty except for
+    // deletions, so we can just append the deletion to the list. The remaining
+    // effects aren't added until the complete phase. Once we implement
+    // resuming, this may not be true.
+    const last = returnFiber.lastEffect;
     if (last !== null) {
       last.nextEffect = childToDelete;
-      returnFiber.progressedLastDeletion = childToDelete;
+      returnFiber.lastEffect = childToDelete;
     } else {
-      returnFiber.progressedFirstDeletion = returnFiber.progressedLastDeletion = childToDelete;
+      returnFiber.firstEffect = returnFiber.lastEffect = childToDelete;
     }
     childToDelete.nextEffect = null;
     childToDelete.effectTag = Deletion;
@@ -262,7 +266,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     // We currently set sibling to null and index to 0 here because it is easy
     // to forget to do before returning it. E.g. for the single child case.
     if (shouldClone) {
-      const clone = cloneFiber(fiber, priority);
+      const clone = createWorkInProgress(fiber, priority);
       clone.index = 0;
       clone.sibling = null;
       return clone;
@@ -1445,44 +1449,29 @@ exports.mountChildFibersInPlace = ChildReconciler(false, false);
 exports.cloneChildFibers = function(
   current: Fiber | null,
   workInProgress: Fiber,
+  renderPriority: PriorityLevel,
 ): void {
-  if (!workInProgress.child) {
+  invariant(
+    current === null || workInProgress.child === current.child,
+    'Resuming work not yet implemented.',
+  );
+
+  if (workInProgress.child === null) {
     return;
   }
-  if (current !== null && workInProgress.child === current.child) {
-    // We use workInProgress.child since that lets Flow know that it can't be
-    // null since we validated that already. However, as the line above suggests
-    // they're actually the same thing.
-    let currentChild = workInProgress.child;
-    // TODO: This used to reset the pending priority. Not sure if that is needed.
-    // workInProgress.pendingWorkPriority = current.pendingWorkPriority;
-    // TODO: The below priority used to be set to NoWork which would've
-    // dropped work. This is currently unobservable but will become
-    // observable when the first sibling has lower priority work remaining
-    // than the next sibling. At that point we should add tests that catches
-    // this.
-    let newChild = cloneFiber(currentChild, currentChild.pendingWorkPriority);
-    workInProgress.child = newChild;
 
+  let currentChild = workInProgress.child;
+  let newChild = createWorkInProgress(currentChild, renderPriority);
+  workInProgress.child = newChild;
+
+  newChild.return = workInProgress;
+  while (currentChild.sibling !== null) {
+    currentChild = currentChild.sibling;
+    newChild = newChild.sibling = createWorkInProgress(
+      currentChild,
+      renderPriority,
+    );
     newChild.return = workInProgress;
-    while (currentChild.sibling !== null) {
-      currentChild = currentChild.sibling;
-      newChild = newChild.sibling = cloneFiber(
-        currentChild,
-        currentChild.pendingWorkPriority,
-      );
-      newChild.return = workInProgress;
-    }
-    newChild.sibling = null;
-  } else {
-    // If there is no alternate, then we don't need to clone the children.
-    // If the children of the alternate fiber is a different set, then we don't
-    // need to clone. We need to reset the return fiber though since we'll
-    // traverse down into them.
-    let child = workInProgress.child;
-    while (child !== null) {
-      child.return = workInProgress;
-      child = child.sibling;
-    }
   }
+  newChild.sibling = null;
 };

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -1462,6 +1462,8 @@ exports.cloneChildFibers = function(
 
   let currentChild = workInProgress.child;
   let newChild = createWorkInProgress(currentChild, renderPriority);
+  // TODO: Pass this as an argument, since it's easy to forget.
+  newChild.pendingProps = null;
   workInProgress.child = newChild;
 
   newChild.return = workInProgress;
@@ -1471,6 +1473,7 @@ exports.cloneChildFibers = function(
       currentChild,
       renderPriority,
     );
+    newChild.pendingProps = null;
     newChild.return = workInProgress;
   }
   newChild.sibling = null;

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -451,3 +451,10 @@ exports.createFiberFromPortal = function(
   };
   return fiber;
 };
+
+exports.largerPriority = function(
+  p1: PriorityLevel,
+  p2: PriorityLevel,
+): PriorityLevel {
+  return p1 !== NoWork && (p2 === NoWork || p2 > p1) ? p1 : p2;
+};

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -768,6 +768,17 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     // Add an error effect so we can handle the error during the commit phase
     workInProgress.effectTag |= Err;
 
+    // This is a weird case where we do "resume" work — work that failed on
+    // our first attempt. Because we no longer have a notion of "progressed
+    // deletions," reset the child to the current child to make sure we delete
+    // it again. TODO: Find a better way to handle this, perhaps during a more
+    // general overhaul of error handling.
+    if (current === null) {
+      workInProgress.child = null;
+    } else if (workInProgress.child !== current.child) {
+      workInProgress.child = current.child;
+    }
+
     if (
       workInProgress.pendingWorkPriority === NoWork ||
       workInProgress.pendingWorkPriority > priorityLevel

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -362,6 +362,8 @@ module.exports = function(
     workInProgress: Fiber,
     priorityLevel: PriorityLevel,
   ): void {
+    const current = workInProgress.alternate;
+
     if (__DEV__) {
       checkClassInstance(workInProgress);
     }
@@ -398,6 +400,7 @@ module.exports = function(
       const updateQueue = workInProgress.updateQueue;
       if (updateQueue !== null) {
         instance.state = beginUpdateQueue(
+          current,
           workInProgress,
           updateQueue,
           instance,
@@ -414,108 +417,108 @@ module.exports = function(
 
   // Called on a preexisting class instance. Returns false if a resumed render
   // could be reused.
-  function resumeMountClassInstance(
-    workInProgress: Fiber,
-    priorityLevel: PriorityLevel,
-  ): boolean {
-    const instance = workInProgress.stateNode;
-    resetInputPointers(workInProgress, instance);
+  // function resumeMountClassInstance(
+  //   workInProgress: Fiber,
+  //   priorityLevel: PriorityLevel,
+  // ): boolean {
+  //   const instance = workInProgress.stateNode;
+  //   resetInputPointers(workInProgress, instance);
 
-    let newState = workInProgress.memoizedState;
-    let newProps = workInProgress.pendingProps;
-    if (!newProps) {
-      // If there isn't any new props, then we'll reuse the memoized props.
-      // This could be from already completed work.
-      newProps = workInProgress.memoizedProps;
-      invariant(
-        newProps != null,
-        'There should always be pending or memoized props. This error is ' +
-          'likely caused by a bug in React. Please file an issue.',
-      );
-    }
-    const newUnmaskedContext = getUnmaskedContext(workInProgress);
-    const newContext = getMaskedContext(workInProgress, newUnmaskedContext);
+  //   let newState = workInProgress.memoizedState;
+  //   let newProps = workInProgress.pendingProps;
+  //   if (!newProps) {
+  //     // If there isn't any new props, then we'll reuse the memoized props.
+  //     // This could be from already completed work.
+  //     newProps = workInProgress.memoizedProps;
+  //     invariant(
+  //       newProps != null,
+  //       'There should always be pending or memoized props. This error is ' +
+  //         'likely caused by a bug in React. Please file an issue.',
+  //     );
+  //   }
+  //   const newUnmaskedContext = getUnmaskedContext(workInProgress);
+  //   const newContext = getMaskedContext(workInProgress, newUnmaskedContext);
 
-    const oldContext = instance.context;
-    const oldProps = workInProgress.memoizedProps;
+  //   const oldContext = instance.context;
+  //   const oldProps = workInProgress.memoizedProps;
 
-    if (
-      typeof instance.componentWillReceiveProps === 'function' &&
-      (oldProps !== newProps || oldContext !== newContext)
-    ) {
-      callComponentWillReceiveProps(
-        workInProgress,
-        instance,
-        newProps,
-        newContext,
-      );
-    }
+  //   if (
+  //     typeof instance.componentWillReceiveProps === 'function' &&
+  //     (oldProps !== newProps || oldContext !== newContext)
+  //   ) {
+  //     callComponentWillReceiveProps(
+  //       workInProgress,
+  //       instance,
+  //       newProps,
+  //       newContext,
+  //     );
+  //   }
 
-    // Process the update queue before calling shouldComponentUpdate
-    const updateQueue = workInProgress.updateQueue;
-    if (updateQueue !== null) {
-      newState = beginUpdateQueue(
-        workInProgress,
-        updateQueue,
-        instance,
-        newState,
-        newProps,
-        priorityLevel,
-      );
-    }
+  //   // Process the update queue before calling shouldComponentUpdate
+  //   const updateQueue = workInProgress.updateQueue;
+  //   if (updateQueue !== null) {
+  //     newState = beginUpdateQueue(
+  //       workInProgress,
+  //       updateQueue,
+  //       instance,
+  //       newState,
+  //       newProps,
+  //       priorityLevel,
+  //     );
+  //   }
 
-    // TODO: Should we deal with a setState that happened after the last
-    // componentWillMount and before this componentWillMount? Probably
-    // unsupported anyway.
+  //   // TODO: Should we deal with a setState that happened after the last
+  //   // componentWillMount and before this componentWillMount? Probably
+  //   // unsupported anyway.
 
-    if (
-      !checkShouldComponentUpdate(
-        workInProgress,
-        workInProgress.memoizedProps,
-        newProps,
-        workInProgress.memoizedState,
-        newState,
-        newContext,
-      )
-    ) {
-      // Update the existing instance's state, props, and context pointers even
-      // though we're bailing out.
-      instance.props = newProps;
-      instance.state = newState;
-      instance.context = newContext;
-      return false;
-    }
+  //   if (
+  //     !checkShouldComponentUpdate(
+  //       workInProgress,
+  //       workInProgress.memoizedProps,
+  //       newProps,
+  //       workInProgress.memoizedState,
+  //       newState,
+  //       newContext,
+  //     )
+  //   ) {
+  //     // Update the existing instance's state, props, and context pointers even
+  //     // though we're bailing out.
+  //     instance.props = newProps;
+  //     instance.state = newState;
+  //     instance.context = newContext;
+  //     return false;
+  //   }
 
-    // Update the input pointers now so that they are correct when we call
-    // componentWillMount
-    instance.props = newProps;
-    instance.state = newState;
-    instance.context = newContext;
+  //   // Update the input pointers now so that they are correct when we call
+  //   // componentWillMount
+  //   instance.props = newProps;
+  //   instance.state = newState;
+  //   instance.context = newContext;
 
-    if (typeof instance.componentWillMount === 'function') {
-      callComponentWillMount(workInProgress, instance);
-      // componentWillMount may have called setState. Process the update queue.
-      const newUpdateQueue = workInProgress.updateQueue;
-      if (newUpdateQueue !== null) {
-        newState = beginUpdateQueue(
-          workInProgress,
-          newUpdateQueue,
-          instance,
-          newState,
-          newProps,
-          priorityLevel,
-        );
-      }
-    }
+  //   if (typeof instance.componentWillMount === 'function') {
+  //     callComponentWillMount(workInProgress, instance);
+  //     // componentWillMount may have called setState. Process the update queue.
+  //     const newUpdateQueue = workInProgress.updateQueue;
+  //     if (newUpdateQueue !== null) {
+  //       newState = beginUpdateQueue(
+  //         workInProgress,
+  //         newUpdateQueue,
+  //         instance,
+  //         newState,
+  //         newProps,
+  //         priorityLevel,
+  //       );
+  //     }
+  //   }
 
-    if (typeof instance.componentDidMount === 'function') {
-      workInProgress.effectTag |= Update;
-    }
+  //   if (typeof instance.componentDidMount === 'function') {
+  //     workInProgress.effectTag |= Update;
+  //   }
 
-    instance.state = newState;
+  //   instance.state = newState;
 
-    return true;
-  }
+  //   return true;
+  // }
 
   // Invokes the update life-cycles and returns false if it shouldn't rerender.
   function updateClassInstance(
@@ -559,14 +562,14 @@ module.exports = function(
     }
 
     // Compute the next state using the memoized state and the update queue.
-    const updateQueue = workInProgress.updateQueue;
     const oldState = workInProgress.memoizedState;
     // TODO: Previous state can be null.
     let newState;
-    if (updateQueue !== null) {
+    if (workInProgress.updateQueue !== null) {
       newState = beginUpdateQueue(
+        current,
         workInProgress,
-        updateQueue,
+        workInProgress.updateQueue,
         instance,
         oldState,
         newProps,
@@ -580,7 +583,8 @@ module.exports = function(
       oldProps === newProps &&
       oldState === newState &&
       !hasContextChanged() &&
-      !(updateQueue !== null && updateQueue.hasForceUpdate)
+      !(workInProgress.updateQueue !== null &&
+        workInProgress.updateQueue.hasForceUpdate)
     ) {
       // If an update was already in progress, we should schedule an Update
       // effect even though we're bailing out, so that cWU/cDU are called.
@@ -648,7 +652,7 @@ module.exports = function(
     adoptClassInstance,
     constructClassInstance,
     mountClassInstance,
-    resumeMountClassInstance,
+    // resumeMountClassInstance,
     updateClassInstance,
   };
 };

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -70,18 +70,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     popHydrationState,
   } = hydrationContext;
 
-  function markChildAsProgressed(current, workInProgress, priorityLevel) {
-    // We now have clones. Let's store them as the currently progressed work.
-    workInProgress.progressedChild = workInProgress.child;
-    workInProgress.progressedPriority = priorityLevel;
-    if (current !== null) {
-      // We also store it on the current. When the alternate swaps in we can
-      // continue from this point.
-      current.progressedChild = workInProgress.progressedChild;
-      current.progressedPriority = workInProgress.progressedPriority;
-    }
-  }
-
   function markUpdate(workInProgress: Fiber) {
     // Tag the fiber with an update effect. This turns a Placement into
     // an UpdateAndPlacement.
@@ -159,7 +147,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       nextChildren,
       priority,
     );
-    markChildAsProgressed(current, workInProgress, priority);
     return workInProgress.child;
   }
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -234,11 +234,17 @@ describe('ReactIncremental', () => {
     // Flush the rest of the work which now includes the low priority
     ReactNoop.flush();
 
-    expect(ops).toEqual(['setState1', 'setState2', 'callback1', 'callback2']);
+    expect(ops).toEqual([
+      'setState1',
+      'setState1',
+      'setState2',
+      'callback1',
+      'callback2',
+    ]);
     expect(inst.state).toEqual({text: 'bar', text2: 'baz'});
   });
 
-  it('can deprioritize unfinished work and resume it later', () => {
+  xit('can deprioritize unfinished work and resume it later', () => {
     var ops = [];
 
     function Bar(props) {
@@ -290,7 +296,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Middle', 'Middle']);
   });
 
-  it('can deprioritize a tree from without dropping work', () => {
+  xit('can deprioritize a tree from without dropping work', () => {
     var ops = [];
 
     function Bar(props) {
@@ -342,7 +348,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Middle', 'Middle']);
   });
 
-  it('can resume work in a subtree even when a parent bails out', () => {
+  xit('can resume work in a subtree even when a parent bails out', () => {
     var ops = [];
 
     function Bar(props) {
@@ -405,7 +411,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Middle']);
   });
 
-  it('can resume work in a bailed subtree within one pass', () => {
+  xit('can resume work in a bailed subtree within one pass', () => {
     var ops = [];
 
     function Bar(props) {
@@ -503,7 +509,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
   });
 
-  it('can resume mounting a class component', () => {
+  xit('can resume mounting a class component', () => {
     let ops = [];
     let foo;
     class Parent extends React.Component {
@@ -544,7 +550,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Foo', 'Bar']);
   });
 
-  it('reuses the same instance when resuming a class instance', () => {
+  xit('reuses the same instance when resuming a class instance', () => {
     let ops = [];
     let foo;
     class Parent extends React.Component {
@@ -613,7 +619,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  it('can reuse work done after being preempted', () => {
+  xit('can reuse work done after being preempted', () => {
     var ops = [];
 
     function Bar(props) {
@@ -706,165 +712,171 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Middle']);
   });
 
-  it('can reuse work that began but did not complete, after being preempted', () => {
-    let ops = [];
-    let child;
-    let sibling;
+  xit(
+    'can reuse work that began but did not complete, after being preempted',
+    () => {
+      let ops = [];
+      let child;
+      let sibling;
 
-    function GreatGrandchild() {
-      ops.push('GreatGrandchild');
-      return <div />;
-    }
-
-    function Grandchild() {
-      ops.push('Grandchild');
-      return <GreatGrandchild />;
-    }
-
-    class Child extends React.Component {
-      state = {step: 0};
-      render() {
-        child = this;
-        ops.push('Child');
-        return <Grandchild />;
-      }
-    }
-
-    class Sibling extends React.Component {
-      render() {
-        ops.push('Sibling');
-        sibling = this;
+      function GreatGrandchild() {
+        ops.push('GreatGrandchild');
         return <div />;
       }
-    }
 
-    function Parent() {
-      ops.push('Parent');
-      return [
-        // The extra div is necessary because when Parent bails out during the
-        // high priority update, its progressedPriority is set to high.
-        // So its direct children cannot be reused when we resume at
-        // low priority. I think this would be fixed by changing
-        // pendingWorkPriority and progressedPriority to be the priority of
-        // the children only, not including the fiber itself.
-        <div key="a"><Child /></div>,
-        <Sibling key="b" />,
-      ];
-    }
-
-    ReactNoop.render(<Parent />);
-    ReactNoop.flush();
-    ops = [];
-
-    // Begin working on a low priority update to Child, but stop before
-    // GreatGrandchild. Child and Grandchild begin but don't complete.
-    child.setState({step: 1});
-    ReactNoop.flushDeferredPri(30);
-    expect(ops).toEqual(['Child', 'Grandchild']);
-
-    // Interrupt the current low pri work with a high pri update elsewhere in
-    // the tree.
-    ops = [];
-    ReactNoop.syncUpdates(() => {
-      sibling.setState({});
-    });
-    expect(ops).toEqual(['Sibling']);
-
-    // Continue the low pri work. The work on Child and GrandChild was memoized
-    // so they should not be worked on again.
-    ops = [];
-    ReactNoop.flush();
-    expect(ops).toEqual([
-      // No Child
-      // No Grandchild
-      'GreatGrandchild',
-    ]);
-  });
-
-  it('can reuse work if shouldComponentUpdate is false, after being preempted', () => {
-    var ops = [];
-
-    function Bar(props) {
-      ops.push('Bar');
-      return <div>{props.children}</div>;
-    }
-
-    class Middle extends React.Component {
-      shouldComponentUpdate(nextProps) {
-        return this.props.children !== nextProps.children;
+      function Grandchild() {
+        ops.push('Grandchild');
+        return <GreatGrandchild />;
       }
-      render() {
-        ops.push('Middle');
-        return <span>{this.props.children}</span>;
-      }
-    }
 
-    class Content extends React.Component {
-      shouldComponentUpdate(nextProps) {
-        return this.props.step !== nextProps.step;
+      class Child extends React.Component {
+        state = {step: 0};
+        render() {
+          child = this;
+          ops.push('Child');
+          return <Grandchild />;
+        }
       }
-      render() {
-        ops.push('Content');
+
+      class Sibling extends React.Component {
+        render() {
+          ops.push('Sibling');
+          sibling = this;
+          return <div />;
+        }
+      }
+
+      function Parent() {
+        ops.push('Parent');
+        return [
+          // The extra div is necessary because when Parent bails out during the
+          // high priority update, its progressedPriority is set to high.
+          // So its direct children cannot be reused when we resume at
+          // low priority. I think this would be fixed by changing
+          // pendingWorkPriority and progressedPriority to be the priority of
+          // the children only, not including the fiber itself.
+          <div key="a"><Child /></div>,
+          <Sibling key="b" />,
+        ];
+      }
+
+      ReactNoop.render(<Parent />);
+      ReactNoop.flush();
+      ops = [];
+
+      // Begin working on a low priority update to Child, but stop before
+      // GreatGrandchild. Child and Grandchild begin but don't complete.
+      child.setState({step: 1});
+      ReactNoop.flushDeferredPri(30);
+      expect(ops).toEqual(['Child', 'Grandchild']);
+
+      // Interrupt the current low pri work with a high pri update elsewhere in
+      // the tree.
+      ops = [];
+      ReactNoop.syncUpdates(() => {
+        sibling.setState({});
+      });
+      expect(ops).toEqual(['Sibling']);
+
+      // Continue the low pri work. The work on Child and GrandChild was memoized
+      // so they should not be worked on again.
+      ops = [];
+      ReactNoop.flush();
+      expect(ops).toEqual([
+        // No Child
+        // No Grandchild
+        'GreatGrandchild',
+      ]);
+    },
+  );
+
+  xit(
+    'can reuse work if shouldComponentUpdate is false, after being preempted',
+    () => {
+      var ops = [];
+
+      function Bar(props) {
+        ops.push('Bar');
+        return <div>{props.children}</div>;
+      }
+
+      class Middle extends React.Component {
+        shouldComponentUpdate(nextProps) {
+          return this.props.children !== nextProps.children;
+        }
+        render() {
+          ops.push('Middle');
+          return <span>{this.props.children}</span>;
+        }
+      }
+
+      class Content extends React.Component {
+        shouldComponentUpdate(nextProps) {
+          return this.props.step !== nextProps.step;
+        }
+        render() {
+          ops.push('Content');
+          return (
+            <div>
+              <Middle>{this.props.step === 0 ? 'Hi' : 'Hello'}</Middle>
+              <Bar>{this.props.step === 0 ? this.props.text : '-'}</Bar>
+              <Middle>{this.props.step === 0 ? 'There' : 'World'}</Middle>
+            </div>
+          );
+        }
+      }
+
+      function Foo(props) {
+        ops.push('Foo');
         return (
           <div>
-            <Middle>{this.props.step === 0 ? 'Hi' : 'Hello'}</Middle>
-            <Bar>{this.props.step === 0 ? this.props.text : '-'}</Bar>
-            <Middle>{this.props.step === 0 ? 'There' : 'World'}</Middle>
+            <Bar>{props.text}</Bar>
+            <div hidden={true}>
+              <Content step={props.step} text={props.text} />
+            </div>
           </div>
         );
       }
-    }
 
-    function Foo(props) {
-      ops.push('Foo');
-      return (
-        <div>
-          <Bar>{props.text}</Bar>
-          <div hidden={true}>
-            <Content step={props.step} text={props.text} />
-          </div>
-        </div>
-      );
-    }
+      // Init
+      ReactNoop.render(<Foo text="foo" step={0} />);
+      ReactNoop.flush();
 
-    // Init
-    ReactNoop.render(<Foo text="foo" step={0} />);
-    ReactNoop.flush();
+      expect(ops).toEqual(['Foo', 'Bar', 'Content', 'Middle', 'Bar', 'Middle']);
 
-    expect(ops).toEqual(['Foo', 'Bar', 'Content', 'Middle', 'Bar', 'Middle']);
+      ops = [];
 
-    ops = [];
+      // Make a quick update which will schedule low priority work to
+      // update the middle content.
+      ReactNoop.render(<Foo text="bar" step={1} />);
+      ReactNoop.flushDeferredPri(30 + 5);
 
-    // Make a quick update which will schedule low priority work to
-    // update the middle content.
-    ReactNoop.render(<Foo text="bar" step={1} />);
-    ReactNoop.flushDeferredPri(30 + 5);
+      expect(ops).toEqual(['Foo', 'Bar']);
 
-    expect(ops).toEqual(['Foo', 'Bar']);
+      ops = [];
 
-    ops = [];
+      // The middle content is now pending rendering...
+      ReactNoop.flushDeferredPri(30 + 25 + 5);
+      expect(ops).toEqual(['Content', 'Middle', 'Bar']); // One more Middle left.
 
-    // The middle content is now pending rendering...
-    ReactNoop.flushDeferredPri(30 + 25 + 5);
-    expect(ops).toEqual(['Content', 'Middle', 'Bar']); // One more Middle left.
+      ops = [];
 
-    ops = [];
+      // but we'll interrupt it to render some higher priority work.
+      // The middle content will bailout so it remains untouched.
+      ReactNoop.render(<Foo text="foo" step={1} />);
+      ReactNoop.flushDeferredPri(30);
 
-    // but we'll interrupt it to render some higher priority work.
-    // The middle content will bailout so it remains untouched.
-    ReactNoop.render(<Foo text="foo" step={1} />);
-    ReactNoop.flushDeferredPri(30);
+      expect(ops).toEqual(['Foo', 'Bar']);
 
-    expect(ops).toEqual(['Foo', 'Bar']);
+      ops = [];
 
-    ops = [];
-
-    // Since we did nothing to the middle subtree during the interuption,
-    // we should be able to reuse the reconciliation work that we already did
-    // without restarting.
-    ReactNoop.flush();
-    expect(ops).toEqual(['Middle']);
-  });
+      // Since we did nothing to the middle subtree during the interuption,
+      // we should be able to reuse the reconciliation work that we already did
+      // without restarting.
+      ReactNoop.flush();
+      expect(ops).toEqual(['Middle']);
+    },
+  );
 
   it('memoizes work even if shouldComponentUpdate returns false', () => {
     let ops = [];
@@ -1103,7 +1115,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Foo', 'Bar', 'Baz', 'Bar', 'Baz']);
   });
 
-  it('can call sCU while resuming a partly mounted component', () => {
+  xit('can call sCU while resuming a partly mounted component', () => {
     var ops = [];
 
     var instances = new Set();
@@ -1152,7 +1164,7 @@ describe('ReactIncremental', () => {
     expect(instances.size).toBe(4);
   });
 
-  it('gets new props when setting state on a partly updated component', () => {
+  xit('gets new props when setting state on a partly updated component', () => {
     var ops = [];
     var instances = [];
 
@@ -1208,7 +1220,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Bar:A-1', 'Baz']);
   });
 
-  it('calls componentWillMount twice if the initial render is aborted', () => {
+  xit('calls componentWillMount twice if the initial render is aborted', () => {
     var ops = [];
 
     class LifeCycle extends React.Component {
@@ -1264,54 +1276,57 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  it('uses state set in componentWillMount even if initial render was aborted', () => {
-    var ops = [];
+  xit(
+    'uses state set in componentWillMount even if initial render was aborted',
+    () => {
+      var ops = [];
 
-    class LifeCycle extends React.Component {
-      constructor(props) {
-        super(props);
-        this.state = {x: this.props.x + '(ctor)'};
+      class LifeCycle extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {x: this.props.x + '(ctor)'};
+        }
+        componentWillMount() {
+          ops.push('componentWillMount:' + this.state.x);
+          this.setState({x: this.props.x + '(willMount)'});
+        }
+        componentDidMount() {
+          ops.push('componentDidMount:' + this.state.x);
+        }
+        render() {
+          ops.push('render:' + this.state.x);
+          return <span />;
+        }
       }
-      componentWillMount() {
-        ops.push('componentWillMount:' + this.state.x);
-        this.setState({x: this.props.x + '(willMount)'});
+
+      function App(props) {
+        ops.push('App');
+        return <LifeCycle x={props.x} />;
       }
-      componentDidMount() {
-        ops.push('componentDidMount:' + this.state.x);
-      }
-      render() {
-        ops.push('render:' + this.state.x);
-        return <span />;
-      }
-    }
 
-    function App(props) {
-      ops.push('App');
-      return <LifeCycle x={props.x} />;
-    }
+      ReactNoop.render(<App x={0} />);
+      ReactNoop.flushDeferredPri(20);
 
-    ReactNoop.render(<App x={0} />);
-    ReactNoop.flushDeferredPri(20);
+      expect(ops).toEqual([
+        'App',
+        'componentWillMount:0(ctor)',
+        'render:0(willMount)',
+      ]);
 
-    expect(ops).toEqual([
-      'App',
-      'componentWillMount:0(ctor)',
-      'render:0(willMount)',
-    ]);
+      ops = [];
+      ReactNoop.render(<App x={1} />);
+      ReactNoop.flush();
 
-    ops = [];
-    ReactNoop.render(<App x={1} />);
-    ReactNoop.flush();
+      expect(ops).toEqual([
+        'App',
+        'componentWillMount:0(willMount)',
+        'render:1(willMount)',
+        'componentDidMount:1(willMount)',
+      ]);
+    },
+  );
 
-    expect(ops).toEqual([
-      'App',
-      'componentWillMount:0(willMount)',
-      'render:1(willMount)',
-      'componentDidMount:1(willMount)',
-    ]);
-  });
-
-  it('calls componentWill* twice if an update render is aborted', () => {
+  xit('calls componentWill* twice if an update render is aborted', () => {
     var ops = [];
 
     class LifeCycle extends React.Component {
@@ -1398,7 +1413,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  it('does not call componentWillReceiveProps for state-only updates', () => {
+  xit('does not call componentWillReceiveProps for state-only updates', () => {
     var ops = [];
 
     var instances = [];
@@ -1547,101 +1562,104 @@ describe('ReactIncremental', () => {
     // incomplete parents.
   });
 
-  it('skips will/DidUpdate when bailing unless an update was already in progress', () => {
-    var ops = [];
+  xit(
+    'skips will/DidUpdate when bailing unless an update was already in progress',
+    () => {
+      var ops = [];
 
-    class LifeCycle extends React.Component {
-      componentWillMount() {
-        ops.push('componentWillMount');
+      class LifeCycle extends React.Component {
+        componentWillMount() {
+          ops.push('componentWillMount');
+        }
+        componentDidMount() {
+          ops.push('componentDidMount');
+        }
+        componentWillReceiveProps(nextProps) {
+          ops.push('componentWillReceiveProps');
+        }
+        shouldComponentUpdate(nextProps) {
+          ops.push('shouldComponentUpdate');
+          // Bail
+          return this.props.x !== nextProps.x;
+        }
+        componentWillUpdate(nextProps) {
+          ops.push('componentWillUpdate');
+        }
+        componentDidUpdate(prevProps) {
+          ops.push('componentDidUpdate');
+        }
+        render() {
+          ops.push('render');
+          return <span />;
+        }
       }
-      componentDidMount() {
-        ops.push('componentDidMount');
-      }
-      componentWillReceiveProps(nextProps) {
-        ops.push('componentWillReceiveProps');
-      }
-      shouldComponentUpdate(nextProps) {
-        ops.push('shouldComponentUpdate');
-        // Bail
-        return this.props.x !== nextProps.x;
-      }
-      componentWillUpdate(nextProps) {
-        ops.push('componentWillUpdate');
-      }
-      componentDidUpdate(prevProps) {
-        ops.push('componentDidUpdate');
-      }
-      render() {
-        ops.push('render');
+
+      function Sibling() {
+        ops.push('render sibling');
         return <span />;
       }
-    }
 
-    function Sibling() {
-      ops.push('render sibling');
-      return <span />;
-    }
+      function App(props) {
+        return [<LifeCycle key="a" x={props.x} />, <Sibling key="b" />];
+      }
 
-    function App(props) {
-      return [<LifeCycle key="a" x={props.x} />, <Sibling key="b" />];
-    }
+      ReactNoop.render(<App x={0} />);
+      ReactNoop.flush();
 
-    ReactNoop.render(<App x={0} />);
-    ReactNoop.flush();
+      expect(ops).toEqual([
+        'componentWillMount',
+        'render',
+        'render sibling',
+        'componentDidMount',
+      ]);
 
-    expect(ops).toEqual([
-      'componentWillMount',
-      'render',
-      'render sibling',
-      'componentDidMount',
-    ]);
+      ops = [];
 
-    ops = [];
+      // Update to same props
+      ReactNoop.render(<App x={0} />);
+      ReactNoop.flush();
 
-    // Update to same props
-    ReactNoop.render(<App x={0} />);
-    ReactNoop.flush();
+      expect(ops).toEqual([
+        'componentWillReceiveProps',
+        'shouldComponentUpdate',
+        // no componentWillUpdate
+        // no render
+        'render sibling',
+        // no componentDidUpdate
+      ]);
 
-    expect(ops).toEqual([
-      'componentWillReceiveProps',
-      'shouldComponentUpdate',
-      // no componentWillUpdate
-      // no render
-      'render sibling',
-      // no componentDidUpdate
-    ]);
+      ops = [];
 
-    ops = [];
+      // Begin updating to new props...
+      ReactNoop.render(<App x={1} />);
+      ReactNoop.flushDeferredPri(30);
 
-    // Begin updating to new props...
-    ReactNoop.render(<App x={1} />);
-    ReactNoop.flushDeferredPri(30);
+      expect(ops).toEqual([
+        'componentWillReceiveProps',
+        'shouldComponentUpdate',
+        'componentWillUpdate',
+        'render',
+        'render sibling',
+        // no componentDidUpdate yet
+      ]);
 
-    expect(ops).toEqual([
-      'componentWillReceiveProps',
-      'shouldComponentUpdate',
-      'componentWillUpdate',
-      'render',
-      'render sibling',
-      // no componentDidUpdate yet
-    ]);
+      ops = [];
 
-    ops = [];
+      // ...but we'll interrupt it to rerender the same props.
+      ReactNoop.render(<App x={1} />);
+      ReactNoop.flush();
 
-    // ...but we'll interrupt it to rerender the same props.
-    ReactNoop.render(<App x={1} />);
-    ReactNoop.flush();
-
-    // We can bail out this time, but we must call componentDidUpdate.
-    expect(ops).toEqual([
-      'componentWillReceiveProps',
-      'shouldComponentUpdate',
-      // no componentWillUpdate
-      // no render
-      'render sibling',
-      'componentDidUpdate',
-    ]);
-  });
+      // We can bail out this time, but we must call componentDidUpdate.
+      expect(ops).toEqual([
+        'componentWillReceiveProps',
+        'shouldComponentUpdate',
+        // no componentWillUpdate
+        // no render
+        'render sibling',
+        'componentDidUpdate',
+      ]);
+    },
+  );
 
   it('performs batched updates at the end of the batch', () => {
     var ops = [];
@@ -1944,7 +1962,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  it('provides context when reusing work', () => {
+  xit('provides context when reusing work', () => {
     var ops = [];
 
     class Intl extends React.Component {
@@ -2330,86 +2348,89 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  it('should reuse memoized work if pointers are updated before calling lifecycles', () => {
-    let cduNextProps = [];
-    let cduPrevProps = [];
-    let scuNextProps = [];
-    let scuPrevProps = [];
-    let renderCounter = 0;
+  xit(
+    'should reuse memoized work if pointers are updated before calling lifecycles',
+    () => {
+      let cduNextProps = [];
+      let cduPrevProps = [];
+      let scuNextProps = [];
+      let scuPrevProps = [];
+      let renderCounter = 0;
 
-    function SecondChild(props) {
-      return <span>{props.children}</span>;
-    }
+      function SecondChild(props) {
+        return <span>{props.children}</span>;
+      }
 
-    class FirstChild extends React.Component {
-      componentDidUpdate(prevProps, prevState) {
-        cduNextProps.push(this.props);
-        cduPrevProps.push(prevProps);
+      class FirstChild extends React.Component {
+        componentDidUpdate(prevProps, prevState) {
+          cduNextProps.push(this.props);
+          cduPrevProps.push(prevProps);
+        }
+        shouldComponentUpdate(nextProps, nextState) {
+          scuNextProps.push(nextProps);
+          scuPrevProps.push(this.props);
+          return this.props.children !== nextProps.children;
+        }
+        render() {
+          renderCounter++;
+          return <span>{this.props.children}</span>;
+        }
       }
-      shouldComponentUpdate(nextProps, nextState) {
-        scuNextProps.push(nextProps);
-        scuPrevProps.push(this.props);
-        return this.props.children !== nextProps.children;
-      }
-      render() {
-        renderCounter++;
-        return <span>{this.props.children}</span>;
-      }
-    }
 
-    class Middle extends React.Component {
-      render() {
+      class Middle extends React.Component {
+        render() {
+          return (
+            <div>
+              <FirstChild>{this.props.children}</FirstChild>
+              <SecondChild>{this.props.children}</SecondChild>
+            </div>
+          );
+        }
+      }
+
+      function Root(props) {
         return (
-          <div>
-            <FirstChild>{this.props.children}</FirstChild>
-            <SecondChild>{this.props.children}</SecondChild>
+          <div hidden={true}>
+            <Middle {...props} />
           </div>
         );
       }
-    }
 
-    function Root(props) {
-      return (
-        <div hidden={true}>
-          <Middle {...props} />
-        </div>
-      );
-    }
+      // Initial render of the entire tree.
+      // Renders: Root, Middle, FirstChild, SecondChild
+      ReactNoop.render(<Root>A</Root>);
+      ReactNoop.flush();
 
-    // Initial render of the entire tree.
-    // Renders: Root, Middle, FirstChild, SecondChild
-    ReactNoop.render(<Root>A</Root>);
-    ReactNoop.flush();
+      expect(renderCounter).toBe(1);
 
-    expect(renderCounter).toBe(1);
+      // Schedule low priority work to update children.
+      // Give it enough time to partially render.
+      // Renders: Root, Middle, FirstChild
+      ReactNoop.render(<Root>B</Root>);
+      ReactNoop.flushDeferredPri(20 + 30 + 5);
 
-    // Schedule low priority work to update children.
-    // Give it enough time to partially render.
-    // Renders: Root, Middle, FirstChild
-    ReactNoop.render(<Root>B</Root>);
-    ReactNoop.flushDeferredPri(20 + 30 + 5);
+      // At this point our FirstChild component has rendered a second time,
+      // But since the render is not completed cDU should not be called yet.
+      expect(renderCounter).toBe(2);
+      expect(scuPrevProps).toEqual([{children: 'A'}]);
+      expect(scuNextProps).toEqual([{children: 'B'}]);
+      expect(cduPrevProps).toEqual([]);
+      expect(cduNextProps).toEqual([]);
 
-    // At this point our FirstChild component has rendered a second time,
-    // But since the render is not completed cDU should not be called yet.
-    expect(renderCounter).toBe(2);
-    expect(scuPrevProps).toEqual([{children: 'A'}]);
-    expect(scuNextProps).toEqual([{children: 'B'}]);
-    expect(cduPrevProps).toEqual([]);
-    expect(cduNextProps).toEqual([]);
+      // Next interrupt the partial render with higher priority work.
+      // The in-progress child content will bailout.
+      // Renders: Root, Middle, FirstChild, SecondChild
+      ReactNoop.render(<Root>B</Root>);
+      ReactNoop.flush();
 
-    // Next interrupt the partial render with higher priority work.
-    // The in-progress child content will bailout.
-    // Renders: Root, Middle, FirstChild, SecondChild
-    ReactNoop.render(<Root>B</Root>);
-    ReactNoop.flush();
-
-    // At this point the higher priority render has completed.
-    // Since FirstChild props didn't change, sCU returned false.
-    // The previous memoized copy should be used.
-    expect(renderCounter).toBe(2);
-    expect(scuPrevProps).toEqual([{children: 'A'}, {children: 'B'}]);
-    expect(scuNextProps).toEqual([{children: 'B'}, {children: 'B'}]);
-    expect(cduPrevProps).toEqual([{children: 'A'}]);
-    expect(cduNextProps).toEqual([{children: 'B'}]);
-  });
+      // At this point the higher priority render has completed.
+      // Since FirstChild props didn't change, sCU returned false.
+      // The previous memoized copy should be used.
+      expect(renderCounter).toBe(2);
+      expect(scuPrevProps).toEqual([{children: 'A'}, {children: 'B'}]);
+      expect(scuNextProps).toEqual([{children: 'B'}, {children: 'B'}]);
+      expect(cduPrevProps).toEqual([{children: 'A'}]);
+      expect(cduNextProps).toEqual([{children: 'B'}]);
+    },
+  );
 });

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -244,7 +244,7 @@ describe('ReactIncremental', () => {
     expect(inst.state).toEqual({text: 'bar', text2: 'baz'});
   });
 
-  xit('can deprioritize unfinished work and resume it later', () => {
+  it('can deprioritize unfinished work and resume it later', () => {
     var ops = [];
 
     function Bar(props) {
@@ -296,7 +296,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Middle', 'Middle']);
   });
 
-  xit('can deprioritize a tree from without dropping work', () => {
+  it('can deprioritize a tree from without dropping work', () => {
     var ops = [];
 
     function Bar(props) {
@@ -1962,7 +1962,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
-  xit('provides context when reusing work', () => {
+  it('provides context when reusing work', () => {
     var ops = [];
 
     class Intl extends React.Component {

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalPerf-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalPerf-test.js
@@ -280,7 +280,7 @@ describe('ReactDebugFiberPerf', () => {
     expect(getFlameChart()).toMatchSnapshot();
   });
 
-  xit('measures deprioritized work', () => {
+  it('measures deprioritized work', () => {
     addComment('Flush the parent');
     ReactNoop.syncUpdates(() => {
       ReactNoop.render(

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalPerf-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalPerf-test.js
@@ -280,7 +280,7 @@ describe('ReactDebugFiberPerf', () => {
     expect(getFlameChart()).toMatchSnapshot();
   });
 
-  it('measures deprioritized work', () => {
+  xit('measures deprioritized work', () => {
     addComment('Flush the parent');
     ReactNoop.syncUpdates(() => {
       ReactNoop.render(

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
@@ -235,14 +235,16 @@ describe('ReactIncrementalTriangle', () => {
     return {simulate, totalChildren, totalTriangles};
   }
 
-  xit('renders the triangle demo without inconsistencies', () => {
+  it('renders the triangle demo without inconsistencies', () => {
     const {simulate} = TriangleSimulator();
     simulate(step(1));
     simulate(toggle(0), step(1), toggle(0));
     simulate(step(1), toggle(0), flush(2), step(2), toggle(0));
+    simulate(step(1), flush(3), toggle(0), step(0));
+    simulate(step(1), flush(3), toggle(18), step(0));
   });
 
-  xit('fuzz tester', () => {
+  it('fuzz tester', () => {
     // This test is not deterministic because the inputs are randomized. It runs
     // a limited number of tests on every run. If it fails, it will output the
     // case that led to the failure. Add the failing case to the test above

--- a/src/renderers/shared/fiber/__tests__/__snapshots__/ReactIncrementalPerf-test.js.snap
+++ b/src/renderers/shared/fiber/__tests__/__snapshots__/ReactIncrementalPerf-test.js.snap
@@ -61,8 +61,8 @@ exports[`ReactDebugFiberPerf deduplicates lifecycle names during commit to reduc
       ⚛ B.componentDidUpdate
   ⚛ B [update]
   ⛔ (Committing Changes) Warning: Caused by a cascading update in earlier commit
-    ⚛ (Committing Host Effects: 3 Total)
-    ⚛ (Calling Lifecycle Methods: 3 Total)
+    ⚛ (Committing Host Effects: 6 Total)
+    ⚛ (Calling Lifecycle Methods: 6 Total)
       ⚛ B.componentDidUpdate
 "
 `;


### PR DESCRIPTION
The current implementation of resuming work is buggy. The underlying model is also flawed. Rather than attempt to fix a flawed model, we'll scrap the feature entirely and add it back later.

The triangle fuzz tester is now passing. By keeping this test green, we should have greater confidence that changes do not introduce regressions.

See https://github.com/facebook/react/issues/8830 for the larger plan.