### PR TITLE
ReactDOM.flushSync(batch)

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -682,6 +682,10 @@ src/renderers/dom/fiber/__tests__/ReactDOMFiberAsync-test.js
 * updates inside an async tree are async by default
 * AsyncComponent creates an async subtree
 * updates inside an async subtree are async by default
+* activeUpdates batches sync updates and flushes them at the end of the batch
+* activeUpdates flushes updates even if nested inside another activeUpdates
+* activeUpdates does not create a nested update
+* activeUpdates flushes updates before end of the tick
 
 src/renderers/dom/shared/__tests__/CSSProperty-test.js
 * should generate browser prefixes for its `isUnitlessNumber`

--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -682,10 +682,10 @@ src/renderers/dom/fiber/__tests__/ReactDOMFiberAsync-test.js
 * updates inside an async tree are async by default
 * AsyncComponent creates an async subtree
 * updates inside an async subtree are async by default
-* activeUpdates batches sync updates and flushes them at the end of the batch
-* activeUpdates flushes updates even if nested inside another activeUpdates
-* activeUpdates does not create a nested update
-* activeUpdates flushes updates before end of the tick
+* flushSync batches sync updates and flushes them at the end of the batch
+* flushSync flushes updates even if nested inside another flushSync
+* flushSync throws if already performing work
+* flushSync flushes updates before end of the tick
 
 src/renderers/dom/shared/__tests__/CSSProperty-test.js
 * should generate browser prefixes for its `isUnitlessNumber`
@@ -2164,7 +2164,6 @@ src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
 * can call setState inside update callback
 * can replaceState
 * can forceUpdate
