### PR TITLE
Add an extra test for arrays and strings from composites

### DIFF
--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -1391,6 +1391,34 @@ describe('ReactDOMServerIntegration', () => {
           expectTextNode(textNode2, '   ');
         },
       );
+
+      if (ReactDOMFeatureFlags.useFiber) {
+        itRenders('a composite with multiple children', async render => {
+          const Component = props => props.children;
+          const e = await render(
+            <Component>{['a', 'b', [undefined], [[false, 'c']]]}</Component>,
+          );
+
+          let parent = e.parentNode;
+          if (
+            render === serverRender ||
+            render === clientRenderOnServerString ||
+            render === streamRender
+          ) {
+            // For plain server markup result we have comments between.
+            // If we're able to hydrate, they remain.
+            expect(parent.childNodes.length).toBe(5);
+            expectTextNode(parent.childNodes[0], 'a');
+            expectTextNode(parent.childNodes[2], 'b');
+            expectTextNode(parent.childNodes[4], 'c');
+          } else {
+            expect(parent.childNodes.length).toBe(3);
+            expectTextNode(parent.childNodes[0], 'a');
+            expectTextNode(parent.childNodes[1], 'b');
+            expectTextNode(parent.childNodes[2], 'c');
+          }
+        });
+      }
     });
 
     describe('escaping >, <, and &', function() {


### PR DESCRIPTION
We tested only top level arrays/strings but not composite return values.
Tests already pass.

Related: it's time we start thinking about splitting up those tests so they can run in parallel.
I can look into it tomorrow.