### PR TITLE
Exclude src/node_modules from .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ chrome-user-data
 *.swp
 *.swo
 *react*min*.js
+!src/node_modules


### PR DESCRIPTION
`src/node_modules` is a directory of package stubs that is checked in for the test suite to use. Unfortunately, though, there is a `node_modules` line in `.gitignore`, which means the `src/node_modules` directory is ignored by git.

I ran into this in #10024, where I had to add a new file to `src/node_modules`, but because of the `.gitignore`, I failed to commit the new file. (Obviously, neither `git commit -a` nor `git stage -A` will add an ignored file.) My failure to commit the new file lead to a confusing situation where tests were working locally but not in CI, and it took me an hour or two to figure out what was going on.

This PR just excludes `src/node_modules` from `.gitignore` so that this kind of thing won't happen again.

Thanks for all your work!