### PR TITLE
Fix failing Prettier command

### DIFF
--- a/fixtures/dom/src/components/propTypes.js
+++ b/fixtures/dom/src/components/propTypes.js
@@ -8,7 +8,7 @@ export function semverString(props, propName, componentName) {
   if (!error && version != null && !semver.valid(version))
     error = new Error(
       `\`${propName}\` should be a valid "semantic version" matching ` +
-        'an existing React version',
+        'an existing React version'
     );
 
   return error || null;

--- a/fixtures/fiber-debugger/src/App.js
+++ b/fixtures/fiber-debugger/src/App.js
@@ -120,7 +120,7 @@ class App extends Component {
     eval(
       window.Babel.transform(code, {
         presets: ['react', 'es2015'],
-      }).code,
+      }).code
     );
   }
 

--- a/fixtures/fiber-debugger/src/Fibers.js
+++ b/fixtures/fiber-debugger/src/Fibers.js
@@ -256,12 +256,12 @@ function formatPriority(priority) {
 
 export default function Fibers({fibers, show, ...rest}) {
   const items = Object.keys(fibers.descriptions).map(
-    id => fibers.descriptions[id],
+    id => fibers.descriptions[id]
   );
 
   const isDragging = rest.className.indexOf('dragging') > -1;
   const [_, sdx, sdy] = rest.style.transform.match(
-    /translate\((-?\d+)px,(-?\d+)px\)/,
+    /translate\((-?\d+)px,(-?\d+)px\)/
   ) || [];
   const dx = Number(sdx);
   const dy = Number(sdy);

--- a/fixtures/packaging/browserify/dev/input.js
+++ b/fixtures/packaging/browserify/dev/input.js
@@ -3,5 +3,5 @@ var ReactDOM = require('react-dom');
 
 ReactDOM.render(
   React.createElement('h1', null, 'Hello World!'),
-  document.getElementById('container'),
+  document.getElementById('container')
 );

--- a/fixtures/packaging/browserify/prod/input.js
+++ b/fixtures/packaging/browserify/prod/input.js
@@ -3,5 +3,5 @@ var ReactDOM = require('react-dom');
 
 ReactDOM.render(
   React.createElement('h1', null, 'Hello World!'),
-  document.getElementById('container'),
+  document.getElementById('container')
 );

--- a/fixtures/packaging/brunch/dev/app/initialize.js
+++ b/fixtures/packaging/brunch/dev/app/initialize.js
@@ -3,5 +3,5 @@ var ReactDOM = require('react-dom');
 
 ReactDOM.render(
   React.createElement('h1', null, 'Hello World!'),
-  document.getElementById('container'),
+  document.getElementById('container')
 );

--- a/fixtures/packaging/brunch/dev/input.js
+++ b/fixtures/packaging/brunch/dev/input.js
@@ -3,5 +3,5 @@ var ReactDOM = require('react-dom');
 
 ReactDOM.render(
   React.createElement('h1', null, 'Hello World!'),
-  document.getElementById('container'),
+  document.getElementById('container')
 );

--- a/fixtures/packaging/brunch/prod/app/initialize.js
+++ b/fixtures/packaging/brunch/prod/app/initialize.js
@@ -3,5 +3,5 @@ var ReactDOM = require('react-dom');
 
 ReactDOM.render(
   React.createElement('h1', null, 'Hello World!'),
-  document.getElementById('container'),
+  document.getElementById('container')
 );

--- a/fixtures/packaging/brunch/prod/input.js
+++ b/fixtures/packaging/brunch/prod/input.js
@@ -3,5 +3,5 @@ var ReactDOM = require('react-dom');
 
 ReactDOM.render(
   React.createElement('h1', null, 'Hello World!'),
-  document.getElementById('container'),
+  document.getElementById('container')
 );

--- a/fixtures/packaging/rjs/dev/input.js
+++ b/fixtures/packaging/rjs/dev/input.js
@@ -1,6 +1,6 @@
 require(['react', 'react-dom'], function(React, ReactDOM) {
   ReactDOM.render(
     React.createElement('h1', null, 'Hello World!'),
-    document.getElementById('container'),
+    document.getElementById('container')
   );
 });

--- a/fixtures/packaging/rjs/prod/input.js
+++ b/fixtures/packaging/rjs/prod/input.js
@@ -1,6 +1,6 @@
 require(['react', 'react-dom'], function(React, ReactDOM) {
   ReactDOM.render(
     React.createElement('h1', null, 'Hello World!'),
-    document.getElementById('container'),
+    document.getElementById('container')
   );
 });

--- a/fixtures/ssr/server/index.js
+++ b/fixtures/ssr/server/index.js
@@ -40,7 +40,7 @@ if (process.env.NODE_ENV === 'development') {
     proxy({
       ws: true,
       target: 'http://localhost:3001',
-    }),
+    })
   );
 }
 

--- a/scripts/prettier/index.js
+++ b/scripts/prettier/index.js
@@ -103,7 +103,7 @@ Object.keys(config).forEach(key => {
             `  This project uses prettier to format all JavaScript code.\n`
           ) +
           chalk.dim(`    Please run `) +
-          chalk.reset('yarn prettier') +
+          chalk.reset('yarn prettier-all') +
           chalk.dim(` and add changes to files listed below to your commit:`) +
           `\n\n` +
           e.message

--- a/scripts/prettier/index.js
+++ b/scripts/prettier/index.js
@@ -13,7 +13,7 @@
 const chalk = require('chalk');
 const glob = require('glob');
 const path = require('path');
-const spawnSync = require('child_process').spawnSync;
+const execFileSync = require('child_process').execFileSync;
 
 const mode = process.argv[2] || 'check';
 const shouldWrite = mode === 'write' || mode === 'write-changed';
@@ -54,11 +54,10 @@ function exec(command, args) {
     stdio: 'pipe',
     encoding: 'utf-8',
   };
-  const childProcess = spawnSync(command, args, options);
-  return childProcess.stdout.trim();
+  return execFileSync(command, args, options);
 }
 
-var mergeBase = exec('git', ['merge-base', 'HEAD', 'master']);
+var mergeBase = exec('git', ['merge-base', 'HEAD', 'master']).trim();
 var changedFiles = new Set(
   exec('git', [
     'diff',
@@ -91,10 +90,7 @@ Object.keys(config).forEach(key => {
   args.push(`--${shouldWrite ? 'write' : 'l'}`);
 
   try {
-    const invalidFiles = exec(prettierCmd, [...args, ...files]);
-    if (!shouldWrite && invalidFiles) {
-      throw Error(invalidFiles);
-    }
+    exec(prettierCmd, [...args, ...files]).trim();
   } catch (e) {
     if (!shouldWrite) {
       console.log(
@@ -106,7 +102,7 @@ Object.keys(config).forEach(key => {
           chalk.reset('yarn prettier-all') +
           chalk.dim(` and add changes to files listed below to your commit:`) +
           `\n\n` +
-          e.message
+          e.stdout
       );
       process.exit(1);
     }


### PR DESCRIPTION
The initial problem was that I was relying on `yarn prettier` to update all files. By default it only updates modified files though, and since I had only modified the prettier script itself- it wasn't picking up on a bunch of files. Running `node scripts/prettier/index.js` directly (like CI does) checks all files though and so we had a mismatch.

This PR updates the files that were skipped.

I also updated the script so that if mismatching files are found, we actually print them (instead of just saying "the list above" when there is none).

Example output:
![screen shot 2017-07-24 at 1 31 14 pm](https://user-images.githubusercontent.com/29597/28543373-67537674-7074-11e7-9c85-2dfdb64ae134.png)
