### PR TITLE
Warn When The HTML Mismatches in DEV

### DIFF
--- a/scripts/fiber/tests-passing-except-dev.txt
+++ b/scripts/fiber/tests-passing-except-dev.txt
@@ -3,6 +3,3 @@ src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * gives source code refs for unknown prop warning for exact elements (ssr)
 * gives source code refs for unknown prop warning for exact elements in composition (ssr)
 * should suggest property name if available (ssr)
-
-src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
-* should error reconnecting a div with different dangerouslySetInnerHTML

--- a/scripts/fiber/tests-passing-except-dev.txt
+++ b/scripts/fiber/tests-passing-except-dev.txt
@@ -5,77 +5,24 @@ src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * should suggest property name if available (ssr)
 
 src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
-* renders a blank div with client render on top of bad server markup
-* renders a div with inline styles with client render on top of bad server markup
 * renders a self-closing tag with client render on top of bad server markup
-* renders a self-closing tag as a child with client render on top of bad server markup
-* renders simple numbers with client render on top of bad server markup
-* renders simple strings with client render on top of bad server markup
 * renders string prop with true value with client render on top of bad server markup
 * renders string prop with false value with client render on top of bad server markup
-* renders boolean prop with true value with client render on top of bad server markup
-* renders boolean prop with false value with client render on top of bad server markup
-* renders boolean prop with self value with client render on top of bad server markup
-* renders boolean prop with "" value with client render on top of bad server markup
-* renders boolean prop with string value with client render on top of bad server markup
-* renders boolean prop with array value with client render on top of bad server markup
-* renders boolean prop with object value with client render on top of bad server markup
-* renders boolean prop with non-zero number value with client render on top of bad server markup
-* renders boolean prop with zero value with client render on top of bad server markup
 * renders download prop with true value with client render on top of bad server markup
 * renders download prop with false value with client render on top of bad server markup
 * renders download prop with string value with client render on top of bad server markup
 * renders download prop with string "true" value with client render on top of bad server markup
-* renders className prop with string value with client render on top of bad server markup
-* renders className prop with empty string value with client render on top of bad server markup
-* renders className prop with true value with client render on top of bad server markup
-* renders className prop with false value with client render on top of bad server markup
-* renders htmlFor with string value with client render on top of bad server markup
-* renders htmlFor with an empty string with client render on top of bad server markup
-* renders className prop with true value with client render on top of bad server markup
-* renders className prop with false value with client render on top of bad server markup
-* renders no ref attribute with client render on top of bad server markup
-* renders no key attribute with client render on top of bad server markup
-* renders no dangerouslySetInnerHTML attribute with client render on top of bad server markup
-* renders no unknown attributes with client render on top of bad server markup
-* renders unknown data- attributes with client render on top of bad server markup
 * renders no unknown attributes for non-standard elements with client render on top of bad server markup
 * renders unknown attributes for custom elements with client render on top of bad server markup
-* renders unknown attributes for custom elements using is with client render on top of bad server markup
-* renders no HTML events with client render on top of bad server markup
-* renders a div with an empty text child with client render on top of bad server markup
-* renders a div with multiple empty text children with client render on top of bad server markup
-* renders a div with multiple whitespace children with client render on top of bad server markup
-* renders a div with text sibling to a node with client render on top of bad server markup
 * renders a non-standard element with text with client render on top of bad server markup
 * renders a custom element with text with client render on top of bad server markup
-* renders a leading blank child with a text sibling with client render on top of bad server markup
-* renders a trailing blank child with a text sibling with client render on top of bad server markup
-* renders an element with two text children with client render on top of bad server markup
-* renders an element with number and text children with client render on top of bad server markup
-* renders null single child as blank with client render on top of bad server markup
-* renders false single child as blank with client render on top of bad server markup
-* renders undefined single child as blank with client render on top of bad server markup
-* renders a null component children as empty with client render on top of bad server markup
-* renders null children as blank with client render on top of bad server markup
-* renders false children as blank with client render on top of bad server markup
-* renders null and false children together as blank with client render on top of bad server markup
-* renders only null and false children as blank with client render on top of bad server markup
 * renders an svg element with client render on top of bad server markup
 * renders svg element with an xlink with client render on top of bad server markup
 * renders a math element with client render on top of bad server markup
 * renders an img with client render on top of bad server markup
 * renders a button with client render on top of bad server markup
-* renders a div with dangerouslySetInnerHTML with client render on top of bad server markup
 * renders a newline-eating tag with content not starting with \n with client render on top of bad server markup
 * renders a newline-eating tag with content starting with \n with client render on top of bad server markup
-* renders single child hierarchies of components with client render on top of bad server markup
-* renders multi-child hierarchies of components with client render on top of bad server markup
-* renders a div with a child with client render on top of bad server markup
-* renders a div with multiple children with client render on top of bad server markup
-* renders a div with multiple children separated by whitespace with client render on top of bad server markup
-* renders a div with a single child surrounded by whitespace with client render on top of bad server markup
-* renders >,<, and & as multiple children with client render on top of bad server markup
 * renders an input with a value and an onChange with client render on top of bad server markup
 * renders an input with a value and readOnly with client render on top of bad server markup
 * renders an input with a value and no onChange/readOnly with client render on top of bad server markup
@@ -106,16 +53,7 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a controlled textarea with client render on top of bad server markup
 * renders a controlled checkbox with client render on top of bad server markup
 * renders a controlled select with client render on top of bad server markup
-* renders class child without context with client render on top of bad server markup
-* renders stateless child without context with client render on top of bad server markup
-* renders class child with wrong context with client render on top of bad server markup
-* renders stateless child with wrong context with client render on top of bad server markup
-* renders a child context merged with a parent context with client render on top of bad server markup
 * should error reconnecting different element types
-* should error reconnecting missing attributes
-* should error reconnecting added attributes
-* should error reconnecting different attribute values
-* should error reconnecting different text in two code blocks
 * should error reconnecting missing children
 * should error reconnecting added children
 * should error reconnecting more children
@@ -130,6 +68,3 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 src/renderers/dom/shared/__tests__/ReactMount-test.js
 * should warn if mounting into dirty rendered markup
 * should account for escaping on a checksum mismatch
-
-src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
-* should have the correct mounting behavior

--- a/scripts/fiber/tests-passing-except-dev.txt
+++ b/scripts/fiber/tests-passing-except-dev.txt
@@ -5,13 +5,6 @@ src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * should suggest property name if available (ssr)
 
 src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
-* renders a textarea with a value and an onChange with client render on top of good server markup
-* renders a textarea with a value and readOnly with client render on top of good server markup
-* renders a textarea with a value and no onChange/readOnly with client render on top of good server markup
-* renders a textarea with a defaultValue with client render on top of good server markup
-* renders a textarea value overriding defaultValue with client render on top of good server markup
-* renders a textarea value overriding defaultValue no matter the prop order with client render on top of good server markup
-* renders a controlled textarea with client render on top of good server markup
 * can distinguish an empty component from an empty text component
 * should error reconnecting a div with different dangerouslySetInnerHTML
 

--- a/scripts/fiber/tests-passing-except-dev.txt
+++ b/scripts/fiber/tests-passing-except-dev.txt
@@ -10,4 +10,3 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 
 src/renderers/dom/shared/__tests__/ReactMount-test.js
 * should warn if mounting into dirty rendered markup
-* should account for escaping on a checksum mismatch

--- a/scripts/fiber/tests-passing-except-dev.txt
+++ b/scripts/fiber/tests-passing-except-dev.txt
@@ -5,5 +5,4 @@ src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * should suggest property name if available (ssr)
 
 src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
-* can distinguish an empty component from an empty text component
 * should error reconnecting a div with different dangerouslySetInnerHTML

--- a/scripts/fiber/tests-passing-except-dev.txt
+++ b/scripts/fiber/tests-passing-except-dev.txt
@@ -7,6 +7,3 @@ src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * can distinguish an empty component from an empty text component
 * should error reconnecting a div with different dangerouslySetInnerHTML
-
-src/renderers/dom/shared/__tests__/ReactMount-test.js
-* should warn if mounting into dirty rendered markup

--- a/scripts/fiber/tests-passing-except-dev.txt
+++ b/scripts/fiber/tests-passing-except-dev.txt
@@ -35,7 +35,6 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders className prop with true value with client render on top of bad server markup
 * renders className prop with false value with client render on top of bad server markup
 * renders no ref attribute with client render on top of bad server markup
