### PR TITLE
Refactor Debug Frames to Enable Renderers to Provide Custom Logic

### DIFF
--- a/scripts/fiber/tests-passing-except-dev.txt
+++ b/scripts/fiber/tests-passing-except-dev.txt
@@ -1,5 +1,2 @@
 src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
-* gives source code refs for unknown prop warning (ssr)
-* gives source code refs for unknown prop warning for exact elements (ssr)
 * gives source code refs for unknown prop warning for exact elements in composition (ssr)
-* should suggest property name if available (ssr)

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -853,10 +853,13 @@ src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * should warn about props that are no longer supported
 * should warn about props that are no longer supported (ssr)
 * gives source code refs for unknown prop warning
+* gives source code refs for unknown prop warning (ssr)
 * gives source code refs for unknown prop warning for update render
 * gives source code refs for unknown prop warning for exact elements
+* gives source code refs for unknown prop warning for exact elements (ssr)
 * gives source code refs for unknown prop warning for exact elements in composition
 * should suggest property name if available
+* should suggest property name if available (ssr)
 * renders innerHTML and preserves whitespace
 * render and then updates innerHTML and preserves whitespace
 

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -381,7 +381,11 @@ const bundles = [
     label: 'shallow-renderer',
     manglePropertiesOnProd: false,
     name: 'react-test-renderer/shallow',
-    paths: ['src/renderers/shared/**/*.js', 'src/renderers/testing/**/*.js'],
+    paths: [
+      'src/renderers/shared/**/*.js',
+      'src/renderers/testing/**/*.js',
+      'src/shared/**/*.js',
+    ],
   },
 
   /******* React Noop Renderer (used only for fixtures/fiber-debugger) *******/

--- a/src/isomorphic/children/traverseAllChildren.js
+++ b/src/isomorphic/children/traverseAllChildren.js
@@ -24,7 +24,7 @@ var REACT_ELEMENT_TYPE =
   0xeac7;
 
 if (__DEV__) {
-  var {getCurrentStackAddendum} = require('ReactComponentTreeHook');
+  var {getStackAddendum} = require('ReactDebugCurrentFrame');
 }
 
 var SEPARATOR = '.';
@@ -171,7 +171,7 @@ function traverseAllChildrenImpl(
             'Using Maps as children is unsupported and will likely yield ' +
               'unexpected results. Convert it to a sequence/iterable of keyed ' +
               'ReactElements instead.%s',
-            getCurrentStackAddendum(),
+            getStackAddendum(),
           );
           didWarnAboutMaps = true;
         }
