### PR TITLE
Fix incorrect reference to undefined diffValueForAttribute

### DIFF
--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -132,11 +132,7 @@ var DOMPropertyOperations = {
           }
         }
       } else if (DOMProperty.isCustomAttribute(name)) {
-        return DOMPropertyOperations.diffValueForAttribute(
-          node,
-          name,
-          expected,
-        );
+        return DOMPropertyOperations.getValueForAttribute(node, name, expected);
       }
     }
   },

--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -131,8 +131,6 @@ var DOMPropertyOperations = {
             return stringValue;
           }
         }
-      } else if (DOMProperty.isCustomAttribute(name)) {
-        return DOMPropertyOperations.getValueForAttribute(node, name, expected);
       }
     }
   },

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -261,4 +261,20 @@ describe('DOMPropertyOperations', () => {
       );
     });
   });
+
+  describe('getValueForProperty', function() {
+    it('uses getValueForAttribute when given a custom attribute', function() {
+      var node = document.createElement('div');
+
+      node.setAttribute('data-test', 'test');
+
+      var value = DOMPropertyOperations.getValueForProperty(
+        node,
+        'data-test',
+        'test',
+      );
+
+      expect(value).toBe('test');
+    });
+  });
 });

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -261,20 +261,4 @@ describe('DOMPropertyOperations', () => {
       );
     });
   });
-
-  describe('getValueForProperty', function() {
-    it('uses getValueForAttribute when given a custom attribute', function() {
-      var node = document.createElement('div');
-
-      node.setAttribute('data-test', 'test');
-
-      var value = DOMPropertyOperations.getValueForProperty(
-        node,
-        'data-test',
-        'test',
-      );
-
-      expect(value).toBe('test');
-    });
-  });
 });


### PR DESCRIPTION
I noticed this when stripping away some DOMProperty stuff. It looks like there is a reference to a `DOMPropertyOperations.diffValueForAttribute` that is not defined:

https://github.com/facebook/react/blob/master/src/renderers/dom/shared/DOMPropertyOperations.js#L133-L137

This is, as far as I can tell, an impossible pathway to hit because of this line here:

https://github.com/facebook/react/blob/master/src/renderers/dom/fiber/ReactDOMFiberComponent.js#L929-L932

So I've added a test to cover the code path.