### PR TITLE
Remove event namespace check from ReactPartialRenderer

### DIFF
--- a/src/renderers/shared/server/ReactPartialRenderer.js
+++ b/src/renderers/shared/server/ReactPartialRenderer.js
@@ -12,7 +12,6 @@
 'use strict';
 
 var DOMMarkupOperations = require('DOMMarkupOperations');
-var {registrationNameModules} = require('EventPluginRegistry');
 var React = require('react');
 var ReactControlledValuePropTypes = require('ReactControlledValuePropTypes');
 
@@ -272,27 +271,22 @@ function createOpenTagMarkup(
     if (propValue == null) {
       continue;
     }
-    if (!registrationNameModules.hasOwnProperty(propKey)) {
-      if (propKey === STYLE) {
-        propValue = createMarkupForStyles(propValue, instForDebug);
-      }
-      var markup = null;
-      if (isCustomComponent(tagLowercase, props)) {
-        if (!RESERVED_PROPS.hasOwnProperty(propKey)) {
-          markup = DOMMarkupOperations.createMarkupForCustomAttribute(
-            propKey,
-            propValue,
-          );
-        }
-      } else {
-        markup = DOMMarkupOperations.createMarkupForProperty(
+    if (propKey === STYLE) {
+      propValue = createMarkupForStyles(propValue, instForDebug);
+    }
+    var markup = null;
+    if (isCustomComponent(tagLowercase, props)) {
+      if (!RESERVED_PROPS.hasOwnProperty(propKey)) {
+        markup = DOMMarkupOperations.createMarkupForCustomAttribute(
           propKey,
           propValue,
         );
       }
-      if (markup) {
-        ret += ' ' + markup;
-      }
+    } else {
+      markup = DOMMarkupOperations.createMarkupForProperty(propKey, propValue);
+    }
+    if (markup) {
+      ret += ' ' + markup;
     }
   }
 


### PR DESCRIPTION
Working through https://github.com/facebook/react/pull/10229, I noticed that `onchange` was coming through as markup in the server-side rendering tests. This is because `ReactPartialRenderer` uses a `registrationNameModules` check to see if a prop is an event name. 

I believe `registrationNameModules` is populated by event plugins, which were removed in https://github.com/facebook/react/pull/10173. So this condition always resolves to true. I've confirmed by running test coverage:

<img width="632" alt="screen shot 2017-08-01 at 7 09 57 pm" src="https://user-images.githubusercontent.com/590904/28851057-28765c70-76ee-11e7-96c4-2cd97893ea04.png">

If we remove the attribute whitelist, we need an answer here for event names on server-side rendering. I've added that to my list in #10229 