### PR TITLE
Add an invariant to ReactTestUtilsEntry.makeSimulator() (#10165)

### DIFF
--- a/src/renderers/dom/test/ReactTestUtilsEntry.js
+++ b/src/renderers/dom/test/ReactTestUtilsEntry.js
@@ -447,6 +447,11 @@ function makeSimulator(eventType) {
       'TestUtils.Simulate expects a component instance and not a ReactElement.' +
         'TestUtils.Simulate will not work if you are using shallow rendering.',
     );
+    invariant(
+      !ReactTestUtils.isCompositeComponent(domComponentOrNode),
+      'TestUtils.Simulate does not support a composite component instance.' +
+        'TestUtils.Simulate only works with DOM component instance or a DOM node.',
+    );
     if (ReactTestUtils.isDOMComponent(domComponentOrNode)) {
       node = findDOMNode(domComponentOrNode);
     } else if (domComponentOrNode.tagName) {


### PR DESCRIPTION
Simulate methods support only passing DOM instances or nodes.
Throw early if a composite component instance is passed.

Closes https://github.com/facebook/react/issues/10165