@@ -196,7 +196,7 @@ function traverseAllChildrenImpl(
         addendum =
           ' If you meant to render a collection of children, use an array ' +
           'instead.' +
-          getCurrentStackAddendum();
+          getStackAddendum();
       }
       var childrenString = '' + children;
       invariant(

--- a/src/isomorphic/classic/element/ReactDebugCurrentFrame.js
+++ b/src/isomorphic/classic/element/ReactDebugCurrentFrame.js
@@ -12,42 +12,18 @@
 
 'use strict';
 
-import type {Fiber} from 'ReactFiber';
-import type {DebugID} from 'ReactInstanceType';
-
 const ReactDebugCurrentFrame = {};
 
 if (__DEV__) {
-  var {
-    getStackAddendumByID,
-    getCurrentStackAddendum,
-  } = require('ReactComponentTreeHook');
-  var {
-    getStackAddendumByWorkInProgressFiber,
-  } = require('ReactFiberComponentTreeHook');
-
   // Component that is being worked on
-  ReactDebugCurrentFrame.current = (null: Fiber | DebugID | null);
+  ReactDebugCurrentFrame.getCurrentStack = (null: null | (() => string | null));
 
   ReactDebugCurrentFrame.getStackAddendum = function(): string | null {
-    let stack = null;
-    const current = ReactDebugCurrentFrame.current;
-    if (current !== null) {
-      if (typeof current === 'number') {
-        // DebugID from Stack.
-        const debugID = current;
-        stack = getStackAddendumByID(debugID);
-      } else if (typeof current.tag === 'number') {
-        // This is a Fiber.
-        // The stack will only be correct if this is a work in progress
-        // version and we're calling it during reconciliation.
-        const workInProgress = current;
-        stack = getStackAddendumByWorkInProgressFiber(workInProgress);
-      }
-    } else {
-      stack = getCurrentStackAddendum();
+    const impl = ReactDebugCurrentFrame.getCurrentStack;
+    if (impl) {
+      return impl();
     }
-    return stack;
+    return null;
   };
 }
 

--- a/src/isomorphic/classic/element/ReactDebugCurrentFrame.js
+++ b/src/isomorphic/classic/element/ReactDebugCurrentFrame.js
@@ -29,13 +29,9 @@ if (__DEV__) {
   // Component that is being worked on
   ReactDebugCurrentFrame.current = (null: Fiber | DebugID | null);
 
-  // Element that is being cloned or created
-  ReactDebugCurrentFrame.element = (null: *);
-
   ReactDebugCurrentFrame.getStackAddendum = function(): string | null {
     let stack = null;
     const current = ReactDebugCurrentFrame.current;
-    const element = ReactDebugCurrentFrame.element;
     if (current !== null) {
       if (typeof current === 'number') {
         // DebugID from Stack.
@@ -48,8 +44,8 @@ if (__DEV__) {
         const workInProgress = current;
         stack = getStackAddendumByWorkInProgressFiber(workInProgress);
       }
-    } else if (element !== null) {
-      stack = getCurrentStackAddendum(element);
+    } else {
+      stack = getCurrentStackAddendum();
     }
     return stack;
   };

--- a/src/isomorphic/hooks/ReactComponentTreeHook.js
+++ b/src/isomorphic/hooks/ReactComponentTreeHook.js
@@ -13,13 +13,9 @@
 'use strict';
 
 var ReactCurrentOwner = require('ReactCurrentOwner');
-var {
-  getStackAddendumByWorkInProgressFiber,
-} = require('ReactFiberComponentTreeHook');
 var invariant = require('fbjs/lib/invariant');
 var warning = require('fbjs/lib/warning');
 var describeComponentFrame = require('describeComponentFrame');
-var getComponentName = require('getComponentName');
 
 import type {ReactElement, Source} from 'ReactElementType';
 import type {DebugID} from 'ReactInstanceType';
@@ -316,12 +312,11 @@ var ReactComponentTreeHook = {
     var info = '';
     var currentOwner = ReactCurrentOwner.current;
     if (currentOwner) {
-      if (typeof currentOwner.tag === 'number') {
-        const workInProgress = ((currentOwner: any): Fiber);
-        // Safe because if current owner exists, we are reconciling,
-        // and it is guaranteed to be the work-in-progress version.
-        info += getStackAddendumByWorkInProgressFiber(workInProgress);
-      } else if (typeof currentOwner._debugID === 'number') {
+      invariant(
+        typeof currentOwner.tag !== 'number',
+        'Fiber owners should not show up in Stack stack traces.',
+      );
+      if (typeof currentOwner._debugID === 'number') {
         info += ReactComponentTreeHook.getStackAddendumByID(
           currentOwner._debugID,
         );

--- a/src/isomorphic/hooks/ReactComponentTreeHook.js
+++ b/src/isomorphic/hooks/ReactComponentTreeHook.js
@@ -15,15 +15,14 @@
 var ReactCurrentOwner = require('ReactCurrentOwner');
 var {
   getStackAddendumByWorkInProgressFiber,
-  describeComponentFrame,
 } = require('ReactFiberComponentTreeHook');
 var invariant = require('fbjs/lib/invariant');
 var warning = require('fbjs/lib/warning');
+var describeComponentFrame = require('describeComponentFrame');
 var getComponentName = require('getComponentName');
 
 import type {ReactElement, Source} from 'ReactElementType';
 import type {DebugID} from 'ReactInstanceType';
-import type {Fiber} from 'ReactFiber';
 
 function isNative(fn) {
   // Based on isNative() from Lodash
@@ -313,18 +312,8 @@ var ReactComponentTreeHook = {
     return item ? item.isMounted : false;
   },
 
-  getCurrentStackAddendum(topElement: ?ReactElement): string {
+  getCurrentStackAddendum(): string {
     var info = '';
-    if (topElement) {
-      var name = getDisplayName(topElement);
-      var owner = topElement._owner;
-      info += describeComponentFrame(
-        name,
-        topElement._source,
-        owner && getComponentName(owner),
-      );
-    }
-
     var currentOwner = ReactCurrentOwner.current;
     if (currentOwner) {
       if (typeof currentOwner.tag === 'number') {

--- a/src/renderers/__tests__/ReactComponentTreeHook-test.js
+++ b/src/renderers/__tests__/ReactComponentTreeHook-test.js
@@ -37,7 +37,7 @@ describe('ReactComponentTreeHook', () => {
   describe('stack addenda', () => {
     it('gets created', () => {
       function getAddendum(element) {
-        var addendum = ReactComponentTreeHook.getCurrentStackAddendum(element);
+        var addendum = ReactComponentTreeHook.getCurrentStackAddendum();
         return addendum.replace(/\(at .+?:\d+\)/g, '(at **)');
       }
 
@@ -52,12 +52,12 @@ describe('ReactComponentTreeHook', () => {
       }
 
       expectDev(getAddendum()).toBe('');
-      expectDev(getAddendum(<div />)).toBe('\n    in div (at **)');
-      expectDev(getAddendum(<Anon />)).toBe('\n    in Unknown (at **)');
-      expectDev(getAddendum(<Orange />)).toBe('\n    in Orange (at **)');
-      expectDev(getAddendum(React.createElement(Orange))).toBe(
-        '\n    in Orange',
-      );
+      // expectDev(getAddendum(<div />)).toBe('\n    in div (at **)');
+      // expectDev(getAddendum(<Anon />)).toBe('\n    in Unknown (at **)');
+      // expectDev(getAddendum(<Orange />)).toBe('\n    in Orange (at **)');
+      // expectDev(getAddendum(React.createElement(Orange))).toBe(
+      //   '\n    in Orange',
+      // );
 
       var renders = 0;
       var rOwnedByQ;
@@ -82,15 +82,15 @@ describe('ReactComponentTreeHook', () => {
               '\n    in Q (at **)',
           );
           expectDev(getAddendum(<span />)).toBe(
-            '\n    in span (at **)' +
-              '\n    in S (at **)' +
+            // '\n    in span (at **)' +
+            '\n    in S (at **)' +
               '\n    in div (at **)' +
               '\n    in R (created by Q)' +
               '\n    in Q (at **)',
           );
           expectDev(getAddendum(React.createElement('span'))).toBe(
-            '\n    in span (created by S)' +
-              '\n    in S (at **)' +
+            // '\n    in span (created by S)' +
+            '\n    in S (at **)' +
               '\n    in div (at **)' +
               '\n    in R (created by Q)' +
               '\n    in Q (at **)',
@@ -103,7 +103,7 @@ describe('ReactComponentTreeHook', () => {
       expectDev(renders).toBe(2);
 
       // Make sure owner is fetched for the top element too.
-      expectDev(getAddendum(rOwnedByQ)).toBe('\n    in R (created by Q)');
+      // expectDev(getAddendum(rOwnedByQ)).toBe('\n    in R (created by Q)');
     });
 
     // These are features and regression tests that only affect

--- a/src/renderers/__tests__/ReactComponentTreeHook-test.js
+++ b/src/renderers/__tests__/ReactComponentTreeHook-test.js
@@ -20,6 +20,7 @@ describe('ReactComponentTreeHook', () => {
   var ReactDOMServer;
   var ReactInstanceMap;
   var ReactComponentTreeHook;
+  var ReactDebugCurrentFiber;
   var ReactComponentTreeTestUtils;
 
   beforeEach(() => {
@@ -29,6 +30,7 @@ describe('ReactComponentTreeHook', () => {
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');
     ReactInstanceMap = require('ReactInstanceMap');
+    ReactDebugCurrentFiber = require('ReactDebugCurrentFiber');
     ReactComponentTreeHook = require('ReactComponentTreeHook');
     ReactComponentTreeTestUtils = require('ReactComponentTreeTestUtils');
   });
@@ -37,7 +39,9 @@ describe('ReactComponentTreeHook', () => {
   describe('stack addenda', () => {
     it('gets created', () => {
       function getAddendum(element) {
-        var addendum = ReactComponentTreeHook.getCurrentStackAddendum();
+        var addendum = ReactDOMFeatureFlags.useFiber
+          ? ReactDebugCurrentFiber.getCurrentFiberStackAddendum() || ''
+          : ReactComponentTreeHook.getCurrentStackAddendum();
         return addendum.replace(/\(at .+?:\d+\)/g, '(at **)');
       }
 
@@ -47,9 +51,9 @@ describe('ReactComponentTreeHook', () => {
       Object.defineProperty(Anon, 'name', {
         value: null,
       });
-      function Orange() {
-        return null;
-      }
+      // function Orange() {
+      //   return null;
+      // }
 
       expectDev(getAddendum()).toBe('');
       // expectDev(getAddendum(<div />)).toBe('\n    in div (at **)');
@@ -60,10 +64,10 @@ describe('ReactComponentTreeHook', () => {
       // );
 
       var renders = 0;
-      var rOwnedByQ;
+      //var rOwnedByQ;
 
       function Q() {
-        return (rOwnedByQ = React.createElement(R));
+        return /*rOwnedByQ =*/ React.createElement(R);
       }
       function R() {
         return <div><S /></div>;

--- a/src/renderers/dom/shared/hooks/ReactDOMInvalidARIAHook.js
+++ b/src/renderers/dom/shared/hooks/ReactDOMInvalidARIAHook.js
@@ -12,7 +12,6 @@
 'use strict';
 
 var DOMProperty = require('DOMProperty');
-var ReactDebugCurrentFiber = require('ReactDebugCurrentFiber');
 
 var warning = require('fbjs/lib/warning');
 
@@ -20,7 +19,10 @@ var warnedProperties = {};
 var rARIA = new RegExp('^(aria)-[' + DOMProperty.ATTRIBUTE_NAME_CHAR + ']*$');
 
 if (__DEV__) {
-  var {ReactComponentTreeHook} = require('ReactGlobalSharedState');
+  var {
+    ReactComponentTreeHook,
+    ReactDebugCurrentFrame,
+  } = require('ReactGlobalSharedState');
   var {getStackAddendumByID} = ReactComponentTreeHook;
 }
 
@@ -29,8 +31,9 @@ function getStackAddendum(debugID) {
     // This can only happen on Stack
     return getStackAddendumByID(debugID);
   } else {
-    // This can only happen on Fiber
-    return ReactDebugCurrentFiber.getCurrentFiberStackAddendum();
+    // This can only happen on Fiber / Server
+    var stack = ReactDebugCurrentFrame.getStackAddendum();
+    return stack != null ? stack : '';
   }
 }
 

--- a/src/renderers/dom/shared/hooks/ReactDOMNullInputValuePropHook.js
+++ b/src/renderers/dom/shared/hooks/ReactDOMNullInputValuePropHook.js
@@ -11,11 +11,13 @@
 
 'use strict';
 
-var ReactDebugCurrentFiber = require('ReactDebugCurrentFiber');
 var warning = require('fbjs/lib/warning');
 
 if (__DEV__) {
-  var {ReactComponentTreeHook} = require('ReactGlobalSharedState');
+  var {
+    ReactComponentTreeHook,
+    ReactDebugCurrentFrame,
+  } = require('ReactGlobalSharedState');
   var {getStackAddendumByID} = ReactComponentTreeHook;
 }
 
@@ -26,8 +28,9 @@ function getStackAddendum(debugID) {
     // This can only happen on Stack
     return getStackAddendumByID(debugID);
   } else {
-    // This can only happen on Fiber
-    return ReactDebugCurrentFiber.getCurrentFiberStackAddendum();
+    // This can only happen on Fiber / Server
+    var stack = ReactDebugCurrentFrame.getStackAddendum();
+    return stack != null ? stack : '';
   }
 }
 

--- a/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
+++ b/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
@@ -13,18 +13,24 @@
 
 var DOMProperty = require('DOMProperty');
 var EventPluginRegistry = require('EventPluginRegistry');
-var ReactDebugCurrentFiber = require('ReactDebugCurrentFiber');
-var {ReactComponentTreeHook} = require('ReactGlobalSharedState');
 
 var warning = require('fbjs/lib/warning');
+
+if (__DEV__) {
+  var {
+    ReactComponentTreeHook,
+    ReactDebugCurrentFrame,
+  } = require('ReactGlobalSharedState');
+  var {getStackAddendumByID} = ReactComponentTreeHook;
+}
 
 function getStackAddendum(debugID) {
   if (debugID != null) {
     // This can only happen on Stack
-    return ReactComponentTreeHook.getStackAddendumByID(debugID);
+    return getStackAddendumByID(debugID);
   } else {
     // This can only happen on Fiber / Server
-    var stack = ReactDebugCurrentFiber.getCurrentFiberStackAddendum();
+    var stack = ReactDebugCurrentFrame.getStackAddendum();
     return stack != null ? stack : '';
   }
 }

--- a/src/renderers/shared/fiber/ReactDebugCurrentFiber.js
+++ b/src/renderers/shared/fiber/ReactDebugCurrentFiber.js
@@ -52,13 +52,13 @@ function getCurrentFiberStackAddendum(): string | null {
 }
 
 function resetCurrentFiber() {
-  ReactDebugCurrentFrame.current = null;
+  ReactDebugCurrentFrame.getCurrentStack = null;
   ReactDebugCurrentFiber.current = null;
   ReactDebugCurrentFiber.phase = null;
 }
 
 function setCurrentFiber(fiber: Fiber | null, phase: LifeCyclePhase | null) {
-  ReactDebugCurrentFrame.current = fiber;
+  ReactDebugCurrentFrame.getCurrentStack = getCurrentFiberStackAddendum;
   ReactDebugCurrentFiber.current = fiber;
   ReactDebugCurrentFiber.phase = phase;
 }

--- a/src/renderers/shared/fiber/ReactDebugCurrentFiber.js
+++ b/src/renderers/shared/fiber/ReactDebugCurrentFiber.js
@@ -16,6 +16,8 @@ import type {Fiber} from 'ReactFiber';
 
 type LifeCyclePhase = 'render' | 'getChildContext';
 
+var {ReactDebugCurrentFrame} = require('ReactGlobalSharedState');
+
 if (__DEV__) {
   var getComponentName = require('getComponentName');
   var {
@@ -49,10 +51,23 @@ function getCurrentFiberStackAddendum(): string | null {
   return null;
 }
 
+function resetCurrentFiber() {
+  ReactDebugCurrentFrame.current = null;
+  ReactDebugCurrentFiber.current = null;
+  ReactDebugCurrentFiber.phase = null;
+}
+
+function setCurrentFiber(fiber: Fiber | null, phase: LifeCyclePhase | null) {
+  ReactDebugCurrentFrame.current = fiber;
+  ReactDebugCurrentFiber.current = fiber;
+  ReactDebugCurrentFiber.phase = phase;
+}
+
 var ReactDebugCurrentFiber = {
   current: (null: Fiber | null),
   phase: (null: LifeCyclePhase | null),
-
+  resetCurrentFiber,
+  setCurrentFiber,
   getCurrentFiberOwnerName,
   getCurrentFiberStackAddendum,
 };

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -217,9 +217,9 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
     if (__DEV__) {
       ReactCurrentOwner.current = workInProgress;
-      ReactDebugCurrentFiber.phase = 'render';
+      ReactDebugCurrentFiber.setCurrentFiber(workInProgress, 'render');
       nextChildren = fn(nextProps, context);
-      ReactDebugCurrentFiber.phase = null;
+      ReactDebugCurrentFiber.setCurrentFiber(workInProgress, null);
     } else {
       nextChildren = fn(nextProps, context);
     }
@@ -286,9 +286,9 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     ReactCurrentOwner.current = workInProgress;
     let nextChildren;
     if (__DEV__) {
-      ReactDebugCurrentFiber.phase = 'render';
+      ReactDebugCurrentFiber.setCurrentFiber(workInProgress, 'render');
       nextChildren = instance.render();
-      ReactDebugCurrentFiber.phase = null;
+      ReactDebugCurrentFiber.setCurrentFiber(workInProgress, null);
     } else {
       nextChildren = instance.render();
     }
@@ -725,7 +725,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
 
     if (__DEV__) {
-      ReactDebugCurrentFiber.current = workInProgress;
+      ReactDebugCurrentFiber.setCurrentFiber(workInProgress, null);
     }
 
     switch (workInProgress.tag) {

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -187,7 +187,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     renderPriority: PriorityLevel,
   ): Fiber | null {
     if (__DEV__) {
-      ReactDebugCurrentFiber.current = workInProgress;
+      ReactDebugCurrentFiber.setCurrentFiber(workInProgress, null);
     }
 
     // Get the latest props.

--- a/src/renderers/shared/fiber/ReactFiberContext.js
+++ b/src/renderers/shared/fiber/ReactFiberContext.js
@@ -26,7 +26,6 @@ const {createCursor, pop, push} = require('ReactFiberStack');
 
 if (__DEV__) {
   var ReactDebugCurrentFiber = require('ReactDebugCurrentFiber');
-  var {ReactDebugCurrentFrame} = require('ReactGlobalSharedState');
   var {startPhaseTimer, stopPhaseTimer} = require('ReactDebugFiberPerf');
   var warnedAboutMissingGetChildContext = {};
 }
@@ -92,15 +91,15 @@ exports.getMaskedContext = function(
 
   if (__DEV__) {
     const name = getComponentName(workInProgress) || 'Unknown';
-    ReactDebugCurrentFrame.current = workInProgress;
+    ReactDebugCurrentFiber.setCurrentFiber(workInProgress, null);
     checkPropTypes(
       contextTypes,
       context,
       'context',
       name,
-      ReactDebugCurrentFrame.getStackAddendum,
+      ReactDebugCurrentFiber.getCurrentFiberStackAddendum,
     );
-    ReactDebugCurrentFrame.current = null;
+    ReactDebugCurrentFiber.resetCurrentFiber();
   }
 
   // Cache unmasked context so we can avoid recreating masked context unless necessary.
@@ -181,11 +180,11 @@ function processChildContext(
 
   let childContext;
   if (__DEV__) {
-    ReactDebugCurrentFiber.phase = 'getChildContext';
+    ReactDebugCurrentFiber.setCurrentFiber(fiber, 'getChildContext');
     startPhaseTimer(fiber, 'getChildContext');
     childContext = instance.getChildContext();
     stopPhaseTimer();
-    ReactDebugCurrentFiber.phase = null;
+    ReactDebugCurrentFiber.resetCurrentFiber();
   } else {
     childContext = instance.getChildContext();
   }
@@ -205,15 +204,15 @@ function processChildContext(
     // assume anything about the given fiber. We won't pass it down if we aren't sure.
     // TODO: remove this hack when we delete unstable_renderSubtree in Fiber.
     const workInProgress = isReconciling ? fiber : null;
-    ReactDebugCurrentFrame.current = workInProgress;
+    ReactDebugCurrentFiber.setCurrentFiber(workInProgress, null);
     checkPropTypes(
       childContextTypes,
       childContext,
       'child context',
       name,
-      ReactDebugCurrentFrame.getStackAddendum,
+      ReactDebugCurrentFiber.getCurrentFiberStackAddendum,
     );
-    ReactDebugCurrentFrame.current = null;
+    ReactDebugCurrentFiber.resetCurrentFiber();
   }
 
   return {...parentContext, ...childContext};

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -322,7 +322,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   function commitAllHostEffects() {
     while (nextEffect !== null) {
       if (__DEV__) {
-        ReactDebugCurrentFiber.current = nextEffect;
+        ReactDebugCurrentFiber.setCurrentFiber(nextEffect, null);
         recordEffect();
       }
 
@@ -383,7 +383,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
 
     if (__DEV__) {
-      ReactDebugCurrentFiber.current = null;
+      ReactDebugCurrentFiber.resetCurrentFiber();
     }
   }
 
@@ -711,7 +711,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
     ReactCurrentOwner.current = null;
     if (__DEV__) {
-      ReactDebugCurrentFiber.current = null;
+      ReactDebugCurrentFiber.resetCurrentFiber();
     }
 
     return next;
@@ -740,7 +740,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
     ReactCurrentOwner.current = null;
     if (__DEV__) {
-      ReactDebugCurrentFiber.current = null;
+      ReactDebugCurrentFiber.resetCurrentFiber();
     }
 
     return next;
@@ -1024,8 +1024,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     // It is no longer valid because we exited the user code.
     ReactCurrentOwner.current = null;
     if (__DEV__) {
-      ReactDebugCurrentFiber.current = null;
-      ReactDebugCurrentFiber.phase = null;
+      ReactDebugCurrentFiber.resetCurrentFiber();
     }
     // It is no longer valid because this unit of work failed.
     nextUnitOfWork = null;

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -23,6 +23,7 @@ var {ReactCurrentOwner} = require('ReactGlobalSharedState');
 
 if (__DEV__) {
   var {ReactDebugCurrentFrame} = require('ReactGlobalSharedState');
+  var ReactDebugCurrentStack = require('ReactDebugCurrentStack');
   var warningAboutMissingGetChildContext = {};
 }
 
@@ -403,6 +404,8 @@ var ReactCompositeComponent = {
   ) {
     if (__DEV__) {
       ReactCurrentOwner.current = this;
+      ReactDebugCurrentFrame.getCurrentStack =
+        ReactDebugCurrentStack.getStackAddendum;
       try {
         return this._constructComponentWithoutOwner(
           doConstruct,
@@ -412,6 +415,7 @@ var ReactCompositeComponent = {
         );
       } finally {
         ReactCurrentOwner.current = null;
+        ReactDebugCurrentFrame.getCurrentStack = null;
       }
     } else {
       return this._constructComponentWithoutOwner(
@@ -746,15 +750,15 @@ var ReactCompositeComponent = {
    */
   _checkContextTypes: function(typeSpecs, values, location: string) {
     if (__DEV__) {
-      ReactDebugCurrentFrame.current = this._debugID;
+      ReactDebugCurrentStack.current = this._debugID;
       checkPropTypes(
         typeSpecs,
         values,
         location,
         this.getName(),
-        ReactDebugCurrentFrame.getStackAddendum,
+        ReactDebugCurrentStack.getStackAddendum,
       );
-      ReactDebugCurrentFrame.current = null;
+      ReactDebugCurrentStack.current = null;
     }
   },
 
@@ -1246,10 +1250,17 @@ var ReactCompositeComponent = {
       this._compositeType !== ReactCompositeComponentTypes.StatelessFunctional
     ) {
       ReactCurrentOwner.current = this;
+      if (__DEV__) {
+        ReactDebugCurrentFrame.getCurrentStack =
+          ReactDebugCurrentStack.getStackAddendum;
+      }
       try {
         renderedElement = this._renderValidatedComponentWithoutOwnerOrContext();
       } finally {
         ReactCurrentOwner.current = null;
+        if (__DEV__) {
+          ReactDebugCurrentFrame.getCurrentStack = null;
+        }
       }
     } else {
       renderedElement = this._renderValidatedComponentWithoutOwnerOrContext();

--- a/src/renderers/shared/stack/reconciler/ReactDebugCurrentStack.js
+++ b/src/renderers/shared/stack/reconciler/ReactDebugCurrentStack.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactDebugCurrentStack
+ * @flow
+ */
+
+'use strict';
+
+import type {DebugID} from 'ReactInstanceType';
+
+const ReactDebugCurrentStack = {};
+
+if (__DEV__) {
+  var {ReactComponentTreeHook} = require('ReactGlobalSharedState');
+  var {getStackAddendumByID, getCurrentStackAddendum} = ReactComponentTreeHook;
+
+  // Component that is being worked on
+  ReactDebugCurrentStack.current = (null: DebugID | null);
+
+  ReactDebugCurrentStack.getStackAddendum = function(): string | null {
+    let stack = null;
+    const current = ReactDebugCurrentStack.current;
+    if (current !== null) {
+      stack = getStackAddendumByID(current);
+    } else {
+      stack = getCurrentStackAddendum();
+    }
+    return stack;
+  };
+}
+
+module.exports = ReactDebugCurrentStack;

--- a/src/renderers/shared/stack/reconciler/ReactMultiChild.js
+++ b/src/renderers/shared/stack/reconciler/ReactMultiChild.js
@@ -18,6 +18,10 @@ var ReactInstrumentation = require('ReactInstrumentation');
 var ReactReconciler = require('ReactReconciler');
 var ReactChildReconciler = require('ReactChildReconciler');
 var {ReactCurrentOwner} = require('ReactGlobalSharedState');
+if (__DEV__) {
+  var {ReactDebugCurrentFrame} = require('ReactGlobalSharedState');
+  var ReactDebugCurrentStack = require('ReactDebugCurrentStack');
+}
 
 var emptyFunction = require('fbjs/lib/emptyFunction');
 var flattenStackChildren = require('flattenStackChildren');
@@ -179,6 +183,8 @@ var ReactMultiChild = {
       if (this._currentElement) {
         try {
           ReactCurrentOwner.current = this._currentElement._owner;
+          ReactDebugCurrentFrame.getCurrentStack =
+            ReactDebugCurrentStack.getStackAddendum;
           return ReactChildReconciler.instantiateChildren(
             nestedChildren,
             transaction,
@@ -187,6 +193,7 @@ var ReactMultiChild = {
           );
         } finally {
           ReactCurrentOwner.current = null;
+          ReactDebugCurrentFrame.getCurrentStack = null;
         }
       }
     }
@@ -212,12 +219,15 @@ var ReactMultiChild = {
       if (this._currentElement) {
         try {
           ReactCurrentOwner.current = this._currentElement._owner;
+          ReactDebugCurrentFrame.getCurrentStack =
+            ReactDebugCurrentStack.getStackAddendum;
           nextChildren = flattenStackChildren(
             nextNestedChildrenElements,
             selfDebugID,
           );
         } finally {
           ReactCurrentOwner.current = null;
+          ReactDebugCurrentFrame.getCurrentStack = null;
         }
         ReactChildReconciler.updateChildren(
           prevChildren,

--- a/src/shared/ReactFiberComponentTreeHook.js
+++ b/src/shared/ReactFiberComponentTreeHook.js
@@ -19,23 +19,10 @@ var {
   ClassComponent,
   HostComponent,
 } = ReactTypeOfWork;
+var describeComponentFrame = require('describeComponentFrame');
 var getComponentName = require('getComponentName');
 
 import type {Fiber} from 'ReactFiber';
-
-function describeComponentFrame(name, source: any, ownerName) {
-  return (
-    '\n    in ' +
-    (name || 'Unknown') +
-    (source
-      ? ' (at ' +
-          source.fileName.replace(/^.*[\\\/]/, '') +
-          ':' +
-          source.lineNumber +
-          ')'
-      : ownerName ? ' (created by ' + ownerName + ')' : '')
-  );
-}
 
 function describeFiber(fiber: Fiber): string {
   switch (fiber.tag) {
@@ -72,5 +59,4 @@ function getStackAddendumByWorkInProgressFiber(workInProgress: Fiber): string {
 
 module.exports = {
   getStackAddendumByWorkInProgressFiber,
-  describeComponentFrame,
 };

--- a/src/shared/describeComponentFrame.js
+++ b/src/shared/describeComponentFrame.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ * @providesModule describeComponentFrame
+ */
+
+'use strict';
+
+module.exports = function(
+  name: null | string,
+  source: any,
+  ownerName: null | string,
+) {
+  return (
+    '\n    in ' +
+    (name || 'Unknown') +
+    (source
+      ? ' (at ' +
+          source.fileName.replace(/^.*[\\\/]/, '') +
+          ':' +
+          source.lineNumber +
+          ')'
+      : ownerName ? ' (created by ' + ownerName + ')' : '')
+  );
+};


### PR DESCRIPTION
This is two parts. First I do some refactoring to decouple the current debug frame.

Then I provide a custom stack frame for the partial renderer.

I still have to deal with stack frames that are not host components which are tail call optimized away right now - in a follow up (that's the last test).