### PR TITLE
Fix scheduler control flow

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -597,6 +597,7 @@ src/renderers/__tests__/ReactUpdates-test.js
 * does not re-render if state update is null
 * synchronously renders hidden subtrees
 * does not fall into an infinite update loop
+* does not fall into an infinite error loop
 
 src/renderers/__tests__/multiple-copies-of-react-test.js
 * throws the "Refs must have owner" warning

--- a/src/renderers/shared/fiber/ReactDebugFiberPerf.js
+++ b/src/renderers/shared/fiber/ReactDebugFiberPerf.js
@@ -270,6 +270,20 @@ if (__DEV__) {
       endFiberMark(fiber, null, null);
     },
 
+    stopFailedWorkTimer(fiber: Fiber): void {
+      if (!supportsUserTiming || shouldIgnoreFiber(fiber)) {
+        return;
+      }
+      // If we pause, its parent is the fiber to unwind from.
+      currentFiber = fiber.return;
+      if (!fiber._debugIsCurrentlyTiming) {
+        return;
+      }
+      fiber._debugIsCurrentlyTiming = false;
+      const warning = 'An error was thrown inside this error boundary';
+      endFiberMark(fiber, null, warning);
+    },
+
     startPhaseTimer(fiber: Fiber, phase: MeasurementPhase): void {
       if (!supportsUserTiming) {
         return;

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -773,11 +773,22 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     workInProgress: Fiber,
     priorityLevel: PriorityLevel,
   ) {
-    invariant(
-      workInProgress.tag === ClassComponent || workInProgress.tag === HostRoot,
-      'Invalid type of work. This error is likely caused by a bug in React. ' +
-        'Please file an issue.',
-    );
+    // Push context providers here to avoid a push/pop context mismatch.
+    switch (workInProgress.tag) {
+      case ClassComponent:
+        pushContextProvider(workInProgress);
+        break;
+      case HostRoot:
+        const root: FiberRoot = workInProgress.stateNode;
+        pushHostContainer(workInProgress, root.containerInfo);
+        break;
+      default:
+        invariant(
+          false,
+          'Invalid type of work. This error is likely caused by a bug in React. ' +
+            'Please file an issue.',
+        );
+    }
 
     // Add an error effect so we can handle the error during the commit phase
     workInProgress.effectTag |= Err;

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -96,6 +96,7 @@ if (__DEV__) {
     recordScheduleUpdate,
     startWorkTimer,
     stopWorkTimer,
+    stopFailedWorkTimer,
     startWorkLoopTimer,
     stopWorkLoopTimer,
     startCommitTimer,
@@ -1226,7 +1227,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
   function unwindContexts(from: Fiber, to: Fiber) {
     let node = from;
-    while (node !== null && node !== to && node.alternate !== to) {
+    while (node !== null) {
       switch (node.tag) {
         case ClassComponent:
           popContextProvider(node);
@@ -1241,7 +1242,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           popHostContainer(node);
           break;
       }
-      if (__DEV__) {
+      if (node === to || node.alternate === to) {
+        if (__DEV__) {
+          stopFailedWorkTimer(node);
+        }
+        break;
+      } else if (__DEV__) {
         stopWorkTimer(node);
       }
       node = node.return;

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
@@ -165,7 +165,7 @@ describe('ReactIncrementalTriangle', () => {
         // first child.
         if (counter === undefined) {
           if (typeof num === 'string') {
-            counter = num.substr(1, num.length - 2);
+            counter = parseInt(num.substr(1, num.length - 2), 10);
           } else {
             counter = num;
           }
@@ -192,8 +192,8 @@ describe('ReactIncrementalTriangle', () => {
       let expectedCounterAtEnd = app.state.counter;
 
       let activeTriangle = null;
-      ReactNoop.batchedUpdates(() => {
-        for (let i = 0; i < actions.length; i++) {
+      for (var i = 0; i < actions.length; i++) {
+        ReactNoop.batchedUpdates(() => {
           const action = actions[i];
           switch (action.type) {
             case FLUSH:
@@ -225,8 +225,9 @@ describe('ReactIncrementalTriangle', () => {
             default:
               break;
           }
-        }
-      });
+        });
+        assertConsistentTree(activeTriangle);
+      }
       // Flush remaining work
       ReactNoop.flush();
       assertConsistentTree(activeTriangle, expectedCounterAtEnd);

--- a/src/renderers/shared/fiber/__tests__/__snapshots__/ReactIncrementalPerf-test.js.snap
+++ b/src/renderers/shared/fiber/__tests__/__snapshots__/ReactIncrementalPerf-test.js.snap
@@ -171,9 +171,6 @@ exports[`ReactDebugFiberPerf recovers from caught errors 1`] = `
 "// Stop on Baddie and restart from Boundary
 ⛔ (React Tree Reconciliation) Warning: There were cascading updates
   ⚛ Parent [mount]
-    ⚛ Boundary [mount]
-      ⚛ Parent [mount]
-        ⚛ Baddie [mount]
   ⛔ (Committing Changes) Warning: Lifecycle hook scheduled a cascading update
     ⚛ (Committing Host Effects: 2 Total)
     ⚛ (Calling Lifecycle Methods: 1 Total)

--- a/src/renderers/shared/fiber/__tests__/__snapshots__/ReactIncrementalPerf-test.js.snap
+++ b/src/renderers/shared/fiber/__tests__/__snapshots__/ReactIncrementalPerf-test.js.snap
@@ -171,6 +171,10 @@ exports[`ReactDebugFiberPerf recovers from caught errors 1`] = `
 "// Stop on Baddie and restart from Boundary
 ⛔ (React Tree Reconciliation) Warning: There were cascading updates
   ⚛ Parent [mount]
+    ⛔ Boundary [mount] Warning: An error was thrown inside this error boundary
+      ⚛ Parent [mount]
+        ⚛ Baddie [mount]
+    ⚛ Boundary [mount]
   ⛔ (Committing Changes) Warning: Lifecycle hook scheduled a cascading update
     ⚛ (Committing Host Effects: 2 Total)
     ⚛ (Calling Lifecycle Methods: 1 Total)


### PR DESCRIPTION
I'm about to start larger error handling PR to fix some outstanding bugs (see https://github.com/facebook/react/pull/9210). This is a smaller one that cleans up some messiness that I noticed when reviewing the error handling logic.

No observable changes, just refactors the code a bit to make it easier to follow.

- The first commit focuses on begin phase errors. It uses `performFailedUnitOfWork` instead of separately calling `beginFailedWork` and `completeUnitOfWork`.
- The second commit focuses on commit phase errors. We have a special, forked version of the work loop that does an additional check on each fiber to see if it's an error boundary with an unhandled error. But this only relevant after the commit phase, because begin phase errors are handled using a stack unwind. So we should only run this loop right after committing.