### PR TITLE
Fix SSR integration test swallowing lack of expected error 

### DIFF
--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -229,11 +229,10 @@ function itClientRenders(desc, testFn) {
 
 function itThrows(desc, testFn) {
   it(`throws ${desc}`, () => {
-    return testFn()
-      .then(() =>
-        expect(false).toBe('The promise resolved and should not have.'),
-      )
-      .catch(() => {});
+    return testFn().then(
+      () => expect(false).toBe('The promise resolved and should not have.'),
+      () => {},
+    );
   });
 }
 


### PR DESCRIPTION
We have some tests that check that *expected* errors are thrown.
These tests use a helper called `itThrowsWhenRendering`.

Currently, there is a bug in this helper. When there is no error (but an error is expected), it tries to fail the test with `expect(false).toBe('The promise resolved and should not have.')`. However the `catch()` block catches and swallows this exception.

The fix is to attach the error handler to the original Promise rather than to the one after our handler.

This fix exposes two missing expected errors in new SSR related to context. The second commit fixes them by adding the respective invariants.

To future proof this, I want to assert on specific error messages instead. I will do so in a follow up PR.