### PR TITLE
Wrap "warning" call in DEV block to prevent PROD error

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberDevToolsHook.js
+++ b/src/renderers/shared/fiber/ReactFiberDevToolsHook.js
@@ -17,6 +17,10 @@ import type {FiberRoot} from 'ReactFiberRoot';
 
 declare var __REACT_DEVTOOLS_GLOBAL_HOOK__: Object | void;
 
+if (__DEV__) {
+  var warning = require('fbjs/lib/warning');
+}
+
 let rendererID = null;
 let injectInternals = null;
 let onCommitRoot = null;
@@ -30,10 +34,11 @@ if (
     onCommitFiberRoot,
     onCommitFiberUnmount,
   } = __REACT_DEVTOOLS_GLOBAL_HOOK__;
-  var warning = require('fbjs/lib/warning');
 
   injectInternals = function(internals: Object) {
-    warning(rendererID == null, 'Cannot inject into DevTools twice.');
+    if (__DEV__) {
+      warning(rendererID == null, 'Cannot inject into DevTools twice.');
+    }
     rendererID = inject(internals);
   };
 

--- a/src/renderers/shared/fiber/ReactFiberDevToolsHook.js
+++ b/src/renderers/shared/fiber/ReactFiberDevToolsHook.js
@@ -12,10 +12,6 @@
 
 'use strict';
 
-if (__DEV__) {
-  var warning = require('fbjs/lib/warning');
-}
-
 import type {Fiber} from 'ReactFiber';
 import type {FiberRoot} from 'ReactFiberRoot';
 
@@ -34,6 +30,7 @@ if (
     onCommitFiberRoot,
     onCommitFiberUnmount,
   } = __REACT_DEVTOOLS_GLOBAL_HOOK__;
+  var warning = require('fbjs/lib/warning');
 
   injectInternals = function(internals: Object) {
     warning(rendererID == null, 'Cannot inject into DevTools twice.');


### PR DESCRIPTION
There is a warning call that should ideally be wrapped in a DEV only block. This PR wraps that warning call, fixing a PROD bundle runtime error.