### PR TITLE
Use boolean assertion for documentMode check

### DIFF
--- a/src/renderers/dom/client/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/client/eventPlugins/ChangeEventPlugin.js
@@ -156,7 +156,7 @@ if (ExecutionEnvironment.canUseDOM) {
 
   isInputEventSupported =
     isEventSupported('input') &&
-    (!('documentMode' in document) || document.documentMode > 9);
+    (!document.documentMode || document.documentMode > 9);
 }
 
 /**


### PR DESCRIPTION
Resolves #10030 

Reverts a small change made in https://github.com/facebook/react/pull/8575. This should be safe, as [we still use this assertion for the change event bubbling check](https://github.com/facebook/react/blob/v15.6.1/src/renderers/dom/client/eventPlugins/ChangeEventPlugin.js#L77).

cc @flarnie @gaearon this will require another 15.6.x release (not sure if one was planned)