-* performs batched updates at the end of the batch
 * can nest batchedUpdates
 * can handle if setState callback throws
 * merges and masks context

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -742,6 +742,8 @@ var ReactDOMFiber = {
 
   unstable_deferredUpdates: DOMRenderer.deferredUpdates,
 
+  activeUpdates: DOMRenderer.activeUpdates,
+
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
     // For TapEventPlugin which is popular in open source
     EventPluginHub: require('EventPluginHub'),

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -742,7 +742,7 @@ var ReactDOMFiber = {
 
   unstable_deferredUpdates: DOMRenderer.deferredUpdates,
 
-  activeUpdates: DOMRenderer.activeUpdates,
+  flushSync: DOMRenderer.flushSync,
 
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
     // For TapEventPlugin which is popular in open source

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiberAsync-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiberAsync-test.js
@@ -134,6 +134,172 @@ describe('ReactDOMFiberAsync', () => {
         jest.runAllTimers();
         expect(container.textContent).toEqual('1');
       });
+
+      it('activeUpdates batches sync updates and flushes them at the end of the batch', () => {
+        let ops = [];
+        let instance;
+
+        class Component extends React.Component {
+          state = {text: ''};
+          push(val) {
+            this.setState(state => ({text: state.text + val}));
+          }
+          componentDidUpdate() {
+            ops.push(this.state.text);
+          }
+          render() {
+            instance = this;
+            return <span>{this.state.text}</span>;
+          }
+        }
+
+        ReactDOM.render(<Component />, container);
+
+        instance.push('A');
+        expect(ops).toEqual(['A']);
+        expect(container.textContent).toEqual('A');
+
+        ReactDOM.activeUpdates(() => {
+          instance.push('B');
+          instance.push('C');
+          // Not flushed yet
+          expect(container.textContent).toEqual('A');
+          expect(ops).toEqual(['A']);
+        });
+        expect(container.textContent).toEqual('ABC');
+        expect(ops).toEqual(['A', 'ABC']);
+        instance.push('D');
+        expect(container.textContent).toEqual('ABCD');
+        expect(ops).toEqual(['A', 'ABC', 'ABCD']);
+      });
+
+      it('activeUpdates flushes updates even if nested inside another activeUpdates', () => {
+        let ops = [];
+        let instance;
+
+        class Component extends React.Component {
+          state = {text: ''};
+          push(val) {
+            this.setState(state => ({text: state.text + val}));
+          }
+          componentDidUpdate() {
+            ops.push(this.state.text);
+          }
+          render() {
+            instance = this;
+            return <span>{this.state.text}</span>;
+          }
+        }
+
+        ReactDOM.render(<Component />, container);
+
+        instance.push('A');
+        expect(ops).toEqual(['A']);
+        expect(container.textContent).toEqual('A');
+
+        ReactDOM.activeUpdates(() => {
+          instance.push('B');
+          instance.push('C');
+          // Not flushed yet
+          expect(container.textContent).toEqual('A');
+          expect(ops).toEqual(['A']);
+
+          ReactDOM.activeUpdates(() => {
+            instance.push('D');
+          });
+          // The nested activeUpdates caused everything to flush.
+          expect(container.textContent).toEqual('ABCD');
+          expect(ops).toEqual(['A', 'ABCD']);
+        });
+        expect(container.textContent).toEqual('ABCD');
+        expect(ops).toEqual(['A', 'ABCD']);
+      });
+
+      it('activeUpdates does not create a nested update', () => {
+        let ops = [];
+
+        class Component extends React.Component {
+          state = {text: ''};
+          push(val) {
+            this.setState(state => ({text: state.text + val}));
+          }
+          componentDidMount() {
+            ReactDOM.activeUpdates(() => {
+              this.push('A');
+              this.push('B');
+              this.push('C');
+            });
+            // Not flushed yet
+            expect(container.textContent).toEqual('');
+            expect(ops).toEqual([]);
+          }
+          componentDidUpdate() {
+            ops.push(this.state.text);
+          }
+          render() {
+            return <span>{this.state.text}</span>;
+          }
+        }
+
+        ReactDOM.render(<Component />, container);
+
+        expect(container.textContent).toEqual('ABC');
+        expect(ops).toEqual(['ABC']);
+      });
+
+      it('activeUpdates flushes updates before end of the tick', () => {
+        let ops = [];
+        let instance;
+
+        class Component extends React.Component {
+          state = {text: ''};
+          push(val) {
+            this.setState(state => ({text: state.text + val}));
+          }
+          componentDidUpdate() {
+            ops.push(this.state.text);
+          }
+          render() {
+            instance = this;
+            return <span>{this.state.text}</span>;
+          }
+        }
+
+        class AsyncWrapper extends React.Component {
+          static unstable_asyncUpdates = true;
+          render() {
+            return this.props.children;
+          }
+        }
+
+        ReactDOM.render(<AsyncWrapper><Component /></AsyncWrapper>, container);
+        jest.runAllTimers();
+
+        // Updates are async by default
+        instance.push('A');
+        expect(ops).toEqual([]);
+        expect(container.textContent).toEqual('');
+
+        ReactDOM.activeUpdates(() => {
+          instance.push('B');
+          instance.push('C');
+          // Not flushed yet
+          expect(container.textContent).toEqual('');
+          expect(ops).toEqual([]);
+        });
+        // Only the active updates have flushed
+        expect(container.textContent).toEqual('BC');
+        expect(ops).toEqual(['BC']);
+
+        instance.push('D');
+        expect(container.textContent).toEqual('BC');
+        expect(ops).toEqual(['BC']);
+
+        // Flush the async updates
+        jest.runAllTimers();
+        expect(container.textContent).toEqual('BCAD');
+        expect(ops).toEqual(['BC', 'BCAD']);
+      });
     });
   }
 });

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiberAsync-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiberAsync-test.js
@@ -215,36 +215,22 @@ describe('ReactDOMFiberAsync', () => {
         expect(ops).toEqual(['A', 'ABCD']);
       });
 