-* renders no children attribute with client render on top of bad server markup
 * renders no key attribute with client render on top of bad server markup
 * renders no dangerouslySetInnerHTML attribute with client render on top of bad server markup
 * renders no unknown attributes with client render on top of bad server markup
@@ -44,8 +43,6 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders unknown attributes for custom elements with client render on top of bad server markup
 * renders unknown attributes for custom elements using is with client render on top of bad server markup
 * renders no HTML events with client render on top of bad server markup
-* renders a div with text with client render on top of bad server markup
-* renders a div with text with flanking whitespace with client render on top of bad server markup
 * renders a div with an empty text child with client render on top of bad server markup
 * renders a div with multiple empty text children with client render on top of bad server markup
 * renders a div with multiple whitespace children with client render on top of bad server markup
@@ -55,8 +52,6 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a leading blank child with a text sibling with client render on top of bad server markup
 * renders a trailing blank child with a text sibling with client render on top of bad server markup
 * renders an element with two text children with client render on top of bad server markup
-* renders a number as single child with client render on top of bad server markup
-* renders zero as single child with client render on top of bad server markup
 * renders an element with number and text children with client render on top of bad server markup
 * renders null single child as blank with client render on top of bad server markup
 * renders false single child as blank with client render on top of bad server markup
@@ -74,17 +69,12 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a div with dangerouslySetInnerHTML with client render on top of bad server markup
 * renders a newline-eating tag with content not starting with \n with client render on top of bad server markup
 * renders a newline-eating tag with content starting with \n with client render on top of bad server markup
-* renders a normal tag with content starting with \n with client render on top of bad server markup
-* renders stateless components with client render on top of bad server markup
-* renders ES6 class components with client render on top of bad server markup
-* renders factory components with client render on top of bad server markup
 * renders single child hierarchies of components with client render on top of bad server markup
 * renders multi-child hierarchies of components with client render on top of bad server markup
 * renders a div with a child with client render on top of bad server markup
 * renders a div with multiple children with client render on top of bad server markup
 * renders a div with multiple children separated by whitespace with client render on top of bad server markup
 * renders a div with a single child surrounded by whitespace with client render on top of bad server markup
-* renders >,<, and & as single child with client render on top of bad server markup
 * renders >,<, and & as multiple children with client render on top of bad server markup
 * renders an input with a value and an onChange with client render on top of bad server markup
 * renders an input with a value and readOnly with client render on top of bad server markup
@@ -116,23 +106,15 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a controlled textarea with client render on top of bad server markup
 * renders a controlled checkbox with client render on top of bad server markup
 * renders a controlled select with client render on top of bad server markup
-* renders class child with context with client render on top of bad server markup
-* renders stateless child with context with client render on top of bad server markup
 * renders class child without context with client render on top of bad server markup
 * renders stateless child without context with client render on top of bad server markup
 * renders class child with wrong context with client render on top of bad server markup
 * renders stateless child with wrong context with client render on top of bad server markup
-* renders with context passed through to a grandchild with client render on top of bad server markup
-* renders a child context overriding a parent context with client render on top of bad server markup
 * renders a child context merged with a parent context with client render on top of bad server markup
-* renders with a call to componentWillMount before getChildContext with client render on top of bad server markup
 * should error reconnecting different element types
 * should error reconnecting missing attributes
 * should error reconnecting added attributes
 * should error reconnecting different attribute values
-* should error reconnecting different text
-* should error reconnecting different numbers
-* should error reconnecting different number from text
 * should error reconnecting different text in two code blocks
 * should error reconnecting missing children
 * should error reconnecting added children
@@ -141,7 +123,6 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * should error reconnecting reordered children
 * should error reconnecting a div with children separated by whitespace on the client
 * should error reconnecting a div with children separated by different whitespace on the server
-* should error reconnecting a div with children separated by different whitespace
 * can distinguish an empty component from a dom node
 * can distinguish an empty component from an empty text component
 * should error reconnecting a div with different dangerouslySetInnerHTML

--- a/scripts/fiber/tests-passing-except-dev.txt
+++ b/scripts/fiber/tests-passing-except-dev.txt
@@ -5,63 +5,13 @@ src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * should suggest property name if available (ssr)
 
 src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
-* renders a self-closing tag with client render on top of bad server markup
-* renders string prop with true value with client render on top of bad server markup
-* renders string prop with false value with client render on top of bad server markup
-* renders download prop with true value with client render on top of bad server markup
-* renders download prop with false value with client render on top of bad server markup
-* renders download prop with string value with client render on top of bad server markup
-* renders download prop with string "true" value with client render on top of bad server markup
-* renders no unknown attributes for non-standard elements with client render on top of bad server markup
-* renders unknown attributes for custom elements with client render on top of bad server markup
-* renders a non-standard element with text with client render on top of bad server markup
-* renders a custom element with text with client render on top of bad server markup
-* renders an svg element with client render on top of bad server markup
-* renders svg element with an xlink with client render on top of bad server markup
-* renders a math element with client render on top of bad server markup
-* renders an img with client render on top of bad server markup
-* renders a button with client render on top of bad server markup
-* renders a newline-eating tag with content not starting with \n with client render on top of bad server markup
-* renders a newline-eating tag with content starting with \n with client render on top of bad server markup
-* renders an input with a value and an onChange with client render on top of bad server markup
-* renders an input with a value and readOnly with client render on top of bad server markup
-* renders an input with a value and no onChange/readOnly with client render on top of bad server markup
-* renders an input with a defaultValue with client render on top of bad server markup
-* renders an input value overriding defaultValue with client render on top of bad server markup
-* renders an input value overriding defaultValue no matter the prop order with client render on top of bad server markup
-* renders a checkbox that is checked with an onChange with client render on top of bad server markup
-* renders a checkbox that is checked with readOnly with client render on top of bad server markup
-* renders a checkbox that is checked and no onChange/readOnly with client render on top of bad server markup
-* renders a checkbox with defaultChecked with client render on top of bad server markup
-* renders a checkbox checked overriding defaultChecked with client render on top of bad server markup
-* renders a checkbox checked overriding defaultChecked no matter the prop order with client render on top of bad server markup
-* renders a textarea with a value and an onChange with client render on top of bad server markup
-* renders a textarea with a value and readOnly with client render on top of bad server markup
-* renders a textarea with a value and no onChange/readOnly with client render on top of bad server markup
-* renders a textarea with a defaultValue with client render on top of bad server markup
-* renders a textarea value overriding defaultValue with client render on top of bad server markup
-* renders a textarea value overriding defaultValue no matter the prop order with client render on top of bad server markup
-* renders a select with a value and an onChange with client render on top of bad server markup
-* renders a select with a value and readOnly with client render on top of bad server markup
-* renders a select with a multiple values and an onChange with client render on top of bad server markup
-* renders a select with a multiple values and readOnly with client render on top of bad server markup
-* renders a select with a value and no onChange/readOnly with client render on top of bad server markup
-* renders a select with a defaultValue with client render on top of bad server markup
-* renders a select value overriding defaultValue with client render on top of bad server markup
-* renders a select value overriding defaultValue no matter the prop order with client render on top of bad server markup
-* renders a controlled text input with client render on top of bad server markup
-* renders a controlled textarea with client render on top of bad server markup
-* renders a controlled checkbox with client render on top of bad server markup
-* renders a controlled select with client render on top of bad server markup
-* should error reconnecting different element types
-* should error reconnecting missing children
-* should error reconnecting added children
-* should error reconnecting more children
-* should error reconnecting fewer children
-* should error reconnecting reordered children
-* should error reconnecting a div with children separated by whitespace on the client
-* should error reconnecting a div with children separated by different whitespace on the server
-* can distinguish an empty component from a dom node
+* renders a textarea with a value and an onChange with client render on top of good server markup
+* renders a textarea with a value and readOnly with client render on top of good server markup
+* renders a textarea with a value and no onChange/readOnly with client render on top of good server markup
+* renders a textarea with a defaultValue with client render on top of good server markup
+* renders a textarea value overriding defaultValue with client render on top of good server markup
+* renders a textarea value overriding defaultValue no matter the prop order with client render on top of good server markup
+* renders a controlled textarea with client render on top of good server markup
 * can distinguish an empty component from an empty text component
 * should error reconnecting a div with different dangerouslySetInnerHTML
 

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -885,10 +885,12 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a blank div with server stream render
 * renders a blank div with clean client render
 * renders a blank div with client render on top of good server markup
