### PR TITLE
Add test fixtures to cover disabled selected options

### DIFF
--- a/fixtures/dom/src/components/IssueList.js
+++ b/fixtures/dom/src/components/IssueList.js
@@ -1,0 +1,26 @@
+const React = window.React;
+
+function csv(string) {
+  return string.split(/\s*,\s*/);
+}
+
+export default function IssueList({issues}) {
+  if (!issues) {
+    return null;
+  }
+
+  if (typeof issues === 'string') {
+    issues = csv(issues);
+  }
+
+  let links = issues.reduce((memo, issue, i) => {
+    return memo.concat(
+      i > 0 && i < issues.length ? ', ' : null,
+      <a href={'https://github.com/facebook/react/issues/' + issue} key={issue}>
+        {issue}
+      </a>
+    );
+  }, []);
+
+  return <span>{links}</span>;
+}

--- a/fixtures/dom/src/components/TestCase.js
+++ b/fixtures/dom/src/components/TestCase.js
@@ -1,7 +1,9 @@
+const React = window.React;
+
 import cn from 'classnames';
 import semver from 'semver';
-import React from 'react';
 import PropTypes from 'prop-types';
+import IssueList from './IssueList';
 import {parse} from 'query-string';
 import {semverString} from './propTypes';
 
@@ -36,6 +38,7 @@ class TestCase extends React.Component {
       resolvedIn,
       resolvedBy,
       affectedBrowsers,
+      relatedIssues,
       children,
     } = this.props;
 
@@ -93,6 +96,9 @@ class TestCase extends React.Component {
 
           {affectedBrowsers && <dt>Affected browsers: </dt>}
           {affectedBrowsers && <dd>{affectedBrowsers}</dd>}
+
+          {relatedIssues && <dt>Related Issues: </dt>}
+          {relatedIssues && <dd><IssueList issues={relatedIssues} /></dd>}
         </dl>
 
         <p className="test-case__desc">

--- a/fixtures/dom/src/components/fixtures/selects/index.js
+++ b/fixtures/dom/src/components/fixtures/selects/index.js
@@ -1,5 +1,8 @@
 const React = window.React;
 
+import FixtureSet from '../../FixtureSet';
+import TestCase from '../../TestCase';
+
 class SelectFixture extends React.Component {
   state = {value: ''};
   onChange = event => {
@@ -7,27 +10,66 @@ class SelectFixture extends React.Component {
   };
   render() {
     return (
-      <form>
-        <fieldset>
-          <legend>Controlled</legend>
-          <select value={this.state.value} onChange={this.onChange}>
-            <option value="">Select a color</option>
-            <option value="red">Red</option>
-            <option value="blue">Blue</option>
-            <option value="green">Green</option>
-          </select>
-          <span className="hint">Value: {this.state.value}</span>
-        </fieldset>
-        <fieldset>
-          <legend>Uncontrolled</legend>
-          <select defaultValue="">
-            <option value="">Select a color</option>
-            <option value="red">Red</option>
-            <option value="blue">Blue</option>
-            <option value="gree">Green</option>
-          </select>
-        </fieldset>
-      </form>
+      <FixtureSet title="Selects" description="">
+        <form className="field-group">
+          <fieldset>
+            <legend>Controlled</legend>
+            <select value={this.state.value} onChange={this.onChange}>
+              <option value="">Select a color</option>
+              <option value="red">Red</option>
+              <option value="blue">Blue</option>
+              <option value="green">Green</option>
+            </select>
+            <span className="hint">Value: {this.state.value}</span>
+          </fieldset>
+          <fieldset>
+            <legend>Uncontrolled</legend>
+            <select defaultValue="">
+              <option value="">Select a color</option>
+              <option value="red">Red</option>
+              <option value="blue">Blue</option>
+              <option value="gree">Green</option>
+            </select>
+          </fieldset>
+        </form>
+
+        <TestCase title="A selected disabled option" relatedIssues="2803">
+          <TestCase.Steps>
+            <li>Open the select</li>
+            <li>Select "1"</li>
+            <li>Attempt to reselect "Please select an item"</li>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            The initial picked option should be "Please select an
+            item", however it should not be a selectable option.
+          </TestCase.ExpectedResult>
+
+          <div className="test-fixture">
+            <select defaultValue="">
+              <option value="" disabled>Please select an item</option>
+              <option>0</option>
+              <option>1</option>
+              <option>2</option>
+            </select>
+          </div>
+        </TestCase>
+
+        <TestCase title="An unselected disabled option" relatedIssues="2803">
+          <TestCase.ExpectedResult>
+            The initial picked option value should "0": the first non-disabled option.
+          </TestCase.ExpectedResult>
+
+          <div className="test-fixture">
+            <select defaultValue="">
+              <option disabled>Please select an item</option>
+              <option>0</option>
+              <option>1</option>
+              <option>2</option>
+            </select>
+          </div>
+        </TestCase>
+      </FixtureSet>
     );
   }
 }

--- a/fixtures/dom/src/style.css
+++ b/fixtures/dom/src/style.css
@@ -8,14 +8,12 @@ html {
   font-size: 10px;
 }
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+    sans-serif;
   font-size: 1.4rem;
   margin: 0;
   padding: 0;
-}
-
-select {
-  width: 12rem;
 }
 
 button {
@@ -24,7 +22,6 @@ button {
   padding: 5px;
 }
 
-
 .header {
   background: #222;
   box-shadow: inset 0 -1px 3px #000;
@@ -32,6 +29,10 @@ button {
   line-height: 3.2rem;
   overflow: hidden;
   padding: .8rem 1.6rem;
+}
+
+.header select {
+  width: 12rem;
 }
 
 .header__inner {
@@ -101,7 +102,8 @@ fieldset {
   overflow: hidden;
 }
 
-ul, ol {
+ul,
+ol {
   margin: 0 0 2rem 0;
 }
 
@@ -211,4 +213,8 @@ li {
   margin: 0 -15px; /* opposite of .test-case padding */
   background-color: #f4f4f4;
   border-top: 1px solid #d9d9d9;
+}
+
+.field-group {
+  overflow: hidden;
 }


### PR DESCRIPTION
Related issues: #2803

We don't have amazing test fixture coverage for selects, so I've added two cases based on the discussion in #2803:

1. A selected, disabled, option should be picked, but not selectable
2. When there is no value match, the default selected option should be the first non-disabled option

Pretty standard stuff. A lot of this is just basic browser behavior, but I believe these test cases *already* caught a bug in the current edge build of React: 

**Selects no longer "skip" over disabled options when selecting the default option.** [(Example of standard DOM behavior)](https://codepen.io/nhunzaker/pen/GEwVYv)

Also, I've added a new field to link related issues in the test cases. Take a look at the result here:

http://react-select-default-option-fixtures.surge.sh/selects