### PR TITLE
More explicit class method for ref doc

### DIFF
--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -39,10 +39,10 @@ When the `ref` attribute is used on an HTML element, the `ref` callback receives
 class CustomTextInput extends React.Component {
   constructor(props) {
     super(props);
-    this.focus = this.focus.bind(this);
+    this.focusTextInput = this.focusTextInput.bind(this);
   }
 
-  focus() {
+  focusTextInput() {
     // Explicitly focus the text input using the raw DOM API
     this.textInput.focus();
   }
@@ -77,7 +77,7 @@ When the `ref` attribute is used on a custom component declared as a class, the 
 ```javascript{3,9}
 class AutoFocusTextInput extends React.Component {
   componentDidMount() {
-    this.textInput.focus();
+    this.textInput.focusTextInput();
   }
 
   render() {


### PR DESCRIPTION
After realizing this was the second time I've visited this exact page within a year and second guessing myself that the `textInput` ref isn't actually the `<input />` element; I'd like to submit this PR to attempt to make this more explicit. 

You are actually accessing the method on the child class and not the `focus` method on the dom input element. 

Having the methods named the same, `focus`, caused some confusion.