### PR TITLE
Make unexpected console.warn() calls fail tests

### DIFF
--- a/scripts/jest/test-framework-setup.js
+++ b/scripts/jest/test-framework-setup.js
@@ -7,33 +7,25 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
 } else {
   var env = jasmine.getEnv();
 
-  var callCount = 0;
-  var oldError = console.error;
-  var newError = function() {
-    callCount++;
-    oldError.apply(this, arguments);
-  };
-
-  console.error = newError;
-
   // TODO: Stop using spyOn in all the test since that seem deprecated.
   // This is a legacy upgrade path strategy from:
   // https://github.com/facebook/jest/blob/v20.0.4/packages/jest-matchers/src/spyMatchers.js#L160
   const isSpy = spy => spy.calls && typeof spy.calls.count === 'function';
 
   env.beforeEach(() => {
-    callCount = 0;
     jasmine.addMatchers({
       toBeReset() {
         return {
-          compare(actual) {
+          compare(actual, methodName) {
             // TODO: Catch test cases that call spyOn() but don't inspect the mock
             // properly.
-            if (actual !== newError && !isSpy(actual)) {
+            if (actual.__callCount === undefined && !isSpy(actual)) {
               return {
                 pass: false,
                 message: () =>
-                  'Test did not tear down console.error mock properly.',
+                  'Test did not tear down console.' +
+                  methodName +
+                  ' mock properly.',
               };
             }
             return {pass: true};
@@ -42,12 +34,17 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
       },
       toNotHaveBeenCalled() {
         return {
-          compare(actual) {
+          compare(actual, methodName) {
             return {
-              pass: callCount === 0,
+              pass: actual.__callCount === 0,
               message: () =>
-                'Expected test not to warn. If the warning is expected, mock ' +
-                "it out using spyOn(console, 'error'); and test that the " +
+                'Expected test not to call console.' +
+                methodName +
+                '(). ' +
+                'If the warning is expected, mock it out using ' +
+                "spyOn(console, '" +
+                methodName +
+                "') and test that the " +
                 'warning occurs.',
             };
           },
@@ -55,9 +52,23 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
       },
     });
   });
-  env.afterEach(() => {
-    expect(console.error).toBeReset();
-    expect(console.error).toNotHaveBeenCalled();
+
+  ['error', 'warn'].forEach(methodName => {
+    var oldMethod = console[methodName];
+    var newMethod = function() {
+      newMethod.__callCount++;
+      oldMethod.apply(this, arguments);
+    };
+    newMethod.__callCount = 0;
+    console[methodName] = newMethod;
+
+    env.beforeEach(() => {
+      newMethod.__callCount = 0;
+    });
+    env.afterEach(() => {
+      expect(console[methodName]).toBeReset(methodName);
+      expect(console[methodName]).toNotHaveBeenCalled(methodName);
+    });
   });
 
   var wrapDevMatcher = function(obj, name) {


### PR DESCRIPTION
We recently started using `lowPriorityWarning` for deprecation messages. However it uses `console.warn` rather than `console.error`. Our test setup is more forgiving for `console.warn` and doesn’t report unintended `console.warn` calls as failures. As a result there’s a risk of deprecation warning false positives getting accidentally ignored.

This change makes unexpected `console.warn` fail the test, just like `console.error` does.

<img width="909" alt="screen shot 2017-08-01 at 16 25 21" src="https://user-images.githubusercontent.com/810438/28833015-0a8c15c8-76d6-11e7-8a1a-5e6700d05f2c.png">

No tests needed change because we don’t currently have stray `console.warn()` calls. I verified adding one crashes a test now.