### PR TITLE
Add missing displayName prop to createReactClass example

### DIFF
--- a/docs/docs/react-without-es6.md
+++ b/docs/docs/react-without-es6.md
@@ -20,6 +20,7 @@ If you don't use ES6 yet, you may use the `create-react-class` module instead:
 ```javascript
 var createReactClass = require('create-react-class');
 var Greeting = createReactClass({
+  displayName: 'Greeting',
   render: function() {
     return <h1>Hello, {this.props.name}</h1>;
   }


### PR DESCRIPTION
Without a `displayName` prop, snapshots generated by Jest would not contain the component name.

Before this change, a snapshot test might fail with a diff that looks like:

```
    -  <View>
    -    <View
    +  <>
    +    <
           onLayout={[Function]}
           style={null}
         >
           <item
             title="i0"
    @@ -47,12 +47,12 @@
               Object {
                 "key": "i0",
               }
             }
           />
    -    </View>
    -    <View
    +    </>
    +    <
```

After this change, the snapshot test referred above would not fail in this manner.