### PR TITLE
Run prettier over the codebase to reduce CI problems.

### DIFF
--- a/scripts/jest/test-framework-setup.js
+++ b/scripts/jest/test-framework-setup.js
@@ -36,9 +36,10 @@ env.beforeEach(() => {
         compare(actual) {
           return {
             pass: callCount === 0,
-            message: 'Expected test not to warn. If the warning is expected, mock ' +
-              "it out using spyOn(console, 'error'); and test that the " +
-              'warning occurs.',
+            message:
+              'Expected test not to warn. If the warning is expected, mock ' +
+                "it out using spyOn(console, 'error'); and test that the " +
+                'warning occurs.',
           };
         },
       };

--- a/scripts/release-manager/commands/init.js
+++ b/scripts/release-manager/commands/init.js
@@ -27,7 +27,9 @@ module.exports = function(vorpal, app) {
             {
               name: 'githubToken',
               type: 'input',
-              message: `${chalk.bold('GitHub token?')} ${chalk.grey('(needs "repo" privs)')} `,
+              message: `${chalk.bold('GitHub token?')} ${chalk.grey(
+                '(needs "repo" privs)'
+              )} `,
             },
             {
               name: 'reactPath',

--- a/scripts/release-manager/commands/npm-check-access.js
+++ b/scripts/release-manager/commands/npm-check-access.js
@@ -27,7 +27,9 @@ module.exports = function(vorpal, app) {
 
         if (packagesNeedingAccess.length) {
           this.log(
-            `${chalk.red('FAILED')} You don't have access to all of the packages ` +
+            `${chalk.red(
+              'FAILED'
+            )} You don't have access to all of the packages ` +
               `you need. We just opened a URL to file a new issue requesting access.`
           );
           opn(

--- a/scripts/release-manager/commands/npm-grant-access.js
+++ b/scripts/release-manager/commands/npm-grant-access.js
@@ -27,11 +27,15 @@ module.exports = function(vorpal, app) {
 
           if (packagesNeedingAccess.length) {
             this.log(
-              `${chalk.yellow('PENDING')} Granting access to ${packagesNeedingAccess}`
+              `${chalk.yellow(
+                'PENDING'
+              )} Granting access to ${packagesNeedingAccess}`
             );
             npmUtils.grantAccess(app, answers.username, packagesNeedingAccess);
             this.log(
-              `${chalk.green('OK')} Access has been granted to ${answers.username}.`
+              `${chalk.green(
+                'OK'
+              )} Access has been granted to ${answers.username}.`
             );
             resolve();
           } else {

--- a/scripts/release-manager/commands/npm-publish.js
+++ b/scripts/release-manager/commands/npm-publish.js
@@ -28,7 +28,8 @@ module.exports = function(vorpal, app) {
         this.prompt([
           {
             type: 'confirm',
-            message: 'Did you run `grunt build` or `grunt release` and bump the version number?',
+            message:
+              'Did you run `grunt build` or `grunt release` and bump the version number?',
             default: false,
             name: 'checklist',
           },

--- a/scripts/release-manager/commands/stable-prs.js
+++ b/scripts/release-manager/commands/stable-prs.js
@@ -66,13 +66,15 @@ module.exports = function(vorpal, app) {
               {
                 name: 'destMilestone',
                 type: 'list',
-                message: 'Which milestone should we assign PRs to upon completion?',
+                message:
+                  'Which milestone should we assign PRs to upon completion?',
                 choices: milestoneChoices,
               },
               {
                 name: 'labels',
                 type: 'checkbox',
-                message: 'Which PRs should we select (use spacebar to check all that apply)',
+                message:
+                  'Which PRs should we select (use spacebar to check all that apply)',
                 choices: labelChoices,
               },
             ]).then(answers => {
@@ -136,7 +138,9 @@ module.exports = function(vorpal, app) {
                       .filter(pr => {
                         if (!pr.merged_at) {
                           this.log(
-                            `${chalk.yellow.bold('WARNING')} ${pr.html_url} was not merged,` +
+                            `${chalk.yellow.bold(
+                              'WARNING'
+                            )} ${pr.html_url} was not merged,` +
                               ` should have the milestone unset.`
                           );
                           return false;
@@ -180,7 +184,9 @@ module.exports = function(vorpal, app) {
                 })
                 .catch(err => {
                   this.log(
-                    `${chalk.red.bold('ERROR')} Something went wrong and your repo is` +
+                    `${chalk.red.bold(
+                      'ERROR'
+                    )} Something went wrong and your repo is` +
                       ` probably in a bad state. Sorry.`
                   );
                   resolve({
@@ -243,13 +249,16 @@ function cherryPickPRs(app, prs) {
           return this.prompt({
             name: 'handle',
             type: 'list',
-            message: `${chalk.red`Failed!`} ${chalk.yellow('This must be resolved manually!')}`,
+            message: `${chalk.red`Failed!`} ${chalk.yellow(
+              'This must be resolved manually!'
+            )}`,
             choices: [
               {value: 'ok', name: 'Continue, mark successful'},
               {value: 'skip', name: 'Continue, mark skipped'},
               {
                 value: 'abort',
-                name: 'Abort process. Will require manual resetting of git state.',
+                name:
+                  'Abort process. Will require manual resetting of git state.',
               },
             ],
           }).then(answers => {

--- a/scripts/release-manager/commands/utils/npm.js
+++ b/scripts/release-manager/commands/utils/npm.js
@@ -26,7 +26,9 @@ function generateAccessNeededIssue(username, packages) {
     body: `In order to publish React to npm I need access to the following repositories:
 ${packages.map(pkg => `- [${pkg}](https://npm.im/${pkg})`).join('\n')}`,
   };
-  return `https://github.com/facebook/react/issues/new?${querystring.stringify(data)}`;
+  return `https://github.com/facebook/react/issues/new?${querystring.stringify(
+    data
+  )}`;
 }
 
 function grantAccess(app, username, packages) {

--- a/scripts/release-manager/commands/version.js
+++ b/scripts/release-manager/commands/version.js
@@ -158,7 +158,8 @@ module.exports = function(vorpal, app) {
           {
             name: 'tag',
             type: 'confirm',
-            message: 'Tag the version commit (not necessary for non-stable releases)?',
+            message:
+              'Tag the version commit (not necessary for non-stable releases)?',
             default: true,
             when: res => res.commit,
           },

--- a/scripts/rollup/modules.js
+++ b/scripts/rollup/modules.js
@@ -225,7 +225,9 @@ function replaceFbjsModuleAliases(bundleType) {
   }
 }
 
-const devOnlyModuleStub = `'${resolve('./scripts/rollup/shims/rollup/DevOnlyStubShim.js')}'`;
+const devOnlyModuleStub = `'${resolve(
+  './scripts/rollup/shims/rollup/DevOnlyStubShim.js'
+)}'`;
 
 function replaceDevOnlyStubbedModules(bundleType) {
   switch (bundleType) {

--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -112,7 +112,9 @@ function validateExplicitKey(element, parentType) {
     element._owner !== ReactCurrentOwner.current
   ) {
     // Give the component that originally created this child.
-    childOwner = ` It was passed a child from ${getComponentName(element._owner)}.`;
+    childOwner = ` It was passed a child from ${getComponentName(
+      element._owner,
+    )}.`;
   }
 
   warning(

--- a/src/renderers/__tests__/ReactCompositeComponentState-test.js
+++ b/src/renderers/__tests__/ReactCompositeComponentState-test.js
@@ -414,7 +414,8 @@ describe('ReactCompositeComponent-state', () => {
         this.setState({step: 2}, () => {
           // Tests that earlier setState callbacks are not dropped
           ops.push(
-            `callback -- step: ${this.state.step}, extra: ${!!this.state.extra}`,
+            `callback -- step: ${this.state.step}, extra: ${!!this.state
+              .extra}`,
           );
         });
         // Treat like replaceState
@@ -458,7 +459,8 @@ describe('ReactCompositeComponent-state', () => {
           this.setState({step: 2}, () => {
             // Tests that earlier setState callbacks are not dropped
             ops.push(
-              `callback -- step: ${this.state.step}, extra: ${!!this.state.extra}`,
+              `callback -- step: ${this.state.step}, extra: ${!!this.state
+                .extra}`,
             );
           });
           // Treat like replaceState

--- a/src/renderers/__tests__/ReactErrorBoundaries-test.js
+++ b/src/renderers/__tests__/ReactErrorBoundaries-test.js
@@ -2001,11 +2001,10 @@ describe('ReactErrorBoundaries', () => {
       ReactDOM.render(
         <ErrorBoundary>
           <BrokenComponentDidMountErrorBoundary
-            renderError={error => (
+            renderError={error =>
               <div>
                 We should never catch our own error: {error.message}.
-              </div>
-            )}
+              </div>}
           />
         </ErrorBoundary>,
         container,

--- a/src/renderers/__tests__/ReactIdentity-test.js
+++ b/src/renderers/__tests__/ReactIdentity-test.js
@@ -25,12 +25,11 @@ describe('ReactIdentity', () => {
 
   it('should allow key property to express identity', () => {
     var node;
-    var Component = props => (
+    var Component = props =>
       <div ref={c => (node = c)}>
         <div key={props.swap ? 'banana' : 'apple'} />
         <div key={props.swap ? 'apple' : 'banana'} />
-      </div>
-    );
+      </div>;
 
     var container = document.createElement('div');
     ReactDOM.render(<Component />, container);

--- a/src/renderers/dom/ReactDOMStackEntry.js
+++ b/src/renderers/dom/ReactDOMStackEntry.js
@@ -61,7 +61,8 @@ if (
 ) {
   __REACT_DEVTOOLS_GLOBAL_HOOK__.inject({
     ComponentTree: {
-      getClosestInstanceFromNode: ReactDOMComponentTree.getClosestInstanceFromNode,
+      getClosestInstanceFromNode:
+        ReactDOMComponentTree.getClosestInstanceFromNode,
       getNodeFromInstance: function(inst) {
         // inst is an internal instance (but could be a composite)
         if (inst._renderedComponent) {

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -96,10 +96,12 @@ let selectionInformation: ?mixed = null;
  * @internal
  */
 function isValidContainer(node) {
-  return !!(node &&
+  return !!(
+    node &&
     (node.nodeType === ELEMENT_NODE ||
       node.nodeType === DOCUMENT_NODE ||
-      node.nodeType === DOCUMENT_FRAGMENT_NODE));
+      node.nodeType === DOCUMENT_FRAGMENT_NODE)
+  );
 }
 
 function getReactRootElementInContainer(container: any) {
@@ -116,9 +118,11 @@ function getReactRootElementInContainer(container: any) {
 
 function shouldReuseContent(container) {
   const rootElement = getReactRootElementInContainer(container);
-  return !!(rootElement &&
+  return !!(
+    rootElement &&
     rootElement.nodeType === ELEMENT_NODE &&
-    rootElement.getAttribute(ID_ATTRIBUTE_NAME));
+    rootElement.getAttribute(ID_ATTRIBUTE_NAME)
+  );
 }
 
 function shouldAutoFocusHostComponent(type: string, props: Props): boolean {
@@ -468,8 +472,9 @@ function renderSubtreeIntoContainer(
   if (__DEV__) {
     const isRootRenderedBySomeReact = !!container._reactRootContainer;
     const rootEl = getReactRootElementInContainer(container);
-    const hasNonRootReactChild = !!(rootEl &&
-      ReactDOMComponentTree.getInstanceFromNode(rootEl));
+    const hasNonRootReactChild = !!(
+      rootEl && ReactDOMComponentTree.getInstanceFromNode(rootEl)
+    );
 
     warning(
       !hasNonRootReactChild || isRootRenderedBySomeReact,

--- a/src/renderers/dom/shared/DOMProperty.js
+++ b/src/renderers/dom/shared/DOMProperty.js
@@ -163,8 +163,8 @@ var DOMProperty = {
   ROOT_ATTRIBUTE_NAME: 'data-reactroot',
 
   ATTRIBUTE_NAME_START_CHAR: ATTRIBUTE_NAME_START_CHAR,
-  ATTRIBUTE_NAME_CHAR: ATTRIBUTE_NAME_START_CHAR +
-    '\\-.0-9\\u00B7\\u0300-\\u036F\\u203F-\\u2040',
+  ATTRIBUTE_NAME_CHAR:
+    ATTRIBUTE_NAME_START_CHAR + '\\-.0-9\\u00B7\\u0300-\\u036F\\u203F-\\u2040',
 
   /**
    * Map from property "standard name" to an object with info about how to set

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -1667,8 +1667,8 @@ describe('ReactDOMComponent', () => {
       var previousLine = (matches || [])[1];
 
       expectDev(console.error.calls.argsFor(1)[0]).toContain('onClick');
-      matches = console.error.calls.argsFor(1)[0].match(/.*\(.*:(\d+)\).*/) || {
-      };
+      matches =
+        console.error.calls.argsFor(1)[0].match(/.*\(.*:(\d+)\).*/) || {};
       var currentLine = (matches || [])[1];
 
       //verify line number has a proper relative difference,

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -2137,22 +2137,22 @@ describe('ReactDOMServerIntegration', () => {
       it('should error reconnecting a div with children separated by whitespace on the client', () =>
         expectMarkupMismatch(
           <div id="parent"><div id="child1" /><div id="child2" /></div>,
-          // prettier-ignore
-          <div id="parent"><div id="child1" />      <div id="child2" /></div>, // eslint-disable-line no-multi-spaces
+          // eslint-disable-next-line no-multi-spaces
+          <div id="parent"><div id="child1" />      <div id="child2" /></div>,
         ));
 
       it('should error reconnecting a div with children separated by different whitespace on the server', () =>
         expectMarkupMismatch(
-          // prettier-ignore
-          <div id="parent"><div id="child1" />      <div id="child2" /></div>, // eslint-disable-line no-multi-spaces
+          // eslint-disable-next-line no-multi-spaces
+          <div id="parent"><div id="child1" />      <div id="child2" /></div>,
           <div id="parent"><div id="child1" /><div id="child2" /></div>,
         ));
 
       it('should error reconnecting a div with children separated by different whitespace', () =>
         expectMarkupMismatch(
           <div id="parent"><div id="child1" /> <div id="child2" /></div>,
-          // prettier-ignore
-          <div id="parent"><div id="child1" />      <div id="child2" /></div>, // eslint-disable-line no-multi-spaces
+          // eslint-disable-next-line no-multi-spaces
+          <div id="parent"><div id="child1" />      <div id="child2" /></div>,
         ));
 
       it('can distinguish an empty component from a dom node', () =>

--- a/src/renderers/dom/shared/eventPlugins/SelectEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/SelectEventPlugin.js
@@ -154,8 +154,8 @@ var SelectEventPlugin = {
     var doc = nativeEventTarget.window === nativeEventTarget
       ? nativeEventTarget.document
       : nativeEventTarget.nodeType === DOCUMENT_NODE
-          ? nativeEventTarget
-          : nativeEventTarget.ownerDocument;
+        ? nativeEventTarget
+        : nativeEventTarget.ownerDocument;
     if (!doc || !isListeningToAllDependencies('onSelect', doc)) {
       return null;
     }

--- a/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
+++ b/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
@@ -69,8 +69,8 @@ if (__DEV__) {
     var standardName = DOMProperty.isCustomAttribute(lowerCasedName)
       ? lowerCasedName
       : DOMProperty.getPossibleStandardName.hasOwnProperty(lowerCasedName)
-          ? DOMProperty.getPossibleStandardName[lowerCasedName]
-          : null;
+        ? DOMProperty.getPossibleStandardName[lowerCasedName]
+        : null;
 
     var registrationName = EventPluginRegistry.possibleRegistrationNames.hasOwnProperty(
       lowerCasedName,

--- a/src/renderers/dom/shared/syntheticEvents/SyntheticWheelEvent.js
+++ b/src/renderers/dom/shared/syntheticEvents/SyntheticWheelEvent.js
@@ -29,9 +29,9 @@ var WheelEventInterface = {
       ? event.deltaY
       : // Fallback to `wheelDeltaY` for Webkit and normalize (down is positive).
         'wheelDeltaY' in event
-          ? -event.wheelDeltaY
-          : // Fallback to `wheelDelta` for IE<9 and normalize (down is positive).
-            'wheelDelta' in event ? -event.wheelDelta : 0;
+        ? -event.wheelDeltaY
+        : // Fallback to `wheelDelta` for IE<9 and normalize (down is positive).
+          'wheelDelta' in event ? -event.wheelDelta : 0;
   },
   deltaZ: null,
 

--- a/src/renderers/dom/stack/client/ReactComponentBrowserEnvironment.js
+++ b/src/renderers/dom/stack/client/ReactComponentBrowserEnvironment.js
@@ -20,7 +20,8 @@ var ReactDOMIDOperations = require('ReactDOMIDOperations');
  * need for this injection.
  */
 var ReactComponentBrowserEnvironment = {
-  processChildrenUpdates: ReactDOMIDOperations.dangerouslyProcessChildrenUpdates,
+  processChildrenUpdates:
+    ReactDOMIDOperations.dangerouslyProcessChildrenUpdates,
 
   replaceNodeWithMarkup: DOMChildrenOperations.dangerouslyReplaceNodeWithMarkup,
 };

--- a/src/renderers/dom/stack/client/ReactMount.js
+++ b/src/renderers/dom/stack/client/ReactMount.js
@@ -205,9 +205,11 @@ function hasNonRootReactChild(container) {
  */
 function nodeIsRenderedByOtherInstance(container) {
   var rootEl = getReactRootElementInContainer(container);
-  return !!(rootEl &&
+  return !!(
+    rootEl &&
     isReactNode(rootEl) &&
-    !ReactDOMComponentTree.getInstanceFromNode(rootEl));
+    !ReactDOMComponentTree.getInstanceFromNode(rootEl)
+  );
 }
 
 /**
@@ -218,10 +220,12 @@ function nodeIsRenderedByOtherInstance(container) {
  * @internal
  */
 function isValidContainer(node) {
-  return !!(node &&
+  return !!(
+    node &&
     (node.nodeType === ELEMENT_NODE ||
       node.nodeType === DOCUMENT_NODE ||
-      node.nodeType === DOCUMENT_FRAGMENT_NODE));
+      node.nodeType === DOCUMENT_FRAGMENT_NODE)
+  );
 }
 
 /**

--- a/src/renderers/dom/test/ReactTestUtilsEntry.js
+++ b/src/renderers/dom/test/ReactTestUtilsEntry.js
@@ -213,8 +213,9 @@ var ReactTestUtils = {
     var internalInstance = ReactInstanceMap.get(inst);
     var constructor = internalInstance._currentElement.type;
 
-    return !!(ReactTestUtils.isCompositeComponentElement(inst) &&
-      constructor === type);
+    return !!(
+      ReactTestUtils.isCompositeComponentElement(inst) && constructor === type
+    );
   },
 
   // TODO: deprecate? It's undocumented and unused.

--- a/src/renderers/native/NativeMethodsMixin.js
+++ b/src/renderers/native/NativeMethodsMixin.js
@@ -31,9 +31,7 @@ import type {
   MeasureOnSuccessCallback,
   NativeMethodsMixinType,
 } from 'ReactNativeTypes';
-import type {
-  ReactNativeBaseComponentViewConfig,
-} from 'ReactNativeViewConfigRegistry';
+import type {ReactNativeBaseComponentViewConfig} from 'ReactNativeViewConfigRegistry';
 
 const findNumericNodeHandle = ReactNativeFeatureFlags.useFiber
   ? require('findNumericNodeHandleFiber')

--- a/src/renderers/native/ReactNativeComponent.js
+++ b/src/renderers/native/ReactNativeComponent.js
@@ -29,9 +29,7 @@ import type {
   MeasureOnSuccessCallback,
   NativeMethodsMixinType,
 } from 'ReactNativeTypes';
-import type {
-  ReactNativeBaseComponentViewConfig,
-} from 'ReactNativeViewConfigRegistry';
+import type {ReactNativeBaseComponentViewConfig} from 'ReactNativeViewConfigRegistry';
 
 const findNumericNodeHandle = ReactNativeFeatureFlags.useFiber
   ? require('findNumericNodeHandleFiber')
@@ -48,8 +46,11 @@ const findNumericNodeHandle = ReactNativeFeatureFlags.useFiber
  *
  * @abstract
  */
-class ReactNativeComponent<DefaultProps, Props, State>
-  extends React.Component<DefaultProps, Props, State> {
+class ReactNativeComponent<DefaultProps, Props, State> extends React.Component<
+  DefaultProps,
+  Props,
+  State,
+> {
   static defaultProps: $Abstract<DefaultProps>;
   props: Props;
   state: $Abstract<State>;

--- a/src/renderers/native/ReactNativeComponentEnvironment.js
+++ b/src/renderers/native/ReactNativeComponentEnvironment.js
@@ -15,9 +15,11 @@ var ReactNativeDOMIDOperations = require('ReactNativeDOMIDOperations');
 var ReactNativeReconcileTransaction = require('ReactNativeReconcileTransaction');
 
 var ReactNativeComponentEnvironment = {
-  processChildrenUpdates: ReactNativeDOMIDOperations.dangerouslyProcessChildrenUpdates,
+  processChildrenUpdates:
+    ReactNativeDOMIDOperations.dangerouslyProcessChildrenUpdates,
 
-  replaceNodeWithMarkup: ReactNativeDOMIDOperations.dangerouslyReplaceNodeWithMarkupByID,
+  replaceNodeWithMarkup:
+    ReactNativeDOMIDOperations.dangerouslyReplaceNodeWithMarkupByID,
 
   /**
    * @param {DOMElement} Element to clear.

--- a/src/renderers/native/ReactNativeFiberEntry.js
+++ b/src/renderers/native/ReactNativeFiberEntry.js
@@ -117,9 +117,11 @@ if (__DEV__) {
 
 if (typeof injectInternals === 'function') {
   injectInternals({
-    findFiberByHostInstance: ReactNativeComponentTree.getClosestInstanceFromNode,
+    findFiberByHostInstance:
+      ReactNativeComponentTree.getClosestInstanceFromNode,
     findHostInstanceByFiber: ReactNativeFiberRenderer.findHostInstance,
-    getInspectorDataForViewTag: ReactNativeFiberInspector.getInspectorDataForViewTag,
+    getInspectorDataForViewTag:
+      ReactNativeFiberInspector.getInspectorDataForViewTag,
     // This is an enum because we may add more (e.g. profiler build)
     bundleType: __DEV__ ? 1 : 0,
     version: ReactVersion,

--- a/src/renderers/native/ReactNativeFiberHostComponent.js
+++ b/src/renderers/native/ReactNativeFiberHostComponent.js
@@ -26,9 +26,7 @@ import type {
   NativeMethodsMixinType,
 } from 'ReactNativeTypes';
 import type {Instance} from 'ReactNativeFiberRenderer';
-import type {
-  ReactNativeBaseComponentViewConfig,
-} from 'ReactNativeViewConfigRegistry';
+import type {ReactNativeBaseComponentViewConfig} from 'ReactNativeViewConfigRegistry';
 
 /**
  * This component defines the same methods as NativeMethodsMixin but without the

--- a/src/renderers/native/ReactNativeFiberRenderer.js
+++ b/src/renderers/native/ReactNativeFiberRenderer.js
@@ -24,9 +24,7 @@ const deepFreezeAndThrowOnMutationInDev = require('deepFreezeAndThrowOnMutationI
 const emptyObject = require('fbjs/lib/emptyObject');
 const invariant = require('fbjs/lib/invariant');
 
-import type {
-  ReactNativeBaseComponentViewConfig,
-} from 'ReactNativeViewConfigRegistry';
+import type {ReactNativeBaseComponentViewConfig} from 'ReactNativeViewConfigRegistry';
 
 export type Container = number;
 export type Instance = {
@@ -225,9 +223,9 @@ const NativeRenderer = ReactFiberReconciler({
     // Either way we need to pass a copy of the Array to prevent it from being frozen.
     const nativeTags = parentInstance._children.map(
       child =>
-        (typeof child === 'number'
+        typeof child === 'number'
           ? child // Leaf node (eg text)
-          : child._nativeTag),
+          : child._nativeTag,
     );
 
     UIManager.setChildren(

--- a/src/renderers/native/ReactNativeStackEntry.js
+++ b/src/renderers/native/ReactNativeStackEntry.js
@@ -48,7 +48,8 @@ var ReactNativeStack: ReactNativeType = {
   unstable_batchedUpdates: ReactUpdates.batchedUpdates,
   /* eslint-enable camelcase */
 
-  unmountComponentAtNodeAndRemoveContainer: ReactNativeMount.unmountComponentAtNodeAndRemoveContainer,
+  unmountComponentAtNodeAndRemoveContainer:
+    ReactNativeMount.unmountComponentAtNodeAndRemoveContainer,
 
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
     // Used as a mixin in many createClass-based components
@@ -101,7 +102,8 @@ if (
     },
     Mount: ReactNativeMount,
     Reconciler: require('ReactReconciler'),
-    getInspectorDataForViewTag: ReactNativeStackInspector.getInspectorDataForViewTag,
+    getInspectorDataForViewTag:
+      ReactNativeStackInspector.getInspectorDataForViewTag,
   });
 }
 

--- a/src/renderers/native/createReactNativeComponentClassFiber.js
+++ b/src/renderers/native/createReactNativeComponentClassFiber.js
@@ -14,9 +14,7 @@
 
 const ReactNativeViewConfigRegistry = require('ReactNativeViewConfigRegistry');
 
-import type {
-  ReactNativeBaseComponentViewConfig,
-} from './createReactNativeComponentClass';
+import type {ReactNativeBaseComponentViewConfig} from './createReactNativeComponentClass';
 
 /**
  * @param {string} config iOS View configuration.

--- a/src/renderers/native/createReactNativeComponentClassStack.js
+++ b/src/renderers/native/createReactNativeComponentClassStack.js
@@ -14,9 +14,7 @@
 
 const ReactNativeBaseComponent = require('ReactNativeBaseComponent');
 
-import type {
-  ReactNativeBaseComponentViewConfig,
-} from './createReactNativeComponentClass';
+import type {ReactNativeBaseComponentViewConfig} from './createReactNativeComponentClass';
 
 /**
  * @param {string} config iOS View configuration.

--- a/src/renderers/shared/ReactDebugTool.js
+++ b/src/renderers/shared/ReactDebugTool.js
@@ -122,9 +122,10 @@ if (__DEV__) {
         updateCount: ReactComponentTreeHook.getUpdateCount(id),
         childIDs: ReactComponentTreeHook.getChildIDs(id),
         // Text nodes don't have owners but this is close enough.
-        ownerID: ownerID ||
-          (parentID && ReactComponentTreeHook.getOwnerID(parentID)) ||
-          0,
+        ownerID:
+          ownerID ||
+            (parentID && ReactComponentTreeHook.getOwnerID(parentID)) ||
+            0,
         parentID,
       };
       return tree;
@@ -209,9 +210,10 @@ if (__DEV__) {
       currentFlushMeasurements.push({
         timerType,
         instanceID: debugID,
-        duration: performanceNow() -
-          currentTimerStartTime -
-          currentTimerNestedFlushDuration,
+        duration:
+          performanceNow() -
+            currentTimerStartTime -
+            currentTimerNestedFlushDuration,
       });
     }
     currentTimerStartTime = 0;

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -947,7 +947,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     for (
       ;
       oldFiber !== null && !step.done;
-      newIdx++, (step = newChildren.next())
+      newIdx++, step = newChildren.next()
     ) {
       if (oldFiber.index > newIdx) {
         nextOldFiber = oldFiber;
@@ -997,7 +997,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     if (oldFiber === null) {
       // If we don't have any more existing children we can choose a fast path
       // since the rest will all be insertions.
-      for (; !step.done; newIdx++, (step = newChildren.next())) {
+      for (; !step.done; newIdx++, step = newChildren.next()) {
         const newFiber = createChild(returnFiber, step.value, priority);
         if (newFiber === null) {
           continue;
@@ -1018,7 +1018,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     const existingChildren = mapRemainingChildren(returnFiber, oldFiber);
 
     // Keep scanning and use the map to restore deleted items as moves.
-    for (; !step.done; newIdx++, (step = newChildren.next())) {
+    for (; !step.done; newIdx++, step = newChildren.next()) {
       const newFiber = updateFromMap(
         existingChildren,
         returnFiber,

--- a/src/renderers/shared/fiber/ReactFiberHydrationContext.js
+++ b/src/renderers/shared/fiber/ReactFiberHydrationContext.js
@@ -46,12 +46,14 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
   // If this doesn't have hydration mode.
   if (
-    !(canHydrateInstance &&
+    !(
+      canHydrateInstance &&
       canHydrateTextInstance &&
       getNextHydratableSibling &&
       getFirstHydratableChild &&
       hydrateInstance &&
-      hydrateTextInstance)
+      hydrateTextInstance
+    )
   ) {
     return {
       enterHydrationState() {

--- a/src/renderers/shared/fiber/__tests__/ReactCoroutine-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactCoroutine-test.js
@@ -63,9 +63,9 @@ describe('ReactCoroutine', () => {
 
     function HandleYields(props, yields) {
       ops.push('HandleYields');
-      return yields.map((y, i) => (
-        <y.continuation key={i} isSame={props.foo === y.props.bar} />
-      ));
+      return yields.map((y, i) =>
+        <y.continuation key={i} isSame={props.foo === y.props.bar} />,
+      );
     }
 
     // An alternative API could mark Parent as something that needs
@@ -122,9 +122,9 @@ describe('ReactCoroutine', () => {
     }
 
     function HandleYields(props, yields) {
-      return yields.map((y, i) => (
-        <y.continuation key={i} isSame={props.foo === y.props.bar} />
-      ));
+      return yields.map((y, i) =>
+        <y.continuation key={i} isSame={props.foo === y.props.bar} />,
+      );
     }
 
     function Parent(props) {
@@ -177,9 +177,9 @@ describe('ReactCoroutine', () => {
 
     function HandleYields(props, yields) {
       ops.push('HandleYields');
-      return yields.map((ContinuationComponent, i) => (
-        <ContinuationComponent key={i} />
-      ));
+      return yields.map((ContinuationComponent, i) =>
+        <ContinuationComponent key={i} />,
+      );
     }
 
     class Parent extends React.Component {

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalPerf-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalPerf-test.js
@@ -455,9 +455,9 @@ describe('ReactDebugFiberPerf', () => {
     }
 
     function HandleYields(props, yields) {
-      return yields.map((y, i) => (
-        <y.continuation key={i} isSame={props.foo === y.props.bar} />
-      ));
+      return yields.map((y, i) =>
+        <y.continuation key={i} isSame={props.foo === y.props.bar} />,
+      );
     }
 
     function CoParent(props) {

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalReflection-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalReflection-test.js
@@ -153,12 +153,12 @@ describe('ReactIncrementalReflection', () => {
         return this.props.step < 2
           ? <span ref={ref => (this.span = ref)} />
           : this.props.step === 2
-              ? <div ref={ref => (this.div = ref)} />
-              : this.props.step === 3
-                  ? null
-                  : this.props.step === 4
-                      ? <div ref={ref => (this.span = ref)} />
-                      : null;
+            ? <div ref={ref => (this.div = ref)} />
+            : this.props.step === 3
+              ? null
+              : this.props.step === 4
+                ? <div ref={ref => (this.span = ref)} />
+                : null;
       }
     }
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalSideEffects-test.js
@@ -72,8 +72,8 @@ describe('ReactIncrementalSideEffects', () => {
           {props.text === 'World'
             ? [<Bar key="a" text={props.text} />, <div key="b" />]
             : props.text === 'Hi'
-                ? [<div key="b" />, <Bar key="a" text={props.text} />]
-                : null}
+              ? [<div key="b" />, <Bar key="a" text={props.text} />]
+              : null}
           <span prop="test" />
         </div>
       );
@@ -169,8 +169,8 @@ describe('ReactIncrementalSideEffects', () => {
           {props.useClass
             ? <ClassComponent />
             : props.useFunction
-                ? <FunctionalComponent />
-                : props.useText ? 'Text' : null}
+              ? <FunctionalComponent />
+              : props.useText ? 'Text' : null}
           Trail
         </div>
       );

--- a/src/renderers/shared/shared/event/BrowserEventConstants.js
+++ b/src/renderers/shared/shared/event/BrowserEventConstants.js
@@ -23,10 +23,10 @@ var getVendorPrefixedEventName = require('getVendorPrefixedEventName');
 var topLevelTypes = {
   topAbort: 'abort',
   topAnimationEnd: getVendorPrefixedEventName('animationend') || 'animationend',
-  topAnimationIteration: getVendorPrefixedEventName('animationiteration') ||
-    'animationiteration',
-  topAnimationStart: getVendorPrefixedEventName('animationstart') ||
-    'animationstart',
+  topAnimationIteration:
+    getVendorPrefixedEventName('animationiteration') || 'animationiteration',
+  topAnimationStart:
+    getVendorPrefixedEventName('animationstart') || 'animationstart',
   topBlur: 'blur',
   topCancel: 'cancel',
   topCanPlay: 'canplay',
@@ -87,8 +87,8 @@ var topLevelTypes = {
   topTouchEnd: 'touchend',
   topTouchMove: 'touchmove',
   topTouchStart: 'touchstart',
-  topTransitionEnd: getVendorPrefixedEventName('transitionend') ||
-    'transitionend',
+  topTransitionEnd:
+    getVendorPrefixedEventName('transitionend') || 'transitionend',
   topVolumeChange: 'volumechange',
   topWaiting: 'waiting',
   topWheel: 'wheel',

--- a/src/renderers/shared/shared/event/eventPlugins/ResponderEventPlugin.js
+++ b/src/renderers/shared/shared/event/eventPlugins/ResponderEventPlugin.js
@@ -323,10 +323,10 @@ function setResponderAndExtractTransfer(
   var shouldSetEventType = isStartish(topLevelType)
     ? eventTypes.startShouldSetResponder
     : isMoveish(topLevelType)
-        ? eventTypes.moveShouldSetResponder
-        : topLevelType === 'topSelectionChange'
-            ? eventTypes.selectionChangeShouldSetResponder
-            : eventTypes.scrollShouldSetResponder;
+      ? eventTypes.moveShouldSetResponder
+      : topLevelType === 'topSelectionChange'
+        ? eventTypes.selectionChangeShouldSetResponder
+        : eventTypes.scrollShouldSetResponder;
 
   // TODO: stop one short of the current responder.
   var bubbleShouldSetFrom = !responderInst
@@ -520,8 +520,8 @@ var ResponderEventPlugin = {
     var incrementalTouch = isResponderTouchStart
       ? eventTypes.responderStart
       : isResponderTouchMove
-          ? eventTypes.responderMove
-          : isResponderTouchEnd ? eventTypes.responderEnd : null;
+        ? eventTypes.responderMove
+        : isResponderTouchEnd ? eventTypes.responderEnd : null;
 
     if (incrementalTouch) {
       var gesture = ResponderSyntheticEvent.getPooled(

--- a/src/renderers/shared/shared/event/eventPlugins/TouchHistoryMath.js
+++ b/src/renderers/shared/shared/event/eventPlugins/TouchHistoryMath.js
@@ -43,10 +43,10 @@ var TouchHistoryMath = {
         total += ofCurrent && isXAxis
           ? oneTouchData.currentPageX
           : ofCurrent && !isXAxis
-              ? oneTouchData.currentPageY
-              : !ofCurrent && isXAxis
-                  ? oneTouchData.previousPageX
-                  : oneTouchData.previousPageY;
+            ? oneTouchData.currentPageY
+            : !ofCurrent && isXAxis
+              ? oneTouchData.previousPageX
+              : oneTouchData.previousPageY;
         count = 1;
       }
     } else {

--- a/src/renderers/shared/shared/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
+++ b/src/renderers/shared/shared/event/eventPlugins/__tests__/ResponderEventPlugin-test.js
@@ -69,12 +69,12 @@ var _touchConfig = function(
   var activeTouchObjects = topType === 'topTouchStart'
     ? allTouchObjects
     : topType === 'topTouchMove'
-        ? allTouchObjects
-        : topType === 'topTouchEnd'
-            ? antiSubsequence(allTouchObjects, changedIndices)
-            : topType === 'topTouchCancel'
-                ? antiSubsequence(allTouchObjects, changedIndices)
-                : null;
+      ? allTouchObjects
+      : topType === 'topTouchEnd'
+        ? antiSubsequence(allTouchObjects, changedIndices)
+        : topType === 'topTouchCancel'
+          ? antiSubsequence(allTouchObjects, changedIndices)
+          : null;
 
   return {
     nativeEvent: touchEvent(

--- a/src/renderers/shared/stack/reconciler/ReactOwner.js
+++ b/src/renderers/shared/stack/reconciler/ReactOwner.js
@@ -26,9 +26,11 @@ import type {ReactInstance} from 'ReactInstanceType';
  * @final
  */
 function isValidOwner(object: any): boolean {
-  return !!(object &&
+  return !!(
+    object &&
     typeof object.attachRef === 'function' &&
-    typeof object.detachRef === 'function');
+    typeof object.detachRef === 'function'
+  );
 }
 
 /**

--- a/src/renderers/shared/stack/reconciler/Transaction.js
+++ b/src/renderers/shared/stack/reconciler/Transaction.js
@@ -132,7 +132,7 @@ var TransactionImpl = {
     E,
     F,
     G,
-    T: (a: A, b: B, c: C, d: D, e: E, f: F) => G
+    T: (a: A, b: B, c: C, d: D, e: E, f: F) => G,
   >(method: T, scope: any, a: A, b: B, c: C, d: D, e: E, f: F): G {
     invariant(
       !this.isInTransaction(),

--- a/src/renderers/testing/__tests__/ReactTestRenderer-test.js
+++ b/src/renderers/testing/__tests__/ReactTestRenderer-test.js
@@ -571,12 +571,11 @@ describe('ReactTestRenderer', () => {
     var Qoo = () => <span className="Qoo">Hello World!</span>;
 
     // SFC returning host. passes through children.
-    var Foo = ({className, children}) => (
+    var Foo = ({className, children}) =>
       <div className={'Foo ' + className}>
         <span className="Foo2">Literal</span>
         {children}
-      </div>
-    );
+      </div>;
 
     // class composite returning composite. passes through children.
     class Bar extends React.Component {


### PR DESCRIPTION
Throughout my work on #10024, I found that I would get intermittent prettier errors from CI, and some of them seemed arbitrary. Changes that didn't fix any prettier issues would make CI prettier stop complaining, and changes that didn't add any bad formatting would make CI prettier get unhappy. Further, `npm run prettier` or `yarn prettier` (the recommended fix) never fixed the CI problems I was having.

I've since realized that the reason that `npm run prettier` wasn't working was that that command attempts to run prettier over only the changed files, but CI checks all files to make sure they are correctly formatted. And, for whatever reason, `master` has a few dozen files that are incorrectly formatted right now. I suspect these files creeped in because of some problem in CI that was causing the arbitrariness I was seeing, but I'm not entirely sure.

This PR is just a result of running `npm run prettier-all` over the codebase and then fixing one tiny problem with linting (prettier eliminated three `eslint-disable-line` comments in `ReactDOMServerIntegration-test.js` which I had to reinstate).

This PR doesn't fix the core problem that CI seems to sometimes approve of builds that violate prettier's formatting and thereby lets incorrectly formatted files in, but I honestly can't really figure out why that happens. In the meantime, though, I'm hoping that this checkin will reduce the number of times CI complains about my other PRs.