### PR TITLE
Add React Boston 2017 to upcoming conferences

### DIFF
--- a/docs/community/conferences.md
+++ b/docs/community/conferences.md
@@ -24,6 +24,11 @@ September 6-7 in Wroclaw, Poland
 
 [Website](http://react-native.eu/)
 
+### React Boston 2017
+September 23-24 in Boston, Massachusetts USA
+
+[Website](http://www.reactboston.com/) - [Twitter](https://twitter.com/ReactBoston)
+
 ### React Alicante 2017
 September 28-30 in Alicante, Spain
 


### PR DESCRIPTION
We just announced [React Boston](http://www.reactboston.com/) and would like to add it to the upcoming conferences page if that's possible.

Thanks!
Andrew
