### PR TITLE
Documentation: added info about streaming character encoding.

### DIFF
--- a/docs/docs/reference-react-dom-node-stream.md
+++ b/docs/docs/reference-react-dom-node-stream.md
@@ -31,6 +31,8 @@ Render a React element to its initial HTML. This should only be used in Node.js;
 
 If you call [`ReactDOM.render()`](/react/docs/react-dom.html#render) on a node that already has this server-rendered markup, React will preserve it and only attach event handlers, allowing you to have a very performant first-load experience.
 
+Note that the stream returned from this method will return a byte stream encoded in utf-8. If you need a stream in another encoding, take a look a project like [iconv-lite](https://www.npmjs.com/package/iconv-lite), which provides transform streams for transcoding text.
+
 * * *
 
 ### `renderToStaticStream()`
@@ -40,3 +42,5 @@ ReactDOMNodeStream.renderToStaticStream(element)
 ```
 
 Similar to [`renderToStream`](#rendertostream), except this doesn't create extra DOM attributes such as `data-reactid`, that React uses internally. This is useful if you want to use React as a simple static page generator, as stripping away the extra attributes can save lots of bytes.
+
+Note that the stream returned from this method will return a byte stream encoded in utf-8. If you need a stream in another encoding, take a look a project like [iconv-lite](https://www.npmjs.com/package/iconv-lite), which provides transform streams for transcoding text.


### PR DESCRIPTION
I just added two lines in the documentation noting that the streaming methods return buffers encoded in utf-8, with pointers to what to do if the user wants to get streaming rendering in another character encoding.