### PR TITLE
Add ReactDOM.hydrate() as explicit SSR hydration API

### DIFF
--- a/src/renderers/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/__tests__/ReactCompositeComponent-test.js
@@ -118,7 +118,7 @@ describe('ReactCompositeComponent', () => {
       }
     }
 
-    spyOn(console, 'error');
+    spyOn(console, 'warn');
     var markup = ReactDOMServer.renderToString(<Parent />);
 
     // Old API based on heuristic
@@ -126,23 +126,23 @@ describe('ReactCompositeComponent', () => {
     container.innerHTML = markup;
     ReactDOM.render(<Parent />, container);
     if (ReactDOMFeatureFlags.useFiber) {
-      expectDev(console.error.calls.count()).toBe(1);
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      expectDev(console.warn.calls.count()).toBe(1);
+      expectDev(console.warn.calls.argsFor(0)[0]).toContain(
         'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
           'will stop working in React v17. Replace the ReactDOM.render() call ' +
           'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
       );
     } else {
-      expectDev(console.error.calls.count()).toBe(0);
+      expectDev(console.warn.calls.count()).toBe(0);
     }
 
     // New explicit API
-    console.error.calls.reset();
+    console.warn.calls.reset();
     if (ReactDOMFeatureFlags.useFiber) {
       container = document.createElement('div');
       container.innerHTML = markup;
       ReactDOM.hydrate(<Parent />, container);
-      expectDev(console.error.calls.count()).toBe(0);
+      expectDev(console.warn.calls.count()).toBe(0);
     }
   });
 

--- a/src/renderers/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/__tests__/ReactCompositeComponent-test.js
@@ -15,6 +15,7 @@ var ChildUpdates;
 var MorphingComponent;
 var React;
 var ReactDOM;
+var ReactDOMFeatureFlags;
 var ReactDOMServer;
 var ReactCurrentOwner;
 var ReactTestUtils;
