### PR TITLE
Replace "children (and grandchildren)" with "descendants"

### DIFF
--- a/docs/_posts/2017-07-26-error-handling-in-react-16.md
+++ b/docs/_posts/2017-07-26-error-handling-in-react-16.md
@@ -15,7 +15,7 @@ In the past, JavaScript errors inside components used to corrupt React’s inter
 
 A JavaScript error in a part of the UI shouldn’t break the whole app. To solve this problem for React users, React 16 introduces a new concept of an “error boundary”.
 
-Error boundaries are React components that **catch JavaScript errors in their children (and grandchildren), log those errors, and display a fallback UI** instead of the component tree that crashed. Error boundaries catch errors during rendering, in lifecycle methods, and in constructors of the whole tree below them.
+Error boundaries are React components that **catch JavaScript errors in their descendants, log those errors, and display a fallback UI** instead of the component tree that crashed. Error boundaries catch errors during rendering, in lifecycle methods, and in constructors of the whole tree below them.
 
 A class component becomes an error boundary if it defines a new lifecycle method called `componentDidCatch(error, info)`:
 


### PR DESCRIPTION
"children (and grandchildren)" implies that the error boundary only goes two levels deep, when in reality it catches errors in the entire subtree.