### PR TITLE
Additional information on PropTypes.func

### DIFF
--- a/docs/docs/typechecking-with-proptypes.md
+++ b/docs/docs/typechecking-with-proptypes.md
@@ -56,6 +56,9 @@ MyComponent.propTypes = {
 
   // A React element.
   optionalElement: PropTypes.element,
+  
+  // A function or class
+  optionalElement: PropTypes.func
 
   // You can also declare that a prop is an instance of a class. This uses
   // JS's instanceof operator.


### PR DESCRIPTION
Added clarification that PropTypes.func can be used to check for a class components.