+* renders a blank div with client render on top of bad server markup
 * renders a div with inline styles with server string render
 * renders a div with inline styles with server stream render
 * renders a div with inline styles with clean client render
 * renders a div with inline styles with client render on top of good server markup
+* renders a div with inline styles with client render on top of bad server markup
 * renders a self-closing tag with server string render
 * renders a self-closing tag with server stream render
 * renders a self-closing tag with clean client render
@@ -897,14 +899,17 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a self-closing tag as a child with server stream render
 * renders a self-closing tag as a child with clean client render
 * renders a self-closing tag as a child with client render on top of good server markup
+* renders a self-closing tag as a child with client render on top of bad server markup
 * renders simple numbers with server string render
 * renders simple numbers with server stream render
 * renders simple numbers with clean client render
 * renders simple numbers with client render on top of good server markup
+* renders simple numbers with client render on top of bad server markup
 * renders simple strings with server string render
 * renders simple strings with server stream render
 * renders simple strings with clean client render
 * renders simple strings with client render on top of good server markup
+* renders simple strings with client render on top of bad server markup
 * renders string prop with true value with server string render
 * renders string prop with true value with server stream render
 * renders string prop with true value with clean client render
@@ -917,38 +922,47 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders boolean prop with true value with server stream render
 * renders boolean prop with true value with clean client render
 * renders boolean prop with true value with client render on top of good server markup
+* renders boolean prop with true value with client render on top of bad server markup
 * renders boolean prop with false value with server string render
 * renders boolean prop with false value with server stream render
 * renders boolean prop with false value with clean client render
 * renders boolean prop with false value with client render on top of good server markup
+* renders boolean prop with false value with client render on top of bad server markup
 * renders boolean prop with self value with server string render
 * renders boolean prop with self value with server stream render
 * renders boolean prop with self value with clean client render
 * renders boolean prop with self value with client render on top of good server markup
+* renders boolean prop with self value with client render on top of bad server markup
 * renders boolean prop with "" value with server string render
 * renders boolean prop with "" value with server stream render
 * renders boolean prop with "" value with clean client render
 * renders boolean prop with "" value with client render on top of good server markup
+* renders boolean prop with "" value with client render on top of bad server markup
 * renders boolean prop with string value with server string render
 * renders boolean prop with string value with server stream render
 * renders boolean prop with string value with clean client render
 * renders boolean prop with string value with client render on top of good server markup
+* renders boolean prop with string value with client render on top of bad server markup
 * renders boolean prop with array value with server string render
 * renders boolean prop with array value with server stream render
 * renders boolean prop with array value with clean client render
 * renders boolean prop with array value with client render on top of good server markup
+* renders boolean prop with array value with client render on top of bad server markup
 * renders boolean prop with object value with server string render
 * renders boolean prop with object value with server stream render
 * renders boolean prop with object value with clean client render
 * renders boolean prop with object value with client render on top of good server markup
+* renders boolean prop with object value with client render on top of bad server markup
 * renders boolean prop with non-zero number value with server string render
 * renders boolean prop with non-zero number value with server stream render
 * renders boolean prop with non-zero number value with clean client render
 * renders boolean prop with non-zero number value with client render on top of good server markup
+* renders boolean prop with non-zero number value with client render on top of bad server markup
 * renders boolean prop with zero value with server string render
 * renders boolean prop with zero value with server stream render
 * renders boolean prop with zero value with clean client render
 * renders boolean prop with zero value with client render on top of good server markup
+* renders boolean prop with zero value with client render on top of bad server markup
 * renders download prop with true value with server string render
 * renders download prop with true value with server stream render
 * renders download prop with true value with clean client render
@@ -969,38 +983,47 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders className prop with string value with server stream render
 * renders className prop with string value with clean client render
 * renders className prop with string value with client render on top of good server markup
+* renders className prop with string value with client render on top of bad server markup
 * renders className prop with empty string value with server string render
 * renders className prop with empty string value with server stream render
 * renders className prop with empty string value with clean client render
 * renders className prop with empty string value with client render on top of good server markup
+* renders className prop with empty string value with client render on top of bad server markup
 * renders className prop with true value with server string render
 * renders className prop with true value with server stream render
 * renders className prop with true value with clean client render
 * renders className prop with true value with client render on top of good server markup
+* renders className prop with true value with client render on top of bad server markup
 * renders className prop with false value with server string render
 * renders className prop with false value with server stream render
 * renders className prop with false value with clean client render
 * renders className prop with false value with client render on top of good server markup
+* renders className prop with false value with client render on top of bad server markup
 * renders htmlFor with string value with server string render
 * renders htmlFor with string value with server stream render
 * renders htmlFor with string value with clean client render
 * renders htmlFor with string value with client render on top of good server markup
+* renders htmlFor with string value with client render on top of bad server markup
 * renders htmlFor with an empty string with server string render
 * renders htmlFor with an empty string with server stream render
 * renders htmlFor with an empty string with clean client render
 * renders htmlFor with an empty string with client render on top of good server markup
+* renders htmlFor with an empty string with client render on top of bad server markup
 * renders className prop with true value with server string render
 * renders className prop with true value with server stream render
 * renders className prop with true value with clean client render
 * renders className prop with true value with client render on top of good server markup
+* renders className prop with true value with client render on top of bad server markup
 * renders className prop with false value with server string render
 * renders className prop with false value with server stream render
 * renders className prop with false value with clean client render
 * renders className prop with false value with client render on top of good server markup
+* renders className prop with false value with client render on top of bad server markup
 * renders no ref attribute with server string render
 * renders no ref attribute with server stream render
 * renders no ref attribute with clean client render
 * renders no ref attribute with client render on top of good server markup
+* renders no ref attribute with client render on top of bad server markup
 * renders no children attribute with server string render
 * renders no children attribute with server stream render
 * renders no children attribute with clean client render
@@ -1010,18 +1033,22 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders no key attribute with server stream render
 * renders no key attribute with clean client render
 * renders no key attribute with client render on top of good server markup
+* renders no key attribute with client render on top of bad server markup
 * renders no dangerouslySetInnerHTML attribute with server string render
 * renders no dangerouslySetInnerHTML attribute with server stream render
 * renders no dangerouslySetInnerHTML attribute with clean client render
 * renders no dangerouslySetInnerHTML attribute with client render on top of good server markup
+* renders no dangerouslySetInnerHTML attribute with client render on top of bad server markup
 * renders no unknown attributes with server string render
 * renders no unknown attributes with server stream render
 * renders no unknown attributes with clean client render
 * renders no unknown attributes with client render on top of good server markup
+* renders no unknown attributes with client render on top of bad server markup
 * renders unknown data- attributes with server string render
 * renders unknown data- attributes with server stream render
 * renders unknown data- attributes with clean client render
 * renders unknown data- attributes with client render on top of good server markup
+* renders unknown data- attributes with client render on top of bad server markup
 * renders no unknown attributes for non-standard elements with server string render
 * renders no unknown attributes for non-standard elements with server stream render
 * renders no unknown attributes for non-standard elements with clean client render
@@ -1034,10 +1061,12 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders unknown attributes for custom elements using is with server stream render
 * renders unknown attributes for custom elements using is with clean client render
 * renders unknown attributes for custom elements using is with client render on top of good server markup
+* renders unknown attributes for custom elements using is with client render on top of bad server markup
 * renders no HTML events with server string render
 * renders no HTML events with server stream render
 * renders no HTML events with clean client render
 * renders no HTML events with client render on top of good server markup
+* renders no HTML events with client render on top of bad server markup
 * renders a div with text with server string render
 * renders a div with text with server stream render
 * renders a div with text with clean client render
@@ -1052,18 +1081,22 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a div with an empty text child with server stream render
 * renders a div with an empty text child with clean client render
 * renders a div with an empty text child with client render on top of good server markup
+* renders a div with an empty text child with client render on top of bad server markup
 * renders a div with multiple empty text children with server string render
 * renders a div with multiple empty text children with server stream render
 * renders a div with multiple empty text children with clean client render
 * renders a div with multiple empty text children with client render on top of good server markup
