### PR TITLE
[docs] Render link as a link

### DIFF
--- a/docs/warnings/unknown-prop.md
+++ b/docs/warnings/unknown-prop.md
@@ -7,7 +7,7 @@ The unknown-prop warning will fire if you attempt to render a DOM element with a
 
 There are a couple of likely reasons this warning could be appearing:
 
-1. Are you using `{...this.props}` or `cloneElement(element, this.props)`? Your component is transferring its own props directly to a child element (eg. https://facebook.github.io/react/docs/transferring-props.html). When transferring props to a child component, you should ensure that you are not accidentally forwarding props that were intended to be interpreted by the parent component.
+1. Are you using `{...this.props}` or `cloneElement(element, this.props)`? Your component is [transferring its own props directly to a child element](https://facebook.github.io/react/docs/transferring-props.html). When transferring props to a child component, you should ensure that you are not accidentally forwarding props that were intended to be interpreted by the parent component.
 
 2. You are using a non-standard DOM attribute on a native DOM node, perhaps to represent custom data. If you are trying to attach custom data to a standard DOM element, consider using a custom data attribute as described [on MDN](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Using_data_attributes).
 


### PR DESCRIPTION
The URL was in the documentation as a non-clickable link. Converting to an actual link and linking the relevant text in the docs.