### PR TITLE
Added info that PropTypes are also nice as "component API docs"

### DIFF
--- a/docs/docs/typechecking-with-proptypes.md
+++ b/docs/docs/typechecking-with-proptypes.md
@@ -30,7 +30,7 @@ Greeting.propTypes = {
 };
 ```
 
-`PropTypes` exports a range of validators that can be used to make sure the data you receive is valid. In this example, we're using `PropTypes.string`. When an invalid value is provided for a prop, a warning will be shown in the JavaScript console. For performance reasons, `propTypes` is only checked in development mode.
+`PropTypes` exports a range of validators that can be used to make sure the data you receive is valid. In this example, we're using `PropTypes.string`. When an invalid value is provided for a prop, a warning will be shown in the JavaScript console. For performance reasons, `propTypes` is only checked in development mode. An additional benefit of PropTypes is that they serve as kind of an "API documentation" of your component, making it easy to see in one place what props can be set for it.
 
 ### PropTypes
 


### PR DESCRIPTION
In my opinion, PropTypes have more benefits than just typechecking. In order to better highlight benefits their usage, I have added a (hopefully)concise information about one particular benefit I noticed, which is the fact that they allow developers to see what props can be set on a component in a single place.