+* renders a div with multiple empty text children with client render on top of bad server markup
 * renders a div with multiple whitespace children with server string render
 * renders a div with multiple whitespace children with server stream render
 * renders a div with multiple whitespace children with clean client render
 * renders a div with multiple whitespace children with client render on top of good server markup
+* renders a div with multiple whitespace children with client render on top of bad server markup
 * renders a div with text sibling to a node with server string render
 * renders a div with text sibling to a node with server stream render
 * renders a div with text sibling to a node with clean client render
 * renders a div with text sibling to a node with client render on top of good server markup
+* renders a div with text sibling to a node with client render on top of bad server markup
 * renders a non-standard element with text with server string render
 * renders a non-standard element with text with server stream render
 * renders a non-standard element with text with clean client render
@@ -1076,14 +1109,17 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a leading blank child with a text sibling with server stream render
 * renders a leading blank child with a text sibling with clean client render
 * renders a leading blank child with a text sibling with client render on top of good server markup
+* renders a leading blank child with a text sibling with client render on top of bad server markup
 * renders a trailing blank child with a text sibling with server string render
 * renders a trailing blank child with a text sibling with server stream render
 * renders a trailing blank child with a text sibling with clean client render
 * renders a trailing blank child with a text sibling with client render on top of good server markup
+* renders a trailing blank child with a text sibling with client render on top of bad server markup
 * renders an element with two text children with server string render
 * renders an element with two text children with server stream render
 * renders an element with two text children with clean client render
 * renders an element with two text children with client render on top of good server markup
+* renders an element with two text children with client render on top of bad server markup
 * renders a number as single child with server string render
 * renders a number as single child with server stream render
 * renders a number as single child with clean client render
@@ -1098,38 +1134,47 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders an element with number and text children with server stream render
 * renders an element with number and text children with clean client render
 * renders an element with number and text children with client render on top of good server markup
+* renders an element with number and text children with client render on top of bad server markup
 * renders null single child as blank with server string render
 * renders null single child as blank with server stream render
 * renders null single child as blank with clean client render
 * renders null single child as blank with client render on top of good server markup
+* renders null single child as blank with client render on top of bad server markup
 * renders false single child as blank with server string render
 * renders false single child as blank with server stream render
 * renders false single child as blank with clean client render
 * renders false single child as blank with client render on top of good server markup
+* renders false single child as blank with client render on top of bad server markup
 * renders undefined single child as blank with server string render
 * renders undefined single child as blank with server stream render
 * renders undefined single child as blank with clean client render
 * renders undefined single child as blank with client render on top of good server markup
+* renders undefined single child as blank with client render on top of bad server markup
 * renders a null component children as empty with server string render
 * renders a null component children as empty with server stream render
 * renders a null component children as empty with clean client render
 * renders a null component children as empty with client render on top of good server markup
+* renders a null component children as empty with client render on top of bad server markup
 * renders null children as blank with server string render
 * renders null children as blank with server stream render
 * renders null children as blank with clean client render
 * renders null children as blank with client render on top of good server markup
+* renders null children as blank with client render on top of bad server markup
 * renders false children as blank with server string render
 * renders false children as blank with server stream render
 * renders false children as blank with clean client render
 * renders false children as blank with client render on top of good server markup
+* renders false children as blank with client render on top of bad server markup
 * renders null and false children together as blank with server string render
 * renders null and false children together as blank with server stream render
 * renders null and false children together as blank with clean client render
 * renders null and false children together as blank with client render on top of good server markup
+* renders null and false children together as blank with client render on top of bad server markup
 * renders only null and false children as blank with server string render
 * renders only null and false children as blank with server stream render
 * renders only null and false children as blank with clean client render
 * renders only null and false children as blank with client render on top of good server markup
+* renders only null and false children as blank with client render on top of bad server markup
 * renders an svg element with server string render
 * renders an svg element with server stream render
 * renders an svg element with clean client render
@@ -1154,6 +1199,7 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a div with dangerouslySetInnerHTML with server stream render
 * renders a div with dangerouslySetInnerHTML with clean client render
 * renders a div with dangerouslySetInnerHTML with client render on top of good server markup
+* renders a div with dangerouslySetInnerHTML with client render on top of bad server markup
 * renders a newline-eating tag with content not starting with \n with server string render
 * renders a newline-eating tag with content not starting with \n with server stream render
 * renders a newline-eating tag with content not starting with \n with clean client render
@@ -1186,26 +1232,32 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders single child hierarchies of components with server stream render
 * renders single child hierarchies of components with clean client render
 * renders single child hierarchies of components with client render on top of good server markup
+* renders single child hierarchies of components with client render on top of bad server markup
 * renders multi-child hierarchies of components with server string render
 * renders multi-child hierarchies of components with server stream render
 * renders multi-child hierarchies of components with clean client render
 * renders multi-child hierarchies of components with client render on top of good server markup
+* renders multi-child hierarchies of components with client render on top of bad server markup
 * renders a div with a child with server string render
 * renders a div with a child with server stream render
 * renders a div with a child with clean client render
 * renders a div with a child with client render on top of good server markup
+* renders a div with a child with client render on top of bad server markup
 * renders a div with multiple children with server string render
 * renders a div with multiple children with server stream render
 * renders a div with multiple children with clean client render
 * renders a div with multiple children with client render on top of good server markup
+* renders a div with multiple children with client render on top of bad server markup
 * renders a div with multiple children separated by whitespace with server string render
 * renders a div with multiple children separated by whitespace with server stream render
 * renders a div with multiple children separated by whitespace with clean client render
 * renders a div with multiple children separated by whitespace with client render on top of good server markup
+* renders a div with multiple children separated by whitespace with client render on top of bad server markup
 * renders a div with a single child surrounded by whitespace with server string render
 * renders a div with a single child surrounded by whitespace with server stream render
 * renders a div with a single child surrounded by whitespace with clean client render
 * renders a div with a single child surrounded by whitespace with client render on top of good server markup
+* renders a div with a single child surrounded by whitespace with client render on top of bad server markup
 * renders >,<, and & as single child with server string render
 * renders >,<, and & as single child with server stream render
 * renders >,<, and & as single child with clean client render
@@ -1215,6 +1267,7 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders >,<, and & as multiple children with server stream render
 * renders >,<, and & as multiple children with clean client render
 * renders >,<, and & as multiple children with client render on top of good server markup
+* renders >,<, and & as multiple children with client render on top of bad server markup
 * throws when rendering a string component with server string render
 * throws when rendering a string component with clean client render
 * throws when rendering a string component with client render on top of bad server markup
@@ -1371,18 +1424,22 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders class child without context with server stream render
 * renders class child without context with clean client render
 * renders class child without context with client render on top of good server markup
+* renders class child without context with client render on top of bad server markup
 * renders stateless child without context with server string render
 * renders stateless child without context with server stream render
 * renders stateless child without context with clean client render
 * renders stateless child without context with client render on top of good server markup
+* renders stateless child without context with client render on top of bad server markup
 * renders class child with wrong context with server string render
 * renders class child with wrong context with server stream render
 * renders class child with wrong context with clean client render
 * renders class child with wrong context with client render on top of good server markup
+* renders class child with wrong context with client render on top of bad server markup
 * renders stateless child with wrong context with server string render
 * renders stateless child with wrong context with server stream render
 * renders stateless child with wrong context with clean client render
 * renders stateless child with wrong context with client render on top of good server markup
+* renders stateless child with wrong context with client render on top of bad server markup
 * renders with context passed through to a grandchild with server string render
 * renders with context passed through to a grandchild with server stream render
 * renders with context passed through to a grandchild with clean client render
@@ -1397,6 +1454,7 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a child context merged with a parent context with server stream render
 * renders a child context merged with a parent context with clean client render
 * renders a child context merged with a parent context with client render on top of good server markup
+* renders a child context merged with a parent context with client render on top of bad server markup
 * renders with a call to componentWillMount before getChildContext with server string render
 * renders with a call to componentWillMount before getChildContext with server stream render
 * renders with a call to componentWillMount before getChildContext with clean client render
@@ -1421,10 +1479,14 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * should reconnect ES6 Class to Bare Element
 * should reconnect Pure Component to Bare Element
 * should reconnect Bare Element to Bare Element
