### PR TITLE
Fix crash on master introduced during the radio bugfix

### DIFF
--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -1,2 +1,1 @@
-src/renderers/dom/shared/__tests__/inputValueTracking-test.js
-* does not crash for nodes with custom value property
+

--- a/scripts/fiber/tests-failing.txt
+++ b/scripts/fiber/tests-failing.txt
@@ -1,1 +1,2 @@
-
+src/renderers/dom/shared/__tests__/inputValueTracking-test.js
+* does not crash for nodes with custom value property

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1658,6 +1658,7 @@ src/renderers/dom/shared/__tests__/inputValueTracking-test.js
 * should track value and return true when updating untracked instance
 * should return tracker from node
 * should stop tracking
+* does not crash for nodes with custom value property
 
 src/renderers/dom/shared/__tests__/quoteAttributeValueForBrowser-test.js
 * should escape boolean to string

--- a/src/renderers/dom/shared/__tests__/inputValueTracking-test.js
+++ b/src/renderers/dom/shared/__tests__/inputValueTracking-test.js
@@ -13,6 +13,7 @@
 
 var React = require('react');
 var ReactDOM = require('react-dom');
+var ReactTestUtils = require('react-dom/test-utils');
 // TODO: can we express this test with only public API?
 var inputValueTracking = require('inputValueTracking');
 
@@ -170,6 +171,8 @@ describe('inputValueTracking', () => {
       var node = ReactDOM.render(<input type="text" />, div);
       // Update
       ReactDOM.render(<input type="text" />, div);
+      // Change
+      ReactTestUtils.SimulateNative.change(node);
       // Unmount
       ReactDOM.unmountComponentAtNode(div);
     } finally {

--- a/src/renderers/dom/shared/__tests__/inputValueTracking-test.js
+++ b/src/renderers/dom/shared/__tests__/inputValueTracking-test.js
@@ -12,7 +12,7 @@
 'use strict';
 
 var React = require('react');
-var ReactTestUtils = require('react-dom/test-utils');
+var ReactDOM = require('react-dom');
 // TODO: can we express this test with only public API?
 var inputValueTracking = require('inputValueTracking');
 
@@ -135,9 +135,8 @@ describe('inputValueTracking', () => {
   });
 
   it('should return tracker from node', () => {
-    var node = ReactTestUtils.renderIntoDocument(
-      <input type="text" defaultValue="foo" />,
-    );
+    var div = document.createElement('div');
+    var node = ReactDOM.render(<input type="text" defaultValue="foo" />, div);
     var tracker = inputValueTracking._getTrackerFromNode(node);
     expect(tracker.getValue()).toEqual('foo');
   });
@@ -152,5 +151,29 @@ describe('inputValueTracking', () => {
     expect(mockComponent._wrapperState.valueTracker).toEqual(null);
 
     expect(input.hasOwnProperty('value')).toBe(false);
+  });
+
+  it('does not crash for nodes with custom value property', () => {
+    // https://github.com/facebook/react/issues/10196
+    try {
+      var originalCreateElement = document.createElement;
+      document.createElement = function() {
+        var node = originalCreateElement.apply(this, arguments);
+        Object.defineProperty(node, 'value', {
+          get() {},
+          set() {},
+        });
+        return node;
+      };
+      var div = document.createElement('div');
+      // Mount
+      var node = ReactDOM.render(<input type="text" />, div);
+      // Update
+      ReactDOM.render(<input type="text" />, div);
+      // Unmount
+      ReactDOM.unmountComponentAtNode(div);
+    } finally {
+      document.createElement = originalCreateElement;
+    }
   });
 });

--- a/src/renderers/dom/shared/inputValueTracking.js
+++ b/src/renderers/dom/shared/inputValueTracking.js
@@ -138,7 +138,6 @@ var inputValueTracking = {
 
     var isNode = (subject: any).nodeType === ELEMENT_NODE;
     var tracker = getTracker(subject);
-
     if (!tracker) {
       if (isNode) {
         // DOM node
@@ -153,8 +152,6 @@ var inputValueTracking = {
       return true;
     }
 
-    var lastValue = tracker.getValue();
-
     var node;
     if (isNode) {
       // DOM node
@@ -164,6 +161,7 @@ var inputValueTracking = {
       node = ReactDOMComponentTree.getNodeFromInstance(subject);
     }
 
+    var lastValue = tracker.getValue();
     var nextValue = getValueFromNode(node);
     if (nextValue !== lastValue) {
       tracker.setValue(nextValue);


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/10196.
See individual commits for descriptions of how this got broken, and why this fix works.

**This is a minimal fix to unbreak master.**

Follow-up items that @jquense and I will look into:

* Remove lazy tracker path from `updateValueIfChanged`. It isn’t useful, and makes code more complicated. It is easier if we can assume that tracker is always exists while component is mounted.

* Simplify the wild polymorphism. This method accepts a fiber, a Stack instance, and a DOM node. Stack will be gone soon, so we should look into either making it always accept a DOM node, or maybe making it always accept a fiber.

* Related: reduce the abstraction in naming. I think #10156 made things slightly more confusing by calling argument a “subject” and we lost track of what it means. Let’s be explicit and precise about what exactly it is, and try to use Flow with less `any`s here.