@@ -27,6 +28,7 @@ describe('ReactCompositeComponent', () => {
     jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
+    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
     ReactDOMServer = require('react-dom/server');
     ReactCurrentOwner = require('react')
       .__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner;
@@ -116,11 +118,32 @@ describe('ReactCompositeComponent', () => {
       }
     }
 
+    spyOn(console, 'error');
     var markup = ReactDOMServer.renderToString(<Parent />);
+
+    // Old API based on heuristic
     var container = document.createElement('div');
     container.innerHTML = markup;
-
     ReactDOM.render(<Parent />, container);
+    if (ReactDOMFeatureFlags.useFiber) {
+      expectDev(console.error.calls.count()).toBe(1);
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
+          'will stop working in React v17. Replace the ReactDOM.render() call ' +
+          'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
+      );
+    } else {
+      expectDev(console.error.calls.count()).toBe(0);
+    }
+
+    // New explicit API
+    console.error.calls.reset();
+    if (ReactDOMFeatureFlags.useFiber) {
+      container = document.createElement('div');
+      container.innerHTML = markup;
+      ReactDOM.hydrate(<Parent />, container);
+      expectDev(console.error.calls.count()).toBe(0);
+    }
   });
 
   it('should react to state changes from callbacks', () => {

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -525,6 +525,7 @@ ReactGenericBatching.injection.injectFiberBatchedUpdates(
 );
 
 var warnedAboutHydrateAPI = false;
+var warnedAboutEmptyContainer = false;
 
 function renderSubtreeIntoContainer(
   parentComponent: ?ReactComponent<any, any, any>,
@@ -614,6 +615,14 @@ function renderSubtreeIntoContainer(
           'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
             'will stop working in React v17. Replace the ReactDOM.render() call ' +
             'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
+        );
+      }
+      if (forceHydrate && !container.firstChild && !warnedAboutEmptyContainer) {
+        warnedAboutEmptyContainer = true;
+        warning(
+          false,
+          'hydrate(): Expected to hydrate from server-rendered markup, but the passed ' +
+            'DOM container node was empty. React will create the DOM from scratch.',
         );
       }
     }

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -523,6 +523,8 @@ ReactGenericBatching.injection.injectFiberBatchedUpdates(
   DOMRenderer.batchedUpdates,
 );
 
+var warnedAboutHydrateAPI = false;
+
 function renderSubtreeIntoContainer(
   parentComponent: ?ReactComponent<any, any, any>,
   children: ReactNodeList,
@@ -581,7 +583,6 @@ function renderSubtreeIntoContainer(
     const shouldHydrate =
       forceHydrate || shouldHydrateDueToLegacyHeuristic(container);
     // First clear any existing content.
-    // TODO: warn if we're hydrating based on heuristic and suggest using hydrate().
     if (!shouldHydrate) {
       let warned = false;
       let rootSibling;
@@ -602,6 +603,17 @@ function renderSubtreeIntoContainer(
           }
         }
         container.removeChild(rootSibling);
+      }
+    }
+    if (__DEV__) {
+      if (shouldHydrate && !forceHydrate && !warnedAboutHydrateAPI) {
+        warnedAboutHydrateAPI = true;
+        warning(
+          false,
+          'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
+            'will stop working in React v17. Replace the ReactDOM.render() call ' +
+            'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
+        );
       }
     }
     const newRoot = DOMRenderer.createContainer(container);

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -58,6 +58,7 @@ var {
 var {precacheFiberNode, updateFiberProps} = ReactDOMComponentTree;
 
 if (__DEV__) {
+  var lowPriorityWarning = require('lowPriorityWarning');
   var warning = require('fbjs/lib/warning');
   var validateDOMNesting = require('validateDOMNesting');
   var {updatedAncestorInfo} = validateDOMNesting;
@@ -608,7 +609,7 @@ function renderSubtreeIntoContainer(
     if (__DEV__) {
       if (shouldHydrate && !forceHydrate && !warnedAboutHydrateAPI) {
         warnedAboutHydrateAPI = true;
-        warning(
+        lowPriorityWarning(
           false,
           'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
             'will stop working in React v17. Replace the ReactDOM.render() call ' +

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponentTree-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponentTree-test.js
@@ -11,6 +11,8 @@
 
 'use strict';
 
+var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
+
 describe('ReactDOMComponentTree', () => {
   var React;
   var ReactDOM;
@@ -21,7 +23,11 @@ describe('ReactDOMComponentTree', () => {
     var container = document.createElement('div');
     // Force server-rendering path:
     container.innerHTML = ReactDOMServer.renderToString(elt);
-    return ReactDOM.render(elt, container);
+    if (ReactDOMFeatureFlags.useFiber) {
+      return ReactDOM.hydrate(elt, container);
+    } else {
+      return ReactDOM.render(elt, container);
+    }
   }
 
   function getTypeOf(instance) {

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -30,9 +30,13 @@ const COMMENT_NODE_TYPE = 8;
 // ====================================
 
 // promisified version of ReactDOM.render()
-function asyncReactDOMRender(reactElement, domElement) {
+function asyncReactDOMRender(reactElement, domElement, forceHydrate) {
   return new Promise(resolve => {
-    ReactDOM.render(reactElement, domElement);
+    if (forceHydrate && ReactDOMFeatureFlags.useFiber) {
+      ReactDOM.hydrate(reactElement, domElement);
+    } else {
+      ReactDOM.render(reactElement, domElement);
+    }
     // We can't use the callback for resolution because that will not catch
     // errors. They're thrown.
     resolve();
@@ -68,10 +72,10 @@ async function expectErrors(fn, count) {
 
 // renders the reactElement into domElement, and expects a certain number of errors.
 // returns a Promise that resolves when the render is complete.
-function renderIntoDom(reactElement, domElement, errorCount = 0) {
+function renderIntoDom(reactElement, domElement, forceHydrate, errorCount = 0) {
   return expectErrors(async () => {
     ExecutionEnvironment.canUseDOM = true;
-    await asyncReactDOMRender(reactElement, domElement);
+    await asyncReactDOMRender(reactElement, domElement, forceHydrate);
     ExecutionEnvironment.canUseDOM = false;
     return domElement.firstChild;
   }, errorCount);
@@ -135,7 +139,7 @@ async function streamRender(reactElement, errorCount = 0) {
 
 const clientCleanRender = (element, errorCount = 0) => {
   const div = document.createElement('div');
-  return renderIntoDom(element, div, errorCount);
+  return renderIntoDom(element, div, false, errorCount);
 };
 
 const clientRenderOnServerString = async (element, errorCount = 0) => {
@@ -146,7 +150,12 @@ const clientRenderOnServerString = async (element, errorCount = 0) => {
   domElement.innerHTML = markup;
   let serverNode = domElement.firstChild;
 
-  const firstClientNode = await renderIntoDom(element, domElement, errorCount);
+  const firstClientNode = await renderIntoDom(
+    element,
+    domElement,
+    true,
+    errorCount,
+  );
   let clientNode = firstClientNode;
 
   // Make sure all top level nodes match up
@@ -154,19 +163,10 @@ const clientRenderOnServerString = async (element, errorCount = 0) => {
     expect(serverNode != null).toBe(true);
     expect(clientNode != null).toBe(true);
     expect(clientNode.nodeType).toBe(serverNode.nodeType);
-    if (clientNode.nodeType === TEXT_NODE_TYPE) {
-      // Text nodes are stateless so we can just compare values.
-      // This works around a current issue where hydration replaces top-level
-      // text node, but otherwise works.
-      // TODO: we can remove this branch if we add explicit hydration opt-in.
-      // https://github.com/facebook/react/issues/10189
-      expect(serverNode.nodeValue).toBe(clientNode.nodeValue);
-    } else {
-      // Assert that the DOM element hasn't been replaced.
-      // Note that we cannot use expect(serverNode).toBe(clientNode) because
-      // of jest bug #1772.
-      expect(serverNode === clientNode).toBe(true);
-    }
+    // Assert that the DOM element hasn't been replaced.
+    // Note that we cannot use expect(serverNode).toBe(clientNode) because
+    // of jest bug #1772.
+    expect(serverNode === clientNode).toBe(true);
     serverNode = serverNode.nextSibling;
     clientNode = clientNode.nextSibling;
   }
@@ -180,7 +180,7 @@ const clientRenderOnBadMarkup = async (element, errorCount = 0) => {
   var domElement = document.createElement('div');
   domElement.innerHTML =
     '<div id="badIdWhichWillCauseMismatch" data-reactroot="" data-reactid="1"></div>';
-  await renderIntoDom(element, domElement, errorCount + 1);
+  await renderIntoDom(element, domElement, true, errorCount + 1);
 
   // This gives us the resulting text content.
   var hydratedTextContent = domElement.textContent;
@@ -188,7 +188,7 @@ const clientRenderOnBadMarkup = async (element, errorCount = 0) => {
   // Next we render the element into a clean DOM node client side.
   const cleanDomElement = document.createElement('div');
   ExecutionEnvironment.canUseDOM = true;
-  await asyncReactDOMRender(element, cleanDomElement);
+  await asyncReactDOMRender(element, cleanDomElement, true);
   ExecutionEnvironment.canUseDOM = false;
   // This gives us the expected text content.
   const cleanTextContent = cleanDomElement.textContent;
@@ -296,6 +296,7 @@ async function testMarkupMatch(serverElement, clientElement, shouldMatch) {
   return renderIntoDom(
     clientElement,
     domElement.parentNode,
+    true,
     shouldMatch ? 0 : 1,
   );
 }

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -1972,7 +1972,11 @@ describe('ReactDOMServerIntegration', () => {
 
           resetModules();
           // client render on top of the server markup.
-          const clientField = await renderIntoDom(element, field.parentNode);
+          const clientField = await renderIntoDom(
+            element,
+            field.parentNode,
+            true,
+          );
           // verify that the input field was not replaced.
           // Note that we cannot use expect(clientField).toBe(field) because
           // of jest bug #1772
@@ -2331,6 +2335,7 @@ describe('ReactDOMServerIntegration', () => {
       await asyncReactDOMRender(
         <RefsComponent ref={e => (component = e)} />,
         root,
+        true,
       );
       expect(component.refs.myDiv).toBe(root.firstChild);
     });

--- a/src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
@@ -14,6 +14,7 @@
 var React;
 var ReactDOM;
 var ReactDOMServer;
+var ReactDOMFeatureFlags;
 
 // In standard React, TextComponent keeps track of different Text templates
 // using comments. However, in React Fiber, those comments are not outputted due
@@ -29,6 +30,7 @@ describe('ReactDOMTextComponent', () => {
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');
+    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
   });
 
   it('updates a mounted text component in place', () => {
@@ -117,7 +119,11 @@ describe('ReactDOMTextComponent', () => {
     var reactEl = <div>{'foo'}{'bar'}{'baz'}</div>;
     el.innerHTML = ReactDOMServer.renderToString(reactEl);
 
-    ReactDOM.render(reactEl, el);
+    if (ReactDOMFeatureFlags.useFiber) {
+      ReactDOM.hydrate(reactEl, el);
+    } else {
+      ReactDOM.render(reactEl, el);
+    }
     expect(el.textContent).toBe('foobarbaz');
 
     ReactDOM.unmountComponentAtNode(el);
@@ -125,7 +131,11 @@ describe('ReactDOMTextComponent', () => {
     reactEl = <div>{''}{''}{''}</div>;
     el.innerHTML = ReactDOMServer.renderToString(reactEl);
 
-    ReactDOM.render(reactEl, el);
+    if (ReactDOMFeatureFlags.useFiber) {
+      ReactDOM.hydrate(reactEl, el);
+    } else {
+      ReactDOM.render(reactEl, el);
+    }
     expect(el.textContent).toBe('');
   });
 

--- a/src/renderers/dom/shared/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactMount-test.js
@@ -146,12 +146,16 @@ describe('ReactMount', () => {
     expect(instance1 === instance2).toBe(true);
   });
 
-  it('should warn if mounting into dirty rendered markup', () => {
+  it('should warn if mounting into left padded rendered markup', () => {
     var container = document.createElement('container');
     container.innerHTML = ReactDOMServer.renderToString(<div />) + ' ';
 
     spyOn(console, 'error');
-    ReactDOM.render(<div />, container);
+    if (ReactDOMFeatureFlags.useFiber) {
+      ReactDOM.hydrate(<div />, container);
+    } else {
+      ReactDOM.render(<div />, container);
+    }
     expectDev(console.error.calls.count()).toBe(1);
     if (ReactDOMFeatureFlags.useFiber) {
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
@@ -162,15 +166,28 @@ describe('ReactMount', () => {
         'Target node has markup rendered by React, but there are unrelated nodes as well.',
       );
     }
+  });
 
-    console.error.calls.reset();
-    ReactDOM.unmountComponentAtNode(container);
+  it('should warn if mounting into right padded rendered markup', () => {
+    var container = document.createElement('container');
     container.innerHTML = ' ' + ReactDOMServer.renderToString(<div />);
-    ReactDOM.render(<div />, container);
+
+    spyOn(console, 'error');
+    if (ReactDOMFeatureFlags.useFiber) {
+      ReactDOM.hydrate(<div />, container);
+    } else {
+      ReactDOM.render(<div />, container);
+    }
     expectDev(console.error.calls.count()).toBe(1);
-    expectDev(console.error.calls.argsFor(0)[0]).toContain(
-      'Target node has markup rendered by React, but there are unrelated nodes as well.',
-    );
+    if (ReactDOMFeatureFlags.useFiber) {
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        'Did not expect server HTML to contain the text node " " in <container>.',
+      );
+    } else {
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        'Target node has markup rendered by React, but there are unrelated nodes as well.',
+      );
+    }
   });
 
   it('should not warn if mounting into non-empty node', () => {
@@ -203,10 +220,17 @@ describe('ReactMount', () => {
     div.innerHTML = markup;
 
     spyOn(console, 'error');
-    ReactDOM.render(
-      <div>This markup contains an nbsp entity: &nbsp; client text</div>,
-      div,
-    );
+    if (ReactDOMFeatureFlags.useFiber) {
+      ReactDOM.hydrate(
+        <div>This markup contains an nbsp entity: &nbsp; client text</div>,
+        div,
+      );
+    } else {
+      ReactDOM.render(
+        <div>This markup contains an nbsp entity: &nbsp; client text</div>,
+        div,
+      );
+    }
     expectDev(console.error.calls.count()).toBe(1);
     if (ReactDOMFeatureFlags.useFiber) {
       expectDev(console.error.calls.argsFor(0)[0]).toContain(

--- a/src/renderers/dom/shared/__tests__/ReactRenderDocument-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactRenderDocument-test.js
@@ -14,9 +14,10 @@
 var React;
 var ReactDOM;
 var ReactDOMServer;
-var ReactDOMFeatureFlags;
 
 var getTestDocument;
+
+var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 
 var UNMOUNT_INVARIANT_MESSAGE =
   '<html> tried to unmount. ' +
@@ -32,256 +33,511 @@ describe('rendering React components at document', () => {
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');
-    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
     getTestDocument = require('getTestDocument');
   });
 
-  it('should be able to adopt server markup', () => {
-    class Root extends React.Component {
-      render() {
-        return (
-          <html>
-            <head>
-              <title>Hello World</title>
-            </head>
-            <body>
-              {'Hello ' + this.props.hello}
-            </body>
-          </html>
+  describe('with old implicit hydration API', () => {
+    function expectDeprecationWarningWithFiber() {
+      if (ReactDOMFeatureFlags.useFiber) {
+        expectDev(console.error.calls.count()).toBe(1);
+        expectDev(console.error.calls.argsFor(0)[0]).toContain(
+          'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
+            'will stop working in React v17. Replace the ReactDOM.render() call ' +
+            'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
         );
+      } else {
+        expectDev(console.error.calls.count()).toBe(0);
       }
     }
 
-    var markup = ReactDOMServer.renderToString(<Root hello="world" />);
-    var testDocument = getTestDocument(markup);
-    var body = testDocument.body;
-
-    ReactDOM.render(<Root hello="world" />, testDocument);
-    expect(testDocument.body.innerHTML).toBe('Hello world');
-
-    ReactDOM.render(<Root hello="moon" />, testDocument);
-    expect(testDocument.body.innerHTML).toBe('Hello moon');
-
-    expect(body === testDocument.body).toBe(true);
-  });
-
-  it('should not be able to unmount component from document node', () => {
-    class Root extends React.Component {
-      render() {
-        return (
-          <html>
-            <head>
-              <title>Hello World</title>
-            </head>
-            <body>
-              Hello world
-            </body>
-          </html>
-        );
-      }
-    }
-
-    var markup = ReactDOMServer.renderToString(<Root />);
-    var testDocument = getTestDocument(markup);
-    ReactDOM.render(<Root />, testDocument);
-    expect(testDocument.body.innerHTML).toBe('Hello world');
-
-    if (ReactDOMFeatureFlags.useFiber) {
-      // In Fiber this actually works. It might not be a good idea though.
-      ReactDOM.unmountComponentAtNode(testDocument);
-      expect(testDocument.firstChild).toBe(null);
-    } else {
-      expect(function() {
-        ReactDOM.unmountComponentAtNode(testDocument);
-      }).toThrowError(UNMOUNT_INVARIANT_MESSAGE);
-
-      expect(testDocument.body.innerHTML).toBe('Hello world');
-    }
-  });
-
-  it('should not be able to switch root constructors', () => {
-    class Component extends React.Component {
-      render() {
-        return (
-          <html>
-            <head>
-              <title>Hello World</title>
-            </head>
-            <body>
-              Hello world
-            </body>
-          </html>
-        );
-      }
-    }
-
-    class Component2 extends React.Component {
-      render() {
-        return (
-          <html>
-            <head>
-              <title>Hello World</title>
-            </head>
-            <body>
-              Goodbye world
-            </body>
-          </html>
-        );
-      }
-    }
-
-    var markup = ReactDOMServer.renderToString(<Component />);
-    var testDocument = getTestDocument(markup);
-
-    ReactDOM.render(<Component />, testDocument);
-
-    expect(testDocument.body.innerHTML).toBe('Hello world');
-
-    // Reactive update
-    if (ReactDOMFeatureFlags.useFiber) {
-      // This works but is probably a bad idea.
-      ReactDOM.render(<Component2 />, testDocument);
-
-      expect(testDocument.body.innerHTML).toBe('Goodbye world');
-    } else {
-      expect(function() {
-        ReactDOM.render(<Component2 />, testDocument);
-      }).toThrowError(UNMOUNT_INVARIANT_MESSAGE);
-
-      expect(testDocument.body.innerHTML).toBe('Hello world');
-    }
-  });
-
-  it('should be able to mount into document', () => {
-    class Component extends React.Component {
-      render() {
-        return (
-          <html>
-            <head>
-              <title>Hello World</title>
-            </head>
-            <body>
-              {this.props.text}
-            </body>
-          </html>
-        );
-      }
-    }
-
-    var markup = ReactDOMServer.renderToString(
-      <Component text="Hello world" />,
-    );
-    var testDocument = getTestDocument(markup);
-
-    ReactDOM.render(<Component text="Hello world" />, testDocument);
-
-    expect(testDocument.body.innerHTML).toBe('Hello world');
-  });
-
-  it('renders over an existing text child without throwing', () => {
-    const container = document.createElement('div');
-    container.textContent = 'potato';
-    ReactDOM.render(<div>parsnip</div>, container);
-    expect(container.textContent).toBe('parsnip');
-  });
-
-  it('should give helpful errors on state desync', () => {
-    class Component extends React.Component {
-      render() {
-        return (
-          <html>
-            <head>
-              <title>Hello World</title>
-            </head>
-            <body>
-              {this.props.text}
-            </body>
-          </html>
-        );
-      }
-    }
-
-    var markup = ReactDOMServer.renderToString(
-      <Component text="Goodbye world" />,
-    );
-    var testDocument = getTestDocument(markup);
-
-    if (ReactDOMFeatureFlags.useFiber) {
+    it('should be able to adopt server markup', () => {
       spyOn(console, 'error');
-      ReactDOM.render(<Component text="Hello world" />, testDocument);
+      class Root extends React.Component {
+        render() {
+          return (
+            <html>
+              <head>
+                <title>Hello World</title>
+              </head>
+              <body>
+                {'Hello ' + this.props.hello}
+              </body>
+            </html>
+          );
+        }
+      }
+
+      var markup = ReactDOMServer.renderToString(<Root hello="world" />);
+      var testDocument = getTestDocument(markup);
+      var body = testDocument.body;
+
+      ReactDOM.render(<Root hello="world" />, testDocument);
       expect(testDocument.body.innerHTML).toBe('Hello world');
-      expectDev(console.error.calls.count()).toBe(1);
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Text content did not match.',
+
+      ReactDOM.render(<Root hello="moon" />, testDocument);
+      expect(testDocument.body.innerHTML).toBe('Hello moon');
+
+      expect(body === testDocument.body).toBe(true);
+      expectDeprecationWarningWithFiber();
+    });
+
+    it('should not be able to unmount component from document node', () => {
+      spyOn(console, 'error');
+      class Root extends React.Component {
+        render() {
+          return (
+            <html>
+              <head>
+                <title>Hello World</title>
+              </head>
+              <body>
+                Hello world
+              </body>
+            </html>
+          );
+        }
+      }
+
+      var markup = ReactDOMServer.renderToString(<Root />);
+      var testDocument = getTestDocument(markup);
+      ReactDOM.render(<Root />, testDocument);
+      expect(testDocument.body.innerHTML).toBe('Hello world');
+
+      if (ReactDOMFeatureFlags.useFiber) {
+        // In Fiber this actually works. It might not be a good idea though.
+        ReactDOM.unmountComponentAtNode(testDocument);
+        expect(testDocument.firstChild).toBe(null);
+      } else {
+        expect(function() {
+          ReactDOM.unmountComponentAtNode(testDocument);
+        }).toThrowError(UNMOUNT_INVARIANT_MESSAGE);
+
+        expect(testDocument.body.innerHTML).toBe('Hello world');
+      }
+
+      expectDeprecationWarningWithFiber();
+    });
+
+    it('should not be able to switch root constructors', () => {
+      spyOn(console, 'error');
+      class Component extends React.Component {
+        render() {
+          return (
+            <html>
+              <head>
+                <title>Hello World</title>
+              </head>
+              <body>
+                Hello world
+              </body>
+            </html>
+          );
+        }
+      }
+
+      class Component2 extends React.Component {
+        render() {
+          return (
+            <html>
+              <head>
+                <title>Hello World</title>
+              </head>
+              <body>
+                Goodbye world
+              </body>
+            </html>
+          );
+        }
+      }
+
+      var markup = ReactDOMServer.renderToString(<Component />);
+      var testDocument = getTestDocument(markup);
+
+      ReactDOM.render(<Component />, testDocument);
+
+      expect(testDocument.body.innerHTML).toBe('Hello world');
+
+      // Reactive update
+      if (ReactDOMFeatureFlags.useFiber) {
+        // This works but is probably a bad idea.
+        ReactDOM.render(<Component2 />, testDocument);
+
+        expect(testDocument.body.innerHTML).toBe('Goodbye world');
+      } else {
+        expect(function() {
+          ReactDOM.render(<Component2 />, testDocument);
+        }).toThrowError(UNMOUNT_INVARIANT_MESSAGE);
+
+        expect(testDocument.body.innerHTML).toBe('Hello world');
+      }
+
+      expectDeprecationWarningWithFiber();
+    });
+
+    it('should be able to mount into document', () => {
+      spyOn(console, 'error');
+      class Component extends React.Component {
+        render() {
+          return (
+            <html>
+              <head>
+                <title>Hello World</title>
+              </head>
+              <body>
+                {this.props.text}
+              </body>
+            </html>
+          );
+        }
+      }
+
+      var markup = ReactDOMServer.renderToString(
+        <Component text="Hello world" />,
       );
-    } else {
-      expect(function() {
-        // Notice the text is different!
+      var testDocument = getTestDocument(markup);
+
+      ReactDOM.render(<Component text="Hello world" />, testDocument);
+
+      expect(testDocument.body.innerHTML).toBe('Hello world');
+      expectDeprecationWarningWithFiber();
+    });
+
+    it('renders over an existing text child without throwing', () => {
+      const container = document.createElement('div');
+      container.textContent = 'potato';
+      ReactDOM.render(<div>parsnip</div>, container);
+      expect(container.textContent).toBe('parsnip');
+      // We don't expect a warning about new hydration API here because
+      // we aren't sure if the user meant to hydrate or replace a stub node.
+      // We would see a warning if the container had React-rendered HTML in it.
+    });
+
+    it('should give helpful errors on state desync', () => {
+      class Component extends React.Component {
+        render() {
+          return (
+            <html>
+              <head>
+                <title>Hello World</title>
+              </head>
+              <body>
+                {this.props.text}
+              </body>
+            </html>
+          );
+        }
+      }
+
+      var markup = ReactDOMServer.renderToString(
+        <Component text="Goodbye world" />,
+      );
+      var testDocument = getTestDocument(markup);
+
+      if (ReactDOMFeatureFlags.useFiber) {
+        spyOn(console, 'error');
         ReactDOM.render(<Component text="Hello world" />, testDocument);
-      }).toThrowError(
-        "You're trying to render a component to the document using " +
-          'server rendering but the checksum was invalid. This usually ' +
-          'means you rendered a different component type or props on ' +
-          'the client from the one on the server, or your render() methods ' +
-          'are impure. React cannot handle this case due to cross-browser ' +
-          'quirks by rendering at the document root. You should look for ' +
-          'environment dependent code in your components and ensure ' +
-          'the props are the same client and server side:\n' +
-          ' (client) dy data-reactid="4">Hello world</body></\n' +
-          ' (server) dy data-reactid="4">Goodbye world</body>',
+        expect(testDocument.body.innerHTML).toBe('Hello world');
+        expectDev(console.error.calls.count()).toBe(2);
+        expectDev(console.error.calls.argsFor(0)[0]).toContain(
+          'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
+            'will stop working in React v17. Replace the ReactDOM.render() call ' +
+            'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
+        );
+        expectDev(console.error.calls.argsFor(1)[0]).toContain(
+          'Warning: Text content did not match.',
+        );
+      } else {
+        expect(function() {
+          // Notice the text is different!
+          ReactDOM.render(<Component text="Hello world" />, testDocument);
+        }).toThrowError(
+          "You're trying to render a component to the document using " +
+            'server rendering but the checksum was invalid. This usually ' +
+            'means you rendered a different component type or props on ' +
+            'the client from the one on the server, or your render() methods ' +
+            'are impure. React cannot handle this case due to cross-browser ' +
+            'quirks by rendering at the document root. You should look for ' +
+            'environment dependent code in your components and ensure ' +
+            'the props are the same client and server side:\n' +
+            ' (client) dy data-reactid="4">Hello world</body></\n' +
+            ' (server) dy data-reactid="4">Goodbye world</body>',
+        );
+      }
+    });
+
+    it('should throw on full document render w/ no markup', () => {
+      var testDocument = getTestDocument();
+
+      class Component extends React.Component {
+        render() {
+          return (
+            <html>
+              <head>
+                <title>Hello World</title>
+              </head>
+              <body>
+                {this.props.text}
+              </body>
+            </html>
+          );
+        }
+      }
+
+      if (ReactDOMFeatureFlags.useFiber) {
+        ReactDOM.render(<Component text="Hello world" />, testDocument);
+        expect(testDocument.body.innerHTML).toBe('Hello world');
+      } else {
+        expect(function() {
+          ReactDOM.render(<Component />, testDocument);
+        }).toThrowError(
+          "You're trying to render a component to the document but you didn't " +
+            "use server rendering. We can't do this without using server " +
+            'rendering due to cross-browser quirks. See ' +
+            'ReactDOMServer.renderToString() for server rendering.',
+        );
+      }
+      // We don't expect a warning about new hydration API here because
+      // we aren't sure if the user meant to hydrate or replace the document.
+      // We would see a warning if the document had React-rendered HTML in it.
+    });
+
+    it('supports findDOMNode on full-page components', () => {
+      spyOn(console, 'error');
+      var tree = (
+        <html>
+          <head>
+            <title>Hello World</title>
+          </head>
+          <body>
+            Hello world
+          </body>
+        </html>
       );
-    }
+
+      var markup = ReactDOMServer.renderToString(tree);
+      var testDocument = getTestDocument(markup);
+      var component = ReactDOM.render(tree, testDocument);
+      expect(testDocument.body.innerHTML).toBe('Hello world');
+      expect(ReactDOM.findDOMNode(component).tagName).toBe('HTML');
+      expectDeprecationWarningWithFiber();
+    });
   });
 
-  it('should throw on full document render w/ no markup', () => {
-    var testDocument = getTestDocument();
+  if (ReactDOMFeatureFlags.useFiber) {
+    describe('with new explicit hydration API', () => {
+      it('should be able to adopt server markup', () => {
+        class Root extends React.Component {
+          render() {
+            return (
+              <html>
+                <head>
+                  <title>Hello World</title>
+                </head>
+                <body>
+                  {'Hello ' + this.props.hello}
+                </body>
+              </html>
+            );
+          }
+        }
 
-    class Component extends React.Component {
-      render() {
-        return (
+        var markup = ReactDOMServer.renderToString(<Root hello="world" />);
+        var testDocument = getTestDocument(markup);
+        var body = testDocument.body;
+
+        ReactDOM.hydrate(<Root hello="world" />, testDocument);
+        expect(testDocument.body.innerHTML).toBe('Hello world');
+
+        ReactDOM.hydrate(<Root hello="moon" />, testDocument);
+        expect(testDocument.body.innerHTML).toBe('Hello moon');
+
+        expect(body === testDocument.body).toBe(true);
+      });
+
+      it('should not be able to unmount component from document node', () => {
+        class Root extends React.Component {
+          render() {
+            return (
+              <html>
+                <head>
+                  <title>Hello World</title>
+                </head>
+                <body>
+                  Hello world
+                </body>
+              </html>
+            );
+          }
+        }
+
+        var markup = ReactDOMServer.renderToString(<Root />);
+        var testDocument = getTestDocument(markup);
+        ReactDOM.hydrate(<Root />, testDocument);
+        expect(testDocument.body.innerHTML).toBe('Hello world');
+
+        // In Fiber this actually works. It might not be a good idea though.
+        ReactDOM.unmountComponentAtNode(testDocument);
+        expect(testDocument.firstChild).toBe(null);
+      });
+
+      it('should not be able to switch root constructors', () => {
+        class Component extends React.Component {
+          render() {
+            return (
+              <html>
+                <head>
+                  <title>Hello World</title>
+                </head>
+                <body>
+                  Hello world
+                </body>
+              </html>
+            );
+          }
+        }
+
+        class Component2 extends React.Component {
+          render() {
+            return (
+              <html>
+                <head>
+                  <title>Hello World</title>
+                </head>
+                <body>
+                  Goodbye world
+                </body>
+              </html>
+            );
+          }
+        }
+
+        var markup = ReactDOMServer.renderToString(<Component />);
+        var testDocument = getTestDocument(markup);
+
+        ReactDOM.hydrate(<Component />, testDocument);
+
+        expect(testDocument.body.innerHTML).toBe('Hello world');
+
+        // This works but is probably a bad idea.
+        ReactDOM.hydrate(<Component2 />, testDocument);
+
+        expect(testDocument.body.innerHTML).toBe('Goodbye world');
+      });
+
+      it('should be able to mount into document', () => {
+        class Component extends React.Component {
+          render() {
+            return (
+              <html>
+                <head>
+                  <title>Hello World</title>
+                </head>
+                <body>
+                  {this.props.text}
+                </body>
+              </html>
+            );
+          }
+        }
+
+        var markup = ReactDOMServer.renderToString(
+          <Component text="Hello world" />,
+        );
+        var testDocument = getTestDocument(markup);
+
+        ReactDOM.hydrate(<Component text="Hello world" />, testDocument);
+
+        expect(testDocument.body.innerHTML).toBe('Hello world');
+      });
+
+      it('renders over an existing text child without throwing', () => {
+        spyOn(console, 'error');
+        const container = document.createElement('div');
+        container.textContent = 'potato';
+        ReactDOM.hydrate(<div>parsnip</div>, container);
+        expect(container.textContent).toBe('parsnip');
+        expectDev(console.error.calls.count()).toBe(1);
+        expectDev(console.error.calls.argsFor(0)[0]).toContain(
+          'Did not expect server HTML to contain the text node "potato" in <div>.',
+        );
+      });
+
+      it('should give helpful errors on state desync', () => {
+        class Component extends React.Component {
+          render() {
+            return (
+              <html>
+                <head>
+                  <title>Hello World</title>
+                </head>
+                <body>
+                  {this.props.text}
+                </body>
+              </html>
+            );
+          }
+        }
+
+        var markup = ReactDOMServer.renderToString(
+          <Component text="Goodbye world" />,
+        );
+        var testDocument = getTestDocument(markup);
+
+        spyOn(console, 'error');
+        ReactDOM.hydrate(<Component text="Hello world" />, testDocument);
+        expect(testDocument.body.innerHTML).toBe('Hello world');
+        expectDev(console.error.calls.count()).toBe(1);
+        expectDev(console.error.calls.argsFor(0)[0]).toContain(
+          'Warning: Text content did not match.',
+        );
+      });
+
+      it('should render w/ no markup to full document', () => {
+        spyOn(console, 'error');
+        var testDocument = getTestDocument();
+
+        class Component extends React.Component {
+          render() {
+            return (
+              <html>
+                <head>
+                  <title>Hello World</title>
+                </head>
+                <body>
+                  {this.props.text}
+                </body>
+              </html>
+            );
+          }
+        }
+
+        ReactDOM.hydrate(<Component text="Hello world" />, testDocument);
+        expect(testDocument.body.innerHTML).toBe('Hello world');
+        expectDev(console.error.calls.count()).toBe(1);
+        expectDev(console.error.calls.argsFor(0)[0]).toContain(
+          // getTestDocument() has an extra <meta> that we didn't render.
+          'Did not expect server HTML to contain a <meta> in <head>.',
+        );
+      });
+
+      it('supports findDOMNode on full-page components', () => {
+        var tree = (
           <html>
             <head>
               <title>Hello World</title>
             </head>
             <body>
-              {this.props.text}
+              Hello world
             </body>
           </html>
         );
-      }
-    }
 
-    if (ReactDOMFeatureFlags.useFiber) {
-      ReactDOM.render(<Component text="Hello world" />, testDocument);
-      expect(testDocument.body.innerHTML).toBe('Hello world');
-    } else {
-      expect(function() {
-        ReactDOM.render(<Component />, testDocument);
-      }).toThrowError(
-        "You're trying to render a component to the document but you didn't " +
-          "use server rendering. We can't do this without using server " +
-          'rendering due to cross-browser quirks. See ' +
-          'ReactDOMServer.renderToString() for server rendering.',
-      );
-    }
-  });
-
-  it('supports findDOMNode on full-page components', () => {
-    var tree = (
-      <html>
-        <head>
-          <title>Hello World</title>
-        </head>
-        <body>
-          Hello world
-        </body>
-      </html>
-    );
-
-    var markup = ReactDOMServer.renderToString(tree);
-    var testDocument = getTestDocument(markup);
-    var component = ReactDOM.render(tree, testDocument);
-    expect(testDocument.body.innerHTML).toBe('Hello world');
-    expect(ReactDOM.findDOMNode(component).tagName).toBe('HTML');
-  });
+        var markup = ReactDOMServer.renderToString(tree);
+        var testDocument = getTestDocument(markup);
+        var component = ReactDOM.hydrate(tree, testDocument);
+        expect(testDocument.body.innerHTML).toBe('Hello world');
+        expect(ReactDOM.findDOMNode(component).tagName).toBe('HTML');
+      });
+    });
+  }
 });

--- a/src/renderers/dom/shared/__tests__/ReactRenderDocument-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactRenderDocument-test.js
@@ -39,19 +39,19 @@ describe('rendering React components at document', () => {
   describe('with old implicit hydration API', () => {
     function expectDeprecationWarningWithFiber() {
       if (ReactDOMFeatureFlags.useFiber) {
-        expectDev(console.error.calls.count()).toBe(1);
-        expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        expectDev(console.warn.calls.count()).toBe(1);
+        expectDev(console.warn.calls.argsFor(0)[0]).toContain(
           'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
             'will stop working in React v17. Replace the ReactDOM.render() call ' +
             'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
         );
       } else {
-        expectDev(console.error.calls.count()).toBe(0);
+        expectDev(console.warn.calls.count()).toBe(0);
       }
     }
 
     it('should be able to adopt server markup', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       class Root extends React.Component {
         render() {
           return (
@@ -82,7 +82,7 @@ describe('rendering React components at document', () => {
     });
 
     it('should not be able to unmount component from document node', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       class Root extends React.Component {
         render() {
           return (
@@ -119,7 +119,7 @@ describe('rendering React components at document', () => {
     });
 
     it('should not be able to switch root constructors', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       class Component extends React.Component {
         render() {
           return (
@@ -175,7 +175,7 @@ describe('rendering React components at document', () => {
     });
 
     it('should be able to mount into document', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       class Component extends React.Component {
         render() {
           return (
@@ -234,16 +234,18 @@ describe('rendering React components at document', () => {
       var testDocument = getTestDocument(markup);
 
       if (ReactDOMFeatureFlags.useFiber) {
+        spyOn(console, 'warn');
         spyOn(console, 'error');
         ReactDOM.render(<Component text="Hello world" />, testDocument);
         expect(testDocument.body.innerHTML).toBe('Hello world');
-        expectDev(console.error.calls.count()).toBe(2);
-        expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        expectDev(console.warn.calls.count()).toBe(1);
+        expectDev(console.warn.calls.argsFor(0)[0]).toContain(
           'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
             'will stop working in React v17. Replace the ReactDOM.render() call ' +
             'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
         );
-        expectDev(console.error.calls.argsFor(1)[0]).toContain(
+        expectDev(console.error.calls.count()).toBe(1);
+        expectDev(console.error.calls.argsFor(0)[0]).toContain(
           'Warning: Text content did not match.',
         );
       } else {
@@ -302,7 +304,7 @@ describe('rendering React components at document', () => {
     });
 
     it('supports findDOMNode on full-page components', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       var tree = (
         <html>
           <head>

--- a/src/renderers/dom/shared/__tests__/ReactRenderDocument-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactRenderDocument-test.js
@@ -327,6 +327,17 @@ describe('rendering React components at document', () => {
 
   if (ReactDOMFeatureFlags.useFiber) {
     describe('with new explicit hydration API', () => {
+      it('warns if there is no server rendered markup to hydrate', () => {
+        spyOn(console, 'error');
+        const container = document.createElement('div');
+        ReactDOM.hydrate(<div />, container);
+        expectDev(console.error.calls.count()).toBe(1);
+        expectDev(console.error.calls.argsFor(0)[0]).toContain(
+          'hydrate(): Expected to hydrate from server-rendered markup, but the passed ' +
+            'DOM container node was empty. React will create the DOM from scratch.',
+        );
+      });
+
       it('should be able to adopt server markup', () => {
         class Root extends React.Component {
           render() {

--- a/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
@@ -242,6 +242,7 @@ describe('ReactDOMServer', () => {
     });
 
     it('should have the correct mounting behavior (old hydrate API)', () => {
+      spyOn(console, 'warn');
       spyOn(console, 'error');
       // This test is testing client-side behavior.
       ExecutionEnvironment.canUseDOM = true;
@@ -298,16 +299,16 @@ describe('ReactDOMServer', () => {
       var instance = ReactDOM.render(<TestComponent name="x" />, element);
       expect(mountCount).toEqual(3);
       if (ReactDOMFeatureFlags.useFiber) {
-        expectDev(console.error.calls.count()).toBe(1);
-        expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        expectDev(console.warn.calls.count()).toBe(1);
+        expectDev(console.warn.calls.argsFor(0)[0]).toContain(
           'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
             'will stop working in React v17. Replace the ReactDOM.render() call ' +
             'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
         );
       } else {
-        expectDev(console.error.calls.count()).toBe(0);
+        expectDev(console.warn.calls.count()).toBe(0);
       }
-      console.error.calls.reset();
+      console.warn.calls.reset();
 
       var expectedMarkup = lastMarkup;
       if (ReactDOMFeatureFlags.useFiber) {
@@ -350,6 +351,7 @@ describe('ReactDOMServer', () => {
       expect(numClicks).toEqual(1);
       ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(instance.refs.span));
       expect(numClicks).toEqual(2);
+      expectDev(console.warn.calls.count()).toBe(0);
       expectDev(console.error.calls.count()).toBe(0);
     });
 

--- a/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
@@ -55,9 +55,10 @@ describe('ReactDOMServer', () => {
         new RegExp(
           '<span ' +
             ROOT_ATTRIBUTE_NAME +
-            '="" ' +
-            ID_ATTRIBUTE_NAME +
-            '="[^"]*"' +
+            '=""' +
+            (ReactDOMFeatureFlags.useFiber
+              ? ''
+              : ' ' + ID_ATTRIBUTE_NAME + '="[^"]*"') +
             (ReactDOMFeatureFlags.useFiber
               ? ''
               : ' ' + ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="[^"]+"') +
@@ -72,9 +73,10 @@ describe('ReactDOMServer', () => {
         new RegExp(
           '<img ' +
             ROOT_ATTRIBUTE_NAME +
-            '="" ' +
-            ID_ATTRIBUTE_NAME +
-            '="[^"]*"' +
+            '=""' +
+            (ReactDOMFeatureFlags.useFiber
+              ? ''
+              : ' ' + ID_ATTRIBUTE_NAME + '="[^"]*"') +
             (ReactDOMFeatureFlags.useFiber
               ? ''
               : ' ' + ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="[^"]+"') +
@@ -89,9 +91,10 @@ describe('ReactDOMServer', () => {
         new RegExp(
           '<img data-attr="&gt;" ' +
             ROOT_ATTRIBUTE_NAME +
-            '="" ' +
-            ID_ATTRIBUTE_NAME +
-            '="[^"]*"' +
+            '=""' +
+            (ReactDOMFeatureFlags.useFiber
+              ? ''
+              : ' ' + ID_ATTRIBUTE_NAME + '="[^"]*"') +
             (ReactDOMFeatureFlags.useFiber
               ? ''
               : ' ' + ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="[^"]+"') +
@@ -135,16 +138,19 @@ describe('ReactDOMServer', () => {
         new RegExp(
           '<div ' +
             ROOT_ATTRIBUTE_NAME +
-            '="" ' +
-            ID_ATTRIBUTE_NAME +
-            '="[^"]*"' +
+            '=""' +
+            (ReactDOMFeatureFlags.useFiber
+              ? ''
+              : ' ' + ID_ATTRIBUTE_NAME + '="[^"]*"') +
             (ReactDOMFeatureFlags.useFiber
               ? ''
               : ' ' + ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="[^"]+"') +
             '>' +
-            '<span ' +
-            ID_ATTRIBUTE_NAME +
-            '="[^"]*">' +
+            '<span' +
+            (ReactDOMFeatureFlags.useFiber
+              ? ''
+              : ' ' + ID_ATTRIBUTE_NAME + '="[^"]*"') +
+            '>' +
             (ReactDOMFeatureFlags.useFiber
               ? 'My name is <!-- -->child'
               : '<!-- react-text: [0-9]+ -->My name is <!-- /react-text -->' +
@@ -206,9 +212,10 @@ describe('ReactDOMServer', () => {
           new RegExp(
             '<span ' +
               ROOT_ATTRIBUTE_NAME +
-              '="" ' +
-              ID_ATTRIBUTE_NAME +
-              '="[^"]*"' +
+              '=""' +
+              (ReactDOMFeatureFlags.useFiber
+                ? ''
+                : ' ' + ID_ATTRIBUTE_NAME + '="[^"]*"') +
               (ReactDOMFeatureFlags.useFiber
                 ? ''
                 : ' ' + ReactMarkupChecksum.CHECKSUM_ATTR_NAME + '="[^"]+"') +

--- a/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
@@ -383,20 +383,20 @@ describe('ReactDOMServer', () => {
         }
 
         var element = document.createElement('div');
-        ReactDOM.hydrate(<TestComponent />, element);
+        ReactDOM.render(<TestComponent />, element);
 
         var lastMarkup = element.innerHTML;
 
         // Exercise the update path. Markup should not change,
         // but some lifecycle methods should be run again.
-        ReactDOM.hydrate(<TestComponent name="x" />, element);
+        ReactDOM.render(<TestComponent name="x" />, element);
         expect(mountCount).toEqual(1);
 
         // Unmount and remount. We should get another mount event and
         // we should get different markup, as the IDs are unique each time.
         ReactDOM.unmountComponentAtNode(element);
         expect(element.innerHTML).toEqual('');
-        ReactDOM.hydrate(<TestComponent name="x" />, element);
+        ReactDOM.render(<TestComponent name="x" />, element);
         expect(mountCount).toEqual(2);
         expect(element.innerHTML).not.toEqual(lastMarkup);
 

--- a/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
+++ b/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
@@ -14,6 +14,7 @@
 let createRenderer;
 let React;
 let ReactDOM;
+let ReactDOMFeatureFlags;
 let ReactDOMServer;
 let ReactTestUtils;
 
@@ -24,6 +25,7 @@ describe('ReactTestUtils', () => {
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');
     ReactTestUtils = require('react-dom/test-utils');
+    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
   });
 
   it('can scryRenderedDOMComponentsWithClass with TextComponent', () => {
@@ -173,7 +175,9 @@ describe('ReactTestUtils', () => {
 
     const markup = ReactDOMServer.renderToString(<Root />);
     const testDocument = getTestDocument(markup);
-    const component = ReactDOM.render(<Root />, testDocument);
+    const component = ReactDOMFeatureFlags.useFiber
+      ? ReactDOM.hydrate(<Root />, testDocument)
+      : ReactDOM.render(<Root />, testDocument);
 
     expect(component.refs.html.tagName).toBe('HTML');
     expect(component.refs.head.tagName).toBe('HEAD');

--- a/src/renderers/shared/server/ReactPartialRenderer.js
+++ b/src/renderers/shared/server/ReactPartialRenderer.js
@@ -305,7 +305,6 @@ function createOpenTagMarkup(
   if (isRootElement) {
     ret += ' ' + DOMMarkupOperations.createMarkupForRoot();
   }
-  ret += ' ' + DOMMarkupOperations.createMarkupForID('');
   return ret;
 }
 


### PR DESCRIPTION
First attempt at https://github.com/facebook/react/issues/10189.

* Removes `data-reactid` from new SSR.
* We now use presence of `data-reactroot` as heuristic for hydration.
* There is also an explicit `ReactDOM.hydrate()` API that never clears the existing content.
* `ReactDOM.render()` will now print a deprecation message when it tries to reuse markup.
* Downgrade deprecation message to `lowPriorityWarning`.
* A warning if we tried to hydrate but there’s no DOM to hydrate into.

This means `ReactDOM.render()` would still attempt to hydrate when there’s an element root, but might not work for new features (like top level strings or fragments). `ReactDOM.hydrate()` would always hydrate.

I have switched the integration test to use the new hydration API when available, and this let me remove the special case for top level text nodes that I added in https://github.com/facebook/react/pull/10333.
