### PR TITLE
Pin prettier to a specific version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "ncp": "^2.0.0",
     "object-assign": "^4.1.1",
     "platform": "^1.1.0",
-    "prettier": "^1.2.2",
+    "prettier": "1.2.2",
     "prop-types": "^15.5.8",
     "rimraf": "^2.6.1",
     "rollup": "^0.41.6",


### PR DESCRIPTION
Right now, prettier's version is `^1.2.2`, which means that a range of versions are acceptable. However, different versions of prettier produce different output. Notably, there are a few dozen files in `master` that format differently with prettier 1.2.2 and 1.4.0 (the most recent release). This can cause inconsistencies between the formatting on dev machines and CI machines, and even between different CI machines, meaning builds can randomly fail depending which CI machine they get.

All this PR does is pins prettier to 1.2.2, which is how the current code in `master` is formatted.

(Note this is a follow-on to PR #10037.)