-      it('flushSync does not create a nested update', () => {
-        let ops = [];
-
+      it('flushSync throws if already performing work', () => {
         class Component extends React.Component {
-          state = {text: ''};
-          push(val) {
-            this.setState(state => ({text: state.text + val}));
-          }
-          componentDidMount() {
-            ReactDOM.flushSync(() => {
-              this.push('A');
-              this.push('B');
-              this.push('C');
-            });
-            // Not flushed yet
-            expect(container.textContent).toEqual('');
-            expect(ops).toEqual([]);
-          }
           componentDidUpdate() {
-            ops.push(this.state.text);
+            ReactDOM.flushSync(() => {});
           }
           render() {
-            return <span>{this.state.text}</span>;
+            return null;
           }
         }
 
+        // Initial mount
         ReactDOM.render(<Component />, container);
-
-        expect(container.textContent).toEqual('ABC');
-        expect(ops).toEqual(['ABC']);
+        // Update
+        expect(() => ReactDOM.render(<Component />, container)).toThrow(
+          'flushSync was called from inside a lifecycle method',
+        );
       });
 
       it('flushSync flushes updates before end of the tick', () => {

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiberAsync-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiberAsync-test.js
@@ -135,7 +135,7 @@ describe('ReactDOMFiberAsync', () => {
         expect(container.textContent).toEqual('1');
       });
 
-      it('activeUpdates batches sync updates and flushes them at the end of the batch', () => {
+      it('flushSync batches sync updates and flushes them at the end of the batch', () => {
         let ops = [];
         let instance;
 
@@ -159,7 +159,7 @@ describe('ReactDOMFiberAsync', () => {
         expect(ops).toEqual(['A']);
         expect(container.textContent).toEqual('A');
 
-        ReactDOM.activeUpdates(() => {
+        ReactDOM.flushSync(() => {
           instance.push('B');
           instance.push('C');
           // Not flushed yet
@@ -173,7 +173,7 @@ describe('ReactDOMFiberAsync', () => {
         expect(ops).toEqual(['A', 'ABC', 'ABCD']);
       });
 
-      it('activeUpdates flushes updates even if nested inside another activeUpdates', () => {
+      it('flushSync flushes updates even if nested inside another flushSync', () => {
         let ops = [];
         let instance;
 
@@ -197,17 +197,17 @@ describe('ReactDOMFiberAsync', () => {
         expect(ops).toEqual(['A']);
         expect(container.textContent).toEqual('A');
 
-        ReactDOM.activeUpdates(() => {
+        ReactDOM.flushSync(() => {
           instance.push('B');
           instance.push('C');
           // Not flushed yet
           expect(container.textContent).toEqual('A');
           expect(ops).toEqual(['A']);
 
-          ReactDOM.activeUpdates(() => {
+          ReactDOM.flushSync(() => {
             instance.push('D');
           });
-          // The nested activeUpdates caused everything to flush.
+          // The nested flushSync caused everything to flush.
           expect(container.textContent).toEqual('ABCD');
           expect(ops).toEqual(['A', 'ABCD']);
         });
@@ -215,7 +215,7 @@ describe('ReactDOMFiberAsync', () => {
         expect(ops).toEqual(['A', 'ABCD']);
       });
 
-      it('activeUpdates does not create a nested update', () => {
+      it('flushSync does not create a nested update', () => {
         let ops = [];
 
         class Component extends React.Component {
@@ -224,7 +224,7 @@ describe('ReactDOMFiberAsync', () => {
             this.setState(state => ({text: state.text + val}));
           }
           componentDidMount() {
-            ReactDOM.activeUpdates(() => {
+            ReactDOM.flushSync(() => {
               this.push('A');
               this.push('B');
               this.push('C');
@@ -247,11 +247,11 @@ describe('ReactDOMFiberAsync', () => {
         expect(ops).toEqual(['ABC']);
       });
 
-      it('activeUpdates flushes updates before end of the tick', () => {
+      it('flushSync flushes updates before end of the tick', () => {
         let ops = [];
         let instance;
 
-        class Component extends React.Component {
+        class Component extends React.unstable_AsyncComponent {
           state = {text: ''};
           push(val) {
             this.setState(state => ({text: state.text + val}));
@@ -265,14 +265,7 @@ describe('ReactDOMFiberAsync', () => {
           }
         }
 
-        class AsyncWrapper extends React.Component {
-          static unstable_asyncUpdates = true;
-          render() {
-            return this.props.children;
-          }
-        }
-
-        ReactDOM.render(<AsyncWrapper><Component /></AsyncWrapper>, container);
+        ReactDOM.render(<Component />, container);
         jest.runAllTimers();
 
         // Updates are async by default
@@ -280,7 +273,7 @@ describe('ReactDOMFiberAsync', () => {
         expect(ops).toEqual([]);
         expect(container.textContent).toEqual('');
 
-        ReactDOM.activeUpdates(() => {
+        ReactDOM.flushSync(() => {
           instance.push('B');
           instance.push('C');
           // Not flushed yet

--- a/src/renderers/native/ReactNativeFiberEntry.js
+++ b/src/renderers/native/ReactNativeFiberEntry.js
@@ -89,6 +89,8 @@ const ReactNativeFiber: ReactNativeType = {
 
   unstable_batchedUpdates: ReactGenericBatching.batchedUpdates,
 
+  activeUpdates: ReactNativeFiberRenderer.activeUpdates,
+
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
     // Used as a mixin in many createClass-based components
     NativeMethodsMixin: require('NativeMethodsMixin'),

--- a/src/renderers/native/ReactNativeFiberEntry.js
+++ b/src/renderers/native/ReactNativeFiberEntry.js
@@ -89,7 +89,7 @@ const ReactNativeFiber: ReactNativeType = {
 
   unstable_batchedUpdates: ReactGenericBatching.batchedUpdates,
 
-  activeUpdates: ReactNativeFiberRenderer.activeUpdates,
+  flushSync: ReactNativeFiberRenderer.flushSync,
 
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
     // Used as a mixin in many createClass-based components

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -361,8 +361,6 @@ var ReactNoop = {
 
   unbatchedUpdates: NoopRenderer.unbatchedUpdates,
 
-  syncUpdates: NoopRenderer.syncUpdates,
-
   flushSync: NoopRenderer.flushSync,
 
   // Logs the current state of the tree.

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -363,6 +363,8 @@ var ReactNoop = {
 
   syncUpdates: NoopRenderer.syncUpdates,
 
+  flushSync: NoopRenderer.flushSync,
+
   // Logs the current state of the tree.
   dumpTree(rootID: string = DEFAULT_ROOT_ID) {
     const root = roots.get(rootID);

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -166,7 +166,6 @@ export type Reconciler<C, I, TI> = {
   performWithPriority(priorityLevel: PriorityLevel, fn: Function): void,
   batchedUpdates<A>(fn: () => A): A,
   unbatchedUpdates<A>(fn: () => A): A,
-  syncUpdates<A>(fn: () => A): A,
   flushSync<A>(fn: () => A): A,
   deferredUpdates<A>(fn: () => A): A,
 
@@ -200,7 +199,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     performWithPriority,
     batchedUpdates,
     unbatchedUpdates,
-    syncUpdates,
     flushSync,
     deferredUpdates,
   } = ReactFiberScheduler(config);
@@ -291,8 +289,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     batchedUpdates,
 
     unbatchedUpdates,
-
-    syncUpdates,
 
     deferredUpdates,
 

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -167,7 +167,7 @@ export type Reconciler<C, I, TI> = {
   batchedUpdates<A>(fn: () => A): A,
   unbatchedUpdates<A>(fn: () => A): A,
   syncUpdates<A>(fn: () => A): A,
-  activeUpdates<A>(fn: () => A): A,
+  flushSync<A>(fn: () => A): A,
   deferredUpdates<A>(fn: () => A): A,
 
   // Used to extract the return value from the initial render. Legacy API.
@@ -201,7 +201,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     batchedUpdates,
     unbatchedUpdates,
     syncUpdates,
-    activeUpdates,
+    flushSync,
     deferredUpdates,
   } = ReactFiberScheduler(config);
 
@@ -296,7 +296,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
     deferredUpdates,
 
-    activeUpdates,
+    flushSync,
 
     getPublicRootInstance(
       container: OpaqueRoot,

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -167,6 +167,7 @@ export type Reconciler<C, I, TI> = {
   batchedUpdates<A>(fn: () => A): A,
   unbatchedUpdates<A>(fn: () => A): A,
   syncUpdates<A>(fn: () => A): A,
+  activeUpdates<A>(fn: () => A): A,
   deferredUpdates<A>(fn: () => A): A,
 
   // Used to extract the return value from the initial render. Legacy API.
@@ -200,6 +201,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     batchedUpdates,
     unbatchedUpdates,
     syncUpdates,
+    activeUpdates,
     deferredUpdates,
   } = ReactFiberScheduler(config);
 
@@ -293,6 +295,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     syncUpdates,
 
     deferredUpdates,
+
+    activeUpdates,
 
     getPublicRootInstance(
       container: OpaqueRoot,

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -1507,13 +1507,13 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
-  function activeUpdates<A>(fn: () => A): A {
+  function flushSync<A>(batch: () => A): A {
     const previousIsBatchingUpdates = isBatchingUpdates;
     const previousPriorityContext = priorityContext;
     isBatchingUpdates = true;
     priorityContext = SynchronousPriority;
     try {
-      return fn();
+      return batch();
     } finally {
       isBatchingUpdates = previousIsBatchingUpdates;
       priorityContext = previousPriorityContext;
@@ -1540,7 +1540,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     batchedUpdates: batchedUpdates,
     unbatchedUpdates: unbatchedUpdates,
     syncUpdates: syncUpdates,
-    activeUpdates: activeUpdates,
+    flushSync: flushSync,
     deferredUpdates: deferredUpdates,
   };
 };

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -1517,9 +1517,13 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     } finally {
       isBatchingUpdates = previousIsBatchingUpdates;
       priorityContext = previousPriorityContext;
-      if (!isPerformingWork) {
-        performWork(TaskPriority, null);
-      }
+
+      invariant(
+        !isPerformingWork,
+        'flushSync was called from inside a lifecycle method. It cannot be ' +
+          'called when React is already rendering.',
+      );
+      performWork(TaskPriority, null);
     }
   }
 

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -1507,6 +1507,22 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
+  function activeUpdates<A>(fn: () => A): A {
+    const previousIsBatchingUpdates = isBatchingUpdates;
+    const previousPriorityContext = priorityContext;
+    isBatchingUpdates = true;
+    priorityContext = SynchronousPriority;
+    try {
+      return fn();
+    } finally {
+      isBatchingUpdates = previousIsBatchingUpdates;
+      priorityContext = previousPriorityContext;
+      if (!isPerformingWork) {
+        performWork(TaskPriority, null);
+      }
+    }
+  }
+
   function deferredUpdates<A>(fn: () => A): A {
     const previousPriorityContext = priorityContext;
     priorityContext = LowPriority;
@@ -1524,6 +1540,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     batchedUpdates: batchedUpdates,
     unbatchedUpdates: unbatchedUpdates,
     syncUpdates: syncUpdates,
+    activeUpdates: activeUpdates,
     deferredUpdates: deferredUpdates,
   };
 };

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -1497,16 +1497,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
-  function syncUpdates<A>(fn: () => A): A {
-    const previousPriorityContext = priorityContext;
-    priorityContext = SynchronousPriority;
-    try {
-      return fn();
-    } finally {
-      priorityContext = previousPriorityContext;
-    }
-  }
-
   function flushSync<A>(batch: () => A): A {
     const previousIsBatchingUpdates = isBatchingUpdates;
     const previousPriorityContext = priorityContext;
@@ -1543,7 +1533,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     performWithPriority: performWithPriority,
     batchedUpdates: batchedUpdates,
     unbatchedUpdates: unbatchedUpdates,
-    syncUpdates: syncUpdates,
     flushSync: flushSync,
     deferredUpdates: deferredUpdates,
   };

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -326,7 +326,7 @@ describe('ReactIncremental', () => {
     }
 
     // Init
-    ReactNoop.syncUpdates(() => {
+    ReactNoop.flushSync(() => {
       ReactNoop.render(<Foo text="foo" />);
     });
     ReactNoop.flush();
@@ -335,7 +335,7 @@ describe('ReactIncremental', () => {
     ops = [];
 
     // Render the high priority work (everying except the hidden trees).
-    ReactNoop.syncUpdates(() => {
+    ReactNoop.flushSync(() => {
       ReactNoop.render(<Foo text="foo" />);
     });
     expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
@@ -773,7 +773,7 @@ describe('ReactIncremental', () => {
       // Interrupt the current low pri work with a high pri update elsewhere in
       // the tree.
       ops = [];
-      ReactNoop.syncUpdates(() => {
+      ReactNoop.flushSync(() => {
         sibling.setState({});
       });
       expect(ops).toEqual(['Sibling']);
@@ -1661,42 +1661,6 @@ describe('ReactIncremental', () => {
     },
   );
 
-  it('performs batched updates at the end of the batch', () => {
-    var ops = [];
-    var instance;
-
-    class Foo extends React.Component {
-      state = {n: 0};
-      render() {
-        instance = this;
-        return <div />;
-      }
-    }
-
-    ReactNoop.render(<Foo />);
-    ReactNoop.flush();
-    ops = [];
-
-    ReactNoop.syncUpdates(() => {
-      ReactNoop.batchedUpdates(() => {
-        instance.setState({n: 1}, () => ops.push('setState 1'));
-        instance.setState({n: 2}, () => ops.push('setState 2'));
-        ops.push('end batchedUpdates');
-      });
-      ops.push('end syncUpdates');
-    });
-
-    // ReactNoop.flush() not needed because updates are synchronous
-
-    expect(ops).toEqual([
-      'end batchedUpdates',
-      'setState 1',
-      'setState 2',
-      'end syncUpdates',
-    ]);
-    expect(instance.state.n).toEqual(2);
-  });
-
   it('can nest batchedUpdates', () => {
     var ops = [];
     var instance;
@@ -1713,7 +1677,7 @@ describe('ReactIncremental', () => {
     ReactNoop.flush();
     ops = [];
 
-    ReactNoop.syncUpdates(() => {
+    ReactNoop.flushSync(() => {
       ReactNoop.batchedUpdates(() => {
         instance.setState({n: 1}, () => ops.push('setState 1'));
         instance.setState({n: 2}, () => ops.push('setState 2'));
@@ -1724,7 +1688,6 @@ describe('ReactIncremental', () => {
         });
         ops.push('end outer batchedUpdates');
       });
-      ops.push('end syncUpdates');
     });
 
     // ReactNoop.flush() not needed because updates are synchronous
@@ -1736,7 +1699,6 @@ describe('ReactIncremental', () => {
       'setState 2',
       'setState 3',
       'setState 4',
-      'end syncUpdates',
     ]);
     expect(instance.state.n).toEqual(4);
   });

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
@@ -134,7 +134,7 @@ describe('ReactIncrementalErrorHandling', () => {
       throw new Error('Hello');
     }
 
-    ReactNoop.syncUpdates(() => {
+    ReactNoop.flushSync(() => {
       ReactNoop.render(
         <ErrorBoundary>
           <BrokenRender />
@@ -176,19 +176,17 @@ describe('ReactIncrementalErrorHandling', () => {
       throw new Error('Hello');
     }
 
-    ReactNoop.syncUpdates(() => {
-      ReactNoop.batchedUpdates(() => {
-        ReactNoop.render(
-          <ErrorBoundary>
-            Before the storm.
-          </ErrorBoundary>,
-        );
-        ReactNoop.render(
-          <ErrorBoundary>
-            <BrokenRender />
-          </ErrorBoundary>,
-        );
-      });
+    ReactNoop.flushSync(() => {
+      ReactNoop.render(
+        <ErrorBoundary>
+          Before the storm.
+        </ErrorBoundary>,
+      );
+      ReactNoop.render(
+        <ErrorBoundary>
+          <BrokenRender />
+        </ErrorBoundary>,
+      );
     });
 
     expect(ops).toEqual([
@@ -292,7 +290,7 @@ describe('ReactIncrementalErrorHandling', () => {
     }
 
     expect(() => {
-      ReactNoop.syncUpdates(() => {
+      ReactNoop.flushSync(() => {
         ReactNoop.render(
           <RethrowErrorBoundary>
             <BrokenRender />
@@ -327,19 +325,17 @@ describe('ReactIncrementalErrorHandling', () => {
     }
 
     expect(() => {
-      ReactNoop.syncUpdates(() => {
-        ReactNoop.batchedUpdates(() => {
-          ReactNoop.render(
-            <RethrowErrorBoundary>
-              Before the storm.
-            </RethrowErrorBoundary>,
-          );
-          ReactNoop.render(
-            <RethrowErrorBoundary>
-              <BrokenRender />
-            </RethrowErrorBoundary>,
-          );
-        });
+      ReactNoop.flushSync(() => {
+        ReactNoop.render(
+          <RethrowErrorBoundary>
+            Before the storm.
+          </RethrowErrorBoundary>,
+        );
+        ReactNoop.render(
+          <RethrowErrorBoundary>
+            <BrokenRender />
+          </RethrowErrorBoundary>,
+        );
       });
     }).toThrow('Hello');
     expect(ops).toEqual([
@@ -383,7 +379,7 @@ describe('ReactIncrementalErrorHandling', () => {
   it('applies sync updates regardless despite errors in scheduling', () => {
     ReactNoop.render(<span prop="a:1" />);
     expect(() => {
-      ReactNoop.syncUpdates(() => {
+      ReactNoop.flushSync(() => {
         ReactNoop.batchedUpdates(() => {
           ReactNoop.render(<span prop="a:2" />);
           ReactNoop.render(<span prop="a:3" />);

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalPerf-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalPerf-test.js
@@ -282,7 +282,7 @@ describe('ReactDebugFiberPerf', () => {
 
   it('measures deprioritized work', () => {
     addComment('Flush the parent');
-    ReactNoop.syncUpdates(() => {
+    ReactNoop.flushSync(() => {
       ReactNoop.render(
         <Parent>
           <div hidden={true}>
@@ -498,7 +498,7 @@ describe('ReactDebugFiberPerf', () => {
         return <span prop={this.state.step} />;
       }
     }
-    ReactNoop.syncUpdates(() => {
+    ReactNoop.flushSync(() => {
       ReactNoop.render(<Component />);
     });
     expect(getFlameChart()).toMatchSnapshot();

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
@@ -79,17 +79,13 @@ describe('ReactIncrementalTriangle', () => {
         if (this.props.depth !== 0) {
           throw new Error('Cannot activate non-leaf component');
         }
-        ReactNoop.syncUpdates(() => {
-          this.setState({isActive: true});
-        });
+        this.setState({isActive: true});
       }
       deactivate() {
         if (this.props.depth !== 0) {
           throw new Error('Cannot deactivate non-leaf component');
         }
-        ReactNoop.syncUpdates(() => {
-          this.setState({isActive: false});
-        });
+        this.setState({isActive: false});
       }
       shouldComponentUpdate(nextProps, nextState) {
         return (
@@ -121,9 +117,7 @@ describe('ReactIncrementalTriangle', () => {
       state = {counter: 0};
       interrupt() {
         // Triggers a restart from the top.
-        ReactNoop.syncUpdates(() => {
-          this.forceUpdate();
-        });
+        this.forceUpdate();
       }
       setCounter(counter) {
         const currentCounter = this.state.counter;
@@ -193,15 +187,17 @@ describe('ReactIncrementalTriangle', () => {
 
       let activeTriangle = null;
       for (var i = 0; i < actions.length; i++) {
-        ReactNoop.batchedUpdates(() => {
+        ReactNoop.flushSync(() => {
           const action = actions[i];
           switch (action.type) {
             case FLUSH:
               ReactNoop.flushUnitsOfWork(action.unitsOfWork);
               break;
             case STEP:
-              app.setCounter(action.counter);
-              expectedCounterAtEnd = action.counter;
+              ReactNoop.deferredUpdates(() => {
+                app.setCounter(action.counter);
+                expectedCounterAtEnd = action.counter;
+              });
               break;
             case INTERRUPT:
               app.interrupt();

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalUpdates-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalUpdates-test.js
@@ -96,18 +96,16 @@ describe('ReactIncrementalUpdates', () => {
     ReactNoop.render(<Foo />);
     ReactNoop.flush();
 
-    ReactNoop.syncUpdates(() => {
-      ReactNoop.batchedUpdates(() => {
-        ReactNoop.deferredUpdates(() => {
-          instance.setState({x: 'x'});
-          instance.setState({y: 'y'});
-        });
-        instance.setState({a: 'a'});
-        instance.setState({b: 'b'});
-        ReactNoop.deferredUpdates(() => {
-          instance.updater.enqueueReplaceState(instance, {c: 'c'});
-          instance.setState({d: 'd'});
-        });
+    ReactNoop.flushSync(() => {
+      ReactNoop.deferredUpdates(() => {
+        instance.setState({x: 'x'});
+        instance.setState({y: 'y'});
+      });
+      instance.setState({a: 'a'});
+      instance.setState({b: 'b'});
+      ReactNoop.deferredUpdates(() => {
+        instance.updater.enqueueReplaceState(instance, {c: 'c'});
+        instance.setState({d: 'd'});
       });
     });
 
@@ -160,15 +158,13 @@ describe('ReactIncrementalUpdates', () => {
     ReactNoop.flushThrough(['a', 'b', 'c']);
     expect(ReactNoop.getChildren()).toEqual([span('')]);
 
-    // Schedule some more updates at different priorities
-    ReactNoop.batchedUpdates(() => {
-      instance.setState(createUpdate('f'));
-      ReactNoop.syncUpdates(() => {
-        instance.setState(createUpdate('d'));
-        instance.setState(createUpdate('e'));
-      });
-      instance.setState(createUpdate('g'));
+    // Schedule some more updates at different priorities{
+    instance.setState(createUpdate('f'));
+    ReactNoop.flushSync(() => {
+      instance.setState(createUpdate('d'));
+      instance.setState(createUpdate('e'));
     });
+    instance.setState(createUpdate('g'));
 
     // The sync updates should have flushed, but not the async ones
     expect(ReactNoop.getChildren()).toEqual([span('de')]);
@@ -210,17 +206,15 @@ describe('ReactIncrementalUpdates', () => {
     ReactNoop.flushThrough(['a', 'b', 'c']);
     expect(ReactNoop.getChildren()).toEqual([span('')]);
 
-    // Schedule some more updates at different priorities
-    ReactNoop.batchedUpdates(() => {
-      instance.setState(createUpdate('f'));
-      ReactNoop.syncUpdates(() => {
-        instance.setState(createUpdate('d'));
-        // No longer a public API, but we can test that it works internally by
-        // reaching into the updater.
-        instance.updater.enqueueReplaceState(instance, createUpdate('e'));
-      });
-      instance.setState(createUpdate('g'));
+    // Schedule some more updates at different priorities{
+    instance.setState(createUpdate('f'));
+    ReactNoop.flushSync(() => {
+      instance.setState(createUpdate('d'));
+      // No longer a public API, but we can test that it works internally by
+      // reaching into the updater.
+      instance.updater.enqueueReplaceState(instance, createUpdate('e'));
     });
+    instance.setState(createUpdate('g'));
 
     // The sync updates should have flushed, but not the async ones. Update d
     // was dropped and replaced by e.
@@ -307,11 +301,9 @@ describe('ReactIncrementalUpdates', () => {
 
     ops = [];
 
-    ReactNoop.batchedUpdates(() => {
-      ReactNoop.syncUpdates(() => {
-        instance.setState({a: 'a'});
-        ReactNoop.render(<Foo />); // Trigger componentWillReceiveProps
-      });
+    ReactNoop.flushSync(() => {
+      instance.setState({a: 'a'});
+      ReactNoop.render(<Foo />); // Trigger componentWillReceiveProps
     });
 
     expect(instance.state).toEqual({a: 'a', b: 'b'});


### PR DESCRIPTION
Updates scheduled inside of activeUpdates are flushed by the end of the current tick. In async mode, this means updates are given sync priority.

In sync mode, updates already have sync priority, so the effect of activeUpdates is to batch the updates together and flush them at the end of the batch.

Unlike unstable_batchedUpdates, activeUpdates flushes at the end even if it's nested inside another batch.