### PR TITLE
Add Node v8.x support to devEngines in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "nodegit": "^0.18.0"
   },
   "devEngines": {
-    "node": "4.x || 5.x || 6.x || 7.x",
+    "node": "4.x || 5.x || 6.x || 7.x || 8.x",
     "npm": "2.x || 3.x || 4.x || 5.x"
   },
   "commonerConfig": {


### PR DESCRIPTION
Adds support for Node `v8.x` as described here https://github.com/facebook/react/issues/10127.