### PR TITLE
Fix Typo in ReactDOMFiberEntry

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -519,7 +519,7 @@ var ReactDOMFiber = {
     callback: ?Function,
   ) {
     if (ReactFeatureFlags.disableNewFiberFeatures) {
-      // Top-level check occurs here instead of inside child reconciler because
+      // Top-level check occurs here instead of inside child reconciler
       // because requirements vary between renderers. E.g. React Art
       // allows arrays.
       if (!isValidElement(element)) {


### PR DESCRIPTION
This PR removes a duplicate "because" from `ReactDOMFiberEntry`
