### PR TITLE
[invokeGuardedCallback] Handle nested errors across separate renderers

### DIFF
--- a/scripts/fiber/tests-passing.txt
+++ b/scripts/fiber/tests-passing.txt
@@ -2334,7 +2334,8 @@ src/renderers/shared/utils/__tests__/ReactErrorUtils-test.js
 * should catch errors (development)
 * should return false from clearCaughtError if no error was thrown (development)
 * can nest with same debug name (development)
-* does not return nested errors (development)
+* handles nested errors (development)
+* handles nested errors in separate renderers
 * can be shimmed (development)
 * it should rethrow caught errors (production)
 * should call the callback the passed arguments (production)
@@ -2342,7 +2343,8 @@ src/renderers/shared/utils/__tests__/ReactErrorUtils-test.js
 * should catch errors (production)
 * should return false from clearCaughtError if no error was thrown (production)
 * can nest with same debug name (production)
-* does not return nested errors (production)
+* handles nested errors (production)
+* handles nested errors in separate renderers
 * catches null values
 * can be shimmed (production)
 

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -47,7 +47,7 @@ if (__DEV__) {
 
 module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   config: HostConfig<T, P, I, TI, PI, C, CX, PL>,
-  captureError: (failedFiber: Fiber, error: Error) => Fiber | null,
+  captureError: (failedFiber: Fiber, error: mixed) => Fiber | null,
 ) {
   const {
     commitMount,


### PR DESCRIPTION
`invokeGuardedCallback` is a function we use in place of try-catch statement. It accepts a function, and if the function throws, it captures the error. In production, the implementation is a normal try- catch. In development, we swap out the prod implementation for a special version designed to preserve "Pause on all exceptions" behavior of the browser DevTools.

`invokeGuardedCallbackDev` works by dispatching an event to a dummy DOM node and calling the provided function inside a handler for that event. We also attach an error event handler to the window object. If the function throws, the global event handler is called and we can access the error.

The global event handler is added and removed right before and after the fake event is dispatched. But if `invokeGuardedCallbackDev` is nested — that is, if it's invoked inside the body of another `invokeGuardedCallbackDev` — multiple error event handlers will be attached simultaneously. We only want the handler that corresponds to the deepest level to handle the error. So we keep track of a depth counter, and within the event handler, we only handle the error if the current depth matches the depth at the time the function was invoked.

The problem that we discovered, and that this PR fixes, is that the depth counter is local to each renderer. So if you nest separate copies of `invokeGuardedCallback` from separate renderers, each renderer will have its own depth counter, and multiple error handlers will fire for a single, nested error.

~~To solve this, I've made the depth counter a global property, stored on `window.__reactDevErrorDepth`. I'd prefer not to use a global, but it's necessary in this case because we're dealing with global event handlers. If there were some way to introspect an error event to determine the event that triggered it, we could avoid using a global counter. But since this is only in DEV, and we already use globals for this use case, I think this is fine.~~ Updated based on @sebmarkbage's [feedback](https://github.com/facebook/react/pull/10270#pullrequestreview-51919909)