### PR TITLE
Dedupe unknown tag name warning and ignore <time>

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -65,6 +65,8 @@ var {
 } = DOMNamespaces;
 
 if (__DEV__) {
+  var warnedUnknownTags = {};
+
   var validatePropertiesInDevelopment = function(type, props) {
     validateARIAProperties(type, props);
     validateInputPropertes(type, props);
@@ -414,15 +416,21 @@ var ReactDOMFiberComponent = {
 
     if (__DEV__) {
       if (namespaceURI === HTML_NAMESPACE) {
-        warning(
-          isCustomComponentTag ||
-            Object.prototype.toString.call(domElement) !==
-              '[object HTMLUnknownElement]',
-          'The tag <%s> is unrecognized in this browser. ' +
-            'If you meant to render a React component, start its name with ' +
-            'an uppercase letter.',
-          type,
-        );
+        if (
+          !isCustomComponentTag &&
+          Object.prototype.toString.call(domElement) ===
+            '[object HTMLUnknownElement]' &&
+          !warnedUnknownTags[type]
+        ) {
+          warnedUnknownTags[type] = true;
+          warning(
+            false,
+            'The tag <%s> is unrecognized in this browser. ' +
+              'If you meant to render a React component, start its name with ' +
+              'an uppercase letter.',
+            type,
+          );
+        }
       }
     }
 

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -426,7 +426,7 @@ var ReactDOMFiberComponent = {
           !isCustomComponentTag &&
           Object.prototype.toString.call(domElement) ===
             '[object HTMLUnknownElement]' &&
-          !warnedUnknownTags.hasOwnProperty(type)
+          !Object.prototype.hasOwnProperty.call(warnedUnknownTags, type)
         ) {
           warnedUnknownTags[type] = true;
           warning(

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -66,10 +66,10 @@ var {
 
 if (__DEV__) {
   var warnedUnknownTags = {
-    // People often believe <time> is a part of HTML5, but it was dropped.
-    // However it is currently widely used for semantic purposes, and Chrome
-    // intends to ship it (as of July 2017). To avoid flooding people with warnings,
-    // we intentionally *don't* warn about <time> even if it's unrecognized.
+    // Chrome is the only major browser not shipping <time>. But as of July
+    // 2017 it intends to ship it due to widespread usage. We intentionally
+    // *don't* warn for <time> even if it's unrecognized by Chrome because
+    // it soon will be, and many apps have been using it anyway.
     time: true,
   };
 

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -65,7 +65,13 @@ var {
 } = DOMNamespaces;
 
 if (__DEV__) {
-  var warnedUnknownTags = {};
+  var warnedUnknownTags = {
+    // People often believe <time> is a part of HTML5, but it was dropped.
+    // However it is currently widely used for semantic purposes, and Chrome
+    // intends to ship it (as of July 2017). To avoid flooding people with warnings,
+    // we intentionally *don't* warn about <time> even if it's unrecognized.
+    time: true,
+  };
 
   var validatePropertiesInDevelopment = function(type, props) {
     validateARIAProperties(type, props);

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -426,7 +426,7 @@ var ReactDOMFiberComponent = {
           !isCustomComponentTag &&
           Object.prototype.toString.call(domElement) ===
             '[object HTMLUnknownElement]' &&
-          !warnedUnknownTags[type]
+          !warnedUnknownTags.hasOwnProperty(type)
         ) {
           warnedUnknownTags[type] = true;
           warning(

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -822,6 +822,10 @@ describe('ReactDOMComponent', () => {
           if (this instanceof window.HTMLUnknownElement) {
             return '[object HTMLUnknownElement]';
           }
+          // Special case! Read explanation below in the test.
+          if (this instanceof window.HTMLTimeElement) {
+            return '[object HTMLUnknownElement]';
+          }
           return realToString.apply(this, arguments);
         };
         Object.prototype.toString = wrappedToString; // eslint-disable-line no-extend-native
@@ -830,6 +834,12 @@ describe('ReactDOMComponent', () => {
         // Test deduplication
         ReactTestUtils.renderIntoDocument(<foo />);
         ReactTestUtils.renderIntoDocument(<foo />);
+        // This is a funny case.
+        // People often believe <time> is a part of HTML5, but it was dropped.
+        // However it is currently widely used for semantic purposes, and Chrome
+        // intends to ship it (as of July 2017). To avoid flooding people with warnings,
+        // we intentionally *don't* warn about <time> even if it's unrecognized.
+        ReactTestUtils.renderIntoDocument(<time />);
       } finally {
         Object.prototype.toString = realToString; // eslint-disable-line no-extend-native
       }

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -840,16 +840,26 @@ describe('ReactDOMComponent', () => {
         // intends to ship it (as of July 2017). To avoid flooding people with warnings,
         // we intentionally *don't* warn about <time> even if it's unrecognized.
         ReactTestUtils.renderIntoDocument(<time />);
+        // Corner case. Make sure out deduplication logic doesn't break with weird tag.
+        ReactTestUtils.renderIntoDocument(<hasOwnProperty />);
       } finally {
         Object.prototype.toString = realToString; // eslint-disable-line no-extend-native
       }
 
-      expectDev(console.error.calls.count()).toBe(2);
+      expectDev(console.error.calls.count()).toBe(4);
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
         'The tag <bar> is unrecognized in this browser',
       );
       expectDev(console.error.calls.argsFor(1)[0]).toContain(
         'The tag <foo> is unrecognized in this browser',
+      );
+      expectDev(console.error.calls.argsFor(2)[0]).toContain(
+        '<hasOwnProperty /> is using uppercase HTML',
+      );
+      expectDev(console.error.calls.argsFor(3)[0]).toContain(
+        ReactDOMFeatureFlags.useFiber
+          ? 'The tag <hasOwnProperty> is unrecognized in this browser'
+          : 'The tag <hasownproperty> is unrecognized in this browser',
       );
     });
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -825,14 +825,21 @@ describe('ReactDOMComponent', () => {
           return realToString.apply(this, arguments);
         };
         Object.prototype.toString = wrappedToString; // eslint-disable-line no-extend-native
-        ReactTestUtils.renderIntoDocument(<mycustomcomponent />);
+
+        ReactTestUtils.renderIntoDocument(<bar />);
+        // Test deduplication
+        ReactTestUtils.renderIntoDocument(<foo />);
+        ReactTestUtils.renderIntoDocument(<foo />);
       } finally {
         Object.prototype.toString = realToString; // eslint-disable-line no-extend-native
       }
 
-      expectDev(console.error.calls.count()).toBe(1);
+      expectDev(console.error.calls.count()).toBe(2);
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'The tag <mycustomcomponent> is unrecognized in this browser',
+        'The tag <bar> is unrecognized in this browser',
+      );
+      expectDev(console.error.calls.argsFor(1)[0]).toContain(
+        'The tag <foo> is unrecognized in this browser',
       );
     });
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -835,10 +835,10 @@ describe('ReactDOMComponent', () => {
         ReactTestUtils.renderIntoDocument(<foo />);
         ReactTestUtils.renderIntoDocument(<foo />);
         // This is a funny case.
-        // People often believe <time> is a part of HTML5, but it was dropped.
-        // However it is currently widely used for semantic purposes, and Chrome
-        // intends to ship it (as of July 2017). To avoid flooding people with warnings,
-        // we intentionally *don't* warn about <time> even if it's unrecognized.
+        // Chrome is the only major browser not shipping <time>. But as of July
+        // 2017 it intends to ship it due to widespread usage. We intentionally
+        // *don't* warn for <time> even if it's unrecognized by Chrome because
+        // it soon will be, and many apps have been using it anyway.
         ReactTestUtils.renderIntoDocument(<time />);
         // Corner case. Make sure out deduplication logic doesn't break with weird tag.
         ReactTestUtils.renderIntoDocument(<hasOwnProperty />);

--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -375,10 +375,10 @@ function validateDangerousTag(tag) {
 
 var globalIdCounter = 1;
 var warnedUnknownTags = {
-  // People often believe <time> is a part of HTML5, but it was dropped.
-  // However it is currently widely used for semantic purposes, and Chrome
-  // intends to ship it (as of July 2017). To avoid flooding people with warnings,
-  // we intentionally *don't* warn about <time> even if it's unrecognized.
+  // Chrome is the only major browser not shipping <time>. But as of July
+  // 2017 it intends to ship it due to widespread usage. We intentionally
+  // *don't* warn for <time> even if it's unrecognized by Chrome because
+  // it soon will be, and many apps have been using it anyway.
   time: true,
 };
 

--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -374,7 +374,13 @@ function validateDangerousTag(tag) {
 }
 
 var globalIdCounter = 1;
-var warnedUnknownTags = {};
+var warnedUnknownTags = {
+  // People often believe <time> is a part of HTML5, but it was dropped.
+  // However it is currently widely used for semantic purposes, and Chrome
+  // intends to ship it (as of July 2017). To avoid flooding people with warnings,
+  // we intentionally *don't* warn about <time> even if it's unrecognized.
+  time: true,
+};
 
 /**
  * Creates a new React class that is idempotent and capable of containing other

--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -374,6 +374,7 @@ function validateDangerousTag(tag) {
 }
 
 var globalIdCounter = 1;
+var warnedUnknownTags = {};
 
 /**
  * Creates a new React class that is idempotent and capable of containing other
@@ -578,15 +579,21 @@ ReactDOMComponent.Mixin = {
           didWarnShadyDOM = true;
         }
         if (this._namespaceURI === DOMNamespaces.html) {
-          warning(
-            isCustomComponentTag ||
-              Object.prototype.toString.call(el) !==
-                '[object HTMLUnknownElement]',
-            'The tag <%s> is unrecognized in this browser. ' +
-              'If you meant to render a React component, start its name with ' +
-              'an uppercase letter.',
-            this._tag,
-          );
+          if (
+            !isCustomComponentTag &&
+            Object.prototype.toString.call(el) ===
+              '[object HTMLUnknownElement]' &&
+            !warnedUnknownTags[this._tag]
+          ) {
+            warnedUnknownTags[this._tag] = true;
+            warning(
+              false,
+              'The tag <%s> is unrecognized in this browser. ' +
+                'If you meant to render a React component, start its name with ' +
+                'an uppercase letter.',
+              this._tag,
+            );
+          }
         }
       }
       ReactDOMComponentTree.precacheNode(this, el);

--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -589,7 +589,7 @@ ReactDOMComponent.Mixin = {
             !isCustomComponentTag &&
             Object.prototype.toString.call(el) ===
               '[object HTMLUnknownElement]' &&
-            !warnedUnknownTags[this._tag]
+            !warnedUnknownTags.hasOwnProperty(this._tag)
           ) {
             warnedUnknownTags[this._tag] = true;
             warning(

--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -589,7 +589,7 @@ ReactDOMComponent.Mixin = {
             !isCustomComponentTag &&
             Object.prototype.toString.call(el) ===
               '[object HTMLUnknownElement]' &&
-            !warnedUnknownTags.hasOwnProperty(this._tag)
+            !Object.prototype.hasOwnProperty.call(warnedUnknownTags, this._tag)
           ) {
             warnedUnknownTags[this._tag] = true;
             warning(


### PR DESCRIPTION
1. Dedupes the warning by tag name (it's noisy on each render)
2. Ignores `<time>` specifically because people actively use it, and Chrome intends to ship it (after all other browsers) [1](https://bugs.chromium.org/p/chromium/issues/detail?id=655921#c12) [2](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/e52E3t3ijHo)