+* should error reconnecting missing attributes
+* should error reconnecting added attributes
+* should error reconnecting different attribute values
 * should error reconnecting different text
 * should reconnect a div with a number and string version of number
 * should error reconnecting different numbers
 * should error reconnecting different number from text
+* should error reconnecting different text in two code blocks
 * should error reconnecting a div with children separated by different whitespace
 
 src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
@@ -1476,6 +1538,7 @@ src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
 * should generate comment markup for component returns null
 * should render composite components
 * should only execute certain lifecycle methods
+* should have the correct mounting behavior
 * should throw with silly args
 * should not put checksum and React ID on components
 * should not put checksum and React ID on text components

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1546,6 +1546,7 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * should error reconnecting a div with children separated by different whitespace
 * can distinguish an empty component from a dom node
 * can distinguish an empty component from an empty text component
+* should error reconnecting a div with different dangerouslySetInnerHTML
 
 src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
 * updates a mounted text component in place

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1373,26 +1373,32 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a textarea with a value and an onChange with server string render
 * renders a textarea with a value and an onChange with server stream render
 * renders a textarea with a value and an onChange with clean client render
+* renders a textarea with a value and an onChange with client render on top of good server markup
 * renders a textarea with a value and an onChange with client render on top of bad server markup
 * renders a textarea with a value and readOnly with server string render
 * renders a textarea with a value and readOnly with server stream render
 * renders a textarea with a value and readOnly with clean client render
+* renders a textarea with a value and readOnly with client render on top of good server markup
 * renders a textarea with a value and readOnly with client render on top of bad server markup
 * renders a textarea with a value and no onChange/readOnly with server string render
 * renders a textarea with a value and no onChange/readOnly with server stream render
 * renders a textarea with a value and no onChange/readOnly with clean client render
+* renders a textarea with a value and no onChange/readOnly with client render on top of good server markup
 * renders a textarea with a value and no onChange/readOnly with client render on top of bad server markup
 * renders a textarea with a defaultValue with server string render
 * renders a textarea with a defaultValue with server stream render
 * renders a textarea with a defaultValue with clean client render
+* renders a textarea with a defaultValue with client render on top of good server markup
 * renders a textarea with a defaultValue with client render on top of bad server markup
 * renders a textarea value overriding defaultValue with server string render
 * renders a textarea value overriding defaultValue with server stream render
 * renders a textarea value overriding defaultValue with clean client render
+* renders a textarea value overriding defaultValue with client render on top of good server markup
 * renders a textarea value overriding defaultValue with client render on top of bad server markup
 * renders a textarea value overriding defaultValue no matter the prop order with server string render
 * renders a textarea value overriding defaultValue no matter the prop order with server stream render
 * renders a textarea value overriding defaultValue no matter the prop order with clean client render
+* renders a textarea value overriding defaultValue no matter the prop order with client render on top of good server markup
 * renders a textarea value overriding defaultValue no matter the prop order with client render on top of bad server markup
 * renders a select with a value and an onChange with server string render
 * renders a select with a value and an onChange with server stream render
@@ -1438,6 +1444,7 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a controlled text input with client render on top of good server markup
 * renders a controlled text input with client render on top of bad server markup
 * renders a controlled textarea with clean client render
+* renders a controlled textarea with client render on top of good server markup
 * renders a controlled textarea with client render on top of bad server markup
 * renders a controlled checkbox with clean client render
 * renders a controlled checkbox with client render on top of good server markup

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1545,6 +1545,7 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * should error reconnecting a div with children separated by different whitespace on the server
 * should error reconnecting a div with children separated by different whitespace
 * can distinguish an empty component from a dom node
+* can distinguish an empty component from an empty text component
 
 src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
 * updates a mounted text component in place

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1567,6 +1567,7 @@ src/renderers/dom/shared/__tests__/ReactMount-test.js
 * should reuse markup if rendering to the same target twice
 * should not warn if mounting into non-empty node
 * should warn when mounting into document.body
+* should account for escaping on a checksum mismatch
 * should warn if render removes React-rendered children
 * should warn if the unmounted node was rendered by another copy of React
 * passes the correct callback context

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1565,6 +1565,7 @@ src/renderers/dom/shared/__tests__/ReactMount-test.js
 * should render different components in same root
 * should unmount and remount if the key changes
 * should reuse markup if rendering to the same target twice
+* should warn if mounting into dirty rendered markup
 * should not warn if mounting into non-empty node
 * should warn when mounting into document.body
 * should account for escaping on a checksum mismatch

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -895,6 +895,7 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a self-closing tag with server stream render
 * renders a self-closing tag with clean client render
 * renders a self-closing tag with client render on top of good server markup
+* renders a self-closing tag with client render on top of bad server markup
 * renders a self-closing tag as a child with server string render
 * renders a self-closing tag as a child with server stream render
 * renders a self-closing tag as a child with clean client render
@@ -914,10 +915,12 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders string prop with true value with server stream render
 * renders string prop with true value with clean client render
 * renders string prop with true value with client render on top of good server markup
+* renders string prop with true value with client render on top of bad server markup
 * renders string prop with false value with server string render
 * renders string prop with false value with server stream render
 * renders string prop with false value with clean client render
 * renders string prop with false value with client render on top of good server markup
+* renders string prop with false value with client render on top of bad server markup
 * renders boolean prop with true value with server string render
 * renders boolean prop with true value with server stream render
 * renders boolean prop with true value with clean client render
@@ -967,18 +970,22 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders download prop with true value with server stream render
 * renders download prop with true value with clean client render
 * renders download prop with true value with client render on top of good server markup
+* renders download prop with true value with client render on top of bad server markup
 * renders download prop with false value with server string render
 * renders download prop with false value with server stream render
 * renders download prop with false value with clean client render
 * renders download prop with false value with client render on top of good server markup
+* renders download prop with false value with client render on top of bad server markup
 * renders download prop with string value with server string render
 * renders download prop with string value with server stream render
 * renders download prop with string value with clean client render
 * renders download prop with string value with client render on top of good server markup
+* renders download prop with string value with client render on top of bad server markup
 * renders download prop with string "true" value with server string render
 * renders download prop with string "true" value with server stream render
 * renders download prop with string "true" value with clean client render
 * renders download prop with string "true" value with client render on top of good server markup
+* renders download prop with string "true" value with client render on top of bad server markup
 * renders className prop with string value with server string render
 * renders className prop with string value with server stream render
 * renders className prop with string value with clean client render
@@ -1053,10 +1060,12 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders no unknown attributes for non-standard elements with server stream render
 * renders no unknown attributes for non-standard elements with clean client render
 * renders no unknown attributes for non-standard elements with client render on top of good server markup
+* renders no unknown attributes for non-standard elements with client render on top of bad server markup
 * renders unknown attributes for custom elements with server string render
 * renders unknown attributes for custom elements with server stream render
 * renders unknown attributes for custom elements with clean client render
 * renders unknown attributes for custom elements with client render on top of good server markup
+* renders unknown attributes for custom elements with client render on top of bad server markup
 * renders unknown attributes for custom elements using is with server string render
 * renders unknown attributes for custom elements using is with server stream render
 * renders unknown attributes for custom elements using is with clean client render
@@ -1101,10 +1110,12 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a non-standard element with text with server stream render
 * renders a non-standard element with text with clean client render
 * renders a non-standard element with text with client render on top of good server markup
+* renders a non-standard element with text with client render on top of bad server markup
 * renders a custom element with text with server string render
 * renders a custom element with text with server stream render
 * renders a custom element with text with clean client render
 * renders a custom element with text with client render on top of good server markup
+* renders a custom element with text with client render on top of bad server markup
 * renders a leading blank child with a text sibling with server string render
 * renders a leading blank child with a text sibling with server stream render
 * renders a leading blank child with a text sibling with clean client render
@@ -1179,22 +1190,27 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders an svg element with server stream render
 * renders an svg element with clean client render
 * renders an svg element with client render on top of good server markup
+* renders an svg element with client render on top of bad server markup
 * renders svg element with an xlink with server string render
 * renders svg element with an xlink with server stream render
 * renders svg element with an xlink with clean client render
 * renders svg element with an xlink with client render on top of good server markup
+* renders svg element with an xlink with client render on top of bad server markup
 * renders a math element with server string render
 * renders a math element with server stream render
 * renders a math element with clean client render
 * renders a math element with client render on top of good server markup
