### PR TITLE
Fix false "unknown property" warnings for events in SSR

### DIFF
--- a/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
+++ b/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
@@ -67,6 +67,11 @@ if (__DEV__) {
     if (EventPluginRegistry.registrationNameModules.hasOwnProperty(name)) {
       return true;
     }
+    if (EventPluginRegistry.plugins.length === 0 && name.indexOf('on') === 0) {
+      // If no event plugins have been injected, we might be in a server environment.
+      // Don't check events in this case.
+      return true;
+    }
     warnedProperties[name] = true;
     var lowerCasedName = name.toLowerCase();
 


### PR DESCRIPTION
This fixes https://github.com/facebook/react/issues/10265.
Verified by running SSR fixture with the fix (I no longer see the erroneous warnings).

I think we should get this in before the beta because otherwise SSR is somewhat unusable due to the false positives on every event.

<s>The fix itself is rather gross. But it‘s the minimal one that works, and I don’t want to change too much before the beta. We *know* it will work because in principle it just reverts the DEV build to what it was before #10173.</s>

<s>I will start working on an alternative fix that forks injections instead of reusing them now. But I think this is an easier/safer thing to get in now.</s>

<s>I’ll also need to understand why tests didn’t catch this. Probably because event plugins are in a shared module so the list is singleton for both ReactDOM and ReactDOMServer in tests. And they share it even though actual bundles would not.</s>

I understand it now. See followup comment.