### PR TITLE
Wraps remaining warning calls that should be removed from FB PROD bundle

### DIFF
--- a/src/renderers/dom/fiber/wrappers/ReactDOMFiberSelect.js
+++ b/src/renderers/dom/fiber/wrappers/ReactDOMFiberSelect.js
@@ -148,20 +148,22 @@ var ReactDOMSelect = {
       wasMultiple: !!props.multiple,
     };
 
-    if (
-      props.value !== undefined &&
-      props.defaultValue !== undefined &&
-      !didWarnValueDefaultValue
-    ) {
-      warning(
-        false,
-        'Select elements must be either controlled or uncontrolled ' +
-          '(specify either the value prop, or the defaultValue prop, but not ' +
-          'both). Decide between using a controlled or uncontrolled select ' +
-          'element and remove one of these props. More info: ' +
-          'https://fb.me/react-controlled-components',
-      );
-      didWarnValueDefaultValue = true;
+    if (__DEV__) {
+      if (
+        props.value !== undefined &&
+        props.defaultValue !== undefined &&
+        !didWarnValueDefaultValue
+      ) {
+        warning(
+          false,
+          'Select elements must be either controlled or uncontrolled ' +
+            '(specify either the value prop, or the defaultValue prop, but not ' +
+            'both). Decide between using a controlled or uncontrolled select ' +
+            'element and remove one of these props. More info: ' +
+            'https://fb.me/react-controlled-components',
+        );
+        didWarnValueDefaultValue = true;
+      }
     }
   },
 

--- a/src/renderers/dom/shared/DOMMarkupOperations.js
+++ b/src/renderers/dom/shared/DOMMarkupOperations.js
@@ -42,7 +42,9 @@ function isAttributeNameSafe(attributeName) {
     return true;
   }
   illegalAttributeNameCache[attributeName] = true;
-  warning(false, 'Invalid attribute name: `%s`', attributeName);
+  if (__DEV__) {
+    warning(false, 'Invalid attribute name: `%s`', attributeName);
+  }
   return false;
 }
 

--- a/src/renderers/dom/shared/DOMPropertyOperations.js
+++ b/src/renderers/dom/shared/DOMPropertyOperations.js
@@ -42,7 +42,9 @@ function isAttributeNameSafe(attributeName) {
     return true;
   }
   illegalAttributeNameCache[attributeName] = true;
-  warning(false, 'Invalid attribute name: `%s`', attributeName);
+  if (__DEV__) {
+    warning(false, 'Invalid attribute name: `%s`', attributeName);
+  }
   return false;
 }
 


### PR DESCRIPTION
This PR is intended to be in addition to stripping out warnings (separate PR https://github.com/facebook/react/pull/10314/). This PR aims to remove the call-sites for the warnings in PROD too.