### PR TITLE
Add node-stream.js to react-dom's package.json files entry

### DIFF
--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -27,6 +27,7 @@
     "README.md",
     "index.js",
     "server.js",
+    "node-stream.js",
     "test-utils.js",
     "cjs/",
     "umd/"


### PR DESCRIPTION
In #10024, I added `node-stream.js` to `react-dom`'s distribution, but I didn't realize that `react-dom`'s package.json specifies which files are to be uploaded to the npm registry. As a result, if we tried to publish `react-dom` right now out of master, `node-stream.js` would not be a part of the package.

This PR fixes that. Sorry!