### PR TITLE
[docs/jsx-in-depth] Add reference to the Repeat component repo

### DIFF
--- a/docs/docs/jsx-in-depth.md
+++ b/docs/docs/jsx-in-depth.md
@@ -370,6 +370,8 @@ function ListOfTenThings() {
 
 Children passed to a custom component can be anything, as long as that component transforms them into something React can understand before rendering. This usage is not common, but it works if you want to stretch what JSX is capable of.
 
+_Note: a ready to use implementation of the `Repeat` component can be found [here](https://github.com/nuragic/react-repeat-component)._
+
 ### Booleans, Null, and Undefined Are Ignored
 
 `false`, `null`, `undefined`, and `true` are valid children. They simply don't render. These JSX expressions will all render to the same thing:


### PR DESCRIPTION
Hi,

I think that perhaps it would be useful for people to found a link to the ready to use `Repeat` component directly from the corresponding docs section. 💭 

Any comment is welcomed and appreciated.

Thanks! :hugs: 