### PR TITLE
Remove didCommit from scheduler

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -232,7 +232,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   let isUnmounting: boolean = false;
 
   // Use these to prevent an infinite loop of nested updates
-  let didCommit = false;
   let nestedSyncUpdates = 0;
   let NESTED_SYNC_UPDATE_LIMIT = 1000;
 
@@ -291,9 +290,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       priorityContext = nextPriorityLevel;
 
       if (
-        didCommit &&
-        (nextPriorityLevel === TaskPriority ||
-          nextPriorityLevel === SynchronousPriority)
+        nextPriorityLevel === TaskPriority ||
+        nextPriorityLevel === SynchronousPriority
       ) {
         invariant(
           nestedSyncUpdates++ <= NESTED_SYNC_UPDATE_LIMIT,
@@ -434,7 +432,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     // local to this function is because errors that occur during cWU are
     // captured elsewhere, to prevent the unmount from being interrupted.
     isCommitting = true;
-    didCommit = true;
     if (__DEV__) {
       startCommitTimer();
     }
@@ -1011,7 +1008,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     firstUncaughtError = null;
     capturedErrors = null;
     failedBoundaries = null;
-    didCommit = false;
     nestedSyncUpdates = 0;
     if (__DEV__) {
       stopWorkLoopTimer();


### PR DESCRIPTION
Don't actually need to track this, now that we moved the infinite loop check to findNextUnitOfWork.