### PR TITLE
Adding missing assertion to ReactDOMComponent-test

### DIFF
--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -57,6 +57,7 @@ describe('ReactDOMComponent', () => {
       ReactDOM.render(<div style={setup} />, container);
       expect(stubStyle.display).toEqual('block');
       expect(stubStyle.left).toEqual('1px');
+      expect(stubStyle.top).toEqual('2px');
       expect(stubStyle.fontFamily).toEqual('Arial');
 
       // reset the style to their default state


### PR DESCRIPTION
It seems clear that this assertion was *meant* to be there. Test still passes, of course.