### PR TITLE
Fix invariant parity for SSR

### DIFF
--- a/src/renderers/dom/ReactDOMNodeStreamRenderer.js
+++ b/src/renderers/dom/ReactDOMNodeStreamRenderer.js
@@ -45,7 +45,7 @@ function renderToStream(element) {
   if (disableNewFiberFeatures) {
     invariant(
       React.isValidElement(element),
-      'renderToStream(): You must pass a valid ReactElement.',
+      'renderToStream(): Invalid component element.',
     );
   }
   return new ReactMarkupReadableStream(element, false);
@@ -61,7 +61,7 @@ function renderToStaticStream(element) {
   if (disableNewFiberFeatures) {
     invariant(
       React.isValidElement(element),
-      'renderToStaticStream(): You must pass a valid ReactElement.',
+      'renderToStaticStream(): Invalid component element.',
     );
   }
   return new ReactMarkupReadableStream(element, true);

--- a/src/renderers/dom/ReactDOMStringRenderer.js
+++ b/src/renderers/dom/ReactDOMStringRenderer.js
@@ -26,7 +26,7 @@ function renderToString(element) {
   if (disableNewFiberFeatures) {
     invariant(
       React.isValidElement(element),
-      'renderToString(): You must pass a valid ReactElement.',
+      'renderToString(): Invalid component element.',
     );
   }
   var renderer = new ReactPartialRenderer(element, false);
@@ -44,7 +44,7 @@ function renderToStaticMarkup(element) {
   if (disableNewFiberFeatures) {
     invariant(
       React.isValidElement(element),
-      'renderToStaticMarkup(): You must pass a valid ReactElement.',
+      'renderToStaticMarkup(): Invalid component element.',
     );
   }
   var renderer = new ReactPartialRenderer(element, true);

--- a/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
@@ -327,7 +327,7 @@ describe('ReactDOMServer', () => {
       ).toThrowError(
         ReactDOMFeatureFlags.useFiber
           ? 'Objects are not valid as a React child (found: object with keys {x})'
-          : 'renderToString(): You must pass a valid ReactElement.',
+          : 'renderToString(): Invalid component element.',
       );
     });
   });
@@ -443,7 +443,7 @@ describe('ReactDOMServer', () => {
       ).toThrowError(
         ReactDOMFeatureFlags.useFiber
           ? 'Objects are not valid as a React child (found: object with keys {x})'
-          : 'renderToStaticMarkup(): You must pass a valid ReactElement.',
+          : 'renderToStaticMarkup(): Invalid component element.',
       );
     });
 

--- a/src/renderers/dom/stack/server/ReactServerRendering.js
+++ b/src/renderers/dom/stack/server/ReactServerRendering.js
@@ -79,7 +79,7 @@ function renderToStringImpl(element, makeStaticMarkup) {
 function renderToString(element) {
   invariant(
     React.isValidElement(element),
-    'renderToString(): You must pass a valid ReactElement.',
+    'renderToString(): Invalid component element.',
   );
   return renderToStringImpl(element, false);
 }
@@ -92,7 +92,7 @@ function renderToString(element) {
 function renderToStaticMarkup(element) {
   invariant(
     React.isValidElement(element),
-    'renderToStaticMarkup(): You must pass a valid ReactElement.',
+    'renderToStaticMarkup(): Invalid component element.',
   );
   return renderToStringImpl(element, true);
 }

--- a/src/renderers/shared/server/ReactPartialRenderer.js
+++ b/src/renderers/shared/server/ReactPartialRenderer.js
@@ -309,6 +309,18 @@ function createOpenTagMarkup(
   return ret;
 }
 
+function validateRenderResult(child, type) {
+  if (child === undefined) {
+    invariant(
+      false,
+      '%s(...): Nothing was returned from render. This usually means a ' +
+        'return statement is missing. Or, to render nothing, ' +
+        'return null.',
+      getComponentName(type) || 'Component',
+    );
+  }
+}
+
 function resolve(child, context) {
   while (React.isValidElement(child)) {
     if (__DEV__) {
@@ -351,6 +363,7 @@ function resolve(child, context) {
       inst = Component(child.props, publicContext, updater);
       if (inst == null || inst.render == null) {
         child = inst;
+        validateRenderResult(child, Component);
         continue;
       }
     }
@@ -405,6 +418,7 @@ function resolve(child, context) {
         child = null;
       }
     }
+    validateRenderResult(child, Component);
 
     var childContext;
     if (typeof inst.getChildContext === 'function') {


### PR DESCRIPTION
There's a few different things here that was a bit difficult to untangle.
The goals were:

* Make sure common invariants give the same messages with client and server render.
* Throw in the same cases. Not throwing in SSR but throwing on the client makes warnings very confusing.
* Turn "new features" on for the DOM integration fixture since we're only working on new SSR now.
* Make sure we have tests for top level rendering (strings, numbers, arrays).

I'll add more inline comments for specific changes.