### PR TITLE
Fixing typo in ReactDOMComponent test name

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -763,7 +763,7 @@ src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
 * should handle className
 * should gracefully handle various style value types
 * should not update styles when mutating a proxy style object
-* should throw when mutating style objectsd
+* should throw when mutating style objects
 * should warn for unknown prop
 * should group multiple unknown prop warnings together
 * should warn for onDblClick prop

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -126,7 +126,7 @@ describe('ReactDOMComponent', () => {
       expect(stubStyle.lineHeight).toBe('');
     });
 
-    it('should throw when mutating style objectsd', () => {
+    it('should throw when mutating style objects', () => {
       var style = {border: '1px solid black'};
 
       class App extends React.Component {


### PR DESCRIPTION
`objectsd` -> `objects`