### PR TITLE
Context improvements

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -277,6 +277,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     markRef(current, workInProgress);
 
     if (!shouldUpdate) {
+      // Context providers should defer to sCU for rendering
+      if (hasContext) {
+        invalidateContextProvider(workInProgress, false);
+      }
+
       return bailoutOnAlreadyFinishedWork(current, workInProgress);
     }
 
@@ -302,8 +307,9 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
     // The context might have changed so we need to recalculate it.
     if (hasContext) {
-      invalidateContextProvider(workInProgress);
+      invalidateContextProvider(workInProgress, true);
     }
+
     return workInProgress.child;
   }
 

--- a/src/renderers/shared/fiber/ReactFiberContext.js
+++ b/src/renderers/shared/fiber/ReactFiberContext.js
@@ -259,6 +259,7 @@ exports.invalidateContextProvider = function(
 
   // Merge parent and own context.
   // Skip this if we're not updating due to sCU.
+  // This avoids unnecessarily recomputing memoized values.
   let mergedContext;
   if (didChange) {
     mergedContext = processChildContext(workInProgress, previousContext, true);

--- a/src/renderers/shared/fiber/ReactFiberContext.js
+++ b/src/renderers/shared/fiber/ReactFiberContext.js
@@ -270,6 +270,7 @@ exports.invalidateContextProvider = function(
   pop(didPerformWorkStackCursor, workInProgress);
   if (didChange) {
     pop(contextStackCursor, workInProgress);
+    // $FlowFixMe - We know that this is always an object when didChange is true.
     push(contextStackCursor, mergedContext, workInProgress);
   }
   push(didPerformWorkStackCursor, didChange, workInProgress);

--- a/src/renderers/shared/fiber/ReactFiberContext.js
+++ b/src/renderers/shared/fiber/ReactFiberContext.js
@@ -257,24 +257,28 @@ exports.invalidateContextProvider = function(
       'This error is likely caused by a bug in React. Please file an issue.',
   );
 
-  // Merge parent and own context.
-  // Skip this if we're not updating due to sCU.
-  // This avoids unnecessarily recomputing memoized values.
-  let mergedContext;
   if (didChange) {
-    mergedContext = processChildContext(workInProgress, previousContext, true);
+    // Merge parent and own context.
+    // Skip this if we're not updating due to sCU.
+    // This avoids unnecessarily recomputing memoized values.
+    const mergedContext = processChildContext(
+      workInProgress,
+      previousContext,
+      true,
+    );
     instance.__reactInternalMemoizedMergedChildContext = mergedContext;
-  }
 
-  // Replace the old (or empty) context with the new one.
-  // It is important to unwind the context in the reverse order.
-  pop(didPerformWorkStackCursor, workInProgress);
-  if (didChange) {
+    // Replace the old (or empty) context with the new one.
+    // It is important to unwind the context in the reverse order.
+    pop(didPerformWorkStackCursor, workInProgress);
     pop(contextStackCursor, workInProgress);
-    // $FlowFixMe - We know that this is always an object when didChange is true.
+    // Now push the new context and mark that it has changed.
     push(contextStackCursor, mergedContext, workInProgress);
+    push(didPerformWorkStackCursor, didChange, workInProgress);
+  } else {
+    pop(didPerformWorkStackCursor, workInProgress);
+    push(didPerformWorkStackCursor, didChange, workInProgress);
   }
-  push(didPerformWorkStackCursor, didChange, workInProgress);
 };
 
 exports.resetContext = function(): void {

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -2444,7 +2444,7 @@ describe('ReactIncremental', () => {
     expect(rendered).toEqual(['count:0', 'count:1']);
   });
 
-  it('updates descendants with multiple context-providing anscestors with new context values', () => {
+  it('updates descendants with multiple context-providing ancestors with new context values', () => {
     let rendered = [];
     let instance;
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncremental-test.js
@@ -2396,10 +2396,7 @@ describe('ReactIncremental', () => {
     },
   );
 
-  // TODO bvaughn Convert new tests to use ReactNoop?
-  // TODO bvaughn Better annotate with comments?
-  // TODO bvaughn Remove any tests that overlap with above?
-  it('should update descendants with new context values', () => {
+  it('updates descendants with new context values', () => {
     let rendered = [];
     let instance;
 
@@ -2447,7 +2444,7 @@ describe('ReactIncremental', () => {
     expect(rendered).toEqual(['count:0', 'count:1']);
   });
 
-  it('should update descendants with multiple context-providing anscestors with new context values', () => {
+  it('updates descendants with multiple context-providing anscestors with new context values', () => {
     let rendered = [];
     let instance;
 


### PR DESCRIPTION
React maintains context using a stack structure (`ReactFiberStack`). Each time a context-providing component is encountered during the begin-work phase, it is pushed onto the stack. We push early to ensure stack size consistency/predictability. However, at the time we initially push, the context-providing instance may not yet exist. In this case we add a placeholder context object and a default value for whether we performed work at this level and assume that we will update both later.

Previously we initialized the "did perform work at this level" value to false. However that approach can cause problems for context-providing components, making it possible for a component to block its own updates by failing [this check in `ReactFiberClassComponent`](https://github.com/facebook/react/blob/1454f9c10c4f487bd87227aad0162d0c888b20e3/src/renderers/shared/fiber/ReactFiberClassComponent.js#L583-L589). This was initially reported by @edvinerikson [via Twitter](https://twitter.com/edvinerikson/status/891974391742988288).

I believe a more correct approach to initializing the "did perform work at this level" bit for a context-providing component is for the component to default to the same value as its parent. We can later update the value using the `invalidateContextProvider` helper to match what `shouldComponentUpdate` returned.

I have added some new test cases to the `ReactIncremental-test` to cover the previous regression case. These new tests may overlap somewhat with the existing ones but I thought it better to be slightly verbose in this case. (I'm open to feedback on this though!)

PS While investigating this issue I also noticed a difference in behavior between stack and fiber DOM renderers. I believe in this case that fiber is behaving correctly _and_ the noop renderer is consistent with fiber's behavior, so I didn't bother adding additional stack-specific tests.