### PR TITLE
ReactNativeFiberErrorDialog mutates error message

### DIFF
--- a/src/renderers/native/ReactNativeFiberErrorDialog.js
+++ b/src/renderers/native/ReactNativeFiberErrorDialog.js
@@ -26,10 +26,15 @@ function ReactNativeFiberErrorDialog(capturedError: CapturedError): boolean {
   let errorMessage: string;
   let errorStack: string;
   let errorType: Class<Error>;
+  let framesToPop: any;
 
   // Typically Errors are thrown but eg strings or null can be thrown as well.
   if (error && typeof error === 'object') {
     const {message, name} = error;
+
+    // Util methods like invariant set 'framesToPop' to create a stack trace
+    // that is more relevant and blame-able by tooling.
+    framesToPop = (error: any).framesToPop;
 
     const summary = message ? `${name}: ${message}` : name;
 
@@ -43,6 +48,7 @@ function ReactNativeFiberErrorDialog(capturedError: CapturedError): boolean {
   }
 
   const newError = new errorType(errorMessage);
+  (newError: any).framesToPop = framesToPop;
   newError.stack = errorStack;
 
   ExceptionsManager.handleException(newError, false);

--- a/src/renderers/native/ReactNativeFiberErrorDialog.js
+++ b/src/renderers/native/ReactNativeFiberErrorDialog.js
@@ -32,7 +32,10 @@ function ReactNativeFiberErrorDialog(capturedError: CapturedError): boolean {
     const summary = message ? `${name}: ${message}` : name;
 
     errorToHandle = error;
-    errorToHandle.message = `${summary}\n\nThis error is located at:${componentStack}`;
+
+    try {
+      errorToHandle.message = `${summary}\n\nThis error is located at:${componentStack}`;
+    } catch (e) {}
   } else if (typeof error === 'string') {
     errorToHandle = new Error(
       `${error}\n\nThis error is located at:${componentStack}`,

--- a/src/renderers/native/ReactNativeFiberErrorDialog.js
+++ b/src/renderers/native/ReactNativeFiberErrorDialog.js
@@ -23,35 +23,25 @@ import type {CapturedError} from 'ReactFiberScheduler';
 function ReactNativeFiberErrorDialog(capturedError: CapturedError): boolean {
   const {componentStack, error} = capturedError;
 
-  let errorMessage: string;
-  let errorStack: string;
-  let errorType: Class<Error>;
-  let framesToPop: any;
+  let errorToHandle: Error;
 
   // Typically Errors are thrown but eg strings or null can be thrown as well.
-  if (error && typeof error === 'object') {
+  if (error instanceof Error) {
     const {message, name} = error;
-
-    // Util methods like invariant set 'framesToPop' to create a stack trace
-    // that is more relevant and blame-able by tooling.
-    framesToPop = (error: any).framesToPop;
 
     const summary = message ? `${name}: ${message}` : name;
 
-    errorMessage = `${summary}\n\nThis error is located at:${componentStack}`;
-    errorStack = error.stack;
-    errorType = error.constructor;
+    errorToHandle = error;
+    errorToHandle.message = `${summary}\n\nThis error is located at:${componentStack}`;
+  } else if (typeof error === 'string') {
+    errorToHandle = new Error(
+      `${error}\n\nThis error is located at:${componentStack}`,
+    );
   } else {
-    errorMessage = `Unspecified error at:${componentStack}`;
-    errorStack = '';
-    errorType = Error;
+    errorToHandle = new Error(`Unspecified error at:${componentStack}`);
   }
 
-  const newError = new errorType(errorMessage);
-  (newError: any).framesToPop = framesToPop;
-  newError.stack = errorStack;
-
-  ExceptionsManager.handleException(newError, false);
+  ExceptionsManager.handleException(errorToHandle, false);
 
   // Return false here to prevent ReactFiberErrorLogger default behavior of
   // logging error details to console.error. Calls to console.error are


### PR DESCRIPTION
The primary motivation for this diff is to fix an issue with the `framesToPop` property (added by `invariant` and others) not being copied over to the "cloned" `Error` object. This caused problems with Facebook's automated error tooling.

After some discussion with Seb, we decided to just mutate the incoming `Error` rather than cloning. I also improved the error messaging for string-type errors on the way (as shown below in the screenshots).

<img width="487" alt="screen shot 2017-06-26 at 10 01 03 am" src="https://user-images.githubusercontent.com/29597/27551028-b09bb870-5a56-11e7-9f08-ef6ea036df7d.png">
<img width="487" alt="screen shot 2017-06-26 at 10 01 09 am" src="https://user-images.githubusercontent.com/29597/27551029-b0a78916-5a56-11e7-8691-523aa776328b.png">
<img width="487" alt="screen shot 2017-06-26 at 10 01 20 am" src="https://user-images.githubusercontent.com/29597/27551030-b0ab7c6a-5a56-11e7-8210-42a73aae478d.png">
