### PR TITLE
Fix process override in ErrorUtils test

### DIFF
--- a/src/renderers/shared/utils/__tests__/ReactErrorUtils-test.js
+++ b/src/renderers/shared/utils/__tests__/ReactErrorUtils-test.js
@@ -28,10 +28,15 @@ describe('ReactErrorUtils', () => {
     let oldProcess;
     beforeEach(() => {
       __DEV__ = false;
+
+      // Mutating process.env.NODE_ENV would cause our babel plugins to do the
+      // wrong thing. If you change this, make sure to test with jest --no-cache.
       oldProcess = process;
       global.process = {
-        env: Object.assign({}, process.env, {NODE_ENV: 'production'}),
+        ...process,
+        env: {...process.env, NODE_ENV: 'production'},
       };
+
       jest.resetModules();
       ReactErrorUtils = require('ReactErrorUtils');
     });


### PR DESCRIPTION
This fixes issue that causes confusing errors like https://circleci.com/gh/facebook/react/4653?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link:

```
 FAIL  src/renderers/shared/utils/__tests__/ReactErrorUtils-test.js
  ● ReactErrorUtils › invokeGuardedCallback (production) › should return false from clearCaughtError if no error was thrown (production)

    TypeError: process.cwd is not a function
```

Lifted this trick from [here](https://github.com/facebook/react/blob/52849c94a732bae67541e0f6f8ff7f5943372a6c/src/renderers/dom/__tests__/ReactDOMProduction-test.js#L23-L29) where we had same issue.