### PR TITLE
Fix shallow renderer callbacks

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -1,2 +1,1 @@
-src/renderers/dom/test/__tests__/ReactTestUtils-test.js
-* can setState with a callback
+

--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -1,1 +1,2 @@
-
+src/renderers/dom/test/__tests__/ReactTestUtils-test.js
+* can setState with a callback

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1955,6 +1955,9 @@ src/renderers/dom/test/__tests__/ReactTestUtils-test.js
 * can setState in componentWillMount when shallow rendering
 * can setState in componentWillReceiveProps when shallow rendering
 * can setState with an updater function
+* can setState with a callback
+* can replaceState with a callback
+* can forceUpdate with a callback
 * can pass context when shallowly rendering
 * should track context across updates
 * can fail context when shallowly rendering

--- a/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
+++ b/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
@@ -435,6 +435,71 @@ describe('ReactTestUtils', () => {
     expect(callback).toHaveBeenCalled();
   });
 
+  it('can replaceState with a callback', () => {
+    let instance;
+
+    class SimpleComponent extends React.Component {
+      state = {
+        counter: 0,
+      };
+      render() {
+        instance = this;
+        return (
+          <p>
+            {this.state.counter}
+          </p>
+        );
+      }
+    }
+
+    const shallowRenderer = createRenderer();
+    const result = shallowRenderer.render(<SimpleComponent />);
+    expect(result.props.children).toBe(0);
+
+    const callback = jest.fn();
+    // No longer a public API, but we can test that it works internally by
+    // reaching into the updater.
+    shallowRenderer._updater.enqueueReplaceState(
+      instance,
+      {counter: 1},
+      callback,
+    );
+
+    const updated = shallowRenderer.getRenderOutput();
+    expect(updated.props.children).toBe(1);
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('can forceUpdate with a callback', () => {
+    let instance;
+
+    class SimpleComponent extends React.Component {
+      state = {
+        counter: 0,
+      };
+      render() {
+        instance = this;
+        return (
+          <p>
+            {this.state.counter}
+          </p>
+        );
+      }
+    }
+
+    const shallowRenderer = createRenderer();
+    const result = shallowRenderer.render(<SimpleComponent />);
+    expect(result.props.children).toBe(0);
+
+    const callback = jest.fn();
+
+    instance.forceUpdate(callback);
+
+    const updated = shallowRenderer.getRenderOutput();
+    expect(updated.props.children).toBe(0);
+    expect(callback).toHaveBeenCalled();
+  });
+
   it('can pass context when shallowly rendering', () => {
     class SimpleComponent extends React.Component {
       static contextTypes = {

--- a/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
+++ b/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
@@ -405,6 +405,36 @@ describe('ReactTestUtils', () => {
     expect(result.props.children).toEqual(2);
   });
 
+  it('can setState with a callback', () => {
+    let instance;
+
+    class SimpleComponent extends React.Component {
+      state = {
+        counter: 0,
+      };
+      render() {
+        instance = this;
+        return (
+          <p>
+            {this.state.counter}
+          </p>
+        );
+      }
+    }
+
+    const shallowRenderer = createRenderer();
+    const result = shallowRenderer.render(<SimpleComponent />);
+    expect(result.props.children).toBe(0);
+
+    const callback = jest.fn();
+
+    instance.setState({counter: 1}, callback);
+
+    const updated = shallowRenderer.getRenderOutput();
+    expect(updated.props.children).toBe(1);
+    expect(callback).toHaveBeenCalled();
+  });
+
   it('can pass context when shallowly rendering', () => {
     class SimpleComponent extends React.Component {
       static contextTypes = {

--- a/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
+++ b/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
@@ -426,7 +426,9 @@ describe('ReactTestUtils', () => {
     const result = shallowRenderer.render(<SimpleComponent />);
     expect(result.props.children).toBe(0);
 
-    const callback = jest.fn();
+    const callback = jest.fn(function() {
+      expect(this).toBe(instance);
+    });
 
     instance.setState({counter: 1}, callback);
 
@@ -456,7 +458,10 @@ describe('ReactTestUtils', () => {
     const result = shallowRenderer.render(<SimpleComponent />);
     expect(result.props.children).toBe(0);
 
-    const callback = jest.fn();
+    const callback = jest.fn(function() {
+      expect(this).toBe(instance);
+    });
+
     // No longer a public API, but we can test that it works internally by
     // reaching into the updater.
     shallowRenderer._updater.enqueueReplaceState(
@@ -491,7 +496,9 @@ describe('ReactTestUtils', () => {
     const result = shallowRenderer.render(<SimpleComponent />);
     expect(result.props.children).toBe(0);
 
-    const callback = jest.fn();
+    const callback = jest.fn(function() {
+      expect(this).toBe(instance);
+    });
 
     instance.forceUpdate(callback);
 

--- a/src/renderers/testing/ReactShallowRendererEntry.js
+++ b/src/renderers/testing/ReactShallowRendererEntry.js
@@ -201,11 +201,19 @@ class Updater {
 
   enqueueForceUpdate(publicInstance, callback, callerName) {
     this._renderer.render(this._renderer._element, this._renderer._context);
+
+    if (typeof callback === 'function') {
+      callback();
+    }
   }
 
   enqueueReplaceState(publicInstance, completeState, callback, callerName) {
     this._renderer._newState = completeState;
     this._renderer.render(this._renderer._element, this._renderer._context);
+
+    if (typeof callback === 'function') {
+      callback();
+    }
   }
 
   enqueueSetState(publicInstance, partialState, callback, callerName) {
@@ -219,6 +227,10 @@ class Updater {
     };
 
     this._renderer.render(this._renderer._element, this._renderer._context);
+
+    if (typeof callback === 'function') {
+      callback();
+    }
   }
 }
 

--- a/src/renderers/testing/ReactShallowRendererEntry.js
+++ b/src/renderers/testing/ReactShallowRendererEntry.js
@@ -203,7 +203,7 @@ class Updater {
     this._renderer.render(this._renderer._element, this._renderer._context);
 
     if (typeof callback === 'function') {
-      callback();
+      callback.call(publicInstance);
     }
   }
 
@@ -212,7 +212,7 @@ class Updater {
     this._renderer.render(this._renderer._element, this._renderer._context);
 
     if (typeof callback === 'function') {
-      callback();
+      callback.call(publicInstance);
     }
   }
 
@@ -229,7 +229,7 @@ class Updater {
     this._renderer.render(this._renderer._element, this._renderer._context);
 
     if (typeof callback === 'function') {
-      callback();
+      callback.call(publicInstance);
     }
   }
 }


### PR DESCRIPTION
Shallow renderer now executes any callbacks passed to setState/replaceState/forceUpdate.

Fixes #10089 
I've incorporated failing tests provided in #10092 by @Leeds-eBooks.
