### PR TITLE
Documentation: ReactDOMStream is an "object", not a "class".

### DIFF
--- a/docs/docs/reference-react-dom-server.md
+++ b/docs/docs/reference-react-dom-server.md
@@ -10,7 +10,7 @@ If you load React from a `<script>` tag, these top-level APIs are available on t
 
 ## Overview
 
-The `ReactDOMServer` class allows you to render your components on the server.
+The `ReactDOMServer` object allows you to render your components on the server.
 
  - [`renderToString()`](#rendertostring)
  - [`renderToStaticMarkup()`](#rendertostaticmarkup)


### PR DESCRIPTION
In code review comment https://github.com/facebook/react/pull/10024#discussion_r123649131 , @gaearon correctly pointed out that the proposed documentation for `ReactDOMNodeStream` is not really a class. I had copied and pasted that incorrect doc from `ReactDOMServer`'s documentation, so I thought we should fix it there, too. That's all this PR does.
