### PR TITLE
Test that ReactDOM.render and renderSubtreeIntoContainer always returns an instance

### DIFF
--- a/src/renderers/__tests__/ReactComponent-test.js
+++ b/src/renderers/__tests__/ReactComponent-test.js
@@ -338,6 +338,41 @@ describe('ReactComponent', () => {
     expect(callback.mock.calls.length).toBe(3);
   });
 
+  it('returns instance during synchronous render', () => {
+    function assertRenderReturnsInstance(element) {
+      var container = document.createElement('div');
+      var inst = ReactDOM.render(element, container);
+      expect(inst).not.toBe(null);
+      expect(inst).toBeInstanceOf(element.type);
+    }
+    class Child extends React.Component {
+      render() {
+        return null;
+      }
+    }
+    class Parent extends React.Component {
+      componentWillMount() {
+        assertRenderReturnsInstance(<Child />);
+      }
+      componentDidMount() {
+        assertRenderReturnsInstance(<Child />);
+      }
+      componentWillUpdate() {
+        assertRenderReturnsInstance(<Child />);
+      }
+      componentDidUpdate() {
+        assertRenderReturnsInstance(<Child />);
+      }
+      componentWillUnmount() {
+        assertRenderReturnsInstance(<Child />);
+      }
+      render() {
+        return null;
+      }
+    }
+    assertRenderReturnsInstance(<Parent />);
+  });
+
   it('throws usefully when rendering badly-typed elements', () => {
     spyOn(console, 'error');
 

--- a/src/renderers/dom/shared/__tests__/renderSubtreeIntoContainer-test.js
+++ b/src/renderers/dom/shared/__tests__/renderSubtreeIntoContainer-test.js
@@ -299,4 +299,40 @@ describe('renderSubtreeIntoContainer', () => {
     ReactDOM.render(<Parent value="foo" />, container);
     expect(portal2.textContent).toBe('foo');
   });
+
+  it('returns instance during synchronous render', () => {
+    function assertRenderReturnsInstance(context, element) {
+      var container = document.createElement('div');
+      var inst = renderSubtreeIntoContainer(context, element, container);
+      expect(inst).not.toBe(null);
+      expect(inst).toBeInstanceOf(element.type);
+    }
+    class Child extends React.Component {
+      render() {
+        return null;
+      }
+    }
+    class Parent extends React.Component {
+      componentWillMount() {
+        assertRenderReturnsInstance(this, <Child />);
+      }
+      componentDidMount() {
+        assertRenderReturnsInstance(this, <Child />);
+      }
+      componentWillUpdate() {
+        assertRenderReturnsInstance(this, <Child />);
+      }
+      componentDidUpdate() {
+        assertRenderReturnsInstance(this, <Child />);
+      }
+      componentWillUnmount() {
+        assertRenderReturnsInstance(this, <Child />);
+      }
+      render() {
+        return null;
+      }
+    }
+    var container = document.createElement('div');
+    ReactDOM.render(<Parent />, container);
+  });
 });


### PR DESCRIPTION
Failing (in Fiber) tests for https://github.com/facebook/react/issues/10309.