### PR TITLE
Improve error message thrown in Fiber with multiple copies of React

### DIFF
--- a/docs/warnings/refs-must-have-owner.md
+++ b/docs/warnings/refs-must-have-owner.md
@@ -4,8 +4,14 @@ layout: single
 permalink: warnings/refs-must-have-owner.html
 ---
 
-You are probably here because you got the following error messages:
+You are probably here because you got one of the following error messages:
 
+*React 16.0.0+*
+> Warning:
+>
+> Element ref was specified as a string (myRefName) but no owner was set. You may have multiple copies of React loaded. (details: https://fb.me/react-refs-must-have-owner).
+
+*earlier versions of React*
 > Warning:
 >
 > addComponentAsRefTo(...): Only a ReactOwner can have refs. You might be adding a ref to a component that was not created inside a component's `render` method, or you have multiple copies of React loaded.

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -597,6 +597,9 @@ src/renderers/__tests__/ReactUpdates-test.js
 * does not re-render if state update is null
 * synchronously renders hidden subtrees
 
+src/renderers/__tests__/multiple-copies-of-react-test.js
+* throws the "Refs must have owner" warning
+
 src/renderers/__tests__/refs-destruction-test.js
 * should remove refs when destroying the parent
 * should remove refs when destroying the child

--- a/src/renderers/__tests__/multiple-copies-of-react-test.js
+++ b/src/renderers/__tests__/multiple-copies-of-react-test.js
@@ -29,39 +29,29 @@ class TextWithStringRef extends React.Component {
 
 
 describe('when different React version is used with string ref', () => {
-  describe('with stack reconciler', () => {
+  it('throws the "Refs must have owner" warning', () => {
     if (!ReactDOMFeatureFlags.useFiber) {
-      it('throws the "Refs must have owner" warning', () => {
-        expect(() => {
-          RefsComponent = ReactTestUtils.renderIntoDocument(
-            <TextWithStringRef />,
-          );
-        }).toThrow(
-          'Only a ReactOwner can have refs. You might be adding a ref to a ' +
-          'component that was not created inside a component\'s `render` ' +
-          'method, or you have multiple copies of React loaded ' +
-          '(details: https://fb.me/react-refs-must-have-owner)',
-        );
-      });
-    }
-  });
-  describe('with fiber reconciler', () => {
-    if (ReactDOMFeatureFlags.useFiber) {
-      it('throws the "Refs must have owner" warning', () => {
-        expect(() => {
-          RefsComponent = ReactTestUtils.renderIntoDocument(
-            <TextWithStringRef />,
-          );
-        }).toThrow(
-          'Only a ReactOwner can have refs. You might be adding a ref to a ' +
-          'component that was not created inside a component\'s `render` ' +
-          'method, or you have multiple copies of React loaded ' +
-          '(details: https://fb.me/react-refs-must-have-owner)',
-        );
-        var testRefsComponent = ReactTestUtils.renderIntoDocument(
+      expect(() => {
+        ReactTestUtils.renderIntoDocument(
           <TextWithStringRef />,
         );
-      });
+      }).toThrow(
+        'Only a ReactOwner can have refs. You might be adding a ref to a ' +
+        'component that was not created inside a component\'s `render` ' +
+        'method, or you have multiple copies of React loaded ' +
+        '(details: https://fb.me/react-refs-must-have-owner)',
+      );
+    } else {
+      expect(() => {
+        ReactTestUtils.renderIntoDocument(
+          <TextWithStringRef />,
+        );
+      }).toThrow(
+        'Only a ReactOwner can have refs. You might be adding a ref to a ' +
+        'component that was not created inside a component\'s `render` ' +
+        'method, or you have multiple copies of React loaded ' +
+        '(details: https://fb.me/react-refs-must-have-owner)',
+      );
     }
   });
 });

--- a/src/renderers/__tests__/multiple-copies-of-react-test.js
+++ b/src/renderers/__tests__/multiple-copies-of-react-test.js
@@ -29,14 +29,13 @@ class TextWithStringRef extends React.Component {
 
 describe('when different React version is used with string ref', () => {
   it('throws the "Refs must have owner" warning', () => {
-    if (!ReactDOMFeatureFlags.useFiber) {
+    if (ReactDOMFeatureFlags.useFiber) {
       expect(() => {
         ReactTestUtils.renderIntoDocument(<TextWithStringRef />);
       }).toThrow(
-        'Only a ReactOwner can have refs. You might be adding a ref to a ' +
-          "component that was not created inside a component's `render` " +
-          'method, or you have multiple copies of React loaded ' +
-          '(details: https://fb.me/react-refs-must-have-owner)',
+        'Element ref was specified as a string (foo) but no owner was set.' +
+          ' You may have multiple copies of React loaded. (details: ' +
+          'https://fb.me/react-refs-must-have-owner).',
       );
     } else {
       expect(() => {

--- a/src/renderers/__tests__/multiple-copies-of-react-test.js
+++ b/src/renderers/__tests__/multiple-copies-of-react-test.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React = require('react');
+var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
+var ReactTestUtils = require('react-dom/test-utils');
+
+class TextWithStringRef extends React.Component {
+  render() {
+    jest.resetModules();
+    React = require('react');
+    return (
+      <span ref="foo">
+        Hello world!
+      </span>
+    );
+  }
+}
+
+
+describe('when different React version is used with string ref', () => {
+  describe('with stack reconciler', () => {
+    if (!ReactDOMFeatureFlags.useFiber) {
+      it('throws the "Refs must have owner" warning', () => {
+        expect(() => {
+          RefsComponent = ReactTestUtils.renderIntoDocument(
+            <TextWithStringRef />,
+          );
+        }).toThrow(
+          'Only a ReactOwner can have refs. You might be adding a ref to a ' +
+          'component that was not created inside a component\'s `render` ' +
+          'method, or you have multiple copies of React loaded ' +
+          '(details: https://fb.me/react-refs-must-have-owner)',
+        );
+      });
+    }
+  });
+  describe('with fiber reconciler', () => {
+    if (ReactDOMFeatureFlags.useFiber) {
+      it('throws the "Refs must have owner" warning', () => {
+        expect(() => {
+          RefsComponent = ReactTestUtils.renderIntoDocument(
+            <TextWithStringRef />,
+          );
+        }).toThrow(
+          'Only a ReactOwner can have refs. You might be adding a ref to a ' +
+          'component that was not created inside a component\'s `render` ' +
+          'method, or you have multiple copies of React loaded ' +
+          '(details: https://fb.me/react-refs-must-have-owner)',
+        );
+        var testRefsComponent = ReactTestUtils.renderIntoDocument(
+          <TextWithStringRef />,
+        );
+      });
+    }
+  });
+});

--- a/src/renderers/__tests__/multiple-copies-of-react-test.js
+++ b/src/renderers/__tests__/multiple-copies-of-react-test.js
@@ -27,30 +27,25 @@ class TextWithStringRef extends React.Component {
   }
 }
 
-
 describe('when different React version is used with string ref', () => {
   it('throws the "Refs must have owner" warning', () => {
     if (!ReactDOMFeatureFlags.useFiber) {
       expect(() => {
-        ReactTestUtils.renderIntoDocument(
-          <TextWithStringRef />,
-        );
+        ReactTestUtils.renderIntoDocument(<TextWithStringRef />);
       }).toThrow(
         'Only a ReactOwner can have refs. You might be adding a ref to a ' +
-        'component that was not created inside a component\'s `render` ' +
-        'method, or you have multiple copies of React loaded ' +
-        '(details: https://fb.me/react-refs-must-have-owner)',
+          "component that was not created inside a component's `render` " +
+          'method, or you have multiple copies of React loaded ' +
+          '(details: https://fb.me/react-refs-must-have-owner)',
       );
     } else {
       expect(() => {
-        ReactTestUtils.renderIntoDocument(
-          <TextWithStringRef />,
-        );
+        ReactTestUtils.renderIntoDocument(<TextWithStringRef />);
       }).toThrow(
         'Only a ReactOwner can have refs. You might be adding a ref to a ' +
-        'component that was not created inside a component\'s `render` ' +
-        'method, or you have multiple copies of React loaded ' +
-        '(details: https://fb.me/react-refs-must-have-owner)',
+          "component that was not created inside a component's `render` " +
+          'method, or you have multiple copies of React loaded ' +
+          '(details: https://fb.me/react-refs-must-have-owner)',
       );
     }
   });

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -162,6 +162,18 @@ function coerceRef(current: Fiber | null, element: ReactElement) {
       };
       ref._stringRef = stringRef;
       return ref;
+    } else {
+      invariant(
+        typeof mixedRef === 'string',
+        'Expected ref to be a function or a string.',
+      );
+      invariant(
+        element._owner,
+        'Element ref was specified as a string (%s) but no owner was ' +
+          'set. You may have multiple copies of React loaded. ' +
+          '(details: https://fb.me/react-refs-must-have-owner).',
+        mixedRef,
+      );
     }
   }
   return mixedRef;

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -557,12 +557,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   function commitAttachRef(finishedWork: Fiber) {
     const ref = finishedWork.ref;
     if (ref !== null) {
-      invariant(
-        typeof ref === 'function',
-        'commitAttachRef(...): Expected ref to be a function. ' +
-          'You may have multiple copies of React loaded. ' +
-          '(details: https://fb.me/react-expected-ref-to-be-function).',
-      );
       const instance = finishedWork.stateNode;
       switch (finishedWork.tag) {
         case HostComponent:

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -557,6 +557,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   function commitAttachRef(finishedWork: Fiber) {
     const ref = finishedWork.ref;
     if (ref !== null) {
+      invariant(
+        typeof ref === 'function',
+        'commitAttachRef(...): Expected ref to be a function. ' +
+          'You may have multiple copies of React loaded. ' +
+          '(details: https://fb.me/react-expected-ref-to-be-function).',
+      );
       const instance = finishedWork.stateNode;
       switch (finishedWork.tag) {
         case HostComponent:


### PR DESCRIPTION
**what is the change?:**
 - Added warning in the place where this error is thrown in Fiber, to
   get parity with older versions of React.
 - Updated docs to mention new error message as well as old one.

I started to write a new docs page for the new error, and realized the
content was the same as the old one. So then I just updated the existing
error page.

**why make this change?:**
We want to avoid confusion when this error is thrown from React v16.

**test plan:**
- `yarn test src/renderers/__tests__/multiple-copies-of-react-test.js`
- `REACT_JEST_USE_FIBER=1 yarn run test src/renderers/__tests__/multiple-copies-of-react-test.js`
- manually inspected docs page
- manually tested in a CRA to trigger the error message

![screen shot 2017-07-12 at 12 15 22 pm](https://user-images.githubusercontent.com/1114467/28135678-f118f4ec-66fb-11e7-8fda-4724a52b80aa.png)


![screen shot 2017-07-12 at 11 52 07 am](https://user-images.githubusercontent.com/1114467/28134792-e14e75ee-66f8-11e7-8149-d2ef0ea45bce.png)

**issue:**
Fixes #9962
Related to #8854