+* renders a math element with client render on top of bad server markup
 * renders an img with server string render
 * renders an img with server stream render
 * renders an img with clean client render
 * renders an img with client render on top of good server markup
+* renders an img with client render on top of bad server markup
 * renders a button with server string render
 * renders a button with server stream render
 * renders a button with clean client render
 * renders a button with client render on top of good server markup
+* renders a button with client render on top of bad server markup
 * renders a div with dangerouslySetInnerHTML with server string render
 * renders a div with dangerouslySetInnerHTML with server stream render
 * renders a div with dangerouslySetInnerHTML with clean client render
@@ -1204,10 +1220,12 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a newline-eating tag with content not starting with \n with server stream render
 * renders a newline-eating tag with content not starting with \n with clean client render
 * renders a newline-eating tag with content not starting with \n with client render on top of good server markup
+* renders a newline-eating tag with content not starting with \n with client render on top of bad server markup
 * renders a newline-eating tag with content starting with \n with server string render
 * renders a newline-eating tag with content starting with \n with server stream render
 * renders a newline-eating tag with content starting with \n with clean client render
 * renders a newline-eating tag with content starting with \n with client render on top of good server markup
+* renders a newline-eating tag with content starting with \n with client render on top of bad server markup
 * renders a normal tag with content starting with \n with server string render
 * renders a normal tag with content starting with \n with server stream render
 * renders a normal tag with content starting with \n with clean client render
@@ -1296,114 +1314,137 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders an input with a value and an onChange with server stream render
 * renders an input with a value and an onChange with clean client render
 * renders an input with a value and an onChange with client render on top of good server markup
+* renders an input with a value and an onChange with client render on top of bad server markup
 * renders an input with a value and readOnly with server string render
 * renders an input with a value and readOnly with server stream render
 * renders an input with a value and readOnly with clean client render
 * renders an input with a value and readOnly with client render on top of good server markup
+* renders an input with a value and readOnly with client render on top of bad server markup
 * renders an input with a value and no onChange/readOnly with server string render
 * renders an input with a value and no onChange/readOnly with server stream render
 * renders an input with a value and no onChange/readOnly with clean client render
 * renders an input with a value and no onChange/readOnly with client render on top of good server markup
+* renders an input with a value and no onChange/readOnly with client render on top of bad server markup
 * renders an input with a defaultValue with server string render
 * renders an input with a defaultValue with server stream render
 * renders an input with a defaultValue with clean client render
 * renders an input with a defaultValue with client render on top of good server markup
+* renders an input with a defaultValue with client render on top of bad server markup
 * renders an input value overriding defaultValue with server string render
 * renders an input value overriding defaultValue with server stream render
 * renders an input value overriding defaultValue with clean client render
 * renders an input value overriding defaultValue with client render on top of good server markup
+* renders an input value overriding defaultValue with client render on top of bad server markup
 * renders an input value overriding defaultValue no matter the prop order with server string render
 * renders an input value overriding defaultValue no matter the prop order with server stream render
 * renders an input value overriding defaultValue no matter the prop order with clean client render
 * renders an input value overriding defaultValue no matter the prop order with client render on top of good server markup
+* renders an input value overriding defaultValue no matter the prop order with client render on top of bad server markup
 * renders a checkbox that is checked with an onChange with server string render
 * renders a checkbox that is checked with an onChange with server stream render
 * renders a checkbox that is checked with an onChange with clean client render
 * renders a checkbox that is checked with an onChange with client render on top of good server markup
+* renders a checkbox that is checked with an onChange with client render on top of bad server markup
 * renders a checkbox that is checked with readOnly with server string render
 * renders a checkbox that is checked with readOnly with server stream render
 * renders a checkbox that is checked with readOnly with clean client render
 * renders a checkbox that is checked with readOnly with client render on top of good server markup
+* renders a checkbox that is checked with readOnly with client render on top of bad server markup
 * renders a checkbox that is checked and no onChange/readOnly with server string render
 * renders a checkbox that is checked and no onChange/readOnly with server stream render
 * renders a checkbox that is checked and no onChange/readOnly with clean client render
 * renders a checkbox that is checked and no onChange/readOnly with client render on top of good server markup
+* renders a checkbox that is checked and no onChange/readOnly with client render on top of bad server markup
 * renders a checkbox with defaultChecked with server string render
 * renders a checkbox with defaultChecked with server stream render
 * renders a checkbox with defaultChecked with clean client render
 * renders a checkbox with defaultChecked with client render on top of good server markup
+* renders a checkbox with defaultChecked with client render on top of bad server markup
 * renders a checkbox checked overriding defaultChecked with server string render
 * renders a checkbox checked overriding defaultChecked with server stream render
 * renders a checkbox checked overriding defaultChecked with clean client render
 * renders a checkbox checked overriding defaultChecked with client render on top of good server markup
+* renders a checkbox checked overriding defaultChecked with client render on top of bad server markup
 * renders a checkbox checked overriding defaultChecked no matter the prop order with server string render
 * renders a checkbox checked overriding defaultChecked no matter the prop order with server stream render
 * renders a checkbox checked overriding defaultChecked no matter the prop order with clean client render
 * renders a checkbox checked overriding defaultChecked no matter the prop order with client render on top of good server markup
+* renders a checkbox checked overriding defaultChecked no matter the prop order with client render on top of bad server markup
 * renders a textarea with a value and an onChange with server string render
 * renders a textarea with a value and an onChange with server stream render
 * renders a textarea with a value and an onChange with clean client render
-* renders a textarea with a value and an onChange with client render on top of good server markup
+* renders a textarea with a value and an onChange with client render on top of bad server markup
 * renders a textarea with a value and readOnly with server string render
 * renders a textarea with a value and readOnly with server stream render
 * renders a textarea with a value and readOnly with clean client render
-* renders a textarea with a value and readOnly with client render on top of good server markup
+* renders a textarea with a value and readOnly with client render on top of bad server markup
 * renders a textarea with a value and no onChange/readOnly with server string render
 * renders a textarea with a value and no onChange/readOnly with server stream render
 * renders a textarea with a value and no onChange/readOnly with clean client render
-* renders a textarea with a value and no onChange/readOnly with client render on top of good server markup
+* renders a textarea with a value and no onChange/readOnly with client render on top of bad server markup
 * renders a textarea with a defaultValue with server string render
 * renders a textarea with a defaultValue with server stream render
 * renders a textarea with a defaultValue with clean client render
-* renders a textarea with a defaultValue with client render on top of good server markup
+* renders a textarea with a defaultValue with client render on top of bad server markup
 * renders a textarea value overriding defaultValue with server string render
 * renders a textarea value overriding defaultValue with server stream render
 * renders a textarea value overriding defaultValue with clean client render
-* renders a textarea value overriding defaultValue with client render on top of good server markup
+* renders a textarea value overriding defaultValue with client render on top of bad server markup
 * renders a textarea value overriding defaultValue no matter the prop order with server string render
 * renders a textarea value overriding defaultValue no matter the prop order with server stream render
 * renders a textarea value overriding defaultValue no matter the prop order with clean client render
-* renders a textarea value overriding defaultValue no matter the prop order with client render on top of good server markup
+* renders a textarea value overriding defaultValue no matter the prop order with client render on top of bad server markup
 * renders a select with a value and an onChange with server string render
 * renders a select with a value and an onChange with server stream render
 * renders a select with a value and an onChange with clean client render
 * renders a select with a value and an onChange with client render on top of good server markup
+* renders a select with a value and an onChange with client render on top of bad server markup
 * renders a select with a value and readOnly with server string render
 * renders a select with a value and readOnly with server stream render
 * renders a select with a value and readOnly with clean client render
 * renders a select with a value and readOnly with client render on top of good server markup
+* renders a select with a value and readOnly with client render on top of bad server markup
 * renders a select with a multiple values and an onChange with server string render
 * renders a select with a multiple values and an onChange with server stream render
 * renders a select with a multiple values and an onChange with clean client render
 * renders a select with a multiple values and an onChange with client render on top of good server markup
+* renders a select with a multiple values and an onChange with client render on top of bad server markup
 * renders a select with a multiple values and readOnly with server string render
 * renders a select with a multiple values and readOnly with server stream render
 * renders a select with a multiple values and readOnly with clean client render
 * renders a select with a multiple values and readOnly with client render on top of good server markup
