### PR TITLE
Address issues where ID of nodeName causes internal errors in React

### DIFF
--- a/fixtures/dom/src/components/fixtures/text-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/text-inputs/index.js
@@ -70,6 +70,22 @@ class TextInputFixtures extends React.Component {
           <InputTestCase type="url" defaultValue="" />
         </TestCase>
 
+        <TestCase title="Inputs with an id of `nodeName`">
+          <TestCase.Steps>
+            <li>Type any character</li>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            There should be no errors in the console.
+          </TestCase.ExpectedResult>
+
+          <form className="control-box">
+            <fieldset>
+              <input id="nodeName" />
+            </fieldset>
+          </form>
+        </TestCase>
+
         <TestCase title="All inputs" description="General test of all inputs">
           <InputTestCase type="text" defaultValue="Text" />
           <InputTestCase type="email" defaultValue="user@example.com" />

--- a/src/renderers/dom/shared/ReactInputSelection.js
+++ b/src/renderers/dom/shared/ReactInputSelection.js
@@ -30,12 +30,10 @@ function isInDocument(node) {
  */
 var ReactInputSelection = {
   hasSelectionCapabilities: function(elem) {
-    var nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
     return (
-      nodeName &&
-      ((nodeName === 'input' && elem.type === 'text') ||
-        nodeName === 'textarea' ||
-        elem.contentEditable === 'true')
+      (elem instanceof HTMLInputElement && elem.type === 'text') ||
+      elem instanceof HTMLTextAreaElement ||
+      elem.contentEditable === 'true'
     );
   },
 

--- a/src/renderers/dom/shared/ReactInputSelection.js
+++ b/src/renderers/dom/shared/ReactInputSelection.js
@@ -22,6 +22,9 @@ function isInDocument(node) {
   return containsNode(document.documentElement, node);
 }
 
+var nodeNameGetter = Object.getOwnPropertyDescriptor(Node.prototype, 'nodeName')
+  .get;
+
 /**
  * @ReactInputSelection: React input selection module. Based on Selection.js,
  * but modified to be suitable for react and has a couple of bug fixes (doesn't
@@ -30,9 +33,15 @@ function isInDocument(node) {
  */
 var ReactInputSelection = {
   hasSelectionCapabilities: function(elem) {
+    if (elem === window) {
+      return false;
+    }
+
+    var nodeName = nodeNameGetter.call(elem);
+
     return (
-      (elem instanceof HTMLInputElement && elem.type === 'text') ||
-      elem instanceof HTMLTextAreaElement ||
+      (nodeName === 'INPUT' && elem.type === 'text') ||
+      nodeName === 'TEXTAREA' ||
       elem.contentEditable === 'true'
     );
   },

--- a/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
@@ -40,16 +40,18 @@ var eventTypes = {
   },
 };
 
-var nodeNameGetter = Object.getOwnPropertyDescriptor(
-  Node.prototype,
-  'nodeName'
-).get;
+var nodeNameGetter = Object.getOwnPropertyDescriptor(Node.prototype, 'nodeName')
+  .get;
 
 function shouldUseChangeEvent(elem) {
-  var nodeName = nodeNameGetter.call(element);
+  if (elem === window) {
+    return false;
+  }
+
+  var nodeName = nodeNameGetter.call(elem);
 
   return (
-    nodeName === 'select' || (nodeName === 'input' && elem.type === 'file')
+    nodeName === 'SELECT' || (nodeName === 'INPUT' && elem.type === 'FILE')
   );
 }
 
@@ -165,7 +167,6 @@ var ChangeEventPlugin = {
     }
 
     var getTargetInstFunc, handleEventFunc;
-
     if (shouldUseChangeEvent(targetNode)) {
       getTargetInstFunc = getTargetInstForChangeEvent;
     } else if (isTextInputElement(targetNode) && !isTextInputEventSupported) {

--- a/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
@@ -40,8 +40,14 @@ var eventTypes = {
   },
 };
 
+var nodeNameGetter = Object.getOwnPropertyDescriptor(
+  Node.prototype,
+  'nodeName'
+).get;
+
 function shouldUseChangeEvent(elem) {
-  var nodeName = elem.nodeName && elem.nodeName.toLowerCase();
+  var nodeName = nodeNameGetter.call(element);
+
   return (
     nodeName === 'select' || (nodeName === 'input' && elem.type === 'file')
   );

--- a/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
@@ -1346,4 +1346,26 @@ describe('ReactDOMInput', () => {
       expect(node.getAttribute('value')).toBe('1');
     });
   });
+
+  it('an input with an id of `nodeName` works as intended', () => {
+    var spy = jest.fn();
+
+    class Test extends React.Component {
+      render() {
+        return (
+          <form onSubmit={spy}>
+            <input id="nodeName" name="nodeName" defaultValue="test" />
+            <input type="submit" />
+          </form>
+        );
+      }
+    }
+
+    var stub = ReactTestUtils.renderIntoDocument(<Test />);
+    var node = ReactDOM.findDOMNode(stub);
+
+    ReactTestUtils.Simulate.submit(node);
+
+    expect(spy).toHaveBeenCalled();
+  });
 });

--- a/src/renderers/shared/utils/isTextInputElement.js
+++ b/src/renderers/shared/utils/isTextInputElement.js
@@ -34,13 +34,11 @@ var supportedInputTypes: {[key: string]: true | void} = {
 };
 
 function isTextInputElement(elem: ?HTMLElement): boolean {
-  var nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
-
-  if (nodeName === 'input') {
+  if (elem instanceof HTMLInputElement) {
     return !!supportedInputTypes[((elem: any): HTMLInputElement).type];
   }
 
-  if (nodeName === 'textarea') {
+  if (elem instanceof HTMLTextAreaElement) {
     return true;
   }
 


### PR DESCRIPTION
This is a continuation of https://github.com/facebook/react/pull/6311. More or less, using `nodeName` as an ID on an input causes references to the `nodeName` prototype property to be overriden. 

I've rebased @jimfb's original PR and added some test coverage. I've also browser tested this against IE11, Firefox, Safari, and Chrome.

I would like to test down to IE9, however it looks like I need the Set polyfill on our DOM fixtures. **Is there a preferred method of adding the Set polyfill?**