### PR TITLE
Don't increase priority when cloning current children

### DIFF
--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -1449,7 +1449,6 @@ exports.mountChildFibersInPlace = ChildReconciler(false, false);
 exports.cloneChildFibers = function(
   current: Fiber | null,
   workInProgress: Fiber,
-  renderPriority: PriorityLevel,
 ): void {
   invariant(
     current === null || workInProgress.child === current.child,
@@ -1461,7 +1460,10 @@ exports.cloneChildFibers = function(
   }
 
   let currentChild = workInProgress.child;
-  let newChild = createWorkInProgress(currentChild, renderPriority);
+  let newChild = createWorkInProgress(
+    currentChild,
+    currentChild.pendingWorkPriority,
+  );
   // TODO: Pass this as an argument, since it's easy to forget.
   newChild.pendingProps = currentChild.pendingProps;
   workInProgress.child = newChild;
@@ -1471,7 +1473,7 @@ exports.cloneChildFibers = function(
     currentChild = currentChild.sibling;
     newChild = newChild.sibling = createWorkInProgress(
       currentChild,
-      renderPriority,
+      currentChild.pendingWorkPriority,
     );
     newChild.pendingProps = currentChild.pendingProps;
     newChild.return = workInProgress;

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -674,9 +674,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     //   return null;
     // }
 
-    // TODO: Pass the priority as an argument
-    const renderPriority = workInProgress.pendingWorkPriority;
-    cloneChildFibers(current, workInProgress, renderPriority);
+    cloneChildFibers(current, workInProgress);
     return workInProgress.child;
   }
 

--- a/src/renderers/shared/fiber/__tests__/__snapshots__/ReactIncrementalPerf-test.js.snap
+++ b/src/renderers/shared/fiber/__tests__/__snapshots__/ReactIncrementalPerf-test.js.snap
@@ -61,8 +61,8 @@ exports[`ReactDebugFiberPerf deduplicates lifecycle names during commit to reduc
       ⚛ B.componentDidUpdate
   ⚛ B [update]
   ⛔ (Committing Changes) Warning: Caused by a cascading update in earlier commit
-    ⚛ (Committing Host Effects: 6 Total)
-    ⚛ (Calling Lifecycle Methods: 6 Total)
+    ⚛ (Committing Host Effects: 3 Total)
+    ⚛ (Calling Lifecycle Methods: 3 Total)
       ⚛ B.componentDidUpdate
 "
 `;


### PR DESCRIPTION
This fixes a snapshot test regression introduced by #10008. I had noticed this change and believed the new behavior was correct, but upon further investigation I was wrong. This reverts the snapshot test and fixes it accordingly.