### PR TITLE
Move input valueTracker to DOM nodes

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -1645,9 +1645,9 @@ src/renderers/dom/shared/__tests__/findDOMNode-test.js
 * findDOMNode should not throw an error when called within a component that is not mounted
 
 src/renderers/dom/shared/__tests__/inputValueTracking-test.js
-* should attach tracker to wrapper state
-* should define `value` on the instance node
-* should define `checked` on the instance node
+* should attach tracker to node
+* should define `value` on the node instance
+* should define `checked` on the node instance
 * should initialize with the current value
 * should initialize with the current `checked`
 * should track value changes
@@ -1655,7 +1655,7 @@ src/renderers/dom/shared/__tests__/inputValueTracking-test.js
 * should update value manually
 * should coerce value to a string
 * should update value if it changed and return result
-* should track value and return true when updating untracked instance
+* should return true when updating untracked instance
 * should return tracker from node
 * should stop tracking
 * does not crash for nodes with custom value property

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -757,7 +757,7 @@ var ReactDOMFiberComponent = {
 
         // We also check that we haven't missed a value update, such as a
         // Radio group shifting the checked value to another named radio input.
-        inputValueTracking.updateValueIfChanged((domElement: any));
+        inputValueTracking.updateNodeValueIfChanged((domElement: any));
         break;
       case 'textarea':
         ReactDOMFiberTextarea.updateWrapper(domElement, nextRawProps);

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -509,13 +509,13 @@ var ReactDOMFiberComponent = {
       case 'input':
         // TODO: Make sure we check if this is still unmounted or do any clean
         // up necessary since we never stop tracking anymore.
-        inputValueTracking.trackNode((domElement: any));
+        inputValueTracking.track((domElement: any));
         ReactDOMFiberInput.postMountWrapper(domElement, rawProps);
         break;
       case 'textarea':
         // TODO: Make sure we check if this is still unmounted or do any clean
         // up necessary since we never stop tracking anymore.
-        inputValueTracking.trackNode((domElement: any));
+        inputValueTracking.track((domElement: any));
         ReactDOMFiberTextarea.postMountWrapper(domElement, rawProps);
         break;
       case 'option':
@@ -757,7 +757,7 @@ var ReactDOMFiberComponent = {
 
         // We also check that we haven't missed a value update, such as a
         // Radio group shifting the checked value to another named radio input.
-        inputValueTracking.updateNodeValueIfChanged((domElement: any));
+        inputValueTracking.updateValueIfChanged((domElement: any));
         break;
       case 'textarea':
         ReactDOMFiberTextarea.updateWrapper(domElement, nextRawProps);
@@ -967,13 +967,13 @@ var ReactDOMFiberComponent = {
       case 'input':
         // TODO: Make sure we check if this is still unmounted or do any clean
         // up necessary since we never stop tracking anymore.
-        inputValueTracking.trackNode((domElement: any));
+        inputValueTracking.track((domElement: any));
         ReactDOMFiberInput.postMountWrapper(domElement, rawProps);
         break;
       case 'textarea':
         // TODO: Make sure we check if this is still unmounted or do any clean
         // up necessary since we never stop tracking anymore.
-        inputValueTracking.trackNode((domElement: any));
+        inputValueTracking.track((domElement: any));
         ReactDOMFiberTextarea.postMountWrapper(domElement, rawProps);
         break;
       case 'select':

--- a/src/renderers/dom/shared/__tests__/inputValueTracking-test.js
+++ b/src/renderers/dom/shared/__tests__/inputValueTracking-test.js
@@ -17,6 +17,8 @@ var ReactTestUtils = require('react-dom/test-utils');
 // TODO: can we express this test with only public API?
 var inputValueTracking = require('inputValueTracking');
 
+var getTracker = inputValueTracking._getTrackerFromNode;
+
 describe('inputValueTracking', () => {
   var input, checkbox, mockComponent;
 
@@ -28,25 +30,30 @@ describe('inputValueTracking', () => {
     mockComponent = {_hostNode: input, _wrapperState: {}};
   });
 
-  it('should attach tracker to wrapper state', () => {
-    inputValueTracking.track(mockComponent);
+  it('should attach tracker to node', () => {
+    var node = ReactTestUtils.renderIntoDocument(
+      <input type="text" />,
+    );
 
-    expect(mockComponent._wrapperState.hasOwnProperty('valueTracker')).toBe(
+    expect(node.hasOwnProperty('_valueTracker')).toBe(
       true,
     );
   });
 
-  it('should define `value` on the instance node', () => {
-    inputValueTracking.track(mockComponent);
+  it('should define `value` on the node instance', () => {
+    var node = ReactTestUtils.renderIntoDocument(
+      <input type="text" />,
+    );
 
-    expect(input.hasOwnProperty('value')).toBe(true);
+    expect(node.hasOwnProperty('value')).toBe(true);
   });
 
-  it('should define `checked` on the instance node', () => {
-    mockComponent._hostNode = checkbox;
-    inputValueTracking.track(mockComponent);
+  it('should define `checked` on the node instance', () => {
+    var node = ReactTestUtils.renderIntoDocument(
+      <input type="checkbox" />,
+    );
 
-    expect(checkbox.hasOwnProperty('checked')).toBe(true);
+    expect(node.hasOwnProperty('checked')).toBe(true);
   });
 
   it('should initialize with the current value', () => {
@@ -54,7 +61,7 @@ describe('inputValueTracking', () => {
 
     inputValueTracking.track(mockComponent);
 
-    var tracker = mockComponent._wrapperState.valueTracker;
+    var tracker = getTracker(input);
 
     expect(tracker.getValue()).toEqual('foo');
   });
@@ -64,92 +71,95 @@ describe('inputValueTracking', () => {
     checkbox.checked = true;
     inputValueTracking.track(mockComponent);
 
-    var tracker = mockComponent._wrapperState.valueTracker;
+    var tracker = getTracker(checkbox);
 
     expect(tracker.getValue()).toEqual('true');
   });
 
   it('should track value changes', () => {
-    input.value = 'foo';
+    var node = ReactTestUtils.renderIntoDocument(
+      <input type="text" defaultValue="foo" />,
+    );
 
-    inputValueTracking.track(mockComponent);
+    var tracker = getTracker(node);
 
-    var tracker = mockComponent._wrapperState.valueTracker;
-
-    input.value = 'bar';
+    node.value = 'bar';
     expect(tracker.getValue()).toEqual('bar');
   });
 
   it('should tracked`checked` changes', () => {
-    mockComponent._hostNode = checkbox;
-    checkbox.checked = true;
-    inputValueTracking.track(mockComponent);
+    var node = ReactTestUtils.renderIntoDocument(
+      <input type="checkbox" defaultChecked={true} />,
+    );
 
-    var tracker = mockComponent._wrapperState.valueTracker;
+    var tracker = getTracker(node);
 
-    checkbox.checked = false;
+    node.checked = false;
     expect(tracker.getValue()).toEqual('false');
   });
 
   it('should update value manually', () => {
-    input.value = 'foo';
-    inputValueTracking.track(mockComponent);
+    var node = ReactTestUtils.renderIntoDocument(
+      <input type="text" defaultValue="foo" />,
+    );
 
-    var tracker = mockComponent._wrapperState.valueTracker;
+    var tracker = getTracker(node);
 
     tracker.setValue('bar');
     expect(tracker.getValue()).toEqual('bar');
   });
 
   it('should coerce value to a string', () => {
-    input.value = 'foo';
-    inputValueTracking.track(mockComponent);
+    var node = ReactTestUtils.renderIntoDocument(
+      <input type="text" defaultValue="foo" />,
+    );
 
-    var tracker = mockComponent._wrapperState.valueTracker;
+    var tracker = getTracker(node);
 
     tracker.setValue(500);
     expect(tracker.getValue()).toEqual('500');
   });
 
   it('should update value if it changed and return result', () => {
-    inputValueTracking.track(mockComponent);
-    input.value = 'foo';
+    var node = ReactTestUtils.renderIntoDocument(
+      <input type="text" defaultValue="foo" />,
+    );
 
-    var tracker = mockComponent._wrapperState.valueTracker;
+    var tracker = getTracker(node);
 
-    expect(inputValueTracking.updateValueIfChanged(mockComponent)).toBe(false);
+    expect(inputValueTracking.updateNodeValueIfChanged(node)).toBe(false);
 
     tracker.setValue('bar');
 
-    expect(inputValueTracking.updateValueIfChanged(mockComponent)).toBe(true);
+    expect(inputValueTracking.updateNodeValueIfChanged(node)).toBe(true);
 
     expect(tracker.getValue()).toEqual('foo');
   });
 
-  it('should track value and return true when updating untracked instance', () => {
+  it('should return true when updating untracked instance', () => {
     input.value = 'foo';
 
     expect(inputValueTracking.updateValueIfChanged(mockComponent)).toBe(true);
 
-    var tracker = mockComponent._wrapperState.valueTracker;
-    expect(tracker.getValue()).toEqual('foo');
+    expect(getTracker(input)).not.toBeDefined();
   });
 
   it('should return tracker from node', () => {
     var div = document.createElement('div');
     var node = ReactDOM.render(<input type="text" defaultValue="foo" />, div);
-    var tracker = inputValueTracking._getTrackerFromNode(node);
+
+    var tracker = getTracker(node);
     expect(tracker.getValue()).toEqual('foo');
   });
 
   it('should stop tracking', () => {
     inputValueTracking.track(mockComponent);
 
-    expect(mockComponent._wrapperState.valueTracker).not.toEqual(null);
+    expect(getTracker(input)).not.toEqual(null);
 
     inputValueTracking.stopTracking(mockComponent);
 
-    expect(mockComponent._wrapperState.valueTracker).toEqual(null);
+    expect(getTracker(input)).toEqual(null);
 
     expect(input.hasOwnProperty('value')).toBe(false);
   });

--- a/src/renderers/dom/shared/__tests__/inputValueTracking-test.js
+++ b/src/renderers/dom/shared/__tests__/inputValueTracking-test.js
@@ -20,20 +20,17 @@ var inputValueTracking = require('inputValueTracking');
 var getTracker = inputValueTracking._getTrackerFromNode;
 
 describe('inputValueTracking', () => {
-  var input, checkbox, mockComponent;
+  var input;
 
   beforeEach(() => {
     input = document.createElement('input');
     input.type = 'text';
-    checkbox = document.createElement('input');
-    checkbox.type = 'checkbox';
-    mockComponent = {_hostNode: input, _wrapperState: {}};
   });
 
   it('should attach tracker to node', () => {
     var node = ReactTestUtils.renderIntoDocument(<input type="text" />);
 
-    expect(node.hasOwnProperty('_valueTracker')).toBe(true);
+    expect(getTracker(node)).toBeDefined();
   });
 
   it('should define `value` on the node instance', () => {
@@ -59,7 +56,9 @@ describe('inputValueTracking', () => {
   });
 
   it('should initialize with the current `checked`', () => {
-    mockComponent._hostNode = checkbox;
+    const checkbox = document.createElement('input');
+
+    checkbox.type = 'checkbox';
     checkbox.checked = true;
     inputValueTracking.track(checkbox);
 

--- a/src/renderers/dom/shared/__tests__/inputValueTracking-test.js
+++ b/src/renderers/dom/shared/__tests__/inputValueTracking-test.js
@@ -51,7 +51,7 @@ describe('inputValueTracking', () => {
   it('should initialize with the current value', () => {
     input.value = 'foo';
 
-    inputValueTracking.track(mockComponent);
+    inputValueTracking.track(input);
 
     var tracker = getTracker(input);
 
@@ -61,7 +61,7 @@ describe('inputValueTracking', () => {
   it('should initialize with the current `checked`', () => {
     mockComponent._hostNode = checkbox;
     checkbox.checked = true;
-    inputValueTracking.track(mockComponent);
+    inputValueTracking.track(checkbox);
 
     var tracker = getTracker(checkbox);
 
@@ -119,11 +119,11 @@ describe('inputValueTracking', () => {
 
     var tracker = getTracker(node);
 
-    expect(inputValueTracking.updateNodeValueIfChanged(node)).toBe(false);
+    expect(inputValueTracking.updateValueIfChanged(node)).toBe(false);
 
     tracker.setValue('bar');
 
-    expect(inputValueTracking.updateNodeValueIfChanged(node)).toBe(true);
+    expect(inputValueTracking.updateValueIfChanged(node)).toBe(true);
 
     expect(tracker.getValue()).toEqual('foo');
   });
@@ -131,7 +131,7 @@ describe('inputValueTracking', () => {
   it('should return true when updating untracked instance', () => {
     input.value = 'foo';
 
-    expect(inputValueTracking.updateValueIfChanged(mockComponent)).toBe(true);
+    expect(inputValueTracking.updateValueIfChanged(input)).toBe(true);
 
     expect(getTracker(input)).not.toBeDefined();
   });
@@ -145,11 +145,11 @@ describe('inputValueTracking', () => {
   });
 
   it('should stop tracking', () => {
-    inputValueTracking.track(mockComponent);
+    inputValueTracking.track(input);
 
     expect(getTracker(input)).not.toEqual(null);
 
-    inputValueTracking.stopTracking(mockComponent);
+    inputValueTracking.stopTracking(input);
 
     expect(getTracker(input)).toEqual(null);
 

--- a/src/renderers/dom/shared/__tests__/inputValueTracking-test.js
+++ b/src/renderers/dom/shared/__tests__/inputValueTracking-test.js
@@ -31,27 +31,19 @@ describe('inputValueTracking', () => {
   });
 
   it('should attach tracker to node', () => {
-    var node = ReactTestUtils.renderIntoDocument(
-      <input type="text" />,
-    );
+    var node = ReactTestUtils.renderIntoDocument(<input type="text" />);
 
-    expect(node.hasOwnProperty('_valueTracker')).toBe(
-      true,
-    );
+    expect(node.hasOwnProperty('_valueTracker')).toBe(true);
   });
 
   it('should define `value` on the node instance', () => {
-    var node = ReactTestUtils.renderIntoDocument(
-      <input type="text" />,
-    );
+    var node = ReactTestUtils.renderIntoDocument(<input type="text" />);
 
     expect(node.hasOwnProperty('value')).toBe(true);
   });
 
   it('should define `checked` on the node instance', () => {
-    var node = ReactTestUtils.renderIntoDocument(
-      <input type="checkbox" />,
-    );
+    var node = ReactTestUtils.renderIntoDocument(<input type="checkbox" />);
 
     expect(node.hasOwnProperty('checked')).toBe(true);
   });

--- a/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
@@ -99,7 +99,11 @@ function runEventInBatch(event) {
 }
 
 function getInstIfValueChanged(targetInst) {
-  if (inputValueTracking.updateValueIfChanged(targetInst)) {
+  if (
+    inputValueTracking.updateValueIfChanged(
+      ReactDOMComponentTree.getNodeFromInstance(targetInst),
+    )
+  ) {
     return targetInst;
   }
 }

--- a/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
@@ -99,11 +99,8 @@ function runEventInBatch(event) {
 }
 
 function getInstIfValueChanged(targetInst) {
-  if (
-    inputValueTracking.updateValueIfChanged(
-      ReactDOMComponentTree.getNodeFromInstance(targetInst),
-    )
-  ) {
+  const targetNode = ReactDOMComponentTree.getNodeFromInstance(targetInst);
+  if (inputValueTracking.updateValueIfChanged(targetNode)) {
     return targetInst;
   }
 }

--- a/src/renderers/dom/shared/inputValueTracking.js
+++ b/src/renderers/dom/shared/inputValueTracking.js
@@ -39,8 +39,8 @@ function getTracker(node: ElementWithValueTracker) {
   return node._valueTracker;
 }
 
-function detachTracker(subject: ElementWithValueTracker) {
-  subject._valueTracker = null;
+function detachTracker(node: ElementWithValueTracker) {
+  node._valueTracker = null;
 }
 
 function getValueFromNode(node: HTMLInputElement): string {
@@ -116,7 +116,7 @@ var inputValueTracking = {
     return getTracker(ReactDOMComponentTree.getNodeFromInstance(inst));
   },
 
-  trackNode(node: ElementWithValueTracker) {
+  track(node: ElementWithValueTracker) {
     if (getTracker(node)) {
       return;
     }
@@ -125,13 +125,7 @@ var inputValueTracking = {
     node._valueTracker = trackValueOnNode(node);
   },
 
-  track(inst: ReactInstance | Fiber) {
-    inputValueTracking.trackNode(
-      ReactDOMComponentTree.getNodeFromInstance(inst),
-    );
-  },
-
-  updateNodeValueIfChanged(node: ElementWithValueTracker) {
+  updateValueIfChanged(node: ElementWithValueTracker) {
     if (!node) {
       return false;
     }
@@ -152,17 +146,8 @@ var inputValueTracking = {
     return false;
   },
 
-  updateValueIfChanged(instOrFiber: ReactInstance | Fiber) {
-    if (!instOrFiber) {
-      return false;
-    }
-    return inputValueTracking.updateNodeValueIfChanged(
-      ReactDOMComponentTree.getNodeFromInstance(instOrFiber),
-    );
-  },
-
-  stopTracking(inst: ReactInstance) {
-    var tracker = getTracker(ReactDOMComponentTree.getNodeFromInstance(inst));
+  stopTracking(node: ElementWithValueTracker) {
+    var tracker = getTracker(node);
     if (tracker) {
       tracker.stopTracking();
     }

--- a/src/renderers/dom/shared/inputValueTracking.js
+++ b/src/renderers/dom/shared/inputValueTracking.js
@@ -12,9 +12,6 @@
 
 'use strict';
 
-import type {Fiber} from 'ReactFiber';
-import type {ReactInstance} from 'ReactInstanceType';
-
 type ValueTracker = {
   getValue(): string,
   setValue(value: string): void,
@@ -22,8 +19,6 @@ type ValueTracker = {
 };
 type WrapperState = {_valueTracker: ?ValueTracker};
 type ElementWithValueTracker = HTMLInputElement & WrapperState;
-
-var ReactDOMComponentTree = require('ReactDOMComponentTree');
 
 function isCheckable(elem: HTMLInputElement) {
   var type = elem.type;

--- a/src/renderers/dom/shared/inputValueTracking.js
+++ b/src/renderers/dom/shared/inputValueTracking.js
@@ -112,10 +112,6 @@ var inputValueTracking = {
     return getTracker(inst);
   },
 
-  _getTrackerFromInstance(inst: ReactInstance | Fiber) {
-    return getTracker(ReactDOMComponentTree.getNodeFromInstance(inst));
-  },
-
   track(node: ElementWithValueTracker) {
     if (getTracker(node)) {
       return;

--- a/src/renderers/dom/shared/inputValueTracking.js
+++ b/src/renderers/dom/shared/inputValueTracking.js
@@ -20,7 +20,7 @@ type ValueTracker = {
   setValue(value: string): void,
   stopTracking(): void,
 };
-type WrapperState = { _valueTracker: ?ValueTracker };
+type WrapperState = {_valueTracker: ?ValueTracker};
 type ElementWithValueTracker = HTMLInputElement & WrapperState;
 
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
@@ -113,9 +113,7 @@ var inputValueTracking = {
   },
 
   _getTrackerFromInstance(inst: ReactInstance | Fiber) {
-    return getTracker(
-      ReactDOMComponentTree.getNodeFromInstance(inst)
-    );
+    return getTracker(ReactDOMComponentTree.getNodeFromInstance(inst));
   },
 
   trackNode(node: ElementWithValueTracker) {
@@ -129,7 +127,7 @@ var inputValueTracking = {
 
   track(inst: ReactInstance | Fiber) {
     inputValueTracking.trackNode(
-      ReactDOMComponentTree.getNodeFromInstance(inst)
+      ReactDOMComponentTree.getNodeFromInstance(inst),
     );
   },
 
@@ -159,7 +157,7 @@ var inputValueTracking = {
       return false;
     }
     return inputValueTracking.updateNodeValueIfChanged(
-      ReactDOMComponentTree.getNodeFromInstance(instOrFiber)
+      ReactDOMComponentTree.getNodeFromInstance(instOrFiber),
     );
   },
 

--- a/src/renderers/dom/shared/inputValueTracking.js
+++ b/src/renderers/dom/shared/inputValueTracking.js
@@ -108,9 +108,7 @@ function trackValueOnNode(node: any): ?ValueTracker {
 
 var inputValueTracking = {
   // exposed for testing
-  _getTrackerFromNode(inst: ElementWithValueTracker) {
-    return getTracker(inst);
-  },
+  _getTrackerFromNode: getTracker,
 
   track(node: ElementWithValueTracker) {
     if (getTracker(node)) {

--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -227,7 +227,7 @@ var mediaEvents = {
 };
 
 function trackInputValue() {
-  inputValueTracking.track(this);
+  inputValueTracking.track(getNode(this));
 }
 
 function trapClickOnNonInteractiveElement() {
@@ -862,7 +862,7 @@ ReactDOMComponent.Mixin = {
         ReactDOMInput.updateWrapper(this);
         // We also check that we haven't missed a value update, such as a
         // Radio group shifting the checked value to another named radio input.
-        inputValueTracking.updateValueIfChanged(this);
+        inputValueTracking.updateValueIfChanged(getNode(this));
         break;
       case 'textarea':
         ReactDOMTextarea.updateWrapper(this);
@@ -1107,7 +1107,7 @@ ReactDOMComponent.Mixin = {
         break;
       case 'input':
       case 'textarea':
-        inputValueTracking.stopTracking(this);
+        inputValueTracking.stopTracking(getNode(this));
         break;
       case 'html':
       case 'head':


### PR DESCRIPTION
This moves the storage of the input value tracker to the DOM node
instead of the wrapperState. This makes it easier to support both Stack
and Fiber without out a lot of ugly type casting and logic branches.

related: #10207