+* renders a select with a multiple values and readOnly with client render on top of bad server markup
 * renders a select with a value and no onChange/readOnly with server string render
 * renders a select with a value and no onChange/readOnly with server stream render
 * renders a select with a value and no onChange/readOnly with clean client render
 * renders a select with a value and no onChange/readOnly with client render on top of good server markup
+* renders a select with a value and no onChange/readOnly with client render on top of bad server markup
 * renders a select with a defaultValue with server string render
 * renders a select with a defaultValue with server stream render
 * renders a select with a defaultValue with clean client render
 * renders a select with a defaultValue with client render on top of good server markup
+* renders a select with a defaultValue with client render on top of bad server markup
 * renders a select value overriding defaultValue with server string render
 * renders a select value overriding defaultValue with server stream render
 * renders a select value overriding defaultValue with clean client render
 * renders a select value overriding defaultValue with client render on top of good server markup
+* renders a select value overriding defaultValue with client render on top of bad server markup
 * renders a select value overriding defaultValue no matter the prop order with server string render
 * renders a select value overriding defaultValue no matter the prop order with server stream render
 * renders a select value overriding defaultValue no matter the prop order with clean client render
 * renders a select value overriding defaultValue no matter the prop order with client render on top of good server markup
+* renders a select value overriding defaultValue no matter the prop order with client render on top of bad server markup
 * renders a controlled text input with clean client render
 * renders a controlled text input with client render on top of good server markup
+* renders a controlled text input with client render on top of bad server markup
 * renders a controlled textarea with clean client render
-* renders a controlled textarea with client render on top of good server markup
+* renders a controlled textarea with client render on top of bad server markup
 * renders a controlled checkbox with clean client render
 * renders a controlled checkbox with client render on top of good server markup
+* renders a controlled checkbox with client render on top of bad server markup
 * renders a controlled select with clean client render
 * renders a controlled select with client render on top of good server markup
+* renders a controlled select with client render on top of bad server markup
 * should not blow away user-entered text on successful reconnect to an uncontrolled input
 * should not blow away user-entered text on successful reconnect to a controlled input
 * should not blow away user-entered text on successful reconnect to an uncontrolled checkbox
@@ -1479,6 +1520,7 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * should reconnect ES6 Class to Bare Element
 * should reconnect Pure Component to Bare Element
 * should reconnect Bare Element to Bare Element
+* should error reconnecting different element types
 * should error reconnecting missing attributes
 * should error reconnecting added attributes
 * should error reconnecting different attribute values
@@ -1487,7 +1529,15 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * should error reconnecting different numbers
 * should error reconnecting different number from text
 * should error reconnecting different text in two code blocks
+* should error reconnecting missing children
+* should error reconnecting added children
+* should error reconnecting more children
+* should error reconnecting fewer children
+* should error reconnecting reordered children
+* should error reconnecting a div with children separated by whitespace on the client
+* should error reconnecting a div with children separated by different whitespace on the server
 * should error reconnecting a div with children separated by different whitespace
+* can distinguish an empty component from a dom node
 
 src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
 * updates a mounted text component in place

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1005,6 +1005,7 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders no children attribute with server stream render
 * renders no children attribute with clean client render
 * renders no children attribute with client render on top of good server markup
+* renders no children attribute with client render on top of bad server markup
 * renders no key attribute with server string render
 * renders no key attribute with server stream render
 * renders no key attribute with clean client render
@@ -1041,10 +1042,12 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a div with text with server stream render
 * renders a div with text with clean client render
 * renders a div with text with client render on top of good server markup
+* renders a div with text with client render on top of bad server markup
 * renders a div with text with flanking whitespace with server string render
 * renders a div with text with flanking whitespace with server stream render
 * renders a div with text with flanking whitespace with clean client render
 * renders a div with text with flanking whitespace with client render on top of good server markup
+* renders a div with text with flanking whitespace with client render on top of bad server markup
 * renders a div with an empty text child with server string render
 * renders a div with an empty text child with server stream render
 * renders a div with an empty text child with clean client render
@@ -1085,10 +1088,12 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a number as single child with server stream render
 * renders a number as single child with clean client render
 * renders a number as single child with client render on top of good server markup
+* renders a number as single child with client render on top of bad server markup
 * renders zero as single child with server string render
 * renders zero as single child with server stream render
 * renders zero as single child with clean client render
 * renders zero as single child with client render on top of good server markup
+* renders zero as single child with client render on top of bad server markup
 * renders an element with number and text children with server string render
 * renders an element with number and text children with server stream render
 * renders an element with number and text children with clean client render
@@ -1161,18 +1166,22 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a normal tag with content starting with \n with server stream render
 * renders a normal tag with content starting with \n with clean client render
 * renders a normal tag with content starting with \n with client render on top of good server markup
+* renders a normal tag with content starting with \n with client render on top of bad server markup
 * renders stateless components with server string render
 * renders stateless components with server stream render
 * renders stateless components with clean client render
 * renders stateless components with client render on top of good server markup
+* renders stateless components with client render on top of bad server markup
 * renders ES6 class components with server string render
 * renders ES6 class components with server stream render
 * renders ES6 class components with clean client render
 * renders ES6 class components with client render on top of good server markup
+* renders ES6 class components with client render on top of bad server markup
 * renders factory components with server string render
 * renders factory components with server stream render
 * renders factory components with clean client render
 * renders factory components with client render on top of good server markup
+* renders factory components with client render on top of bad server markup
 * renders single child hierarchies of components with server string render
 * renders single child hierarchies of components with server stream render
 * renders single child hierarchies of components with clean client render
@@ -1201,6 +1210,7 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders >,<, and & as single child with server stream render
 * renders >,<, and & as single child with clean client render
 * renders >,<, and & as single child with client render on top of good server markup
+* renders >,<, and & as single child with client render on top of bad server markup
 * renders >,<, and & as multiple children with server string render
 * renders >,<, and & as multiple children with server stream render
 * renders >,<, and & as multiple children with clean client render
@@ -1351,10 +1361,12 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders class child with context with server stream render
 * renders class child with context with clean client render
 * renders class child with context with client render on top of good server markup
+* renders class child with context with client render on top of bad server markup
 * renders stateless child with context with server string render
 * renders stateless child with context with server stream render
 * renders stateless child with context with clean client render
 * renders stateless child with context with client render on top of good server markup
+* renders stateless child with context with client render on top of bad server markup
 * renders class child without context with server string render
 * renders class child without context with server stream render
 * renders class child without context with clean client render
@@ -1375,10 +1387,12 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders with context passed through to a grandchild with server stream render
 * renders with context passed through to a grandchild with clean client render
 * renders with context passed through to a grandchild with client render on top of good server markup
+* renders with context passed through to a grandchild with client render on top of bad server markup
 * renders a child context overriding a parent context with server string render
 * renders a child context overriding a parent context with server stream render
 * renders a child context overriding a parent context with clean client render
 * renders a child context overriding a parent context with client render on top of good server markup
+* renders a child context overriding a parent context with client render on top of bad server markup
 * renders a child context merged with a parent context with server string render
 * renders a child context merged with a parent context with server stream render
 * renders a child context merged with a parent context with clean client render
@@ -1387,6 +1401,7 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders with a call to componentWillMount before getChildContext with server stream render
 * renders with a call to componentWillMount before getChildContext with clean client render
 * renders with a call to componentWillMount before getChildContext with client render on top of good server markup
+* renders with a call to componentWillMount before getChildContext with client render on top of bad server markup
 * throws when rendering if getChildContext exists without childContextTypes with server string render
 * throws when rendering if getChildContext exists without childContextTypes with clean client render
 * throws when rendering if getChildContext exists without childContextTypes with client render on top of bad server markup
@@ -1406,7 +1421,11 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * should reconnect ES6 Class to Bare Element
 * should reconnect Pure Component to Bare Element
 * should reconnect Bare Element to Bare Element
+* should error reconnecting different text
 * should reconnect a div with a number and string version of number
+* should error reconnecting different numbers
+* should error reconnecting different number from text
+* should error reconnecting a div with children separated by different whitespace
 
 src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
 * updates a mounted text component in place

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -972,6 +972,80 @@ var ReactDOMFiberComponent = {
     return isDifferent;
   },
 
