### PR TITLE
Remove "unstable" warning from ReactDOM

### DIFF
--- a/src/renderers/__tests__/refs-test.js
+++ b/src/renderers/__tests__/refs-test.js
@@ -355,7 +355,6 @@ describe('string refs between fiber and stack', () => {
   });
 
   it('attaches, detaches from stack component with fiber layer', () => {
-    spyOn(console, 'error');
     const ReactCurrentOwner = require('ReactCurrentOwner');
     const ReactDOM = require('ReactDOMStackEntry');
     const ReactDOMFiber = require('ReactDOMFiberEntry');
@@ -391,14 +390,6 @@ describe('string refs between fiber and stack', () => {
     ReactDOM.unmountComponentAtNode(container);
     expect(a.refs.span).toBe(undefined);
     expect(layerMounted).toBe(true);
-    if (!ReactDOMFeatureFlags.useFiber) {
-      expectDev(console.error.calls.count()).toBe(1);
-      expectDev(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: You are using React DOM Fiber which is an experimental ' +
-          'renderer. It is likely to have bugs, breaking changes and is ' +
-          'unsupported.',
-      );
-    }
   });
 });
 

--- a/src/renderers/__tests__/refs-test.js
+++ b/src/renderers/__tests__/refs-test.js
@@ -316,7 +316,6 @@ describe('string refs between fiber and stack', () => {
   });
 
   it('attaches, detaches from fiber component with stack layer', () => {
-    spyOn(console, 'error');
     const ReactCurrentOwner = require('ReactCurrentOwner');
 
     const ReactDOMStack = require('ReactDOMStackEntry');
@@ -353,14 +352,6 @@ describe('string refs between fiber and stack', () => {
     ReactDOMFiber.unmountComponentAtNode(container);
     expect(a.refs.span).toBe(undefined);
     expect(layerMounted).toBe(true);
-    if (!ReactDOMFeatureFlags.useFiber) {
-      expectDev(console.error.calls.count()).toBe(1);
-      expectDev(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: You are using React DOM Fiber which is an experimental ' +
-          'renderer. It is likely to have bugs, breaking changes and is ' +
-          'unsupported.',
-      );
-    }
   });
 
   it('attaches, detaches from stack component with fiber layer', () => {

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -454,18 +454,6 @@ ReactGenericBatching.injection.injectFiberBatchedUpdates(
   DOMRenderer.batchedUpdates,
 );
 
-var warned = false;
-
-function warnAboutUnstableUse() {
-  // Ignore this warning is the feature flag is turned on. E.g. for tests.
-  warning(
-    warned || ReactDOMFeatureFlags.useFiber,
-    'You are using React DOM Fiber which is an experimental renderer. ' +
-      'It is likely to have bugs, breaking changes and is unsupported.',
-  );
-  warned = true;
-}
-
 function renderSubtreeIntoContainer(
   parentComponent: ?ReactComponent<any, any, any>,
   children: ReactNodeList,
@@ -588,7 +576,6 @@ var ReactDOMFiber = {
       isValidContainer(container),
       'unmountComponentAtNode(...): Target container is not a DOM element.',
     );
-    warnAboutUnstableUse();
 
     if (container._reactRootContainer) {
       if (__DEV__) {


### PR DESCRIPTION
Seems like the warning is in the wrong place anyway (in unmounting only).
I'm not sure this is very valuable now as this code is only present in alphas now.