### PR TITLE
Don't use the render callback with promises

### DIFF
--- a/scripts/fiber/tests-passing-except-dev.txt
+++ b/scripts/fiber/tests-passing-except-dev.txt
@@ -86,12 +86,6 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders a div with a single child surrounded by whitespace with client render on top of bad server markup
 * renders >,<, and & as single child with client render on top of bad server markup
 * renders >,<, and & as multiple children with client render on top of bad server markup
-* throws when rendering a string component with clean client render
-* throws when rendering a string component with client render on top of bad server markup
-* throws when rendering an undefined component with clean client render
-* throws when rendering an undefined component with client render on top of bad server markup
-* throws when rendering a number component with clean client render
-* throws when rendering a number component with client render on top of bad server markup
 * renders an input with a value and an onChange with client render on top of bad server markup
 * renders an input with a value and readOnly with client render on top of bad server markup
 * renders an input with a value and no onChange/readOnly with client render on top of bad server markup

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1206,8 +1206,14 @@ src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
 * renders >,<, and & as multiple children with clean client render
 * renders >,<, and & as multiple children with client render on top of good server markup
 * throws when rendering a string component with server string render
+* throws when rendering a string component with clean client render
+* throws when rendering a string component with client render on top of bad server markup
 * throws when rendering an undefined component with server string render
+* throws when rendering an undefined component with clean client render
+* throws when rendering an undefined component with client render on top of bad server markup
 * throws when rendering a number component with server string render
+* throws when rendering a number component with clean client render
+* throws when rendering a number component with client render on top of bad server markup
 * throws when rendering null with server string render
 * throws when rendering null with clean client render
 * throws when rendering null with client render on top of bad server markup

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -28,9 +28,12 @@ const stream = require('stream');
 
 // promisified version of ReactDOM.render()
 function asyncReactDOMRender(reactElement, domElement) {
-  return new Promise(resolve =>
-    ReactDOM.render(reactElement, domElement, resolve),
-  );
+  return new Promise(resolve => {
+    ReactDOM.render(reactElement, domElement);
+    // We can't use the callback for resolution because that will not catch
+    // errors. They're thrown.
+    resolve();
+  });
 }
 // performs fn asynchronously and expects count errors logged to console.error.
 // will fail the test if the count of errors logged is not equal to count.


### PR DESCRIPTION
This covers up errors that are thrown in Fiber, because callback gets fired *and* an error is thrown. Created a follow up #10049 to reevaluate these semantics.