+  warnForDeletedHydratableElement(
+    parentNode: Element | Document,
+    child: Element,
+  ) {
+    if (__DEV__) {
+      if (didWarnInvalidHydration) {
+        return;
+      }
+      didWarnInvalidHydration = true;
+      warning(
+        false,
+        'Did not expect server HTML to contain a <%s> in <%s>.',
+        child.nodeName.toLowerCase(),
+        parentNode.nodeName.toLowerCase(),
+      );
+    }
+  },
+
+  warnForDeletedHydratableText(parentNode: Element | Document, child: Text) {
+    if (__DEV__) {
+      if (didWarnInvalidHydration) {
+        return;
+      }
+      didWarnInvalidHydration = true;
+      warning(
+        false,
+        'Did not expect server HTML to contain the text node "%s" in <%s>.',
+        child.nodeValue,
+        parentNode.nodeName.toLowerCase(),
+      );
+    }
+  },
+
+  warnForInsertedHydratedElement(
+    parentNode: Element | Document,
+    tag: string,
+    props: Object,
+  ) {
+    if (__DEV__) {
+      if (didWarnInvalidHydration) {
+        return;
+      }
+      didWarnInvalidHydration = true;
+      warning(
+        false,
+        'Did not find a matching <%s> in <%s>.',
+        tag,
+        parentNode.nodeName.toLowerCase(),
+      );
+    }
+  },
+
+  warnForInsertedHydratedText(parentNode: Element | Document, text: string) {
+    if (__DEV__) {
+      if (text === '') {
+        // We expect to insert empty text nodes since they're not represented in
+        // the HTML.
+        // TODO: Remove this special case if we can just avoid inserting empty
+        // text nodes.
+        return;
+      }
+      if (didWarnInvalidHydration) {
+        return;
+      }
+      didWarnInvalidHydration = true;
+      warning(
+        false,
+        'Did not find a matching text node for "%s" in <%s>.',
+        text,
+        parentNode.nodeName.toLowerCase(),
+      );
+    }
+  },
+
   restoreControlledState(
     domElement: Element,
     tag: string,

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -319,6 +319,7 @@ var DOMRenderer = ReactFiberReconciler({
 
   shouldSetTextContent(type: string, props: Props): boolean {
     return (
+      type === 'textarea' ||
       typeof props.children === 'string' ||
       typeof props.children === 'number' ||
       (typeof props.dangerouslySetInnerHTML === 'object' &&

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -51,6 +51,7 @@ var {
   diffProperties,
   updateProperties,
   diffHydratedProperties,
+  diffHydratedText,
 } = ReactDOMFiberComponent;
 var {precacheFiberNode, updateFiberProps} = ReactDOMComponentTree;
 
@@ -475,7 +476,7 @@ var DOMRenderer = ReactFiberReconciler({
     internalInstanceHandle: Object,
   ): boolean {
     precacheFiberNode(internalInstanceHandle, textInstance);
-    return textInstance.nodeValue !== text;
+    return diffHydratedText(textInstance, text);
   },
 
   scheduleDeferredCallback: ReactDOMFrameScheduling.rIC,

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -52,6 +52,10 @@ var {
   updateProperties,
   diffHydratedProperties,
   diffHydratedText,
+  warnForDeletedHydratableElement,
+  warnForDeletedHydratableText,
+  warnForInsertedHydratedElement,
+  warnForInsertedHydratedText,
 } = ReactDOMFiberComponent;
 var {precacheFiberNode, updateFiberProps} = ReactDOMComponentTree;
 
@@ -477,6 +481,32 @@ var DOMRenderer = ReactFiberReconciler({
   ): boolean {
     precacheFiberNode(internalInstanceHandle, textInstance);
     return diffHydratedText(textInstance, text);
+  },
+
+  didNotHydrateInstance(
+    parentInstance: Instance | Container,
+    instance: Instance | TextInstance,
+  ) {
+    if (instance.nodeType === 1) {
+      warnForDeletedHydratableElement(parentInstance, (instance: any));
+    } else {
+      warnForDeletedHydratableText(parentInstance, (instance: any));
+    }
+  },
+
+  didNotFindHydratableInstance(
+    parentInstance: Instance | Container,
+    type: string,
+    props: Props,
+  ) {
+    warnForInsertedHydratedElement(parentInstance, type, props);
+  },
+
+  didNotFindHydratableTextInstance(
+    parentInstance: Instance | Container,
+    text: string,
+  ) {
+    warnForInsertedHydratedText(parentInstance, text);
   },
 
   scheduleDeferredCallback: ReactDOMFrameScheduling.rIC,

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -2142,7 +2142,12 @@ describe('ReactDOMServerIntegration', () => {
         ));
 
       it('can distinguish an empty component from an empty text component', () =>
-        expectMarkupMismatch(<div><EmptyComponent /></div>, <div>{''}</div>));
+        (ReactDOMFeatureFlags.useFiber
+          ? expectMarkupMatch
+          : expectMarkupMismatch)(
+          <div><EmptyComponent /></div>,
+          <div>{''}</div>,
+        ));
     });
 
     // Markup Mismatches: misc

--- a/src/renderers/dom/shared/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactMount-test.js
@@ -153,6 +153,8 @@ describe('ReactMount', () => {
     ReactDOM.render(<div />, container);
     expectDev(console.error.calls.count()).toBe(1);
 
+    ReactDOM.unmountComponentAtNode(container);
+
     container.innerHTML = ' ' + ReactDOMServer.renderToString(<div />);
 
     ReactDOM.render(<div />, container);

--- a/src/renderers/dom/shared/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactMount-test.js
@@ -194,10 +194,17 @@ describe('ReactMount', () => {
       div,
     );
     expectDev(console.error.calls.count()).toBe(1);
-    expectDev(console.error.calls.argsFor(0)[0]).toContain(
-      ' (client) nbsp entity: &nbsp; client text</div>\n' +
-        ' (server) nbsp entity: &nbsp; server text</div>',
-    );
+    if (ReactDOMFeatureFlags.useFiber) {
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        'Server: "This markup contains an nbsp entity:   server text" ' +
+          'Client: "This markup contains an nbsp entity:   client text"',
+      );
+    } else {
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        ' (client) nbsp entity: &nbsp; client text</div>\n' +
+          ' (server) nbsp entity: &nbsp; server text</div>',
+      );
+    }
   });
 
   if (WebComponents !== undefined) {

--- a/src/renderers/dom/shared/__tests__/ReactRenderDocument-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactRenderDocument-test.js
@@ -207,8 +207,13 @@ describe('rendering React components at document', () => {
     var testDocument = getTestDocument(markup);
 
     if (ReactDOMFeatureFlags.useFiber) {
+      spyOn(console, 'error');
       ReactDOM.render(<Component text="Hello world" />, testDocument);
       expect(testDocument.body.innerHTML).toBe('Hello world');
+      expectDev(console.error.calls.count()).toBe(1);
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        'Warning: Text content did not match.',
+      );
     } else {
       expect(function() {
         // Notice the text is different!

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -138,6 +138,16 @@ export type HostConfig<T, P, I, TI, PI, C, CX, PL> = {
     text: string,
     internalInstanceHandle: OpaqueHandle,
   ) => boolean,
+  didNotHydrateInstance?: (parentInstance: I | C, instance: I | TI) => void,
+  didNotFindHydratableInstance?: (
+    parentInstance: I | C,
+    type: T,
+    props: P,
+  ) => void,
+  didNotFindHydratableTextInstance?: (
+    parentInstance: I | C,
+    text: string,
+  ) => void,
 
   useSyncScheduling?: boolean,
 };


### PR DESCRIPTION
In the new hydration strategy we do our best to recover when the server response isn't valid but we don't check the attributes. However, we should still warn in DEV because that can end up pretty bad.

This starts adding warnings for those cases. I still have several steps left but this can ideally be landed at any midway point if someone wants to review it.

- [x] Warn for differences in text content.
- [x] Warn for known props that have different values.
- [x] Warn for extra attributes that are not known.
- [x] Warn for dangerouslySetInnerHTML differences.
- [x] Warn for extra nodes that will be deleted.
- [x] Warn for missing nodes that will have a new node inserted.

Left this for a follow up PR.

- [ ] Warn for inline styles that have different values.
- [ ] Add more text coverage for individual attribute mismatches, insert/delete, style mismatches, single child text content mismatches.
- [ ] Consolidate multiple warnings into a single warn (ideally with a HTML diff like format) instead of just warning for one difference at a time.
