### PR TITLE
Remove hydrate() warning about empty container

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -525,7 +525,6 @@ ReactGenericBatching.injection.injectFiberBatchedUpdates(
 );
 
 var warnedAboutHydrateAPI = false;
-var warnedAboutEmptyContainer = false;
 
 function renderSubtreeIntoContainer(
   parentComponent: ?ReactComponent<any, any, any>,
@@ -615,14 +614,6 @@ function renderSubtreeIntoContainer(
           'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
             'will stop working in React v17. Replace the ReactDOM.render() call ' +
             'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
-        );
-      }
-      if (forceHydrate && !container.firstChild && !warnedAboutEmptyContainer) {
-        warnedAboutEmptyContainer = true;
-        warning(
-          false,
-          'hydrate(): Expected to hydrate from server-rendered markup, but the passed ' +
-            'DOM container node was empty. React will create the DOM from scratch.',
         );
       }
     }

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -458,7 +458,7 @@ describe('ReactDOMServerIntegration', () => {
 
       itRenders('emptyish values', async render => {
         let e = await render(0);
-        expect(e.nodeType).toBe(3);
+        expect(e.nodeType).toBe(TEXT_NODE_TYPE);
         expect(e.nodeValue).toMatch('0');
 
         // TODO: This one is broken because client renders a node

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -455,6 +455,22 @@ describe('ReactDOMServerIntegration', () => {
         expect(parent.childNodes[1].tagName).toBe('DIV');
         expect(parent.childNodes[2].tagName).toBe('DIV');
       });
+
+      itRenders('emptyish values', async render => {
+        let e = await render(0);
+        expect(e.nodeType).toBe(3);
+        expect(e.nodeValue).toMatch('0');
+
+        // TODO: This one is broken because client renders a node
+        // but server returns empty HTML.
+        // expect(await render('')).toBe(null);
+
+        expect(await render([])).toBe(null);
+        expect(await render(false)).toBe(null);
+        expect(await render(true)).toBe(null);
+        expect(await render(undefined)).toBe(null);
+        expect(await render([[[false]], undefined])).toBe(null);
+      });
     }
   });
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -461,9 +461,9 @@ describe('ReactDOMServerIntegration', () => {
         expect(e.nodeType).toBe(TEXT_NODE_TYPE);
         expect(e.nodeValue).toMatch('0');
 
-        // TODO: This one is broken because client renders a node
-        // but server returns empty HTML.
-        // expect(await render('')).toBe(null);
+        // Empty string is special because client renders a node
+        // but server returns empty HTML. So we compare parent text.
+        expect((await render(<div>{''}</div>)).textContent).toBe('');
 
         expect(await render([])).toBe(null);
         expect(await render(false)).toBe(null);

--- a/src/renderers/dom/shared/__tests__/ReactRenderDocument-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactRenderDocument-test.js
@@ -327,17 +327,6 @@ describe('rendering React components at document', () => {
 
   if (ReactDOMFeatureFlags.useFiber) {
     describe('with new explicit hydration API', () => {
-      it('warns if there is no server rendered markup to hydrate', () => {
-        spyOn(console, 'error');
-        const container = document.createElement('div');
-        ReactDOM.hydrate(<div />, container);
-        expectDev(console.error.calls.count()).toBe(1);
-        expectDev(console.error.calls.argsFor(0)[0]).toContain(
-          'hydrate(): Expected to hydrate from server-rendered markup, but the passed ' +
-            'DOM container node was empty. React will create the DOM from scratch.',
-        );
-      });
-
       it('should be able to adopt server markup', () => {
         class Root extends React.Component {
           render() {


### PR DESCRIPTION
It used to have false positives for cases where we legitimately don't render anything.
Per https://github.com/facebook/react/pull/10339#discussion_r130716334.