### PR TITLE
Reword duplicate key warning

### DIFF
--- a/src/isomorphic/children/flattenChildren.js
+++ b/src/isomorphic/children/flattenChildren.js
@@ -38,11 +38,10 @@ function flattenSingleChildIntoContext(
         warning(
           false,
           'flattenChildren(...): Encountered two children with the same key, ' +
-            '`%s`. There is a possibility that maybe your app will break due ' +
-            'to you using keys this way. If it happens – unlucky!' +
-            ' To be honest it happens to all of us. ' +
-            'See https://fb.me/react-warning-keys for more information on ' +
-            'how to fix this.%s',
+            '`%s`. Keys should be unique so that components maintain their ' +
+            'identity across updates. Non-unique keys may cause children to ' +
+            'be duplicated and/or omitted in — the behavior is ' +
+            'unsupported and could change in a future version.%s',
           unescapeInDev(name),
           ReactComponentTreeHook.getStackAddendumByID(selfDebugID),
         );

--- a/src/isomorphic/children/flattenChildren.js
+++ b/src/isomorphic/children/flattenChildren.js
@@ -40,7 +40,7 @@ function flattenSingleChildIntoContext(
           'flattenChildren(...): Encountered two children with the same key, ' +
             '`%s`. Keys should be unique so that components maintain their ' +
             'identity across updates. Non-unique keys may cause children to ' +
-            'be duplicated and/or omitted in — the behavior is ' +
+            'be duplicated and/or omitted — the behavior is ' +
             'unsupported and could change in a future version.%s',
           unescapeInDev(name),
           ReactComponentTreeHook.getStackAddendumByID(selfDebugID),

--- a/src/isomorphic/children/flattenChildren.js
+++ b/src/isomorphic/children/flattenChildren.js
@@ -38,8 +38,11 @@ function flattenSingleChildIntoContext(
         warning(
           false,
           'flattenChildren(...): Encountered two children with the same key, ' +
-            '`%s`. Child keys must be unique; when two children share a key, only ' +
-            'the first child will be used.%s',
+            '`%s`. There is a possibility that maybe your app will break due ' +
+            'to you using keys this way. If it happens – unlucky!' +
+            ' To be honest it happens to all of us. ' +
+            'See https://fb.me/react-warning-keys for more information on ' +
+            'how to fix this.%s',
           unescapeInDev(name),
           ReactComponentTreeHook.getStackAddendumByID(selfDebugID),
         );

--- a/src/renderers/__tests__/ReactChildReconciler-test.js
+++ b/src/renderers/__tests__/ReactChildReconciler-test.js
@@ -62,7 +62,7 @@ describe('ReactChildReconciler', () => {
     expectDev(console.error.calls.argsFor(0)[0]).toContain(
       'Keys should be unique so that components maintain their identity ' +
         'across updates. Non-unique keys may cause children to be ' +
-        'duplicated and/or omitted in — the behavior is unsupported and ' +
+        'duplicated and/or omitted — the behavior is unsupported and ' +
         'could change in a future version.',
     );
   });
@@ -97,7 +97,7 @@ describe('ReactChildReconciler', () => {
       'Encountered two children with the same key, `1`. ' +
         'Keys should be unique so that components maintain their identity ' +
         'across updates. Non-unique keys may cause children to be ' +
-        'duplicated and/or omitted in — the behavior is unsupported and ' +
+        'duplicated and/or omitted — the behavior is unsupported and ' +
         'could change in a future version.',
       '    in div (at **)\n' +
         '    in Component (at **)\n' +
@@ -121,7 +121,7 @@ describe('ReactChildReconciler', () => {
     expectDev(console.error.calls.argsFor(0)[0]).toContain(
       'Keys should be unique so that components maintain their identity ' +
         'across updates. Non-unique keys may cause children to be ' +
-        'duplicated and/or omitted in — the behavior is unsupported and ' +
+        'duplicated and/or omitted — the behavior is unsupported and ' +
         'could change in a future version.',
     );
   });
@@ -156,7 +156,7 @@ describe('ReactChildReconciler', () => {
       'Encountered two children with the same key, `1`. ' +
         'Keys should be unique so that components maintain their identity ' +
         'across updates. Non-unique keys may cause children to be ' +
-        'duplicated and/or omitted in — the behavior is unsupported and ' +
+        'duplicated and/or omitted — the behavior is unsupported and ' +
         'could change in a future version.',
       '    in div (at **)\n' +
         '    in Component (at **)\n' +

--- a/src/renderers/__tests__/ReactChildReconciler-test.js
+++ b/src/renderers/__tests__/ReactChildReconciler-test.js
@@ -60,7 +60,10 @@ describe('ReactChildReconciler', () => {
 
     expectDev(console.error.calls.count()).toBe(1);
     expectDev(console.error.calls.argsFor(0)[0]).toContain(
-      'Child keys must be unique; when two children share a key, only the first child will be used.',
+      'There is a possibility that maybe your app will break due to you ' +
+        'using keys this way. If it happens – unlucky! To be honest it ' +
+        'happens to all of us. See https://fb.me/react-warning-keys for ' +
+        'more information on how to fix this.',
     );
   });
 
@@ -92,9 +95,11 @@ describe('ReactChildReconciler', () => {
       normalizeCodeLocInfo(console.error.calls.argsFor(0)[0]),
     ).toContain(
       'Encountered two children with the same key, `1`. ' +
-        'Child keys must be unique; when two children share a key, ' +
-        'only the first child will be used.\n' +
-        '    in div (at **)\n' +
+        'There is a possibility that maybe your app will break due to you ' +
+        'using keys this way. If it happens – unlucky! To be honest it ' +
+        'happens to all of us. See https://fb.me/react-warning-keys for ' +
+        'more information on how to fix this.',
+      '    in div (at **)\n' +
         '    in Component (at **)\n' +
         '    in Parent (at **)\n' +
         '    in GrandParent (at **)',
@@ -114,7 +119,10 @@ describe('ReactChildReconciler', () => {
 
     expectDev(console.error.calls.count()).toBe(1);
     expectDev(console.error.calls.argsFor(0)[0]).toContain(
-      'Child keys must be unique; when two children share a key, only the first child will be used.',
+      'There is a possibility that maybe your app will break due to you ' +
+        'using keys this way. If it happens – unlucky! To be honest it ' +
+        'happens to all of us. See https://fb.me/react-warning-keys for ' +
+        'more information on how to fix this.',
     );
   });
 
@@ -146,9 +154,11 @@ describe('ReactChildReconciler', () => {
       normalizeCodeLocInfo(console.error.calls.argsFor(0)[0]),
     ).toContain(
       'Encountered two children with the same key, `1`. ' +
-        'Child keys must be unique; when two children share a key, ' +
-        'only the first child will be used.\n' +
-        '    in div (at **)\n' +
+        'There is a possibility that maybe your app will break due to you ' +
+        'using keys this way. If it happens – unlucky! To be honest it ' +
+        'happens to all of us. See https://fb.me/react-warning-keys for ' +
+        'more information on how to fix this.',
+      '    in div (at **)\n' +
         '    in Component (at **)\n' +
         '    in Parent (at **)\n' +
         '    in GrandParent (at **)',

--- a/src/renderers/__tests__/ReactChildReconciler-test.js
+++ b/src/renderers/__tests__/ReactChildReconciler-test.js
@@ -99,7 +99,7 @@ describe('ReactChildReconciler', () => {
         'across updates. Non-unique keys may cause children to be ' +
         'duplicated and/or omitted in — the behavior is unsupported and ' +
         'could change in a future version.',
-        '    in div (at **)\n' +
+      '    in div (at **)\n' +
         '    in Component (at **)\n' +
         '    in Parent (at **)\n' +
         '    in GrandParent (at **)',
@@ -158,7 +158,7 @@ describe('ReactChildReconciler', () => {
         'across updates. Non-unique keys may cause children to be ' +
         'duplicated and/or omitted in — the behavior is unsupported and ' +
         'could change in a future version.',
-        '    in div (at **)\n' +
+      '    in div (at **)\n' +
         '    in Component (at **)\n' +
         '    in Parent (at **)\n' +
         '    in GrandParent (at **)',

--- a/src/renderers/__tests__/ReactChildReconciler-test.js
+++ b/src/renderers/__tests__/ReactChildReconciler-test.js
@@ -60,10 +60,10 @@ describe('ReactChildReconciler', () => {
 
     expectDev(console.error.calls.count()).toBe(1);
     expectDev(console.error.calls.argsFor(0)[0]).toContain(
-      'There is a possibility that maybe your app will break due to you ' +
-        'using keys this way. If it happens – unlucky! To be honest it ' +
-        'happens to all of us. See https://fb.me/react-warning-keys for ' +
-        'more information on how to fix this.',
+      'Keys should be unique so that components maintain their identity ' +
+        'across updates. Non-unique keys may cause children to be ' +
+        'duplicated and/or omitted in — the behavior is unsupported and ' +
+        'could change in a future version.',
     );
   });
 
@@ -95,11 +95,11 @@ describe('ReactChildReconciler', () => {
       normalizeCodeLocInfo(console.error.calls.argsFor(0)[0]),
     ).toContain(
       'Encountered two children with the same key, `1`. ' +
-        'There is a possibility that maybe your app will break due to you ' +
-        'using keys this way. If it happens – unlucky! To be honest it ' +
-        'happens to all of us. See https://fb.me/react-warning-keys for ' +
-        'more information on how to fix this.',
-      '    in div (at **)\n' +
+        'Keys should be unique so that components maintain their identity ' +
+        'across updates. Non-unique keys may cause children to be ' +
+        'duplicated and/or omitted in — the behavior is unsupported and ' +
+        'could change in a future version.',
+        '    in div (at **)\n' +
         '    in Component (at **)\n' +
         '    in Parent (at **)\n' +
         '    in GrandParent (at **)',
@@ -119,10 +119,10 @@ describe('ReactChildReconciler', () => {
 
     expectDev(console.error.calls.count()).toBe(1);
     expectDev(console.error.calls.argsFor(0)[0]).toContain(
-      'There is a possibility that maybe your app will break due to you ' +
-        'using keys this way. If it happens – unlucky! To be honest it ' +
-        'happens to all of us. See https://fb.me/react-warning-keys for ' +
-        'more information on how to fix this.',
+      'Keys should be unique so that components maintain their identity ' +
+        'across updates. Non-unique keys may cause children to be ' +
+        'duplicated and/or omitted in — the behavior is unsupported and ' +
+        'could change in a future version.',
     );
   });
 
@@ -154,11 +154,11 @@ describe('ReactChildReconciler', () => {
       normalizeCodeLocInfo(console.error.calls.argsFor(0)[0]),
     ).toContain(
       'Encountered two children with the same key, `1`. ' +
-        'There is a possibility that maybe your app will break due to you ' +
-        'using keys this way. If it happens – unlucky! To be honest it ' +
-        'happens to all of us. See https://fb.me/react-warning-keys for ' +
-        'more information on how to fix this.',
-      '    in div (at **)\n' +
+        'Keys should be unique so that components maintain their identity ' +
+        'across updates. Non-unique keys may cause children to be ' +
+        'duplicated and/or omitted in — the behavior is unsupported and ' +
+        'could change in a future version.',
+        '    in div (at **)\n' +
         '    in Component (at **)\n' +
         '    in Parent (at **)\n' +
         '    in GrandParent (at **)',

--- a/src/renderers/__tests__/ReactMultiChild-test.js
+++ b/src/renderers/__tests__/ReactMultiChild-test.js
@@ -191,7 +191,7 @@ describe('ReactMultiChild', () => {
         'Encountered two children with the same key, `1`. ' +
           'Keys should be unique so that components maintain their identity ' +
           'across updates. Non-unique keys may cause children to be ' +
-          'duplicated and/or omitted in — the behavior is unsupported and ' +
+          'duplicated and/or omitted — the behavior is unsupported and ' +
           'could change in a future version.',
         '    in div (at **)\n' +
           '    in WrapperComponent (at **)\n' +
@@ -258,7 +258,7 @@ describe('ReactMultiChild', () => {
         'Encountered two children with the same key, `1`. ' +
           'Keys should be unique so that components maintain their identity ' +
           'across updates. Non-unique keys may cause children to be ' +
-          'duplicated and/or omitted in — the behavior is unsupported and ' +
+          'duplicated and/or omitted — the behavior is unsupported and ' +
           'could change in a future version.',
         '    in div (at **)\n' +
           '    in WrapperComponent (at **)\n' +

--- a/src/renderers/__tests__/ReactMultiChild-test.js
+++ b/src/renderers/__tests__/ReactMultiChild-test.js
@@ -189,12 +189,11 @@ describe('ReactMultiChild', () => {
         normalizeCodeLocInfo(console.error.calls.argsFor(0)[0]),
       ).toContain(
         'Encountered two children with the same key, `1`. ' +
-          'There is a possibility that maybe your app will break due ' +
-          'to you using keys this way. If it happens – unlucky!' +
-          ' To be honest it happens to all of us. ' +
-          'See https://fb.me/react-warning-keys for more information on ' +
-          'how to fix this.',
-        '    in div (at **)\n' +
+          'Keys should be unique so that components maintain their identity ' +
+          'across updates. Non-unique keys may cause children to be ' +
+          'duplicated and/or omitted in — the behavior is unsupported and ' +
+          'could change in a future version.',
+          '    in div (at **)\n' +
           '    in WrapperComponent (at **)\n' +
           '    in div (at **)\n' +
           '    in Parent (at **)',
@@ -257,12 +256,11 @@ describe('ReactMultiChild', () => {
         normalizeCodeLocInfo(console.error.calls.argsFor(0)[0]),
       ).toContain(
         'Encountered two children with the same key, `1`. ' +
-          'There is a possibility that maybe your app will break due ' +
-          'to you using keys this way. If it happens – unlucky!' +
-          ' To be honest it happens to all of us. ' +
-          'See https://fb.me/react-warning-keys for more information on ' +
-          'how to fix this.',
-        '    in div (at **)\n' +
+          'Keys should be unique so that components maintain their identity ' +
+          'across updates. Non-unique keys may cause children to be ' +
+          'duplicated and/or omitted in — the behavior is unsupported and ' +
+          'could change in a future version.',
+          '    in div (at **)\n' +
           '    in WrapperComponent (at **)\n' +
           '    in div (at **)\n' +
           '    in Parent (at **)',

--- a/src/renderers/__tests__/ReactMultiChild-test.js
+++ b/src/renderers/__tests__/ReactMultiChild-test.js
@@ -193,7 +193,7 @@ describe('ReactMultiChild', () => {
           'across updates. Non-unique keys may cause children to be ' +
           'duplicated and/or omitted in — the behavior is unsupported and ' +
           'could change in a future version.',
-          '    in div (at **)\n' +
+        '    in div (at **)\n' +
           '    in WrapperComponent (at **)\n' +
           '    in div (at **)\n' +
           '    in Parent (at **)',
@@ -260,7 +260,7 @@ describe('ReactMultiChild', () => {
           'across updates. Non-unique keys may cause children to be ' +
           'duplicated and/or omitted in — the behavior is unsupported and ' +
           'could change in a future version.',
-          '    in div (at **)\n' +
+        '    in div (at **)\n' +
           '    in WrapperComponent (at **)\n' +
           '    in div (at **)\n' +
           '    in Parent (at **)',

--- a/src/renderers/__tests__/ReactMultiChild-test.js
+++ b/src/renderers/__tests__/ReactMultiChild-test.js
@@ -189,9 +189,12 @@ describe('ReactMultiChild', () => {
         normalizeCodeLocInfo(console.error.calls.argsFor(0)[0]),
       ).toContain(
         'Encountered two children with the same key, `1`. ' +
-          'Child keys must be unique; when two children share a key, ' +
-          'only the first child will be used.\n' +
-          '    in div (at **)\n' +
+          'There is a possibility that maybe your app will break due ' +
+          'to you using keys this way. If it happens – unlucky!' +
+          ' To be honest it happens to all of us. ' +
+          'See https://fb.me/react-warning-keys for more information on ' +
+          'how to fix this.',
+        '    in div (at **)\n' +
           '    in WrapperComponent (at **)\n' +
           '    in div (at **)\n' +
           '    in Parent (at **)',
@@ -254,9 +257,12 @@ describe('ReactMultiChild', () => {
         normalizeCodeLocInfo(console.error.calls.argsFor(0)[0]),
       ).toContain(
         'Encountered two children with the same key, `1`. ' +
-          'Child keys must be unique; when two children share a key, ' +
-          'only the first child will be used.\n' +
-          '    in div (at **)\n' +
+          'There is a possibility that maybe your app will break due ' +
+          'to you using keys this way. If it happens – unlucky!' +
+          ' To be honest it happens to all of us. ' +
+          'See https://fb.me/react-warning-keys for more information on ' +
+          'how to fix this.',
+        '    in div (at **)\n' +
           '    in WrapperComponent (at **)\n' +
           '    in div (at **)\n' +
           '    in Parent (at **)',

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -721,7 +721,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
             'Encountered two children with the same key, `%s`. ' +
               'Keys should be unique so that components maintain their identity ' +
               'across updates. Non-unique keys may cause children to be ' +
-              'duplicated and/or omitted in — the behavior is unsupported and ' +
+              'duplicated and/or omitted — the behavior is unsupported and ' +
               'could change in a future version.%s',
             key,
             getCurrentFiberStackAddendum(),

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -718,9 +718,12 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
           }
           warning(
             false,
-            'Encountered two children with the same key, ' +
-              '`%s`. Child keys must be unique; when two children share a key, ' +
-              'only the first child will be used.%s',
+            'Encountered two children with the same key, `%s`. ' +
+              'There is a possibility that maybe your app will break due ' +
+              'to you using keys this way. If it happens – unlucky!' +
+              ' To be honest it happens to all of us. ' +
+              'See https://fb.me/react-warning-keys for more information on ' +
+              'how to fix this.%s',
             key,
             getCurrentFiberStackAddendum(),
           );

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -719,11 +719,10 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
           warning(
             false,
             'Encountered two children with the same key, `%s`. ' +
-              'There is a possibility that maybe your app will break due ' +
-              'to you using keys this way. If it happens – unlucky!' +
-              ' To be honest it happens to all of us. ' +
-              'See https://fb.me/react-warning-keys for more information on ' +
-              'how to fix this.%s',
+              'Keys should be unique so that components maintain their identity ' +
+              'across updates. Non-unique keys may cause children to be ' +
+              'duplicated and/or omitted in — the behavior is unsupported and ' +
+              'could change in a future version.%s',
             key,
             getCurrentFiberStackAddendum(),
           );

--- a/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
+++ b/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
@@ -46,9 +46,13 @@ function instantiateChild(childInstances, child, name, selfDebugID) {
     if (!keyUnique) {
       warning(
         false,
-        'flattenChildren(...): Encountered two children with the same key, ' +
-          '`%s`. Child keys must be unique; when two children share a key, only ' +
-          'the first child will be used.%s',
+        'flattenChildren(...):' +
+          'Encountered two children with the same key, `%s`. ' +
+          'There is a possibility that maybe your app will break due ' +
+          'to you using keys this way. If it happens – unlucky!' +
+          ' To be honest it happens to all of us. ' +
+          'See https://fb.me/react-warning-keys for more information on ' +
+          'how to fix this.%s',
         KeyEscapeUtils.unescapeInDev(name),
         ReactComponentTreeHook.getStackAddendumByID(selfDebugID),
       );

--- a/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
+++ b/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
@@ -48,11 +48,10 @@ function instantiateChild(childInstances, child, name, selfDebugID) {
         false,
         'flattenChildren(...):' +
           'Encountered two children with the same key, `%s`. ' +
-          'There is a possibility that maybe your app will break due ' +
-          'to you using keys this way. If it happens – unlucky!' +
-          ' To be honest it happens to all of us. ' +
-          'See https://fb.me/react-warning-keys for more information on ' +
-          'how to fix this.%s',
+          'Keys should be unique so that components maintain their identity ' +
+          'across updates. Non-unique keys may cause children to be ' +
+          'duplicated and/or omitted in — the behavior is unsupported and ' +
+          'could change in a future version.%s',
         KeyEscapeUtils.unescapeInDev(name),
         ReactComponentTreeHook.getStackAddendumByID(selfDebugID),
       );

--- a/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
+++ b/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
@@ -50,7 +50,7 @@ function instantiateChild(childInstances, child, name, selfDebugID) {
           'Encountered two children with the same key, `%s`. ' +
           'Keys should be unique so that components maintain their identity ' +
           'across updates. Non-unique keys may cause children to be ' +
-          'duplicated and/or omitted in — the behavior is unsupported and ' +
+          'duplicated and/or omitted — the behavior is unsupported and ' +
           'could change in a future version.%s',
         KeyEscapeUtils.unescapeInDev(name),
         ReactComponentTreeHook.getStackAddendumByID(selfDebugID),

--- a/src/renderers/shared/stack/reconciler/flattenStackChildren.js
+++ b/src/renderers/shared/stack/reconciler/flattenStackChildren.js
@@ -57,11 +57,11 @@ function flattenSingleChildIntoContext(
         warning(
           false,
           'flattenChildren(...): Encountered two children with the same key, ' +
-            '`%s`. There is a possibility that maybe your app will break due ' +
-            'to you using keys this way. If it happens – unlucky!' +
-            ' To be honest it happens to all of us. ' +
-            'See https://fb.me/react-warning-keys for more information on ' +
-            'how to fix this.%s',
+            '`%s`. ' +
+            'Keys should be unique so that components maintain their identity ' +
+            'across updates. Non-unique keys may cause children to be ' +
+            'duplicated and/or omitted in — the behavior is unsupported and ' +
+            'could change in a future version.%s',
           KeyEscapeUtils.unescapeInDev(name),
           ReactComponentTreeHook.getStackAddendumByID(selfDebugID),
         );

--- a/src/renderers/shared/stack/reconciler/flattenStackChildren.js
+++ b/src/renderers/shared/stack/reconciler/flattenStackChildren.js
@@ -60,7 +60,7 @@ function flattenSingleChildIntoContext(
             '`%s`. ' +
             'Keys should be unique so that components maintain their identity ' +
             'across updates. Non-unique keys may cause children to be ' +
-            'duplicated and/or omitted in — the behavior is unsupported and ' +
+            'duplicated and/or omitted — the behavior is unsupported and ' +
             'could change in a future version.%s',
           KeyEscapeUtils.unescapeInDev(name),
           ReactComponentTreeHook.getStackAddendumByID(selfDebugID),

--- a/src/renderers/shared/stack/reconciler/flattenStackChildren.js
+++ b/src/renderers/shared/stack/reconciler/flattenStackChildren.js
@@ -57,8 +57,11 @@ function flattenSingleChildIntoContext(
         warning(
           false,
           'flattenChildren(...): Encountered two children with the same key, ' +
-            '`%s`. Child keys must be unique; when two children share a key, only ' +
-            'the first child will be used.%s',
+            '`%s`. There is a possibility that maybe your app will break due ' +
+            'to you using keys this way. If it happens – unlucky!' +
+            ' To be honest it happens to all of us. ' +
+            'See https://fb.me/react-warning-keys for more information on ' +
+            'how to fix this.%s',
           KeyEscapeUtils.unescapeInDev(name),
           ReactComponentTreeHook.getStackAddendumByID(selfDebugID),
         );


### PR DESCRIPTION
**what is the change?:**
 - Removes the now-inaccurate description of behavior around duplicate
   keys
 - Adds link to 'key' docs page
 - Changes tone to be more casual and friendly

Alternative wording idea;
'Encountered two children with the same key, ${key}
Child keys must be unique; using duplicate keys is not supported and
will cause unexpected behavior in some versions of React.
See https://fb.me/react-warning-keys for more information on how to
fix this.'

**why make this change?:**
Mainly this change was needed because in React 16, duplicate keys will
not cause omission of items with duplicate keys. All items will be
rendered. It could happen that in future versions of React we will have
different behavior though.

**test plan:**
`yarn test`

**issue:**
Wishlist item on https://github.com/facebook/react/issues/8854